### PR TITLE
docs(skills): codify leaf-size ceiling — ≤250L / ≤16KB (rf2-zkca8)

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -137,3 +137,22 @@ Skills do not run independently of re-frame2's CI; their workflows have
 been removed in favour of release coordination through re-frame2's own
 release pipeline. See each skill's `RELEASING.md` (where present) for
 historical npm publish mechanics.
+
+### Leaf size discipline
+
+Single source of truth for the per-leaf size ceiling — per-skill
+`spec/authoring-prompt.md` files defer here instead of restating.
+
+- Each leaf file SHOULD be **≤250 lines AND ≤16 KB** (target ~150 lines /
+  ~10 KB). The byte ceiling catches leaves whose long unwrapped prose
+  lines fit under the line count but still bloat the per-session token
+  load.
+- `SKILL.md` orchestrators SHOULD be ≤500 lines (target ~300–400).
+- No SKILL → A → B chains; routing is one level deep.
+- Catalogue-shaped leaves (e.g. `re-frame-pair2/references/recipes.md`)
+  may exceed the ceiling if splitting would multiply file-handle overhead
+  without reducing tokens-per-session. Test: would splitting reduce total
+  tokens loaded per session?
+
+Corpus stats supporting these numbers: `ai/findings/skill-leaf-size-audit-20260513.md`
+(local-only; max 203 L, p95 148 L, median 88 L).


### PR DESCRIPTION
## Summary

Codifies the per-leaf size ceiling in `skills/README.md` as the single source of truth. Per rf2-94gpb audit, the ≤250-line / target ~150-line rule was restated in 7+ per-skill `spec/authoring-prompt.md` files but absent from the corpus-wide README — files would drift in lockstep.

- New "Leaf size discipline" subsection (19 lines) under §Layout convention.
- Adds parallel **≤16 KB byte ceiling** (target ~10 KB) to catch leaves with long unwrapped prose lines that fit under the line count.
- Captures the existing rules: SKILL.md ≤500 L (target ~300–400), one-level routing, catalogue-shaped exemption (e.g. `re-frame-pair2/references/recipes.md`).
- Points at `ai/findings/skill-leaf-size-audit-20260513.md` for the corpus stats (max 203 L, p95 148 L, median 88 L — already compliant).

Single-file edit. No per-skill files touched in this PR; they'll defer here in follow-up work.

## Test plan

- [x] Only `skills/README.md` modified
- [x] New subsection renders correctly under §Layout convention
- [x] No AI attribution in commit/PR