### PR TITLE
spec(causa): mount.cljs lazy-mount lifecycle normative shape (rf2-9kkrm)

### DIFF
--- a/tools/causa/spec/011-Launch-Modes.md
+++ b/tools/causa/spec/011-Launch-Modes.md
@@ -109,6 +109,117 @@ class swap). Respects `prefers-reduced-motion` (instant fade).
 App content underneath dims 12% via a CSS overlay; app interactions
 still pass through (pointer-events on the dim overlay are disabled).
 
+### Mount lifecycle (rf2-9kkrm)
+
+The in-app overlay's <80ms first-paint target is paid for by a
+**lazy mount** — the substrate render tree is not constructed at
+preload time, only on the user's first toggle keypress. The
+lifecycle is normative.
+
+**Two-phase boot.** Loading the preload namespace runs the
+**foundation** side-effects only:
+
+1. Register Causa's `:rf.causa/*` handlers (subs / events / fxs)
+   against the `:rf/causa` frame.
+2. Register the trace collector via
+   [`re-frame.trace/register-trace-cb!`](../../../spec/009-Instrumentation.md)
+   under `:rf.causa/trace-collector`.
+3. Register the epoch collector via `rf/register-epoch-cb!` under
+   `:rf.causa/epoch-collector` (no-op when the
+   `day8/re-frame2-epoch` artefact is absent).
+4. Attach a global `Ctrl+Shift+C` keydown listener on
+   `document`.
+
+The preload MUST NOT mount the shell, construct the substrate
+render tree, or create any DOM under `document.body`. The shell
+mounts on the **first** `Ctrl+Shift+C` press (or first click on
+the launcher pill) — never before. This is the lazy-mount
+contract: the React-tree construction cost is paid on first open,
+not at app-boot.
+
+**Boot order.** Within the preload's foundation phase the side-
+effects MUST run in the order **register-handlers → register-
+trace-cb → register-epoch-cb → attach-keybinding**. The keybinding
+listener is attached last so that, in the unlikely race where the
+user presses `Ctrl+Shift+C` mid-load, the handlers required by the
+shell render are already in the registry when the mount fires.
+
+Within the lazy-mount phase (first toggle press) the order MUST be
+**create-mount-node → substrate-render → mark-visible**. The
+substrate adapter's `:render` slot is the canonical mount path
+(per [`spec/006-ReactiveSubstrate.md`](../../../spec/006-ReactiveSubstrate.md)
+§Render contract) — Causa MUST NOT bypass the adapter and call
+React directly. The render call returns an unmount fn which the
+mount machinery MUST retain for `teardown!`.
+
+**Subsequent toggles.** Once mounted, the shell's container stays
+in the DOM for the rest of the page's lifetime. Close MUST be a
+CSS-only `display: none` on the mount-node — never an unmount.
+Re-open MUST be a CSS-only `display: block`. This is what
+preserves the <80ms first-paint on every toggle after the first
+(per §Animation above): subsequent paints reuse the existing
+React tree, the existing subscriptions, the existing local UI
+state. A re-mount would discard internal panel state (current tab,
+scroll position, selected epoch, AI-rail conversation) and miss
+the toggle-paint target.
+
+**Idempotency under hot-reload.** Every piece of mount-adjacent
+state — the registration sentinels, the keybinding sentinel, the
+mount-state singleton — MUST be `defonce`-guarded so that
+shadow-cljs `:after-load` reruns the preload's side-effects
+without double-attaching the listener, replacing the trace
+callback (which would emit a console warning per
+[`spec/009-Instrumentation.md`](../../../spec/009-Instrumentation.md)
+§Trace callbacks), or re-creating the mount node. The mount-state
+itself MUST survive reload — the user's currently-open Causa
+panel MUST remain open across an `:after-load`, with its internal
+state intact. This is the hot-reload story for rf2-iw5ym's
+reactive-container parity: trace-buffer and mount-state share the
+same "outlast the namespace reload" posture.
+
+**Before-mount probe.** Host code (re-frame app code, tests,
+adjacent tools) MUST be able to ask "is Causa currently mounted /
+currently visible?" **without** forcing a mount. The mount API
+exposes two read-only predicates for this purpose:
+
+- `mounted?` — `true` iff the shell has been mounted at least once
+  in the current page lifetime. May be `true` while `visible?` is
+  `false` (the user opened then closed Causa).
+- `visible?` — `true` iff the shell exists *and* its container is
+  currently displayed (`display != none`).
+
+Calling either predicate MUST be side-effect-free: no DOM mutation,
+no substrate render, no allocation of mount-state. The probes are
+the contract surface for "is Causa loaded?" introspection — tools
+that decorate their output when Causa is open (e.g. story-mode
+re-dispatch chips) read `visible?` and degrade gracefully when
+Causa is closed or absent.
+
+**Unmount semantics.** Production sessions never tear the shell
+down — the shell lives for the page's lifetime once mounted, and
+`Ctrl+Shift+C` close is a CSS hide, not an unmount. The
+`teardown!` operation is **test-only**: it MUST invoke the
+substrate adapter's unmount fn (returned by `:render` at mount
+time), MUST remove the mount-node from `document.body`, and MUST
+reset the mount-state singleton to `nil` so the next test starts
+from a clean slate. The unmount fn MUST be invoked inside a
+swallow-errors guard — substrate adapters MAY throw on a
+double-unmount and `teardown!` is the test fixture's last-chance
+cleanup, not a contract-checking call site.
+
+**Production posture.** The whole foundation block MUST be gated
+on a single dev-only sentinel (the framework's
+`interop/debug-enabled?` flag, per
+[`spec/009-Instrumentation.md`](../../../spec/009-Instrumentation.md)
+§Production elision) so Closure DCE strips every side-effect from
+production bundles compiled with `(set! goog.DEBUG false)`. The
+mount module itself carries no elision logic — the call-site gate
+in the preload is sufficient. If the preload is mistakenly
+included in a production bundle, the trace registration is a no-op
+(the framework elides the trace surface) and the mount call fails
+silently because `current-adapter` is unset; the fallback is
+graceful, not catastrophic.
+
 ## Standalone via MCP
 
 ### Mechanism


### PR DESCRIPTION
## Summary

Promote the lazy-mount lifecycle in `tools/causa/src/day8/re_frame2_causa/mount.cljs` (+ its `preload.cljs` + `keybinding.cljs` satellites) to a normative subsection of `tools/causa/spec/011-Launch-Modes.md` §In-app overlay. The implementation pays the spec's <80ms first-paint target via a two-phase boot — foundation side-effects at preload time, substrate render on first `Ctrl+Shift+C` — but the contract has had no spec home. Pinned:

- **Two-phase boot.** Preload runs foundation only (register handlers, trace cb, epoch cb, keybinding); shell mounts on first toggle press. Preload MUST NOT mount the shell or touch the DOM.
- **Boot order.** Within foundation: register-handlers → trace-cb → epoch-cb → attach-keybinding (so the registry is populated before any race-mount could fire). Within mount: create-node → substrate-render → mark-visible via the adapter's `:render` slot — no direct React.
- **Subsequent toggles.** MUST be CSS `display` swaps, never re-mounts — preserves panel state and the <80ms repeat-paint.
- **Idempotency under `:after-load`.** Every mount-adjacent sentinel `defonce`-guarded; mount-state survives hot-reload (cross-links rf2-iw5ym's reactive-container hot-reload posture).
- **Before-mount probe.** `mounted?` + `visible?` MUST be side-effect-free so host code / adjacent tools can ask "is Causa loaded?" without forcing a mount.
- **Unmount.** Test-only via `teardown!`; production sessions never unmount. `teardown!` MUST invoke the adapter unmount fn, remove the node, reset the singleton.
- **Production posture.** Single `interop/debug-enabled?` gate at the preload call-site; mount.cljs carries no elision logic of its own.

16 MUSTs across the section. Closes the gap surfaced by rf2-j41ya Gap #8.

## Test plan

- [ ] `mkdocs build --strict` resolves the new cross-links to `../../../spec/006-ReactiveSubstrate.md` and `../../../spec/009-Instrumentation.md`.
- [ ] Section renders correctly in the Causa spec sidebar under `011-Launch-Modes.md`.