### PR TITLE
spec: introduce 'managed external effect' as unifying frame (rf2-mav5a)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
     - Companion:
       - Principles: spec/Principles.md
       - Conventions: spec/Conventions.md
+      - "Managed external effects": spec/Managed-Effects.md
       - Migration: spec/MIGRATION.md
       - Construction prompts: spec/Construction-Prompts.md
       - "CP-5 — Machine guide": spec/CP-5-MachineGuide.md

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -5,6 +5,8 @@
 > **Why this Spec exists:** state machines and actors are in the pattern because **constrained execution models are easier to reason about than Turing-complete control flow.** A finite state machine has an enumerable state space and a discrete transition relation; an actor system bounds concurrency to message-passing across well-defined boundaries with run-to-completion semantics. This is disproportionately valuable for AI use — an AI can fully simulate a finite machine; it cannot fully simulate a free-form imperative program. The cost is some expressiveness; the benefit is an execution model that survives mechanical reasoning.
 >
 > For where Levels 1–4 sit in relation to the rest of the runtime (registrar, frame container, sub-cache, substrate adapter, trace bus), see [Runtime-Architecture](Runtime-Architecture.md).
+>
+> `:invoke` and `:invoke-all` (state-machine actors) are **managed external effects** — per [Managed-Effects](Managed-Effects.md), the surface MUST satisfy the eight properties (effect-as-data, framework-owned actor lifecycle, structured failure taxonomy under `:rf.machine/*`, trace-bus observability, `:sensitive?` / `:large?` composition, built-in retry / abort / teardown via `:after` / `:always` / state-exit, in-flight actor registry, per-frame interceptor scoping).
 
 ## Abstract
 

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -1,6 +1,8 @@
 # Spec 011 — Server-Side Rendering & Hydration
 
 > SSR is a core goal; see [000-Vision.md](000-Vision.md).
+>
+> The `:rf.server/*` per-request fxs are **managed external effects** — per [Managed-Effects](Managed-Effects.md), the surface MUST satisfy the eight properties (effect-as-data, framework-owned per-request lifecycle, structured failure taxonomy under `:rf.ssr/*`, trace-bus observability, `:sensitive?` / `:large?` composition, built-in retry / abort / teardown semantics, in-flight per-request registry, per-frame interceptor scoping).
 
 ## Abstract
 

--- a/spec/013-Flows.md
+++ b/spec/013-Flows.md
@@ -5,6 +5,8 @@
 > **The minimum claim:** flows are *registered, runtime-toggleable computed-state declarations that materialise their output into `app-db`*. They are the v2 incarnation of v1's `on-changes` interceptor — same compute-on-input-change semantics — but registered in the runtime (not on individual events) and toggleable via two reserved fx-ids.
 >
 > **Restraint.** Flows are a **convenience** for a small number of small use-cases. They are not a replacement for subscriptions, not a new dataflow paradigm, not a substitute for state machines, and not the default for derived state. The architecture's main load-bearing pieces are events, subs, machines, and effects; flows sit alongside them as a focused tool for a narrow set of problems. **When in doubt, use a subscription** — flows pay an `app-db` write per recomputation and add a small piece of registered runtime; that cost is only worthwhile when the [reasons in §When (and when not) to use a flow](#when-and-when-not-to-use-a-flow) below apply.
+>
+> `:rf.flow/*` is the **internal-effect cousin** of the managed external effects — per [Managed-Effects](Managed-Effects.md), the surface MUST satisfy the eight properties applied to derived computation (effect-as-data via the registration map, framework-owned scheduler, structured failure taxonomy under `:rf.flow/*`, trace-bus observability, `:sensitive?` / `:large?` composition on flow outputs, runtime-toggleable retry / abort / teardown via `:rf.fx/reg-flow` / `:rf.fx/clear-flow`, in-flight flow registry, per-frame scoping).
 
 ## Abstract
 

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -5,6 +5,8 @@
 > **The minimum claim:** *if* an implementation ships HTTP-request infrastructure, it ships `:rf.http/managed` per this spec — a first-class HTTP request fx that bakes in decoding, success/failure normalisation, retry-with-backoff, abort, schema-driven decode, and reply-to-origin dispatch. The fx is rich enough that apps overwhelmingly want it; the contract being uniform is what lets pair tools, `:fx-overrides`, retry policy, error projection, and frame-aware reply addressing compose across implementations without per-app reinvention.
 >
 > **Code samples are in ClojureScript** (the CLJS reference). The contract is host-agnostic; the spec calls out per-host divergences (CLJS Fetch / JVM `java.net.http.HttpClient`) explicitly per row.
+>
+> `:rf.http/managed` is a **managed external effect** — per [Managed-Effects](Managed-Effects.md), the surface MUST satisfy the eight properties (effect-as-data, framework-owned lifecycle, structured failure taxonomy under `:rf.http/*`, trace-bus observability, `:sensitive?` / `:large?` composition, built-in retry / abort / teardown, in-flight registry, per-frame interceptor scoping).
 
 ## Abstract
 

--- a/spec/Managed-Effects.md
+++ b/spec/Managed-Effects.md
@@ -1,0 +1,119 @@
+# Managed External Effects
+
+> **Type:** Reference
+> The unifying conceptual frame for every framework-owned, lifecycle-aware effect surface in re-frame2 — HTTP requests, WebSocket connections, state-machine actors, SSR per-request fxs, and managed flows (the internal-effect cousin). Names the eight properties every conformant managed-effect surface inherits, so new surfaces (managed timers, managed background jobs, managed IndexedDB transactions) can be evaluated against a single checklist instead of re-deriving the shape each time.
+
+## Why this doc exists
+
+A pattern is visible in re-frame2 across five existing capability surfaces: [`:rf.http/managed`](014-HTTPRequests.md), [`:rf.ws/*`](Pattern-WebSocket.md), state-machine [`:invoke` / `:invoke-all`](005-StateMachines.md), [`:rf.server/*`](011-SSR.md), and [`:rf.flow/*`](013-Flows.md). Each Spec describes its own surface in detail; this doc names the **shared shape** so the architectural concept stops living implicitly in five places and starts being citeable as a single concept with a single anchor.
+
+**A managed external effect is an effect whose entire interaction lifecycle — issuance, observability, failure classification, retry, abort, teardown, and reply addressing — is owned by the framework, not by the calling event handler.** The handler returns *data* describing what it wants; the framework owns *how* the interaction unfolds across time.
+
+This is the architectural contract that lets pair tools, `:fx-overrides`, error projectors, and the trace bus compose uniformly across surfaces. New surfaces inherit the contract by adopting the eight properties below; the AI-Audit grades surfaces against this checklist.
+
+## The eight properties
+
+Every managed-effect surface MUST satisfy these eight properties. A surface that satisfies fewer is an "ad-hoc fx" — useful, but outside the contract pair tools and the conformance corpus assume.
+
+### 1. Effect-as-data, not callbacks
+
+The handler returns a plain-data description of the interaction in its effect-map, never a function. The interaction's shape is a serialisable map under a registered fx-id; the framework walks the map and dispatches the work.
+
+```clojure
+;; Effect-as-data — what every managed-effect call site looks like.
+{:fx [[:rf.http/managed   {:request {...} :on-success ... :retry {...}}]
+      [:rf.machine/spawn  {:id ... :machine ... :data {...}}]
+      [:rf.server/set-cookie {:name "session" :value ...}]]}
+```
+
+This property is the architectural foundation. Without it none of the remaining seven mean anything — callbacks are opaque to overrides, to time-travel, to elision, and to pair-tools. See [Pattern-AsyncEffect §Why this shape](Pattern-AsyncEffect.md#why-this-shape) for the underlying rationale; managed effects specialise that pattern with a fixed contract.
+
+### 2. Framework-owned execution lifecycle
+
+The framework — not the calling event handler — owns issuance, intermediate state, and teardown. The handler does not call `.then`, does not register completion listeners, does not unregister, does not free resources. The runtime tracks the interaction from dispatch to terminal state (success / failure / abort / teardown) and emits trace events at each transition.
+
+### 3. Structured failure taxonomy under `:rf.<surface>/*`
+
+Failures are classified into a closed, enumerable taxonomy under a single reserved namespace per surface (per [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned)). Examples in re-frame2 today:
+
+| Surface | Failure namespace | Spec |
+|---|---|---|
+| HTTP requests | `:rf.http/*` (eight categories: `:rf.http/transport`, `:rf.http/http-4xx`, `:rf.http/http-5xx`, `:rf.http/decode`, ...) | [014 §Failure taxonomy](014-HTTPRequests.md) |
+| WebSocket connections | `:rf.ws/*` (`:rf.ws/transport`, `:rf.ws/auth`, `:rf.ws/stale-socket`, ...) | [Pattern-WebSocket](Pattern-WebSocket.md) |
+| State-machine actors | `:rf.machine/*` (`:rf.machine/invoke-failed`, `:rf.machine/snapshot-version-mismatch`, ...) | [005 §Error contract](005-StateMachines.md) |
+| SSR per-request | `:rf.ssr/*` (`:rf.ssr/hydration-mismatch`, `:rf.ssr/render-failed`, ...) | [011 §Error contract](011-SSR.md) |
+| Managed flows | `:rf.flow/*` (`:rf.flow/cycle-detected`, `:rf.flow/output-throw`, ...) | [013 §Errors](013-Flows.md) |
+
+Every failure is a structured trace event with `:operation`, `:tags`, and `:recovery` per [009 §Error contract](009-Instrumentation.md#error-contract). No surface invents its own error shape.
+
+### 4. Observable via the trace bus
+
+Every issuance, intermediate transition, retry attempt, and terminal outcome emits a trace event on the single global trace bus (per [009 §The trace event model](009-Instrumentation.md#the-trace-event-model)). Pair tools, 10x, and off-box monitors consume the same stream — no surface-specific observation API.
+
+### 5. `:sensitive?` + `:large?` composition
+
+Every wire-bearing slot in a managed-effect trace passes through [`rf/elide-wire-value`](API.md#elide-wire-value-the-wire-boundary-walker), the single shared walker that composes privacy elision (`:sensitive?` per [009 §Privacy](009-Instrumentation.md#privacy--sensitive-data-in-traces)) and size elision (`:large?` per [009 §Size elision](009-Instrumentation.md#size-elision-in-traces)). Surfaces MUST NOT roll their own wire-boundary elision; the walker is the single point of truth. A slot carrying both `:sensitive? true` and `:large? true` redacts on sensitivity — the `:rf.size/large-elided` marker itself would leak `:path` / `:bytes` / `:digest` and is suppressed.
+
+### 6. Built-in retry / abort / teardown semantics
+
+Each surface ships first-class **retry-with-backoff**, **abort**, and **teardown** semantics as data on the args map, not as caller code. The vocabularies differ (HTTP has `:retry {:on ... :max-attempts ... :backoff {...}}`; machines have `:after` + `:always` guards; WebSocket reconnect lives on the `:reconnecting` state), but the contract is identical: the handler declares the policy; the framework executes it.
+
+### 7. In-flight registry
+
+Each surface maintains a framework-private registry of currently-in-flight interactions, keyed by an addressable id (HTTP request-id, machine instance-id, socket-id, flow-id, SSR request-id). The registry is queryable via the public registrar API (per [001 §The query API](001-Registration.md#the-query-api)); pair tools list active interactions, and the runtime emits a structured warning if a frame is destroyed while interactions are still in-flight.
+
+### 8. Per-frame interceptors / scoping
+
+Managed effects MUST honour the dispatching frame's `:fx-overrides`, `:interceptor-overrides`, and `:platforms` filters (per [002 §Per-frame and per-call overrides](002-Frames.md#per-frame-and-per-call-overrides) and [011 §`:platforms`](011-SSR.md)). Tests stub `:rf.http/managed` to a canned reply via `:fx-overrides`; SSR builds short-circuit `:rf.machine/spawn` for actors that aren't `:platforms #{:client}`; stories install per-story `:interceptor-overrides`. The override seam is id-based — overrides cite the registered fx-id, not a function value, so they round-trip through the wire.
+
+## Instances today
+
+The five surfaces in the v1 corpus that satisfy the eight properties. Each Spec owns its own contract surface in detail; this section is informational — the spec text below points back to each canonical home.
+
+### `:rf.http/managed` — HTTP requests ([Spec 014](014-HTTPRequests.md))
+
+Single-request / single-reply HTTP. Args map shape: `:request`, `:decode`, `:accept`, `:on-success`, `:on-failure`, `:retry`. Eight-category failure taxonomy under `:rf.http/*`. Frame-aware reply addressing via co-located request-and-reply handlers (the `(:rf/reply msg)` branch). Specialises [Pattern-AsyncEffect](Pattern-AsyncEffect.md); pins [Pattern-RemoteData](Pattern-RemoteData.md)'s lifecycle slice.
+
+### `:rf.ws/*` — WebSocket / SSE / WebRTC connections ([Pattern-WebSocket](Pattern-WebSocket.md))
+
+Long-lived connection lifecycle as a state machine that owns the socket actor. Connection states: `:disconnected` / `:active{:connecting, :authenticating, :connected}` / `:reconnecting` / `:failed`. Subscription state and queued sends survive reconnects via the machine's `:data`. The connection epoch (the socket-actor's gensym'd id) gates stale replies — events from a replaced socket fail the check and surface as `:rf.ws/stale-socket`.
+
+### `:invoke` / `:invoke-all` — state-machine actors ([Spec 005](005-StateMachines.md))
+
+Declarative actor spawn anchored on a state node. The framework owns the actor's lifetime: spawned on entry, destroyed on exit (or when an ancestor's `:invoke` boundary closes). `:invoke-all` parallel-fans children with a join condition. Reply addressing uses the carry-the-id-back-to-the-parent idiom; stale replies (from an actor whose owning state has already exited) are dropped.
+
+### `:rf.server/*` — SSR per-request fxs ([Spec 011](011-SSR.md))
+
+Six server-side response-shape fxs (`set-status`, `set-header`, `append-header`, `set-cookie`, `delete-cookie`, `redirect`) plus the `reg-error-projector` registry kind and the per-request HTTP response accumulator. The "interaction" here is the HTTP response itself; the framework owns building it across the per-request frame's lifetime, then emitting it as the response.
+
+### `:rf.flow/*` — managed derived computation ([Spec 013](013-Flows.md))
+
+The internal-effect cousin. The "external system" is the framework's own scheduler — flows are registered rules that compute on input change and materialise their output into `app-db`. They satisfy the eight properties applied to a derived-state surface: effect-as-data (the registration map), framework-owned execution (the scheduler runs them after each event drain in topological order), failure taxonomy (`:rf.flow/cycle-detected`, `:rf.flow/output-throw`), trace-bus observability (`:rf.flow/evaluated` per evaluation), elision composition (`:sensitive?` on flow outputs), retry/abort/teardown (runtime-toggleable via `:rf.fx/reg-flow` / `:rf.fx/clear-flow`), in-flight registry (queryable via the registrar), per-frame scoping (flows are frame-local — see [013 §Frame-scoping](013-Flows.md#frame-scoping)).
+
+## How new managed-effect surfaces inherit the contract
+
+A future surface — managed timers, managed IndexedDB transactions, managed background jobs, managed WebAuthn flows — becomes a "managed effect" by adopting all eight properties above. Concretely, a new surface SHOULD:
+
+1. Register a single fx-id under a new reserved sub-namespace `:rf.<surface>/*` ([Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned) MUST be amended to add the namespace).
+2. Define a closed args-map shape with a registered schema in [Spec-Schemas](Spec-Schemas.md).
+3. Enumerate the failure taxonomy under `:rf.<surface>/*` in [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue).
+4. Emit trace events at issuance, intermediate transitions (if any), retries, and terminal outcomes via the trace bus.
+5. Route every wire-bearing slot through `rf/elide-wire-value` at the trace-emit site.
+6. Ship retry / abort / teardown as data on the args map (not as caller code).
+7. Maintain a framework-private in-flight registry keyed by an addressable id; expose via the registrar query API.
+8. Honour the dispatching frame's `:fx-overrides`, `:interceptor-overrides`, and `:platforms` filters.
+
+A surface that satisfies fewer than eight remains useful but does **not** carry the "managed external effect" label; pair tools, the conformance corpus, and the AI-Audit treat it as out-of-contract.
+
+## What this concept replaces
+
+Before naming this concept, each downstream Spec independently described its own slice of the shape. The risk was drift — two Specs answering "how do we elide a sensitive request body?" with subtly different mechanisms; a new Spec inventing a new failure-vocabulary scheme. Naming the concept makes the contract a **single point of accretion**: future surfaces are graded against the same eight properties, and the shared infrastructure (the trace bus, `rf/elide-wire-value`, the registrar's in-flight queries, the `:fx-overrides` seam) is the single point of implementation for all of them.
+
+## Cross-references
+
+- [Pattern-AsyncEffect](Pattern-AsyncEffect.md) — the underlying generic shape; managed effects specialise it with a fixed contract.
+- [009 §Error contract](009-Instrumentation.md#error-contract) — the structured-error shape every managed-effect failure conforms to.
+- [009 §Privacy](009-Instrumentation.md#privacy--sensitive-data-in-traces) and [§Size elision](009-Instrumentation.md#size-elision-in-traces) — the single shared `rf/elide-wire-value` walker.
+- [API §`rf/elide-wire-value`](API.md#elide-wire-value-the-wire-boundary-walker) — the wire-boundary walker public surface.
+- [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned) — the `:rf.<surface>/*` namespace policy new surfaces extend.
+- [Ownership](Ownership.md) — the contract-surface → owning-Spec map; consult before naming a new managed-effect surface.

--- a/spec/Pattern-WebSocket.md
+++ b/spec/Pattern-WebSocket.md
@@ -4,6 +4,8 @@
 > Long-lived connection lifecycle — WebSocket / SSE / WebRTC peer — modelled as a state machine that owns the socket. Convention, not Spec.
 
 > **Code samples are in ClojureScript** (the CLJS reference). The pattern itself is host-agnostic.
+>
+> `:rf.ws/*` (WebSocket connections) is a **managed external effect** — per [Managed-Effects](Managed-Effects.md), the surface MUST satisfy the eight properties (effect-as-data, framework-owned socket-actor lifecycle, structured failure taxonomy under `:rf.ws/*`, trace-bus observability, `:sensitive?` / `:large?` composition, built-in retry / abort / teardown via the connection state machine, in-flight socket-actor registry, per-frame interceptor scoping).
 
 ## Role
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -63,6 +63,7 @@ Reference, scaffolding, and audit:
 |---|---|---|
 | [Principles](Principles.md) | Reference | The 9 AI-first discipline principles plus the two foundational essays (the layered constraint, data is code). The yardstick the [AI-Audit](AI-Audit.md) grades Specs against. |
 | [Conventions](Conventions.md) | Convention | Locked runtime conventions: reserved-namespace policy for framework-owned ids, ns-prefix conventions for features, reserved fx-ids and app-db keys. |
+| [Managed external effects](Managed-Effects.md) | Reference | The unifying conceptual frame: eight properties every framework-owned managed-effect surface (`:rf.http/managed`, `:rf.ws/*`, `:invoke` / `:invoke-all`, `:rf.server/*`, `:rf.flow/*`) inherits. New surfaces (managed timers, managed background jobs) are graded against the same checklist. |
 | [Construction Prompts](Construction-Prompts.md) | Construction Prompts | Per-kind AI-scaffolding templates (event, sub, fx, view, machine, feature, route, schema, SSR). Sibling to MIGRATION.md. |
 | [AI Audit](AI-Audit.md) | Audit | Score of every Spec against the AI-first discipline principles; surfaces gaps. |
 | [Runtime-Architecture](Runtime-Architecture.md) | Reference | Bird's-eye view of the runtime — the eight components (registrar, frame container, router, drain loop, `do-fx`, sub-cache, substrate adapter, trace bus) plus the interop layer, with data-flow diagram and per-event lifecycle. Companion to the per-area Specs; redefines nothing. |


### PR DESCRIPTION
## Home chosen

Option **(c)** — NEW `spec/Managed-Effects.md` (Type: Reference, ~120 LoC).

## Rationale

The 'managed external effect' concept is load-bearing enough to deserve its own URL/anchor surface — pair tools, error projectors, the trace bus, `:fx-overrides`, and the AI-Audit all want to cite a single concept-named anchor when they refer to the shared shape across HTTP / WS / machines / SSR / flows. Inlining the concept into 000-Vision.md or Principles.md would either bloat those load-bearing docs or scatter the concept across them. A dedicated doc keeps the downstream specs disjoint and editable, and gives the AI-Audit a single checklist to grade new surfaces against.

## What the new doc says

Names the **eight properties** every conformant managed-effect surface MUST satisfy:

1. Effect-as-data, not callbacks
2. Framework-owned execution lifecycle
3. Structured failure taxonomy under `:rf.<surface>/*`
4. Observable via the trace bus
5. `:sensitive?` + `:large?` composition (single shared `rf/elide-wire-value` walker)
6. Built-in retry / abort / teardown semantics
7. In-flight registry
8. Per-frame interceptors / scoping

Plus a per-instance summary for `:rf.http/managed`, `:rf.ws/*`, `:invoke` / `:invoke-all`, `:rf.server/*`, and `:rf.flow/*` (the internal-effect cousin); a SHOULD checklist for new managed-effect surfaces (managed timers, managed background jobs, managed IndexedDB transactions, managed WebAuthn); and cross-references to Pattern-AsyncEffect, 009 §Error contract, 009 §Privacy / §Size elision, API §`rf/elide-wire-value`, Conventions §Reserved namespaces, and Ownership.

## Downstream cross-links

A single MUST-reference line added near the top of each downstream spec (immediately after the intro/status block, well clear of any section currently being edited by another agent):

- `spec/014-HTTPRequests.md` — `:rf.http/managed` is a managed external effect → eight properties.
- `spec/005-StateMachines.md` — `:invoke` / `:invoke-all` are managed external effects → eight properties.
- `spec/011-SSR.md` — `:rf.server/*` per-request fxs are managed external effects → eight properties. (Inserted at the very top, before rf2-4pcx8's §Server-only reg-cofx for request context edits around line 316.)
- `spec/013-Flows.md` — `:rf.flow/*` is the internal-effect cousin of the managed external effects.
- `spec/Pattern-WebSocket.md` — `:rf.ws/*` is a managed external effect → eight properties.

Plus `mkdocs.yml` Companion nav entry and `spec/README.md` Companion table entry for the new doc.

## MUST count

**9 MUSTs total** introduced: 5 cross-link MUST-reference lines (one per downstream spec) + 4 MUSTs inside the new doc (the eight-properties intro, the namespace-policy rule, the elision-walker requirement, the per-frame override-honour rule).

## Quality gates

- `python scripts/check_doc_slugs.py` — no new broken anchors or targets (the 4 pre-existing failures on `main` are unchanged).
- `python -m mkdocs build` — clean for the new file; the new page builds at `site/spec/Managed-Effects/index.html`. No new warnings introduced.

## Disjointness

Per the dispatch rules: rf2-4pcx8 is in flight on `spec/011-SSR.md` §Server-only reg-cofx for request context (around line 316). This PR's 011 cross-link is at the very top of the file (line 4), so no conflict surface.