### PR TITLE
feat(http): redact sensitive query-string params + handler-meta-driven full-URL scrub (rf2-2p8wr)

### DIFF
--- a/implementation/http/src/re_frame/http.cljc
+++ b/implementation/http/src/re_frame/http.cljc
@@ -93,6 +93,23 @@
   See `re-frame.http-privacy/clear-sensitive-headers!`."
   privacy/clear-sensitive-headers!)
 
+(def declare-sensitive-query-param!
+  "Spec 014 §Privacy (rf2-2p8wr) — extend the query-string-param denylist
+  with an app-specific sensitive parameter name. Names stored lower-
+  cased; matching is case-insensitive. URLs carrying a denylisted param
+  have the *value* redacted (preserving param name + position) in every
+  `:rf.http/*` trace event regardless of the originating handler's
+  `:sensitive?` flag.
+  See `re-frame.http-privacy/declare-sensitive-query-param!`."
+  privacy/declare-sensitive-query-param!)
+
+(def clear-sensitive-query-params!
+  "Spec 014 §Privacy (rf2-2p8wr) — reset the app-extended query-param
+  denylist (defaults remain). Test-only; production code should not
+  need this.
+  See `re-frame.http-privacy/clear-sensitive-query-params!`."
+  privacy/clear-sensitive-query-params!)
+
 (defn- build
   "Build a `[:rf.http/managed args-map]` fx vector for the given verb,
   URL, and caller args. Internal — the public helpers are thin wrappers."

--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -24,6 +24,7 @@
   §Failure categories, §Reply addressing, §Retry and backoff."
   (:require [clojure.string  :as str]
             [re-frame.interop :as interop]
+            [re-frame.http-privacy :as privacy]
             [re-frame.trace   :as trace]
             [re-frame.util-json :as util-json])
   #?(:clj (:import [java.net URLEncoder])))
@@ -141,19 +142,26 @@
 
 (defn- maybe-emit-decode-defaulted!
   "Per Spec 014 §`:auto`: emit `:rf.warning/decode-defaulted` when the
-  user did NOT supply `:decode`."
-  [{:keys [decode-supplied? request-id url content-type resolved-decoder]}]
+  user did NOT supply `:decode`.
+
+  Per rf2-2p8wr: the URL passes through `privacy/prepare-emit-tags`,
+  which redacts denylisted query-string param values (and stamps
+  `:sensitive?` when the originating request was sensitive or when a
+  denylisted param name was present)."
+  [{:keys [decode-supplied? request-id url content-type resolved-decoder sensitive?]}]
   (when (and (not decode-supplied?) interop/debug-enabled?)
     (trace/emit! :warning :rf.warning/decode-defaulted
-                 {:request-id       request-id
-                  :url              url
-                  :content-type     content-type
-                  :resolved-decoder resolved-decoder})))
+                 (privacy/prepare-emit-tags
+                   {:request-id       request-id
+                    :url              url
+                    :content-type     content-type
+                    :resolved-decoder resolved-decoder}
+                   (true? sensitive?)))))
 
 (defn decode-response-body
   "Per Spec 014 §Decoding. Returns the decoded value or throws an
   ex-info that the caller maps to `:rf.http/decode-failure`."
-  [{:keys [body-text headers decode decode-supplied? request-id url]}]
+  [{:keys [body-text headers decode decode-supplied? request-id url sensitive?]}]
   (let [content-type (or (get headers "content-type")
                          (get headers "Content-Type"))
         decoder      (cond
@@ -169,6 +177,7 @@
          :request-id       request-id
          :url              url
          :content-type     content-type
+         :sensitive?       sensitive?
          :resolved-decoder (cond
                              (keyword? resolved) resolved
                              :else               :auto)}))

--- a/implementation/http/src/re_frame/http_privacy.cljc
+++ b/implementation/http/src/re_frame/http_privacy.cljc
@@ -9,7 +9,7 @@
   redacting known-sensitive slots before the value reaches the trace
   surface.
 
-  Two cooperating mechanisms, mirroring Spec 009's `:sensitive?` /
+  Three cooperating mechanisms, mirroring Spec 009's `:sensitive?` /
   `with-redacted` split:
 
   1. **Header denylist** (this namespace) — a canonical set of always-
@@ -19,18 +19,30 @@
      leaking would be a leak even if the surrounding handler was not
      declared sensitive).
 
-  2. **Per-call / per-handler `:sensitive?`** — the originating event
+  2. **Query-param denylist** (this namespace, rf2-2p8wr) — a canonical
+     set of always-sensitive query-string parameter names (e.g.
+     `api_key`, `access_token`, `auth`). URLs carrying these params
+     are redacted **inline** in every `:rf.http/*` trace event that
+     carries a `:url` slot, regardless of the handler / request
+     `:sensitive?` flag. Same rationale as the header denylist: the
+     param name itself is the signal.
+
+  3. **Per-call / per-handler `:sensitive?`** — the originating event
      handler's `:sensitive?` registration metadata propagates to every
      `:rf.http/*` trace event emitted within the cascade. A per-call
      `:sensitive?` arg on the `:rf.http/managed` args map opts in for
      a specific request when the handler itself is not sensitive (e.g.
      a generic POST handler that is sensitive only when posting to
-     `/auth/login`).
+     `/auth/login`). When the request is sensitive, **all** query
+     params are redacted (broader rule than the denylist).
 
   The runtime stamps `:sensitive? true` on the emitted trace event's
   `:tags` (and at the top level when the core runtime stamp lands per
   rf2 G1) so consumers consult one keyword to decide ship / drop /
-  redact.
+  redact. When ANY query param is redacted by the denylist alone (no
+  per-call sensitivity), the trace event still stamps `:sensitive? true`
+  — the presence of a denylisted query param is itself a signal that
+  the request carries an auth secret.
 
   ## Defaults and extensibility
 
@@ -41,14 +53,20 @@
   `(declare-sensitive-header! \"X-My-Auth\")` — names are
   case-insensitive; the registry stores lower-cased.
 
+  `default-query-param-denylist` covers the canonical query-string-auth
+  surface (api_key, apikey, access_token, auth, token, key, secret,
+  password, session, signature, sig). Apps extend via
+  `(declare-sensitive-query-param! \"my_token\")` — names are
+  case-insensitive; the registry stores lower-cased.
+
   ## Production elision
 
   The redact / stamp helpers all gate on `interop/debug-enabled?` at
   their call sites (the same gate as `trace/emit!`). In production
   builds the trace surface elides entirely; the privacy machinery is
-  moot. The header denylist atom itself ships in production (it's
-  app-readable state — `declare-sensitive-header!` writes through),
-  but no walker runs against it without the trace surface."
+  moot. The denylist atoms themselves ship in production (they're
+  app-readable state — `declare-sensitive-*!` writes through), but no
+  walker runs against them without the trace surface."
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [re-frame.registrar :as registrar]))
@@ -109,6 +127,72 @@
       (contains? (set/union default-header-denylist @extra-headers)
                  (str/lower-case header-name)))))
 
+;; ---- query-param denylist (rf2-2p8wr) -------------------------------------
+
+(def default-query-param-denylist
+  "Canonical always-sensitive HTTP query-string parameter names, lower-
+  cased. URLs carrying these params have the *values* redacted in
+  `:rf.http/*` trace events regardless of the handler's `:sensitive?`
+  flag — the param names themselves are the signal (mirrors the header
+  denylist contract).
+
+  Drawn from common API-key / bearer-token idioms in older REST APIs,
+  webhook receivers, and signed-URL schemes. Apps extend at boot via
+  `declare-sensitive-query-param!` for app-specific param names (e.g.
+  `\"shop_token\"`, `\"hmac\"`)."
+  #{"api_key"
+    "apikey"
+    "api-key"
+    "access_token"
+    "accesstoken"
+    "auth"
+    "auth_token"
+    "authtoken"
+    "key"
+    "token"
+    "secret"
+    "password"
+    "passwd"
+    "session"
+    "session_id"
+    "sessionid"
+    "signature"
+    "sig"
+    "hmac"})
+
+(defonce
+  ^{:doc "App-extended query-param denylist. Augments
+  `default-query-param-denylist`. Names stored lower-cased. Cleared by
+  `clear-sensitive-query-params!` for test ergonomics."}
+  extra-query-params
+  (atom #{}))
+
+(defn declare-sensitive-query-param!
+  "Declare a query-string parameter name as sensitive. Stored lower-
+  cased; matching is case-insensitive when the redactor consults the
+  merged set. Returns the new merged set (defaults ∪ extras)."
+  [param-name]
+  (when (string? param-name)
+    (swap! extra-query-params conj (str/lower-case param-name)))
+  (set/union default-query-param-denylist @extra-query-params))
+
+(defn clear-sensitive-query-params!
+  "Reset the app-extended query-param denylist to empty (default
+  denylist remains). Test-only — invoked by reset fixtures alongside
+  `clear-sensitive-headers!`."
+  []
+  (reset! extra-query-params #{})
+  nil)
+
+(defn sensitive-query-param?
+  "Predicate: is `param-name` in the merged query-param denylist?
+  Case-insensitive."
+  [param-name]
+  (boolean
+    (when (string? param-name)
+      (contains? (set/union default-query-param-denylist @extra-query-params)
+                 (str/lower-case param-name)))))
+
 ;; ---- redaction sentinel ---------------------------------------------------
 
 (def redacted-sentinel
@@ -117,6 +201,15 @@
   produce it as a payload value. Consumers wanting \"was this redacted?\"
   check `(= :rf/redacted v)`."
   :rf/redacted)
+
+(def ^:private redacted-url-token
+  "Inline string form of the `:rf/redacted` sentinel suitable for splicing
+  into a URL string. Trace consumers parsing the URL still see a structural
+  token they can detect (`:rf%2Fredacted` once URL-encoded into the wire
+  string we serialise). The unencoded form is `:rf/redacted` — identical
+  text to the keyword's `pr-str` — chosen so a human inspecting a trace
+  event reads the same sentinel they see in any other redacted slot."
+  ":rf/redacted")
 
 (defn redact-headers
   "Walk `headers-map` (string→string or string→vector-of-strings); replace
@@ -136,6 +229,87 @@
                  v)))
       {}
       headers-map)))
+
+;; ---- URL query-string redaction (rf2-2p8wr) -------------------------------
+
+(defn- split-url-on-query
+  "Split `url-str` into `[base query-string]`. `query-string` is nil
+  when the URL has no `?`. Preserves URL fragments (`#…`) on the
+  query-string side so the redactor can put them back verbatim."
+  [url-str]
+  (let [qidx (str/index-of url-str "?")]
+    (if (nil? qidx)
+      [url-str nil]
+      [(subs url-str 0 qidx)
+       (subs url-str (inc qidx))])))
+
+(defn- split-query-on-fragment
+  "Split `query-and-fragment` on the first `#` so the fragment can be
+  preserved verbatim past the redaction step. Returns `[query fragment]`
+  where `fragment` includes the leading `#` or is nil."
+  [query-and-fragment]
+  (if (nil? query-and-fragment)
+    [nil nil]
+    (let [fidx (str/index-of query-and-fragment "#")]
+      (if (nil? fidx)
+        [query-and-fragment nil]
+        [(subs query-and-fragment 0 fidx)
+         (subs query-and-fragment fidx)]))))
+
+(defn- redact-query-param
+  "Given a single `name=value` pair (string), return the redacted form:
+  `name=:rf/redacted` if the param is denylisted OR `force-all?` is
+  true; the pair unchanged otherwise. Tolerates malformed pairs (no
+  `=`, empty value)."
+  [pair force-all?]
+  (let [eq-idx (str/index-of pair "=")
+        [pname _pvalue] (if eq-idx
+                          [(subs pair 0 eq-idx) (subs pair (inc eq-idx))]
+                          [pair nil])]
+    (if (or force-all? (sensitive-query-param? pname))
+      (str pname "=" redacted-url-token)
+      pair)))
+
+(defn redact-url-query-string
+  "Redact denylisted query-string parameter values in `url-str`.
+
+  When `sensitive?` is true, redacts **every** param value (the broader
+  rule per Spec 014 §Privacy — a sensitive request leaks nothing).
+  When `sensitive?` is false, redacts only values whose param name is
+  in the merged query-param denylist.
+
+  The redaction shape preserves param name + position; only the value
+  is replaced with the framework-reserved `:rf/redacted` text token
+  (e.g. `?api_key=SECRET&page=2` → `?api_key=:rf/redacted&page=2`).
+  Fragment portion (`#…`) preserved verbatim.
+
+  Returns `[redacted-url any-redacted?]` where `any-redacted?` is true
+  iff at least one param value was redacted (the caller uses this to
+  decide whether to stamp `:sensitive?` per the denylist-is-signal
+  rule). Nil / non-string / no-query inputs return `[url-str false]`."
+  [url-str sensitive?]
+  (cond
+    (not (string? url-str))
+    [url-str false]
+
+    :else
+    (let [[base query-and-fragment] (split-url-on-query url-str)
+          [query fragment]          (split-query-on-fragment query-and-fragment)]
+      (if (str/blank? query)
+        [url-str false]
+        (let [pairs    (str/split query #"&")
+              redacted (mapv (fn [p] (redact-query-param p (true? sensitive?)))
+                             pairs)
+              changed? (boolean (some true? (map not= pairs redacted)))
+              rebuilt  (str base "?" (str/join "&" redacted) (or fragment ""))]
+          [rebuilt changed?])))))
+
+(defn redact-url
+  "Convenience wrapper around `redact-url-query-string` that returns only
+  the redacted URL string. Use when the caller does not need the
+  any-redacted? flag (e.g. inside a generic tag-walker)."
+  [url-str sensitive?]
+  (first (redact-url-query-string url-str sensitive?)))
 
 ;; ---- per-request / per-handler :sensitive? --------------------------------
 
@@ -180,7 +354,9 @@
   "Given a tags map about to ride a `:rf.http/*` trace event, redact
   the request-side payload when `sensitive?` is true. Always redacts
   denylisted headers regardless of `sensitive?` — the header denylist
-  is unconditional.
+  is unconditional. URL query-string values whose param name is in the
+  query-param denylist (rf2-2p8wr) are always redacted regardless of
+  `sensitive?` — denylisted param names are themselves the signal.
 
   Idempotent and total: missing slots are left alone."
   [tags sensitive?]
@@ -188,6 +364,11 @@
     ;; Always-on header redaction (denylist).
     (map? (:headers tags))
     (update :headers redact-headers)
+
+    ;; URL query-string redaction — always-on for denylisted params
+    ;; (rf2-2p8wr); when sensitive? true ALL params are scrubbed.
+    (string? (:url tags))
+    (update :url redact-url sensitive?)
 
     ;; Sensitive-request redaction — body becomes the sentinel.
     (and sensitive? (contains? tags :body))
@@ -200,12 +381,19 @@
 (defn redact-failure
   "Given a failure map (per Spec 014 §Failure categories) about to ride
   a `:rf.http/*` trace event, redact response-side payload slots when
-  `sensitive?` is true. Always redacts headers via the denylist."
+  `sensitive?` is true. Always redacts headers via the denylist; always
+  redacts URL query-string values whose param name is in the query-
+  param denylist (rf2-2p8wr) — denylisted param names are the signal."
   [failure sensitive?]
   (when failure
     (cond-> failure
       (map? (:headers failure))
       (update :headers redact-headers)
+
+      ;; URL query-string redaction — always-on for denylisted params
+      ;; (rf2-2p8wr); when sensitive? true ALL params are scrubbed.
+      (string? (:url failure))
+      (update :url redact-url sensitive?)
 
       (and sensitive? (contains? failure :body))
       (assoc :body redacted-sentinel)
@@ -238,22 +426,64 @@
   (cond-> tags
     sensitive? (assoc :sensitive? true)))
 
+(defn- query-denylist-hit?
+  "Return true iff `url-str` carries a query-string param whose name is
+  on the merged query-param denylist. The denylist-alone hit is itself
+  a signal that the request carries an auth secret (rf2-2p8wr) — the
+  prepare-emit-* composers use this to stamp `:sensitive?` even when
+  the originating handler was not declared sensitive."
+  [url-str]
+  (and (string? url-str)
+       (let [[_ q-and-f] (split-url-on-query url-str)
+             [q _]       (split-query-on-fragment q-and-f)]
+         (and (not (str/blank? q))
+              (boolean
+                (some (fn [pair]
+                        (let [eq-idx (str/index-of pair "=")
+                              pname  (if eq-idx (subs pair 0 eq-idx) pair)]
+                          (sensitive-query-param? pname)))
+                      (str/split q #"&")))))))
+
 (defn prepare-emit-tags
   "Compose `redact-request-tags` + `stamp-sensitive` for a request-side
   trace event (`:rf.http/retry-attempt`, `:rf.http/aborted-on-actor-destroy`,
   `:rf.warning/decode-defaulted`, `:rf.warning/cljs-only-key-ignored-on-jvm`).
-  Returns a tags map ready for `trace/emit!`."
+  Returns a tags map ready for `trace/emit!`.
+
+  Two distinct decisions per rf2-2p8wr:
+
+  - **What to redact in `:url`** uses the `sensitive?` arg (handler /
+    per-call). When `sensitive?` true, ALL query-string param values
+    are scrubbed; when false, only denylisted param values are scrubbed.
+    The denylist-only redaction does NOT promote the URL scrub to ALL
+    params — denylisted names are signals, not licenses to scrub
+    unrelated params.
+
+  - **Whether to stamp `:sensitive?`** OR-combines `sensitive?` with a
+    denylist-hit check on `:url` / `:failure :url`. A denylisted query-
+    param name alone is enough to stamp the event — the name is the
+    signal that the request carries a secret."
   [tags sensitive?]
-  (-> tags
-      (redact-request-tags sensitive?)
-      (cond-> (contains? tags :failure)
-              (update :failure redact-failure sensitive?))
-      (stamp-sensitive sensitive?)))
+  (let [denylist-hit? (or (query-denylist-hit? (:url tags))
+                          (query-denylist-hit? (get-in tags [:failure :url])))
+        stamp?        (or (true? sensitive?) denylist-hit?)]
+    (-> tags
+        (redact-request-tags (true? sensitive?))
+        (cond-> (contains? tags :failure)
+                (update :failure redact-failure (true? sensitive?)))
+        (stamp-sensitive stamp?))))
 
 (defn prepare-emit-failure
   "Compose `redact-failure` + `stamp-sensitive` for an error-side trace
   event (`emit-error!` on a `:rf.http/*` failure kind). The whole
-  failure map is the tags map for `emit-error!`."
+  failure map is the tags map for `emit-error!`.
+
+  Two distinct decisions per rf2-2p8wr — same split as `prepare-emit-
+  tags`: URL redaction uses the explicit `sensitive?` arg; `:sensitive?`
+  stamping OR-combines that arg with a query-param denylist hit on the
+  failure's `:url`."
   [failure sensitive?]
-  (-> (redact-failure failure sensitive?)
-      (stamp-sensitive sensitive?)))
+  (let [denylist-hit? (query-denylist-hit? (:url failure))
+        stamp?        (or (true? sensitive?) denylist-hit?)]
+    (-> (redact-failure failure (true? sensitive?))
+        (stamp-sensitive stamp?))))

--- a/implementation/http/src/re_frame/http_transport_cljs.cljc
+++ b/implementation/http/src/re_frame/http_transport_cljs.cljc
@@ -321,7 +321,8 @@
                                            :decode    decode
                                            :decode-supplied? decode-supplied?
                                            :request-id request-id
-                                           :url        url})
+                                           :url        url
+                                           :sensitive? (:sensitive? ctx')})
                                 accepted (encoding/run-accept accept decoded {:status status})]
                             (cond
                               (contains? accepted :ok)

--- a/implementation/http/src/re_frame/http_transport_jvm.cljc
+++ b/implementation/http/src/re_frame/http_transport_jvm.cljc
@@ -328,7 +328,8 @@
                                                        :decode    decode
                                                        :decode-supplied? decode-supplied?
                                                        :request-id request-id
-                                                       :url        url})
+                                                       :url        url
+                                                       :sensitive? (:sensitive? ctx')})
                                             accepted (encoding/run-accept accept decoded {:status status})]
                                         (finalise-success!
                                           (assoc ctx' :decoded decoded) accepted))

--- a/implementation/http/test/re_frame/http_privacy_integration_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_integration_test.clj
@@ -35,6 +35,7 @@
   ((requiring-resolve 're-frame.machines/reset-counters!))
   (http-managed/clear-all-in-flight!)
   (privacy/clear-sensitive-headers!)
+  (privacy/clear-sensitive-query-params!)
   (trace/clear-trace-cbs!)
   (t))
 
@@ -261,5 +262,123 @@
               headers (get-in ev [:tags :headers])]
           (is (= :rf/redacted (find-header headers "X-Honeycomb-Team"))
               "app-declared sensitive header was redacted"))
+        (finally
+          (stop-server! srv))))))
+
+;; ---- 6. URL query-string denylist applies on failure trace events (rf2-2p8wr) -----
+
+(deftest sensitive-query-param-redacted-in-failure-url
+  (testing "a denylisted query-string param (api_key) has its value redacted
+            in the failure trace event's URL even when the handler is not
+            declared sensitive — the param name itself is the signal"
+    (let [srv (start-server!
+                (fn [^HttpExchange ex]
+                  (write-response! ex 500 "text/plain" "boom")))
+          port (:port srv)
+          captured (atom [])]
+      (try
+        (trace/register-trace-cb! :test/capture
+                                  (fn [ev] (swap! captured conj ev)))
+
+        (rf/reg-event-fx :api/fetch
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:method :get
+                                 :url    (str "http://127.0.0.1:" port "/x?api_key=SECRET&page=2")}
+                    :on-failure nil}]]}))
+
+        (rf/dispatch-sync [:api/fetch])
+
+        (let [_ (wait-for!
+                  (fn []
+                    (some #(= :rf.http/http-5xx (:operation %)) @captured))
+                  3000)
+              ev (first (filter #(= :rf.http/http-5xx (:operation %)) @captured))
+              url (get-in ev [:tags :url])]
+          (is (string? url))
+          (is (str/includes? url "api_key=:rf/redacted")
+              "denylisted api_key value redacted in URL")
+          (is (str/includes? url "page=2")
+              "non-denylisted page param preserved")
+          (is (or (true? (:sensitive? ev))
+                  (true? (get-in ev [:tags :sensitive?])))
+              "denylist hit stamps :sensitive? on the trace event"))
+        (finally
+          (stop-server! srv))))))
+
+;; ---- 7. Sensitive handler scrubs ALL URL query params (rf2-2p8wr) ----------------
+
+(deftest sensitive-handler-redacts-all-url-query-params
+  (testing "when the originating handler is :sensitive?, ALL query-string
+            params (denylisted or not) are scrubbed in the failure trace
+            event's URL — the broader rule (rf2-2p8wr)"
+    (let [srv (start-server!
+                (fn [^HttpExchange ex]
+                  (write-response! ex 500 "text/plain" "boom")))
+          port (:port srv)
+          captured (atom [])]
+      (try
+        (trace/register-trace-cb! :test/capture
+                                  (fn [ev] (swap! captured conj ev)))
+
+        (rf/reg-event-fx :auth/login
+          {:doc        "Sensitive login op."
+           :sensitive? true}
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:method :get
+                                 :url    (str "http://127.0.0.1:" port "/x?user_id=42&page=2")}
+                    :on-failure nil}]]}))
+
+        (rf/dispatch-sync [:auth/login])
+
+        (let [_ (wait-for!
+                  (fn []
+                    (some #(= :rf.http/http-5xx (:operation %)) @captured))
+                  3000)
+              ev (first (filter #(= :rf.http/http-5xx (:operation %)) @captured))
+              url (get-in ev [:tags :url])]
+          (is (string? url))
+          (is (str/includes? url "user_id=:rf/redacted")
+              "every param value scrubbed when sensitive — user_id")
+          (is (str/includes? url "page=:rf/redacted")
+              "every param value scrubbed when sensitive — page"))
+        (finally
+          (stop-server! srv))))))
+
+;; ---- 8. App-extended query-param denylist applies on failure URL (rf2-2p8wr) -----
+
+(deftest app-extended-query-param-denylist-redacts-failure-url
+  (testing "declare-sensitive-query-param! extends URL redaction to app-defined params"
+    (privacy/declare-sensitive-query-param! "shop_token")
+    (let [srv (start-server!
+                (fn [^HttpExchange ex]
+                  (write-response! ex 500 "text/plain" "boom")))
+          port (:port srv)
+          captured (atom [])]
+      (try
+        (trace/register-trace-cb! :test/capture
+                                  (fn [ev] (swap! captured conj ev)))
+
+        (rf/reg-event-fx :api/fetch
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:method :get
+                                 :url    (str "http://127.0.0.1:" port "/x?shop_token=abc&page=2")}
+                    :on-failure nil}]]}))
+
+        (rf/dispatch-sync [:api/fetch])
+
+        (let [_ (wait-for!
+                  (fn []
+                    (some #(= :rf.http/http-5xx (:operation %)) @captured))
+                  3000)
+              ev (first (filter #(= :rf.http/http-5xx (:operation %)) @captured))
+              url (get-in ev [:tags :url])]
+          (is (string? url))
+          (is (str/includes? url "shop_token=:rf/redacted")
+              "app-declared sensitive query-param was redacted")
+          (is (str/includes? url "page=2")
+              "non-denylisted page param preserved"))
         (finally
           (stop-server! srv))))))

--- a/implementation/http/test/re_frame/http_privacy_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_test.clj
@@ -18,6 +18,7 @@
 (defn- reset-runtime [t]
   (registrar/clear-all!)
   (privacy/clear-sensitive-headers!)
+  (privacy/clear-sensitive-query-params!)
   (t))
 
 (use-fixtures :each reset-runtime)
@@ -238,3 +239,213 @@
     (is (= :rf/redacted (:body r)))
     (is (= :rf/redacted (get-in r [:headers "Set-Cookie"])))
     (is (true? (:sensitive? r)))))
+
+;; ---- 8. query-param denylist (rf2-2p8wr) ----------------------------------
+
+(deftest default-query-param-denylist-covers-canonical-set
+  (testing "the default denylist contains the canonical query-string-auth surface"
+    (is (contains? privacy/default-query-param-denylist "api_key"))
+    (is (contains? privacy/default-query-param-denylist "access_token"))
+    (is (contains? privacy/default-query-param-denylist "token"))
+    (is (contains? privacy/default-query-param-denylist "auth"))
+    (is (contains? privacy/default-query-param-denylist "key"))
+    (is (contains? privacy/default-query-param-denylist "secret"))
+    (is (contains? privacy/default-query-param-denylist "password"))
+    (is (contains? privacy/default-query-param-denylist "signature"))
+    (is (contains? privacy/default-query-param-denylist "session"))))
+
+(deftest sensitive-query-param-is-case-insensitive
+  (testing "param-name match ignores case"
+    (is (privacy/sensitive-query-param? "api_key"))
+    (is (privacy/sensitive-query-param? "API_KEY"))
+    (is (privacy/sensitive-query-param? "Api_Key"))
+    (is (privacy/sensitive-query-param? "access_token"))
+    (is (privacy/sensitive-query-param? "ACCESS_TOKEN"))))
+
+(deftest non-sensitive-query-params-pass
+  (testing "ordinary query params are not in the denylist"
+    (is (not (privacy/sensitive-query-param? "page")))
+    (is (not (privacy/sensitive-query-param? "limit")))
+    (is (not (privacy/sensitive-query-param? "q")))
+    (is (not (privacy/sensitive-query-param? "id")))
+    (is (not (privacy/sensitive-query-param? "user_id")))))
+
+(deftest declare-sensitive-query-param-extends-denylist
+  (testing "app-extended denylist composes with defaults"
+    (privacy/declare-sensitive-query-param! "shop_token")
+    (is (privacy/sensitive-query-param? "shop_token"))
+    (is (privacy/sensitive-query-param? "SHOP_TOKEN"))
+    ;; defaults still apply
+    (is (privacy/sensitive-query-param? "api_key"))
+    (privacy/clear-sensitive-query-params!)
+    (is (not (privacy/sensitive-query-param? "shop_token")))
+    ;; defaults survive the clear
+    (is (privacy/sensitive-query-param? "api_key"))))
+
+(deftest sensitive-query-param-tolerates-non-string
+  (testing "nil / non-string is not sensitive"
+    (is (not (privacy/sensitive-query-param? nil)))
+    (is (not (privacy/sensitive-query-param? :keyword)))
+    (is (not (privacy/sensitive-query-param? 42)))))
+
+;; ---- 9. redact-url-query-string (rf2-2p8wr) -------------------------------
+
+(deftest redact-url-denylist-replaces-sensitive-values
+  (testing "denylisted query-param values become :rf/redacted; non-denylisted preserved"
+    (let [[url any?] (privacy/redact-url-query-string
+                       "https://api.example.com/users?api_key=SECRET&page=2"
+                       false)]
+      (is (= "https://api.example.com/users?api_key=:rf/redacted&page=2" url))
+      (is (true? any?)))))
+
+(deftest redact-url-sensitive-true-redacts-everything
+  (testing "when sensitive? true, ALL params are redacted (broader rule)"
+    (let [[url any?] (privacy/redact-url-query-string
+                       "https://api.example.com/users?user_id=42&page=2&sort=asc"
+                       true)]
+      (is (= "https://api.example.com/users?user_id=:rf/redacted&page=:rf/redacted&sort=:rf/redacted"
+             url))
+      (is (true? any?)))))
+
+(deftest redact-url-no-query-string-unchanged
+  (testing "URL with no query string returns unchanged"
+    (let [[url any?] (privacy/redact-url-query-string
+                       "https://api.example.com/users/42" false)]
+      (is (= "https://api.example.com/users/42" url))
+      (is (false? any?)))))
+
+(deftest redact-url-no-denylist-hit-unchanged
+  (testing "URL with no denylisted params returns unchanged when not sensitive"
+    (let [[url any?] (privacy/redact-url-query-string
+                       "https://api.example.com/users?page=2&limit=10" false)]
+      (is (= "https://api.example.com/users?page=2&limit=10" url))
+      (is (false? any?)))))
+
+(deftest redact-url-preserves-fragment
+  (testing "fragment is preserved verbatim after the redacted query string"
+    (let [[url _] (privacy/redact-url-query-string
+                    "https://api.example.com/x?token=abc&page=2#section-3" false)]
+      (is (= "https://api.example.com/x?token=:rf/redacted&page=2#section-3" url)))))
+
+(deftest redact-url-empty-value-redacted
+  (testing "param with empty value still has the value slot replaced"
+    (let [[url _] (privacy/redact-url-query-string
+                    "https://api.example.com/x?token=&page=2" false)]
+      (is (= "https://api.example.com/x?token=:rf/redacted&page=2" url)))))
+
+(deftest redact-url-handles-url-encoded-values
+  (testing "URL-encoded special chars in values are replaced wholesale, not parsed"
+    (let [[url _] (privacy/redact-url-query-string
+                    "https://api.example.com/x?api_key=a%20b%26c&page=2" false)]
+      (is (= "https://api.example.com/x?api_key=:rf/redacted&page=2" url)))))
+
+(deftest redact-url-multiple-denylist-hits
+  (testing "all denylisted params in a URL are redacted"
+    (let [[url any?] (privacy/redact-url-query-string
+                       "https://api.example.com/x?api_key=A&token=B&page=2&secret=C" false)]
+      (is (= "https://api.example.com/x?api_key=:rf/redacted&token=:rf/redacted&page=2&secret=:rf/redacted"
+             url))
+      (is (true? any?)))))
+
+(deftest redact-url-app-extended-denylist
+  (testing "app-extended denylist applies on URL redaction"
+    (privacy/declare-sensitive-query-param! "shop_token")
+    (let [[url _] (privacy/redact-url-query-string
+                    "https://api.example.com/x?shop_token=abc&page=2" false)]
+      (is (= "https://api.example.com/x?shop_token=:rf/redacted&page=2" url)))))
+
+(deftest redact-url-tolerates-non-string
+  (is (= [nil false] (privacy/redact-url-query-string nil false)))
+  (is (= [42 false] (privacy/redact-url-query-string 42 false))))
+
+(deftest redact-url-handles-malformed-pair
+  (testing "param without `=` is not crashed on"
+    (let [[url _] (privacy/redact-url-query-string
+                    "https://api.example.com/x?orphan&api_key=SECRET" false)]
+      ;; The orphan is not in the denylist and is preserved; api_key is redacted.
+      (is (= "https://api.example.com/x?orphan&api_key=:rf/redacted" url)))))
+
+;; ---- 10. redact-request-tags integrates URL redaction --------------------
+
+(deftest redact-request-tags-redacts-url-denylist-always
+  (testing "URL with denylisted query param is redacted regardless of :sensitive?"
+    (let [tags {:url "https://api.example.com/x?api_key=SECRET&page=2"}
+          r    (privacy/redact-request-tags tags false)]
+      (is (= "https://api.example.com/x?api_key=:rf/redacted&page=2" (:url r))))))
+
+(deftest redact-request-tags-redacts-all-params-when-sensitive
+  (testing "URL gets ALL params redacted when sensitive? is true"
+    (let [tags {:url "https://api.example.com/x?user_id=42&page=2"}
+          r    (privacy/redact-request-tags tags true)]
+      (is (= "https://api.example.com/x?user_id=:rf/redacted&page=:rf/redacted" (:url r))))))
+
+;; ---- 11. redact-failure integrates URL redaction -------------------------
+
+(deftest redact-failure-redacts-url-denylist-always
+  (testing "URL on failure map redacted regardless of :sensitive?"
+    (let [f {:kind :rf.http/http-5xx
+             :status 500
+             :url "https://api.example.com/x?token=abc&page=2"}
+          r (privacy/redact-failure f false)]
+      (is (= "https://api.example.com/x?token=:rf/redacted&page=2" (:url r))))))
+
+(deftest redact-failure-redacts-all-url-params-when-sensitive
+  (testing "all URL params redacted on failure when sensitive? true"
+    (let [f {:kind :rf.http/http-5xx
+             :status 500
+             :url "https://api.example.com/x?user_id=42&page=2"}
+          r (privacy/redact-failure f true)]
+      (is (= "https://api.example.com/x?user_id=:rf/redacted&page=:rf/redacted" (:url r))))))
+
+;; ---- 12. prepare-emit-* stamps :sensitive? on denylist-only hit ----------
+
+(deftest prepare-emit-tags-stamps-sensitive-on-denylist-hit
+  (testing "denylisted query-param alone (no per-call :sensitive?) stamps :sensitive?"
+    (let [tags {:url "https://api.example.com/x?api_key=SECRET&page=2"}
+          r    (privacy/prepare-emit-tags tags false)]
+      (is (= "https://api.example.com/x?api_key=:rf/redacted&page=2" (:url r)))
+      (is (true? (:sensitive? r))
+          "denylist hit alone is signal — :sensitive? stamped"))))
+
+(deftest prepare-emit-tags-stamps-sensitive-on-failure-url-denylist-hit
+  (testing "denylisted URL inside a failure map stamps :sensitive? at tags top level"
+    (let [tags {:url "/x"
+                :failure {:kind :rf.http/http-5xx
+                          :url "https://api.example.com/x?token=abc&page=2"}}
+          r    (privacy/prepare-emit-tags tags false)]
+      (is (= "https://api.example.com/x?token=:rf/redacted&page=2"
+             (get-in r [:failure :url])))
+      (is (true? (:sensitive? r))))))
+
+(deftest prepare-emit-tags-no-stamp-when-no-denylist-and-not-sensitive
+  (testing "URL with no denylisted params and no per-call :sensitive? does NOT stamp"
+    (let [tags {:url "https://api.example.com/x?page=2&limit=10"}
+          r    (privacy/prepare-emit-tags tags false)]
+      (is (= "https://api.example.com/x?page=2&limit=10" (:url r)))
+      (is (not (contains? r :sensitive?))))))
+
+(deftest prepare-emit-failure-stamps-sensitive-on-denylist-hit
+  (testing "denylisted URL on failure stamps :sensitive? even when not declared sensitive"
+    (let [f {:kind :rf.http/http-5xx
+             :status 500
+             :url "https://api.example.com/x?api_key=SECRET&page=2"}
+          r (privacy/prepare-emit-failure f false)]
+      (is (= "https://api.example.com/x?api_key=:rf/redacted&page=2" (:url r)))
+      (is (true? (:sensitive? r))))))
+
+(deftest prepare-emit-failure-no-stamp-when-no-denylist
+  (testing "non-denylisted URL on failure with sensitive? false does NOT stamp"
+    (let [f {:kind :rf.http/http-5xx
+             :status 500
+             :url "https://api.example.com/x?page=2"}
+          r (privacy/prepare-emit-failure f false)]
+      (is (not (contains? r :sensitive?))))))
+
+(deftest prepare-emit-failure-handler-sensitive-redacts-all-url-params
+  (testing "handler-sensitive flag forces ALL URL params redacted even non-denylisted"
+    (let [f {:kind :rf.http/http-5xx
+             :status 500
+             :url "https://api.example.com/x?user_id=42&page=2"}
+          r (privacy/prepare-emit-failure f true)]
+      (is (= "https://api.example.com/x?user_id=:rf/redacted&page=:rf/redacted" (:url r)))
+      (is (true? (:sensitive? r))))))

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -949,7 +949,35 @@ Apps extend the denylist for app-specific tokens (e.g. `X-Honeycomb-Team`, `X-St
 
 Names stored lower-cased; matching is case-insensitive. The default denylist is fixed at boot; the app-extended set is mutable and clearable for test ergonomics via `(rf.http/clear-sensitive-headers!)`.
 
-### 2. Per-call / per-request / per-handler `:sensitive?`
+### 2. Query-param denylist (always-on) (rf2-2p8wr)
+
+A parallel-axis canonical set of HTTP query-string **parameter names** is **always sensitive** — the names themselves declare the value secret regardless of the surrounding handler's `:sensitive?` flag. URLs in `:rf.http/*` trace events that carry a denylisted query-string parameter have the **value** redacted inline: `?api_key=SECRET&page=2` → `?api_key=:rf/redacted&page=2`. The parameter name and position are preserved so the operator can still see which endpoint was called and which parameters were present, but the secret value is replaced with the framework-reserved sentinel text. Parameter-name matching is **case-insensitive**.
+
+The v1 closed denylist:
+
+| Param name | Why |
+|---|---|
+| `api_key` / `apikey` / `api-key` | API key in URL query — common legacy idiom |
+| `access_token` / `accesstoken` | Bearer-token idiom carried on the URL |
+| `auth` / `auth_token` / `authtoken` | Generic auth-token names |
+| `token` | Generic bearer-token name |
+| `key` | Generic key name (covers `?key=...` API-key idioms) |
+| `secret` | Generic secret-name |
+| `password` / `passwd` | Password in URL — rare but seen on legacy POST-as-GET endpoints |
+| `session` / `session_id` / `sessionid` | Session identifier carried on the URL |
+| `signature` / `sig` / `hmac` | Signed-URL HMAC / signature value |
+
+Apps extend the denylist for app-specific tokens (e.g. `shop_token` for Shopify, `signature` variants in webhook receivers) via:
+
+```clojure
+(rf.http/declare-sensitive-query-param! "shop_token")
+```
+
+Names stored lower-cased; matching is case-insensitive. The default denylist is fixed at boot; the app-extended set is mutable and clearable for test ergonomics via `(rf.http/clear-sensitive-query-params!)`.
+
+A query-param denylist hit **alone** (no per-handler / per-call `:sensitive?`) **stamps `:sensitive? true`** on the resulting trace event — the presence of a denylisted parameter name is itself a signal that the request carries an auth secret, and downstream privacy-honouring consumers should treat the event accordingly. This is the analogue of the header denylist contract: the name is the signal.
+
+### 3. Per-call / per-request / per-handler `:sensitive?`
 
 Three OR-reduced sources contribute the request-side `:sensitive?` flag for a given `:rf.http/managed` invocation:
 
@@ -985,14 +1013,16 @@ Any source set to `true` makes the request sensitive; all sources defaulting to 
             :sensitive? true}]]}))
 ```
 
-### 3. Trace-event redaction + stamping rules
+### 4. Trace-event redaction + stamping rules
 
 For every `:rf.http/*` trace event the runtime emits (`:rf.http/retry-attempt`, `:rf.http/aborted-on-actor-destroy`, the eight `:rf.http/*` failure categories from [§Failure categories](#failure-categories-closed-set), `:rf.warning/decode-defaulted`), implementations MUST:
 
 1. **Redact denylisted headers** in `:headers` slots regardless of the effective `:sensitive?` flag.
-2. **Redact body / body-text / decoded / detail** slots when the effective `:sensitive?` is true. Specifically: `:body` (request and response), `:body-text` (decode-failure raw text), `:decoded` (the pre-`:accept` decoded value carried by `:rf.http/accept-failure`), and `:detail` (the user-supplied failure map carried by `:rf.http/accept-failure`). All slot values become `:rf/redacted`.
-3. **Redact `:params`** (query-string params) when the effective `:sensitive?` is true. Query parameters frequently carry tokens (`?api_key=…`) and the redaction rule matches the body — when the request is sensitive, anything that rides the wire is.
-4. **Stamp `:sensitive?`** on the trace event per [Spec 009 §Trace-event field](009-Instrumentation.md#trace-event-field-sensitive-at-the-top-level). The canonical contract is that the flag rides at the top level of the trace envelope (consumers consult `(:sensitive? ev)` for a one-keyword read). The HTTP layer stamps `:sensitive? true` on the tags map passed to `trace/emit!` / `trace/emit-error!`. If the core trace surface implements the [rf2-isdwf](#) hoist (Spec 009 §Privacy core-stamping), the flag is moved from tags to top-level by the emit walker; if core does not yet hoist, the flag stays under `:tags`. Once core lands the hoist universally, the tags-slot becomes redundant but harmless. Absent (NOT `false`) when not sensitive — per Spec 009 line 1176 "Consumers treat absent as false."
+2. **Redact denylisted query-string parameter values** in `:url` slots regardless of the effective `:sensitive?` flag (rf2-2p8wr). Param-name + position preserved; the value is replaced inline with the `:rf/redacted` text token.
+3. **Redact body / body-text / decoded / detail** slots when the effective `:sensitive?` is true. Specifically: `:body` (request and response), `:body-text` (decode-failure raw text), `:decoded` (the pre-`:accept` decoded value carried by `:rf.http/accept-failure`), and `:detail` (the user-supplied failure map carried by `:rf.http/accept-failure`). All slot values become `:rf/redacted`.
+4. **Redact `:params`** (the structured query-string params map on the request side) when the effective `:sensitive?` is true. The whole `:params` map value becomes `:rf/redacted`.
+5. **Redact ALL `:url` query-string param values** when the effective `:sensitive?` is true (broader rule than the always-on denylist) — when the request is sensitive, anything that rides the wire is. Non-denylisted params (e.g. `user_id=42`) are scrubbed alongside denylisted ones.
+6. **Stamp `:sensitive?`** on the trace event per [Spec 009 §Trace-event field](009-Instrumentation.md#trace-event-field-sensitive-at-the-top-level). The canonical contract is that the flag rides at the top level of the trace envelope (consumers consult `(:sensitive? ev)` for a one-keyword read). The HTTP layer stamps `:sensitive? true` on the tags map passed to `trace/emit!` / `trace/emit-error!`. A **query-param denylist hit alone** (no per-handler / per-call `:sensitive?`) also stamps `:sensitive? true` — the denylisted name is itself the signal. If the core trace surface implements the [rf2-isdwf](#) hoist (Spec 009 §Privacy core-stamping), the flag is moved from tags to top-level by the emit walker; if core does not yet hoist, the flag stays under `:tags`. Once core lands the hoist universally, the tags-slot becomes redundant but harmless. Absent (NOT `false`) when not sensitive — per Spec 009 line 1176 "Consumers treat absent as false."
 
 The cascade-wide stamping uses the **innermost in-scope handler** rule from [Spec 009 §Privacy](009-Instrumentation.md#the-sensitive-registration-metadata-key): each handler in a cascade contributes its own `:sensitive?` reading. A sensitive handler dispatching a non-sensitive child event does NOT transitively widen the flag — the HTTP fx fired inside the child handler's scope reflects the child's flag. The OR-reduce-by-cascade rollup is the consumer's responsibility (group by `:dispatch-id`).
 


### PR DESCRIPTION
## Summary

Follow-on from rf2-bma05 PR #675. The HTTP `:sensitive?` coverage redacted headers + bodies but did NOT yet redact query-string auth params in URLs. A request to `https://api.example.com/users?api_key=SECRET&page=2` still landed in trace events with the secret visible.

This PR closes that gap with two cooperating mechanisms, parallel to the existing header-denylist contract:

1. **Query-param denylist** (always-on) — 19 canonical names: `api_key`, `apikey`, `api-key`, `access_token`, `accesstoken`, `auth`, `auth_token`, `authtoken`, `token`, `key`, `secret`, `password`, `passwd`, `session`, `session_id`, `sessionid`, `signature`, `sig`, `hmac`. Always redacted in trace events regardless of handler `:sensitive?` — the param name is the signal. App-extensible via `(rf.http/declare-sensitive-query-param! "shop_token")`. Cleared in tests via `(rf.http/clear-sensitive-query-params!)`.

2. **Handler-driven full-URL scrub** — when the originating handler / per-call args declares `:sensitive?`, ALL query params (denylisted or not) get scrubbed (the broader rule per Spec 014 §Privacy).

## Redaction shape (worked example)

```
;; Not sensitive, denylist hit:
https://api.example.com/users?api_key=SECRET&page=2
↓
https://api.example.com/users?api_key=:rf/redacted&page=2
;; (+ trace event stamps :sensitive? — denylist name is the signal)

;; Handler/per-call :sensitive?:
https://api.example.com/users?user_id=42&page=2
↓
https://api.example.com/users?user_id=:rf/redacted&page=:rf/redacted
```

The inline string sentinel `:rf/redacted` matches the `pr-str` of the `:rf/redacted` keyword so consumers see the same token they detect in any other redacted slot. Param name and position are preserved so the operator can still see which endpoint was called and which parameters were present.

## What changed

- `implementation/http/src/re_frame/http_privacy.cljc` — new query-param denylist (`default-query-param-denylist`, `extra-query-params`, `declare-sensitive-query-param!`, `clear-sensitive-query-params!`, `sensitive-query-param?`); new URL redactor (`redact-url-query-string`, `redact-url`); `redact-request-tags` / `redact-failure` redact `:url`; `prepare-emit-tags` / `prepare-emit-failure` stamp `:sensitive?` on denylist hit
- `implementation/http/src/re_frame/http_encoding.cljc` — `maybe-emit-decode-defaulted!` and `decode-response-body` accept `:sensitive?` and route the warning emit through `privacy/prepare-emit-tags` (fixes the `:rf.warning/decode-defaulted` URL slot)
- `implementation/http/src/re_frame/http_transport_cljs.cljc` / `http_transport_jvm.cljc` — thread `:sensitive?` into `decode-response-body`
- `implementation/http/src/re_frame/http.cljc` — re-export `declare-sensitive-query-param!` + `clear-sensitive-query-params!` on the `rf.http` surface
- `spec/014-HTTPRequests.md` — new §Privacy subsection "2. Query-param denylist (always-on)" with the 19-name table; section numbering bumped; rule 4 (now rule 6) expanded with denylist-hit stamping + ALL-params-on-sensitive scrub

## Test count

- **24 new unit tests** in `http_privacy_test.clj` (denylist defaults, case-insensitivity, app extension, URL redaction edge cases: no-query, empty value, URL-encoded chars, fragment preservation, malformed pair, multiple denylist hits, app-extended; integration with `redact-request-tags` / `redact-failure`; `:sensitive?` stamping on denylist hit at both `prepare-emit-tags` and `prepare-emit-failure`)
- **3 new integration tests** in `http_privacy_integration_test.clj` (denylisted param in failure URL redacted with stamp; sensitive handler scrubs all URL params; app-extended denylist on failure URL)

Full results: **134 http tests** + **1688 CLJS tests** + **production elision probe** all pass.

## Test plan

- [x] `clojure -M:test` from `implementation/http/` — 134 tests, 369 assertions, 0 failures, 0 errors
- [x] `npm run test:cljs` from `implementation/` — 1688 tests, 4677 assertions, 0 failures, 0 errors
- [x] `npm run test:elision` from `implementation/` — passes (HTTP trace emit sentinels still present in dev, elide in production)