### PR TITLE
feat(causa): Performance panel — per-cascade duration + budget warnings (rf2-75121)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/performance.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/performance.cljs
@@ -1,0 +1,308 @@
+(ns day8.re-frame2-causa.panels.performance
+  "Performance panel — Phase 5 (rf2-75121, parent rf2-5aw5v).
+
+  Per `tools/causa/spec/000-Vision.md` L92 (panel-inventory row) the
+  Performance panel surfaces per-cascade duration capture, perf-tier
+  colour mapping, and budget-warning markers. It's the UI consumer of
+  the runtime substrate Spec 009 §Performance instrumentation publishes
+  (the User Timing channel, plus the trace stream's per-event :time
+  fields the v1 derives durations from).
+
+  ## What this panel shows
+
+  Each dispatch cascade in the trace buffer renders as a row:
+
+      tier-glyph · dispatch-id · event vector · duration · per-step bar
+
+  The tier-glyph + colour follow `tools/causa/spec/007-UX-IA.md`
+  §Colour system §Perf scale (per spec §Colour is never alone — every
+  hue pairs with a shape):
+
+      ● green   :fast      <16ms
+      ● yellow  :medium    16-50ms
+      ▲ orange  :slow      50-100ms
+      ▲ red     :blocking  >=100ms
+
+  Rows whose duration crosses the active budget threshold (`default-
+  budget-ms`, currently 16ms = one frame at 60fps) carry an extra
+  `over-budget` marker chip on the right edge — the budget warning is
+  the panel's hero affordance per the bead's contract. Clicking the
+  marker pivots to the event-detail panel for that cascade so the
+  programmer can dig into 'why was this slow?'.
+
+  ## Pure hiccup (rf2-tijr)
+
+  Same contract as every other Causa panel — the view is pure hiccup,
+  no Reagent / UIx / Helix references. Frame isolation comes from the
+  enclosing `[rf/frame-provider {:frame :rf/causa}]` in `shell.cljs`.
+
+  ## Helpers
+
+  All pure-data logic — tier classification, step-breakdown, format /
+  truncate, composite projection — lives in `performance_helpers.cljc`
+  so the algebra runs under the JVM unit-test target. The view here
+  is a thin renderer that reads the `:rf.causa/performance-data`
+  composite sub.
+
+  ## What v1 does NOT include
+
+  Per the bead's minimum-viable contract:
+
+    - No `PerformanceObserver` integration (INP / long-task / layout-
+      shift overlays). These ride a follow-on bead once the shared
+      `rf.causa.fx/install-performance-observer!` effect lands (the
+      Trace panel will share that effect once both panels are live).
+    - No drag-zoom horizontal ribbon. v1 ships the row view; the
+      ribbon canvas is follow-on work alongside the time-axis
+      synchronisation with the Trace panel (rf2-xxx).
+    - No re-render-counts-per-epoch projection from the epoch-record's
+      `:renders` slot. The row's render-count is a cheap proxy
+      (count of `:view/render` traces in the cascade) until that slot
+      surfaces."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.performance-helpers :as h]))
+
+;; ---- design tokens (mirrors event_detail.cljs / issues_ribbon.cljs) -----
+
+(def ^:private tokens
+  "Subset of shell.cljs's dark-theme tokens used by this panel."
+  {:bg-1            "#15171B"
+   :bg-2            "#1B1E24"
+   :bg-3            "#232730"
+   :bg-active       "#2A2F3D"
+   :border-subtle   "#232730"
+   :border-default  "#2F3441"
+   :text-primary    "#E8EAF0"
+   :text-secondary  "#A8AEC0"
+   :text-tertiary   "#6B7080"
+   :accent-violet   "#7C5CFF"
+   :cyan            "#43C3D0"
+   :green           "#4ADE80"
+   :yellow          "#FBBF24"
+   :orange          "#FB923C"
+   :red             "#F87171"
+   :magenta         "#E879F9"})
+
+(def ^:private mono-stack
+  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
+  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
+
+(def ^:private sans-stack
+  "Inter stack per spec/007-UX-IA.md §Typography."
+  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+
+;; ---- tier chip helpers ---------------------------------------------------
+
+(defn- tier-chip
+  "One tier-histogram chip in the header. Shows tier label + count;
+  colour follows the spec's perf scale."
+  [tier count]
+  [:span {:data-testid (str "rf-causa-perf-tier-chip-" (name tier))
+          :style       {:display       "inline-flex"
+                        :align-items   "center"
+                        :gap           "4px"
+                        :padding       "1px 8px"
+                        :border        (str "1px solid "
+                                            (:border-subtle tokens))
+                        :border-radius "999px"
+                        :color         (h/tier-colour tier)
+                        :font-family   sans-stack
+                        :font-size     "11px"
+                        :font-weight   600
+                        :margin-right  "6px"}}
+   [:span {:style {:font-weight 700}} (h/tier-glyph tier)]
+   [:span {:style {:color (:text-secondary tokens)}} (h/tier-label tier)]
+   [:span {:style {:color (:text-tertiary tokens) :font-family mono-stack}}
+    (str count)]])
+
+(defn- header
+  "Panel header — title + total count + tier histogram + budget caption."
+  [{:keys [total tier-counts over-budget-count budget-ms]}]
+  [:header {:style {:padding       "12px 16px 8px 16px"
+                    :border-bottom (str "1px solid " (:border-subtle tokens))}}
+   [:div {:style {:display     "flex"
+                  :align-items "baseline"
+                  :gap         "12px"}}
+    [:h1 {:style {:font-size   "16px"
+                  :font-weight 600
+                  :margin      0
+                  :color       (:text-primary tokens)}}
+     "Performance"]
+    [:span {:data-testid "rf-causa-perf-totals"
+            :style {:font-size   "11px"
+                    :color       (:text-tertiary tokens)
+                    :font-family mono-stack}}
+     (str total " cascade" (if (= 1 total) "" "s"))]
+    (when (pos? over-budget-count)
+      [:span {:data-testid "rf-causa-perf-over-budget-count"
+              :style {:margin-left "auto"
+                      :color       (:red tokens)
+                      :font-family mono-stack
+                      :font-size   "11px"
+                      :font-weight 600}}
+       (str "▲ " over-budget-count " over " budget-ms "ms")])]
+   [:div {:data-testid "rf-causa-perf-tier-chips"
+          :style {:margin-top "8px"
+                  :display    "flex"
+                  :flex-wrap  "wrap"}}
+    (for [tier h/tier-order]
+      ^{:key tier}
+      [tier-chip tier (get tier-counts tier 0)])]])
+
+;; ---- per-step bar --------------------------------------------------------
+
+(defn- step-bar
+  "Render the per-step duration breakdown as a horizontal stacked bar.
+  Each slice's width is proportional to its share of the cascade's
+  total duration; the slice colour follows the per-domino tones used
+  by `event_detail.cljs` so the cross-panel visual stays consistent."
+  [{:keys [breakdown duration-ms] :as _row}]
+  (let [segs (h/breakdown-segments breakdown duration-ms)]
+    [:div {:data-testid "rf-causa-perf-step-bar"
+           :style {:display       "flex"
+                   :height        "8px"
+                   :width         "100%"
+                   :background    (:bg-3 tokens)
+                   :border-radius "4px"
+                   :overflow      "hidden"}}
+     (for [{:keys [key ms width-pct]} segs]
+       ^{:key key}
+       [:div {:data-testid (str "rf-causa-perf-step-segment-" (name key))
+              :title (str (h/breakdown-label key) " · "
+                          (h/format-duration ms))
+              :style {:width      (str width-pct "%")
+                      :background (h/breakdown-colour key)
+                      :height     "100%"}}])]))
+
+;; ---- per-row -------------------------------------------------------------
+
+(defn- perf-row
+  "One row in the performance feed. Click the row → pivot to the
+  cascade in the event-detail panel (parity with the Issues ribbon's
+  pivot affordance)."
+  [{:keys [dispatch-id event tier duration-ms over-budget?
+           render-count effect-count sub-count]
+    :as row}]
+  (let [row-test-id (str "rf-causa-perf-row-" dispatch-id)
+        colour      (h/tier-colour tier)]
+    [:li {:key         dispatch-id
+          :data-testid row-test-id
+          :data-tier   (name tier)
+          :data-over-budget (str (boolean over-budget?))
+          :on-click    (fn []
+                         (rf/dispatch [:rf.causa/select-dispatch-id dispatch-id])
+                         (rf/dispatch [:rf.causa/select-panel :event-detail]))
+          :style       {:display       "grid"
+                        :grid-template-columns "18px 60px minmax(140px, 1fr) 70px 110px 1.2fr 70px"
+                        :gap           "10px"
+                        :align-items   "center"
+                        :padding       "6px 16px"
+                        :border-bottom (str "1px solid " (:border-subtle tokens))
+                        :cursor        "pointer"
+                        :color         (:text-primary tokens)
+                        :font-family   mono-stack
+                        :font-size     "12px"
+                        :line-height   1.35}}
+     ;; Tier glyph
+     [:span {:data-testid (str row-test-id "-tier")
+             :title       (h/tier-label tier)
+             :style       {:color       colour
+                           :font-weight 700
+                           :text-align  "center"}}
+      (h/tier-glyph tier)]
+     ;; Dispatch-id
+     [:span {:data-testid (str row-test-id "-id")
+             :style       {:color (:accent-violet tokens)
+                           :overflow "hidden"
+                           :text-overflow "ellipsis"
+                           :white-space "nowrap"}}
+      (str "#" dispatch-id)]
+     ;; Event vector
+     [:span {:data-testid (str row-test-id "-event")
+             :style       {:color       (:text-primary tokens)
+                           :overflow    "hidden"
+                           :text-overflow "ellipsis"
+                           :white-space "nowrap"}
+             :title       (h/format-event event)}
+      (h/truncate (h/format-event event) 48)]
+     ;; Total duration
+     [:span {:data-testid (str row-test-id "-duration")
+             :style       {:color colour
+                           :font-weight 600
+                           :text-align "right"}}
+      (h/format-duration duration-ms)]
+     ;; Counts (sub-label)
+     [:span {:data-testid (str row-test-id "-counts")
+             :style       {:color (:text-tertiary tokens)
+                           :font-size "11px"
+                           :white-space "nowrap"}}
+      (str "fx " effect-count " · v " render-count " · s " sub-count)]
+     ;; Per-step bar
+     [step-bar row]
+     ;; Over-budget marker (right edge)
+     (if over-budget?
+       [:span {:data-testid (str row-test-id "-over-budget")
+               :style       {:color       (:red tokens)
+                             :font-family sans-stack
+                             :font-size   "10px"
+                             :font-weight 700
+                             :text-align  "right"}
+               :title       "Over budget — click to inspect"}
+        "▲ over"]
+       [:span {:style {:color     (:text-tertiary tokens)
+                       :font-size "10px"
+                       :text-align "right"}}
+        "—"])]))
+
+;; ---- empty state ---------------------------------------------------------
+
+(defn- empty-state
+  "Per the bead's contract — 'No performance data yet — perform actions
+  in the app to capture cascades.'"
+  []
+  [:div {:data-testid "rf-causa-perf-empty"
+         :style       {:padding     "24px"
+                       :font-family sans-stack
+                       :font-size   "13px"
+                       :line-height 1.5
+                       :color       (:text-secondary tokens)}}
+   [:p {:style {:margin "0 0 8px 0"
+                :color  (:text-primary tokens)
+                :font-weight 600}}
+    "No performance data yet"]
+   [:p {:style {:margin 0
+                :color  (:text-tertiary tokens)}}
+    "Perform actions in the app to capture cascades. Each dispatch lands "
+    "as one row with a per-step duration breakdown."]])
+
+;; ---- public view --------------------------------------------------------
+
+(defn performance-view
+  "The Performance panel's root view. Subscribes to
+  `:rf.causa/performance-data` and renders the empty-state or the
+  feed."
+  []
+  (let [{:keys [rows total tier-counts over-budget-count budget-ms empty?]
+         :as _data}
+        @(rf/subscribe [:rf.causa/performance-data])]
+    [:section {:data-testid "rf-causa-performance"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      "14px"}}
+     (header {:total              total
+              :tier-counts        tier-counts
+              :over-budget-count  over-budget-count
+              :budget-ms          budget-ms})
+     [:div {:style {:flex 1 :overflow "auto"}}
+      (if empty?
+        (empty-state)
+        (into [:ul {:data-testid "rf-causa-perf-feed"
+                    :style       {:list-style "none"
+                                  :margin     0
+                                  :padding    0}}]
+              (for [row rows]
+                (perf-row row))))]]))

--- a/tools/causa/src/day8/re_frame2_causa/panels/performance_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/performance_helpers.cljc
@@ -1,0 +1,477 @@
+(ns day8.re-frame2-causa.panels.performance-helpers
+  "Pure-data helpers for Causa's Performance panel (Phase 5, rf2-75121).
+
+  ## Why a separate `.cljc` ns
+
+  The panel view in `performance.cljs` paints per-cascade duration rows
+  and dispatches into the Causa frame. The *logic* — folding the trace
+  buffer into per-cascade duration records, classifying each cascade
+  against the perf-tier scale (fast / medium / slow / blocking), and
+  marking over-budget rows — is pure data → data. Splitting the algebra
+  into `.cljc` so it runs under the JVM unit-test target
+  (`clojure -M:test`) is required by the standing rule
+  `feedback_jvm_interop_must_work.md`.
+
+  ## Spec substrate
+
+  Two surfaces feed this panel:
+
+    - **Trace stream** (Spec 009 §Subscription / consumption) — every
+      emit carries `:id`, `:time` (host-clock ms), `:op-type`,
+      `:operation`, `:tags`. The stream is event-at-a-time; there is
+      no first-class `:duration` field on the trace event itself (per
+      Spec 009 L38: 'no separate start/end pair, no :duration, no
+      :child-of'). The Performance panel derives cascade-level
+      durations from the `:time` deltas across a cascade's events.
+
+    - **User Timing surface** (Spec 009 §Performance instrumentation,
+      `re-frame.performance/enabled?` flag) — `rf:event:*`, `rf:sub:*`,
+      `rf:fx:*`, `rf:render:*` measure entries with `name`, `startTime`,
+      `duration`. This is the prod-friendly default-off channel; v1
+      Performance panel reads the trace stream instead since:
+
+        1. Dev builds carry the trace stream by default
+           (`goog.DEBUG=true`); flipping a *second* compile-time
+           constant just to use the panel is friction.
+        2. The User Timing entries are per-mark, not per-cascade —
+           reassembling them into a six-domino cascade requires the
+           same `:dispatch-id` correlation the trace stream already
+           ships, so reading the trace stream is the shorter path.
+
+      The User Timing surface remains the right consumer for an APM
+      pipeline (Chrome DevTools' Performance panel, `PerformanceObserver`
+      sinks); the Causa Performance panel and the User Timing channel
+      coexist as distinct consumers of distinct surfaces.
+
+  ## Perf tier scale (per `tools/causa/spec/007-UX-IA.md` §Colour system)
+
+  The colour-only signal is paired with a glyph per spec §Colour is
+  never alone:
+
+      :fast      <16ms       green   #4ADE80   ●
+      :medium    16-50ms     yellow  #FBBF24   ●
+      :slow      50-100ms    orange  #FB923C   ▲
+      :blocking  >100ms      red     #F87171   ▲    INP threshold
+
+  Thresholds are right-open (`<16` ∧ `≥16` boundary). `:fast` is the
+  one-frame-at-60fps target; `:blocking` is the INP-blocking band per
+  the Web Vitals `INP` definition (>200ms is poor; >100ms is needs-
+  improvement — the spec collapses both into the blocking band so the
+  programmer's eye is drawn to *anything* the user perceives as a hang).
+
+  ## Budget warnings
+
+  The 'budget' is the configurable threshold above which a cascade
+  carries a warning marker. v1 default = 16ms (one frame at 60fps),
+  which makes `:medium` / `:slow` / `:blocking` all over-budget. The
+  threshold is a sub-readable slot on Causa's app-db
+  (`:performance-budget-ms`); a follow-on bead may add a slider in the
+  panel header (currently set programmatically via
+  `:rf.causa/set-performance-budget-ms`).
+
+  ## Cascade duration model
+
+  The trace events for one cascade share a `:dispatch-id`. The
+  cascade's total duration is `(- (max :time) (min :time))` across
+  every event carrying that `:dispatch-id`. The per-step breakdown is
+  computed from the same time deltas:
+
+      handler-ms  — first :handler trace's :time → last :handler's :time
+      fx-ms       — :event/do-fx :time → last :effect's :time
+      sub-ms      — first :sub run/create :time → last :sub :time
+      render-ms   — first :render :time → last :render :time
+
+  Each slice is non-overlapping by construction (the six-domino order
+  is event → handler → fx → effects → subs → renders) — but **the
+  slices are derived, not authoritative**; the trace stream is event-
+  at-a-time and the actual call graph can interleave (e.g. a sub recompute
+  may fire mid-render). The slice is the 'where in the cascade did time
+  go' approximation, not a profiler-grade attribution.
+
+  ## What's NOT in v1
+
+  Per the bead's minimum-viable contract:
+
+    - No `PerformanceObserver` integration (INP / long-task / layout-
+      shift overlays). The bead description sketches these but they
+      ride the `rf.causa.fx/install-performance-observer!` effect
+      which has not landed.
+    - No drag-zoom on a horizontal ribbon. v1 ships a tabular row
+      view; the ribbon canvas is follow-on work.
+    - No re-render-counts-per-epoch projection; the row's render-count
+      is the count of `:view/render` traces in the cascade, which is a
+      cheap proxy until the epoch-record's `:renders` projection
+      surfaces.")
+
+;; ---- defaults ------------------------------------------------------------
+
+(def default-budget-ms
+  "Default budget threshold above which a cascade row carries the
+  over-budget warning marker. 16ms = one frame at 60fps — the v1
+  ergonomic default. The slot is sub-readable so a follow-on bead can
+  surface a slider in the panel header."
+  16)
+
+(def tier-order
+  "Render order for the perf tiers when the panel renders a histogram
+  / chip row. Fastest first because the goal is 'mostly green'."
+  [:fast :medium :slow :blocking])
+
+;; ---- tier classification -------------------------------------------------
+
+(defn classify-tier
+  "Map a `duration-ms` (number) to one of the four perf tiers per
+  `tools/causa/spec/007-UX-IA.md` §Colour system:
+
+      <16ms     → :fast       one-frame-at-60fps
+      16-50ms   → :medium
+      50-100ms  → :slow
+      >=100ms   → :blocking   INP-blocking band
+
+  Boundaries are right-open at the lower edge (the next tier owns the
+  threshold value itself). Negative or nil durations classify as
+  `:fast` — a robust default for cascades whose `:time` deltas
+  collapse to zero (single-event cascades).
+
+  Pure data → keyword; JVM-testable."
+  [duration-ms]
+  (cond
+    (not (number? duration-ms)) :fast
+    (< duration-ms 16)          :fast
+    (< duration-ms 50)          :medium
+    (< duration-ms 100)         :slow
+    :else                       :blocking))
+
+(defn tier-colour
+  "Hex swatch per perf tier. Mirrors the spec/007-UX-IA.md §Colour
+  system §Perf scale. The strings are returned so the helper stays
+  pure (no token-map dependency)."
+  [tier]
+  (case tier
+    :fast     "#4ADE80"  ; green
+    :medium   "#FBBF24"  ; yellow
+    :slow     "#FB923C"  ; orange
+    :blocking "#F87171"  ; red
+    "#6B7080"))           ; text-tertiary fallback
+
+(defn tier-glyph
+  "Single-character glyph paired with the tier colour per spec
+  §Colour is never alone. `●` for fast/medium (within-budget,
+  acceptable); `▲` for slow/blocking (over-budget, attention-needed).
+  Pure data → string; JVM-testable."
+  [tier]
+  (case tier
+    :fast     "●"
+    :medium   "●"
+    :slow     "▲"
+    :blocking "▲"
+    "○"))
+
+(defn tier-label
+  "Human-readable label for a tier — used in the over-budget caption
+  and the chip-row tooltip."
+  [tier]
+  (case tier
+    :fast     "fast"
+    :medium   "medium"
+    :slow     "slow"
+    :blocking "blocking"
+    (str tier)))
+
+(defn over-budget?
+  "True iff `duration-ms` is at or above `budget-ms`. nil / non-number
+  inputs are treated as within-budget so a malformed cascade record
+  doesn't false-flag. Pure data → bool; JVM-testable."
+  [budget-ms duration-ms]
+  (boolean
+    (and (number? budget-ms)
+         (number? duration-ms)
+         (>= duration-ms budget-ms))))
+
+;; ---- duration projection -------------------------------------------------
+
+(defn- event-time
+  "Lift `:time` off a trace event. nil-safe — returns nil when the
+  event is nil or carries no :time."
+  [ev]
+  (when (map? ev)
+    (let [t (:time ev)]
+      (when (number? t) t))))
+
+(defn- bookend
+  "Min / max of `:time` across a non-empty sequence of trace events.
+  Returns `nil` when `evs` is empty or every event lacks `:time`."
+  [evs]
+  (let [times (keep event-time evs)]
+    (when (seq times)
+      [(apply min times) (apply max times)])))
+
+(defn slice-duration
+  "Compute the duration of one cascade slice — `(max :time) - (min
+  :time)` across `evs`. Pure data → number-or-nil; JVM-testable.
+
+  Returns `nil` when `evs` is empty / every event lacks :time. Returns
+  `0` when only one event has a :time (the bookends collapse)."
+  [evs]
+  (when-let [[t-min t-max] (bookend evs)]
+    (- t-max t-min)))
+
+(defn cascade-events
+  "Collect every trace event in `cascade` into one sequence — the six
+  domino slots plus the `:other` bucket. Used to compute the cascade's
+  total wall-clock span. Pure data → seq; JVM-testable."
+  [{:keys [handler fx effects subs renders other] :as _cascade}]
+  (concat (when handler [handler])
+          (when fx [fx])
+          effects
+          subs
+          renders
+          other))
+
+(defn cascade-duration
+  "Total wall-clock duration of `cascade` in ms — `(max :time) - (min
+  :time)` across every event in the cascade. nil when no event carries
+  a :time. Pure data → number-or-nil; JVM-testable."
+  [cascade]
+  (slice-duration (cascade-events cascade)))
+
+(defn step-breakdown
+  "Per-step duration breakdown for one cascade. Returns a map keyed by
+  the six-domino bucket; each value is ms-or-nil.
+
+  `:handler` is a single event (the `:run-end` emit), so its
+  contribution is collapsed under the handler-and-fx span:
+
+      :handler  — wall-clock from :handler.time → :fx.time
+      :fx       — :fx.time → max of :effects :time
+      :effects  — min :effects :time → max :effects :time (or nil)
+      :subs     — slice-duration over :subs
+      :renders  — slice-duration over :renders
+
+  Each slice is independent — they may overlap with each other in
+  wall-clock time when the trace stream interleaves (e.g. a sub
+  recompute fires during render). v1 ships the simple model; a
+  follow-on bead can lift this into a profiler-grade attribution
+  once the trace stream carries per-event `:duration-ms`.
+
+  Pure data → map; JVM-testable."
+  [{:keys [handler fx effects subs renders] :as _cascade}]
+  (let [t-handler (event-time handler)
+        t-fx      (event-time fx)
+        eff-min   (some-> (bookend effects) first)
+        eff-max   (some-> (bookend effects) second)]
+    {:handler  (when (and t-handler t-fx)
+                 (max 0 (- t-fx t-handler)))
+     :fx       (cond
+                 (and t-fx eff-max) (max 0 (- eff-max t-fx))
+                 t-fx               0
+                 :else              nil)
+     :effects  (when (and eff-min eff-max)
+                 (- eff-max eff-min))
+     :subs     (slice-duration subs)
+     :renders  (slice-duration renders)}))
+
+;; ---- per-cascade projection ---------------------------------------------
+
+(defn- safe-event-vec
+  "Pluck the event vector from a cascade record. Falls back to
+  `[:ungrouped]` for free-floating events / cascades whose dispatched
+  trace isn't in the buffer. Pure data → vector."
+  [{:keys [event] :as _cascade}]
+  (or event [:ungrouped]))
+
+(defn project-cascade
+  "Project one cascade record into a Performance panel row:
+
+      {:dispatch-id  <id-or-:ungrouped>
+       :event        <event-vec>
+       :duration-ms  <number-or-nil>
+       :tier         <:fast :medium :slow :blocking>
+       :over-budget? <bool>
+       :breakdown    {handler fx effects subs renders}
+       :render-count <int>
+       :effect-count <int>
+       :sub-count    <int>}
+
+  Pure data → map; JVM-testable. `budget-ms` is the over-budget
+  threshold; nil disables the over-budget axis (every row classifies
+  as within-budget)."
+  [budget-ms {:keys [dispatch-id effects subs renders] :as cascade}]
+  (let [duration  (cascade-duration cascade)
+        tier      (classify-tier duration)
+        breakdown (step-breakdown cascade)]
+    {:dispatch-id  dispatch-id
+     :event        (safe-event-vec cascade)
+     :duration-ms  duration
+     :tier         tier
+     :over-budget? (over-budget? budget-ms duration)
+     :breakdown    breakdown
+     :render-count (count renders)
+     :effect-count (count effects)
+     :sub-count    (count subs)}))
+
+(defn project-cascades
+  "Project every cascade record in `cascades` into a vector of
+  Performance rows. Cascades whose `:dispatch-id` is `:ungrouped`
+  are dropped — they represent free-floating events (registry-time
+  emits, frame lifecycle outside a drain) that don't carry a
+  meaningful cascade duration. Pure data → vector; JVM-testable."
+  [budget-ms cascades]
+  (into []
+        (comp (remove #(= :ungrouped (:dispatch-id %)))
+              (map #(project-cascade budget-ms %)))
+        cascades))
+
+;; ---- aggregates ----------------------------------------------------------
+
+(defn tier-counts
+  "Histogram of rows by perf tier — used for the panel header summary.
+  Returns a map keyed by every tier in `tier-order` so the chip-row
+  renders with zero counts for missing tiers (no flickering chip set).
+  Pure data → map; JVM-testable."
+  [rows]
+  (let [base (zipmap tier-order (repeat 0))]
+    (reduce
+      (fn [acc {:keys [tier]}]
+        (update acc tier (fnil inc 0)))
+      base
+      rows)))
+
+(defn over-budget-count
+  "Number of rows marked `:over-budget?`. Pure data → int; JVM-
+  testable."
+  [rows]
+  (count (filter :over-budget? rows)))
+
+;; ---- formatting ----------------------------------------------------------
+
+(defn format-duration
+  "Render `duration-ms` as a human-readable string. nil → `\"—\"`.
+  Decimals collapsed at the ms level (sub-millisecond resolution
+  isn't useful for the cascade view). Pure data → string; JVM-
+  testable."
+  [duration-ms]
+  (cond
+    (not (number? duration-ms)) "—"
+    (< duration-ms 1)           "<1ms"
+    :else                       (str (long duration-ms) "ms")))
+
+(defn format-event
+  "Render the event vector as a compact one-line string for the row
+  label. Falls back to `(str event)` when `pr-str` throws. Pure data
+  → string; JVM-testable."
+  [event-vec]
+  (try
+    (pr-str event-vec)
+    (catch #?(:clj Throwable :cljs :default) _
+      (str event-vec))))
+
+(defn truncate
+  "Truncate `s` to `n` chars (with an ellipsis when truncated). The
+  row label uses this to fit inside the panel's fixed grid column.
+  Pure data → string; JVM-testable."
+  [s n]
+  (let [s (str s)]
+    (if (<= (count s) n)
+      s
+      (str (subs s 0 (max 0 (dec n))) "…"))))
+
+;; ---- composite projection (the panel reads this) -----------------------
+
+(defn project-feed
+  "Top-level projection — produces every slot the view needs in one
+  pass. Pure data → data; JVM-testable.
+
+  Returns:
+
+      {:rows               [<row> ...]      ;; newest first
+       :total              <int>            ;; pre-filter count
+       :tier-counts        {tier count}     ;; histogram across rows
+       :over-budget-count  <int>
+       :budget-ms          <number>
+       :empty?             <bool>}
+
+  `cascades` is the six-domino projection over the raw trace buffer
+  (use `re-frame.trace.projection/group-cascades`). `budget-ms` is the
+  over-budget threshold; nil falls back to `default-budget-ms`.
+
+  `:empty?` is true when no cascades carry a dispatch-id (e.g. only
+  free-floating registry traces have landed). The view paints the
+  empty-state in that case."
+  [cascades budget-ms]
+  (let [budget         (or budget-ms default-budget-ms)
+        rows           (project-cascades budget cascades)
+        ;; Newest first — the panel header summarises the latest
+        ;; activity at-a-glance. Per cascade-ordering convention in
+        ;; group-cascades the input is oldest-first.
+        sorted-display (vec (reverse rows))]
+    {:rows              sorted-display
+     :total             (count rows)
+     :tier-counts       (tier-counts rows)
+     :over-budget-count (over-budget-count rows)
+     :budget-ms         budget
+     :empty?            (empty? rows)}))
+
+;; ---- lookup ---------------------------------------------------------------
+
+(defn find-row
+  "Look up a projected row by `:dispatch-id`. Returns nil when not
+  found. Pure data → row-or-nil; JVM-testable."
+  [rows dispatch-id]
+  (some (fn [r] (when (= dispatch-id (:dispatch-id r)) r)) rows))
+
+;; ---- breakdown helpers (view-side) --------------------------------------
+
+(defn breakdown-segments
+  "Lay out the per-step breakdown as a vector of `{:key :ms :width-pct}`
+  segments. `total-ms` is the cascade's total duration (the bar's full
+  width); each segment's `:width-pct` is the fraction of that total it
+  occupies, clamped to `[0, 100]`.
+
+  Slices whose ms is nil / zero are dropped. Pure data → vector;
+  JVM-testable."
+  [breakdown total-ms]
+  (if (or (not (number? total-ms)) (<= total-ms 0))
+    []
+    (let [step-order [:handler :fx :effects :subs :renders]]
+      (into []
+            (keep (fn [k]
+                    (when-let [ms (get breakdown k)]
+                      (when (and (number? ms) (pos? ms))
+                        {:key       k
+                         :ms        ms
+                         :width-pct (min 100.0
+                                         (max 0.0
+                                              (* 100.0 (/ ms total-ms))))})))
+                  step-order)))))
+
+(defn breakdown-colour
+  "Colour swatch for a breakdown slice. Mirrors the per-domino tones
+  used by `event_detail.cljs` so the cross-panel visual is consistent:
+
+      :handler  cyan
+      :fx       cyan
+      :effects  green
+      :subs     cyan
+      :renders  magenta
+
+  Pure data → hex string."
+  [step]
+  (case step
+    :handler  "#43C3D0"  ; cyan
+    :fx       "#43C3D0"  ; cyan
+    :effects  "#4ADE80"  ; green
+    :subs     "#43C3D0"  ; cyan
+    :renders  "#E879F9"  ; magenta
+    "#6B7080"))
+
+(defn breakdown-label
+  "Human-readable label for a breakdown slice."
+  [step]
+  (case step
+    :handler  "handler"
+    :fx       "fx"
+    :effects  "effects"
+    :subs     "subs"
+    :renders  "renders"
+    (str step)))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -126,6 +126,7 @@
             [day8.re-frame2-causa.panels.app-db-diff-helpers :as diff-helpers]
             [day8.re-frame2-causa.panels.hydration-debugger-helpers :as hd-helpers]
             [day8.re-frame2-causa.panels.issues-ribbon-helpers :as issues-helpers]
+            [day8.re-frame2-causa.panels.performance-helpers :as perf-helpers]
             [day8.re-frame2-causa.panels.schema-violation-timeline-helpers :as svt-helpers]
             [day8.re-frame2-causa.panels.subscriptions-helpers :as subs-helpers]
             [day8.re-frame2-causa.panels.trace-helpers :as trace-helpers]))
@@ -1181,6 +1182,49 @@
     (rf/reg-event-db :rf.causa/clear-trace-filters
       (fn [db _event]
         (dissoc db :trace-filters)))
+
+    ;; ---- Phase 5 (rf2-75121) — Performance panel -----------------------
+    ;;
+    ;; Per `tools/causa/spec/000-Vision.md` L92 the Performance panel
+    ;; surfaces per-cascade duration capture, perf-tier colour mapping,
+    ;; and budget-warning markers. The runtime substrate is
+    ;; `spec/009-Instrumentation.md §Performance instrumentation` (the
+    ;; default-off User Timing channel); v1 reads the dev-build trace
+    ;; stream's `:time` deltas instead so the panel works against the
+    ;; same buffer every other Causa panel consumes.
+    ;;
+    ;; Shape of `:rf.causa/performance-data`:
+    ;;
+    ;;     {:rows               [<row> ...]    ;; newest first
+    ;;      :total              <int>
+    ;;      :tier-counts        {tier count}
+    ;;      :over-budget-count  <int>
+    ;;      :budget-ms          <number>
+    ;;      :empty?             <bool>}
+    ;;
+    ;; No new events are required — the panel reuses
+    ;; `:rf.causa/select-dispatch-id` + `:rf.causa/select-panel` for the
+    ;; pivot-into-event-detail affordance (parity with the Issues
+    ;; ribbon's row-click). The over-budget threshold is sub-readable
+    ;; via `:rf.causa/performance-budget-ms` so a follow-on bead can
+    ;; surface a slider in the panel header without rewiring consumers.
+    (rf/reg-sub :rf.causa/performance-budget-ms
+      (fn [db _query]
+        (get db :performance-budget-ms perf-helpers/default-budget-ms)))
+
+    (rf/reg-sub :rf.causa/performance-data
+      :<- [:rf.causa/trace-buffer]
+      :<- [:rf.causa/performance-budget-ms]
+      (fn [[buffer budget-ms] _query]
+        (let [cascades (projection/group-cascades buffer)]
+          (perf-helpers/project-feed cascades budget-ms))))
+
+    ;; Set the over-budget threshold. Pass nil to reset to default.
+    (rf/reg-event-db :rf.causa/set-performance-budget-ms
+      (fn [db [_ budget-ms]]
+        (if (and (number? budget-ms) (pos? budget-ms))
+          (assoc db :performance-budget-ms budget-ms)
+          (dissoc db :performance-budget-ms))))
 
     ;; ---- Phase 5 (rf2-rccf3) — AI Co-Pilot panel -----------------------
     ;;

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -44,6 +44,7 @@
             [day8.re-frame2-causa.panels.causality-graph :as causality-graph]
             [day8.re-frame2-causa.panels.hydration-debugger :as hydration-debugger]
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
+            [day8.re-frame2-causa.panels.performance :as performance]
             [day8.re-frame2-causa.panels.schema-violation-timeline :as schema-violation-timeline]
             [day8.re-frame2-causa.panels.subscriptions :as subscriptions]
             [day8.re-frame2-causa.panels.trace :as trace]
@@ -85,7 +86,7 @@
    {:id :trace        :label "Trace"         :bead "rf2-argrj" :live? true}
    {:id :machines     :label "Machines"      :bead "rf2-xxx"}
    {:id :flows        :label "Flows"         :bead "rf2-xxx"}
-   {:id :performance  :label "Performance"   :bead "rf2-xxx"}
+   {:id :performance  :label "Performance"   :bead "rf2-75121" :live? true}
    {:id :issues       :label "Issues"        :bead "rf2-d1p4o" :live? true}
    {:id :schemas      :label "Schemas"       :bead "rf2-htffa" :live? true}
    ;; Phase 5 (rf2-pzxsr). Per spec/006-Hydration-Debugger.md §Visibility
@@ -270,6 +271,7 @@
       :hydration    [hydration-debugger/hydration-debugger-view]
       :issues       [issues-ribbon/issues-ribbon-view]
       :trace        [trace/trace-view]
+      :performance  [performance/performance-view]
       ;; Sidebar Co-pilot row renders the panel-style view in the
       ;; canvas; the rail still lives in the shell's right margin per
       ;; spec/007-UX-IA.md §The five regions item 4.

--- a/tools/causa/test/day8/re_frame2_causa/panels/performance_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/performance_helpers_cljs_test.cljc
@@ -1,0 +1,426 @@
+(ns day8.re-frame2-causa.panels.performance-helpers-cljs-test
+  "Pure-data tests for Causa's Performance panel helpers (Phase 5,
+  rf2-75121).
+
+  ## Why the `.cljc` + `_cljs_test` naming
+
+  Same dual-target pattern as `issues_ribbon_helpers_cljs_test.cljc`:
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  ## What's under test
+
+    1. **classify-tier** — duration → perf tier per spec/007 §Colour
+       scale (boundaries: 16ms, 50ms, 100ms).
+    2. **tier-colour / -glyph / -label** — stable mappings.
+    3. **over-budget?** — threshold-based classification.
+    4. **slice-duration / cascade-duration** — :time delta math.
+    5. **step-breakdown** — per-domino slice durations.
+    6. **project-cascade / project-cascades** — row projection.
+    7. **tier-counts / over-budget-count** — aggregates.
+    8. **project-feed** — the composite the panel reads.
+    9. **find-row** — selection lookup.
+   10. **breakdown-segments** — view-side bar layout.
+   11. **format-duration / format-event / truncate** — formatting."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [re-frame.trace.projection :as projection]
+            [day8.re-frame2-causa.panels.performance-helpers :as h]))
+
+;; ---- fixture builders ----------------------------------------------------
+
+(defn- dispatched-ev
+  "Build a `:event/dispatched` trace event for `dispatch-id`."
+  [id time dispatch-id event-vec]
+  {:id        id
+   :op-type   :event
+   :operation :event/dispatched
+   :time      time
+   :tags      {:dispatch-id dispatch-id
+               :event       event-vec
+               :origin      :app}})
+
+(defn- handler-ev
+  "Build a `:run-end` handler trace event."
+  [id time dispatch-id]
+  {:id id :time time :op-type :event :operation :event
+   :tags {:dispatch-id dispatch-id :phase :run-end}})
+
+(defn- fx-emit-ev
+  "Build a `:event/do-fx` trace event — the third domino marker."
+  [id time dispatch-id]
+  {:id id :time time :op-type :event :operation :event/do-fx
+   :tags {:dispatch-id dispatch-id}})
+
+(defn- effect-ev
+  [id time dispatch-id fx-id]
+  {:id id :time time :op-type :fx :operation :rf.fx/handled
+   :tags {:dispatch-id dispatch-id :fx-id fx-id}})
+
+(defn- sub-ev
+  [id time dispatch-id sub-id]
+  {:id id :time time :op-type :sub/run :operation :sub/run
+   :tags {:dispatch-id dispatch-id :sub-id sub-id}})
+
+(defn- render-ev
+  [id time dispatch-id render-key]
+  {:id id :time time :op-type :view :operation :view/render
+   :tags {:dispatch-id dispatch-id :render-key render-key}})
+
+(defn- cascade-events
+  "Build a representative one-cascade trace stream where each domino
+  marker is offset by `+step-ms` from the previous one. Used to
+  exercise the duration math against a known set of bookends."
+  [dispatch-id event-vec base-time]
+  [(dispatched-ev (* 10 dispatch-id) base-time dispatch-id event-vec)
+   (handler-ev   (+ (* 10 dispatch-id) 1) (+ base-time 1)  dispatch-id)
+   (fx-emit-ev   (+ (* 10 dispatch-id) 2) (+ base-time 3)  dispatch-id)
+   (effect-ev    (+ (* 10 dispatch-id) 3) (+ base-time 5)  dispatch-id :db)
+   (effect-ev    (+ (* 10 dispatch-id) 4) (+ base-time 7)  dispatch-id :dispatch)
+   (sub-ev       (+ (* 10 dispatch-id) 5) (+ base-time 8)  dispatch-id :foo)
+   (render-ev    (+ (* 10 dispatch-id) 6) (+ base-time 10) dispatch-id :app)
+   (render-ev    (+ (* 10 dispatch-id) 7) (+ base-time 12) dispatch-id :header)])
+
+;; ---- (1) tier classification --------------------------------------------
+
+(deftest classify-tier-spec-boundaries
+  (testing "fast < 16ms"
+    (is (= :fast (h/classify-tier 0)))
+    (is (= :fast (h/classify-tier 1)))
+    (is (= :fast (h/classify-tier 15)))
+    (is (= :fast (h/classify-tier 15.9))))
+  (testing "medium = [16, 50)"
+    (is (= :medium (h/classify-tier 16)))
+    (is (= :medium (h/classify-tier 30)))
+    (is (= :medium (h/classify-tier 49))))
+  (testing "slow = [50, 100)"
+    (is (= :slow (h/classify-tier 50)))
+    (is (= :slow (h/classify-tier 75)))
+    (is (= :slow (h/classify-tier 99))))
+  (testing "blocking >= 100"
+    (is (= :blocking (h/classify-tier 100)))
+    (is (= :blocking (h/classify-tier 500)))
+    (is (= :blocking (h/classify-tier 1000))))
+  (testing "nil / negative / non-numeric collapse to :fast"
+    (is (= :fast (h/classify-tier nil)))
+    (is (= :fast (h/classify-tier -5)))
+    (is (= :fast (h/classify-tier "not a number")))))
+
+(deftest tier-colour-mirrors-spec
+  (testing "perf-scale hex strings match tools/causa/spec/007-UX-IA.md §Colour system"
+    (is (= "#4ADE80" (h/tier-colour :fast)))      ; green
+    (is (= "#FBBF24" (h/tier-colour :medium)))    ; yellow
+    (is (= "#FB923C" (h/tier-colour :slow)))      ; orange
+    (is (= "#F87171" (h/tier-colour :blocking)))  ; red
+    (is (= "#6B7080" (h/tier-colour :unknown))))) ; fallback
+
+(deftest tier-glyph-pairs-shape-with-colour
+  (testing "Colour is never alone (spec/007 §Colour is never alone)"
+    ;; Within-budget tiers — calm dot
+    (is (= "●" (h/tier-glyph :fast)))
+    (is (= "●" (h/tier-glyph :medium)))
+    ;; Over-budget tiers — attention triangle
+    (is (= "▲" (h/tier-glyph :slow)))
+    (is (= "▲" (h/tier-glyph :blocking)))))
+
+(deftest tier-label-stable
+  (is (= "fast"     (h/tier-label :fast)))
+  (is (= "medium"   (h/tier-label :medium)))
+  (is (= "slow"     (h/tier-label :slow)))
+  (is (= "blocking" (h/tier-label :blocking))))
+
+(deftest tier-order-is-fastest-first
+  (is (= [:fast :medium :slow :blocking] h/tier-order)))
+
+;; ---- (2) over-budget? ---------------------------------------------------
+
+(deftest over-budget-honours-threshold
+  (testing "duration at or above budget is over-budget"
+    (is (true? (h/over-budget? 16 16)))
+    (is (true? (h/over-budget? 16 17)))
+    (is (true? (h/over-budget? 16 100))))
+  (testing "duration below budget is within-budget"
+    (is (false? (h/over-budget? 16 0)))
+    (is (false? (h/over-budget? 16 15.9))))
+  (testing "nil / non-number guards"
+    (is (false? (h/over-budget? nil 100)))
+    (is (false? (h/over-budget? 16 nil)))
+    (is (false? (h/over-budget? "x" 50)))
+    (is (false? (h/over-budget? 16 "x")))))
+
+(deftest default-budget-is-one-frame-at-60fps
+  (testing "16ms default budget per dispatch instructions"
+    (is (= 16 h/default-budget-ms))))
+
+;; ---- (3) slice / cascade duration ---------------------------------------
+
+(deftest slice-duration-bookends
+  (testing "max - min across the events"
+    (is (= 5 (h/slice-duration [{:time 10} {:time 12} {:time 15}])))
+    (is (= 0 (h/slice-duration [{:time 100}])))
+    (is (nil? (h/slice-duration [])))
+    (is (nil? (h/slice-duration [{:no-time-here true}])))))
+
+(deftest cascade-duration-spans-every-event
+  (testing "duration is max-time minus min-time across the whole cascade"
+    (let [cascade {:dispatch-id 1
+                   :handler  {:time 5}
+                   :fx       {:time 8}
+                   :effects  [{:time 10} {:time 12}]
+                   :subs     [{:time 14}]
+                   :renders  [{:time 18} {:time 20}]
+                   :other    []}]
+      (is (= 15 (h/cascade-duration cascade))))))
+
+(deftest cascade-duration-nil-when-no-times
+  (let [cascade {:dispatch-id 1
+                 :handler nil
+                 :fx nil
+                 :effects []
+                 :subs []
+                 :renders []
+                 :other []}]
+    (is (nil? (h/cascade-duration cascade)))))
+
+;; ---- (4) step-breakdown -------------------------------------------------
+
+(deftest step-breakdown-derives-per-domino-slices
+  (let [cascade {:dispatch-id 1
+                 :handler  {:time 5}
+                 :fx       {:time 8}
+                 :effects  [{:time 10} {:time 14}]
+                 :subs     [{:time 16} {:time 18}]
+                 :renders  [{:time 20} {:time 26}]
+                 :other    []}
+        bd      (h/step-breakdown cascade)]
+    (testing "handler = handler.time → fx.time"
+      (is (= 3 (:handler bd))))
+    (testing "fx = fx.time → max effects.time"
+      (is (= 6 (:fx bd))))
+    (testing "effects = bookend over effects"
+      (is (= 4 (:effects bd))))
+    (testing "subs / renders = bookend slices"
+      (is (= 2 (:subs bd)))
+      (is (= 6 (:renders bd))))))
+
+(deftest step-breakdown-missing-slots-collapse-to-nil
+  (let [cascade {:dispatch-id 1
+                 :handler nil
+                 :fx nil
+                 :effects []
+                 :subs []
+                 :renders []
+                 :other []}
+        bd      (h/step-breakdown cascade)]
+    (is (nil? (:handler bd)))
+    (is (nil? (:fx bd)))
+    (is (nil? (:effects bd)))
+    (is (nil? (:subs bd)))
+    (is (nil? (:renders bd)))))
+
+;; ---- (5) project-cascade ------------------------------------------------
+
+(deftest project-cascade-row-shape
+  (let [stream  (cascade-events 1 [:counter/inc] 100)
+        cascade (first (projection/group-cascades stream))
+        row     (h/project-cascade 16 cascade)]
+    (testing "every documented row slot is populated"
+      (is (= 1 (:dispatch-id row)))
+      (is (= [:counter/inc] (:event row)))
+      ;; The cascade record's bookends come from the six-domino slots
+      ;; (handler / fx / effects / subs / renders / other); the
+      ;; :event/dispatched event itself only contributes the event
+      ;; vector (per re-frame.trace.projection/absorb). The fixture's
+      ;; handler lands at base+1, last render at base+12 → 11ms span.
+      (is (= 11 (:duration-ms row)))
+      (is (= :fast (:tier row)))         ; 11ms < 16ms
+      (is (false? (:over-budget? row))) ; 11ms < 16ms budget
+      (is (map? (:breakdown row)))
+      (is (= 2 (:render-count row)))
+      (is (= 2 (:effect-count row)))
+      (is (= 1 (:sub-count row))))))
+
+(deftest project-cascade-over-budget-flag
+  (testing "duration >= budget marks over-budget"
+    (let [;; Stretch the cascade so it crosses the 50ms boundary —
+          ;; handler at +5, last render at +60 → 55ms span → :slow.
+          stream  [(dispatched-ev 1 0   1 [:slow/op])
+                   (handler-ev    2 5   1)
+                   (fx-emit-ev    3 7   1)
+                   (effect-ev     4 12  1 :db)
+                   (render-ev     5 60  1 :app)]
+          cascade (first (projection/group-cascades stream))
+          row     (h/project-cascade 16 cascade)]
+      (is (= 55 (:duration-ms row)))
+      (is (= :slow (:tier row)))         ; 55ms → slow (50-100ms band)
+      (is (true? (:over-budget? row))))))
+
+(deftest project-cascade-event-fallback
+  (testing "missing :event vector falls back to [:ungrouped]"
+    (let [cascade {:dispatch-id 5
+                   :event nil
+                   :handler {:time 1}
+                   :fx {:time 2}
+                   :effects [] :subs [] :renders [] :other []}
+          row     (h/project-cascade 16 cascade)]
+      (is (= [:ungrouped] (:event row))))))
+
+;; ---- (6) project-cascades ----------------------------------------------
+
+(deftest project-cascades-drops-ungrouped
+  (testing "free-floating events (cascade-id :ungrouped) don't surface"
+    (let [;; Three cascades: 2 dispatched, 1 ungrouped (no :dispatch-id tag)
+          stream (concat
+                   (cascade-events 1 [:a] 0)
+                   (cascade-events 2 [:b] 1000)
+                   ;; A free-floating registry event without a dispatch-id
+                   [{:id 999 :time 500 :op-type :warning
+                     :operation :rf.warning/handler-replaced
+                     :tags {}}])
+          cascades (projection/group-cascades stream)
+          rows     (h/project-cascades 16 cascades)]
+      (is (= 2 (count rows)))
+      (is (every? (fn [r] (not= :ungrouped (:dispatch-id r))) rows)))))
+
+(deftest project-cascades-newest-first-not-required-here
+  ;; project-cascades preserves group-cascades' oldest-first order;
+  ;; project-feed flips to newest-first (the panel-facing slot).
+  (let [stream (concat (cascade-events 1 [:a] 0)
+                       (cascade-events 2 [:b] 1000))
+        rows   (h/project-cascades 16 (projection/group-cascades stream))]
+    (is (= [1 2] (mapv :dispatch-id rows)))))
+
+;; ---- (7) tier-counts / over-budget-count -------------------------------
+
+(deftest tier-counts-histogram
+  (let [rows [{:tier :fast}      {:tier :fast}
+              {:tier :medium}
+              {:tier :slow}
+              {:tier :blocking}  {:tier :blocking}]]
+    (is (= {:fast 2 :medium 1 :slow 1 :blocking 2}
+           (h/tier-counts rows)))))
+
+(deftest tier-counts-zero-fill-missing
+  (testing "missing tiers carry an explicit 0 so the chip-row is stable"
+    (is (= {:fast 0 :medium 0 :slow 0 :blocking 0}
+           (h/tier-counts [])))
+    (is (= {:fast 1 :medium 0 :slow 0 :blocking 0}
+           (h/tier-counts [{:tier :fast}])))))
+
+(deftest over-budget-count-honours-flag
+  (let [rows [{:over-budget? true}
+              {:over-budget? false}
+              {:over-budget? true}
+              {:over-budget? nil}]]
+    (is (= 2 (h/over-budget-count rows)))))
+
+;; ---- (8) project-feed (composite the panel reads) ----------------------
+
+(deftest project-feed-populates-every-slot
+  (let [stream   (concat (cascade-events 1 [:a] 0)
+                         (cascade-events 2 [:b] 1000))
+        cascades (projection/group-cascades stream)
+        feed     (h/project-feed cascades 16)]
+    (testing "row-set"
+      (is (= 2 (count (:rows feed))))
+      (testing "rows are newest first per the bead's contract"
+        (is (= [2 1] (mapv :dispatch-id (:rows feed))))))
+    (testing "total / counts / budget"
+      (is (= 2 (:total feed)))
+      (is (= 4 (count (:tier-counts feed))))
+      (is (= 0 (:over-budget-count feed)))
+      (is (= 16 (:budget-ms feed)))
+      (is (false? (:empty? feed))))))
+
+(deftest project-feed-empty-state
+  (let [feed (h/project-feed [] nil)]
+    (is (true? (:empty? feed)))
+    (is (= [] (:rows feed)))
+    (is (= 0 (:total feed)))
+    (is (= h/default-budget-ms (:budget-ms feed)))))
+
+(deftest project-feed-budget-default
+  (testing "nil :budget-ms falls back to default-budget-ms"
+    (let [feed (h/project-feed [] nil)]
+      (is (= h/default-budget-ms (:budget-ms feed))))
+    (let [feed (h/project-feed [] 100)]
+      (is (= 100 (:budget-ms feed))))))
+
+(deftest project-feed-flags-over-budget
+  (let [;; Cascade spans handler@10 → render@70 = 60ms → :slow
+        stream   [(dispatched-ev 1 0  1 [:slow])
+                  (handler-ev    2 10 1)
+                  (fx-emit-ev    3 20 1)
+                  (render-ev     4 70 1 :app)]
+        cascades (projection/group-cascades stream)
+        feed     (h/project-feed cascades 16)]
+    (is (= 1 (:over-budget-count feed)))
+    (is (true? (-> feed :rows first :over-budget?)))
+    (is (= :slow (-> feed :rows first :tier)))))
+
+;; ---- (9) find-row ------------------------------------------------------
+
+(deftest find-row-lookup
+  (let [rows [{:dispatch-id 1 :tier :fast}
+              {:dispatch-id 2 :tier :medium}
+              {:dispatch-id 3 :tier :blocking}]]
+    (is (= :medium (:tier (h/find-row rows 2))))
+    (is (nil? (h/find-row rows 99)))))
+
+;; ---- (10) breakdown-segments (view-side) -------------------------------
+
+(deftest breakdown-segments-shape
+  (let [bd        {:handler 5 :fx 3 :effects 4 :subs 2 :renders 6}
+        total     20
+        segs      (h/breakdown-segments bd total)]
+    (testing "every slice with a positive ms produces a segment"
+      (is (= 5 (count segs)))
+      (is (= [:handler :fx :effects :subs :renders]
+             (mapv :key segs))))
+    (testing "width-pct sums to 100 when slices span the full total"
+      (is (= 100.0
+             (reduce + (map :width-pct segs)))))))
+
+(deftest breakdown-segments-drops-zero-and-nil
+  (let [bd    {:handler nil :fx 0 :effects 5 :subs nil :renders 5}
+        segs  (h/breakdown-segments bd 10)]
+    (is (= 2 (count segs)))
+    (is (= [:effects :renders] (mapv :key segs)))))
+
+(deftest breakdown-segments-zero-or-nil-total
+  (testing "non-positive / nil total → empty vector"
+    (is (= [] (h/breakdown-segments {:handler 5} 0)))
+    (is (= [] (h/breakdown-segments {:handler 5} nil)))
+    (is (= [] (h/breakdown-segments {:handler 5} -1)))))
+
+(deftest breakdown-colour-stable
+  (is (= "#43C3D0" (h/breakdown-colour :handler)))
+  (is (= "#43C3D0" (h/breakdown-colour :fx)))
+  (is (= "#4ADE80" (h/breakdown-colour :effects)))
+  (is (= "#43C3D0" (h/breakdown-colour :subs)))
+  (is (= "#E879F9" (h/breakdown-colour :renders))))
+
+;; ---- (11) formatting --------------------------------------------------
+
+(deftest format-duration-stable
+  (is (= "—"     (h/format-duration nil)))
+  (is (= "—"     (h/format-duration "x")))
+  (is (= "<1ms"  (h/format-duration 0)))
+  (is (= "<1ms"  (h/format-duration 0.4)))
+  (is (= "1ms"   (h/format-duration 1)))
+  (is (= "16ms"  (h/format-duration 16)))
+  (is (= "120ms" (h/format-duration 120.7))))
+
+(deftest format-event-stable
+  (is (= "[:counter/inc]"  (h/format-event [:counter/inc])))
+  (is (= "[:ungrouped]"    (h/format-event [:ungrouped]))))
+
+(deftest truncate-honours-cap
+  (is (= "hello" (h/truncate "hello" 10)))
+  (is (= "hell…" (h/truncate "hello world" 5)))
+  ;; Truncating to 0 keeps just the ellipsis — the indicator that
+  ;; *something* was elided rather than a silent empty string.
+  (is (= "…"     (h/truncate "x" 0))))


### PR DESCRIPTION
## Summary

Phase 5 of the rf2-5aw5v Causa epic. Lights up the Performance sidebar entry with a UI consumer of the Spec 009 §Performance instrumentation surface — v1 reads the dev-build trace stream's `:time` deltas so the panel works against the same buffer every other Causa panel already consumes.

Per-cascade rows show *tier-glyph · dispatch-id · event vector · total duration · per-step bar · over-budget marker*. The perf-tier scale follows `tools/causa/spec/007-UX-IA.md` §Colour system §Perf scale:

| Tier | Threshold | Glyph | Colour |
|---|---|---|---|
| `:fast` | <16ms (1 frame @ 60fps) | ● | green `#4ADE80` |
| `:medium` | 16-50ms | ● | yellow `#FBBF24` |
| `:slow` | 50-100ms | ▲ | orange `#FB923C` |
| `:blocking` | ≥100ms (INP threshold) | ▲ | red `#F87171` |

Default budget threshold = **16ms** (sub-readable via `:rf.causa/performance-budget-ms`; settable via `:rf.causa/set-performance-budget-ms`). Rows whose duration crosses the budget carry an `over` marker on the right edge; clicking any row pivots into the event-detail panel for that cascade.

## Surfaces

- `tools/causa/src/day8/re_frame2_causa/panels/performance.cljs` — view (pure hiccup, reads `:rf.causa/performance-data`).
- `tools/causa/src/day8/re_frame2_causa/panels/performance_helpers.cljc` — `.cljc` + JVM-testable: tier classification, slice-duration math, step-breakdown, project-cascade / project-feed, format helpers.
- `tools/causa/test/day8/re_frame2_causa/panels/performance_helpers_cljs_test.cljc` — 27 deftests covering tier boundaries, over-budget classification, cascade-duration math, step-breakdown, project-feed shape, aggregates, formatting.
- `registry.cljs` — `:rf.causa/performance-data` composite sub + `:rf.causa/set-performance-budget-ms` event.
- `shell.cljs` — sidebar `:performance` flipped to `:live? true`; canvas mounts `[performance/performance-view]`.

## Out of v1 scope

Per the bead's minimum-viable contract:

- No `PerformanceObserver` integration (INP / long-task / layout-shift overlays). These ride a follow-on bead once the shared `rf.causa.fx/install-performance-observer!` effect lands (Trace panel will share it).
- No drag-zoom horizontal ribbon; v1 ships the row view.
- No re-render-counts-per-epoch projection from `:rf/epoch-record :renders`; the row's render-count is the count of `:view/render` traces in the cascade (cheap proxy).

## Test plan

- [x] `clojure -M:test` in `tools/causa/` — 269 tests, 793 assertions, 0 failures (adds 27 new perf-helpers assertions)
- [x] `npm run test:cljs` — 1183 tests, 3136 assertions, 0 failures
- [x] `npm run test:elision` — PASS
- [x] `npm run test:bundle-isolation` — PASS
- [ ] Manual UX smoke (next session)

Parent epic: rf2-5aw5v.