### PR TITLE
feat(story): reg-tag :axis + :default-filter slots (rf2-frtec)

### DIFF
--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -173,16 +173,60 @@ The five-rule embed contract is defined in
 (reg-tag id metadata)
 ```
 
-Body:
+Body (all slots optional):
 
 ```clojure
-{:doc "..."}
+{:doc            "..."
+ :axis           :status                       ; optional — facet grouping hint
+ :default-filter :exclude}                      ; optional — :include (default) | :exclude
 ```
 
 The seven canonical tags (`:dev`, `:docs`, `:test`, `:screenshot`,
 `:experimental`, `:internal`, `:agent`) register at Story load.
 Project tags must be registered before use. An unregistered tag on a
 variant's `:tags` set raises `:rf.error/unknown-tag` at registration.
+
+#### `:axis` — facet grouping (SB9 parity)
+
+The optional `:axis` slot is a keyword classifier (e.g. `:status`,
+`:role`, `:team`, `:feature`) that groups registered tags into
+collapsible facet rows in the sidebar tag-filter UI. Tags registered
+without `:axis` render in a trailing un-grouped row. Mirrors
+Storybook 9's status / role / team / feature axes (rf2-v05qb SB9
+parity).
+
+Query the axis grouping via:
+
+- `(story/tags-by-axis :status)` — set of tag ids on a given axis.
+- `(story/tags-without-axis)` — set of tag ids with no axis.
+
+The `:axis` slot is purely a UI grouping hint — it does not affect
+variant `:tags` set semantics or `variants-with-tags` filtering.
+
+#### `:default-filter` — sidebar boot state (SB9 parity)
+
+The optional `:default-filter` slot is `:include` (default) or
+`:exclude`. When `:exclude`, the sidebar pre-excludes variants
+carrying this tag at boot. Use this to register tags like `:internal`
+or `:experimental` whose variants should be hidden from the default
+dev shell until manually toggled on.
+
+Query the default-excluded set via:
+
+- `(story/tags-default-excluded)` — set of tag ids with `:default-filter :exclude`.
+
+```clojure
+(rf/reg-tag :auth/regression-set
+  {:doc  "Auth regression-suite variants."
+   :axis :team})
+
+(rf/reg-tag :alpha
+  {:doc            "Pre-release status."
+   :axis           :status
+   :default-filter :exclude})
+```
+
+#### `!`-prefix removal syntax
 
 `!`-prefix removal syntax: `:!dev` removes `:dev` from the inherited
 tag set when included in a child variant's `:tags`. Per Phase 1 §2.1

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -259,10 +259,12 @@
    (defmacro reg-tag
      "Register a tag. Per spec/007 §Inclusion tags + IMPL-SPEC §3.1.
 
-     Body:
+     Body (all slots optional):
 
      ```
-     {:doc \"...\"}
+     {:doc            \"...\"
+      :axis           :status                 ; e.g. :status / :role / :team / :feature
+      :default-filter :exclude}               ; :include (default) | :exclude
      ```
 
      The seven canonical tags (`:dev :docs :test :screenshot :experimental
@@ -270,6 +272,18 @@
      register these. Project-specific tags must register before use; a
      variant whose `:tags` set carries an unregistered tag raises
      `:rf.error/unknown-tag`.
+
+     **`:axis`** — optional keyword classifier. The sidebar tag-filter UI
+     groups registered tags by `:axis` into collapsible facet rows
+     (rf2-v05qb SB9 parity). Tags registered without `:axis` render in a
+     trailing un-grouped facet row. Query the axis grouping via
+     `tags-by-axis` / `tags-without-axis`.
+
+     **`:default-filter`** — `:include` (default) | `:exclude`. When
+     `:exclude`, the sidebar pre-excludes variants carrying this tag at
+     boot (e.g. `:internal` / `:experimental` start hidden so they don't
+     crowd the dev shell). Query the default-excluded set via
+     `tags-default-excluded`.
 
      `!`-prefix removal-syntax (e.g. `:!dev`) on a variant `:tags` set
      resolves at registration time against the inherited set — see
@@ -337,6 +351,30 @@
   "Per IMPL-SPEC §7.4 — return the set of registered mode ids."
   []
   (ids :mode))
+
+(defn tags-by-axis
+  "Per spec/001 §reg-tag — return the set of registered tag ids whose
+  body's `:axis` equals `axis-kw` (e.g. `:status` / `:role` / `:team` /
+  `:feature`). The sidebar tag-filter UI uses this to group registered
+  tags into collapsible facet rows (rf2-v05qb SB9 parity). Returns the
+  empty set if no tag carries that axis."
+  [axis-kw]
+  (registrar/tags-by-axis axis-kw))
+
+(defn tags-without-axis
+  "Per spec/001 §reg-tag — return the set of registered tag ids whose
+  body carries no `:axis`. The sidebar renders these in a trailing
+  un-grouped facet row."
+  []
+  (registrar/tags-without-axis))
+
+(defn tags-default-excluded
+  "Per spec/001 §reg-tag — return the set of registered tag ids whose
+  body's `:default-filter` is `:exclude`. The sidebar tag-filter
+  pre-excludes variants carrying any of these at boot (e.g.
+  `:internal` / `:experimental`)."
+  []
+  (registrar/tags-default-excluded))
 
 (def canonical-tags
   "Re-export of the seven canonical tag ids from spec/007 §Inclusion

--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -368,3 +368,34 @@
                      (some #(contains? tset %) qs))))
          (map first)
          set)))
+
+(defn tags-by-axis
+  "Return the set of registered tag ids whose body's `:axis` equals
+  `axis-kw`. Per spec/001 §reg-tag the optional `:axis` slot groups
+  tags into facet rows in the sidebar tag-filter UI (rf2-v05qb SB9
+  parity). Tags registered without `:axis` are excluded from every
+  axis-keyed result."
+  [axis-kw]
+  (->> (handlers :tag)
+       (filter (fn [[_ body]] (= axis-kw (:axis body))))
+       (map first)
+       set))
+
+(defn tags-without-axis
+  "Return the set of registered tag ids whose body carries no `:axis`.
+  The sidebar renders these in a trailing un-grouped facet row."
+  []
+  (->> (handlers :tag)
+       (filter (fn [[_ body]] (nil? (:axis body))))
+       (map first)
+       set))
+
+(defn tags-default-excluded
+  "Return the set of registered tag ids whose body's `:default-filter`
+  is `:exclude`. The sidebar tag-filter pre-excludes variants carrying
+  any of these at boot (e.g. `:internal` / `:experimental`)."
+  []
+  (->> (handlers :tag)
+       (filter (fn [[_ body]] (= :exclude (:default-filter body))))
+       (map first)
+       set))

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -375,10 +375,26 @@
 ;; ---- :rf/tag --------------------------------------------------------------
 
 (def Tag
-  "Schema for the body of `reg-tag`. Tag bodies carry a `:doc` only.
-  The vocabulary itself is queryable via `(story/handlers :tag)`."
+  "Schema for the body of `reg-tag`. The vocabulary itself is queryable
+  via `(story/handlers :tag)`.
+
+  Slots (all optional):
+
+  - `:doc` — string, one-sentence what/why.
+  - `:axis` — keyword classifier (e.g. `:status`, `:role`, `:team`,
+    `:feature`). Per spec/001 §reg-tag — the sidebar tag-filter UI
+    groups registered tags by `:axis` into collapsible facet rows
+    (rf2-v05qb SB9 parity). Tags without `:axis` render in a trailing
+    un-grouped row.
+  - `:default-filter` — `:include` | `:exclude`. Pre-applied to the
+    sidebar tag filter at boot. `:exclude` hides variants carrying
+    this tag from the default sidebar view (e.g. `:internal` /
+    `:experimental` start excluded so they don't crowd the dev shell).
+    Tags without `:default-filter` default to `:include` semantics."
   [:map
-   [:doc {:optional true} :string]])
+   [:doc            {:optional true} :string]
+   [:axis           {:optional true} :keyword]
+   [:default-filter {:optional true} [:enum :include :exclude]]])
 
 ;; ---- validator dispatch table ---------------------------------------------
 

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -313,6 +313,73 @@
        :tags   #{:dev :auth/regression-set}})
     (is (story/registered? :variant :story.auth.login/regression-empty))))
 
+;; ---- :axis + :default-filter slots (rf2-frtec / SB9 parity) ------------
+
+(deftest reg-tag-stores-axis
+  (testing ":axis is stored on the registered tag body"
+    (story/reg-tag :auth/regression-set
+      {:doc  "Auth regression-suite variants."
+       :axis :team})
+    (is (= :team (:axis (story/handler-meta :tag :auth/regression-set))))))
+
+(deftest reg-tag-stores-default-filter
+  (testing ":default-filter is stored on the registered tag body"
+    (story/reg-tag :status/alpha
+      {:doc            "Pre-release status."
+       :axis           :status
+       :default-filter :exclude})
+    (let [body (story/handler-meta :tag :status/alpha)]
+      (is (= :status (:axis body)))
+      (is (= :exclude (:default-filter body))))))
+
+(deftest reg-tag-without-axis-defaults-sanely
+  (testing "tags without :axis / :default-filter remain valid and queryable"
+    ;; Canonical tags carry neither slot — they're pre-installed by the
+    ;; fixture's `install-canonical-vocabulary!`. Confirm they're absent
+    ;; from every axis-keyed lookup and the default-excluded set.
+    (is (= #{} (story/tags-by-axis :status)))
+    (is (= #{} (story/tags-by-axis :role)))
+    (is (= #{} (story/tags-default-excluded)))
+    ;; And the canonical seven all live in the un-axis-grouped bucket.
+    (is (= schemas/canonical-tags (story/tags-without-axis)))))
+
+(deftest tags-by-axis-filters-correctly
+  (testing "tags-by-axis returns only tags registered on the requested axis"
+    (story/reg-tag :status/alpha       {:axis :status :default-filter :exclude})
+    (story/reg-tag :status/beta        {:axis :status})
+    (story/reg-tag :role/dev           {:axis :role})
+    (story/reg-tag :auth/regression    {:axis :team})
+    (story/reg-tag :no-axis/freeform   {:doc "no axis here"})
+    (is (= #{:status/alpha :status/beta} (story/tags-by-axis :status)))
+    (is (= #{:role/dev}                  (story/tags-by-axis :role)))
+    (is (= #{:auth/regression}           (story/tags-by-axis :team)))
+    (is (= #{} (story/tags-by-axis :nonexistent)))
+    ;; un-axis-grouped tag sits in tags-without-axis alongside the canonical seven
+    (is (contains? (story/tags-without-axis) :no-axis/freeform))
+    (is (not (contains? (story/tags-by-axis :status) :no-axis/freeform)))))
+
+(deftest tags-default-excluded-filters-correctly
+  (testing "tags-default-excluded returns only tags with :default-filter :exclude"
+    (story/reg-tag :status/alpha    {:axis :status :default-filter :exclude})
+    (story/reg-tag :status/beta     {:axis :status :default-filter :include})
+    (story/reg-tag :status/stable   {:axis :status})                ; no slot — defaults to include
+    (story/reg-tag :hidden/internal {:default-filter :exclude})
+    (is (= #{:status/alpha :hidden/internal} (story/tags-default-excluded)))))
+
+(deftest reg-tag-rejects-bad-default-filter
+  (testing ":default-filter must be :include or :exclude"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"does not match tag schema"
+                          (story/reg-tag :bad/df
+                            {:default-filter :sometimes})))))
+
+(deftest reg-tag-rejects-non-keyword-axis
+  (testing ":axis must be a keyword"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"does not match tag schema"
+                          (story/reg-tag :bad/axis
+                            {:axis "status"})))))
+
 ;; ---- !-prefix removal syntax -------------------------------------------
 
 (deftest tags-with-bang-prefix-validate


### PR DESCRIPTION
## Summary

Extends `reg-tag` body schema with two optional slots for SB9 parity (rf2-v05qb audit):

- **`:axis`** — keyword classifier (e.g. `:status` / `:role` / `:team` / `:feature`) that the sidebar tag-filter UI groups registered tags into collapsible facet rows. Mirrors Storybook 9's status / role / team / feature axes.
- **`:default-filter`** — `:include` (default) | `:exclude`. When `:exclude` the sidebar pre-excludes variants carrying the tag at boot, mirroring SB9's `defaultFilterSelection` (e.g. `:internal` / `:experimental` start hidden).

## What ships

- `Tag` schema in `tools/story/src/re_frame/story/schemas.cljc` accepts the two new optional slots (`:axis :keyword`, `:default-filter [:enum :include :exclude]`). Additive — every existing tag body remains valid.
- `reg-tag` macro docstring in `tools/story/src/re_frame/story.cljc` updated.
- Registry-side accessors exposed on `re-frame.story`:
  - `(tags-by-axis :status)` — set of tag ids on a given axis.
  - `(tags-without-axis)` — set of tag ids with no axis.
  - `(tags-default-excluded)` — set of tag ids with `:default-filter :exclude`.
- Spec update: `tools/story/spec/001-Authoring.md §reg-tag` with worked example + query API documentation.
- 7 new tests in `tools/story/test/re_frame/story_test.clj`:
  - `:axis` storage on the registered body.
  - `:default-filter` storage.
  - Tags without `:axis` default sanely (canonical seven live in `tags-without-axis`; absent from every axis-keyed lookup and from `tags-default-excluded`).
  - `tags-by-axis` filters correctly across multiple axes.
  - `tags-default-excluded` filters correctly.
  - Schema rejects bad `:default-filter` value.
  - Schema rejects non-keyword `:axis`.

## Coordination

This is the registration side only. The sidebar consumer (rf2-nwiwr) reads these slots in a separate worktree — independent surfaces, no overlap. This PR touches only `tools/story/src/re_frame/story.cljc`, `tools/story/src/re_frame/story/registrar.cljc`, `tools/story/src/re_frame/story/schemas.cljc`, `tools/story/spec/001-Authoring.md`, and `tools/story/test/re_frame/story_test.clj`.

## Test plan

- [x] `clojure -M:test` in `tools/story/` — 321 tests / 943 assertions / 0 failures / 0 errors