### PR TITLE
spec(Cross-Cutting-Designs): align wire-elision mechanism count with wire-vocab (rf2-pas38)

### DIFF
--- a/spec/Cross-Cutting-Designs.md
+++ b/spec/Cross-Cutting-Designs.md
@@ -21,7 +21,7 @@ This doc is an **inventory**, not a redefinition. Every entry below cites an own
 - [Spec-Schemas.md §`:rf/elision-marker`](Spec-Schemas.md#rfelision-marker) — the marker's Malli shape.
 
 **Consumers.**
-- [Tool-Pair.md](Tool-Pair.md) — pair-shaped tools consume the walker at the wire boundary; the `:rf.size/large-elided` marker is the fifth wire-elision mechanism alongside the four MCP-side shapes (`:rf.mcp/summary`, `:rf.mcp/overflow`, `:rf.mcp/diff-from`, `:rf.mcp/dedup-table`).
+- [Tool-Pair.md](Tool-Pair.md) — pair-shaped tools consume the walker at the wire boundary; the `:rf.size/large-elided` marker is the sixth of six normative wire-protocol markers catalogued in [`tools/mcp-conformance/wire-vocab/`](../tools/mcp-conformance/wire-vocab/README.md) and pinned in [`tools/causa-mcp/spec/DESIGN-RATIONALE.md` §Lock #10](../tools/causa-mcp/spec/DESIGN-RATIONALE.md) — the four MCP-side response shapes (`:rf.mcp/overflow`, `:rf.mcp/summary`, `:rf.mcp/dedup-table`, `:rf.mcp/diff-from`), the `:rf.size/large-elided` per-value elision marker, and the `:rf.elision/at` fetch-handle tag that pairs with it.
 - `tools/pair2-mcp/` — applies the walker in `tools.cljs` invoke pipeline; the `elision_test.cljs` suite pins the wire shape.
 - `tools/causa/` — on-box trace listener panels default `:rf.size/include-large?` to `false`; the `[● ELIDED N]` indicator surfaces the marker.
 - `tools/story/` — variant snapshots and trace scrubbers consume the same walker.


### PR DESCRIPTION
## Summary

Aligns the wire-elision mechanism count in `spec/Cross-Cutting-Designs.md` §1 with the two authoritative catalogues:

- [`tools/mcp-conformance/wire-vocab/README.md`](../tree/main/tools/mcp-conformance/wire-vocab/README.md) inventories **six** wire-protocol markers.
- [`tools/causa-mcp/spec/DESIGN-RATIONALE.md` §Lock #10](../tree/main/tools/causa-mcp/spec/DESIGN-RATIONALE.md) calls `:rf.size/large-elided` "the sixth wire-protocol mechanism".

Cross-Cutting-Designs previously said it was "the fifth wire-elision mechanism alongside the four MCP-side shapes" and was missing `:rf.elision/at` (the fetch-handle tag). The drift left a reader hopping between docs seeing five-vs-six.

## What ships

- Update §1 Wire elision Consumers Tool-Pair line: say "sixth of six normative wire-protocol markers", enumerate all six (`:rf.mcp/overflow`, `:rf.mcp/summary`, `:rf.mcp/dedup-table`, `:rf.mcp/diff-from`, `:rf.size/large-elided`, `:rf.elision/at`), cross-link to wire-vocab and Lock #10 as the authoritative catalogues.
- No structural change; one-line spec edit.

Source bead: rf2-pas38. Audit source: `ai/findings/spec-impl-alignment-audit-2026-05-13.md` NH-2.

## Test plan

- [ ] Visual: §1 Wire elision Consumers line names six markers and points to both catalogues.
- [ ] Cross-check: enumerated marker set matches `tools/mcp-conformance/wire-vocab/README.md` lines 13-18.
- [ ] Cross-check: count ("sixth") matches `tools/causa-mcp/spec/DESIGN-RATIONALE.md` §Lock #10.