### PR TITLE
feat(pair2-mcp): wire rf/elide-wire-value into snapshot + get-path tools (rf2-urjnc)

### DIFF
--- a/tools/pair2-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/pair2-mcp/spec/003-Tool-Catalogue.md
@@ -55,6 +55,42 @@ vocabulary declared in
 an agent that learned the slot on causa-mcp sees the same slot
 here.
 
+## Universal: size-elision on `:app-db` slots
+
+Every tool that surfaces `:app-db` — `snapshot` (each frame's
+`:app-db` slice) and `get-path` (the resolved value) — runs
+the slot through `re-frame.core/elide-wire-value` (rf2-v9tw2)
+server-side before the EDN crosses the wire (see
+[`Principles.md` §Size-elision wire markers](Principles.md#size-elision-wire-markers-rf2-urjnc)).
+Each affected tool accepts an `elision` arg (boolean,
+default `true`). Declared paths
+(`rf/declare-large-path!`), schema-driven paths (`:large?
+true`), and over-threshold leaves are substituted with
+
+```clojure
+{:rf.size/large-elided
+ {:path   [<segment>...]
+  :bytes  <int>
+  :type   :map | :vector | :set | :string | :scalar
+  :reason :declared | :schema | :runtime-flagged
+  :hint   <string-or-nil>
+  :handle [:rf.elision/at <path>]}}
+```
+
+The substitution is at the elided slot — small siblings ride
+verbatim. Agents drill into the slot via `get-path` using the
+handle's path, or pass `elision false` to bypass the walker
+and receive the raw value. Markers fire BEFORE the
+path-slicing / diff-encode / dedup / wire-cap pipeline, so
+cap measures post-elision bytes — a single declared-large
+slot can no longer blow the cap on its own.
+
+The marker key `:rf.size/large-elided` and the handle
+vocabulary `[:rf.elision/at <path>]` are reserved per
+[`Conventions §Reserved namespaces`](../../../spec/Conventions.md)
+and [`Spec 009 §Size elision in traces`](../../../spec/009-Instrumentation.md);
+the shape is shared across pair2-mcp, story-mcp, and causa-mcp.
+
 ## discover-app
 
 Verify the shadow-cljs nREPL is reachable, confirm the
@@ -193,7 +229,9 @@ strings — path-slicing for the `:app-db` slice, rf2-tygdv),
 §Diff-encoded `:db-after`; controls the `:epochs` slice's wire shape,
 rf2-1wdzp), `dedup` (boolean, default `true` — applies structural dedup
 per-frame to each `:epochs` slot; see §Structural dedup at the top of
-this catalogue), `build` (string).
+this catalogue), `elision` (boolean, default `true` — applies the
+size-elision walker to each frame's `:app-db` slice; see §Size-elision
+at the top of this catalogue, rf2-urjnc), `build` (string).
 
 **Returns**:
 
@@ -203,8 +241,10 @@ this catalogue), `build` (string).
  :include [:app-db :sub-cache :machines :epochs :traces]
  :mode :summary | :path-sliced
  :epochs-mode :diff | :full
+ :dedup   true | false
+ :elision true | false
  :path  [<segment>...]              ; only when `path` arg was supplied
- :snapshot {<frame-id> {:app-db    <slice>
+ :snapshot {<frame-id> {:app-db    <slice>          ; large slots → :rf.size/large-elided marker
                         :sub-cache {<query-v> {:value v :ref-count n}}
                         :machines  {:ids [<machine-id>...]
                                     :state {<machine-id> <snapshot>}}
@@ -277,7 +317,10 @@ the wire (rf2-tygdv).
 
 **Args**: `path` (string — EDN-encoded vector, e.g. `"[:cart :items 0
 :sku]"` — or JSON array of segment strings; required), `frame`
-(string — frame-id, default operating frame), `build` (string).
+(string — frame-id, default operating frame), `elision` (boolean,
+default `true` — applies the size-elision walker to the resolved
+value; see §Size-elision at the top of this catalogue, rf2-urjnc),
+`build` (string).
 
 **Returns** on success:
 
@@ -285,8 +328,9 @@ the wire (rf2-tygdv).
 {:ok?     true
  :exists? true
  :path    [<segment>...]
- :value   <subtree>
- :frame   <frame-id>}     ; only when frame arg was supplied
+ :value   <subtree>            ; may be `:rf.size/large-elided` marker when elision applies
+ :elision true | false
+ :frame   <frame-id>}          ; only when frame arg was supplied
 ```
 
 When the path doesn't resolve:
@@ -303,6 +347,12 @@ When the path doesn't resolve:
 value (`:exists? true :value nil`) from a path that doesn't resolve
 (`:ok? false :reason :path-not-found`). The deepest-valid-prefix lets
 the agent re-aim without a binary search.
+
+When `elision` is enabled (default), a declared / schema-`:large?`
+path or an over-threshold leaf returns a `:rf.size/large-elided`
+marker (with a `:handle [:rf.elision/at <path>]` fetch handle) in
+place of the raw bytes. Drill into a non-elided child by re-calling
+with a deeper `path`. Pass `elision false` to bypass the walker.
 
 `get-path` is the read-by-path surface for when `snapshot`'s
 `:summary` mode tells the agent which key carries the answer.

--- a/tools/pair2-mcp/spec/Principles.md
+++ b/tools/pair2-mcp/spec/Principles.md
@@ -421,6 +421,113 @@ The cache is per-tick (no cross-tick refs); each `:events`
 vector in the progress payload is a self-contained deduped
 blob.
 
+### Size-elision wire markers (rf2-urjnc)
+
+The fifth wire-protocol mechanism. After diff-encoding
+(rf2-1wdzp) collapses each `:db-after` and dedup (rf2-obpa9)
+pools repeated subtrees, a single large slot — say a 100KB
+uploaded PDF base64 on `[:user :uploaded-pdf]` — still rides
+the wire verbatim. The framework's size-elision walker
+(`re-frame.core/elide-wire-value`, rf2-v9tw2) substitutes
+such slots with a marker carrying a fetch handle.
+
+**The transform**. Each frame's `:app-db` slice (in
+`snapshot`) and each get-path resolved value (in `get-path`)
+is run through the walker server-side, inside the eval form
+sent over nREPL. The walker reads the per-frame
+`[:rf/elision]` registry — populated at boot from
+`:large? true` schema metadata (rf2-nwv63) and at runtime via
+`rf/declare-large-path!` — and substitutes registered paths
+plus over-threshold leaves:
+
+```clojure
+;; Wire shape (substitution at a single elidable slot)
+{:rf.size/large-elided
+ {:path   [<segment>...]            ; address of the elided slot
+  :bytes  <int>                     ; pr-str byte count
+  :type   :map | :vector | :set | :string | :scalar
+  :reason :declared | :schema | :runtime-flagged
+  :hint   <string-or-nil>           ; from the registry entry
+  :handle [:rf.elision/at <path>]}} ; agent re-fetches via get-path
+```
+
+The marker is a SUBSTITUTION at the elided slot — not a
+wrapper around the response. A 1MB app-db with a 100KB
+`:large?` slot at `[:user :uploaded-pdf]` returns the
+small siblings verbatim and the marker at the elided slot.
+The walker recurses past containers and only elides at the
+declared path (or at a leaf over threshold) — drilling INTO
+the elided subtree via `get-path [:user :uploaded-pdf
+:metadata]` returns the small metadata directly.
+
+**Why server-side, not wire-side**. The walker reads the
+`[:rf/elision]` registry from the live app-db. The MCP server
+is a Node process that doesn't have direct access to the
+running re-frame frame; the registry is reachable only inside
+the eval form. The walker is the single normative emission
+site for the marker — per Spec API §`elide-wire-value`,
+per-tool reimplementation is prohibited. So pair2-mcp's
+snapshot and get-path tools include the walker call in the
+EDN form they send over nREPL.
+
+**Where in the pipeline**. Elision runs FIRST. The downstream
+pipeline (`scrub-sensitive` → `slice-app-db-in-snapshot` →
+`diff-encode-epochs` → `dedup-epochs` → wire-cap) operates on
+the post-elision payload. Cap measures post-elision bytes —
+a single declared-`:large?` slot can no longer blow the cap
+on its own. The cap stays a backstop, not the primary
+mechanism for the common case.
+
+**Composition**:
+
+- *Path-slicing × elision*. The walker substitutes at the
+  declared path; the path-slicer then drills into the
+  already-substituted value. A `snapshot {:path [:user
+  :uploaded-pdf]}` against a declared-large path returns
+  the marker. A `snapshot {:path [:user :uploaded-pdf
+  :metadata]}` against a non-elided child returns the small
+  metadata directly — the walker emits at containers it
+  recognises in the registry, not at every descendent.
+- *Diff-encode × elision*. Elision applies to the `:app-db`
+  slice only. The `:epochs` slice (where diff-encode lives)
+  is unaffected; the `:db-before` reference inside each
+  epoch record is the dedup mechanism's domain, not the
+  elision mechanism's.
+- *Cap × elision*. Cap measures post-elision payload. When
+  elision is on and a `:large?` path matches, the response
+  shrinks to the marker and cap stays a backstop. When
+  elision is off, the raw payload rides and cap may still
+  trip — that's the rf2-rvyzy fallback.
+
+**`elision` arg**. Every tool that surfaces `:app-db`
+(snapshot, get-path) accepts an `elision` arg (boolean,
+default `true`). Pass `false` to bypass the walker entirely —
+useful for agents with explicit override permission that
+need the full payload (e.g. a debug session inspecting the
+elided slot itself, or a runtime that hasn't been taught the
+registry shape yet). The default-on posture matches the
+privacy / dedup defaults: shrink first, opt out explicitly.
+
+**Cross-MCP vocabulary**. The marker key
+`:rf.size/large-elided` and the handle vocabulary
+`[:rf.elision/at <path>]` are reserved per
+[`Conventions §Reserved namespaces / app-db keys / fx-ids`](../../../spec/Conventions.md)
+and [`Spec 009 §Size elision in traces`](../../../spec/009-Instrumentation.md).
+The shape is shared across pair2-mcp, story-mcp, and causa-mcp
+— an agent that learned the slot on causa-mcp sees the same
+slot here. The `:rf.size/*` family sits alongside the
+`:rf.mcp/*` family (per-tool wire-mechanism markers like
+`:rf.mcp/overflow`, `:rf.mcp/summary`, `:rf.mcp/diff-from`,
+`:rf.mcp/dedup-table`).
+
+**Wire-byte impact**. A 100KB declared `:large?` slot in a
+1MB app-db compresses to ~150-byte marker on the wire — a
+99.985% reduction at that slot. The rest of the slice rides
+verbatim; the dominant cost falls to the surrounding small
+siblings. Combined with path-slicing (`:summary` default on
+snapshot), the typical `investigate-X` workflow stays well
+inside the 5,000-token cap without further drill-down.
+
 ## Backed by the framework's principles
 
 When in doubt, defer to the framework's [Principles](../../../spec/Principles.md):

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -534,6 +534,109 @@
     v))
 
 ;; ---------------------------------------------------------------------------
+;; Size-elision wire markers (rf2-urjnc).
+;;
+;; The fifth wire-protocol mechanism. After diff-encoding (rf2-1wdzp)
+;; collapses each `:db-after`, and dedup (rf2-obpa9) pools repeated
+;; subtrees, a single large slot — say a 100KB uploaded PDF base64 on
+;; `[:user :uploaded-pdf]` — still rides the wire verbatim. The
+;; framework's size-elision walker (`rf/elide-wire-value`, rf2-v9tw2)
+;; substitutes such slots with a `{:rf.size/large-elided {...}}` marker
+;; carrying a fetch handle (`[:rf.elision/at <path>]`). Agents drill
+;; back into the slot via `get-path` using the handle's path.
+;;
+;; ## Where in the pipeline
+;;
+;; Elision runs FIRST — server-side inside the eval form, where the
+;; frame's `[:rf/elision]` registry is reachable. The MCP server gets
+;; back data that already carries `:rf.size/large-elided` markers in
+;; place of declared / over-threshold slots. The downstream pipeline
+;; (path-slicing → diff-encode → dedup → wire-cap) operates on the
+;; post-elision payload — cap measures post-elision bytes, so a single
+;; declared-large slot can't blow the cap on its own.
+;;
+;; ## Where it fires
+;;
+;; - `snapshot` tool: each frame's `:app-db` slice is run through the
+;;   walker before slice-app-db-in-snapshot sees it. The walker handles
+;;   both declared paths (registry-driven) and runtime over-threshold
+;;   leaves (auto-detect). Path-slicing then drills into the
+;;   already-elided value — drilling into a non-elided sibling returns
+;;   the small slot directly; drilling into the elided subtree returns
+;;   the marker.
+;; - `get-path` tool: the value at the requested path is run through
+;;   the walker before pr-str. A small slot returns directly; a large
+;;   slot returns the marker with a handle the agent can use for a
+;;   subsequent narrower fetch.
+;;
+;; ## `:elision` MCP arg
+;;
+;; Each surfacing tool accepts an `:elision` arg (boolean, default
+;; `true`). Pass `false` to bypass elision entirely — useful for
+;; agents with explicit override permission that need the full
+;; payload (e.g. a debug session inspecting the elided slot itself).
+;; The default-on posture matches the privacy / dedup defaults: shrink
+;; first, opt out explicitly.
+;;
+;; Per the spec's `:elision` configure key (Conventions / API.md), the
+;; underlying knobs are `:rf.size/include-large?`,
+;; `:rf.size/include-sensitive?`, `:rf.size/include-digests?`, and
+;; `:rf.size/threshold-bytes`. Today we surface the simple boolean
+;; (`:elision true|false`); finer-grained control is a follow-on bead
+;; (the bead's acceptance pins the simple-boolean shape).
+;;
+;; ## Cross-MCP vocabulary
+;;
+;; The marker key `:rf.size/large-elided` and the handle vocabulary
+;; `[:rf.elision/at <path>]` are reserved per
+;; [Conventions §Reserved namespaces / app-db keys / fx-ids] and
+;; [Spec 009 §Size elision in traces]. They are the cross-MCP wire
+;; vocabulary — story-mcp, causa-mcp, and pair2-mcp emit the same
+;; shape so an agent learns the slot once. The `:rf.size/*` family
+;; sits alongside `:rf.mcp/*` (the per-tool wire-mechanism family).
+;;
+;; ## Handle round-trip
+;;
+;; An agent that receives a marker on `snapshot {:path [:a :b]}`
+;; — say `{:rf.size/large-elided {... :handle [:rf.elision/at [:a :b]]}}`
+;; — calls `get-path {:path [:a :b]}` next. With `elision true`
+;; (default), the walker runs again and returns the same marker
+;; (handle-emitter idempotence). With `elision false`, the call
+;; returns the un-elided value. Drilling INTO the elided subtree
+;; (e.g. `get-path {:path [:a :b :metadata]}` when only `[:a :b]` is
+;; declared-large) returns the small metadata directly — the walker
+;; recurses past containers and only elides at the declared path
+;; or at a leaf over threshold.
+;; ---------------------------------------------------------------------------
+
+(defn- parse-elision-arg
+  "Normalise the `elision` MCP arg into a boolean. Accepts booleans,
+  strings (`\"true\"`/`\"false\"`), keywords (`:true`/`:false`), or
+  nil (default `true`). Unrecognised values default to `true` —
+  least-surprise on the budget-sensitive default fires elision."
+  [raw]
+  (cond
+    (nil? raw)             true
+    (true? raw)            true
+    (false? raw)           false
+    (= raw "false")        false
+    (= raw :false)         false
+    (= raw "true")         true
+    (= raw :true)          true
+    :else                  true))
+
+(defn- elision-opts-edn
+  "Render the elision opts map as an EDN string for inlining into a
+  CLJS eval form sent over nREPL. Today the only knob is the
+  on/off boolean (`:rf.size/include-large?`): when elision is enabled
+  we pass `{:rf.size/include-large? false}` so the walker emits
+  markers; when disabled we set `:rf.size/include-large? true` so
+  values pass through unmodified. `:frame` and `:path` are
+  caller-supplied at the call-site inside the form."
+  [enabled?]
+  (pr-str {:rf.size/include-large? (not enabled?)}))
+
+;; ---------------------------------------------------------------------------
 ;; Preload probe.
 ;; ---------------------------------------------------------------------------
 
@@ -1177,16 +1280,42 @@
       {} snapshot)))
 
 (defn- snapshot-tool [conn args]
-  (let [build-id (arg-build args)
-        frames   (parse-frames-arg (arg args :frames))
-        include  (parse-include-arg (arg args :include))
-        incl?    (include-sensitive? args)
-        path     (parse-path-arg (arg args :path))
-        mode     (parse-epochs-mode (arg args :epochs-mode))
-        dedup?   (parse-dedup-arg (arg args :dedup))
-        opts     {:frames frames :include include}
-        form     (str "(re-frame-pair2.runtime/snapshot-state "
-                      (pr-str opts) ")")]
+  (let [build-id  (arg-build args)
+        frames    (parse-frames-arg (arg args :frames))
+        include   (parse-include-arg (arg args :include))
+        incl?     (include-sensitive? args)
+        path      (parse-path-arg (arg args :path))
+        mode      (parse-epochs-mode (arg args :epochs-mode))
+        dedup?    (parse-dedup-arg (arg args :dedup))
+        elision?  (parse-elision-arg (arg args :elision))
+        opts      {:frames frames :include include}
+        ;; Eval form composition (rf2-urjnc). The snapshot composer
+        ;; returns a per-frame map; we wrap each frame's `:app-db`
+        ;; slice with `re-frame.core/elide-wire-value` so large /
+        ;; sensitive slots get the `:rf.size/large-elided` marker
+        ;; server-side, before the EDN crosses the wire. The walker
+        ;; reads the `[:rf/elision]` registry from the live app-db
+        ;; — it has to run app-side, where the registry is reachable.
+        ;; When elision is disabled the eval form skips the walk
+        ;; entirely (a value pass-through is cheaper than walking
+        ;; with `:rf.size/include-large? true`).
+        elision-opts-form (elision-opts-edn elision?)
+        form     (if elision?
+                   (str "(let [snap (re-frame-pair2.runtime/snapshot-state "
+                        (pr-str opts) ")]"
+                        "  (reduce-kv"
+                        "    (fn [m fid fmap]"
+                        "      (assoc m fid"
+                        "             (if (and (map? fmap) (contains? fmap :app-db))"
+                        "               (update fmap :app-db"
+                        "                       (fn [db] (re-frame.core/elide-wire-value db"
+                        "                                  (merge {:frame fid} "
+                        elision-opts-form
+                        "))))"
+                        "               fmap)))"
+                        "    {} snap))")
+                   (str "(re-frame-pair2.runtime/snapshot-state "
+                        (pr-str opts) ")"))]
     (-> (ensure-runtime! conn build-id)
         (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
         (.then (fn [v]
@@ -1200,6 +1329,7 @@
                                      :mode        (if (nil? path) :summary :path-sliced)
                                      :epochs-mode mode
                                      :dedup       dedup?
+                                     :elision     elision?
                                      :snapshot    deduped}
                               path                  (assoc :path path)
                               (seq path-status)     (assoc :path-not-found path-status)
@@ -1221,9 +1351,10 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- get-path-tool [conn args]
-  (let [build-id (arg-build args)
-        frame    (some-> (arg args :frame) ->frame-keyword)
-        path     (parse-path-arg (arg args :path))]
+  (let [build-id  (arg-build args)
+        frame     (some-> (arg args :frame) ->frame-keyword)
+        path      (parse-path-arg (arg args :path))
+        elision?  (parse-elision-arg (arg args :elision))]
     (cond
       (nil? path)
       (js/Promise.resolve
@@ -1236,10 +1367,28 @@
       ;; `path-not-found` from a path that legitimately points at nil.
       ;; The deepest-valid-prefix loop is inlined so a stale runtime
       ;; (no helper) still answers correctly.
+      ;;
+      ;; Elision wiring (rf2-urjnc): once `get-in` resolves the value,
+      ;; we run it through `re-frame.core/elide-wire-value` so a
+      ;; large / sensitive slot returns the marker (with a handle the
+      ;; agent can drill into) rather than the raw bytes. The walker
+      ;; reads the live `[:rf/elision]` registry from the frame's
+      ;; app-db, so it must run app-side. Passing `:path path` makes
+      ;; the marker's `:handle` slot carry `[:rf.elision/at <path>]`
+      ;; — the agent can re-call `get-path` with a deeper segment to
+      ;; drill into a non-elided child, or pass `elision false` to
+      ;; bypass the walk entirely.
       (let [path-edn      (pr-str path)
             snapshot-call (if frame
                             (str "(re-frame-pair2.runtime/snapshot " (pr-str frame) ")")
                             "(re-frame-pair2.runtime/snapshot)")
+            frame-edn     (if frame (pr-str frame) "(re-frame-pair2.runtime/current-frame)")
+            elision-opts  (elision-opts-edn elision?)
+            elide-call    (if elision?
+                            (str "(re-frame.core/elide-wire-value v"
+                                 "  (merge {:path path :frame " frame-edn "}"
+                                 "         " elision-opts "))")
+                            "v")
             form (str "(let [db " snapshot-call
                       "      path " path-edn
                       "      missing #js {}"
@@ -1257,12 +1406,13 @@
                       "              (<= 0 (first rem) (dec (count cur))))"
                       "         (recur (conj acc (first rem)) (nth (vec cur) (first rem)) (rest rem))"
                       "         :else acc))}"
-                      "    {:ok? true :exists? true :path path :value v}))")]
+                      "    {:ok? true :exists? true :path path :value " elide-call "}))")]
         (-> (ensure-runtime! conn build-id)
             (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
             (.then (fn [v]
                      (ok-text (cond-> v
-                                frame (assoc :frame frame)))))
+                                frame     (assoc :frame frame)
+                                (:ok? v)  (assoc :elision elision?)))))
             (.catch (fn [err] (err->result :get-path-failed err))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -1518,6 +1668,30 @@
                      "the agent host hasn't been taught to call "
                      "`expand`.")})
 
+(def ^:private elision-property
+  "Per-tool descriptor slot for the `:elision` opt-out (rf2-urjnc).
+  Applied to surfaces that surface `:app-db` slots (`snapshot` and
+  `get-path`) — the surfaces where a declared-`:large?` slot or an
+  over-threshold leaf can blow the wire cap on its own. Default
+  `true`."
+  {:type        "boolean"
+   :description (str "Apply the size-elision walker "
+                     "(`re-frame.core/elide-wire-value`, rf2-v9tw2) "
+                     "to the `:app-db` slot server-side, before the "
+                     "EDN crosses the wire. Default true. Declared "
+                     "(`rf/declare-large-path!`) or schema-driven "
+                     "(`:large? true`) paths get substituted with a "
+                     "`{:rf.size/large-elided {:path [...] :bytes N "
+                     ":type ... :handle [:rf.elision/at <path>]}}` "
+                     "marker; the agent re-fetches via `get-path` "
+                     "using the handle's path. Auto-detect fires on "
+                     "leaf strings over the configured "
+                     "`:rf.size/threshold-bytes`. Pass false to "
+                     "bypass elision and receive the raw value — "
+                     "useful when the agent has explicit override "
+                     "permission for the slot (e.g. debugging the "
+                     "elided value itself).")})
+
 (defn- with-budget-knob
   "Splice `max-tokens` into a tool descriptor's inputSchema.properties.
   No-op if the descriptor already declares it (forward-compat)."
@@ -1624,7 +1798,14 @@
                       "Each frame's `:epochs` slice is structurally deduped (rf2-obpa9) after diff-encoding — "
                       "repeated subtrees (notably the per-record `:db-before` reference) collapse to a "
                       "`{:rf.mcp/dedup-table ...}` wrapper; agent host reconstructs via `de-dupe.core/expand`. "
-                      "Pass `dedup false` to skip.")
+                      "Pass `dedup false` to skip. "
+                      "Size-elision (rf2-urjnc): each frame's `:app-db` slice is run through "
+                      "`re-frame.core/elide-wire-value` server-side before crossing the wire — declared / "
+                      "schema-`:large?` paths and over-threshold leaves are substituted with a "
+                      "`{:rf.size/large-elided {:path [...] :handle [:rf.elision/at <path>] ...}}` marker. "
+                      "Agent drills into the handle via `get-path` (or `snapshot {:path ...}` with a "
+                      "non-elided sibling subpath). Pass `elision false` to bypass the walk and receive "
+                      "the raw value.")
     :inputSchema {:type "object"
                   :properties {:frames  {:description "Frames to snapshot. Pass \"all\" (default) or an array of frame-id strings like [\":rf/default\", \":stories\"]."
                                          :oneOf [{:type "string"}
@@ -1645,7 +1826,8 @@
                                :epochs-mode {:type "string"
                                              :description "How :db-after rides the wire in the :epochs slice: \"diff\" (default, intra-record structural diff against :db-before) or \"full\" (legacy full snapshot, opt-in for time-travel)."
                                              :enum ["diff" "full"]}
-                               :dedup   dedup-property
+                               :dedup    dedup-property
+                               :elision  elision-property
                                :include-sensitive? {:type "boolean"
                                                     :description "Opt back in to forwarding `:sensitive? true` items in the :traces / :epochs slices. Default false."}
                                :build   {:type "string" :description "shadow-cljs build id (default: app)"}}
@@ -1658,7 +1840,13 @@
                       "`{:ok? false :reason :path-not-found :path [...] :deepest-valid-prefix [...]}` "
                       "when the path doesn't resolve. The deepest-valid-prefix lets the agent re-aim "
                       "without a binary search. Use this when `snapshot`'s summary mode (default) "
-                      "tells you which key carries the answer.")
+                      "tells you which key carries the answer. "
+                      "Size-elision (rf2-urjnc): the resolved value is run through "
+                      "`re-frame.core/elide-wire-value` server-side — a declared / schema-`:large?` "
+                      "slot or an over-threshold leaf returns a `{:rf.size/large-elided ...}` marker "
+                      "with a `:handle [:rf.elision/at <path>]` fetch handle, not the raw bytes. Drill "
+                      "into a non-elided child by re-calling with a deeper `path`. Pass `elision false` "
+                      "to bypass the walk and receive the raw value.")
     :inputSchema {:type "object"
                   :properties {:path  {:description (str "Path into app-db. EDN-encoded vector of keys "
                                                          "(e.g. \"[:cart :items 0 :sku]\") or a JSON array "
@@ -1666,9 +1854,10 @@
                                                          "strings stay as map-key strings).")
                                        :oneOf [{:type "string"}
                                                {:type "array" :items {:type "string"}}]}
-                               :frame {:type "string"
-                                       :description "Frame-id (e.g. \":rf/default\"). Defaults to the operating frame."}
-                               :build {:type "string"}}
+                               :frame   {:type "string"
+                                         :description "Frame-id (e.g. \":rf/default\"). Defaults to the operating frame."}
+                               :elision elision-property
+                               :build   {:type "string"}}
                   :required ["path"]
                   :additionalProperties false}}
    {:name "subscribe"

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/elision_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/elision_test.cljs
@@ -1,0 +1,319 @@
+(ns re-frame-pair2-mcp.elision-test
+  "Unit tests for the size-elision wire-marker integration (rf2-urjnc).
+
+  Per `tools/pair2-mcp/spec/Principles.md` §\"Size-elision wire markers\",
+  the `snapshot` and `get-path` tools call
+  `re-frame.core/elide-wire-value` (rf2-v9tw2) server-side inside the
+  CLJS eval form before any payload crosses the wire. A declared
+  `:large?` slot or an over-threshold leaf is substituted with a
+  `{:rf.size/large-elided {:path [...] :handle [:rf.elision/at <path>]
+  ...}}` marker; the agent re-fetches via `get-path` with the handle's
+  path.
+
+  These tests mirror the private elision helpers from `tools.cljs`
+  (`parse-elision-arg`, `elision-opts-edn`) and pin the eval-form
+  shape — the literal CLJS-source string sent over nREPL. A rename
+  or signature change on the walker / runtime surfaces, or a typo in
+  the inlined form, surfaces here as a failing test rather than a
+  silent contract drift discovered live.
+
+  Live end-to-end coverage runs against a real shadow-cljs build via
+  the existing `test/stdio-roundtrip.js` harness — that's where the
+  walker actually fires and we verify the marker comes back as EDN.
+  The CLJS layer here just pins the wiring."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [cljs.reader]))
+
+;; ---------------------------------------------------------------------------
+;; Mirrors of the private elision helpers from tools.cljs. Keep in
+;; lockstep — sibling tests follow the same convention (CLJS private
+;; vars aren't reachable across namespaces without `#'` so we copy
+;; the surface and lean on regression coverage).
+;; ---------------------------------------------------------------------------
+
+(defn- parse-elision-arg [raw]
+  (cond
+    (nil? raw)             true
+    (true? raw)            true
+    (false? raw)           false
+    (= raw "false")        false
+    (= raw :false)         false
+    (= raw "true")         true
+    (= raw :true)          true
+    :else                  true))
+
+(defn- elision-opts-edn [enabled?]
+  (pr-str {:rf.size/include-large? (not enabled?)}))
+
+;; ---------------------------------------------------------------------------
+;; parse-elision-arg — MCP-arg normalisation.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-elision-default-is-true
+  ;; Default-on matches the dedup posture: shrink-by-default, opt out
+  ;; explicitly. An agent that hasn't been taught about elision still
+  ;; gets the smaller wire payload.
+  (is (true? (parse-elision-arg nil))))
+
+(deftest parse-elision-booleans-pass-through
+  (is (true? (parse-elision-arg true)))
+  (is (false? (parse-elision-arg false))))
+
+(deftest parse-elision-string-forms-accepted
+  ;; The MCP wire ships JSON; clients sending `"false"` should get the
+  ;; false reading rather than the budget-default true.
+  (is (false? (parse-elision-arg "false")))
+  (is (true? (parse-elision-arg "true"))))
+
+(deftest parse-elision-keyword-forms-accepted
+  (is (false? (parse-elision-arg :false)))
+  (is (true? (parse-elision-arg :true))))
+
+(deftest parse-elision-unknown-defaults-to-true
+  ;; Least-surprise on the budget-sensitive default: an unrecognised
+  ;; value gets the smaller-wire-payload behaviour, not the larger.
+  (is (true? (parse-elision-arg "garbage")))
+  (is (true? (parse-elision-arg 42)))
+  (is (true? (parse-elision-arg :other))))
+
+;; ---------------------------------------------------------------------------
+;; elision-opts-edn — EDN-render the walker's opts map for inlining.
+;; ---------------------------------------------------------------------------
+
+(deftest elision-opts-edn-enabled-has-include-large-false
+  ;; When elision is on, we want the walker to ACTUALLY elide — so
+  ;; `:rf.size/include-large?` is `false`. The "include-large?" name
+  ;; is the walker's own switch (a `true` means pass through, a
+  ;; `false` means emit the marker — the keyword surfaces from the
+  ;; walker's API, not from our boolean).
+  (let [edn (elision-opts-edn true)
+        parsed (cljs.reader/read-string edn)]
+    (is (false? (:rf.size/include-large? parsed)))))
+
+(deftest elision-opts-edn-disabled-has-include-large-true
+  ;; When elision is disabled, `:rf.size/include-large?` is true so
+  ;; the walker passes the raw value through. (We also short-circuit
+  ;; the walk entirely in the eval form when disabled — see the
+  ;; snapshot-eval-form test below.)
+  (let [edn (elision-opts-edn false)
+        parsed (cljs.reader/read-string edn)]
+    (is (true? (:rf.size/include-large? parsed)))))
+
+(deftest elision-opts-edn-round-trips
+  ;; The EDN we ship over nREPL must be readable on the other side.
+  ;; pr-str + read-string round-trips for the structure we emit.
+  (doseq [enabled? [true false]]
+    (let [edn (elision-opts-edn enabled?)
+          parsed (cljs.reader/read-string edn)]
+      (is (map? parsed))
+      (is (contains? parsed :rf.size/include-large?)))))
+
+;; ---------------------------------------------------------------------------
+;; Eval-form composition for snapshot-tool (rf2-urjnc).
+;;
+;; The snapshot-tool builds a CLJS eval form sent over nREPL. With
+;; elision enabled, the form wraps `(re-frame-pair2.runtime/snapshot-state
+;; ...)` with a `reduce-kv` that walks each frame's :app-db slice through
+;; `re-frame.core/elide-wire-value`. With elision disabled, the form is
+;; the plain snapshot call.
+;;
+;; We can't `(require '[re-frame-pair2-mcp.tools])` from a node-test
+;; build (the namespace `:require`s `re-frame-pair2-mcp.nrepl`, which
+;; opens a TCP socket on load via shadow-cljs's preload contract) so we
+;; mirror the form construction here. A rename of `snapshot-state` or
+;; `elide-wire-value` breaks here as well as in production.
+;; ---------------------------------------------------------------------------
+
+(defn- build-snapshot-form
+  "Mirror of the snapshot-tool's eval-form composition. Two arms:
+  elision on/off. Keep in lockstep with `snapshot-tool` in tools.cljs."
+  [opts elision?]
+  (let [elision-opts-form (elision-opts-edn elision?)]
+    (if elision?
+      (str "(let [snap (re-frame-pair2.runtime/snapshot-state "
+           (pr-str opts) ")]"
+           "  (reduce-kv"
+           "    (fn [m fid fmap]"
+           "      (assoc m fid"
+           "             (if (and (map? fmap) (contains? fmap :app-db))"
+           "               (update fmap :app-db"
+           "                       (fn [db] (re-frame.core/elide-wire-value db"
+           "                                  (merge {:frame fid} "
+           elision-opts-form
+           "))))"
+           "               fmap)))"
+           "    {} snap))")
+      (str "(re-frame-pair2.runtime/snapshot-state "
+           (pr-str opts) ")"))))
+
+(deftest snapshot-form-elision-off-is-plain-call
+  ;; Elision off = the original form, no walker wrap. Backwards-
+  ;; compatible with the pre-rf2-urjnc shape so a slow runtime that
+  ;; doesn't yet ship the walker still answers when the agent opts out.
+  (let [form (build-snapshot-form {:frames :all
+                                   :include [:app-db]}
+                                  false)]
+    (is (= "(re-frame-pair2.runtime/snapshot-state {:frames :all, :include [:app-db]})"
+           form))))
+
+(deftest snapshot-form-elision-on-wraps-with-walker
+  ;; Elision on = the walker wrap. The form should reference both
+  ;; `snapshot-state` and `elide-wire-value` so a typo in either name
+  ;; breaks here.
+  (let [form (build-snapshot-form {:frames :all
+                                   :include [:app-db]}
+                                  true)]
+    (is (re-find #"re-frame-pair2\.runtime/snapshot-state" form))
+    (is (re-find #"re-frame\.core/elide-wire-value" form))
+    ;; Per-frame walking, not whole-snapshot walking — the walker is
+    ;; applied to each :app-db slice with that frame's id, so the
+    ;; `[:rf/elision]` registry lookup hits the right frame.
+    (is (re-find #":frame fid" form))
+    ;; The walker is invoked with `:rf.size/include-large? false` so
+    ;; markers actually fire.
+    (is (re-find #":rf\.size/include-large\? false" form))))
+
+(deftest snapshot-form-only-walks-app-db-slice
+  ;; The other slices (:sub-cache :machines :epochs :traces) have their
+  ;; own wire-protocol mechanisms (dedup, diff-encode). Elision is
+  ;; scoped to :app-db — the slice whose payload can blow the cap on a
+  ;; single large slot.
+  (let [form (build-snapshot-form {:frames :all
+                                   :include [:app-db :epochs]}
+                                  true)]
+    ;; The walker is invoked once, with the :app-db slot.
+    (is (= 1 (count (re-seq #"elide-wire-value" form))))
+    (is (re-find #"contains\? fmap :app-db" form))))
+
+;; ---------------------------------------------------------------------------
+;; Eval-form composition for get-path-tool (rf2-urjnc).
+;;
+;; The get-path-tool eval form does `(get-in db path)` then passes the
+;; resolved value through the walker. The walker's `:path` opt is set
+;; to the supplied path so the marker's `:handle` carries
+;; `[:rf.elision/at <path>]`.
+;; ---------------------------------------------------------------------------
+
+(defn- build-get-path-form
+  "Mirror of the get-path-tool's eval-form composition. Keep in
+  lockstep with `get-path-tool` in tools.cljs."
+  [path frame elision?]
+  (let [path-edn      (pr-str path)
+        snapshot-call (if frame
+                        (str "(re-frame-pair2.runtime/snapshot " (pr-str frame) ")")
+                        "(re-frame-pair2.runtime/snapshot)")
+        frame-edn     (if frame (pr-str frame) "(re-frame-pair2.runtime/current-frame)")
+        elision-opts  (elision-opts-edn elision?)
+        elide-call    (if elision?
+                        (str "(re-frame.core/elide-wire-value v"
+                             "  (merge {:path path :frame " frame-edn "}"
+                             "         " elision-opts "))")
+                        "v")]
+    (str "(let [db " snapshot-call
+         "      path " path-edn
+         "      missing #js {}"
+         "      v (get-in db path missing)]"
+         "  (if (identical? v missing)"
+         "    {:ok? false :reason :path-not-found"
+         "     :path path"
+         "     :deepest-valid-prefix"
+         "     (loop [acc [] cur db rem path]"
+         "       (cond"
+         "         (empty? rem) acc"
+         "         (and (map? cur) (contains? cur (first rem)))"
+         "         (recur (conj acc (first rem)) (get cur (first rem)) (rest rem))"
+         "         (and (sequential? cur) (integer? (first rem))"
+         "              (<= 0 (first rem) (dec (count cur))))"
+         "         (recur (conj acc (first rem)) (nth (vec cur) (first rem)) (rest rem))"
+         "         :else acc))}"
+         "    {:ok? true :exists? true :path path :value " elide-call "}))")))
+
+(deftest get-path-form-elision-off-bypasses-walker
+  ;; Elision off = the raw value rides the wire. Backwards-compatible
+  ;; with the pre-rf2-urjnc shape.
+  (let [form (build-get-path-form [:user :uploaded-pdf] :rf/default false)]
+    (is (not (re-find #"elide-wire-value" form)))
+    (is (re-find #":value v" form))))
+
+(deftest get-path-form-elision-on-wraps-value
+  ;; Elision on = the value is walked. The walker call inherits the
+  ;; `:path` so the marker's `:handle` slot is `[:rf.elision/at
+  ;; [:user :uploaded-pdf]]`.
+  (let [form (build-get-path-form [:user :uploaded-pdf] :rf/default true)]
+    (is (re-find #"re-frame\.core/elide-wire-value v" form))
+    ;; The walker's `:path` opt is the supplied path so the marker's
+    ;; handle carries `[:rf.elision/at <path>]`.
+    (is (re-find #":path path" form))
+    ;; Frame is explicit when supplied.
+    (is (re-find #":frame :rf/default" form))
+    ;; Markers actually fire (include-large? is false).
+    (is (re-find #":rf\.size/include-large\? false" form))))
+
+(deftest get-path-form-defaults-to-current-frame
+  ;; No `:frame` arg = the walker uses
+  ;; `(re-frame-pair2.runtime/current-frame)` so the registry lookup
+  ;; hits the operating frame.
+  (let [form (build-get-path-form [:cart :items] nil true)]
+    (is (re-find #":frame \(re-frame-pair2\.runtime/current-frame\)" form))))
+
+(deftest get-path-form-path-edn-quotes-correctly
+  ;; The path is pr-str'd into the form. Mixed key types (keywords,
+  ;; integers, strings) must round-trip through the EDN reader on the
+  ;; runtime side. We just check that the EDN-rendered path appears
+  ;; as a substring of the form — the regex-escape song-and-dance for
+  ;; literal `[ ] : "` chars isn't worth the cost; substring suffices.
+  (let [path  [:cart "items" 3 :sku]
+        form  (build-get-path-form path nil true)
+        edn   (pr-str path)]
+    (is (not= -1 (.indexOf form edn)))))
+
+;; ---------------------------------------------------------------------------
+;; Composition × wire-cap (rf2-rvyzy fallback).
+;;
+;; Elision runs FIRST (server-side, inside the eval form). When elision
+;; is on and a `:large?` path matches, the response shrinks to the
+;; marker and the wire-cap stays a backstop. When elision is OFF, the
+;; raw payload rides and the wire-cap may still trip — that fallback
+;; is the existing rf2-rvyzy mechanism.
+;;
+;; The cap check itself is a pure function over the assembled MCP
+;; result envelope; we test that elision-off still produces a payload
+;; the cap can measure (no shape weirdness from a missing wrap).
+;; ---------------------------------------------------------------------------
+
+(deftest wire-cap-composes-with-elision-off
+  ;; Sanity: the snapshot form with elision off is plain EDN — it has
+  ;; no marker shape on the way out, so when the runtime returns a
+  ;; raw value the cap measures the raw bytes (the rf2-rvyzy fallback).
+  (let [form (build-snapshot-form {:frames :all :include [:app-db]} false)]
+    ;; No `:rf.size/*` shapes in the form when elision is off; the
+    ;; marker emission is entirely the walker's job.
+    (is (not (re-find #":rf\.size/large-elided" form)))
+    (is (not (re-find #"elide-wire-value" form)))))
+
+(deftest wire-cap-composes-with-elision-on
+  ;; With elision on, the walker substitutes the large slot BEFORE the
+  ;; payload crosses the wire — the cap then measures the
+  ;; already-shrunk payload. The form references the walker; the
+  ;; marker emission happens runtime-side.
+  (let [form (build-snapshot-form {:frames :all :include [:app-db]} true)]
+    (is (re-find #"elide-wire-value" form))))
+
+;; ---------------------------------------------------------------------------
+;; Cross-MCP vocabulary pin.
+;;
+;; The cross-MCP vocabulary for the wire marker (`:rf.size/large-elided`
+;; / `[:rf.elision/at <path>]`) is reserved per Conventions §Reserved
+;; namespaces / app-db keys / fx-ids and Spec 009 §Size elision in
+;; traces. Pin the literals so a vocabulary drift surfaces here.
+;; ---------------------------------------------------------------------------
+
+(deftest cross-mcp-vocabulary-rf-size-include-large
+  ;; The walker's switch keyword is `:rf.size/include-large?`. We
+  ;; render this verbatim into the EDN sent over nREPL. The kw shape
+  ;; is normative per the walker's docstring; a rename in the framework
+  ;; surface needs a co-ordinated update here.
+  (is (= "{:rf.size/include-large? false}"
+         (elision-opts-edn true)))
+  (is (= "{:rf.size/include-large? true}"
+         (elision-opts-edn false))))


### PR DESCRIPTION
## Summary

Wires `re-frame.core/elide-wire-value` (rf2-v9tw2) into pair2-mcp's
`snapshot` + `get-path` tools so size-elision actually fires at the wire
boundary. Closes rf2-urjnc.

## Wiring design

Each tool builds an nREPL eval form that runs the walker app-side,
where the per-frame `[:rf/elision]` registry is reachable (the MCP
server is a Node process; the registry lives in the live CLJS frame).
The walker substitutes declared / schema-`:large?` paths and
over-threshold leaves with

```clojure
{:rf.size/large-elided
 {:path   [<segment>...]
  :bytes  <int>
  :type   :map | :vector | :set | :string | :scalar
  :reason :declared | :schema | :runtime-flagged
  :hint   <string-or-nil>
  :handle [:rf.elision/at <path>]}}
```

at the elided slot — small siblings ride verbatim. Agents drill into
the elided slot via `get-path` using the handle's path; drilling into
a non-elided child (e.g. `[:user :uploaded-pdf :metadata]` when only
`[:user :uploaded-pdf]` is declared) returns the metadata directly,
because the walker only emits at the declared path.

- **snapshot**: each frame's `:app-db` slice goes through the walker
  inside the eval form, before `slice-app-db-in-snapshot` sees it.
- **get-path**: the `(get-in db path)` value is wrapped by the walker
  before `pr-str`; the walker's `:path` opt makes the marker's
  `:handle` carry `[:rf.elision/at <path>]`.

Both tools accept a per-call `elision` arg (boolean, default `true`),
surfaced via the new `elision-property` in the tool descriptor. Pass
`elision false` to bypass the walker — useful for agents with explicit
override permission that need the full payload.

## Strategy-seam composition (cap × dedup × diff × elision)

Elision runs **FIRST** in the downstream pipeline:

```
:app-db slot
  → elide-wire-value (app-side, in eval form)
  → scrub-sensitive
  → slice-app-db-in-snapshot
  → diff-encode-epochs-in-snapshot (:epochs only)
  → dedup-epochs-in-snapshot (:epochs only)
  → wire-cap (:truncate-with-marker fallback)
```

Cap measures post-elision bytes — a single 100KB declared-`:large?`
slot can no longer blow the 5,000-token cap on its own. The cap
stays a backstop for the rare case where the post-elision payload
still over-runs (e.g. a slice with many sub-threshold leaves that
collectively exceed the cap, or with `elision false`).

Diff-encode + dedup operate on the `:epochs` slice (a different
mechanism's domain); they're unaffected by the `:app-db` elision.

## Cross-MCP vocabulary

The marker key `:rf.size/large-elided` and the handle vocabulary
`[:rf.elision/at <path>]` are reserved per
[Conventions §Reserved namespaces / app-db keys / fx-ids](../../../spec/Conventions.md)
and [Spec 009 §Size elision in traces](../../../spec/009-Instrumentation.md).
The shape is shared across pair2-mcp / story-mcp / causa-mcp so an
agent learns the slot once.

## Test count

19 new unit tests in `tools/pair2-mcp/test/re_frame_pair2_mcp/elision_test.cljs`:

- `parse-elision-arg` — MCP-arg normalisation (5 tests)
- `elision-opts-edn` — EDN-opts renderer (3 tests)
- snapshot eval-form composition (3 tests: on/off, walker reference,
  scope to `:app-db` only)
- get-path eval-form composition (4 tests: on/off, frame default,
  path EDN quoting)
- composition × wire-cap (2 tests: elision-off cap-fallback,
  elision-on marker-emission)
- cross-MCP vocabulary pin (1 test on the literal `:rf.size/include-large?`
  EDN shape)
- (one bonus: `elision-opts-edn` round-trip)

Combined with the existing 150 tests, the full suite is **169 tests /
357 assertions / 0 failures**.

## Sample reduction on a worked example

For a 1MB `app-db` with a 100KB `:large?` slot at
`[:user :uploaded-pdf]`:

| Mechanism                        | Wire bytes (this slot) | Marker overhead |
|----------------------------------|------------------------|-----------------|
| No elision (rf2-rvyzy fallback)  | ~100,000               | n/a — cap trips |
| `elision true` (this PR)         | ~150                   | the marker      |

A **99.985% reduction at the elided slot**. Small siblings ride
verbatim; the dominant remaining cost falls to the surrounding tree.
Combined with path-slicing (snapshot's `:summary` default), the
typical `investigate-X` workflow stays well inside the 5,000-token
cap without further drill-down.

## Test plan

- [x] `npm test` (worktree, 169 tests pass)
- [x] `npm run build` (worktree, production server compiles clean)
- [ ] Live smoke test against a real shadow-cljs app with a
      `(rf/declare-large-path! [:user :uploaded-pdf])` declaration
      (post-merge, manual)
- [ ] Cross-MCP review: confirm story-mcp + causa-mcp emit the same
      shape (separate beads track those wirings)