### PR TITLE
feat(core/elision): rf/elide-wire-value walker + :rf.size/* fxs + schema-driven boot (rf2-v9tw2)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -46,6 +46,7 @@
             [re-frame.interop :as interop]
             [re-frame.trace :as trace]
             [re-frame.trace.projection :as trace-projection]
+            [re-frame.elision :as elision]
             [re-frame.substrate.adapter :as adapter]
             ;; Optional-artefact wrappers (rf2-hoiu). Each ns wraps a
             ;; per-feature Maven artefact and looks the producing fns
@@ -959,6 +960,29 @@
 (def trace-buffer        trace/trace-buffer)
 (def clear-trace-buffer! trace/clear-trace-buffer!)
 
+;; ---- size-elision wire-boundary walker (rf2-v9tw2; Spec 009) -------------
+;;
+;; Per [API.md §Size-elision wire-boundary walker]. The walker is the
+;; single normative emission site for the `:rf/redacted` privacy
+;; sentinel and the `:rf.size/large-elided` marker; per-tool
+;; reimplementation is prohibited. The registry of declared paths
+;; lives at `[:rf/elision]` in every frame's app-db (per
+;; [Conventions §Reserved app-db keys]) so declarations survive
+;; restore-epoch and persist across hot reload. Surface:
+;;
+;;   rf/elide-wire-value            — the walker
+;;   rf/declare-large-path!         — REPL/boot wrapper around :rf.size/declare-large
+;;   rf/clear-large-path!           — REPL/boot wrapper around :rf.size/clear
+;;   rf/populate-elision-from-schemas!
+;;                                  — schema-driven boot population
+
+(def elide-wire-value             elision/elide-wire-value)
+(def declare-large-path!          elision/declare-large-path!)
+(def clear-large-path!            elision/clear-large-path!)
+(def populate-elision-from-schemas! elision/populate-elision-from-schemas!)
+(def elision-declarations         elision/declarations)
+(def elision-runtime-flagged      elision/runtime-flagged)
+
 ;; Per rf2-wvzgd: cascade projection. Pure-data fn lifted from Story's
 ;; trace panel; consumed by Story (`tools/story/src/re_frame/story/ui/
 ;; trace.cljs`), and (when impl lands) Causa (rf2-5aw5v) and pair2's
@@ -992,9 +1016,10 @@
 
 (defn configure
   "Configure a process-level runtime knob. v1 keys:
-    :epoch-history {:depth N}            ring depth (default 50; 0 disables)
-    :trace-buffer  {:depth N}            ring depth (default 200; 0 disables)
-    :sub-cache     {:grace-period-ms N}  dispose grace (default 50ms)
+    :epoch-history {:depth N}                       ring depth (default 50; 0 disables)
+    :trace-buffer  {:depth N}                       ring depth (default 200; 0 disables)
+    :sub-cache     {:grace-period-ms N}             dispose grace (default 50ms)
+    :elision       {:rf.size/threshold-bytes N}     runtime auto-detect threshold (default 16384; 0 disables)
   Unknown keys silently no-op. Per-frame settings live on frame metadata.
   Per Tool-Pair §How AI tools attach."
   [knob opts]
@@ -1008,6 +1033,7 @@
                      (f opts))
     :trace-buffer  (trace/configure-trace-buffer! opts)
     :sub-cache     (subs/configure! opts)
+    :elision       (elision/configure-elision! opts)
     nil))
 
 ;; ---- substrate adapter ----------------------------------------------------

--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -1,0 +1,597 @@
+(ns re-frame.elision
+  "Size-elision wire-boundary walker plus the `[:rf/elision ...]` app-db
+   registry mechanics. Per Spec 009 §Size elision in traces, Spec API
+   §Size-elision wire-boundary walker, Spec-Schemas §`:rf/elision-registry`
+   / `:rf/elision-marker`, and Conventions §Reserved app-db keys / fx-ids.
+
+   The walker `elide-wire-value` is the **single normative emission site**
+   for the `:rf/redacted` privacy sentinel and the `:rf.size/large-elided`
+   size marker — every tool that emits wire data goes through it; per-tool
+   reimplementation is prohibited.
+
+   Surface:
+
+   - `elide-wire-value`           — the walker; takes a value and an opts
+                                    map; returns the value or a substitution.
+   - `declare-large-path!`        — REPL/boot wrapper that dispatches
+                                    `:rf.size/declare-large` against the
+                                    current frame.
+   - `clear-large-path!`          — REPL/boot wrapper for `:rf.size/clear`.
+   - `:rf.size/declare-large` fx  — declarative path registration from
+                                    `:fx`.
+   - `:rf.size/clear` fx          — declarative path removal.
+   - `configure-elision!`         — process-level knob for
+                                    `:rf.size/threshold-bytes`.
+   - `populate-elision-from-schemas!`
+                                  — schema-driven boot population: walks
+                                    every registered app-schema and
+                                    pre-populates `[:rf/elision :declarations]`
+                                    for every path whose registration carries
+                                    `:large? true` in its metadata."
+  (:require [re-frame.frame :as frame]
+            [re-frame.fx :as fx]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.trace :as trace]))
+
+;; ---- configuration --------------------------------------------------------
+
+(def default-threshold-bytes
+  "Default `:rf.size/threshold-bytes` (16 KiB). Per Spec API §Configure
+   keys (`:elision`). Values exceeding this in their `pr-str` form get
+   auto-flagged by the runtime auto-detect path; declared / schema
+   entries bypass the threshold (their predicate is a registry hit, not
+   a measurement)."
+  16384)
+
+(defonce
+  ^{:doc "Process-level `:rf.size/threshold-bytes` knob. Mutated by
+          `configure-elision!`. 0 disables runtime auto-detect (only
+          declared / schema entries elide)."}
+  threshold-bytes
+  (atom default-threshold-bytes))
+
+(defn configure-elision!
+  "Set the process-level `:rf.size/threshold-bytes` knob. Per Spec API
+   §Configure keys, dispatched from `(rf/configure :elision opts)`. A
+   non-negative integer; 0 disables runtime auto-detect."
+  [opts]
+  (let [n (:rf.size/threshold-bytes opts)]
+    (when (and (number? n) (not (neg? n)))
+      (reset! threshold-bytes (long n))))
+  nil)
+
+;; ---- registry primitives (in-app-db) --------------------------------------
+;;
+;; The registry lives at `[:rf/elision]` in every frame's app-db. Per
+;; Spec-Schemas §`:rf/elision-registry`:
+;;
+;;   {:declarations    {<path-vec> {:large? bool :hint <str-or-nil> :source <kw>}}
+;;    :runtime-flagged {<path-vec> {:bytes <int> :first-seen-epoch <int>}}}
+;;
+;; The slot is allocated lazily — absent until the first declaration.
+;; User code MUST NOT write under `:rf/elision`; the runtime owns it.
+
+(defn- registry-of
+  "Read the current `:rf/elision` registry value for a frame; nil when
+   the frame doesn't exist or the slot is unallocated."
+  [frame-id]
+  (when-let [container (frame/get-frame-db frame-id)]
+    (get (adapter/read-container container) :rf/elision)))
+
+(defn- swap-registry!
+  "Atomic update of a frame's `[:rf/elision ...]` registry via
+   `(f registry)`. Skips silently when the frame doesn't exist."
+  [frame-id f]
+  (when-let [container (frame/get-frame-db frame-id)]
+    (let [old-db (adapter/read-container container)
+          old-reg (get old-db :rf/elision)
+          new-reg (f old-reg)
+          new-db  (if (nil? new-reg)
+                    (dissoc old-db :rf/elision)
+                    (assoc old-db :rf/elision new-reg))]
+      (adapter/replace-container! container new-db)))
+  nil)
+
+(defn- write-declaration!
+  "Write `[:rf/elision :declarations <path>] -> entry` on the frame's
+   app-db. Idempotent — last-write-wins on duplicate paths."
+  [frame-id path entry]
+  (swap-registry! frame-id
+    (fn [reg]
+      (assoc-in (or reg {}) [:declarations path] entry))))
+
+(defn- clear-declaration!
+  "Remove `[:rf/elision :declarations <path>]` and the parallel
+   `:runtime-flagged` slot. Per [Conventions §Reserved fx-ids] —
+   `:rf.size/clear` dissocs both slots."
+  [frame-id path]
+  (swap-registry! frame-id
+    (fn [reg]
+      (when reg
+        (let [r1 (update reg :declarations dissoc path)
+              r2 (update r1  :runtime-flagged dissoc path)
+              r3 (cond-> r2
+                   (empty? (:declarations r2))    (dissoc :declarations)
+                   (empty? (:runtime-flagged r2)) (dissoc :runtime-flagged))]
+          (when (seq r3) r3))))))
+
+(defn- write-runtime-flagged!
+  "Write `[:rf/elision :runtime-flagged <path>] -> {:bytes N
+   :first-seen-epoch nil}`. Idempotent — caller short-circuits on a
+   prior flag so this only fires once per (path, frame)."
+  [frame-id path bytes]
+  (swap-registry! frame-id
+    (fn [reg]
+      (assoc-in (or reg {})
+                [:runtime-flagged path]
+                {:bytes (long bytes)}))))
+
+;; ---- public registry surface ----------------------------------------------
+
+(defn declarations
+  "Return the current `[:rf/elision :declarations]` map for a frame, or
+   `{}`. Pair tools and tests read this to introspect what paths are
+   nominated for elision. Default frame is `:rf/default`."
+  ([] (declarations :rf/default))
+  ([frame-id]
+   (or (get (registry-of frame-id) :declarations) {})))
+
+(defn runtime-flagged
+  "Return the current `[:rf/elision :runtime-flagged]` map for a frame,
+   or `{}`."
+  ([] (runtime-flagged :rf/default))
+  ([frame-id]
+   (or (get (registry-of frame-id) :runtime-flagged) {})))
+
+(defn- resolve-declaration
+  "Given a frame's `[:rf/elision]` registry and a path, return the
+   merged declaration map or nil. Conflict-resolution rule per
+   [009 §Size elision in traces]: declared wins, then runtime-flagged.
+   Schema entries live alongside declared entries (both under
+   `:declarations`) and are distinguished by `:source`."
+  [reg path]
+  (when reg
+    (or (get-in reg [:declarations path])
+        (when-let [rt (get-in reg [:runtime-flagged path])]
+          {:large? true
+           :hint   nil
+           :source :runtime-flagged
+           :bytes  (:bytes rt)}))))
+
+;; ---- public !-suffix wrappers ---------------------------------------------
+
+(defn declare-large-path!
+  "REPL / boot-time convenience wrapper for `:rf.size/declare-large`.
+   Writes `{:large? true :hint <hint-or-nil> :source :declared}` into
+   `[:rf/elision :declarations <path>]` against the current frame.
+   Per [API.md §`declare-large-path!`].
+
+   Three arities:
+
+     (declare-large-path! path)                ;; hint nil, current frame
+     (declare-large-path! path hint)           ;; hint, current frame
+     (declare-large-path! path hint frame-id)  ;; named frame
+
+   Returns nil. Idempotent on the same (path, frame) — last-write-wins."
+  ([path]      (declare-large-path! path nil  (frame/current-frame)))
+  ([path hint] (declare-large-path! path hint (frame/current-frame)))
+  ([path hint frame-id]
+   (write-declaration! frame-id path
+                       {:large? true
+                        :hint   hint
+                        :source :declared})
+   nil))
+
+(defn clear-large-path!
+  "REPL / boot-time convenience wrapper for `:rf.size/clear`. Clears
+   both the `:declarations` and `:runtime-flagged` slots for the path.
+   Per [API.md §`clear-large-path!`].
+
+   Two arities:
+
+     (clear-large-path! path)
+     (clear-large-path! path frame-id)
+
+   Returns nil."
+  ([path]          (clear-large-path! path (frame/current-frame)))
+  ([path frame-id] (clear-declaration! frame-id path) nil))
+
+;; ---- fx handlers ----------------------------------------------------------
+;;
+;; Per [Conventions §Reserved fx-ids]:
+;;   :rf.size/declare-large {:path [...] :hint <str-or-nil>}
+;;   :rf.size/clear         {:path [...]}
+
+(defn ^:no-doc declare-large-fx
+  "fx handler for `:rf.size/declare-large`. Per [Conventions §Reserved
+   fx-ids]. Args: `{:path [...] :hint <str-or-nil>}`. Writes (or merges)
+   a `{:large? true :hint ... :source :declared}` entry into
+   `[:rf/elision :declarations <path>]`."
+  [{:keys [frame]} {:keys [path hint source]}]
+  (let [frame-id (or frame :rf/default)]
+    (when (vector? path)
+      (write-declaration! frame-id path
+                          {:large? true
+                           :hint   hint
+                           :source (or source :declared)}))
+    nil))
+
+(defn ^:no-doc clear-fx
+  "fx handler for `:rf.size/clear`. Per [Conventions §Reserved fx-ids].
+   Args: `{:path [...]}`. `dissoc`s the slot at
+   `[:rf/elision :declarations <path>]` (and the parallel
+   `[:rf/elision :runtime-flagged <path>]`, if present)."
+  [{:keys [frame]} {:keys [path]}]
+  (let [frame-id (or frame :rf/default)]
+    (when (vector? path)
+      (clear-declaration! frame-id path))
+    nil))
+
+;; Register the fx-ids at namespace load. Per the `:rf.machine/spawn`
+;; pattern (rf2-xbtj) the elision fx ride the regular fx-registry; core
+;; ships them unconditionally because every implementation must support
+;; the size-elision contract (per Conventions §Reserved fx-ids the ids
+;; are reserved framework-owned even on ports that don't ship the
+;; walker, but the CLJS reference ships both).
+(fx/reg-fx :rf.size/declare-large
+  {:doc "Declare an app-db path as a candidate for size-elision at the wire boundary. Args: {:path [...] :hint <str-or-nil>}. Per Spec 009 §Size elision in traces."}
+  declare-large-fx)
+
+(fx/reg-fx :rf.size/clear
+  {:doc "Clear an elision declaration. Args: {:path [...]}. Per Spec 009 §Size elision in traces."}
+  clear-fx)
+
+;; ---- schema-driven boot population ---------------------------------------
+;;
+;; Per [009 §Size elision in traces] nomination 1 (Schema-driven): the
+;; runtime walks every registered app-schema at boot and writes
+;; `{:large? true :source :schema}` entries into the registry for every
+;; `:large? true` slot. The Malli-side walker (rf2-nwv63) ships
+;; separately; this helper provides the integration point that the
+;; schemas artefact (or a user app) calls when it wants the registry
+;; populated.
+;;
+;; This boot-time fn is idempotent: re-populating doesn't duplicate
+;; entries; declared entries (`:source :declared`) take precedence and
+;; are not overwritten.
+
+(defn- schema-properties
+  "Return the top-level Malli properties map of a schema form, or nil.
+   Recognises the literal vector form `[:map {props} & children]` and
+   the metadata-map fallback (some Malli setups carry props as
+   Clojure metadata on the schema value)."
+  [schema]
+  (cond
+    (and (vector? schema)
+         (> (count schema) 1)
+         (map? (nth schema 1)))
+    (nth schema 1)
+
+    ;; Fallback: metadata-form attachment. Try (meta schema) — returns
+    ;; nil for values that don't carry metadata; safe on both runtimes.
+    :else
+    (try
+      (meta schema)
+      (catch #?(:clj Throwable :cljs :default) _ nil))))
+
+(defn- schema-large?
+  "Return true when a registered schema slot carries `:large? true`.
+   Per [Spec-Schemas §`:rf/app-schema-meta`] — the `:large?` key lives
+   in the Malli-properties map of the schema. We deliberately accept
+   both the vector-form (`[:map {props} ...]`) and a metadata-form
+   fallback so test fixtures can attach `:large?` either way."
+  [schema]
+  (true? (:large? (schema-properties schema))))
+
+(defn populate-elision-from-schemas!
+  "Walk the registered app-schema set for a frame and write
+   `{:large? true :source :schema}` entries into the elision
+   `[:rf/elision :declarations]` registry for every path whose
+   registered schema carries `:large? true` in its top-level Malli
+   properties.
+
+   Per [009 §Size elision in traces] nomination 1 (Schema-driven).
+   Idempotent — re-populating updates existing `:source :schema`
+   entries in place. **Declared entries are preserved** (`:source
+   :declared` wins over `:source :schema`, per the conflict-resolution
+   rule).
+
+   No-op when the schemas artefact (day8/re-frame2-schemas) is not on
+   the classpath. Returns the vector of paths that were populated
+   (possibly empty)."
+  ([] (populate-elision-from-schemas! (frame/current-frame)))
+  ([frame-id]
+   (if-let [entries-fn (late-bind/get-fn :schemas/frame-schema-entries)]
+     (let [entries (entries-fn frame-id)]
+       (reduce
+        (fn [acc [path entry]]
+          (let [schema (:schema entry)]
+            (if (schema-large? schema)
+              (let [existing (get-in (registry-of frame-id) [:declarations path])]
+                ;; Preserve declared entries: don't clobber them with schema source.
+                (if (= :declared (:source existing))
+                  acc
+                  (do
+                    (write-declaration! frame-id path
+                                        {:large? true
+                                         :hint   (:hint (schema-properties schema))
+                                         :source :schema})
+                    (conj acc path))))
+              acc)))
+        []
+        entries))
+     [])))
+
+;; ---- walker primitives ----------------------------------------------------
+
+(def ^:private ^:const max-pr-str-bytes
+  "Safety ceiling on `pr-str-bytes` sampling — we never need to walk a
+   value beyond this size to decide it's too big; short-circuit at
+   threshold-bytes + 1 to keep auto-detect cheap."
+  (long 1048576))                       ; 1 MiB
+
+(defn- pr-str-bytes
+  "Approximate the `pr-str` byte count of `v`, capped at
+   `max-pr-str-bytes`. Returns an exact count for small values and the
+   cap for very large ones — exact-ness above the cap is irrelevant
+   because the elision predicate fires on (n > threshold)."
+  [v]
+  #?(:clj  (count (.getBytes ^String (pr-str v) "UTF-8"))
+     :cljs (count (pr-str v))))
+
+(defn- value-type
+  "Top-level shape of `v` for the marker's `:type` slot. Per Spec 009
+   one of `:map :vector :set :scalar :string`."
+  [v]
+  (cond
+    (map? v)     :map
+    (vector? v)  :vector
+    (set? v)     :set
+    (string? v)  :string
+    :else        :scalar))
+
+(defn- sha256-hex
+  "Compute a `sha256:<hex>` digest of `(pr-str v)` for the marker's
+   optional `:digest` slot. Only invoked when `:rf.size/include-digests?`
+   is true on the call. CLJS path uses an in-process hash via
+   `goog.crypt.Sha256` — not available, so the CLJS branch returns nil
+   (the field is OPTIONAL per the marker schema)."
+  [v]
+  #?(:clj
+     (let [bytes (.getBytes ^String (pr-str v) "UTF-8")
+           md    (doto (java.security.MessageDigest/getInstance "SHA-256")
+                   (.update bytes))
+           hex   (format "%064x" (java.math.BigInteger. 1 (.digest md)))]
+       (str "sha256:" hex))
+     :cljs
+     ;; goog.crypt.Sha256 is available in the closure library; we keep
+     ;; the CLJS branch simple by returning nil — callers that opt into
+     ;; digests on a CLJS runtime can wire in a host-side helper. Per
+     ;; the marker schema, :digest is OPTIONAL.
+     nil))
+
+(defn- handle-of
+  "Build the `:handle` slot for the marker. Per [Spec-Schemas
+   §`:rf/elision-marker`] — `[:rf.elision/at <path>]` or
+   `[:rf.elision/at <path> :as-of-epoch <epoch-id>]` when the marker
+   rides inside a past-epoch payload."
+  [path as-of-epoch]
+  (if as-of-epoch
+    [:rf.elision/at path :as-of-epoch as-of-epoch]
+    [:rf.elision/at path]))
+
+(defn- ->marker
+  "Build the `{:rf.size/large-elided {...}}` substitution map for an
+   elided value. Per Spec 009 §Wire marker."
+  [v path {:keys [reason hint as-of-epoch include-digests? known-bytes]}]
+  (let [bytes (or known-bytes (pr-str-bytes v))
+        body  (cond-> {:path   (vec path)
+                       :bytes  bytes
+                       :type   (value-type v)
+                       :reason (or reason :declared)
+                       :hint   hint
+                       :handle (handle-of (vec path) as-of-epoch)}
+                include-digests? (assoc :digest (sha256-hex v)))]
+    {:rf.size/large-elided body}))
+
+(def ^:private redacted-sentinel
+  "The `:rf/redacted` privacy sentinel emitted by the walker for slots
+   matching the `:sensitive?` predicate. Per [009 §Privacy / sensitive
+   data in traces] — the existing surface; the walker is the single
+   normative emission site (rf2-isdwf wires the per-event `:sensitive?`
+   stamping that this walker consults)."
+  :rf/redacted)
+
+(defn- sensitive-decl?
+  "Per-path `:sensitive?` predicate. Today the registry doesn't carry
+   per-path sensitivity (that's the rf2-isdwf cofx-side stamping work
+   in flight); we surface a forward-compatible read so that when the
+   sensitivity registry lands, callers don't need to revisit the
+   walker. Reads `:sensitive?` from a declaration entry if present."
+  [decl]
+  (true? (:sensitive? decl)))
+
+;; ---- the walker ----------------------------------------------------------
+
+(defn elide-wire-value
+  "Walk `v`, eliding values that match an elision predicate. Per
+   [API.md §`elide-wire-value`] — the framework primitive every wire-
+   emitting tool calls.
+
+   `opts` is a map:
+
+     :path                          — current path inside the slice's root
+                                      (default `[]`).
+     :frame                         — frame-id whose `[:rf/elision]`
+                                      registry to consult (default
+                                      `(frame/current-frame)`).
+     :rf.size/include-large?        — when true, large values pass
+                                      through unmodified (default
+                                      false).
+     :rf.size/include-sensitive?    — when true, sensitive values pass
+                                      through unmodified (default
+                                      false).
+     :rf.size/include-digests?      — when true, the marker's `:digest`
+                                      slot is computed (default false).
+     :rf.size/threshold-bytes       — runtime auto-detect threshold;
+                                      falls back to the configured
+                                      knob (default 16384). 0 disables
+                                      runtime auto-detect.
+     :as-of-epoch                   — when set, the marker's `:handle`
+                                      carries `:as-of-epoch <id>` for
+                                      past-epoch payloads (per Spec 009
+                                      §Composition × :rf.mcp/diff-from).
+
+   Composition rule (normative): when both predicates match the
+   **sensitive drop wins** — `:rf/redacted` is emitted; no
+   `:rf.size/large-elided` marker is produced (the marker itself would
+   leak `:path` / `:bytes` / `:digest`).
+
+   Returns either `v` (unmodified) or a substitution. Short-circuits
+   on elided subtrees — once a subtree is elided we don't recurse
+   into it."
+  ([v]
+   (elide-wire-value v {}))
+  ([v opts]
+   (let [path        (or (:path opts) [])
+         frame       (:frame opts)
+         as-of-epoch (:as-of-epoch opts)
+         include-large?     (true? (:rf.size/include-large? opts))
+         include-sensitive? (true? (:rf.size/include-sensitive? opts))
+         include-digests?   (true? (:rf.size/include-digests? opts))
+         threshold-opt      (:rf.size/threshold-bytes opts)
+         frame-id   (or frame (frame/current-frame) :rf/default)
+         threshold  (long (or threshold-opt @re-frame.elision/threshold-bytes))
+         reg        (registry-of frame-id)
+         path-vec   (vec path)]
+     (cond
+       ;; Nil / scalar fast path — never elidable.
+       (or (nil? v) (number? v) (boolean? v) (keyword? v) (symbol? v))
+       v
+
+       ;; Consult the registry first; declared / schema / runtime-flagged hit?
+       :else
+       (let [decl              (resolve-declaration reg path-vec)
+             ;; sensitive? — registry may carry it; the rf2-isdwf
+             ;; per-event :sensitive? stamping lands separately. The
+             ;; walker reads it as a regular predicate.
+             sensitive?        (sensitive-decl? decl)
+             ;; large? — declared / schema hit, or auto-detect over threshold.
+             ;;
+             ;; Runtime auto-detect fires on:
+             ;;   - leaf values (strings, scalars whose pr-str over-runs)
+             ;; but NOT on containers (maps/vectors/sets/seqs). Containers
+             ;; get walked; the per-leaf decision is where elision
+             ;; meaningfully shrinks the wire. (A 5MB base64 string lives
+             ;; at a leaf; eliding the wrapping map would discard small
+             ;; siblings unnecessarily.) Declared / schema entries
+             ;; override this and elide at any level.
+             declared-large?   (and (some? decl) (:large? decl))
+             auto-large?       (and (not declared-large?)
+                                    (pos? threshold)
+                                    (not (coll? v))
+                                    (string? v)
+                                    (let [n (pr-str-bytes v)]
+                                      (when (> n threshold)
+                                        n)))
+             large?            (or declared-large? auto-large?)
+             reason            (cond
+                                 declared-large?    (:source decl)
+                                 auto-large?        :runtime-flagged
+                                 :else              nil)
+             hint              (when declared-large? (:hint decl))
+             known-bytes       (cond
+                                 (number? auto-large?) auto-large?
+                                 declared-large?       nil
+                                 :else                 nil)]
+         (cond
+           ;; Composition rule: sensitive drop wins on both-flagged value.
+           (and sensitive? large?)
+           (if include-sensitive?
+             v
+             redacted-sentinel)
+
+           sensitive?
+           (if include-sensitive?
+             v
+             redacted-sentinel)
+
+           large?
+           (if include-large?
+             v
+             (do
+               ;; First-time auto-flag: persist the heuristic decision
+               ;; and emit the one-shot warning per (path, frame).
+               (when (and auto-large?
+                          (not (get-in reg [:runtime-flagged path-vec])))
+                 (write-runtime-flagged! frame-id path-vec
+                                         (or known-bytes (pr-str-bytes v)))
+                 (trace/emit! :warning :rf.warning/runtime-large-elision
+                              {:frame    frame-id
+                               :path     path-vec
+                               :bytes    (or known-bytes (pr-str-bytes v))
+                               :reason   :runtime-flagged
+                               :recovery :warned-and-replaced}))
+               (->marker v path-vec
+                         {:reason       reason
+                          :hint         hint
+                          :as-of-epoch  as-of-epoch
+                          :include-digests? include-digests?
+                          :known-bytes known-bytes})))
+
+           ;; No elision at this level — recurse into containers,
+           ;; preserving the per-key path. Per the short-circuit rule,
+           ;; we only descend when nothing here was substituted.
+           (map? v)
+           (reduce-kv
+            (fn [acc k vv]
+              (assoc acc k
+                     (elide-wire-value vv
+                                       (assoc opts
+                                              :path (conj path-vec k)
+                                              :frame frame-id))))
+            (empty v) v)
+
+           (vector? v)
+           (mapv (fn [idx vv]
+                   (elide-wire-value vv (assoc opts
+                                               :path (conj path-vec idx)
+                                               :frame frame-id)))
+                 (range) v)
+
+           (set? v)
+           (set (map (fn [vv]
+                       ;; Sets don't have indices; walk children with
+                       ;; the same path so a registered set-element
+                       ;; predicate still applies. Most callers won't
+                       ;; declare individual set members.
+                       (elide-wire-value vv (assoc opts
+                                                   :path path-vec
+                                                   :frame frame-id)))
+                     v))
+
+           (seq? v)
+           ;; Sequences (lists / lazy seqs) — walk and return a vector
+           ;; for wire stability. Per Tool-Pair, wire payloads are EDN
+           ;; data; converting seq -> vector is safe.
+           (mapv (fn [idx vv]
+                   (elide-wire-value vv (assoc opts
+                                               :path (conj path-vec idx)
+                                               :frame frame-id)))
+                 (range) v)
+
+           :else
+           v))))))
+
+;; ---- introspection sugar --------------------------------------------------
+
+(defn marker?
+  "True when `v` is a `:rf.size/large-elided` wire marker."
+  [v]
+  (and (map? v) (contains? v :rf.size/large-elided)))
+
+(defn handle?
+  "True when `v` is a `[:rf.elision/at <path> ...]` fetch-handle vector."
+  [v]
+  (and (vector? v) (= :rf.elision/at (first v))))

--- a/implementation/core/test/re_frame/elision_test.clj
+++ b/implementation/core/test/re_frame/elision_test.clj
@@ -1,0 +1,454 @@
+(ns re-frame.elision-test
+  "Coverage for the size-elision wire-boundary walker (rf2-v9tw2).
+
+  Per Spec API §`rf/elide-wire-value`, Spec 009 §Size elision in
+  traces, Spec-Schemas §`:rf/elision-registry` / `:rf/elision-marker`,
+  and Conventions §Reserved fx-ids / §Reserved app-db keys.
+
+  The walker is the single normative emission site for the
+  `:rf/redacted` privacy sentinel and the `:rf.size/large-elided`
+  size marker; this file exercises every nomination path (declared,
+  schema, runtime-flagged), the composition rule (sensitive drop
+  wins), the threshold knob, the fx-driven entry, the REPL wrappers,
+  and the restore-epoch / snapshot-restore correctness."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (reset! elision/threshold-bytes elision/default-threshold-bytes)
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr     :reload)
+  (require 're-frame.machines :reload)
+  ;; Re-register elision fxs after registrar/clear-all! wiped them.
+  (require 're-frame.elision :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+(defn- frame-db []
+  (rf/get-frame-db :rf/default))
+
+(defn- frame-db-value []
+  (frame/frame-app-db-value :rf/default))
+
+(defn- collect-traces! [id]
+  (let [acc (atom [])]
+    (rf/register-trace-cb! id (fn [ev] (swap! acc conj ev)))
+    acc))
+
+;; ---- 1. Walker no-op on small / non-elidable values ----------------------
+
+(deftest walker-noop-on-small-values
+  (testing "scalars pass through unmodified"
+    (is (= 42        (rf/elide-wire-value 42)))
+    (is (= nil       (rf/elide-wire-value nil)))
+    (is (= "hello"   (rf/elide-wire-value "hello")))
+    (is (= :a-keyword (rf/elide-wire-value :a-keyword)))
+    (is (= true      (rf/elide-wire-value true))))
+
+  (testing "small collections pass through unmodified"
+    (is (= {:a 1 :b 2}  (rf/elide-wire-value {:a 1 :b 2})))
+    (is (= [:x :y :z]   (rf/elide-wire-value [:x :y :z])))
+    (is (= #{1 2 3}     (rf/elide-wire-value #{1 2 3}))))
+
+  (testing "nested structure walks but does not elide when nothing declared"
+    (let [v {:user {:name "Ada" :age 36}
+             :ui   {:open? true}}]
+      (is (= v (rf/elide-wire-value v))))))
+
+;; ---- 2. Declared paths emit the size marker -------------------------------
+
+(deftest declared-path-emits-marker
+  (testing "declare-large-path! writes the registry slot"
+    (rf/declare-large-path! [:user :uploaded-pdf] "Upload preview blob")
+    (let [decls (rf/elision-declarations :rf/default)]
+      (is (= 1 (count decls)))
+      (is (= {:large? true :hint "Upload preview blob" :source :declared}
+             (get decls [:user :uploaded-pdf])))))
+
+  (testing "the walker substitutes a :rf.size/large-elided marker at the declared path"
+    (rf/declare-large-path! [:user :uploaded-pdf] "Upload preview blob")
+    (let [db    {:user {:name "Ada" :uploaded-pdf "<<5MB-blob>>"}}
+          out   (rf/elide-wire-value db)
+          slot  (get-in out [:user :uploaded-pdf])]
+      (is (elision/marker? slot))
+      (is (= [:user :uploaded-pdf]
+             (get-in slot [:rf.size/large-elided :path])))
+      (is (= :string (get-in slot [:rf.size/large-elided :type])))
+      (is (= :declared (get-in slot [:rf.size/large-elided :reason])))
+      (is (= "Upload preview blob"
+             (get-in slot [:rf.size/large-elided :hint])))
+      (is (= [:rf.elision/at [:user :uploaded-pdf]]
+             (get-in slot [:rf.size/large-elided :handle])))
+      (is (pos-int? (get-in slot [:rf.size/large-elided :bytes])))))
+
+  (testing "non-declared siblings ride through unmodified"
+    (rf/declare-large-path! [:user :uploaded-pdf])
+    (let [db  {:user {:name "Ada" :uploaded-pdf "X" :role :admin}
+               :ui   {:open? true}}
+          out (rf/elide-wire-value db)]
+      (is (= "Ada"   (get-in out [:user :name])))
+      (is (= :admin  (get-in out [:user :role])))
+      (is (= true    (get-in out [:ui :open?])))
+      (is (elision/marker? (get-in out [:user :uploaded-pdf]))))))
+
+;; ---- 3. include-large? bypasses the elision -------------------------------
+
+(deftest include-large-bypasses-elision
+  (rf/declare-large-path! [:big])
+  (testing "default opts elide"
+    (let [out (rf/elide-wire-value {:big "blob"})]
+      (is (elision/marker? (get out :big)))))
+  (testing ":rf.size/include-large? true passes the value through"
+    (let [out (rf/elide-wire-value {:big "blob"}
+                                   {:rf.size/include-large? true})]
+      (is (= "blob" (get out :big))))))
+
+;; ---- 4. Runtime auto-detect over threshold --------------------------------
+
+(deftest runtime-auto-detect-over-threshold
+  (testing "values whose pr-str exceeds threshold are auto-flagged"
+    (rf/configure :elision {:rf.size/threshold-bytes 64})
+    (let [big   (apply str (repeat 100 "ABCDEFGH"))   ; ~800 bytes
+          db    {:user {:photo big}}
+          traces (collect-traces! :elision-test/auto-detect)
+          out   (rf/elide-wire-value db)]
+      (is (elision/marker? (get-in out [:user :photo])))
+      (is (= :runtime-flagged
+             (get-in out [:user :photo :rf.size/large-elided :reason])))
+      (testing "the path is persisted in [:rf/elision :runtime-flagged]"
+        (let [rf-flagged (rf/elision-runtime-flagged :rf/default)]
+          (is (contains? rf-flagged [:user :photo]))
+          (is (pos-int? (get-in rf-flagged [[:user :photo] :bytes])))))
+      (testing "the one-shot warning fires"
+        (is (some #(= :rf.warning/runtime-large-elision (:operation %)) @traces)))
+      (rf/remove-trace-cb! :elision-test/auto-detect))))
+
+(deftest runtime-auto-detect-fires-once-per-path
+  (testing "subsequent emits on the same path don't re-emit the warning"
+    (rf/configure :elision {:rf.size/threshold-bytes 64})
+    (let [big    (apply str (repeat 100 "ABCDEFGH"))
+          db     {:photo big}
+          traces (collect-traces! :elision-test/auto-once)
+          _      (rf/elide-wire-value db)
+          n1     (count (filter #(= :rf.warning/runtime-large-elision (:operation %)) @traces))
+          _      (rf/elide-wire-value db)
+          _      (rf/elide-wire-value db)
+          n2     (count (filter #(= :rf.warning/runtime-large-elision (:operation %)) @traces))]
+      (is (= 1 n1))
+      (is (= 1 n2)
+          "warning is one-shot per (path, frame)")
+      (rf/remove-trace-cb! :elision-test/auto-once))))
+
+;; ---- 5. Threshold-bytes knob honoured ------------------------------------
+
+(deftest threshold-knob-honoured
+  (testing "default 16384 lets a 1KB value pass"
+    (let [med (apply str (repeat 100 "ABCDEFGH"))    ; ~800 bytes
+          out (rf/elide-wire-value {:m med})]
+      (is (= med (get out :m)))))
+  (testing "lowering the threshold to 100 elides a 1KB value"
+    (rf/configure :elision {:rf.size/threshold-bytes 100})
+    (let [med (apply str (repeat 100 "ABCDEFGH"))
+          out (rf/elide-wire-value {:m med})]
+      (is (elision/marker? (get out :m)))))
+  (testing "threshold 0 disables runtime auto-detect"
+    (rf/configure :elision {:rf.size/threshold-bytes 0})
+    (let [big (apply str (repeat 5000 "ABCDEFGH"))    ; ~40K bytes
+          out (rf/elide-wire-value {:b big})]
+      (is (= big (get out :b))
+          "no declared / schema entry + threshold 0 = no elision"))))
+
+;; ---- 6. Per-call threshold override --------------------------------------
+
+(deftest per-call-threshold-override
+  (testing "opts :rf.size/threshold-bytes overrides the process knob"
+    (let [med (apply str (repeat 200 "ABCD"))    ; ~800 bytes
+          out (rf/elide-wire-value {:m med}
+                                   {:rf.size/threshold-bytes 100})]
+      (is (elision/marker? (get out :m))))))
+
+;; ---- 7. clear-large-path! removes the declaration ------------------------
+
+(deftest clear-large-path-removes-declaration
+  (rf/declare-large-path! [:big] "hint")
+  (is (contains? (rf/elision-declarations) [:big]))
+  (rf/clear-large-path! [:big])
+  (is (not (contains? (rf/elision-declarations) [:big])))
+  (testing "after clear, the value rides through"
+    (let [out (rf/elide-wire-value {:big "v"})]
+      (is (= "v" (get out :big))))))
+
+(deftest clear-also-clears-runtime-flagged
+  (rf/configure :elision {:rf.size/threshold-bytes 32})
+  (let [big (apply str (repeat 100 "X"))]
+    (rf/elide-wire-value {:p big})        ;; populates runtime-flagged
+    (is (contains? (rf/elision-runtime-flagged) [:p]))
+    (rf/clear-large-path! [:p])
+    (is (not (contains? (rf/elision-runtime-flagged) [:p])))))
+
+;; ---- 8. fx-driven entry — :rf.size/declare-large -------------------------
+
+(deftest fx-declare-large-writes-registry
+  (rf/reg-event-fx :elision-test/setup
+    (fn [_ _]
+      {:fx [[:rf.size/declare-large {:path [:user :photo] :hint "avatar"}]]}))
+  (rf/dispatch-sync [:elision-test/setup])
+  (let [decls (rf/elision-declarations)]
+    (is (= {:large? true :hint "avatar" :source :declared}
+           (get decls [:user :photo])))))
+
+(deftest fx-clear-removes-registry
+  (rf/declare-large-path! [:p] "h")
+  (rf/reg-event-fx :elision-test/clear
+    (fn [_ _]
+      {:fx [[:rf.size/clear {:path [:p]}]]}))
+  (rf/dispatch-sync [:elision-test/clear])
+  (is (not (contains? (rf/elision-declarations) [:p]))))
+
+(deftest fx-atomic-with-db-write
+  (testing "a cascade that writes :db AND declares a path sees both effects"
+    (rf/reg-event-fx :elision-test/atomic
+      (fn [{:keys [db]} _]
+        {:db (assoc db :user/uploaded "BLOB")
+         :fx [[:rf.size/declare-large {:path [:user/uploaded] :hint nil}]]}))
+    (rf/dispatch-sync [:elision-test/atomic])
+    (is (= "BLOB" (get (frame-db-value) :user/uploaded)))
+    (is (contains? (rf/elision-declarations) [:user/uploaded]))
+    (testing "the walker on the post-cascade db elides the new slot"
+      (let [out (rf/elide-wire-value (frame-db-value))]
+        (is (elision/marker? (get out :user/uploaded)))))))
+
+;; ---- 9. Composition: sensitive drop wins on both-flagged value ----------
+
+(deftest sensitive-wins-over-large
+  (testing "a path declared :large? AND :sensitive? drops to :rf/redacted (sensitive wins)"
+    ;; Write the registry slot directly so we can co-flag both predicates.
+    ;; The fx-driven path doesn't expose :sensitive? today (rf2-isdwf
+    ;; ships that separately); the walker's composition rule is verified
+    ;; against the registry-level read.
+    (rf/declare-large-path! [:secret-pdf] "private blob")
+    (let [c (frame/get-frame-db :rf/default)]
+      ;; Mutate in-place: write a :sensitive? slot alongside :large?.
+      (adapter/replace-container! c
+                                  (assoc-in (adapter/read-container c)
+                                            [:rf/elision :declarations [:secret-pdf]]
+                                            {:large? true
+                                             :sensitive? true
+                                             :hint "private blob"
+                                             :source :declared})))
+    (let [out (rf/elide-wire-value {:secret-pdf "X"})]
+      (is (= :rf/redacted (get out :secret-pdf))
+          "sensitive sentinel emitted; no :rf.size/large-elided marker")
+      (is (not (elision/marker? (get out :secret-pdf)))))))
+
+;; ---- 10. Walker short-circuits inside an elided subtree ------------------
+
+(deftest walker-short-circuits-inside-elided-subtree
+  (rf/declare-large-path! [:huge])
+  (testing "the walker does not recurse into an elided value"
+    ;; Build a deeply nested map; if the walker descended, it would
+    ;; elide inner nodes too. With short-circuit, only the top is a
+    ;; marker — and the marker carries the absolute path of the
+    ;; elision site, not any inner key.
+    (let [inner (into {} (for [i (range 50)] [(keyword (str "k" i)) i]))
+          v     {:huge inner}
+          out   (rf/elide-wire-value v)
+          slot  (get out :huge)]
+      (is (elision/marker? slot))
+      (is (= :map (get-in slot [:rf.size/large-elided :type])))
+      (testing "marker body does not embed the original inner map"
+        (let [body (:rf.size/large-elided slot)]
+          (is (not (contains? body :k0))
+              "inner keys did not bubble into the marker body")
+          (is (= [:huge] (:path body))
+              "marker path is the elision site, not any inner subkey"))))))
+
+;; ---- 11. The marker's :path field is absolute ----------------------------
+
+(deftest marker-path-is-absolute
+  (rf/declare-large-path! [:a :b :c])
+  (let [v   {:a {:b {:c "X" :d :ok}}}
+        out (rf/elide-wire-value v)]
+    (is (= [:a :b :c]
+           (get-in out [:a :b :c :rf.size/large-elided :path]))
+        "marker carries the absolute path, not the elision-site offset")))
+
+;; ---- 12. The marker's :handle round-trips through the path ---------------
+
+(deftest marker-handle-is-fetchable-vector
+  (rf/declare-large-path! [:user :uploaded-pdf] "blob")
+  (let [out    (rf/elide-wire-value {:user {:uploaded-pdf "X"}})
+        handle (get-in out [:user :uploaded-pdf :rf.size/large-elided :handle])]
+    (is (elision/handle? handle))
+    (is (= [:rf.elision/at [:user :uploaded-pdf]] handle))))
+
+(deftest marker-handle-carries-as-of-epoch
+  (rf/declare-large-path! [:big])
+  (let [out    (rf/elide-wire-value {:big "X"} {:as-of-epoch 42})
+        handle (get-in out [:big :rf.size/large-elided :handle])]
+    (is (= [:rf.elision/at [:big] :as-of-epoch 42] handle))))
+
+;; ---- 13. include-digests? gates the :digest slot --------------------------
+
+(deftest include-digests-gates-digest-slot
+  (rf/declare-large-path! [:b])
+  (testing "default: :digest is absent"
+    (let [out (rf/elide-wire-value {:b "X"})]
+      (is (not (contains? (get-in out [:b :rf.size/large-elided]) :digest)))))
+  (testing "with :rf.size/include-digests? true, :digest is computed (CLJ runtime)"
+    (let [out (rf/elide-wire-value {:b "X"}
+                                   {:rf.size/include-digests? true})
+          digest (get-in out [:b :rf.size/large-elided :digest])]
+      (is (string? digest))
+      (is (.startsWith ^String digest "sha256:")))))
+
+;; ---- 14. Schema-driven boot population -----------------------------------
+
+(deftest schema-driven-boot-population
+  (testing "populate-elision-from-schemas! walks registered app-schemas"
+    ;; Register schemas where one path's schema literal carries :large? true.
+    (rf/reg-app-schema [:user] [:map {:doc "the user"} [:name :string]])
+    (rf/reg-app-schema [:uploaded-pdf]
+                       [:map {:large? true :hint "uploaded blob"}
+                        [:bytes :string]])
+    (rf/reg-app-schema [:csv-rows]
+                       [:vector {:large? true} :any])
+    (let [populated (rf/populate-elision-from-schemas!)
+          decls     (rf/elision-declarations)]
+      (is (= 2 (count populated)))
+      (is (= #{[:uploaded-pdf] [:csv-rows]} (set populated)))
+      (is (= :schema (get-in decls [[:uploaded-pdf] :source])))
+      (is (= "uploaded blob" (get-in decls [[:uploaded-pdf] :hint])))
+      (is (= :schema (get-in decls [[:csv-rows] :source]))))))
+
+(deftest schema-population-is-idempotent
+  (rf/reg-app-schema [:big] [:any {:large? true}])
+  (rf/populate-elision-from-schemas!)
+  (rf/populate-elision-from-schemas!)
+  (let [decls (rf/elision-declarations)]
+    (is (= 1 (count decls)))
+    (is (= :schema (get-in decls [[:big] :source])))))
+
+(deftest schema-population-preserves-declared-entries
+  (testing "a :source :declared entry is NOT overwritten by schema-driven population"
+    (rf/declare-large-path! [:foo] "app declared this")
+    (rf/reg-app-schema [:foo] [:any {:large? true :hint "schema thinks otherwise"}])
+    (rf/populate-elision-from-schemas!)
+    (let [d (get (rf/elision-declarations) [:foo])]
+      (is (= :declared (:source d)) "declared wins over schema")
+      (is (= "app declared this" (:hint d))))))
+
+(deftest schema-population-noop-when-schemas-artefact-absent
+  (testing "with no late-bind hook, population is a no-op"
+    (let [restore-fn (late-bind/get-fn :schemas/frame-schema-entries)]
+      (late-bind/set-fn! :schemas/frame-schema-entries nil)
+      (try
+        (is (= [] (rf/populate-elision-from-schemas!)))
+        (finally
+          (late-bind/set-fn! :schemas/frame-schema-entries restore-fn))))))
+
+;; ---- 15. Snapshot-restore correctness ------------------------------------
+
+(deftest declarations-survive-app-db-snapshot-restore
+  (testing "declarations live in app-db; serialising + restoring round-trips them"
+    (rf/declare-large-path! [:user :uploaded-pdf] "blob")
+    (let [snap (frame-db-value)
+          decls-before (rf/elision-declarations)]
+      (is (contains? decls-before [:user :uploaded-pdf]))
+      ;; Simulate restore: blow away app-db then push the snapshot back.
+      (let [container (frame/get-frame-db :rf/default)]
+        (adapter/replace-container! container {})
+        (is (= {} (rf/elision-declarations))
+            "wipe confirmed")
+        (adapter/replace-container! container snap)
+        (is (= decls-before (rf/elision-declarations))
+            "restored snapshot carries the same declarations")
+        (let [out (rf/elide-wire-value {:user {:uploaded-pdf "X"}})]
+          (is (elision/marker? (get-in out [:user :uploaded-pdf]))))))))
+
+;; ---- 16. Recursive nested walk ------------------------------------------
+
+(deftest walker-recurses-into-children
+  (rf/declare-large-path! [:a :b :c])
+  (rf/declare-large-path! [:x])
+  (let [v   {:a {:b {:c "blob1"} :d :ok} :x "blob2" :y "small"}
+        out (rf/elide-wire-value v)]
+    (is (elision/marker? (get-in out [:a :b :c])))
+    (is (= :ok (get-in out [:a :d])))
+    (is (elision/marker? (get out :x)))
+    (is (= "small" (get out :y)))))
+
+;; ---- 17. Walker handles vectors with indexed paths -----------------------
+
+(deftest walker-walks-vectors-by-index
+  (rf/declare-large-path! [:items 1])
+  (let [v   {:items ["a" "b" "c"]}
+        out (rf/elide-wire-value v)]
+    (is (= "a" (get-in out [:items 0])))
+    (is (elision/marker? (get-in out [:items 1])))
+    (is (= "c" (get-in out [:items 2])))))
+
+;; ---- 18. registry helpers return empty maps for fresh frames -------------
+
+(deftest registry-helpers-return-empty-maps
+  (is (= {} (rf/elision-declarations)))
+  (is (= {} (rf/elision-runtime-flagged))))
+
+;; ---- 19. Marker shape carries required fields ----------------------------
+
+(deftest marker-shape-spec-compliance
+  (rf/declare-large-path! [:b] "hint")
+  (let [out  (rf/elide-wire-value {:b "X"})
+        body (get-in out [:b :rf.size/large-elided])]
+    (testing "Spec-Schemas §:rf/elision-marker — required fields present"
+      (is (contains? body :path))
+      (is (contains? body :bytes))
+      (is (contains? body :type))
+      (is (contains? body :reason))
+      (is (contains? body :hint))
+      (is (contains? body :handle)))
+    (testing "field types per the schema"
+      (is (vector? (:path body)))
+      (is (int?    (:bytes body)))
+      (is (#{:map :vector :set :scalar :string} (:type body)))
+      (is (#{:declared :schema :runtime-flagged} (:reason body)))
+      (is (vector? (:handle body))))))
+
+;; ---- 20. Boot-time wrapper: declare-large-path! at REPL works ------------
+
+(deftest repl-wrappers-work-outside-event-cycle
+  (testing "declare-large-path! without dispatch — REPL/boot-time form"
+    (rf/declare-large-path! [:repl])
+    (is (contains? (rf/elision-declarations) [:repl])))
+
+  (testing "clear-large-path! without dispatch"
+    (rf/declare-large-path! [:repl2])
+    (rf/clear-large-path! [:repl2])
+    (is (not (contains? (rf/elision-declarations) [:repl2])))))
+
+;; ---- 21. Multiple frames keep isolated registries ------------------------
+
+(deftest registries-are-frame-isolated
+  (testing "declarations on :rf/default do not bleed to another frame"
+    (frame/reg-frame :elision-test/other {})
+    (rf/declare-large-path! [:on-default] nil :rf/default)
+    (rf/declare-large-path! [:on-other]   nil :elision-test/other)
+    (is (contains? (rf/elision-declarations :rf/default) [:on-default]))
+    (is (not (contains? (rf/elision-declarations :rf/default) [:on-other])))
+    (is (contains? (rf/elision-declarations :elision-test/other) [:on-other]))
+    (is (not (contains? (rf/elision-declarations :elision-test/other) [:on-default])))))


### PR DESCRIPTION
Implements the framework runtime layer for size-elision in `implementation/core/`, locking the contract that rf2-hmmx7 (PR #664) spec'd. Bead: **rf2-v9tw2**.

## Summary

- New namespace `implementation/core/src/re_frame/elision.cljc` carrying the walker, the in-app-db registry mechanics, the `:rf.size/declare-large` / `:rf.size/clear` fxs, the `(rf/configure :elision ...)` knob, and the schema-driven boot helper.
- Public surface re-exported through `re-frame.core`:
  - `rf/elide-wire-value` (the walker)
  - `rf/declare-large-path!` / `rf/clear-large-path!` (REPL/boot wrappers)
  - `rf/populate-elision-from-schemas!` (schema-driven boot)
  - `rf/elision-declarations` / `rf/elision-runtime-flagged` (introspection)
- The walker is the **single normative emission site** for the `:rf/redacted` privacy sentinel and the `:rf.size/large-elided` marker per [spec/API.md §Size-elision wire-boundary walker](../blob/main/spec/API.md#elide-wire-value-the-wire-boundary-walker).

## Walker algorithm decisions

- **Auto-detect fires on string leaves only** (and non-coll scalars). Containers get walked rather than measured — eliding a wrapping map would discard small siblings. Declared/schema entries override at any level.
- **Composition rule (normative):** when both `:sensitive?` and `:large?` match the **sensitive drop wins** — `:rf/redacted` emitted, no `:rf.size/large-elided` marker (the marker would leak `:path` / `:bytes` / `:digest`). Walker reads `:sensitive?` from the registry as a forward-compatible predicate; rf2-isdwf's cofx-side stamping lands the canonical write path separately.
- **Short-circuit:** once a subtree is elided, the walker does NOT recurse. A 5MB nested map elides at the top.
- **`:handle` carries `:as-of-epoch`** when the marker rides a past-epoch payload (per spec/009 §Composition × `:rf.mcp/diff-from`).
- **Runtime auto-flag** persists into `[:rf/elision :runtime-flagged]` AND emits `:rf.warning/runtime-large-elision` once per `(path, frame)`.

## Registry shape

Lives at `[:rf/elision]` in every frame's app-db (reserved key per [spec/Conventions.md §Reserved app-db keys](../blob/main/spec/Conventions.md#reserved-app-db-keys)). Per [Spec-Schemas §`:rf/elision-registry`](../blob/main/spec/Spec-Schemas.md#rfelision-registry):

```clojure
{:declarations    {<path-vec> {:large? true :hint <str-or-nil> :source <:declared|:schema|:runtime-flagged>}}
 :runtime-flagged {<path-vec> {:bytes <int>}}}
```

Living in app-db gives **restore-epoch correctness for free** — same mechanism by which `:rf/machines`, `:rf/spawned`, `:rf/route` inherit frame-state revertibility (covered by the `declarations-survive-app-db-snapshot-restore` test).

## Threshold default

`:rf.size/threshold-bytes` defaults to **16384** per [spec/API.md §Configure keys](../blob/main/spec/API.md#configure-keys). `0` disables runtime auto-detect (only declared/schema entries elide). Set via `(rf/configure :elision {:rf.size/threshold-bytes N})`.

## Tests

29 deftests / 98 assertions in `implementation/core/test/re_frame/elision_test.clj`. Coverage:

- Walker no-op on small / non-elidable values
- Declared path emits marker with full shape
- `:rf.size/include-large? true` bypass
- Runtime auto-detect over threshold + one-shot warning per `(path, frame)`
- Threshold knob (default, per-call override, 0 disables)
- `clear-large-path!` removes both `:declarations` and `:runtime-flagged`
- fx-driven entry (`:rf.size/declare-large` / `:rf.size/clear`)
- Atomic `:db` + `:fx` cascade
- **Sensitive wins over large** (composition rule)
- Walker short-circuit inside elided subtree
- Marker `:path` is absolute
- `:handle` round-trip with and without `:as-of-epoch`
- `:digest` gating on `:rf.size/include-digests?`
- Schema-driven boot population (populate, idempotent, preserves declared, no-op without schemas artefact)
- Snapshot-restore correctness
- Nested recursive walk
- Vector indexing
- Marker shape spec compliance (`:rf/elision-marker` schema)
- REPL wrappers outside event cycle
- Frame-isolated registries

## Suite totals

- `implementation/core` (JVM, `clojure -M:test`): **387 tests / 2083 assertions** — was 358 / 1985 before.
- `npm run test:cljs` (CLJS / node): **1685 tests / 4660 assertions** — unchanged.

## Dependency on parallel work

- **rf2-isdwf** (parallel, in-flight): per-event `:sensitive?` stamping that the walker reads. The composition-rule branch is wired and tested via direct registry mutation; the test scenario `sensitive-wins-over-large` covers the walker contract independently of rf2-isdwf's emit-side work landing.
- **rf2-nwv63** (separate): deeper Malli-walker for nested `:large?` metadata on app-schema subtrees. Current schema-driven boot handles the top-level Malli properties form, which is what ships today.

## Cross-cutting follow-ons spotted

- The `:sensitive?` slot on declarations is writeable only by direct registry mutation today; rf2-isdwf's cofx-side stamping will land the canonical write path.
- The walker's CLJS `:digest` branch returns nil; a future CLJS-side `sha256` helper (goog.crypt.Sha256 wrapper) can fill that in without changing the marker schema (`:digest` is OPTIONAL).
- The walker turns sequences into vectors for wire stability — worth confirming this is the right call when streaming-from-server payloads land.

## Test plan

- [x] `clojure -M:test` from `implementation/core` (387 / 2083, green)
- [x] `npm run test:cljs` from `implementation` (1685 / 4660, green)
- [ ] Reviewer eyes the composition rule + short-circuit
- [ ] Reviewer eyes the schema-driven boot's `:source` precedence (declared wins over schema)