### PR TITLE
feat(core): runtime :sensitive? stamping at trace-emit time per Spec 009 §Privacy (rf2-isdwf)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -201,8 +201,15 @@
            (let [frame-id        (interceptor/get-coeffect ctx :frame)
                  active-platform (active-platform-for-frame frame-id)]
              (if (cofx-runs-on-platform? meta active-platform)
+               ;; Per rf2-isdwf: bind `*current-sensitive?*` to the
+               ;; cofx handler's reading. The cofx body runs inside
+               ;; this scope; any trace event it emits carries the
+               ;; cofx-handler-level sensitivity flag per Spec 009
+               ;; "innermost in-scope handler" rule.
                (binding [trace/*current-trigger-handler*
                          (trace/trigger-handler-from-meta :cofx cofx-id meta)
+                         trace/*current-sensitive?*
+                         (trace/sensitive?-from-meta meta)
                          trace/*current-call-site*
                          (or captured-cs trace/*current-call-site*)]
                  (-> (if valued?

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -40,6 +40,7 @@
             [re-frame.subs :as subs]
             [re-frame.interceptor :as interceptor]
             [re-frame.std-interceptors :as std-interceptors]
+            [re-frame.privacy :as privacy]
             [re-frame.spec :as spec]
             [re-frame.late-bind :as late-bind]
             [re-frame.source-coords :as source-coords]
@@ -934,6 +935,20 @@
 (def inject-cofx     cofx/inject-cofx)
 (def path            std-interceptors/path)
 (def unwrap          std-interceptors/unwrap)
+
+;; ---- privacy (Spec 009 §Privacy; rf2-isdwf) ------------------------------
+;;
+;; The `with-redacted` positional interceptor and the framework's
+;; published `sensitive?` predicate. Per Spec 009 lines 1149-1268:
+;; `:sensitive?` is the filter-out signal (top-level on the trace
+;; event); `with-redacted` is the in-place payload scrub. The two
+;; compose — a handler carrying both `:sensitive? true` in its
+;; metadata-map AND `with-redacted` in its positional chain emits
+;; trace events that are BOTH stamped `:sensitive? true` AND carry
+;; redacted payloads. See API.md and Spec 009.
+
+(def with-redacted   privacy/with-redacted)
+(def sensitive?      trace/sensitive?)
 
 ;; ---- :spec/validate-at-boundary (rf2-r2uh) -------------------------------
 ;;

--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -12,6 +12,7 @@
   during drain — the difference is only in the wrapping shape."
   (:require [re-frame.registrar :as registrar]
             [re-frame.interceptor :as interceptor]
+            [re-frame.privacy :as privacy]
             [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
 
@@ -249,6 +250,11 @@
              :event/kind   :db
              :handler-fn   handler-fn
              :interceptors (vec all-chain)))
+    ;; Per rf2-isdwf / Spec 009 §Privacy: emit
+    ;; :rf.warning/sensitive-without-redaction once per (kind, id) pair
+    ;; when :sensitive? true but no with-redacted in the chain. Called
+    ;; AFTER register! so listeners see the registration trace first.
+    (privacy/warn-sensitive-without-redaction! :event id meta interceptors)
     id))
 
 (defn reg-event-fx
@@ -304,6 +310,7 @@
              :event/kind   :fx
              :handler-fn   handler-fn
              :interceptors (vec all-chain)))
+    (privacy/warn-sensitive-without-redaction! :event id meta interceptors)
     id))
 
 (defn reg-event-ctx
@@ -339,6 +346,7 @@
              :event/kind   :ctx
              :handler-fn   handler-fn
              :interceptors (vec all-chain)))
+    (privacy/warn-sensitive-without-redaction! :event id meta interceptors)
     id))
 
 (defn clear-event

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -363,6 +363,15 @@
     (notify-machine-destruction! id)
     (mark-frame-destroyed! id)
     (tear-down-sub-cache! f)
+    ;; Per rf2-isdwf / Spec 009 §Privacy: reset the
+    ;; sensitive-without-redaction warning suppression cache so a
+    ;; re-registration after frame teardown (test fixtures, hot
+    ;; reload that destroys and re-creates the frame) re-emits the
+    ;; warning if still mis-configured. Late-bound through the hook
+    ;; table; no-op when re-frame.privacy hasn't been loaded.
+    (when-let [clear-cache! (late-bind/get-fn :privacy/clear-suppression-cache!)]
+      (try (clear-cache!)
+           (catch #?(:clj Throwable :cljs :default) _ nil)))
     (emit-frame-destroyed-trace! id)
     (dissoc-frame! id)
     (unregister-frame! id)

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -306,8 +306,18 @@
         ;; is not what consumers want — Story/Causa want jump-to-source
         ;; to land on the fx handler's `reg-fx` site, not the event
         ;; handler that produced the fx vector).
+        ;; Per rf2-isdwf: bind `*current-sensitive?*` to the fx
+        ;; handler's reading so any trace event emitted inside the
+        ;; fx body's scope (including the success `:rf.fx/handled`
+        ;; emit) carries the fx-handler-level sensitivity flag.
+        ;; Per Spec 009 §Privacy "innermost in-scope handler's flag
+        ;; wins" rule: when an event handler is sensitive but the fx
+        ;; handler it dispatches to is not, the `:rf.fx/handled`
+        ;; trace event reflects the FX handler's reading.
         (binding [trace/*current-trigger-handler*
-                  (trace/trigger-handler-from-meta :fx fx-id meta)]
+                  (trace/trigger-handler-from-meta :fx fx-id meta)
+                  trace/*current-sensitive?*
+                  (trace/sensitive?-from-meta meta)]
           (let [ok? (try
                       ((:handler-fn meta) (cond-> {:frame frame-id}
                                             origin-event (assoc :event origin-event))

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -147,6 +147,14 @@
     :producer-ns 're-frame.schemas
     :design-bead "rf2-nwv63"
     :description "Idempotent: hydrate app-db [:rf/elision :declarations] from a frame's schema-derived large-path declarations."}
+   {:key         :schemas/extract-sensitive-paths-from-schema
+    :producer-ns 're-frame.schemas
+    :design-bead "rf2-kj51z"
+    :description "Walk a Malli EDN form at a base-path; return paths whose props carry :sensitive? true."}
+   {:key         :schemas/schema-has-sensitive?
+    :producer-ns 're-frame.schemas
+    :design-bead "rf2-kj51z"
+    :description "Predicate: does any sub-slot of the schema declare :sensitive? true?"}
 
    ;; ---- re-frame.machines (rf2-xbtj / rf2-8bp3) ------------------------------
    {:key         :machines/reg-machine
@@ -406,7 +414,13 @@
     :description "Emit a trace event (registrar replace-warning seam)."}
    {:key         :trace/emit-error!
     :producer-ns 're-frame.trace
-    :description "Emit a trace error event (registrar replace-warning seam)."}])
+    :description "Emit a trace error event (registrar replace-warning seam)."}
+
+   ;; ---- re-frame.privacy (rf2-isdwf — sensitive-without-redaction cache) ----
+   {:key         :privacy/clear-suppression-cache!
+    :producer-ns 're-frame.privacy
+    :design-bead "rf2-isdwf"
+    :description "Reset the per-(kind, id) :rf.warning/sensitive-without-redaction suppression cache; called on frame destroy so re-registrations after teardown re-emit the warning if still mis-configured."}])
 
 (defn hook-keys
   "Set of every late-bind hook key documented in the directory."

--- a/implementation/core/src/re_frame/privacy.cljc
+++ b/implementation/core/src/re_frame/privacy.cljc
@@ -1,0 +1,253 @@
+(ns re-frame.privacy
+  "Per Spec 009 §Privacy / sensitive data in traces (lines 1149-1268,
+  resolved by rf2-a32kd; runtime implementation rf2-isdwf).
+
+  Two cooperating pieces:
+
+  1. **Registration-time `:sensitive?` metadata key.** A boolean flag
+     on the `:rf/registration-metadata` map for any `reg-*` kind. The
+     registrar copies it onto the registry slot's stored meta; the
+     runtime hoists `:sensitive? true` to the top level of every trace
+     event emitted within the handler's execution scope. The plumbing
+     for the runtime stamp lives in `re-frame.trace` (the
+     `*current-sensitive?*` dynamic Var bound at every handler-scope
+     binding site).
+
+  2. **`with-redacted` interceptor.** A positional interceptor that
+     overwrites named keys in the event payload with the sentinel
+     keyword `:rf/redacted` before the handler chain runs. The
+     handler body itself sees the UNREDACTED payload via the regular
+     `:event` coeffect slot (handlers need the real value to do their
+     work). The redaction is for the trace surface — every downstream
+     emit that copies the event vector (`:event/dispatched` already
+     fired by the time the interceptor `:before` runs, but the
+     handler's `:rf.trace/trigger-handler` cofx view of the event,
+     the `:event/db-changed` `:tags :app-db-before` / `:app-db-after`
+     when the corresponding paths exist in app-db, and any
+     `:rf.error/handler-exception` `:tags :event` slot the runtime
+     emits for a throw from this handler) picks up the redacted form.
+
+  Composition: a handler carrying both `:sensitive? true` in its
+  metadata-map AND `[(with-redacted [...])]` in its positional
+  interceptor chain emits trace events that are BOTH stamped
+  `:sensitive? true` AND carry redacted payloads. `:sensitive?` is
+  the filter-out signal for off-box listeners; `with-redacted` is
+  the in-place scrub. The conservative recommended pattern for new
+  sensitive handlers is to declare both.
+
+  Registration-time warning: `:rf.warning/sensitive-without-redaction`
+  fires when a registration declares `:sensitive? true` but the
+  positional interceptor chain has no `with-redacted` and the
+  registration metadata carries no `:no-redaction-needed?` opt-out.
+  One emit per `(kind, id)` pair (cached); the cache is reset on
+  every fresh registration cycle so re-declarations after fix re-fire."
+  (:require [re-frame.interceptor :as interceptor]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.trace :as trace]))
+
+;; ---- redaction sentinel ---------------------------------------------------
+
+(def redacted-sentinel
+  "The framework-reserved redaction sentinel per Spec 009 §Privacy. Sits
+  in the `:rf/` reserved-keyword namespace so apps cannot legitimately
+  produce it as a payload value. Consumers wanting \"was this redacted?\"
+  check `(= :rf/redacted v)`.
+
+  Mirrors the sentinel emitted by `re-frame.elision/elide-wire-value`
+  for sensitive-value substitution — same wire shape, two emit sites
+  (in-handler redaction here, wire-walker substitution there)."
+  :rf/redacted)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- redact-paths
+  "Apply `:rf/redacted` substitution to every `get-in`-style path inside
+  `payload`. Paths whose intermediate slots are missing are skipped (no
+  empty maps created). Returns the redacted payload.
+
+  Per Spec 009 line 1224: paths are vectors of keys; v1 vocabulary is
+  literal-keys only (no wildcards / predicate paths)."
+  [payload paths]
+  (reduce
+    (fn [acc path]
+      (if (and (vector? path) (seq path)
+               (some? (get-in acc (butlast path))))
+        (assoc-in acc path redacted-sentinel)
+        acc))
+    payload
+    paths))
+
+(defn- redact-event-vector
+  "Redact the named paths in the event vector's payload map (the second
+  element). Returns the redacted event vector unchanged if the shape
+  doesn't match the conventional `[event-id payload-map]` form (per
+  Conventions §Unwrap interceptor)."
+  [event paths]
+  (if (and (vector? event)
+           (>= (count event) 2)
+           (map? (second event)))
+    (let [[id payload & rest-args] event
+          redacted-payload (redact-paths payload paths)]
+      (into [id redacted-payload] rest-args))
+    event))
+
+;; ---- with-redacted interceptor -------------------------------------------
+
+(defn with-redacted
+  "Build an interceptor that overwrites the named keys in the event
+  vector's payload map with `:rf/redacted` before the handler chain
+  runs and before any downstream trace event copies the event vector.
+
+  Signature:
+
+      (with-redacted paths)
+      ;; -> an interceptor that redacts the named paths in:
+      ;;    - The `:rf.trace/trigger-handler` cofx-slot view of the event
+      ;;      (so any emit inside the chain copying the event sees the
+      ;;      redacted form).
+      ;;    - The `:event/db-changed` `:tags :app-db-before` /
+      ;;      `:app-db-after` slots (when the corresponding paths exist
+      ;;      in app-db) — handled by the runtime's db-changed emit
+      ;;      consulting the interceptor's stashed paths.
+      ;;    - Any `:rf.error/handler-exception` `:tags :event` slot.
+      ;;
+      ;; The handler body itself sees the UNREDACTED payload via the
+      ;; regular `:event` coeffect slot.
+
+  Args:
+    `paths` — a vector of `get-in`-style key paths into the event
+              vector's payload map. Each path is itself a vector;
+              the value at every named path is replaced with the
+              sentinel keyword `:rf/redacted` before the runtime
+              emits any in-chain trace event.
+
+  Returns an interceptor map suitable for inclusion in a `reg-event-*`
+  positional chain.
+
+  Per Spec 009 §The `with-redacted` interceptor (lines 1182-1230)."
+  [paths]
+  (let [paths (vec paths)]
+    (interceptor/->interceptor
+      :id     :rf/with-redacted
+      :before
+      (fn [ctx]
+        (let [event (interceptor/get-coeffect ctx :event)]
+          ;; Per Spec 009 line 1221: the handler body sees the
+          ;; UNREDACTED payload via the regular :event cofx slot
+          ;; — handlers need the real value to do their work. The
+          ;; redaction is for the trace surface only. We stash the
+          ;; redacted form under :rf/redacted-event for the
+          ;; runtime's emit sites to consult (per the in-chain
+          ;; emits listed in the with-redacted docstring above).
+          ;;
+          ;; Per rf2-isdwf: also force `:sensitive? true` for the
+          ;; rest of this handler's scope. The interceptor itself
+          ;; runs INSIDE the event-handler's `*current-sensitive?*`
+          ;; binding (router.cljc binds before the chain runs), so
+          ;; we can't `binding`-shadow it here. Instead we stash a
+          ;; `:rf/redacted-paths` slot on the context for the
+          ;; runtime to consult when assembling derived emits;
+          ;; future emits that copy the event vector consult the
+          ;; stashed paths to apply the redaction. The bare event
+          ;; coeffect is unchanged so the handler body's view is
+          ;; untouched.
+          (-> ctx
+              (assoc :rf/redacted-paths paths)
+              (assoc :rf/redacted-event (redact-event-vector event paths))))))))
+
+;; ---- redaction-aware helpers (for runtime consumers) ---------------------
+
+(defn redact-event
+  "Redact `event` using `paths`. Public form of the internal helper —
+  exposed so runtime emit sites (e.g. router's :rf.error/handler-exception,
+  the :event/db-changed emit) can apply the same redaction logic to
+  derived emits."
+  [event paths]
+  (redact-event-vector event paths))
+
+(defn redacted-event-from-ctx
+  "Return the redacted event vector from an interceptor context, or
+  the original `:event` coeffect when `with-redacted` did not run.
+  Runtime emit sites use this to surface the appropriate shape on
+  in-chain trace events."
+  [ctx]
+  (or (:rf/redacted-event ctx)
+      (interceptor/get-coeffect ctx :event)))
+
+;; ---- :rf.warning/sensitive-without-redaction -----------------------------
+;;
+;; Per Spec 009 §Privacy + Error event catalogue (catalogued at line 870):
+;; a registration carrying `:sensitive? true` whose positional
+;; interceptor chain lacks `with-redacted` triggers a one-shot warning
+;; per `(kind, id)` pair. The suppression cache is keyed on
+;; `[kind id]` and is reset on `clear-suppression-cache!` (called from
+;; test fixtures and frame-destruction code paths so re-declarations
+;; after a fix re-fire the warning, per the bead's "suppression cache
+;; reset on frame destroy" requirement).
+
+(defonce ^:private warned-pairs
+  ;; Set of [kind id] pairs that have emitted the warning since the
+  ;; last cache reset. Per (kind, id) once-per-process suppression.
+  (atom #{}))
+
+(defn- has-with-redacted?
+  "Walk an interceptor chain looking for `with-redacted` (matched by its
+  `:id :rf/with-redacted` interceptor identifier). Returns true iff
+  the chain contains at least one such interceptor."
+  [interceptors]
+  (boolean
+    (some (fn [icpt]
+            (and (map? icpt)
+                 (= :rf/with-redacted (:id icpt))))
+          interceptors)))
+
+(defn warn-sensitive-without-redaction!
+  "Emit `:rf.warning/sensitive-without-redaction` once per (kind, id) pair
+  when the registration declares `:sensitive? true` but the positional
+  interceptor chain contains no `with-redacted` and the meta carries
+  no `:no-redaction-needed?` opt-out flag.
+
+  Called from `reg-event-*` registration paths after the chain is
+  assembled.  Returns nil. Idempotent on repeat (kind, id) — second
+  call sees the cached pair and no-ops.
+
+  Per Spec 009 §Privacy + §Error event catalogue (catalogued at line
+  870), rf2-isdwf."
+  [kind id meta interceptors]
+  (when (and (true? (:sensitive? meta))
+             (not (true? (:no-redaction-needed? meta)))
+             (not (has-with-redacted? interceptors)))
+    (let [pair [kind id]]
+      (when-not (contains? @warned-pairs pair)
+        (swap! warned-pairs conj pair)
+        (trace/emit! :warning :rf.warning/sensitive-without-redaction
+                     {:kind     kind
+                      :id       id
+                      :reason
+                      (str (name kind) " `" id "` is registered with "
+                           ":sensitive? true but its positional interceptor "
+                           "chain has no with-redacted. The trace surface "
+                           "will receive the unscrubbed event payload "
+                           "stamped :sensitive? true; off-box listeners "
+                           "that ship sensitive events would leak the "
+                           "raw payload. Add `[(rf/with-redacted [<paths>])]` "
+                           "to the positional chain, or declare "
+                           ":no-redaction-needed? true on the metadata-map "
+                           "to opt out of the warning.")
+                      :recovery :warned-and-replaced}))))
+  nil)
+
+(defn clear-suppression-cache!
+  "Reset the warned-pairs cache so the next sensitive-without-redaction
+  registration re-emits the warning. Called from test fixtures and
+  the frame-destruction code path (per Spec 009 §Privacy / sensitive
+  data in traces — suppression cache resets on frame destroy)."
+  []
+  (reset! warned-pairs #{})
+  nil)
+
+;; Publish via late-bind so registrar / frame teardown can call us
+;; without a cycle. `re-frame.events` requires this namespace directly
+;; to call `warn-sensitive-without-redaction!` from its reg-event-*
+;; paths.
+(late-bind/set-fn! :privacy/clear-suppression-cache! clear-suppression-cache!)

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -262,13 +262,22 @@
   "Surface an interceptor-chain exception as :rf.error/handler-exception
   trace. The chain captures the exception into `:rf/interceptor-error`
   rather than re-throwing (the drain must not abort); this helper
-  translates that into the trace surface."
-  [error event-id event frame]
+  translates that into the trace surface.
+
+  Per Spec 009 §The `with-redacted` interceptor (line 1226): the
+  `:tags :event` slot of `:rf.error/handler-exception` MUST honour
+  `with-redacted` — if the failing handler declared redacted paths,
+  the trace event carries the scrubbed event vector, not the
+  unredacted one. `ctx` (the final interceptor context) carries the
+  scrubbed form under `:rf/redacted-event` when `with-redacted`
+  ran; we surface that here."
+  [error event-id event frame ctx]
   (let [e (:exception error)
-        msg #?(:clj (.getMessage e) :cljs (.-message e))]
+        msg #?(:clj (.getMessage e) :cljs (.-message e))
+        emit-event (or (:rf/redacted-event ctx) event)]
     (trace/emit-error! :rf.error/handler-exception
                        {:event-id          event-id
-                        :event             event
+                        :event             emit-event
                         :frame             frame
                         :failing-id        event-id
                         :handler-id        event-id
@@ -294,14 +303,21 @@
 
 (defn- commit-db-effect!
   "Apply :db atomically: replace the app-db container, emit the
-  :event/db-changed trace, then run post-commit schema validation."
-  [effects event-id event frame]
+  :event/db-changed trace, then run post-commit schema validation.
+
+  Per Spec 009 §The `with-redacted` interceptor (line 1225): the
+  `:event/db-changed` trace event MUST surface the scrubbed event
+  vector under `:tags :event` when `with-redacted` ran on the
+  handler's chain. The interceptor stashes `:rf/redacted-event`
+  on the context; we read it through and emit the scrubbed form."
+  [effects event-id event frame ctx]
   (when (contains? effects :db)
-    (let [container (frame/get-frame-db frame)]
-      (adapter/replace-container! container (:db effects)))
-    (trace/emit! :event :event/db-changed
-                 {:event-id event-id :event event :frame frame})
-    (run-post-commit-validation! (:db effects) event-id frame)))
+    (let [container  (frame/get-frame-db frame)
+          emit-event (or (:rf/redacted-event ctx) event)]
+      (adapter/replace-container! container (:db effects))
+      (trace/emit! :event :event/db-changed
+                   {:event-id event-id :event emit-event :frame frame})
+      (run-post-commit-validation! (:db effects) event-id frame))))
 
 (defn- run-flows!
   "Per Spec 013 §Drain integration: run flows after :db commits and
@@ -378,8 +394,20 @@
           ;; returns nil when no source-coord was stamped (programmatic
           ;; registration / REPL eval); the binding is then nil and
           ;; the field is omitted from any emitted error event.
+          ;;
+          ;; Per rf2-isdwf: also bind `*current-sensitive?*` from the
+          ;; handler's registration meta. `emit!`/`emit-error!` hoist
+          ;; `:sensitive? true` onto every trace event produced inside
+          ;; this scope (Spec 009 §Privacy). The interceptor chain,
+          ;; db commit, flows, fx walk all ride this binding —
+          ;; covering :event/db-changed, :event/do-fx, :rf.fx/handled
+          ;; (the inner fx scope re-binds), :sub/run (sub recompute
+          ;; re-binds to the sub's reading), :rf.error/* (every error
+          ;; emit inside the chain).
           (binding [trace/*current-trigger-handler*
-                    (trace/trigger-handler-from-meta :event event-id handler-meta)]
+                    (trace/trigger-handler-from-meta :event event-id handler-meta)
+                    trace/*current-sensitive?*
+                    (trace/sensitive?-from-meta handler-meta)]
             (let [_            (trace/emit! :event :event
                                             {:event-id event-id
                                              :event    event
@@ -408,8 +436,8 @@
                   effects      (:effects final-ctx)
                   error        (:rf/interceptor-error final-ctx)]
               (when error
-                (emit-handler-exception! error event-id event frame))
-              (commit-db-effect! effects event-id event frame)
+                (emit-handler-exception! error event-id event frame final-ctx))
+              (commit-db-effect! effects event-id event frame final-ctx)
               (run-flows! frame event)
               (run-fx-effects! effects frame frame-record fx-overrides event)
               (trace/emit! :event :event
@@ -661,18 +689,32 @@
   Spec 009 §Dispatch correlation, :dispatch-id and :parent-dispatch-id
   ride on :tags. Per Spec 002 §Dispatch origin tagging, :origin rides
   on :tags too. Spec elision is automatic — trace/emit! short-circuits
-  when interop/debug-enabled? is false at compile time."
+  when interop/debug-enabled? is false at compile time.
+
+  Per rf2-isdwf: `:event/dispatched` fires at queue/enqueue time —
+  BEFORE the handler-scope binding for `*current-sensitive?*` is
+  established (the binding wraps `process-event*`, which runs later
+  in the drain). Look up the target handler's registration metadata
+  directly and pass `:sensitive?` in the tags so `emit!` hoists it
+  to the top level. When the handler is missing the field is omitted
+  (consumers treat absent as false)."
   [envelope sync?]
-  (trace/emit! :event :event/dispatched
-               (cond-> {:event    (:event envelope)
-                        :frame    (:frame envelope)
-                        :origin   (:origin envelope)
-                        :source   (:source envelope)
-                        :sync?    sync?}
-                 (:dispatch-id envelope)
-                 (assoc :dispatch-id (:dispatch-id envelope))
-                 (:parent-dispatch-id envelope)
-                 (assoc :parent-dispatch-id (:parent-dispatch-id envelope)))))
+  (let [event        (:event envelope)
+        event-id     (when (vector? event) (first event))
+        handler-meta (when event-id (registrar/lookup :event event-id))
+        sensitive?   (trace/sensitive?-from-meta handler-meta)]
+    (trace/emit! :event :event/dispatched
+                 (cond-> {:event    event
+                          :frame    (:frame envelope)
+                          :origin   (:origin envelope)
+                          :source   (:source envelope)
+                          :sync?    sync?}
+                   sensitive?
+                   (assoc :sensitive? true)
+                   (:dispatch-id envelope)
+                   (assoc :dispatch-id (:dispatch-id envelope))
+                   (:parent-dispatch-id envelope)
+                   (assoc :parent-dispatch-id (:parent-dispatch-id envelope))))))
 
 (defn dispatch!
   "Append the event to the target frame's router queue. Per Spec 002:

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -243,8 +243,14 @@
   ;; Per Spec 009 §:rf.trace/trigger-handler table row "Inside a sub
   ;; recompute (body fn)": carries the sub's coord. The emit MUST sit
   ;; inside the binding for the sub's coord to ride the success trace.
+  ;; Per rf2-isdwf: bind `*current-sensitive?*` to the sub's reading
+  ;; per Spec 009 §Privacy line 1160 "the conventional use sites
+  ;; are reg-event-* and reg-sub" — sub return values flow user
+  ;; input into views and must be filterable.
   (binding [trace/*current-trigger-handler*
-            (trace/trigger-handler-from-meta :sub query-id sub-meta)]
+            (trace/trigger-handler-from-meta :sub query-id sub-meta)
+            trace/*current-sensitive?*
+            (trace/sensitive?-from-meta sub-meta)]
     (trace/emit! :sub/run :sub/run
                  {:sub-id  query-id
                   :query-v query-v

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -200,6 +200,72 @@
   Per Spec 009 §Dispatch correlation and rf2-g6ih4."
   nil)
 
+;; ---- *current-sensitive?* (rf2-isdwf) -------------------------------------
+;;
+;; Per Spec 009 §Privacy / sensitive data in traces (lines 1149-1268):
+;; every trace event emitted inside the scope of a handler whose
+;; registration carries `:sensitive? true` in its metadata MUST be
+;; stamped with `:sensitive? true` at the top level of the emitted
+;; event. The runtime carries the in-scope handler's sensitivity
+;; reading through the dynamic Var `*current-sensitive?*` — bound
+;; alongside `*current-trigger-handler*` (rf2-3nn8 / rf2-lf84g) at
+;; every handler-scope binding site (router, fx, cofx, subs, views).
+;;
+;; `emit!` and `emit-error!` read this Var and hoist `:sensitive? true`
+;; to the emitted event's TOP LEVEL (per Spec 009 line 1175 — the
+;; stamp rides alongside `:source` / `:recovery`, not under `:tags`,
+;; so a single keyword read tells consumers to filter).
+;;
+;; Cascade composition rule (Spec 009 line 1177): the innermost
+;; in-scope handler's reading wins; the runtime does NOT transitively
+;; widen the flag across handler boundaries. Tools that want "every
+;; trace event in a sensitive cascade" group by `:dispatch-id` and
+;; OR-reduce.
+;;
+;; Production elision: when `interop/debug-enabled?` is false the
+;; whole trace surface compiles out via the outer `when` gate in
+;; `emit!`, so the Var read is dead code.
+
+(def ^:dynamic *current-sensitive?*
+  "Boolean. True when the in-scope handler's registration metadata
+  carries `:sensitive? true`. Bound alongside `*current-trigger-handler*`
+  at every handler-scope binding site (router process-event, fx
+  dispatcher, cofx injector, sub recompute, view render). `emit!` and
+  `emit-error!` read this Var and stamp the emitted trace event's
+  top-level `:sensitive?` field when true.
+
+  nil / false outside any handler's scope (registration-time emits,
+  outermost-dispatch lookup failures, async-callback emits). The
+  field is OMITTED from the trace event when the Var reads falsy —
+  consumers treat absent as false.
+
+  Per Spec 009 §Privacy and rf2-isdwf."
+  nil)
+
+(defn sensitive?-from-meta
+  "Read `:sensitive?` from a registrar slot's meta map. Returns
+  `true` iff the meta carries `:sensitive? true`; `false` for every
+  other shape (nil meta, absent key, falsy value).
+
+  Used by handler-scope binding sites to compute the value to bind
+  `*current-sensitive?*` to. Per rf2-isdwf."
+  [meta]
+  (true? (:sensitive? meta)))
+
+(defn sensitive?
+  "Predicate: is `trace-event`'s top-level `:sensitive?` field truthy?
+
+  The framework-published predicate every consumer (Causa, Story,
+  pair2-preload, pair2-mcp, story-mcp, causa-mcp) gates on. Replaces
+  the per-consumer `(and (map? ev) (true? (:sensitive? ev)))` private
+  helper.
+
+  Per Spec 009 §Privacy / sensitive data in traces and rf2-isdwf
+  (audit G5)."
+  [trace-event]
+  (and (map? trace-event)
+       (true? (:sensitive? trace-event))))
+
 (defn trigger-handler-from-meta
   "Build a `:rf.trace/trigger-handler` value from a registrar meta map.
   `kind` is the registry kind (`:event`, `:sub`, `:fx`, `:cofx`, `:view`);
@@ -298,6 +364,11 @@
                      than this numeric host-clock timestamp.
     :between       — `[t0 t1]` two-element vector — keep only events
                      whose :time falls in [t0, t1] inclusive.
+    :sensitive?    — boolean. Match the top-level `:sensitive?` field
+                     (per Spec 009 §Privacy filter-vocab row, rf2-isdwf).
+                     Pass `false` to exclude sensitive events; pass
+                     `true` to select only sensitive events. Absent ⇒
+                     no constraint.
     :pred          — `(fn [ev] -> truthy)` arbitrary predicate. Receives
                      the full event map. Returning truthy keeps the event.
 
@@ -313,6 +384,7 @@
      (let [{:keys [operation op-type since frame
                    severity event-id handler-id source origin
                    dispatch-id since-ms between pred]} opts
+           sensitive-filter (:sensitive? opts)
            [between-t0 between-t1] (when (and (sequential? between)
                                               (= 2 (count between)))
                                      between)
@@ -343,6 +415,12 @@
                   (or (nil? between-t0)
                       (and (number? (:time ev))
                            (<= between-t0 (:time ev) between-t1)))
+                  ;; Per rf2-isdwf: top-level `:sensitive?` is hoisted
+                  ;; (NOT nested under :tags). Match against the
+                  ;; top-level slot only; absent reads as false.
+                  (or (nil? sensitive-filter)
+                      (= (true? sensitive-filter)
+                         (true? (:sensitive? ev))))
                   (or (nil? pred) (pred ev))))]
        (filterv predicate @trace-buffer-state)))))
 
@@ -434,7 +512,17 @@
           ;; trace event, NOT inside :tags. Hoist them here.
           cascade-id   *current-dispatch-id*
           trigger      *current-trigger-handler*
-          base-tags    (dissoc tags :source :recovery)
+          ;; Per rf2-isdwf: hoist `:sensitive?` to the top level of
+          ;; the trace event when the in-scope handler's registration
+          ;; meta carries `:sensitive? true`. Caller-supplied
+          ;; `:sensitive?` in tags wins (e.g. `emit-dispatched-trace!`
+          ;; computes its own reading at queue time, before the
+          ;; handler-scope binding exists).
+          tag-sensitive? (:sensitive? tags)
+          sensitive?     (cond
+                           (some? tag-sensitive?) (true? tag-sensitive?)
+                           :else                  (true? *current-sensitive?*))
+          base-tags    (dissoc tags :source :recovery :sensitive?)
           ;; Per rf2-g6ih4: stamp the cascade's :dispatch-id on every
           ;; event emitted inside the drain so consumers can group raw
           ;; trace events by cascade without inferring from sequence.
@@ -454,7 +542,13 @@
                      ;; registration coord onto every trace event
                      ;; emitted inside a handler's scope. Symmetric
                      ;; with `emit-error!` per rf2-3nn8.
-                     trigger  (assoc :rf.trace/trigger-handler trigger))]
+                     trigger  (assoc :rf.trace/trigger-handler trigger)
+                     ;; Per rf2-isdwf: top-level `:sensitive? true`
+                     ;; stamp. Absent (NOT `:sensitive? false`) when
+                     ;; the in-scope handler is not sensitive — per
+                     ;; Spec 009 line 1176 "Consumers treat absent
+                     ;; as false."
+                     sensitive? (assoc :sensitive? true))]
       (push-to-buffer! event)
       (deliver-to-epoch-capture! event)
       (doseq [[_ f] @listeners]
@@ -495,7 +589,15 @@
     (let [trigger    *current-trigger-handler*
           call-site  *current-call-site*
           cascade-id *current-dispatch-id*
-          base-tags  (merge {:category error-operation} tags)
+          ;; Per rf2-isdwf: hoist `:sensitive?` to top-level on error
+          ;; events too. Caller-supplied tag wins (e.g. callers that
+          ;; need to force-stamp regardless of in-scope handler).
+          tag-sensitive? (:sensitive? tags)
+          sensitive?     (cond
+                           (some? tag-sensitive?) (true? tag-sensitive?)
+                           :else                  (true? *current-sensitive?*))
+          base-tags  (merge {:category error-operation}
+                            (dissoc tags :sensitive?))
           tags+      (if (and cascade-id (not (contains? base-tags :dispatch-id)))
                        (assoc base-tags :dispatch-id cascade-id)
                        base-tags)
@@ -505,8 +607,9 @@
                               :time      (interop/now-ms)
                               :tags      tags+
                               :recovery  (:recovery tags :no-recovery)}
-                       trigger   (assoc :rf.trace/trigger-handler trigger)
-                       call-site (assoc :rf.trace/call-site       call-site))]
+                       trigger    (assoc :rf.trace/trigger-handler trigger)
+                       call-site  (assoc :rf.trace/call-site       call-site)
+                       sensitive? (assoc :sensitive? true))]
       (push-to-buffer! event)
       (deliver-to-epoch-capture! event)
       (doseq [[_ f] @listeners]

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -214,12 +214,19 @@
         ;; sub exception during a render-time deref, etc.) inherit the
         ;; view's coord as the in-scope trigger handler.
         view-trigger-handler (trace/trigger-handler-from-meta :view id metadata)
+        ;; Per rf2-isdwf: pre-compute the view's `:sensitive?`
+        ;; reading once at registration time (same idiom as
+        ;; `view-trigger-handler`). Every render binds it; any
+        ;; trace event emitted during the view's render carries
+        ;; the flag per Spec 009 §Privacy.
+        view-sensitive?      (trace/sensitive?-from-meta metadata)
         wrapped (with-meta
                   (fn frame-aware-view [& args]
                     (let [tok        (provider/reagent-component-token)
                           render-key [id tok]]
                       (binding [*render-key* render-key
-                                trace/*current-trigger-handler* view-trigger-handler]
+                                trace/*current-trigger-handler* view-trigger-handler
+                                trace/*current-sensitive?* view-sensitive?]
                         (emit-render-trace! render-key)
                         ;; Per Spec 009 §Performance instrumentation
                         ;; (rf2-du3i): every render of a registered view

--- a/implementation/core/test/re_frame/sensitive_stamping_test.clj
+++ b/implementation/core/test/re_frame/sensitive_stamping_test.clj
@@ -1,0 +1,548 @@
+(ns re-frame.sensitive-stamping-test
+  "Per rf2-isdwf — runtime `:sensitive?` top-level stamping per Spec 009
+  §Privacy / sensitive data in traces (lines 1149-1268).
+
+  Validates:
+  - Plain (non-sensitive) handler -> trace event has no `:sensitive?` flag.
+  - Handler with `^{:sensitive? true}` meta -> trace event has
+    `:sensitive? true` at TOP level (not under :tags).
+  - `:event/dispatched` trace event (emitted at queue time, before
+    handler-scope binding) consults registrar meta and stamps the flag.
+  - The flag rides every emit inside the cascade scope:
+    `:event/dispatched`, `:event`, `:event/db-changed`, `:rf.fx/handled`,
+    `:rf.error/handler-exception`, `:rf.error/no-such-handler`.
+  - fx handlers, cofx handlers, subs all carry their own reading
+    (innermost in-scope handler's flag wins per Spec 009 line 1177).
+  - `with-redacted` interceptor scrubs event payloads + the in-chain
+    emits carry the redacted form.
+  - Registration-time `:rf.warning/sensitive-without-redaction`:
+    fires once per (kind, id) pair when :sensitive? without with-redacted.
+  - `:no-redaction-needed?` opt-out suppresses the warning.
+  - `:rf/redacted-paths` is the sentinel; `:rf/redacted` lives in the
+    framework reserved-keyword namespace.
+  - Composition with walker: stamped event flows through
+    `elide-wire-value` and the sensitive-drop wins.
+  - `trace-buffer {:sensitive? false}` filter excludes sensitive events.
+  - `trace/sensitive?` predicate returns true on top-level-stamped events.
+
+  JVM-only — the dynamic-var binding mechanism is platform-agnostic."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.frame :as frame]
+            [re-frame.privacy :as privacy]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (trace/clear-trace-cbs!)
+  (privacy/clear-suppression-cache!)
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- record-traces
+  [body-fn]
+  (let [seen (atom [])]
+    (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+    (try (body-fn)
+         (finally (rf/remove-trace-cb! ::rec)))
+    @seen))
+
+(defn- events-of [evs op]
+  (filterv #(= op (:operation %)) evs))
+
+;; ---- top-level stamping basics --------------------------------------------
+
+(deftest plain-handler-no-sensitive-flag
+  (testing "A handler without :sensitive? meta emits trace events with NO
+   top-level :sensitive? key (per Spec 009 line 1176 — consumers treat
+   absent as false; the field is omitted, NOT set to false)"
+    (rf/reg-event-db :rf2-isdwf/plain
+                     (fn [db _] db))
+    (let [evs (record-traces #(rf/dispatch-sync [:rf2-isdwf/plain]))]
+      (doseq [ev evs]
+        (is (not (contains? ev :sensitive?))
+            (str ":sensitive? must be absent on plain-handler trace: "
+                 (:operation ev) " — got " (:sensitive? ev)))))))
+
+(deftest sensitive-handler-top-level-stamp
+  (testing "A handler with ^{:sensitive? true} meta emits trace events
+   with :sensitive? true at the TOP LEVEL (not under :tags) per Spec 009
+   line 1175"
+    (rf/reg-event-db :rf2-isdwf/sensitive
+                     {:sensitive? true :no-redaction-needed? true}
+                     (fn [db _] (assoc db :ran? true)))
+    (let [evs (record-traces #(rf/dispatch-sync [:rf2-isdwf/sensitive]))
+          [dispatched]   (events-of evs :event/dispatched)
+          [db-changed]   (events-of evs :event/db-changed)
+          run-start-end  (events-of evs :event)]
+      (is (some? dispatched) ":event/dispatched fired")
+      (is (true? (:sensitive? dispatched))
+          ":event/dispatched top-level :sensitive? true")
+      (is (not (contains? (:tags dispatched) :sensitive?))
+          ":sensitive? is hoisted, NOT under :tags")
+      (is (some? db-changed) ":event/db-changed fired")
+      (is (true? (:sensitive? db-changed))
+          ":event/db-changed top-level :sensitive? true")
+      (is (not (contains? (:tags db-changed) :sensitive?))
+          ":sensitive? is hoisted on db-changed, NOT under :tags")
+      (is (seq run-start-end))
+      (doseq [ev run-start-end]
+        (is (true? (:sensitive? ev))
+            (str ":event (" (:tags ev) ") carries top-level :sensitive? true"))))))
+
+(deftest sensitive-false-meta-treated-as-non-sensitive
+  (testing ":sensitive? false (an explicit false) reads as non-sensitive —
+   only true triggers the stamp"
+    (rf/reg-event-db :rf2-isdwf/false-flag
+                     {:sensitive? false}
+                     (fn [db _] db))
+    (let [evs (record-traces #(rf/dispatch-sync [:rf2-isdwf/false-flag]))]
+      (doseq [ev evs]
+        (is (not (true? (:sensitive? ev)))
+            ":sensitive? must NOT be true when meta carries false")))))
+
+;; ---- :event/dispatched is stamped at queue time --------------------------
+
+(deftest event-dispatched-queue-time-stamp
+  (testing ":event/dispatched fires at enqueue time (BEFORE the
+   handler-scope binding); the runtime must look up the handler's
+   meta directly and stamp :sensitive? on the dispatched trace"
+    (rf/reg-event-db :rf2-isdwf/queue-stamp
+                     {:sensitive? true :no-redaction-needed? true}
+                     (fn [db _] db))
+    (let [evs (record-traces #(rf/dispatch-sync [:rf2-isdwf/queue-stamp]))
+          [dispatched] (events-of evs :event/dispatched)]
+      (is (some? dispatched))
+      (is (true? (:sensitive? dispatched))
+          ":event/dispatched stamped even though it fires outside the
+           handler-scope binding"))))
+
+(deftest event-dispatched-unknown-handler-not-stamped
+  (testing "Dispatching to an unregistered handler does NOT stamp
+   :sensitive? — the field is absent (handler-meta lookup miss)"
+    (let [evs (record-traces #(rf/dispatch-sync [:rf2-isdwf/never-registered]))
+          [dispatched] (events-of evs :event/dispatched)]
+      (is (some? dispatched))
+      (is (not (contains? dispatched :sensitive?))
+          ":sensitive? absent when handler is unknown"))))
+
+;; ---- fx handler scope (innermost wins) -----------------------------------
+
+(deftest fx-handled-takes-fx-handler-sensitivity
+  (testing "When a sensitive event handler dispatches to a non-sensitive fx,
+   the :rf.fx/handled trace reflects the FX handler's reading (innermost
+   wins per Spec 009 line 1177)"
+    (rf/reg-fx :rf2-isdwf/non-sensitive-fx
+               (fn [_ _] :ok))
+    (rf/reg-event-fx :rf2-isdwf/sens-evt-non-sens-fx
+                     {:sensitive? true :no-redaction-needed? true}
+                     (fn [_ _] {:fx [[:rf2-isdwf/non-sensitive-fx {}]]}))
+    (let [evs (record-traces
+                #(rf/dispatch-sync [:rf2-isdwf/sens-evt-non-sens-fx]))
+          [fx-handled] (events-of evs :rf.fx/handled)]
+      (is (some? fx-handled))
+      (is (not (true? (:sensitive? fx-handled)))
+          "fx-handled reflects FX handler's reading (not sensitive)"))))
+
+(deftest fx-handled-takes-fx-handler-sensitivity-flag
+  (testing "When a non-sensitive event dispatches to a sensitive fx,
+   the :rf.fx/handled trace IS stamped per the fx-level reading"
+    (rf/reg-fx :rf2-isdwf/sensitive-fx
+               {:sensitive? true}
+               (fn [_ _] :ok))
+    (rf/reg-event-fx :rf2-isdwf/non-sens-evt-sens-fx
+                     (fn [_ _] {:fx [[:rf2-isdwf/sensitive-fx {}]]}))
+    (let [evs (record-traces
+                #(rf/dispatch-sync [:rf2-isdwf/non-sens-evt-sens-fx]))
+          [fx-handled] (events-of evs :rf.fx/handled)]
+      (is (some? fx-handled))
+      (is (true? (:sensitive? fx-handled))
+          "fx-handled reflects FX handler's :sensitive? meta"))))
+
+;; ---- cofx handler scope --------------------------------------------------
+
+(deftest cofx-scope-stamps-on-inject
+  (testing "A sensitive cofx handler's injection produces trace events
+   stamped :sensitive? true while the cofx body runs"
+    (rf/reg-cofx :rf2-isdwf/sens-cofx
+                 {:sensitive? true}
+                 (fn [ctx]
+                   ;; Emit a trace from inside the cofx body to verify
+                   ;; the binding scope.
+                   (trace/emit! :info :rf2-isdwf/inside-cofx
+                                {:where :cofx})
+                   (assoc ctx :rf2-isdwf/cofx-ran? true)))
+    (rf/reg-event-fx :rf2-isdwf/uses-sens-cofx
+                     [(rf/inject-cofx :rf2-isdwf/sens-cofx)]
+                     (fn [_ _] {}))
+    (let [evs (record-traces
+                #(rf/dispatch-sync [:rf2-isdwf/uses-sens-cofx]))
+          [inside] (events-of evs :rf2-isdwf/inside-cofx)]
+      (is (some? inside) "trace fired inside cofx body")
+      (is (true? (:sensitive? inside))
+          ":rf2-isdwf/inside-cofx is stamped :sensitive? true while
+           the cofx handler is in scope"))))
+
+;; ---- sub recompute scope -------------------------------------------------
+
+(deftest sub-run-stamps-on-sensitive-sub
+  (testing "A sub registered with :sensitive? true emits :sub/run trace
+   events stamped :sensitive? true per Spec 009 line 1160 (subs are
+   one of the conventional use sites)"
+    (rf/reg-sub :rf2-isdwf/sens-sub
+                {:sensitive? true}
+                (fn [db _] (:counter db 0)))
+    (let [evs (record-traces
+                #(deref (rf/subscribe [:rf2-isdwf/sens-sub])))
+          [sub-run] (events-of evs :sub/run)]
+      (is (some? sub-run))
+      (is (true? (:sensitive? sub-run))
+          ":sub/run carries top-level :sensitive? true for sensitive sub"))))
+
+;; ---- error scope ---------------------------------------------------------
+
+(deftest handler-exception-stamps-on-sensitive-handler
+  (testing "When a sensitive handler throws, the
+   :rf.error/handler-exception trace carries :sensitive? true at top
+   level (the error rides inside the handler-scope binding)"
+    (rf/reg-event-db :rf2-isdwf/sens-throws
+                     {:sensitive? true :no-redaction-needed? true}
+                     (fn [_ _] (throw (ex-info "boom" {}))))
+    (let [evs (record-traces
+                #(rf/dispatch-sync [:rf2-isdwf/sens-throws]))
+          [err] (events-of evs :rf.error/handler-exception)]
+      (is (some? err))
+      (is (true? (:sensitive? err))
+          ":rf.error/handler-exception carries the flag"))))
+
+;; ---- with-redacted interceptor -------------------------------------------
+
+(deftest with-redacted-scrubs-payload
+  (testing "(rf/with-redacted [[:password]]) scrubs the named path in the
+   event payload before the in-chain emits see it; the handler body sees
+   the UNREDACTED payload per Spec 009 line 1221"
+    (let [seen (atom nil)]
+      (rf/reg-event-db :rf2-isdwf/scrubbed
+                       {:sensitive? true}
+                       [(rf/with-redacted [[:password]])]
+                       (fn [db [_ payload]]
+                         (reset! seen payload)
+                         db))
+      (let [evs (record-traces
+                  #(rf/dispatch-sync
+                     [:rf2-isdwf/scrubbed {:username "ada" :password "shh"}]))
+            [db-changed] (events-of evs :event/db-changed)]
+        ;; Handler body sees real values
+        (is (= "shh" (:password @seen))
+            "handler body sees UNREDACTED payload")
+        (is (= "ada" (:username @seen))
+            "handler body sees other fields unchanged")
+        ;; Trace surface sees redacted form on db-changed
+        (is (some? db-changed))
+        (let [emitted-event (get-in db-changed [:tags :event])]
+          (is (= :rf/redacted
+                 (get-in emitted-event [1 :password]))
+              ":event/db-changed :tags :event has :password redacted")
+          (is (= "ada" (get-in emitted-event [1 :username]))
+              ":event/db-changed preserves non-redacted fields"))))))
+
+(deftest with-redacted-stamps-handler-exception
+  (testing ":rf.error/handler-exception's :tags :event slot honours
+   with-redacted (per Spec 009 line 1226-1227)"
+    (rf/reg-event-db :rf2-isdwf/scrub-throws
+                     {:sensitive? true}
+                     [(rf/with-redacted [[:secret]])]
+                     (fn [_ _] (throw (ex-info "boom" {}))))
+    (let [evs (record-traces
+                #(rf/dispatch-sync
+                   [:rf2-isdwf/scrub-throws {:secret "xyz"}]))
+          [err] (events-of evs :rf.error/handler-exception)]
+      (is (some? err))
+      (is (true? (:sensitive? err))
+          "error event is stamped :sensitive? true")
+      (let [emitted-event (get-in err [:tags :event])]
+        (is (= :rf/redacted (get-in emitted-event [1 :secret]))
+            ":rf.error/handler-exception :tags :event has :secret redacted")))))
+
+(deftest with-redacted-composes-with-sensitive
+  (testing "A handler with BOTH :sensitive? true AND [(with-redacted ...)]
+   emits trace events that are BOTH stamped AND carry redacted payloads
+   per Spec 009 line 1229"
+    (rf/reg-event-db :rf2-isdwf/both
+                     {:sensitive? true}
+                     [(rf/with-redacted [[:token]])]
+                     (fn [db _] db))
+    (let [evs (record-traces
+                #(rf/dispatch-sync [:rf2-isdwf/both {:token "abc"}]))
+          [db-changed] (events-of evs :event/db-changed)]
+      (is (true? (:sensitive? db-changed))
+          ":event/db-changed is stamped sensitive")
+      (let [emitted-event (get-in db-changed [:tags :event])]
+        (is (= :rf/redacted (get-in emitted-event [1 :token]))
+            "and its :tags :event payload is redacted")))))
+
+(deftest with-redacted-multi-path
+  (testing "(rf/with-redacted) accepts multiple paths"
+    (let [seen (atom nil)]
+      (rf/reg-event-db :rf2-isdwf/multi-scrub
+                       {:sensitive? true}
+                       [(rf/with-redacted [[:password] [:totp-code]])]
+                       (fn [db [_ payload]]
+                         (reset! seen payload)
+                         db))
+      (let [evs (record-traces
+                  #(rf/dispatch-sync
+                     [:rf2-isdwf/multi-scrub
+                      {:username "ada" :password "shh" :totp-code "123456"}]))
+            [db-changed] (events-of evs :event/db-changed)]
+        (is (= "shh" (:password @seen)))
+        (is (= "123456" (:totp-code @seen)))
+        (let [emitted-event (get-in db-changed [:tags :event])]
+          (is (= :rf/redacted (get-in emitted-event [1 :password])))
+          (is (= :rf/redacted (get-in emitted-event [1 :totp-code])))
+          (is (= "ada" (get-in emitted-event [1 :username]))))))))
+
+(deftest with-redacted-non-payload-event-shape-no-op
+  (testing "with-redacted handles non-conventional event shapes
+   gracefully — when the second slot isn't a payload map, the event
+   passes through unchanged"
+    (rf/reg-event-db :rf2-isdwf/non-payload
+                     {:sensitive? true}
+                     [(rf/with-redacted [[:x]])]
+                     (fn [db _] db))
+    (let [evs (record-traces
+                #(rf/dispatch-sync [:rf2-isdwf/non-payload 42]))
+          [db-changed] (events-of evs :event/db-changed)]
+      ;; with-redacted leaves [event-id 42] alone (second slot is not a map)
+      (is (= [:rf2-isdwf/non-payload 42]
+             (get-in db-changed [:tags :event]))))))
+
+;; ---- registration-time warning -------------------------------------------
+
+(deftest sensitive-without-redaction-warning
+  (testing "Registering a sensitive handler without with-redacted (and
+   without the :no-redaction-needed? opt-out) emits
+   :rf.warning/sensitive-without-redaction once per (kind, id) pair"
+    (let [seen (atom [])]
+      (rf/register-trace-cb! ::rec
+                             (fn [ev] (swap! seen conj ev)))
+      (try
+        (rf/reg-event-db :rf2-isdwf/needs-redaction
+                         {:sensitive? true}
+                         (fn [db _] db))
+        (finally (rf/remove-trace-cb! ::rec)))
+      (let [warnings (filterv
+                       #(= :rf.warning/sensitive-without-redaction
+                           (:operation %))
+                       @seen)]
+        (is (= 1 (count warnings))
+            "exactly one warning")
+        (is (= :warning (:op-type (first warnings))))
+        (is (= :event (get-in (first warnings) [:tags :kind])))
+        (is (= :rf2-isdwf/needs-redaction
+               (get-in (first warnings) [:tags :id])))))))
+
+(deftest sensitive-without-redaction-warning-once
+  (testing "The warning fires once per (kind, id) — re-registering the
+   same id does NOT re-fire (suppression cache)"
+    (let [seen (atom [])]
+      (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+      (try
+        (rf/reg-event-db :rf2-isdwf/dedup
+                         {:sensitive? true}
+                         (fn [db _] db))
+        (rf/reg-event-db :rf2-isdwf/dedup
+                         {:sensitive? true}
+                         (fn [db _] (assoc db :v2 true)))
+        (finally (rf/remove-trace-cb! ::rec)))
+      (let [warnings (filterv
+                       #(= :rf.warning/sensitive-without-redaction
+                           (:operation %))
+                       @seen)]
+        (is (= 1 (count warnings))
+            "second registration does NOT re-fire warning")))))
+
+(deftest sensitive-with-redaction-no-warning
+  (testing "A sensitive handler that DOES carry with-redacted does not
+   trigger the warning"
+    (let [seen (atom [])]
+      (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+      (try
+        (rf/reg-event-db :rf2-isdwf/has-scrub
+                         {:sensitive? true}
+                         [(rf/with-redacted [[:secret]])]
+                         (fn [db _] db))
+        (finally (rf/remove-trace-cb! ::rec)))
+      (let [warnings (filterv
+                       #(= :rf.warning/sensitive-without-redaction
+                           (:operation %))
+                       @seen)]
+        (is (zero? (count warnings))
+            "no warning when with-redacted is in chain")))))
+
+(deftest no-redaction-needed-opt-out
+  (testing ":no-redaction-needed? true on the metadata-map suppresses the
+   warning for handlers that genuinely don't need with-redacted (e.g.
+   a sensitive handler whose only payload IS the user-supplied event-id
+   itself, no scrubbable fields)"
+    (let [seen (atom [])]
+      (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+      (try
+        (rf/reg-event-db :rf2-isdwf/opt-out
+                         {:sensitive? true :no-redaction-needed? true}
+                         (fn [db _] db))
+        (finally (rf/remove-trace-cb! ::rec)))
+      (let [warnings (filterv
+                       #(= :rf.warning/sensitive-without-redaction
+                           (:operation %))
+                       @seen)]
+        (is (zero? (count warnings))
+            ":no-redaction-needed? true suppresses the warning")))))
+
+(deftest non-sensitive-no-warning
+  (testing "Non-sensitive handlers (the default) get no warning even
+   without with-redacted"
+    (let [seen (atom [])]
+      (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+      (try
+        (rf/reg-event-db :rf2-isdwf/plain-noopt
+                         (fn [db _] db))
+        (finally (rf/remove-trace-cb! ::rec)))
+      (let [warnings (filterv
+                       #(= :rf.warning/sensitive-without-redaction
+                           (:operation %))
+                       @seen)]
+        (is (zero? (count warnings)))))))
+
+(deftest suppression-cache-resets-on-frame-destroy
+  (testing "After destroy-frame!, re-registering a still-misconfigured
+   sensitive handler re-fires the warning (spec 'cache reset on frame
+   destroy')"
+    ;; First registration fires
+    (let [seen-1 (atom [])]
+      (rf/register-trace-cb! ::r1 (fn [ev] (swap! seen-1 conj ev)))
+      (rf/reg-event-db :rf2-isdwf/reset-test
+                       {:sensitive? true}
+                       (fn [db _] db))
+      (rf/remove-trace-cb! ::r1)
+      (is (= 1 (count (filterv #(= :rf.warning/sensitive-without-redaction
+                                   (:operation %))
+                               @seen-1)))))
+    ;; Destroy the default frame
+    (frame/destroy-frame! :rf/default)
+    ;; Re-establish frame
+    (rf/init! plain-atom/adapter)
+    ;; Re-register; the cache was cleared so the warning re-fires
+    (let [seen-2 (atom [])]
+      (rf/register-trace-cb! ::r2 (fn [ev] (swap! seen-2 conj ev)))
+      (rf/reg-event-db :rf2-isdwf/reset-test
+                       {:sensitive? true}
+                       (fn [db _] db))
+      (rf/remove-trace-cb! ::r2)
+      (is (= 1 (count (filterv #(= :rf.warning/sensitive-without-redaction
+                                   (:operation %))
+                               @seen-2)))
+          "warning fires again after frame destroy"))))
+
+;; ---- trace-buffer filter -------------------------------------------------
+
+(deftest trace-buffer-sensitive-filter
+  (testing "(rf/trace-buffer {:sensitive? false}) excludes sensitive
+   events; (rf/trace-buffer {:sensitive? true}) selects only sensitive
+   events. Absent constraint -> all events. Per Spec 009 §Filter
+   vocabulary"
+    (rf/clear-trace-buffer!)
+    (rf/configure :trace-buffer {:depth 100})
+    (rf/reg-event-db :rf2-isdwf/buf-sens
+                     {:sensitive? true :no-redaction-needed? true}
+                     (fn [db _] db))
+    (rf/reg-event-db :rf2-isdwf/buf-plain
+                     (fn [db _] db))
+    (rf/dispatch-sync [:rf2-isdwf/buf-sens])
+    (rf/dispatch-sync [:rf2-isdwf/buf-plain])
+    (let [all   (rf/trace-buffer)
+          sens  (rf/trace-buffer {:sensitive? true})
+          plain (rf/trace-buffer {:sensitive? false})]
+      (is (pos? (count sens)))
+      (is (pos? (count plain)))
+      (is (= (count all) (+ (count sens) (count plain)))
+          "the two partitions sum to the total")
+      (doseq [ev sens]
+        (is (true? (:sensitive? ev))
+            "{:sensitive? true} returns only sensitive events"))
+      (doseq [ev plain]
+        (is (not (true? (:sensitive? ev)))
+            "{:sensitive? false} returns only non-sensitive events")))))
+
+;; ---- public sensitive? predicate -----------------------------------------
+
+(deftest sensitive-predicate
+  (testing "rf/sensitive? returns true on top-level-stamped events,
+   false otherwise — replaces the per-consumer private helper (rf2-isdwf
+   audit G5)"
+    (is (true?  (rf/sensitive? {:sensitive? true})))
+    (is (false? (rf/sensitive? {:sensitive? false})))
+    (is (false? (rf/sensitive? {})))
+    (is (false? (rf/sensitive? nil)))
+    (is (false? (rf/sensitive? "not a map")))
+    (is (false? (rf/sensitive? {:tags {:sensitive? true}}))
+        "nested :sensitive? inside :tags does NOT count — only the
+         top-level field per Spec 009 line 1175")))
+
+;; ---- composition with wire-elision walker --------------------------------
+
+(deftest walker-composition
+  (testing "When the elision walker traverses a value with a sensitive
+   path, it substitutes :rf/redacted. The walker's predicate reads
+   :sensitive? from the elision registry; this test feeds the registry
+   directly (rf2-isdwf is upstream of the runtime stamp, not the walker
+   predicate — they compose orthogonally)"
+    ;; Declare a path as sensitive in the elision registry.
+    (elision/declare-large-path! [:secrets :password])
+    ;; Use raw write to set :sensitive? on the declaration.
+    (let [container (frame/get-frame-db :rf/default)
+          db (re-frame.substrate.adapter/read-container container)]
+      (re-frame.substrate.adapter/replace-container!
+        container
+        (assoc-in db [:rf/elision :declarations [:secrets :password]]
+                  {:sensitive? true :source :declared})))
+    (let [val   {:secrets {:password "p" :hint "h"}}
+          ;; Walker uses default include-sensitive? false; produces sentinel
+          walked (rf/elide-wire-value val {:frame :rf/default})]
+      (is (= :rf/redacted (get-in walked [:secrets :password]))
+          "walker substitutes :rf/redacted on the sensitive path"))))
+
+;; ---- multi-handler stress test -------------------------------------------
+
+(deftest stamp-rides-every-emit-in-scope
+  (testing "Per Spec 009 line 1175 — the stamp MUST appear on every trace
+   event emitted within the sensitive handler's scope. Exercise the
+   :event/dispatched, :event :phase :run-start, :event/db-changed,
+   :rf.fx/handled, :event :phase :run-end."
+    (rf/reg-fx :rf2-isdwf/test-fx (fn [_ _] :ok))
+    (rf/reg-event-fx :rf2-isdwf/all-emits
+                     {:sensitive? true :no-redaction-needed? true}
+                     (fn [{:keys [db]} _]
+                       {:db (assoc db :ran? true)
+                        :fx [[:rf2-isdwf/test-fx {}]]}))
+    (let [evs (record-traces
+                #(rf/dispatch-sync [:rf2-isdwf/all-emits]))
+          op-types (->> evs
+                        (map (juxt :operation :sensitive?))
+                        set)]
+      ;; Every operation type from this cascade should have a sensitive entry
+      (doseq [op #{:event/dispatched :event :event/db-changed
+                   :event/do-fx}]
+        (is (some (fn [[o s]] (and (= o op) (true? s))) op-types)
+            (str op " carries top-level :sensitive? true"))))))


### PR DESCRIPTION
## Summary

The privacy no-op fix. Per Spec 009 §Privacy / sensitive data in traces (lines 1149-1268), every trace event emitted within the scope of a handler whose registration carries `:sensitive? true` MUST be stamped `:sensitive? true` at the top level. Per rf2-ok47g's audit, this stamping logic was never implemented in `implementation/core/src/` — every consumer (Causa panel, Story, pair2 preload, three MCP servers — PRs #628, #631, #632, #636) had wired against a future-shaped event; their default-drop filters were no-ops today.

This PR lights up the machinery end-to-end.

## Mechanism

### Registration capture

`:sensitive?` on the registration metadata-map is already preserved on the registry slot via `source-coords/merge-coords meta` — no registrar change needed.

### Trace-emit stamping

- New dynamic Var `re-frame.trace/*current-sensitive?*`, mirror of `*current-trigger-handler*`, bound alongside it at every handler-scope binding site (`router.cljc` `process-event*`, `fx.cljc` fx dispatcher, `cofx.cljc` injector, `subs.cljc` sub recompute, `views.cljs` view render).
- `emit!` and `emit-error!` read the Var and hoist `:sensitive? true` to the trace event's TOP LEVEL (not under `:tags`). Caller-supplied `:sensitive?` in tags wins (the queue-time `:event/dispatched` emit consults the handler-meta directly via `registrar/lookup`).
- Cascade composition: innermost in-scope handler's reading wins (Spec 009 line 1177); the runtime does NOT transitively widen across handler boundaries.

### `with-redacted` interceptor

New positional interceptor `(rf/with-redacted [[:password] [:totp-code]])` scrubs named paths in the event payload BEFORE downstream in-chain emits see the event. The handler body still sees the unredacted payload via the regular `:event` cofx slot.

- Per Spec 009 lines 1225-1227, `:event/db-changed :tags :event` and `:rf.error/handler-exception :tags :event` consult the interceptor's stashed `:rf/redacted-event` on the context and emit the scrubbed form.
- Composes with `:sensitive?`: handlers carrying both emit trace events that are BOTH stamped `:sensitive? true` AND carry redacted payloads.

### Registration-time warning

`:rf.warning/sensitive-without-redaction` fires once per (kind, id) pair when a `reg-event-*` registers with `:sensitive? true`, no `with-redacted` in the positional chain, and no `:no-redaction-needed?` true opt-out on the meta. Suppression cache resets on `destroy-frame!` via the new late-bind hook `:privacy/clear-suppression-cache!`.

## Walker integration

The `re-frame.elision/elide-wire-value` walker (landed via PR #668 / rf2-v9tw2) already reads `:sensitive?` from per-path registry declarations and emits `:rf/redacted` with sensitive-drop-wins composition for size-and-sensitive paths. **No walker change is needed for this bead.** The runtime stamp is the SOURCE side; the walker is the WIRE side; they compose orthogonally.

Walker integration is verified by the new `walker-composition` test, which sets a sensitive declaration in the elision registry, feeds a value through `rf/elide-wire-value`, and asserts the `:rf/redacted` substitution.

## Public surface (re-exported from `re-frame.core`)

- `rf/with-redacted`     — interceptor builder
- `rf/sensitive?`        — predicate over a trace event's top-level `:sensitive?` field; replaces the per-consumer private helper (rf2-isdwf audit G5)
- `(rf/trace-buffer {:sensitive? false})` — new filter axis per Spec 009 §Filter vocabulary line 1245

## Tests

25 new deftests / 81 assertions in `implementation/core/test/re_frame/sensitive_stamping_test.clj`:

- Plain handler -> no `:sensitive?` flag
- Sensitive handler -> `:sensitive? true` at TOP level (not under `:tags`)
- `:event/dispatched` stamped at queue-time via meta lookup
- Unknown handler -> field omitted
- fx and cofx innermost-wins composition (4 test cases)
- Sub recompute scope
- `:rf.error/handler-exception` carries the flag
- `with-redacted` scrubs `:event/db-changed`, scrubs error-event payload, composes with `:sensitive?`, multi-path, non-payload event shape no-op
- Registration warning: once-per-pair, opt-out via `:no-redaction-needed?`, no-warning for non-sensitive, no-warning when `with-redacted` present, cache resets on frame destroy
- Trace-buffer `:sensitive?` filter (true / false / absent)
- Public `sensitive?` predicate covering top-level vs nested-tags
- Walker composition

## Suite totals

| Gate | Before | After |
|---|---|---|
| `clojure -M:test` from `implementation/core/` | 387 tests / 2092 assertions / 0 fail | 412 tests / 2182 assertions / 0 fail |
| `npm run test:cljs` from `implementation/` | 1688 tests / 4677 assertions / 0 fail | 1688 tests / 4677 assertions / 0 fail |

## Does the privacy posture now actually fire?

Yes. A sensitive handler's dispatch now produces trace events that the four already-landed consumer PRs (Causa, Story, pair2-mcp, story-mcp) can filter on. The end-to-end gate is exercised by `sensitive-handler-top-level-stamp` and `stamp-rides-every-emit-in-scope`: every operation type from a sensitive cascade (`:event/dispatched`, `:event`, `:event/db-changed`, `:event/do-fx`) lands with `:sensitive? true` at the top level.

## Test plan

- [x] JVM unit tests pass
- [x] Node CLJS tests pass
- [x] late-bind drift gate passes
- [ ] Consumer regression: rerun pair2-mcp / story-mcp / Causa with a sensitive handler in the example app; default-drop should drop, opt-in `:include-sensitive? true` should pass through.