### PR TITLE
test(conformance): tag fixtures exercising core/trace + core/frame (rf2-3pnob)

### DIFF
--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -82,6 +82,9 @@
     :core/sub
     :core/fx
     :core/error
+    ;; :core/trace + :core/frame — rf2-3pnob. See JVM runner for rationale.
+    :core/trace
+    :core/frame
     :fsm/flat
     :fsm/eventless-always
     :fsm/hierarchical

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -41,6 +41,15 @@
     :core/sub
     :core/fx
     :core/error
+    ;; :core/trace + :core/frame — rf2-3pnob. Pattern-required surfaces
+    ;; per the README's §Capability tagging list and worked-example table.
+    ;; :core/trace is exercised by the structured error-trace fixtures
+    ;; and by drain-depth-limit; :core/frame is exercised by
+    ;; frame-lifecycle, frame-multi-instance, dispatch-envelope (the
+    ;; :frame envelope key surfacing in cofx), routing-multi-frame, and
+    ;; http-managed-frame-isolation.
+    :core/trace
+    :core/frame
     :fsm/flat
     :fsm/eventless-always
     :fsm/hierarchical

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -166,6 +166,9 @@ The conventions above describe the schema; the corpus itself shows what those ta
 | Fixture | `:fixture/capabilities` | What the tag set means |
 |---|---|---|
 | `counter-inc-once.edn` | `#{:core/event-handler :core/sub}` | The simplest pattern-required-only fixture: a single event handler, one sub. Every conformant port runs this. |
+| `frame-lifecycle.edn` | `#{:core/event-handler :core/frame :core/trace}` | The default frame's `:on-create` / `:on-destroy` events fire at frame creation and destruction; the runtime emits `:frame/created` / `:frame/destroyed` trace ops. Verifies both the frame-lifecycle contract and the trace-bus emission. |
+| `frame-multi-instance.edn` | `#{:core/event-handler :core/sub :core/frame :core/trace}` | Two frames sharing one registrar with isolated app-db; each trace event carries a per-frame `:frame` tag so the bus is multi-frame addressable. |
+| `error-handler-exception.edn` | `#{:core/event-handler :core/error :core/trace}` | A handler throws; the runtime emits a structured `:rf.error/handler-exception` trace with `:op-type :error` and `:recovery :no-recovery`. The trace shape is the primary contract. |
 | `after-hierarchy.edn` | `#{:fsm/hierarchical :fsm/delayed-after}` | A parent compound state with an `:after` timer. Only ports that claim both hierarchical FSM and `:after` will run it. |
 | `spawn-from-action.edn` | `#{:fsm/flat :actor/spawn-destroy}` | Imperative spawn of a child actor from inside a transition action. Requires the actor-model spawn-destroy capability on top of flat FSMs. |
 | `flow-lifecycle-emits-traces.edn` | `#{:core/event-handler :flow/basic :flow/trace}` | The flow primitive emits its five lifecycle trace events. Requires the flow substrate and the flow-trace stream. |

--- a/spec/conformance/fixtures/dispatch-envelope.edn
+++ b/spec/conformance/fixtures/dispatch-envelope.edn
@@ -5,7 +5,7 @@
 
 {:fixture/id           :dispatch/envelope
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:core/event-handler}
+ :fixture/capabilities #{:core/event-handler :core/frame :core/trace}
  :fixture/doc          "An event dispatched with :source :ui surfaces in the cofx context map. Implementations expose :frame, :trace-id, and :source as additional keys on the cofx map for reg-event-fx handlers."
 
  :fixture/registry

--- a/spec/conformance/fixtures/drain-depth-limit.edn
+++ b/spec/conformance/fixtures/drain-depth-limit.edn
@@ -7,7 +7,7 @@
 
 {:fixture/id           :drain/depth-limit
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:core/event-handler :core/error}
+ :fixture/capabilities #{:core/event-handler :core/error :core/trace}
  :fixture/doc          "A handler that always dispatches itself recursively. Drain hits the configured depth limit and emits :rf.error/drain-depth-exceeded. The runtime rolls app-db back to the pre-drain snapshot (atomic rollback per Spec 002 rule 3) and the cascade halts."
 
  :fixture/registry

--- a/spec/conformance/fixtures/error-fx-handler-exception.edn
+++ b/spec/conformance/fixtures/error-fx-handler-exception.edn
@@ -6,7 +6,7 @@
 
 {:fixture/id           :error/fx-handler-exception
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:core/event-handler :core/fx :core/error}
+ :fixture/capabilities #{:core/event-handler :core/fx :core/error :core/trace}
  :fixture/doc          "An fx implementation throws while processing its args. The runtime emits :rf.error/fx-handler-exception, skips the offending fx, and continues with the rest of the effect map's :fx vector."
 
  :fixture/registry

--- a/spec/conformance/fixtures/error-handler-exception.edn
+++ b/spec/conformance/fixtures/error-handler-exception.edn
@@ -6,7 +6,7 @@
 
 {:fixture/id           :error/handler-exception
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:core/event-handler :core/error}
+ :fixture/capabilities #{:core/event-handler :core/error :core/trace}
  :fixture/doc          "An event handler throws. The runtime emits a structured :rf.error/handler-exception trace event and halts the cascade."
 
  :fixture/registry

--- a/spec/conformance/fixtures/error-no-such-handler.edn
+++ b/spec/conformance/fixtures/error-no-such-handler.edn
@@ -5,7 +5,7 @@
 
 {:fixture/id           :error/no-such-handler
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:core/event-handler :core/error}
+ :fixture/capabilities #{:core/event-handler :core/error :core/trace}
  :fixture/doc          "Dispatching an unknown event id. Runtime logs a structured error trace event and the cascade continues (no-op for that event)."
 
  :fixture/registry

--- a/spec/conformance/fixtures/error-override-fallthrough.edn
+++ b/spec/conformance/fixtures/error-override-fallthrough.edn
@@ -6,7 +6,7 @@
 
 {:fixture/id           :error/override-fallthrough
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:core/event-handler :core/fx :core/error}
+ :fixture/capabilities #{:core/event-handler :core/fx :core/error :core/trace}
  :fixture/doc          "An :fx-overrides map points :http at :nonexistent-stub which has not been registered. The runtime emits :rf.error/override-fallthrough and falls through to the registered :http handler."
 
  :fixture/registry

--- a/spec/conformance/fixtures/error-schema-failure.edn
+++ b/spec/conformance/fixtures/error-schema-failure.edn
@@ -9,7 +9,7 @@
 
 {:fixture/id           :error/schema-failure
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:core/error :schemas/runtime}
+ :fixture/capabilities #{:core/error :schemas/runtime :core/trace}
  :fixture/doc          "An event handler returns an app-db that fails the registered :rf/app-schema at the affected path. The runtime emits a :rf.error/schema-validation-failure trace event with the explanation."
  :fixture/dynamic-host-only? true
 

--- a/spec/conformance/fixtures/error-sub-exception.edn
+++ b/spec/conformance/fixtures/error-sub-exception.edn
@@ -5,7 +5,7 @@
 
 {:fixture/id           :error/sub-exception
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:core/sub :core/error}
+ :fixture/capabilities #{:core/sub :core/error :core/trace}
  :fixture/doc          "A sub's computation-fn throws. The runtime emits :rf.error/sub-exception and the sub resolves to nil (default :replaced-with-default recovery)."
 
  :fixture/registry

--- a/spec/conformance/fixtures/frame-lifecycle.edn
+++ b/spec/conformance/fixtures/frame-lifecycle.edn
@@ -4,7 +4,7 @@
 
 {:fixture/id           :frame/lifecycle
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:core/event-handler}
+ :fixture/capabilities #{:core/event-handler :core/frame :core/trace}
  :fixture/doc          "Per [002]: a frame's :on-create event fires once at creation; :on-destroy fires once at destruction. Both are dispatched synchronously, before the frame becomes available to user code."
 
  :fixture/registry

--- a/spec/conformance/fixtures/frame-multi-instance.edn
+++ b/spec/conformance/fixtures/frame-multi-instance.edn
@@ -4,7 +4,7 @@
 
 {:fixture/id           :frame/multi-instance
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:core/event-handler :core/sub}
+ :fixture/capabilities #{:core/event-handler :core/sub :core/frame :core/trace}
  :fixture/doc          "Two frames sharing the same handler registry; their app-db state is isolated."
 
  :fixture/registry

--- a/spec/conformance/fixtures/http-managed-frame-isolation.edn
+++ b/spec/conformance/fixtures/http-managed-frame-isolation.edn
@@ -14,7 +14,7 @@
 
 {:fixture/id           :rf.http.managed/frame-isolation
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:core/event-handler :core/fx
+ :fixture/capabilities #{:core/event-handler :core/fx :core/frame
                          :rf.http/managed}
  :fixture/doc          "Two frames issue managed requests against the same registered :article/load handler; the canned-success replies land in the same frame each request was issued from. The handler registry is shared; the app-db slices are per-frame. Per Spec 014 §Frame awareness + Spec 002 §Routing."
 

--- a/spec/conformance/fixtures/routing-multi-frame.edn
+++ b/spec/conformance/fixtures/routing-multi-frame.edn
@@ -8,7 +8,7 @@
 
 {:fixture/id           :routing/multi-frame
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:routing/match-url :core/event-handler}
+ :fixture/capabilities #{:routing/match-url :core/event-handler :core/frame}
  :fixture/doc          "Two frames navigate the same registered routes independently. Each frame's :route slice carries its own id/params; the registry is shared but the slice is per-frame."
 
  :fixture/registry


### PR DESCRIPTION
## Summary

- Tag 12 existing conformance fixtures with `:core/trace` and/or `:core/frame` so the README's worked-example mention of those capability tags points at real fixtures (per rf2-mtq4h's sub-decision: ADD, not drop).
- Update both runners' `claimed-capabilities` (JVM + CLJS) so the tagged fixtures continue to run (per rf2-a3q1r, an unclaimed-and-unallowlisted capability fails the suite).
- Refresh the README's `§Capability tagging worked example` table to include three rows that actually carry `:core/trace` / `:core/frame` — `frame-lifecycle`, `frame-multi-instance`, `error-handler-exception`.

## Tag map

- `:core/frame` — fixtures whose primary purpose is a frame surface: `frame-multi-instance`, `frame-lifecycle`, `dispatch-envelope` (envelope `:frame` field surfacing in cofx), `routing-multi-frame`, `http-managed-frame-isolation`.
- `:core/trace` — fixtures whose primary contract IS the structured trace shape: `frame-multi-instance` (per-frame `:frame` tag in trace), `frame-lifecycle` (`:frame/created` / `:frame/destroyed` ops), `dispatch-envelope` (`:source` / `:trace-id` propagation), `drain-depth-limit` + the six `error-*.edn` fixtures (each verifying a specific `:rf.error/*` trace shape).

## Background

rf2-mtq4h surfaced two adjacent vocabulary gaps in the conformance corpus. The actor-axis rename (`:actor/spawn` → `:actor/spawn-destroy`) was already handled in PR #624; this follow-on bead handles the residual `:core/trace` + `:core/frame` mentions.

## Test plan
- [x] JVM conformance (`clojure -M:test -n re-frame.conformance-test` from `implementation/core/`): 111/111 runnable, 111/111 passed, 0 failed, 0 skipped — unchanged before/after.
- [x] CLJS conformance + full CLJS gate (`npm run test:cljs` from `implementation/`): 1481 tests / 3918 assertions, 0 failures, 0 errors — full suite includes the CLJS conformance runner.