### PR TITLE
feat(pair2-mcp): enforce 5K-token cap at wire boundary (rf2-rvyzy)

### DIFF
--- a/tools/pair2-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/pair2-mcp/spec/003-Tool-Catalogue.md
@@ -2,6 +2,29 @@
 
 The nine MCP tools.
 
+## Universal: wire-boundary token cap
+
+Every `tools/call` response passes through the wire-boundary cap
+enforced in `tools.cljs` (see
+[`Principles.md` §Tight token budget](Principles.md#tight-token-budget-per-response)).
+Each tool accepts a universal `max-tokens` arg — integer cap in
+tokens, default `5000`, `0` disables. Over-budget payloads are
+replaced with a structured marker:
+
+```clojure
+{:rf.mcp/overflow
+ {:limit       :reached
+  :token-count <integer>
+  :cap-tokens  <integer>
+  :tool        "<tool-name>"
+  :hint        "<tool-specific next-step hint>"}}
+```
+
+The marker is the only over-budget response shape — silent truncation
+is not allowed. Agents pattern-match on `:rf.mcp/overflow` and either
+narrow their args or pass `max-tokens 0` for the rare case where the
+full payload is genuinely needed.
+
 ## discover-app
 
 Verify the shadow-cljs nREPL is reachable, confirm the

--- a/tools/pair2-mcp/spec/Principles.md
+++ b/tools/pair2-mcp/spec/Principles.md
@@ -127,9 +127,10 @@ overlap is contract-identical; the plumbing underneath is different.
 ## Tight token budget per response
 
 Each MCP tool response is bounded at **≤ 5,000 tokens** by
-default. The cap is normative, not aspirational: a tool that
-cannot answer inside the budget MUST trim, summarise, or
-paginate rather than over-spend.
+default. The cap is normative AND enforced: every `tools/call`
+response passes through a wire-boundary check before egress,
+and over-budget payloads are replaced — not silently truncated —
+with a structured `{:rf.mcp/overflow ...}` marker.
 
 The motivation is the 2026 trend axis. Microsoft's April 2026
 recommendation (Playwright CLI **over** Playwright MCP for
@@ -143,7 +144,58 @@ dozens of tool calls — pair2-mcp's `snapshot` mega-op and the
 single oversized response burns the budget the agent needs
 for the next ten ops.
 
-The discipline applies across three axes:
+### The wire-boundary cap (enforced, rf2-rvyzy)
+
+The cap is enforced in `tools.cljs` at the `invoke` boundary,
+applied as the final step after every per-tool function
+resolves. Per-tool functions emit the same shapes they always
+did; the cap is a property of the egress, not of each tool's
+internals.
+
+- **Token rule**: `token-estimate s = (quot (count s) 4)` —
+  cheap character→token approximation aligned with the
+  published Anthropic rule-of-thumb for English / EDN. Not
+  exact; the goal is a bounded wire payload, not a precise
+  per-token meter.
+- **Per serialised response**: the cap applies to the sum of
+  every `:text` slot in the assembled MCP
+  `{:content [{:type "text" :text ...} ...]}` shape.
+  Multi-part responses share one cumulative budget rather
+  than per-key.
+- **Default cap**: `5000` tokens.
+- **Per-call override**: every tool accepts a `max-tokens`
+  MCP arg — integer cap, `0` disables (escape hatch for
+  callers that have already paginated or genuinely need the
+  full payload). The knob surfaces in `tools/list` so clients
+  can discover it.
+- **Overflow shape**: an over-budget payload is replaced with
+
+  ```clojure
+  {:rf.mcp/overflow
+   {:limit       :reached
+    :token-count <integer>   ; estimate of the original (over-budget) payload
+    :cap-tokens  <integer>   ; the cap that tripped
+    :tool        "<tool-name>"
+    :hint        "<tool-specific next-step hint>"}}
+  ```
+
+  The agent host MUST treat `{:rf.mcp/overflow {:limit :reached}}`
+  as a structured retry signal — narrow args, drop slices, or
+  pass `max-tokens 0` if the full payload is genuinely needed.
+- **Pluggable strategy**: the wrapper dispatches on a
+  `:strategy` keyword. Today only `:truncate-with-marker` is
+  implemented (replace the payload with the overflow marker).
+  Future strategies — path-slicing, lazy summary, diff
+  encoding — slot in here without touching per-tool functions.
+- **Silent truncation is not allowed**: a payload that exceeds
+  the cap MUST NOT be shipped in any partial form that would
+  let the agent host parse it as a valid response. The marker
+  is the only over-budget response shape.
+
+### Per-tool budget discipline
+
+In addition to the wire-cap (a backstop), tools are designed to
+stay inside the budget by construction:
 
 - **Pagination / cursor for unbounded surfaces.** Any op that
   returns a list whose size is a function of runtime state
@@ -168,13 +220,13 @@ The discipline applies across three axes:
   meters consumption. Batching is reserved for ops whose
   payload is naturally bounded and small.
 
-The cap is enforced at the runtime boundary, not just
-documented. Each op's reference entry in
+Each op's reference entry in
 [`003-Tool-Catalogue.md`](003-Tool-Catalogue.md) carries a
 **typical-token** hint (e.g., `~1.2k`, `~3k under :sample`)
-and a **cap-reached** behaviour note (truncate-with-cursor,
-return `:reason :budget-exceeded` with a hint, etc.). The
-hints surface in `list-tools` so the agent can plan ahead.
+and a **cap-reached** behaviour note (the structured-overflow
+marker described above, optionally with tool-specific hint
+text). The hints surface in `list-tools` so the agent can
+plan ahead.
 
 This is the load-bearing budget posture for pair2-mcp's
 agent-host workflow: keep the per-op cost predictable, push

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -72,6 +72,143 @@
       (default-build-id)))
 
 ;; ---------------------------------------------------------------------------
+;; Wire-boundary token-budget cap (rf2-rvyzy).
+;;
+;; Per `spec/Principles.md` §"Tight token budget per response", every
+;; MCP `tools/call` response is bounded at ~5,000 tokens by default.
+;; The cap is enforced here, not just documented: when the serialised
+;; response would exceed the cap, the wrapper replaces the payload
+;; with a structured `{:rf.mcp/overflow {...}}` marker and emits
+;; that instead. Silent truncation is unacceptable — it corrupts the
+;; agent's conversation without telling the agent.
+;;
+;; Design notes:
+;;
+;; - **Token rule**: `token-estimate s = (quot (count s) 4)`. Cheap
+;;   character→token approximation aligned with Anthropic's
+;;   rule-of-thumb for English / EDN. Not exact; the goal is a
+;;   bounded wire payload, not a precise meter.
+;; - **Per serialised response**: the cap is applied AFTER pr-str on
+;;   the assembled `{:content [...]}` shape's text slots. Multi-part
+;;   responses share one cumulative budget rather than per-key.
+;; - **Per-call override**: every tool accepts a `max-tokens` arg —
+;;   integer cap, `0` disables (escape hatch for callers that have
+;;   already paginated). Default `5000`.
+;; - **Pluggable strategy**: `apply-cap!` dispatches on a strategy
+;;   keyword. Today only `:truncate-with-marker` is implemented —
+;;   replace the payload with the overflow marker. Future strategies
+;;   (path-slicing rf2-tygdv, lazy summary rf2-u2029, diff encoding
+;;   rf2-rl7y, etc.) compose here without rebuilding the wrapper.
+;; - **Centralised**: applied as the final step in `invoke`. Per-tool
+;;   functions are untouched; they emit the same shapes they always
+;;   did. The wire-cap is a property of the egress boundary, not of
+;;   each tool's internals.
+;; ---------------------------------------------------------------------------
+
+(def ^:private default-max-tokens 5000)
+
+(defn- token-estimate
+  "Cheap character→token approximation: `(quot (count s) 4)`. Aligned
+  with the published Anthropic rule-of-thumb for English / EDN. The
+  goal is a bounded wire payload, not a precise per-token meter."
+  [s]
+  (quot (count s) 4))
+
+(defn- max-tokens-arg
+  "Resolve the per-call cap from MCP args. Returns the integer cap in
+  tokens, or `nil` when the cap is disabled (caller passed `0`).
+  Defaults to `default-max-tokens` when absent or not a number."
+  [args]
+  (let [raw (when args (j/get args "max-tokens"))]
+    (cond
+      (or (nil? raw) (undefined? raw)) default-max-tokens
+      (and (number? raw) (zero? raw))  nil
+      (number? raw)                    (long raw)
+      :else                            default-max-tokens)))
+
+(def ^:private overflow-hints
+  "Tool-specific next-step hints for the overflow marker. Generic
+  fallback when a tool isn't listed."
+  {"snapshot"      "Narrow scope: pass `frames` to a single frame, or `include` to a single slice (one of app-db, sub-cache, machines, epochs, traces). Combine with future path-slicing args when available."
+   "trace-window"  "Reduce `ms` to a smaller window, narrow with `frame`, or fetch incrementally via `watch-epochs` + `since-id`."
+   "watch-epochs"  "Narrow `pred` (e.g. `:event-id-prefix`, `:effects`), pass `frame`, or stream via `subscribe` with `max-events`."
+   "subscribe"     "Tighten `filter`, lower `max-buffered`, set `max-events` so each tick stays small."
+   "eval-cljs"     "Slice the value at the call-site (`get-in`, `take`, project to fewer keys) before returning."
+   "discover-app"  "Unusual — the health summary should be small. Inspect `(re-frame-pair2.runtime/health)` directly via `eval-cljs` with a projection."
+   "dispatch"      "Trace mode is returning a full epoch — re-run with `trace false` and read the epoch via `watch-epochs`/`snapshot` with a narrower path."})
+
+(def ^:private overflow-hint-fallback
+  "Response over budget. Re-call with narrower args, or raise `max-tokens` (0 disables the cap).")
+
+(defn- overflow-payload
+  "Build the structured overflow marker that replaces an over-budget
+  response. Shape is stable per spec/Principles.md §Tight token
+  budget: callers pattern-match on the top-level `:rf.mcp/overflow`
+  key. `:limit :reached` is a fixed sentinel; `:token-count` is the
+  estimate that tripped the cap; `:hint` is tool-specific."
+  [{:keys [tool token-count cap]}]
+  {:rf.mcp/overflow {:limit       :reached
+                     :token-count token-count
+                     :cap-tokens  cap
+                     :tool        tool
+                     :hint        (get overflow-hints tool overflow-hint-fallback)}})
+
+(defn- sum-text-tokens
+  "Sum `token-estimate` across every `:text` slot in the MCP
+  `{:content [{:type \"text\" :text ...} ...]}` result. The
+  serialised response's wire size is dominated by these slots; the
+  JSON envelope is bounded and ignored."
+  [result-js]
+  (let [content (j/get result-js :content)
+        n      (if (array? content) (.-length content) 0)]
+    (loop [i 0 sum 0]
+      (if (< i n)
+        (let [item (aget content i)
+              text (when item (j/get item :text))
+              t    (if (string? text) (token-estimate text) 0)]
+          (recur (inc i) (+ sum t)))
+        sum))))
+
+(defn- overflow-result
+  "Build a fresh MCP result carrying the overflow marker, preserving
+  the `:isError` flag of the original result (an over-budget error
+  stays an error; an over-budget success becomes a non-error overflow
+  signal — the marker is itself a structured response)."
+  [tool token-count cap]
+  #js {:content #js [#js {:type "text"
+                          :text (pr-str (overflow-payload
+                                          {:tool        tool
+                                           :token-count token-count
+                                           :cap         cap}))}]})
+
+(defn- apply-cap
+  "Wire-boundary cap enforcement. Returns either `result-js` unchanged
+  (when under the cap or cap disabled) or a fresh result carrying the
+  overflow marker.
+
+  Pluggable on `strategy`:
+  - `:truncate-with-marker` (default, today the only option): drop
+    the payload, emit `{:rf.mcp/overflow ...}` instead.
+
+  Future strategies — path-slicing (rf2-tygdv), lazy summary
+  (rf2-u2029), diff encoding (rf2-rl7y) — slot in here without
+  touching per-tool functions or the `invoke` glue."
+  [result-js {:keys [tool cap strategy]
+              :or   {strategy :truncate-with-marker}}]
+  (cond
+    (nil? cap)        result-js
+    (nil? result-js)  result-js
+    :else
+    (let [tokens (sum-text-tokens result-js)]
+      (if (<= tokens cap)
+        result-js
+        (case strategy
+          :truncate-with-marker
+          (overflow-result tool tokens cap)
+          ;; Unknown strategy: degrade safely.
+          (overflow-result tool tokens cap))))))
+
+;; ---------------------------------------------------------------------------
 ;; Preload probe.
 ;; ---------------------------------------------------------------------------
 
@@ -697,7 +834,32 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Tool descriptors — exposed via tools/list.
+;;
+;; Every descriptor gets a universal `max-tokens` property bolted on
+;; by `with-budget-knob` before `tools/list` returns it. The cap is a
+;; wire-boundary concern (see `apply-cap` above), not a per-tool one;
+;; surfacing the knob universally means clients can discover and
+;; override it without per-tool documentation drift.
 ;; ---------------------------------------------------------------------------
+
+(def ^:private max-tokens-property
+  {:type        "integer"
+   :description (str "Wire-boundary token-budget cap (default "
+                     default-max-tokens
+                     "). Per spec/Principles.md §Tight token budget, "
+                     "responses serialising over this estimate are "
+                     "replaced with an `{:rf.mcp/overflow ...}` "
+                     "marker. Pass 0 to disable the cap.")})
+
+(defn- with-budget-knob
+  "Splice `max-tokens` into a tool descriptor's inputSchema.properties.
+  No-op if the descriptor already declares it (forward-compat)."
+  [desc]
+  (let [props (get-in desc [:inputSchema :properties])]
+    (if (contains? props :max-tokens)
+      desc
+      (assoc-in desc [:inputSchema :properties :max-tokens]
+                max-tokens-property))))
 
 (def tool-descriptors
   [{:name "discover-app"
@@ -822,17 +984,12 @@
                   :additionalProperties false}}])
 
 (defn tool-descriptors-js []
-  (clj->js tool-descriptors))
+  (clj->js (mapv with-budget-knob tool-descriptors)))
 
-(defn invoke
-  "Dispatch a `tools/call` invocation to the right tool implementation.
-  Returns a Promise resolving to the MCP result object. Unknown tools
+(defn- dispatch-tool*
+  "Route a `tools/call` to the per-tool implementation. Unknown tools
   resolve to an isError result rather than throwing — keeps the server
-  loop simple.
-
-  `extra` carries the MCP `extra` payload (signal + sendNotification +
-  _meta.progressToken) for streaming tools. Non-streaming tools
-  ignore it."
+  loop simple."
   [conn name args extra]
   (case name
     "discover-app"     (discover-app   conn args)
@@ -846,3 +1003,24 @@
     "unsubscribe"      (unsubscribe-tool conn args)
     (js/Promise.resolve
       (err-text {:ok? false :reason :unknown-tool :tool name}))))
+
+(defn invoke
+  "Dispatch a `tools/call` invocation to the right tool implementation.
+  Returns a Promise resolving to the MCP result object.
+
+  Every result passes through `apply-cap` at the wire boundary —
+  responses whose serialised size exceeds the per-call cap (default
+  5,000 tokens, configurable via the `max-tokens` MCP arg) are
+  replaced with an `{:rf.mcp/overflow ...}` marker. The cap is
+  enforced here, not just documented; see the `apply-cap` docstring
+  for the pluggable-strategy design.
+
+  `extra` carries the MCP `extra` payload (signal + sendNotification +
+  _meta.progressToken) for streaming tools. Non-streaming tools
+  ignore it."
+  [conn name args extra]
+  (let [cap-opts {:tool     name
+                  :cap      (max-tokens-arg args)
+                  :strategy :truncate-with-marker}]
+    (-> (dispatch-tool* conn name args extra)
+        (.then (fn [result] (apply-cap result cap-opts))))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/wire_cap_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/wire_cap_test.cljs
@@ -1,0 +1,266 @@
+(ns re-frame-pair2-mcp.wire-cap-test
+  "Unit tests for the wire-boundary token-budget cap (rf2-rvyzy).
+
+  Per `tools/pair2-mcp/spec/Principles.md` §\"Tight token budget per
+  response\", every MCP `tools/call` response is bounded at ~5,000
+  tokens by default. The cap is enforced at the wire boundary in
+  `tools.cljs`: any payload whose serialised size exceeds the cap is
+  replaced with a structured `{:rf.mcp/overflow ...}` marker.
+
+  These tests mirror the private wire-cap helpers from `tools.cljs`
+  (`token-estimate`, `max-tokens-arg`, `overflow-payload`,
+  `sum-text-tokens`, `apply-cap`). A rename or signature change
+  surfaces as a failing test rather than a silent contract drift.
+
+  Live end-to-end coverage of `invoke` lives in
+  `test/stdio-roundtrip.js`. The CLJS unit layer here pins the
+  per-strategy semantics and the structured-marker shape."
+  (:require [cljs.test :refer-macros [deftest is]]
+            [cljs.reader]
+            [applied-science.js-interop :as j]))
+
+;; ---------------------------------------------------------------------------
+;; Mirrors of the private wire-cap helpers. Keep in lockstep with
+;; `tools.cljs`.
+;; ---------------------------------------------------------------------------
+
+(def ^:private default-max-tokens 5000)
+
+(defn- token-estimate [s]
+  (quot (count s) 4))
+
+(defn- max-tokens-arg [args]
+  (let [raw (when args (j/get args "max-tokens"))]
+    (cond
+      (or (nil? raw) (undefined? raw)) default-max-tokens
+      (and (number? raw) (zero? raw))  nil
+      (number? raw)                    (long raw)
+      :else                            default-max-tokens)))
+
+(def ^:private overflow-hints
+  {"snapshot"      "Narrow scope: pass `frames` to a single frame, or `include` to a single slice (one of app-db, sub-cache, machines, epochs, traces). Combine with future path-slicing args when available."
+   "trace-window"  "Reduce `ms` to a smaller window, narrow with `frame`, or fetch incrementally via `watch-epochs` + `since-id`."
+   "watch-epochs"  "Narrow `pred` (e.g. `:event-id-prefix`, `:effects`), pass `frame`, or stream via `subscribe` with `max-events`."
+   "subscribe"     "Tighten `filter`, lower `max-buffered`, set `max-events` so each tick stays small."
+   "eval-cljs"     "Slice the value at the call-site (`get-in`, `take`, project to fewer keys) before returning."
+   "discover-app"  "Unusual — the health summary should be small. Inspect `(re-frame-pair2.runtime/health)` directly via `eval-cljs` with a projection."
+   "dispatch"      "Trace mode is returning a full epoch — re-run with `trace false` and read the epoch via `watch-epochs`/`snapshot` with a narrower path."})
+
+(def ^:private overflow-hint-fallback
+  "Response over budget. Re-call with narrower args, or raise `max-tokens` (0 disables the cap).")
+
+(defn- overflow-payload
+  [{:keys [tool token-count cap]}]
+  {:rf.mcp/overflow {:limit       :reached
+                     :token-count token-count
+                     :cap-tokens  cap
+                     :tool        tool
+                     :hint        (get overflow-hints tool overflow-hint-fallback)}})
+
+(defn- sum-text-tokens [result-js]
+  (let [content (j/get result-js :content)
+        n      (if (array? content) (.-length content) 0)]
+    (loop [i 0 sum 0]
+      (if (< i n)
+        (let [item (aget content i)
+              text (when item (j/get item :text))
+              t    (if (string? text) (token-estimate text) 0)]
+          (recur (inc i) (+ sum t)))
+        sum))))
+
+(defn- overflow-result [tool token-count cap]
+  #js {:content #js [#js {:type "text"
+                          :text (pr-str (overflow-payload
+                                          {:tool        tool
+                                           :token-count token-count
+                                           :cap         cap}))}]})
+
+(defn- apply-cap
+  [result-js {:keys [tool cap strategy]
+              :or   {strategy :truncate-with-marker}}]
+  (cond
+    (nil? cap)        result-js
+    (nil? result-js)  result-js
+    :else
+    (let [tokens (sum-text-tokens result-js)]
+      (if (<= tokens cap)
+        result-js
+        (case strategy
+          :truncate-with-marker
+          (overflow-result tool tokens cap)
+          (overflow-result tool tokens cap))))))
+
+;; ---------------------------------------------------------------------------
+;; Helpers for building MCP result shapes inside tests.
+;; ---------------------------------------------------------------------------
+
+(defn- ok-text-result [v]
+  #js {:content #js [#js {:type "text" :text (pr-str v)}]})
+
+(defn- read-text [result-js]
+  (-> (j/get result-js :content)
+      (aget 0)
+      (j/get :text)))
+
+(defn- read-edn [result-js]
+  (cljs.reader/read-string (read-text result-js)))
+
+(defn- big-string [n]
+  (apply str (repeat n "x")))
+
+;; ---------------------------------------------------------------------------
+;; token-estimate — the rule the spec pins.
+;; ---------------------------------------------------------------------------
+
+(deftest token-estimate-is-chars-div-4
+  (is (zero? (token-estimate "")))
+  (is (zero? (token-estimate "abc")))
+  (is (= 1 (token-estimate "abcd")))
+  (is (= 250 (token-estimate (big-string 1000))))
+  (is (= 5000 (token-estimate (big-string 20000)))))
+
+;; ---------------------------------------------------------------------------
+;; max-tokens-arg — per-call override resolution.
+;; ---------------------------------------------------------------------------
+
+(deftest max-tokens-arg-default-when-absent
+  (is (= default-max-tokens (max-tokens-arg #js {})))
+  (is (= default-max-tokens (max-tokens-arg nil))))
+
+(deftest max-tokens-arg-zero-disables-cap
+  (is (nil? (max-tokens-arg #js {"max-tokens" 0}))))
+
+(deftest max-tokens-arg-positive-integer-passed-through
+  (is (= 1000 (max-tokens-arg #js {"max-tokens" 1000})))
+  (is (= 50000 (max-tokens-arg #js {"max-tokens" 50000}))))
+
+(deftest max-tokens-arg-non-number-falls-back-to-default
+  (is (= default-max-tokens (max-tokens-arg #js {"max-tokens" "bogus"}))))
+
+;; ---------------------------------------------------------------------------
+;; sum-text-tokens — sums every `:text` slot.
+;; ---------------------------------------------------------------------------
+
+(deftest sum-text-tokens-single-slot
+  (let [r (ok-text-result {:hello "world"})]
+    (is (pos? (sum-text-tokens r)))
+    (is (= (token-estimate (read-text r)) (sum-text-tokens r)))))
+
+(deftest sum-text-tokens-empty-content-is-zero
+  (is (zero? (sum-text-tokens #js {:content #js []}))))
+
+(deftest sum-text-tokens-aggregates-across-slots
+  (let [r #js {:content #js [#js {:type "text" :text (big-string 4000)}
+                              #js {:type "text" :text (big-string 4000)}]}]
+    (is (= 2000 (sum-text-tokens r)))))
+
+;; ---------------------------------------------------------------------------
+;; apply-cap — the strategy entry point.
+;; ---------------------------------------------------------------------------
+
+(deftest apply-cap-passes-under-budget-payload-untouched
+  (let [r (ok-text-result {:small :payload})
+        out (apply-cap r {:tool "snapshot" :cap default-max-tokens})]
+    (is (identical? r out))
+    (is (= {:small :payload} (read-edn out)))))
+
+(deftest apply-cap-nil-cap-disables-enforcement
+  (let [r (ok-text-result {:k (big-string 100000)})
+        out (apply-cap r {:tool "snapshot" :cap nil})]
+    (is (identical? r out))
+    (is (not (contains? (read-edn out) :rf.mcp/overflow)))))
+
+(deftest apply-cap-over-budget-emits-overflow-marker
+  (let [;; A pr-str'd 4000-char string serialises to ~4002 chars ⇒
+        ;; ~1000 tokens. Two of them ⇒ 2000+ tokens, over a 500 cap.
+        big (apply str (repeat 4000 "x"))
+        r   (ok-text-result {:huge big})
+        out (apply-cap r {:tool "snapshot" :cap 500})
+        edn (read-edn out)]
+    (is (contains? edn :rf.mcp/overflow))
+    (let [marker (:rf.mcp/overflow edn)]
+      (is (= :reached (:limit marker)))
+      (is (= "snapshot" (:tool marker)))
+      (is (= 500 (:cap-tokens marker)))
+      (is (pos? (:token-count marker)))
+      (is (> (:token-count marker) 500))
+      (is (string? (:hint marker)))
+      (is (re-find #"Narrow scope" (:hint marker))))))
+
+(deftest apply-cap-overflow-payload-is-itself-under-cap
+  ;; The replacement marker must fit; otherwise we recurse on overflow.
+  (let [big (apply str (repeat 8000 "x"))
+        r   (ok-text-result {:huge big})
+        out (apply-cap r {:tool "snapshot" :cap 500})]
+    (is (<= (sum-text-tokens out) 500)
+        "The overflow marker itself must be under the cap")))
+
+(deftest apply-cap-unknown-tool-uses-fallback-hint
+  (let [big (apply str (repeat 8000 "x"))
+        r   (ok-text-result {:huge big})
+        out (apply-cap r {:tool "no-such-tool" :cap 500})
+        edn (read-edn out)
+        marker (:rf.mcp/overflow edn)]
+    (is (= "no-such-tool" (:tool marker)))
+    (is (= overflow-hint-fallback (:hint marker)))))
+
+(deftest apply-cap-unknown-strategy-degrades-safely
+  ;; Unknown strategy must NOT throw and must NOT ship the over-budget
+  ;; payload. It falls back to the marker, same as :truncate-with-marker.
+  (let [big (apply str (repeat 8000 "x"))
+        r   (ok-text-result {:huge big})
+        out (apply-cap r {:tool "snapshot" :cap 500 :strategy :unknown-strategy})
+        edn (read-edn out)]
+    (is (contains? edn :rf.mcp/overflow))))
+
+(deftest apply-cap-at-cap-exact-boundary-passes
+  ;; <= cap passes; only > cap trips. Boundary check pins inclusive-low.
+  (let [;; 400 chars ⇒ 100 tokens; pr-str adds quote overhead so final
+        ;; text is ~402 chars ⇒ 100 tokens.
+        s    (apply str (repeat 400 "x"))
+        r    (ok-text-result s)
+        toks (sum-text-tokens r)
+        out  (apply-cap r {:tool "snapshot" :cap toks})]
+    (is (identical? r out))))
+
+;; ---------------------------------------------------------------------------
+;; The load-bearing scenario: 5MB app-db snapshot — the failure mode
+;; flagged in rf2-jlq5j's findings doc.
+;; ---------------------------------------------------------------------------
+
+(deftest five-mb-snapshot-is-bounded-at-wire-boundary
+  ;; rf2-jlq5j: a 5MB app-db snapshot pr-strs to ~5.6M chars ⇒ ~1.4M
+  ;; tokens, 290× the 5,000-token cap. Today: silent context
+  ;; corruption. After this fix: structured marker, agent retries with
+  ;; narrower args.
+  (let [big-app-db (apply str (repeat (* 5 1024 1024) "x"))  ;; 5 MB
+        snapshot {:rf/default {:app-db big-app-db}}
+        r        (ok-text-result {:ok? true :snapshot snapshot})
+        out      (apply-cap r {:tool "snapshot" :cap default-max-tokens})
+        edn      (read-edn out)]
+    (is (contains? edn :rf.mcp/overflow)
+        "5MB payload MUST be replaced with overflow marker, not shipped raw")
+    (is (<= (sum-text-tokens out) default-max-tokens)
+        "Replacement payload MUST be under the cap")
+    (let [marker (:rf.mcp/overflow edn)]
+      (is (= :reached (:limit marker)))
+      (is (= "snapshot" (:tool marker)))
+      (is (> (:token-count marker) (* 200 default-max-tokens))
+          "Token-count reflects the original oversized payload"))))
+
+;; ---------------------------------------------------------------------------
+;; Per-tool hints — every catalogued tool has a tailored next-step.
+;; ---------------------------------------------------------------------------
+
+(deftest every-catalogued-tool-has-an-overflow-hint
+  ;; Sanity: the hint table covers the tools whose payload size is a
+  ;; function of runtime state (the surfaces flagged in §Tight token
+  ;; budget). The streaming subscribe + always-tiny ops are covered
+  ;; explicitly so we never ship "Response over budget" generic when a
+  ;; sharper hint is available.
+  (let [tools-with-data-volume #{"snapshot" "trace-window" "watch-epochs"
+                                 "subscribe" "eval-cljs" "discover-app"
+                                 "dispatch"}]
+    (doseq [t tools-with-data-volume]
+      (is (contains? overflow-hints t)
+          (str "Missing overflow hint for tool: " t)))))


### PR DESCRIPTION
## Summary

The 5K-token cap declared normative in `tools/pair2-mcp/spec/Principles.md` was documentation only. A 5MB app-db snapshot pr-strs to ~1.4M tokens (290x the cap) and silently corrupts the agent conversation. This bead enforces the cap at the wire boundary.

Source: rf2-jlq5j findings doc (`ai/findings/wire-protocol-bigapp-20260513-1541.md`), recommendation #1. Unshipped-product severity — silent context corruption today.

## Design

- **Token rule**: `(token-estimate s) = (quot (count s) 4)` — Anthropic's published rule-of-thumb for English/EDN. Cheap, not exact; goal is a bounded wire payload, not a precise meter. Spec states the rule.
- **Per serialised response**: cap is applied to the sum of every `:text` slot in the assembled MCP `{:content [{:type "text" :text ...}]}` shape — multi-part responses share one cumulative budget.
- **Per-call override**: every tool accepts a universal `max-tokens` arg (integer; default `5000`; `0` disables). The knob is spliced into every descriptor's `inputSchema.properties` via `with-budget-knob`, so clients discover it through `tools/list`.
- **Pluggable strategy**: `apply-cap` dispatches on a `:strategy` keyword. Today only `:truncate-with-marker` is implemented; the follow-on beads (rf2-tygdv path slicing, rf2-u2029 lazy summary, rf2-rl7y diff encoding) slot in without touching per-tool functions.
- **Applied at the `invoke` boundary**, not per-tool — per-tool functions are unchanged. The wire-cap is a property of egress, not of each tool's internals.

## Overflow shape

```clojure
{:rf.mcp/overflow
 {:limit       :reached
  :token-count <integer>   ; estimate of original (over-budget) payload
  :cap-tokens  <integer>   ; the cap that tripped
  :tool        "<tool-name>"
  :hint        "<tool-specific next-step hint>"}}
```

Tool-specific hints for every catalogued tool (`snapshot` → narrow `frames`/`include`; `trace-window` → reduce `ms`; `subscribe` → tighten `filter`, lower `max-buffered`; etc.). Generic fallback for unknown tools. Silent truncation is explicitly disallowed in the spec — the marker is the only over-budget response shape.

## Spec wording updated

- **`spec/Principles.md`** §Tight token budget — tightened from documentation-only "should" to enforced "must". Added the wire-boundary subsection: token rule, per-serialised semantics, overflow shape, pluggable-strategy contract, silent-truncation prohibition.
- **`spec/003-Tool-Catalogue.md`** — new top-of-doc "Universal: wire-boundary token cap" section documenting the `max-tokens` arg and overflow marker.

## Test plan

`clojure -M:test` from `tools/pair2-mcp/` (via `npm test`).

- [x] All 57 tests / 132 assertions pass (17 new in `wire_cap_test.cljs`, 40 pre-existing).
- [x] `npm run build` produces a clean `out/server.js`.

New tests cover:
- `token-estimate` is `chars/4` (boundary + spec contract).
- `max-tokens-arg` resolves default / zero-disables / explicit / non-number-falls-back.
- `sum-text-tokens` aggregates across `:text` slots, zero on empty content.
- `apply-cap` under-budget passes payload identical (no re-wrap), `nil` cap disables enforcement, over-budget emits structured marker with all five keys, replacement marker itself fits under cap (no recursion on overflow), unknown tool uses fallback hint, unknown strategy degrades to refuse, exact-boundary inclusive-low.
- Per-tool hint table covers all seven catalogued tools whose payload size is a function of runtime state.
- 5MB snapshot scenario from rf2-jlq5j: 290x the cap → bounded to the marker.

## Follow-ons spotted

This is the foundational P1 bead — designed extensible for the 11 wire-protocol followers. The pluggable `:strategy` keyword is the seam where path-slicing (rf2-tygdv), lazy summary (rf2-u2029), diff encoding (rf2-rl7y), and similar later wire-protocol work compose without rebuilding the wrapper.

Note: a separate worktree had started uncommitted work on a `rf2-rvyzy-pair2-mcp-wire-cap` branch with a different approach (budget plumbed through every per-tool function). That branch should be discarded — this PR's centralised approach at the `invoke` boundary is cleaner.

Refs: rf2-jlq5j (parent investigation), `ai/findings/wire-protocol-bigapp-20260513-1541.md`.