### PR TITLE
test(story-mcp): add stdio-roundtrip + live-server integration tests (rf2-h8z5l)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1166,3 +1166,66 @@ jobs:
       # (`snapshot_test`), and the subscribe surface (`subscribe_test`).
       - name: Run shadow-cljs :server-test (tools/pair2-mcp artefact)
         run: npm test
+
+  node-test-tools-story-mcp:
+    name: Node tools/story-mcp (stdio roundtrip + live-server, rf2-h8z5l)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/story-mcp
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08  # 13.4
+        with:
+          cli: latest
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '24'
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-node-tools-story-mcp-${{ hashFiles('tools/story-mcp/deps.edn', 'tools/story/deps.edn', 'implementation/core/deps.edn', 'implementation/adapters/reagent/deps.edn', 'implementation/machines/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-node-tools-story-mcp-
+            ${{ runner.os }}-clj-tools-story-mcp-
+            ${{ runner.os }}-clj-
+
+      # tools/story-mcp is a JVM artefact (Clojure-side stdio JSON-RPC
+      # server) — unlike pair2-mcp which is a self-contained Node script
+      # compiled via shadow-cljs, story-mcp launches via
+      # `clojure -M -m re-frame.story-mcp.server`. The JVM unit tests live
+      # in the parallel `jvm-tools-story-mcp` job above; this job adds the
+      # pair2-mcp-parity integration tests landed by rf2-h8z5l:
+      #
+      #   - test/stdio-roundtrip.js — spawns the server, walks initialize
+      #     → tools/list → tools/call across the canonical read-side tools,
+      #     asserts the gating contract for register-variant, and verifies
+      #     -32601 method-not-found for an unknown tool name.
+      #   - test/live-server.js   — drives a representative agent-loop
+      #     workflow with --allow-writes enabled (register-variant →
+      #     get-variant → preview-variant → run-variant → read-failures →
+      #     snapshot-identity → record-as-variant → unregister-variant).
+      #
+      # Both scripts spawn a real Clojure subprocess so JVM boot latency
+      # is observable from the CI logs; the cold-cache job takes ~30-60s
+      # end-to-end. Per-script watchdogs cap at 60s/90s respectively.
+      - name: Run stdio-roundtrip integration test (tools/story-mcp artefact)
+        run: node test/stdio-roundtrip.js
+
+      - name: Run live-server workflow integration test (tools/story-mcp artefact)
+        run: node test/live-server.js

--- a/tools/story-mcp/test/live-server.js
+++ b/tools/story-mcp/test/live-server.js
@@ -1,0 +1,292 @@
+// Live story-mcp server integration test — drives a representative
+// agent-loop scenario through a single running JVM process with the
+// write surface enabled.
+//
+// Story-MCP is JVM-side (a Clojure subprocess speaking JSON-RPC on
+// stdio). Unlike pair2-mcp's live-nrepl.js (which connects out to a
+// separate shadow-cljs runtime over bencode), this artefact is
+// self-contained — the same process that terminates stdin/stdout also
+// holds the Story registrar, so a single boot suffices for the entire
+// register → run → read → refine loop.
+//
+// Scenario (per IMPL-SPEC §7.2 + the self-healing-loop motif from rf2-h8z5l):
+//
+//   1. initialize handshake
+//   2. tools/list — confirm 17 tools advertised
+//   3. register-variant — write a fixture variant (gate open via
+//                          --allow-writes)
+//   4. get-variant — read it back; assert the body round-trips
+//   5. preview-variant — exercise the run-variant lifecycle (loaders →
+//                        events → render → play); expect a passing run
+//                        (no assertions ⇒ vacuously passing)
+//   6. run-variant — same lifecycle via the testing-category tool; assert
+//                    the result map shape (:frame :assertions :passing?)
+//   7. read-failures — zero accumulated failures expected
+//   8. snapshot-identity — stable content-hash twice in a row
+//   9. record-as-variant — zero-duration capture (empty :play snippet);
+//                          proves the recorder bridge is wired (rf2-luhdu)
+//  10. unregister-variant — tear the fixture variant back down; assert
+//                            it's gone from the read surface
+//
+// Run with: `node test/live-server.js` from tools/story-mcp/. Exits 0 on
+// success.
+
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+
+const CWD = path.join(__dirname, '..');
+const CLOJURE = process.env.STORY_MCP_CMD || 'clojure';
+const ARGS = ['-M', '-m', 're-frame.story-mcp.server', '--allow-writes'];
+
+// A fixture variant id we can safely create + tear down; namespaced under
+// `story.live-server` so it won't collide with anything the
+// canonical-vocabulary install registers.
+const FIXTURE_VARIANT = 'story.live-server/probe.primary';
+
+function run() {
+  return new Promise((resolve, reject) => {
+    const env = { ...process.env };
+    const child = spawn(CLOJURE, ARGS, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: CWD,
+      env,
+    });
+    child.stderr.on('data', (d) => process.stderr.write('[server] ' + d.toString()));
+
+    let next = 1;
+    const pending = new Map();
+    let buf = '';
+    child.stdout.on('data', (chunk) => {
+      buf += chunk.toString('utf8');
+      let i;
+      while ((i = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, i).trim();
+        buf = buf.slice(i + 1);
+        if (!line) continue;
+        try {
+          const f = JSON.parse(line);
+          if (f.id != null && pending.has(f.id)) {
+            pending.get(f.id)(f);
+            pending.delete(f.id);
+          }
+        } catch (e) {
+          console.error('FAIL: malformed JSON on stdout:', line);
+          child.kill();
+          reject(e);
+        }
+      }
+    });
+    const call = (m, p) => {
+      const id = next++;
+      return new Promise((r) => {
+        pending.set(id, r);
+        child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method: m, params: p }) + '\n');
+      });
+    };
+    const notify = (m, p) =>
+      child.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: m, params: p }) + '\n');
+
+    // Watchdog — generous because we cover multiple `run-variant`
+    // executions and Clojure boot is slow on a cold CI worker.
+    const watchdog = setTimeout(() => {
+      console.error('FAIL: watchdog timeout (90s) — workflow stalled');
+      child.kill();
+      reject(new Error('watchdog timeout'));
+    }, 90000);
+
+    (async () => {
+      // 1. initialize
+      const init = await call('initialize', {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'live-server', version: '0' },
+      });
+      if (!init.result?.protocolVersion) {
+        throw new Error('initialize failed: ' + JSON.stringify(init));
+      }
+      console.log('OK   initialize ->', init.result.serverInfo);
+      notify('notifications/initialized', {});
+
+      // 2. tools/list — 17 tools advertised.
+      const list = await call('tools/list', {});
+      const tools = list.result?.tools || [];
+      if (tools.length !== 17) {
+        throw new Error('expected 17 tools; got ' + tools.length);
+      }
+      console.log('OK   tools/list -> ' + tools.length + ' tools advertised');
+
+      // 3. register-variant — write the fixture variant. The MCP write
+      // surface exposes ONLY `register-variant`; there is no parallel
+      // `register-story` tool. Story's registrar accepts orphan variants
+      // in dev mode (per tools/story tests `register-variant-happy-when-allowed`)
+      // so we go straight to the variant registration.
+      //
+      // The `:body` parameter accepts either a structured object or an
+      // EDN string per tools.cljc's `tool-register-variant` — we use the
+      // EDN string so JSON's lack of keyword support doesn't dilute the
+      // assertion (Cheshire would coerce {"doc": "..."} into a
+      // string-keyed map, which Story's registrar would reject).
+      const variantBodyEdn =
+        '{:doc "Primary live-server probe variant."' +
+        ' :args {:label "OK"}' +
+        ' :tags #{:dev}}';
+      const regVResp = await call('tools/call', {
+        name: 'register-variant',
+        arguments: {
+          'variant-id': FIXTURE_VARIANT,
+          body: variantBodyEdn,
+        },
+      });
+      if (regVResp.result?.isError) {
+        throw new Error('register-variant for fixture failed: ' + JSON.stringify(regVResp));
+      }
+      const regVStruct = regVResp.result?.structuredContent || {};
+      if (regVStruct.registered !== true && regVStruct['registered?'] !== true) {
+        throw new Error('register-variant did not report :registered? true: ' + JSON.stringify(regVResp));
+      }
+      console.log('OK   register-variant -> ' + FIXTURE_VARIANT + ' registered');
+
+      // 4. get-variant — round-trip the body. Cheshire coerces keys to
+      // strings on the wire, so the comparison reads the :doc back from
+      // the text payload (EDN-encoded, keyword keys preserved).
+      const getResp = await call('tools/call', {
+        name: 'get-variant',
+        arguments: { 'variant-id': FIXTURE_VARIANT },
+      });
+      if (getResp.result?.isError) {
+        throw new Error('get-variant after register failed: ' + JSON.stringify(getResp));
+      }
+      const getText = getResp.result?.content?.[0]?.text || '';
+      if (!/Primary live-server probe variant\./.test(getText)) {
+        throw new Error('get-variant text payload missing :doc; got: ' + getText.slice(0, 200));
+      }
+      console.log('OK   get-variant -> body :doc round-trips through EDN text');
+
+      // 5. preview-variant — exercise the full lifecycle. With no :play
+      // events the run is vacuously passing.
+      const prevResp = await call('tools/call', {
+        name: 'preview-variant',
+        arguments: { 'variant-id': FIXTURE_VARIANT },
+      });
+      if (prevResp.result?.isError) {
+        throw new Error('preview-variant on fixture failed: ' + JSON.stringify(prevResp));
+      }
+      const prevStruct = prevResp.result?.structuredContent || {};
+      if (!('lifecycle' in prevStruct)) {
+        throw new Error('preview-variant structuredContent missing :lifecycle: ' + JSON.stringify(prevResp));
+      }
+      console.log('OK   preview-variant -> lifecycle=' + prevStruct.lifecycle);
+
+      // 6. run-variant — same lifecycle via the testing-category tool.
+      // Assert the result-map shape (:assertions vector, :passing? true).
+      const runResp = await call('tools/call', {
+        name: 'run-variant',
+        arguments: { 'variant-id': FIXTURE_VARIANT },
+      });
+      if (runResp.result?.isError) {
+        throw new Error('run-variant on fixture failed: ' + JSON.stringify(runResp));
+      }
+      const runStruct = runResp.result?.structuredContent || {};
+      if (!Array.isArray(runStruct.assertions)) {
+        throw new Error('run-variant :assertions not an array: ' + JSON.stringify(runResp));
+      }
+      // `passing?` arrives as a top-level key whose JSON name preserves the
+      // question-mark suffix.
+      if (runStruct['passing?'] !== true) {
+        throw new Error('run-variant :passing? expected true (no assertions ⇒ vacuous); got: ' + JSON.stringify(runResp));
+      }
+      console.log('OK   run-variant -> :passing?=true, assertions=[] (vacuous pass)');
+
+      // 7. read-failures — no assertions ran, so zero failures.
+      const failResp = await call('tools/call', {
+        name: 'read-failures',
+        arguments: { 'variant-id': FIXTURE_VARIANT },
+      });
+      if (failResp.result?.isError) {
+        throw new Error('read-failures on fixture failed: ' + JSON.stringify(failResp));
+      }
+      const failStruct = failResp.result?.structuredContent || {};
+      if (failStruct.total !== 0) {
+        throw new Error('read-failures :total expected 0; got: ' + JSON.stringify(failResp));
+      }
+      if (!Array.isArray(failStruct.failures) || failStruct.failures.length !== 0) {
+        throw new Error('read-failures :failures expected empty vector; got: ' + JSON.stringify(failResp));
+      }
+      console.log('OK   read-failures -> total=0, failures=[]');
+
+      // 8. snapshot-identity — same args ⇒ same content-hash.
+      const snap1 = await call('tools/call', {
+        name: 'snapshot-identity',
+        arguments: { 'variant-id': FIXTURE_VARIANT },
+      });
+      const snap2 = await call('tools/call', {
+        name: 'snapshot-identity',
+        arguments: { 'variant-id': FIXTURE_VARIANT },
+      });
+      if (snap1.result?.isError || snap2.result?.isError) {
+        throw new Error('snapshot-identity errored: ' + JSON.stringify(snap1) + ' / ' + JSON.stringify(snap2));
+      }
+      const h1 = snap1.result?.structuredContent?.['content-hash'];
+      const h2 = snap2.result?.structuredContent?.['content-hash'];
+      if (!h1 || h1 !== h2) {
+        throw new Error('snapshot-identity content-hash not stable: ' + h1 + ' vs ' + h2);
+      }
+      console.log('OK   snapshot-identity -> stable hash: ' + h1);
+
+      // 9. record-as-variant — zero-duration capture; empty :play snippet.
+      // Proves the recorder bridge (rf2-luhdu) is wired into dispatch.
+      const recResp = await call('tools/call', {
+        name: 'record-as-variant',
+        arguments: { 'variant-id': FIXTURE_VARIANT },
+      });
+      if (recResp.result?.isError) {
+        throw new Error('record-as-variant zero-duration failed: ' + JSON.stringify(recResp));
+      }
+      const recStruct = recResp.result?.structuredContent || {};
+      if (recStruct['recorded-event-count'] !== 0) {
+        throw new Error('record-as-variant :recorded-event-count expected 0; got: ' + JSON.stringify(recResp));
+      }
+      if (typeof recStruct['play-snippet'] !== 'string') {
+        throw new Error('record-as-variant :play-snippet missing/non-string: ' + JSON.stringify(recResp));
+      }
+      console.log('OK   record-as-variant -> recorded-event-count=0, play-snippet emitted');
+
+      // 10. unregister-variant — symmetric tear-down. After this the
+      // variant must no longer be reachable through the read surface.
+      const unregResp = await call('tools/call', {
+        name: 'unregister-variant',
+        arguments: { 'variant-id': FIXTURE_VARIANT },
+      });
+      if (unregResp.result?.isError) {
+        throw new Error('unregister-variant failed: ' + JSON.stringify(unregResp));
+      }
+      const unregStruct = unregResp.result?.structuredContent || {};
+      if (unregStruct['unregistered?'] !== true) {
+        throw new Error('unregister-variant :unregistered? expected true: ' + JSON.stringify(unregResp));
+      }
+      // Read-back must now fail.
+      const verify = await call('tools/call', {
+        name: 'get-variant',
+        arguments: { 'variant-id': FIXTURE_VARIANT },
+      });
+      if (!verify.result?.isError || !/not found/i.test(verify.result?.content?.[0]?.text || '')) {
+        throw new Error('after unregister, get-variant should yield not-found; got: ' + JSON.stringify(verify));
+      }
+      console.log('OK   unregister-variant -> :unregistered?=true; subsequent get-variant -> not-found');
+
+      clearTimeout(watchdog);
+      child.kill();
+      console.log('\nSTORY-MCP LIVE-SERVER WORKFLOW GREEN');
+      resolve();
+    })().catch((e) => {
+      clearTimeout(watchdog);
+      child.kill();
+      reject(e);
+    });
+  });
+}
+
+run().then(() => process.exit(0)).catch((e) => {
+  console.error('FAIL:', e.message);
+  process.exit(1);
+});

--- a/tools/story-mcp/test/stdio-roundtrip.js
+++ b/tools/story-mcp/test/stdio-roundtrip.js
@@ -1,0 +1,305 @@
+// Stdio integration test for tools/story-mcp.
+//
+// Spawns the JVM story-mcp server via `clojure -M -m re-frame.story-mcp.server`
+// and walks the MCP handshake against it:
+//
+//   - initialize                  (negotiate protocolVersion 2025-06-18)
+//   - notifications/initialized   (notification, no response)
+//   - tools/list                  (expect all 17 tools per spec/002)
+//   - tools/call list-tags        (read-side smoke; canonical seven present)
+//   - tools/call list-substrates  (returns a vector, possibly empty on JVM)
+//   - tools/call get-story-instructions (text content)
+//   - tools/call preview-variant on an unregistered variant
+//                                 (expect tool-execution error — proves the
+//                                  tool is wired into the dispatch table)
+//   - tools/call get-variant on an unregistered variant
+//                                 (same shape — wires to dispatch table)
+//   - tools/call register-variant without --allow-writes
+//                                 (expect gated tool-execution error — proves
+//                                  the gating contract per IMPL-SPEC §7.3)
+//   - tools/call no-such-tool     (expect method-not-found protocol error)
+//   - ping                        (empty result, liveness probe)
+//
+// A separate live-server.js drives a representative workflow against a
+// running server with --allow-writes enabled.
+//
+// Run with: `node test/stdio-roundtrip.js` from tools/story-mcp/. Exits 0 on
+// success, 1 with a FAIL marker on the failing assertion.
+
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+
+const CWD = path.join(__dirname, '..');
+
+// The agent-host canonical launch (per tools/story-mcp/README.md). On
+// Linux CI the `clojure` binary lands via DeLaGuardo/setup-clojure; on
+// Windows it's an .exe on PATH (the GitHub-hosted runner provides it).
+// We spawn the binary directly — no shell wrap — so Node 24+'s
+// shell-with-args deprecation (DEP0190) stays quiet.
+const CLOJURE = process.env.STORY_MCP_CMD || 'clojure';
+const ARGS = ['-M', '-m', 're-frame.story-mcp.server'];
+
+function run() {
+  return new Promise((resolve, reject) => {
+    const env = { ...process.env };
+    const child = spawn(CLOJURE, ARGS, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: CWD,
+      env,
+    });
+    child.stderr.on('data', (d) => process.stderr.write('[server] ' + d.toString()));
+
+    let next = 1;
+    const pending = new Map();
+    let buf = '';
+    child.stdout.on('data', (chunk) => {
+      buf += chunk.toString('utf8');
+      let i;
+      while ((i = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, i).trim();
+        buf = buf.slice(i + 1);
+        if (!line) continue;
+        try {
+          const f = JSON.parse(line);
+          if (f.id != null && pending.has(f.id)) {
+            pending.get(f.id)(f);
+            pending.delete(f.id);
+          }
+        } catch (e) {
+          console.error('FAIL: malformed JSON on stdout:', line);
+          child.kill();
+          reject(e);
+        }
+      }
+    });
+    const call = (m, p) => {
+      const id = next++;
+      return new Promise((r) => {
+        pending.set(id, r);
+        child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method: m, params: p }) + '\n');
+      });
+    };
+    const notify = (m, p) =>
+      child.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: m, params: p }) + '\n');
+
+    // Watchdog: kill the child if assertions take longer than 60s. Clojure
+    // boot on a cold CI runner can take 10-20s; 60s is comfortably above
+    // that without leaving a hung process.
+    const watchdog = setTimeout(() => {
+      console.error('FAIL: watchdog timeout (60s) — server did not respond');
+      child.kill();
+      reject(new Error('watchdog timeout'));
+    }, 60000);
+
+    (async () => {
+      // 1. initialize handshake. The JVM boot needs a moment; the first
+      // call's response will land whenever the server hits its read loop.
+      const init = await call('initialize', {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'roundtrip', version: '0' },
+      });
+      if (!init.result?.protocolVersion) {
+        throw new Error('initialize failed: ' + JSON.stringify(init));
+      }
+      console.log('OK   initialize ->', init.result.serverInfo);
+
+      notify('notifications/initialized', {});
+
+      // 2. tools/list — expect all 17 tools per spec/002-Tool-Registry.md +
+      // rf2-luhdu (record-as-variant landing).
+      const list = await call('tools/list', {});
+      const names = (list.result?.tools || []).map((t) => t.name).sort();
+      const expected = [
+        'get-story',
+        'get-story-instructions',
+        'get-variant',
+        'list-assertions',
+        'list-modes',
+        'list-stories',
+        'list-substrates',
+        'list-tags',
+        'preview-variant',
+        'read-failures',
+        'record-as-variant',
+        'register-variant',
+        'run-a11y',
+        'run-variant',
+        'snapshot-identity',
+        'unregister-variant',
+        'variant->edn',
+      ];
+      if (JSON.stringify(names) !== JSON.stringify(expected)) {
+        throw new Error(
+          'tools/list mismatch:\n  expected ' +
+            JSON.stringify(expected) +
+            '\n  got      ' +
+            JSON.stringify(names),
+        );
+      }
+      console.log('OK   tools/list -> 17 tools:', names.join(', '));
+
+      // 2b. Verify the preview-variant descriptor: required `variant-id`,
+      // optional `substrate`/`active-modes`/`cell-overrides`/`base-url`.
+      const previewDesc = (list.result?.tools || []).find((t) => t.name === 'preview-variant');
+      if (!previewDesc) throw new Error('preview-variant descriptor missing from tools/list');
+      const previewProps = previewDesc.inputSchema?.properties || {};
+      for (const k of ['variant-id', 'substrate', 'active-modes', 'cell-overrides', 'base-url']) {
+        if (!(k in previewProps)) {
+          throw new Error('preview-variant inputSchema missing property: ' + k);
+        }
+      }
+      if (!previewDesc.inputSchema?.required?.includes('variant-id')) {
+        throw new Error('preview-variant.inputSchema missing required: variant-id');
+      }
+      console.log('OK   preview-variant descriptor -> variant-id (required) + substrate/active-modes/cell-overrides/base-url');
+
+      // 2c. Verify the register-variant descriptor: required
+      // `variant-id` + `body`. This is the write-gated tool per IMPL-SPEC
+      // §7.3 — descriptor advertised whether the gate is open or not.
+      const regDesc = (list.result?.tools || []).find((t) => t.name === 'register-variant');
+      if (!regDesc) throw new Error('register-variant descriptor missing from tools/list');
+      const regReq = regDesc.inputSchema?.required || [];
+      for (const k of ['variant-id', 'body']) {
+        if (!regReq.includes(k)) {
+          throw new Error('register-variant.inputSchema missing required: ' + k);
+        }
+      }
+      console.log('OK   register-variant descriptor -> variant-id + body required');
+
+      // 2d. Verify the record-as-variant descriptor (rf2-luhdu landing):
+      // required `variant-id`; optional duration-ms / new-variant-id / doc
+      // / extends / alias / write-back?.
+      const recDesc = (list.result?.tools || []).find((t) => t.name === 'record-as-variant');
+      if (!recDesc) throw new Error('record-as-variant descriptor missing from tools/list');
+      const recProps = recDesc.inputSchema?.properties || {};
+      for (const k of ['variant-id', 'duration-ms', 'new-variant-id', 'doc', 'extends', 'alias', 'write-back?']) {
+        if (!(k in recProps)) {
+          throw new Error('record-as-variant inputSchema missing property: ' + k);
+        }
+      }
+      if (!recDesc.inputSchema?.required?.includes('variant-id')) {
+        throw new Error('record-as-variant.inputSchema missing required: variant-id');
+      }
+      console.log('OK   record-as-variant descriptor -> variant-id (required) + duration-ms/new-variant-id/doc/extends/alias/write-back?');
+
+      // 3. tools/call list-tags — read-side smoke; the canonical seven
+      // tags must be present (loaded by `install-canonical-vocabulary!` in
+      // server `boot!`).
+      const tagsResp = await call('tools/call', { name: 'list-tags', arguments: {} });
+      if (tagsResp.result?.isError) {
+        throw new Error('list-tags returned isError: ' + JSON.stringify(tagsResp));
+      }
+      const tagsStructured = tagsResp.result?.structuredContent;
+      const canonical = (tagsStructured?.canonical || []).map(String);
+      // Cheshire's `generate-string` writes keywords as bare names without
+      // the leading colon — `:dev` arrives on the wire as `"dev"`.
+      for (const tag of ['dev', 'docs', 'test', 'screenshot', 'experimental', 'internal', 'agent']) {
+        if (!canonical.includes(tag)) {
+          throw new Error('list-tags missing canonical tag ' + tag + '; got ' + JSON.stringify(canonical));
+        }
+      }
+      console.log('OK   tools/call list-tags -> canonical seven present:', canonical.join(', '));
+
+      // 3b. tools/call list-substrates — JVM-standalone deploy returns an
+      // empty substrate set; the contract is the result-shape (a vector,
+      // possibly empty).
+      const subsResp = await call('tools/call', { name: 'list-substrates', arguments: {} });
+      if (subsResp.result?.isError) {
+        throw new Error('list-substrates returned isError: ' + JSON.stringify(subsResp));
+      }
+      const subsArr = subsResp.result?.structuredContent?.substrates;
+      if (!Array.isArray(subsArr)) {
+        throw new Error('list-substrates :substrates not an array: ' + JSON.stringify(subsResp));
+      }
+      console.log('OK   tools/call list-substrates -> vector (count=' + subsArr.length + ')');
+
+      // 3c. tools/call get-story-instructions — returns the agent-onboarding
+      // text. Smoke-check key authoring vocab is present.
+      const instrResp = await call('tools/call', { name: 'get-story-instructions', arguments: {} });
+      const instrText = instrResp.result?.content?.[0]?.text || '';
+      if (instrResp.result?.isError || !instrText.includes('reg-story')) {
+        throw new Error('get-story-instructions did not contain `reg-story`: ' + JSON.stringify(instrResp).slice(0, 300));
+      }
+      console.log('OK   tools/call get-story-instructions -> text contains reg-story/reg-variant');
+
+      // 4. tools/call preview-variant on an unknown variant — expect
+      // tool-execution error (`isError: true`) with a "not found" message.
+      // This proves the tool is wired into the dispatch table; in degraded
+      // states the response would carry a different shape.
+      const prevResp = await call('tools/call', {
+        name: 'preview-variant',
+        arguments: { 'variant-id': 'story.no-such-fixture/missing' },
+      });
+      const prevText = prevResp.result?.content?.[0]?.text || '';
+      if (!prevResp.result?.isError || !/not found/i.test(prevText)) {
+        throw new Error('preview-variant on missing variant did not yield isError + not-found; got: ' + JSON.stringify(prevResp));
+      }
+      console.log('OK   tools/call preview-variant (missing) -> isError + not-found');
+
+      // 4b. tools/call get-variant on an unknown variant — same shape.
+      const getVResp = await call('tools/call', {
+        name: 'get-variant',
+        arguments: { 'variant-id': 'story.no-such-fixture/missing' },
+      });
+      const getVText = getVResp.result?.content?.[0]?.text || '';
+      if (!getVResp.result?.isError || !/not found/i.test(getVText)) {
+        throw new Error('get-variant on missing variant did not yield isError + not-found; got: ' + JSON.stringify(getVResp));
+      }
+      console.log('OK   tools/call get-variant (missing) -> isError + not-found');
+
+      // 5. tools/call register-variant without --allow-writes — the
+      // server boots with the gate closed by default; the write tool must
+      // surface a gated tool-execution error.
+      const regResp = await call('tools/call', {
+        name: 'register-variant',
+        arguments: {
+          'variant-id': 'story.gated/probe',
+          body: { doc: 'probe' },
+        },
+      });
+      const regText = regResp.result?.content?.[0]?.text || '';
+      if (!regResp.result?.isError || !/Write surface disabled/.test(regText)) {
+        throw new Error('register-variant gated path expected; got: ' + JSON.stringify(regResp));
+      }
+      const regStruct = regResp.result?.structuredContent;
+      if (!regStruct || regStruct.gated !== true) {
+        throw new Error('register-variant gated result missing structuredContent.gated=true: ' + JSON.stringify(regResp));
+      }
+      console.log('OK   tools/call register-variant (gated) -> isError + structuredContent.gated=true');
+
+      // 6. tools/call no-such-tool — unknown tool name; the dispatcher
+      // surfaces a protocol-level method-not-found (-32601) per
+      // server.cljc's `handle-tools-call`.
+      const unkResp = await call('tools/call', {
+        name: 'no-such-tool',
+        arguments: {},
+      });
+      if (unkResp.error?.code !== -32601) {
+        throw new Error('no-such-tool should yield method-not-found (-32601); got: ' + JSON.stringify(unkResp));
+      }
+      console.log('OK   tools/call no-such-tool -> -32601 method-not-found');
+
+      // 7. ping — empty result, MCP §Utilities/ping liveness probe.
+      const pingResp = await call('ping', {});
+      if (pingResp.result === undefined || Object.keys(pingResp.result || {}).length !== 0) {
+        throw new Error('ping should return empty {}; got: ' + JSON.stringify(pingResp));
+      }
+      console.log('OK   ping -> empty result {}');
+
+      clearTimeout(watchdog);
+      child.kill();
+      console.log('\nSTORY-MCP STDIO ROUND-TRIP GREEN');
+      resolve();
+    })().catch((e) => {
+      clearTimeout(watchdog);
+      child.kill();
+      reject(e);
+    });
+  });
+}
+
+run().then(() => process.exit(0)).catch((e) => {
+  console.error('FAIL:', e.message);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes the parity gap surfaced by the MCP-testing audit: pair2-mcp ships
`test/stdio-roundtrip.js` + `test/live-nrepl.js`; story-mcp had no
parallel surface.

## Summary

- `tools/story-mcp/test/stdio-roundtrip.js` — spawns the JVM story-mcp
  server (`clojure -M -m re-frame.story-mcp.server`), walks the MCP
  handshake (`initialize` → `notifications/initialized` → `tools/list` →
  `tools/call`), asserts the descriptor shape for the key tools
  (`preview-variant` / `register-variant` / `record-as-variant`),
  exercises the read-side tools (`list-tags`, `list-substrates`,
  `get-story-instructions`, `preview-variant`/`get-variant` on missing
  ids), proves the write-surface gating contract (`register-variant`
  without `--allow-writes` returns `isError` + `structuredContent.gated=true`
  per IMPL-SPEC §7.3), verifies a `-32601 method-not-found` for an unknown
  tool name, and round-trips `ping`.

- `tools/story-mcp/test/live-server.js` — drives a representative
  agent-loop workflow with `--allow-writes` enabled:
  `register-variant` → `get-variant` → `preview-variant` →
  `run-variant` → `read-failures` → `snapshot-identity` (twice, stable
  hash) → `record-as-variant` (zero-duration capture) →
  `unregister-variant` (with read-back-not-found verification).

- `.github/workflows/test.yml` — adds `node-test-tools-story-mcp`
  parallel to the existing `node-test-tools-pair2-mcp` job (JDK 21 +
  Clojure CLI + Node 24, with Maven/gitlibs cache).

Both scripts spawn the canonical binary directly (no shell wrap), so
Node 24+'s DEP0190 stays quiet. Each carries an internal watchdog
(60s/90s) so a hung server fails fast.

## Sample handshake output

```
[server] [re-frame2-story-mcp] booted; allow-writes?= false  protocol= 2025-06-18  server= re-frame2-story-mcp
OK   initialize -> { name: 're-frame2-story-mcp', version: 'dev' }
OK   tools/list -> 17 tools: get-story, get-story-instructions, get-variant, list-assertions, list-modes, list-stories, list-substrates, list-tags, preview-variant, read-failures, record-as-variant, register-variant, run-a11y, run-variant, snapshot-identity, unregister-variant, variant->edn
OK   preview-variant descriptor -> variant-id (required) + substrate/active-modes/cell-overrides/base-url
OK   register-variant descriptor -> variant-id + body required
OK   record-as-variant descriptor -> variant-id (required) + duration-ms/new-variant-id/doc/extends/alias/write-back?
OK   tools/call list-tags -> canonical seven present: agent, dev, docs, experimental, internal, screenshot, test
OK   tools/call list-substrates -> vector (count=0)
OK   tools/call get-story-instructions -> text contains reg-story/reg-variant
OK   tools/call preview-variant (missing) -> isError + not-found
OK   tools/call get-variant (missing) -> isError + not-found
OK   tools/call register-variant (gated) -> isError + structuredContent.gated=true
OK   tools/call no-such-tool -> -32601 method-not-found
OK   ping -> empty result {}

STORY-MCP STDIO ROUND-TRIP GREEN
```

```
[server] [re-frame2-story-mcp] booted; allow-writes?= true  protocol= 2025-06-18  server= re-frame2-story-mcp
OK   initialize -> { name: 're-frame2-story-mcp', version: 'dev' }
OK   tools/list -> 17 tools advertised
OK   register-variant -> story.live-server/probe.primary registered
OK   get-variant -> body :doc round-trips through EDN text
OK   preview-variant -> lifecycle=pre-mount
OK   run-variant -> :passing?=true, assertions=[] (vacuous pass)
OK   read-failures -> total=0, failures=[]
OK   snapshot-identity -> stable hash: c05e4e16
OK   record-as-variant -> recorded-event-count=0, play-snippet emitted
OK   unregister-variant -> :unregistered?=true; subsequent get-variant -> not-found

STORY-MCP LIVE-SERVER WORKFLOW GREEN
```

## Test plan

- [x] `node test/stdio-roundtrip.js` from `tools/story-mcp/` — green
- [x] `node test/live-server.js` from `tools/story-mcp/` — green
- [x] `clojure -M:test` from `tools/story-mcp/` — all 80 JVM unit tests pass (no regression)
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` — valid YAML
- [ ] CI: new `node-test-tools-story-mcp` job runs green