### PR TITLE
docs(causa): add :windsurf + :zed editor schemes (rf2-queq0)

### DIFF
--- a/tools/causa/spec/API.md
+++ b/tools/causa/spec/API.md
@@ -173,6 +173,8 @@ dispatches to the configured editor:
 |---|---|
 | `:vscode` (default) | `vscode://file/<path>:<line>:<column>` |
 | `:cursor`           | `cursor://file/<path>:<line>:<column>` |
+| `:windsurf`         | `windsurf://file/<path>:<line>:<column>` |
+| `:zed`              | `zed://file/<path>:<line>:<column>` |
 | `:idea`             | `idea://open?file=<path>&line=<line>&column=<column>` |
 | `{:custom <tpl>}`   | user template with `{path}` / `{file}` / `{line}` / `{column}` placeholders |
 

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -30,7 +30,8 @@
 (defonce
   ^{:doc "Atom holding Causa's 'Open in editor' preference. Default
          `:vscode`. Accepts the keywords `:vscode` / `:cursor` /
-         `:idea` plus the `{:custom \"<uri-template>\"}` form (see
+         `:windsurf` / `:zed` / `:idea` plus the
+         `{:custom \"<uri-template>\"}` form (see
          `re-frame.source-coords.editor-uri/editor-uri`)."}
   editor
   (atom :vscode))
@@ -43,6 +44,8 @@
   Accepts:
     - `:vscode` (default) — `vscode://file/<path>:<line>:<column>`
     - `:cursor`           — `cursor://file/<path>:<line>:<column>`
+    - `:windsurf`         — `windsurf://file/<path>:<line>:<column>`
+    - `:zed`              — `zed://file/<path>:<line>:<column>`
     - `:idea`             — `idea://open?file=<path>&line=<line>&column=<column>`
     - `{:custom <uri-template>}` — user template with `{path}` / `{file}` /
                                    `{line}` / `{column}` placeholders.

--- a/tools/causa/test/day8/re_frame2_causa/config_test.clj
+++ b/tools/causa/test/day8/re_frame2_causa/config_test.clj
@@ -19,10 +19,14 @@
   (testing "set-editor! writes and get-editor reads"
     (config/set-editor! :cursor)
     (is (= :cursor (config/get-editor)))
+    (config/set-editor! :windsurf)
+    (is (= :windsurf (config/get-editor)))
+    (config/set-editor! :zed)
+    (is (= :zed (config/get-editor)))
     (config/set-editor! :idea)
     (is (= :idea (config/get-editor)))
-    (config/set-editor! {:custom "zed://file/{path}:{line}"})
-    (is (= {:custom "zed://file/{path}:{line}"} (config/get-editor)))))
+    (config/set-editor! {:custom "helix://file/{path}:{line}"})
+    (is (= {:custom "helix://file/{path}:{line}"} (config/get-editor)))))
 
 (deftest nil-editor-resets-to-vscode
   (testing "set-editor! with nil resets to :vscode"
@@ -50,6 +54,10 @@
       (is (= "vscode://file/src/x.cljs:12:4" (config/editor-uri coord)))
       (config/set-editor! :cursor)
       (is (= "cursor://file/src/x.cljs:12:4" (config/editor-uri coord)))
+      (config/set-editor! :windsurf)
+      (is (= "windsurf://file/src/x.cljs:12:4" (config/editor-uri coord)))
+      (config/set-editor! :zed)
+      (is (= "zed://file/src/x.cljs:12:4" (config/editor-uri coord)))
       (config/set-editor! :idea)
       (is (= "idea://open?file=src/x.cljs&line=12&column=4"
              (config/editor-uri coord))))))


### PR DESCRIPTION
## Summary

Follow-on to rf2-mqm2d (spec matrix) and rf2-achw1 (URI builder): sync Causa's `config.cljc` docstrings + `tools/causa/spec/API.md` URI-scheme table with the `:windsurf` and `:zed` editor schemes that those two beads added upstream. Doc-only sync — the underlying `editor-uri` builder already handled both keywords; users just had no documented way to discover them from Causa's own surface.

- `tools/causa/src/day8/re_frame2_causa/config.cljc` — extend the `editor` atom doc + the `set-editor!` docstring's bullet list with `:windsurf` and `:zed` rows mirroring the VS Code colon-suffix grammar.
- `tools/causa/spec/API.md` — add two rows to the "Open in editor" URI-scheme table.
- `tools/causa/test/day8/re_frame2_causa/config_test.clj` — extend `set-editor-round-trips` and `editor-uri-uses-current-preference` to cover both new keywords; swap the `:custom` example string from a now-built-in `zed://` to a still-custom `helix://` so the test continues to exercise the custom branch rather than colliding with a built-in scheme.

## Test plan

- [x] `clojure -M:test` from `tools/causa/` — 462 tests, 1303 assertions, 0 failures/errors (was 1299 assertions pre-edit; the 4 added assertions all pass).
- [x] Diff is minimal — no unrelated churn.