### PR TITLE
feat(story-mcp): add record-as-variant tool (rf2-luhdu)

### DIFF
--- a/tools/story-mcp/spec/002-Tool-Registry.md
+++ b/tools/story-mcp/spec/002-Tool-Registry.md
@@ -1,6 +1,6 @@
 # Story-MCP — Tool Registry
 
-> The 16 tools the server exposes, across four categories — Dev,
+> The 17 tools the server exposes, across four categories — Dev,
 > Docs, Testing, Write. One section per category, one paragraph per
 > tool. The wire-shape for each tool (input schema, output shape)
 > lives in [`API.md`](API.md); this document is the orientation read.
@@ -131,9 +131,11 @@ last-run state without paying the cost of a fresh `run-variant`.
 
 ## Write — v1.1, dev-only, gated
 
-Two write tools, both gated behind
-`re-frame.story-mcp.config/allow-writes?` per
-[`003-Write-Surface-Gating.md`](003-Write-Surface-Gating.md).
+Three write tools. `register-variant` and `unregister-variant` are
+both gated behind `re-frame.story-mcp.config/allow-writes?` per
+[`003-Write-Surface-Gating.md`](003-Write-Surface-Gating.md);
+`record-as-variant` is ungated for the recording path and gated only
+when `:write-back?` is set.
 
 ### `register-variant`
 
@@ -145,6 +147,35 @@ string.
 
 Invokes `re-frame.story/unregister! :variant <id>`. Symmetric to
 `register-variant`. Same gate.
+
+### `record-as-variant`
+
+Bridges the recorder primitives (`start-recording!` → `stop-recording!`
+→ `gen-play-snippet`) across the MCP boundary. The agent calls the tool
+naming an existing variant id; the server starts a recording against
+that variant's frame, blocks for `:duration-ms` while the agent (or
+human-in-canvas) drives dispatches, stops the recording, and returns
+the `(reg-variant ...)` snippet `gen-play-snippet` emits.
+
+Filter layers are inherited verbatim from
+`re-frame.story.recorder/recordable-event?` — op-type `:event/dispatched`,
+frame scope match against the recording target, and an internal-namespace
+skip (`:rf.assert/*`, `:rf.story/*`, `:re-frame.story.*`). The tool
+does not expose a free-form filter knob; the recorder owns that
+contract per
+[`tools/story/spec/005-SOTA-Features.md`](../../story/spec/005-SOTA-Features.md)
+§Test Codegen.
+
+Optional `:write-back?` re-registers the source variant with
+`:play <captured-events>` via `reg-variant*` (preserving the
+existing `:component`, `:args`, `:decorators`, etc.). This branch is
+gated behind the same `allow-writes?` flag as `register-variant`; the
+read-only path (snippet only) needs no gate.
+
+`:new-variant-id` lets the write-back land under a different id (the
+default is to overwrite the source). `:extends` defaults to the source
+variant so the emitted snippet re-uses its `:component` / `:args` /
+`:decorators` rather than duplicating them.
 
 The agent's self-healing loop (write story → run → read failures →
 fix) activates with the write surface; without it the loop is
@@ -177,5 +208,6 @@ Each of these is a deliberate omission:
 - [`003-Write-Surface-Gating.md`](003-Write-Surface-Gating.md) —
   how the Write category gates.
 - [`API.md`](API.md) — per-tool input / output schemas.
+- [`tools/story/spec/005-SOTA-Features.md`](../../story/spec/005-SOTA-Features.md) §Test Codegen — the recorder primitives `record-as-variant` wraps.
 - [`tools/story/spec/006-MCP-Surface.md`](../../story/spec/006-MCP-Surface.md) —
   Story's side of the read/write primitives.

--- a/tools/story-mcp/spec/API.md
+++ b/tools/story-mcp/spec/API.md
@@ -200,6 +200,50 @@ Both tools require `:rf.story-mcp/allow-writes?` to be true; see
 **Errors.** `isError: true` when gate is closed; `isError: true`
 when variant is not registered.
 
+### `record-as-variant`
+
+Bridges `re-frame.story`'s recorder primitives (per
+[`tools/story/spec/005-SOTA-Features.md`](../../story/spec/005-SOTA-Features.md)
+§Test Codegen) across the MCP boundary.
+
+**Input.**
+
+```clojure
+{:variant-id     keyword (required)
+ :duration-ms    integer (optional, default 0)    ; ms to block between start and stop
+ :new-variant-id keyword (optional)                ; defaults to :variant-id
+ :doc            string  (optional)                ; embedded in snippet
+ :extends        keyword (optional)                ; defaults to :variant-id
+ :alias          string  (optional, default "story")
+ :write-back?    boolean (optional, default false) ; re-register with :play <captured>
+}
+```
+
+**Output.**
+
+```clojure
+{:variant-id           keyword           ; the source variant id
+ :play-snippet         string            ; (reg-variant ...) form, read-string-able
+ :recorded-event-count integer
+ :duration-ms          integer           ; actual ms blocked
+ :captured             [event-vec]       ; the recorded event vectors
+ :written-back?        boolean
+ :new-variant-id       keyword (when :written-back? is true)}
+```
+
+**Errors.**
+- `isError: true` when the source `:variant-id` is not registered.
+- `isError: true` when `:write-back?` is true but the gate is closed
+  (`{:gated true}` in `structuredContent`).
+- `isError: true` when the write-back `reg-variant*` call fails (shape
+  validation, unresolved `:extends`, etc.).
+
+Filter layers (op-type `:event/dispatched`, frame scope, internal-ns
+skip) are inherited from the recorder; this tool does not expose a
+free-form filter knob.
+
+**Spec.** [`002-Tool-Registry.md`](002-Tool-Registry.md) §Write.
+
 ## Protocol-level methods
 
 Not tools per se, but documented here for completeness:
@@ -221,7 +265,7 @@ Full wire details in
 - [`000-Vision.md`](000-Vision.md) — what this jar is for.
 - [`001-Wire-Protocol.md`](001-Wire-Protocol.md) — JSON-RPC envelope
   + framing.
-- [`002-Tool-Registry.md`](002-Tool-Registry.md) — the 16 tools in
+- [`002-Tool-Registry.md`](002-Tool-Registry.md) — the 17 tools in
   prose.
 - [`003-Write-Surface-Gating.md`](003-Write-Surface-Gating.md) —
   write-gate behaviour.

--- a/tools/story-mcp/src/re_frame/story_mcp/tools.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools.cljc
@@ -539,6 +539,145 @@
               (text-result (pr-edn payload) payload)))))))
 
 ;; ---------------------------------------------------------------------------
+;; record-as-variant — the recorder's MCP surface (rf2-luhdu)
+;;
+;; Wraps `re-frame.story`'s recorder primitives (start-recording! →
+;; sleep for :duration-ms → stop-recording! → gen-play-snippet) per
+;; tools/story/spec/005-SOTA-Features.md §Test Codegen "MCP wiring".
+;;
+;; This tool's job is the cross-process bridge: an agent calls it and
+;; gets back the `(reg-variant ...)` snippet for whatever the canvas
+;; dispatched during the recording window. The recorder itself does the
+;; filter work (op-type :event/dispatched, frame scope, internal-ns
+;; suppression) — see `re-frame.story.recorder/recordable-event?`.
+;;
+;; Optional `:write-back?` re-registers the source variant with the
+;; captured `:play` slot — gated by the same `allow-writes?` flag as
+;; `register-variant`. This is the self-healing-loop hook the spec
+;; mentions: agent drives canvas → tool returns snippet AND patches the
+;; variant in place.
+;; ---------------------------------------------------------------------------
+
+(defn- sleep-ms
+  "Block the caller for `ms` milliseconds. CLJS host has no blocking
+  primitive, so this is a no-op there — CLJS callers wanting a recording
+  window dispatch their interactions between `start-recording!` and the
+  tool's stop step from their own scheduler. The MCP server's canonical
+  deploy is JVM, where `Thread/sleep` is honest."
+  [ms]
+  #?(:clj  (when (pos? ms) (Thread/sleep ^long ms))
+     :cljs nil))
+
+(defn- now-ms
+  []
+  #?(:clj  (System/currentTimeMillis)
+     :cljs (.now js/Date)))
+
+(defn- tool-record-as-variant
+  "Dev (or Write when `:write-back?` is true): bridge the recorder's
+  start → capture → snippet pipeline across the MCP boundary.
+
+  Args:
+    :variant-id    required — keyword id of the existing variant to
+                              record against (the recording's target
+                              frame).
+    :duration-ms   optional — block the tool call for this many ms
+                              between `start-recording!` and
+                              `stop-recording!`. Default 0 (the caller
+                              is expected to drive dispatches in
+                              parallel and stop the recording out-of-
+                              band). JVM only — CLJS sleeps are a no-op.
+    :new-variant-id optional — when `:write-back?` is true, register the
+                              captured `:play` body as a NEW variant
+                              with this id. Defaults to the source
+                              `:variant-id` (overwrites in place).
+    :doc           optional — docstring to embed in the snippet.
+    :extends       optional — variant id to embed as the snippet's
+                              `:extends` slot (defaults to the source
+                              `:variant-id` — recording extends from the
+                              canvas it ran against).
+    :alias         optional — short ns alias in the rendered form
+                              (default `\"story\"`).
+    :write-back?   optional — when true, also re-register the variant
+                              via `reg-variant*` with `:play <captured>`.
+                              Requires `allow-writes?` (same gate as
+                              `register-variant`).
+
+  Output:
+    `{:variant-id <source>
+      :play-snippet <string>
+      :recorded-event-count <int>
+      :duration-ms <actual ms blocked>
+      :captured [<event-vec>]
+      :written-back? <bool>
+      :new-variant-id <new>?      ; only when write-back happened
+     }`
+
+  Errors:
+    - Source `:variant-id` is not registered.
+    - `:write-back?` true but `allow-writes?` is false.
+    - `:write-back?` true and the underlying `reg-variant*` fails (shape
+      validation, unknown extends, etc.).
+
+  Filter layers are inherited from the recorder verbatim (op-type
+  `:event/dispatched`, frame scope match, internal-namespace skip). The
+  tool does not expose a free-form filter knob — the recorder owns that
+  contract."
+  [args]
+  (let [[vid err] (required-arg args :variant-id)]
+    (if err err
+      (let [vk           (read-keyword vid)
+            body         (story/variant->edn vk)]
+        (if (nil? body)
+          (error-result (str "Variant not found: " (pr-str vk)))
+          (let [write-back?   (boolean (:write-back? args))
+                gate-err      (when write-back? (assert-writes-allowed))]
+            (if gate-err gate-err
+              (let [duration-ms (or (:duration-ms args) 0)
+                    new-vid     (some-> (:new-variant-id args) read-keyword)
+                    target-vid  (or new-vid vk)
+                    doc         (:doc args)
+                    extends     (or (some-> (:extends args) read-keyword) vk)
+                    alias-arg   (:alias args)
+                    started     (now-ms)
+                    _           (story/start-recording! vk)
+                    _           (sleep-ms duration-ms)
+                    final-state (story/stop-recording!)
+                    actual-ms   (- (now-ms) started)
+                    events      (vec (:events final-state))
+                    snippet-opts (cond-> {:variant-id target-vid
+                                          :extends    extends}
+                                   (string? doc)       (assoc :doc doc)
+                                   (string? alias-arg) (assoc :alias alias-arg))
+                    snippet     (story/gen-play-snippet events snippet-opts)
+                    base-payload {:variant-id           vk
+                                  :play-snippet         snippet
+                                  :recorded-event-count (count events)
+                                  :duration-ms          actual-ms
+                                  :captured             events
+                                  :written-back?        false}]
+                (if-not write-back?
+                  (text-result (pr-edn base-payload) base-payload)
+                  ;; Write-back: re-register the target variant with the
+                  ;; captured :play body. We preserve the source variant's
+                  ;; existing body keys (so :component, :args, :decorators
+                  ;; survive) and overwrite :play with the captured events.
+                  (try
+                    (let [new-body (assoc body :play events)
+                          id       (story/reg-variant* target-vid new-body)
+                          payload  (assoc base-payload
+                                          :written-back?   true
+                                          :new-variant-id  id)]
+                      (text-result (pr-edn payload) payload))
+                    (catch #?(:clj Throwable :cljs :default) e
+                      (error-result (str "Write-back failed: " (ex-message e))
+                                    (merge base-payload
+                                           {:written-back? false
+                                            :new-variant-id target-vid}
+                                           (select-keys (ex-data e)
+                                                        [:rf.error :explain]))))))))))))))
+
+;; ---------------------------------------------------------------------------
 ;; Tool registry
 ;; ---------------------------------------------------------------------------
 
@@ -698,7 +837,28 @@
                   :properties {:variant-id kw-or-string}
                   :required ["variant-id"]
                   :additionalProperties false}
-    :handler     tool-unregister-variant}])
+    :handler     tool-unregister-variant}
+
+   {:name        "record-as-variant"
+    :category    :write
+    :description "Bridge the recorder's start → capture → snippet pipeline across the MCP boundary. Starts a recording against the source variant's frame, blocks for `:duration-ms`, stops, returns the `(reg-variant ...)` snippet `gen-play-snippet` emits. Optional `:write-back?` re-registers the variant with the captured `:play` slot — GATED behind `:rf.story-mcp/allow-writes?` (same gate as `register-variant`)."
+    :inputSchema {:type "object"
+                  :properties {:variant-id     kw-or-string
+                               :duration-ms    {:type "integer" :minimum 0
+                                                :description "Milliseconds to block between start and stop. Default 0. JVM-only (CLJS hosts no-op)."}
+                               :new-variant-id (assoc kw-or-string
+                                                 :description "When `:write-back?` is true, register the captured `:play` body under this id. Defaults to the source `:variant-id` (overwrites in place).")
+                               :doc            {:type "string"
+                                                :description "Optional docstring embedded in the rendered snippet."}
+                               :extends        (assoc kw-or-string
+                                                 :description "Variant id embedded as `:extends` in the snippet. Defaults to the source `:variant-id`.")
+                               :alias          {:type "string"
+                                                :description "Short ns alias for the rendered form (default \"story\")."}
+                               :write-back?    {:type "boolean"
+                                                :description "When true, also re-register the variant with the captured `:play`. Requires `allow-writes?`."}}
+                  :required ["variant-id"]
+                  :additionalProperties false}
+    :handler     tool-record-as-variant}])
 
 (defn tool-descriptors
   "Build the `tools/list` response payload: each tool's name +

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -8,6 +8,7 @@
   something to read."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.story :as story]
+            [re-frame.story.recorder :as recorder]
             [re-frame.story-mcp.config :as config]
             [re-frame.story-mcp.protocol :as proto]
             [re-frame.story-mcp.server :as server]
@@ -23,6 +24,9 @@
   (story/clear-all!)
   (story/install-canonical-vocabulary!)
   (config/set-allow-writes! false)
+  ;; Recorder atom is per-process — clear between tests so a previous
+  ;; test's captured events don't bleed in.
+  (recorder/clear!)
   ;; Fixture story + variant.
   (story/reg-story :story.button
     {:doc       "A clickable button."
@@ -100,7 +104,8 @@
       (is (contains? names "read-failures"))
       ;; Write
       (is (contains? names "register-variant"))
-      (is (contains? names "unregister-variant")))))
+      (is (contains? names "unregister-variant"))
+      (is (contains? names "record-as-variant")))))
 
 ;; ---------------------------------------------------------------------------
 ;; Dev tools
@@ -314,6 +319,123 @@
     (is (success? r))
     (is (true? (-> r :structuredContent :unregistered?)))
     (is (nil? (story/variant->edn :story.button/primary)))))
+
+;; ---------------------------------------------------------------------------
+;; record-as-variant (rf2-luhdu)
+;;
+;; The recorder normally captures events off the trace bus; for these tests
+;; we drive `recorder/record-event!` directly during the tool's blocking
+;; window via a worker thread so the assertions exercise the start →
+;; capture → snippet plumbing without needing a live trace emitter.
+;; ---------------------------------------------------------------------------
+
+(defn- drive-events-during-recording
+  "Helper: spawn a worker thread that, after a short delay (to ensure the
+  tool has called `start-recording!`), pushes `events` into the recorder
+  one at a time. The tool's `:duration-ms` must outlast the delay."
+  [events ^long delay-ms]
+  (doto (Thread.
+          ^Runnable
+          (fn []
+            (Thread/sleep delay-ms)
+            (doseq [ev events]
+              (recorder/record-event! ev))))
+    (.setDaemon true)
+    (.start)))
+
+(deftest record-as-variant-not-found
+  (testing "unknown source variant ⇒ tool-execution error"
+    (let [r (invoke "record-as-variant" {:variant-id "story.nope/missing"})]
+      (is (error? r))
+      (is (re-find #"not found" (-> r :content first :text))))))
+
+(deftest record-as-variant-missing-arg
+  (testing "missing :variant-id ⇒ tool-execution error"
+    (let [r (invoke "record-as-variant" {})]
+      (is (error? r))
+      (is (re-find #"variant-id" (-> r :content first :text))))))
+
+(deftest record-as-variant-zero-duration-empty-capture
+  (testing "duration 0 with no in-flight dispatches ⇒ empty :play snippet"
+    (let [r (invoke "record-as-variant" {:variant-id "story.button/primary"})
+          s (:structuredContent r)]
+      (is (success? r))
+      (is (= :story.button/primary (:variant-id s)))
+      (is (= 0 (:recorded-event-count s)))
+      (is (false? (:written-back? s)))
+      (is (string? (:play-snippet s)))
+      (is (re-find #":play \[\]" (:play-snippet s)))
+      (is (re-find #":story\.button/primary" (:play-snippet s))))))
+
+(deftest record-as-variant-captures-events-during-window
+  (testing "events pushed during the blocking window land in :captured"
+    (drive-events-during-recording [[:counter/inc] [:counter/by 7]] 20)
+    (let [r (invoke "record-as-variant"
+                    {:variant-id  "story.button/primary"
+                     :duration-ms 100})
+          s (:structuredContent r)]
+      (is (success? r))
+      (is (= 2 (:recorded-event-count s)))
+      (is (= [[:counter/inc] [:counter/by 7]] (:captured s)))
+      (is (re-find #":counter/inc" (:play-snippet s)))
+      (is (re-find #":counter/by 7" (:play-snippet s))))))
+
+(deftest record-as-variant-write-back-gated-by-default
+  (testing "write-back? true with allow-writes? false ⇒ gated error"
+    (is (false? (config/writes-allowed?)))
+    (let [r (invoke "record-as-variant" {:variant-id  "story.button/primary"
+                                         :write-back? true})]
+      (is (error? r))
+      (is (re-find #"Write surface disabled" (-> r :content first :text)))
+      (is (true? (-> r :structuredContent :gated))))))
+
+(deftest record-as-variant-write-back-overwrites-source
+  (testing "write-back? true with gate open re-registers the source variant"
+    (config/set-allow-writes! true)
+    (drive-events-during-recording [[:counter/inc] [:counter/inc]] 20)
+    (let [r (invoke "record-as-variant"
+                    {:variant-id  "story.button/primary"
+                     :duration-ms 100
+                     :write-back? true})
+          s (:structuredContent r)]
+      (is (success? r))
+      (is (true? (:written-back? s)))
+      (is (= :story.button/primary (:new-variant-id s)))
+      ;; Source variant's :play slot now carries the captured events.
+      (is (= [[:counter/inc] [:counter/inc]]
+             (:play (story/variant->edn :story.button/primary))))
+      ;; Pre-existing body keys survive (e.g. :doc).
+      (is (= "Primary button." (:doc (story/variant->edn :story.button/primary)))))))
+
+(deftest record-as-variant-write-back-new-id
+  (testing ":new-variant-id lands the capture under a fresh id"
+    (config/set-allow-writes! true)
+    (drive-events-during-recording [[:counter/inc]] 20)
+    (let [r (invoke "record-as-variant"
+                    {:variant-id     "story.button/primary"
+                     :new-variant-id "story.button/recorded"
+                     :duration-ms    100
+                     :write-back?    true})
+          s (:structuredContent r)]
+      (is (success? r))
+      (is (true? (:written-back? s)))
+      (is (= :story.button/recorded (:new-variant-id s)))
+      (is (= [[:counter/inc]] (:play (story/variant->edn :story.button/recorded))))
+      ;; Source variant is untouched.
+      (is (nil? (:play (story/variant->edn :story.button/primary)))))))
+
+(deftest record-as-variant-snippet-honours-doc-and-alias
+  (testing ":doc and :alias flow into the rendered snippet"
+    (let [r (invoke "record-as-variant"
+                    {:variant-id "story.button/primary"
+                     :doc        "Recorded counter run."
+                     :alias      "s"})
+          snippet (-> r :structuredContent :play-snippet)]
+      (is (success? r))
+      (is (re-find #"\(s/reg-variant" snippet))
+      (is (re-find #"Recorded counter run\." snippet))
+      ;; Default :extends = source variant id.
+      (is (re-find #":extends :story\.button/primary" snippet)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Server dispatcher (initialize, tools/list, tools/call, error paths)


### PR DESCRIPTION
## Summary

Adds the `record-as-variant` MCP tool to story-mcp, bridging `re-frame.story`'s recorder primitives (`start-recording!` → `stop-recording!` → `gen-play-snippet`) across the MCP boundary. Closes the gap left by PR #634 where `skills/re-frame2/reference/tooling/story-mcp-loop.md` references `record-as-variant` but `tools/story-mcp/spec/002-Tool-Registry.md` did not list it.

The recorder API contract was locked by `tools/story/spec/005-SOTA-Features.md` §Test Codegen "MCP wiring" specifically so this MCP surface could land downstream against a stable Story-side surface.

## Tool surface

Input:

- `:variant-id` (required) — source variant whose frame is recorded.
- `:duration-ms` (optional, default 0) — JVM `Thread/sleep` window between start and stop. CLJS hosts no-op.
- `:new-variant-id` (optional) — target id when `:write-back?` is true; defaults to the source `:variant-id` (overwrites in place).
- `:doc` / `:extends` / `:alias` — flow into the rendered snippet. `:extends` defaults to the source variant id.
- `:write-back?` (optional, default false) — re-register the variant with `:play <captured-events>` via `reg-variant*`. Gated by the same `:rf.story-mcp/allow-writes?` flag as `register-variant`; the read-only snippet path needs no gate.

Output:

- `:variant-id` — the source variant id.
- `:play-snippet` — `(reg-variant ... :play [...])` form, `read-string`-able.
- `:recorded-event-count` — int.
- `:duration-ms` — actual ms blocked.
- `:captured` — vector of recorded event vectors.
- `:written-back?` — boolean.
- `:new-variant-id` — present when write-back happened.

Filter layers (op-type `:event/dispatched`, frame scope, internal-ns skip) are inherited verbatim from `re-frame.story.recorder/recordable-event?`. The tool does not expose a free-form filter knob; the recorder owns that contract.

## Catalogue

Now 17 tools (was 16). `002-Tool-Registry.md` opening, `API.md` cross-ref, and category-paragraph all updated.

## Test plan

- [x] `clojure -M:test` from `tools/story-mcp/` — 80 tests, 326 assertions, 0 failures.
- [x] `python scripts/check_skill_mcp_drift.py --ci` — exits 0. Story-mcp's consumer-skill mapping is still commented out (pending the rf2-1v7tu skill decision), so no allow-list drift is introduced.
- [x] Per-tool tests cover: unknown variant, missing arg, zero-duration empty capture, mid-window capture via worker thread, gate-closed write-back rejection, write-back overwrites source, `:new-variant-id` lands fresh registration, `:doc` / `:alias` / default `:extends` flow into the snippet.