### PR TITLE
docs(skills/pair2): sync allowed-tools + docstrings for get-path + summary-mode snapshot (rf2-nkygg)

### DIFF
--- a/skills/re-frame-pair2/SKILL.md
+++ b/skills/re-frame-pair2/SKILL.md
@@ -22,6 +22,7 @@ allowed-tools:
   - mcp__re-frame-pair2__watch-epochs
   - mcp__re-frame-pair2__tail-build
   - mcp__re-frame-pair2__snapshot
+  - mcp__re-frame-pair2__get-path
   - mcp__re-frame-pair2__subscribe
   - mcp__re-frame-pair2__unsubscribe
   - Read

--- a/skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs
+++ b/skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs
@@ -1214,6 +1214,20 @@
 ;;
 ;; Each slice delegates to the existing per-slice reader — no parallel
 ;; reimplementation. The composer just routes by `:include` keys.
+;;
+;; Wire-boundary wrapping (rf2-tygdv). `snapshot-state` here returns the
+;; full slice values; the MCP server's `snapshot` tool then wraps the
+;; `:app-db` slice with path-slicing + lazy-summary before crossing the
+;; wire. The default mode at the wire is `:summary` — the slice value
+;; is replaced with a `{:rf.mcp/summary {:type :map :keys [...] :count
+;; ... :bytes ~...}}` marker carrying the top-level shape only. Callers
+;; pass `:path [...]` to receive `(get-in db path)` (`:mode
+;; :path-sliced`); root `:path []` opts back into the full slice
+;; (equivalent to the legacy default). Out-of-range paths surface
+;; per-frame in a `:path-not-found` map with `:deepest-valid-prefix`
+;; so the agent can re-aim. The `get-path` tool exposes the same
+;; targeted-read primitive directly — `:exists?` distinguishes a path
+;; that legitimately points at `nil` from one that doesn't resolve.
 
 (def ^:private all-snapshot-slices
   [:app-db :sub-cache :machines :epochs :traces])
@@ -1267,7 +1281,13 @@
 
    Routes through existing per-slice readers — no parallel implementation.
    Side effects: installs the trace + epoch listeners (idempotent via
-   `health`)."
+   `health`).
+
+   Note: this runtime-side form returns the *full* `:app-db` slice for
+   every frame. The MCP `snapshot` tool wraps this output with
+   path-slicing + lazy-summary at the wire boundary (rf2-tygdv) — see
+   the section header above for the modes. The wrapping is wire-side
+   only; direct callers of this CLJS form see slices verbatim."
   ([] (snapshot-state {}))
   ([{:keys [frames include]
      :or   {frames  :all

--- a/skills/re-frame-pair2/references/mcp-transport.md
+++ b/skills/re-frame-pair2/references/mcp-transport.md
@@ -50,7 +50,8 @@ The server auto-discovers the nREPL port from (in order):
 | `scripts/trace-window.sh 1000`    | `trace-window` | `{ms: 1000}` |
 | `scripts/watch-epochs.sh --event-id-prefix :cart` | `watch-epochs` | `{pred: {"event-id-prefix": ":cart"}}` (pull-mode — call repeatedly with `since-id`) |
 | `scripts/tail-build.sh --probe '<form>'` | `tail-build` | `{probe: "..."}` |
-| _(none — MCP-only)_                | `snapshot`     | `{frames: "all"\|[":rf/default"...], include: ["app-db","sub-cache","machines","epochs","traces"]}` |
+| _(none — MCP-only)_                | `snapshot`     | `{frames: "all"\|[":rf/default"...], include: ["app-db","sub-cache","machines","epochs","traces"], path: "[:cart :items]"}` — default `:app-db` mode is **`:summary`** (tree-summary marker, not the full value); pass `path` to slice. Root `path: "[]"` opts back into the full slice. See [`ops.md` §Read](ops.md#read). |
+| _(none — MCP-only)_                | `get-path`     | `{path: "[:cart :items 0 :sku]", frame: ":rf/default"}` — targeted-read primitive (rf2-tygdv). Returns `{ok? true :exists? true :value <subtree>}` or `{ok? false :reason :path-not-found :deepest-valid-prefix [...]}`. `:exists?` distinguishes a path that legitimately points at `nil` from a missing path. |
 | _(none — MCP-only, push-mode)_     | `subscribe`    | `{topic: "trace"\|"epoch"\|"fx"\|"error", filter: {...}, max-events: 0, max-ms: 0}` — emits `notifications/progress` ticks; resolves on cancel / `max-events` / `max-ms` / `unsubscribe`. See `references/streaming-subscriptions.md`. |
 | _(none — MCP-only)_                | `unsubscribe`  | `{sub-id: "<uuid>"}` — idempotent close. |
 
@@ -88,6 +89,16 @@ Use the per-op reads when:
 `snapshot` accepts `include` to subset the slices —
 `{include: ["app-db","epochs"]}` returns just those two — and
 `frames` to pick a subset of frame-ids — `{frames: [":stories"]}`.
+
+**`:app-db` slice modes (rf2-tygdv).** The `:app-db` slice no longer defaults to the full value. Two modes:
+
+- **`:summary` (default, no `path`)** — the `:app-db` slot is a `{:rf.mcp/summary {:type :map :keys [...] :count ... :bytes ...}}` marker carrying the top-level shape without committing the token budget. Map-key lists over 64 entries get truncated and flagged `:keys-truncated? true` so the marker itself can never blow the wire cap.
+- **`:path-sliced` (with `path`)** — the slot is `(get-in db path)`. Out-of-range paths surface per-frame in a top-level `:path-not-found` map with `:deepest-valid-prefix` so the agent can re-aim without a binary search.
+- **Root path `path: "[]"`** — explicit request for the full `:app-db`, equivalent to the legacy default. The wire cap (rf2-rvyzy) is then the backstop.
+
+The other slices (`:sub-cache`, `:machines`, `:epochs`, `:traces`) pass through unchanged.
+
+Use `get-path` (next section) when you already know the addressed subtree — it's a single-slice round-trip rather than the multi-slice composition `snapshot` does.
 
 ## Preload probe (no inject step)
 

--- a/skills/re-frame-pair2/references/ops.md
+++ b/skills/re-frame-pair2/references/ops.md
@@ -16,8 +16,9 @@ The op vocabulary the skill operates through. Each op is a short `scripts/eval-c
 
 | Op | Invocation | Returns |
 |---|---|---|
-| `app-db/snapshot` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/snapshot)'` | Current app-db value for the operating frame (via `rf/get-frame-db`) |
-| `app-db/get` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/app-db-at [:path :to :value])'` | Path-scoped value (via `rf/snapshot-of`) |
+| `app-db/snapshot` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/snapshot)'` | Current app-db value for the operating frame (via `rf/get-frame-db`). Note: the MCP `snapshot` tool wraps this with `:summary`-by-default + `:path`-slicing at the wire boundary (rf2-tygdv) — see [`mcp-transport.md` §:app-db slice modes](mcp-transport.md#when-to-use-snapshot-vs-the-per-op-reads). The runtime form here returns the full value unchanged. |
+| `app-db/get` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/app-db-at [:path :to :value])'` | Path-scoped value (via `rf/snapshot-of`). For targeted reads from the MCP transport, prefer the `get-path` tool — single round-trip, structured `{:exists?}` answer, shared `:path` vocabulary with `snapshot`. |
+| `app-db/get-path` (MCP) | `mcp__re-frame-pair2__get-path {path: "[:cart :items 0 :sku]"}` | Targeted read at `path` (rf2-tygdv). `{:ok? true :exists? true :value <subtree>}` on hit; `{:ok? false :reason :path-not-found :deepest-valid-prefix [...]}` on miss. `:exists?` distinguishes a path that points at `nil` from a missing path. |
 | `app-db/schemas` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/schemas)'` | Map of `path → schema` from `rf/app-schemas` |
 | `registrar/list` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/registrar-list :event)'` | Ids registered under `:event` / `:sub` / `:fx` / `:cofx` (via `rf/handlers`) |
 | `registrar/describe` | `scripts/eval-cljs.sh '(re-frame-pair2.runtime/registrar-describe :event :cart/apply-coupon)'` | Full handler metadata: kind, interceptor ids, `:ns` / `:line` / `:file`, `:rf/machine?`, retained source form when present |

--- a/skills/re-frame-pair2/references/recipes.md
+++ b/skills/re-frame-pair2/references/recipes.md
@@ -25,6 +25,7 @@ Named procedures the user may ask for. When the user asks a matching question, r
 ## "What's in `app-db`?" / "What did the last event do?"
 
 - Snapshot or get: `app-db/snapshot`, `app-db/get`, or for a diff between an epoch's `:db-before` and `:db-after`: `trace/last-epoch` and compute the diff with `clojure.data/diff`. The runtime helper `(re-frame-pair2.runtime/epoch-diff <epoch>)` returns a pre-computed `{:only-before :only-after :common}` map.
+- From the MCP transport, `snapshot`'s `:app-db` slice now defaults to **`:summary` mode** (top-level keys + count + size marker, not the full value — rf2-tygdv); drill in with `mcp__re-frame-pair2__get-path {path: "[:that :key]"}` or with a follow-up `snapshot {path: "[:that :key]"}`. Root path `path: "[]"` opts back into the full `:app-db` slice when you really want it. See [`mcp-transport.md` §:app-db slice modes](mcp-transport.md#when-to-use-snapshot-vs-the-per-op-reads).
 
 ## "Why didn't my view update?"
 


### PR DESCRIPTION
## Summary

Closes the rf2-flzdp CI drift check that was failing on `main` after rf2-tygdv (PR #648) landed with `--admin` — the new `get-path` MCP tool was server-exposed but not in the skill's `allowed-tools`.

Files touched (skill-only — `skills/re-frame-pair2/` per the bead's scope):

- **`SKILL.md`** — add `mcp__re-frame-pair2__get-path` to the `allowed-tools` front-matter list.
- **`preload/re_frame_pair2/runtime.cljs`** — docstring updates on the Coarse-grained snapshot section header and the `snapshot-state` docstring describing the wire-side wrapping (rf2-tygdv): default `:summary` mode, `:path` arg for subtree reads, root `[]` opts into the full slice, missing paths land in `:path-not-found` with `:deepest-valid-prefix`, plus the new `get-path` tool with its `:exists?` semantics. No behavioural changes — the runtime form still returns the full `:app-db` slice; only the MCP wire boundary applies the wrapping.
- **`references/mcp-transport.md`** — bash-shim mapping table gains a `get-path` row + extends the `snapshot` row with the new `path` arg; new "`:app-db` slice modes" paragraph in the `snapshot` vs per-op-reads section.
- **`references/ops.md`** — Read table updated: `snapshot` row notes the wire wrapping, `app-db/get` row points at `get-path` for targeted reads, new `app-db/get-path (MCP)` row.
- **`references/recipes.md`** — "What's in `app-db`?" recipe notes the summary-mode default + the `get-path` / `snapshot {path: ...}` drill-in path.

## Verification

`python scripts/check_skill_mcp_drift.py --ci` exits 0.

Before:
```
::error::pair2-mcp <-> re-frame-pair2: MCP server exposes tool 'get-path'
but skill 'skills\re-frame-pair2\SKILL.md' does not allow-list
mcp__re-frame-pair2__get-path.
```

After: clean (only a `::warning::` about stale baseline entries for `subscribe`/`unsubscribe` that already landed in rf2-aks1t — separate cleanup, not blocking).

`bb tests/runtime/preload_sentinel_test.clj` — 3/3 pass (docstring-only edits don't touch structural assertions).

## Test plan

- [x] Drift check `--ci` exits 0
- [x] Preload sentinel test green
- [x] Skill scope only (`skills/re-frame-pair2/`); pair2-mcp + spec untouched