### PR TITLE
fix(elision): boot-walker descends :maybe wrapper for :large? props (rf2-b20zm)

### DIFF
--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -256,17 +256,43 @@
 ;; entries; declared entries (`:source :declared`) take precedence and
 ;; are not overwritten.
 
+(def ^:private descend-wrapper-ops
+  "Single-child Malli wrapper ops whose own properties don't introduce a
+   new app-db path segment, so an inner `:large?` / `:hint` claim on
+   the wrapped schema applies to the wrapper's path. Conservative v1:
+   only `:maybe`. `:and` / `:or` / `:enum` may carry MULTIPLE children
+   with different props (merge / priority semantics TBD per rf2-b20zm
+   follow-on); a future iteration may extend this set."
+  #{:maybe})
+
 (defn- schema-properties
   "Return the top-level Malli properties map of a schema form, or nil.
-   Recognises the literal vector form `[:map {props} & children]` and
+   Recognises the literal vector form `[:op {props} & children]` and
    the metadata-map fallback (some Malli setups carry props as
-   Clojure metadata on the schema value)."
+   Clojure metadata on the schema value).
+
+   When the top-level op is a single-child wrapper (`:maybe`) and
+   carries NO props of its own, descend into the wrapped schema so the
+   idiomatic Malli shape `[:maybe [:string {:large? true :hint ...}]]`
+   exposes the inner `:large?` to callers. The descent preserves an
+   explicit outer props map — if the wrapper itself carries props
+   (`[:maybe {:large? true} :string]`), those win and no descent
+   happens. Per rf2-b20zm."
   [schema]
   (cond
     (and (vector? schema)
          (> (count schema) 1)
          (map? (nth schema 1)))
     (nth schema 1)
+
+    ;; Wrapper descent: `[:maybe inner]` (no props) — peek at the inner
+    ;; schema's top-level props so an inner `:large?` propagates. Only
+    ;; for single-child wrappers per `descend-wrapper-ops`.
+    (and (vector? schema)
+         (> (count schema) 1)
+         (contains? descend-wrapper-ops (nth schema 0))
+         (not (map? (nth schema 1))))
+    (recur (nth schema 1))
 
     ;; Fallback: metadata-form attachment. Try (meta schema) — returns
     ;; nil for values that don't carry metadata; safe on both runtimes.

--- a/implementation/core/test/re_frame/elision_test.clj
+++ b/implementation/core/test/re_frame/elision_test.clj
@@ -353,6 +353,39 @@
       (is (= :declared (:source d)) "declared wins over schema")
       (is (= "app declared this" (:hint d))))))
 
+(deftest schema-population-descends-maybe-wrapper
+  (testing "the idiomatic Malli shape `[:maybe [:string {:large? true}]]` claims the slot's path (rf2-b20zm)"
+    ;; Per rf2-b20zm: when `:large?` lives inside a `[:maybe inner]`
+    ;; wrapper, the walker descends so the inner flag propagates to the
+    ;; wrapper's app-db path. Without this descent, idiomatic "optional
+    ;; but typed" schemas silently drop the elision claim.
+    (rf/reg-app-schema [:user :pdf]
+                       [:maybe [:string {:large? true :hint "upload preview"}]])
+    (let [populated (rf/populate-elision-from-schemas!)
+          decls     (rf/elision-declarations)]
+      (is (= [[:user :pdf]] populated))
+      (is (= :schema (get-in decls [[:user :pdf] :source])))
+      (is (= "upload preview" (get-in decls [[:user :pdf] :hint]))))))
+
+(deftest schema-population-top-level-large-still-works
+  (testing "the existing top-level shape `[:string {:large? true}]` is unchanged by rf2-b20zm"
+    (rf/reg-app-schema [:user :pdf] [:string {:large? true :hint "blob"}])
+    (let [populated (rf/populate-elision-from-schemas!)
+          decls     (rf/elision-declarations)]
+      (is (= [[:user :pdf]] populated))
+      (is (= :schema (get-in decls [[:user :pdf] :source])))
+      (is (= "blob" (get-in decls [[:user :pdf] :hint]))))))
+
+(deftest schema-population-maybe-without-large-no-claim
+  (testing "`[:maybe [:string]]` (no flag) produces NO declaration"
+    ;; Negative control: the wrapper descent must not synthesise a claim
+    ;; when the wrapped schema carries no `:large?` flag.
+    (rf/reg-app-schema [:user :pdf] [:maybe [:string]])
+    (let [populated (rf/populate-elision-from-schemas!)
+          decls     (rf/elision-declarations)]
+      (is (= [] populated))
+      (is (nil? (get decls [:user :pdf]))))))
+
 (deftest schema-population-noop-when-schemas-artefact-absent
   (testing "with no late-bind hook, population is a no-op"
     (let [restore-fn (late-bind/get-fn :schemas/frame-schema-entries)]


### PR DESCRIPTION
## Summary

Fixes rf2-b20zm: `populate-elision-from-schemas!` in `core/elision.cljc` consulted `schema-properties` which only peeked at the top-level Malli props. The idiomatic "optional but typed" shape `[:maybe [:string {:large? true :hint ...}]]` puts the flag INSIDE the `:maybe` wrapper, so the shallow scan saw nothing and silently dropped the elision declaration.

- Extend `schema-properties` to descend single-child `:maybe` wrappers (when the wrapper itself carries no props).
- Conservative v1 — only `:maybe`. Multi-child wrappers (`:and`, `:or`) and `:enum` are NOT descended; merge / priority semantics warrant a separate follow-on.
- An explicit outer props map (`[:maybe {:large? true} :string]`) still wins — no descent in that case.

Note on naming: the bead originally suggested the fix lived in `implementation/schemas/`, but the schemas-artefact `walk-schema` already handles `:maybe` correctly. The actual silent-drop was in core's parallel `schema-properties` helper used by the boot-population path. Fix lives where the bug is.

## Test plan

- [x] `clojure -M:test -n re-frame.elision-test` (core) — 32 tests / 106 assertions, all pass
- [x] `clojure -M:test` (schemas) — 116 tests / 310 assertions, all pass
- [x] Three new tests for rf2-b20zm scenarios: `[:maybe [:string {:large? true}]]` produces a declaration; `[:string {:large? true}]` still works; `[:maybe [:string]]` produces no declaration

Discovered by rf2-vw0to (the `:sensitive?` + `:large?` example agent).