### PR TITLE
refactor(mcp): factor mcp-base for shared primitives across triplet (rf2-vw4sq)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1076,6 +1076,50 @@ jobs:
       - name: Run JVM tests (tools/story-mcp artefact)
         run: clojure -M:test
 
+  jvm-tools-mcp-base:
+    name: JVM tools/mcp-base (clojure -M:test)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/mcp-base
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08  # 13.4
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-tools-mcp-base-${{ hashFiles('tools/mcp-base/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-tools-mcp-base-
+            ${{ runner.os }}-clj-
+
+      # tools/mcp-base ships as a `.cljc` library (rf2-vw4sq) shared
+      # across the MCP triplet (pair2-mcp, story-mcp, causa-mcp). The
+      # algorithmic content (sensitive-filter, diff-encode, args
+      # parsers, overflow shape, vocab constants) is platform-agnostic
+      # — a JVM round-trip is the cheapest PR-time gate. Pair2-mcp's
+      # CLJS-side coverage (under `node-test-tools-pair2-mcp` below)
+      # exercises the same primitives via the shadow-cljs compile
+      # path; story-mcp's `jvm-tools-story-mcp` job covers the JVM
+      # consumer.
+      - name: Run JVM tests (tools/mcp-base artefact)
+        run: clojure -M:test
+
   jvm-tools-template:
     name: JVM tools/template (clojure -M:test)
     runs-on: ubuntu-latest

--- a/tools/README.md
+++ b/tools/README.md
@@ -83,6 +83,15 @@ wired into the build, and consumers can use it today.
   timeline, hydration debugger, issues ribbon, AI co-pilot rail. See
   [`tools/causa/spec/000-Vision.md`](./causa/spec/000-Vision.md).
 
+- **`tools/mcp-base/`** — `day8/re-frame2-mcp-base`. Shared primitives
+  for the MCP triplet (`pair2-mcp`, `story-mcp`, `causa-mcp`):
+  wire-vocabulary constants (`:rf.mcp/*`, `:rf.size/*`, JSON-RPC error
+  codes), the spec/009 §Privacy default-suppress filter, MCP argument
+  coercion helpers, the path-keyed structural diff-encode (rf2-1wdzp),
+  and the overflow-marker shape (rf2-rvyzy). Pure `.cljc` with zero
+  runtime deps beyond `org.clojure/clojure`. Per rf2-vw4sq. See
+  [`tools/mcp-base/spec/README.md`](./mcp-base/spec/README.md).
+
 - **`tools/pair2-mcp/`** — `@day8/re-frame-pair2-mcp`. A Node-based
   stdio JSON-RPC **MCP server** (compiled from ClojureScript via
   shadow-cljs) that pair-programs with a live re-frame2 app over a

--- a/tools/mcp-base/deps.edn
+++ b/tools/mcp-base/deps.edn
@@ -1,0 +1,82 @@
+;; day8/re-frame2-mcp-base — shared primitives for the re-frame2 MCP
+;; tool triplet (pair2-mcp, story-mcp, causa-mcp). Filed under rf2-vw4sq.
+;;
+;; ## Why this artefact exists
+;;
+;; The three MCP servers in `tools/` consume the same Spec 009
+;; instrumentation API and emit the same Spec / Conventions wire
+;; vocabulary (`:rf.mcp/*` markers, `:rf.size/*` markers, JSON-RPC
+;; error codes, the spec/009 §Privacy `:sensitive?` default-suppress
+;; filter). Each was implementing those primitives privately; this
+;; jar lifts the genuinely-shared pieces into one place so the wire
+;; shapes stay byte-identical across the triplet and the agent learns
+;; the vocabulary once.
+;;
+;; What lives here:
+;;   - `vocab.cljc`     — cross-MCP wire-vocabulary constants (the
+;;                        `:rf.mcp/*` and `:rf.size/*` namespaced
+;;                        keywords, JSON-RPC error codes).
+;;   - `sensitive.cljc` — spec/009 §Privacy default-suppress filter.
+;;   - `args.cljc`      — argument-coercion helpers (booleans, limits,
+;;                        keyword reading) used by every MCP tool.
+;;   - `diff_encode.cljc` — path-keyed structural diff for epoch
+;;                          records (rf2-1wdzp, used at the wire
+;;                          boundary inside pair2-mcp; the encoding
+;;                          contract is a cross-MCP convention).
+;;   - `overflow.cljc`  — overflow-marker payload builder (rf2-rvyzy).
+;;
+;; What deliberately does NOT live here:
+;;   - Wire-transport code (cheshire JSON for story-mcp's JVM-side;
+;;     applied-science.js-interop / npm MCP SDK for pair2-mcp's
+;;     CLJS-side). Each consumer terminates its own transport.
+;;   - Cursor base64 encoding — `js/Buffer` (pair2-mcp) vs `Base64`
+;;     (story-mcp would use java.util.Base64 if it had cursors). The
+;;     EDN-cursor SHAPE is conventional; the base64 codec is
+;;     consumer-side.
+;;   - Tool registry — each MCP server's tools are domain-specific.
+;;
+;; ## Bundle isolation
+;;
+;; Per `tools/README.md` the dependency arrow flows tool →
+;; implementation (never the reverse). This artefact has no
+;; `:local/root` dep on `implementation/`: its sources are
+;; framework-agnostic `.cljc` shapes (the wire vocabulary, the
+;; predicate, the diff algorithm). Consumers add the impl-side dep
+;; themselves.
+;;
+;; ## CLJC
+;;
+;; Sources are `.cljc` so they load identically into the JVM
+;; classpath (story-mcp, causa-mcp) and the shadow-cljs CLJS build
+;; (pair2-mcp). The tests target Clojure (test runner via
+;; cognitect-labs/test-runner) — the algorithmic content is platform-
+;; agnostic, so a JVM round-trip is the cheapest gate.
+;;
+;; ## Release
+;;
+;; Independent cadence from the consumers; ships as
+;; `day8/re-frame2-mcp-base` on Clojars (workflow rewrites
+;; `:local/root` → `:mvn/version` before invoking clein, mirroring
+;; the adapter jars).
+{:paths ["src"]
+ :deps  {org.clojure/clojure {:mvn/version "1.12.0"}}
+
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps  {io.github.cognitect-labs/test-runner
+                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+         :main-opts   ["-m" "cognitect.test-runner"]}
+
+  ;; Clojars deploy — mirrors tools/story-mcp/deps.edn.
+  :clein {:extra-deps {io.github.noahtheduke/clein
+                       {:git/url "https://github.com/day8/clein.git"
+                        :git/sha "2b83503246e8291fc023d688574640a9b23d8c50"}}
+          :main-opts  ["-m" "noahtheduke.clein"]}
+
+  :clein/build
+  {:lib      day8/re-frame2-mcp-base
+   :url      "https://github.com/day8/re-frame2"
+   :version  "../../VERSION"
+   :license  {:name "MIT"
+              :url  "https://opensource.org/licenses/MIT"}
+   :src-dirs ["src"]}}}

--- a/tools/mcp-base/spec/README.md
+++ b/tools/mcp-base/spec/README.md
@@ -1,0 +1,80 @@
+# `re-frame2-mcp-base` — shared primitives for the MCP triplet
+
+`day8/re-frame2-mcp-base` is the CLJC library that holds the
+genuinely-cross-cutting primitives consumed by every MCP server in
+the re-frame2 tool triplet:
+
+- `tools/pair2-mcp/` (CLJS / Node — runs over nREPL to a browser app)
+- `tools/story-mcp/` (JVM / Clojure — bridges to `tools/story/`)
+- `tools/causa-mcp/` (planned; spec lives at `tools/causa-mcp/spec/`)
+
+The factoring landed under [rf2-vw4sq][bead].
+
+[bead]: https://github.com/day8/re-frame2/issues/rf2-vw4sq
+
+## What lives here
+
+Five small namespaces under `re-frame.mcp-base.*`:
+
+| ns           | Surface                                                        |
+|--------------|----------------------------------------------------------------|
+| `vocab`      | `:rf.mcp/*` / `:rf.size/*` marker keys + JSON-RPC error codes.  |
+| `sensitive`  | spec/009 §Privacy default-suppress filter (`sensitive-event?`, `strip-sensitive`, `scrub-snapshot`). |
+| `args`       | Argument coercion helpers (`parse-boolean`, `parse-positive-int`, `parse-keyword`, `parse-mode`, …). |
+| `diff-encode` | Path-keyed structural diff for epoch records (rf2-1wdzp).      |
+| `overflow`   | Overflow-marker payload builder (rf2-rvyzy).                   |
+
+All `.cljc`, so consumers compile them under their own platform —
+pair2-mcp's shadow-cljs node build, story-mcp / causa-mcp's JVM
+classpath.
+
+## What deliberately does NOT live here
+
+The bead's scope holds the line at primitives that are truly
+identical across the triplet's wire / privacy / size surfaces.
+Three categories stay consumer-side:
+
+1. **Wire transport.** story-mcp uses Cheshire for JSON-RPC over
+   stdin/stdout; pair2-mcp uses the npm `@modelcontextprotocol/sdk`'s
+   stdio transport. The framing is different by language; there's
+   nothing useful to share here.
+
+2. **Cursor base64 codec.** The cursor *shape* (`{:v 1 :after-id ...
+   :ms ... :until-ms ... :frame ...}`) is conventional — but
+   pair2-mcp uses `js/Buffer.from … "base64"` and a JVM consumer
+   would use `java.util.Base64`. Factoring the codec means a
+   protocol-shaped helper per platform; not worth the indirection
+   until causa-mcp lands and demonstrates the third call site.
+
+3. **Tool registries.** Each MCP server's tool catalogue is domain-
+   specific. The base provides building blocks; it does NOT
+   prescribe how the registry is shaped.
+
+## Cross-MCP vocabulary
+
+The `vocab.cljc` ns is the single source of truth for the marker
+keys an agent learns once and recognises across every MCP it talks
+to. A rename here is a wire-protocol break; `vocab_test.clj` fails
+loud when that happens.
+
+The marker family is documented in the consumer-side principles
+files:
+
+- [`tools/pair2-mcp/spec/Principles.md`](../../pair2-mcp/spec/Principles.md)
+- [`tools/causa-mcp/spec/Principles.md`](../../causa-mcp/spec/Principles.md)
+
+## Adding to the base
+
+Two rules:
+
+1. **It must be implemented somewhere already.** This artefact is
+   for factoring duplication, not for landing speculative shared
+   surfaces. New primitives land in a consumer first; if a second
+   consumer needs the same code, lift it then.
+
+2. **It must be pure CLJC with no consumer-side deps.** The base's
+   `deps.edn` carries only `org.clojure/clojure`. If your primitive
+   needs cheshire / re-frame.trace / shadow-cljs / js-interop, it
+   belongs in its consumer, not here. (story-mcp's `sensitive.cljc`
+   ns keeps a thin local alias over `re-frame.trace/sensitive?` for
+   code-review locality — the predicate itself lives here.)

--- a/tools/mcp-base/src/re_frame/mcp_base/args.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/args.cljc
@@ -1,0 +1,137 @@
+(ns re-frame.mcp-base.args
+  "Argument-coercion helpers for MCP tools. The parsers in this ns
+  take an ALREADY-RESOLVED raw value (extracted by the consumer from
+  its platform-specific args object: a JS object for pair2-mcp, a
+  Clojure map for story-mcp/causa-mcp) and normalise it into the
+  Clojure-side type the tool body expects.
+
+  ## Cross-server convention
+
+  Argument names and default postures are a cross-MCP convention. An
+  agent that learns `:dedup` defaults true on pair2-mcp must see the
+  same default everywhere. These parsers encode the defaults so they
+  can't drift across consumers."
+  (:refer-clojure :exclude [parse-boolean])
+  (:require [clojure.string :as str]))
+
+(defn parse-boolean
+  "Normalise a possibly-string MCP arg into a boolean. Accepts
+  booleans (passthrough), strings (`\"true\"`/`\"false\"`/`\"1\"`/
+  `\"0\"`/`\"yes\"`/`\"no\"`, case-insensitive), keywords
+  (`:true`/`:false`), or nil. Unrecognised values fall back to
+  `default`.
+
+  Use a small wrapper at each call-site to bake the default and the
+  rejection posture (default-suppress vs default-allow)."
+  [raw default]
+  (cond
+    (nil? raw)       default
+    (boolean? raw)   raw
+    (= raw :true)    true
+    (= raw :false)   false
+    (string? raw)    (let [s (str/lower-case (str/trim raw))]
+                       (cond
+                         (contains? #{"true" "1" "yes" "y" "on"} s)   true
+                         (contains? #{"false" "0" "no" "n" "off"} s)  false
+                         :else default))
+    :else            default))
+
+(defn parse-positive-int
+  "Normalise a possibly-string MCP arg into a positive integer. Accepts
+  ints (passed through, clamped to ≥1), strings (parsed; non-numeric
+  falls back to `default`), or nil (returns `default`). Non-positive
+  numeric inputs clamp to 1.
+
+  The `default` is the convention's documented cap (e.g. 50 for cursor
+  pagination, 5000 for token caps)."
+  [raw default]
+  (cond
+    (nil? raw)
+    default
+
+    (integer? raw)
+    (max 1 (long raw))
+
+    (number? raw)
+    (let [n (long raw)]
+      (if (zero? n) 1 (max 1 n)))
+
+    (string? raw)
+    #?(:clj (try
+              (max 1 (Long/parseLong (str/trim raw)))
+              (catch NumberFormatException _ default))
+       :cljs (let [n (js/parseInt raw 10)]
+               (if (and (number? n) (not (js/isNaN n)))
+                 (max 1 (long n))
+                 default)))
+
+    :else
+    default))
+
+(defn parse-non-negative-int
+  "Like `parse-positive-int` but admits zero (useful when zero means
+  \"disabled\" — e.g. max-tokens=0 disables the cap)."
+  [raw default]
+  (cond
+    (nil? raw)
+    default
+
+    (integer? raw)
+    (max 0 (long raw))
+
+    (number? raw)
+    (max 0 (long raw))
+
+    (string? raw)
+    #?(:clj (try
+              (max 0 (Long/parseLong (str/trim raw)))
+              (catch NumberFormatException _ default))
+       :cljs (let [n (js/parseInt raw 10)]
+               (if (and (number? n) (not (js/isNaN n)))
+                 (max 0 (long n))
+                 default)))
+
+    :else
+    default))
+
+(defn parse-keyword
+  "Read a keyword from an agent-supplied argument. MCP arguments
+  arrive as JSON, so keyword-typed ids come in as strings. Strips a
+  leading `:` if present (some agents may serialise EDN-ish). Returns
+  nil for nil / blank input.
+
+  Namespaced keywords are supported (`\"ns/name\"` ⇒ `:ns/name`)."
+  [v]
+  (cond
+    (keyword? v) v
+    (nil? v)     nil
+    (string? v)
+    (let [s (if (and (> (count v) 0) (= \: (.charAt ^String v 0)))
+              (subs v 1)
+              v)]
+      (cond
+        (str/blank? s)
+        nil
+
+        (str/includes? s "/")
+        (let [parts (str/split s #"/" 2)]
+          (keyword (first parts) (second parts)))
+
+        :else (keyword s)))
+    :else nil))
+
+(defn parse-mode
+  "Normalise a possibly-string MCP arg into one of a small set of
+  mode keywords. Accepts strings (`\"diff\"`/`\"full\"` etc),
+  keywords (passthrough if recognised), or nil. Unrecognised values
+  fall back to `default`.
+
+  `recognised` is a set of accepted keywords (e.g. `#{:diff :full}`)."
+  [raw default recognised]
+  (cond
+    (nil? raw)              default
+    (contains? recognised raw)   raw
+    (and (string? raw)
+         (contains? recognised (keyword raw)))
+    (keyword raw)
+    :else                   default))

--- a/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
@@ -1,0 +1,166 @@
+(ns re-frame.mcp-base.diff-encode
+  "Path-keyed structural diff for epoch records (rf2-1wdzp).
+
+  ## What this does
+
+  Each `:rf/epoch-record` carries `:db-before` and `:db-after` —
+  near-identical full app-db snapshots. `pr-str` doesn't preserve
+  structural sharing, so on the wire the pair is roughly 2× app-db
+  per epoch; a 50-epoch default `:epochs` slice ⇒ up to 100× app-db.
+
+  The transform replaces `:db-after` with a path-keyed structural diff
+  against `:db-before`:
+
+      {:db-before <full>
+       :db-after  {:rf.mcp/diff-from :db-before
+                   :patches [[<path> :assoc <new-value>]
+                             [<path> :dissoc]]}}
+
+  A patch is a 2- or 3-element vector — `[path :assoc v]` for new /
+  changed leaves, `[path :dissoc]` for keys that disappeared. The
+  decoder applies each patch in order via `assoc-in` / `update-in` to
+  reconstruct `:db-after`.
+
+  ## Self-contained records
+
+  The diff is intra-record (each epoch's `:db-after` is encoded against
+  the SAME record's `:db-before`); records remain self-contained and
+  decodable without reference to siblings. The slice can be reordered,
+  paginated, or filtered without breaking decode.
+
+  ## Why not `clojure.data/diff`
+
+  Its parallel-vector sparse form for vector diffs (with `nil`
+  placeholders meaning \"common at this position\") loses information
+  once you only carry one half plus the original — you can't tell
+  `nil` (the leaf value `nil`) apart from `nil` (the no-change
+  sentinel). Path-keyed patches are unambiguous for any value the
+  runtime can produce.
+
+  ## Cross-MCP vocabulary
+
+  The `:rf.mcp/diff-from` marker key follows the same `:rf.mcp/*`
+  namespace convention as `:rf.mcp/overflow` (rf2-rvyzy),
+  `:rf.mcp/summary` (rf2-tygdv), and causa-mcp's `:rf.mcp/dedup-table`
+  (rf2-lwgg8 mechanism 5). Agents recognise the family once."
+  (:require [re-frame.mcp-base.vocab :as vocab]))
+
+(declare collect-patches)
+
+(defn- collect-map-patches
+  "Generate patches that transform map `a` into map `b` at `path`.
+  Recurses into sub-maps; vectors and scalars are treated as leaves
+  (replaced wholesale via `:assoc` rather than re-diffed element-wise
+  — element-wise vector diff doesn't shrink the wire for the typical
+  app-db where vector values are short)."
+  [a b path]
+  (let [ks (into #{} (concat (keys a) (keys b)))]
+    (reduce
+      (fn [acc k]
+        (let [av (get a k ::absent)
+              bv (get b k ::absent)
+              p  (conj path k)]
+          (cond
+            ;; Key removed.
+            (= bv ::absent)
+            (conj acc [p :dissoc])
+            ;; Key added.
+            (= av ::absent)
+            (conj acc [p :assoc bv])
+            ;; Unchanged — skip.
+            (= av bv)
+            acc
+            ;; Both maps: recurse.
+            (and (map? av) (map? bv))
+            (into acc (collect-patches av bv p))
+            ;; Otherwise: leaf replacement.
+            :else
+            (conj acc [p :assoc bv]))))
+      []
+      ks)))
+
+(defn collect-patches
+  "Patch-list factory. Two maps recurse via `collect-map-patches`; any
+  other shape change is a single root-level `:assoc` replacement.
+  Exposed for tests and for advanced consumers that want to diff
+  arbitrary structures (not just `:db-after` vs `:db-before`)."
+  [a b path]
+  (cond
+    (= a b) []
+    (and (map? a) (map? b)) (collect-map-patches a b path)
+    :else [[path :assoc b]]))
+
+(defn apply-patches
+  "Apply a vector of patches to `base`, returning the reconstructed
+  value. Patches are `[path :assoc v]` or `[path :dissoc]`. Root-path
+  patches (path `[]`) replace `base` outright (for `:assoc`) or are a
+  no-op (for `:dissoc`, by convention)."
+  [base patches]
+  (reduce
+    (fn [acc patch]
+      (let [[path op v] patch]
+        (cond
+          (empty? path)
+          (if (= op :assoc) v acc)
+          (= op :assoc)
+          (assoc-in acc path v)
+          (= op :dissoc)
+          (let [parent-path (vec (butlast path))
+                k           (last path)]
+            (if (empty? parent-path)
+              (dissoc acc k)
+              (update-in acc parent-path dissoc k)))
+          :else acc)))
+    base
+    patches))
+
+(defn diff-encode-db-after
+  "Replace an epoch's `:db-after` with a path-keyed structural diff
+  against its own `:db-before`. Returns the epoch with `:db-after`
+  shaped as `{:rf.mcp/diff-from :db-before :patches [...]}`.
+
+  When `:db-before` is missing (older epoch from a runtime that pruned
+  it, or a synthetic record), the function leaves the epoch unchanged
+  — there's nothing to diff against and silently shipping a half-shape
+  would corrupt the agent's view."
+  [epoch]
+  (if-not (and (map? epoch)
+               (contains? epoch :db-before)
+               (contains? epoch :db-after))
+    epoch
+    (let [patches (collect-patches (:db-before epoch) (:db-after epoch) [])]
+      (assoc epoch :db-after
+             {vocab/diff-from-key :db-before
+              :patches            patches}))))
+
+(defn decode-db-after
+  "Reverse `diff-encode-db-after`. Given an epoch whose `:db-after` is
+  a `{:rf.mcp/diff-from :db-before :patches [...]}` marker, reconstruct
+  the full `:db-after` from the epoch's `:db-before` and the patch list.
+  Idempotent on already-full epochs (the marker check returns the input
+  unchanged when `:db-after` isn't a diff). Provided for agent-host
+  round-trip parity and for the unit tests."
+  [epoch]
+  (let [da (when (map? epoch) (:db-after epoch))]
+    (if-not (and (map? da)
+                 (= :db-before (get da vocab/diff-from-key)))
+      epoch
+      (let [patches   (:patches da)
+            db-before (:db-before epoch)
+            rebuilt   (apply-patches db-before (or patches []))]
+        (assoc epoch :db-after rebuilt)))))
+
+(defn diff-encode-epochs
+  "Apply `diff-encode-db-after` to every epoch in `epochs` unless `mode`
+  is `:full` (in which case the vector passes through unchanged). Each
+  record is encoded against ITS OWN `:db-before` — no cross-record
+  dependency; the slice can be reordered, paginated, or filtered
+  without breaking decode.
+
+  `mode` is one of:
+    :diff — default. Each `:db-after` becomes a structural diff.
+    :full — pass through (legacy behaviour, opt-in)."
+  [epochs mode]
+  (if (= mode :full)
+    epochs
+    (mapv diff-encode-db-after epochs)))

--- a/tools/mcp-base/src/re_frame/mcp_base/overflow.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/overflow.cljc
@@ -1,0 +1,60 @@
+(ns re-frame.mcp-base.overflow
+  "Wire-boundary token-budget cap (rf2-rvyzy) shape builder.
+
+  Per `spec/Principles.md` §Tight token budget per response, every MCP
+  `tools/call` response is bounded at ~5,000 tokens by default. When
+  the serialised response would exceed the cap, the wrapper replaces
+  the payload with a structured `{:rf.mcp/overflow {...}}` marker and
+  emits that instead. Silent truncation is unacceptable — it corrupts
+  the agent's conversation without telling the agent.
+
+  This namespace owns the SHAPE of the marker (so it stays byte-
+  identical across the triplet); the cap-enforcement glue (counting
+  tokens, replacing the payload) lives consumer-side because the
+  payload representation differs (CLJS JS object for pair2-mcp; CLJ
+  map for story-mcp/causa-mcp).
+
+  ## Token rule
+
+  `token-estimate s = (quot (count s) 4)`. Cheap character→token
+  approximation aligned with Anthropic's rule-of-thumb for English /
+  EDN. Not exact; the goal is a bounded wire payload, not a precise
+  meter."
+  (:require [re-frame.mcp-base.vocab :as vocab]))
+
+(def ^:const default-max-tokens
+  "The convention's documented cap. Sized for a typical 5K-token MCP
+  response envelope after diff-encode + dedup. Per rf2-rvyzy."
+  5000)
+
+(defn token-estimate
+  "Cheap character→token approximation: `(quot (count s) 4)`. Aligned
+  with the published Anthropic rule-of-thumb for English / EDN. The
+  goal is a bounded wire payload, not a precise per-token meter."
+  [s]
+  (quot (count s) 4))
+
+(def overflow-hint-fallback
+  "Generic overflow hint used when a tool isn't listed in the per-tool
+  hint table. Re-exported as a default for consumers."
+  "Response over budget. Re-call with narrower args, or raise `max-tokens` (0 disables the cap).")
+
+(defn overflow-payload
+  "Build the structured overflow marker that replaces an over-budget
+  response. Shape is stable per spec/Principles.md §Tight token
+  budget: callers pattern-match on the top-level `:rf.mcp/overflow`
+  key. `:limit :reached` is a fixed sentinel; `:token-count` is the
+  estimate that tripped the cap; `:hint` is tool-specific.
+
+  `opts` keys:
+    :tool        - the tool name (string)
+    :token-count - estimated token count of the over-budget payload
+    :cap         - the cap (tokens)
+    :hint        - tool-specific next-step hint (optional;
+                   `overflow-hint-fallback` if absent)"
+  [{:keys [tool token-count cap hint]}]
+  {vocab/overflow-key {:limit       :reached
+                       :token-count token-count
+                       :cap-tokens  cap
+                       :tool        tool
+                       :hint        (or hint overflow-hint-fallback)}})

--- a/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
@@ -1,0 +1,92 @@
+(ns re-frame.mcp-base.sensitive
+  "Spec/009 §Privacy default-suppress filter for `:sensitive?` trace
+  events.
+
+  ## What spec/009 mandates
+
+  Framework-published forwarders — Sentry / Honeybadger, pair2 server,
+  Story-MCP, Causa-MCP — MUST default-drop trace events whose
+  registration declared `:sensitive? true`. The runtime stamps the
+  flag at the top level of every emitted trace event inside such a
+  registration's handler scope; the forwarder's job is to gate egress
+  on it before any data crosses the trust boundary into the agent
+  surface.
+
+  ## Cross-server convention
+
+  The opt-in arg name (`:include-sensitive?`) is the fixed, cross-
+  server vocabulary an agent learns once. Every MCP tool that surfaces
+  trace-like data MUST accept this arg, default it to false, and feed
+  it to `strip-sensitive` (and any analogous walker that recurses
+  through snapshot slices).
+
+  ## Why this ns is zero-dep
+
+  Pair2-mcp is a CLJS Node bundle (no `re-frame.trace` on its
+  classpath); story-mcp / causa-mcp are JVM-side and DO have the
+  framework primitive available. The predicate itself
+  (`(and (map? ev) (true? (:sensitive? ev)))`) is conservative and
+  identical to `re-frame.trace/sensitive?`; per the spec the runtime
+  always stamps the literal boolean. Consumers that want to bind to
+  the framework primitive (story-mcp does, for code-review locality)
+  alias the surface in their own ns and delegate through here.")
+
+(defn sensitive-event?
+  "Does this event carry the top-level `:sensitive? true` stamp?
+
+  Conservative: only the literal `true` value drops; any other value
+  (including a possible string-coercion via an ill-behaved transport)
+  passes through. The `:rf/trace-event` schema types `:sensitive?` as
+  a boolean (Spec 009 + Spec-Schemas); any other shape is a contract
+  violation we surface rather than silently treat as sensitive."
+  [ev]
+  (and (map? ev)
+       (true? (:sensitive? ev))))
+
+(defn strip-sensitive
+  "Remove `:sensitive? true` events from `events` unless the caller has
+  opted in. Returns `[kept dropped-count]`. Cheap on the common path
+  (no sensitive events ⇒ identical-vector return + zero drop count).
+
+  This is the load-bearing default-suppress filter per spec/009
+  §Privacy. Apply it to any vector of trace-event-shaped maps before
+  the result crosses the MCP boundary into the agent surface."
+  [events include?]
+  (cond
+    include?         [events 0]
+    (empty? events)  [events 0]
+    :else
+    (let [kept (filterv (complement sensitive-event?) events)
+          n    (- (count events) (count kept))]
+      [kept n])))
+
+(defn scrub-snapshot
+  "Walk a per-frame snapshot map and apply `strip-sensitive` to every
+  `:traces` / `:epochs` slice. Returns `[scrubbed-snapshot
+  total-dropped]`. Non-map slices and non-snapshot inputs pass
+  through unchanged.
+
+  Per rf2-zq0n1 / rf2-3cted, sensitive trace events are stripped from
+  `:traces` and `:epochs` but `:app-db`, `:sub-cache`, `:machines`
+  are LEFT ALONE — app-db payload redaction is `with-redacted`'s job
+  at write-time, not the forwarder's job at read-time. Re-asserted
+  by the snapshot-scrubber tests in every MCP that emits per-frame
+  snapshots."
+  [snapshot include?]
+  (if (or include? (not (map? snapshot)))
+    [snapshot 0]
+    (let [dropped (volatile! 0)
+          scrub-slice
+          (fn [items]
+            (let [[kept n] (strip-sensitive (vec items) false)]
+              (vswap! dropped + n)
+              kept))
+          scrub-frame
+          (fn [frame-map]
+            (cond-> frame-map
+              (contains? frame-map :traces) (update :traces scrub-slice)
+              (contains? frame-map :epochs) (update :epochs scrub-slice)))
+          scrubbed (reduce-kv (fn [m k v]
+                                (assoc m k (if (map? v) (scrub-frame v) v)))
+                              {} snapshot)]
+      [scrubbed @dropped])))

--- a/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
@@ -1,0 +1,164 @@
+(ns re-frame.mcp-base.vocab
+  "Cross-MCP wire-vocabulary constants. One place to learn — and pin —
+  the namespaced keys that the agent learns once and recognises across
+  every MCP tool in the re-frame2 triplet (pair2-mcp, story-mcp,
+  causa-mcp).
+
+  ## Why a vocab ns
+
+  Every wire mechanism (overflow cap, cursor pagination, structural
+  dedup, diff-encode, size-elision) decorates the payload with a
+  marker key. The marker keys MUST stay byte-identical across the
+  triplet — an agent that learns `:rf.mcp/overflow` on pair2-mcp must
+  see the same key shape from story-mcp / causa-mcp. Defining the
+  keys here, once, prevents per-consumer drift and gives a single
+  search target when the vocabulary grows.
+
+  ## Two namespaces
+
+  `:rf.mcp/*` — per-tool wire-mechanism markers (overflow, cursor,
+                dedup-table, diff-from, cache-hit, cursor-stale).
+                Owned by the MCP servers; not part of the framework
+                runtime vocabulary.
+
+  `:rf.size/*` — size-elision markers (large-elided, threshold, opts).
+                 Owned jointly with the framework's
+                 `rf/elide-wire-value` walker (Conventions §Reserved
+                 namespaces; Spec 009 §Size elision in traces). The
+                 walker emits the marker; MCP servers re-emit it on
+                 the wire.
+
+  ## JSON-RPC error codes
+
+  Per JSON-RPC 2.0 §5.1 and MCP's reuse of them — the same numeric
+  codes apply across the triplet. Story-mcp emits them via Cheshire;
+  pair2-mcp would emit them via the npm MCP SDK if it surfaced
+  JSON-RPC-level errors directly (today it uses the SDK's
+  `isError: true` tool-result shape, but the codes still pin the
+  cross-consumer protocol if a future bead lifts them).")
+
+;; ---------------------------------------------------------------------------
+;; :rf.mcp/* — per-tool wire mechanism markers
+;; ---------------------------------------------------------------------------
+
+(def overflow-key
+  "Top-level marker on a response that exceeded the per-call token cap.
+  Shape (per pair2-mcp's `apply-cap`):
+    `{:rf.mcp/overflow {:limit :reached :token-count N :cap-tokens M
+                        :tool \"<name>\" :hint \"...\"}}`.
+  Per rf2-rvyzy."
+  :rf.mcp/overflow)
+
+(def dedup-table-key
+  "Top-level marker on a structurally-deduped payload. The value is the
+  de-dupe library's flat cache map; the agent expands locally via
+  `de-dupe.core/expand`.
+  Shape: `{:rf.mcp/dedup-table <cache-map>}`. Per rf2-obpa9.
+
+  causa-mcp uses the same key for its mechanism-5 dedup
+  (cross-MCP-conventions, per causa-mcp/spec/Principles.md §5)."
+  :rf.mcp/dedup-table)
+
+(def diff-from-key
+  "Marker on an epoch's `:db-after` slot indicating it is a structural
+  diff against a sibling slot. The value names the source slot
+  (`:db-before`). Shape:
+    `{:db-after {:rf.mcp/diff-from :db-before :patches [...]}}`.
+  Per rf2-1wdzp."
+  :rf.mcp/diff-from)
+
+(def cursor-stale-reason
+  "Structured error-result `:reason` value indicating the cursor's
+  epoch-id is no longer in the runtime ring. Per rf2-kbqq3.
+
+  Agents pattern-match on this `:reason` to either drop the cursor
+  and restart, or widen the window to recover."
+  :rf.mcp/cursor-stale)
+
+(def cache-hit-key
+  "Top-level marker on a response that short-circuited via the
+  per-session cache (rf2-3rt1f, rf2-36xod). Shape:
+    `{:rf.mcp/cache-hit {:tool ... :digest ... :hint ...}}`. The agent
+  re-uses the previously-shipped payload (the marker is content-free —
+  the agent host correlates by cache key)."
+  :rf.mcp/cache-hit)
+
+(def summary-key
+  "Top-level marker on a lazy-summary response (snapshot mode
+  `:summary`). Per rf2-tygdv / rf2-u2029. Shape:
+    `{:rf.mcp/summary {...tree-summary...}}`. The summary is a
+  deliberately small tree-keyed projection; agents drill in via
+  `get-path` once they know the key of interest."
+  :rf.mcp/summary)
+
+;; ---------------------------------------------------------------------------
+;; :rf.size/* — size-elision markers
+;; ---------------------------------------------------------------------------
+
+(def large-elided-key
+  "Marker substituted for an over-threshold leaf (or a declared-large
+  registry-path) by the framework's `rf/elide-wire-value` walker.
+  Shape (per Spec 009 §Size elision in traces):
+    `{:rf.size/large-elided {:bytes N :type \"...\"
+                             :handle [:rf.elision/at <path>]}}`.
+  Agents drill back into the slot via `get-path` using the handle's
+  path. Reserved per Conventions §Reserved namespaces. Per rf2-urjnc."
+  :rf.size/large-elided)
+
+(def elision-handle-key
+  "First slot in the elision handle vector. The vector shape
+  `[:rf.elision/at <path>]` is the cross-MCP convention for re-fetch
+  by path. Reserved per Conventions §Reserved namespaces."
+  :rf.elision/at)
+
+(def include-large-opt
+  "The framework `rf/elide-wire-value` walker opt that controls
+  whether large leaves emit the marker (`false` ⇒ emit marker;
+  `true` ⇒ pass through). MCP servers surface this as the high-level
+  `:elision` boolean MCP arg; the underlying knob is this."
+  :rf.size/include-large?)
+
+(def include-sensitive-opt
+  "The framework opt that controls whether sensitive payloads emit
+  the marker. Surfaced by MCP servers as the `:include-sensitive?`
+  arg (the same name as the high-level filter — see
+  `re-frame.mcp-base.sensitive`)."
+  :rf.size/include-sensitive?)
+
+(def include-digests-opt
+  "Framework opt: whether elided values include a content digest. Per
+  Spec 009 §Size elision in traces."
+  :rf.size/include-digests?)
+
+(def threshold-bytes-opt
+  "Framework opt: byte threshold above which an auto-detected leaf is
+  elided. Per Spec 009 §Size elision in traces."
+  :rf.size/threshold-bytes)
+
+;; ---------------------------------------------------------------------------
+;; JSON-RPC 2.0 error codes (per §5.1; reused by MCP per the spec)
+;; ---------------------------------------------------------------------------
+
+(def ^:const code-parse-error
+  "Malformed JSON on the wire. JSON-RPC 2.0 §5.1."
+  -32700)
+
+(def ^:const code-invalid-request
+  "Not a valid JSON-RPC request envelope."
+  -32600)
+
+(def ^:const code-method-not-found
+  "Unknown method (or unknown tool, when a `tools/call` resolves to
+  no registered handler)."
+  -32601)
+
+(def ^:const code-invalid-params
+  "Method recognised; params shape wrong."
+  -32602)
+
+(def ^:const code-internal-error
+  "Server-side fault. Tool-execution errors should NOT use this code —
+  they use the MCP tool-result shape with `isError: true` so the agent
+  client can surface the failure to the LLM without aborting the
+  conversation."
+  -32603)

--- a/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
@@ -1,0 +1,114 @@
+(ns re-frame.mcp-base.args-test
+  "Tests for the shared MCP argument-coercion helpers (rf2-vw4sq)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.mcp-base.args :as args]))
+
+;; ---------------------------------------------------------------------------
+;; parse-boolean
+;; ---------------------------------------------------------------------------
+
+(deftest parse-boolean-passthrough
+  (is (true? (args/parse-boolean true false)))
+  (is (false? (args/parse-boolean false true))))
+
+(deftest parse-boolean-nil-returns-default
+  (is (true? (args/parse-boolean nil true)))
+  (is (false? (args/parse-boolean nil false))))
+
+(deftest parse-boolean-recognises-truthy-strings
+  (is (true? (args/parse-boolean "true" false)))
+  (is (true? (args/parse-boolean "TRUE" false)))
+  (is (true? (args/parse-boolean "1" false)))
+  (is (true? (args/parse-boolean "yes" false)))
+  (is (true? (args/parse-boolean "on" false))))
+
+(deftest parse-boolean-recognises-falsy-strings
+  (is (false? (args/parse-boolean "false" true)))
+  (is (false? (args/parse-boolean "0" true)))
+  (is (false? (args/parse-boolean "no" true)))
+  (is (false? (args/parse-boolean "off" true))))
+
+(deftest parse-boolean-recognises-keywords
+  (is (true? (args/parse-boolean :true false)))
+  (is (false? (args/parse-boolean :false true))))
+
+(deftest parse-boolean-unrecognised-falls-back
+  (is (true? (args/parse-boolean "maybe" true)))
+  (is (false? (args/parse-boolean "maybe" false)))
+  (is (true? (args/parse-boolean 42 true))))
+
+;; ---------------------------------------------------------------------------
+;; parse-positive-int
+;; ---------------------------------------------------------------------------
+
+(deftest parse-positive-int-passes-through-ints
+  (is (= 5 (args/parse-positive-int 5 50)))
+  (is (= 100 (args/parse-positive-int 100 50))))
+
+(deftest parse-positive-int-nil-returns-default
+  (is (= 50 (args/parse-positive-int nil 50))))
+
+(deftest parse-positive-int-clamps-non-positive
+  (is (= 1 (args/parse-positive-int 0 50)))
+  (is (= 1 (args/parse-positive-int -5 50))))
+
+(deftest parse-positive-int-parses-strings
+  (is (= 12 (args/parse-positive-int "12" 50)))
+  (is (= 1 (args/parse-positive-int "0" 50))))
+
+(deftest parse-positive-int-non-numeric-string-falls-back
+  (is (= 50 (args/parse-positive-int "abc" 50)))
+  (is (= 50 (args/parse-positive-int "" 50))))
+
+;; ---------------------------------------------------------------------------
+;; parse-non-negative-int
+;; ---------------------------------------------------------------------------
+
+(deftest parse-non-negative-int-admits-zero
+  (is (zero? (args/parse-non-negative-int 0 5000)))
+  (is (zero? (args/parse-non-negative-int "0" 5000))))
+
+(deftest parse-non-negative-int-clamps-negative-to-zero
+  (is (zero? (args/parse-non-negative-int -5 5000))))
+
+;; ---------------------------------------------------------------------------
+;; parse-keyword
+;; ---------------------------------------------------------------------------
+
+(deftest parse-keyword-passes-through-keywords
+  (is (= :foo (args/parse-keyword :foo)))
+  (is (= :ns/foo (args/parse-keyword :ns/foo))))
+
+(deftest parse-keyword-nil-returns-nil
+  (is (nil? (args/parse-keyword nil))))
+
+(deftest parse-keyword-strips-leading-colon
+  (is (= :foo (args/parse-keyword ":foo")))
+  (is (= :ns/foo (args/parse-keyword ":ns/foo"))))
+
+(deftest parse-keyword-parses-namespaced
+  (is (= :rf.assert/path-equals (args/parse-keyword "rf.assert/path-equals")))
+  (is (= :rf.assert/path-equals (args/parse-keyword ":rf.assert/path-equals"))))
+
+(deftest parse-keyword-blank-returns-nil
+  (is (nil? (args/parse-keyword "")))
+  (is (nil? (args/parse-keyword ":"))))
+
+;; ---------------------------------------------------------------------------
+;; parse-mode
+;; ---------------------------------------------------------------------------
+
+(deftest parse-mode-recognised-keyword
+  (is (= :diff (args/parse-mode :diff :diff #{:diff :full})))
+  (is (= :full (args/parse-mode :full :diff #{:diff :full}))))
+
+(deftest parse-mode-recognised-string
+  (is (= :diff (args/parse-mode "diff" :diff #{:diff :full})))
+  (is (= :full (args/parse-mode "full" :diff #{:diff :full}))))
+
+(deftest parse-mode-nil-returns-default
+  (is (= :diff (args/parse-mode nil :diff #{:diff :full}))))
+
+(deftest parse-mode-unrecognised-returns-default
+  (is (= :diff (args/parse-mode "maybe" :diff #{:diff :full})))
+  (is (= :diff (args/parse-mode :unknown :diff #{:diff :full}))))

--- a/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
@@ -1,0 +1,126 @@
+(ns re-frame.mcp-base.diff-encode-test
+  "Tests for the path-keyed structural diff used at the MCP wire
+  boundary (rf2-1wdzp, shared across the triplet via rf2-vw4sq)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.mcp-base.diff-encode :as de]))
+
+;; ---------------------------------------------------------------------------
+;; collect-patches — direct cases.
+;; ---------------------------------------------------------------------------
+
+(deftest collect-patches-empty-when-equal
+  (is (= [] (de/collect-patches {:a 1} {:a 1} []))))
+
+(deftest collect-patches-handles-added-key
+  (is (= [[[:b] :assoc 2]]
+         (de/collect-patches {:a 1} {:a 1 :b 2} []))))
+
+(deftest collect-patches-handles-removed-key
+  (is (= [[[:b] :dissoc]]
+         (de/collect-patches {:a 1 :b 2} {:a 1} []))))
+
+(deftest collect-patches-handles-changed-leaf
+  (is (= [[[:a] :assoc 3]]
+         (de/collect-patches {:a 1} {:a 3} []))))
+
+(deftest collect-patches-recurses-into-nested-maps
+  (let [a {:user {:name "ada" :age 30}}
+        b {:user {:name "ada" :age 31}}]
+    (is (= [[[:user :age] :assoc 31]]
+           (de/collect-patches a b [])))))
+
+(deftest collect-patches-leaf-replacement-for-shape-mismatch
+  (is (= [[[] :assoc [1 2 3]]]
+         (de/collect-patches {:a 1} [1 2 3] [])))
+  (is (= [[[:a] :assoc [1 2 3]]]
+         (de/collect-patches {:a {:b 1}} {:a [1 2 3]} []))))
+
+;; ---------------------------------------------------------------------------
+;; apply-patches — round-trips collect-patches.
+;; ---------------------------------------------------------------------------
+
+(deftest apply-patches-reverses-collect-patches
+  (testing "trivial"
+    (let [a {:a 1}
+          b {:a 1 :b 2}
+          p (de/collect-patches a b [])]
+      (is (= b (de/apply-patches a p)))))
+  (testing "nested + delete + change"
+    (let [a {:user {:name "ada" :age 30} :session :idle}
+          b {:user {:name "ada" :age 31 :role :admin}}
+          p (de/collect-patches a b [])]
+      (is (= b (de/apply-patches a p)))))
+  (testing "shape change at root"
+    (let [a {:a 1}
+          b [1 2 3]
+          p (de/collect-patches a b [])]
+      (is (= b (de/apply-patches a p))))))
+
+(deftest apply-patches-dissoc-at-root-via-direct-path
+  (is (= {:a 1} (de/apply-patches {:a 1 :b 2} [[[:b] :dissoc]]))))
+
+;; ---------------------------------------------------------------------------
+;; diff-encode-db-after / decode-db-after — round-trip.
+;; ---------------------------------------------------------------------------
+
+(deftest diff-encode-db-after-emits-diff-shape
+  (let [epoch    {:db-before {:a 1 :b 2}
+                  :db-after  {:a 1 :b 3}}
+        encoded  (de/diff-encode-db-after epoch)]
+    (is (= :db-before (get-in encoded [:db-after :rf.mcp/diff-from])))
+    (is (vector? (get-in encoded [:db-after :patches])))
+    (is (= [[[:b] :assoc 3]] (get-in encoded [:db-after :patches])))))
+
+(deftest diff-encode-then-decode-restores-original
+  (let [epoch   {:db-before {:user {:name "ada" :age 30}
+                             :session :idle}
+                 :db-after  {:user {:name "ada" :age 31 :role :admin}}
+                 :event     [:user/birthday]}
+        encoded (de/diff-encode-db-after epoch)
+        decoded (de/decode-db-after encoded)]
+    (is (= epoch decoded))))
+
+(deftest diff-encode-db-after-passes-through-when-missing-halves
+  (testing "missing db-before"
+    (let [epoch {:db-after {:x 1}}]
+      (is (= epoch (de/diff-encode-db-after epoch)))))
+  (testing "missing db-after"
+    (let [epoch {:db-before {:x 1}}]
+      (is (= epoch (de/diff-encode-db-after epoch)))))
+  (testing "non-map epoch"
+    (is (= [1 2 3] (de/diff-encode-db-after [1 2 3])))))
+
+(deftest decode-db-after-passes-through-when-not-a-diff
+  ;; Already-full epoch (no marker) decodes to itself.
+  (let [epoch {:db-before {:a 1} :db-after {:a 1 :b 2}}]
+    (is (= epoch (de/decode-db-after epoch)))))
+
+;; ---------------------------------------------------------------------------
+;; diff-encode-epochs — vector form + mode toggle.
+;; ---------------------------------------------------------------------------
+
+(deftest diff-encode-epochs-diff-mode-encodes-each-record
+  (let [epochs [{:db-before {:a 1} :db-after {:a 2}}
+                {:db-before {:b 1} :db-after {:b 2}}]
+        out    (de/diff-encode-epochs epochs :diff)]
+    (is (= 2 (count out)))
+    (is (= :db-before (get-in (first out) [:db-after :rf.mcp/diff-from])))
+    (is (= :db-before (get-in (second out) [:db-after :rf.mcp/diff-from])))))
+
+(deftest diff-encode-epochs-full-mode-is-passthrough
+  (let [epochs [{:db-before {:a 1} :db-after {:a 2}}]]
+    (is (= epochs (de/diff-encode-epochs epochs :full)))))
+
+(deftest diff-encode-epochs-each-record-self-contained
+  ;; The slice can be reordered, paginated, or filtered without
+  ;; breaking decode — every record carries its own :db-before so it
+  ;; round-trips standalone.
+  (let [epochs [{:db-before {:a 1} :db-after {:a 2}}
+                {:db-before {:b 1} :db-after {:b 2}}]
+        out    (de/diff-encode-epochs epochs :diff)
+        reversed (vec (reverse out))]
+    (doseq [enc reversed]
+      (let [dec (de/decode-db-after enc)]
+        (is (= (dissoc enc :db-after :patches)
+               (dissoc dec :db-after))
+            "non-:db-after fields unchanged on decode")))))

--- a/tools/mcp-base/test/re_frame/mcp_base/overflow_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/overflow_test.clj
@@ -1,0 +1,35 @@
+(ns re-frame.mcp-base.overflow-test
+  "Tests for the overflow-marker shape (rf2-rvyzy / rf2-vw4sq)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.mcp-base.overflow :as overflow]
+            [re-frame.mcp-base.vocab :as vocab]))
+
+(deftest token-estimate-quarter-rule
+  (is (zero? (overflow/token-estimate "")))
+  (is (zero? (overflow/token-estimate "abc")))
+  (is (= 1 (overflow/token-estimate "abcd")))
+  (is (= 25 (overflow/token-estimate (apply str (repeat 100 \x))))))
+
+(deftest overflow-payload-shape
+  (let [payload (overflow/overflow-payload {:tool "snapshot" :token-count 6000 :cap 5000})]
+    (is (contains? payload vocab/overflow-key))
+    (let [body (get payload vocab/overflow-key)]
+      (is (= :reached (:limit body)))
+      (is (= 6000 (:token-count body)))
+      (is (= 5000 (:cap-tokens body)))
+      (is (= "snapshot" (:tool body)))
+      (is (string? (:hint body))))))
+
+(deftest overflow-payload-uses-fallback-hint-when-absent
+  (let [p (overflow/overflow-payload {:tool "unknown-tool" :token-count 6000 :cap 5000})]
+    (is (= overflow/overflow-hint-fallback
+           (get-in p [vocab/overflow-key :hint])))))
+
+(deftest overflow-payload-uses-explicit-hint
+  (let [p (overflow/overflow-payload {:tool "snapshot" :token-count 6000 :cap 5000
+                                      :hint "tighten the path"})]
+    (is (= "tighten the path"
+           (get-in p [vocab/overflow-key :hint])))))
+
+(deftest default-max-tokens-pinned
+  (is (= 5000 overflow/default-max-tokens)))

--- a/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
@@ -1,0 +1,145 @@
+(ns re-frame.mcp-base.sensitive-test
+  "Tests for the spec/009 §Privacy default-suppress filter shared
+  across the MCP triplet (rf2-vw4sq). The predicate and the filter
+  must stay byte-identical across pair2-mcp, story-mcp, and causa-mcp
+  — these tests pin the contract."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.mcp-base.sensitive :as sensitive]))
+
+;; ---------------------------------------------------------------------------
+;; sensitive-event? — the boolean predicate.
+;; ---------------------------------------------------------------------------
+
+(deftest sensitive-event?-true-stamp-detected
+  (is (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? true})))
+
+(deftest sensitive-event?-false-stamp-passes
+  (is (not (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? false}))))
+
+(deftest sensitive-event?-absent-stamp-passes
+  ;; Per spec/009: "Consumers treat absent as `false`."
+  (is (not (sensitive/sensitive-event? {:operation :event/dispatched}))))
+
+(deftest sensitive-event?-non-true-truthy-passes
+  ;; Conservative: only the literal `true` triggers the drop. A string
+  ;; or non-boolean value passes through (the `:rf/trace-event` schema
+  ;; types `:sensitive?` as a boolean — any other value is a contract
+  ;; violation we surface rather than silently treat as sensitive).
+  (is (not (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? "true"})))
+  (is (not (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? :yes}))))
+
+(deftest sensitive-event?-non-map-input-passes
+  (is (not (sensitive/sensitive-event? nil)))
+  (is (not (sensitive/sensitive-event? [:sensitive? true])))
+  (is (not (sensitive/sensitive-event? "anything"))))
+
+;; ---------------------------------------------------------------------------
+;; strip-sensitive — the default-suppress filter applied per batch.
+;; ---------------------------------------------------------------------------
+
+(deftest strip-sensitive-default-drops-true-stamps
+  (let [evts [{:id 1 :sensitive? false}
+              {:id 2 :sensitive? true}
+              {:id 3}
+              {:id 4 :sensitive? true}]
+        [kept dropped] (sensitive/strip-sensitive evts false)]
+    (is (= [{:id 1 :sensitive? false} {:id 3}] kept))
+    (is (= 2 dropped))))
+
+(deftest strip-sensitive-include-opt-in-passes-everything
+  (let [evts [{:id 1 :sensitive? true}
+              {:id 2 :sensitive? false}
+              {:id 3 :sensitive? true}]
+        [kept dropped] (sensitive/strip-sensitive evts true)]
+    (is (= evts kept))
+    (is (zero? dropped))))
+
+(deftest strip-sensitive-empty-batch-zero-overhead
+  (let [[kept dropped] (sensitive/strip-sensitive [] false)]
+    (is (= [] kept))
+    (is (zero? dropped))))
+
+(deftest strip-sensitive-no-sensitive-events-zero-drop
+  (let [evts [{:id 1} {:id 2 :sensitive? false} {:id 3}]
+        [kept dropped] (sensitive/strip-sensitive evts false)]
+    (is (= evts kept))
+    (is (zero? dropped))))
+
+(deftest strip-sensitive-all-sensitive-drops-all
+  (let [evts [{:id 1 :sensitive? true}
+              {:id 2 :sensitive? true}
+              {:id 3 :sensitive? true}]
+        [kept dropped] (sensitive/strip-sensitive evts false)]
+    (is (= [] kept))
+    (is (= 3 dropped))))
+
+;; ---------------------------------------------------------------------------
+;; Default posture — the load-bearing assertion for the spec/009 MUST.
+;; ---------------------------------------------------------------------------
+
+(deftest spec-009-default-posture-is-suppress
+  (testing "the default (include-sensitive? omitted ⇒ false) suppresses"
+    (let [sensitive-batch [{:operation :event/dispatched
+                            :tags      {:event-id :auth/sign-in}
+                            :sensitive? true}]
+          [kept dropped] (sensitive/strip-sensitive sensitive-batch false)]
+      (is (= [] kept) "sensitive event must NOT reach the agent surface by default")
+      (is (= 1 dropped))))
+  (testing "include-sensitive? true is the documented opt-in"
+    (let [sensitive-batch [{:operation :event/dispatched
+                            :tags      {:event-id :auth/sign-in}
+                            :sensitive? true}]
+          [kept dropped] (sensitive/strip-sensitive sensitive-batch true)]
+      (is (= sensitive-batch kept))
+      (is (zero? dropped)))))
+
+;; ---------------------------------------------------------------------------
+;; scrub-snapshot — strip sensitive trace events from per-frame slices.
+;; ---------------------------------------------------------------------------
+
+(deftest scrub-snapshot-strips-sensitive-from-traces
+  (let [snap {:rf/default
+              {:app-db  {:user/name "ada" :password "secret"}
+               :traces  [{:id 1 :sensitive? false}
+                         {:id 2 :sensitive? true}
+                         {:id 3}]
+               :epochs  [{:event-id :foo} {:event-id :auth/sign-in :sensitive? true}]
+               :machines {}}
+              :stories
+              {:app-db {} :traces [{:id 10 :sensitive? true}]}}
+        [out dropped] (sensitive/scrub-snapshot snap false)]
+    (is (= 3 dropped))
+    (is (= [{:id 1 :sensitive? false} {:id 3}]
+           (get-in out [:rf/default :traces])))
+    (is (= [{:event-id :foo}]
+           (get-in out [:rf/default :epochs])))
+    (is (= [] (get-in out [:stories :traces])))))
+
+(deftest scrub-snapshot-leaves-non-trace-slices-alone
+  ;; App-db payload redaction is `with-redacted`'s job, not the
+  ;; forwarder's. The scrubber must NOT touch :app-db / :sub-cache /
+  ;; :machines even when they carry literal "sensitive"-looking shapes.
+  (let [snap {:rf/default
+              {:app-db    {:password "still-here" :sensitive? true}
+               :sub-cache {:user/profile {:sensitive? true :data "x"}}
+               :machines  {:auth {:state :idle}}
+               :traces    [{:id 1}]}}
+        [out _] (sensitive/scrub-snapshot snap false)]
+    (is (= {:password "still-here" :sensitive? true}
+           (get-in out [:rf/default :app-db])))
+    (is (= {:user/profile {:sensitive? true :data "x"}}
+           (get-in out [:rf/default :sub-cache])))
+    (is (= {:auth {:state :idle}}
+           (get-in out [:rf/default :machines])))))
+
+(deftest scrub-snapshot-include-opt-in-passes-everything
+  (let [snap {:rf/default {:traces [{:id 1 :sensitive? true}
+                                    {:id 2 :sensitive? true}]}}
+        [out dropped] (sensitive/scrub-snapshot snap true)]
+    (is (= snap out))
+    (is (zero? dropped))))
+
+(deftest scrub-snapshot-non-map-input-passes-through
+  (let [[out dropped] (sensitive/scrub-snapshot nil false)]
+    (is (nil? out))
+    (is (zero? dropped))))

--- a/tools/mcp-base/test/re_frame/mcp_base/vocab_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/vocab_test.clj
@@ -1,0 +1,29 @@
+(ns re-frame.mcp-base.vocab-test
+  "Pins the wire-vocabulary constants (rf2-vw4sq). The marker keys are
+  the cross-MCP convention that an agent learns once — a rename here
+  is a wire-protocol break. These tests fail loud when that happens."
+  (:require [clojure.test :refer [deftest is]]
+            [re-frame.mcp-base.vocab :as vocab]))
+
+(deftest rf-mcp-marker-keys-pinned
+  (is (= :rf.mcp/overflow      vocab/overflow-key))
+  (is (= :rf.mcp/dedup-table   vocab/dedup-table-key))
+  (is (= :rf.mcp/diff-from     vocab/diff-from-key))
+  (is (= :rf.mcp/cursor-stale  vocab/cursor-stale-reason))
+  (is (= :rf.mcp/cache-hit     vocab/cache-hit-key))
+  (is (= :rf.mcp/summary       vocab/summary-key)))
+
+(deftest rf-size-elision-keys-pinned
+  (is (= :rf.size/large-elided        vocab/large-elided-key))
+  (is (= :rf.elision/at               vocab/elision-handle-key))
+  (is (= :rf.size/include-large?      vocab/include-large-opt))
+  (is (= :rf.size/include-sensitive?  vocab/include-sensitive-opt))
+  (is (= :rf.size/include-digests?    vocab/include-digests-opt))
+  (is (= :rf.size/threshold-bytes     vocab/threshold-bytes-opt)))
+
+(deftest jsonrpc-error-codes-pinned
+  (is (= -32700 vocab/code-parse-error))
+  (is (= -32600 vocab/code-invalid-request))
+  (is (= -32601 vocab/code-method-not-found))
+  (is (= -32602 vocab/code-invalid-params))
+  (is (= -32603 vocab/code-internal-error)))

--- a/tools/pair2-mcp/deps.edn
+++ b/tools/pair2-mcp/deps.edn
@@ -52,6 +52,13 @@
          org.clojure/clojurescript {:mvn/version "1.12.145"}
          applied-science/js-interop {:mvn/version "0.4.2"}
          thheller/shadow-cljs      {:mvn/version "3.4.10"}
+
+         ;; Shared MCP primitives across the triplet (pair2-mcp,
+         ;; story-mcp, causa-mcp): wire vocabulary, the spec/009
+         ;; default-suppress filter, the path-keyed diff-encode, and
+         ;; the overflow-marker shape. Per rf2-vw4sq.
+         day8/re-frame2-mcp-base  {:local/root "../mcp-base"}
+
          ;; day8/de-dupe — structural dedup of persistent data structures
          ;; (rf2-obpa9). The library substitutes repeated subtrees with
          ;; namespaced-symbol references (`de-dupe.cache/cache-N`); the

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -60,7 +60,16 @@
             [clojure.string :as str]
             [de-dupe.core :as dedup]
             [re-frame-pair2-mcp.cache :as cache]
-            [re-frame-pair2-mcp.nrepl :as nrepl]))
+            [re-frame-pair2-mcp.nrepl :as nrepl]
+            ;; rf2-vw4sq — shared MCP primitives. The wire-vocabulary
+            ;; keys, the spec/009 default-suppress filter, the
+            ;; argument-coercion helpers, the path-keyed diff-encode,
+            ;; and the overflow-marker shape are all in the base now.
+            [re-frame.mcp-base.args :as base-args]
+            [re-frame.mcp-base.diff-encode :as base-diff]
+            [re-frame.mcp-base.overflow :as base-overflow]
+            [re-frame.mcp-base.sensitive :as base-sensitive]
+            [re-frame.mcp-base.vocab :as base-vocab]))
 
 ;; ---------------------------------------------------------------------------
 ;; Config — build id.
@@ -126,14 +135,16 @@
 ;;   each tool's internals.
 ;; ---------------------------------------------------------------------------
 
-(def ^:private default-max-tokens 5000)
+;; `default-max-tokens` and `token-estimate` come from
+;; `re-frame.mcp-base.overflow` (rf2-vw4sq) — the cap value and the
+;; character→token approximation are cross-MCP conventions, pinned
+;; once in the base.
+(def ^:private default-max-tokens base-overflow/default-max-tokens)
 
 (defn- token-estimate
-  "Cheap character→token approximation: `(quot (count s) 4)`. Aligned
-  with the published Anthropic rule-of-thumb for English / EDN. The
-  goal is a bounded wire payload, not a precise per-token meter."
+  "Delegates to `base-overflow/token-estimate`."
   [s]
-  (quot (count s) 4))
+  (base-overflow/token-estimate s))
 
 (defn- max-tokens-arg
   "Resolve the per-call cap from MCP args. Returns the integer cap in
@@ -159,21 +170,21 @@
    "discover-app"  "Unusual — the health summary should be small. Inspect `(re-frame-pair2.runtime/health)` directly via `eval-cljs` with a projection."
    "dispatch"      "Trace mode is returning a full epoch — re-run with `trace false` and read the epoch via `watch-epochs`/`snapshot` with a narrower path."})
 
-(def ^:private overflow-hint-fallback
-  "Response over budget. Re-call with narrower args, or raise `max-tokens` (0 disables the cap).")
+;; The fallback string lives in `re-frame.mcp-base.overflow` so the
+;; cross-MCP marker presents identically. Re-exported here to avoid
+;; touching the every-call-site `get overflow-hints` usage.
+(def ^:private overflow-hint-fallback base-overflow/overflow-hint-fallback)
 
 (defn- overflow-payload
-  "Build the structured overflow marker that replaces an over-budget
-  response. Shape is stable per spec/Principles.md §Tight token
-  budget: callers pattern-match on the top-level `:rf.mcp/overflow`
-  key. `:limit :reached` is a fixed sentinel; `:token-count` is the
-  estimate that tripped the cap; `:hint` is tool-specific."
+  "Build the structured overflow marker. Shape lives in
+  `re-frame.mcp-base.overflow/overflow-payload` (rf2-vw4sq); per-tool
+  hint table stays local."
   [{:keys [tool token-count cap]}]
-  {:rf.mcp/overflow {:limit       :reached
-                     :token-count token-count
-                     :cap-tokens  cap
-                     :tool        tool
-                     :hint        (get overflow-hints tool overflow-hint-fallback)}})
+  (base-overflow/overflow-payload
+    {:tool        tool
+     :token-count token-count
+     :cap         cap
+     :hint        (get overflow-hints tool overflow-hint-fallback)}))
 
 (defn- sum-text-tokens
   "Sum `token-estimate` across every `:text` slot in the MCP
@@ -273,137 +284,26 @@
 ;; (rf2-lwgg8 mechanism 5). Agents recognise the family once.
 ;; ---------------------------------------------------------------------------
 
-(declare collect-patches)
-
-(defn- collect-map-patches
-  "Generate patches that transform map `a` into map `b` at `path`.
-  Recurses into sub-maps; vectors and scalars are treated as leaves
-  (replaced wholesale via `:assoc` rather than re-diffed element-wise
-  — element-wise vector diff doesn't shrink the wire for the typical
-  app-db where vector values are short)."
-  [a b path]
-  (let [ks (into #{} (concat (keys a) (keys b)))]
-    (reduce
-      (fn [acc k]
-        (let [av (get a k ::absent)
-              bv (get b k ::absent)
-              p  (conj path k)]
-          (cond
-            ;; Key removed.
-            (= bv ::absent)
-            (conj acc [p :dissoc])
-            ;; Key added.
-            (= av ::absent)
-            (conj acc [p :assoc bv])
-            ;; Unchanged — skip.
-            (= av bv)
-            acc
-            ;; Both maps: recurse.
-            (and (map? av) (map? bv))
-            (into acc (collect-patches av bv p))
-            ;; Otherwise: leaf replacement.
-            :else
-            (conj acc [p :assoc bv]))))
-      []
-      ks)))
-
-(defn- collect-patches
-  "Patch-list factory. Two maps recurse via `collect-map-patches`; any
-  other shape change is a single root-level `:assoc` replacement."
-  [a b path]
-  (cond
-    (= a b) []
-    (and (map? a) (map? b)) (collect-map-patches a b path)
-    :else [[path :assoc b]]))
-
-(defn- apply-patches
-  "Apply a vector of patches to `base`, returning the reconstructed
-  value. Patches are `[path :assoc v]` or `[path :dissoc]`. Root-path
-  patches (path `[]`) replace `base` outright (for `:assoc`) or are a
-  no-op (for `:dissoc`, by convention)."
-  [base patches]
-  (reduce
-    (fn [acc patch]
-      (let [[path op v] patch]
-        (cond
-          (empty? path)
-          (if (= op :assoc) v acc)
-          (= op :assoc)
-          (assoc-in acc path v)
-          (= op :dissoc)
-          (let [parent-path (vec (butlast path))
-                k           (last path)]
-            (if (empty? parent-path)
-              (dissoc acc k)
-              (update-in acc parent-path dissoc k)))
-          :else acc)))
-    base
-    patches))
+;; Diff-encode helpers all live in `re-frame.mcp-base.diff-encode`
+;; (rf2-vw4sq). Local names are retained as thin aliases so the
+;; call-sites below stay readable without sprinkling `base-diff/` at
+;; every use.
 
 (defn- diff-encode-db-after
-  "Replace an epoch's `:db-after` with a path-keyed structural diff
-  against its own `:db-before`. Returns the epoch with `:db-after`
-  shaped as `{:rf.mcp/diff-from :db-before :patches [...]}`.
-
-  When `:db-before` is missing (older epoch from a runtime that
-  pruned it, or a synthetic record), the function leaves the epoch
-  unchanged — there's nothing to diff against and silently shipping a
-  half-shape would corrupt the agent's view."
+  "Delegates to `re-frame.mcp-base.diff-encode/diff-encode-db-after`."
   [epoch]
-  (if-not (and (map? epoch)
-               (contains? epoch :db-before)
-               (contains? epoch :db-after))
-    epoch
-    (let [patches (collect-patches (:db-before epoch) (:db-after epoch) [])]
-      (assoc epoch :db-after
-             {:rf.mcp/diff-from :db-before
-              :patches          patches}))))
-
-(defn- decode-db-after
-  "Reverse `diff-encode-db-after`. Given an epoch whose `:db-after` is
-  a `{:rf.mcp/diff-from :db-before :patches [...]}` marker,
-  reconstruct the full `:db-after` from the epoch's `:db-before` and
-  the patch list. Idempotent on already-full epochs (the marker check
-  returns the input unchanged when `:db-after` isn't a diff).
-  Provided for agent-host round-trip parity and for the unit tests."
-  [epoch]
-  (let [da (when (map? epoch) (:db-after epoch))]
-    (if-not (and (map? da)
-                 (= :db-before (:rf.mcp/diff-from da)))
-      epoch
-      (let [patches   (:patches da)
-            db-before (:db-before epoch)
-            rebuilt   (apply-patches db-before (or patches []))]
-        (assoc epoch :db-after rebuilt)))))
+  (base-diff/diff-encode-db-after epoch))
 
 (defn- diff-encode-epochs
-  "Apply `diff-encode-db-after` to every epoch in `epochs` unless
-  `mode` is `:full` (in which case the vector passes through
-  unchanged). Each record is encoded against ITS OWN `:db-before` —
-  no cross-record dependency; the slice can be reordered, paginated,
-  or filtered without breaking decode.
-
-  `mode` is one of:
-    :diff — default. Each `:db-after` becomes a structural diff.
-    :full — pass through (legacy behaviour, opt-in)."
+  "Delegates to `re-frame.mcp-base.diff-encode/diff-encode-epochs`."
   [epochs mode]
-  (if (= mode :full)
-    epochs
-    (mapv diff-encode-db-after epochs)))
+  (base-diff/diff-encode-epochs epochs mode))
 
 (defn- parse-epochs-mode
-  "Normalise the `epochs-mode` MCP arg into the keyword the encoder
-  expects. Accepts strings (`\"diff\"` / `\"full\"`), keywords
-  (`:diff` / `:full`), or nil (default `:diff`). Unrecognised values
-  fall back to `:diff` — least surprise on a budget-sensitive default."
+  "Normalise the `epochs-mode` MCP arg. Delegates to
+  `re-frame.mcp-base.args/parse-mode` (rf2-vw4sq)."
   [raw]
-  (cond
-    (nil? raw)         :diff
-    (= raw :full)      :full
-    (= raw "full")     :full
-    (= raw :diff)      :diff
-    (= raw "diff")     :diff
-    :else              :diff))
+  (base-args/parse-mode raw :diff #{:diff :full}))
 
 ;; ---------------------------------------------------------------------------
 ;; Structural dedup at the wire boundary (rf2-obpa9).
@@ -486,20 +386,11 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- parse-dedup-arg
-  "Normalise the `dedup` MCP arg into a boolean. Accepts booleans,
-  strings (`\"true\"`/`\"false\"`), keywords (`:true`/`:false`), or
-  nil (default `true`). Unrecognised values default to `true` —
-  the budget-sensitive default fires dedup."
+  "Normalise the `dedup` MCP arg into a boolean. Default `true` —
+  the budget-sensitive default fires dedup. Delegates to
+  `re-frame.mcp-base.args/parse-boolean` (rf2-vw4sq)."
   [raw]
-  (cond
-    (nil? raw)             true
-    (true? raw)            true
-    (false? raw)           false
-    (= raw "false")        false
-    (= raw :false)         false
-    (= raw "true")         true
-    (= raw :true)          true
-    :else                  true))
+  (base-args/parse-boolean raw true))
 
 (defn- empty-payload?
   "True for values where dedup yields no win — nil, empty collections,
@@ -512,15 +403,15 @@
 
 (defn- dedup-value
   "Apply structural dedup to `v` and wrap the result in the cross-MCP
-  marker. Returns `v` unchanged when `enabled?` is false or when
-  `v` is empty / scalar (no dedup opportunity). Uses `de-dupe-eq`
-  (equality-based) — see the section header for the identity-vs-equality
-  rationale."
+  marker (`base-vocab/dedup-table-key` — rf2-vw4sq). Returns `v`
+  unchanged when `enabled?` is false or when `v` is empty / scalar
+  (no dedup opportunity). Uses `de-dupe-eq` (equality-based) — see
+  the section header for the identity-vs-equality rationale."
   [v enabled?]
   (if (or (not enabled?) (empty-payload? v))
     v
     (let [cache (dedup/de-dupe-eq v)]
-      {:rf.mcp/dedup-table cache})))
+      {base-vocab/dedup-table-key cache})))
 
 (defn- dedup-expand
   "Reverse `dedup-value`. Given a value possibly wrapped in the
@@ -530,8 +421,8 @@
   isn't present). Provided for round-trip parity and for the unit
   tests; the agent host can call the same shape locally."
   [v]
-  (if (and (map? v) (contains? v :rf.mcp/dedup-table))
-    (dedup/expand (:rf.mcp/dedup-table v))
+  (if (and (map? v) (contains? v base-vocab/dedup-table-key))
+    (dedup/expand (get v base-vocab/dedup-table-key))
     v))
 
 ;; ---------------------------------------------------------------------------
@@ -611,31 +502,22 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- parse-elision-arg
-  "Normalise the `elision` MCP arg into a boolean. Accepts booleans,
-  strings (`\"true\"`/`\"false\"`), keywords (`:true`/`:false`), or
-  nil (default `true`). Unrecognised values default to `true` —
-  least-surprise on the budget-sensitive default fires elision."
+  "Normalise the `elision` MCP arg into a boolean. Default `true` —
+  least-surprise on the budget-sensitive default fires elision.
+  Delegates to `re-frame.mcp-base.args/parse-boolean` (rf2-vw4sq)."
   [raw]
-  (cond
-    (nil? raw)             true
-    (true? raw)            true
-    (false? raw)           false
-    (= raw "false")        false
-    (= raw :false)         false
-    (= raw "true")         true
-    (= raw :true)          true
-    :else                  true))
+  (base-args/parse-boolean raw true))
 
 (defn- elision-opts-edn
   "Render the elision opts map as an EDN string for inlining into a
   CLJS eval form sent over nREPL. Today the only knob is the
-  on/off boolean (`:rf.size/include-large?`): when elision is enabled
-  we pass `{:rf.size/include-large? false}` so the walker emits
-  markers; when disabled we set `:rf.size/include-large? true` so
-  values pass through unmodified. `:frame` and `:path` are
+  on/off boolean (`base-vocab/include-large-opt`): when elision is
+  enabled we pass `{:rf.size/include-large? false}` so the walker
+  emits markers; when disabled we set `:rf.size/include-large? true`
+  so values pass through unmodified. `:frame` and `:path` are
   caller-supplied at the call-site inside the form."
   [enabled?]
-  (pr-str {:rf.size/include-large? (not enabled?)}))
+  (pr-str {base-vocab/include-large-opt (not enabled?)}))
 
 ;; ---------------------------------------------------------------------------
 ;; Preload probe.
@@ -711,19 +593,17 @@
 
 (defn- include-sensitive?
   "True iff the caller has opted in to forwarding `:sensitive? true`
-  events for this call. Default off."
+  events for this call. Default off. The arg name
+  `:include-sensitive?` is the cross-MCP convention (rf2-vw4sq)."
   [args]
   (boolean (arg args :include-sensitive?)))
 
 (defn- sensitive-event?
-  "Does this event carry the top-level `:sensitive? true` stamp? The
-  filter is conservative — only the literal `true` value drops; any
-  other value (including the runtime's possible string-coercion via an
-  ill-behaved transport) passes through. The `:rf/trace-event` schema
-  (per spec/009) types `:sensitive?` as a boolean."
+  "Delegates to `re-frame.mcp-base.sensitive/sensitive-event?`
+  (rf2-vw4sq). The predicate is the conservative spec/009 stamp
+  check: only the literal `true` value drops."
   [ev]
-  (and (map? ev)
-       (true? (:sensitive? ev))))
+  (base-sensitive/sensitive-event? ev))
 
 (defn- sensitive-epoch?
   "Does this epoch record carry — or transitively contain — a
@@ -759,7 +639,13 @@
   has no `:trace-events` slot so `sensitive-epoch?` collapses to the
   same `:sensitive?` top-level check; an epoch record with a
   sensitive constituent trace event drops even if its top-level
-  rollup is absent."
+  rollup is absent.
+
+  Cross-MCP factoring (rf2-vw4sq): the predicate `sensitive-event?`
+  delegates to `re-frame.mcp-base.sensitive`. The epoch-level union
+  check is pair2-mcp-specific (story-mcp doesn't emit epoch records);
+  the trace-event-only `strip-sensitive` in the base is the right fit
+  for story-mcp / causa-mcp consumers."
   [items include?]
   (cond
     include?            [items 0]
@@ -839,19 +725,11 @@
   50)
 
 (defn- parse-limit-arg
-  "Normalise the `:limit` MCP arg into a positive integer. Accepts ints
-  (passed through), strings (parsed), or nil (default 50). Non-positive
-  values clamp to 1; non-numeric falls back to default. The cap is a
-  guarantee — the response will never contain more than `limit` items."
+  "Normalise the `:limit` MCP arg into a positive integer. Default
+  `default-limit` (50). Delegates to
+  `re-frame.mcp-base.args/parse-positive-int` (rf2-vw4sq)."
   [raw]
-  (cond
-    (or (nil? raw) (undefined? raw)) default-limit
-    (number? raw) (max 1 (long raw))
-    (string? raw) (let [n (js/parseInt raw 10)]
-                    (if (and (number? n) (not (js/isNaN n)))
-                      (max 1 (long n))
-                      default-limit))
-    :else default-limit))
+  (base-args/parse-positive-int raw default-limit))
 
 (defn- encode-cursor
   "Encode a cursor payload as a base64 string. Returns nil on a nil/empty
@@ -884,12 +762,13 @@
       (catch :default _ ::malformed))))
 
 (defn- cursor-stale-result
-  "Structured `:rf.mcp/cursor-stale` error result. Agents pattern-match
-  on `:reason :rf.mcp/cursor-stale` and either restart (drop the
-  cursor) or rewind via a wider window."
+  "Structured cursor-stale error result. The `:reason` value
+  (`base-vocab/cursor-stale-reason`, namespaced `:rf.mcp/cursor-stale`)
+  is the cross-MCP convention agents pattern-match on (rf2-vw4sq);
+  they either restart (drop the cursor) or rewind via a wider window."
   [tool {:keys [requested-id head-id]}]
   (err-text (cond-> {:ok? false
-                     :reason :rf.mcp/cursor-stale
+                     :reason base-vocab/cursor-stale-reason
                      :tool   tool
                      :hint   (str "Cursor's epoch-id is no longer in the runtime ring. "
                                   "Drop the cursor and restart, or widen the window "

--- a/tools/story-mcp/deps.edn
+++ b/tools/story-mcp/deps.edn
@@ -38,6 +38,12 @@
          ;; `snapshot-identity`, …) — see IMPL-SPEC §7.4.
          day8/re-frame2-story {:local/root "../story"}
 
+         ;; Shared MCP primitives across the triplet (pair2-mcp,
+         ;; story-mcp, causa-mcp): wire vocabulary, the spec/009
+         ;; default-suppress filter, the path-keyed diff-encode, and
+         ;; the overflow-marker shape. Per rf2-vw4sq.
+         day8/re-frame2-mcp-base {:local/root "../mcp-base"}
+
          ;; JSON wire format. Cheshire is the project's existing JSON
          ;; library (implementation/http uses it via requiring-resolve);
          ;; we declare it as a direct runtime dep here because every

--- a/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
@@ -26,17 +26,30 @@
 
   Tool-execution errors (a known tool returning a failure) use the
   `tools/call` result shape with `isError: true` per the MCP spec §Error
-  Handling guidance — they are NOT protocol-level errors."
+  Handling guidance — they are NOT protocol-level errors.
+
+  ## Cross-MCP factoring (rf2-vw4sq)
+
+  The JSON-RPC error-code constants are re-exported from
+  `re-frame.mcp-base.vocab` — the cross-MCP shared vocabulary
+  artefact. The local names are retained as aliases so existing
+  callers don't need to touch their `:require` lists; the canonical
+  source of truth lives in the base."
   (:require [cheshire.core :as json]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [re-frame.mcp-base.vocab :as vocab]))
 
 ;; ---- error codes ----------------------------------------------------------
+;;
+;; Re-exported from `re-frame.mcp-base.vocab` per rf2-vw4sq. The
+;; numeric values are pinned by JSON-RPC 2.0 §5.1; the alias layer
+;; ensures the triplet shares one definition.
 
-(def ^:const code-parse-error      -32700)
-(def ^:const code-invalid-request  -32600)
-(def ^:const code-method-not-found -32601)
-(def ^:const code-invalid-params   -32602)
-(def ^:const code-internal-error   -32603)
+(def ^:const code-parse-error      vocab/code-parse-error)
+(def ^:const code-invalid-request  vocab/code-invalid-request)
+(def ^:const code-method-not-found vocab/code-method-not-found)
+(def ^:const code-invalid-params   vocab/code-invalid-params)
+(def ^:const code-internal-error   vocab/code-internal-error)
 
 ;; ---- envelope construction -----------------------------------------------
 

--- a/tools/story-mcp/src/re_frame/story_mcp/sensitive.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/sensitive.cljc
@@ -2,57 +2,45 @@
   "Spec/009 §Privacy default-suppress filter for `:sensitive?` trace
   events (rf2-zq0n1, follows rf2-a32kd).
 
-  ## Why this ns exists in story-mcp
+  ## Cross-MCP factoring (rf2-vw4sq)
 
-  Spec 009 mandates that framework-published forwarders — Sentry /
-  Honeybadger, pair2 server, Story-MCP, Causa-MCP — MUST default-drop
-  trace events whose registration declared `:sensitive? true`. The
-  runtime stamps the flag at the top level of every emitted trace
-  event inside such a registration's handler scope; the forwarder's
-  job is to gate egress on it before any data crosses the trust
-  boundary into the agent surface.
+  Most of the behaviour now lives in `re-frame.mcp-base.sensitive`,
+  the shared CLJC primitive consumed by every MCP server in the
+  re-frame2 triplet. This namespace keeps a local alias so:
+
+  - `sensitive-event?` binds to `re-frame.trace/sensitive?` (the
+    framework primitive, per rf2-sqxjn — every consumer of
+    `:sensitive?` composes against ONE check rather than
+    reimplementing the five-token shape). The base's predicate is
+    the same boolean check; the JVM-side alias preserves code-review
+    locality with the framework dep.
+  - The MCP-side helpers (`strip-sensitive`, `include-sensitive?`)
+    surface the canonical shape and the arg name an agent learns
+    once.
+
+  ## What spec/009 mandates
+
+  Framework-published forwarders — Sentry / Honeybadger, pair2 server,
+  Story-MCP, Causa-MCP — MUST default-drop trace events whose
+  registration declared `:sensitive? true`. The runtime stamps the
+  flag at the top level of every emitted trace event inside such a
+  registration's handler scope; the forwarder's job is to gate
+  egress on it before any data crosses the trust boundary into the
+  agent surface.
+
+  ## Why this ns exists in story-mcp
 
   Story-MCP's current tool surface (`run-variant`, `preview-variant`,
   `read-failures`, ...) returns *assertion records* and the *post-run
   app-db*, not raw `:rf/trace-event` items. The literal default-drop
   filter has nothing to filter in v1: the trace stream is not part of
-  any return shape. Still, this ns ships now so:
-
-  - When a future story-mcp tool surfaces raw traces (the natural
-    extension is a `play-traces` op that returns the trace events
-    emitted during the play phase, mirroring pair2-mcp's `subscribe
-    :trace`), the filter is already in place and the wiring is one
-    `update` call.
-  - The opt-in arg name (`:include-sensitive?`) is fixed
-    cross-server. An agent that knows the slot on pair2-mcp gets the
-    same slot on story-mcp the moment story-mcp grows a trace surface.
-  - The spec/009 MUST is honoured at the artefact level — a
-    code-review of story-mcp can see the filter machinery rather
-    than relying on a forward reference to pair2-mcp.
-
-  ## API
-
-  - `sensitive-event?` — predicate. True iff the map carries
-    `:sensitive? true` at the top level.
-  - `strip-sensitive` — `[events include?] -> [kept dropped-count]`.
-    The default-suppress filter; pass `include? true` to disable.
-  - `include-sensitive?` — read the per-call opt-in arg off a tool
-    arg map. Default false.
-
-  ## Worked example (future trace surface)
-
-  ```clojure
-  (defn- tool-play-traces [args]
-    (let [[vid err] (required-arg args :variant-id)
-          incl?     (sensitive/include-sensitive? args)]
-      (if err err
-        (let [raw          (run-and-collect-traces vid)
-              [kept dropped] (sensitive/strip-sensitive raw incl?)
-              payload      (cond-> {:variant-id vid :traces kept}
-                             (pos? dropped) (assoc :dropped-sensitive dropped))]
-          (text-result (pr-edn payload) payload)))))
-  ```"
+  any return shape. Still, this ns ships now so a future trace
+  surface (the natural extension is a `play-traces` op that returns
+  the trace events emitted during the play phase, mirroring
+  pair2-mcp's `subscribe :trace`) inherits the filter and the arg-name
+  contract automatically."
   (:require [clojure.string :as str]
+            [re-frame.mcp-base.sensitive :as base]
             [re-frame.trace :as trace]))
 
 (defn sensitive-event?
@@ -61,30 +49,20 @@
   predicate (re-exported as `re-frame.core/sensitive?`) — per rf2-sqxjn,
   every consumer of `:sensitive?` (Causa, Story, story-mcp, pair2-mcp,
   causa-mcp) composes against ONE framework primitive rather than
-  reimplementing the five-token check. The filter is conservative —
-  only the literal `true` value drops; any other value (including a
-  possible string-coercion via an ill-behaved transport) passes through.
-  The `:rf/trace-event` schema types `:sensitive?` as a boolean (per
-  spec/009 + spec/Spec-Schemas)."
+  reimplementing the five-token check."
   [ev]
   (trace/sensitive? ev))
 
 (defn strip-sensitive
   "Remove `:sensitive? true` events from `events` unless the caller has
-  opted in. Returns `[kept dropped-count]`. Cheap on the common path
-  (no sensitive events ⇒ identical-vector return + zero drop count).
+  opted in. Returns `[kept dropped-count]`.
 
-  This is the load-bearing default-suppress filter per spec/009
-  §Privacy. Apply it to any vector of trace-event-shaped maps before
-  the result crosses the MCP boundary into the agent surface."
+  Delegates to `re-frame.mcp-base.sensitive/strip-sensitive` (the
+  cross-MCP shared primitive per rf2-vw4sq). Local definition retained
+  for backwards compatibility — story-mcp consumers that already
+  binding-named this fn get the same shape."
   [events include?]
-  (cond
-    include?         [events 0]
-    (empty? events)  [events 0]
-    :else
-    (let [kept (filterv (complement sensitive-event?) events)
-          n    (- (count events) (count kept))]
-      [kept n])))
+  (base/strip-sensitive events include?))
 
 (defn- truthy-arg?
   "Coerce an MCP arg value into a boolean. JSON booleans arrive as


### PR DESCRIPTION
## Summary

- Create `tools/mcp-base/` — a `.cljc` library holding the cross-cutting primitives consumed by the MCP triplet (pair2-mcp, story-mcp, causa-mcp): wire-vocabulary constants (`:rf.mcp/*`, `:rf.size/*`, JSON-RPC error codes), the spec/009 §Privacy default-suppress filter, MCP argument coercion helpers, path-keyed diff-encode (rf2-1wdzp), and the overflow-marker shape (rf2-rvyzy).
- Refactor `pair2-mcp/tools.cljs` to delegate ~130 lines of duplicate diff-encode / arg-parsing / sensitive-filter / overflow / vocab logic to the base; the pair2-mcp-specific epoch-level sensitivity union check from rf2-re2s3 stays local.
- Refactor `story-mcp/sensitive.cljc` to delegate `strip-sensitive` to the base while keeping the `re-frame.trace/sensitive?` alias for code-review locality; `protocol.cljc` re-exports JSON-RPC error code constants from `base-vocab`.

## Out of scope (deliberate)

Per the bead's scope hold ("ship the unambiguously-shared bits"), these stay consumer-side:
- Wire transport (Cheshire JVM vs npm MCP SDK CLJS).
- Cursor base64 codec (`js/Buffer` vs `java.util.Base64`).
- Tool registries (domain-specific to each MCP).

## Test plan

- [x] `mcp-base`: `clojure -M:test` — 60 tests / 134 assertions, 0 failures.
- [x] `pair2-mcp`: `npm test` (`shadow-cljs compile server-test && node out/server-test.js`) — 265 tests / 605 assertions, 0 failures.
- [x] `story-mcp`: `clojure -M:test` — 82 tests / 357 assertions, 0 failures.
- [x] Added new CI gate `jvm-tools-mcp-base` (mirrors `jvm-tools-story-mcp` shape).

Closes rf2-vw4sq.