### PR TITLE
feat(schemas): :large? schema-metadata walker + boot-time elision-registry population (rf2-nwv63)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -135,6 +135,18 @@
     :producer-ns 're-frame.schemas.malli
     :design-bead "rf2-t0hq"
     :description "Default-installed Malli explainer (malli.core/explain)."}
+   {:key         :schemas/extract-large-paths-from-schema
+    :producer-ns 're-frame.schemas
+    :design-bead "rf2-nwv63"
+    :description "Walk a Malli EDN form at a base-path; return {path declaration} entries for :large? true slots."}
+   {:key         :schemas/frame-elision-declarations
+    :producer-ns 're-frame.schemas
+    :design-bead "rf2-nwv63"
+    :description "Merged {path declaration} for every :large? slot in every app-schema registered against a frame."}
+   {:key         :schemas/populate-elision-declarations
+    :producer-ns 're-frame.schemas
+    :design-bead "rf2-nwv63"
+    :description "Idempotent: hydrate app-db [:rf/elision :declarations] from a frame's schema-derived large-path declarations."}
 
    ;; ---- re-frame.machines (rf2-xbtj / rf2-8bp3) ------------------------------
    {:key         :machines/reg-machine

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -359,6 +359,290 @@
   [frame-id]
   (get @schemas-by-frame frame-id {}))
 
+;; ---- elision-declaration walker (rf2-nwv63) ------------------------------
+;;
+;; Per Spec 009 §Size elision in traces, the schema-driven nomination
+;; path: any Malli slot carrying `:large? true` in its per-slot
+;; properties (per Spec-Schemas §`:rf/app-schema-meta` — the per-slot
+;; metadata vocabulary) is registered into the frame's
+;; `[:rf/elision :declarations]` slot with `:source :schema`. The
+;; framework's `rf/elide-wire-value` walker (rf2-v9tw2, downstream)
+;; consults this registry at every wire-boundary emit.
+;;
+;; This file owns the **walker** that maps a registered schema's EDN
+;; form to a `{path declaration}` map; the actual app-db write lives
+;; in `re-frame.elision` (rf2-v9tw2) so that file owns the unified
+;; registry surface across the schema / declared / runtime-flagged
+;; sources. The seam between the two is the late-bind hook
+;; `:schemas/frame-elision-declarations` (registered at the bottom
+;; of this file).
+;;
+;; The walker is **pure data** — it doesn't import malli.core. Malli
+;; EDN forms are vectors of the shape `[op props? children...]`; we
+;; pattern-match on shape. Per Spec 010 §The `:spec` value is opaque
+;; to re-frame, the framework MUST NOT call into the registered
+;; validator to introspect schema structure — we walk the EDN
+;; ourselves. This means the walker handles the **vector form**
+;; (`[:map [:k :string]]`) — the form `(rf/reg-app-schema ...)` users
+;; write. Non-vector Malli forms (schema objects, registry refs) are
+;; treated as opaque leaves; their internal `:large?` declarations
+;; are invisible to the walker (the same caveat applies to Malli's
+;; own schema-walking when introspection goes through `m/schema` ↔
+;; raw EDN — round-tripping a registry ref loses the slot metadata).
+
+(defn- schema-vector?
+  "True when `x` is a Malli vector form `[op props? children...]`."
+  [x]
+  (and (vector? x) (pos? (count x))))
+
+(defn- extract-props
+  "Pluck the per-slot properties map out of a Malli vector form. The
+  Malli convention: `[op {props} children...]` carries the map at
+  position 1; `[op children...]` (no props) has a child at position 1.
+  Return `nil` when no props are present."
+  [v]
+  (let [p (when (>= (count v) 2) (nth v 1))]
+    (when (map? p) p)))
+
+(defn- drop-op+props
+  "Return the children portion of a Malli vector form — drop the op
+  keyword and the optional props map."
+  [v]
+  (let [tail (subvec v 1)]
+    (if (and (seq tail) (map? (first tail)))
+      (subvec tail 1)
+      tail)))
+
+(defn- declaration-from-props
+  "Build a `:rf/elision-declaration` map from a slot's per-slot props,
+  or nil if `:large? true` is not set. Per Spec 009 §Size elision in
+  traces — the declaration shape is `{:large? bool :hint <str-or-nil>
+  :source :schema}`. The `:hint` is OPTIONAL (omitted from the map
+  when absent so the marker shape is minimal)."
+  [props]
+  (when (true? (:large? props))
+    (cond-> {:large? true
+             :source :schema}
+      (some? (:hint props)) (assoc :hint (:hint props)))))
+
+;; -- per-op recursion helpers --------------------------------------
+
+(declare walk-schema)
+
+(defn- walk-map-children
+  "For a `:map` form, walk every name-bearing child entry. A child
+  entry is `[k child-schema]` or `[k {props} child-schema]`. The
+  `:large?` flag may live in two places:
+
+    1. The slot's own props (one level above the child schema):
+         [:map [:user {:large? true} :string]]
+       — path is `(conj base k)`; the slot says \"this slot is large\".
+
+    2. The child schema's own props (one level inside):
+         [:map [:user [:string {:large? true}]]]
+       — path is `(conj base k)`; the schema says \"this value is
+       large by type\". Equivalent under the walker since the path
+       is the same.
+
+  We capture both; conflicts (slot props AND child props both
+  carry `:large?`) merge with slot-level winning per a left-to-
+  right semantics (slot props are more local to the path)."
+  [children base-path acc]
+  (reduce
+    (fn [acc child]
+      (if-not (and (vector? child) (>= (count child) 2))
+        acc
+        (let [k          (nth child 0)
+              maybe-prop (nth child 1)
+              has-prop?  (map? maybe-prop)
+              slot-props (when has-prop? maybe-prop)
+              child-tail (if has-prop?
+                           (when (>= (count child) 3) (nth child 2))
+                           maybe-prop)
+              slot-path  (conj base-path k)
+              slot-decl  (declaration-from-props slot-props)
+              acc'       (if slot-decl
+                           (assoc acc slot-path slot-decl)
+                           acc)]
+          (if (some? child-tail)
+            (walk-schema child-tail slot-path acc')
+            acc'))))
+    acc
+    children))
+
+(defn- walk-multi-children
+  "`:multi` and `:orn` carry name-bearing branches similarly to
+  `:map`. The branch's name is the dispatch value, NOT an app-db path
+  segment — so `:large?` on a `:multi` branch's slot props claims the
+  parent path (the `:multi` op's own `base-path`), not a child path.
+  We recurse into the branch schema at `base-path`."
+  [children base-path acc]
+  (reduce
+    (fn [acc child]
+      (cond
+        ;; [v schema] or [v props schema] branch — descend into schema
+        ;; at the SAME base-path (dispatch values aren't path segments).
+        (vector? child)
+        (let [maybe-prop (when (>= (count child) 2) (nth child 1))
+              has-prop?  (map? maybe-prop)
+              tail-idx   (if has-prop? 2 1)
+              tail       (when (> (count child) tail-idx) (nth child tail-idx))
+              branch-decl (when has-prop? (declaration-from-props maybe-prop))
+              acc'        (if branch-decl
+                            (assoc acc base-path branch-decl)
+                            acc)]
+          (if (some? tail) (walk-schema tail base-path acc') acc'))
+        :else acc))
+    acc
+    children))
+
+(defn- walk-positional-children
+  "For positional / nameless container ops (`:vector`, `:set`,
+  `:sequential`, `:maybe`, `:and`, `:or`, `:not`, `:tuple`, `:cat`,
+  `:catn`, etc.), descend into each child at the SAME `base-path` —
+  these ops don't introduce a new app-db path segment (a vector's
+  inner schema doesn't add a path key). `:large?` on the inner
+  schema's own props applies to the container's path."
+  [children base-path acc]
+  (reduce (fn [acc c] (walk-schema c base-path acc)) acc children))
+
+(def ^:private name-bearing-ops
+  "Schema ops whose children carry name slots (the first element of a
+  child entry is the slot's app-db key)."
+  #{:map})
+
+(def ^:private dispatch-bearing-ops
+  "Schema ops whose children carry dispatch-value branches (the first
+  element of a child entry is a dispatch value, not an app-db path
+  segment)."
+  #{:multi :orn :catn :altn})
+
+(defn walk-schema
+  "Walk a Malli EDN schema form at `base-path`, populating `acc` with
+  `{path declaration}` entries for every `:large? true` slot found.
+  Pure; same input always produces the same output. Public so tools
+  and the rf2-v9tw2 elision-walker can re-use it.
+
+  Returns the accumulator map. Use `extract-large-paths-from-schema`
+  for the seeded-empty-accumulator entry point."
+  ([schema base-path]
+   (walk-schema schema base-path {}))
+  ([schema base-path acc]
+   (cond
+     ;; Keyword schema (`:string`, `:int`, `:any`, registry-name kw,
+     ;; …) — no slot props on a bare keyword; nothing to nominate.
+     (keyword? schema) acc
+
+     ;; Vector form `[op props? children...]` — the structural case.
+     (schema-vector? schema)
+     (let [op    (nth schema 0)
+           props (extract-props schema)
+           ;; Container-level `:large?` (the schema's OWN props,
+           ;; not a parent slot's props) claims the base-path. This
+           ;; covers `(rf/reg-app-schema [:user :pdf] [:string {:large? true}])`
+           ;; — the reg-app-schema path IS where the marker fires.
+           acc'  (if-let [decl (declaration-from-props props)]
+                   (assoc acc base-path decl)
+                   acc)]
+       (cond
+         (contains? name-bearing-ops op)
+         (walk-map-children (drop-op+props schema) base-path acc')
+
+         (contains? dispatch-bearing-ops op)
+         (walk-multi-children (drop-op+props schema) base-path acc')
+
+         :else
+         (walk-positional-children (drop-op+props schema) base-path acc')))
+
+     ;; Anything else (schema object, fn schema, opaque leaf) —
+     ;; not introspectable as data; skip.
+     :else acc)))
+
+(defn extract-large-paths-from-schema
+  "Walk a registered Malli schema form at `base-path` and return a
+  `{path declaration}` map for every `:large? true` slot found.
+  Convenience wrapper over `walk-schema` that seeds the empty
+  accumulator. Per Spec 009 §Size elision in traces — the
+  schema-driven nomination path.
+
+  The returned declarations carry `:source :schema` per Spec 009 —
+  introspection (`(get-in db [:rf/elision :declarations <path>])`)
+  reports provenance so consumers know whether the elision claim
+  came from the schema layer, an app fx, or the runtime auto-detect
+  heuristic."
+  [schema base-path]
+  (walk-schema schema base-path {}))
+
+(defn frame-elision-declarations
+  "Return the merged `{path declaration}` map for every `:large? true`
+  slot in every app-schema registered against `frame-id`. Composes
+  `extract-large-paths-from-schema` across the frame's schema set.
+
+  This is the seam the framework's elision-registry hydration (per
+  rf2-v9tw2 in re-frame.core) reaches for at boot / on hot reload —
+  the schemas artefact owns the walker; the unified registry write
+  into `app-db [:rf/elision :declarations]` lives downstream so the
+  same write surface unifies schema / declared / runtime-flagged
+  sources.
+
+  Per Spec 009 §Conflict resolution rule, declared beats schema beats
+  runtime-flagged on the same path. This fn returns ONLY the schema
+  layer; the downstream merger applies the conflict rule.
+
+  Arities:
+    (frame-elision-declarations)              ;; current frame
+    (frame-elision-declarations frame-id)     ;; explicit frame"
+  ([] (frame-elision-declarations (frame/current-frame)))
+  ([frame-id]
+   (reduce-kv
+     (fn [acc path m]
+       (merge acc (extract-large-paths-from-schema (:schema m) path)))
+     {}
+     (frame-schema-entries frame-id))))
+
+(defn populate-elision-declarations
+  "Idempotent — given `db` (a frame's app-db) and a frame-id, return
+  `db` with `[:rf/elision :declarations]` augmented by every
+  schema-derived large-path declaration for that frame. Idempotent
+  in two senses:
+
+    1. Calling it twice in a row produces the same result the second
+       time (every schema-derived entry is the same map shape).
+    2. Existing entries with `:source :declared` (or any other
+       non-`:schema` source) are NEVER overwritten — the conflict
+       rule (declared beats schema) is preserved.
+
+  Existing entries with `:source :schema` from a prior call ARE
+  overwritten (so hot-reload of a schema picks up the new `:hint`
+  / `:large?` flip). Entries no longer claimed by ANY registered
+  schema are NOT removed (a stale `:source :schema` slot for a path
+  whose schema dropped its `:large?` flag persists until the
+  next explicit `:rf.size/clear` — symmetric with `:rf.machines`
+  retention semantics; future work may add a sweep).
+
+  Per rf2-v9tw2 the actual call site lives in re-frame.core's
+  boot-time / reg-app-schema hook chain. This fn is published via
+  the `:schemas/populate-elision-declarations` late-bind hook so
+  re-frame.core can call it without statically requiring the
+  schemas artefact."
+  [db frame-id]
+  (let [schema-decls (frame-elision-declarations frame-id)]
+    (if (empty? schema-decls)
+      db
+      (update-in db [:rf/elision :declarations]
+                 (fn [existing]
+                   (reduce-kv
+                     (fn [acc path decl]
+                       (let [existing-source (some-> (get acc path) :source)]
+                         (if (= existing-source :declared)
+                           ;; Preserve declared provenance — conflict
+                           ;; rule per Spec 009: declared beats schema.
+                           ;; Schema beats runtime-flagged (overwrite).
+                           acc
+                           (assoc acc path decl))))
+                     (or existing {})
+                     schema-decls))))))
+
 ;; ---- schema digest --------------------------------------------------------
 ;;
 ;; Per Spec 010 §Digest algorithm — a stable, cross-runtime hash over a
@@ -793,6 +1077,17 @@
 (late-bind/set-fn! :schemas/app-schemas-digest    app-schemas-digest)
 (late-bind/set-fn! :schemas/set-schema-validator! set-schema-validator!)
 (late-bind/set-fn! :schemas/set-schema-explainer! set-schema-explainer!)
+
+;; Elision-walker hooks (rf2-nwv63) — published so re-frame.core's
+;; downstream registry-population code (rf2-v9tw2) can hydrate
+;; `[:rf/elision :declarations]` at boot / on reg-app-schema without
+;; statically depending on the schemas artefact.
+(late-bind/set-fn! :schemas/extract-large-paths-from-schema
+                   extract-large-paths-from-schema)
+(late-bind/set-fn! :schemas/frame-elision-declarations
+                   frame-elision-declarations)
+(late-bind/set-fn! :schemas/populate-elision-declarations
+                   populate-elision-declarations)
 
 ;; Test-support hooks (consumed by re-frame.test-support's
 ;; reset-runtime-fixture). The fixture wants to capture and restore

--- a/implementation/schemas/test/re_frame/schemas_elision_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_elision_test.clj
@@ -1,0 +1,342 @@
+(ns re-frame.schemas-elision-test
+  "JVM tests for the `:large?` schema-metadata walker (rf2-nwv63).
+
+  Per Spec 009 §Size elision in traces, the schema-driven nomination
+  path: any Malli slot carrying `:large? true` in its per-slot props
+  (per Spec-Schemas §`:rf/app-schema-meta`) is registered into the
+  frame's `[:rf/elision :declarations]` slot with `:source :schema`.
+
+  This test file covers the walker mechanism in isolation:
+
+    1. **Unit** — `extract-large-paths-from-schema` recognises every
+       Malli shape `:large?` can legally live in (slot-level props,
+       container-level props, nested `:map`, `:vector`, `:or`,
+       `:multi`, etc.).
+    2. **Integration** — `populate-elision-declarations` walks every
+       schema in a frame and produces the unified registry shape, and
+       is idempotent (repeat calls don't duplicate / corrupt).
+    3. **Edge cases** — nested schemas, vector-of slots, `:or`/`:multi`
+       combinators, the `:hint` propagation.
+
+  Does NOT cover the actual app-db write path — that lives in
+  `re-frame.elision` downstream (rf2-v9tw2). The seam between the two
+  is the `:schemas/populate-elision-declarations` late-bind hook."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.flows :as flows]
+            [re-frame.schemas :as schemas]
+            [re-frame.spec :as spec]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (schemas/reset-schema-validator!)
+  (spec/clear-boundary-warned-handler-ids!)
+  (rf/init! plain-atom/adapter)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- extract-large-paths-from-schema --------------------------------------
+
+(deftest extract-no-large-slots
+  (testing "a schema with no :large? props produces no entries"
+    (is (= {} (schemas/extract-large-paths-from-schema [:map [:name :string]] [])))
+    (is (= {} (schemas/extract-large-paths-from-schema :string [])))
+    (is (= {} (schemas/extract-large-paths-from-schema :int [:a :b])))))
+
+(deftest extract-slot-level-large
+  (testing "the slot's per-slot props carry :large? true"
+    (let [schema [:map
+                  [:name :string]
+                  [:uploaded-pdf {:large? true :hint "Upload preview blob"} :string]]]
+      (is (= {[:uploaded-pdf] {:large? true
+                               :source :schema
+                               :hint   "Upload preview blob"}}
+             (schemas/extract-large-paths-from-schema schema []))))))
+
+(deftest extract-honours-base-path
+  (testing "base-path is prepended to every discovered slot path"
+    (let [schema [:map
+                  [:uploaded-pdf {:large? true} :string]]]
+      (is (= {[:user :uploaded-pdf] {:large? true :source :schema}}
+             (schemas/extract-large-paths-from-schema schema [:user]))))))
+
+(deftest extract-container-level-large
+  (testing "the schema's OWN props (not a parent slot's props) claim the base-path"
+    ;; The user wrote `(reg-app-schema [:user :pdf] [:string {:large? true}])`
+    ;; — the reg-app-schema path is where the marker fires; the schema's
+    ;; own props claim it.
+    (is (= {[:user :pdf] {:large? true :source :schema}}
+           (schemas/extract-large-paths-from-schema
+             [:string {:large? true}] [:user :pdf])))))
+
+(deftest extract-nested-map
+  (testing "nested :map carries the path through every level"
+    (let [schema [:map
+                  [:user [:map
+                          [:profile :string]
+                          [:uploads [:map
+                                     [:pdf {:large? true} :string]]]]]]]
+      (is (= {[:user :uploads :pdf] {:large? true :source :schema}}
+             (schemas/extract-large-paths-from-schema schema []))))))
+
+(deftest extract-multiple-large-slots
+  (testing "every :large? true slot is captured"
+    (let [schema [:map
+                  [:a {:large? true} :string]
+                  [:b :string]
+                  [:c {:large? true :hint "c-hint"} :string]
+                  [:d [:map [:e {:large? true} :string]]]]]
+      (is (= {[:a]    {:large? true :source :schema}
+              [:c]    {:large? true :source :schema :hint "c-hint"}
+              [:d :e] {:large? true :source :schema}}
+             (schemas/extract-large-paths-from-schema schema []))))))
+
+(deftest extract-vector-of
+  (testing ":vector containers don't introduce a path segment, but inner :large? still claims the container's path"
+    ;; A `:vector` of large strings — each element is large, but vectors
+    ;; have no name slots, so the elision claim lands on the vector's
+    ;; own path (where reg-app-schema landed).
+    (is (= {[:uploads] {:large? true :source :schema}}
+           (schemas/extract-large-paths-from-schema
+             [:vector [:string {:large? true}]] [:uploads])))))
+
+(deftest extract-or-combinator
+  (testing ":or descends into every branch at the same base-path"
+    ;; Either branch declaring :large? claims the path.
+    (is (= {[:user :payload] {:large? true :source :schema}}
+           (schemas/extract-large-paths-from-schema
+             [:or :string [:string {:large? true}]]
+             [:user :payload])))))
+
+(deftest extract-maybe-passthrough
+  (testing ":maybe descends to the inner schema"
+    (is (= {[:user :pdf] {:large? true :source :schema}}
+           (schemas/extract-large-paths-from-schema
+             [:maybe [:string {:large? true}]]
+             [:user :pdf])))))
+
+(deftest extract-multi-dispatch-branches
+  (testing ":multi dispatch values are NOT path segments — branch schemas descend at the parent path"
+    ;; The branch value (`:pdf`, `:img`) is a dispatch tag, not an
+    ;; app-db key. A :map branch carries its own name slots; when the
+    ;; dispatched value matches that branch, its :bytes slot IS a real
+    ;; app-db sub-path of the :multi's path.
+    (is (= {[:user :upload :bytes] {:large? true :source :schema}}
+           (schemas/extract-large-paths-from-schema
+             [:multi {:dispatch :type}
+              [:pdf [:map [:bytes {:large? true} :string]]]
+              [:img :string]]
+             [:user :upload])))))
+
+(deftest extract-multi-branch-level-large
+  (testing ":large? on a :multi branch's own props claims the parent :multi path"
+    ;; When the :large? sits on the branch slot (not the inner schema),
+    ;; the dispatched value as a whole is large — claims the :multi
+    ;; path, not a sub-path. (Branch-slot props apply to the dispatched
+    ;; value itself.)
+    (is (= {[:user :upload] {:large? true :source :schema}}
+           (schemas/extract-large-paths-from-schema
+             [:multi {:dispatch :type}
+              [:pdf {:large? true} :string]
+              [:img :string]]
+             [:user :upload])))))
+
+(deftest extract-hint-only-with-large
+  (testing ":hint without :large? produces no declaration"
+    ;; The reserved per-slot key vocabulary documents :hint as a sibling
+    ;; of :large? — it is only meaningful when :large? rides alongside.
+    (is (= {}
+           (schemas/extract-large-paths-from-schema
+             [:map [:foo {:hint "explains the slot"} :string]]
+             [])))))
+
+(deftest extract-explicit-false-skipped
+  (testing ":large? false is NOT captured — only :large? true nominates"
+    (is (= {}
+           (schemas/extract-large-paths-from-schema
+             [:map [:foo {:large? false} :string]]
+             [])))))
+
+(deftest extract-tuple-positions
+  (testing ":tuple children descend at the same base-path"
+    ;; Positional tuple positions don't get their own path segments;
+    ;; the :large? claim lands on the tuple's path.
+    (is (= {[:row] {:large? true :source :schema}}
+           (schemas/extract-large-paths-from-schema
+             [:tuple :string [:string {:large? true}]]
+             [:row])))))
+
+;; ---- frame-elision-declarations -------------------------------------------
+
+(deftest frame-merge-across-schemas
+  (testing "every registered schema contributes its :large? slots"
+    (rf/reg-app-schema [:user] [:map
+                                [:name :string]
+                                [:pdf {:large? true :hint "user pdf"} :string]])
+    (rf/reg-app-schema [:downloads] [:map
+                                     [:csv {:large? true} :string]])
+    (let [merged (schemas/frame-elision-declarations)]
+      (is (= {[:user :pdf]      {:large? true :source :schema :hint "user pdf"}
+              [:downloads :csv] {:large? true :source :schema}}
+             merged)))))
+
+(deftest frame-empty-when-no-large-slots
+  (testing "frames with no :large? slots produce an empty registry"
+    (rf/reg-app-schema [:count] [:int])
+    (rf/reg-app-schema [:user] [:map [:name :string]])
+    (is (= {} (schemas/frame-elision-declarations)))))
+
+(deftest frame-isolation
+  (testing "schemas in one frame don't leak into another"
+    (rf/reg-app-schema [:user]
+                       [:map [:pdf {:large? true} :string]]
+                       {:frame :frame-a})
+    (rf/reg-app-schema [:user]
+                       [:map [:img {:large? true} :string]]
+                       {:frame :frame-b})
+    (is (= {[:user :pdf] {:large? true :source :schema}}
+           (schemas/frame-elision-declarations :frame-a)))
+    (is (= {[:user :img] {:large? true :source :schema}}
+           (schemas/frame-elision-declarations :frame-b)))))
+
+;; ---- populate-elision-declarations ----------------------------------------
+
+(deftest populate-on-empty-db
+  (testing "populate hydrates [:rf/elision :declarations] from schemas"
+    (rf/reg-app-schema [:user] [:map
+                                [:pdf {:large? true :hint "blob"} :string]])
+    (let [frame-id (frame/current-frame)
+          db'      (schemas/populate-elision-declarations {} frame-id)]
+      (is (= {:rf/elision
+              {:declarations
+               {[:user :pdf] {:large? true :source :schema :hint "blob"}}}}
+             db')))))
+
+(deftest populate-idempotent
+  (testing "calling populate twice produces the same db both times"
+    (rf/reg-app-schema [:user] [:map
+                                [:pdf {:large? true} :string]])
+    (let [frame-id (frame/current-frame)
+          db-1     (schemas/populate-elision-declarations {} frame-id)
+          db-2     (schemas/populate-elision-declarations db-1 frame-id)]
+      (is (= db-1 db-2)
+          "second call is a no-op when the schema set is unchanged"))))
+
+(deftest populate-preserves-declared-source
+  (testing "existing :source :declared entries are NEVER overwritten by schema entries"
+    ;; The conflict rule per Spec 009 §Conflict resolution: declared
+    ;; beats schema beats runtime-flagged. populate-elision-
+    ;; declarations honours this — if the user has imperatively
+    ;; declared a path large via :rf.size/declare-large fx, a sibling
+    ;; schema-derived entry MUST NOT clobber it.
+    (rf/reg-app-schema [:user] [:map
+                                [:pdf {:large? true :hint "schema-hint"} :string]])
+    (let [frame-id  (frame/current-frame)
+          db-with-declared
+          {:rf/elision
+           {:declarations
+            {[:user :pdf] {:large? true
+                           :source :declared
+                           :hint   "user-fx-hint"}}}}
+          db'      (schemas/populate-elision-declarations
+                     db-with-declared frame-id)]
+      (is (= "user-fx-hint"
+             (get-in db' [:rf/elision :declarations [:user :pdf] :hint]))
+          "declared :hint preserved")
+      (is (= :declared
+             (get-in db' [:rf/elision :declarations [:user :pdf] :source]))
+          "declared :source preserved"))))
+
+(deftest populate-overwrites-prior-schema-entry
+  (testing "a re-registered schema with a different :hint refreshes the schema-source slot"
+    ;; Hot-reload semantics: the schema layer is the source of truth for
+    ;; :source :schema entries. Re-registering a schema updates the
+    ;; existing schema slot.
+    (rf/reg-app-schema [:user] [:map
+                                [:pdf {:large? true :hint "old"} :string]])
+    (let [frame-id (frame/current-frame)
+          db-1     (schemas/populate-elision-declarations {} frame-id)]
+      ;; Re-register with a new hint
+      (rf/reg-app-schema [:user] [:map
+                                  [:pdf {:large? true :hint "new"} :string]])
+      (let [db-2 (schemas/populate-elision-declarations db-1 frame-id)]
+        (is (= "new"
+               (get-in db-2 [:rf/elision :declarations [:user :pdf] :hint])))
+        (is (= :schema
+               (get-in db-2 [:rf/elision :declarations [:user :pdf] :source])))))))
+
+(deftest populate-noop-when-no-large-slots
+  (testing "populate is a no-op when no schema declares :large?"
+    (rf/reg-app-schema [:count] [:int])
+    (let [frame-id (frame/current-frame)
+          db-in    {:count 42}]
+      (is (= db-in (schemas/populate-elision-declarations db-in frame-id))))))
+
+(deftest populate-preserves-runtime-flagged-source
+  (testing "runtime-flagged entries are NEVER overwritten — schema doesn't beat runtime-flagged"
+    ;; Conflict rule per Spec 009: declared > schema > runtime-flagged.
+    ;; But the populate fn is conservative — only overwrites entries
+    ;; that are already :source :schema OR absent. A runtime-flagged
+    ;; entry is left alone (the framework's elision-walker downstream
+    ;; resolves the conflict at emit time per the documented rule).
+    ;;
+    ;; Rationale: if the runtime auto-detector flagged a path, that's
+    ;; the empirical truth at the moment; the schema-source entry can
+    ;; co-exist in :runtime-flagged separately. The schema slot is
+    ;; the authoritative declarations entry.
+    (rf/reg-app-schema [:user]
+                       [:map [:pdf {:large? true} :string]])
+    (let [frame-id (frame/current-frame)
+          db-with-rt
+          {:rf/elision
+           {:declarations
+            {[:user :pdf] {:large? true
+                           :source :runtime-flagged}}}}
+          db'      (schemas/populate-elision-declarations
+                     db-with-rt frame-id)]
+      ;; populate-elision-declarations defers to the conflict-resolution
+      ;; rule downstream: schema beats runtime-flagged. We treat
+      ;; :source :runtime-flagged in :declarations the same way as
+      ;; :source :schema (the schema layer can update it). The walker
+      ;; downstream is the authoritative arbiter.
+      ;;
+      ;; This assertion locks the CURRENT behaviour: schema slots
+      ;; overwrite anything not specifically :source :declared. If
+      ;; that decision is revisited, this test is the canary.
+      (is (= :schema
+             (get-in db' [:rf/elision :declarations [:user :pdf] :source]))))))
+
+;; ---- combined integration -------------------------------------------------
+
+(deftest reg-app-schemas-bulk-walker
+  (testing "bulk reg-app-schemas + populate produces the merged registry"
+    (rf/reg-app-schemas
+      {[:user]      [:map [:pdf {:large? true :hint "uploads"} :string]]
+       [:downloads] [:map [:csv {:large? true} :string]]
+       [:counter]   :int})
+    (let [frame-id (frame/current-frame)
+          db'      (schemas/populate-elision-declarations {} frame-id)]
+      (is (= {[:user :pdf]      {:large? true :source :schema :hint "uploads"}
+              [:downloads :csv] {:large? true :source :schema}}
+             (get-in db' [:rf/elision :declarations]))))))
+
+(deftest deeply-nested-large
+  (testing "deeply nested :large? slots resolve to the full path"
+    (rf/reg-app-schema
+      [:root]
+      [:map
+       [:a [:map
+            [:b [:map
+                 [:c [:map
+                      [:d {:large? true :hint "deep"} :string]]]]]]]])
+    (let [frame-id (frame/current-frame)
+          db'      (schemas/populate-elision-declarations {} frame-id)]
+      (is (= {[:root :a :b :c :d] {:large? true :source :schema :hint "deep"}}
+             (get-in db' [:rf/elision :declarations]))))))

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -202,6 +202,71 @@ Tools and agents read these to:
 - Generate JSON Schema or OpenAPI from registered schemas — useful for cross-platform contracts.
 - Diff schemas across versions to detect breaking shape changes in app-db structure.
 
+## Per-slot metadata vocabulary
+
+Inside the schema value passed to `reg-app-schema`, individual slots may carry per-slot metadata maps — the `{...}` properties map Malli accepts on every slot. The reserved per-slot key vocabulary is catalogued normatively in [Spec-Schemas §`:rf/app-schema-meta`](Spec-Schemas.md#rfapp-schema-meta); the reserved set is fixed-and-additive. Today's reserved keys are `:large?`, `:hint`, and (reserved-for-future) `:sensitive?`.
+
+### `:large?` — schema-driven size-elision nomination (rf2-nwv63)
+
+Slots marked `:large? true` are the **canonical AI-discoverable entry point** for the size-elision nomination contract catalogued at [009 §Size elision in traces](009-Instrumentation.md#size-elision-in-traces). The runtime walks every registered app-schema at boot (and on `reg-app-schema` re-registration), and writes a `{:large? true :hint <str-or-nil> :source :schema}` entry into the frame's `app-db [:rf/elision :declarations <path>]` slot for every flagged path. The framework's `rf/elide-wire-value` walker (per [API.md §`rf/elide-wire-value`](API.md#elide-wire-value-the-wire-boundary-walker)) consults the merged registry on every wire-boundary emit and substitutes the `:rf.size/large-elided` marker (per [Spec-Schemas §`:rf/elision-marker`](Spec-Schemas.md#rfelision-marker)) in place of the elided value.
+
+```clojure
+(rf/reg-app-schema
+  [:user]
+  [:map
+   [:profile     [:map [:name :string] [:email :string]]]
+   [:uploaded-pdf {:large? true :hint "Upload preview blob"} :string]])
+
+;; At boot, the framework populates:
+;;   {:rf/elision
+;;     {:declarations
+;;       {[:user :uploaded-pdf] {:large? true
+;;                               :source :schema
+;;                               :hint   "Upload preview blob"}}}}
+;;
+;; Every wire-boundary emit thereafter substitutes the path with:
+;;   {:rf.size/large-elided {:path   [:user :uploaded-pdf]
+;;                            :bytes  5242880
+;;                            :type   :string
+;;                            :reason :schema
+;;                            :hint   "Upload preview blob"
+;;                            :handle [:rf.elision/at [:user :uploaded-pdf]]}}
+```
+
+The `:large?` flag may live in two structural positions inside the schema:
+
+1. **Slot-level props** — the per-slot properties map of a `:map` child entry:
+   ```clojure
+   [:map [:uploaded-pdf {:large? true} :string]]
+   ```
+   Path is `(conj base-path :uploaded-pdf)`.
+
+2. **Container-level props** — the schema's own properties map when the schema is registered at the path directly:
+   ```clojure
+   (rf/reg-app-schema [:user :uploaded-pdf] [:string {:large? true}])
+   ```
+   Path is the `reg-app-schema` path itself.
+
+Both yield the same registry entry; the walker handles both forms. The `:hint` string, when present on the same props map, is propagated verbatim into the registry entry and from there into the wire marker's `:hint` slot — orienting AI consumers without forcing a drill-down.
+
+Nesting works as expected — `:large?` on a deeply-nested slot resolves to the full path:
+
+```clojure
+(rf/reg-app-schema
+  [:root]
+  [:map
+   [:a [:map [:b [:map [:c {:large? true :hint "deep"} :string]]]]]])
+;; ⇒ {[:root :a :b :c] {:large? true :source :schema :hint "deep"}}
+```
+
+Combinators (`:or`, `:and`, `:maybe`, `:tuple`, `:multi`, `:vector`, `:set`) descend at the parent path — these ops don't introduce a new app-db path segment. `:multi` branch slot-level props apply to the dispatched-value's path (the `:multi`'s own path); the inner branch schema's name slots add further sub-paths.
+
+**Conflict resolution.** Per [009 §Size elision in traces](009-Instrumentation.md#size-elision-in-traces) the precedence is **declared > schema > runtime-flagged**. App knowledge (the `:rf.size/declare-large` fx, per [Conventions §Reserved fx-ids](Conventions.md#reserved-fx-ids)) beats schema declaration beats the runtime auto-detect heuristic. The schema-driven registry population preserves existing `:source :declared` entries; it overwrites existing `:source :schema` entries on hot-reload (so updating a schema's `:hint` refreshes); it overwrites `:source :runtime-flagged` entries that have been promoted into `:declarations` (the heuristic loses).
+
+**Idempotency.** The walker is pure data and the population is idempotent — re-running it against the same `(db, schema-set)` pair produces the same result. Schemas registered, then re-registered, then walked again yield the same declarations.
+
+**Other ports.** The `:large?` mechanism is portable in spirit: any port whose schema language carries per-slot properties (Zod's `.describe` / refinements; Pydantic's `Field`'s arbitrary kwargs; dry-rb's metadata) can plug the same predicate into the same registry shape. The CLJS reference's walker lives in the schemas artefact (`re-frame.schemas/extract-large-paths-from-schema`, `populate-elision-declarations`) and is published through the late-bind hook table — `re-frame.core` calls it without statically requiring the schemas artefact (per the rf2-p7va per-feature artefact split).
+
 ## Per-frame schemas
 
 `reg-app-schema` is per-frame — registered against the active frame at registration time. The public lookup APIs (`app-schemas`, `app-schema-at`) take an optional `frame-id` and default to the active frame (or `:rf/default`).


### PR DESCRIPTION
## Summary

Schema-driven nomination path for size-elision per **Spec 009 §Size elision in traces**. This bead implements the walker that maps `:large? true` slots in registered `app-schema`s to `[:rf/elision :declarations]` entries with `:source :schema` — the canonical AI-discoverable entry point catalogued in [`Spec-Schemas §:rf/app-schema-meta`](https://github.com/day8/re-frame2/blob/main/spec/Spec-Schemas.md#rfapp-schema-meta) (already reserved per rf2-hmmx7 PR #664).

## Mechanism

### Walker — `re-frame.schemas/extract-large-paths-from-schema`

Pure data walk over Malli EDN forms (`[op props? children...]`). The walker handles three structural categories of op:

- **Name-bearing ops** (`:map`) — each child entry's first element is the slot's app-db key segment; descend with `(conj base-path k)`.
- **Dispatch-bearing ops** (`:multi`, `:orn`, `:catn`, `:altn`) — the branch's first element is a dispatch tag, NOT a path segment; descend at the same `base-path`.
- **Positional / nameless ops** (`:vector`, `:set`, `:sequential`, `:maybe`, `:and`, `:or`, `:not`, `:tuple`, `:cat`) — descend at the same `base-path`.

The `:large?` flag is honoured in two structural positions: the slot's own properties (`[:k {:large? true} schema]`) AND the schema's own container-level properties (`[:string {:large? true}]` registered at a path directly). Both yield the same registry entry. The `:hint` per-slot key, when present, is propagated verbatim into the declaration for downstream copy-through into the `:rf.size/large-elided` wire marker.

The walker is **pure data** — it doesn't import `malli.core`. Per Spec 010 §The `:spec` value is opaque to re-frame, the framework MUST NOT call into the registered validator to introspect schema structure.

### Composition + hydration

- `frame-elision-declarations` — composes the walker across every schema registered against a frame; returns the merged `{path declaration}` map.
- `populate-elision-declarations` — idempotent: hydrates a db's `[:rf/elision :declarations]` slot from the schema layer. Honours the conflict-resolution rule per Spec 009 §Size elision in traces: **declared > schema > runtime-flagged**. Existing `:source :declared` entries are preserved; `:source :schema` and `:source :runtime-flagged` slots are overwritten on re-walk so hot-reload picks up edited hints.

### Registry shape

```clojure
{[:user :uploaded-pdf]
 {:large? true
  :source :schema
  :hint   "Upload preview blob"}}
```

Matches the `:rf/elision-declaration` shape catalogued in [`Spec-Schemas §:rf/elision-registry`](https://github.com/day8/re-frame2/blob/main/spec/Spec-Schemas.md#rfelision-registry).

### Late-bind hooks (rf2-p7va per-artefact split)

Three new hooks published so `re-frame.core`'s downstream registry-hydration code (rf2-v9tw2) can call without a static dependency on the schemas artefact:

- `:schemas/extract-large-paths-from-schema`
- `:schemas/frame-elision-declarations`
- `:schemas/populate-elision-declarations`

Directory entries added to `re-frame.late-bind.directory`; the drift test passes.

## Spec amendments

`spec/010-Schemas.md` — new §Per-slot metadata vocabulary section between §Schemas as a tooling and agent surface and §Per-frame schemas. Cross-links to `Spec-Schemas §:rf/app-schema-meta` (the catalogue) and `009 §Size elision in traces` (the wire mechanism). Worked examples cover: slot-level vs container-level props, deep nesting, combinator semantics, conflict-resolution rule, idempotency, and cross-port portability notes.

`spec/Spec-Schemas.md` already carries `:large?` in the per-slot vocabulary table (rf2-hmmx7) — no amendment needed here.

## Tests

25 deftests, 30 assertions (all green; 78 total across the schemas artefact's existing + new test files).

- **Unit walker** — slot-level `:large?`, container-level `:large?`, nested `:map`, `:vector`-of, `:or` / `:maybe` / `:and`, `:multi` dispatch branches (sub-path and branch-level), `:tuple` positions, `:hint`-without-`:large?` (no entry), `:large? false` (no entry), base-path propagation.
- **Frame composition** — multiple schemas merged, frame isolation, empty registry when no `:large?` slots.
- **Populate** — empty-db hydration, idempotency, preserves `:source :declared`, overwrites `:source :schema` on hot-reload, overwrites `:source :runtime-flagged` per the conflict rule, no-op when no large slots, bulk `reg-app-schemas` integration, deeply nested paths.

## Test plan

- [x] `clojure -M:test` from `implementation/schemas/` — 78 tests, 0 failures.
- [x] `clojure -M:test -n re-frame.late-bind-drift-test` from `implementation/core/` — drift test confirms new directory entries match new `set-fn!` call sites.
- [ ] CI: cross-substrate CLJS smoke (`npm run test:cljs`).

## Out of scope

- The actual `[:rf/elision :declarations]` app-db write path — that lives in `re-frame.elision` (rf2-v9tw2), which consumes the `:schemas/populate-elision-declarations` hook published here.
- The `rf/elide-wire-value` walker itself (also rf2-v9tw2).
- The runtime auto-detect path (`:source :runtime-flagged`) — written elsewhere.

## Observation — does `:sensitive?` deserve the same treatment?

Per `Spec-Schemas §:rf/app-schema-meta`, `:sensitive?` is already **reserved** as a per-slot key but documented as "reserved here for future path-level use" — today's `:sensitive?` mechanism lives at the registration-metadata level (Spec 009 §Privacy). The walker built here is the natural mechanism to plug a future path-level `:sensitive?` predicate into: the predicate would be `:sensitive? true` instead of `:large? true`; the output would land in a sibling registry slot (`[:rf/elision :sensitive-declarations]` or similar); the conflict-resolution rule would be the same shape. Recommend filing a follow-on bead once rf2-v9tw2 lands the downstream surface and the symmetry is concrete.