### PR TITLE
feat(story): save current canvas state as new variant (rf2-one3t)

### DIFF
--- a/docs/guide/21-stories.md
+++ b/docs/guide/21-stories.md
@@ -220,6 +220,23 @@ The sidebar's foot carries a **test widget** that aggregates `run-variant` outco
 
 This is Story's Vitest-reporter parity per [`tools/story/spec/009-Test-Mode.md`](https://github.com/day8/re-frame2/blob/main/tools/story/spec/009-Test-Mode.md) §Chrome-level test widget — when a project's CI gates on `assertions-passing?`, the chrome widget is the at-a-glance gauge that says "every variant is green right now". Watch-mode auto-re-run is deferred to v2 (needs a registration-diff signal the runtime doesn't yet expose).
 
+## Save current canvas state as a new variant
+
+Tweak the controls on an existing variant, click **save as new variant…** at the bottom of the controls panel, and Story emits a `(reg-variant ...)` form pinned to the current selection — args, mode overrides, and cell-local edits collapsed into one snapshot. The form opens in a modal preview: edit the new variant id inline, copy to clipboard, paste into your stories namespace.
+
+```clojure
+;; Click 'save as new variant…' after dragging :n up to 7 in a :dark mode →
+(story/reg-variant :story.counter/saved-739221
+  {:extends :story.counter/happy-path
+   :args    {:label "Counter"
+             :n     7
+             :theme :dark}})
+```
+
+The captured `:args` are the **effective** args — the five-layer precedence chain (global < story < modes < variant < cell-overrides) resolved to a single map. Source is never written directly; the modal preview gives you a review-then-commit step. This is Story's parity with Storybook 9's 'Save' affordance — without the AST-rewrite plumbing.
+
+You can also drive the flow programmatically — the `:rf.story/save-current-as-variant` event dispatches against the standard re-frame router and accepts an optional `{:variant-id ...}` payload to target a non-focused variant (the agent-facing surface in [`tools/story-mcp/`](https://github.com/day8/re-frame2/tree/main/tools/story-mcp) consumes this path).
+
 ## Mounting the Story shell
 
 In your app's entry namespace:

--- a/tools/story/spec/005-SOTA-Features.md
+++ b/tools/story/spec/005-SOTA-Features.md
@@ -205,6 +205,99 @@ back to the user's stories namespace. That bead is filed separately
 as a P2 follow-up; this spec locks the recorder's runtime contract
 so the MCP side can build against a stable surface.
 
+### Save current canvas state as variant (rf2-one3t)
+
+Storybook 9's second story-from-UI surface (per the SB9 parity audit
+at `ai/findings/story-storybook9-parity-20260513.md` §2.2): tweak
+controls on an existing story, click 'Save', and the change writes
+back to source as a new exported story. SB9's implementation
+auto-writes the source file via a Vite plugin (format-on-save
+respects project Prettier config). Story takes the
+review-then-commit path instead — same as Test Codegen — because
+auto-writing entangles the playground with the project's editor
+config, source-control conflicts, and CI hooks.
+
+The save flow is a **controls-panel button**: with a variant focused,
+clicking 'save as new variant…' captures the live effective args (per
+[`002-Runtime.md`](002-Runtime.md) §Args resolution) and surfaces an
+EDN `(reg-variant ...)` form in a modal. The user reviews, edits the
+new variant id inline, and copies the form to the clipboard for
+pasting into their stories namespace:
+
+```clojure
+(story/reg-variant :story.counter/saved-739221
+  {:extends :story.counter/happy-path
+   :args    {:label "Counter"
+             :n     7
+             :theme :dark}})
+```
+
+The captured args are the **resolved** effective args — the five-layer
+precedence chain (global < story < modes < variant < cell-overrides
+per [`002-Runtime.md`](002-Runtime.md) §Args resolution) collapses to a
+single snapshot map. Tweaking a control then saving produces a variant
+that re-renders with the exact state the user was looking at, with no
+extra plumbing.
+
+#### Public API
+
+```clojure
+;; In re-frame.story.save-variant
+(snapshot-args                 variant-id)           ; pure args snapshot
+(snapshot-args                 variant-id opts)      ; with :active-modes, :cell-overrides
+(gen-variant-snippet           opts)                 ; render (reg-variant ...)
+(save-current-as-variant!)                           ; impure trigger — uses focused variant
+(save-current-as-variant!      {:variant-id ...})    ; explicit target
+
+;; Event surface — dispatchable from agent / chrome contexts
+(rf/dispatch [:rf.story/save-current-as-variant])
+(rf/dispatch [:rf.story/save-current-as-variant {:variant-id ...}])
+```
+
+`opts` for `gen-variant-snippet`:
+
+- `:variant-id` (required) — keyword id for the new variant.
+- `:extends`    (optional) — source variant id (pins `:component`,
+                              `:decorators`, non-overridden args).
+- `:args`       (required) — the captured args map.
+- `:doc`        (optional) — docstring.
+- `:alias`      (optional) — short alias for the form (default `story`).
+
+Pure data → string; the emitted form is `read-string`-able and
+round-trips through re-frame's registrar machinery. Args keys render
+in sorted order for determinism.
+
+#### Why this is structurally simpler than Storybook's save-as
+
+Storybook 9 inspects the project's source tree at build time, parses
+the existing CSF file's AST, splices a new exported story object into
+the module, and re-writes the source via a Vite plugin that honours
+the project's Prettier config. The plugin has to handle TypeScript
+type imports, named exports, default exports, `meta` objects,
+control-spec types, and decorator chains — all in JavaScript text
+form. Story's save-as is one snapshot of the args atom + one EDN
+pretty-printer. No AST. No source-file write. No format-on-save
+config. The user pastes the snippet; the project's editor handles
+the formatting via the editor's own re-frame / Clojure tooling.
+
+The `:rf.story/save-current-as-variant` event id sits under the
+`:rf.story/*` reserved namespace (per
+[spec/Conventions.md](../../../spec/Conventions.md) §Reserved namespaces)
+and is filtered by the Test Codegen recorder's `recordable-event?`
+predicate — a save dispatched during an active recording never appears
+in the recorded `:play` body.
+
+#### MCP wiring
+
+The agent-facing path mirrors the Test Codegen flow: a story-mcp
+`save-current-as-variant` tool dispatches
+`:rf.story/save-current-as-variant` against the live Story process
+through the Tool-Pair bridge (per
+[`006-MCP-Surface.md`](006-MCP-Surface.md)), reads the snippet from
+the resulting dialog state, and returns the EDN form as structured
+output. Filed as a separate P3 follow-up; this spec locks the
+runtime contract so the MCP side can build against a stable surface.
+
 ## v1.1 deferrals
 
 ### Live performance ribbon

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -61,6 +61,11 @@
             ;; snippet generator; the CLJS-only UI surface
             ;; (`re-frame.story.ui.recorder`) wires the trace listener.
             [re-frame.story.recorder  :as recorder]
+            ;; rf2-one3t — save-current-canvas-state-as-variant.
+            ;; Pure-data args snapshot + EDN-form code-gen; the CLJS-
+            ;; only UI surface (`re-frame.story.ui.save-variant`) wires
+            ;; the controls-panel button + modal dialog.
+            [re-frame.story.save-variant :as save-variant]
             ;; Stage 6 (rf2-zhwd) — SOTA features. layout-debug + share
             ;; live in .cljc; multi-substrate / a11y / panels are
             ;; CLJS-only so the JVM classpath stays lean.
@@ -394,6 +399,11 @@
   ;; Stage 5 — assertions + play + force-fx-stub.
   (assertions/install-canonical-assertions!)
   (fx-stubs/install-canonical-fx-stubs!)
+  ;; rf2-one3t — `:rf.story/save-current-as-variant` event handler.
+  ;; Registers a global event-fx handler so the save flow is
+  ;; dispatchable from agent / chrome surfaces alongside the controls-
+  ;; panel button.
+  (save-variant/install-canonical-event-handlers!)
   ;; Wire the late-bound shims so the frames runtime can tap
   ;; into the assertion module without a circular require.
   (frames/set-tap-stub-event-fn! fx-stubs/tap-stub-event!)

--- a/tools/story/src/re_frame/story/save_variant.cljc
+++ b/tools/story/src/re_frame/story/save_variant.cljc
@@ -1,0 +1,305 @@
+(ns re-frame.story.save-variant
+  "Save-current-canvas-state-as-new-variant — the SB9 'Save' affordance
+  (rf2-one3t; SB9 story-from-UI parity per rf2-v05qb §2.2).
+
+  Story-from-UI in two affordances: (a) record-as-`:play` (Test Codegen,
+  rf2-5fc15 — `re-frame.story.recorder`); (b) snapshot-args-as-`:args`
+  (this namespace). Both surface the captured state through the same
+  review-then-commit modal pattern — Story emits an EDN snippet the user
+  copies into source. Source is never written directly; the modal-preview
+  step is the elegant escape hatch from Storybook's auto-write-to-file
+  approach (which entangles the playground with Prettier configuration,
+  source-control conflicts, and the project's editor settings).
+
+  ## What this namespace does
+
+  1. Pure helper `snapshot-args` — given a variant-id (+ optional active
+     modes + cell overrides) returns the live effective args via
+     `re-frame.story.args/resolve-args`. The args map IS the snapshot.
+  2. Pure code-gen `gen-variant-snippet` — emits an EDN
+     `(reg-variant <id> {:extends <src-id> :args {...}})` form the user
+     copies into source.
+  3. Impure trigger `save-current-as-variant!` — looks up the focused
+     variant in the shell-state, takes a snapshot, opens the save-as
+     dialog. Called from the controls panel's 'Save variant' button and
+     dispatchable as `:rf.story/save-current-as-variant`.
+
+  ## Why a pure ns
+
+  Mirrors `re-frame.story.recorder`'s split — pure snippet machinery + a
+  thin CLJS-only UI surface (`re-frame.story.ui.save-variant`). The JVM
+  test corpus exercises the snippet generator + the snapshot helper
+  end-to-end without pulling Reagent / DOM into the test classpath.
+
+  ## Elision
+
+  Every public fn opens with `(when config/enabled? ...)` or is pure data
+  → data so production CLJS builds short-circuit before any side effect.
+  The dialog ratom + button component live in
+  `re-frame.story.ui.save-variant` (CLJS-only)."
+  (:require [clojure.string :as str]
+            [re-frame.core            :as rf]
+            [re-frame.story.args      :as args]
+            [re-frame.story.config    :as config]
+            [re-frame.story.ui.state  :as state]))
+
+;; ---------------------------------------------------------------------------
+;; Pure: args-snapshot helper
+;;
+;; The snapshot IS `(args/resolve-args variant-id opts)` — the effective
+;; args after the five-layer precedence chain (global < story < modes <
+;; variant < cell-overrides) collapses. This wrapper exists so callers
+;; have a single entry point + so the JVM test corpus can pin the
+;; snapshot semantics without coupling to the args ns directly.
+;; ---------------------------------------------------------------------------
+
+(defn snapshot-args
+  "Return the effective args map for `variant-id` — the snapshot the
+  save-as-variant flow writes into the generated `(reg-variant ...)`
+  form. Pure data → data; JVM-testable.
+
+  `opts` (optional):
+  - `:active-modes`   — sequential coll of mode ids active for the snapshot.
+  - `:cell-overrides` — `{arg-key → value}` runtime overrides for THIS
+                       variant (NOT the whole `:cell-overrides` map).
+
+  When the variant has no resolvable args (the variant body has no
+  `:args` slot and no override is in flight) the snapshot is `{}`. The
+  fn never throws on an unregistered variant — the caller's preview
+  shows the resulting form so the missing slot is visible."
+  ([variant-id]
+   (snapshot-args variant-id nil))
+  ([variant-id {:keys [active-modes cell-overrides] :as _opts}]
+   (args/resolve-args variant-id
+                      {:active-modes   (or active-modes [])
+                       :cell-overrides (or cell-overrides {})})))
+
+;; ---------------------------------------------------------------------------
+;; Pure: code-gen — `(reg-variant ... :args {...})` snippet
+;; ---------------------------------------------------------------------------
+
+(defn- pr-args-map
+  "Pretty-print an args map as a multi-line EDN form. Each top-level
+  key/value pair renders on its own line indented two columns under the
+  enclosing brace. Empty maps render as `{}`."
+  [m]
+  (if (empty? m)
+    "{}"
+    (str "{"
+         (->> (sort-by (fn [[k _]] (str k)) m)
+              (map (fn [[k v]] (str (pr-str k) " " (pr-str v))))
+              (str/join "\n            "))
+         "}")))
+
+(defn gen-variant-snippet
+  "Build the EDN snippet for a save-as-variant flow. Pure data → string.
+
+  Returns a `(re-frame.story/reg-variant <id> {:extends <src> :args {...}})`
+  form the user can paste into source. The new variant id, source variant
+  id (for `:extends`), and the args snapshot come from `opts`:
+
+      :variant-id  required — keyword id of the new variant
+                              (e.g. `:story.counter/saved-739221`)
+      :extends     optional — keyword id of the source variant
+                              (carries `:component`, `:decorators`,
+                              non-overridden args)
+      :args        required — args map captured from the live canvas
+      :doc         optional — docstring
+      :alias       optional — short alias to use in the form
+                              (default `\"story\"`)
+
+  The output is human-readable EDN — args render on their own lines,
+  sorted by key for determinism. The form is `read-string`-able and
+  round-trips through re-frame's registrar machinery.
+
+  Unlike `re-frame.story.recorder/gen-play-snippet` (which produces a
+  `:play` body for record-as-test), this generator captures the canvas
+  STATE — the args snapshot — so the new variant renders with the same
+  controls as the source the user was tweaking when they clicked Save."
+  [{:keys [variant-id extends args doc alias]
+    :or   {alias "story"}}]
+  (let [body-keys (cond-> []
+                    doc     (conj [:doc (pr-str doc)])
+                    extends (conj [:extends (pr-str extends)])
+                    true    (conj [:args (pr-args-map (or args {}))]))
+        body-str  (->> body-keys
+                       (map (fn [[k v]] (str k " " v)))
+                       (str/join "\n   "))]
+    (str "(" alias "/reg-variant "
+         (pr-str (or variant-id :story.saved/example))
+         "\n  {" body-str "})")))
+
+;; ---------------------------------------------------------------------------
+;; Pure: default-id derivation
+;;
+;; The save-as flow seeds the dialog's id input with a sensible default —
+;; the source variant's namespace + a wall-clock-derived suffix so two
+;; saves against the same source don't collide before the user edits.
+;; Mirrors `re-frame.story.ui.recorder/default-variant-id`'s shape but
+;; uses a `saved-` prefix to distinguish from `recorded-` traces.
+;; ---------------------------------------------------------------------------
+
+(defn default-variant-id
+  "Derive a sensible default id for the new variant given the source
+  variant id + a wall-clock millis stamp. Pure data → keyword.
+
+  Returns nil if `source-variant-id` is not a qualified keyword."
+  [source-variant-id now-ms]
+  (when (qualified-keyword? source-variant-id)
+    (let [suffix (mod (long now-ms) 1000000)]
+      (keyword (namespace source-variant-id)
+               (str "saved-" suffix)))))
+
+;; ---------------------------------------------------------------------------
+;; Pure: dialog-state shape + transitions
+;;
+;; The save-as-variant dialog carries its own state — open?, the draft
+;; id the user types, the source variant id, and the snapshot args. The
+;; pure transitions are JVM-testable; the impure ratom + UI live in
+;; `re-frame.story.ui.save-variant`.
+;; ---------------------------------------------------------------------------
+
+(def initial-dialog-state
+  "The save-variant dialog's idle state shape."
+  {:open?       false
+   :draft-id    nil
+   :source-id   nil
+   :args        nil})
+
+(defn open
+  "Pure: return the dialog state for opening against `source-variant-id`
+  with the captured `args-snapshot`. `now-ms` seeds the default id."
+  [_state source-variant-id args-snapshot now-ms]
+  {:open?     true
+   :source-id source-variant-id
+   :args      args-snapshot
+   :draft-id  (default-variant-id source-variant-id now-ms)})
+
+(defn close
+  "Pure: return the dialog state for closing — open? flips false; the
+  args/source slots clear so the next open starts fresh."
+  [_state]
+  initial-dialog-state)
+
+(defn set-draft-id
+  "Pure: replace the draft id in the dialog state. `id` may be a keyword
+  or a string (the UI layer parses string input into keywords on best-
+  effort; the pure transition just stores whatever the caller passes)."
+  [state id]
+  (assoc state :draft-id id))
+
+;; ---------------------------------------------------------------------------
+;; Impure: capture + open
+;;
+;; Called by the controls-panel button and by the
+;; `:rf.story/save-current-as-variant` event handler. Reads the shell
+;; state for the focused variant + active modes + overrides, takes a
+;; snapshot, and signals the UI layer (which owns the dialog ratom) to
+;; open against the snapshot.
+;;
+;; The CLJS-only UI layer registers a callback at install-time so this
+;; .cljc helper can stay free of Reagent / DOM coupling. Pure-logic
+;; tests can stub the callback to assert the snapshot shape without
+;; pulling in the UI.
+;; ---------------------------------------------------------------------------
+
+(defonce ^{:doc "The UI-layer callback to open the save-variant dialog.
+                 Registered once at shell mount; called by
+                 `save-current-as-variant!` with the snapshot + source-
+                 variant-id. JVM tests can register a probe callback to
+                 inspect what the helper would emit."}
+  open-dialog-fn (atom nil))
+
+(defn set-open-dialog-fn!
+  "Register the UI-layer dialog-open callback. The callback is invoked
+  as `(callback source-variant-id args-snapshot)`. Idempotent — calling
+  again replaces."
+  [f]
+  (reset! open-dialog-fn f))
+
+(defn focused-variant-id
+  "Pure helper: return the shell's currently-focused variant id, or nil.
+  Read off the shell-state map so callers can pass either the live atom
+  deref or a probe map in tests."
+  [shell-state]
+  (:selected-variant shell-state))
+
+(defn save-current-as-variant!
+  "Capture the current canvas state as a save-as-variant snapshot and
+  surface the EDN form in the dialog modal. Idempotent — calling while
+  the dialog is already open re-opens with a fresh snapshot.
+
+  `opts` (optional):
+  - `:variant-id` — override the source variant id; defaults to the
+                    shell's `:selected-variant`. Used by the MCP / agent
+                    paths that drive the save against a specific target.
+  - `:now-ms`     — wall-clock millis for the default-id seed; defaults
+                    to the current time on the platform.
+
+  Returns the captured snapshot map `{:source-id ... :args ...}` so the
+  caller (the event handler / the MCP tool) can echo it back. Returns
+  nil when no variant is focused — the UI button is disabled in that
+  case, so the only path that hits the nil branch is a programmatic
+  call without a focused variant."
+  ([] (save-current-as-variant! nil))
+  ([{:keys [variant-id now-ms]}]
+   (when config/enabled?
+     (let [shell      (state/get-state)
+           target     (or variant-id (focused-variant-id shell))
+           now-ms     (or now-ms #?(:clj  (System/currentTimeMillis)
+                                    :cljs (.now js/Date)))]
+       (when target
+         (let [snapshot (snapshot-args
+                          target
+                          {:active-modes   (:active-modes shell)
+                           :cell-overrides (get-in shell [:cell-overrides target])})
+               record   {:source-id target
+                         :args      snapshot
+                         :now-ms    now-ms}]
+           (when-let [cb @open-dialog-fn]
+             (cb target snapshot now-ms))
+           record))))))
+
+;; ---------------------------------------------------------------------------
+;; Event registration — `:rf.story/save-current-as-variant`
+;;
+;; Dispatchable from the agent surface (story-mcp) and from any host
+;; chrome that wants to drive the save flow without holding a direct
+;; reference to `save-current-as-variant!`. Payload is an optional
+;; opts map matching `save-current-as-variant!`'s arity:
+;;
+;;     (rf/dispatch [:rf.story/save-current-as-variant])
+;;     (rf/dispatch [:rf.story/save-current-as-variant
+;;                   {:variant-id :story.counter/happy-path}])
+;;
+;; The handler delegates to `save-current-as-variant!` and returns no
+;; effects — the dialog opens via the UI-layer callback registered at
+;; shell mount. Registered by `install-canonical-event-handlers!`,
+;; called from `re-frame.story/install-canonical-vocabulary!` at boot.
+;; Idempotent.
+;;
+;; The event id is `:rf.story/save-current-as-variant`; the namespace
+;; prefix `:rf.story/*` is filtered by the Test Codegen recorder's
+;; `recordable-event?` predicate, so a save dispatched during an active
+;; recording never appears in the recorded `:play` body.
+;; ---------------------------------------------------------------------------
+
+(def ^:const id-save-current-as-variant
+  "The canonical event id for the save-as-variant trigger. Per spec/007
+  §Reserved namespaces the `:rf.story/*` prefix is reserved for the
+  Story runtime's own helper events."
+  :rf.story/save-current-as-variant)
+
+(defn install-canonical-event-handlers!
+  "Register the canonical `:rf.story/save-current-as-variant` event
+  handler. Idempotent. Production builds (with `config/enabled?` false)
+  skip the registration."
+  []
+  (when config/enabled?
+    (rf/reg-event-fx
+      id-save-current-as-variant
+      (fn [_cofx [_ opts]]
+        (save-current-as-variant! opts)
+        {}))
+    nil))
+

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -36,6 +36,7 @@
   (:require [re-frame.story.registrar :as registrar]
             [re-frame.story.args      :as args]
             [re-frame.story.decorators :as decorators]
+            [re-frame.story.ui.save-variant :as save-variant-ui]
             [re-frame.story.ui.state  :as state]))
 
 ;; ---- styling -------------------------------------------------------------
@@ -564,13 +565,20 @@
 
 (defn panel
   "The full controls panel — args editor + decorator list + save-layout
-  action. Per rf2-xi9zk the per-variant mode-picker moved to the
-  chrome-level toolbar (`re-frame.story.ui.toolbar`); the controls
-  panel keeps args / decorator sections only."
+  + save-as-variant actions. Per rf2-xi9zk the per-variant mode-picker
+  moved to the chrome-level toolbar (`re-frame.story.ui.toolbar`); the
+  controls panel keeps args / decorator sections only.
+
+  rf2-one3t: the 'save as new variant' button captures the live canvas
+  state (effective args after the five-layer precedence chain) and
+  surfaces an EDN `(reg-variant ...)` form in a review-then-commit
+  modal — the SB9 story-from-UI parity affordance (per
+  spec/005-SOTA-Features §Save current canvas state as variant)."
   [variant-id]
   [:div {:style (:wrap styles)}
    (when variant-id
      [args-editor variant-id])
    (when variant-id
      [decorator-list variant-id])
+   [save-variant-ui/save-variant-button variant-id]
    [save-layout-button]])

--- a/tools/story/src/re_frame/story/ui/save_variant.cljs
+++ b/tools/story/src/re_frame/story/ui/save_variant.cljs
@@ -1,0 +1,272 @@
+(ns re-frame.story.ui.save-variant
+  "Save-current-canvas-state-as-new-variant UI — the SB9 'Save' affordance
+  (rf2-one3t). The pure machinery lives in
+  `re-frame.story.save-variant`; this ns wires the Reagent ratom, the
+  controls-panel button, and the modal dialog around it.
+
+  ## Surface
+
+  - `(save-variant-button variant-id)` — the controls-panel button.
+    Disabled when no variant is focused; on click captures the live args
+    snapshot and opens the dialog.
+  - `(save-dialog)` — the modal that previews the generated
+    `(reg-variant ...)` form with a copy-to-clipboard affordance. The
+    user edits the new variant id inline; the snippet re-generates on
+    every keystroke. Discard / close drop the snapshot.
+
+  ## Why a separate UI ns
+
+  Mirrors the recorder split (`re-frame.story.recorder` pure +
+  `re-frame.story.ui.recorder` CLJS-only). The dialog ratom + DOM
+  interactions live here; the pure snippet generator + state-machine
+  transitions stay JVM-testable in `re-frame.story.save-variant`.
+
+  ## Elision
+
+  Every public fn opens with `(when config/enabled? ...)` so production
+  CLJS builds short-circuit before any DOM call. The UI-callback wiring
+  via `install!` is the only impure registration the ns owns; idempotent
+  on re-mount."
+  (:require [clojure.string :as str]
+            [reagent.core :as r]
+            [re-frame.story.config       :as config]
+            [re-frame.story.save-variant :as save-variant]
+            [re-frame.story.ui.state     :as state]))
+
+;; ---------------------------------------------------------------------------
+;; Dialog ratom — the impure mirror of `save-variant/initial-dialog-state`.
+;;
+;; The pure transitions in `save-variant` produce new state maps; the
+;; UI swaps the ratom around them so Reagent re-renders the modal on
+;; every keystroke.
+;; ---------------------------------------------------------------------------
+
+(defonce ui-dialog
+  (r/atom save-variant/initial-dialog-state))
+
+(defn- open-dialog!
+  "Open the dialog against `source-variant-id` with the captured
+  `args-snapshot`. `now-ms` seeds the default id."
+  [source-variant-id args-snapshot now-ms]
+  (swap! ui-dialog save-variant/open source-variant-id args-snapshot now-ms))
+
+(defn- close-dialog! []
+  (swap! ui-dialog save-variant/close))
+
+(defn- set-draft-id! [s]
+  (let [k (try
+            (let [stripped (cond-> s
+                             (and (string? s)
+                                  (re-find #"^:" s))
+                             (subs 1))]
+              (when (and (string? stripped) (seq stripped))
+                (if (re-find #"/" stripped)
+                  (let [[ns nm] (str/split stripped #"/" 2)]
+                    (keyword ns nm))
+                  (keyword stripped))))
+            (catch :default _ nil))]
+    (swap! ui-dialog save-variant/set-draft-id (or k s))))
+
+;; ---------------------------------------------------------------------------
+;; Install — register the CLJS open-callback against the pure ns so
+;; `save-variant/save-current-as-variant!` can drive the dialog without
+;; coupling the .cljc helper to Reagent / DOM. Idempotent.
+;; ---------------------------------------------------------------------------
+
+(defn install!
+  "Register the dialog-open callback against the pure ns. Called once at
+  shell mount; idempotent."
+  []
+  (when config/enabled?
+    (save-variant/set-open-dialog-fn! open-dialog!)
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; Styling — mirrors the recorder's dialog so the two save-as flows
+;; (record-as-:play + snapshot-as-:args) share visual language.
+;; ---------------------------------------------------------------------------
+
+(def ^:private styles
+  {:button       {:padding         "4px 8px"
+                  :background      "#0e639c"
+                  :color           "white"
+                  :border          "none"
+                  :border-radius   "3px"
+                  :cursor          "pointer"
+                  :font-size       "10px"
+                  :margin-top      "8px"
+                  :font-family     "monospace"}
+   :button-disabled {:padding       "4px 8px"
+                     :background    "#2d2d30"
+                     :color         "#777"
+                     :border        "1px solid #444"
+                     :border-radius "3px"
+                     :cursor        "not-allowed"
+                     :font-size     "10px"
+                     :margin-top    "8px"
+                     :font-family   "monospace"}
+   :modal-back   {:position "fixed"
+                  :top "0" :left "0" :right "0" :bottom "0"
+                  :background "rgba(0,0,0,0.55)"
+                  :z-index 1700
+                  :display "flex"
+                  :align-items "center"
+                  :justify-content "center"}
+   :modal        {:width        "640px"
+                  :max-width    "90vw"
+                  :max-height   "80vh"
+                  :background   "#1e1e1e"
+                  :color        "#ddd"
+                  :border       "1px solid #444"
+                  :border-radius "6px"
+                  :padding      "16px"
+                  :font-family  "monospace"
+                  :font-size    "12px"
+                  :display      "flex"
+                  :flex-direction "column"
+                  :gap          "12px"
+                  :box-shadow   "0 12px 32px rgba(0,0,0,0.7)"
+                  :overflow     "hidden"}
+   :modal-title  {:font-weight "bold"
+                  :color "#9cdcfe"
+                  :font-size "13px"}
+   :id-input     {:padding "6px 8px"
+                  :background "#252526"
+                  :color "white"
+                  :border "1px solid #444"
+                  :border-radius "3px"
+                  :font-family "monospace"
+                  :font-size "12px"
+                  :width "100%"
+                  :box-sizing "border-box"}
+   :snippet      {:background "#0e0e10"
+                  :color "#dcdcaa"
+                  :padding "10px"
+                  :border "1px solid #333"
+                  :border-radius "4px"
+                  :white-space "pre"
+                  :overflow "auto"
+                  :max-height "44vh"
+                  :font-family "monospace"
+                  :font-size "11px"
+                  :line-height "1.45"
+                  :flex "1 1 auto"}
+   :btn-row      {:display "flex"
+                  :gap "8px"
+                  :justify-content "flex-end"}
+   :btn          {:padding "5px 12px"
+                  :background "#0e639c"
+                  :color "white"
+                  :border "none"
+                  :border-radius "3px"
+                  :cursor "pointer"
+                  :font-family "monospace"
+                  :font-size "11px"}
+   :btn-muted    {:padding "5px 12px"
+                  :background "transparent"
+                  :color "#cccccc"
+                  :border "1px solid #444"
+                  :border-radius "3px"
+                  :cursor "pointer"
+                  :font-family "monospace"
+                  :font-size "11px"}
+   :hint         {:color "#9a9a9a"
+                  :font-style "italic"
+                  :font-size "10px"}})
+
+;; ---------------------------------------------------------------------------
+;; Controls-panel button
+;;
+;; Disabled when no variant is focused. Click captures the live snapshot
+;; and opens the dialog.
+;; ---------------------------------------------------------------------------
+
+(defn save-variant-button
+  "Render the 'Save current canvas state as new variant' button. Lives
+  on the controls panel (per IMPL-SPEC §4 — the controls panel is the
+  natural home for args-snapshot affordances; spec/005-SOTA-Features
+  §Save-current-canvas-state-as-variant).
+
+  Public so tests can introspect the button-level hiccup without driving
+  the full controls panel."
+  [variant-id]
+  (let [enabled? (some? variant-id)]
+    [:button
+     {:style     (if enabled?
+                   (:button styles)
+                   (:button-disabled styles))
+      :disabled  (not enabled?)
+      :data-test "story-save-variant-button"
+      :title     (if enabled?
+                   "Capture the current canvas state as a new variant"
+                   "Select a variant to capture its current state")
+      :on-click  (fn [_]
+                   (when enabled?
+                     (save-variant/save-current-as-variant!
+                       {:variant-id variant-id})))}
+     "save as new variant…"]))
+
+;; ---------------------------------------------------------------------------
+;; Modal dialog — review-then-commit
+;;
+;; The user reviews the generated EDN snippet, edits the new variant id
+;; inline, copies to clipboard, and pastes into source. Source is never
+;; written directly — same as the recorder's save-as-variant dialog.
+;; ---------------------------------------------------------------------------
+
+(defn- copy-to-clipboard! [snippet]
+  (try
+    (when (and (exists? js/navigator) (.-clipboard js/navigator))
+      (.writeText (.-clipboard js/navigator) snippet))
+    (catch :default _ nil)))
+
+(defn save-dialog
+  "Render the save-variant modal. Visible iff `:open?` is true on the
+  dialog ratom. The snippet re-generates on every keystroke as the user
+  edits the new variant id; copy-to-clipboard surfaces the form for the
+  user to paste into source.
+
+  Public so tests can render the dialog hiccup directly after seeding
+  the dialog ratom."
+  []
+  (let [{:keys [open? draft-id source-id args]} @ui-dialog]
+    (when open?
+      (let [snippet (save-variant/gen-variant-snippet
+                      {:variant-id (or draft-id :story.saved/example)
+                       :extends    source-id
+                       :args       args})]
+        [:div {:style (:modal-back styles)
+               :data-test "story-save-variant-dialog"
+               :on-click  (fn [e]
+                            (when (= (.-target e) (.-currentTarget e))
+                              (close-dialog!)))}
+         [:div {:style (:modal styles)
+                :on-click (fn [e] (.stopPropagation e))}
+          [:div {:style (:modal-title styles)}
+           "Save current canvas state as new variant"]
+          [:div {:style (:hint styles)}
+           "Args snapshot captured from "
+           (pr-str source-id)
+           " — edit the new variant id and copy + paste into your "
+           "stories namespace. Source is never written directly."]
+          [:input
+           {:type          "text"
+            :style         (:id-input styles)
+            :data-test     "story-save-variant-id-input"
+            :default-value (pr-str (or draft-id :story.saved/example))
+            :on-change     (fn [e] (set-draft-id! (.. e -target -value)))
+            :placeholder   ":story.your-story/saved-flow"}]
+          [:pre {:style     (:snippet styles)
+                 :data-test "story-save-variant-snippet"}
+           snippet]
+          [:div {:style (:btn-row styles)}
+           [:button
+            {:style     (:btn styles)
+             :data-test "story-save-variant-copy"
+             :on-click  (fn [_] (copy-to-clipboard! snippet))}
+            "copy to clipboard"]
+           [:button
+            {:style    (:btn-muted styles)
+             :data-test "story-save-variant-close"
+             :on-click (fn [_] (close-dialog!))}
+            "close"]]]]))))

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -50,6 +50,7 @@
             [re-frame.story.ui.mode-tabs :as mode-tabs]
             [re-frame.story.ui.panels :as panels]
             [re-frame.story.ui.recorder :as recorder-ui]
+            [re-frame.story.ui.save-variant :as save-variant-ui]
             [re-frame.story.ui.scrubber :as scrubber]
             [re-frame.story.ui.sidebar :as sidebar]
             [re-frame.story.ui.state :as state]
@@ -361,6 +362,11 @@
          ;; it installed is free; we only need to make sure it
          ;; exists before the user clicks REC.
          (recorder-ui/install-trace-listener!)
+         ;; rf2-one3t: install the save-as-variant dialog-open callback
+         ;; against the pure ns so `save-variant/save-current-as-variant!`
+         ;; can drive the modal without coupling the .cljc helper to
+         ;; Reagent / DOM. Idempotent.
+         (save-variant-ui/install!)
          (when-let [vid (:selected-variant @state/shell-state-atom)]
            (ensure-listeners-for-variant! vid))))
      :component-will-unmount
@@ -391,7 +397,12 @@
         ;; (opens after stop). Both are fixed-position so they float
         ;; above the three-pane layout.
         [recorder-ui/recording-overlay]
-        [recorder-ui/save-dialog]])}))
+        [recorder-ui/save-dialog]
+        ;; rf2-one3t: save-current-canvas-state-as-variant dialog. Lives
+        ;; alongside the recorder's save dialog — both float above the
+        ;; three-pane layout via fixed positioning; both surface the
+        ;; generated EDN snippet for review-then-commit.
+        [save-variant-ui/save-dialog]])}))
 
 ;; ---- mount / unmount surface ---------------------------------------------
 

--- a/tools/story/test/re_frame/story/ui/save_variant_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/save_variant_cljs_test.cljc
@@ -1,0 +1,122 @@
+(ns re-frame.story.ui.save-variant-cljs-test
+  "Tests for the save-current-canvas-state-as-variant UI surface
+  (rf2-one3t).
+
+  Splits into two tiers:
+
+  - **JVM + CLJS** (pure machinery in `save_variant.cljc`) — the
+    `gen-variant-snippet` shape contract, the dialog state machine,
+    and the default-id derivation. Mirrors the corpus in
+    `story_save_variant_test.clj` / `story_save_variant_cljs_test.cljs`.
+    These cases assert the contract surface `save-variant-button` and
+    `save-dialog` depend on.
+
+  - **CLJS-only** (`save_variant.cljs` is CLJS-only — depends on
+    Reagent / DOM) — the button hiccup carries the disabled attr +
+    data-test slot when no variant is focused, and the dialog renders
+    a snippet preview when the dialog ratom is open.
+
+  Runs on the JVM under `clojure -M:test` and on CLJS under shadow's
+  `:node-test` / `:browser-test` targets (ns suffix `-cljs-test`)."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.story.save-variant :as save-variant]
+            #?(:cljs [re-frame.story.ui.save-variant :as ui-sv])))
+
+;; ---- JVM + CLJS: contract surface ----------------------------------------
+
+(deftest gen-variant-snippet-emits-reg-variant-form
+  (testing "the generator emits an EDN (reg-variant ...) form the UI previews"
+    (let [snip (save-variant/gen-variant-snippet
+                 {:variant-id :story.x/y
+                  :extends    :story.x/source
+                  :args       {:n 1}})]
+      (is (str/starts-with? snip "(story/reg-variant "))
+      (is (str/includes? snip ":story.x/y"))
+      (is (str/includes? snip ":story.x/source"))
+      (is (str/ends-with? snip "})")))))
+
+(deftest dialog-state-machine-open-close
+  (testing "open + close are the two transitions the UI ratom swaps"
+    (let [opened (save-variant/open save-variant/initial-dialog-state
+                                    :story.x/y {:n 1} 0)
+          closed (save-variant/close opened)]
+      (is (:open? opened))
+      (is (= :story.x/y (:source-id opened)))
+      (is (= {:n 1} (:args opened)))
+      (is (false? (:open? closed)))
+      (is (nil? (:source-id closed))))))
+
+(deftest dialog-set-draft-id-replaces-id-slot
+  (testing "set-draft-id is the per-keystroke transition the UI calls on edit"
+    (let [s (save-variant/set-draft-id
+              (save-variant/open save-variant/initial-dialog-state
+                                 :story.x/y {} 0)
+              :story.x/edited)]
+      (is (= :story.x/edited (:draft-id s))))))
+
+;; ---- CLJS-only: button hiccup --------------------------------------------
+
+#?(:cljs
+   (deftest save-variant-button-disabled-without-variant
+     (testing "the button is disabled + carries a hinted title when no variant focused"
+       (let [hiccup (ui-sv/save-variant-button nil)
+             attrs  (second hiccup)]
+         (is (true? (:disabled attrs)))
+         (is (str/includes? (:title attrs) "Select a variant"))
+         (is (= "story-save-variant-button" (:data-test attrs)))))))
+
+#?(:cljs
+   (deftest save-variant-button-enabled-with-variant
+     (testing "the button enables when a variant is in focus"
+       (let [hiccup (ui-sv/save-variant-button :story.x/y)
+             attrs  (second hiccup)]
+         (is (false? (:disabled attrs)))
+         (is (str/includes? (:title attrs) "Capture"))
+         (is (= "story-save-variant-button" (:data-test attrs)))))))
+
+#?(:cljs
+   (deftest save-variant-button-on-click-callable
+     (testing "the on-click handler is a 1-arg fn (event); calling does not throw"
+       (let [hiccup (ui-sv/save-variant-button :story.x/y)
+             attrs  (second hiccup)
+             on-click (:on-click attrs)]
+         (is (fn? on-click))))))
+
+;; ---- CLJS-only: dialog hiccup --------------------------------------------
+
+#?(:cljs
+   (deftest save-dialog-not-rendered-when-closed
+     (testing "the dialog renders nil when the ratom :open? is false"
+       (reset! ui-sv/ui-dialog save-variant/initial-dialog-state)
+       (is (nil? (ui-sv/save-dialog))))))
+
+#?(:cljs
+   (deftest save-dialog-renders-snippet-when-open
+     (testing "the dialog renders a hiccup tree with the snippet preview"
+       (reset! ui-sv/ui-dialog
+               (save-variant/open save-variant/initial-dialog-state
+                                  :story.x/source
+                                  {:label "hello" :n 42}
+                                  12345))
+       (let [hiccup (ui-sv/save-dialog)
+             flat   (str hiccup)]
+         (is (vector? hiccup) "the dialog renders a hiccup tree")
+         (is (str/includes? flat "story-save-variant-dialog"))
+         (is (str/includes? flat "story-save-variant-snippet"))
+         (is (str/includes? flat ":story.x/source")
+             "the source-variant id appears in the rendered preview")
+         (is (str/includes? flat "hello")
+             "the snapshot args appear in the rendered snippet")))))
+
+#?(:cljs
+   (deftest save-dialog-snippet-renders-extends
+     (testing "the rendered snippet pins :extends to the source variant"
+       (reset! ui-sv/ui-dialog
+               (save-variant/open save-variant/initial-dialog-state
+                                  :story.x/source
+                                  {}
+                                  12345))
+       (let [flat (str (ui-sv/save-dialog))]
+         (is (str/includes? flat ":extends"))
+         (is (str/includes? flat ":story.x/source"))))))

--- a/tools/story/test/re_frame/story_save_variant_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_save_variant_cljs_test.cljs
@@ -1,0 +1,139 @@
+(ns re-frame.story-save-variant-cljs-test
+  "CLJS-side tests for the save-current-canvas-state-as-variant flow
+  (rf2-one3t).
+
+  Runs under shadow's `:node-test` build (ns-regexp `cljs-test$`).
+  The pure-data corpus mirrors the JVM `re-frame.story-save-variant-
+  test` arm — same args-snapshot + snippet generator + dialog state
+  machine — so the cljs build proves the namespace compiles under CLJS
+  as well as the JVM.
+
+  Browser-only behaviour (Reagent ratom, modal dialog rendering) lives
+  in the CLJS-only `re-frame.story.ui.save-variant` ns and is exercised
+  under the `:browser-test` target via a separate Playwright spec
+  when that layer ships."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [cljs.reader :as edn]
+            [clojure.string :as str]
+            [re-frame.story :as story]
+            [re-frame.story.save-variant :as save-variant]
+            [re-frame.story.ui.state :as state]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn reset-all! [f]
+  (story/clear-all!)
+  (state/reset-shell-state!)
+  (story/install-canonical-vocabulary!)
+  (save-variant/set-open-dialog-fn! nil)
+  (f))
+
+(use-fixtures :each reset-all!)
+
+;; ---- snapshot-args -------------------------------------------------------
+
+(deftest snapshot-args-returns-resolved-args
+  (story/reg-variant :story.snap/v
+    {:args {:label "hello" :n 1}
+     :events []})
+  (let [snap (save-variant/snapshot-args :story.snap/v)]
+    (is (= "hello" (:label snap)))
+    (is (= 1 (:n snap)))))
+
+(deftest snapshot-args-includes-cell-overrides
+  (story/reg-variant :story.snap/v
+    {:args   {:label "before" :keep "yes"}
+     :events []})
+  (let [snap (save-variant/snapshot-args
+               :story.snap/v
+               {:cell-overrides {:label "after"}})]
+    (is (= "after" (:label snap)))
+    (is (= "yes"   (:keep snap)))))
+
+;; ---- gen-variant-snippet -------------------------------------------------
+
+(deftest gen-variant-snippet-renders-reg-variant
+  (let [snip (save-variant/gen-variant-snippet
+               {:variant-id :story.counter/saved
+                :extends    :story.counter/happy-path
+                :args       {:label "hi" :n 3}})]
+    (is (str/includes? snip "reg-variant"))
+    (is (str/includes? snip ":story.counter/saved"))
+    (is (str/includes? snip ":story.counter/happy-path"))
+    (is (str/includes? snip ":args"))
+    (is (str/includes? snip ":label"))
+    (is (str/includes? snip "\"hi\""))))
+
+(deftest gen-variant-snippet-empty-args-renders-empty-map
+  (let [snip (save-variant/gen-variant-snippet
+               {:variant-id :story.x/y :args {}})]
+    (is (str/includes? snip ":args"))
+    (is (str/includes? snip "{}"))))
+
+(deftest gen-variant-snippet-args-roundtrip
+  (let [args   {:label "alice" :n 42}
+        snip   (save-variant/gen-variant-snippet
+                 {:variant-id :story.x/y :args args})
+        start  (str/index-of snip ":args")
+        after  (subs snip start)
+        open   (str/index-of after "{")
+        end    (loop [i (inc open) depth 1]
+                 (cond
+                   (>= i (count after)) nil
+                   (zero? depth) i
+                   :else (let [c (.charAt after i)]
+                           (case c
+                             "{" (recur (inc i) (inc depth))
+                             "}" (recur (inc i) (dec depth))
+                             (recur (inc i) depth)))))
+        args-str (subs after open end)]
+    (is (= args (edn/read-string args-str)))))
+
+;; ---- default-variant-id --------------------------------------------------
+
+(deftest default-variant-id-derives-from-source
+  (let [k (save-variant/default-variant-id :story.counter/happy-path 12345)]
+    (is (qualified-keyword? k))
+    (is (= "story.counter" (namespace k)))
+    (is (str/starts-with? (name k) "saved-"))))
+
+(deftest default-variant-id-nil-for-unqualified
+  (is (nil? (save-variant/default-variant-id :unqualified 0))))
+
+;; ---- dialog state machine -------------------------------------------------
+
+(deftest open-builds-dialog-state
+  (let [s (save-variant/open save-variant/initial-dialog-state
+                             :story.x/y {:n 1} 1000)]
+    (is (:open? s))
+    (is (= :story.x/y (:source-id s)))
+    (is (= {:n 1} (:args s)))))
+
+(deftest close-returns-idle
+  (let [opened (save-variant/open save-variant/initial-dialog-state
+                                  :story.x/y {} 0)]
+    (is (= save-variant/initial-dialog-state
+           (save-variant/close opened)))))
+
+;; ---- save-current-as-variant! --------------------------------------------
+
+(deftest save-current-as-variant!-triggers-callback
+  (story/reg-variant :story.snap/v {:args {:n 7} :events []})
+  (state/swap-state! state/select-variant :story.snap/v)
+  (let [captured (atom nil)]
+    (save-variant/set-open-dialog-fn!
+      (fn [source-id args _]
+        (reset! captured {:source-id source-id :args args})))
+    (let [result (save-variant/save-current-as-variant!)]
+      (is (some? @captured))
+      (is (= :story.snap/v (:source-id @captured)))
+      (is (= 7 (-> @captured :args :n)))
+      (is (= :story.snap/v (:source-id result))))))
+
+(deftest save-current-as-variant!-nil-without-focus
+  (state/swap-state! state/select-variant nil)
+  (let [captured (atom nil)]
+    (save-variant/set-open-dialog-fn!
+      (fn [_ _ _] (reset! captured :fired)))
+    (is (nil? (save-variant/save-current-as-variant!)))
+    (is (nil? @captured))))

--- a/tools/story/test/re_frame/story_save_variant_test.clj
+++ b/tools/story/test/re_frame/story_save_variant_test.clj
@@ -1,0 +1,302 @@
+(ns re-frame.story-save-variant-test
+  "JVM tests for the save-current-canvas-state-as-variant flow (rf2-one3t).
+
+  Pure-data coverage: the args-snapshot helper, the EDN code-gen
+  (`gen-variant-snippet`), the dialog state-machine transitions, and the
+  default-id derivation. Mirrors the cljs-test arm in
+  `story_save_variant_cljs_test.cljs`.
+
+  ## Coverage layers
+
+  - `snapshot-args` — pure args-resolution against the live registrar +
+    shell-state cell-overrides.
+  - `gen-variant-snippet` — codegen output is `read-string`-able EDN
+    with the expected `(reg-variant <id> {:extends ... :args {...}})`
+    shape.
+  - Dialog state machine (`open` / `close` / `set-draft-id`) — pure
+    transitions JVM-testable in isolation.
+  - `:rf.story/save-current-as-variant` event handler — registered via
+    `install-canonical-event-handlers!` and dispatchable through the
+    standard re-frame router."
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story :as story]
+            [re-frame.story.save-variant :as save-variant]
+            [re-frame.story.ui.state :as state]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn reset-all! [f]
+  (story/clear-all!)
+  (state/reset-shell-state!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch clojure.lang.ExceptionInfo _ nil))
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (save-variant/set-open-dialog-fn! nil)
+  (f))
+
+(use-fixtures :each reset-all!)
+
+;; ---- snapshot-args -------------------------------------------------------
+
+(deftest snapshot-args-returns-resolved-args
+  (testing "snapshot-args delegates to args/resolve-args + returns the merged map"
+    (story/reg-story :story.snap {:args {:theme :light}})
+    (story/reg-variant :story.snap/v
+      {:args {:label "hello" :n 1}
+       :events []})
+    (let [snap (save-variant/snapshot-args :story.snap/v)]
+      (is (= "hello" (:label snap)))
+      (is (= 1 (:n snap)))
+      (is (= :light (:theme snap)) "story-level args are part of the snapshot"))))
+
+(deftest snapshot-args-includes-cell-overrides
+  (testing "cell-overrides supplied as opts override the variant args"
+    (story/reg-variant :story.snap/v
+      {:args   {:label "before" :keep "yes"}
+       :events []})
+    (let [snap (save-variant/snapshot-args
+                 :story.snap/v
+                 {:cell-overrides {:label "after"}})]
+      (is (= "after" (:label snap)) "override wins over variant args")
+      (is (= "yes"   (:keep snap))  "non-overridden keys come through"))))
+
+(deftest snapshot-args-empty-for-unknown-variant
+  (testing "an unknown variant returns an empty map (no throw)"
+    (is (= {} (save-variant/snapshot-args :story.nope/missing)))))
+
+;; ---- gen-variant-snippet -------------------------------------------------
+
+(deftest gen-variant-snippet-renders-reg-variant
+  (testing "snippet renders the (reg-variant ...) form with :args"
+    (let [snip (save-variant/gen-variant-snippet
+                 {:variant-id :story.counter/saved
+                  :extends    :story.counter/happy-path
+                  :args       {:label "hi" :n 3}})]
+      (is (str/includes? snip "reg-variant"))
+      (is (str/includes? snip ":story.counter/saved"))
+      (is (str/includes? snip ":extends"))
+      (is (str/includes? snip ":story.counter/happy-path"))
+      (is (str/includes? snip ":args"))
+      (is (str/includes? snip ":label"))
+      (is (str/includes? snip "\"hi\""))
+      (is (str/includes? snip ":n"))
+      (is (str/includes? snip "3")))))
+
+(deftest gen-variant-snippet-empty-args
+  (testing "snippet with empty args renders an empty map literal"
+    (let [snip (save-variant/gen-variant-snippet
+                 {:variant-id :story.x/y
+                  :args       {}})]
+      (is (str/includes? snip ":args"))
+      (is (str/includes? snip "{}")))))
+
+(deftest gen-variant-snippet-without-extends
+  (testing "no :extends → no :extends slot in the form"
+    (let [snip (save-variant/gen-variant-snippet
+                 {:variant-id :story.x/y
+                  :args       {:n 1}})]
+      (is (not (str/includes? snip ":extends"))))))
+
+(deftest gen-variant-snippet-includes-doc
+  (let [snip (save-variant/gen-variant-snippet
+               {:variant-id :story.x/y
+                :doc        "captured via Save"
+                :args       {:n 1}})]
+    (is (str/includes? snip ":doc"))
+    (is (str/includes? snip "captured via Save"))))
+
+(deftest gen-variant-snippet-custom-alias
+  (let [snip (save-variant/gen-variant-snippet
+               {:variant-id :story.x/y
+                :alias      "rf"
+                :args       {}})]
+    (is (str/includes? snip "rf/reg-variant"))))
+
+(defn- extract-args-map
+  "Walk balanced braces after the `:args` token to extract the args-map
+  substring from the generated snippet."
+  [snippet]
+  (let [start (str/index-of snippet ":args")
+        after (subs snippet start)
+        open  (str/index-of after "{")]
+    (loop [i (inc open) depth 1]
+      (cond
+        (or (nil? i) (>= i (count after)))
+        nil
+
+        (zero? depth)
+        (subs after open i)
+
+        :else
+        (let [c (.charAt ^String after i)]
+          (case c
+            \{ (recur (inc i) (inc depth))
+            \} (recur (inc i) (dec depth))
+            (recur (inc i) depth)))))))
+
+(deftest gen-variant-snippet-args-roundtrip
+  (testing "the rendered :args map reads back as the original map"
+    (let [args     {:label "alice" :n 42 :tags #{:a :b} :nested {:k 1}}
+          snippet  (save-variant/gen-variant-snippet
+                     {:variant-id :story.x/y :args args})
+          args-str (extract-args-map snippet)]
+      (is (some? args-str) "extractor found an :args map substring")
+      (is (= args (edn/read-string args-str))))))
+
+(deftest gen-variant-snippet-sorted-keys
+  (testing "args keys render in sorted order for determinism"
+    (let [args   {:z 1 :a 2 :m 3}
+          snip   (save-variant/gen-variant-snippet
+                   {:variant-id :story.x/y :args args})
+          a      (str/index-of snip ":a")
+          m      (str/index-of snip ":m")
+          z      (str/index-of snip ":z")]
+      (is (< a m z) ":a < :m < :z by index in the rendered form"))))
+
+;; ---- default-variant-id --------------------------------------------------
+
+(deftest default-variant-id-uses-source-namespace
+  (is (= "story.counter"
+         (namespace (save-variant/default-variant-id
+                      :story.counter/happy-path 12345))))
+  (is (str/starts-with?
+        (name (save-variant/default-variant-id
+                :story.counter/happy-path 12345))
+        "saved-")))
+
+(deftest default-variant-id-nil-for-unqualified
+  (is (nil? (save-variant/default-variant-id :unqualified 0)))
+  (is (nil? (save-variant/default-variant-id nil 0))))
+
+;; ---- dialog state machine -------------------------------------------------
+
+(deftest open-builds-dialog-state
+  (let [s (save-variant/open save-variant/initial-dialog-state
+                             :story.x/y
+                             {:n 1}
+                             1000)]
+    (is (true? (:open? s)))
+    (is (= :story.x/y (:source-id s)))
+    (is (= {:n 1} (:args s)))
+    (is (qualified-keyword? (:draft-id s)))))
+
+(deftest close-returns-idle
+  (let [opened (save-variant/open save-variant/initial-dialog-state
+                                  :story.x/y {:n 1} 0)
+        closed (save-variant/close opened)]
+    (is (= save-variant/initial-dialog-state closed))))
+
+(deftest set-draft-id-replaces
+  (let [s (-> save-variant/initial-dialog-state
+              (save-variant/open :story.x/y {} 0)
+              (save-variant/set-draft-id :story.x/edited))]
+    (is (= :story.x/edited (:draft-id s)))))
+
+;; ---- save-current-as-variant! end-to-end ---------------------------------
+
+(deftest save-current-as-variant!-triggers-callback
+  (testing "the impure trigger calls the registered open-dialog callback"
+    (story/reg-variant :story.snap/v {:args {:n 7} :events []})
+    (state/swap-state! state/select-variant :story.snap/v)
+    (let [captured (atom nil)]
+      (save-variant/set-open-dialog-fn!
+        (fn [source-id args _now-ms]
+          (reset! captured {:source-id source-id :args args})))
+      (let [result (save-variant/save-current-as-variant!)]
+        (is (some? @captured) "the callback fired")
+        (is (= :story.snap/v (:source-id @captured)))
+        (is (= 7 (-> @captured :args :n)))
+        (is (= :story.snap/v (:source-id result)))))))
+
+(deftest save-current-as-variant!-nil-when-no-focus
+  (testing "without a focused variant the trigger is a no-op"
+    (state/swap-state! state/select-variant nil)
+    (let [captured (atom nil)]
+      (save-variant/set-open-dialog-fn!
+        (fn [_ _ _] (reset! captured :fired)))
+      (let [result (save-variant/save-current-as-variant!)]
+        (is (nil? result) "no result without a focus")
+        (is (nil? @captured) "callback never fires without a focus")))))
+
+(deftest save-current-as-variant!-variant-id-override
+  (testing "an explicit :variant-id overrides the shell's focus"
+    (story/reg-variant :story.snap/override {:args {:n 42} :events []})
+    (state/swap-state! state/select-variant nil)
+    (let [captured (atom nil)]
+      (save-variant/set-open-dialog-fn!
+        (fn [source-id args _]
+          (reset! captured {:source-id source-id :args args})))
+      (save-variant/save-current-as-variant! {:variant-id :story.snap/override})
+      (is (= :story.snap/override (:source-id @captured)))
+      (is (= 42 (-> @captured :args :n))))))
+
+;; ---- :rf.story/save-current-as-variant event handler ---------------------
+
+(deftest event-handler-is-registered
+  (testing "install-canonical-vocabulary! registers the save-as-variant event"
+    (is (some? (registrar/handler :event
+                save-variant/id-save-current-as-variant))
+        "the :rf.story/save-current-as-variant handler is in the registry")))
+
+(deftest event-handler-triggers-callback
+  (testing "dispatching :rf.story/save-current-as-variant runs the save flow"
+    (story/reg-variant :story.event/v {:args {:n 9} :events []})
+    (state/swap-state! state/select-variant :story.event/v)
+    (let [captured (atom nil)]
+      (save-variant/set-open-dialog-fn!
+        (fn [source-id args _]
+          (reset! captured {:source-id source-id :args args})))
+      (rf/dispatch-sync [save-variant/id-save-current-as-variant])
+      (is (= :story.event/v (:source-id @captured)))
+      (is (= 9 (-> @captured :args :n))))))
+
+(deftest event-handler-honors-payload-opts
+  (testing "the event payload's :variant-id overrides the focused variant"
+    (story/reg-variant :story.event/explicit {:args {:n 11} :events []})
+    (state/swap-state! state/select-variant nil)
+    (let [captured (atom nil)]
+      (save-variant/set-open-dialog-fn!
+        (fn [source-id args _]
+          (reset! captured {:source-id source-id :args args})))
+      (rf/dispatch-sync [save-variant/id-save-current-as-variant
+                         {:variant-id :story.event/explicit}])
+      (is (= :story.event/explicit (:source-id @captured)))
+      (is (= 11 (-> @captured :args :n))))))
+
+;; ---- end-to-end ----------------------------------------------------------
+
+(deftest end-to-end-snapshot-to-snippet
+  (testing "the full snapshot→snippet cycle produces a reg-variant form"
+    (story/reg-story :story.counter {:args {:theme :dark}})
+    (story/reg-variant :story.counter/happy-path
+      {:args {:label "Counter" :n 0}
+       :events []})
+    (state/swap-state! state/select-variant :story.counter/happy-path)
+    ;; Capture via the impure trigger; harvest snapshot from the callback.
+    (let [captured (atom nil)]
+      (save-variant/set-open-dialog-fn!
+        (fn [source-id args _]
+          (reset! captured {:source-id source-id :args args})))
+      (save-variant/save-current-as-variant!)
+      (let [snippet  (save-variant/gen-variant-snippet
+                       {:variant-id :story.counter/saved-1
+                        :extends    (:source-id @captured)
+                        :args       (:args @captured)})
+            args-str (extract-args-map snippet)]
+        (is (= :story.counter/happy-path (:source-id @captured)))
+        (is (= :dark (-> @captured :args :theme)))
+        (is (str/includes? snippet "reg-variant"))
+        (is (str/includes? snippet ":story.counter/saved-1"))
+        (is (str/includes? snippet ":story.counter/happy-path")
+            "the source-id rides into :extends")
+        (is (= (:args @captured) (edn/read-string args-str))
+            "the snapshot args round-trip through the snippet")))))


### PR DESCRIPTION
## Summary

SB9 story-from-UI parity (per rf2-v05qb §2.2). Adds the second of two
story-from-UI affordances: tweak controls on an existing variant,
click **save as new variant…**, and Story emits a `(reg-variant ...)`
form pinned to the current selection — args, mode overrides, and
cell-local edits collapsed into one snapshot.

```clojure
;; Click 'save as new variant…' after dragging :n up to 7 in :dark mode →
(story/reg-variant :story.counter/saved-739221
  {:extends :story.counter/happy-path
   :args    {:label "Counter"
             :n     7
             :theme :dark}})
```

The captured `:args` are the **effective** args — the five-layer
precedence chain (global < story < modes < variant < cell-overrides)
resolved to a single map. Source is never written directly; the modal
preview gives a review-then-commit step (same pattern as Test Codegen).

## What ships

- **`re-frame.story.save-variant`** (cljc, pure) — `snapshot-args`
  helper (wraps `args/resolve-args`), `gen-variant-snippet` EDN
  code-gen, dialog state-machine transitions, and the impure
  `save-current-as-variant!` trigger.
- **`re-frame.story.ui.save-variant`** (CLJS-only) — Reagent ratom +
  controls-panel button + modal dialog. Mirrors the recorder's UI
  split so both save-as flows share visual language.
- **`:rf.story/save-current-as-variant` event handler** — registered
  via `install-canonical-event-handlers!`; dispatchable from agent /
  chrome surfaces with an optional `{:variant-id ...}` payload.
- **Controls-panel wiring** — button below the args editor.
- **Shell wiring** — installs the dialog-open callback at mount;
  renders the save dialog alongside the recorder's.

## Why review-then-commit (not auto-write)

Storybook 9 auto-writes the source file via a Vite plugin. That
entangles the playground with the project's Prettier config,
source-control conflicts, and CI hooks. Story takes the
review-then-commit path instead: the modal previews an EDN form the
user copies into source. One snapshot of the args atom + one EDN
pretty-printer — no AST rewriting, no format-on-save coupling.

The `:rf.story/save-current-as-variant` event id sits under the
`:rf.story/*` reserved namespace and is filtered by the Test Codegen
recorder's `recordable-event?` predicate — a save dispatched during an
active recording never appears in the recorded `:play` body.

## Docs

- Spec: `tools/story/spec/005-SOTA-Features.md` §Save current canvas
  state as variant.
- Guide: `docs/guide/21-stories.md` §Save current canvas state as a
  new variant.

## Test plan

- [x] JVM: `clojure -M:test` from `tools/story/` — 300 tests / 835
      assertions, 0 failures. 22 new tests in
      `re-frame.story-save-variant-test`.
- [x] CLJS: `npm run test:cljs` — 1726 tests / 4779 assertions, 0
      failures. New tests in `re-frame.story-save-variant-cljs-test`
      and `re-frame.story.ui.save-variant-cljs-test`.
- [x] Bundle isolation: `npm run test:bundle-isolation` — passes.
      Save-variant is gated under `config/enabled?` so production
      builds elide cleanly.