### PR TITLE
docs(skills/pair2): note :on-error closed return shape per rf2-ciy (rf2-bf409)

### DIFF
--- a/skills/re-frame-pair2/SKILL.md
+++ b/skills/re-frame-pair2/SKILL.md
@@ -125,6 +125,7 @@ Read the leaf that matches the task. Each reference file is ≤250 lines.
 | Pick a structured op (read, write, trace, DOM bridge, watch, hot-reload, time-travel) | [references/ops.md](references/ops.md) |
 | Run a named procedure the user asked for ("why didn't my view update?", post-mortem, experiment loop, etc.) | [references/recipes.md](references/recipes.md) |
 | Translate a structured `{:ok? false :reason ...}` to plain English; suggest the recovery | [references/errors.md](references/errors.md) |
+| Inspect, propose, or hot-swap a frame's `:on-error` policy — the closed return-map contract | [references/on-error.md](references/on-error.md) |
 | Edit source, then wait for the browser to pick up the new code | [references/hot-reload-protocol.md](references/hot-reload-protocol.md) |
 | Map a v1 (`re-frame-pair`) surface to its v2 equivalent (or know that it was dropped) | [references/migration-from-v1.md](references/migration-from-v1.md) |
 | Install/configure the persistent-connection MCP server | [references/mcp-transport.md](references/mcp-transport.md) |

--- a/skills/re-frame-pair2/references/errors.md
+++ b/skills/re-frame-pair2/references/errors.md
@@ -19,3 +19,10 @@ Every `:rf.error/*` trace event carries `:rf.trace/trigger-handler` — `{:kind 
 - `:timed-out? true` on a `dispatch-and-collect` → drain didn't settle in the wait window (a long-running async cascade, or a stuck `:dispatch-later`). Inspect the in-flight cascade via the trace buffer.
 - `:connection :lost` → reconnect by calling `scripts/discover-app.sh` again.
 - Restore failures (`:rf.epoch/restore-*`) → see the time-travel failure table in [ops.md](ops.md#time-travel-epoch-restore).
+
+## `:on-error` policy violations (rf2-ciy)
+
+Two error categories surface when a frame's `:on-error` policy violates its return-map contract. Both ride the trace stream like any other `:rf.error/*` event — pull them with `(rf/trace-buffer {:op-type :error})` and surface to the user verbatim. For the full contract (closed return shape, the `:recovery` enum, why `:retry-count` is gone), see [on-error.md](on-error.md).
+
+- `:rf.error/bad-on-error-return` (`:recovery :logged-and-skipped`) → the policy returned a map with a `:recovery` outside the closed enum (commonly the now-removed `:retried`), or set `:replacement` malformed or on a category that has no substitutable value. The runtime falls back to the original error's category default. `:tags {:received <map> :reason <str>}` names the offending shape — quote it to the user; the fix is almost always "drop `:retry-count` and pick a real `:recovery` keyword".
+- `:rf.error/on-error-policy-exception` (`:recovery :no-recovery`) → the policy fn itself threw. The runtime does NOT recursively invoke the policy on its own exception — it emits this trace and falls back to the original error's category default. `:tags {:original <input-error-event> :exception-message <str>}` carries the original error the policy was handling plus the throw message. Cascade halts; the policy's exception does not propagate to user code. Surface both the original op and the throw site to the user.

--- a/skills/re-frame-pair2/references/on-error.md
+++ b/skills/re-frame-pair2/references/on-error.md
@@ -1,0 +1,80 @@
+# `:on-error` per-frame policy — return-map contract
+
+When the user wires (or asks you to wire) a frame's `:on-error` policy, the return value is a **closed shape**. The contract was pinned by rf2-ciy (PR #618) — the canonical normative source is [spec/009-Instrumentation.md §Error-handler policy (`:on-error` per frame)](../../../spec/009-Instrumentation.md). This file is the operational reminder agents need before they propose or inspect a policy at the REPL.
+
+## The closed shape
+
+```clojure
+{:recovery     <keyword>   ;; REQUIRED — one of the closed recovery set
+ :replacement  <value>     ;; OPTIONAL — honoured ONLY under :replaced-with-default
+ :notes        <string>}   ;; OPTIONAL — free-form; surfaced on the augmented trace
+```
+
+Returning `nil` is the idiomatic "delegate to the category default" — that's what monitoring-library forwarders (Sentry, Honeybadger, etc.) do.
+
+## The `:recovery` enum (closed set)
+
+The runtime accepts exactly six values; anything else triggers `:rf.error/bad-on-error-return` and the category default is used.
+
+| Recovery | Meaning |
+|---|---|
+| `:no-recovery` | The error propagates; the failing op is not retried or substituted. Cascade halts at the offending point. |
+| `:replaced-with-default` | The runtime substitutes `:replacement` into the failing slot and resumes. Shape of `:replacement` is category-specific (see below). |
+| `:skipped` | The runtime declines to act; cascade continues. |
+| `:warned-and-replaced` | A `:warning` trace is emitted and a category-specific default is substituted. |
+| `:logged-and-skipped` | The trace is emitted and the offending input is dropped; sibling inputs still apply. |
+| `:ignored` | Advisory only; the snapshot/state is unchanged. |
+
+## What `:retry-count` was — and isn't
+
+The framework does NOT implement retry semantics. `:retry-count` is **not part of the contract** and never was. If you find a policy in the user's code returning `{:recovery :retried :retry-count 3}` (an old idiom from drafts), the runtime now rejects it: `:rf.error/bad-on-error-return` is emitted and the category default applies. The `:retried` keyword exists in the recovery enum but is **reserved for `:rf.http/retry-attempt`** traces emitted by managed-HTTP — that surface owns its own backoff. An `:on-error` policy that wants to fire the event again MUST dispatch a fresh event from the policy body.
+
+## `:replacement` — only honoured under `:replaced-with-default`
+
+For every other `:recovery` value the runtime ignores `:replacement` if present (and MAY emit `:rf.warning/replacement-ignored-on-recovery`).
+
+The shape of `:replacement` matches what the failing operation would normally return:
+
+- `:rf.error/handler-exception` — an effect-map (`{:db ...}`, `{:fx [[...] ...]}`, or both). The runtime applies it as if the handler had returned it. Non-map or malformed → `:rf.error/bad-on-error-return` and fall back to `:no-recovery`.
+- `:rf.error/schema-validation-failure` — a value of the same position the validator was checking (event vector / sub return / app-db / fx-args / cofx-args / machine `on-create` payload — read the failing trace's `:where` tag).
+- Categories whose default is `:no-recovery` with no substitutable value (registration-time failures, drain-depth-exceeded, `:rf.epoch/restore-*` rejections, `:rf.machine/*` registration-time rejections) — `:replacement` is NOT honoured and triggers `:rf.error/bad-on-error-return`.
+
+## Two new error categories agents must recognise
+
+These appear in the trace buffer when an `:on-error` policy violates the contract — surface them verbatim to the user; the structured `:tags` payload names exactly what was wrong.
+
+| Operation | `:recovery` | When |
+|---|---|---|
+| `:rf.error/bad-on-error-return` | `:logged-and-skipped` | Policy returned a map with bad `:recovery`, malformed `:replacement`, or `:replacement` on a non-substitutable category. `:tags {:received <map> :reason <str>}`. Runtime falls back to the original error's category default. |
+| `:rf.error/on-error-policy-exception` | `:no-recovery` | The `:on-error` policy fn threw. Runtime does NOT recursively invoke the policy on its own exception. `:tags {:original <input-error-event> :exception-message <str>}`. Cascade halts; the policy's exception does not propagate to user code. |
+
+## Inspecting a policy at the REPL
+
+```
+;; Read the registered policy fn for the operating frame:
+scripts/eval-cljs.sh '(:on-error (rf/frame-meta :rf/default))'
+
+;; Pull recent policy-contract violations from the trace buffer:
+scripts/eval-cljs.sh
+  '(filter #(#{:rf.error/bad-on-error-return
+               :rf.error/on-error-policy-exception} (:operation %))
+           (rf/trace-buffer {:op-type :error}))'
+
+;; Hot-swap a policy (ephemeral; survives until full page reload):
+scripts/eval-cljs.sh
+  '(rf/reg-frame :rf/default
+     {:on-error (fn [error-event]
+                  (case (:operation error-event)
+                    :rf.error/handler-exception {:recovery :no-recovery}
+                    nil))})'
+```
+
+## Quick checklist for proposing a policy
+
+1. Return `nil` unless the user actually wants to override the category default.
+2. If overriding, return a closed map with `:recovery` drawn from the enum above.
+3. Only set `:replacement` when `:recovery` is `:replaced-with-default`, and match the failing op's normal return shape.
+4. Never set `:retry-count`. To retry, dispatch a fresh event from the policy body.
+5. Wrap host side effects (logging, monitoring fanout) in a `try` — the runtime catches policy throws, but cleaner to keep the policy total.
+
+For the full normative text (the RFC 2119 clauses, the ordering rules inside the runtime, the style rubric for `:reason` strings), see [spec/009-Instrumentation.md §Error-handler policy](../../../spec/009-Instrumentation.md).


### PR DESCRIPTION
## Summary

- rf2-ciy (PR #618) pinned the `:on-error` per-frame policy contract: closed `{:recovery :replacement :notes}` return map, six-keyword `:recovery` enum, `:replacement` only honoured under `:replaced-with-default`, `:retry-count` struck. Two new error categories — `:rf.error/bad-on-error-return` and `:rf.error/on-error-policy-exception` — capture the contract-violation paths.
- The pair2 skill teaches agents to wire and inspect frame-level error policy at the REPL; until this PR the skill's references didn't carry the new contract. An agent proposing `{:recovery :retried :retry-count 3}` would have seen it silently rejected with no skill-side breadcrumb back to the new shape.

## Changes

- **`skills/re-frame-pair2/references/on-error.md`** (new leaf) — the closed shape, the `:recovery` enum, `:replacement` rules per-category, why `:retry-count` is gone, the two new error categories, and REPL inspection snippets. Links `spec/009-Instrumentation.md §Error-handler policy` as the canonical normative source.
- **`skills/re-frame-pair2/SKILL.md`** — loading-map table gains a row pointing at the new leaf.
- **`skills/re-frame-pair2/references/errors.md`** — appends a section noting the two new contract-violation trace events that agents should expect to see in the trace buffer when a policy goes wrong.

Bead: rf2-bf409 (P3, doc-only sweep after rf2-ciy merge). Spec/009 is unchanged; this is the pair2 skill catching up to the contract pinned there.

## Test plan

- [ ] Render the new `references/on-error.md` leaf — links to spec/009 and to ops.md resolve.
- [ ] SKILL.md loading-map row renders and the link target exists.
- [ ] `errors.md` appended section reads cleanly against the existing transport-error catalogue.