### PR TITLE
feat(story): default-suppress :sensitive? trace events per spec/009 §Privacy (rf2-bclgj)

### DIFF
--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -431,13 +431,24 @@
   `re-frame.source-coords.editor-uri/editor-uri` for the per-editor URI
   grammar.
 
+  `{:trace/show-sensitive? <bool>}` — privacy gate for `:sensitive?
+  true` trace events per Spec 009 §Privacy (rf2-bclgj). Defaults to
+  `false` — Story's trace, actions, recorder, and play-assertion
+  listeners drop sensitive events and the UI surfaces a `[● REDACTED]`
+  hint. Set to `true` while debugging redaction policy to see the raw
+  cascade.
+
   Other keys are accepted for forward compatibility but ignored at
   Stage 3."
-  [{:keys [global-args editor] :as _opts}]
+  [{:keys [global-args editor]
+    show-sensitive? :trace/show-sensitive?
+    :as opts}]
   (when (some? global-args)
     (config/set-global-args! global-args))
   (when (some? editor)
     (config/set-editor! editor))
+  (when (contains? opts :trace/show-sensitive?)
+    (config/set-show-sensitive! show-sensitive?))
   nil)
 
 ;; ---- registry reset (test fixtures) -------------------------------------

--- a/tools/story/src/re_frame/story/config.cljc
+++ b/tools/story/src/re_frame/story/config.cljc
@@ -173,3 +173,110 @@
   "Return the current editor preference."
   []
   @editor)
+
+;; ---- *show-sensitive?* (rf2-bclgj — :sensitive? trace-event policy) ------
+;;
+;; Per Spec 009 §Privacy (resolved by rf2-a32kd): framework-published
+;; trace-consuming integrations MUST default-suppress `:sensitive? true`
+;; events. Story is a framework-published consumer — the trace panel,
+;; actions panel, recorder, and play assertions module all subscribe to
+;; the raw trace stream — so each listener body gates on this flag.
+;;
+;; Default is `false` (suppress sensitive events). A story author
+;; debugging redaction policy flips this on via
+;; `(story/configure! {:trace/show-sensitive? true})`.
+;;
+;; The flag is read at the head of every listener body, so toggling it
+;; takes effect on the next trace event without re-registering listeners.
+
+(defonce
+  ^{:doc "Atom holding the `:trace/show-sensitive?` flag. Default
+         `false`. When `false` (default), every Story-registered trace
+         listener short-circuits on events whose `:sensitive?` field is
+         true, and the UI surface tracks how many were suppressed.
+         When `true`, listeners receive every event unchanged. Per
+         Spec 009 §Privacy + bead rf2-bclgj."}
+  show-sensitive?
+  (atom false))
+
+(defn set-show-sensitive!
+  "Replace the `:trace/show-sensitive?` flag. Story's `configure!`
+  calls this. `nil` resets to the default (`false`)."
+  [v]
+  (reset! show-sensitive? (boolean v))
+  nil)
+
+(defn get-show-sensitive
+  "Return the current `:trace/show-sensitive?` flag value."
+  []
+  @show-sensitive?)
+
+(defn sensitive-event?
+  "True iff the trace event `ev` carries `:sensitive? true` at the top
+  level. Per Spec 009 §Privacy + §Listener filtering semantics — the
+  framework stamps `:sensitive? true` on every trace event emitted
+  inside a registration that opted in, and consumers branch on this
+  flag. Absent/false means non-sensitive."
+  [ev]
+  (boolean (and (map? ev) (= true (:sensitive? ev)))))
+
+(defn suppress-sensitive?
+  "Should this trace event be suppressed by a Story-registered
+  listener under the current `:trace/show-sensitive?` setting?
+
+  Returns `true` iff (a) the event is `:sensitive? true` AND (b) the
+  show-sensitive flag is `false`. Listeners wrap their body in
+  `(when-not (suppress-sensitive? ev) ...)`."
+  [ev]
+  (and (sensitive-event? ev)
+       (not @show-sensitive?)))
+
+;; ---- *suppressed-counters* (rf2-bclgj — UI redaction indicator) ----------
+;;
+;; The UI panels (trace, actions) render a `[● REDACTED]` hint when
+;; sensitive events were suppressed for the focused variant. The hint
+;; tells the user "you're seeing fewer events than the runtime emitted
+;; because the privacy gate is on" — useful when a sensitive cascade
+;; would otherwise vanish silently.
+;;
+;; The counter is per-variant (keyed by `:tags :frame`), with a `:global`
+;; bucket for events that have no frame scope (registration-time emits,
+;; outermost-dispatch lookup failures — `:sensitive?` is rarely set on
+;; those, but we keep the bucket so a count is never lost).
+
+(defonce
+  ^{:doc "Atom: `{variant-id → suppressed-count}`. Each Story-side
+         listener that drops a sensitive event bumps the counter for
+         the event's `:tags :frame`. The UI's redaction hint reads
+         this counter; `reset-suppressed-count!` clears it (e.g. on
+         variant teardown or 'clear' button)."}
+  suppressed-counters
+  (atom {}))
+
+(defn note-suppressed!
+  "Bump the suppressed-events counter for the variant the event
+  targeted. Called by every Story-registered listener when
+  `suppress-sensitive?` returned true. `variant-id` may be `nil` /
+  absent — those count under `:global`."
+  [variant-id]
+  (let [k (or variant-id :global)]
+    (swap! suppressed-counters update k (fnil inc 0)))
+  nil)
+
+(defn suppressed-count
+  "Return the count of sensitive trace events that have been
+  suppressed for `variant-id`. Zero if no events have been suppressed
+  (or no listener has reported any) for that variant. `nil` /
+  unspecified returns the `:global` bucket."
+  ([] (suppressed-count :global))
+  ([variant-id]
+   (or (get @suppressed-counters (or variant-id :global)) 0)))
+
+(defn reset-suppressed-count!
+  "Reset the suppressed-events counter. With no arg, clears all.
+  With a `variant-id`, clears just that bucket. Called from the UI's
+  'clear' button and on variant teardown."
+  ([] (reset! suppressed-counters {}) nil)
+  ([variant-id]
+   (swap! suppressed-counters dissoc (or variant-id :global))
+   nil))

--- a/tools/story/src/re_frame/story/play.cljc
+++ b/tools/story/src/re_frame/story/play.cljc
@@ -109,28 +109,39 @@
 
   Listener executes INSIDE the running dispatch drain, so it never
   re-enters dispatch-sync — it stores side-effects in atoms and lets
-  the play-runner drain them between events."
+  the play-runner drain them between events.
+
+  Per Spec 009 §Privacy + rf2-bclgj: events whose `:sensitive?` flag
+  is true are dropped before any accumulator updates when the global
+  `:trace/show-sensitive?` flag is false (the default). The
+  suppressed-events counter bumps for the targeted frame so the UI
+  can surface a `[● REDACTED]` hint."
   [frame-id]
   (fn [ev]
     (when (= frame-id (frame-of ev))
-      (case (:op-type ev)
-        :warning      (assertions/record-warning! frame-id ev)
-        :error        (do (assertions/record-warning! frame-id ev)
-                          (when (= :rf.error/handler-exception (:operation ev))
-                            (record-pending-exception! frame-id ev)))
-        :event        (when (= :event/dispatched (:operation ev))
-                        (let [event-vec (get-in ev [:tags :event])]
-                          (when (and event-vec
-                                     (not (assertions/assertion-event? event-vec)))
-                            (assertions/record-dispatched! frame-id event-vec))))
-        :event/do-fx  (let [fx-map (get-in ev [:tags :fx])]
-                        (when (map? fx-map)
-                          (doseq [fx-id (keys fx-map)]
-                            (assertions/record-emitted-fx! frame-id fx-id))))
-        :fx           (let [fx-id (get-in ev [:tags :fx-id])]
-                        (when fx-id
-                          (assertions/record-emitted-fx! frame-id fx-id)))
-        nil))))
+      (cond
+        (config/suppress-sensitive? ev)
+        (config/note-suppressed! frame-id)
+
+        :else
+        (case (:op-type ev)
+          :warning      (assertions/record-warning! frame-id ev)
+          :error        (do (assertions/record-warning! frame-id ev)
+                            (when (= :rf.error/handler-exception (:operation ev))
+                              (record-pending-exception! frame-id ev)))
+          :event        (when (= :event/dispatched (:operation ev))
+                          (let [event-vec (get-in ev [:tags :event])]
+                            (when (and event-vec
+                                       (not (assertions/assertion-event? event-vec)))
+                              (assertions/record-dispatched! frame-id event-vec))))
+          :event/do-fx  (let [fx-map (get-in ev [:tags :fx])]
+                          (when (map? fx-map)
+                            (doseq [fx-id (keys fx-map)]
+                              (assertions/record-emitted-fx! frame-id fx-id))))
+          :fx           (let [fx-id (get-in ev [:tags :fx-id])]
+                          (when fx-id
+                            (assertions/record-emitted-fx! frame-id fx-id)))
+          nil)))))
 
 (defn- drain-pending-exceptions!
   "Append any pending exception trace events from `frame-id` as

--- a/tools/story/src/re_frame/story/recorder.cljc
+++ b/tools/story/src/re_frame/story/recorder.cljc
@@ -279,21 +279,31 @@
   "Trace-bus callback. Routes a single trace event through the
   recorder's filter chain:
 
-    1. Must be a `:event/dispatched` emission.
-    2. Must target the recorder's `:variant-id` (skip cross-frame
+    1. Must NOT be a `:sensitive? true` event (per Spec 009 §Privacy
+       + rf2-bclgj — Story is a framework-published trace consumer
+       that default-suppresses sensitive events; otherwise the
+       recorder would capture an event vector that the surrounding
+       cascade is trying to keep out of off-box egress).
+    2. Must be a `:event/dispatched` emission.
+    3. Must target the recorder's `:variant-id` (skip cross-frame
        traffic — interactions in another canvas shouldn't show up).
-    3. Must carry an event vector on `:tags :event`.
+    4. Must carry an event vector on `:tags :event`.
 
   `record-event!` applies the `recordable-event?` filter (assertion
   events, internal helpers) before appending."
   [ev]
   (when (recording?)
-    (let [{:keys [op-type operation tags]} ev]
-      (when (and (= op-type :event)
-                 (= operation :event/dispatched)
-                 (= (:frame tags) (recording-variant))
-                 (vector? (:event tags)))
-        (record-event! (:event tags))))))
+    (cond
+      (config/suppress-sensitive? ev)
+      (config/note-suppressed! (get-in ev [:tags :frame]))
+
+      :else
+      (let [{:keys [op-type operation tags]} ev]
+        (when (and (= op-type :event)
+                   (= operation :event/dispatched)
+                   (= (:frame tags) (recording-variant))
+                   (vector? (:event tags)))
+          (record-event! (:event tags)))))))
 
 (defn install-trace-listener!
   "Install the recorder's trace-bus listener. Idempotent — re-installing

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -91,14 +91,27 @@
   collects `:rf.error/handler-exception` events targeting `variant-id`'s
   frame. After the body returns, walks the captured errors and records
   each as a phase-tagged assertion via `record-error!`. Returns `body-fn`'s
-  return value."
+  return value.
+
+  Per Spec 009 §Privacy + rf2-bclgj: handler-exception trace events
+  whose `:sensitive?` flag is true are dropped from the capture set
+  when the global `:trace/show-sensitive?` flag is false (the
+  default). A counter bump is recorded so the UI's redaction hint
+  can surface 'N sensitive events suppressed'. Sensitive cascades
+  fail silently to the developer's eye on purpose — opt in via
+  `(story/configure! {:trace/show-sensitive? true})` to surface them
+  in the assertions list while debugging redaction policy."
   [variant-id phase body-fn]
   (let [collected (atom [])
         cb-id     (keyword "re-frame.story.runtime"
                            (str "capture-" (swap! capture-counter inc)))
         listener  (fn [ev]
-                    (when (and (= :rf.error/handler-exception (:operation ev))
-                               (= variant-id (get-in ev [:tags :frame])))
+                    (cond
+                      (config/suppress-sensitive? ev)
+                      (config/note-suppressed! (get-in ev [:tags :frame]))
+
+                      (and (= :rf.error/handler-exception (:operation ev))
+                           (= variant-id (get-in ev [:tags :frame])))
                       (swap! collected conj ev)))]
     (trace/register-trace-cb! cb-id listener)
     (try

--- a/tools/story/src/re_frame/story/ui/actions.cljc
+++ b/tools/story/src/re_frame/story/ui/actions.cljc
@@ -97,6 +97,7 @@
   contract."
   #?(:cljs
      (:require [reagent.core            :as r]
+               [re-frame.story.config   :as config]
                [re-frame.story.ui.trace :as trace])))
 
 ;; ---- the dispatch-shaped fx-ids -----------------------------------------
@@ -356,9 +357,14 @@
      "Clear the underlying trace buffer for `variant-id`.  Shared with
      the trace panel — both panels read the same buffer — so this is
      a destructive operation.  Unpauses on clear (otherwise the panel
-     would still render the now-stale snapshot)."
+     would still render the now-stale snapshot).
+
+     Per rf2-bclgj: also clears the per-variant suppressed-events
+     counter so the redaction hint hides when the user resets the
+     panel."
      [variant-id]
      (trace/clear-buffer! variant-id)
+     (config/reset-suppressed-count! variant-id)
      (unpause! variant-id)
      nil))
 
@@ -397,6 +403,13 @@
                        :color "white"
                        :border-color "#264f78"}
       :hint           {:color "#9a9a9a"
+                       :font-style "italic"
+                       :font-size "10px"
+                       :margin-bottom "6px"}
+      ;; rf2-bclgj: the redaction hint mirrors the trace panel's
+      ;; `[● REDACTED]` indicator. Muted red so the privacy-gate state
+      ;; reads as advisory, not as a hard error.
+      :redact-note    {:color "#d16969"
                        :font-style "italic"
                        :font-size "10px"
                        :margin-bottom "6px"}
@@ -479,12 +492,20 @@
        (fn [variant-id]
          (let [paused (paused? variant-id)
                events (current-events variant-id)
-               rows   (project-rows events)]
+               rows   (project-rows events)
+               ;; rf2-bclgj: same per-variant suppressed-events counter
+               ;; the trace panel reads. The trace listener bumps it once
+               ;; per sensitive event, the actions panel renders the
+               ;; redaction hint when the count is non-zero. Read on every
+               ;; render — the buffer's reactive deref above is what re-
+               ;; runs the render.
+               redacted-count (config/suppressed-count variant-id)]
            [:div {:style      (:panel styles)
                   :role       "region"
                   :aria-label "Actions"
                   :tab-index  "0"
-                  :data-test  "story-actions-panel"}
+                  :data-test  "story-actions-panel"
+                  :data-redacted-count (str redacted-count)}
             [:div {:style (:title styles)}
              [:span {:style (:title-text styles)}
               "Actions" (when variant-id (str " " (pr-str variant-id)))
@@ -505,6 +526,17 @@
             [:div {:style (:hint styles)}
              "auto-captures every dispatch + dispatch-shaped fx — "
              "no manual instrumentation needed."]
+            ;; rf2-bclgj: surface the same `[● REDACTED]` hint the trace
+            ;; panel renders so users on the actions panel see the
+            ;; privacy-gate state too.
+            (when (pos? redacted-count)
+              [:div {:style     (:redact-note styles)
+                     :data-test "story-actions-redact-note"}
+               "[● REDACTED] " redacted-count " sensitive event"
+               (when (> redacted-count 1) "s")
+               " suppressed — set "
+               [:code {:style {:color "#9cdcfe"}} ":trace/show-sensitive? true"]
+               " to surface"])
             (if (zero? (count rows))
               [:div {:style (:empty styles)}
                "no actions yet — interact with the variant to see dispatches stream in"]

--- a/tools/story/src/re_frame/story/ui/trace.cljs
+++ b/tools/story/src/re_frame/story/ui/trace.cljs
@@ -83,19 +83,27 @@
         a)))
 
 (defn clear-buffer!
-  "Drop the buffer for `variant-id` (or all buffers when no arg)."
+  "Drop the buffer for `variant-id` (or all buffers when no arg).
+  Per rf2-bclgj: also clears the matching per-variant suppressed-
+  events counter so the `[● REDACTED]` hint hides when the user
+  resets the panel."
   ([]
    (doseq [a (vals @buffers)] (reset! a []))
+   (config/reset-suppressed-count!)
    nil)
   ([variant-id]
    (when-let [a (get @buffers variant-id)]
      (reset! a []))
+   (config/reset-suppressed-count! variant-id)
    nil))
 
 (defn drop-buffer!
-  "Remove the buffer entry entirely. Called from shell unmount."
+  "Remove the buffer entry entirely. Called from shell unmount.
+  Per rf2-bclgj: also clears the per-variant suppressed-events
+  counter so it doesn't leak across variant teardowns."
   [variant-id]
   (swap! buffers dissoc variant-id)
+  (config/reset-suppressed-count! variant-id)
   nil)
 
 (defn- append!
@@ -128,14 +136,25 @@
 (defn register-listener!
   "Install a trace listener that appends every `variant-id`-scoped event
   into the per-variant buffer. Idempotent (re-registering replaces).
-  Returns the listener id."
+  Returns the listener id.
+
+  Per Spec 009 §Privacy + rf2-bclgj: events whose `:sensitive?` flag
+  is true are dropped from the buffer when the global
+  `:trace/show-sensitive?` flag is false (the default). The
+  suppressed-events counter bumps for the variant so the panel's
+  `[● REDACTED]` hint can advertise that the buffer is shorter than
+  the runtime's actual emit count. The actions panel reads from the
+  same buffer (per rf2-5yriz), so the suppression cascades to it for
+  free."
   [variant-id]
   (when config/enabled?
     (let [id (listener-id variant-id)]
       (trace/register-trace-cb! id
         (fn [ev]
           (when (variant-event? variant-id ev)
-            (append! variant-id ev))))
+            (if (config/suppress-sensitive? ev)
+              (config/note-suppressed! variant-id)
+              (append! variant-id ev)))))
       id)))
 
 (defn remove-listener!
@@ -186,6 +205,15 @@
                   :color "#9cdcfe"}
    :scrub-note   {:font-size "10px"
                   :color "#dcdcaa"
+                  :font-style "italic"
+                  :margin-bottom "4px"}
+   ;; rf2-bclgj: the redaction hint surfaces when sensitive events have
+   ;; been suppressed by the per-listener privacy gate. A muted red dot
+   ;; + count + the literal `[● REDACTED]` token from the spec so the
+   ;; user sees why the buffer is shorter than the cascade's actual
+   ;; emit count.
+   :redact-note  {:font-size "10px"
+                  :color "#d16969"
                   :font-style "italic"
                   :margin-bottom "4px"}
    :row          {:display "grid"
@@ -270,7 +298,14 @@
             all-cascades       (group-cascades events)
             visible-cascades   (filter-cascades-up-to all-cascades cap)
             hidden-by-scrub    (- (count all-cascades)
-                                  (count visible-cascades))]
+                                  (count visible-cascades))
+            ;; rf2-bclgj: read the per-variant suppressed-events counter
+            ;; on every render. The atom is plain (not a Reagent ratom),
+            ;; so the dereference doesn't drive reactivity; the buffer's
+            ;; reactive deref above is what re-runs the render — every
+            ;; suppressed event also runs the per-listener body so the
+            ;; counter is up to date the moment we read it.
+            redacted-count     (config/suppressed-count variant-id)]
         ;; Per rf2-xc65: the panel wrap is scrollable (`overflow auto`
         ;; + `max-height 240px`). `tab-index "0"` + an aria-label make
         ;; it keyboard-focusable and named so axe-core's
@@ -280,7 +315,8 @@
                :aria-label "Trace cascades"
                :tab-index  "0"
                :data-test  "story-trace-panel"
-               :data-scrubbed-epoch (when selected-epoch (str selected-epoch))}
+               :data-scrubbed-epoch (when selected-epoch (str selected-epoch))
+               :data-redacted-count (str redacted-count)}
          [:div {:style (:title styles)}
           "Trace " (when variant-id (str (pr-str variant-id))) " — "
           (count events) " events, " (count visible-cascades) " cascades"]
@@ -293,6 +329,18 @@
             (when (pos? hidden-by-scrub)
               (str " — " hidden-by-scrub " later cascade"
                    (when (> hidden-by-scrub 1) "s") " hidden"))])
+         ;; rf2-bclgj: when sensitive events have been suppressed, render
+         ;; the `[● REDACTED]` indicator so the user knows the buffer is
+         ;; shorter than the runtime's actual emit count. The number
+         ;; comes from the per-listener suppression counter.
+         (when (pos? redacted-count)
+           [:div {:style (:redact-note styles)
+                  :data-test "story-trace-redact-note"}
+            "[● REDACTED] " redacted-count " sensitive event"
+            (when (> redacted-count 1) "s")
+            " suppressed — set "
+            [:code {:style {:color "#9cdcfe"}} ":trace/show-sensitive? true"]
+            " to surface"])
          [:div {:style (merge (:row styles) (:header styles))}
           [:span {:style (:cell styles)} "event"]
           [:span {:style (:cell styles)} "handler"]

--- a/tools/story/test/re_frame/story/sensitive_trace_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/sensitive_trace_cljs_test.cljc
@@ -1,0 +1,289 @@
+(ns re-frame.story.sensitive-trace-cljs-test
+  "Privacy / sensitive-trace tests for re-frame2-story (rf2-bclgj).
+
+  Per Spec 009 §Privacy (resolved by rf2-a32kd): framework-published
+  trace-consuming integrations MUST default-suppress `:sensitive? true`
+  events. Story is a framework-published consumer — its play-runner's
+  per-frame listener, the recorder's listener, the runtime's
+  capture-phase-errors listener, and the UI trace-buffer listener all
+  feed accumulators / buffers that the dev panels read.
+
+  ## Coverage
+
+  - **Pure config**: `sensitive-event?`, `suppress-sensitive?`,
+    `note-suppressed!`, `suppressed-count`, `reset-suppressed-count!`
+    against the `show-sensitive?` flag.
+  - **`configure!`**: the `:trace/show-sensitive?` opts key wires
+    through to the config atom.
+  - **Play listener**: the per-frame trace listener default-suppresses
+    sensitive events from the assertions module's accumulators
+    (warnings, dispatched-events, emitted-fx).
+  - **Recorder listener**: a sensitive event does not land in the
+    recorder's captured-events vector.
+
+  Runs on both the JVM (`clojure -M:test`) and the CLJS node-test
+  build (shadow's `:node-test` target; ns ends in `-test.cljc` and
+  picks up via the test-runner's regex).  The trace-panel listener
+  ships as `.cljs` only — its coverage rides on the same
+  `suppress-sensitive?` helper exercised here, and the panel-level
+  redaction indicator is verified by the CLJS ui-cljs test arm."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story            :as story]
+            [re-frame.story.assertions :as assertions]
+            [re-frame.story.config     :as config]
+            [re-frame.story.play       :as play]
+            [re-frame.story.recorder   :as recorder]))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures
+;; ---------------------------------------------------------------------------
+
+(defn reset-config! [f]
+  ;; Always restore the flag to the default before AND after every test
+  ;; so a failing test can't poison the next one.
+  (config/set-show-sensitive! false)
+  (config/reset-suppressed-count!)
+  (try
+    (f)
+    (finally
+      (config/set-show-sensitive! false)
+      (config/reset-suppressed-count!))))
+
+(use-fixtures :each reset-config!)
+
+;; ---------------------------------------------------------------------------
+;; Helpers — synthetic trace events
+;; ---------------------------------------------------------------------------
+
+(defn- sensitive-dispatch-event
+  "Build a `:event/dispatched` trace event flagged `:sensitive? true`.
+  Mirrors the runtime's emit shape per Spec 009 §Privacy."
+  [frame-id event]
+  {:op-type    :event
+   :operation  :event/dispatched
+   :id         1
+   :time       1700000000000
+   :sensitive? true
+   :tags       {:dispatch-id 1
+                :frame       frame-id
+                :event-id    (first event)
+                :event       event}})
+
+(defn- plain-dispatch-event
+  "Build an ordinary `:event/dispatched` trace event (no `:sensitive?`)."
+  [frame-id event]
+  {:op-type   :event
+   :operation :event/dispatched
+   :id        2
+   :time      1700000000010
+   :tags      {:dispatch-id 2
+               :frame       frame-id
+               :event-id    (first event)
+               :event       event}})
+
+(defn- sensitive-warning-event
+  "Build a `:warning` trace event flagged `:sensitive? true`."
+  [frame-id]
+  {:op-type    :warning
+   :operation  :rf.warning/example
+   :id         3
+   :time       1700000000020
+   :sensitive? true
+   :tags       {:dispatch-id 3
+                :frame       frame-id}})
+
+;; ---------------------------------------------------------------------------
+;; Pure config helpers
+;; ---------------------------------------------------------------------------
+
+(deftest sensitive-event?-recognises-flag
+  (testing "events with :sensitive? true are recognised"
+    (is (config/sensitive-event? (sensitive-dispatch-event :v/x [:auth/login])))
+    (is (config/sensitive-event? {:sensitive? true})))
+  (testing "events without :sensitive? or with :sensitive? false are not"
+    (is (not (config/sensitive-event? (plain-dispatch-event :v/x [:counter/inc]))))
+    (is (not (config/sensitive-event? {})))
+    (is (not (config/sensitive-event? {:sensitive? false})))
+    (is (not (config/sensitive-event? {:sensitive? nil}))))
+  (testing "non-map inputs are tolerated"
+    (is (not (config/sensitive-event? nil)))
+    (is (not (config/sensitive-event? "trace event")))
+    (is (not (config/sensitive-event? 42)))))
+
+(deftest suppress-sensitive?-default-suppresses
+  (testing "by default (show-sensitive? false) sensitive events are suppressed"
+    (is (false? (config/get-show-sensitive)))
+    (is (true?  (config/suppress-sensitive?
+                  (sensitive-dispatch-event :v/x [:auth/login])))))
+  (testing "non-sensitive events are never suppressed"
+    (is (false? (config/suppress-sensitive?
+                  (plain-dispatch-event :v/x [:counter/inc]))))))
+
+(deftest suppress-sensitive?-opts-out-when-flag-on
+  (testing "with show-sensitive? true, sensitive events are NOT suppressed"
+    (config/set-show-sensitive! true)
+    (is (true? (config/get-show-sensitive)))
+    (is (false? (config/suppress-sensitive?
+                  (sensitive-dispatch-event :v/x [:auth/login])))))
+  (testing "non-sensitive events remain unsuppressed regardless of flag"
+    (config/set-show-sensitive! true)
+    (is (false? (config/suppress-sensitive?
+                  (plain-dispatch-event :v/x [:counter/inc]))))))
+
+(deftest configure!-wires-show-sensitive-flag
+  (testing "story/configure! routes :trace/show-sensitive? to the config atom"
+    (is (false? (config/get-show-sensitive)) "default is false")
+    (story/configure! {:trace/show-sensitive? true})
+    (is (true? (config/get-show-sensitive))
+        "opt-in flips the flag")
+    (story/configure! {:trace/show-sensitive? false})
+    (is (false? (config/get-show-sensitive))
+        "passing false toggles back"))
+  (testing "configure! without the key leaves the flag untouched"
+    (config/set-show-sensitive! true)
+    (story/configure! {:editor :cursor})
+    (is (true? (config/get-show-sensitive))
+        "the unrelated key didn't reset the flag")))
+
+(deftest set-show-sensitive!-coerces-to-bool
+  (testing "set-show-sensitive! always stores a boolean"
+    (config/set-show-sensitive! "truthy string")
+    (is (true? (config/get-show-sensitive)))
+    (config/set-show-sensitive! nil)
+    (is (false? (config/get-show-sensitive)))
+    (config/set-show-sensitive! false)
+    (is (false? (config/get-show-sensitive)))))
+
+;; ---------------------------------------------------------------------------
+;; Suppressed-events counter
+;; ---------------------------------------------------------------------------
+
+(deftest suppressed-count-defaults-to-zero
+  (is (zero? (config/suppressed-count)))
+  (is (zero? (config/suppressed-count :story.x/y))))
+
+(deftest note-suppressed!-bumps-counter
+  (config/note-suppressed! :story.x/y)
+  (config/note-suppressed! :story.x/y)
+  (config/note-suppressed! :story.a/b)
+  (is (= 2 (config/suppressed-count :story.x/y)))
+  (is (= 1 (config/suppressed-count :story.a/b)))
+  (is (zero? (config/suppressed-count :story.never/seen))))
+
+(deftest note-suppressed!-routes-nil-to-global
+  (config/note-suppressed! nil)
+  (config/note-suppressed! nil)
+  (is (= 2 (config/suppressed-count)))
+  (is (= 2 (config/suppressed-count :global))))
+
+(deftest reset-suppressed-count!-clears
+  (config/note-suppressed! :story.x/y)
+  (config/note-suppressed! :story.a/b)
+  (config/reset-suppressed-count! :story.x/y)
+  (is (zero? (config/suppressed-count :story.x/y)))
+  (is (= 1 (config/suppressed-count :story.a/b)))
+  (config/reset-suppressed-count!)
+  (is (zero? (config/suppressed-count :story.a/b))))
+
+;; ---------------------------------------------------------------------------
+;; Play listener — accumulator routing default-suppresses
+;; ---------------------------------------------------------------------------
+
+(deftest play-listener-suppresses-sensitive-warnings
+  (testing "by default a :sensitive? warning event doesn't reach the warnings accumulator"
+    (let [frame-id :story.sensitive/v
+          build    @#'play/listener-for-frame
+          listen   (build frame-id)
+          ev       (sensitive-warning-event frame-id)]
+      ;; Reset the accumulators per the play-runner's contract.
+      (assertions/reset-trace-accumulators! frame-id)
+      ;; The listener is the fn returned by the (private)
+      ;; `listener-for-frame` builder; rather than emitting through
+      ;; the global trace bus (which spans the whole process), invoke
+      ;; the per-frame listener directly with our synthetic event.
+      (listen ev)
+      (is (empty? (assertions/frame-warnings frame-id))
+          "the warnings accumulator should be empty — the sensitive event was suppressed")
+      (is (pos? (config/suppressed-count frame-id))
+          "the suppressed-events counter should have bumped"))))
+
+(deftest play-listener-suppresses-sensitive-dispatched
+  (testing "by default a :sensitive? :event/dispatched is dropped from the dispatched accumulator"
+    (let [frame-id :story.sensitive/v
+          build    @#'play/listener-for-frame
+          listen   (build frame-id)
+          ev       (sensitive-dispatch-event frame-id [:auth/login {:user "a"
+                                                                    :password "pw"}])]
+      (assertions/reset-trace-accumulators! frame-id)
+      (listen ev)
+      (is (empty? (assertions/frame-dispatched frame-id))
+          "the dispatched-events accumulator stays empty")
+      (is (pos? (config/suppressed-count frame-id))))))
+
+(deftest play-listener-passes-sensitive-when-opted-in
+  (testing "with show-sensitive? true the listener routes sensitive events normally"
+    (config/set-show-sensitive! true)
+    (let [frame-id :story.sensitive/v
+          build    @#'play/listener-for-frame
+          listen   (build frame-id)
+          ev       (sensitive-dispatch-event frame-id [:auth/login {:user "a"}])]
+      (assertions/reset-trace-accumulators! frame-id)
+      (listen ev)
+      (is (seq (assertions/frame-dispatched frame-id))
+          "the dispatched-events accumulator captured the event")
+      (is (zero? (config/suppressed-count frame-id))
+          "the suppressed-events counter stays at zero"))))
+
+(deftest play-listener-still-records-non-sensitive
+  (testing "regression: non-sensitive events flow through both default and opt-in modes"
+    (let [frame-id :story.regression/v
+          build    @#'play/listener-for-frame
+          listen   (build frame-id)
+          ev       (plain-dispatch-event frame-id [:counter/inc])]
+      (assertions/reset-trace-accumulators! frame-id)
+      (listen ev)
+      (is (= [[:counter/inc]] (assertions/frame-dispatched frame-id))
+          "non-sensitive event landed in the accumulator under default settings")
+      (is (zero? (config/suppressed-count frame-id))))))
+
+;; ---------------------------------------------------------------------------
+;; Recorder listener — sensitive events skipped
+;; ---------------------------------------------------------------------------
+
+(deftest recorder-listener-suppresses-sensitive-dispatches
+  (testing "by default the recorder drops :sensitive? events from the capture"
+    (recorder/clear!)
+    (recorder/start-recording! :story.recorder/sens 0)
+    (let [listen @#'recorder/trace-listener
+          ev     (sensitive-dispatch-event :story.recorder/sens
+                                           [:auth/login {:password "x"}])]
+      (listen ev)
+      (is (= [] (recorder/recorded-events))
+          "the recorder's captured-events vector stays empty")
+      (is (pos? (config/suppressed-count :story.recorder/sens))))
+    (recorder/clear!)))
+
+(deftest recorder-listener-captures-sensitive-when-opted-in
+  (testing "with show-sensitive? true the recorder captures :sensitive? events"
+    (config/set-show-sensitive! true)
+    (recorder/clear!)
+    (recorder/start-recording! :story.recorder/sens 0)
+    (let [listen @#'recorder/trace-listener
+          ev     (sensitive-dispatch-event :story.recorder/sens
+                                           [:auth/login {:password "x"}])]
+      (listen ev)
+      (is (= [[:auth/login {:password "x"}]] (recorder/recorded-events))
+          "the captured-events vector now has the sensitive event verbatim")
+      (is (zero? (config/suppressed-count :story.recorder/sens))))
+    (recorder/clear!)))
+
+(deftest recorder-listener-still-captures-non-sensitive
+  (testing "regression: ordinary events still land in the recorder under default settings"
+    (recorder/clear!)
+    (recorder/start-recording! :story.recorder/plain 0)
+    (let [listen @#'recorder/trace-listener
+          ev     (plain-dispatch-event :story.recorder/plain [:counter/inc])]
+      (listen ev)
+      (is (= [[:counter/inc]] (recorder/recorded-events)))
+      (is (zero? (config/suppressed-count :story.recorder/plain))))
+    (recorder/clear!)))


### PR DESCRIPTION
## Summary

Per Spec 009 §Privacy (resolved by rf2-a32kd / PR #564), framework-published trace-consuming integrations MUST default-suppress `:sensitive? true` events. Story is a framework-published consumer with four `register-trace-cb!` sites that ingest the raw trace stream — none yet honoured the flag.

This PR adds the privacy gate at each listener body and surfaces a `[● REDACTED]` UI hint when sensitive events have been suppressed.

## Listener sites filtered

- `tools/story/src/re_frame/story/play.cljc` — per-frame play-runner listener (feeds assertion warnings / dispatched-events / emitted-fx accumulators).
- `tools/story/src/re_frame/story/runtime.cljc` — phase-error capture listener (collects `:rf.error/handler-exception` events for assertion projection).
- `tools/story/src/re_frame/story/recorder.cljc` — recorder listener (captures `:event/dispatched` for Test Codegen `:play` bodies).
- `tools/story/src/re_frame/story/ui/trace.cljs` — UI trace-buffer listener (feeds the six-domino trace panel AND the actions panel, which read from the same per-variant buffer).

## Surface contract

- Default behaviour: sensitive events drop at the listener; the per-variant `suppressed-count` bumps so the UI can advertise the omission.
- Opt-in: `(story/configure! {:trace/show-sensitive? true})` flips the global gate; every Story listener then receives sensitive events unchanged.
- UI indicator: trace panel + actions panel render `[● REDACTED] N sensitive event(s) suppressed — set :trace/show-sensitive? true to surface` when the counter is non-zero. Reset on `clear-buffer!` / `drop-buffer!` / actions `clear!`.

## Test plan

- [x] JVM tests pass (`clojure -M:test` in `tools/story/`): 275 tests / 772 assertions, 0 failures.
- [x] CLJS node-test passes (`npm run test:cljs` in `implementation/`): 1418 tests / 3751 assertions, 0 failures.
- [x] 16 new tests cover `sensitive-event?`, `suppress-sensitive?`, the `note-suppressed!` / `suppressed-count` / `reset-suppressed-count!` counter API, `configure!` wiring, the play-listener default-suppress + opt-in unmask, and the recorder-listener default-suppress + opt-in unmask. Test file is `.cljc` so it runs on both JVM and CLJS targets.