### PR TITLE
docs(guide): hide advanced concepts until their own chapter (rf2-ccnp)

### DIFF
--- a/docs/guide/01-why-re-frame2.md
+++ b/docs/guide/01-why-re-frame2.md
@@ -131,5 +131,5 @@ If you want the precise contracts before the prose, the [specification](../../sp
 
 [^app-db]: You'll meet `app-db` properly in [chapter 02](02-app-db.md) — it's the single immutable map every re-frame2 app pivots around.
 [^machines]: State machines get their own treatment in [chapter 08](08-state-machines.md).
-[^frames]: Frames — re-frame2's unit of isolated state and dispatch — are introduced in [chapter 06](06-views-and-frames.md).
+[^frames]: Frames — re-frame2's unit of isolated state and dispatch — are introduced in [chapter 06](06-views-and-frames.md), with a dedicated walk-through in [chapter 06a](06a-frames.md).
 [^causa]: Causa is the re-frame2 devtools UI (Maven coord `day8/re-frame2-causa`); it's covered in [chapter 15](15-devtools-and-pair-tools.md).

--- a/docs/guide/02-app-db.md
+++ b/docs/guide/02-app-db.md
@@ -92,31 +92,6 @@ Everything to the left of the new app-db is a *transformation*; everything to th
 
 That's the whole picture. There aren't more steps; there aren't different kinds of state moving differently. A click produces an event, an event produces a new app-db, a new app-db produces a new view. The loop closes on the next user action.
 
-## Per-frame, not global
-
-A subtle but load-bearing point: in re-frame v1, there was *one* app-db per process — a single global. In re-frame2, app-db is **per-frame**.
-
-A **frame** is an isolated runtime boundary — its own app-db, its own event queue, its own subscription cache. Every re-frame2 app has at least one frame; most have exactly one (the implicit `:rf/default`).
-
-The reason for the change is composition. Multi-instance scenarios — devcards on a documentation page, a story-tool playground with twenty variants on screen, server-side rendering where each request gets its own frame, isolated widgets embedded in a host page — all need *independent* app-dbs. v1 papered over this with explicit reset patterns; v2 names the boundary.
-
-For everyday code, this changes very little: there's still one app-db you read from and write to. You just don't have to invent the isolation when you finally need it. Chapter [06 — Views and frames](06-views-and-frames.md) introduces the multi-frame story in the context of views; chapter [06a — Frames](06a-frames.md) is the dedicated deep-dive — motivation, lifecycle, `:rf/default`, the per-test / per-story / per-request shapes. Until then, mentally substitute "app-db" with "the default frame's app-db" and you'll be right every time.
-
-The minimal API for reading the value of a frame's app-db at the REPL or in a test:
-
-```clojure
-(rf/get-frame-db :rf/default)   ;; → the current app-db value of the default frame
-```
-
-In tests with `rf/with-frame`, the frame id is bound for you:
-
-```clojure
-(rf/with-frame [f (rf/make-frame {:on-create [:counter/initialise]})]
-  (rf/get-frame-db f))           ;; → {:count 5}
-```
-
-You almost never write `get-frame-db` in application code — your event handlers receive `db` as their first argument, your subscriptions receive it implicitly. `get-frame-db` is for tests, the REPL, and tools.
-
 ## Where does *this kind of state* go in app-db?
 
 A question new readers ask early: "Where does X go in app-db?"
@@ -166,4 +141,4 @@ That's app-db.
 
 Chapter [03 — Your first app](03-your-first-app.md) walks a counter end-to-end and shows app-db in motion: the `:on-create` event seeds the initial value, three event-handlers transform it, one subscription reads from it, one view renders.
 
-If you're migrating from re-frame v1 and the per-frame model is the most surprising delta, [18 — From re-frame v1](18-from-re-frame-v1.md) covers the migration shape; the v1 "single global app-db" maps cleanly to the v2 "default frame's app-db" — most v1 apps move over with no shape change.
+If you're migrating from re-frame v1, [18 — From re-frame v1](18-from-re-frame-v1.md) covers the migration shape — the v1 mental model maps cleanly across, and most v1 apps move over with no shape change to `app-db`.

--- a/docs/guide/03-your-first-app.md
+++ b/docs/guide/03-your-first-app.md
@@ -158,22 +158,19 @@ This is the only piece with substantive shape. Let's look at it carefully.
 
 Inside the body, two names are available that you didn't define:
 
-- **`subscribe`** — frame-bound. `@(subscribe [:count])` reads the current value of the `:count` subscription, scoped to the surrounding frame.
-- **`dispatch`** — frame-bound. `(dispatch [:counter/inc])` dispatches the event to the surrounding frame.
+- **`subscribe`** — `@(subscribe [:count])` reads the current value of the `:count` subscription.
+- **`dispatch`** — `(dispatch [:counter/inc])` puts an event on the queue.
 
-These are *injected* by `reg-view`. The reason: views need to know which frame they belong to (so that dispatching from a story-tool variant doesn't spam the production frame, for instance), and the cleanest way to make that work without forcing every view to take a frame argument is to inject the frame-bound versions implicitly.
-
-The body uses them just like the original re-frame's `subscribe` and `dispatch`. No ceremony. The `@(...)` syntax is Clojure's "unwrap this reactive value to its current contents" — it's how Reagent (the underlying view substrate) tracks dependencies.
+These are *injected* by `reg-view`. The body uses them just like the original re-frame's `subscribe` and `dispatch`. No ceremony. The `@(...)` syntax is Clojure's "unwrap this reactive value to its current contents" — it's how Reagent (the underlying view substrate) tracks dependencies.
 
 ### Why register views?
 
-Three reasons:
+Two reasons:
 
-1. **Frame routing**. As above — registered views know their frame.
-2. **AI inspection**. `(rf/handlers :view)` returns every registered view in the app. An AI can list, filter, and inspect them without parsing source files.
-3. **Hot reload that works**. Re-evaluating the `reg-view` form replaces the registered view; mounted instances pick up the new code on next render.
+1. **AI inspection**. `(rf/handlers :view)` returns every registered view in the app. An AI can list, filter, and inspect them without parsing source files.
+2. **Hot reload that works**. Re-evaluating the `reg-view` form replaces the registered view; mounted instances pick up the new code on next render.
 
-There's a tradeoff: plain Reagent functions also work, but they don't get frame-routing for free. If you're writing a single-frame app, you can use plain `defn` views with no observable difference; if you're writing anything that might end up multi-frame (which, increasingly, is everything — stories, devcards, SSR), `reg-view` is the safer default.
+There's a tradeoff: plain Reagent functions also work, but they don't get registry introspection. For a small app you can use plain `defn` views with no observable difference; `reg-view` is the safer default.
 
 ## The mount
 
@@ -217,24 +214,22 @@ That's the entire dynamic story. Five steps, all named, no surprises.
 
 ## Testing what we just built
 
+The handler is a pure function — given `db` and `event`, return new `db`. That alone is testable directly:
+
 ```clojure
-(deftest counter-flow
-  (rf/dispatch-sync [:counter/initialise])
-  (is (= 5 (:count (rf/get-frame-db :rf/default))))
-  (rf/dispatch-sync [:counter/inc])
-  (is (= 6 (:count (rf/get-frame-db :rf/default))))
-  (rf/dispatch-sync [:counter/dec])
-  (rf/dispatch-sync [:counter/dec])
-  (is (= 4 (:count (rf/get-frame-db :rf/default)))))
+(deftest counter-handlers
+  (let [inc-handler (:handler-fn (rf/handler-meta :event :counter/inc))
+        dec-handler (:handler-fn (rf/handler-meta :event :counter/dec))]
+    (is (= {:count 6} (inc-handler {:count 5} [:counter/inc])))
+    (is (= {:count 4} (dec-handler {:count 5} [:counter/dec])))))
 ```
 
-That test runs on the JVM. There's no browser. There's no React. It's the same two calls you saw at mount — `dispatch-sync` to run an event synchronously, plus `get-frame-db` to read the resulting `app-db` *value* off the default frame — with `is` assertions threaded between them. The test reads as the production code does. Tests like this run in milliseconds and you can have thousands of them. [Chapter 13 — Testing](13-testing.md) covers the richer testing primitives (isolated frames, sub computation without dispatch, fixtures) for when the shape above isn't enough.
+That test runs on the JVM. There's no browser, no React, no runtime needed — `handler-meta` looks up the registered function, you call it with a value, you assert on the return. Tests like this run in milliseconds and you can have thousands of them. [Chapter 13 — Testing](13-testing.md) covers the richer testing primitives (driving a full event through the dispatch loop, sub computation, fixtures) for when "call the handler as a function" isn't enough.
 
 ## What the example covered
 
 We touched every load-bearing primitive at least once:
 
-- ✓ A frame.
 - ✓ Three event handlers.
 - ✓ A subscription.
 - ✓ A view.
@@ -243,7 +238,6 @@ We touched every load-bearing primitive at least once:
 What we didn't cover yet:
 
 - **Effects** that aren't state changes — HTTP, navigation, localStorage. Coming in [04 — Events, state, and the cycle](04-events-state-cycle.md).
-- **Multiple frames** — you only need them when you need them. Coming in [06 — Views and frames](06-views-and-frames.md).
 - **State machines** — for flows where "what's the next state?" is the load-bearing question. Coming in [08 — State machines](08-state-machines.md).
 - **HTTP requests, the canonical way** — the `:rf.http/managed` fx with retry, abort, decode, and reply addressing. Coming in [10 — Doing HTTP requests](10-doing-http-requests.md).
 

--- a/docs/guide/04-events-state-cycle.md
+++ b/docs/guide/04-events-state-cycle.md
@@ -109,7 +109,7 @@ The button's `on-click` fires:
 [:button {:on-click #(dispatch [:counter/inc])} "+"]
 ```
 
-`dispatch` puts the event vector `[:counter/inc]` onto the frame's queue and returns immediately. No handler has run yet. The click handler is done. The browser's event loop can move on.
+`dispatch` puts the event vector `[:counter/inc]` onto the runtime's queue and returns immediately. No handler has run yet. The click handler is done. The browser's event loop can move on.
 
 The event is *data*: a vector with a keyword id and (optionally) more args. Nothing more.
 
@@ -136,7 +136,7 @@ That's the entire effect map for this event. No `:fx` vector — no HTTP, no loc
 
 ### Domino 4 — Effects executed
 
-The runtime walks the effect map. It sees `:db` and resets the frame's `app-db` to `{:count 6}` as a single atomic swap. No intermediate state is visible. If there were an `:fx` vector, the runtime would walk it next, looking up each registered fx by id and invoking it with its args; for this event there is none.
+The runtime walks the effect map. It sees `:db` and resets `app-db` to `{:count 6}` as a single atomic swap. No intermediate state is visible. If there were an `:fx` vector, the runtime would walk it next, looking up each registered fx by id and invoking it with its args; for this event there is none.
 
 The queue is now empty. The cycle proceeds to subscriptions.
 
@@ -165,7 +165,7 @@ The `counter-buttons` view derefs `:count`:
 
 Reagent re-runs the function body. `@(subscribe [:count])` now returns `6`. The new hiccup tree is `[:div [:button "-"] [:span 6] [:button "+"]]`. Reagent diffs against the previous tree, sees that only the `<span>`'s text content changed, and patches the DOM.
 
-And the view re-renders. One event, six dominoes, frame stays consistent.
+And the view re-renders. One event, six dominoes, the app stays consistent.
 
 ## The standard effect map
 
@@ -206,7 +206,7 @@ Three things to notice:
 
 1. **`reg-fx` is the *only* place in your codebase that calls `js/localStorage`.** The handler that triggered the write didn't. The handler that reads the value back later doesn't either. The browser-side imperative call appears once. That's the entire surface for the effect.
 
-2. **The fx receives a frame context (carrying `:frame`, `:event`, etc.) and the args the event handler put in the effect map.** Most fxs only use the args; ones that re-dispatch follow-up events thread the frame through so the dispatch lands in the right frame.
+2. **The fx receives a runtime context (carrying `:event` and other dispatch metadata) and the args the event handler put in the effect map.** Most fxs only use the args; ones that re-dispatch follow-up events thread the context through so the dispatch routes correctly.
 
 3. **`:platforms` says where this effect is allowed to run.** `#{:client}` means it's skipped during SSR with a `:rf.fx/skipped-on-platform` trace event; the handler doesn't have to branch. We'll come back to this in [chapter 11](11-server-side.md).
 
@@ -246,18 +246,7 @@ The benefits:
 
 **Tests don't need a network.** The handler that produces the effect map can be tested as a pure function. The success and error handlers similarly. The fx itself can be tested by stubbing the HTTP call. None of these tests need React, JSDOM, or a running server.
 
-**You can swap the implementation.** A test wants `:rf.http/managed` to return a canned response? Override it for that test:
-
-```clojure
-(rf/with-managed-request-stubs
-  {[:get "/api/inc.json"] {:reply {:ok {:delta 1}}}}
-  (rf/with-frame [f (rf/make-frame
-                     {:on-create [:counter/initialise]})]
-    (rf/dispatch-sync [:counter/inc-from-server] {:frame f})
-    (is (= 6 (:count (rf/get-frame-db f))))))
-```
-
-The framework ships `with-managed-request-stubs` (and the lower-level `:rf.http/managed-canned-success` / `:rf.http/managed-canned-failure` fxs) precisely so tests can synthesise managed-HTTP replies without a network. It's a registry redirect, not a mock — the same dispatch shape the real fx produces lands in the test handler.
+**You can swap the implementation.** Effects are looked up by id. A test that wants `:rf.http/managed` to return a canned response overrides the entry for the test's duration — the framework ships `with-managed-request-stubs` (and the lower-level `:rf.http/managed-canned-success` / `:rf.http/managed-canned-failure` fxs) precisely so tests can synthesise managed-HTTP replies without a network. It's a registry redirect, not a mock — the same dispatch shape the real fx produces lands in the test handler. [Chapter 13](13-testing.md) walks through the full testing surface; the upshot for this chapter is: effects-as-data is what makes that override possible at all.
 
 **You can record what happened.** Because effects are data, the runtime can log them, replay them, ship them across the wire, store them in a fixture file. re-frame2's trace stream surfaces every effect that fired, with its args, in order. Debugging an asynchronous interaction stops being archaeology.
 
@@ -269,7 +258,7 @@ The framework ships `with-managed-request-stubs` (and the lower-level `:rf.http/
 
 Pulling it all together, here's the cycle for one event with effects:
 
-1. **Something dispatches** an event. The event vector lands in the frame's queue.
+1. **Something dispatches** an event. The event vector lands in the runtime's queue.
 
 2. **The runtime pops the event** and looks up the registered handler.
 
@@ -280,7 +269,7 @@ Pulling it all together, here's the cycle for one event with effects:
    - Walks `:fx`, looking up each registered fx handler by id and invoking it with the args.
    - Each fx may, in turn, dispatch follow-up events. Those events join the queue.
 
-5. **The runtime drains the queue.** It pops the next event and repeats. This continues *until the queue is empty*. Subscriptions only update once at the end — the app moves from one well-defined state to the next, with no intermediate frames visible to the view.
+5. **The runtime drains the queue.** It pops the next event and repeats. This continues *until the queue is empty*. Subscriptions only update once at the end — the app moves from one well-defined state to the next, with no intermediate snapshots visible to the view.
 
 6. **Subscriptions recompute.** The view re-renders. The DOM updates.
 
@@ -292,7 +281,7 @@ The detail in step 5 is worth a pause. The runtime drains the *whole queue* befo
 
 This is called **run-to-completion drain semantics**, and it's a fairly opinionated choice. The alternative — letting each event update the view independently — is what most React apps do. It's faster in microbenchmarks. It's also why React apps occasionally show flickers, half-updated states, or out-of-order renders during fast interactions.
 
-Run-to-completion says: *the user sees coherent states, not transitions*. Either the form is in submitting state, or it's in error state, never both for a frame. Either the page has navigated, or it hasn't, never the in-between. The cost is some flexibility for the developer; the gain is dramatically more predictable behaviour for the user.
+Run-to-completion says: *the user sees coherent states, not transitions*. Either the form is in submitting state, or it's in error state, never both for one render. Either the page has navigated, or it hasn't, never the in-between. The cost is some flexibility for the developer; the gain is dramatically more predictable behaviour for the user.
 
 ## Effects as the testable surface
 
@@ -319,11 +308,11 @@ The rest of the Pattern catalogue — Forms, Boot, WebSocket, LongRunningWork, S
 
 ## A note on revertibility
 
-One consequence of the discipline above worth pausing on: because state lives in one place and updates atomically, **the entire frame's state at any moment is a single value**. That value can be captured, stored, compared, restored. Any prior frame value can be restored as a pointer swap, with no out-of-band state left behind. App-level undo is a thin interceptor. Time-travel debugging records values, not events. SSR ships a value. AI experimentation can try a change, observe, revert, retry without registry pollution. Each of these is a consequence of "state is a value"; the architecture commits to that discipline so the consequences are real.
+One consequence of the discipline above worth pausing on: because state lives in one place and updates atomically, **the entire app's state at any moment is a single value**. That value can be captured, stored, compared, restored. Any prior value can be restored as a pointer swap, with no out-of-band state left behind. App-level undo is a thin interceptor. Time-travel debugging records values, not events. SSR ships a value. AI experimentation can try a change, observe, revert, retry without registry pollution. Each of these is a consequence of "state is a value"; the architecture commits to that discipline so the consequences are real.
 
 ## A note on app-db shape
 
-A frame's `app-db` is "your app's state, in one map." There's no required schema, but a useful convention is one top-level key per *feature* — each feature owning its own slice, accessed through that feature's subs and events:
+`app-db` is "your app's state, in one map." There's no required schema, but a useful convention is one top-level key per *feature* — each feature owning its own slice, accessed through that feature's subs and events:
 
 ```clojure
 {:auth     {:user nil :loading? false :error nil}

--- a/docs/guide/05-coeffects.md
+++ b/docs/guide/05-coeffects.md
@@ -22,7 +22,7 @@ The handler destructures `:db` out of its first argument. That first argument *i
 
 | Coeffect | What it is | Set by |
 |---|---|---|
-| `:db` | The frame's `app-db` value at drain start. | The drain loop, before the interceptor chain runs. |
+| `:db` | The current `app-db` value at drain start. | The drain loop, before the interceptor chain runs. |
 | `:event` | The dispatched event vector. | The dispatch envelope. |
 
 These two are always present; you can rely on them being there. Everything beyond `:db` and `:event` — every other piece of "data from outside the handler" — is opt-in, named, and injected by a small piece of machinery: a registered **cofx**, fetched into the coeffects map by an **`inject-cofx`** interceptor.
@@ -287,18 +287,20 @@ This is the payoff. A handler that uses `(inject-cofx :now)` is testable without
       (fn [ctx]
         (assoc-in ctx [:coeffects :new-id] #uuid "00000000-0000-0000-0000-000000000001")))
 
-    (rf/with-frame [f (rf/make-frame {})]
-      (rf/dispatch-sync [:todo/add "buy milk"])
-      (let [todo (-> (rf/get-frame-db f)
-                     :todos
-                     (get #uuid "00000000-0000-0000-0000-000000000001"))]
-        (is (= "buy milk" (:title todo)))
-        (is (= #inst "2026-01-01T12:00:00.000Z" (:created-at todo)))))))
+    (let [handler (:handler-fn (rf/handler-meta :event :todo/add))
+          coeffects {:db        {}
+                     :event     [:todo/add "buy milk"]
+                     :now       #inst "2026-01-01T12:00:00.000Z"
+                     :new-id    #uuid "00000000-0000-0000-0000-000000000001"}
+          {:keys [db]} (handler coeffects [:todo/add "buy milk"])
+          todo (get-in db [:todos #uuid "00000000-0000-0000-0000-000000000001"])]
+      (is (= "buy milk" (:title todo)))
+      (is (= #inst "2026-01-01T12:00:00.000Z" (:created-at todo))))))
 ```
 
 Three things to notice:
 
-**The stubs are re-registrations, not mocks.** They live in the same registry as the production cofx handlers; they're addressed by the same keyword id. `inject-cofx` finds the re-registered version with no special test-mode flag. A frame's `:interceptor-overrides` slot can go further still — swapping the *interceptor itself* (e.g. `:rf/inject-cofx-now`) for one frame's events when you want the stub scoped to one frame rather than to the whole test registry.
+**The stubs are re-registrations, not mocks.** They live in the same registry as the production cofx handlers; they're addressed by the same keyword id. `inject-cofx` finds the re-registered version with no special test-mode flag. [Chapter 13](13-testing.md) walks the end-to-end-through-the-dispatch-loop variant of this test; this chapter shows the pure-function-of-coeffects shape.
 
 **`with-fresh-registrar` keeps the stubs scoped.** It snapshots the registrar around the body and restores on exit — production `:now` is intact for the next test. Without it, a test that re-registers `:now` leaves a stub in place for whatever runs next, which is the classic "passes alone, fails together" failure mode covered in [chapter 13 §Registrar isolation](13-testing.md#registrar-isolation-with-fresh-registrar).
 

--- a/docs/guide/06a-frames.md
+++ b/docs/guide/06a-frames.md
@@ -2,7 +2,7 @@
 
 > **If you're skipping this chapter, the upshot:** A **frame** is an *isolated runtime boundary* — its own `app-db`, its own event queue, its own subscription cache, identified by a keyword. Every re-frame2 app has at least one frame; single-frame apps run inside an invisible default frame called `:rf/default` and never name it. Reach for multiple frames when you need *multiple instances of the same app's handlers with different state* — a split-screen widget, a story variant, a per-test fixture, a per-request server-side render. Create them with `(rf/reg-frame :id {...})` or `(rf/make-frame {...})`; scope a subtree to one with `[rf/frame-provider {:frame :id} ...]`. The full normative surface lives in [Spec 002](../../spec/002-Frames.md); this chapter is the motivation.
 
-Up to this point in the guide, the word *frame* has been a quiet presence — chapter 02 named it as a per-app boundary, chapter 06 mentioned it whenever `dispatch` or `subscribe` came up. The mental model you've been carrying is "one app, one `app-db`, one queue, one sub-cache." That mental model is right for 90% of apps. This chapter is for the other 10%, and for the small piece of vocabulary even the 90% case has to recognise — `:rf/default`.
+Up to this point in the guide, the word *frame* has barely appeared — [chapter 06](06-views-and-frames.md) introduced it as the boundary `reg-view` routes against, with a split-counter example. The mental model you've been carrying is "one app, one `app-db`, one queue, one sub-cache." That mental model is right for 90% of apps. This chapter is for the other 10%, and for the small piece of vocabulary even the 90% case has to recognise — `:rf/default`.
 
 ## The motivating need
 
@@ -154,7 +154,7 @@ That's the whole thing. Same registered handlers. Same registered sub. Same regi
 
 ## `:rf/default` — the frame you've been using all along
 
-Every example before this chapter — the counter in chapter 02, the events-and-effects walkthrough in chapter 04, the schema-bound counter in 04a, the views in 06 — has been running inside a frame. You just didn't see it. The framework pre-registers a frame called `:rf/default` at load time, and every `dispatch` / `subscribe` that doesn't specify a `:frame` resolves against it.
+Every example before this chapter — the counter in chapter 03, the events-and-effects walkthrough in chapter 04, the schema-bound counter in 04a, the views in 06 — has been running inside a frame. You just didn't see it. The framework pre-registers a frame called `:rf/default` at load time, and every `dispatch` / `subscribe` that doesn't specify a `:frame` resolves against it.
 
 ```clojure
 ;; What you've been writing:
@@ -215,7 +215,6 @@ Each preset's intent is **visible at the call site** — a reader of the source 
 ## Cross-references
 
 - [Spec 002 — Frames](../../spec/002-Frames.md) — the full normative surface: lifecycle, surgical re-registration, the preset expansion table, the dispatch envelope, the per-instance `make-frame` shape, drain semantics, destroyed-frame behaviour.
-- [chapter 02 — app-db](02-app-db.md#per-frame-not-global) — where the per-frame story was first named.
 - [chapter 06 — Views and frames](06-views-and-frames.md) — `reg-view`, `frame-provider`, and the split-counter in context.
 - [chapter 13 — Testing](13-testing.md) — `with-frame`/`make-frame` as the per-test fixture; the `:test` preset.
 - [chapter 21 — Stories](21-stories.md) — frame-per-variant; the `:story` preset.

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -23,7 +23,7 @@ Read these in order. Each chapter assumes the previous one.
 | # | Chapter | What it covers |
 |---|---|---|
 | 01 | [Why re-frame2](01-why-re-frame2.md) | The argument. What problem this solves. Why it works. |
-| 02 | [app-db](02-app-db.md) | The single immutable map every re-frame2 app pivots around — what it is, why immutable, why per-frame. |
+| 02 | [app-db](02-app-db.md) | The single immutable map every re-frame2 app pivots around — what it is, why immutable, the consequences. |
 | 03 | [Your first app](03-your-first-app.md) | The counter, walked through in narrative. |
 | 04 | [Events, state, and the cycle](04-events-state-cycle.md) | The core loop, with side-effects-as-data. |
 | 04a | [Schemas](04a-schemas.md) | The Malli warmup — `reg-app-schema`, event `:spec`, dev-vs-production timing. Read before forms or HTTP, where schemas show up in volume. |


### PR DESCRIPTION
## Summary

Progressive-disclosure audit of guide chapters 01-06. The motivating case (Mike's): frames were leaking into early chapters (especially ch.02 'app-db' and ch.03 'your first app') before their dedicated chapter (06a) introduces them. Each chapter should surface concepts the reader needs *now*, not concepts they'll meet later.

This PR addresses the headline case — frames in chapters 01-06 — surgically, in-place. Other concepts flagged by the audit findings (Pattern-* enumerations, schemas warmup deficit, ch.07 SSR reference-half divider) are out of scope here and should be filed as follow-on beads.

## Chapters touched (7 files)

- **01 — Why re-frame2**: footnote now points at both ch.06 (introduction) and ch.06a (dedicated walk-through).
- **02 — app-db**: removed the 'Per-frame, not global' section in its entirety (~27 lines). The section pulled `reg-frame`, `make-frame`, `with-frame`, `get-frame-db`, and `:rf/default` into the chapter that is supposed to teach 'what app-db is'. Closing migration-from-v1 pointer reworded to drop 'default frame's app-db' phrasing.
- **03 — Your first app**: the chapter-ending test was rewritten to call the registered handler directly via `handler-meta`, dropping `get-frame-db :rf/default`. Removed 'subscribe/dispatch are frame-bound' commentary and the 'Frame routing' reason from 'Why register views?'. Removed 'A frame' / 'Multiple frames' bullets from the chapter summary.
- **04 — Events, state, and the cycle**: 'frame's queue' / 'frame's app-db' / 'frame context' reworded to 'runtime's queue' / 'app-db' / 'runtime context'; the `with-frame`/`make-frame`/`get-frame-db` test-stub example was replaced with a one-line pointer to ch.13. 'A note on revertibility' / 'A note on app-db shape' had 'frame's' qualifiers removed.
- **05 — Coeffects**: 'Testing via cofx stubs' worked example rewritten to call the handler as a pure function over coeffects, instead of using `with-frame` + `dispatch-sync` + `get-frame-db`. The optional side-track sits before ch.06; readers haven't yet met frames.
- **06a — Frames**: removed the cross-ref to the deleted §'Per-frame, not global' anchor in ch.02; chapter intro reworded so it no longer claims ch.02 named frames first.
- **README**: ch.02 tagline updated — no longer claims it covers 'why per-frame'.

## Concept-by-concept summary of deferred references

- `reg-frame`, `make-frame`, `with-frame`, `get-frame-db`, `:rf/default` — all removed from ch.02, ch.03, ch.04, ch.05. First appear at ch.06 (split-counter) and given full coverage at ch.06a.
- 'Frame routing' / 'frame-bound' subscribe and dispatch — removed from ch.03; the relevant explanation lives at ch.06 §`dispatch` and `subscribe` are auto-injected.
- 'A frame' / 'Multiple frames' bullets in summary lists — removed; the chapter pre-views in ch.03 no longer enumerate concepts the reader will meet later.
- 'Frame's queue' / 'frame's app-db' / 'frame context' / 'frame stays consistent' — wording rephrased in ch.04 to avoid pulling the boundary concept forward.

## What was NOT changed in this PR (worth follow-on beads)

The findings doc `ai/findings/guide-progressive-disclosure-audit-2026-05-12.md` (local-only) catalogues 23 surfaced-too-early concepts and 5 surfaced-too-late. This PR addressed only the frames cluster. The remaining items — Pattern-* enumerations, Malli warmup deficit, ch.05 state-machines overload, ch.07 SSR reference-half divider, ch.10 advanced-test-sections defer, etc. — are bead-shaped in the findings doc but require either content trims that affect adjacent surface or structural reorganisation that should not be folded into this PR.

## Test plan

- [x] `mkdocs build --strict` — 131 warnings before this change, 131 warnings after (all pre-existing `spec/` link warnings unrelated to this audit); no new warnings introduced; the broken anchor I created when removing the §'Per-frame, not global' section in ch.02 was fixed in 06a's cross-references.
- [ ] Manual read-through of ch.01 → ch.06 → ch.06a — confirm that 'frame' as a vocabulary item now first appears in ch.06's split-counter context and is given its dedicated walk-through in 06a.