### PR TITLE
docs(skills/improver): populate 6-pattern anti-catalogue (rf2-bquci)

### DIFF
--- a/skills/re-frame2-improver/references/README.md
+++ b/skills/re-frame2-improver/references/README.md
@@ -2,28 +2,34 @@
 
 Anti-pattern catalogue for `re-frame2-improver`. Each leaf is one anti-pattern with: detection rule, symptom example, canonical re-frame2 idiom, suggested rewrite, and a cross-link to the matching leaf under `skills/re-frame2/patterns/` or the relevant `spec/` document.
 
-## Status — scaffold only (rf2-u8j31)
+## Status — populated (rf2-bquci)
 
-This directory is currently a **scaffold placeholder**. The skill's `SKILL.md` is live; the catalogue leaves are deferred.
+Six launch anti-patterns are now resident. The catalogue is intentionally narrow — grow it as new anti-patterns surface across 3+ real review sessions (same growth discipline as `re-frame-pair-improver2/references/known-frictions.md`).
 
-## Planned leaves (rf2-bquci will populate)
+## Catalogue
 
-Six anti-patterns at launch, per the rf2-zf7zd findings (`ai/findings/improver-architecture-20260513-1752.md` §Angle 2):
+| # | Leaf | Anti-pattern | Canonical idiom (cross-link) |
+|---|---|---|---|
+| 1 | [`manual-retry-loops.md`](manual-retry-loops.md) | Hand-rolled HTTP retry — `setTimeout` + counters + manual back-off in handlers | Managed HTTP — [`skills/re-frame2/patterns/managed-http.md`](../../re-frame2/patterns/managed-http.md), [`spec/014-HTTPRequests.md`](../../../spec/014-HTTPRequests.md) |
+| 2 | [`boolean-discriminator-subs.md`](boolean-discriminator-subs.md) | 3+ boolean subs (`:*/loading?`, `:*/error?`, `:*/loaded?`) on one path acting as a hand-rolled FSM | Tags query layer — [`skills/re-frame2/reference/state-machines/tags.md`](../../re-frame2/reference/state-machines/tags.md), [`spec/005-StateMachines.md`](../../../spec/005-StateMachines.md) |
+| 3 | [`manual-loading-flags.md`](manual-loading-flags.md) | `(assoc db :*/loading? true)` paired with `dissoc` across multiple terminator handlers | Nine States — [`skills/re-frame2/patterns/nine-states.md`](../../re-frame2/patterns/nine-states.md), [`spec/Pattern-NineStates.md`](../../../spec/Pattern-NineStates.md) |
+| 4 | [`schemaless-events.md`](schemaless-events.md) | Boundary handler ingests untrusted payload without `:spec` or `reg-app-schema` for the destination path | Schemas at boundaries — [`skills/re-frame2/reference/fundamentals/schemas.md`](../../re-frame2/reference/fundamentals/schemas.md), [`spec/010-Schemas.md`](../../../spec/010-Schemas.md) |
+| 5 | [`imperative-effects.md`](imperative-effects.md) | Direct `js/localStorage` / DOM / `js/console` calls inside `reg-event-*` bodies | Data-only fx via `reg-fx` — [`skills/re-frame2/reference/fundamentals/fx.md`](../../re-frame2/reference/fundamentals/fx.md), [`spec/Conventions.md`](../../../spec/Conventions.md) |
+| 6 | [`view-side-hook-state.md`](view-side-hook-state.md) | `reagent/atom` (or `useState`) inside a view holding state read by sibling components | Move to `app-db` + `reg-sub` — [`skills/re-frame2/reference/fundamentals/subs.md`](../../re-frame2/reference/fundamentals/subs.md), [`spec/Principles.md`](../../../spec/Principles.md) |
 
-1. **Manual HTTP retry loops** — `cljs-http` calls inside `reg-event-fx` with manual retry counters or `setTimeout` retries. Canonical idiom: Managed HTTP (Spec 014 `Pattern-RemoteData`).
-2. **Boolean discriminator subs for FSM states** — `reg-sub :screen/loading?`, `:screen/error?`, etc. on the same key. Canonical idiom: Tags query layer (Spec 005 §Tags + `:rf/in-tag` sub).
-3. **Manual loading flags** — `(assoc db :foo/loading? true)` + matching `dissoc`. Canonical idiom: Nine States pattern (`skills/re-frame2/patterns/nine-states.md`).
-4. **Schemaless events at HTTP boundary** — `reg-event-fx :api/loaded` with no `:rf/event-schema` and no `reg-app-schema` for the destination path. Canonical idiom: Spec 010 schemas at boundaries.
-5. **Imperative effects** — direct DOM / JS API calls (`(.setItem js/localStorage ...)`) inside event handler body. Canonical idiom: data-only fx via `reg-fx` (Spec 003).
-6. **View-side state via React hooks** — `reagent/atom` inside view body for app-wide-visible state, or `useState` for non-render-local concerns. Canonical idiom: move to `app-db` + `reg-sub`.
+## Per-leaf format (locked)
 
-Per-leaf format (locked under rf2-bquci):
+Each leaf carries the same five sections:
 
-- `symptom` — code shape to detect, with a small concrete example.
-- `detection` — agent-actionable rule (Grep pattern, structural shape) for spotting the anti-pattern in `.cljs` / `.cljc` files.
-- `canonical` — the re-frame2 idiom that replaces it.
-- `rewrite` — a short mechanical-rewrite recipe for grounded fixes.
-- `cross-link` — pointer to `skills/re-frame2/patterns/<idiom>.md` or `spec/<N>-<topic>.md`.
+- **Detection rules** — Greppable signals and structural cues for spotting the anti-pattern in `.cljs` / `.cljc` source.
+- **Why it's an anti-pattern** — 2-3 paragraphs on the underlying issue (what invariant breaks, what downstream cost is incurred).
+- **The canonical fix** — Cross-reference to the `skills/re-frame2/patterns/` leaf or `spec/` document that documents the idiomatic alternative.
+- **Worked example** — Before-and-after CLJS snippets (~10 lines each side).
+- **Edge cases** — When the anti-pattern is actually fine (avoids over-eager false-positives during review).
+
+## Growth procedure
+
+When a new anti-pattern surfaces across 3+ review sessions, add it as a new leaf and a new row above. Mirrors how `re-frame-pair-improver2/references/known-frictions.md` grows organically. Anti-patterns flagged in `ai/findings/improver-architecture-20260513-1752.md` §Angle 2 as "bonus" candidates (view renders only happy state; effect handlers writing to foreign frames) are deferred until they surface in real reviews.
 
 ## Planned shared leaf (rf2-dhe9v will land)
 

--- a/skills/re-frame2-improver/references/boolean-discriminator-subs.md
+++ b/skills/re-frame2-improver/references/boolean-discriminator-subs.md
@@ -1,0 +1,72 @@
+# Anti-pattern — Boolean discriminator subs for FSM states
+
+A cluster of boolean subscriptions all reading the same `app-db` path, each answering "is the screen in state X?" — `:screen/loading?`, `:screen/error?`, `:screen/empty?`, `:screen/loaded?`. The view then chains `cond` clauses derefing each. The cluster is a hand-rolled finite-state machine pretending to be subs.
+
+## Detection rules
+
+Greppable signals:
+
+- Three or more `reg-sub` declarations whose ids end in `?` and read the **same** `app-db` path (or the same parent sub).
+- Sub ids in an FSM-shaped set: `:*-loading?` / `:*-loaded?` / `:*-error?` / `:*-empty?` / `:*-pending?` / `:*-ready?` for one logical screen.
+- A view body that derefs 3+ such subs and routes via `cond`.
+- Sub handlers shaped like `(= :loading (:status db))` / `(some? (:error db))` / `(empty? (:items db))` reading the same parent map.
+
+Structural signal: the boolean subs are mutually exclusive (exactly one is `true` at any time) — that is the definition of an FSM, and it should be modelled as one.
+
+## Why it's an anti-pattern
+
+Each boolean sub is a fresh probe of the same underlying state, with no machine-readable declaration of the mutual exclusion. The view re-renders on **every** discriminator deref. The mutual-exclusion invariant is enforced by convention only — nothing prevents `:loading?` and `:error?` from being simultaneously `true` if a careless handler forgets a `dissoc`. New states (e.g. `:stale`, `:reloading`, `:partial`) require a new sub + a new view branch + an audit of all the existing booleans for the new mutual-exclusion case — a cost that scales with the *square* of the state count.
+
+A re-frame2 state machine declares the states once; tags label the per-state intent; one selector sub answers the render question.
+
+## The canonical fix
+
+[`skills/re-frame2/reference/state-machines/tags.md`](../../re-frame2/reference/state-machines/tags.md) — declare a `reg-machine` whose states carry `:tags`, then use `@(rf/has-tag? machine-id tag)` (or a single render-priority selector sub) instead of the boolean cluster.
+
+For full page-level rendering with cardinality buckets, [`skills/re-frame2/patterns/nine-states.md`](../../re-frame2/patterns/nine-states.md) is the canonical pattern.
+
+Spec source: [`spec/005-StateMachines.md`](../../../spec/005-StateMachines.md) §Tags.
+
+## Worked example
+
+**Before** — boolean discriminator cluster:
+
+```clojure
+(rf/reg-sub :article/loading? (fn [db _] (= :loading (get-in db [:article :status]))))
+(rf/reg-sub :article/error?   (fn [db _] (= :error   (get-in db [:article :status]))))
+(rf/reg-sub :article/empty?   (fn [db _] (and (= :loaded (get-in db [:article :status]))
+                                              (empty?   (get-in db [:article :data])))))
+(rf/reg-sub :article/loaded?  (fn [db _] (and (= :loaded (get-in db [:article :status]))
+                                              (seq      (get-in db [:article :data])))))
+
+(defn article-page []
+  (cond
+    @(rf/subscribe [:article/loading?]) [spinner]
+    @(rf/subscribe [:article/error?])   [error-banner]
+    @(rf/subscribe [:article/empty?])   [empty-state]
+    @(rf/subscribe [:article/loaded?])  [article-body]))
+```
+
+**After** — machine + tags + one selector:
+
+```clojure
+(rf/reg-machine :article
+  {:initial :loading
+   :states  {:loading {:tags #{:article/loading}}
+             :error   {:tags #{:article/error}}
+             :empty   {:tags #{:article/empty}}
+             :loaded  {:tags #{:article/loaded}}}})
+
+(defn article-page []
+  (cond
+    @(rf/has-tag? :article :article/loading) [spinner]
+    @(rf/has-tag? :article :article/error)   [error-banner]
+    @(rf/has-tag? :article :article/empty)   [empty-state]
+    @(rf/has-tag? :article :article/loaded)  [article-body]))
+```
+
+## Edge cases — when boolean subs are fine
+
+- **Genuinely independent predicates** that aren't mutually exclusive — `:cart/has-items?` and `:cart/over-shipping-threshold?` can both be `true` and aren't states of one FSM. Keep them as subs.
+- **Layer-1 readers of one boolean app-db key** that aren't an FSM — `:flag/feature-x-enabled?` reading `(:feature-x? db)` is fine.
+- **A two-state toggle** (`:open?` / `:closed?`) is small enough that a single sub + `if` in the view costs less than declaring a machine. The smell scales: 3+ mutually-exclusive booleans on the same path is the trigger.

--- a/skills/re-frame2-improver/references/imperative-effects.md
+++ b/skills/re-frame2-improver/references/imperative-effects.md
@@ -1,0 +1,68 @@
+# Anti-pattern — Imperative effects inside handlers
+
+Direct JS / DOM / browser-API calls inside the body of a `reg-event-db` or `reg-event-fx` handler — `(.setItem js/localStorage ...)`, `(js/console.log ...)`, `(.scrollTo js/window ...)`, `(set! (.-title js/document) ...)`. The handler stops being a pure function from `db` to `db`; the side-effect leaks out of the data-only `:fx` channel.
+
+## Detection rules
+
+Greppable signals inside `reg-event-db` / `reg-event-fx` handler bodies:
+
+- `js/` interop calls — `js/localStorage`, `js/sessionStorage`, `js/document`, `js/window`, `js/console`, `js/fetch`, `js/Math.random`, `js/Date.now`.
+- `.-prop` setter forms with `set!` — `(set! (.-href js/location) "...")`, `(set! (.-title js/document) "...")`.
+- Direct `.method` calls on browser globals — `(.scrollTo js/window 0 0)`, `(.focus el)`, `(.preventDefault e)`, `(.alert js/window "...")`.
+- `(rf/dispatch ...)` invoked **from inside** a handler body (rather than returned as `:fx [[:dispatch ...]]`) — a sneaky imperative form because it queues without going through the fx data channel.
+- Native timer calls — `js/setTimeout`, `js/setInterval`, `js/requestAnimationFrame` (manual `setTimeout` retry loops also covered by [`manual-retry-loops.md`](manual-retry-loops.md)).
+
+Structural signal: the handler returns a `db` value (or an fx-map) **and** has visible side-effects on the way there.
+
+## Why it's an anti-pattern
+
+The whole point of re-frame's data-driven loop is that handlers describe *what* should happen as data, and a separate registered fx-handler decides *how* it happens. Imperative leaks defeat:
+
+- **Testability** — the handler can no longer run under `compute-event` without a browser; tests need DOM mocks.
+- **Time-travel & replay** — re-frame-10x replays the event vector against the pre-`db`; imperative side-effects fire again on replay, double-writing to `localStorage` or refocusing the wrong element.
+- **Server-side rendering** — Spec 011 SSR runs handlers on the server; `js/document` blows up.
+- **Instrumentation** — Spec 009's `:rf.fx/*` trace channel sees only what flows through `reg-fx`; imperative calls are invisible to the inspector, story, and pair-tool surfaces.
+- **`:platforms` gating** — Spec 003 lets an fx declare `:platforms #{:client}`; an imperative side-effect inside a handler cannot be skipped on the server.
+
+A re-frame2 effect is data: a `[fx-id args]` pair. The runtime walks the `:fx` vector and dispatches to the registered handler.
+
+## The canonical fix
+
+[`skills/re-frame2/reference/fundamentals/fx.md`](../../re-frame2/reference/fundamentals/fx.md) — wrap the side-effect in `reg-fx` once, then issue `[[:my-fx args]]` from the handler. The fx-handler is the one place where imperative interop is legitimate.
+
+Spec source: [`spec/Conventions.md`](../../../spec/Conventions.md) (data-only fx) and Cardinal Rule #1 (implementation is ground truth; the runtime's effect-map shape is closed — `:rf.error/effect-map-shape` fires if you try to sneak `:dispatch` or `:http` as a top-level key).
+
+## Worked example
+
+**Before** — imperative side-effect in the handler:
+
+```clojure
+(rf/reg-event-db :prefs/save-theme
+  (fn [db [_ theme]]
+    (.setItem js/localStorage "theme" (name theme))            ;; <-- imperative side-effect
+    (set! (.-className js/document.body) (str "theme-" (name theme)))   ;; <-- DOM mutation
+    (assoc db :prefs/theme theme)))
+```
+
+**After** — data-only fx:
+
+```clojure
+(rf/reg-fx :local-storage/set
+  (fn [_ctx {:keys [k v]}] (.setItem js/localStorage k v)))
+
+(rf/reg-fx :dom/set-body-class
+  {:platforms #{:client}}
+  (fn [_ctx class] (set! (.-className js/document.body) class)))
+
+(rf/reg-event-fx :prefs/save-theme
+  (fn [{:keys [db]} [_ theme]]
+    {:db (assoc db :prefs/theme theme)
+     :fx [[:local-storage/set    {:k "theme" :v (name theme)}]
+          [:dom/set-body-class   (str "theme-" (name theme))]]}))
+```
+
+## Edge cases — when imperative is fine
+
+- **Inside a `reg-fx` handler body itself** — that's the *whole job* of an fx-handler. Imperative interop is legitimate here.
+- **Pure local computation that happens to use `js/Math` or similar** — `(js/parseInt s 10)`, `(js/Math.max a b)` are pure function calls, not side-effects. The line is: does the call observably mutate anything outside the handler? `parseInt` doesn't; `localStorage.setItem` does.
+- **Boot-time DOM reads** that aren't inside any handler (top-level `(def !root (js/document.getElementById "app"))`) — outside the event loop entirely. Not in scope for this anti-pattern.

--- a/skills/re-frame2-improver/references/manual-loading-flags.md
+++ b/skills/re-frame2-improver/references/manual-loading-flags.md
@@ -1,0 +1,69 @@
+# Anti-pattern — Manual loading flags
+
+Boolean flag keys in `app-db` — `:foo/loading?`, `:bar/saving?`, `:baz/in-flight?` — flipped on by a "start" event and flipped off by every "done" / "failed" / "cancelled" terminator. The flag and the data live as separate keys; keeping them coherent is the application's problem.
+
+## Detection rules
+
+Greppable signals:
+
+- `(assoc db :*/loading? true)` paired anywhere in the codebase with `(dissoc db :*/loading?)` or `(assoc db :*/loading? false)`.
+- Keys matching `:*/loading?`, `:*/saving?`, `:*/in-flight?`, `:*/pending?`, `:*/fetching?` at the top level or one level deep in `app-db`.
+- Failure / cancellation handlers that need to remember to flip the flag off — typically a `dissoc` of the flag in two or more terminator handlers.
+- View code that reads the flag and the data **separately**: `@(subscribe [:items])` next to `@(subscribe [:items-loading?])`.
+
+Structural signal: the data path and the flag path are siblings (`{:items [...] :items-loading? true}`), not a single value whose shape encodes the lifecycle.
+
+## Why it's an anti-pattern
+
+A boolean flag is a one-bit state machine implemented in `assoc` calls. It cannot represent the **nine** legal page-level states the framework's canonical pattern enumerates: `:nothing`, `:loading`, `:empty`, `:one`, `:some`, `:too-many`, `:error`, `:reloading`, `:stale`. Worse, the flag's lifecycle is implicit — every code path that can terminate the in-flight operation must remember to flip it. The most common bug is a missing `dissoc` on the failure branch, leaving the UI stuck on a spinner. The data and the flag drift: rendering needs both, must guard against the `{:items [] :items-loading? true}` race (is this "initial load" or "loaded zero items"?), and ends up with the boolean-discriminator-sub cluster downstream.
+
+## The canonical fix
+
+[`skills/re-frame2/patterns/nine-states.md`](../../re-frame2/patterns/nine-states.md) — model the page-level lifecycle as a parallel `reg-machine` with `:data`, `:form`, and `:mode` regions; tag each state with per-axis intent; resolve render via a priority table in plain data.
+
+For the simpler one-axis case (just data lifecycle), the same `reg-machine` shape with a single region replaces the flag.
+
+Spec source: [`spec/Pattern-NineStates.md`](../../../spec/Pattern-NineStates.md).
+
+## Worked example
+
+**Before** — manual flag with `dissoc` discipline:
+
+```clojure
+(rf/reg-event-db :items/load-start
+  (fn [db _] (assoc db :items/loading? true :items/error nil)))
+
+(rf/reg-event-db :items/load-success
+  (fn [db [_ items]]
+    (-> db (dissoc :items/loading?) (assoc :items items))))
+
+(rf/reg-event-db :items/load-failure
+  (fn [db [_ err]]
+    (-> db (dissoc :items/loading?) (assoc :items/error err))))   ;; if you forget the dissoc, spinner-forever
+```
+
+**After** — machine with tag-based render selection:
+
+```clojure
+(rf/reg-machine :items
+  {:initial :nothing
+   :data    {:items [] :error nil}
+   :actions {:set-items (fn [d [_ items]] {:data (assoc d :items items :error nil)})
+             :set-error (fn [d [_ err]]   {:data (assoc d :error err)})}
+   :states
+   {:nothing {:tags #{:items/nothing} :on {:load :loading}}
+    :loading {:tags #{:items/loading :items/transient}
+              :on   {:load-success {:target :loaded :action :set-items}
+                     :load-failure {:target :error  :action :set-error}}}
+    :loaded  {:tags #{:items/loaded} :on {:load :loading}}
+    :error   {:tags #{:items/error}  :on {:load :loading}}}})
+
+;; View reads one tag-question, no flag-and-data race:
+@(rf/has-tag? :items :items/loading)
+```
+
+## Edge cases — when a boolean flag is fine
+
+- **Render-local UI state** that never crosses an asynchronous boundary — `(:menu-open? db)`, `(:tooltip-visible? db)`. No retry / failure / cancellation lifecycle exists, so no flag-coherence bug exists.
+- **Truly binary flags** that aren't lifecycle markers — `(:auth/authenticated? db)`, `(:user/preferences-loaded? db)` set once at boot. These are facts, not state machines.
+- **One-shot transitions** with no error or cancellation paths (rare). Even then, prefer a tiny machine for consistency — but a flag is not *wrong*.

--- a/skills/re-frame2-improver/references/manual-retry-loops.md
+++ b/skills/re-frame2-improver/references/manual-retry-loops.md
@@ -1,0 +1,69 @@
+# Anti-pattern — Manual HTTP retry loops
+
+Hand-rolled retry logic for HTTP calls — `setTimeout` re-dispatching the same fetch, retry counters in `app-db`, ad-hoc back-off arithmetic inside event handlers. Re-frame2 ships Managed HTTP precisely so this code does not have to exist in application files.
+
+## Detection rules
+
+Greppable signals (run inside any `.cljs` / `.cljc` source under review):
+
+- `setTimeout` *and* `dispatch` in the same handler body — `(js/setTimeout #(rf/dispatch [...]) ...)`.
+- A retry counter in `app-db`: keys named `:*/retries`, `:*/attempts`, `:*/retry-count`, or `(update db :*/attempts inc)` paired with a re-dispatch.
+- A `cljs-http`, `js/fetch`, `goog.net.XhrIo`, or `axios` call inside `reg-event-fx` whose `:on-failure` (or shaped equivalent) re-dispatches the same originating event id.
+- Exponential-back-off arithmetic inline in a handler — `(* base (Math/pow 2 attempt))`, `js/Math.pow`, `(min max-ms (* ...))`.
+
+Structural signal: the originating event id appears in **both** the `:dispatch` of the failure branch and the initial-dispatch trigger.
+
+## Why it's an anti-pattern
+
+Retry policy is a **transport concern**, not a domain concern. Hand-rolled loops bake transport semantics (when to retry, how long to wait, when to give up, how to abort an in-flight attempt) into application event handlers — where they cannot be observed, tested, or composed with state-machine lifetimes. They also obscure the eight failure categories the Managed HTTP taxonomy distinguishes (`:rf.http/transport`, `:rf.http/cors`, `:rf.http/timeout`, `:rf.http/aborted`, `:rf.http/http-4xx`, `:rf.http/http-5xx`, `:rf.http/decode-failure`, `:rf.http/payload`), collapsing them into a single "it failed, try again" branch that retries on `:rf.http/http-4xx` (which is almost never the right move).
+
+## The canonical fix
+
+[`skills/re-frame2/patterns/managed-http.md`](../../re-frame2/patterns/managed-http.md) — the `:rf.http/managed` fx. Pass a `:retry` map declaring the failure categories that warrant retry, the maximum attempts, and the back-off curve. The runtime handles scheduling, abort, and reply-addressing.
+
+Spec source: [`spec/014-HTTPRequests.md`](../../../spec/014-HTTPRequests.md) and [`spec/Pattern-RemoteData.md`](../../../spec/Pattern-RemoteData.md).
+
+## Worked example
+
+**Before** — hand-rolled retry in a handler:
+
+```clojure
+(rf/reg-event-fx :article/load
+  (fn [{:keys [db]} [_ slug attempt]]
+    (let [attempt (or attempt 0)]
+      {:db (assoc-in db [:article :status] :loading)
+       :fx [[:http-xhrio
+             {:method :get :uri (str "/articles/" slug)
+              :on-success [:article/loaded]
+              :on-failure [:article/retry slug attempt]}]]})))
+
+(rf/reg-event-fx :article/retry
+  (fn [_ [_ slug attempt]]
+    (when (< attempt 4)
+      {:fx [[:dispatch-later
+             {:ms    (min 5000 (* 250 (Math/pow 2 attempt)))
+              :event [:article/load slug (inc attempt)]}]]})))
+```
+
+**After** — Managed HTTP:
+
+```clojure
+(rf/reg-event-fx :article/load
+  (fn [{:keys [db]} [_ {:keys [slug] :as msg}]]
+    (if-let [reply (:rf/reply msg)]
+      (case (:kind reply)
+        :success {:db (assoc-in db [:article] {:status :loaded :data (:value reply)})}
+        :failure {:db (assoc-in db [:article] {:status :error  :error (:failure reply)})})
+      {:db (assoc-in db [:article :status] :loading)
+       :fx [[:rf.http/managed
+             {:request {:method :get :url (str "/articles/" slug)}
+              :retry   {:on           #{:rf.http/transport :rf.http/http-5xx :rf.http/timeout}
+                        :max-attempts 4
+                        :backoff      {:base-ms 250 :factor 2 :max-ms 5000 :jitter true}}}]]})))
+```
+
+## Edge cases — when manual is fine
+
+- **Domain-level retry** (e.g. "poll the job every 5s until it reports `:complete`") is semantic, not transport — model it in a state machine (`:invoke` with `:after`) rather than in `:retry`. The presence of `setTimeout` + `dispatch` is only an anti-pattern when it's compensating for transport failure.
+- **One-shot pages** that explicitly want no retry — `:retry` simply omitted from the Managed HTTP args. The anti-pattern is the manual loop, not the absence of retry.
+- **Non-HTTP transports** (a custom WebSocket protocol, IndexedDB, postMessage) — Managed HTTP doesn't apply; manual scheduling is the correct shape until a dedicated managed fx exists.

--- a/skills/re-frame2-improver/references/schemaless-events.md
+++ b/skills/re-frame2-improver/references/schemaless-events.md
@@ -1,0 +1,70 @@
+# Anti-pattern — Schemaless events at boundaries
+
+`reg-event-fx` (or `reg-event-db`) handlers that ingest untrusted data — HTTP responses, WebSocket frames, `postMessage` payloads, query-string params — with no `:spec` on the handler and no `reg-app-schema` for the destination `app-db` path. The event vector is a payload of unknown shape; the handler writes it into `app-db` without validating either side.
+
+## Detection rules
+
+Greppable signals:
+
+- `reg-event-fx` whose `:effects` (return-map `:fx`) include `:rf.http/managed`, `:http-xhrio`, websocket-id keywords, or whose handler reads `(:rf/reply event)` / `(:body event)` — and whose declaration has **no** `:spec` metadata key.
+- `reg-event-db` named `:*/loaded`, `:*/received`, `:*/decoded`, `:*/synced` whose handler writes `(assoc db :foo/bar payload)` — without a corresponding `reg-app-schema` somewhere in the codebase for `[:foo/bar]` or `[:foo]`.
+- Events that take an unstructured second arg — `(fn [db [_ data]] (assoc db :remote data))` where `data` is the raw HTTP body — and no validator-at-boundary interceptor (`spec/validate-at-boundary`).
+- New handlers introduced in a feature whose `app-db` writes use paths absent from `(rf/app-schemas)`.
+
+Structural signal: the boundary between **untrusted input** and **trusted `app-db`** is crossed without a Malli schema gate.
+
+## Why it's an anti-pattern
+
+`app-db` is the trust boundary. The whole substrate downstream of it (subs, views, machine reads, story snapshots, time-travel) assumes the values it reads conform to the application's mental model. A schemaless boundary event smuggles arbitrary data past the gate — a stale API field, a server schema change, a malformed query string — and the failure surfaces hundreds of dispatches later in a sub that crashes on a missing key. Schemas at boundaries are Cardinal Rule #4 (`skills/re-frame2/SKILL.md`).
+
+The runtime offers two complementary tools: handler `:spec` (validates the **event vector** before the handler runs) and `reg-app-schema` (validates the **app-db path** after the handler writes). The first catches malformed dispatches; the second catches malformed writes. Both are dev-elided in production unless explicitly attached at the boundary via `validate-at-boundary`.
+
+## The canonical fix
+
+[`skills/re-frame2/reference/fundamentals/schemas.md`](../../re-frame2/reference/fundamentals/schemas.md) — `reg-app-schema` for the destination path, `:spec` on the handler metadata, and the `validate-at-boundary` interceptor for handlers that must validate in production builds.
+
+Spec source: [`spec/010-Schemas.md`](../../../spec/010-Schemas.md). The `:rf.error/schema-validation-failure` error category is the corresponding instrumentation signal.
+
+## Worked example
+
+**Before** — schemaless boundary handler:
+
+```clojure
+(rf/reg-event-fx :article/load
+  (fn [{:keys [db]} [_ {:keys [slug] :as msg}]]
+    (if-let [reply (:rf/reply msg)]
+      {:db (assoc db :article (:value reply))}                  ;; trust everything that comes back
+      {:db (assoc-in db [:article :status] :loading)
+       :fx [[:rf.http/managed {:request {:url (str "/articles/" slug)}}]]})))
+```
+
+**After** — schema-validated boundary:
+
+```clojure
+(def Article
+  [:map
+   [:slug    :string]
+   [:title   :string]
+   [:body    :string]
+   [:authors [:vector [:map [:id :uuid] [:name :string]]]]])
+
+(rf/reg-app-schema [:article] Article)
+
+(rf/reg-event-fx :article/load
+  {:doc  "Load one article by slug."
+   :spec [:cat [:= :article/load] [:map [:slug :string]]]}
+  [spec/validate-at-boundary]
+  (fn [{:keys [db]} [_ {:keys [slug] :as msg}]]
+    (if-let [reply (:rf/reply msg)]
+      {:db (assoc db :article (:value reply))}                  ;; now validated by reg-app-schema
+      {:db (assoc-in db [:article :status] :loading)
+       :fx [[:rf.http/managed
+             {:request {:url (str "/articles/" slug)}
+              :decode  Article}]]})))                            ;; Managed HTTP decode also runs Article
+```
+
+## Edge cases — when schemaless is fine
+
+- **Internal-only events** that never touch untrusted data — UI toggles, navigation events with structurally-fixed arg shapes (`[:menu/toggle]`, `[:nav/to :route-id]`). The handler's args come from the application's own code; a `:spec` adds runtime cost in dev for no boundary-trust gain.
+- **Pre-alpha throwaway prototypes** where the schema would churn faster than the data — but mark the path with a `TODO` and add the schema before the path stabilises into a feature.
+- **Events whose payload is genuinely opaque** to the handler (it just forwards the value to another fx without inspecting it) — but then `:spec` should still pin the **shape of the forwarded slot** so the receiver downstream can rely on it.

--- a/skills/re-frame2-improver/references/view-side-hook-state.md
+++ b/skills/re-frame2-improver/references/view-side-hook-state.md
@@ -1,0 +1,83 @@
+# Anti-pattern — View-side state for non-render-local concerns
+
+`reagent.core/atom` declared inside (or at the top of) a view function and used to hold state that is **read by another component**, **persisted across the view's lifetime**, or **observed by event handlers**. Equivalent React forms: `useState` / `useRef` / `useReducer` carrying state that ought to live in `app-db`.
+
+## Detection rules
+
+Greppable signals inside `.cljs` / `.cljc` files containing views:
+
+- `(reagent/atom ...)` or `(r/atom ...)` declared **inside** a view function or at the top of a view namespace, and the resulting atom is **named & exported**, or referenced from a sibling view.
+- `(let [!state (reagent/atom ...)] ...)` inside a view body whose value is then derefed in a sibling component imported elsewhere.
+- React hooks (`uix.core/use-state`, `helix.hooks/use-state`, `(.useState js/React ...)`) holding values like `:current-filter`, `:selected-id`, `:modal-open?`, `:form-data` — concerns the rest of the application would want to query or dispatch about.
+- Event handlers (in `events.cljs`) reaching into a view-owned atom — e.g. `(deref view-ns/!current-tab)` from inside a `reg-event-fx`.
+
+Structural signal: the state lives outside `app-db` *but* is consumed by anything other than the very component that declared it.
+
+## Why it's an anti-pattern
+
+The re-frame2 mental model has one source of truth per frame: `app-db`. Subs project read-views; views render those projections; events transition `app-db`. State hidden inside a view's `reagent/atom` is:
+
+- **Invisible to subs** — sibling components must `require` the view's namespace just to deref the atom, coupling otherwise-independent views.
+- **Invisible to events** — handlers cannot consult the value as part of their decision (they'd have to reach into the view module, breaking the data-flow direction).
+- **Invisible to pair-tools** — re-frame-pair2's `app-db` inspector, time-travel, and re-frame-10x's epoch buffer see only `app-db`. A view-side atom is dark to every diagnostic.
+- **Invisible to SSR / story / replay** — the story artefact serialises `app-db`; the view-atom is reconstructed only when the view mounts, and its value at render time is not what produced the snapshot.
+- **Not testable** — `compute-sub` and `compute-event` operate on `app-db` values; a test for "what does the view show when state is X" requires mounting the view to set the atom.
+
+A `reagent/atom` is legitimate when its state is **render-local** — a hovered-over flag, an in-flight input draft that never leaves the component, an animation tick. The smell is using it as a stand-in for `app-db`.
+
+## The canonical fix
+
+Move the state to `app-db` behind a `reg-sub`. Reads use `(subscribe [:sub-id])`; writes go through `reg-event-db` / `reg-event-fx`. See [`skills/re-frame2/reference/fundamentals/subs.md`](../../re-frame2/reference/fundamentals/subs.md) and [`skills/re-frame2/reference/fundamentals/events.md`](../../re-frame2/reference/fundamentals/events.md).
+
+Spec source: [`spec/Principles.md`](../../../spec/Principles.md) (single source of truth for application state) and [`spec/004-Views.md`](../../../spec/004-Views.md) (views as pure projections).
+
+## Worked example
+
+**Before** — view-side atom shared across components:
+
+```clojure
+(ns my-app.dashboard
+  (:require [reagent.core :as r]
+            [re-frame.core :as rf]))
+
+(defonce !current-tab (r/atom :overview))                       ;; <-- module-level mutable state
+
+(defn tab-buttons []
+  [:div
+   (for [t [:overview :stats :settings]]
+     [:button {:on-click #(reset! !current-tab t)} (name t)])])
+
+(defn tab-content []
+  [:div (case @!current-tab                                     ;; deref'd by sibling — coupling
+          :overview [overview-pane]
+          :stats    [stats-pane]
+          :settings [settings-pane])])
+```
+
+**After** — `app-db` + sub + events:
+
+```clojure
+(rf/reg-event-db :dashboard/select-tab
+  (fn [db [_ tab]] (assoc-in db [:dashboard :current-tab] tab)))
+
+(rf/reg-sub :dashboard/current-tab
+  (fn [db _] (get-in db [:dashboard :current-tab] :overview)))
+
+(defn tab-buttons []
+  [:div
+   (for [t [:overview :stats :settings]]
+     [:button {:on-click #(rf/dispatch [:dashboard/select-tab t])} (name t)])])
+
+(defn tab-content []
+  [:div (case @(rf/subscribe [:dashboard/current-tab])
+          :overview [overview-pane]
+          :stats    [stats-pane]
+          :settings [settings-pane])])
+```
+
+## Edge cases — when view-side state is fine
+
+- **Genuinely render-local UI** — hover state, focus-within bookkeeping, drag-and-drop in-flight offsets, transient animation values that no other component consults. These can stay as `reagent/atom` or `useState`.
+- **Performance-critical render-loop state** that would cause `app-db` churn at every frame (60fps animation cursors). Promote to `app-db` only when another part of the app needs to read it.
+- **Form-draft state in tightly-scoped one-shot forms** that don't need re-frame-10x debugging or replay. Once the form gets non-trivial, move it to `app-db` behind a state machine — see [`skills/re-frame2/patterns/forms.md`](../../re-frame2/patterns/forms.md).
+- **Component-local refs to DOM nodes** (`useRef`, `(r/create-ref)`) — these hold a *handle*, not domain state. Not in scope.


### PR DESCRIPTION
## Summary

Lands the launch anti-pattern catalogue for `re-frame2-improver`. The scaffold from #684 (rf2-u8j31) enumerated 6 planned leaves under `references/`; this PR populates them.

**6 new leaves** (453 LoC added, 16 README lines refactored):

| Leaf | Anti-pattern | Canonical fix |
|---|---|---|
| [`manual-retry-loops.md`](https://github.com/day8/re-frame2/blob/rf2-bquci-improver-anti-pattern-catalogue/skills/re-frame2-improver/references/manual-retry-loops.md) (69 lines) | `setTimeout` + counters + manual back-off inside `reg-event-fx` | Managed HTTP — `skills/re-frame2/patterns/managed-http.md`, Spec 014 |
| [`boolean-discriminator-subs.md`](https://github.com/day8/re-frame2/blob/rf2-bquci-improver-anti-pattern-catalogue/skills/re-frame2-improver/references/boolean-discriminator-subs.md) (72 lines) | 3+ mutually-exclusive boolean subs on one path | Tags + `has-tag?` — `skills/re-frame2/reference/state-machines/tags.md`, Spec 005 |
| [`manual-loading-flags.md`](https://github.com/day8/re-frame2/blob/rf2-bquci-improver-anti-pattern-catalogue/skills/re-frame2-improver/references/manual-loading-flags.md) (69 lines) | `(assoc db :foo/loading? true)` paired with `dissoc` discipline | Nine States — `skills/re-frame2/patterns/nine-states.md` |
| [`schemaless-events.md`](https://github.com/day8/re-frame2/blob/rf2-bquci-improver-anti-pattern-catalogue/skills/re-frame2-improver/references/schemaless-events.md) (70 lines) | Boundary handler ingests untrusted payload without `:spec` / `reg-app-schema` | Spec 010 schemas — `skills/re-frame2/reference/fundamentals/schemas.md` |
| [`imperative-effects.md`](https://github.com/day8/re-frame2/blob/rf2-bquci-improver-anti-pattern-catalogue/skills/re-frame2-improver/references/imperative-effects.md) (68 lines) | Direct `js/localStorage`, DOM, console calls inside event handlers | Data-only fx — `skills/re-frame2/reference/fundamentals/fx.md` |
| [`view-side-hook-state.md`](https://github.com/day8/re-frame2/blob/rf2-bquci-improver-anti-pattern-catalogue/skills/re-frame2-improver/references/view-side-hook-state.md) (83 lines) | `reagent/atom` / `useState` holding state read by sibling components | `app-db` + `reg-sub` — `skills/re-frame2/reference/fundamentals/subs.md` |

Each leaf follows the per-leaf format locked in `references/README.md`:

- **Detection rules** — greppable signals + structural cues.
- **Why it's an anti-pattern** — what invariant breaks, what downstream cost.
- **The canonical fix** — cross-linked to canonical pattern leaf and the relevant spec.
- **Worked example** — before/after CLJS snippets (~10 lines each side).
- **Edge cases** — when the smell is actually fine (avoids false-positives).

`references/README.md` is restructured from a "scaffold only — planned leaves" placeholder into a catalogue index with a per-leaf cross-reference table + the per-leaf format spec + a growth procedure.

## Cross-references

- Source design: `ai/findings/improver-architecture-20260513-1752.md` §Angle 2 (rf2-zf7zd).
- Scaffold landed via #684 (rf2-u8j31).
- Bonus anti-patterns (`view-only-renders-happy-state`, `foreign-frame-app-db-writes`) deferred per the findings.
- Shared `retro-protocol.md` (referenced by `SKILL.md`) lands separately under rf2-dhe9v — its broken-link entry in `python scripts/check_doc_slugs.py` predates this PR.

## Test plan

- [x] `python scripts/check_doc_slugs.py` — no new broken links from this PR. The 2 pre-existing broken links (`SKILL.md` → `retro-protocol.md`) are rf2-dhe9v territory.
- [x] All cross-links to `skills/re-frame2/patterns/`, `skills/re-frame2/reference/`, and `spec/` resolve.
- [x] Per-leaf size 68-83 lines — within the 50-80 target.
- [ ] Human read-through for tone alignment with existing `re-frame-pair-improver2/references/` shape.