### PR TITLE
fix(ci): cache Maven deps for hermetic MCP conformance harness (rf2-c565x)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1325,13 +1325,29 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Cache Maven / gitlibs (shadow-cljs deps for pair2-mcp build)
+      # Single Maven/gitlibs cache that covers BOTH shadow-cljs boots in
+      # this job — the pair2-mcp server bundle compile AND the hermetic
+      # fixture watch (rf2-c565x). The fixture at
+      # `skills/re-frame-pair2/tests/fixture/` resolves core + reagent +
+      # epoch as `:local/root` entries, so a cold-cache run pulls every
+      # transitive dep of those three artefacts (Reagent, Malli, …)
+      # before shadow-cljs can even write the nREPL port file.
+      #
+      # On a cold-cache GHA runner that resolve takes >240s and the
+      # hermetic orchestrator's `SHADOW_BOOT_TIMEOUT_MS` watchdog fires
+      # before the port file lands — "boot failed: nREPL port not
+      # found". Hashing the fixture's deps.edn / shadow-cljs.edn and the
+      # three local-root deps.edn files into the cache key keeps the
+      # cache warm across runs that don't touch those files; the wider
+      # `restore-keys` ladder still lets a partial hit land when only
+      # one file changes.
+      - name: Cache Maven / gitlibs (shadow-cljs deps for pair2-mcp build + hermetic fixture)
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: |
             ~/.m2/repository
             ~/.gitlibs
-          key: ${{ runner.os }}-mcp-conformance-pair2-${{ hashFiles('tools/pair2-mcp/shadow-cljs.edn', 'tools/pair2-mcp/package.json') }}
+          key: ${{ runner.os }}-mcp-conformance-pair2-${{ hashFiles('tools/pair2-mcp/shadow-cljs.edn', 'tools/pair2-mcp/package.json', 'skills/re-frame-pair2/tests/fixture/deps.edn', 'skills/re-frame-pair2/tests/fixture/shadow-cljs.edn', 'implementation/core/deps.edn', 'implementation/adapters/reagent/deps.edn', 'implementation/epoch/deps.edn') }}
           restore-keys: |
             ${{ runner.os }}-mcp-conformance-pair2-
             ${{ runner.os }}-cljs-tools-pair2-mcp-

--- a/tools/mcp-conformance/scripts/run-live-pair2-overflow-hermetic.cjs
+++ b/tools/mcp-conformance/scripts/run-live-pair2-overflow-hermetic.cjs
@@ -70,10 +70,16 @@ const FIXTURE_URL = `http://127.0.0.1:${FIXTURE_HTTP_PORT}/`;
 
 // Wall-clock caps. shadow-cljs cold-start with a warm Maven cache is
 // typically 30-60s on GHA; warm restart is much faster. We give the
-// boot 240s so a cold-cache run still has headroom.
-const SHADOW_BOOT_TIMEOUT_MS = 240_000;
+// boot 360s so the first cold-cache run of the day (no `~/.m2`
+// restore hit at all) still has headroom while Maven resolves the
+// fixture's :local/root deps (core + reagent + epoch + Reagent/Malli
+// trees). The CI workflow's `mcp-conformance-pair2` job hashes those
+// inputs into its actions/cache key (rf2-c565x), so this stopgap only
+// kicks in on the truly cold path; warm-cache runs still bind the
+// nREPL port in <60s.
+const SHADOW_BOOT_TIMEOUT_MS = 360_000;
 const RUNTIME_PRELOAD_TIMEOUT_MS = 60_000;
-const HERMETIC_TIMEOUT_MS = 360_000;
+const HERMETIC_TIMEOUT_MS = 540_000;
 const POLL_MS = 500;
 
 const LIVE_TEST = path.join(


### PR DESCRIPTION
## Summary

Fixes rf2-c565x — the `mcp-conformance-pair2` job's hermetic step
(rf2-uw6d6) flakes on cold-cache GHA runners with "boot failed: nREPL
port not found".

- **Path B (root cause)** — widen the job's `actions/cache` key to hash
  the pair2 fixture's `deps.edn` / `shadow-cljs.edn` plus the three
  `:local/root` artefacts (`core`, `adapters/reagent`, `epoch`) the
  fixture pulls in. The single cache step now covers both shadow-cljs
  boots in the job (pair2-mcp server bundle compile and the hermetic
  fixture watch). Restore-keys ladder unchanged.
- **Path A (stopgap)** — bump `SHADOW_BOOT_TIMEOUT_MS` 240s → 360s and
  `HERMETIC_TIMEOUT_MS` 360s → 540s in
  `tools/mcp-conformance/scripts/run-live-pair2-overflow-hermetic.cjs`
  so the first run of the day (no restore-key hit at all) still has
  headroom while Maven resolves the fixture's transitive deps. Warm-
  cache runs keep their existing fast path.

## Test plan

- [ ] CI green: `mcp-conformance-pair2` job completes without "nREPL
      port not found"
- [ ] Cache step still hits on subsequent PRs that don't touch the
      hashed inputs (verify via "Cache hit" line in the action log)
- [ ] No regression in the other shadow-cljs jobs that share `~/.m2`
      cache (`cljs`, `cljs-browser`, `cljs-elision`, …)

CI-only fix; can't simulate cold-cache locally. YAML validated with
`python -c "import yaml; yaml.safe_load(...)"`.