### PR TITLE
fix(core): event-emit :elapsed-ms must be integer on CLJS (rf2-ph8pa)

### DIFF
--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -492,13 +492,21 @@
               ;; nil and the fan-out is a single nil-check. Per Spec
               ;; 009 §Event-emit listener.
               (when-let [emit-event! (late-bind/get-fn :event-emit/dispatch-on-event)]
-                (let [end-ms (interop/now-ms)]
+                (let [end-ms     (interop/now-ms)
+                      ;; Per rf2-rirbq §Record shape: `:elapsed-ms`
+                      ;; is an integer. `interop/now-ms` returns a
+                      ;; long on the JVM (System/currentTimeMillis)
+                      ;; but a float on CLJS (`js/performance.now()`
+                      ;; carries sub-millisecond precision). Round
+                      ;; once at the substrate boundary so the
+                      ;; record's contract holds on both platforms.
+                      elapsed-ms (long (max 0 (- end-ms start-ms)))]
                   (emit-event! event
                                event-id
                                frame
                                end-ms
                                (if error :error :ok)
-                               (max 0 (- end-ms start-ms))))))))))))
+                               elapsed-ms))))))))))
 
 (defn- process-event!
   "Wrap process-event* in two dynamic bindings:


### PR DESCRIPTION
## Summary

Follow-up to **rf2-rirbq** (PR #746). Per Spec 009 §What IS available in production #2 the event-emit record shape is `{:event :event-id :frame :time :outcome :elapsed-ms <int>}`. On the JVM the contract holds (`System/currentTimeMillis` returns a long; subtraction lands an integer). On CLJS `interop/now-ms` uses `js/performance.now()` which returns a float with sub-millisecond precision, so the subtraction lands a JS Number that fails `integer?`.

The prod-elision suite asserts `(integer? (:elapsed-ms r))` and currently fails on origin/main post-rf2-rirbq merge:

```
FAIL in (event-emit-fires-under-prod)
expected: (integer? (:elapsed-ms r))
  actual: (not (integer? 0.20000000298023224))
```

Coerce once at the substrate boundary in `router.cljc` (`(long (max 0 (- end-ms start-ms)))`). JVM is already a long (no-op coerce); CLJS rounds to the integer-millis contract Spec 009 documents.

## Test plan

- [x] `clojure -M:test -n re-frame.event-emit-test` (JVM) — 7/7 pass
- [x] `npm run test:browser-prod-elision` — 17/17 pass (the previously-failing `event-emit-fires-under-prod` deftest now asserts an integer)
- [x] `npm run test:cljs` — 1758/1758 pass
- [x] `npm run test:browser` — 1758/1758 pass
- [x] `npm run test:elision` — pass
- [x] `clojure -M:test` (full core suite) — 423/423 pass