### PR TITLE
docs(pair2-mcp): cross-link Tool-Pair contract (rf2-4chtm)

### DIFF
--- a/tools/pair2-mcp/spec/000-Vision.md
+++ b/tools/pair2-mcp/spec/000-Vision.md
@@ -1,5 +1,11 @@
 # 000-Vision: re-frame-pair2 MCP server
 
+> Implements the [Tool-Pair contract](../../../spec/Tool-Pair.md) —
+> pair2-mcp is the canonical consumer of `get-frame-db`,
+> `epoch-history`, `register-trace-cb!`, `register-epoch-cb!`,
+> `restore-epoch`, `reset-frame-db!`, `dispatch`, `dispatch-sync`,
+> plus the destroyed-frame and operating-frame rules.
+
 ## Why it exists
 
 The bash-shim chain in `skills/re-frame-pair2/scripts/` pays a heavy

--- a/tools/pair2-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/pair2-mcp/spec/003-Tool-Catalogue.md
@@ -1,5 +1,11 @@
 # 003-Tool-Catalogue
 
+> Implements the [Tool-Pair contract](../../../spec/Tool-Pair.md) —
+> each MCP tool below routes through one or more of the Tool-Pair
+> primitives (`get-frame-db`, `epoch-history`, `register-trace-cb!`,
+> `register-epoch-cb!`, `restore-epoch`, `reset-frame-db!`,
+> `dispatch`, `dispatch-sync`).
+
 The nine MCP tools.
 
 ## Universal: wire-boundary token cap

--- a/tools/pair2-mcp/spec/API.md
+++ b/tools/pair2-mcp/spec/API.md
@@ -1,5 +1,9 @@
 # API
 
+> Implements the [Tool-Pair contract](../../../spec/Tool-Pair.md) —
+> the framework-side contract for pair-shaped AI tools that pair2-mcp
+> exposes over MCP/stdio.
+
 The consolidated user-facing surface. One-stop reference for
 installing, configuring, launching, and calling pair2-mcp.
 

--- a/tools/pair2-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/pair2-mcp/spec/DESIGN-RATIONALE.md
@@ -1,5 +1,10 @@
 # DESIGN-RATIONALE
 
+> Implements the [Tool-Pair contract](../../../spec/Tool-Pair.md) —
+> the locks below operate within that contract; where a decision
+> intersects a Tool-Pair primitive, the spec there is the source of
+> truth.
+
 The direction-setting decisions that shape pair2-mcp. Each entry
 captures:
 

--- a/tools/pair2-mcp/spec/Principles.md
+++ b/tools/pair2-mcp/spec/Principles.md
@@ -1,5 +1,9 @@
 # Principles
 
+> Implements the [Tool-Pair contract](../../../spec/Tool-Pair.md) —
+> these principles tie-break design decisions within the bounds that
+> contract sets for pair-shaped AI tools.
+
 The load-bearing principles. When a design call has two reasonable
 options, these are the tie-breakers. Implementers and contributors
 should be able to read this doc and reach the same answers

--- a/tools/pair2-mcp/spec/README.md
+++ b/tools/pair2-mcp/spec/README.md
@@ -1,5 +1,9 @@
 # re-frame-pair2 MCP server — Spec
 
+> Implements the [Tool-Pair contract](../../../spec/Tool-Pair.md) —
+> the framework-side contract for pair-shaped AI tools. pair2-mcp is
+> the canonical consumer of its primitives.
+
 ## Files
 
 - **[000-Vision.md](000-Vision.md)** — Why an MCP server beats the bash-shim chain: pay cold-connect cost once per session, not per op (~700ms → ~5–50ms).


### PR DESCRIPTION
## Summary

- Audit (rf2-wnvcd NH-3) found pair2-mcp's spec docs contained zero references to `spec/Tool-Pair.md`, despite pair2-mcp being the canonical consumer of that contract.
- Adds a top-of-doc "Implements the [Tool-Pair contract](../../../spec/Tool-Pair.md)" cross-link to: `README.md`, `000-Vision.md`, `003-Tool-Catalogue.md`, `API.md`, `Principles.md`, `DESIGN-RATIONALE.md`.
- Skips `001-Wire-Protocol.md` and `002-nREPL-Transport.md` — these cover MCP wire framing and bencode/socket mechanics, infrastructural concerns below the Tool-Pair contract layer.

Mirrors `story-mcp/spec/000-Vision.md` §Tool-Pair-contract reference that the audit used as the pattern.

Closes rf2-4chtm.

## Test plan

- [x] Relative path `../../../spec/Tool-Pair.md` resolves from `tools/pair2-mcp/spec/`.
- [x] Doc-only change; no code paths affected.