### PR TITLE
docs(skills/re-frame2): Story authoring leaf extensions (rf2-7iks3)

### DIFF
--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -61,7 +61,7 @@ Load at most two leaves per task. If a task seems to need three, it likely spans
 
 **State machines — `reference/state-machines/`**: `reg-machine.md`, `regions.md` (parallel), `tags.md`, `invoke.md` (child machines), `cancellation.md`.
 
-**Tooling — `reference/tooling/`**: `stories.md`, `routing.md`.
+**Tooling — `reference/tooling/`**: `stories.md`, `routing.md`, `story-recorder.md` (record canvas interactions as `:play`), `story-mcp-loop.md` (agent self-healing loop over MCP).
 
 **Cross-cutting — `reference/cross-cutting/`**: `testing.md` (with-frame, dispatch-sync, compute-sub), `api-cheatsheet.md`.
 

--- a/skills/re-frame2/reference/tooling/stories.md
+++ b/skills/re-frame2/reference/tooling/stories.md
@@ -80,13 +80,39 @@ Distilled from `examples/reagent/counter_with_stories/stories.cljs` — every ke
 
 - **No fn slots in variant bodies.** `:events`, `:play`, `:decorators`, `:loaders` carry **event-vectors and ids** — never anonymous functions. The `:rf/variant` schema (in `spec/Spec-Schemas.md`) enforces this; macro-time validation rejects with `:rf.error/variant-shape`. The single legal closure site is a `:hiccup`-kind decorator's `:wrap` slot at the decorator's registration site (not the variant body).
 - **`:events` vs `:play`.** `:events` (phase 2) runs before render; the trace-bus accumulator is NOT yet installed, so `:rf.assert/dispatched?` will not see those events. Put events you want to assert against in `:play` (phase 4). Variant 3 in the counter example demonstrates this — three `[:counter/inc]` dispatches in `:play`, then `[:rf.assert/dispatched? [:counter/inc]]`.
-- **Component is an id, not a fn.** `:component :app.views/counter-card` — the keyword id of a `reg-view`. Story consults the view's registered Malli schema (Spec 010) to auto-derive `:argtypes` for the controls panel; supplying `:argtypes` overrides per-key.
+- **Component is an id, not a fn.** `:component :app.views/counter-card` — the keyword id of a `reg-view`. Story consults the view's registered Malli schema (Spec 010) to auto-derive `:argtypes` for the controls panel — see Schema-derivation pipeline below; supplying `:argtypes` overrides per-key.
 - **Reference events / views / decorators by id; require their namespaces only to trigger registration.** The stories namespace does not `:refer` view fns — it `:require`s `[app.events] [app.views]` for side-effect loading and uses the keyword ids.
 - **`:rf.assert/*` events record, they do not throw.** The seven canonical assertions append a record to `:assertions` rather than aborting the play sequence. Use `(story/read-assertions variant-id)` and `(story/assertions-passing? result)` from a test runner. See `tools/story/spec/004-Assertions.md`.
 - **`:extends` is resolved at registration time.** A variant inheriting from another merges the parent's body once; cycles raise `:rf.error/extends-cycle` at `reg-variant` time, not at render.
-- **Modes multiply snapshot identity.** Each `(variant × mode)` cell has an independent `snapshot-identity` — visual-regression services iterate cells, not variants. Precedence (lowest to highest): global `configure!` args < mode args < story args < variant args.
+- **Loaders run before events, in their own phase.** Phase 1 (`:loaders`) seeds remote-data or installs long-lived fx — websocket subscriptions, firestore listeners — *before* phase-2 `:events`. The runtime waits for `:loaders-complete-when` (default: HTTP fx complete on response-event dispatch; long-lived fx complete on first inbound message) before draining `:events`. Authors override the predicate by setting `:loaders-complete-when` to an event id or a literal vector-of-event-vectors. Phase 3 renders; phase 4 runs `:play`. Put fixture seeds in `:loaders`, pre-render setup in `:events`, user interactions to assert against in `:play`.
+- **Modes multiply snapshot identity; args precedence is strict.** Each `(variant × mode)` cell has an independent `snapshot-identity` — visual-regression services iterate cells, not variants. Effective args compose in this order (later wins): global `configure!` args → story `:args` → mode `:args` (deep-merge of nested maps, replace for vectors) → variant `:args` → cell-local overrides from the controls panel (`:story/set-arg`).
 - **Combined form (Form B).** `(reg-story id {:variants {:a {...} :b {...}}})` desugars at macro-expansion time to one `reg-story*` + N `reg-variant*` top-level forms — hot-reload-by-variant still works. The `*`-suffixed runtime helpers are public for programmatic / MCP-driven registration.
 - **Production elision.** Under `:advanced` every `reg-*` and the seven `:rf.assert/*` event-ids drop to `nil` via the `:rf.story/enabled?` goog-define. Do not condition production code on story state.
+
+## Schema-derivation pipeline (controls panel)
+
+The controls panel auto-derives a widget per arg-key by walking the component's Malli schema. `resolve-argtypes` consults, in order:
+
+1. **Explicit `:argtypes`** on the variant body, then the parent story (per-key override).
+2. **Explicit `:schema` slot** on the variant, story, or registered view (forward-compatible — Spec 010 will land `:rf/schema` on variants).
+3. **Value-shape fallback** — infer the widget from the live CLJS value when no schema is available.
+
+Walker output for the common Malli forms (rf2-agshe):
+
+| Schema | Widget |
+|---|---|
+| `:string` / `:keyword` | `:text` (keyword-coercion at edit time) |
+| `:int` / `:double` (optional `:min` / `:max`) | `:number` |
+| `:boolean` | `:boolean` |
+| `[:enum a b c]` | `:select` with `:options [a b c]` |
+| `[:map [k1 s1] [k2 s2] ...]` | `:group` — one nested row per key |
+| `[:vector X]` | `:repeater` — rows of `X` with `[+]` / `[-]` affordances |
+| `[:set X]` | `:repeater` `:kind :set` — values round-trip through `set` |
+| `[:tuple X Y ...]` | `:tuple` — fixed-arity, one row per position |
+
+The walker recurses: `[:map [:meta [:map [:author :string]]]]` yields a `:group` whose `[:meta]` entry is itself a `:group` with one `:author` `:text` row. Editing entry `kN` writes through to `[:cell-overrides variant-id arg-key kN ...]` at the appropriate depth; integer indices for vector/tuple slots.
+
+When no schema is available the fallback infers from the value: maps recurse as `:group`, vectors as `:repeater`, scalars classify by `string?`/`integer?`/`boolean?`. This keeps "zero argtypes" stories from collapsing to inert `:text` widgets for non-trivial shapes. Author-supplied `:argtypes` still wins key-by-key over either derivation path.
 
 ## Stories as a unit-test substrate
 
@@ -97,9 +123,13 @@ For tests that don't need a render shell, run variants headless from a JVM test 
 ## Deeper material
 
 - Authoring grammar in full (every key, every slot) → `SKILL-REDIRECT.md` → *EP — Stories (007)*.
+- Schema-derivation pipeline reference (every collection operator, default-element seeding, path-aware write contract) → `tools/story/spec/001-Authoring.md` §Schema-derivation pipeline.
+- Args precedence + four-phase lifecycle full detail → `tools/story/spec/002-Runtime.md` §Args resolution precedence, §Four-phase lifecycle.
 - Worked example, every macro at least once → `examples/reagent/counter_with_stories/`.
 - The seven `:rf.assert/*` events, semantics + source-stamping → `SKILL-REDIRECT.md` → *EP — Stories (007)* §Assertions.
 - Render shell, panel placement, multi-substrate pane → `SKILL-REDIRECT.md` → *Guide — Stories*.
+- Test Codegen (record canvas interactions as `:play`) → `story-recorder.md` (sibling leaf).
+- Agent self-healing loop over MCP (variant authoring → run → assert → refine) → `story-mcp-loop.md` (sibling leaf).
 - MCP write surface (programmatic registration via `reg-*` helpers) → `SKILL-REDIRECT.md` → *EP — Stories (007)* §MCP Surface.
 
 ---

--- a/skills/re-frame2/reference/tooling/story-mcp-loop.md
+++ b/skills/re-frame2/reference/tooling/story-mcp-loop.md
@@ -1,0 +1,108 @@
+# Story-MCP self-healing loop
+
+> The agent loop pattern: write a variant → run it via story-mcp → assert via `:rf.assert/*` → refine on failure. Assumes you already know what MCP is — this leaf covers the four-step loop and the story-mcp tools that wire each step.
+
+## When to load this leaf
+
+- An agent (Claude Code, Cursor, Copilot) is generating variants against a re-frame2 codebase and needs to iterate against the running Story library.
+- You're hand-driving the loop yourself via the MCP tool palette to debug a flaky variant.
+- You're explaining why the agent never needs to read source files to refine — `read-failures` returns enough.
+
+Do **not** load this leaf to learn how to author a variant — see `stories.md`. Load it for: the tools in the loop, the step boundaries, and one worked iteration.
+
+## The four steps
+
+```
+   ┌──────────────────────────────────────────────────────────────┐
+   │  1. Author     2. Run         3. Assert        4. Refine     │
+   │  variant   →   via MCP    →   via :rf.assert/*  →   on fail  │
+   │  (or edit)     run-variant    read-failures        update    │
+   └──────────────────────────────────────────────────────────────┘
+                              ↑                            │
+                              └────────────────────────────┘
+                                  loop until :passing? true
+```
+
+Each step has a story-mcp tool. The loop terminates when `run-variant` returns `:passing? true` or the agent hits its retry ceiling.
+
+## Tool catalogue — by step
+
+Per `tools/story-mcp/spec/002-Tool-Registry.md`, sixteen tools across four categories. The seven that participate in the loop:
+
+| Step | Tool | Category | What it does |
+|---|---|---|---|
+| 1 | `register-variant` | Write (gated) | `re-frame.story/reg-variant*` with the agent's body |
+| 1 | `unregister-variant` | Write (gated) | symmetric tear-down between iterations |
+| 2 | `run-variant` | Testing | full four-phase lifecycle; returns `:passing?` boolean |
+| 2 | `preview-variant` | Dev | "show me what this looks like" — post-pipeline state plus share URL |
+| 3 | `read-failures` | Testing | diagnostic over `:rf.story/assertions` accumulator (no re-run) |
+| 4 | `get-variant` | Docs | full variant body as canonical EDN, for the agent to read before editing |
+| 4 | `register-variant` | Write (gated) | re-registration with the refined body (overwrites) |
+
+`get-story-instructions` (Dev) is the agent's onboarding read — it returns the EDN-first constraint, the canonical variant body keys, the seven `:rf.assert/*` events, the four-phase lifecycle, and the inclusion-tag vocabulary as one self-contained string. Agents call it once per session, before authoring.
+
+## Worked loop
+
+The agent has been asked to add a "user clicks delete then confirms" variant for `:story.todos/list-with-items`. Iteration one:
+
+```
+agent → register-variant
+  {:variant-id :story.todos/delete-confirmed
+   :body {:extends :story.todos/list-with-items
+          :play [[:todo/delete-pressed 3]
+                 [:todo/confirm-pressed]
+                 [:rf.assert/path-equals [:todos :items] []]]}}
+
+agent → run-variant {:variant-id :story.todos/delete-confirmed}
+  ← {:passing? false :lifecycle :ok :elapsed-ms 18 ...}
+
+agent → read-failures {:variant-id :story.todos/delete-confirmed}
+  ← [{:assertion :rf.assert/path-equals
+      :path [:todos :items]
+      :expected []
+      :actual  [{:id 1 :text "buy milk"} {:id 2 :text "..."}]
+      :passed? false
+      :source {:file ".../todos.cljs" :line 47}}]
+```
+
+The agent reads the failure: two items still remain because the parent variant seeded *three* todos and the delete only removed id `3`. The assertion was wrong. The agent refines:
+
+```
+agent → register-variant   ; overwrites
+  {:variant-id :story.todos/delete-confirmed
+   :body {:extends :story.todos/list-with-items
+          :play [[:todo/delete-pressed 3]
+                 [:todo/confirm-pressed]
+                 [:rf.assert/path-equals [:todos :items] [{:id 1} {:id 2}]]
+                 [:rf.assert/dispatched? [:todo/deleted 3]]]}}
+
+agent → run-variant {:variant-id :story.todos/delete-confirmed}
+  ← {:passing? true ...}
+```
+
+Loop terminates. The agent reports the final variant body back to the user.
+
+## Gates and prerequisites
+
+- **Write surface is gated.** `register-variant` / `unregister-variant` require `re-frame.story-mcp.config/allow-writes?` truthy — set via `--allow-writes` flag, `RF_STORY_MCP_ALLOW_WRITES=true` env, or `-Drf.story-mcp.allow-writes=true` JVM property. Without it the loop is read-only (`run-variant` + `read-failures` still work against existing variants).
+- **`register-variant`'s parent story must already exist.** v1.1 omits `register-story` deliberately. The agent fails into a documented error when the `:story.<path>` parent isn't registered; the user lands the parent inline.
+- **`read-failures` does not re-run.** It reads the last-run accumulator. Pair with `run-variant` per iteration; do not assume an old `:passing? false` reflects the current body.
+
+## Common gotchas — loop-specific
+
+- **`:rf.assert/*` events record, they do not throw.** A failing assertion does not abort the play sequence. `read-failures` returns the full failure list per iteration — the agent sees every mismatch at once, not just the first.
+- **`:passing?` is the loop terminator.** Truthy when every assertion in the play sequence passed. Equivalent to `(every? :passed? (:assertions result))` but pre-computed by `run-variant`.
+- **Snapshot-identity for skip-when-unchanged.** `snapshot-identity` returns a content hash of `(variant × args × decorators × loaders × substrate × modes)`. Agents that iterate across N variants skip cells whose identity matches a previous run.
+- **Source-coord stamping survives MCP registration.** `register-variant` stamps `{:file <agent-supplied> :line <n>}` if provided in the body; without it, `:source` is omitted and failure records carry no jump-to-line affordance. Agents that want clickable failures supply `:source` from the file they'll write the variant back into.
+
+## Deeper material
+
+- Full tool registry + per-tool I/O schemas → `tools/story-mcp/spec/002-Tool-Registry.md` and `tools/story-mcp/spec/API.md`.
+- Wire protocol (JSON-RPC over stdio, `initialize` handshake) → `tools/story-mcp/spec/001-Wire-Protocol.md`.
+- Write-surface gating → `tools/story-mcp/spec/003-Write-Surface-Gating.md`.
+- Recorder integration (`record-as-variant`) → `story-recorder.md` (sibling leaf).
+- Variant body shape, `:rf.assert/*` vocabulary → `stories.md` (sibling leaf).
+
+---
+
+*Derived from `tools/story-mcp/spec/` @ main. Re-verify after MCP tool-registry changes or write-surface gating updates.*

--- a/skills/re-frame2/reference/tooling/story-recorder.md
+++ b/skills/re-frame2/reference/tooling/story-recorder.md
@@ -1,0 +1,90 @@
+# Story Test Codegen — record-as-`:play`
+
+> Recording canvas interactions and pasting the captured trace into a `:play` body. Assumes you already know what record-and-save UX is (Storybook 9's marquee feature) — this leaf covers re-frame2's specific recorder surface and the canvas-as-fixture pattern that makes it work.
+
+## When to load this leaf
+
+- A variant's `:play` body needs to grow but you'd rather drive the canvas than hand-author the event vectors.
+- You're scripting an MCP agent that calls `start-recording!` / `stop-recording!` on the variant frame.
+- You're explaining why this is one screenful of code in re-frame2 vs Storybook's Testing-Library translation layer.
+
+Do **not** load this leaf to learn what a story is, or to author a variant body from scratch — see `stories.md` first. Load it for: the recorder's public surface, the filter layers, and the snippet that drops out.
+
+## Canvas-as-fixture — why the recorder is trivial here
+
+A variant's frame is already a self-contained fixture: phase-1 loaders seed remote-data, phase-2 `:events` reach the pre-render state, the canvas renders against that frame's app-db. Every interaction (click, type, route) lands as a `dispatch` on the variant's router; the trace bus already projects those dispatches with `:event/dispatched` emissions per Spec 009 §Listener contract.
+
+So the recorder is one filter on the existing emit stream, scoped to the recording's target frame, and the output shape is the exact vector the runtime will re-dispatch under `:play`. No DOM-event capture, no Testing-Library translation, no page-object layer.
+
+## Public surface
+
+```clojure
+;; In re-frame.story
+(story/start-recording!  variant-id)   ; idle → recording; returns recorder state
+(story/stop-recording!)                ; recording → captured; returns state map
+(story/recording?)                     ; boolean
+(story/recorder-state)                 ; read-only view; observe transitions
+(story/clear-recording!)               ; captured → idle; drop the trace
+(story/gen-play-snippet events opts)   ; pure data → string snippet
+```
+
+`gen-play-snippet` opts: `:variant-id` (required keyword id), `:doc` (optional docstring), `:extends` (variant id to inherit `:component` / `:args` / `:decorators` from), `:alias` (form alias, default `story`). The returned string is `read-string`-able and round-trips through the registrar.
+
+## Three filter layers
+
+The trace-bus callback short-circuits unless a recording is in flight, so it's free to leave installed. When recording, three filters apply (in order):
+
+1. **Op-type** — only `:event/dispatched` emissions qualify (`:fx`, `:sub`, `:view`, `:cofx` traffic is dropped).
+2. **Frame scope** — emission `:frame` must match the recording's target variant. Typing in another canvas while a recording is active is dropped.
+3. **Event vocabulary** — `:rf.assert/*` events and Story-internal helpers (`:rf.story/*`, `:re-frame.story.*`) are filtered. Recorded `:play` bodies capture user intent; assertions get added by hand afterwards.
+
+## Worked example — recorded `:play` body
+
+The author starts with a `happy-path` variant. They want a new variant that exercises three increments and a `:by 7`. They click `REC` in the toolbar (right of the strip, just before `[reset]`), drive the canvas, click `REC` again. The save-as-variant modal shows the generated form:
+
+```clojure
+(story/reg-variant :story.counter/recorded-739221
+  {:extends :story.counter/happy-path
+   :play [[:counter/inc]
+          [:counter/inc]
+          [:counter/inc]
+          [:counter/by 7]]})
+```
+
+The author edits the id (`recorded-739221` → `triple-inc-then-seven`), adds a `:doc`, adds the assertions they want by hand:
+
+```clojure
+(story/reg-variant :story.counter/triple-inc-then-seven
+  {:doc     "Three increments then by-7 lands on ten."
+   :extends :story.counter/happy-path
+   :play [[:counter/inc]
+          [:counter/inc]
+          [:counter/inc]
+          [:counter/by 7]
+          [:rf.assert/path-equals [:count] 10]]})
+```
+
+Paste into the stories namespace. Done.
+
+## Common gotchas — recorder-specific
+
+- **Recorder is dev-only; elides under `:advanced`.** Like every Story registration, the recorder ns + UI + API are gated by `:rf.story/enabled?`. Production builds drop the trace-bus listener and the public API stubs return `nil`.
+- **Cross-frame dispatches are dropped, not buffered.** If the user types in another canvas mid-recording, those events do not land in the trace and re-replaying them is not possible. Scope a recording to one variant frame at a time.
+- **Assertions are not auto-recorded.** The third filter layer explicitly drops `:rf.assert/*`. Authored assertions are a deliberate act — the recorder captures *what happened*, the author decides *what to assert about it*.
+- **`:extends` is the canonical extension point for recorded variants.** The recorder generates an `:extends` link to the source variant rather than re-emitting `:component` / `:args` / `:decorators`. Edit the id and add assertions; do not duplicate the parent's body.
+- **One trace-bus callback, process-wide.** The shell installs it at mount, removes at unmount. No per-variant listener registration; the callback's filters do the routing.
+
+## MCP — `record-as-variant`
+
+The story-mcp `record-as-variant` tool calls the same public surface through the Tool-Pair bridge: `start-recording!` → drive interactions (programmatic dispatches or human-in-canvas) → `stop-recording!` → `gen-play-snippet` → snippet returned as the tool's structured output. See `story-mcp-loop.md` for the agent self-healing loop that uses this.
+
+## Deeper material
+
+- Capture boundary, public API, MCP wiring rationale → `tools/story/spec/005-SOTA-Features.md` §Test Codegen.
+- Trace-bus listener primitive → `tools/story/spec/003-Render-Shell.md` §Trace bus, and Spec 009 §Listener contract.
+- Variant body shape (where the recorded `:play` lands) → `stories.md` (sibling leaf).
+- MCP self-healing loop → `story-mcp-loop.md` (sibling leaf).
+
+---
+
+*Derived from `tools/story/spec/005-SOTA-Features.md` §Test Codegen (rf2-5fc15) and `re-frame.story.recorder` source @ main. Re-verify after recorder API or filter-layer changes.*


### PR DESCRIPTION
## Summary

First piece of the HYBRID recommendation from rf2-ncp5n's investigation: extend the existing re-frame2 skill with Story-authoring depth rather than spinning up a separate re-frame-pair-story skill.

- **New leaf `skills/re-frame2/reference/tooling/story-recorder.md`** (90L) — covers the Test Codegen feature (rf2-5fc15): the canvas-as-fixture pattern, the public recorder API (`start-recording!` / `stop-recording!` / `gen-play-snippet`), the three filter layers (op-type / frame-scope / event-vocabulary), and a worked recorded-`:play` snippet. Cross-refs the MCP loop leaf for `record-as-variant`.
- **New leaf `skills/re-frame2/reference/tooling/story-mcp-loop.md`** (108L) — covers the agent self-healing loop: a four-step diagram (author → run → assert → refine), a tool-per-step table (`register-variant`, `run-variant`, `read-failures`, `get-variant`, …), a worked two-iteration loop on a todos delete-confirm variant, and the gates (`allow-writes?`, parent-story prerequisite).
- **Extensions to `stories.md`** (107L → 137L) — wove three additions into the existing flow: schema-derivation pipeline section (rf2-agshe: the three resolution-order steps, walker table for scalar + four collection operators, recursion behaviour, value-shape fallback); a new loaders-phase gotcha covering the four-phase lifecycle and `:loaders-complete-when` defaults; rewrote the modes-precedence gotcha to include the full five-step strict precedence order with deep-merge semantics.
- **SKILL.md** loading-map entry under `Tooling` now points at both new leaves.

All three leaves land under the 150L ceiling (rf2-rdzbz convention).

## Test plan

- [ ] Markdown renders cleanly (preview the three leaves).
- [ ] Cross-refs resolve: sibling `stories.md` / `story-recorder.md` / `story-mcp-loop.md`; external `tools/story/spec/001-Authoring.md`, `002-Runtime.md`, `005-SOTA-Features.md`; `tools/story-mcp/spec/001-`, `002-`, `003-`, `API.md`.
- [ ] Each new leaf has the standard preamble (1-2 line "when to load") + meaty content + cross-refs structure, matching `stories.md` / `routing.md` style.