### PR TITLE
fix(frame): flatten frame-meta return to canonical :rf/frame-meta shape (rf2-p6f0h)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_cross_spec_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_cross_spec_cljs_test.cljs
@@ -106,9 +106,9 @@
   "#4 Machines under SSR (allowed-subset) — under Helix."
   (rf/reg-frame :req {:preset :ssr-server})
   (let [meta (rf/frame-meta :req)]
-    (is (= :server (get-in meta [:config :platform]))
-        ":ssr-server preset sets :platform :server on the frame config")
-    (is (= :rf.error/server-projection (get-in meta [:config :on-error]))
+    (is (= :server (:platform meta))
+        ":ssr-server preset sets :platform :server on the frame metadata")
+    (is (= :rf.error/server-projection (:on-error meta))
         ":ssr-server preset wires :on-error to :rf.error/server-projection"))
   (rf/reg-machine :ssr/timed
     {:initial :idle

--- a/implementation/adapters/reagent/test/re_frame/cross_spec_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/cross_spec_cljs_test.cljs
@@ -181,9 +181,9 @@
    place of `:rf.machine.timer/scheduled`."
   (rf/reg-frame :req {:preset :ssr-server})
   (let [meta (rf/frame-meta :req)]
-    (is (= :server (get-in meta [:config :platform]))
-        ":ssr-server preset sets :platform :server on the frame config")
-    (is (= :rf.error/server-projection (get-in meta [:config :on-error]))
+    (is (= :server (:platform meta))
+        ":ssr-server preset sets :platform :server on the frame metadata")
+    (is (= :rf.error/server-projection (:on-error meta))
         ":ssr-server preset wires :on-error to :rf.error/server-projection"))
   ;; Register a machine whose `:loading` state declares an `:after` table.
   ;; The transition `:idle → :loading` enters an `:after`-bearing state;

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_cross_spec_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_cross_spec_cljs_test.cljs
@@ -106,9 +106,9 @@
   "#4 Machines under SSR (allowed-subset) — under UIx."
   (rf/reg-frame :req {:preset :ssr-server})
   (let [meta (rf/frame-meta :req)]
-    (is (= :server (get-in meta [:config :platform]))
-        ":ssr-server preset sets :platform :server on the frame config")
-    (is (= :rf.error/server-projection (get-in meta [:config :on-error]))
+    (is (= :server (:platform meta))
+        ":ssr-server preset sets :platform :server on the frame metadata")
+    (is (= :rf.error/server-projection (:on-error meta))
         ":ssr-server preset wires :on-error to :rf.error/server-projection"))
   (rf/reg-machine :ssr/timed
     {:initial :idle

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -61,13 +61,24 @@
       f)))
 
 (defn frame-meta
-  "Per Spec 002 §The public registrar query API: return the public metadata
-  for a frame (config, lifecycle info, override maps)."
+  "Per Spec 002 §The public registrar query API and Spec-Schemas
+  §`:rf/frame-meta`: return the effective metadata map for a frame as a
+  flat shape — `:id` plus the post-preset-expansion user-supplied
+  metadata keys (`:preset`, `:fx-overrides`, `:drain-depth`, `:doc`,
+  `:tags`, `:url-bound?`, `:platform`, `:on-error`, `:ssr`, …) merged
+  with the lifecycle fields (`:created-at`, `:destroyed?`, `:listeners`).
+
+  Per Spec 002 §Frame presets, the `:preset` key is preserved verbatim
+  on the returned map so tools can inspect which preset was applied; the
+  expansion keys appear at the top level alongside it. The internal
+  storage groupings (`:config` / `:lifecycle` on the frame record) are
+  flattened away — tools must not depend on the registry's storage
+  organisation, only on the canonical `:rf/frame-meta` shape."
   [id]
   (when-let [f (frame id)]
-    {:id        (:id f)
-     :config    (:config f)
-     :lifecycle (:lifecycle f)}))
+    (merge (:config f)
+           (:lifecycle f)
+           {:id (:id f)})))
 
 (defn frame-ids
   "All registered, non-destroyed frame ids.

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -605,7 +605,9 @@
           "frame-ids excludes ids that were never registered"))))
 
 (deftest frame-meta-round-trip
-  (testing "(rf/frame-meta id) returns the registered metadata map shape"
+  (testing "(rf/frame-meta id) returns the canonical flat :rf/frame-meta shape
+            per Spec-Schemas §:rf/frame-meta — user-supplied metadata,
+            preset-expansion keys, and lifecycle fields all at the top level"
     (rf/reg-frame :tenants/acme {:doc          "acme tenant"
                                  :preset       :default
                                  :fx-overrides {:rf.http/managed
@@ -614,17 +616,40 @@
       (is (map? m) "frame-meta returns a map")
       (is (= :tenants/acme (:id m))
           ":id reflects the registered frame id")
-      (is (map? (:config m))
-          ":config slot is the metadata map merged into the frame record")
-      (is (= "acme tenant" (get-in m [:config :doc]))
-          "user-supplied :doc round-trips through :config")
+      (is (= "acme tenant" (:doc m))
+          "user-supplied :doc is at the top level of the flat shape")
+      (is (= :default (:preset m))
+          ":preset is preserved verbatim per Spec 002 §Frame presets")
       (is (= {:rf.http/managed :rf.http/managed-canned-success}
-             (get-in m [:config :fx-overrides]))
-          ":fx-overrides round-trips through :config")
-      (is (map? (:lifecycle m))
-          ":lifecycle slot carries the frame's lifecycle map")
-      (is (number? (get-in m [:lifecycle :created-at]))
-          ":lifecycle :created-at is the host clock at reg-frame time"))))
+             (:fx-overrides m))
+          ":fx-overrides is at the top level of the flat shape")
+      (is (number? (:created-at m))
+          ":created-at is the host clock at reg-frame time — flat, not nested
+           under any :lifecycle sub-map")
+      (is (false? (:destroyed? m))
+          ":destroyed? is at the top level of the flat shape")
+      (is (nil? (:config m))
+          "no internal :config grouping leaks through — flat shape only")
+      (is (nil? (:lifecycle m))
+          "no internal :lifecycle grouping leaks through — flat shape only"))))
+
+(deftest frame-meta-preset-expansion-flat-shape
+  (testing "(rf/frame-meta id) on a preset frame returns the preset expansion
+            merged flat per Spec 002 §Expansion algorithm worked example:
+              {:preset       :test
+               :fx-overrides {:rf.http/managed :rf.http/managed-canned-success}
+               :drain-depth  100}"
+    (rf/reg-frame :test/auth-flow {:preset :test})
+    (let [m (rf/frame-meta :test/auth-flow)]
+      (is (= :test (:preset m))
+          ":preset key preserved verbatim")
+      (is (= {:rf.http/managed :rf.http/managed-canned-success}
+             (:fx-overrides m))
+          ":test preset's :fx-overrides expansion lifted to top level")
+      (is (= 100 (:drain-depth m))
+          ":test preset's :drain-depth expansion lifted to top level")
+      (is (= :test/auth-flow (:id m))
+          ":id reflects the registered frame id"))))
 
 (deftest frame-meta-nonexistent-is-nil
   (testing "(rf/frame-meta id) on an unregistered id returns nil cleanly

--- a/implementation/core/test/re_frame/hot_reload_test.clj
+++ b/implementation/core/test/re_frame/hot_reload_test.clj
@@ -212,10 +212,10 @@
             "machine snapshot is preserved across frame re-registration"))
       ;; Metadata was updated.
       (is (= "v2 metadata"
-             (get-in (rf/frame-meta :tenant) [:config :doc]))
+             (:doc (rf/frame-meta :tenant)))
           ":doc reflects the v2 metadata")
-      (is (= 2 (get-in (rf/frame-meta :tenant) [:config :version]))
-          "new :version key is present in the merged config")
+      (is (= 2 (:version (rf/frame-meta :tenant)))
+          "new :version key is present in the merged metadata")
       ;; The machine still progresses against its preserved snapshot.
       (rf/dispatch-sync [:traffic-light [:tick]] {:frame :tenant})
       (let [final-snapshot (get-in (rf/get-frame-db :tenant)

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx.cljc
@@ -785,7 +785,7 @@
             ;; fx handlers to address the runtime-owned [:rf/spawned
             ;; <parent-id> <invoke-id>] registry slot).
             frame-id   (or frame :rf/default)
-            platform   (or (get-in (frame/frame-meta frame-id) [:config :platform])
+            platform   (or (:platform (frame/frame-meta frame-id))
                            :client)
             machine    (assoc machine
                               :rf/frame     frame-id

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -861,7 +861,7 @@ response with no body."
   "Read the :ssr config's :public-error-id for a frame, falling back
   to :rf.ssr/default-error-projector when no config / no id."
   [frame-id]
-  (or (get-in (frame/frame-meta frame-id) [:config :ssr :public-error-id])
+  (or (get-in (frame/frame-meta frame-id) [:ssr :public-error-id])
       :rf.ssr/default-error-projector))
 
 (defn- frame-dev-error-detail?
@@ -870,7 +870,7 @@ response with no body."
   :details key with the raw trace event."
   [frame-id]
   (boolean
-    (get-in (frame/frame-meta frame-id) [:config :ssr :dev-error-detail?])))
+    (get-in (frame/frame-meta frame-id) [:ssr :dev-error-detail?])))
 
 (defn project-error
   "Resolve the active projector for the given frame and apply it to
@@ -931,7 +931,7 @@ response with no body."
   "True when the frame's :platform is :server. The error-projection
   hook only fires for server frames."
   [frame-id]
-  (= :server (get-in (frame/frame-meta frame-id) [:config :platform])))
+  (= :server (:platform (frame/frame-meta frame-id))))
 
 (defn- candidate-frame-for-error
   "Select the frame to project against for a trace-event. Prefer the

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -270,9 +270,10 @@
 
 (defn variant-frame?
   "True iff `frame-id` is a variant frame (was allocated via
-  `allocate!`). Reads the frame's `:config :rf/story?` slot."
+  `allocate!`). Reads the frame's `:rf/story?` slot on its frame-meta
+  (per Spec-Schemas §`:rf/frame-meta` — flat shape)."
   [frame-id]
-  (true? (get-in (rf/frame-meta frame-id) [:config :rf/story?])))
+  (true? (:rf/story? (rf/frame-meta frame-id))))
 
 (defn variant-frames
   "Return every registered variant frame id. Stage 4's UI shell uses

--- a/tools/story/test/re_frame/story_fx_stubs_test.clj
+++ b/tools/story/test/re_frame/story_fx_stubs_test.clj
@@ -119,7 +119,7 @@
        :events     []})
     (let [r (async/deref-blocking (story/run-variant :story.fxstub-frame/v) 5000)]
       (is (= :ready (:lifecycle r)))
-      (let [overrides (-> (rf/frame-meta :story.fxstub-frame/v) :config :fx-overrides)]
+      (let [overrides (:fx-overrides (rf/frame-meta :story.fxstub-frame/v))]
         (is (map? overrides))
         (is (contains? overrides :http)
             "the :http fx is redirected to the stub event")))

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -414,9 +414,9 @@
     (let [r (story/resolve-decorators :story.fm/v)]
       (frames/allocate! :story.fm/v r)
       (let [m (rf/frame-meta :story.fm/v)]
-        (is (true?              (get-in m [:config :rf/story?])))
-        (is (= :story.fm/v      (get-in m [:config :rf/variant])))
-        (is (= :story           (get-in m [:config :preset]))))
+        (is (true?              (:rf/story? m)))
+        (is (= :story.fm/v      (:rf/variant m)))
+        (is (= :story           (:preset m))))
       (is (contains? (story/variant-frames) :story.fm/v))
       (is (true? (story/variant-frame? :story.fm/v)))
       (frames/destroy! :story.fm/v))))


### PR DESCRIPTION
## Summary

`(frame-meta id)` was returning the internal storage groupings as `{:id :config :lifecycle}`, defeating Spec 002 §Frame presets' merge (\"the effective metadata is what `(frame-meta <id>)` returns\") and conflicting with both Spec-Schemas §`:rf/frame-meta` and the Spec 002:268-273 worked example, which pin a FLAT map shape — `:id` plus the post-preset-expansion user metadata keys (`:preset`, `:fx-overrides`, `:drain-depth`, `:doc`, `:tags`, `:url-bound?`, `:platform`, `:on-error`, `:ssr`, …) plus lifecycle fields (`:created-at`, `:destroyed?`, `:listeners`).

- Spec-Schemas wins per Mike's decision on rf2-p6f0h. `frame-meta` now `merge`s `:config` + `:lifecycle` + `{:id ...}` into one flat map. The internal frame-record storage shape is unchanged — only the public projection changes.
- 7 production / test caller sites rewritten to read flat keys: SSR (`[:config :ssr ...]` → `[:ssr ...]`, `[:config :platform]` → `:platform`); machines lifecycle\_fx (`[:config :platform]` → `:platform`); story frames introspection (`[:config :rf/story?]` → `:rf/story?`); plus 5 test sites across `hot_reload_test`, `story_fx_stubs_test`, `story_runtime_test`, and the 3 substrate cross-spec suites (reagent, helix, uix).
- `frame-meta-round-trip` updated to assert the canonical flat shape end-to-end (`:doc`, `:preset`, `:fx-overrides`, `:created-at`, `:destroyed?` all at the top level; no `:config` / `:lifecycle` leak). New positive test `frame-meta-preset-expansion-flat-shape` pins the Spec 002:268-273 worked example for the `:test` preset.

## Test plan

- [x] `clojure -M:test` from `implementation/core` — 355 tests / 1973 assertions / 0 failures
- [x] `clojure -M:test` from `implementation/ssr` — 31 tests / 118 assertions / 0 failures
- [x] `clojure -M:test` from `implementation/machines` — 119 tests / 332 assertions / 0 failures
- [x] `clojure -M:test` from `tools/story` — 259 tests / 726 assertions / 0 failures
- [x] `npm run test:cljs` (node-runtime CLJS) — 1365 tests / 3587 assertions / 0 failures
- [x] New positive test asserts the Spec 002:268-273 flat-shape worked example