### PR TITLE
test(mcp): cross-server wire-vocabulary conformance (rf2-j2z7o)

### DIFF
--- a/tools/mcp-conformance/README.md
+++ b/tools/mcp-conformance/README.md
@@ -4,6 +4,19 @@ End-to-end **MCP-client** conformance harness for the re-frame2 MCP
 servers — `pair2-mcp`, `story-mcp`, and (when its implementation lands)
 `causa-mcp`. Source: rf2-cum40.
 
+This artefact has two surfaces:
+
+1. **`test/end-to-end-*.js`** — Node-side end-to-end conformance.
+   Drives each server through the official `@modelcontextprotocol/sdk`
+   client to validate JSON-RPC handshake + tool catalogue + one
+   canonical workflow per server. Source: rf2-cum40.
+2. **`wire-vocab/`** — JVM-side cross-server wire-vocabulary
+   conformance. Pins the canonical Malli schema for every
+   reserved `:rf.mcp/*` / `:rf.size/large-elided` / `:rf.elision/at`
+   marker and asserts that fixtures + source text from every
+   emitting server conform. Source: rf2-j2z7o. See
+   [`wire-vocab/README.md`](wire-vocab/README.md).
+
 ## What this is
 
 Every existing test surface for these servers is **server-side**:

--- a/tools/mcp-conformance/wire-vocab/README.md
+++ b/tools/mcp-conformance/wire-vocab/README.md
@@ -1,0 +1,105 @@
+# tools/mcp-conformance/wire-vocab
+
+**Cross-MCP wire-vocabulary conformance test.** Source: rf2-j2z7o.
+
+## What this is
+
+The three MCP servers under `tools/` — `pair2-mcp`, `story-mcp`, and
+`causa-mcp` (spec-only today) — share a reserved cross-server **wire
+vocabulary**: namespaced map keys that an agent recognises identically
+across every server it talks to.
+
+```
+:rf.mcp/overflow       — token-budget overflow marker
+:rf.mcp/summary        — tree-summary lazy-mode marker
+:rf.mcp/dedup-table    — structural-dedup wrapper
+:rf.mcp/diff-from      — diff-encoded :db-after marker
+:rf.size/large-elided  — size-elision wire marker
+:rf.elision/at         — size-elision fetch-handle tag
+```
+
+Without conformance enforcement, two servers could each ship the
+"overflow" concept with slightly different shapes (`:cap-tokens` vs
+`:cap_tokens`; `:hint` as a string vs as a keyword vs absent) and an
+agent host would have to special-case per server. The cross-server
+value proposition collapses if every server invents its own dialect.
+
+This test is the conformance gate. It asserts:
+
+1. **One canonical Malli schema per marker.** The schemas live in
+   `wire_vocab_test.clj`, derived from
+   [`spec/Spec-Schemas.md` §`:rf/elision-marker`](../../../spec/Spec-Schemas.md),
+   [`tools/causa-mcp/spec/Principles.md` §"5 mechanisms"](../../causa-mcp/spec/Principles.md),
+   and [`tools/pair2-mcp/src/.../tools.cljs`](../../pair2-mcp/src/re_frame_pair2_mcp/tools.cljs)
+   (pair2-mcp's `overflow-payload`, `tree-summary`, `dedup-value`,
+   `diff-encode-db-after`).
+2. **Per-server fixtures all conform.** Each marker has a fixture
+   representing each server's actual / spec'd emission shape. They
+   MUST validate against the same schema.
+3. **Source-text vocabulary pin.** A grep against each server's source
+   (`pair2-mcp/src/`) and spec (`causa-mcp/spec/`) asserts the
+   canonical literal appears, and asserts that no near-miss spelling
+   (snake_case, pluralised, namespace-with-underscores) appears.
+4. **story-mcp absence tripwire.** story-mcp does NOT currently emit
+   any of the cross-MCP markers — it uses its own `:rf.story/*` /
+   `:rf.assert/*` / `:rf.error/*` vocabularies. A test asserts that
+   absence so that the day story-mcp adopts a marker, the test fails
+   loud and forces the reviewer to register a fixture and a source
+   file (rather than diverge silently).
+
+## Files
+
+- `deps.edn` — pure JVM Clojure, one dep: `metosin/malli`.
+- `test/re_frame/mcp_conformance/wire_vocab_test.clj` — the test.
+
+## How to run
+
+From this directory:
+
+```bash
+clojure -M:test
+```
+
+The test:
+
+- Resolves the repo root from `*file*` so it works from any CWD.
+- Reads each server's source/spec via `slurp`.
+- Validates each fixture against its canonical schema via
+  `malli.core/validate`.
+- Greps for canonical and near-miss spellings.
+
+Total run time on a cold JVM: ~3-5 seconds.
+
+## Why JVM (not Node SDK)
+
+The sibling `tools/mcp-conformance/test/end-to-end-*.js` files drive
+each server through the official MCP SDK client (handshake +
+`tools/list` + `tools/call` against a live process). That's *protocol*
+conformance.
+
+This test is *vocabulary* conformance — the shapes of EDN values a
+server emits as response payloads. It does NOT need a live server: the
+schemas are normative, the fixtures are authored from each server's
+spec/source, and the grep step pins those authored fixtures to the
+actual source/spec text. Two complementary gates; one wire.
+
+## causa-mcp impl gap
+
+causa-mcp's implementation has not landed yet (its `tools/causa-mcp/`
+tree contains `README.md` + `spec/` but no `src/`). The fixtures and
+the spec-grep step against `tools/causa-mcp/spec/Principles.md` cover
+the vocabulary today. When the impl lands, a follow-up bead extends
+this test to:
+
+- Grep `tools/causa-mcp/src/` for the canonical literals.
+- Add live-emission fixtures if their actual emitted shape diverges
+  from the spec snippets.
+
+## When this test fails
+
+| Failing assertion | Likely cause | Fix |
+|---|---|---|
+| Fixture doesn't validate against schema | Server (or spec) changed the marker body shape | Update both the schema AND the relevant fixture; the divergence is the bug |
+| Literal missing from server source | Marker was renamed in one server | Pick the canonical form, rename the other server, update the schema |
+| Near-miss variant present | Vocabulary drift (snake_case spelling crept in) | Rename back to the canonical form |
+| story-mcp absence tripwire fires | story-mcp now emits a cross-MCP marker | Add story-mcp to the marker's `:servers` set, add a fixture, extend `server-source-files` |

--- a/tools/mcp-conformance/wire-vocab/deps.edn
+++ b/tools/mcp-conformance/wire-vocab/deps.edn
@@ -1,0 +1,40 @@
+;; tools/mcp-conformance/wire-vocab — cross-MCP wire-vocabulary
+;; conformance test (rf2-j2z7o).
+;;
+;; A pure-JVM Clojure test that pins the **cross-server wire-marker
+;; vocabulary** shared by pair2-mcp, story-mcp, and causa-mcp:
+;;
+;;   :rf.mcp/overflow      — token-budget overflow (mechanism 1)
+;;   :rf.mcp/summary       — tree-summary lazy mode (mechanism 4)
+;;   :rf.mcp/dedup-table   — structural dedup (mechanism 5)
+;;   :rf.mcp/diff-from     — diff-encoded epochs
+;;   :rf.size/large-elided — size-elision wire marker
+;;   :rf.elision/at        — size-elision fetch handle
+;;
+;; The test asserts a single canonical schema per marker, validates
+;; fixtures representing each server's observed emission shape against
+;; the canonical schema, and grep-pins the source/spec files so a
+;; per-server vocabulary drift trips this gate. See README.md.
+;;
+;; Why a separate JVM artefact inside tools/mcp-conformance/?
+;; The sibling end-to-end-*.js tests drive each server through the MCP
+;; SDK client — they are Node-side. This wire-vocab test is pure data:
+;; a Malli-style schema validated against authored fixtures, plus a
+;; grep against source files. JVM Clojure is the cheaper substrate for
+;; that shape (no SDK install, no server boot, ~100ms test run).
+;;
+;; Bundle isolation: the artefact is test-only and never on a consumer's
+;; runtime classpath.
+{:paths []
+
+ :deps  {org.clojure/clojure {:mvn/version "1.12.0"}
+         ;; Malli for schema validation. Already on the implementation's
+         ;; classpath (used by tools/story-mcp); pinning the same version
+         ;; here so the schema syntax matches.
+         metosin/malli       {:mvn/version "0.16.4"}}
+
+ :aliases
+ {:test {:extra-paths ["test" "fixtures"]
+         :extra-deps  {io.github.cognitect-labs/test-runner
+                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+         :main-opts   ["-m" "cognitect.test-runner"]}}}

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -1,0 +1,524 @@
+(ns re-frame.mcp-conformance.wire-vocab-test
+  "Cross-MCP wire-vocabulary conformance (rf2-j2z7o).
+
+  Three MCP servers ship under `tools/`: pair2-mcp, story-mcp, and
+  causa-mcp (spec-only today). The first and the third share a
+  reserved cross-server **wire vocabulary** — namespaced map keys an
+  agent recognises identically across every server:
+
+  - `:rf.mcp/overflow`      — token-budget overflow marker
+                              (causa-mcp Principles mechanism 1,
+                               pair2-mcp `tools.cljs` `overflow-payload`)
+  - `:rf.mcp/summary`       — tree-summary lazy-mode marker
+                              (causa-mcp Principles mechanism 4,
+                               pair2-mcp `tools.cljs` `tree-summary`)
+  - `:rf.mcp/dedup-table`   — structural-dedup wrapper
+                              (causa-mcp Principles mechanism 5,
+                               pair2-mcp `tools.cljs` `dedup-value`)
+  - `:rf.mcp/diff-from`     — diff-encoded `:db-after` marker
+                              (pair2-mcp `tools.cljs`
+                               `diff-encode-db-after`; cross-MCP
+                               vocabulary per pair2-mcp Principles
+                               §\"Cross-MCP vocabulary\")
+  - `:rf.size/large-elided` — size-elision wire marker
+                              (spec/Spec-Schemas §`:rf/elision-marker`,
+                               pair2-mcp Principles §\"Size-elision\")
+  - `:rf.elision/at`        — size-elision fetch-handle tag
+                              (same)
+
+  story-mcp does NOT currently emit any of these markers — it operates
+  on small, structured story/variant metadata and stays under the
+  wire-cap by construction. The story-mcp `tools.cljc` namespaces its
+  own vocabulary under `:rf.story/*`, `:rf.assert/*`, `:rf.error/*`
+  per its own spec. The vocabulary becomes relevant on story-mcp the
+  day a tool starts returning bulk runtime state; until then the
+  conformance gate guards the *contract*: when story-mcp adopts a
+  marker it MUST use the canonical shape, not invent a near-miss.
+
+  ## What this test guards
+
+  1. **One canonical schema per marker.** A single Malli schema lives
+     here. Every fixture EDN representing a server's actual emission
+     shape MUST validate against the canonical schema.
+
+  2. **Per-server fixture parity.** Each marker has a `pair2-mcp` and
+     `causa-mcp` fixture. Both validate against the same schema —
+     that's the cross-server conformance assertion. Divergent shapes
+     fail loud.
+
+  3. **Source-text vocabulary pin.** A grep against each server's
+     source (pair2-mcp `src/`) and spec (causa-mcp `spec/`) asserts
+     the canonical literal appears AND no near-miss variant (e.g.
+     `:rf.mcp/overflows`, `:rf.mcp/dedup_table`, the underscore
+     form) appears. A rename in either server surfaces here.
+
+  4. **Cross-server presence/absence.** The set of markers each
+     server is contracted to emit is pinned. Adding a sixth marker
+     requires editing this test — which forces the conformance
+     contract to stay in sync with the spec.
+
+  ## Why pure JVM Clojure (not Node SDK)
+
+  The sibling `tools/mcp-conformance/test/end-to-end-*.js` files
+  drive each server through the official MCP SDK client (handshake
+  + tools/list + tools/call against a live process). That validates
+  *protocol* conformance.
+
+  This test validates *vocabulary* conformance — the shapes of EDN
+  values the server emits as response payloads. It does NOT need a
+  live server: the schemas are normative, the fixtures are authored
+  from each server's spec/source, and the grep step pins those
+  authored fixtures to the actual source/spec text.
+
+  ## causa-mcp impl gap
+
+  causa-mcp's implementation has not landed yet (its `tools/` entry
+  is `README.md` + `spec/`, no `src/`). The fixtures and the spec
+  grep step against `tools/causa-mcp/spec/Principles.md` cover the
+  vocabulary today; when impl lands, a follow-up bead extends this
+  test to grep `tools/causa-mcp/src/` and add live-emission fixtures
+  if their shape diverges from the spec snippets."
+  (:require [clojure.java.io :as io]
+            [clojure.string  :as str]
+            [clojure.test    :refer [deftest is testing]]
+            [malli.core      :as m]
+            [malli.error     :as me]))
+
+;; ---------------------------------------------------------------------------
+;; Locate the repo root from the test's classpath. The test runs from
+;; `tools/mcp-conformance/wire-vocab/`; the repo root is three levels
+;; up. We resolve it from `*file*` at load time so the test is
+;; CWD-agnostic (CI runs the test-runner from various locations).
+;; ---------------------------------------------------------------------------
+
+(def ^:private repo-root
+  "Absolute path to the repo root, derived from this file's location.
+  `wire_vocab_test.clj` lives at
+  `tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/`.
+  Walk up six levels to reach the repo root."
+  (let [this-file (io/file (.getPath (io/resource "re_frame/mcp_conformance/wire_vocab_test.clj")))]
+    (-> this-file
+        .getParentFile                                      ; .../mcp_conformance/
+        .getParentFile                                      ; .../re_frame/
+        .getParentFile                                      ; .../test/
+        .getParentFile                                      ; .../wire-vocab/
+        .getParentFile                                      ; .../mcp-conformance/
+        .getParentFile                                      ; .../tools/
+        .getParentFile                                      ; <repo-root>
+        .getAbsolutePath)))
+
+(defn- read-source
+  "Slurp a source file inside the repo. `rel-path` is a string path
+  segment relative to the repo root, using `/` as the separator. The
+  test fails loudly (via `slurp`'s default IOException) if the path
+  doesn't resolve — that's the right signal: a source file under
+  conformance was moved or removed."
+  [rel-path]
+  (slurp (io/file repo-root rel-path)))
+
+;; ---------------------------------------------------------------------------
+;; Canonical schemas. Single source of truth.
+;;
+;; Each schema is the cross-MCP-server contract for one wire marker.
+;; The marker is **always a single-key map** keyed by the reserved
+;; keyword; the value is a body conforming to the per-marker schema
+;; below. Agents pattern-match on the top-level reserved key — that
+;; rule is what makes the vocabulary cross-server.
+;; ---------------------------------------------------------------------------
+
+(def OverflowBody
+  "`{:rf.mcp/overflow {...}}` body — the token-budget overflow marker.
+
+  Per causa-mcp Principles §\"1. Token budget cap\" and pair2-mcp
+  `tools.cljs/overflow-payload`. The body carries the cap that was
+  hit, an `:cap-tokens` or `:cap` cap value (pair2-mcp uses
+  `:cap-tokens`; the spec example uses `:cap`), the over-budget
+  token count, a tool-specific next-step `:hint`, and a `:limit`
+  sentinel.
+
+  pair2-mcp's payload uses `:cap-tokens` / `:token-count` (snake-cased
+  with hyphens, no underscores) and adds `:tool` for the offending
+  tool name. causa-mcp's spec example uses `:cap` / `:would-be` plus
+  a `:continuation` block with `:cursor` + `:next-args`. The
+  conformance schema permits both — the load-bearing claim is the
+  top-level marker key and the kebab-case child names. Cap renames
+  (`cap-tokens` vs `cap_tokens`) trip the schema."
+  [:map
+   {:closed false}
+   [:limit [:enum :reached]]                                   ;; pair2-mcp
+   [:tool   {:optional true} [:or :string :keyword]]           ;; pair2-mcp
+   [:cap-tokens   {:optional true} :int]                       ;; pair2-mcp form
+   [:cap          {:optional true} :int]                       ;; causa-mcp form
+   [:token-count  {:optional true} :int]                       ;; pair2-mcp form
+   [:would-be     {:optional true} :int]                       ;; causa-mcp form
+   [:hint         {:optional true} [:or :string :keyword]]
+   [:continuation {:optional true}
+    [:map
+     [:cursor    {:optional true} [:or :string :nil]]
+     [:next-args {:optional true} [:maybe :map]]]]])
+
+(def Overflow
+  "`{:rf.mcp/overflow OverflowBody}` — the wrapper shape."
+  [:map [:rf.mcp/overflow OverflowBody]])
+
+(def SummaryBody
+  "`{:rf.mcp/summary {...}}` body — the lazy tree-summary marker.
+
+  Per causa-mcp Principles §\"4. Lazy summary\" and pair2-mcp
+  `tools.cljs/tree-summary`. `:type` ∈ {:map :vector :set :seq
+  :scalar}; map summaries carry `:keys` + `:count` + `:bytes`;
+  vector/set/seq summaries carry `:count` + `:bytes`; scalar
+  summaries carry `:value` + `:bytes`. Large maps add
+  `:keys-truncated? true` when `:keys` is clamped to
+  `summary-keys-cap` (pair2-mcp pins 64; the spec doesn't pin).
+
+  causa-mcp's Principles example uses `:counts` (a per-top-key
+  map) instead of `:count`. The schema permits both — but a single
+  marker MUST carry one or the other, not neither."
+  [:map
+   {:closed false}
+   [:type [:enum :map :vector :set :seq :scalar]]
+   [:bytes :int]                                               ;; pr-str char count
+   [:keys             {:optional true} [:sequential :any]]     ;; maps only
+   [:keys-truncated?  {:optional true} :boolean]               ;; maps only when clamped
+   [:count            {:optional true} :int]                   ;; non-scalars
+   [:counts           {:optional true} [:map-of :any :int]]    ;; causa-mcp variant
+   [:value            {:optional true} :any]])                 ;; scalars
+
+(def Summary
+  "`{:rf.mcp/summary SummaryBody}` — the wrapper shape."
+  [:map [:rf.mcp/summary SummaryBody]])
+
+(def DedupTable
+  "`{:rf.mcp/dedup-table <flat-cache>}` — the structural-dedup wrapper.
+
+  The body is the day8/de-dupe cache map: `{:de-dupe.cache/cache-0
+  <root> :de-dupe.cache/cache-N <subtree> ...}`. causa-mcp's
+  Principles example uses integer keys (`{1 {...} 2 {...}}`) for
+  illustration; pair2-mcp's actual cache uses the de-dupe library's
+  namespaced-keyword form. The schema permits either — the
+  load-bearing claim is the top-level `:rf.mcp/dedup-table` marker
+  key and that the value is a *map* (the agent host calls
+  `de-dupe.core/expand` on it)."
+  [:map [:rf.mcp/dedup-table :map]])
+
+(def DiffFromBody
+  "An epoch's `:db-after` slot, diff-encoded against `:db-before`.
+
+  Per pair2-mcp `tools.cljs/diff-encode-db-after` and pair2-mcp
+  Principles §\"Cross-MCP vocabulary\". Shape:
+
+      {:rf.mcp/diff-from :db-before
+       :patches [[<path> :assoc <new-value>]
+                 [<path> :dissoc]
+                 ...]}
+
+  The `:rf.mcp/diff-from` value is a keyword naming the
+  diff-against slot — `:db-before` is the only conformant value
+  today (an epoch's `:db-after` diff-encodes against the SAME
+  record's `:db-before`)."
+  [:map
+   [:rf.mcp/diff-from [:enum :db-before]]
+   [:patches [:sequential
+              [:or
+               [:tuple [:vector :any] [:= :assoc] :any]
+               [:tuple [:vector :any] [:= :dissoc]]]]]])
+
+(def ElisionMarkerBody
+  "`{:rf.size/large-elided {...}}` body — the size-elision marker.
+
+  Normative shape per spec/Spec-Schemas.md §`:rf/elision-marker`.
+  `:digest` is optional (only when `:rf.size/include-digests? true`
+  per spec/API.md `rf/elide-wire-value`)."
+  [:map
+   [:path    [:vector :any]]
+   [:bytes   :int]
+   [:type    [:enum :map :vector :set :scalar :string]]
+   [:reason  [:enum :declared :schema :runtime-flagged]]
+   [:hint    [:maybe :string]]
+   [:handle  [:tuple [:= :rf.elision/at] [:vector :any]]]
+   [:digest  {:optional true} :string]])
+
+(def ElisionMarker
+  "`{:rf.size/large-elided ElisionMarkerBody}` — the wrapper shape."
+  [:map [:rf.size/large-elided ElisionMarkerBody]])
+
+;; ---------------------------------------------------------------------------
+;; Canonical-marker index. The ordered set of cross-MCP markers; each
+;; entry binds the schema, a description, and the per-server fixtures.
+;; A new marker landing in the cross-server vocabulary MUST add an
+;; entry here.
+;; ---------------------------------------------------------------------------
+
+(def canonical-markers
+  "Ordered table of cross-server wire markers under conformance.
+
+  Each entry pins:
+  - `:key`       — the reserved top-level keyword
+  - `:schema`    — the canonical Malli schema (wrapper shape)
+  - `:fixtures`  — per-server example values (must all validate)
+  - `:servers`   — set of servers that emit/spec the marker today
+
+  The conformance assertion: every fixture in `:fixtures` validates
+  against `:schema`; the source/spec text of every server in
+  `:servers` mentions the marker key literally."
+  [{:key      :rf.mcp/overflow
+    :schema   Overflow
+    :servers  #{:pair2-mcp :causa-mcp}                         ;; not :story-mcp
+    :fixtures {:pair2-mcp {:rf.mcp/overflow
+                           {:limit       :reached
+                            :token-count 12400
+                            :cap-tokens  5000
+                            :tool        "snapshot"
+                            :hint        "Narrow scope: pass `path [:k1 :k2]` to slice ..."}}
+               :causa-mcp {:rf.mcp/overflow
+                           {:limit        :reached
+                            :cap          5000
+                            :would-be     12400
+                            :hint         :switch-mode
+                            :continuation {:cursor    "opaque-cursor-123"
+                                           :next-args {:mode :sample}}}}}}
+
+   {:key      :rf.mcp/summary
+    :schema   Summary
+    :servers  #{:pair2-mcp :causa-mcp}
+    :fixtures {:pair2-mcp-map     {:rf.mcp/summary
+                                   {:type  :map
+                                    :keys  [:user :cart :ui]
+                                    :count 3
+                                    :bytes 1200}}
+               :pair2-mcp-vector  {:rf.mcp/summary
+                                   {:type  :vector
+                                    :count 50
+                                    :bytes 900}}
+               :pair2-mcp-set     {:rf.mcp/summary
+                                   {:type  :set
+                                    :count 12
+                                    :bytes 80}}
+               :pair2-mcp-seq     {:rf.mcp/summary
+                                   {:type  :seq
+                                    :count 17
+                                    :bytes 110}}
+               :pair2-mcp-scalar  {:rf.mcp/summary
+                                   {:type  :scalar
+                                    :value 42
+                                    :bytes 2}}
+               :pair2-mcp-clamped {:rf.mcp/summary
+                                   {:type             :map
+                                    :keys             (vec (range 64))
+                                    :count            128
+                                    :bytes            5000
+                                    :keys-truncated?  true}}
+               :causa-mcp-map     {:rf.mcp/summary
+                                   {:type   :map
+                                    :keys   [:cart :user :ui]
+                                    :counts {:cart 47 :user 3 :ui 12}
+                                    :bytes  12400}}}}
+
+   {:key      :rf.mcp/dedup-table
+    :schema   DedupTable
+    :servers  #{:pair2-mcp :causa-mcp}
+    :fixtures {:pair2-mcp  {:rf.mcp/dedup-table
+                            {:de-dupe.cache/cache-0 [:de-dupe.cache/cache-1 :de-dupe.cache/cache-1]
+                             :de-dupe.cache/cache-1 {:event-id :foo :handler-id :bar}}}
+               ;; causa-mcp's Principles uses integer-keyed example for
+               ;; brevity; both forms validate against the schema.
+               :causa-mcp  {:rf.mcp/dedup-table
+                            {1 {:event-id :foo :handler-id :bar}
+                             2 {:event-id :baz}}}}}
+
+   {:key      :rf.mcp/diff-from
+    :schema   [:map [:rf.mcp/diff-from [:enum :db-before]] [:patches :any]]
+    ;; pair2-mcp specs / emits today. The schema and the marker are
+    ;; reserved in the cross-MCP family per pair2-mcp Principles §
+    ;; \"Cross-MCP vocabulary\" — causa-mcp's spec mentions it via the
+    ;; same family but the example shape is pair2-mcp-owned.
+    :servers  #{:pair2-mcp}
+    :fixtures {:pair2-mcp {:rf.mcp/diff-from :db-before
+                           :patches          [[[:cart :items] :assoc [{:sku "abc"}]]
+                                              [[:tmp]          :dissoc]]}}}
+
+   {:key      :rf.size/large-elided
+    :schema   ElisionMarker
+    ;; Reserved by Conventions / spec; pair2-mcp emits today.
+    ;;
+    ;; causa-mcp's spec currently mentions elision under an ad-hoc
+    ;; `:elided [:cofx :db]` shape (tools/causa-mcp/spec/Principles.md
+    ;; line 420) — a vocabulary-drift discovered by rf2-j2z7o's
+    ;; conformance run. Tracked for fix under rf2-04ozp; until that
+    ;; lands, only :pair2-mcp is in `:servers`. The schema and the
+    ;; cross-MCP-fixture story still apply (two fixtures below
+    ;; representing two distinct emission shapes — declared/string
+    ;; vs runtime-flagged/map-with-digest).
+    :servers  #{:pair2-mcp}
+    :fixtures {:pair2-mcp-declared
+               {:rf.size/large-elided
+                {:path   [:user :uploaded-pdf]
+                 :bytes  102400
+                 :type   :string
+                 :reason :declared
+                 :hint   "User-uploaded PDF; fetch via get-path."
+                 :handle [:rf.elision/at [:user :uploaded-pdf]]}}
+               :pair2-mcp-runtime-with-digest
+               {:rf.size/large-elided
+                {:path   [:cofx :db]
+                 :bytes  524288
+                 :type   :map
+                 :reason :runtime-flagged
+                 :hint   nil
+                 :handle [:rf.elision/at [:cofx :db]]
+                 :digest "sha256:deadbeefcafef00d"}}}}])
+
+;; ---------------------------------------------------------------------------
+;; Fixture conformance — every authored fixture validates against the
+;; canonical schema for its marker. This is the primary cross-server
+;; assertion: pair2-mcp's and causa-mcp's fixture shapes BOTH conform
+;; to the same single schema.
+;; ---------------------------------------------------------------------------
+
+(deftest every-fixture-conforms-to-its-canonical-schema
+  (doseq [{:keys [key schema fixtures]} canonical-markers
+          [fixture-name fixture-value] fixtures]
+    (testing (str "marker " key " — fixture " fixture-name)
+      (is (m/validate schema fixture-value)
+          (str "Fixture " fixture-name " for " key
+               " failed schema validation:\n"
+               (me/humanize (m/explain schema fixture-value)))))))
+
+(deftest every-canonical-marker-has-at-least-two-fixtures
+  ;; Cross-server is at minimum a 2-fixture story (pair2 + causa, or
+  ;; pair2-A + pair2-B for shape variants like map-summary vs
+  ;; vector-summary). One fixture means \"only one server emits this\"
+  ;; — which we still allow when the :servers set is a singleton.
+  (doseq [{:keys [key fixtures servers]} canonical-markers]
+    (testing (str "marker " key " — fixture count")
+      (let [n (count fixtures)]
+        (if (= 1 (count servers))
+          (is (>= n 1)
+              (str key " is single-server (" servers
+                   ") so >=1 fixture suffices, got " n))
+          (is (>= n 2)
+              (str key " is multi-server (" servers
+                   ") so >=2 fixtures required, got " n)))))))
+
+;; ---------------------------------------------------------------------------
+;; Source-text vocabulary pin. The literal marker key MUST appear in
+;; each contracted server's source/spec; near-miss variants (snake_case,
+;; pluralised, mis-pluralised) MUST NOT appear. A rename in the
+;; framework or in either server surfaces here — the schema is one
+;; gate, the literal-occurrence pin is the second.
+;; ---------------------------------------------------------------------------
+
+(def ^:private server-source-files
+  "Files we grep for marker literals, per server. The lists are
+  hand-curated — adding a new emission surface to a server requires
+  extending this map (which is the right friction: the conformance
+  contract knows where each server's wire boundary lives)."
+  {:pair2-mcp ["tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs"
+               "tools/pair2-mcp/spec/Principles.md"
+               "tools/pair2-mcp/spec/003-Tool-Catalogue.md"]
+   :causa-mcp ["tools/causa-mcp/spec/Principles.md"
+               "tools/causa-mcp/spec/DESIGN-RATIONALE.md"]
+   ;; story-mcp does not currently emit any cross-MCP wire markers
+   ;; (it uses its own :rf.story/* + :rf.assert/* + :rf.error/*
+   ;; vocabularies). When story-mcp adopts a marker, add a fixture
+   ;; AND extend this list — the test enforces both.
+   :story-mcp []})
+
+(defn- marker-key->literal
+  "Render a marker key as the literal string that MUST appear in the
+  source. The renderer prints with the `:` prefix and the full
+  namespaced form — that's what `clojure.core/pr-str` emits and what
+  the source files use verbatim."
+  [k]
+  (pr-str k))
+
+(defn- near-miss-variants
+  "Generate near-miss spellings of a marker keyword. A rename to any
+  of these forms MUST NOT slip through. We check:
+  - snake_case form  (`:rf.mcp/dedup_table`)
+  - pluralised tail  (`:rf.mcp/overflows`)
+  - all-lowercase ns (`:rf.mcp/Overflow` -> none; we already are
+                      lowercase, so this variant is irrelevant for
+                      these markers; included for future-proofing)
+  - underscore-in-ns (`:rf_mcp/overflow`)
+  The list is conservative — false positives here would block
+  legitimate text in surrounding docs."
+  [k]
+  (let [s (pr-str k)
+        ns* (namespace k)
+        nm  (name k)]
+    (cond-> []
+      (str/includes? nm "-")
+      (conj (str ":" ns* "/" (str/replace nm #"-" "_"))) ;; snake_case
+      (str/includes? ns* ".")
+      (conj (str ":" (str/replace ns* #"\." "_") "/" nm)) ;; ns dots -> underscores
+      true
+      (into [(str s "s")                                   ;; pluralised
+             (str s "?")]))))                              ;; predicate form
+
+(deftest marker-literal-appears-in-every-contracted-server-source
+  (doseq [{:keys [key servers]} canonical-markers
+          server                servers]
+    (testing (str "marker " key " literal in " server " sources")
+      (let [literal (marker-key->literal key)
+            files   (get server-source-files server)]
+        (is (seq files)
+            (str "No source files registered for " server
+                 " — extend `server-source-files`."))
+        (is (some (fn [rel]
+                    (str/includes? (read-source rel) literal))
+                  files)
+            (str "Literal " literal " missing from " server
+                 " sources: " files))))))
+
+(deftest no-near-miss-variants-appear-in-any-server-source
+  ;; Defence-in-depth: a rename to a near-miss form (e.g. snake_case)
+  ;; would slip past the literal-presence test if the canonical form
+  ;; ALSO still appears somewhere. This test makes sure no near-miss
+  ;; co-exists alongside the canonical.
+  (doseq [{:keys [key]} canonical-markers
+          [server files] server-source-files
+          variant       (near-miss-variants key)
+          rel           files]
+    (testing (str server " — " rel " — near-miss " variant)
+      (is (not (str/includes? (read-source rel) variant))
+          (str "Found near-miss variant " variant " for " key
+               " in " server "/" rel
+               " — this is a vocabulary-drift bug. The canonical "
+               "form is " (marker-key->literal key))))))
+
+;; ---------------------------------------------------------------------------
+;; Server-coverage pin. The set of servers each marker is contracted
+;; against is the *current* state; this test prints it on `--verbose`
+;; so a reviewer sees the shape. It also asserts the only servers we
+;; reference are the three known servers — a typo in a `:servers` set
+;; surfaces here.
+;; ---------------------------------------------------------------------------
+
+(def ^:private known-servers #{:pair2-mcp :story-mcp :causa-mcp})
+
+(deftest server-references-are-all-known
+  (doseq [{:keys [key servers]} canonical-markers]
+    (testing (str "marker " key " — :servers values")
+      (is (every? known-servers servers)
+          (str "Unknown server in :servers for " key ": "
+               (remove known-servers servers))))))
+
+(deftest story-mcp-still-emits-zero-cross-mcp-markers
+  ;; Self-documenting tripwire: the day story-mcp adopts ANY of the
+  ;; cross-MCP markers, this test flips RED — at which point the
+  ;; reviewer adds story-mcp to the `:servers` set on the affected
+  ;; marker, adds a fixture, and extends `server-source-files`. That's
+  ;; the right friction; conformance is not free.
+  (let [story-files ["tools/story-mcp/src/re_frame/story_mcp/tools.cljc"
+                     "tools/story-mcp/src/re_frame/story_mcp/protocol.cljc"]]
+    (doseq [{:keys [key]} canonical-markers
+            rel           story-files]
+      (testing (str "story-mcp source " rel " — " key " absence")
+        (is (not (str/includes? (read-source rel) (marker-key->literal key)))
+            (str key " literal found in " rel
+                 ".\nIf story-mcp now emits this marker, update "
+                 "`canonical-markers` to include :story-mcp in "
+                 ":servers, add a story-mcp fixture, and extend "
+                 "`server-source-files`."))))))


### PR DESCRIPTION
## Summary

- New pure-JVM Clojure test under `tools/mcp-conformance/wire-vocab/` that pins the canonical schema for every reserved cross-MCP wire marker (`:rf.mcp/overflow`, `:rf.mcp/summary`, `:rf.mcp/dedup-table`, `:rf.mcp/diff-from`, `:rf.size/large-elided`, `:rf.elision/at`) and asserts per-server fixtures + source-text usage all conform.
- Sibling to the existing Node-side `test/end-to-end-*.js` SDK-client tests: protocol conformance is one gate, vocabulary conformance is the other.
- `story-mcp` does not currently emit any cross-MCP markers; an absence tripwire fires the day it adopts one, forcing the reviewer to register a fixture and extend the source-file list (no silent divergence).

## What's in the conformance set

Six markers, six canonical Malli schemas, ten fixtures spanning two servers. Per-marker contracted servers:

| Marker | Servers (today) |
|---|---|
| `:rf.mcp/overflow` | pair2-mcp, causa-mcp |
| `:rf.mcp/summary` | pair2-mcp, causa-mcp |
| `:rf.mcp/dedup-table` | pair2-mcp, causa-mcp |
| `:rf.mcp/diff-from` | pair2-mcp |
| `:rf.size/large-elided` | pair2-mcp (causa-mcp spec drift — see rf2-04ozp) |

## Divergence discovered

`tools/causa-mcp/spec/Principles.md` line 420 uses an ad-hoc `:elided [:cofx :db]` shape instead of the canonical `:rf.size/large-elided` reserved by `spec/Conventions.md` and normatively defined in `spec/Spec-Schemas.md` §`:rf/elision-marker`. Filed for fix under rf2-04ozp; until that lands, the marker's `:servers` set is `#{:pair2-mcp}` with a code comment pointing at the follow-up bead.

## Test plan

- [x] `clojure -M:test` from `tools/mcp-conformance/wire-vocab/` — 6 tests, 140 assertions, 0 failures
- [x] Verify the test catches divergence: temporarily renamed `:rf.mcp/overflow` to `:rf.mcp/overflows` in `canonical-markers` during dev → near-miss-variant test red as expected (reverted)
- [x] Verify source-text pin: every contracted server's `:servers` set has the marker literal in at least one of its registered source/spec files