### PR TITLE
docs(skills/setup): dedupe routing table vs frontmatter description (rf2-iz6si)

### DIFF
--- a/skills/re-frame2-setup/SKILL.md
+++ b/skills/re-frame2-setup/SKILL.md
@@ -11,14 +11,8 @@ description: >
   project", "scaffold re-frame2", "hello-world re-frame2 app", "new
   re-frame2 app", or a build failure on a freshly-scaffolded project that
   traces to missing `re-frame.core` / `re-frame.adapter.reagent` wiring.
-  Do not use for: adding re-frame2 to an existing application that
-  already has its own state management or non-trivial code (that is an
-  authoring task — use `re-frame2`); writing application code on a
-  working re-frame2 project (use `re-frame2`); live-app inspection (use
-  `re-frame-pair2`); v1→v2 migration of an existing re-frame v1 codebase
-  (use `re-frame-migration`); spec, architecture, or porting questions
-  about re-frame2 itself (use `re-frame2-implementor`). Exits once the
-  counter mounts.
+  Exits once the counter mounts. For full disqualifier list and routing
+  to sibling skills, see `skills/README.md` §Skill routing — single source.
 allowed-tools:
   - Bash(clojure *)
   - Bash(npm *)


### PR DESCRIPTION
## Summary

- The `re-frame2-setup` frontmatter `description:` carried its own "Do not use for: ..." negative-routing block (5 sibling-skill routes) that overlapped with the body §"When NOT to use" pointer + `skills/README.md` §Skill routing (the declared single source).
- Trimmed the frontmatter's negative-routing tail to a one-line pointer back to `skills/README.md` §Skill routing — single source. Body §"When NOT to use" is untouched and continues to carry the brief in-skill summary.
- Net change: −8 / +2 lines in `skills/re-frame2-setup/SKILL.md`. Voice / wording elsewhere unchanged.

## Test plan

- [ ] `skills/re-frame2-setup/SKILL.md` frontmatter `description:` reads cleanly without the duplicated "Do not use for:" block.
- [ ] Body §"When NOT to use" still points at `skills/README.md` §Skill routing — single source.
- [ ] No other files touched.