### PR TITLE
feat(runtime): expose public sensitive? predicate (rf2-sqxjn)

### DIFF
--- a/implementation/core/test/re_frame/sensitive_stamping_test.clj
+++ b/implementation/core/test/re_frame/sensitive_stamping_test.clj
@@ -490,7 +490,7 @@
 (deftest sensitive-predicate
   (testing "rf/sensitive? returns true on top-level-stamped events,
    false otherwise — replaces the per-consumer private helper (rf2-isdwf
-   audit G5)"
+   audit G5; consumer-side dedup landed in rf2-sqxjn)"
     (is (true?  (rf/sensitive? {:sensitive? true})))
     (is (false? (rf/sensitive? {:sensitive? false})))
     (is (false? (rf/sensitive? {})))
@@ -498,7 +498,10 @@
     (is (false? (rf/sensitive? "not a map")))
     (is (false? (rf/sensitive? {:tags {:sensitive? true}}))
         "nested :sensitive? inside :tags does NOT count — only the
-         top-level field per Spec 009 line 1175")))
+         top-level field per Spec 009 line 1175"))
+  (testing "rf/sensitive? and re-frame.trace/sensitive? are the same fn
+   — re-frame.core re-exports from re-frame.trace via (def ...) (rf2-sqxjn)"
+    (is (identical? rf/sensitive? trace/sensitive?))))
 
 ;; ---- composition with wire-elision walker --------------------------------
 

--- a/spec/API.md
+++ b/spec/API.md
@@ -432,6 +432,15 @@ Errors are emitted as structured trace events with `:op-type :error` (or `:warni
 
 Per-Spec emit-sites: [002-Frames](002-Frames.md), [005-StateMachines](005-StateMachines.md), [006-ReactiveSubstrate](006-ReactiveSubstrate.md), [010-Schemas](010-Schemas.md), [011-SSR](011-SSR.md), [012-Routing](012-Routing.md), [013-Flows](013-Flows.md), [014-HTTPRequests](014-HTTPRequests.md), [Tool-Pair](Tool-Pair.md). Each catalogue row's "Per [N]" cross-link names the owning Spec section.
 
+### Privacy (Spec 009 §Privacy / sensitive data in traces)
+
+Per [Spec 009 §Privacy](009-Instrumentation.md) the runtime stamps `:sensitive? true` at the top level of every trace event emitted inside the scope of a registration declared `:sensitive? true`. Framework-published trace consumers (Sentry/Honeybadger forwarders, pair2 server, Causa, Story, story-mcp, pair2-mcp, causa-mcp) MUST default-drop the stamped events at their egress boundary. `with-redacted` is the in-place payload scrub composed alongside the stamp.
+
+| API | M/Fn | Signature | Status | Spec |
+|---|---|---|---|---|
+| `sensitive?` | Fn | `(sensitive? trace-event)` → `boolean`. True iff `trace-event` is a map carrying `:sensitive? true` at the top level (not under `:tags`). The framework-published predicate every consumer composes against — replaces per-consumer reimplementations of the same five-token check (rf2-sqxjn). | v1 | 009 |
+| `with-redacted` | Fn | `(with-redacted paths)` → interceptor. Build a positional interceptor that overwrites the named keys in the event vector's payload map with the `:rf/redacted` sentinel before the handler chain runs. The handler body itself sees the UNREDACTED payload via the regular `:event` coeffect slot; the redaction is for the trace surface only. `paths` is a vector of `get-in`-style key paths into the payload map. | v1 | 009 |
+
 ---
 
 ## Spec-internal schemas

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -24,6 +24,7 @@
   atom survives but is never read. CLJC so the JVM test corpus can
   cover the round-trip without a CLJS runtime."
   (:require [re-frame.source-coords.editor-uri :as editor-uri]
+            [re-frame.trace :as trace]
             #?@(:cljs [[re-frame.core :as rf]
                        [re-frame.frame :as frame]])))
 
@@ -104,12 +105,13 @@
 
 (defn sensitive-event?
   "True iff the trace event `ev` carries `:sensitive? true` at the top
-  level. Per Spec 009 §Privacy + §Listener filtering semantics — the
-  framework stamps `:sensitive? true` on every trace event emitted
-  inside a registration that opted in, and consumers branch on this
-  flag. Absent/false means non-sensitive."
+  level. Thin alias over the framework-published `re-frame.trace/sensitive?`
+  predicate (re-exported as `re-frame.core/sensitive?`) — per rf2-sqxjn,
+  every consumer of `:sensitive?` (Causa, Story, story-mcp, pair2-mcp,
+  causa-mcp) composes against ONE framework primitive rather than
+  reimplementing the five-token check. Per Spec 009 §Privacy."
   [ev]
-  (boolean (and (map? ev) (= true (:sensitive? ev)))))
+  (trace/sensitive? ev))
 
 (defn suppress-sensitive?
   "Should this trace event be suppressed by Causa's trace collector

--- a/tools/story-mcp/src/re_frame/story_mcp/sensitive.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/sensitive.cljc
@@ -52,17 +52,22 @@
                              (pos? dropped) (assoc :dropped-sensitive dropped))]
           (text-result (pr-edn payload) payload)))))
   ```"
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [re-frame.trace :as trace]))
 
 (defn sensitive-event?
-  "Does this event carry the top-level `:sensitive? true` stamp? The
-  filter is conservative — only the literal `true` value drops; any
-  other value (including a possible string-coercion via an ill-behaved
-  transport) passes through. The `:rf/trace-event` schema types
-  `:sensitive?` as a boolean (per spec/009 + spec/Spec-Schemas)."
+  "Does this event carry the top-level `:sensitive? true` stamp? Thin
+  alias over the framework-published `re-frame.trace/sensitive?`
+  predicate (re-exported as `re-frame.core/sensitive?`) — per rf2-sqxjn,
+  every consumer of `:sensitive?` (Causa, Story, story-mcp, pair2-mcp,
+  causa-mcp) composes against ONE framework primitive rather than
+  reimplementing the five-token check. The filter is conservative —
+  only the literal `true` value drops; any other value (including a
+  possible string-coercion via an ill-behaved transport) passes through.
+  The `:rf/trace-event` schema types `:sensitive?` as a boolean (per
+  spec/009 + spec/Spec-Schemas)."
   [ev]
-  (and (map? ev)
-       (true? (:sensitive? ev))))
+  (trace/sensitive? ev))
 
 (defn strip-sensitive
   "Remove `:sensitive? true` events from `events` unless the caller has

--- a/tools/story/src/re_frame/story/config.cljc
+++ b/tools/story/src/re_frame/story/config.cljc
@@ -29,6 +29,7 @@
   true (the registration call); to `nil` when false. Production code
   that accidentally requires a stories ns sees the namespace load but
   with no registrations, every Story query returns empty."
+  (:require [re-frame.trace :as trace])
   #?(:cljs (:require-macros [re-frame.story.config])))
 
 ;; ---- the compile-time flag -----------------------------------------------
@@ -213,12 +214,13 @@
 
 (defn sensitive-event?
   "True iff the trace event `ev` carries `:sensitive? true` at the top
-  level. Per Spec 009 §Privacy + §Listener filtering semantics — the
-  framework stamps `:sensitive? true` on every trace event emitted
-  inside a registration that opted in, and consumers branch on this
-  flag. Absent/false means non-sensitive."
+  level. Thin alias over the framework-published `re-frame.trace/sensitive?`
+  predicate (re-exported as `re-frame.core/sensitive?`) — per rf2-sqxjn,
+  every consumer of `:sensitive?` (Causa, Story, story-mcp, pair2-mcp,
+  causa-mcp) composes against ONE framework primitive rather than
+  reimplementing the five-token check. Per Spec 009 §Privacy."
   [ev]
-  (boolean (and (map? ev) (= true (:sensitive? ev)))))
+  (trace/sensitive? ev))
 
 (defn suppress-sensitive?
   "Should this trace event be suppressed by a Story-registered


### PR DESCRIPTION
## Summary

- The framework already publishes `re-frame.core/sensitive?` (re-exported from `re-frame.trace`), but every trace consumer in the repo was still reimplementing the same five-token `(and (map? ev) (true? (:sensitive? ev)))` check as a private helper. Per the rf2-isdwf §G5 audit finding, the framework predicate exists so consumers can compose against ONE line.
- Dedupe three consumer-side copies (Causa, Story, story-mcp) — each artefact's local `sensitive-event?` collapses to a one-line delegate over `re-frame.trace/sensitive?`, preserving the existing public name + tests but removing the body duplication and the drift risk if the spec ever extends the predicate (e.g. a future `:rf.privacy/*` axis).
- Document the predicate (plus the long-undocumented `with-redacted` interceptor) under a new "Privacy" heading in spec/API.md.

## What stays

- **pair2-mcp** keeps its private `sensitive-event?`. Per `tools/pair2-mcp/deps.edn`'s bundle-isolation contract, that artefact has no \`:local/root\` dep on \`implementation/\` and so \`re-frame.trace\` is not on its classpath. Nothing to delegate to.

## Test plan

- [x] \`clojure -M:test\` from \`implementation/core/\` — 412 tests, 2189 assertions, 0 failures (includes \`sensitive-stamping-test/sensitive-predicate\` which now asserts \`(identical? rf/sensitive? trace/sensitive?)\`).
- [x] \`clojure -M:test\` from \`tools/causa/\` — 487 tests, 1349 assertions, 0 failures.
- [x] \`clojure -M:test\` from \`tools/story/\` — 275 tests, 772 assertions, 0 failures.
- [x] \`clojure -M:test\` from \`tools/story-mcp/\` — 80 tests, 326 assertions, 0 failures.
- [x] \`npm run test:cljs\` from \`implementation/\` — 1688 tests, 4680 assertions, 0 failures.

Closes rf2-sqxjn.