### PR TITLE
feat(ssr): implement :rf.server/request cofx per Spec 011 (rf2-e825b)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -33,12 +33,19 @@
       projector when an error trace fires inside a server frame and
       writes the public-error's :status to the response accumulator.
       Per Spec 011 §Server error projection.
+    - :rf.server/request cofx + per-frame request slot
+      (set-request! / get-request / clear-request!) — host adapters
+      populate the slot before drain; event handlers consume via
+      (inject-cofx :rf.server/request). Gated by :platforms #{:server}
+      so client dispatches no-op via :rf.cofx/skipped-on-platform. Per
+      Spec 011 §Server-only reg-cofx for request context.
 
   Conformance fixtures cover all of the above (ssr/render-to-string,
   ssr/hydrate, ssr/hydration-mismatch, ssr/head-emits, ssr/head-hydration,
   ssr/error-known-mapping, ssr/error-sanitisation, ssr/cookie,
   ssr/redirect, ssr/set-status, fx/platforms)."
-  (:require [re-frame.frame :as frame]
+  (:require [re-frame.cofx :as cofx]
+            [re-frame.frame :as frame]
             [re-frame.fx :as fx]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
@@ -1042,6 +1049,113 @@ response with no body."
           (buffer-error-trace! fid event))))))
 
 (trace/register-trace-cb! ::error-projection error-projection-listener)
+
+;; ---- :rf.server/request cofx + per-frame request slot ---------------------
+;;
+;; Per Spec 011 §Server-only `reg-cofx` for request context. The
+;; :rf.server/request cofx surfaces the active HTTP request map to
+;; event handlers via `(rf/inject-cofx :rf.server/request)`. Use cases:
+;; reading the URL inside :rf/server-init, pulling a session cookie
+;; in :auth/check-session, branching on :request-method, etc.
+;;
+;; The mechanism is a per-frame slot — NOT a single dynamic var — so
+;; two simultaneous per-request frames (the common SSR shape under
+;; concurrent load) carry independent request data without leaking
+;; into each other. Host adapters (rf2-ny6v7's Ring adapter; future
+;; Pedestal / raw-HTTP / edge-runtime adapters) populate the slot via
+;; `set-request!` before kicking off the drain and clear it via
+;; `clear-request!` after the response is built (typically inside
+;; `frame.cljc`'s `destroy-frame!` teardown — but adapters that re-use
+;; a long-lived frame can clear inline).
+;;
+;; Storage shape: `defonce` side-channel atom keyed by frame-id. This
+;; mirrors `pending-error-traces` rather than living in app-db because
+;; the request map is HOST-CONTROLLED INPUT (the host's wire-shape data
+;; — Ring request map, Pedestal context, etc.); the cofx surfaces it
+;; into the handler's :coeffects map, but it has no place in the
+;; application's serialisable app-db. Storing it outside app-db keeps
+;; it out of the hydration payload (`:rf/app-db` ships to the client)
+;; — server-side request data must never leak into the client's
+;; bootstrap state.
+;;
+;; The cofx is `:platforms #{:server}` so client-side dispatches that
+;; reference it silently no-op via `:rf.cofx/skipped-on-platform`
+;; (the standard cofx-gating contract per Spec 011 §634-642).
+
+(defonce
+  ^{:doc "Per-frame storage for the active HTTP request. Keys are
+  frame-ids; values are the host-supplied request map (Ring shape, or
+  whatever the host adapter normalises to). Side-channel — not in
+  app-db so the request never rides the hydration payload to the
+  client. Host adapters populate via `set-request!` before drain and
+  clear via `clear-request!` after response materialisation."}
+  request-slots
+  (atom {}))
+
+(defn set-request!
+  "Populate the per-frame request slot. Called by an SSR host adapter
+  (rf2-ny6v7 ships the Ring adapter; future Pedestal / raw-HTTP / edge-
+  runtime adapters follow the same contract) once per request, before
+  kicking off the drain.
+
+  The shape of `request` is host-defined: the Ring adapter passes the
+  Ring request map (`:request-method`, `:uri`, `:headers`, `:cookies`,
+  `:body`, `:query-string`, `:server-name`, `:scheme`, etc.); other
+  adapters may pass their native context shape. The cofx surfaces
+  whatever the adapter stored — the runtime never inspects the request.
+
+  Returns `frame-id`."
+  [frame-id request]
+  (swap! request-slots assoc frame-id request)
+  frame-id)
+
+(defn get-request
+  "Read the active request for `frame-id`. Returns nil when no host
+  adapter has populated the slot (e.g. JVM tests that drive the drain
+  directly without a host wrapper, or a client-side dispatch that
+  injected the cofx — in that case the `:platforms` gate fires the
+  `:rf.cofx/skipped-on-platform` trace before this fn is called).
+
+  Public read surface — host adapters and tools may inspect the active
+  request via this fn."
+  [frame-id]
+  (get @request-slots frame-id))
+
+(defn clear-request!
+  "Clear the per-frame request slot. Host adapters call this after
+  building the wire response (typically as part of per-request frame
+  teardown). Safe to call when no slot is populated.
+
+  Returns `frame-id`."
+  [frame-id]
+  (swap! request-slots dissoc frame-id)
+  frame-id)
+
+(cofx/reg-cofx :rf.server/request
+  {:doc       "The active HTTP request. Server only. Surfaces the
+host-supplied request map (Ring shape under rf2-ny6v7's Ring adapter;
+host-defined for other adapters) so handlers can read URL, headers,
+session cookies, etc. without threading the request as an event arg.
+
+The host adapter populates the slot via `re-frame.ssr/set-request!`
+once per request before the drain begins. Apps consume via
+`(inject-cofx :rf.server/request)` in any server-side event handler.
+
+The 2-arity form accepts an explicit value override — useful in tests
+and conformance harnesses that drive the drain without a host adapter:
+`(inject-cofx :rf.server/request {:uri \"/articles\" ...})`.
+
+Per Spec 011 §Server-only `reg-cofx` for request context."
+   :platforms #{:server}}
+  ;; 1-arity: read from the per-frame slot.
+  (fn
+    ([ctx]
+     (let [frame-id (get-in ctx [:coeffects :frame])
+           request  (get-request frame-id)]
+       (assoc-in ctx [:coeffects :rf.server/request] request)))
+    ;; 2-arity: explicit value override (tests / harnesses).
+    ([ctx request]
+     (assoc-in ctx [:coeffects :rf.server/request] request))))
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;

--- a/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
@@ -1,0 +1,284 @@
+(ns re-frame.ssr-request-cofx-test
+  "Coverage for the :rf.server/request cofx + per-frame request slot
+  (rf2-e825b). Per Spec 011 §Server-only `reg-cofx` for request context.
+
+  The cofx surfaces the active HTTP request map to event handlers so
+  setup events can read URL, headers, session cookies, etc. without
+  threading the request through as an event arg. Mechanism:
+
+    1. The host adapter (rf2-ny6v7 ships the Ring adapter) populates
+       the per-frame request slot via `re-frame.ssr/set-request!`
+       before kicking off the drain.
+    2. Event handlers use `(rf/inject-cofx :rf.server/request)` and
+       read the request map under `:rf.server/request` in their
+       coeffects.
+    3. After the response is materialised, the host adapter calls
+       `clear-request!` (typically as part of frame teardown).
+
+  This test pins the cofx-registration, the read path, the platforms
+  gating (client-side dispatches silently no-op), the frame-isolation
+  invariant (two simultaneous per-request frames don't leak), and the
+  explicit-value override surface (2-arity form for tests/harnesses
+  that drive the drain without a host adapter)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.registrar :as registrar]
+            [re-frame.ssr :as ssr]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (reset! ssr/request-slots {})
+  (rf/init! ssr/adapter)
+  ;; Namespace-load-time registrations get wiped by clear-all!; reload
+  ;; so :rf/hydrate, :rf.server/* fxs, AND the :rf.server/request cofx
+  ;; resurrect between tests.
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr     :reload)
+  (require 're-frame.machines :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+(defn- collect-traces!
+  "Register a trace listener under `id`, returning the atom that
+  accumulates events. Tests must (rf/remove-trace-cb! id) to detach."
+  [id]
+  (let [acc (atom [])]
+    (rf/register-trace-cb! id (fn [ev] (swap! acc conj ev)))
+    acc))
+
+;; ---- registration -----------------------------------------------------------
+;;
+;; The :rf.server/request cofx must be present in the cofx registry at
+;; namespace-load time — same model as the :rf.server/* fxs.
+
+(deftest cofx-is-registered-after-namespace-load
+  (testing ":rf.server/request resolves in the cofx registry"
+    (let [meta (registrar/lookup :cofx :rf.server/request)]
+      (is (some? meta)
+          "the cofx registry holds an entry under :rf.server/request")
+      (is (fn? (:handler-fn meta))
+          "the entry carries a :handler-fn")
+      (is (= #{:server} (:platforms meta))
+          ":platforms #{:server} per Spec 011 §634-642 — server-only")
+      (is (string? (:doc meta))
+          "the registration carries a :doc string"))))
+
+;; ---- read path: populated slot ---------------------------------------------
+;;
+;; The canonical pattern: host adapter writes the request to the per-
+;; frame slot before drain; a server-side event handler reads it via
+;; (inject-cofx :rf.server/request).
+
+(deftest cofx-reads-populated-request
+  (testing "(set-request! frame req) → (inject-cofx :rf.server/request) → handler reads req"
+    (let [server-frame (rf/make-frame
+                         {:doc      "SSR request frame"
+                          :platform :server})
+          request      {:request-method :get
+                        :uri            "/articles/42"
+                        :headers        {"accept"   "text/html"
+                                         "cookie"   "session=abc123"}
+                        :query-string   "preview=1"
+                        :server-name    "example.com"
+                        :scheme         :https}
+          observed     (atom :unset)]
+      ;; Host adapter populates the slot.
+      (ssr/set-request! server-frame request)
+      ;; A server-side handler reads it via the cofx.
+      (rf/reg-event-fx :req-test/read
+        [(rf/inject-cofx :rf.server/request)]
+        (fn [{:keys [rf.server/request]} _]
+          (reset! observed request)
+          {}))
+      (rf/dispatch-sync [:req-test/read] {:frame server-frame})
+
+      (is (= request @observed)
+          "the handler saw the request map that was placed in the slot"))))
+
+(deftest get-request-mirrors-cofx
+  (testing "ssr/get-request is the public read surface — same value as the cofx"
+    (let [server-frame (rf/make-frame {:platform :server})
+          request      {:request-method :post
+                        :uri            "/api/articles"
+                        :body           "{\"title\":\"new\"}"}]
+      (ssr/set-request! server-frame request)
+      (is (= request (ssr/get-request server-frame))
+          "get-request returns the host-supplied map verbatim"))))
+
+;; ---- unpopulated slot ------------------------------------------------------
+;;
+;; If no host adapter populated the slot (e.g. tests that drive the
+;; drain directly, or a misconfigured deployment), the cofx injects nil
+;; rather than failing — handlers can branch on `(nil? request)`.
+
+(deftest cofx-injects-nil-when-slot-unpopulated
+  (testing "cofx returns nil when no host adapter has populated the slot"
+    (let [server-frame (rf/make-frame {:platform :server})
+          observed     (atom :unset)]
+      (rf/reg-event-fx :req-test/read-empty
+        [(rf/inject-cofx :rf.server/request)]
+        (fn [{:keys [rf.server/request] :as ctx} _]
+          (reset! observed
+                  ;; Distinguish between "key absent" and "key present
+                  ;; but nil" — the cofx always assoc's the key.
+                  (if (contains? ctx :rf.server/request)
+                    [:present request]
+                    [:absent  request]))
+          {}))
+      (rf/dispatch-sync [:req-test/read-empty] {:frame server-frame})
+
+      (is (= [:present nil] @observed)
+          "the cofx assoc's the key with a nil value when the slot is empty"))))
+
+;; ---- platforms gating ------------------------------------------------------
+;;
+;; Per Spec 011 §634-642 and cofx.cljc's gate: a :platforms #{:server}
+;; cofx is skipped when injected on a client-side frame. The runtime
+;; emits :rf.cofx/skipped-on-platform (warning, :recovery :skipped) and
+;; the handler chain continues — only the injection is skipped, not
+;; the dispatch.
+
+(deftest cofx-is-skipped-on-client-frame
+  (testing ":rf.server/request is skipped on a :platform :client frame
+            and emits :rf.cofx/skipped-on-platform"
+    (let [client-frame (rf/make-frame {:platform :client})
+          traces       (collect-traces! ::req-client)
+          observed     (atom :unset)]
+      (rf/reg-event-fx :req-test/read-on-client
+        [(rf/inject-cofx :rf.server/request)]
+        (fn [{:keys [rf.server/request] :as ctx} _]
+          (reset! observed
+                  (if (contains? ctx :rf.server/request)
+                    [:present request]
+                    [:absent  request]))
+          {}))
+      (rf/dispatch-sync [:req-test/read-on-client] {:frame client-frame})
+      (rf/remove-trace-cb! ::req-client)
+
+      (is (= [:absent nil] @observed)
+          "the cofx did NOT run — :rf.server/request is absent from coeffects")
+
+      (let [skips (filter #(= :rf.cofx/skipped-on-platform (:operation %))
+                          @traces)]
+        (is (= 1 (count skips))
+            "exactly one :rf.cofx/skipped-on-platform trace was emitted")
+        (let [t (first skips)]
+          (is (= :rf.server/request (get-in t [:tags :cofx-id]))
+              ":cofx-id identifies the gated cofx")
+          (is (= :client (get-in t [:tags :platform]))
+              ":platform carries the active platform that excluded the cofx")
+          (is (= #{:server} (get-in t [:tags :registered-platforms]))
+              ":registered-platforms surfaces the cofx's declared set")
+          (is (= :skipped (:recovery t))
+              ":recovery is :skipped — the runtime declined to act"))))))
+
+;; ---- frame isolation -------------------------------------------------------
+;;
+;; The per-frame slot mechanism's whole point: two concurrent per-
+;; request frames (the normal SSR shape under load) carry independent
+;; request data. If the impl used a single dynamic var or a global
+;; atom, request A's data would leak into request B's handler.
+
+(deftest two-frames-carry-independent-request-data
+  (testing "two simultaneous per-request frames have isolated request slots"
+    (let [frame-a    (rf/make-frame {:platform :server :doc "request A"})
+          frame-b    (rf/make-frame {:platform :server :doc "request B"})
+          request-a  {:uri "/articles/aaa" :headers {"cookie" "session=user-a"}}
+          request-b  {:uri "/articles/bbb" :headers {"cookie" "session=user-b"}}
+          observed-a (atom :unset)
+          observed-b (atom :unset)]
+      (ssr/set-request! frame-a request-a)
+      (ssr/set-request! frame-b request-b)
+
+      (rf/reg-event-fx :req-test/read-isolated
+        [(rf/inject-cofx :rf.server/request)]
+        (fn [{:keys [rf.server/request frame]} _]
+          (cond
+            (= frame frame-a) (reset! observed-a request)
+            (= frame frame-b) (reset! observed-b request))
+          {}))
+
+      (rf/dispatch-sync [:req-test/read-isolated] {:frame frame-a})
+      (rf/dispatch-sync [:req-test/read-isolated] {:frame frame-b})
+
+      (is (= request-a @observed-a)
+          "frame A's handler saw frame A's request")
+      (is (= request-b @observed-b)
+          "frame B's handler saw frame B's request — no leak from A")
+      ;; Independent reads via the public surface.
+      (is (= request-a (ssr/get-request frame-a)))
+      (is (= request-b (ssr/get-request frame-b))))))
+
+(deftest clear-request-removes-the-slot
+  (testing "clear-request! removes the per-frame slot — subsequent reads return nil"
+    (let [server-frame (rf/make-frame {:platform :server})
+          request      {:uri "/x"}]
+      (ssr/set-request! server-frame request)
+      (is (= request (ssr/get-request server-frame)))
+      (ssr/clear-request! server-frame)
+      (is (nil? (ssr/get-request server-frame))
+          "the slot was cleared")
+
+      ;; The cofx now injects nil.
+      (let [observed (atom :unset)]
+        (rf/reg-event-fx :req-test/read-after-clear
+          [(rf/inject-cofx :rf.server/request)]
+          (fn [{:keys [rf.server/request]} _]
+            (reset! observed request)
+            {}))
+        (rf/dispatch-sync [:req-test/read-after-clear] {:frame server-frame})
+        (is (nil? @observed)
+            "the cofx injects nil after clear-request!")))))
+
+;; ---- explicit-value override (2-arity inject-cofx) -------------------------
+;;
+;; Tests and conformance harnesses that drive the drain without a host
+;; adapter can supply the request inline. The 2-arity form bypasses the
+;; slot lookup.
+
+(deftest cofx-2-arity-injects-explicit-value
+  (testing "(inject-cofx :rf.server/request {...}) injects the explicit value
+            even when no host adapter has populated the slot"
+    (let [server-frame (rf/make-frame {:platform :server})
+          explicit     {:uri "/explicit" :headers {"x-test" "1"}}
+          observed     (atom :unset)]
+      ;; No set-request! call — the slot is empty.
+      (is (nil? (ssr/get-request server-frame)))
+      (rf/reg-event-fx :req-test/read-explicit
+        [(rf/inject-cofx :rf.server/request explicit)]
+        (fn [{:keys [rf.server/request]} _]
+          (reset! observed request)
+          {}))
+      (rf/dispatch-sync [:req-test/read-explicit] {:frame server-frame})
+
+      (is (= explicit @observed)
+          "the 2-arity form injects the explicit value, bypassing the slot"))))
+
+;; ---- :ssr-server preset frames --------------------------------------------
+;;
+;; The :ssr-server preset (frame.cljc §preset-expansion) sets
+;; :platform :server — confirm the cofx works under the preset shape
+;; the same way it does with an explicit :platform :server.
+
+(deftest cofx-works-under-ssr-server-preset
+  (testing "the cofx surfaces the request under a :preset :ssr-server frame"
+    (let [server-frame (rf/make-frame {:preset :ssr-server})
+          request      {:uri "/preset" :request-method :get}
+          observed     (atom :unset)]
+      (ssr/set-request! server-frame request)
+      (rf/reg-event-fx :req-test/read-preset
+        [(rf/inject-cofx :rf.server/request)]
+        (fn [{:keys [rf.server/request]} _]
+          (reset! observed request)
+          {}))
+      (rf/dispatch-sync [:req-test/read-preset] {:frame server-frame})
+
+      (is (= request @observed)
+          "the cofx flows the request through under the :ssr-server preset"))))


### PR DESCRIPTION
## Summary

Per Spec 011 §Server-only `reg-cofx` for request context — the cofx contract was declared in spec but absent from `re-frame.ssr`. Identified by the rf2-ul137 SSR audit (gap #2, P1).

## Cofx contract

```clojure
(rf/reg-event-fx :auth/check-session
  [(rf/inject-cofx :rf.server/request)]
  (fn [{:keys [rf.server/request]} _]
    ;; request is the host-supplied request map (Ring shape under
    ;; rf2-ny6v7's Ring adapter; host-defined for other adapters).
    ;; Read :uri, :headers, :cookies, :request-method, etc.
    ...))
```

## Per-frame slot mechanism

`defonce` side-channel atom keyed by frame-id (mirrors `pending-error-traces`):

- `(ssr/set-request! frame-id request)` — host adapter populates before drain
- `(ssr/get-request frame-id)` — public read surface
- `(ssr/clear-request! frame-id)` — host adapter clears after response materialisation

Storage is OUT of app-db so the request never rides the hydration payload to the client (server-side request data must not leak into the client's bootstrap state). The pattern is intentionally HOST-CONTROLLED INPUT, mirroring Ring's request/response separation.

## Platforms gating

`:platforms #{:server}` — client-side dispatches that inject the cofx silently no-op via `:rf.cofx/skipped-on-platform` (Spec 011 §634-642, mirroring `reg-fx`'s gate). Standard cofx-gating contract.

## Coordination with rf2-ny6v7

This artefact owns the **consumer-side cofx**; rf2-ny6v7 (Ring host adapter) owns the **populator** — Ring adapter calls `ssr/set-request!` with the Ring request map before kicking off the drain. Spec-level coupling only — no direct file dep between `implementation/ssr/` and `implementation/ssr-ring/`.

The 2-arity inject-cofx form `(inject-cofx :rf.server/request {...})` supplies an explicit-value override for tests / conformance harnesses that drive the drain without a host adapter.

## Test plan

8 deftests in `ssr_request_cofx_test.clj` covering:

- [x] cofx registration (`:rf.server/request` resolves in the cofx registry with `:platforms #{:server}` + `:handler-fn`)
- [x] read path (`set-request!` → `(inject-cofx :rf.server/request)` → handler reads the request map)
- [x] `get-request` public read surface mirrors the cofx
- [x] cofx injects nil when the slot is unpopulated (handler can branch)
- [x] `:platforms` gating skips on `:client` frames + emits `:rf.cofx/skipped-on-platform` trace (correct `:cofx-id`, `:platform`, `:registered-platforms`, `:recovery :skipped`)
- [x] frame isolation — two simultaneous per-request frames carry independent request data
- [x] `clear-request!` removes the slot; subsequent reads return nil
- [x] 2-arity `inject-cofx :rf.server/request value` injects the explicit value
- [x] `:ssr-server` preset path (`:preset :ssr-server` → `:platform :server` → cofx works)

Full SSR test suite passes: 40 tests, 141 assertions, 0 failures. Core JVM test suite passes: 358 tests, 1985 assertions, 0 failures.

## Bead

[rf2-e825b](../tree/main/.beads) — leaves OPEN per dispatch-protocol; Mike closes after review.