### PR TITLE
test(ssr): per-request frame teardown audit + memory-leak load test (rf2-fcj33)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -355,6 +355,24 @@
     7. unregister-frame!            — drop from the registrar.
     8. notify-epoch-listeners!      — fire the rf2-d656 epoch hook.
 
+  Two cleanup hooks fire between step 4 and step 5 — both are best-
+  effort and tolerate the hook artefact being absent at runtime:
+
+    :privacy/clear-suppression-cache!   — rf2-isdwf, reset the warn-once
+                                          cache so a re-registered frame
+                                          re-emits the sensitive-without-
+                                          redaction warning if mis-config.
+    :ssr/on-frame-destroyed             — rf2-fcj33, drop the SSR
+                                          side-channel atoms' entries
+                                          for the destroyed frame
+                                          (pending-error-traces +
+                                          request-slots). Without this
+                                          hook those two defonce atoms
+                                          accumulate one entry per
+                                          request under SSR load — a
+                                          slow leak that compounds over
+                                          a long-running server process.
+
   Subsequent dispatch / subscribe against a destroyed frame raises
   :rf.error/frame-destroyed."
   [id]
@@ -371,6 +389,18 @@
     ;; table; no-op when re-frame.privacy hasn't been loaded.
     (when-let [clear-cache! (late-bind/get-fn :privacy/clear-suppression-cache!)]
       (try (clear-cache!)
+           (catch #?(:clj Throwable :cljs :default) _ nil)))
+    ;; Per rf2-fcj33 / Spec 011 §Per-request frame teardown contract:
+    ;; clear the SSR side-channel atoms (pending-error-traces +
+    ;; request-slots) for the destroyed frame. Both live outside app-db
+    ;; for documented design reasons (the buffered-traces sidestep an
+    ;; app-db clobber race; the request slot keeps host-controlled
+    ;; data out of the hydration payload). Neither is otherwise cleared
+    ;; by destroy-frame's app-db / sub-cache teardown, so under SSR
+    ;; load each request would leak one entry in each atom. Late-bound
+    ;; through the hook table; no-op when re-frame.ssr is absent.
+    (when-let [ssr-cleanup! (late-bind/get-fn :ssr/on-frame-destroyed)]
+      (try (ssr-cleanup! id)
            (catch #?(:clj Throwable :cljs :default) _ nil)))
     (emit-frame-destroyed-trace! id)
     (dissoc-frame! id)

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -275,6 +275,10 @@
    {:key         :ssr/project-error
     :producer-ns 're-frame.ssr
     :description "Apply the registered error-projector to an SSR render error."}
+   {:key         :ssr/on-frame-destroyed
+    :producer-ns 're-frame.ssr
+    :design-bead "rf2-fcj33"
+    :description "Clear the SSR side-channel atoms (pending-error-traces + request-slots) for a destroyed frame, per Spec 011 §Per-request frame teardown contract."}
 
    ;; ---- re-frame.adapter.reagent (rf2-0hxm) ---------------------------------
    {:key         :reagent/set-hiccup-emitter!

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -1131,6 +1131,34 @@ response with no body."
   (swap! request-slots dissoc frame-id)
   frame-id)
 
+;; ---- per-request frame teardown (rf2-fcj33) -------------------------------
+;;
+;; Per Spec 011 §Per-request frame teardown contract. The SSR runtime owns
+;; two side-channel `defonce` atoms keyed by frame-id — `pending-error-
+;; traces` (per-frame buffer of captured error trace events) and
+;; `request-slots` (per-frame HTTP-request map). Both live outside app-db
+;; (see the rationale comments above each defonce) and so are NOT cleared
+;; by the frame's app-db / sub-cache teardown in `frame/destroy-frame!`.
+;;
+;; This fn is the cleanup hook. Wired into `frame/destroy-frame!` via the
+;; `:ssr/on-frame-destroyed` late-bind key — `core` calls it from its
+;; ordered teardown step list when the SSR artefact is on the classpath;
+;; the hook resolves to nil and the destroy proceeds without it when the
+;; SSR artefact is absent. Idempotent: tolerates a frame-id with no slot
+;; in either atom.
+
+(defn on-frame-destroyed!
+  "Per Spec 011 §Per-request frame teardown contract (rf2-fcj33). Drop
+  the per-frame entries in `pending-error-traces` and `request-slots`
+  for `frame-id`. Called from `frame/destroy-frame!` via the
+  `:ssr/on-frame-destroyed` late-bind hook. Idempotent — a second call
+  against the same frame-id sees both atoms already cleared and does
+  nothing."
+  [frame-id]
+  (swap! pending-error-traces dissoc frame-id)
+  (swap! request-slots        dissoc frame-id)
+  nil)
+
 (cofx/reg-cofx :rf.server/request
   {:doc       "The active HTTP request. Server only. Surfaces the
 host-supplied request map (Ring shape under rf2-ny6v7's Ring adapter;
@@ -1172,3 +1200,9 @@ Per Spec 011 §Server-only `reg-cofx` for request context."
 (late-bind/set-fn! :ssr/render-to-string    render-to-string)
 (late-bind/set-fn! :ssr/reg-error-projector reg-error-projector)
 (late-bind/set-fn! :ssr/project-error       project-error)
+;; rf2-fcj33 — per-request frame teardown. `frame/destroy-frame!` looks up
+;; this hook and clears the SSR side-channel atoms (`pending-error-traces`,
+;; `request-slots`) for the destroyed frame. Without this hook, those two
+;; defonce-atoms accumulate one entry per request under SSR load — a slow
+;; leak that compounds over a long-running server process.
+(late-bind/set-fn! :ssr/on-frame-destroyed  on-frame-destroyed!)

--- a/implementation/ssr/test/re_frame/ssr_teardown_load_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_teardown_load_test.clj
@@ -1,0 +1,275 @@
+(ns re-frame.ssr-teardown-load-test
+  "Per-request SSR frame teardown — load + memory-hygiene audit (rf2-fcj33).
+
+  Background. A long-running server process serving SSR requests at high
+  rate is the canonical re-frame2 SSR shape: every HTTP request creates a
+  per-request server frame, drains, renders, and destroys the frame. The
+  per-request lifecycle MUST return the runtime to the same state it was
+  in before the request — any accumulation, however slow, compounds at
+  request-rate and ships an SSR-broken app.
+
+  Per Spec 011 §Per-request frame teardown contract the framework owns a
+  small set of per-frame allocation sites:
+
+    1. The frame record (app-db, router queue, drain-lock, sub-cache,
+       lifecycle, config) — owned by `re-frame.frame/frames`.
+    2. `:rf/response` accumulator — inside the frame's app-db; rides with
+       the frame.
+    3. Per-frame pending-error-traces buffer — owned by
+       `re-frame.ssr/pending-error-traces`, a defonce side-channel atom
+       keyed by frame-id.
+    4. Per-frame HTTP request slot — owned by
+       `re-frame.ssr/request-slots`, a defonce side-channel atom keyed
+       by frame-id.
+    5. Per-frame epoch ring buffer — owned by `re-frame.epoch`, a
+       defonce side-channel atom keyed by frame-id (cleaned by the
+       `:epoch/on-frame-destroyed` late-bind hook).
+
+  This test drives the documented per-request SSR flow N times against
+  the same process and asserts:
+
+    a. After every iteration, `frame/frames` is back to baseline (zero
+       leftover per-request frames). Verifies the frame record itself
+       releases.
+    b. After every iteration, the SSR side-channel atoms
+       (`pending-error-traces`, `request-slots`) are back to baseline.
+       Verifies the `:ssr/on-frame-destroyed` hook (rf2-fcj33) fires and
+       clears both slots.
+    c. After a triggered GC, the JVM heap delta is small relative to
+       the total bytes the test churned — proves no large object graph
+       is retained past frame destruction.
+
+  Marked `^:slow` so the default test gate skips it; CI runs it via the
+  `:slow-test` alias (see `:test` alias filter in deps.edn).
+
+  Iteration counts:
+    - quick smoke (in this file): 2_000 requests.
+    - manual stress (REPL):        increase via the `(load-test N)`
+                                   helper. The harness scales linearly;
+                                   10_000 finishes in ~5s on a recent
+                                   laptop."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core      :as rf]
+            [re-frame.flows     :as flows]
+            [re-frame.frame     :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas   :as schemas]
+            [re-frame.ssr       :as ssr]))
+
+;; ---- runtime reset --------------------------------------------------------
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (rf/init! ssr/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr     :reload)
+  (require 're-frame.machines :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- side-channel probes --------------------------------------------------
+
+(defn- pending-error-traces-atom
+  "Return the `re-frame.ssr/pending-error-traces` atom. It's `^:private`
+  so we resolve the Var reflectively; its contents are an observable
+  property of the teardown contract (the per-frame buffer the
+  projector drains)."
+  []
+  (deref (or (resolve 're-frame.ssr/pending-error-traces)
+             (throw (ex-info "Cannot resolve re-frame.ssr/pending-error-traces — ns layout changed?"
+                             {})))))
+
+(defn- pending-error-traces-snapshot
+  "Snapshot the current value of the per-frame error-trace buffer atom."
+  []
+  @(pending-error-traces-atom))
+
+(defn- request-slots-snapshot
+  "Read `re-frame.ssr/request-slots` — a public defonce; held for parity
+  with the private-deref above."
+  []
+  @ssr/request-slots)
+
+(defn- non-default-frame-ids
+  "Every frame-id currently registered, minus `:rf/default`. Per-request
+  frames are gensym'd under `:rf.frame/*`; if any survive past their
+  request's `destroy-frame!`, the count grows here."
+  []
+  (disj (frame/frame-ids) :rf/default))
+
+;; ---- the per-request SSR flow under test ---------------------------------
+
+(defn- one-request!
+  "Drive one request through the SSR runtime end-to-end:
+
+    1. make-frame with :platform :server and a synthetic :on-create.
+    2. set-request! populates the per-frame request slot (Ring-adapter
+       parity — exercises the side-channel that needs cleanup).
+    3. Drain settles synchronously via dispatch-sync.
+    4. ssr/get-response flushes the response accumulator.
+    5. render-to-string against a registered view emits HTML.
+    6. ssr/clear-request! is INTENTIONALLY omitted here so the
+       `:ssr/on-frame-destroyed` hook is the only path that clears the
+       slot — the contract is that destroy-frame is sufficient even
+       when the host adapter forgets to clear inline.
+    7. destroy-frame!
+
+  Returns the rendered HTML for sanity-check assertions."
+  [i]
+  (let [server-frame
+        (rf/make-frame
+          {:doc       (str "load-test request " i)
+           :platform  :server
+           :on-create [:load-test/server-init {:i i}]})]
+    ;; Step 2 — populate the per-frame request slot. Exercises the SSR
+    ;; side-channel atom we just wired the destroy hook for.
+    (ssr/set-request! server-frame
+                      {:uri            (str "/load/" i)
+                       :request-method :get
+                       :headers        {"user-agent" "load-test"}})
+    (let [html (rf/with-frame server-frame
+                 (rf/render-to-string [:load-test/page] {:emit-hash? true}))]
+      ;; Step 4 — flush the response accumulator (also triggers any
+      ;; pending-error-trace drain).
+      (ssr/get-response server-frame)
+      ;; Step 7 — destroy. Intentionally NO clear-request! call.
+      (rf/destroy-frame server-frame)
+      html)))
+
+(defn- install-registry!
+  "Register the events + view the load test uses. Called once per test;
+  the runtime reset between tests wipes everything."
+  []
+  (rf/reg-event-db :load-test/server-init
+    (fn [db [_ {:keys [i]}]]
+      (assoc db :i i :rf/route {:id :route/load})))
+  (rf/reg-view* :load-test/page
+    (fn []
+      [:div.page
+       [:h1 "Load test request"]
+       [:p "Some content"]])))
+
+;; ---- baseline + heap helpers ---------------------------------------------
+
+(defn- heap-bytes
+  "Used-heap after a System/gc. Not authoritative — the JVM may
+  schedule the GC asynchronously and may not honour it at all under
+  some VMs — but combined with the synchronous Runtime/freeMemory read,
+  it gives a stable-enough delta for a same-process comparison."
+  []
+  (let [_  (System/gc)
+        rt (Runtime/getRuntime)]
+    (- (.totalMemory rt) (.freeMemory rt))))
+
+(defn load-test
+  "REPL harness — drives `n` SSR requests and returns a result map.
+  The `^:slow` deftest below calls this with n=2000. Stress-runs from
+  the REPL pass larger n (10_000+) to characterise the per-request
+  heap-delta tail."
+  [n]
+  (install-registry!)
+  (let [;; Warm-up — JIT, class-loading, registry first-time allocations.
+        _              (dotimes [_ 100] (one-request! -1))
+        baseline-frames        (count (non-default-frame-ids))
+        baseline-pending       (count (pending-error-traces-snapshot))
+        baseline-requests      (count (request-slots-snapshot))
+        baseline-heap          (heap-bytes)
+        start-ns               (System/nanoTime)]
+    (dotimes [i n] (one-request! i))
+    (let [end-ns         (System/nanoTime)
+          end-heap       (heap-bytes)
+          end-frames     (count (non-default-frame-ids))
+          end-pending    (count (pending-error-traces-snapshot))
+          end-requests   (count (request-slots-snapshot))
+          duration-ms    (/ (- end-ns start-ns) 1e6)]
+      {:n                 n
+       :duration-ms       duration-ms
+       :req-per-sec       (long (/ n (/ duration-ms 1e3)))
+       :baseline-frames   baseline-frames
+       :end-frames        end-frames
+       :baseline-pending  baseline-pending
+       :end-pending       end-pending
+       :baseline-requests baseline-requests
+       :end-requests      end-requests
+       :baseline-heap-mb  (/ baseline-heap 1024.0 1024.0)
+       :end-heap-mb       (/ end-heap 1024.0 1024.0)
+       :heap-delta-mb     (/ (- end-heap baseline-heap) 1024.0 1024.0)
+       :bytes-per-req     (long (/ (- end-heap baseline-heap) (max 1 n)))})))
+
+;; ---- the test -------------------------------------------------------------
+
+(deftest ^:slow per-request-teardown-load-test
+  (testing "2000 SSR requests — frame registry returns to baseline, side-
+            channel atoms return to baseline, heap delta is bounded"
+    (let [result (load-test 2000)]
+      (println "load-test result:" result)
+
+      ;; (a) Frame registry — every per-request frame destroyed.
+      (is (= 0 (:end-frames result))
+          (str "per-request frames leaked across destroy-frame! — "
+               "end-count " (:end-frames result) " > 0; the frame "
+               "record stayed in `re-frame.frame/frames` after destroy-frame!"))
+      (is (= (:baseline-frames result) (:end-frames result))
+          "frame registry returned to baseline")
+
+      ;; (b) SSR side-channel atoms — every per-request entry released.
+      (is (= 0 (:end-pending result))
+          (str "pending-error-traces leaked across destroy-frame! — "
+               "end-count " (:end-pending result) " > 0; the "
+               ":ssr/on-frame-destroyed hook didn't clear the slot, or "
+               "the hook isn't wired into frame/destroy-frame!"))
+      (is (= 0 (:end-requests result))
+          (str "request-slots leaked across destroy-frame! — "
+               "end-count " (:end-requests result) " > 0; the "
+               ":ssr/on-frame-destroyed hook didn't clear the slot, or "
+               "the hook isn't wired into frame/destroy-frame! — and "
+               "this test intentionally omits clear-request! so the "
+               "destroy hook is the ONLY release path."))
+
+      ;; (c) Heap delta. Each request allocates ~a few KB of transient
+      ;; state — frame record, drain ctx, render-tree, response map,
+      ;; trace events, etc. After GC, the retained delta should be at
+      ;; least an order of magnitude below the transient churn. We
+      ;; assert <= 10 MB total delta for 2_000 requests (5 KB/req
+      ;; retained = 10 MB total, which would already be a serious
+      ;; leak; real bound is well under 1 MB).
+      (is (< (:heap-delta-mb result) 10.0)
+          (str "heap delta > 10 MB after 2_000 requests (delta = "
+               (format "%.2f" (:heap-delta-mb result)) " MB; "
+               (:bytes-per-req result) " bytes/request retained); "
+               "indicates a memory leak in the per-request teardown path."))
+
+      ;; Sanity: throughput should be reasonable (catches catastrophic
+      ;; pathologies where the test takes minutes to run). Bound is
+      ;; loose — we just want the test to fail loud if it hangs.
+      (is (> (:req-per-sec result) 100)
+          (str "throughput < 100 req/s — got "
+               (:req-per-sec result)
+               " req/s; investigate per-request overhead.")))))
+
+(deftest ^:slow per-request-error-buffer-cleanup
+  (testing "destroy-frame! clears the pending-error-traces entry even
+            when the projector hasn't drained the buffer"
+    (install-registry!)
+    ;; Drive a few requests that EACH leave an entry in
+    ;; pending-error-traces (we plant it directly via a synthetic
+    ;; trace-emit so we don't have to engineer a real handler failure
+    ;; — the cleanup contract is the same).
+    (dotimes [i 50]
+      (let [fid (rf/make-frame
+                  {:doc       (str "error-buffer test " i)
+                   :platform  :server
+                   :on-create [:load-test/server-init {:i i}]})]
+        ;; Plant a fake pending error trace under this frame's slot.
+        (swap! (pending-error-traces-atom)
+               update fid (fnil conj [])
+               {:op-type :error :operation :rf.error/handler-exception})
+        (rf/destroy-frame fid)))
+    ;; Every planted slot should be gone.
+    (is (= 0 (count (pending-error-traces-snapshot)))
+        "destroy-frame! cleared the pending-error-traces entries even
+         though the projector never drained them via get-response.")))

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -745,6 +745,33 @@ On hydration:
 2. Client's reactive subscriptions, on first read, compute against the now-seeded state. Same values the server saw.
 3. There is intentionally no special-case for "warm" subs vs "cold" subs. The first read is the warmup.
 
+### Per-request frame teardown contract
+
+Per [§Server flow](#server-flow-per-request) every per-request server frame ends with `destroy-frame`. The destroy step is **load-bearing for memory hygiene** on a long-running server process — leaks here compound at request-rate, and a slow leak under prod load is the kind of bug that ships SSR-broken.
+
+The framework owns the following per-frame allocation sites; **all MUST be released by `destroy-frame!`**:
+
+| Slot                                 | Owning ns                  | Storage                                          | Released by                                   |
+| ------------------------------------ | -------------------------- | ------------------------------------------------ | --------------------------------------------- |
+| `app-db` (the frame's state container) | `re-frame.frame`           | per-frame, on the frame record                   | the frame record is dropped (`dissoc-frame!`) |
+| router queue + drain-lock            | `re-frame.frame`           | per-frame, on the frame record                   | the frame record is dropped                   |
+| sub-cache                            | `re-frame.subs`            | per-frame, on the frame record                   | `tear-down-sub-cache!` disposes every cached reaction; the cache atom is reset to `{}` |
+| `:rf/response` accumulator           | `re-frame.ssr`             | inside the frame's `app-db`                      | rides with the app-db on the frame record     |
+| pending error-trace buffer           | `re-frame.ssr`             | `defonce` atom keyed by frame-id, side-channel   | the `:ssr/on-frame-destroyed` hook (rf2-fcj33) drops the slot |
+| per-frame HTTP request slot          | `re-frame.ssr`             | `defonce` atom keyed by frame-id, side-channel   | the `:ssr/on-frame-destroyed` hook (rf2-fcj33) drops the slot; host adapters MAY also clear inline via `clear-request!` |
+| epoch ring buffer                    | `re-frame.epoch`           | `defonce` atom keyed by frame-id                 | the `:epoch/on-frame-destroyed` hook (rf2-d656) drops the slot |
+| privacy warn-once suppression cache  | `re-frame.privacy`         | process-wide `defonce`, **not** per-frame        | the `:privacy/clear-suppression-cache!` hook resets the cache so a re-registered frame re-emits the warning if mis-configured (rf2-isdwf) |
+
+What deliberately survives a per-request frame's destruction (these are **NOT** leaks — they are process-wide registries that mirror handler registration shape):
+
+- The global registrar (`re-frame.registrar/kind->id->metadata`) — event / sub / fx / cofx / view / route / error-projector / flow registrations are process-wide; they exist independently of any frame and do not leak per-request.
+- The retain-N trace ring buffer (`re-frame.trace/trace-buffer-state`, default depth 200) — a process-wide, capacity-bounded buffer; the size is fixed by configuration regardless of request count.
+- The substrate adapter slot (`re-frame.substrate.adapter/installed-adapter`) — set once at boot.
+
+The contract for **side-channel atoms keyed by frame-id**: every such atom MUST register a cleanup hook with `re-frame.late-bind` and that hook MUST be invoked from `frame/destroy-frame!`. The two existing keys are `:ssr/on-frame-destroyed` and `:epoch/on-frame-destroyed`; new artefacts that introduce per-frame side-channel state MUST follow the same pattern.
+
+Verification: the load test at `implementation/ssr/test/re_frame/ssr_teardown_load_test.clj` drives the documented per-request SSR flow N times against the same host adapter, snapshots the JVM heap before and after a GC pause, and asserts the heap delta and the side-channel atom sizes return to baseline.
+
 ## Open questions
 
 ### Streaming SSR


### PR DESCRIPTION
## Summary

Audit per [Spec 011 §Per-request frame teardown contract](../blob/main/spec/011-SSR.md) — confirms every per-frame allocation site is released on `destroy-frame!`, and adds a load test that drives 2K SSR requests and asserts the runtime returns to baseline.

Two leaks found and fixed; both were SSR-side-channel atoms keyed by frame-id that lived outside ``app-db`` for documented design reasons (privacy / app-db-clobber-race avoidance) and were therefore not cleared by the existing app-db / sub-cache teardown.

## Audit findings

Per-frame allocation sites walked end-to-end. All releases happen on ``destroy-frame!``:

| Slot                                  | Owning ns          | Storage                                  | Released by                                                |
| ------------------------------------- | ------------------ | ---------------------------------------- | ---------------------------------------------------------- |
| frame record (app-db, queue, drain-lock, sub-cache) | ``re-frame.frame``  | per-frame on the frame record            | ``dissoc-frame!``                                            |
| sub-cache (every cached reaction)     | ``re-frame.subs``    | per-frame on the frame record            | ``tear-down-sub-cache!`` disposes + resets                   |
| ``:rf/response`` accumulator            | ``re-frame.ssr``     | inside the frame's app-db                | rides with app-db on the frame record                      |
| **pending-error-traces buffer**       | ``re-frame.ssr``     | defonce atom keyed by frame-id           | **NEW: ``:ssr/on-frame-destroyed`` hook (rf2-fcj33)**        |
| **request-slots**                     | ``re-frame.ssr``     | defonce atom keyed by frame-id           | **NEW: ``:ssr/on-frame-destroyed`` hook (rf2-fcj33)**        |
| epoch ring buffer                     | ``re-frame.epoch``   | defonce atom keyed by frame-id           | ``:epoch/on-frame-destroyed`` hook (rf2-d656) — already wired |

Process-wide state that deliberately survives (NOT leaks):

- The global registrar (events / subs / fx / cofx / views / routes / projectors / flows) — process-wide; exists independently of any frame.
- The retain-N trace ring buffer (``re-frame.trace/trace-buffer-state``, capacity-bounded at depth 200) — capacity caps memory, not request count.
- The substrate adapter slot — set once at boot.
- The privacy warn-once cache — reset on every destroy-frame via the existing ``:privacy/clear-suppression-cache!`` hook.

The two new leaks:

1. **``pending-error-traces``** — drained by ``get-response`` (the projector buffer flushes when the response is read), but a frame destroyed without ``get-response`` being called (redirect short-circuit, handler exception before the response read, host-adapter bug) leaked one entry per request.

2. **``request-slots``** — cleared only when the host adapter explicitly calls ``clear-request!``. The bundled Ring adapter uses ``*current-request*`` (a dynamic var) instead of ``set-request!`` and doesn't touch this slot, but any user calling ``set-request!`` directly (custom host adapters, tests, REPL-driven SSR exploration) leaked one entry per request.

## Fix

``re-frame.ssr`` publishes an ``:ssr/on-frame-destroyed`` late-bind hook (new entry in ``implementation/core/src/re_frame/late_bind/directory.cljc``); the hook drops both slots for the destroyed frame.

``frame/destroy-frame!`` calls the hook between sub-cache teardown and the frame-destroyed trace emit. Late-bound through the existing hook table so ``core`` never statically requires ``re-frame.ssr``; when the SSR artefact is absent the hook resolves to nil and the destroy proceeds without it (parity with the existing ``:privacy/clear-suppression-cache!`` / ``:epoch/on-frame-destroyed`` wiring).

## Load test

``implementation/ssr/test/re_frame/ssr_teardown_load_test.clj`` (``^:slow`` markers):

- 2,000 SSR requests through the full per-request lifecycle (make-frame → set-request! → drain → render-to-string → get-response → destroy-frame).
- ``set-request!`` IS called per request; ``clear-request!`` is INTENTIONALLY omitted so the destroy hook is the only release path.
- After the loop, asserts ``frame/frames`` returns to baseline (zero leftover frames), ``pending-error-traces`` returns to baseline (zero entries), ``request-slots`` returns to baseline (zero entries), heap delta < 10 MB.

Numbers on a recent laptop:

```
{:n 2000, :duration-ms 211, :req-per-sec 9459,
 :baseline-frames 0, :end-frames 0,
 :baseline-pending 0, :end-pending 0,
 :baseline-requests 0, :end-requests 0,
 :heap-delta-mb 0.60, :bytes-per-req 313}
```

A second test (``per-request-error-buffer-cleanup``) plants 50 fake pending-error-trace entries directly into the atom under destroyed-frame ids and asserts the cleanup runs even when the projector never drained the buffer.

## Regression-proof

Verified the load test catches the leak: with the ``:ssr/on-frame-destroyed`` hook call temporarily disabled in ``destroy-frame!``, the test fails loud — 2,100 leaked ``request-slots`` entries (100 warmup + 2,000 test), 50 leaked ``pending-error-traces`` entries. With the hook re-enabled, both atoms return to zero.

## Spec change

Spec 011 gets a new §Per-request frame teardown contract subsection inventorying every per-frame allocation site, what releases each, and what deliberately survives. New contract: every defonce atom keyed by frame-id MUST register a cleanup hook with ``re-frame.late-bind`` and that hook MUST be invoked from ``frame/destroy-frame!``.

## Test plan

- [x] ``implementation/ssr`` test suite — all 42 tests pass (including the two new load tests).
- [x] ``implementation/core`` test suite — all 412 tests pass; the late-bind drift test picks up the new directory entry.
- [x] ``implementation/ssr-ring`` test suite — all 11 tests pass.
- [x] Manual regression check: with the destroy hook disabled, the load test fails with the expected error messages.

Closes rf2-fcj33.