### PR TITLE
spec(causa-mcp): :rf.size/large-elided as 6th wire-protocol mechanism (rf2-knshj)

### DIFF
--- a/tools/causa-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/causa-mcp/spec/DESIGN-RATIONALE.md
@@ -630,6 +630,105 @@ forestall the same drift pair2-mcp is paying down. Pre-dates
 
 ---
 
+## Lock #10 — Size-elision marker shape is normative across MCP servers
+
+**Locked 2026-05-13 (Mike).** **`:rf.size/large-elided` is the
+sixth wire-protocol mechanism, and the marker shape is
+normative across the MCP triplet (pair2-mcp, story-mcp,
+causa-mcp).** The marker substitutes per-value inside any
+tree-typed payload; sensitive-drop wins over large-elide when
+both predicates match. Per-call opt-out is `:include-large?`
+(default `false`); the `:elided-large` indicator field rides
+every consumer-facing tool response that walks a tree-typed
+payload.
+
+### Question
+
+Lock #9 baked five wire-protocol mechanisms before impl began.
+spec/009-Instrumentation.md (rf2-hmmx7) and spec/Conventions.md
+subsequently landed `:rf.size/large-elided` as a per-value
+substitution marker, distinct from the four `:rf.mcp/*`
+top-level markers (cap / summary / diff / dedup). pair2-mcp's
+Principles.md picked up the marker as its fifth mechanism
+(rf2-urjnc). Should Causa-MCP promote it to the sixth
+mechanism in `Principles.md` before impl begins, on the same
+"bake-before-impl" calculus as Lock #9 — or wait until impl
+surfaces the same drift?
+
+### Pick
+
+**Promote `:rf.size/large-elided` to mechanism #6 in
+`Principles.md`.** Bake the marker shape, the `:sensitive?`
+composition rule ("sensitive wins"), the `:include-large?`
+opt-out slot, the `:elided-large` indicator field, and the
+pipeline order ("elision runs first") into the spec before
+`tools/causa-mcp/src/` exists.
+
+### Why
+
+- **Same calculus as Lock #9.** Greenfield is the rare cheap
+  window. pair2-mcp added the marker after impl shipped
+  (rf2-urjnc) and is paying the retrofit cost (the
+  `elide-wire-value` walker now has to be plumbed into every
+  existing tool's eval-form generator). Causa-MCP is spec-only
+  today; locking the sixth mechanism alongside the first five
+  means the impl is born compliant — no retrofit pass.
+- **The shape is already normative upstream.** spec/009
+  §"Size elision in traces" and spec/Spec-Schemas
+  §`:rf/elision-marker` are the source-of-truth normative
+  catalogue. Lock #10 promotes that normative shape into the
+  Causa-MCP Principles.md so the catalogue contract
+  (`003-Tool-Catalogue.md`, when it lands) has a per-mechanism
+  slot to bind every tool to.
+- **The composition rule is load-bearing.** "Sensitive wins"
+  isn't an obvious default — naively, a value matching both
+  predicates could emit a marker carrying a `:path` /
+  `:bytes` / `:digest` triple, leaking signal an audit
+  mustn't see. The spec ([Spec 009 §Composition](../../../spec/009-Instrumentation.md))
+  locks the cascade `(and sensitive? large?) → ::drop`
+  upstream; Lock #10 lifts that rule into Causa-MCP's
+  principles so the impl can't accidentally invert it.
+- **Cross-server alignment.** pair2-mcp's
+  [`Principles.md` §"Size-elision wire markers"](../../pair2-mcp/spec/Principles.md#size-elision-wire-markers-rf2-urjnc)
+  declares the same marker shape, the same handle vocabulary,
+  the same opt-out arg name (`:include-large?`). An agent that
+  learns the slot on pair2-mcp gets the same slot on
+  causa-mcp. Lock #10 is the Causa-MCP-side pin.
+- **The `:include-large?` opt-out is the deliberate slot.**
+  Default-off, opt-in. Same posture as `:include-sensitive?`
+  (Lock #4-adjacent privacy gate) — the shape rhymes so the
+  agent's mental model carries across both axes.
+
+### Date locked
+
+2026-05-13 (Mike). Locked in rf2-knshj, following rf2-04ozp's
+alignment pass (PR #709) that brought causa-mcp's existing
+references to `:rf.size/large-elided` in line with pair2-mcp's
+wording. This lock promotes the marker from "referenced in
+the streaming section" to "named sixth mechanism with full
+catalogue contract".
+
+### Trail-of-thought citations
+
+- [Spec 009 §Size elision in traces](../../../spec/009-Instrumentation.md)
+  (rf2-hmmx7) — the normative source-of-truth for the marker
+  shape, the policy keys, and the composition cascade.
+- [Spec-Schemas §`:rf/elision-marker`](../../../spec/Spec-Schemas.md#rfelision-marker)
+  — the schema-level catalogue entry.
+- [Conventions §Reserved namespaces](../../../spec/Conventions.md#reserved-namespaces-framework-owned)
+  — the `:rf.size/*` and `:rf.elision/*` reservations.
+- pair2-mcp
+  [`Principles.md` §"Size-elision wire markers"](../../pair2-mcp/spec/Principles.md#size-elision-wire-markers-rf2-urjnc)
+  (rf2-urjnc) — the precedent consumer; same shape on the
+  wire.
+- causa-mcp alignment pass (rf2-04ozp, PR #709) — the
+  preceding edit that landed the marker references in the
+  streaming section and in §"Tight token budget per
+  response"; Lock #10 promotes those references to a top-level
+  mechanism.
+
+---
+
 ## Summary table
 
 | # | Question | Pick | Date |
@@ -643,8 +742,9 @@ forestall the same drift pair2-mcp is paying down. Pre-dates
 | 7 | Chrome DevTools MCP posture | **Co-install, stay in lane** | 2026-05-12 |
 | 8 | bencode pinning | **`bencode@~2.0.3`** (inherited from pair2-mcp Lock #5) | 2026-05-12 |
 | 9 | Wire-protocol budget posture | **Five mechanisms baked into spec before impl** (cap + slicing + pagination + lazy-summary + dedup) | 2026-05-13 |
+| 10 | Size-elision marker shape | **`:rf.size/large-elided` is the sixth mechanism; shape normative across MCP triplet; sensitive wins on composition** | 2026-05-13 |
 
-These nine locks define Causa-MCP's pre-implementation surface.
+These ten locks define Causa-MCP's pre-implementation surface.
 They were extracted from
 [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
 and [Causa's own DESIGN-RATIONALE](../../causa/spec/DESIGN-RATIONALE.md)

--- a/tools/causa-mcp/spec/Principles.md
+++ b/tools/causa-mcp/spec/Principles.md
@@ -281,9 +281,9 @@ triplet because its catalogue includes
 the `subscribe` stream, all of which return payloads whose
 size scales with runtime state.
 
-The discipline rests on **five normative mechanisms**, each
+The discipline rests on **six normative mechanisms**, each
 catalogued below. Every catalogue entry (when
-`003-Tool-Catalogue.md` lands) MUST declare which of the five
+`003-Tool-Catalogue.md` lands) MUST declare which of the six
 apply to that tool, with a **typical-token** hint
 (`~1.2k`, `~3k under :sample`) and a **cap-reached** behaviour
 note. The hints surface in `list-tools` so the agent can plan
@@ -395,7 +395,126 @@ substituting refs against the table. Dedup is **opt-out** per
 call (`:dedup? false`); on by default for trace-shaped
 sequences and off for everything else.
 
-The five mechanisms together are the load-bearing budget
+### 6. Size elision (`:rf.size/large-elided` marker)
+
+Mechanisms 1-5 cap the **top-level** response shape; the sixth
+mechanism substitutes **per-value** inside any tree-typed
+payload. A single large slot — say a 100KB base64 PDF on
+`[:user :uploaded-pdf]`, a 5MB cached fetch response on
+`[:net :last-payload]` — would otherwise ride the wire
+verbatim and either trip the cap (forcing the agent to re-aim)
+or, worse, slip through under cap and burn the agent host's
+context budget. The framework's size-elision walker
+(`re-frame.core/elide-wire-value`, per
+[`spec/API.md` §`elide-wire-value`](../../../spec/API.md#elide-wire-value-the-wire-boundary-walker))
+substitutes such slots with a canonical marker carrying a
+fetch handle.
+
+**Wire shape**. The marker is normative across the MCP triplet
+(pair2-mcp, story-mcp, causa-mcp) and is catalogued at
+[`spec/Spec-Schemas.md §:rf/elision-marker`](../../../spec/Spec-Schemas.md#rfelision-marker)
+and [`spec/009-Instrumentation.md §Size elision in traces`](../../../spec/009-Instrumentation.md#size-elision-in-traces):
+
+```clojure
+{:rf.size/large-elided
+ {:path   [<segment>...]            ; absolute path inside the slice's root
+  :bytes  <int>                     ; pr-str byte count, exact when known
+  :type   :map | :vector | :set | :scalar | :string
+  :reason :declared | :schema | :runtime-flagged
+  :hint   <string-or-nil>           ; copied verbatim from the registry entry
+  :digest <"sha256:hex">            ; OPTIONAL; gated on :rf.size/include-digests?
+  :handle [:rf.elision/at <path>]}} ; EDN handle passable to get-path
+```
+
+The marker is a **substitution at the elided slot**, not a
+wrapper around the response. A 1MB app-db with a 100KB `:large?`
+slot at `[:user :uploaded-pdf]` returns the small siblings
+verbatim and the marker at the elided slot. The `:rf.elision/at`
+handle is a normal EDN vector (no reader hook needed); agents
+pattern-match on the leading keyword. The marker keyword and
+handle-namespace are reserved in
+[`spec/Conventions.md §Reserved namespaces`](../../../spec/Conventions.md#reserved-namespaces-framework-owned).
+
+**Composition with `:sensitive?` — sensitive wins**. The walker
+operates downstream of the privacy filter (§"Privacy:
+default-drop `:sensitive?` events at the MCP boundary" above)
+and the predicate cascade is:
+
+```clojure
+(cond
+  (and sensitive? large?)  ::drop                  ; no marker; sensitive wins
+  sensitive?               ::redact-or-drop        ; :rf/redacted sentinel
+  large?                   ::elide-with-marker     ; :rf.size/large-elided
+  :else                    ::pass-through)
+```
+
+A value matching both predicates is dropped/redacted **without**
+emitting a marker — the marker itself carries `:path` /
+`:bytes` / `:digest` slots that would leak signal an audit
+mustn't see. The two axes (drop-and-forget for `:sensitive?`,
+elide-with-fetch-handle for `:large?`) compose into a single
+predictable cascade. Per
+[`spec/009-Instrumentation.md §Composition`](../../../spec/009-Instrumentation.md#size-elision-in-traces).
+
+**When this fires**. Any tool emitting a tree-typed payload —
+the canonical Causa-MCP set is `get-app-db`, `app-db-diff`,
+`get-epoch`, `get-epoch-history` (per-record `:db-before` /
+`:db-after`), `get-machine-snapshot`, `get-causality-graph`,
+and `subscribe` payloads carrying trace events with rich
+coeffect / effect slots. Each runs the elided slice through
+the walker inside the eval form sent over nREPL (the registry
+lives in app-db; the Node process can't reach it directly).
+The walker is the **single normative emission site** — per-tool
+reimplementation is prohibited.
+
+**Where in the pipeline**. Elision runs **first**. The downstream
+mechanisms (mechanisms 1-5) operate on the post-elision
+payload: the cap measures post-elision bytes, summary /
+sample / full modes see markers in place of large values,
+dedup pools across already-elided slices. A single declared
+`:large?` slot can no longer blow the cap on its own; the cap
+stays a backstop, not the primary mechanism for the common case.
+
+**Per-call opt-out**. Every tool whose return walks a tree-typed
+payload accepts an `:include-large?` boolean argument (default
+`false` — markers ride; large values stay home). Passing
+`:include-large? true` bypasses the walker entirely — useful
+for the rare workflow where the agent has explicit permission
+and budget to fetch the full payload (e.g. debugging a
+declared-large slot itself, or a session running with a
+purpose-built large-context model). The argument slot is
+cross-server identical (`:include-large?` is the same key on
+pair2-mcp's `snapshot` / `get-path` tools, on story-mcp, and
+on causa-mcp's catalogue when impl lands).
+
+**Per-call digest opt-in**. The `:rf.size/include-digests?`
+slot defaults `false`; setting `true` computes a `sha256:<hex>`
+content digest per elided value. The digest forces a full walk
+of each elided value, which negates the cost-saving — opt in
+deliberately for integrity-check workflows (compare digests
+across turns to detect change-without-fetch).
+
+**Indicator field**. Tool responses that walk tree-typed
+payloads carry an `:elided-large` count alongside the existing
+`:dropped-sensitive` count — one per consumer-facing tool. The
+two counts surface together so an agent sees both axes
+("trimmed 3 sensitive events; elided 2 large values") on the
+same envelope.
+
+**Cross-MCP consumer state**. pair2-mcp already consumes the
+marker through its `snapshot` and `get-path` tools (rf2-urjnc,
+per
+[pair2-mcp Principles §"Size-elision wire markers"](../../pair2-mcp/spec/Principles.md#size-elision-wire-markers-rf2-urjnc));
+the marker shape is identical on the wire. Causa-MCP's
+catalogue (`003-Tool-Catalogue.md`, when it lands) MUST declare
+the `:include-large?` slot, the `:elided-large` indicator
+field, and the default elision-policy on every tool emitting
+tree-typed payloads. Impl alignment is tracked separately —
+this section is the spec-side normative pin; the
+implementation pass lands against the catalogue once
+`tools/causa-mcp/src/` exists.
+
+The six mechanisms together are the load-bearing budget
 posture for Causa-MCP's agent-host workflow: keep the per-op
 cost predictable, push the agent to ask for what it actually
 needs, and never let a single op blow the session. Causa-MCP's
@@ -415,19 +534,18 @@ The `subscribe` stream returns one event per JSON-RPC
 `notifications/progress`, not a buffered batch. The cap applies
 per notification; the agent host meters consumption. A
 `subscribe` topic whose individual events can exceed the cap
-(a trace event with a large coeffect payload) MUST attach a
-server-side trimmer (drop the heavy fields, substitute the
-canonical `:rf.size/large-elided` marker at the elided slot —
-body shape per
+(a trace event with a large coeffect payload) relies on
+mechanism 6 (size elision) running per-notification — the
+walker substitutes the canonical `:rf.size/large-elided` marker
+at each elided slot (body shape per
 [spec/Spec-Schemas §`:rf/elision-marker`](../../../spec/Spec-Schemas.md#rfelision-marker),
-fetch-handle `[:rf.elision/at <path>]` per
-[pair2-mcp Principles §"Size-elision wire markers"](../../pair2-mcp/spec/Principles.md#size-elision-wire-markers-rf2-urjnc) —
-and surface a follow-up `get-trace-buffer` cursor).
-Mechanisms 1, 4, and 5 apply per-notification; mechanisms 2 and
-3 are inapplicable inside a single notification but DO apply to
-the `subscribe` call's own arguments (e.g., a `:path` filter on
-the topic, a `:limit` on total notifications before
-auto-unsubscribe).
+fetch-handle `[:rf.elision/at <path>]`) — and surfaces a
+follow-up `get-trace-buffer` cursor when the trimmed
+notification still trips the cap. Mechanisms 1, 4, 5, and 6
+apply per-notification; mechanisms 2 and 3 are inapplicable
+inside a single notification but DO apply to the `subscribe`
+call's own arguments (e.g., a `:path` filter on the topic, a
+`:limit` on total notifications before auto-unsubscribe).
 
 ## Backed by Causa's and the framework's principles
 


### PR DESCRIPTION
## Summary

- Promotes `:rf.size/large-elided` from a reference in the streaming section to a top-level **§6 mechanism** in `tools/causa-mcp/spec/Principles.md` §"Tight token budget per response", alongside the five existing wire-protocol mechanisms (cap, slicing, pagination, lazy-summary, dedup).
- Documents the marker wire shape, the per-call `:include-large?` opt-out, the `:elided-large` indicator field, the pipeline-first ordering, and the cross-server contract (pair2-mcp + story-mcp + causa-mcp share the shape).
- Locks the `:sensitive?` composition rule: **sensitive wins** — no marker emitted when both predicates match.
- Adds **Lock #10** to `DESIGN-RATIONALE.md` (Size-elision marker shape is normative across MCP servers) — same bake-before-impl calculus as Lock #9; cites the spec/009 + Spec-Schemas + Conventions trail and the pair2-mcp precedent (rf2-urjnc).

## Why now

Causa-MCP is spec-only today (no `src/`). pair2-mcp added the marker after impl shipped (rf2-urjnc) and is paying the retrofit cost. Locking the sixth mechanism alongside the first five (Lock #9, rf2-lwgg8) means the Causa-MCP impl is born compliant — no retrofit pass when `tools/causa-mcp/src/` lands.

The marker keyword + handle namespace are already reserved upstream:

- [`spec/009-Instrumentation.md` §Size elision in traces](../../spec/009-Instrumentation.md) (rf2-hmmx7) — normative shape, policy keys, composition cascade.
- [`spec/Spec-Schemas.md` §`:rf/elision-marker`](../../spec/Spec-Schemas.md) — schema-level catalogue entry.
- [`spec/Conventions.md` §Reserved namespaces](../../spec/Conventions.md) — `:rf.size/*` and `:rf.elision/*` reservations.

This PR is the Causa-MCP-side pin lifting that normative shape into the per-tool principle catalogue so the catalogue-entry contract (`003-Tool-Catalogue.md`, when it lands) has a per-mechanism slot to bind every tool to.

## Cross-server alignment

pair2-mcp's [`Principles.md` §"Size-elision wire markers"](../../tools/pair2-mcp/spec/Principles.md) (rf2-urjnc) already declares the same marker shape, handle vocabulary, and opt-out arg name (`:include-large?`). An agent that learns the slot on pair2-mcp gets the same slot on causa-mcp.

The preceding alignment pass (rf2-04ozp, PR #709) brought causa-mcp's existing references to `:rf.size/large-elided` in line with pair2-mcp's wording; this PR promotes those references from "mentioned in the streaming section" to "named sixth mechanism with full catalogue contract".

## Test plan

- [ ] `mkdocs build --strict` from repo root (markdown link integrity).
- [ ] Manual proof-read of §6 against the spec/009 §Size elision normative source — wording is downstream, no contradictions.
- [ ] Manual proof-read of Lock #10 against Lock #9's shape — same template, same depth.

## Out of scope

- `tools/causa-mcp/src/` impl alignment — tracked separately; lands against `003-Tool-Catalogue.md` once impl exists.
- Touching `spec/009-Instrumentation.md` §Size elision DESIGN-RATIONALE — `rf2-dbpya` covers that (HOT-ZONE; sequenced separately).