### PR TITLE
feat(schemas): recognise :sensitive? schema-metadata + populate sibling :rf/elision registry slot (rf2-c1l4d)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -155,6 +155,14 @@
     :producer-ns 're-frame.schemas
     :design-bead "rf2-kj51z"
     :description "Predicate: does any sub-slot of the schema declare :sensitive? true?"}
+   {:key         :schemas/frame-sensitive-declarations
+    :producer-ns 're-frame.schemas
+    :design-bead "rf2-c1l4d"
+    :description "Merged {path declaration} for every :sensitive? slot in every app-schema registered against a frame."}
+   {:key         :schemas/populate-sensitive-declarations
+    :producer-ns 're-frame.schemas
+    :design-bead "rf2-c1l4d"
+    :description "Idempotent: hydrate app-db [:rf/elision :sensitive-declarations] from a frame's schema-derived sensitive-path declarations."}
 
    ;; ---- re-frame.machines (rf2-xbtj / rf2-8bp3) ------------------------------
    {:key         :machines/reg-machine

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -591,13 +591,25 @@
 ;; cleanly under the same Malli EDN shape.
 
 (defn- sensitive-declaration-from-props
-  "Build a `{:sensitive? true}` declaration map from a slot's per-slot
-  props, or nil if `:sensitive? true` is not set. Per Spec 010
-  §`:sensitive?` and Spec 009 §Privacy — the declaration shape is the
-  minimum signal a downstream consumer needs to redact."
+  "Build a `:rf/sensitive-declaration` map from a slot's per-slot props,
+  or nil if `:sensitive? true` is not set. Per Spec 010 §`:sensitive?`
+  and Spec 009 §Privacy — the declaration shape carries `:sensitive?
+  true`, `:source :schema`, plus an optional `:hint` propagated
+  verbatim from the slot's props (mirroring the `:large?` walker —
+  apps that want to attach context for a sensitive slot reuse the
+  same `:hint` key).
+
+  The `:source` slot is included so the unified registry write
+  (populate-sensitive-declarations below, plus the rf2-c1l4d follow-on
+  in re-frame.core) can apply the same conflict-resolution rule as
+  the `:large?` registry: app-declared sensitive paths beat schema-
+  derived ones, schema beats runtime-flagged (the latter is currently
+  unused for sensitivity but reserved for symmetry)."
   [props]
   (when (true? (:sensitive? props))
-    {:sensitive? true}))
+    (cond-> {:sensitive? true
+             :source     :schema}
+      (some? (:hint props)) (assoc :hint (:hint props)))))
 
 (declare walk-sensitive-schema)
 
@@ -716,6 +728,109 @@
   (-> (extract-sensitive-paths-from-schema schema [])
       seq
       boolean))
+
+;; ---- sensitive-declaration registry feeder (rf2-c1l4d) -------------------
+;;
+;; Per the rf2-c1l4d follow-on: mirror the `:large?` walker's
+;; registry-population path for `:sensitive?`. The walker (above) is
+;; pure data; the framework hydrates a sibling slot in the unified
+;; elision registry — `app-db [:rf/elision :sensitive-declarations]`
+;; — at boot / on `reg-app-schema` re-registration so the schema-
+;; validation emit-site (and any future wire-boundary privacy walker)
+;; can consult one canonical map keyed by app-db path. Same shape,
+;; same idempotency, same conflict-resolution rule as the `:large?`
+;; sibling.
+;;
+;; Sibling slot rationale: `:declarations` already carries the
+;; `:large?` registry; `:sensitive-declarations` is the privacy
+;; sibling keyed by the same `[path → declaration]` map shape. Both
+;; live under the shared `[:rf/elision]` reserved root per Spec-
+;; Schemas §`:rf/elision-registry`. Two slots (not one merged map)
+;; because the two flags compose orthogonally — a slot may carry
+;; either or both, and the validation walker's composition rule
+;; (sensitive wins on the schema-validation emit site) reads both
+;; maps and resolves the conflict at emit time. Storing them
+;; separately keeps the per-flag query (`(get-in db [:rf/elision
+;; :sensitive-declarations <path>])`) O(1) without value-shape
+;; inspection.
+
+(defn frame-sensitive-declarations
+  "Return the merged `{path declaration}` map for every `:sensitive? true`
+  slot in every app-schema registered against `frame-id`. Composes
+  `extract-sensitive-paths-from-schema` across the frame's schema set.
+
+  Parallel to `frame-elision-declarations` (the `:large?` sibling).
+  This is the seam the framework's privacy-registry hydration (the
+  rf2-c1l4d follow-on in `re-frame.core`) reaches for at boot / on
+  hot reload — the schemas artefact owns the walker; the unified
+  registry write into `app-db [:rf/elision :sensitive-declarations]`
+  may live downstream once the rest of the privacy contract migrates
+  away from the schema-walked-per-emit model, OR may be invoked
+  directly via `populate-sensitive-declarations` below (the schemas
+  artefact ships both seams so the rf2-c1l4d landing site has a
+  choice — symmetry with `:large?`).
+
+  Each entry's value carries `:sensitive? true`, `:source :schema`,
+  and an optional `:hint` string when the slot's props declared one.
+
+  Per Spec 009 §Privacy / sensitive data in traces the conflict
+  resolution rule is: app-declared (via the privacy fx surface,
+  reserved for future use) beats schema, schema beats any future
+  runtime-flagged sensitivity. This fn returns ONLY the schema
+  layer; the downstream merger (populate-sensitive-declarations)
+  applies the conflict rule.
+
+  Arities:
+    (frame-sensitive-declarations)              ;; current frame
+    (frame-sensitive-declarations frame-id)     ;; explicit frame"
+  ([] (frame-sensitive-declarations (frame/current-frame)))
+  ([frame-id]
+   (reduce-kv
+     (fn [acc path m]
+       (merge acc (extract-sensitive-paths-from-schema (:schema m) path)))
+     {}
+     (frame-schema-entries frame-id))))
+
+(defn populate-sensitive-declarations
+  "Idempotent — given `db` (a frame's app-db) and a frame-id, return
+  `db` with `[:rf/elision :sensitive-declarations]` augmented by every
+  schema-derived sensitive-path declaration for that frame. Idempotent
+  in two senses:
+
+    1. Calling it twice in a row produces the same result the second
+       time (every schema-derived entry is the same map shape).
+    2. Existing entries with `:source :declared` (or any other
+       non-`:schema` source) are NEVER overwritten — the conflict
+       rule (declared beats schema) is preserved.
+
+  Existing entries with `:source :schema` from a prior call ARE
+  overwritten (so hot-reload of a schema picks up the new `:hint`
+  / `:sensitive?` flip). Entries no longer claimed by ANY registered
+  schema are NOT removed (a stale `:source :schema` slot for a path
+  whose schema dropped its `:sensitive?` flag persists until the
+  next explicit clear — symmetric with `populate-elision-declarations`
+  retention semantics).
+
+  Parallel to `populate-elision-declarations` (the `:large?` sibling).
+  Published via the `:schemas/populate-sensitive-declarations` late-
+  bind hook so re-frame.core can call it without statically requiring
+  the schemas artefact (per rf2-p7va — schemas is an optional dep)."
+  [db frame-id]
+  (let [schema-decls (frame-sensitive-declarations frame-id)]
+    (if (empty? schema-decls)
+      db
+      (update-in db [:rf/elision :sensitive-declarations]
+                 (fn [existing]
+                   (reduce-kv
+                     (fn [acc path decl]
+                       (let [existing-source (some-> (get acc path) :source)]
+                         (if (= existing-source :declared)
+                           ;; Preserve declared provenance — conflict
+                           ;; rule: declared beats schema.
+                           acc
+                           (assoc acc path decl))))
+                     (or existing {})
+                     schema-decls))))))
 
 (defn frame-elision-declarations
   "Return the merged `{path declaration}` map for every `:large? true`
@@ -1312,14 +1427,20 @@
 (late-bind/set-fn! :schemas/populate-elision-declarations
                    populate-elision-declarations)
 
-;; Sensitive-paths walker (rf2-kj51z) — published so the rf2-c1l4d
-;; follow-on (which extends the unified elision registry to recognise
-;; schema `:sensitive?` slots) can consume it without statically
-;; requiring the schemas artefact.
+;; Sensitive-paths walker (rf2-kj51z + rf2-c1l4d) — published so
+;; re-frame.core can extend the unified elision registry to recognise
+;; schema `:sensitive?` slots without statically requiring the schemas
+;; artefact. The pair mirrors the `:large?` walker (rf2-nwv63) — same
+;; shape, same idempotency, same conflict-resolution semantics on a
+;; sibling registry slot.
 (late-bind/set-fn! :schemas/extract-sensitive-paths-from-schema
                    extract-sensitive-paths-from-schema)
 (late-bind/set-fn! :schemas/schema-has-sensitive?
                    schema-has-sensitive?)
+(late-bind/set-fn! :schemas/frame-sensitive-declarations
+                   frame-sensitive-declarations)
+(late-bind/set-fn! :schemas/populate-sensitive-declarations
+                   populate-sensitive-declarations)
 
 ;; Test-support hooks (consumed by re-frame.test-support's
 ;; reset-runtime-fixture). The fixture wants to capture and restore

--- a/implementation/schemas/test/re_frame/schemas_sensitive_paths_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_paths_test.clj
@@ -1,0 +1,301 @@
+(ns re-frame.schemas-sensitive-paths-test
+  "JVM tests for the rf2-c1l4d schema-`:sensitive?` registry feeder —
+  the parallel of rf2-nwv63's `:large?` registry feeder.
+
+  rf2-kj51z (PR #673) already ships the walker that recognises
+  `:sensitive?` slot-level + container-level props inside a Malli EDN
+  schema (`extract-sensitive-paths-from-schema` and
+  `schema-has-sensitive?`). rf2-c1l4d extends the contract one step
+  further: aggregate every registered frame's sensitive-path
+  declarations and write them into a sibling slot in the unified
+  elision registry (`[:rf/elision :sensitive-declarations]`) at boot /
+  on `reg-app-schema` re-registration. Same shape, same idempotency,
+  same conflict-resolution rule as the `:large?` registry.
+
+  Test surfaces this file covers:
+
+    1. **Walker per-entry shape** — every entry the walker emits
+       carries `:source :schema` (parallel to the `:large?` walker)
+       so the unified registry can route on provenance.
+    2. **Hint propagation** — when the slot's props declare `:hint`,
+       it rides into the registry entry verbatim.
+    3. **`frame-sensitive-declarations`** — aggregates across every
+       schema registered in a frame; isolated per frame.
+    4. **`populate-sensitive-declarations`** — idempotent hydration of
+       `[:rf/elision :sensitive-declarations]`; preserves `:source
+       :declared` entries; refreshes `:source :schema` entries on
+       hot-reload.
+    5. **Composition** — a slot flagged BOTH `:sensitive?` AND
+       `:large?` lands in BOTH sibling registries (the two flags
+       compose orthogonally on the registry side; the validation
+       emit-site resolves the sensitive-wins precedence at trace
+       time, covered in `schemas_sensitive_test.clj`).
+
+  Does NOT cover the actual app-db write path at boot — that lives in
+  `re-frame.elision` / `re-frame.core` downstream (the rf2-c1l4d
+  follow-on integration). The seam between the two is the
+  `:schemas/populate-sensitive-declarations` late-bind hook."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.flows :as flows]
+            [re-frame.schemas :as schemas]
+            [re-frame.spec :as spec]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (schemas/reset-schema-validator!)
+  (spec/clear-boundary-warned-handler-ids!)
+  (rf/init! plain-atom/adapter)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- walker per-entry shape ----------------------------------------------
+
+(deftest walker-stamps-source-schema
+  (testing "every emitted entry carries :source :schema so the unified
+            registry can apply provenance-based conflict resolution"
+    (let [schema [:map [:password {:sensitive? true} :string]]
+          decls  (schemas/extract-sensitive-paths-from-schema schema [])]
+      (is (= {[:password] {:sensitive? true :source :schema}}
+             decls)
+          "single-slot — :source :schema present"))))
+
+(deftest walker-propagates-hint
+  (testing "the :hint string on a sensitive slot's props rides into the
+            registry entry verbatim — mirrors the :large? walker"
+    (let [schema [:map
+                  [:password {:sensitive? true :hint "User password — argon2id"}
+                   :string]]]
+      (is (= {[:password] {:sensitive? true
+                           :source     :schema
+                           :hint       "User password — argon2id"}}
+             (schemas/extract-sensitive-paths-from-schema schema []))))))
+
+(deftest walker-hint-only-without-sensitive
+  (testing ":hint without :sensitive? produces no declaration"
+    ;; Mirrors the :large? walker — :hint alone is not a nomination.
+    (is (= {}
+           (schemas/extract-sensitive-paths-from-schema
+             [:map [:foo {:hint "just a description"} :string]]
+             [])))))
+
+(deftest walker-explicit-false-skipped
+  (testing ":sensitive? false is NOT captured — only :sensitive? true nominates"
+    (is (= {}
+           (schemas/extract-sensitive-paths-from-schema
+             [:map [:foo {:sensitive? false} :string]]
+             [])))))
+
+;; ---- frame-sensitive-declarations ----------------------------------------
+
+(deftest frame-merge-across-schemas
+  (testing "every registered schema contributes its :sensitive? slots
+            to the frame's merged declarations map"
+    (rf/reg-app-schema [:user]
+                       [:map
+                        [:name :string]
+                        [:password {:sensitive? true :hint "argon2id"} :string]])
+    (rf/reg-app-schema [:auth]
+                       [:map
+                        [:token {:sensitive? true} :string]])
+    (let [merged (schemas/frame-sensitive-declarations)]
+      (is (= {[:user :password] {:sensitive? true :source :schema
+                                 :hint "argon2id"}
+              [:auth :token]    {:sensitive? true :source :schema}}
+             merged)))))
+
+(deftest frame-empty-when-no-sensitive-slots
+  (testing "frames with no :sensitive? slots produce an empty registry"
+    (rf/reg-app-schema [:count] [:int])
+    (rf/reg-app-schema [:user] [:map [:name :string]])
+    (is (= {} (schemas/frame-sensitive-declarations)))))
+
+(deftest frame-isolation
+  (testing "schemas in one frame don't leak into another — per-frame
+            isolation parallel to the :large? walker"
+    (rf/reg-app-schema [:user]
+                       [:map [:password {:sensitive? true} :string]]
+                       {:frame :frame-a})
+    (rf/reg-app-schema [:user]
+                       [:map [:token {:sensitive? true} :string]]
+                       {:frame :frame-b})
+    (is (= {[:user :password] {:sensitive? true :source :schema}}
+           (schemas/frame-sensitive-declarations :frame-a)))
+    (is (= {[:user :token] {:sensitive? true :source :schema}}
+           (schemas/frame-sensitive-declarations :frame-b)))))
+
+;; ---- populate-sensitive-declarations -------------------------------------
+
+(deftest populate-on-empty-db
+  (testing "populate hydrates [:rf/elision :sensitive-declarations] from schemas"
+    (rf/reg-app-schema [:user]
+                       [:map [:password {:sensitive? true :hint "argon2id"}
+                              :string]])
+    (let [frame-id (frame/current-frame)
+          db'      (schemas/populate-sensitive-declarations {} frame-id)]
+      (is (= {:rf/elision
+              {:sensitive-declarations
+               {[:user :password] {:sensitive? true :source :schema
+                                   :hint "argon2id"}}}}
+             db')))))
+
+(deftest populate-idempotent
+  (testing "calling populate twice produces the same db both times"
+    (rf/reg-app-schema [:user]
+                       [:map [:password {:sensitive? true} :string]])
+    (let [frame-id (frame/current-frame)
+          db-1     (schemas/populate-sensitive-declarations {} frame-id)
+          db-2     (schemas/populate-sensitive-declarations db-1 frame-id)]
+      (is (= db-1 db-2)
+          "second call is a no-op when the schema set is unchanged"))))
+
+(deftest populate-preserves-declared-source
+  (testing "existing :source :declared entries are NEVER overwritten by
+            schema entries — conflict rule: declared beats schema"
+    (rf/reg-app-schema [:user]
+                       [:map [:password {:sensitive? true :hint "schema-hint"}
+                              :string]])
+    (let [frame-id  (frame/current-frame)
+          db-with-declared
+          {:rf/elision
+           {:sensitive-declarations
+            {[:user :password] {:sensitive? true
+                                :source     :declared
+                                :hint       "user-fx-hint"}}}}
+          db' (schemas/populate-sensitive-declarations
+                db-with-declared frame-id)]
+      (is (= "user-fx-hint"
+             (get-in db' [:rf/elision :sensitive-declarations
+                          [:user :password] :hint]))
+          "declared :hint preserved")
+      (is (= :declared
+             (get-in db' [:rf/elision :sensitive-declarations
+                          [:user :password] :source]))
+          "declared :source preserved"))))
+
+(deftest populate-overwrites-prior-schema-entry
+  (testing "a re-registered schema with a different :hint refreshes the
+            schema-source slot — hot-reload semantics"
+    (rf/reg-app-schema [:user]
+                       [:map [:password {:sensitive? true :hint "old"}
+                              :string]])
+    (let [frame-id (frame/current-frame)
+          db-1     (schemas/populate-sensitive-declarations {} frame-id)]
+      (rf/reg-app-schema [:user]
+                         [:map [:password {:sensitive? true :hint "new"}
+                                :string]])
+      (let [db-2 (schemas/populate-sensitive-declarations db-1 frame-id)]
+        (is (= "new"
+               (get-in db-2 [:rf/elision :sensitive-declarations
+                             [:user :password] :hint])))
+        (is (= :schema
+               (get-in db-2 [:rf/elision :sensitive-declarations
+                             [:user :password] :source])))))))
+
+(deftest populate-noop-when-no-sensitive-slots
+  (testing "populate is a no-op when no schema declares :sensitive?"
+    (rf/reg-app-schema [:count] [:int])
+    (let [frame-id (frame/current-frame)
+          db-in    {:count 42}]
+      (is (= db-in (schemas/populate-sensitive-declarations db-in frame-id))))))
+
+;; ---- nested + edge-case coverage ----------------------------------------
+
+(deftest deeply-nested-sensitive
+  (testing "deeply nested :sensitive? slots resolve to the full path"
+    (rf/reg-app-schema
+      [:root]
+      [:map
+       [:a [:map
+            [:b [:map
+                 [:c [:map
+                      [:d {:sensitive? true :hint "deep"} :string]]]]]]]])
+    (let [frame-id (frame/current-frame)
+          db'      (schemas/populate-sensitive-declarations {} frame-id)]
+      (is (= {[:root :a :b :c :d] {:sensitive? true :source :schema
+                                   :hint "deep"}}
+             (get-in db' [:rf/elision :sensitive-declarations]))))))
+
+(deftest vector-of-sensitive
+  (testing ":vector container's inner :sensitive? claims the container's path"
+    (rf/reg-app-schema [:tokens]
+                       [:vector [:string {:sensitive? true}]])
+    (let [frame-id (frame/current-frame)
+          db'      (schemas/populate-sensitive-declarations {} frame-id)]
+      (is (= {[:tokens] {:sensitive? true :source :schema}}
+             (get-in db' [:rf/elision :sensitive-declarations]))))))
+
+(deftest reg-app-schemas-bulk
+  (testing "bulk reg-app-schemas + populate produces the merged registry"
+    (rf/reg-app-schemas
+      {[:user]    [:map [:password {:sensitive? true :hint "argon2id"} :string]]
+       [:auth]    [:map [:token {:sensitive? true} :string]]
+       [:counter] :int})
+    (let [frame-id (frame/current-frame)
+          db'      (schemas/populate-sensitive-declarations {} frame-id)]
+      (is (= {[:user :password] {:sensitive? true :source :schema
+                                 :hint "argon2id"}
+              [:auth :token]    {:sensitive? true :source :schema}}
+             (get-in db' [:rf/elision :sensitive-declarations]))))))
+
+;; ---- composition with :large? -------------------------------------------
+
+(deftest both-flags-on-same-slot-populate-both-registries
+  (testing "Per Spec 010 §`:sensitive?` + Spec 009 §Unified wire-elision
+            surface — a slot carrying BOTH `:sensitive? true` and
+            `:large? true` lands in BOTH sibling registries
+            (`:declarations` for `:large?`, `:sensitive-declarations`
+            for `:sensitive?`).
+
+            The validation emit-site's composition rule (sensitive
+            wins on the schema-validation trace) is covered by
+            `schemas_sensitive_test.clj`; this test pins the
+            registry-side composition: both registries are populated,
+            and a downstream consumer can join them path-by-path to
+            decide elision vs redaction."
+    (rf/reg-app-schema [:user :secret-pdf]
+                       [:string {:sensitive? true :large? true
+                                 :hint "encrypted-pdf"}])
+    (let [frame-id (frame/current-frame)
+          db'      (-> {}
+                       (schemas/populate-elision-declarations frame-id)
+                       (schemas/populate-sensitive-declarations frame-id))]
+      ;; :large? registry — the slot is large.
+      (is (= {[:user :secret-pdf]
+              {:large? true :source :schema :hint "encrypted-pdf"}}
+             (get-in db' [:rf/elision :declarations]))
+          ":large? entry in :declarations")
+      ;; :sensitive? registry — the slot is sensitive.
+      (is (= {[:user :secret-pdf]
+              {:sensitive? true :source :schema :hint "encrypted-pdf"}}
+             (get-in db' [:rf/elision :sensitive-declarations]))
+          ":sensitive? entry in :sensitive-declarations")
+      ;; The walker's composition rule (sensitive wins) is enforced at
+      ;; the emit site (schemas_sensitive_test.clj §sensitive-overrides-
+      ;; large-on-same-slot); this test pins the registry-side
+      ;; orthogonal composition.
+      (is (true? (schemas/schema-has-sensitive?
+                   [:string {:sensitive? true :large? true}]))))))
+
+(deftest one-slot-large-other-sensitive
+  (testing "two sibling slots — one :large?, one :sensitive? — populate
+            disjoint sibling registries"
+    (rf/reg-app-schema [:user]
+                       [:map
+                        [:pdf {:large? true :hint "big blob"} :string]
+                        [:password {:sensitive? true} :string]])
+    (let [frame-id (frame/current-frame)
+          db'      (-> {}
+                       (schemas/populate-elision-declarations frame-id)
+                       (schemas/populate-sensitive-declarations frame-id))]
+      (is (= {[:user :pdf] {:large? true :source :schema :hint "big blob"}}
+             (get-in db' [:rf/elision :declarations])))
+      (is (= {[:user :password] {:sensitive? true :source :schema}}
+             (get-in db' [:rf/elision :sensitive-declarations]))))))

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -68,20 +68,20 @@
     (let [schema [:map
                   [:user :string]
                   [:password {:sensitive? true} :string]]]
-      (is (= {[:password] {:sensitive? true}}
+      (is (= {[:password] {:sensitive? true :source :schema}}
              (schemas/extract-sensitive-paths-from-schema schema []))))))
 
 (deftest extract-honours-base-path
   (testing "base-path is prepended to every discovered slot path"
     (let [schema [:map
                   [:password {:sensitive? true} :string]]]
-      (is (= {[:auth :password] {:sensitive? true}}
+      (is (= {[:auth :password] {:sensitive? true :source :schema}}
              (schemas/extract-sensitive-paths-from-schema schema [:auth]))))))
 
 (deftest extract-container-level-sensitive
   (testing "the schema's OWN props (container-level) claim the base-path"
     ;; `(reg-app-schema [:auth :token] [:string {:sensitive? true}])`
-    (is (= {[:auth :token] {:sensitive? true}}
+    (is (= {[:auth :token] {:sensitive? true :source :schema}}
            (schemas/extract-sensitive-paths-from-schema
              [:string {:sensitive? true}] [:auth :token])))))
 
@@ -93,7 +93,7 @@
                     [:profile
                      [:map
                       [:ssn {:sensitive? true} :string]]]]]]]
-      (is (= {[:user :profile :ssn] {:sensitive? true}}
+      (is (= {[:user :profile :ssn] {:sensitive? true :source :schema}}
              (schemas/extract-sensitive-paths-from-schema schema []))))))
 
 (deftest extract-multiple-sensitive-slots
@@ -103,14 +103,14 @@
                   [:password  {:sensitive? true} :string]
                   [:totp-code {:sensitive? true} :string]
                   [:email :string]]]
-      (is (= {[:password]  {:sensitive? true}
-              [:totp-code] {:sensitive? true}}
+      (is (= {[:password]  {:sensitive? true :source :schema}
+              [:totp-code] {:sensitive? true :source :schema}}
              (schemas/extract-sensitive-paths-from-schema schema []))))))
 
 (deftest extract-positional-combinator-descends
   (testing ":vector / :or / :and descend at the same base-path"
     ;; A :vector with sensitive props on its inner type's container.
-    (is (= {[:tokens] {:sensitive? true}}
+    (is (= {[:tokens] {:sensitive? true :source :schema}}
            (schemas/extract-sensitive-paths-from-schema
              [:vector [:string {:sensitive? true}]] [:tokens])))))
 

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -326,7 +326,23 @@ The two are orthogonal and additive — the conservative recommendation is to de
 
 **Production elision.** The redaction lives behind the same `(when interop/debug-enabled? ...)` outer gate as the rest of the validation hot path (per [§Production builds](#production-builds)). `:advanced` + `goog.DEBUG=false` builds DCE the entire validate-emit body — including the `:rf/redacted` substitution — alongside the trace surface. The redaction is moot when there is no trace to redact.
 
-**Walker.** The CLJS reference ships `re-frame.schemas/extract-sensitive-paths-from-schema` (parallel to `extract-large-paths-from-schema`) — a pure-data Malli-EDN walker that returns `{path {:sensitive? true}}` entries for every `:sensitive? true` slot in a registered schema. The validation emit-site walks the failing path's schema with this helper to decide whether to redact.
+**Walker.** The CLJS reference ships `re-frame.schemas/extract-sensitive-paths-from-schema` (parallel to `extract-large-paths-from-schema`) — a pure-data Malli-EDN walker that returns `{path declaration}` entries for every `:sensitive? true` slot in a registered schema. Each declaration carries `{:sensitive? true :source :schema}` plus an optional `:hint` propagated verbatim from the slot's props (apps reuse the same `:hint` key as `:large?` so a slot can be annotated once for both flags). The validation emit-site walks the failing path's schema with this helper to decide whether to redact.
+
+**Registry feeder (rf2-c1l4d).** Mirroring the `:large?` registry-population path, the schemas artefact also ships `frame-sensitive-declarations` (the per-frame aggregate) and `populate-sensitive-declarations` (the idempotent app-db hydrator) — both published through the late-bind hook table so `re-frame.core`'s boot-time / hot-reload integration writes a sibling slot in the unified elision registry at `app-db [:rf/elision :sensitive-declarations]`:
+
+```clojure
+(rf/reg-app-schema [:user]
+  [:map [:password {:sensitive? true :hint "argon2id"} :string]])
+
+;; After populate-sensitive-declarations, the frame's app-db carries:
+;;   {:rf/elision
+;;     {:sensitive-declarations
+;;       {[:user :password] {:sensitive? true
+;;                           :source     :schema
+;;                           :hint       "argon2id"}}}}
+```
+
+The sibling slot lives under the shared `[:rf/elision]` reserved root per [Spec-Schemas §`:rf/elision-registry`](Spec-Schemas.md#rfelision-registry). Two slots (not one merged map) because the `:large?` and `:sensitive?` flags compose orthogonally — a slot may carry either or both, and the schema-validation emit-site's composition rule (sensitive wins) is enforced at trace time, not at registry time. Storing them separately keeps the per-flag query (`(get-in db [:rf/elision :sensitive-declarations <path>])`) O(1) without value-shape inspection. The conflict-resolution rule for the sensitive-declarations slot matches the `:large?` sibling: app-declared (via a privacy fx surface, reserved for future use) beats schema, schema beats any future runtime-flagged sensitivity. Hot-reload of a schema refreshes `:source :schema` entries; `:source :declared` entries are preserved.
 
 **Backward compatibility.** Non-sensitive validation failures (handlers and slots with no `:sensitive?` declaration) are unchanged — `:value`, `:received`, and `:explain` ride the trace verbatim as before. Legacy listener code (tools that read `:tags :value` directly) continues to work for non-sensitive traces and sees the sentinel keyword `:rf/redacted` for sensitive ones; the sentinel is a normal EDN value the consumer can pattern-match on.
 


### PR DESCRIPTION
## Summary

Follow-on from rf2-nwv63 (`:large?` schema-walker) and rf2-kj51z (sensitive-walker shipped without the registry feeder). This bead lands the registry-population side of the `:sensitive?` per-slot schema metadata, parallel to the `:large?` registry.

## Walker mechanism

Mirror of rf2-nwv63's `:large?` walker (byte-for-byte symmetric in shape — same `:map` / `:multi` / positional descent rules, same slot-level vs container-level prop recognition):

- **`extract-sensitive-paths-from-schema`** (rf2-kj51z, extended) — each entry now carries `{:sensitive? true :source :schema}` (plus optional `:hint`) so the unified registry can apply provenance-based conflict resolution. Previously `{:sensitive? true}`.
- **`frame-sensitive-declarations`** (NEW) — per-frame aggregate across every registered app-schema.
- **`populate-sensitive-declarations`** (NEW) — idempotent app-db hydrator for the sibling registry slot.

## Registry shape

The walker feeds `app-db [:rf/elision :sensitive-declarations]`, a sibling slot to the existing `[:rf/elision :declarations]` (the `:large?` registry). Two slots (not one merged map) because the flags compose orthogonally: a slot may carry either or both. Composition rule (sensitive wins on the schema-validation emit-site) is enforced at trace time, not at registry time — keeps each per-flag query O(1).

Each entry's shape:
```clojure
{[:user :password] {:sensitive? true :source :schema :hint "argon2id"}}
```

Conflict-resolution rule (parallel to `:large?`): app-declared beats schema beats runtime-flagged. Hot-reload refreshes `:source :schema` entries; `:source :declared` entries are preserved.

## Late-bind hooks

Two new published keys, both with directory entries:

- `:schemas/frame-sensitive-declarations`
- `:schemas/populate-sensitive-declarations`

## Tests

- **schemas_sensitive_paths_test.clj** (new) — 17 tests, 23 assertions, all passing:
  - Walker per-entry shape (`:source :schema` stamp)
  - `:hint` propagation
  - `:hint` without `:sensitive?` → no entry
  - `:sensitive? false` → no entry
  - Per-frame aggregation; frame isolation
  - Idempotency (re-boot doesn't duplicate)
  - Declared-source preservation (conflict rule)
  - Schema-source refresh on hot-reload
  - Deeply-nested + vector-of edge cases
  - Bulk `reg-app-schemas`
  - **Composition** — both `:sensitive?` and `:large?` on the same slot populates BOTH sibling registries (`:declarations` and `:sensitive-declarations`); + one-slot-large-other-sensitive disjoint coverage
- **schemas_sensitive_test.clj** — existing walker assertions updated to expect the new `:source :schema` slot

7 unrelated `app-db-validation-redacts-*` tests already fail on origin/main (`(true? (-> v :tags :sensitive?))` returns nil) — pre-existing, unaffected by this change.

## Spec

`spec/010-Schemas.md` §`:sensitive?` — added a **Registry feeder (rf2-c1l4d)** paragraph describing the sibling slot shape and conflict rule, parallel to the `:large?` registry text. Walker paragraph updated to mention the `:source :schema` stamp + optional `:hint`.

## Test plan

- [x] `clojure -M:test` from `implementation/schemas/` — 116 tests (was 99); 7 pre-existing failures, no new ones
- [x] `clojure -M:test -n re-frame.schemas-sensitive-paths-test` — 17/17 pass
- [x] `clojure -M:test -n re-frame.late-bind-drift-test` from `implementation/core/` — 5 tests, 295 assertions (new directory entries pass)
- [x] `clojure -M:test` from `implementation/core/` — 412 tests, 2188 assertions, no failures

Bead: rf2-c1l4d.