### PR TITLE
spec(Tool-Pair): consolidate Wire-protocol mechanisms cross-refs (rf2-5rh6r)

### DIFF
--- a/spec/Tool-Pair.md
+++ b/spec/Tool-Pair.md
@@ -527,6 +527,20 @@ Edge-case behaviour the example does not exercise but consumers should know abou
 
 The framework is **infrastructure-complete** for AI-tool consumption: data shapes, query APIs, retention policies, configuration knobs, production elision. Downstream tools own *presentation and orchestration*; they do not need to ship infrastructure that should live in the framework.
 
+### Wire-protocol mechanisms (MCP-tool layer, not framework)
+
+A pair-shaped tool reaching an AI agent over MCP must shape the payload at the wire boundary — a runtime snapshot, an epoch record, or a trace slice is routinely far larger than the agent's per-call budget can absorb. The mechanisms that solve this (token-budget cap, path slicing, cursor pagination, lazy summary, structural dedup, size-elision wire markers, and — pair2-mcp-specific — diff-encoded `:db-after` and streaming subscribe byte+event budgets) live **at the MCP-server layer**, not in this Spec. Tool-Pair.md commits to the framework surfaces (data shapes, query APIs, listener APIs); how an MCP tool packages those surfaces for an agent is downstream.
+
+The cross-MCP catalogue is normative and shared across the re-frame2 MCP triplet (pair2-mcp, causa-mcp, story-mcp). Canonical homes:
+
+- [`spec/Cross-Cutting-Designs.md §3 Token budgets`](Cross-Cutting-Designs.md) — the cross-cutting design problem statement and the index of canonical homes below.
+- [`tools/mcp-conformance/TOKEN-BUDGETS.md`](../tools/mcp-conformance/TOKEN-BUDGETS.md) — the cross-server contract: default cap (5,000 tokens), per-call `max-tokens` override slot, `{:rf.mcp/overflow ...}` reserved marker, agent-host retry contract, chained-budget rules when an agent attaches multiple servers in one session.
+- [`tools/pair2-mcp/spec/Principles.md §Tight token budget per response`](../tools/pair2-mcp/spec/Principles.md) — pair2-mcp's eight-mechanism expansion (cap → path slicing → per-tool budget → diff encoding → dedup → size elision → cursor pagination → streaming subscribe byte+event budget) in pipeline order.
+- [`tools/causa-mcp/spec/Principles.md §Tight token budget per response`](../tools/causa-mcp/spec/Principles.md) — causa-mcp's six-mechanism sibling lock (mechanisms 1-6 align cross-server so an agent learning a slot on one server gets the same slot on the others).
+- [`spec/Conventions.md §Reserved namespaces (framework-owned)`](Conventions.md#reserved-namespaces-framework-owned) — the framework-side reservation of the `:rf.mcp/*` and `:rf.size/*` keys that appear on the wire (`:rf.mcp/overflow`, `:rf.mcp/summary`, `:rf.mcp/dedup-table`, `:rf.mcp/diff-from`, `:rf.size/large-elided`).
+
+The framework owns the *data*; the wire-protocol layer owns the *packaging*. Findings docs and downstream Specs reaching for the mechanism catalogue link to the MCP-server homes above, not back into this Spec.
+
 ## What pair-shaped tools NOT to ship as part of re-frame2
 
 - **The Claude integration** itself (prompts, retrieval, model selection). Lives in the pair tool.
@@ -553,6 +567,8 @@ The pair tool can rely on all of these surviving across re-frame2 minor versions
 - [009-Instrumentation.md](009-Instrumentation.md) — the trace stream and error contract.
 - [011-SSR.md](011-SSR.md) — server-side runtime is the same contract; pair tools work there too.
 - [Spec-Schemas §`:rf/epoch-record`](Spec-Schemas.md#rfepoch-record) — the recorded shape.
+- [Cross-Cutting-Designs §3 Token budgets](Cross-Cutting-Designs.md) — wire-protocol mechanisms index (canonical homes for cap / slice / paginate / lazy-summary / dedup / elision live at the MCP-server layer).
+- [tools/mcp-conformance/TOKEN-BUDGETS.md](../tools/mcp-conformance/TOKEN-BUDGETS.md), [tools/mcp-conformance/NAMING.md](../tools/mcp-conformance/NAMING.md) — cross-MCP conformance pins (token-budget contract; tool-naming verb table).
 - [re-frame-pair-improver](https://github.com/day8/re-frame-pair-improver) — post-v1 companion (Claude skill).
 
 ---


### PR DESCRIPTION
## Summary

Adds a §Wire-protocol mechanisms (MCP-tool layer, not framework) subsection to `spec/Tool-Pair.md` that names the mechanism catalogue and cross-links to the canonical homes in the MCP-server layer. Resolves the missing-section problem that two findings docs encountered (rf2-vnmt6, rf2-ok47g) — Tool-Pair.md now carries a stable anchor that routes readers to the actual canonical homes.

## Decision

Tool-Pair.md is the framework-level runtime contract — data shapes, query APIs, listener APIs. The wire-protocol mechanisms (token-budget cap, path slicing, cursor pagination, lazy summary, structural dedup, size-elision wire markers, plus pair2-mcp-specific diff-encoded `:db-after` and streaming subscribe byte+event budgets) govern how an MCP tool packages framework surfaces for an agent — that's downstream, at the MCP-server layer.

So **don't duplicate** the catalogue in Tool-Pair.md; **cross-link** to the canonical homes that already exist after the recent triplet of PRs:

- `spec/Cross-Cutting-Designs.md §3 Token budgets` — the cross-cutting design problem statement + canonical-home index
- `tools/mcp-conformance/TOKEN-BUDGETS.md` (PR #752, rf2-ll0yq) — cross-server contract
- `tools/pair2-mcp/spec/Principles.md` (PR #721, rf2-pkve3) — eight-mechanism expansion in pipeline order
- `tools/causa-mcp/spec/Principles.md` (PR #715, rf2-knshj) — six-mechanism sibling lock
- `spec/Conventions.md §Reserved namespaces (framework-owned)` — the wire-shape keys (`:rf.mcp/*`, `:rf.size/*`)

Also updates the trailing Cross-references section with pointers to Cross-Cutting-Designs §3 and the mcp-conformance pins.

## Scope

- Doc-only. One file changed: `spec/Tool-Pair.md` (+16 lines).
- Hot-zone file; narrow change.
- No impl, no schema, no API.

## Test plan

- [x] mkdocs cross-ref targets verified (all 5 linked files exist; anchor `reserved-namespaces-framework-owned` confirmed in Conventions.md)
- [x] No duplication: catalogue stays at canonical homes; Tool-Pair.md only names + cross-links
- [x] Findings docs (rf2-vnmt6, rf2-ok47g) now have a stable §Wire-protocol mechanisms anchor in spec/Tool-Pair.md to reference (this resolves the dangling-anchor concern from PR #664's wake)

Closes rf2-5rh6r.