### PR TITLE
feat(skills/pair2): default-suppress :sensitive? in preload streaming (rf2-3cted)

### DIFF
--- a/skills/re-frame-pair2/SKILL.md
+++ b/skills/re-frame-pair2/SKILL.md
@@ -145,6 +145,7 @@ Load at most two references for a single task. If you find yourself wanting thre
 - **Surface restore limits.** Before any time-travel experiment, walk the cascade's effects and tell the user which effects already fired and cannot be reversed.
 - **Use the assembled epoch stream by default; reach for the raw trace stream when you need detail the projection drops.** `:sub-runs`, `:renders`, `:effects` are the routing surface; `:trace-events` is the escape hatch when the projection is incomplete (e.g. successful-fx attribution).
 - **One trace listener per skill.** This skill registers exactly one listener (`:re-frame-pair2`) and one epoch listener (`:re-frame-pair2-epoch`). Multi-tool coexistence is the expected default — don't worry about other listeners; per Spec 009 §Listener ordering, ordering is not contract.
+- **Sensitive data does not cross the LLM boundary by default.** Per [Spec 009 §Privacy](../../spec/009-Instrumentation.md), the preload's streaming dispatch drops `:sensitive? true` trace events before they reach the agent-facing queue. The retain-N ring buffer is unaffected; explicit `(rf/trace-buffer)` reads see everything. Apps that want sensitive cascades visible to pair2 opt in via `(re-frame-pair2.runtime/configure-privacy! {:include-sensitive? true})`. See [references/vocabulary.md §Privacy posture](references/vocabulary.md#privacy-posture--sensitive-and-the-streaming-surface).
 
 ---
 

--- a/skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs
+++ b/skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs
@@ -526,6 +526,68 @@
 
 (def ^:private default-max-buffered 500)
 
+;; ---------------------------------------------------------------------------
+;; Privacy posture for the streaming surface (rf2-3cted)
+;; ---------------------------------------------------------------------------
+;;
+;; Per Spec 009 §Privacy / sensitive data: framework-published listener
+;; integrations — including the pair2 server — MUST default-suppress
+;; `:sensitive? true` trace events before forwarding to the AI surface.
+;;
+;; The trust boundary is "any trace data that leaves the browser tab and
+;; reaches the LLM-facing channel". Streaming subscriptions are how that
+;; happens in pair2: the MCP server registers a subscription, polls
+;; `drain-subscription!`, and forwards every drained event back to the
+;; agent as a `notifications/progress` payload. The retain-N ring buffer
+;; reached via `(rf/trace-buffer)` is a separate, explicit read surface;
+;; agents asking for it are making a deliberate request and the filter
+;; vocabulary already exposes `:sensitive? false` for tools that want to
+;; pre-filter (see Spec 009 §Filter vocabulary).
+;;
+;; The default is **drop**. Apps that need sensitive cascades visible to
+;; the pair tool (rare; only when the tool is itself the trust boundary)
+;; opt in explicitly via `configure-privacy!`.
+;;
+;; The flag is consulted at `on-trace-streaming` entry — before any
+;; subscription's queue sees the event. Dropped events still update the
+;; `last-trace-id` cursor (so `last-trace-event-id` keeps incrementing
+;; monotonically) and still ride `(rf/trace-buffer)` unchanged — only
+;; the streaming dispatch is gated.
+
+(defonce ^:private privacy-config
+  ;; {:include-sensitive? bool}
+  ;; Default: false — suppress `:sensitive? true` events from the
+  ;; streaming dispatch path. See namespace docs above.
+  (atom {:include-sensitive? false}))
+
+(defn configure-privacy!
+  "Set the privacy posture for the streaming surface. Opts:
+
+     :include-sensitive?  boolean — when true, `:sensitive? true` trace
+                          events ride the streaming dispatch unchanged.
+                          Default: **false** (drop) per Spec 009 §Privacy.
+
+   Returns the merged config map. Idempotent. Use sparingly — the
+   default exists because pair2 forwards events to an LLM-facing
+   channel, and the framework's privacy contract is that sensitive
+   data does not cross that boundary by accident."
+  [{:keys [include-sensitive?] :as opts}]
+  (swap! privacy-config merge (select-keys opts [:include-sensitive?]))
+  (assoc @privacy-config :ok? true))
+
+(defn privacy-config-snapshot
+  "Return the current privacy config — diagnostic helper."
+  []
+  (assoc @privacy-config :ok? true))
+
+(defn- streaming-drop?
+  "True when the streaming surface should drop `ev` for privacy reasons.
+   Today: any trace event stamped `:sensitive? true` at the top level
+   unless the operator has opted in via `configure-privacy!`."
+  [ev]
+  (and (true? (:sensitive? ev))
+       (not (true? (:include-sensitive? @privacy-config)))))
+
 (defn- topic->base-filter
   "Map a topic keyword to its base trace-filter constraints. `:fx` and
    `:error` are sugar over `:op-type`; `:trace` and `:epoch` add no
@@ -625,11 +687,19 @@
 
 (defn- on-trace-streaming
   "Replacement raw-trace listener that drives both the last-trace-id
-   cursor (legacy) and the streaming subs dispatch."
+   cursor (legacy) and the streaming subs dispatch.
+
+   Privacy filter (rf2-3cted): trace events stamped `:sensitive? true`
+   at the top level are dropped from the streaming dispatch by default,
+   per Spec 009 §Privacy. The `last-trace-id` cursor still advances so
+   the legacy `since`-based ring-buffer reads remain monotonic — only
+   the LLM-facing streaming surface is gated. Opt in via
+   `(configure-privacy! {:include-sensitive? true})`."
   [ev]
   (when-let [id (:id ev)]
     (when (number? id) (reset! last-trace-id id)))
-  (dispatch-trace-to-subs! ev))
+  (when-not (streaming-drop? ev)
+    (dispatch-trace-to-subs! ev)))
 
 (defn- on-epoch-streaming
   "Replacement assembled-epoch listener that drives both the observed

--- a/skills/re-frame-pair2/references/ops.md
+++ b/skills/re-frame-pair2/references/ops.md
@@ -53,6 +53,7 @@ Read-only from the trace stream + epoch history.
 | `trace/find-where` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/find-where <pred>)'` | Most recent epoch matching a predicate — primary forensic op for "when did X happen?" post-mortems |
 | `trace/find-all-where` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/find-all-where <pred>)'` | Every matching epoch, newest first — for trajectories rather than single transitions |
 | `trace/cascade` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/cascade-of <dispatch-id>)'` | Walk `:dispatch-id` / `:parent-dispatch-id` (Spec 009 §Dispatch correlation) to reconstruct the full cascade tree from a root dispatch |
+| `trace/configure-privacy` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/configure-privacy! {:include-sensitive? true})'` | Set the privacy posture for the streaming subscription surface. Default: `{:include-sensitive? false}` — drops `:sensitive? true` trace events before they reach the LLM-facing queue, per [Spec 009 §Privacy](../../../spec/009-Instrumentation.md). Resets on page reload. See [references/vocabulary.md §Privacy posture](vocabulary.md#privacy-posture--sensitive-and-the-streaming-surface). |
 
 ## DOM source bridge
 

--- a/skills/re-frame-pair2/references/vocabulary.md
+++ b/skills/re-frame-pair2/references/vocabulary.md
@@ -49,3 +49,51 @@ A bare mention of any of these terms does **not** mean the skill should
 activate. Activation depends on whether the user is *operating on a running
 app* or *reading source / spec*. The former is this skill's job; the latter
 belongs to `skills/re-frame2/` (authoring) or direct spec reading.
+
+## Privacy posture — `:sensitive?` and the streaming surface
+
+Per [Spec 009 §Privacy / sensitive data](../../../spec/009-Instrumentation.md), trace
+events carry an optional top-level `:sensitive?` boolean stamped by the
+runtime when the in-scope handler's registration metadata declared
+`:sensitive? true`. The framework contract is that **framework-published
+listener integrations — including the pair2 server — MUST default-suppress
+`:sensitive? true` events before forwarding to the AI surface.**
+
+This skill honours that contract. The preload's streaming dispatch
+(`on-trace-streaming` → `dispatch-trace-to-subs!`, fed by every
+`subscribe!`) drops `:sensitive? true` events before any subscription
+queue sees them. The retain-N ring buffer reached via
+`(rf/trace-buffer)` is unaffected — agents asking for it are making a
+deliberate request and can pre-filter with `(rf/trace-buffer {:sensitive? false})`.
+
+### What gets dropped, what doesn't
+
+- **Dropped from streaming subs by default**: any trace event whose
+  top-level `:sensitive?` is `true`. The legacy `last-trace-event-id`
+  cursor still advances over them so `:since`-based ring-buffer reads
+  remain monotonic.
+- **Not dropped**: events with `:sensitive? false` or no `:sensitive?`
+  key, the underlying `rf/trace-buffer` ring, and `:rf/epoch-record`
+  values surfaced via `epoch-history` / the `:epoch` streaming topic.
+  Epoch records do not carry a top-level `:sensitive?` stamp per spec —
+  if the app needs the per-event payload redacted inside an epoch, the
+  authoring side must use `(rf/with-redacted [...])` in the handler's
+  interceptor chain.
+- **Sentinel-aware**: `:rf/redacted` keywords still appear in event
+  vectors and db snapshots that rode through `with-redacted` —
+  redaction is a separate, orthogonal mechanism (the payload value is
+  replaced), `:sensitive?` is the routing flag (the event is dropped).
+
+### Asking for the unmasked view
+
+When the user explicitly wants sensitive cascades visible to the pair
+tool — rare; only when the pair tool is itself the trust boundary, e.g.
+a self-hosted MCP server inside a private network — they opt in via:
+
+```clojure
+(re-frame-pair2.runtime/configure-privacy! {:include-sensitive? true})
+```
+
+The setting persists for the session; the next page reload resets it
+to the default-suppress posture. State the trade-off plainly when
+proposing the change; this is not a knob to flip casually.

--- a/skills/re-frame-pair2/tests/runtime/streaming_subscriptions_test.clj
+++ b/skills/re-frame-pair2/tests/runtime/streaming_subscriptions_test.clj
@@ -104,6 +104,35 @@
         acc))
     subs subs))
 
+;; ---------------------------------------------------------------------------
+;; Privacy posture (rf2-3cted) — mirror of the runtime guard.
+;; ---------------------------------------------------------------------------
+;;
+;; Per Spec 009 §Privacy: framework-published listener integrations —
+;; including the pair2 server — MUST default-suppress `:sensitive? true`
+;; trace events before forwarding to the AI surface. The runtime
+;; consults a `privacy-config` slot at `on-trace-streaming` entry and
+;; drops sensitive events from the streaming dispatch unless the
+;; operator has explicitly opted in via `configure-privacy!`.
+;;
+;; KEEP IN SYNC WITH preload/re_frame_pair2/runtime.cljs §Privacy posture.
+
+(defn streaming-drop?
+  "Mirror of `runtime/streaming-drop?` — true when the streaming surface
+   should drop `ev` for privacy reasons given the current privacy config."
+  [privacy-cfg ev]
+  (and (true? (:sensitive? ev))
+       (not (true? (:include-sensitive? privacy-cfg)))))
+
+(defn on-trace-streaming
+  "Mirror of `runtime/on-trace-streaming` for the privacy guard. Takes
+   the privacy config explicitly so the test can drive both branches
+   without global state."
+  [subs privacy-cfg ev]
+  (if (streaming-drop? privacy-cfg ev)
+    subs
+    (dispatch-trace-to-subs! subs ev)))
+
 (defn dispatch-epoch-to-subs!
   [subs record]
   (reduce-kv
@@ -294,6 +323,81 @@
   (let [recognised #{:trace :epoch :fx :error}]
     (is (not (contains? recognised :other)))
     (is (every? recognised [:trace :epoch :fx :error]))))
+
+;; ---------------------------------------------------------------------------
+;; Privacy posture (rf2-3cted)
+;; ---------------------------------------------------------------------------
+
+(deftest streaming-drop-defaults-to-suppressing-sensitive-events
+  (testing "default privacy config suppresses :sensitive? true events"
+    (let [default-cfg {:include-sensitive? false}]
+      (is (true? (streaming-drop? default-cfg {:sensitive? true})))
+      (is (true? (streaming-drop? default-cfg {:sensitive? true :op-type :fx})))))
+  (testing "non-sensitive events are never dropped on the privacy axis"
+    (let [default-cfg {:include-sensitive? false}]
+      (is (false? (streaming-drop? default-cfg {:sensitive? false})))
+      (is (false? (streaming-drop? default-cfg {})))           ;; absent ⇒ not sensitive
+      (is (false? (streaming-drop? default-cfg {:op-type :fx}))))))
+
+(deftest streaming-drop-allows-opt-in-via-include-sensitive
+  (testing "opting in lets :sensitive? true events through"
+    (let [opt-in-cfg {:include-sensitive? true}]
+      (is (false? (streaming-drop? opt-in-cfg {:sensitive? true})))
+      (is (false? (streaming-drop? opt-in-cfg {:sensitive? false})))
+      (is (false? (streaming-drop? opt-in-cfg {}))))))
+
+(deftest sensitive-events-not-forwarded-to-subscribers-by-default
+  ;; Spec 009 §Privacy default contract: a `:sensitive? true` trace
+  ;; event registered against a matching subscription MUST NOT be
+  ;; enqueued under the default privacy posture.
+  (let [default-cfg {:include-sensitive? false}
+        subs (-> {} (subscribe! "s1" {:topic :trace}))
+        sensitive-ev    {:op-type :event :sensitive? true
+                         :tags {:event-id :auth/sign-in}}
+        ordinary-ev    {:op-type :event :sensitive? false
+                         :tags {:event-id :cart/add}}
+        absent-flag-ev {:op-type :event ;; no :sensitive? at all
+                         :tags {:event-id :route/change}}
+        subs (-> subs
+                 (on-trace-streaming default-cfg sensitive-ev)
+                 (on-trace-streaming default-cfg ordinary-ev)
+                 (on-trace-streaming default-cfg absent-flag-ev))]
+    (let [queue (get-in subs ["s1" :queue])]
+      (testing "sensitive event is absent from the streaming queue"
+        (is (not-any? #(true? (:sensitive? %)) queue)))
+      (testing "ordinary events still flow through unchanged"
+        (is (= 2 (count queue)))
+        (is (= [ordinary-ev absent-flag-ev] queue))))))
+
+(deftest sensitive-events-forwarded-when-operator-opts-in
+  ;; The opt-in path is the escape hatch for apps where pair2 itself is
+  ;; the trust boundary. With `:include-sensitive? true` the streaming
+  ;; surface forwards every event regardless of the flag.
+  (let [opt-in-cfg {:include-sensitive? true}
+        subs (-> {} (subscribe! "s1" {:topic :trace}))
+        sensitive-ev {:op-type :event :sensitive? true
+                      :tags {:event-id :auth/sign-in}}
+        ordinary-ev  {:op-type :event :sensitive? false
+                      :tags {:event-id :cart/add}}
+        subs (-> subs
+                 (on-trace-streaming opt-in-cfg sensitive-ev)
+                 (on-trace-streaming opt-in-cfg ordinary-ev))]
+    (testing "both events ride the queue when the operator opts in"
+      (is (= [sensitive-ev ordinary-ev] (get-in subs ["s1" :queue]))))))
+
+(deftest privacy-filter-respects-topic-filter-composition
+  ;; The privacy guard runs *before* the per-subscription filter, so
+  ;; even a subscription whose filter would otherwise match a sensitive
+  ;; event sees nothing under the default policy.
+  (let [default-cfg {:include-sensitive? false}
+        subs (-> {} (subscribe! "auth-events"
+                                 {:topic :trace
+                                  :filter {:event-id :auth/sign-in}}))
+        sensitive-ev {:op-type :event :sensitive? true
+                      :tags {:event-id :auth/sign-in}}
+        subs (on-trace-streaming subs default-cfg sensitive-ev)]
+    (is (empty? (get-in subs ["auth-events" :queue]))
+        "even a filter that *names* the sensitive event must not pull it through")))
 
 (let [{:keys [fail error]} (run-tests 'streaming-subscriptions-test)]
   (when (or (pos? fail) (pos? error))


### PR DESCRIPTION
## Summary

Per [Spec 009 §Privacy / sensitive data](../blob/main/spec/009-Instrumentation.md): *framework-published listener integrations — including the pair2 server — MUST default-suppress \`:sensitive? true\` trace events before forwarding to the AI surface.*

Until this PR, the pair2 preload's streaming subscription path (`on-trace-streaming` → `dispatch-trace-to-subs!`, polled by the MCP server and forwarded to the LLM as `notifications/progress`) ingested every trace event without honouring the `:sensitive?` flag stamped by the runtime (rf2-a32kd / #564). That's a contract violation: redacted data could leak to the LLM.

## What changed

**`skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs`**
- New private `privacy-config` atom; default `{:include-sensitive? false}`.
- New public `configure-privacy!` — the opt-in escape hatch for apps where the pair tool itself is the trust boundary (e.g. self-hosted MCP inside a private VPN).
- New public `privacy-config-snapshot` for diagnostics.
- New private `streaming-drop?` guard consulted at `on-trace-streaming` entry — drops `:sensitive? true` events from streaming-sub dispatch under the default policy.

The `last-trace-id` cursor still advances over dropped events so `:since`-based ring-buffer reads stay monotonic. The retain-N ring via `(rf/trace-buffer)` is unaffected — explicit reads were never in scope and already expose `(rf/trace-buffer {:sensitive? false})` as the filter knob (Spec 009 §Filter vocabulary).

**`tests/runtime/streaming_subscriptions_test.clj`** — mirror the guard in the bb-runnable test substrate and add five deftests:

- `streaming-drop-defaults-to-suppressing-sensitive-events`
- `streaming-drop-allows-opt-in-via-include-sensitive`
- `sensitive-events-not-forwarded-to-subscribers-by-default`
- `sensitive-events-forwarded-when-operator-opts-in`
- `privacy-filter-respects-topic-filter-composition` (the guard runs *before* the per-sub filter)

**Documentation**
- `references/vocabulary.md` — new §Privacy posture explaining what `:sensitive?` means, what gets dropped, what doesn't (epoch records, ring buffer), the relationship to `with-redacted`, and the opt-in incantation.
- `references/ops.md` — new `trace/configure-privacy` row in the Trace table.
- `SKILL.md` — one-line bullet in style guidance pointing at the references.

## Scope

Held tight to the trace-event surface per the bead's `Sites` notes. Epoch records do not carry a top-level `:sensitive?` per spec — apps that need per-event payload redaction inside an epoch use the framework's `with-redacted` interceptor (rf2-a32kd / #564); this is documented in the new vocabulary section as a deliberate separation. A follow-on bead can extend the streaming guard to epoch records if defense-in-depth proves necessary.

## Test plan

- [x] `bb tests/runtime/streaming_subscriptions_test.clj` — 20 tests / 57 assertions / 0 failures
- [x] All other `tests/runtime/*.clj` — green (80 tests total across the runtime suite)
- [ ] Manual smoke test against a live shadow-cljs build with a `:sensitive? true` handler — confirm streaming subs no longer receive the events; ring buffer + epoch records still do.