### PR TITLE
spec(causa-mcp): bake wire-protocol mechanisms — cap + slicing + pagination + lazy-summary + dedup (rf2-lwgg8)

### DIFF
--- a/tools/causa-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/causa-mcp/spec/DESIGN-RATIONALE.md
@@ -527,6 +527,109 @@ pin doesn't silently drift on a future `npm audit` pass.
 
 ---
 
+## Lock #9 — Wire-protocol budget posture (five mechanisms)
+
+**Locked 2026-05-13 (Mike).** **Five normative mechanisms bake
+the token cap into the spec before implementation begins:**
+(1) 5K-token budget cap with `:max-tokens` override and a
+`{:rf.mcp/overflow {...}}` overflow marker; (2) `:path`
+slicing on rich-value tools, with tree-summary as the default;
+(3) opaque-cursor pagination with `:limit` defaults that fit
+the cap; (4) lazy `:summary` as the default mode for rich
+values, with `:sample` and `:full` opt-ins; (5) optional
+structural dedup via [`day8/de-dupe`](https://github.com/day8/de-dupe)
+for trace-shaped bursts.
+
+### Question
+
+Causa-MCP is spec-only today (no `src/`). pair2-mcp shipped its
+5K cap (Principles §"Tight token budget per response") *after*
+its impl already existed; retrofitting the cap into running
+code is expensive (rf2-rvyzy + 10 sibling beads in flight as of
+2026-05-13). Should Causa-MCP bake the entire wire-protocol
+posture into its spec **before** implementation begins, so the
+impl is born compliant — or wait until implementation surfaces
+the same drift?
+
+### Pick
+
+**Bake all five mechanisms into the spec now.** The
+[`Principles.md`](./Principles.md) §"Tight token budget per
+response" section enumerates each mechanism with normative MUST
+wording, a reserved `:rf.mcp/overflow` / `:rf.mcp/summary` /
+`:rf.mcp/dedup-table` payload shape, and a catalogue-entry
+contract binding `003-Tool-Catalogue.md` when it lands. No tool
+ships without declaring which mechanisms apply, its
+typical-token hint, its cap-reached behaviour, and its default
+`:mode` / `:limit` / `:dedup?` values.
+
+### Why
+
+- **Greenfield is the rare cheap window.** pair2-mcp's drift
+  cost (rf2-rvyzy + siblings) is the comparator. Locking the
+  five mechanisms into the spec before any code exists means
+  the impl is born compliant — no retrofit pass, no parallel
+  code paths during transition.
+- **The five mechanisms compose.** Cap (1) is the gate; slicing
+  (2), pagination (3), and lazy-summary (4) are the trim
+  strategies; dedup (5) is the on-wire compression that buys
+  margin on top. Each mechanism alone is insufficient
+  (pagination doesn't help a single 50KB map; slicing doesn't
+  help an unbounded trace buffer; summary doesn't help a 10K
+  sample of small events that share structure). All five
+  together cover the failure modes Causa-MCP's catalogue can
+  produce.
+- **Cross-server alignment.** pair2-mcp's
+  [`Principles.md`](../../pair2-mcp/spec/Principles.md) §"Tight
+  token budget per response" already declares the cap and the
+  three-axis discipline (pagination / summary / streaming);
+  Causa-MCP's wording aligns deliberately so an agent learning
+  the slot on one server gets the same slot on the others. The
+  reserved `:rf.mcp/overflow` / `:rf.mcp/summary` keys are
+  cross-server reservations, not Causa-MCP-private vocabulary.
+  Where pair2-mcp's wording is silent (path slicing, structural
+  dedup, `:max-tokens` override, the overflow marker shape),
+  Causa-MCP's spec is the forward-locking site — a follow-up
+  alignment bead may lift the wording back into pair2-mcp.
+- **Structural dedup is the new mechanism.** Mechanisms 1–4 are
+  refinements of pair2-mcp's three-axis discipline. Mechanism 5
+  (`day8/de-dupe` substitution-table for trace bursts) is novel
+  to Causa-MCP because Causa's catalogue is trace-bus-heavy and
+  trace events share structural prefixes 3–5× under typical
+  load. Dedup is opt-out, not opt-in, so the default agent
+  experience is the compressed wire.
+- **The catalogue-entry contract is the enforcement.** A
+  principle without a per-tool slot is aspirational. Binding
+  every catalogue entry to declare its mechanism set turns the
+  cap into a compile-time-equivalent constraint: a tool entry
+  missing the slots fails review, not runtime.
+
+### Date locked
+
+2026-05-13 (Mike). Locked in this revision (rf2-lwgg8) to
+forestall the same drift pair2-mcp is paying down. Pre-dates
+`tools/causa-mcp/src/` by design.
+
+### Trail-of-thought citations
+
+- pair2-mcp
+  [`Principles.md`](../../pair2-mcp/spec/Principles.md)
+  §"Tight token budget per response" — the precedent at three
+  axes.
+- pair2-mcp `tools.cljs` retrofit beads (rf2-rvyzy and 10
+  siblings, in flight 2026-05-13) — the cost of not locking
+  before impl.
+- `ai/findings/wire-protocol-bigapp-20260513-1541.md`
+  (recommendation #10, local-only) — the source-of-truth
+  investigation that motivated baking before impl.
+- [`day8/de-dupe`](https://github.com/day8/de-dupe) — the
+  substitution-table substrate for mechanism 5; proven on
+  re-frame-10x's epoch payloads.
+- [Spec 009](../../../spec/009-Instrumentation.md) — the trace
+  bus whose burst-shape mechanism 5 compresses.
+
+---
+
 ## Summary table
 
 | # | Question | Pick | Date |
@@ -539,8 +642,9 @@ pin doesn't silently drift on a future `npm audit` pass.
 | 6 | npm package coord | **`@day8/re-frame2-causa-mcp`** | 2026-05-12 |
 | 7 | Chrome DevTools MCP posture | **Co-install, stay in lane** | 2026-05-12 |
 | 8 | bencode pinning | **`bencode@~2.0.3`** (inherited from pair2-mcp Lock #5) | 2026-05-12 |
+| 9 | Wire-protocol budget posture | **Five mechanisms baked into spec before impl** (cap + slicing + pagination + lazy-summary + dedup) | 2026-05-13 |
 
-These eight locks define Causa-MCP's pre-implementation surface.
+These nine locks define Causa-MCP's pre-implementation surface.
 They were extracted from
 [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
 and [Causa's own DESIGN-RATIONALE](../../causa/spec/DESIGN-RATIONALE.md)

--- a/tools/causa-mcp/spec/Principles.md
+++ b/tools/causa-mcp/spec/Principles.md
@@ -265,8 +265,8 @@ Lock #6.
 
 Each MCP tool response is bounded at **≤ 5,000 tokens** by
 default. The cap is normative, not aspirational: a tool that
-cannot answer inside the budget MUST trim, summarise, or
-paginate rather than over-spend.
+cannot answer inside the budget MUST trim, summarise, slice,
+paginate, or dedupe rather than over-spend.
 
 The motivation is the 2026 trend axis. Microsoft's April 2026
 recommendation (Playwright CLI **over** Playwright MCP for
@@ -281,55 +281,148 @@ triplet because its catalogue includes
 the `subscribe` stream, all of which return payloads whose
 size scales with runtime state.
 
-The discipline applies across three axes:
+The discipline rests on **five normative mechanisms**, each
+catalogued below. Every catalogue entry (when
+`003-Tool-Catalogue.md` lands) MUST declare which of the five
+apply to that tool, with a **typical-token** hint
+(`~1.2k`, `~3k under :sample`) and a **cap-reached** behaviour
+note. The hints surface in `list-tools` so the agent can plan
+ahead. The cap is enforced at the runtime boundary, not just
+documented.
 
-- **Pagination / cursor for unbounded surfaces.**
-  `get-trace-buffer`, `get-epoch-history`,
-  `list-subscriptions`, `get-causality-graph`, and any read
-  tool whose return size is a function of trace-bus depth
-  MUST accept a `:limit` argument and return a `:cursor` for
-  continuation. The default `:limit` MUST keep the response
-  under the cap. No unbounded list responses; no
-  "best-effort" omission of pagination. The `:since-ms` and
-  `:filter` arguments are not substitutes for pagination —
-  an active app can still blow the budget inside a 5-second
-  window.
-- **Summarisation modes for rich payloads.** Ops with rich
-  per-item shape (`app-db-diff`, `get-causality-graph`,
-  `get-epoch`, `get-machine-snapshot`) MUST expose a `:mode`
-  argument with at least `:count` (return totals only),
-  `:sample` (return a bounded prefix or stratified sample
-  with sizes attached), and `:full` (return everything,
-  paginated). The default MUST be `:sample` for any op whose
-  `:full` payload can exceed the cap. `app-db-diff` in
-  particular MUST default to a path-summary mode (changed
-  paths + cardinalities) rather than the full nested diff.
-- **Streaming over batch where appropriate.** The
-  `subscribe` stream returns one event per JSON-RPC
-  notification, not a buffered batch. The cap applies per
-  notification; the agent host meters consumption. A
-  `subscribe` topic whose individual events can exceed the
-  cap (e.g., a trace event with a large coeffect payload)
-  MUST attach a server-side trimmer (drop the heavy fields,
-  attach a `:elided [:cofx :db]` marker, surface a follow-up
-  `get-trace-buffer` cursor).
+The wording below aligns deliberately with
+[`tools/pair2-mcp/spec/Principles.md`](../../pair2-mcp/spec/Principles.md)
+§Tight token budget per response so that an agent learning the
+slot on one server gets the same slot on the others.
 
-The cap is enforced at the runtime boundary, not just
-documented. Each tool's reference entry in the catalogue
-carries a **typical-token** hint (e.g., `~1.5k`,
-`~3k under :sample`) and a **cap-reached** behaviour note
-(truncate-with-cursor, return `:ok? false :reason
-:budget-exceeded` with a hint to narrow the filter, switch
-mode, or paginate). The hints surface in `list-tools` so the
-agent can plan ahead.
+### 1. Token budget cap
 
-This is the load-bearing budget posture for Causa-MCP's
-agent-host workflow: keep the per-op cost predictable, push
-the agent to ask for what it actually needs, and never let a
-single op blow the session. Causa-MCP's value over a
-generalist surface (Chrome DevTools MCP's
-`evaluate_script`) collapses if the agent can't afford to
-call the tools.
+The **5,000-token default** is the per-response budget. Every
+tool that returns to the agent MUST measure the rendered
+payload (post-EDN-encoding, post-JSON-wrap) against the cap
+before returning. Each call MAY override via a `:max-tokens`
+integer argument (server clamps to `[1, 50000]`).
+
+A tool that would exceed the cap MUST NOT silently truncate.
+Instead it MUST return a structured overflow marker at the top
+of the payload:
+
+```clojure
+{:rf.mcp/overflow {:cap         5000
+                   :would-be    ~12400
+                   :hint        :switch-mode  ; or :paginate, :slice, :narrow-filter
+                   :continuation {:cursor "opaque…" :next-args {...}}}
+ …trimmed-payload…}
+```
+
+The `:rf.mcp/overflow` key is reserved cross-server (pair2-mcp,
+story-mcp, causa-mcp use the same shape) so an agent that
+recognises it once recognises it everywhere.
+
+### 2. Path slicing
+
+Tools returning rich nested values (`get-app-db`,
+`get-machine-snapshot`, `get-epoch`, `get-causality-graph`)
+MUST accept an optional `:path` argument — an EDN-encoded
+vector of keys (e.g. `"[:cart :items 3 :sku]"`) addressing a
+subtree.
+
+The default behaviour **without** a `:path` argument MUST be a
+tree-summary (per mechanism 4), not the full payload. With
+`:path`, the tool returns the addressed subtree subject to the
+remaining mechanisms (still budgeted, still summarised at the
+leaf if rich). Out-of-range paths return
+`:ok? false :reason :path-not-found` with the deepest valid
+prefix attached so the agent can re-aim. This is the same
+slicing convention pair2-mcp's `snapshot` op already uses.
+
+### 3. Cursor pagination
+
+Sequence-returning tools (`get-trace-buffer`,
+`get-epoch-history`, `list-subscriptions`,
+`get-causality-graph` when walking trace events, and any read
+tool whose return size is a function of trace-bus depth) MUST
+accept `:cursor` (opaque server-managed string, omitted on the
+first call) and `:limit` (integer, default chosen so the
+response fits the cap).
+
+Responses MUST carry `:next-cursor` (an opaque string for the
+next page, or `nil` when exhausted) and `:remaining` (count or
+estimate). Cursors are server-managed — the agent does not
+inspect them. The `:since-ms` and `:filter` arguments are NOT
+substitutes for pagination; an active app can blow the budget
+inside a 5-second window. No unbounded list responses; no
+"best-effort" omission of pagination.
+
+### 4. Lazy summary (default mode for rich values)
+
+The **default response mode** for any tool returning a rich
+nested value is a **summary**, not the full payload. A summary
+declares the shape without committing the budget:
+
+```clojure
+{:rf.mcp/summary {:type   :map        ; :map | :vector | :set | :scalar
+                  :keys   [:cart :user :ui :…]
+                  :counts {:cart 47 :user 3 :ui 12 :…}
+                  :bytes  ~12400}}
+```
+
+Tools MUST expose a `:mode` argument with at least `:summary`
+(default), `:sample` (bounded prefix or stratified sample with
+sizes attached), and `:full` (paginated complete payload).
+Agents drill down via `:path` (mechanism 2) or `:cursor`
+(mechanism 3); `:full` is opt-in for the cases where the agent
+genuinely needs everything. `app-db-diff` in particular MUST
+default to changed-paths-with-cardinalities, not the nested
+diff.
+
+### 5. Structural dedup (trace burst compaction)
+
+The wire format for sequence-returning tools whose items can
+repeat structural prefixes (trace bursts where many events
+share the same `:event-id` / `:handler-id` / `:source-coord`
+backbone) MAY apply **structural dedup** before counting
+tokens: shared subtrees are emitted once and referenced by an
+integer id; the wire payload carries
+`{:rf.mcp/dedup-table {1 {...} 2 {...}} :items [{:rf.mcp/ref 1 …} …]}`.
+
+The dedup algorithm is the
+[`day8/de-dupe`](https://github.com/day8/de-dupe) substitution
+table — proven on re-frame-10x's epoch payloads, where it
+typically compresses trace bursts 3-5× without semantic loss.
+The agent reconstructs the full structure with a one-pass walk
+substituting refs against the table. Dedup is **opt-out** per
+call (`:dedup? false`); on by default for trace-shaped
+sequences and off for everything else.
+
+The five mechanisms together are the load-bearing budget
+posture for Causa-MCP's agent-host workflow: keep the per-op
+cost predictable, push the agent to ask for what it actually
+needs, and never let a single op blow the session. Causa-MCP's
+value over a generalist surface (Chrome DevTools MCP's
+`evaluate_script`) collapses if the agent can't afford to call
+the tools.
+
+The **catalogue-entry contract** (binding on
+`003-Tool-Catalogue.md` when it lands): every tool entry MUST
+declare which mechanisms apply, the **typical-token** hint, the
+**cap-reached** behaviour, and the default `:mode` /
+`:limit` / `:dedup?` values. No tool ships without these slots.
+
+### Streaming over batch (cross-cutting)
+
+The `subscribe` stream returns one event per JSON-RPC
+`notifications/progress`, not a buffered batch. The cap applies
+per notification; the agent host meters consumption. A
+`subscribe` topic whose individual events can exceed the cap
+(a trace event with a large coeffect payload) MUST attach a
+server-side trimmer (drop the heavy fields, attach an
+`:elided [:cofx :db]` marker, surface a follow-up
+`get-trace-buffer` cursor). Mechanisms 1, 4, and 5 apply
+per-notification; mechanisms 2 and 3 are inapplicable inside a
+single notification but DO apply to the `subscribe` call's own
+arguments (e.g., a `:path` filter on the topic, a `:limit` on
+total notifications before auto-unsubscribe).
 
 ## Backed by Causa's and the framework's principles
 

--- a/tools/causa-mcp/spec/README.md
+++ b/tools/causa-mcp/spec/README.md
@@ -9,8 +9,8 @@ before this folder existed.
 ## Files
 
 - **[000-Vision.md](000-Vision.md)** — Causa-MCP is the agent face of Causa; eighteen MCP tools across five bands; same shadow-cljs / Node / persistent-nREPL architecture as pair2-mcp; relationship to Causa, pair2-mcp, and Chrome DevTools MCP.
-- **[Principles.md](Principles.md)** — Load-bearing principles: origin tagging is the convention (not a suggestion), EDN canonical, closed-set catalogue with `eval-cljs` as the deliberate escape valve, single persistent nREPL socket, stage-marker-independent.
-- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — Eight direction-setting decisions: question, options, pick, why, date locked. Inheritance from pair2-mcp's locks is cited rather than duplicated.
+- **[Principles.md](Principles.md)** — Load-bearing principles: origin tagging is the convention (not a suggestion), EDN canonical, closed-set catalogue with `eval-cljs` as the deliberate escape valve, single persistent nREPL socket, stage-marker-independent, and the **five-mechanism wire-protocol budget posture** (token cap + path slicing + cursor pagination + lazy summary + structural dedup) — baked into the spec before implementation begins so the impl is born compliant.
+- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — Nine direction-setting decisions: question, options, pick, why, date locked. Inheritance from pair2-mcp's locks is cited rather than duplicated.
 
 ## Files that will land at implementation time
 


### PR DESCRIPTION
## Summary

Causa-MCP is spec-only today (no `src/`). Rare cheap window to bake the wire-protocol scalability mechanisms into the spec before the impl exists, so the impl is born compliant — versus pair2-mcp's pattern of retrofitting the cap into running code (rf2-rvyzy + 10 sibling beads in flight 2026-05-13).

## Where the new content lives

- **`tools/causa-mcp/spec/Principles.md`** §"Tight token budget per response" — restructured from a three-axis bullet list into **five normative mechanisms** with MUST wording, reserved cross-server payload shapes (`:rf.mcp/overflow`, `:rf.mcp/summary`, `:rf.mcp/dedup-table`), and a catalogue-entry contract binding `003-Tool-Catalogue.md` when it lands.
- **`tools/causa-mcp/spec/DESIGN-RATIONALE.md`** — adds **Lock #9 — Wire-protocol budget posture (five mechanisms)** with question/options/pick/why trail. Summary table bumps from eight to nine.
- **`tools/causa-mcp/spec/README.md`** — headline updated to mention the five-mechanism posture.

## The five mechanisms

1. **Token budget cap** — 5K default; `:max-tokens` per-call override (clamped `[1, 50000]`); `{:rf.mcp/overflow {:cap :would-be :hint :continuation}}` marker. Cross-server reserved key.
2. **Path slicing** — `:path` EDN arg (e.g. `"[:cart :items 3 :sku]"`) for rich-value tools (`get-app-db`, `get-machine-snapshot`, `get-epoch`, `get-causality-graph`); default without `:path` is tree-summary, not full payload.
3. **Cursor pagination** — opaque server-managed `:cursor` + `:limit` on sequence-returning tools; `:next-cursor` + `:remaining` in response; `:since-ms` and `:filter` are NOT substitutes.
4. **Lazy summary** — default `:mode` is `:summary`; `:sample` and `:full` opt-in; `{:rf.mcp/summary {:type :keys :counts :bytes}}` payload shape; `app-db-diff` defaults to changed-paths-with-cardinalities.
5. **Structural dedup** — opt-out [`day8/de-dupe`](https://github.com/day8/de-dupe) substitution-table on trace-shaped sequences; `{:rf.mcp/dedup-table ... :items [{:rf.mcp/ref N} ...]}` wire shape; proven on re-frame-10x's epoch payloads (3-5× compression).

## Cross-MCP alignment

Wording aligns deliberately with [`tools/pair2-mcp/spec/Principles.md`](../blob/main/tools/pair2-mcp/spec/Principles.md) §"Tight token budget per response". Where pair2-mcp's wording is silent (path slicing, structural dedup, `:max-tokens` override, the overflow marker shape), Causa-MCP's spec is the forward-locking site — a follow-up alignment bead may lift the wording back into pair2-mcp once Causa-MCP's wording is judged settled.

## Test plan

- [ ] Spec-only change; no code touched (causa-mcp has no `src/` yet — by design at this stage).
- [ ] `mkdocs build --strict` passes (no broken links).
- [ ] Cross-references to pair2-mcp Principles.md resolve.