### PR TITLE
docs(skills/re-frame2): sync api-cheatsheet rf/frame-meta row (rf2-v002h)

### DIFF
--- a/skills/re-frame2/reference/cross-cutting/api-cheatsheet.md
+++ b/skills/re-frame2/reference/cross-cutting/api-cheatsheet.md
@@ -119,7 +119,8 @@ One-line signatures for the public `re-frame.core` surface. **For full docstring
 | `rf/clear-event` / `rf/clear-sub` / `rf/clear-fx` / `rf/clear-flow` / `rf/clear-subscription-cache!` | targeted deregistration |
 | `rf/configure` | `(:epoch-history\|:trace-buffer\|:sub-cache opts)` — runtime knobs |
 | `rf/handlers` / `rf/handler-meta` / `rf/handler-ids` / `rf/registry-summary` | registrar reads |
-| `rf/frame-ids` / `rf/frame-meta` / `rf/view` | registry reads |
+| `rf/frame-ids` / `rf/view` | registry reads |
+| `rf/frame-meta` | `(frame-id)` → flat map: `:id` + preset-expansion (`:preset` `:fx-overrides` `:drain-depth` `:doc` `:tags` `:url-bound?` `:platform` `:on-error` …) + lifecycle (`:created-at` `:destroyed?` `:listeners`) — all top-level per Spec-Schemas `:rf/frame-meta` |
 | `rf/sub-cache` (CLJS) / `rf/sub-topology` | dynamic / static sub graph reads |
 
 Optional-artefact surfaces raise `:rf.error/<artefact>-artefact-missing` (registrations / writes) or degrade to `nil`/`[]`/`false` (read-only queries) when the artefact is absent.


### PR DESCRIPTION
## Summary

- rf2-p6f0h flattened `frame-meta`'s return shape; the cheatsheet row in `skills/re-frame2/reference/cross-cutting/api-cheatsheet.md` still grouped `rf/frame-meta` with `frame-ids`/`view` under the vague 'registry reads' caption.
- Split `rf/frame-meta` into its own row that names the canonical flat shape per Spec-Schemas `:rf/frame-meta` — `:id` + preset-expansion (`:preset`, `:fx-overrides`, `:drain-depth`, `:doc`, `:tags`, `:url-bound?`, `:platform`, `:on-error`, …) + lifecycle (`:created-at`, `:destroyed?`, `:listeners`) — all top-level.
- Tiny doc sync; touches only `skills/re-frame2/`.

## Test plan

- [x] Visual diff: only `skills/re-frame2/reference/cross-cutting/api-cheatsheet.md` modified (2 lines).
- [x] Shape matches `spec/Spec-Schemas.md` `:rf/frame-meta` (L2088–2110) and `frame-meta` impl in `implementation/core/src/re_frame/frame.cljc` (L63–81).
- [x] Wording aligns with `skills/re-frame-pair2/SKILL.md:127`, which describes the same flat shape.