### PR TITLE
feat(examples): state_machine_walkthrough adopts :tags (ch.08 companion) (rf2-eo0y4)

### DIFF
--- a/examples/reagent/state_machine_walkthrough/core.cljc
+++ b/examples/reagent/state_machine_walkthrough/core.cljc
@@ -90,7 +90,11 @@
                               :action :clear-error}}}
 
     :submitting
-    {:entry :issue-request
+    ;; :auth/busy tag — views query (rf/has-tag? :auth.login/flow
+    ;; :auth/busy) to disable inputs and re-label the submit button
+    ;; while the request is in flight (ch.08 §State tags).
+    {:tags  #{:auth/busy}
+     :entry :issue-request
      :on    {:auth.login/success {:target :authed
                                   :action :store-session}
              :auth.login/failure [{:target :error-shown
@@ -103,8 +107,18 @@
     {:on {:auth.login/dismiss {:target :idle}
           :auth.login/submit  {:target :submitting}}}
 
-    :authed      {:meta {:terminal? true}}
-    :locked-out  {:meta {:terminal? true}}}})
+    :authed
+    ;; :auth/authenticated tag — views query
+    ;; (rf/has-tag? :auth.login/flow :auth/authenticated) once the
+    ;; flow reaches this terminal state.
+    {:tags #{:auth/authenticated}
+     :meta {:terminal? true}}
+
+    :locked-out
+    ;; :auth/locked tag — root-view swaps the form for the locked-out
+    ;; panel when (rf/has-tag? :auth.login/flow :auth/locked) is true.
+    {:tags #{:auth/locked}
+     :meta {:terminal? true}}}})
 
 ;; ============================================================================
 ;; FX — chapter §Wiring a machine into the rest of re-frame
@@ -135,19 +149,18 @@
 ;; SUBSCRIPTIONS — chapter §Reading a machine: sub-machine
 ;; ============================================================================
 
+;; The machine snapshot lives at [:rf/machines :auth.login/flow] (per
+;; Spec 005). These named subs project out the convenient pieces. The
+;; "in :submitting?" / "in :authed?" / "in :locked-out?" predicates
+;; moved to the `rf/has-tag?` queries in views.cljs (ch.08 §State
+;; tags) — discriminating on the machine's runtime-projected `:tags`
+;; set decouples view code from individual state-keyword identity.
+
 (rf/reg-sub :auth.login/state
   (fn [db _] (get-in db [:rf/machines :auth.login/flow :state])))
 
 (rf/reg-sub :auth.login/error
   (fn [db _] (get-in db [:rf/machines :auth.login/flow :data :error])))
-
-(rf/reg-sub :auth.login/submitting?
-  :<- [:auth.login/state]
-  (fn [state _] (= :submitting state)))
-
-(rf/reg-sub :auth.login/authenticated?
-  :<- [:auth.login/state]
-  (fn [state _] (= :authed state)))
 
 ;; ============================================================================
 ;; TEST STUBS — per-test wrappers that delegate to the framework-shipped

--- a/examples/reagent/state_machine_walkthrough/views.cljs
+++ b/examples/reagent/state_machine_walkthrough/views.cljs
@@ -24,30 +24,33 @@
 
 (reg-view ^{:doc "The login form view. Captures email + password in a Reagent
                   atom across renders (Form-2 outer/inner shape) and dispatches
-                  :auth.login/flow → :auth.login/submit on submit."}
+                  :auth.login/flow → :auth.login/submit on submit.
+
+                  View-side discriminators read the machine's runtime-projected
+                  `:tags` set (ch.08 §State tags) via `rf/has-tag?`, not boolean
+                  state-predicate subs."}
           login-form []
   (let [state (atom {:email "" :password ""})]
     (fn []
-      (let [submitting? @(subscribe [:auth.login/submitting?])
-            err         @(subscribe [:auth.login/error])
-            login-state @(subscribe [:auth.login/state])
-            locked?     (= :locked-out login-state)]
+      (let [busy?   @(rf/has-tag? :auth.login/flow :auth/busy)
+            locked? @(rf/has-tag? :auth.login/flow :auth/locked)
+            err     @(subscribe [:auth.login/error])]
         [:form.login-form
          {:on-submit (fn [e]
                        (.preventDefault e)
-                       (when-not (or submitting? locked?)
+                       (when-not (or busy? locked?)
                          (dispatch [:auth.login/flow
                                     [:auth.login/submit @state]])))}
          [:input  {:type        "email"
                    :placeholder "Email"
-                   :disabled    (or submitting? locked?)
+                   :disabled    (or busy? locked?)
                    :on-change   #(swap! state assoc :email (.. % -target -value))}]
          [:input  {:type        "password"
                    :placeholder "Password"
-                   :disabled    (or submitting? locked?)
+                   :disabled    (or busy? locked?)
                    :on-change   #(swap! state assoc :password (.. % -target -value))}]
-         [:button {:type "submit" :disabled (or submitting? locked?)}
-          (if submitting? "Signing in…" "Sign in")]
+         [:button {:type "submit" :disabled (or busy? locked?)}
+          (if busy? "Signing in…" "Sign in")]
          (when (and err (not locked?))
            [:div.error-row
             [:p.error err]
@@ -73,7 +76,7 @@
    [:p "Three failed attempts. Contact support to unlock."]])
 
 (reg-view root-view []
-  (let [locked? (= :locked-out @(subscribe [:auth.login/state]))]
+  (let [locked? @(rf/has-tag? :auth.login/flow :auth/locked)]
     [:div.app
      [:h1 "State-machines walkthrough — login lockout"]
      [status-banner]


### PR DESCRIPTION
## Summary

The `state_machine_walkthrough` example is the literal runnable companion to `docs/guide/08-state-machines.md`, which teaches `:tags` as the canonical view-side discriminator pattern. The example was lagging — its three view-level state reads went through boolean-discriminator subs and a direct `(= :locked-out state)` comparison instead.

This PR applies the chapter's vocabulary on the machine spec and rewrites the three view-side discriminator reads as `rf/has-tag?` queries.

## Changes

**`examples/reagent/state_machine_walkthrough/core.cljc`** — add `:tags` to the three relevant states:

| state         | tag                      |
| ------------- | ------------------------ |
| `:submitting` | `#{:auth/busy}`          |
| `:authed`     | `#{:auth/authenticated}` |
| `:locked-out` | `#{:auth/locked}`        |

Also drop the now-orphaned `:auth.login/submitting?` and `:auth.login/authenticated?` boolean-discriminator subs — a ch.08 companion that ships dead boolean subs would mislead readers.

**`examples/reagent/state_machine_walkthrough/views.cljs`** — rewrite the three view-level discriminator reads:

- `login-form`: `submitting?` + `locked?` → `(rf/has-tag? :auth.login/flow :auth/busy)` + `(rf/has-tag? :auth.login/flow :auth/locked)`
- `root-view`: `(= :locked-out @(subscribe [:auth.login/state]))` → `@(rf/has-tag? :auth.login/flow :auth/locked)`

`status-banner` keeps reading `:auth.login/state` directly — it renders the state name, it is not a discriminator.

## Out of scope

- `core.cljc` headless tests stay state-based: they exercise the transition table, not view-side projection.
- The Playwright spec is unchanged — it watches `strong.state` which still renders `:auth.login/state` by name.

## Test plan

- [x] `clojure -M:test --var re-frame.examples-test/state-machine-walkthrough-runs-headless` — passes (0 failures, 0 errors)
- [x] `shadow-cljs compile examples/state-machine-walkthrough` — clean (0 warnings)
- [x] `npm run test:examples` — full Playwright suite passes, including `state-machines walkthrough (lockout) PASS`

## Bead

`rf2-eo0y4` (P3, filed from rf2-zuwz audit).