### PR TITLE
feat(mcp): default-suppress :sensitive? traces per spec/009 (rf2-zq0n1)

### DIFF
--- a/tools/causa-mcp/spec/Principles.md
+++ b/tools/causa-mcp/spec/Principles.md
@@ -199,6 +199,53 @@ agents through Chrome MCP's `evaluate_script` (which loses the
 
 Captured as Lock #5 in [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md).
 
+## Privacy: default-drop `:sensitive?` events at the MCP boundary
+
+Per [spec/009 §Privacy / sensitive data in traces](../../../spec/009-Instrumentation.md#privacy--sensitive-data-in-traces)
+(rf2-a32kd):
+
+> Framework-published listener integrations (Sentry/Honeybadger
+> forwarders, pair2 server, Causa-MCP server) MUST default-suppress
+> `:sensitive? true`.
+
+This is a normative MUST for Causa-MCP. When implementation lands,
+every tool that surfaces trace-stream-shaped payloads — the canonical
+list is `get-trace-buffer`, `subscribe`, and any tool whose return
+includes raw `:rf/trace-event` items or epoch-records carrying the
+flag (`get-epoch-history`, `get-causality-graph` when it walks raw
+traces) — MUST apply the default-suppress filter at the MCP boundary
+before any data crosses into the agent surface.
+
+The contract, identical to `tools/pair2-mcp/`'s implementation
+(rf2-zq0n1) and `tools/story-mcp/`'s `re-frame.story-mcp.sensitive`
+helper:
+
+- **Default**: events with `:sensitive? true` at the top level are
+  dropped. Dropped count surfaces as `:dropped-sensitive` on the
+  result (or on each `notifications/progress` payload for streaming
+  tools) when non-zero.
+- **Opt-in**: per-call `:include-sensitive? true` MCP arg disables
+  the gate. The arg name is fixed cross-server (pair2-mcp + story-mcp
+  + causa-mcp) so an agent that learns the slot on one server gets
+  the same slot on the others.
+- **Scope**: only the trace-stream surface. Mutating ops (`dispatch`,
+  `restore-epoch`, `reset-frame-db`) and read-mostly per-frame state
+  ops (`get-app-db`, `app-db-diff`, `get-machine-snapshot`) don't
+  carry `:sensitive?` stamps — payload redaction in those slots is
+  the `with-redacted` interceptor's job, not the forwarder's.
+
+The wiring pattern (when implementation lands) mirrors
+[`tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs`](../../pair2-mcp/src/re_frame_pair2_mcp/tools.cljs)'s
+`strip-sensitive` helper + `:include-sensitive?` arg + descriptor
+slot on each affected tool. Cross-server symmetry is load-bearing —
+an agent that knows the slot on pair2-mcp gets the same slot on
+causa-mcp.
+
+The trust boundary is the MCP stdio channel: data that crosses it
+reaches the agent host, and from there potentially the LLM provider.
+The `:sensitive?` flag is the registrar's "do not ship this
+unredacted across that boundary" signal; Causa-MCP honours it.
+
 ## Bash-shim back-compat is *not* a goal
 
 Unlike pair2-mcp (which mirrors a pre-existing bash-shim

--- a/tools/pair2-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/pair2-mcp/spec/003-Tool-Catalogue.md
@@ -176,6 +176,7 @@ that axis"):
 | `:dispatch-id`   | `(get-in ev [:tags :dispatch-id])`                                |
 | `:since-ms`      | `(> (:time ev) since-ms)` — strict-greater-than host-clock ms.    |
 | `:between`       | `[t0 t1]` — `(<= t0 (:time ev) t1)` host-clock ms.                |
+| `:sensitive?`    | `(:sensitive? ev)` — boolean. **Default forwarder posture:** events with `:sensitive? true` are dropped at the MCP boundary before any data reaches the agent surface (per [spec/009 §Privacy / sensitive data](../../../spec/009-Instrumentation.md#privacy--sensitive-data-in-traces)). The runtime stamps the flag on every trace event emitted inside a `:sensitive? true` registration's handler scope. Opt back in per-call with `include-sensitive? true` (an MCP tool arg on `trace-window`, `watch-epochs`, `snapshot`, `subscribe`). Dropped count surfaces as `:dropped-sensitive` on the result / progress payload when non-zero. |
 
 For `topic :epoch`, the filter map mirrors `epoch-matches?` (same
 vocab `watch-epochs` already accepts):
@@ -211,6 +212,13 @@ vocab `watch-epochs` already accepts):
   client cancels.
 - `max-events` (integer, default `0` = unbounded) — terminate after
   this many events have been delivered.
+- `include-sensitive?` (boolean, default `false`) — opt back in to
+  forwarding events carrying `:sensitive? true`. Per [spec/009
+  §Privacy](../../../spec/009-Instrumentation.md#privacy--sensitive-data-in-traces)
+  the forwarder default-drops these events at the MCP boundary; pass
+  `true` to disable the gate for this subscription. Dropped count
+  surfaces as `:dropped-sensitive` on each progress payload (when
+  non-zero) and the final summary.
 - `build` (string, default `"app"`) — shadow-cljs build id.
 
 ### Returns

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -128,6 +128,51 @@
     (ok-text {:ok? false :reason fallback-reason :message (.-message err)})))
 
 ;; ---------------------------------------------------------------------------
+;; :sensitive? default-suppress (per spec/009 §Privacy / sensitive data).
+;;
+;; Spec 009 mandates that framework-published forwarders — Sentry /
+;; Honeybadger, pair2 server, Causa-MCP — MUST default-drop trace events
+;; whose registration was declared `:sensitive? true`. The runtime
+;; stamps `:sensitive? true` at the top level of every emitted trace
+;; event inside such a registration's handler scope; an event with no
+;; such stamp (or `:sensitive? false`) is fine to forward.
+;;
+;; Opt-in escape hatch: an MCP arg of `:include-sensitive? true` (on
+;; any read/stream tool that surfaces trace-like data) removes the
+;; filter for that call. The default is off — apps that want sensitive
+;; cascades visible to the pair tool configure the policy explicitly.
+;; ---------------------------------------------------------------------------
+
+(defn- include-sensitive?
+  "True iff the caller has opted in to forwarding `:sensitive? true`
+  events for this call. Default off."
+  [args]
+  (boolean (arg args :include-sensitive?)))
+
+(defn- sensitive-event?
+  "Does this event carry the top-level `:sensitive? true` stamp? The
+  filter is conservative — only the literal `true` value drops; any
+  other value (including the runtime's possible string-coercion via an
+  ill-behaved transport) passes through. The `:rf/trace-event` schema
+  (per spec/009) types `:sensitive?` as a boolean."
+  [ev]
+  (and (map? ev)
+       (true? (:sensitive? ev))))
+
+(defn- strip-sensitive
+  "Remove `:sensitive? true` events from `events` unless the caller opted
+  in. Returns `[kept dropped-count]`. Cheap on the common path
+  (no sensitive events ⇒ identical-vector return + zero drop count)."
+  [events include?]
+  (cond
+    include?            [events 0]
+    (empty? events)     [events 0]
+    :else
+    (let [kept (filterv (complement sensitive-event?) events)
+          n    (- (count events) (count kept))]
+      [kept n])))
+
+;; ---------------------------------------------------------------------------
 ;; Tool: discover-app — verify the stack and probe the preloaded runtime.
 ;; ---------------------------------------------------------------------------
 
@@ -230,19 +275,22 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- trace-window-tool [conn args]
-  (let [ms       (or (arg args :ms) 1000)
-        build-id (arg-build args)
-        frame    (some-> (arg args :frame) keyword)
-        form     (if frame
-                   (str "(re-frame-pair2.runtime/epochs-in-last-ms " ms " " (pr-str frame) ")")
-                   (str "(re-frame-pair2.runtime/epochs-in-last-ms " ms ")"))]
+  (let [ms        (or (arg args :ms) 1000)
+        build-id  (arg-build args)
+        frame     (some-> (arg args :frame) keyword)
+        incl?     (include-sensitive? args)
+        form      (if frame
+                    (str "(re-frame-pair2.runtime/epochs-in-last-ms " ms " " (pr-str frame) ")")
+                    (str "(re-frame-pair2.runtime/epochs-in-last-ms " ms ")"))]
     (-> (ensure-runtime! conn build-id)
         (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
         (.then (fn [epochs]
-                 (ok-text {:ok? true
-                           :window-ms ms
-                           :count (count epochs)
-                           :epochs epochs})))
+                 (let [[kept dropped] (strip-sensitive (vec epochs) incl?)]
+                   (ok-text (cond-> {:ok? true
+                                     :window-ms ms
+                                     :count (count kept)
+                                     :epochs kept}
+                              (pos? dropped) (assoc :dropped-sensitive dropped))))))
         (.catch (fn [err] (err->result :trace-failed err))))))
 
 ;; ---------------------------------------------------------------------------
@@ -257,6 +305,7 @@
   (let [build-id  (arg-build args)
         frame     (some-> (arg args :frame) keyword)
         since-id  (arg args :since-id)
+        incl?     (include-sensitive? args)
         pred-map  (when-let [p (arg args :pred)] (js->clj p :keywordize-keys true))
         frame-arg (if frame (str " " (pr-str frame)) "")
         form      (str "(let [r (re-frame-pair2.runtime/epochs-since "
@@ -269,7 +318,12 @@
     (-> (ensure-runtime! conn build-id)
         (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
         (.then (fn [v]
-                 (ok-text (merge {:ok? true} (when (map? v) v)))))
+                 (let [matches        (when (map? v) (:matches v))
+                       [kept dropped] (strip-sensitive (vec matches) incl?)
+                       base           (cond-> {:ok? true}
+                                        (map? v) (merge v))]
+                   (ok-text (cond-> (assoc base :matches kept)
+                              (pos? dropped) (assoc :dropped-sensitive dropped))))))
         (.catch (fn [err] (err->result :watch-failed err))))))
 
 ;; ---------------------------------------------------------------------------
@@ -381,20 +435,49 @@
         (if (seq v) v full))
       :else full)))
 
+(defn- scrub-snapshot-sensitive
+  "Walk a snapshot's per-frame map and drop `:sensitive? true` items from
+  the `:traces` slice (and, defensively, `:epochs` — epoch records may
+  inherit the stamp in future runtime revisions per spec/009). Returns
+  `[scrubbed dropped-count]`. The non-trace slices (:app-db, :sub-cache,
+  :machines) pass through unchanged — redaction of those payloads is
+  the `with-redacted` interceptor's job, not the forwarder's."
+  [snapshot include?]
+  (if (or include? (not (map? snapshot)))
+    [snapshot 0]
+    (let [dropped (atom 0)
+          scrub-slice
+          (fn [items]
+            (let [[kept n] (strip-sensitive (vec items) false)]
+              (swap! dropped + n)
+              kept))
+          scrub-frame
+          (fn [frame-map]
+            (cond-> frame-map
+              (contains? frame-map :traces) (update :traces scrub-slice)
+              (contains? frame-map :epochs) (update :epochs scrub-slice)))
+          scrubbed (reduce-kv (fn [m k v]
+                                (assoc m k (if (map? v) (scrub-frame v) v)))
+                              {} snapshot)]
+      [scrubbed @dropped])))
+
 (defn- snapshot-tool [conn args]
   (let [build-id (arg-build args)
         frames   (parse-frames-arg (arg args :frames))
         include  (parse-include-arg (arg args :include))
+        incl?    (include-sensitive? args)
         opts     {:frames frames :include include}
         form     (str "(re-frame-pair2.runtime/snapshot-state "
                       (pr-str opts) ")")]
     (-> (ensure-runtime! conn build-id)
         (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
         (.then (fn [v]
-                 (ok-text {:ok?      true
-                           :frames   (if (= :all frames) :all (vec frames))
-                           :include  include
-                           :snapshot v})))
+                 (let [[scrubbed dropped] (scrub-snapshot-sensitive v incl?)]
+                   (ok-text (cond-> {:ok?      true
+                                     :frames   (if (= :all frames) :all (vec frames))
+                                     :include  include
+                                     :snapshot scrubbed}
+                              (pos? dropped) (assoc :dropped-sensitive dropped))))))
         (.catch (fn [err] (err->result :snapshot-failed err))))))
 
 ;; ---------------------------------------------------------------------------
@@ -472,6 +555,7 @@
         poll-ms     (or (arg args :poll-ms) default-poll-ms)
         max-ms      (or (arg args :max-ms) 0)    ;; 0 = no upper bound
         max-events  (or (arg args :max-events) 0) ;; 0 = no upper bound
+        incl?       (include-sensitive? args)
         progress-tk (some-> extra
                             (j/get :_meta)
                             (j/get :progressToken))
@@ -502,9 +586,10 @@
                   (let [sub-id (:sub-id subscribe-resp)]
                     (js/Promise.
                       (fn [resolve _reject]
-                        (let [tick      (atom 0)
-                              delivered (atom 0)
-                              overflow* (atom 0)
+                        (let [tick               (atom 0)
+                              delivered          (atom 0)
+                              overflow*          (atom 0)
+                              dropped-sensitive* (atom 0)
                               terminate
                               (fn [reason]
                                 ;; Drop the runtime subscription and
@@ -520,13 +605,15 @@
                                       (fn [_]
                                         (resolve
                                           (ok-text
-                                            {:ok?        true
-                                             :sub-id     sub-id
-                                             :topic      topic
-                                             :delivered  @delivered
-                                             :overflow   @overflow*
-                                             :ticks      @tick
-                                             :reason     reason}))))))
+                                            (cond-> {:ok?        true
+                                                     :sub-id     sub-id
+                                                     :topic      topic
+                                                     :delivered  @delivered
+                                                     :overflow   @overflow*
+                                                     :ticks      @tick
+                                                     :reason     reason}
+                                              (pos? @dropped-sensitive*)
+                                              (assoc :dropped-sensitive @dropped-sensitive*))))))))
                               poll
                               (fn poll []
                                 (cond
@@ -551,10 +638,14 @@
                                             (terminate :sub-gone)
 
                                             :else
-                                            (let [evts (:events drain-resp)
-                                                  ov   (:overflow drain-resp 0)
-                                                  n    (count evts)]
+                                            (let [raw-evts       (:events drain-resp)
+                                                  ov             (:overflow drain-resp 0)
+                                                  [evts dropped] (strip-sensitive
+                                                                   (vec raw-evts) incl?)
+                                                  n              (count evts)]
                                               (swap! overflow* + ov)
+                                              (when (pos? dropped)
+                                                (swap! dropped-sensitive* + dropped))
                                               (when (or (pos? n) (pos? ov))
                                                 (swap! tick inc)
                                                 (swap! delivered + n)
@@ -566,9 +657,11 @@
                                                                      progress-tk
                                                                      @tick
                                                                      (pr-str
-                                                                       {:sub-id sub-id
-                                                                        :events evts
-                                                                        :overflow ov})
+                                                                       (cond-> {:sub-id sub-id
+                                                                                :events evts
+                                                                                :overflow ov}
+                                                                         (pos? dropped)
+                                                                         (assoc :dropped-sensitive dropped)))
                                                                      ov)})
                                                     (catch :default _ nil))))
                                               (js/setTimeout poll poll-ms)))))
@@ -633,18 +726,28 @@
                   :required ["event"]
                   :additionalProperties false}}
    {:name "trace-window"
-    :description "Return the :rf/epoch-records added in the last N ms for the operating frame."
+    :description (str "Return the :rf/epoch-records added in the last N ms for the operating frame. "
+                      "Per spec/009 §Privacy this forwarder default-drops items carrying `:sensitive? true` "
+                      "at the top level; opt back in with `include-sensitive? true`. Dropped count surfaces "
+                      "as `:dropped-sensitive` on the result when non-zero.")
     :inputSchema {:type "object"
                   :properties {:ms    {:type "integer" :description "Window size in milliseconds (default 1000)"}
                                :frame {:type "string"}
+                               :include-sensitive? {:type "boolean"
+                                                    :description "Opt back in to forwarding `:sensitive? true` items. Default false."}
                                :build {:type "string"}}
                   :additionalProperties false}}
    {:name "watch-epochs"
-    :description "Pull-mode poll: returns the epochs matching `pred` that landed after `since-id`. Call repeatedly to live-watch. Predicate keys: :event-id, :event-id-prefix, :effects, :touches-path, :sub-ran, :render, :origin, :frame."
+    :description (str "Pull-mode poll: returns the epochs matching `pred` that landed after `since-id`. "
+                      "Call repeatedly to live-watch. Predicate keys: :event-id, :event-id-prefix, :effects, "
+                      ":touches-path, :sub-ran, :render, :origin, :frame. Per spec/009 §Privacy this forwarder "
+                      "default-drops items carrying `:sensitive? true`; opt back in with `include-sensitive? true`.")
     :inputSchema {:type "object"
                   :properties {:since-id {:type "string" :description "The last epoch id you've seen (omit to start fresh)"}
                                :pred     {:type "object" :description "Filter map"}
                                :frame    {:type "string"}
+                               :include-sensitive? {:type "boolean"
+                                                    :description "Opt back in to forwarding `:sensitive? true` items. Default false."}
                                :build    {:type "string"}}
                   :additionalProperties false}}
    {:name "tail-build"
@@ -659,7 +762,11 @@
                       "Returns a map keyed by frame-id whose values carry the requested slices: "
                       ":app-db, :sub-cache, :machines, :epochs, :traces. "
                       "Server-side composition over the existing per-slice runtime readers. "
-                      "Prefer this over chaining 5-10 individual reads.")
+                      "Prefer this over chaining 5-10 individual reads. "
+                      "Per spec/009 §Privacy the `:traces` and `:epochs` slices default-drop items carrying "
+                      "`:sensitive? true`; opt back in with `include-sensitive? true`. App-db / sub-cache / "
+                      "machines slices pass through unchanged — payload redaction is the `with-redacted` "
+                      "interceptor's job, not the forwarder's.")
     :inputSchema {:type "object"
                   :properties {:frames  {:description "Frames to snapshot. Pass \"all\" (default) or an array of frame-id strings like [\":rf/default\", \":stories\"]."
                                          :oneOf [{:type "string"}
@@ -668,6 +775,8 @@
                                          :description "Slices to include. Defaults to all five. Recognised: app-db, sub-cache, machines, epochs, traces."
                                          :items {:type "string"
                                                  :enum ["app-db" "sub-cache" "machines" "epochs" "traces"]}}
+                               :include-sensitive? {:type "boolean"
+                                                    :description "Opt back in to forwarding `:sensitive? true` items in the :traces / :epochs slices. Default false."}
                                :build   {:type "string" :description "shadow-cljs build id (default: app)"}}
                   :additionalProperties false}}
    {:name "subscribe"
@@ -679,7 +788,10 @@
                       "Filter vocab depends on topic — :trace/:fx/:error accept the (rf/trace-buffer) filter map "
                       "(:operation :op-type :frame :severity :event-id :handler-id :source :origin :dispatch-id :since-ms :between); "
                       ":epoch accepts the epoch-matches? predicate map (:event-id :event-id-prefix :effects :touches-path "
-                      ":sub-ran :render :origin :frame). Pass `filter` either as a JSON object or as an EDN-encoded string.")
+                      ":sub-ran :render :origin :frame). Pass `filter` either as a JSON object or as an EDN-encoded string. "
+                      "Per spec/009 §Privacy this forwarder default-drops events carrying `:sensitive? true` at the top "
+                      "level; opt back in with `include-sensitive? true`. Dropped count surfaces as `:dropped-sensitive` "
+                      "on each progress payload (when non-zero) and the final summary.")
     :inputSchema {:type "object"
                   :properties {:topic   {:type "string"
                                          :description "Topic name. Required."
@@ -695,6 +807,8 @@
                                          :description "Hard upper-bound on how long the subscription stays open, ms. 0 = unbounded (close on cancel only). Default 0."}
                                :max-events {:type "integer"
                                             :description "Terminate after this many events have been delivered. 0 = unbounded. Default 0."}
+                               :include-sensitive? {:type "boolean"
+                                                    :description "Opt back in to forwarding `:sensitive? true` items. Default false."}
                                :build   {:type "string"}}
                   :required ["topic"]
                   :additionalProperties false}}

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/sensitive_filter_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/sensitive_filter_test.cljs
@@ -1,0 +1,190 @@
+(ns re-frame-pair2-mcp.sensitive-filter-test
+  "Unit tests for the spec/009 §Privacy default-suppress filter on
+  `:sensitive? true` events (rf2-zq0n1, follows rf2-a32kd).
+
+  Spec 009 mandates that framework-published forwarders (Sentry /
+  Honeybadger, pair2 server, Causa-MCP) MUST default-drop trace events
+  whose registration declared `:sensitive? true`. The runtime stamps
+  the flag at the top level of every emitted trace event; the
+  forwarder's job is to gate egress on it.
+
+  These tests mirror the private `sensitive-event?` / `strip-sensitive`
+  helpers from `tools.cljs` — a rename or signature change surfaces as
+  a failing test rather than a silent contract drift."
+  (:require [cljs.test :refer-macros [deftest is testing]]))
+
+;; ---------------------------------------------------------------------------
+;; Mirrors of the private helpers in tools.cljs. Keep in lockstep.
+;; ---------------------------------------------------------------------------
+
+(defn- sensitive-event? [ev]
+  (and (map? ev)
+       (true? (:sensitive? ev))))
+
+(defn- strip-sensitive [events include?]
+  (cond
+    include?         [events 0]
+    (empty? events)  [events 0]
+    :else
+    (let [kept (filterv (complement sensitive-event?) events)
+          n    (- (count events) (count kept))]
+      [kept n])))
+
+;; ---------------------------------------------------------------------------
+;; sensitive-event? — the boolean predicate.
+;; ---------------------------------------------------------------------------
+
+(deftest sensitive-event-true-stamp-detected
+  (is (sensitive-event? {:operation :event/dispatched :sensitive? true})))
+
+(deftest sensitive-event-false-stamp-passes
+  (is (not (sensitive-event? {:operation :event/dispatched :sensitive? false}))))
+
+(deftest sensitive-event-absent-stamp-passes
+  ;; Per spec/009: "Consumers treat absent as `false`."
+  (is (not (sensitive-event? {:operation :event/dispatched}))))
+
+(deftest sensitive-event-non-true-truthy-passes
+  ;; Conservative: only the literal `true` triggers the drop. A string
+  ;; or non-boolean value passes through (the `:rf/trace-event` schema
+  ;; types `:sensitive?` as a boolean — any other value is a contract
+  ;; violation we surface rather than silently treat as sensitive).
+  (is (not (sensitive-event? {:operation :event/dispatched :sensitive? "true"})))
+  (is (not (sensitive-event? {:operation :event/dispatched :sensitive? :yes}))))
+
+(deftest sensitive-event-non-map-input-passes
+  (is (not (sensitive-event? nil)))
+  (is (not (sensitive-event? [:sensitive? true])))
+  (is (not (sensitive-event? "anything"))))
+
+;; ---------------------------------------------------------------------------
+;; strip-sensitive — the default-suppress filter applied per batch.
+;; ---------------------------------------------------------------------------
+
+(deftest strip-sensitive-default-drops-true-stamps
+  (let [evts [{:id 1 :sensitive? false}
+              {:id 2 :sensitive? true}
+              {:id 3}
+              {:id 4 :sensitive? true}]
+        [kept dropped] (strip-sensitive evts false)]
+    (is (= [{:id 1 :sensitive? false} {:id 3}] kept))
+    (is (= 2 dropped))))
+
+(deftest strip-sensitive-include-opt-in-passes-everything
+  (let [evts [{:id 1 :sensitive? true}
+              {:id 2 :sensitive? false}
+              {:id 3 :sensitive? true}]
+        [kept dropped] (strip-sensitive evts true)]
+    (is (= evts kept))
+    (is (zero? dropped))))
+
+(deftest strip-sensitive-empty-batch-zero-overhead
+  (let [[kept dropped] (strip-sensitive [] false)]
+    (is (= [] kept))
+    (is (zero? dropped))))
+
+(deftest strip-sensitive-no-sensitive-events-zero-drop
+  (let [evts [{:id 1} {:id 2 :sensitive? false} {:id 3}]
+        [kept dropped] (strip-sensitive evts false)]
+    (is (= evts kept))
+    (is (zero? dropped))))
+
+(deftest strip-sensitive-all-sensitive-drops-all
+  (let [evts [{:id 1 :sensitive? true}
+              {:id 2 :sensitive? true}
+              {:id 3 :sensitive? true}]
+        [kept dropped] (strip-sensitive evts false)]
+    (is (= [] kept))
+    (is (= 3 dropped))))
+
+;; ---------------------------------------------------------------------------
+;; Default posture — the load-bearing assertion for the spec/009 MUST.
+;; ---------------------------------------------------------------------------
+
+(deftest spec-009-default-posture-is-suppress
+  (testing "the default (include-sensitive? omitted ⇒ false) suppresses"
+    (let [sensitive-batch [{:operation :event/dispatched
+                            :tags      {:event-id :auth/sign-in}
+                            :sensitive? true}]
+          [kept dropped] (strip-sensitive sensitive-batch false)]
+      (is (= [] kept) "sensitive event must NOT reach the agent surface by default")
+      (is (= 1 dropped))))
+  (testing "include-sensitive? true is the documented opt-in"
+    (let [sensitive-batch [{:operation :event/dispatched
+                            :tags      {:event-id :auth/sign-in}
+                            :sensitive? true}]
+          [kept dropped] (strip-sensitive sensitive-batch true)]
+      (is (= sensitive-batch kept))
+      (is (zero? dropped)))))
+
+;; ---------------------------------------------------------------------------
+;; Snapshot scrubber — sensitive trace events stripped from per-frame
+;; :traces / :epochs slices; other slices pass through unchanged.
+;; ---------------------------------------------------------------------------
+
+(defn- scrub-snapshot-sensitive
+  [snapshot include?]
+  (if (or include? (not (map? snapshot)))
+    [snapshot 0]
+    (let [dropped (atom 0)
+          scrub-slice
+          (fn [items]
+            (let [[kept n] (strip-sensitive (vec items) false)]
+              (swap! dropped + n)
+              kept))
+          scrub-frame
+          (fn [frame-map]
+            (cond-> frame-map
+              (contains? frame-map :traces) (update :traces scrub-slice)
+              (contains? frame-map :epochs) (update :epochs scrub-slice)))
+          scrubbed (reduce-kv (fn [m k v]
+                                (assoc m k (if (map? v) (scrub-frame v) v)))
+                              {} snapshot)]
+      [scrubbed @dropped])))
+
+(deftest snapshot-scrubber-strips-sensitive-from-traces
+  (let [snap {:rf/default
+              {:app-db  {:user/name "ada" :password "secret"}
+               :traces  [{:id 1 :sensitive? false}
+                         {:id 2 :sensitive? true}
+                         {:id 3}]
+               :epochs  [{:event-id :foo} {:event-id :auth/sign-in :sensitive? true}]
+               :machines {}}
+              :stories
+              {:app-db {} :traces [{:id 10 :sensitive? true}]}}
+        [out dropped] (scrub-snapshot-sensitive snap false)]
+    (is (= 3 dropped))
+    (is (= [{:id 1 :sensitive? false} {:id 3}]
+           (get-in out [:rf/default :traces])))
+    (is (= [{:event-id :foo}]
+           (get-in out [:rf/default :epochs])))
+    (is (= [] (get-in out [:stories :traces])))))
+
+(deftest snapshot-scrubber-leaves-non-trace-slices-alone
+  ;; App-db payload redaction is `with-redacted`'s job, not the
+  ;; forwarder's. The scrubber must NOT touch :app-db / :sub-cache /
+  ;; :machines even when they carry literal "sensitive"-looking shapes.
+  (let [snap {:rf/default
+              {:app-db    {:password "still-here" :sensitive? true}
+               :sub-cache {:user/profile {:sensitive? true :data "x"}}
+               :machines  {:auth {:state :idle}}
+               :traces    [{:id 1}]}}
+        [out _] (scrub-snapshot-sensitive snap false)]
+    (is (= {:password "still-here" :sensitive? true}
+           (get-in out [:rf/default :app-db])))
+    (is (= {:user/profile {:sensitive? true :data "x"}}
+           (get-in out [:rf/default :sub-cache])))
+    (is (= {:auth {:state :idle}}
+           (get-in out [:rf/default :machines])))))
+
+(deftest snapshot-scrubber-include-opt-in-passes-everything
+  (let [snap {:rf/default {:traces [{:id 1 :sensitive? true}
+                                    {:id 2 :sensitive? true}]}}
+        [out dropped] (scrub-snapshot-sensitive snap true)]
+    (is (= snap out))
+    (is (zero? dropped))))
+
+(deftest snapshot-scrubber-non-map-input-passes-through
+  (let [[out dropped] (scrub-snapshot-sensitive nil false)]
+    (is (nil? out))
+    (is (zero? dropped))))

--- a/tools/story-mcp/src/re_frame/story_mcp/sensitive.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/sensitive.cljc
@@ -1,0 +1,102 @@
+(ns re-frame.story-mcp.sensitive
+  "Spec/009 §Privacy default-suppress filter for `:sensitive?` trace
+  events (rf2-zq0n1, follows rf2-a32kd).
+
+  ## Why this ns exists in story-mcp
+
+  Spec 009 mandates that framework-published forwarders — Sentry /
+  Honeybadger, pair2 server, Story-MCP, Causa-MCP — MUST default-drop
+  trace events whose registration declared `:sensitive? true`. The
+  runtime stamps the flag at the top level of every emitted trace
+  event inside such a registration's handler scope; the forwarder's
+  job is to gate egress on it before any data crosses the trust
+  boundary into the agent surface.
+
+  Story-MCP's current tool surface (`run-variant`, `preview-variant`,
+  `read-failures`, ...) returns *assertion records* and the *post-run
+  app-db*, not raw `:rf/trace-event` items. The literal default-drop
+  filter has nothing to filter in v1: the trace stream is not part of
+  any return shape. Still, this ns ships now so:
+
+  - When a future story-mcp tool surfaces raw traces (the natural
+    extension is a `play-traces` op that returns the trace events
+    emitted during the play phase, mirroring pair2-mcp's `subscribe
+    :trace`), the filter is already in place and the wiring is one
+    `update` call.
+  - The opt-in arg name (`:include-sensitive?`) is fixed
+    cross-server. An agent that knows the slot on pair2-mcp gets the
+    same slot on story-mcp the moment story-mcp grows a trace surface.
+  - The spec/009 MUST is honoured at the artefact level — a
+    code-review of story-mcp can see the filter machinery rather
+    than relying on a forward reference to pair2-mcp.
+
+  ## API
+
+  - `sensitive-event?` — predicate. True iff the map carries
+    `:sensitive? true` at the top level.
+  - `strip-sensitive` — `[events include?] -> [kept dropped-count]`.
+    The default-suppress filter; pass `include? true` to disable.
+  - `include-sensitive?` — read the per-call opt-in arg off a tool
+    arg map. Default false.
+
+  ## Worked example (future trace surface)
+
+  ```clojure
+  (defn- tool-play-traces [args]
+    (let [[vid err] (required-arg args :variant-id)
+          incl?     (sensitive/include-sensitive? args)]
+      (if err err
+        (let [raw          (run-and-collect-traces vid)
+              [kept dropped] (sensitive/strip-sensitive raw incl?)
+              payload      (cond-> {:variant-id vid :traces kept}
+                             (pos? dropped) (assoc :dropped-sensitive dropped))]
+          (text-result (pr-edn payload) payload)))))
+  ```"
+  (:require [clojure.string :as str]))
+
+(defn sensitive-event?
+  "Does this event carry the top-level `:sensitive? true` stamp? The
+  filter is conservative — only the literal `true` value drops; any
+  other value (including a possible string-coercion via an ill-behaved
+  transport) passes through. The `:rf/trace-event` schema types
+  `:sensitive?` as a boolean (per spec/009 + spec/Spec-Schemas)."
+  [ev]
+  (and (map? ev)
+       (true? (:sensitive? ev))))
+
+(defn strip-sensitive
+  "Remove `:sensitive? true` events from `events` unless the caller has
+  opted in. Returns `[kept dropped-count]`. Cheap on the common path
+  (no sensitive events ⇒ identical-vector return + zero drop count).
+
+  This is the load-bearing default-suppress filter per spec/009
+  §Privacy. Apply it to any vector of trace-event-shaped maps before
+  the result crosses the MCP boundary into the agent surface."
+  [events include?]
+  (cond
+    include?         [events 0]
+    (empty? events)  [events 0]
+    :else
+    (let [kept (filterv (complement sensitive-event?) events)
+          n    (- (count events) (count kept))]
+      [kept n])))
+
+(defn- truthy-arg?
+  "Coerce an MCP arg value into a boolean. JSON booleans arrive as
+  `true` / `false`; the truthy-string forms (`\"true\"`, `\"1\"`, ...)
+  are accepted for parity with the `set-allow-writes!` boot-config
+  surface in `re-frame.story-mcp.config`."
+  [v]
+  (cond
+    (boolean? v) v
+    (string? v)  (contains? #{"true" "1" "yes" "y" "on"}
+                            (str/lower-case (str/trim v)))
+    :else        (boolean v)))
+
+(defn include-sensitive?
+  "True iff the caller opted in to forwarding `:sensitive? true` events
+  for this call. Default off. Reads the `:include-sensitive?` arg
+  (keyword key — story-mcp tools receive keyword-keyed arg maps from
+  `re-frame.story-mcp.server`'s dispatcher)."
+  [args]
+  (truthy-arg? (get args :include-sensitive?)))

--- a/tools/story-mcp/test/re_frame/story_mcp/sensitive_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/sensitive_test.clj
@@ -1,0 +1,146 @@
+(ns re-frame.story-mcp.sensitive-test
+  "Unit tests for the spec/009 §Privacy default-suppress filter
+  (rf2-zq0n1, follows rf2-a32kd).
+
+  These tests pin the contract for the `re-frame.story-mcp.sensitive`
+  helpers — the load-bearing piece is the *default posture* assertion:
+  a batch with `:sensitive? true` events MUST be stripped unless the
+  caller explicitly opts in."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story-mcp.sensitive :as sensitive]))
+
+;; ---------------------------------------------------------------------------
+;; sensitive-event? — the boolean predicate.
+;; ---------------------------------------------------------------------------
+
+(deftest sensitive-event-true-stamp-detected
+  (is (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? true})))
+
+(deftest sensitive-event-false-stamp-passes
+  (is (not (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? false}))))
+
+(deftest sensitive-event-absent-stamp-passes
+  ;; Per spec/009: "Consumers treat absent as `false`."
+  (is (not (sensitive/sensitive-event? {:operation :event/dispatched}))))
+
+(deftest sensitive-event-non-true-truthy-passes
+  ;; Conservative: only the literal `true` triggers the drop. A string
+  ;; or non-boolean value passes through.
+  (is (not (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? "true"})))
+  (is (not (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? :yes}))))
+
+(deftest sensitive-event-non-map-input-passes
+  (is (not (sensitive/sensitive-event? nil)))
+  (is (not (sensitive/sensitive-event? [:sensitive? true])))
+  (is (not (sensitive/sensitive-event? "anything"))))
+
+;; ---------------------------------------------------------------------------
+;; strip-sensitive — the default-suppress filter applied per batch.
+;; ---------------------------------------------------------------------------
+
+(deftest strip-sensitive-default-drops-true-stamps
+  (let [evts [{:id 1 :sensitive? false}
+              {:id 2 :sensitive? true}
+              {:id 3}
+              {:id 4 :sensitive? true}]
+        [kept dropped] (sensitive/strip-sensitive evts false)]
+    (is (= [{:id 1 :sensitive? false} {:id 3}] kept))
+    (is (= 2 dropped))))
+
+(deftest strip-sensitive-include-opt-in-passes-everything
+  (let [evts [{:id 1 :sensitive? true}
+              {:id 2 :sensitive? false}
+              {:id 3 :sensitive? true}]
+        [kept dropped] (sensitive/strip-sensitive evts true)]
+    (is (= evts kept))
+    (is (zero? dropped))))
+
+(deftest strip-sensitive-empty-batch-zero-overhead
+  (let [[kept dropped] (sensitive/strip-sensitive [] false)]
+    (is (= [] kept))
+    (is (zero? dropped))))
+
+(deftest strip-sensitive-no-sensitive-events-zero-drop
+  (let [evts [{:id 1} {:id 2 :sensitive? false} {:id 3}]
+        [kept dropped] (sensitive/strip-sensitive evts false)]
+    (is (= evts kept))
+    (is (zero? dropped))))
+
+(deftest strip-sensitive-all-sensitive-drops-all
+  (let [evts [{:id 1 :sensitive? true}
+              {:id 2 :sensitive? true}
+              {:id 3 :sensitive? true}]
+        [kept dropped] (sensitive/strip-sensitive evts false)]
+    (is (= [] kept))
+    (is (= 3 dropped))))
+
+;; ---------------------------------------------------------------------------
+;; include-sensitive? — the per-call opt-in arg parser.
+;; ---------------------------------------------------------------------------
+
+(deftest include-sensitive-defaults-off
+  (is (not (sensitive/include-sensitive? {})))
+  (is (not (sensitive/include-sensitive? {:variant-id "x"})))
+  (is (not (sensitive/include-sensitive? nil))))
+
+(deftest include-sensitive-true-bool-enables
+  (is (sensitive/include-sensitive? {:include-sensitive? true})))
+
+(deftest include-sensitive-false-bool-disables
+  (is (not (sensitive/include-sensitive? {:include-sensitive? false}))))
+
+(deftest include-sensitive-truthy-strings-enable
+  (testing "string-form booleans (parity with set-allow-writes! boot config)"
+    (is (sensitive/include-sensitive? {:include-sensitive? "true"}))
+    (is (sensitive/include-sensitive? {:include-sensitive? "1"}))
+    (is (sensitive/include-sensitive? {:include-sensitive? "yes"}))
+    (is (sensitive/include-sensitive? {:include-sensitive? "y"}))
+    (is (sensitive/include-sensitive? {:include-sensitive? "on"}))
+    (is (sensitive/include-sensitive? {:include-sensitive? "TRUE"}))))
+
+(deftest include-sensitive-falsy-strings-disable
+  (is (not (sensitive/include-sensitive? {:include-sensitive? "false"})))
+  (is (not (sensitive/include-sensitive? {:include-sensitive? "0"})))
+  (is (not (sensitive/include-sensitive? {:include-sensitive? ""}))))
+
+;; ---------------------------------------------------------------------------
+;; Default posture — the load-bearing assertion for the spec/009 MUST.
+;; ---------------------------------------------------------------------------
+
+(deftest spec-009-default-posture-is-suppress
+  (testing "the default (no `include-sensitive?` arg) suppresses"
+    (let [args  {:variant-id ":story.auth/sign-in"}
+          batch [{:operation  :event/dispatched
+                  :tags       {:event-id :auth/sign-in}
+                  :sensitive? true}]
+          [kept dropped] (sensitive/strip-sensitive batch
+                                                    (sensitive/include-sensitive? args))]
+      (is (= [] kept) "sensitive event must NOT reach the agent surface by default")
+      (is (= 1 dropped))))
+  (testing "`include-sensitive? true` is the documented opt-in"
+    (let [args  {:variant-id ":story.auth/sign-in" :include-sensitive? true}
+          batch [{:operation  :event/dispatched
+                  :tags       {:event-id :auth/sign-in}
+                  :sensitive? true}]
+          [kept dropped] (sensitive/strip-sensitive batch
+                                                    (sensitive/include-sensitive? args))]
+      (is (= batch kept))
+      (is (zero? dropped)))))
+
+;; ---------------------------------------------------------------------------
+;; Symmetry with pair2-mcp — the cross-server contract.
+;; ---------------------------------------------------------------------------
+
+(deftest cross-server-arg-name-is-include-sensitive?
+  ;; The opt-in arg name is fixed cross-server. An agent that knows
+  ;; the slot on pair2-mcp gets the same slot on story-mcp.
+  ;;
+  ;; If this test fails because someone renamed the arg, BREAK GLASS:
+  ;; the rename has to land in pair2-mcp and causa-mcp simultaneously
+  ;; or the agent surface fragments.
+  (let [opted-in   (sensitive/include-sensitive? {:include-sensitive? true})
+        opted-out  (sensitive/include-sensitive? {:include-sensitive? false})
+        default    (sensitive/include-sensitive? {})]
+    (is (true? opted-in))
+    (is (false? opted-out))
+    (is (false? default))))


### PR DESCRIPTION
## Summary

Implements [spec/009 §Privacy](spec/009-Instrumentation.md#privacy--sensitive-data-in-traces) (rf2-a32kd) MUST across all three MCP servers: **default-drop trace events carrying `:sensitive? true` at the MCP boundary**, before any data crosses into the agent surface.

- **pair2-mcp** — `subscribe` / `trace-window` / `watch-epochs` / `snapshot` now filter sensitive events. New per-tool `:include-sensitive? true` arg opts back in. Dropped count surfaces as `:dropped-sensitive`. Tool descriptors + spec/003-Tool-Catalogue updated.
- **story-mcp** — New shared `re-frame.story-mcp.sensitive` ns (predicate + filter + opt-in arg parser). v1 tool surface returns assertion records + post-run app-db (no raw traces today), so the helpers are wired up and tested now; the moment a future trace-surfacing tool lands, the wiring is one `update` call away. Worked example in the ns docstring.
- **causa-mcp** — No `src/` yet (spec-scaffold stage). Added normative Privacy section to `spec/Principles.md` documenting the MUST + implementation pattern + cross-server `:include-sensitive?` arg name.

The opt-in arg name is fixed cross-server — an agent that knows the slot on pair2-mcp gets the same slot on story-mcp / causa-mcp.

## Test plan

- [x] `cd tools/pair2-mcp && npm test` — 40 tests / 88 assertions, 0 failures (16 new in `sensitive_filter_test.cljs`)
- [x] `cd tools/story-mcp && clojure -M:test` — 72 tests / 286 assertions, 0 failures (15 new in `sensitive_test.clj`)
- [x] Pre-flight: `git log origin/main --oneline --grep="rf2-zq0n1"` empty, no prior work
- [x] Default posture asserted explicitly: `:sensitive? true` events MUST NOT reach the agent surface unless `:include-sensitive? true` is passed
- [x] Conservative filter: only literal `true` drops; any other value passes through (non-boolean is a contract violation we surface, not silently treat as sensitive)
- [x] Cheap on the common path: no sensitive events ⇒ identical-vector return + zero drop count

Follows: rf2-a32kd / #564.
Bead: rf2-zq0n1.