### PR TITLE
docs(guide/21): variant-side :rf/schema schema-derivation row (rf2-i5ezr)

### DIFF
--- a/docs/guide/21-stories.md
+++ b/docs/guide/21-stories.md
@@ -85,6 +85,20 @@ Deep-merge, left-to-right. Variants that don't say anything inherit; variants th
 
 The **controls panel** in the right-side pane auto-derives editors. If the parent story carries `:argtypes {:label {:control :text}}`, the panel renders a text input wired to dispatch a cell-override. If you've gone further and tagged the schema in `re-frame.schemas` (spec/010), the panel reads the schema directly — a `:keyword` schema becomes a select, an `:int` schema with `:max`/`:min` becomes a number-input or slider, an `:enum` becomes a radio group. No `argTypes` plumbing; the schema is the source of truth.
 
+A variant can also **declare its own schema inline** via the `:rf/schema` slot — useful when one variant exercises a narrower (or stricter, or experimental) shape than the component-wide registered schema:
+
+```clojure
+(story/reg-variant :story.counter/labelled
+  {:rf/schema [:map
+               [:label  :string]
+               [:colour [:enum :red :green :blue]]
+               [:count  [:int {:min 0 :max 99}]]]
+   :args      {:label "Count" :colour :green :count 0}
+   :events    [[:counter/initialise 0]]})
+```
+
+Schema resolution walks variant body → parent story → registered view (per `tools/story/spec/001-Authoring.md` §Schema-derivation pipeline); first match wins, no merge. The args editor renders one row per `:map` entry (`:colour` as a select of `[:red :green :blue]`, `:count` as a number-input clamped 0–99), and the schema-validation panel surfaces any boundary failures (resolved args that don't conform, plus `:rf.error/schema-validation-failure` traces scoped to the variant's frame) — both auto-derived from the same one declaration. Authors who want most of a registered view's schema but one tightened slot still reach for `:argtypes` (which overrides key-by-key); `:rf/schema` is the all-or-nothing override.
+
 ## Decorators — three kinds
 
 Decorators are how you **wrap the canvas with re-usable concerns**: layout, theming, mock data, fx mocking. Per IMPL-SPEC §3.1 there are three kinds:

--- a/skills/re-frame2/reference/tooling/stories.md
+++ b/skills/re-frame2/reference/tooling/stories.md
@@ -94,7 +94,7 @@ Distilled from `examples/reagent/counter_with_stories/stories.cljs` — every ke
 The controls panel auto-derives a widget per arg-key by walking the component's Malli schema. `resolve-argtypes` consults, in order:
 
 1. **Explicit `:argtypes`** on the variant body, then the parent story (per-key override).
-2. **Explicit `:schema` slot** on the variant, story, or registered view (forward-compatible — Spec 010 will land `:rf/schema` on variants).
+2. **Explicit `:rf/schema` slot** (Spec 010 canonical key; the legacy `:schema` alias is still read for backward compat) on the variant body, then the parent story, then the registered view's `:spec`. First match wins — no merge. A variant-side `:rf/schema` is the all-or-nothing override when one variant exercises a narrower / stricter / experimental shape than the component-wide schema; the args editor inputs and the schema-validation panel both auto-derive from this one declaration.
 3. **Value-shape fallback** — infer the widget from the live CLJS value when no schema is available.
 
 Walker output for the common Malli forms (rf2-agshe):


### PR DESCRIPTION
## Summary

- Adds a worked example to `docs/guide/21-stories.md` showing variant-side `:rf/schema` declaration on `reg-variant` (a `[:map ...]` shape inline on a variant body) right after the existing controls-panel paragraph. Documents the resolution chain (variant body -> parent story -> registered view, first match wins, no merge) and what auto-derives: args-editor inputs and schema-validation panel rows from the one declaration. Notes the `:argtypes` per-key override vs. `:rf/schema` all-or-nothing distinction.
- Refreshes `skills/re-frame2/reference/tooling/stories.md` schema-derivation precedence list: drops the "forward-compatible — Spec 010 will land" hedge (Spec 010 has landed), names `:rf/schema` as the canonical key, keeps a one-line note that `:schema` survives as a legacy alias, restates the resolution order.

Doc-only. Closes rf2-i5ezr.

## Test plan

- [ ] `mkdocs build --strict` clean (the worktree environment doesn't have mkdocs installed; CI will gate)
- [ ] Spot-check rendered `docs/guide/21-stories.md` schema-derivation paragraph reads as one continuous thread after the controls-panel paragraph