### PR TITLE
test(mcp): end-to-end MCP-client harness for pair2 + story servers (rf2-cum40)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1229,3 +1229,146 @@ jobs:
 
       - name: Run live-server workflow integration test (tools/story-mcp artefact)
         run: node test/live-server.js
+
+  # ---------------------------------------------------------------------------
+  # MCP-client conformance jobs (rf2-cum40).
+  #
+  # The `node-test-tools-{pair2,story}-mcp` jobs above drive each server
+  # via hand-rolled JSON-RPC on stdin/stdout. That catches server-side
+  # bugs but cannot see protocol-mismatch bugs visible only when a real
+  # MCP-aware consumer (Claude Code, Continue, …) attaches via the
+  # official `@modelcontextprotocol/sdk` `Client` — that library
+  # validates every response against the spec's Zod schemas
+  # (InitializeResultSchema, ListToolsResultSchema, CallToolResultSchema,
+  # …), so a server response that's "close enough" to fool a hand-rolled
+  # probe can still fail the SDK's parse step.
+  #
+  # The `tools/mcp-conformance/` artefact closes that gap. One script
+  # per server, each driving the server through the SDK's
+  # StdioClientTransport + Client.connect() + listTools()/callTool()
+  # surface, walking one canonical workflow per server. See
+  # tools/mcp-conformance/README.md for the full rationale and per-test
+  # scope.
+  # ---------------------------------------------------------------------------
+
+  mcp-conformance-pair2:
+    name: MCP conformance tools/pair2-mcp (rf2-cum40)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/mcp-conformance
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '24'
+
+      - name: Cache Maven / gitlibs (shadow-cljs deps for pair2-mcp build)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: ${{ runner.os }}-mcp-conformance-pair2-${{ hashFiles('tools/pair2-mcp/shadow-cljs.edn', 'tools/pair2-mcp/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-mcp-conformance-pair2-
+            ${{ runner.os }}-cljs-tools-pair2-mcp-
+            ${{ runner.os }}-cljs-
+
+      # The conformance harness drives the pair2-mcp Node bundle, so we
+      # need to compile that bundle first. Same shadow-cljs entry point
+      # as the node-test-tools-pair2-mcp job above. We don't run
+      # pair2-mcp's own tests here — that's the parallel job's
+      # responsibility.
+      - name: Install pair2-mcp deps
+        working-directory: tools/pair2-mcp
+        run: npm install
+
+      - name: Compile pair2-mcp server bundle (shadow-cljs :server)
+        working-directory: tools/pair2-mcp
+        run: npx shadow-cljs compile server
+
+      - name: Install mcp-conformance deps
+        run: npm install
+
+      - name: Run pair2-mcp end-to-end MCP-client conformance
+        run: npm run test:pair2
+
+  mcp-conformance-story:
+    name: MCP conformance tools/story-mcp (rf2-cum40)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/mcp-conformance
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08  # 13.4
+        with:
+          cli: latest
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '24'
+
+      - name: Cache Maven / gitlibs (story-mcp Clojure deps)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-mcp-conformance-story-${{ hashFiles('tools/story-mcp/deps.edn', 'tools/story/deps.edn', 'implementation/core/deps.edn', 'implementation/adapters/reagent/deps.edn', 'implementation/machines/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-mcp-conformance-story-
+            ${{ runner.os }}-node-tools-story-mcp-
+            ${{ runner.os }}-clj-tools-story-mcp-
+            ${{ runner.os }}-clj-
+
+      - name: Install mcp-conformance deps
+        run: npm install
+
+      - name: Run story-mcp end-to-end MCP-client conformance
+        run: npm run test:story
+
+  mcp-conformance-causa:
+    name: MCP conformance tools/causa-mcp (rf2-cum40, SKIPPED until impl)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/mcp-conformance
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '24'
+
+      # The causa-mcp server implementation hasn't landed yet
+      # (tools/causa-mcp is spec-only). The script exits 0 with a SKIP
+      # marker so this gate stays green and the placeholder doesn't go
+      # stale. When the impl lands, replace test/end-to-end-causa.js's
+      # body wholesale (the file's header comment documents the
+      # expected shape).
+      - name: Install mcp-conformance deps
+        run: npm install
+
+      - name: Run causa-mcp end-to-end MCP-client conformance (SKIPPED)
+        run: npm run test:causa

--- a/tools/mcp-conformance/README.md
+++ b/tools/mcp-conformance/README.md
@@ -1,0 +1,116 @@
+# tools/mcp-conformance
+
+End-to-end **MCP-client** conformance harness for the re-frame2 MCP
+servers — `pair2-mcp`, `story-mcp`, and (when its implementation lands)
+`causa-mcp`. Source: rf2-cum40.
+
+## What this is
+
+Every existing test surface for these servers is **server-side**:
+
+- per-tool unit tests (under each server artefact's `test/`)
+- `stdio-roundtrip.js` — a hand-rolled JSON-RPC wire-format probe
+- `live-{nrepl,server}.js` — workflow tests against a running runtime
+
+None of these drive a server from the **client** side of MCP — they all
+either hand-roll JSON-RPC framing or skip the protocol layer entirely.
+That leaves a gap: when a real MCP-aware consumer (Claude Code,
+Continue, etc.) talks to one of these servers, it goes through the
+official `@modelcontextprotocol/sdk` `Client`, which validates **every**
+response against the spec's Zod schemas (`InitializeResultSchema`,
+`ListToolsResultSchema`, `CallToolResultSchema`, …). A server response
+that's "close enough" to the spec to fool a hand-rolled probe can still
+fail the SDK's parse step, and that bug ships unobserved until a real
+consumer attaches.
+
+This harness closes that gap. It spawns each server through the SDK's
+`StdioClientTransport`, completes the full `Client.connect()`
+handshake, walks one canonical workflow per server using `listTools()`
+and `callTool()`, and tears the transport down cleanly. Any spec drift
+on the server side surfaces as an SDK parse-error.
+
+## Files
+
+- `package.json` — depends on `@modelcontextprotocol/sdk` only
+- `test/end-to-end-pair2.js` — pair2-mcp conformance (degraded mode,
+  no nREPL needed — same shape as pair2-mcp's stdio-roundtrip)
+- `test/end-to-end-story.js` — story-mcp conformance (full write-loop
+  with `--allow-writes` enabled)
+- `test/end-to-end-causa.js` — placeholder; exits 0 with a `SKIP`
+  marker until causa-mcp's server implementation lands
+
+## How to run
+
+From this directory:
+
+```bash
+npm install
+
+# pair2-mcp: requires the server bundle on disk at
+# ../pair2-mcp/out/server.js. Build it first with:
+#   cd ../pair2-mcp && npx shadow-cljs compile server
+npm run test:pair2
+
+# story-mcp: requires `clojure` on PATH (override via
+# $STORY_MCP_CMD if non-default). No pre-build step — the server is
+# launched via `clojure -M -m re-frame.story-mcp.server`.
+npm run test:story
+
+# causa-mcp: currently a SKIPPED no-op (see comment in the file).
+npm run test:causa
+
+# All three (pair2 must be pre-built):
+npm test
+```
+
+## What each test covers
+
+### `end-to-end-pair2.js`
+
+1. Connect — full SDK handshake against the freshly spawned bundle
+2. `tools/list` — confirm the ten advertised tools match the pinned
+   catalogue
+3. Spot-check every descriptor carries an `inputSchema`
+4. Walk degraded-mode `dispatch` / `watch-epochs` / `snapshot` /
+   `subscribe` — each call routes through the SDK's
+   `CallToolResultSchema` parse step
+5. Clean `Client.close()`
+
+Runs without an nREPL on `$SHADOW_CLJS_NREPL_PORT`, so it's
+self-contained and reproducible.
+
+### `end-to-end-story.js`
+
+1. Connect — `clojure -M -m re-frame.story-mcp.server --allow-writes`
+2. `tools/list` — confirm the 17 advertised tools
+3. Spot-check every descriptor carries an `inputSchema`
+4. `register-variant` → `run-variant` (vacuous pass) →
+   `read-failures` (total=0) → `unregister-variant` + verify
+5. Clean `Client.close()`
+
+Watchdog: 90s (cold JVM boot is ~10–30s on a CI runner).
+
+### `end-to-end-causa.js`
+
+Placeholder — exits 0 with a `SKIP` marker. Will be filled in when
+the causa-mcp server implementation lands; the file's body comment
+documents the expected shape.
+
+## CI
+
+`.github/workflows/test.yml` runs each of the three scripts in its own
+`mcp-conformance-{pair2,story,causa}` job, parallel to the existing
+`node-test-tools-{pair2,story}-mcp` jobs. Same Node 24 + JDK 21 setup
+as those jobs.
+
+## Why a separate artefact?
+
+The harness only depends on `@modelcontextprotocol/sdk` and Node's
+stdlib. Putting it under each server's `test/` would duplicate the
+dependency and tie the client-side fixture to each server's
+build/dependency graph. A standalone artefact keeps the conformance
+contract in one place and makes "add an MCP server, add a conformance
+script" a one-file change.
+
+The artefact is bundle-isolated from production builds by construction
+(it's pure Node-side test fixtures; no CLJS sources).

--- a/tools/mcp-conformance/package-lock.json
+++ b/tools/mcp-conformance/package-lock.json
@@ -1,0 +1,1139 @@
+{
+  "name": "@day8/re-frame2-mcp-conformance",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@day8/re-frame2-mcp-conformance",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/tools/mcp-conformance/package.json
+++ b/tools/mcp-conformance/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@day8/re-frame2-mcp-conformance",
+  "version": "0.1.0",
+  "private": true,
+  "description": "End-to-end MCP-client conformance harness for re-frame2 MCP servers (pair2-mcp, story-mcp, causa-mcp). Drives each server via the official @modelcontextprotocol/sdk Client so a real MCP-aware consumer (not a hand-rolled JSON-RPC shim) exercises the handshake, tool catalogue, and one canonical workflow per server.",
+  "license": "MIT",
+  "scripts": {
+    "test:pair2": "node test/end-to-end-pair2.js",
+    "test:story": "node test/end-to-end-story.js",
+    "test:causa": "node test/end-to-end-causa.js",
+    "test": "node test/end-to-end-pair2.js && node test/end-to-end-story.js && node test/end-to-end-causa.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0"
+  },
+  "keywords": [
+    "re-frame",
+    "re-frame2",
+    "mcp",
+    "model-context-protocol",
+    "conformance",
+    "integration-test"
+  ]
+}

--- a/tools/mcp-conformance/test/end-to-end-causa.js
+++ b/tools/mcp-conformance/test/end-to-end-causa.js
@@ -1,0 +1,21 @@
+// End-to-end MCP-client conformance test for tools/causa-mcp.
+//
+// SKIPPED (rf2-cum40): causa-mcp is spec-only at the moment — see
+// tools/causa-mcp/ which contains a README + spec/ subtree but no
+// server implementation yet. When the implementation lands, this
+// script should be filled in mirroring end-to-end-{pair2,story}.js
+// against the canonical causa workflow (likely something along the
+// lines of:
+//
+//   1. connect (initialize)
+//   2. tools/list — assert advertised catalogue
+//   3. walk a representative read-loop (record → query → reset, or
+//      whatever the eventual server surfaces)
+//   4. clean disconnect
+//
+// The script intentionally exits 0 with a "SKIPPED" marker so the CI
+// step that runs it can stay green and the placeholder doesn't go
+// stale. When the implementation lands, replace this body wholesale.
+
+console.log('SKIP causa-mcp end-to-end conformance test (impl not landed yet; see rf2-cum40)');
+process.exit(0);

--- a/tools/mcp-conformance/test/end-to-end-pair2.js
+++ b/tools/mcp-conformance/test/end-to-end-pair2.js
@@ -1,0 +1,230 @@
+// End-to-end MCP-client conformance test for tools/pair2-mcp.
+//
+// Unlike tools/pair2-mcp/test/stdio-roundtrip.js (which hand-rolls the
+// JSON-RPC framing on stdin/stdout), this harness drives the server
+// through the official @modelcontextprotocol/sdk `Client` — the same
+// library a real MCP-aware consumer (Claude Code, Continue, …) would
+// use. That catches a class of protocol-mismatch bugs the server-side
+// tests can't see:
+//
+//   - response-envelope drift (the SDK's CallToolResultSchema rejects
+//     payloads that fail the spec contract)
+//   - capability negotiation drift (initialize result must round-trip
+//     through ServerCapabilitiesSchema)
+//   - tool-descriptor schema drift (the SDK's ListToolsResultSchema
+//     enforces the descriptor shape)
+//   - cap-marker handling (the {:rf.mcp/overflow ...} payload flowing
+//     through a degraded error result still has to validate as a tool
+//     result; this harness asserts the SDK accepts what the server
+//     sends)
+//
+// Run with: `node test/end-to-end-pair2.js` from this directory after
+// `cd ../pair2-mcp && shadow-cljs compile server`. Exits 0 on success.
+//
+// The test runs in degraded mode (no nREPL on $SHADOW_CLJS_NREPL_PORT)
+// — same shape as the upstream stdio-roundtrip — so it stays
+// self-contained and reproducible on CI without needing a live
+// shadow-cljs runtime. Source: rf2-cum40.
+
+const path = require('node:path');
+const os = require('node:os');
+const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
+const { StdioClientTransport } = require('@modelcontextprotocol/sdk/client/stdio.js');
+
+const SERVER = path.resolve(__dirname, '..', '..', 'pair2-mcp', 'out', 'server.js');
+
+// Expected tools advertised by pair2-mcp's tools/list. Pinned exact so
+// accidental renames / additions / deletions surface here. Mirrors the
+// upstream stdio-roundtrip baseline (ten tools, post-rf2-tygdv).
+const EXPECTED_TOOLS = [
+  'discover-app',
+  'dispatch',
+  'eval-cljs',
+  'get-path',
+  'snapshot',
+  'subscribe',
+  'tail-build',
+  'trace-window',
+  'unsubscribe',
+  'watch-epochs',
+];
+
+async function main() {
+  // Force degraded mode: empty out $SHADOW_CLJS_NREPL_PORT and boot
+  // from a tmpdir so the port-file probe misses. Same setup as the
+  // pair2-mcp upstream stdio-roundtrip.
+  const env = { ...process.env };
+  delete env.SHADOW_CLJS_NREPL_PORT;
+
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [SERVER],
+    cwd: os.tmpdir(),
+    env,
+    stderr: 'pipe',
+  });
+
+  const client = new Client(
+    { name: 'mcp-conformance-pair2', version: '0.1.0' },
+    { capabilities: {} },
+  );
+
+  // Pipe server stderr to ours so CI logs surface server-side debug
+  // output if a step fails.
+  transport.stderr?.on('data', (d) => process.stderr.write('[server] ' + d.toString()));
+
+  // 1. Connect — the SDK Client.connect() does the full initialize
+  // handshake (initialize request, response, notifications/initialized)
+  // and validates the result envelope against InitializeResultSchema.
+  // If the server's initialize response drifts from the spec, this
+  // throws.
+  await client.connect(transport);
+  const serverInfo = client.getServerVersion();
+  if (!serverInfo) throw new Error('connect succeeded but getServerVersion() is empty');
+  console.log('OK   connect ->', serverInfo);
+
+  try {
+    // 2. tools/list via SDK. The SDK validates the response against
+    // ListToolsResultSchema, so any descriptor-shape drift surfaces
+    // here.
+    const listed = await client.listTools();
+    const names = listed.tools.map((t) => t.name).sort();
+    if (JSON.stringify(names) !== JSON.stringify(EXPECTED_TOOLS)) {
+      throw new Error(
+        'tools/list catalogue mismatch:\n  expected ' +
+          JSON.stringify(EXPECTED_TOOLS) +
+          '\n  got      ' +
+          JSON.stringify(names),
+      );
+    }
+    console.log('OK   tools/list -> ' + names.length + ' tools advertised:', names.join(', '));
+
+    // 2b. Spot-check that each advertised descriptor carries an
+    // inputSchema. A real MCP consumer reads this to know what
+    // arguments to pass. The SDK's ListToolsResultSchema does loose
+    // structural validation; we tighten it here.
+    for (const t of listed.tools) {
+      if (!t.inputSchema || typeof t.inputSchema !== 'object') {
+        throw new Error('tool ' + t.name + ' has no inputSchema');
+      }
+    }
+    console.log('OK   every tool descriptor carries an inputSchema');
+
+    // 3. Canonical workflow (degraded, since no nREPL is available):
+    //    a. dispatch — proves the write-shaped tool routes through the
+    //       SDK; expect graceful degraded `isError: true`.
+    //    b. watch-epochs — proves a pull-mode tool routes through the
+    //       SDK; expect graceful degraded `isError: true` matching the
+    //       documented pattern.
+    //    c. snapshot — proves the mega-op tool routes; expect graceful
+    //       degraded.
+    //
+    // Each call goes through the SDK's CallToolResultSchema, so a
+    // malformed degraded response (missing `content` array, malformed
+    // structuredContent) would surface here as a Zod parse error
+    // before we even reach the `isError` assertion.
+    const dispatchResp = await client.callTool({
+      name: 'dispatch',
+      arguments: { 'event-v': '[:rf-conformance/probe]' },
+    });
+    if (!dispatchResp.isError) {
+      throw new Error(
+        'dispatch in degraded mode should isError; got: ' + JSON.stringify(dispatchResp),
+      );
+    }
+    const dispatchText = dispatchResp.content?.[0]?.text || '';
+    if (!dispatchText.includes('nrepl-port-not-found')) {
+      throw new Error(
+        'dispatch degraded text should mention :nrepl-port-not-found; got: ' + dispatchText,
+      );
+    }
+    console.log('OK   tools/call dispatch (degraded) -> isError + nrepl-port-not-found');
+
+    const watchResp = await client.callTool({
+      name: 'watch-epochs',
+      arguments: { 'max-ms': 50 },
+    });
+    if (!watchResp.isError) {
+      throw new Error(
+        'watch-epochs in degraded mode should isError; got: ' + JSON.stringify(watchResp),
+      );
+    }
+    const watchText = watchResp.content?.[0]?.text || '';
+    if (!watchText.includes('nrepl-port-not-found')) {
+      throw new Error(
+        'watch-epochs degraded text should mention :nrepl-port-not-found; got: ' + watchText,
+      );
+    }
+    console.log('OK   tools/call watch-epochs (degraded) -> isError + nrepl-port-not-found');
+
+    const snapResp = await client.callTool({
+      name: 'snapshot',
+      arguments: { frames: 'all' },
+    });
+    if (!snapResp.isError) {
+      throw new Error(
+        'snapshot in degraded mode should isError; got: ' + JSON.stringify(snapResp),
+      );
+    }
+    const snapText = snapResp.content?.[0]?.text || '';
+    if (!snapText.includes('nrepl-port-not-found')) {
+      throw new Error(
+        'snapshot degraded text should mention :nrepl-port-not-found; got: ' + snapText,
+      );
+    }
+    console.log('OK   tools/call snapshot (degraded) -> isError + nrepl-port-not-found');
+
+    // 3b. subscribe — same degraded shape. The streaming-shaped tool
+    // still routes through `tools/call`; in connected mode it would
+    // open a notification stream, but in degraded mode it just
+    // returns the same nrepl-port-not-found error envelope.
+    const subResp = await client.callTool({
+      name: 'subscribe',
+      arguments: { topic: 'trace' },
+    });
+    if (!subResp.isError) {
+      throw new Error(
+        'subscribe in degraded mode should isError; got: ' + JSON.stringify(subResp),
+      );
+    }
+    const subText = subResp.content?.[0]?.text || '';
+    if (!subText.includes('nrepl-port-not-found')) {
+      throw new Error(
+        'subscribe degraded text should mention :nrepl-port-not-found; got: ' + subText,
+      );
+    }
+    console.log('OK   tools/call subscribe (degraded) -> isError + nrepl-port-not-found');
+
+    // 4. Clean disconnect. The SDK closes the transport which kills
+    // the child process. If the server hangs on shutdown the harness
+    // will be killed by the watchdog timeout.
+    await client.close();
+    console.log('OK   client.close() -> transport torn down cleanly');
+    console.log('\nPAIR2-MCP MCP-CLIENT CONFORMANCE GREEN');
+  } catch (err) {
+    try {
+      await client.close();
+    } catch (_e) {
+      // best-effort
+    }
+    throw err;
+  }
+}
+
+// Hard cap so a hung server doesn't wedge CI.
+const watchdog = setTimeout(() => {
+  console.error('FAIL: watchdog timeout (60s)');
+  process.exit(2);
+}, 60000);
+
+main()
+  .then(() => {
+    clearTimeout(watchdog);
+    process.exit(0);
+  })
+  .catch((e) => {
+    clearTimeout(watchdog);
+    console.error('FAIL:', e.message);
+    if (e.stack) console.error(e.stack);
+    process.exit(1);
+  });

--- a/tools/mcp-conformance/test/end-to-end-story.js
+++ b/tools/mcp-conformance/test/end-to-end-story.js
@@ -1,0 +1,234 @@
+// End-to-end MCP-client conformance test for tools/story-mcp.
+//
+// Unlike tools/story-mcp/test/{stdio-roundtrip,live-server}.js (which
+// hand-roll JSON-RPC on stdin/stdout), this harness drives the JVM
+// story-mcp server through the official @modelcontextprotocol/sdk
+// `Client`. The same library a real MCP-aware consumer (Claude Code,
+// Continue, …) would use. Catches protocol-mismatch bugs the
+// server-side tests cannot:
+//
+//   - response-envelope drift (CallToolResultSchema rejection)
+//   - initialize-result drift (InitializeResultSchema rejection)
+//   - tool-descriptor-shape drift (ListToolsResultSchema rejection)
+//   - structuredContent shape drift (every assertion below routes
+//     through the SDK's own parse step before user code sees it)
+//
+// Workflow (canonical write-loop with --allow-writes enabled):
+//
+//   1. connect (initialize + notifications/initialized via SDK)
+//   2. tools/list — confirm 17 tools advertised (mirrors live-server.js)
+//   3. register-variant — write a fixture variant
+//   4. run-variant — exercise lifecycle, assert :passing?=true
+//   5. read-failures — zero failures expected
+//   6. unregister-variant — symmetric teardown
+//   7. clean disconnect
+//
+// Run with: `node test/end-to-end-story.js` from this directory. Exits
+// 0 on success. Source: rf2-cum40.
+
+const path = require('node:path');
+const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
+const { StdioClientTransport } = require('@modelcontextprotocol/sdk/client/stdio.js');
+
+const STORY_MCP_CWD = path.resolve(__dirname, '..', '..', 'story-mcp');
+const CLOJURE = process.env.STORY_MCP_CMD || 'clojure';
+
+// Per-server tool catalogue. Same set as tools/story-mcp/test/stdio-roundtrip.js
+// — pin exact so accidental renames / additions / deletions surface here.
+const EXPECTED_TOOLS = [
+  'get-story',
+  'get-story-instructions',
+  'get-variant',
+  'list-assertions',
+  'list-modes',
+  'list-stories',
+  'list-substrates',
+  'list-tags',
+  'preview-variant',
+  'read-failures',
+  'record-as-variant',
+  'register-variant',
+  'run-a11y',
+  'run-variant',
+  'snapshot-identity',
+  'unregister-variant',
+  'variant->edn',
+];
+
+// Fixture variant — namespaced under `story.mcp-conformance` so it
+// won't collide with anything the canonical-vocabulary install
+// registers, and distinct from the live-server.js fixture so the two
+// test scripts could in principle run against the same JVM.
+const FIXTURE_VARIANT = 'story.mcp-conformance/probe.primary';
+
+async function main() {
+  const env = { ...process.env };
+
+  const transport = new StdioClientTransport({
+    command: CLOJURE,
+    args: ['-M', '-m', 're-frame.story-mcp.server', '--allow-writes'],
+    cwd: STORY_MCP_CWD,
+    env,
+    stderr: 'pipe',
+  });
+
+  const client = new Client(
+    { name: 'mcp-conformance-story', version: '0.1.0' },
+    { capabilities: {} },
+  );
+
+  transport.stderr?.on('data', (d) => process.stderr.write('[server] ' + d.toString()));
+
+  // 1. Connect. Initialize handshake runs through SDK.
+  await client.connect(transport);
+  const serverInfo = client.getServerVersion();
+  if (!serverInfo) throw new Error('connect succeeded but getServerVersion() is empty');
+  console.log('OK   connect ->', serverInfo);
+
+  try {
+    // 2. tools/list — confirm catalogue.
+    const listed = await client.listTools();
+    const names = listed.tools.map((t) => t.name).sort();
+    if (JSON.stringify(names) !== JSON.stringify(EXPECTED_TOOLS)) {
+      throw new Error(
+        'tools/list catalogue mismatch:\n  expected ' +
+          JSON.stringify(EXPECTED_TOOLS) +
+          '\n  got      ' +
+          JSON.stringify(names),
+      );
+    }
+    console.log('OK   tools/list -> ' + names.length + ' tools advertised');
+
+    for (const t of listed.tools) {
+      if (!t.inputSchema || typeof t.inputSchema !== 'object') {
+        throw new Error('tool ' + t.name + ' has no inputSchema');
+      }
+    }
+    console.log('OK   every tool descriptor carries an inputSchema');
+
+    // 3. register-variant — body as an EDN string so JSON's lack of
+    // keyword support doesn't dilute the assertion (same approach as
+    // live-server.js).
+    const variantBodyEdn =
+      '{:doc "MCP-conformance harness probe variant."' +
+      ' :args {:label "OK"}' +
+      ' :tags #{:dev}}';
+    const regResp = await client.callTool({
+      name: 'register-variant',
+      arguments: {
+        'variant-id': FIXTURE_VARIANT,
+        body: variantBodyEdn,
+      },
+    });
+    if (regResp.isError) {
+      throw new Error('register-variant failed: ' + JSON.stringify(regResp));
+    }
+    const regStruct = regResp.structuredContent || {};
+    if (regStruct.registered !== true && regStruct['registered?'] !== true) {
+      throw new Error(
+        'register-variant did not report registered=true: ' + JSON.stringify(regResp),
+      );
+    }
+    console.log('OK   register-variant -> ' + FIXTURE_VARIANT + ' registered');
+
+    // 4. run-variant — exercise lifecycle; vacuous pass since :play
+    // is empty.
+    const runResp = await client.callTool({
+      name: 'run-variant',
+      arguments: { 'variant-id': FIXTURE_VARIANT },
+    });
+    if (runResp.isError) {
+      throw new Error('run-variant failed: ' + JSON.stringify(runResp));
+    }
+    const runStruct = runResp.structuredContent || {};
+    if (!Array.isArray(runStruct.assertions)) {
+      throw new Error('run-variant :assertions not an array: ' + JSON.stringify(runResp));
+    }
+    if (runStruct['passing?'] !== true) {
+      throw new Error(
+        'run-variant :passing? expected true (vacuous pass); got: ' + JSON.stringify(runResp),
+      );
+    }
+    console.log('OK   run-variant -> :passing?=true, assertions=[] (vacuous pass)');
+
+    // 5. read-failures — zero failures expected after a vacuous-pass
+    // run.
+    const failResp = await client.callTool({
+      name: 'read-failures',
+      arguments: { 'variant-id': FIXTURE_VARIANT },
+    });
+    if (failResp.isError) {
+      throw new Error('read-failures failed: ' + JSON.stringify(failResp));
+    }
+    const failStruct = failResp.structuredContent || {};
+    if (failStruct.total !== 0) {
+      throw new Error('read-failures :total expected 0; got: ' + JSON.stringify(failResp));
+    }
+    if (!Array.isArray(failStruct.failures) || failStruct.failures.length !== 0) {
+      throw new Error(
+        'read-failures :failures expected empty vector; got: ' + JSON.stringify(failResp),
+      );
+    }
+    console.log('OK   read-failures -> total=0, failures=[]');
+
+    // 6. unregister-variant — symmetric teardown.
+    const unregResp = await client.callTool({
+      name: 'unregister-variant',
+      arguments: { 'variant-id': FIXTURE_VARIANT },
+    });
+    if (unregResp.isError) {
+      throw new Error('unregister-variant failed: ' + JSON.stringify(unregResp));
+    }
+    const unregStruct = unregResp.structuredContent || {};
+    if (unregStruct['unregistered?'] !== true) {
+      throw new Error(
+        'unregister-variant :unregistered? expected true: ' + JSON.stringify(unregResp),
+      );
+    }
+    // Read-back must now fail.
+    const verify = await client.callTool({
+      name: 'get-variant',
+      arguments: { 'variant-id': FIXTURE_VARIANT },
+    });
+    const verifyText = verify.content?.[0]?.text || '';
+    if (!verify.isError || !/not found/i.test(verifyText)) {
+      throw new Error(
+        'after unregister, get-variant should yield not-found; got: ' + JSON.stringify(verify),
+      );
+    }
+    console.log('OK   unregister-variant -> teardown verified by subsequent get-variant -> not-found');
+
+    // 7. Clean disconnect.
+    await client.close();
+    console.log('OK   client.close() -> transport torn down cleanly');
+    console.log('\nSTORY-MCP MCP-CLIENT CONFORMANCE GREEN');
+  } catch (err) {
+    try {
+      await client.close();
+    } catch (_e) {
+      // best-effort
+    }
+    throw err;
+  }
+}
+
+// JVM boot is slow on a cold CI worker (~10-30s); the whole register →
+// run → read → unregister loop adds a few more seconds. 90s is
+// comfortably above that without leaving a hung process if something
+// stalls.
+const watchdog = setTimeout(() => {
+  console.error('FAIL: watchdog timeout (90s)');
+  process.exit(2);
+}, 90000);
+
+main()
+  .then(() => {
+    clearTimeout(watchdog);
+    process.exit(0);
+  })
+  .catch((e) => {
+    clearTimeout(watchdog);
+    console.error('FAIL:', e.message);
+    if (e.stack) console.error(e.stack);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

Closes the gap surfaced by the MCP-testing audit: every existing test for `pair2-mcp` / `story-mcp` is **server-side** (hand-rolled JSON-RPC on stdin/stdout). None drives a server via a real **MCP-client** — so protocol-mismatch bugs visible only to the official `@modelcontextprotocol/sdk` `Client` (the library a real MCP-aware consumer like Claude Code / Continue uses) ship unobserved.

New artefact `tools/mcp-conformance/` adds three scripts that drive each server through the SDK's `StdioClientTransport` + `Client.connect()` + `listTools()` / `callTool()` surface. The SDK validates every response against the spec's Zod schemas (`InitializeResultSchema`, `ListToolsResultSchema`, `CallToolResultSchema`), so server-side drift that fools a hand-rolled probe still fails the SDK's parse step.

## Artefact location

`tools/mcp-conformance/`
- `package.json` — sole dep is `@modelcontextprotocol/sdk@^1.29.0`
- `README.md` — rationale, run instructions, per-test scope
- `test/end-to-end-pair2.js` — pair2-mcp conformance (degraded mode, no nREPL needed)
- `test/end-to-end-story.js` — story-mcp conformance (full register → run → read → unregister loop with `--allow-writes`)
- `test/end-to-end-causa.js` — `SKIP` placeholder; causa-mcp is spec-only today. File header documents the expected shape for when the impl lands.

## CI

Three new jobs added to `.github/workflows/test.yml`, parallel to the existing `node-test-tools-{pair2,story}-mcp` jobs:

- `mcp-conformance-pair2` — installs pair2-mcp deps, compiles the Node bundle via `shadow-cljs compile server`, then runs the harness
- `mcp-conformance-story` — installs deps, launches `clojure -M -m re-frame.story-mcp.server --allow-writes`
- `mcp-conformance-causa` — runs the SKIPPED no-op so the placeholder doesn't go stale

## Sample handshake output

**pair2-mcp:**
```
OK   connect -> { name: 're-frame-pair2-mcp', version: '0.1.0' }
OK   tools/list -> 10 tools advertised: discover-app, dispatch, eval-cljs, get-path, snapshot, subscribe, tail-build, trace-window, unsubscribe, watch-epochs
OK   every tool descriptor carries an inputSchema
OK   tools/call dispatch (degraded) -> isError + nrepl-port-not-found
OK   tools/call watch-epochs (degraded) -> isError + nrepl-port-not-found
OK   tools/call snapshot (degraded) -> isError + nrepl-port-not-found
OK   tools/call subscribe (degraded) -> isError + nrepl-port-not-found
OK   client.close() -> transport torn down cleanly

PAIR2-MCP MCP-CLIENT CONFORMANCE GREEN
```

**story-mcp:**
```
OK   connect -> { name: 're-frame2-story-mcp', version: 'dev' }
OK   tools/list -> 17 tools advertised
OK   every tool descriptor carries an inputSchema
OK   register-variant -> story.mcp-conformance/probe.primary registered
OK   run-variant -> :passing?=true, assertions=[] (vacuous pass)
OK   read-failures -> total=0, failures=[]
OK   unregister-variant -> teardown verified by subsequent get-variant -> not-found
OK   client.close() -> transport torn down cleanly

STORY-MCP MCP-CLIENT CONFORMANCE GREEN
```

## Test plan

- [x] `node test/end-to-end-pair2.js` — GREEN locally against `origin/main` HEAD
- [x] `node test/end-to-end-story.js` — GREEN locally against `origin/main` HEAD
- [x] `node test/end-to-end-causa.js` — exits 0 with `SKIP` marker
- [x] Upstream `tools/pair2-mcp/test/stdio-roundtrip.js` still passes — no regression introduced
- [ ] CI runs `mcp-conformance-pair2` / `mcp-conformance-story` / `mcp-conformance-causa` jobs on this PR