### PR TITLE
cleanup(scripts): trim stale _BASELINE entries from drift check (rf2-iugyd)

### DIFF
--- a/scripts/check_skill_mcp_drift.py
+++ b/scripts/check_skill_mcp_drift.py
@@ -124,13 +124,7 @@ MAPPINGS: list[Mapping] = [
 #
 # Entries are keyed by mapping-name (not host_prefix) so renames in MAPPINGS
 # above stay self-consistent.
-_BASELINE: set[tuple[str, str, str]] = {
-    # rf2-aks1t fixes both of these on the pair2 skill side; once that PR
-    # lands, remove these two entries and the gate will turn red on any
-    # future drift.
-    ("pair2-mcp <-> re-frame-pair2", "missing-in-skill", "subscribe"),
-    ("pair2-mcp <-> re-frame-pair2", "missing-in-skill", "unsubscribe"),
-}
+_BASELINE: set[tuple[str, str, str]] = set()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

rf2-aks1t (PR #633) added `subscribe`/`unsubscribe` to the pair2 skill's
`allowed-tools`. The drift-check script's `_BASELINE` entries that silenced
those gaps are now stale -- the script was emitting a `::warning::` about
them on every run.

This trims both entries from `_BASELINE` in `scripts/check_skill_mcp_drift.py`.
`_BASELINE` is now empty (every drift is a failure going forward), which is
the desired post-rf2-aks1t state.

Closes rf2-iugyd.

## Verification

```
$ python scripts/check_skill_mcp_drift.py --ci
exit=0
```

Verbose run, also clean:

```
$ python scripts/check_skill_mcp_drift.py --ci --verbose
pair2-mcp <-> re-frame-pair2: server=10 tools, skill=10 allow-listed.
causa-mcp <-> <tbd>: server src 'tools\causa-mcp\src\re_frame\causa_mcp\tools.cljc' missing -- skipping (optional).
No skill <-> MCP drift detected.
exit=0
```

Zero stale-baseline warnings. Pre-trim run still showed the two warnings
the bead described.

## Test plan

- [x] `python scripts/check_skill_mcp_drift.py --ci` exits 0 with no output
- [x] `python scripts/check_skill_mcp_drift.py --ci --verbose` shows clean summary, no warnings
- [x] `python scripts/check_skill_mcp_drift.py --show-baseline` reports empty baseline