### PR TITLE
spec(Conventions): reserve :rf.cofx/* namespace (rf2-bdxci)

### DIFF
--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -18,6 +18,7 @@ The previous v1-and-early-v2 scheme used 14 separate top-level prefixes (`:regis
 | `:rf.frame/<operation>` | Frame-lifecycle trace-operation namespace, owned by the router and frame lifecycle (e.g. `:rf.frame/drain-interrupted`, `:rf.frame/destroyed`). | 002 / 009 |
 | `:rf.registry/*` | Registrar mutation trace operations (`:rf.registry/handler-registered`, `:rf.registry/handler-cleared`, `:rf.registry/handler-replaced`) | 001 / 009 |
 | `:rf.fx/*` | Effect-resolution advisories (`:rf.fx/skipped-on-platform`, `:rf.fx/override-applied`); reserved fx-ids in machine `:fx` (`:rf.fx/spawn-args`) | 002 / 009 |
+| `:rf.cofx/*` | Cofx-resolution advisories — cofx-substrate events that ride the error envelope but are not necessarily failures. Reserved members: `:rf.cofx/skipped-on-platform` (emitted as a `:warning` with `:recovery :skipped` when a registered cofx's `:platforms` set excludes the active platform; mirror of `:rf.fx/skipped-on-platform`). Per [009 §Error namespace convention](009-Instrumentation.md#error-namespace-convention--five-prefix-shapes) and [011 §Effect handling on the server](011-SSR.md#effect-handling-on-the-server). | 009 / 011 |
 | `:rf.error/*` | Error trace operations (handler exception, sub exception, fx exception, etc.) | 009 |
 | `:rf.warning/*` | Warning trace operations (e.g. `:rf.warning/plain-fn-under-non-default-frame-once`) | 009 |
 | `:rf.machine/*` | Machine lifecycle and transition trace operations (`:rf.machine/transition`, `:rf.machine/snapshot-updated`); machine framework subs (`[:rf/machine <id>]`) | 005 |


### PR DESCRIPTION
## Summary
- Adds `:rf.cofx/*` row to `spec/Conventions.md §Reserved namespaces` — cofx-resolution advisories that ride the error envelope but are not necessarily failures.
- Reserved canonical member: `:rf.cofx/skipped-on-platform` (mirror of `:rf.fx/skipped-on-platform`; emitted as a `:warning` with `:recovery :skipped` when a registered cofx's `:platforms` set excludes the active platform).
- Slotted adjacent to `:rf.fx/*` to make the fx/cofx parity explicit.
- Closes audit gap from rf2-wnvcd INF-2: the cofx-skip op was emitted by `implementation/ssr` and the core cofx runtime, and referenced in specs 009 / 011 / Spec-Schemas, but the Conventions reserved-namespaces table had no `:rf.cofx/*` row.

Closes rf2-bdxci.

## Test plan
- [x] mkdocs anchor targets verified (`009-Instrumentation.md#error-namespace-convention--five-prefix-shapes`, `011-SSR.md#effect-handling-on-the-server`).
- [ ] CI gates (docs build, link check).