### PR TITLE
feat(pair2-mcp): per-session app-db cache keyed on root hash (rf2-3rt1f)

### DIFF
--- a/tools/pair2-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/pair2-mcp/spec/003-Tool-Catalogue.md
@@ -91,6 +91,54 @@ vocabulary `[:rf.elision/at <path>]` are reserved per
 and [`Spec 009 §Size elision in traces`](../../../spec/009-Instrumentation.md);
 the shape is shared across pair2-mcp, story-mcp, and causa-mcp.
 
+## Universal: per-session response cache
+
+Every read tool — `snapshot`, `get-path`, `trace-window`,
+`watch-epochs`, `discover-app` — opts into an 8-slot LRU
+keyed on `(tool, args-fingerprint)` (see
+[`Principles.md` §Per-session response cache](Principles.md#per-session-response-cache-rf2-3rt1f)).
+Each tool accepts a universal `cache` arg (boolean, default
+`false`). When `true` and the result's hash matches the prior
+call for the same `(tool, args)`, the full payload is replaced
+with a tiny marker:
+
+```clojure
+{:rf.mcp/cache-hit
+ {:hash            <integer>
+  :unchanged-since <ms-since-epoch>
+  :tool            "<tool-name>"
+  :hint            "<agent-host instruction string>"}}
+```
+
+The agent host already has the byte-identical bytes from the
+prior `tools/call`; re-shipping doubles the conversation cost
+for no new information. On a hash miss (state moved on), the
+fresh payload is returned and the new hash is stored. Capacity
+is 8 — sized for the typical "inspect, dispatch one thing,
+inspect again" rhythm; least-recently-used entries are evicted
+first. Cache lifetime is the MCP server process (= one MCP
+session per the [persistent-socket principle](Principles.md#single-persistent-nrepl-socket));
+no cross-process leak, no manual invalidation.
+
+Action tools (`dispatch`, `eval-cljs`, `tail-build`) and
+streaming tools (`subscribe`, `unsubscribe`) bypass the cache —
+their return value is the result of an action, not a read.
+`:isError` results bypass too; a transient failure must not
+mask a future successful read.
+
+The marker key `:rf.mcp/cache-hit` matches the cross-MCP wire-
+vocabulary family (`:rf.mcp/overflow`, `:rf.mcp/dedup-table`,
+`:rf.mcp/summary`, `:rf.size/large-elided`). Agents that
+learned the slot family see one more slot.
+
+The cache saves wire bytes, not the nREPL round-trip — the
+tool still runs server-side and the result is built locally.
+The byte saving is the one the bead targets: a typical
+"inspect, dispatch, inspect" workflow today re-ships the full
+app-db on the second inspect; with the cache it ships ~100
+bytes. Saving the round-trip too needs a server-side hash
+precheck and is filed as a follow-on bead.
+
 ## discover-app
 
 Verify the shadow-cljs nREPL is reachable, confirm the

--- a/tools/pair2-mcp/spec/Principles.md
+++ b/tools/pair2-mcp/spec/Principles.md
@@ -772,6 +772,88 @@ privacy filter (Spec 009 §Privacy / rf2-3cted) — the agent
 host learns one shape: "dropped count + the reason it was
 dropped".
 
+## Per-session response cache (rf2-3rt1f)
+
+**The principle**. The common pair2-mcp workflow rhythm is
+*inspect state → dispatch one event → inspect state again*.
+The second inspect is byte-identical to the first when nothing
+else mutated, yet today the wire pays the full app-db cost
+twice. A small per-session cache keyed on a result-hash
+collapses the second pay to a sub-100-byte marker.
+
+**Mechanism**. Each MCP server process holds an 8-slot LRU,
+keyed by `(tool, args-fingerprint)`. Each entry records the
+hash of the prior response's serialised text plus the
+`:sent-at` timestamp of first emission. On every read-tool
+invocation:
+
+1. Run the tool normally — compute the MCP result.
+2. Hash the result's `:text` slots.
+3. Look up `(tool, args-fingerprint)` in the LRU.
+   - **Miss**: store `{:hash h :sent-at now :tool t}`; return
+     the original result unchanged.
+   - **Hit, matching hash**: emit
+     ```clojure
+     {:rf.mcp/cache-hit
+      {:hash            h
+       :unchanged-since <ms>
+       :tool            <name>
+       :hint            "<agent-host instruction string>"}}
+     ```
+     instead of the full payload. Touch the entry to the tail
+     (LRU bookkeeping).
+   - **Hit, different hash**: state moved on; store the new
+     hash + `:sent-at`, return the fresh result.
+
+**Why hash the result, not app-db directly**. The bead
+proposed `(hash app-db)`. The framing here is one step
+downstream: by the time the result is built, it has been
+path-sliced, summarised, diff-encoded, deduped, scrubbed.
+Two calls with the same args against the same upstream state
+produce the same serialised text — so hashing the text catches
+the same hit and is robust against every transform in the wire
+pipeline. One mechanism covers every read tool uniformly
+instead of per-tool hash strategies.
+
+**Scope**. The cache saves wire bytes, not the nREPL round-
+trip — the tool still runs server-side and the result is
+built locally. The byte saving is the one the bead targets.
+Saving the round-trip too needs a server-side hash precheck
+(precompute `(hash app-db)` in the runtime, ship the hash
+first, only ship the body on miss) — out of scope for
+rf2-3rt1f, filed as a follow-on bead.
+
+**Why opt-in by default**. Agent hosts that haven't been
+taught the `:rf.mcp/cache-hit` marker shape would receive a
+sub-100-byte marker instead of the expected payload on the
+second call and either error out or, worse, silently confuse
+their internal model. Default-`false` matches the `dedup`
+default before its flip (rf2-obpa9 left dedup opt-out until
+host coverage was confirmed). Once the marker shape is in the
+re-frame-pair2 skill catalogue and agents pattern-match on it
+routinely, the default can flip.
+
+**Why 8 slots**. Sized for the typical session's
+"inspect different frames + a couple of get-path calls"
+working set, not for full coverage. An LRU at 8 fits the
+session's hot working set without retaining state long enough
+to mask a slow background mutation. Capacity is a `def`-level
+constant; future ergonomics work may surface it as an env
+var.
+
+**Bypass policy**. Action tools (`dispatch`, `eval-cljs`,
+`tail-build`) bypass — their return value is the result of an
+action, not a read. Streaming tools (`subscribe`,
+`unsubscribe`) bypass — they emit progress notifications, not
+single payloads. `:isError` results bypass — a transient
+failure must not mask a future successful read.
+
+**Cross-MCP vocabulary**. `:rf.mcp/cache-hit` is the wire
+marker name. It joins the `:rf.mcp/*` family already declared
+for `:rf.mcp/overflow` (rf2-rvyzy), `:rf.mcp/dedup-table`
+(rf2-obpa9), `:rf.mcp/summary` (rf2-tygdv). The agent learns
+the namespace once and recognises every marker.
+
 ## Backed by the framework's principles
 
 When in doubt, defer to the framework's [Principles](../../../spec/Principles.md):

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/cache.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/cache.cljs
@@ -1,0 +1,304 @@
+(ns re-frame-pair2-mcp.cache
+  "Per-session response cache keyed on a hash of the serialised wire
+  payload (rf2-3rt1f).
+
+  ## What this is
+
+  An 8-slot LRU that lives for the lifetime of one MCP server process
+  (= one MCP session per the `Single persistent nREPL socket`
+  principle — see `spec/Principles.md`). Each entry is keyed by a
+  `(tool, args-fingerprint)` pair and stores the hash of the most-
+  recently-emitted MCP result's text payload plus the timestamp it
+  was first seen.
+
+  On a fresh tool call:
+
+    1. Run the tool — compute the MCP result the usual way.
+    2. Hash the result's serialised `:text` slot.
+    3. Look up `(tool, args-fingerprint)` in the LRU.
+       - Miss → store `{:hash h :sent-at now :tool t}`. Return the
+         original result unchanged.
+       - Hit with matching hash → return a tiny
+         `{:rf.mcp/cache-hit {:hash h :unchanged-since <ms> :tool t}}`
+         marker instead of the full payload. The agent host's prior
+         `tools/call` for this tool already received the byte-identical
+         payload; re-shipping it doubles the conversation cost for no
+         new information.
+       - Hit with different hash → app-db (or the relevant runtime
+         state) has moved on; store the new hash + `:sent-at`, return
+         the fresh result.
+
+  ## Why hash the result text, not app-db directly
+
+  The bead (rf2-3rt1f) proposes `(hash app-db)`. The framing here is
+  one step downstream: by the time the result is built, it has already
+  been path-sliced, summarised, diff-encoded, deduped, scrubbed, etc.
+  Two calls with the same args against an unchanged app-db produce the
+  same serialised text — so hashing the text catches the same hit and
+  is robust against every transform in the wire pipeline. It also lets
+  one cache cover every tool uniformly (snapshot, get-path,
+  trace-window, etc.) instead of needing per-tool hash strategies.
+
+  The trade-off: we still pay the nREPL round-trip and the local
+  transform pipeline; the cache only saves the *wire bytes*. That's
+  the byte cost the bead identifies (\"the wire pays full app-db cost
+  twice\"). Saving the round-trip needs a server-side hash precheck
+  — out of scope here; filed as a follow-on bead.
+
+  ## LRU policy
+
+  Capacity 8. Eviction is least-recently-USED (touch on every hit and
+  every store). One entry per `(tool, args-fingerprint)` — a fresh
+  hash for the same key replaces the prior entry in place (the slot
+  is repurposed, not duplicated). Cache is cleared on
+  `reset!` (process restart resets implicitly).
+
+  ## Bounded by design
+
+  - **Cap**: 8 entries × ~128 bytes of metadata = ~1KB ceiling.
+    Stored payloads are NOT retained — only the hash. The marker we
+    emit on a hit is tiny (sub-100 bytes); the agent host already
+    has the full payload from the prior call.
+  - **Disabled by default**: pass `cache true` (or the per-call MCP
+    arg) to opt in. Default-off keeps the contract simple for
+    callers who haven't yet learned the `:rf.mcp/cache-hit` shape.
+    See `parse-cache-arg`.
+  - **Per-tool opt-out**: streaming / progress-bearing tools
+    (`subscribe`, `dispatch` with `:trace`) bypass the cache. Their
+    return value is the result of an action, not a read.
+
+  ## Marker shape
+
+  ```clojure
+  {:rf.mcp/cache-hit
+   {:hash             <integer>
+    :unchanged-since  <ms-since-epoch>
+    :tool             \"<tool-name>\"
+    :hint             \"<agent-host instruction string>\"}}
+  ```
+
+  The `:rf.mcp/*` namespace matches the wire-vocabulary convention
+  used by `:rf.mcp/overflow` (rf2-rvyzy), `:rf.mcp/dedup-table`
+  (rf2-obpa9), `:rf.mcp/summary` (rf2-tygdv), `:rf.size/large-elided`
+  (rf2-urjnc). Agents that learned the family see one more slot."
+  (:require [applied-science.js-interop :as j]
+            [clojure.string :as str]))
+
+;; ---------------------------------------------------------------------------
+;; LRU state — module-level atom; one MCP server process = one session.
+;; ---------------------------------------------------------------------------
+
+(def ^:private capacity 8)
+
+(def ^:private state
+  "{:entries {<key> {:hash <int> :sent-at <ms> :tool <str>}}
+    :order   <vector of keys, oldest first>}
+
+  A small vector preserves insertion order; on hit we re-insert at the
+  tail (touch) and on overflow we drop from the head."
+  (atom {:entries {} :order []}))
+
+(defn clear!
+  "Empty the cache. Exposed for tests and for the process-restart path.
+  Named `clear!` rather than `reset!` to avoid shadowing
+  `cljs.core/reset!` (which the namespace uses internally)."
+  []
+  (reset! state {:entries {} :order []}))
+
+;; ---------------------------------------------------------------------------
+;; Key + hash helpers.
+;; ---------------------------------------------------------------------------
+
+(defn args->fingerprint
+  "Stabilise a JS args object into a value suitable for use as part of
+  a cache key. The JS object's own keys are sorted lexicographically
+  so that the same logical args always produce the same fingerprint
+  irrespective of JSON-object key order. `nil` / `undefined` arrays
+  collapse to a canonical `nil` so two callers that pass nothing
+  share an entry."
+  [args]
+  (cond
+    (or (nil? args) (undefined? args)) nil
+    (object? args)
+    (let [ks (sort (js->clj (js/Object.keys args)))]
+      (reduce
+        (fn [acc k]
+          (let [v (j/get args k)]
+            (assoc acc k (cond
+                           (or (nil? v) (undefined? v)) nil
+                           (array? v)                   (vec (js->clj v))
+                           (object? v)                  (js->clj v)
+                           :else                        v))))
+        {}
+        ks))
+    :else (js->clj args)))
+
+(defn cache-key
+  "Build the cache key tuple for a tool invocation."
+  [tool args]
+  [tool (args->fingerprint args)])
+
+(defn hash-result
+  "Compute the cache hash for an MCP result. We sum every text slot's
+  Clojure-`hash` and the slot's character count — using both shields
+  against the rare hash collision (a different payload of the same
+  length AND the same `hash` would still slip past, but the byte-count
+  guard catches the common near-collision)."
+  [result-js]
+  (let [content (when result-js (j/get result-js :content))
+        n       (if (array? content) (.-length content) 0)
+        err?    (boolean (j/get result-js :isError))]
+    (loop [i 0 acc 0 chars 0]
+      (if (< i n)
+        (let [item (aget content i)
+              t    (when item (j/get item :text))]
+          (if (string? t)
+            (recur (inc i) (bit-xor acc (hash t)) (+ chars (count t)))
+            (recur (inc i) acc chars)))
+        ;; Encode isError into the high bits so an error-vs-success
+        ;; flip on the same text payload doesn't read as a hit.
+        (bit-xor acc chars (if err? 0xA5A5A5A5 0))))))
+
+;; ---------------------------------------------------------------------------
+;; LRU operations.
+;; ---------------------------------------------------------------------------
+
+(defn- touch
+  "Move `k` to the tail of the `:order` vector (most-recently-used)."
+  [order k]
+  (conj (filterv #(not= % k) order) k))
+
+(defn- enforce-capacity
+  "Drop oldest entries until under `capacity`."
+  [{:keys [entries order] :as st}]
+  (if (<= (count order) capacity)
+    st
+    (let [drop-n  (- (count order) capacity)
+          dropped (take drop-n order)
+          order'  (vec (drop drop-n order))
+          ents'   (apply dissoc entries dropped)]
+      {:entries ents' :order order'})))
+
+(defn lookup
+  "Return the entry for `k`, or `nil`. Does NOT touch ordering — the
+  caller decides hit vs. store semantics."
+  [k]
+  (get-in @state [:entries k]))
+
+(defn store!
+  "Record `entry` under key `k`. Touches the LRU and enforces capacity."
+  [k entry]
+  (swap! state
+         (fn [{:keys [entries order]}]
+           (enforce-capacity
+             {:entries (assoc entries k entry)
+              :order   (touch order k)}))))
+
+(defn record-hit!
+  "Touch `k` on a cache hit so the entry moves to the tail. Returns the
+  existing entry."
+  [k]
+  (swap! state update :order touch k)
+  (get-in @state [:entries k]))
+
+(defn size
+  "Current number of cached entries — exposed for tests and for the
+  health surface."
+  []
+  (count (:order @state)))
+
+;; ---------------------------------------------------------------------------
+;; Marker construction.
+;; ---------------------------------------------------------------------------
+
+(def ^:private cache-hit-hint
+  "The agent-host instruction. Pattern-matches against
+  `:rf.mcp/cache-hit` and reuses the prior `tools/call` payload for
+  this tool+args. State has not moved since the timestamp."
+  (str "Payload byte-identical to the prior tools/call for this "
+       "(tool,args). Re-use the agent's previous response; "
+       "no fresh state to inspect since :unchanged-since."))
+
+(defn cache-hit-payload
+  "Build the structured wire marker that replaces a cached response."
+  [{:keys [tool hash sent-at]}]
+  {:rf.mcp/cache-hit {:hash            hash
+                      :unchanged-since sent-at
+                      :tool            tool
+                      :hint            cache-hit-hint}})
+
+(defn cache-hit-result
+  "Wrap `cache-hit-payload` in the MCP `{:content [{:type \"text\" ...}]}`
+  envelope."
+  [entry tool]
+  #js {:content #js [#js {:type "text"
+                          :text (pr-str (cache-hit-payload
+                                          (assoc entry :tool tool)))}]})
+
+;; ---------------------------------------------------------------------------
+;; Arg parsing — opt-in switch.
+;; ---------------------------------------------------------------------------
+
+(defn parse-cache-arg
+  "Resolve the per-call cache switch. Accepts boolean or stringified
+  boolean; default is FALSE (cache opt-in until agent hosts have been
+  taught the marker shape — same pattern as `dedup` before its
+  default flipped)."
+  [raw]
+  (cond
+    (nil? raw)         false
+    (true? raw)        true
+    (false? raw)       false
+    (= raw "true")     true
+    (= raw "false")    false
+    (= raw :true)      true
+    (= raw :false)     false
+    (and (string? raw) (= (str/lower-case raw) "true"))  true
+    (and (string? raw) (= (str/lower-case raw) "false")) false
+    :else              false))
+
+;; ---------------------------------------------------------------------------
+;; The wire-boundary entry-point.
+;; ---------------------------------------------------------------------------
+
+(def ^:private cacheable-tools
+  "Tools whose return value is a read of state — re-asking with the
+  same args against unchanged state legitimately returns the same
+  bytes. Action tools (`dispatch`, `eval-cljs`, `tail-build`) and
+  streaming tools (`subscribe`, `unsubscribe`) are excluded — their
+  return value is the result of an action, not a read."
+  #{"snapshot" "get-path" "trace-window" "watch-epochs" "discover-app"})
+
+(defn cacheable?
+  "Predicate — should this tool ever consult the cache?"
+  [tool]
+  (contains? cacheable-tools tool))
+
+(defn apply-cache
+  "Wire-boundary cache check. Returns either:
+
+    - `result-js` unchanged (cache disabled, tool not cacheable,
+      isError result, or fresh store) — and as a side effect records
+      the hash for future hits.
+    - A fresh result carrying `{:rf.mcp/cache-hit ...}` — when the
+      hash matches the prior entry for `(tool, args)`.
+
+  Errors are never cached: an `:isError` result is passed through
+  untouched and does NOT poison the cache. That keeps a transient
+  failure from masking a future successful read."
+  [result-js {:keys [tool args enabled?]}]
+  (cond
+    (not enabled?)               result-js
+    (nil? result-js)             result-js
+    (not (cacheable? tool))      result-js
+    (boolean (j/get result-js :isError)) result-js
+    :else
+    (let [k          (cache-key tool args)
+          h          (hash-result result-js)
+          prior      (lookup k)
+          now        (.getTime (js/Date.))]
+      (if (and prior (= (:hash prior) h))
+        (do (record-hit! k)
+            (cache-hit-result prior tool))
+        (do (store! k {:hash h :sent-at now :tool tool})
+            result-js)))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -59,6 +59,7 @@
             [cljs.reader]
             [clojure.string :as str]
             [de-dupe.core :as dedup]
+            [re-frame-pair2-mcp.cache :as cache]
             [re-frame-pair2-mcp.nrepl :as nrepl]))
 
 ;; ---------------------------------------------------------------------------
@@ -2184,6 +2185,28 @@
                      "permission for the slot (e.g. debugging the "
                      "elided value itself).")})
 
+(def ^:private cache-property
+  "Per-tool descriptor slot for the `:cache` opt-in (rf2-3rt1f).
+  Applied to read-tool descriptors via `with-cache-knob`. Default
+  `false` — opt-in until the agent host has been taught the
+  `:rf.mcp/cache-hit` marker shape."
+  {:type        "boolean"
+   :description (str "Consult the per-session response cache. Default "
+                     "false. When true and the result's hash matches "
+                     "the prior call for this (tool, args), the full "
+                     "payload is replaced with a "
+                     "`{:rf.mcp/cache-hit {:hash <h> "
+                     ":unchanged-since <ms> :tool <t> :hint <s>}}` "
+                     "marker — the agent host already has the byte-"
+                     "identical payload from the prior call. Cache is "
+                     "an 8-slot LRU keyed by (tool, args-fingerprint); "
+                     "lifetime is the MCP server process (= one "
+                     "session per persistent-socket principle). Read "
+                     "tools only (snapshot, get-path, trace-window, "
+                     "watch-epochs, discover-app); action tools "
+                     "(dispatch, eval-cljs, tail-build) and streaming "
+                     "tools (subscribe) bypass.")})
+
 (defn- with-budget-knob
   "Splice `max-tokens` into a tool descriptor's inputSchema.properties.
   No-op if the descriptor already declares it (forward-compat)."
@@ -2193,6 +2216,20 @@
       desc
       (assoc-in desc [:inputSchema :properties :max-tokens]
                 max-tokens-property))))
+
+(defn- with-cache-knob
+  "Splice `cache` into a tool descriptor's inputSchema.properties — but
+  only for the read tools that consult `cache/apply-cache`. Action
+  tools and streaming tools don't list the knob because it has no
+  effect there (bypassed in `cache/cacheable?`)."
+  [desc]
+  (let [name  (:name desc)
+        props (get-in desc [:inputSchema :properties])]
+    (if (or (contains? props :cache)
+            (not (cache/cacheable? name)))
+      desc
+      (assoc-in desc [:inputSchema :properties :cache]
+                cache-property))))
 
 (def tool-descriptors
   [{:name "discover-app"
@@ -2440,7 +2477,7 @@
                   :additionalProperties false}}])
 
 (defn tool-descriptors-js []
-  (clj->js (mapv with-budget-knob tool-descriptors)))
+  (clj->js (mapv (comp with-cache-knob with-budget-knob) tool-descriptors)))
 
 (defn- dispatch-tool*
   "Route a `tools/call` to the per-tool implementation. Unknown tools
@@ -2465,19 +2502,42 @@
   "Dispatch a `tools/call` invocation to the right tool implementation.
   Returns a Promise resolving to the MCP result object.
 
-  Every result passes through `apply-cap` at the wire boundary —
-  responses whose serialised size exceeds the per-call cap (default
-  5,000 tokens, configurable via the `max-tokens` MCP arg) are
-  replaced with an `{:rf.mcp/overflow ...}` marker. The cap is
-  enforced here, not just documented; see the `apply-cap` docstring
-  for the pluggable-strategy design.
+  ## Wire-boundary pipeline
+
+  Each result passes through two egress transforms in order:
+
+  1. `cache/apply-cache` (rf2-3rt1f) — per-session response cache
+     keyed on a hash of the result's text payload. On a hit (same
+     hash for `(tool, args)` as the prior call) the full payload is
+     replaced with a tiny `{:rf.mcp/cache-hit ...}` marker; the
+     agent host already has the byte-identical bytes from the prior
+     `tools/call`. Opt-in via the per-call `cache` arg (default
+     `false`); read-only tools only; `:isError` results bypass
+     entirely. See `cache/apply-cache` for the LRU policy.
+
+  2. `apply-cap` (rf2-rvyzy) — responses whose serialised size
+     exceeds the per-call cap (default 5,000 tokens, configurable
+     via the `max-tokens` MCP arg) are replaced with an
+     `{:rf.mcp/overflow ...}` marker. Silent truncation is not
+     allowed; see the `apply-cap` docstring for the pluggable-
+     strategy design.
+
+  Cache before cap is the right order: a cache hit emits a sub-100-
+  byte marker that's trivially under any reasonable cap, so flipping
+  the order would never change behaviour but would waste the
+  `sum-text-tokens` walk on the hit path.
 
   `extra` carries the MCP `extra` payload (signal + sendNotification +
   _meta.progressToken) for streaming tools. Non-streaming tools
   ignore it."
   [conn name args extra]
-  (let [cap-opts {:tool     name
-                  :cap      (max-tokens-arg args)
-                  :strategy :truncate-with-marker}]
+  (let [cap-opts   {:tool     name
+                    :cap      (max-tokens-arg args)
+                    :strategy :truncate-with-marker}
+        cache-opts {:tool     name
+                    :args     args
+                    :enabled? (cache/parse-cache-arg
+                                (when args (j/get args "cache")))}]
     (-> (dispatch-tool* conn name args extra)
+        (.then (fn [result] (cache/apply-cache result cache-opts)))
         (.then (fn [result] (apply-cap result cap-opts))))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/cache_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/cache_test.cljs
@@ -1,0 +1,350 @@
+(ns re-frame-pair2-mcp.cache-test
+  "Unit tests for the per-session response cache (rf2-3rt1f).
+
+  Per `tools/pair2-mcp/spec/Principles.md` §\"Per-session response
+  cache\", every read-tool result passes through an 8-slot LRU keyed
+  on `(tool, args-fingerprint)`. On a hit (same hash for the same
+  (tool, args) as the prior call), the full payload is replaced with
+  a `{:rf.mcp/cache-hit ...}` marker. On a miss or fresh hash, the
+  result is stored and returned unchanged.
+
+  These tests pin the contract directly against the real
+  `re-frame-pair2-mcp.cache` namespace (not a mirror — the module
+  is fresh and has no JS interop that would force a copy)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [cljs.reader :as edn]
+            [applied-science.js-interop :as j]
+            [re-frame-pair2-mcp.cache :as cache]))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures — cache is module-level state; reset between tests so each
+;; case starts from a clean slate.
+;; ---------------------------------------------------------------------------
+
+(use-fixtures :each
+  {:before (fn [] (cache/clear!))
+   :after  (fn [] (cache/clear!))})
+
+;; ---------------------------------------------------------------------------
+;; Test helpers — build MCP-shaped JS results with predictable text.
+;; ---------------------------------------------------------------------------
+
+(defn- mcp-result
+  "Build an MCP `{:content [{:type \"text\" :text ...}]}` shape with
+  the given text. Mirrors the output of `ok-text` in `tools.cljs`."
+  [text & {:keys [error?]}]
+  (cond-> #js {:content #js [#js {:type "text" :text text}]}
+    error? (j/assoc! :isError true)))
+
+(defn- args-js
+  "Construct a JS args object from a CLJS map (helps the
+  `j/get`-by-name paths in `args->fingerprint`)."
+  [m]
+  (let [o #js {}]
+    (doseq [[k v] m]
+      (j/assoc! o (name k) v))
+    o))
+
+(defn- extract-text
+  "Pull the first text slot off an MCP result."
+  [result]
+  (let [content (j/get result :content)
+        item    (when (array? content) (aget content 0))]
+    (when item (j/get item :text))))
+
+(defn- cache-hit-result?
+  "True iff `result` is a `:rf.mcp/cache-hit` marker."
+  [result]
+  (let [t (extract-text result)
+        v (when t (try (edn/read-string t) (catch :default _ nil)))]
+    (and (map? v) (contains? v :rf.mcp/cache-hit))))
+
+;; ---------------------------------------------------------------------------
+;; parse-cache-arg — MCP-arg normalisation.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-cache-arg-default-is-false
+  ;; Opt-in by default — least surprise for agent hosts that haven't
+  ;; been taught the marker shape.
+  (is (false? (cache/parse-cache-arg nil))))
+
+(deftest parse-cache-arg-booleans-pass-through
+  (is (true? (cache/parse-cache-arg true)))
+  (is (false? (cache/parse-cache-arg false))))
+
+(deftest parse-cache-arg-string-forms-accepted
+  ;; MCP wire ships JSON; clients sending `"true"` should get the
+  ;; opt-in.
+  (is (true? (cache/parse-cache-arg "true")))
+  (is (false? (cache/parse-cache-arg "false")))
+  (is (true? (cache/parse-cache-arg "TRUE")))
+  (is (false? (cache/parse-cache-arg "False"))))
+
+(deftest parse-cache-arg-keyword-forms-accepted
+  (is (true? (cache/parse-cache-arg :true)))
+  (is (false? (cache/parse-cache-arg :false))))
+
+(deftest parse-cache-arg-unknown-defaults-to-false
+  ;; Conservative default for unrecognised values — opt-in semantics
+  ;; should never sneak on accidentally.
+  (is (false? (cache/parse-cache-arg "garbage")))
+  (is (false? (cache/parse-cache-arg 42)))
+  (is (false? (cache/parse-cache-arg :other))))
+
+;; ---------------------------------------------------------------------------
+;; cacheable? — tool-allowlist guard.
+;; ---------------------------------------------------------------------------
+
+(deftest cacheable-read-tools
+  ;; The five read tools listed in `cacheable-tools` should all hit.
+  (is (cache/cacheable? "snapshot"))
+  (is (cache/cacheable? "get-path"))
+  (is (cache/cacheable? "trace-window"))
+  (is (cache/cacheable? "watch-epochs"))
+  (is (cache/cacheable? "discover-app")))
+
+(deftest cacheable-excludes-action-and-streaming-tools
+  ;; Action tools' return values are the result of an action; their
+  ;; hashes will differ even on \"identical\" state.
+  (is (not (cache/cacheable? "dispatch")))
+  (is (not (cache/cacheable? "eval-cljs")))
+  (is (not (cache/cacheable? "tail-build")))
+  (is (not (cache/cacheable? "subscribe")))
+  (is (not (cache/cacheable? "unsubscribe")))
+  (is (not (cache/cacheable? "unknown-tool"))))
+
+;; ---------------------------------------------------------------------------
+;; args->fingerprint — stable across JS-object key order.
+;; ---------------------------------------------------------------------------
+
+(deftest args-fingerprint-stable-across-key-order
+  ;; Same logical args, different insertion order → same fingerprint.
+  (let [a (args-js {:frame ":rf/default" :path "[:cart :items]"})
+        b (let [o #js {}]
+            (j/assoc! o "path" "[:cart :items]")
+            (j/assoc! o "frame" ":rf/default")
+            o)]
+    (is (= (cache/args->fingerprint a)
+           (cache/args->fingerprint b))
+        "args fingerprint is order-insensitive")))
+
+(deftest args-fingerprint-empty-cases
+  (is (nil? (cache/args->fingerprint nil)))
+  (is (nil? (cache/args->fingerprint js/undefined)))
+  (is (= {} (cache/args->fingerprint #js {}))))
+
+(deftest args-fingerprint-distinguishes-different-args
+  (let [a (args-js {:frame ":rf/default"})
+        b (args-js {:frame ":stories"})]
+    (is (not= (cache/args->fingerprint a)
+              (cache/args->fingerprint b)))))
+
+;; ---------------------------------------------------------------------------
+;; hash-result — sensitive to text + error flag.
+;; ---------------------------------------------------------------------------
+
+(deftest hash-result-stable-for-same-text
+  (let [r1 (mcp-result "{:ok? true :app-db {:k :v}}")
+        r2 (mcp-result "{:ok? true :app-db {:k :v}}")]
+    (is (= (cache/hash-result r1) (cache/hash-result r2)))))
+
+(deftest hash-result-differs-for-different-text
+  (let [r1 (mcp-result "{:ok? true :app-db {:k :v}}")
+        r2 (mcp-result "{:ok? true :app-db {:k :other}}")]
+    (is (not= (cache/hash-result r1) (cache/hash-result r2)))))
+
+(deftest hash-result-distinguishes-error-vs-success
+  ;; Same text payload but :isError true vs. false should hash
+  ;; distinctly — otherwise a transient error could mask the success.
+  (let [text "{:ok? false :reason :foo}"
+        ok   (mcp-result text)
+        err  (mcp-result text :error? true)]
+    (is (not= (cache/hash-result ok) (cache/hash-result err)))))
+
+;; ---------------------------------------------------------------------------
+;; The load-bearing scenarios from the bead.
+;; ---------------------------------------------------------------------------
+
+(deftest fresh-call-stores-and-returns-unchanged
+  ;; First call: cache is cold → return the original result, record
+  ;; the hash, leave a single entry behind.
+  (let [args   (args-js {:frame ":rf/default"})
+        result (mcp-result "{:ok? true :snapshot {:db {:k :v}}}")
+        out    (cache/apply-cache result {:tool "snapshot"
+                                          :args args
+                                          :enabled? true})]
+    (is (identical? result out)
+        "fresh call returns the original result untouched")
+    (is (not (cache-hit-result? out))
+        "fresh call does not emit a cache-hit marker")
+    (is (= 1 (cache/size))
+        "fresh call stored an entry in the LRU")))
+
+(deftest same-state-call-returns-cache-hit
+  ;; Second call with byte-identical state: the hash matches, the
+  ;; LRU emits the marker instead of the full payload.
+  (let [args (args-js {:frame ":rf/default"})
+        text "{:ok? true :snapshot {:db {:k :v}}}"
+        r1   (mcp-result text)
+        r2   (mcp-result text)
+        opts {:tool "snapshot" :args args :enabled? true}]
+    ;; Prime the cache.
+    (cache/apply-cache r1 opts)
+    ;; Second call hits.
+    (let [out (cache/apply-cache r2 opts)]
+      (is (cache-hit-result? out)
+          "second call returns a :rf.mcp/cache-hit marker")
+      (let [v (edn/read-string (extract-text out))]
+        (testing "marker carries the expected slots"
+          (is (= "snapshot"
+                 (get-in v [:rf.mcp/cache-hit :tool])))
+          (is (number?
+                (get-in v [:rf.mcp/cache-hit :unchanged-since])))
+          (is (integer?
+                (get-in v [:rf.mcp/cache-hit :hash])))
+          (is (string?
+                (get-in v [:rf.mcp/cache-hit :hint]))))))
+    (is (= 1 (cache/size))
+        "no new entry — same key still occupies one slot")))
+
+(deftest mutation-invalidates-cache
+  ;; Third scenario: state moves on between calls. Second call's hash
+  ;; differs → the LRU stores the new hash and returns the fresh
+  ;; payload, NOT a hit marker. The agent host gets the new bytes.
+  (let [args (args-js {:frame ":rf/default"})
+        r1   (mcp-result "{:ok? true :snapshot {:db {:k :v}}}")
+        r2   (mcp-result "{:ok? true :snapshot {:db {:k :other}}}")
+        opts {:tool "snapshot" :args args :enabled? true}]
+    ;; Prime.
+    (cache/apply-cache r1 opts)
+    ;; Mutation → different text → different hash → miss.
+    (let [out (cache/apply-cache r2 opts)]
+      (is (identical? r2 out)
+          "mutation returns the fresh result untouched")
+      (is (not (cache-hit-result? out))
+          "mutation does not emit a cache-hit marker"))
+    (is (= 1 (cache/size))
+        "key was overwritten in place, not duplicated")))
+
+;; ---------------------------------------------------------------------------
+;; Opt-out / bypass semantics.
+;; ---------------------------------------------------------------------------
+
+(deftest disabled-cache-is-pure-pass-through
+  ;; enabled? false → nothing stored, nothing read.
+  (let [args (args-js {:frame ":rf/default"})
+        r    (mcp-result "{:ok? true}")
+        opts {:tool "snapshot" :args args :enabled? false}]
+    (let [out (cache/apply-cache r opts)]
+      (is (identical? r out)))
+    (is (zero? (cache/size))
+        "disabled cache stores nothing")))
+
+(deftest non-cacheable-tool-bypasses
+  ;; Action tools (`dispatch`, `eval-cljs`, `tail-build`) bypass even
+  ;; when `enabled? true`.
+  (let [args (args-js {:event "[:cart/checkout]"})
+        r    (mcp-result "{:ok? true :dispatched? true}")
+        opts {:tool "dispatch" :args args :enabled? true}]
+    (let [out (cache/apply-cache r opts)]
+      (is (identical? r out)))
+    (is (zero? (cache/size))
+        "action tools never poison the cache")))
+
+(deftest error-results-bypass-cache
+  ;; An :isError result should not be cached — a transient error
+  ;; would otherwise mask future successful reads on the same key.
+  (let [args (args-js {:frame ":rf/default"})
+        err  (mcp-result "{:ok? false :reason :foo}" :error? true)
+        opts {:tool "snapshot" :args args :enabled? true}]
+    (let [out (cache/apply-cache err opts)]
+      (is (identical? err out)
+          "error result passes through untouched"))
+    (is (zero? (cache/size))
+        "error did not poison the cache")
+    ;; Subsequent successful call still treated as fresh.
+    (let [ok (mcp-result "{:ok? true}")]
+      (let [out (cache/apply-cache ok opts)]
+        (is (identical? ok out)
+            "successful follow-up is a fresh miss")))))
+
+(deftest different-tools-same-args-do-not-collide
+  ;; (snapshot, args) and (get-path, args) are different keys.
+  (let [args (args-js {:frame ":rf/default"})
+        text "{:ok? true}"
+        r1   (mcp-result text)
+        r2   (mcp-result text)]
+    (cache/apply-cache r1 {:tool "snapshot" :args args :enabled? true})
+    (let [out (cache/apply-cache r2 {:tool "get-path" :args args :enabled? true})]
+      (is (identical? r2 out)
+          "get-path miss — separate key from snapshot"))
+    (is (= 2 (cache/size))
+        "both tools have their own slot")))
+
+;; ---------------------------------------------------------------------------
+;; LRU policy — capacity + eviction.
+;; ---------------------------------------------------------------------------
+
+(deftest lru-bounded-at-capacity
+  ;; Capacity is 8. 12 distinct (tool, args) pairs → 8 entries
+  ;; survive, the 4 oldest get evicted.
+  (let [opts (fn [i] {:tool "snapshot"
+                      :args (args-js {:frame (str ":f" i)})
+                      :enabled? true})]
+    (dotimes [i 12]
+      (cache/apply-cache (mcp-result (str "{:i " i "}")) (opts i)))
+    (is (= 8 (cache/size))
+        "LRU never exceeds capacity")))
+
+(deftest lru-evicts-oldest-first
+  ;; Fill to capacity, then add one more — the first key is gone.
+  (let [opts (fn [i] {:tool "snapshot"
+                      :args (args-js {:frame (str ":f" i)})
+                      :enabled? true})]
+    (dotimes [i 8]
+      (cache/apply-cache (mcp-result (str "{:i " i "}")) (opts i)))
+    (is (= 8 (cache/size)))
+    ;; A re-call against the OLDEST key should still be a hit (it's
+    ;; been in the cache since we primed it).
+    (let [out (cache/apply-cache (mcp-result "{:i 0}") (opts 0))]
+      (is (cache-hit-result? out)
+          "before eviction, oldest entry still hits"))
+    ;; Add a NEW key — capacity stays at 8, but the oldest
+    ;; un-touched entry rotates out. After the touch above, entry 0
+    ;; is now most-recently-used; entry 1 is the new oldest.
+    (cache/apply-cache (mcp-result "{:i 99}") (opts 99))
+    (is (= 8 (cache/size)))
+    ;; Entry 1 should be evicted now → cold miss on re-call.
+    (let [out (cache/apply-cache (mcp-result "{:i 1}") (opts 1))]
+      (is (not (cache-hit-result? out))
+          "least-recently-used key was evicted; re-call is a miss"))))
+
+;; ---------------------------------------------------------------------------
+;; Marker shape — cross-MCP vocabulary.
+;; ---------------------------------------------------------------------------
+
+(deftest cache-hit-marker-uses-rf-mcp-namespace
+  ;; The `:rf.mcp/cache-hit` key follows the same namespace convention
+  ;; as `:rf.mcp/overflow`, `:rf.mcp/dedup-table`, etc. Agents
+  ;; recognise the family.
+  (let [args (args-js {})
+        text "{:ok? true}"
+        opts {:tool "snapshot" :args args :enabled? true}]
+    (cache/apply-cache (mcp-result text) opts)
+    (let [hit (cache/apply-cache (mcp-result text) opts)
+          v   (edn/read-string (extract-text hit))]
+      (is (contains? v :rf.mcp/cache-hit)
+          "marker key is :rf.mcp/cache-hit"))))
+
+(deftest cache-hit-marker-payload-is-small
+  ;; The whole point — the marker should be sub-100 bytes so it can't
+  ;; itself blow the wire-cap.
+  (let [args (args-js {:frame ":rf/default"})
+        big  (mcp-result (apply str (repeat 50000 \X)))
+        opts {:tool "snapshot" :args args :enabled? true}]
+    (cache/apply-cache big opts)
+    (let [hit  (cache/apply-cache big opts)
+          text (extract-text hit)]
+      (is (cache-hit-result? hit))
+      (is (< (count text) 500)
+          "cache-hit marker fits well under a 5K-token cap"))))


### PR DESCRIPTION
## Summary

- Adds an 8-slot per-session LRU keyed on `(tool, args-fingerprint)` for pair2-mcp read tools. On a hit (result hash matches the prior call for the same args), the full payload is replaced with a sub-100-byte `{:rf.mcp/cache-hit {:hash h :unchanged-since ms :tool t :hint s}}` marker — the agent host already has the byte-identical bytes from the prior `tools/call`.
- Universal `cache` arg (boolean, default `false` — opt-in until hosts learn the marker shape) on every read-tool descriptor: `snapshot`, `get-path`, `trace-window`, `watch-epochs`, `discover-app`. Action tools (`dispatch`, `eval-cljs`, `tail-build`) and streaming tools (`subscribe`, `unsubscribe`) bypass; `:isError` results bypass too.
- Wired into `tools/invoke` BEFORE `apply-cap` (a hit emits a tiny marker, so cap-after-cache is a no-op on the hit path).
- Spec notes: new section in `tools/pair2-mcp/spec/003-Tool-Catalogue.md` (Universal: per-session response cache) and `tools/pair2-mcp/spec/Principles.md` (Per-session response cache (rf2-3rt1f)).

## Design notes

- Hash the result text (after path-slicing / summary / diff-encode / dedup / scrub / elision have run) rather than `(hash app-db)`. Robust against every transform in the wire pipeline; one mechanism covers every read tool uniformly.
- This saves wire bytes, not the nREPL round-trip. Saving the round-trip too requires a server-side hash precheck — filed as follow-on bead **rf2-36xod**.
- Capacity 8 chosen for the typical inspect / dispatch / inspect working set; LRU on key touches.

## Test plan

- [x] `npm test` — 243 tests / 566 assertions green; the new `cache_test.cljs` contributes 25 assertions across fresh-call / same-state-hit / mutation-invalidation / LRU eviction / disabled-bypass / non-cacheable-bypass / error-bypass / marker-shape / hint-text / hash-stability / order-invariant fingerprint.
- [x] `shadow-cljs compile server` — production server build is clean (0 warnings).
- [ ] Live end-to-end smoke against a running shadow-cljs build (manual; the next pair2 session will exercise it via the new `cache` arg).

Closes rf2-3rt1f.