### PR TITLE
test(causa): add view-tree tests for trace + performance + issues_ribbon panels (rf2-zvrbw)

### DIFF
--- a/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
@@ -1,0 +1,471 @@
+(ns day8.re-frame2-causa.panels.issues-ribbon-view-cljs-test
+  "CLJS-side wiring + view tests for Causa's Issues ribbon panel
+  (Phase 5, rf2-d1p4o; view-test coverage filed under rf2-zvrbw).
+
+  ## What's under test (in addition to the pure-data tests in
+  `issues_ribbon_helpers_cljs_test.cljc`)
+
+    1. **Registry wires the composite sub** under
+       `:rf.causa/issues-ribbon` + every filter event.
+
+    2. **Render contract** — the section + header + chip rows + since
+       input + counts + data-testid wiring matches the production view
+       tree.
+
+    3. **Empty states** — `:no-issues` (the desired state — All clear)
+       and `:no-matches` (filters hide everything) each render their
+       distinct container.
+
+    4. **Sub-driven rendering** — when issues are in the buffer the
+       panel renders one `<li>` per issue.
+
+    5. **Issue category pills** — every issue surfaces a category
+       prefix; the prefix chip-row only renders when at least one
+       prefix has issues.
+
+    6. **Severity filter** — `:rf.causa/toggle-issues-severity` adds/
+       removes severities from the active set and the rendered rows
+       narrow to match.
+
+    7. **Prefix filter** — `:rf.causa/toggle-issues-prefix` works the
+       same way for category prefixes.
+
+    8. **Since-ms filter** — `:rf.causa/set-issues-since-seconds`
+       sets/clears the time window.
+
+    9. **Row interactions** — clicking a row pivots to event-detail
+       when the dispatch-id is present; clicking the source chip
+       fires :open-in-editor and does NOT also pivot.
+
+   10. **Frame isolation** — the panel's filter state lives on
+       `:rf/causa`, never on `:rf/default`.
+
+  ## Pure hiccup
+
+  Same approach as the other Causa view tests — walk the view's
+  hiccup tree by `data-testid` rather than mounting to the DOM."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walkers (mirror machine_inspector_view_cljs_test) -----------
+
+(declare expand-fn-component)
+
+(defn- expand-children [node]
+  (cond
+    (vector? node) (mapv expand-fn-component node)
+    (seq? node)    (map  expand-fn-component node)
+    :else          node))
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (expand-children (apply (first node) (rest node)))
+    (expand-children node)))
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (hiccup-seq tree)))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- push-trace! [ev]
+  (trace-bus/collect-trace! ev))
+
+;; Synthetic issue trace event.
+(defn- mk-issue
+  [{:keys [id time op-type operation dispatch-id reason]
+    :or   {time 1000}}]
+  {:id        id
+   :time      time
+   :op-type   op-type
+   :operation operation
+   :tags      (cond-> {}
+                dispatch-id (assoc :dispatch-id dispatch-id)
+                reason      (assoc :reason reason))})
+
+;; ---- (1) registry wiring ------------------------------------------------
+
+(deftest registry-installs-issues-ribbon-handlers
+  (testing "register-causa-handlers! installs the Phase 5 (rf2-d1p4o)
+            composite sub + every supporting event"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/issues-ribbon))
+        ":rf.causa/issues-ribbon sub registered")
+    (is (some? (registrar/handler :sub :rf.causa/issues-filters))
+        ":rf.causa/issues-filters sub registered")
+    (is (some? (registrar/handler :event :rf.causa/toggle-issues-severity))
+        ":rf.causa/toggle-issues-severity event registered")
+    (is (some? (registrar/handler :event :rf.causa/toggle-issues-prefix))
+        ":rf.causa/toggle-issues-prefix event registered")
+    (is (some? (registrar/handler :event :rf.causa/set-issues-since-seconds))
+        ":rf.causa/set-issues-since-seconds event registered")
+    (is (some? (registrar/handler :event :rf.causa/clear-issues-filters))
+        ":rf.causa/clear-issues-filters event registered")))
+
+(deftest issues-ribbon-defaults-to-no-issues
+  (testing "with no events the composite returns empty-kind :no-issues"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [data @(rf/subscribe [:rf.causa/issues-ribbon])]
+        (is (= [] (:issues data)))
+        (is (= 0 (:total data)))
+        (is (= :no-issues (:empty-kind data)))))))
+
+(deftest issues-ribbon-filters-non-issue-events
+  (testing "success-path traces (`:op-type :event`, `:fx`, `:frame`,
+            `:sub/run`, `:view/render`) are NOT issues and never reach
+            the ribbon — only `:error / :warning / :info` do"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Three non-issue events + two real issues.
+      (push-trace! (mk-issue {:id 1 :op-type :event :operation :event/dispatched}))
+      (push-trace! (mk-issue {:id 2 :op-type :fx    :operation :rf.fx/handled}))
+      (push-trace! (mk-issue {:id 3 :op-type :view  :operation :view/render}))
+      (push-trace! (mk-issue {:id 4 :op-type :error :operation :rf.error/handler-threw
+                              :dispatch-id 1 :reason "kaboom"}))
+      (push-trace! (mk-issue {:id 5 :op-type :warning :operation :rf.warning/recoverable
+                              :dispatch-id 1}))
+      (let [data @(rf/subscribe [:rf.causa/issues-ribbon])]
+        (is (= 2 (:total data)) "only issues land on the ribbon")
+        (is (= #{4 5} (set (map :id (:issues data)))))))))
+
+;; ---- (2) render contract ------------------------------------------------
+
+(deftest panel-container-renders
+  (testing "the panel renders its root container regardless of buffer state"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [tree (issues-ribbon/issues-ribbon-view)]
+        (is (some? (find-by-testid tree "rf-causa-issues-ribbon"))
+            "panel container present")
+        (is (some? (find-by-testid tree "rf-causa-issues-counts"))
+            "counts span in header present")
+        (is (some? (find-by-testid tree "rf-causa-issues-severity-chips"))
+            "severity chip row present")
+        (is (some? (find-by-testid tree "rf-causa-issues-since-input"))
+            "since-ms input present")))))
+
+;; ---- (3) empty states ---------------------------------------------------
+
+(deftest empty-state-no-issues-renders
+  (testing "with no issues the panel renders the :no-issues empty-state
+            (the 'All clear' positive-result branch)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [tree (issues-ribbon/issues-ribbon-view)]
+        (is (some? (find-by-testid tree "rf-causa-issues-empty-no-issues"))
+            ":no-issues empty-state container present")
+        (is (nil? (find-by-testid tree "rf-causa-issues-feed"))
+            "no feed list when buffer carries no issues")))))
+
+(deftest empty-state-no-matches-renders-when-filters-hide-all
+  (testing "with issues present but a filter that matches nothing the
+            panel renders the :no-matches empty-state with clear button"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-trace! (mk-issue {:id 1 :op-type :error
+                              :operation :rf.error/handler-threw}))
+      ;; Toggle in a severity the issue doesn't carry — filter excludes it.
+      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :advisory])
+      (let [tree (issues-ribbon/issues-ribbon-view)]
+        (is (some? (find-by-testid tree "rf-causa-issues-empty-no-matches"))
+            ":no-matches empty-state container present")
+        (is (some? (find-by-testid tree "rf-causa-issues-empty-clear-filters"))
+            "clear-filters button surfaces in :no-matches state")
+        (is (nil? (find-by-testid tree "rf-causa-issues-feed"))
+            "no feed list when no rows survive filtering")))))
+
+;; ---- (4) sub-driven rendering -------------------------------------------
+
+(deftest feed-list-renders-when-issues-present
+  (testing "with issues in the buffer the panel renders the <ul> feed
+            with one <li> per issue"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-trace! (mk-issue {:id 1 :op-type :error
+                              :operation :rf.error/handler-threw
+                              :dispatch-id 1}))
+      (push-trace! (mk-issue {:id 2 :op-type :warning
+                              :operation :rf.warning/missing
+                              :dispatch-id 1}))
+      (let [tree (issues-ribbon/issues-ribbon-view)]
+        (is (some? (find-by-testid tree "rf-causa-issues-feed"))
+            "feed <ul> present")
+        (is (some? (find-by-testid tree "rf-causa-issues-row-1"))
+            "row for issue id 1 present")
+        (is (some? (find-by-testid tree "rf-causa-issues-row-2"))
+            "row for issue id 2 present")))))
+
+;; ---- (5) issue category pills -------------------------------------------
+
+(deftest each-row-surfaces-severity-glyph-and-category
+  (testing "every row surfaces the severity glyph + the category prefix"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-trace! (mk-issue {:id 3 :op-type :error
+                              :operation :rf.error/handler-threw}))
+      (let [tree (issues-ribbon/issues-ribbon-view)]
+        (is (some? (find-by-testid tree "rf-causa-issues-row-3-time"))
+            "row timestamp span present")
+        (is (some? (find-by-testid tree "rf-causa-issues-row-3-severity"))
+            "row severity glyph present")
+        (is (some? (find-by-testid tree "rf-causa-issues-row-3-category"))
+            "row category prefix span present")
+        (is (some? (find-by-testid tree "rf-causa-issues-row-3-description"))
+            "row description span present")))))
+
+(deftest severity-chip-row-renders-three-buckets
+  (testing "the severity chip-row renders one chip per bucket in
+            severity-order — error / warning / advisory"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Push at least one issue so any-filter? is false initially.
+      (let [tree (issues-ribbon/issues-ribbon-view)]
+        (is (some? (find-by-testid tree "rf-causa-issues-severity-chip-error")))
+        (is (some? (find-by-testid tree "rf-causa-issues-severity-chip-warning")))
+        (is (some? (find-by-testid tree "rf-causa-issues-severity-chip-advisory")))))))
+
+(deftest prefix-chip-row-suppressed-when-no-issues
+  (testing "the prefix chip-row only renders when at least one issue
+            carries a prefix — with an empty buffer the chip-row is
+            suppressed"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; No issues — prefix chip-row suppressed.
+      (is (nil? (find-by-testid (issues-ribbon/issues-ribbon-view)
+                                "rf-causa-issues-prefix-chips"))
+          "no prefix chip-row when buffer carries no issues"))))
+
+(deftest prefix-chip-row-renders-when-issues-have-prefixes
+  (testing "with an issue carrying a category prefix the chip-row
+            renders the corresponding prefix chip. Seed the trace
+            buffer BEFORE the first subscribe — mirrors the production
+            sequencing where preload's trace-cb fires before any panel
+            mounts."
+    (setup-causa-frame!)
+    (push-trace! (mk-issue {:id 1 :op-type :error
+                            :operation :rf.error/handler-threw}))
+    (rf/with-frame :rf/causa
+      (let [tree (issues-ribbon/issues-ribbon-view)]
+        (is (some? (find-by-testid tree "rf-causa-issues-prefix-chips"))
+            "prefix chip-row renders once at least one prefix exists")
+        (is (some? (find-by-testid tree "rf-causa-issues-prefix-chip-rf.error"))
+            "rf.error prefix chip surfaces")))))
+
+;; ---- (6) severity filter ------------------------------------------------
+
+(deftest toggle-severity-mutates-causa-frame
+  (testing ":rf.causa/toggle-issues-severity toggles set membership on
+            the Causa frame"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :error])
+      (is (= #{:error}
+             (:severities @(rf/subscribe [:rf.causa/issues-filters]))))
+      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :warning])
+      (is (= #{:error :warning}
+             (:severities @(rf/subscribe [:rf.causa/issues-filters]))))
+      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :error])
+      (is (= #{:warning}
+             (:severities @(rf/subscribe [:rf.causa/issues-filters])))
+          "second toggle removes the severity"))))
+
+(deftest severity-filter-narrows-rendered-rows
+  (testing "an active severity filter cuts the row list down to matching rows"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-trace! (mk-issue {:id 1 :op-type :error
+                              :operation :rf.error/handler-threw}))
+      (push-trace! (mk-issue {:id 2 :op-type :warning
+                              :operation :rf.warning/recoverable}))
+      (push-trace! (mk-issue {:id 3 :op-type :info
+                              :operation :rf.info/note}))
+      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :warning])
+      (let [data @(rf/subscribe [:rf.causa/issues-ribbon])]
+        (is (= 3 (:total data)))
+        (is (= 1 (:rendered data)))
+        (is (= [2] (mapv :id (:issues data))))))))
+
+;; ---- (7) prefix filter --------------------------------------------------
+
+(deftest toggle-prefix-mutates-causa-frame
+  (testing ":rf.causa/toggle-issues-prefix toggles set membership on
+            the Causa frame"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/toggle-issues-prefix "rf.error"])
+      (is (= #{"rf.error"}
+             (:prefixes @(rf/subscribe [:rf.causa/issues-filters]))))
+      (rf/dispatch-sync [:rf.causa/toggle-issues-prefix "rf.error"])
+      (is (= #{} (:prefixes @(rf/subscribe [:rf.causa/issues-filters])))
+          "second toggle removes the prefix"))))
+
+(deftest prefix-filter-narrows-rendered-rows
+  (testing "an active prefix filter cuts the row list down to matching prefixes"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-trace! (mk-issue {:id 1 :op-type :error
+                              :operation :rf.error/handler-threw}))
+      (push-trace! (mk-issue {:id 2 :op-type :error
+                              :operation :rf.ssr/hydration-mismatch}))
+      (rf/dispatch-sync [:rf.causa/toggle-issues-prefix "rf.ssr"])
+      (let [data @(rf/subscribe [:rf.causa/issues-ribbon])]
+        (is (= 1 (:rendered data)))
+        (is (= [2] (mapv :id (:issues data))))))))
+
+;; ---- (8) since-ms filter ------------------------------------------------
+
+(deftest set-since-seconds-converts-to-ms
+  (testing ":rf.causa/set-issues-since-seconds takes seconds and stores ms"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-issues-since-seconds 30])
+      (is (= 30000 (:since-ms @(rf/subscribe [:rf.causa/issues-filters])))
+          "30s stored as 30000ms")
+      (rf/dispatch-sync [:rf.causa/set-issues-since-seconds nil])
+      (is (nil? (:since-ms @(rf/subscribe [:rf.causa/issues-filters])))
+          "nil clears the axis")
+      (rf/dispatch-sync [:rf.causa/set-issues-since-seconds 0])
+      (is (nil? (:since-ms @(rf/subscribe [:rf.causa/issues-filters])))
+          "0 / non-positive clears the axis"))))
+
+(deftest clear-issues-filters-drops-every-axis
+  (testing ":rf.causa/clear-issues-filters drops all three axes in one shot"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :error])
+      (rf/dispatch-sync [:rf.causa/toggle-issues-prefix "rf.error"])
+      (rf/dispatch-sync [:rf.causa/set-issues-since-seconds 60])
+      (rf/dispatch-sync [:rf.causa/clear-issues-filters])
+      (let [filters @(rf/subscribe [:rf.causa/issues-filters])]
+        (is (or (nil? (:severities filters)) (empty? (:severities filters))))
+        (is (or (nil? (:prefixes filters)) (empty? (:prefixes filters))))
+        (is (nil? (:since-ms filters)))))))
+
+(deftest clear-filters-button-renders-when-filter-active
+  (testing "the header's Clear filters button surfaces iff at least one
+            filter axis is active"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-trace! (mk-issue {:id 1 :op-type :error
+                              :operation :rf.error/handler-threw}))
+      (is (nil? (find-by-testid (issues-ribbon/issues-ribbon-view)
+                                "rf-causa-issues-clear-filters"))
+          "no Clear filters button when no axis is active")
+      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :error])
+      (is (some? (find-by-testid (issues-ribbon/issues-ribbon-view)
+                                 "rf-causa-issues-clear-filters"))
+          "Clear filters button surfaces once a severity is active"))))
+
+;; ---- (9) row interactions ------------------------------------------------
+
+(deftest row-click-pivots-to-event-detail-when-dispatch-id-present
+  (testing "clicking an issue row dispatches :rf.causa/select-dispatch-id
+            and :rf.causa/select-panel — same cross-panel pivot as the
+            other ribbons"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-trace! (mk-issue {:id 4 :op-type :error
+                              :operation :rf.error/handler-threw
+                              :dispatch-id 99}))
+      (let [dispatches (atom [])]
+        (with-redefs [rf/dispatch* (fn
+                                     ([ev]      (swap! dispatches conj ev) nil)
+                                     ([ev _o]   (swap! dispatches conj ev) nil))]
+          (let [tree    (issues-ribbon/issues-ribbon-view)
+                row     (find-by-testid tree "rf-causa-issues-row-4")
+                handler (:on-click (second row))]
+            (is (some? row) "row node present in rendered tree")
+            (is (some? handler) "row carries an :on-click handler")
+            (when handler (handler))))
+        (is (some #(= [:rf.causa/select-dispatch-id 99] %) @dispatches)
+            "select-dispatch-id fired with the issue's dispatch-id")
+        (is (some #(= [:rf.causa/select-panel :event-detail] %) @dispatches)
+            "select-panel fired to pivot")))))
+
+(deftest source-coord-click-fires-open-in-editor
+  (testing "clicking the source-coord chip fires :rf.causa/open-in-editor;
+            stopPropagation prevents the row's pivot from also firing"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Push an issue whose :rf.trace/trigger-handler carries source-coord.
+      (push-trace! (-> (mk-issue {:id 8 :op-type :error
+                                  :operation :rf.error/handler-threw
+                                  :dispatch-id 1})
+                       (assoc :rf.trace/trigger-handler
+                              {:source-coord {:file "events.cljs" :line 17}})))
+      (let [dispatches (atom [])
+            stop-evt   (atom nil)]
+        (with-redefs [rf/dispatch* (fn
+                                     ([ev]      (swap! dispatches conj ev) nil)
+                                     ([ev _o]   (swap! dispatches conj ev) nil))]
+          (let [tree    (issues-ribbon/issues-ribbon-view)
+                node    (find-by-testid tree "rf-causa-issues-row-8-source")
+                handler (:on-click (second node))]
+            (is (some? node) "source-coord chip rendered")
+            (when handler
+              (handler #js {:stopPropagation #(reset! stop-evt true)}))))
+        (is (some (fn [ev]
+                    (and (vector? ev)
+                         (= :rf.causa/open-in-editor (first ev))
+                         (= {:source-coord "events.cljs:17"} (second ev))))
+                  @dispatches)
+            ":rf.causa/open-in-editor fired with the projected coord")
+        (is @stop-evt "stopPropagation was called so the row's pivot
+                       handler doesn't also fire")))))
+
+;; ---- (10) frame isolation ----------------------------------------------
+
+(deftest issues-filter-state-does-not-leak-into-default-frame
+  (testing "the panel's filter state lives on :rf/causa, never :rf/default"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :error])
+      (rf/dispatch-sync [:rf.causa/set-issues-since-seconds 60]))
+    (let [causa-db   (frame/frame-app-db-value :rf/causa)
+          default-db (frame/frame-app-db-value :rf/default)]
+      (is (= #{:error} (:issues-active-severities causa-db))
+          "severities land on Causa")
+      (is (= 60000 (:issues-since-ms causa-db))
+          "since-ms lands on Causa")
+      (is (nil? (:issues-active-severities default-db))
+          "severities did NOT leak into :rf/default")
+      (is (nil? (:issues-since-ms default-db))
+          "since-ms did NOT leak into :rf/default"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/performance_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/performance_view_cljs_test.cljs
@@ -1,0 +1,353 @@
+(ns day8.re-frame2-causa.panels.performance-view-cljs-test
+  "CLJS-side wiring + view tests for Causa's Performance panel
+  (Phase 5, rf2-75121; view-test coverage filed under rf2-zvrbw).
+
+  ## What's under test (in addition to the pure-data tests in
+  `performance_helpers_cljs_test.cljc`)
+
+    1. **Registry wires the composite sub** under
+       `:rf.causa/performance-data` + the budget event.
+
+    2. **Render contract** — the section + header + tier chips + counts
+       + data-testid wiring matches the production view tree.
+
+    3. **Empty state** — with no cascades in the buffer the panel
+       renders the empty container.
+
+    4. **Sub-driven rendering** — with cascades in the buffer the panel
+       renders one row per dispatch-id.
+
+    5. **Perf budget** — when a row's duration is at or above the
+       budget threshold the over-budget marker chip surfaces.
+
+    6. **Budget threshold event** — `:rf.causa/set-performance-budget-ms`
+       mutates the threshold; nil resets to default.
+
+    7. **Tier counts** — every tier in the order renders a chip even
+       when count is zero.
+
+    8. **Row interactions** — clicking a row pivots to event-detail.
+
+    9. **Frame isolation** — the panel's state lives on `:rf/causa`,
+       never on `:rf/default`.
+
+  ## Pure hiccup
+
+  Same approach as the other Causa view tests — walk the view's hiccup
+  tree by `data-testid` rather than mounting to the DOM."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.performance :as performance]
+            [day8.re-frame2-causa.panels.performance-helpers :as h]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walkers (mirror machine_inspector_view_cljs_test) -----------
+
+(declare expand-fn-component)
+
+(defn- expand-children [node]
+  (cond
+    (vector? node) (mapv expand-fn-component node)
+    (seq? node)    (map  expand-fn-component node)
+    :else          node))
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (expand-children (apply (first node) (rest node)))
+    (expand-children node)))
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (hiccup-seq tree)))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- push-trace! [ev]
+  (trace-bus/collect-trace! ev))
+
+;; Build a synthetic cascade — :event/dispatched + handler + fx + effects
+;; — with the given dispatch-id, span (last-time minus first-time gives
+;; the cascade duration the perf-helper derives), and event vec.
+(defn- push-cascade!
+  [{:keys [dispatch-id event-vec base-time span-ms]
+    :or   {event-vec [:cart/add] base-time 1000 span-ms 5}}]
+  (let [t0 base-time
+        t1 (+ base-time span-ms)]
+    (push-trace! {:id        (* dispatch-id 10)
+                  :time      t0
+                  :op-type   :event
+                  :operation :event/dispatched
+                  :tags      {:dispatch-id dispatch-id
+                              :event       event-vec}})
+    (push-trace! {:id        (+ (* dispatch-id 10) 1)
+                  :time      t0
+                  :op-type   :event
+                  :operation :event
+                  :tags      {:dispatch-id dispatch-id
+                              :phase       :run-end}})
+    (push-trace! {:id        (+ (* dispatch-id 10) 2)
+                  :time      (+ t0 1)
+                  :op-type   :event
+                  :operation :event/do-fx
+                  :tags      {:dispatch-id dispatch-id}})
+    (push-trace! {:id        (+ (* dispatch-id 10) 3)
+                  :time      t1
+                  :op-type   :fx
+                  :operation :rf.fx/handled
+                  :tags      {:dispatch-id dispatch-id
+                              :fx-id       :http/get}})))
+
+;; ---- (1) registry wiring ------------------------------------------------
+
+(deftest registry-installs-performance-handlers
+  (testing "register-causa-handlers! installs the Phase 5 (rf2-75121)
+            composite sub + the budget event"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/performance-data))
+        ":rf.causa/performance-data sub registered")
+    (is (some? (registrar/handler :sub :rf.causa/performance-budget-ms))
+        ":rf.causa/performance-budget-ms sub registered")
+    (is (some? (registrar/handler :event :rf.causa/set-performance-budget-ms))
+        ":rf.causa/set-performance-budget-ms event registered")))
+
+(deftest performance-data-defaults-empty
+  (testing "with no cascades in the buffer the composite returns
+            empty? true + budget defaulted"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [data @(rf/subscribe [:rf.causa/performance-data])]
+        (is (= [] (:rows data)))
+        (is (= 0 (:total data)))
+        (is (true? (:empty? data)))
+        (is (= h/default-budget-ms (:budget-ms data))
+            "budget defaults to performance-helpers/default-budget-ms")))))
+
+(deftest performance-data-projects-cascades
+  (testing "with one cascade in the buffer the composite returns one row"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-cascade! {:dispatch-id 1 :span-ms 5})
+      (let [data @(rf/subscribe [:rf.causa/performance-data])]
+        (is (= 1 (:total data)))
+        (is (false? (:empty? data)))
+        (is (= [1] (mapv :dispatch-id (:rows data))))))))
+
+;; ---- (2) render contract ------------------------------------------------
+
+(deftest panel-container-renders
+  (testing "the panel renders its root container regardless of buffer state"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [tree (performance/performance-view)]
+        (is (some? (find-by-testid tree "rf-causa-performance"))
+            "panel container present")
+        (is (some? (find-by-testid tree "rf-causa-perf-totals"))
+            "totals span in header present")
+        (is (some? (find-by-testid tree "rf-causa-perf-tier-chips"))
+            "tier-chip row in header present")))))
+
+;; ---- (3) empty state ----------------------------------------------------
+
+(deftest empty-state-renders-when-no-cascades
+  (testing "with no cascades the panel renders the empty container"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [tree (performance/performance-view)]
+        (is (some? (find-by-testid tree "rf-causa-perf-empty"))
+            "empty-state container present")
+        (is (nil? (find-by-testid tree "rf-causa-perf-feed"))
+            "no feed list when no cascades")))))
+
+;; ---- (4) sub-driven rendering -------------------------------------------
+
+(deftest feed-list-renders-when-cascades-present
+  (testing "with cascades in the buffer the panel renders the <ul> feed
+            with one <li> per cascade row"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-cascade! {:dispatch-id 1 :span-ms 5})
+      (push-cascade! {:dispatch-id 2 :span-ms 25})
+      (push-cascade! {:dispatch-id 3 :span-ms 200})
+      (let [tree (performance/performance-view)]
+        (is (some? (find-by-testid tree "rf-causa-perf-feed"))
+            "feed <ul> present")
+        (is (some? (find-by-testid tree "rf-causa-perf-row-1"))
+            "row for dispatch-id 1 present")
+        (is (some? (find-by-testid tree "rf-causa-perf-row-2"))
+            "row for dispatch-id 2 present")
+        (is (some? (find-by-testid tree "rf-causa-perf-row-3"))
+            "row for dispatch-id 3 present")))))
+
+(deftest row-carries-dispatch-id-event-duration-counts
+  (testing "every row surfaces the four detail spans by data-testid"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-cascade! {:dispatch-id 5 :span-ms 30 :event-vec [:cart/add 1]})
+      (let [tree (performance/performance-view)]
+        (is (some? (find-by-testid tree "rf-causa-perf-row-5-tier"))
+            "tier span present")
+        (is (some? (find-by-testid tree "rf-causa-perf-row-5-id"))
+            "dispatch-id span present")
+        (is (some? (find-by-testid tree "rf-causa-perf-row-5-event"))
+            "event-vec span present")
+        (is (some? (find-by-testid tree "rf-causa-perf-row-5-duration"))
+            "duration span present")
+        (is (some? (find-by-testid tree "rf-causa-perf-row-5-counts"))
+            "counts span present")))))
+
+;; ---- (5) perf budget ----------------------------------------------------
+
+(deftest over-budget-marker-renders-above-threshold
+  (testing "a row whose duration >= budget surfaces the over-budget marker"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Cascade spans 30ms; default budget is 16ms → over-budget.
+      (push-cascade! {:dispatch-id 7 :span-ms 30})
+      (let [tree (performance/performance-view)]
+        (is (some? (find-by-testid tree "rf-causa-perf-row-7-over-budget"))
+            "over-budget marker present for over-budget row")
+        (is (some? (find-by-testid tree "rf-causa-perf-over-budget-count"))
+            "header over-budget count surfaces")))))
+
+(deftest over-budget-marker-suppressed-under-threshold
+  (testing "a row whose duration < budget has no over-budget marker"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Cascade spans 5ms; default budget 16ms → within budget.
+      (push-cascade! {:dispatch-id 11 :span-ms 5})
+      (let [tree (performance/performance-view)]
+        (is (nil? (find-by-testid tree "rf-causa-perf-row-11-over-budget"))
+            "no over-budget marker for fast row")
+        (is (nil? (find-by-testid tree "rf-causa-perf-over-budget-count"))
+            "header over-budget count suppressed when no rows over-budget")))))
+
+(deftest setting-budget-changes-over-budget-classification
+  (testing "raising the budget moves a row from over-budget to within-budget"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-cascade! {:dispatch-id 13 :span-ms 30})
+      (is (true? (-> @(rf/subscribe [:rf.causa/performance-data])
+                     :rows first :over-budget?))
+          "default budget 16ms → row at 30ms is over-budget")
+      (rf/dispatch-sync [:rf.causa/set-performance-budget-ms 100])
+      (is (false? (-> @(rf/subscribe [:rf.causa/performance-data])
+                      :rows first :over-budget?))
+          "budget raised to 100ms → row at 30ms is now within-budget"))))
+
+(deftest setting-budget-nil-resets-to-default
+  (testing "passing nil to :rf.causa/set-performance-budget-ms resets the
+            threshold to the default"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-performance-budget-ms 100])
+      (is (= 100 @(rf/subscribe [:rf.causa/performance-budget-ms])))
+      (rf/dispatch-sync [:rf.causa/set-performance-budget-ms nil])
+      (is (= h/default-budget-ms
+             @(rf/subscribe [:rf.causa/performance-budget-ms]))
+          "nil resets to default"))))
+
+;; ---- (6) tier chips -----------------------------------------------------
+
+(deftest every-tier-renders-a-chip
+  (testing "the header renders one chip per tier in `tier-order`"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-cascade! {:dispatch-id 1 :span-ms 5})
+      (let [tree (performance/performance-view)
+            chips (find-all-by-testid-prefix tree "rf-causa-perf-tier-chip-")]
+        (is (= 4 (count chips))
+            "4 chips — one per tier in tier-order")
+        (is (some? (find-by-testid tree "rf-causa-perf-tier-chip-fast")))
+        (is (some? (find-by-testid tree "rf-causa-perf-tier-chip-medium")))
+        (is (some? (find-by-testid tree "rf-causa-perf-tier-chip-slow")))
+        (is (some? (find-by-testid tree "rf-causa-perf-tier-chip-blocking")))))))
+
+;; ---- (7) row interactions -----------------------------------------------
+
+(deftest row-click-pivots-to-event-detail
+  (testing "clicking a row dispatches :rf.causa/select-dispatch-id and
+            :rf.causa/select-panel"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-cascade! {:dispatch-id 42 :span-ms 5})
+      (let [dispatches (atom [])]
+        (with-redefs [rf/dispatch* (fn
+                                     ([ev]      (swap! dispatches conj ev) nil)
+                                     ([ev _o]   (swap! dispatches conj ev) nil))]
+          (let [tree    (performance/performance-view)
+                row     (find-by-testid tree "rf-causa-perf-row-42")
+                handler (:on-click (second row))]
+            (is (some? row) "row node present in rendered tree")
+            (is (some? handler) "row carries an :on-click handler")
+            (when handler (handler))))
+        (is (some #(= [:rf.causa/select-dispatch-id 42] %) @dispatches)
+            "select-dispatch-id fired with the row's dispatch-id")
+        (is (some #(= [:rf.causa/select-panel :event-detail] %) @dispatches)
+            "select-panel fired to pivot")))))
+
+;; ---- (8) row data-attrs -------------------------------------------------
+
+(deftest row-carries-data-tier-and-over-budget-attrs
+  (testing "the row carries data-tier + data-over-budget attrs that test
+            harnesses outside Hiccup walking (e.g. Playwright) can grep on"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; 5ms → :fast, within-budget. 200ms → :blocking, over-budget.
+      (push-cascade! {:dispatch-id 1 :span-ms 5})
+      (push-cascade! {:dispatch-id 2 :span-ms 200})
+      (let [tree (performance/performance-view)
+            r1   (find-by-testid tree "rf-causa-perf-row-1")
+            r2   (find-by-testid tree "rf-causa-perf-row-2")]
+        (is (= "fast"     (:data-tier (second r1))))
+        (is (= "false"    (:data-over-budget (second r1))))
+        (is (= "blocking" (:data-tier (second r2))))
+        (is (= "true"     (:data-over-budget (second r2))))))))
+
+;; ---- (9) frame isolation ------------------------------------------------
+
+(deftest performance-budget-state-does-not-leak-into-default-frame
+  (testing "the panel's budget state lives on :rf/causa, never :rf/default"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-performance-budget-ms 50]))
+    (let [causa-db   (frame/frame-app-db-value :rf/causa)
+          default-db (frame/frame-app-db-value :rf/default)]
+      (is (= 50 (:performance-budget-ms causa-db))
+          "budget lands on Causa")
+      (is (nil? (:performance-budget-ms default-db))
+          "budget did NOT leak into :rf/default"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
@@ -1,0 +1,414 @@
+(ns day8.re-frame2-causa.panels.trace-view-cljs-test
+  "CLJS-side wiring + view tests for Causa's Trace panel
+  (Phase 5, rf2-argrj; view-test coverage filed under rf2-zvrbw).
+
+  ## What's under test (in addition to the pure-data tests in
+  `trace_helpers_cljs_test.cljc`)
+
+    1. **Registry wires the composite sub** under
+       `:rf.causa/trace-feed`, plus the per-axis filter events
+       (`:rf.causa/set-trace-filter`, `:rf.causa/clear-trace-filters`).
+
+    2. **Render contract** — the section + header + counts +
+       data-testid wiring matches the production view tree.
+
+    3. **Empty states** — `:no-events` and `:no-matches` branches each
+       render their distinct container; the `:no-matches` branch
+       carries a clear-filters affordance.
+
+    4. **Sub-driven rendering** — when the trace buffer is populated
+       the feed renders one `<li>` per row.
+
+    5. **9-axis filter** — each canonical axis narrows the rendered
+       row set (source / origin / frame / op-type / severity / event-id /
+       handler-id / dispatch-id / operation) and axis combinations
+       compose AND-wise.
+
+    6. **Chip rows** — only axes with >=2 distinct values render their
+       chip row (so a single-value axis isn't noise). The clear-all
+       affordance surfaces whenever any filter axis is active.
+
+    7. **Row interactions** — clicking a row with a dispatch-id pivots
+       to event-detail; clicking a row chip narrows the corresponding
+       axis; clicking the source-coord chip fires :open-in-editor and
+       does NOT also pivot.
+
+    8. **Frame isolation** — the panel's filter state lives on
+       `:rf/causa`, never on `:rf/default`.
+
+  ## Pure hiccup
+
+  Same approach as `subscriptions_view_cljs_test.cljs` — walk the view's
+  hiccup tree by `data-testid` rather than mounting to the DOM."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.trace :as trace]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walkers (mirror machine_inspector_view_cljs_test) ----------
+
+(declare expand-fn-component)
+
+(defn- expand-children [node]
+  (cond
+    (vector? node) (mapv expand-fn-component node)
+    (seq? node)    (map  expand-fn-component node)
+    :else          node))
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (expand-children (apply (first node) (rest node)))
+    (expand-children node)))
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (hiccup-seq tree)))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- push-trace! [ev]
+  (trace-bus/collect-trace! ev))
+
+;; Construct a synthetic trace event with the canonical 9-axis tags.
+(defn- mk-trace
+  [{:keys [id time op-type operation source origin frame
+           severity event-id handler-id dispatch-id reason]
+    :or   {time 1000}}]
+  {:id        id
+   :time      time
+   :op-type   op-type
+   :operation operation
+   :source    source
+   :tags      (cond-> {}
+                origin      (assoc :origin origin)
+                frame       (assoc :frame frame)
+                event-id    (assoc :event-id event-id)
+                handler-id  (assoc :handler-id handler-id)
+                dispatch-id (assoc :dispatch-id dispatch-id)
+                source      (assoc :source source)
+                severity    (assoc :severity severity)
+                reason      (assoc :reason reason))})
+
+;; ---- (1) registry wiring ------------------------------------------------
+
+(deftest registry-installs-trace-handlers
+  (testing "register-causa-handlers! installs the Phase 5 (rf2-argrj)
+            composite sub + every supporting event"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/trace-feed))
+        ":rf.causa/trace-feed sub registered")
+    (is (some? (registrar/handler :sub :rf.causa/trace-filters))
+        ":rf.causa/trace-filters sub registered")
+    (is (some? (registrar/handler :event :rf.causa/set-trace-filter))
+        ":rf.causa/set-trace-filter event registered")
+    (is (some? (registrar/handler :event :rf.causa/clear-trace-filters))
+        ":rf.causa/clear-trace-filters event registered")))
+
+(deftest trace-feed-defaults-empty
+  (testing "with no events in the buffer the composite returns an empty
+            feed with empty-kind :no-events"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
+        (is (= [] (:rows feed)))
+        (is (= 0 (:total feed)))
+        (is (= 0 (:rendered feed)))
+        (is (false? (:any-filter? feed)))
+        (is (= :no-events (:empty-kind feed)))))))
+
+(deftest trace-feed-projects-events-into-rows
+  (testing "with events in the buffer the composite returns one row per
+            event with the canonical 9-axis projection"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                              :source :ui :origin :app :frame :rf/default
+                              :event-id :cart/add :dispatch-id 42}))
+      (push-trace! (mk-trace {:id 2 :op-type :error :operation :rf.error/handler-threw
+                              :source :ui :origin :app :frame :rf/default
+                              :event-id :cart/add :handler-id :cart/add-handler
+                              :dispatch-id 42 :reason "boom"}))
+      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
+        (is (= 2 (:total feed)))
+        (is (= 2 (:rendered feed)))
+        (is (nil? (:empty-kind feed)))
+        (is (= #{1 2} (set (map :id (:rows feed)))))))))
+
+;; ---- (2) render contract ------------------------------------------------
+
+(deftest panel-container-renders
+  (testing "the panel renders its root container regardless of buffer state"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [tree (trace/trace-view)]
+        (is (some? (find-by-testid tree "rf-causa-trace"))
+            "panel container present")
+        (is (some? (find-by-testid tree "rf-causa-trace-counts"))
+            "counts span present")))))
+
+(deftest feed-list-renders-when-events-present
+  (testing "with events in the buffer the panel renders the <ul> feed
+            with one <li> per row"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                              :dispatch-id 1}))
+      (push-trace! (mk-trace {:id 2 :op-type :fx :operation :rf.fx/handled
+                              :dispatch-id 1}))
+      (push-trace! (mk-trace {:id 3 :op-type :sub/run :operation :sub/run
+                              :dispatch-id 1}))
+      (let [tree (trace/trace-view)
+            rows (find-all-by-testid-prefix tree "rf-causa-trace-row-")]
+        (is (some? (find-by-testid tree "rf-causa-trace-feed"))
+            "feed <ul> present")
+        ;; Each row has many sub-testids prefixed with rf-causa-trace-row-<id>-…
+        ;; so filter to just the row containers (no trailing -dash).
+        (is (>= (count rows) 3)
+            "at least one rendered node per row")))))
+
+;; ---- (3) empty states ---------------------------------------------------
+
+(deftest empty-state-no-events-renders
+  (testing "with no events the panel renders the :no-events empty-state"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [tree (trace/trace-view)]
+        (is (some? (find-by-testid tree "rf-causa-trace-empty-no-events"))
+            ":no-events empty-state container present")
+        (is (nil? (find-by-testid tree "rf-causa-trace-feed"))
+            "no feed list when buffer is empty")))))
+
+(deftest empty-state-no-matches-renders-when-filters-hide-all
+  (testing "with events present but a filter that matches nothing the
+            panel renders the :no-matches empty-state with clear button"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                              :source :ui}))
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :no-such-source])
+      (let [tree (trace/trace-view)]
+        (is (some? (find-by-testid tree "rf-causa-trace-empty-no-matches"))
+            ":no-matches empty-state container present")
+        (is (some? (find-by-testid tree "rf-causa-trace-empty-clear-filters"))
+            "clear-filters button surfaces in :no-matches state")
+        (is (nil? (find-by-testid tree "rf-causa-trace-feed"))
+            "no feed list when no rows survive filtering")))))
+
+;; ---- (4) 9-axis filter --------------------------------------------------
+
+(deftest set-trace-filter-writes-to-causa-frame
+  (testing ":rf.causa/set-trace-filter mutates the per-axis filter map"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
+      (is (= {:source :ui} @(rf/subscribe [:rf.causa/trace-filters])))
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :origin :app])
+      (is (= {:source :ui :origin :app}
+             @(rf/subscribe [:rf.causa/trace-filters]))
+          "second axis adds; existing axis is preserved")
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :source nil])
+      (is (= {:origin :app} @(rf/subscribe [:rf.causa/trace-filters]))
+          "passing nil clears that axis"))))
+
+(deftest clear-trace-filters-drops-every-axis
+  (testing ":rf.causa/clear-trace-filters drops every axis in one shot"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :frame :rf/default])
+      (rf/dispatch-sync [:rf.causa/clear-trace-filters])
+      (is (= {} @(rf/subscribe [:rf.causa/trace-filters]))
+          "every filter axis cleared"))))
+
+(deftest filter-by-source-narrows-rendered-rows
+  (testing "setting :source narrows the feed to events with that source"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                              :source :ui :dispatch-id 1}))
+      (push-trace! (mk-trace {:id 2 :op-type :event :operation :event/dispatched
+                              :source :timer :dispatch-id 2}))
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
+      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
+        (is (= 2 (:total feed)))
+        (is (= 1 (:rendered feed)))
+        (is (= [1] (mapv :id (:rows feed))))))))
+
+(deftest filter-by-op-type-narrows-rendered-rows
+  (testing "setting :op-type narrows the feed to events with that op-type"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched}))
+      (push-trace! (mk-trace {:id 2 :op-type :error :operation :rf.error/handler-threw}))
+      (push-trace! (mk-trace {:id 3 :op-type :fx    :operation :rf.fx/handled}))
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :op-type :error])
+      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
+        (is (= 1 (:rendered feed)))
+        (is (= [2] (mapv :id (:rows feed))))))))
+
+(deftest filter-axes-compose-and-wise
+  (testing "two filter axes compose AND-wise — only rows matching both
+            survive"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                              :source :ui    :frame :rf/default}))
+      (push-trace! (mk-trace {:id 2 :op-type :event :operation :event/dispatched
+                              :source :ui    :frame :rf/causa}))
+      (push-trace! (mk-trace {:id 3 :op-type :event :operation :event/dispatched
+                              :source :timer :frame :rf/default}))
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :frame  :rf/default])
+      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
+        (is (= 1 (:rendered feed))
+            "only the row matching both axes survives")
+        (is (= [1] (mapv :id (:rows feed))))))))
+
+(deftest filter-by-dispatch-id-collapses-cascade
+  (testing "setting :dispatch-id slices the feed to one cascade's events"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                              :dispatch-id 42}))
+      (push-trace! (mk-trace {:id 2 :op-type :fx    :operation :rf.fx/handled
+                              :dispatch-id 42}))
+      (push-trace! (mk-trace {:id 3 :op-type :event :operation :event/dispatched
+                              :dispatch-id 99}))
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :dispatch-id 42])
+      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
+        (is (= 2 (:rendered feed)))
+        (is (= #{1 2} (set (map :id (:rows feed)))))))))
+
+;; ---- (5) chip rows ------------------------------------------------------
+
+(deftest chip-row-renders-only-when-axis-has-two-plus-values
+  (testing "an axis with one distinct value has nothing to filter on,
+            so its chip row is suppressed; an axis with >=2 renders"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Two events with the same :source but different :op-type.
+      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                              :source :ui}))
+      (push-trace! (mk-trace {:id 2 :op-type :error :operation :rf.error/handler-threw
+                              :source :ui}))
+      (let [tree (trace/trace-view)]
+        (is (some? (find-by-testid tree "rf-causa-trace-axis-row-op-type"))
+            ":op-type has two distinct values → chip row renders")
+        (is (nil? (find-by-testid tree "rf-causa-trace-axis-row-source"))
+            ":source has one distinct value → chip row suppressed")))))
+
+(deftest clear-filters-button-renders-only-when-axis-active
+  (testing "the header's Clear filters affordance appears iff at least
+            one filter axis is active"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                              :source :ui}))
+      (is (nil? (find-by-testid (trace/trace-view) "rf-causa-trace-clear-filters"))
+          "no Clear filters button when no axis is active")
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
+      (is (some? (find-by-testid (trace/trace-view) "rf-causa-trace-clear-filters"))
+          "Clear filters button surfaces once an axis is active"))))
+
+;; ---- (6) row interactions -----------------------------------------------
+
+(deftest row-click-pivots-to-event-detail-when-dispatch-id-present
+  (testing "clicking a row whose event carries a :dispatch-id dispatches
+            :rf.causa/select-dispatch-id + :rf.causa/select-panel"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-trace! (mk-trace {:id 7 :op-type :event :operation :event/dispatched
+                              :dispatch-id 42}))
+      (let [dispatches (atom [])]
+        (with-redefs [rf/dispatch* (fn
+                                     ([ev]      (swap! dispatches conj ev) nil)
+                                     ([ev _o]   (swap! dispatches conj ev) nil))]
+          (let [tree    (trace/trace-view)
+                row     (find-by-testid tree "rf-causa-trace-row-7")
+                handler (:on-click (second row))]
+            (is (some? row) "row node present")
+            (is (some? handler) "row carries an :on-click handler")
+            (when handler (handler))))
+        (is (some #(= [:rf.causa/select-dispatch-id 42] %) @dispatches)
+            "select-dispatch-id fired with the row's dispatch-id")
+        (is (some #(= [:rf.causa/select-panel :event-detail] %) @dispatches)
+            "select-panel fired to pivot")))))
+
+(deftest source-coord-click-fires-open-in-editor
+  (testing "clicking the source-coord chip fires :rf.causa/open-in-editor;
+            stopPropagation prevents the row's pivot from also firing"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Push a trace whose :rf.trace/trigger-handler carries a source-coord.
+      (push-trace! (-> (mk-trace {:id 9 :op-type :event :operation :event/dispatched
+                                  :dispatch-id 1})
+                       (assoc :rf.trace/trigger-handler
+                              {:source-coord {:file "core.cljs" :line 42}})))
+      (let [dispatches (atom [])
+            stop-evt   (atom nil)]
+        (with-redefs [rf/dispatch* (fn
+                                     ([ev]      (swap! dispatches conj ev) nil)
+                                     ([ev _o]   (swap! dispatches conj ev) nil))]
+          (let [tree    (trace/trace-view)
+                node    (find-by-testid tree "rf-causa-trace-row-9-source-coord")
+                handler (:on-click (second node))]
+            (is (some? node) "source-coord chip rendered")
+            (when handler
+              (handler #js {:stopPropagation #(reset! stop-evt true)}))))
+        (is (some (fn [ev]
+                    (and (vector? ev)
+                         (= :rf.causa/open-in-editor (first ev))
+                         (= {:source-coord "core.cljs:42"} (second ev))))
+                  @dispatches)
+            ":rf.causa/open-in-editor fired with the projected coord")
+        (is @stop-evt "stopPropagation was called so the row's pivot
+                       handler doesn't also fire")))))
+
+;; ---- (7) frame isolation ------------------------------------------------
+
+(deftest trace-filter-state-does-not-leak-into-default-frame
+  (testing "the panel's filter state lives on :rf/causa, never :rf/default"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui]))
+    (let [causa-db   (frame/frame-app-db-value :rf/causa)
+          default-db (frame/frame-app-db-value :rf/default)]
+      (is (= {:source :ui} (:trace-filters causa-db))
+          "filter map lands on Causa")
+      (is (nil? (:trace-filters default-db))
+          "filter map did NOT leak into :rf/default"))))


### PR DESCRIPTION
## Summary

The Causa test-coverage audit (rf2-otcbz) found that three Phase 5
panels ship with **no view-tree tests** despite each carrying 16-17
`data-testid` attributes — they were designed for testing but the
tests never landed. Only the pure-data helpers were covered.

This PR adds the three missing test files, walking the rendered
hiccup by `data-testid` (same approach as `subscriptions_view_cljs_test`
and `machine_inspector_view_cljs_test`). No production source changed.

## Files added

| File | Tests | Assertions |
|---|---:|---:|
| `tools/causa/test/.../panels/trace_view_cljs_test.cljs`         | 18 | 48 |
| `tools/causa/test/.../panels/performance_view_cljs_test.cljs`   | 15 | 47 |
| `tools/causa/test/.../panels/issues_ribbon_view_cljs_test.cljs` | 21 | 62 |
| **Total**                                                        | **54** | **157** |

## Coverage per panel

**Trace panel** (rf2-argrj — 9-axis filter vocabulary)
- Registry wires `:rf.causa/trace-feed` + `set-trace-filter` /
  `clear-trace-filters` events.
- `:no-events` and `:no-matches` empty-state branches each render.
- Each filter axis (`:source`, `:op-type`, `:dispatch-id`, …)
  narrows rendered rows; two axes compose AND-wise.
- Chip rows render iff axis has >=2 distinct values.
- Row click pivots to `:event-detail`; source-coord click fires
  `:rf.causa/open-in-editor` with `stopPropagation`.
- Filter state isolated to `:rf/causa` frame.

**Performance panel** (rf2-75121 — perf-tier + budget)
- Registry wires `:rf.causa/performance-data` + budget event.
- Empty / populated states each render.
- Over-budget marker surfaces above threshold, hidden below.
- `:rf.causa/set-performance-budget-ms` reclassifies rows; nil
  resets to default.
- Every tier in `tier-order` renders a chip.
- Row click pivots to `:event-detail`; `data-tier` /
  `data-over-budget` attrs carried for non-hiccup harnesses.
- Budget state isolated to `:rf/causa` frame.

**Issues ribbon panel** (rf2-d1p4o — severity / prefix / since-ms)
- Registry wires `:rf.causa/issues-ribbon` + every filter event.
- Non-issue success-path traces filtered out at the projection.
- `:no-issues` ('All clear') and `:no-matches` branches render.
- Three severity chips always render; prefix chip-row renders only
  when at least one issue carries a prefix.
- Severity / prefix / since-ms filters each narrow rendered rows;
  `:rf.causa/clear-issues-filters` drops all three.
- Row click pivots to `:event-detail`; source-coord click fires
  `:rf.causa/open-in-editor` with `stopPropagation`.
- Filter state isolated to `:rf/causa` frame.

## Suite totals (before -> after)

- CLJS (`npm run test:cljs`): **1481 -> 1535 tests, 3918 -> 4075 assertions** (0 failures).
- JVM (`clojure -M:test` from `tools/causa/`): **462 / 1303 unchanged** — the new tests are CLJS-only by design (they walk the view's hiccup output).

## Test plan

- [x] `npm run test:cljs` from `implementation/` — 1535 tests, 0 failures.
- [x] `clojure -M:test` from `tools/causa/` — 462 tests, 0 failures.
- [x] No production source touched; only the three new test files added.