### PR TITLE
docs(skills/pair2): sync frame-meta shape to canonical flat (rf2-bba4s)

### DIFF
--- a/skills/re-frame-pair2/SKILL.md
+++ b/skills/re-frame-pair2/SKILL.md
@@ -112,7 +112,7 @@ re-frame2 supports multiple, named frames (Spec 002). Most apps run with one fra
 
 - `frames/list` — `(rf/frame-ids)` — set of registered, non-destroyed frame ids.
 - `frames/select` — set the session's default operating frame (the runtime caches it).
-- `frames/meta` — `(rf/frame-meta id)` — config + lifecycle for one frame.
+- `frames/meta` — `(rf/frame-meta id)` — flat metadata map for one frame: `:id`, `:created-at`, the preset-expansion keys (`:preset`, `:fx-overrides`, `:drain-depth`, …), and lifecycle fields (`:destroyed?`, `:listeners`) all at the top level. See `:rf/frame-meta` in Spec-Schemas.
 
 When the operating frame is ambiguous (more than one is registered and the session hasn't selected one), **mutating ops refuse with `:ambiguous-frame`** and read ops proceed against `:rf/default` after warning. This mirrors the Spec 002 §Frame presets / lifecycle convention.
 


### PR DESCRIPTION
PR #625 (rf2-p6f0h) flattened `(rf/frame-meta id)` from the previous nested `{:id :config :lifecycle}` grouping to the canonical flat shape pinned by Spec-Schemas `:rf/frame-meta` — `:id` plus the preset-expansion keys (`:preset`, `:fx-overrides`, `:drain-depth`, …) and the lifecycle fields (`:created-at`, `:destroyed?`, `:listeners`) all at the top level of the returned map.

`skills/re-frame-pair2/SKILL.md` §Multi-frame model still described the result as "config + lifecycle for one frame". Rewrite the one-liner so it matches the post-flatten shape and points consumers at `:rf/frame-meta` in Spec-Schemas for the authoritative key list.

## Scope

One line in `skills/re-frame-pair2/SKILL.md` (the `frames/meta` bullet at L115).

## Out of scope (filed as follow-ons)

- `skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs:119` — docstring "Frame metadata (config, lifecycle) for `id`" still uses the stale phrasing. Out of dispatcher scope (preload/), filing follow-on.
- `skills/re-frame2/reference/cross-cutting/api-cheatsheet.md:122` — the row for `rf/frame-meta` in a different skill. Out of dispatcher scope, filing follow-on.

## Verified clean

- No other "config + lifecycle" prose in `skills/re-frame-pair2/`.
- No `(:config ...)` or `(:lifecycle ...)` accessors on the `frame-meta` result anywhere in the skill (`references/on-error.md:55` already uses the flat `(:on-error (rf/frame-meta :rf/default))`).