### PR TITLE
fix(causa): trace-cb skips self-emitted suppressed events (rf2-nk01x)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
@@ -90,6 +90,80 @@
       (subvec buffer' (- n depth))
       buffer')))
 
+;; ---- self-emit recognition (rf2-nk01x) ----------------------------------
+;;
+;; `collect-trace!` itself dispatches Causa's own bookkeeping events
+;; (`:rf.causa/note-sensitive-suppressed`, `:rf.causa/note-trace-event`)
+;; into `:rf/causa` whenever it processes a trace event. Those
+;; dispatches each produce their own `:event/dispatched` trace event
+;; (plus a short cascade of `:event/handled` / `:event/db-changed` /
+;; ... per Spec 002 §Dispatch lifecycle). The framework delivers EVERY
+;; emitted trace event back through `register-trace-cb!`, so the
+;; collector sees its own self-emit.
+;;
+;; Two loops result without a guard:
+;;
+;;   1. A `:sensitive?` event lands. `note-suppressed!` dispatches
+;;      `:rf.causa/note-sensitive-suppressed`. Because the dispatch
+;;      happens INSIDE the outer sensitive handler's scope, the
+;;      framework's `*current-sensitive?*` Var (re-frame.trace,
+;;      rf2-isdwf) is still bound true at the `emit-dispatched-trace!`
+;;      callsite, so `emit!` hoists `:sensitive? true` onto the
+;;      `:event/dispatched` trace event for `:rf.causa/note-sensitive-
+;;      suppressed` ITSELF. The collector sees that event as
+;;      `suppress-sensitive?`-true, fires `note-suppressed!` again, …
+;;      The framework's drain-depth limit (re-frame.router,
+;;      `drain-depth-default` = 100) terminates the cascade loudly, but
+;;      by then the suppressed-count has been inflated AND the
+;;      cascade-terminator emits `:rf.error/drain-depth-exceeded`.
+;;
+;;   2. Symmetric loop for `:rf.causa/note-trace-event` on non-sensitive
+;;      events — each non-sensitive trace event pushes to the buffer
+;;      AND dispatches the mirror event, whose own `:event/dispatched`
+;;      trace re-enters the collector, pushes to the buffer AGAIN, and
+;;      dispatches another mirror event, …
+;;
+;; Both loops resolve the same way: recognise the self-emitted trace
+;; events at the top of `collect-trace!` and short-circuit before any
+;; buffer push or dispatch. The self-emits are purely internal
+;; bookkeeping — they have no diagnostic value to a user inspecting the
+;; trace buffer or the REDACTED indicator, and counting them inflates
+;; both surfaces.
+
+(def ^:private causa-bookkeeping-event-ids
+  "Event ids dispatched by `collect-trace!` itself (plus the related
+  reset-* / clear-* paths under `trace-bus` and `config`). Trace
+  events scoped under these handlers are Causa's internal plumbing
+  and must NOT re-enter the collector — see the self-emit ns comment
+  above."
+  #{:rf.causa/note-sensitive-suppressed
+    :rf.causa/note-trace-event
+    :rf.causa/clear-trace-buffer
+    :rf.causa/reset-suppressed-counters
+    :rf.causa/sync-trace-buffer})
+
+(defn self-emitted?
+  "True iff `event` is a trace event scoped to one of Causa's own
+  bookkeeping dispatches (rf2-nk01x). Two recognised shapes:
+
+    1. `:event/dispatched` trace event for the bookkeeping event:
+       `:tags :event` is `[<bookkeeping-id> ...]`.
+    2. Any trace event emitted INSIDE the bookkeeping event's handler
+       scope: `:tags :event-id` is the bookkeeping id.
+
+  Pure-data + JVM-runnable so the guard's algebra is testable
+  without a CLJS runtime. Always returns a boolean (never nil)
+  so the predicate composes cleanly under `cond` + `false?`."
+  [event]
+  (if (map? event)
+    (let [tags          (:tags event)
+          event-id      (:event-id tags)
+          dispatched-id (let [ev (:event tags)]
+                          (when (vector? ev) (first ev)))]
+      (boolean (or (contains? causa-bookkeeping-event-ids event-id)
+                   (contains? causa-bookkeeping-event-ids dispatched-id))))
+    false))
+
 ;; ---- collector --------------------------------------------------------
 
 (defn collect-trace!
@@ -119,10 +193,29 @@
   `:rf.causa/trace-buffer` sub fires on the standard write path.
   Guarded on the `:rf/causa` frame's existence — production preload
   always installs it, but tests / hot-reload windows may emit
-  trace events before the frame registers."
+  trace events before the frame registers.
+
+  Per rf2-nk01x: trace events emitted by Causa's own bookkeeping
+  dispatches (`:rf.causa/note-sensitive-suppressed`, `:rf.causa/
+  note-trace-event`, …) short-circuit at the top of the body — see
+  `self-emitted?` and the ns comment above. Without this guard, a
+  single `:sensitive?` event would dispatch
+  `:rf.causa/note-sensitive-suppressed` which itself emits a
+  `:sensitive? true` trace event (inherited from
+  `*current-sensitive?*`) re-entering the collector and re-dispatching
+  the bookkeeping event, until the framework's drain-depth limit
+  terminates the cascade. The fix preserves a clean 1-bump-per-event
+  suppressed count and removes the need for tests to
+  `clear-trace-cbs!` per fixture."
   [event]
   (when interop/debug-enabled?
     (cond
+      ;; rf2-nk01x: drop Causa's own bookkeeping self-emits before any
+      ;; counter bump or buffer push. They are pure internal plumbing
+      ;; and re-entering the collector for them is the cb-dispatch loop.
+      (self-emitted? event)
+      nil
+
       (config/suppress-sensitive? event)
       (config/note-suppressed! (get-in event [:tags :frame]))
 

--- a/tools/causa/test/day8/re_frame2_causa/sensitive_trace_loop_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/sensitive_trace_loop_cljs_test.cljs
@@ -1,0 +1,195 @@
+(ns day8.re-frame2-causa.sensitive-trace-loop-cljs-test
+  "Loop-proof tests for the `:sensitive?` trace-callback path (rf2-nk01x).
+
+  ## Why this file exists
+
+  Causa registers `trace-bus/collect-trace!` as the
+  `:rf.causa/trace-collector` callback at preload time. Whenever a
+  `:sensitive?` trace event arrives, `collect-trace!` calls
+  `config/note-suppressed!`, which itself dispatches
+  `:rf.causa/note-sensitive-suppressed` into the `:rf/causa` frame so
+  the reactive `[● REDACTED N]` indicator updates on the standard
+  app-db-write path (rf2-0vxdn).
+
+  Before rf2-nk01x's fix, that dispatch was the root of an infinite
+  loop:
+
+    1. The dispatch is queued via `dispatch!`, which synchronously
+       calls `emit-dispatched-trace!`.
+    2. `emit-dispatched-trace!` lands inside `emit!` while the framework's
+       `*current-sensitive?*` Var (re-frame.trace, rf2-isdwf) is still
+       bound TRUE (the outer sensitive handler's scope hasn't unwound
+       yet — the callback iterates listeners during the outer emit).
+    3. `emit!` hoists `:sensitive? true` onto the `:event/dispatched`
+       trace event for `:rf.causa/note-sensitive-suppressed` itself.
+    4. `collect-trace!` sees that event, calls `note-suppressed!` again,
+       dispatches again, … until the JavaScript stack overflows or the
+       framework's drain-depth limit truncates the cascade.
+
+  The fix is `trace-bus/self-emitted?`: a predicate that recognises
+  the bookkeeping self-emits and short-circuits `collect-trace!` for
+  them. The pure-data predicate is covered by the JVM `trace_bus_test`;
+  this CLJS file drives the END-TO-END loop scenario through real
+  `dispatch-sync` calls against the registered trace callback.
+
+  ## What the tests assert
+
+    - A single sensitive `dispatch-sync` completes cleanly (no
+      stack overflow, no `:rf.error/drain-depth-exceeded` trace).
+    - 200 sensitive dispatches complete cleanly and the
+      suppressed-counter advances in lockstep — i.e. the per-dispatch
+      fan-out under sensitive scope is stable (no run-away
+      multiplication from re-entrant counter bumps).
+    - The non-sensitive-mirror loop is also closed —
+      `:rf.causa/note-trace-event` does not re-enter the collector via
+      its own `:event/dispatched` trace.
+    - Tests run WITHOUT a per-fixture `trace/clear-trace-cbs!`
+      workaround. The Causa callback is registered exactly as the
+      production preload installs it."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixtures -----------------------------------------------------------
+;;
+;; `reset-runtime-fixture` snapshots/restores the registrar around each
+;; test, clears trace listeners, and disposes the substrate adapter. The
+;; init-fn flips Causa's idempotency sentinels, re-registers the trace
+;; collector (so each test runs against the SAME wiring the production
+;; preload installs), and clears the per-process buffer + counter +
+;; flag so each test starts from the baseline.
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (registry/register-causa-handlers!)
+  ;; Allocate the :rf/causa frame so `note-suppressed!`'s dispatch
+  ;; guard passes. Without the frame, `note-suppressed!` skips the
+  ;; dispatch entirely — which would mask the loop scenario.
+  (frame/reg-frame :rf/causa {})
+  ;; Re-install the trace collector. The fixture above cleared it.
+  (preload/register-trace-collector!)
+  (trace-bus/clear-buffer!)
+  (config/reset-suppressed-count!)
+  (config/set-show-sensitive! false))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- helpers ------------------------------------------------------------
+
+(defn- register-sensitive-event! []
+  (rf/reg-event-db :test/sensitive-bump
+    ;; Registration metadata map — `:sensitive? true` flows through
+    ;; the registrar's meta-merge and the runtime hoists it onto every
+    ;; trace event emitted inside this handler's scope (rf2-isdwf).
+    {:sensitive? true}
+    (fn [db [_ n]]
+      (assoc db :test/last-bump n))))
+
+(defn- register-non-sensitive-event! []
+  (rf/reg-event-db :test/plain-bump
+    (fn [db [_ n]]
+      (assoc db :test/last-bump n))))
+
+(defn- drain-depth-exceeded?
+  "True iff Causa's trace buffer contains a `:rf.error/drain-depth-
+  exceeded` event. The framework's drain-depth limit terminates a
+  runaway cascade; this is the signal that the loop wasn't contained."
+  []
+  (boolean
+    (some (fn [ev] (= :rf.error/drain-depth-exceeded (:operation ev)))
+          (trace-bus/buffer))))
+
+;; ---- (1) single dispatch — no loop --------------------------------------
+
+(deftest single-sensitive-dispatch-does-not-loop
+  (testing "one :sensitive? dispatch lands cleanly under the registered
+            trace-cb — no stack overflow, no drain-depth-exceeded, and
+            the suppressed-counter advances deterministically (NOT
+            zero, NOT capped at the framework's drain-depth limit)"
+    (register-sensitive-event!)
+    (rf/dispatch-sync [:test/sensitive-bump 0])
+    (is (not (drain-depth-exceeded?))
+        "no drain-depth-exceeded — the cb-dispatch loop is closed")
+    (is (pos? (config/suppressed-count))
+        "the counter advanced — sensitive trace events DID fire and
+         DID hit the privacy gate")))
+
+;; ---- (2) 200 dispatches — count is proportional, not capped ------------
+
+(deftest two-hundred-sensitive-dispatches-scale-linearly
+  (testing "firing 200 :sensitive? dispatches advances the counter
+            proportionally — pre-fix the loop would terminate every
+            cascade at the framework's drain-depth limit (~100
+            dispatches) and inflate the counter inconsistently;
+            post-fix the per-dispatch fan-out is stable"
+    (register-sensitive-event!)
+    ;; Baseline: count the per-dispatch fan-out under sensitive scope.
+    (rf/dispatch-sync [:test/sensitive-bump :baseline])
+    (let [per-dispatch (config/suppressed-count)]
+      (is (pos? per-dispatch)
+          "sensitive cascade emits at least one suppressible trace event")
+      ;; Reset and fire 200 more. The expected total is
+      ;; `per-dispatch * 200`. The actual fan-out is stable (the
+      ;; cascade shape doesn't change between dispatches — same handler,
+      ;; same fx, same db-changed sequence).
+      (config/reset-suppressed-count!)
+      (dotimes [n 200]
+        (rf/dispatch-sync [:test/sensitive-bump n]))
+      (is (not (drain-depth-exceeded?))
+          "no drain-depth-exceeded across 200 dispatches — the loop is
+           closed for every cascade, not just the first")
+      (is (= (* 200 per-dispatch) (config/suppressed-count))
+          "counter = 200 × per-dispatch fan-out — EXACT, no inflation
+           from re-entrant counter bumps and no truncation from
+           drain-depth-exceeded"))))
+
+;; ---- (3) non-sensitive mirror loop is also closed ----------------------
+
+(deftest two-hundred-non-sensitive-dispatches-do-not-loop
+  (testing "the symmetric loop for `:rf.causa/note-trace-event` (the
+            non-sensitive mirror dispatch, rf2-iw5ym) is also closed —
+            self-emitted? recognises the bookkeeping event id and
+            short-circuits collect-trace! before the buffer push.
+            Non-sensitive events land in the buffer cleanly with no
+            re-entry inflation."
+    (register-non-sensitive-event!)
+    (dotimes [n 200]
+      (rf/dispatch-sync [:test/plain-bump n]))
+    (is (not (drain-depth-exceeded?))
+        "no drain-depth-exceeded — non-sensitive cb-dispatch loop closed")
+    ;; The buffer contains many trace events per dispatch (event/
+    ;; dispatched, event/handled, event/db-changed, event/do-fx, ...)
+    ;; — we don't assert an exact count, just that the runtime
+    ;; survived all 200 dispatches without runaway re-entry.
+    (is (pos? (count (trace-bus/buffer)))
+        "buffer received the trace events from 200 plain dispatches")))
+
+;; ---- (4) opted-in pass-through stays loop-proof ------------------------
+
+(deftest opted-in-sensitive-dispatches-also-loop-proof
+  (testing "with `:trace/show-sensitive? true` sensitive events flow
+            into the buffer instead of bumping the counter — the
+            self-emit guard still catches the bookkeeping path so the
+            collector doesn't re-enter via `:rf.causa/note-trace-event`
+            either"
+    (config/configure! {:trace/show-sensitive? true})
+    (register-sensitive-event!)
+    (dotimes [n 50]
+      (rf/dispatch-sync [:test/sensitive-bump n]))
+    (is (not (drain-depth-exceeded?))
+        "opted-in path is also loop-proof")
+    (is (zero? (config/suppressed-count))
+        "the counter does NOT advance when show-sensitive? is true")
+    (is (pos? (count (trace-bus/buffer)))
+        "sensitive trace events DID land in the buffer (pass-through
+         mode)")))

--- a/tools/causa/test/day8/re_frame2_causa/trace_bus_test.clj
+++ b/tools/causa/test/day8/re_frame2_causa/trace_bus_test.clj
@@ -37,3 +37,87 @@
       (is (= [{:id 4} {:id 5} {:id 6}]
              (trace-bus/push buf 3 {:id 6}))
           "depth 3 retains 3 newest entries after the next push"))))
+
+;; ---- self-emitted? predicate (rf2-nk01x) --------------------------------
+;;
+;; `collect-trace!`'s guard for Causa's own bookkeeping dispatches.
+;; Pure-data + JVM-runnable so the predicate's algebra is covered
+;; without a CLJS runtime. The integration coverage (`dispatch-sync`
+;; under a real cascade) lives in the CLJS sensitive_trace test.
+
+(deftest self-emitted?-recognises-bookkeeping-dispatched-trace
+  (testing ":event/dispatched trace events for Causa's own bookkeeping
+            event ids are self-emits"
+    (is (true? (trace-bus/self-emitted?
+                {:op-type :event :operation :event/dispatched
+                 :sensitive? true
+                 :tags {:event [:rf.causa/note-sensitive-suppressed :rf/default]
+                        :frame :rf/causa}}))
+        ":rf.causa/note-sensitive-suppressed dispatch trace is self-emit")
+    (is (true? (trace-bus/self-emitted?
+                {:op-type :event :operation :event/dispatched
+                 :tags {:event [:rf.causa/note-trace-event {:fake :event}]
+                        :frame :rf/causa}}))
+        ":rf.causa/note-trace-event dispatch trace is self-emit")
+    (is (true? (trace-bus/self-emitted?
+                {:op-type :event :operation :event/dispatched
+                 :tags {:event [:rf.causa/clear-trace-buffer]
+                        :frame :rf/causa}}))
+        ":rf.causa/clear-trace-buffer dispatch trace is self-emit")
+    (is (true? (trace-bus/self-emitted?
+                {:op-type :event :operation :event/dispatched
+                 :tags {:event [:rf.causa/reset-suppressed-counters]
+                        :frame :rf/causa}}))
+        ":rf.causa/reset-suppressed-counters dispatch trace is self-emit")
+    (is (true? (trace-bus/self-emitted?
+                {:op-type :event :operation :event/dispatched
+                 :tags {:event [:rf.causa/sync-trace-buffer []]
+                        :frame :rf/causa}}))
+        ":rf.causa/sync-trace-buffer dispatch trace is self-emit")))
+
+(deftest self-emitted?-recognises-handler-scoped-bookkeeping-trace
+  (testing "trace events emitted INSIDE the bookkeeping handler's scope
+            (with :tags :event-id pointing at the bookkeeping id) are
+            self-emits — this catches :event/handled, :event/db-changed,
+            :rf.fx/handled, etc., emitted under the handler's dynamic
+            binding"
+    (is (true? (trace-bus/self-emitted?
+                {:op-type :event :operation :event/db-changed
+                 :tags {:event-id :rf.causa/note-sensitive-suppressed
+                        :frame :rf/causa}})))
+    (is (true? (trace-bus/self-emitted?
+                {:op-type :event :operation :event/handled
+                 :tags {:event-id :rf.causa/note-trace-event
+                        :frame :rf/causa}})))))
+
+(deftest self-emitted?-rejects-non-bookkeeping-events
+  (testing "user-domain events are NOT self-emits"
+    (is (false? (trace-bus/self-emitted?
+                 {:op-type :event :operation :event/dispatched
+                  :sensitive? true
+                  :tags {:event [:auth/sign-in {:password "x"}]
+                         :frame :rf/default}}))
+        "a real :sensitive? event is NOT a self-emit")
+    (is (false? (trace-bus/self-emitted?
+                 {:op-type :event :operation :event/handled
+                  :tags {:event-id :user/click
+                         :frame :rf/default}}))
+        "a normal user event handled-trace is NOT a self-emit"))
+  (testing "non-:rf.causa/* re-frame internal events are NOT self-emits"
+    (is (false? (trace-bus/self-emitted?
+                 {:op-type :event :operation :event/dispatched
+                  :tags {:event [:rf.fx/dispatch [:user/foo]]}}))))
+  (testing "non-map / nil / bare values are not self-emits (no NPE)"
+    (is (false? (trace-bus/self-emitted? nil)))
+    (is (false? (trace-bus/self-emitted? :keyword)))
+    (is (false? (trace-bus/self-emitted? [:vector])))
+    (is (false? (trace-bus/self-emitted? {})))
+    (is (false? (trace-bus/self-emitted? {:tags {}}))))
+  (testing "shapes that look LIKE the bookkeeping events but aren't"
+    (is (false? (trace-bus/self-emitted?
+                 {:op-type :event :operation :event/dispatched
+                  :tags {:event [:user/note-sensitive-suppressed]}}))
+        "different ns, same suffix — must NOT match")
+    (is (false? (trace-bus/self-emitted?
+                 {:tags {:event-id :rf.causa/select-panel}}))
+        ":rf.causa/* but NOT a bookkeeping id")))


### PR DESCRIPTION
## Summary

Closes rf2-nk01x. Causa's preload-registered trace-cb infinite-dispatched on `:sensitive?` events (and on the non-sensitive mirror dispatch from rf2-iw5ym), because the bookkeeping dispatch's own `:event/dispatched` trace event re-entered the collector. The loop terminated only when the JS heap exhausted or the framework's drain-depth limit fired — and pre-termination it inflated `suppressed-count` past the real number of suppressed events.

## Fix

`tools/causa/src/day8/re_frame2_causa/trace_bus.cljc`

- New pure-data predicate `self-emitted?` recognises trace events scoped to Causa's own bookkeeping dispatches (`:rf.causa/note-sensitive-suppressed`, `:rf.causa/note-trace-event`, `:rf.causa/clear-trace-buffer`, `:rf.causa/reset-suppressed-counters`, `:rf.causa/sync-trace-buffer`) via either `:tags :event-id` (for handler-scoped trace events) or `(first (:event tags))` (for `:event/dispatched` trace events).
- `collect-trace!` short-circuits on a `self-emitted?` reading before any counter bump, buffer push, or re-dispatch.

## Why the cheap fix (Option A from the bead)

Option B (framework-level `:no-trace` event meta) is the principled fix — see follow-on **rf2-qsjda**. It belongs at the framework boundary (every consumer of `register-trace-cb!` has the same re-entry risk, not just Causa). The cheap fix lands today and unblocks the rf2-vw0to elision demo from carrying its `clear-trace-cbs!` workaround.

## Test plan

- [x] JVM: 6 new tests in `trace_bus_test.clj` cover the predicate (positive / negative / non-map inputs / look-alikes). `clojure -M:test` 491 tests, 0 failures.
- [x] CLJS: new `sensitive_trace_loop_cljs_test.cljs` drives 200 sensitive dispatches through `dispatch-sync` against the LIVE Causa cb wiring and asserts the counter advances proportionally with no drain-depth-exceeded. Also covers the non-sensitive mirror loop + the `:trace/show-sensitive? true` pass-through path. `npm run test:cljs` 1778 tests, 0 failures.
- [x] Failure-mode verified: temporarily reverting the `self-emitted?` short-circuit in `collect-trace!` reproduces a `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory` on the first dispatch — confirms the test detects the bug.

## Out of scope (filed as rf2-qsjda)

- Framework-level `:rf.trace/no-emit?` event meta — the principled fix
- Removal of the `trace/clear-trace-cbs!` workaround in `examples/reagent/counter_with_stories/elision_demo_cljs_test.cljs:49`