### PR TITLE
ci(drift): smoke-test skill allowed-tools vs MCP tool catalogue (rf2-flzdp)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,34 @@ jobs:
       - name: Verify lockstep version contract
         run: ./.github/scripts/verify-version-lockstep.sh
 
+  # PR-time drift detection for the skill ↔ MCP tool-catalogue contract
+  # (rf2-flzdp). Source: rf2-fvy7o audit, finding #6. When an MCP server
+  # adds a tool (e.g. pair2-mcp added `subscribe`/`unsubscribe` under
+  # rf2-hq49) the consumer skill's `allowed-tools` front-matter doesn't
+  # auto-update; the agent host blocks the new tool even though the
+  # server advertises it. The script in scripts/check_skill_mcp_drift.py
+  # diffs every MCP-server tool catalogue against its consumer skill's
+  # allow-list and fails on drift in either direction.
+  #
+  # Fast — pure Python stdlib, no setup beyond actions/setup-python.
+  # The script ships with a `_BASELINE` set that documents the drift on
+  # main at PR-landing time so this gate lands before its companion
+  # fix (rf2-aks1t) completes; trim entries from `_BASELINE` as their
+  # underlying drift is resolved.
+  verify-skill-mcp-drift:
+    name: Verify skill ↔ MCP allowed-tools drift (rf2-flzdp)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f  # v5
+        with:
+          python-version: '3.12'
+
+      - name: Diff MCP tool catalogues vs skill allowed-tools
+        run: python scripts/check_skill_mcp_drift.py --verbose --ci
+
   jvm-core:
     name: JVM core (clojure -M:test)
     runs-on: ubuntu-latest

--- a/scripts/check_skill_mcp_drift.py
+++ b/scripts/check_skill_mcp_drift.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+"""Drift smoke-test: skill `allowed-tools` vs MCP server tool catalogue (rf2-flzdp).
+
+Cross-checks every (mcp-server, consumer-skill) pair declared in `MAPPINGS`
+below. For each pair, builds two sets:
+
+  - SERVER tool names — extracted from the MCP server's source (the Clojure
+    `tool-descriptors` / `tool-registry` literal where each tool is a
+    `:name "..."` map entry).
+  - SKILL tool names — extracted from the consumer skill's YAML front-matter
+    `allowed-tools:` block, filtered to `mcp__<prefix>__*` entries.
+
+Then reports two drift directions:
+
+  - MISSING-IN-SKILL — server exposes the tool but skill doesn't allow-list it.
+    Always a failure unless the tool is in `:intentional_server_only` for that
+    mapping. The agent host's permission gate blocks the tool either way; this
+    drift means the skill silently can't reach it.
+
+  - MISSING-IN-SERVER — skill allow-lists a tool the server doesn't expose
+    (any more, or yet). Always a failure — the skill is referencing a phantom.
+
+Causa-MCP is currently spec-only (no `src/`); the script skips its entry
+gracefully rather than failing on missing files.
+
+Exit code:
+    0  no drift detected
+    1  drift detected (printed line-by-line, GitHub-Actions ::error:: style
+       when run under CI)
+    2  invocation / setup error
+
+Usage:
+    python scripts/check_skill_mcp_drift.py
+    python scripts/check_skill_mcp_drift.py --verbose
+    python scripts/check_skill_mcp_drift.py --ci             # tighter output
+                                                             #   (auto on under
+                                                             #   GITHUB_ACTIONS)
+    python scripts/check_skill_mcp_drift.py --show-baseline  # print current
+                                                             #   shipped baseline
+    python scripts/check_skill_mcp_drift.py --no-baseline    # fail on every
+                                                             #   drift, current
+                                                             #   or new
+
+The `_BASELINE` set lets us land this gate before rf2-aks1t completes -- the
+script remembers the current drift and only fails on new drift introduced on
+top of it. As beads close pre-existing drift, trim `_BASELINE` accordingly.
+
+rf2-flzdp.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# ---------------------------------------------------------------------------
+# Configuration.
+#
+# `mappings` declares the (mcp-server source file, MCP-host prefix, consumer
+# skill path) triples that we cross-check. The MCP-host prefix is the
+# `mcp__<prefix>__<tool-name>` string the agent host generates when the
+# server is named in the host's mcp.json — it is conventionally the server's
+# advertised name minus a `-mcp` suffix (re-frame-pair2-mcp → re-frame-pair2).
+#
+# `intentional_server_only` is the escape hatch — names listed there are
+# exposed by the server but intentionally not consumed by the skill (e.g. a
+# write-surface tool gated for non-skill callers). The script ignores the
+# MISSING-IN-SKILL direction for those names; the MISSING-IN-SERVER direction
+# still fires.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Mapping:
+    name: str
+    server_src: Path
+    host_prefix: str
+    skill_md: Path
+    intentional_server_only: frozenset[str] = field(default_factory=frozenset)
+    optional: bool = False  # True ⇒ missing server_src is a skip, not an error.
+
+
+MAPPINGS: list[Mapping] = [
+    Mapping(
+        name="pair2-mcp <-> re-frame-pair2",
+        server_src=REPO_ROOT / "tools" / "pair2-mcp" / "src" / "re_frame_pair2_mcp" / "tools.cljs",
+        host_prefix="re-frame-pair2",
+        skill_md=REPO_ROOT / "skills" / "re-frame-pair2" / "SKILL.md",
+    ),
+    # story-mcp has no canonical consumer skill yet (rf2-1v7tu pending the
+    # Mike-decision). Once a skill ships, add a Mapping for it. Until then
+    # we still validate that the server descriptor file PARSES -- drift in
+    # the catalogue would otherwise be invisible. The skill_md=None path
+    # below treats the missing skill side as a no-op.
+    #
+    # NB: keep this entry commented-in once the decision lands; the empty
+    # skill side prevents false-positives until then.
+    # Mapping(
+    #     name="story-mcp <-> <tbd>",
+    #     server_src=REPO_ROOT / "tools" / "story-mcp" / "src" / "re_frame" / "story_mcp" / "tools.cljc",
+    #     host_prefix="story-mcp",
+    #     skill_md=REPO_ROOT / "skills" / "<tbd>" / "SKILL.md",
+    # ),
+    Mapping(
+        name="causa-mcp <-> <tbd>",
+        server_src=REPO_ROOT / "tools" / "causa-mcp" / "src" / "re_frame" / "causa_mcp" / "tools.cljc",
+        host_prefix="causa",
+        skill_md=REPO_ROOT / "skills" / "causa" / "SKILL.md",
+        optional=True,  # spec-only artefact; src/ doesn't exist yet.
+    ),
+]
+
+# Pre-existing drift the gate accepts as the shipped baseline. Entries are
+# `(mapping-name, direction, tool-name)`. `direction` is one of
+# "missing-in-skill" / "missing-in-server". As follow-up beads fix each
+# entry, drop it from this list — the gate then catches any regression.
+#
+# Entries are keyed by mapping-name (not host_prefix) so renames in MAPPINGS
+# above stay self-consistent.
+_BASELINE: set[tuple[str, str, str]] = {
+    # rf2-aks1t fixes both of these on the pair2 skill side; once that PR
+    # lands, remove these two entries and the gate will turn red on any
+    # future drift.
+    ("pair2-mcp <-> re-frame-pair2", "missing-in-skill", "subscribe"),
+    ("pair2-mcp <-> re-frame-pair2", "missing-in-skill", "unsubscribe"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Server-side extraction.
+#
+# Tool descriptors in both pair2-mcp (.cljs) and story-mcp (.cljc) sit
+# inside a top-level `def` of a vector-of-maps literal. Each tool's name
+# appears as `{:name "<dash-separated>"`. We don't try to evaluate Clojure
+# — we lex out the `:name "..."` pairs from the file. False positives are
+# rare because `:name` is a strong convention and the tools.cljs/cljc files
+# don't use `:name` for anything else.
+#
+# An alternative approach is to spawn `clojure -X` and have it print the
+# tool-descriptor names. We avoid that because:
+#   - it would force the CI step to install + warm a Clojure CLI cache for
+#     a 200ms parse,
+#   - the regex shape is robust against the way these files are actually
+#     written, AND
+#   - the per-tool descriptor blocks are very disciplined (Conventions.md
+#     mandates the `{:name <string> :description ... :inputSchema ...}` map
+#     shape for every MCP tool surface).
+# ---------------------------------------------------------------------------
+
+# Tool-name character class: dash-cased identifiers, plus `>` and `*` and
+# `?` and `!` so we cover the Clojure-flavoured shapes (`variant->edn`,
+# `epochs-since!`, `state-is?`). The MCP names are technically free-form
+# strings, but in practice every tool in the re-frame2 triplet uses these
+# chars. A stricter parser would EDN-read the file -- we keep the regex
+# tight enough that an accidental `:name "foo bar"` (with a space) would
+# fail to match, surfacing as missing-in-skill if the skill listed it.
+_TOOL_NAME_CHARS = r"a-zA-Z0-9_./>!?*-"
+# Matches `{:name "..."` to be safer against an unrelated `:name "..."`
+# appearing in a docstring elsewhere. The actual descriptors always open
+# with `{` immediately before `:name`. The `<` char is deliberately not in
+# the class so the docstring example `{:name "<dash-separated-name>"` --
+# present in tools/story-mcp/src/.../tools.cljc -- does not match.
+STRICT_NAME_RE = re.compile(rf"\{{[^}}]*?:name\s+\"([{_TOOL_NAME_CHARS}]+)\"")
+
+
+def extract_server_tools(path: Path) -> set[str]:
+    """Lex the MCP server source for tool names.
+
+    Returns the set of names declared inside `{:name "..." ...}` map literals.
+    Raises FileNotFoundError if the source doesn't exist (caller handles
+    `optional=True` skip).
+    """
+    text = path.read_text(encoding="utf-8")
+    # Drop comment regions inside descriptor strings (Clojure ;; line
+    # comments) so we don't pick up `;; :name "..."` examples in docstrings.
+    # Pragmatic strip — full reader-aware parsing is overkill for this gate.
+    stripped_lines: list[str] = []
+    for line in text.splitlines():
+        # Strip everything from the first ;; to EOL. Inside-string ;;'s are
+        # extremely rare in this codebase and would only cause a false
+        # positive (extra name spotted), which the cross-check would
+        # surface as a missing-in-skill — caller debugs it.
+        comment = line.find(";;")
+        if comment >= 0:
+            stripped_lines.append(line[:comment])
+        else:
+            stripped_lines.append(line)
+    clean = "\n".join(stripped_lines)
+    return set(STRICT_NAME_RE.findall(clean))
+
+
+# ---------------------------------------------------------------------------
+# Skill-side extraction.
+#
+# `allowed-tools:` is a YAML list under the SKILL.md front-matter. The
+# front-matter is delimited by `---` lines at the top of the file. We do
+# not depend on PyYAML — the format is constrained and we can lex it with
+# a small state machine. The list items can be either bare strings
+# (`- mcp__re-frame-pair2__discover-app`) or `Bash(bd *)`-style wrapped
+# entries. We only care about the `mcp__<prefix>__*` entries for the
+# given prefix.
+# ---------------------------------------------------------------------------
+
+FRONTMATTER_DELIM = "---"
+
+
+def extract_skill_tools(path: Path, host_prefix: str) -> set[str]:
+    """Pull the `mcp__<host_prefix>__*` tool names from a SKILL.md.
+
+    Returns the set of tool names (the trailing chunk after the second `__`).
+    """
+    text = path.read_text(encoding="utf-8")
+    fm = _read_frontmatter(text)
+    if fm is None:
+        # No front-matter at all — treat as empty allow-list; the cross-check
+        # will surface every server tool as missing-in-skill. That's the right
+        # answer.
+        return set()
+    return _parse_allowed_tools(fm, host_prefix)
+
+
+def _read_frontmatter(text: str) -> str | None:
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != FRONTMATTER_DELIM:
+        return None
+    body = []
+    for line in lines[1:]:
+        if line.strip() == FRONTMATTER_DELIM:
+            return "\n".join(body)
+        body.append(line)
+    return None
+
+
+_ALLOWED_TOOLS_KEY = re.compile(r"^allowed-tools\s*:\s*$")
+_LIST_ITEM = re.compile(r"^\s*-\s+(.*?)\s*$")
+
+
+def _parse_allowed_tools(frontmatter: str, host_prefix: str) -> set[str]:
+    """Tiny state machine: find `allowed-tools:`, then collect `- foo`
+    items until indentation drops back to column zero (i.e. the next top
+    level key).  Comment lines (`# ...`) inside the list are tolerated.
+    """
+    tools: set[str] = set()
+    in_block = False
+    prefix_marker = f"mcp__{host_prefix}__"
+    for line in frontmatter.splitlines():
+        if _ALLOWED_TOOLS_KEY.match(line):
+            in_block = True
+            continue
+        if not in_block:
+            continue
+        # Block end: a non-indented, non-list line means we've fallen out
+        # of the allowed-tools block.
+        stripped = line.lstrip()
+        if not stripped:
+            # Blank line — stay in the block (YAML allows blank lines
+            # between list items).
+            continue
+        if stripped.startswith("#"):
+            continue
+        m = _LIST_ITEM.match(line)
+        if not m:
+            # First non-list, non-comment, non-blank line ends the block.
+            break
+        item = m.group(1).strip()
+        if item.startswith(prefix_marker):
+            tools.add(item[len(prefix_marker):])
+    return tools
+
+
+# ---------------------------------------------------------------------------
+# Drift detection.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Drift:
+    mapping_name: str
+    direction: str  # "missing-in-skill" | "missing-in-server"
+    tool: str
+
+    @property
+    def key(self) -> tuple[str, str, str]:
+        return (self.mapping_name, self.direction, self.tool)
+
+    def message(self, mapping: Mapping) -> str:
+        if self.direction == "missing-in-skill":
+            return (
+                f"{mapping.name}: MCP server exposes tool '{self.tool}' "
+                f"but skill '{mapping.skill_md.relative_to(REPO_ROOT)}' "
+                f"does not allow-list mcp__{mapping.host_prefix}__{self.tool}."
+            )
+        return (
+            f"{mapping.name}: skill '{mapping.skill_md.relative_to(REPO_ROOT)}' "
+            f"allow-lists mcp__{mapping.host_prefix}__{self.tool} "
+            f"but the MCP server does not expose a tool by that name."
+        )
+
+
+def check_mapping(mapping: Mapping) -> tuple[list[Drift], list[str]]:
+    """Return (drift, info-messages) for one mapping. Empty drift list = OK."""
+    info: list[str] = []
+    drift: list[Drift] = []
+
+    if not mapping.server_src.exists():
+        if mapping.optional:
+            info.append(
+                f"{mapping.name}: server src '{mapping.server_src.relative_to(REPO_ROOT)}' "
+                "missing -- skipping (optional)."
+            )
+            return drift, info
+        # Hard error -- the mapping declares a server that should be there.
+        raise FileNotFoundError(
+            f"{mapping.name}: server src not found at {mapping.server_src}"
+        )
+
+    if not mapping.skill_md.exists():
+        if mapping.optional:
+            info.append(
+                f"{mapping.name}: skill md '{mapping.skill_md.relative_to(REPO_ROOT)}' "
+                "missing -- skipping (optional)."
+            )
+            return drift, info
+        raise FileNotFoundError(
+            f"{mapping.name}: skill md not found at {mapping.skill_md}"
+        )
+
+    server_tools = extract_server_tools(mapping.server_src)
+    skill_tools = extract_skill_tools(mapping.skill_md, mapping.host_prefix)
+
+    info.append(
+        f"{mapping.name}: server={len(server_tools)} tools, "
+        f"skill={len(skill_tools)} allow-listed."
+    )
+
+    # MISSING-IN-SKILL: server tool not in skill, and not annotated as
+    # intentionally server-only.
+    for t in sorted(server_tools - skill_tools):
+        if t in mapping.intentional_server_only:
+            continue
+        drift.append(Drift(mapping.name, "missing-in-skill", t))
+
+    # MISSING-IN-SERVER: skill allow-list refers to a tool the server does
+    # not expose. Always a failure — `intentional_server_only` cannot relax
+    # this direction (a phantom reference is always wrong).
+    for t in sorted(skill_tools - server_tools):
+        drift.append(Drift(mapping.name, "missing-in-server", t))
+
+    return drift, info
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+def _is_ci() -> bool:
+    return os.environ.get("GITHUB_ACTIONS") == "true"
+
+
+def _emit_error(msg: str, ci: bool) -> None:
+    if ci:
+        # `::error::` lines render as PR-attached annotations.
+        print(f"::error::{msg}", file=sys.stderr)
+    else:
+        print(f"ERROR: {msg}", file=sys.stderr)
+
+
+def main(argv: Iterable[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Diff MCP server tool catalogues against skill allowed-tools.",
+    )
+    parser.add_argument("--verbose", action="store_true",
+                        help="Print per-mapping summary even when no drift.")
+    parser.add_argument("--ci", action="store_true",
+                        help="Emit GitHub-Actions ::error:: lines (auto-on under GITHUB_ACTIONS).")
+    parser.add_argument("--no-baseline", action="store_true",
+                        help="Ignore the shipped baseline — fail on every drift, current or new.")
+    parser.add_argument("--show-baseline", action="store_true",
+                        help="Print the current accepted baseline and exit.")
+    args = parser.parse_args(list(argv))
+
+    ci = args.ci or _is_ci()
+
+    if args.show_baseline:
+        if not _BASELINE:
+            print("Baseline is empty — every drift is a failure.")
+            return 0
+        print("Accepted-baseline drift entries (each will silence one finding):")
+        for k in sorted(_BASELINE):
+            print(f"  {k[0]} | {k[1]} | {k[2]}")
+        return 0
+
+    all_drift: list[tuple[Mapping, Drift]] = []
+    all_info: list[str] = []
+    saw_setup_error = False
+
+    for mapping in MAPPINGS:
+        try:
+            drift, info = check_mapping(mapping)
+        except FileNotFoundError as e:
+            _emit_error(str(e), ci)
+            saw_setup_error = True
+            continue
+        all_info.extend(info)
+        for d in drift:
+            all_drift.append((mapping, d))
+
+    if args.verbose:
+        for line in all_info:
+            print(line)
+
+    # Partition drift against the baseline.
+    new_drift = []
+    silenced = []
+    for m, d in all_drift:
+        if (not args.no_baseline) and d.key in _BASELINE:
+            silenced.append((m, d))
+        else:
+            new_drift.append((m, d))
+
+    if args.verbose and silenced:
+        print()
+        print(f"Silenced by baseline ({len(silenced)}):")
+        for m, d in silenced:
+            print(f"  - {d.message(m)}")
+
+    if new_drift:
+        print()
+        print(f"Drift detected ({len(new_drift)} finding{'' if len(new_drift) == 1 else 's'}):", file=sys.stderr)
+        for m, d in new_drift:
+            _emit_error(d.message(m), ci)
+        # The baseline can be stale: entries in _BASELINE that no longer
+        # reflect actual drift (because the underlying gap was fixed) are
+        # surfaced as a warning so the maintainer trims them. Stale baseline
+        # entries don't fail the build.
+        _warn_stale_baseline(all_drift, args.no_baseline, ci)
+        return 1
+
+    if saw_setup_error:
+        return 2
+
+    if args.verbose or not all_info:
+        print("No skill <-> MCP drift detected.")
+    _warn_stale_baseline(all_drift, args.no_baseline, ci)
+    return 0
+
+
+def _warn_stale_baseline(all_drift, no_baseline: bool, ci: bool) -> None:
+    if no_baseline:
+        return
+    actual_keys = {d.key for _m, d in all_drift}
+    stale = sorted(_BASELINE - actual_keys)
+    if not stale:
+        return
+    msg_header = "Baseline contains entries that no longer reflect actual drift -- trim them from _BASELINE in scripts/check_skill_mcp_drift.py:"
+    if ci:
+        print(f"::warning::{msg_header}", file=sys.stderr)
+    else:
+        print(msg_header, file=sys.stderr)
+    for k in stale:
+        line = f"  stale: {k[0]} | {k[1]} | {k[2]}"
+        print(line, file=sys.stderr)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Adds a CI gate that diffs every MCP server's exported tool catalogue against its consumer skill's `allowed-tools` front-matter and fails on drift. Source: rf2-fvy7o audit, finding #6 / rec #2.

The drift this catches: pair2-mcp grew `subscribe` / `unsubscribe` under rf2-hq49, but the `re-frame-pair2` skill's `allowed-tools` block wasn't updated. The agent host's permission gate silently blocks both tools, even though the server advertises them. This drift went undetected until the rf2-fvy7o audit.

## What's in the PR

- `scripts/check_skill_mcp_drift.py` — pure-stdlib Python script (matches the existing `scripts/check_doc_slugs.py` precedent). Lexes `:name "..."` literals from each MCP server's `tools.cljs`/`tools.cljc` source, parses the skill's YAML front-matter `allowed-tools:` block (no PyYAML dep — small state machine), and reports both drift directions:
  - **missing-in-skill** — server exposes a tool the skill doesn't allow-list (silenceable via `intentional_server_only`)
  - **missing-in-server** — skill allow-lists a phantom (always fails)

- `.github/workflows/test.yml` — adds `verify-skill-mcp-drift` job parallel to `verify-version-lockstep`. Pure Python, sub-second, runs on PRs.

## Current drift baseline

The script ships with a `_BASELINE` set listing the drift currently on `main`, so this gate can land before its companion fix (rf2-aks1t) completes:

```
pair2-mcp <-> re-frame-pair2 | missing-in-skill | subscribe
pair2-mcp <-> re-frame-pair2 | missing-in-skill | unsubscribe
```

As rf2-aks1t closes that drift, the `_BASELINE` entries get trimmed; the gate then catches any future regression. The script warns (without failing) when a baseline entry becomes stale (i.e. the underlying gap was fixed) so the baseline doesn't ossify.

## Mappings

- `pair2-mcp <-> re-frame-pair2` — active, 9 server tools vs 7 allow-listed.
- `causa-mcp <-> <tbd>` — `optional=True`, gracefully skipped (causa-mcp is spec-only).
- `story-mcp <-> <tbd>` — commented out pending the rf2-1v7tu Mike-decision on who owns the consumer skill.

## Test plan

- [x] Run locally with current drift: passes (baseline silences the two known findings)
- [x] Run with `--no-baseline`: fails with both subscribe/unsubscribe errors
- [x] Run with `--show-baseline`: prints the accepted entries
- [x] Inject a phantom skill tool (missing-in-server simulation): correctly fails
- [x] Inject a stale baseline entry: warns but doesn't fail (exit 0)
- [x] Verifies tool extraction matches the rf2-fvy7o audit count (9 for pair2-mcp, 16 for story-mcp including `variant->edn`)
- [x] Skill front-matter parser handles both bare strings and `Bash(bd *)`-style wrapped entries
- [ ] CI run on this PR passes the new job