### PR TITLE
feat(causa): migrate to reagent-slim — Causa dogfoods the framework's own rewrite (rf2-wl5pa)

### DIFF
--- a/tools/causa/deps.edn
+++ b/tools/causa/deps.edn
@@ -34,12 +34,37 @@
 {:paths ["src"]
  :deps  {day8/re-frame2 {:local/root "../../implementation/core"}
 
-         ;; Reagent is the default substrate for Causa's UI at v1 (the
-         ;; preload uses Reagent's createRoot via reagent.dom.client
-         ;; when the host is Reagent; the substrate adapter abstracts
-         ;; the render path for other adapters). Pinned to the same
-         ;; version implementation/shadow-cljs.edn carries.
-         reagent/reagent {:mvn/version "2.0.1"}}
+         ;; Per rf2-wl5pa — Causa targets day8/reagent-slim (the rewrite)
+         ;; rather than stock Reagent. Causa has zero direct `reagent.*`
+         ;; requires under tools/causa/src/ (the dep is purely the
+         ;; substrate the host installs and that mount.cljs reaches via
+         ;; re-frame.substrate.adapter/render). Switching from stock
+         ;; Reagent to slim means:
+         ;;
+         ;;   1. UIx-only / Helix-only / plain-atom users get Causa
+         ;;      without dragging stock Reagent into their transitive
+         ;;      deps — Causa picks the lighter substrate regardless
+         ;;      of the host's adapter choice.
+         ;;
+         ;;   2. The smaller dev bundle (3954 bytes smaller on the
+         ;;      counter example per the rf2-tba5e smoke test) shaves
+         ;;      hot-reload latency — Causa overhead is felt most
+         ;;      acutely in the watch loop where the dev bundle dominates.
+         ;;
+         ;;   3. The framework's own devtools dogfood the framework's
+         ;;      Reagent rewrite at the load profile that matters.
+         ;;
+         ;; Note on the adapter ns: the in-tree slim adapter ns is
+         ;; `re-frame.adapter.reagent-slim`; at artefact-publication
+         ;; time the slim artefact ships its own `re-frame.adapter.reagent`
+         ;; ns (per implementation/adapters/reagent-slim/IMPL-SPEC.md §1.8).
+         ;; Either way, Causa never directly :requires the adapter ns —
+         ;; mount.cljs reaches the substrate via
+         ;; re-frame.substrate.adapter/render so the host's installed
+         ;; adapter governs the render path; the slim dep here is purely
+         ;; transitive-classpath assembly so Causa's published artefact
+         ;; carries an adapter on the consumer side.
+         day8/reagent-slim {:local/root "../../implementation/adapters/reagent-slim"}}
 
  :aliases
  {:test {:extra-paths ["test"]


### PR DESCRIPTION
## Summary

- Swap `tools/causa/deps.edn` from stock Reagent (`reagent/reagent {:mvn/version "2.0.1"}`) to `day8/reagent-slim {:local/root "../../implementation/adapters/reagent-slim"}`. Per the rf2-tba5e smoke test, the slim rewrite is operational and React-19 native (`createRoot`).
- Causa carries **zero direct `reagent.*` requires** under `tools/causa/src/` (every hit in `Grep -i reagent` is a comment, not a `:require`). The dep is purely the substrate the host installs and that `mount.cljs` reaches via `re-frame.substrate.adapter/render`. The swap is therefore packaging-side: Causa's published artefact stops pulling stock Reagent transitively. UIx-only / Helix-only / plain-atom users get Causa without dragging stock Reagent in.
- The framework's own devtools dogfood the framework's Reagent rewrite at the load profile that matters (the dev hot-reload loop).

## Why this is the minimal surgical change

The smoke-test recommendation (`ai/findings/reagent-slim-smoke-20260513-1830.md` §Recommendation) explicitly named the deps swap as the in-tree migration path: _"Set the `tools/causa/deps.edn` to `:local/root \"../../implementation/adapters/reagent-slim\"` instead of waiting for the Maven release."_

The bead description also called out a deeper "mount.cljs uses slim directly to sidestep rf2-fn5rk" framing — but **rf2-fn5rk has already landed** on `origin/main` (commit `16ec8844`) and the Causa Playwright spec is already unskipped. The fn5rk-sidestep motivation no longer applies; the deps swap stands on its own three benefits.

`mount.cljs` continues to delegate through `re-frame.substrate.adapter/render` — that is the correct contract for substrate-agnostic devtools (Spec 006 §Single adapter per process). Switching Causa to mount via slim directly would require Causa to install its own adapter, which the spec forbids.

## Ns rewrites

**Zero.** No `:require` changes anywhere in `tools/causa/src/` or `tools/causa/test/`. Verified via `Grep -i 'reagent' tools/causa/src/` and `Grep -i 'reagent' tools/causa/test/` — every hit is a docstring or comment, none of them an actual import. The slim adapter ns at publication time is `re-frame.adapter.reagent` (per `implementation/adapters/reagent-slim/IMPL-SPEC.md §1.8`); in-tree it is `re-frame.adapter.reagent-slim`. Causa never directly :requires either, so the rename is transparent.

## Playwright spec status

`examples/reagent/counter/causa.spec.cjs` is **already unskipped** on `origin/main` (rf2-fn5rk landed). This PR keeps it green:

```
PASS  causa
```

(from `npm run test:examples` — 26 / 26 example specs pass.)

## Bundle-size delta

The dev bundle for `:examples/counter` is `out/examples/counter/main.js` at 5,778,049 bytes after the swap. Bundle-size impact of swapping the Causa dep alone is invisible in the counter bundle because Causa preload only ships in `:devtools` mode (not in `release`), and the shadow-cljs build pulls **both** adapter trees onto its classpath via `implementation/shadow-cljs.edn` `:source-paths` regardless of which artefact Causa's deps.edn names. Net effect at the in-tree shadow build level: neutral.

The published-artefact downstream impact is the real win: a UIx-only consumer pulling `day8/re-frame2-causa` no longer transitively pulls `reagent/reagent` — they pull `day8/reagent-slim` instead, which per rf2-tba5e is 3,954 bytes smaller than stock on the same source (after `:advanced` + DCE).

## Test count

Before / after (no regressions):

| Gate | Before | After |
|---|---|---|
| `clojure -M:test` from `tools/causa/` | 487 / 1349 / 0 fail | 487 / 1349 / 0 fail |
| `npm run test:cljs` from `implementation/` | 1688 / 4677 / 0 fail | 1688 / 4677 / 0 fail |
| `npm run test:bundle-isolation` | PASS | PASS |
| `npm run test:examples` (Playwright) | 26 / 26 PASS incl. `causa` | 26 / 26 PASS incl. `causa` |

## Pre-existing failures (unrelated to this change)

Verified via stash + re-run on `origin/main` baseline — both fail identically before and after:

- `npm run test:perf-bundle` — 13 hits in perf-off counter (expected 0). Pre-existing.
- `npm run test:bundle-comparison` — `cljsLegacyRender` (1) and `react-dom/server` (4) leaked into slim bundle. This is the leftover-dev-output trap the rf2-tba5e findings flagged for rf2-z9a06.

## Test plan

- [x] Causa per-artefact JVM test suite green (`cd tools/causa && clojure -M:test`)
- [x] Full CLJS suite green (`cd implementation && npm run test:cljs`)
- [x] Bundle isolation green (`cd implementation && npm run test:bundle-isolation`)
- [x] Examples Playwright green including `causa` (`cd implementation && npm run test:examples`)
- [x] Diff is one file, one logical change, comprehensively commented

Bead: rf2-wl5pa