### PR TITLE
docs(skills/pair2): add story-mcp live-session tools (rf2-day7u / rf2-1v7tu HYBRID)

### DIFF
--- a/skills/re-frame-pair2/SKILL.md
+++ b/skills/re-frame-pair2/SKILL.md
@@ -25,6 +25,17 @@ allowed-tools:
   - mcp__re-frame-pair2__get-path
   - mcp__re-frame-pair2__subscribe
   - mcp__re-frame-pair2__unsubscribe
+  # story-mcp — live-session tools only (rf2-1v7tu HYBRID). The
+  # authoring-side surface (register-variant, get-variant,
+  # preview-variant, list-stories, …) is allow-listed by the
+  # `re-frame2` skill. These entries cover running a variant against
+  # the live runtime, inspecting failures, and capturing the cascade
+  # back into a `:play` snippet from within a pair-session.
+  - mcp__re-frame2-story-mcp__run-variant
+  - mcp__re-frame2-story-mcp__read-failures
+  - mcp__re-frame2-story-mcp__snapshot-identity
+  - mcp__re-frame2-story-mcp__run-a11y
+  - mcp__re-frame2-story-mcp__record-as-variant
   - Read
   - Edit
   - Write
@@ -127,6 +138,7 @@ Read the leaf that matches the task. Each reference file is ≤250 lines.
 |---|---|
 | Pick a structured op (read, write, trace, DOM bridge, watch, hot-reload, time-travel) | [references/ops.md](references/ops.md) |
 | Run a named procedure the user asked for ("why didn't my view update?", post-mortem, experiment loop, etc.) | [references/recipes.md](references/recipes.md) |
+| Drive a Story variant from a pair-session — variant-id ↔ frame-id identity, per-variant isolation, the four-phase lifecycle | [references/variant-as-frame.md](references/variant-as-frame.md) |
 | Open a push-mode subscription on the trace or epoch bus (topics, filters, termination) | [references/streaming-subscriptions.md](references/streaming-subscriptions.md) |
 | Translate a structured `{:ok? false :reason ...}` to plain English; suggest the recovery | [references/errors.md](references/errors.md) |
 | Inspect, propose, or hot-swap a frame's `:on-error` policy — the closed return-map contract | [references/on-error.md](references/on-error.md) |


### PR DESCRIPTION
## Summary

Per the rf2-1v7tu HYBRID decision, the `re-frame-pair2` skill owns the LIVE-SESSION side of `story-mcp`. This PR allow-lists the five live-driven story-mcp tools and slots the existing `variant-as-frame.md` reference into the loading-map.

## Tools added to `allowed-tools`

- `mcp__re-frame2-story-mcp__run-variant` (Testing — full lifecycle invocation against the live runtime)
- `mcp__re-frame2-story-mcp__read-failures` (Testing — read the variant's `:rf.story/assertions` accumulator without re-running)
- `mcp__re-frame2-story-mcp__snapshot-identity` (Testing — content hash for skip-unchanged / pixel-diff keying)
- `mcp__re-frame2-story-mcp__run-a11y` (Testing — axe-core against the live canvas)
- `mcp__re-frame2-story-mcp__record-as-variant` (Write — recorder → `gen-play-snippet`; the read-only path is ungated)

Authoring-side tools (`register-variant`, `unregister-variant`, `get-variant`, `preview-variant`, `list-stories`, `list-modes`, `list-tags`, `list-assertions`, `list-substrates`, `variant->edn`, `get-story`, `get-story-instructions`) stay with the `re-frame2` skill — that side lands in **rf2-5h6xr**.

## Loading-map

Added the `references/variant-as-frame.md` row (rf2-pxrhh PR #678) — drives an agent to that leaf when the user mentions a Story variant or workspace during a pair-session. The matching `stories.md` leaf lands later via **rf2-2owf3** (not touched here per scope guard).

## Drift check

```
$ python scripts/check_skill_mcp_drift.py --ci
EXIT=0
```

`--verbose` confirms `pair2-mcp <-> re-frame-pair2: server=10 tools, skill=10 allow-listed. No skill <-> MCP drift detected.` The `story-mcp <-> ...` mapping in `MAPPINGS` is still commented out in the script (pre-existing), so the new `mcp__re-frame2-story-mcp__*` entries are unchecked by the gate at this point — that mapping should be enabled in a follow-up once both skill sides land.

## Test plan

- [x] `python scripts/check_skill_mcp_drift.py --ci` exits 0
- [x] front-matter still parses (YAML list under `allowed-tools:` is well-formed)
- [x] `references/variant-as-frame.md` exists at the linked path (merged via rf2-pxrhh PR #678)

Refs: rf2-day7u, rf2-1v7tu (HYBRID decision), rf2-pxrhh (PR #678 — variant-as-frame leaf), rf2-5h6xr (authoring side), rf2-2owf3 (stories.md leaf).