### PR TITLE
feat(causa): MCP Server UI hookup — Phase 5 (rf2-81qjj)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/mcp_server.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/mcp_server.cljs
@@ -1,0 +1,485 @@
+(ns day8.re-frame2-causa.panels.mcp-server
+  "MCP Server panel — Phase 5 (rf2-81qjj, parent rf2-5aw5v).
+
+  Causa's panel-side surface for the `tools/causa-mcp/` agent server.
+  This panel shows what the AI agent is doing in the host app, by
+  filtering the trace-buffer to events tagged `:tags :origin
+  :causa-mcp` (the canonical tag the causa-mcp jar stamps on every
+  side-effect it performs — per
+  `tools/causa/spec/010-MCP-Server.md` §Origin tagging +
+  `tools/causa-mcp/spec/Principles.md` §Origin tagging is the
+  convention).
+
+  ## What this panel shows
+
+  A read-only, scrollable, timestamped ribbon of every trace event
+  the agent has produced this session. Each row carries:
+
+      timestamp · op-type · operation · tool · description · source-coord
+
+  Click a row → the parent dispatch-id is selected
+  (`:rf.causa/select-dispatch-id`) and the user pivots to the
+  event-detail panel for the cascade. Empty `:dispatch-id` events
+  (registry-time / lifecycle) stay non-clickable.
+
+  ## Settings sub-pane
+
+  Two settings surface inline above the feed (in lieu of a separate
+  Settings modal section — those land with the broader Settings work
+  per spec/007-UX-IA.md §Modal layers):
+
+  - **Origin colour** — read-only swatch + label. Currently locked to
+    cyan `#06B6D4` per the v1 inferential decision (see
+    mcp_server_helpers.cljc §INFERENTIAL DECISIONS). A follow-on bead
+    promotes this to spec/007-UX-IA.md §Colour system and surfaces a
+    full picker.
+
+  - **Origin-filter enable / disable** — drives the
+    `:rf.causa/mcp-origin-filter-enabled?` toggle which the Trace +
+    Causality + Event-detail panels can read to dim non-agent events
+    (the cross-panel wiring is a follow-on bead; this panel ships
+    the toggle so Mike can flick it at any time and any consumer
+    that reads the sub honours it immediately).
+
+  ## INFERENTIAL DECISIONS (rf2-81qjj — spec-deficient bead)
+
+  Three open questions the bead-filing agent flagged; each is
+  documented inline as a `;; DECISION` comment so a follow-on bead
+  can refine without spelunking history:
+
+  - (a) **Sidebar panel y/n** → yes (dedicated `:mcp-server` panel).
+  - (b) **Origin colour for `:causa-mcp`** → cyan `#06B6D4`.
+  - (c) **Bidirectional Causa→agent surface** → out of scope for v1
+        (causa-mcp jar implementation concern, not a Causa panel
+        concern).
+
+  See mcp_server_helpers.cljc for the rationale on each.
+
+  ## Pure hiccup (rf2-tijr)
+
+  Same contract as every other Causa panel — pure hiccup, no
+  Reagent / UIx / Helix references. Frame isolation comes from the
+  enclosing `[rf/frame-provider {:frame :rf/causa}]` in shell.cljs.
+
+  ## Helpers
+
+  All pure-data logic — origin classification, row projection, filter
+  application, empty-state classification — lives in
+  `mcp_server_helpers.cljc` so the algebra runs under the JVM
+  unit-test target."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.mcp-server-helpers :as h]))
+
+;; ---- design tokens (mirrors event_detail.cljs / issues_ribbon.cljs) -----
+
+(def ^:private tokens
+  "Subset of shell.cljs's dark-theme tokens used by this panel."
+  {:bg-1            "#15171B"
+   :bg-2            "#1B1E24"
+   :bg-3            "#232730"
+   :bg-active       "#2A2F3D"
+   :border-subtle   "#232730"
+   :border-default  "#2F3441"
+   :text-primary    "#E8EAF0"
+   :text-secondary  "#A8AEC0"
+   :text-tertiary   "#6B7080"
+   :accent-violet   "#7C5CFF"
+   :cyan            "#43C3D0"
+   :green           "#4ADE80"
+   :yellow          "#FBBF24"
+   :red             "#F87171"
+   :magenta         "#E879F9"
+   ;; DECISION (b) — `:origin :causa-mcp` gets cyan #06B6D4. Distinct
+   ;; from :pair indigo (locked) and :story/:test cyan (#43C3D0).
+   ;; Follow-on bead promotes this to spec/007-UX-IA.md §Colour system.
+   :causa-mcp-cyan  h/causa-mcp-origin-colour})
+
+(def ^:private mono-stack
+  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
+  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
+
+(def ^:private sans-stack
+  "Inter stack per spec/007-UX-IA.md §Typography."
+  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+
+;; ---- chip helpers -------------------------------------------------------
+
+(defn- chip
+  "One toggleable filter chip. `active?` drives the highlighted
+  styling. Mirrors `issues_ribbon.cljs`'s chip helper so the visual
+  rhythm matches across the two feeds."
+  [{:keys [label active? on-click test-id colour]}]
+  [:button {:data-testid test-id
+            :on-click    on-click
+            :style       {:background    (if active?
+                                           (:bg-active tokens)
+                                           "transparent")
+                          :color         (if active?
+                                           (:text-primary tokens)
+                                           (or colour (:text-secondary tokens)))
+                          :border        (str "1px solid "
+                                              (if active?
+                                                (or colour (:border-default tokens))
+                                                (:border-subtle tokens)))
+                          :border-radius "999px"
+                          :padding       "2px 10px"
+                          :cursor        "pointer"
+                          :font-family   sans-stack
+                          :font-size     "11px"
+                          :font-weight   (if active? 600 400)
+                          :letter-spacing "0.2px"
+                          :margin-right  "6px"
+                          :margin-bottom "4px"}}
+   label])
+
+(defn- op-type-chips
+  "Filter chip row over the distinct op-types present in the feed.
+  Each chip toggles membership in the active op-type filter set."
+  [active-op-types distinct-op-types op-type-counts]
+  (when (seq distinct-op-types)
+    (into [:div {:data-testid "rf-causa-mcp-op-type-chips"
+                 :style       {:display "flex" :flex-wrap "wrap"}}]
+          (for [op-type distinct-op-types
+                :let [active? (contains? active-op-types op-type)
+                      n       (get op-type-counts op-type 0)]]
+            (chip {:label    (str (name op-type) " · " n)
+                   :active?  active?
+                   :colour   (:causa-mcp-cyan tokens)
+                   :test-id  (str "rf-causa-mcp-op-type-chip-" (name op-type))
+                   :on-click #(rf/dispatch [:rf.causa/toggle-mcp-op-type
+                                            op-type])})))))
+
+(defn- since-input
+  "The `since-ms` filter — a numeric input rendered as a chip-row
+  sibling. Values are in seconds for ergonomic typing; the helper
+  converts to ms before dispatching. Mirrors the Issues ribbon's
+  identical surface."
+  [since-ms]
+  [:div {:data-testid "rf-causa-mcp-since-input"
+         :style {:display "flex"
+                 :align-items "center"
+                 :gap "6px"
+                 :margin-top "4px"
+                 :font-family sans-stack
+                 :font-size "11px"
+                 :color (:text-secondary tokens)}}
+   [:span "since"]
+   [:input {:type      "number"
+            :min       "0"
+            :step      "10"
+            :value     (str (when (number? since-ms) (long (/ since-ms 1000))))
+            :on-change (fn [e]
+                         (let [v (.. e -target -value)
+                               n (try
+                                   (let [parsed (js/parseInt v 10)]
+                                     (when-not (js/isNaN parsed) parsed))
+                                   (catch :default _ nil))]
+                           (rf/dispatch [:rf.causa/set-mcp-since-seconds n])))
+            :style     {:width "60px"
+                        :background (:bg-3 tokens)
+                        :color (:text-primary tokens)
+                        :border (str "1px solid " (:border-subtle tokens))
+                        :border-radius "3px"
+                        :padding "2px 4px"
+                        :font-family mono-stack
+                        :font-size "11px"}}]
+   [:span "s ago"]])
+
+;; ---- settings sub-pane --------------------------------------------------
+
+(defn- settings-sub-pane
+  "Inline Settings strip — origin colour swatch + origin-filter
+  enable/disable toggle. Per the bead's contract these settings
+  surface here (not in a separate Settings modal section) until the
+  broader Settings work lands."
+  [{:keys [origin-filter-enabled?]}]
+  [:section {:data-testid "rf-causa-mcp-settings"
+             :style       {:padding "8px 16px"
+                           :border-bottom (str "1px solid " (:border-subtle tokens))
+                           :background (:bg-1 tokens)
+                           :font-family sans-stack
+                           :font-size "11px"
+                           :color (:text-secondary tokens)
+                           :display "flex"
+                           :align-items "center"
+                           :gap "16px"
+                           :flex-wrap "wrap"}}
+   ;; Origin colour swatch (read-only v1; picker is a follow-on bead).
+   [:div {:data-testid "rf-causa-mcp-origin-swatch"
+          :style {:display "flex" :align-items "center" :gap "6px"}}
+    [:span {:style {:display "inline-block"
+                    :width "10px"
+                    :height "10px"
+                    :border-radius "50%"
+                    :background (:causa-mcp-cyan tokens)
+                    :border (str "1px solid " (:border-default tokens))}}]
+    [:span {:style {:color (:text-tertiary tokens)}}
+     "origin :causa-mcp →"]
+    [:code {:style {:font-family mono-stack
+                    :font-size "10px"
+                    :color (:causa-mcp-cyan tokens)}}
+     h/causa-mcp-origin-colour]]
+   ;; Origin-filter enable / disable toggle.
+   [:label {:data-testid "rf-causa-mcp-origin-filter-toggle"
+            :style {:display "flex"
+                    :align-items "center"
+                    :gap "6px"
+                    :cursor "pointer"
+                    :color (:text-secondary tokens)}}
+    [:input {:type      "checkbox"
+             :checked   (boolean origin-filter-enabled?)
+             :on-change #(rf/dispatch [:rf.causa/toggle-mcp-origin-filter])
+             :style     {:cursor "pointer"}}]
+    [:span "Highlight :causa-mcp events across panels"]]])
+
+;; ---- header strip -------------------------------------------------------
+
+(defn- header
+  "Panel header — title + agent-attached badge + counts + filter
+  chips. Mirrors `issues_ribbon.cljs`'s header for visual continuity."
+  [{:keys [agent-attached? total rendered active-op-types
+           distinct-op-types op-type-counts since-ms any-filter?]}]
+  [:header {:style {:padding "12px 16px 6px 16px"
+                    :border-bottom (str "1px solid " (:border-subtle tokens))}}
+   [:div {:style {:display     "flex"
+                  :align-items "baseline"
+                  :gap         "12px"}}
+    [:h1 {:style {:font-size "16px"
+                  :font-weight 600
+                  :margin 0
+                  :color  (:text-primary tokens)}}
+     "MCP"]
+    [:span {:data-testid "rf-causa-mcp-attached-badge"
+            :style {:font-size   "11px"
+                    :font-family sans-stack
+                    :color       (if agent-attached?
+                                   (:causa-mcp-cyan tokens)
+                                   (:text-tertiary tokens))
+                    :border      (str "1px solid "
+                                      (if agent-attached?
+                                        (:causa-mcp-cyan tokens)
+                                        (:border-subtle tokens)))
+                    :border-radius "999px"
+                    :padding     "1px 8px"}}
+     (if agent-attached?
+       "agent attached"
+       "no activity")]
+    [:span {:data-testid "rf-causa-mcp-counts"
+            :style {:font-size   "11px"
+                    :color       (:text-tertiary tokens)
+                    :font-family mono-stack}}
+     (str rendered " / " total " in view")]
+    (when any-filter?
+      [:button {:data-testid "rf-causa-mcp-clear-filters"
+                :on-click    #(rf/dispatch [:rf.causa/clear-mcp-filters])
+                :style       {:margin-left "auto"
+                              :background  "transparent"
+                              :color       (:cyan tokens)
+                              :border      (str "1px solid " (:border-default tokens))
+                              :padding     "2px 8px"
+                              :border-radius "3px"
+                              :cursor      "pointer"
+                              :font-family sans-stack
+                              :font-size   "11px"}}
+       "Clear filters"])]
+   [:div {:style {:margin-top "8px"}}
+    (op-type-chips active-op-types distinct-op-types op-type-counts)
+    (since-input since-ms)]])
+
+;; ---- per-row -------------------------------------------------------------
+
+(defn- mcp-row
+  "One row in the agent-activity feed. Click the row → pivot to the
+  cascade in the event-detail panel. Click the source-coord chip →
+  open in editor (via the open-in-editor module's stub event)."
+  [{:keys [id time op-type operation tool description
+           source-coord dispatch-id]
+    :as _row}]
+  (let [row-test-id (str "rf-causa-mcp-row-" id)]
+    [:li {:key         id
+          :data-testid row-test-id
+          :on-click    (fn []
+                         (when dispatch-id
+                           (rf/dispatch [:rf.causa/select-dispatch-id dispatch-id])
+                           (rf/dispatch [:rf.causa/select-panel :event-detail])))
+          :style       {:display       "grid"
+                        :grid-template-columns "84px 90px minmax(120px, 1fr) auto 2fr auto"
+                        :gap           "10px"
+                        :align-items   "center"
+                        :padding       "6px 16px"
+                        :border-bottom (str "1px solid " (:border-subtle tokens))
+                        :cursor        (if dispatch-id "pointer" "default")
+                        :color         (:text-primary tokens)
+                        :font-family   mono-stack
+                        :font-size     "12px"
+                        :line-height   1.35}}
+     ;; Timestamp
+     [:span {:data-testid (str row-test-id "-time")
+             :style {:color (:text-tertiary tokens)
+                     :font-size "11px"
+                     :white-space "nowrap"}}
+      (or (h/format-time time) "—")]
+     ;; op-type
+     [:span {:data-testid (str row-test-id "-op-type")
+             :style       {:color       (:causa-mcp-cyan tokens)
+                           :overflow    "hidden"
+                           :text-overflow "ellipsis"
+                           :white-space "nowrap"
+                           :font-weight 500}}
+      (if op-type (name op-type) "—")]
+     ;; operation
+     [:span {:data-testid (str row-test-id "-operation")
+             :style       {:color       (:accent-violet tokens)
+                           :overflow    "hidden"
+                           :text-overflow "ellipsis"
+                           :white-space "nowrap"}}
+      (if operation (str operation) "—")]
+     ;; tool (the causa-mcp tool name lifted off :tags :tool)
+     (if tool
+       [:span {:data-testid (str row-test-id "-tool")
+               :title       "causa-mcp tool"
+               :style       {:color       (:causa-mcp-cyan tokens)
+                             :font-size   "10px"
+                             :background  (:bg-3 tokens)
+                             :border      (str "1px solid " (:border-subtle tokens))
+                             :border-radius "3px"
+                             :padding     "1px 6px"
+                             :white-space "nowrap"}}
+        (str tool)]
+       [:span {:style {:color (:text-tertiary tokens) :font-size "10px"}} "—"])
+     ;; description
+     [:span {:data-testid (str row-test-id "-description")
+             :style       {:color (:text-secondary tokens)
+                           :overflow "hidden"
+                           :text-overflow "ellipsis"
+                           :white-space "nowrap"}
+             :title       description}
+      description]
+     ;; source-coord (when present)
+     (if source-coord
+       [:button {:data-testid (str row-test-id "-source")
+                 :on-click    (fn [e]
+                                ;; Stop propagation so the row's pivot
+                                ;; handler doesn't also fire.
+                                (.stopPropagation e)
+                                (rf/dispatch [:rf.causa/open-in-editor
+                                              {:source-coord source-coord}]))
+                 :style       {:background  "transparent"
+                               :color       (:cyan tokens)
+                               :border      (str "1px solid " (:border-subtle tokens))
+                               :padding     "1px 6px"
+                               :border-radius "3px"
+                               :cursor      "pointer"
+                               :font-family mono-stack
+                               :font-size   "10px"}}
+        source-coord]
+       [:span {:style {:color (:text-tertiary tokens) :font-size "10px"}}
+        "—"])]))
+
+;; ---- empty states -------------------------------------------------------
+
+(defn- empty-state-no-activity
+  "Rendered when no causa-mcp-tagged events have landed in the
+  buffer this session. The desired state when no agent is attached
+  (or when an attached agent hasn't yet performed any side-effect).
+  Carries pointer copy about origin-tagging discipline so the user
+  knows what they're looking at."
+  []
+  [:div {:data-testid "rf-causa-mcp-empty-no-activity"
+         :style       {:padding     "24px"
+                       :font-family sans-stack
+                       :font-size   "13px"
+                       :line-height 1.5
+                       :color       (:text-secondary tokens)}}
+   [:div {:style {:display "flex"
+                  :align-items "center"
+                  :gap "10px"
+                  :margin-bottom "8px"}}
+    [:span {:style {:color       (:causa-mcp-cyan tokens)
+                    :font-size   "16px"
+                    :font-weight 700}}
+     "⌬"]
+    [:span {:style {:color       (:text-primary tokens)
+                    :font-weight 600}}
+     "No agent activity"]]
+   [:p {:style {:margin "0 0 8px 0" :color (:text-tertiary tokens)}}
+    "Causa-MCP (the agent server) tags every operation it performs "
+    "with " [:code {:style {:font-family mono-stack
+                            :color (:causa-mcp-cyan tokens)}}
+             ":origin :causa-mcp"]
+    ". Nothing tagged that way has landed in the buffer this session."]
+   [:p {:style {:margin 0 :color (:text-tertiary tokens)
+                :font-size "12px"
+                :font-style "italic"}}
+    "Once an agent connects via the causa-mcp jar and performs an op, "
+    "this feed lights up."]])
+
+(defn- empty-state-no-matches
+  "Events exist but the active filters hide them all."
+  []
+  [:div {:data-testid "rf-causa-mcp-empty-no-matches"
+         :style       {:padding     "24px"
+                       :font-family sans-stack
+                       :font-size   "13px"
+                       :line-height 1.5
+                       :color       (:text-secondary tokens)}}
+   [:p {:style {:margin "0 0 12px 0"
+                :color (:text-primary tokens)
+                :font-weight 600}}
+    "No agent events match the active filters."]
+   [:p {:style {:margin "0 0 12px 0" :color (:text-tertiary tokens)}}
+    "Adjust the op-type / since-ms chips above to widen the feed."]
+   [:button {:data-testid "rf-causa-mcp-empty-clear-filters"
+             :on-click    #(rf/dispatch [:rf.causa/clear-mcp-filters])
+             :style       {:background "transparent"
+                           :color      (:cyan tokens)
+                           :border     (str "1px solid " (:border-default tokens))
+                           :padding    "4px 10px"
+                           :border-radius "3px"
+                           :cursor     "pointer"
+                           :font-family sans-stack
+                           :font-size  "12px"}}
+    "Clear filters"]])
+
+;; ---- public view --------------------------------------------------------
+
+(defn mcp-server-view
+  "The MCP Server panel's root view. Subscribes to
+  `:rf.causa/mcp-server` (composite) + `:rf.causa/mcp-origin-filter-
+  enabled?` (settings sub-pane state)."
+  []
+  (let [{:keys [rows total rendered op-type-counts distinct-op-types
+                filters agent-attached? empty-kind]
+         :as _data}
+        @(rf/subscribe [:rf.causa/mcp-server])
+        origin-filter-enabled?
+        @(rf/subscribe [:rf.causa/mcp-origin-filter-enabled?])
+        {:keys [op-types since-ms]} filters
+        any-filter? (boolean (or (seq op-types) (some? since-ms)))]
+    [:section {:data-testid "rf-causa-mcp-server"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      "14px"}}
+     (header {:agent-attached?    agent-attached?
+              :total              total
+              :rendered           rendered
+              :active-op-types    (or op-types #{})
+              :distinct-op-types  distinct-op-types
+              :op-type-counts     op-type-counts
+              :since-ms           since-ms
+              :any-filter?        any-filter?})
+     (settings-sub-pane {:origin-filter-enabled? origin-filter-enabled?})
+     [:div {:style {:flex 1 :overflow "auto"}}
+      (case empty-kind
+        :no-activity (empty-state-no-activity)
+        :no-matches  (empty-state-no-matches)
+        nil          (into [:ul {:data-testid "rf-causa-mcp-feed"
+                                 :style       {:list-style "none"
+                                               :margin     0
+                                               :padding    0}}]
+                           (for [row rows]
+                             (mcp-row row))))]]))

--- a/tools/causa/src/day8/re_frame2_causa/panels/mcp_server_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/mcp_server_helpers.cljc
@@ -1,0 +1,394 @@
+(ns day8.re-frame2-causa.panels.mcp-server-helpers
+  "Pure-data helpers for Causa's MCP Server panel (Phase 5, rf2-81qjj,
+  parent rf2-5aw5v).
+
+  ## Why a separate `.cljc` ns
+
+  Same dual-target pattern as the other Causa panel helpers (e.g.
+  `issues_ribbon_helpers.cljc`, `trace_helpers.cljc`): the *view* in
+  `mcp_server.cljs` paints hiccup and dispatches into the Causa frame;
+  the *logic* — filter the trace buffer to events tagged
+  `:origin :causa-mcp`, project each event into a flat row shape,
+  classify the empty state — is pure data → data. Splitting the
+  algebra into `.cljc` so it runs under the JVM unit-test target
+  (`clojure -M:test`) is required by the standing rule
+  `feedback_jvm_interop_must_work.md`.
+
+  ## Substrate (per `tools/causa/spec/010-MCP-Server.md` §Origin tagging
+  + `tools/causa-mcp/spec/Principles.md` §Origin tagging is the
+  convention)
+
+  The causa-mcp jar tags every side-effect it performs on the trace
+  bus with `:tags :origin :causa-mcp`. The panel reads these tagged
+  events out of Causa's trace-buffer and surfaces them as a read-only
+  feed so the user can see at-a-glance what the AI agent is doing in
+  their app.
+
+  Closed-set `:origin` vocabulary per Spec 009 §Origin axis:
+
+      :app         — application code (user clicks, timers, normal dispatch)
+      :pair        — tools/pair2-mcp/ (editor-side AI workflows)
+      :causa-mcp   — tools/causa-mcp/ (debugger-side AI workflows)
+      :story       — Tool-Pair stories playing back in the browser
+      :test        — test runs (cljs.test, kaocha, etc.)
+
+  This panel filters to `:causa-mcp` exclusively; the Trace panel
+  remains the all-origins surface.
+
+  ## INFERENTIAL DECISIONS (rf2-81qjj — spec-deficient bead)
+
+  The bead flagged three open questions. This helper records the
+  inferential calls made under §Phase 5 of rf2-5aw5v; each is a
+  candidate for refinement via a follow-on bead.
+
+  **(a) Sidebar panel y/n** — yes, a dedicated `:mcp-server` panel.
+      Rationale: parallels every other Phase 5 panel (Issues, Trace,
+      Performance, …) and gives the user a single entry point for
+      'what is the agent doing.' Settings-only would force users to
+      hunt across the Trace panel with the `:origin` filter manually
+      set every session.
+
+  **(b) Origin colour for `:causa-mcp`** — `cyan` `#06B6D4`.
+      Rationale: spec/007-UX-IA.md §Colour system locks `:pair` to
+      indigo `#5570FF`; `:story` / `:test` already share cyan
+      `#43C3D0` (light-cyan). `:causa-mcp` gets a deeper / more
+      saturated cyan `#06B6D4` (Tailwind cyan-500) to distinguish from
+      the lighter `:story` cyan without re-using indigo. The colour
+      token registers under `:causa-mcp-cyan` in the panel; a
+      follow-on bead can promote it to spec/007-UX-IA.md §Colour
+      system + the shared shell token map.
+
+  **(c) Bidirectional Causa→agent surface** — OUT OF SCOPE for v1.
+      Rationale: the causa-mcp jar is the agent→host direction;
+      anything the panel would 'expose back' (e.g. session attention
+      hints) is a causa-mcp implementation concern, not a Causa
+      panel concern. Filed as follow-on if Mike wants it.
+
+  ## Filter axes (panel-local)
+
+  The panel always pre-filters to `:origin :causa-mcp`. On top of
+  that, two view-toggleable axes:
+
+      :op-type-set     — which op-types to include (default: all
+                         seen, presented as toggleable chips)
+      :since-ms        — relative time window in ms (nil = all)
+
+  Each axis is independent; empty filter sets / nil since-ms
+  disable the axis.
+
+  ## Pull-only — no probe
+
+  The panel does NOT probe for the causa-mcp jar's session-id
+  sentinel. Detection runs implicitly: if any event tagged
+  `:origin :causa-mcp` has landed in the buffer the agent IS
+  attached. Empty buffer (no causa-mcp events) → 'No agent
+  activity observed' empty state. This is simpler than a separate
+  detector loop and matches the trace-bus-is-truth posture of
+  every other Causa panel."
+  (:require [clojure.string :as str]))
+
+;; ---- the inferential origin colour --------------------------------------
+
+(def causa-mcp-origin-colour
+  "Hex colour for `:origin :causa-mcp`. v1 inferential pick — Tailwind
+  cyan-500 `#06B6D4`. Distinct from `:pair`'s indigo `#5570FF` (locked
+  in spec/007-UX-IA.md §Colour system) and from `:story` / `:test`'s
+  lighter cyan `#43C3D0` (the existing `:cyan` token in shell.cljs).
+
+  Follow-on bead candidate: promote into spec/007-UX-IA.md §Colour
+  system + the shared shell token map so every panel that renders an
+  `:origin` swatch reads the same source of truth."
+  "#06B6D4")
+
+(def causa-mcp-origin-tag
+  "The closed-set origin keyword Causa-MCP stamps on every side-effect
+  it performs. Documented in `tools/causa/spec/010-MCP-Server.md`
+  §Origin tagging + `tools/causa-mcp/spec/Principles.md` §Origin
+  tagging is the convention."
+  :causa-mcp)
+
+;; ---- defaults -----------------------------------------------------------
+
+(def default-since-ms
+  "Default 'since' window in ms. The panel shows agent events from
+  this many ms ago to now. 10 minutes — long enough that a programmer
+  stepping back from the screen can return and still see the burst,
+  parity with the Issues ribbon."
+  600000)
+
+;; ---- origin classification ----------------------------------------------
+
+(defn origin-of
+  "Project the dispatch-origin slot per Spec 009 §Origin tagging
+  (`:tags :origin`). Defensive against absence — returns nil. Mirrors
+  `trace_helpers.cljc/origin-of` so the two panels are in lockstep."
+  [ev]
+  (get-in ev [:tags :origin]))
+
+(defn causa-mcp-event?
+  "True iff `ev` carries `:tags :origin :causa-mcp`. The single
+  classifier the panel uses to slice the buffer. Pure data → bool;
+  JVM-testable."
+  [ev]
+  (= causa-mcp-origin-tag (origin-of ev)))
+
+;; ---- source-coord projection --------------------------------------------
+
+(defn source-coord
+  "Extract a `file:line` string from `:rf.trace/trigger-handler`'s
+  `:source-coord` slot. Per Spec 009 every emit inside a dispatch
+  carries this slot when handler scope is bound (per rf2-3nn8 /
+  rf2-lf84g). Pure data → string-or-nil; JVM-testable. Mirrors the
+  helpers in issues_ribbon_helpers.cljc / trace_helpers.cljc."
+  [ev]
+  (when-let [trigger (:rf.trace/trigger-handler ev)]
+    (let [{:keys [file line]} (:source-coord trigger)]
+      (when file
+        (cond-> file
+          line (str ":" line))))))
+
+;; ---- short description --------------------------------------------------
+
+(defn short-description
+  "Build the per-row one-line description. Reads (in priority order):
+
+    1. `[:tags :event]`               — dispatched event vector
+    2. `[:tags :tool]`                — which causa-mcp tool ran
+    3. `[:tags :reason]`              — error categories
+    4. `[:tags :exception-message]`   — handler / fx exceptions
+    5. `[:tags :sub-id]`              — sub-related ops
+    6. `[:tags :fx-id]`               — fx invocations
+    7. `(str operation)` only         — fallback
+
+  Pure data → string; JVM-testable. The `:tool` slot is the canonical
+  causa-mcp annotation per the spec/010-MCP-Server.md catalogue (each
+  tool name lands as a tag so the buffer carries the agent-action
+  provenance)."
+  [{:keys [operation tags] :as _ev}]
+  (let [op-str (if operation (str operation) "(unknown)")
+        detail (or (when (vector? (:event tags))
+                     (try (pr-str (:event tags))
+                          (catch #?(:clj Throwable :cljs :default) _ nil)))
+                   (when (some? (:tool tags))
+                     (str (:tool tags)))
+                   (:reason tags)
+                   (:exception-message tags)
+                   (when (some? (:sub-id tags))
+                     (str (:sub-id tags)))
+                   (when (some? (:fx-id tags))
+                     (str (:fx-id tags))))]
+    (if (and detail (not (str/blank? (str detail))))
+      (str op-str " — " detail)
+      op-str)))
+
+;; ---- per-row projection -------------------------------------------------
+
+(defn project-row
+  "Project one raw trace event into the panel's row shape:
+
+      {:id              <int>
+       :time            <ms>
+       :op-type         <kw>
+       :operation       <kw>
+       :origin          <kw>          ;; always :causa-mcp by construction
+       :tool            <kw-or-nil>   ;; lifted off :tags :tool
+       :description     <string>
+       :source-coord    <string-or-nil>
+       :dispatch-id     <int-or-nil>
+       :raw             <trace-event>}
+
+  Pure data → data; JVM-testable. Returns nil when `ev` is not a
+  causa-mcp-tagged event so callers can `keep` over a mixed stream."
+  [{:keys [id time op-type operation tags] :as ev}]
+  (when (causa-mcp-event? ev)
+    {:id              id
+     :time            time
+     :op-type         op-type
+     :operation       operation
+     :origin          causa-mcp-origin-tag
+     :tool            (:tool tags)
+     :description     (short-description ev)
+     :source-coord    (source-coord ev)
+     :dispatch-id     (or (:dispatch-id tags)
+                          (get-in ev [:tags :dispatch-id]))
+     :raw             ev}))
+
+(defn project-rows
+  "Filter `events` to the causa-mcp subset and project each one.
+  Returns a vector in chronological order (oldest first). Pure data →
+  data; JVM-testable."
+  [events]
+  (into []
+        (keep project-row)
+        events))
+
+;; ---- now-ms (abstracted for test fixtures) -------------------------------
+
+(defn now-ms
+  "Return host-clock time in ms. Pure-ish — abstracted so test
+  fixtures can stub via `with-redefs`. Cross-platform via
+  `#?(:clj ... :cljs ...)`. Mirrors the issues_ribbon_helpers /
+  trace_helpers convention."
+  []
+  #?(:clj  (System/currentTimeMillis)
+     :cljs (.getTime (js/Date.))))
+
+;; ---- filter application -------------------------------------------------
+
+(defn passes-op-type?
+  "True iff `row`'s op-type is in the active filter set, or if the
+  filter set is empty (= no op-type restriction). Pure data → bool;
+  JVM-testable."
+  [active-op-types {:keys [op-type] :as _row}]
+  (or (empty? active-op-types)
+      (contains? active-op-types op-type)))
+
+(defn passes-since?
+  "True iff `row`'s `:time` is within `since-ms` of `now`. Pure data →
+  bool; JVM-testable. Mirrors issues_ribbon_helpers/passes-since?
+
+  `nil` `since-ms` disables the axis. `nil` `:time` falls back to
+  'in window' so events without a stamp still surface — defensive
+  against malformed trace events."
+  [now since-ms {:keys [time] :as _row}]
+  (or (nil? since-ms)
+      (nil? time)
+      (and (number? time)
+           (number? now)
+           (>= time (- now since-ms)))))
+
+(defn apply-filters
+  "Apply the two filter axes to `rows`. Pure data → vector;
+  JVM-testable. Each axis is independent — empty filter sets / nil
+  since-ms disable the axis.
+
+  `filters` is `{:op-types #{...} :since-ms <ms>}`. `now` is the
+  wall-clock 'now' to test :time against (helper-injected so tests
+  don't depend on the system clock)."
+  [rows filters now]
+  (let [{:keys [op-types since-ms]} filters]
+    (filterv
+      (fn [row]
+        (and (passes-op-type? op-types row)
+             (passes-since? now since-ms row)))
+      rows)))
+
+;; ---- op-type enumeration -------------------------------------------------
+
+(defn distinct-op-types
+  "Return the distinct op-types present in `rows` in first-seen order.
+  The view uses this to populate the op-type chip row with only the
+  op-types that have at least one row — empty chips would be noise.
+  Pure data → vector; JVM-testable."
+  [rows]
+  (into []
+        (comp (map :op-type)
+              (remove nil?)
+              (distinct))
+        rows))
+
+(defn op-type-counts
+  "Histogram of op-type → count over `rows`. Drives chip badge counts.
+  Pure data → map; JVM-testable."
+  [rows]
+  (reduce
+    (fn [acc {:keys [op-type]}]
+      (if (nil? op-type)
+        acc
+        (update acc op-type (fnil inc 0))))
+    {}
+    rows))
+
+;; ---- detection ----------------------------------------------------------
+
+(defn agent-attached?
+  "True iff at least one causa-mcp-tagged event has landed in the
+  buffer. The pull-only proxy for 'is the agent attached' — the
+  trace-bus is the truth, no separate sentinel probe required.
+
+  Pure data → bool; JVM-testable."
+  [events]
+  (boolean (some causa-mcp-event? events)))
+
+;; ---- composite projection (the panel reads this) ------------------------
+
+(defn project-feed
+  "Top-level projection — produces every slot the view needs in one
+  pass. Pure data → data; JVM-testable.
+
+  Returns:
+
+      {:rows               [<row> ...]       ;; post-filter, newest first
+       :total              <int>             ;; pre-filter count
+       :rendered           <int>             ;; post-filter count
+       :op-type-counts     {op-type count}
+       :distinct-op-types  [<op-type> ...]
+       :filters            <pass-through>
+       :agent-attached?    <bool>
+       :empty-kind         <:no-activity / :no-matches / nil>}
+
+  `events` is the raw trace-buffer. `filters` is the current filter
+  state. `now` is wall-clock ms.
+
+  `:empty-kind` discriminates:
+
+      :no-activity — no causa-mcp events at all (agent not attached
+                     OR has done nothing this session).
+      :no-matches  — events exist but the active filters hide them
+                     all. The view paints 'No matches' with a
+                     clear-filters affordance.
+      nil          — at least one event passed; render the feed."
+  [events filters now]
+  (let [all              (project-rows events)
+        filtered         (apply-filters all filters now)
+        ;; Newest first for display — parity with the Issues ribbon's
+        ;; feed orientation.
+        sorted-display   (vec (reverse filtered))
+        op-type-counts'  (op-type-counts all)
+        empty-kind       (cond
+                           (empty? all)      :no-activity
+                           (empty? filtered) :no-matches
+                           :else             nil)]
+    {:rows              sorted-display
+     :total             (count all)
+     :rendered          (count filtered)
+     :op-type-counts    op-type-counts'
+     :distinct-op-types (distinct-op-types all)
+     :filters           filters
+     :agent-attached?   (boolean (seq all))
+     :empty-kind        empty-kind}))
+
+;; ---- selection ----------------------------------------------------------
+
+(defn find-row
+  "Look up a projected row by `:id` in `rows`. Returns nil when not
+  found. Pure data → row-or-nil; JVM-testable."
+  [rows row-id]
+  (some (fn [v] (when (= row-id (:id v)) v)) rows))
+
+;; ---- formatting ---------------------------------------------------------
+
+(defn format-time
+  "Render `t` (ms-since-epoch) as `HH:MM:SS.mmm`. Matches the Issues
+  ribbon / Trace panel's format so the three feeds share a visual
+  rhythm. Pure-ish — uses the platform Date constructor."
+  [t]
+  (when (number? t)
+    #?(:clj  (let [^java.time.Instant inst (java.time.Instant/ofEpochMilli (long t))
+                   ^java.time.LocalTime lt (.toLocalTime
+                                             (.atZone inst (java.time.ZoneId/systemDefault)))]
+               (format "%02d:%02d:%02d.%03d"
+                       (.getHour lt)
+                       (.getMinute lt)
+                       (.getSecond lt)
+                       (long (mod t 1000))))
+       :cljs (let [d   (js/Date. t)
+                   pad (fn [n w]
+                         (let [s (str n)]
+                           (if (< (count s) w)
+                             (str (apply str (repeat (- w (count s)) "0")) s)
+                             s)))]
+               (str (pad (.getHours d) 2) ":"
+                    (pad (.getMinutes d) 2) ":"
+                    (pad (.getSeconds d) 2) "."
+                    (pad (.getMilliseconds d) 3))))))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -127,6 +127,7 @@
             [day8.re-frame2-causa.panels.flows-helpers :as flows-helpers]
             [day8.re-frame2-causa.panels.hydration-debugger-helpers :as hd-helpers]
             [day8.re-frame2-causa.panels.issues-ribbon-helpers :as issues-helpers]
+            [day8.re-frame2-causa.panels.mcp-server-helpers :as mcp-helpers]
             [day8.re-frame2-causa.panels.performance-helpers :as perf-helpers]
             [day8.re-frame2-causa.panels.schema-violation-timeline-helpers :as svt-helpers]
             [day8.re-frame2-causa.panels.subscriptions-helpers :as subs-helpers]
@@ -1321,6 +1322,109 @@
     (rf/reg-event-db :rf.causa/clear-trace-filters
       (fn [db _event]
         (dissoc db :trace-filters)))
+
+    ;; ── mcp-server panel begin ──
+    ;;
+    ;; Phase 5 (rf2-81qjj) — MCP Server panel
+    ;;
+    ;; Per `tools/causa/spec/010-MCP-Server.md` §Origin tagging +
+    ;; `tools/causa-mcp/spec/Principles.md` §Origin tagging is the
+    ;; convention the panel filters the trace-buffer to events tagged
+    ;; `:tags :origin :causa-mcp` (the canonical tag the causa-mcp jar
+    ;; stamps on every side-effect it performs). The composite is a
+    ;; thin wrapper over `mcp-helpers/project-feed`; the panel is a
+    ;; read-only feed of agent activity in the host.
+    ;;
+    ;; Shape of `:rf.causa/mcp-server`:
+    ;;
+    ;;     {:rows              [<row> ...]
+    ;;      :total             <int>
+    ;;      :rendered          <int>
+    ;;      :op-type-counts    {op-type count}
+    ;;      :distinct-op-types [<op-type> ...]
+    ;;      :filters           <pass-through>
+    ;;      :agent-attached?   <bool>
+    ;;      :empty-kind        <:no-activity / :no-matches / nil>}
+    ;;
+    ;; ## INFERENTIAL DECISIONS (rf2-81qjj — spec-deficient bead)
+    ;;
+    ;; (a) Dedicated sidebar panel — yes. Parallels every other Phase 5
+    ;;     panel; gives users one entry point for 'what is the agent
+    ;;     doing'.
+    ;; (b) Origin colour for `:causa-mcp` — cyan #06B6D4 (see helpers
+    ;;     ns). Distinct from :pair indigo (locked) and :story/:test
+    ;;     light-cyan (#43C3D0).
+    ;; (c) Bidirectional Causa→agent surface — out of scope (causa-mcp
+    ;;     jar implementation concern).
+    ;;
+    ;; Each is a follow-on bead candidate.
+
+    ;; Active filter state — the panel reads the two slots through one
+    ;; sub so the view re-renders atomically when filters change.
+    (rf/reg-sub :rf.causa/mcp-filters
+      (fn [db _query]
+        {:op-types (get db :mcp-active-op-types #{})
+         :since-ms (get db :mcp-since-ms)}))
+
+    ;; Composite — produces every slot the view consumes. The
+    ;; helper's `project-feed` does the heavy lifting; the sub is a
+    ;; thin wrapper that injects `now-ms` (so the since-ms axis is
+    ;; meaningful) and reads the trace-buffer + filter state through
+    ;; the reactive surface.
+    (rf/reg-sub :rf.causa/mcp-server
+      :<- [:rf.causa/trace-buffer]
+      :<- [:rf.causa/mcp-filters]
+      (fn [[buffer filters] _query]
+        (mcp-helpers/project-feed buffer filters (mcp-helpers/now-ms))))
+
+    ;; The cross-panel highlight toggle. When true, other panels MAY
+    ;; honour this (Trace / Event-detail / Causality) to dim non-agent
+    ;; events. Default false — the toggle is an opt-in.
+    ;;
+    ;; The cross-panel wiring (other panels reading this sub) is a
+    ;; follow-on bead; this panel ships the toggle so the surface is
+    ;; in place and any consumer that subscribes honours it
+    ;; immediately. Filed as: 'Causa: cross-panel :causa-mcp origin
+    ;; highlight.'
+    (rf/reg-sub :rf.causa/mcp-origin-filter-enabled?
+      (fn [db _query]
+        (boolean (get db :mcp-origin-filter-enabled? false))))
+
+    ;; ---- MCP Server panel events --------------------------------------
+
+    ;; Toggle an op-type chip in/out of the active filter set.
+    (rf/reg-event-db :rf.causa/toggle-mcp-op-type
+      (fn [db [_ op-type]]
+        (let [current (get db :mcp-active-op-types #{})]
+          (assoc db :mcp-active-op-types
+                 (if (contains? current op-type)
+                   (disj current op-type)
+                   (conj current op-type))))))
+
+    ;; Set the since-ms axis from a seconds-typed user input. The
+    ;; view converts s → ms here so the helper's filter-application
+    ;; stays uniform in ms. nil / non-positive values clear the axis.
+    (rf/reg-event-db :rf.causa/set-mcp-since-seconds
+      (fn [db [_ seconds]]
+        (if (and (number? seconds) (pos? seconds))
+          (assoc db :mcp-since-ms (* (long seconds) 1000))
+          (dissoc db :mcp-since-ms))))
+
+    ;; Clear every filter axis in one shot. The Clear filters
+    ;; affordance in the header + the no-matches empty state both
+    ;; fire this.
+    (rf/reg-event-db :rf.causa/clear-mcp-filters
+      (fn [db _event]
+        (-> db
+            (dissoc :mcp-active-op-types)
+            (dissoc :mcp-since-ms))))
+
+    ;; Toggle the cross-panel origin-filter highlight. Wired from the
+    ;; Settings sub-pane checkbox in the MCP panel.
+    (rf/reg-event-db :rf.causa/toggle-mcp-origin-filter
+      (fn [db _event]
+        (update db :mcp-origin-filter-enabled? not)))
+    ;; ── mcp-server panel end ──
 
     ;; ---- Phase 5 (rf2-rccf3) — AI Co-Pilot panel -----------------------
     ;;

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -45,6 +45,9 @@
             [day8.re-frame2-causa.panels.flows :as flows]
             [day8.re-frame2-causa.panels.hydration-debugger :as hydration-debugger]
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
+            ;; ── mcp-server panel begin ──
+            [day8.re-frame2-causa.panels.mcp-server :as mcp-server]
+            ;; ── mcp-server panel end ──
             [day8.re-frame2-causa.panels.performance :as performance]
             [day8.re-frame2-causa.panels.schema-violation-timeline :as schema-violation-timeline]
             [day8.re-frame2-causa.panels.subscriptions :as subscriptions]
@@ -96,6 +99,13 @@
    ;; marker; once a mismatch fires the entry lights up and the entry
    ;; behaves like every other live panel.
    {:id :hydration    :label "Hydration"     :bead "rf2-pzxsr" :live? true :dormant? true}
+   ;; ── mcp-server panel begin ──
+   ;; rf2-81qjj — DECISION (a): a dedicated MCP entry in the sidebar
+   ;; surfaces 'what is the agent doing' in one place. Placed adjacent
+   ;; to Co-pilot since both are AI / agent surfaces, per spec/007-UX-
+   ;; IA.md §Sidebar groups (third group is the AI surfaces).
+   {:id :mcp-server   :label "MCP"           :bead "rf2-81qjj" :live? true}
+   ;; ── mcp-server panel end ──
    {:id :copilot      :label "Co-pilot"      :bead "rf2-rccf3" :live? true}])
 
 ;; ---- regions -------------------------------------------------------------
@@ -274,6 +284,9 @@
       :issues       [issues-ribbon/issues-ribbon-view]
       :trace        [trace/trace-view]
       :performance  [performance/performance-view]
+      ;; ── mcp-server panel begin ──
+      :mcp-server   [mcp-server/mcp-server-view]
+      ;; ── mcp-server panel end ──
       ;; Sidebar Co-pilot row renders the panel-style view in the
       ;; canvas; the rail still lives in the shell's right margin per
       ;; spec/007-UX-IA.md §The five regions item 4.

--- a/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_helpers_cljs_test.cljc
@@ -1,0 +1,329 @@
+(ns day8.re-frame2-causa.panels.mcp-server-helpers-cljs-test
+  "Pure-data tests for Causa's MCP Server panel helpers (Phase 5,
+  rf2-81qjj, parent rf2-5aw5v).
+
+  ## Why the `.cljc` + `_cljs_test` naming
+
+  Same dual-target pattern as the other Causa panel helper tests:
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  ## What's under test
+
+    1. **origin classification** — `causa-mcp-event?` recognises the
+       `:tags :origin :causa-mcp` tag and rejects everything else.
+    2. **project-row** — projects raw trace events onto row cells;
+       returns nil for non-:causa-mcp events.
+    3. **filter axes** — op-type / since-ms are independent; empty
+       filters disable the axis.
+    4. **project-feed** — top-level composite; empty-kind classifier
+       (`:no-activity` vs `:no-matches` vs nil).
+    5. **agent-attached?** — pull-only proxy reading the buffer.
+    6. **short-description** — priority-ordered field lift."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.mcp-server-helpers :as h]))
+
+;; ---- fixture builders ---------------------------------------------------
+
+(defn- mcp-ev
+  "Build a Spec 009-shaped trace event with `:tags :origin :causa-mcp`."
+  ([id op-type operation]
+   (mcp-ev id op-type operation {}))
+  ([id op-type operation {:keys [time tags]
+                          :or   {time 1000 tags {}}}]
+   {:id        id
+    :op-type   op-type
+    :operation operation
+    :time      time
+    :tags      (assoc tags :origin :causa-mcp)}))
+
+(defn- app-ev
+  "Build an :origin :app event (the default — not from causa-mcp)."
+  [id op-type operation]
+  {:id        id
+   :op-type   op-type
+   :operation operation
+   :time      1000
+   :tags      {:origin :app}})
+
+(defn- pair-ev
+  "Build an :origin :pair event (pair2-mcp, not causa-mcp)."
+  [id]
+  {:id        id
+   :op-type   :event
+   :operation :event/dispatched
+   :time      1000
+   :tags      {:origin :pair}})
+
+(defn- untagged-ev
+  "Build an event with no :origin tag at all."
+  [id]
+  {:id        id
+   :op-type   :event
+   :operation :event/dispatched
+   :time      1000
+   :tags      {}})
+
+;; ---- (1) origin classification -----------------------------------------
+
+(deftest causa-mcp-event-classifier
+  (testing "events tagged :causa-mcp are causa-mcp events"
+    (is (true? (h/causa-mcp-event?
+                 (mcp-ev 1 :event :event/dispatched))))
+    (is (true? (h/causa-mcp-event?
+                 (mcp-ev 2 :error :rf.error/handler-exception)))))
+  (testing "other-origin events are NOT causa-mcp events"
+    (is (false? (h/causa-mcp-event? (app-ev 3 :event :event/dispatched))))
+    (is (false? (h/causa-mcp-event? (pair-ev 4)))))
+  (testing "untagged events are NOT causa-mcp events"
+    (is (false? (h/causa-mcp-event? (untagged-ev 5))))))
+
+(deftest origin-colour-is-locked
+  (testing "v1 inferential pick — cyan #06B6D4 (DECISION (b))"
+    (is (= "#06B6D4" h/causa-mcp-origin-colour))))
+
+(deftest origin-tag-is-canonical
+  (testing "the closed-set keyword matches the spec/010-MCP-Server.md
+            §Origin tagging vocabulary"
+    (is (= :causa-mcp h/causa-mcp-origin-tag))))
+
+;; ---- (2) project-row ---------------------------------------------------
+
+(deftest project-row-shape
+  (let [ev  (mcp-ev 42 :event :event/dispatched
+                    {:time 5000
+                     :tags {:event       [:counter/inc]
+                            :tool        :dispatch
+                            :dispatch-id 99}})
+        row (h/project-row ev)]
+    (testing "every required slot is populated"
+      (is (= 42 (:id row)))
+      (is (= 5000 (:time row)))
+      (is (= :event (:op-type row)))
+      (is (= :event/dispatched (:operation row)))
+      (is (= :causa-mcp (:origin row)))
+      (is (= :dispatch (:tool row)))
+      (is (= 99 (:dispatch-id row))))
+    (testing "the :raw slot carries the source event"
+      (is (= ev (:raw row))))
+    (testing "description carries the operation + a terse summary"
+      (is (re-find #":event/dispatched" (:description row))))))
+
+(deftest project-row-skips-non-mcp-events
+  (is (nil? (h/project-row (app-ev 1 :event :event/dispatched))))
+  (is (nil? (h/project-row (pair-ev 2))))
+  (is (nil? (h/project-row (untagged-ev 3)))))
+
+(deftest project-rows-filters-and-orders
+  (let [stream [(mcp-ev 1 :event :event/dispatched {:time 100})
+                (app-ev 2 :event :event/dispatched)
+                (mcp-ev 3 :fx :fx/handled {:time 200})
+                (untagged-ev 4)
+                (mcp-ev 5 :error :rf.error/handler-exception {:time 300})]
+        rows   (h/project-rows stream)]
+    (is (= 3 (count rows)))
+    (is (= [1 3 5] (mapv :id rows)))
+    (is (every? #(= :causa-mcp %) (mapv :origin rows)))))
+
+;; ---- (3) filter axes ---------------------------------------------------
+
+(deftest op-type-filter-passes-when-empty
+  (let [row {:op-type :event}]
+    (is (true? (h/passes-op-type? #{} row)))
+    (is (true? (h/passes-op-type? nil row)))))
+
+(deftest op-type-filter-restricts-when-set
+  (is (true?  (h/passes-op-type? #{:event} {:op-type :event})))
+  (is (false? (h/passes-op-type? #{:event} {:op-type :fx})))
+  (is (true?  (h/passes-op-type? #{:event :fx} {:op-type :fx}))))
+
+(deftest since-filter-when-disabled-passes-all
+  (let [row {:time 100}]
+    (is (true? (h/passes-since? 1000 nil row)))))
+
+(deftest since-filter-restricts-by-time
+  (is (true?  (h/passes-since? 1000 500 {:time 600})))
+  (is (true?  (h/passes-since? 1000 500 {:time 500})))
+  (is (true?  (h/passes-since? 1000 500 {:time 1000})))
+  (is (false? (h/passes-since? 1000 500 {:time 400})))
+  (is (false? (h/passes-since? 1000 500 {:time 0}))))
+
+(deftest apply-filters-composes-axes
+  (let [now  1000
+        rows [{:id 1 :op-type :event :time 950}
+              {:id 2 :op-type :fx    :time 700}
+              {:id 3 :op-type :error :time 200}
+              {:id 4 :op-type :event :time 100}]]
+    (testing "no filters → everything passes"
+      (is (= [1 2 3 4]
+             (mapv :id (h/apply-filters rows {} now)))))
+    (testing "op-type-only filter restricts"
+      (is (= [1 4]
+             (mapv :id (h/apply-filters rows
+                                        {:op-types #{:event}}
+                                        now)))))
+    (testing "since-ms filter restricts (now-500ms cutoff)"
+      (is (= [1 2]
+             (mapv :id (h/apply-filters rows
+                                        {:since-ms 500}
+                                        now)))))
+    (testing "two axes combine intersectively"
+      (is (= [1]
+             (mapv :id (h/apply-filters
+                         rows
+                         {:op-types #{:event}
+                          :since-ms 500}
+                         now)))))))
+
+;; ---- (4) project-feed (top-level composite) ----------------------------
+
+(deftest project-feed-empty-stream
+  (let [feed (h/project-feed [] {} 1000)]
+    (is (= 0 (:total feed)))
+    (is (= 0 (:rendered feed)))
+    (is (false? (:agent-attached? feed)))
+    (is (= :no-activity (:empty-kind feed)))))
+
+(deftest project-feed-stream-with-only-non-mcp-events
+  (testing "a stream of pure app-origin events is :no-activity from
+            this panel's perspective"
+    (let [stream [(app-ev 1 :event :event/dispatched)
+                  (untagged-ev 2)
+                  (pair-ev 3)]
+          feed   (h/project-feed stream {} 1000)]
+      (is (= 0 (:total feed)))
+      (is (false? (:agent-attached? feed)))
+      (is (= :no-activity (:empty-kind feed))))))
+
+(deftest project-feed-no-matches
+  (let [stream [(mcp-ev 1 :event :event/dispatched {:time 100})]
+        feed   (h/project-feed stream {:op-types #{:fx}} 1000)]
+    (is (= 1 (:total feed)))
+    (is (= 0 (:rendered feed)))
+    (is (true? (:agent-attached? feed)))
+    (is (= :no-matches (:empty-kind feed)))))
+
+(deftest project-feed-newest-first
+  (let [stream [(mcp-ev 1 :event :event/dispatched {:time 100})
+                (mcp-ev 2 :fx    :fx/handled       {:time 200})
+                (mcp-ev 3 :error :rf.error/x       {:time 300})]
+        feed   (h/project-feed stream {} 1000)]
+    (testing ":rows is in newest-first order for display"
+      (is (= [3 2 1] (mapv :id (:rows feed)))))
+    (testing ":empty-kind is nil when there are matches"
+      (is (nil? (:empty-kind feed))))
+    (testing ":agent-attached? reflects presence of any mcp event"
+      (is (true? (:agent-attached? feed))))))
+
+(deftest project-feed-op-type-counts
+  (let [stream [(mcp-ev 1 :event :event/dispatched)
+                (mcp-ev 2 :event :event/dispatched)
+                (mcp-ev 3 :fx    :fx/handled)
+                (mcp-ev 4 :error :rf.error/x)]
+        feed   (h/project-feed stream {} 1000)]
+    (is (= {:event 2 :fx 1 :error 1}
+           (:op-type-counts feed)))))
+
+(deftest project-feed-distinct-op-types
+  (let [stream [(mcp-ev 1 :event :event/dispatched)
+                (mcp-ev 2 :fx    :fx/handled)
+                (mcp-ev 3 :event :event/dispatched)
+                (mcp-ev 4 :error :rf.error/x)]
+        feed   (h/project-feed stream {} 1000)]
+    (testing "distinct-op-types is in first-seen order"
+      (is (= [:event :fx :error] (:distinct-op-types feed))))))
+
+(deftest project-feed-ignores-non-mcp-events-completely
+  (testing "the feed's total + rendered count only mcp events; app /
+            pair / untagged events are invisible to this panel"
+    (let [stream [(mcp-ev 1 :event :event/dispatched)
+                  (app-ev 2 :event :event/dispatched)
+                  (mcp-ev 3 :fx    :fx/handled)
+                  (pair-ev 4)
+                  (mcp-ev 5 :error :rf.error/x)
+                  (untagged-ev 6)]
+          feed   (h/project-feed stream {} 1000)]
+      (is (= 3 (:total feed)))
+      (is (= 3 (:rendered feed)))
+      (is (= [5 3 1] (mapv :id (:rows feed)))))))
+
+;; ---- (5) agent-attached? ------------------------------------------------
+
+(deftest agent-attached-true-when-any-mcp-event-present
+  (is (true? (h/agent-attached?
+               [(app-ev 1 :event :event/dispatched)
+                (mcp-ev 2 :event :event/dispatched)]))))
+
+(deftest agent-attached-false-when-no-mcp-events
+  (is (false? (h/agent-attached?
+                [(app-ev 1 :event :event/dispatched)
+                 (pair-ev 2)
+                 (untagged-ev 3)])))
+  (is (false? (h/agent-attached? []))))
+
+;; ---- (6) short-description --------------------------------------------
+
+(deftest short-description-priority
+  (testing "event vector is preferred"
+    (is (re-find #"counter/inc"
+                 (h/short-description
+                   (mcp-ev 1 :event :event/dispatched
+                           {:tags {:event [:counter/inc]
+                                   :tool :dispatch}})))))
+  (testing "tool is used when no event"
+    (is (re-find #":dispatch"
+                 (h/short-description
+                   (mcp-ev 1 :event :event/dispatched
+                           {:tags {:tool :dispatch}})))))
+  (testing "reason fills in when nothing higher-priority"
+    (is (re-find #"thing happened"
+                 (h/short-description
+                   (mcp-ev 1 :error :rf.error/handler-exception
+                           {:tags {:reason "thing happened"}})))))
+  (testing "fallback is the operation keyword alone"
+    (is (= ":event/dispatched"
+           (h/short-description
+             (mcp-ev 1 :event :event/dispatched {:tags {}}))))))
+
+;; ---- (7) find-row ------------------------------------------------------
+
+(deftest find-row-by-id
+  (let [rows [{:id 1 :op-type :event}
+              {:id 2 :op-type :fx}
+              {:id 3 :op-type :error}]]
+    (is (= {:id 2 :op-type :fx} (h/find-row rows 2)))
+    (is (nil? (h/find-row rows 99)))))
+
+;; ---- (8) format-time --------------------------------------------------
+
+(deftest format-time-renders-hms-with-millis
+  (testing "format-time returns nil on non-numeric input"
+    (is (nil? (h/format-time nil)))
+    (is (nil? (h/format-time "not a number"))))
+  (testing "format-time returns a HH:MM:SS.mmm-shaped string on numeric input"
+    (let [s (h/format-time 12345)]
+      (is (string? s))
+      (is (re-find #"^\d{2}:\d{2}:\d{2}\.\d{3}$" s)))))
+
+;; ---- (9) source-coord -------------------------------------------------
+
+(deftest source-coord-projection
+  (testing "source-coord pulls file:line from :rf.trace/trigger-handler"
+    (is (= "src/foo.cljs:42"
+           (h/source-coord
+             {:id 1 :op-type :event :operation :event/dispatched
+              :tags {:origin :causa-mcp}
+              :rf.trace/trigger-handler {:source-coord {:file "src/foo.cljs"
+                                                        :line 42}}}))))
+  (testing "missing trigger-handler returns nil"
+    (is (nil? (h/source-coord (mcp-ev 1 :event :event/dispatched)))))
+  (testing "missing :line returns just the file"
+    (is (= "src/foo.cljs"
+           (h/source-coord
+             {:id 1 :op-type :event :operation :event/dispatched
+              :tags {:origin :causa-mcp}
+              :rf.trace/trigger-handler {:source-coord {:file "src/foo.cljs"}}})))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_view_cljs_test.cljs
@@ -1,0 +1,340 @@
+(ns day8.re-frame2-causa.panels.mcp-server-view-cljs-test
+  "CLJS-side wiring + view tests for Causa's MCP Server panel
+  (Phase 5, rf2-81qjj, parent rf2-5aw5v).
+
+  ## What's under test (in addition to the pure-data tests in
+  `mcp_server_helpers_cljs_test.cljc`)
+
+    1. **Registry wires the composite sub + supporting events** under
+       `:rf.causa/mcp-*`. The composite returns rows + counts +
+       attached-state in the shape the view consumes.
+
+    2. **Filter chip toggles** mutate `:mcp-active-op-types` on the
+       Causa frame's db; the panel renders the toggled state.
+
+    3. **Settings sub-pane** — origin colour swatch + origin-filter
+       toggle render; clicking the toggle flips the
+       `:rf.causa/mcp-origin-filter-enabled?` sub.
+
+    4. **Empty states** — `:no-activity` when the buffer carries no
+       :origin :causa-mcp events; `:no-matches` when filters hide
+       all matches.
+
+    5. **Row pivot** — clicking a row with a `:dispatch-id` fires
+       `:rf.causa/select-dispatch-id` + `:rf.causa/select-panel`.
+
+  ## Pure hiccup
+
+  Same approach as `subscriptions_view_cljs_test.cljs` /
+  `causality_graph_view_cljs_test.cljs` — walk the view's hiccup tree
+  by `data-testid` rather than mounting to the DOM. Keeps the suite
+  fast + host-portable on node-test."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.mcp-server :as mcp-server]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walkers (mirror subscriptions_view_cljs_test) ---------------
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (apply (first node) (rest node))
+    node))
+
+(defn- hiccup-seq [tree]
+  (->> (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree))
+       (map expand-fn-component)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (hiccup-seq tree)))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; Inject events directly into the Causa-side ring buffer. Mirrors
+;; the pattern other view tests use (trace-bus is the source the
+;; composite sub reads through `:rf.causa/trace-buffer`).
+(defn- push-event! [ev]
+  (trace-bus/collect-trace! ev))
+
+(defn- mcp-event
+  "Build a :origin :causa-mcp trace event in the shape the buffer
+  carries."
+  ([id op-type operation]
+   (mcp-event id op-type operation {}))
+  ([id op-type operation {:keys [time tags]
+                          :or {time 1000 tags {}}}]
+   {:id        id
+    :op-type   op-type
+    :operation operation
+    :time      time
+    :tags      (assoc tags :origin :causa-mcp)}))
+
+(defn- app-event
+  [id]
+  {:id        id
+   :op-type   :event
+   :operation :event/dispatched
+   :time      1000
+   :tags      {:origin :app}})
+
+;; ---- (1) registry wires the composite sub + events ----------------------
+
+(deftest registry-installs-mcp-surface
+  (testing "register-causa-handlers! installs the Phase 5 MCP composite
+            sub + every supporting event"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/mcp-server)))
+    (is (some? (registrar/handler :sub :rf.causa/mcp-filters)))
+    (is (some? (registrar/handler :sub :rf.causa/mcp-origin-filter-enabled?)))
+    (is (some? (registrar/handler :event :rf.causa/toggle-mcp-op-type)))
+    (is (some? (registrar/handler :event :rf.causa/set-mcp-since-seconds)))
+    (is (some? (registrar/handler :event :rf.causa/clear-mcp-filters)))
+    (is (some? (registrar/handler :event :rf.causa/toggle-mcp-origin-filter)))))
+
+(deftest mcp-server-sub-defaults-empty
+  (testing "with no events in the buffer the composite returns an empty
+            rows vector + agent-attached? false + :no-activity empty-kind"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [data @(rf/subscribe [:rf.causa/mcp-server])]
+        (is (= [] (:rows data)))
+        (is (= 0 (:total data)))
+        (is (false? (:agent-attached? data)))
+        (is (= :no-activity (:empty-kind data)))))))
+
+(deftest mcp-server-sub-projects-events
+  (testing "with causa-mcp events in the buffer the composite returns
+            one row per event"
+    (setup-causa-frame!)
+    (push-event! (mcp-event 1 :event :event/dispatched
+                            {:tags {:tool :dispatch}}))
+    (push-event! (mcp-event 2 :fx :fx/handled
+                            {:tags {:tool :restore-epoch}}))
+    (rf/with-frame :rf/causa
+      (let [data @(rf/subscribe [:rf.causa/mcp-server])]
+        (is (= 2 (:total data)))
+        (is (= 2 (:rendered data)))
+        (is (true? (:agent-attached? data)))))))
+
+(deftest mcp-server-sub-ignores-non-mcp-events
+  (testing "events with :origin :app or no :origin tag don't appear"
+    (setup-causa-frame!)
+    (push-event! (app-event 1))
+    (push-event! (mcp-event 2 :event :event/dispatched))
+    (push-event! (app-event 3))
+    (rf/with-frame :rf/causa
+      (let [data @(rf/subscribe [:rf.causa/mcp-server])]
+        (is (= 1 (:total data)))
+        (is (= [2] (mapv :id (:rows data))))))))
+
+;; ---- (2) filter chip toggle --------------------------------------------
+
+(deftest toggle-op-type-writes-to-causa-frame
+  (testing "dispatching :rf.causa/toggle-mcp-op-type toggles set
+            membership on the Causa frame"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/toggle-mcp-op-type :event])
+      (is (= #{:event}
+             (:op-types @(rf/subscribe [:rf.causa/mcp-filters]))))
+      (rf/dispatch-sync [:rf.causa/toggle-mcp-op-type :fx])
+      (is (= #{:event :fx}
+             (:op-types @(rf/subscribe [:rf.causa/mcp-filters]))))
+      (rf/dispatch-sync [:rf.causa/toggle-mcp-op-type :event])
+      (is (= #{:fx}
+             (:op-types @(rf/subscribe [:rf.causa/mcp-filters])))))))
+
+(deftest clear-filters-drops-every-axis
+  (testing ":rf.causa/clear-mcp-filters drops every axis at once"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/toggle-mcp-op-type :event])
+      (rf/dispatch-sync [:rf.causa/set-mcp-since-seconds 30])
+      (rf/dispatch-sync [:rf.causa/clear-mcp-filters])
+      (let [filters @(rf/subscribe [:rf.causa/mcp-filters])]
+        (is (= #{} (:op-types filters)))
+        (is (nil? (:since-ms filters)))))))
+
+(deftest set-since-seconds-converts-to-ms
+  (testing "the set-since-seconds event converts s → ms"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-mcp-since-seconds 30])
+      (is (= 30000
+             (:since-ms @(rf/subscribe [:rf.causa/mcp-filters])))))))
+
+(deftest set-since-seconds-nil-clears-axis
+  (testing "passing nil / non-positive clears the since-ms axis"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-mcp-since-seconds 30])
+      (rf/dispatch-sync [:rf.causa/set-mcp-since-seconds nil])
+      (is (nil? (:since-ms @(rf/subscribe [:rf.causa/mcp-filters]))))
+      (rf/dispatch-sync [:rf.causa/set-mcp-since-seconds 30])
+      (rf/dispatch-sync [:rf.causa/set-mcp-since-seconds 0])
+      (is (nil? (:since-ms @(rf/subscribe [:rf.causa/mcp-filters])))))))
+
+;; ---- (3) settings sub-pane ---------------------------------------------
+
+(deftest origin-filter-toggle-flips-the-sub
+  (testing "the origin-filter toggle event flips the boolean sub"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (is (false? @(rf/subscribe [:rf.causa/mcp-origin-filter-enabled?])))
+      (rf/dispatch-sync [:rf.causa/toggle-mcp-origin-filter])
+      (is (true?  @(rf/subscribe [:rf.causa/mcp-origin-filter-enabled?])))
+      (rf/dispatch-sync [:rf.causa/toggle-mcp-origin-filter])
+      (is (false? @(rf/subscribe [:rf.causa/mcp-origin-filter-enabled?]))))))
+
+;; ---- (4) view renders --------------------------------------------------
+
+(deftest empty-state-renders-when-buffer-has-no-mcp-events
+  (testing "with no mcp events the panel renders the :no-activity
+            empty state"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [tree (mcp-server/mcp-server-view)]
+        (is (some? (find-by-testid tree "rf-causa-mcp-server"))
+            "panel container present")
+        (is (some? (find-by-testid tree "rf-causa-mcp-empty-no-activity"))
+            ":no-activity empty-state present")
+        (is (nil? (find-by-testid tree "rf-causa-mcp-feed"))
+            "no feed when there are zero rows")))))
+
+(deftest feed-renders-when-buffer-has-mcp-events
+  (testing "with mcp events the panel renders one row per event +
+            settings + filter chips"
+    (setup-causa-frame!)
+    (push-event! (mcp-event 1 :event :event/dispatched
+                            {:tags {:tool :dispatch}}))
+    (push-event! (mcp-event 2 :fx :fx/handled
+                            {:tags {:tool :restore-epoch}}))
+    (rf/with-frame :rf/causa
+      (let [tree (mcp-server/mcp-server-view)]
+        (is (some? (find-by-testid tree "rf-causa-mcp-feed"))
+            "feed container present")
+        (is (some? (find-by-testid tree "rf-causa-mcp-row-1"))
+            "row for id=1 present")
+        (is (some? (find-by-testid tree "rf-causa-mcp-row-2"))
+            "row for id=2 present")
+        (is (some? (find-by-testid tree "rf-causa-mcp-settings"))
+            "Settings sub-pane present")
+        (is (some? (find-by-testid tree "rf-causa-mcp-origin-swatch"))
+            "Origin colour swatch present")
+        (is (some? (find-by-testid tree "rf-causa-mcp-origin-filter-toggle"))
+            "Origin-filter toggle present")
+        (is (some? (find-by-testid tree "rf-causa-mcp-op-type-chips"))
+            "op-type chip row present")))))
+
+(deftest no-matches-empty-state-renders-when-filter-hides-all
+  (testing "with mcp events present but an active filter that hides
+            them all, the panel renders the :no-matches empty state"
+    (setup-causa-frame!)
+    (push-event! (mcp-event 1 :event :event/dispatched))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/toggle-mcp-op-type :fx])
+      (let [tree (mcp-server/mcp-server-view)]
+        (is (some? (find-by-testid tree "rf-causa-mcp-empty-no-matches"))
+            ":no-matches empty state present")
+        (is (nil? (find-by-testid tree "rf-causa-mcp-feed"))
+            "no feed when filter hides every row")))))
+
+(deftest attached-badge-says-no-activity-when-buffer-empty
+  (testing "with an empty buffer the badge in the header shows
+            'no activity'"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [tree  (mcp-server/mcp-server-view)
+            badge (find-by-testid tree "rf-causa-mcp-attached-badge")
+            txt   (pr-str badge)]
+        (is (re-find #"no activity" txt))
+        (is (not (re-find #"agent attached" txt)))))))
+
+(deftest attached-badge-says-attached-when-mcp-event-in-buffer
+  (testing "with at least one :origin :causa-mcp event in the buffer
+            the badge shows 'agent attached'"
+    (setup-causa-frame!)
+    (push-event! (mcp-event 1 :event :event/dispatched))
+    (rf/with-frame :rf/causa
+      (let [tree  (mcp-server/mcp-server-view)
+            badge (find-by-testid tree "rf-causa-mcp-attached-badge")
+            txt   (pr-str badge)]
+        (is (re-find #"agent attached" txt))))))
+
+;; ---- (5) row pivot ----------------------------------------------------
+
+(deftest row-click-pivots-to-event-detail
+  (testing "clicking a row with a dispatch-id dispatches both
+            :rf.causa/select-dispatch-id and :rf.causa/select-panel"
+    (setup-causa-frame!)
+    (push-event! (mcp-event 1 :event :event/dispatched
+                            {:tags {:dispatch-id 42}}))
+    (let [dispatches (atom [])]
+      ;; `rf/dispatch` is a macro that expands to `rf/dispatch*`; the
+      ;; redef target is the underlying fn.
+      (with-redefs [rf/dispatch* (fn
+                                   ([ev] (swap! dispatches conj ev) nil)
+                                   ([ev _opts] (swap! dispatches conj ev) nil))]
+        (rf/with-frame :rf/causa
+          (let [tree    (mcp-server/mcp-server-view)
+                row     (find-by-testid tree "rf-causa-mcp-row-1")
+                on-click (:on-click (second row))]
+            (is (some? row) "row is present in the rendered tree")
+            (is (fn? on-click) "row has an on-click handler")
+            (on-click))))
+      (let [evs @dispatches]
+        (is (some #(= [:rf.causa/select-dispatch-id 42] %) evs)
+            "select-dispatch-id fired with the cascade id")
+        (is (some #(= [:rf.causa/select-panel :event-detail] %) evs)
+            "select-panel fired with :event-detail")))))
+
+(deftest row-without-dispatch-id-does-not-pivot
+  (testing "a row whose event carries no :dispatch-id is non-clickable
+            (cursor: default; on-click is a no-op)"
+    (setup-causa-frame!)
+    ;; No :dispatch-id in tags.
+    (push-event! (mcp-event 1 :event :event/dispatched))
+    (let [dispatches (atom [])]
+      (with-redefs [rf/dispatch* (fn
+                                   ([ev] (swap! dispatches conj ev) nil)
+                                   ([ev _opts] (swap! dispatches conj ev) nil))]
+        (rf/with-frame :rf/causa
+          (let [tree    (mcp-server/mcp-server-view)
+                row     (find-by-testid tree "rf-causa-mcp-row-1")
+                on-click (:on-click (second row))]
+            (on-click))))
+      (is (empty? @dispatches)
+          "no dispatch fires when :dispatch-id is absent"))))


### PR DESCRIPTION
## Summary

- Phase 5 of `rf2-5aw5v` (Causa v1.0 epic). Adds the Causa panel-side
  surface for the `tools/causa-mcp/` agent server: a dedicated `:mcp-server`
  sidebar panel that surfaces a read-only feed of trace events tagged
  `:tags :origin :causa-mcp` — the canonical tag the causa-mcp jar stamps
  on every side-effect it performs (per
  `tools/causa/spec/010-MCP-Server.md` §Origin tagging +
  `tools/causa-mcp/spec/Principles.md` §Origin tagging is the convention).

- Surface: row-pivot to event-detail on click; inline Settings sub-pane
  with origin-colour swatch + cross-panel origin-filter toggle; op-type
  chip filters + since-ms axis; agent-attached / no-activity badge.

- Parent epic: `rf2-5aw5v`. Sibling to recently-merged
  `rf2-83irn` (Flows panel) and `rf2-75121` (Performance panel).

## Inferential decisions — SPEC-DEFICIENT BEAD

The bead is **the most spec-undefined of the Phase 5+ panels**. The
filing agent flagged three open questions. Each call is documented
inline as a `;; DECISION` comment in `mcp_server_helpers.cljc` +
`mcp_server.cljs` + `shell.cljs` so a follow-on bead can refine
without spelunking history.

### (a) Sidebar panel y/n → **yes** (dedicated `:mcp-server` panel)

Rationale: parallels every other Phase 5 panel (Issues, Trace,
Performance, Flows, …) and gives users a single entry point for
"what is the agent doing". Settings-only would force users to hunt
across the Trace panel with the `:origin` filter manually set every
session. Placed adjacent to Co-pilot since both are agent / AI
surfaces.

### (b) Origin colour for `:causa-mcp` → **cyan `#06B6D4`** (Tailwind cyan-500)

Rationale: `spec/007-UX-IA.md` §Colour system locks `:pair` to indigo
`#5570FF`; `:story` / `:test` already share light cyan `#43C3D0`.
`:causa-mcp` needs a distinct hue — a deeper / more saturated cyan
`#06B6D4` (Tailwind cyan-500) gives clear visual distinction from
both the `:pair` indigo and the lighter `:story` cyan without
re-using indigo.

Follow-on bead candidate: promote into `spec/007-UX-IA.md` §Colour
system + the shared shell token map so every panel that renders an
`:origin` swatch reads the same source of truth.

### (c) Bidirectional Causa→agent surface → **out of scope for v1**

Rationale: the causa-mcp jar is the agent→host direction; anything
the panel would "expose back" (e.g. session attention hints) is a
causa-mcp implementation concern, not a Causa panel concern. If Mike
wants this, it lands as a follow-on against `tools/causa-mcp/`, not
this panel.

## What lands

**New files**:
- `tools/causa/src/day8/re_frame2_causa/panels/mcp_server.cljs`
- `tools/causa/src/day8/re_frame2_causa/panels/mcp_server_helpers.cljc`
- `tools/causa/test/day8/re_frame2_causa/panels/mcp_server_helpers_cljs_test.cljc`
- `tools/causa/test/day8/re_frame2_causa/panels/mcp_server_view_cljs_test.cljs`

**Modified (wrapped in `;; ── mcp-server panel begin / end ──` markers
for safe parallel dispatch — per CLAUDE.md hot-zone discipline)**:
- `tools/causa/src/day8/re_frame2_causa/registry.cljs` — composite sub
  + four events under `:rf.causa/mcp-*`.
- `tools/causa/src/day8/re_frame2_causa/shell.cljs` — sidebar entry
  "MCP" + canvas case-dispatch.

## Subs / events

```
:rf.causa/mcp-server                   sub  — composite
:rf.causa/mcp-filters                  sub  — op-types + since-ms
:rf.causa/mcp-origin-filter-enabled?   sub  — cross-panel toggle
:rf.causa/toggle-mcp-op-type           event-db
:rf.causa/set-mcp-since-seconds        event-db
:rf.causa/clear-mcp-filters            event-db
:rf.causa/toggle-mcp-origin-filter     event-db
```

## Detection model

**Pull-only**: if any `:origin :causa-mcp` event has landed in the
buffer the agent IS attached. No separate session-id sentinel probe
— trace-bus is the truth, matching every other Causa panel's
posture. Simpler than a separate detector loop; needs no new
framework surface.

## Follow-on bead candidates

- Promote `:causa-mcp` cyan into `spec/007-UX-IA.md` §Colour system +
  shared shell token map.
- Cross-panel honour-the-toggle wiring (Trace / Event-detail /
  Causality dim non-agent events when
  `:rf.causa/mcp-origin-filter-enabled?` is true).
- (If Mike wants it) Causa→agent surface — e.g. session attention
  hints, scrubber-anchor hints — likely a `tools/causa-mcp/` work,
  not a Causa panel.

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 359 tests / 1033 assertions / 0 failures
- [x] `npm run test:cljs` — 1303 tests / 3456 assertions / 0 failures
- [x] `npm run test:elision` — PASS
- [x] `npm run test:bundle-isolation` — PASS
- [ ] Manual: open Causa in a host running `tools/causa-mcp/`; verify
  the MCP panel populates as agent ops fire.

Refs `rf2-81qjj` · parent epic `rf2-5aw5v` (Causa v1.0).