### PR TITLE
feat(core): corpus-wide register-error-emit-listener! API (rf2-bacs4)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -53,6 +53,14 @@
             ;; Survives `:advanced` + `goog.DEBUG=false` — see
             ;; `re-frame.event-emit` docstring.
             [re-frame.event-emit :as event-emit]
+            ;; Always-on error-emit substrate (rf2-hqbeh per-frame
+            ;; `:on-error` + rf2-bacs4 corpus-wide listener registry).
+            ;; Required eagerly so the
+            ;; `register-error-emit-listener!` surface and the
+            ;; `:error-emit/dispatch-on-error` late-bind hook are
+            ;; populated before any dispatch can fire. Survives
+            ;; `:advanced` + `goog.DEBUG=false`.
+            [re-frame.error-emit :as error-emit]
             [re-frame.elision :as elision]
             [re-frame.substrate.adapter :as adapter]
             ;; Optional-artefact wrappers (rf2-hoiu). Each ns wraps a
@@ -1018,6 +1026,24 @@
 
 (def register-event-emit-listener!   event-emit/register-event-emit-listener!)
 (def unregister-event-emit-listener! event-emit/unregister-event-emit-listener!)
+
+;; ---- always-on error-emit (Spec 009 §Error-emit listener; rf2-bacs4) -----
+;;
+;; Production-survivable listener registry for `:rf.error/*` events.
+;; Sibling of `register-event-emit-listener!` (rf2-rirbq); independent
+;; from the per-frame `:on-error` policy fn (rf2-hqbeh) — both fire
+;; from one normative emission site in `router.cljc` along two
+;; independent fan-out paths. Survives `:advanced` + `goog.DEBUG=false`
+;; — the canonical wire-up point for Sentry / Honeybadger / Rollbar
+;; forwarders that need handler-exception observability without
+;; preserving the full trace surface. Listener bodies receive a tight
+;; record whose `:event` vector has already been passed through
+;; `elide-wire-value` with off-box defaults; see `re-frame.error-emit`
+;; for the full record shape and registration-site `goog.DEBUG` belt-
+;; and-braces pattern.
+
+(def register-error-emit-listener!   error-emit/register-error-emit-listener!)
+(def unregister-error-emit-listener! error-emit/unregister-error-emit-listener!)
 
 ;; ---- size-elision wire-boundary walker (rf2-v9tw2; Spec 009) -------------
 ;;

--- a/implementation/core/src/re_frame/error_emit.cljc
+++ b/implementation/core/src/re_frame/error_emit.cljc
@@ -1,7 +1,6 @@
 (ns re-frame.error-emit
-  "Always-on error-emit substrate for the per-frame `:on-error` slot.
-  Per rf2-hqbeh / Spec 002 §`:on-error` and Spec 009 §Error-handler
-  policy.
+  "Always-on error-emit substrate. Per rf2-hqbeh (per-frame `:on-error`
+  policy fan-out) and rf2-bacs4 (corpus-wide listener fan-out).
 
   ## Why this namespace exists
 
@@ -22,53 +21,177 @@
     - The per-frame `:on-error` policy fn fires through THIS path on
       both dev and prod. The policy receives the structured error event
       and may return a recovery map per Spec 009 §Error-handler policy.
+    - Corpus-wide listeners registered through
+      [[register-error-emit-listener!]] fire through THIS path on both
+      dev and prod. Each listener receives one tight error-record per
+      `:rf.error/*` event the runtime emits through this substrate.
+      Sibling to the event-emit listener surface (rf2-rirbq).
 
-  ## Surface (tiny by design)
+  ## Two surfaces, one substrate
 
-  - [[dispatch-on-error!]] — invoke the `:on-error` policy fn for the
-    given frame with the supplied error event map. Catches policy-fn
-    exceptions per Spec 009 §1052 so a buggy policy fn cannot break the
-    cascade. Returns the policy's return value (the runtime uses it to
-    apply recovery; the return-map contract is dev-side material today
-    — production callers ignore the return for now). No-op when the
-    frame's config has no `:on-error` slot.
+  The error-emit substrate carries two independent fan-out paths from
+  one normative emission site (the router's handler-exception path):
+
+  | Surface                              | Consumer concern                 | Bead       |
+  |--------------------------------------|----------------------------------|------------|
+  | Per-frame `:on-error` policy fn      | In-app recovery / retry / mark   | rf2-hqbeh  |
+  | Corpus-wide listener registry        | Off-box observability shippers   | rf2-bacs4  |
+
+  Both paths are independent (one bad listener cannot affect the
+  policy fn; a policy-fn throw cannot affect listeners). Both paths
+  are wrapped in try/catch. Both paths are always-on; both survive
+  `:advanced` + `goog.DEBUG=false`.
+
+  ## Surface
+
+  - [[dispatch-on-error!]] — invoked by `router.cljc` on handler-
+    exception. Builds the tight error-record once, runs
+    `re-frame.elision/elide-wire-value` against `:event`, fans out
+    to BOTH the registered corpus-wide listeners AND the per-frame
+    `:on-error` policy. Each fan-out leg is independent and try/catch
+    wrapped per Spec 009 §1052.
+  - [[register-error-emit-listener!]]   — register a listener fn
+    under an id. Re-registering the same id replaces.
+  - [[unregister-error-emit-listener!]] — drop a listener by id.
+  - [[clear-error-emit-listeners!]]     — wipe the registry; test
+    isolation only.
+
+  ## Record shape (TIGHT — Spec 009)
+
+    {:error      <kw>        ;; e.g. :rf.error/handler-exception
+     :event      <vector>     ;; the dispatched event vector (elided)
+     :event-id   <kw>         ;; (first event)
+     :frame      <kw>         ;; resolved frame-id
+     :time       <millis>     ;; emit timestamp (host clock, ms since epoch)
+     :exception  <ex>         ;; the thrown exception object
+     :elapsed-ms <int>}       ;; wall-clock from queue → throw
+
+  No trace-bus keys (`:dispatch-id`, `:parent-dispatch-id`,
+  `:rf.trace/trigger-handler`, ...) — those ride the dev-only trace
+  surface and DCE under `:advanced` + `goog.DEBUG=false`. Listeners
+  that want them must run a `register-trace-cb!` listener too (dev-
+  only path).
+
+  ## goog.DEBUG framing
+
+  The substrate is always-on (no `goog.DEBUG` check inside this
+  namespace). Listener REGISTRATION sites SHOULD use `goog.DEBUG` as a
+  belt-and-braces gate alongside the user's explicit config flag, e.g.
+
+    (when (and (= \"production\" (:env config))
+               (not ^boolean re-frame.interop/debug-enabled?)
+               (:api-key config))
+      (rf/register-error-emit-listener!
+        :sentry/forward
+        (fn [error-record]
+          (sentry/capture-exception (:exception error-record)
+                                    {:tags {:event-id (:event-id error-record)
+                                            :frame    (:frame error-record)}}))))
+
+  Catches the 'accidentally deployed a dev bundle with prod config'
+  bug class — symmetric with rf2-rirbq's event-emit substrate.
+
+  ## Listener responsibilities
+
+  - Listeners are invoked synchronously after the handler exception is
+    surfaced. Keep bodies cheap; ship work to a background channel if
+    it cannot fit inside the drain step's wall-clock budget.
+  - Listeners receive an error-record whose `:event` vector has
+    ALREADY been passed through `re-frame.elision/elide-wire-value`
+    with off-box defaults (large values → `:rf.size/large-elided`
+    marker; sensitive values → `:rf/redacted`). Listeners SHOULD
+    NOT re-run elision unless they want to widen the policy.
+  - Exceptions raised by a listener are caught here; sibling
+    listeners still run and the per-frame `:on-error` policy fn
+    still fires. No retry, no recursive emit.
 
   ## What this namespace deliberately does NOT do
 
   - It does NOT allocate or push to the trace ring buffer.
   - It does NOT fan out to `register-trace-cb!` listeners. Cross-frame
-    error observation through trace listeners remains a dev-only surface
-    (per Spec 009 §Subscription / consumption).
+    error observation through trace listeners remains a dev-only
+    surface (per Spec 009 §Subscription / consumption).
   - It does NOT validate the return map's shape. Return-map validation
     (`:rf.error/bad-on-error-return`) is itself a trace emission and
     remains dev-side. Production callers should treat the policy fn's
     return as advisory until the validation path is widened.
+  - It does NOT carry `:dispatch-id` / `:parent-dispatch-id` /
+    source-coord enrichment — those are trace-surface-only.
 
   Per Spec 009 §Production debugging: this is the recommended way to
-  wire production error monitoring (Sentry, Honeybadger, Rollbar) when
-  full trace-surface preservation (`:closure-defines {goog.DEBUG true}`)
-  is undesirable for bundle-size reasons."
-  (:require [re-frame.frame :as frame]))
+  wire production error monitoring (Sentry, Honeybadger, Rollbar, …)
+  when full trace-surface preservation (`:closure-defines {goog.DEBUG
+  true}`) is undesirable for bundle-size reasons. Use the per-frame
+  `:on-error` slot for in-app recovery; use
+  [[register-error-emit-listener!]] for off-box observability."
+  (:require [re-frame.elision :as elision]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]))
 
-(defn dispatch-on-error!
-  "Invoke the frame's `:on-error` policy fn with `error-event`. Always-on
-  (NOT gated by `re-frame.interop/debug-enabled?`) — fires in CLJS
-  production builds where the trace surface is elided.
+;; ---- listener registry ----------------------------------------------------
 
-  - `frame-id` — the keyword id of the frame whose `:on-error` slot
-    should be consulted. When the frame is unregistered or destroyed,
-    no-op (returns nil).
-  - `error-event` — a structured error-event map per Spec 009 §Core
-    fields shape, at minimum carrying `:operation`, `:op-type :error`,
-    and a `:tags` map.
+(defonce ^:private listeners
+  ;; id -> listener fn. `defonce` so hot reload of this namespace
+  ;; does not silently drop a long-lived production listener that
+  ;; the consuming app registered at boot.
+  (atom {}))
 
-  Per Spec 009 §1052: exceptions raised by the policy fn are caught
-  here; the runtime does NOT recursively invoke the policy on its own
-  exception. The cascade caller falls back to the documented per-
-  category recovery in that case.
+(defn register-error-emit-listener!
+  "Register a listener `f` under `id`. The id can be any value usable
+  as a map key; re-registering under the same id replaces. `f`
+  receives a single error-record map (see ns docstring §Record
+  shape) and its return value is ignored. Returns `id`.
 
-  Returns the policy fn's return value, or nil when no policy was
-  registered / the frame is missing / the policy threw."
+  Always-on: the substrate is NOT gated on
+  `re-frame.interop/debug-enabled?`. Registration sites SHOULD still
+  use `goog.DEBUG=false` as a belt-and-braces gate around
+  production-only listeners — see the ns docstring §goog.DEBUG
+  framing.
+
+  Per rf2-bacs4. Sibling of `rf/register-event-emit-listener!`
+  (rf2-rirbq); the two listener surfaces are independent — register
+  both when forwarding to a single hosted observability back-end."
+  [id f]
+  (swap! listeners assoc id f)
+  id)
+
+(defn unregister-error-emit-listener!
+  "Drop the listener registered under `id`. Returns nil. Per rf2-bacs4."
+  [id]
+  (swap! listeners dissoc id)
+  nil)
+
+(defn clear-error-emit-listeners!
+  "Drop every registered listener. Test-isolation only; production
+  code should never call this. Returns nil. Per rf2-bacs4."
+  []
+  (reset! listeners {})
+  nil)
+
+;; ---- fan-out --------------------------------------------------------------
+
+(defn- fan-out-listeners!
+  "Fan an elided error-record out to every registered listener.
+  Short-circuits to nil when the registry is empty so the per-error
+  hot-path cost reduces to one deref + an empty-map check. Listener
+  exceptions are caught — the cascade does NOT abort and sibling
+  listeners still run. Per rf2-bacs4."
+  [record]
+  (let [reg @listeners]
+    (when (seq reg)
+      (doseq [[_id f] reg]
+        (try
+          (f record)
+          (catch #?(:clj Throwable :cljs :default) _ nil)))))
+  nil)
+
+(defn- fire-on-error-policy!
+  "Invoke the frame's `:on-error` policy fn with `error-event`. No-op
+  when the frame is unregistered, when no `:on-error` slot is
+  configured, or when the slot is not a fn. Per Spec 009 §1052
+  policy-fn exceptions are caught here so a buggy policy fn cannot
+  break the cascade. Returns the policy fn's return value or nil.
+  Per rf2-hqbeh."
   [frame-id error-event]
   (when-let [f (frame/frame frame-id)]
     (when-let [policy (get-in f [:config :on-error])]
@@ -76,3 +199,65 @@
         (try
           (policy error-event)
           (catch #?(:clj Throwable :cljs :default) _ nil))))))
+
+(defn dispatch-on-error!
+  "Surface an `:rf.error/*` event through the two always-on error-emit
+  fan-out paths. Always-on (NOT gated by `re-frame.interop/debug-
+  enabled?`) — fires in CLJS production builds where the trace
+  surface is elided.
+
+  Builds the tight error-record (Spec 009; rf2-bacs4 §Record shape)
+  ONCE, runs `re-frame.elision/elide-wire-value` against `:event`
+  with off-box defaults (large → `:rf.size/large-elided`;
+  sensitive → `:rf/redacted`), then fans out along two independent
+  paths:
+
+    1. **Corpus-wide listener registry** (rf2-bacs4) — every fn
+       registered through [[register-error-emit-listener!]] receives
+       the elided tight record. Listener exceptions are caught;
+       siblings still run.
+
+    2. **Per-frame `:on-error` policy fn** (rf2-hqbeh) — the
+       frame's `:on-error` slot, when present, receives the
+       supplied `error-event` map (the legacy structured shape with
+       `:operation`/`:tags`/`:recovery` keys, used for in-app
+       recovery decisions). Policy-fn exceptions are caught per
+       Spec 009 §1052.
+
+  Both fan-out paths are independent: a buggy listener cannot block
+  the policy fn, and a buggy policy fn cannot block listeners. The
+  runtime does NOT recursively invoke either path on its own
+  exception.
+
+  Called by `router.cljc` from the handler-exception path. The
+  `start-ms` argument is the cascade-start wall-clock (already
+  captured for the event-emit substrate); the elapsed-ms is computed
+  here once at the substrate boundary, integer on both platforms per
+  the contract.
+
+  Returns nil."
+  [error-kw event event-id frame-id exception elapsed-ms time error-event]
+  (let [elided-event (elision/elide-wire-value event {:frame frame-id})
+        record       {:error      error-kw
+                      :event      elided-event
+                      :event-id   event-id
+                      :frame      frame-id
+                      :time       time
+                      :exception  exception
+                      :elapsed-ms elapsed-ms}]
+    (fan-out-listeners! record)
+    (fire-on-error-policy! frame-id error-event))
+  nil)
+
+;; ---- late-bind hook registration ------------------------------------------
+;;
+;; `router.cljc` invokes `dispatch-on-error!` on the handler-exception
+;; path. It already statically `:require`s this namespace (per
+;; rf2-hqbeh; the substrate is a foundational always-on surface
+;; alongside the router itself), so a late-bind hook isn't strictly
+;; needed here. We publish one anyway for symmetry with rf2-rirbq's
+;; `:event-emit/dispatch-on-event` hook and to keep the substrate
+;; addressable from other artefacts that may want to fire error
+;; records without static-requiring this ns.
+
+(late-bind/set-fn! :error-emit/dispatch-on-error dispatch-on-error!)

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -460,6 +460,12 @@
     :design-bead "rf2-rirbq"
     :description "Always-on per-event fan-out for production observability (Datadog / Honeycomb / Sentry). Survives `:advanced` + `goog.DEBUG=false`; parallel to (not a fallback for) the dev-only trace surface. Router invokes once per processed event after the cascade settles."}
 
+   ;; ---- re-frame.error-emit (rf2-bacs4 — always-on error observability) -----
+   {:key         :error-emit/dispatch-on-error
+    :producer-ns 're-frame.error-emit
+    :design-bead "rf2-bacs4"
+    :description "Always-on per-`:rf.error/*` fan-out: builds the tight error-record once (elided), then fans out to BOTH the corpus-wide listener registry (rf2-bacs4 — Sentry / Honeybadger / Rollbar shippers) AND the per-frame `:on-error` policy fn (rf2-hqbeh — in-app recovery). Both fan-out paths independent and try/catch wrapped. Survives `:advanced` + `goog.DEBUG=false`. Router invokes from the handler-exception path."}
+
    ;; ---- re-frame.privacy (rf2-isdwf — sensitive-without-redaction cache) ----
    {:key         :privacy/clear-suppression-cache!
     :producer-ns 're-frame.privacy

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -277,18 +277,30 @@
 
   Per rf2-hqbeh: the per-frame `:on-error` slot is a runtime error-
   recovery surface and MUST fire even when the trace surface is
-  compile-time elided in CLJS production builds. We build the structured
-  error-event map up-front, hand it to `error-emit/dispatch-on-error!`
-  (always-on; survives `goog.DEBUG=false`), then forward to the dev-only
-  `trace/emit-error!` for trace listeners and the retain-N buffer. The
-  trace path enriches the emitted event with the cascade's
-  `:dispatch-id` and the in-scope handler's source-coord; the always-on
-  path delivers the same `:operation`/`:tags` body the policy fn
-  expects."
-  [error event-id event frame ctx]
+  compile-time elided in CLJS production builds. Per rf2-bacs4: a
+  corpus-wide listener registry runs in parallel for off-box
+  observability shippers (Sentry / Honeybadger / Rollbar). We build
+  the structured error-event map AND the tight error-record up-front,
+  hand both to `error-emit/dispatch-on-error!` (always-on; survives
+  `goog.DEBUG=false`), then forward to the dev-only
+  `trace/emit-error!` for trace listeners and the retain-N buffer.
+  The trace path enriches the emitted event with the cascade's
+  `:dispatch-id` and the in-scope handler's source-coord; the
+  always-on path delivers the same `:operation`/`:tags` body the
+  policy fn expects PLUS the tight `:error/:event/:event-id/:frame/
+  :time/:exception/:elapsed-ms` record to corpus-wide listeners."
+  [error event-id event frame ctx start-ms]
   (let [e          (:exception error)
         msg        #?(:clj (.getMessage e) :cljs (.-message e))
         emit-event (or (:rf/redacted-event ctx) event)
+        end-ms     (interop/now-ms)
+        ;; Per rf2-bacs4 §Record shape: `:elapsed-ms` is an integer.
+        ;; `interop/now-ms` returns a long on the JVM but a float on
+        ;; CLJS (`js/performance.now()` carries sub-millisecond
+        ;; precision). Round once at the substrate boundary so the
+        ;; record's contract holds on both platforms (mirrors
+        ;; rf2-ph8pa / rf2-rirbq).
+        elapsed-ms (long (max 0 (- end-ms start-ms)))
         tags       {:event-id          event-id
                     :event             emit-event
                     :frame             frame
@@ -299,15 +311,23 @@
                     :exception-message msg
                     :reason            "Event handler threw."
                     :recovery          :no-recovery}]
-    ;; Always-on per rf2-hqbeh: the `:on-error` policy fn fires through
-    ;; the always-on substrate so production builds with the trace
-    ;; surface elided still observe the error. The synthesised event
+    ;; Always-on per rf2-hqbeh / rf2-bacs4: the `:on-error` policy fn
+    ;; fires through the always-on substrate so production builds with
+    ;; the trace surface elided still observe the error; in parallel,
+    ;; every fn registered through `rf/register-error-emit-listener!`
+    ;; receives the tight error-record. The synthesised error-event
     ;; matches the dev-side `:rf/trace-event` shape closely enough for
     ;; policy fns to discriminate on `:operation` / `:tags`. Trigger-
     ;; handler / dispatch-id enrichment is dev-only and not present
     ;; here — those ride the trace path below.
     (error-emit/dispatch-on-error!
+      :rf.error/handler-exception
+      emit-event
+      event-id
       frame
+      e
+      elapsed-ms
+      end-ms
       {:operation :rf.error/handler-exception
        :op-type   :error
        :tags      tags
@@ -474,7 +494,7 @@
                   effects      (:effects final-ctx)
                   error        (:rf/interceptor-error final-ctx)]
               (when error
-                (emit-handler-exception! error event-id event frame final-ctx))
+                (emit-handler-exception! error event-id event frame final-ctx start-ms))
               (commit-db-effect! effects event-id event frame final-ctx)
               (run-flows! frame event)
               (run-fx-effects! effects frame frame-record fx-overrides event)

--- a/implementation/core/test/re_frame/on_error_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/on_error_elision_prod_test.cljs
@@ -10,6 +10,13 @@
   forwarder went silent on the production-build path it was written
   for. This file pins the fix.
 
+  Per rf2-bacs4 — the corpus-wide
+  `register-error-emit-listener!` registry is the second always-on
+  fan-out path from the same error-emit substrate; off-box
+  observability shippers (Sentry / Honeybadger / Rollbar) wire through
+  it. This file pins that the listener registry survives elision
+  alongside the per-frame `:on-error` policy.
+
   Companion to `re-frame.trace-listener-elision-prod-test` (rf2-2zdu)
   and `re-frame.source-coord-dom-elision-prod-test` (rf2-uwg5). The
   shared runner is `re-frame.prod-elision-runner`; the shadow-cljs
@@ -22,12 +29,17 @@
   this suffix, so these tests run only under prod-mode compilation."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]))
 
 (use-fixtures :each
   (test-support/reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+    {:adapter reagent-adapter/adapter
+     :init-fn (fn []
+                ;; Per rf2-bacs4: clear the listener registry between
+                ;; tests — defonce means it would otherwise leak.
+                (error-emit/clear-error-emit-listeners!))}))
 
 ;; ---- :on-error survives goog.DEBUG=false ----------------------------------
 
@@ -94,3 +106,75 @@
     ;; error-emit/dispatch-on-error!.
     (is (nil? (rf/dispatch-sync [:prod/policy-throw]))
         "dispatch-sync returned nil despite both handler AND policy throwing")))
+
+;; ---- rf2-bacs4 corpus-wide listener survives goog.DEBUG=false -----------
+
+(deftest error-emit-listener-fires-under-prod
+  (testing "Per rf2-bacs4: under `:advanced` + `goog.DEBUG=false`, a
+            registered corpus-wide error-emit listener MUST fire for
+            every handler exception — the trace surface is gone but
+            the always-on error-emit substrate delivers the tight
+            record so off-box observability shippers (Sentry /
+            Honeybadger / Rollbar) still see every framework error."
+    (let [seen (atom [])]
+      (rf/register-error-emit-listener!
+        :prod/recorder
+        (fn [record] (swap! seen conj record)))
+      (rf/reg-event-db :prod/err-throw
+                       (fn [_db _]
+                         (throw (ex-info "kaboom" {:cause :test}))))
+      (rf/dispatch-sync [:prod/err-throw])
+      (is (= 1 (count @seen))
+          "listener fired exactly once — prod-elision contract holds")
+      (let [r (first @seen)]
+        (is (= :rf.error/handler-exception (:error r)))
+        (is (= [:prod/err-throw] (:event r)))
+        (is (= :prod/err-throw   (:event-id r)))
+        (is (= :rf/default       (:frame r)))
+        (is (number? (:time r)))
+        (is (integer? (:elapsed-ms r))
+            ":elapsed-ms is an integer under :advanced + goog.DEBUG=false
+             — the substrate boundary rounds the CLJS float-precision
+             performance.now() value")))))
+
+(deftest error-emit-listener-exception-swallowed-under-prod
+  (testing "A buggy listener cannot break the cascade under prod. The
+            substrate catches listener throws silently — the dispatch
+            settles and sibling listeners still run. Mirrors the dev-
+            mode contract from `re-frame.on-error-test`; pinned here
+            so the prod-build behaviour is locked too."
+    (let [seen (atom [])]
+      (rf/register-error-emit-listener!
+        :prod/throws
+        (fn [_record] (throw (ex-info "listener went boom" {}))))
+      (rf/register-error-emit-listener!
+        :prod/sibling
+        (fn [record] (swap! seen conj record)))
+      (rf/reg-event-db :prod/two-listeners
+                       (fn [_db _] (throw (ex-info "handler boom" {}))))
+      (is (nil? (rf/dispatch-sync [:prod/two-listeners]))
+          "dispatch-sync returned nil despite the listener throw")
+      (is (= 1 (count @seen))
+          "the sibling listener still received the record under prod"))))
+
+(deftest listener-and-policy-fire-independently-under-prod
+  (testing "Per rf2-bacs4 §independent paths under prod: when both a
+            per-frame `:on-error` policy fn AND a corpus-wide listener
+            are registered, BOTH fire on a handler exception. Neither
+            blocks the other under `:advanced` + `goog.DEBUG=false`."
+    (let [listener-saw (atom nil)
+          policy-saw   (atom nil)]
+      (rf/reg-frame :rf/default
+                    {:on-error (fn [ev] (reset! policy-saw ev) nil)})
+      (rf/register-error-emit-listener!
+        :prod/recorder
+        (fn [record] (reset! listener-saw record)))
+      (rf/reg-event-db :prod/both
+                       (fn [_db _] (throw (ex-info "boom" {}))))
+      (rf/dispatch-sync [:prod/both])
+      (is (some? @policy-saw)
+          "per-frame :on-error fired under prod")
+      (is (some? @listener-saw)
+          "corpus-wide listener fired under prod — both paths survive elision")
+      (is (= :rf.error/handler-exception (:error @listener-saw)))
+      (is (= :prod/both (:event-id @listener-saw))))))

--- a/implementation/core/test/re_frame/on_error_test.cljc
+++ b/implementation/core/test/re_frame/on_error_test.cljc
@@ -11,18 +11,44 @@
     - Re-registration of the frame replaces the `:on-error` slot;
       the old policy fn does NOT fire after replacement.
 
+  Per rf2-bacs4 — exercise the corpus-wide
+  `register-error-emit-listener!` registry alongside the per-frame
+  slot:
+
+    - A registered listener fires per `:rf.error/*` event.
+    - Listener exceptions are swallowed; siblings still run.
+    - Unregistering a listener stops it receiving subsequent events.
+    - The listener and the per-frame `:on-error` policy fn are
+      INDEPENDENT — a buggy listener cannot block the policy fn, and
+      a buggy policy fn cannot block listeners.
+    - The error-record shape is TIGHT: exactly
+      `{:error :event :event-id :frame :time :exception :elapsed-ms}`.
+    - `:elapsed-ms` is an integer on every platform (rf2-ph8pa
+      contract).
+
   Dev-side coverage (runs under `:node-test` / `:browser-test` /
   `clojure -M:test`). The CLJS production-mode counterpart lives in
   `re-frame.on-error-elision-prod-test` — that suite pins the same
   contract under `:advanced` + `goog.DEBUG=false`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
 
 (use-fixtures :each
   (test-support/reset-runtime-fixture
-    {:adapter plain-atom/adapter}))
+    {:adapter plain-atom/adapter
+     :init-fn (fn []
+                ;; Per rf2-bacs4: the listener registry is a `defonce`
+                ;; atom that survives test re-runs. Clear before each
+                ;; test so a listener registered by one test doesn't
+                ;; leak into the next.
+                (error-emit/clear-error-emit-listeners!))}))
+
+;; ============================================================================
+;; rf2-hqbeh — per-frame :on-error policy
+;; ============================================================================
 
 (deftest on-error-fires-when-handler-throws
   (testing "Per rf2-hqbeh / Spec 009 §Error-handler policy: a frame
@@ -88,3 +114,162 @@
                        (throw (ex-info "boom" {}))))
     ;; :rf/default is registered by the fixture with no :on-error.
     (is (nil? (rf/dispatch-sync [:on-error-test/no-policy-throw])))))
+
+;; ============================================================================
+;; rf2-bacs4 — corpus-wide register-error-emit-listener!
+;; ============================================================================
+
+(deftest error-listener-fires-on-handler-exception
+  (testing "Per rf2-bacs4: a registered listener receives exactly one
+            tight error-record per `:rf.error/handler-exception`. The
+            record's shape is fixed: `:error :event :event-id :frame
+            :time :exception :elapsed-ms`."
+    (let [seen (atom [])]
+      (rf/register-error-emit-listener!
+        :test/recorder
+        (fn [record] (swap! seen conj record)))
+      (rf/reg-event-db :err/throw
+                       (fn [_db _]
+                         (throw (ex-info "kaboom" {:cause :test}))))
+      (rf/dispatch-sync [:err/throw])
+      (is (= 1 (count @seen))
+          "listener fired exactly once for one thrown handler")
+      (let [r (first @seen)]
+        (is (= :rf.error/handler-exception (:error r)))
+        (is (= [:err/throw]    (:event r)))
+        (is (= :err/throw      (:event-id r)))
+        (is (= :rf/default     (:frame r)))
+        (is (some? (:exception r))           ":exception present")
+        (is (number? (:time r))              ":time is a wall-clock millis number")
+        (is (integer? (:elapsed-ms r))       ":elapsed-ms is an integer ms count")
+        (is (not (neg? (:elapsed-ms r)))     ":elapsed-ms is non-negative")
+        (is (= #{:error :event :event-id :frame :time :exception :elapsed-ms}
+               (set (keys r)))
+            "record carries ONLY the tight rf2-bacs4 keys — no trace-bus enrichment")))))
+
+(deftest error-listener-exception-is-swallowed
+  (testing "Per the substrate contract: a buggy listener cannot break
+            the cascade OR prevent sibling listeners from running.
+            Listener throws are caught inside the substrate and
+            silently dropped — no recursive emit, no propagation to
+            user code."
+    (let [seen (atom [])]
+      (rf/register-error-emit-listener!
+        :test/throws
+        (fn [_record]
+          (throw (ex-info "listener went boom" {}))))
+      (rf/register-error-emit-listener!
+        :test/sibling
+        (fn [record] (swap! seen conj record)))
+      (rf/reg-event-db :err/throw2
+                       (fn [_db _]
+                         (throw (ex-info "handler kaboom" {}))))
+      ;; Must NOT throw — the listener's exception is swallowed.
+      (is (nil? (rf/dispatch-sync [:err/throw2]))
+          "dispatch-sync returned nil despite the listener throw")
+      (is (= 1 (count @seen))
+          "the sibling listener still received the record — fan-out is
+           defensive across listeners"))))
+
+(deftest error-listener-unregister-stops-delivery
+  (testing "Per rf2-bacs4: unregistering a listener stops it receiving
+            subsequent events. Re-registering under the same id
+            reattaches it."
+    (let [seen (atom [])]
+      (rf/register-error-emit-listener!
+        :test/recorder
+        (fn [record] (swap! seen conj record)))
+      (rf/reg-event-db :err/throw3 (fn [_db _] (throw (ex-info "x" {}))))
+      (rf/dispatch-sync [:err/throw3])
+      (is (= 1 (count @seen)) "listener fired before unregister")
+      (rf/unregister-error-emit-listener! :test/recorder)
+      (rf/dispatch-sync [:err/throw3])
+      (is (= 1 (count @seen)) "listener silent after unregister")
+      ;; Re-register under the same id and dispatch again.
+      (rf/register-error-emit-listener!
+        :test/recorder
+        (fn [record] (swap! seen conj record)))
+      (rf/dispatch-sync [:err/throw3])
+      (is (= 2 (count @seen))
+          "listener fired again after re-registration under the same id"))))
+
+(deftest listener-and-on-error-policy-fire-independently
+  (testing "Per rf2-bacs4: the corpus-wide listener registry and the
+            per-frame `:on-error` policy fn fire from ONE normative
+            emission site along TWO independent fan-out paths. Both
+            see the same handler exception; a buggy listener cannot
+            block the policy fn, and a buggy policy fn cannot block
+            listeners."
+    (let [listener-saw (atom nil)
+          policy-saw   (atom nil)]
+      (rf/reg-frame :rf/default
+                    {:on-error (fn [ev] (reset! policy-saw ev) nil)})
+      (rf/register-error-emit-listener!
+        :test/recorder
+        (fn [record] (reset! listener-saw record)))
+      (rf/reg-event-db :err/both
+                       (fn [_db _] (throw (ex-info "boom" {}))))
+      (rf/dispatch-sync [:err/both])
+      ;; Both paths fired.
+      (is (some? @policy-saw)   "per-frame :on-error policy fired")
+      (is (some? @listener-saw) "corpus-wide listener fired")
+      ;; The two paths carry DIFFERENT shapes — the policy fn receives
+      ;; the legacy structured error-event (with `:operation`/`:tags`),
+      ;; the listener receives the tight record (rf2-bacs4 shape).
+      (is (= :rf.error/handler-exception (:operation @policy-saw))
+          "policy fn received the legacy structured shape")
+      (is (= :rf.error/handler-exception (:error @listener-saw))
+          "listener received the tight record shape")
+      (is (= :err/both (:event-id @listener-saw))))))
+
+(deftest listener-isolation-policy-throw-does-not-block-listener
+  (testing "Per rf2-bacs4 §independent paths: a policy-fn throw is
+            caught by the substrate and does NOT prevent the
+            corpus-wide listener from firing — the two fan-out paths
+            are mutually isolated."
+    (let [listener-saw (atom nil)]
+      (rf/reg-frame :rf/default
+                    {:on-error (fn [_ev] (throw (ex-info "policy boom" {})))})
+      (rf/register-error-emit-listener!
+        :test/recorder
+        (fn [record] (reset! listener-saw record)))
+      (rf/reg-event-db :err/policy-throws
+                       (fn [_db _] (throw (ex-info "handler boom" {}))))
+      (is (nil? (rf/dispatch-sync [:err/policy-throws]))
+          "dispatch settled despite both handler and policy throwing")
+      (is (some? @listener-saw)
+          "corpus-wide listener fired even though policy fn threw"))))
+
+(deftest listener-isolation-listener-throw-does-not-block-policy
+  (testing "Per rf2-bacs4 §independent paths: a listener throw is
+            caught by the substrate and does NOT prevent the
+            per-frame `:on-error` policy fn from firing."
+    (let [policy-saw (atom nil)]
+      (rf/reg-frame :rf/default
+                    {:on-error (fn [ev] (reset! policy-saw ev) nil)})
+      (rf/register-error-emit-listener!
+        :test/throws
+        (fn [_record] (throw (ex-info "listener boom" {}))))
+      (rf/reg-event-db :err/listener-throws
+                       (fn [_db _] (throw (ex-info "handler boom" {}))))
+      (is (nil? (rf/dispatch-sync [:err/listener-throws]))
+          "dispatch settled despite both handler and listener throwing")
+      (is (some? @policy-saw)
+          "per-frame :on-error policy fired even though listener threw"))))
+
+(deftest listener-elapsed-ms-is-integer
+  (testing "Per rf2-bacs4 §Record shape + rf2-ph8pa contract:
+            `:elapsed-ms` MUST be an integer on every platform. CLJS
+            `performance.now()` returns a float; the substrate
+            rounds at the boundary so the contract holds."
+    (let [seen (atom nil)]
+      (rf/register-error-emit-listener!
+        :test/recorder
+        (fn [record] (reset! seen record)))
+      (rf/reg-event-db :err/elapsed (fn [_db _] (throw (ex-info "x" {}))))
+      (rf/dispatch-sync [:err/elapsed])
+      (let [r @seen]
+        (is (some? r))
+        (is (integer? (:elapsed-ms r))
+            ":elapsed-ms is integer on every platform (no float leak from
+             CLJS performance.now())")))))

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -504,6 +504,22 @@ Five surfaces survive elision and are the canonical production-debugging fallbac
    ```
 
    Catches the "accidentally deployed a dev bundle with prod config" bug class.
+
+   **The error-emit listener surface** (per rf2-bacs4, `register-error-emit-listener!` / `unregister-error-emit-listener!` — see [API.md §Error-emit](API.md#error-emit-always-on-production-survivable)) — sibling of #2 above, runs through the SAME always-on error-emit substrate as the per-frame `:on-error` slot (#1) but along an independent fan-out path. NOT gated by `re-frame.interop/debug-enabled?`. The router fans out one record per `:rf.error/*` event after the handler-exception path runs. The record is intentionally tight — `{:error <kw> :event <vector> :event-id <kw> :frame <kw> :time <millis> :exception <ex> :elapsed-ms <int>}` — enough discriminator for production error observability (failing event-id, frame, exception object, latency); not enough for causal reconstruction (`:dispatch-id`, source-coord, `:rf.trace/trigger-handler` ride the dev-only trace surface and elide with it). The `:event` vector is passed through `re-frame.elision/elide-wire-value` ONCE before fan-out with off-box defaults (large → `:rf.size/large-elided`; sensitive → `:rf/redacted`). The two paths from the substrate are mutually isolated: a buggy listener cannot block the per-frame `:on-error` policy fn, and a buggy policy fn cannot block listeners. Listener registration sites SHOULD use `^boolean re-frame.interop/debug-enabled?` as a belt-and-braces gate alongside the user's explicit config flag, symmetric with the event-emit pattern above:
+
+   ```clojure
+   (when (and (= "production" (:env config))
+              (not ^boolean re-frame.interop/debug-enabled?)
+              (:dsn config))
+     (rf/register-error-emit-listener!
+       :sentry/forward
+       (fn [error-record]
+         (sentry/capture-exception (:exception error-record)
+                                   {:tags {:event-id (:event-id error-record)
+                                           :frame    (:frame error-record)}}))))
+   ```
+
+   Use the two listener surfaces together to route both events and errors through one hosted observability back-end without preserving the full trace surface.
 3. **The Performance API channel** (per [§Performance instrumentation](#performance-instrumentation)) — gated on the independent `re-frame.performance/enabled?` `goog-define`, default off. A production build that wants timing observability flips `{:closure-defines {re-frame.performance/enabled? true}}`; the bracket sites at the four hot paths (`:event`, `:sub`, `:fx`, `:render`) emit User-Timing measure entries that any `PerformanceObserver` — including the host APM's — reads via `performance.getEntriesByType('measure')`. This is the production observability surface re-frame2 ships and supports.
 4. **The SSR error-projector boundary** (per [011 §Server error projection](011-SSR.md#server-error-projection)) — on the server (JVM/SSR), `re-frame.interop/debug-enabled?` is hardcoded `true` (per [§JVM builds](#jvm-builds)), so the trace surface is live. The runtime emits structured `:rf.error/*` traces, the registered error projector consumes them, and the locked `:rf/public-error` shape is written to the HTTP response. Apps with an SSR tier get the full trace + projection pipeline server-side independent of the client-side bundle's elision.
 5. **Native browser machinery** — uncaught exceptions still reach `window.onerror` / `window.onunhandledrejection`. A re-frame2 event handler that throws in production still surfaces there; what's missing is the structured `:rf.error/handler-exception` shape, the `:dispatch-id` correlation, and the `:rf.trace/trigger-handler` coord — those rode the trace surface. Prefer the `:on-error` slot (#1) for structured access to the failing handler's id and the exception.

--- a/spec/API.md
+++ b/spec/API.md
@@ -371,6 +371,15 @@ Per [009 §What IS available in production](009-Instrumentation.md#what-is-avail
 | `register-event-emit-listener!` | Fn | `(register-event-emit-listener! id listener-fn)` — `listener-fn` receives one event-record per processed event (shape above). Re-registering the same `id` replaces. Returns `id`. **Always-on**: survives CLJS `:advanced` + `goog.DEBUG=false`. | v1 | 009 |
 | `unregister-event-emit-listener!` | Fn | `(unregister-event-emit-listener! id)` → nil | v1 | 009 |
 
+## Error-emit (always-on, production-survivable)
+
+Per [009 §What IS available in production](009-Instrumentation.md#what-is-available-in-production) (#2 second paragraph). Sibling of the event-emit surface above (rf2-bacs4); runs through the SAME always-on error-emit substrate as the per-frame `:on-error` slot ([§Frames](#frames)) but along an INDEPENDENT corpus-wide fan-out path. Survives `:advanced` + `goog.DEBUG=false`. Intended consumers are hosted error monitors (Sentry, Honeybadger, Rollbar). One tight record per `:rf.error/*` event the router emits through the handler-exception path; record shape `{:error :event :event-id :frame :time :exception :elapsed-ms}`. The `:event` slot is passed through [`rf/elide-wire-value`](#size-elision-wire-boundary-walker) once before fan-out, so `:sensitive?` paths land as `:rf/redacted` and `:large?` paths land as `:rf.size/large-elided`. The two paths from the substrate (corpus-wide listeners AND the per-frame `:on-error` policy fn) are mutually isolated; either may throw without affecting the other.
+
+| API | M/Fn | Signature | Status | Spec |
+|---|---|---|---|---|
+| `register-error-emit-listener!` | Fn | `(register-error-emit-listener! id listener-fn)` — `listener-fn` receives one error-record per `:rf.error/*` event (shape above). Re-registering the same `id` replaces. Returns `id`. **Always-on**: survives CLJS `:advanced` + `goog.DEBUG=false`. | v1 | 009 |
+| `unregister-error-emit-listener!` | Fn | `(unregister-error-emit-listener! id)` → nil | v1 | 009 |
+
 ## Tracing
 
 All tracing is **dev-only** (elided in production). See [009 §Tracing](009-Instrumentation.md) for emit semantics and synchronous listener delivery.


### PR DESCRIPTION
## Summary

Extends rf2-hqbeh's always-on error-emit substrate with a **corpus-wide listener registry** so off-box shippers (Sentry / Honeybadger / Rollbar) can observe every framework `:rf.error/*` event without preserving the full trace surface. Sibling of rf2-rirbq's `register-event-emit-listener!`; the two listener surfaces are independent and registration sites typically wire both into one hosted observability back-end.

The error-emit substrate now carries **two independent fan-out paths** from one normative emission site in the router's handler-exception path:

1. **Corpus-wide listener registry** (new — rf2-bacs4) — every fn registered through `rf/register-error-emit-listener!` receives a tight error-record:

   ```clojure
   {:error      <kw>       ;; e.g. :rf.error/handler-exception
    :event      <vector>    ;; elided via rf/elide-wire-value (off-box defaults)
    :event-id   <kw>
    :frame      <kw>
    :time       <millis>
    :exception  <ex>
    :elapsed-ms <int>}      ;; integer on every platform (rf2-ph8pa contract)
   ```

   The `:event` vector is passed through `rf/elide-wire-value` once before fan-out with off-box defaults (large -> `:rf.size/large-elided`; sensitive -> `:rf/redacted`). Listener exceptions are caught; siblings still run.

2. **Per-frame `:on-error` policy fn** (existing — rf2-hqbeh) — unchanged in shape. The frame's `:on-error` slot, when present, receives the legacy `{:operation :tags :recovery}` structured event for in-app recovery decisions. Policy-fn exceptions are caught per Spec 009 §1052.

The two paths are mutually isolated: a buggy listener cannot block the policy fn, and a buggy policy fn cannot block listeners. Both paths are always-on; both survive `:advanced` + `goog.DEBUG=false`.

## Surfaces changed

- **impl**: `re-frame.error-emit` (extended) — listener registry + tight record builder + two-path fan-out
- **impl**: `re-frame.core` — re-export `register-error-emit-listener!` / `unregister-error-emit-listener!` + eager-require the error-emit ns
- **impl**: `re-frame.router` — `emit-handler-exception!` builds the tight record and calls `dispatch-on-error!` with the rf2-bacs4 argument shape
- **impl**: `re-frame.late-bind.directory` — register `:error-emit/dispatch-on-error` hook for symmetry with `:event-emit/dispatch-on-event`
- **tests**: `re-frame.on-error-test` (extended) — 7 new dev-side JVM tests
- **tests**: `re-frame.on-error-elision-prod-test` (extended) — 3 new prod-elision tests pinning the contract under `:advanced` + `goog.DEBUG=false`
- **spec**: `spec/009-Instrumentation.md` §What IS available in production — error-emit listener paragraph alongside event-emit
- **spec**: `spec/API.md` — new Error-emit section + 2 new public-fn rows

## Test plan

- [x] `npm run test:cljs` — 1769 tests, 4908 assertions, 0 failures
- [x] `clojure -M:test -n re-frame.on-error-test` (JVM) — 11 tests, 36 assertions, 0 failures
- [x] `clojure -M:test -n re-frame.event-emit-test` (JVM, regression) — 7 tests, 0 failures
- [x] `clojure -M:test -n re-frame.late-bind-drift-test` — 5 tests, 322 assertions, 0 failures (new `:error-emit/dispatch-on-error` hook directory entry validated)
- [x] `npm run test:elision` — prod- and control-bundle sentinels all pass (always-on substrate carries no dev-only sentinels by design)