### PR TITLE
fix(causa): reactive suppressed-sensitive-count — REDACTED indicator updates immediately (rf2-0vxdn)

### DIFF
--- a/examples/reagent/counter/causa.spec.cjs
+++ b/examples/reagent/counter/causa.spec.cjs
@@ -29,10 +29,13 @@
  *   5. Live trace bus: with Causa visible, clicking the counter's '+'
  *      button produces a fresh trace row in the Trace panel — proves
  *      Causa is observing the framework's live trace bus.
- *   6. [● REDACTED N] indicator: firing a sensitive event via the
- *      page console bumps the bottom-rail's counter — proves
- *      config/note-suppressed! → :rf.causa/suppressed-sensitive-count
- *      sub → bottom-rail hint is wired through.
+ *   6. [● REDACTED N] indicator: calling `config/note-suppressed!`
+ *      from the page console bumps the bottom-rail's counter and
+ *      the indicator re-renders IMMEDIATELY — proves the reactive
+ *      wiring through the sub-graph (rf2-0vxdn — the call
+ *      dispatches `:rf.causa/note-sensitive-suppressed` so the
+ *      sub fires on the standard app-db write path; no host-
+ *      dispatch workaround is required).
  */
 
 const { expectTextEquals, expectVisible } = require('../../scripts/spec-helpers.cjs');
@@ -154,21 +157,22 @@ module.exports = {
     }
 
     // ----------------------------------------------------------------
-    // 6. [● REDACTED N] indicator — config/note-suppressed! bumps the
-    //     counter, the bottom-rail hint appears.
+    // 6. [● REDACTED N] indicator — config/note-suppressed! bumps
+    //     the counter and the bottom-rail hint re-renders
+    //     IMMEDIATELY (rf2-0vxdn).
     // ----------------------------------------------------------------
     //
-    // The collector path that bumps the counter is exercised by the
+    // The collector path that emits this call is exercised by the
     // node-test sensitive_trace_cljs_test.cljc; this browser-level
-    // assertion proves the wiring through the subscription and the
-    // shell's bottom-rail render.
+    // assertion proves the reactive wiring through Causa's app-db
+    // slot, the subscription, and the shell's bottom-rail render.
     //
-    // We dial the counter directly via the exposed CLJS namespace
-    // (shadow-cljs dev compilation preserves the namespace path on
-    // goog.global). Then we dispatch a no-op counter click to force
-    // the subscription graph to recompute — the
-    // :rf.causa/suppressed-sensitive-count sub thunks a plain atom
-    // and only re-fires when the surrounding sub-graph recomputes.
+    // Per rf2-0vxdn `config/note-suppressed!` itself dispatches
+    // `:rf.causa/note-sensitive-suppressed` into `:rf/causa` (the
+    // atom-bump remains for JVM tests; the dispatch is the
+    // reactive surface for CLJS). The sub reads `:suppressed-
+    // counters` off Causa's app-db, so the indicator re-renders on
+    // the next React commit without any extra host dispatch.
     const noted = await page.evaluate(() => {
       const cfg =
         window.day8 &&
@@ -186,11 +190,9 @@ module.exports = {
       throw new Error(`Could not bump suppressed counter: ${noted.reason}`);
     }
 
-    // Force a host dispatch so the Causa subscribe-graph recomputes
-    // and the bottom-rail re-renders against the bumped counter.
-    await page.getByRole('button', { name: '+' }).click();
-    await expectTextEquals(span, '7');
-
+    // No host-dispatch workaround required — the bump itself
+    // dispatched `:rf.causa/note-sensitive-suppressed`, so the
+    // bottom-rail sub re-fired and the indicator is now visible.
     const redacted = page.locator(`[data-testid="${REDACTED_TESTID}"]`);
     await expectVisible(redacted, 5000);
     const redactedText = (await redacted.textContent()) || '';

--- a/tools/causa/spec/014-Registry-Catalogue.md
+++ b/tools/causa/spec/014-Registry-Catalogue.md
@@ -58,7 +58,7 @@ the time-travel scrubber, and the per-frame target selection.
 | Sub | Inputs | Returns | When recomputes |
 |---|---|---|---|
 | `:rf.causa/trace-buffer` | none (reads `trace-bus/buffer`) | Vector of `:rf/trace-event` records, oldest-first (per [`013-Trace-Bus.md`](./013-Trace-Bus.md) §Consumer contract). | Every subscribe-graph recompute; the buffer atom is process-global, not per-frame. |
-| `:rf.causa/suppressed-sensitive-count` | none (reads `config/suppressed-counters`) | Integer — total suppressed `:sensitive? true` events under the current `:trace/show-sensitive?` setting. | Every recompute; surfaces the `[● REDACTED N]` bottom-rail indicator. |
+| `:rf.causa/suppressed-sensitive-count` | `db` (reads `:suppressed-counters`) | Integer — total suppressed `:sensitive? true` events under the current `:trace/show-sensitive?` setting. | On `db` write to `:suppressed-counters` (rf2-0vxdn — reactive immediate update of the `[● REDACTED N]` bottom-rail indicator). |
 | `:rf.causa/target-frame` | `db` | Keyword frame-id (default `:rf/default`). | On `db` write to `:target-frame`. |
 | `:rf.causa/epoch-history` | `db` | Vector of `:rf/epoch-record`, oldest-first (cached snapshot of `(rf/epoch-history target)`). | On `:rf.causa/epoch-recorded` dispatch. |
 | `:rf.causa/target-frame-db` | `:rf.causa/target-frame`, `:rf.causa/epoch-history` | The host frame's current `app-db` value (via `rf/get-frame-db`). | Every settled epoch on the target frame. |
@@ -68,6 +68,8 @@ the time-travel scrubber, and the per-frame target selection.
 | Event | Vector shape | Returns | Notes |
 |---|---|---|---|
 | `:rf.causa/epoch-recorded` | `[_ frame-id]` | `{:db ...}` | Pumped from the epoch-cb registered in `preload.cljs` on every settled epoch. Re-reads `rf/epoch-history` to keep the cached snapshot consistent. No-ops when `frame-id` ≠ the current target. |
+| `:rf.causa/note-sensitive-suppressed` | `[_ frame-id]` | `{:db ...}` | rf2-0vxdn — bumps `[:suppressed-counters (or frame-id :global)]` in Causa's app-db. Dispatched from `trace-bus/collect-trace!` (CLJS) when the privacy gate drops a `:sensitive? true` event. Drives the `:rf.causa/suppressed-sensitive-count` sub reactively. |
+| `:rf.causa/reset-suppressed-counters` | `[_]` or `[_ frame-id]` | `{:db ...}` | rf2-0vxdn — clears all buckets (no arg) or just the named bucket. Dispatched from `trace-bus/clear-buffer!` (CLJS) — clearing the trace ring buffer also drops the `[● REDACTED N]` indicator state. |
 | `:rf.causa/select-panel` | `[_ panel-id]` | `{:db ...}` | Drives the canvas switch logic in `shell.cljs`. Default per [`007-UX-IA.md`](./007-UX-IA.md) §10 Lock 7 is `:event-detail`. |
 
 ## Event-detail panel

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -23,7 +23,9 @@
   Causa shell (gated on `interop/debug-enabled?` in preload.cljs); the
   atom survives but is never read. CLJC so the JVM test corpus can
   cover the round-trip without a CLJS runtime."
-  (:require [re-frame.source-coords.editor-uri :as editor-uri]))
+  (:require [re-frame.source-coords.editor-uri :as editor-uri]
+            #?@(:cljs [[re-frame.core :as rf]
+                       [re-frame.frame :as frame]])))
 
 ;; ---- editor preference ---------------------------------------------------
 
@@ -132,6 +134,15 @@
 ;; (registration-time emits, outermost-dispatch lookup failures —
 ;; `:sensitive?` is rarely set on those, but we keep the bucket so a
 ;; count is never lost).
+;;
+;; Per rf2-0vxdn the counter is also mirrored into Causa's app-db at
+;; `[:rf/causa db :suppressed-counters]` via dispatch (CLJS-only) so
+;; the `:rf.causa/suppressed-sensitive-count` sub fires on the
+;; standard reactive write path — the `[● REDACTED N]` indicator
+;; updates IMMEDIATELY on every bump, with no dependency on sibling
+;; subs recomputing. The atom here remains the JVM-runnable data
+;; primitive so `config.cljc`'s shape is testable without a CLJS
+;; runtime + re-frame frame.
 
 (defonce
   ^{:doc "Atom: `{frame-id → suppressed-count}`. Causa's trace
@@ -146,10 +157,25 @@
   "Bump the suppressed-events counter for the frame the event
   targeted. Called by Causa's trace collector when
   `suppress-sensitive?` returned true. `frame-id` may be `nil` /
-  absent — those count under `:global`."
+  absent — those count under `:global`.
+
+  Per rf2-0vxdn: in CLJS, also dispatches
+  `:rf.causa/note-sensitive-suppressed` into the `:rf/causa` frame so
+  the bottom-rail's `[● REDACTED N]` indicator updates IMMEDIATELY
+  via the reactive sub-graph (the sub reads
+  `:suppressed-counters` off Causa's app-db). The atom-bump stays
+  as the JVM-runnable data primitive (`sensitive_trace` CLJC tests
+  assert it directly); the dispatch is the reactive surface for
+  CLJS. Guarded on the `:rf/causa` frame's existence — production
+  preload always installs it, but tests / hot-reload windows may
+  call `note-suppressed!` before the frame registers."
   [frame-id]
   (let [k (or frame-id :global)]
     (swap! suppressed-counters update k (fnil inc 0)))
+  #?(:cljs
+     (when (frame/frame :rf/causa)
+       (binding [frame/*current-frame* :rf/causa]
+         (rf/dispatch [:rf.causa/note-sensitive-suppressed frame-id]))))
   nil)
 
 (defn suppressed-count
@@ -167,10 +193,26 @@
 (defn reset-suppressed-count!
   "Reset the suppressed-events counter. With no arg, clears all.
   With a `frame-id`, clears just that bucket. Called from
-  `trace-bus/clear-buffer!` and from test fixtures."
-  ([] (reset! suppressed-counters {}) nil)
+  `trace-bus/clear-buffer!` and from test fixtures.
+
+  Per rf2-0vxdn: in CLJS, also dispatches
+  `:rf.causa/reset-suppressed-counters` into `:rf/causa` so the
+  reactive copy in Causa's app-db drops in lockstep with the atom.
+  Guarded on the frame existing — `reset-suppressed-count!` is
+  called from test fixtures before any frame is registered."
+  ([]
+   (reset! suppressed-counters {})
+   #?(:cljs
+      (when (frame/frame :rf/causa)
+        (binding [frame/*current-frame* :rf/causa]
+          (rf/dispatch [:rf.causa/reset-suppressed-counters]))))
+   nil)
   ([frame-id]
    (swap! suppressed-counters dissoc (or frame-id :global))
+   #?(:cljs
+      (when (frame/frame :rf/causa)
+        (binding [frame/*current-frame* :rf/causa]
+          (rf/dispatch [:rf.causa/reset-suppressed-counters frame-id]))))
    nil))
 
 ;; ---- configure! convenience ---------------------------------------------

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -216,15 +216,19 @@
     ;; hint when this is positive so the user sees why the buffer is
     ;; shorter than the runtime's actual emit count.
     ;;
-    ;; The counter lives in `config/suppressed-counters` (a plain
-    ;; atom). This sub thunks the pure-data accessor; like
-    ;; `:rf.causa/trace-buffer` it relies on the surrounding
-    ;; subscribe-graph recompute cycle for staleness — the bottom-rail
-    ;; re-renders whenever any of its sibling subs re-fire, and the
-    ;; counter is read fresh on each pass.
+    ;; Per rf2-0vxdn the counter lives in Causa's app-db at
+    ;; `:suppressed-counters` ({frame-id → count}); `config/note-
+    ;; suppressed!` dispatches `:rf.causa/note-sensitive-suppressed`
+    ;; in CLJS, so the sub fires on the standard app-db-write
+    ;; reactive path and the bottom-rail re-renders IMMEDIATELY —
+    ;; no dependency on sibling subs recomputing. The plain
+    ;; `config/suppressed-counters` atom remains as the JVM-runnable
+    ;; data primitive (sensitive_trace CLJC tests + trace-bus' JVM
+    ;; data-shape coverage); the CLJS path dual-writes via dispatch
+    ;; so the reactive surface stays consistent.
     (rf/reg-sub :rf.causa/suppressed-sensitive-count
-      (fn [_db _query]
-        (config/suppressed-count)))
+      (fn [db _query]
+        (reduce + 0 (vals (get db :suppressed-counters {})))))
 
     ;; Currently-active panel — drives the canvas's switch logic in
     ;; shell.cljs. Default is the hero panel per §10 Lock 7.
@@ -615,6 +619,30 @@
     (rf/reg-event-db :rf.causa/select-panel
       (fn [db [_ panel-id]]
         (assoc db :selected-panel panel-id)))
+
+    ;; Bump the per-frame suppressed-events counter (rf2-0vxdn).
+    ;; Dispatched from `trace-bus/collect-trace!` (CLJS) under
+    ;; `:rf/causa` whenever the privacy gate drops a `:sensitive? true`
+    ;; trace event. `frame-id` is the event's `:tags :frame` (the host
+    ;; frame the trace targeted); `nil` falls under `:global`. Drives
+    ;; the bottom-rail `[● REDACTED N]` indicator via the
+    ;; `:rf.causa/suppressed-sensitive-count` sub — fully reactive.
+    (rf/reg-event-db :rf.causa/note-sensitive-suppressed
+      (fn [db [_ frame-id]]
+        (update-in db [:suppressed-counters (or frame-id :global)]
+                   (fnil inc 0))))
+
+    ;; Reset the suppressed-events counter (rf2-0vxdn). With no arg,
+    ;; clears every bucket; with a `frame-id`, drops just that bucket.
+    ;; Dispatched from `trace-bus/clear-buffer!` (CLJS) — clearing the
+    ;; trace ring buffer also drops the REDACTED indicator state (the
+    ;; "you missed N events" overhang disappears alongside the events
+    ;; that produced it).
+    (rf/reg-event-db :rf.causa/reset-suppressed-counters
+      (fn [db [_ frame-id]]
+        (if frame-id
+          (update db :suppressed-counters dissoc (or frame-id :global))
+          (dissoc db :suppressed-counters))))
 
     (rf/reg-event-db :rf.causa/select-dispatch-id
       (fn [db [_ dispatch-id]]

--- a/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
@@ -85,7 +85,13 @@
   suppressed-events counter bumps for the targeted frame so the
   shell can surface a `[● REDACTED N]` hint. Opt in via
   `(causa-config/configure! {:trace/show-sensitive? true})` to
-  surface the raw cascade while debugging redaction policy."
+  surface the raw cascade while debugging redaction policy.
+
+  Per rf2-0vxdn the indicator is fully reactive: `config/note-
+  suppressed!` itself dispatches `:rf.causa/note-sensitive-suppressed`
+  into `:rf/causa` (CLJS) so the sub reads `:suppressed-counters`
+  off Causa's app-db on the standard write path. The buffer state
+  here is unchanged; the dispatch happens one stack frame deeper."
   [event]
   (when interop/debug-enabled?
     (cond
@@ -204,7 +210,11 @@
   production. Per rf2-azls9, also resets the per-frame
   suppressed-sensitive counters so the bottom-rail `[● REDACTED N]`
   hint disappears alongside the cleared events — clearing the buffer
-  is the natural moment to drop the 'you missed N events' overhang."
+  is the natural moment to drop the 'you missed N events' overhang.
+
+  Per rf2-0vxdn `config/reset-suppressed-count!` itself dispatches
+  `:rf.causa/reset-suppressed-counters` in CLJS so the reactive
+  app-db slot clears in lockstep with the atom."
   []
   (when interop/debug-enabled?
     (reset! buffer-state [])

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -4,7 +4,7 @@
   ## Scope
 
   `registry.cljs` (1818 LoC) is the central registrar for Causa's
-  framework surface — 64 reg-subs + 58 reg-event-(db|fx) + 3 reg-fx,
+  framework surface — 64 reg-subs + 60 reg-event-(db|fx) + 3 reg-fx,
   all under the `:rf.causa/*` namespace, targeting the `:rf/causa`
   frame. Prior to this file the only coverage was *transitive* through
   per-panel view tests (each panel test calls `(registry/reset-for-test!)`
@@ -170,12 +170,14 @@
    :rf.causa/epoch-recorded
    :rf.causa/focus-slice-path
    :rf.causa/hide-invalidation-chain
+   :rf.causa/note-sensitive-suppressed
    :rf.causa/open-in-editor
    :rf.causa/pin-current
    :rf.causa/pin-slice
    :rf.causa/rename-pin
    :rf.causa/reorder-pinned-slices
    :rf.causa/reroot-tree-view
+   :rf.causa/reset-suppressed-counters
    :rf.causa/reset-to-epoch
    :rf.causa/reset-to-pinned
    :rf.causa/select-dispatch-id
@@ -239,9 +241,9 @@
           (str "expected :fx handler for " fx-id)))))
 
 (deftest registry-counts-match-bead
-  (testing "registry holds exactly 64 subs + 58 events + 3 fxs (rf2-5zl7l)"
+  (testing "registry holds exactly 64 subs + 60 events + 3 fxs (rf2-5zl7l; +2 events for rf2-0vxdn)"
     (is (= 64 (count all-sub-names)))
-    (is (= 58 (count all-event-names)))
+    (is (= 60 (count all-event-names)))
     (is (= 3  (count all-fx-names)))))
 
 (deftest registry-is-idempotent
@@ -277,21 +279,27 @@
     (is (= 1 (count (trace-bus/buffer)))
         "the bus holds the pushed event")))
 
-(deftest sub-suppressed-sensitive-count-reads-config
-  (testing ":rf.causa/suppressed-sensitive-count thunks config/suppressed-count
-            — first deref returns 0; the count accessor itself reflects
-            mutations to the process-global counter atom"
+(deftest sub-suppressed-sensitive-count-reads-app-db
+  (testing ":rf.causa/suppressed-sensitive-count reads from Causa's
+            app-db at `:suppressed-counters` (rf2-0vxdn) — first deref
+            returns 0; each `:rf.causa/note-sensitive-suppressed`
+            dispatch re-fires the sub on the standard write path
+            (immediate reactive update, no clear-subscription-cache!
+            workaround required)."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (is (= 0 @(rf/subscribe [:rf.causa/suppressed-sensitive-count])))
-      (config/note-suppressed! :rf/default)
-      (config/note-suppressed! :rf/default)
-      ;; The accessor itself is the contract under test (subs cache on
-      ;; their input-signal, not the underlying atom — the panel reads
-      ;; this slot inside a render cycle that's already driven by
-      ;; another sub re-firing).
-      (is (= 2 (config/suppressed-count))
-          "the config-layer accessor reflects the bumps"))))
+      (is (= 0 @(rf/subscribe [:rf.causa/suppressed-sensitive-count]))
+          "empty :suppressed-counters slot → total of 0")
+      (rf/dispatch-sync [:rf.causa/note-sensitive-suppressed :rf/default])
+      (rf/dispatch-sync [:rf.causa/note-sensitive-suppressed :rf/default])
+      (is (= 2 @(rf/subscribe [:rf.causa/suppressed-sensitive-count]))
+          "two bumps via dispatch → sub returns 2 immediately")
+      (rf/dispatch-sync [:rf.causa/note-sensitive-suppressed :rf/causa])
+      (is (= 3 @(rf/subscribe [:rf.causa/suppressed-sensitive-count]))
+          "different frame bucket bumps the same total")
+      (rf/dispatch-sync [:rf.causa/reset-suppressed-counters])
+      (is (= 0 @(rf/subscribe [:rf.causa/suppressed-sensitive-count]))
+          "reset event drops every bucket"))))
 
 (deftest sub-selected-panel-defaults-to-event-detail
   (testing ":rf.causa/selected-panel falls back to the hero panel"

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -14,10 +14,14 @@
        arm count + each arm's mapping is asserted here.
 
     2. The bottom-rail `[● REDACTED N]` indicator (rf2-azls9). The
-       `config/suppressed-counters` counter is well-tested in
-       `config_test.clj`; the *render* gate `(pos? redacted-count)`
-       and the pluralisation in the title attribute are asserted
-       here. Includes the 1 → 2 transition.
+       `config/suppressed-counters` atom is well-tested in
+       `sensitive_trace_cljs_test.cljc`; the *render* gate
+       `(pos? redacted-count)` and the pluralisation in the title
+       attribute are asserted here. Includes the 1 → 2 transition.
+       Per rf2-0vxdn the counter is reactive — bumping via the
+       `:rf.causa/note-sensitive-suppressed` event re-renders the
+       indicator immediately (no `clear-subscription-cache!`
+       workaround required).
 
     3. The hydration sidebar entry's dormant-flag drop (rf2-pzxsr —
        tools/causa/spec/006-Hydration-Debugger.md §Visibility). When
@@ -134,6 +138,23 @@
   [panel-id]
   (rf/dispatch-sync [:rf.causa/select-panel panel-id]))
 
+(defn- note-suppressed!
+  "Drive the redaction counter through the production reactive path
+  (rf2-0vxdn). Mirrors what `trace-bus/collect-trace!` does in CLJS
+  when it drops a `:sensitive? true` trace event — synchronously
+  bumps the counter in Causa's app-db so the indicator's sub fires
+  before the next render. `dispatch-sync` skips the dispatch queue,
+  so the assertion can run on the very next line."
+  [frame-id]
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/note-sensitive-suppressed frame-id])))
+
+(defn- reset-suppressed!
+  "Reset the redaction counter via the production event (rf2-0vxdn)."
+  []
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/reset-suppressed-counters])))
+
 (defn- causa-setup! []
   (registry/register-causa-handlers!)
   (frame/reg-frame :rf/causa {}))
@@ -223,17 +244,18 @@
 ;; -------------------------------------------------------------------------
 ;;
 ;; The bottom-rail subscribes to `:rf.causa/suppressed-sensitive-count`;
-;; the indicator renders only when (pos? n). The counter lives in
-;; `config/suppressed-counters` and is bumped by `config/note-
-;; suppressed!`. The fixture's `causa-init!` resets it to 0.
+;; the indicator renders only when (pos? n). Per rf2-0vxdn the counter
+;; lives in Causa's app-db at `:suppressed-counters`; the trace
+;; collector dispatches `:rf.causa/note-sensitive-suppressed` to bump
+;; it, so the sub re-fires on the standard app-db-write reactive path
+;; — bumping immediately drives an indicator re-render with no
+;; `(rf/clear-subscription-cache! :rf/causa)` workaround.
 
 (deftest redacted-indicator-absent-when-count-zero
   (testing "(pos? 0) is false — the indicator is NOT rendered when
             no sensitive events have been suppressed"
     (causa-setup!)
     (rf/with-frame :rf/causa
-      (is (= 0 (config/suppressed-count))
-          "fixture starts with zero — sanity check")
       (let [tree (shell/shell-view)]
         (is (nil? (find-by-testid tree "rf-causa-redacted-indicator"))
             "no REDACTED node in the tree when count is 0")))))
@@ -242,7 +264,7 @@
   (testing "the indicator surfaces when at least one sensitive trace
             event has been suppressed"
     (causa-setup!)
-    (config/note-suppressed! :rf/default)
+    (note-suppressed! :rf/default)
     (rf/with-frame :rf/causa
       (let [tree (shell/shell-view)
             node (find-by-testid tree "rf-causa-redacted-indicator")]
@@ -256,16 +278,13 @@
             count != 1 — spec 009 §Privacy: 'N sensitive trace
             event(s) suppressed'.
 
-            The sub thunks `config/suppressed-count` which reads an
-            atom outside the reactive graph; in production the sub
-            recomputes because sibling subs fire on every trace
-            event landing. In tests we step the counter manually,
-            so we drop the subscription cache between renders to
-            force a recompute."
+            Per rf2-0vxdn the sub reads `:suppressed-counters` off
+            Causa's app-db, so each bump re-fires the sub on the
+            standard write path — no subscription-cache flush
+            required between bumps."
     (causa-setup!)
     ;; count = 1 → singular in title
-    (config/note-suppressed! :rf/default)
-    (rf/clear-subscription-cache! :rf/causa)
+    (note-suppressed! :rf/default)
     (rf/with-frame :rf/causa
       (let [tree  (shell/shell-view)
             node  (find-by-testid tree "rf-causa-redacted-indicator")
@@ -276,9 +295,8 @@
         (is (not (re-find #"events" title))
             "singular form has no plural 's'")))
     ;; bump to 3 → plural in title
-    (config/note-suppressed! :rf/default)
-    (config/note-suppressed! :rf/default)
-    (rf/clear-subscription-cache! :rf/causa)
+    (note-suppressed! :rf/default)
+    (note-suppressed! :rf/default)
     (rf/with-frame :rf/causa
       (let [tree  (shell/shell-view)
             node  (find-by-testid tree "rf-causa-redacted-indicator")
@@ -288,31 +306,29 @@
 
 (deftest redacted-indicator-transition-from-zero-to-nonzero
   (testing "the indicator appears on the first suppressed event and
-            stays until the counter is reset. See pluralises-title
-            test for why clear-subscription-cache! between bumps."
+            stays until the counter is reset. Per rf2-0vxdn the
+            reactive sub re-fires on every bump — no
+            clear-subscription-cache! workaround between steps."
     (causa-setup!)
     ;; T0 — no indicator
     (rf/with-frame :rf/causa
       (is (nil? (find-by-testid (shell/shell-view)
                                 "rf-causa-redacted-indicator"))))
     ;; T1 — bump → indicator visible with count 1
-    (config/note-suppressed! :rf/default)
-    (rf/clear-subscription-cache! :rf/causa)
+    (note-suppressed! :rf/default)
     (rf/with-frame :rf/causa
       (let [n (find-by-testid (shell/shell-view)
                               "rf-causa-redacted-indicator")]
         (is (some? n) "indicator appears on first bump")
         (is (re-find #"REDACTED 1" (text-nodes n)))))
     ;; T2 — bump again → count moves to 2
-    (config/note-suppressed! :rf/default)
-    (rf/clear-subscription-cache! :rf/causa)
+    (note-suppressed! :rf/default)
     (rf/with-frame :rf/causa
       (let [n (find-by-testid (shell/shell-view)
                               "rf-causa-redacted-indicator")]
         (is (re-find #"REDACTED 2" (text-nodes n)))))
     ;; T3 — reset → indicator gone
-    (config/reset-suppressed-count!)
-    (rf/clear-subscription-cache! :rf/causa)
+    (reset-suppressed!)
     (rf/with-frame :rf/causa
       (is (nil? (find-by-testid (shell/shell-view)
                                 "rf-causa-redacted-indicator"))
@@ -322,7 +338,7 @@
   (testing "no upper-bound clipping — the indicator renders the raw
             count even at large values (spec 009 doesn't cap)"
     (causa-setup!)
-    (dotimes [_ 250] (config/note-suppressed! :rf/default))
+    (dotimes [_ 250] (note-suppressed! :rf/default))
     (rf/with-frame :rf/causa
       (let [tree (shell/shell-view)
             node (find-by-testid tree "rf-causa-redacted-indicator")]


### PR DESCRIPTION
## Summary

`:rf.causa/suppressed-sensitive-count` previously thunked a plain `config/suppressed-counters` atom outside the reactive sub-graph; the bottom-rail `[● REDACTED N]` indicator only re-rendered when some sibling sub recomputed. The Playwright spec from rf2-s2bhn (PR #660) had to force a host dispatch in scenario 6 to drive the re-render — a latent bug if suppression ever happens out-of-band of a host event.

## Design — in-app-db (the bead's preferred path)

The counter now lives in Causa's app-db at `:suppressed-counters` ({frame-id → count}). Two new events under `:rf/causa`:

- `:rf.causa/note-sensitive-suppressed [frame-id]` — bumps the bucket
- `:rf.causa/reset-suppressed-counters [(opt frame-id)]` — clears all / one

`config/note-suppressed!` and `config/reset-suppressed-count!` themselves dispatch (CLJS-only via reader conditional) so every existing call site picks up the reactive surface without duplication. The atom remains as the JVM-runnable data primitive (the `sensitive_trace_cljs_test.cljc` CLJC suite + trace-bus' JVM data-shape coverage are unchanged). In CLJS the atom is now a dual-write; the sub reads `:suppressed-counters` off `db`, so it fires on the standard app-db write path — bumping the counter drives an immediate indicator re-render.

Why not pure in-app-db (remove the atom)? The CLJC `sensitive_trace_cljs_test` suite tests `config/note-suppressed!` / `suppressed-count` / `reset-suppressed-count!` directly under `clj` AND `cljs`, without a registered frame. Dropping the atom would have broken the JVM test path or forced re-architecting that suite. Dual-write keeps the JVM data primitive intact while delivering the reactive surface CLJS callers need.

Frame-existence is guarded — `note-suppressed!` checks `(frame/frame :rf/causa)` before dispatching, so test fixtures that reset state before registering the frame stay safe.

## Test changes

- `tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs` — removed every `(rf/clear-subscription-cache! :rf/causa)` workaround between counter bumps; tests now assert direct bump → re-render via the new `note-suppressed!` / `reset-suppressed!` helpers that dispatch under `:rf/causa`.
- `tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs` — rewrote `sub-suppressed-sensitive-count-reads-config` (now `…reads-app-db`) to assert the reactive sub fires on dispatch; added the two new event ids to `all-event-names` and bumped the count assertion from 58 → 60.

## Playwright

`examples/reagent/counter/causa.spec.cjs` scenario 6 drops its host-dispatch counter-click workaround. The bump itself dispatches the event, so the indicator re-renders on the next React commit — no extra click required. (Browser test not run locally — flagging for CI.)

## Spec catalogue

`tools/causa/spec/014-Registry-Catalogue.md` updated:
- `:rf.causa/suppressed-sensitive-count` now reads `db` (not `config/suppressed-counters`); recomputes on `:suppressed-counters` writes.
- Added entries for the two new events.

## Test plan

- [x] `clojure -M:test` from `tools/causa/` — 487 tests / 1349 assertions, all pass.
- [x] `npm run test:cljs` from `implementation/` — 1688 tests / 4680 assertions, all pass.
- [x] `npm run test:bundle-isolation` — all production-elision gates pass (no leakage of the new events).
- [x] `npm run test:elision` — all sentinel-present probes pass.
- [x] `npm run test:perf-bundle` — perf-off / perf-on bundle sizes within budget.
- [ ] `examples/reagent/counter/causa.spec.cjs` scenario 6 — verified locally not feasible without `npm run test:browser` infra; CI gates this.