### PR TITLE
fix(causa): :rf.causa/trace-buffer reactive-container parity with rf2-0vxdn (rf2-iw5ym)

### DIFF
--- a/tools/causa/spec/014-Registry-Catalogue.md
+++ b/tools/causa/spec/014-Registry-Catalogue.md
@@ -57,7 +57,7 @@ the time-travel scrubber, and the per-frame target selection.
 
 | Sub | Inputs | Returns | When recomputes |
 |---|---|---|---|
-| `:rf.causa/trace-buffer` | none (reads `trace-bus/buffer`) | Vector of `:rf/trace-event` records, oldest-first (per [`013-Trace-Bus.md`](./013-Trace-Bus.md) §Consumer contract). | Every subscribe-graph recompute; the buffer atom is process-global, not per-frame. |
+| `:rf.causa/trace-buffer` | `db` (reads `:trace-buffer`) | Vector of `:rf/trace-event` records, oldest-first (per [`013-Trace-Bus.md`](./013-Trace-Bus.md) §Consumer contract). | On `db` write to `:trace-buffer` (rf2-iw5ym — reactive immediate update on every push, matching the rf2-0vxdn recipe for `:suppressed-counters`). |
 | `:rf.causa/suppressed-sensitive-count` | `db` (reads `:suppressed-counters`) | Integer — total suppressed `:sensitive? true` events under the current `:trace/show-sensitive?` setting. | On `db` write to `:suppressed-counters` (rf2-0vxdn — reactive immediate update of the `[● REDACTED N]` bottom-rail indicator). |
 | `:rf.causa/target-frame` | `db` | Keyword frame-id (default `:rf/default`). | On `db` write to `:target-frame`. |
 | `:rf.causa/epoch-history` | `db` | Vector of `:rf/epoch-record`, oldest-first (cached snapshot of `(rf/epoch-history target)`). | On `:rf.causa/epoch-recorded` dispatch. |
@@ -70,6 +70,9 @@ the time-travel scrubber, and the per-frame target selection.
 | `:rf.causa/epoch-recorded` | `[_ frame-id]` | `{:db ...}` | Pumped from the epoch-cb registered in `preload.cljs` on every settled epoch. Re-reads `rf/epoch-history` to keep the cached snapshot consistent. No-ops when `frame-id` ≠ the current target. |
 | `:rf.causa/note-sensitive-suppressed` | `[_ frame-id]` | `{:db ...}` | rf2-0vxdn — bumps `[:suppressed-counters (or frame-id :global)]` in Causa's app-db. Dispatched from `trace-bus/collect-trace!` (CLJS) when the privacy gate drops a `:sensitive? true` event. Drives the `:rf.causa/suppressed-sensitive-count` sub reactively. |
 | `:rf.causa/reset-suppressed-counters` | `[_]` or `[_ frame-id]` | `{:db ...}` | rf2-0vxdn — clears all buckets (no arg) or just the named bucket. Dispatched from `trace-bus/clear-buffer!` (CLJS) — clearing the trace ring buffer also drops the `[● REDACTED N]` indicator state. |
+| `:rf.causa/note-trace-event` | `[_ event]` | `{:db ...}` | rf2-iw5ym — appends `event` to `:trace-buffer` with eviction at `trace-bus/current-depth` (mirrors `trace-bus/push`'s algebra). Dispatched from `trace-bus/collect-trace!` (CLJS) on every non-sensitive trace event. Drives the `:rf.causa/trace-buffer` sub reactively. |
+| `:rf.causa/clear-trace-buffer` | `[_]` | `{:db ...}` | rf2-iw5ym — `dissoc`s the `:trace-buffer` slot. Dispatched from `trace-bus/clear-buffer!` (CLJS); the atom-side ring buffer + the app-db mirror drop in lockstep. |
+| `:rf.causa/sync-trace-buffer` | `[_ buf]` | `{:db ...}` | rf2-iw5ym — replaces the `:trace-buffer` slot with `buf` wholesale. Dispatched from `trace-bus/set-buffer-depth!` (CLJS) when shrinking the depth so the mirror reflects the post-shrink contents. |
 | `:rf.causa/select-panel` | `[_ panel-id]` | `{:db ...}` | Drives the canvas switch logic in `shell.cljs`. Default per [`007-UX-IA.md`](./007-UX-IA.md) §10 Lock 7 is `:event-detail`. |
 
 ## Event-detail panel

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -186,12 +186,18 @@
 ;; ---- subscriptions -------------------------------------------------------
 
 ;; Causa's trace-buffer sub returns the Causa-side ring buffer
-;; contents (NOT the framework's `(rf/trace-buffer)`). Reading directly
-;; from `trace-bus/buffer` is the right shape here because the buffer
-;; is process-global, not per-frame — every Causa shell mounted across
-;; any frame should see the same trace stream. The sub thunks the
-;; pure-data accessor so reactive contexts get a fresh read on every
-;; recompute.
+;; contents (NOT the framework's `(rf/trace-buffer)`).
+;;
+;; Per rf2-iw5ym the buffer lives in Causa's app-db at `:trace-buffer`
+;; (same recipe as rf2-0vxdn for `:suppressed-counters`); `trace-bus/
+;; collect-trace!` dispatches `:rf.causa/note-trace-event` in CLJS so
+;; the sub fires on the standard app-db-write reactive path. Panels
+;; reading the buffer re-render IMMEDIATELY on every push — no
+;; dependency on sibling subs recomputing. The plain `trace-bus/
+;; buffer-state` atom remains as the JVM-runnable data primitive
+;; (`push` algebra, depth-shrink algebra, sensitive_trace_cljs_test);
+;; the CLJS path dual-writes via dispatch so the reactive surface
+;; stays consistent.
 (defonce ^:private registered?
   ;; Idempotency sentinel. Re-loading the namespace (shadow-cljs
   ;; `:after-load`) must not re-register the sub (would harmlessly
@@ -207,8 +213,8 @@
   (when (compare-and-set! registered? false true)
     ;; ---- subs ----------------------------------------------------
     (rf/reg-sub :rf.causa/trace-buffer
-      (fn [_db _query]
-        (trace-bus/buffer)))
+      (fn [db _query]
+        (get db :trace-buffer [])))
 
     ;; Total count of :sensitive? trace events the collector has
     ;; suppressed under the current `:trace/show-sensitive?` setting
@@ -643,6 +649,39 @@
         (if frame-id
           (update db :suppressed-counters dissoc (or frame-id :global))
           (dissoc db :suppressed-counters))))
+
+    ;; Append a trace event to Causa's reactive trace-buffer slot
+    ;; (rf2-iw5ym). Dispatched from `trace-bus/collect-trace!` (CLJS)
+    ;; whenever a non-sensitive event lands on the bus. The handler
+    ;; mirrors the atom-side `trace-bus/push` algebra (conj + subvec
+    ;; on overflow) so the app-db slot stays bounded by the same
+    ;; depth contract; the depth is sourced from `trace-bus`'s own
+    ;; atom (process-global, not per-frame). Drives the
+    ;; `:rf.causa/trace-buffer` sub via the standard reactive write
+    ;; path — panels reading the buffer re-render immediately.
+    (rf/reg-event-db :rf.causa/note-trace-event
+      (fn [db [_ event]]
+        (let [depth (trace-bus/current-depth)
+              buf   (get db :trace-buffer [])
+              buf'  (trace-bus/push buf depth event)]
+          (assoc db :trace-buffer buf'))))
+
+    ;; Clear Causa's reactive trace-buffer slot (rf2-iw5ym).
+    ;; Dispatched from `trace-bus/clear-buffer!` (CLJS) — clearing
+    ;; the atom-side ring buffer must drop the app-db mirror in
+    ;; lockstep so panels reading the buffer empty alongside.
+    (rf/reg-event-db :rf.causa/clear-trace-buffer
+      (fn [db _event]
+        (dissoc db :trace-buffer)))
+
+    ;; Re-sync Causa's reactive trace-buffer slot to an explicit
+    ;; value (rf2-iw5ym). Dispatched from `trace-bus/set-buffer-
+    ;; depth!` (CLJS) when shrinking the depth would otherwise
+    ;; leave the app-db mirror longer than the atom side. The
+    ;; payload is the post-shrink vector.
+    (rf/reg-event-db :rf.causa/sync-trace-buffer
+      (fn [db [_ buf]]
+        (assoc db :trace-buffer (vec buf))))
 
     (rf/reg-event-db :rf.causa/select-dispatch-id
       (fn [db [_ dispatch-id]]

--- a/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
@@ -35,9 +35,29 @@
   events bump a per-frame counter that drives the bottom-rail's
   `[● REDACTED N]` hint. An engineer debugging redaction policy
   opts in via `(causa-config/configure! {:trace/show-sensitive?
-  true})`."
+  true})`.
+
+  ## Reactive container (rf2-iw5ym)
+
+  Per rf2-iw5ym (same recipe as rf2-0vxdn's `suppressed-counters`
+  fix): the buffer is also mirrored into Causa's app-db at
+  `[:rf/causa db :trace-buffer]` via dispatch (CLJS only) so the
+  `:rf.causa/trace-buffer` sub fires on the standard reactive
+  write path — panels reading the buffer re-render IMMEDIATELY on
+  every push, with no dependency on a sibling sub recomputing. The
+  `buffer-state` atom here remains as the JVM-runnable data
+  primitive (`push` algebra, depth-shrink algebra, `clear-buffer!`)
+  so trace_bus's pure-data shape is testable without a CLJS runtime
+  + re-frame frame; the CLJS path dual-writes via dispatch. The
+  dispatch is async — production reads see a one-tick lag,
+  invisible at trace-rate UI cadence; tests that need the reactive
+  surface to settle synchronously dispatch the new
+  `:rf.causa/note-trace-event` / `:rf.causa/clear-trace-buffer`
+  events directly via `dispatch-sync`."
   (:require [re-frame.interop :as interop]
-            [day8.re-frame2-causa.config :as config]))
+            [day8.re-frame2-causa.config :as config]
+            #?@(:cljs [[re-frame.core :as rf]
+                       [re-frame.frame :as frame]])))
 
 ;; ---- ring-buffer state ----------------------------------------------------
 
@@ -91,7 +111,15 @@
   suppressed!` itself dispatches `:rf.causa/note-sensitive-suppressed`
   into `:rf/causa` (CLJS) so the sub reads `:suppressed-counters`
   off Causa's app-db on the standard write path. The buffer state
-  here is unchanged; the dispatch happens one stack frame deeper."
+  here is unchanged; the dispatch happens one stack frame deeper.
+
+  Per rf2-iw5ym the buffer push is the same shape: the atom swap
+  remains (JVM-runnable data primitive) and CLJS also dispatches
+  `:rf.causa/note-trace-event` into `:rf/causa` so the
+  `:rf.causa/trace-buffer` sub fires on the standard write path.
+  Guarded on the `:rf/causa` frame's existence — production preload
+  always installs it, but tests / hot-reload windows may emit
+  trace events before the frame registers."
   [event]
   (when interop/debug-enabled?
     (cond
@@ -99,7 +127,12 @@
       (config/note-suppressed! (get-in event [:tags :frame]))
 
       :else
-      (swap! buffer-state push @buffer-depth event))))
+      (do
+        (swap! buffer-state push @buffer-depth event)
+        #?(:cljs
+           (when (frame/frame :rf/causa)
+             (binding [frame/*current-frame* :rf/causa]
+               (rf/dispatch [:rf.causa/note-trace-event event]))))))))
 
 ;; ---- read-side accessors -------------------------------------------
 
@@ -109,6 +142,15 @@
   `interop/debug-enabled?` is false at compile time)."
   []
   @buffer-state)
+
+(defn current-depth
+  "Return the configured buffer depth (`default-buffer-depth` until
+  `set-buffer-depth!` rewrites it). Public so the registry's
+  `:rf.causa/note-trace-event` event-db handler can mirror the
+  same eviction-on-overflow algebra `collect-trace!` uses (per
+  rf2-iw5ym)."
+  []
+  @buffer-depth)
 
 ;; ---- consumer-side filter (rf2-qi8au) -----------------------------------
 ;;
@@ -214,17 +256,31 @@
 
   Per rf2-0vxdn `config/reset-suppressed-count!` itself dispatches
   `:rf.causa/reset-suppressed-counters` in CLJS so the reactive
-  app-db slot clears in lockstep with the atom."
+  app-db slot clears in lockstep with the atom.
+
+  Per rf2-iw5ym the buffer's app-db mirror also clears in lockstep
+  — the CLJS path dispatches `:rf.causa/clear-trace-buffer` so the
+  `:rf.causa/trace-buffer` sub re-fires off the standard write
+  path and panels reading the buffer drop to empty immediately."
   []
   (when interop/debug-enabled?
     (reset! buffer-state [])
-    (config/reset-suppressed-count!))
+    (config/reset-suppressed-count!)
+    #?(:cljs
+       (when (frame/frame :rf/causa)
+         (binding [frame/*current-frame* :rf/causa]
+           (rf/dispatch [:rf.causa/clear-trace-buffer])))))
   nil)
 
 (defn set-buffer-depth!
   "Set the buffer's depth. `depth=0` keeps the collector wired (so the
   callback can be replaced or augmented) but flushes the buffer to
-  empty and prevents further accumulation. No-op in production."
+  empty and prevents further accumulation. No-op in production.
+
+  Per rf2-iw5ym: when the new depth shrinks the buffer, the app-db
+  mirror is re-synced via `:rf.causa/sync-trace-buffer` so the
+  reactive `:rf.causa/trace-buffer` sub reflects the truncated
+  shape rather than the pre-shrink contents."
   [depth]
   (when (and interop/debug-enabled? (number? depth) (not (neg? depth)))
     (reset! buffer-depth depth)
@@ -234,5 +290,9 @@
                (cond
                  (zero? depth) []
                  (> n depth)   (subvec v (- n depth))
-                 :else         v)))))
+                 :else         v))))
+    #?(:cljs
+       (when (frame/frame :rf/causa)
+         (binding [frame/*current-frame* :rf/causa]
+           (rf/dispatch [:rf.causa/sync-trace-buffer @buffer-state])))))
   nil)

--- a/tools/causa/test/day8/re_frame2_causa/panels/causality_graph_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/causality_graph_view_cljs_test.cljs
@@ -67,13 +67,19 @@
 
 (defn- seed-buffer!
   "Wire the trace collector (preload-style) and push the supplied
-  events through it so the Causa buffer matches the production
-  delivery path."
+  events through Causa's reactive trace-buffer slot.
+
+  Per rf2-iw5ym `:rf.causa/trace-buffer` is reactive off Causa's
+  app-db, not the trace-bus atom. Tests use `dispatch-sync` of
+  `:rf.causa/note-trace-event` to mirror what production's
+  `trace-bus/collect-trace!` does (async dispatch), driving the
+  sub re-fire synchronously before the next subscribe."
   [evs]
   (registry/register-causa-handlers!)
   (frame/reg-frame :rf/causa {})
-  (doseq [ev evs]
-    (trace-bus/collect-trace! ev)))
+  (rf/with-frame :rf/causa
+    (doseq [ev evs]
+      (rf/dispatch-sync [:rf.causa/note-trace-event ev]))))
 
 (defn- expand-fn-component [node]
   (if (and (vector? node) (fn? (first node)))

--- a/tools/causa/test/day8/re_frame2_causa/panels/effects_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/effects_view_cljs_test.cljs
@@ -89,7 +89,12 @@
   (rf/dispatch-sync [:rf.causa/set-registered-fxs-override-for-test m]))
 
 (defn- push-trace! [ev]
-  (trace-bus/collect-trace! ev))
+  ;; Per rf2-iw5ym: `:rf.causa/trace-buffer` is reactive off Causa's
+  ;; app-db, not the trace-bus atom. Tests drive the reactive write
+  ;; path directly via `dispatch-sync` so the composite sub re-fires
+  ;; synchronously on the next subscribe.
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/note-trace-event ev])))
 
 ;; ---- (1) registry wires the composite sub -------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
@@ -71,14 +71,23 @@
     :tags {:dispatch-id dispatch-id :render-key [:app/root nil]}}])
 
 (defn- seed-buffer!
-  "Wire the trace collector (preload-style) and push the supplied
-  events through it so the Causa buffer matches the production
-  delivery path."
+  "Register Causa's handlers, allocate the :rf/causa frame, then push
+  the supplied events through Causa's reactive trace-buffer slot.
+
+  Per rf2-iw5ym `:rf.causa/trace-buffer` is reactive off Causa's
+  app-db; the buffer-bus atom is no longer the sub's source of
+  truth. Tests drive the new reactive write path via `dispatch-sync`
+  of `:rf.causa/note-trace-event` so the composite sub re-fires
+  synchronously before the view is rendered. (Production wiring
+  still goes through `trace-bus/collect-trace!`; that path is
+  covered by sensitive_trace_cljs_test + filter_vocab_consumer_
+  cljs_test.)"
   [evs]
   (registry/register-causa-handlers!)
   (frame/reg-frame :rf/causa {})
-  (doseq [ev evs]
-    (trace-bus/collect-trace! ev)))
+  (rf/with-frame :rf/causa
+    (doseq [ev evs]
+      (rf/dispatch-sync [:rf.causa/note-trace-event ev]))))
 
 (defn- expand-fn-component
   "When `node` is a hiccup-style `[fn-component args...]` vector

--- a/tools/causa/test/day8/re_frame2_causa/panels/flows_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/flows_view_cljs_test.cljs
@@ -87,7 +87,12 @@
   (rf/dispatch-sync [:rf.causa/set-registered-flows-override-for-test m]))
 
 (defn- push-trace! [ev]
-  (trace-bus/collect-trace! ev))
+  ;; Per rf2-iw5ym: `:rf.causa/trace-buffer` is reactive off Causa's
+  ;; app-db, not the trace-bus atom. Tests drive the reactive write
+  ;; path directly via `dispatch-sync` so the composite sub re-fires
+  ;; synchronously on the next subscribe.
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/note-trace-event ev])))
 
 ;; ---- (1) registry wires the composite sub -------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_view_cljs_test.cljs
@@ -68,13 +68,18 @@
                       extra-tags)}))
 
 (defn- seed-buffer!
-  "Wire the trace collector (preload-style) and push events through it
-  so the Causa buffer matches the production delivery path."
+  "Register Causa's handlers, allocate the :rf/causa frame, then push
+  the supplied events through Causa's reactive trace-buffer slot
+  (per rf2-iw5ym `:rf.causa/trace-buffer` is reactive off Causa's
+  app-db; `dispatch-sync` of `:rf.causa/note-trace-event` is the
+  test-side write path that mirrors `trace-bus/collect-trace!`'s
+  production async dispatch)."
   [evs]
   (registry/register-causa-handlers!)
   (frame/reg-frame :rf/causa {})
-  (doseq [ev evs]
-    (trace-bus/collect-trace! ev)))
+  (rf/with-frame :rf/causa
+    (doseq [ev evs]
+      (rf/dispatch-sync [:rf.causa/note-trace-event ev]))))
 
 ;; ---- hiccup walker (lifted from causality_graph_view_cljs_test) ---------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
@@ -106,7 +106,12 @@
   (frame/reg-frame :rf/causa {}))
 
 (defn- push-trace! [ev]
-  (trace-bus/collect-trace! ev))
+  ;; Per rf2-iw5ym: `:rf.causa/trace-buffer` is reactive off Causa's
+  ;; app-db, not the trace-bus atom. Tests drive the reactive write
+  ;; path directly via `dispatch-sync` so the composite sub re-fires
+  ;; synchronously on the next subscribe.
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/note-trace-event ev])))
 
 ;; Synthetic issue trace event.
 (defn- mk-issue

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
@@ -247,14 +247,19 @@
     (rf/with-frame :rf/causa
       (override-machines! [:auth/login])
       ;; Push two transition events into the Causa trace buffer.
-      (trace-bus/collect-trace!
-        {:id 1 :operation :rf.machine/transition :time 100
-         :tags {:machine-id :auth/login :from :idle :to :authing
-                :event [:auth/submit] :dispatch-id "d-1"}})
-      (trace-bus/collect-trace!
-        {:id 2 :operation :rf.machine/transition :time 200
-         :tags {:machine-id :auth/login :from :authing :to :idle
-                :event [:auth/cancel] :dispatch-id "d-2"}})
+      ;; Per rf2-iw5ym `:rf.causa/trace-buffer` is reactive off
+      ;; Causa's app-db; tests drive the reactive write path
+      ;; directly via `dispatch-sync` of `:rf.causa/note-trace-event`.
+      (rf/dispatch-sync
+        [:rf.causa/note-trace-event
+         {:id 1 :operation :rf.machine/transition :time 100
+          :tags {:machine-id :auth/login :from :idle :to :authing
+                 :event [:auth/submit] :dispatch-id "d-1"}}])
+      (rf/dispatch-sync
+        [:rf.causa/note-trace-event
+         {:id 2 :operation :rf.machine/transition :time 200
+          :tags {:machine-id :auth/login :from :authing :to :idle
+                 :event [:auth/cancel] :dispatch-id "d-2"}}])
       (let [tree    (machine-inspector/machine-inspector-view)
             entries (find-all-by-testid-prefix
                       tree "rf-causa-machine-inspector-transition-")]
@@ -267,10 +272,14 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-machines! [:auth/login])
-      (trace-bus/collect-trace!
-        {:id 1 :operation :rf.machine/transition :time 100
-         :tags {:machine-id :auth/login :from :idle :to :authing
-                :event [:auth/submit] :dispatch-id "d-42"}})
+      ;; Per rf2-iw5ym `:rf.causa/trace-buffer` is reactive off
+      ;; Causa's app-db; tests drive the reactive write path
+      ;; directly via `dispatch-sync` of `:rf.causa/note-trace-event`.
+      (rf/dispatch-sync
+        [:rf.causa/note-trace-event
+         {:id 1 :operation :rf.machine/transition :time 100
+          :tags {:machine-id :auth/login :from :idle :to :authing
+                 :event [:auth/submit] :dispatch-id "d-42"}}])
       (let [dispatches (atom [])]
         ;; rf/dispatch is async; with-redefs on the underlying
         ;; rf/dispatch* fn captures the event vector synchronously

--- a/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_view_cljs_test.cljs
@@ -87,7 +87,12 @@
 ;; the pattern other view tests use (trace-bus is the source the
 ;; composite sub reads through `:rf.causa/trace-buffer`).
 (defn- push-event! [ev]
-  (trace-bus/collect-trace! ev))
+  ;; Per rf2-iw5ym: `:rf.causa/trace-buffer` is reactive off Causa's
+  ;; app-db, not the trace-bus atom. Tests drive the reactive write
+  ;; path directly via `dispatch-sync` so the composite sub re-fires
+  ;; synchronously on the next subscribe.
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/note-trace-event ev])))
 
 (defn- mcp-event
   "Build a :origin :causa-mcp trace event in the shape the buffer

--- a/tools/causa/test/day8/re_frame2_causa/panels/performance_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/performance_view_cljs_test.cljs
@@ -98,7 +98,12 @@
   (frame/reg-frame :rf/causa {}))
 
 (defn- push-trace! [ev]
-  (trace-bus/collect-trace! ev))
+  ;; Per rf2-iw5ym: `:rf.causa/trace-buffer` is reactive off Causa's
+  ;; app-db, not the trace-bus atom. Tests drive the reactive write
+  ;; path directly via `dispatch-sync` so the composite sub re-fires
+  ;; synchronously on the next subscribe.
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/note-trace-event ev])))
 
 ;; Build a synthetic cascade — :event/dispatched + handler + fx + effects
 ;; — with the given dispatch-id, span (last-time minus first-time gives

--- a/tools/causa/test/day8/re_frame2_causa/panels/routes_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/routes_view_cljs_test.cljs
@@ -95,7 +95,12 @@
   (rf/dispatch-sync [:rf.causa/set-active-route-slice-override-for-test s]))
 
 (defn- push-trace! [ev]
-  (trace-bus/collect-trace! ev))
+  ;; Per rf2-iw5ym: `:rf.causa/trace-buffer` is reactive off Causa's
+  ;; app-db, not the trace-bus atom. Tests drive the reactive write
+  ;; path directly via `dispatch-sync` so the composite sub re-fires
+  ;; synchronously on the next subscribe.
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/note-trace-event ev])))
 
 ;; ---- (1) registry wires the composite sub -------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/schema_violation_timeline_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/schema_violation_timeline_cljs_test.cljs
@@ -92,8 +92,13 @@
                 :frame  :rf/default}}))
 
 (defn- push-failures! [evs]
-  (doseq [ev evs]
-    (trace-bus/collect-trace! ev)))
+  ;; Per rf2-iw5ym: `:rf.causa/trace-buffer` is reactive off Causa's
+  ;; app-db, not the trace-bus atom. Tests drive the reactive write
+  ;; path directly via `dispatch-sync` so the composite sub re-fires
+  ;; synchronously on the next subscribe.
+  (rf/with-frame :rf/causa
+    (doseq [ev evs]
+      (rf/dispatch-sync [:rf.causa/note-trace-event ev]))))
 
 ;; ---- (1) registry wires subs / events -----------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
@@ -102,7 +102,12 @@
   (frame/reg-frame :rf/causa {}))
 
 (defn- push-trace! [ev]
-  (trace-bus/collect-trace! ev))
+  ;; Per rf2-iw5ym: `:rf.causa/trace-buffer` is reactive off Causa's
+  ;; app-db, not the trace-bus atom. Tests drive the reactive write
+  ;; path directly via `dispatch-sync` so the composite sub re-fires
+  ;; synchronously on the next subscribe.
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/note-trace-event ev])))
 
 ;; Construct a synthetic trace event with the canonical 9-axis tags.
 (defn- mk-trace

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -4,7 +4,7 @@
   ## Scope
 
   `registry.cljs` (1818 LoC) is the central registrar for Causa's
-  framework surface — 64 reg-subs + 60 reg-event-(db|fx) + 3 reg-fx,
+  framework surface — 64 reg-subs + 63 reg-event-(db|fx) + 3 reg-fx,
   all under the `:rf.causa/*` namespace, targeting the `:rf/causa`
   frame. Prior to this file the only coverage was *transitive* through
   per-panel view tests (each panel test calls `(registry/reset-for-test!)`
@@ -162,6 +162,7 @@
    :rf.causa/clear-selected-epoch
    :rf.causa/clear-selected-sub
    :rf.causa/clear-slice-focus
+   :rf.causa/clear-trace-buffer
    :rf.causa/clear-trace-filters
    :rf.causa/clear-violation-selection
    :rf.causa/copy-path-to-clipboard
@@ -171,6 +172,7 @@
    :rf.causa/focus-slice-path
    :rf.causa/hide-invalidation-chain
    :rf.causa/note-sensitive-suppressed
+   :rf.causa/note-trace-event
    :rf.causa/open-in-editor
    :rf.causa/pin-current
    :rf.causa/pin-slice
@@ -204,6 +206,7 @@
    :rf.causa/set-sub-cache-override-for-test
    :rf.causa/set-trace-filter
    :rf.causa/show-invalidation-chain
+   :rf.causa/sync-trace-buffer
    :rf.causa/toggle-issues-prefix
    :rf.causa/toggle-issues-severity
    :rf.causa/toggle-mcp-op-type
@@ -241,9 +244,10 @@
           (str "expected :fx handler for " fx-id)))))
 
 (deftest registry-counts-match-bead
-  (testing "registry holds exactly 64 subs + 60 events + 3 fxs (rf2-5zl7l; +2 events for rf2-0vxdn)"
+  (testing "registry holds exactly 64 subs + 63 events + 3 fxs (rf2-5zl7l;
+            +2 events for rf2-0vxdn; +3 events for rf2-iw5ym)"
     (is (= 64 (count all-sub-names)))
-    (is (= 60 (count all-event-names)))
+    (is (= 63 (count all-event-names)))
     (is (= 3  (count all-fx-names)))))
 
 (deftest registry-is-idempotent
@@ -259,25 +263,129 @@
 
 ;; ---- (2) high-value sub contracts: defaults on a fresh frame ------------
 
-(deftest sub-trace-buffer-reads-trace-bus
-  (testing ":rf.causa/trace-buffer is a thunk over trace-bus/buffer — the
-            sub returns whatever the bus holds at deref time, scoped to
-            the frame's reactive cache. Seeding via `collect-trace!`
-            then re-subscribing under a fresh reactive context surfaces
-            the pushed event."
+(deftest sub-trace-buffer-reads-app-db
+  (testing ":rf.causa/trace-buffer reads from Causa's app-db at
+            `:trace-buffer` (rf2-iw5ym — same recipe as rf2-0vxdn's
+            `:suppressed-counters` fix). First deref returns the
+            default `[]`; each `:rf.causa/note-trace-event` dispatch
+            re-fires the sub on the standard write path (immediate
+            reactive update, no clear-subscription-cache! workaround
+            required). `:rf.causa/clear-trace-buffer` drops the slot
+            back to empty."
     (setup-causa-frame!)
-    (trace-bus/clear-buffer!)
     (rf/with-frame :rf/causa
       (is (= [] @(rf/subscribe [:rf.causa/trace-buffer]))
-          "fresh buffer surfaces as []")
-      (trace-bus/collect-trace!
-        {:op-type :event :operation :rf.test/x :tags {} :sensitive? false}))
-    ;; Drop the prior subscription's cache by entering a new frame
-    ;; context (the reactive sub caches its last value against the
-    ;; (no-op) input signal — the assertion here is on the underlying
-    ;; bus state, which is process-global per Phase 1 contract).
-    (is (= 1 (count (trace-bus/buffer)))
-        "the bus holds the pushed event")))
+          "empty :trace-buffer slot → sub returns []")
+      (rf/dispatch-sync
+        [:rf.causa/note-trace-event
+         {:id 1 :op-type :event :operation :rf.test/x :tags {}}])
+      (let [buf @(rf/subscribe [:rf.causa/trace-buffer])]
+        (is (= 1 (count buf))
+            "one bump via dispatch → sub returns one-element buffer")
+        (is (= 1 (:id (first buf)))
+            "the dispatched event is in the buffer"))
+      (rf/dispatch-sync
+        [:rf.causa/note-trace-event
+         {:id 2 :op-type :event :operation :rf.test/y :tags {}}])
+      (let [buf @(rf/subscribe [:rf.causa/trace-buffer])]
+        (is (= 2 (count buf))
+            "second bump appends — sub returns a two-element buffer")
+        (is (= [1 2] (mapv :id buf))
+            "events are oldest-first, matching trace-bus/push algebra"))
+      (rf/dispatch-sync [:rf.causa/clear-trace-buffer])
+      (is (= [] @(rf/subscribe [:rf.causa/trace-buffer]))
+          "clear event drops the slot back to default empty"))))
+
+(deftest sub-trace-buffer-evicts-on-overflow-via-event
+  (testing ":rf.causa/note-trace-event mirrors trace-bus/push's
+            eviction-on-overflow algebra against `trace-bus/current-
+            depth`. We shrink the depth to 3 then push 5 events; the
+            sub returns the 3 newest in oldest-first order
+            (rf2-iw5ym)."
+    (setup-causa-frame!)
+    (trace-bus/set-buffer-depth! 3)
+    (try
+      (rf/with-frame :rf/causa
+        (dotimes [i 5]
+          (rf/dispatch-sync
+            [:rf.causa/note-trace-event
+             {:id i :op-type :event :operation :rf.test/x :tags {}}]))
+        (let [buf @(rf/subscribe [:rf.causa/trace-buffer])]
+          (is (= 3 (count buf))
+              "depth=3 caps the sub-visible buffer at 3 entries")
+          (is (= [2 3 4] (mapv :id buf))
+              "oldest entries evicted; newest retained in oldest-first order")))
+      (finally
+        (trace-bus/set-buffer-depth! 1000)))))
+
+(deftest sub-trace-buffer-survives-hot-reload
+  (testing "re-running `register-causa-handlers!` (shadow-cljs
+            `:after-load`) preserves the previously-pushed events
+            — the idempotency sentinel skips re-registration so the
+            event-db handler is the same instance and the app-db
+            `:trace-buffer` slot is untouched (rf2-iw5ym)."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync
+        [:rf.causa/note-trace-event
+         {:id 1 :op-type :event :operation :rf.test/x :tags {}}])
+      (is (= 1 (count @(rf/subscribe [:rf.causa/trace-buffer]))))
+      ;; Hot-reload simulation — `register-causa-handlers!` is
+      ;; idempotent under the `defonce ^:private registered?` gate
+      ;; (rf2-n6x4q). Calling it again must NOT replace handlers
+      ;; nor drop the buffer.
+      (registry/register-causa-handlers!)
+      (is (= 1 (count @(rf/subscribe [:rf.causa/trace-buffer])))
+          "buffer survives a no-op re-registration")
+      (rf/dispatch-sync
+        [:rf.causa/note-trace-event
+         {:id 2 :op-type :event :operation :rf.test/y :tags {}}])
+      (is (= 2 (count @(rf/subscribe [:rf.causa/trace-buffer])))
+          "subsequent pushes still land in the existing slot"))))
+
+(deftest sub-trace-buffer-restarts-from-clean-state
+  (testing "after `:rf.causa/clear-trace-buffer` + frame reset the
+            sub returns []; the next push starts from id 0
+            (rf2-iw5ym — restart-from-clean-state contract)."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (dotimes [i 3]
+        (rf/dispatch-sync
+          [:rf.causa/note-trace-event
+           {:id i :op-type :event :operation :rf.test/x :tags {}}]))
+      (is (= 3 (count @(rf/subscribe [:rf.causa/trace-buffer]))))
+      (rf/dispatch-sync [:rf.causa/clear-trace-buffer])
+      (is (= [] @(rf/subscribe [:rf.causa/trace-buffer]))
+          "clear drops the slot")
+      (rf/dispatch-sync
+        [:rf.causa/note-trace-event
+         {:id 0 :op-type :event :operation :rf.test/x :tags {}}])
+      (let [buf @(rf/subscribe [:rf.causa/trace-buffer])]
+        (is (= 1 (count buf))
+            "the next push starts a fresh buffer")
+        (is (= 0 (:id (first buf)))
+            "the fresh buffer begins at the re-pushed id")))))
+
+(deftest event-sync-trace-buffer-replaces-slot
+  (testing ":rf.causa/sync-trace-buffer overwrites the slot wholesale
+            (rf2-iw5ym — used by `trace-bus/set-buffer-depth!` when
+            shrinking the depth would otherwise leave the mirror
+            longer than the atom side)."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (dotimes [i 4]
+        (rf/dispatch-sync
+          [:rf.causa/note-trace-event
+           {:id i :op-type :event :operation :rf.test/x :tags {}}]))
+      (is (= 4 (count @(rf/subscribe [:rf.causa/trace-buffer]))))
+      (rf/dispatch-sync
+        [:rf.causa/sync-trace-buffer
+         [{:id 99 :op-type :event :operation :rf.test/z :tags {}}]])
+      (let [buf @(rf/subscribe [:rf.causa/trace-buffer])]
+        (is (= 1 (count buf))
+            "sync replaces the slot, doesn't merge")
+        (is (= 99 (:id (first buf)))
+            "the replacement vector is exactly what the sub returns")))))
 
 (deftest sub-suppressed-sensitive-count-reads-app-db
   (testing ":rf.causa/suppressed-sensitive-count reads from Causa's

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -393,7 +393,14 @@
             composite's :has-mismatch? flips true and the dormant
             marker drops"
     (causa-setup!)
-    (trace-bus/collect-trace! (mismatch-ev 1))
+    ;; Per rf2-iw5ym `:rf.causa/trace-buffer` is reactive off Causa's
+    ;; app-db; the test drives the reactive write path directly via
+    ;; `dispatch-sync` so the hydration composite re-fires before the
+    ;; shell renders (production wiring goes through
+    ;; `trace-bus/collect-trace!` which dispatches async — covered by
+    ;; `sensitive_trace_cljs_test`).
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/note-trace-event (mismatch-ev 1)]))
     (rf/with-frame :rf/causa
       (let [tree (shell/shell-view)
             row  (find-by-testid tree "rf-causa-sidebar-item-hydration")


### PR DESCRIPTION
## Summary

- Apply rf2-0vxdn's reactive-container recipe to `:rf.causa/trace-buffer`. Previously the sub thunked `trace-bus/buffer` (a plain atom outside the reactive sub-graph), so panels reading the buffer only re-rendered when some sibling sub recomputed.
- Mirror the buffer into Causa's app-db at `:trace-buffer`. `trace-bus/collect-trace!` + `clear-buffer!` + `set-buffer-depth!` dual-write (atom + dispatch) in CLJS. The atom remains as the JVM-runnable data primitive (push algebra, sensitive_trace_cljs_test, filter_vocab_consumer_cljs_test).
- New events: `:rf.causa/note-trace-event` (mirrors `trace-bus/push`'s eviction algebra against `trace-bus/current-depth`), `:rf.causa/clear-trace-buffer` (drops the slot), `:rf.causa/sync-trace-buffer` (replaces the slot wholesale; used by `set-buffer-depth!` when shrinking).

## Test plan

- [x] `npm run test:cljs` — all 1730 tests / 4798 assertions pass (panel tests included).
- [x] `clojure -M:test` (tools/causa) — all 487 tests / 1349 assertions pass.
- [x] New registry tests cover: reactive read off app-db, eviction-on-overflow via event, hot-reload survival (sentinel-idempotent re-registration preserves the buffer), restart-from-clean-state (clear + restart), wholesale-replace via `:rf.causa/sync-trace-buffer`.
- [x] Panel-test fixtures (`seed-buffer!`, `push-trace!`, `push-event!`, `push-failures!` across 14 helpers + shell-test) migrated to `dispatch-sync` of `:rf.causa/note-trace-event` so composite subs re-fire synchronously before rendered-tree assertions.
- [x] Spec catalogue (`014-Registry-Catalogue.md`) updated — sub now sources from `db`, three new events documented.
- [x] Smoke-block event-name list bumped 60 → 63; `registry-counts-match-bead` assertion follows.

Pre-alpha. Recipe-transfer fix; minimal scope.