### PR TITLE
feat(ssr): reg-head / render-head / active-head (rf2-4dra9)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -395,6 +395,9 @@
 (def render-to-string rf-ssr/render-to-string)
 (def render-tree-hash rf-ssr/render-tree-hash)
 (def project-error    rf-ssr/project-error)
+(def render-head      rf-ssr/render-head)
+(def active-head      rf-ssr/active-head)
+(def head-model->html rf-ssr/head-model->html)
 
 ;; ---- frame management ----------------------------------------------------
 
@@ -549,6 +552,26 @@
 
 #?(:cljs
    (def reg-error-projector -reg-error-projector))
+
+;; reg-head — Spec 011 §Head/meta contract (rf2-4dra9). Same macro/CLJS-
+;; alias pattern as reg-error-projector — re-frame.ssr.head ships the
+;; producing fn behind the :ssr/reg-head late-bind hook; the macro form
+;; captures source-coords (Spec 001) at the user's call site.
+
+(def ^:private -reg-head rf-ssr/-reg-head)
+
+#?(:clj
+   (defmacro reg-head
+     "Register a head-fragment producer — `(fn [db route] head-model)`.
+     `id` is a namespaced keyword (e.g. `:my.app/article`); routes name
+     a head via `:head` route metadata. Captures source-coords (Spec 001)
+     at this call site. Per Spec 011 §Head/meta contract."
+     [& args]
+     (with-coords-form (meta &form) *file* (symbol (str (ns-name *ns*)))
+                       `(rf-ssr/-reg-head ~@args))))
+
+#?(:cljs
+   (def reg-head -reg-head))
 
 ;; ---- flows / schemas — plain-fn re-exports -------------------------------
 

--- a/implementation/core/src/re_frame/core_ssr.cljc
+++ b/implementation/core/src/re_frame/core_ssr.cljc
@@ -73,3 +73,85 @@
                      :frame    frame-id
                      :recovery :no-recovery
                      :reason   "rf/project-error requires day8/re-frame2-ssr on the classpath; add it to deps and require re-frame.ssr at app boot."}))))
+
+;; ---- Head/meta contract — rf2-4dra9 --------------------------------------
+;;
+;; Per Spec 011 §Head/meta contract. `re-frame.ssr.head` ships the impl;
+;; the wrappers below look the producing fns up through the late-bind hook
+;; table so core never statically requires re-frame.ssr.head. Apps that
+;; don't pull `day8/re-frame2-ssr` see `:rf.error/ssr-artefact-missing`
+;; when these surfaces are called.
+
+(defn -reg-head
+  "Internal helper — prefer `reg-head` from public callers. This is the
+  fn-form delegate the public macro / CLJS alias forward to. Late-bound
+  via :ssr/reg-head."
+  ([id head-fn]
+   (-reg-head id {} head-fn))
+  ([id metadata head-fn]
+   (if-let [f (late-bind/get-fn :ssr/reg-head)]
+     (f id metadata head-fn)
+     (throw (ex-info ":rf.error/ssr-artefact-missing"
+                     {:where    'rf/reg-head
+                      :id       id
+                      :recovery :no-recovery
+                      :reason   "rf/reg-head requires day8/re-frame2-ssr on the classpath; add it to deps and require re-frame.ssr at app boot."})))))
+
+(defn render-head
+  "Apply the head fn registered under `head-id` against a frame's
+  app-db and active route. Returns the produced `:rf/head-model`. Per
+  Spec 011 §Head/meta contract. Late-bound via :ssr/render-head.
+
+  Two opt shapes:
+
+    (render-head head-id frame-id)
+    (render-head head-id {:frame frame-id :route route})"
+  [head-id opts]
+  (if-let [f (late-bind/get-fn :ssr/render-head)]
+    (f head-id opts)
+    (throw (ex-info ":rf.error/ssr-artefact-missing"
+                    {:where    'rf/render-head
+                     :head-id  head-id
+                     :recovery :no-recovery
+                     :reason   "rf/render-head requires day8/re-frame2-ssr on the classpath; add it to deps and require re-frame.ssr at app boot."}))))
+
+(defn active-head
+  "Look up the active route's `:head` metadata; if set, call
+  `render-head` and return the model. Otherwise return the
+  default head per Spec 011 §Default head. Late-bound via
+  :ssr/active-head.
+
+  Arities:
+
+    (active-head)            — uses the default frame `:rf/default`.
+    (active-head frame-id)"
+  ([]
+   (if-let [f (late-bind/get-fn :ssr/active-head)]
+     (f)
+     (throw (ex-info ":rf.error/ssr-artefact-missing"
+                     {:where    'rf/active-head
+                      :recovery :no-recovery
+                      :reason   "rf/active-head requires day8/re-frame2-ssr on the classpath; add it to deps and require re-frame.ssr at app boot."}))))
+  ([frame-id]
+   (if-let [f (late-bind/get-fn :ssr/active-head)]
+     (f frame-id)
+     (throw (ex-info ":rf.error/ssr-artefact-missing"
+                     {:where    'rf/active-head
+                      :frame    frame-id
+                      :recovery :no-recovery
+                      :reason   "rf/active-head requires day8/re-frame2-ssr on the classpath; add it to deps and require re-frame.ssr at app boot."})))))
+
+(defn head-model->html
+  "Render a `:rf/head-model` map to its inner-head HTML fragment in
+  canonical order. Per Spec 011 §Default flow step 4. Late-bound via
+  :ssr/head-model-html (the hook key drops the user-facing fn's
+  `->` decoration for late-bind naming hygiene)."
+  ([head-model]
+   (head-model->html head-model {}))
+  ([head-model opts]
+   (if-let [f (late-bind/get-fn :ssr/head-model-html)]
+     (f head-model opts)
+     (throw (ex-info ":rf.error/ssr-artefact-missing"
+                     {:where    'rf/head-model->html
+                      :recovery :no-recovery
+                      :reason   "rf/head-model->html requires day8/re-frame2-ssr on the classpath; add it to deps and require re-frame.ssr at app boot."})))))

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -278,7 +278,33 @@
    {:key         :ssr/on-frame-destroyed
     :producer-ns 're-frame.ssr
     :design-bead "rf2-fcj33"
-    :description "Clear the SSR side-channel atoms (pending-error-traces + request-slots) for a destroyed frame, per Spec 011 §Per-request frame teardown contract."}
+    :description "Clear the SSR side-channel atoms (pending-error-traces + request-slots) for a destroyed frame, per Spec 011 §Per-request frame teardown contract. Also invokes `:ssr/head-on-frame-destroyed` (if registered) so the head ns can release per-frame snapshot bookkeeping (rf2-4dra9)."}
+
+   ;; ---- re-frame.ssr.head (rf2-4dra9 — head/meta contract) ------------------
+   {:key         :ssr/reg-head
+    :producer-ns 're-frame.ssr.head
+    :design-bead "rf2-4dra9"
+    :description "Register a head-fragment producer fn `(fn [db route] head-model)` under id, per Spec 011 §Head/meta contract."}
+   {:key         :ssr/render-head
+    :producer-ns 're-frame.ssr.head
+    :design-bead "rf2-4dra9"
+    :description "Apply the head fn registered under `head-id` against a frame's app-db and active route, returning the produced `:rf/head-model`."}
+   {:key         :ssr/active-head
+    :producer-ns 're-frame.ssr.head
+    :design-bead "rf2-4dra9"
+    :description "Look up the active route's `:head` metadata; if set, call `render-head` and return the model. Otherwise return the default head per Spec 011 §Default head."}
+   {:key         :ssr/head-snapshot
+    :producer-ns 're-frame.ssr.head
+    :design-bead "rf2-4dra9"
+    :description "Read the per-frame `{head-id → last-produced head-model}` snapshot. Cleared on frame destroy via the `:ssr.head/on-frame-destroyed` hook chained from re-frame.ssr's teardown."}
+   {:key         :ssr/head-model-html
+    :producer-ns 're-frame.ssr.head
+    :design-bead "rf2-4dra9"
+    :description "Render a `:rf/head-model` map to its inner-head HTML fragment in canonical order: title → meta → link → script → JSON-LD."}
+   {:key         :ssr/head-on-frame-destroyed
+    :producer-ns 're-frame.ssr.head
+    :design-bead "rf2-4dra9"
+    :description "Clear the per-frame head-snapshot entry on destroy. `re-frame.ssr/on-frame-destroyed!` invokes this hook by key after clearing its own side-channel atoms."}
 
    ;; ---- re-frame.adapter.reagent (rf2-0hxm) ---------------------------------
    {:key         :reagent/set-hiccup-emitter!

--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -64,16 +64,24 @@
     via `(inject-cofx :rf.server/request)` get nil until the cofx
     lands.
 
+  Head/meta integration (rf2-4dra9):
+
+    The adapter resolves the active route's `:head` registration via
+    `rf/active-head` after the drain settles; the produced
+    `:rf/head-model` is rendered to its inner-head HTML fragment via
+    `rf/head-model->html` and threaded into the shell as the `:head`
+    opt. Custom shells (`:html-shell` opt) receive the resolved head
+    fragment in the merged opts map. Routes that don't declare `:head`
+    fall back to the default head model (Spec 011 §Default head); the
+    fragment is empty when there is no useful head data.
+
   Out of scope here (deferred / other beads):
 
     - Streaming SSR (rf2-olb64)            — `render-to-string` is
                                              a single-shot emitter; this
                                              adapter mirrors that.
     - Async Ring handler (3-arity)         — synchronous-only in v1;
-                                             extension is additive.
-    - reg-head / render-head integration   — deferred per rf2-gr0n;
-                                             the v1 html-shell is the
-                                             escape hatch."
+                                             extension is additive."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.ssr :as ssr])
@@ -315,6 +323,20 @@
     (let [hiccup (if (fn? root-view) (root-view) root-view)]
       (ssr/render-tree-hash hiccup))))
 
+(defn- resolve-head-html
+  "Resolve the active route's `:head` against `frame-id` (or the default
+  head when the route doesn't declare one). Returns the inner-head HTML
+  fragment as a string. Exceptions during resolution degrade gracefully
+  to an empty string so a buggy head fn can't take down the request —
+  the trace surface still carries the throw for monitoring.
+
+  Per Spec 011 §Head/meta contract (rf2-4dra9)."
+  [frame-id]
+  (try
+    (let [model (rf/active-head frame-id)]
+      (rf/head-model->html model))
+    (catch Throwable _ "")))
+
 (defn- on-create-with-request
   "Conj the Ring request map onto the caller's :on-create event vector
   so handlers can read it as an event arg. The `:rf.server/request`
@@ -460,7 +482,14 @@
                                                   :schema-digest schema-digest
                                                   :payload-keys  payload-keys})
                       payload-edn (pr-str payload)
-                      html        (html-shell body-html payload-edn opts)
+                      ;; rf2-4dra9: resolve the active route's :head
+                      ;; (or default-head fallback) and pass the rendered
+                      ;; fragment as the :head opt. Callers that supplied
+                      ;; an explicit :head opt take precedence — they
+                      ;; chose to bypass route-driven head resolution.
+                      head-html   (or (:head opts) (resolve-head-html frame-id))
+                      shell-opts  (assoc opts :head head-html)
+                      html        (html-shell body-html payload-edn shell-opts)
                       ;; Ensure Content-Type is set; the SSR runtime
                       ;; defaults [:rf/response :headers] to include
                       ;; content-type so this is usually a no-op, but

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -53,6 +53,14 @@
             [re-frame.source-coords :as source-coords]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.trace :as trace]
+            ;; rf2-4dra9 — head/meta contract surface (Spec 011 §Head/meta).
+            ;; The head ns publishes its late-bind hooks at ns-load time;
+            ;; static `:require` here ensures the hooks are available
+            ;; before any user code calls `rf/reg-head` / `rf/render-head`
+            ;; / `rf/active-head`. The dependency is acyclic — head.cljc
+            ;; only pulls re-frame.frame / re-frame.registrar (already in
+            ;; this ns's requires).
+            re-frame.ssr.head
             #?(:cljs [re-frame.substrate.plain-atom :as plain-atom-cljs])))
 
 (defn- escape-html [s]
@@ -1153,10 +1161,18 @@ response with no body."
   for `frame-id`. Called from `frame/destroy-frame!` via the
   `:ssr/on-frame-destroyed` late-bind hook. Idempotent — a second call
   against the same frame-id sees both atoms already cleared and does
-  nothing."
+  nothing.
+
+  Per rf2-4dra9 (Spec 011 §Head/meta contract), also invokes any
+  registered `:ssr/head-on-frame-destroyed` hook so `re-frame.ssr.head`
+  can release its per-frame head-snapshot bookkeeping. Hook lookup is
+  late-bound so the call is a no-op when the head ns is absent."
   [frame-id]
   (swap! pending-error-traces dissoc frame-id)
   (swap! request-slots        dissoc frame-id)
+  (when-let [head-cleanup! (late-bind/get-fn :ssr/head-on-frame-destroyed)]
+    (try (head-cleanup! frame-id)
+         (catch #?(:clj Throwable :cljs :default) _ nil)))
   nil)
 
 (cofx/reg-cofx :rf.server/request
@@ -1206,3 +1222,12 @@ Per Spec 011 §Server-only `reg-cofx` for request context."
 ;; defonce-atoms accumulate one entry per request under SSR load — a slow
 ;; leak that compounds over a long-running server process.
 (late-bind/set-fn! :ssr/on-frame-destroyed  on-frame-destroyed!)
+
+;; rf2-4dra9 — `re-frame.ssr.head` is required from the top-of-file ns
+;; form so its late-bind hooks (`:ssr/reg-head`, `:ssr/render-head`,
+;; `:ssr/active-head`, `:ssr/head-snapshot`, `:ssr/head-model-html`)
+;; AND the per-frame head-snapshot cleanup hook
+;; (`:ssr.head/on-frame-destroyed`) land at ssr-ns load time on both
+;; JVM and CLJS. `on-frame-destroyed!` above invokes the head cleanup
+;; hook by key — load order between this ns and head.cljc is
+;; irrelevant to the call shape. Per Spec 011 §Head/meta contract.

--- a/implementation/ssr/src/re_frame/ssr/head.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head.cljc
@@ -1,0 +1,406 @@
+(ns re-frame.ssr.head
+  "Head/meta contract — `reg-head`, `render-head`, `active-head`. Per
+  Spec 011 §Head/meta contract (rf2-4dra9).
+
+  The server-rendered HTML must carry head metadata — `<title>`,
+  `<meta>`, `<link>`, JSON-LD — on first byte; crawlers and link-
+  unfurlers don't run JS. The pattern's commitment: **the head model
+  is data derived from app-db**, not an imperative DOM API.
+
+  Public surface:
+
+    `reg-head`          — register a head-fragment producer `(fn [db
+                          route] head-model)` keyed by id (e.g.
+                          `:rf.ssr/title`, `:my.app/article`). New
+                          registry kind `:head` (Spec 001 §Registry
+                          model — already in the closed v1 set).
+    `render-head`       — given a head-id and a frame (and optionally
+                          an explicit route), invoke the head fn
+                          against the frame's app-db and the active
+                          route; record the produced model in the
+                          per-frame snapshot map; return the model.
+    `active-head`       — sugar — looks up the active route's `:head`
+                          metadata in the registrar; if set, calls
+                          `render-head`; otherwise returns the default
+                          head per Spec 011 §Default head.
+    `head-model->html`  — emit `<head>…</head>` (or the inner fragment)
+                          from a `:rf/head-model`. Canonical order:
+                          `<title>` first, then `<meta>` (declaration
+                          order), then `<link>`, then `<script>`, then
+                          JSON-LD `<script type=\"application/ld+json\">`.
+                          `:html-attrs` / `:body-attrs` are exposed on
+                          the returned record so a host shell can
+                          stamp them onto `<html>` / `<body>`.
+    `head-snapshot`     — read the per-frame `{head-id → last-produced
+                          fragment}` snapshot. Useful for tests +
+                          introspection. Cleared on frame destroy.
+
+  Per-request frame lifecycle: the head-snapshot side-channel atom is
+  keyed by frame-id and cleared via the `:ssr/on-frame-destroyed`
+  late-bind hook (per Spec 011 §Per-request frame teardown / rf2-fcj33).
+  Head registrations under `:head` themselves are process-wide registry
+  entries (not per-frame state); cleanup applies only to the per-frame
+  snapshot, not to the registered fns."
+  (:require [clojure.string :as str]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.registrar :as registrar]
+            [re-frame.source-coords :as source-coords]))
+
+;; ---- HTML helpers (mirrors re-frame.ssr's escape/attr helpers) -------------
+;;
+;; head.cljc lives alongside ssr.cljc but is loaded after it; both produce
+;; HTML and share the same escape rules. We re-derive the helpers here
+;; (rather than depending on private symbols from ssr.cljc) so head.cljc
+;; remains a self-contained namespace whose contracts are visible at the
+;; public boundary.
+
+(defn- escape-html [s]
+  (-> (str s)
+      (str/replace "&" "&amp;")
+      (str/replace "<" "&lt;")
+      (str/replace ">" "&gt;")
+      (str/replace "\"" "&quot;")
+      (str/replace "'" "&#39;")))
+
+(defn- escape-attr [s]
+  (-> (str s)
+      (str/replace "&" "&amp;")
+      (str/replace "\"" "&quot;")))
+
+(defn- attr-string
+  "Render an attribute map as ` k1=\"v1\" k2=\"v2\"`. Boolean true → bare
+  attribute name; false / nil → omitted. Mirrors the rules in
+  `re-frame.ssr/-attr-string`."
+  [attrs]
+  (if (empty? attrs)
+    ""
+    (str " "
+         (str/join " "
+                   (keep (fn [[k v]]
+                           (cond
+                             (true? v)  (name k)
+                             (false? v) nil
+                             (nil? v)   nil
+                             :else      (str (name k) "=\"" (escape-attr v) "\"")))
+                         attrs)))))
+
+;; ---- canonical-order emitter ----------------------------------------------
+;;
+;; Per Spec 011 §Default flow: emit `<title>` first, then `<meta>` (in
+;; declaration order), then `<link>`, then `<script>`, then JSON-LD
+;; `<script type=\"application/ld+json\">`. `:html-attrs` populate
+;; `<html>`; `:body-attrs` populate `<body>` — those are emitted by the
+;; host shell, not by this fn.
+;;
+;; The result is a *string* containing the inner-head fragment (no
+;; surrounding `<head>` / `</head>` tags by default — host shells can
+;; choose whether they wrap). For convenience the 2-arity form opts in
+;; to the surrounding `<head>` tags.
+
+(defn- emit-title [title]
+  (when (and title (not= "" title))
+    (str "<title>" (escape-html title) "</title>")))
+
+(defn- emit-meta-tag [m]
+  (str "<meta" (attr-string m) ">"))
+
+(defn- emit-link-tag [m]
+  (str "<link" (attr-string m) ">"))
+
+(defn- emit-script-tag [m]
+  (let [{:keys [src async defer type integrity crossorigin nomodule]} m
+        attrs (cond-> {}
+                src         (assoc :src src)
+                type        (assoc :type type)
+                async       (assoc :async async)
+                defer       (assoc :defer defer)
+                integrity   (assoc :integrity integrity)
+                crossorigin (assoc :crossorigin crossorigin)
+                nomodule    (assoc :nomodule nomodule))]
+    (str "<script" (attr-string (merge attrs (dissoc m :src :async :defer :type :integrity :crossorigin :nomodule))) "></script>")))
+
+(defn- ld-json-string
+  "Serialise a JSON-LD object map to its `<script type=\"application/ld+json\">`
+  body. CLJ uses a minimal printer (works for the spec's canonical shape:
+  strings, numbers, booleans, vectors, maps with string keys). CLJS uses
+  `js/JSON.stringify` via `clj->js`."
+  [x]
+  #?(:cljs (js/JSON.stringify (clj->js x))
+     :clj  (letfn [(emit [v]
+                     (cond
+                       (nil? v)     "null"
+                       (boolean? v) (if v "true" "false")
+                       (number? v)  (str v)
+                       (string? v)  (str "\""
+                                         (-> v
+                                             (str/replace "\\" "\\\\")
+                                             (str/replace "\"" "\\\""))
+                                         "\"")
+                       (keyword? v) (emit (if-let [ns (namespace v)]
+                                            (str ns "/" (name v))
+                                            (name v)))
+                       (map? v)     (str "{"
+                                         (str/join "," (map (fn [[k val]]
+                                                              (str (emit (if (keyword? k) (name k) k))
+                                                                   ":"
+                                                                   (emit val)))
+                                                            v))
+                                         "}")
+                       (sequential? v) (str "[" (str/join "," (map emit v)) "]")
+                       :else (emit (str v))))]
+             (emit x))))
+
+(defn- emit-json-ld [m]
+  (str "<script type=\"application/ld+json\">"
+       (ld-json-string m)
+       "</script>"))
+
+(defn head-model->html
+  "Render a `:rf/head-model` map to its inner-head HTML fragment in
+  canonical order — `<title>`, `<meta>` (declaration order), `<link>`,
+  `<script>`, JSON-LD `<script type=\"application/ld+json\">`. The two
+  attribute-bag keys (`:html-attrs`, `:body-attrs`) are NOT emitted by
+  this fn — they're consumed by host shells that stamp them onto
+  `<html>` / `<body>`.
+
+  The 1-arity form returns the inner fragment (no surrounding `<head>`
+  tags); the 2-arity form with `{:wrap? true}` wraps in `<head>…</head>`.
+
+  Per Spec 011 §Default flow step 4."
+  ([head-model] (head-model->html head-model {}))
+  ([head-model {:keys [wrap?]}]
+   (let [{:keys [title meta link script json-ld]} head-model
+         parts (cond-> []
+                 (and title (not= "" title))
+                 (conj (emit-title title))
+
+                 (seq meta)
+                 (into (map emit-meta-tag) meta)
+
+                 (seq link)
+                 (into (map emit-link-tag) link)
+
+                 (seq script)
+                 (into (map emit-script-tag) script)
+
+                 (seq json-ld)
+                 (into (map emit-json-ld) json-ld))
+         inner (apply str parts)]
+     (if wrap?
+       (str "<head>" inner "</head>")
+       inner))))
+
+;; ---- per-frame snapshot ---------------------------------------------------
+;;
+;; A side-channel atom keyed by frame-id, mapping `head-id → last-produced
+;; head-model`. Cleared on per-request frame destroy via the
+;; `:ssr/on-frame-destroyed` hook (rf2-fcj33). Storage shape mirrors the
+;; pattern used by `re-frame.ssr/pending-error-traces` and
+;; `re-frame.ssr/request-slots` — the data is per-request bookkeeping
+;; that has no place in app-db (and must not ride the hydration payload
+;; to the client).
+
+(defonce
+  ^{:doc "Per-frame head snapshot. Keys are frame-ids; values are
+  `{head-id → head-model}` maps recording each render-head call's
+  output. Cleared on frame destroy. Inspectable via `head-snapshot`."}
+  head-snapshots
+  (atom {}))
+
+(defn- record-fragment!
+  "Stash the just-produced head-model under (frame-id, head-id) so
+  `head-snapshot` reflects the most recent render-head output."
+  [frame-id head-id head-model]
+  (when frame-id
+    (swap! head-snapshots assoc-in [frame-id head-id] head-model))
+  head-model)
+
+(defn head-snapshot
+  "Read the per-frame `{head-id → last-produced head-model}` snapshot.
+  Useful for tests and introspection. Returns `{}` for a frame that has
+  never seen a `render-head` call (or whose snapshot has been cleared
+  via the per-request frame teardown hook)."
+  ([frame-id]
+   (get @head-snapshots frame-id {})))
+
+(defn on-frame-destroyed!
+  "Clear the head-snapshot entry for `frame-id`. Wired into the
+  `:ssr/on-frame-destroyed` late-bind hook chain so per-request frames
+  release their head bookkeeping on destroy. Idempotent."
+  [frame-id]
+  (swap! head-snapshots dissoc frame-id)
+  nil)
+
+;; ---- reg-head -------------------------------------------------------------
+
+(defn reg-head
+  "Register a head-fragment producer under `id` (a namespaced keyword
+  such as `:my.app/article` or `:rf.ssr/title`).
+
+  `head-fn` signature is `(fn [db route] head-model)` — pure,
+  deterministic, no side-effects. Same shape and discipline as a sub.
+  `db` is the frame's app-db value (plain map, deref'd through the
+  substrate adapter); `route` is the `:rf/route` slice (or whatever
+  the caller passed to `render-head`).
+
+  Two arities:
+
+    (reg-head id           head-fn)
+    (reg-head id metadata  head-fn)
+
+  Returns `id` per the family-wide `reg-*` return-value convention
+  (Conventions.md §`reg-*` return-value convention).
+
+  Re-registering an existing id replaces the slot atomically. Per
+  Spec 011 §Mechanism — registered head function + route metadata."
+  ([id head-fn]
+   (reg-head id {} head-fn))
+  ([id metadata head-fn]
+   (registrar/register! :head id
+                        (assoc (source-coords/merge-coords metadata)
+                               :handler-fn head-fn))
+   id))
+
+;; ---- default head ---------------------------------------------------------
+;;
+;; Per Spec 011 §Default head when no route declares `:head`:
+;;
+;;   {:title (or (:doc (frame-meta frame-id)) "")
+;;    :meta [{:charset "utf-8"}
+;;           {:name "viewport" :content "width=device-width, initial-scale=1"}]}
+;;
+;; No registered head is required. The default is silent — no warning.
+
+(defn default-head
+  "The fallback head-model used when the active route does not declare
+  `:head` (or there is no active route). Per Spec 011 §Default head.
+
+  Pulls `:title` from the frame's `:doc` if set, otherwise empty."
+  [frame-id]
+  (let [doc (when frame-id (:doc (frame/frame-meta frame-id)))]
+    (cond-> {:meta [{:charset "utf-8"}
+                    {:name "viewport" :content "width=device-width, initial-scale=1"}]}
+      (and doc (not= "" doc)) (assoc :title doc))))
+
+;; ---- render-head ----------------------------------------------------------
+
+(defn- frame-route
+  "Read the `:rf/route` slice from a frame's app-db. nil-safe — a frame
+  whose app-db has never been initialised resolves to nil."
+  [frame-id]
+  (when frame-id
+    (let [db (frame/frame-app-db-value frame-id)]
+      (when db (:rf/route db)))))
+
+(defn render-head
+  "Apply the head fn registered under `head-id` against a frame's
+  app-db and active route, returning the produced `:rf/head-model`.
+
+  Two opt shapes are accepted:
+
+    (render-head head-id frame-id)
+    (render-head head-id {:frame frame-id :route route})
+
+  When `:route` is absent, the active route slice (`:rf/route`) is
+  read from the frame's app-db. The produced fragment is recorded in
+  the per-frame snapshot so `head-snapshot` reflects the most recent
+  render-head output.
+
+  Raises `:rf.error/no-such-head` when `head-id` is not registered.
+  Per Spec 011 §`render-head`."
+  ([head-id opts]
+   (let [opts'    (if (keyword? opts) {:frame opts} opts)
+         frame-id (:frame opts')
+         route    (if (contains? opts' :route)
+                    (:route opts')
+                    (frame-route frame-id))
+         meta     (registrar/lookup :head head-id)]
+     (when-not meta
+       (throw (ex-info ":rf.error/no-such-head"
+                       {:head-id  head-id
+                        :reason   (str "No head registered under " head-id ".")
+                        :recovery :no-recovery})))
+     (let [head-fn (:handler-fn meta)
+           db      (when frame-id (frame/frame-app-db-value frame-id))
+           model   (head-fn db route)]
+       (record-fragment! frame-id head-id model)
+       model))))
+
+;; ---- active-head ----------------------------------------------------------
+
+(defn- route-head-id
+  "Read the `:head` route-metadata key for the route-id named in the
+  active `:rf/route` slice. Returns nil when there's no active route,
+  no route registration, or no `:head` declared on the route."
+  [route]
+  (when-let [route-id (:id route)]
+    (when-let [route-meta (registrar/lookup :route route-id)]
+      (:head route-meta))))
+
+(defn active-head
+  "Sugar — look up the active route's `:head` metadata; if set, call
+  `render-head` and return the model. Otherwise return the `default-head`
+  per Spec 011 §Default head.
+
+  Two arities:
+
+    (active-head)            — uses the default frame `:rf/default`
+                               (matches the call shape in tools / dev
+                               consoles).
+    (active-head frame-id)   — explicit frame.
+
+  Returns the resolved head-model. Per Spec 011 §`render-head`."
+  ([] (active-head :rf/default))
+  ([frame-id]
+   (let [route   (frame-route frame-id)
+         head-id (route-head-id route)]
+     (if head-id
+       ;; The route declares an id but it may not be registered — surface
+       ;; that as :rf.error/no-such-head per Spec 011, but only when the
+       ;; route explicitly opts in. Routes without :head silently fall
+       ;; back to the default per Spec 011 §Default head.
+       (render-head head-id {:frame frame-id :route route})
+       (default-head frame-id)))))
+
+;; ---- late-bind hook registration ------------------------------------------
+;;
+;; Per the optional-artefact wrapper convention (Conventions.md
+;; §Optional-artefact wrapper convention), each public surface is
+;; reachable via `re-frame.core` through a late-bind hook so core never
+;; statically `:require`s `re-frame.ssr.head`. Apps that don't depend
+;; on the SSR artefact see `:rf.error/ssr-artefact-missing` when they
+;; call into these surfaces.
+
+(late-bind/set-fn! :ssr/reg-head          reg-head)
+(late-bind/set-fn! :ssr/render-head       render-head)
+(late-bind/set-fn! :ssr/active-head       active-head)
+(late-bind/set-fn! :ssr/head-snapshot     head-snapshot)
+;; NB: late-bind keys conventionally use `-` only (the drift-detector
+;; regex limits its grammar to alpha-numeric + standard symbol chars);
+;; the user-facing fn is `head-model->html` but the hook key drops the
+;; `->` decoration.
+(late-bind/set-fn! :ssr/head-model-html   head-model->html)
+
+;; ---- per-request frame teardown -------------------------------------------
+;;
+;; `re-frame.ssr/on-frame-destroyed!` (under the `:ssr/on-frame-destroyed`
+;; late-bind hook) clears `pending-error-traces` and `request-slots` per
+;; rf2-fcj33. The head ns adds per-frame head-snapshot cleanup; we
+;; surface our cleanup via a separate `:ssr.head/on-frame-destroyed`
+;; hook that `re-frame.ssr`'s teardown fn looks up and invokes.
+;;
+;; Why a separate hook rather than wrapping `:ssr/on-frame-destroyed`?
+;; Load order is unpredictable under the optional-artefact wrapper
+;; convention — `re-frame.ssr` `:require`s `re-frame.ssr.head` so the
+;; head ns loads BEFORE ssr's body publishes its hook. Any chain we
+;; install here would be overwritten when ssr runs its own
+;; `(late-bind/set-fn! :ssr/on-frame-destroyed ...)`. The keyed hook
+;; sidesteps the ordering issue: ssr's fn invokes ours by key,
+;; regardless of which ns loaded first.
+;;
+;; Hook key naming: `:ssr/head-on-frame-destroyed` (not
+;; `:ssr.head/on-frame-destroyed`) because the drift-detector regex
+;; only matches single-segment namespace components on late-bind keys.
+
+(late-bind/set-fn! :ssr/head-on-frame-destroyed on-frame-destroyed!)

--- a/implementation/ssr/test/re_frame/ssr_head_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_head_test.clj
@@ -1,0 +1,390 @@
+(ns re-frame.ssr-head-test
+  "Spec 011 §Head/meta contract — reg-head / render-head / active-head
+  (rf2-4dra9).
+
+  Covers:
+    - reg-head registers under registry kind :head
+    - render-head invokes the registered fn against db + route
+    - active-head reads the active route's :head metadata and dispatches
+    - default-head fires when no route declares :head
+    - head-snapshot records last-produced fragments per frame
+    - per-request frame teardown clears head bookkeeping
+    - head-model->html emits canonical-ordered tags
+    - :rf.error/no-such-head raised for unregistered ids
+    - reg-head is idempotent — re-registering replaces the slot
+
+  Mirrors the reset-runtime fixture pattern from ssr_end_to_end_test.clj."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.flows :as flows]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.ssr :as ssr]
+            [re-frame.ssr.head :as head]))
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (reset! head/head-snapshots {})
+  (reset! ssr/request-slots {})
+  ;; The defonce-backed `pending-error-traces` atom in re-frame.ssr is
+  ;; private; reach it reflectively. Resetting between tests prevents
+  ;; the load-test downstream from inheriting stale entries left by
+  ;; earlier suites — the ssr-head tests themselves don't drive any
+  ;; error-projection path, but the defonce atom is process-wide.
+  (when-let [v (resolve 're-frame.ssr/pending-error-traces)]
+    (reset! @v {}))
+  (rf/init! ssr/adapter)
+  ;; Resurrect ns-load-time registrations after clear-all!.
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (require 're-frame.ssr.head :reload)
+  (require 're-frame.machines :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ===========================================================================
+;; reg-head — registry kind :head with handler-fn
+;; ===========================================================================
+
+(deftest reg-head-registers-under-head-kind
+  (testing "reg-head adds an entry to the :head registry kind, keyed by id,
+            with the head-fn under :handler-fn"
+    (let [head-fn (fn [_db _route] {:title "Hello"})]
+      (rf/reg-head :head/static head-fn)
+      (let [meta (registrar/lookup :head :head/static)]
+        (is (some? meta) "registry slot exists")
+        (is (= head-fn (:handler-fn meta))
+            "the head-fn is stored under :handler-fn")))))
+
+(deftest reg-head-returns-the-id
+  (testing "reg-head returns its id arg per Conventions §reg-* return-value"
+    (is (= :head/whatever
+           (rf/reg-head :head/whatever (fn [_ _] {}))))))
+
+(deftest reg-head-accepts-metadata-arity
+  (testing "the (reg-head id metadata head-fn) arity stores metadata keys"
+    (rf/reg-head :head/with-meta
+                 {:doc "Article-page head model"}
+                 (fn [_db _route] {:title "x"}))
+    (let [m (registrar/lookup :head :head/with-meta)]
+      (is (= "Article-page head model" (:doc m))
+          ":doc metadata is preserved on the registry slot"))))
+
+(deftest reg-head-is-idempotent
+  (testing "re-registering the same id replaces the slot (registrar contract)"
+    (let [first-fn  (fn [_ _] {:title "first"})
+          second-fn (fn [_ _] {:title "second"})]
+      (rf/reg-head :head/redo first-fn)
+      (rf/reg-head :head/redo second-fn)
+      (is (= second-fn (:handler-fn (registrar/lookup :head :head/redo)))
+          "second registration wins"))))
+
+;; ===========================================================================
+;; render-head — invoke against frame + active route
+;; ===========================================================================
+
+(deftest render-head-invokes-handler-against-db-and-route
+  (testing "render-head reads the frame's app-db, the active route from the
+            :rf/route slice, and applies the registered fn"
+    (rf/reg-head :head/article
+                 (fn [db {:keys [params]}]
+                   (let [{:keys [title summary]} (get-in db [:articles (:id params)])]
+                     {:title title
+                      :meta  [{:name "description" :content summary}]})))
+    (let [f (rf/make-frame
+              {:doc       "head test frame"
+               :platform  :server
+               :on-create [:set-test-state]})]
+      (rf/reg-event-db :set-test-state
+                       (fn [db _]
+                         (-> db
+                             (assoc-in [:articles "123"]
+                                       {:title   "Hello SSR"
+                                        :summary "A summary"})
+                             (assoc :rf/route
+                                    {:id :route/article :params {:id "123"}}))))
+      (rf/dispatch-sync [:set-test-state] {:frame f})
+      (let [model (rf/render-head :head/article {:frame f})]
+        (is (= "Hello SSR" (:title model)))
+        (is (= [{:name "description" :content "A summary"}]
+               (:meta model)))))))
+
+(deftest render-head-accepts-frame-keyword-shorthand
+  (testing "(render-head head-id frame-id) is sugar for (render-head head-id
+            {:frame frame-id})"
+    (rf/reg-head :head/simple (fn [_ _] {:title "bare"}))
+    (let [f (rf/make-frame {:doc "shorthand frame" :platform :server})]
+      (is (= {:title "bare"} (rf/render-head :head/simple f))))))
+
+(deftest render-head-accepts-explicit-route-override
+  (testing ":route opt overrides the slice read from app-db — useful for
+            tools that want a hypothetical-route preview"
+    (rf/reg-head :head/echo (fn [_ route] {:title (str (:id route))}))
+    (let [f (rf/make-frame {:doc "explicit-route frame" :platform :server})]
+      (is (= ":route/explicit"
+             (:title (rf/render-head :head/echo
+                                     {:frame f
+                                      :route {:id :route/explicit}})))))))
+
+(deftest render-head-raises-on-unregistered-id
+  (testing "render-head against an unknown id throws :rf.error/no-such-head"
+    (let [f (rf/make-frame {:doc "missing-head frame" :platform :server})]
+      (try
+        (rf/render-head :head/nope {:frame f})
+        (is false "expected exception")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= ":rf.error/no-such-head" (.getMessage e)))
+          (is (= :head/nope (:head-id (ex-data e)))))))))
+
+(deftest render-head-records-fragment-in-snapshot
+  (testing "every render-head call records the produced model under (frame,
+            head-id) so head-snapshot reflects the latest output"
+    (rf/reg-head :head/a (fn [_ _] {:title "A"}))
+    (rf/reg-head :head/b (fn [_ _] {:title "B"}))
+    (let [f (rf/make-frame {:doc "snapshot frame" :platform :server})]
+      (rf/render-head :head/a {:frame f})
+      (rf/render-head :head/b {:frame f})
+      (let [snap (head/head-snapshot f)]
+        (is (= 2 (count snap)))
+        (is (= {:title "A"} (snap :head/a)))
+        (is (= {:title "B"} (snap :head/b)))))))
+
+;; ===========================================================================
+;; active-head — resolves via :head route metadata
+;; ===========================================================================
+
+(deftest active-head-uses-route-head-metadata
+  (testing "active-head reads the :head key from the active route's
+            registration; calls render-head; returns the model"
+    (rf/reg-head :head/article
+                 (fn [_db {:keys [params]}]
+                   {:title (str "Article " (:id params))}))
+    (rf/reg-route :route/article
+                  {:doc  "Article page"
+                   :path "/articles/:id"
+                   :head :head/article})
+    (let [f (rf/make-frame {:doc "active-route frame" :platform :server})]
+      (rf/dispatch-sync
+        [::seed-route] {:frame f})
+      ;; The test sub-handler isn't registered; instead seed app-db directly
+      ;; via with-frame and assoc — but the framework's :rf/route slice
+      ;; populates via dispatch-driven routing. We bypass with a one-shot
+      ;; event below.
+      (rf/reg-event-db ::seed-route
+                       (fn [db _]
+                         (assoc db :rf/route
+                                {:id :route/article :params {:id "42"}})))
+      (rf/dispatch-sync [::seed-route] {:frame f})
+      (is (= {:title "Article 42"}
+             (rf/active-head f))))))
+
+(deftest active-head-falls-back-to-default-when-route-omits-head
+  (testing "no :head on the route → default-head fires (charset + viewport)"
+    (rf/reg-route :route/no-head
+                  {:doc  "Bare route"
+                   :path "/"})
+    (let [f (rf/make-frame {:doc "Default-head probe" :platform :server})]
+      (rf/reg-event-db ::seed-route-no-head
+                       (fn [db _]
+                         (assoc db :rf/route {:id :route/no-head})))
+      (rf/dispatch-sync [::seed-route-no-head] {:frame f})
+      (let [model (rf/active-head f)]
+        (is (= "Default-head probe" (:title model))
+            ":doc rolls into :title per Spec 011 §Default head")
+        (is (some #(= "utf-8" (:charset %)) (:meta model))
+            "default carries the utf-8 charset meta")
+        (is (some #(= "viewport" (:name %)) (:meta model))
+            "default carries the viewport meta")))))
+
+(deftest active-head-uses-default-when-no-route-at-all
+  (testing "no :rf/route slice (e.g. a frame that hasn't routed yet) → default"
+    (let [f (rf/make-frame {:doc "Bare" :platform :server})
+          model (rf/active-head f)]
+      (is (= "Bare" (:title model)))
+      (is (seq (:meta model))))))
+
+;; ===========================================================================
+;; head-model->html — canonical-ordered emitter
+;; ===========================================================================
+
+(deftest head-model->html-canonical-order
+  (testing "tags emit in canonical order: title → meta → link → script →
+            JSON-LD. The model below intentionally provides keys in a
+            non-canonical order to exercise ordering."
+    (let [model {:link    [{:rel "canonical" :href "https://example.com/x"}]
+                 :title   "Hello"
+                 :meta    [{:name "description" :content "x"}
+                           {:property "og:title" :content "Hello"}]
+                 :script  [{:src "/main.js" :defer true}]
+                 :json-ld [{"@type" "Article" "headline" "Hello"}]}
+          html  (rf/head-model->html model)]
+      (is (str/starts-with? html "<title>Hello</title>")
+          "title is first")
+      (let [t (.indexOf html "<title")
+            m (.indexOf html "<meta")
+            l (.indexOf html "<link")
+            s (.indexOf html "<script src")
+            j (.indexOf html "<script type=\"application/ld+json")]
+        (is (< t m l s j)
+            (str "tags not in canonical order: "
+                 {:title t :meta m :link l :script s :json-ld j}))))))
+
+(deftest head-model->html-meta-tags-shape
+  (testing "meta tags render with declaration-order attributes; self-closing
+            void elements emit without a closing tag"
+    (let [html (rf/head-model->html
+                 {:meta [{:name "description" :content "A summary"}
+                         {:property "og:title" :content "T"}]})]
+      (is (str/includes? html "<meta"))
+      (is (str/includes? html "name=\"description\""))
+      (is (str/includes? html "content=\"A summary\""))
+      (is (str/includes? html "property=\"og:title\""))
+      ;; void elements: no </meta> closing tag.
+      (is (not (str/includes? html "</meta>"))))))
+
+(deftest head-model->html-link-tags
+  (testing "link tags render with canonical/href/rel attrs"
+    (let [html (rf/head-model->html
+                 {:link [{:rel "canonical" :href "https://example.com/x"}
+                         {:rel "icon" :href "/favicon.ico"}]})]
+      (is (str/includes? html "rel=\"canonical\""))
+      (is (str/includes? html "href=\"https://example.com/x\""))
+      (is (str/includes? html "rel=\"icon\"")))))
+
+(deftest head-model->html-script-tags
+  (testing "script tags render with src + boolean attrs (async/defer)"
+    (let [html (rf/head-model->html
+                 {:script [{:src "/main.js" :async true}
+                           {:src "/other.js" :defer true :type "module"}]})]
+      (is (str/includes? html "src=\"/main.js\""))
+      (is (str/includes? html " async"))
+      (is (str/includes? html " defer"))
+      (is (str/includes? html "type=\"module\""))
+      ;; <script> is not void — needs closing tag.
+      (is (str/includes? html "</script>")))))
+
+(deftest head-model->html-json-ld
+  (testing "JSON-LD tags serialise the structured map and ride a
+            <script type=\"application/ld+json\"> envelope"
+    (let [html (rf/head-model->html
+                 {:json-ld [{"@context" "https://schema.org"
+                             "@type"    "Article"
+                             "headline" "Hello"}]})]
+      (is (str/includes? html "type=\"application/ld+json\""))
+      (is (str/includes? html "\"@context\""))
+      (is (str/includes? html "\"@type\":\"Article\""))
+      (is (str/includes? html "\"headline\":\"Hello\"")))))
+
+(deftest head-model->html-empty-model
+  (testing "an empty / minimal model emits nothing (no orphan tags)"
+    (is (= "" (rf/head-model->html {})))
+    (is (= "" (rf/head-model->html nil)))
+    (is (= "<head></head>"
+           (rf/head-model->html {} {:wrap? true})))))
+
+(deftest head-model->html-escaping
+  (testing "title and attribute values are HTML/attribute escaped — no raw
+            tag injection"
+    (let [html (rf/head-model->html
+                 {:title "Hello <script>alert(1)</script>"
+                  :meta  [{:name "x" :content "\"weird\""}]})]
+      (is (str/includes? html "&lt;script&gt;")
+          "title is HTML-escaped — no raw tag injection")
+      (is (str/includes? html "content=\"&quot;weird&quot;\"")
+          "attribute values are attribute-escaped"))))
+
+(deftest head-model->html-wraps-on-opt
+  (testing "the {:wrap? true} opt surrounds with <head></head>"
+    (let [html (rf/head-model->html {:title "Hi"} {:wrap? true})]
+      (is (str/starts-with? html "<head>"))
+      (is (str/ends-with? html "</head>"))
+      (is (str/includes? html "<title>Hi</title>")))))
+
+;; ===========================================================================
+;; per-request frame teardown — head bookkeeping cleared on destroy
+;; ===========================================================================
+
+(deftest head-snapshot-cleared-on-frame-destroy
+  (testing "destroying a per-request frame drops its head-snapshot entry —
+            head bookkeeping must not leak across requests, per Spec 011
+            §Per-request frame teardown and rf2-fcj33"
+    (rf/reg-head :head/leaktest (fn [_ _] {:title "snapshot-A"}))
+    (let [f (rf/make-frame {:doc "teardown frame" :platform :server})]
+      (rf/render-head :head/leaktest {:frame f})
+      (is (= {:title "snapshot-A"}
+             (get (head/head-snapshot f) :head/leaktest))
+          "snapshot present pre-destroy")
+      (rf/destroy-frame f)
+      (is (= {} (head/head-snapshot f))
+          "snapshot cleared post-destroy"))))
+
+(deftest head-snapshot-isolated-across-frames
+  (testing "two frames carry independent head-snapshots — destroying one
+            doesn't touch the other"
+    (rf/reg-head :head/iso (fn [_ _] {:title "x"}))
+    (let [f1 (rf/make-frame {:doc "frame-1" :platform :server})
+          f2 (rf/make-frame {:doc "frame-2" :platform :server})]
+      (rf/render-head :head/iso {:frame f1})
+      (rf/render-head :head/iso {:frame f2})
+      (is (seq (head/head-snapshot f1)))
+      (is (seq (head/head-snapshot f2)))
+      (rf/destroy-frame f1)
+      (is (= {} (head/head-snapshot f1)))
+      (is (seq (head/head-snapshot f2))
+          "destroying f1 did not clear f2's bookkeeping"))))
+
+;; ===========================================================================
+;; full integration — reg-head + reg-route + active-head + html emission
+;; ===========================================================================
+
+(deftest head-emits-canonical-html-from-active-route
+  (testing "the canonical Spec-011 example flow: an article route declares
+            :head :head/article; the head fn derives title/meta/link from
+            app-db; active-head → head-model->html emits the tags in
+            canonical order"
+    (rf/reg-event-db :seed-article
+                     (fn [db _]
+                       (-> db
+                           (assoc-in [:articles "123"]
+                                     {:title   "re-frame2 SSR"
+                                      :summary "How re-frame2 ships SSR"
+                                      :image   "https://example.com/og.png"})
+                           (assoc :rf/route
+                                  {:id :route/article :params {:id "123"}}))))
+    (rf/reg-head :head/article
+                 {:doc "Article-page head model"}
+                 (fn [db {:keys [params]}]
+                   (let [{:keys [title summary image]}
+                         (get-in db [:articles (:id params)])]
+                     {:title (str "Article: " title " — Example")
+                      :meta  [{:name "description" :content summary}
+                              {:property "og:title" :content title}
+                              {:property "og:image" :content image}]
+                      :link  [{:rel "canonical"
+                               :href (str "https://example.com/articles/"
+                                          (:id params))}]})))
+    (rf/reg-route :route/article
+                  {:doc  "Article page"
+                   :path "/articles/:id"
+                   :head :head/article})
+    (let [f (rf/make-frame {:doc "article frame" :platform :server})]
+      (rf/dispatch-sync [:seed-article] {:frame f})
+      (let [model (rf/active-head f)
+            html  (rf/head-model->html model)]
+        (is (= "Article: re-frame2 SSR — Example" (:title model)))
+        (is (str/includes? html
+                           "<title>Article: re-frame2 SSR — Example</title>"))
+        (is (str/includes? html
+                           "<meta name=\"description\" content=\"How re-frame2 ships SSR\">"))
+        (is (str/includes? html
+                           "<meta property=\"og:title\" content=\"re-frame2 SSR\">"))
+        (is (str/includes? html
+                           "<meta property=\"og:image\" content=\"https://example.com/og.png\">"))
+        (is (str/includes? html
+                           "<link rel=\"canonical\" href=\"https://example.com/articles/123\">"))))))

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -437,7 +437,7 @@ These defaults are the runtime's; user fx can override any of them. The runtime 
 
 ### Head/meta contract
 
-> **Status: deferred — rf2-gr0n.** The `reg-head` / `render-head` / `active-head` surface described in this section is **not shipped in v1**. Per the per-symbol triage at [API.md §Head](API.md), `reg-head` is recorded as a deferred symbol; this section documents the design that lands when the surface is implemented (rf2-3i3m / rf2-pgma / rf2-h96i). v1 implementations rely on the [§Default head when no route declares `:head`](#default-head-when-no-route-declares-head) fallback and on body-tree-embedded `<head>` content; the hash-on-wire path (per [§Hydration-mismatch detection](#hydration-mismatch-detection)) covers head as part of the unified render-tree hash so head-mismatch detection works without `reg-head` having to ship.
+> **Status: shipped — rf2-4dra9.** The `reg-head` / `render-head` / `active-head` surface described in this section ships in the `day8/re-frame2-ssr` artefact (`re-frame.ssr.head`). The hash-on-wire path (per [§Hydration-mismatch detection](#hydration-mismatch-detection)) covers head as part of the unified render-tree hash; head-mismatch detection discriminates via `:failing-id :rf.ssr/head-mismatch`. A dedicated `data-rf-head-hash` payload key + wire attribute remains reserved for a post-v1 head-only-hash extension.
 
 The server-rendered HTML must carry head metadata — `<title>`, `<meta>`, `<link>`, JSON-LD — on first byte, because crawlers and link-unfurlers don't run JS. The pattern's commitment: **the head model is data derived from app-db**, not an imperative DOM API.
 

--- a/spec/API.md
+++ b/spec/API.md
@@ -39,7 +39,7 @@
 | `reg-app-schemas` | M | `(reg-app-schemas {path-1 schema-1, path-2 schema-2, ...})` / `(reg-app-schemas {…} opts)` — bulk plural form for feature-modular apps that register 5–20 paths against the same prefix (per Conventions §Feature-modularity prefix convention). Each entry routes through the singular `reg-app-schema` and is stamped with this call's source-coords. Returns the vector of paths registered (rf2-jzs9) | v1 | 010 | |
 | `reg-flow` | Fn | `(reg-flow flow)` / `(reg-flow id flow)` | v1 | 013 | |
 | `reg-route` | M | `(reg-route id metadata)` | v1 | 012 | |
-| `reg-head` | M | `(reg-head id ?metadata head-fn)` | v1 (deferred — see rf2-gr0n) | 011 | New registry kind `:head`; routes name a registered head via `:head` route metadata. |
+| `reg-head` | M | `(reg-head id ?metadata head-fn)` | v1 | 011 | New registry kind `:head`; routes name a registered head via `:head` route metadata. Captures source-coords; under the optional-artefact wrapper convention the surface routes through the `:ssr/reg-head` late-bind hook. |
 | `reg-error-projector` | M | `(reg-error-projector id ?metadata projector-fn)` | v1 | 011 | New registry kind `:error-projector`; named per-frame via the frame's `:ssr {:public-error-id ...}` metadata (per `reg-frame` / `make-frame`). |
 
 ### Clearing registrations
@@ -191,8 +191,9 @@ Standard route-related fx (canonical detail in [012-Routing.md](012-Routing.md))
 | `render-to-string` | Fn | `(render-to-string view-or-hiccup opts)` → HTML string | v1 | 011 |
 | `render-tree-hash` | Fn | `(render-tree-hash render-tree)` → 32-bit FNV-1a structural hash (lowercase hex). Identical output on JVM and CLJS for the same canonical-EDN representation. Per [011 §Hydration-mismatch detection](011-SSR.md). | v1 | 011 |
 | `project-error` | Fn | `(project-error frame-id trace-event)` → `:rf/public-error`. Applies the active error-projector (selected by the frame's `:ssr {:public-error-id ...}` metadata) for the named frame. Per [011 §Server error projection](011-SSR.md). | v1 | 011 |
-| `render-head` | Fn | `(render-head head-id opts)` → `:rf/head-model` | v1 (deferred — see rf2-gr0n) | 011 |
-| `active-head` | Fn | `(active-head)` / `(active-head frame-id)` → `:rf/head-model` | v1 (deferred — see rf2-gr0n) | 011 |
+| `render-head` | Fn | `(render-head head-id opts)` → `:rf/head-model` | v1 | 011 |
+| `active-head` | Fn | `(active-head)` / `(active-head frame-id)` → `:rf/head-model` | v1 | 011 |
+| `head-model->html` | Fn | `(head-model->html head-model)` / `(head-model->html head-model {:wrap? bool})` → inner-head HTML string | v1 | 011 |
 
 Standard SSR-related events:
 


### PR DESCRIPTION
## Summary

Ships the head/meta contract surface Spec 011 §Head/meta documented but
never implemented. Closes **rf2-4dra9** (per `ssr-audit-20260513-1757`
gap #5).

- New artefact namespace `re-frame.ssr.head`:
  - `reg-head id ?metadata head-fn` registers a `(fn [db route] head-model)` under the `:head` registry kind
  - `render-head head-id opts` invokes the registered fn against a frame's app-db + active route, returns the model, and records it in the per-frame snapshot
  - `active-head ?frame-id` resolves the active route's `:head` metadata (or falls back to the default-head per Spec 011 §Default head)
  - `head-model->html` emits the inner-head HTML fragment in canonical order (title → meta → link → script → JSON-LD)
  - `head-snapshot frame-id` exposes the per-frame `{head-id → last-fragment}` map for tests / introspection
- `re-frame.core` re-exports `reg-head` (source-coord-capturing macro), `render-head`, `active-head`, `head-model->html`. Late-bound through `:ssr/reg-head` / `:ssr/render-head` / `:ssr/active-head` / `:ssr/head-model-html` so core never statically requires the SSR artefact.
- `re-frame.ssr.ring` resolves the active head per request via `rf/active-head` and threads the rendered fragment into the shell as the `:head` opt; explicit `:head` opts on shell-callers still win.
- Per-request frame teardown clears the head-snapshot via a new `:ssr/head-on-frame-destroyed` hook that `re-frame.ssr/on-frame-destroyed!` invokes by key — keeps load order between ssr.cljc and head.cljc irrelevant.
- Spec/API.md flips `reg-head` / `render-head` / `active-head` from deferred to v1; adds `head-model->html`. Spec/011-SSR.md replaces the §Head/meta deferral banner with a "shipped — rf2-4dra9" status.
- Late-bind directory entries added for all six new keys.

## Test plan

- [x] `clojure -M:test` in `implementation/ssr/` — 65 tests / 207 assertions / 0 failures (23 new head-test cases in `ssr_head_test.clj`)
- [x] `clojure -M:test` in `implementation/core/` — 416 tests / 2220 assertions / 0 failures (late-bind drift test green)
- [x] `clojure -M:test` in `implementation/ssr-ring/` — 11 tests / 50 assertions / 0 failures
- [x] `npm run test:cljs` — 1688 tests / 4680 assertions / 0 failures
- [x] `npm run test:bundle-isolation` — every SSR-only sentinel still elided from non-SSR builds