### PR TITLE
docs(skills/migration): point to spec 009 as single source for error-event catalogue (rf2-ldjfh)

### DIFF
--- a/skills/re-frame-migration/SKILL.md
+++ b/skills/re-frame-migration/SKILL.md
@@ -61,6 +61,7 @@ Six phases. Each links to a leaf for the detail; the SKILL.md carries only the w
 - [`reference/auto-cross-cutting.md`](reference/auto-cross-cutting.md) — Type A: cross-cutting renames, interceptor cleanup, view / hiccup rewrites, init wiring, per-feature artefact adds.
 - [`reference/guided-handlers-state.md`](reference/guided-handlers-state.md) — Type B: handler / view / db-seeding / error-handler walkthroughs (M-3, M-5, M-10, M-11, M-12, M-13, M-14, M-15).
 - [`reference/guided-interceptors-subs.md`](reference/guided-interceptors-subs.md) — Type B: interceptor / subscription / payload / observer walkthroughs (M-17, M-18, M-19, M-21, M-23, M-26).
+- [`reference/error-events.md`](reference/error-events.md) — pointer to [`spec/009-Instrumentation.md` §Error event catalogue](../../spec/009-Instrumentation.md#error-event-catalogue) as the single source of truth for `:rf.error/*` / `:rf.warning/*` / `:rf.fx/*` / `:rf.cofx/*` / `:rf.ssr/*` / `:rf.epoch/*` / `:rf.http/*` categories. Load when writing `:on-error` / `register-trace-cb!` (M-13, M-17, M-26).
 - [`reference/breaking-changes.md`](reference/breaking-changes.md) — one-page index of every M-/O-rule by trigger surface; grep here to find the rule id.
 
 **Phase 4 — Verify.** Recompile, re-run unit tests, smoke-test boot / dispatch / sub / hot-reload. If a step fails, find the rule, apply it, re-verify. The skill does not run tests for the author.
@@ -94,6 +95,7 @@ Hand off: *"Migration complete. Switch to **`re-frame2`** for new application co
 - [`reference/auto-cross-cutting.md`](reference/auto-cross-cutting.md) — Type A: cross-cutting renames, view / hiccup, init, per-feature artefacts.
 - [`reference/guided-handlers-state.md`](reference/guided-handlers-state.md) — Type B: handler / view / db-seeding / error-handler walkthroughs.
 - [`reference/guided-interceptors-subs.md`](reference/guided-interceptors-subs.md) — Type B: interceptor / subscription / payload / observer walkthroughs.
+- [`reference/error-events.md`](reference/error-events.md) — pointer to Spec 009's error-event catalogue (single source); load when writing `:on-error` policies or `register-trace-cb!` listeners.
 - [`reference/output-format.md`](reference/output-format.md) — migration-report shape with worked examples.
 
 ## Anti-patterns

--- a/skills/re-frame-migration/reference/error-events.md
+++ b/skills/re-frame-migration/reference/error-events.md
@@ -1,0 +1,96 @@
+# error-events
+
+The **single source of truth** for re-frame2's error / warning / advisory event vocabulary is [`spec/009-Instrumentation.md` §Error event catalogue](../../../spec/009-Instrumentation.md#error-event-catalogue). The catalogue enumerates ~95 categories with `:operation`, `:op-type`, trigger, default `:recovery`, and `:tags` columns. **Do not inline the catalogue here** — duplication will drift; cross-reference the spec instead.
+
+When an agent migrating a v1 codebase needs to answer *"is this error name old or new?"* or *"what does the new `:on-error` policy actually intercept?"* — the answer is one click away in the spec, and this leaf points the way.
+
+## Why this leaf exists
+
+The migration touches three surfaces that hand-off to the error event stream:
+
+- **M-13** — `reg-event-error-handler` is gone. The replacements (frame-level `:on-error`, `register-trace-cb!`) consume events from the catalogue.
+- **M-17 / M-26** — observer-shaped interceptors / post-event callbacks become trace listeners; they filter on `:operation` / `:op-type` from the catalogue.
+- **M-23** — `re-frame.alpha` lifecycle annotations dropped; some user error-recognition code referenced old category names.
+
+Anywhere a migration prompt or post-migration audit mentions "error category", "error event", "trace listener filter", or `:op-type` — point at the spec catalogue. Don't re-list the categories here.
+
+## Namespace prefixes (the closed set)
+
+The catalogue uses **six stable prefixes** (per [Spec 009 §Error namespace convention](../../../spec/009-Instrumentation.md#error-namespace-convention--five-prefix-shapes)):
+
+| Prefix | Meaning |
+|---|---|
+| `:rf.error/*` | A genuine runtime error: a contract was violated. |
+| `:rf.warning/*` | A misuse the runtime recovers from but wants surfaced. |
+| `:rf.fx/*` | An fx-substrate event riding the error envelope (success-path or warning). |
+| `:rf.cofx/*` | A cofx-substrate event riding the error envelope. |
+| `:rf.ssr/*` | An SSR-substrate diagnostic (hydration mismatches, head-divergence). |
+| `:rf.epoch/*` | Time-axis tooling diagnostics (epoch restore failures). |
+
+Plus two narrower families surfaced by the per-feature artefacts:
+
+| Prefix | Meaning |
+|---|---|
+| `:rf.http/*` / `:rf.http.interceptor/*` | Managed-HTTP request lifecycle (retry, abort, interceptor failure). |
+| `:route.nav-token/*` | Navigation-token suppression on stale async results. |
+| `:rf.frame/*` | Frame lifecycle (drain interruption). |
+
+The closed catalogue at [Spec 009 §Error event catalogue](../../../spec/009-Instrumentation.md#error-event-catalogue) enumerates every category. **The prefix list is stable**; new categories adopt an existing prefix. New ad-hoc prefixes are not part of the contract.
+
+## How an `:on-error` policy uses the catalogue
+
+A frame's `:on-error` policy (M-13 replacement) receives any error event whose `:frame` matches the policy's frame. The policy fn dispatches on `:operation`:
+
+```clojure
+(rf/reg-frame
+  :rf/default
+  {:on-error
+   (fn [{:keys [operation tags] :as evt}]
+     (case operation
+       :rf.error/handler-exception {:fx [[:dispatch [:app/log-error evt]]]}
+       :rf.error/sub-exception     {:recovery :replaced-with-default :replacement nil}
+       ;; ... etc — see the catalogue for every :operation the policy may receive
+       nil))})                                       ; let the default recovery apply
+```
+
+The full list of `:operation` values the policy may see is exactly the catalogue. **Reference Spec 009 when writing the `case` arms** — don't guess from memory.
+
+## How a trace listener filters
+
+`register-trace-cb!` (M-13's process-wide-observer replacement and M-17's audit-interceptor replacement) sees every emitted trace event. Filter on `:op-type` for severity branching, `:operation` for category routing:
+
+```clojure
+(rf/register-trace-cb!
+  :audit/sentry
+  (fn [evt]
+    (when (= :error (:op-type evt))                  ; severity branch
+      (sentry/capture evt))))
+```
+
+`:op-type` values: `:error`, `:warning`, `:info`, `:fx`, `:cofx`, `:frame`, `:flow`. The mapping from `:operation` prefix to `:op-type` is in the catalogue's `:op-type` column.
+
+## Production elision
+
+Every recovery in the catalogue applies in **dev only** — trace emission is production-elided per [Spec 009 §Production builds](../../../spec/009-Instrumentation.md#production-builds-zero-overhead-zero-code). Registered `:on-error` callbacks **do not fire in CLJS prod**. Migration audits that surface "the new error-handler doesn't run" reports in production are hitting the elision, not a bug.
+
+## Stale advice the migration agent will encounter
+
+When auditing a v1 codebase, **assume any error-category name not present in the spec catalogue is stale**. Old prose, blog posts, Stack Overflow answers naming specific v1 categories may have invented names or used pre-rf2-wfbn3 spellings. The catalogue at Spec 009 wins; do not infer categories from project comments.
+
+Specific drift to watch:
+
+- v1 `:rf.warning/machine-unhandled-event` / `:rf.warning/machine-state-not-in-definition` / `:rf.warning/machine-snapshot-version-mismatch` were renamed to `:rf.error/*` form (per the catalogue's "Older drafts spelled this…" notes). User code matching the old `:rf.warning/*` spelling needs updating.
+- v1 prose sometimes named ad-hoc keys like `:rf/error` or `:re-frame/error`. The contract surface is `:rf.error/<category>` — closed set only.
+
+## When to point an author at this leaf
+
+- They're writing the `:on-error` fn for M-13 and need to know what events arrive.
+- They're writing a `register-trace-cb!` listener and ask "which categories are errors vs warnings vs informational?"
+- They have a `(case operation …)` shape and want a complete list of arms.
+- A test asserts on an error event's `:operation` keyword and they need the canonical name.
+
+In every case: **link to [Spec 009 §Error event catalogue](../../../spec/009-Instrumentation.md#error-event-catalogue)**. Do not re-enumerate the categories.
+
+---
+
+*Authoritative catalogue: [`spec/009-Instrumentation.md` §Error event catalogue](../../../spec/009-Instrumentation.md#error-event-catalogue). Per-category `:tags` schemas: [`spec/Spec-Schemas.md` §Per-category `:tags` schemas](../../../spec/Spec-Schemas.md#per-category-tags-schemas). Cross-references: M-13 in [`guided-handlers-state.md`](guided-handlers-state.md), M-17 / M-26 in [`guided-interceptors-subs.md`](guided-interceptors-subs.md).*

--- a/skills/re-frame-migration/reference/guided-handlers-state.md
+++ b/skills/re-frame-migration/reference/guided-handlers-state.md
@@ -119,6 +119,8 @@ A v1 codebase that stacked multiple handlers (e.g. one for recovery, one for log
 
 Present the categorisation; confirm with the author; apply.
 
+**Writing the new `:on-error` / trace listener**: the closed set of `:operation` keywords the policy receives — and the `:op-type` / `:tags` shape for filtering trace listeners — lives in [`spec/009-Instrumentation.md` §Error event catalogue](../../../spec/009-Instrumentation.md#error-event-catalogue). See [`error-events.md`](error-events.md) for the pointer and the prefix-family reference. Do not infer category names from the v1 code or comments — the catalogue at Spec 009 is authoritative.
+
 ---
 
 ## M-14 — `:rf.route/not-found` requirement

--- a/skills/re-frame-migration/reference/guided-interceptors-subs.md
+++ b/skills/re-frame-migration/reference/guided-interceptors-subs.md
@@ -142,7 +142,7 @@ Read the body and propose; author confirms.
 
 **Decision shape**:
 
-1. **Observer-shaped callback**: convert to `(rf/register-trace-cb! key cb)`. Trace listeners see every dispatched event; filter on `:operation` for the equivalent.
+1. **Observer-shaped callback**: convert to `(rf/register-trace-cb! key cb)`. Trace listeners see every dispatched event; filter on `:operation` / `:op-type` for the equivalent. The closed catalogue of `:operation` keywords and `:op-type` values lives in [`spec/009-Instrumentation.md` §Error event catalogue](../../../spec/009-Instrumentation.md#error-event-catalogue) — see [`error-events.md`](error-events.md) for the pointer.
 2. **Behaviour-modifying callback**: convert to a frame-level interceptor declared in `reg-frame` metadata.
 
 Read the callback body; categorise; propose; author confirms.


### PR DESCRIPTION
## Summary

Closes rf2-ldjfh. Per rf2-wfbn3 (PR #575, merged earlier this session) the error / warning / advisory event vocabulary now lives in a single normative table at `spec/009-Instrumentation.md` §Error event catalogue — ~95 categories with `:operation`, `:op-type`, trigger, default `:recovery`, and `:tags` columns. The migration skill needed a pointer so prompts and post-migration audits reference one place and don't drift.

## Changes

- **New leaf** `skills/re-frame-migration/reference/error-events.md` (96 lines, under the 150L target per rf2-rdzbz). Points at Spec 009 §Error event catalogue as the single source, lists the six stable namespace prefixes (`:rf.error/*`, `:rf.warning/*`, `:rf.fx/*`, `:rf.cofx/*`, `:rf.ssr/*`, `:rf.epoch/*`) plus the narrower families (`:rf.http/*`, `:route.nav-token/*`, `:rf.frame/*`), shows how an `:on-error` policy / `register-trace-cb!` listener consumes the catalogue, and explicitly warns against inlining categories ("will drift").
- **SKILL.md** loading map updated — the new leaf is referenced from both the Phase-3 workflow listing and the reference-files index.
- **Cross-references** added from M-13 (`guided-handlers-state.md`) and M-26 (`guided-interceptors-subs.md`) — the two `register-trace-cb!` / `:on-error` migration touch-points — so an agent working those rules is one click from the catalogue.

No spec, implementation, or other-skill files touched. No inlined catalogue introduced.

## Test plan

- [ ] `mkdocs build --strict` succeeds with the new file and the new spec links.
- [ ] Visual review: links resolve relative to the leaf's location (`../../../spec/009-Instrumentation.md#error-event-catalogue`).