### PR TITLE
fix(ci): root-cause + fix 3 of 4 pair2-mcp + CLJS browser-test + causa-redacted-indicator failures (rf2-higwg)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1136,6 +1136,11 @@ jobs:
           distribution: temurin
           java-version: '21'
 
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08  # 13.4
+        with:
+          cli: latest
+
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
@@ -1265,6 +1270,11 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08  # 13.4
+        with:
+          cli: latest
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -162,22 +162,37 @@
   absent — those count under `:global`.
 
   Per rf2-0vxdn: in CLJS, also dispatches
-  `:rf.causa/note-sensitive-suppressed` into the `:rf/causa` frame so
-  the bottom-rail's `[● REDACTED N]` indicator updates IMMEDIATELY
-  via the reactive sub-graph (the sub reads
-  `:suppressed-counters` off Causa's app-db). The atom-bump stays
-  as the JVM-runnable data primitive (`sensitive_trace` CLJC tests
-  assert it directly); the dispatch is the reactive surface for
-  CLJS. Guarded on the `:rf/causa` frame's existence — production
-  preload always installs it, but tests / hot-reload windows may
-  call `note-suppressed!` before the frame registers."
+  `:rf.causa/note-sensitive-suppressed` so the bottom-rail's
+  `[● REDACTED N]` indicator updates IMMEDIATELY via the reactive
+  sub-graph (the event handler updates the active frame's app-db
+  `:suppressed-counters` slot; the sub reads off the same db). The
+  atom-bump stays as the JVM-runnable data primitive
+  (`sensitive_trace` CLJC tests assert it directly); the dispatch
+  is the reactive surface for CLJS.
+
+  Per rf2-higwg: the dispatch follows the active frame chain rather
+  than binding to `:rf/causa` explicitly. The shell's bottom-rail
+  is a plain Reagent fn (not `reg-view`-registered) so its
+  subscribe resolves through the chain to `:rf/default` — the
+  framework emits the `:rf.warning/plain-fn-under-non-default-
+  frame-once` warning on first render but the routing falls
+  through cleanly. Pairing the dispatch's write target with the
+  read's read target (both chain-resolved) keeps the indicator
+  reactive without requiring an explicit `reg-frame :rf/causa` at
+  preload time (which would fail — `reg-frame` needs a substrate
+  adapter installed via `rf/init!`, and the preload runs at
+  ns-load time before that).
+
+  Guarded on `:rf/default`'s existence so JVM / pre-`init!` callers
+  (`sensitive_trace_cljs_test`'s fixture has no frames registered)
+  bump the atom without emitting an `:rf.error/frame-destroyed`
+  trace into the bus."
   [frame-id]
   (let [k (or frame-id :global)]
     (swap! suppressed-counters update k (fnil inc 0)))
   #?(:cljs
-     (when (frame/frame :rf/causa)
-       (binding [frame/*current-frame* :rf/causa]
-         (rf/dispatch [:rf.causa/note-sensitive-suppressed frame-id]))))
+     (when (frame/frame :rf/default)
+       (rf/dispatch [:rf.causa/note-sensitive-suppressed frame-id])))
   nil)
 
 (defn suppressed-count

--- a/tools/causa/test/day8/re_frame2_causa/keybinding_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/keybinding_cljs_test.cljs
@@ -88,24 +88,61 @@
                                                 xs))))))
      :listeners listeners}))
 
+(defn- can-stub-js-document?
+  "True iff the running host lets us write `js/document` via `set!`.
+
+  In node-test there is no real `document` global; `(set! js/document
+  ...)` installs a fresh slot on `goog.global` and subsequent reads
+  see the new value. In a real browser `window.document` is a non-
+  configurable read-only WebIDL accessor — the JS engine silently
+  drops the assignment (or throws in strict mode), so subsequent
+  reads still return the genuine `HTMLDocument`. Test code that
+  installs a stub via `set! js/document` and asserts against that
+  stub silently fails in that case.
+
+  Per rf2-higwg: detect the host by writing-and-checking; if the
+  write didn't take effect we're inside a real browser
+  (`:browser-test` build under Playwright) and the keybinding /
+  mount tests' stub-driven contracts can't be exercised. The
+  predicate gates `with-stub-document*` so the deftest bodies no-op
+  on that host. The contracts are still proven on the node-test
+  build where stubbing works."
+  []
+  (let [marker (js-obj "rf2-higwg-marker" true)
+        prior  (when (exists? js/document) js/document)]
+    (set! js/document marker)
+    (let [installed? (identical? js/document marker)]
+      (if prior
+        (set! js/document prior)
+        (when installed?
+          (js-delete js/goog.global "document")))
+      installed?)))
+
 (defn- with-stub-document* [f]
   ;; `set!` on `js/document` installs at goog.global; restoring nil
   ;; afterwards puts the binding back to the node-test baseline (absent).
-  (let [{:keys [doc listeners]} (mk-stub-document)
-        had-doc?                (exists? js/document)
-        prior                   (when had-doc? js/document)]
-    (set! js/document doc)
-    (try
-      (f {:listeners listeners})
-      (finally
-        ;; Make sure no leftover listener / sentinel from a partial
-        ;; test bleeds across runs. The sentinel is the contract we're
-        ;; testing — but if a deftest threw mid-way the global state
-        ;; would survive, so we hard-reset both here.
-        (try (keybinding/detach!) (catch :default _))
-        (if had-doc?
-          (set! js/document prior)
-          (js-delete js/goog.global "document"))))))
+  ;;
+  ;; Per rf2-higwg: in `:browser-test` the host's `window.document` is
+  ;; non-configurable and the `set!` silently no-ops — the stub never
+  ;; takes effect and `attach!`'s `addEventListener` lands on the real
+  ;; document. Skip the body cleanly in that host; the same contracts
+  ;; run on node-test where the stub does install.
+  (when (can-stub-js-document?)
+    (let [{:keys [doc listeners]} (mk-stub-document)
+          had-doc?                (exists? js/document)
+          prior                   (when had-doc? js/document)]
+      (set! js/document doc)
+      (try
+        (f {:listeners listeners})
+        (finally
+          ;; Make sure no leftover listener / sentinel from a partial
+          ;; test bleeds across runs. The sentinel is the contract we're
+          ;; testing — but if a deftest threw mid-way the global state
+          ;; would survive, so we hard-reset both here.
+          (try (keybinding/detach!) (catch :default _))
+          (if had-doc?
+            (set! js/document prior)
+            (js-delete js/goog.global "document")))))))
 
 (defn- with-stub-document [f]
   (with-stub-document* f))

--- a/tools/causa/test/day8/re_frame2_causa/mount_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/mount_cljs_test.cljs
@@ -122,17 +122,54 @@
      "_created"
      created)))
 
+(defn- can-stub-js-document?
+  "True iff the running host lets us write `js/document` via `set!`.
+
+  In node-test there is no real `document` global; `(set! js/document
+  ...)` installs a fresh slot on `goog.global` and subsequent reads
+  see the new value. In a real browser `window.document` is a non-
+  configurable read-only WebIDL accessor — the JS engine silently
+  drops the assignment (or throws in strict mode), so subsequent
+  reads still return the genuine `HTMLDocument`. Test code that
+  installs a stub via `set! js/document` and asserts against that
+  stub silently fails in that case.
+
+  Per rf2-higwg: detect the host by writing-and-checking; if the
+  write didn't take effect we're inside a real browser
+  (`:browser-test` build under Playwright) and the mount tests'
+  stub-driven contracts can't be exercised. The predicate gates
+  `with-stub-document*` so the deftest bodies no-op on that host.
+  The contracts are still proven on the node-test build where
+  stubbing works."
+  []
+  (let [marker (js-obj "rf2-higwg-marker" true)
+        prior  (when (exists? js/document) js/document)]
+    (set! js/document marker)
+    (let [installed? (identical? js/document marker)]
+      (if prior
+        (set! js/document prior)
+        (when installed?
+          (js-delete js/goog.global "document")))
+      installed?)))
+
 (defn- with-stub-document* [f]
-  (let [doc       (mk-stub-document)
-        had-doc?  (exists? js/document)
-        prior     (when had-doc? js/document)]
-    (set! js/document doc)
-    (try
-      (f doc)
-      (finally
-        (if had-doc?
-          (set! js/document prior)
-          (js-delete js/goog.global "document"))))))
+  ;; Per rf2-higwg: in `:browser-test` the host's `window.document` is
+  ;; non-configurable and `set!` silently no-ops — the stub never
+  ;; takes effect and `mount/open!`'s `(.appendChild (.-body
+  ;; js/document) node)` lands on the real document. Skip the body
+  ;; cleanly in that host; the contracts run on node-test where the
+  ;; stub does install.
+  (when (can-stub-js-document?)
+    (let [doc       (mk-stub-document)
+          had-doc?  (exists? js/document)
+          prior     (when had-doc? js/document)]
+      (set! js/document doc)
+      (try
+        (f doc)
+        (finally
+          (if had-doc?
+            (set! js/document prior)
+            (js-delete js/goog.global "document")))))))
 
 (defn- with-stub-document [f]
   (with-stub-document* f))


### PR DESCRIPTION
## Summary

Four CI jobs had been RED across every PR since approximately the PR #708/#710 wave. This PR fixes 3 of them at the root layer; the 4th is filed as rf2-e9s81 (a deeper architectural fix exposed by rf2-iw5ym which landed AFTER the failing-CI cluster this bead is tracking).

## Root causes & fixes

| # | Failing job | Root cause | Fix |
|---|-------------|------------|-----|
| 1 | `Node tools/pair2-mcp (shadow-cljs :server-test)` | Workflow steps include JDK 21 + Node.js but NO `Set up Clojure CLI`. `npm test` runs `shadow-cljs compile server-test` which spawns `clojure` to bootstrap → `Executable 'clojure' not found on system path`. | Add the `DeLaGuardo/setup-clojure` action (same pin as every other clojure-needing job) before `npm install`. |
| 2 | `MCP conformance tools/pair2-mcp (rf2-cum40)` | Same as #1 — `npx shadow-cljs compile server` needs `clojure`. | Same fix. |
| 3 | `CLJS (shadow-cljs :browser-test, headless Chromium)` | `keybinding_cljs_test.cljs` and `mount_cljs_test.cljs` install a `js/document` stub via `(set! js/document doc)`. In node-test that cleanly installs at `goog.global`; in real browsers `window.document` is a non-configurable read-only WebIDL accessor — the assignment silently no-ops, the stub never takes effect, the tests' `addEventListener`/`appendChild` lands on the REAL document, and the stub's atoms stay at 0. The tests were authored as node-test-only (their docstrings explicitly say so) but the `:browser-test` ns-regexp `-cljs-test$` matches them anyway. | Add a `can-stub-js-document?` write-and-check predicate to both `with-stub-document*` helpers — gate the test body on stubbing actually working. Tests no-op cleanly in browser-test where stubbing is impossible; contracts still prove on node-test. |
| 4 | `Examples (browser, headless Chromium, rf2-lyj0)` causa.spec step 6 — `[● REDACTED N]` indicator timeout | `config/note-suppressed!` dispatches `:rf.causa/note-sensitive-suppressed` wrapped in `(binding [frame/*current-frame* :rf/causa] (rf/dispatch ...))`, guarded on `(frame/frame :rf/causa)` existing. But `:rf/causa` is NEVER registered: re-frame2 doesn't auto-create on dispatch; the preload can't `reg-frame` either (needs a substrate adapter, which only exists after `rf/init!`). So the dispatch is silently skipped, the sub never re-fires off the write path, the indicator never renders. | Drop the `:rf/causa` binding from `note-suppressed!`. Dispatch follows the active frame chain (plain-fn callers fall through to `:rf/default`, matching where the bottom-rail's plain-fn `subscribe` reads from). Guard on `:rf/default` existing so JVM / pre-init! callers (sensitive_trace_cljs_test fixture) bump the atom without emitting `:rf.error/frame-destroyed` into the bus. `reset-suppressed-count!` keeps the original guard intentionally — it's called from `clear-buffer!` and test fixtures where reset-trace pollution would break neighboring tests. |

## Not fixed here — rf2-e9s81 filed

rf2-iw5ym (commit 769ba9d4) moved `:rf.causa/trace-buffer` from thunking `(trace-bus/buffer)` to reading `(get db :trace-buffer [])`. That landed AFTER the failing-CI cluster this bead tracks. The change exposes the same `:rf/causa`-never-registered issue across step 5 of causa.spec (Trace panel row count after dispatch). Fixing it cleanly needs a wider design decision (revert iw5ym vs. reg-view-wrap the Causa shell vs. fixed-frame sub mechanism) so it's filed as **rf2-e9s81** with the three options + tradeoffs spelled out.

## Local test plan

- [x] `cd implementation && npm run test:cljs` — 1734 tests, 4805 assertions, 0 failures, 0 errors (was 0 failures pre-change; this PR doesn't regress it)
- [x] `cd implementation && npm run test:browser` — 1734 tests, 4730 assertions, 0 failures, 0 errors (was failing before this PR with the mount + keybinding stub-DOM tests)
- [x] `cd tools/pair2-mcp && npm test` — 219 tests, 506 assertions, 0 failures, 0 errors (was failing in CI with `Executable 'clojure' not found`; locally has clojure on PATH)
- [x] `cd implementation && npm run test:examples` — step 6 (REDACTED indicator) is now reachable; step 5 (Trace panel) still fails — that's the rf2-e9s81 follow-on path

After this lands the CI cluster on a fresh main is 3 of 4 green (pair2-mcp ×2 + browser-test). Examples remains red on the post-iw5ym trace panel; rf2-e9s81 is the path to closing it.