### PR TITLE
docs(skills/re-frame-pair2): sync preload runtime docstring (rf2-qnls2)

### DIFF
--- a/skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs
+++ b/skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs
@@ -116,7 +116,10 @@
    :operating        (current-frame)})
 
 (defn frames-meta
-  "Frame metadata (config, lifecycle) for `id` — `(rf/frame-meta id)`."
+  "Flat metadata map for frame `id` — `(rf/frame-meta id)`. Returns `:id`,
+   `:created-at`, the preset-expansion keys (`:preset`, `:fx-overrides`,
+   `:drain-depth`, …) and lifecycle fields (`:destroyed?`, `:listeners`)
+   all at the top level. See `:rf/frame-meta` in Spec-Schemas."
   [id]
   (or (rf/frame-meta id)
       {:ok? false :reason :no-such-frame :frame-id id}))


### PR DESCRIPTION
## Summary
- Sync `frames-meta` docstring in `skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs` after rf2-p6f0h flattened `frame-meta` to the canonical `:rf/frame-meta` shape.
- rf2-bba4s (PR #637) updated `SKILL.md`'s `frames/meta` bullet but the dispatcher scoped that PR to `SKILL.md` + `references/`, excluding `preload/` — leaving the runtime docstring stale.
- The docstring now mirrors `SKILL.md`'s wording: a flat top-level map of `:id`, `:created-at`, preset-expansion keys (`:preset`, `:fx-overrides`, `:drain-depth`, …) and lifecycle fields (`:destroyed?`, `:listeners`), with a pointer to `:rf/frame-meta` in Spec-Schemas.

## Test plan
- [ ] Docstring text only — no behaviour change; no tests required.
- [ ] Visual sanity: docstring reads consistently with the SKILL.md `frames/meta` bullet.

Closes rf2-qnls2.