### PR TITLE
feat(pair2-mcp): cursor pagination on trace-window + watch-epochs (rf2-kbqq3)

### DIFF
--- a/tools/pair2-mcp/README.md
+++ b/tools/pair2-mcp/README.md
@@ -30,8 +30,8 @@ cljs-eval compile.
 | `discover-app` | `discover-app.sh`         | Verify shadow-cljs nREPL is reachable, probe the preloaded pair2 runtime marker, return a health summary. Run first every session. |
 | `eval-cljs`    | `eval-cljs.sh`            | Evaluate a CLJS form via shadow-cljs's `cljs-eval`. Returns the EDN value. |
 | `dispatch`     | `dispatch.sh`             | Fire a re-frame2 event with `:origin :pair`. Modes: queued, sync, trace. Frame and fx-overrides supported. |
-| `trace-window` | `trace-window.sh`         | Return the epochs that landed in the last N ms. |
-| `watch-epochs` | `watch-epochs.sh`         | Pull-mode poll for matching epochs added after a given epoch-id. Predicate keys: `:event-id`, `:event-id-prefix`, `:effects`, `:touches-path`, `:sub-ran`, `:render`, `:origin`, `:frame`. |
+| `trace-window` | `trace-window.sh`         | Return the epochs that landed in the last N ms. Cursor-paginated (`:limit` / `:cursor`, default limit 50). |
+| `watch-epochs` | `watch-epochs.sh`         | Pull-mode poll for matching epochs added after a given epoch-id. Predicate keys: `:event-id`, `:event-id-prefix`, `:effects`, `:touches-path`, `:sub-ran`, `:render`, `:origin`, `:frame`. Cursor-paginated (`:limit` / `:cursor`, default limit 50). |
 | `tail-build`   | `tail-build.sh`           | Wait for a hot-reload to land by polling a probe form until its value changes. |
 | `snapshot`     | _(new — no bash equivalent)_ | Coarse-grained per-frame state read in one round-trip. Returns a map keyed by frame-id with `:app-db`, `:sub-cache`, `:machines`, `:epochs`, `:traces` slices. Prefer for investigate-X workflows over chaining 5-10 individual reads. The `:app-db` slice defaults to a tree-summary marker (rf2-tygdv); drill down with `path`. |
 | `get-path`     | _(new — no bash equivalent)_ | Read a single value at `path` from a frame's app-db (rf2-tygdv). Minimal targeted-read primitive; server-side `get-in` so only the addressed subtree crosses the wire. Distinguishes a path that points at `nil` from a path that doesn't resolve, and attaches `deepest-valid-prefix` on misses so the agent can re-aim. |

--- a/tools/pair2-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/pair2-mcp/spec/003-Tool-Catalogue.md
@@ -138,17 +138,66 @@ Fire a re-frame2 event tagged with `:origin :pair`. Three modes:
 
 **Returns**: the runtime's response, merged with `:mode`.
 
+## Universal: cursor pagination on epoch slices
+
+The two tools that ship unbounded epoch vectors — `trace-window` and
+`watch-epochs` — accept `:limit` (int, default 50) and `:cursor`
+(opaque string). Pages over a stale ring surface as a structured
+error rather than silently restarting (see
+[`Principles.md` §Pagination](Principles.md#per-tool-budget-discipline)).
+
+```clojure
+{:ok?                 true
+ :limit               50              ; the cap that bounded this page
+ :count               50              ; items in this page
+ :epochs              [...]           ; the page itself
+ :has-more?           true|false
+ :estimated-remaining N                ; remaining matches in current ring
+ :next-cursor         "<base64-edn>" | nil}
+```
+
+The cursor is opaque on the wire — agents pass `:next-cursor` back as
+`:cursor` on the next call. Default `:limit` (50) is sized to fit the
+5K-token wire-cap after diff-encode (rf2-1wdzp) and dedup (rf2-obpa9).
+The cursor's payload (base64-encoded EDN; subject to change behind the
+opaque boundary) carries the last-emitted epoch-id plus sticky window
+fields (`:ms`, `:until-ms`, `:frame`) so subsequent pages see the same
+window the first call did — fresh epochs landing during pagination
+don't sneak in mid-iteration.
+
+### Cursor staleness
+
+The runtime's epoch ring is bounded. If the cursor's epoch-id has
+rotated out between calls (or the cursor is malformed), the response
+is:
+
+```clojure
+{:ok?          false
+ :reason       :rf.mcp/cursor-stale
+ :tool         "trace-window" | "watch-epochs"
+ :requested-id <id>
+ :head-id      <current-head>
+ :hint         "..."}
+```
+
+Agents pattern-match on `:reason :rf.mcp/cursor-stale` and either drop
+the cursor and restart, or widen the window (`watch-epochs` accepts a
+larger pred filter; `trace-window` accepts a larger `ms`).
+
 ## trace-window
 
 Return `:rf/epoch-record`s that landed in the last N ms for the
 operating frame.
 
-**Args**: `ms` (integer, default 1000), `frame` (string),
-`epochs-mode` (string — `"diff"` (default) or `"full"`, see §Diff-encoded
-`:db-after` below), `dedup` (boolean, default `true` — see §Structural
-dedup at the top of this catalogue), `build` (string).
+**Args**: `ms` (integer, default 1000 — sticky across cursor pagination,
+encoded in the cursor on the first call), `frame` (string),
+`limit` (int, default 50 — see §Cursor pagination above),
+`cursor` (string, opaque continuation token — see §Cursor pagination
+above), `epochs-mode` (string — `"diff"` (default) or `"full"`, see
+§Diff-encoded `:db-after` below), `dedup` (boolean, default `true` —
+see §Structural dedup at the top of this catalogue), `build` (string).
 
-**Returns**: `{:ok? true :window-ms N :count K :epochs-mode :diff|:full :epochs [...]}`.
+**Returns**: `{:ok? true :window-ms N :until-ms T :count K :limit L :epochs-mode :diff|:full :epochs [...] :has-more? bool :estimated-remaining N :next-cursor "<base64>"|nil}`.
 
 ### Diff-encoded `:db-after` (rf2-1wdzp)
 
@@ -183,16 +232,18 @@ This is the MCP equivalent of the bash `watch-epochs.sh` script's
 poll loop — but MCP isn't streaming, so callers that want a tight
 loop should call us repeatedly with the same `since-id`.
 
-**Args**: `since-id` (string, optional — omit to start fresh),
-`pred` (object, optional predicate filter, keys from:
-`:event-id`, `:event-id-prefix`, `:effects`, `:touches-path`,
-`:sub-ran`, `:render`, `:origin`, `:frame`), `frame`,
+**Args**: `since-id` (string, optional — omit to start fresh; supplanted
+by `cursor` when both are supplied), `pred` (object, optional predicate
+filter, keys from: `:event-id`, `:event-id-prefix`, `:effects`,
+`:touches-path`, `:sub-ran`, `:render`, `:origin`, `:frame`), `frame`,
+`limit` (int, default 50 — see §Cursor pagination above), `cursor`
+(string, opaque continuation token — see §Cursor pagination above),
 `epochs-mode` (string — `"diff"` (default) or `"full"`, see
 `trace-window` §Diff-encoded `:db-after`), `dedup` (boolean,
 default `true` — see §Structural dedup at the top of this
 catalogue), `build`.
 
-**Returns**: `{:ok? true :matches [...] :head-id "..." :id-aged-out? bool :epochs-mode :diff|:full}`.
+**Returns**: `{:ok? true :matches [...] :limit L :count K :head-id "..." :id-aged-out? bool :epochs-mode :diff|:full :has-more? bool :estimated-remaining N :next-cursor "<base64>"|nil}`.
 
 Each match has its `:db-after` diff-encoded against its own
 `:db-before` by default (rf2-1wdzp); pass `epochs-mode "full"` for

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -738,6 +738,133 @@
       [kept n])))
 
 ;; ---------------------------------------------------------------------------
+;; Cursor pagination on epoch-shipping tools (rf2-kbqq3).
+;;
+;; `trace-window` and `watch-epochs` both surface unbounded epoch
+;; vectors. With default ring depth 50 and ~2× app-db per record (or ~1%
+;; that, post-rf2-1wdzp diff-encode), a single call can blow the 5K
+;; wire-cap (rf2-rvyzy). Lazy-summary (rf2-u2029) trims `snapshot` for
+;; discovery; here the agent explicitly asked for the records — the
+;; right answer is to PAGE the slice, not to collapse it.
+;;
+;; ## Mechanism
+;;
+;; Both tools accept `:limit` (int, default 50 — sized to fit the cap
+;; after diff-encode + dedup) and `:cursor` (opaque string). The
+;; response carries:
+;;
+;;   {:items [...]                                ; capped at :limit
+;;    :next-cursor "<base64>"                     ; nil when no more
+;;    :has-more? true|false
+;;    :estimated-remaining N}
+;;
+;; The opaque cursor is `pr-str`+base64 of a small EDN map. Encoding is
+;; an implementation detail — agents pass it back verbatim. The shape
+;; (today; subject to change behind the opaque boundary) is:
+;;
+;;   {:v 1
+;;    :after-id <epoch-id-string>     ; the last epoch-id we emitted
+;;    :ms <int-or-nil>                 ; trace-window's :ms arg (sticky)
+;;    :until-ms <int-or-nil>           ; first-call clock; bounds the
+;;                                     ; window so trace-window doesn't
+;;                                     ; admit fresh epochs mid-page
+;;    :frame <keyword-or-nil>}
+;;
+;; ## Cursor staleness
+;;
+;; The runtime's epoch ring (depth 50 by default) is a bounded buffer.
+;; If a cursor's `:after-id` no longer exists in the ring (because
+;; enough epochs landed between calls that the buffer rotated past it),
+;; the server returns a structured error rather than silently restarting
+;; or shipping an out-of-order batch:
+;;
+;;   {:ok? false
+;;    :reason :rf.mcp/cursor-stale
+;;    :requested-id <id>
+;;    :head-id <current-head>
+;;    :hint "..."}
+;;
+;; The runtime already surfaces `:id-aged-out? true` from
+;; `epochs-since` when the cursor's id can't be found — we lift that
+;; signal to a top-level error.
+;;
+;; ## Why opaque
+;;
+;; Per `spec/Principles.md` §Pagination, cursors are opaque on the
+;; wire. The agent has no business decoding the format; it MUST pass
+;; the value back verbatim. The base64 + EDN-inside choice gives us
+;; room to evolve the cursor shape (add fields, switch keys) without
+;; a wire-protocol break.
+;; ---------------------------------------------------------------------------
+
+(def ^:private default-limit
+  ;; Sized to fit a 5K-token cap after diff-encode (rf2-1wdzp) and
+  ;; dedup (rf2-obpa9). With diff-encode collapsing `:db-after` to ~1%
+  ;; of `:db-before` and dedup pooling repeated `:db-before` references,
+  ;; 50 epochs fit comfortably under 5K tokens for typical app-db sizes.
+  ;; Agents that have explicit budget headroom raise via `:limit` arg.
+  50)
+
+(defn- parse-limit-arg
+  "Normalise the `:limit` MCP arg into a positive integer. Accepts ints
+  (passed through), strings (parsed), or nil (default 50). Non-positive
+  values clamp to 1; non-numeric falls back to default. The cap is a
+  guarantee — the response will never contain more than `limit` items."
+  [raw]
+  (cond
+    (or (nil? raw) (undefined? raw)) default-limit
+    (number? raw) (max 1 (long raw))
+    (string? raw) (let [n (js/parseInt raw 10)]
+                    (if (and (number? n) (not (js/isNaN n)))
+                      (max 1 (long n))
+                      default-limit))
+    :else default-limit))
+
+(defn- encode-cursor
+  "Encode a cursor payload as a base64 string. Returns nil on a nil/empty
+  payload — pagination is over."
+  [payload]
+  (when (and (map? payload) (some? (:after-id payload)))
+    (let [edn (pr-str payload)
+          buf (js/Buffer.from edn "utf8")]
+      (.toString buf "base64"))))
+
+(defn- decode-cursor
+  "Decode a base64 cursor back to its EDN payload. Returns nil if the
+  cursor is absent; returns `::malformed` if the cursor exists but
+  doesn't decode to a valid payload map. Callers translate `::malformed`
+  into the same `:rf.mcp/cursor-stale` error as a runtime age-out — a
+  cursor that doesn't decode is, in effect, stale."
+  [s]
+  (cond
+    (or (nil? s) (undefined? s)) nil
+    (not (string? s)) ::malformed
+    (str/blank? s)    nil
+    :else
+    (try
+      (let [buf (js/Buffer.from s "base64")
+            edn (.toString buf "utf8")
+            v   (cljs.reader/read-string edn)]
+        (if (and (map? v) (string? (:after-id v)))
+          v
+          ::malformed))
+      (catch :default _ ::malformed))))
+
+(defn- cursor-stale-result
+  "Structured `:rf.mcp/cursor-stale` error result. Agents pattern-match
+  on `:reason :rf.mcp/cursor-stale` and either restart (drop the
+  cursor) or rewind via a wider window."
+  [tool {:keys [requested-id head-id]}]
+  (err-text (cond-> {:ok? false
+                     :reason :rf.mcp/cursor-stale
+                     :tool   tool
+                     :hint   (str "Cursor's epoch-id is no longer in the runtime ring. "
+                                  "Drop the cursor and restart, or widen the window "
+                                  "to recover the missed records.")}
+              requested-id (assoc :requested-id requested-id)
+              head-id      (assoc :head-id head-id))))
+
+;; ---------------------------------------------------------------------------
 ;; Tool: discover-app — verify the stack and probe the preloaded runtime.
 ;; ---------------------------------------------------------------------------
 
@@ -837,6 +964,12 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Tool: trace-window — epochs in the last N ms.
+;;
+;; Cursor pagination (rf2-kbqq3): the response is bounded at `:limit`
+;; items (default 50). When more remain, `:next-cursor` is non-nil.
+;; The cursor encodes a sticky `:until-ms` so subsequent pages see
+;; the same window the first call did — fresh epochs landing during
+;; pagination don't sneak in mid-iteration.
 ;; ---------------------------------------------------------------------------
 
 (defn- trace-window-tool [conn args]
@@ -846,23 +979,80 @@
         incl?     (include-sensitive? args)
         mode      (parse-epochs-mode (arg args :epochs-mode))
         dedup?    (parse-dedup-arg (arg args :dedup))
-        form      (if frame
-                    (str "(re-frame-pair2.runtime/epochs-in-last-ms " ms " " (pr-str frame) ")")
-                    (str "(re-frame-pair2.runtime/epochs-in-last-ms " ms ")"))]
-    (-> (ensure-runtime! conn build-id)
-        (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-        (.then (fn [epochs]
-                 (let [[kept dropped] (strip-sensitive (vec epochs) incl?)
-                       encoded         (diff-encode-epochs kept mode)
-                       deduped         (dedup-value encoded dedup?)]
-                   (ok-text (cond-> {:ok? true
-                                     :window-ms ms
-                                     :count (count encoded)
-                                     :epochs-mode mode
-                                     :dedup dedup?
-                                     :epochs deduped}
-                              (pos? dropped) (assoc :dropped-sensitive dropped))))))
-        (.catch (fn [err] (err->result :trace-failed err))))))
+        limit     (parse-limit-arg (arg args :limit))
+        cursor-in (decode-cursor (arg args :cursor))]
+    (if (= cursor-in ::malformed)
+      (js/Promise.resolve
+        (cursor-stale-result "trace-window" {:requested-id nil}))
+      (let [after-id  (:after-id cursor-in)
+            ;; Sticky window upper-bound: encoded on the first call so
+            ;; subsequent pages see the SAME window the first call did.
+            until-ms  (or (:until-ms cursor-in) (js/Date.now))
+            ;; Sticky ms — agent's first-call value drives all pages.
+            window-ms (or (:ms cursor-in) ms)
+            cutoff-ms (- until-ms window-ms)
+            sticky-frame (or (:frame cursor-in) frame)
+            frame-form (when sticky-frame (str " " (pr-str sticky-frame)))
+            ;; Server-side slice: pull the history, drop up-to-cursor,
+            ;; filter to the window, take `limit`. The runtime ships
+            ;; only what the page needs — not the whole history.
+            form (str "(let [hist (vec (re-frame-pair2.runtime/epoch-history"
+                      (or frame-form "") "))"
+                      " after-id " (pr-str after-id)
+                      " aged-out? (and after-id (not-any? #(= after-id (:epoch-id %)) hist))"
+                      " sliced (if aged-out? []"
+                      "          (if after-id"
+                      "            (vec (rest (drop-while #(not= after-id (:epoch-id %)) hist)))"
+                      "            hist))"
+                      " filtered (filterv #(and (>= (or (:committed-at %) 0) " cutoff-ms ")"
+                      "                         (<= (or (:committed-at %) 0) " until-ms "))"
+                      "                   sliced)"
+                      " page (vec (take " limit " filtered))"
+                      " next-id (when (< (count page) (count filtered))"
+                      "           (:epoch-id (last page)))]"
+                      " {:epochs page"
+                      "  :id-aged-out? aged-out?"
+                      "  :requested-id after-id"
+                      "  :head-id (some-> hist peek :epoch-id)"
+                      "  :next-id next-id"
+                      "  :remaining (max 0 (- (count filtered) (count page)))})")]
+        (-> (ensure-runtime! conn build-id)
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+            (.then
+              (fn [v]
+                (let [v             (if (map? v) v {})
+                      aged-out?     (:id-aged-out? v)
+                      raw-epochs    (vec (:epochs v))]
+                  (if aged-out?
+                    (cursor-stale-result "trace-window"
+                                         {:requested-id (:requested-id v)
+                                          :head-id      (:head-id v)})
+                    (let [[kept dropped] (strip-sensitive raw-epochs incl?)
+                          encoded        (diff-encode-epochs kept mode)
+                          deduped        (dedup-value encoded dedup?)
+                          next-id        (:next-id v)
+                          next-cursor    (encode-cursor
+                                           (when next-id
+                                             {:v        1
+                                              :after-id next-id
+                                              :ms       window-ms
+                                              :until-ms until-ms
+                                              :frame    sticky-frame}))
+                          has-more?      (some? next-cursor)
+                          remaining      (or (:remaining v) 0)]
+                      (ok-text (cond-> {:ok?         true
+                                        :window-ms   window-ms
+                                        :until-ms    until-ms
+                                        :count       (count encoded)
+                                        :limit       limit
+                                        :epochs-mode mode
+                                        :dedup       dedup?
+                                        :epochs      deduped
+                                        :has-more?   has-more?
+                                        :estimated-remaining remaining
+                                        :next-cursor next-cursor}
+                                 (pos? dropped) (assoc :dropped-sensitive dropped))))))))
+            (.catch (fn [err] (err->result :trace-failed err))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Tool: watch-epochs — pull-mode polling with predicate filter.
@@ -870,6 +1060,13 @@
 ;; The bash version streams via repeated `emit`s on stdout. MCP tools
 ;; aren't streaming — we return one bundle of matches per call. Callers
 ;; that want a tight loop call us repeatedly with the same `since-id`.
+;;
+;; Cursor pagination (rf2-kbqq3): a single poll's matches vector is
+;; bounded by `:limit` (default 50). When more matches remain in the
+;; current ring, `:next-cursor` rides the response — the agent calls
+;; back with the cursor to consume the remainder. The cursor is the
+;; opaque sibling of the `:since-id` arg; both can be used, but
+;; `:cursor` takes precedence (it carries sticky pred/frame state).
 ;; ---------------------------------------------------------------------------
 
 (defn- watch-epochs-tool [conn args]
@@ -879,30 +1076,69 @@
         incl?     (include-sensitive? args)
         mode      (parse-epochs-mode (arg args :epochs-mode))
         dedup?    (parse-dedup-arg (arg args :dedup))
+        limit     (parse-limit-arg (arg args :limit))
         pred-map  (when-let [p (arg args :pred)] (js->clj p :keywordize-keys true))
-        frame-arg (if frame (str " " (pr-str frame)) "")
-        form      (str "(let [r (re-frame-pair2.runtime/epochs-since "
-                       (pr-str since-id) frame-arg ")"
-                       "      matches (filterv #(re-frame-pair2.runtime/epoch-matches? "
-                       (pr-str (or pred-map {})) " %) (:epochs r))]"
-                       "  {:matches matches"
-                       "   :id-aged-out? (:id-aged-out? r)"
-                       "   :head-id (:head-id r)})")]
-    (-> (ensure-runtime! conn build-id)
-        (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-        (.then (fn [v]
-                 (let [matches        (when (map? v) (:matches v))
-                       [kept dropped] (strip-sensitive (vec matches) incl?)
-                       encoded        (diff-encode-epochs kept mode)
-                       deduped        (dedup-value encoded dedup?)
-                       base           (cond-> {:ok? true}
-                                        (map? v) (merge v))]
-                   (ok-text (cond-> (assoc base
-                                           :matches deduped
-                                           :epochs-mode mode
-                                           :dedup dedup?)
-                              (pos? dropped) (assoc :dropped-sensitive dropped))))))
-        (.catch (fn [err] (err->result :watch-failed err))))))
+        cursor-in (decode-cursor (arg args :cursor))]
+    (if (= cursor-in ::malformed)
+      (js/Promise.resolve
+        (cursor-stale-result "watch-epochs" {:requested-id nil}))
+      (let [;; Cursor's :after-id overrides bare :since-id when both
+            ;; are supplied. Both shapes share semantics; cursor wins
+            ;; so the agent's continuation flow stays consistent.
+            effective-after (or (:after-id cursor-in) since-id)
+            sticky-frame    (or (:frame cursor-in) frame)
+            frame-arg       (if sticky-frame (str " " (pr-str sticky-frame)) "")
+            form (str "(let [r (re-frame-pair2.runtime/epochs-since "
+                      (pr-str effective-after) frame-arg ")"
+                      "      matches (filterv #(re-frame-pair2.runtime/epoch-matches? "
+                      (pr-str (or pred-map {})) " %) (:epochs r))"
+                      "      page (vec (take " limit " matches))"
+                      "      next-id (when (< (count page) (count matches))"
+                      "                (:epoch-id (last page)))]"
+                      "  {:matches page"
+                      "   :id-aged-out? (:id-aged-out? r)"
+                      "   :requested-id (:requested-id r)"
+                      "   :head-id (:head-id r)"
+                      "   :next-id next-id"
+                      "   :remaining (max 0 (- (count matches) (count page)))})")]
+        (-> (ensure-runtime! conn build-id)
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+            (.then
+              (fn [v]
+                (let [v          (if (map? v) v {})
+                      aged-out?  (:id-aged-out? v)]
+                  (if (and aged-out? (some? effective-after))
+                    (cursor-stale-result "watch-epochs"
+                                         {:requested-id (or (:requested-id v) effective-after)
+                                          :head-id      (:head-id v)})
+                    (let [matches        (vec (:matches v))
+                          [kept dropped] (strip-sensitive matches incl?)
+                          encoded        (diff-encode-epochs kept mode)
+                          deduped        (dedup-value encoded dedup?)
+                          next-id        (:next-id v)
+                          next-cursor    (encode-cursor
+                                           (when next-id
+                                             {:v        1
+                                              :after-id next-id
+                                              :ms       nil
+                                              :until-ms nil
+                                              :frame    sticky-frame}))
+                          remaining      (or (:remaining v) 0)
+                          base           (cond-> {:ok?           true
+                                                  :head-id       (:head-id v)
+                                                  :id-aged-out?  (boolean aged-out?)}
+                                           (:requested-id v) (assoc :requested-id (:requested-id v)))]
+                      (ok-text (cond-> (assoc base
+                                              :matches             deduped
+                                              :limit               limit
+                                              :count               (count encoded)
+                                              :epochs-mode         mode
+                                              :dedup               dedup?
+                                              :has-more?           (some? next-cursor)
+                                              :estimated-remaining remaining
+                                              :next-cursor         next-cursor)
+                                 (pos? dropped) (assoc :dropped-sensitive dropped))))))))
+            (.catch (fn [err] (err->result :watch-failed err))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Tool: tail-build — wait for hot-reload to land.
@@ -1829,6 +2065,31 @@
                      "replaced with an `{:rf.mcp/overflow ...}` "
                      "marker. Pass 0 to disable the cap.")})
 
+(def ^:private limit-property
+  "Per-tool descriptor slot for the `:limit` cursor-pagination knob
+  (rf2-kbqq3). Applied to surfaces that ship epoch vectors and would
+  otherwise blow the wire-cap on a single call: `trace-window` and
+  `watch-epochs`. Default 50 — sized to fit the 5K-token cap after
+  diff-encode (rf2-1wdzp) + dedup (rf2-obpa9)."
+  {:type        "integer"
+   :description (str "Maximum number of epoch records in the response "
+                     "(default 50). The default is sized to fit the "
+                     "5K-token wire-cap (rf2-rvyzy) with diff-encode + "
+                     "dedup active. When more records remain, "
+                     "`:next-cursor` is non-nil and `:has-more? true`; "
+                     "pass the cursor back to fetch the next page.")})
+
+(def ^:private cursor-property
+  "Per-tool descriptor slot for the opaque `:cursor` continuation token
+  (rf2-kbqq3). Applied to `trace-window` and `watch-epochs`."
+  {:type        "string"
+   :description (str "Opaque cursor returned by a previous call's "
+                     "`:next-cursor`. Pass back verbatim to fetch the "
+                     "next page. A cursor whose epoch-id has aged out "
+                     "of the runtime ring surfaces as "
+                     "`{:ok? false :reason :rf.mcp/cursor-stale ...}` — "
+                     "drop the cursor and restart, or widen the window.")})
+
 (def ^:private dedup-property
   "Per-tool descriptor slot for the `:dedup` opt-out (rf2-obpa9).
   Applied to surfaces that ship epoch slices (`snapshot`,
@@ -1915,10 +2176,17 @@
                       "— pass `epochs-mode \"full\"` for the legacy full-pair shape (needed for time-travel restore). "
                       "The epoch vector is structurally deduped by default (rf2-obpa9) — repeated subtrees "
                       "(notably the per-record `:db-before` reference) collapse to a `{:rf.mcp/dedup-table ...}` "
-                      "wrapper; the agent host calls `(de-dupe.core/expand cache)` to reconstruct. Pass `dedup false` to skip.")
+                      "wrapper; the agent host calls `(de-dupe.core/expand cache)` to reconstruct. Pass `dedup false` to skip. "
+                      "Cursor pagination (rf2-kbqq3): the response is bounded at `:limit` records (default 50). "
+                      "When more remain, `:next-cursor` carries an opaque continuation token and `:has-more? true`; "
+                      "pass `cursor` back on the next call to resume. The window's upper bound is sticky across "
+                      "pages — fresh epochs landing during pagination don't sneak in mid-iteration. A cursor "
+                      "whose epoch-id has aged out of the runtime ring surfaces as `:reason :rf.mcp/cursor-stale`.")
     :inputSchema {:type "object"
-                  :properties {:ms    {:type "integer" :description "Window size in milliseconds (default 1000)"}
+                  :properties {:ms    {:type "integer" :description "Window size in milliseconds (default 1000). Sticky across pagination — encoded into the cursor on the first call."}
                                :frame {:type "string"}
+                               :limit limit-property
+                               :cursor cursor-property
                                :epochs-mode {:type "string"
                                              :description "How :db-after rides the wire: \"diff\" (default, intra-record structural diff against :db-before) or \"full\" (legacy full snapshot, opt-in for time-travel)."
                                              :enum ["diff" "full"]}
@@ -1934,11 +2202,18 @@
                       "default-drops items carrying `:sensitive? true`; opt back in with `include-sensitive? true`. "
                       "Each epoch's :db-after is diff-encoded against its own :db-before by default (rf2-1wdzp) "
                       "— pass `epochs-mode \"full\"` for the legacy full-pair shape. "
-                      "The matches vector is structurally deduped by default (rf2-obpa9); pass `dedup false` to skip.")
+                      "The matches vector is structurally deduped by default (rf2-obpa9); pass `dedup false` to skip. "
+                      "Cursor pagination (rf2-kbqq3): the matches vector is bounded at `:limit` (default 50). "
+                      "When more matches remain, `:next-cursor` is non-nil and `:has-more? true`; pass `cursor` "
+                      "back to consume the next page. The `:cursor` arg overrides `:since-id` when both are "
+                      "supplied. A cursor whose epoch-id has aged out of the ring surfaces as "
+                      "`:reason :rf.mcp/cursor-stale`.")
     :inputSchema {:type "object"
-                  :properties {:since-id {:type "string" :description "The last epoch id you've seen (omit to start fresh)"}
+                  :properties {:since-id {:type "string" :description "The last epoch id you've seen (omit to start fresh). Supplanted by :cursor when both are passed."}
                                :pred     {:type "object" :description "Filter map"}
                                :frame    {:type "string"}
+                               :limit    limit-property
+                               :cursor   cursor-property
                                :epochs-mode {:type "string"
                                              :description "How :db-after rides the wire: \"diff\" (default) or \"full\" (legacy, opt-in for time-travel restore)."
                                              :enum ["diff" "full"]}

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/cursor_pagination_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/cursor_pagination_test.cljs
@@ -1,0 +1,316 @@
+(ns re-frame-pair2-mcp.cursor-pagination-test
+  "Unit tests for the cursor-pagination mechanism on `trace-window`
+  and `watch-epochs` (rf2-kbqq3).
+
+  Both tools accept `:limit` (int, default 50) + `:cursor` (opaque
+  string). Responses carry `:next-cursor`, `:has-more?` and
+  `:estimated-remaining`. A cursor whose epoch-id has aged out of the
+  runtime ring surfaces as a `:rf.mcp/cursor-stale` error rather than
+  silently restarting.
+
+  These tests mirror the private helpers from `tools.cljs`
+  (`parse-limit-arg`, `encode-cursor`, `decode-cursor`,
+  `cursor-stale-result`) and exercise the full host-side pagination
+  logic by simulating the runtime form's output. The live runtime
+  call sits behind the nREPL eval boundary and is covered by the
+  stdio-roundtrip harness; this layer pins the cursor contract."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [cljs.reader]
+            [clojure.string :as str]
+            [applied-science.js-interop :as j]))
+
+;; ---------------------------------------------------------------------------
+;; Mirrors of the private cursor helpers. Keep in lockstep with tools.cljs.
+;; ---------------------------------------------------------------------------
+
+(def ^:private default-limit 50)
+
+(defn- parse-limit-arg [raw]
+  (cond
+    (or (nil? raw) (undefined? raw)) default-limit
+    (number? raw) (max 1 (long raw))
+    (string? raw) (let [n (js/parseInt raw 10)]
+                    (if (and (number? n) (not (js/isNaN n)))
+                      (max 1 (long n))
+                      default-limit))
+    :else default-limit))
+
+(defn- encode-cursor [payload]
+  (when (and (map? payload) (some? (:after-id payload)))
+    (let [edn (pr-str payload)
+          buf (js/Buffer.from edn "utf8")]
+      (.toString buf "base64"))))
+
+(defn- decode-cursor [s]
+  (cond
+    (or (nil? s) (undefined? s)) nil
+    (not (string? s)) ::malformed
+    (str/blank? s)    nil
+    :else
+    (try
+      (let [buf (js/Buffer.from s "base64")
+            edn (.toString buf "utf8")
+            v   (cljs.reader/read-string edn)]
+        (if (and (map? v) (string? (:after-id v)))
+          v
+          ::malformed))
+      (catch :default _ ::malformed))))
+
+;; ---------------------------------------------------------------------------
+;; parse-limit-arg — MCP-arg normalisation.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-limit-default-when-absent
+  (is (= default-limit (parse-limit-arg nil)))
+  (is (= default-limit (parse-limit-arg js/undefined))))
+
+(deftest parse-limit-positive-integer-pass-through
+  (is (= 10 (parse-limit-arg 10)))
+  (is (= 1  (parse-limit-arg 1)))
+  (is (= 1000 (parse-limit-arg 1000))))
+
+(deftest parse-limit-clamps-non-positive-to-one
+  (is (= 1 (parse-limit-arg 0)))
+  (is (= 1 (parse-limit-arg -5))))
+
+(deftest parse-limit-parses-numeric-string
+  (is (= 25 (parse-limit-arg "25"))))
+
+(deftest parse-limit-non-numeric-string-falls-back
+  (is (= default-limit (parse-limit-arg "bogus"))))
+
+;; ---------------------------------------------------------------------------
+;; encode-cursor / decode-cursor — opaque round-trip.
+;; ---------------------------------------------------------------------------
+
+(deftest encode-cursor-nil-when-no-after-id
+  (is (nil? (encode-cursor nil)))
+  (is (nil? (encode-cursor {})))
+  (is (nil? (encode-cursor {:v 1 :after-id nil}))))
+
+(deftest encode-cursor-returns-string-on-valid-payload
+  (let [c (encode-cursor {:v 1 :after-id "abc"})]
+    (is (string? c))
+    (is (pos? (count c)))))
+
+(deftest cursor-round-trip-preserves-payload
+  (let [payload {:v 1 :after-id "epoch-42" :ms 5000 :until-ms 1234567890
+                 :frame :rf/default}
+        encoded (encode-cursor payload)
+        decoded (decode-cursor encoded)]
+    (is (= payload decoded))))
+
+(deftest decode-cursor-nil-on-nil-input
+  (is (nil? (decode-cursor nil)))
+  (is (nil? (decode-cursor "")))
+  (is (nil? (decode-cursor js/undefined))))
+
+(deftest decode-cursor-malformed-on-junk
+  (is (= ::malformed (decode-cursor "not-real-base64-edn-juzlblahHFGYbn")))
+  (is (= ::malformed (decode-cursor 12345)))
+  ;; base64 of "not-a-map" — decodes but isn't a map with :after-id
+  (let [bogus (.toString (js/Buffer.from "[1 2 3]" "utf8") "base64")]
+    (is (= ::malformed (decode-cursor bogus)))))
+
+(deftest decode-cursor-malformed-on-missing-after-id
+  (let [bogus (.toString (js/Buffer.from "{:v 1}" "utf8") "base64")]
+    (is (= ::malformed (decode-cursor bogus)))))
+
+(deftest cursor-is-opaque-on-wire
+  ;; The agent has no business decoding the cursor — but the encoding
+  ;; MUST be a self-contained string (no embedded JSON-confusing chars
+  ;; that would break round-trip through bencode + JSON-RPC).
+  (let [c (encode-cursor {:v 1 :after-id "abc-def"})]
+    (is (re-matches #"^[A-Za-z0-9+/=]+$" c))))
+
+;; ---------------------------------------------------------------------------
+;; First-page (no cursor) — the bead's acceptance scenario #1.
+;; ---------------------------------------------------------------------------
+;;
+;; Simulates the host-side post-processing of the runtime form's
+;; return value. The runtime form returns
+;;   {:epochs <slice> :id-aged-out? bool :head-id <id> :next-id <id> :remaining N}
+;; The host wraps that into the final MCP response.
+
+(defn- make-epoch [n]
+  {:epoch-id     (str "epoch-" n)
+   :committed-at (+ 1000000 n)
+   :event-id     :test/ev
+   :db-before    {}
+   :db-after     {}})
+
+(defn- runtime-form-output
+  "Simulate what the inlined eval form in `trace-window-tool` returns
+  after server-side slicing. `history` is the full epoch-history vec
+  for the frame; `after-id` is the cursor's after-id (or nil for the
+  first call); `cutoff-ms`/`until-ms` are the window bounds; `limit`
+  caps the page."
+  [history {:keys [after-id cutoff-ms until-ms limit]}]
+  (let [aged-out? (and after-id (not-any? #(= after-id (:epoch-id %)) history))
+        sliced    (cond
+                    aged-out?    []
+                    after-id     (vec (rest (drop-while #(not= after-id (:epoch-id %))
+                                                        history)))
+                    :else        history)
+        filtered  (filterv #(and (>= (or (:committed-at %) 0) (or cutoff-ms 0))
+                                 (<= (or (:committed-at %) 0) (or until-ms (js/Date.now))))
+                           sliced)
+        page      (vec (take limit filtered))
+        next-id   (when (< (count page) (count filtered))
+                    (:epoch-id (last page)))]
+    {:epochs page
+     :id-aged-out? aged-out?
+     :requested-id after-id
+     :head-id      (some-> history peek :epoch-id)
+     :next-id      next-id
+     :remaining    (max 0 (- (count filtered) (count page)))}))
+
+(deftest first-page-no-cursor-returns-limit-records
+  (let [;; 50-epoch ring; ask for page 1 with limit 10
+        hist (vec (for [n (range 50)] (make-epoch n)))
+        out  (runtime-form-output hist {:after-id nil
+                                        :cutoff-ms 0
+                                        :until-ms 99999999
+                                        :limit 10})]
+    (is (= 10 (count (:epochs out))))
+    (is (false? (boolean (:id-aged-out? out))))
+    (is (= "epoch-9" (:next-id out)))
+    (is (= 40 (:remaining out)))))
+
+(deftest first-page-no-cursor-honours-default-limit
+  ;; 30 epochs, default limit 50 → all 30 fit, no next-id.
+  (let [hist (vec (for [n (range 30)] (make-epoch n)))
+        out  (runtime-form-output hist {:after-id nil
+                                        :cutoff-ms 0
+                                        :until-ms 99999999
+                                        :limit default-limit})]
+    (is (= 30 (count (:epochs out))))
+    (is (nil? (:next-id out)))
+    (is (zero? (:remaining out)))))
+
+;; ---------------------------------------------------------------------------
+;; Second-page (with cursor) — the bead's acceptance scenario #2.
+;; ---------------------------------------------------------------------------
+
+(deftest second-page-with-cursor-resumes-after-watermark
+  (let [hist (vec (for [n (range 50)] (make-epoch n)))
+        ;; First call: limit 10 ⇒ next-id "epoch-9"
+        page-1 (runtime-form-output hist {:after-id nil
+                                          :cutoff-ms 0
+                                          :until-ms 99999999
+                                          :limit 10})
+        ;; Cursor encodes "epoch-9"
+        cursor (encode-cursor {:v 1 :after-id (:next-id page-1)
+                               :until-ms 99999999 :ms nil :frame nil})
+        decoded (decode-cursor cursor)
+        ;; Second call resumes after "epoch-9"
+        page-2 (runtime-form-output hist {:after-id (:after-id decoded)
+                                          :cutoff-ms 0
+                                          :until-ms 99999999
+                                          :limit 10})]
+    (is (= 10 (count (:epochs page-2))))
+    (is (= "epoch-10" (-> page-2 :epochs first :epoch-id)))
+    (is (= "epoch-19" (-> page-2 :epochs last :epoch-id)))
+    (is (= "epoch-19" (:next-id page-2)))
+    (is (= 30 (:remaining page-2)))))
+
+(deftest five-page-walk-over-50-epoch-ring-returns-distinct-records-in-order
+  ;; Bead acceptance: "50-epoch ring; pagination over 5 batches returns
+  ;; 50 distinct records in order."
+  (let [hist (vec (for [n (range 50)] (make-epoch n)))
+        walk (loop [cursor   nil
+                    pages    []
+                    safety   10]
+               (if (zero? safety)
+                 pages
+                 (let [decoded (decode-cursor cursor)
+                       after-id (:after-id decoded)
+                       out (runtime-form-output hist {:after-id after-id
+                                                      :cutoff-ms 0
+                                                      :until-ms 99999999
+                                                      :limit 10})
+                       pages' (conj pages (:epochs out))]
+                   (if-let [next-id (:next-id out)]
+                     (recur (encode-cursor {:v 1 :after-id next-id
+                                            :until-ms 99999999 :ms nil :frame nil})
+                            pages'
+                            (dec safety))
+                     pages'))))
+        all-records (vec (mapcat identity walk))]
+    (is (= 5 (count walk))
+        "Exactly 5 pages of 10")
+    (is (= 50 (count all-records))
+        "50 records walked total")
+    (is (apply distinct? (map :epoch-id all-records))
+        "All epoch-ids distinct")
+    (is (= (map :epoch-id hist) (map :epoch-id all-records))
+        "Records returned in original order")))
+
+;; ---------------------------------------------------------------------------
+;; Stale cursor — the bead's acceptance scenario #3.
+;; ---------------------------------------------------------------------------
+
+(deftest stale-cursor-trips-id-aged-out
+  ;; Cursor references "epoch-99" but the ring only has "epoch-0".."epoch-49".
+  (let [hist (vec (for [n (range 50)] (make-epoch n)))
+        out  (runtime-form-output hist {:after-id "epoch-99"
+                                        :cutoff-ms 0
+                                        :until-ms 99999999
+                                        :limit 10})]
+    (is (true? (boolean (:id-aged-out? out))))
+    (is (empty? (:epochs out)))
+    (is (nil? (:next-id out)))))
+
+(deftest stale-cursor-also-detected-after-buffer-rotation
+  ;; Initial ring has "epoch-0".."epoch-9"; agent gets cursor pointing
+  ;; at "epoch-5". Buffer then rotates so head moves to "epoch-100";
+  ;; "epoch-5" no longer present.
+  (let [hist-old (vec (for [n (range 10)] (make-epoch n)))
+        first-page (runtime-form-output hist-old {:after-id nil
+                                                  :cutoff-ms 0
+                                                  :until-ms 99999999
+                                                  :limit 5})
+        next-id (:next-id first-page)
+        ;; Ring rotates — old epochs gone, new ones in.
+        hist-new (vec (for [n (range 100 110)] (make-epoch n)))
+        page-2 (runtime-form-output hist-new {:after-id next-id
+                                              :cutoff-ms 0
+                                              :until-ms 99999999
+                                              :limit 5})]
+    (is (= "epoch-4" next-id))
+    (is (true? (boolean (:id-aged-out? page-2))))
+    (is (empty? (:epochs page-2)))))
+
+(deftest malformed-cursor-decodes-as-malformed-sentinel
+  ;; Caller passes garbage. Host translates ::malformed to the same
+  ;; :rf.mcp/cursor-stale error path as a true age-out.
+  (is (= ::malformed (decode-cursor "not-base64-edn")))
+  (is (= ::malformed (decode-cursor "AAAA"))))
+
+;; ---------------------------------------------------------------------------
+;; Sticky window — fresh epochs don't sneak in mid-iteration.
+;; ---------------------------------------------------------------------------
+
+(deftest sticky-until-ms-bounds-window-across-pages
+  ;; Page 1 fetches at time T; new epochs land BEFORE page 2 fetches.
+  ;; The cursor's `:until-ms` clamps the second page to the original T.
+  (let [hist-t1   (vec (for [n (range 50)] (make-epoch n)))
+        ;; At time T1, until-ms = max committed-at = 1000049
+        until-t1  1000049
+        page-1    (runtime-form-output hist-t1 {:after-id nil
+                                                :cutoff-ms 0
+                                                :until-ms until-t1
+                                                :limit 10})
+        ;; History grows with 5 fresh epochs while agent is thinking.
+        hist-t2   (into hist-t1 (for [n (range 100 105)] (make-epoch n)))
+        ;; Second call passes the SAME until-ms (sticky from cursor).
+        page-2    (runtime-form-output hist-t2 {:after-id (:next-id page-1)
+                                                :cutoff-ms 0
+                                                :until-ms until-t1
+                                                :limit 100})
+        all-ids   (set (map :epoch-id (concat (:epochs page-1) (:epochs page-2))))]
+    (is (not (contains? all-ids "epoch-100"))
+        "Fresh epochs landing after first call's clock don't appear in page 2")
+    (is (not (contains? all-ids "epoch-104")))
+    (is (= 50 (count all-ids))
+        "Page 1 + page 2 = original 50 records, no admission of fresh ones")))


### PR DESCRIPTION
## Summary

Closes rf2-kbqq3.

Both `trace-window` and `watch-epochs` now accept `:limit` (int,
default 50) and `:cursor` (opaque continuation token). Responses carry
`:next-cursor`, `:has-more?`, and `:estimated-remaining`.

- **Default `:limit` 50** — sized to fit the 5K-token wire-cap after
  diff-encode (rf2-1wdzp) and dedup (rf2-obpa9) shrink each record.
- **Opaque cursor** — base64-encoded EDN payload carrying the
  last-emitted epoch-id plus sticky window state (`:ms`, `:until-ms`,
  `:frame`). Agents pass it back verbatim; the format can evolve
  behind the opaque boundary.
- **Sticky window** — the cursor encodes `:until-ms` on the first
  call so subsequent pages see the same window. Fresh epochs landing
  during pagination don't sneak in mid-iteration.
- **Cursor-stale error** — a cursor whose epoch-id has aged out of
  the runtime ring (or is malformed) surfaces as
  `{:ok? false :reason :rf.mcp/cursor-stale ...}` rather than
  silently restarting. Agents pattern-match and either drop the
  cursor or widen the window.
- **No runtime changes** — pagination is host-side over the existing
  `epochs-since` / `epoch-history` surfaces. The inline eval form
  does server-side slicing so only the page itself crosses the wire.

## Test plan

- [x] 19 new cljs unit tests in `cursor_pagination_test.cljs`:
  - `parse-limit-arg` boundary cases (default, clamp, parse-string)
  - cursor round-trip (`encode-cursor` -> `decode-cursor`)
  - malformed-cursor decode → `::malformed` sentinel
  - first-page-no-cursor returns at most `:limit` records
  - second-page-with-cursor resumes after the watermark
  - **bead acceptance**: 50-epoch ring, 5 batches of 10 → 50 distinct
    records in order
  - stale-cursor age-out (both "id never existed" and "buffer rotated
    past id" forms)
  - sticky `:until-ms` discipline: fresh epochs landing after first
    call don't appear in page 2
- [x] All 212 tests pass (`npm test`)
- [x] Production server builds clean (`npm run build`)
- [x] stdio-roundtrip integration test green