### PR TITLE
fix(adapter-reagent): use rdc/create-root + Root for React 18 (rf2-fn5rk)

### DIFF
--- a/examples/reagent/counter/causa.spec.cjs
+++ b/examples/reagent/counter/causa.spec.cjs
@@ -55,20 +55,6 @@ const PANEL_HANDOFFS = [
 module.exports = {
   name: 'causa',
   url: '/counter/',
-  // Awaiting rf2-fn5rk — the spec's first run-through surfaced a real
-  // bug in implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs:
-  // the `render` slot calls `(rdc/render mount-point render-tree)` directly,
-  // but React 18's `reagent.dom.client/render` requires a `Root` (from
-  // `create-root`) as its first arg. Causa's mount/open! therefore throws
-  // `TypeError: root.render is not a function`, the shell never lands in
-  // the DOM, and every shell-visibility assertion below fails.
-  //
-  // The spec is shipped now so the wiring (testid surface, sidebar IDs,
-  // toggle sequence, panel handoffs, REDACTED hint, trace-bus
-  // observation) is reviewed end-to-end and ready to light up the
-  // moment the adapter fix lands. Drop the `skip:` field as part of
-  // rf2-fn5rk's PR.
-  skip: 'awaiting rf2-fn5rk — reagent adapter render() must use rdc/create-root before rdc/render (Causa mount currently throws "root.render is not a function")',
   run: async (page) => {
     // ----------------------------------------------------------------
     // 1. Mount — counter is ready, Causa shell is NOT in the DOM yet.

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -53,11 +53,27 @@
 ;; ---- render ---------------------------------------------------------------
 
 (defn- render [render-tree mount-point opts]
+  ;; React 18+ uses the root API: `reagent.dom.client/render` takes a Root
+  ;; (from `create-root`) — NOT a raw DOM element. Calling
+  ;; `(rdc/render mount-point …)` directly throws
+  ;; `TypeError: root.render is not a function` at runtime.
+  ;;
+  ;; Per Reagent v2's `reagent.dom.client` API:
+  ;;   - `(rdc/create-root <dom>)`       → Root
+  ;;   - `(rdc/render <root> <tree>)`    → render into the Root
+  ;;   - `(rdc/hydrate-root <dom> <tree>)` → returns its own Root
+  ;;   - `(rdc/unmount <root>)`          → tear the Root down
+  ;;
+  ;; The unmount thunk closes over the Root so the runtime can release
+  ;; it without consulting the DOM element again. Hydrate path mirrors
+  ;; the slim adapter (rf2-6hyy) — `hydrate-root` returns its own Root.
   (let [hydrate? (boolean (:hydrate? opts))]
     (if hydrate?
-      (rdc/hydrate-root mount-point render-tree)
-      (rdc/render        mount-point render-tree))
-    (fn unmount [] (rdc/unmount mount-point))))
+      (let [root (rdc/hydrate-root mount-point render-tree)]
+        (fn unmount [] (rdc/unmount root)))
+      (let [root (rdc/create-root mount-point)]
+        (rdc/render root render-tree)
+        (fn unmount [] (rdc/unmount root))))))
 
 (defonce ^:private hiccup-emitter (atom nil))
 

--- a/implementation/adapters/reagent/test/re_frame/adapter_render_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_render_cljs_test.cljs
@@ -1,0 +1,194 @@
+(ns re-frame.adapter-render-cljs-test
+  "Per rf2-fn5rk — the Reagent adapter's `render` slot must follow the
+  React 18+ Root API: `(rdc/create-root mount-point)` first, then
+  `(rdc/render root render-tree)` — NOT `(rdc/render mount-point tree)`
+  directly. The pre-fix code passed a raw DOM element where the Root
+  was required, causing
+  `TypeError: root.render is not a function` at Causa mount time.
+
+  This test pins the call sequence by spying through `with-redefs` on
+  `reagent.dom.client`'s `create-root` / `render` / `hydrate-root` /
+  `unmount` fns. It does NOT touch a real DOM (no jsdom in
+  :node-test); it asserts the adapter wires the Root API correctly.
+
+  Test surface: the private `:render` slot on the adapter map plus the
+  spy stubs let us confirm the contract:
+
+    1. Non-hydrate path: create-root is called exactly once with the
+       mount-point; render is called exactly once with the resulting
+       Root + the render-tree (in that order).
+    2. The returned unmount thunk calls unmount with the Root (not the
+       mount-point).
+    3. Hydrate path: hydrate-root is called once with the mount-point +
+       render-tree; create-root + render are NOT called; the unmount
+       thunk calls unmount with the Root returned by hydrate-root.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [reagent.dom.client :as rdc]
+            [re-frame.adapter.reagent :as reagent-adapter]))
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- mk-fake-root
+  "A fake Root identity — just an object with a `.unmount` method we
+  never actually call (the spy replaces `rdc/unmount`). Using `(js-obj)`
+  keeps the value JS-shaped without depending on React being present."
+  [tag]
+  #js {:rf-test-root-tag tag})
+
+;; ---- non-hydrate path ------------------------------------------------------
+
+(deftest render-uses-create-root-then-render
+  (testing "non-hydrate render: (rdc/create-root mount-point) is called
+            first; (rdc/render root render-tree) follows; the unmount
+            thunk closes over the Root (rf2-fn5rk)"
+    (let [calls         (atom [])
+          fake-root     (mk-fake-root :non-hydrate)
+          fake-mount    #js {:rf-test-mount :non-hydrate}
+          fake-tree     [:div "tree"]]
+      ;; Stubs are multi-arity to mirror reagent.dom.client's API
+      ;; (create-root: 1/2, render: 2/3/4, hydrate-root: 2/3). The
+      ;; with-redefs rebinding replaces the var's value with a plain fn;
+      ;; if we only provide a single arity, real Reagent code calling
+      ;; the multi-arity form during the rebinding scope would throw.
+      ;; Only the lowest arities are exercised by our adapter today, but
+      ;; covering the published arities keeps the stubs robust against
+      ;; passes through reagent internals.
+      (with-redefs [rdc/create-root   (fn
+                                        ([mp]   (swap! calls conj [:create-root mp])
+                                                fake-root)
+                                        ([mp _] (swap! calls conj [:create-root mp])
+                                                fake-root))
+                    rdc/render        (fn
+                                        ([root tree]
+                                         (swap! calls conj [:render root tree]) nil)
+                                        ([root tree _]
+                                         (swap! calls conj [:render root tree]) nil)
+                                        ([root tree _ _]
+                                         (swap! calls conj [:render root tree]) nil))
+                    rdc/hydrate-root  (fn
+                                        ([_ _]
+                                         (swap! calls conj [:hydrate-root])
+                                         (throw (ex-info "hydrate-root must not be called on non-hydrate path" {})))
+                                        ([_ _ _]
+                                         (swap! calls conj [:hydrate-root])
+                                         (throw (ex-info "hydrate-root must not be called on non-hydrate path" {}))))
+                    rdc/unmount       (fn [arg]
+                                        (swap! calls conj [:unmount arg])
+                                        nil)]
+        (let [render-fn (:render reagent-adapter/adapter)
+              unmount   (render-fn fake-tree fake-mount nil)]
+          (is (fn? unmount)
+              "render returns an unmount thunk")
+          ;; Pre-unmount: exactly create-root + render, in order.
+          (is (= 2 (count @calls))
+              (str "expected 2 calls after render, got " (count @calls)
+                   " — " (pr-str @calls)))
+          (let [[c1 c2] @calls]
+            (is (= [:create-root fake-mount] c1)
+                "first call is (create-root mount-point)")
+            (is (= :render (first c2))
+                "second call is (render …)")
+            (is (identical? fake-root (second c2))
+                "render's first arg is the Root from create-root,
+                NOT the mount-point — this is the React 18 contract
+                the bug violated")
+            (is (= fake-tree (nth c2 2))
+                "render's second arg is the render-tree"))
+          ;; Unmount: the thunk calls (rdc/unmount root) — NOT the
+          ;; mount-point.
+          (unmount)
+          (let [last-call (last @calls)]
+            (is (= :unmount (first last-call))
+                "unmount thunk invoked rdc/unmount")
+            (is (identical? fake-root (second last-call))
+                "unmount thunk passed the Root to rdc/unmount,
+                NOT the mount-point")))))))
+
+;; ---- hydrate path ----------------------------------------------------------
+
+(deftest render-hydrate-uses-hydrate-root
+  (testing "hydrate render: (rdc/hydrate-root mount-point render-tree)
+            returns the Root; create-root / render are NOT called; the
+            unmount thunk closes over the Root from hydrate-root
+            (rf2-fn5rk)"
+    (let [calls       (atom [])
+          fake-root   (mk-fake-root :hydrate)
+          fake-mount  #js {:rf-test-mount :hydrate}
+          fake-tree   [:section "ssr-tree"]]
+      (with-redefs [rdc/create-root  (fn
+                                       ([_]   (swap! calls conj [:create-root])
+                                              (throw (ex-info "create-root must not be called on hydrate path" {})))
+                                       ([_ _] (swap! calls conj [:create-root])
+                                              (throw (ex-info "create-root must not be called on hydrate path" {}))))
+                    rdc/render       (fn
+                                       ([_ _]
+                                        (swap! calls conj [:render])
+                                        (throw (ex-info "render must not be called on hydrate path" {})))
+                                       ([_ _ _]
+                                        (swap! calls conj [:render])
+                                        (throw (ex-info "render must not be called on hydrate path" {})))
+                                       ([_ _ _ _]
+                                        (swap! calls conj [:render])
+                                        (throw (ex-info "render must not be called on hydrate path" {}))))
+                    rdc/hydrate-root (fn
+                                       ([mp tree]
+                                        (swap! calls conj [:hydrate-root mp tree])
+                                        fake-root)
+                                       ([mp tree _]
+                                        (swap! calls conj [:hydrate-root mp tree])
+                                        fake-root))
+                    rdc/unmount      (fn [arg]
+                                       (swap! calls conj [:unmount arg])
+                                       nil)]
+        (let [render-fn (:render reagent-adapter/adapter)
+              unmount   (render-fn fake-tree fake-mount {:hydrate? true})]
+          (is (fn? unmount))
+          (is (= 1 (count @calls))
+              (str "expected exactly 1 call (hydrate-root) before unmount, got "
+                   (count @calls) " — " (pr-str @calls)))
+          (is (= [:hydrate-root fake-mount fake-tree] (first @calls))
+              "hydrate-root called once with (mount-point render-tree)")
+          (unmount)
+          (let [last-call (last @calls)]
+            (is (= :unmount (first last-call)))
+            (is (identical? fake-root (second last-call))
+                "unmount thunk passes the Root returned by hydrate-root")))))))
+
+;; ---- regression pin --------------------------------------------------------
+
+(deftest render-does-not-pass-mount-point-to-rdc-render
+  (testing "regression pin for rf2-fn5rk — the pre-fix code called
+            `(rdc/render mount-point render-tree)` which threw
+            `TypeError: root.render is not a function` in real React
+            18. This test asserts the mount-point never appears as
+            the first arg to rdc/render."
+    (let [render-calls (atom [])
+          fake-root    (mk-fake-root :regression)
+          fake-mount   #js {:rf-test-mount :regression}]
+      (with-redefs [rdc/create-root  (fn
+                                       ([_]   fake-root)
+                                       ([_ _] fake-root))
+                    rdc/render       (fn
+                                       ([root tree]
+                                        (swap! render-calls conj [root tree]))
+                                       ([root tree _]
+                                        (swap! render-calls conj [root tree]))
+                                       ([root tree _ _]
+                                        (swap! render-calls conj [root tree])))
+                    rdc/hydrate-root (fn
+                                       ([_ _]   fake-root)
+                                       ([_ _ _] fake-root))
+                    rdc/unmount      (fn [_] nil)]
+        (let [render-fn (:render reagent-adapter/adapter)]
+          (render-fn [:div] fake-mount nil)
+          (is (= 1 (count @render-calls)))
+          (let [[root tree] (first @render-calls)]
+            (is (not (identical? fake-mount root))
+                "rdc/render's first arg is NEVER the raw mount-point
+                — that was the bug")
+            (is (identical? fake-root root)
+                "rdc/render's first arg is the Root from create-root")
+            (is (= [:div] tree)
+                "the render-tree is passed through unchanged")))))))

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -178,7 +178,7 @@ Renders the render-tree onto the substrate's surface and returns a function that
 ;; unmount-fn signature: (fn [] nil) — idempotent; releases all resources
 ```
 
-CLJS-Reagent: wraps `reagent.dom.client/render`; returns `(fn [] (rdc/unmount mount-point))`.
+CLJS-Reagent: wraps `reagent.dom.client/create-root` + `reagent.dom.client/render` (React 18+ Root API); the unmount-fn closes over the Root and calls `(rdc/unmount root)`. Hydrate path uses `(rdc/hydrate-root mount-point render-tree)` which returns its own Root (rf2-fn5rk).
 SSR-on-JVM: this function isn't called server-side — `render-to-string` is used instead. The adapter may stub `render` to throw on the JVM.
 
 ### `(render-to-string render-tree opts) → string`
@@ -606,15 +606,20 @@ This section is the **bridging pseudocode** for both. For each contract function
     (fn [] (apply compute-fn (map deref source-containers)))))
 
 ;; -- 6. render --------------------------------------------------------------
-;; reagent.dom.client/render mounts the React 18 root; the returned unmount-fn
-;; is the only handle the runtime keeps. Idempotent: calling unmount twice
-;; is a no-op.
+;; React 18+ takes a `Root` (from `reagent.dom.client/create-root`) — NOT
+;; a raw DOM element. The non-hydrate path creates the Root then renders
+;; into it; the hydrate path's `hydrate-root` returns its own Root. The
+;; returned unmount-fn closes over the Root so the runtime can release it
+;; without re-consulting the DOM element. Idempotent: calling unmount
+;; twice is a no-op (rf2-fn5rk).
 (defn render [render-tree mount-point opts]
   (let [hydrate? (boolean (:hydrate? opts))]
     (if hydrate?
-      (rdc/hydrate-root mount-point render-tree)
-      (rdc/render        mount-point render-tree))
-    (fn unmount [] (rdc/unmount mount-point))))
+      (let [root (rdc/hydrate-root mount-point render-tree)]
+        (fn unmount [] (rdc/unmount root)))
+      (let [root (rdc/create-root mount-point)]
+        (rdc/render root render-tree)
+        (fn unmount [] (rdc/unmount root))))))
 
 ;; -- 7. render-to-string ----------------------------------------------------
 ;; Pure JVM-runnable walk over the hiccup render-tree per [011-SSR


### PR DESCRIPTION
## Summary

The Reagent adapter's `render` slot called `(rdc/render mount-point render-tree)` directly, but React 18's `reagent.dom.client/render` takes a `Root` (from `create-root`) — **NOT a raw DOM element.** Causa's `mount/open!` therefore threw `TypeError: root.render is not a function`; the shell never landed in a real browser end-to-end. The Playwright spec from rf2-s2bhn (PR #660) was the first time the substrate-adapter render slot was exercised through a real React 18 runtime — it caught the bug instantly. Spec shipped with `skip:` awaiting this fix.

## Design

**Root-cache strategy: closed-over Root in the unmount thunk** (no separate cache atom). The unmount thunk closes over the Root returned by `create-root` / `hydrate-root`; the runtime keeps the thunk; that's the only handle anyone needs. `substrate-adapter/render` is only called once per mount-point per the Causa mount design (`mount.cljs`'s `second-open!-does-not-re-render` test pins this), so a per-mount-point Root cache atom would be dead weight. The reagent-slim adapter (rf2-6hyy) uses the same closed-over-Root shape.

### Before

```clojure
(defn- render [render-tree mount-point opts]
  (let [hydrate? (boolean (:hydrate? opts))]
    (if hydrate?
      (rdc/hydrate-root mount-point render-tree)
      (rdc/render        mount-point render-tree))    ;; <-- BUG: expects a Root, got a DOM element
    (fn unmount [] (rdc/unmount mount-point))))         ;; <-- BUG: expects a Root, got a DOM element
```

### After

```clojure
(defn- render [render-tree mount-point opts]
  (let [hydrate? (boolean (:hydrate? opts))]
    (if hydrate?
      (let [root (rdc/hydrate-root mount-point render-tree)]
        (fn unmount [] (rdc/unmount root)))
      (let [root (rdc/create-root mount-point)]
        (rdc/render root render-tree)
        (fn unmount [] (rdc/unmount root))))))
```

## Changes

- `implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs` — the fix.
- `implementation/adapters/reagent/test/re_frame/adapter_render_cljs_test.cljs` — **new** unit test pinning the create-root → render call order + unmount-passes-Root contract via `with-redefs` spies on `reagent.dom.client`. Includes a regression-pin assertion that `rdc/render`'s first arg is never the raw mount-point.
- `examples/reagent/counter/causa.spec.cjs` — remove the `skip:` placeholder rf2-s2bhn shipped.
- `spec/006-ReactiveSubstrate.md` — update §`(render …)` contract paragraph and the per-contract-fn Reagent pseudocode to match the React-18 Root API.

## API citation

Per `reagent.dom.client` (Reagent v2.0.1; sourced from the artefact's `client.cljs`):

- `create-root container [options?]` → `react-dom-client/createRoot` → Root
- `render root el [compiler? [strict-mode?]]` → calls `.render` on the Root
- `hydrate-root container el [options?]` → `react-dom-client/hydrateRoot` → its own Root
- `unmount root` → `.unmount` on the Root

## Test plan

- [x] `npm run test:cljs` from `implementation/` — 1688 tests, 4677 assertions, 0 failures (3 new tests add 14 assertions).
- [x] `npm run test:examples` from `implementation/` — `PASS causa` + all 25 other example specs pass. The Playwright spec now drives the full mount → keybinding → substrate-adapter render → shell hiccup tree → panel routing pipeline end-to-end.
- [x] `npm run test:browser` from `implementation/` — 1688 tests, 4707 assertions, **10 failures** all pre-existing on `origin/main` (Causa keybinding/mount cljs tests + realworld CORS errors); 9 new assertions from our test add 0 failures.

## Follow-on observations for rf2-uwozn (UIx + Helix parity)

The bug only ever lived in the Reagent adapter. Per Spec 006 §UIx adapter / §Helix adapter (lines 871, 895), both UIx and Helix adapters describe their render contract as `react-dom/client.createRoot` + `root.render`, which is the post-fix Reagent shape. The UIx and Helix example browser specs (`counter-uix`, `login-uix`, `counter-helix`, `login-helix`) all pass — no observable symptom. Recommend rf2-uwozn audit their adapter sources to confirm the implementation matches the spec (no equivalent latent bug).