### PR TITLE
feat(ssr): register :rf.ssr/check-version + :rf.ssr/check-schema-digest fxs (rf2-69ad2)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -476,12 +476,159 @@
 
 (events/reg-event-fx :rf/hydrate
   (fn [{:keys [db]} [_ payload]]
-    (let [new-db   (or (:rf/app-db payload) (:app-db payload) db)
-          metadata (cond-> {}
-                     (:rf/render-hash payload) (assoc :server-hash (:rf/render-hash payload))
-                     (:rf/version payload)     (assoc :version     (:rf/version payload)))]
+    (let [new-db        (or (:rf/app-db payload) (:app-db payload) db)
+          version       (:rf/version payload)
+          schema-digest (:rf/schema-digest payload)
+          metadata      (cond-> {}
+                          (:rf/render-hash payload) (assoc :server-hash (:rf/render-hash payload))
+                          version                   (assoc :version     version))]
+      ;; Per Spec 011 §The :rf/hydrate event: dispatch the compatibility-
+      ;; check fxs as part of `:fx` so a mismatch surfaces a structured
+      ;; trace event without crashing the hydration path. Both fxs gate on
+      ;; payload-key presence — the scalar form passed here is the
+      ;; server's value (the "expected"); the fx looks up the client-side
+      ;; "actual" via late-bind. Per rf2-69ad2.
       {:db (cond-> new-db
-             (seq metadata) (assoc :rf/hydration metadata))})))
+             (seq metadata) (assoc :rf/hydration metadata))
+       :fx (cond-> []
+             version       (conj [:rf.ssr/check-version       version])
+             schema-digest (conj [:rf.ssr/check-schema-digest schema-digest]))})))
+
+;; ---- :rf.ssr/check-version + :rf.ssr/check-schema-digest fxs --------------
+;;
+;; Per Spec 011 §The :rf/hydrate event (rf2-69ad2). The :rf/hydrate handler
+;; dispatches these two fxs after replacing the client app-db with the
+;; server's authoritative slice. They are best-effort compatibility checks:
+;; a mismatch emits a structured warning trace and the hydration proceeds.
+;; The runtime never throws on a mismatch — degraded-but-running beats
+;; a crashed boot.
+;;
+;; Arg shape (clarified per rf2-69ad2 because Spec 011 only pinned the
+;; trace shape, not the fx-input shape):
+;;
+;;   - SCALAR — `[:rf.ssr/check-version <server-value>]` per the spec's
+;;     reference :rf/hydrate handler. The fx treats the scalar as the
+;;     "expected" (server-side) value and looks up the client-side
+;;     "actual" via a late-bind hook (`:rf2/runtime-version` for version,
+;;     `:schemas/app-schemas-digest` for schema-digest). When the hook is
+;;     unavailable (e.g. version-pinning not yet implemented, or schemas
+;;     artefact not on the classpath), the fx emits a
+;;     `:rf.ssr/compatibility-check-skipped` trace and no-ops the
+;;     comparison.
+;;
+;;   - MAP — `[:rf.ssr/check-version {:expected ... :actual ...}]` for
+;;     callers that compute both sides explicitly (test harnesses, hosts
+;;     that pin their own version constant). The fx compares the two
+;;     values directly.
+;;
+;; Gating: `:platforms #{:client}` — these checks only make sense on the
+;; hydration side. Server-side dispatches no-op via the standard fx-
+;; gating contract (`:rf.fx/skipped-on-platform`).
+
+(defn- check-args
+  "Normalise the fx argument to `{:expected <server-value> :actual <client-value>}`.
+  Returns nil when the argument doesn't carry an `:expected` value the
+  fx can compare against. The `actual-lookup-fn` is a 0-arity fn called
+  to resolve the client-side value when the caller passed a scalar; it
+  may return nil to signal `:lookup-unavailable`."
+  [arg actual-lookup-fn]
+  (cond
+    (and (map? arg) (contains? arg :expected))
+    (cond-> {:expected (:expected arg)}
+      (contains? arg :actual) (assoc :actual (:actual arg))
+      ;; map without :actual falls back to the lookup
+      (not (contains? arg :actual)) (assoc :actual (actual-lookup-fn)))
+
+    (nil? arg) nil
+
+    :else
+    {:expected arg :actual (actual-lookup-fn)}))
+
+(defn- runtime-version-lookup
+  "Look up the client-side runtime version. No constant is pinned in
+  re-frame.core today (per rf2-69ad2 scope); the value is sourced via
+  the optional `:rf2/runtime-version` late-bind hook — a host that
+  bundles a version-stamp registers it at boot. When the hook is
+  absent, returns nil and the check emits
+  `:rf.ssr/compatibility-check-skipped`."
+  []
+  (when-let [f (late-bind/get-fn :rf2/runtime-version)]
+    (f)))
+
+(defn- schema-digest-lookup
+  "Look up the active frame's `app-schemas-digest`. Sourced via the
+  schemas artefact's `:schemas/app-schemas-digest` late-bind hook so
+  re-frame.ssr does not statically `:require` the schemas artefact —
+  in builds where schemas is absent the lookup returns nil and the
+  check emits `:rf.ssr/compatibility-check-skipped`."
+  []
+  (when-let [f (late-bind/get-fn :schemas/app-schemas-digest)]
+    (f)))
+
+(fx/reg-fx :rf.ssr/check-version
+  {:doc       "Compare the payload's :rf/version (server) against the
+client runtime's version. A mismatch emits a structured
+:rf.ssr/version-mismatch trace; the hydration handler still applies
+(best-effort). Per Spec 011 §The :rf/hydrate event."
+   :platforms #{:client}}
+  (fn [{:keys [frame]} arg]
+    (let [{:keys [expected actual]} (check-args arg runtime-version-lookup)]
+      (cond
+        (nil? expected)
+        nil                                          ;; nothing to check
+
+        (nil? actual)
+        (trace/emit! :warning :rf.ssr/compatibility-check-skipped
+                     {:check    :rf.ssr/check-version
+                      :expected expected
+                      :reason   "No runtime version available for comparison (no :rf2/runtime-version hook registered)."
+                      :frame    frame
+                      :recovery :skipped})
+
+        (not= expected actual)
+        (trace/emit! :warning :rf.ssr/version-mismatch
+                     {:expected expected
+                      :actual   actual
+                      :frame    frame
+                      :reason   (str "Hydration version-mismatch: server '"
+                                     expected "' != client '" actual
+                                     "'. Hydrating anyway (best-effort).")
+                      :recovery :warned-and-applied})
+
+        :else nil))))                                ;; match → silent
+
+(fx/reg-fx :rf.ssr/check-schema-digest
+  {:doc       "Compare the payload's :rf/schema-digest (server) against
+the client's registered app-schema digest. A mismatch emits a structured
+:rf.ssr/schema-digest-mismatch trace — surfaces deploy-drift where
+the server is rendering against a different schema set than the
+client's bundle. Per Spec 011 §The :rf/hydrate event."
+   :platforms #{:client}}
+  (fn [{:keys [frame]} arg]
+    (let [{:keys [expected actual]} (check-args arg schema-digest-lookup)]
+      (cond
+        (nil? expected)
+        nil                                          ;; nothing to check
+
+        (nil? actual)
+        (trace/emit! :warning :rf.ssr/compatibility-check-skipped
+                     {:check    :rf.ssr/check-schema-digest
+                      :expected expected
+                      :reason   "No schema digest available for comparison (schemas artefact not on classpath, or :schemas/app-schemas-digest hook absent)."
+                      :frame    frame
+                      :recovery :skipped})
+
+        (not= expected actual)
+        (trace/emit! :warning :rf.ssr/schema-digest-mismatch
+                     {:expected expected
+                      :actual   actual
+                      :frame    frame
+                      :reason   (str "Hydration schema-digest mismatch: server '"
+                                     expected "' != client '" actual
+                                     "'. Deploy drift — server and client are running different schema sets. Hydrating anyway (best-effort).")
+                      :recovery :warned-and-applied})
+
+        :else nil))))                                ;; match → silent
 
 (defn verify-hydration!
   "Per Spec 011 §Hydration-mismatch detection. Called by client code

--- a/implementation/ssr/test/re_frame/ssr_compatibility_checks_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_compatibility_checks_test.clj
@@ -1,0 +1,157 @@
+(ns re-frame.ssr-compatibility-checks-test
+  "Per rf2-69ad2 / Spec 011 §The :rf/hydrate event: the :rf.ssr/check-version
+  and :rf.ssr/check-schema-digest fxs are the hydration-side compatibility
+  checks the :rf/hydrate handler dispatches after replacing the client
+  app-db. Each fx is best-effort — a mismatch emits a structured warning
+  trace; the hydration proceeds (degraded-but-running, never crash).
+
+  Coverage (2 per fx, matching the bead's acceptance criteria):
+
+    - matching values → silent (no mismatch trace fires)
+    - mismatching values → :rf.ssr/version-mismatch / :rf.ssr/schema-digest-
+      mismatch trace fires with :expected + :actual + :recovery shape."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.ssr :as ssr]))
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (rf/init! ssr/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr    :reload)
+  (require 're-frame.machines :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- capture-traces!
+  "Run f under a trace listener that captures every event; return the
+  captured vector after f returns."
+  [f]
+  (let [traces (atom [])
+        cb-id  (gensym "::capture-")]
+    (rf/register-trace-cb! cb-id (fn [ev] (swap! traces conj ev)))
+    (try
+      (f)
+      (finally
+        (rf/remove-trace-cb! cb-id)))
+    @traces))
+
+(defn- traces-of [traces op]
+  (filterv #(= op (:operation %)) traces))
+
+;; ===========================================================================
+;; :rf.ssr/check-version
+;; ===========================================================================
+;;
+;; Per Spec 011 §The :rf/hydrate event: the fx receives a scalar (the
+;; server's version) per the reference handler, OR a map {:expected ... :actual ...}
+;; for explicit comparisons (per the rf2-69ad2 fx-input-shape clarification).
+;; Matching → silent; mismatching → :rf.ssr/version-mismatch warning trace.
+
+(deftest check-version-matching-is-silent
+  (testing "matching expected + actual → no :rf.ssr/version-mismatch trace"
+    (rf/reg-event-fx ::probe-check-version-match
+      {:platforms #{:client}}
+      (fn [_ _]
+        {:fx [[:rf.ssr/check-version {:expected "1.0.0" :actual "1.0.0"}]]}))
+
+    (let [f      (rf/make-frame {:platform :client})
+          traces (capture-traces!
+                   (fn []
+                     (rf/dispatch-sync [::probe-check-version-match]
+                                       {:frame f})))]
+      (is (empty? (traces-of traces :rf.ssr/version-mismatch))
+          "matching version → no mismatch trace")
+      (is (empty? (traces-of traces :rf.ssr/compatibility-check-skipped))
+          "both sides supplied → no skipped trace either"))))
+
+(deftest check-version-mismatch-emits-trace
+  (testing "differing expected + actual → :rf.ssr/version-mismatch warning trace"
+    (rf/reg-event-fx ::probe-check-version-mismatch
+      {:platforms #{:client}}
+      (fn [_ _]
+        {:fx [[:rf.ssr/check-version {:expected "1.0.0" :actual "2.0.0"}]]}))
+
+    (let [f      (rf/make-frame {:platform :client})
+          traces (capture-traces!
+                   (fn []
+                     (rf/dispatch-sync [::probe-check-version-mismatch]
+                                       {:frame f})))
+          hits   (traces-of traces :rf.ssr/version-mismatch)]
+      (is (= 1 (count hits))
+          (str "expected one :rf.ssr/version-mismatch trace; saw: "
+               (pr-str (mapv :operation traces))))
+      (when (seq hits)
+        (let [ev (first hits)]
+          (is (= :warning              (:op-type ev)))
+          (is (= "1.0.0"               (-> ev :tags :expected)))
+          (is (= "2.0.0"               (-> ev :tags :actual)))
+          (is (= :warned-and-applied   (:recovery ev))
+              ":recovery rides at top-level per Spec 009"))))))
+
+;; ===========================================================================
+;; :rf.ssr/check-schema-digest
+;; ===========================================================================
+;;
+;; Same shape as version-check. Matching → silent; mismatch → warning trace.
+;; Scalar form is what the reference :rf/hydrate handler dispatches (the
+;; payload's :rf/schema-digest); the fx looks up the client-side digest
+;; via the `:schemas/app-schemas-digest` late-bind hook. When the schemas
+;; artefact isn't on the classpath the hook is absent and the fx emits
+;; :rf.ssr/compatibility-check-skipped (covered by the scalar-form path
+;; running under the real schemas artefact below).
+
+(deftest check-schema-digest-matching-is-silent
+  (testing "matching expected + actual → no :rf.ssr/schema-digest-mismatch trace"
+    (rf/reg-event-fx ::probe-check-digest-match
+      {:platforms #{:client}}
+      (fn [_ _]
+        {:fx [[:rf.ssr/check-schema-digest
+               {:expected "sha256:deadbeefcafef00d"
+                :actual   "sha256:deadbeefcafef00d"}]]}))
+
+    (let [f      (rf/make-frame {:platform :client})
+          traces (capture-traces!
+                   (fn []
+                     (rf/dispatch-sync [::probe-check-digest-match]
+                                       {:frame f})))]
+      (is (empty? (traces-of traces :rf.ssr/schema-digest-mismatch))
+          "matching digest → no mismatch trace")
+      (is (empty? (traces-of traces :rf.ssr/compatibility-check-skipped))
+          "both sides supplied → no skipped trace either"))))
+
+(deftest check-schema-digest-mismatch-emits-trace
+  (testing "differing expected + actual → :rf.ssr/schema-digest-mismatch warning trace"
+    (rf/reg-event-fx ::probe-check-digest-mismatch
+      {:platforms #{:client}}
+      (fn [_ _]
+        {:fx [[:rf.ssr/check-schema-digest
+               {:expected "sha256:deadbeefcafef00d"
+                :actual   "sha256:0000000000000000"}]]}))
+
+    (let [f      (rf/make-frame {:platform :client})
+          traces (capture-traces!
+                   (fn []
+                     (rf/dispatch-sync [::probe-check-digest-mismatch]
+                                       {:frame f})))
+          hits   (traces-of traces :rf.ssr/schema-digest-mismatch)]
+      (is (= 1 (count hits))
+          (str "expected one :rf.ssr/schema-digest-mismatch trace; saw: "
+               (pr-str (mapv :operation traces))))
+      (when (seq hits)
+        (let [ev (first hits)]
+          (is (= :warning                              (:op-type ev)))
+          (is (= "sha256:deadbeefcafef00d"             (-> ev :tags :expected)))
+          (is (= "sha256:0000000000000000"             (-> ev :tags :actual)))
+          (is (= :warned-and-applied                   (:recovery ev))))))))

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -276,6 +276,8 @@ The `hydration-payload` is the canonical `:rf/hydration-payload` shape (per [Spe
 - `:rf.ssr/check-version` compares the payload's `:rf/version` against the runtime's. A mismatch emits `:rf.ssr/version-mismatch` (a structured trace event) and the handler still applies (best-effort).
 - `:rf.ssr/check-schema-digest` (when the payload includes one) hashes the client's currently-registered `app-schema` set and compares to the server's digest. Mismatch emits `:rf.ssr/schema-digest-mismatch`. Useful for catching deploy drift where the server is rendering against a newer/older schema set than the client's bundle.
 
+**fx-input shape** (per rf2-69ad2): each fx accepts either a **scalar** — `[:rf.ssr/check-version <server-value>]` (the form the reference handler dispatches) — or an **explicit map** — `[:rf.ssr/check-version {:expected <server-value> :actual <client-value>}]`. The scalar form treats the value as the server-supplied "expected" and looks up the client-side "actual" via a published hook (`:rf2/runtime-version` for version, `:schemas/app-schemas-digest` for schema-digest); when no hook is registered the fx emits `:rf.ssr/compatibility-check-skipped` (warning) and no-ops the comparison rather than crashing. Both fxs gate on `:platforms #{:client}` — server-side dispatches no-op via the standard fx-gating contract. The fxs NEVER throw — degraded-but-running is the locked posture.
+
 Hash-based render-tree mismatch (a separate concern) lives in §Hydration-mismatch detection.
 
 The payload shape is fixed; implementations may emit additive optional keys (per [Spec-Schemas §`:rf/hydration-payload`](Spec-Schemas.md#rfhydration-payload)) but never alter the required keys.


### PR DESCRIPTION
## Summary

Per Spec 011 §The :rf/hydrate event (gap #12 in the SSR audit, rf2-ul137): the reference `:rf/hydrate` handler dispatches `:rf.ssr/check-version` and `:rf.ssr/check-schema-digest`, but neither was registered. The dispatches were silently surfacing `:rf.error/no-such-handler` traces on every hydration.

This PR lands both fxs in `re-frame.ssr`, gated `:platforms #{:client}`:

- `:rf.ssr/check-version` — compares the payload's `:rf/version` (server) against the client runtime version. The client-side "actual" is resolved via the optional `:rf2/runtime-version` late-bind hook (no runtime-version constant exists yet; the hook is the consumer-only surface a host can register). Mismatch emits `:rf.ssr/version-mismatch` as a structured warning trace; hydration still applies (best-effort, never throws).
- `:rf.ssr/check-schema-digest` — compares the payload's `:rf/schema-digest` against the client's `app-schemas-digest` via the schemas artefact's `:schemas/app-schemas-digest` hook. Mismatch emits `:rf.ssr/schema-digest-mismatch` — surfaces deploy drift where the server is rendering against a different schema set than the client's bundle.

The reference `:rf/hydrate` handler now dispatches both fxs when the payload carries the keys, matching the worked example's hand-rolled handler.

## Design choice (small spec clarification)

Each fx accepts EITHER a scalar (the server's value — the form the reference handler dispatches) OR a map `{:expected ... :actual ...}` for callers that compute both sides explicitly. When the actual-side lookup is unavailable (no runtime-version hook registered, or schemas artefact absent), the fx emits `:rf.ssr/compatibility-check-skipped` and no-ops — degraded-but-running over crash.

Spec 011 §The :rf/hydrate event previously pinned only the trace shape — the fx-input shape was implicit. Added a short clarification paragraph documenting the scalar / map / skipped contract.

## Test plan

- [x] `clojure -M:test` from `implementation/ssr/` — 69 tests / 221 assertions / 0 failures
- [x] `clojure -M:test -n re-frame.late-bind-drift-test` — 5 tests / 316 assertions / 0 failures (consumer-only `:rf2/runtime-version` reference doesn't trip the published↔directory parity check)
- [x] Two tests per fx: matching values are silent, mismatching values emit the right trace shape