### PR TITLE
fix(ci): bundle-comparison verifier filters to top-level main.js (rf2-z9a06)

### DIFF
--- a/implementation/scripts/check-counter-slim-and-fast.cjs
+++ b/implementation/scripts/check-counter-slim-and-fast.cjs
@@ -116,25 +116,35 @@ const REACT_DOM_SERVER_SENTINELS = [
 // ----- helpers ---------------------------------------------------------------
 
 function readAllJs(dir) {
-  // Concatenate every *.js file under dir into a single blob, mirroring
-  // scripts/check-bundle-isolation.cjs's readAllJs. :advanced may split
-  // the runtime across files (cljs_base, the module's own file); a
-  // global grep is the right shape for the comparison contract.
+  // Concatenate every top-level *.js file in dir into a single blob.
+  // For shadow-cljs :browser :release builds the closure-compiled
+  // output lives in top-level files (main.js, plus any sibling module
+  // files like cljs_base.js); the only subdirectory that appears in
+  // the output dir is `cljs-runtime/`, which is dev-build debug source
+  // left behind by a prior `shadow-cljs compile` and NOT cleaned by a
+  // subsequent `shadow-cljs release` (rf2-z9a06).
+  //
+  // Walking recursively (as the sibling readAllJs in
+  // check-bundle-isolation.cjs does) means a stale `cljs-runtime/`
+  // dir gets grepped alongside the release main.js — producing false
+  // FAILs on sentinels that only appear in the unoptimised dev
+  // sources (e.g. cljsLegacyRender, react-dom/server). CI is unaffected
+  // because every CI run is on a clean dir, but local repros after a
+  // dev `compile` trip the trap; the contract should measure the
+  // release artefact regardless.
+  //
+  // The release artefact IS exactly the top-level *.js — that's what a
+  // consumer ships. Filtering to it makes the contract robust against
+  // dev-build leftovers in the output dir.
   if (!fs.existsSync(dir)) {
     return null;
   }
   const out = [];
-  const walk = (d) => {
-    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
-      const full = path.join(d, entry.name);
-      if (entry.isDirectory()) {
-        walk(full);
-      } else if (entry.isFile() && entry.name.endsWith('.js')) {
-        out.push(fs.readFileSync(full, 'utf8'));
-      }
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.endsWith('.js')) {
+      out.push(fs.readFileSync(path.join(dir, entry.name), 'utf8'));
     }
-  };
-  walk(dir);
+  }
   return out.join('\n');
 }
 


### PR DESCRIPTION
## Summary

Fixes rf2-z9a06: `scripts/check-counter-slim-and-fast.cjs` produced false FAILs locally when a prior `shadow-cljs compile` had left a `cljs-runtime/` debug-source subdir under `out/examples/<build>/`. The verifier's `readAllJs` walked the output dir recursively and grepped both the release `main.js` AND the stale dev sources, so sentinels that only live in the unoptimised output (e.g. `cljsLegacyRender`, `react-dom/server`) fired.

The release artefact is exactly the top-level `*.js` — that's what a consumer ships and what the bundle-comparison contract measures. Restricting `readAllJs` to top-level `*.js` makes the contract robust against dev-build leftovers in the output dir regardless of the caller's local shadow-cljs history.

CI is unaffected (every run uses a clean dir); this fix recovers the local-repro path caught during rf2-tba5e's reagent-slim smoke test.

## Approach: filter, not clean

Of the three options the bead listed, I took (a) — filter `readAllJs` to top-level `*.js` only. Rationale:

- **Localised.** Single-file change to the verifier; doesn't touch `package.json` scripts or `shadow-cljs.edn` config. The fix lives where the bug was diagnosed (the script trusts too much about what's in the dir).
- **Correct shape for the contract.** The release artefact a consumer ships *is* the top-level `*.js`. Measuring that — and only that — is exactly what S3-008 / S3-005 are claiming about. Cleaning the dir before `release` would also work but would couple the verifier's correctness to a side-channel npm-script convention.
- **Won't regress on real splits.** `shadow-cljs :browser :release` for these examples uses a single `:modules {:main ...}` (see `shadow-cljs.edn` :examples/counter and :examples/counter-slim-and-fast), so all release output lives in top-level files. Even if a future split adds a sibling `cljs_base.js` etc., it lands at the top level, not under `cljs-runtime/` (which is dev-only).

The sibling `check-bundle-isolation.cjs` has the same recursive `readAllJs` shape but the bead scopes the fix to this script; the same trap could be addressed there in a follow-up if it ever bites.

## Test plan

- [x] `node --check` passes on the modified script
- [ ] Local repro: `npx shadow-cljs compile examples/counter-slim-and-fast` (creates `cljs-runtime/`), then `npm run test:bundle-comparison` — should PASS after this change (previously: false FAILs on `cljsLegacyRender` and `react-dom/server`)
- [ ] CI: `cljs-bundle-comparison` job continues to PASS (dir is clean per run, no behavioural change)