### PR TITLE
feat(causa): Machine Inspector panel — Phase 5 (rf2-r9f9u)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -1,0 +1,410 @@
+(ns day8.re-frame2-causa.panels.machine-inspector
+  "Machine Inspector panel — Phase 5+ (rf2-r9f9u, parent rf2-5aw5v).
+
+  Per `tools/causa/spec/003-Machine-Inspector.md` this panel renders a
+  Stately-quality state-chart per registered machine. The chart
+  component itself lives in `tools/machines-viz/` per
+  `tools/machines-viz/spec/API.md`; Causa embeds it as a thin wrapper
+  that adds the machine picker + transition-history ribbon + (future)
+  source-coord jump affordance.
+
+  ## MachineChart placeholder
+
+  **The `tools/machines-viz/` implementation does not exist yet.**
+  Only the spec scaffold landed via rf2-x50eu (the `MachineChart`
+  prop contract + share-URL encoding are normative). This panel
+  embeds the contract via a **placeholder component** that renders
+  the prop summary as text — the rendering is the chart component's
+  job, and the contract is what matters here. When the impl ships
+  the placeholder swaps for `[viz/MachineChart prop-map]` without
+  touching the rest of the panel chrome.
+
+  Per spec/003-Machine-Inspector.md §Embedding posture the dependency
+  arrow is `tools/causa/ → tools/machines-viz/ → implementation/
+  machines/`; nothing reverses. The placeholder lives inside Causa
+  for now because there is nothing to depend on yet; the moment
+  machines-viz publishes a CLJS bundle this ns swaps the placeholder
+  for the require.
+
+  ## What this panel shows (v1)
+
+    1. **Machine picker** — a dropdown over `(rf/machines)`. Switching
+       the selection re-binds the chart + transition-history ribbon to
+       the new machine.
+
+    2. **MachineChart placeholder** — a text/JSON summary of the prop
+       map that the real component would consume (per
+       `tools/machines-viz/spec/API.md` §Props). Includes a banner
+       calling out the deferred impl + the source-of-truth links.
+
+    3. **Active state** — read off the snapshot at
+       `[:rf/machine <id>]`, surfaced on the picker + the placeholder.
+
+    4. **Transition history ribbon** — filter the Causa trace buffer
+       to `:rf.machine/transition` events for the selected machine.
+       Click a row → `:rf.causa/select-dispatch-id` (pivots to
+       event-detail, parity with every other Causa cross-panel jump).
+
+    5. **Empty state** — when no machines are registered.
+
+  ## What v1 does NOT include
+
+    - **`:invoke-all` viz / `:after` countdown rings / share
+      affordance** — those live in `tools/machines-viz/` per Spec 003
+      §Embedding posture. This panel embeds the component; the
+      rendering is the component's job.
+    - **Source-coord jumps** — the cross-panel jump API hasn't
+      stabilised (same v1 deferral the routes panel carries).
+    - **Auto-pan toggle** — lives on the chart component itself per
+      `tools/machines-viz/spec/API.md` §Props (`:auto-pan?`); the
+      panel header gets the toggle when the component ships.
+
+  ## Pure hiccup (rf2-tijr)
+
+  Same contract as every other Causa panel — the view is pure hiccup,
+  no Reagent / UIx / Helix references. Frame isolation comes from the
+  enclosing `[rf/frame-provider {:frame :rf/causa}]` in `shell.cljs`.
+  Every `subscribe` / `dispatch` here resolves to `:rf/causa`.
+
+  ## Helpers
+
+  All pure-data logic — `project-data`, `project-machine-rows`,
+  `project-transitions`, `chart-props`, ... — lives in
+  `machine_inspector_helpers.cljc` so the algebra runs under the JVM
+  unit-test target. The view here is a thin renderer that reads the
+  `:rf.causa/machine-inspector-data` composite sub."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.machine-inspector-helpers :as h]))
+
+;; ---- design tokens (mirrors routes.cljs / subscriptions.cljs) -----------
+
+(def ^:private tokens
+  "Subset of shell.cljs's dark-theme tokens used by this panel. Kept
+  in sync manually for now — the v1.0 styling pass replaces these
+  with CSS variables across all panels."
+  {:bg-1            "#15171B"
+   :bg-2            "#1B1E24"
+   :bg-3            "#232730"
+   :bg-active       "#2A2F3D"
+   :border-subtle   "#232730"
+   :border-default  "#2F3441"
+   :text-primary    "#E8EAF0"
+   :text-secondary  "#A8AEC0"
+   :text-tertiary   "#6B7080"
+   :accent-violet   "#7C5CFF"
+   :cyan            "#43C3D0"
+   :green           "#4ADE80"
+   :yellow          "#FBBF24"
+   :red             "#F87171"
+   :magenta         "#E879F9"})
+
+(def ^:private mono-stack
+  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
+  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
+
+(def ^:private sans-stack
+  "Inter stack per spec/007-UX-IA.md §Typography."
+  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+
+;; ---- machine picker -----------------------------------------------------
+
+(defn- machine-picker
+  "Dropdown over the registered machines. Per spec/003-Machine-
+  Inspector.md §Selection and switching the picker shows the
+  machine-id + current state for each option; selecting fires
+  `:rf.causa/select-machine-id`."
+  [rows selected-id]
+  [:div {:data-testid "rf-causa-machine-inspector-picker"
+         :style       {:display "flex"
+                       :align-items "center"
+                       :gap "8px"
+                       :padding "10px 16px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))}}
+   [:label {:style {:color (:text-tertiary tokens)
+                    :font-family sans-stack
+                    :font-size "10px"
+                    :text-transform "uppercase"
+                    :letter-spacing "0.5px"}}
+    "Machine"]
+   [:select {:data-testid "rf-causa-machine-inspector-picker-select"
+             :value       (if selected-id (str selected-id) "")
+             :on-change   (fn [e]
+                            (let [v   (-> e .-target .-value)
+                                  row (some #(when (= v (str (:machine-id %))) %) rows)]
+                              (when-let [id (:machine-id row)]
+                                (rf/dispatch [:rf.causa/select-machine-id id]))))
+             :style       {:flex 1
+                           :background (:bg-3 tokens)
+                           :border (str "1px solid " (:border-default tokens))
+                           :color (:text-primary tokens)
+                           :padding "4px 8px"
+                           :border-radius "4px"
+                           :font-family mono-stack
+                           :font-size "12px"
+                           :cursor "pointer"}}
+    (for [{:keys [machine-id state]} rows]
+      ^{:key (str machine-id)}
+      [:option {:value (str machine-id)}
+       (str (h/format-machine-id machine-id)
+            "   "
+            (h/format-state state))])]
+   [:span {:style {:color (:text-tertiary tokens)
+                   :font-family mono-stack
+                   :font-size "11px"}}
+    (str (count rows) " machine" (when-not (= 1 (count rows)) "s"))]])
+
+;; ---- placeholder chart --------------------------------------------------
+
+(defn- placeholder-banner
+  "Calls out the deferred `tools/machines-viz/` impl + cites the
+  spec sources so a future reader (human or AI) knows the panel
+  contract is live even though the rendering surface is a stub."
+  []
+  [:div {:data-testid "rf-causa-machine-inspector-placeholder-banner"
+         :style       {:padding "10px 12px"
+                       :margin "10px 12px 0 12px"
+                       :border (str "1px dashed " (:accent-violet tokens))
+                       :border-radius "4px"
+                       :background "rgba(124, 92, 255, 0.08)"
+                       :color (:text-secondary tokens)
+                       :font-family sans-stack
+                       :font-size "11px"
+                       :line-height 1.5}}
+   [:strong {:style {:color (:accent-violet tokens)
+                     :font-weight 600
+                     :font-size "11px"
+                     :text-transform "uppercase"
+                     :letter-spacing "0.5px"}}
+    "MachineChart placeholder"]
+   [:p {:style {:margin "4px 0 0 0"}}
+    "The "
+    [:code {:style {:font-family mono-stack :color (:text-primary tokens)}}
+     "tools/machines-viz/"]
+    " implementation is deferred — only the spec scaffold has landed "
+    "(rf2-x50eu). This panel renders the prop summary the real "
+    [:code {:style {:font-family mono-stack :color (:text-primary tokens)}}
+     "MachineChart"]
+    " component would consume per "
+    [:code {:style {:font-family mono-stack :color (:text-primary tokens)}}
+     "tools/machines-viz/spec/API.md"]
+    ". When the impl ships, the placeholder swaps for the real "
+    "component without touching the panel chrome."]])
+
+(defn- prop-row
+  "One labelled row inside the placeholder's prop summary."
+  [label value]
+  [:div {:data-testid (str "rf-causa-machine-inspector-prop-" label)
+         :style       {:display "flex"
+                       :flex-direction "column"
+                       :gap "2px"
+                       :padding "6px 0"
+                       :border-bottom (str "1px dotted " (:border-subtle tokens))}}
+   [:span {:style {:color (:text-tertiary tokens)
+                   :font-family sans-stack
+                   :font-size "10px"
+                   :text-transform "uppercase"
+                   :letter-spacing "0.5px"}}
+    label]
+   [:code {:style {:color (:text-primary tokens)
+                   :font-family mono-stack
+                   :font-size "12px"
+                   :word-break "break-all"}}
+    value]])
+
+(defn- placeholder-chart
+  "Renders the prop map a real MachineChart would consume. This is
+  the v1 surface — when machines-viz ships the placeholder becomes
+  `[viz/MachineChart props]`."
+  [props]
+  (if (nil? props)
+    [:div {:data-testid "rf-causa-machine-inspector-placeholder-empty"
+           :style       {:padding "16px"
+                         :color (:text-tertiary tokens)
+                         :font-family sans-stack
+                         :font-size "12px"}}
+     "No machine selected — nothing to chart."]
+    [:div {:data-testid "rf-causa-machine-inspector-placeholder"
+           :style       {:padding "12px"
+                         :background (:bg-1 tokens)
+                         :border (str "1px solid " (:border-subtle tokens))
+                         :border-radius "4px"
+                         :margin "12px"}}
+     [prop-row "machine-id" (h/format-machine-id (:machine-id props))]
+     [prop-row "frame-id"   (h/format-machine-id (:frame-id props))]
+     (when-let [override (:current-state-override props)]
+       [prop-row "current-state-override"
+        (pr-str (select-keys override [:state :data]))])
+     [:div {:style {:margin-top "10px"
+                    :font-family sans-stack
+                    :font-size "10px"
+                    :color (:text-tertiary tokens)
+                    :text-transform "uppercase"
+                    :letter-spacing "0.5px"}}
+      "Defaults applied at chart-mount (per tools/machines-viz/spec/API.md §Props):"]
+     [:ul {:style {:margin "4px 0 0 0"
+                   :padding "0 0 0 16px"
+                   :color (:text-secondary tokens)
+                   :font-family mono-stack
+                   :font-size "11px"
+                   :list-style "disc"}}
+      [:li ":read-only? false"]
+      [:li ":show-microsteps? true"]
+      [:li ":show-after-rings? true"]
+      [:li ":show-invoke-all? true"]
+      [:li ":auto-pan? false"]]]))
+
+;; ---- transition history ribbon ------------------------------------------
+
+(defn- transition-entry
+  "One transition-history ribbon entry. Per spec/003-Machine-
+  Inspector.md §Transition history ribbon clicking the entry jumps to
+  event-detail for that transition (parity with the Issues ribbon /
+  Trace panel)."
+  [{:keys [id from to event dispatch-id microstep?]}]
+  [:li {:data-testid (str "rf-causa-machine-inspector-transition-" id)
+        :on-click    (when dispatch-id
+                       #(rf/dispatch [:rf.causa/select-dispatch-id dispatch-id]))
+        :title       (h/format-event event)
+        :style       {:display "inline-flex"
+                      :align-items "center"
+                      :gap "6px"
+                      :padding (if microstep? "3px 8px 3px 16px" "5px 10px")
+                      :margin "3px"
+                      :background (if microstep?
+                                    (:bg-1 tokens)
+                                    (:bg-3 tokens))
+                      :border (str "1px solid " (:border-subtle tokens))
+                      :border-radius "3px"
+                      :cursor (if dispatch-id "pointer" "default")
+                      :font-family mono-stack
+                      :font-size "11px"
+                      :color (:text-primary tokens)
+                      :white-space "nowrap"}}
+   (when microstep?
+     [:span {:style {:color (:text-tertiary tokens)
+                     :font-size "10px"}}
+      "↳"])
+   [:span (h/format-state from)]
+   [:span {:style {:color (:accent-violet tokens)}} "→"]
+   [:span (h/format-state to)]])
+
+(defn- transition-ribbon
+  "Horizontal scrubbable list of transitions for the selected
+  machine. Per spec/003-Machine-Inspector.md §Transition history
+  ribbon — the v1 surface caps at 200 entries (per spec §Performance);
+  the helper returns the full projection and the view applies the
+  cap here so tests can assert against either shape."
+  [transitions]
+  (let [capped (h/cap-transitions transitions)]
+    [:section {:data-testid "rf-causa-machine-inspector-ribbon"
+               :style       {:border-top (str "1px solid " (:border-default tokens))
+                             :background (:bg-2 tokens)}}
+     [:header {:style {:padding "8px 12px"
+                       :display "flex"
+                       :align-items "center"
+                       :justify-content "space-between"
+                       :background (:bg-3 tokens)
+                       :border-bottom (str "1px solid " (:border-subtle tokens))}}
+      [:span {:style {:font-family sans-stack
+                      :font-size "12px"
+                      :font-weight 600
+                      :color (:text-primary tokens)}}
+       "Transition history"]
+      [:span {:style {:color (:text-tertiary tokens)
+                      :font-family mono-stack
+                      :font-size "11px"}}
+       (str (count capped)
+            (if (< (count capped) (count transitions))
+              (str " of " (count transitions))
+              "")
+            " transition"
+            (when-not (= 1 (count capped)) "s"))]]
+     (if (empty? capped)
+       [:div {:data-testid "rf-causa-machine-inspector-ribbon-empty"
+              :style {:padding "12px"
+                      :color (:text-tertiary tokens)
+                      :font-family sans-stack
+                      :font-size "12px"}}
+        "No transitions recorded for this machine yet."]
+       (into [:ul {:data-testid "rf-causa-machine-inspector-ribbon-list"
+                   :style {:list-style "none"
+                           :margin 0
+                           :padding "6px 8px"
+                           :overflow-x "auto"
+                           :white-space "nowrap"}}]
+             (for [row capped]
+               ^{:key (:id row)}
+               (transition-entry row))))]))
+
+;; ---- empty state --------------------------------------------------------
+
+(defn- empty-state
+  "Rendered when `(rf/machines)` returns nothing — either the host
+  app has not yet called `reg-machine`, or `day8/re-frame2-machines`
+  is not on the classpath. Per spec/003-Machine-Inspector.md §Empty
+  state."
+  []
+  [:div {:data-testid "rf-causa-machine-inspector-empty"
+         :style       {:padding "16px"
+                       :color (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size "13px"}}
+   [:p {:style {:margin "0 0 8px 0"}}
+    "No machines registered."]
+   [:p {:style {:margin 0
+                :font-size "12px"}}
+    "Once your app registers a machine via "
+    [:code {:style {:font-family mono-stack :color (:accent-violet tokens)}}
+     "rf/reg-machine"]
+    " (Spec 005), it will appear here with:"]
+   [:ul {:style {:margin "8px 0 0 0"
+                 :padding "0 0 0 18px"
+                 :font-size "12px"}}
+    [:li "Live state-chart highlighting"]
+    [:li "Transition history ribbon"]
+    [:li ":after countdown rings (via "
+     [:code {:style {:font-family mono-stack :color (:text-tertiary tokens)}}
+      "tools/machines-viz/"]
+     ")"]]])
+
+;; ---- public view --------------------------------------------------------
+
+(defn machine-inspector-view
+  "The Machine Inspector panel's root view. Subscribes to
+  `:rf.causa/machine-inspector-data` and renders either the empty
+  state (no machines registered) or the picker + chart placeholder +
+  transition-history ribbon."
+  []
+  (let [{:keys [machines total selected-id chart-props transitions empty-kind]}
+        @(rf/subscribe [:rf.causa/machine-inspector-data])]
+    [:section {:data-testid "rf-causa-machine-inspector"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      "14px"}}
+     [:header {:style {:padding "16px 16px 8px 16px"}}
+      [:h1 {:style {:font-size "16px"
+                    :font-weight 600
+                    :margin 0
+                    :color (:text-primary tokens)}}
+       "Machine inspector"]
+      [:p {:style {:font-size "12px"
+                   :color     (:text-tertiary tokens)
+                   :margin    "4px 0 0 0"}}
+       "State-chart per registered machine. Picker switches the focus; "
+       "the chart placeholder mirrors the prop contract from "
+       [:code {:style {:font-family mono-stack :color (:accent-violet tokens)}}
+        "tools/machines-viz/"]
+       "."]]
+     (if (= :no-machines empty-kind)
+       (empty-state)
+       [:div {:style {:flex 1 :display "flex" :flex-direction "column"
+                      :overflow "hidden"}}
+        [machine-picker machines selected-id]
+        [:div {:style {:flex 1 :overflow "auto"}}
+         (placeholder-banner)
+         (placeholder-chart chart-props)]
+        (transition-ribbon transitions)])]))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_helpers.cljc
@@ -1,0 +1,342 @@
+(ns day8.re-frame2-causa.panels.machine-inspector-helpers
+  "Pure-data helpers for Causa's Machine Inspector panel
+  (Phase 5+, rf2-r9f9u, parent rf2-5aw5v).
+
+  ## Why a separate `.cljc` ns
+
+  Same dual-target pattern every other panel uses (causality-graph,
+  subscriptions, routes, ...). The panel view in
+  `machine_inspector.cljs` builds the hiccup; the *logic* — projecting
+  the registered-machine set + the live snapshots + the trace-buffer's
+  `:rf.machine/transition` slice into per-machine row + chart-prop
+  data — is pure data → data and runs under the JVM unit-test target
+  (`clojure -M:test`).
+
+  ## What this panel surfaces (per tools/causa/spec/003-Machine-Inspector.md)
+
+  Per spec/003-Machine-Inspector.md the panel's minimum surface is:
+
+    1. **Machine picker** — a dropdown over `(rf/machines)` (Spec 005
+       §Querying machines). Switching the selection re-binds the chart
+       + transition-history ribbon to the new machine. Each picker
+       option shows machine-id + current-state.
+
+    2. **MachineChart placeholder** — a `[viz/MachineChart {...}]`
+       embed per `tools/machines-viz/spec/API.md`. **At v1 the
+       `tools/machines-viz/` implementation does not exist** (only the
+       spec scaffold landed via rf2-x50eu). The panel mounts a
+       placeholder that renders the prop summary as text — the
+       contract is what matters here. When the impl lands the
+       placeholder swaps for the real component without touching the
+       panel chrome.
+
+    3. **Active state** — read off `[:rf/machine <id>]` (Spec 005
+       §Subscribing to machines via sub-machine), surfaced on the
+       picker row + in the placeholder's prop summary.
+
+    4. **Transition history ribbon** — filter the Causa trace buffer
+       to `:rf.machine/transition` events for the selected machine and
+       render them as a scrubbable horizontal list. Click a row →
+       `:rf.causa/select-dispatch-id` (pivots to event-detail, parity
+       with every other Causa cross-panel jump).
+
+  ## What v1 does NOT include
+
+    - No source-coord jumps (the cross-panel jump API hasn't
+      stabilised yet — same as the routes panel's v1 deferral).
+    - No `:invoke-all` viz / `:after` countdown rings / share
+      affordance — those live in `tools/machines-viz/` per Spec
+      003 §Embedding posture. This panel embeds the component; the
+      rendering is the component's job. The placeholder simply
+      surfaces the props the real component would consume.
+    - No share-URL encoding — that lives in
+      `tools/machines-viz/spec/API.md` §Share-URL encoding under the
+      `share/encode-share-url` surface. The panel will wire the
+      affordance through to those exports when machines-viz ships.
+
+  ## Inputs to the projection
+
+  The composite sub `:rf.causa/machine-inspector-data` feeds three
+  sources into `project-data`:
+
+    1. **`machines`** — vector of registered machine-ids
+       (`(rf/machines)`). Empty when the machines artefact is not on
+       the classpath (Spec 005 §Querying machines: returns `[]`).
+
+    2. **`snapshots`** — `{machine-id snapshot-or-nil}` map; each
+       value is the result of `(rf/machine-meta-via-sub machine-id)`
+       (i.e. `(get-in app-db [:rf/machines <id>])` against the target
+       frame). nil when the machine is registered but not yet
+       initialised.
+
+    3. **`trace-buffer`** — Causa's trace ring buffer. The helper
+       filters it to `:rf.machine/transition` events for the selected
+       machine.
+
+  ## Helper output
+
+  `project-data` returns a map shaped:
+
+      {:machines      [<machine-row> ...]    ;; one per registered id
+       :total         <int>
+       :selected-id   <keyword-or-nil>
+       :selected      <machine-row-or-nil>   ;; the picker focus
+       :chart-props   {<MachineChart props>} ;; per machines-viz API
+       :transitions   [<transition-row> ...] ;; ribbon entries
+       :empty-kind    <:no-machines / nil>}
+
+  Each `machine-row` is `{:machine-id :state :data :registered?}`. The
+  `:state` slot is the snapshot's `:state` keyword (nil for
+  uninitialised machines).
+
+  Each `transition-row` is `{:id :time :from :to :event :dispatch-id
+  :microstep?}`. Microstep events (`:rf.machine.microstep/transition`)
+  are folded in at v1 with the `:microstep?` flag so the view can
+  indent them.
+
+  ## What this doesn't do
+
+  Pure data. No subscription, no atom, no `js/` interop — the same
+  fn runs under CLJ and CLJS. The CLJS-only surfaces (`rf/machines`
+  on a populated registrar, `rf/get-frame-db` on a frame) are read
+  by the composite sub in `registry.cljs`; the result is handed to
+  this ns as a plain map."
+  (:require [clojure.string :as str]))
+
+;; ---- canonical operation taxonomy ---------------------------------------
+
+(def transition-operations
+  "Trace operations the transition-history ribbon surfaces. Per
+  spec/005-StateMachines.md + spec/009-Instrumentation.md the runtime
+  emits `:rf.machine/transition` for outer transitions and
+  `:rf.machine.microstep/transition` for `:always`-driven
+  microsteps. The set is the v1 vocabulary; future additions (timer
+  fired, invoke-all join resolved) ride follow-on beads."
+  #{:rf.machine/transition
+    :rf.machine.microstep/transition})
+
+(defn transition-event?
+  "True iff `ev` is one of the transition-history operations. Pure
+  predicate. Tolerant of an event without a `:operation` key (returns
+  false rather than throwing)."
+  [ev]
+  (and (map? ev)
+       (contains? transition-operations (:operation ev))))
+
+;; ---- machine-id resolution ----------------------------------------------
+
+(defn machine-id-of
+  "Resolve the machine-id off a trace event. Per Spec 009 the runtime
+  stamps `:tags :machine-id` (or `:tags :handler-id` for the machine's
+  registered handler-id, which is the same value); the helper falls
+  back to either. Returns nil when the slot is missing — the caller
+  filters those out before sorting."
+  [ev]
+  (or (get-in ev [:tags :machine-id])
+      (get-in ev [:tags :handler-id])))
+
+;; ---- projection ---------------------------------------------------------
+
+(defn project-machine-row
+  "One row per registered machine. `machine-id` is the keyword the
+  machine is registered under (per Spec 005); `snapshot` is the
+  current `{:state :data}` map (or nil for uninitialised machines).
+
+  Per the panel's minimum-viable contract the row carries:
+
+    :machine-id   — the registered id (keyword)
+    :state        — the snapshot's :state keyword (nil if uninit)
+    :data         — the snapshot's :data map (nil if uninit)
+    :registered?  — always true (the row exists because the id is
+                    registered); included so the view can render the
+                    fact distinctly from `:state` (an uninitialised
+                    registered machine still appears in the picker)."
+  [machine-id snapshot]
+  {:machine-id  machine-id
+   :state       (when (map? snapshot) (:state snapshot))
+   :data        (when (map? snapshot) (:data snapshot))
+   :registered? true})
+
+(defn project-machine-rows
+  "Project the registered-machine set + the live snapshots map into
+  one row per id. Sorted alphabetically by `(name machine-id)` for
+  deterministic test output. Pure fn — JVM-runnable."
+  [machines snapshots]
+  (->> (or machines [])
+       (map (fn [id]
+              (project-machine-row id (get snapshots id))))
+       (sort-by (fn [{:keys [machine-id]}]
+                  (str machine-id)))
+       vec))
+
+(defn pick-selected
+  "Resolve the row for the selected machine-id. When `selected-id` is
+  nil the first row is the default focus (so the panel renders
+  *something* on first open). Returns nil when there are no rows."
+  [rows selected-id]
+  (or (some #(when (= (:machine-id %) selected-id) %) rows)
+      (first rows)))
+
+(defn chart-props
+  "Build the MachineChart prop map for the selected machine. Per
+  `tools/machines-viz/spec/API.md` §Props the chart accepts:
+
+      :machine-id  (required)
+      :frame-id    (required)
+      :on-state-click
+      :on-transition-click
+      :read-only?
+      :show-microsteps? / :show-after-rings? / :show-invoke-all?
+      :auto-pan?
+      :current-state-override
+
+  At v1 the panel only fills the required props + the live-snapshot
+  override (so the placeholder can render the active state without
+  reaching back through the framework). Callback wiring (jump to
+  source, scrub transition history) lands when machines-viz ships.
+
+  Returns nil when there is no selected machine — the placeholder
+  renders the empty-chart state in that case."
+  [selected-row frame-id]
+  (when selected-row
+    (let [{:keys [machine-id state data]} selected-row]
+      (cond-> {:machine-id machine-id
+               :frame-id   frame-id}
+        (some? state)
+        (assoc :current-state-override
+               (cond-> {:state state}
+                 (some? data) (assoc :data data)))))))
+
+;; ---- transition history --------------------------------------------------
+
+(defn- transition-row
+  "One transition-history row from a trace event. Pure data."
+  [ev]
+  (let [tags (get ev :tags {})]
+    {:id          (:id ev)
+     :time        (:time ev)
+     :operation   (:operation ev)
+     :from        (or (:from tags) (:from-state tags))
+     :to          (or (:to tags)   (:to-state   tags))
+     :event       (or (:event tags) (:event-v tags))
+     :dispatch-id (:dispatch-id tags)
+     :microstep?  (= :rf.machine.microstep/transition (:operation ev))}))
+
+(defn project-transitions
+  "Filter `trace-buffer` to transition events for `machine-id`. Pure
+  fn — JVM-runnable so the JVM test target can drive it without a
+  CLJS runtime.
+
+  Per spec/003-Machine-Inspector.md §Transition history ribbon the
+  ribbon is *newest-first* (the most recent transition sits at the
+  far right of the strip; the view renders the projection in display
+  order). v1 caps the rendered ribbon at 200 entries — the helper
+  returns the full filtered vector and the view applies the cap so
+  tests can assert the unbounded shape.
+
+  Returns `[]` when `machine-id` is nil (nothing focused → nothing
+  to project)."
+  [trace-buffer machine-id]
+  (if (nil? machine-id)
+    []
+    (->> (or trace-buffer [])
+         (filter (fn [ev]
+                   (and (transition-event? ev)
+                        (= machine-id (machine-id-of ev)))))
+         (map transition-row)
+         ;; Newest first — the ribbon scrolls right-to-left in the
+         ;; view, but the data side leads with the most recent so
+         ;; the head element is the freshest transition.
+         (sort-by (fn [{:keys [id time]}]
+                    ;; Prefer :id when present (stable, monotonic per
+                    ;; Spec 009); fall back to :time. Negate for
+                    ;; newest-first.
+                    (- (or id time 0))))
+         vec)))
+
+(defn cap-transitions
+  "Apply the v1 200-entry cap. Pure fn. The view calls this before
+  rendering; the helper returns the unbounded projection so tests can
+  exercise it."
+  ([rows] (cap-transitions rows 200))
+  ([rows n]
+   (if (<= (count rows) n)
+     (vec rows)
+     (vec (take n rows)))))
+
+;; ---- top-level composite -------------------------------------------------
+
+(defn project-data
+  "Fold the registered-machine set + the snapshots map + the trace
+  buffer + the user's selection into the data shape the panel view
+  consumes.
+
+  Inputs:
+
+    `machines`     — vector / seq of registered machine-ids
+                     (`(rf/machines)`). nil-safe.
+    `snapshots`    — `{machine-id snapshot-or-nil}`. nil-safe.
+    `trace-buffer` — Causa's trace ring buffer. nil-safe.
+    `selected-id`  — the user's picker focus (keyword) or nil. nil
+                     defaults to the first row.
+    `frame-id`     — the frame the chart should resolve the machine
+                     against. Passed through to `chart-props`.
+
+  Returns:
+
+      {:machines     [<machine-row> ...]
+       :total        <int>
+       :selected-id  <id-or-nil>          ;; effective selection
+       :selected     <row-or-nil>
+       :chart-props  <props-or-nil>
+       :transitions  [<transition-row> ...]
+       :empty-kind   <:no-machines / nil>}"
+  [machines snapshots trace-buffer selected-id frame-id]
+  (let [rows         (project-machine-rows machines snapshots)
+        total        (count rows)
+        selected     (pick-selected rows selected-id)
+        effective-id (:machine-id selected)
+        props        (chart-props selected frame-id)
+        transitions  (project-transitions trace-buffer effective-id)
+        empty-kind   (when (zero? total) :no-machines)]
+    {:machines    rows
+     :total       total
+     :selected-id effective-id
+     :selected    selected
+     :chart-props props
+     :transitions transitions
+     :empty-kind  empty-kind}))
+
+;; ---- formatting helpers (consumed by the view) --------------------------
+
+(defn format-machine-id
+  "Pretty-print a machine-id for display. Keywords keep their `:`
+  prefix; everything else falls back to `str`."
+  [id]
+  (cond
+    (nil? id)         ""
+    (keyword? id)     (str id)
+    :else             (str/trim (str id))))
+
+(defn format-state
+  "Render a snapshot `:state` for display. nil → `(uninit)` so the
+  picker / placeholder render *something* rather than a blank for
+  registered-but-uninitialised machines."
+  [state]
+  (cond
+    (nil? state)      "(uninit)"
+    (keyword? state)  (str state)
+    :else             (str/trim (str state))))
+
+(defn format-event
+  "Compact event-vector formatter for the transition row. Falls back
+  to `str` if `pr-str` throws (mirrors the format-edn helper in
+  event_detail.cljs but lives here so the test suite can assert
+  against the formatted output without booting the view)."
+  [event]
+  (if (nil? event)
+    ""
+    (try
+      (pr-str event)
+      (catch #?(:clj Throwable :cljs :default) _
+        (str event)))))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -116,6 +116,30 @@
                                               (no-op on non-browser
                                               targets)
 
+  ## Phase 5+ scope (rf2-r9f9u) — Machine Inspector panel
+
+  Folds `(rf/machines)` + the live `:rf/machine` snapshots + the
+  trace-buffer's `:rf.machine/transition` slice into the data shape
+  the panel renders.
+
+  Subs:
+
+    - `:rf.causa/registered-machines`        sub — vector of ids
+    - `:rf.causa/machine-snapshots`          sub — {id snapshot}
+    - `:rf.causa/selected-machine-id`        sub — picker focus
+    - `:rf.causa/machine-inspector-data`     sub — composite
+
+  Events:
+
+    - `:rf.causa/select-machine-id`          event-db
+    - `:rf.causa/clear-machine-selection`    event-db
+    - `:rf.causa/set-registered-machines-override-for-test` event-db
+    - `:rf.causa/set-machine-snapshots-override-for-test`   event-db
+
+  No new fxs — the panel is read-only at v1 (share-affordance,
+  source-coord jumps live in `tools/machines-viz/` per Spec 003
+  §Embedding posture and require its impl to land first).
+
   Subsequent panel beads add their own per-panel events / subs / fxs."
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
@@ -128,6 +152,7 @@
             [day8.re-frame2-causa.panels.flows-helpers :as flows-helpers]
             [day8.re-frame2-causa.panels.hydration-debugger-helpers :as hd-helpers]
             [day8.re-frame2-causa.panels.issues-ribbon-helpers :as issues-helpers]
+            [day8.re-frame2-causa.panels.machine-inspector-helpers :as machine-helpers]
             [day8.re-frame2-causa.panels.mcp-server-helpers :as mcp-helpers]
             [day8.re-frame2-causa.panels.performance-helpers :as perf-helpers]
             [day8.re-frame2-causa.panels.routes-helpers :as routes-helpers]
@@ -1646,6 +1671,116 @@
     (rf/reg-event-db :rf.causa/clear-route-selection
       (fn [db _event]
         (dissoc db :selected-route-id)))
+
+    ;; ---- Phase 5+ (rf2-r9f9u) — Machine Inspector panel --------------
+    ;;
+    ;; Per `tools/causa/spec/003-Machine-Inspector.md` the panel
+    ;; surfaces every registered machine (via `(rf/machines)` — Spec
+    ;; 005 §Querying machines), the live `:rf/machine` snapshot per id
+    ;; (via the framework `:rf/machine` sub — Spec 005 §Subscribing to
+    ;; machines), and the Causa trace buffer's `:rf.machine/transition`
+    ;; slice for the selected machine.
+    ;;
+    ;; The chart component itself lives in `tools/machines-viz/` per
+    ;; `tools/machines-viz/spec/API.md`. At v1 the impl is deferred
+    ;; (only the scaffold landed via rf2-x50eu); the panel embeds the
+    ;; prop contract through a placeholder component (see panel ns
+    ;; docstring for the swap-when-impl-ships plan).
+    ;;
+    ;; Tests stub the registered-machine + snapshot surfaces by
+    ;; writing override slots to Causa's app-db (mirrors the routes
+    ;; panel's `:rf.causa/set-registered-routes-override-for-test`
+    ;; pattern) so the JVM + node-test suites can drive the projection
+    ;; without booting a host with `rf/reg-machine` calls. Production
+    ;; paths read through `rf/machines` + `subscribe [:rf/machine id]`
+    ;; directly.
+    ;;
+    ;; Shape of `:rf.causa/machine-inspector-data`:
+    ;;
+    ;;     {:machines     [<machine-row> ...]
+    ;;      :total        <int>
+    ;;      :selected-id  <id-or-nil>
+    ;;      :selected     <row-or-nil>
+    ;;      :chart-props  <props-or-nil>
+    ;;      :transitions  [<transition-row> ...]
+    ;;      :empty-kind   <:no-machines / nil>}
+
+    ;; Read the registered-machine vector. Reads `(rf/machines)` —
+    ;; returns `[]` when the machines artefact is not on the
+    ;; classpath (see implementation/core/src/re_frame/core_machines.cljc
+    ;; §machines). The fallback path is wrapped in a `try` so any
+    ;; future API change collapses to an empty registry rather than
+    ;; throwing through the sub.
+    (rf/reg-sub :rf.causa/registered-machines
+      (fn [db _query]
+        (let [ov (get db :registered-machines-override)]
+          (or ov
+              (try (vec (rf/machines))
+                   (catch :default _ []))))))
+
+    ;; Test-only override hook for the registered-machines surface.
+    ;; Production code paths never dispatch this — the slot exists
+    ;; only so JVM + node-test suites can drive the projection
+    ;; without booting a host with `rf/reg-machine` calls.
+    (rf/reg-event-db :rf.causa/set-registered-machines-override-for-test
+      (fn [db [_ ov]]
+        (if (nil? ov)
+          (dissoc db :registered-machines-override)
+          (assoc db :registered-machines-override ov))))
+
+    ;; The live snapshots map for every registered machine, keyed by
+    ;; machine-id. Reads off the target-frame-db's `:rf/machines`
+    ;; slot (per Spec 005 §Where snapshots live — `:rf/machines` is
+    ;; the reserved app-db key); the test override slot mirrors the
+    ;; registered-machines pattern so JVM tests write a snapshot map
+    ;; without a live frame.
+    (rf/reg-sub :rf.causa/machine-snapshots
+      :<- [:rf.causa/target-frame-db]
+      (fn [target-frame-db _query]
+        (when (map? target-frame-db)
+          (get target-frame-db :rf/machines {}))))
+
+    (rf/reg-sub :rf.causa/machine-snapshots-override
+      (fn [db _query]
+        (get db :machine-snapshots-override)))
+
+    (rf/reg-event-db :rf.causa/set-machine-snapshots-override-for-test
+      (fn [db [_ ov]]
+        (if (nil? ov)
+          (dissoc db :machine-snapshots-override)
+          (assoc db :machine-snapshots-override ov))))
+
+    ;; The user's per-panel machine selection (drives the picker
+    ;; focus). nil = default to first row.
+    (rf/reg-sub :rf.causa/selected-machine-id
+      (fn [db _query]
+        (get db :selected-machine-id)))
+
+    ;; The composite — one read produces every slot the panel
+    ;; consumes (matches the per-panel composite pattern every other
+    ;; Causa panel uses).
+    (rf/reg-sub :rf.causa/machine-inspector-data
+      :<- [:rf.causa/registered-machines]
+      :<- [:rf.causa/machine-snapshots]
+      :<- [:rf.causa/machine-snapshots-override]
+      :<- [:rf.causa/trace-buffer]
+      :<- [:rf.causa/selected-machine-id]
+      :<- [:rf.causa/target-frame]
+      (fn [[machines live-snapshots snapshots-override buffer selected-id target-frame]
+           _query]
+        (let [snapshots (or snapshots-override live-snapshots {})]
+          (machine-helpers/project-data
+            machines snapshots buffer selected-id target-frame))))
+
+    ;; ---- Machine Inspector panel events ----------------------------
+
+    (rf/reg-event-db :rf.causa/select-machine-id
+      (fn [db [_ machine-id]]
+        (assoc db :selected-machine-id machine-id)))
+
+    (rf/reg-event-db :rf.causa/clear-machine-selection
+      (fn [db _event]
+        (dissoc db :selected-machine-id)))
 
     ;; ---- Phase 5 (rf2-rccf3) — AI Co-Pilot panel -----------------------
     ;;

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -48,6 +48,7 @@
             [day8.re-frame2-causa.panels.flows :as flows]
             [day8.re-frame2-causa.panels.hydration-debugger :as hydration-debugger]
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
+            [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]
             ;; ── mcp-server panel begin ──
             [day8.re-frame2-causa.panels.mcp-server :as mcp-server]
             ;; ── mcp-server panel end ──
@@ -94,7 +95,7 @@
    {:id :fx           :label "Effects"       :bead "rf2-ts41u" :live? true}
    ;; ── effects panel end ──
    {:id :trace        :label "Trace"         :bead "rf2-argrj" :live? true}
-   {:id :machines     :label "Machines"      :bead "rf2-xxx"}
+   {:id :machines     :label "Machines"      :bead "rf2-r9f9u" :live? true}
    {:id :flows        :label "Flows"         :bead "rf2-83irn" :live? true}
    {:id :routes       :label "Routes"        :bead "rf2-6blai" :live? true}
    {:id :performance  :label "Performance"   :bead "rf2-75121" :live? true}
@@ -291,6 +292,7 @@
       :routes       [routes/routes-view]
       :schemas      [schema-violation-timeline/schema-violation-timeline-view]
       :subs         [subscriptions/subscriptions-view]
+      :machines     [machine-inspector/machine-inspector-view]
       :hydration    [hydration-debugger/hydration-debugger-view]
       :issues       [issues-ribbon/issues-ribbon-view]
       :trace        [trace/trace-view]

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_helpers_cljs_test.cljc
@@ -1,0 +1,303 @@
+(ns day8.re-frame2-causa.panels.machine-inspector-helpers-cljs-test
+  "Pure-data tests for Causa's Machine Inspector panel helpers
+  (Phase 5+, rf2-r9f9u).
+
+  ## Why the `.cljc` + `_cljs_test` naming
+
+  Same dual-target pattern as `causality_graph_cljs_test.cljc`,
+  `subscriptions_helpers_cljs_test.cljc`, etc.:
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  ## What's under test
+
+    1. **transition-event?**     — recognises the v1 transition
+                                   operations (outer + microstep).
+    2. **machine-id-of**         — pulls the machine-id off the trace
+                                   event's `:tags`.
+    3. **project-machine-rows**  — folds the registered ids + snapshot
+                                   map into the row shape; sorts
+                                   deterministically.
+    4. **pick-selected**         — defaults to the first row when the
+                                   selection is nil or unknown.
+    5. **chart-props**           — builds the prop map per
+                                   `tools/machines-viz/spec/API.md`.
+    6. **project-transitions**   — filters the trace buffer to the
+                                   selected machine; newest first.
+    7. **cap-transitions**       — applies the v1 200-entry cap.
+    8. **project-data**          — the top-level composite shape.
+    9. **format-* helpers**      — display formatters."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.machine-inspector-helpers :as h]))
+
+;; ---- (1) transition-event? ---------------------------------------------
+
+(deftest transition-event-recognises-outer-transition
+  (is (true?  (h/transition-event? {:operation :rf.machine/transition})))
+  (is (true?  (h/transition-event?
+                {:operation :rf.machine.microstep/transition})))
+  (is (false? (h/transition-event? {:operation :event/dispatched})))
+  (is (false? (h/transition-event? nil)))
+  (is (false? (h/transition-event? {}))))
+
+;; ---- (2) machine-id-of -------------------------------------------------
+
+(deftest machine-id-of-reads-tags
+  (testing "the :tags :machine-id slot wins when present"
+    (is (= :auth/login
+           (h/machine-id-of {:tags {:machine-id :auth/login}}))))
+  (testing "falls back to :handler-id (same value for machines)"
+    (is (= :auth/login
+           (h/machine-id-of {:tags {:handler-id :auth/login}}))))
+  (testing "nil when neither slot is present"
+    (is (nil? (h/machine-id-of {:tags {}})))
+    (is (nil? (h/machine-id-of {})))))
+
+;; ---- (3) project-machine-rows ------------------------------------------
+
+(deftest project-machine-rows-empty-when-no-machines
+  (is (= [] (h/project-machine-rows nil nil)))
+  (is (= [] (h/project-machine-rows [] {}))))
+
+(deftest project-machine-rows-one-per-id
+  (let [rows (h/project-machine-rows [:auth/login :checkout/flow]
+                                     {:auth/login {:state :idle :data {}}})]
+    (is (= 2 (count rows)))
+    (is (= #{:auth/login :checkout/flow}
+           (set (map :machine-id rows))))))
+
+(deftest project-machine-rows-fills-state-from-snapshot
+  (let [rows (h/project-machine-rows [:auth/login]
+                                     {:auth/login {:state :authing
+                                                   :data {:user "ada"}}})
+        row  (first rows)]
+    (is (= :authing (:state row)))
+    (is (= {:user "ada"} (:data row)))
+    (is (true? (:registered? row)))))
+
+(deftest project-machine-rows-tolerates-missing-snapshot
+  (let [rows (h/project-machine-rows [:auth/login] {})
+        row  (first rows)]
+    (is (= :auth/login (:machine-id row)))
+    (is (nil? (:state row)))
+    (is (nil? (:data row)))
+    (is (true? (:registered? row))
+        "registered? stays true even when uninitialised")))
+
+(deftest project-machine-rows-sorts-deterministically
+  (let [rows (h/project-machine-rows [:z/last :a/first :m/middle] {})
+        ids  (map :machine-id rows)]
+    (is (= [:a/first :m/middle :z/last] ids))))
+
+;; ---- (4) pick-selected -------------------------------------------------
+
+(deftest pick-selected-returns-matching-row
+  (let [rows [{:machine-id :a} {:machine-id :b} {:machine-id :c}]]
+    (is (= :b (:machine-id (h/pick-selected rows :b))))))
+
+(deftest pick-selected-falls-back-to-first-when-nil
+  (let [rows [{:machine-id :a} {:machine-id :b}]]
+    (is (= :a (:machine-id (h/pick-selected rows nil))))))
+
+(deftest pick-selected-falls-back-to-first-when-unknown
+  (let [rows [{:machine-id :a} {:machine-id :b}]]
+    (is (= :a (:machine-id (h/pick-selected rows :unknown))))))
+
+(deftest pick-selected-returns-nil-on-empty
+  (is (nil? (h/pick-selected [] :anything)))
+  (is (nil? (h/pick-selected nil nil))))
+
+;; ---- (5) chart-props ---------------------------------------------------
+
+(deftest chart-props-nil-when-no-row
+  (is (nil? (h/chart-props nil :rf/default))))
+
+(deftest chart-props-fills-required-keys
+  (let [props (h/chart-props {:machine-id :auth/login :state nil :data nil}
+                             :rf/default)]
+    (is (= :auth/login (:machine-id props)))
+    (is (= :rf/default (:frame-id props)))
+    (is (nil? (:current-state-override props))
+        "no override when the snapshot has no :state")))
+
+(deftest chart-props-includes-current-state-override-when-state-present
+  (let [props (h/chart-props {:machine-id :auth/login
+                              :state      :authing
+                              :data       {:user "ada"}}
+                             :rf/default)]
+    (is (= {:state :authing :data {:user "ada"}}
+           (:current-state-override props)))))
+
+(deftest chart-props-omits-data-from-override-when-nil
+  (let [props (h/chart-props {:machine-id :auth/login
+                              :state      :idle
+                              :data       nil}
+                             :rf/default)]
+    (is (= {:state :idle}
+           (:current-state-override props))
+        "data slot is omitted rather than nil")))
+
+;; ---- (6) project-transitions -------------------------------------------
+
+(deftest project-transitions-empty-when-machine-id-nil
+  (is (= [] (h/project-transitions [{:operation :rf.machine/transition
+                                     :tags {:machine-id :auth/login}}]
+                                   nil))))
+
+(deftest project-transitions-empty-when-buffer-empty
+  (is (= [] (h/project-transitions [] :auth/login)))
+  (is (= [] (h/project-transitions nil :auth/login))))
+
+(deftest project-transitions-filters-by-machine-id
+  (let [buffer [{:id 1 :operation :rf.machine/transition
+                 :tags {:machine-id :auth/login :from :idle :to :authing}}
+                {:id 2 :operation :rf.machine/transition
+                 :tags {:machine-id :checkout/flow :from :idle :to :cart}}
+                {:id 3 :operation :rf.machine/transition
+                 :tags {:machine-id :auth/login :from :authing :to :idle}}]
+        rows   (h/project-transitions buffer :auth/login)
+        ids    (set (map :id rows))]
+    (is (= 2 (count rows)) "only the focused machine's transitions surface")
+    (is (= #{1 3} ids)
+        "events #1 and #3 (both :auth/login) survive; #2 (:checkout/flow) is dropped")))
+
+(deftest project-transitions-newest-first
+  (let [buffer [{:id 10 :operation :rf.machine/transition
+                 :tags {:machine-id :auth/login :from :idle :to :a}}
+                {:id 30 :operation :rf.machine/transition
+                 :tags {:machine-id :auth/login :from :a :to :b}}
+                {:id 20 :operation :rf.machine/transition
+                 :tags {:machine-id :auth/login :from :b :to :c}}]
+        rows   (h/project-transitions buffer :auth/login)]
+    (is (= [30 20 10] (map :id rows))
+        "highest :id first (newest first)")))
+
+(deftest project-transitions-marks-microsteps
+  (let [buffer [{:id 1 :operation :rf.machine.microstep/transition
+                 :tags {:machine-id :auth/login :from :idle :to :a}}
+                {:id 2 :operation :rf.machine/transition
+                 :tags {:machine-id :auth/login :from :a :to :b}}]
+        rows   (h/project-transitions buffer :auth/login)
+        outer  (first (filter #(= 2 (:id %)) rows))
+        micro  (first (filter #(= 1 (:id %)) rows))]
+    (is (false? (:microstep? outer)))
+    (is (true?  (:microstep? micro)))))
+
+(deftest project-transitions-drops-non-transition-events
+  (let [buffer [{:id 1 :operation :event/dispatched
+                 :tags {:machine-id :auth/login}}
+                {:id 2 :operation :rf.machine/transition
+                 :tags {:machine-id :auth/login :from :idle :to :a}}
+                {:id 3 :operation :sub/run
+                 :tags {:machine-id :auth/login}}]
+        rows   (h/project-transitions buffer :auth/login)]
+    (is (= [2] (map :id rows)))))
+
+(deftest project-transitions-row-carries-event-and-dispatch-id
+  (let [buffer [{:id 1 :operation :rf.machine/transition
+                 :time 100
+                 :tags {:machine-id :auth/login
+                        :from :idle :to :authing
+                        :event [:auth/submit "ada"]
+                        :dispatch-id "d-42"}}]
+        rows   (h/project-transitions buffer :auth/login)
+        row    (first rows)]
+    (is (= [:auth/submit "ada"] (:event row)))
+    (is (= "d-42" (:dispatch-id row)))
+    (is (= :idle (:from row)))
+    (is (= :authing (:to row)))
+    (is (= 100 (:time row)))))
+
+;; ---- (7) cap-transitions -----------------------------------------------
+
+(deftest cap-transitions-defaults-to-200
+  (let [rows (vec (repeat 250 {:id 1}))]
+    (is (= 200 (count (h/cap-transitions rows))))))
+
+(deftest cap-transitions-keeps-under-cap-rows-unchanged
+  (let [rows [{:id 1} {:id 2} {:id 3}]]
+    (is (= rows (h/cap-transitions rows)))))
+
+(deftest cap-transitions-honours-custom-cap
+  (let [rows [{:id 1} {:id 2} {:id 3} {:id 4} {:id 5}]]
+    (is (= 2 (count (h/cap-transitions rows 2))))
+    (is (= [{:id 1} {:id 2}] (h/cap-transitions rows 2))
+        "takes from the head — newest first preserved by project-transitions")))
+
+;; ---- (8) project-data --------------------------------------------------
+
+(deftest project-data-empty-when-no-machines
+  (let [d (h/project-data [] {} [] nil :rf/default)]
+    (is (= [] (:machines d)))
+    (is (= 0 (:total d)))
+    (is (nil? (:selected-id d)))
+    (is (nil? (:selected d)))
+    (is (nil? (:chart-props d)))
+    (is (= [] (:transitions d)))
+    (is (= :no-machines (:empty-kind d)))))
+
+(deftest project-data-shapes-everything-the-view-needs
+  (let [machines  [:auth/login :checkout/flow]
+        snapshots {:auth/login {:state :authing :data {:user "ada"}}}
+        buffer    [{:id 1 :operation :rf.machine/transition
+                    :tags {:machine-id :auth/login
+                           :from :idle :to :authing
+                           :event [:auth/submit] :dispatch-id "d-1"}}]
+        d         (h/project-data machines snapshots buffer nil :rf/default)]
+    (is (= 2 (:total d)))
+    (is (= :auth/login (:selected-id d))
+        "selection defaults to first row (sorted) when no explicit pick")
+    (is (some? (:selected d)))
+    (is (= :auth/login (-> d :chart-props :machine-id)))
+    (is (= :rf/default (-> d :chart-props :frame-id)))
+    (is (= {:state :authing :data {:user "ada"}}
+           (-> d :chart-props :current-state-override)))
+    (is (= 1 (count (:transitions d))))
+    (is (nil? (:empty-kind d)))))
+
+(deftest project-data-honours-explicit-selection
+  (let [d (h/project-data [:auth/login :checkout/flow]
+                          {}
+                          []
+                          :checkout/flow
+                          :rf/default)]
+    (is (= :checkout/flow (:selected-id d)))))
+
+(deftest project-data-falls-back-to-first-when-selection-stale
+  (let [d (h/project-data [:auth/login]
+                          {}
+                          []
+                          :nonexistent/machine
+                          :rf/default)]
+    (is (= :auth/login (:selected-id d))
+        "stale selection -> first row (the picker can't focus a non-row)")))
+
+(deftest project-data-transitions-scoped-to-selection
+  (let [machines [:auth/login :checkout/flow]
+        buffer   [{:id 1 :operation :rf.machine/transition
+                   :tags {:machine-id :auth/login   :from :idle :to :a}}
+                  {:id 2 :operation :rf.machine/transition
+                   :tags {:machine-id :checkout/flow :from :idle :to :a}}]
+        d        (h/project-data machines {} buffer :checkout/flow :rf/default)]
+    (is (= 1 (count (:transitions d))))
+    (is (= 2 (:id (first (:transitions d))))
+        "only the selected machine's transitions are surfaced")))
+
+;; ---- (9) format-* helpers ----------------------------------------------
+
+(deftest format-machine-id-handles-keywords
+  (is (= ":auth/login" (h/format-machine-id :auth/login)))
+  (is (= "" (h/format-machine-id nil)))
+  (is (= "" (h/format-machine-id ""))))
+
+(deftest format-state-handles-uninit
+  (is (= "(uninit)" (h/format-state nil)))
+  (is (= ":authing" (h/format-state :authing))))
+
+(deftest format-event-handles-nil-and-vector
+  (is (= "" (h/format-event nil)))
+  (is (= "[:auth/submit]" (h/format-event [:auth/submit]))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
@@ -1,0 +1,303 @@
+(ns day8.re-frame2-causa.panels.machine-inspector-view-cljs-test
+  "CLJS-side wiring + view tests for Causa's Machine Inspector panel
+  (Phase 5+, rf2-r9f9u).
+
+  ## What's under test (in addition to the pure-data tests in
+  `machine_inspector_helpers_cljs_test.cljc`)
+
+    1. **Registry wires the composite sub + supporting subs / events**
+       under `:rf.causa/*`.
+
+    2. **The empty state** renders when no machines are registered.
+
+    3. **The picker** enumerates rows from the override and dispatching
+       the change event updates Causa's frame.
+
+    4. **The placeholder banner** + prop summary render when a machine
+       is selected (the MachineChart impl is deferred per spec).
+
+    5. **The transition history ribbon** renders entries from the
+       trace-buffer when transition events are present for the
+       selected machine.
+
+  ## Pure hiccup
+
+  Same approach as `subscriptions_view_cljs_test.cljs` /
+  `causality_graph_view_cljs_test.cljs` — walk the view's hiccup tree
+  by `data-testid` rather than mounting to the DOM."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walkers -----------------------------------------------------
+;;
+;; The picker / placeholder / ribbon are *function components* (the panel
+;; calls them as `[picker rows id]`). A naive `tree-seq` over the
+;; rendered view sees the fn-as-first-element vector but doesn't descend
+;; into its expansion. We expand fn-components eagerly first (recursively
+;; rewriting the tree), then `tree-seq` walks the fully-expanded hiccup —
+;; so a `:select` nested inside the picker's expansion is reachable.
+
+(declare expand-fn-component)
+
+(defn- expand-children [node]
+  (cond
+    (vector? node) (mapv expand-fn-component node)
+    (seq? node)    (map  expand-fn-component node)
+    :else          node))
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (expand-children (apply (first node) (rest node)))
+    (expand-children node)))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-fn-component tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (hiccup-seq tree)))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- override-machines! [machines]
+  (rf/dispatch-sync
+    [:rf.causa/set-registered-machines-override-for-test machines]))
+
+(defn- override-snapshots! [snapshots]
+  (rf/dispatch-sync
+    [:rf.causa/set-machine-snapshots-override-for-test snapshots]))
+
+;; ---- (1) registry wiring ------------------------------------------------
+
+(deftest registry-installs-machine-inspector-handlers
+  (testing "register-causa-handlers! installs every rf2-r9f9u handler"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/registered-machines)))
+    (is (some? (registrar/handler :sub :rf.causa/machine-snapshots)))
+    (is (some? (registrar/handler :sub :rf.causa/selected-machine-id)))
+    (is (some? (registrar/handler :sub :rf.causa/machine-inspector-data)))
+    (is (some? (registrar/handler :event :rf.causa/select-machine-id)))
+    (is (some? (registrar/handler :event :rf.causa/clear-machine-selection)))
+    (is (some? (registrar/handler
+                 :event :rf.causa/set-registered-machines-override-for-test)))
+    (is (some? (registrar/handler
+                 :event :rf.causa/set-machine-snapshots-override-for-test)))))
+
+(deftest composite-defaults-to-empty-when-no-override
+  (testing "with an empty machines override the composite returns the
+            empty-shape map. The override is required because the
+            process-global registrar may carry machines registered by
+            other test namespaces (fixture-reset clears Causa's app-db
+            but not the global registrar's :machines kind)."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines! [])
+      (let [d @(rf/subscribe [:rf.causa/machine-inspector-data])]
+        (is (= [] (:machines d)))
+        (is (= 0 (:total d)))
+        (is (= :no-machines (:empty-kind d)))))))
+
+(deftest composite-projects-machines-into-rows
+  (testing "with a machines + snapshots override the composite returns
+            one row per id with the live snapshot"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines!  [:auth/login :checkout/flow])
+      (override-snapshots! {:auth/login {:state :authing :data {}}})
+      (let [d @(rf/subscribe [:rf.causa/machine-inspector-data])]
+        (is (= 2 (:total d)))
+        (is (= #{:auth/login :checkout/flow}
+               (set (map :machine-id (:machines d)))))
+        (is (= :auth/login (:selected-id d))
+            "first row is the default focus")
+        (is (= :authing (-> d :selected :state)))))))
+
+;; ---- (2) empty state ----------------------------------------------------
+
+(deftest empty-state-renders-when-no-machines
+  (testing "with the override-empty machines slot the panel renders
+            the empty state. The override is required because the
+            process-global registrar may carry machines registered by
+            other test namespaces."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines! [])
+      (let [tree (machine-inspector/machine-inspector-view)]
+        (is (some? (find-by-testid tree "rf-causa-machine-inspector"))
+            "panel container present")
+        (is (some? (find-by-testid tree "rf-causa-machine-inspector-empty"))
+            "empty-state container present")
+        (is (nil? (find-by-testid tree "rf-causa-machine-inspector-picker"))
+            "no picker when there are zero machines")))))
+
+;; ---- (3) picker ---------------------------------------------------------
+
+(deftest picker-renders-with-machines
+  (testing "with the override populated the picker renders the dropdown"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines! [:auth/login :checkout/flow])
+      (let [tree (machine-inspector/machine-inspector-view)]
+        (is (some? (find-by-testid tree "rf-causa-machine-inspector-picker"))
+            "picker container present")
+        (is (some? (find-by-testid
+                     tree "rf-causa-machine-inspector-picker-select"))
+            "picker dropdown present")))))
+
+(deftest select-machine-id-event-writes-to-causa-frame
+  (testing ":rf.causa/select-machine-id stores the machine-id on the Causa frame"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-machine-id :checkout/flow])
+      (is (= :checkout/flow @(rf/subscribe [:rf.causa/selected-machine-id]))))))
+
+(deftest clear-machine-selection-drops-the-pick
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/select-machine-id :checkout/flow])
+    (rf/dispatch-sync [:rf.causa/clear-machine-selection])
+    (is (nil? @(rf/subscribe [:rf.causa/selected-machine-id])))))
+
+(deftest selection-narrows-the-composite
+  (testing "the explicit selection drives the chart-props machine-id"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines! [:auth/login :checkout/flow])
+      (rf/dispatch-sync [:rf.causa/select-machine-id :checkout/flow])
+      (let [d @(rf/subscribe [:rf.causa/machine-inspector-data])]
+        (is (= :checkout/flow (:selected-id d)))
+        (is (= :checkout/flow (-> d :chart-props :machine-id)))))))
+
+;; ---- (4) placeholder ----------------------------------------------------
+
+(deftest placeholder-banner-renders-with-selection
+  (testing "the placeholder banner calls out the deferred machines-viz
+            impl whenever a machine is selected"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines! [:auth/login])
+      (let [tree (machine-inspector/machine-inspector-view)]
+        (is (some? (find-by-testid
+                     tree "rf-causa-machine-inspector-placeholder-banner"))
+            "placeholder banner present — surfaces the deferred impl")))))
+
+(deftest placeholder-shows-prop-summary-with-selection
+  (testing "the placeholder renders the MachineChart prop summary for
+            the selected machine — the contract is what matters at v1"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines!  [:auth/login])
+      (override-snapshots! {:auth/login {:state :authing :data {}}})
+      (let [tree (machine-inspector/machine-inspector-view)]
+        (is (some? (find-by-testid tree "rf-causa-machine-inspector-placeholder")))
+        (is (some? (find-by-testid tree "rf-causa-machine-inspector-prop-machine-id")))
+        (is (some? (find-by-testid tree "rf-causa-machine-inspector-prop-frame-id")))))))
+
+;; ---- (5) transition history ribbon --------------------------------------
+
+(deftest ribbon-renders-empty-when-no-transitions
+  (testing "with no transition events in the buffer the ribbon shows
+            its empty branch"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines! [:auth/login])
+      (let [tree (machine-inspector/machine-inspector-view)]
+        (is (some? (find-by-testid tree "rf-causa-machine-inspector-ribbon")))
+        (is (some? (find-by-testid tree "rf-causa-machine-inspector-ribbon-empty")))))))
+
+(deftest ribbon-renders-entries-when-transitions-present
+  (testing "with transition events in the buffer for the selected machine
+            the ribbon renders one entry per transition"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines! [:auth/login])
+      ;; Push two transition events into the Causa trace buffer.
+      (trace-bus/collect-trace!
+        {:id 1 :operation :rf.machine/transition :time 100
+         :tags {:machine-id :auth/login :from :idle :to :authing
+                :event [:auth/submit] :dispatch-id "d-1"}})
+      (trace-bus/collect-trace!
+        {:id 2 :operation :rf.machine/transition :time 200
+         :tags {:machine-id :auth/login :from :authing :to :idle
+                :event [:auth/cancel] :dispatch-id "d-2"}})
+      (let [tree    (machine-inspector/machine-inspector-view)
+            entries (find-all-by-testid-prefix
+                      tree "rf-causa-machine-inspector-transition-")]
+        (is (= 2 (count entries))
+            "two ribbon entries — one per transition event")))))
+
+(deftest ribbon-entry-click-pivots-to-event-detail
+  (testing "clicking a ribbon entry dispatches :rf.causa/select-dispatch-id
+            (parity with the Issues ribbon + Trace panel cross-panel jump)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines! [:auth/login])
+      (trace-bus/collect-trace!
+        {:id 1 :operation :rf.machine/transition :time 100
+         :tags {:machine-id :auth/login :from :idle :to :authing
+                :event [:auth/submit] :dispatch-id "d-42"}})
+      (let [dispatches (atom [])]
+        ;; rf/dispatch is async; with-redefs on the underlying
+        ;; rf/dispatch* fn captures the event vector synchronously
+        ;; (same approach the mcp-server view test uses).
+        (with-redefs [rf/dispatch* (fn
+                                     ([ev] (swap! dispatches conj ev) nil)
+                                     ([ev _opts] (swap! dispatches conj ev) nil))]
+          (let [tree    (machine-inspector/machine-inspector-view)
+                entry   (find-by-testid
+                          tree "rf-causa-machine-inspector-transition-1")
+                handler (:on-click (second entry))]
+            (is (some? entry) "entry node present in the rendered tree")
+            (is (some? handler) "entry carries an :on-click handler")
+            (when handler (handler))))
+        (is (some #(= [:rf.causa/select-dispatch-id "d-42"] %) @dispatches)
+            "select-dispatch-id fired with the dispatch-id from the trace event")))))
+
+;; ---- (6) frame isolation ------------------------------------------------
+
+(deftest selection-state-does-not-leak-into-default-frame
+  (testing "the panel's selection state lives on :rf/causa, never :rf/default"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login]))
+    (let [causa-db   (frame/frame-app-db-value :rf/causa)
+          default-db (frame/frame-app-db-value :rf/default)]
+      (is (= :auth/login (:selected-machine-id causa-db))
+          "selection lands on Causa")
+      (is (nil? (:selected-machine-id default-db))
+          "selection did NOT leak into :rf/default"))))


### PR DESCRIPTION
## Summary

- **The final Causa Phase 5+ panel — completes the 13-panel set (13/13).**
- New panel `:machines` mounts under the `:rf/causa` frame-provider and surfaces every registered machine (`(rf/machines)`) with the live `[:rf/machine <id>]` snapshot, a picker, a `MachineChart` placeholder per `tools/machines-viz/spec/API.md`, and a transition-history ribbon filtered to the selected machine.
- Sidebar entry `:machines` flips from `Coming soon — rf2-xxx` stub to `:live? true`; canvas case routes to the new view.

## MachineChart placeholder

The `tools/machines-viz/` implementation does not exist yet — only the spec scaffold landed via #581 (rf2-x50eu). This panel embeds the chart contract through a **placeholder component** that renders the prop summary as text/JSON — the contract is what matters at v1. When the impl ships, the placeholder swaps for `[viz/MachineChart props]` without touching the panel chrome.

The placeholder explicitly:
- Surfaces the prop map the real component would consume (`:machine-id`, `:frame-id`, `:current-state-override`).
- Lists the chart-mount defaults documented in `tools/machines-viz/spec/API.md` §Props (`:read-only?`, `:show-microsteps?`, `:show-after-rings?`, `:show-invoke-all?`, `:auto-pan?`).
- Carries a banner calling out the deferred impl + cites the spec sources.

The panel ns docstring documents the swap-when-impl-ships plan.

## Surface

- `tools/causa/src/.../panels/machine_inspector.cljs` (new — view, pure hiccup)
- `tools/causa/src/.../panels/machine_inspector_helpers.cljc` (new — pure-data projection, JVM-runnable)
- `tools/causa/test/.../panels/machine_inspector_helpers_cljs_test.cljc` (45 pure-data assertions; dual CLJ/CLJS)
- `tools/causa/test/.../panels/machine_inspector_view_cljs_test.cljs` (registry wiring, picker, placeholder, ribbon, frame isolation)
- `registry.cljs`: 4 subs (`:rf.causa/registered-machines`, `:rf.causa/machine-snapshots`, `:rf.causa/selected-machine-id`, `:rf.causa/machine-inspector-data` composite) + 4 events (`:rf.causa/select-machine-id`, `:rf.causa/clear-machine-selection`, and two test-only override setters mirroring the routes panel pattern).
- `shell.cljs`: sidebar `:bead` flips to `rf2-r9f9u` with `:live? true`; canvas case routes `:machines` to the new view.

## What v1 does NOT include (deferred to `tools/machines-viz/` impl)

- `:invoke-all` viz / `:after` countdown rings / share affordance / source-coord jumps / auto-pan toggle — those live on the chart component itself per spec/003-Machine-Inspector.md §Embedding posture. This panel embeds the component; the rendering is the component's job.

## Test plan

- [x] `tools/causa/` JVM tests: 451 tests / 1258 assertions pass.
- [x] `implementation/` `npm run test:cljs`: 1449 tests / 3817 assertions pass.
- [x] `npm run test:bundle-isolation` passes (no tools-leak introduced).
- [x] Frame isolation verified: panel selection lands on `:rf/causa`, never `:rf/default`.
- [ ] Manual smoke once the `tools/machines-viz/` impl lands (placeholder swap confirms the prop contract).