### PR TITLE
docs(skills/improver2): allow discover-app for live tool-catalogue introspection (rf2-87kv7)

### DIFF
--- a/skills/re-frame-pair-improver2/SKILL.md
+++ b/skills/re-frame-pair-improver2/SKILL.md
@@ -26,6 +26,7 @@ allowed-tools:
   - Write
   - Grep
   - Glob
+  - mcp__re-frame-pair2__discover-app
 ---
 
 # re-frame-pair-improver2

--- a/skills/re-frame-pair-improver2/references/known-frictions.md
+++ b/skills/re-frame-pair-improver2/references/known-frictions.md
@@ -131,6 +131,18 @@ Typical improvements:
 - make "I am attached to a production-elided build" a first-class result state
 - recipe for switching to a dev build before continuing
 
+### Tool-catalogue / build-capability uncertainty
+
+Signals:
+- the retrospective is unsure whether a tool the user "should have reached for" was actually exposed by the running pair2-mcp build, or whether it was reasoning from stale docs
+- the session reasons about tool availability from `re-frame-pair2/references/ops.md` alone — that doc can drift from the live `tools.cljs` catalogue (see rf2-flzdp on the drift gate)
+- a "why didn't they use tool X?" thread surfaces with no way to confirm X was actually callable in that session
+
+Typical improvements:
+- run `mcp__re-frame-pair2__discover-app` once at the start of a retrospective to capture the live build's id, health, and session sentinel — confirms the runtime the user was operating against and (combined with the server's `tools/list`) sanity-checks "tool X was actually available"
+- when proposing a fix that adds or renames a tool, cross-reference the live catalogue rather than the skill's docs alone
+- if `discover-app` itself fails or returns `:reason :runtime-not-preloaded`, that becomes evidence the user's environment never had the pair2 surface — a finding in its own right, not a retro blocker
+
 ### Source-coordinate availability
 
 Signals:


### PR DESCRIPTION
## Summary

- Adds `mcp__re-frame-pair2__discover-app` to `skills/re-frame-pair-improver2/SKILL.md` `allowed-tools` so retrospectives can introspect the live pair2-mcp runtime (build id, session sentinel, health). The tool is a read-only marker probe — no runtime mutation.
- Adds a "Tool-catalogue / build-capability uncertainty" class to `references/known-frictions.md` naming when to reach for `discover-app` during a retrospective: signals (reasoning from possibly-stale docs; unsure whether tool X was exposed in the session being retro'd) and typical improvements (probe the live runtime; cross-reference the catalogue when proposing fixes; treat a `discover-app` failure as evidence in its own right).

Source: rf2-fvy7o skills↔MCP audit, finding #7 / recommendation #6.

## Test plan

- [x] `python scripts/check_skill_mcp_drift.py --verbose` — no new drift. The gate validates `re-frame-pair2` (not improver2) against the pair2-mcp catalogue, so adding a tool to improver2's allow-list doesn't shift the gate output. Pre-existing stale-baseline warnings (`subscribe`, `unsubscribe`) are unrelated and tracked under rf2-aks1t.
- [x] Front-matter parses (YAML list item appended; same indent as siblings).
- [x] New `known-frictions.md` section follows the existing class shape (Signals / Typical improvements bullets).

Closes rf2-87kv7 once merged.