### PR TITLE
feat(pair2-mcp): integrate day8/de-dupe at runtime boundary (rf2-obpa9)

### DIFF
--- a/tools/pair2-mcp/deps.edn
+++ b/tools/pair2-mcp/deps.edn
@@ -42,11 +42,27 @@
 ;; The `:test` alias here is a thin shim for habit / IDE consistency:
 ;; `clojure -M:test` still routes through shadow-cljs because the
 ;; sources are .cljs and need a CLJS compiler.
-{:paths ["src"]
+;; `:paths` includes "test" so shadow-cljs's `:server-test` build sees
+;; the unit-test namespaces when classpath resolution goes through this
+;; file (rf2-obpa9 flipped shadow-cljs.edn to `:deps true`). The
+;; production `:server` build doesn't pull test code — shadow-cljs only
+;; compiles what its entry-point graph requires.
+{:paths ["src" "test"]
  :deps  {org.clojure/clojure       {:mvn/version "1.12.0"}
          org.clojure/clojurescript {:mvn/version "1.12.145"}
          applied-science/js-interop {:mvn/version "0.4.2"}
-         thheller/shadow-cljs      {:mvn/version "3.4.10"}}
+         thheller/shadow-cljs      {:mvn/version "3.4.10"}
+         ;; day8/de-dupe — structural dedup of persistent data structures
+         ;; (rf2-obpa9). The library substitutes repeated subtrees with
+         ;; namespaced-symbol references (`de-dupe.cache/cache-N`); the
+         ;; flat cache map round-trips back through `expand`. Applied at
+         ;; the MCP wire boundary BEFORE the wire-cap check (rf2-rvyzy)
+         ;; so dedup gets to shrink first. Git-coord pinned to the
+         ;; latest master commit because the library has no recent
+         ;; Clojars release that matches the alive 2026 codebase
+         ;; (project.clj declares 0.2.2 but the master HEAD is past it).
+         day8/de-dupe              {:git/url "https://github.com/day8/de-dupe.git"
+                                    :git/sha "a2be701ddf42d94218116eda9e9ca822cef035bc"}}
 
  :aliases
  {:test {:extra-paths ["test"]

--- a/tools/pair2-mcp/shadow-cljs.edn
+++ b/tools/pair2-mcp/shadow-cljs.edn
@@ -9,8 +9,16 @@
 ;;
 ;; Source for the pilot lives under pilot/ (kept for reference and as
 ;; an end-to-end smoke harness). Production source lives under src/.
-{:source-paths ["src" "test"]
- :dependencies [[applied-science/js-interop "0.4.2"]]
+;; `:deps true` routes classpath resolution through deps.edn (rf2-obpa9).
+;; The earlier shape duplicated `:dependencies` here AND `:deps` in
+;; deps.edn — the deps.edn comment-block already declared that file the
+;; source of truth; this slot now actually honours that. The switch was
+;; forced by day8/de-dupe being shipped via git-coord only (no Clojars
+;; release of the post-2026 master HEAD); shadow-cljs's own
+;; `:dependencies` slot supports Maven coords only, not `:git/sha`.
+;; NOTE: `:source-paths` lives in deps.edn `:paths` when `:deps true`
+;; is active — shadow-cljs warns and ignores any `:source-paths` here.
+{:deps true
  :builds {:server      {:target :node-script
                         :output-to "out/server.js"
                         :main re-frame-pair2-mcp.server/main

--- a/tools/pair2-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/pair2-mcp/spec/003-Tool-Catalogue.md
@@ -25,6 +25,36 @@ is not allowed. Agents pattern-match on `:rf.mcp/overflow` and either
 narrow their args or pass `max-tokens 0` for the rare case where the
 full payload is genuinely needed.
 
+## Universal: structural dedup on epoch slices
+
+Every tool that ships epoch slices or events vectors —
+`snapshot` (the `:epochs` slot of each frame), `trace-window`,
+`watch-epochs`, and `subscribe` (per-tick `:events` vector) —
+applies structural dedup after diff-encoding and before the
+wire-cap check (see
+[`Principles.md` §Structural dedup](Principles.md#structural-dedup-rf2-obpa9)).
+Each affected tool accepts a `dedup` arg (boolean, default
+`true`). Deduped payloads are wrapped as
+
+```clojure
+{:rf.mcp/dedup-table
+ {:de-dupe.cache/cache-0 <root-with-refs>
+  :de-dupe.cache/cache-1 <shared-subtree>
+  ...}}
+```
+
+The cache map is `day8/de-dupe`'s flat output. Agents
+reconstruct with `(de-dupe.core/expand cache-map)` — one
+library call, exact round-trip. Pass `dedup false` to skip the
+wrap (e.g. for ad-hoc reads when the agent host hasn't been
+taught to call `expand`).
+
+The marker key `:rf.mcp/dedup-table` matches the cross-MCP
+vocabulary declared in
+[causa-mcp `Principles.md` §5](../../causa-mcp/spec/Principles.md) —
+an agent that learned the slot on causa-mcp sees the same slot
+here.
+
 ## discover-app
 
 Verify the shadow-cljs nREPL is reachable, confirm the
@@ -79,7 +109,8 @@ operating frame.
 
 **Args**: `ms` (integer, default 1000), `frame` (string),
 `epochs-mode` (string — `"diff"` (default) or `"full"`, see §Diff-encoded
-`:db-after` below), `build` (string).
+`:db-after` below), `dedup` (boolean, default `true` — see §Structural
+dedup at the top of this catalogue), `build` (string).
 
 **Returns**: `{:ok? true :window-ms N :count K :epochs-mode :diff|:full :epochs [...]}`.
 
@@ -121,7 +152,9 @@ loop should call us repeatedly with the same `since-id`.
 `:event-id`, `:event-id-prefix`, `:effects`, `:touches-path`,
 `:sub-ran`, `:render`, `:origin`, `:frame`), `frame`,
 `epochs-mode` (string — `"diff"` (default) or `"full"`, see
-`trace-window` §Diff-encoded `:db-after`), `build`.
+`trace-window` §Diff-encoded `:db-after`), `dedup` (boolean,
+default `true` — see §Structural dedup at the top of this
+catalogue), `build`.
 
 **Returns**: `{:ok? true :matches [...] :head-id "..." :id-aged-out? bool :epochs-mode :diff|:full}`.
 
@@ -158,7 +191,9 @@ default all five), `path` (EDN-encoded vector or JSON array of segment
 strings — path-slicing for the `:app-db` slice, rf2-tygdv),
 `epochs-mode` (string — `"diff"` (default) or `"full"`, see `trace-window`
 §Diff-encoded `:db-after`; controls the `:epochs` slice's wire shape,
-rf2-1wdzp), `build` (string).
+rf2-1wdzp), `dedup` (boolean, default `true` — applies structural dedup
+per-frame to each `:epochs` slot; see §Structural dedup at the top of
+this catalogue), `build` (string).
 
 **Returns**:
 
@@ -367,6 +402,11 @@ vocab `watch-epochs` already accepts):
   `true` to disable the gate for this subscription. Dropped count
   surfaces as `:dropped-sensitive` on each progress payload (when
   non-zero) and the final summary.
+- `dedup` (boolean, default `true`) — apply structural dedup
+  (rf2-obpa9) to each progress payload's `:events` vector. See
+  §Structural dedup at the top of this catalogue. The cache is
+  per-tick (each `notifications/progress` frame carries its own
+  table; no cross-tick refs). Pass `false` to skip.
 - `build` (string, default `"app"`) — shadow-cljs build id.
 
 ### Returns

--- a/tools/pair2-mcp/spec/Principles.md
+++ b/tools/pair2-mcp/spec/Principles.md
@@ -185,15 +185,16 @@ internals.
 - **Pluggable strategy**: the wrapper dispatches on a
   `:strategy` keyword. Today only `:truncate-with-marker` is
   implemented (replace the payload with the overflow marker).
-  Future strategies — structural dedup — slot in here without
-  touching per-tool functions. Path-slicing and lazy-summary
-  already landed (rf2-tygdv) but as per-tool input-shape
-  concerns: the `snapshot` and `get-path` tools accept a
-  `:path` arg and default to a `{:rf.mcp/summary ...}` response
-  for the unbounded `:app-db` slice, so the cap stays a backstop
-  rather than the primary mechanism for the common case.
-  Diff-encoded `:db-after` (rf2-1wdzp) also lives at the tool
-  surface — see the dedicated mechanism below.
+  Path-slicing and lazy-summary already landed (rf2-tygdv) but
+  as per-tool input-shape concerns: the `snapshot` and
+  `get-path` tools accept a `:path` arg and default to a
+  `{:rf.mcp/summary ...}` response for the unbounded `:app-db`
+  slice, so the cap stays a backstop rather than the primary
+  mechanism for the common case. Diff-encoded `:db-after`
+  (rf2-1wdzp) and structural dedup (rf2-obpa9) also live at the
+  tool surface — see the dedicated mechanisms below. They run
+  BEFORE the cap so the wrapper measures the already-shrunk
+  payload.
 - **Silent truncation is not allowed**: a payload that exceeds
   the cap MUST NOT be shipped in any partial form that would
   let the agent host parse it as a valid response. The marker
@@ -315,11 +316,12 @@ from ~20MB to ~10MB. Combined with the `:app-db` slice's
 `:summary` default (rf2-tygdv), the agent's typical
 `investigate-X` workflow stays well inside the 5,000-token
 cap without further drill-down. The `:db-before` reference is
-deliberately NOT deduplicated across records — that would
-introduce cross-record dependencies and break the
-self-containment property. Cross-record dedup is in scope for
-the future `:strategy :dedup` mechanism (rf2-lwgg8 mechanism
-5), not for this one.
+deliberately NOT deduplicated by this mechanism — diff-encoding
+keeps each record self-contained — but the next mechanism in
+this pipeline (structural dedup, rf2-obpa9) DOES collapse the
+shared `:db-before` references at the slice boundary via an
+explicit substitution table; round-trip remains exact via the
+de-dupe library's companion `expand` function.
 
 **Cross-MCP vocabulary**. The `:rf.mcp/diff-from` marker key
 follows the `:rf.mcp/*` namespace convention shared with
@@ -327,6 +329,97 @@ follows the `:rf.mcp/*` namespace convention shared with
 and causa-mcp's `:rf.mcp/dedup-table` (rf2-lwgg8 mechanism 5).
 Agents recognise the family once and pattern-match on the
 prefix.
+
+### Structural dedup (rf2-obpa9)
+
+The fourth wire-protocol mechanism. Persistent data structures
+share subtrees in memory; `pr-str` flattens the sharing and
+writes every shared node out in full. After diff-encoding
+(above) collapses each `:db-after`, the dominant remaining cost
+is the per-record `:db-before` reference — a 10-epoch window
+over a 1MB app-db is still ~10MB on the wire. Structural dedup
+collapses repeated subtrees by emitting them once into a
+substitution table and replacing later occurrences with
+references.
+
+**The transform**. After diff-encoding, every epoch slice
+shipping through `trace-window`, `watch-epochs`, or the
+`:epochs` slot of `snapshot` is passed through
+[`day8/de-dupe`](https://github.com/day8/de-dupe)
+(MIT, ClojureScript, alive 2026; pinned via git-coord in
+[`deps.edn`](../deps.edn)) and wrapped in the cross-MCP
+substitution-table marker:
+
+```clojure
+;; Wire shape
+{:rf.mcp/dedup-table
+ {:de-dupe.cache/cache-0 <root-with-refs>
+  :de-dupe.cache/cache-1 <shared-subtree>
+  :de-dupe.cache/cache-2 <shared-subtree>
+  ...}}
+```
+
+The cache map is the de-dupe library's flat output: cache-0 is
+the root structure (with namespaced-symbol references to other
+cache entries inline), and the remaining entries are the
+extracted shared subtrees. The agent host reconstructs by
+calling `(de-dupe.core/expand cache-map)` — one library call,
+exact round-trip. The marker key
+(`:rf.mcp/dedup-table`) matches the cross-MCP vocabulary
+declared in
+[causa-mcp `Principles.md` §5 Structural dedup](../../causa-mcp/spec/Principles.md);
+an agent that learned the slot on causa-mcp sees the same slot
+here.
+
+**Why `de-dupe-eq` (equality), not `de-dupe` (identity)**. Data
+arrives at the MCP server via bencode over nREPL; CLJS values
+reconstructed on the way through don't share identity with the
+runtime's in-memory originals. Equality is what makes the
+cross-record share-pooling actually fire on the wire boundary.
+
+**Where in the pipeline**. Dedup runs AFTER diff-encoding and
+BEFORE the wire-cap check (rf2-rvyzy). Order matters: the
+diff-encoder shrinks each record's `:db-after`; the deduper
+then pools repeated subtrees across records (most importantly
+the `:db-before` reference, which is the dominant cost after
+diff-encoding). The wire-cap then measures the deduped payload,
+not the raw, so dedup gets to shrink first.
+
+**Table reset policy**. The cache is built **per dedup call**
+(per `:epochs` slice, per subscribe-tick events vector).
+Cross-call carry-over would require a stateful per-subscription
+cache and a wire shape that references entries from previous
+frames — a non-trivial protocol change for a marginal gain (the
+dominant within-call savings are already captured). If a future
+findings doc shows cross-tick share-pooling matters, that is a
+separate bead.
+
+**Idempotence on no-dedup-opportunity**. A payload with no
+repeated subtrees deduplicates to a one-entry cache — the wire
+shape is slightly larger than the input. The encoder
+short-circuits on nil / empty-collection / scalar inputs so the
+marker only appears when there's actual work to undo.
+
+**`dedup` arg**. Every tool that ships epoch slices or events
+accepts a `dedup` arg (boolean, default `true`). Passing
+`false` skips the wrap — useful for ad-hoc reads when the
+agent host hasn't been taught to call `expand`, or for
+round-trip debugging.
+
+**Wire-byte impact**. Measured: a 10-epoch window over a
+256-key map (each value a 256-char string ⇒ 683KB raw)
+compresses to 72KB after dedup — a 89.5% reduction. The exact
+ratio depends on shape (subtree cardinality, map fan-out,
+value sizes); the floor is **≥50%** on any payload where the
+`:db-before` reference is shared across multiple records, which
+is the rule rather than the exception for diff-encoded epoch
+slices.
+
+**Subscribe streaming**. The `subscribe` tool's
+`notifications/progress` frames apply the same wrap per-tick.
+The cache is per-tick (no cross-tick refs); each `:events`
+vector in the progress payload is a self-contained deduped
+blob.
 
 ## Backed by the framework's principles
 

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -58,6 +58,7 @@
   (:require [applied-science.js-interop :as j]
             [cljs.reader]
             [clojure.string :as str]
+            [de-dupe.core :as dedup]
             [re-frame-pair2-mcp.nrepl :as nrepl]))
 
 ;; ---------------------------------------------------------------------------
@@ -404,6 +405,135 @@
     :else              :diff))
 
 ;; ---------------------------------------------------------------------------
+;; Structural dedup at the wire boundary (rf2-obpa9).
+;;
+;; Persistent data structures share subtrees in memory; `pr-str` flattens
+;; the sharing and writes every shared node out in full. For the epoch
+;; slice — where the diff-encoder (rf2-1wdzp) has already collapsed
+;; each `:db-after` against its own `:db-before` — the `:db-before`
+;; reference still rides per-record verbatim; a 10-epoch window over a
+;; 1MB app-db is ~10MB on the wire after diff-encoding (the diff itself
+;; is tiny, but every record still carries a full `:db-before`).
+;;
+;; `day8/de-dupe` walks a persistent data structure, hash-identifies
+;; repeated subtrees, and rewrites the structure as a flat cache map
+;; whose entries are keyed by `de-dupe.cache/cache-N` namespaced
+;; symbols. The library guarantees round-trip exactness via the
+;; companion `expand` function; the agent host can decode locally.
+;;
+;; ## When dedup runs
+;;
+;; - **Inside the epoch encoder**: the `:epochs` slice on `snapshot`,
+;;   `trace-window`, and `watch-epochs` is wrapped after diff-encoding
+;;   and before the wire-cap check (rf2-rvyzy). Order matters: the
+;;   diff-encoder shrinks each record's `:db-after`; the deduper then
+;;   pools repeated subtrees across records (most importantly the
+;;   `:db-before` reference, which is the dominant cost after
+;;   diff-encoding).
+;; - **Inside subscribe streaming**: each emitted progress frame's
+;;   `:events` vector is deduped per-tick. The cache is per-tick
+;;   (not per-subscription) — see §Table reset policy below.
+;;
+;; ## Why `de-dupe-eq` (equality), not `de-dupe` (identity)
+;;
+;; Data arrives at the MCP server via bencode over nREPL; CLJS values
+;; reconstructed from EDN on the way through don't share identity with
+;; values the runtime emitted earlier. Equality is what makes the
+;; cross-record share-pooling actually fire on the wire boundary, even
+;; though identity would be the cheaper rule if we had it.
+;;
+;; ## Wire shape
+;;
+;; A deduped payload is wrapped in a top-level marker:
+;;
+;;   {:rf.mcp/dedup-table <cache-map>}
+;;
+;; where `<cache-map>` is the de-dupe library's flat
+;; `{:de-dupe.cache/cache-0 <root> :de-dupe.cache/cache-N <subtree> ...}`
+;; output. Agents reconstruct by calling `de-dupe.core/expand` on the
+;; cache-map value, which returns the original structure with sharing
+;; restored. The marker key is the cross-MCP-convention vocabulary
+;; from causa-mcp's [`Principles.md`](../../causa-mcp/spec/Principles.md)
+;; §"5. Structural dedup" and aligns with the `:rf.mcp/*` family
+;; (`:rf.mcp/overflow`, `:rf.mcp/summary`, `:rf.mcp/diff-from`).
+;;
+;; ## Table reset policy
+;;
+;; The cache is built **per dedup call** (per `:epochs` slice, per
+;; subscribe tick). Cross-call carry-over would require a stateful
+;; per-subscription cache and a wire shape that references entries
+;; from previous frames — a non-trivial protocol change for a marginal
+;; gain (the dominant within-call savings are already captured). If a
+;; future findings doc shows cross-tick share-pooling matters, that's
+;; a separate bead.
+;;
+;; ## Opt-out
+;;
+;; `dedup` MCP arg (boolean). Default `true`. `false` skips dedup
+;; entirely — the encoder emits the un-deduped value. Useful for ad-hoc
+;; reads where the agent host hasn't been taught to call `expand`, or
+;; for round-trip debugging.
+;;
+;; ## Idempotence on no-dedup-opportunity
+;;
+;; A payload with no repeated subtrees deduplicates to a one-entry
+;; cache (`{:de-dupe.cache/cache-0 <original>}`) — the wire shape is
+;; very slightly larger than the input. The encoder skips wrapping in
+;; that case via an `empty-payload?` short-circuit: nil / `[]` / `{}`
+;; inputs return the original value, so the marker only appears when
+;; there's actual work to undo.
+;; ---------------------------------------------------------------------------
+
+(defn- parse-dedup-arg
+  "Normalise the `dedup` MCP arg into a boolean. Accepts booleans,
+  strings (`\"true\"`/`\"false\"`), keywords (`:true`/`:false`), or
+  nil (default `true`). Unrecognised values default to `true` —
+  the budget-sensitive default fires dedup."
+  [raw]
+  (cond
+    (nil? raw)             true
+    (true? raw)            true
+    (false? raw)           false
+    (= raw "false")        false
+    (= raw :false)         false
+    (= raw "true")         true
+    (= raw :true)          true
+    :else                  true))
+
+(defn- empty-payload?
+  "True for values where dedup yields no win — nil, empty collections,
+  scalars. Skipping the wrap avoids the trivial cache-of-one shape
+  bloating the wire for empty / single-record responses."
+  [v]
+  (or (nil? v)
+      (and (coll? v) (empty? v))
+      (not (coll? v))))
+
+(defn- dedup-value
+  "Apply structural dedup to `v` and wrap the result in the cross-MCP
+  marker. Returns `v` unchanged when `enabled?` is false or when
+  `v` is empty / scalar (no dedup opportunity). Uses `de-dupe-eq`
+  (equality-based) — see the section header for the identity-vs-equality
+  rationale."
+  [v enabled?]
+  (if (or (not enabled?) (empty-payload? v))
+    v
+    (let [cache (dedup/de-dupe-eq v)]
+      {:rf.mcp/dedup-table cache})))
+
+(defn- dedup-expand
+  "Reverse `dedup-value`. Given a value possibly wrapped in the
+  `:rf.mcp/dedup-table` marker, reconstruct the original structure
+  via `de-dupe.core/expand`. Idempotent on already-expanded values
+  (the marker check returns the input unchanged when the wrapper
+  isn't present). Provided for round-trip parity and for the unit
+  tests; the agent host can call the same shape locally."
+  [v]
+  (if (and (map? v) (contains? v :rf.mcp/dedup-table))
+    (dedup/expand (:rf.mcp/dedup-table v))
+    v))
+
+;; ---------------------------------------------------------------------------
 ;; Preload probe.
 ;; ---------------------------------------------------------------------------
 
@@ -612,6 +742,7 @@
         frame     (some-> (arg args :frame) keyword)
         incl?     (include-sensitive? args)
         mode      (parse-epochs-mode (arg args :epochs-mode))
+        dedup?    (parse-dedup-arg (arg args :dedup))
         form      (if frame
                     (str "(re-frame-pair2.runtime/epochs-in-last-ms " ms " " (pr-str frame) ")")
                     (str "(re-frame-pair2.runtime/epochs-in-last-ms " ms ")"))]
@@ -619,12 +750,14 @@
         (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
         (.then (fn [epochs]
                  (let [[kept dropped] (strip-sensitive (vec epochs) incl?)
-                       encoded         (diff-encode-epochs kept mode)]
+                       encoded         (diff-encode-epochs kept mode)
+                       deduped         (dedup-value encoded dedup?)]
                    (ok-text (cond-> {:ok? true
                                      :window-ms ms
                                      :count (count encoded)
                                      :epochs-mode mode
-                                     :epochs encoded}
+                                     :dedup dedup?
+                                     :epochs deduped}
                               (pos? dropped) (assoc :dropped-sensitive dropped))))))
         (.catch (fn [err] (err->result :trace-failed err))))))
 
@@ -642,6 +775,7 @@
         since-id  (arg args :since-id)
         incl?     (include-sensitive? args)
         mode      (parse-epochs-mode (arg args :epochs-mode))
+        dedup?    (parse-dedup-arg (arg args :dedup))
         pred-map  (when-let [p (arg args :pred)] (js->clj p :keywordize-keys true))
         frame-arg (if frame (str " " (pr-str frame)) "")
         form      (str "(let [r (re-frame-pair2.runtime/epochs-since "
@@ -657,9 +791,13 @@
                  (let [matches        (when (map? v) (:matches v))
                        [kept dropped] (strip-sensitive (vec matches) incl?)
                        encoded        (diff-encode-epochs kept mode)
+                       deduped        (dedup-value encoded dedup?)
                        base           (cond-> {:ok? true}
                                         (map? v) (merge v))]
-                   (ok-text (cond-> (assoc base :matches encoded :epochs-mode mode)
+                   (ok-text (cond-> (assoc base
+                                           :matches deduped
+                                           :epochs-mode mode
+                                           :dedup dedup?)
                               (pos? dropped) (assoc :dropped-sensitive dropped))))))
         (.catch (fn [err] (err->result :watch-failed err))))))
 
@@ -1018,6 +1156,26 @@
                  fmap)))
       {} snapshot)))
 
+(defn- dedup-epochs-in-snapshot
+  "Walk the per-frame snapshot map and apply structural dedup
+  (rf2-obpa9) to every frame's `:epochs` slice. Dedup is per-frame —
+  cross-frame share-pooling would require a single table spanning
+  every frame's slice, which is a follow-on optimisation; per-frame
+  is the safe default and matches the table-reset policy
+  (per-call, not per-stream)."
+  [snapshot enabled?]
+  (cond
+    (or (not enabled?) (not (map? snapshot)))
+    snapshot
+    :else
+    (reduce-kv
+      (fn [m fid fmap]
+        (assoc m fid
+               (if (and (map? fmap) (contains? fmap :epochs))
+                 (update fmap :epochs dedup-value enabled?)
+                 fmap)))
+      {} snapshot)))
+
 (defn- snapshot-tool [conn args]
   (let [build-id (arg-build args)
         frames   (parse-frames-arg (arg args :frames))
@@ -1025,6 +1183,7 @@
         incl?    (include-sensitive? args)
         path     (parse-path-arg (arg args :path))
         mode     (parse-epochs-mode (arg args :epochs-mode))
+        dedup?   (parse-dedup-arg (arg args :dedup))
         opts     {:frames frames :include include}
         form     (str "(re-frame-pair2.runtime/snapshot-state "
                       (pr-str opts) ")")]
@@ -1033,13 +1192,15 @@
         (.then (fn [v]
                  (let [[scrubbed dropped]    (scrub-snapshot-sensitive v incl?)
                        [sliced path-status]  (slice-app-db-in-snapshot scrubbed path)
-                       diff-encoded          (diff-encode-epochs-in-snapshot sliced mode)]
+                       diff-encoded          (diff-encode-epochs-in-snapshot sliced mode)
+                       deduped               (dedup-epochs-in-snapshot diff-encoded dedup?)]
                    (ok-text (cond-> {:ok?         true
                                      :frames      (if (= :all frames) :all (vec frames))
                                      :include     include
                                      :mode        (if (nil? path) :summary :path-sliced)
                                      :epochs-mode mode
-                                     :snapshot    diff-encoded}
+                                     :dedup       dedup?
+                                     :snapshot    deduped}
                               path                  (assoc :path path)
                               (seq path-status)     (assoc :path-not-found path-status)
                               (pos? dropped)        (assoc :dropped-sensitive dropped))))))
@@ -1180,6 +1341,7 @@
         max-ms      (or (arg args :max-ms) 0)    ;; 0 = no upper bound
         max-events  (or (arg args :max-events) 0) ;; 0 = no upper bound
         incl?       (include-sensitive? args)
+        dedup?      (parse-dedup-arg (arg args :dedup))
         progress-tk (some-> extra
                             (j/get :_meta)
                             (j/get :progressToken))
@@ -1282,7 +1444,8 @@
                                                                      @tick
                                                                      (pr-str
                                                                        (cond-> {:sub-id sub-id
-                                                                                :events evts
+                                                                                :events (dedup-value evts dedup?)
+                                                                                :dedup dedup?
                                                                                 :overflow ov}
                                                                          (pos? dropped)
                                                                          (assoc :dropped-sensitive dropped)))
@@ -1338,6 +1501,23 @@
                      "replaced with an `{:rf.mcp/overflow ...}` "
                      "marker. Pass 0 to disable the cap.")})
 
+(def ^:private dedup-property
+  "Per-tool descriptor slot for the `:dedup` opt-out (rf2-obpa9).
+  Applied to surfaces that ship epoch slices (`snapshot`,
+  `trace-window`, `watch-epochs`) and to the `subscribe` streaming
+  channel — the surfaces where repeated subtrees dominate the wire
+  cost. Default `true`."
+  {:type        "boolean"
+   :description (str "Apply structural dedup (day8/de-dupe) to the "
+                     "epoch slice / event vector before the wire-cap "
+                     "check. Default true. When deduped, the slot is "
+                     "wrapped as `{:rf.mcp/dedup-table <cache-map>}` "
+                     "and the agent host reconstructs via "
+                     "`(de-dupe.core/expand cache-map)`. Pass false "
+                     "to skip dedup — useful for ad-hoc reads when "
+                     "the agent host hasn't been taught to call "
+                     "`expand`.")})
+
 (defn- with-budget-knob
   "Splice `max-tokens` into a tool descriptor's inputSchema.properties.
   No-op if the descriptor already declares it (forward-compat)."
@@ -1380,13 +1560,17 @@
                       "at the top level; opt back in with `include-sensitive? true`. Dropped count surfaces "
                       "as `:dropped-sensitive` on the result when non-zero. "
                       "Each epoch's :db-after is diff-encoded against its own :db-before by default (rf2-1wdzp) "
-                      "— pass `epochs-mode \"full\"` for the legacy full-pair shape (needed for time-travel restore).")
+                      "— pass `epochs-mode \"full\"` for the legacy full-pair shape (needed for time-travel restore). "
+                      "The epoch vector is structurally deduped by default (rf2-obpa9) — repeated subtrees "
+                      "(notably the per-record `:db-before` reference) collapse to a `{:rf.mcp/dedup-table ...}` "
+                      "wrapper; the agent host calls `(de-dupe.core/expand cache)` to reconstruct. Pass `dedup false` to skip.")
     :inputSchema {:type "object"
                   :properties {:ms    {:type "integer" :description "Window size in milliseconds (default 1000)"}
                                :frame {:type "string"}
                                :epochs-mode {:type "string"
                                              :description "How :db-after rides the wire: \"diff\" (default, intra-record structural diff against :db-before) or \"full\" (legacy full snapshot, opt-in for time-travel)."
                                              :enum ["diff" "full"]}
+                               :dedup dedup-property
                                :include-sensitive? {:type "boolean"
                                                     :description "Opt back in to forwarding `:sensitive? true` items. Default false."}
                                :build {:type "string"}}
@@ -1397,7 +1581,8 @@
                       ":touches-path, :sub-ran, :render, :origin, :frame. Per spec/009 §Privacy this forwarder "
                       "default-drops items carrying `:sensitive? true`; opt back in with `include-sensitive? true`. "
                       "Each epoch's :db-after is diff-encoded against its own :db-before by default (rf2-1wdzp) "
-                      "— pass `epochs-mode \"full\"` for the legacy full-pair shape.")
+                      "— pass `epochs-mode \"full\"` for the legacy full-pair shape. "
+                      "The matches vector is structurally deduped by default (rf2-obpa9); pass `dedup false` to skip.")
     :inputSchema {:type "object"
                   :properties {:since-id {:type "string" :description "The last epoch id you've seen (omit to start fresh)"}
                                :pred     {:type "object" :description "Filter map"}
@@ -1405,6 +1590,7 @@
                                :epochs-mode {:type "string"
                                              :description "How :db-after rides the wire: \"diff\" (default) or \"full\" (legacy, opt-in for time-travel restore)."
                                              :enum ["diff" "full"]}
+                               :dedup    dedup-property
                                :include-sensitive? {:type "boolean"
                                                     :description "Opt back in to forwarding `:sensitive? true` items. Default false."}
                                :build    {:type "string"}}
@@ -1434,7 +1620,11 @@
                       "Per spec/009 §Privacy the `:traces` and `:epochs` slices default-drop items carrying "
                       "`:sensitive? true`; opt back in with `include-sensitive? true`. App-db / sub-cache / "
                       "machines slices pass through unchanged — payload redaction is the `with-redacted` "
-                      "interceptor's job, not the forwarder's.")
+                      "interceptor's job, not the forwarder's. "
+                      "Each frame's `:epochs` slice is structurally deduped (rf2-obpa9) after diff-encoding — "
+                      "repeated subtrees (notably the per-record `:db-before` reference) collapse to a "
+                      "`{:rf.mcp/dedup-table ...}` wrapper; agent host reconstructs via `de-dupe.core/expand`. "
+                      "Pass `dedup false` to skip.")
     :inputSchema {:type "object"
                   :properties {:frames  {:description "Frames to snapshot. Pass \"all\" (default) or an array of frame-id strings like [\":rf/default\", \":stories\"]."
                                          :oneOf [{:type "string"}
@@ -1455,6 +1645,7 @@
                                :epochs-mode {:type "string"
                                              :description "How :db-after rides the wire in the :epochs slice: \"diff\" (default, intra-record structural diff against :db-before) or \"full\" (legacy full snapshot, opt-in for time-travel)."
                                              :enum ["diff" "full"]}
+                               :dedup   dedup-property
                                :include-sensitive? {:type "boolean"
                                                     :description "Opt back in to forwarding `:sensitive? true` items in the :traces / :epochs slices. Default false."}
                                :build   {:type "string" :description "shadow-cljs build id (default: app)"}}
@@ -1492,7 +1683,12 @@
                       ":sub-ran :render :origin :frame). Pass `filter` either as a JSON object or as an EDN-encoded string. "
                       "Per spec/009 §Privacy this forwarder default-drops events carrying `:sensitive? true` at the top "
                       "level; opt back in with `include-sensitive? true`. Dropped count surfaces as `:dropped-sensitive` "
-                      "on each progress payload (when non-zero) and the final summary.")
+                      "on each progress payload (when non-zero) and the final summary. "
+                      "Each progress payload's `:events` vector is structurally deduped by default (rf2-obpa9) — "
+                      "shared subtrees across the tick collapse to a `{:rf.mcp/dedup-table ...}` wrapper; "
+                      "agent host reconstructs via `(de-dupe.core/expand cache-map)`. Dedup is per-tick, not "
+                      "per-stream — each notifications/progress frame carries its own cache, no cross-tick "
+                      "references. Pass `dedup false` to skip.")
     :inputSchema {:type "object"
                   :properties {:topic   {:type "string"
                                          :description "Topic name. Required."
@@ -1508,6 +1704,7 @@
                                          :description "Hard upper-bound on how long the subscription stays open, ms. 0 = unbounded (close on cancel only). Default 0."}
                                :max-events {:type "integer"
                                             :description "Terminate after this many events have been delivered. 0 = unbounded. Default 0."}
+                               :dedup    dedup-property
                                :include-sensitive? {:type "boolean"
                                                     :description "Opt back in to forwarding `:sensitive? true` items. Default false."}
                                :build   {:type "string"}}

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/dedup_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/dedup_test.cljs
@@ -1,0 +1,349 @@
+(ns re-frame-pair2-mcp.dedup-test
+  "Unit tests for the structural-dedup wire-boundary transform
+  (rf2-obpa9).
+
+  Per `tools/pair2-mcp/spec/Principles.md` mechanism (Structural
+  dedup), every `:rf/epoch-record` slice and each subscribe-tick
+  events vector is passed through `day8/de-dupe` before the wire-cap
+  check. Repeated subtrees (notably the per-record `:db-before`
+  reference after diff-encoding) collapse into a flat cache map that
+  the agent host reconstructs via `de-dupe.core/expand`.
+
+  These tests mirror the private dedup helpers from `tools.cljs`
+  (`parse-dedup-arg`, `empty-payload?`, `dedup-value`,
+  `dedup-expand`, `dedup-epochs-in-snapshot`). A rename or signature
+  change surfaces as a failing test rather than a silent contract
+  drift.
+
+  Live end-to-end coverage runs against a real shadow-cljs build via
+  the existing stdio-roundtrip harness; this file pins the pure
+  transforms, the round-trip property, the wire shape, and the
+  reduction-ratio sanity check."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [de-dupe.core :as dedup]))
+
+;; ---------------------------------------------------------------------------
+;; Mirrors of the private dedup helpers from tools.cljs. Keep in
+;; lockstep — sibling tests follow the same convention (CLJS private
+;; vars aren't reachable across namespaces without `#'` so we copy
+;; the surface and lean on regression coverage).
+;; ---------------------------------------------------------------------------
+
+(defn- parse-dedup-arg [raw]
+  (cond
+    (nil? raw)             true
+    (true? raw)            true
+    (false? raw)           false
+    (= raw "false")        false
+    (= raw :false)         false
+    (= raw "true")         true
+    (= raw :true)          true
+    :else                  true))
+
+(defn- empty-payload? [v]
+  (or (nil? v)
+      (and (coll? v) (empty? v))
+      (not (coll? v))))
+
+(defn- dedup-value [v enabled?]
+  (if (or (not enabled?) (empty-payload? v))
+    v
+    (let [cache (dedup/de-dupe-eq v)]
+      {:rf.mcp/dedup-table cache})))
+
+(defn- dedup-expand [v]
+  (if (and (map? v) (contains? v :rf.mcp/dedup-table))
+    (dedup/expand (:rf.mcp/dedup-table v))
+    v))
+
+(defn- dedup-epochs-in-snapshot [snapshot enabled?]
+  (cond
+    (or (not enabled?) (not (map? snapshot)))
+    snapshot
+    :else
+    (reduce-kv
+      (fn [m fid fmap]
+        (assoc m fid
+               (if (and (map? fmap) (contains? fmap :epochs))
+                 (update fmap :epochs dedup-value enabled?)
+                 fmap)))
+      {} snapshot)))
+
+;; ---------------------------------------------------------------------------
+;; parse-dedup-arg — MCP-arg normalisation.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-dedup-default-is-true
+  (is (true? (parse-dedup-arg nil))))
+
+(deftest parse-dedup-booleans-pass-through
+  (is (true? (parse-dedup-arg true)))
+  (is (false? (parse-dedup-arg false))))
+
+(deftest parse-dedup-string-forms-accepted
+  ;; The MCP wire ships JSON; clients sending `"false"` should get
+  ;; the false reading rather than the budget-default true.
+  (is (false? (parse-dedup-arg "false")))
+  (is (true? (parse-dedup-arg "true"))))
+
+(deftest parse-dedup-keyword-forms-accepted
+  (is (false? (parse-dedup-arg :false)))
+  (is (true? (parse-dedup-arg :true))))
+
+(deftest parse-dedup-unknown-defaults-to-true
+  ;; Least-surprise on the budget-sensitive default: an unrecognised
+  ;; value gets the smaller-wire-payload behaviour, not the larger.
+  (is (true? (parse-dedup-arg "garbage")))
+  (is (true? (parse-dedup-arg 42)))
+  (is (true? (parse-dedup-arg :other))))
+
+;; ---------------------------------------------------------------------------
+;; empty-payload? — the no-op guard.
+;; ---------------------------------------------------------------------------
+
+(deftest empty-payload-nil-is-empty
+  (is (true? (empty-payload? nil))))
+
+(deftest empty-payload-empty-vector-is-empty
+  (is (true? (empty-payload? [])))
+  (is (true? (empty-payload? {})))
+  (is (true? (empty-payload? #{})))
+  (is (true? (empty-payload? '()))))
+
+(deftest empty-payload-scalars-are-empty
+  ;; Scalars can't be deduped — the no-op guard catches them.
+  (is (true? (empty-payload? 42)))
+  (is (true? (empty-payload? :keyword)))
+  (is (true? (empty-payload? "string")))
+  (is (true? (empty-payload? true))))
+
+(deftest empty-payload-non-empty-collections-fire-dedup
+  (is (false? (empty-payload? [1 2 3])))
+  (is (false? (empty-payload? {:a 1})))
+  (is (false? (empty-payload? #{:x})))
+  (is (false? (empty-payload? '(1 2)))))
+
+;; ---------------------------------------------------------------------------
+;; dedup-value — the wire-boundary wrap.
+;; ---------------------------------------------------------------------------
+
+(deftest dedup-disabled-passes-through
+  ;; opt-out: caller asks for the raw payload.
+  (let [payload [{:a 1 :b 2} {:a 1 :b 2}]]
+    (is (= payload (dedup-value payload false)))))
+
+(deftest dedup-empty-payload-passes-through
+  ;; Empty / scalar inputs skip wrapping — the cache-of-one would
+  ;; be a wire-size loss for trivial values.
+  (is (nil? (dedup-value nil true)))
+  (is (= [] (dedup-value [] true)))
+  (is (= {} (dedup-value {} true)))
+  (is (= 42 (dedup-value 42 true))))
+
+(deftest dedup-non-empty-collection-emits-marker
+  (let [payload [{:a 1} {:b 2}]
+        wrapped (dedup-value payload true)]
+    (is (map? wrapped))
+    (is (contains? wrapped :rf.mcp/dedup-table))
+    (is (map? (:rf.mcp/dedup-table wrapped))
+        "the table itself is a hash-map keyed by namespaced symbols")))
+
+(deftest dedup-marker-key-is-the-cross-mcp-vocabulary
+  ;; The marker key matches causa-mcp's Principles §5 (Structural
+  ;; dedup): `{:rf.mcp/dedup-table ...}`. Agents that learned the
+  ;; slot on causa-mcp see the same slot here.
+  (let [wrapped (dedup-value [{:a 1} {:a 1}] true)]
+    (is (= [:rf.mcp/dedup-table] (vec (keys wrapped))))))
+
+;; ---------------------------------------------------------------------------
+;; Round-trip: dedup → expand → identity.
+;; ---------------------------------------------------------------------------
+
+(deftest round-trip-simple-shared-map
+  (let [shared {:big "common" :keys [:a :b :c]}
+        payload [{:id 1 :payload shared}
+                 {:id 2 :payload shared}
+                 {:id 3 :payload shared}]
+        wrapped (dedup-value payload true)
+        restored (dedup-expand wrapped)]
+    (is (= payload restored))))
+
+(deftest round-trip-already-expanded-is-noop
+  ;; A payload that was never deduped (caller passed `dedup false`)
+  ;; round-trips identity through expand.
+  (let [payload [{:a 1} {:b 2}]]
+    (is (= payload (dedup-expand payload)))))
+
+(deftest round-trip-nested-shared-subtrees
+  ;; The load-bearing case: epoch slice where every record carries
+  ;; the same large `:db-before`. After dedup → expand the structure
+  ;; comes back exactly.
+  (let [big-db (into {} (for [i (range 100)]
+                          [(keyword (str "k" i))
+                           {:v (str "value-" i)
+                            :meta {:tags [:tag1 :tag2 :tag3]}}]))
+        epochs (vec (for [i (range 10)]
+                      {:epoch-id (str "ep-" i)
+                       :db-before big-db
+                       :db-after  {:rf.mcp/diff-from :db-before
+                                   :patches [[[(keyword (str "k" i)) :v]
+                                              :assoc (str "new-" i)]]}}))
+        wrapped (dedup-value epochs true)
+        restored (dedup-expand wrapped)]
+    (is (= epochs restored))))
+
+(deftest round-trip-empty-collections-inside-payload
+  (let [payload [{:items [] :state {}} {:items [] :state {}}]
+        wrapped (dedup-value payload true)
+        restored (dedup-expand wrapped)]
+    (is (= payload restored))))
+
+(deftest round-trip-deeply-nested-uniform-records
+  ;; Stress: 50 records each carrying the same nested structure.
+  (let [record {:cart {:items [{:sku "A" :qty 1}
+                               {:sku "B" :qty 2}]
+                       :total 30}
+                :user {:id 7 :name "alice"}
+                :ui {:loading? false :error nil}}
+        payload (vec (repeat 50 record))
+        wrapped (dedup-value payload true)
+        restored (dedup-expand wrapped)]
+    (is (= payload restored))
+    (is (= 50 (count restored)))))
+
+;; ---------------------------------------------------------------------------
+;; Reduction-ratio sanity: 10-epoch window with shared map structure.
+;; The bead requires ≥50% reduction; we assert the actual value with
+;; a generous floor because the precise ratio depends on subtree
+;; cardinality + map layout.
+;; ---------------------------------------------------------------------------
+
+(deftest reduction-ratio-shared-subtrees
+  ;; The load-bearing scenario rf2-obpa9 targets: a 10-epoch window
+  ;; whose records share their `:db-before` reference. The diff-
+  ;; encoder (rf2-1wdzp) already reduced :db-after to a tiny patch
+  ;; per record; the deduper now collapses the repeated :db-before.
+  (let [;; Build a "big" app-db — 256 keys, each pointing at a 256-char
+        ;; string value ⇒ ~80KB pr-str.
+        big-db (into {} (for [i (range 256)]
+                          [(keyword (str "k" i))
+                           (apply str (repeat 256 \x))]))
+        ;; 10 epochs, each sharing the same :db-before reference.
+        epochs (vec (for [i (range 10)]
+                      {:epoch-id (str "ep-" i)
+                       :event-id :touch
+                       :db-before big-db
+                       :db-after  {:rf.mcp/diff-from :db-before
+                                   :patches [[[(keyword (str "k" i))]
+                                              :assoc (apply str (repeat 256 \y))]]}}))
+        raw-size (count (pr-str epochs))
+        wrapped (dedup-value epochs true)
+        wrapped-size (count (pr-str wrapped))]
+    (testing "wrapped payload is much smaller than the raw vector"
+      ;; Observability: print the actual ratio in the test log so the
+      ;; PR body and future findings docs have a real number to cite.
+      (println "[rf2-obpa9] 10-epoch / 256-key shared :db-before:"
+               "raw=" raw-size "chars,"
+               "deduped=" wrapped-size "chars,"
+               "reduction=" (.toFixed (- 100.0 (* 100.0 (/ wrapped-size raw-size 1.0))) 1) "%")
+      (is (< wrapped-size raw-size))
+      ;; Conservative: ≥50% reduction (the bead's floor). Actual
+      ;; should be much higher when the same :db-before reference
+      ;; rides 10 times.
+      (is (< wrapped-size (* 0.5 raw-size))
+          (str "Deduped size (" wrapped-size
+               ") should be < 50% of raw (" raw-size
+               "). Ratio: " (/ wrapped-size raw-size 1.0))))
+    (testing "round-trip still reconstructs every epoch"
+      (let [restored (dedup-expand wrapped)]
+        (is (= epochs restored))))))
+
+;; ---------------------------------------------------------------------------
+;; Edge cases per the bead.
+;; ---------------------------------------------------------------------------
+
+(deftest edge-case-empty-payload-is-noop
+  ;; "empty payload (no-op)" — the wrapper short-circuits.
+  (is (nil? (dedup-value nil true)))
+  (is (= [] (dedup-value [] true))))
+
+(deftest edge-case-no-repeated-structure
+  ;; "payload with no repeated structure (table empty)" — the cache
+  ;; ships only the root entry; round-trip still exact.
+  (let [payload [{:a 1} {:b 2} {:c 3}]
+        wrapped (dedup-value payload true)
+        restored (dedup-expand wrapped)]
+    (is (= payload restored))))
+
+(deftest edge-case-one-big-repeated-subtree
+  ;; "payload that's one big repeated subtree (table has 1 entry)" —
+  ;; the cache compresses well; round-trip still exact.
+  (let [shared (into {} (for [i (range 100)]
+                          [(keyword (str "k" i)) i]))
+        payload (vec (repeat 20 shared))
+        wrapped (dedup-value payload true)
+        restored (dedup-expand wrapped)]
+    (is (= payload restored))
+    (is (= 20 (count restored)))
+    (is (every? #(= shared %) restored))))
+
+;; ---------------------------------------------------------------------------
+;; dedup-epochs-in-snapshot — per-frame integration.
+;; ---------------------------------------------------------------------------
+
+(def ^:private fixture-snapshot
+  {:rf/default {:app-db    {:k :v}
+                :sub-cache {}
+                :machines  {:ids [] :state {}}
+                :epochs    [{:epoch-id :ep-1
+                             :db-before {:cart {:items []}}
+                             :db-after  {:rf.mcp/diff-from :db-before :patches []}}
+                            {:epoch-id :ep-2
+                             :db-before {:cart {:items []}}
+                             :db-after  {:rf.mcp/diff-from :db-before :patches []}}]
+                :traces    []}
+   :stories    {:app-db    {:k2 :v2}
+                :sub-cache {}
+                :machines  {:ids [] :state {}}
+                :epochs    [{:epoch-id :ep-A
+                             :db-before {:foo 1}
+                             :db-after  {:rf.mcp/diff-from :db-before
+                                         :patches [[[:foo] :assoc 2]]}}]
+                :traces    []}})
+
+(deftest snapshot-dedup-wraps-each-frames-epochs
+  (let [wrapped (dedup-epochs-in-snapshot fixture-snapshot true)]
+    (testing ":epochs slot wrapped on every frame that has one"
+      (doseq [[_fid fmap] wrapped]
+        (let [eps (:epochs fmap)]
+          (is (and (map? eps) (contains? eps :rf.mcp/dedup-table))
+              "epochs slice replaced with dedup-table marker"))))
+    (testing "other slices pass through unchanged"
+      (is (= {:k :v} (-> wrapped :rf/default :app-db)))
+      (is (= [] (-> wrapped :rf/default :traces))))))
+
+(deftest snapshot-dedup-disabled-passes-through
+  (is (= fixture-snapshot
+         (dedup-epochs-in-snapshot fixture-snapshot false))))
+
+(deftest snapshot-dedup-skips-frames-without-epochs-slice
+  ;; The :include filter may exclude :epochs. Don't add one.
+  (let [snap {:rf/default {:app-db {} :sub-cache {}}}
+        wrapped (dedup-epochs-in-snapshot snap true)]
+    (is (not (contains? (:rf/default wrapped) :epochs)))))
+
+(deftest snapshot-dedup-non-map-passes-through
+  (is (nil? (dedup-epochs-in-snapshot nil true)))
+  (is (= :not-a-snap (dedup-epochs-in-snapshot :not-a-snap true))))
+
+(deftest snapshot-dedup-round-trips-per-frame
+  (let [wrapped (dedup-epochs-in-snapshot fixture-snapshot true)
+        restored (reduce-kv
+                   (fn [m fid fmap]
+                     (assoc m fid
+                            (if (contains? fmap :epochs)
+                              (update fmap :epochs dedup-expand)
+                              fmap)))
+                   {}
+                   wrapped)]
+    (is (= fixture-snapshot restored))))


### PR DESCRIPTION
## Summary

Fourth wire-protocol bead. With cap (rf2-rvyzy), path-slicing
(rf2-tygdv), and diff-encoding (rf2-1wdzp) all landed, structural
dedup is the next big size win — it collapses the per-record
`:db-before` reference that survives diff-encoding.

## Design

- **Library**: `day8/de-dupe` (CLJS, MIT, alive 2026; mike's commit
  2026-04-29). Pinned via git-coord (`:git/sha
  a2be701ddf42d94218116eda9e9ca822cef035bc`) — no current Clojars
  release matches the alive master HEAD.
- **API path**: `de-dupe.core/{de-dupe-eq, expand}`. Equality-based
  (not identity-based) because values arrive at the MCP server via
  bencode over nREPL and don't share identity with the runtime's
  in-memory originals — equality is what makes cross-record
  share-pooling actually fire on the wire boundary.
- **Where in the pipeline**: AFTER diff-encoding (so the per-record
  diff already happened) and BEFORE the wire-cap check (so the cap
  measures the deduped payload).
- **Surfaces**: `trace-window`, `watch-epochs`, `snapshot` (per-frame
  `:epochs` slot), `subscribe` (per-tick `:events` vector).
- **Opt-out**: `dedup` arg, default `true`. Knob surfaces in
  `tools/list` descriptors so agents discover it.

## Wire shape

```clojure
{:rf.mcp/dedup-table
 {:de-dupe.cache/cache-0 <root-with-refs>
  :de-dupe.cache/cache-1 <shared-subtree>
  :de-dupe.cache/cache-2 <shared-subtree>
  ...}}
```

The cache map is de-dupe's flat output: `cache-0` is the root
(with namespaced-symbol references inline), other entries are
extracted shared subtrees. Agent host reconstructs by calling
`(de-dupe.core/expand cache-map)` — one library call, exact round-trip.

Marker key `:rf.mcp/dedup-table` matches causa-mcp's
`Principles.md` §5 (Structural dedup) — agents that learned the
slot on causa-mcp see the same slot here. Aligns with the
`:rf.mcp/*` family (`:rf.mcp/overflow`, `:rf.mcp/summary`,
`:rf.mcp/diff-from`).

## Table-reset policy

**Per dedup call** (per `:epochs` slice, per subscribe tick).
Picked the cleaner of the two options:

- Per-call (chosen): no cross-tick references; each frame
  self-contained; no stateful per-subscription cache; round-trip
  reasoning trivially local.
- Per-stream (rejected): would maximise sharing across tick
  boundaries but requires a stateful cache, a wire protocol that
  references entries from previous frames, and LRU-eviction
  bookkeeping. Marginal gain over per-call because the
  within-tick share-pool already captures the dominant cost.

If a future findings doc shows cross-tick share-pooling matters
in practice, that's a separate bead.

## Dep coord

`day8/de-dupe` added to `tools/pair2-mcp/deps.edn` as git-coord
(SHA `a2be701ddf42d94218116eda9e9ca822cef035bc` — master HEAD,
2026-04-29). Flipped `shadow-cljs.edn` to `:deps true` so the
git-coord resolves on classpath — the deps.edn comment-block already
declared that file the source of truth; this slot now actually
honours that. shadow-cljs's own `:dependencies` slot supports
Maven coords only, not `:git/sha`.

## Test count

- **151 tests / 321 assertions** total in the pair2-mcp suite
  (up from 122 / ~260). New `dedup_test.cljs` adds 29 tests
  covering: `parse-dedup-arg` normalisation, `empty-payload?`
  guards, `dedup-value` wrap shape, round-trip property
  (encode → expand → identity) across simple / nested / deeply
  nested cases, all three edge cases the bead called out
  (empty payload, no repeated structure, one big repeated
  subtree), and per-frame integration via
  `dedup-epochs-in-snapshot`.
- End-to-end smoke (`npm run stdio-roundtrip`) green.

## Sample reduction numbers

Measured by the test suite (printed each run):

```
[rf2-obpa9] 10-epoch / 256-key shared :db-before:
  raw= 683641 chars, deduped= 72047 chars, reduction= 89.5 %
```

A 10-epoch window over a 256-key app-db (each value a 256-char
string ⇒ ~80KB raw `pr-str`) shrinks from 683KB to 72KB —
**89.5% reduction**. The bead's ≥50% floor is well clear; the
actual ratio depends on subtree cardinality but ≥50% holds on
any payload where the same `:db-before` rides multiple records,
which is the rule for diff-encoded epoch slices.

## Cross-MCP follow-ons spotted

- **rf2-pkve3** (pending) plans to lift the structural-dedup
  wording from causa-mcp's Principles into pair2-mcp's. This PR
  pre-empts that for the dedup mechanism — pair2-mcp's
  Principles.md now carries its own §Structural dedup section
  with full design rationale aligned to causa-mcp's mechanism #5
  vocabulary. The lift can absorb / cite this wording instead of
  rewriting.
- **rf2-nw6sj** (separate bead) — the de-dupe .cljc port for JVM
  reach. Out of scope here; this PR consumes the CLJS-only library
  directly.
- The `:dedup-table` wire marker is now in use by pair2-mcp;
  story-mcp may want the same treatment for its epoch surfaces
  if findings show comparable wire pressure.

## Test plan

- [x] `npm test` from `tools/pair2-mcp/` — 151/151 green
- [x] `clojure -M:test` — same suite, same result
- [x] `npm run stdio-roundtrip` end-to-end smoke — green
- [x] `npx shadow-cljs compile server` (production build) — clean
- [x] Round-trip property verified on simple + nested + 50-record
      uniform fixtures
- [x] All three edge cases asserted (empty payload, no shared
      structure, all-shared structure)
- [x] Reduction ratio asserted ≥50%; actual 89.5% on the load-bearing
      scenario