### PR TITLE
spec(causa): enumerate App-DB-Diff reserved-keys group (rf2-qictc)

### DIFF
--- a/tools/causa/spec/004-App-DB-Diff.md
+++ b/tools/causa/spec/004-App-DB-Diff.md
@@ -77,10 +77,24 @@ sessions.
 
 ## Reserved-keys group
 
-The runtime's reserved app-db keys (`:rf/machines`, `:rf/route`,
-`:rf/system-ids`, `:rf/pending-navigation`, `:rf/spawned`, per
-[Conventions §Reserved app-db keys](../../../spec/Conventions.md#reserved-app-db-keys))
-render in a separate `[runtime]` group at the bottom of the panel:
+The runtime owns a fixed set of top-level `app-db` keys, catalogued
+in [Conventions §Reserved app-db keys](../../../spec/Conventions.md#reserved-app-db-keys).
+Causa's `[runtime]` group segregates these five:
+
+| Reserved key | Owner | One-line role |
+|---|---|---|
+| `:rf/machines` | machine runtime | Per-frame map of `<machine-id> → :rf/machine-snapshot` — every active machine's snapshot. |
+| `:rf/system-ids` | machine runtime | Reverse index `<system-id> → <gensym'd-machine-id>` for `:system-id` named-machine addressing. |
+| `:rf/spawned` | machine runtime | Declarative-`:invoke` / `:invoke-all` spawn registry — `<parent-id> → {<invoke-id> <slot>}` for the destroy-cascade walker. |
+| `:rf/route` | routing runtime | The current route slice `{:id :params :query :transition :error}`. |
+| `:rf/pending-navigation` | routing runtime | Pending-navigation slot populated when a `:can-leave` guard rejects; cleared by `:rf.route/continue` / `:rf.route/cancel`. |
+
+Conventions is the canonical home; this table is the panel-facing
+projection. The five above are the keys Causa's `partition-reserved`
+treats as runtime-owned in the diff panel — diff triples rooted in
+one of them render here rather than as slice mini-panels. If a new
+reserved key lands in Conventions, the `[runtime]` group's coverage
+and this table are updated in lockstep.
 
 ```
 ┌─ [runtime] ───────────────────────────────────────┐


### PR DESCRIPTION
## Summary

Causa's `004-App-DB-Diff.md` §Reserved-keys group previously listed the
five runtime-owned keys inline in a parenthetical (`:rf/machines`,
`:rf/route`, `:rf/system-ids`, `:rf/pending-navigation`, `:rf/spawned`).
An AI working from the spec couldn't easily see what each key is
without grepping the codebase or chasing the Conventions cross-link.

Expanded to an enumerated table with one-line role descriptions for
each of the five keys — matching the impl's `partition-reserved` set
in `tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_helpers.cljc`.

Cross-links `spec/Conventions.md` §Reserved app-db keys as the canonical
home; notes the table is the panel-facing projection so a future
reserved key landing in Conventions has a clear lockstep contract.

Closes rf2-qictc. Fixes Gap #9 from `ai/findings/causa-impl-spec-gap-20260513-1705.md`.

## Test plan

- [ ] Spec-only doc change; no code paths touched.
- [ ] `mkdocs build --strict` if Causa spec is in the docs build (not currently — `tools/causa/spec/` is the project's spec tree, not user docs).