### PR TITLE
feat(causa): Flows panel — Phase 5 (rf2-83irn)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/flows.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/flows.cljs
@@ -1,0 +1,303 @@
+(ns day8.re-frame2-causa.panels.flows
+  "Flows panel — Phase 5 (rf2-83irn, parent rf2-5aw5v).
+
+  Surfaces re-frame2's registered flows + their per-flow inputs / output
+  path / live recomputation indicator. Consumer of:
+
+    - Spec 013 (Flows)             — the registered-flow surface;
+                                     `(rf/handlers :flow)` is the
+                                     `{flow-id metadata}` projection
+                                     the composite sub reads.
+    - Spec 009 (Instrumentation)   — the `:rf.flow/*` trace event
+                                     vocabulary. The panel filters the
+                                     Causa trace buffer to `:op-type
+                                     :flow` and derives a per-flow
+                                     status from the latest event.
+
+  ## What this panel shows
+
+  One row per registered flow, with — left to right:
+
+    - status badge (`:failed` / `:computing` / `:skipping` / `:idle`),
+    - the flow-id (mono column),
+    - the inputs paths (` · `-separated),
+    - the output path,
+    - a `RAN` cue when the flow recomputed *this* cascade (the live
+      recomputation indicator),
+    - the most-recent operation in a small caption (for at-a-glance
+      flow-state debugging).
+
+  Clicking a row selects that flow — Phase-5 minimum-viable contract
+  carries the selection; the deeper detail strip (recent events,
+  jump-to-event-detail) lands when the cross-panel wiring stabilises.
+
+  Empty state: \"No flows registered.\"
+
+  ## Pure hiccup
+
+  Same contract as every other Causa panel — the view is pure hiccup,
+  no Reagent / UIx / Helix references. Frame isolation comes from the
+  enclosing `[rf/frame-provider {:frame :rf/causa}]` in `shell.cljs`.
+  Every `subscribe` / `dispatch` here resolves to the `:rf/causa`
+  frame.
+
+  ## Helpers
+
+  All pure-data logic — `project-rows`, `compute-status`, `latest-
+  cascade-dispatch-id`, ... — lives in `flows_helpers.cljc` so the
+  algebra runs under the JVM unit-test target."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.flows-helpers :as h]))
+
+;; ---- design tokens (mirrors subscriptions.cljs / event_detail.cljs) ----
+
+(def ^:private tokens
+  "Subset of shell.cljs's dark-theme tokens used by this panel. Kept
+  in sync manually for now — the v1.0 styling pass replaces these
+  with CSS variables across all panels."
+  {:bg-1            "#15171B"
+   :bg-2            "#1B1E24"
+   :bg-3            "#232730"
+   :bg-active       "#2A2F3D"
+   :border-subtle   "#232730"
+   :border-default  "#2F3441"
+   :text-primary    "#E8EAF0"
+   :text-secondary  "#A8AEC0"
+   :text-tertiary   "#6B7080"
+   :accent-violet   "#7C5CFF"
+   :cyan            "#43C3D0"
+   :green           "#4ADE80"
+   :yellow          "#FBBF24"
+   :red             "#F87171"
+   :magenta         "#E879F9"})
+
+(def ^:private mono-stack
+  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
+  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
+
+(def ^:private sans-stack
+  "Inter stack per spec/007-UX-IA.md §Typography."
+  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+
+;; ---- pure helpers -------------------------------------------------------
+
+(defn- status-colour
+  "Resolve a status's colour token to its hex via the panel's
+  `tokens` map. Single point of indirection so the test suite can
+  assert against the token without touching the hex."
+  [status]
+  (let [tok (get h/status->token status :text-tertiary)]
+    (get tokens tok (:text-tertiary tokens))))
+
+;; ---- status badge -------------------------------------------------------
+
+(defn- status-badge
+  "Colour + shape + tooltip-label, 14px on cosy density. Sits at the
+  left margin of every flow row. `status` is one of the canonical
+  four — `#{:computing :idle :skipping :failed}`."
+  [status]
+  (let [glyph   (get h/status->glyph status "?")
+        colour  (status-colour status)
+        tooltip (get h/status->tooltip status "Unknown")]
+    [:span {:data-testid     (str "rf-causa-flow-badge-" (name status))
+            :title           tooltip
+            :aria-label      tooltip
+            :style           {:display        "inline-block"
+                              :width          "14px"
+                              :height         "14px"
+                              :line-height    "14px"
+                              :text-align     "center"
+                              :color          colour
+                              :font-family    mono-stack
+                              :font-size      "14px"
+                              :font-weight    700
+                              :margin-right   "8px"
+                              :flex-shrink    0}}
+     glyph]))
+
+;; ---- flow row -----------------------------------------------------------
+
+(defn- frame-pill
+  "Compact frame indicator — flows are frame-scoped per Spec 013
+  §Frame-scoping; surfacing the frame on the row lets the panel
+  carry multi-frame setups without ambiguity. nil-safe."
+  [frame]
+  [:span {:style {:display       "inline-block"
+                  :padding       "1px 6px"
+                  :margin-right  "8px"
+                  :border-radius "3px"
+                  :background    (:bg-3 tokens)
+                  :color         (:text-secondary tokens)
+                  :font-family   mono-stack
+                  :font-size     "10px"}}
+   (if (nil? frame) "—" (str frame))])
+
+(defn- flow-row
+  "One row in the flow list. Clicking the row fires
+  `:rf.causa/select-flow-id` so a follow-on cross-panel affordance
+  can drill into the event-detail panel filtered to this flow's
+  recent recomputations."
+  [{:keys [flow-id frame inputs path status recomputing? last-operation]
+    :as _row}
+   selected?]
+  [:li {:data-testid (str "rf-causa-flow-row-" (h/format-flow-id flow-id))
+        :on-click   #(rf/dispatch [:rf.causa/select-flow-id flow-id])
+        :style      {:display       "flex"
+                     :align-items   "center"
+                     :padding       "6px 12px"
+                     :background    (if selected?
+                                      (:bg-active tokens)
+                                      "transparent")
+                     :border-bottom (str "1px solid " (:border-subtle tokens))
+                     :cursor        "pointer"
+                     :font-family   mono-stack
+                     :font-size     "13px"
+                     :color         (:text-primary tokens)}}
+   (status-badge status)
+   (frame-pill frame)
+   [:span {:style {:flex 1
+                   :min-width 0
+                   :overflow "hidden"
+                   :text-overflow "ellipsis"
+                   :white-space "nowrap"}}
+    [:span {:data-testid (str "rf-causa-flow-id-" (h/format-flow-id flow-id))
+            :style {:color (:text-primary tokens) :margin-right "8px"}}
+     (h/format-flow-id flow-id)]
+    [:span {:data-testid (str "rf-causa-flow-inputs-" (h/format-flow-id flow-id))
+            :style {:color (:text-secondary tokens) :margin-right "8px"
+                    :font-size "11px"}}
+     (h/format-inputs inputs)]
+    [:span {:style {:color (:text-tertiary tokens) :margin-right "6px"
+                    :font-size "11px"}}
+     "→"]
+    [:span {:data-testid (str "rf-causa-flow-path-" (h/format-flow-id flow-id))
+            :style {:color (:accent-violet tokens) :font-size "11px"}}
+     (h/format-path path)]]
+   (when recomputing?
+     [:span {:data-testid (str "rf-causa-flow-row-recomputing-"
+                               (h/format-flow-id flow-id))
+             :style {:color (:cyan tokens)
+                     :font-size "10px"
+                     :margin-left "8px"
+                     :text-transform "uppercase"
+                     :letter-spacing "0.5px"}}
+      "ran"])
+   (when last-operation
+     [:span {:style {:color (:text-tertiary tokens)
+                     :font-size "10px"
+                     :margin-left "8px"
+                     :font-family sans-stack}}
+      (case last-operation
+        :rf.flow/computed   "computed"
+        :rf.flow/skip       "skipped"
+        :rf.flow/failed     "failed"
+        :rf.flow/registered "registered"
+        :rf.flow/cleared    "cleared"
+        (str last-operation))])])
+
+;; ---- flow list ----------------------------------------------------------
+
+(defn- flow-list
+  "The default list view. Renders one row per registered flow in the
+  canonical sort order (failures first, then computing, skipping,
+  idle)."
+  [rows selected-flow-id]
+  (into [:ul {:data-testid "rf-causa-flows-list"
+              :style {:list-style "none"
+                      :margin     0
+                      :padding    0
+                      :background (:bg-2 tokens)}}]
+        (for [row rows]
+          ^{:key (h/format-flow-id (:flow-id row))}
+          (flow-row row (= (:flow-id row) selected-flow-id)))))
+
+;; ---- summary header -----------------------------------------------------
+
+(defn- summary-header
+  "Per-status tally + total count, mirroring the Subscriptions
+  panel's filter header (sans the filter chips — the four-status
+  taxonomy is small enough that v1 sorts rather than filters)."
+  [status-counts total]
+  [:div {:data-testid "rf-causa-flows-summary"
+         :style       {:padding "8px 12px"
+                       :display "flex"
+                       :align-items "center"
+                       :gap "8px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :color (:text-tertiary tokens)
+                       :font-family mono-stack
+                       :font-size "11px"}}
+   (for [s h/statuses
+         :let [n (get status-counts s 0)]
+         :when (pos? n)]
+     ^{:key s}
+     [:span {:data-testid (str "rf-causa-flows-summary-" (name s))
+             :style {:color (status-colour s)
+                     :margin-right "6px"}}
+      (str (get h/status->glyph s) " " n " " (name s))])
+   [:span {:style {:flex 1}}]
+   [:span (str total " flow" (if (= 1 total) "" "s"))]])
+
+;; ---- empty state --------------------------------------------------------
+
+(defn- empty-state
+  "Rendered when no flows are registered. The empty surface matches
+  the bead's minimum-viable contract — exactly the copy 'No flows
+  registered.' and a one-line orienting caption."
+  []
+  [:div {:data-testid "rf-causa-flows-empty"
+         :style       {:padding "16px"
+                       :color   (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size "13px"}}
+   [:p {:style {:margin "0 0 8px 0"
+                :color  (:text-secondary tokens)}}
+    "No flows registered."]
+   [:p {:style {:margin 0
+                :font-size "12px"
+                :color (:text-tertiary tokens)}}
+    "Register a flow via "
+    [:code {:style {:font-family mono-stack
+                    :color       (:accent-violet tokens)}}
+     "rf/reg-flow"]
+    " — the panel populates as flows register. See "
+    [:code {:style {:font-family mono-stack
+                    :color       (:accent-violet tokens)}}
+     "spec/013-Flows.md"]
+    "."]])
+
+;; ---- public view --------------------------------------------------------
+
+(defn flows-view
+  "The Flows panel's root view. Subscribes to
+  `:rf.causa/flows-data` and renders the summary header + flow
+  list (or the empty state when no flows are registered)."
+  []
+  (let [{:keys [rows status-counts total selected-flow-id]}
+        @(rf/subscribe [:rf.causa/flows-data])]
+    [:section {:data-testid "rf-causa-flows"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      "14px"}}
+     [:header {:style {:padding "16px 16px 8px 16px"}}
+      [:h1 {:style {:font-size   "16px"
+                    :font-weight 600
+                    :margin      0
+                    :color       (:text-primary tokens)}}
+       "Flows"]
+      [:p {:style {:font-size "12px"
+                   :color     (:text-tertiary tokens)
+                   :margin    "4px 0 0 0"}}
+       "Registered flows + their inputs / output paths. The "
+       [:em "ran"]
+       " cue pulses when a flow recomputes this cascade."]]
+     (when (pos? total)
+       (summary-header status-counts total))
+     [:div {:style {:flex 1 :overflow "auto"}}
+      (if (zero? total)
+        (empty-state)
+        (flow-list rows selected-flow-id))]]))

--- a/tools/causa/src/day8/re_frame2_causa/panels/flows_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/flows_helpers.cljc
@@ -1,0 +1,284 @@
+(ns day8.re-frame2-causa.panels.flows-helpers
+  "Pure-data helpers for Causa's Flows panel (Phase 5, rf2-83irn,
+  parent rf2-5aw5v).
+
+  ## Why a separate `.cljc` ns
+
+  Same dual-target pattern every other panel uses (subscriptions,
+  causality-graph, time-travel, app-db-diff, ...). The panel view in
+  `flows.cljs` builds the hiccup; the *logic* — folding the registered-
+  flow set + the trace-buffer's `:flow`-op-type events into per-flow
+  rows with a recomputation indicator — is pure data → data and runs
+  under the JVM unit-test target (`clojure -M:test`).
+
+  ## The four-status taxonomy
+
+  The Flows panel surfaces one status per flow row, derived from the
+  most recent `:rf.flow/*` trace event for that flow:
+
+  | Status        | Glyph | Colour token | Tooltip                         |
+  |---------------|-------|--------------|---------------------------------|
+  | `:computing`  | `◐`   | `:cyan`      | Recomputed                      |
+  | `:idle`       | `●`   | `:green`     | Idle                            |
+  | `:skipping`   | `○`   | `:text-tertiary` | Skipped (inputs unchanged)  |
+  | `:failed`     | `▲`   | `:red`       | Failed                          |
+
+  `:computing` is a *pulse* — when the most recent trace event for a
+  flow is `:rf.flow/computed` and that event is part of the latest
+  cascade, the row's status renders as `:computing` so the view
+  surfaces the live recomputation indicator the bead's
+  minimum-viable contract calls for. Older `:rf.flow/computed` events
+  decay to `:idle` as soon as another cascade lands.
+
+  `:skipping` corresponds to the runtime's `:rf.flow/skip` trace event
+  (per rf2-719e value-equal recompute suppression — Spec 013 §Dirty-
+  check semantics + Spec 009 §Flow trace events). It surfaces the
+  'flow ran but inputs were stable' signal as a distinct status.
+
+  Flows that registered but have never emitted a `:rf.flow/computed`
+  / `:rf.flow/skip` / `:rf.flow/failed` event are `:idle` by default.
+
+  Cleared flows (`:rf.flow/cleared`) drop out of the registered-flows
+  list at the same instant — they never appear in the panel; the
+  `:rf.flow/cleared` event is informational only.
+
+  ## What this doesn't do
+
+  Pure data. No subscription, no atom, no `js/` interop — the same
+  fn runs under CLJ and CLJS. The CLJS-only surfaces (`rf/handlers`
+  on a populated registrar) are read by the composite sub in
+  `registry.cljs`; the result is handed to this ns as a plain map."
+  (:require [clojure.string :as str]))
+
+;; ---- design tokens (mirrors view tokens — kept here for tests) ----------
+;;
+;; The view consumes these via this ns so the status → token mapping has
+;; one source of truth. The pure-data side stays JVM-portable.
+
+(def status->token
+  "Status → colour-token mapping. The view resolves the token to a hex
+  via its private `tokens` map. Source of truth for the panel + any
+  follow-on Causa surface that wants to render a flow status badge."
+  {:computing :cyan
+   :idle      :green
+   :skipping  :text-tertiary
+   :failed    :red})
+
+(def status->glyph
+  "Status → shape-glyph mapping. The glyph carries the taxonomy
+  without any colour signal so the panel is legible to colour-blind
+  users — same 'colour is never alone' discipline the Subscriptions
+  panel ships."
+  {:computing "◐"
+   :idle      "●"
+   :skipping  "○"
+   :failed    "▲"})
+
+(def status->tooltip
+  "Status → hover-tooltip mapping. Hover over a badge surfaces this
+  string."
+  {:computing "Recomputed this cascade"
+   :idle      "Idle"
+   :skipping  "Skipped (inputs unchanged)"
+   :failed    "Failed"})
+
+(def statuses
+  "Canonical row-ordering — failures first, then recently-recomputed,
+  then skipping, then idle. The view sorts rows by this order so the
+  most actionable rows surface at the top."
+  [:failed :computing :skipping :idle])
+
+;; ---- helpers ------------------------------------------------------------
+
+(defn flow-trace-event?
+  "True when `ev` is a `:op-type :flow` trace event. Pure predicate
+  — used by the composite sub to filter the Causa trace buffer down
+  to the flow stream."
+  [ev]
+  (= :flow (:op-type ev)))
+
+(defn filter-flow-events
+  "Return only the `:op-type :flow` events from a trace-event vector.
+  Oldest first (matches the buffer's natural order). Pure fn."
+  [events]
+  (filterv flow-trace-event? (or events [])))
+
+(defn- tag
+  "Pull a tag value off a trace event. Trace events nest per-event
+  metadata under `:tags`; the helper reads the slot defensively so
+  test fixtures that supply a flat shape (no `:tags`) also work."
+  [ev k]
+  (or (get-in ev [:tags k])
+      (get ev k)))
+
+(defn- event-flow-id [ev] (tag ev :flow-id))
+(defn- event-dispatch-id [ev] (tag ev :dispatch-id))
+
+(defn latest-event-per-flow
+  "Index `flow-events` (oldest first) into `{flow-id <latest-event>}`.
+  Pure fn — the linear scan keeps the latest event seen per flow-id
+  as the buffer iterates oldest→newest. Tools render the row's
+  current status from the latest event's `:operation`."
+  [flow-events]
+  (reduce (fn [acc ev]
+            (if-let [fid (event-flow-id ev)]
+              (assoc acc fid ev)
+              acc))
+          {}
+          (or flow-events [])))
+
+(defn latest-cascade-dispatch-id
+  "Return the `:dispatch-id` of the newest event in `events`, or nil
+  when no event carries one. Used to mark a flow as `:computing` only
+  when its most recent recompute happened *in the latest cascade* — so
+  the live-recomputation indicator pulses with the cascade rather than
+  staying lit forever."
+  [events]
+  (->> (or events [])
+       reverse
+       (some event-dispatch-id)))
+
+(defn compute-status
+  "Project one flow's status from its latest `:rf.flow/*` trace event
+  and the cascade context. Pure fn.
+
+  Arguments:
+    `latest-ev`       — the newest `:op-type :flow` event for this
+                        flow-id, or nil if the flow has never emitted.
+    `latest-cascade-id` — the `:dispatch-id` of the newest event in
+                        the buffer (any op-type). When the latest
+                        flow-event for this flow shares this id, the
+                        row is in the *current* cascade and renders
+                        the `:computing` pulse.
+
+  Decision order:
+
+    1. `:failed`     — latest event is `:rf.flow/failed`. Wins over
+                       everything; the row stays in the failure
+                       status until a successful recompute lands.
+    2. `:computing`  — latest event is `:rf.flow/computed` AND that
+                       event is in the latest cascade.
+    3. `:skipping`   — latest event is `:rf.flow/skip` AND that event
+                       is in the latest cascade.
+    4. `:idle`       — every other case (no events; latest event is
+                       `:rf.flow/registered`; older `:rf.flow/computed`
+                       / `:rf.flow/skip` that's no longer the active
+                       cascade)."
+  [latest-ev latest-cascade-id]
+  (let [op           (:operation latest-ev)
+        ev-cascade   (event-dispatch-id latest-ev)
+        in-cascade?  (and (some? latest-cascade-id)
+                          (= ev-cascade latest-cascade-id))]
+    (cond
+      (= op :rf.flow/failed)                       :failed
+      (and in-cascade? (= op :rf.flow/computed))   :computing
+      (and in-cascade? (= op :rf.flow/skip))       :skipping
+      :else                                        :idle)))
+
+(defn project-rows
+  "Project the registered-flows map + the Causa trace-buffer's
+  `:flow`-op-type slice into a vector of row maps the view consumes.
+  Pure fn — JVM-runnable.
+
+  Row shape:
+
+      {:flow-id          <id>
+       :frame            <frame-id-or-nil>
+       :inputs           [<path> ...]    ;; vector of app-db paths
+       :path             <path>          ;; output app-db path
+       :status           :failed | :computing | :skipping | :idle
+       :recomputing?     <bool>          ;; true when status :computing
+       :doc              <string-or-nil>
+       :last-operation   <:rf.flow/...-or-nil>
+       :last-trace-id    <int-or-nil>}   ;; trace event :id; nil when
+                                          ;; the flow never emitted
+
+  Inputs:
+
+    `flows-map`   — `{flow-id metadata}` from `(rf/handlers :flow)`.
+                    May be empty / nil; the projection returns `[]`.
+
+    `flow-events` — trace events filtered to `:op-type :flow`,
+                    oldest first.
+
+  The returned vector is sorted by `statuses` (failures first, then
+  computing, then skipping, then idle). Within a status, rows are
+  sorted by `:flow-id` (as a printable string) for deterministic
+  test output."
+  [flows-map flow-events]
+  (if (empty? flows-map)
+    []
+    (let [latest-by-flow      (latest-event-per-flow flow-events)
+          latest-cascade-id   (latest-cascade-dispatch-id flow-events)
+          rows                (for [[flow-id meta] flows-map
+                                    :let [latest-ev (get latest-by-flow flow-id)
+                                          status    (compute-status
+                                                      latest-ev
+                                                      latest-cascade-id)]]
+                                {:flow-id        flow-id
+                                 :frame          (:frame meta)
+                                 :inputs         (vec (or (:inputs meta) []))
+                                 :path           (:path meta)
+                                 :status         status
+                                 :recomputing?   (= status :computing)
+                                 :doc            (:doc meta)
+                                 :last-operation (:operation latest-ev)
+                                 :last-trace-id  (:id latest-ev)})
+          sorter              (zipmap statuses (range))]
+      (vec
+        (sort-by (fn [{:keys [status flow-id]}]
+                   [(get sorter status (count statuses))
+                    (pr-str flow-id)])
+                 rows)))))
+
+(defn status-counts
+  "Per-status tally over the projected rows. Pure fn."
+  [rows]
+  (frequencies (map :status rows)))
+
+(defn recent-events-for-flow
+  "Return the trace events for `flow-id`, newest first, capped at
+  `n` (default 20). Used by the panel's per-flow detail strip so the
+  user can scan the flow's recent recompute history without leaving
+  the panel.
+
+  Pure fn — JVM-runnable; the cap keeps the render cost bounded even
+  on a deep trace buffer."
+  ([flow-events flow-id]
+   (recent-events-for-flow flow-events flow-id 20))
+  ([flow-events flow-id n]
+   (let [matches (filterv #(= flow-id (event-flow-id %))
+                          (or flow-events []))]
+     (vec (take n (reverse matches))))))
+
+;; ---- formatting helpers (consumed by the view) -------------------------
+
+(defn format-flow-id
+  "Render a flow-id for compact display in the mono column. Keywords
+  keep their `:` prefix; symbols / strings render plain."
+  [flow-id]
+  (cond
+    (keyword? flow-id) (str flow-id)
+    (symbol?  flow-id) (str flow-id)
+    :else              (str/trim (str flow-id))))
+
+(defn format-path
+  "Pretty-print an `app-db` path for display. Mirrors `pr-str`'s
+  output but tolerates an unprintable element (falling back to
+  `str`) — flow paths are always plain vectors of keywords / strings
+  in practice, but the helper is forgiving."
+  [path]
+  (try
+    (pr-str path)
+    (catch #?(:clj Throwable :cljs :default) _
+      (str path))))
+
+(defn format-inputs
+  "Render the `:inputs` vector — each path pr-str'd, separated by
+  ` · ` so the mono column stays readable when a flow takes several
+  inputs. Returns the empty-marker `\"—\"` for the empty case rather
+  than an empty string."
+  [inputs]
+  (if (empty? inputs)
+    "—"
+    (str/join " · " (map format-path inputs))))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -124,6 +124,7 @@
             [day8.re-frame2-causa.panels.time-travel-helpers :as tt-helpers]
             [day8.re-frame2-causa.panels.causality-graph-helpers :as cg-helpers]
             [day8.re-frame2-causa.panels.app-db-diff-helpers :as diff-helpers]
+            [day8.re-frame2-causa.panels.flows-helpers :as flows-helpers]
             [day8.re-frame2-causa.panels.hydration-debugger-helpers :as hd-helpers]
             [day8.re-frame2-causa.panels.issues-ribbon-helpers :as issues-helpers]
             [day8.re-frame2-causa.panels.performance-helpers :as perf-helpers]
@@ -1129,6 +1130,144 @@
             (dissoc :issues-active-prefixes)
             (dissoc :issues-since-ms))))
 
+    ;; ---- Phase 5 (rf2-83irn) — Flows panel ----------------------------
+    ;;
+    ;; Surfaces re-frame2's registered flows + their per-flow inputs /
+    ;; output path / live recomputation indicator. Consumer of Spec 013
+    ;; (the registered-flow surface) + Spec 009 (the `:rf.flow/*` trace
+    ;; event vocabulary).
+    ;;
+    ;; The panel reads two surfaces — the framework's registered-flow
+    ;; map (`(rf/handlers :flow)`) and the Causa trace-buffer's
+    ;; `:op-type :flow` slice — and folds them via
+    ;; `flows-helpers/project-rows` into one row per registered flow.
+    ;;
+    ;; Tests stub the registered-flows surface by writing
+    ;; `:registered-flows-override` to Causa's app-db (via
+    ;; `:rf.causa/set-registered-flows-override-for-test`) so the suite
+    ;; can assert against a deterministic flow set without booting the
+    ;; flows artefact.
+    ;;
+    ;; Shape of `:rf.causa/flows-data`:
+    ;;
+    ;;     {:rows             [<row> ...]
+    ;;      :status-counts    {status count}
+    ;;      :total            <int>
+    ;;      :selected-flow-id <flow-id-or-nil>}
+
+    ;; Read the registered-flow map. Reads `(rf/handlers :flow)` —
+    ;; per Spec 001 §The public registrar query API the registrar is
+    ;; process-global so this surfaces every registered flow across
+    ;; every frame. CLJS-only — `rf/handlers` exists under both
+    ;; targets, but the v1 wiring threads it through the override
+    ;; slot so the JVM test target can drive the projection without
+    ;; booting the flows artefact.
+    (rf/reg-sub :rf.causa/registered-flows
+      (fn [db _query]
+        (let [ov (get db :registered-flows-override)]
+          (or ov (rf/handlers :flow)))))
+
+    ;; Test-only override hook for the registered-flows surface.
+    ;; Production code paths never dispatch this — the slot exists
+    ;; only so JVM + node-test suites can drive the projection
+    ;; without booting the flows artefact's registrar.
+    (rf/reg-event-db :rf.causa/set-registered-flows-override-for-test
+      (fn [db [_ ov]]
+        (if (nil? ov)
+          (dissoc db :registered-flows-override)
+          (assoc db :registered-flows-override ov))))
+
+    ;; The Causa trace-buffer's `:op-type :flow` slice. Pure-data
+    ;; filter — the helper's predicate is JVM-runnable so tests can
+    ;; drive it without a CLJS runtime.
+    ;;
+    ;; Note the single-signal `:<-` arity: re-frame2's `reg-sub`
+    ;; passes the upstream value DIRECTLY (not vector-wrapped) when
+    ;; there's exactly one `:<-` chain entry — per Spec 002 §The
+    ;; reg-sub forms + subs.cljc parse-reg-sub-args. Multi-signal
+    ;; `:<-` chains pass `[a b c]`; single-signal passes `a`.
+    (rf/reg-sub :rf.causa/flow-trace-events
+      :<- [:rf.causa/trace-buffer]
+      (fn [buffer _query]
+        (flows-helpers/filter-flow-events buffer)))
+
+    ;; The user's per-panel flow selection. Drives a follow-on
+    ;; cross-panel affordance (click flow → event-detail filtered to
+    ;; that flow's recent recomputations); v1 wiring carries the
+    ;; selection only — the cross-panel jump lands when the
+    ;; cross-panel filter API stabilises.
+    (rf/reg-sub :rf.causa/selected-flow-id
+      (fn [db _query]
+        (get db :selected-flow-id)))
+
+    ;; The composite the panel consumes. One read produces every slot
+    ;; the view needs (matches the per-panel composite pattern every
+    ;; other Causa panel uses).
+    (rf/reg-sub :rf.causa/flows-data
+      :<- [:rf.causa/registered-flows]
+      :<- [:rf.causa/flow-trace-events]
+      :<- [:rf.causa/selected-flow-id]
+      (fn [[flows-map flow-events selected-flow-id] _query]
+        (let [rows   (flows-helpers/project-rows flows-map flow-events)
+              counts (flows-helpers/status-counts rows)]
+          {:rows             rows
+           :status-counts    counts
+           :total            (count rows)
+           :selected-flow-id selected-flow-id})))
+
+    ;; ---- Phase 5 (rf2-83irn) — Flows panel events --------------------
+
+    (rf/reg-event-db :rf.causa/select-flow-id
+      (fn [db [_ flow-id]]
+        (assoc db :selected-flow-id flow-id)))
+
+    (rf/reg-event-db :rf.causa/clear-flow-selection
+      (fn [db _event]
+        (dissoc db :selected-flow-id)))
+
+    ;; ---- Phase 5 (rf2-75121) — Performance panel -----------------------
+    ;;
+    ;; Per `tools/causa/spec/000-Vision.md` L92 the Performance panel
+    ;; surfaces per-cascade duration capture, perf-tier colour mapping,
+    ;; and budget-warning markers. The runtime substrate is
+    ;; `spec/009-Instrumentation.md §Performance instrumentation` (the
+    ;; default-off User Timing channel); v1 reads the dev-build trace
+    ;; stream's `:time` deltas instead so the panel works against the
+    ;; same buffer every other Causa panel consumes.
+    ;;
+    ;; Shape of `:rf.causa/performance-data`:
+    ;;
+    ;;     {:rows               [<row> ...]    ;; newest first
+    ;;      :total              <int>
+    ;;      :tier-counts        {tier count}
+    ;;      :over-budget-count  <int>
+    ;;      :budget-ms          <number>
+    ;;      :empty?             <bool>}
+    ;;
+    ;; No new events are required — the panel reuses
+    ;; `:rf.causa/select-dispatch-id` + `:rf.causa/select-panel` for the
+    ;; pivot-into-event-detail affordance (parity with the Issues
+    ;; ribbon's row-click). The over-budget threshold is sub-readable
+    ;; via `:rf.causa/performance-budget-ms` so a follow-on bead can
+    ;; surface a slider in the panel header without rewiring consumers.
+    (rf/reg-sub :rf.causa/performance-budget-ms
+      (fn [db _query]
+        (get db :performance-budget-ms perf-helpers/default-budget-ms)))
+
+    (rf/reg-sub :rf.causa/performance-data
+      :<- [:rf.causa/trace-buffer]
+      :<- [:rf.causa/performance-budget-ms]
+      (fn [[buffer budget-ms] _query]
+        (let [cascades (projection/group-cascades buffer)]
+          (perf-helpers/project-feed cascades budget-ms))))
+
+    ;; Set the over-budget threshold. Pass nil to reset to default.
+    (rf/reg-event-db :rf.causa/set-performance-budget-ms
+      (fn [db [_ budget-ms]]
+        (if (and (number? budget-ms) (pos? budget-ms))
+          (assoc db :performance-budget-ms budget-ms)
+          (dissoc db :performance-budget-ms))))
+
     ;; ---- Phase 5 (rf2-argrj) — Trace panel ------------------------------
     ;;
     ;; The Trace panel is the UI consumer of the canonical 9-axis filter
@@ -1182,49 +1321,6 @@
     (rf/reg-event-db :rf.causa/clear-trace-filters
       (fn [db _event]
         (dissoc db :trace-filters)))
-
-    ;; ---- Phase 5 (rf2-75121) — Performance panel -----------------------
-    ;;
-    ;; Per `tools/causa/spec/000-Vision.md` L92 the Performance panel
-    ;; surfaces per-cascade duration capture, perf-tier colour mapping,
-    ;; and budget-warning markers. The runtime substrate is
-    ;; `spec/009-Instrumentation.md §Performance instrumentation` (the
-    ;; default-off User Timing channel); v1 reads the dev-build trace
-    ;; stream's `:time` deltas instead so the panel works against the
-    ;; same buffer every other Causa panel consumes.
-    ;;
-    ;; Shape of `:rf.causa/performance-data`:
-    ;;
-    ;;     {:rows               [<row> ...]    ;; newest first
-    ;;      :total              <int>
-    ;;      :tier-counts        {tier count}
-    ;;      :over-budget-count  <int>
-    ;;      :budget-ms          <number>
-    ;;      :empty?             <bool>}
-    ;;
-    ;; No new events are required — the panel reuses
-    ;; `:rf.causa/select-dispatch-id` + `:rf.causa/select-panel` for the
-    ;; pivot-into-event-detail affordance (parity with the Issues
-    ;; ribbon's row-click). The over-budget threshold is sub-readable
-    ;; via `:rf.causa/performance-budget-ms` so a follow-on bead can
-    ;; surface a slider in the panel header without rewiring consumers.
-    (rf/reg-sub :rf.causa/performance-budget-ms
-      (fn [db _query]
-        (get db :performance-budget-ms perf-helpers/default-budget-ms)))
-
-    (rf/reg-sub :rf.causa/performance-data
-      :<- [:rf.causa/trace-buffer]
-      :<- [:rf.causa/performance-budget-ms]
-      (fn [[buffer budget-ms] _query]
-        (let [cascades (projection/group-cascades buffer)]
-          (perf-helpers/project-feed cascades budget-ms))))
-
-    ;; Set the over-budget threshold. Pass nil to reset to default.
-    (rf/reg-event-db :rf.causa/set-performance-budget-ms
-      (fn [db [_ budget-ms]]
-        (if (and (number? budget-ms) (pos? budget-ms))
-          (assoc db :performance-budget-ms budget-ms)
-          (dissoc db :performance-budget-ms))))
 
     ;; ---- Phase 5 (rf2-rccf3) — AI Co-Pilot panel -----------------------
     ;;

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -42,6 +42,7 @@
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.time-travel :as time-travel]
             [day8.re-frame2-causa.panels.causality-graph :as causality-graph]
+            [day8.re-frame2-causa.panels.flows :as flows]
             [day8.re-frame2-causa.panels.hydration-debugger :as hydration-debugger]
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
             [day8.re-frame2-causa.panels.performance :as performance]
@@ -85,7 +86,7 @@
    {:id :fx           :label "Effects"       :bead "rf2-xxx"}
    {:id :trace        :label "Trace"         :bead "rf2-argrj" :live? true}
    {:id :machines     :label "Machines"      :bead "rf2-xxx"}
-   {:id :flows        :label "Flows"         :bead "rf2-xxx"}
+   {:id :flows        :label "Flows"         :bead "rf2-83irn" :live? true}
    {:id :performance  :label "Performance"   :bead "rf2-75121" :live? true}
    {:id :issues       :label "Issues"        :bead "rf2-d1p4o" :live? true}
    {:id :schemas      :label "Schemas"       :bead "rf2-htffa" :live? true}
@@ -266,6 +267,7 @@
       :time-travel  [time-travel/time-travel-view]
       :app-db       [app-db-diff/app-db-diff-view]
       :causality    [causality-graph/causality-graph-view]
+      :flows        [flows/flows-view]
       :schemas      [schema-violation-timeline/schema-violation-timeline-view]
       :subs         [subscriptions/subscriptions-view]
       :hydration    [hydration-debugger/hydration-debugger-view]

--- a/tools/causa/test/day8/re_frame2_causa/panels/flows_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/flows_helpers_cljs_test.cljc
@@ -1,0 +1,313 @@
+(ns day8.re-frame2-causa.panels.flows-helpers-cljs-test
+  "Pure-data tests for Causa's Flows panel helpers
+  (Phase 5, rf2-83irn).
+
+  ## Why the `.cljc` + `_cljs_test` naming
+
+  Same dual-target pattern as the other helper tests:
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  ## What's under test
+
+    1. **flow-trace-event? / filter-flow-events** — the `:op-type
+       :flow` predicate that slices the trace buffer down to the flow
+       stream.
+    2. **latest-event-per-flow / latest-cascade-dispatch-id** — the
+       reductions that drive per-flow status derivation.
+    3. **compute-status** — the four-status state machine that
+       classifies a flow's most recent trace event against the
+       latest cascade.
+    4. **project-rows** — the fold over the registered-flows map +
+       the `:flow`-op-type trace events. Row shape, ordering
+       (failures first), empty-state behaviour.
+    5. **status-counts** — the summary-header feed.
+    6. **recent-events-for-flow** — newest-first cap'd projection
+       the panel uses for the per-flow detail strip.
+    7. **format-flow-id / format-path / format-inputs** — the view-
+       side formatters."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.flows-helpers :as h]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- flow-ev
+  "Build a minimal `:op-type :flow` trace event. The runtime stamps
+  `:flow-id`, `:frame`, and (when in a drain) `:dispatch-id` under
+  `:tags`. The helper here mirrors that shape so the tests assert
+  against the realistic payload."
+  ([op flow-id] (flow-ev op flow-id {}))
+  ([op flow-id extra-tags]
+   {:operation op
+    :op-type   :flow
+    :id        (rand-int 1000000)
+    :time      (rand-int 1000000)
+    :tags      (merge {:flow-id flow-id :frame :rf/default} extra-tags)}))
+
+;; ---- (1) flow-trace-event? / filter-flow-events ------------------------
+
+(deftest flow-trace-event?-true-for-op-type-flow
+  (testing "the predicate returns true for `:op-type :flow` events"
+    (is (true? (h/flow-trace-event? (flow-ev :rf.flow/computed :rect/area))))))
+
+(deftest flow-trace-event?-false-for-other-op-types
+  (testing "the predicate is false for non-flow trace events"
+    (is (false? (h/flow-trace-event? {:op-type :event :operation :event/dispatched})))
+    (is (false? (h/flow-trace-event? {:op-type :sub  :operation :sub/run})))
+    (is (false? (h/flow-trace-event? {})))))
+
+(deftest filter-flow-events-keeps-flow-events-in-order
+  (testing "filter-flow-events keeps `:op-type :flow` events in input
+            order, dropping everything else"
+    (let [buf [{:op-type :event :operation :event/dispatched}
+               (flow-ev :rf.flow/computed :a)
+               {:op-type :sub :operation :sub/run}
+               (flow-ev :rf.flow/skip :b)
+               (flow-ev :rf.flow/failed :a)]]
+      (is (= [:rf.flow/computed :rf.flow/skip :rf.flow/failed]
+             (map :operation (h/filter-flow-events buf)))))))
+
+(deftest filter-flow-events-nil-and-empty-safe
+  (testing "filter-flow-events tolerates nil + empty input"
+    (is (= [] (h/filter-flow-events nil)))
+    (is (= [] (h/filter-flow-events [])))))
+
+;; ---- (2) latest-event-per-flow / latest-cascade-dispatch-id ------------
+
+(deftest latest-event-per-flow-keeps-newest
+  (testing "latest-event-per-flow returns one entry per flow-id, keyed
+            to the newest event (rightmost wins in the oldest→newest
+            scan)"
+    (let [events [(flow-ev :rf.flow/registered :a)
+                  (flow-ev :rf.flow/computed   :b)
+                  (flow-ev :rf.flow/skip       :a)]
+          m      (h/latest-event-per-flow events)]
+      (is (= :rf.flow/skip     (:operation (get m :a))))
+      (is (= :rf.flow/computed (:operation (get m :b)))))))
+
+(deftest latest-event-per-flow-empty-input
+  (is (= {} (h/latest-event-per-flow nil)))
+  (is (= {} (h/latest-event-per-flow []))))
+
+(deftest latest-cascade-dispatch-id-returns-newest
+  (testing "latest-cascade-dispatch-id returns the :dispatch-id of the
+            newest event carrying one"
+    (let [events [(flow-ev :rf.flow/computed :a {:dispatch-id 1})
+                  (flow-ev :rf.flow/computed :b {:dispatch-id 2})]]
+      (is (= 2 (h/latest-cascade-dispatch-id events))))))
+
+(deftest latest-cascade-dispatch-id-nil-when-no-cascade
+  (testing "nil when no event carries a dispatch-id"
+    (is (nil? (h/latest-cascade-dispatch-id [])))
+    (is (nil? (h/latest-cascade-dispatch-id [(flow-ev :rf.flow/registered :a)])))))
+
+;; ---- (3) compute-status -------------------------------------------------
+
+(deftest compute-status-failed-wins
+  (testing ":rf.flow/failed surfaces :failed regardless of cascade state"
+    (is (= :failed (h/compute-status (flow-ev :rf.flow/failed :a) 42)))
+    (is (= :failed (h/compute-status (flow-ev :rf.flow/failed :a {:dispatch-id 1})
+                                     2)))))
+
+(deftest compute-status-computed-in-cascade-is-computing
+  (testing ":rf.flow/computed in the active cascade surfaces :computing"
+    (let [ev (flow-ev :rf.flow/computed :a {:dispatch-id 7})]
+      (is (= :computing (h/compute-status ev 7))))))
+
+(deftest compute-status-computed-in-old-cascade-is-idle
+  (testing ":rf.flow/computed in a *past* cascade decays to :idle"
+    (let [ev (flow-ev :rf.flow/computed :a {:dispatch-id 1})]
+      (is (= :idle (h/compute-status ev 5))))))
+
+(deftest compute-status-skip-in-cascade-is-skipping
+  (testing ":rf.flow/skip in the active cascade surfaces :skipping"
+    (let [ev (flow-ev :rf.flow/skip :a {:dispatch-id 7})]
+      (is (= :skipping (h/compute-status ev 7))))))
+
+(deftest compute-status-skip-in-old-cascade-is-idle
+  (testing ":rf.flow/skip in a past cascade decays to :idle"
+    (let [ev (flow-ev :rf.flow/skip :a {:dispatch-id 1})]
+      (is (= :idle (h/compute-status ev 5))))))
+
+(deftest compute-status-no-event-is-idle
+  (testing "a flow with no prior trace event is :idle"
+    (is (= :idle (h/compute-status nil nil)))
+    (is (= :idle (h/compute-status nil 7)))))
+
+(deftest compute-status-registered-without-cascade-is-idle
+  (testing ":rf.flow/registered alone is :idle"
+    (let [ev (flow-ev :rf.flow/registered :a)]
+      (is (= :idle (h/compute-status ev nil))))))
+
+;; ---- (4) project-rows ---------------------------------------------------
+
+(deftest project-rows-empty-map-is-empty
+  (testing "no registered flows => empty rows"
+    (is (= [] (h/project-rows nil nil)))
+    (is (= [] (h/project-rows {} nil)))))
+
+(deftest project-rows-emits-row-per-registered-flow
+  (testing "one row per entry in the registered-flows map"
+    (let [flows  {:rect/area  {:inputs [[:w] [:h]] :path [:area]
+                               :frame  :rf/default}
+                  :cart/total {:inputs [[:items]] :path [:total]
+                               :frame  :rf/default
+                               :doc    "sum of items"}}
+          rows   (h/project-rows flows nil)
+          ids    (set (map :flow-id rows))]
+      (is (= 2 (count rows)))
+      (is (= #{:rect/area :cart/total} ids)))))
+
+(deftest project-rows-carries-frame-inputs-path-doc
+  (testing "each row carries :frame :inputs :path :doc off the
+            registered-flow metadata"
+    (let [flows {:rect/area {:inputs [[:w] [:h]] :path [:area]
+                             :frame  :rf/default
+                             :doc    "Rectangle area"}}
+          row   (first (h/project-rows flows nil))]
+      (is (= :rect/area   (:flow-id row)))
+      (is (= [[:w] [:h]]  (:inputs row)))
+      (is (= [:area]      (:path row)))
+      (is (= :rf/default  (:frame row)))
+      (is (= "Rectangle area" (:doc row))))))
+
+(deftest project-rows-marks-recomputing-in-active-cascade
+  (testing "a flow whose latest event is :rf.flow/computed in the latest
+            cascade is :computing + :recomputing? true"
+    (let [flows  {:rect/area {:inputs [[:w] [:h]] :path [:area]}}
+          events [(flow-ev :rf.flow/computed :rect/area {:dispatch-id 7})]
+          row    (first (h/project-rows flows events))]
+      (is (= :computing (:status row)))
+      (is (true? (:recomputing? row)))
+      (is (= :rf.flow/computed (:last-operation row))))))
+
+(deftest project-rows-marks-skip-in-active-cascade
+  (testing ":rf.flow/skip in the latest cascade surfaces :skipping +
+            :recomputing? false (the row is NOT recomputing)"
+    (let [flows  {:rect/area {:inputs [[:w] [:h]] :path [:area]}}
+          events [(flow-ev :rf.flow/skip :rect/area {:dispatch-id 7})]
+          row    (first (h/project-rows flows events))]
+      (is (= :skipping (:status row)))
+      (is (false? (:recomputing? row))))))
+
+(deftest project-rows-marks-failed
+  (testing ":rf.flow/failed surfaces :failed regardless of cascade"
+    (let [flows  {:rect/area {:inputs [[:w] [:h]] :path [:area]}}
+          events [(flow-ev :rf.flow/failed :rect/area {:dispatch-id 7})]
+          row    (first (h/project-rows flows events))]
+      (is (= :failed (:status row))))))
+
+(deftest project-rows-idle-when-flow-has-no-events
+  (testing "registered flow with no prior trace events is :idle"
+    (let [flows {:rect/area {:inputs [[:w] [:h]] :path [:area]}}
+          row   (first (h/project-rows flows nil))]
+      (is (= :idle (:status row)))
+      (is (false? (:recomputing? row))))))
+
+(deftest project-rows-sorts-failures-first
+  (testing "canonical sort: failed → computing → skipping → idle"
+    (let [flows  {:a-idle    {:inputs [] :path [:a]}
+                  :b-failed  {:inputs [] :path [:b]}
+                  :c-comp    {:inputs [] :path [:c]}
+                  :d-skip    {:inputs [] :path [:d]}}
+          events [(flow-ev :rf.flow/failed   :b-failed {:dispatch-id 7})
+                  (flow-ev :rf.flow/computed :c-comp   {:dispatch-id 7})
+                  (flow-ev :rf.flow/skip     :d-skip   {:dispatch-id 7})]
+          rows   (h/project-rows flows events)]
+      (is (= [:failed :computing :skipping :idle]
+             (map :status rows))))))
+
+(deftest project-rows-stable-within-status
+  (testing "within a status, rows are sorted by flow-id for deterministic
+            test output"
+    (let [flows {:zebra/a {:inputs [] :path [:z]}
+                 :apple/b {:inputs [] :path [:a]}
+                 :mango/c {:inputs [] :path [:m]}}
+          rows  (h/project-rows flows nil)]
+      (is (= [:apple/b :mango/c :zebra/a]
+             (map :flow-id rows))))))
+
+(deftest project-rows-decays-after-cascade-changes
+  (testing "a flow that recomputed in cascade 1 decays to :idle once
+            cascade 2 lands without touching it"
+    (let [flows  {:rect/area {:inputs [[:w] [:h]] :path [:area]}}
+          ;; rect/area computed in cascade 1; later, a sibling cascade 2
+          ;; happens (e.g. another event runs).
+          events [(flow-ev :rf.flow/computed :rect/area {:dispatch-id 1})
+                  (flow-ev :rf.flow/computed :other-flow {:dispatch-id 2})]
+          row    (first (filter #(= :rect/area (:flow-id %))
+                                (h/project-rows flows events)))]
+      (is (= :idle (:status row))
+          "older computed decays once a newer cascade lands"))))
+
+;; ---- (5) status-counts --------------------------------------------------
+
+(deftest status-counts-tallies-by-status
+  (let [rows [{:status :idle}
+              {:status :idle}
+              {:status :computing}
+              {:status :failed}]]
+    (is (= {:idle 2 :computing 1 :failed 1}
+           (h/status-counts rows)))))
+
+;; ---- (6) recent-events-for-flow ----------------------------------------
+
+(deftest recent-events-newest-first
+  (testing "recent-events-for-flow returns the flow's events newest first"
+    (let [events [(flow-ev :rf.flow/registered :a)
+                  (flow-ev :rf.flow/computed   :b)
+                  (flow-ev :rf.flow/skip       :a)
+                  (flow-ev :rf.flow/computed   :a)]
+          out    (h/recent-events-for-flow events :a)]
+      (is (= [:rf.flow/computed :rf.flow/skip :rf.flow/registered]
+             (map :operation out))))))
+
+(deftest recent-events-caps-output
+  (testing "the cap limits the returned vector"
+    (let [events (mapv (fn [_] (flow-ev :rf.flow/computed :a)) (range 30))]
+      (is (= 5 (count (h/recent-events-for-flow events :a 5)))))))
+
+(deftest recent-events-empty-for-unknown-flow
+  (is (= [] (h/recent-events-for-flow [(flow-ev :rf.flow/computed :a)]
+                                      :nonexistent))))
+
+;; ---- (7) taxonomy invariants -------------------------------------------
+
+(deftest every-status-has-glyph-colour-tooltip
+  (testing "every status in the canonical vocabulary has a glyph,
+            colour token, and tooltip"
+    (doseq [s h/statuses]
+      (is (some? (get h/status->glyph s))   (str "glyph for " s))
+      (is (some? (get h/status->token s))   (str "token for " s))
+      (is (some? (get h/status->tooltip s)) (str "tooltip for " s)))))
+
+(deftest statuses-canonical-order
+  (testing "spec'd default sort order — failures first, then computing,
+            then skipping, then idle"
+    (is (= [:failed :computing :skipping :idle] h/statuses))))
+
+(deftest taxonomy-has-exactly-four
+  (testing "exactly four statuses — not three, not five"
+    (is (= 4 (count h/statuses)))
+    (is (= 4 (count h/status->glyph)))
+    (is (= 4 (count h/status->token)))
+    (is (= 4 (count h/status->tooltip)))))
+
+;; ---- (8) formatters -----------------------------------------------------
+
+(deftest format-flow-id-keyword-keeps-colon
+  (is (= ":rect/area"   (h/format-flow-id :rect/area)))
+  (is (= ":cart/total"  (h/format-flow-id :cart/total))))
+
+(deftest format-path-prints-edn
+  (is (= "[:area]"           (h/format-path [:area])))
+  (is (= "[:cart :items]"    (h/format-path [:cart :items]))))
+
+(deftest format-inputs-joins-with-bullet
+  (is (= "—" (h/format-inputs nil)))
+  (is (= "—" (h/format-inputs [])))
+  (is (= "[:w] · [:h]" (h/format-inputs [[:w] [:h]]))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/flows_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/flows_view_cljs_test.cljs
@@ -1,0 +1,295 @@
+(ns day8.re-frame2-causa.panels.flows-view-cljs-test
+  "CLJS-side wiring + view tests for Causa's Flows panel
+  (Phase 5, rf2-83irn).
+
+  ## What's under test (in addition to the pure-data tests in
+  `flows_helpers_cljs_test.cljc`)
+
+    1. **Registry wires the composite sub** under
+       `:rf.causa/flows-data`. The composite returns rows + counts +
+       selection in the shape the view consumes.
+
+    2. **Empty state** — with no registered flows and no override,
+       the panel renders 'No flows registered.'
+
+    3. **Populated list** — with a registered-flows override the
+       panel renders one row per flow + the summary header.
+
+    4. **Live recomputation indicator** — with a `:rf.flow/computed`
+       trace event in the latest cascade, the matching row carries
+       the `ran` cue.
+
+    5. **Flow selection** — clicking a row fires
+       `:rf.causa/select-flow-id`; the panel highlights the selection.
+
+    6. **Frame isolation** — the panel's state lives on `:rf/causa`,
+       never on `:rf/default`.
+
+  ## Pure hiccup
+
+  Same approach as `subscriptions_view_cljs_test` — walk the view's
+  hiccup tree by `data-testid` rather than mounting to the DOM."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.flows :as flows]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walkers (mirror subscriptions_view_cljs_test) ---------------
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (apply (first node) (rest node))
+    node))
+
+(defn- hiccup-seq [tree]
+  (->> (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree))
+       (map expand-fn-component)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (hiccup-seq tree)))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- override-flows! [m]
+  (rf/dispatch-sync [:rf.causa/set-registered-flows-override-for-test m]))
+
+(defn- push-trace! [ev]
+  (trace-bus/collect-trace! ev))
+
+;; ---- (1) registry wires the composite sub -------------------------------
+
+(deftest registry-installs-flows-subs-and-events
+  (testing "register-causa-handlers! installs the Phase 5 (rf2-83irn)
+            composite sub + every supporting event"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/flows-data)))
+    (is (some? (registrar/handler :sub :rf.causa/registered-flows)))
+    (is (some? (registrar/handler :sub :rf.causa/flow-trace-events)))
+    (is (some? (registrar/handler :sub :rf.causa/selected-flow-id)))
+    (is (some? (registrar/handler :event :rf.causa/select-flow-id)))
+    (is (some? (registrar/handler :event :rf.causa/clear-flow-selection)))
+    (is (some? (registrar/handler :event
+                                  :rf.causa/set-registered-flows-override-for-test)))))
+
+(deftest flows-data-sub-defaults-empty
+  (testing "with no override and no flows registered the composite
+            returns empty rows + zero total"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [data @(rf/subscribe [:rf.causa/flows-data])]
+        (is (= [] (:rows data)))
+        (is (= 0  (:total data)))
+        (is (nil? (:selected-flow-id data)))))))
+
+(deftest flows-data-sub-projects-override-into-rows
+  (testing "with a registered-flows override the composite returns one
+            row per entry — projected via the helpers"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-flows!
+        {:rect/area  {:inputs [[:w] [:h]] :path [:area]
+                      :frame  :rf/default}
+         :cart/total {:inputs [[:items]] :path [:total]
+                      :frame  :rf/default
+                      :doc    "sum of items"}})
+      (let [data @(rf/subscribe [:rf.causa/flows-data])
+            ids  (set (map :flow-id (:rows data)))]
+        (is (= 2 (:total data)))
+        (is (= #{:rect/area :cart/total} ids))))))
+
+;; ---- (2) view renders ---------------------------------------------------
+
+(deftest empty-state-renders-when-no-flows
+  (testing "with no registered flows the panel renders the empty state"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [tree (flows/flows-view)]
+        (is (some? (find-by-testid tree "rf-causa-flows"))
+            "panel container present")
+        (is (some? (find-by-testid tree "rf-causa-flows-empty"))
+            "empty-state container present")
+        (is (nil? (find-by-testid tree "rf-causa-flows-list"))
+            "no list when there are zero flows")))))
+
+(deftest list-renders-when-flows-populated
+  (testing "with a populated override the panel renders one row per flow
+            plus the summary header"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-flows!
+        {:rect/area  {:inputs [[:w] [:h]] :path [:area]}
+         :cart/total {:inputs [[:items]]  :path [:total]}})
+      (let [tree (flows/flows-view)]
+        (is (some? (find-by-testid tree "rf-causa-flows-list"))
+            "list container present")
+        (is (some? (find-by-testid tree "rf-causa-flow-row-:rect/area"))
+            "row for :rect/area present")
+        (is (some? (find-by-testid tree "rf-causa-flow-row-:cart/total"))
+            "row for :cart/total present")
+        (is (some? (find-by-testid tree "rf-causa-flows-summary"))
+            "summary header present")))))
+
+(deftest row-renders-flow-id-inputs-and-path
+  (testing "each row carries the flow-id + inputs vector + output path"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-flows!
+        {:rect/area {:inputs [[:w] [:h]] :path [:area]}})
+      (let [tree (flows/flows-view)]
+        (is (some? (find-by-testid tree "rf-causa-flow-id-:rect/area")))
+        (is (some? (find-by-testid tree "rf-causa-flow-inputs-:rect/area")))
+        (is (some? (find-by-testid tree "rf-causa-flow-path-:rect/area")))))))
+
+(deftest idle-status-badge-renders-by-default
+  (testing "a flow with no prior trace events surfaces the :idle badge"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-flows!
+        {:rect/area {:inputs [[:w] [:h]] :path [:area]}})
+      (let [tree (flows/flows-view)]
+        (is (some? (find-by-testid tree "rf-causa-flow-badge-idle")))))))
+
+;; ---- (3) live recomputation indicator -----------------------------------
+
+(deftest recomputing-cue-renders-when-flow-computed-this-cascade
+  (testing "with a :rf.flow/computed trace event in the latest cascade,
+            the matching row carries the 'ran' cue + the :computing badge"
+    (setup-causa-frame!)
+    ;; Seed the trace buffer BEFORE the first subscribe — the
+    ;; `:rf.causa/trace-buffer` sub reads `(trace-bus/buffer)` once
+    ;; on first compute and re-fires only when its (db) signal
+    ;; changes; pushing the trace before the view's first subscribe
+    ;; matches the production sequencing (preload's trace-cb fires
+    ;; the moment the buffer fills, well before any panel mounts).
+    (push-trace! {:operation :rf.flow/computed
+                  :op-type   :flow
+                  :id        100
+                  :time      100
+                  :tags      {:flow-id     :rect/area
+                              :frame       :rf/default
+                              :dispatch-id 42}})
+    (rf/with-frame :rf/causa
+      (override-flows!
+        {:rect/area {:inputs [[:w] [:h]] :path [:area]}})
+      (let [tree (flows/flows-view)]
+        (is (some? (find-by-testid tree "rf-causa-flow-badge-computing"))
+            "computing badge surfaces")
+        (is (some? (find-by-testid tree
+                                   "rf-causa-flow-row-recomputing-:rect/area"))
+            "'ran' cue surfaces on the row")))))
+
+(deftest skipping-status-renders-when-flow-skipped-this-cascade
+  (testing ":rf.flow/skip in the latest cascade surfaces the :skipping
+            badge (no 'ran' cue — the flow didn't actually recompute)"
+    (setup-causa-frame!)
+    (push-trace! {:operation :rf.flow/skip
+                  :op-type   :flow
+                  :id        100
+                  :time      100
+                  :tags      {:flow-id     :rect/area
+                              :frame       :rf/default
+                              :dispatch-id 42}})
+    (rf/with-frame :rf/causa
+      (override-flows!
+        {:rect/area {:inputs [[:w] [:h]] :path [:area]}})
+      (let [tree (flows/flows-view)]
+        (is (some? (find-by-testid tree "rf-causa-flow-badge-skipping")))
+        (is (nil? (find-by-testid tree
+                                  "rf-causa-flow-row-recomputing-:rect/area"))
+            "no 'ran' cue when the flow was skipped")))))
+
+(deftest failed-status-renders-when-flow-failed
+  (testing ":rf.flow/failed surfaces the :failed badge"
+    (setup-causa-frame!)
+    (push-trace! {:operation :rf.flow/failed
+                  :op-type   :flow
+                  :id        100
+                  :time      100
+                  :tags      {:flow-id     :rect/area
+                              :frame       :rf/default
+                              :dispatch-id 42}})
+    (rf/with-frame :rf/causa
+      (override-flows!
+        {:rect/area {:inputs [[:w] [:h]] :path [:area]}})
+      (let [tree (flows/flows-view)]
+        (is (some? (find-by-testid tree "rf-causa-flow-badge-failed")))))))
+
+;; ---- (4) selection ------------------------------------------------------
+
+(deftest select-flow-event-writes-to-causa-frame
+  (testing ":rf.causa/select-flow-id stores the flow-id on the Causa frame"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-flow-id :rect/area])
+      (is (= :rect/area @(rf/subscribe [:rf.causa/selected-flow-id]))))))
+
+(deftest clear-flow-selection-drops-selection
+  (testing ":rf.causa/clear-flow-selection dissocs the selected flow-id"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-flow-id :rect/area])
+      (rf/dispatch-sync [:rf.causa/clear-flow-selection])
+      (is (nil? @(rf/subscribe [:rf.causa/selected-flow-id]))))))
+
+;; ---- (5) summary chips render -------------------------------------------
+
+(deftest summary-renders-one-chip-per-non-zero-status
+  (testing "the summary header renders one chip per status with a
+            non-zero row count"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-flows!
+        {:a {:inputs [] :path [:a]}
+         :b {:inputs [] :path [:b]}})
+      ;; Both flows :idle — exactly one chip should render.
+      (let [tree  (flows/flows-view)
+            chips (find-all-by-testid-prefix tree "rf-causa-flows-summary-")]
+        (is (= 1 (count chips))
+            "one chip for the :idle status")))))
+
+;; ---- (6) frame isolation ------------------------------------------------
+
+(deftest flow-selection-does-not-leak-into-default-frame
+  (testing "the panel's selection state lives on :rf/causa, never :rf/default"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-flow-id :rect/area]))
+    (let [causa-db   (frame/frame-app-db-value :rf/causa)
+          default-db (frame/frame-app-db-value :rf/default)]
+      (is (= :rect/area (:selected-flow-id causa-db))
+          "selection lands on Causa")
+      (is (nil? (:selected-flow-id default-db))
+          "selection did NOT leak into :rf/default"))))


### PR DESCRIPTION
Closes rf2-83irn. Phase 5 of rf2-5aw5v (Causa v1.0 epic).

## Summary

- New **Flows panel** under `tools/causa/` — surfaces re-frame2's registered flows + their per-flow inputs / output path + a live recomputation indicator. Consumer of Spec 013 (the registered-flow surface, via `(rf/handlers :flow)`) and Spec 009 (the `:rf.flow/*` trace event vocabulary).
- Four-status taxonomy: `:failed` (sticky), `:computing` (pulse — `:rf.flow/computed` in the latest cascade), `:skipping` (`:rf.flow/skip` in the latest cascade — Spec 013 §Dirty-check semantics / rf2-719e value-equal recompute suppression), `:idle` (no events or events older than the latest cascade). Sticky failure + cascade-scoped pulse mean the row decays cleanly to `:idle` as new cascades land.
- Empty state: \"No flows registered.\"
- All wiring registered under the `:rf.causa/*` namespace prefix; panel state lives on the `:rf/causa` frame (per rf2-tijr Option C frame isolation).

## Subs added

- `:rf.causa/registered-flows` — reads `(rf/handlers :flow)` with a test-only override slot.
- `:rf.causa/flow-trace-events` — `:op-type :flow` slice of the trace buffer.
- `:rf.causa/selected-flow-id` — per-panel selection state.
- `:rf.causa/flows-data` — composite the view consumes (`{:rows :status-counts :total :selected-flow-id}`).

## Events added

- `:rf.causa/select-flow-id` — store the selected flow.
- `:rf.causa/clear-flow-selection` — drop the selection.
- `:rf.causa/set-registered-flows-override-for-test` — test-only stub hook.

## Surface scope

- `tools/causa/src/day8/re_frame2_causa/panels/flows.cljs` — view (pure hiccup).
- `tools/causa/src/day8/re_frame2_causa/panels/flows_helpers.cljc` — pure-data projection (JVM-runnable for unit tests).
- `tools/causa/test/day8/re_frame2_causa/panels/flows_helpers_cljs_test.cljc` — 35 helper tests (71 assertions). Covers `flow-trace-event?` / `filter-flow-events`, `latest-event-per-flow`, `latest-cascade-dispatch-id`, the `compute-status` four-status state machine, `project-rows` (row shape, ordering, idle defaults, cascade-decay), `status-counts`, `recent-events-for-flow`, taxonomy invariants, formatters.
- `tools/causa/test/day8/re_frame2_causa/panels/flows_view_cljs_test.cljs` — CLJS view + wiring tests (registry sub installation, empty state, populated list, live recomputation cue, skip / failed badges, selection events, summary chips, frame isolation).
- `registry.cljs` + `shell.cljs` — additions wrapped in `;; ── flows panel begin ──` / `;; ── flows panel end ──` markers per the parallel-conflict guidance with rf2-75121 (Performance panel). Markers can be dropped on the second-merging PR after the rebase recovery agent reconciles.

## Test plan

- [x] `clojure -M:test` under `tools/causa/` — 272 tests, 745 assertions, 0 failures, 0 errors.
- [x] `npm run test:cljs` — 1200 tests, 3121 assertions, 0 failures, 0 errors.
- [x] `npm run test:elision` — production elision smoke green.

## Known follow-ons (out of scope for this bead)

- Cross-panel jump: clicking a flow row should filter the event-detail panel to that flow's recent recomputations. The selection wiring is in place (`:rf.causa/select-flow-id`); the actual filter API lands when the cross-panel filter contract stabilises.
- Per-flow detail strip / DAG view: the helper carries `recent-events-for-flow` but the v1 row layout is list-only. A follow-on bead can add the deeper detail surface once Mike weighs the masterpiece-grade route (see the bead's spec-deficiency block — `008-Flows.md` per-panel spec).