### PR TITLE
docs(skills/re-frame2): document :platforms cofx metadata (rf2-t84ye)

### DIFF
--- a/skills/re-frame2/reference/fundamentals/cofx.md
+++ b/skills/re-frame2/reference/fundamentals/cofx.md
@@ -20,7 +20,11 @@ Registering a `reg-cofx` handler that injects an input (current time, localStora
 (rf/inject-cofx :cofx-id value)
 ```
 
-Verified in `implementation/core/src/re_frame/cofx.cljc:44` (`reg-cofx`) and `cofx.cljc:57` (`inject-cofx`).
+Verified in `implementation/core/src/re_frame/cofx.cljc:77` (`reg-cofx`) and `cofx.cljc:134` (`inject-cofx`). Metadata may carry:
+
+- `:doc` — one-sentence what-and-why
+- `:spec` — Malli schema for the injected value (Spec 010 §Validation order step 2)
+- `:platforms` — `#{:client :server}`; defaults to both. Cofx with mismatched platforms emit `:rf.cofx/skipped-on-platform` instead of running. Mirrors the `reg-fx` contract per `spec/011-SSR.md` §Effect handling on the server — a client-only cofx (browser locale, localStorage, navigator-info) silently no-ops when injected under an SSR-server frame so it neither blows up under JVM render nor injects nonsense values. The event handler still runs; only the injection is skipped. Example: `^{:platforms #{:client}} (rf/reg-cofx :browser-locale (fn [ctx] (assoc-in ctx [:coeffects :browser-locale] js/navigator.language)))` is safe to register on both platforms; under an `:ssr-server` frame the injection is skipped and the handler sees `nil` for `:browser-locale`.
 
 `inject-cofx` returns an **interceptor** — pass it in the event's interceptors vector (the positional slot, not the metadata-map):
 
@@ -112,6 +116,7 @@ Narrative treatment of the same pattern (for humans): `SKILL-REDIRECT.md` → **
 - **Order matters.** Interceptors run in vector order; a cofx that depends on another cofx's value must come after it.
 - **Two-arg form is for parameterised injection.** Use `(inject-cofx :random-int max-value)` when the same cofx-id needs a different value per attachment.
 - **Missing registration is a structured error trace, not a throw.** `inject-cofx` of an unregistered id emits `:rf.error/no-such-cofx` (carrying `:cofx-id`, `:event-id`, and the optional 2-arity `:cofx-value`) and lets the ctx flow through unchanged (`cofx.cljc:~78,88`). Subscribe via `register-trace-cb!` (or watch through 10x / re-frame-pair) to surface these.
+- **`:platforms #{:client}` makes the cofx skip silently under an SSR-server frame.** A `:rf.cofx/skipped-on-platform` warning trace fires (carrying `:cofx-id`, `:frame`, `:platform`, `:registered-platforms`, and on the 2-arity form `:cofx-value`); the event handler still runs but reads `nil` for the injected key. Active platform comes from the frame's `:config :platform` (set by the `:ssr-server` preset) falling back to host `interop/platform`. Check this first if a cofx mysteriously doesn't fire under SSR. Spec: `spec/011-SSR.md` §Effect handling on the server.
 
 ## Deeper material
 
@@ -119,4 +124,4 @@ Cofx validation (`:spec`), the late-bind seam for `:schemas/validate-cofx!`, ful
 
 ---
 
-*Derived from `implementation/core/src/re_frame/cofx.cljc` @ main `89bd9c3`. Re-verify line numbers after cofx-chain or schema-validation changes.*
+*Derived from `implementation/core/src/re_frame/cofx.cljc` @ main `9d548e18`. Re-verify line numbers after cofx-chain, schema-validation, or `:platforms`-gate changes.*


### PR DESCRIPTION
## Summary

rf2-gey3d (PR #557) extended `:platforms` gating to `reg-cofx` so a cofx tagged `:platforms #{:client}` silently no-ops under an SSR-server frame (browser-locale, localStorage, navigator-info, etc — the cofx side of the same gate `reg-fx` has long honoured). The `re-frame2` skill's fundamentals cofx leaf documented neither the metadata key nor the `:rf.cofx/skipped-on-platform` trace; an author reading the leaf to write a localStorage / browser-locale cofx wouldn't learn about the SSR contract.

Closes rf2-t84ye.

## Changes

Two surgical edits to `skills/re-frame2/reference/fundamentals/cofx.md` (the only file touched):

- **Canonical signature block** — enumerate the three metadata keys (`:doc`, `:spec`, `:platforms`) analogous to `fx.md` L18-23. The `:platforms` row spells out the contract, names the `:rf.cofx/skipped-on-platform` trace, and carries a one-line worked example (browser-locale cofx).
- **Common gotchas** — new bullet on `:platforms #{:client}` skip behaviour: trace shape (`:cofx-id`, `:frame`, `:platform`, `:registered-platforms`, optional `:cofx-value`), active-platform precedence (frame `:config :platform` overrides host `interop/platform`), and the diagnostic angle ("cofx mysteriously doesn't fire under SSR").

Also refreshed source-line citations (`cofx.cljc:44` → `:77`, `cofx.cljc:57` → `:134`) to track the new gating block, and updated the trailing fingerprint to `@ main 9d548e18` (the rf2-gey3d landing commit).

Cross-link points to `spec/011-SSR.md` §Effect handling on the server in both sites.

Leaf grows 122 → 127 lines, well under the 150L convention.

## Test plan

- [x] No source code touched — docs-only PR.
- [x] Verified `:platforms` shape against `implementation/core/src/re_frame/cofx.cljc` post-rf2-gey3d: `cofx-runs-on-platform?` predicate defaults to `#{:client :server}`, gate is in `inject-cofx`'s `:before` (L194-220), trace tags shape matches `cofx.cljc:213-219`.
- [x] Verified spec cross-ref against `spec/011-SSR.md` §634-642 (rule 3 of the symmetric fx + cofx gate).
- [x] Verified vocabulary against `spec/011-SSR.md` L182-194 and `breaking-changes.md` L27 — `:client` / `:server` (no `:jvm` / `:cljs`).
- [x] Line count: 127 lines (under the 150L convention).