### PR TITLE
feat(causa): Effects panel — Phase 5 (rf2-ts41u)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/effects.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/effects.cljs
@@ -1,0 +1,327 @@
+(ns day8.re-frame2-causa.panels.effects
+  "Effects panel — Phase 5 (rf2-ts41u, parent rf2-5aw5v).
+
+  Surfaces re-frame2's registered fxs + their per-fx invocations,
+  outcome status, and stub indicator. Consumer of:
+
+    - Spec 002 (`reg-fx`)          — the registered-fx surface;
+                                     `(rf/handlers :fx)` is the
+                                     `{fx-id metadata}` projection
+                                     the composite sub reads.
+    - Spec 009 (Instrumentation)   — the `:rf.fx/*` trace event
+                                     vocabulary (`:rf.fx/handled`,
+                                     `:rf.fx/override-applied`,
+                                     `:rf.fx/skipped-on-platform`)
+                                     plus the fx-layer error events
+                                     (`:rf.error/fx-handler-exception`,
+                                     `:rf.error/no-such-fx`). The
+                                     panel filters the Causa trace
+                                     buffer to the fx-related slice
+                                     and derives a per-fx outcome
+                                     from the latest event.
+
+  ## What this panel shows
+
+  One row per registered fx, with — left to right:
+
+    - status badge (`:error` / `:overridden` / `:skipped` / `:ok` /
+      `:never-invoked`),
+    - the fx-id (mono column),
+    - the `:platforms` chip (`any` / `client` / `server`),
+    - the most-recent operation in a small caption,
+    - the invocation count for this buffer,
+    - a `STUB` indicator when an `:fx-overrides` is active for that id
+      (per Spec 002 §`:fx-overrides`).
+
+  Clicking a row selects that fx and dispatches the panel pivot to
+  `:event-detail` filtered to the fx's recent invocations — the
+  bead's per-row click-through. The selection alone lands in v1; the
+  cross-panel filter wiring rides the `:rf.causa/select-fx-id`
+  selection.
+
+  Empty state: \"No fx registered.\"
+
+  ## Pure hiccup
+
+  Same contract as every other Causa panel — the view is pure hiccup,
+  no Reagent / UIx / Helix references. Frame isolation comes from the
+  enclosing `[rf/frame-provider {:frame :rf/causa}]` in `shell.cljs`.
+  Every `subscribe` / `dispatch` here resolves to the `:rf/causa`
+  frame.
+
+  ## Helpers
+
+  All pure-data logic — `project-rows`, `compute-outcome`,
+  `latest-override-per-fx`, ... — lives in `effects_helpers.cljc` so
+  the algebra runs under the JVM unit-test target."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.effects-helpers :as h]))
+
+;; ---- design tokens (mirrors subscriptions.cljs / flows.cljs) ------------
+
+(def ^:private tokens
+  "Subset of shell.cljs's dark-theme tokens used by this panel. Kept
+  in sync manually for now — the v1.0 styling pass replaces these
+  with CSS variables across all panels."
+  {:bg-1            "#15171B"
+   :bg-2            "#1B1E24"
+   :bg-3            "#232730"
+   :bg-active       "#2A2F3D"
+   :border-subtle   "#232730"
+   :border-default  "#2F3441"
+   :text-primary    "#E8EAF0"
+   :text-secondary  "#A8AEC0"
+   :text-tertiary   "#6B7080"
+   :accent-violet   "#7C5CFF"
+   :cyan            "#43C3D0"
+   :green           "#4ADE80"
+   :yellow          "#FBBF24"
+   :red             "#F87171"
+   :magenta         "#E879F9"})
+
+(def ^:private mono-stack
+  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
+  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
+
+(def ^:private sans-stack
+  "Inter stack per spec/007-UX-IA.md §Typography."
+  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+
+;; ---- pure helpers -------------------------------------------------------
+
+(defn- outcome-colour
+  "Resolve an outcome's colour token to its hex via the panel's
+  `tokens` map. Single point of indirection so the test suite can
+  assert against the token without touching the hex."
+  [outcome]
+  (let [tok (get h/outcome->token outcome :text-tertiary)]
+    (get tokens tok (:text-tertiary tokens))))
+
+;; ---- status badge -------------------------------------------------------
+
+(defn- outcome-badge
+  "Colour + shape + tooltip-label, 14px on cosy density. Sits at the
+  left margin of every fx row. `outcome` is one of the canonical
+  five — `#{:error :overridden :skipped :ok :never-invoked}`."
+  [outcome]
+  (let [glyph   (get h/outcome->glyph outcome "?")
+        colour  (outcome-colour outcome)
+        tooltip (get h/outcome->tooltip outcome "Unknown")]
+    [:span {:data-testid     (str "rf-causa-fx-badge-" (name outcome))
+            :title           tooltip
+            :aria-label      tooltip
+            :style           {:display        "inline-block"
+                              :width          "14px"
+                              :height         "14px"
+                              :line-height    "14px"
+                              :text-align     "center"
+                              :color          colour
+                              :font-family    mono-stack
+                              :font-size      "14px"
+                              :font-weight    700
+                              :margin-right   "8px"
+                              :flex-shrink    0}}
+     glyph]))
+
+;; ---- fx row -------------------------------------------------------------
+
+(defn- platforms-pill
+  "Compact platforms indicator — `any`, `client`, `server`. Per
+  Spec 002 §reg-fx fxs default to both platforms; the chip surfaces
+  the non-default cases so a programmer scanning the list spots an
+  SSR-restricted handler at a glance."
+  [platforms]
+  [:span {:style {:display       "inline-block"
+                  :padding       "1px 6px"
+                  :margin-right  "8px"
+                  :border-radius "3px"
+                  :background    (:bg-3 tokens)
+                  :color         (:text-secondary tokens)
+                  :font-family   mono-stack
+                  :font-size     "10px"}}
+   (h/format-platforms platforms)])
+
+(defn- stub-indicator
+  "Render the `STUB` indicator for an fx with an active override. Per
+  Spec 002 §`:fx-overrides` an override replaces the registered
+  handler at the call site; the indicator gives the programmer
+  immediate visibility that the fx's real handler is being bypassed."
+  [fx-id]
+  [:span {:data-testid (str "rf-causa-fx-row-stub-" (h/format-fx-id fx-id))
+          :title       "An :fx-overrides redirect is active for this fx — the registered handler is being replaced at the call site."
+          :style       {:color         (:accent-violet tokens)
+                        :background    "rgba(124, 92, 255, 0.15)"
+                        :border        (str "1px solid " (:accent-violet tokens))
+                        :border-radius "3px"
+                        :padding       "0px 6px"
+                        :margin-left   "8px"
+                        :font-family   mono-stack
+                        :font-size     "10px"
+                        :font-weight   700
+                        :letter-spacing "0.5px"}}
+   "STUB"])
+
+(defn- fx-row
+  "One row in the fx list. Clicking the row fires
+  `:rf.causa/select-fx-id` so the cross-panel affordance can drill
+  into the event-detail panel filtered to this fx's recent
+  invocations."
+  [{:keys [fx-id platforms outcome stubbed? invocation-count last-operation]
+    :as _row}
+   selected?]
+  [:li {:data-testid (str "rf-causa-fx-row-" (h/format-fx-id fx-id))
+        :on-click   #(rf/dispatch [:rf.causa/select-fx-id fx-id])
+        :style      {:display       "flex"
+                     :align-items   "center"
+                     :padding       "6px 12px"
+                     :background    (if selected?
+                                      (:bg-active tokens)
+                                      "transparent")
+                     :border-bottom (str "1px solid " (:border-subtle tokens))
+                     :cursor        "pointer"
+                     :font-family   mono-stack
+                     :font-size     "13px"
+                     :color         (:text-primary tokens)}}
+   (outcome-badge outcome)
+   (platforms-pill platforms)
+   [:span {:style {:flex 1
+                   :min-width 0
+                   :overflow "hidden"
+                   :text-overflow "ellipsis"
+                   :white-space "nowrap"}}
+    [:span {:data-testid (str "rf-causa-fx-id-" (h/format-fx-id fx-id))
+            :style {:color (:text-primary tokens) :margin-right "8px"}}
+     (h/format-fx-id fx-id)]
+    (when last-operation
+      [:span {:style {:color (:text-tertiary tokens)
+                      :font-size "11px"
+                      :font-family sans-stack}}
+       (case last-operation
+         :rf.fx/handled                  "handled"
+         :rf.fx/override-applied         "override"
+         :rf.fx/skipped-on-platform      "skipped"
+         :rf.error/fx-handler-exception  "exception"
+         :rf.error/no-such-fx            "no-handler"
+         (str last-operation))])]
+   (when (pos? invocation-count)
+     [:span {:data-testid (str "rf-causa-fx-row-invocations-"
+                               (h/format-fx-id fx-id))
+             :style {:color (:text-tertiary tokens)
+                     :font-size "10px"
+                     :margin-left "8px"
+                     :font-family mono-stack}}
+      (str invocation-count "×")])
+   (when stubbed?
+     (stub-indicator fx-id))])
+
+;; ---- fx list ------------------------------------------------------------
+
+(defn- fx-list
+  "The default list view. Renders one row per registered fx in the
+  canonical sort order (errors first, then overridden, then skipped,
+  then ok, then never-invoked)."
+  [rows selected-fx-id]
+  (into [:ul {:data-testid "rf-causa-fx-list"
+              :style {:list-style "none"
+                      :margin     0
+                      :padding    0
+                      :background (:bg-2 tokens)}}]
+        (for [row rows]
+          ^{:key (h/format-fx-id (:fx-id row))}
+          (fx-row row (= (:fx-id row) selected-fx-id)))))
+
+;; ---- summary header -----------------------------------------------------
+
+(defn- summary-header
+  "Per-outcome tally + total count, mirroring the Flows panel's
+  summary header. The five-outcome taxonomy is small enough that v1
+  sorts rather than filters — the most actionable rows surface at
+  the top via the canonical outcome order."
+  [outcome-counts total]
+  [:div {:data-testid "rf-causa-fx-summary"
+         :style       {:padding "8px 12px"
+                       :display "flex"
+                       :align-items "center"
+                       :gap "8px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :color (:text-tertiary tokens)
+                       :font-family mono-stack
+                       :font-size "11px"}}
+   (for [o h/outcomes
+         :let [n (get outcome-counts o 0)]
+         :when (pos? n)]
+     ^{:key o}
+     [:span {:data-testid (str "rf-causa-fx-summary-" (name o))
+             :style {:color (outcome-colour o)
+                     :margin-right "6px"}}
+      (str (get h/outcome->glyph o) " " n " " (name o))])
+   [:span {:style {:flex 1}}]
+   [:span (str total " fx" (if (= 1 total) "" "s"))]])
+
+;; ---- empty state --------------------------------------------------------
+
+(defn- empty-state
+  "Rendered when no fxs are registered. The empty surface matches the
+  bead's minimum-viable contract — exactly the copy 'No fx
+  registered.' and a one-line orienting caption."
+  []
+  [:div {:data-testid "rf-causa-fx-empty"
+         :style       {:padding "16px"
+                       :color   (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size "13px"}}
+   [:p {:style {:margin "0 0 8px 0"
+                :color  (:text-secondary tokens)}}
+    "No fx registered."]
+   [:p {:style {:margin 0
+                :font-size "12px"
+                :color (:text-tertiary tokens)}}
+    "Register an fx via "
+    [:code {:style {:font-family mono-stack
+                    :color       (:accent-violet tokens)}}
+     "rf/reg-fx"]
+    " — the panel populates as fxs register. See "
+    [:code {:style {:font-family mono-stack
+                    :color       (:accent-violet tokens)}}
+     "spec/002-Frames.md"]
+    " §reg-fx."]])
+
+;; ---- public view --------------------------------------------------------
+
+(defn effects-view
+  "The Effects panel's root view. Subscribes to
+  `:rf.causa/effects-data` and renders the summary header + fx list
+  (or the empty state when no fxs are registered)."
+  []
+  (let [{:keys [rows outcome-counts total selected-fx-id]}
+        @(rf/subscribe [:rf.causa/effects-data])]
+    [:section {:data-testid "rf-causa-fx"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      "14px"}}
+     [:header {:style {:padding "16px 16px 8px 16px"}}
+      [:h1 {:style {:font-size   "16px"
+                    :font-weight 600
+                    :margin      0
+                    :color       (:text-primary tokens)}}
+       "Effects"]
+      [:p {:style {:font-size "12px"
+                   :color     (:text-tertiary tokens)
+                   :margin    "4px 0 0 0"}}
+       "Registered fxs + recent invocations. The "
+       [:em "STUB"]
+       " indicator surfaces when an "
+       [:code {:style {:font-family mono-stack
+                       :color       (:accent-violet tokens)}}
+        ":fx-overrides"]
+       " redirect is active."]]
+     (when (pos? total)
+       (summary-header outcome-counts total))
+     [:div {:style {:flex 1 :overflow "auto"}}
+      (if (zero? total)
+        (empty-state)
+        (fx-list rows selected-fx-id))]]))

--- a/tools/causa/src/day8/re_frame2_causa/panels/effects_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/effects_helpers.cljc
@@ -1,0 +1,312 @@
+(ns day8.re-frame2-causa.panels.effects-helpers
+  "Pure-data helpers for Causa's Effects panel (Phase 5, rf2-ts41u,
+  parent rf2-5aw5v).
+
+  ## Why a separate `.cljc` ns
+
+  Same dual-target pattern every other panel uses (flows, subscriptions,
+  causality-graph, time-travel, app-db-diff, ...). The panel view in
+  `effects.cljs` builds the hiccup; the *logic* — folding the
+  registered-fx set + the trace-buffer's `:op-type :fx` events into
+  per-fx rows with a stub indicator and an outcome summary — is pure
+  data → data and runs under the JVM unit-test target
+  (`clojure -M:test`).
+
+  ## The four-outcome taxonomy
+
+  Each fx row's status is derived from the latest `:rf.fx/*` event for
+  that fx-id (per Spec 009 §Error event catalogue):
+
+  | Outcome      | Glyph | Colour token   | Source operation                |
+  |--------------|-------|----------------|----------------------------------|
+  | `:ok`        | `●`   | `:green`       | `:rf.fx/handled`                |
+  | `:overridden`| `◑`   | `:accent-violet`| `:rf.fx/override-applied`      |
+  | `:skipped`   | `○`   | `:text-tertiary`| `:rf.fx/skipped-on-platform`  |
+  | `:error`     | `▲`   | `:red`          | `:rf.error/fx-handler-exception` / `:rf.error/no-such-fx` |
+
+  `:never-invoked` (no prior event) renders as the empty/idle state —
+  the `:text-tertiary` `○` — so a freshly-registered fx that has never
+  fired is legible at a glance.
+
+  ## Stub indicator
+
+  Per the bead's contract, a per-fx 'stub indicator' surfaces when an
+  fx-override is active for that id. Spec 002 §Per-frame and per-call
+  overrides documents `:fx-overrides` as the canonical surface; when
+  the runtime emits `:rf.fx/override-applied` for a given fx-id, that
+  fx is being stubbed (replaced) at the call site. The most recent
+  `:rf.fx/override-applied` event flags the row's `:stubbed?` boolean.
+
+  ## What this doesn't do
+
+  Pure data. No subscription, no atom, no `js/` interop — the same
+  fn runs under CLJ and CLJS. The CLJS-only surfaces (`rf/handlers`
+  on a populated registrar) are read by the composite sub in
+  `registry.cljs`; the result is handed to this ns as a plain map."
+  (:require [clojure.string :as str]))
+
+;; ---- design tokens (mirrors view tokens — kept here for tests) ----------
+;;
+;; The view consumes these via this ns so the outcome → token mapping
+;; has one source of truth. The pure-data side stays JVM-portable.
+
+(def outcome->token
+  "Outcome → colour-token mapping. The view resolves the token to a hex
+  via its private `tokens` map. Source of truth for the panel + any
+  follow-on Causa surface that wants to render an fx outcome badge."
+  {:ok            :green
+   :overridden    :accent-violet
+   :skipped       :text-tertiary
+   :error         :red
+   :never-invoked :text-tertiary})
+
+(def outcome->glyph
+  "Outcome → shape-glyph mapping. The glyph carries the taxonomy
+  without any colour signal so the panel is legible to colour-blind
+  users — same 'colour is never alone' discipline the Subscriptions /
+  Flows panels ship."
+  {:ok            "●"
+   :overridden    "◑"
+   :skipped       "○"
+   :error         "▲"
+   :never-invoked "○"})
+
+(def outcome->tooltip
+  "Outcome → hover-tooltip mapping. Hover over a badge surfaces this
+  string."
+  {:ok            "Handled"
+   :overridden    "Override applied"
+   :skipped       "Skipped on platform"
+   :error         "Errored"
+   :never-invoked "Never invoked"})
+
+(def outcomes
+  "Canonical row-ordering — errors first, then overridden (a stubbed
+  fx in flight needs visibility), then skipped, then ok, then
+  never-invoked. The view sorts rows by this order so the most
+  actionable rows surface at the top."
+  [:error :overridden :skipped :ok :never-invoked])
+
+;; ---- helpers ------------------------------------------------------------
+
+(defn fx-trace-event?
+  "True when `ev` is an fx-related trace event the Effects panel
+  consumes. Includes the `:op-type :fx` success / lifecycle stream
+  (`:rf.fx/handled`, `:rf.fx/override-applied`) AND the two `:op-type
+  :error` categories the fx layer emits (`:rf.error/fx-handler-
+  exception`, `:rf.error/no-such-fx`) AND the platform-skip warning
+  (`:rf.fx/skipped-on-platform`). Pure predicate — used by the
+  composite sub to filter the Causa trace buffer down to the fx
+  stream."
+  [{:keys [op-type operation] :as _ev}]
+  (or (= op-type :fx)
+      (and (= op-type :error)
+           (contains? #{:rf.error/fx-handler-exception
+                        :rf.error/no-such-fx}
+                      operation))
+      (= operation :rf.fx/skipped-on-platform)))
+
+(defn filter-fx-events
+  "Return only the fx-related events from a trace-event vector. Oldest
+  first (matches the buffer's natural order). Pure fn."
+  [events]
+  (filterv fx-trace-event? (or events [])))
+
+(defn- tag
+  "Pull a tag value off a trace event. Trace events nest per-event
+  metadata under `:tags`; the helper reads the slot defensively so
+  test fixtures that supply a flat shape (no `:tags`) also work."
+  [ev k]
+  (or (get-in ev [:tags k])
+      (get ev k)))
+
+(defn- event-fx-id
+  "The fx-id this event refers to. `:rf.fx/handled` and friends carry
+  `:fx-id` directly under `:tags`; the helper falls back on a flat
+  shape. `:rf.fx/override-applied` carries `:from` (the original
+  fx-id being overridden) — that's the id we want for attribution."
+  [ev]
+  (or (tag ev :fx-id)
+      (tag ev :from)))
+
+(defn- event-dispatch-id [ev] (tag ev :dispatch-id))
+
+(defn latest-event-per-fx
+  "Index `fx-events` (oldest first) into `{fx-id <latest-event>}`.
+  Pure fn — the linear scan keeps the latest event seen per fx-id as
+  the buffer iterates oldest→newest. Tools render the row's current
+  outcome from the latest event's `:operation`."
+  [fx-events]
+  (reduce (fn [acc ev]
+            (if-let [fid (event-fx-id ev)]
+              (assoc acc fid ev)
+              acc))
+          {}
+          (or fx-events [])))
+
+(defn latest-override-per-fx
+  "Index `fx-events` into `{fx-id <latest-override-event>}` — used to
+  surface the per-row stub indicator. Only `:rf.fx/override-applied`
+  events contribute. Pure fn."
+  [fx-events]
+  (reduce (fn [acc ev]
+            (if (and (= :rf.fx/override-applied (:operation ev))
+                     (some? (event-fx-id ev)))
+              (assoc acc (event-fx-id ev) ev)
+              acc))
+          {}
+          (or fx-events [])))
+
+(defn invocation-count-per-fx
+  "Index `fx-events` into `{fx-id <count>}` — used by the row's
+  invocation-counter caption. Counts every `:rf.fx/handled` /
+  `:rf.fx/override-applied` / `:rf.fx/skipped-on-platform` /
+  `:rf.error/fx-handler-exception` / `:rf.error/no-such-fx` event
+  per fx-id. Pure fn."
+  [fx-events]
+  (reduce (fn [acc ev]
+            (if-let [fid (event-fx-id ev)]
+              (update acc fid (fnil inc 0))
+              acc))
+          {}
+          (or fx-events [])))
+
+(defn compute-outcome
+  "Project one fx's outcome from its latest fx-related trace event.
+  Pure fn.
+
+  Decision order:
+
+    1. `:error`         — `:rf.error/fx-handler-exception` or
+                          `:rf.error/no-such-fx`.
+    2. `:overridden`    — `:rf.fx/override-applied` (the fx ran via
+                          override; surfaces the stub indicator).
+    3. `:skipped`       — `:rf.fx/skipped-on-platform`.
+    4. `:ok`            — `:rf.fx/handled` (the canonical success
+                          path).
+    5. `:never-invoked` — no prior event for this fx-id."
+  [latest-ev]
+  (let [op (:operation latest-ev)]
+    (cond
+      (= op :rf.error/fx-handler-exception)  :error
+      (= op :rf.error/no-such-fx)            :error
+      (= op :rf.fx/override-applied)         :overridden
+      (= op :rf.fx/skipped-on-platform)      :skipped
+      (= op :rf.fx/handled)                  :ok
+      :else                                  :never-invoked)))
+
+(defn project-rows
+  "Project the registered-fx map + the Causa trace-buffer's fx-related
+  slice into a vector of row maps the view consumes. Pure fn —
+  JVM-runnable.
+
+  Row shape:
+
+      {:fx-id            <id>
+       :platforms        #{:client :server} | nil
+       :doc              <string-or-nil>
+       :outcome          :ok | :overridden | :skipped | :error
+                                | :never-invoked
+       :stubbed?         <bool>          ;; true when an override is
+                                          ;; active for this fx-id
+       :invocation-count <int>           ;; total fx-related events
+                                          ;; seen for this fx-id in
+                                          ;; the current buffer
+       :last-operation   <:rf.fx/...-or-nil>
+       :last-trace-id    <int-or-nil>    ;; trace event :id; nil when
+                                          ;; the fx has never fired
+       :last-dispatch-id <int-or-nil>}   ;; cascade attribution for
+                                          ;; the latest event
+
+  Inputs:
+
+    `fx-map`    — `{fx-id metadata}` from `(rf/handlers :fx)`. May be
+                  empty / nil; the projection returns `[]`.
+
+    `fx-events` — trace events filtered to the fx-related stream,
+                  oldest first.
+
+  The returned vector is sorted by `outcomes` (errors first, then
+  overridden, then skipped, then ok, then never-invoked). Within an
+  outcome, rows are sorted by `:fx-id` (as a printable string) for
+  deterministic test output."
+  [fx-map fx-events]
+  (if (empty? fx-map)
+    []
+    (let [latest-by-fx    (latest-event-per-fx fx-events)
+          override-by-fx  (latest-override-per-fx fx-events)
+          counts          (invocation-count-per-fx fx-events)
+          rows            (for [[fx-id meta] fx-map
+                                :let [latest-ev (get latest-by-fx fx-id)
+                                      outcome   (compute-outcome latest-ev)]]
+                            {:fx-id            fx-id
+                             :platforms        (:platforms meta)
+                             :doc              (:doc meta)
+                             :outcome          outcome
+                             :stubbed?         (contains? override-by-fx fx-id)
+                             :invocation-count (get counts fx-id 0)
+                             :last-operation   (:operation latest-ev)
+                             :last-trace-id    (:id latest-ev)
+                             :last-dispatch-id (event-dispatch-id latest-ev)})
+          sorter          (zipmap outcomes (range))]
+      (vec
+        (sort-by (fn [{:keys [outcome fx-id]}]
+                   [(get sorter outcome (count outcomes))
+                    (pr-str fx-id)])
+                 rows)))))
+
+(defn outcome-counts
+  "Per-outcome tally over the projected rows. Pure fn."
+  [rows]
+  (frequencies (map :outcome rows)))
+
+(defn recent-events-for-fx
+  "Return the fx-related trace events for `fx-id`, newest first,
+  capped at `n` (default 20). Used by the panel's per-fx detail strip
+  so the user can scan the fx's recent invocations without leaving
+  the panel.
+
+  Pure fn — JVM-runnable; the cap keeps the render cost bounded even
+  on a deep trace buffer."
+  ([fx-events fx-id]
+   (recent-events-for-fx fx-events fx-id 20))
+  ([fx-events fx-id n]
+   (let [matches (filterv #(= fx-id (event-fx-id %))
+                          (or fx-events []))]
+     (vec (take n (reverse matches))))))
+
+(defn dispatch-ids-for-fx
+  "Return the set of `:dispatch-id`s the fx fired under, across the
+  current buffer. Used by the click-to-event-detail affordance — the
+  user clicks an fx row and the panel pivots to event-detail filtered
+  to invocations of this fx. Pure fn."
+  [fx-events fx-id]
+  (into #{}
+        (comp (filter #(= fx-id (event-fx-id %)))
+              (keep event-dispatch-id))
+        (or fx-events [])))
+
+;; ---- formatting helpers (consumed by the view) -------------------------
+
+(defn format-fx-id
+  "Render an fx-id for compact display in the mono column. Keywords
+  keep their `:` prefix; symbols / strings render plain."
+  [fx-id]
+  (cond
+    (keyword? fx-id) (str fx-id)
+    (symbol?  fx-id) (str fx-id)
+    :else            (str/trim (str fx-id))))
+
+(defn format-platforms
+  "Render the `:platforms` set as a short caption — `client`,
+  `server`, or `client/server`. Returns the empty-marker `\"any\"` for
+  the nil / fully-defaulted case (per Spec 002 §reg-fx the default is
+  `#{:client :server}`)."
+  [platforms]
+  (cond
+    (nil? platforms)                              "any"
+    (and (contains? platforms :client)
+         (contains? platforms :server))            "any"
+    (contains? platforms :client)                  "client"
+    (contains? platforms :server)                  "server"
+    :else                                          (str/join "/" (map name platforms))))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -124,6 +124,7 @@
             [day8.re-frame2-causa.panels.time-travel-helpers :as tt-helpers]
             [day8.re-frame2-causa.panels.causality-graph-helpers :as cg-helpers]
             [day8.re-frame2-causa.panels.app-db-diff-helpers :as diff-helpers]
+            [day8.re-frame2-causa.panels.effects-helpers :as effects-helpers]
             [day8.re-frame2-causa.panels.flows-helpers :as flows-helpers]
             [day8.re-frame2-causa.panels.hydration-debugger-helpers :as hd-helpers]
             [day8.re-frame2-causa.panels.issues-ribbon-helpers :as issues-helpers]
@@ -1224,6 +1225,100 @@
     (rf/reg-event-db :rf.causa/clear-flow-selection
       (fn [db _event]
         (dissoc db :selected-flow-id)))
+
+    ;; ---- Phase 5 (rf2-ts41u) — Effects panel ---------------------------
+    ;;
+    ;; Surfaces re-frame2's registered fxs + their per-fx invocations,
+    ;; outcome status, and stub indicator. Consumer of Spec 002 §reg-fx
+    ;; (the registered-fx surface) + Spec 009 (the `:rf.fx/*` trace event
+    ;; vocabulary).
+    ;;
+    ;; The panel reads two surfaces — the framework's registered-fx map
+    ;; (`(rf/handlers :fx)`) and the Causa trace-buffer's fx-related
+    ;; slice (`:op-type :fx` plus the fx-layer error categories) — and
+    ;; folds them via `effects-helpers/project-rows` into one row per
+    ;; registered fx.
+    ;;
+    ;; Tests stub the registered-fx surface by writing
+    ;; `:registered-fxs-override` to Causa's app-db (via
+    ;; `:rf.causa/set-registered-fxs-override-for-test`) so the suite
+    ;; can assert against a deterministic fx set without booting a host
+    ;; runtime that registers fxs.
+    ;;
+    ;; Shape of `:rf.causa/effects-data`:
+    ;;
+    ;;     {:rows           [<row> ...]
+    ;;      :outcome-counts {outcome count}
+    ;;      :total          <int>
+    ;;      :selected-fx-id <fx-id-or-nil>}
+
+    ;; Read the registered-fx map. Reads `(rf/handlers :fx)` — per
+    ;; Spec 001 §The public registrar query API the registrar is
+    ;; process-global so this surfaces every registered fx across
+    ;; every frame. The v1 wiring threads it through the override
+    ;; slot so the JVM test target can drive the projection without
+    ;; booting a substrate that registers fxs.
+    (rf/reg-sub :rf.causa/registered-fxs
+      (fn [db _query]
+        (let [ov (get db :registered-fxs-override)]
+          (or ov (rf/handlers :fx)))))
+
+    ;; Test-only override hook for the registered-fxs surface.
+    ;; Production code paths never dispatch this — the slot exists
+    ;; only so JVM + node-test suites can drive the projection
+    ;; without booting the fx registrar.
+    (rf/reg-event-db :rf.causa/set-registered-fxs-override-for-test
+      (fn [db [_ ov]]
+        (if (nil? ov)
+          (dissoc db :registered-fxs-override)
+          (assoc db :registered-fxs-override ov))))
+
+    ;; The Causa trace-buffer's fx-related slice. Pure-data filter —
+    ;; the helper's predicate is JVM-runnable so tests can drive it
+    ;; without a CLJS runtime.
+    ;;
+    ;; Note the single-signal `:<-` arity: re-frame2's `reg-sub`
+    ;; passes the upstream value DIRECTLY (not vector-wrapped) when
+    ;; there's exactly one `:<-` chain entry — per Spec 002 §The
+    ;; reg-sub forms + subs.cljc parse-reg-sub-args.
+    (rf/reg-sub :rf.causa/fx-trace-events
+      :<- [:rf.causa/trace-buffer]
+      (fn [buffer _query]
+        (effects-helpers/filter-fx-events buffer)))
+
+    ;; The user's per-panel fx selection. Drives a cross-panel
+    ;; affordance (click fx → event-detail filtered to that fx's
+    ;; recent invocations); v1 wiring carries the selection only —
+    ;; the cross-panel jump lands when the cross-panel filter API
+    ;; stabilises.
+    (rf/reg-sub :rf.causa/selected-fx-id
+      (fn [db _query]
+        (get db :selected-fx-id)))
+
+    ;; The composite the panel consumes. One read produces every slot
+    ;; the view needs (matches the per-panel composite pattern every
+    ;; other Causa panel uses).
+    (rf/reg-sub :rf.causa/effects-data
+      :<- [:rf.causa/registered-fxs]
+      :<- [:rf.causa/fx-trace-events]
+      :<- [:rf.causa/selected-fx-id]
+      (fn [[fxs-map fx-events selected-fx-id] _query]
+        (let [rows   (effects-helpers/project-rows fxs-map fx-events)
+              counts (effects-helpers/outcome-counts rows)]
+          {:rows           rows
+           :outcome-counts counts
+           :total          (count rows)
+           :selected-fx-id selected-fx-id})))
+
+    ;; ---- Phase 5 (rf2-ts41u) — Effects panel events ------------------
+
+    (rf/reg-event-db :rf.causa/select-fx-id
+      (fn [db [_ fx-id]]
+        (assoc db :selected-fx-id fx-id)))
+
+    (rf/reg-event-db :rf.causa/clear-fx-selection
+      (fn [db _event]
+        (dissoc db :selected-fx-id)))
 
     ;; ---- Phase 5 (rf2-75121) — Performance panel -----------------------
     ;;

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -42,6 +42,9 @@
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.time-travel :as time-travel]
             [day8.re-frame2-causa.panels.causality-graph :as causality-graph]
+            ;; ── effects panel begin ──
+            [day8.re-frame2-causa.panels.effects :as effects]
+            ;; ── effects panel end ──
             [day8.re-frame2-causa.panels.flows :as flows]
             [day8.re-frame2-causa.panels.hydration-debugger :as hydration-debugger]
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
@@ -83,7 +86,9 @@
    {:id :app-db       :label "App-db"        :bead "rf2-jps1o" :live? true}
    {:id :causality    :label "Causality"     :bead "rf2-4rqs1" :live? true}
    {:id :subs         :label "Subscriptions" :bead "rf2-x0f5v" :live? true}
-   {:id :fx           :label "Effects"       :bead "rf2-xxx"}
+   ;; ── effects panel begin ──
+   {:id :fx           :label "Effects"       :bead "rf2-ts41u" :live? true}
+   ;; ── effects panel end ──
    {:id :trace        :label "Trace"         :bead "rf2-argrj" :live? true}
    {:id :machines     :label "Machines"      :bead "rf2-xxx"}
    {:id :flows        :label "Flows"         :bead "rf2-83irn" :live? true}
@@ -267,6 +272,9 @@
       :time-travel  [time-travel/time-travel-view]
       :app-db       [app-db-diff/app-db-diff-view]
       :causality    [causality-graph/causality-graph-view]
+      ;; ── effects panel begin ──
+      :fx           [effects/effects-view]
+      ;; ── effects panel end ──
       :flows        [flows/flows-view]
       :schemas      [schema-violation-timeline/schema-violation-timeline-view]
       :subs         [subscriptions/subscriptions-view]

--- a/tools/causa/test/day8/re_frame2_causa/panels/effects_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/effects_helpers_cljs_test.cljc
@@ -1,0 +1,345 @@
+(ns day8.re-frame2-causa.panels.effects-helpers-cljs-test
+  "Pure-data tests for Causa's Effects panel helpers
+  (Phase 5, rf2-ts41u).
+
+  ## Why the `.cljc` + `_cljs_test` naming
+
+  Same dual-target pattern as the other helper tests:
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  ## What's under test
+
+    1. **fx-trace-event? / filter-fx-events** — the predicate that
+       slices the trace buffer down to the fx-related stream
+       (`:op-type :fx` plus the two fx-layer error categories plus
+       the platform-skip warning).
+    2. **latest-event-per-fx / latest-override-per-fx /
+       invocation-count-per-fx** — the reductions that drive
+       per-fx state derivation.
+    3. **compute-outcome** — the five-outcome state machine that
+       classifies an fx's most recent trace event.
+    4. **project-rows** — the fold over the registered-fxs map +
+       the fx-related trace slice. Row shape, ordering (errors
+       first), empty-state behaviour, stub indicator.
+    5. **outcome-counts** — the summary-header feed.
+    6. **recent-events-for-fx / dispatch-ids-for-fx** — newest-first
+       cap'd projection + the cross-panel pivot feed.
+    7. **format-fx-id / format-platforms** — the view-side formatters."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.effects-helpers :as h]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- fx-ev
+  "Build a minimal fx-related trace event. The runtime stamps
+  `:fx-id`, `:fx-args`, `:frame`, and `:dispatch-id` under `:tags`.
+  The helper here mirrors that shape so the tests assert against the
+  realistic payload."
+  ([op fx-id] (fx-ev op fx-id {}))
+  ([op fx-id extra-tags]
+   (let [op-type (cond
+                   (contains? #{:rf.error/fx-handler-exception
+                                :rf.error/no-such-fx}
+                              op)
+                   :error
+                   (= op :rf.fx/skipped-on-platform) :warning
+                   :else                             :fx)
+         tags    (cond-> (merge {:fx-id fx-id :frame :rf/default}
+                                extra-tags)
+                   ;; override-applied carries :from + :to, not :fx-id —
+                   ;; mirror the runtime's shape so the helper reads it.
+                   (= op :rf.fx/override-applied)
+                   (-> (dissoc :fx-id) (assoc :from fx-id)))]
+     {:operation op
+      :op-type   op-type
+      :id        (rand-int 1000000)
+      :time      (rand-int 1000000)
+      :tags      tags})))
+
+;; ---- (1) fx-trace-event? / filter-fx-events ----------------------------
+
+(deftest fx-trace-event?-true-for-op-type-fx
+  (testing "the predicate returns true for `:op-type :fx` events"
+    (is (true? (h/fx-trace-event? (fx-ev :rf.fx/handled :my/fx))))))
+
+(deftest fx-trace-event?-true-for-fx-handler-exception
+  (testing "the predicate returns true for `:rf.error/fx-handler-exception`"
+    (is (true? (h/fx-trace-event?
+                 {:op-type :error :operation :rf.error/fx-handler-exception
+                  :tags {:fx-id :my/fx}})))))
+
+(deftest fx-trace-event?-true-for-no-such-fx
+  (testing "the predicate returns true for `:rf.error/no-such-fx`"
+    (is (true? (h/fx-trace-event?
+                 {:op-type :error :operation :rf.error/no-such-fx
+                  :tags {:fx-id :my/fx}})))))
+
+(deftest fx-trace-event?-true-for-skipped-on-platform
+  (testing "the predicate returns true for `:rf.fx/skipped-on-platform`"
+    (is (true? (h/fx-trace-event? (fx-ev :rf.fx/skipped-on-platform :my/fx))))))
+
+(deftest fx-trace-event?-false-for-other-op-types
+  (testing "the predicate is false for non-fx trace events"
+    (is (false? (h/fx-trace-event? {:op-type :event :operation :event/dispatched})))
+    (is (false? (h/fx-trace-event? {:op-type :sub  :operation :sub/run})))
+    (is (false? (h/fx-trace-event? {:op-type :flow :operation :rf.flow/computed})))
+    (is (false? (h/fx-trace-event? {})))))
+
+(deftest filter-fx-events-keeps-fx-events-in-order
+  (testing "filter-fx-events keeps fx-related events in input order,
+            dropping everything else"
+    (let [buf [{:op-type :event :operation :event/dispatched}
+               (fx-ev :rf.fx/handled :a)
+               {:op-type :sub :operation :sub/run}
+               (fx-ev :rf.fx/skipped-on-platform :b)
+               (fx-ev :rf.error/fx-handler-exception :a)]]
+      (is (= [:rf.fx/handled :rf.fx/skipped-on-platform
+              :rf.error/fx-handler-exception]
+             (map :operation (h/filter-fx-events buf)))))))
+
+(deftest filter-fx-events-nil-and-empty-safe
+  (testing "filter-fx-events tolerates nil + empty input"
+    (is (= [] (h/filter-fx-events nil)))
+    (is (= [] (h/filter-fx-events [])))))
+
+;; ---- (2) latest-event-per-fx -------------------------------------------
+
+(deftest latest-event-per-fx-keeps-newest
+  (testing "latest-event-per-fx returns one entry per fx-id, keyed to
+            the newest event (rightmost wins in the oldest→newest scan)"
+    (let [events [(fx-ev :rf.fx/handled :a)
+                  (fx-ev :rf.fx/handled :b)
+                  (fx-ev :rf.fx/skipped-on-platform :a)]
+          m      (h/latest-event-per-fx events)]
+      (is (= :rf.fx/skipped-on-platform (:operation (get m :a))))
+      (is (= :rf.fx/handled              (:operation (get m :b)))))))
+
+(deftest latest-event-per-fx-empty-input
+  (is (= {} (h/latest-event-per-fx nil)))
+  (is (= {} (h/latest-event-per-fx []))))
+
+(deftest latest-override-per-fx-only-tracks-override-applied
+  (testing "latest-override-per-fx only indexes :rf.fx/override-applied"
+    (let [events [(fx-ev :rf.fx/handled :a)
+                  (fx-ev :rf.fx/override-applied :a)
+                  (fx-ev :rf.fx/handled :b)]
+          m      (h/latest-override-per-fx events)]
+      (is (contains? m :a))
+      (is (not (contains? m :b))))))
+
+(deftest invocation-count-per-fx-counts-every-event-per-fx
+  (testing "invocation-count-per-fx tallies every fx-related event per fx-id"
+    (let [events [(fx-ev :rf.fx/handled :a)
+                  (fx-ev :rf.fx/handled :a)
+                  (fx-ev :rf.fx/skipped-on-platform :a)
+                  (fx-ev :rf.fx/handled :b)]
+          m      (h/invocation-count-per-fx events)]
+      (is (= 3 (get m :a)))
+      (is (= 1 (get m :b))))))
+
+;; ---- (3) compute-outcome -----------------------------------------------
+
+(deftest compute-outcome-no-event-is-never-invoked
+  (testing "no prior event surfaces :never-invoked"
+    (is (= :never-invoked (h/compute-outcome nil)))))
+
+(deftest compute-outcome-handled-is-ok
+  (testing ":rf.fx/handled surfaces :ok"
+    (is (= :ok (h/compute-outcome (fx-ev :rf.fx/handled :a))))))
+
+(deftest compute-outcome-override-applied-is-overridden
+  (testing ":rf.fx/override-applied surfaces :overridden"
+    (is (= :overridden
+           (h/compute-outcome (fx-ev :rf.fx/override-applied :a))))))
+
+(deftest compute-outcome-skipped-on-platform-is-skipped
+  (testing ":rf.fx/skipped-on-platform surfaces :skipped"
+    (is (= :skipped
+           (h/compute-outcome (fx-ev :rf.fx/skipped-on-platform :a))))))
+
+(deftest compute-outcome-fx-handler-exception-is-error
+  (testing ":rf.error/fx-handler-exception surfaces :error"
+    (is (= :error
+           (h/compute-outcome
+             {:operation :rf.error/fx-handler-exception
+              :op-type   :error
+              :tags      {:fx-id :a}})))))
+
+(deftest compute-outcome-no-such-fx-is-error
+  (testing ":rf.error/no-such-fx surfaces :error"
+    (is (= :error
+           (h/compute-outcome
+             {:operation :rf.error/no-such-fx
+              :op-type   :error
+              :tags      {:fx-id :a}})))))
+
+;; ---- (4) project-rows --------------------------------------------------
+
+(deftest project-rows-empty-map-is-empty
+  (testing "no registered fxs => empty rows"
+    (is (= [] (h/project-rows nil nil)))
+    (is (= [] (h/project-rows {} nil)))))
+
+(deftest project-rows-emits-row-per-registered-fx
+  (testing "one row per entry in the registered-fx map"
+    (let [fxs   {:my/notify {:platforms #{:client}
+                             :doc "Show a toast"}
+                 :my/persist {:platforms #{:client :server}}}
+          rows  (h/project-rows fxs nil)
+          ids   (set (map :fx-id rows))]
+      (is (= 2 (count rows)))
+      (is (= #{:my/notify :my/persist} ids)))))
+
+(deftest project-rows-carries-platforms-and-doc
+  (testing "each row carries :platforms + :doc off the registered-fx
+            metadata"
+    (let [fxs   {:my/notify {:platforms #{:client}
+                             :doc "Show a toast"}}
+          row   (first (h/project-rows fxs nil))]
+      (is (= :my/notify     (:fx-id row)))
+      (is (= #{:client}     (:platforms row)))
+      (is (= "Show a toast" (:doc row))))))
+
+(deftest project-rows-never-invoked-when-no-events
+  (testing "a registered fx with no prior trace events is :never-invoked"
+    (let [fxs  {:my/notify {:platforms #{:client}}}
+          row  (first (h/project-rows fxs nil))]
+      (is (= :never-invoked (:outcome row)))
+      (is (false? (:stubbed? row)))
+      (is (= 0 (:invocation-count row))))))
+
+(deftest project-rows-marks-ok-on-handled
+  (testing ":rf.fx/handled surfaces :ok"
+    (let [fxs    {:my/notify {:platforms #{:client}}}
+          events [(fx-ev :rf.fx/handled :my/notify {:dispatch-id 7})]
+          row    (first (h/project-rows fxs events))]
+      (is (= :ok (:outcome row)))
+      (is (= :rf.fx/handled (:last-operation row)))
+      (is (= 7 (:last-dispatch-id row)))
+      (is (= 1 (:invocation-count row))))))
+
+(deftest project-rows-marks-error-on-fx-handler-exception
+  (testing ":rf.error/fx-handler-exception surfaces :error"
+    (let [fxs    {:my/notify {:platforms #{:client}}}
+          events [{:operation :rf.error/fx-handler-exception
+                   :op-type   :error
+                   :id        9
+                   :tags      {:fx-id :my/notify :dispatch-id 7}}]
+          row    (first (h/project-rows fxs events))]
+      (is (= :error (:outcome row))))))
+
+(deftest project-rows-marks-stubbed-when-override-active
+  (testing "an fx whose latest override-applied event lives in the
+            buffer is :stubbed? true"
+    (let [fxs    {:my/notify {:platforms #{:client}}}
+          events [(fx-ev :rf.fx/override-applied :my/notify)]
+          row    (first (h/project-rows fxs events))]
+      (is (true? (:stubbed? row)))
+      (is (= :overridden (:outcome row))))))
+
+(deftest project-rows-sorts-errors-first
+  (testing "canonical sort: error → overridden → skipped → ok → never-invoked"
+    (let [fxs    {:fx-a-ok       {:platforms #{:client}}
+                  :fx-b-error    {:platforms #{:client}}
+                  :fx-c-override {:platforms #{:client}}
+                  :fx-d-skip     {:platforms #{:client}}
+                  :fx-e-never    {:platforms #{:client}}}
+          events [(fx-ev :rf.fx/handled :fx-a-ok)
+                  {:operation :rf.error/fx-handler-exception
+                   :op-type   :error
+                   :tags      {:fx-id :fx-b-error}}
+                  (fx-ev :rf.fx/override-applied :fx-c-override)
+                  (fx-ev :rf.fx/skipped-on-platform :fx-d-skip)]
+          rows   (h/project-rows fxs events)]
+      (is (= [:error :overridden :skipped :ok :never-invoked]
+             (map :outcome rows))))))
+
+(deftest project-rows-stable-within-outcome
+  (testing "within an outcome, rows are sorted by fx-id for deterministic
+            test output"
+    (let [fxs  {:zebra/a {:platforms #{:client}}
+                :apple/b {:platforms #{:client}}
+                :mango/c {:platforms #{:client}}}
+          rows (h/project-rows fxs nil)]
+      (is (= [:apple/b :mango/c :zebra/a]
+             (map :fx-id rows))))))
+
+;; ---- (5) outcome-counts ------------------------------------------------
+
+(deftest outcome-counts-tallies-by-outcome
+  (let [rows [{:outcome :ok}
+              {:outcome :ok}
+              {:outcome :overridden}
+              {:outcome :error}]]
+    (is (= {:ok 2 :overridden 1 :error 1}
+           (h/outcome-counts rows)))))
+
+;; ---- (6) recent-events-for-fx ------------------------------------------
+
+(deftest recent-events-newest-first
+  (testing "recent-events-for-fx returns the fx's events newest first"
+    (let [events [(fx-ev :rf.fx/handled :a)
+                  (fx-ev :rf.fx/handled :b)
+                  (fx-ev :rf.fx/skipped-on-platform :a)
+                  (fx-ev :rf.fx/handled :a)]
+          out    (h/recent-events-for-fx events :a)]
+      (is (= [:rf.fx/handled :rf.fx/skipped-on-platform :rf.fx/handled]
+             (map :operation out))))))
+
+(deftest recent-events-caps-output
+  (testing "the cap limits the returned vector"
+    (let [events (mapv (fn [_] (fx-ev :rf.fx/handled :a)) (range 30))]
+      (is (= 5 (count (h/recent-events-for-fx events :a 5)))))))
+
+(deftest recent-events-empty-for-unknown-fx
+  (is (= [] (h/recent-events-for-fx [(fx-ev :rf.fx/handled :a)]
+                                    :nonexistent))))
+
+(deftest dispatch-ids-for-fx-returns-set
+  (testing "dispatch-ids-for-fx surfaces the cascade ids the fx fired under"
+    (let [events [(fx-ev :rf.fx/handled :a {:dispatch-id 1})
+                  (fx-ev :rf.fx/handled :a {:dispatch-id 2})
+                  (fx-ev :rf.fx/handled :b {:dispatch-id 3})
+                  (fx-ev :rf.fx/handled :a {:dispatch-id 1})]]
+      (is (= #{1 2} (h/dispatch-ids-for-fx events :a)))
+      (is (= #{3}   (h/dispatch-ids-for-fx events :b))))))
+
+;; ---- (7) taxonomy invariants -------------------------------------------
+
+(deftest every-outcome-has-glyph-colour-tooltip
+  (testing "every outcome in the canonical vocabulary has a glyph,
+            colour token, and tooltip"
+    (doseq [o h/outcomes]
+      (is (some? (get h/outcome->glyph o))   (str "glyph for " o))
+      (is (some? (get h/outcome->token o))   (str "token for " o))
+      (is (some? (get h/outcome->tooltip o)) (str "tooltip for " o)))))
+
+(deftest outcomes-canonical-order
+  (testing "spec'd default sort order — error → overridden → skipped
+            → ok → never-invoked"
+    (is (= [:error :overridden :skipped :ok :never-invoked]
+           h/outcomes))))
+
+(deftest taxonomy-has-exactly-five
+  (testing "exactly five outcomes — not four, not six"
+    (is (= 5 (count h/outcomes)))
+    (is (= 5 (count h/outcome->glyph)))
+    (is (= 5 (count h/outcome->token)))
+    (is (= 5 (count h/outcome->tooltip)))))
+
+;; ---- (8) formatters ----------------------------------------------------
+
+(deftest format-fx-id-keyword-keeps-colon
+  (is (= ":my/notify"     (h/format-fx-id :my/notify)))
+  (is (= ":cart/persist"  (h/format-fx-id :cart/persist))))
+
+(deftest format-platforms-renders-short-caption
+  (is (= "any"    (h/format-platforms nil)))
+  (is (= "any"    (h/format-platforms #{:client :server})))
+  (is (= "client" (h/format-platforms #{:client})))
+  (is (= "server" (h/format-platforms #{:server}))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/effects_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/effects_view_cljs_test.cljs
@@ -1,0 +1,334 @@
+(ns day8.re-frame2-causa.panels.effects-view-cljs-test
+  "CLJS-side wiring + view tests for Causa's Effects panel
+  (Phase 5, rf2-ts41u).
+
+  ## What's under test (in addition to the pure-data tests in
+  `effects_helpers_cljs_test.cljc`)
+
+    1. **Registry wires the composite sub** under
+       `:rf.causa/effects-data`. The composite returns rows + counts
+       + selection in the shape the view consumes.
+
+    2. **Empty state** — with no registered fxs and no override,
+       the panel renders 'No fx registered.'
+
+    3. **Populated list** — with a registered-fxs override the
+       panel renders one row per fx + the summary header.
+
+    4. **Outcome badge** — with a `:rf.fx/handled` trace event in
+       the buffer, the matching row carries the `:ok` badge.
+
+    5. **Stub indicator** — with a `:rf.fx/override-applied` event
+       in the buffer for an fx-id, the row's STUB indicator surfaces.
+
+    6. **Fx selection** — clicking a row fires
+       `:rf.causa/select-fx-id`; the panel highlights the selection.
+
+    7. **Frame isolation** — the panel's state lives on `:rf/causa`,
+       never on `:rf/default`.
+
+  ## Pure hiccup
+
+  Same approach as `flows_view_cljs_test` — walk the view's hiccup
+  tree by `data-testid` rather than mounting to the DOM."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.effects :as effects]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walkers (mirror flows_view_cljs_test) -----------------------
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (apply (first node) (rest node))
+    node))
+
+(defn- hiccup-seq [tree]
+  (->> (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree))
+       (map expand-fn-component)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (hiccup-seq tree)))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- override-fxs! [m]
+  (rf/dispatch-sync [:rf.causa/set-registered-fxs-override-for-test m]))
+
+(defn- push-trace! [ev]
+  (trace-bus/collect-trace! ev))
+
+;; ---- (1) registry wires the composite sub -------------------------------
+
+(deftest registry-installs-effects-subs-and-events
+  (testing "register-causa-handlers! installs the Phase 5 (rf2-ts41u)
+            composite sub + every supporting event"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/effects-data)))
+    (is (some? (registrar/handler :sub :rf.causa/registered-fxs)))
+    (is (some? (registrar/handler :sub :rf.causa/fx-trace-events)))
+    (is (some? (registrar/handler :sub :rf.causa/selected-fx-id)))
+    (is (some? (registrar/handler :event :rf.causa/select-fx-id)))
+    (is (some? (registrar/handler :event :rf.causa/clear-fx-selection)))
+    (is (some? (registrar/handler :event
+                                  :rf.causa/set-registered-fxs-override-for-test)))))
+
+(deftest effects-data-sub-defaults-empty
+  (testing "with no override and no fxs registered the composite
+            returns empty rows + zero total"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-fxs! {})
+      (let [data @(rf/subscribe [:rf.causa/effects-data])]
+        (is (= [] (:rows data)))
+        (is (= 0  (:total data)))
+        (is (nil? (:selected-fx-id data)))))))
+
+(deftest effects-data-sub-projects-override-into-rows
+  (testing "with a registered-fxs override the composite returns one
+            row per entry — projected via the helpers"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-fxs!
+        {:my/notify  {:platforms #{:client}
+                      :doc "Show a toast"}
+         :my/persist {:platforms #{:client :server}}})
+      (let [data @(rf/subscribe [:rf.causa/effects-data])
+            ids  (set (map :fx-id (:rows data)))]
+        (is (= 2 (:total data)))
+        (is (= #{:my/notify :my/persist} ids))))))
+
+;; ---- (2) view renders ---------------------------------------------------
+
+(deftest empty-state-renders-when-no-fxs
+  (testing "with no registered fxs the panel renders the empty state"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-fxs! {})
+      (let [tree (effects/effects-view)]
+        (is (some? (find-by-testid tree "rf-causa-fx"))
+            "panel container present")
+        (is (some? (find-by-testid tree "rf-causa-fx-empty"))
+            "empty-state container present")
+        (is (nil? (find-by-testid tree "rf-causa-fx-list"))
+            "no list when there are zero fxs")))))
+
+(deftest list-renders-when-fxs-populated
+  (testing "with a populated override the panel renders one row per fx
+            plus the summary header"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-fxs!
+        {:my/notify  {:platforms #{:client}}
+         :my/persist {:platforms #{:client :server}}})
+      (let [tree (effects/effects-view)]
+        (is (some? (find-by-testid tree "rf-causa-fx-list"))
+            "list container present")
+        (is (some? (find-by-testid tree "rf-causa-fx-row-:my/notify"))
+            "row for :my/notify present")
+        (is (some? (find-by-testid tree "rf-causa-fx-row-:my/persist"))
+            "row for :my/persist present")
+        (is (some? (find-by-testid tree "rf-causa-fx-summary"))
+            "summary header present")))))
+
+(deftest row-renders-fx-id
+  (testing "each row carries the fx-id"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-fxs!
+        {:my/notify {:platforms #{:client}}})
+      (let [tree (effects/effects-view)]
+        (is (some? (find-by-testid tree "rf-causa-fx-id-:my/notify")))))))
+
+(deftest never-invoked-badge-renders-by-default
+  (testing "an fx with no prior trace events surfaces the :never-invoked
+            badge"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-fxs!
+        {:my/notify {:platforms #{:client}}})
+      (let [tree (effects/effects-view)]
+        (is (some? (find-by-testid tree "rf-causa-fx-badge-never-invoked")))))))
+
+;; ---- (3) outcome surfaces from trace events -----------------------------
+
+(deftest ok-badge-renders-when-fx-handled
+  (testing "with a :rf.fx/handled trace event in the buffer, the
+            matching row carries the :ok badge + invocation counter"
+    (setup-causa-frame!)
+    ;; Seed the trace buffer BEFORE the first subscribe — mirrors the
+    ;; production sequencing where preload's trace-cb fires before any
+    ;; panel mounts.
+    (push-trace! {:operation :rf.fx/handled
+                  :op-type   :fx
+                  :id        100
+                  :time      100
+                  :tags      {:fx-id       :my/notify
+                              :frame       :rf/default
+                              :dispatch-id 42}})
+    (rf/with-frame :rf/causa
+      (override-fxs!
+        {:my/notify {:platforms #{:client}}})
+      (let [tree (effects/effects-view)]
+        (is (some? (find-by-testid tree "rf-causa-fx-badge-ok"))
+            ":ok badge surfaces")
+        (is (some? (find-by-testid tree
+                                   "rf-causa-fx-row-invocations-:my/notify"))
+            "invocation counter surfaces on the row")))))
+
+(deftest skipped-badge-renders-when-fx-skipped-on-platform
+  (testing ":rf.fx/skipped-on-platform surfaces the :skipped badge"
+    (setup-causa-frame!)
+    (push-trace! {:operation :rf.fx/skipped-on-platform
+                  :op-type   :warning
+                  :id        100
+                  :time      100
+                  :tags      {:fx-id       :my/notify
+                              :frame       :rf/default
+                              :platform    :server
+                              :registered-platforms #{:client}
+                              :dispatch-id 42}})
+    (rf/with-frame :rf/causa
+      (override-fxs!
+        {:my/notify {:platforms #{:client}}})
+      (let [tree (effects/effects-view)]
+        (is (some? (find-by-testid tree "rf-causa-fx-badge-skipped")))))))
+
+(deftest error-badge-renders-when-fx-handler-throws
+  (testing ":rf.error/fx-handler-exception surfaces the :error badge"
+    (setup-causa-frame!)
+    (push-trace! {:operation :rf.error/fx-handler-exception
+                  :op-type   :error
+                  :id        100
+                  :time      100
+                  :tags      {:fx-id             :my/notify
+                              :fx-args           {}
+                              :exception-message "boom"
+                              :dispatch-id       42}})
+    (rf/with-frame :rf/causa
+      (override-fxs!
+        {:my/notify {:platforms #{:client}}})
+      (let [tree (effects/effects-view)]
+        (is (some? (find-by-testid tree "rf-causa-fx-badge-error")))))))
+
+;; ---- (4) stub indicator -------------------------------------------------
+
+(deftest stub-indicator-renders-when-override-applied
+  (testing "with a :rf.fx/override-applied event in the buffer, the
+            STUB indicator surfaces on the matching row + the
+            :overridden badge"
+    (setup-causa-frame!)
+    (push-trace! {:operation :rf.fx/override-applied
+                  :op-type   :fx
+                  :id        100
+                  :time      100
+                  :tags      {:from        :my/notify
+                              :to          :my/notify-stub
+                              :dispatch-id 42}})
+    (rf/with-frame :rf/causa
+      (override-fxs!
+        {:my/notify {:platforms #{:client}}})
+      (let [tree (effects/effects-view)]
+        (is (some? (find-by-testid tree "rf-causa-fx-badge-overridden"))
+            ":overridden badge surfaces")
+        (is (some? (find-by-testid tree
+                                   "rf-causa-fx-row-stub-:my/notify"))
+            "STUB indicator surfaces on the row")))))
+
+(deftest stub-indicator-absent-without-override
+  (testing "without an override-applied event the STUB indicator
+            does not render"
+    (setup-causa-frame!)
+    (push-trace! {:operation :rf.fx/handled
+                  :op-type   :fx
+                  :id        100
+                  :time      100
+                  :tags      {:fx-id       :my/notify
+                              :dispatch-id 42}})
+    (rf/with-frame :rf/causa
+      (override-fxs!
+        {:my/notify {:platforms #{:client}}})
+      (let [tree (effects/effects-view)]
+        (is (nil? (find-by-testid tree
+                                  "rf-causa-fx-row-stub-:my/notify"))
+            "STUB indicator absent when no override active")))))
+
+;; ---- (5) selection ------------------------------------------------------
+
+(deftest select-fx-event-writes-to-causa-frame
+  (testing ":rf.causa/select-fx-id stores the fx-id on the Causa frame"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-fx-id :my/notify])
+      (is (= :my/notify @(rf/subscribe [:rf.causa/selected-fx-id]))))))
+
+(deftest clear-fx-selection-drops-selection
+  (testing ":rf.causa/clear-fx-selection dissocs the selected fx-id"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-fx-id :my/notify])
+      (rf/dispatch-sync [:rf.causa/clear-fx-selection])
+      (is (nil? @(rf/subscribe [:rf.causa/selected-fx-id]))))))
+
+;; ---- (6) summary chips render -------------------------------------------
+
+(deftest summary-renders-one-chip-per-non-zero-outcome
+  (testing "the summary header renders one chip per outcome with a
+            non-zero row count"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-fxs!
+        {:a {:platforms #{:client}}
+         :b {:platforms #{:client}}})
+      ;; Both fxs :never-invoked — exactly one chip should render.
+      (let [tree  (effects/effects-view)
+            chips (find-all-by-testid-prefix tree "rf-causa-fx-summary-")]
+        (is (= 1 (count chips))
+            "one chip for the :never-invoked outcome")))))
+
+;; ---- (7) frame isolation ------------------------------------------------
+
+(deftest fx-selection-does-not-leak-into-default-frame
+  (testing "the panel's selection state lives on :rf/causa, never :rf/default"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-fx-id :my/notify]))
+    (let [causa-db   (frame/frame-app-db-value :rf/causa)
+          default-db (frame/frame-app-db-value :rf/default)]
+      (is (= :my/notify (:selected-fx-id causa-db))
+          "selection lands on Causa")
+      (is (nil? (:selected-fx-id default-db))
+          "selection did NOT leak into :rf/default"))))


### PR DESCRIPTION
## Summary

- New **Effects** panel for Causa (Phase 5 of the rf2-5aw5v Causa v1.0 epic). Per-fx slot inspection — every registered fx, outcome from latest trace event, invocation count, STUB indicator when an `:fx-overrides` redirect is active.
- Composite sub `:rf.causa/effects-data` folds `(rf/handlers :fx)` + the Causa trace buffer's fx-related slice (`:op-type :fx` plus the two `:rf.error/fx-*` categories plus `:rf.fx/skipped-on-platform`) into one row per registered fx via the JVM-portable helpers in `effects_helpers.cljc`.
- Five-outcome taxonomy (`:error` / `:overridden` / `:skipped` / `:ok` / `:never-invoked`) follows the spec/007-UX-IA.md §Colour-is-never-alone discipline used by Flows and Subscriptions — glyph + colour token + tooltip per outcome.

## Surface scope

- `tools/causa/src/day8/re_frame2_causa/panels/effects.cljs` — pure-hiccup view
- `tools/causa/src/day8/re_frame2_causa/panels/effects_helpers.cljc` — pure-data fold (JVM-runnable)
- `tools/causa/test/.../panels/effects_helpers_cljs_test.cljc` — 36 tests / 76 assertions
- `tools/causa/test/.../panels/effects_view_cljs_test.cljs` — CLJS wiring + view tests (registry installs, empty state, populated list, outcome badges, stub indicator, selection, frame isolation)
- `registry.cljs` — `:rf.causa/effects-data` composite + supporting subs/events (incl. `:rf.causa/set-registered-fxs-override-for-test` for the JVM-test path)
- `shell.cljs` — sidebar entry + canvas case, fenced by `;; ── effects panel begin/end ──` markers for rebase recovery in the parallel Causa panel dispatches in flight

## Test plan

- [x] `clojure -M:test` in `tools/causa/` (371 tests / 1037 assertions — full suite)
- [x] `npm run test:cljs` (1315 tests / 3446 assertions — node-runtime)
- [x] `npm run test:browser` (1315 tests / 3478 assertions — Playwright/Chromium)
- [x] `npm run test:elision` (production-bundle elision probe — pass)
- [x] `npm run test:bundle-isolation` (tools must not leak into prod bundles — pass)
- [x] `npm run test:examples` (every example builds + runs — pass)

Parent epic: rf2-5aw5v.