### PR TITLE
fix(conformance): rename :actor/spawn -> :actor/spawn-destroy to match spec vocabulary (rf2-mtq4h)

### DIFF
--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -103,7 +103,7 @@
     :routing/fragment
     :routing/blocking
     :routing/nav-token
-    :actor/spawn
+    :actor/spawn-destroy   ;; rf2-mtq4h — renamed from :actor/spawn to align with spec vocabulary
     :actor/invoke
     :actor/spawn-and-join
     :actor/system-id

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -62,7 +62,7 @@
     :routing/fragment
     :routing/blocking
     :routing/nav-token
-    :actor/spawn
+    :actor/spawn-destroy                               ;; rf2-mtq4h — renamed from :actor/spawn to align with spec vocabulary
     :actor/invoke
     :actor/spawn-and-join                              ;; rf2-6vmw / rf2-er0t
     :actor/system-id                                   ;; rf2-suue / rf2-ecv4

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -167,7 +167,7 @@ The conventions above describe the schema; the corpus itself shows what those ta
 |---|---|---|
 | `counter-inc-once.edn` | `#{:core/event-handler :core/sub}` | The simplest pattern-required-only fixture: a single event handler, one sub. Every conformant port runs this. |
 | `after-hierarchy.edn` | `#{:fsm/hierarchical :fsm/delayed-after}` | A parent compound state with an `:after` timer. Only ports that claim both hierarchical FSM and `:after` will run it. |
-| `spawn-from-action.edn` | `#{:fsm/flat :actor/spawn}` | Imperative spawn of a child actor from inside a transition action. Requires the actor-model spawn capability on top of flat FSMs. |
+| `spawn-from-action.edn` | `#{:fsm/flat :actor/spawn-destroy}` | Imperative spawn of a child actor from inside a transition action. Requires the actor-model spawn-destroy capability on top of flat FSMs. |
 | `flow-lifecycle-emits-traces.edn` | `#{:core/event-handler :flow/basic :flow/trace}` | The flow primitive emits its five lifecycle trace events. Requires the flow substrate and the flow-trace stream. |
 | `http-managed-get-success.edn` | `#{:core/event-handler :core/sub :core/fx :rf.http/managed}` | The managed-HTTP fx happy path. Builds on the core triad and adds the managed-HTTP capability from [Spec 014](../014-HTTPRequests.md). |
 

--- a/spec/conformance/fixtures/cross-actor-send.edn
+++ b/spec/conformance/fixtures/cross-actor-send.edn
@@ -20,7 +20,7 @@
 
 {:fixture/id           :machine/cross-actor-send
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:fsm/flat :actor/spawn}
+ :fixture/capabilities #{:fsm/flat :actor/spawn-destroy}
  :fixture/doc          "Cross-actor send via :fx. The sender's action returns a [:dispatch [:receiver [:ping]]] fx; verified by inspecting the sender's fx vector. The receiver's pure machine-transition for the inner [:ping] event produces the :received state — confirming the round-trip works as ordinary dispatch with no special substrate."
 
  :fixture/registry

--- a/spec/conformance/fixtures/destroy-clears-snapshot.edn
+++ b/spec/conformance/fixtures/destroy-clears-snapshot.edn
@@ -14,7 +14,7 @@
 
 {:fixture/id           :machine/destroy-clears-snapshot
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:fsm/flat :actor/spawn}
+ :fixture/capabilities #{:fsm/flat :actor/spawn-destroy}
  :fixture/doc          "An action returns :fx [[:rf.machine/destroy actor-id]]; pure machine-transition surfaces the destroy fx. The runtime's :rf.machine/destroy fx handler removes [:rf/machines actor-id] from app-db; here we verify the fx-emission half of that contract."
 
  :fixture/registry

--- a/spec/conformance/fixtures/destroy-machine-clears-system-id-index.edn
+++ b/spec/conformance/fixtures/destroy-machine-clears-system-id-index.edn
@@ -15,7 +15,7 @@
 
 {:fixture/id           :machine/destroy-machine-clears-system-id-index
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:fsm/flat :actor/spawn :actor/invoke :actor/system-id}
+ :fixture/capabilities #{:fsm/flat :actor/spawn-destroy :actor/invoke :actor/system-id}
  :fixture/doc          "Destroying a :system-id-bound machine clears [:rf/system-ids] and [:rf/machines <id>] atomically; emits :rf.machine/system-id-released."
 
  :fixture/registry

--- a/spec/conformance/fixtures/invoke-all-join-all-completes.edn
+++ b/spec/conformance/fixtures/invoke-all-join-all-completes.edn
@@ -24,7 +24,7 @@
 
 {:fixture/id           :machine/invoke-all-join-all-completes
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:fsm/flat :actor/spawn :actor/invoke :actor/spawn-and-join}
+ :fixture/capabilities #{:fsm/flat :actor/spawn-destroy :actor/invoke :actor/spawn-and-join}
  :fixture/doc          "Declarative :invoke-all spawn-and-join with :join :all desugars to entry-cascade :rf.machine/invoke-all-init + N :rf.machine/spawn fxs at registration time. Verifies the entry-side fx emission for the auth-flow worked example shape (3 parallel children)."
 
  :fixture/registry

--- a/spec/conformance/fixtures/invoke-all-join-any-fails-cancels.edn
+++ b/spec/conformance/fixtures/invoke-all-join-any-fails-cancels.edn
@@ -19,7 +19,7 @@
 
 {:fixture/id           :machine/invoke-all-join-any-fails-cancels
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:fsm/flat :actor/spawn :actor/invoke :actor/spawn-and-join}
+ :fixture/capabilities #{:fsm/flat :actor/spawn-destroy :actor/invoke :actor/spawn-and-join}
  :fixture/doc          "Exiting an :invoke-all-bearing state emits one :rf.machine/destroy fx whose args carry :rf/invoke-all true. The destroy-fx handler reads the join-state map at [:rf/spawned <parent> <invoke-id>] and tears each child down. Verifies the exit-side fx emission for the cancel-on-decision = true (default) path."
 
  :fixture/registry

--- a/spec/conformance/fixtures/invoke-all-n-of-cancels-extras.edn
+++ b/spec/conformance/fixtures/invoke-all-n-of-cancels-extras.edn
@@ -14,7 +14,7 @@
 
 {:fixture/id           :machine/invoke-all-n-of-cancels-extras
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:fsm/flat :actor/spawn :actor/invoke :actor/spawn-and-join}
+ :fixture/capabilities #{:fsm/flat :actor/spawn-destroy :actor/invoke :actor/spawn-and-join}
  :fixture/doc          "An :invoke-all with :join {:n 3} and 5 children desugars to one invoke-all-init fx + 5 spawn fxs on entry; the exit cascade emits ONE :rf.machine/destroy fx with :rf/invoke-all true (the runtime's destroy handler tears down all live :children). Verifies entry- and exit-side fx emission for the {:n N} join shape."
 
  :fixture/registry

--- a/spec/conformance/fixtures/invoke-spawn-on-entry-destroy-on-exit.edn
+++ b/spec/conformance/fixtures/invoke-spawn-on-entry-destroy-on-exit.edn
@@ -50,7 +50,7 @@
 
 {:fixture/id           :machine/invoke-spawn-on-entry-destroy-on-exit
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:fsm/flat :actor/spawn :actor/invoke}
+ :fixture/capabilities #{:fsm/flat :actor/spawn-destroy :actor/invoke}
  :fixture/doc          "Declarative :invoke on a state node desugars to entry/exit :rf.machine/spawn / :rf.machine/destroy fx at registration time. Verifies that entering the state emits :rf.machine/spawn with the declared spec, the :on-spawn callback updates the parent's :data with the spawned id, and exiting the state emits :rf.machine/destroy with the recorded id."
 
  :fixture/registry

--- a/spec/conformance/fixtures/machine-actor-isolation.edn
+++ b/spec/conformance/fixtures/machine-actor-isolation.edn
@@ -17,7 +17,7 @@
 
 {:fixture/id           :machine/actor-isolation
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:fsm/flat :actor/spawn}
+ :fixture/capabilities #{:fsm/flat :actor/spawn-destroy}
  :fixture/doc          "Two machines coexist; events to one don't perturb the other. Pure machine-transition is parameterised by (machine, snapshot, event) — by construction each call's snapshot is the only state mutated. The fixture confirms the contract by interleaving transitions on two distinct machines and asserting each ends in its own expected snapshot."
 
  :fixture/registry

--- a/spec/conformance/fixtures/spawn-from-action.edn
+++ b/spec/conformance/fixtures/spawn-from-action.edn
@@ -17,7 +17,7 @@
 
 {:fixture/id           :machine/spawn-from-action
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:fsm/flat :actor/spawn}
+ :fixture/capabilities #{:fsm/flat :actor/spawn-destroy}
  :fixture/doc          "An action returns :fx [[:rf.machine/spawn {...}]]; pure machine-transition surfaces the spawn fx in the result. Confirms imperative spawn from an action emits the same shape the declarative :invoke desugar produces."
 
  :fixture/registry

--- a/spec/conformance/fixtures/spawn-on-spawn-callback.edn
+++ b/spec/conformance/fixtures/spawn-on-spawn-callback.edn
@@ -23,7 +23,7 @@
 
 {:fixture/id           :machine/spawn-on-spawn-callback
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:fsm/flat :actor/spawn :actor/invoke}
+ :fixture/capabilities #{:fsm/flat :actor/spawn-destroy :actor/invoke}
  :fixture/doc          "The :on-spawn callback receives (data, spawned-id) and returns new data. Verifies the callback fires with the just-allocated actor-id by recording the id in :data under a distinct key."
 
  :fixture/registry

--- a/spec/conformance/fixtures/spawn-tracked-without-data-pending.edn
+++ b/spec/conformance/fixtures/spawn-tracked-without-data-pending.edn
@@ -34,7 +34,7 @@
 
 {:fixture/id           :machine/spawn-tracked-without-data-pending
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:fsm/flat :actor/spawn :actor/invoke}
+ :fixture/capabilities #{:fsm/flat :actor/spawn-destroy :actor/invoke}
  :fixture/doc          "rf2-t07u (Option A revised) — the runtime tracks each declarative-:invoke spawn-id at [:rf/spawned <parent-id> <invoke-id>]. The fixture's machine omits :on-spawn entirely; the destroy fx still resolves the actor on state-exit because the runtime no longer reads :data :pending."
 
  :fixture/registry

--- a/spec/conformance/fixtures/spawn-with-system-id-then-lookup-resolves.edn
+++ b/spec/conformance/fixtures/spawn-with-system-id-then-lookup-resolves.edn
@@ -14,7 +14,7 @@
 
 {:fixture/id           :machine/spawn-with-system-id-then-lookup-resolves
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:fsm/flat :actor/spawn :actor/invoke :actor/system-id}
+ :fixture/capabilities #{:fsm/flat :actor/spawn-destroy :actor/invoke :actor/system-id}
  :fixture/doc          "Spawn with :system-id binds the per-frame reverse index; snapshot lives at [:rf/machines <spawned-id>]; lookup by name resolves."
 
  :fixture/registry

--- a/spec/conformance/fixtures/spawn-without-system-id-leaves-index-empty.edn
+++ b/spec/conformance/fixtures/spawn-without-system-id-leaves-index-empty.edn
@@ -10,7 +10,7 @@
 
 {:fixture/id           :machine/spawn-without-system-id-leaves-index-empty
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:fsm/flat :actor/spawn :actor/invoke :actor/system-id}
+ :fixture/capabilities #{:fsm/flat :actor/spawn-destroy :actor/invoke :actor/system-id}
  :fixture/doc          "An :invoke that omits :system-id does not allocate [:rf/system-ids] in the spawning frame's app-db."
 
  :fixture/registry

--- a/spec/conformance/fixtures/system-id-collision-warns-and-rebinds.edn
+++ b/spec/conformance/fixtures/system-id-collision-warns-and-rebinds.edn
@@ -15,7 +15,7 @@
 
 {:fixture/id           :machine/system-id-collision-warns-and-rebinds
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:fsm/flat :actor/spawn :actor/system-id}
+ :fixture/capabilities #{:fsm/flat :actor/spawn-destroy :actor/system-id}
  :fixture/doc          "Re-spawning under an already-bound :system-id emits :rf.error/system-id-collision and rebinds the slot (last-write-wins)."
 
  :fixture/registry


### PR DESCRIPTION
## Summary

Spec corpus and conformance fixture corpus had diverged on the actor capability vocabulary: spec/005-StateMachines.md, spec/Implementor-Checklist.md, and spec/conformance/README.md all name the imperative-spawn/destroy capability `:actor/spawn-destroy` (three normative enumerations), but 14 conformance fixtures plus both conformance runners tagged `:actor/spawn`. An AI port author following the spec would declare `:actor/spawn-destroy` in their harness manifest and silently skip every spawn fixture (subset check fails).

Per rf2-mtq4h Mike chose path (a) - spec wins. This PR renames the fixture tag + claim-set vocabulary:

- 14 fixture EDNs updated in `:fixture/capabilities` (tags only — fixture filenames + `:fixture/id` slugs unchanged):
  - `cross-actor-send`, `destroy-clears-snapshot`, `destroy-machine-clears-system-id-index`
  - `invoke-all-join-all-completes`, `invoke-all-join-any-fails-cancels`, `invoke-all-n-of-cancels-extras`
  - `invoke-spawn-on-entry-destroy-on-exit`, `machine-actor-isolation`
  - `spawn-from-action`, `spawn-on-spawn-callback`, `spawn-tracked-without-data-pending`
  - `spawn-with-system-id-then-lookup-resolves`, `spawn-without-system-id-leaves-index-empty`
  - `system-id-collision-warns-and-rebinds`
- `implementation/core/test/re_frame/conformance_test.clj` (JVM) claim-set: `:actor/spawn` → `:actor/spawn-destroy`
- `implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs` (CLJS) claim-set: same
- `spec/conformance/README.md` worked-example row for `spawn-from-action.edn` updated to match.

Spec docs (005, Implementor-Checklist, conformance/README §Capability tagging) already used `:actor/spawn-destroy` — no spec edit needed; the fixtures and runners now agree with the spec.

The README's `:core/trace` / `:core/frame` example mentions (which no fixture currently carries) are preserved per Mike's sub-decision and handled in a separate follow-on bead.

## Test plan

- [x] JVM conformance suite (`clojure -M:test -n re-frame.conformance-test`): 111 fixtures total, 111 runnable, 111 passed, 0 failed, 0 skipped. All 14 affected fixtures appear in the pass list.
- [x] CLJS conformance suite (`npm run test:cljs`): 1263 tests / 3337 assertions, 0 failures, 0 errors. Conformance-corpus-cljs: 111 fixtures total, 111 runnable, 111 passed, 0 failed, 0 skipped. All 14 affected fixtures appear in the pass list.
- [x] Repo-wide `:actor/spawn(?!-)` grep returns no matches outside `.beads/issues.jsonl`.