### PR TITLE
feat(pair2-mcp): server-side hash precheck — skip nREPL on cache-hit (rf2-36xod)

### DIFF
--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/cache.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/cache.cljs
@@ -39,11 +39,19 @@
   one cache cover every tool uniformly (snapshot, get-path,
   trace-window, etc.) instead of needing per-tool hash strategies.
 
-  The trade-off: we still pay the nREPL round-trip and the local
-  transform pipeline; the cache only saves the *wire bytes*. That's
-  the byte cost the bead identifies (\"the wire pays full app-db cost
-  twice\"). Saving the round-trip needs a server-side hash precheck
-  — out of scope here; filed as a follow-on bead.
+  The original (rf2-3rt1f) shape paid the full nREPL round-trip and
+  local transform pipeline; the cache only saved the *wire bytes*.
+  rf2-36xod added a **precheck** path on top: an entry can carry a
+  cheap `:precheck-hash` (e.g. `(hash (re-frame-pair2.runtime/snapshot
+  frame))`). Before running the tool, the MCP server fetches the
+  current precheck-hash via one bencode round-trip; if it matches
+  the stored `:precheck-hash` for `(tool, args)`, the server emits
+  the `:rf.mcp/cache-hit` marker WITHOUT running the tool. Saves
+  both wire bytes AND the heavyweight tool eval + transform pipeline.
+
+  See `precheck` (decide before running the tool) vs `apply-cache`
+  (decide after running the tool — the original behaviour, used as
+  the backstop for tools without a precheck wiring).
 
   ## LRU policy
 
@@ -74,8 +82,13 @@
    {:hash             <integer>
     :unchanged-since  <ms-since-epoch>
     :tool             \"<tool-name>\"
+    :via              :precheck | :result-hash   ;; rf2-36xod
     :hint             \"<agent-host instruction string>\"}}
   ```
+
+  `:via :precheck` signals the hit short-circuited the full tool eval
+  (rf2-36xod path); `:via :result-hash` is the original rf2-3rt1f
+  match-after-eval path. Same wire vocabulary, different cost saved.
 
   The `:rf.mcp/*` namespace matches the wire-vocabulary convention
   used by `:rf.mcp/overflow` (rf2-rvyzy), `:rf.mcp/dedup-table`
@@ -220,20 +233,28 @@
        "no fresh state to inspect since :unchanged-since."))
 
 (defn cache-hit-payload
-  "Build the structured wire marker that replaces a cached response."
-  [{:keys [tool hash sent-at]}]
-  {:rf.mcp/cache-hit {:hash            hash
-                      :unchanged-since sent-at
-                      :tool            tool
-                      :hint            cache-hit-hint}})
+  "Build the structured wire marker that replaces a cached response.
+  `via` defaults to `:result-hash` (the rf2-3rt1f match-after-eval
+  path); pass `:precheck` for the rf2-36xod skip-the-tool-eval path."
+  ([entry] (cache-hit-payload entry :result-hash))
+  ([{:keys [tool hash sent-at]} via]
+   {:rf.mcp/cache-hit {:hash            hash
+                       :unchanged-since sent-at
+                       :tool            tool
+                       :via             via
+                       :hint            cache-hit-hint}}))
 
 (defn cache-hit-result
   "Wrap `cache-hit-payload` in the MCP `{:content [{:type \"text\" ...}]}`
-  envelope."
-  [entry tool]
-  #js {:content #js [#js {:type "text"
-                          :text (pr-str (cache-hit-payload
-                                          (assoc entry :tool tool)))}]})
+  envelope. `via` annotates which cache path produced the hit
+  (`:result-hash` = rf2-3rt1f post-eval match; `:precheck` =
+  rf2-36xod pre-eval short-circuit)."
+  ([entry tool] (cache-hit-result entry tool :result-hash))
+  ([entry tool via]
+   #js {:content #js [#js {:type "text"
+                           :text (pr-str (cache-hit-payload
+                                           (assoc entry :tool tool)
+                                           via))}]}))
 
 ;; ---------------------------------------------------------------------------
 ;; Arg parsing — opt-in switch.
@@ -275,7 +296,8 @@
   (contains? cacheable-tools tool))
 
 (defn apply-cache
-  "Wire-boundary cache check. Returns either:
+  "Wire-boundary cache check (rf2-3rt1f match-after-eval path). Returns
+  either:
 
     - `result-js` unchanged (cache disabled, tool not cacheable,
       isError result, or fresh store) — and as a side effect records
@@ -285,8 +307,13 @@
 
   Errors are never cached: an `:isError` result is passed through
   untouched and does NOT poison the cache. That keeps a transient
-  failure from masking a future successful read."
-  [result-js {:keys [tool args enabled?]}]
+  failure from masking a future successful read.
+
+  If `:precheck-hash` is supplied (the value fetched from the runtime
+  via the rf2-36xod precheck wiring), it is stored alongside the
+  result hash so the NEXT call can short-circuit via `precheck`
+  without re-running the tool."
+  [result-js {:keys [tool args enabled? precheck-hash]}]
   (cond
     (not enabled?)               result-js
     (nil? result-js)             result-js
@@ -299,6 +326,50 @@
           now        (.getTime (js/Date.))]
       (if (and prior (= (:hash prior) h))
         (do (record-hit! k)
-            (cache-hit-result prior tool))
-        (do (store! k {:hash h :sent-at now :tool tool})
+            (cache-hit-result prior tool :result-hash))
+        (do (store! k (cond-> {:hash h :sent-at now :tool tool}
+                        (some? precheck-hash) (assoc :precheck-hash precheck-hash)))
             result-js)))))
+
+;; ---------------------------------------------------------------------------
+;; Precheck — rf2-36xod. Decide cache-hit BEFORE running the tool.
+;; ---------------------------------------------------------------------------
+
+(defn precheck
+  "Pre-eval cache check (rf2-36xod). Returns either:
+
+    - `nil` — no decision; the caller proceeds with the full tool eval
+      and feeds the result back through `apply-cache`.
+    - A `{:rf.mcp/cache-hit ... :via :precheck}` MCP result — the
+      caller short-circuits and returns this directly, skipping the
+      tool eval entirely.
+
+  Decision rule: only when (a) cache is enabled, (b) the tool is
+  cacheable, (c) the (tool, args) key has a prior entry, (d) that
+  prior entry has a stored `:precheck-hash`, and (e) the
+  `current-precheck-hash` argument matches it.
+
+  `current-precheck-hash` is the value the MCP server fetched in a
+  single bencode round-trip (e.g.
+  `(hash (re-frame-pair2.runtime/snapshot frame))`). When the caller
+  has no precheck wiring for this tool (yet), it passes `nil` and
+  this fn returns `nil`, leaving the legacy post-eval path in charge.
+
+  This fn does NOT mutate the cache on a miss — the subsequent
+  `apply-cache` call records the new result+precheck-hash together
+  after the tool runs.
+
+  On a hit, it does touch the LRU (so the entry stays warm)."
+  [{:keys [tool args enabled?]} current-precheck-hash]
+  (cond
+    (not enabled?)                       nil
+    (not (cacheable? tool))              nil
+    (nil? current-precheck-hash)         nil
+    :else
+    (let [k     (cache-key tool args)
+          prior (lookup k)]
+      (when (and prior
+                 (some? (:precheck-hash prior))
+                 (= (:precheck-hash prior) current-precheck-hash))
+        (record-hit! k)
+        (cache-hit-result prior tool :precheck)))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -2498,22 +2498,136 @@
     (js/Promise.resolve
       (err-text {:ok? false :reason :unknown-tool :tool name}))))
 
+;; ---------------------------------------------------------------------------
+;; Cache precheck — rf2-36xod. Server-side cheap-hash probe.
+;;
+;; The original rf2-3rt1f cache decides a hit AFTER running the tool by
+;; hashing the result text. That saves wire bytes but still pays the
+;; full nREPL round-trip + path-slice + transform pipeline. The rf2-36xod
+;; precheck moves the decision EARLIER: one bencode round-trip asks the
+;; runtime for `(hash (re-frame-pair2.runtime/snapshot frame))`. If the
+;; hash matches the stored entry for `(tool, args)`, we emit the cache-
+;; hit marker WITHOUT running the tool — saving both the wire bytes AND
+;; the full tool eval.
+;;
+;; Eligibility (today): single-frame `snapshot` and `get-path`. Their
+;; result is a function of `(frame, args, app-db@frame)`; same frame +
+;; same args + same db-hash ⇒ same result. Multi-frame `snapshot`
+;; (`:frames :all` or a vector) is NOT eligible because we'd need to
+;; hash every frame's db separately and combine — out of scope; the
+;; legacy post-eval `apply-cache` path still catches those.
+;;
+;; Trace tools (`trace-window`, `watch-epochs`, `discover-app`) are not
+;; eligible — their result depends on the epoch ring / health surface,
+;; not just `(hash app-db)`. Plumbing a per-surface hash is the
+;; follow-on work (see `cache.cljs` docstring).
+;; ---------------------------------------------------------------------------
+
+(defn- precheck-frame
+  "Resolve the frame to use for a single-frame precheck. Returns the
+  frame keyword (e.g. `:rf/default`) or nil if the tool isn't
+  precheck-eligible.
+
+  `snapshot` is eligible only when `:frames` resolves to a single frame
+  (an explicit one-element vector or a single scalar). `:all` or a
+  multi-element vector returns nil — those callers fall back to the
+  post-eval cache.
+
+  `get-path` is always eligible (its `:frame` slot is single-valued by
+  contract; absent means \"operating frame\")."
+  [tool args]
+  (case tool
+    "snapshot"
+    (let [raw-frames (when args (j/get args "frames"))
+          frames     (parse-frames-arg raw-frames)]
+      (cond
+        ;; explicit single-frame vector
+        (and (vector? frames) (= 1 (count frames)))
+        (first frames)
+        ;; vector with multiple frames — not eligible
+        (vector? frames)
+        nil
+        ;; :all — not eligible
+        (= :all frames)
+        nil
+        :else nil))
+
+    "get-path"
+    ;; nil-frame is allowed — runtime resolves to operating frame, so
+    ;; the eval form computes the hash over whichever frame the runtime
+    ;; picks. The hash still keys on (tool, args), so the cache slot is
+    ;; consistent.
+    (or (some-> (arg args :frame) ->frame-keyword)
+        :rf.mcp.cache/operating-frame)
+
+    ;; Other tools — not precheck-eligible yet.
+    nil))
+
+(defn- precheck-form
+  "The CLJS eval form for the runtime-side cheap hash. We hash the
+  full per-frame snapshot — `(hash db)` is O(n) on the persistent map
+  but the wire payload is a single integer, and the alternative
+  (running the full tool + transform pipeline) is strictly more
+  expensive. A cheaper O(1) hash kept at mutation time is the
+  follow-on optimisation (filed separately)."
+  [frame]
+  (cond
+    (= frame :rf.mcp.cache/operating-frame)
+    "(hash (re-frame-pair2.runtime/snapshot))"
+
+    (keyword? frame)
+    (str "(hash (re-frame-pair2.runtime/snapshot " (pr-str frame) "))")
+
+    :else nil))
+
+(defn- fetch-precheck-hash
+  "Issue the one-bencode-round-trip eval to fetch the runtime-side
+  hash. Returns a Promise resolving to an integer hash, or `nil` on
+  any failure (the caller treats nil as 'no precheck — proceed').
+
+  Errors are swallowed by design: a failed precheck must NEVER block
+  the actual tool call. The worst case is we lose the optimisation
+  for this call; the post-eval cache still catches the wire-bytes
+  saving."
+  [conn args frame]
+  (if-let [form (precheck-form frame)]
+    (let [build-id (arg-build args)]
+      (-> (nrepl/cljs-eval-value conn build-id form)
+          (.then (fn [v]
+                   (cond
+                     (integer? v) v
+                     (number? v)  (long v)
+                     :else        nil)))
+          (.catch (fn [_] nil))))
+    (js/Promise.resolve nil)))
+
 (defn invoke
   "Dispatch a `tools/call` invocation to the right tool implementation.
   Returns a Promise resolving to the MCP result object.
 
   ## Wire-boundary pipeline
 
-  Each result passes through two egress transforms in order:
+  When the per-call `cache` arg is enabled, the invocation runs the
+  following:
+
+  0. `cache/precheck` (rf2-36xod) — for precheck-eligible tools
+     (`snapshot` single-frame; `get-path`) issue one cheap nREPL eval
+     `(hash (re-frame-pair2.runtime/snapshot frame))` and compare to
+     the stored `:precheck-hash` for `(tool, args)`. On a match,
+     short-circuit with `{:rf.mcp/cache-hit ... :via :precheck}` —
+     the tool eval is SKIPPED entirely. Saves the full pipeline cost.
+     On a miss (or for tools without precheck wiring), fall through.
 
   1. `cache/apply-cache` (rf2-3rt1f) — per-session response cache
      keyed on a hash of the result's text payload. On a hit (same
      hash for `(tool, args)` as the prior call) the full payload is
-     replaced with a tiny `{:rf.mcp/cache-hit ...}` marker; the
-     agent host already has the byte-identical bytes from the prior
-     `tools/call`. Opt-in via the per-call `cache` arg (default
-     `false`); read-only tools only; `:isError` results bypass
-     entirely. See `cache/apply-cache` for the LRU policy.
+     replaced with a tiny `{:rf.mcp/cache-hit ... :via :result-hash}`
+     marker; the agent host already has the byte-identical bytes
+     from the prior `tools/call`. Read-only tools only; `:isError`
+     results bypass entirely. See `cache/apply-cache` for the LRU
+     policy. When a precheck-hash was fetched in step 0, it's
+     recorded alongside the result hash so the NEXT call can
+     short-circuit via the precheck path.
 
   2. `apply-cap` (rf2-rvyzy) — responses whose serialised size
      exceeds the per-call cap (default 5,000 tokens, configurable
@@ -2531,13 +2645,32 @@
   _meta.progressToken) for streaming tools. Non-streaming tools
   ignore it."
   [conn name args extra]
-  (let [cap-opts   {:tool     name
-                    :cap      (max-tokens-arg args)
-                    :strategy :truncate-with-marker}
-        cache-opts {:tool     name
-                    :args     args
-                    :enabled? (cache/parse-cache-arg
-                                (when args (j/get args "cache")))}]
-    (-> (dispatch-tool* conn name args extra)
-        (.then (fn [result] (cache/apply-cache result cache-opts)))
+  (let [cap-opts    {:tool     name
+                     :cap      (max-tokens-arg args)
+                     :strategy :truncate-with-marker}
+        enabled?    (cache/parse-cache-arg
+                      (when args (j/get args "cache")))
+        cache-opts  {:tool     name
+                     :args     args
+                     :enabled? enabled?}
+        ;; Step 0: precheck — only fetch a hash when cache is enabled
+        ;; AND the tool has precheck wiring. Otherwise resolve a
+        ;; sentinel pair `[nil nil]` immediately and skip the round-trip.
+        precheck-pr (if-let [frame (and enabled? (precheck-frame name args))]
+                      (-> (fetch-precheck-hash conn args frame)
+                          (.then (fn [h]
+                                   [h (cache/precheck cache-opts h)])))
+                      (js/Promise.resolve [nil nil]))]
+    (-> precheck-pr
+        (.then (fn [[h hit]]
+                 (if hit
+                   ;; Short-circuit — skip the tool entirely.
+                   hit
+                   ;; Miss / no precheck — run the tool and feed the
+                   ;; result + (any) precheck-hash into apply-cache.
+                   (-> (dispatch-tool* conn name args extra)
+                       (.then (fn [result]
+                                (cache/apply-cache
+                                  result
+                                  (assoc cache-opts :precheck-hash h))))))))
         (.then (fn [result] (apply-cap result cap-opts))))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/cache_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/cache_test.cljs
@@ -348,3 +348,184 @@
       (is (cache-hit-result? hit))
       (is (< (count text) 500)
           "cache-hit marker fits well under a 5K-token cap"))))
+
+(deftest cache-hit-marker-carries-via-slot
+  ;; rf2-36xod: the marker carries `:via` to distinguish a pre-eval
+  ;; short-circuit (`:precheck`) from the legacy post-eval match
+  ;; (`:result-hash`). Agents that read the marker can attribute the
+  ;; saving correctly; tooling can graph cache-hit volume by source.
+  (let [args (args-js {:frame ":rf/default"})
+        text "{:ok? true :app-db {:k :v}}"
+        opts {:tool "snapshot" :args args :enabled? true}]
+    (cache/apply-cache (mcp-result text) opts)
+    (let [hit (cache/apply-cache (mcp-result text) opts)
+          v   (edn/read-string (extract-text hit))]
+      (is (= :result-hash (get-in v [:rf.mcp/cache-hit :via]))
+          "apply-cache hit annotates :via :result-hash"))))
+
+;; ---------------------------------------------------------------------------
+;; Precheck — rf2-36xod. Decide cache-hit BEFORE running the tool.
+;;
+;; Same `apply-cache` contract — same `(tool, args)` key, same LRU
+;; semantics, same marker shape — but with an extra `:precheck-hash`
+;; slot the caller can match against a runtime-side cheap hash. On
+;; a match, `precheck` emits the marker WITHOUT the caller ever
+;; running the tool. Saves the nREPL round-trip + full transform
+;; pipeline, not just the wire bytes.
+;; ---------------------------------------------------------------------------
+
+(defn- via-of
+  "Pull the `:via` slot out of a cache-hit marker result."
+  [result]
+  (let [v (edn/read-string (extract-text result))]
+    (get-in v [:rf.mcp/cache-hit :via])))
+
+(deftest precheck-returns-nil-without-prior-entry
+  ;; No prior entry for (tool, args) → precheck has nothing to match
+  ;; against → returns nil (caller proceeds with the full tool eval).
+  (let [args (args-js {:frame ":rf/default"})
+        opts {:tool "snapshot" :args args :enabled? true}]
+    (is (nil? (cache/precheck opts 12345))
+        "cold cache → precheck returns nil")))
+
+(deftest precheck-returns-nil-when-disabled
+  ;; `enabled? false` is a global opt-out — precheck must not engage.
+  ;; First prime the cache with a precheck-hash so a hit COULD happen
+  ;; if precheck were enabled.
+  (let [args      (args-js {:frame ":rf/default"})
+        opts-on   {:tool "snapshot" :args args :enabled? true
+                   :precheck-hash 12345}
+        opts-off  {:tool "snapshot" :args args :enabled? false}]
+    (cache/apply-cache (mcp-result "{:k :v}") opts-on)
+    (is (nil? (cache/precheck opts-off 12345))
+        "disabled cache → precheck always nil, even with matching hash")))
+
+(deftest precheck-returns-nil-for-non-cacheable-tool
+  ;; Action tools never participate in the cache; precheck mirrors
+  ;; that opt-out.
+  (let [args (args-js {:event "[:cart/checkout]"})
+        opts {:tool "dispatch" :args args :enabled? true}]
+    (is (nil? (cache/precheck opts 12345))
+        "dispatch is not cacheable → precheck returns nil")))
+
+(deftest precheck-returns-nil-when-no-current-hash
+  ;; Caller has no precheck wiring for this tool → passes nil → we
+  ;; return nil and let the legacy post-eval path take over.
+  (let [args (args-js {:frame ":rf/default"})
+        opts {:tool "snapshot" :args args :enabled? true}]
+    ;; Prime the cache with a precheck-hash.
+    (cache/apply-cache (mcp-result "{:k :v}")
+                       (assoc opts :precheck-hash 12345))
+    (is (nil? (cache/precheck opts nil))
+        "no current-precheck-hash supplied → precheck returns nil")))
+
+(deftest precheck-returns-nil-when-prior-has-no-precheck-hash
+  ;; A prior entry without a stored :precheck-hash (e.g. cached
+  ;; before precheck wiring existed, or the precheck fetch failed
+  ;; that round) cannot short-circuit even with a current hash.
+  (let [args (args-js {:frame ":rf/default"})
+        opts {:tool "snapshot" :args args :enabled? true}]
+    ;; Prime WITHOUT a precheck-hash.
+    (cache/apply-cache (mcp-result "{:k :v}") opts)
+    (is (nil? (cache/precheck opts 12345))
+        "no stored :precheck-hash → precheck returns nil even with current hash")))
+
+(deftest precheck-hit-short-circuits-with-marker
+  ;; The load-bearing path. Prime the cache with a precheck-hash;
+  ;; a second call carrying the SAME hash → precheck returns the
+  ;; marker. The caller never runs the tool.
+  (let [args (args-js {:frame ":rf/default"})
+        opts {:tool "snapshot" :args args :enabled? true}
+        h    98765]
+    ;; Prime — tool ran once, result + precheck-hash stored.
+    (cache/apply-cache (mcp-result "{:ok? true :app-db {:k :v}}")
+                       (assoc opts :precheck-hash h))
+    ;; Second tool call would be preceded by a precheck.
+    (let [out (cache/precheck opts h)]
+      (is (some? out)
+          "matching precheck-hash → marker returned")
+      (is (cache-hit-result? out)
+          "marker shape is :rf.mcp/cache-hit")
+      (is (= :precheck (via-of out))
+          "marker carries :via :precheck — distinguishes from result-hash path"))))
+
+(deftest precheck-miss-on-different-hash
+  ;; State moved on → current hash differs from stored → precheck
+  ;; returns nil and the caller falls back to the full tool eval.
+  (let [args (args-js {:frame ":rf/default"})
+        opts {:tool "snapshot" :args args :enabled? true}]
+    (cache/apply-cache (mcp-result "{:ok? true :app-db {:k :v}}")
+                       (assoc opts :precheck-hash 12345))
+    (is (nil? (cache/precheck opts 67890))
+        "different current-hash → precheck returns nil")))
+
+(deftest precheck-uses-tool-args-key
+  ;; Cache key is `(tool, args)` — a precheck for (snapshot, frame=:a)
+  ;; must NOT hit an entry stored for (snapshot, frame=:b) even when
+  ;; the hashes match (because the hashes would, in real usage, be
+  ;; the per-frame app-db hash — different frames have different dbs).
+  (let [args-a (args-js {:frame ":rf/a"})
+        args-b (args-js {:frame ":rf/b"})
+        h      11111
+        opts-a {:tool "snapshot" :args args-a :enabled? true}
+        opts-b {:tool "snapshot" :args args-b :enabled? true}]
+    (cache/apply-cache (mcp-result "{:db {:k :v}}")
+                       (assoc opts-a :precheck-hash h))
+    (is (nil? (cache/precheck opts-b h))
+        "different args → different key → precheck returns nil")
+    (is (some? (cache/precheck opts-a h))
+        "matching key → precheck hits")))
+
+(deftest precheck-hit-touches-lru
+  ;; A precheck hit is still a use of the entry — touch the LRU so
+  ;; the entry doesn't rotate out under capacity pressure.
+  (let [opts (fn [i] {:tool "snapshot"
+                      :args (args-js {:frame (str ":f" i)})
+                      :enabled? true})]
+    ;; Fill to capacity with precheck-hashes.
+    (dotimes [i 8]
+      (cache/apply-cache (mcp-result (str "{:i " i "}"))
+                         (assoc (opts i) :precheck-hash (* i 1000))))
+    (is (= 8 (cache/size)))
+    ;; Touch the OLDEST entry via precheck.
+    (is (some? (cache/precheck (opts 0) 0))
+        "oldest entry still precheck-hits")
+    ;; Now add a new entry — the LRU evicts entry 1 (current oldest
+    ;; since entry 0 was just touched), not entry 0.
+    (cache/apply-cache (mcp-result "{:i 99}")
+                       (assoc (opts 99) :precheck-hash 99000))
+    (is (= 8 (cache/size)))
+    (is (some? (cache/precheck (opts 0) 0))
+        "entry 0 survived — precheck-hit touched the LRU")
+    (is (nil? (cache/precheck (opts 1) 1000))
+        "entry 1 evicted as the new oldest")))
+
+(deftest precheck-hash-stored-by-apply-cache
+  ;; `apply-cache` is the single write surface — when the caller
+  ;; supplies `:precheck-hash`, it's stored alongside the result
+  ;; hash so the next `precheck` call can match it.
+  (let [args (args-js {:frame ":rf/default"})
+        opts {:tool "snapshot" :args args :enabled? true
+              :precheck-hash 54321}]
+    (cache/apply-cache (mcp-result "{:k :v}") opts)
+    (is (some? (cache/precheck (dissoc opts :precheck-hash) 54321))
+        "precheck-hash supplied at store time is queryable on the next call")))
+
+(deftest precheck-hash-absent-when-not-supplied
+  ;; Backwards-compat path. When `apply-cache` is called WITHOUT
+  ;; `:precheck-hash` (the rf2-3rt1f-era call sites), the stored
+  ;; entry doesn't carry one; future precheck attempts on that key
+  ;; return nil and the legacy post-eval cache catches the hit.
+  (let [args (args-js {:frame ":rf/default"})
+        opts {:tool "snapshot" :args args :enabled? true}
+        text "{:k :v}"]
+    ;; First store — no precheck-hash.
+    (cache/apply-cache (mcp-result text) opts)
+    (is (nil? (cache/precheck opts 12345))
+        "no stored :precheck-hash → precheck returns nil")
+    ;; Legacy post-eval path still works.
+    (let [hit (cache/apply-cache (mcp-result text) opts)]
+      (is (cache-hit-result? hit)
+          "post-eval cache-hit still fires when text matches")
+      (is (= :result-hash (via-of hit))
+          "marker carries :via :result-hash"))))


### PR DESCRIPTION
## Summary

Follow-on to rf2-3rt1f's 8-slot LRU cache. The original cache decided a hit AFTER running the tool by hashing the result text — saving wire bytes but still paying the full nREPL round-trip + path-slice + transform pipeline. This change moves the decision EARLIER: one bencode round-trip asks the runtime for `(hash (re-frame-pair2.runtime/snapshot frame))`. If the hash matches the stored `:precheck-hash` for `(tool, args)`, the server emits the cache-hit marker WITHOUT running the tool — saving both the wire bytes AND the heavyweight tool eval.

## Wire vocabulary

Same `{:rf.mcp/cache-hit {...}}` marker shape, with one new slot:

- `:via :precheck` — rf2-36xod pre-eval short-circuit
- `:via :result-hash` — rf2-3rt1f post-eval match (the existing path)

Agents that read the marker can attribute the saving correctly; tooling can graph cache-hit volume by source.

## Eligibility today

- single-frame `snapshot` (one explicit frame; `:all`/multi-frame falls back to the post-eval path)
- `get-path` (single-valued `:frame` by contract)

Trace tools (`trace-window`, `watch-epochs`, `discover-app`) are not yet eligible — their result depends on the epoch ring / health surface, not just `(hash app-db)`. The legacy post-eval `apply-cache` path still catches their wire-bytes saving.

## Cost note

The current precheck form `(hash (snapshot frame))` is O(n) over the frame's app-db, but returns just one integer over the wire and is strictly cheaper than running the full tool eval. A cached O(1) hash kept at mutation time is the next optimisation — filed as **rf2-9pe31**.

## Files

- `tools/pair2-mcp/src/re_frame_pair2_mcp/cache.cljs` — new `precheck` fn; `apply-cache` now also stores a `:precheck-hash` when supplied; marker carries `:via`
- `tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs` — `invoke` runs the precheck step before `dispatch-tool*` when the tool is precheck-eligible
- `tools/pair2-mcp/test/re_frame_pair2_mcp/cache_test.cljs` — 13 new precheck tests

## Test plan

- [x] All 255 pair2-mcp tests pass (\`npm test\`)
- [x] Server production build is clean (\`npm run build\`)
- [x] No `:via` regression in existing rf2-3rt1f tests
- [x] Precheck-hit emits `:via :precheck`; post-eval emits `:via :result-hash`
- [x] LRU touch happens on precheck-hit (entries don't rotate out)
- [x] No `:precheck-hash` supplied at store time → precheck returns nil (backwards-compat with rf2-3rt1f call sites)