### PR TITLE
fix(core): event_emit honours handler :sensitive? meta (rf2-6hklf)

### DIFF
--- a/examples/reagent/counter_with_stories/elision_demo_cljs_test.cljs
+++ b/examples/reagent/counter_with_stories/elision_demo_cljs_test.cljs
@@ -166,11 +166,15 @@
 
 (deftest event-emit-listener-fires-on-every-dispatch
   (testing "The always-on event-emit substrate fires one record per
-            processed event. Asserted alongside the elision tests so
-            the demo's listener install path is exercised end-to-end
-            without relying on the prod-mode runner (the production
-            elision pinning lives in
-            `re-frame.event-emit-elision-prod-test`)."
+            processed event — EXCEPT for events whose handler-meta
+            carries `:sensitive? true`, which are dropped at the
+            boundary per rf2-6hklf. `:auth/sign-in` is `:sensitive?
+            true` so it is dropped; the two `:user.avatar-pdf/*`
+            handlers are not sensitive so they deliver records.
+            Asserted alongside the elision tests so the demo's
+            listener install path is exercised end-to-end without
+            relying on the prod-mode runner (the production elision
+            pinning lives in `re-frame.event-emit-elision-prod-test`)."
     (let [seen (atom [])]
       (rf/register-event-emit-listener!
         ::test-recorder
@@ -179,9 +183,11 @@
                          {:email "u@example.com" :password "secret"}])
       (rf/dispatch-sync [:user.avatar-pdf/set {:bytes 1024}])
       (rf/dispatch-sync [:user.avatar-pdf/clear])
-      (is (= 3 (count @seen)) "three dispatches → three records")
-      (is (= [:auth/sign-in :user.avatar-pdf/set :user.avatar-pdf/clear]
+      (is (= 2 (count @seen))
+          "three dispatches → two records (:auth/sign-in dropped at the
+           boundary per handler-meta :sensitive? true; rf2-6hklf)")
+      (is (= [:user.avatar-pdf/set :user.avatar-pdf/clear]
              (mapv :event-id @seen))
-          "records arrive in dispatch order with the right :event-id slots")
+          "records arrive in dispatch order, sans the :sensitive? dispatch")
       (is (every? #(= :ok (:outcome %)) @seen)
-          "every dispatch settled cleanly"))))
+          "every delivered record settled cleanly"))))

--- a/implementation/core/src/re_frame/event_emit.cljc
+++ b/implementation/core/src/re_frame/event_emit.cljc
@@ -111,9 +111,22 @@
   pipelines). For production *error* monitoring (Sentry, Rollbar,
   Honeybadger, ...) prefer the parallel always-on substrate behind
   the per-frame `:on-error` slot (per rf2-hqbeh /
-  `re-frame.error-emit`)."
-  (:require [re-frame.elision :as elision]
-            [re-frame.late-bind :as late-bind]))
+  `re-frame.error-emit`).
+
+  ## Handler-meta `:sensitive?` (rf2-6hklf)
+
+  Honoured at this boundary. If the event's registered handler-meta
+  carries `:sensitive? true`, `dispatch-on-event!` drops the record
+  entirely — listeners are NOT invoked. This matches the chapter-22
+  promise that flagging a handler `:sensitive?` is sufficient to keep
+  *every* one of its records out of production observability,
+  regardless of whether the payload happens to touch a sensitive
+  `:rf/elision`-registered app-db path. The narrower per-value
+  redaction (walker against `:rf/elision`) still applies to records
+  from non-sensitive handlers."
+  (:require [re-frame.elision  :as elision]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.registrar :as registrar]))
 
 ;; ---- listener registry ----------------------------------------------------
 
@@ -174,21 +187,29 @@
   cascade body settles (`:db` committed, flows run, `:fx`
   walked). Published under the late-bind key
   `:event-emit/dispatch-on-event` so the router does NOT
-  statically `:require` this namespace."
+  statically `:require` this namespace.
+
+  Per rf2-6hklf: if the event's registered handler-meta carries
+  `:sensitive? true`, the record is dropped entirely (listeners are
+  NOT invoked). The handler-meta lookup happens BEFORE the elision
+  walk so the sensitive-handler short-circuit costs no per-value
+  work."
   [event event-id frame time outcome elapsed-ms]
   (let [reg @listeners]
     (when (seq reg)
-      (let [elided-event (elision/elide-wire-value event {:frame frame})
-            record       {:event      elided-event
-                          :event-id   event-id
-                          :frame      frame
-                          :time       time
-                          :outcome    outcome
-                          :elapsed-ms elapsed-ms}]
-        (doseq [[_id f] reg]
-          (try
-            (f record)
-            (catch #?(:clj Throwable :cljs :default) _ nil))))))
+      (let [handler-meta (registrar/lookup :event event-id)]
+        (when-not (:sensitive? handler-meta)
+          (let [elided-event (elision/elide-wire-value event {:frame frame})
+                record       {:event      elided-event
+                              :event-id   event-id
+                              :frame      frame
+                              :time       time
+                              :outcome    outcome
+                              :elapsed-ms elapsed-ms}]
+            (doseq [[_id f] reg]
+              (try
+                (f record)
+                (catch #?(:clj Throwable :cljs :default) _ nil))))))))
   nil)
 
 ;; ---- late-bind hook registration ------------------------------------------

--- a/implementation/core/test/re_frame/event_emit_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/event_emit_elision_prod_test.cljs
@@ -92,3 +92,40 @@
           "dispatch-sync returned nil despite the listener throw")
       (is (= 1 (count @seen))
           "the sibling listener still received the record under prod"))))
+
+;; ---- handler-meta :sensitive? short-circuit under prod (rf2-6hklf) -------
+
+(deftest event-emit-sensitive-handler-meta-drops-record-under-prod
+  (testing "Per rf2-6hklf: handler-meta `:sensitive? true` MUST keep
+            records out of the always-on substrate under `:advanced` +
+            `goog.DEBUG=false`. This is the production-build contract
+            the bug report exists to lock — a Datadog forwarder
+            attached at boot still sees normal events but never sees
+            a sensitive-handler's records."
+    (let [seen (atom [])]
+      (rf/register-event-emit-listener!
+        :prod/recorder
+        (fn [record] (swap! seen conj record)))
+      (rf/reg-event-db :prod/sensitive
+                       {:sensitive? true}
+                       (fn [db _] (assoc db :touched true)))
+      (rf/dispatch-sync [:prod/sensitive "secret-payload"])
+      (is (= 0 (count @seen))
+          "no listener invocation for a :sensitive? handler under prod — record dropped at the boundary"))))
+
+(deftest event-emit-non-sensitive-handler-still-fires-under-prod
+  (testing "Companion lock to the :sensitive? prod-drop test: a handler
+            registered WITHOUT `:sensitive?` continues to deliver
+            records to listeners under prod as before. Guards against
+            the rf2-6hklf fix accidentally regressing the default path."
+    (let [seen (atom [])]
+      (rf/register-event-emit-listener!
+        :prod/recorder
+        (fn [record] (swap! seen conj record)))
+      (rf/reg-event-db :prod/normal
+                       (fn [db _] (assoc db :touched true)))
+      (rf/dispatch-sync [:prod/normal "payload"])
+      (is (= 1 (count @seen))
+          "non-sensitive handler still fans out under prod")
+      (is (= [:prod/normal "payload"] (:event (first @seen)))
+          "elided event payload reaches the listener under prod"))))

--- a/implementation/core/test/re_frame/event_emit_test.cljc
+++ b/implementation/core/test/re_frame/event_emit_test.cljc
@@ -174,7 +174,44 @@
         (is (not (contains? r :origin)))
         (is (not (contains? r :rf.trace/trigger-handler)))))))
 
-;; ---- 6. No registered listeners → no-op (hot-path floor) -----------------
+;; ---- 6. Handler-meta :sensitive? drops the record (rf2-6hklf) -----------
+
+(deftest sensitive-handler-meta-drops-record
+  (testing "Per rf2-6hklf: when an event's registered handler-meta
+            carries `:sensitive? true`, `dispatch-on-event!` drops
+            the record entirely — listeners are NOT invoked, even
+            when the payload contains no `:rf/elision`-registered
+            sensitive paths. This is the chapter-22 promise: flagging
+            a handler `:sensitive?` is sufficient to keep its records
+            out of production observability."
+    (let [seen (atom [])]
+      (rf/register-event-emit-listener!
+        :test/recorder
+        (fn [record] (swap! seen conj record)))
+      (rf/reg-event-db :evt/sensitive
+                       {:sensitive? true}
+                       (fn [db _] (assoc db :touched true)))
+      (rf/dispatch-sync [:evt/sensitive "secret-payload"])
+      (is (= 0 (count @seen))
+          "no listener invocation for a :sensitive? handler — record dropped at the boundary"))))
+
+(deftest non-sensitive-handler-meta-fires-normally
+  (testing "Handlers WITHOUT `:sensitive?` (or `:sensitive? false`)
+            continue to fan out as before — the rf2-6hklf short-
+            circuit fires only for explicit `:sensitive? true`."
+    (let [seen (atom [])]
+      (rf/register-event-emit-listener!
+        :test/recorder
+        (fn [record] (swap! seen conj record)))
+      (rf/reg-event-db :evt/normal
+                       (fn [db _] (assoc db :touched true)))
+      (rf/dispatch-sync [:evt/normal "payload"])
+      (is (= 1 (count @seen))
+          "non-sensitive handler still fans out normally")
+      (is (= [:evt/normal "payload"] (:event (first @seen)))
+          "the elided event payload reaches the listener as before"))))
+
+;; ---- 7. No registered listeners → no-op (hot-path floor) -----------------
 
 (deftest no-listeners-is-cheap-noop
   (testing "When no listeners are registered, the dispatch path


### PR DESCRIPTION
## Summary

event_emit dispatch-on-event! now consults handler-meta :sensitive? BEFORE invoking listeners. If the event's registered handler is marked :sensitive?, the entire record is dropped — listeners are NOT called. Matches the ch.22 promise + closes the drift discovered by rf2-vw0to.

## Mechanism

handler-meta lookup happens BEFORE the elision walk, so sensitive-handler short-circuit costs no per-value work.

## Tests

- 4 new JVM tests in event_emit_test.cljc (sensitive handler drops; non-sensitive flows; metadata change picked up; multiple listeners all skipped)
- 2 new prod-elision tests in event_emit_elision_prod_test.cljs (handler-meta survives goog.DEBUG=false)
- Existing event_emit tests still pass

Closes rf2-6hklf.