### PR TITLE
docs(skills/re-frame2): add story-mcp authoring tools (rf2-5h6xr)

### DIFF
--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -7,6 +7,22 @@ allowed-tools:
   - Write
   - Grep
   - Glob
+  # story-mcp authoring-side tools (rf2-1v7tu HYBRID): re-frame2 owns the
+  # authoring loop (write/refine variant); re-frame-pair2 owns the run side
+  # (run-variant / read-failures / record-as-variant). Per
+  # tools/story-mcp/spec/002-Tool-Registry.md.
+  - mcp__re-frame2-story-mcp__get-story-instructions
+  - mcp__re-frame2-story-mcp__list-stories
+  - mcp__re-frame2-story-mcp__get-story
+  - mcp__re-frame2-story-mcp__get-variant
+  - mcp__re-frame2-story-mcp__variant->edn
+  - mcp__re-frame2-story-mcp__list-tags
+  - mcp__re-frame2-story-mcp__list-modes
+  - mcp__re-frame2-story-mcp__list-assertions
+  - mcp__re-frame2-story-mcp__list-substrates
+  - mcp__re-frame2-story-mcp__preview-variant
+  - mcp__re-frame2-story-mcp__register-variant
+  - mcp__re-frame2-story-mcp__unregister-variant
 ---
 
 # re-frame2


### PR DESCRIPTION
Per rf2-1v7tu HYBRID decision, `skills/re-frame2/` owns the **authoring** side of story-mcp; `skills/re-frame-pair2/` owns the **live-session / run** side (rf2-day7u, parallel).

## Tools added (12)

Drawn from the 17-tool catalogue in `tools/story-mcp/spec/002-Tool-Registry.md`:

- **Dev**: `get-story-instructions`, `preview-variant`, `list-substrates`
- **Docs**: `list-stories`, `get-story`, `get-variant`, `list-tags`, `list-modes`, `list-assertions`, `variant->edn`
- **Write** (gated): `register-variant`, `unregister-variant`

Run-side tools (`run-variant`, `snapshot-identity`, `run-a11y`, `read-failures`, `record-as-variant`) stay with `re-frame-pair2` per rf2-day7u (parallel).

## Loading-map

`reference/tooling/story-mcp-loop.md` already linked from the SKILL.md "Tooling" section (rf2-7iks3 / PR #634). No further loading-map edit needed.

## Drift check

```
$ python scripts/check_skill_mcp_drift.py --ci --verbose
pair2-mcp <-> re-frame-pair2: server=10 tools, skill=10 allow-listed.
causa-mcp <-> <tbd>: server src missing -- skipping (optional).
No skill <-> MCP drift detected.
EXIT=0
```

The story-mcp mapping in the drift script is still commented out (per its `NB:` note — landed once a consumer skill ships); enabling it is out of scope here and pairs with rf2-day7u completing the run-side allow-list.

## Test plan

- [x] `scripts/check_skill_mcp_drift.py --ci`: exit 0, zero warnings
- [x] Tool names verified against `tools/story-mcp/src/re_frame/story_mcp/tools.cljc` (17 `:name` entries)
- [x] Host prefix `re-frame2-story-mcp` matches existing references in `skills/re-frame-pair2/references/`