### PR TITLE
fix(examples): counter-with-stories §10 selector scoped to active variant — closes 16% flake (rf2-9la06)

### DIFF
--- a/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
+++ b/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
@@ -748,8 +748,26 @@ module.exports = {
     // Clicking the canvas's "+" button dispatches `:counter/inc` —
     // the trace listener buckets it into a cascade and the panel's
     // title bumps its event count above zero.
+    //
+    // Per rf2-9la06: scope all main-pane selectors via the
+    // `data-test-variant` anchor that canvas.cljs stamps on the active
+    // variant's <section>. Without that anchor, `main.locator(...)`
+    // can resolve to a stale workspace cell that's still mounted under
+    // <main> because §§5/6 selected a workspace and §7's variant click
+    // doesn't clear `:selected-workspace` (selection slots are
+    // independent — see tools/story state.cljc). When the workspace
+    // is still mounted, `main.locator('[data-test="inc"]').first()`
+    // picks the alphabetically-first cell (`:story.counter/clicked-
+    // three-times`, count=3 after :play), the click bumps it to 4,
+    // and the §11 scrubber assertion (driven against the right-pane
+    // slider, which IS scoped to the active variant) reports "still
+    // 4" — the canonical signature of this flake.
     const main = page.getByRole('main');
-    await main.locator('[data-test="inc"]').first().click();
+    const loadedCanvas = main.locator(
+      '[data-test-variant=":story.counter/loaded"]',
+    );
+    await loadedCanvas.waitFor({ state: 'visible', timeout: 5000 });
+    await loadedCanvas.locator('[data-test="inc"]').first().click();
 
     // The trace panel's title is "Trace <variant-id> — N events, M cascades".
     // We wait until the count is non-zero.
@@ -838,7 +856,14 @@ module.exports = {
     // mouseup via :on-mouse-up; Playwright's fill() doesn't fire that,
     // so we set the value via DOM and dispatch the events the panel
     // listens for explicitly.
-    const canvasCount = main.locator('[data-test="count"]').first();
+    //
+    // Per rf2-9la06: read the count from the active variant's canvas
+    // via the `data-test-variant` anchor — `main.locator(...).first()`
+    // could land on a workspace cell from §§5/6 whose `:counter/
+    // initialise` settled to a different value (the scrubber here is
+    // the right-pane slider, which IS scoped to the active variant;
+    // mismatched canvas + slider was the original "still 4" failure).
+    const canvasCount = loadedCanvas.locator('[data-test="count"]').first();
     const beforeText = (await canvasCount.textContent()) || '';
 
     await slider.evaluate((el) => {
@@ -923,7 +948,12 @@ module.exports = {
     // record the slider's current `max` and scrub to it; the latest
     // record IS the inc we just clicked because every dispatch settles
     // a new epoch at the tail.
-    await main.locator('[data-test="inc"]').first().click();
+    //
+    // Per rf2-9la06: scope the click to the active variant's canvas
+    // (same rationale as the §10 click above — `.first()` under raw
+    // <main> could land on a workspace cell whose state is unrelated
+    // to the right-pane scrubber's variant).
+    await loadedCanvas.locator('[data-test="inc"]').first().click();
 
     // Wait for the slider's max to advance once the inc settles in the
     // framework's epoch ring buffer (the listener wires synchronous

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -310,9 +310,18 @@
          ;; passes. The `<section>` element + aria-label give it a
          ;; landmark name (it's nested inside the shell's <main> so
          ;; landmark structure remains: main > section).
-         [:section {:style      (:wrap styles)
-                    :aria-label "Variant canvas"
-                    :tab-index  "0"}
+         ;;
+         ;; Per rf2-9la06: also stamp `data-test-variant` with the
+         ;; active variant id so Playwright specs can scope selectors
+         ;; to the canvas of a specific variant — disambiguates the
+         ;; canvas from sibling workspace cells whose state may not yet
+         ;; have torn down (sidebar `:selected-variant` and
+         ;; `:selected-workspace` are independent slots; clicking a
+         ;; variant doesn't clear a previously-selected workspace).
+         [:section (cond-> {:style      (:wrap styles)
+                            :aria-label "Variant canvas"
+                            :tab-index  "0"}
+                     variant-id (assoc :data-test-variant (pr-str variant-id)))
           (if variant-id
             [canvas-inner variant-id]
             [:div {:style (:empty styles)}

--- a/tools/story/src/re_frame/story/ui/workspace.cljc
+++ b/tools/story/src/re_frame/story/ui/workspace.cljc
@@ -200,7 +200,13 @@
                                                       variant-id])})
            assertions     (runtime/read-assertions variant-id)
            errors         (:errors decorator-pack)]
-       [:div {:style (:cell styles)}
+       ;; Per rf2-9la06: stamp `data-test-variant` on each cell so
+       ;; Playwright specs can disambiguate workspace cells from each
+       ;; other and from the canvas's variant when both are mounted
+       ;; (sidebar `:selected-variant` and `:selected-workspace` are
+       ;; independent slots; one doesn't clear the other on selection).
+       [:div {:style (:cell styles)
+              :data-test-variant (pr-str variant-id)}
         [:div {:style (:cell-title styles)}
          [:span (pr-str variant-id)]
          (when view-id


### PR DESCRIPTION
## Summary

- Adds `data-test-variant` anchors on the Story canvas `<section>` and on each workspace cell so Playwright specs can scope main-pane selectors to a specific variant.
- Updates `counter_with_stories.spec.cjs` §10 / §11 / §11b to drive every `inc` click and `count` read through a `loadedCanvas` locator pinned to `:story.counter/loaded`.

**Root cause.** The Story shell's `:selected-variant` and `:selected-workspace` slots are independent (see `tools/story/src/re_frame/story/ui/state.cljc`). After §§5/6 select a workspace, §7's variant click sets `:selected-variant` but leaves `:selected-workspace` populated — the `cond` in `shell.cljs::main-pane` picks workspace over canvas, so the workspace pane keeps rendering while the right-pane inspectors bind to the variant. In that state, `main.locator('[data-test="inc"]').first()` lands on the alphabetically-first cell of `:Workspace.counter/auto-grid` — `:story.counter/clicked-three-times`, whose `:play` sequence drives count=3. §10 bumps it to 4. §11 then scrubs the right-pane slider (correctly scoped to `/loaded`) but the canvas-count locator under `<main>` still reads the workspace cell, so `beforeText="4"` and `afterText="4"` and the assertion throws "time-travel scrub did not visibly change :count (still 4)" — the exact CI signature.

**Fix path.** Path (b) from the bead — `data-test-variant` anchor + tighter locators. Both code paths (canvas-rendered AND workspace-rendered) now stamp `data-test-variant="<variant-id>"`, and the spec scopes through it. The fix is robust regardless of whether the underlying workspace/variant state hazard ever gets addressed (which is a separate UX discussion — the current independence is intentional for sidebar + breadcrumb navigation).

## Test plan

- [x] **20/20 consecutive local runs pass** of the `counter-with-stories` spec against the chromium build at `out/examples/counter-with-stories`. (CI flake rate was 16% per the bead investigation; 20 consecutive passes is the bead's stated verification threshold.)
- [x] `shadow-cljs compile examples/counter-with-stories` succeeds.
- [x] No CLJS tests reference `data-test-variant`, the workspace cell hiccup shape, or the canvas section attribute set, so the new attribute is purely additive.
- [ ] CI green on `Examples (browser, headless Chromium)` — the load-bearing gate.

Closes the flake without changing shell state semantics.

rf2-9la06