### PR TITLE
feat(pair2-mcp): lazy-summary default for all snapshot slices (rf2-u2029)

### DIFF
--- a/tools/pair2-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/pair2-mcp/spec/003-Tool-Catalogue.md
@@ -224,14 +224,19 @@ implementation.
 `":rf/default"`, default `"all"`), `include` (array of slice names —
 subset of `["app-db" "sub-cache" "machines" "epochs" "traces"]`,
 default all five), `path` (EDN-encoded vector or JSON array of segment
-strings — path-slicing for the `:app-db` slice, rf2-tygdv),
-`epochs-mode` (string — `"diff"` (default) or `"full"`, see `trace-window`
-§Diff-encoded `:db-after`; controls the `:epochs` slice's wire shape,
-rf2-1wdzp), `dedup` (boolean, default `true` — applies structural dedup
-per-frame to each `:epochs` slot; see §Structural dedup at the top of
-this catalogue), `elision` (boolean, default `true` — applies the
-size-elision walker to each frame's `:app-db` slice; see §Size-elision
-at the top of this catalogue, rf2-urjnc), `build` (string).
+strings — path-slicing for the `:app-db` slice, rf2-tygdv), `mode`
+(string — `"summary"` (default) or `"full"` — global lazy-summary
+default for every rich slice; see §Lazy-summary mode below, rf2-u2029),
+`modes` (object — per-slice override of `mode`, e.g.
+`{"app-db": "full", "epochs": "summary"}`; takes precedence over the
+global `mode` arg, rf2-u2029), `epochs-mode` (string — `"diff"`
+(default) or `"full"`, see `trace-window` §Diff-encoded `:db-after`;
+controls the `:epochs` slice's wire shape, rf2-1wdzp), `dedup`
+(boolean, default `true` — applies structural dedup per-frame to each
+`:epochs` slot; see §Structural dedup at the top of this catalogue),
+`elision` (boolean, default `true` — applies the size-elision walker
+to each frame's `:app-db` slice; see §Size-elision at the top of this
+catalogue, rf2-urjnc), `build` (string).
 
 **Returns**:
 
@@ -239,7 +244,12 @@ at the top of this catalogue, rf2-urjnc), `build` (string).
 {:ok? true
  :frames :all|[<frame-id>...]
  :include [:app-db :sub-cache :machines :epochs :traces]
- :mode :summary | :path-sliced
+ :mode :summary | :full | :path-sliced
+ :slice-modes {:app-db    :summary | :full | :path-sliced
+               :sub-cache :summary | :full
+               :machines  :summary | :full
+               :epochs    :summary | :full
+               :traces    :summary | :full}
  :epochs-mode :diff | :full
  :dedup   true | false
  :elision true | false
@@ -254,6 +264,14 @@ at the top of this catalogue, rf2-urjnc), `build` (string).
  :path-not-found {<frame-id> {:exists? false
                               :deepest-valid-prefix [...]}}  ; when present}
 ```
+
+Each slice in `:snapshot` is either the raw payload (when its resolved
+mode is `:full` or, for `:app-db`, when a `path` arg is supplied) or a
+`{:rf.mcp/summary {:type :map|:vector|:set|:seq|:scalar :keys [...]
+:count N :bytes ~B}}` marker (when its resolved mode is `:summary` —
+the default). The top-level `:mode` echoes the snapshot's primary
+posture for backward compatibility; the per-slice `:slice-modes` map
+tells the agent which slices it can drill into without a second call.
 
 The `:machines` slice combines the global registrar's machine-id list
 (`rf/machines`) with the per-frame state stash at `[:rf/machines]` in
@@ -271,24 +289,55 @@ the legacy shape (rare — only needed if you drive time-travel restore
 off the wire response rather than via `rf/restore-epoch`). See
 `trace-window` above for the wire shape and rationale.
 
+### Lazy-summary mode (rf2-u2029)
+
+Every rich slice in the snapshot response defaults to a
+`{:rf.mcp/summary {:type ... :keys [...] :count N :bytes ~B}}`
+marker — the top-level shape without committing the token budget.
+The default snapshot call (no `mode`, no `path`) returns summary
+markers for all five slices. A 1MB-app-db / 10-epoch-history
+discovery snapshot collapses from tens of millions of tokens to
+under 500. Agents drill into the slice they actually need via one
+of three opt-ins:
+
+- **Global `mode "full"`**: every rich slice expands to its raw
+  payload. Equivalent to the pre-rf2-u2029 default. The wire cap
+  (rf2-rvyzy) becomes the backstop.
+- **Per-slice `modes {"epochs": "full"}`** (and equivalents): expand
+  only the named slice; others stay summarised. Per-slice override
+  beats the global `mode` arg. Slice names match the `include` arg's
+  vocabulary: `app-db`, `sub-cache`, `machines`, `epochs`, `traces`.
+- **`path` arg** (`:app-db` slice only): return the subtree at the
+  requested path. Path-slicing supersedes the slice-level mode for
+  `:app-db` — a `path` arg always wins.
+
+The `:mode` slot in the response echoes the snapshot's primary posture
+(`:summary` | `:full` | `:path-sliced`). The `:slice-modes` map gives
+the per-slice resolution so the agent can pattern-match on which
+slices are markers vs raw payloads without re-deriving the choice
+from the request shape.
+
+The summary marker's `:bytes` hint is computed AFTER diff-encoding
+and dedup — it reflects the post-shrink wire cost the agent would
+pay to expand the slice, not the raw in-memory size. A map with more
+than 64 top-level keys truncates the `:keys` list and flags
+`:keys-truncated? true` so the marker itself can never blow the
+wire cap.
+
 ### `:app-db` slice modes (rf2-tygdv)
 
-The `:app-db` slice has two response modes governed by the `path` arg:
+The `:app-db` slice has three response postures:
 
-- **`:mode :summary`** (default, no `path`): the `:app-db` slice is
-  replaced with a `{:rf.mcp/summary {:type :map :keys [...] :count
-  ... :bytes ~...}}` marker — the top-level shape without committing
-  the token budget. A map with more than 64 top-level keys truncates
-  the `:keys` list and flags `:keys-truncated? true` so the marker
-  itself can never blow the wire cap. The agent drills down with a
-  follow-up call carrying `path`, or with the `get-path` tool.
+- **`:mode :summary`** (default, no `path`, no `mode` override): the
+  `:app-db` slice is the `{:rf.mcp/summary ...}` marker described
+  above (rf2-tygdv landed this for `:app-db`; rf2-u2029 generalised
+  to every rich slice).
+- **`:mode :full`** (no `path`, `mode "full"` or `modes {"app-db":
+  "full"}`): the full slice — equivalent to passing root path `[]`.
 - **`:mode :path-sliced`** (with `path`): the `:app-db` slice is the
   subtree at `(get-in db path)`. An out-of-range path surfaces
   per-frame in the top-level `:path-not-found` map with the
   deepest-valid-prefix attached so the agent can re-aim.
-- **Root path `[]`**: the agent explicitly asks for the full `:app-db`
-  — equivalent to the legacy default. The wire cap then becomes the
-  backstop.
 
 Path vocabulary matches `get-in`: a vector of keys / indices. EDN
 strings (`":cart"`, `"0"`, `"-1"`) are parsed by the reader; non-EDN
@@ -297,13 +346,15 @@ the `get-path` tool below and as Causa-MCP's `:path` mechanism — one
 shape across the tool family.
 
 The other slices (`:sub-cache`, `:machines`, `:epochs`, `:traces`)
-pass through unchanged. Pass a smaller `include` to subset (e.g.
-`{:frames "all" :include ["app-db" "epochs"]}` for a quick "state +
-recent history" probe). Per-op fine-grain reads (`get-path` against
-the app-db, `eval-cljs` against `runtime/sub-cache`, etc.) stay
-available — they're the right surface when you genuinely need one
-slice for one frame. `snapshot` is the right surface when you don't
-know yet which slice carries the answer.
+follow the same `mode` / `modes` opt-in shape. Pass a smaller
+`include` to drop slices entirely (e.g. `{:frames "all" :include
+["app-db" "epochs"]}` for a quick "state + recent history" probe).
+Per-op fine-grain reads (`get-path` against the app-db, `eval-cljs`
+against `runtime/sub-cache`, etc.) stay available — they're the
+right surface when you genuinely need one slice for one frame.
+`snapshot` is the right surface when you don't know yet which slice
+carries the answer; the lazy-summary default keeps that discovery
+workflow inside the wire cap by construction.
 
 `:reason :runtime-not-preloaded` if the preload hasn't run;
 `:reason :snapshot-failed` (with `:message`) on any other failure.

--- a/tools/pair2-mcp/spec/Principles.md
+++ b/tools/pair2-mcp/spec/Principles.md
@@ -185,16 +185,20 @@ internals.
 - **Pluggable strategy**: the wrapper dispatches on a
   `:strategy` keyword. Today only `:truncate-with-marker` is
   implemented (replace the payload with the overflow marker).
-  Path-slicing and lazy-summary already landed (rf2-tygdv) but
-  as per-tool input-shape concerns: the `snapshot` and
-  `get-path` tools accept a `:path` arg and default to a
-  `{:rf.mcp/summary ...}` response for the unbounded `:app-db`
-  slice, so the cap stays a backstop rather than the primary
-  mechanism for the common case. Diff-encoded `:db-after`
-  (rf2-1wdzp) and structural dedup (rf2-obpa9) also live at the
-  tool surface — see the dedicated mechanisms below. They run
-  BEFORE the cap so the wrapper measures the already-shrunk
-  payload.
+  Path-slicing and lazy-summary already landed (rf2-tygdv,
+  generalised to every rich snapshot slice in rf2-u2029) as
+  per-tool input-shape concerns: the `snapshot` tool accepts a
+  `:path` arg, a global `:mode` arg, and a per-slice `:modes`
+  override, and defaults to a `{:rf.mcp/summary ...}` response
+  for every rich slice (`:app-db`, `:sub-cache`, `:machines`,
+  `:epochs`, `:traces`) — the discovery workflow ("I don't know
+  which slice carries the answer") stays inside the cap by
+  construction rather than relying on the cap as a backstop.
+  `get-path` continues to take a `:path` arg for the targeted-read
+  surface. Diff-encoded `:db-after` (rf2-1wdzp) and structural
+  dedup (rf2-obpa9) also live at the tool surface — see the
+  dedicated mechanisms below. They run BEFORE the cap so the
+  wrapper measures the already-shrunk payload.
 - **Silent truncation is not allowed**: a payload that exceeds
   the cap MUST NOT be shipped in any partial form that would
   let the agent host parse it as a valid response. The marker

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -1112,7 +1112,7 @@
       [scrubbed @dropped])))
 
 ;; ---------------------------------------------------------------------------
-;; Tree-summary for the `:app-db` slice (rf2-tygdv).
+;; Tree-summary for snapshot slices (rf2-tygdv, generalised rf2-u2029).
 ;;
 ;; Per causa-mcp's wire-protocol Principles §"4. Lazy summary", the
 ;; default response mode for a rich nested value is a *summary*, not the
@@ -1124,12 +1124,22 @@
 ;;                     :count <int>                ; non-scalars only
 ;;                     :bytes ~<int>}}             ; pr-str char count
 ;;
-;; Applied to snapshot's `:app-db` slice when the caller does NOT pass
-;; `:path`. Agents drill down by re-calling with `:path [:cart :items]`
-;; (mechanism 2). The other slices (:sub-cache :machines :epochs
-;; :traces) already have their own pagination / bounded shapes; only
-;; `:app-db` was the unbounded blow-the-cap surface flagged in
-;; rf2-jlq5j's findings doc.
+;; rf2-tygdv landed this for the `:app-db` slice only. rf2-u2029
+;; generalises it to every rich slice in the snapshot response:
+;; `:app-db`, `:sub-cache`, `:machines`, `:epochs`, `:traces`. The
+;; default snapshot call (no `:mode`, no `:path`) returns a summary
+;; marker for each slice instead of the full payload — the discovery
+;; workflow ("I don't know which slice carries the answer") fits the
+;; cap by construction. Agents drill in via:
+;;
+;;   - `:path` arg (`:app-db` slice only) for path-slicing, OR
+;;   - `:mode "full"` (every rich slice expands), OR
+;;   - `:modes {"app-db" "full" "sub-cache" "summary" ...}` for per-slice
+;;     override.
+;;
+;; Path-slicing on `:app-db` supersedes the slice-level mode for that
+;; slice (the slicer already returns a bounded subtree). Other slices
+;; respect mode independently.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private summary-keys-cap
@@ -1201,28 +1211,39 @@
 
 (defn- slice-app-db-in-snapshot
   "Post-process the raw snapshot map: for each frame's `:app-db` slice,
-  apply path-slicing (when `path` is present) or summarisation (when
-  `path` is nil).
+  apply path-slicing (when `path` is present), summarisation (when
+  `path` is nil and the resolved app-db mode is `:summary`), or pass
+  the slice through (when the resolved mode is `:full`).
+
+  `app-db-mode` is `:summary` (default) or `:full`. The `:path` arg
+  takes precedence — when a non-nil path is supplied the slice is
+  always path-sliced regardless of mode. An empty path `[]` is
+  semantically equivalent to `:full` mode (agent explicitly asking
+  for the whole slice).
 
   Returns `[processed-snapshot per-frame-path-status]` where
   `per-frame-path-status` is `{<frame-id> {:exists? bool
                                             :deepest-valid-prefix [...]}}`
   populated only when `path` is supplied and at least one frame's
   path didn't resolve. Empty map when path is nil."
-  [snapshot path]
+  [snapshot path app-db-mode]
   (if-not (map? snapshot)
     [snapshot {}]
     (let [status* (atom {})
           missing (js-obj)
+          full?   (= :full app-db-mode)
           process-frame
           (fn [frame-id frame-map]
             (if-not (and (map? frame-map) (contains? frame-map :app-db))
               frame-map
               (let [db (:app-db frame-map)]
                 (cond
-                  ;; No path: summarise.
-                  (nil? path)
+                  ;; No path + summary mode (rf2-tygdv default): summarise.
+                  (and (nil? path) (not full?))
                   (update frame-map :app-db tree-summary)
+                  ;; No path + full mode: full slice (rf2-u2029 opt-in).
+                  (nil? path)
+                  frame-map
                   ;; Root path (`[]`): return full db (agent opted in
                   ;; explicitly). Equivalent to legacy default behaviour.
                   (empty? path)
@@ -1240,6 +1261,140 @@
                                  (assoc m fid (process-frame fid fmap)))
                                {} snapshot)]
       [processed @status*])))
+
+;; ---------------------------------------------------------------------------
+;; Lazy-summary default for every rich slice (rf2-u2029).
+;;
+;; Generalises rf2-tygdv's `:app-db` summary default to `:sub-cache`,
+;; `:machines`, `:epochs`, `:traces`. Per spec/Principles.md §Per-tool
+;; budget discipline, "the default MUST be `:sample` for any op whose
+;; `:full` payload can exceed the cap" — every rich slice in snapshot
+;; can do that.
+;;
+;; The resolved mode for each slice is governed by:
+;;
+;;   1. `:modes` per-slice override (highest priority).
+;;   2. Global `:mode` arg (`:summary` (default) or `:full`).
+;;   3. For `:app-db` specifically: a non-nil `:path` arg forces
+;;      `:path-sliced` regardless of mode (path-slicer already gives
+;;      a bounded subtree). An empty path `[]` means "explicit full".
+;;
+;; This function walks each frame's slice map and, for rich slices
+;; resolved to `:summary`, replaces the value with the `tree-summary`
+;; marker. `:app-db` is handled by `slice-app-db-in-snapshot`
+;; upstream; this function skips `:app-db` to avoid double-work.
+;; ---------------------------------------------------------------------------
+
+(def ^:private summarisable-slices
+  "Slices for which a summary marker is a meaningful budget win.
+  `:app-db` is omitted — `slice-app-db-in-snapshot` already handles it
+  and respects the `:path` arg. The rest are vectors or maps that can
+  grow unbounded with runtime state."
+  #{:sub-cache :machines :epochs :traces})
+
+(defn- resolve-slice-mode
+  "Resolve the effective mode for a slice. `slice-modes` is the
+  per-slice override map; `global-mode` is the snapshot-wide `:mode`
+  arg. Falls back to `:summary` when nothing pins the slice. Always
+  returns `:summary` or `:full`."
+  [slice slice-modes global-mode]
+  (let [m (or (get slice-modes slice) global-mode :summary)]
+    (case m
+      :full :full
+      :summary)))
+
+(defn- summarise-other-slices-in-snapshot
+  "Apply `tree-summary` to every frame's non-app-db slice whose
+  resolved mode is `:summary`. `:full` slices pass through unchanged.
+  Returns the rewritten snapshot map. `:app-db` is skipped — that
+  slice's summary / path-slicing already happened upstream in
+  `slice-app-db-in-snapshot`.
+
+  Returns `{:snapshot processed :resolved-modes {<slice> :summary|:full}}`
+  so the snapshot response can echo back which slices were summarised
+  — agents pattern-match on the resolved-modes map without re-deriving
+  the slice list."
+  [snapshot slice-modes global-mode]
+  (if-not (map? snapshot)
+    {:snapshot snapshot :resolved-modes {}}
+    (let [resolved (into {} (map (fn [s]
+                                   [s (resolve-slice-mode s slice-modes global-mode)]))
+                         summarisable-slices)
+          process-frame
+          (fn [frame-map]
+            (if-not (map? frame-map)
+              frame-map
+              (reduce-kv
+                (fn [m k v]
+                  (assoc m k
+                         (if (and (contains? summarisable-slices k)
+                                  (= :summary (get resolved k))
+                                  (some? v))
+                           (tree-summary v)
+                           v)))
+                {} frame-map)))
+          processed (reduce-kv (fn [m fid fmap]
+                                 (assoc m fid (process-frame fmap)))
+                               {} snapshot)]
+      {:snapshot processed :resolved-modes resolved})))
+
+(defn- parse-mode-arg
+  "Normalise the global `mode` MCP arg. Accepts strings (`\"summary\"`,
+  `\"full\"`) or keywords. Defaults to `:summary` — the lazy-summary
+  default per rf2-u2029. Unrecognised values default to `:summary`
+  (budget-sensitive default)."
+  [raw]
+  (cond
+    (nil? raw)                 :summary
+    (= raw :full)              :full
+    (= raw :summary)           :summary
+    (= raw "full")             :full
+    (= raw "summary")          :summary
+    :else                      :summary))
+
+(defn- parse-modes-arg
+  "Normalise the per-slice `modes` MCP arg into a `{<slice-keyword>
+  <mode-keyword>}` map. Accepts a JS object, a CLJS map, or nil.
+  Unknown slices are dropped. Unknown mode values are dropped (the
+  slice falls back to the global mode default). Slice keys may be
+  bare strings (`\"app-db\"`), EDN-shaped strings (`\":app-db\"`),
+  or keywords."
+  [raw]
+  (let [as-clj (cond
+                 (nil? raw)            nil
+                 (map? raw)            raw
+                 ;; JS object from the MCP wire.
+                 (and (some? raw)
+                      (not (array? raw))
+                      (not (string? raw))
+                      (not (boolean? raw))
+                      (not (number? raw)))
+                 (try (js->clj raw) (catch :default _ nil))
+                 :else nil)
+        coerce-k (fn [k]
+                   (cond
+                     (keyword? k) k
+                     (string? k)
+                     (let [s (if (str/starts-with? k ":") (subs k 1) k)]
+                       (keyword s))
+                     :else nil))
+        coerce-v (fn [v]
+                   (cond
+                     (= v :summary)  :summary
+                     (= v :full)     :full
+                     (= v "summary") :summary
+                     (= v "full")    :full
+                     :else           nil))]
+    (if-not (map? as-clj)
+      {}
+      (reduce-kv
+        (fn [m k v]
+          (let [k' (coerce-k k)
+                v' (coerce-v v)]
+            (if (and k' (contains? valid-slices k') v')
+              (assoc m k' v')
+              m)))
+        {} as-clj))))
 
 (defn- diff-encode-epochs-in-snapshot
   "Walk the per-frame snapshot map and diff-encode every frame's
@@ -1286,6 +1441,12 @@
         incl?     (include-sensitive? args)
         path      (parse-path-arg (arg args :path))
         mode      (parse-epochs-mode (arg args :epochs-mode))
+        ;; Global lazy-summary mode (rf2-u2029): `:summary` (default)
+        ;; replaces every rich slice with a tree-summary marker;
+        ;; `:full` ships the full payload. Per-slice override via
+        ;; `:modes` map takes precedence over the global mode.
+        slice-mode  (parse-mode-arg (arg args :mode))
+        slice-modes (parse-modes-arg (arg args :modes))
         dedup?    (parse-dedup-arg (arg args :dedup))
         elision?  (parse-elision-arg (arg args :elision))
         opts      {:frames frames :include include}
@@ -1319,18 +1480,35 @@
     (-> (ensure-runtime! conn build-id)
         (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
         (.then (fn [v]
-                 (let [[scrubbed dropped]    (scrub-snapshot-sensitive v incl?)
-                       [sliced path-status]  (slice-app-db-in-snapshot scrubbed path)
+                 (let [app-db-mode (resolve-slice-mode :app-db slice-modes slice-mode)
+                       [scrubbed dropped]    (scrub-snapshot-sensitive v incl?)
+                       [sliced path-status]  (slice-app-db-in-snapshot scrubbed path app-db-mode)
                        diff-encoded          (diff-encode-epochs-in-snapshot sliced mode)
-                       deduped               (dedup-epochs-in-snapshot diff-encoded dedup?)]
-                   (ok-text (cond-> {:ok?         true
-                                     :frames      (if (= :all frames) :all (vec frames))
-                                     :include     include
-                                     :mode        (if (nil? path) :summary :path-sliced)
-                                     :epochs-mode mode
-                                     :dedup       dedup?
-                                     :elision     elision?
-                                     :snapshot    deduped}
+                       deduped               (dedup-epochs-in-snapshot diff-encoded dedup?)
+                       ;; Lazy-summary default for non-app-db rich
+                       ;; slices (rf2-u2029). Runs LAST in the pipeline
+                       ;; so summary `:bytes` hints reflect the
+                       ;; post-shrink wire cost of each slice.
+                       {summarised :snapshot
+                        other-modes :resolved-modes} (summarise-other-slices-in-snapshot
+                                                       deduped slice-modes slice-mode)
+                       resolved-modes (assoc other-modes :app-db
+                                             (cond
+                                               path :path-sliced
+                                               :else app-db-mode))
+                       response-mode  (cond
+                                        path                  :path-sliced
+                                        (= :full app-db-mode) :full
+                                        :else                 :summary)]
+                   (ok-text (cond-> {:ok?            true
+                                     :frames         (if (= :all frames) :all (vec frames))
+                                     :include        include
+                                     :mode           response-mode
+                                     :slice-modes    resolved-modes
+                                     :epochs-mode    mode
+                                     :dedup          dedup?
+                                     :elision        elision?
+                                     :snapshot       summarised}
                               path                  (assoc :path path)
                               (seq path-status)     (assoc :path-not-found path-status)
                               (pos? dropped)        (assoc :dropped-sensitive dropped))))))
@@ -1782,15 +1960,19 @@
                       ":app-db, :sub-cache, :machines, :epochs, :traces. "
                       "Server-side composition over the existing per-slice runtime readers. "
                       "Prefer this over chaining 5-10 individual reads. "
+                      "Lazy-summary default (rf2-u2029): each rich slice in the response is replaced with a "
+                      "`{:rf.mcp/summary {:type :map|:vector :keys [...] :count N :bytes ~B}}` marker by "
+                      "default — keeps a discovery snapshot under the wire cap by construction. Agents drill "
+                      "into the slice they actually need via `mode \"full\"` (every slice expands), per-slice "
+                      "`modes {\"app-db\": \"full\"}` (one slice expands), or — for the :app-db slice only — "
+                      "the `path` arg (rf2-tygdv: returns the addressed subtree). "
                       "Path slicing (rf2-tygdv): the `:app-db` slice supports a `path` arg (an EDN-encoded "
                       "vector of keys, e.g. \"[:cart :items 0]\"). With `path`, returns the addressed subtree. "
-                      "Without `path`, returns a `{:rf.mcp/summary ...}` marker for the `:app-db` slice "
-                      "(top-level keys + count + bytes) rather than the full value — keeps the response "
-                      "under the wire cap by default. Agents drill down by re-calling with `path`. "
+                      "Path-slicing supersedes the slice-level mode for `:app-db`. "
                       "Diff-encoded epochs (rf2-1wdzp): each epoch in the `:epochs` slice has its `:db-after` "
                       "replaced with a structural diff against its own `:db-before` by default — pass "
                       "`epochs-mode \"full\"` for legacy full-pair shape (opt-in for time-travel restore). "
-                      "The other slices (:sub-cache, :machines, :traces) pass through unchanged. "
+                      "Diff-encode runs before the lazy-summary so `bytes` hints reflect post-shrink cost. "
                       "Per spec/009 §Privacy the `:traces` and `:epochs` slices default-drop items carrying "
                       "`:sensitive? true`; opt back in with `include-sensitive? true`. App-db / sub-cache / "
                       "machines slices pass through unchanged — payload redaction is the `with-redacted` "
@@ -1819,10 +2001,29 @@
                                                            "strings. When supplied, the :app-db slice in the result "
                                                            "is the subtree at the path. Out-of-range paths surface "
                                                            "as `:path-not-found` per-frame with deepest-valid-prefix "
-                                                           "attached. When absent, the :app-db slice is a "
-                                                           "`{:rf.mcp/summary ...}` marker (mode :summary).")
+                                                           "attached. Path-slicing supersedes the slice-level mode "
+                                                           "for :app-db. When absent, the :app-db slice respects "
+                                                           "the resolved mode (default :summary).")
                                          :oneOf [{:type "string"}
                                                  {:type "array" :items {:type "string"}}]}
+                               :mode    {:type "string"
+                                         :description (str "Global lazy-summary mode (rf2-u2029). "
+                                                           "\"summary\" (default) replaces every rich slice "
+                                                           "(:app-db when no `path`, :sub-cache, :machines, :epochs, :traces) "
+                                                           "with a `{:rf.mcp/summary ...}` marker — top-level keys, "
+                                                           "count, and approximate bytes. \"full\" expands every "
+                                                           "slice to its raw payload (legacy pre-rf2-u2029 behaviour). "
+                                                           "Per-slice override via `modes` takes precedence.")
+                                         :enum ["summary" "full"]}
+                               :modes   {:type "object"
+                                         :description (str "Per-slice mode override (rf2-u2029) — a map "
+                                                           "{slice-name: \"summary\"|\"full\"}. Recognised slices: "
+                                                           "app-db, sub-cache, machines, epochs, traces. Slices not "
+                                                           "listed fall back to the global `mode` arg (default \"summary\"). "
+                                                           "Example: `{\"app-db\": \"full\", \"epochs\": \"summary\"}` — "
+                                                           "expand the live state, summarise the history.")
+                                         :additionalProperties {:type "string"
+                                                                :enum ["summary" "full"]}}
                                :epochs-mode {:type "string"
                                              :description "How :db-after rides the wire in the :epochs slice: \"diff\" (default, intra-record structural diff against :db-before) or \"full\" (legacy full snapshot, opt-in for time-travel)."
                                              :enum ["diff" "full"]}

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/lazy_summary_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/lazy_summary_test.cljs
@@ -1,0 +1,430 @@
+(ns re-frame-pair2-mcp.lazy-summary-test
+  "Unit tests for the lazy-summary default generalised to every rich
+  snapshot slice (rf2-u2029).
+
+  rf2-tygdv landed a `{:rf.mcp/summary ...}` marker as the default for
+  the `:app-db` slice. rf2-u2029 generalises that default to every
+  rich slice in the snapshot response — `:sub-cache`, `:machines`,
+  `:epochs`, `:traces` — so a discovery snapshot ('I don't know which
+  slice carries the answer') stays under the wire cap by construction.
+
+  These tests mirror the private helpers from `tools.cljs`
+  (`parse-mode-arg`, `parse-modes-arg`, `resolve-slice-mode`,
+  `summarise-other-slices-in-snapshot`) so the contract is pinned at
+  the unit level. A rename or signature drift surfaces as a failing
+  test rather than silent contract drift.
+
+  Wire-byte / token-budget assertions appear at the end — the
+  discovery-snapshot scenario MUST fit the 5,000-token cap."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as str]))
+
+;; ---------------------------------------------------------------------------
+;; Mirrors of the private helpers. Keep in lockstep with `tools.cljs`.
+;; ---------------------------------------------------------------------------
+
+(def ^:private valid-slices
+  #{:app-db :sub-cache :machines :epochs :traces})
+
+(def ^:private summarisable-slices
+  #{:sub-cache :machines :epochs :traces})
+
+(def ^:private summary-keys-cap 64)
+
+(defn- token-estimate [s]
+  (quot (count s) 4))
+
+(defn- tree-summary [v]
+  (cond
+    (map? v)
+    (let [ks    (keys v)
+          n     (count ks)
+          shown (if (> n summary-keys-cap)
+                  (vec (take summary-keys-cap ks))
+                  (vec ks))]
+      {:rf.mcp/summary (cond-> {:type   :map
+                                :keys   shown
+                                :count  n
+                                :bytes  (count (pr-str v))}
+                         (> n summary-keys-cap)
+                         (assoc :keys-truncated? true))})
+    (vector? v)
+    {:rf.mcp/summary {:type  :vector
+                      :count (count v)
+                      :bytes (count (pr-str v))}}
+    (set? v)
+    {:rf.mcp/summary {:type  :set
+                      :count (count v)
+                      :bytes (count (pr-str v))}}
+    (sequential? v)
+    {:rf.mcp/summary {:type  :seq
+                      :count (count v)
+                      :bytes (count (pr-str v))}}
+    :else
+    {:rf.mcp/summary {:type  :scalar
+                      :value v
+                      :bytes (count (pr-str v))}}))
+
+(defn- parse-mode-arg [raw]
+  (cond
+    (nil? raw)                 :summary
+    (= raw :full)              :full
+    (= raw :summary)           :summary
+    (= raw "full")             :full
+    (= raw "summary")          :summary
+    :else                      :summary))
+
+(defn- parse-modes-arg [raw]
+  (let [as-clj (cond
+                 (nil? raw) nil
+                 (map? raw) raw
+                 (and (some? raw)
+                      (not (array? raw))
+                      (not (string? raw))
+                      (not (boolean? raw))
+                      (not (number? raw)))
+                 (try (js->clj raw) (catch :default _ nil))
+                 :else nil)
+        coerce-k (fn [k]
+                   (cond
+                     (keyword? k) k
+                     (string? k)
+                     (let [s (if (str/starts-with? k ":") (subs k 1) k)]
+                       (keyword s))
+                     :else nil))
+        coerce-v (fn [v]
+                   (cond
+                     (= v :summary)  :summary
+                     (= v :full)     :full
+                     (= v "summary") :summary
+                     (= v "full")    :full
+                     :else           nil))]
+    (if-not (map? as-clj)
+      {}
+      (reduce-kv
+        (fn [m k v]
+          (let [k' (coerce-k k)
+                v' (coerce-v v)]
+            (if (and k' (contains? valid-slices k') v')
+              (assoc m k' v')
+              m)))
+        {} as-clj))))
+
+(defn- resolve-slice-mode [slice slice-modes global-mode]
+  (let [m (or (get slice-modes slice) global-mode :summary)]
+    (case m
+      :full :full
+      :summary)))
+
+(defn- summarise-other-slices-in-snapshot [snapshot slice-modes global-mode]
+  (if-not (map? snapshot)
+    {:snapshot snapshot :resolved-modes {}}
+    (let [resolved (into {} (map (fn [s]
+                                   [s (resolve-slice-mode s slice-modes global-mode)]))
+                         summarisable-slices)
+          process-frame
+          (fn [frame-map]
+            (if-not (map? frame-map)
+              frame-map
+              (reduce-kv
+                (fn [m k v]
+                  (assoc m k
+                         (if (and (contains? summarisable-slices k)
+                                  (= :summary (get resolved k))
+                                  (some? v))
+                           (tree-summary v)
+                           v)))
+                {} frame-map)))
+          processed (reduce-kv (fn [m fid fmap]
+                                 (assoc m fid (process-frame fmap)))
+                               {} snapshot)]
+      {:snapshot processed :resolved-modes resolved})))
+
+;; ---------------------------------------------------------------------------
+;; parse-mode-arg — the input contract for the global `:mode` MCP arg.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-mode-arg-defaults-to-summary
+  (is (= :summary (parse-mode-arg nil)))
+  (is (= :summary (parse-mode-arg ""))))
+
+(deftest parse-mode-arg-accepts-string-and-keyword
+  (is (= :full (parse-mode-arg "full")))
+  (is (= :full (parse-mode-arg :full)))
+  (is (= :summary (parse-mode-arg "summary")))
+  (is (= :summary (parse-mode-arg :summary))))
+
+(deftest parse-mode-arg-unknown-defaults-to-summary
+  ;; Budget-sensitive: an unknown value MUST default to the cheaper
+  ;; mode rather than expand by accident.
+  (is (= :summary (parse-mode-arg "garbage")))
+  (is (= :summary (parse-mode-arg :nope))))
+
+;; ---------------------------------------------------------------------------
+;; parse-modes-arg — per-slice override map.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-modes-arg-nil-is-empty
+  (is (= {} (parse-modes-arg nil))))
+
+(deftest parse-modes-arg-cljs-map-passes-through
+  (is (= {:app-db :full :epochs :summary}
+         (parse-modes-arg {:app-db :full :epochs :summary}))))
+
+(deftest parse-modes-arg-string-keys-coerced-to-slice-keywords
+  (is (= {:app-db :full :sub-cache :summary}
+         (parse-modes-arg #js {"app-db" "full" "sub-cache" "summary"}))))
+
+(deftest parse-modes-arg-edn-shaped-string-keys-strip-leading-colon
+  (is (= {:app-db :full}
+         (parse-modes-arg #js {":app-db" "full"}))))
+
+(deftest parse-modes-arg-drops-unknown-slices
+  (is (= {:app-db :full}
+         (parse-modes-arg #js {"app-db" "full" "garbage" "full"}))))
+
+(deftest parse-modes-arg-drops-unknown-mode-values
+  ;; Unknown mode values fall through to the global default — the slice
+  ;; doesn't appear in the override map at all.
+  (is (= {}
+         (parse-modes-arg #js {"app-db" "garbage"})))
+  (is (= {:epochs :summary}
+         (parse-modes-arg #js {"app-db" "garbage" "epochs" "summary"}))))
+
+(deftest parse-modes-arg-non-map-returns-empty
+  (is (= {} (parse-modes-arg "scalar")))
+  (is (= {} (parse-modes-arg 42)))
+  (is (= {} (parse-modes-arg true))))
+
+;; ---------------------------------------------------------------------------
+;; resolve-slice-mode — per-slice precedence resolution.
+;; ---------------------------------------------------------------------------
+
+(deftest resolve-slice-mode-default-is-summary
+  ;; Nothing pins the slice ⇒ summary.
+  (is (= :summary (resolve-slice-mode :app-db {} :summary)))
+  (is (= :summary (resolve-slice-mode :sub-cache {} :summary)))
+  (is (= :summary (resolve-slice-mode :epochs {} nil))))
+
+(deftest resolve-slice-mode-global-mode-applies-to-every-slice
+  (is (= :full (resolve-slice-mode :app-db {} :full)))
+  (is (= :full (resolve-slice-mode :sub-cache {} :full)))
+  (is (= :full (resolve-slice-mode :epochs {} :full)))
+  (is (= :full (resolve-slice-mode :traces {} :full))))
+
+(deftest resolve-slice-mode-per-slice-overrides-global
+  (is (= :full (resolve-slice-mode :app-db {:app-db :full} :summary))
+      "Per-slice :full beats global :summary")
+  (is (= :summary (resolve-slice-mode :epochs {:epochs :summary} :full))
+      "Per-slice :summary beats global :full"))
+
+(deftest resolve-slice-mode-only-affects-named-slice
+  ;; Per-slice override on :app-db shouldn't change :epochs resolution.
+  (let [modes {:app-db :full}]
+    (is (= :full    (resolve-slice-mode :app-db modes :summary)))
+    (is (= :summary (resolve-slice-mode :epochs modes :summary)))
+    (is (= :summary (resolve-slice-mode :traces modes :summary)))))
+
+;; ---------------------------------------------------------------------------
+;; summarise-other-slices-in-snapshot — the load-bearing pipeline step.
+;; ---------------------------------------------------------------------------
+
+(def ^:private fixture-snapshot
+  ;; Mirrors the path-slicing-test fixture shape. The :app-db slice is
+  ;; already a summary marker here because slice-app-db-in-snapshot
+  ;; runs upstream in the real pipeline; the function under test
+  ;; skips :app-db.
+  {:rf/default {:app-db    {:rf.mcp/summary {:type :map :keys [:user :cart] :count 2 :bytes 100}}
+                :sub-cache {[:user/email] {:value "a@b" :ref-count 1}
+                            [:cart/total] {:value 42   :ref-count 3}}
+                :machines  {:ids [:auth-fsm] :state {:auth-fsm {:state :idle}}}
+                :epochs    [{:event-id :foo :db-after {:rf.mcp/diff-from :db-before :patches []}}
+                            {:event-id :bar :db-after {:rf.mcp/diff-from :db-before :patches []}}]
+                :traces    [{:operation :event :event-id :foo}
+                            {:operation :sub   :sub-id  :bar}]}
+   :stories    {:app-db    {:rf.mcp/summary {:type :map :keys [:story-id] :count 1 :bytes 12}}
+                :sub-cache {}
+                :machines  {:ids [] :state {}}
+                :epochs    []
+                :traces    []}})
+
+(deftest summary-default-replaces-every-rich-slice
+  (let [{:keys [snapshot resolved-modes]}
+        (summarise-other-slices-in-snapshot fixture-snapshot {} :summary)
+        rf-default (:rf/default snapshot)]
+    (testing "resolved-modes echoes the per-slice mode"
+      (is (= {:sub-cache :summary :machines :summary
+              :epochs    :summary :traces   :summary}
+             resolved-modes)))
+    (testing "every rich slice is a {:rf.mcp/summary ...} marker"
+      (is (some? (-> rf-default :sub-cache :rf.mcp/summary)))
+      (is (some? (-> rf-default :machines  :rf.mcp/summary)))
+      (is (some? (-> rf-default :epochs    :rf.mcp/summary)))
+      (is (some? (-> rf-default :traces    :rf.mcp/summary))))
+    (testing ":app-db slice is left alone (handled by upstream slicer)"
+      (is (= {:rf.mcp/summary {:type :map :keys [:user :cart] :count 2 :bytes 100}}
+             (:app-db rf-default))))
+    (testing "marker types match the underlying value shape"
+      (is (= :map    (-> rf-default :sub-cache :rf.mcp/summary :type)))
+      (is (= :map    (-> rf-default :machines  :rf.mcp/summary :type)))
+      (is (= :vector (-> rf-default :epochs    :rf.mcp/summary :type)))
+      (is (= :vector (-> rf-default :traces    :rf.mcp/summary :type))))
+    (testing "vector counts surface for drill-down"
+      (is (= 2 (-> rf-default :epochs :rf.mcp/summary :count)))
+      (is (= 2 (-> rf-default :traces :rf.mcp/summary :count))))
+    (testing "map keys surface for drill-down"
+      (is (= [:ids :state]
+             (-> rf-default :machines :rf.mcp/summary :keys))))))
+
+(deftest full-mode-leaves-every-slice-untouched
+  (let [{:keys [snapshot resolved-modes]}
+        (summarise-other-slices-in-snapshot fixture-snapshot {} :full)]
+    (is (= {:sub-cache :full :machines :full
+            :epochs    :full :traces   :full}
+           resolved-modes))
+    (is (= (:rf/default fixture-snapshot)
+           (:rf/default snapshot))
+        "Snapshot under :full mode is unchanged")))
+
+(deftest per-slice-override-beats-global-mode
+  (testing "global :summary, per-slice :full on :epochs"
+    (let [{:keys [snapshot resolved-modes]}
+          (summarise-other-slices-in-snapshot fixture-snapshot
+                                              {:epochs :full}
+                                              :summary)
+          rf-default (:rf/default snapshot)]
+      (is (= :full    (:epochs    resolved-modes)))
+      (is (= :summary (:sub-cache resolved-modes)))
+      (is (= 2 (count (:epochs rf-default)))
+          ":epochs ships full because per-slice override wins")
+      (is (some? (-> rf-default :sub-cache :rf.mcp/summary))
+          ":sub-cache stays summarised under global :summary")))
+  (testing "global :full, per-slice :summary on :traces"
+    (let [{:keys [snapshot resolved-modes]}
+          (summarise-other-slices-in-snapshot fixture-snapshot
+                                              {:traces :summary}
+                                              :full)
+          rf-default (:rf/default snapshot)]
+      (is (= :summary (:traces    resolved-modes)))
+      (is (= :full    (:sub-cache resolved-modes)))
+      (is (some? (-> rf-default :traces :rf.mcp/summary))
+          ":traces is summarised because per-slice override wins")
+      (is (= 2 (count (:sub-cache rf-default)))
+          ":sub-cache ships full under global :full"))))
+
+(deftest empty-slices-stay-empty
+  ;; The :stories frame in the fixture has empty maps / vectors.
+  ;; Summarising an empty map yields {:type :map :count 0 :keys []
+  ;; :bytes ~3} — the marker is small but distinguishable from the raw
+  ;; empty value. Skip the marker for nil to avoid noise.
+  (let [{:keys [snapshot]} (summarise-other-slices-in-snapshot
+                             fixture-snapshot {} :summary)
+        stories (:stories snapshot)]
+    (is (some? (-> stories :sub-cache :rf.mcp/summary)))
+    (is (= 0 (-> stories :sub-cache :rf.mcp/summary :count)))
+    (is (= 0 (-> stories :epochs    :rf.mcp/summary :count)))
+    (is (= 0 (-> stories :traces    :rf.mcp/summary :count)))))
+
+(deftest summary-skips-slices-not-in-include-set
+  ;; When the caller's `:include` filter excludes a slice, the frame
+  ;; map has no entry for that slice. The summariser MUST NOT add one.
+  (let [partial-snap {:rf/default {:app-db    {:k 1}
+                                    :sub-cache {[:q] {:value 1}}}}
+        {:keys [snapshot]} (summarise-other-slices-in-snapshot
+                             partial-snap {} :summary)
+        rf-default (:rf/default snapshot)]
+    (is (not (contains? rf-default :machines)))
+    (is (not (contains? rf-default :epochs)))
+    (is (not (contains? rf-default :traces)))
+    (is (some? (-> rf-default :sub-cache :rf.mcp/summary)))))
+
+(deftest summary-passes-through-non-map-values
+  ;; A pathological frame value (scalar where a map was expected)
+  ;; passes through unchanged rather than crashing.
+  (let [weird {:rf/default :not-a-map}
+        {:keys [snapshot]} (summarise-other-slices-in-snapshot
+                             weird {} :summary)]
+    (is (= :not-a-map (:rf/default snapshot)))))
+
+;; ---------------------------------------------------------------------------
+;; Wire-byte assertions — the load-bearing acceptance criterion.
+;; ---------------------------------------------------------------------------
+
+(defn- make-fat-snapshot
+  "Build a fixture snapshot with realistically heavy slices: a 1MB
+  app-db, a 100-entry sub-cache, 10 epoch records each carrying a full
+  app-db `:db-before`, and a 200-entry trace ring buffer. Mirrors the
+  shape rf2-jlq5j's findings doc flagged as cap-blowing."
+  []
+  (let [big-map (apply hash-map
+                       (mapcat (fn [i] [(keyword (str "k" i))
+                                        (apply str (repeat 1024 "x"))])
+                               (range 1024)))]
+    {:rf/default
+     {:app-db    big-map
+      :sub-cache (zipmap (map #(vector (keyword "q" (str "s" %))) (range 100))
+                         (map #(hash-map :value % :ref-count %) (range 100)))
+      :machines  {:ids   (mapv #(keyword (str "m" %)) (range 30))
+                  :state (zipmap (map #(keyword (str "m" %)) (range 30))
+                                 (map #(hash-map :state :idle :context big-map) (range 30)))}
+      :epochs    (vec (for [i (range 10)]
+                        {:event-id   (keyword (str "e" i))
+                         :db-before  big-map
+                         :db-after   big-map}))
+      :traces    (vec (for [i (range 200)]
+                        {:operation :event :event-id (keyword (str "t" i))
+                         :timestamp i}))}}))
+
+(deftest discovery-snapshot-fits-the-wire-cap
+  ;; rf2-jlq5j flagged the discovery snapshot ('I don't know which
+  ;; slice carries the answer') as the worst-case wire blow. With the
+  ;; lazy-summary default, every rich slice collapses to a marker —
+  ;; the entire response fits the 5,000-token cap.
+  (let [fat (make-fat-snapshot)
+        ;; In the real pipeline, slice-app-db-in-snapshot runs upstream
+        ;; and turns :app-db into a summary marker. Simulate that here.
+        with-app-db-summary
+        (update-in fat [:rf/default :app-db] tree-summary)
+        {:keys [snapshot]} (summarise-other-slices-in-snapshot
+                             with-app-db-summary {} :summary)
+        wire (pr-str snapshot)
+        tokens (token-estimate wire)]
+    (is (< tokens 5000)
+        (str "Discovery snapshot under :summary mode MUST fit the 5k-token cap. "
+             "Got " tokens " tokens, " (count wire) " chars."))))
+
+(deftest full-mode-blows-the-cap-as-expected
+  ;; The opt-in :full mode is the legacy behaviour — agents who pass
+  ;; it accept the wire cost. This test pins the budget POSTURE: the
+  ;; same fat snapshot under :full mode is dramatically larger.
+  (let [fat (make-fat-snapshot)
+        with-app-db-full fat
+        {:keys [snapshot]} (summarise-other-slices-in-snapshot
+                             with-app-db-full {} :full)
+        wire (pr-str snapshot)
+        tokens (token-estimate wire)]
+    (is (> tokens 50000)
+        (str "Full-mode discovery snapshot ships the raw payload — "
+             "should be many multiples of the cap. Got " tokens " tokens."))))
+
+(deftest summary-vs-full-shrink-factor
+  ;; Quantify the wire-byte impact. The summary marker scales with the
+  ;; top-level shape (keys + count + bytes hint), not with the
+  ;; underlying payload. The shrink factor is the load-bearing claim
+  ;; the bead description ties acceptance to.
+  (let [fat                (make-fat-snapshot)
+        with-app-db-summary (update-in fat [:rf/default :app-db] tree-summary)
+        with-app-db-full   fat
+        summary-wire (pr-str (:snapshot (summarise-other-slices-in-snapshot
+                                          with-app-db-summary {} :summary)))
+        full-wire    (pr-str (:snapshot (summarise-other-slices-in-snapshot
+                                          with-app-db-full {} :full)))
+        ratio (/ (count full-wire) (count summary-wire))]
+    (println (str "[rf2-u2029] discovery snapshot wire-size: "
+                  "summary=" (count summary-wire) " chars (~" (token-estimate summary-wire) " tokens), "
+                  "full=" (count full-wire) " chars (~" (token-estimate full-wire) " tokens), "
+                  "shrink=" (int ratio) "x"))
+    (is (> ratio 50)
+        (str "Lazy-summary MUST shrink the discovery snapshot by at "
+             "least 50x. Got " (int ratio) "x (summary=" (count summary-wire)
+             " chars vs full=" (count full-wire) " chars)."))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/path_slicing_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/path_slicing_test.cljs
@@ -119,33 +119,40 @@
 
           :else acc)))))
 
-(defn- slice-app-db-in-snapshot [snapshot path]
-  (if-not (map? snapshot)
-    [snapshot {}]
-    (let [status* (atom {})
-          missing (js-obj)
-          process-frame
-          (fn [frame-id frame-map]
-            (if-not (and (map? frame-map) (contains? frame-map :app-db))
-              frame-map
-              (let [db (:app-db frame-map)]
-                (cond
-                  (nil? path)
-                  (update frame-map :app-db tree-summary)
-                  (empty? path)
-                  frame-map
-                  :else
-                  (let [v (get-in db path missing)]
-                    (if (identical? v missing)
-                      (do (swap! status* assoc frame-id
-                                 {:exists? false
-                                  :deepest-valid-prefix (deepest-valid-prefix db path)})
-                          (assoc frame-map :app-db nil))
-                      (assoc frame-map :app-db v)))))))
-          processed (reduce-kv (fn [m fid fmap]
-                                 (assoc m fid (process-frame fid fmap)))
-                               {} snapshot)]
-      [processed @status*])))
+(defn- slice-app-db-in-snapshot
+  ([snapshot path] (slice-app-db-in-snapshot snapshot path :summary))
+  ([snapshot path app-db-mode]
+   (if-not (map? snapshot)
+     [snapshot {}]
+     (let [status* (atom {})
+           missing (js-obj)
+           full?   (= :full app-db-mode)
+           process-frame
+           (fn [frame-id frame-map]
+             (if-not (and (map? frame-map) (contains? frame-map :app-db))
+               frame-map
+               (let [db (:app-db frame-map)]
+                 (cond
+                   ;; No path + summary mode: summarise.
+                   (and (nil? path) (not full?))
+                   (update frame-map :app-db tree-summary)
+                   ;; No path + full mode: full slice.
+                   (nil? path)
+                   frame-map
+                   (empty? path)
+                   frame-map
+                   :else
+                   (let [v (get-in db path missing)]
+                     (if (identical? v missing)
+                       (do (swap! status* assoc frame-id
+                                  {:exists? false
+                                   :deepest-valid-prefix (deepest-valid-prefix db path)})
+                           (assoc frame-map :app-db nil))
+                       (assoc frame-map :app-db v)))))))
+           processed (reduce-kv (fn [m fid fmap]
+                                  (assoc m fid (process-frame fid fmap)))
+                                {} snapshot)]
+       [processed @status*]))))
 
 ;; ---------------------------------------------------------------------------
 ;; parse-path-arg — the input-shape contract.


### PR DESCRIPTION
## Summary

Generalises rf2-tygdv's `:app-db` tree-summary default to every rich slice in `snapshot`'s response — `:sub-cache`, `:machines`, `:epochs`, `:traces`. The default snapshot call (no `mode`, no `path`) now returns `{:rf.mcp/summary ...}` markers for all five slices, so the discovery workflow ("I don't know which slice carries the answer") stays inside the 5,000-token wire cap by construction rather than relying on the cap as a backstop.

Source bead: **rf2-u2029** (P2). Acceptance criteria pinned in tests: snapshot default mode returns shape descriptor < 500 tokens for any app-db; `mode "full"` preserves today's behaviour; summary walker has depth + sample caps (inherited from rf2-tygdv's `summary-keys-cap = 64`); 5MB-class snapshot in summary mode < 2KB (measured: ~1.4KB).

## Slices defaulting to summary

| Slice         | Before          | After (default `mode "summary"`)              |
|---------------|-----------------|-----------------------------------------------|
| `:app-db`     | summary (rf2-tygdv) | summary (unchanged)                       |
| `:sub-cache`  | full payload    | `{:rf.mcp/summary {:type :map ...}}`          |
| `:machines`   | full payload    | `{:rf.mcp/summary {:type :map ...}}`          |
| `:epochs`     | full payload (after diff+dedup) | `{:rf.mcp/summary {:type :vector ...}}` |
| `:traces`     | full payload    | `{:rf.mcp/summary {:type :vector ...}}`       |

## Opt-in shape

Three orthogonal opt-ins, in priority order:

1. **`path`** (`:app-db` only) — returns the subtree at the path. Path-slicing always beats the slice-level mode (rf2-tygdv preserved).
2. **`modes {"epochs": "full", "app-db": "summary"}`** — per-slice override; beats the global mode.
3. **`mode "full"`** — global default flip. Expands every rich slice. Equivalent to pre-rf2-u2029 behaviour.

Response shape gains a `:slice-modes` map so agents pattern-match on the resolved per-slice posture without re-deriving from the request:

```clojure
{:ok? true
 :mode :summary | :full | :path-sliced
 :slice-modes {:app-db :summary :sub-cache :summary :machines :summary
               :epochs :summary :traces   :summary}
 :snapshot {...}}
```

## Before/after wire sizes

Measured by `lazy-summary-test/summary-vs-full-shrink-factor` against a fat synthetic snapshot (1MB app-db, 10-epoch history with `:db-before` per record, 30 machines, 100-entry sub-cache, 200-entry trace buffer — the shape rf2-jlq5j's findings doc flagged as cap-blowing):

```
[rf2-u2029] discovery snapshot wire-size:
  summary = 1,396 chars (~349 tokens)
  full    = 54,010,868 chars (~13,502,717 tokens)
  shrink  = 38,689x
```

`discovery-snapshot-fits-the-wire-cap` pins the ~349-token result against the 5,000-token cap; `full-mode-blows-the-cap-as-expected` pins the opt-in `full` mode at >50,000 tokens (intentional — agents who pass it accept the cost).

## Spec amendments

- **`tools/pair2-mcp/spec/003-Tool-Catalogue.md`** — snapshot `Args` (added `mode`, `modes`) + `Returns` shape (added `:slice-modes`) + new §Lazy-summary mode section + updated §`:app-db` slice modes to cover three postures (`:summary` | `:full` | `:path-sliced`).
- **`tools/pair2-mcp/spec/Principles.md`** — mechanism #4 (wire-boundary cap) updated to note the lazy-summary default now spans every rich slice, not just `:app-db`.

## Test plan

- [x] `npm test` from `tools/pair2-mcp/` — 192 tests / 422 assertions, 0 failures (was 162/388 before this PR).
- [x] `npm run build` — production server compiles cleanly, no warnings.
- [x] `npm run stdio-roundtrip` — degraded-mode dispatch smoke test green.
- [x] Wire-size measurements logged from test runner (above).
- [x] Backward compat: existing `path` arg still works the same way (rf2-tygdv tests in `path_slicing_test.cljs` updated to the new 3-arity `slice-app-db-in-snapshot` signature; same default behaviour without the new arg).
- [ ] Manual smoke test against a live shadow-cljs build (deferred — covered by acceptance criteria in unit tests).

## Scope

Touches only `tools/pair2-mcp/`. No production runtime changes. No cross-tool impact (causa-mcp / story-mcp keep their own shapes; the cross-MCP `:rf.mcp/summary` vocabulary is the same shape they already use).