### PR TITLE
feat(pair2-mcp): path slicing on snapshot + new get-path tool (rf2-tygdv)

### DIFF
--- a/tools/pair2-mcp/README.md
+++ b/tools/pair2-mcp/README.md
@@ -33,7 +33,8 @@ cljs-eval compile.
 | `trace-window` | `trace-window.sh`         | Return the epochs that landed in the last N ms. |
 | `watch-epochs` | `watch-epochs.sh`         | Pull-mode poll for matching epochs added after a given epoch-id. Predicate keys: `:event-id`, `:event-id-prefix`, `:effects`, `:touches-path`, `:sub-ran`, `:render`, `:origin`, `:frame`. |
 | `tail-build`   | `tail-build.sh`           | Wait for a hot-reload to land by polling a probe form until its value changes. |
-| `snapshot`     | _(new — no bash equivalent)_ | Coarse-grained per-frame state read in one round-trip. Returns a map keyed by frame-id with `:app-db`, `:sub-cache`, `:machines`, `:epochs`, `:traces` slices. Prefer for investigate-X workflows over chaining 5-10 individual reads. |
+| `snapshot`     | _(new — no bash equivalent)_ | Coarse-grained per-frame state read in one round-trip. Returns a map keyed by frame-id with `:app-db`, `:sub-cache`, `:machines`, `:epochs`, `:traces` slices. Prefer for investigate-X workflows over chaining 5-10 individual reads. The `:app-db` slice defaults to a tree-summary marker (rf2-tygdv); drill down with `path`. |
+| `get-path`     | _(new — no bash equivalent)_ | Read a single value at `path` from a frame's app-db (rf2-tygdv). Minimal targeted-read primitive; server-side `get-in` so only the addressed subtree crosses the wire. Distinguishes a path that points at `nil` from a path that doesn't resolve, and attaches `deepest-valid-prefix` on misses so the agent can re-aim. |
 | `subscribe`    | _(new — no bash equivalent)_ | Streaming subscription on the trace / epoch bus (rf2-hq49). Push-mode replacement for `watch-epochs`; each matching event arrives as a `notifications/progress` notification. Topics: `trace`, `epoch`, `fx`, `error`. |
 | `unsubscribe`  | _(new — no bash equivalent)_ | Close a streaming subscription out-of-band. Idempotent — closing an unknown sub-id returns `:existed? false` rather than an error. |
 

--- a/tools/pair2-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/pair2-mcp/spec/003-Tool-Catalogue.md
@@ -120,7 +120,9 @@ implementation.
 **Args**: `frames` (string `"all"` or array of frame-id strings like
 `":rf/default"`, default `"all"`), `include` (array of slice names —
 subset of `["app-db" "sub-cache" "machines" "epochs" "traces"]`,
-default all five), `build` (string).
+default all five), `path` (EDN-encoded vector or JSON array of segment
+strings — path-slicing for the `:app-db` slice, rf2-tygdv), `build`
+(string).
 
 **Returns**:
 
@@ -128,13 +130,17 @@ default all five), `build` (string).
 {:ok? true
  :frames :all|[<frame-id>...]
  :include [:app-db :sub-cache :machines :epochs :traces]
- :snapshot {<frame-id> {:app-db    {...}
+ :mode :summary | :path-sliced
+ :path  [<segment>...]              ; only when `path` arg was supplied
+ :snapshot {<frame-id> {:app-db    <slice>
                         :sub-cache {<query-v> {:value v :ref-count n}}
                         :machines  {:ids [<machine-id>...]
                                     :state {<machine-id> <snapshot>}}
                         :epochs    [<:rf/epoch-record> ...]
                         :traces    [<trace-event> ...]}
-            ...}}
+            ...}
+ :path-not-found {<frame-id> {:exists? false
+                              :deepest-valid-prefix [...]}}  ; when present}
 ```
 
 The `:machines` slice combines the global registrar's machine-id list
@@ -143,16 +149,88 @@ the frame's `app-db` (per Spec 005). The `:traces` slice filters the
 retain-N trace ring buffer by `:frame`. Other slices delegate
 verbatim to the public per-slice surface.
 
-Pass a smaller `include` to subset (e.g.
-`{:frames "all" :include ["app-db" "epochs"]}` for a quick
-"state + recent history" probe). Per-op fine-grain reads (`eval-cljs`
-against `runtime/app-db-at`, `runtime/sub-cache`, etc.) stay
+### `:app-db` slice modes (rf2-tygdv)
+
+The `:app-db` slice has two response modes governed by the `path` arg:
+
+- **`:mode :summary`** (default, no `path`): the `:app-db` slice is
+  replaced with a `{:rf.mcp/summary {:type :map :keys [...] :count
+  ... :bytes ~...}}` marker — the top-level shape without committing
+  the token budget. A map with more than 64 top-level keys truncates
+  the `:keys` list and flags `:keys-truncated? true` so the marker
+  itself can never blow the wire cap. The agent drills down with a
+  follow-up call carrying `path`, or with the `get-path` tool.
+- **`:mode :path-sliced`** (with `path`): the `:app-db` slice is the
+  subtree at `(get-in db path)`. An out-of-range path surfaces
+  per-frame in the top-level `:path-not-found` map with the
+  deepest-valid-prefix attached so the agent can re-aim.
+- **Root path `[]`**: the agent explicitly asks for the full `:app-db`
+  — equivalent to the legacy default. The wire cap then becomes the
+  backstop.
+
+Path vocabulary matches `get-in`: a vector of keys / indices. EDN
+strings (`":cart"`, `"0"`, `"-1"`) are parsed by the reader; non-EDN
+strings (`"bare-key"`) stay as map-key strings. Same vocabulary as
+the `get-path` tool below and as Causa-MCP's `:path` mechanism — one
+shape across the tool family.
+
+The other slices (`:sub-cache`, `:machines`, `:epochs`, `:traces`)
+pass through unchanged. Pass a smaller `include` to subset (e.g.
+`{:frames "all" :include ["app-db" "epochs"]}` for a quick "state +
+recent history" probe). Per-op fine-grain reads (`get-path` against
+the app-db, `eval-cljs` against `runtime/sub-cache`, etc.) stay
 available — they're the right surface when you genuinely need one
 slice for one frame. `snapshot` is the right surface when you don't
 know yet which slice carries the answer.
 
 `:reason :runtime-not-preloaded` if the preload hasn't run;
 `:reason :snapshot-failed` (with `:message`) on any other failure.
+
+## get-path
+
+Read a single value at `path` from a frame's `app-db`. Minimal
+primitive for targeted reads — the agent already knows the path.
+Server-side `(get-in db path)`; only the addressed subtree crosses
+the wire (rf2-tygdv).
+
+**Args**: `path` (string — EDN-encoded vector, e.g. `"[:cart :items 0
+:sku]"` — or JSON array of segment strings; required), `frame`
+(string — frame-id, default operating frame), `build` (string).
+
+**Returns** on success:
+
+```clojure
+{:ok?     true
+ :exists? true
+ :path    [<segment>...]
+ :value   <subtree>
+ :frame   <frame-id>}     ; only when frame arg was supplied
+```
+
+When the path doesn't resolve:
+
+```clojure
+{:ok?                  false
+ :reason               :path-not-found
+ :path                 [<segment>...]
+ :deepest-valid-prefix [<segment>...]
+ :frame                <frame-id>}     ; only when frame arg was supplied
+```
+
+`:exists?` distinguishes a path that legitimately points at a `nil`
+value (`:exists? true :value nil`) from a path that doesn't resolve
+(`:ok? false :reason :path-not-found`). The deepest-valid-prefix lets
+the agent re-aim without a binary search.
+
+`get-path` is the read-by-path surface for when `snapshot`'s
+`:summary` mode tells the agent which key carries the answer.
+`snapshot {... :path [...]}` is the equivalent surface when the agent
+wants several slices in the same round-trip; both share the same
+`:path` vocabulary.
+
+`:reason :runtime-not-preloaded` if the preload hasn't run;
+`:reason :missing-path` if `path` was omitted;
+`:reason :get-path-failed` (with `:message`) on any other failure.
 
 ## subscribe
 

--- a/tools/pair2-mcp/spec/Principles.md
+++ b/tools/pair2-mcp/spec/Principles.md
@@ -185,8 +185,14 @@ internals.
 - **Pluggable strategy**: the wrapper dispatches on a
   `:strategy` keyword. Today only `:truncate-with-marker` is
   implemented (replace the payload with the overflow marker).
-  Future strategies — path-slicing, lazy summary, diff
-  encoding — slot in here without touching per-tool functions.
+  Future strategies — diff encoding (rf2-1wdzp), structural
+  dedup — slot in here without touching per-tool functions.
+  Path-slicing and lazy-summary already landed (rf2-tygdv) but
+  as per-tool input-shape concerns: the `snapshot` and
+  `get-path` tools accept a `:path` arg and default to a
+  `{:rf.mcp/summary ...}` response for the unbounded `:app-db`
+  slice, so the cap stays a backstop rather than the primary
+  mechanism for the common case.
 - **Silent truncation is not allowed**: a payload that exceeds
   the cap MUST NOT be shipped in any partial form that would
   let the agent host parse it as a valid response. The marker

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -14,6 +14,7 @@
   | watch-epochs  | Pull-mode live epoch streaming                            |
   | tail-build    | Wait for a hot-reload to land                             |
   | snapshot      | Coarse-grained per-frame state read (mega-op)             |
+  | get-path      | Direct read-by-path against a frame's app-db (rf2-tygdv)  |
   | subscribe     | Streaming trace/epoch channel — push-mode replacement for |
   |               | watch-epochs (rf2-hq49)                                   |
   | unsubscribe   | Close a streaming subscription                            |
@@ -129,7 +130,8 @@
 (def ^:private overflow-hints
   "Tool-specific next-step hints for the overflow marker. Generic
   fallback when a tool isn't listed."
-  {"snapshot"      "Narrow scope: pass `frames` to a single frame, or `include` to a single slice (one of app-db, sub-cache, machines, epochs, traces). Combine with future path-slicing args when available."
+  {"snapshot"      "Narrow scope: pass `path [:k1 :k2]` to slice the :app-db slice, `frames` to a single frame, or `include` to a single slice (one of app-db, sub-cache, machines, epochs, traces). Default mode is :summary — drill down via `get-path` once you know the key."
+   "get-path"      "Narrow the path further — pass a deeper segment so the addressed subtree is smaller. Or call `snapshot` with no `path` first for a tree-summary, then re-aim."
    "trace-window"  "Reduce `ms` to a smaller window, narrow with `frame`, or fetch incrementally via `watch-epochs` + `since-id`."
    "watch-epochs"  "Narrow `pred` (e.g. `:event-id-prefix`, `:effects`), pass `frame`, or stream via `subscribe` with `max-events`."
    "subscribe"     "Tighten `filter`, lower `max-buffered`, set `max-events` so each tick stays small."
@@ -536,6 +538,78 @@
       (keyword s))
     :else (keyword x)))
 
+;; ---------------------------------------------------------------------------
+;; Path-arg parsing (rf2-tygdv).
+;;
+;; Two tools take a `:path` argument: `snapshot` (slice the :app-db slice)
+;; and `get-path` (direct read-by-path). Same parser, same semantics so
+;; agents learn the shape once.
+;;
+;; Accepted shapes from the MCP host:
+;;   - JS array of strings  ⇒ each entry parsed as EDN; non-EDN entries
+;;                            stay as strings.
+;;   - CLJS vector          ⇒ pass through.
+;;   - EDN-encoded string   ⇒ read-string (e.g. `"[:cart :items 3 :sku]"`).
+;;   - nil / missing        ⇒ nil (no path slicing).
+;;
+;; This mirrors the causa-mcp wire-protocol Principles §"2. Path slicing"
+;; convention: a path is an EDN-encoded vector of keys addressing a
+;; subtree. The vocabulary is shared across pair2-mcp / causa-mcp /
+;; story-mcp so agents recognise the surface once.
+;; ---------------------------------------------------------------------------
+
+(defn- coerce-path-segment
+  "Coerce one segment of a JS-array path argument.
+
+  Heuristic: an EDN-shaped string is parsed (`\":cart\"` ⇒ `:cart`,
+  `\"0\"` ⇒ `0`, `\"-1\"` ⇒ `-1`), but a bare identifier
+  (`\"items\"`, `\"bare-key\"`) stays a string — the default reader
+  would otherwise coerce it to a symbol, which is a different
+  `get-in` key. Trigger characters are the EDN literal openers `:`
+  (keyword), a leading digit, or `-`/`+` (signed number); anything
+  else falls through as a plain string."
+  [s]
+  (if-not (string? s)
+    s
+    (let [trimmed   (str/trim s)
+          fc        (when (pos? (count trimmed)) (.charAt trimmed 0))
+          edn-shape (and fc
+                         (or (= ":" fc)
+                             (= "-" fc)
+                             (= "+" fc)
+                             (boolean (re-matches #"\d" fc))))]
+      (if edn-shape
+        (try (cljs.reader/read-string trimmed)
+             (catch :default _ s))
+        s))))
+
+(defn- parse-path-arg
+  "Normalise the `path` MCP arg into a CLJS vector suitable for
+   `get-in`. Returns `nil` when the path is absent. Returns `[]` for an
+   explicit empty path (root). Unparsable strings fall through as
+   strings — `get-in` will then treat them as map keys."
+  [raw]
+  (cond
+    (nil? raw) nil
+    (vector? raw) raw
+    (sequential? raw) (vec raw)
+    (array? raw) (mapv coerce-path-segment (js->clj raw))
+    (string? raw)
+    (let [trimmed (str/trim raw)]
+      (cond
+        (str/blank? trimmed) nil
+        :else
+        (try
+          (let [parsed (cljs.reader/read-string trimmed)]
+            (cond
+              (vector? parsed)     parsed
+              (sequential? parsed) (vec parsed)
+              :else                [parsed]))
+          (catch :default _
+            ;; Unparseable; treat the whole string as a single segment.
+            [trimmed]))))
+    :else nil))
+
 (defn- parse-frames-arg
   "Normalise the `frames` MCP arg into the form the runtime expects.
    Accepts `:all`, the string \"all\", a JS array of strings, or a CLJS
@@ -598,24 +672,218 @@
                               {} snapshot)]
       [scrubbed @dropped])))
 
+;; ---------------------------------------------------------------------------
+;; Tree-summary for the `:app-db` slice (rf2-tygdv).
+;;
+;; Per causa-mcp's wire-protocol Principles §"4. Lazy summary", the
+;; default response mode for a rich nested value is a *summary*, not the
+;; full payload. The summary declares the shape without committing the
+;; token budget:
+;;
+;;   {:rf.mcp/summary {:type  :map | :vector | :set | :scalar
+;;                     :keys  [<top-level keys>]   ; maps only
+;;                     :count <int>                ; non-scalars only
+;;                     :bytes ~<int>}}             ; pr-str char count
+;;
+;; Applied to snapshot's `:app-db` slice when the caller does NOT pass
+;; `:path`. Agents drill down by re-calling with `:path [:cart :items]`
+;; (mechanism 2). The other slices (:sub-cache :machines :epochs
+;; :traces) already have their own pagination / bounded shapes; only
+;; `:app-db` was the unbounded blow-the-cap surface flagged in
+;; rf2-jlq5j's findings doc.
+;; ---------------------------------------------------------------------------
+
+(def ^:private summary-keys-cap
+  "Top-N keys included verbatim in a tree-summary marker. Above this,
+  the summary truncates and attaches `:keys-truncated? true` so the
+  marker itself stays bounded — a 5,000-entry map's key list alone
+  would exceed the wire cap otherwise. 64 is large enough that a
+  human-scale app-db root surfaces every key, and small enough that
+  the marker is always tens of tokens."
+  64)
+
+(defn- tree-summary
+  "Compute a server-friendly tree summary of `v`. Returns the marker
+  shape causa-mcp's §Lazy-summary mechanism pins. Cheap — one pass
+  over the top-level structure, no deep walk. The marker itself is
+  bounded: long key lists are truncated to `summary-keys-cap` entries
+  and flagged via `:keys-truncated? true` so the marker can never
+  blow the wire cap."
+  [v]
+  (cond
+    (map? v)
+    (let [ks      (keys v)
+          n       (count ks)
+          shown   (if (> n summary-keys-cap)
+                    (vec (take summary-keys-cap ks))
+                    (vec ks))]
+      {:rf.mcp/summary (cond-> {:type   :map
+                                :keys   shown
+                                :count  n
+                                :bytes  (count (pr-str v))}
+                         (> n summary-keys-cap)
+                         (assoc :keys-truncated? true))})
+    (vector? v)
+    {:rf.mcp/summary {:type  :vector
+                      :count (count v)
+                      :bytes (count (pr-str v))}}
+    (set? v)
+    {:rf.mcp/summary {:type  :set
+                      :count (count v)
+                      :bytes (count (pr-str v))}}
+    (sequential? v)
+    {:rf.mcp/summary {:type  :seq
+                      :count (count v)
+                      :bytes (count (pr-str v))}}
+    :else
+    {:rf.mcp/summary {:type  :scalar
+                      :value v
+                      :bytes (count (pr-str v))}}))
+
+(defn- deepest-valid-prefix
+  "Walk `path` against `db` and return the deepest prefix that
+  resolves. Used in `:path-not-found` errors so the agent can re-aim
+  without a binary search. Handles map keys + sequential indices;
+  anything else (a scalar at depth, a function value, etc.) terminates
+  the walk."
+  [db path]
+  (loop [acc [] cur db remaining path]
+    (if (empty? remaining)
+      acc
+      (let [k (first remaining)]
+        (cond
+          (and (map? cur) (contains? cur k))
+          (recur (conj acc k) (get cur k) (rest remaining))
+
+          (and (sequential? cur) (integer? k) (<= 0 k (dec (count cur))))
+          (recur (conj acc k) (nth (vec cur) k) (rest remaining))
+
+          :else acc)))))
+
+(defn- slice-app-db-in-snapshot
+  "Post-process the raw snapshot map: for each frame's `:app-db` slice,
+  apply path-slicing (when `path` is present) or summarisation (when
+  `path` is nil).
+
+  Returns `[processed-snapshot per-frame-path-status]` where
+  `per-frame-path-status` is `{<frame-id> {:exists? bool
+                                            :deepest-valid-prefix [...]}}`
+  populated only when `path` is supplied and at least one frame's
+  path didn't resolve. Empty map when path is nil."
+  [snapshot path]
+  (if-not (map? snapshot)
+    [snapshot {}]
+    (let [status* (atom {})
+          missing (js-obj)
+          process-frame
+          (fn [frame-id frame-map]
+            (if-not (and (map? frame-map) (contains? frame-map :app-db))
+              frame-map
+              (let [db (:app-db frame-map)]
+                (cond
+                  ;; No path: summarise.
+                  (nil? path)
+                  (update frame-map :app-db tree-summary)
+                  ;; Root path (`[]`): return full db (agent opted in
+                  ;; explicitly). Equivalent to legacy default behaviour.
+                  (empty? path)
+                  frame-map
+                  ;; Path supplied: get-in with missing sentinel.
+                  :else
+                  (let [v (get-in db path missing)]
+                    (if (identical? v missing)
+                      (do (swap! status* assoc frame-id
+                                 {:exists? false
+                                  :deepest-valid-prefix (deepest-valid-prefix db path)})
+                          (assoc frame-map :app-db nil))
+                      (assoc frame-map :app-db v)))))))
+          processed (reduce-kv (fn [m fid fmap]
+                                 (assoc m fid (process-frame fid fmap)))
+                               {} snapshot)]
+      [processed @status*])))
+
 (defn- snapshot-tool [conn args]
   (let [build-id (arg-build args)
         frames   (parse-frames-arg (arg args :frames))
         include  (parse-include-arg (arg args :include))
         incl?    (include-sensitive? args)
+        path     (parse-path-arg (arg args :path))
         opts     {:frames frames :include include}
         form     (str "(re-frame-pair2.runtime/snapshot-state "
                       (pr-str opts) ")")]
     (-> (ensure-runtime! conn build-id)
         (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
         (.then (fn [v]
-                 (let [[scrubbed dropped] (scrub-snapshot-sensitive v incl?)]
+                 (let [[scrubbed dropped]    (scrub-snapshot-sensitive v incl?)
+                       [sliced path-status]  (slice-app-db-in-snapshot scrubbed path)]
                    (ok-text (cond-> {:ok?      true
                                      :frames   (if (= :all frames) :all (vec frames))
                                      :include  include
-                                     :snapshot scrubbed}
-                              (pos? dropped) (assoc :dropped-sensitive dropped))))))
+                                     :mode     (if (nil? path) :summary :path-sliced)
+                                     :snapshot sliced}
+                              path                  (assoc :path path)
+                              (seq path-status)     (assoc :path-not-found path-status)
+                              (pos? dropped)        (assoc :dropped-sensitive dropped))))))
         (.catch (fn [err] (err->result :snapshot-failed err))))))
+
+;; ---------------------------------------------------------------------------
+;; Tool: get-path — direct read-by-path against a frame's app-db
+;;       (rf2-tygdv).
+;;
+;; Minimal, focused primitive. The `snapshot` tool is the right surface
+;; when the agent doesn't know yet which slice carries the answer;
+;; `get-path` is the right surface when the agent already knows the
+;; path. Each call is one bencode round-trip; the runtime computes
+;; `(get-in app-db path)` server-side so only the addressed subtree
+;; crosses the wire.
+;;
+;; Path vocabulary mirrors `get-in`: a vector of keys / indices.
+;; ---------------------------------------------------------------------------
+
+(defn- get-path-tool [conn args]
+  (let [build-id (arg-build args)
+        frame    (some-> (arg args :frame) ->frame-keyword)
+        path     (parse-path-arg (arg args :path))]
+    (cond
+      (nil? path)
+      (js/Promise.resolve
+        (err-text {:ok? false :reason :missing-path
+                   :hint "usage: get-path {path '[:cart :items 0 :sku]' [frame :rf/default]}"}))
+
+      :else
+      ;; Server-side eval form: call `snapshot` (full db for the frame)
+      ;; then `get-in` with a missing sentinel, so we can distinguish
+      ;; `path-not-found` from a path that legitimately points at nil.
+      ;; The deepest-valid-prefix loop is inlined so a stale runtime
+      ;; (no helper) still answers correctly.
+      (let [path-edn      (pr-str path)
+            snapshot-call (if frame
+                            (str "(re-frame-pair2.runtime/snapshot " (pr-str frame) ")")
+                            "(re-frame-pair2.runtime/snapshot)")
+            form (str "(let [db " snapshot-call
+                      "      path " path-edn
+                      "      missing #js {}"
+                      "      v (get-in db path missing)]"
+                      "  (if (identical? v missing)"
+                      "    {:ok? false :reason :path-not-found"
+                      "     :path path"
+                      "     :deepest-valid-prefix"
+                      "     (loop [acc [] cur db rem path]"
+                      "       (cond"
+                      "         (empty? rem) acc"
+                      "         (and (map? cur) (contains? cur (first rem)))"
+                      "         (recur (conj acc (first rem)) (get cur (first rem)) (rest rem))"
+                      "         (and (sequential? cur) (integer? (first rem))"
+                      "              (<= 0 (first rem) (dec (count cur))))"
+                      "         (recur (conj acc (first rem)) (nth (vec cur) (first rem)) (rest rem))"
+                      "         :else acc))}"
+                      "    {:ok? true :exists? true :path path :value v}))")]
+        (-> (ensure-runtime! conn build-id)
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+            (.then (fn [v]
+                     (ok-text (cond-> v
+                                frame (assoc :frame frame)))))
+            (.catch (fn [err] (err->result :get-path-failed err))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Tool: subscribe — streaming trace + epoch channel (rf2-hq49).
@@ -925,6 +1193,12 @@
                       ":app-db, :sub-cache, :machines, :epochs, :traces. "
                       "Server-side composition over the existing per-slice runtime readers. "
                       "Prefer this over chaining 5-10 individual reads. "
+                      "Path slicing (rf2-tygdv): the `:app-db` slice supports a `path` arg (an EDN-encoded "
+                      "vector of keys, e.g. \"[:cart :items 0]\"). With `path`, returns the addressed subtree. "
+                      "Without `path`, returns a `{:rf.mcp/summary ...}` marker for the `:app-db` slice "
+                      "(top-level keys + count + bytes) rather than the full value — keeps the response "
+                      "under the wire cap by default. Agents drill down by re-calling with `path`. The "
+                      "other slices (:sub-cache, :machines, :epochs, :traces) pass through unchanged. "
                       "Per spec/009 §Privacy the `:traces` and `:epochs` slices default-drop items carrying "
                       "`:sensitive? true`; opt back in with `include-sensitive? true`. App-db / sub-cache / "
                       "machines slices pass through unchanged — payload redaction is the `with-redacted` "
@@ -937,9 +1211,39 @@
                                          :description "Slices to include. Defaults to all five. Recognised: app-db, sub-cache, machines, epochs, traces."
                                          :items {:type "string"
                                                  :enum ["app-db" "sub-cache" "machines" "epochs" "traces"]}}
+                               :path    {:description (str "Path into the :app-db slice. EDN-encoded vector of keys "
+                                                           "(e.g. \"[:cart :items 0]\") or a JSON array of segment "
+                                                           "strings. When supplied, the :app-db slice in the result "
+                                                           "is the subtree at the path. Out-of-range paths surface "
+                                                           "as `:path-not-found` per-frame with deepest-valid-prefix "
+                                                           "attached. When absent, the :app-db slice is a "
+                                                           "`{:rf.mcp/summary ...}` marker (mode :summary).")
+                                         :oneOf [{:type "string"}
+                                                 {:type "array" :items {:type "string"}}]}
                                :include-sensitive? {:type "boolean"
                                                     :description "Opt back in to forwarding `:sensitive? true` items in the :traces / :epochs slices. Default false."}
                                :build   {:type "string" :description "shadow-cljs build id (default: app)"}}
+                  :additionalProperties false}}
+   {:name "get-path"
+    :description (str "Read a single value at `path` from a frame's app-db. Minimal primitive for "
+                      "targeted reads — the agent already knows the path. Server-side `(get-in db path)`; "
+                      "only the addressed subtree crosses the wire. Returns "
+                      "`{:ok? true :exists? true :path [...] :value <subtree>}` on success or "
+                      "`{:ok? false :reason :path-not-found :path [...] :deepest-valid-prefix [...]}` "
+                      "when the path doesn't resolve. The deepest-valid-prefix lets the agent re-aim "
+                      "without a binary search. Use this when `snapshot`'s summary mode (default) "
+                      "tells you which key carries the answer.")
+    :inputSchema {:type "object"
+                  :properties {:path  {:description (str "Path into app-db. EDN-encoded vector of keys "
+                                                         "(e.g. \"[:cart :items 0 :sku]\") or a JSON array "
+                                                         "of segment strings (each parsed as EDN — bare "
+                                                         "strings stay as map-key strings).")
+                                       :oneOf [{:type "string"}
+                                               {:type "array" :items {:type "string"}}]}
+                               :frame {:type "string"
+                                       :description "Frame-id (e.g. \":rf/default\"). Defaults to the operating frame."}
+                               :build {:type "string"}}
+                  :required ["path"]
                   :additionalProperties false}}
    {:name "subscribe"
     :description (str "Open a streaming subscription on the trace or epoch bus. Push-mode replacement for watch-epochs. "
@@ -999,6 +1303,7 @@
     "watch-epochs"     (watch-epochs-tool conn args)
     "tail-build"       (tail-build-tool conn args)
     "snapshot"         (snapshot-tool  conn args)
+    "get-path"         (get-path-tool  conn args)
     "subscribe"        (subscribe-tool conn args extra)
     "unsubscribe"      (unsubscribe-tool conn args)
     (js/Promise.resolve

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/path_slicing_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/path_slicing_test.cljs
@@ -1,0 +1,389 @@
+(ns re-frame-pair2-mcp.path-slicing-test
+  "Unit tests for the path-slicing surfaces added under rf2-tygdv.
+
+  Two MCP surfaces share the same path vocabulary:
+
+    - The `snapshot` tool gained a `:path` arg that slices the
+      `:app-db` slice. Without `:path`, the `:app-db` slice is
+      replaced by a `{:rf.mcp/summary ...}` marker (default mode
+      `:summary`) so the response stays under the wire cap.
+    - The new `get-path` tool returns the value at a single path —
+      a minimal primitive for targeted reads.
+
+  These tests mirror the private helpers from `tools.cljs`
+  (`parse-path-arg`, `coerce-path-segment`, `tree-summary`,
+  `deepest-valid-prefix`, `slice-app-db-in-snapshot`). A rename or
+  signature change surfaces as a failing test rather than a silent
+  contract drift.
+
+  Live end-to-end coverage of `get-path-tool` and the snapshot
+  `:path` arg lives in `test/stdio-roundtrip.js` (degraded-mode
+  dispatch) and the manual live-nREPL integration test."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [cljs.reader]
+            [clojure.string :as str]
+            [applied-science.js-interop :as j]))
+
+;; ---------------------------------------------------------------------------
+;; Mirrors of the private path-slicing helpers. Keep in lockstep with
+;; `tools.cljs`. (Private vars aren't accessible across ns boundaries
+;; in CLJS without `#'` and `:private false` — copying the surface
+;; here is the convention the sibling tests use.)
+;; ---------------------------------------------------------------------------
+
+(defn- token-estimate
+  "Mirror of `tools.cljs`'s `token-estimate` — `(quot (count s) 4)`."
+  [s]
+  (quot (count s) 4))
+
+(defn- coerce-path-segment [s]
+  (if-not (string? s)
+    s
+    (let [trimmed   (str/trim s)
+          fc        (when (pos? (count trimmed)) (.charAt trimmed 0))
+          edn-shape (and fc
+                         (or (= ":" fc)
+                             (= "-" fc)
+                             (= "+" fc)
+                             (boolean (re-matches #"\d" fc))))]
+      (if edn-shape
+        (try (cljs.reader/read-string trimmed)
+             (catch :default _ s))
+        s))))
+
+(defn- parse-path-arg [raw]
+  (cond
+    (nil? raw) nil
+    (vector? raw) raw
+    (sequential? raw) (vec raw)
+    (array? raw) (mapv coerce-path-segment (js->clj raw))
+    (string? raw)
+    (let [trimmed (str/trim raw)]
+      (cond
+        (str/blank? trimmed) nil
+        :else
+        (try
+          (let [parsed (cljs.reader/read-string trimmed)]
+            (cond
+              (vector? parsed)     parsed
+              (sequential? parsed) (vec parsed)
+              :else                [parsed]))
+          (catch :default _
+            [trimmed]))))
+    :else nil))
+
+(def ^:private summary-keys-cap 64)
+
+(defn- tree-summary [v]
+  (cond
+    (map? v)
+    (let [ks    (keys v)
+          n     (count ks)
+          shown (if (> n summary-keys-cap)
+                  (vec (take summary-keys-cap ks))
+                  (vec ks))]
+      {:rf.mcp/summary (cond-> {:type   :map
+                                :keys   shown
+                                :count  n
+                                :bytes  (count (pr-str v))}
+                         (> n summary-keys-cap)
+                         (assoc :keys-truncated? true))})
+    (vector? v)
+    {:rf.mcp/summary {:type  :vector
+                      :count (count v)
+                      :bytes (count (pr-str v))}}
+    (set? v)
+    {:rf.mcp/summary {:type  :set
+                      :count (count v)
+                      :bytes (count (pr-str v))}}
+    (sequential? v)
+    {:rf.mcp/summary {:type  :seq
+                      :count (count v)
+                      :bytes (count (pr-str v))}}
+    :else
+    {:rf.mcp/summary {:type  :scalar
+                      :value v
+                      :bytes (count (pr-str v))}}))
+
+(defn- deepest-valid-prefix [db path]
+  (loop [acc [] cur db remaining path]
+    (if (empty? remaining)
+      acc
+      (let [k (first remaining)]
+        (cond
+          (and (map? cur) (contains? cur k))
+          (recur (conj acc k) (get cur k) (rest remaining))
+
+          (and (sequential? cur) (integer? k) (<= 0 k (dec (count cur))))
+          (recur (conj acc k) (nth (vec cur) k) (rest remaining))
+
+          :else acc)))))
+
+(defn- slice-app-db-in-snapshot [snapshot path]
+  (if-not (map? snapshot)
+    [snapshot {}]
+    (let [status* (atom {})
+          missing (js-obj)
+          process-frame
+          (fn [frame-id frame-map]
+            (if-not (and (map? frame-map) (contains? frame-map :app-db))
+              frame-map
+              (let [db (:app-db frame-map)]
+                (cond
+                  (nil? path)
+                  (update frame-map :app-db tree-summary)
+                  (empty? path)
+                  frame-map
+                  :else
+                  (let [v (get-in db path missing)]
+                    (if (identical? v missing)
+                      (do (swap! status* assoc frame-id
+                                 {:exists? false
+                                  :deepest-valid-prefix (deepest-valid-prefix db path)})
+                          (assoc frame-map :app-db nil))
+                      (assoc frame-map :app-db v)))))))
+          processed (reduce-kv (fn [m fid fmap]
+                                 (assoc m fid (process-frame fid fmap)))
+                               {} snapshot)]
+      [processed @status*])))
+
+;; ---------------------------------------------------------------------------
+;; parse-path-arg — the input-shape contract.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-path-arg-nil-is-nil
+  (is (nil? (parse-path-arg nil))))
+
+(deftest parse-path-arg-blank-string-is-nil
+  (is (nil? (parse-path-arg "")))
+  (is (nil? (parse-path-arg "   "))))
+
+(deftest parse-path-arg-edn-vector-string
+  (is (= [:cart :items 0] (parse-path-arg "[:cart :items 0]")))
+  (is (= [:a :b :c] (parse-path-arg "[:a :b :c]"))))
+
+(deftest parse-path-arg-edn-empty-vector-is-root
+  (is (= [] (parse-path-arg "[]"))))
+
+(deftest parse-path-arg-cljs-vector-passes-through
+  (is (= [:a :b :c] (parse-path-arg [:a :b :c])))
+  (is (= [] (parse-path-arg []))))
+
+(deftest parse-path-arg-cljs-sequential-coerces-to-vector
+  (is (= [:a :b :c] (parse-path-arg (list :a :b :c)))))
+
+(deftest parse-path-arg-js-array-of-edn-strings
+  ;; Each segment is parsed as EDN: keywords, integers, etc.
+  (is (= [:cart :items 0]
+         (parse-path-arg #js [":cart" ":items" "0"]))))
+
+(deftest parse-path-arg-js-array-with-bare-strings-stays-strings
+  ;; Non-EDN segments (bare strings) pass through as map keys.
+  (is (= [:a "bare-key" :b]
+         (parse-path-arg #js [":a" "bare-key" ":b"]))))
+
+(deftest parse-path-arg-non-vector-edn-wraps-as-single-segment
+  ;; A lone keyword string becomes a 1-segment path.
+  (is (= [:foo] (parse-path-arg ":foo")))
+  ;; A bare integer string also becomes a 1-segment path.
+  (is (= [42] (parse-path-arg "42"))))
+
+(deftest parse-path-arg-unparseable-string-is-single-string-segment
+  ;; Pathological — EDN parser barfs; fall back to treating as one
+  ;; map-key string segment rather than raising.
+  (is (= ["((("] (parse-path-arg "(((")))
+  (is (= ["[" "]"] (parse-path-arg #js ["[" "]"]))))
+
+;; ---------------------------------------------------------------------------
+;; tree-summary — the {:rf.mcp/summary ...} marker shape.
+;; ---------------------------------------------------------------------------
+
+(deftest tree-summary-map-records-top-level-keys-and-bytes
+  (let [v {:a 1 :b 2 :nested {:deep {:value 42}}}
+        s (tree-summary v)
+        marker (:rf.mcp/summary s)]
+    (is (= :map (:type marker)))
+    (is (= #{:a :b :nested} (set (:keys marker))))
+    (is (= 3 (:count marker)))
+    (is (= (count (pr-str v)) (:bytes marker)))))
+
+(deftest tree-summary-vector-records-count
+  (let [v [1 2 3 4 5]
+        marker (:rf.mcp/summary (tree-summary v))]
+    (is (= :vector (:type marker)))
+    (is (= 5 (:count marker)))))
+
+(deftest tree-summary-set-and-seq
+  (is (= :set (-> (tree-summary #{1 2 3}) :rf.mcp/summary :type)))
+  (is (= :seq (-> (tree-summary (list 1 2 3)) :rf.mcp/summary :type))))
+
+(deftest tree-summary-map-truncates-huge-key-lists
+  ;; A 5k-entry map's key list alone would blow the cap. The summary
+  ;; marker MUST stay bounded.
+  (let [big-map (zipmap (map #(keyword (str "k" %)) (range 5000))
+                        (repeat :_))
+        marker  (:rf.mcp/summary (tree-summary big-map))]
+    (is (= :map (:type marker)))
+    (is (= 5000 (:count marker)))
+    (is (= summary-keys-cap (count (:keys marker))))
+    (is (true? (:keys-truncated? marker)))
+    (is (< (token-estimate (pr-str marker)) 5000)
+        "Marker for a 5k-entry map MUST still fit the wire cap")))
+
+(deftest tree-summary-scalar-keeps-the-value
+  ;; Scalars are cheap; summarising would lose information without
+  ;; saving any tokens.
+  (let [marker (:rf.mcp/summary (tree-summary 42))]
+    (is (= :scalar (:type marker)))
+    (is (= 42 (:value marker)))))
+
+;; ---------------------------------------------------------------------------
+;; deepest-valid-prefix — the error-recovery breadcrumb.
+;; ---------------------------------------------------------------------------
+
+(deftest deepest-valid-prefix-walks-map-keys
+  (let [db {:user {:auth {:token "abc"}}}]
+    (is (= [:user :auth :token]
+           (deepest-valid-prefix db [:user :auth :token])))
+    (is (= [:user :auth]
+           (deepest-valid-prefix db [:user :auth :missing])))
+    (is (= []
+           (deepest-valid-prefix db [:missing])))))
+
+(deftest deepest-valid-prefix-walks-vector-indices
+  (let [db {:items [:apple :banana :cherry]}]
+    (is (= [:items 1]
+           (deepest-valid-prefix db [:items 1])))
+    (is (= [:items]
+           (deepest-valid-prefix db [:items 99])))
+    (is (= [:items]
+           ;; non-integer key on a vector terminates the walk
+           (deepest-valid-prefix db [:items :nope])))))
+
+(deftest deepest-valid-prefix-stops-at-scalar
+  (let [db {:user {:name "alice"}}]
+    ;; Walking past a string scalar stops at the scalar's parent.
+    (is (= [:user :name]
+           (deepest-valid-prefix db [:user :name :char])))))
+
+(deftest deepest-valid-prefix-handles-nil-leaf
+  ;; nil is a legitimate map value; the path that points at it is
+  ;; "valid" up to the nil, but a further step terminates.
+  (let [db {:k nil}]
+    (is (= [:k] (deepest-valid-prefix db [:k])))
+    (is (= [:k] (deepest-valid-prefix db [:k :anything])))))
+
+;; ---------------------------------------------------------------------------
+;; slice-app-db-in-snapshot — snapshot's `:app-db` post-processing.
+;; ---------------------------------------------------------------------------
+
+(def ^:private fixture-snapshot
+  {:rf/default {:app-db    {:user {:profile {:name "alice"}}
+                            :cart {:items [{:sku "A1"} {:sku "A2"}]
+                                   :total 42}}
+                :sub-cache {[:user/email] {:value "a@b" :ref-count 1}}
+                :machines  {:ids [] :state {}}
+                :epochs    []
+                :traces    []}
+   :stories    {:app-db    {:story-id 7}
+                :sub-cache {}
+                :machines  {:ids [] :state {}}
+                :epochs    []
+                :traces    []}})
+
+(deftest snapshot-without-path-summarises-app-db
+  (let [[out status] (slice-app-db-in-snapshot fixture-snapshot nil)]
+    (is (empty? status) "No path-not-found entries when path is nil")
+    (testing "every frame's :app-db is replaced with a summary marker"
+      (let [marker-default (-> out :rf/default :app-db :rf.mcp/summary)]
+        (is (some? marker-default))
+        (is (= :map (:type marker-default)))
+        (is (= #{:user :cart} (set (:keys marker-default))))
+        (is (= 2 (:count marker-default))))
+      (let [marker-stories (-> out :stories :app-db :rf.mcp/summary)]
+        (is (some? marker-stories))
+        (is (= [:story-id] (:keys marker-stories)))))
+    (testing "other slices pass through unchanged"
+      (is (= {[:user/email] {:value "a@b" :ref-count 1}}
+             (-> out :rf/default :sub-cache)))
+      (is (= [] (-> out :rf/default :epochs))))))
+
+(deftest snapshot-with-path-returns-subtree
+  (let [[out status] (slice-app-db-in-snapshot
+                       fixture-snapshot
+                       [:user :profile])]
+    (is (= {:name "alice"}
+           (-> out :rf/default :app-db))
+        "Subtree replaces the :app-db slice on the matching frame")
+    (testing "non-matching frames record :path-not-found"
+      ;; :stories has no :user key. The same path call records the
+      ;; miss in `path-not-found` and zeroes the slice.
+      (is (contains? status :stories))
+      (is (= false (-> status :stories :exists?)))
+      (is (= [] (-> status :stories :deepest-valid-prefix)))
+      (is (nil? (-> out :stories :app-db))
+          "Missing-path slice becomes nil — agent reads :path-not-found")
+      (is (not (contains? status :rf/default))
+          "Matching frame doesn't appear in the path-not-found map"))))
+
+(deftest snapshot-with-vector-index-path
+  (let [[out _] (slice-app-db-in-snapshot
+                  fixture-snapshot
+                  [:cart :items 1 :sku])]
+    (is (= "A2" (-> out :rf/default :app-db)))))
+
+(deftest snapshot-with-empty-path-returns-full-app-db
+  ;; Root path is the agent opting in to the full slice.
+  (let [[out _] (slice-app-db-in-snapshot fixture-snapshot [])]
+    (is (= {:user {:profile {:name "alice"}}
+            :cart {:items [{:sku "A1"} {:sku "A2"}]
+                   :total 42}}
+           (-> out :rf/default :app-db)))))
+
+(deftest snapshot-path-not-found-attaches-deepest-prefix
+  (let [[_ status] (slice-app-db-in-snapshot
+                     fixture-snapshot
+                     [:user :auth :token])]
+    (is (= false (-> status :rf/default :exists?)))
+    (is (= [:user] (-> status :rf/default :deepest-valid-prefix)))))
+
+(deftest snapshot-summarise-handles-empty-map
+  (let [snap {:f1 {:app-db {} :sub-cache {} :machines {} :epochs [] :traces []}}
+        [out _] (slice-app-db-in-snapshot snap nil)
+        marker (-> out :f1 :app-db :rf.mcp/summary)]
+    (is (= :map (:type marker)))
+    (is (= 0 (:count marker)))
+    (is (= [] (:keys marker)))))
+
+(deftest snapshot-skips-frames-without-app-db
+  ;; The :include filter may exclude :app-db from the slice list.
+  ;; In that case the frame map has no :app-db key at all; the
+  ;; post-processor MUST NOT add one.
+  (let [snap {:f1 {:sub-cache {} :epochs []}}
+        [out _] (slice-app-db-in-snapshot snap nil)
+        [out2 _] (slice-app-db-in-snapshot snap [:foo])]
+    (is (not (contains? (:f1 out) :app-db)))
+    (is (not (contains? (:f1 out2) :app-db)))))
+
+;; ---------------------------------------------------------------------------
+;; Wire-cap interaction: tree-summary keeps a 5MB app-db inside the cap.
+;; ---------------------------------------------------------------------------
+
+(deftest summary-mode-bounds-the-5mb-scenario
+  ;; rf2-jlq5j: a 5MB app-db pr-strs to ~5.6M chars ⇒ ~1.4M tokens,
+  ;; 290× the 5,000-token cap. With path slicing's :summary default,
+  ;; the same call replaces the slice with a small marker — fits the
+  ;; cap by construction. The wire-cap remains the backstop for the
+  ;; remaining slices, but :app-db alone no longer blows the budget.
+  (let [big-app-db (apply hash-map
+                          (mapcat (fn [i] [(keyword (str "k" i))
+                                           (apply str (repeat 1024 "x"))])
+                                  (range 5120)))   ;; ~5MB worth of map
+        snap {:rf/default {:app-db big-app-db
+                            :sub-cache {} :machines {} :epochs [] :traces []}}
+        [out _] (slice-app-db-in-snapshot snap nil)
+        wire    (pr-str (-> out :rf/default :app-db))]
+    (is (contains? (-> out :rf/default :app-db) :rf.mcp/summary))
+    (is (< (token-estimate wire) 5000)
+        (str "Summary marker MUST be under the 5k cap. Got "
+             (token-estimate wire) " tokens for serialised marker"))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/wire_cap_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/wire_cap_test.cljs
@@ -38,7 +38,8 @@
       :else                            default-max-tokens)))
 
 (def ^:private overflow-hints
-  {"snapshot"      "Narrow scope: pass `frames` to a single frame, or `include` to a single slice (one of app-db, sub-cache, machines, epochs, traces). Combine with future path-slicing args when available."
+  {"snapshot"      "Narrow scope: pass `path [:k1 :k2]` to slice the :app-db slice, `frames` to a single frame, or `include` to a single slice (one of app-db, sub-cache, machines, epochs, traces). Default mode is :summary — drill down via `get-path` once you know the key."
+   "get-path"      "Narrow the path further — pass a deeper segment so the addressed subtree is smaller. Or call `snapshot` with no `path` first for a tree-summary, then re-aim."
    "trace-window"  "Reduce `ms` to a smaller window, narrow with `frame`, or fetch incrementally via `watch-epochs` + `since-id`."
    "watch-epochs"  "Narrow `pred` (e.g. `:event-id-prefix`, `:effects`), pass `frame`, or stream via `subscribe` with `max-events`."
    "subscribe"     "Tighten `filter`, lower `max-buffered`, set `max-events` so each tick stays small."
@@ -258,7 +259,7 @@
   ;; budget). The streaming subscribe + always-tiny ops are covered
   ;; explicitly so we never ship "Response over budget" generic when a
   ;; sharper hint is available.
-  (let [tools-with-data-volume #{"snapshot" "trace-window" "watch-epochs"
+  (let [tools-with-data-volume #{"snapshot" "get-path" "trace-window" "watch-epochs"
                                  "subscribe" "eval-cljs" "discover-app"
                                  "dispatch"}]
     (doseq [t tools-with-data-volume]

--- a/tools/pair2-mcp/test/stdio-roundtrip.js
+++ b/tools/pair2-mcp/test/stdio-roundtrip.js
@@ -3,11 +3,13 @@
 //
 // This test does NOT need a live shadow-cljs nREPL — it exercises:
 //   - initialize handshake
-//   - tools/list (expects all nine tools, including the snapshot mega-op
-//     and the subscribe/unsubscribe streaming pair)
+//   - tools/list (expects all ten tools: nine original + get-path under
+//     rf2-tygdv)
 //   - tools/call eval-cljs against an absent nREPL (expects graceful
 //     :nrepl-port-not-found degraded mode)
 //   - tools/call snapshot against an absent nREPL (same degraded mode —
+//     proves the new tool is wired into the dispatch table)
+//   - tools/call get-path against an absent nREPL (same degraded mode —
 //     proves the new tool is wired into the dispatch table)
 //
 // A separate live-nrepl test (spec/INTEGRATION.md) covers the
@@ -81,16 +83,18 @@ function run() {
 
       notify('notifications/initialized', {});
 
-      // 2. tools/list — expect all nine tools (six original + snapshot
+      // 2. tools/list — expect all ten tools (six original + snapshot
       // mega-op from rf2-x70e + subscribe/unsubscribe streaming pair
-      // from rf2-hq49). rf2-7dvg cut inject-runtime in favour of a
-      // shadow-cljs :preloads entry; see SKILL.md §Setup.
+      // from rf2-hq49 + get-path read-by-path primitive from rf2-tygdv).
+      // rf2-7dvg cut inject-runtime in favour of a shadow-cljs
+      // :preloads entry; see SKILL.md §Setup.
       const list = await call('tools/list', {});
       const names = (list.result?.tools || []).map((t) => t.name).sort();
       const expected = [
         'discover-app',
         'dispatch',
         'eval-cljs',
+        'get-path',
         'snapshot',
         'subscribe',
         'tail-build',
@@ -133,17 +137,34 @@ function run() {
       console.log('OK   unsubscribe descriptor -> sub-id required');
 
       // 2b. Verify the snapshot descriptor carries the documented input
-      // schema (frames + include + build), so accidental future renames
-      // break the test instead of silently shipping a broken contract.
+      // schema (frames + include + path + build), so accidental future
+      // renames break the test instead of silently shipping a broken
+      // contract. `path` joined the schema under rf2-tygdv (path-based
+      // slicing for the :app-db slice).
       const snapDesc = (list.result?.tools || []).find((t) => t.name === 'snapshot');
       if (!snapDesc) throw new Error('snapshot descriptor missing from tools/list');
       const props = snapDesc.inputSchema?.properties || {};
-      for (const k of ['frames', 'include', 'build']) {
+      for (const k of ['frames', 'include', 'path', 'build']) {
         if (!(k in props)) {
           throw new Error('snapshot inputSchema missing property: ' + k);
         }
       }
-      console.log('OK   snapshot descriptor -> frames/include/build');
+      console.log('OK   snapshot descriptor -> frames/include/path/build');
+
+      // 2d. Verify the get-path descriptor (rf2-tygdv). Required
+      // input: `path`; optional: `frame`, `build`.
+      const gpDesc = (list.result?.tools || []).find((t) => t.name === 'get-path');
+      if (!gpDesc) throw new Error('get-path descriptor missing from tools/list');
+      const gpProps = gpDesc.inputSchema?.properties || {};
+      for (const k of ['path', 'frame', 'build']) {
+        if (!(k in gpProps)) {
+          throw new Error('get-path inputSchema missing property: ' + k);
+        }
+      }
+      if (!gpDesc.inputSchema?.required?.includes('path')) {
+        throw new Error('get-path.inputSchema missing required: path');
+      }
+      console.log('OK   get-path descriptor -> path (required) + frame/build');
 
       // 3. tools/call eval-cljs without nREPL — expect graceful degraded result
       const evalResp = await call('tools/call', {
@@ -168,6 +189,18 @@ function run() {
         throw new Error('snapshot degraded mode expected, got: ' + JSON.stringify(snapResp));
       }
       console.log('OK   tools/call snapshot (no nREPL) -> degraded isError');
+
+      // 3b'. tools/call get-path — same degraded path. Proves the
+      // rf2-tygdv tool is wired into the dispatch table.
+      const gpResp = await call('tools/call', {
+        name: 'get-path',
+        arguments: { path: '[:user :email]' },
+      });
+      const gpText = gpResp.result?.content?.[0]?.text || '';
+      if (!gpResp.result?.isError || !gpText.includes('nrepl-port-not-found')) {
+        throw new Error('get-path degraded mode expected, got: ' + JSON.stringify(gpResp));
+      }
+      console.log('OK   tools/call get-path (no nREPL) -> degraded isError');
 
       // 3c. tools/call subscribe (no nREPL) — degraded path. Proves
       // the streaming-shaped tool is wired into the dispatch table


### PR DESCRIPTION
## Summary

Second wire-protocol P1 in the rf2-jlq5j wave. Layers on the cap enforcement from rf2-rvyzy (PR #641) by giving the agent a way to ask for the subtree it actually needs — the `:app-db` slice was the surface driving the cap blowouts; now it's a tree-summary by default.

## Two changes

1. **`snapshot` `:path` arg.** EDN-encoded vector (`\"[:cart :items 0]\"`) or JSON string-array. Slices the `:app-db` slice via `get-in`. **Default behaviour changes (pre-alpha cut)**: without `:path`, the `:app-db` slice is replaced with a `{:rf.mcp/summary ...}` marker (top-level keys + count + bytes). Mode surfaces as `:mode :summary` or `:mode :path-sliced`. Missing paths surface per-frame in `:path-not-found` with `:deepest-valid-prefix` so the agent can re-aim. Map-key lists truncate at 64 (with `:keys-truncated? true`) so the marker itself can never blow the cap. Empty path `[]` opts back into the full slice.

2. **New `get-path` tool.** Minimal targeted-read primitive. `{:path [...] :frame :foo}` → `{:ok? true :exists? true :value <subtree>}` or `{:ok? false :reason :path-not-found :deepest-valid-prefix [...]}`. Server-side `get-in` so only the addressed subtree crosses the wire. `:exists?` distinguishes a path that legitimately points at `nil` from one that doesn't resolve.

## Design decisions

- **Path vocabulary is shared with causa-mcp's wire-protocol Principles §2.** EDN vector of keys; EDN strings (`\":cart\"`, `\"0\"`) parsed; bare strings (`\"items\"`) stay strings — the default reader would otherwise coerce them to symbols (different `get-in` key). One shape across the tool family.
- **Summary, not pagination, for `:app-db`.** The slice is structurally a map, not a sequence; summary + drill-down is cleaner than cursor pagination. Other slices keep their existing pagination story.
- **Bounded summary marker.** Long key lists truncate at 64 entries with `:keys-truncated? true` — a 5,000-entry map's key list alone would blow the cap.
- **Server-side computation for `get-path`.** Inlined `get-in` + missing-sentinel + deepest-prefix loop in one eval form — one bencode round-trip, only the subtree crosses the wire.
- **Extensible for rf2-1wdzp.** The diff-encoding follow-on can layer naturally — diff-encoded paths fit the same `:path` vocabulary; the `:strategy` seam still has room for `:diff-encoded` as a future cap strategy.

## Out of scope (filed as follow-ups)

- The runtime preload's `snapshot` / `snapshot-state` docstrings live in `skills/re-frame-pair2/preload/...` — out of this bead's scope (\"Touch only `tools/pair2-mcp/`\"). Spec updates that DO live in pair2-mcp's tree (`spec/003-Tool-Catalogue.md` + `spec/Principles.md`) landed here.

## Test plan

- [x] Unit tests for the path resolver: missing paths, deep paths, vector-index paths, scalar termination, nil leaves
- [x] Unit tests for `tree-summary`: maps/vectors/sets/seqs/scalars, truncation at 64 keys
- [x] Unit tests for `slice-app-db-in-snapshot`: summary default, path-sliced subtree, root path (full), path-not-found with per-frame status
- [x] Unit tests for `parse-path-arg`: nil, blank, EDN vector string, JS array of EDN strings, bare strings stay strings, unparseable strings degrade to single segment
- [x] Wire-cap integration: 5MB app-db scenario reduces to a sub-cap summary marker
- [x] `stdio-roundtrip.js` pins the 10-tool catalogue and the new schema properties
- [x] `wire_cap_test.cljs` adds `get-path` to the overflow-hints sanity check
- [x] Production server build clean (`npm run build`)
- [x] All tests green: **84 tests / 198 assertions, 0 failures**