### PR TITLE
spec(causa-mcp): align elision vocab to :rf.size/large-elided (rf2-04ozp)

### DIFF
--- a/tools/causa-mcp/spec/Principles.md
+++ b/tools/causa-mcp/spec/Principles.md
@@ -416,13 +416,18 @@ The `subscribe` stream returns one event per JSON-RPC
 per notification; the agent host meters consumption. A
 `subscribe` topic whose individual events can exceed the cap
 (a trace event with a large coeffect payload) MUST attach a
-server-side trimmer (drop the heavy fields, attach an
-`:elided [:cofx :db]` marker, surface a follow-up
-`get-trace-buffer` cursor). Mechanisms 1, 4, and 5 apply
-per-notification; mechanisms 2 and 3 are inapplicable inside a
-single notification but DO apply to the `subscribe` call's own
-arguments (e.g., a `:path` filter on the topic, a `:limit` on
-total notifications before auto-unsubscribe).
+server-side trimmer (drop the heavy fields, substitute the
+canonical `:rf.size/large-elided` marker at the elided slot —
+body shape per
+[spec/Spec-Schemas §`:rf/elision-marker`](../../../spec/Spec-Schemas.md#rfelision-marker),
+fetch-handle `[:rf.elision/at <path>]` per
+[pair2-mcp Principles §"Size-elision wire markers"](../../pair2-mcp/spec/Principles.md#size-elision-wire-markers-rf2-urjnc) —
+and surface a follow-up `get-trace-buffer` cursor).
+Mechanisms 1, 4, and 5 apply per-notification; mechanisms 2 and
+3 are inapplicable inside a single notification but DO apply to
+the `subscribe` call's own arguments (e.g., a `:path` filter on
+the topic, a `:limit` on total notifications before
+auto-unsubscribe).
 
 ## Backed by Causa's and the framework's principles
 

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -340,17 +340,12 @@
 
    {:key      :rf.size/large-elided
     :schema   ElisionMarker
-    ;; Reserved by Conventions / spec; pair2-mcp emits today.
-    ;;
-    ;; causa-mcp's spec currently mentions elision under an ad-hoc
-    ;; `:elided [:cofx :db]` shape (tools/causa-mcp/spec/Principles.md
-    ;; line 420) — a vocabulary-drift discovered by rf2-j2z7o's
-    ;; conformance run. Tracked for fix under rf2-04ozp; until that
-    ;; lands, only :pair2-mcp is in `:servers`. The schema and the
-    ;; cross-MCP-fixture story still apply (two fixtures below
-    ;; representing two distinct emission shapes — declared/string
-    ;; vs runtime-flagged/map-with-digest).
-    :servers  #{:pair2-mcp}
+    ;; Reserved by Conventions / spec; pair2-mcp emits today and
+    ;; causa-mcp's Principles cross-links the canonical shape from
+    ;; its §"Streaming over batch" trimmer. Two fixtures below
+    ;; represent two distinct emission shapes — declared/string vs
+    ;; runtime-flagged/map-with-digest.
+    :servers  #{:pair2-mcp :causa-mcp}
     :fixtures {:pair2-mcp-declared
                {:rf.size/large-elided
                 {:path   [:user :uploaded-pdf]


### PR DESCRIPTION
## Summary

Replaces the ad-hoc `:elided [:cofx :db]` marker in
`tools/causa-mcp/spec/Principles.md` §"Streaming over batch" with the
canonical `:rf.size/large-elided` wire marker reserved by
`spec/Conventions.md` and shape-specified at `spec/Spec-Schemas.md`
§`:rf/elision-marker`. Cross-links the canonical fetch-handle
`[:rf.elision/at <path>]` and pair2-mcp's §"Size-elision wire markers"
so a causa-mcp implementer lands on the framework shape, not a
near-miss.

Re-adds `:causa-mcp` to the `:rf.size/large-elided` marker's
`:servers` set in the cross-MCP wire-vocab conformance test
(`tools/mcp-conformance/wire-vocab/`) and drops the pointer comment to
this bead — the test now gates causa-mcp's spec alongside pair2-mcp's
source for that marker.

## Test plan

- [x] `clojure -M:test` from `tools/mcp-conformance/wire-vocab/` —
      6 tests / 142 assertions, 0 failures, 0 errors.

## Stacked on

This PR targets `agent/rf2-j2z7o` (PR #707) because the wire-vocab
test it edits ships in that PR. Merge order: #707 first, then this.