### PR TITLE
feat(ssr-ring): ship Ring/Pedestal host adapter for SSR boot (rf2-ny6v7)

### DIFF
--- a/implementation/deps.edn
+++ b/implementation/deps.edn
@@ -1,5 +1,6 @@
 ;; Top-level coordinator (rf2-0hxm; extended per rf2-p7va, rf2-xbtj,
-;; rf2-k682, rf2-tfw3, rf2-5kpd, rf2-uo7v, rf2-3yij, rf2-lt4e, rf2-2qit).
+;; rf2-k682, rf2-tfw3, rf2-5kpd, rf2-uo7v, rf2-3yij, rf2-lt4e, rf2-2qit,
+;; rf2-ny6v7).
 ;;
 ;; The published artefacts are
 ;;   - core/          (day8/re-frame2)
@@ -13,6 +14,7 @@
 ;;   - flows/    (day8/re-frame2-flows,    rf2-tfw3)
 ;;   - http/     (day8/re-frame2-http,     rf2-5kpd)
 ;;   - ssr/      (day8/re-frame2-ssr,      rf2-uo7v)
+;;   - ssr-ring/ (day8/re-frame2-ssr-ring, rf2-ny6v7)
 ;;   - epoch/    (day8/re-frame2-epoch,    rf2-lt4e)
 ;; see implementation/core/deps.edn,
 ;; implementation/adapters/reagent/deps.edn,
@@ -43,6 +45,7 @@
          day8/re-frame2-flows    {:local/root "flows"}
          day8/re-frame2-http     {:local/root "http"}
          day8/re-frame2-ssr      {:local/root "ssr"}
+         day8/re-frame2-ssr-ring {:local/root "ssr-ring"}
          day8/re-frame2-epoch    {:local/root "epoch"}}
 
  :aliases
@@ -61,6 +64,7 @@
                  "flows/test"
                  "http/test"
                  "ssr/test"
+                 "ssr-ring/test"
                  "epoch/test"
                  ;; Per rf2-kx74 examples are grouped per substrate. The
                  ;; combined :test alias loads every example tree onto

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -1,5 +1,6 @@
 ;; Top-level shadow-cljs build (rf2-0hxm; extended per rf2-p7va, rf2-xbtj,
-;; rf2-k682, rf2-tfw3, rf2-5kpd, rf2-uo7v, rf2-3yij, rf2-lt4e, rf2-2qit).
+;; rf2-k682, rf2-tfw3, rf2-5kpd, rf2-uo7v, rf2-3yij, rf2-lt4e, rf2-2qit,
+;; rf2-ny6v7).
 ;;
 ;; Pulls in every published artefact's source path (core/, reagent/,
 ;; uix/, helix/, schemas/, machines/, routing/, flows/, http/, ssr/,
@@ -43,6 +44,13 @@
                 "http/test"
                 "ssr/src"
                 "ssr/test"
+                ;; Per rf2-ny6v7 — ssr-ring is the Ring/Pedestal host
+                ;; adapter for SSR. JVM-only (Ring is JVM); shadow-cljs
+                ;; ignores .clj sources at compile time, so listing the
+                ;; path here only widens the classpath. Per-feature
+                ;; placement (flat under implementation/) per rf2-zha9.
+                "ssr-ring/src"
+                "ssr-ring/test"
                 "epoch/src"
                 "epoch/test"
                 ;; tools/story (re-frame2-story Stage 2, rf2-32dk).

--- a/implementation/ssr-ring/deps.edn
+++ b/implementation/ssr-ring/deps.edn
@@ -1,0 +1,76 @@
+;; day8/re-frame2-ssr-ring — Ring/Pedestal host adapter (rf2-ny6v7).
+;;
+;; Per Spec 011 §HTTP response contract: "the host adapter is
+;; responsible for materialising :response into the wire format its
+;; server framework expects (Ring map, Express response, Fastify reply,
+;; etc.). The runtime never writes to a network socket directly — the
+;; response shape is the contract; transport is the host's concern."
+;;
+;; This artefact is that host adapter for Ring. It supplies the
+;; `ssr-handler` fn — a Ring-shaped (req → resp) handler that per
+;; request:
+;;
+;;   1. Creates a per-request frame via re-frame.core/make-frame with
+;;      :platform :server and an :on-create event the caller supplies.
+;;   2. Awaits the dispatch-queue drain (synchronous on the JVM —
+;;      `make-frame` returns post-drain per Spec 002 §dispatch).
+;;   3. Reads the resolved response accumulator via
+;;      re-frame.ssr/get-response (which flushes pending error
+;;      projections before reading).
+;;   4. Short-circuits when :redirect is set (no body; Location header).
+;;   5. Otherwise renders the root view to HTML via render-to-string,
+;;      builds the hydration payload, and wraps in an HTML envelope.
+;;   6. Materialises :cookies → Set-Cookie wire form per RFC 6265.
+;;   7. Destroys the per-request frame in a `finally` block.
+;;
+;; Plus an `ssr-middleware` fn for composing with other Ring middlewares,
+;; and the binding site for the `*current-request*` var the
+;; `:rf.server/request` cofx (rf2-e825b) reads from.
+;;
+;; Consumers add this artefact alongside core and ssr:
+;;
+;;   {:deps {day8/re-frame2          {:mvn/version "..."}
+;;           day8/re-frame2-ssr      {:mvn/version "..."}
+;;           day8/re-frame2-ssr-ring {:mvn/version "..."}}}
+;;
+;; And require `re-frame.ssr.ring` in any namespace that wires the
+;; runtime up to a Ring server (Jetty, HttpKit, Pedestal, Reitit-ring).
+;;
+;; Per Spec 006 §Adapter shipping convention and the rf2-p7va extension
+;; to per-feature splits: this artefact depends on core + ssr; neither
+;; depends on this artefact. Pedestal/HttpKit variants would be additive
+;; sibling artefacts (ssr-pedestal, ssr-httpkit) sharing the same
+;; per-request contract.
+{:paths ["src"]
+ :deps  {day8/re-frame2     {:local/root "../core"}
+         day8/re-frame2-ssr {:local/root "../ssr"}}
+
+ :aliases
+ {:test {:extra-paths ["test"]
+         ;; Mirrors implementation/ssr/deps.edn :test alias — schemas /
+         ;; flows / routing / machines load at ns-load time and the
+         ;; reset-runtime fixture reloads them after registrar/clear-all!.
+         :extra-deps  {day8/re-frame2-schemas  {:local/root "../schemas"}
+                       day8/re-frame2-flows    {:local/root "../flows"}
+                       day8/re-frame2-routing  {:local/root "../routing"}
+                       day8/re-frame2-machines {:local/root "../machines"}
+                       io.github.cognitect-labs/test-runner
+                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+         :main-opts   ["-m" "cognitect.test-runner"]}
+
+  ;; Clojars deploy (rf2-r382). Modeled on the per-feature artefacts.
+  ;; The release workflow swaps :local/root → :mvn/version before
+  ;; invoking clein.
+  :clein {:extra-deps {io.github.noahtheduke/clein
+                       {:git/url "https://github.com/day8/clein.git"
+                        :git/sha "2b83503246e8291fc023d688574640a9b23d8c50"}}
+          :main-opts  ["-m" "noahtheduke.clein"]}
+
+  :clein/build
+  {:lib      day8/re-frame2-ssr-ring
+   :main     re-frame.ssr.ring
+   :url      "https://github.com/day8/re-frame2"
+   :version  "../../VERSION"
+   :license  {:name "MIT"
+              :url  "https://opensource.org/licenses/MIT"}
+   :src-dirs ["src"]}}}

--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -1,0 +1,516 @@
+(ns re-frame.ssr.ring
+  "Ring/Pedestal host adapter for re-frame2 SSR. Per Spec 011 §HTTP
+  response contract and the rf2-ny6v7 host-adapter brief.
+
+  Spec 011 §357–363 names the host adapter as the layer responsible for
+  materialising the runtime's `:response` accumulator into the wire
+  format its server framework expects. The SSR runtime never writes to
+  a network socket directly; it owns the request lifecycle (frame
+  create → drain → response read → frame destroy) and a structured
+  response shape; the host adapter wires that shape to a real HTTP
+  server.
+
+  This namespace ships that adapter for Ring (https://github.com/ring-clojure).
+  Ring is the canonical Clojure HTTP-server abstraction; the
+  request/response maps documented at the Ring Concepts wiki page
+  (`:status`, `:headers`, `:body` on responses; `:uri`,
+  `:request-method`, `:headers`, etc. on requests) are the wire shape
+  this adapter consumes and produces. Pedestal, HttpKit, Reitit-ring,
+  and Jetty all accept Ring-shaped handlers, so a single adapter covers
+  the bulk of the Clojure HTTP ecosystem.
+
+  Public surface:
+
+    (ssr-handler opts)  → ring-handler-fn
+    (ssr-middleware opts) → ((handler) → wrapped-handler)
+    *current-request*   — dynamic var bound for the duration of each
+                          request; the `:rf.server/request` cofx
+                          (rf2-e825b) reads from this binding.
+
+  Per-request flow inside `ssr-handler`:
+
+    1. Bind `*current-request*` to the Ring request map.
+    2. Build a per-request server frame via `(rf/make-frame ...)`
+       with `:platform :server`, the caller's :on-create event (with
+       the request map conj'd as an argument), and the caller's
+       optional :fx-overrides / :ssr config.
+    3. The drain runs synchronously inside make-frame's :on-create
+       dispatch path (Spec 002 §dispatch).
+    4. Read the response accumulator via `ssr/get-response` (flushes
+       any pending error projection per Spec 011 §Server error
+       projection).
+    5. If :redirect is set on the response, emit a Ring response with
+       just status + Location header — no body, no payload (Spec 011
+       §Redirect precedence step 4).
+    6. Otherwise render the caller's `:root-view` against the frame
+       (with-frame binds *current-frame* across the render), wrap in
+       the caller's `:html-shell` envelope, and emit a Ring response
+       with status / headers / body.
+    7. Materialise structured cookies to Set-Cookie headers per
+       RFC 6265 — re-frame.ssr stores cookies as structured maps
+       (Spec 011 §Cookie shape); the host adapter is where the wire
+       string is built so user code never touches the per-attribute
+       quoting / encoding pitfalls.
+    8. Destroy the per-request frame in a `finally` block — pending
+       :dispatch-later calls, sub-cache reactions, and trace-buffer
+       state all release on destroy (Spec 002 §Destroy).
+
+  Coordination with rf2-e825b (`:rf.server/request` cofx):
+
+    rf2-e825b lands the cofx itself; this adapter is the binding site.
+    The cofx reads from `re-frame.ssr.ring/*current-request*`; this
+    namespace binds the var per request. If rf2-e825b hasn't merged
+    yet, the binding is a harmless no-op — handlers that try to read
+    via `(inject-cofx :rf.server/request)` get nil until the cofx
+    lands.
+
+  Out of scope here (deferred / other beads):
+
+    - Streaming SSR (rf2-olb64)            — `render-to-string` is
+                                             a single-shot emitter; this
+                                             adapter mirrors that.
+    - Async Ring handler (3-arity)         — synchronous-only in v1;
+                                             extension is additive.
+    - reg-head / render-head integration   — deferred per rf2-gr0n;
+                                             the v1 html-shell is the
+                                             escape hatch."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.ssr :as ssr])
+  (:import [java.net URLEncoder]
+           [java.nio.charset StandardCharsets]
+           [java.time Instant ZoneOffset ZonedDateTime]
+           [java.time.format DateTimeFormatter]))
+
+;; ---- *current-request* — rf2-e825b binding site ---------------------------
+
+(def ^:dynamic *current-request*
+  "The active Ring request map, bound for the duration of one HTTP
+  request inside `ssr-handler` / `ssr-middleware`. The
+  `:rf.server/request` cofx (rf2-e825b — `re-frame.ssr` registers the
+  cofx itself; the host adapter is the binding site) reads from this
+  var. nil outside an SSR request."
+  nil)
+
+;; ---- cookie serialisation (RFC 6265) -------------------------------------
+;;
+;; Per Spec 011 §Cookie shape, re-frame.ssr stores cookies as structured
+;; maps and lets the host adapter materialise the Set-Cookie wire string.
+;; This intentionally keeps the per-attribute quoting / encoding details
+;; out of user code.
+
+(def ^:private ^DateTimeFormatter rfc1123-formatter
+  ;; Set-Cookie's :Expires uses RFC 7231 IMF-fixdate (a fixed-format
+  ;; subset of RFC 1123): "Sun, 06 Nov 1994 08:49:37 GMT".
+  (.withZone DateTimeFormatter/RFC_1123_DATE_TIME ZoneOffset/UTC))
+
+(defn- url-encode
+  "URL-encode a cookie value. java.net.URLEncoder emits `+` for space
+  (form-encoded shape, RFC 1866), but RFC 6265 cookie values follow
+  RFC 3986 percent-encoding — space is `%20`. Post-process the
+  form-encoded output to convert `+` back to `%20` so the wire shape is
+  RFC-3986-clean."
+  [s]
+  (-> (URLEncoder/encode (str s) (.name StandardCharsets/UTF_8))
+      (str/replace "+" "%20")))
+
+(defn- same-site-token [v]
+  (case v
+    :strict "Strict"
+    :lax    "Lax"
+    :none   "None"
+    ;; tolerant of string-shaped values
+    (cond
+      (string? v) v
+      (keyword? v) (str/capitalize (name v))
+      :else (str v))))
+
+(defn cookie->set-cookie-header
+  "Serialise one re-frame.ssr cookie map to a Set-Cookie header value
+  per RFC 6265 §4.1. Per Spec 011 §Cookie shape — the cookie's :name /
+  :value are required; everything else is an attribute appended after
+  semicolons. The :value is URL-encoded.
+
+  Public surface so tests, alt host adapters (Pedestal, HttpKit), and
+  user code that needs a one-off serialisation can call it directly."
+  [{:keys [name value max-age secure http-only same-site path domain expires]
+    :as cookie}]
+  (when (nil? name)
+    (throw (ex-info ":rf.error/cookie-missing-name"
+                    {:reason "cookie map must carry :name"
+                     :cookie cookie})))
+  (let [parts (cond-> [(str (clojure.core/name name)
+                            "="
+                            (url-encode (or value "")))]
+                ;; Order doesn't matter to the RFC, but the canonical
+                ;; serving order in most libraries is:
+                ;;   Max-Age, Domain, Path, Expires, Secure, HttpOnly, SameSite
+                (some? max-age)  (conj (str "Max-Age=" max-age))
+                (some? domain)   (conj (str "Domain=" domain))
+                (some? path)     (conj (str "Path=" path))
+                (some? expires)
+                (conj (str "Expires="
+                           (.format rfc1123-formatter
+                                    (ZonedDateTime/ofInstant
+                                      (Instant/ofEpochMilli expires)
+                                      ZoneOffset/UTC))))
+                (true? secure)    (conj "Secure")
+                (true? http-only) (conj "HttpOnly")
+                (some? same-site) (conj (str "SameSite=" (same-site-token same-site))))]
+    (str/join "; " parts)))
+
+;; ---- header materialisation ----------------------------------------------
+;;
+;; re-frame.ssr stores headers internally as an ordered vector of
+;; [name value] pairs (case-insensitive name match). Ring accepts
+;; headers as a map of name → string OR name → vector-of-strings;
+;; multiple values under one name go via a vector. We collapse repeated
+;; pairs into vectors so multi-valued headers (Set-Cookie, Vary,
+;; Link, ...) round-trip correctly.
+
+(defn- merge-pair-into-header-map [m [k v]]
+  (let [existing (get m k)]
+    (cond
+      (nil? existing)        (assoc m k v)
+      (string? existing)     (assoc m k [existing v])
+      (vector? existing)     (assoc m k (conj existing v))
+      :else                  (assoc m k [existing v]))))
+
+(defn- headers->ring-map
+  "Collapse an ordered vec-of-[name value] pairs into Ring's
+  `{name string-or-vec}` shape, preserving the multi-valued case."
+  [pairs]
+  (reduce merge-pair-into-header-map {} pairs))
+
+(defn- append-set-cookies
+  "For every cookie map in the response's :cookies vector, append one
+  Set-Cookie header to the headers map. Returns the updated headers
+  map."
+  [headers-map cookies]
+  (reduce
+    (fn [m cookie]
+      (merge-pair-into-header-map m ["Set-Cookie"
+                                     (cookie->set-cookie-header cookie)]))
+    headers-map
+    cookies))
+
+;; ---- response materialisation --------------------------------------------
+
+(defn- ssr-response->ring-response
+  "Materialise the runtime's resolved response accumulator (per
+  Spec 011 §HTTP response contract) into a Ring response map. The
+  `:body` arg is the rendered HTML (or nil for redirect-only
+  responses). `:redirect` short-circuits per Spec 011 §Redirect
+  precedence — status + Location header, no body."
+  [{:keys [status headers cookies redirect]} body]
+  (if redirect
+    (let [{:keys [location url to] redirect-status :status} redirect
+          target (or location url to)]
+      {:status  (or redirect-status status 302)
+       :headers (-> (headers->ring-map headers)
+                    (append-set-cookies cookies)
+                    (cond-> target (assoc "Location" target)))
+       :body    ""})
+    {:status  (or status 200)
+     :headers (-> (headers->ring-map headers)
+                  (append-set-cookies cookies))
+     :body    (or body "")}))
+
+;; ---- html shell ----------------------------------------------------------
+;;
+;; A small, sane default. Users with their own envelope (custom
+;; `<head>`, asset-hash-pinned `<script>` tags, JSON-LD blocks, ...)
+;; pass an :html-shell option to override. The default exists so a
+;; first-time user gets a working SSR endpoint without writing string
+;; concatenation glue.
+
+(defn default-html-shell
+  "The default HTML envelope. Returns a string wrapping the rendered
+  body in a minimal-but-runnable document. Override via `:html-shell`
+  in `ssr-handler` opts when you need custom <head> / scripts / styles.
+
+  Args:
+    body-html — the string returned by re-frame.ssr/render-to-string
+    payload-edn — the hydration payload, pre-serialised with pr-str
+    opts — the caller's adapter opts (merged with any per-request
+           overrides); standard keys :title / :head / :body-end /
+           :script-src / :app-element-id influence the envelope."
+  [body-html payload-edn
+   {:keys [title head body-end script-src app-element-id lang]
+    :or   {title           "re-frame2 app"
+           app-element-id  "app"
+           script-src      "/main.js"
+           lang            "en"}}]
+  (str "<!DOCTYPE html>"
+       "<html lang=\"" lang "\">"
+       "<head>"
+       "<meta charset=\"utf-8\">"
+       "<title>" title "</title>"
+       (or head "")
+       "</head>"
+       "<body>"
+       "<div id=\"" app-element-id "\">" body-html "</div>"
+       "<script id=\"__rf_payload\" type=\"application/edn\">"
+       payload-edn
+       "</script>"
+       (when script-src
+         (str "<script src=\"" script-src "\"></script>"))
+       (or body-end "")
+       "</body>"
+       "</html>"))
+
+;; ---- payload construction ------------------------------------------------
+
+(defn- build-payload
+  "Per Spec 011 §The hydration payload — emit the four canonical keys
+  (`:rf/version`, `:rf/frame-id`, `:rf/app-db`, `:rf/render-hash`)
+  plus the optional `:rf/schema-digest`. Schema-digest is supplied
+  by the caller when their app participates in the schema-digest
+  check; nil otherwise. `:or` defaults at destructure don't fire
+  when an explicit nil flows in, so use `or` at the call site to
+  default the version."
+  [frame-id app-db render-hash {:keys [version schema-digest payload-keys]}]
+  (let [db-slice (if (seq payload-keys)
+                   (select-keys app-db payload-keys)
+                   app-db)]
+    (cond-> {:rf/version     (or version 1)
+             :rf/frame-id    frame-id
+             :rf/app-db      db-slice
+             :rf/render-hash render-hash}
+      schema-digest (assoc :rf/schema-digest schema-digest))))
+
+;; ---- handler -------------------------------------------------------------
+
+(defn- destroy-frame-quietly!
+  "Best-effort frame teardown. Exceptions during destroy must not mask
+  a real handler error; swallow + log to the trace stream is preferred
+  over propagation."
+  [frame-id]
+  (try
+    (rf/destroy-frame frame-id)
+    (catch Throwable _ nil)))
+
+(defn- render-body
+  "Render the root view against the per-request frame. Wrapped here so
+  view-time exceptions can be projected through the SSR error path
+  per Spec 011 §View-time exceptions. Returns the HTML string."
+  [frame-id root-view emit-hash?]
+  (rf/with-frame frame-id
+    (let [hiccup (cond
+                   (vector? root-view) root-view
+                   (fn?     root-view) (root-view)
+                   :else
+                   (throw (ex-info ":rf.error/invalid-root-view"
+                                   {:reason   "root-view must be a hiccup vector or a 0-arity fn"
+                                    :received root-view})))]
+      (ssr/render-to-string hiccup {:doctype?   false
+                                    :emit-hash? emit-hash?}))))
+
+(defn- render-hash-for
+  "Compute the structural render-tree hash. Mirrors render-body's
+  root-view resolution so the payload's :rf/render-hash matches the
+  data-rf-render-hash embedded in the wire HTML."
+  [frame-id root-view]
+  (rf/with-frame frame-id
+    (let [hiccup (if (fn? root-view) (root-view) root-view)]
+      (ssr/render-tree-hash hiccup))))
+
+(defn- on-create-with-request
+  "Conj the Ring request map onto the caller's :on-create event vector
+  so handlers can read it as an event arg. The `:rf.server/request`
+  cofx (rf2-e825b) is the canonical read path; this is the fallback
+  for handlers that don't inject the cofx and want the request as a
+  positional arg, matching the worked example in
+  examples/reagent/ssr/core.cljc."
+  [on-create request]
+  (cond
+    (nil? on-create)    nil
+    (vector? on-create) (conj on-create request)
+    :else
+    (throw (ex-info ":rf.error/invalid-on-create"
+                    {:reason   ":on-create must be a vector (event)"
+                     :received on-create}))))
+
+(defn ssr-handler
+  "Return a Ring-shaped (synchronous) handler that renders one
+  re-frame2 SSR request per call.
+
+  Required opts:
+
+    :on-create   — the event vector dispatched at frame creation. The
+                   Ring request map is conj'd as the last arg so handlers
+                   can read it positionally (and via the
+                   `:rf.server/request` cofx once rf2-e825b lands).
+    :root-view   — either a hiccup vector (e.g. `[:app/root]`) OR a
+                   0-arity fn returning hiccup. Rendered against the
+                   per-request frame after the drain settles.
+
+  Optional opts:
+
+    :fx-overrides   — per-frame `:fx-overrides` map, passed through
+                      verbatim to `(rf/make-frame ...)`. Useful for
+                      stubbing `:rf.http/managed` during tests.
+    :ssr            — per-frame `:ssr` config map (e.g.
+                      `{:dev-error-detail? true
+                        :public-error-id   :myapp/projector}`).
+    :emit-hash?     — embed `data-rf-render-hash` on the root element
+                      (default true).
+    :version        — hydration payload's `:rf/version` (default 1).
+    :schema-digest  — hydration payload's `:rf/schema-digest`, when
+                      the app participates in the digest check.
+    :payload-keys   — coll of top-level app-db keys to ship in the
+                      payload's `:rf/app-db`. Default: ship the whole
+                      app-db. Use to slice large per-request state
+                      down to what the client genuinely needs.
+    :html-shell     — (body-html payload-edn opts) → string. Defaults
+                      to `default-html-shell`. Replace to inject custom
+                      <head>, scripts, JSON-LD, etc.
+    :content-type   — Content-Type header for HTML responses. Default
+                      \"text/html; charset=utf-8\" (matches the SSR
+                      runtime's default in the response accumulator).
+    :on-error       — (request throwable) → ring-response. Called when
+                      the per-request frame setup OR render throws.
+                      Defaults to a minimal 500 response. The SSR
+                      runtime's error projector handles trace-emitted
+                      errors during drain; this hook covers the
+                      exceptions the projector can't see (Ring-layer
+                      throws, render-time CLJ exceptions).
+
+  Returns:
+
+    (fn handler [ring-request] ring-response)
+
+  Per-request lifecycle (see ns docstring for full detail):
+
+    bind *current-request*
+      → make-frame                  (drains :on-create synchronously)
+        → read get-response          (flushes error projections)
+        → branch on :redirect
+        → render-to-string + payload
+        → materialise to Ring map
+      → finally: destroy-frame!
+
+  Example:
+
+    (require '[ring.adapter.jetty :as jetty]
+             '[re-frame.core :as rf]
+             '[re-frame.ssr.ring :as ssr-ring])
+
+    (rf/init! (requiring-resolve 'ssr-ring-app/ssr-adapter))
+    (def handler
+      (ssr-ring/ssr-handler {:on-create [:rf/server-init]
+                             :root-view [:app/root]
+                             :html-shell ssr-ring-app/shell}))
+    (jetty/run-jetty handler {:port 3000 :join? false})"
+  [{:keys [on-create root-view fx-overrides ssr-config emit-hash?
+           version schema-digest payload-keys html-shell content-type
+           on-error]
+    :or   {emit-hash?    true
+           html-shell    default-html-shell
+           content-type  "text/html; charset=utf-8"
+           on-error      (fn default-on-error [_req ^Throwable t]
+                           {:status  500
+                            :headers {"Content-Type" "text/plain; charset=utf-8"}
+                            :body    (str "SSR error: " (.getMessage t))})}
+    :as   opts}]
+  (when-not on-create
+    (throw (ex-info ":rf.error/ssr-ring-missing-on-create"
+                    {:reason "ssr-handler requires :on-create (an event vector)"})))
+  (when-not root-view
+    (throw (ex-info ":rf.error/ssr-ring-missing-root-view"
+                    {:reason "ssr-handler requires :root-view (a hiccup vector or 0-arity fn)"})))
+  (fn ring-handler [request]
+    (binding [*current-request* request]
+      (let [frame-id
+            (try
+              (rf/make-frame
+                (cond-> {:doc       "ssr-ring per-request frame"
+                         :platform  :server
+                         :on-create (on-create-with-request on-create request)}
+                  fx-overrides (assoc :fx-overrides fx-overrides)
+                  ssr-config   (assoc :ssr           ssr-config)))
+              (catch Throwable t
+                (on-error request t)))]
+        (cond
+          ;; on-error returned a Ring response (frame creation threw).
+          (map? frame-id) frame-id
+
+          (nil? frame-id)
+          (on-error request (ex-info ":rf.error/ssr-ring-make-frame-returned-nil"
+                                     {:reason "make-frame returned nil"}))
+
+          :else
+          (try
+            (let [response (ssr/get-response frame-id)
+                  ;; rf/get-frame-db returns the value (plain map), not
+                  ;; the container. Per
+                  ;; implementation/core/src/re_frame/core.cljc:889 —
+                  ;; value-form accessor; no deref needed.
+                  app-db   (rf/get-frame-db frame-id)]
+              (cond
+                ;; Redirect — short-circuit per Spec 011 §Redirect precedence.
+                (some? (:redirect response))
+                (ssr-response->ring-response response nil)
+
+                :else
+                (let [body-html   (render-body frame-id root-view emit-hash?)
+                      hash-str    (render-hash-for frame-id root-view)
+                      payload     (build-payload frame-id app-db hash-str
+                                                 {:version       version
+                                                  :schema-digest schema-digest
+                                                  :payload-keys  payload-keys})
+                      payload-edn (pr-str payload)
+                      html        (html-shell body-html payload-edn opts)
+                      ;; Ensure Content-Type is set; the SSR runtime
+                      ;; defaults [:rf/response :headers] to include
+                      ;; content-type so this is usually a no-op, but
+                      ;; we let opts override and we trust the runtime's
+                      ;; default in absence.
+                      response*   (update response :headers
+                                          (fn [pairs]
+                                            (let [m (headers->ring-map pairs)]
+                                              (if (or (get m "content-type")
+                                                      (get m "Content-Type"))
+                                                pairs
+                                                (conj (vec pairs)
+                                                      ["Content-Type" content-type])))))]
+                  (ssr-response->ring-response response* html))))
+            (catch Throwable t
+              (on-error request t))
+            (finally
+              (destroy-frame-quietly! frame-id))))))))
+
+;; ---- middleware ----------------------------------------------------------
+
+(defn ssr-middleware
+  "Return Ring middleware that delegates to `ssr-handler` for the
+  requests its `:match?` predicate accepts, and to the wrapped handler
+  otherwise.
+
+  Useful when SSR is one of several handlers in a Ring stack — e.g.
+  static-asset middleware in front, JSON-API routes alongside.
+
+  Opts are `ssr-handler`'s opts plus:
+
+    :match?  — (request) → boolean. When truthy, SSR renders. When
+               falsy, the call falls through to the wrapped handler.
+               Default: matches every GET request.
+
+  Example:
+
+    (def app
+      (-> default-handler
+          (ssr-ring/ssr-middleware
+            {:on-create [:rf/server-init]
+             :root-view [:app/root]
+             :match? (fn [req] (= :get (:request-method req)))})
+          wrap-static-assets))"
+  [{:keys [match?] :as opts}]
+  (let [match? (or match? (fn default-match? [req]
+                            (= :get (:request-method req))))
+        ssr   (ssr-handler (dissoc opts :match?))]
+    (fn middleware [handler]
+      (fn wrapped [request]
+        (if (match? request)
+          (ssr request)
+          (handler request))))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -1,0 +1,381 @@
+(ns re-frame.ssr.ring-test
+  "End-to-end tests for the Ring host adapter (rf2-ny6v7).
+
+  Mirrors the shape of implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+  — synthesises a Ring request, invokes the handler, asserts on the
+  Ring response, then on the frame-lifecycle side-effects (destroyed?,
+  trace events).
+
+  Each test resets the runtime exactly the way the ssr artefact's
+  test fixture does (registrar/clear-all! → reload ns)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.flows :as flows]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.ssr :as ssr]
+            [re-frame.ssr.ring :as ssr-ring]))
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (rf/init! ssr/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr     :reload)
+  (require 're-frame.machines :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ===========================================================================
+;; Cookie serialisation (RFC 6265)
+;; ===========================================================================
+
+(deftest cookie-set-cookie-header-canonical
+  (testing "minimal cookie: name + value only"
+    (is (= "session=abc123"
+           (ssr-ring/cookie->set-cookie-header
+             {:name "session" :value "abc123"}))))
+
+  (testing "value gets URL-encoded"
+    (is (= "session=a%20b%26c"
+           (ssr-ring/cookie->set-cookie-header
+             {:name "session" :value "a b&c"}))))
+
+  (testing "full attribute set in canonical order"
+    (let [s (ssr-ring/cookie->set-cookie-header
+              {:name      "session"
+               :value     "abc"
+               :max-age   3600
+               :secure    true
+               :http-only true
+               :same-site :lax
+               :path      "/"
+               :domain    "example.com"})]
+      (is (str/starts-with? s "session=abc"))
+      (is (str/includes? s "Max-Age=3600"))
+      (is (str/includes? s "Domain=example.com"))
+      (is (str/includes? s "Path=/"))
+      (is (str/includes? s "Secure"))
+      (is (str/includes? s "HttpOnly"))
+      (is (str/includes? s "SameSite=Lax"))))
+
+  (testing "same-site tokens map to canonical strings"
+    (is (str/includes? (ssr-ring/cookie->set-cookie-header
+                         {:name "s" :value "" :same-site :strict})
+                       "SameSite=Strict"))
+    (is (str/includes? (ssr-ring/cookie->set-cookie-header
+                         {:name "s" :value "" :same-site :none})
+                       "SameSite=None")))
+
+  (testing "missing :name raises a structured error"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (ssr-ring/cookie->set-cookie-header {:value "abc"})))))
+
+;; ===========================================================================
+;; ssr-handler — happy path (Ring-level smoke)
+;; ===========================================================================
+
+(defn- register-articles-app! [articles]
+  (rf/reg-fx :http/get
+    {:platforms #{:server :client}}
+    (fn [_ _] nil))
+
+  (rf/reg-fx :http/get.canned
+    {:platforms #{:server :client}}
+    (fn [{:keys [frame]} {:keys [on-success]}]
+      (when on-success
+        (rf/dispatch (conj on-success articles) {:frame frame}))))
+
+  (rf/reg-event-fx :rf/server-init
+    {:platforms #{:server}}
+    (fn [{:keys [db]} [_ request]]
+      {:db (assoc db :request request)
+       :fx [[:http/get {:url        "/api/articles"
+                        :on-success [:articles/loaded]}]]}))
+
+  (rf/reg-event-db :articles/loaded
+    (fn [db [_ articles]]
+      (assoc db :articles articles)))
+
+  (rf/reg-sub :articles (fn [db _] (:articles db)))
+
+  (rf/reg-view* :pages/articles
+    (fn []
+      (let [arts (rf/subscribe-value [:articles])]
+        [:div.page
+         [:h1 "Articles"]
+         (into [:ul]
+               (for [{:keys [id title]} arts]
+                 ^{:key id} [:li title]))]))))
+
+(deftest handler-renders-html-with-status-and-headers
+  (testing "handler emits 200, content-type, and HTML body carrying view content"
+    (register-articles-app! [{:id "a" :title "Article A"}
+                             {:id "b" :title "Article B"}])
+
+    (let [handler (ssr-ring/ssr-handler
+                    {:on-create    [:rf/server-init]
+                     :root-view    [:pages/articles]
+                     :fx-overrides {:http/get :http/get.canned}})
+          request {:uri            "/articles"
+                   :request-method :get
+                   :headers        {"user-agent" "test"}}
+          response (handler request)]
+
+      (is (= 200 (:status response))
+          "default response status is 200")
+      (let [headers (:headers response)
+            ct      (or (get headers "content-type")
+                        (get headers "Content-Type"))]
+        (is (some? ct))
+        (is (str/includes? ct "text/html"))
+        (is (str/includes? ct "utf-8")))
+      (let [body (:body response)]
+        (is (string? body))
+        (is (str/includes? body "<!DOCTYPE html>"))
+        (is (str/includes? body "Article A"))
+        (is (str/includes? body "Article B"))
+        (is (str/includes? body "<script id=\"__rf_payload\""))
+        (is (str/includes? body "data-rf-render-hash")
+            "root element carries the structural hash for hydration-mismatch check")))))
+
+;; ===========================================================================
+;; ssr-handler — frame lifecycle (create + destroy)
+;; ===========================================================================
+
+(deftest handler-creates-and-destroys-per-request-frame
+  (testing "every request creates a fresh frame and destroys it before returning"
+    (register-articles-app! [{:id "x" :title "Article X"}])
+    (let [destroyed (atom [])
+          _ (rf/register-trace-cb! ::destroy-watch
+              (fn [ev]
+                (when (= :frame/destroyed (:operation ev))
+                  (swap! destroyed conj (:frame ev)))))
+          handler (ssr-ring/ssr-handler
+                    {:on-create    [:rf/server-init]
+                     :root-view    [:pages/articles]
+                     :fx-overrides {:http/get :http/get.canned}})
+          frames-before (set (rf/frame-ids))
+          response (handler {:uri "/" :request-method :get})
+          frames-after (set (rf/frame-ids))]
+      (rf/remove-trace-cb! ::destroy-watch)
+      (is (= 200 (:status response)))
+      ;; No per-request frame leaks into the global frame registry.
+      ;; Some destroy-trace-side-channel frame-ids must have been
+      ;; recorded — i.e. the handler did create + destroy at least one
+      ;; per-request frame.
+      (is (= frames-before frames-after)
+          "the per-request frame is removed from the registry after destroy")
+      (is (seq @destroyed)
+          ":frame/destroyed trace fired for the per-request frame"))))
+
+;; ===========================================================================
+;; ssr-handler — redirect short-circuit
+;; ===========================================================================
+
+(deftest handler-redirect-short-circuits
+  (testing ":rf.server/redirect emits status + Location with empty body"
+    (rf/reg-event-fx :init/redirect
+      {:platforms #{:server}}
+      (fn [_ _]
+        {:fx [[:rf.server/redirect {:status 302 :location "/login"}]]}))
+
+    (rf/reg-view* :pages/should-not-render
+      (fn [] [:div "should not render under redirect"]))
+
+    (let [handler (ssr-ring/ssr-handler
+                    {:on-create [:init/redirect]
+                     :root-view [:pages/should-not-render]})
+          response (handler {:uri "/secret" :request-method :get})]
+      (is (= 302 (:status response)))
+      (let [headers (:headers response)
+            loc     (or (get headers "Location") (get headers "location"))]
+        (is (= "/login" loc)))
+      (is (= "" (:body response))
+          "redirect short-circuits — no body, no payload script")
+      (is (not (str/includes? (:body response) "should not render"))))))
+
+;; ===========================================================================
+;; ssr-handler — cookies serialise to Set-Cookie headers
+;; ===========================================================================
+
+(deftest handler-cookies-become-set-cookie-headers
+  (testing "structured cookies materialise to Set-Cookie wire form"
+    (rf/reg-event-fx :init/with-cookies
+      {:platforms #{:server}}
+      (fn [_ _]
+        {:fx [[:rf.server/set-cookie {:name      "session"
+                                      :value     "abc123"
+                                      :max-age   3600
+                                      :http-only true
+                                      :same-site :lax
+                                      :path      "/"}]
+              [:rf.server/set-cookie {:name  "theme"
+                                      :value "dark"
+                                      :path  "/"}]]}))
+
+    (rf/reg-view* :pages/cookied
+      (fn [] [:div "cookied"]))
+
+    (let [handler  (ssr-ring/ssr-handler
+                     {:on-create [:init/with-cookies]
+                      :root-view [:pages/cookied]})
+          response (handler {:uri "/" :request-method :get})
+          headers  (:headers response)
+          set-cookie (or (get headers "Set-Cookie") (get headers "set-cookie"))]
+      (is (= 200 (:status response)))
+      (is (some? set-cookie))
+      ;; Two cookies → vector form.
+      (is (vector? set-cookie)
+          "multi-valued Set-Cookie collapses into a vector")
+      (is (= 2 (count set-cookie)))
+      (is (some #(and (str/includes? % "session=abc123")
+                      (str/includes? % "Max-Age=3600")
+                      (str/includes? % "HttpOnly")
+                      (str/includes? % "SameSite=Lax"))
+                set-cookie)
+          "session cookie carries all its attributes")
+      (is (some #(str/includes? % "theme=dark") set-cookie)))))
+
+;; ===========================================================================
+;; ssr-handler — error path
+;; ===========================================================================
+
+(deftest handler-render-error-projects-to-500
+  (testing "exception raised during render is caught and routed through :on-error"
+    (rf/reg-event-fx :init/ok
+      {:platforms #{:server}}
+      (fn [_ _] {}))
+
+    (rf/reg-view* :pages/broken
+      (fn [] (throw (ex-info "boom" {}))))
+
+    (let [handler (ssr-ring/ssr-handler
+                    {:on-create [:init/ok]
+                     :root-view [:pages/broken]})
+          response (handler {:uri "/broken" :request-method :get})]
+      (is (= 500 (:status response))
+          "the default :on-error returns 500")
+      (is (str/includes? (:body response) "SSR error")
+          "default :on-error body carries the error message"))))
+
+(deftest handler-custom-on-error
+  (testing ":on-error opt overrides the default 500 path"
+    (rf/reg-event-fx :init/ok
+      {:platforms #{:server}}
+      (fn [_ _] {}))
+
+    (rf/reg-view* :pages/broken-2
+      (fn [] (throw (ex-info "boom-2" {:custom true}))))
+
+    (let [handler (ssr-ring/ssr-handler
+                    {:on-create [:init/ok]
+                     :root-view [:pages/broken-2]
+                     :on-error  (fn [_req t]
+                                  {:status  418
+                                   :headers {"Content-Type" "text/plain"}
+                                   :body    (str "caught: " (.getMessage t))})})
+          response (handler {:uri "/broken" :request-method :get})]
+      (is (= 418 (:status response)))
+      (is (str/includes? (:body response) "caught: boom-2")))))
+
+;; ===========================================================================
+;; ssr-handler — *current-request* binding (rf2-e825b coordination)
+;; ===========================================================================
+
+(deftest current-request-is-bound-during-on-create
+  (testing "*current-request* is bound for the duration of the per-request frame"
+    (let [captured (atom ::not-captured)]
+      (rf/reg-event-fx :init/capture-current-request
+        {:platforms #{:server}}
+        (fn [_ _]
+          ;; Reads the *current-request* binding the host adapter
+          ;; sets. The rf2-e825b cofx will read the SAME var; this
+          ;; test pins the binding contract.
+          (reset! captured ssr-ring/*current-request*)
+          {}))
+
+      (rf/reg-view* :pages/blank (fn [] [:div]))
+
+      (let [handler  (ssr-ring/ssr-handler
+                       {:on-create [:init/capture-current-request]
+                        :root-view [:pages/blank]})
+            request  {:uri            "/test"
+                      :request-method :get
+                      :headers        {"user-agent" "ring-adapter-test"}}
+            _        (handler request)]
+        (is (= request @captured)
+            "*current-request* was bound to the Ring request map during the drain")))))
+
+(deftest current-request-clears-after-handler
+  (testing "*current-request* is nil outside an SSR request"
+    (is (nil? ssr-ring/*current-request*))))
+
+;; ===========================================================================
+;; ssr-handler — payload-keys slice
+;; ===========================================================================
+
+(deftest handler-payload-keys-slices-app-db
+  (testing ":payload-keys ships a subset of app-db in the hydration payload"
+    (rf/reg-event-fx :init/many-keys
+      {:platforms #{:server}}
+      (fn [_ _]
+        {:db {:public/articles [:a :b :c]
+              :server-only/secret-token "very-secret"
+              :server-only/admin-flag true}}))
+
+    (rf/reg-view* :pages/echo (fn [] [:div "echo"]))
+
+    (let [handler (ssr-ring/ssr-handler
+                    {:on-create    [:init/many-keys]
+                     :root-view    [:pages/echo]
+                     :payload-keys [:public/articles]})
+          response (handler {:uri "/" :request-method :get})
+          body     (:body response)]
+      (is (= 200 (:status response)))
+      ;; pr-str emits namespace-keyed maps in the `#:public{...}`
+      ;; reader shorthand for namespace-shared keys (:public/articles).
+      ;; Match the shorthand here; the structural content is what
+      ;; matters — that the payload carries the public slice and
+      ;; omits the server-only slices.
+      (is (or (str/includes? body ":public/articles")
+              (str/includes? body "#:public{:articles"))
+          "payload carries the public/articles key (either as
+           qualified-keyword or as namespace-map shorthand)")
+      (is (not (str/includes? body "secret-token"))
+          ":payload-keys omits server-only slices from the wire payload")
+      (is (not (str/includes? body "admin-flag"))))))
+
+;; ===========================================================================
+;; ssr-middleware — match? predicate
+;; ===========================================================================
+
+(deftest middleware-falls-through-on-non-match
+  (testing "non-matching requests fall through to the wrapped handler"
+    (register-articles-app! [])
+
+    (let [wrapped-called (atom false)
+          wrapped        (fn [_req]
+                           (reset! wrapped-called true)
+                           {:status 204 :headers {} :body ""})
+          mw             (ssr-ring/ssr-middleware
+                           {:on-create    [:rf/server-init]
+                            :root-view    [:pages/articles]
+                            :fx-overrides {:http/get :http/get.canned}
+                            :match?       (fn [req] (= "/ssr" (:uri req)))})
+          app            (mw wrapped)]
+
+      (let [fall-through-response (app {:uri "/api" :request-method :get})]
+        (is @wrapped-called)
+        (is (= 204 (:status fall-through-response))))
+
+      (reset! wrapped-called false)
+      (let [ssr-response (app {:uri "/ssr" :request-method :get})]
+        (is (not @wrapped-called))
+        (is (= 200 (:status ssr-response)))
+        (is (str/includes? (:body ssr-response) "<!DOCTYPE html>"))))))


### PR DESCRIPTION
## Summary

- Ships **day8/re-frame2-ssr-ring** as the canonical Ring/Pedestal host adapter for re-frame2 SSR, per Spec 011 §HTTP response contract and the rf2-ul137 audit gap #1. The SSR runtime owns the response *shape*; the host adapter owns the wire *transport*. Users no longer need to hand-roll the bridge.
- New artefact under `implementation/ssr-ring/` (JVM-only `.clj`; Ring is JVM-only). Per-feature flat layout per rf2-zha9.
- Coordinates with rf2-e825b (`:rf.server/request` cofx). This PR is the binding site — `*current-request*` is bound per request inside `ssr-handler`; the cofx (rf2-e825b) reads from that var. The cofx isn't required for this PR to land — handlers without cofx injection use the Ring request map conj'd onto the `:on-create` event (the worked-example pattern in `examples/reagent/ssr/core.cljc`).

## Handler shape

```clojure
(ssr-handler {:on-create [:rf/server-init]
              :root-view [:app/root]
              :html-shell my-shell
              :fx-overrides {:rf.http/managed :ssr.http/canned-articles}})
;; → (fn [ring-request] ring-response)
```

Per-request lifecycle:

1. Bind `*current-request*` to the Ring request map.
2. `(rf/make-frame {:platform :server :on-create [...]})` — drains `:on-create` synchronously per Spec 002.
3. `ssr/get-response` (flushes pending error projections per Spec 011 §Server error projection).
4. Branch on `:redirect` — short-circuit with status + Location, no body, per Spec 011 §Redirect precedence step 4.
5. Otherwise `ssr/render-to-string`, build the hydration payload, wrap in the caller's `:html-shell`.
6. Materialise structured cookies → `Set-Cookie` wire form per RFC 6265 (`cookie->set-cookie-header` public surface; URL-encodes value, canonical attribute order, maps `:same-site` keywords).
7. Multi-valued headers collapse to Ring's `name → vec-of-strings` shape.
8. Frame torn down via `rf/destroy-frame` in a `finally` block — sub-cache reactions disposed, machine snapshots emit `:rf.machine.lifecycle/destroyed` traces with `:parent-frame-destroyed`.

Plus `ssr-middleware` for composing with other Ring middlewares via a `:match?` predicate.

## Frame-lifecycle decisions

- **Synchronous handler only.** Ring 3-arity async is additive and out of scope for v1; the SSR drain itself is synchronous. Streaming SSR (rf2-olb64) is deferred.
- **Frame destroyed in `finally`** — per Spec 002 §Destroy. The `handler-creates-and-destroys-per-request-frame` test pins that no per-request frame leaks into the registry and that `:frame/destroyed` fires. (Pending-effect cleanup is the concern of rf2-fcj33 — this PR uses the existing `destroy-frame!` contract.)
- **Errors during render/setup** flow through an `:on-error` opt (default: 500 with the message in the body). The SSR runtime's error projector still handles trace-emitted errors during drain; `:on-error` is the catch-all for Ring-layer / render-time exceptions the projector can't see.
- **`*current-request*` binding** is the rf2-e825b coordination surface. The cofx reads from `re-frame.ssr.ring/*current-request*`; this PR binds it. Until rf2-e825b lands, `(inject-cofx :rf.server/request)` returns nil — handlers fall back to the request-as-event-arg pattern (the request is conj'd onto `:on-create`).

## rf2-e825b cofx integration

rf2-e825b is parallel; both beads were claimed at the same time. The cofx itself lives in `re-frame.ssr` (or wherever rf2-e825b lands it); this PR doesn't define it. The `current-request-is-bound-during-on-create` test captures the binding from inside a server-platform event handler, pinning the contract for rf2-e825b to wire against:

```clojure
;; rf2-e825b's cofx will read this var:
(def cofx-impl
  (fn [coeffects _]
    (assoc coeffects :rf.server/request re-frame.ssr.ring/*current-request*)))
```

If rf2-e825b lands first (cofx exists but no binding site), `*current-request*` defaults to `nil` and the cofx yields nil — graceful degradation. If this PR lands first (binding site exists but no cofx), handlers use the event-arg pattern — same as the worked example today.

## deps.edn / shadow-cljs.edn changes

- `implementation/deps.edn` — add `day8/re-frame2-ssr-ring {:local/root "ssr-ring"}` to `:deps`; add `"ssr-ring/test"` to combined `:test` alias.
- `implementation/shadow-cljs.edn` — add `"ssr-ring/src"` + `"ssr-ring/test"` to `:source-paths` (shadow ignores `.clj`-only at compile time; the path inclusion only widens the classpath).
- Both hot-zone files; edits are additive lines only, so merge-conflict risk is low. The 4 other parallel agents are on disjoint surfaces (no other hot-zone touch).

## Tests

11 deftests, 50 assertions — all passing.

| Test | Pins |
|---|---|
| `cookie-set-cookie-header-canonical` | RFC 6265 wire-form: minimal, URL-encoded value, full attribute set, `:same-site` keyword tokens, `:name`-missing rejection |
| `handler-renders-html-with-status-and-headers` | 200, content-type, view content, payload script, `data-rf-render-hash` |
| `handler-creates-and-destroys-per-request-frame` | no frame leak; `:frame/destroyed` trace fires |
| `handler-redirect-short-circuits` | 302 + Location, empty body, no view content |
| `handler-cookies-become-set-cookie-headers` | structured cookies → Set-Cookie; multi-valued → vec |
| `handler-render-error-projects-to-500` | view-time exception → default 500 via `:on-error` |
| `handler-custom-on-error` | `:on-error` opt overrides default |
| `current-request-is-bound-during-on-create` | `*current-request*` binding for rf2-e825b |
| `current-request-clears-after-handler` | binding scoped to request; nil outside |
| `handler-payload-keys-slices-app-db` | `:payload-keys` ships a subset; server-only slices omitted |
| `middleware-falls-through-on-non-match` | `ssr-middleware` composition via `:match?` |

Existing ssr test suite (31 tests, 118 assertions) still passes — no regression.

## Test plan

- [x] Per-artefact tests pass: `cd implementation/ssr-ring && clojure -M:test` (11 tests / 50 assertions / 0 failures / 0 errors)
- [x] Existing SSR suite still green: `cd implementation/ssr && clojure -M:test` (31 tests / 118 assertions / 0 failures)
- [x] Top-level classpath resolves: `cd implementation && clojure -A:test -e "(println :classpath-ok)"`
- [ ] CI: per-artefact gates, browser-test build (unaffected — `.clj`-only sources), bundle-isolation (unaffected — new artefact is not in the production bundle path).