### PR TITLE
spec(causa): :rf.causa/epoch-collector callback contract (rf2-yp92j)

### DIFF
--- a/tools/causa/spec/011-Launch-Modes.md
+++ b/tools/causa/spec/011-Launch-Modes.md
@@ -220,6 +220,178 @@ included in a production bundle, the trace registration is a no-op
 silently because `current-adapter` is unset; the fallback is
 graceful, not catastrophic.
 
+### Epoch pump (rf2-yp92j)
+
+The foundation phase's third step registers an
+[`rf/register-epoch-cb!`](../../../spec/009-Instrumentation.md#register-epoch-cb--assembled-epoch-listener)
+callback under the key `:rf.causa/epoch-collector`. Where the trace
+collector buffers raw events for panel-side projections (per
+[`013-Trace-Bus.md`](./013-Trace-Bus.md)), the epoch-collector serves
+a different job: it is the **reactive pump** that keeps Causa's
+cached epoch-history snapshot consistent with the framework's. Causa
+cannot subscribe directly against `(rf/epoch-history target)` —
+the framework atom backs a side-effecting read, not a reactive
+source. Routing each settle through Causa's `:rf/causa` frame is
+what makes the
+[`:rf.causa/epoch-history`](./014-Registry-Catalogue.md#shared-infrastructure)
+sub re-fire when the host appends an epoch. This subsection pins
+the callback's contract.
+
+**Registration key and signature.** The callback MUST be registered
+under the keyword `:rf.causa/epoch-collector` (the
+`:rf.causa/` namespace per
+[`spec/Conventions.md`](../../../spec/Conventions.md)) with the
+signature `(fn [record] ...)` where `record` is a fully-assembled
+`:rf/epoch-record` per
+[Spec-Schemas](../../../spec/Spec-Schemas.md#rfepoch-record). The
+key is reserved — host code MUST NOT register a competing callback
+under the same id (a duplicate registration would replace the
+collector and silence Causa's epoch-driven panels).
+
+**Trigger.** The callback fires once per **drain-settle**, after
+the framework has appended the assembled record to its per-frame
+`epoch-history` ring buffer. The callback runs synchronously on the
+framework's emit call stack, per
+[Spec 009 §Listener invocation rules](../../../spec/009-Instrumentation.md#listener-invocation-rules)
+— there is no batching, no debounce, no background delivery. A
+multi-event cascade yields exactly one callback invocation, not
+one per event (the trace collector's job is per-event; the epoch
+collector's is per-cascade).
+
+**What the callback does.** On every invocation the callback MUST
+re-enter the runtime under the `:rf/causa` frame binding (via
+`rf/with-frame`) and dispatch
+`[:rf.causa/epoch-recorded (:frame record)]`. The event handler is
+registered against `:rf/causa` (per
+[`014-Registry-Catalogue.md` §Shared infrastructure](./014-Registry-Catalogue.md#shared-infrastructure))
+and is responsible for the no-op-vs-update decision: when the
+record's `:frame` does not match the currently-selected target
+frame, the handler returns `db` unchanged; when it matches, the
+handler re-reads `(rf/epoch-history target)` and writes the fresh
+vector into Causa's app-db. Re-reading rather than threading the
+record's contents through the dispatch arg keeps the snapshot
+consistent with the framework's own view — the record is the
+trigger, not the payload.
+
+**Ordering guarantees.** The callback receives records in
+**emission order** — the order in which the framework finished
+draining each cascade. Per
+[Spec 009 §Listener invocation rules](../../../spec/009-Instrumentation.md#listener-invocation-rules),
+each listener sees events in the runtime's emit order; no
+re-ordering occurs between framework emit and the collector body.
+Ordering *across* sibling listeners (other tools that register
+their own `register-epoch-cb!` callbacks alongside Causa) is **not
+contract** — the same rule that applies to `register-trace-cb!`
+applies here. Causa's handler MUST NOT depend on the relative
+order of Causa's invocation versus any other tool's.
+
+**Frame-scoping.** The dispatch MUST be wrapped in
+`(rf/with-frame :rf/causa ...)` so the resulting event handler
+writes to Causa's own app-db, not the host frame's. The wrap is
+load-bearing: without it, the dispatch would resolve in the
+outermost-dispatch frame (typically the host's `:rf/default` per
+[Spec 002 §Frame resolution](../../../spec/002-Frames.md)) and
+Causa's `:rf.causa/epoch-recorded` handler — registered only
+against `:rf/causa` — would miss entirely. The record's `:frame`
+field (the *host* frame whose drain settled) is passed as the
+dispatch arg so the handler can compare against its target-frame
+sub and skip work for non-target frames; it MUST NOT be confused
+with the dispatch's effective frame binding (`:rf/causa`).
+
+**Backpressure.** None. The collector body is fire-and-forget per
+[Spec 009 §Listener invocation rules](../../../spec/009-Instrumentation.md#listener-invocation-rules)
+— the dispatched event enters the `:rf/causa` frame's event queue
+and the callback returns immediately. The framework's emit path
+MUST NOT block on Causa's dispatch draining. If the `:rf/causa`
+queue is busy when an epoch settles, the new dispatch enqueues
+behind the existing work and the framework moves on. Causa MUST
+NOT introduce a back-pressure throttle on the framework's emit
+path; the framework's epoch-cb fan-out is fire-and-forget and any
+back-pressure attempt would violate
+[`Principles.md`](./Principles.md) §Observation only — no new
+runtime surfaces.
+
+**No drop semantics.** Unlike the trace bus's bounded ring (per
+[`013-Trace-Bus.md`](./013-Trace-Bus.md) §Eviction policy), the
+epoch pump does **not** drop callbacks under load. Every settle
+fires the callback; every callback dispatches into `:rf/causa`.
+The framework's own `epoch-history` ring buffer is the only
+lossy substrate in this chain — when its depth (default 50, per
+[Tool-Pair](../../../spec/Tool-Pair.md)) is exceeded the oldest
+epoch evicts, and Causa's next re-read picks up the post-eviction
+vector. Causa MUST NOT maintain its own deeper epoch retention;
+the framework's `epoch-history` is the source of truth and
+Causa's cache is a pure mirror.
+
+**Exception isolation.** An exception thrown inside the callback
+body MUST be caught by the framework's epoch-cb fan-out (per
+[Spec 009 §`register-epoch-cb!` invocation rules](../../../spec/009-Instrumentation.md#register-epoch-cb--assembled-epoch-listener))
+and MUST NOT propagate to the framework or to other registered
+epoch listeners. Causa's collector body is small (it only wraps a
+dispatch); the realistic failure mode is the dispatched event
+handler throwing, and that runs inside the `:rf/causa` frame's
+own drain — its exception is the responsibility of the
+re-frame2 error catalogue, not the epoch-cb surface.
+
+**Idempotency.** The registration is gated by a `defonce`
+sentinel (`epoch-cb-registered?`) so shadow-cljs `:after-load`
+reruns of the preload do NOT re-register the callback. A
+re-registration under the same key would be a no-op at the
+framework level (the same-key replacement semantics) but the
+sentinel suppresses it explicitly to keep the preload's
+side-effect surface auditable. Test fixtures MAY call
+`reset-for-test!` to drop the sentinel and drive multiple
+registration cycles; production code MUST NOT.
+
+**Absent-artefact behaviour.** The `day8/re-frame2-epoch`
+artefact is optional. When it is not on the classpath,
+`rf/register-epoch-cb!` is itself a no-op (per
+[Spec 009 §Hook-table-driven late binding](../../../spec/009-Instrumentation.md))
+and the registration call is silently a no-op. Causa's
+time-travel panel detects the absent-artefact case via
+`(empty? (rf/epoch-history ...))` and renders the
+"epoch artefact not installed" empty state.
+
+**Frame-destroy handling.** When the host frame whose drain
+produced an epoch is later destroyed (per
+[Spec 002 §Destroy](../../../spec/002-Frames.md)), the framework
+emits a one-shot
+`:rf.epoch.cb/silenced-on-frame-destroy` trace event for each
+`(frame, cb-id)` pair whose previously-firing callback has gone
+silent (per
+[Tool-Pair §Surface behaviour against destroyed frames](../../../spec/Tool-Pair.md#surface-behaviour-against-destroyed-frames)).
+Causa MAY surface this trace in the event log (it flows through
+the trace bus like any other event) but MUST NOT take any
+additional action on it — the silencing is the framework's
+contract surface; Causa's role is read-only observation. If the
+destroyed frame was Causa's selected target, the
+`:rf.causa/epoch-history` sub returns the last-cached vector
+until the user selects a different target frame.
+
+**Unmount cancellation.** Causa's `teardown!` operation (test-
+only, per §Mount lifecycle) MUST NOT unregister the epoch
+callback — the callback is registered at preload time, not at
+mount time, and the preload's foundation phase persists across
+shell unmounts. Test fixtures driving teardown across runs MAY
+call `rf/remove-epoch-cb!` directly on the
+`:rf.causa/epoch-collector` key to unwire the pump; the
+sentinel-based registration will then re-fire on the next
+preload reload. Production sessions never tear down.
+
+**Production elision.** Per
+[`Principles.md`](./Principles.md) §Production elision is
+non-negotiable, the entire foundation block (including the
+epoch-collector registration) is gated on
+`re-frame.interop/debug-enabled?` at the preload's call site.
+Production builds compiled with `(set! goog.DEBUG false)` strip
+the registration, the callback body, and the `:rf/causa`
+event-queue entries entirely — no per-settle dispatch fires in
+production. The framework's epoch surface elides under the same
+gate (per
+[Spec 009 §Production builds](../../../spec/009-Instrumentation.md#production-builds-zero-overhead-zero-code))
+so even an accidentally-included preload would find the
+register-epoch-cb! call resolve to a no-op.
+
 ## Standalone via MCP
 
 ### Mechanism


### PR DESCRIPTION
## Summary

Adds a normative §Epoch pump (rf2-yp92j) subsection to
`tools/causa/spec/011-Launch-Modes.md` under §In-app overlay / Mount
lifecycle that pins the contract for the
`:rf.causa/epoch-collector` callback the preload registers via
`rf/register-epoch-cb!`.

The callback is the reactive bridge that keeps Causa's
`:rf.causa/epoch-history` sub firing — every drain-settle dispatches
`[:rf.causa/epoch-recorded (:frame record)]` into the `:rf/causa`
frame, the registered handler re-reads `rf/epoch-history`, and the
scrubber sub fires on the resulting app-db write. Without a spec
home its trigger, frame-scoping, ordering, and lifecycle were
implicit in `preload.cljs`; this subsection makes them normative.

Pins:

- Registration key + signature (`:rf.causa/epoch-collector`, `(fn [record] ...)`).
- Per-drain-settle trigger; one record per cascade, not per event.
- Emission-order guarantee; no cross-listener ordering contract.
- Required `(rf/with-frame :rf/causa ...)` wrap so the dispatch resolves
  in Causa's frame; the record's `:frame` field is the *host*
  frame compared against the target.
- Fire-and-forget posture; no back-pressure on framework emit.
- No-drop semantics — `epoch-history` is the only lossy substrate
  in the chain.
- Exception isolation inherited from the framework's epoch-cb fan-out.
- `defonce`-sentinel idempotency under shadow-cljs `:after-load`.
- Silent no-op when `day8/re-frame2-epoch` is absent.
- Frame-destroy observation via the
  `:rf.epoch.cb/silenced-on-frame-destroy` trace.
- Test-only `teardown!` semantics; production never tears down.
- Production elision via `re-frame.interop/debug-enabled?`.

14 MUSTs in the new subsection.

Spec-only — no impl, no test changes.

## Test plan

- [x] `mkdocs build --strict` clean (validated locally; the cross-refs to `spec/009-Instrumentation.md#register-epoch-cb--assembled-epoch-listener` match the anchor Tool-Pair.md already uses).
- [x] Cross-refs against `Spec-Schemas.md`, `Tool-Pair.md`, `Conventions.md`, `Principles.md`, `013-Trace-Bus.md`, `014-Registry-Catalogue.md` all resolve to existing anchors.