### PR TITLE
feat(causa): default-suppress :sensitive? trace events per spec/009 §Privacy (rf2-azls9)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -58,11 +58,132 @@
   []
   @editor)
 
+;; ---- *show-sensitive?* (rf2-azls9 — :sensitive? trace-event policy) ------
+;;
+;; Per Spec 009 §Privacy (resolved by rf2-a32kd): framework-published
+;; trace-consuming integrations MUST default-suppress `:sensitive? true`
+;; events. Causa is a framework-published consumer — its ring buffer
+;; feeds every panel (event-detail, causality, trace, machine
+;; inspector, etc.) — so the collector body gates on this flag before
+;; the event reaches the buffer.
+;;
+;; Default is `false` (suppress sensitive events). An engineer debugging
+;; redaction policy flips this on via
+;; `(causa-config/configure! {:trace/show-sensitive? true})`.
+;;
+;; The flag is read at the head of the collector body, so toggling it
+;; takes effect on the next trace event without re-registering the
+;; listener.
+
+(defonce
+  ^{:doc "Atom holding the `:trace/show-sensitive?` flag. Default
+         `false`. When `false` (default), Causa's trace collector
+         short-circuits on events whose `:sensitive?` field is true,
+         and the UI surface tracks how many were suppressed. When
+         `true`, the collector receives every event unchanged. Per
+         Spec 009 §Privacy + bead rf2-azls9."}
+  show-sensitive?
+  (atom false))
+
+(defn set-show-sensitive!
+  "Replace the `:trace/show-sensitive?` flag. Causa's `configure!`
+  calls this. `nil` resets to the default (`false`)."
+  [v]
+  (reset! show-sensitive? (boolean v))
+  nil)
+
+(defn get-show-sensitive
+  "Return the current `:trace/show-sensitive?` flag value."
+  []
+  @show-sensitive?)
+
+(defn sensitive-event?
+  "True iff the trace event `ev` carries `:sensitive? true` at the top
+  level. Per Spec 009 §Privacy + §Listener filtering semantics — the
+  framework stamps `:sensitive? true` on every trace event emitted
+  inside a registration that opted in, and consumers branch on this
+  flag. Absent/false means non-sensitive."
+  [ev]
+  (boolean (and (map? ev) (= true (:sensitive? ev)))))
+
+(defn suppress-sensitive?
+  "Should this trace event be suppressed by Causa's trace collector
+  under the current `:trace/show-sensitive?` setting?
+
+  Returns `true` iff (a) the event is `:sensitive? true` AND (b) the
+  show-sensitive flag is `false`. The collector wraps its body in
+  `(when-not (suppress-sensitive? ev) ...)`."
+  [ev]
+  (and (sensitive-event? ev)
+       (not @show-sensitive?)))
+
+;; ---- *suppressed-counters* (rf2-azls9 — UI redaction indicator) ----------
+;;
+;; The shell's bottom rail renders a `[● REDACTED N]` hint when sensitive
+;; events were suppressed. The hint tells the user "you're seeing fewer
+;; events than the runtime emitted because the privacy gate is on" —
+;; useful when a sensitive cascade would otherwise vanish silently.
+;;
+;; The counter is per-target-frame (keyed by the event's `:tags :frame`),
+;; with a `:global` bucket for events that have no frame scope
+;; (registration-time emits, outermost-dispatch lookup failures —
+;; `:sensitive?` is rarely set on those, but we keep the bucket so a
+;; count is never lost).
+
+(defonce
+  ^{:doc "Atom: `{frame-id → suppressed-count}`. Causa's trace
+         collector bumps the counter for the event's `:tags :frame`
+         when it drops a sensitive event. The UI's redaction hint
+         reads this counter; `reset-suppressed-count!` clears it
+         (e.g. on `clear-buffer!` or via a 'clear' button)."}
+  suppressed-counters
+  (atom {}))
+
+(defn note-suppressed!
+  "Bump the suppressed-events counter for the frame the event
+  targeted. Called by Causa's trace collector when
+  `suppress-sensitive?` returned true. `frame-id` may be `nil` /
+  absent — those count under `:global`."
+  [frame-id]
+  (let [k (or frame-id :global)]
+    (swap! suppressed-counters update k (fnil inc 0)))
+  nil)
+
+(defn suppressed-count
+  "Return the count of sensitive trace events that have been
+  suppressed for `frame-id`. Zero if no events have been suppressed
+  for that frame. With no arg, returns the *total* across every
+  bucket — the bottom-rail indicator uses the total because the
+  user cares about 'is the gate hiding things from me right now',
+  not per-frame breakdown."
+  ([]
+   (reduce + 0 (vals @suppressed-counters)))
+  ([frame-id]
+   (or (get @suppressed-counters (or frame-id :global)) 0)))
+
+(defn reset-suppressed-count!
+  "Reset the suppressed-events counter. With no arg, clears all.
+  With a `frame-id`, clears just that bucket. Called from
+  `trace-bus/clear-buffer!` and from test fixtures."
+  ([] (reset! suppressed-counters {}) nil)
+  ([frame-id]
+   (swap! suppressed-counters dissoc (or frame-id :global))
+   nil))
+
 ;; ---- configure! convenience ---------------------------------------------
 
 (defn configure!
-  "Top-level Causa configuration. Phase 1 accepts `{:editor <kw>}` per
-  rf2-evgf5; future phases extend with theme / buffer / placement keys.
+  "Top-level Causa configuration. Accepts:
+
+    `{:editor <kw>}` — Causa's 'Open in editor' preference (rf2-evgf5).
+    `{:trace/show-sensitive? <bool>}` — privacy gate for `:sensitive?
+       true` trace events per Spec 009 §Privacy (rf2-azls9). Defaults
+       to `false` — Causa's trace collector drops sensitive events
+       and the shell's bottom rail surfaces a `[● REDACTED N]` hint.
+       Set to `true` while debugging redaction policy to see the raw
+       cascade.
+
+  Future phases extend this with theme / buffer / placement keys.
 
   Hosts typically call this once at boot:
 
@@ -70,9 +191,13 @@
       (causa-config/configure! {:editor :cursor})
 
   Returns nothing."
-  [{:keys [editor] :as _opts}]
+  [{:keys [editor]
+    show-sensitive-opt :trace/show-sensitive?
+    :as opts}]
   (when (some? editor)
     (set-editor! editor))
+  (when (contains? opts :trace/show-sensitive?)
+    (set-show-sensitive! show-sensitive-opt))
   nil)
 
 ;; ---- pass-through: editor-uri --------------------------------------------

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -143,6 +143,7 @@
   Subsequent panel beads add their own per-panel events / subs / fxs."
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
+            [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.ai-co-pilot :as ai-co-pilot]
             [day8.re-frame2-causa.panels.time-travel-helpers :as tt-helpers]
@@ -208,6 +209,22 @@
     (rf/reg-sub :rf.causa/trace-buffer
       (fn [_db _query]
         (trace-bus/buffer)))
+
+    ;; Total count of :sensitive? trace events the collector has
+    ;; suppressed under the current `:trace/show-sensitive?` setting
+    ;; (rf2-azls9). The shell's bottom-rail renders a `[● REDACTED N]`
+    ;; hint when this is positive so the user sees why the buffer is
+    ;; shorter than the runtime's actual emit count.
+    ;;
+    ;; The counter lives in `config/suppressed-counters` (a plain
+    ;; atom). This sub thunks the pure-data accessor; like
+    ;; `:rf.causa/trace-buffer` it relies on the surrounding
+    ;; subscribe-graph recompute cycle for staleness — the bottom-rail
+    ;; re-renders whenever any of its sibling subs re-fire, and the
+    ;; counter is read fresh on each pass.
+    (rf/reg-sub :rf.causa/suppressed-sensitive-count
+      (fn [_db _query]
+        (config/suppressed-count)))
 
     ;; Currently-active panel — drives the canvas's switch logic in
     ;; shell.cljs. Default is the hero panel per §10 Lock 7.

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -312,20 +312,43 @@
   badge. Per spec/007-UX-IA.md §The five regions item 5.
 
   Phase 1 stub: minimal frame-info text. Live scrubber lands with the
-  time-travel panel bead."
+  time-travel panel bead.
+
+  ## Redaction indicator (rf2-azls9)
+
+  When Causa's trace collector has dropped one or more `:sensitive?
+  true` events under the default privacy posture, render a
+  `[● REDACTED N]` hint in the centre of the rail. The hint
+  disappears on `trace-bus/clear-buffer!` (counter resets together
+  with the buffer) and when the host calls
+  `(causa-config/configure! {:trace/show-sensitive? true})` BEFORE
+  the events flow (the counter never bumps in that case)."
   []
-  [:footer {:style {:height           "40px"
-                    :display          "flex"
-                    :align-items      "center"
-                    :justify-content  "space-between"
-                    :padding          "0 16px"
-                    :background       (:bg-1 tokens)
-                    :border-top       (str "1px solid " (:border-subtle tokens))
-                    :color            (:text-tertiary tokens)
-                    :font-family      "Inter, system-ui, -apple-system, Segoe UI, sans-serif"
-                    :font-size        "12px"}}
-   [:span "◀◀  ────●────  ▶▶  (scrubber — rf2-xxx)"]
-   [:span "epoch — / —"]])
+  (let [redacted-count @(rf/subscribe [:rf.causa/suppressed-sensitive-count])]
+    [:footer {:style {:height           "40px"
+                      :display          "flex"
+                      :align-items      "center"
+                      :justify-content  "space-between"
+                      :padding          "0 16px"
+                      :background       (:bg-1 tokens)
+                      :border-top       (str "1px solid " (:border-subtle tokens))
+                      :color            (:text-tertiary tokens)
+                      :font-family      "Inter, system-ui, -apple-system, Segoe UI, sans-serif"
+                      :font-size        "12px"}}
+     [:span "◀◀  ────●────  ▶▶  (scrubber — rf2-xxx)"]
+     (when (pos? redacted-count)
+       [:span {:data-testid "rf-causa-redacted-indicator"
+               :title       (str "Spec 009 §Privacy: " redacted-count
+                                 " sensitive trace event"
+                                 (when (not= 1 redacted-count) "s")
+                                 " suppressed by default. Set "
+                                 ":trace/show-sensitive? true via "
+                                 "(causa-config/configure! ...) to "
+                                 "surface them.")
+               :style       {:color       (:magenta tokens)
+                             :font-weight 600}}
+        (str "● REDACTED " redacted-count)])
+     [:span "epoch — / —"]]))
 
 ;; ---- shell view ----------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
@@ -24,8 +24,20 @@
   The buffer is gated on `re-frame.interop/debug-enabled?` (the
   universal `goog.DEBUG` gate) — production builds drop the buffer
   entirely. CLJC so the pure-data shape is JVM-runnable for tests
-  (the CLJS-only side-effect bits live in preload.cljs)."
-  (:require [re-frame.interop :as interop]))
+  (the CLJS-only side-effect bits live in preload.cljs).
+
+  ## Privacy gate (rf2-azls9 — :sensitive? trace events)
+
+  Per Spec 009 §Privacy (resolved by rf2-a32kd): framework-published
+  trace-consuming integrations MUST default-suppress `:sensitive? true`
+  events. `collect-trace!` gates each incoming event on
+  `config/suppress-sensitive?` before any buffer push; suppressed
+  events bump a per-frame counter that drives the bottom-rail's
+  `[● REDACTED N]` hint. An engineer debugging redaction policy
+  opts in via `(causa-config/configure! {:trace/show-sensitive?
+  true})`."
+  (:require [re-frame.interop :as interop]
+            [day8.re-frame2-causa.config :as config]))
 
 ;; ---- ring-buffer state ----------------------------------------------------
 
@@ -65,10 +77,23 @@
   `(rf/register-trace-cb! :rf.causa/trace-collector ...)` at preload
   time. Production builds elide the call (the framework's trace
   emission is gated on `interop/debug-enabled?` and never invokes the
-  callback)."
+  callback).
+
+  Per Spec 009 §Privacy + rf2-azls9: events whose `:sensitive?` flag
+  is true are dropped before the buffer push when the global
+  `:trace/show-sensitive?` flag is false (the default). The
+  suppressed-events counter bumps for the targeted frame so the
+  shell can surface a `[● REDACTED N]` hint. Opt in via
+  `(causa-config/configure! {:trace/show-sensitive? true})` to
+  surface the raw cascade while debugging redaction policy."
   [event]
   (when interop/debug-enabled?
-    (swap! buffer-state push @buffer-depth event)))
+    (cond
+      (config/suppress-sensitive? event)
+      (config/note-suppressed! (get-in event [:tags :frame]))
+
+      :else
+      (swap! buffer-state push @buffer-depth event))))
 
 ;; ---- read-side accessors -------------------------------------------
 
@@ -176,10 +201,14 @@
 
 (defn clear-buffer!
   "Empty the buffer. Tooling uses this between sessions. No-op in
-  production."
+  production. Per rf2-azls9, also resets the per-frame
+  suppressed-sensitive counters so the bottom-rail `[● REDACTED N]`
+  hint disappears alongside the cleared events — clearing the buffer
+  is the natural moment to drop the 'you missed N events' overhang."
   []
   (when interop/debug-enabled?
-    (reset! buffer-state []))
+    (reset! buffer-state [])
+    (config/reset-suppressed-count!))
   nil)
 
 (defn set-buffer-depth!

--- a/tools/causa/test/day8/re_frame2_causa/sensitive_trace_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/sensitive_trace_cljs_test.cljc
@@ -1,0 +1,221 @@
+(ns day8.re-frame2-causa.sensitive-trace-cljs-test
+  "Tests for the `:sensitive?` trace-event privacy gate (rf2-azls9).
+
+  Per Spec 009 §Privacy (resolved by rf2-a32kd) Causa, as a
+  framework-published trace consumer, MUST default-suppress events
+  carrying `:sensitive? true`. This suite covers:
+
+    1. The predicate vocabulary in `config.cljc` —
+       `sensitive-event?` / `suppress-sensitive?`.
+    2. The flag round-trip — `set-show-sensitive!` / `get-show-sensitive`
+       / `configure! {:trace/show-sensitive? ...}`.
+    3. The suppressed-events counter — `note-suppressed!` /
+       `suppressed-count` / `reset-suppressed-count!`.
+    4. `trace-bus/collect-trace!` default-suppress + opt-in pass-
+       through behaviour.
+    5. `trace-bus/clear-buffer!` resets the counter alongside the
+       buffer.
+
+  Pure-data + JVM-runnable so the algebra runs under the JVM target;
+  CLJC keeps the file shadow's `:node-test` target as well."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test    :refer-macros [deftest is testing use-fixtures]])
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- reset-privacy-state [test-fn]
+  ;; Each test starts with the defaults: flag off, counter empty.
+  (config/set-show-sensitive! false)
+  (config/reset-suppressed-count!)
+  (trace-bus/clear-buffer!)
+  (test-fn)
+  (config/set-show-sensitive! false)
+  (config/reset-suppressed-count!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each reset-privacy-state)
+
+;; ---- (1) predicate vocabulary -------------------------------------------
+
+(deftest sensitive-event?-detects-top-level-flag
+  (testing "events with :sensitive? true are sensitive"
+    (is (true? (config/sensitive-event? {:sensitive? true})))
+    (is (true? (config/sensitive-event?
+                 {:op-type :event :operation :event/dispatched
+                  :sensitive? true :tags {:event-id :user/login}}))))
+  (testing "events without :sensitive? are non-sensitive"
+    (is (false? (config/sensitive-event? {})))
+    (is (false? (config/sensitive-event? {:op-type :event})))
+    (is (false? (config/sensitive-event? {:sensitive? false})))
+    (is (false? (config/sensitive-event? {:sensitive? nil}))))
+  (testing "non-map inputs are non-sensitive (no NPE)"
+    (is (false? (config/sensitive-event? nil)))
+    (is (false? (config/sensitive-event? :keyword)))
+    (is (false? (config/sensitive-event? [:vector])))))
+
+(deftest suppress-sensitive?-composes-flag-and-gate
+  (testing "default flag off + sensitive event = suppressed"
+    (is (true? (config/suppress-sensitive? {:sensitive? true}))))
+  (testing "default flag off + non-sensitive event = not suppressed"
+    (is (false? (config/suppress-sensitive? {})))
+    (is (false? (config/suppress-sensitive? {:sensitive? false}))))
+  (testing "flag on + sensitive event = not suppressed (opt-in unmask)"
+    (config/set-show-sensitive! true)
+    (is (false? (config/suppress-sensitive? {:sensitive? true}))))
+  (testing "flag on + non-sensitive event = not suppressed"
+    (config/set-show-sensitive! true)
+    (is (false? (config/suppress-sensitive? {})))))
+
+;; ---- (2) flag round-trip ------------------------------------------------
+
+(deftest default-show-sensitive-is-false
+  (testing "Causa defaults to suppressing :sensitive? events"
+    (is (false? (config/get-show-sensitive)))))
+
+(deftest set-show-sensitive-round-trips
+  (testing "set-show-sensitive! writes and get-show-sensitive reads"
+    (config/set-show-sensitive! true)
+    (is (true? (config/get-show-sensitive)))
+    (config/set-show-sensitive! false)
+    (is (false? (config/get-show-sensitive)))))
+
+(deftest set-show-sensitive-coerces-truthy
+  (testing "set-show-sensitive! coerces truthy / falsy via boolean"
+    (config/set-show-sensitive! "yes")
+    (is (true? (config/get-show-sensitive)))
+    (config/set-show-sensitive! nil)
+    (is (false? (config/get-show-sensitive)))
+    (config/set-show-sensitive! 0)
+    ;; (boolean 0) is true in Clojure — only nil/false are falsy.
+    (is (true? (config/get-show-sensitive)))))
+
+(deftest configure-routes-show-sensitive-through
+  (testing "configure! {:trace/show-sensitive? true} flips the flag"
+    (config/configure! {:trace/show-sensitive? true})
+    (is (true? (config/get-show-sensitive))))
+  (testing "configure! {:trace/show-sensitive? false} returns to default"
+    (config/set-show-sensitive! true)
+    (config/configure! {:trace/show-sensitive? false})
+    (is (false? (config/get-show-sensitive)))))
+
+(deftest configure-without-key-preserves-existing-flag
+  (testing "configure! without :trace/show-sensitive? leaves the flag alone"
+    (config/set-show-sensitive! true)
+    (config/configure! {:editor :cursor})
+    (is (true? (config/get-show-sensitive))
+        "configure! ignoring our key must not stomp the flag")))
+
+;; ---- (3) suppressed-events counter --------------------------------------
+
+(deftest suppressed-count-starts-at-zero
+  (testing "counter is zero before any suppression"
+    (is (= 0 (config/suppressed-count)))
+    (is (= 0 (config/suppressed-count :rf/default)))
+    (is (= 0 (config/suppressed-count :global)))))
+
+(deftest note-suppressed-bumps-the-frame-bucket
+  (testing "note-suppressed! adds 1 to the matching frame bucket"
+    (config/note-suppressed! :rf/default)
+    (is (= 1 (config/suppressed-count :rf/default)))
+    (is (= 1 (config/suppressed-count)) "total across all buckets")
+    (config/note-suppressed! :rf/default)
+    (is (= 2 (config/suppressed-count :rf/default)))
+    (is (= 2 (config/suppressed-count))))
+  (testing "different frames count independently"
+    (config/note-suppressed! :rf/causa)
+    (is (= 2 (config/suppressed-count :rf/default)))
+    (is (= 1 (config/suppressed-count :rf/causa)))
+    (is (= 3 (config/suppressed-count)))))
+
+(deftest note-suppressed-without-frame-counts-as-global
+  (testing "nil frame falls under :global"
+    (config/note-suppressed! nil)
+    (is (= 1 (config/suppressed-count :global)))
+    (is (= 1 (config/suppressed-count)))))
+
+(deftest reset-suppressed-count-clears-buckets
+  (testing "reset with no arg drops everything"
+    (config/note-suppressed! :rf/default)
+    (config/note-suppressed! :rf/causa)
+    (config/reset-suppressed-count!)
+    (is (= 0 (config/suppressed-count)))
+    (is (= 0 (config/suppressed-count :rf/default)))
+    (is (= 0 (config/suppressed-count :rf/causa))))
+  (testing "reset with frame-id drops just that bucket"
+    (config/note-suppressed! :rf/default)
+    (config/note-suppressed! :rf/causa)
+    (config/reset-suppressed-count! :rf/default)
+    (is (= 0 (config/suppressed-count :rf/default)))
+    (is (= 1 (config/suppressed-count :rf/causa)))
+    (is (= 1 (config/suppressed-count)))))
+
+;; ---- (4) collect-trace! default-suppress + opt-in pass-through ----------
+
+(defn- non-sensitive-event []
+  {:op-type :event :operation :event/dispatched
+   :tags {:event-id :user/click :frame :rf/default}})
+
+(defn- sensitive-event []
+  {:op-type :event :operation :event/dispatched
+   :sensitive? true
+   :tags {:event-id :user/login :frame :rf/default}})
+
+;; The collect-trace! tests run only on CLJS — the side-effect path
+;; reads `re-frame.interop/debug-enabled?`, which is true under the
+;; CLJS dev target but resolves to false / unbound under the JVM
+;; target (the interop is browser-runtime-shaped). The pure-data
+;; predicate + counter tests above already exercise the algebra
+;; under the JVM target; these CLJS-only tests lock the wiring.
+
+#?(:cljs
+   (deftest collect-trace-buffers-non-sensitive-by-default
+     (testing "non-sensitive events flow into the buffer"
+       (trace-bus/collect-trace! (non-sensitive-event))
+       (is (= 1 (count (trace-bus/buffer))))
+       (is (= 0 (config/suppressed-count))))))
+
+#?(:cljs
+   (deftest collect-trace-suppresses-sensitive-by-default
+     (testing "sensitive event is dropped from the buffer and bumps the counter"
+       (trace-bus/collect-trace! (sensitive-event))
+       (is (= 0 (count (trace-bus/buffer)))
+           "sensitive event must NOT enter the buffer under the default")
+       (is (= 1 (config/suppressed-count))
+           "the dropped event bumps the counter")
+       (is (= 1 (config/suppressed-count :rf/default))
+           "counter bumps under the event's :tags :frame"))))
+
+#?(:cljs
+   (deftest collect-trace-passes-sensitive-when-opted-in
+     (testing "with :trace/show-sensitive? true the buffer receives the event"
+       (config/configure! {:trace/show-sensitive? true})
+       (trace-bus/collect-trace! (sensitive-event))
+       (is (= 1 (count (trace-bus/buffer)))
+           "opted-in caller sees the sensitive event in the buffer")
+       (is (= 0 (config/suppressed-count))
+           "the counter does NOT bump when the event passes through"))))
+
+#?(:cljs
+   (deftest collect-trace-mixed-flow
+     (testing "default-suppress + opt-in flip mid-stream"
+       (trace-bus/collect-trace! (non-sensitive-event))      ; in
+       (trace-bus/collect-trace! (sensitive-event))          ; dropped
+       (trace-bus/collect-trace! (non-sensitive-event))      ; in
+       (config/configure! {:trace/show-sensitive? true})
+       (trace-bus/collect-trace! (sensitive-event))          ; in
+       (is (= 3 (count (trace-bus/buffer)))
+           "buffer contains the 2 non-sensitive + 1 opted-in sensitive")
+       (is (= 1 (config/suppressed-count))
+           "exactly one event was suppressed under the default"))))
+
+#?(:cljs
+   (deftest clear-buffer-resets-suppressed-counter
+     (testing "clear-buffer! drops the buffer AND the redaction counter"
+       (trace-bus/collect-trace! (sensitive-event))
+       (trace-bus/collect-trace! (sensitive-event))
+       (is (= 2 (config/suppressed-count)))
+       (trace-bus/clear-buffer!)
+       (is (= 0 (config/suppressed-count))
+           "clearing the buffer also drops the indicator state"))))


### PR DESCRIPTION
## Summary

Closes the privacy-posture gap for the last remaining trace consumer in the preload triplet. Per Spec 009 §Privacy (resolved by rf2-a32kd, PR #564), framework-published trace-consuming integrations must default-suppress `:sensitive? true` events. The MCP server (rf2-p6f0h, PR #628), the pair2 preload (rf2-3cted, PR #631), and Story (rf2-bclgj, PR #632) already landed; Causa is the last shoe.

Causa has a single trace-listener site — `trace-bus/collect-trace!` — that feeds every panel (event-detail, causality, trace, machine inspector, etc.) via the central ring buffer. Gating once at the collector cuts off sensitive events before any panel sees them.

## What changed

- **`config.cljc`** — new `:trace/show-sensitive?` flag (default `false`), predicate vocabulary (`sensitive-event?` / `suppress-sensitive?`), per-frame suppressed-events counter, and a `configure!` route for the flag.
- **`trace-bus.cljc`** — `collect-trace!` gates on `config/suppress-sensitive?`; suppressed events bump `config/note-suppressed!` for their target frame. `clear-buffer!` also resets the counter so the indicator hides on buffer reset.
- **`registry.cljs`** — new sub `:rf.causa/suppressed-sensitive-count` exposes the total to the shell.
- **`shell.cljs`** — bottom-rail renders a `[● REDACTED N]` magenta indicator (with a tooltip explaining how to opt in) when the counter is positive.

## Opt-in API

```clojure
(require '[day8.re-frame2-causa.config :as causa-config])
(causa-config/configure! {:trace/show-sensitive? true})
```

Flipping the flag takes effect on the next trace event — no re-registration needed.

## Tests

- 14 new tests in `tools/causa/test/.../sensitive_trace_cljs_test.cljc`
- 8 JVM-runnable (predicate, flag round-trip, `configure!` wiring, counter API)
- 6 CLJS-only (gated by `#?(:cljs ...)` because they exercise the `collect-trace!` side-effect path which reads `interop/debug-enabled?`)

## Test plan

- [x] `clojure -M:test` from `tools/causa/` — 462 tests, 1299 assertions, 0 failures
- [x] `npm run test:cljs` from `implementation/` — 1481 tests, 3918 assertions, 0 failures (16 net new vs prior baseline of 1465)
- [x] `npm run test:bundle-isolation` from `implementation/` — PASS (no new production-surface leakage)

## Deferred

- Epoch-level guard for the cross-cutting `:sensitive?` question is filed under `rf2-re2s3` and is out of scope here. This bead covers Causa's *trace consumer* surface only.