### PR TITLE
refactor(examples): consume rf/route-link instead of custom reimplementations (rf2-izohg)

### DIFF
--- a/examples/reagent/realworld/README.md
+++ b/examples/reagent/realworld/README.md
@@ -47,7 +47,7 @@ The normative contract lives in [`spec/014-HTTPRequests.md`](../../../spec/014-H
 | `core.cljs` | implemented | Entry point, app shell, route switch, mount; installs the demo `:rf.http/managed` stub. |
 | `schema.cljs` | implemented | Wire shapes (User/Profile/Article/...) and their per-endpoint response wrappers used as `:decode` schemas. |
 | `http.cljs` | implemented | `request` builder + `data-fetch-retry` policy + `failure->message` projector for `:rf.http/managed`. |
-| `routing.cljs` | implemented | Route table, auth guard, route-link helper, browser wiring. |
+| `routing.cljs` | implemented | Route table, auth guard, browser wiring. Anchors render via `rf/route-link` (framework-shipped, registered at `:route/link`). |
 | `auth.cljs` | implemented | Auth machine plus login/register forms (managed-HTTP). |
 | `articles.cljs` | implemented | Home page, global feed, tag filter UI; managed-HTTP with retry + abort. Home page uses Pattern-NineStates — a `:realworld/articles-home` parallel machine with three regions (`:feed` × `:filter` × `:data`) + a render-priority table; the root view is a `case` over `:articles.home/render`. Popular-tags loading moved to `tags.cljs`. |
 | `favorites.cljs` | implemented | Favorite toggle and followed-authors feed; optimistic updates with managed-HTTP rollback. |

--- a/examples/reagent/realworld/articles.cljs
+++ b/examples/reagent/realworld/articles.cljs
@@ -24,8 +24,7 @@
             ;; resolve.
             [re-frame.machines]
             [realworld.schema :as schema]
-            [realworld.http :as rh]
-            [realworld.routing :as routing])
+            [realworld.http :as rh])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 (defn request-slice [data]
@@ -341,11 +340,11 @@
   (let [{:keys [slug title description createdAt favoritesCount author tagList]} article]
     [:div.article-preview
      [:div.article-meta
-      [routing/route-link {:to     :route/profile
+      [rf/route-link {:to     :route/profile
                            :params {:username (:username author)}}
        [:img {:src (:image author)}]]
       [:div.info
-       [routing/route-link {:to     :route/profile
+       [rf/route-link {:to     :route/profile
                             :params {:username (:username author)}
                             :class  "author"}
         (:username author)]
@@ -354,7 +353,7 @@
        {:type "button"
         :on-click #(dispatch [:article/toggle-favorite slug])}
        [:i.ion-heart] " " favoritesCount]]
-     [routing/route-link {:to          :route/article
+     [rf/route-link {:to          :route/article
                           :params      {:slug slug}
                           :class       "preview-link"
                           :data-testid (str "article-preview-link-" slug)}

--- a/examples/reagent/realworld/auth.cljs
+++ b/examples/reagent/realworld/auth.cljs
@@ -18,8 +18,7 @@
             ;; sub resolve.
             [re-frame.machines]
             [realworld.schema :as schema]
-            [realworld.http :as rh]
-            [realworld.routing :as routing])
+            [realworld.http :as rh])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
@@ -315,7 +314,7 @@
         err         @(subscribe [:auth/error])]
     [:div.auth-page {:data-testid "login-page"}
      [:h1 "Sign in"]
-     [routing/route-link {:to :route/register} "Need an account?"]
+     [rf/route-link {:to :route/register} "Need an account?"]
      (when err [:ul.error-messages [:li err]])
      [:form
       {:data-testid "login-form"
@@ -349,7 +348,7 @@
         err         @(subscribe [:auth/error])]
     [:div.auth-page
      [:h1 "Sign up"]
-     [routing/route-link {:to :route/login} "Have an account?"]
+     [rf/route-link {:to :route/login} "Have an account?"]
      (when err [:ul.error-messages [:li err]])
      [:form
       {:on-submit (fn [e]

--- a/examples/reagent/realworld/comments.cljs
+++ b/examples/reagent/realworld/comments.cljs
@@ -9,8 +9,7 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [realworld.schema :as schema]
-            [realworld.http :as rh]
-            [realworld.routing :as routing])
+            [realworld.http :as rh])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 (defn comment-form-defaults []
@@ -296,7 +295,7 @@
     [:div.card {:data-testid (str "comment-card-" (:id comment))}
      [:div.card-block [:p.card-text {:data-testid "comment-body"} (:body comment)]]
      [:div.card-footer
-      [routing/route-link {:to     :route/profile
+      [rf/route-link {:to     :route/profile
                            :params {:username (get-in comment [:author :username])}
                            :class  "comment-author"}
        [:img.comment-author-img {:src (get-in comment [:author :image])}]
@@ -354,7 +353,7 @@
               [:li.tag-default.tag-pill.tag-outline tag])]]]
          [:hr]
          [:div.article-actions
-          [routing/route-link {:to :route/home} "Back to feed"]]
+          [rf/route-link {:to :route/home} "Back to feed"]]
          [:div.row
           [:div.col-xs-12.col-md-8.offset-md-2
            (if current-user
@@ -383,9 +382,9 @@
               (when submit-error
                 [:div.error-messages submit-error])]
              [:p
-              [routing/route-link {:to :route/login} "Sign in"]
+              [rf/route-link {:to :route/login} "Sign in"]
               " or "
-              [routing/route-link {:to :route/register} "sign up"]
+              [rf/route-link {:to :route/register} "sign up"]
               " to add comments."])
            (when comments-error
              [:div.article-preview.error

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -95,20 +95,20 @@
         user    @(subscribe [:auth/user])]
     [:nav.navbar.navbar-light
      [:div.container
-      [routing/route-link {:to :route/home :class "navbar-brand"} "conduit"]
+      [rf/route-link {:to :route/home :class "navbar-brand"} "conduit"]
       [:ul.nav.navbar-nav.pull-xs-right
        [:li.nav-item
-        [routing/route-link {:to :route/home :class "nav-link"} "Home"]]
+        [rf/route-link {:to :route/home :class "nav-link"} "Home"]]
        (if authed?
          [:<>
           [:li.nav-item
-           [routing/route-link {:to :route/editor :class "nav-link"}
+           [rf/route-link {:to :route/editor :class "nav-link"}
             [:i.ion-compose] " New Article"]]
           [:li.nav-item
-           [routing/route-link {:to :route/settings :class "nav-link"}
+           [rf/route-link {:to :route/settings :class "nav-link"}
             [:i.ion-gear-a] " Settings"]]
           [:li.nav-item
-           [routing/route-link {:to :route/profile
+           [rf/route-link {:to :route/profile
                                 :params {:username (:username user)}
                                 :class "nav-link"
                                 :data-testid "nav-username"}
@@ -121,12 +121,12 @@
             "Logout"]]]
          [:<>
           [:li.nav-item
-           [routing/route-link {:to :route/login
+           [rf/route-link {:to :route/login
                                 :class "nav-link"
                                 :data-testid "nav-signin"}
             "Sign in"]]
           [:li.nav-item
-           [routing/route-link {:to :route/register
+           [rf/route-link {:to :route/register
                                 :class "nav-link"
                                 :data-testid "nav-signup"}
             "Sign up"]]])]]]))
@@ -134,7 +134,7 @@
 (reg-view footer []
   [:footer
    [:div.container
-    [routing/route-link {:to :route/home :class "logo-font"} "conduit"]
+    [rf/route-link {:to :route/home :class "logo-font"} "conduit"]
     [:span.attribution "An interactive learning project from Thinkster."
      " Code & design licensed under MIT."]]])
 
@@ -155,7 +155,7 @@
     [:div.not-found-page
      [:h1 "Page not found"]
      (when url [:p (str "No route matches: " url)])
-     [routing/route-link {:to :route/home} "Home"]]))
+     [rf/route-link {:to :route/home} "Home"]]))
 
 (reg-view ^{:doc "App-level root. Switches on :rf.route/id to render the active page."}
           root-view []

--- a/examples/reagent/realworld/profile.cljs
+++ b/examples/reagent/realworld/profile.cljs
@@ -33,7 +33,6 @@
             [re-frame.machines]
             [realworld.schema :as schema]
             [realworld.http :as rh]
-            [realworld.routing :as routing]
             [realworld.articles :as articles])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
@@ -406,7 +405,7 @@
          [:h4 (:username profile)]
          [:p (:bio profile)]
          (if own?
-           [routing/route-link {:to :route/settings
+           [rf/route-link {:to :route/settings
                                 :class "btn btn-sm btn-outline-secondary action-btn"}
             [:i.ion-gear-a] " Edit Profile Settings"]
            [:button.btn.btn-sm.btn-outline-secondary.action-btn
@@ -422,12 +421,12 @@
         [:div.articles-toggle
          [:ul.nav.nav-pills.outline-active
           [:li.nav-item
-           [routing/route-link {:to     :route/profile
+           [rf/route-link {:to     :route/profile
                                 :params {:username (:username profile)}
                                 :class  (str "nav-link" (when-not on-favs? " active"))}
             "My Articles"]]
           [:li.nav-item
-           [routing/route-link {:to     :route/profile.favorites
+           [rf/route-link {:to     :route/profile.favorites
                                 :params {:username (:username profile)}
                                 :class  (str "nav-link" (when on-favs? " active"))}
             "Favorited Articles"]]]]

--- a/examples/reagent/realworld/routing.cljs
+++ b/examples/reagent/realworld/routing.cljs
@@ -1,11 +1,14 @@
 (ns realworld.routing
   "Routes for the RealWorld (Conduit) example.
 
-   This file owns the route table, an app-specific auth guard, and a local
-   route-link helper view. It uses the current runtime routing surface
-   directly:
+   This file owns the route table and an app-specific auth guard. The
+   anchor view is the framework-shipped `rf/route-link` (registered at
+   `:route/link`); call sites pass `:class` / `:data-testid` through to
+   the underlying `<a>`. The example uses the current runtime routing
+   surface directly:
 
    - `reg-route`
+   - `rf/route-link` (registered view at `:route/link`)
    - `:rf.route/navigate`
    - `:rf.route/handle-url-change`
    - `:rf.route/continue` / `:rf.route/cancel`
@@ -17,8 +20,7 @@
             ;; Requiring re-frame.routing here triggers its load-time
             ;; hook + reg-sub registrations; without it, the rf/reg-route
             ;; calls below throw :rf.error/routing-artefact-missing.
-            [re-frame.routing])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [re-frame.routing]))
 
 ;; ============================================================================
 ;; ROUTES
@@ -111,37 +113,6 @@
 
 (rf/reg-sub :rf/pending-navigation
   (fn [db _] (:rf/pending-navigation db)))
-
-;; ============================================================================
-;; LINK VIEW
-;; ============================================================================
-
-(reg-view ^{:doc "Anchor helper for the RealWorld example. Uses the runtime's
-                   `:rf/url-requested` event so modifier-key and browser-navigation
-                   semantics stay on the framework path.
-
-                   `:data-testid` (optional) is propagated to the underlying
-                   anchor so Playwright specs can target individual nav
-                   links and article-preview cards by stable id."}
-          route-link [{:keys [to params query fragment class data-testid]} & children]
-  (let [base-url (rf/route-url to (or params {}) (or query {}))
-        url      (str base-url (when fragment (str "#" fragment)))]
-    [:a (cond-> {:href     url
-                 :class    class
-                 :on-click (fn [e]
-                             (when (and (zero? (.-button e))
-                                        (not (.-metaKey e))
-                                        (not (.-ctrlKey e))
-                                        (not (.-shiftKey e)))
-                               (.preventDefault e)
-                               (dispatch [:rf/url-requested
-                                          {:url url
-                                           :to to
-                                           :params params
-                                           :query query
-                                           :fragment fragment}])))}
-          data-testid (assoc :data-testid data-testid))
-     (into [:<>] children)]))
 
 ;; ============================================================================
 ;; ROUTER WIRING

--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -62,34 +62,23 @@
     (first (filter #(= id (:id %)) articles))))
 
 ;; ============================================================================
-;; LINK VIEW
-;; ============================================================================
-
-(reg-view route-link [{:keys [to params data-testid]} & children]
-  (let [url (rf/route-url to (or params {}))]
-    [:a (cond-> {:href     url
-                 :on-click (fn [e]
-                             (when (and (zero? (.-button e))
-                                        (not (.-metaKey e))
-                                        (not (.-ctrlKey e))
-                                        (not (.-shiftKey e)))
-                               (.preventDefault e)
-                               (dispatch [:rf/url-requested
-                                          {:url url :to to :params (or params {})}])))}
-          ;; Optional :data-testid hook so Playwright specs can anchor
-          ;; on stable testids rather than visible text (rf2-0gdsb).
-          data-testid (assoc :data-testid data-testid))
-     (into [:span] children)]))
-
-;; ============================================================================
 ;; PAGES
 ;; ============================================================================
+;;
+;; Links use `rf/route-link` — the registered view at `:route/link` shipped
+;; by `day8/re-frame2-routing`. Per Spec 012 §Linking from views and the
+;; API.md `route-link` row, the framework view renders an `<a href=...>`,
+;; intercepts plain primary-button clicks to dispatch `:rf/url-requested`,
+;; and defers modifier-key / auxiliary-button (middle-click) clicks to the
+;; browser so the native open-in-new-tab affordance is preserved. Any
+;; passthrough HTML attrs on the props map (e.g. `:data-testid` used by
+;; the Playwright spec, rf2-0gdsb) land on the underlying `<a>`.
 
 (reg-view home-page []
   [:div
    [:h1 "Welcome"]
-   [:p [route-link {:to :route/articles
-                    :data-testid "route-link-articles"}
+   [:p [rf/route-link {:to :route/articles
+                       :data-testid "route-link-articles"}
         "See the articles →"]]])
 
 (reg-view articles-page []
@@ -98,9 +87,9 @@
    [:ul
     (for [{:keys [id title]} @(subscribe [:articles])]
       ^{:key id}
-      [:li [route-link {:to :route/article-detail
-                        :params {:id id}
-                        :data-testid (str "route-link-article-" id)}
+      [:li [rf/route-link {:to :route/article-detail
+                           :params {:id id}
+                           :data-testid (str "route-link-article-" id)}
             title]])]])
 
 (reg-view article-detail-page []
@@ -110,13 +99,13 @@
       [:div
        [:h1 (:title article)]
        [:p (:body article)]
-       [:p [route-link {:to :route/articles
-                        :data-testid "route-link-back-to-articles"}
+       [:p [rf/route-link {:to :route/articles
+                           :data-testid "route-link-back-to-articles"}
             "← Back"]]]
       [:div
        [:p "Article not found."]
-       [:p [route-link {:to :route/articles
-                        :data-testid "route-link-back-to-articles"}
+       [:p [rf/route-link {:to :route/articles
+                           :data-testid "route-link-back-to-articles"}
             "← Back"]]])))
 
 (reg-view not-found-page []
@@ -124,8 +113,8 @@
     [:div
      [:h1 "Not found"]
      [:p (str "No route matches: " url)]
-     [:p [route-link {:to :route/home
-                      :data-testid "route-link-home"}
+     [:p [rf/route-link {:to :route/home
+                         :data-testid "route-link-home"}
           "Home"]]]))
 
 (reg-view root-view []


### PR DESCRIPTION
## Summary

- The `reagent/routing` and `reagent/realworld` examples each shipped a custom `route-link` `reg-view`. Both were stale relative to the canonical `rf/route-link` registered at `:route/link` by `day8/re-frame2-routing` (`implementation/routing/src/re_frame/routing.cljc:939-1084`) — missing the auxiliary-button (middle-click) defer branch and the user-supplied `:on-click` passthrough rule per the [API.md](spec/API.md) `route-link` row. The custom impls also re-derived URLs via `rf/route-url` + ad-hoc fragment concatenation instead of delegating to the framework view.
- Delete the two custom `reg-view`s. Rewrite **27 callsites** ([`routing/route-link`] -> [`rf/route-link`]) across `routing/core.cljs`, `realworld/{core,articles,auth,comments,profile}.cljs`.
- Trim the now-unused `[realworld.routing :as routing]` alias from `auth.cljs`, `articles.cljs`, `comments.cljs`, `profile.cljs` (the ns is still required transitively from `realworld.core` for its route-table side effects plus the `set-base-path!` / `install-router!` exports).
- Update the realworld README and `routing.cljs` ns docstring to point at the framework view.

Source: `rf2-zuwz` examples-idiom-drift audit, finding #2.

## Test plan

- [x] `npm run test:cljs` — 1263 tests, 3337 assertions, 0 failures / 0 errors.
- [x] `npm run test:examples` — all 25 example smokes PASS, including `routing` and `realworld (Conduit) — Spec 014 demo` which exercise the route-link click path end-to-end via Playwright.
- [x] Manual review: every `[rf/route-link ...]` callsite preserves its prior `:to` / `:params` / `:query` / `:class` / `:data-testid` props — the framework view forwards passthrough HTML attrs (per API.md `& passthrough-html-attrs`) onto the underlying `<a>`.