### PR TITLE
docs(skills/pair2): expose subscribe/unsubscribe + streaming recipe (rf2-aks1t)

### DIFF
--- a/skills/re-frame-pair2/SKILL.md
+++ b/skills/re-frame-pair2/SKILL.md
@@ -22,6 +22,8 @@ allowed-tools:
   - mcp__re-frame-pair2__watch-epochs
   - mcp__re-frame-pair2__tail-build
   - mcp__re-frame-pair2__snapshot
+  - mcp__re-frame-pair2__subscribe
+  - mcp__re-frame-pair2__unsubscribe
   - Read
   - Edit
   - Write
@@ -124,6 +126,7 @@ Read the leaf that matches the task. Each reference file is ≤250 lines.
 |---|---|
 | Pick a structured op (read, write, trace, DOM bridge, watch, hot-reload, time-travel) | [references/ops.md](references/ops.md) |
 | Run a named procedure the user asked for ("why didn't my view update?", post-mortem, experiment loop, etc.) | [references/recipes.md](references/recipes.md) |
+| Open a push-mode subscription on the trace or epoch bus (topics, filters, termination) | [references/streaming-subscriptions.md](references/streaming-subscriptions.md) |
 | Translate a structured `{:ok? false :reason ...}` to plain English; suggest the recovery | [references/errors.md](references/errors.md) |
 | Inspect, propose, or hot-swap a frame's `:on-error` policy — the closed return-map contract | [references/on-error.md](references/on-error.md) |
 | Edit source, then wait for the browser to pick up the new code | [references/hot-reload-protocol.md](references/hot-reload-protocol.md) |

--- a/skills/re-frame-pair2/references/mcp-transport.md
+++ b/skills/re-frame-pair2/references/mcp-transport.md
@@ -51,6 +51,10 @@ The server auto-discovers the nREPL port from (in order):
 | `scripts/watch-epochs.sh --event-id-prefix :cart` | `watch-epochs` | `{pred: {"event-id-prefix": ":cart"}}` (pull-mode — call repeatedly with `since-id`) |
 | `scripts/tail-build.sh --probe '<form>'` | `tail-build` | `{probe: "..."}` |
 | _(none — MCP-only)_                | `snapshot`     | `{frames: "all"\|[":rf/default"...], include: ["app-db","sub-cache","machines","epochs","traces"]}` |
+| _(none — MCP-only, push-mode)_     | `subscribe`    | `{topic: "trace"\|"epoch"\|"fx"\|"error", filter: {...}, max-events: 0, max-ms: 0}` — emits `notifications/progress` ticks; resolves on cancel / `max-events` / `max-ms` / `unsubscribe`. See `references/streaming-subscriptions.md`. |
+| _(none — MCP-only)_                | `unsubscribe`  | `{sub-id: "<uuid>"}` — idempotent close. |
+
+The `subscribe` / `unsubscribe` pair is the **push-mode** replacement for `watch-epochs`. Each batch of matching events arrives as a `notifications/progress` notification correlated by the call's `progressToken`; the tool's final result is a summary. Use `subscribe` whenever you want a live narration; fall back to `watch-epochs` (pull-mode) when the agent host doesn't surface progress notifications to the model.
 
 (`inject-runtime` is gone — the runtime ships into the app via
 shadow-cljs `:devtools :preloads`. See `SKILL.md` §Setup.)

--- a/skills/re-frame-pair2/references/ops.md
+++ b/skills/re-frame-pair2/references/ops.md
@@ -80,6 +80,17 @@ Read-only from the trace stream + epoch history.
 
 ## Live watch (push-mode)
 
+Two transports, same underlying assembled-epoch / trace stream.
+
+**MCP streaming subscriptions (preferred for push-mode).** True server-pushed events delivered via `notifications/progress`, correlated by the call's `progressToken`. See [streaming-subscriptions.md](streaming-subscriptions.md) for topics, filters, termination, and the recipes that prefer this path.
+
+| Op | MCP tool | Behaviour |
+|---|---|---|
+| `trace/subscribe` | `mcp__re-frame-pair2__subscribe` | Open a streaming subscription on the `:trace`, `:epoch`, `:fx`, or `:error` bus. Returns a `sub-id`; each batch arrives as a `notifications/progress` tick until termination. |
+| `trace/unsubscribe` | `mcp__re-frame-pair2__unsubscribe` | Close a subscription by `sub-id`. Idempotent — unknown ids return `:existed? false`. |
+
+**Pull-mode poll (legacy / fallback).** The `watch-epochs` MCP tool and the bash-shim `scripts/watch-epochs.sh` are pull-mode wrappers: call repeatedly with `since-id` to drain new matches. Use these when the agent host doesn't surface `notifications/progress` to the model, or when you want a finite window summary rather than a live stream.
+
 | Op | Invocation | Behaviour |
 |---|---|---|
 | `watch/window` | `scripts/watch-epochs.sh --window-ms 30000 --event-id-prefix :checkout/` | Runs for N ms, reports every matching epoch, summarises at end |

--- a/skills/re-frame-pair2/references/recipes.md
+++ b/skills/re-frame-pair2/references/recipes.md
@@ -152,12 +152,30 @@ For `:rf.http/managed` failure-category experiments (Spec 014 §Failure categori
 
 ## "Narrate the next N events"
 
-`watch/count N` with no filter. Report each epoch as a short paragraph (event id, `:trigger-event`, key entries from `:effects` and `:sub-runs`, `app-db` diff summary) as it fires.
+Prefer the push-mode MCP path: call `mcp__re-frame-pair2__subscribe` with `{topic: "epoch", max-events: N}`. Each batch arrives as a `notifications/progress` tick; report each epoch as a short paragraph (event id, `:trigger-event`, key entries from `:effects` and `:sub-runs`, `app-db` diff summary) as it fires. The tool resolves with a summary once `max-events` is reached.
+
+Fallback (host doesn't surface progress notifications): `watch/count N` with no filter, narrate on each pull.
+
+See [streaming-subscriptions.md](streaming-subscriptions.md) for topic / filter / termination detail.
 
 ## "Alert me on slow events"
 
-`watch/stream --timing-ms '>100'`. Silent until a match; report with the `:event/run` duration plus per-interceptor timings from the raw trace.
+Prefer `subscribe {topic: "epoch"}` with no server-side filter (the `epoch-matches?` filter vocab doesn't include a timing predicate — see [streaming-subscriptions.md](streaming-subscriptions.md) §Filter shape). On each `notifications/progress` tick, caller-side check the epoch's `:event/run` duration against the threshold; report matches with per-interceptor timings from the raw trace. Close with `unsubscribe` when the user moves on (or pass `max-ms` for a hard upper bound).
+
+Fallback: `watch/stream --timing-ms '>100'` (the bash shim applies the timing predicate caller-side too, but the wrapper hides that detail).
 
 ## "Watch for X while I interact"
 
-`watch/stream --event-id-prefix :checkout/` (or other predicate). Narrate each match; summarise when idle.
+Prefer `subscribe {topic: "epoch", filter: {":event-id-prefix": ":checkout/"}}` (or other predicate from the `epoch-matches?` vocab — see [streaming-subscriptions.md](streaming-subscriptions.md) §Filter shape). Narrate each match as it arrives via `notifications/progress`; summarise when the stream goes idle. Close with `unsubscribe` (or `max-events` / `max-ms`) when the user moves on.
+
+Fallback: `watch/stream --event-id-prefix :checkout/`.
+
+### Inspect what's currently subscribed
+
+`re-frame-pair2.runtime/subscription-info` reports every open subscription's `{:id :topic :filter :queue-depth :overflow :created-at}` without draining the queues. To list active streams:
+
+```
+mcp__re-frame-pair2__eval-cljs {form: "(re-frame-pair2.runtime/subscription-info)"}
+```
+
+Use this when a streaming probe seems to have gone quiet — confirm it's still registered (and that its queue-depth isn't piling up against a dead consumer) before assuming the bus is dry.

--- a/skills/re-frame-pair2/references/streaming-subscriptions.md
+++ b/skills/re-frame-pair2/references/streaming-subscriptions.md
@@ -1,0 +1,164 @@
+# Streaming subscriptions — push-mode trace and epoch buses
+
+True server-pushed events from the running re-frame2 app, delivered as
+`notifications/progress` notifications on a long-running MCP `tools/call`.
+The MCP tools are `subscribe` and `unsubscribe`; the runtime-side
+implementation lives in `re-frame-pair2.runtime/subscribe!` /
+`drain-subscription!` / `unsubscribe!`.
+
+## Contents
+
+- [When to use this vs. `watch-epochs`](#when-to-use-this-vs-watch-epochs)
+- [Topic vocabulary](#topic-vocabulary)
+- [Filter shape per topic](#filter-shape-per-topic)
+- [Progress-notification correlation](#progress-notification-correlation)
+- [Termination](#termination)
+- [Privacy posture](#privacy-posture)
+- [Worked invocation](#worked-invocation)
+- [Diagnostics — what's currently registered?](#diagnostics--whats-currently-registered)
+
+## When to use this vs. `watch-epochs`
+
+Two transports cover the same buses; pick by interaction shape.
+
+| Want | Reach for |
+|---|---|
+| Live narration while the user interacts; report events the moment they fire | `subscribe` (push-mode) |
+| Finite window summary at the end (e.g. "show me everything in the next 30s") | `watch-epochs` (pull-mode) with `since-id` polling, or the `scripts/watch-epochs.sh --window-ms` shim |
+| Stream until a fixed number of matches, then summarise | `subscribe` with `max-events` |
+| Agent host doesn't surface `notifications/progress` to the model | `watch-epochs` (pull-mode) |
+
+`subscribe` is the **push-mode** path; the long-running tools/call holds open until termination and emits each batch of matching events as a `notifications/progress` tick. `watch-epochs` is the **pull-mode** path; you call it repeatedly with the last `:epoch-id` you've seen and drain matches each time. Op semantics are otherwise identical — both consume the same runtime sub queues.
+
+## Topic vocabulary
+
+Four topics, two underlying buses.
+
+| Topic | Bus | Returns |
+|---|---|---|
+| `:trace` | raw trace stream | every trace event matching `:filter` |
+| `:epoch` | assembled-epoch bus | every `:rf/epoch-record` matching `:filter` |
+| `:fx` | raw trace stream | sugar for `:topic :trace :filter {:op-type :fx ...}` |
+| `:error` | raw trace stream | sugar for `:topic :trace :filter {:op-type :error ...}` |
+
+The `:fx` and `:error` topics are convenience sugar — they pre-pin the `:op-type` filter so you can layer additional trace-vocab keys on top.
+
+Use `:epoch` whenever you want assembled cascades (with their `:sub-runs` / `:renders` / `:effects` projections); use `:trace` (or its sugar) when you need raw trace-event detail (handler timings, registry traces, sub-cache events, the things the projection drops).
+
+## Filter shape per topic
+
+The filter map is `nil` (no filter) or a topic-specific map. Server-side normalisation happens on the runtime via `compose-trace-filter` (trace family) or `epoch-matches?` (epoch family).
+
+### `:trace` / `:fx` / `:error` — trace-buffer filter vocab
+
+Mirrors `(rf/trace-buffer)` per Spec 009. Recognised keys:
+
+- `:operation` — exact trace operation keyword (e.g. `:event/dispatched`)
+- `:op-type` — broad category: `:event` `:sub` `:fx` `:render` `:cofx` `:error` `:registry` `:internal`
+- `:frame` — frame id (e.g. `:rf/default`)
+- `:severity` — `:debug` `:info` `:warn` `:error`
+- `:event-id` — exact event id keyword
+- `:handler-id` — exact handler id keyword (e.g. for `:sub/run` traces)
+- `:source` — `:tags.source` value
+- `:origin` — `:tags.origin` value (`:pair` `:app` `:ui` `:timer` `:http`)
+- `:dispatch-id` — exact dispatch-id; combine with `cascade-of` for tree drills
+- `:since-ms` / `:between` — time-window keys (see [ops.md](ops.md) `trace/buffer`)
+
+See [ops.md `trace/buffer`](ops.md#trace) for the full vocab.
+
+### `:epoch` — epoch-matches? predicate vocab
+
+Mirrors the `watch-epochs` pull-mode pred map. Recognised keys:
+
+- `:event-id` — exact match against the epoch's `:event-id`
+- `:event-id-prefix` — `str/starts-with?` match (so `:cart` matches `:cart/apply-coupon`)
+- `:effects` — fx-id appearing in the `:effects` projection
+- `:touches-path` — vector path that resolves to a non-nil value in either `:db-before` or `:db-after`
+- `:sub-ran` — sub-id or first element of `:query-v` appearing in `:sub-runs`
+- `:render` — render-key (stringified) appearing in `:renders`
+- `:origin` — `:origin` tag on the trigger event's `:event/dispatched` trace
+- `:frame` — frame id
+
+**No timing-ms filter on the server side.** The `:epoch` vocab doesn't include timing predicates; for "alert me on slow events" you subscribe with no timing filter and apply the threshold caller-side on each progress tick.
+
+## Progress-notification correlation
+
+The MCP client passes a `progressToken` on the `tools/call` for `subscribe`; each batch the server emits as a `notifications/progress` notification carries that same token, so the host can correlate notifications to the originating call. The progress payload looks like:
+
+```json
+{
+  "progressToken": "<client-supplied>",
+  "progress": <tick-number>,
+  "message": "<EDN-printed batch of events>",
+  "data": { "overflow": <count> }
+}
+```
+
+The `message` slot is an EDN-printed string of the batch (a vector of events for `:trace` topics, a vector of `:rf/epoch-record` maps for `:epoch`). The agent reads `message` directly; capable hosts can additionally inspect `data` for structured counts.
+
+When sensitive events are dropped, the payload carries an extra `:dropped-sensitive` count; see [Privacy posture](#privacy-posture) below.
+
+## Termination
+
+A subscription terminates — and the originating `tools/call` resolves with a summary — when any of the following fires (first wins):
+
+| Reason | Trigger |
+|---|---|
+| `:aborted` | The MCP client cancels the `tools/call` (user interrupt, host shutdown) |
+| `:max-events-reached` | `max-events > 0` and the delivered-count reached it |
+| `:max-ms-reached` | `max-ms > 0` and that many ms elapsed |
+| `:sub-gone` | The runtime-side sub was removed externally (e.g. an `unsubscribe` call with this `sub-id`, or a full-page reload that dropped the runtime) |
+
+`unsubscribe` is **idempotent** — closing an unknown `sub-id` returns `:existed? false` rather than erroring. Safe to call as a cleanup hook even if you don't know whether the subscription is still live.
+
+The final summary the call resolves with:
+
+```edn
+{:ok? true
+ :sub-id   "<uuid>"
+ :topic    :epoch
+ :delivered <count>
+ :overflow  <count>
+ :ticks     <count>
+ :reason    :max-events-reached  ;; or one of the four above
+ ;; optional, only when sensitive drops occurred:
+ :dropped-sensitive <count>}
+```
+
+## Privacy posture
+
+Per Spec 009 §Privacy, framework-published listener integrations MUST default-suppress `:sensitive? true` events before they cross the LLM boundary. The pair2 streaming forwarder enforces this on both the runtime side (subscription queue dispatch drops sensitive events before they ever enqueue) and the MCP side (the server strips any that slip through).
+
+Opt back in per-call with `include-sensitive?: true`. Dropped count surfaces as `:dropped-sensitive` on each progress payload (when non-zero) and on the final summary.
+
+See [vocabulary.md §Privacy posture](vocabulary.md#privacy-posture--sensitive-and-the-streaming-surface) for the full posture and how to opt in app-wide.
+
+## Worked invocation
+
+Narrate the next 5 cart-prefixed dispatches:
+
+```
+mcp__re-frame-pair2__subscribe {
+  topic: "epoch",
+  filter: {":event-id-prefix": ":cart/"},
+  max-events: 5
+}
+```
+
+The call returns a `sub-id` on first response, emits a `notifications/progress` for each batch, and resolves with `:reason :max-events-reached` after the fifth event. No explicit `unsubscribe` needed in this shape — `max-events` closes the sub.
+
+For an open-ended live narration, omit `max-events` and `max-ms`; close manually with `unsubscribe` when the user moves on:
+
+```
+mcp__re-frame-pair2__unsubscribe {sub-id: "<the uuid from the subscribe response>"}
+```
+
+## Diagnostics — what's currently registered?
+
+`re-frame-pair2.runtime/subscription-info` reports every open subscription without draining its queue:
+
+```
+mcp__re-frame-pair2__eval-cljs {form: "(re-frame-pair2.runtime/subscription-info)"}
+```
+
+Returns `{:ok? true :subs [{:id :topic :filter :queue-depth :overflow :created-at}]}`. Useful when a probe seems to have gone quiet — confirm the sub is still registered (and that `queue-depth` isn't piling up against a dead consumer) before assuming the bus is dry.


### PR DESCRIPTION
## Summary

The pair2-mcp server exposes `subscribe` and `unsubscribe` tools (rf2-hq49) but the consumer skill's `allowed-tools` front-matter doesn't list them — so the agent host blocks the tools even though the server advertises them.

This PR:

- Adds `mcp__re-frame-pair2__subscribe` and `mcp__re-frame-pair2__unsubscribe` to `skills/re-frame-pair2/SKILL.md` `allowed-tools`.
- Adds a new `references/streaming-subscriptions.md` leaf (164 lines) covering: push-mode vs. pull-mode, topic vocab (`:trace` / `:epoch` / `:fx` / `:error`), per-topic filter shape, the `notifications/progress` correlation model, termination (cancel / `max-events` / `max-ms` / `unsubscribe`), privacy posture, a worked invocation, and the `subscription-info` diagnostic.
- Updates the three streaming-shaped recipes in `references/recipes.md` ("Narrate the next N events" / "Alert me on slow events" / "Watch for X while I interact") to prefer the push-mode `subscribe` path with `watch-epochs` as the pull-mode fallback.
- Reorganises `references/ops.md` §"Live watch (push-mode)" so MCP streaming is presented as preferred and the bash-shim pull-mode block stays as fallback.
- Adds `subscribe` / `unsubscribe` rows to `references/mcp-transport.md` §"Bash-shim → MCP tool mapping".

Closes the cleanest immediate win from the skills↔MCP audit (rf2-fvy7o).

## Test plan

No code-test surface for skill-doc changes. Verified:

- [x] `grep -c "mcp__re-frame-pair2__" skills/re-frame-pair2/SKILL.md` → 11 (9 front-matter + 2 prose); 9 entries in `allowed-tools` matches the 9 tools exported from `tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs`.
- [x] New leaf is 164 lines — under the 250-line per-leaf cap.
- [x] Cross-references resolve: new leaf is linked from SKILL.md loading map, ops.md, recipes.md (×2), mcp-transport.md.
- [x] Tool names match server-side exports (verified against `tool-descriptors` in `tools.cljs`).
- [x] `epoch-matches?` filter vocab in the new leaf matches the runtime function's recognised keys; called out the missing `:timing-ms` predicate (caller-side filtering required for the "slow events" recipe).