### PR TITLE
feat(schemas): honour :sensitive? in validation-error trace events (rf2-kj51z)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -573,6 +573,150 @@
   [schema base-path]
   (walk-schema schema base-path {}))
 
+;; ---- sensitive-declaration walker (rf2-kj51z) ----------------------------
+;;
+;; Parallel to the `:large?` walker above. Per Spec 010 §`:sensitive?`
+;; — privacy in schema-validation error traces (rf2-kj51z) and per
+;; Spec-Schemas §`:rf/app-schema-meta`, any Malli slot carrying
+;; `:sensitive? true` in its per-slot properties (or container-level
+;; props when the schema is registered at the path directly) declares
+;; that slot's value as sensitive. The schema-validation emit-site
+;; consults this walker on every failure to decide whether to redact
+;; the failing value before stamping the trace event.
+;;
+;; Implementation mirrors `extract-large-paths-from-schema` byte for
+;; byte — same structural recognition (`:map` name-bearing,
+;; `:multi`/`:orn`/`:catn`/`:altn` dispatch-bearing, positional
+;; combinators descend at the same base-path) so the two flags compose
+;; cleanly under the same Malli EDN shape.
+
+(defn- sensitive-declaration-from-props
+  "Build a `{:sensitive? true}` declaration map from a slot's per-slot
+  props, or nil if `:sensitive? true` is not set. Per Spec 010
+  §`:sensitive?` and Spec 009 §Privacy — the declaration shape is the
+  minimum signal a downstream consumer needs to redact."
+  [props]
+  (when (true? (:sensitive? props))
+    {:sensitive? true}))
+
+(declare walk-sensitive-schema)
+
+(defn- walk-sensitive-map-children
+  [children base-path acc]
+  (reduce
+    (fn [acc child]
+      (if-not (and (vector? child) (>= (count child) 2))
+        acc
+        (let [k          (nth child 0)
+              maybe-prop (nth child 1)
+              has-prop?  (map? maybe-prop)
+              slot-props (when has-prop? maybe-prop)
+              child-tail (if has-prop?
+                           (when (>= (count child) 3) (nth child 2))
+                           maybe-prop)
+              slot-path  (conj base-path k)
+              slot-decl  (sensitive-declaration-from-props slot-props)
+              acc'       (if slot-decl
+                           (assoc acc slot-path slot-decl)
+                           acc)]
+          (if (some? child-tail)
+            (walk-sensitive-schema child-tail slot-path acc')
+            acc'))))
+    acc
+    children))
+
+(defn- walk-sensitive-multi-children
+  [children base-path acc]
+  (reduce
+    (fn [acc child]
+      (cond
+        (vector? child)
+        (let [maybe-prop  (when (>= (count child) 2) (nth child 1))
+              has-prop?   (map? maybe-prop)
+              tail-idx    (if has-prop? 2 1)
+              tail        (when (> (count child) tail-idx) (nth child tail-idx))
+              branch-decl (when has-prop? (sensitive-declaration-from-props maybe-prop))
+              acc'        (if branch-decl
+                            (assoc acc base-path branch-decl)
+                            acc)]
+          (if (some? tail) (walk-sensitive-schema tail base-path acc') acc'))
+        :else acc))
+    acc
+    children))
+
+(defn- walk-sensitive-positional-children
+  [children base-path acc]
+  (reduce (fn [acc c] (walk-sensitive-schema c base-path acc)) acc children))
+
+(defn walk-sensitive-schema
+  "Walk a Malli EDN schema form at `base-path`, populating `acc` with
+  `{path {:sensitive? true}}` entries for every `:sensitive? true`
+  slot found. Pure; same input always produces the same output.
+  Public so tools and validation emit-sites can re-use it.
+
+  Returns the accumulator map. Use `extract-sensitive-paths-from-schema`
+  for the seeded-empty-accumulator entry point."
+  ([schema base-path]
+   (walk-sensitive-schema schema base-path {}))
+  ([schema base-path acc]
+   (cond
+     (keyword? schema) acc
+
+     (schema-vector? schema)
+     (let [op    (nth schema 0)
+           props (extract-props schema)
+           acc'  (if-let [decl (sensitive-declaration-from-props props)]
+                   (assoc acc base-path decl)
+                   acc)]
+       (cond
+         (contains? name-bearing-ops op)
+         (walk-sensitive-map-children (drop-op+props schema) base-path acc')
+
+         (contains? dispatch-bearing-ops op)
+         (walk-sensitive-multi-children (drop-op+props schema) base-path acc')
+
+         :else
+         (walk-sensitive-positional-children (drop-op+props schema) base-path acc')))
+
+     :else acc)))
+
+(defn extract-sensitive-paths-from-schema
+  "Walk a registered Malli schema form at `base-path` and return a
+  `{path {:sensitive? true}}` map for every `:sensitive? true` slot
+  found. Convenience wrapper over `walk-sensitive-schema` that seeds
+  the empty accumulator. Per Spec 010 §`:sensitive?` — privacy in
+  schema-validation error traces.
+
+  Used by the validation emit-sites (`validate-app-db!` and the
+  per-step `validate-event!` / `validate-cofx!` /
+  `validate-sub-return!` helpers) to decide whether the failing slot's
+  value MUST be redacted before the trace event ships."
+  [schema base-path]
+  (walk-sensitive-schema schema base-path {}))
+
+(defn schema-has-sensitive?
+  "True when the registered schema declares ANY slot sensitive —
+  either:
+
+    (a) the schema's container-level props carry `:sensitive? true`
+        (covers the whole registered slot); or
+    (b) any nested `:sensitive? true` slot lives anywhere inside the
+        schema.
+
+  Per Spec 010 §`:sensitive?` — privacy in schema-validation error
+  traces. The schema-validation emit-sites ship the WHOLE registered
+  slot's value (not just a failing leaf) in the trace's `:value` /
+  `:received` / `:explain` slots; a sensitive child slot still leaks
+  if the value rides verbatim. Conservative redaction — when any
+  slot in the schema is sensitive, the whole trace's value-bearing
+  slots are redacted.
+
+  Returns boolean. Pure; same input always produces the same output."
+  [schema]
+  (-> (extract-sensitive-paths-from-schema schema [])
+      seq
+      boolean))
+
 (defn frame-elision-declarations
   "Return the merged `{path declaration}` map for every `:large? true`
   slot in every app-schema registered against `frame-id`. Composes
@@ -805,6 +949,52 @@
 
 ;; ---- validation entry points ----------------------------------------------
 
+;; Per Spec 010 §`:sensitive?` — privacy in schema-validation error
+;; traces (rf2-kj51z). The validation emit-sites redact the failing
+;; value before stamping a trace event when either:
+;;   1. The schema slot at the failing path (or a containing slot)
+;;      carries `:sensitive? true` in its Malli props.
+;;   2. The surrounding registration metadata (handler-meta / cofx-meta /
+;;      sub-meta) carries `:sensitive? true` — applies to every
+;;      validation failure in that handler's scope as a coarse fallback.
+;; The substitution sentinel is `:rf/redacted` (the framework-reserved
+;; keyword per Spec 009 §`with-redacted`). The trace event's `:tags`
+;; map is stamped with `:sensitive? true` so consumers can route on it
+;; (until rf2-isdwf's top-level hoisting lands in core).
+;;
+;; The `:value`, `:received`, and `:explain` slots are redacted; the
+;; structural / categorical slots (`:path`, `:failing-id`, `:spec-id`,
+;; `:reason`) are kept — consumers need them to locate the broken slot
+;; without leaking user data.
+
+(def ^:private redacted-sentinel
+  "The `:rf/redacted` privacy sentinel emitted by validation traces
+  for slots matching the `:sensitive?` predicate. Per Spec 009
+  §`with-redacted` — the framework-reserved keyword that cannot
+  collide with an app-defined value."
+  :rf/redacted)
+
+(defn- meta-sensitive?
+  "True when the registration metadata (handler / cofx / sub) carries
+  `:sensitive? true`. Per Spec 009 §`:sensitive?` registration
+  metadata key — the coarse, handler-level signal."
+  [m]
+  (true? (:sensitive? m)))
+
+(defn- redact-tags
+  "Replace value-bearing slots in a tags map with the `:rf/redacted`
+  sentinel. Per Spec 010 §`:sensitive?` — privacy in schema-validation
+  error traces. Stamps `:sensitive? true` so consumers filter
+  correctly. Idempotent — safe to call on an already-redacted map."
+  [tags]
+  (cond-> tags
+    (contains? tags :value)       (assoc :value       redacted-sentinel)
+    (contains? tags :received)    (assoc :received    redacted-sentinel)
+    (contains? tags :explain)     (assoc :explain     redacted-sentinel)
+    (contains? tags :malli-error) (assoc :malli-error redacted-sentinel)
+    (contains? tags :event)       (assoc :event       redacted-sentinel)
+    true                          (assoc :sensitive?  true)))
+
 (defn- type-of-value [v]
   (cond
     (string? v)  "string"
@@ -852,24 +1042,34 @@
          (let [val-at (get-in db path)
                schema (:schema m)]
            (when-not (run-validator schema val-at)
-             (trace/emit-error! :rf.error/schema-validation-failure
-                                (cond-> {:where    :app-db
-                                         :path     path
-                                         :value    val-at
-                                         :frame    frame-id
-                                         :explain  (run-explainer schema val-at)
-                                         :reason   (str "App-db at path " path
-                                                        " failed schema " schema
-                                                        ": expected "
-                                                        (cond
-                                                          (and (vector? schema)
-                                                               (= 1 (count schema))
-                                                               (keyword? (first schema)))
-                                                          (first schema)
-                                                          :else schema)
-                                                        ", got " (type-of-value val-at) ".")
-                                         :recovery :no-recovery}
-                                  event-id (assoc :failing-id event-id))))))))))
+             ;; Per Spec 010 §`:sensitive?` — privacy in schema-
+             ;; validation error traces (rf2-kj51z). Consult the
+             ;; schema's per-slot `:sensitive?` props before
+             ;; including the failing value. The failing path is
+             ;; the reg-app-schema path itself (per-path validation
+             ;; only flags the whole registered slot); the walker
+             ;; checks for container-level OR any nested slot the
+             ;; failure path crosses.
+             (let [sensitive? (schema-has-sensitive? schema)
+                   base-tags  (cond-> {:where    :app-db
+                                       :path     path
+                                       :value    val-at
+                                       :frame    frame-id
+                                       :explain  (run-explainer schema val-at)
+                                       :reason   (str "App-db at path " path
+                                                      " failed schema " schema
+                                                      ": expected "
+                                                      (cond
+                                                        (and (vector? schema)
+                                                             (= 1 (count schema))
+                                                             (keyword? (first schema)))
+                                                        (first schema)
+                                                        :else schema)
+                                                      ", got " (type-of-value val-at) ".")
+                                       :recovery :no-recovery}
+                                event-id (assoc :failing-id event-id))
+                   tags       (if sensitive? (redact-tags base-tags) base-tags)]
+               (trace/emit-error! :rf.error/schema-validation-failure tags)))))))))
 
 (defn validate-event!
   "Per Spec 010 §Validation order step 1 — before an event handler runs,
@@ -895,21 +1095,28 @@
       (if-let [schema (:spec handler-meta)]
         (if (run-validator schema event)
           true
-          (let [explanation (run-explainer schema event)]
-            (trace/emit-error! :rf.error/schema-validation-failure
-                               {:where       :event
-                                :event-id    event-id
-                                :failing-id  event-id
-                                :spec-id     event-id
-                                :received    event
-                                :event       event
-                                :malli-error explanation
-                                :explain     explanation
-                                :reason      (str "Event " event-id
-                                                  " payload failed schema "
-                                                  schema ", got "
-                                                  (type-of-value event) ".")
-                                :recovery    :no-recovery})
+          (let [explanation (run-explainer schema event)
+                ;; Per Spec 010 §`:sensitive?` — privacy in
+                ;; schema-validation error traces (rf2-kj51z).
+                ;; Consult the handler's registration meta —
+                ;; `:sensitive? true` on the reg-event-* declares
+                ;; the whole event vector sensitive.
+                sensitive? (meta-sensitive? handler-meta)
+                base-tags  {:where       :event
+                            :event-id    event-id
+                            :failing-id  event-id
+                            :spec-id     event-id
+                            :received    event
+                            :event       event
+                            :malli-error explanation
+                            :explain     explanation
+                            :reason      (str "Event " event-id
+                                              " payload failed schema "
+                                              schema ", got "
+                                              (type-of-value event) ".")
+                            :recovery    :no-recovery}
+                tags       (if sensitive? (redact-tags base-tags) base-tags)]
+            (trace/emit-error! :rf.error/schema-validation-failure tags)
             false))
         true)
       true)
@@ -937,22 +1144,31 @@
       (if-let [schema (:spec sub-meta)]
         (if (run-validator schema value)
           true
-          (let [explanation (run-explainer schema value)]
-            (trace/emit-error! :rf.error/schema-validation-failure
-                               {:where       :sub-return
-                                :sub-id      sub-id
-                                :failing-id  sub-id
-                                :spec-id     sub-id
-                                :query-v     query-v
-                                :received    value
-                                :value       value
-                                :malli-error explanation
-                                :explain     explanation
-                                :reason      (str "Subscription " sub-id
-                                                  " return value failed schema "
-                                                  schema ", got "
-                                                  (type-of-value value) ".")
-                                :recovery    :replaced-with-default})
+          (let [explanation (run-explainer schema value)
+                ;; Per Spec 010 §`:sensitive?` — privacy in
+                ;; schema-validation error traces (rf2-kj51z).
+                ;; Two sources: the sub's registration meta
+                ;; (`:sensitive?` on reg-sub) and the schema's own
+                ;; per-slot `:sensitive?` (a container-level flag
+                ;; on the spec covers every failing return).
+                sensitive? (or (meta-sensitive? sub-meta)
+                               (schema-has-sensitive? schema))
+                base-tags  {:where       :sub-return
+                            :sub-id      sub-id
+                            :failing-id  sub-id
+                            :spec-id     sub-id
+                            :query-v     query-v
+                            :received    value
+                            :value       value
+                            :malli-error explanation
+                            :explain     explanation
+                            :reason      (str "Subscription " sub-id
+                                              " return value failed schema "
+                                              schema ", got "
+                                              (type-of-value value) ".")
+                            :recovery    :replaced-with-default}
+                tags       (if sensitive? (redact-tags base-tags) base-tags)]
+            (trace/emit-error! :rf.error/schema-validation-failure tags)
             false))
         true)
       true)
@@ -980,22 +1196,29 @@
       (if-let [schema (:spec cofx-meta)]
         (if (run-validator schema value)
           true
-          (let [explanation (run-explainer schema value)]
-            (trace/emit-error! :rf.error/schema-validation-failure
-                               {:where       :cofx
-                                :cofx-id     cofx-id
-                                :event-id    event-id
-                                :failing-id  event-id
-                                :spec-id     cofx-id
-                                :received    value
-                                :value       value
-                                :malli-error explanation
-                                :explain     explanation
-                                :reason      (str "Coeffect " cofx-id
-                                                  " injected value failed schema "
-                                                  schema ", got "
-                                                  (type-of-value value) ".")
-                                :recovery    :no-recovery})
+          (let [explanation (run-explainer schema value)
+                ;; Per Spec 010 §`:sensitive?` — privacy in
+                ;; schema-validation error traces (rf2-kj51z).
+                ;; Cofx-meta or container-level schema-prop both
+                ;; trigger redaction.
+                sensitive? (or (meta-sensitive? cofx-meta)
+                               (schema-has-sensitive? schema))
+                base-tags  {:where       :cofx
+                            :cofx-id     cofx-id
+                            :event-id    event-id
+                            :failing-id  event-id
+                            :spec-id     cofx-id
+                            :received    value
+                            :value       value
+                            :malli-error explanation
+                            :explain     explanation
+                            :reason      (str "Coeffect " cofx-id
+                                              " injected value failed schema "
+                                              schema ", got "
+                                              (type-of-value value) ".")
+                            :recovery    :no-recovery}
+                tags       (if sensitive? (redact-tags base-tags) base-tags)]
+            (trace/emit-error! :rf.error/schema-validation-failure tags)
             false))
         true)
       true)
@@ -1088,6 +1311,15 @@
                    frame-elision-declarations)
 (late-bind/set-fn! :schemas/populate-elision-declarations
                    populate-elision-declarations)
+
+;; Sensitive-paths walker (rf2-kj51z) — published so the rf2-c1l4d
+;; follow-on (which extends the unified elision registry to recognise
+;; schema `:sensitive?` slots) can consume it without statically
+;; requiring the schemas artefact.
+(late-bind/set-fn! :schemas/extract-sensitive-paths-from-schema
+                   extract-sensitive-paths-from-schema)
+(late-bind/set-fn! :schemas/schema-has-sensitive?
+                   schema-has-sensitive?)
 
 ;; Test-support hooks (consumed by re-frame.test-support's
 ;; reset-runtime-fixture). The fixture wants to capture and restore

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -1,0 +1,418 @@
+(ns re-frame.schemas-sensitive-test
+  "JVM tests for the `:sensitive?` redaction contract in schema-validation
+  error traces (rf2-kj51z).
+
+  Per Spec 010 §`:sensitive?` — privacy in schema-validation error
+  traces, the validation hot path MUST consult the registered schema's
+  per-slot `:sensitive?` (and the registration-meta `:sensitive?`)
+  before including the failing value in the
+  `:rf.error/schema-validation-failure` trace event. When either source
+  declares the slot sensitive:
+
+    1. The failing value (`:value` / `:received`) is replaced with the
+       framework-reserved `:rf/redacted` sentinel.
+    2. The Malli explainer output (`:explain` / `:malli-error`) is
+       redacted — it carries the failing value verbatim.
+    3. The trace event's `:tags` are stamped `:sensitive? true` so
+       consumers route on it.
+
+  Structural slots (`:path`, `:failing-id`, `:spec-id`, `:reason`) ride
+  unchanged — consumers need them to locate the broken slot without
+  leaking user data.
+
+  This file covers three surfaces:
+
+    1. **Walker unit tests** — `extract-sensitive-paths-from-schema`
+       recognises every Malli shape `:sensitive?` can legally live in
+       (slot-level props, container-level props, nested, dispatch-
+       bearing combinators).
+    2. **Redaction substitution** — direct invocation of
+       `validate-app-db!` / `validate-event!` / `validate-cofx!` /
+       `validate-sub-return!` against a `:sensitive?`-bearing schema
+       fires a trace with the redaction shape pinned.
+    3. **Backward-compat** — non-sensitive validation failures emit
+       unchanged (`:value`, `:explain` ride verbatim; no
+       `:sensitive?` stamp on the tags)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.flows :as flows]
+            [re-frame.schemas :as schemas]
+            [re-frame.spec :as spec]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (schemas/reset-schema-validator!)
+  (spec/clear-boundary-warned-handler-ids!)
+  (rf/init! plain-atom/adapter)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- walker unit tests ----------------------------------------------------
+
+(deftest extract-no-sensitive-slots
+  (testing "a schema with no :sensitive? props produces no entries"
+    (is (= {} (schemas/extract-sensitive-paths-from-schema
+                [:map [:name :string]] [])))
+    (is (= {} (schemas/extract-sensitive-paths-from-schema :string [])))
+    (is (= {} (schemas/extract-sensitive-paths-from-schema :int [:a :b])))))
+
+(deftest extract-slot-level-sensitive
+  (testing "the slot's per-slot props carry :sensitive? true"
+    (let [schema [:map
+                  [:user :string]
+                  [:password {:sensitive? true} :string]]]
+      (is (= {[:password] {:sensitive? true}}
+             (schemas/extract-sensitive-paths-from-schema schema []))))))
+
+(deftest extract-honours-base-path
+  (testing "base-path is prepended to every discovered slot path"
+    (let [schema [:map
+                  [:password {:sensitive? true} :string]]]
+      (is (= {[:auth :password] {:sensitive? true}}
+             (schemas/extract-sensitive-paths-from-schema schema [:auth]))))))
+
+(deftest extract-container-level-sensitive
+  (testing "the schema's OWN props (container-level) claim the base-path"
+    ;; `(reg-app-schema [:auth :token] [:string {:sensitive? true}])`
+    (is (= {[:auth :token] {:sensitive? true}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:string {:sensitive? true}] [:auth :token])))))
+
+(deftest extract-nested-map
+  (testing "nested :map carries the path through every level"
+    (let [schema [:map
+                  [:user
+                   [:map
+                    [:profile
+                     [:map
+                      [:ssn {:sensitive? true} :string]]]]]]]
+      (is (= {[:user :profile :ssn] {:sensitive? true}}
+             (schemas/extract-sensitive-paths-from-schema schema []))))))
+
+(deftest extract-multiple-sensitive-slots
+  (testing "multiple sensitive slots in the same schema produce one entry each"
+    (let [schema [:map
+                  [:username :string]
+                  [:password  {:sensitive? true} :string]
+                  [:totp-code {:sensitive? true} :string]
+                  [:email :string]]]
+      (is (= {[:password]  {:sensitive? true}
+              [:totp-code] {:sensitive? true}}
+             (schemas/extract-sensitive-paths-from-schema schema []))))))
+
+(deftest extract-positional-combinator-descends
+  (testing ":vector / :or / :and descend at the same base-path"
+    ;; A :vector with sensitive props on its inner type's container.
+    (is (= {[:tokens] {:sensitive? true}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:vector [:string {:sensitive? true}]] [:tokens])))))
+
+;; ---- schema-has-sensitive? -----------------------------------------------
+
+(deftest schema-has-sensitive-slot-level
+  (testing "schema-has-sensitive? returns true when ANY slot carries
+            :sensitive? — emit-sites carry the whole registered value
+            in the trace, so a sensitive child slot still leaks
+            unredacted"
+    (let [schema [:map [:password {:sensitive? true} :string]]]
+      (is (true? (schemas/schema-has-sensitive? schema))
+          "slot-level :sensitive? — conservative redact"))))
+
+(deftest schema-has-sensitive-container-level
+  (testing "a container-level :sensitive? on a schema registered at a path
+            triggers redaction"
+    (let [schema [:string {:sensitive? true}]]
+      (is (true? (schemas/schema-has-sensitive? schema))))))
+
+(deftest schema-has-sensitive-nested
+  (testing "a nested :sensitive? slot deep inside a map also triggers redaction"
+    (let [schema [:map
+                  [:user [:map
+                          [:profile [:map
+                                     [:ssn {:sensitive? true} :string]]]]]]]
+      (is (true? (schemas/schema-has-sensitive? schema))))))
+
+(deftest schema-has-sensitive-no-match
+  (testing "no :sensitive? anywhere → false"
+    (let [schema [:map [:user :string] [:age :int]]]
+      (is (false? (schemas/schema-has-sensitive? schema))))
+    (is (false? (schemas/schema-has-sensitive? :int)))
+    (is (false? (schemas/schema-has-sensitive? [:vector :string])))))
+
+;; ---- redaction at app-db validation site ----------------------------------
+
+(deftest app-db-validation-redacts-sensitive-slot
+  (testing "Per Spec 010 §`:sensitive?` — a failing app-db value at a
+            :sensitive? slot emits a trace whose :value and :explain
+            are the :rf/redacted sentinel and whose :tags are stamped
+            :sensitive? true"
+    ;; A schema where the WHOLE registered slot is marked sensitive
+    ;; (container-level :sensitive?).
+    (rf/reg-app-schema [:auth :token] [:string {:sensitive? true}])
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::redact (fn [ev] (swap! traces conj ev)))
+      ;; The value at [:auth :token] is an int (42) — fails :string.
+      (schemas/validate-app-db! {:auth {:token 42}} :auth/init-bad)
+      (rf/remove-trace-cb! ::redact)
+      (let [violations (filter #(= :rf.error/schema-validation-failure
+                                   (:operation %))
+                               @traces)]
+        (is (= 1 (count violations))
+            "exactly one schema-validation-failure trace fired")
+        (let [v (first violations)]
+          (is (true? (-> v :tags :sensitive?))
+              ":tags :sensitive? true — consumers can filter")
+          (is (= :rf/redacted (-> v :tags :value))
+              ":value is the :rf/redacted sentinel — original value scrubbed")
+          (is (= :rf/redacted (-> v :tags :explain))
+              ":explain is also redacted — Malli's explanation re-leaks the value")
+          ;; Structural slots remain visible.
+          (is (= [:auth :token] (-> v :tags :path))
+              ":path stays visible — consumers need it to locate the slot")
+          (is (= :auth/init-bad (-> v :tags :failing-id))
+              ":failing-id stays visible — the handler is not sensitive")
+          (is (= :app-db (-> v :tags :where)))
+          (is (string? (-> v :tags :reason))
+              ":reason — human-readable explanation, no value"))))))
+
+(deftest app-db-validation-redacts-slot-level-sensitive
+  (testing "Slot-level :sensitive? on a child entry inside a registered
+            map schema covers that slot's failures"
+    ;; reg-app-schema covers [:user], the :password child is sensitive.
+    (rf/reg-app-schema [:user]
+                       [:map
+                        [:name     :string]
+                        [:password {:sensitive? true} :string]])
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::slot (fn [ev] (swap! traces conj ev)))
+      ;; password is an int — fails :string. Since validation is
+      ;; per-registered-path, the whole [:user] value fails the schema.
+      ;; But schema-sensitive-at? checks if [:user] is sensitive (no)
+      ;; OR a child slot of [:user] under the registered path crosses
+      ;; the failing path. Since reg-app-schema validates the whole
+      ;; registered slot, we need the :sensitive? to flag the WHOLE
+      ;; failure when ANY slot within is sensitive.
+      (schemas/validate-app-db! {:user {:name "alice" :password 99}}
+                                :user/bad)
+      (rf/remove-trace-cb! ::slot)
+      (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                             @traces))]
+        (is (some? v) "a trace fired")
+        (is (true? (-> v :tags :sensitive?))
+            "the registered schema contains a :sensitive? slot — the failure is redacted")
+        (is (= :rf/redacted (-> v :tags :value)))
+        (is (= :rf/redacted (-> v :tags :explain)))))))
+
+(deftest app-db-validation-non-sensitive-passes-through-verbatim
+  (testing "Backward-compat — a schema with no :sensitive? props emits
+            unchanged traces; :value and :explain ride verbatim"
+    (rf/reg-app-schema [:count] [:int])
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::plain (fn [ev] (swap! traces conj ev)))
+      (schemas/validate-app-db! {:count "not-an-int"} :count/bad)
+      (rf/remove-trace-cb! ::plain)
+      (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                             @traces))]
+        (is (some? v))
+        (is (not (contains? (:tags v) :sensitive?))
+            "no :sensitive? stamp on non-sensitive validation")
+        (is (= "not-an-int" (-> v :tags :value))
+            ":value rides verbatim — legacy behaviour preserved")
+        (is (some? (-> v :tags :explain))
+            ":explain is present (Malli's structural explanation)")))))
+
+;; ---- redaction at event validation site ----------------------------------
+
+(deftest event-validation-redacts-when-registration-sensitive
+  (testing "Per Spec 010 §`:sensitive?` — handler :sensitive? true
+            triggers redaction of the event-payload validation trace"
+    (let [calls (atom 0)]
+      (rf/reg-event-db :auth/sign-in
+        {:doc        "Verify creds"
+         :sensitive? true
+         :spec       [:cat [:= :auth/sign-in] :string :string]}
+        (fn [db _] (swap! calls inc) db))
+      (let [traces (atom [])]
+        (rf/register-trace-cb! ::ev (fn [ev] (swap! traces conj ev)))
+        ;; Malformed payload — second arg should be string.
+        (rf/dispatch-sync [:auth/sign-in "ada" 42])
+        (rf/remove-trace-cb! ::ev)
+        (is (= 0 @calls) "handler skipped — validation failed")
+        (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                               @traces))]
+          (is (some? v))
+          (is (true? (-> v :tags :sensitive?))
+              ":sensitive? stamp present — consumers filter on this")
+          (is (= :rf/redacted (-> v :tags :event))
+              ":event slot — the event vector — is the redacted sentinel")
+          (is (= :rf/redacted (-> v :tags :received))
+              ":received — duplicate of the event — also redacted")
+          (is (= :rf/redacted (-> v :tags :explain))
+              ":explain — Malli explanation re-leaks the values")
+          (is (= :rf/redacted (-> v :tags :malli-error))
+              ":malli-error — duplicate of explain — also redacted")
+          ;; Structural slots survive.
+          (is (= :event (-> v :tags :where)))
+          (is (= :auth/sign-in (-> v :tags :event-id)))
+          (is (= :auth/sign-in (-> v :tags :failing-id)))
+          (is (= :auth/sign-in (-> v :tags :spec-id))))))))
+
+(deftest event-validation-non-sensitive-passes-through-verbatim
+  (testing "Backward-compat — a handler without :sensitive? emits the
+            unredacted trace (legacy behaviour for non-sensitive
+            handlers)"
+    (rf/reg-event-db :user/register
+      {:spec [:cat [:= :user/register]
+                   [:map [:email :string] [:age :int]]]}
+      (fn [db [_ payload]] (update db :users (fnil conj []) payload)))
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::reg (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:user/register {:email "carol@example.com" :age "no"}])
+      (rf/remove-trace-cb! ::reg)
+      (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                             @traces))]
+        (is (some? v))
+        (is (not (contains? (:tags v) :sensitive?))
+            "no sensitive stamp on non-sensitive handler")
+        (is (= [:user/register {:email "carol@example.com" :age "no"}]
+               (-> v :tags :event))
+            ":event rides verbatim")))))
+
+;; ---- redaction at cofx validation site -----------------------------------
+
+(deftest cofx-validation-redacts-when-cofx-meta-sensitive
+  (testing "Per Spec 010 §`:sensitive?` — cofx :sensitive? true triggers
+            redaction of the cofx-validation trace"
+    (rf/reg-cofx :auth/credentials
+      {:doc "Inject the user's auth token"
+       :sensitive? true
+       :spec :string}
+      (fn [ctx] (assoc-in ctx [:coeffects :auth/credentials] 42))) ; int, not string
+    (rf/reg-event-fx :auth/use-creds
+      [(rf/inject-cofx :auth/credentials)]
+      (fn [_ _] {}))
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::cf (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:auth/use-creds])
+      (rf/remove-trace-cb! ::cf)
+      (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                             @traces))]
+        (is (some? v))
+        (is (true? (-> v :tags :sensitive?)))
+        (is (= :rf/redacted (-> v :tags :value)))
+        (is (= :rf/redacted (-> v :tags :received)))
+        (is (= :rf/redacted (-> v :tags :explain)))
+        (is (= :cofx (-> v :tags :where))
+            "structural :where slot survives")
+        (is (= :auth/credentials (-> v :tags :cofx-id))
+            "structural :cofx-id survives")))))
+
+(deftest cofx-validation-redacts-when-schema-container-sensitive
+  (testing "A container-level :sensitive? on the cofx :spec also triggers
+            redaction even when the cofx-meta doesn't carry the flag"
+    (rf/reg-cofx :secret-blob
+      {:spec [:string {:sensitive? true}]}
+      (fn [ctx] (assoc-in ctx [:coeffects :secret-blob] 99))) ; int, fails :string
+    (rf/reg-event-fx :use-secret
+      [(rf/inject-cofx :secret-blob)]
+      (fn [_ _] {}))
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::cb (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:use-secret])
+      (rf/remove-trace-cb! ::cb)
+      (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                             @traces))]
+        (is (some? v))
+        (is (true? (-> v :tags :sensitive?))
+            "container-level :sensitive? on the schema triggered redaction")
+        (is (= :rf/redacted (-> v :tags :value)))))))
+
+;; ---- redaction at sub-return validation site -----------------------------
+
+(deftest sub-return-validation-redacts-when-sensitive
+  (testing "Per Spec 010 §`:sensitive?` — sub :sensitive? true triggers
+            redaction of the sub-return validation trace"
+    (rf/reg-event-db :secrets/init (fn [_ _] {:secrets ["a-secret"]}))
+    (rf/reg-event-db :secrets/break (fn [db _] (assoc db :secrets [1 2 3])))
+    (rf/reg-sub :secrets
+      {:sensitive? true
+       :spec [:vector :string]}
+      (fn [db _] (:secrets db)))
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::sr (fn [ev] (swap! traces conj ev)))
+      (rf/dispatch-sync [:secrets/init])
+      ;; First subscribe materialises; well-typed.
+      (rf/subscribe-value [:secrets])
+      (rf/dispatch-sync [:secrets/break])
+      ;; Resubscribe; malformed return — fails.
+      (rf/subscribe-value [:secrets])
+      (rf/remove-trace-cb! ::sr)
+      (let [violations (filter #(= :rf.error/schema-validation-failure (:operation %))
+                               @traces)]
+        (is (pos? (count violations)))
+        (let [v (first violations)]
+          (is (true? (-> v :tags :sensitive?))
+              ":sensitive? stamp on sub-return validation")
+          (is (= :rf/redacted (-> v :tags :value))
+              ":value redacted")
+          (is (= :rf/redacted (-> v :tags :received)))
+          (is (= :rf/redacted (-> v :tags :explain)))
+          ;; Structural slots survive.
+          (is (= :sub-return (-> v :tags :where)))
+          (is (= :secrets (-> v :tags :sub-id)))
+          (is (= :replaced-with-default (:recovery v))))))))
+
+;; ---- composition with :large? --------------------------------------------
+
+(deftest sensitive-overrides-large-on-same-slot
+  (testing "Per Spec 010 §`:sensitive?` + Spec 009 §Unified wire-elision
+            surface — a slot carrying both :sensitive? and :large? in
+            schema-validation traces redacts on sensitivity; the size
+            marker would re-leak :path / :bytes and is NOT emitted"
+    ;; Schema declares the slot BOTH large and sensitive.
+    (rf/reg-app-schema [:user :secret-pdf]
+                       [:string {:sensitive? true :large? true}])
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::both (fn [ev] (swap! traces conj ev)))
+      ;; Value is a long string but is an int (42) here — actually let's
+      ;; make it a wrong type to force a validation failure regardless
+      ;; of how :large? would behave at runtime.
+      (schemas/validate-app-db! {:user {:secret-pdf 42}} :doc/bad)
+      (rf/remove-trace-cb! ::both)
+      (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                             @traces))]
+        (is (some? v))
+        (is (true? (-> v :tags :sensitive?))
+            "the slot's :sensitive? flag claims the trace")
+        (is (= :rf/redacted (-> v :tags :value))
+            "sensitive drop wins on a both-flagged slot")
+        ;; No size marker leaked into the value slot — the redaction
+        ;; sentinel sits there instead of a {:rf.size/large-elided ...}
+        ;; envelope.
+        (is (not (and (map? (-> v :tags :value))
+                      (contains? (-> v :tags :value) :rf.size/large-elided)))
+            "no :rf.size/large-elided marker — would re-leak :path/:bytes")))))
+
+;; ---- elision: redaction is dev-time -------------------------------------
+
+(deftest sensitive-redaction-elides-with-validation
+  (testing "Per Spec 010 §Production builds + Spec 009 §Production-elision
+            behaviour — the entire validation body (including the
+            redaction substitution) lives behind the
+            interop/debug-enabled? gate. Production builds DCE both."
+    (rf/reg-app-schema [:auth :token] [:string {:sensitive? true}])
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::prod (fn [ev] (swap! traces conj ev)))
+      (with-redefs [re-frame.interop/debug-enabled? false]
+        (schemas/validate-app-db! {:auth {:token 42}} :auth/init-bad))
+      (rf/remove-trace-cb! ::prod)
+      (is (empty? (filter #(= :rf.error/schema-validation-failure (:operation %))
+                          @traces))
+          "no validation trace fires when debug-enabled? is false — redaction is moot"))))

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -267,6 +267,69 @@ Combinators (`:or`, `:and`, `:maybe`, `:tuple`, `:multi`, `:vector`, `:set`) des
 
 **Other ports.** The `:large?` mechanism is portable in spirit: any port whose schema language carries per-slot properties (Zod's `.describe` / refinements; Pydantic's `Field`'s arbitrary kwargs; dry-rb's metadata) can plug the same predicate into the same registry shape. The CLJS reference's walker lives in the schemas artefact (`re-frame.schemas/extract-large-paths-from-schema`, `populate-elision-declarations`) and is published through the late-bind hook table — `re-frame.core` calls it without statically requiring the schemas artefact (per the rf2-p7va per-feature artefact split).
 
+### `:sensitive?` — privacy in schema-validation error traces (rf2-kj51z)
+
+Per [009 §Privacy / sensitive data in traces](009-Instrumentation.md#privacy--sensitive-data-in-traces), the `:sensitive?` flag is the framework's declarative privacy marker. The schema-validation hot path MUST honour it before emitting `:rf.error/schema-validation-failure` trace events — those events carry the **failing value verbatim** by default (Malli's standard behaviour), and a sensitive credential / PII slot whose post-handler `app-db` value fails its schema would leak through the trace surface to every registered listener (including off-box error monitors and pair-tool forwarders).
+
+**Two sources of sensitivity** the validation site MUST consult, in this order (most-specific wins):
+
+1. **Per-slot `:sensitive?` on the failing path's schema.** A slot or container whose Malli props carry `:sensitive? true` declares the slot's value sensitive — parallel to `:large?` (per [§`:large?` — schema-driven size-elision nomination](#large--schema-driven-size-elision-nomination-rf2-nwv63) above). Two structural positions are accepted, exactly as for `:large?`:
+
+   ```clojure
+   ;; (a) slot-level — the schema slot's per-slot props
+   [:map [:password {:sensitive? true} :string]]
+   ;; ⇒ [:password] sensitive
+
+   ;; (b) container-level — the schema's own props when the schema is
+   ;;     registered at the path directly
+   (rf/reg-app-schema [:auth :token] [:string {:sensitive? true}])
+   ;; ⇒ [:auth :token] sensitive
+   ```
+
+2. **Registration-meta `:sensitive?`** on the surrounding `reg-event-*` / `reg-sub` / `reg-cofx`. The handler-meta consulted at validation time (per [009 §`:sensitive?` registration metadata key](009-Instrumentation.md#the-sensitive-registration-metadata-key)) carries `:sensitive? true` for handlers that opted in. Per-step validation sites apply it as a coarse fallback: any failure in a sensitive handler's scope is redacted regardless of per-slot props. The `app-db` validation site reads the per-slot props only (no surrounding handler scope to consult — the `validate-app-db!` call is keyed by frame, not by a single handler's registration).
+
+**Redaction shape.** When either source declares the failing slot sensitive, the trace event MUST:
+
+- Replace `:value` (the failing value) and `:received` (if present) with the framework-reserved sentinel keyword `:rf/redacted` (per [009 §`with-redacted` interceptor](009-Instrumentation.md#the-with-redacted-interceptor) — same sentinel, same reserved-keyword guarantee).
+- Replace `:explain` with `:rf/redacted` — the Malli explainer output carries the failing value verbatim under `:value` / `:errors[].value` and re-leaks it. Tools that want a structural error description without the value reach for the path (`:tags :path`) and the schema's id (`:tags :spec-id`).
+- Stamp `:sensitive? true` in the trace event's `:tags` map. Consumers route on `(get-in trace-event [:tags :sensitive?])` until top-level hoisting lands (rf2-isdwf is in flight in core; once landed, the runtime promotes `:tags :sensitive?` to the top-level `:sensitive?` slot per [009 §Trace-event field: `:sensitive?` at the top level](009-Instrumentation.md#trace-event-field-sensitive-at-the-top-level) — the schemas-side emit-site does not need to be revisited).
+
+Path-of-failure (`:tags :path`), failing handler id (`:tags :failing-id`), schema id (`:tags :spec-id`), and the human-readable `:reason` string remain unredacted — these are structural / categorical signals that do not carry user data, and consumers need them to locate the broken slot. Only the value-bearing slots (`:value`, `:received`, `:explain`) are redacted.
+
+```clojure
+;; Failing app-db at a sensitive slot:
+(rf/reg-app-schema [:auth]
+  [:map [:token {:sensitive? true} :string]])
+
+(rf/dispatch [:auth/init-bad])   ;; commits {:auth {:token 42}} — int, not string
+
+;; The schema-validation-failure trace is shaped:
+{:operation :rf.error/schema-validation-failure
+ :op-type   :error
+ :tags      {:where      :app-db
+             :path       [:auth :token]    ;; structural — kept
+             :frame      :rf/default
+             :value      :rf/redacted      ;; value redacted (was 42)
+             :explain    :rf/redacted      ;; Malli explanation redacted (re-leaks)
+             :sensitive? true              ;; consumers route on this
+             :reason     "App-db at path [:auth :token] failed schema ..."
+             :failing-id :auth/init-bad}
+ :recovery :no-recovery}
+```
+
+**Composition with `:large?`** (per [009 §Unified wire-elision surface](009-Instrumentation.md#privacy--sensitive-data-in-traces)). A slot carrying both `:sensitive? true` and `:large? true` redacts on sensitivity — the schema-validation emit site never produces a `:rf.size/large-elided` marker for a sensitive value (the marker itself would leak `:path` / `:bytes` / `:digest`). The validation emit-site mirrors the `rf/elide-wire-value` walker's composition rule.
+
+**Composition with `with-redacted`.** Independent. `with-redacted` (per [009](009-Instrumentation.md#the-with-redacted-interceptor)) overwrites named keys in the event vector and downstream cofx; it does not reach into the schema-validation failure trace. A handler declaring both `:sensitive? true` and `(with-redacted [...])` gets:
+- the event vector redacted at the named keys (via `with-redacted`), AND
+- the schema-validation `:value` / `:explain` redacted on top (via this section's contract).
+The two are orthogonal and additive — the conservative recommendation is to declare both when the handler is sensitive enough to want both layers of defence.
+
+**Production elision.** The redaction lives behind the same `(when interop/debug-enabled? ...)` outer gate as the rest of the validation hot path (per [§Production builds](#production-builds)). `:advanced` + `goog.DEBUG=false` builds DCE the entire validate-emit body — including the `:rf/redacted` substitution — alongside the trace surface. The redaction is moot when there is no trace to redact.
+
+**Walker.** The CLJS reference ships `re-frame.schemas/extract-sensitive-paths-from-schema` (parallel to `extract-large-paths-from-schema`) — a pure-data Malli-EDN walker that returns `{path {:sensitive? true}}` entries for every `:sensitive? true` slot in a registered schema. The validation emit-site walks the failing path's schema with this helper to decide whether to redact.
+
+**Backward compatibility.** Non-sensitive validation failures (handlers and slots with no `:sensitive?` declaration) are unchanged — `:value`, `:received`, and `:explain` ride the trace verbatim as before. Legacy listener code (tools that read `:tags :value` directly) continues to work for non-sensitive traces and sees the sentinel keyword `:rf/redacted` for sensitive ones; the sentinel is a normal EDN value the consumer can pattern-match on.
+
 ## Per-frame schemas
 
 `reg-app-schema` is per-frame — registered against the active frame at registration time. The public lookup APIs (`app-schemas`, `app-schema-at`) take an optional `frame-id` and default to the active frame (or `:rf/default`).


### PR DESCRIPTION
## Summary

- Per Spec 010 §`:sensitive?` — privacy in schema-validation error traces, the four validation emit-sites (`validate-app-db!` / `validate-event!` / `validate-cofx!` / `validate-sub-return!`) now consult the schema's per-slot `:sensitive?` props AND the registration-meta `:sensitive?` flag before stamping a `:rf.error/schema-validation-failure` trace event. The failing value (`:value` / `:received` / `:event` / `:explain` / `:malli-error`) is replaced with the framework-reserved `:rf/redacted` sentinel; `:tags :sensitive? true` is stamped so consumers route on it (until rf2-isdwf's top-level hoisting lands in core). Structural slots (`:path`, `:where`, `:failing-id`, `:spec-id`, `:reason`) survive unredacted — consumers need them to locate the broken slot.
- Adds a parallel walker `extract-sensitive-paths-from-schema` plus `schema-has-sensitive?` predicate (mirrors the rf2-nwv63 `:large?` walker), published through the late-bind hook table so the rf2-c1l4d follow-on (unified elision registry recognising schema `:sensitive?`) can consume them without statically requiring the schemas artefact.
- Composition rules: sensitive overrides `:large?` on the same slot (sensitive drop wins); independent of `with-redacted` (additive); production elision unchanged (entire validation body behind `interop/debug-enabled?`).

## Spec amendment

`spec/010-Schemas.md` — new §`:sensitive?` — privacy in schema-validation error traces (rf2-kj51z) under §Per-slot metadata vocabulary. Documents the two sources (per-slot props + registration-meta), the redaction shape, the `:rf/redacted` substitution, the `:tags :sensitive?` stamp, composition with `:large?` / `with-redacted`, production-elision behaviour, and the cross-spec references to 009 §Privacy.

## Redaction mechanism

- `redact-tags` helper substitutes `:rf/redacted` into every value-bearing slot in the tags map and stamps `:sensitive? true`.
- `validate-app-db!` calls `(schema-has-sensitive? schema)` against the registered slot's schema — the trace ships the WHOLE registered slot's value, so any sensitive child slot inside the schema triggers conservative full-trace redaction.
- `validate-event!` / `validate-cofx!` / `validate-sub-return!` consult `(meta-sensitive? handler-meta)` on the registration AND `(schema-has-sensitive? schema)` on the `:spec` — either path triggers redaction.

## Test plan

- [x] Unit: walker recognises slot-level / container-level / nested / dispatch-bearing / positional-combinator `:sensitive?` slots (8 unit tests).
- [x] Unit: `schema-has-sensitive?` predicate (4 unit tests).
- [x] Integration: redaction substitution at all four emit-sites (`validate-app-db!`, `validate-event!`, `validate-cofx!`, `validate-sub-return!`).
- [x] Edge: non-sensitive validation failure rides verbatim (legacy behaviour preserved).
- [x] Composition: `:sensitive?` + `:large?` on same slot → sensitive drop wins, no size marker emitted.
- [x] Production elision: redaction lives behind `interop/debug-enabled?` gate.
- [x] `clojure -M:test` from `implementation/schemas/` — 99 tests, 285 assertions, 0 failures, 0 errors (21 new tests added).