### PR TITLE
feat(pair2-mcp): byte+event budget on subscribe overflow (rf2-ho4ve)

### DIFF
--- a/skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs
+++ b/skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs
@@ -499,9 +499,29 @@
 ;;    :topic    :trace | :epoch | :fx | :error
 ;;    :filter   <filter-map>         ;; vocab depends on topic
 ;;    :queue    <vector of events>   ;; appended-to by the cb, drained by the server
-;;    :overflow <integer>            ;; events dropped because queue exceeded :max-buffered
+;;    :queue-bytes <integer>         ;; running sum of (count (pr-str ev)) for queued events
+;;    :dropped-events <integer>      ;; events evicted because EITHER budget tripped
+;;    :dropped-bytes  <integer>      ;; bytes evicted alongside :dropped-events
+;;    :overflow-reason :max-buffered-events | :max-buffered-bytes | nil
+;;                                   ;; budget that tripped LAST — surfaced verbatim
+;;                                   ;; so the AI client knows WHICH limit it should
+;;                                   ;; tune. Reset at every drain alongside the
+;;                                   ;; counters.
 ;;    :created-at <ms>
-;;    :max-buffered <integer>}       ;; queue cap; default 500
+;;    :max-buffered-events <integer> ;; queue cap in events; default 500
+;;    :max-buffered-bytes  <integer>} ;; queue cap in bytes; default 5_000_000 (~5 MB)
+;;
+;; Overflow policy (drop-oldest, byte+event budget — rf2-ho4ve):
+;;   On enqueue, we first append the new event, then evict from the
+;;   FRONT until BOTH budgets hold. Event-count overflow trips
+;;   `:overflow-reason :max-buffered-events`; byte overflow trips
+;;   `:overflow-reason :max-buffered-bytes`. When both trip on the
+;;   same enqueue, the more-recently-tripped budget wins (typically
+;;   bytes — a single fat event can put us over bytes while still
+;;   inside events). Drop-oldest is the only sensible policy for a
+;;   byte budget: a single fat newcomer can require evicting many
+;;   small predecessors to fit, and there's no way to know that on
+;;   entry without already having admitted it.
 ;;
 ;; Topic semantics:
 ;;   :trace  — every event in the raw trace stream matching `:filter`
@@ -524,7 +544,17 @@
   ;; sub-id -> subscription map (see above)
   (atom {}))
 
-(def ^:private default-max-buffered 500)
+(def ^:private default-max-buffered-events 500)
+(def ^:private default-max-buffered-bytes
+  ;; ~5 MB — sized to match the 5,000-token wire-cap posture of the
+  ;; MCP egress boundary scaled up by the per-tick batching ratio.
+  ;; The streaming progress payload is metered per-tick, but the
+  ;; underlying runtime queue is the upstream bound: it must be big
+  ;; enough that a normal drain cadence (~100 ms server poll) drains
+  ;; bursts before they back up, while small enough that an idle
+  ;; subscription forgotten for hours doesn't accumulate hundreds of
+  ;; megabytes of stale events.
+  5000000)
 
 ;; ---------------------------------------------------------------------------
 ;; Privacy posture for the streaming surface (rf2-3cted)
@@ -640,21 +670,74 @@
            (or (nil? t0)         (and (number? (:time ev))
                                       (<= t0 (:time ev) t1)))))))
 
+(defn- event-byte-size
+  "Cheap, monotonic estimate of an event's on-wire byte cost. Uses the
+   same `pr-str`-char-count discipline as the wire-cap helper in
+   `tools.cljs` (`token-estimate`) — keeps the runtime queue's budget
+   in the same units as the egress cap, so the two budgets stay
+   coherent. `pr-str` failure (a reader-unfriendly value somehow on
+   the bus) falls back to `0` rather than blowing up enqueue."
+  [event]
+  (try (count (pr-str event))
+       (catch :default _ 0)))
+
+(defn- evict-oldest
+  "Drop events from the FRONT of `sub`'s queue until BOTH budgets
+   hold (or the queue is empty). Returns the updated sub with the
+   queue/byte-running-total trimmed and `:dropped-events` /
+   `:dropped-bytes` / `:overflow-reason` updated. Drop-oldest is the
+   only sensible policy for a byte budget — see the namespace docs
+   above."
+  [sub max-events max-bytes]
+  (loop [q       (:queue sub)
+         bytes   (:queue-bytes sub 0)
+         dropped-n 0
+         dropped-b 0
+         reason    nil]
+    (let [n (count q)
+          over-events? (> n max-events)
+          over-bytes?  (> bytes max-bytes)]
+      (if (and (or over-events? over-bytes?)
+               (pos? n))
+        (let [head     (nth q 0)
+              head-bs  (event-byte-size head)]
+          (recur (subvec q 1)
+                 (max 0 (- bytes head-bs))
+                 (inc dropped-n)
+                 (+ dropped-b head-bs)
+                 ;; bytes wins ties — if both budgets trip on the
+                 ;; same enqueue, the byte budget is the one the
+                 ;; agent likely needs to know about. (Event-count
+                 ;; alone tripping is the easy case; bytes tripping
+                 ;; signals a large-payload storm.)
+                 (cond over-bytes?  :max-buffered-bytes
+                       over-events? :max-buffered-events
+                       :else        reason)))
+        (cond-> (assoc sub :queue q :queue-bytes bytes)
+          (pos? dropped-n)
+          (-> (update :dropped-events (fnil + 0) dropped-n)
+              (update :dropped-bytes  (fnil + 0) dropped-b)
+              (assoc :overflow-reason reason)))))))
+
 (defn- enqueue!
-  "Append an event to a subscription's queue, honouring max-buffered.
-   When the queue is full we drop the new event and increment overflow —
-   keeping the oldest events lets the agent reconstruct the start of a
-   storm rather than seeing only the tail."
+  "Append an event to a subscription's queue, honouring the byte+event
+   buffer budget (rf2-ho4ve). Drop-oldest semantics: we always admit
+   the new event first, then evict from the FRONT until both budgets
+   hold. A single fat newcomer can therefore evict an arbitrary
+   number of small predecessors — that's correct: the byte budget is
+   a hard upstream bound, and the agent draining the sub gets the
+   most recent state of the world."
   [sub-state sub-id event]
   (update sub-state sub-id
           (fn [sub]
             (when sub
-              (let [q  (:queue sub)
-                    n  (count q)
-                    cap (:max-buffered sub default-max-buffered)]
-                (if (>= n cap)
-                  (update sub :overflow (fnil inc 0))
-                  (update sub :queue conj event)))))))
+              (let [max-events (:max-buffered-events sub default-max-buffered-events)
+                    max-bytes  (:max-buffered-bytes  sub default-max-buffered-bytes)
+                    ev-bytes   (event-byte-size event)
+                    sub'       (-> sub
+                                   (update :queue       conj event)
+                                   (update :queue-bytes (fnil + 0) ev-bytes))]
+                (evict-oldest sub' max-events max-bytes))))))
 
 (defn- dispatch-trace-to-subs!
   "Called from the raw-trace listener — iterates active subscriptions of
@@ -722,13 +805,23 @@
    Opts:
      :topic   :trace | :epoch | :fx | :error  (required)
      :filter  filter map — vocab depends on topic. See namespace docs.
-     :max-buffered  cap on the in-runtime queue. Default 500. Once
-                    the cap is reached, new events are dropped and
-                    counted in `:overflow`.
+     :max-buffered-events  cap on the in-runtime queue in events.
+                           Default 500. When either budget trips, the
+                           OLDEST events are evicted (drop-oldest FIFO).
+     :max-buffered-bytes   cap on the in-runtime queue in pr-str bytes.
+                           Default 5_000_000 (~5 MB). Same drop-oldest
+                           policy. The two budgets are OR-combined:
+                           whichever trips first evicts.
+
+   Drop counts surface on `drain-subscription!` as `:dropped-events`
+   and `:dropped-bytes`, with `:overflow-reason` carrying the budget
+   keyword (`:max-buffered-events` or `:max-buffered-bytes`) that
+   tripped LAST. The bookkeeping reset happens on drain — each tick
+   reports the deltas since the previous tick.
 
    Idempotency: each call returns a fresh sub-id — repeated `subscribe!`
    calls do not share state. Use `unsubscribe!` to release."
-  [{:keys [topic filter max-buffered] :as opts}]
+  [{:keys [topic filter max-buffered-events max-buffered-bytes] :as opts}]
   (cond
     (not (contains? #{:trace :epoch :fx :error} topic))
     {:ok? false :reason :unknown-topic
@@ -739,14 +832,20 @@
     (let [sub-id (str (random-uuid))
           compiled (when (#{:trace :fx :error} topic)
                      (compose-trace-filter topic filter))
-          sub {:id            sub-id
-               :topic         topic
-               :filter        (or filter {})
+          sub {:id              sub-id
+               :topic           topic
+               :filter          (or filter {})
                :compiled-filter compiled
-               :queue         []
-               :overflow      0
-               :created-at    (js/Date.now)
-               :max-buffered  (or max-buffered default-max-buffered)}]
+               :queue           []
+               :queue-bytes     0
+               :dropped-events  0
+               :dropped-bytes   0
+               :overflow-reason nil
+               :created-at      (js/Date.now)
+               :max-buffered-events (or max-buffered-events
+                                        default-max-buffered-events)
+               :max-buffered-bytes  (or max-buffered-bytes
+                                        default-max-buffered-bytes)}]
       ;; Make sure the upgraded listeners are wired (idempotent — same
       ;; id, replaces the basic listeners installed by `health`).
       (rf/register-trace-cb! :re-frame-pair2 on-trace-streaming)
@@ -765,37 +864,62 @@
 
 (defn drain-subscription!
   "Pop every queued event for `sub-id` and return them in order.
-   Returns `{:ok? true :sub-id ... :events [...] :overflow <n> :gone? bool}`.
+   Returns `{:ok? true :sub-id ... :events [...] :dropped-events <n>
+   :dropped-bytes <m> :overflow-reason <kw|nil> :gone? bool}`.
    If the subscription doesn't exist (already unsubscribed or runtime
-   was reloaded), `:gone? true`."
+   was reloaded), `:gone? true`.
+
+   The `:dropped-events`, `:dropped-bytes`, and `:overflow-reason`
+   counters report what got EVICTED from the queue between drains —
+   they reset on every drain so the next tick reports the delta. AI
+   clients pattern-match on `:overflow-reason` to know which budget
+   tripped (`:max-buffered-events` or `:max-buffered-bytes`); the
+   `:dropped-bytes` figure tells them how much state they missed."
   [sub-id]
   (let [snap (atom nil)]
     (swap! subscriptions
            (fn [m]
              (if-let [sub (get m sub-id)]
-               (do (reset! snap {:events (:queue sub)
-                                 :overflow (:overflow sub)})
+               (do (reset! snap {:events          (:queue sub)
+                                 :dropped-events  (:dropped-events sub 0)
+                                 :dropped-bytes   (:dropped-bytes  sub 0)
+                                 :overflow-reason (:overflow-reason sub)})
                    (assoc m sub-id (-> sub
                                        (assoc :queue [])
-                                       (assoc :overflow 0))))
+                                       (assoc :queue-bytes 0)
+                                       (assoc :dropped-events 0)
+                                       (assoc :dropped-bytes 0)
+                                       (assoc :overflow-reason nil))))
                (do (reset! snap nil) m))))
-    (if-let [{:keys [events overflow]} @snap]
-      {:ok? true :sub-id sub-id :events events :overflow (or overflow 0) :gone? false}
-      {:ok? true :sub-id sub-id :events [] :overflow 0 :gone? true})))
+    (if-let [{:keys [events dropped-events dropped-bytes overflow-reason]} @snap]
+      {:ok? true :sub-id sub-id :events events
+       :dropped-events (or dropped-events 0)
+       :dropped-bytes  (or dropped-bytes  0)
+       :overflow-reason overflow-reason
+       :gone? false}
+      {:ok? true :sub-id sub-id :events []
+       :dropped-events 0
+       :dropped-bytes  0
+       :overflow-reason nil
+       :gone? true})))
 
 (defn subscription-info
   "Return active subscription metadata — handy for diagnostics. Returns
-   `{:ok? true :subs [{:id :topic :filter :queue-depth :overflow :created-at}]}`.
-   Does not drain."
+   `{:ok? true :subs [{:id :topic :filter :queue-depth :queue-bytes
+                       :dropped-events :dropped-bytes :overflow-reason
+                       :created-at}]}`. Does not drain."
   []
   {:ok? true
    :subs (mapv (fn [[sub-id sub]]
-                 {:id        sub-id
-                  :topic     (:topic sub)
-                  :filter    (:filter sub)
-                  :queue-depth (count (:queue sub))
-                  :overflow  (:overflow sub)
-                  :created-at (:created-at sub)})
+                 {:id              sub-id
+                  :topic           (:topic sub)
+                  :filter          (:filter sub)
+                  :queue-depth     (count (:queue sub))
+                  :queue-bytes     (:queue-bytes sub 0)
+                  :dropped-events  (:dropped-events sub 0)
+                  :dropped-bytes   (:dropped-bytes  sub 0)
+                  :overflow-reason (:overflow-reason sub)
+                  :created-at      (:created-at sub)})
                @subscriptions)})
 
 ;; ---------------------------------------------------------------------------

--- a/skills/re-frame-pair2/references/recipes.md
+++ b/skills/re-frame-pair2/references/recipes.md
@@ -185,7 +185,7 @@ Fallback: `mcp__re-frame-pair2__watch-epochs {stream: true, pred: {"event-id-pre
 
 ### Inspect what's currently subscribed
 
-`re-frame-pair2.runtime/subscription-info` reports every open subscription's `{:id :topic :filter :queue-depth :overflow :created-at}` without draining the queues. To list active streams:
+`re-frame-pair2.runtime/subscription-info` reports every open subscription's `{:id :topic :filter :queue-depth :queue-bytes :dropped-events :dropped-bytes :overflow-reason :created-at}` without draining the queues. To list active streams:
 
 ```
 mcp__re-frame-pair2__eval-cljs {form: "(re-frame-pair2.runtime/subscription-info)"}

--- a/skills/re-frame-pair2/references/streaming-subscriptions.md
+++ b/skills/re-frame-pair2/references/streaming-subscriptions.md
@@ -90,11 +90,15 @@ The MCP client passes a `progressToken` on the `tools/call` for `subscribe`; eac
   "progressToken": "<client-supplied>",
   "progress": <tick-number>,
   "message": "<EDN-printed batch of events>",
-  "data": { "overflow": <count> }
+  "data": {
+    "dropped-events":  <count>,
+    "dropped-bytes":   <count>,
+    "overflow-reason": ":max-buffered-events" | ":max-buffered-bytes" | null
+  }
 }
 ```
 
-The `message` slot is an EDN-printed string of the batch (a vector of events for `:trace` topics, a vector of `:rf/epoch-record` maps for `:epoch`). The agent reads `message` directly; capable hosts can additionally inspect `data` for structured counts.
+The `message` slot is an EDN-printed string of the batch (a vector of events for `:trace` topics, a vector of `:rf/epoch-record` maps for `:epoch`). The agent reads `message` directly; capable hosts can additionally inspect `data` for structured counts. `overflow-reason` carries the stringified EDN keyword of the budget that tripped on this tick (`null` when no eviction happened).
 
 When sensitive events are dropped, the payload carries an extra `:dropped-sensitive` count; see [Privacy posture](#privacy-posture) below.
 
@@ -117,13 +121,18 @@ The final summary the call resolves with:
 {:ok? true
  :sub-id   "<uuid>"
  :topic    :epoch
- :delivered <count>
- :overflow  <count>
- :ticks     <count>
- :reason    :max-events-reached  ;; or one of the four above
+ :delivered      <count>
+ :dropped-events <count>   ;; events evicted from the runtime queue
+ :dropped-bytes  <count>   ;; bytes evicted alongside (pr-str char count)
+ :ticks          <count>
+ :reason         :max-events-reached  ;; or one of the four above
+ ;; optional, only when overflow eviction occurred:
+ :overflow-reason :max-buffered-events  ;; or :max-buffered-bytes
  ;; optional, only when sensitive drops occurred:
  :dropped-sensitive <count>}
 ```
+
+The byte+event buffer budget (rf2-ho4ve): the runtime queue is bounded by an OR-combined pair — `max-buffered-events` (default 500) and `max-buffered-bytes` (default 5_000_000, ~5 MB pr-str char count). On overflow the OLDEST queued events are evicted (drop-oldest FIFO) and the count/bytes/reason surface on the next `notifications/progress` tick and the final summary. The byte budget is the load-bearing bound; the event budget is a coarse backstop for chatty-filter overruns. Tune `max-buffered-bytes` when `:overflow-reason :max-buffered-bytes` keeps tripping — that's a large-payload storm.
 
 ## Privacy posture
 
@@ -161,4 +170,4 @@ mcp__re-frame-pair2__unsubscribe {sub-id: "<the uuid from the subscribe response
 mcp__re-frame-pair2__eval-cljs {form: "(re-frame-pair2.runtime/subscription-info)"}
 ```
 
-Returns `{:ok? true :subs [{:id :topic :filter :queue-depth :overflow :created-at}]}`. Useful when a probe seems to have gone quiet — confirm the sub is still registered (and that `queue-depth` isn't piling up against a dead consumer) before assuming the bus is dry.
+Returns `{:ok? true :subs [{:id :topic :filter :queue-depth :queue-bytes :dropped-events :dropped-bytes :overflow-reason :created-at}]}`. Useful when a probe seems to have gone quiet — confirm the sub is still registered (and that `queue-depth` / `queue-bytes` isn't piling up against a dead consumer) before assuming the bus is dry. A non-nil `:overflow-reason` indicates the queue has been evicting older events to stay inside its budget.

--- a/skills/re-frame-pair2/tests/runtime/streaming_subscriptions_test.clj
+++ b/skills/re-frame-pair2/tests/runtime/streaming_subscriptions_test.clj
@@ -28,7 +28,8 @@
 ;; Mirror of the subscription registry + helpers.
 ;; ---------------------------------------------------------------------------
 
-(def default-max-buffered 500)
+(def default-max-buffered-events 500)
+(def default-max-buffered-bytes 5000000)
 
 (defn topic->base-filter
   [topic]
@@ -85,14 +86,50 @@
         (if p-fx     (some #(= p-fx (:fx-id %)) effects) true)
         (if p-frame  (= p-frame frame) true)))))
 
+(defn event-byte-size
+  "Mirror of `runtime/event-byte-size` — `pr-str` char count."
+  [event]
+  (count (pr-str event)))
+
+(defn evict-oldest
+  "Mirror of `runtime/evict-oldest`. Drops events from the FRONT of
+   `sub`'s queue until BOTH budgets hold. Drop-oldest is the only
+   sensible policy for a byte budget (a fat newcomer evicts as many
+   small predecessors as it needs to fit)."
+  [sub max-events max-bytes]
+  (loop [q       (:queue sub)
+         bytes   (:queue-bytes sub 0)
+         dropped-n 0
+         dropped-b 0
+         reason    nil]
+    (let [n (count q)
+          over-events? (> n max-events)
+          over-bytes?  (> bytes max-bytes)]
+      (if (and (or over-events? over-bytes?) (pos? n))
+        (let [head    (nth q 0)
+              head-bs (event-byte-size head)]
+          (recur (subvec q 1)
+                 (max 0 (- bytes head-bs))
+                 (inc dropped-n)
+                 (+ dropped-b head-bs)
+                 (cond over-bytes?  :max-buffered-bytes
+                       over-events? :max-buffered-events
+                       :else        reason)))
+        (cond-> (assoc sub :queue q :queue-bytes bytes)
+          (pos? dropped-n)
+          (-> (update :dropped-events (fnil + 0) dropped-n)
+              (update :dropped-bytes  (fnil + 0) dropped-b)
+              (assoc :overflow-reason reason)))))))
+
 (defn enqueue!
   [sub event]
-  (let [q   (:queue sub)
-        n   (count q)
-        cap (:max-buffered sub default-max-buffered)]
-    (if (>= n cap)
-      (update sub :overflow (fnil inc 0))
-      (update sub :queue conj event))))
+  (let [max-events (:max-buffered-events sub default-max-buffered-events)
+        max-bytes  (:max-buffered-bytes  sub default-max-buffered-bytes)
+        ev-bytes   (event-byte-size event)
+        sub'       (-> sub
+                       (update :queue       conj event)
+                       (update :queue-bytes (fnil + 0) ev-bytes))]
+    (evict-oldest sub' max-events max-bytes)))
 
 (defn dispatch-trace-to-subs!
   [subs ev]
@@ -144,25 +181,44 @@
     subs subs))
 
 (defn subscribe!
-  [subs sub-id {:keys [topic filter max-buffered]}]
+  [subs sub-id {:keys [topic filter max-buffered-events max-buffered-bytes]}]
   (let [compiled (when (#{:trace :fx :error} topic)
                    (compose-trace-filter topic filter))
         sub {:id sub-id
              :topic topic
              :filter (or filter {})
              :compiled-filter compiled
-             :queue []
-             :overflow 0
-             :created-at 0
-             :max-buffered (or max-buffered default-max-buffered)}]
+             :queue           []
+             :queue-bytes     0
+             :dropped-events  0
+             :dropped-bytes   0
+             :overflow-reason nil
+             :created-at      0
+             :max-buffered-events (or max-buffered-events
+                                      default-max-buffered-events)
+             :max-buffered-bytes  (or max-buffered-bytes
+                                      default-max-buffered-bytes)}]
     (assoc subs sub-id sub)))
 
 (defn drain-subscription!
   [subs sub-id]
   (if-let [sub (get subs sub-id)]
-    [{:events (:queue sub) :overflow (:overflow sub) :gone? false}
-     (assoc subs sub-id (-> sub (assoc :queue []) (assoc :overflow 0)))]
-    [{:events [] :overflow 0 :gone? true}
+    [{:events          (:queue sub)
+      :dropped-events  (:dropped-events  sub 0)
+      :dropped-bytes   (:dropped-bytes   sub 0)
+      :overflow-reason (:overflow-reason sub)
+      :gone?           false}
+     (assoc subs sub-id (-> sub
+                            (assoc :queue [])
+                            (assoc :queue-bytes 0)
+                            (assoc :dropped-events 0)
+                            (assoc :dropped-bytes 0)
+                            (assoc :overflow-reason nil)))]
+    [{:events []
+      :dropped-events 0
+      :dropped-bytes 0
+      :overflow-reason nil
+      :gone? true}
      subs]))
 
 (defn unsubscribe!
@@ -302,8 +358,22 @@
                  (dispatch-trace-to-subs! ok))]
     (is (= [err] (get-in subs ["err-sub" :queue])))))
 
-(deftest queue-cap-counts-overflow-keeps-oldest
-  (let [subs (-> {} (subscribe! "s" {:topic :trace :max-buffered 2}))
+;; ---------------------------------------------------------------------------
+;; Byte+event overflow budget (rf2-ho4ve)
+;; ---------------------------------------------------------------------------
+;;
+;; Replacement for the pre-budget `:max-buffered` event-count cap. The
+;; runtime now applies an OR-combined byte+event budget on enqueue
+;; with drop-OLDEST semantics, and surfaces `:overflow-reason` so the
+;; AI client knows WHICH budget tripped. The four tests below cover
+;; the four-corner matrix: count-only trip, bytes-only trip, both
+;; with count-first, both with bytes-first.
+
+(deftest overflow-count-only-trip-drops-oldest-and-reports-events-reason
+  ;; bytes budget set generously so it can't trip — count budget = 2.
+  (let [subs (-> {} (subscribe! "s" {:topic :trace
+                                     :max-buffered-events 2
+                                     :max-buffered-bytes  100000000}))
         e1 {:op-type :info :id 1}
         e2 {:op-type :info :id 2}
         e3 {:op-type :info :id 3}
@@ -313,9 +383,101 @@
                  (dispatch-trace-to-subs! e2)
                  (dispatch-trace-to-subs! e3)
                  (dispatch-trace-to-subs! e4))]
-    (is (= 2 (count (get-in subs ["s" :queue]))))
-    (is (= [e1 e2] (get-in subs ["s" :queue])))
-    (is (= 2 (get-in subs ["s" :overflow])))))
+    (testing "queue holds the newest two; oldest were evicted"
+      (is (= 2 (count (get-in subs ["s" :queue]))))
+      (is (= [e3 e4] (get-in subs ["s" :queue]))))
+    (testing "dropped count and reason surface correctly"
+      (is (= 2 (get-in subs ["s" :dropped-events])))
+      (is (= :max-buffered-events (get-in subs ["s" :overflow-reason]))))
+    (testing "drain reports the eviction stats and resets them"
+      (let [[drain subs'] (drain-subscription! subs "s")]
+        (is (= 2 (:dropped-events drain)))
+        (is (pos? (:dropped-bytes drain)))
+        (is (= :max-buffered-events (:overflow-reason drain)))
+        ;; reset on drain
+        (is (zero? (get-in subs' ["s" :dropped-events])))
+        (is (nil?  (get-in subs' ["s" :overflow-reason])))))))
+
+(deftest overflow-bytes-only-trip-drops-oldest-and-reports-bytes-reason
+  ;; event budget set generously — fat events trip the byte budget.
+  (let [;; Each event's pr-str is dominated by :payload's length.
+        fat (apply str (repeat 300 "x"))
+        e1 {:op-type :info :id 1 :payload fat}
+        e2 {:op-type :info :id 2 :payload fat}
+        e3 {:op-type :info :id 3 :payload fat}
+        one-size (event-byte-size e1)
+        ;; Cap that fits ~2 events.
+        byte-cap (int (* one-size 2.5))
+        subs (-> {} (subscribe! "s" {:topic :trace
+                                     :max-buffered-events 1000
+                                     :max-buffered-bytes  byte-cap}))
+        subs (-> subs
+                 (dispatch-trace-to-subs! e1)
+                 (dispatch-trace-to-subs! e2)
+                 (dispatch-trace-to-subs! e3))]
+    (testing "queue holds the newest events that fit; oldest evicted"
+      (is (<= (count (get-in subs ["s" :queue])) 2))
+      (let [q (get-in subs ["s" :queue])]
+        (is (= e3 (last q)))))
+    (testing "byte-budget eviction reports :max-buffered-bytes"
+      (is (pos? (get-in subs ["s" :dropped-events])))
+      (is (pos? (get-in subs ["s" :dropped-bytes])))
+      (is (= :max-buffered-bytes (get-in subs ["s" :overflow-reason]))))))
+
+(deftest overflow-both-budgets-count-trips-first
+  ;; Small events + tight count cap + roomy byte cap = count trips first.
+  ;; The reason MUST be :max-buffered-events when only the event budget
+  ;; was exceeded on the tripping enqueue (bytes are still under cap).
+  (let [tiny {:id 1} ;; pr-str ~= 7 chars
+        events (map #(assoc tiny :id %) (range 1 11)) ;; 10 events
+        byte-cap 1000000 ;; never trips
+        subs (-> {} (subscribe! "s" {:topic :trace
+                                     :max-buffered-events 3
+                                     :max-buffered-bytes  byte-cap}))
+        subs (reduce dispatch-trace-to-subs! subs events)]
+    (testing "queue trimmed to count cap"
+      (is (= 3 (count (get-in subs ["s" :queue])))))
+    (testing "exactly seven events evicted; reason is :max-buffered-events"
+      (is (= 7 (get-in subs ["s" :dropped-events])))
+      (is (= :max-buffered-events (get-in subs ["s" :overflow-reason]))))))
+
+(deftest overflow-both-budgets-bytes-trips-first
+  ;; Fat events + roomy count cap + tight byte cap = bytes trip first.
+  ;; The reason MUST be :max-buffered-bytes since the byte budget is
+  ;; what's forcing eviction.
+  (let [fat (apply str (repeat 1000 "y"))
+        e1  {:id 1 :payload fat}
+        e2  {:id 2 :payload fat}
+        e3  {:id 3 :payload fat}
+        one-size (event-byte-size e1)
+        ;; cap fits ONE event; byte budget trips on the second enqueue.
+        byte-cap (int (* one-size 1.2))
+        subs (-> {} (subscribe! "s" {:topic :trace
+                                     :max-buffered-events 100
+                                     :max-buffered-bytes  byte-cap}))
+        subs (-> subs
+                 (dispatch-trace-to-subs! e1)
+                 (dispatch-trace-to-subs! e2)
+                 (dispatch-trace-to-subs! e3))]
+    (testing "queue holds only the newest event — byte cap forces eviction"
+      (is (= 1 (count (get-in subs ["s" :queue]))))
+      (is (= [e3] (get-in subs ["s" :queue]))))
+    (testing "bytes-budget eviction reports :max-buffered-bytes"
+      (is (= 2 (get-in subs ["s" :dropped-events])))
+      (is (= :max-buffered-bytes (get-in subs ["s" :overflow-reason]))))))
+
+(deftest overflow-defaults-honour-runtime-defaults
+  ;; Subscribe with neither budget specified — defaults populate from
+  ;; the runtime constants. A queue under both caps takes no eviction.
+  (let [subs (-> {} (subscribe! "s" {:topic :trace}))
+        sub  (get subs "s")]
+    (is (= default-max-buffered-events (:max-buffered-events sub)))
+    (is (= default-max-buffered-bytes  (:max-buffered-bytes  sub)))
+    (let [subs (reduce dispatch-trace-to-subs! subs
+                       (map #(assoc {:id %} :ix %) (range 100)))]
+      (is (= 100 (count (get-in subs ["s" :queue]))))
+      (is (zero? (get-in subs ["s" :dropped-events])))
+      (is (nil?  (get-in subs ["s" :overflow-reason]))))))
 
 (deftest unknown-topic-rejected-at-subscribe-level
   ;; The runtime's `subscribe!` returns {:ok? false :reason :unknown-topic}

--- a/tools/pair2-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/pair2-mcp/spec/003-Tool-Catalogue.md
@@ -474,7 +474,8 @@ replacement for the polling-shaped `watch-epochs` op. The MCP
 each batch of matching events is emitted as a
 `notifications/progress` notification correlated to the original call
 via `extra._meta.progressToken`. The final `tools/call` result is a
-summary `{:ok? true :sub-id :delivered N :overflow N :ticks K :reason
+summary `{:ok? true :sub-id :delivered N :dropped-events N
+:dropped-bytes M :overflow-reason <kw> :ticks K :reason
 <terminated-reason>}`.
 
 ### Topics
@@ -535,10 +536,20 @@ vocab `watch-epochs` already accepts):
   a JSON object or an EDN-encoded string. EDN is preferred when the
   filter carries keywords or namespaced ids (a JSON object can't
   carry `:cart/add` natively).
-- `max-buffered` (integer, default `500`) — runtime-side queue cap.
-  When full, new events are dropped and the count is reported in
-  `:overflow`. The dropped events are the *newest* — keeping the
-  oldest lets you reconstruct the start of a storm.
+- `max-buffered-events` (integer, default `500`) — runtime-side queue
+  cap in EVENTS. OR-combined with `max-buffered-bytes` — whichever
+  budget trips first evicts. On overflow the OLDEST events are
+  evicted (drop-oldest FIFO); the count and which budget tripped
+  surface on the next progress tick as `:dropped-events` and
+  `:overflow-reason :max-buffered-events`.
+- `max-buffered-bytes` (integer, default `5_000_000` ≈ 5 MB) —
+  runtime-side queue cap in BYTES (pr-str char count, the same
+  unit as the wire-boundary cap). Same drop-oldest policy; reports
+  `:dropped-bytes` and `:overflow-reason :max-buffered-bytes`. This
+  exists (rf2-ho4ve) because an event-count-only budget can't bound
+  memory pressure under large payloads — 500 small events fit in a
+  few KB, while 500 large events can be tens of MB. The byte budget
+  is the load-bearing bound; the event budget is a coarse backstop.
 - `poll-ms` (integer, default `100`) — server-side poll cadence. The
   MCP server polls the runtime's drain at this interval and emits a
   progress notification per non-empty batch.
@@ -571,16 +582,24 @@ While the subscription is open, each non-empty batch tick emits
   "params": {
     "progressToken": "<token>",  // echoed from the call's _meta
     "progress": <tick-number>,   // monotonic, 1-based
-    "message": "{:sub-id \"...\" :events [...] :overflow 0}",
-    "data": { "overflow": 0 }
+    "message": "{:sub-id \"...\" :events [...] :dropped-events 0 :dropped-bytes 0}",
+    "data": {
+      "dropped-events": 0,                    // events evicted this tick
+      "dropped-bytes":  0,                    // bytes evicted this tick (pr-str)
+      "overflow-reason": null                 // ":max-buffered-events" | ":max-buffered-bytes" | null
+    }
   }
 }
 ```
 
 `message` is an EDN-printed string carrying the event batch — the
 same shape the runtime's `drain-subscription!` returns. Capable MCP
-clients can also inspect `data.overflow` for the count of dropped
-events on this tick.
+clients can also inspect the `data` slot for the structured drop
+counts. `overflow-reason` carries the stringified EDN keyword of the
+budget that tripped LAST (`":max-buffered-events"` or
+`":max-buffered-bytes"` — see [`Principles.md` §Streaming subscribe
+byte+event budget](Principles.md#streaming-subscribe-byteevent-budget-rf2-ho4ve)
+for the policy). `null` when no eviction happened on this tick.
 
 On termination, the `tools/call` result is
 
@@ -588,8 +607,10 @@ On termination, the `tools/call` result is
 {:ok? true
  :sub-id <uuid>
  :topic  <keyword>
- :delivered <integer>
- :overflow  <integer>
+ :delivered      <integer>
+ :dropped-events <integer>   ; total events evicted from the runtime queue
+ :dropped-bytes  <integer>   ; total bytes evicted
+ :overflow-reason :max-buffered-events | :max-buffered-bytes | (key absent)
  :ticks     <integer>
  :reason    :aborted | :sub-gone | :max-ms-reached | :max-events-reached}
 ```

--- a/tools/pair2-mcp/spec/Principles.md
+++ b/tools/pair2-mcp/spec/Principles.md
@@ -532,6 +532,84 @@ siblings. Combined with path-slicing (`:summary` default on
 snapshot), the typical `investigate-X` workflow stays well
 inside the 5,000-token cap without further drill-down.
 
+### Streaming subscribe byte+event budget (rf2-ho4ve)
+
+The sixth wire-protocol mechanism, applied at the *upstream*
+edge — the runtime-side queue feeding the `subscribe` tool —
+rather than at the wire boundary itself. The motivation is
+memory pressure: an event-count-only buffer (`:max-buffered
+500`) is misleading when event size varies by orders of
+magnitude. Five small trace events fit in ~500 bytes; five
+overflowed epoch records with diff-encoded 1MB app-db
+references can hit 5MB. The bound the operator cares about
+is bytes, not events.
+
+**The budget**. Every active subscription carries an
+OR-combined pair on the runtime side:
+
+- `:max-buffered-events` — integer event-count cap, default
+  500. The coarse backstop.
+- `:max-buffered-bytes` — integer pr-str byte cap, default
+  5_000_000 (~5 MB). The load-bearing bound. The unit
+  matches the wire-cap's `pr-str` character count discipline
+  (`token-estimate = (quot bytes 4)`), so the budgets across
+  the upstream-queue and the egress-wire stay coherent.
+
+The runtime's `enqueue!` admits the new event first, then
+evicts from the FRONT of the queue until BOTH budgets hold.
+Drop-OLDEST FIFO is the only sensible policy for a byte
+budget — a single fat newcomer can require evicting an
+arbitrary number of small predecessors, and there's no way to
+know that on admission without already having admitted it.
+
+**Eviction reporting**. On every `drain-subscription!` the
+runtime returns:
+
+```clojure
+{:events          [...]                       ; queued events
+ :dropped-events  <integer>                   ; evicted events since last drain
+ :dropped-bytes   <integer>                   ; evicted bytes since last drain
+ :overflow-reason :max-buffered-events
+                 | :max-buffered-bytes
+                 | nil                        ; which budget tripped LAST
+ :gone?           <boolean>}
+```
+
+The counters reset on drain — each tick reports the delta
+since the previous tick. `:overflow-reason` is the LAST budget
+that tripped (bytes wins on a same-enqueue tie because the
+byte budget tripping signals a large-payload storm — the
+event-budget tripping in isolation is the easy case).
+
+The MCP server forwards these on every `notifications/progress`
+frame's `:data` slot (with the keyword stringified per JSON-RPC
+constraints) and accumulates them onto the final tools/call
+summary. The agent host pattern-matches on `:overflow-reason`
+to decide which budget to raise — bytes-bound storms call for
+`max-buffered-bytes` (or a tighter `filter`); event-bound
+storms call for `max-buffered-events`.
+
+**Why two budgets, not just one**. The byte budget alone
+suffices in principle (bytes is what hurts), but the event
+budget is cheap to maintain and a useful coarse cap against
+runaway subscriptions with a pathologically chatty filter —
+"please don't keep more than 500 events even if they're
+small". The event budget rarely trips in practice for normal
+filters but is the backstop for the chatty-filter case the
+byte budget can't catch (lots of tiny events, none over
+budget individually but together swamp drain throughput).
+
+**Cross-MCP vocabulary**. The `:overflow-reason` keywords
+(`:max-buffered-events`, `:max-buffered-bytes`) sit in the
+runtime's own namespace because they're a property of the
+upstream queue, not a wire marker. The MCP wire payload's
+`:data` slot stringifies them for JSON-RPC. The
+`:dropped-events` / `:dropped-bytes` field names mirror the
+existing `:dropped-sensitive` slot already used for the
+privacy filter (Spec 009 §Privacy / rf2-3cted) — the agent
+host learns one shape: "dropped count + the reason it was
+dropped".
+
 ## Backed by the framework's principles
 
 When in doubt, defer to the framework's [Principles](../../../spec/Principles.md):

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -153,7 +153,7 @@
    "get-path"      "Narrow the path further — pass a deeper segment so the addressed subtree is smaller. Or call `snapshot` with no `path` first for a tree-summary, then re-aim."
    "trace-window"  "Reduce `ms` to a smaller window, narrow with `frame`, or fetch incrementally via `watch-epochs` + `since-id`."
    "watch-epochs"  "Narrow `pred` (e.g. `:event-id-prefix`, `:effects`), pass `frame`, or stream via `subscribe` with `max-events`."
-   "subscribe"     "Tighten `filter`, lower `max-buffered`, set `max-events` so each tick stays small."
+   "subscribe"     "Tighten `filter`, lower `max-buffered-events` / `max-buffered-bytes`, set `max-events` so each tick stays small."
    "eval-cljs"     "Slice the value at the call-site (`get-in`, `take`, project to fewer keys) before returning."
    "discover-app"  "Unusual — the health summary should be small. Inspect `(re-frame-pair2.runtime/health)` directly via `eval-cljs` with a projection."
    "dispatch"      "Trace mode is returning a full epoch — re-run with `trace false` and read the epoch via `watch-epochs`/`snapshot` with a narrower path."})
@@ -1843,11 +1843,15 @@
 ;; `tools/call` result is a summary `{:ok? true :sub-id :delivered N
 ;; :overflow N :reason <terminated-reason>}`.
 ;;
-;; The runtime queue is bounded (default 500); overflow events get
-;; counted in a per-sub `:overflow` slot and surfaced verbatim. The
-;; server's poll cadence (`:poll-ms`, default 100) is well below the
-;; agent-loop perceptual threshold and costs one bencode round-trip
-;; per tick.
+;; The runtime queue is bounded by a byte+event budget (rf2-ho4ve):
+;; default 500 events OR ~5 MB of pr-str bytes, whichever trips
+;; first. On overflow the OLDEST queued events are evicted
+;; (drop-oldest FIFO). The drain payload carries `:dropped-events`,
+;; `:dropped-bytes`, and `:overflow-reason`
+;; (`:max-buffered-events` / `:max-buffered-bytes`) so the AI
+;; client knows which budget to tune. The server's poll cadence
+;; (`:poll-ms`, default 100) is well below the agent-loop
+;; perceptual threshold and costs one bencode round-trip per tick.
 ;;
 ;; Filter vocabulary (server-side normalisation happens on the runtime).
 ;;
@@ -1870,8 +1874,12 @@
 (defn- progress-payload
   "Build the JSON params payload for one `notifications/progress` tick.
   `events` is the EDN-printed string of the batch (kept as a string so
-  the agent host sees the same shape as `tools/call` results)."
-  [progress-token tick events overflow]
+  the agent host sees the same shape as `tools/call` results). The
+  `:data` slot carries the structured drop counts and the
+  `:overflow-reason` keyword (per rf2-ho4ve) so AI clients can
+  pattern-match on which budget tripped without re-parsing the EDN
+  message."
+  [progress-token tick events dropped-events dropped-bytes overflow-reason]
   #js {:progressToken progress-token
        :progress      tick
        ;; `message` is the human-readable slot. We stash an EDN form
@@ -1880,7 +1888,15 @@
        ;; additionally inspect the `data` slot for the structured
        ;; counts.
        :message       events
-       :data          #js {:overflow overflow}})
+       :data          #js {:dropped-events  dropped-events
+                           :dropped-bytes   dropped-bytes
+                           ;; `overflow-reason` is an EDN keyword on
+                           ;; the runtime side — stringify here so it
+                           ;; rides JSON-RPC cleanly. The runtime
+                           ;; sentinels are `:max-buffered-events` /
+                           ;; `:max-buffered-bytes`.
+                           :overflow-reason (when overflow-reason
+                                              (pr-str overflow-reason))}})
 
 (defn- parse-filter-arg
   "MCP-side filter arg can be either a JS object or an EDN string. We
@@ -1896,21 +1912,32 @@
     (map? raw)        raw
     :else             (js->clj raw :keywordize-keys true)))
 
+(def ^:private default-max-buffered-events 500)
+(def ^:private default-max-buffered-bytes
+  ;; ~5 MB — see runtime.cljs's identical default for the rationale.
+  ;; Mirrored here so the MCP server can fill in the slot before the
+  ;; nREPL call if the caller omits it; the runtime still applies
+  ;; the same default if the slot is `nil`.
+  5000000)
+
 (defn- subscribe-tool [conn args extra]
-  (let [build-id    (arg-build args)
-        topic       (some-> (arg args :topic) keyword)
-        filter-map  (parse-filter-arg (arg args :filter))
-        max-buf     (or (arg args :max-buffered) 500)
-        poll-ms     (or (arg args :poll-ms) default-poll-ms)
-        max-ms      (or (arg args :max-ms) 0)    ;; 0 = no upper bound
-        max-events  (or (arg args :max-events) 0) ;; 0 = no upper bound
-        incl?       (include-sensitive? args)
-        dedup?      (parse-dedup-arg (arg args :dedup))
-        progress-tk (some-> extra
-                            (j/get :_meta)
-                            (j/get :progressToken))
-        send-note   (some-> extra (j/get :sendNotification))
-        signal      (some-> extra (j/get :signal))]
+  (let [build-id           (arg-build args)
+        topic              (some-> (arg args :topic) keyword)
+        filter-map         (parse-filter-arg (arg args :filter))
+        max-buf-events     (or (arg args :max-buffered-events)
+                               default-max-buffered-events)
+        max-buf-bytes      (or (arg args :max-buffered-bytes)
+                               default-max-buffered-bytes)
+        poll-ms            (or (arg args :poll-ms) default-poll-ms)
+        max-ms             (or (arg args :max-ms) 0)    ;; 0 = no upper bound
+        max-events         (or (arg args :max-events) 0) ;; 0 = no upper bound
+        incl?              (include-sensitive? args)
+        dedup?             (parse-dedup-arg (arg args :dedup))
+        progress-tk        (some-> extra
+                                   (j/get :_meta)
+                                   (j/get :progressToken))
+        send-note          (some-> extra (j/get :sendNotification))
+        signal             (some-> extra (j/get :signal))]
     (cond
       (or (nil? topic)
           (not (#{:trace :epoch :fx :error} topic)))
@@ -1922,8 +1949,9 @@
       :else
       (let [subscribe-form
             (str "(re-frame-pair2.runtime/subscribe! "
-                 (pr-str (cond-> {:topic topic
-                                  :max-buffered max-buf}
+                 (pr-str (cond-> {:topic               topic
+                                  :max-buffered-events max-buf-events
+                                  :max-buffered-bytes  max-buf-bytes}
                            filter-map (assoc :filter filter-map)))
                  ")")]
         (-> (ensure-runtime! conn build-id)
@@ -1938,7 +1966,17 @@
                       (fn [resolve _reject]
                         (let [tick               (atom 0)
                               delivered          (atom 0)
-                              overflow*          (atom 0)
+                              ;; Total events evicted from the runtime
+                              ;; queue across the lifetime of this
+                              ;; subscription (rf2-ho4ve, replacing the
+                              ;; pre-byte-budget `:overflow` counter).
+                              dropped-events*    (atom 0)
+                              dropped-bytes*     (atom 0)
+                              ;; Last-trip reason — the keyword sticks
+                              ;; on the final summary so the AI client
+                              ;; gets a clear signal about which budget
+                              ;; tripped most recently.
+                              overflow-reason*   (atom nil)
                               dropped-sensitive* (atom 0)
                               terminate
                               (fn [reason]
@@ -1955,13 +1993,16 @@
                                       (fn [_]
                                         (resolve
                                           (ok-text
-                                            (cond-> {:ok?        true
-                                                     :sub-id     sub-id
-                                                     :topic      topic
-                                                     :delivered  @delivered
-                                                     :overflow   @overflow*
-                                                     :ticks      @tick
-                                                     :reason     reason}
+                                            (cond-> {:ok?            true
+                                                     :sub-id         sub-id
+                                                     :topic          topic
+                                                     :delivered      @delivered
+                                                     :dropped-events @dropped-events*
+                                                     :dropped-bytes  @dropped-bytes*
+                                                     :ticks          @tick
+                                                     :reason         reason}
+                                              @overflow-reason*
+                                              (assoc :overflow-reason @overflow-reason*)
                                               (pos? @dropped-sensitive*)
                                               (assoc :dropped-sensitive @dropped-sensitive*))))))))
                               poll
@@ -1989,14 +2030,21 @@
 
                                             :else
                                             (let [raw-evts       (:events drain-resp)
-                                                  ov             (:overflow drain-resp 0)
+                                                  ev-dropped     (:dropped-events  drain-resp 0)
+                                                  by-dropped     (:dropped-bytes   drain-resp 0)
+                                                  ov-reason      (:overflow-reason drain-resp)
                                                   [evts dropped] (strip-sensitive
                                                                    (vec raw-evts) incl?)
                                                   n              (count evts)]
-                                              (swap! overflow* + ov)
+                                              (when (pos? ev-dropped)
+                                                (swap! dropped-events* + ev-dropped))
+                                              (when (pos? by-dropped)
+                                                (swap! dropped-bytes* + by-dropped))
+                                              (when ov-reason
+                                                (reset! overflow-reason* ov-reason))
                                               (when (pos? dropped)
                                                 (swap! dropped-sensitive* + dropped))
-                                              (when (or (pos? n) (pos? ov))
+                                              (when (or (pos? n) (pos? ev-dropped))
                                                 (swap! tick inc)
                                                 (swap! delivered + n)
                                                 (when (and send-note progress-tk)
@@ -2010,10 +2058,15 @@
                                                                        (cond-> {:sub-id sub-id
                                                                                 :events (dedup-value evts dedup?)
                                                                                 :dedup dedup?
-                                                                                :overflow ov}
+                                                                                :dropped-events ev-dropped
+                                                                                :dropped-bytes  by-dropped}
+                                                                         ov-reason
+                                                                         (assoc :overflow-reason ov-reason)
                                                                          (pos? dropped)
                                                                          (assoc :dropped-sensitive dropped)))
-                                                                     ov)})
+                                                                     ev-dropped
+                                                                     by-dropped
+                                                                     ov-reason)})
                                                     (catch :default _ nil))))
                                               (js/setTimeout poll poll-ms)))))
                                       (.catch
@@ -2361,8 +2414,10 @@
                                :filter  {:description "Filter map (JSON object) or EDN string. Vocab depends on topic."
                                          :oneOf [{:type "object"}
                                                  {:type "string"}]}
-                               :max-buffered {:type "integer"
-                                              :description "Runtime-side queue cap. Default 500. Overflow is counted, not blocked."}
+                               :max-buffered-events {:type "integer"
+                                                     :description "Runtime-side queue cap in EVENTS. Default 500. On overflow the OLDEST events are evicted (drop-oldest FIFO) and reported as `:dropped-events` / `:overflow-reason :max-buffered-events` on the next progress tick. OR-combined with :max-buffered-bytes — whichever trips first evicts."}
+                               :max-buffered-bytes  {:type "integer"
+                                                     :description "Runtime-side queue cap in BYTES (pr-str char count). Default 5_000_000 (~5 MB). Same drop-oldest policy; reports `:dropped-bytes` / `:overflow-reason :max-buffered-bytes`. Sized to fit the 5,000-token wire-cap posture across a normal poll cadence."}
                                :poll-ms {:type "integer"
                                          :description "Server poll cadence in ms. Default 100."}
                                :max-ms  {:type "integer"

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/subscribe_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/subscribe_test.cljs
@@ -56,29 +56,48 @@
 ;; pin the exact CLJS form we send to the runtime.
 
 (defn- subscribe-form
-  [topic filter-map max-buf]
+  [topic filter-map max-buf-events max-buf-bytes]
   (str "(re-frame-pair2.runtime/subscribe! "
-       (pr-str (cond-> {:topic topic :max-buffered max-buf}
+       (pr-str (cond-> {:topic               topic
+                        :max-buffered-events max-buf-events
+                        :max-buffered-bytes  max-buf-bytes}
                  filter-map (assoc :filter filter-map)))
        ")"))
 
 (deftest subscribe-form-with-trace-and-filter
-  (let [form (subscribe-form :trace {:op-type :error :event-id :user/login} 500)]
+  (let [form (subscribe-form :trace {:op-type :error :event-id :user/login}
+                             500 5000000)]
     (is (re-find #":topic :trace" form))
-    (is (re-find #":max-buffered 500" form))
+    (is (re-find #":max-buffered-events 500" form))
+    (is (re-find #":max-buffered-bytes 5000000" form))
     (is (re-find #":op-type :error" form))
     (is (re-find #":event-id :user/login" form))))
 
 (deftest subscribe-form-without-filter-omits-key
-  (let [form (subscribe-form :epoch nil 250)]
+  (let [form (subscribe-form :epoch nil 250 1000000)]
     (is (re-find #":topic :epoch" form))
-    (is (re-find #":max-buffered 250" form))
+    (is (re-find #":max-buffered-events 250" form))
+    (is (re-find #":max-buffered-bytes 1000000" form))
     (is (not (re-find #":filter" form)))))
 
 (deftest subscribe-form-fx-topic
-  (let [form (subscribe-form :fx {:event-id :http/get} 100)]
+  (let [form (subscribe-form :fx {:event-id :http/get} 100 100000)]
     (is (re-find #":topic :fx" form))
+    (is (re-find #":max-buffered-events 100" form))
+    (is (re-find #":max-buffered-bytes 100000" form))
     (is (re-find #":event-id :http/get" form))))
+
+(deftest subscribe-form-carries-both-budgets
+  ;; rf2-ho4ve: the wire shape must always carry BOTH :max-buffered-events
+  ;; and :max-buffered-bytes — the runtime applies an OR-combined budget,
+  ;; so half the pair would leak through to the runtime's default for the
+  ;; missing slot. Pin the round-trip here.
+  (let [form (subscribe-form :trace nil 1000 2000000)
+        edn  (cljs.reader/read-string
+               (subs form (count "(re-frame-pair2.runtime/subscribe! ")
+                     (dec (count form))))]
+    (is (= 1000    (:max-buffered-events edn)))
+    (is (= 2000000 (:max-buffered-bytes  edn)))))
 
 ;; Recognised topics — keep this set in lockstep with the runtime's
 ;; subscribe! whitelist.
@@ -92,26 +111,44 @@
     (is (not (contains? recognised :unknown)))))
 
 ;; The progress payload shape — the MCP notifications/progress
-;; notification we emit on each batch tick.
+;; notification we emit on each batch tick. Per rf2-ho4ve the `:data`
+;; slot now carries `:dropped-events`, `:dropped-bytes`, and
+;; `:overflow-reason` (stringified keyword) so the AI client can
+;; pattern-match on WHICH budget tripped without re-parsing EDN.
 
 (defn- progress-payload
-  [progress-token tick events-edn overflow]
+  [progress-token tick events-edn dropped-events dropped-bytes overflow-reason]
   #js {:progressToken progress-token
        :progress      tick
        :message       events-edn
-       :data          #js {:overflow overflow}})
+       :data          #js {:dropped-events  dropped-events
+                           :dropped-bytes   dropped-bytes
+                           :overflow-reason (when overflow-reason
+                                              (pr-str overflow-reason))}})
 
 (deftest progress-payload-carries-token-and-counters
-  (let [p (progress-payload "tok-1" 3 "{:events [...]}" 0)]
+  (let [p (progress-payload "tok-1" 3 "{:events [...]}" 0 0 nil)]
     (is (= "tok-1" (j/get p :progressToken)))
     (is (= 3 (j/get p :progress)))
     (is (= "{:events [...]}" (j/get p :message)))
-    (is (= 0 (j/get-in p [:data :overflow])))))
+    (is (= 0 (j/get-in p [:data :dropped-events])))
+    (is (= 0 (j/get-in p [:data :dropped-bytes])))
+    (is (nil? (j/get-in p [:data :overflow-reason])))))
 
-(deftest progress-payload-with-overflow
-  (let [p (progress-payload 42 1 "{...}" 7)]
+(deftest progress-payload-with-events-overflow
+  ;; Count-budget eviction.
+  (let [p (progress-payload 42 1 "{...}" 7 0 :max-buffered-events)]
     (is (= 42 (j/get p :progressToken)))
-    (is (= 7 (j/get-in p [:data :overflow])))))
+    (is (= 7 (j/get-in p [:data :dropped-events])))
+    (is (= 0 (j/get-in p [:data :dropped-bytes])))
+    (is (= ":max-buffered-events" (j/get-in p [:data :overflow-reason])))))
+
+(deftest progress-payload-with-bytes-overflow
+  ;; Byte-budget eviction — same shape, different reason keyword.
+  (let [p (progress-payload "tok-9" 4 "{...}" 3 12345 :max-buffered-bytes)]
+    (is (= 3 (j/get-in p [:data :dropped-events])))
+    (is (= 12345 (j/get-in p [:data :dropped-bytes])))
+    (is (= ":max-buffered-bytes" (j/get-in p [:data :overflow-reason])))))
 
 ;; Unsubscribe-form pinning — the CLJS form sent over nREPL.
 
@@ -130,3 +167,128 @@
 (deftest drain-form-roundtrips
   (is (= "(re-frame-pair2.runtime/drain-subscription! \"sub-xyz\")"
          (drain-form "sub-xyz"))))
+
+;; ---------------------------------------------------------------------------
+;; Byte+event overflow budget — rf2-ho4ve corner-matrix
+;; ---------------------------------------------------------------------------
+;;
+;; Parallel fixture of the runtime's `evict-oldest` / `enqueue!`
+;; (drop-oldest, OR-combined budget) so the MCP-side test harness pins
+;; the contract. The runtime itself is bb-tested under
+;; `skills/re-frame-pair2/tests/runtime/streaming_subscriptions_test.clj`;
+;; this CLJS fixture lets `npm test` exercise the same contract
+;; alongside the MCP wire surface assertions above.
+
+(def ^:private default-max-events 500)
+(def ^:private default-max-bytes 5000000)
+
+(defn- event-byte-size [event]
+  (count (pr-str event)))
+
+(defn- evict-oldest
+  [sub max-events max-bytes]
+  (loop [q       (:queue sub)
+         bytes   (:queue-bytes sub 0)
+         dropped-n 0
+         dropped-b 0
+         reason    nil]
+    (let [n (count q)
+          over-events? (> n max-events)
+          over-bytes?  (> bytes max-bytes)]
+      (if (and (or over-events? over-bytes?) (pos? n))
+        (let [head    (nth q 0)
+              head-bs (event-byte-size head)]
+          (recur (subvec q 1)
+                 (max 0 (- bytes head-bs))
+                 (inc dropped-n)
+                 (+ dropped-b head-bs)
+                 (cond over-bytes?  :max-buffered-bytes
+                       over-events? :max-buffered-events
+                       :else        reason)))
+        (cond-> (assoc sub :queue q :queue-bytes bytes)
+          (pos? dropped-n)
+          (-> (update :dropped-events (fnil + 0) dropped-n)
+              (update :dropped-bytes  (fnil + 0) dropped-b)
+              (assoc :overflow-reason reason)))))))
+
+(defn- enqueue!
+  [sub event]
+  (let [max-events (:max-buffered-events sub default-max-events)
+        max-bytes  (:max-buffered-bytes  sub default-max-bytes)
+        ev-bytes   (event-byte-size event)
+        sub'       (-> sub
+                       (update :queue       conj event)
+                       (update :queue-bytes (fnil + 0) ev-bytes))]
+    (evict-oldest sub' max-events max-bytes)))
+
+(defn- empty-sub [max-events max-bytes]
+  {:queue [] :queue-bytes 0
+   :dropped-events 0 :dropped-bytes 0 :overflow-reason nil
+   :max-buffered-events max-events
+   :max-buffered-bytes  max-bytes})
+
+(deftest overflow-count-only-trip-drops-oldest-reports-events
+  ;; bytes budget set generously so it can't trip — count budget = 2.
+  (let [sub  (empty-sub 2 100000000)
+        sub  (-> sub
+                 (enqueue! {:id 1})
+                 (enqueue! {:id 2})
+                 (enqueue! {:id 3})
+                 (enqueue! {:id 4}))]
+    (is (= 2 (count (:queue sub))))
+    (is (= [{:id 3} {:id 4}] (:queue sub)))
+    (is (= 2 (:dropped-events sub)))
+    (is (pos? (:dropped-bytes sub)))
+    (is (= :max-buffered-events (:overflow-reason sub)))))
+
+(deftest overflow-bytes-only-trip-drops-oldest-reports-bytes
+  ;; event budget set generously — fat events trip the byte budget.
+  (let [fat       (apply str (repeat 300 "x"))
+        e1        {:id 1 :payload fat}
+        one-size  (event-byte-size e1)
+        ;; ~2 events fit.
+        byte-cap  (long (* one-size 2.5))
+        sub       (empty-sub 1000 byte-cap)
+        sub       (-> sub
+                      (enqueue! e1)
+                      (enqueue! {:id 2 :payload fat})
+                      (enqueue! {:id 3 :payload fat}))]
+    (is (<= (count (:queue sub)) 2))
+    (is (= 3 (:id (last (:queue sub)))))
+    (is (pos? (:dropped-events sub)))
+    (is (pos? (:dropped-bytes  sub)))
+    (is (= :max-buffered-bytes (:overflow-reason sub)))))
+
+(deftest overflow-both-budgets-count-trips-first
+  ;; tiny events + tight count cap + roomy byte cap → events budget trips.
+  (let [sub  (empty-sub 3 1000000)
+        sub  (reduce enqueue! sub
+                     (map #(hash-map :id %) (range 1 11)))] ;; 10 events
+    (is (= 3 (count (:queue sub))))
+    (is (= 7 (:dropped-events sub)))
+    (is (= :max-buffered-events (:overflow-reason sub)))))
+
+(deftest overflow-both-budgets-bytes-trips-first
+  ;; fat events + roomy count cap + tight byte cap → bytes budget trips.
+  (let [fat       (apply str (repeat 1000 "y"))
+        e1        {:id 1 :payload fat}
+        one-size  (event-byte-size e1)
+        byte-cap  (long (* one-size 1.2))
+        sub       (empty-sub 100 byte-cap)
+        sub       (-> sub
+                      (enqueue! e1)
+                      (enqueue! {:id 2 :payload fat})
+                      (enqueue! {:id 3 :payload fat}))]
+    (is (= 1 (count (:queue sub))))
+    (is (= 3 (:id (first (:queue sub)))))
+    (is (= 2 (:dropped-events sub)))
+    (is (= :max-buffered-bytes (:overflow-reason sub)))))
+
+(deftest overflow-empty-queue-no-eviction-no-reason
+  ;; Sanity: under both budgets, no eviction, reason stays nil.
+  (let [sub (empty-sub 10 100000)
+        sub (-> sub (enqueue! {:id 1}) (enqueue! {:id 2}))]
+    (is (= 2 (count (:queue sub))))
+    (is (zero? (:dropped-events sub)))
+    (is (zero? (:dropped-bytes sub)))
+    (is (nil?  (:overflow-reason sub)))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/wire_cap_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/wire_cap_test.cljs
@@ -42,7 +42,7 @@
    "get-path"      "Narrow the path further — pass a deeper segment so the addressed subtree is smaller. Or call `snapshot` with no `path` first for a tree-summary, then re-aim."
    "trace-window"  "Reduce `ms` to a smaller window, narrow with `frame`, or fetch incrementally via `watch-epochs` + `since-id`."
    "watch-epochs"  "Narrow `pred` (e.g. `:event-id-prefix`, `:effects`), pass `frame`, or stream via `subscribe` with `max-events`."
-   "subscribe"     "Tighten `filter`, lower `max-buffered`, set `max-events` so each tick stays small."
+   "subscribe"     "Tighten `filter`, lower `max-buffered-events` / `max-buffered-bytes`, set `max-events` so each tick stays small."
    "eval-cljs"     "Slice the value at the call-site (`get-in`, `take`, project to fewer keys) before returning."
    "discover-app"  "Unusual — the health summary should be small. Inspect `(re-frame-pair2.runtime/health)` directly via `eval-cljs` with a projection."
    "dispatch"      "Trace mode is returning a full epoch — re-run with `trace false` and read the epoch via `watch-epochs`/`snapshot` with a narrower path."})

--- a/tools/pair2-mcp/test/stdio-roundtrip.js
+++ b/tools/pair2-mcp/test/stdio-roundtrip.js
@@ -108,17 +108,24 @@ function run() {
       console.log('OK   tools/list ->', names.join(', '));
 
       // 2c. Verify the subscribe descriptor carries the documented
-      // input schema (topic + filter + max-buffered + poll-ms +
-      // max-ms + max-events + build) and the enum of recognised
-      // topics. Pinning the exact set so accidental renames break
-      // the test instead of silently shipping a broken contract.
+      // input schema (topic + filter + max-buffered-events +
+      // max-buffered-bytes + poll-ms + max-ms + max-events + build)
+      // and the enum of recognised topics. Pinning the exact set so
+      // accidental renames break the test instead of silently
+      // shipping a broken contract. rf2-ho4ve replaced the
+      // pre-byte-budget `max-buffered` event-count slot with the
+      // `max-buffered-events` / `max-buffered-bytes` pair.
       const subDesc = (list.result?.tools || []).find((t) => t.name === 'subscribe');
       if (!subDesc) throw new Error('subscribe descriptor missing from tools/list');
       const subProps = subDesc.inputSchema?.properties || {};
-      for (const k of ['topic', 'filter', 'max-buffered', 'poll-ms', 'max-ms', 'max-events', 'build']) {
+      for (const k of ['topic', 'filter', 'max-buffered-events', 'max-buffered-bytes', 'poll-ms', 'max-ms', 'max-events', 'build']) {
         if (!(k in subProps)) {
           throw new Error('subscribe inputSchema missing property: ' + k);
         }
+      }
+      // Pre-byte-budget slot MUST be gone — catch accidental revert.
+      if ('max-buffered' in subProps) {
+        throw new Error('subscribe inputSchema still carries removed `max-buffered` property — should be replaced by max-buffered-events / max-buffered-bytes (rf2-ho4ve)');
       }
       const topicEnum = subProps.topic?.enum || [];
       const expectedTopics = ['trace', 'epoch', 'fx', 'error'];
@@ -127,7 +134,7 @@ function run() {
           throw new Error('subscribe.topic.enum missing: ' + t);
         }
       }
-      console.log('OK   subscribe descriptor -> topic/filter/max-buffered/poll-ms/max-ms/max-events/build');
+      console.log('OK   subscribe descriptor -> topic/filter/max-buffered-events/max-buffered-bytes/poll-ms/max-ms/max-events/build');
 
       const unsubDesc = (list.result?.tools || []).find((t) => t.name === 'unsubscribe');
       if (!unsubDesc) throw new Error('unsubscribe descriptor missing from tools/list');


### PR DESCRIPTION
## Summary

Replace the streaming-subscribe runtime queue''s event-count-only `:max-buffered` cap with an OR-combined byte+event budget — `:max-buffered-events` (default 500) and `:max-buffered-bytes` (default 5 MB, `pr-str` char count matching the wire-cap unit). Whichever budget trips first evicts. Drop-oldest FIFO semantics: a single fat newcomer can evict an arbitrary number of small predecessors to fit.

The runtime queue tracks `:queue-bytes` alongside `:queue`, and `drain-subscription!` returns `:dropped-events`, `:dropped-bytes`, and `:overflow-reason` (`:max-buffered-events` | `:max-buffered-bytes` | nil). The MCP server forwards those on every `notifications/progress` frame''s `:data` slot (keyword stringified for JSON-RPC) and accumulates them onto the tools/call summary.

**Motivation**: a 500-event buffer of small trace events fits in a few KB; the same 500-event buffer with overflowed diff-encoded epoch records can hit tens of MB. The bound the operator cares about is bytes, not events. With both budgets the agent host pattern-matches `:overflow-reason` to know which knob to tune.

**API change (pre-alpha, no back-compat shim)**:
- Dropped: `:max-buffered` (single event-count slot).
- Added:   `:max-buffered-events` (event count cap, default 500) and `:max-buffered-bytes` (byte cap, default ~5 MB).
- Drain payload renamed: `:overflow <n>` → `:dropped-events <n>` + `:dropped-bytes <m>` + `:overflow-reason <kw>`.
- Progress payload''s `:data` slot mirrors: `dropped-events`, `dropped-bytes`, `overflow-reason`.

## Test plan

- [x] bb-runnable runtime mirror (`skills/re-frame-pair2/tests/runtime/streaming_subscriptions_test.clj`) — 24 tests, 80 assertions, including 5 new corner-matrix cases (count-only trip, bytes-only trip, both with count-first, both with bytes-first, no-eviction defaults).
- [x] CLJS-side parallel fixture in `tools/pair2-mcp/test/re_frame_pair2_mcp/subscribe_test.cljs` mirrors the four-corner matrix and pins descriptor wire shape.
- [x] `npm test` in `tools/pair2-mcp/` — 219 tests, 506 assertions, all pass.
- [x] `npm run build` — production server build compiles clean.
- [x] `stdio-roundtrip.js` updated to pin both new property names and assert the old `max-buffered` slot is gone.

## Files touched

- `skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs` — `enqueue!`/`subscribe!`/`drain-subscription!`/`subscription-info` rewritten.
- `tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs` — subscribe-tool MCP args, runtime-form, progress-payload, descriptor, summary accumulation.
- `tools/pair2-mcp/spec/003-Tool-Catalogue.md` + `tools/pair2-mcp/spec/Principles.md` — new mechanism section §Streaming subscribe byte+event budget.
- Tests: `tools/pair2-mcp/test/re_frame_pair2_mcp/subscribe_test.cljs`, `tools/pair2-mcp/test/re_frame_pair2_mcp/wire_cap_test.cljs`, `tools/pair2-mcp/test/stdio-roundtrip.js`, `skills/re-frame-pair2/tests/runtime/streaming_subscriptions_test.clj`.
- Skill references: `skills/re-frame-pair2/references/streaming-subscriptions.md`, `skills/re-frame-pair2/references/recipes.md`.