### PR TITLE
fix(causa): partition-reserved covers :rf/elision (lockstep with Conventions) (rf2-w1r29)

### DIFF
--- a/tools/causa/spec/004-App-DB-Diff.md
+++ b/tools/causa/spec/004-App-DB-Diff.md
@@ -79,7 +79,7 @@ sessions.
 
 The runtime owns a fixed set of top-level `app-db` keys, catalogued
 in [Conventions §Reserved app-db keys](../../../spec/Conventions.md#reserved-app-db-keys).
-Causa's `[runtime]` group segregates these five:
+Causa's `[runtime]` group segregates these six:
 
 | Reserved key | Owner | One-line role |
 |---|---|---|
@@ -88,13 +88,15 @@ Causa's `[runtime]` group segregates these five:
 | `:rf/spawned` | machine runtime | Declarative-`:invoke` / `:invoke-all` spawn registry — `<parent-id> → {<invoke-id> <slot>}` for the destroy-cascade walker. |
 | `:rf/route` | routing runtime | The current route slice `{:id :params :query :transition :error}`. |
 | `:rf/pending-navigation` | routing runtime | Pending-navigation slot populated when a `:can-leave` guard rejects; cleared by `:rf.route/continue` / `:rf.route/cancel`. |
+| `:rf/elision` | elision runtime | Wire-elision declaration registry — `{:declarations {<path> {:large? :hint :source}} :runtime-flagged {<path> {:bytes :first-seen-epoch}}}`. Mutated via `:rf.size/declare-large` / `:rf.size/clear`; consulted by `rf/elide-wire-value` at every wire-boundary emit. |
 
 Conventions is the canonical home; this table is the panel-facing
-projection. The five above are the keys Causa's `partition-reserved`
+projection. The six above are the keys Causa's `partition-reserved`
 treats as runtime-owned in the diff panel — diff triples rooted in
 one of them render here rather than as slice mini-panels. If a new
 reserved key lands in Conventions, the `[runtime]` group's coverage
-and this table are updated in lockstep.
+and this table are updated in lockstep; the drift-detector test in
+`app_db_diff_helpers_cljs_test.cljc` enforces this on every run.
 
 ```
 ┌─ [runtime] ───────────────────────────────────────┐

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_helpers.cljc
@@ -55,7 +55,7 @@
 ;; ---- reserved keys --------------------------------------------------------
 
 (def reserved-app-db-keys
-  "Per spec/Conventions.md §Reserved app-db keys the runtime owns five
+  "Per spec/Conventions.md §Reserved app-db keys the runtime owns six
   top-level slots in `app-db`. Diff triples whose path roots in one
   of these keys render in the `[runtime]` group rather than as a
   slice mini-panel.
@@ -64,12 +64,19 @@
   - `:rf/system-ids` — system-id reverse index
   - `:rf/route` — current route slice (per spec/012-Routing.md)
   - `:rf/pending-navigation` — pending-nav slot
-  - `:rf/spawned` — spawned-actor table"
+  - `:rf/spawned` — spawned-actor table
+  - `:rf/elision` — wire-elision declaration registry (per spec/009-Instrumentation.md §Size elision)
+
+  Lockstep contract: this set MUST match the rows of
+  spec/Conventions.md §Reserved app-db keys exactly. The drift-detector
+  test `reserved-app-db-keys-matches-conventions-md` in
+  `app_db_diff_helpers_cljs_test.cljc` enforces the invariant."
   #{:rf/machines
     :rf/route
     :rf/system-ids
     :rf/pending-navigation
-    :rf/spawned})
+    :rf/spawned
+    :rf/elision})
 
 (defn reserved-path?
   "True when `path`'s root key is a reserved-app-db key. Pure data →

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_helpers_cljs_test.cljc
@@ -146,14 +146,51 @@
 
 ;; ---- (3) reserved-keys partition ----------------------------------------
 
-(deftest reserved-app-db-keys-includes-the-five-runtime-keys
+(deftest reserved-app-db-keys-includes-the-six-runtime-keys
   (testing "reserved-app-db-keys matches spec/Conventions.md
             §Reserved app-db keys"
     (is (contains? h/reserved-app-db-keys :rf/machines))
     (is (contains? h/reserved-app-db-keys :rf/route))
     (is (contains? h/reserved-app-db-keys :rf/system-ids))
     (is (contains? h/reserved-app-db-keys :rf/pending-navigation))
-    (is (contains? h/reserved-app-db-keys :rf/spawned))))
+    (is (contains? h/reserved-app-db-keys :rf/spawned))
+    (is (contains? h/reserved-app-db-keys :rf/elision))))
+
+(def ^:private conventions-reserved-app-db-keys
+  "The canonical set of reserved app-db keys per spec/Conventions.md
+  §Reserved app-db keys. Hard-coded here as a drift-detector: if a
+  new reserved key lands in Conventions and this set is updated,
+  `partition-reserved`'s coverage MUST be updated in lockstep — see
+  rf2-w1r29 for the gap that motivated this test (rf2-qictc surfaced
+  the lockstep expectation; `:rf/elision` had drifted out of the
+  partition set).
+
+  Per the rule in tools/causa/spec/004-App-DB-Diff.md §Reserved-keys
+  group: 'If a new reserved key lands in Conventions, the `[runtime]`
+  group's coverage and this table are updated in lockstep.' This
+  hard-coded set is the test-side mirror of that table; updating
+  Conventions, the panel table, AND this set is a single atomic
+  change."
+  #{:rf/machines
+    :rf/route
+    :rf/system-ids
+    :rf/pending-navigation
+    :rf/spawned
+    :rf/elision})
+
+(deftest reserved-app-db-keys-matches-conventions-md
+  (testing "drift-detector: every key in spec/Conventions.md §Reserved
+            app-db keys is covered by partition-reserved (rf2-w1r29
+            follow-on to rf2-qictc)"
+    (is (= conventions-reserved-app-db-keys h/reserved-app-db-keys)
+        "partition-reserved's reserved-app-db-keys must equal the
+        canonical Conventions set exactly — additions and removals
+        in Conventions must land in Causa in the same change.")
+    (doseq [k conventions-reserved-app-db-keys]
+      (is (h/reserved-path? [k :child :leaf])
+          (str "reserved-path? must return true for a path rooted at " k))
+      (is (h/reserved-path? [k])
+          (str "reserved-path? must return true for a top-level " k " path")))))
 
 (deftest reserved-path-true-for-rf-roots
   (testing "reserved-path? returns true when the first path key is reserved"


### PR DESCRIPTION
## Summary

- spec/Conventions.md §Reserved app-db keys lists six reserved keys; Causa's `partition-reserved` only handled five — `:rf/elision` was missing, so diff triples rooted in `:rf/elision` would render as a slice mini-panel rather than in the `[runtime]` group.
- Adds `:rf/elision` to `reserved-app-db-keys` and updates `tools/causa/spec/004-App-DB-Diff.md` §Reserved-keys group to enumerate all six.
- Adds a drift-detector test that hard-codes the canonical Conventions set and asserts `partition-reserved` covers each key exactly — Conventions additions/removals must land in Causa in the same change.

Follow-on to rf2-qictc which enumerated the five in spec/004-App-DB-Diff.md but didn't notice the partition-set drift.

## Test plan

- [x] `npm run test:cljs` from `implementation/` — 1735 tests / 4819 assertions, 0 failures.
- [x] `clojure -M:test` from `tools/causa/` — 488 tests / 1363 assertions, 0 failures.
- [x] New `reserved-app-db-keys-matches-conventions-md` drift-detector asserts equality with the canonical six and `reserved-path?` coverage for each.
- [x] Renamed/extended `reserved-app-db-keys-includes-the-six-runtime-keys` covers `:rf/elision`.