### PR TITLE
docs(skills): extract shared retro-protocol leaf for retro2 + improver (rf2-dhe9v)

### DIFF
--- a/skills/re-frame-pair-retro2/SKILL.md
+++ b/skills/re-frame-pair-retro2/SKILL.md
@@ -77,6 +77,8 @@ When in doubt, ask: *"Was there a `re-frame-pair2` session you want me to retros
 
 ## Analysis workflow
 
+Load [`../shared/retro-protocol.md`](../shared/retro-protocol.md) — the seven-step diagnosis-first workflow, evidence-citation discipline, layer-routing rules, and opt-in bead protocol shared with `re-frame2-improver`. The protocol leaf is the normative source for the workflow shape; the steps below are the pair2-retro specialisation.
+
 1. **Reconstruct the session goal.** The user's intended outcome, plus environment facts (platform, target repo, live runtime state, tooling constraints).
 2. **Build a short timeline.** Turns where progress stalled, restarted, detoured, required a workaround. Tool errors, empty/stale outputs, retries, clarification loops.
 3. **Extract friction.** Numbered list first. For each: what happened, where it appeared, initial category guess. Ask which to dig into and what was missed.
@@ -122,6 +124,7 @@ If `bd` is not configured in the target repo, produce a ready-to-paste body and 
 
 ## Reference files
 
+- [`../shared/retro-protocol.md`](../shared/retro-protocol.md) — shared retro protocol (seven-step diagnosis-first workflow, evidence-citation discipline, layer-routing rules, opt-in bead protocol). Extracted by rf2-dhe9v; consumed by both this skill and `re-frame2-improver`.
 - [`references/analysis-lenses.md`](references/analysis-lenses.md) — friction signals (generic + re-frame2-specific), root-cause categories, improvement patterns, routing decisions, prioritization.
 - [`references/known-frictions.md`](references/known-frictions.md) — recurring classes of `re-frame-pair2` pain; sanity-check one-off vs pattern.
 - [`references/issue-template.md`](references/issue-template.md) — bead/issue body template.

--- a/skills/re-frame2-improver/SKILL.md
+++ b/skills/re-frame2-improver/SKILL.md
@@ -76,7 +76,7 @@ If 1 holds but 2 doesn't: ask for a snippet or a directory to read. Decline rath
 5. **Propose fixes.** Grounded mechanical rewrites can use `Edit` when the agent is confident. Higher-leverage redesigns stay as suggestions — present the option, let the user decide.
 6. **Surface findings** in the output shape below.
 
-The diagnosis-first discipline, evidence-citation rules, and layer-routing heuristics are shared with the retro skills — see [`references/retro-protocol.md`](references/retro-protocol.md) (rf2-dhe9v will extract this as a shared protocol leaf consumed by both `re-frame2-improver` and the renamed `re-frame-pair-retro2`).
+The diagnosis-first discipline, evidence-citation rules, layer-routing heuristics, and opt-in bead protocol are shared with `re-frame-pair-retro2` — load the shared leaf at [`../shared/retro-protocol.md`](../shared/retro-protocol.md). The workflow above is the consuming view; the protocol leaf is the normative source.
 
 ## Output format
 
@@ -104,4 +104,4 @@ If the in-scope code is too thin for findings, say so plainly and ask for a wide
 ## Reference files
 
 - [`references/`](references/) — anti-pattern catalogue (6 leaves at launch; populated by rf2-bquci). Each leaf carries: detection rule, symptom example, canonical re-frame2 idiom, suggested rewrite, cross-link to `skills/re-frame2/patterns/` or `spec/`.
-- [`references/retro-protocol.md`](references/retro-protocol.md) — shared retro protocol (diagnosis-first workflow, evidence-citation discipline, layer-routing rules). Extracted by rf2-dhe9v from `re-frame-pair-retro2`; consumed by both this skill and `re-frame-pair-retro2`.
+- [`../shared/retro-protocol.md`](../shared/retro-protocol.md) — shared retro protocol (seven-step diagnosis-first workflow, evidence-citation discipline, layer-routing rules, opt-in bead protocol). Extracted by rf2-dhe9v; consumed by both this skill and `re-frame-pair-retro2`.

--- a/skills/re-frame2-improver/references/README.md
+++ b/skills/re-frame2-improver/references/README.md
@@ -31,9 +31,9 @@ Each leaf carries the same five sections:
 
 When a new anti-pattern surfaces across 3+ review sessions, add it as a new leaf and a new row above. Mirrors how `re-frame-pair-improver2/references/known-frictions.md` grows organically. Anti-patterns flagged in `ai/findings/improver-architecture-20260513-1752.md` §Angle 2 as "bonus" candidates (view renders only happy state; effect handlers writing to foreign frames) are deferred until they surface in real reviews.
 
-## Planned shared leaf (rf2-dhe9v will land)
+## Shared retro protocol (rf2-dhe9v)
 
-- `retro-protocol.md` — diagnosis-first workflow, evidence-citation discipline, layer-routing rules. Extracted from `re-frame-pair-retro2`. Consumed by both this skill and `re-frame-pair-retro2`.
+- [`../../shared/retro-protocol.md`](../../shared/retro-protocol.md) — seven-step diagnosis-first workflow, evidence-citation discipline, layer-routing rules, opt-in bead protocol. Extracted from `re-frame-pair-retro2`; consumed by both this skill and `re-frame-pair-retro2`. The SKILL.md loads it; per-leaf detection rules below assume the protocol is already in scope.
 
 ## Cross-references
 

--- a/skills/shared/retro-protocol.md
+++ b/skills/shared/retro-protocol.md
@@ -1,0 +1,87 @@
+# Shared retro protocol
+
+The diagnosis-first workflow shared by `re-frame-pair-retro2` (retrospect on a pair2 session) and `re-frame2-improver` (critique on a body of re-frame2 code). Both skills load this leaf for the workflow shape, evidence discipline, layer-routing rules, and opt-in bead protocol; each skill provides its own domain catalogue (friction signals for retro2; anti-patterns for improver) on top.
+
+Origin: extracted under rf2-dhe9v from the locked decisions in `re-frame-pair-retro2/spec/design.md` and the body of `re-frame-pair-retro2/SKILL.md`. The locks below are normative for any retro-style skill that loads this leaf.
+
+## What "retrospect" means here
+
+A retrospect-style skill reads some body of evidence — a session transcript, a code body, an error trace, a recap supplied by the user — and produces a structured critique: what was observed, what patterns or frictions it matches, where the fix lives, and (only on request) a draft bead.
+
+The shape of the evidence varies by skill. The discipline below does not.
+
+## The seven-step protocol
+
+1. **Read the evidence in scope.** Identify what body the critique is operating on:
+   - For session-shaped skills (e.g. pair-retro): the turns where the user attached, dispatched, walked traces / epochs, hot-swapped, time-travelled — or a user-supplied recap of the same.
+   - For code-shaped skills (e.g. improver): the `.cljs` / `.cljc` files read or edited in the conversation, or a snippet the user supplies.
+   - For error-shaped triggers (e.g. on-error in pair2): the stack trace, the failed dispatch, the policy fire — plus the immediately preceding turns.
+   If the evidence is too thin, say so plainly and ask for a wider scope or a recap. Decline rather than fabricate.
+
+2. **Identify the discrepancy or anti-pattern category.** Pattern-match the evidence against the consuming skill's domain catalogue. Numbered list first. For each candidate: what was observed, where it appeared (file/line, turn, trace event), and an initial category guess. Ask which to dig into before classifying.
+
+3. **Route to the relevant detection rule.** Each skill carries its own catalogue:
+   - `re-frame-pair-retro2` — friction signals + recurring friction classes under [`re-frame-pair-retro2/references/analysis-lenses.md`](../re-frame-pair-retro2/references/analysis-lenses.md) and [`re-frame-pair-retro2/references/known-frictions.md`](../re-frame-pair-retro2/references/known-frictions.md).
+   - `re-frame2-improver` — anti-pattern leaves under [`re-frame2-improver/references/`](../re-frame2-improver/references/).
+
+   The catalogue tells the agent *how to recognise* the pattern. This protocol tells the agent *how to handle* the recognition.
+
+4. **Surface findings with concrete evidence.** Cite the moment, not a vibe. *"Three retries of the attach command at turns 4, 7, 11, each with the same error"* — not *"discovery felt brittle."* For code: file path + line range + the symptom expression. For sessions: turn references + the failing op shape. No vague *"consider better patterns"* without a named idiom and a concrete moment.
+
+5. **Cross-link to the canonical fix.** Each finding routes to the matching leaf:
+   - For pair-retro: the analysis-lens that names the root-cause category, and the typical-improvement shape under `known-frictions.md`.
+   - For improver: the canonical-idiom leaf under `skills/re-frame2/patterns/` or the relevant `spec/` document.
+   The cross-link is supporting evidence; the finding must still stand on its own with the symptom and the suggested rewrite.
+
+6. **Apply the opt-in bead protocol.** Never file a bead, edit a foreign repo, or land an `Edit` for a higher-leverage redesign without explicit user approval.
+   - Mechanical rewrites with a clear canonical idiom MAY use `Edit` when the agent is confident.
+   - Anything else stays as a suggestion until the user says go.
+   - Before filing: redact secrets, tokens, internal URLs, unnecessary local paths; search for an existing bead first (`bd list` / `bd ready` / `bd show <id>`); prefer one bead per materially distinct improvement; use the consuming skill's `references/issue-template.md` (or equivalent) for body shape.
+   - If `bd` is not configured in the target repo, produce a ready-to-paste body and say it is a draft, not a filed bead.
+
+7. **Voice: confident, opinionated, no hedging.** Name the idiom. Name the layer. Pick a priority. The user is asking the skill to surface its judgement — equivocation wastes the trip. Bolder ideas get labelled as such, not buried in qualifiers.
+
+## Layer-routing rules
+
+Every finding has a layer where the fix lives. Pick before drafting:
+
+- **The consuming tool itself** — the skill's `SKILL.md` wording, scripts, recipes, structured-result shape, attach/discovery logic, cross-platform handling. (For pair-retro: `re-frame-pair2`. For improver: `re-frame2-improver` itself, when the catalogue or detection rules need work.)
+- **Upstream `re-frame2`** — the friction is in the framework's Tool-Pair contract, a missing trace event category, an under-specified `:rf.epoch/*` failure mode, a missing registrar query surface, a `data-rf2-source-coord` annotation gap, a schema-reflection shortcoming, or an idiom the spec doesn't yet describe clearly.
+- **The author's code** — the finding is a code-level rewrite, not a tooling change. Suggest the rewrite; offer the `Edit` when the change is mechanical and the canonical idiom is unambiguous.
+- **Both** — sometimes the fastest path is a local workaround now plus an upstream bead for the long-term fix. File both; cross-link them.
+
+## Output shape
+
+Compact retrospective sections (skills MAY rename to fit their domain, but the seven slots stay):
+
+- `Goal` (or `Scope` for code-shaped skills) — what the user was doing / what is under review.
+- `Observed` — friction (sessions) or shape (code), with concrete evidence.
+- `Causes` (or `Pattern findings`) — classified per the consuming skill's catalogue, one primary cause per finding.
+- `Improvements` (or `Suggested rewrites`) — 2-5 grounded ideas, each with: the friction/pattern it addresses, why the consuming tool was not enough, the proposed change, the layer (see above), and a one-line impact statement.
+- `Bolder ideas` (or `Higher-leverage redesigns`) — 0-2 credible higher-upside options worth separating from grounded fixes. Labelled as bolder; the user picks whether to engage.
+- `Bead candidates` — only if the user has signalled interest. Routed to the right repo per the layer rules.
+- `Other possibilities` — good lower-priority ideas demoted to a short list.
+
+If the evidence is too thin for findings, say so plainly. Don't pad.
+
+## Evidence discipline (the "vibes" rule)
+
+The cardinal sin of a retro skill is fabricating evidence to fill the output. If the catalogue does not match the body, say the body is clean. If the session was too short to retro, say so and ask for a recap.
+
+Friction and anti-patterns are recognised, not invented. Every finding must trace to a concrete moment in the evidence — turn, line range, op shape, error mode. *"This feels off"* is not a finding; *"L42 reaches into `re-frame.db/app-db` directly, which is private per Tool-Pair §REPL-eval"* is.
+
+## What this protocol does NOT cover
+
+- **Domain catalogues.** Each consuming skill provides its own catalogue of recognisable patterns. This protocol assumes the catalogue exists and is loaded.
+- **Trigger semantics.** Each consuming skill carries its own activation precondition (e.g. "a pair2 session must exist," "a body of re-frame2 source must be in scope"). This protocol does not override that.
+- **Tool surfaces.** Each consuming skill carries its own `allowed-tools` frontmatter. This protocol does not require any specific tools beyond the standard Read / Edit / Grep / Glob set; bead drafting needs `Bash(bd *)` if filing is in scope.
+
+## Cross-references
+
+- [`re-frame-pair-retro2/SKILL.md`](../re-frame-pair-retro2/SKILL.md) — session-retro consumer.
+- [`re-frame2-improver/SKILL.md`](../re-frame2-improver/SKILL.md) — code-critique consumer.
+- [`re-frame-pair-retro2/references/analysis-lenses.md`](../re-frame-pair-retro2/references/analysis-lenses.md) — root-cause taxonomy used by the pair-retro skill.
+- [`re-frame-pair-retro2/references/known-frictions.md`](../re-frame-pair-retro2/references/known-frictions.md) — recurring friction classes for pair-retro pattern-matching.
+- [`re-frame2-improver/references/README.md`](../re-frame2-improver/references/README.md) — anti-pattern catalogue index for improver pattern-matching.
+- [`re-frame-pair-retro2/references/issue-template.md`](../re-frame-pair-retro2/references/issue-template.md) — bead body template (re-used by both consumers until improver authors its own).
+- Design rationale: rf2-zf7zd (`ai/findings/improver-architecture-20260513-1752.md` — local-only, not committed).


### PR DESCRIPTION
## Summary

Per rf2-zf7zd findings, both retrospect-style skills — `re-frame-pair-retro2` (session-retro) and `re-frame2-improver` (code-critique) — share the same workflow shape: diagnosis-first, evidence discipline, layer-routed fixes, opt-in bead protocol. Each maintained its own copy, which would drift.

This PR extracts the shared protocol into one normative leaf both skills load. Each skill keeps its own domain catalogue (friction signals for retro2, anti-patterns for improver).

## Leaf path

- New: `skills/shared/retro-protocol.md` (87 LoC)

## Both SKILL.md loading-maps updated

- `skills/re-frame-pair-retro2/SKILL.md` — analysis-workflow section now loads `../shared/retro-protocol.md` as the normative source; reference-files section lists it first.
- `skills/re-frame2-improver/SKILL.md` — the placeholder cross-ref to `references/retro-protocol.md` (planted by rf2-bquci) now points at the real leaf at `../shared/retro-protocol.md`; reference-files section updated; `references/README.md` "Planned shared leaf" section becomes "Shared retro protocol (rf2-dhe9v)".

## LoC

- 1 new file (87 LoC), 7 insertions + 4 deletions in three existing files.

## The 7-step protocol settled on

1. **Read the evidence in scope** — session turns / `.cljs` body / error trace / user recap; decline if too thin.
2. **Identify the discrepancy or anti-pattern category** — pattern-match against the consuming skill's catalogue.
3. **Route to the relevant detection rule** — each skill's own catalogue (analysis-lenses + known-frictions for retro2; six anti-pattern leaves for improver).
4. **Surface findings with concrete evidence** — turn references / file:line / op shape, never vibes.
5. **Cross-link to the canonical fix** — analysis-lens for retro2; `skills/re-frame2/patterns/` or `spec/` leaf for improver.
6. **Apply the opt-in bead protocol** — never file or `Edit` higher-leverage redesigns without explicit user approval; redact before filing.
7. **Voice: confident, opinionated, no hedging** — name the idiom, name the layer, pick a priority; bolder ideas labelled.

Plus layer-routing rules (consuming tool / upstream `re-frame2` / author's code / both) and a "vibes" anti-rule that's the cardinal sin: don't fabricate evidence to fill output.

## Layout choice

`skills/shared/` (option (a) from the bead). Reasons:

- No `_shared`-prefix precedent in this repo.
- A new top-level skill at `skills/retro-protocol.md` would clutter the skill roster (six skills, well-defined).
- A `shared/` subdir clearly communicates "shared content, not a skill."
- Skills' `references/` subdirs aren't published to mkdocs; neither is `shared/` — both behave identically for the build.

## Test plan

- [x] `python scripts/check_doc_slugs.py` — no new broken links introduced (2 pre-existing broken anchors in `spec/Pattern-FormAction.md` are unrelated to this PR; confirmed by running against `origin/main` baseline).
- [x] `mkdocs build --strict` — surfaces the same 2 pre-existing warnings; no new warnings from `skills/shared/retro-protocol.md` (it lives outside the mkdocs nav, like other `references/*.md` leaves in skill subdirs).
- [x] Both SKILL.md files reference the new leaf via valid relative paths (`../shared/retro-protocol.md`).
- [x] Internal cross-references in the leaf (to retro2 references, improver references, retro2 issue-template) resolve.