### PR TITLE
test(causa): add mount.cljs lifecycle + missing-adapter gate tests (rf2-5x20s)

### DIFF
--- a/tools/causa/test/day8/re_frame2_causa/mount_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/mount_cljs_test.cljs
@@ -1,0 +1,623 @@
+(ns day8.re-frame2-causa.mount-cljs-test
+  "Tests for Causa's DOM-side mount state machine (rf2-5x20s; source
+  rf2-otcbz audit recommendation #6).
+
+  `mount.cljs` carries six public fns — `mounted?`, `visible?`,
+  `open!`, `close!`, `toggle!`, `teardown!` — whose combined contract
+  is a small state machine over a single `defonce` singleton atom.
+  Until this file the surface was untouched: the keybinding tests
+  (rf2-jbhm5) cover the *attach/detach* listener-management lane and
+  the shell tests (rf2-3lh6h) cover the *rendered hiccup* — neither
+  exercises the *open → close → toggle → teardown* transitions nor
+  the silent-no-op posture when no substrate adapter is installed.
+
+  ## Three contract surfaces under test
+
+  1. **State machine.** `(mounted?) ⇔ (some? @mount-state)`;
+     `(visible?) ⇔ (:visible? @mount-state)`. After `open!`, both
+     true; after `close!`, mounted? remains true but visible?
+     flips false; after `teardown!`, both false again (the
+     singleton is cleared and the DOM node removed).
+
+  2. **Lazy-mount affordance.** The mount cost (DOM node + substrate
+     render) is paid once on first `open!`. Subsequent `open!`s flip
+     the container's CSS display only — no re-render, no new DOM
+     node, no second `substrate-adapter/render` call. This is the
+     spec/007-UX-IA.md §The default landing view <80ms toggle
+     target: re-mounting would discard internal state and miss the
+     budget.
+
+  3. **Missing-adapter gate.** Per the source docstring `open!` is
+     gated on `(substrate-adapter/current-adapter)`. When no
+     adapter is installed — production-bundle accident, host that
+     never called `rf/init!`, mid-`dispose-adapter!` race — the
+     call returns nil silently. No DOM node, no state mutation, no
+     throw. The user's Ctrl+Shift+C is a no-op until an adapter
+     installs.
+
+  ## Why these tests run on node-test (not browser-test)
+
+  The mount logic is pure DOM-manipulation: `document.createElement`,
+  `appendChild`, `removeChild`, `style.display`. Node-test has no
+  `js/document` by default, so we install a minimal stub for the
+  duration of each test. The substrate `render` fn that mount.cljs
+  delegates to is stubbed via `with-redefs` so the test never depends
+  on a real React tree (the shell tests live in shell_cljs_test.cljs
+  on the hiccup-walk lane). The browser-level integration story —
+  shadow-cljs preload + real Reagent render + real Ctrl+Shift+C —
+  lives in the Playwright lane (rf2-s2bhn)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.mount :as mount]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- private-state accessors --------------------------------------------
+;;
+;; `mount/mount-state` is a `defonce` private atom — reaching it through
+;; `#'mount/mount-state` lets the fixture reset the singleton between
+;; tests so the state-machine transitions start from a known baseline.
+;; The atom is reset, not replaced, so the defonce identity is preserved
+;; (mirrors the keybinding-test pattern of poking `(detach!)` rather
+;; than re-binding the sentinel itself).
+
+(defn- reset-mount-state! []
+  (reset! @#'mount/mount-state nil))
+
+;; ---- js/document stub ---------------------------------------------------
+;;
+;; Node-test has no `js/document`; the mount fns call
+;; `(.createElement js/document "div")`, `(.appendChild ...)`,
+;; `(.removeChild ...)` and read `(.-parentNode node)`. We install a
+;; hand-rolled stub for the duration of each test that exposes:
+;;
+;;   - `js/document` with `createElement` + `body`
+;;   - body.appendChild / body.removeChild
+;;   - each created node has its own `style` map, `parentNode` slot,
+;;     `id` slot, plus an `appendChild` / `removeChild` so the shell's
+;;     render tree can attach children if it wants to.
+;;
+;; The stub mirrors the surface mount.cljs actually touches —
+;; `createElement`, `appendChild`, `removeChild`, `style.display`,
+;; `parentNode`. We do not try to be a full JSDOM; we just cover the
+;; calls `create-mount-node!` and `teardown!` make.
+
+(defn- mk-stub-node []
+  (let [node (js-obj
+              "style"     (js-obj "display" "")
+              "id"        ""
+              "tagName"   "DIV"
+              "children"  (array))]
+    (set! (.-parentNode node) nil)
+    (set! (.-appendChild node)
+          (fn [child]
+            (.push (.-children node) child)
+            (set! (.-parentNode child) node)
+            child))
+    (set! (.-removeChild node)
+          (fn [child]
+            (let [idx (.indexOf (.-children node) child)]
+              (when (>= idx 0)
+                (.splice (.-children node) idx 1))
+              (set! (.-parentNode child) nil)
+              child)))
+    node))
+
+(defn- mk-stub-document []
+  (let [created (atom [])
+        body    (mk-stub-node)]
+    (js-obj
+     "body"
+     body
+     "createElement"
+     (fn [_tag]
+       (let [n (mk-stub-node)]
+         (swap! created conj n)
+         n))
+     ;; Test introspection — not part of the DOM API, but lets the
+     ;; assertions count nodes created during a run.
+     "_created"
+     created)))
+
+(defn- with-stub-document* [f]
+  (let [doc       (mk-stub-document)
+        had-doc?  (exists? js/document)
+        prior     (when had-doc? js/document)]
+    (set! js/document doc)
+    (try
+      (f doc)
+      (finally
+        (if had-doc?
+          (set! js/document prior)
+          (js-delete js/goog.global "document"))))))
+
+(defn- with-stub-document [f]
+  (with-stub-document* f))
+
+;; ---- substrate-render stub ----------------------------------------------
+;;
+;; The fixture installs `plain-atom/adapter` — its `:render` slot
+;; throws (per substrate/plain_atom.cljc line 39: render is not
+;; supported on the JVM/headless adapter). Real `open!` calls
+;; `(substrate-adapter/render [shell/shell-view] node nil)`; we
+;; intercept that delegation with `with-redefs` so the test never
+;; spins a React tree. The stub records its arguments + returns a
+;; sentinel unmount fn so `teardown!` has something to invoke and
+;; the assertion can verify it was called exactly once.
+
+(defn- mk-render-stub
+  "Build a stub for `substrate-adapter/render`. Returns
+  `{:render-fn ..., :calls (atom []), :unmount-calls (atom 0)}` so
+  tests can assert call counts. The render-fn signature matches the
+  contract: 3 args, returns an unmount fn."
+  []
+  (let [calls         (atom [])
+        unmount-calls (atom 0)
+        unmount-fn    (fn unmount-stub []
+                        (swap! unmount-calls inc)
+                        nil)]
+    {:render-fn     (fn render-stub [tree node opts]
+                      (swap! calls conj {:tree tree :node node :opts opts})
+                      unmount-fn)
+     :calls         calls
+     :unmount-calls unmount-calls
+     :unmount-fn    unmount-fn}))
+
+;; ---- fixtures -----------------------------------------------------------
+;;
+;; `reset-runtime-fixture` installs `plain-atom/adapter` and snapshots
+;; the registrar — same pattern preload_cljs_test.cljs uses. The
+;; per-test cleanup also resets the mount-state defonce so a failing
+;; transition test doesn't poison neighbours via stale singleton state.
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!)
+  (reset-mount-state!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; -------------------------------------------------------------------------
+;; (1) Predicates on a clean baseline
+;; -------------------------------------------------------------------------
+
+(deftest mounted?-and-visible?-are-false-on-clean-state
+  (testing "before any open!/teardown! cycle both predicates report false
+            — the fixture's reset-mount-state! puts the singleton back
+            at nil"
+    (is (false? (mount/mounted?))
+        "mounted? false when @mount-state is nil")
+    (is (false? (mount/visible?))
+        "visible? false when @mount-state is nil")))
+
+;; -------------------------------------------------------------------------
+;; (2) Open — first call (mount + show)
+;; -------------------------------------------------------------------------
+
+(deftest first-open!-creates-dom-node-and-renders
+  (testing "first open! creates a fresh <div id=\"rf-causa-root\"> under
+            document.body, delegates to substrate-adapter/render with
+            the shell-view tree and the new node, and marks visible"
+    (with-stub-document
+      (fn [doc]
+        (let [{:keys [render-fn calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (let [result (mount/open!)]
+              (is (some? result) "open! returns the mount-state map")
+              (is (map? result))
+              (is (= 1 (count @calls))
+                  "substrate-adapter/render invoked exactly once")
+              (let [{:keys [tree node opts]} (first @calls)]
+                (is (vector? tree) "render received a hiccup vector")
+                (is (some? node) "render received the mount node")
+                (is (nil? opts)
+                    "render called with nil opts (mount.cljs passes nil)")
+                (is (= "rf-causa-root" (.-id node))
+                    "the created div has id rf-causa-root")
+                (is (= 1 (.-length (.-children (.-body doc))))
+                    "the div was appended to document.body")
+                (is (identical? node (aget (.-children (.-body doc)) 0))
+                    "the appended child is the created node"))
+              (is (true? (mount/mounted?))
+                  "mounted? flips true after first open!")
+              (is (true? (mount/visible?))
+                  "visible? flips true after first open!"))))))))
+
+(deftest first-open!-leaves-display-at-browser-default
+  (testing "first open! creates the container WITHOUT explicitly
+            writing style.display — the source's create-mount-node!
+            leaves default block-level styling intact (the shell
+            handles its own position:fixed geometry). Only the
+            second open!-after-close! / toggle! show path writes
+            style.display=block via set-visible!"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (mount/open!)
+            (let [node (:node @@#'mount/mount-state)]
+              ;; The stub's default is "" — matches the browser's
+              ;; "no inline style" baseline. The point of the
+              ;; assertion is that mount.cljs does NOT touch the
+              ;; display property on first mount (re-mount via
+              ;; close+open will write "block" explicitly — see
+              ;; second-open!-does-not-re-render).
+              (is (= "" (.-display (.-style node)))
+                  "no explicit display written on first mount"))))))))
+
+;; -------------------------------------------------------------------------
+;; (3) Open — second call (already mounted; no re-render)
+;; -------------------------------------------------------------------------
+
+(deftest second-open!-does-not-re-render
+  (testing "calling open! when already mounted is a CSS-only show —
+            substrate-adapter/render is NOT invoked again, the
+            existing DOM node is reused, display flips back to block.
+            This is the <80ms toggle target the spec calls out:
+            re-rendering would discard internal shell state"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (let [first-state (mount/open!)
+                  first-node  (:node first-state)]
+              (is (= 1 (count @calls)) "first open! triggered one render")
+              ;; Flip to invisible so we can confirm the second open!
+              ;; flips it back to block.
+              (mount/close!)
+              (is (= "none" (.-display (.-style first-node))))
+              (let [second-state (mount/open!)]
+                (is (= 1 (count @calls))
+                    "second open! did NOT trigger another render")
+                (is (identical? first-node (:node second-state))
+                    "second open! reuses the same DOM node")
+                (is (= "block" (.-display (.-style first-node)))
+                    "second open! flips display back to block")
+                (is (true? (:visible? second-state))
+                    "second open! marks visible? true again")))))))))
+
+;; -------------------------------------------------------------------------
+;; (4) Close — hide without unmounting
+;; -------------------------------------------------------------------------
+
+(deftest close!-hides-but-retains-mount-state
+  (testing "close! flips display=none and visible?=false, but the
+            singleton + DOM node + unmount fn stay in place so a
+            subsequent open! is a CSS-only show"
+    (with-stub-document
+      (fn [doc]
+        (let [{:keys [render-fn calls unmount-calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (mount/open!)
+            (let [pre-close @@#'mount/mount-state]
+              (is (some? pre-close))
+              (mount/close!)
+              (let [post-close @@#'mount/mount-state]
+                (is (some? post-close)
+                    "mount-state retained (not nil'd) on close")
+                (is (false? (:visible? post-close))
+                    "visible? flipped to false in the singleton")
+                (is (= "none" (.-display (.-style (:node post-close))))
+                    "container.style.display = none")
+                (is (identical? (:node pre-close) (:node post-close))
+                    "same DOM node retained")
+                (is (= 0 @unmount-calls)
+                    "close! must NOT invoke the substrate unmount fn")
+                (is (= 1 (count @calls))
+                    "close! must NOT trigger a second render")
+                (is (= 1 (.-length (.-children (.-body doc))))
+                    "the node stays attached to document.body")))))))))
+
+(deftest close!-on-clean-state-is-safe
+  (testing "calling close! before any open! is a no-op — does not
+            throw, does not allocate state, returns nil"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (is (nil? (mount/close!))
+                "close! returns nil on clean state")
+            (is (nil? @@#'mount/mount-state)
+                "mount-state stays nil — close! did not allocate")
+            (is (zero? (count @calls))
+                "no render invocation triggered by close!")
+            (is (false? (mount/mounted?)))
+            (is (false? (mount/visible?)))))))))
+
+(deftest close!-after-close!-is-idempotent
+  (testing "close! when already hidden is a no-op — visible? stays
+            false, the DOM node is not re-styled (already display=none),
+            no second unmount fires"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn unmount-calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (mount/open!)
+            (mount/close!)
+            (is (false? (mount/visible?)))
+            (is (nil? (mount/close!))
+                "second close! returns nil")
+            (is (false? (mount/visible?))
+                "visible? remains false after two closes")
+            (is (= 0 @unmount-calls)
+                "still no unmount fn invocation")))))))
+
+;; -------------------------------------------------------------------------
+;; (5) Toggle — open + close + open round-trip
+;; -------------------------------------------------------------------------
+
+(deftest toggle!-mounts-on-first-call
+  (testing "toggle! on clean state behaves like open! — creates the
+            DOM node, renders, marks visible"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (mount/toggle!)
+            (is (= 1 (count @calls))
+                "first toggle! triggers a substrate render")
+            (is (true? (mount/visible?)) "shell is visible after toggle!")
+            (is (true? (mount/mounted?)) "shell is mounted after toggle!")))))))
+
+(deftest toggle!-hides-when-currently-visible
+  (testing "toggle! while visible is equivalent to close! — flips
+            visible? false, does NOT unmount"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn unmount-calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (mount/open!)
+            (is (true? (mount/visible?)))
+            (mount/toggle!)
+            (is (false? (mount/visible?))
+                "toggle! while visible flips to hidden")
+            (is (true? (mount/mounted?))
+                "mount-state retained")
+            (is (= 0 @unmount-calls)
+                "toggle!-as-close must not invoke unmount")))))))
+
+(deftest toggle!-shows-when-currently-hidden
+  (testing "toggle! while hidden is equivalent to a second open! —
+            flips visible? true, reuses the existing DOM node (no
+            re-render)"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (mount/open!)
+            (mount/close!)
+            (is (false? (mount/visible?)))
+            (mount/toggle!)
+            (is (true? (mount/visible?))
+                "toggle!-as-open flips visible? back true")
+            (is (= 1 (count @calls))
+                "the re-show did NOT trigger a second render")))))))
+
+(deftest toggle!-round-trips-cleanly-three-times
+  (testing "open → close → open → close → open via repeated toggle!
+            calls — render fires exactly once (lazy-mount affordance);
+            visible? toggles exactly with each call"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (mount/toggle!)  ;; #1 open
+            (is (true? (mount/visible?)))
+            (mount/toggle!)  ;; #2 close
+            (is (false? (mount/visible?)))
+            (mount/toggle!)  ;; #3 open
+            (is (true? (mount/visible?)))
+            (mount/toggle!)  ;; #4 close
+            (is (false? (mount/visible?)))
+            (mount/toggle!)  ;; #5 open
+            (is (true? (mount/visible?)))
+            (is (= 1 (count @calls))
+                "all five toggles share the single initial render —
+                 the substrate render must not fire on the four
+                 toggle-after-mount transitions")))))))
+
+;; -------------------------------------------------------------------------
+;; (6) Teardown — full destroy
+;; -------------------------------------------------------------------------
+
+(deftest teardown!-invokes-unmount-and-removes-node
+  (testing "teardown! invokes the substrate unmount fn returned at
+            render time, removes the DOM node from document.body, and
+            clears the singleton so a subsequent open! is back to
+            first-mount semantics"
+    (with-stub-document
+      (fn [doc]
+        (let [{:keys [render-fn unmount-calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (mount/open!)
+            (is (= 1 (.-length (.-children (.-body doc)))))
+            (let [pre-node (:node @@#'mount/mount-state)]
+              (mount/teardown!)
+              (is (= 1 @unmount-calls)
+                  "unmount fn invoked exactly once")
+              (is (nil? (.-parentNode pre-node))
+                  "the DOM node is detached from its parent")
+              (is (= 0 (.-length (.-children (.-body doc))))
+                  "document.body no longer carries the node")
+              (is (nil? @@#'mount/mount-state)
+                  "mount-state cleared back to nil")
+              (is (false? (mount/mounted?)))
+              (is (false? (mount/visible?))))))))))
+
+(deftest teardown!-after-open!-then-mount!-cycle
+  (testing "open → teardown → open: the second open! is a fresh
+            first-mount (new DOM node, fresh render call) — not a
+            CSS-only show. This is the distinction between close!
+            (which retains state) and teardown! (which destroys it)"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (mount/open!)
+            (let [first-node (:node @@#'mount/mount-state)]
+              (mount/teardown!)
+              (is (nil? @@#'mount/mount-state))
+              (mount/open!)
+              (let [second-node (:node @@#'mount/mount-state)]
+                (is (= 2 (count @calls))
+                    "teardown then open triggers a SECOND render —
+                     teardown destroys state so the next open is a
+                     fresh first-mount")
+                (is (not (identical? first-node second-node))
+                    "the second open allocates a new DOM node")))))))))
+
+(deftest teardown!-on-clean-state-is-safe
+  (testing "teardown! before any open! is a no-op — does not throw,
+            does not allocate, returns nil. Symmetric with close!'s
+            clean-state behaviour"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn unmount-calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (is (nil? (mount/teardown!)))
+            (is (nil? @@#'mount/mount-state))
+            (is (= 0 @unmount-calls)
+                "no unmount fn to invoke — the no-op posture must not
+                 invent calls")))))))
+
+(deftest teardown!-swallows-unmount-errors
+  (testing "if the substrate's unmount fn throws (mid-dispose race,
+            unmounted-already React error) teardown! still removes
+            the DOM node and clears the singleton. The source uses
+            (try (unmount) (catch :default _ nil)) for exactly this"
+    (with-stub-document
+      (fn [doc]
+        ;; Build a stub render that returns a throwing unmount.
+        (let [calls (atom [])]
+          (with-redefs [substrate-adapter/render
+                        (fn [tree node opts]
+                          (swap! calls conj [tree node opts])
+                          (fn throwing-unmount []
+                            (throw (ex-info "unmount blew up"
+                                            {:reason :test}))))]
+            (mount/open!)
+            (is (= 1 (count @calls)))
+            ;; teardown! must not propagate the unmount exception.
+            (is (nil? (mount/teardown!))
+                "teardown returns nil even when unmount throws")
+            (is (= 0 (.-length (.-children (.-body doc))))
+                "DOM node still removed despite the unmount throw")
+            (is (nil? @@#'mount/mount-state)
+                "singleton still cleared despite the unmount throw")))))))
+
+;; -------------------------------------------------------------------------
+;; (7) Missing-adapter gate — graceful no-op when no substrate installed
+;; -------------------------------------------------------------------------
+
+(deftest open!-without-adapter-is-silent-no-op
+  (testing "when no substrate adapter is installed (e.g. preload loaded
+            into a production bundle, or a host that never called
+            rf/init!), open! returns nil, does NOT create a DOM node,
+            does NOT mutate mount-state, does NOT call substrate
+            render. This is the silent-failure mode the source docs
+            describe — the user's Ctrl+Shift+C is a no-op until an
+            adapter installs"
+    (with-stub-document
+      (fn [doc]
+        (let [{:keys [render-fn calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            ;; Tear down the fixture's plain-atom install so
+            ;; current-adapter returns nil.
+            (substrate-adapter/dispose-adapter!)
+            (is (nil? (substrate-adapter/current-adapter))
+                "sanity — no adapter is currently installed")
+            (is (nil? (mount/open!))
+                "open! returns nil when no adapter is installed")
+            (is (nil? @@#'mount/mount-state)
+                "mount-state untouched — no singleton allocated")
+            (is (zero? (count @calls))
+                "substrate render was NOT called")
+            (is (zero? (.-length (.-children (.-body doc))))
+                "no <div> was appended to document.body")
+            (is (false? (mount/mounted?)))
+            (is (false? (mount/visible?)))))))))
+
+(deftest toggle!-without-adapter-is-silent-no-op
+  (testing "toggle! routes through open! when nothing is mounted; the
+            missing-adapter gate inside open! short-circuits the
+            allocation. The user pressing Ctrl+Shift+C with no adapter
+            installed must not throw"
+    (with-stub-document
+      (fn [doc]
+        (let [{:keys [render-fn calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (substrate-adapter/dispose-adapter!)
+            (is (nil? (mount/toggle!))
+                "toggle! returns nil rather than throwing")
+            (is (nil? @@#'mount/mount-state))
+            (is (zero? (count @calls)))
+            (is (zero? (.-length (.-children (.-body doc)))))))))))
+
+(deftest open!-recovers-after-adapter-installs-late
+  (testing "the missing-adapter posture is transient: once an adapter
+            is installed, the next open! proceeds normally. This
+            matters because the preload loads before the host's
+            rf/init! call in some hot-reload orderings — the listener
+            attaches, the first Ctrl+Shift+C is a no-op, but the
+            second (after init! runs) succeeds"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (substrate-adapter/dispose-adapter!)
+            (is (nil? (mount/open!)) "first open! is a no-op")
+            ;; Re-install — same plain-atom adapter the fixture had.
+            (substrate-adapter/install-adapter! plain-atom/adapter)
+            (let [result (mount/open!)]
+              (is (some? result) "second open! succeeds after install")
+              (is (= 1 (count @calls))
+                  "exactly one render — first open! was a true no-op")
+              (is (true? (mount/visible?))))))))))
+
+;; -------------------------------------------------------------------------
+;; (8) State-machine cross-checks
+;; -------------------------------------------------------------------------
+
+(deftest visible?-tracks-the-singleton-not-the-style
+  (testing "visible? reads the :visible? slot of the singleton, not
+            the DOM node's style.display. This matters because tests
+            (and production diagnostics) can rely on visible? without
+            paying the .-style lookup cost"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (mount/open!)
+            (is (true? (mount/visible?)))
+            ;; Forcibly mutate the singleton's :visible? slot — visible?
+            ;; must reflect the change immediately.
+            (swap! @#'mount/mount-state assoc :visible? false)
+            (is (false? (mount/visible?))
+                "visible? returns the singleton's :visible? slot")))))))
+
+(deftest mounted?-tracks-the-singleton-presence
+  (testing "mounted? is (some? @mount-state) — the predicate is true
+            whether the shell is currently visible or hidden, and
+            flips back to false only after teardown!"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (is (false? (mount/mounted?)) "clean baseline")
+            (mount/open!)
+            (is (true? (mount/mounted?)) "mounted? true after open!")
+            (mount/close!)
+            (is (true? (mount/mounted?))
+                "mounted? STAYS true after close! — only teardown! clears it")
+            (mount/open!)
+            (is (true? (mount/mounted?)))
+            (mount/teardown!)
+            (is (false? (mount/mounted?))
+                "mounted? flips back to false after teardown!")))))))


### PR DESCRIPTION
## Summary

Per rf2-5x20s (source rf2-otcbz audit, recommendation #6), adds dedicated tests for Causa's mount state machine. `tools/causa/src/day8/re_frame2_causa/mount.cljs` (123 LoC) had six untested public fns — `mounted?`, `visible?`, `open!`, `close!`, `toggle!`, `teardown!` — and a silent failure mode where `open!` is gated on `(substrate-adapter/current-adapter)` and no test exercised the missing-adapter path.

New file: `tools/causa/test/day8/re_frame2_causa/mount_cljs_test.cljs` (20 deftests / 92 assertions).

## Scenarios covered

1. **Clean baseline** — `mounted?` / `visible?` both false before any open.
2. **First open** — creates `<div id=\"rf-causa-root\">` under `document.body`, invokes `substrate-adapter/render` exactly once, marks `:visible? true`.
3. **First-mount display posture** — `create-mount-node!` does NOT explicitly set `style.display` (browser default applies).
4. **Second open (already mounted)** — no re-render; existing DOM node reused; `display` flips back to `block` via `set-visible!`.
5. **Close** — `display=none`, `:visible? false`, but singleton + DOM node + unmount fn retained.
6. **Close idempotency / safety** — close on clean state or after close: no-op, no throw.
7. **Toggle round-trip** — open → close → open → close → open: render fires exactly once; `visible?` toggles with each call.
8. **Teardown** — invokes substrate unmount fn, removes DOM node, clears singleton. Open-after-teardown is a fresh first-mount.
9. **Teardown safety** — clean-state teardown is no-op; teardown swallows unmount-fn exceptions and still clears state.
10. **Missing-adapter gate** — open with no adapter installed: returns nil, no DOM node, no state mutation, no render call. Toggle inherits same posture. Recovery: once an adapter installs, subsequent open succeeds.
11. **State-machine cross-checks** — `visible?` tracks the singleton slot; `mounted?` stays true through close cycles, only flips false after teardown.

Style mirrors `keybinding_cljs_test.cljs` (rf2-jbhm5 / PR #659) and `shell_cljs_test.cljs` (rf2-3lh6h / PR #652) — node-test lane with a hand-rolled `js/document` stub installed via `with-stub-document`, plus `with-redefs` on `substrate-adapter/render` so the test never depends on a real React tree. Fixture uses `test-support/reset-runtime-fixture` with `plain-atom/adapter` plus a `causa-init!` that resets the mount-state defonce between tests.

## Suite totals

- Before: 1665 tests / 4568 assertions
- After:  1685 tests / 4660 assertions
- Delta:  +20 tests / +92 assertions

## Test plan

- [x] `npm run test:cljs` from `implementation/` — 0 failures, 0 errors
- [x] `clojure -M:test` from `tools/causa/` — 487 tests / 1349 assertions, 0 failures (CLJS-only file not picked up by clojure runner, same as sibling `*_cljs_test.cljs` files)
- [x] No source files changed; only the new test file added