### PR TITLE
spec(mcp): canonicalise token-budget posture across triplet (rf2-ll0yq)

### DIFF
--- a/tools/causa-mcp/spec/Principles.md
+++ b/tools/causa-mcp/spec/Principles.md
@@ -268,6 +268,14 @@ default. The cap is normative, not aspirational: a tool that
 cannot answer inside the budget MUST trim, summarise, slice,
 paginate, or dedupe rather than over-spend.
 
+The cross-server contract — default cap, override slot name
+(`max-tokens`), overflow marker key (`:rf.mcp/overflow`),
+agent-host retry contract, and chained-budget rules when an agent
+attaches the triplet in one session — lives at
+[`tools/mcp-conformance/TOKEN-BUDGETS.md`](../../mcp-conformance/TOKEN-BUDGETS.md).
+The six mechanisms below are causa-mcp's expansion of that
+contract.
+
 The motivation is the 2026 trend axis. Microsoft's April 2026
 recommendation (Playwright CLI **over** Playwright MCP for
 coding agents) was driven by MCP responses being roughly 4×

--- a/tools/mcp-conformance/README.md
+++ b/tools/mcp-conformance/README.md
@@ -4,7 +4,7 @@ End-to-end **MCP-client** conformance harness for the re-frame2 MCP
 servers — `pair2-mcp`, `story-mcp`, and (when its implementation lands)
 `causa-mcp`. Source: rf2-cum40.
 
-This artefact has three surfaces:
+This artefact has four surfaces:
 
 1. **`test/end-to-end-*.js`** — Node-side end-to-end conformance.
    Drives each server through the official `@modelcontextprotocol/sdk`
@@ -23,6 +23,13 @@ This artefact has three surfaces:
    / `tail-` / `dispatch` / `eval-cljs` / `subscribe` / `unsubscribe`
    / mega-op bare verbs), with one-line semantics and the per-server
    audit table. Source: rf2-mzf1r.
+4. **[`TOKEN-BUDGETS.md`](TOKEN-BUDGETS.md)** — the cross-MCP
+   token-budget posture: the 5,000-token default cap, the
+   `max-tokens` per-call override, the `:rf.mcp/overflow` retry
+   marker, per-server mechanism inventory, chained-budget rules
+   when an agent attaches all three servers in one session, and
+   the deliberate divergences between server implementations.
+   Source: rf2-ll0yq.
 
 ## What this is
 

--- a/tools/mcp-conformance/TOKEN-BUDGETS.md
+++ b/tools/mcp-conformance/TOKEN-BUDGETS.md
@@ -1,0 +1,355 @@
+# Cross-MCP token-budget posture
+
+Source: rf2-ll0yq.
+
+The re-frame2 MCP triplet — `tools/pair2-mcp/`, `tools/story-mcp/`, and
+`tools/causa-mcp/` (spec-only today) — shares a normative **token-budget
+posture**: a 5,000-token-per-response cap, a single per-call override
+slot (`max-tokens`), and a single cross-server overflow marker
+(`:rf.mcp/overflow`). An agent host that attaches all three sees one
+disciplined surface, not three dialects of "I'm too big".
+
+This doc is the canonical pin. Each server's `Principles.md` carries
+the per-server expansion (mechanism inventory, pipeline order,
+implementation notes); this doc carries the **cross-server contract**
+— what is shared verbatim, where deliberate divergence lives today,
+and how the budget interacts when an agent chains multiple servers in
+one session.
+
+The peer cross-server docs are:
+
+- [`NAMING.md`](./NAMING.md) — verb vocabulary (catalogue surface).
+- [`wire-vocab/README.md`](./wire-vocab/README.md) — the `:rf.mcp/*` /
+  `:rf.size/*` keyword namespaces (wire payload surface).
+- **This doc** — the budget posture (response-size discipline).
+
+## Why a cap exists
+
+Microsoft's April 2026 recommendation — **Playwright CLI over
+Playwright MCP for coding agents** — was driven by MCP responses being
+~4× larger in tokens than the equivalent CLI output. Anthropic's own
+router-SKILL guidance lands at the same ~5k ceiling. An agent host
+with a 200k-token context window absorbs a handful of 20k tool returns
+fine, but the realistic working session fires dozens of tool calls. A
+single oversized response burns the budget the agent needs for the
+next ten ops.
+
+The triplet's exposed surfaces are exactly the SOTA-flagged shapes:
+
+| Server | Exposed surfaces | Why exposed |
+|---|---|---|
+| `pair2-mcp` | `snapshot`, `subscribe`, `watch-epochs`, `trace-window` | Mega-op spans 5 registries; subscribe batches scale with traffic; epochs carry full app-db pairs. |
+| `story-mcp` | `run-variant`, `list-stories` on populous libraries | Variant output carries assertions + rendered hiccup + snapshot; list-* size is a function of registry size. |
+| `causa-mcp` | `get-trace-buffer`, `get-epoch-history`, `app-db-diff`, `subscribe` | All return payloads that scale with runtime state — the most-exposed of the three. |
+
+Cap-first design pushes each server to **bound its egress by
+construction** (path-slicing, lazy summary, cursor pagination,
+diff-encoding, structural dedup, size elision) rather than relying on
+the cap as a backstop. The cap is the safety net; the per-tool
+mechanisms are the load-bearing budget posture.
+
+## The shared contract
+
+These slots are **identical across all three servers**. An agent that
+learns them once recognises them everywhere.
+
+### Default cap
+
+**5,000 tokens per response.** Every tool that returns to the agent
+MUST measure its rendered payload against this cap before egress.
+"Token" here is the Anthropic rule-of-thumb estimate: `(quot (count
+serialised-text) 4)` — a cheap character→token approximation, not a
+precise per-token meter. The goal is a bounded wire payload, not
+exact metering.
+
+The cap applies to the sum of every `:text` slot in the assembled MCP
+`{:content [{:type "text" :text ...} ...]}` result. Multi-part
+responses share one cumulative budget rather than per-key.
+
+### Per-call override slot
+
+**Argument name**: `max-tokens` (integer).
+
+- Absent or non-numeric ⇒ server defaults to 5,000.
+- `0` ⇒ cap disabled. Escape hatch for callers that have already
+  paginated, applied filters, or genuinely need the full payload (e.g.
+  a debug session inspecting an elided slot itself, or a session
+  running with a large-context model).
+- Positive integer ⇒ that cap applies for this call.
+
+The slot surfaces in `tools/list` on every tool descriptor so clients
+discover it automatically. Story-mcp's spec'd shape uses the same
+`:max-tokens` keyword and the same defaults — when its
+implementation passes lands the wire shape is identical.
+
+### Overflow marker (cross-server reserved key)
+
+A tool that would exceed the cap MUST NOT silently truncate. The
+payload is replaced with a structured marker the agent host
+recognises as a retry signal:
+
+```clojure
+{:rf.mcp/overflow {... slot vocabulary varies (see "Divergence" below) ...}}
+```
+
+The reserved keyword `:rf.mcp/overflow` is pinned in
+[`spec/Conventions.md` §Reserved namespaces (framework-owned)](../../spec/Conventions.md)
+and gated by the conformance test in
+[`wire-vocab/`](./wire-vocab/). Cross-server reserved-keyword
+absence ≠ free divergence — every server's overflow shape MUST
+validate against the canonical Malli schema pinned in
+`wire-vocab/wire_vocab_test.clj`.
+
+**The agent-host contract**: a result whose first key is
+`:rf.mcp/overflow` is a structured retry signal, not an error. The
+agent narrows args (drop slices, pass a tighter `:path`, tighter
+`:filter`, smaller `:limit`) or passes `max-tokens 0` if the full
+payload is genuinely needed. `:isError` stays `false` on overflow —
+the call succeeded; the response is a budget signal.
+
+### Cap-aware planning slots in tool descriptors
+
+Every catalogue entry (per pair2-mcp's
+[`003-Tool-Catalogue.md`](../pair2-mcp/spec/003-Tool-Catalogue.md),
+story-mcp's
+[`002-Tool-Registry.md`](../story-mcp/spec/002-Tool-Registry.md), and
+causa-mcp's planned `003-Tool-Catalogue.md`) carries:
+
+- A **typical-token** hint (`~1.2k`, `~3k under :sample`,
+  `~0.8k`) — surfaces in `list-tools` so the agent plans before
+  calling.
+- A **cap-reached** behaviour note — usually the overflow-marker hint
+  string the wrapper emits, optionally tool-specific (pair2-mcp's
+  `snapshot` recommends path-slicing; `subscribe` recommends tighter
+  filter; etc.).
+
+The hints are part of the descriptor, not a separate registry — an
+agent's `tools/list` walk pulls them automatically.
+
+## Per-server posture today
+
+### pair2-mcp — enforced, 8 mechanisms
+
+The cap is **enforced at the wire boundary** in
+`tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs` (`apply-cap` at
+the `invoke` boundary, rf2-rvyzy). Per-tool functions emit the same
+shapes they always did; the cap is a property of egress, not of each
+tool's internals.
+
+The discipline rests on **eight mechanisms**, running in pipeline
+order:
+
+1. **Size elision** — `:rf.size/large-elided` substitution at
+   declared-large slots, BEFORE everything else (rf2-urjnc).
+2. **Diff-encoded `:db-after`** — `:rf.mcp/diff-from` patches in epoch
+   slices (rf2-1wdzp).
+3. **Structural dedup** — `:rf.mcp/dedup-table` cross-record
+   substitution table (rf2-obpa9).
+4. **Path slicing** — `:path` arg defaults to tree-summary on rich
+   slices (rf2-tygdv).
+5. **Lazy summary** — `:rf.mcp/summary` mode for rich payloads
+   (rf2-u2029).
+6. **Cursor pagination** — `:cursor` + `:limit` on unbounded
+   surfaces.
+7. **Streaming budget** — runtime-side OR-combined event-count +
+   byte caps on `subscribe` queue (rf2-ho4ve).
+8. **Wire-boundary cap** — final 5,000-token check, swap with
+   overflow marker if over (rf2-rvyzy).
+
+Per-session response cache (`:rf.mcp/cache-hit`, rf2-3rt1f) layers on
+top: byte-identical second reads collapse to a sub-100-byte marker.
+
+Full per-mechanism documentation:
+[`tools/pair2-mcp/spec/Principles.md` §"Tight token budget per response"](../pair2-mcp/spec/Principles.md#tight-token-budget-per-response).
+
+### story-mcp — normative, enforcement pending
+
+The cap is **normative in spec** — every catalogue entry in
+[`002-Tool-Registry.md`](../story-mcp/spec/002-Tool-Registry.md) must
+respect it — but the runtime wire-boundary check is not yet wired in
+`tools/story-mcp/src/`. The exposed surfaces (`run-variant` output,
+`list-*` enumerations on populous libraries) currently stay inside
+the cap by construction via:
+
+- **Pagination / cursor** on `list-variants`, `list-modes`,
+  `list-assertions`, `list-stories`, `list-substrates`, `list-tags`.
+- **Summarisation modes** (`:count` / `:sample` / `:full`) on
+  `run-variant`, `snapshot-identity`, `variant->edn`, with `:sample`
+  as the default for rich payloads.
+
+The self-healing loop (run → read-failures → fix) naturally biases
+towards failure-only payloads — `:sample` mode under a failure filter
+keeps the typical workflow well inside the cap.
+
+Full posture text:
+[`tools/story-mcp/spec/Principles.md` §"Tight token budget per response"](../story-mcp/spec/Principles.md#tight-token-budget-per-response).
+
+When the wire-boundary check lands, it follows pair2-mcp's shape
+(`max-tokens` arg, `:rf.mcp/overflow` marker) — the keyword namespace
+is reserved cross-server.
+
+### causa-mcp — spec-locked, impl pending
+
+The cap is **spec-locked** in
+[`tools/causa-mcp/spec/Principles.md` §"Tight token budget per response"](../causa-mcp/spec/Principles.md#tight-token-budget-per-response)
+with **six normative mechanisms**:
+
+1. **Token budget cap** (5,000-token default, `:max-tokens`
+   override).
+2. **Path slicing** (`:path` arg + tree-summary default).
+3. **Cursor pagination** (`:cursor` + `:limit`).
+4. **Lazy summary** (`:rf.mcp/summary` shape, `:mode` arg).
+5. **Structural dedup** (`:rf.mcp/dedup-table`, opt-out via
+   `:dedup? false`).
+6. **Size elision** (`:rf.size/large-elided` substitution, opt-out
+   via `:include-large? true`).
+
+Mechanisms 1-6 are deliberately the same numbered set pair2-mcp's
+mechanisms 1-6 align against. Mechanisms 7-8 in pair2-mcp
+(diff-encoded `:db-after`, streaming subscribe byte+event budget) are
+**pair2-mcp-specific today** but the cross-server vocabulary
+(`:rf.mcp/diff-from`, `:overflow-reason`) is already pinned —
+causa-mcp's catalogue is expected to absorb them when its streaming /
+epoch-pair surfaces land.
+
+## Chained budgets — when agents attach multiple servers
+
+The realistic agent host attaches **all three servers in one
+session** (causa-mcp inspecting trace causality, pair2-mcp dispatching
+events, story-mcp running variants). The 5,000-token cap is **per
+response**, not per session — the agent host's total context budget
+absorbs the sum.
+
+The triplet's design assumes the agent meters consumption:
+
+- **Each server's responses are bounded.** No server can blow the
+  session on its own.
+- **No cross-server budget coordination.** Servers don't know about
+  each other's outputs; the agent host is the metering authority.
+- **Per-server `max-tokens` overrides compose additively.** An agent
+  that needs a full pair2-mcp `snapshot` payload AND a full causa-mcp
+  `get-epoch-history` payload passes `max-tokens 0` to both — total
+  cost is the sum.
+
+The agent-host workflow Mike's skills assume:
+
+1. **Start with summaries.** Default `:summary` / `:sample` modes
+   keep the first read cheap (~1-3k tokens).
+2. **Drill down with `:path`.** Subsequent reads target the addressed
+   subtree — the cap stays a backstop, not the primary mechanism for
+   the common case.
+3. **Paginate when summarising won't help.** Trace bursts, epoch
+   history, populous list-* surfaces all carry `:cursor` + `:limit`.
+4. **Override only when you have to.** `max-tokens 0` is the escape
+   hatch; the convention is to narrow args first.
+
+## Divergence — what differs cross-server today
+
+The contract above is shared. These differences exist today and are
+deliberate or pending alignment.
+
+### Overflow-marker slot vocabulary
+
+| Server | Slot shape |
+|---|---|
+| `pair2-mcp` (implemented) | `{:rf.mcp/overflow {:limit :reached :token-count <int> :cap-tokens <int> :tool <str> :hint <str>}}` |
+| `causa-mcp` (spec'd) | `{:rf.mcp/overflow {:cap <int> :would-be <int> :hint <kw-or-str> :continuation {:cursor <str> :next-args {...}}}}` |
+| `story-mcp` (spec'd, generic) | `:isError true` with `:reason :budget-exceeded` + hint string (legacy path; converges to `:rf.mcp/overflow` when wire-boundary check lands) |
+
+**The divergence is intentional** for pair2-mcp vs causa-mcp.
+pair2-mcp's wrapper measures the *post-shrunk* payload after the
+full diff-encode/dedup/elision pipeline, so the continuation hint is
+tool-specific rather than a generic `:continuation {:cursor ...
+:next-args ...}` shape. causa-mcp's spec'd `:continuation` slot is
+designed for the cursor-paginated read tools where the next call's
+args are mechanically computable.
+
+Cross-server convergence on a single slot vocabulary is tracked
+separately — when both wrappers stabilise, one shape wins. The
+**reserved keyword** (`:rf.mcp/overflow`) and the **retry-signal
+contract** are identical today; only the slot vocabulary differs.
+
+### Streaming-overflow surface
+
+pair2-mcp ships an **upstream-queue budget** (`:max-buffered-events`
++ `:max-buffered-bytes`, OR-combined) per subscription, with
+`:overflow-reason` reported per drain. causa-mcp's spec defers the
+upstream-queue model to impl. story-mcp doesn't ship streaming.
+
+When causa-mcp's streaming impl lands, it absorbs pair2-mcp's posture
+(the chatty-filter case and the large-payload-storm case both apply
+to causa-mcp's trace stream).
+
+### Enforcement surface
+
+| Server | Enforcement | Note |
+|---|---|---|
+| `pair2-mcp` | Runtime — `apply-cap` at `invoke` boundary | Live in `tools.cljs`. |
+| `story-mcp` | Spec-only — pagination + summary modes are normative but no wire-boundary check yet | Cap-violating tools would currently ship. Pending wiring. |
+| `causa-mcp` | Spec-only — six mechanisms catalogued, impl pending | `tools/causa-mcp/src/` does not exist yet. |
+
+The shared **default cap (5,000)**, the **shared override slot name
+(`max-tokens`)**, and the **shared overflow keyword
+(`:rf.mcp/overflow`)** are pinned cross-server even where enforcement
+hasn't landed.
+
+## Recommended client-side override convention
+
+Agent hosts and skills that drive the triplet follow one
+override-pattern convention:
+
+1. **First call: defaults.** No `max-tokens` arg. The server's default
+   (5,000) applies. The agent learns the rough size from the
+   typical-token hint in `tools/list`.
+2. **Cap tripped: narrow first.** On `:rf.mcp/overflow`, the agent
+   narrows args (`:path`, `:filter`, `:limit`, `:mode :sample`)
+   before raising the cap.
+3. **Cap raised: deliberate.** When the agent genuinely needs the
+   full payload, it passes `max-tokens 0` (disable) — not `100000`
+   (raise). The disable-form signals "I am taking responsibility for
+   the budget" rather than "I am guessing at a bigger number".
+4. **Per-server, not per-session.** Each call carries its own
+   `max-tokens` slot. Servers don't coordinate; the agent host meters
+   consumption across the session.
+
+The skill catalogue
+([`skills/re-frame-pair/`](../../skills/re-frame-pair/),
+[`skills/re-frame-story/`](../../skills/re-frame-story/), and
+causa-mcp's skill when its impl lands) encodes this pattern; agents
+attaching ad-hoc are encouraged to follow it.
+
+## When this convention changes
+
+The 5,000-token default, the `max-tokens` override slot name, the
+`:rf.mcp/overflow` reserved keyword, and the agent-host retry
+contract are **stable cross-server pins**. Changing any of them
+requires:
+
+1. A Lock entry in the relevant server's `DESIGN-RATIONALE.md`
+   recording the question / options / pick / why / date.
+2. A return-trip to this doc to revise the cross-server contract.
+3. A conformance-test update in [`wire-vocab/`](./wire-vocab/) if the
+   change touches the marker shape.
+4. Cross-server alignment — a default-cap change in one server
+   without the others creates a per-server-budget surprise the agent
+   has to special-case.
+
+Don't change silently. Agents pattern-match on the slot shapes the
+table above pins; silent divergence forces per-server
+special-casing and erodes the "one signal, one meaning" property the
+cross-server contract exists to enforce.
+
+## See also
+
+- [`NAMING.md`](./NAMING.md) — cross-MCP verb vocabulary.
+- [`wire-vocab/README.md`](./wire-vocab/README.md) — `:rf.mcp/*` /
+  `:rf.size/*` keyword conformance.
+- [`tools/pair2-mcp/spec/Principles.md` §"Tight token budget per response"](../pair2-mcp/spec/Principles.md#tight-token-budget-per-response)
+  — pair2-mcp's eight mechanisms, in pipeline order.
+- [`tools/story-mcp/spec/Principles.md` §"Tight token budget per response"](../story-mcp/spec/Principles.md#tight-token-budget-per-response)
+  — story-mcp's three-axis discipline.
+- [`tools/causa-mcp/spec/Principles.md` §"Tight token budget per response"](../causa-mcp/spec/Principles.md#tight-token-budget-per-response)
+  — causa-mcp's six mechanisms.
+- [`spec/Conventions.md` §"Reserved namespaces (framework-owned)"](../../spec/Conventions.md)
+  — the `:rf.mcp/*` / `:rf.size/*` keyword discipline this contract
+  inherits.

--- a/tools/pair2-mcp/spec/Principles.md
+++ b/tools/pair2-mcp/spec/Principles.md
@@ -132,6 +132,13 @@ response passes through a wire-boundary check before egress,
 and over-budget payloads are replaced — not silently truncated —
 with a structured `{:rf.mcp/overflow ...}` marker.
 
+The cross-server contract — default cap, override slot name,
+overflow marker key, agent-host retry contract, and chained-budget
+rules when an agent attaches the triplet in one session — lives at
+[`tools/mcp-conformance/TOKEN-BUDGETS.md`](../../mcp-conformance/TOKEN-BUDGETS.md).
+The eight mechanisms below are pair2-mcp's expansion of that
+contract.
+
 The motivation is the 2026 trend axis. Microsoft's April 2026
 recommendation (Playwright CLI **over** Playwright MCP for
 coding agents) was driven by MCP responses being roughly 4×

--- a/tools/story-mcp/spec/Principles.md
+++ b/tools/story-mcp/spec/Principles.md
@@ -170,6 +170,14 @@ default. The cap is normative, not aspirational: a tool that
 cannot answer inside the budget MUST trim, summarise, or
 paginate rather than over-spend.
 
+The cross-server contract — default cap, override slot name
+(`max-tokens`), overflow marker key (`:rf.mcp/overflow`),
+agent-host retry contract, and chained-budget rules when an agent
+attaches the triplet in one session — lives at
+[`tools/mcp-conformance/TOKEN-BUDGETS.md`](../../mcp-conformance/TOKEN-BUDGETS.md).
+The three-axis discipline below is story-mcp's expansion of that
+contract.
+
 The motivation is the 2026 trend axis. Microsoft's April 2026
 recommendation (Playwright CLI **over** Playwright MCP for
 coding agents) was driven by MCP responses being roughly 4×


### PR DESCRIPTION
## Summary

Adds `tools/mcp-conformance/TOKEN-BUDGETS.md` as the canonical cross-server pin for the MCP triplet's token-budget posture. Sits alongside the existing cross-MCP docs in the same dir: `NAMING.md` (verb vocabulary) and `wire-vocab/` (`:rf.mcp/*` keyword schemas). Doc-only; no source-code changes.

Tracks rf2-ll0yq.

## Context

The per-server Principles.md docs (`tools/{pair2-mcp,story-mcp,causa-mcp}/spec/Principles.md`) each carry a "Tight token budget per response" section today — PR #602 landed those. But there was no single cross-server pin documenting the **shared contract**: what slots are identical, where deliberate divergence lives, and how budgets interact when an agent chains the triplet in one session. The MCP triplet is the only re-frame2 surface where an agent host genuinely sees three servers as one tool surface; the token-budget posture is the second-most-load-bearing cross-server discipline after the naming convention.

## What ships

- **`tools/mcp-conformance/TOKEN-BUDGETS.md`** (new) — the canonical posture doc. Covers:
  - Why a cap exists (Microsoft April 2026 / Anthropic router-SKILL motivation).
  - The shared contract: 5,000-token default, `max-tokens` override slot, `:rf.mcp/overflow` retry marker, typical-token + cap-reached planning slots on tool descriptors.
  - Per-server posture today: pair2-mcp (8 mechanisms, enforced), story-mcp (3-axis discipline, normative-spec / enforcement pending), causa-mcp (6 mechanisms, spec-locked / impl pending).
  - Chained-budget rules when an agent attaches all three servers in one session.
  - Divergence catalogue: overflow-marker slot vocabulary (pair2 vs causa), streaming-overflow surface, enforcement maturity.
  - Recommended client-side override convention (narrow first, raise via `max-tokens 0`, per-call not per-session).
  - Change-control rules.
- **`tools/mcp-conformance/README.md`** — surface-count bumped 3 -> 4; new entry pointing at the doc.
- **`tools/{pair2-mcp,story-mcp,causa-mcp}/spec/Principles.md`** — short cross-link added to the top of each server's "Tight token budget per response" section, framing the per-server expansion as an extension of the shared contract.

## Coordination

- Touches only `tools/mcp-conformance/` and the three Principles.md files. No source-code changes.
- Does NOT touch `tools/pair2-mcp/src/` (rf2-re2s3, rf2-36xod, rf2-vw4sq all in flight).

## Validation

- `python scripts/check_doc_slugs.py` -> exit 0.

## Test plan

- [ ] Reviewer eyes the cross-server contract table — is the slot-vocabulary divergence (pair2's `{:limit :reached :token-count ...}` vs causa's `{:cap :would-be :continuation ...}`) framed accurately, or does one shape need to win in this PR?
- [ ] Reviewer eyes the "chained budgets" section — does the per-response-not-per-session framing match how Mike thinks agents should meter consumption?
- [ ] Reviewer confirms TOKEN-BUDGETS.md sits with NAMING.md + wire-vocab/ as the third cross-MCP discipline doc (not promoted to spec/, not absorbed into Conventions.md).