### PR TITLE
feat(mcp): typical-tokens hint on every tool descriptor (rf2-6sddv)

### DIFF
--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -2143,14 +2143,24 @@
                 cache-property))))
 
 (def tool-descriptors
+  "MCP `tools/list` descriptors for every pair2-mcp tool.
+
+  Each entry carries `:name`, `:description`, `:inputSchema`, and
+  `:typicalTokens` (rf2-6sddv) — an informational ballpark of the
+  response-payload size in tokens that AI clients use to budget
+  calls and pick size-conscious args (`max-tokens`, `cache`,
+  `cursor`) without trial-and-error. Hint only; the real cap is
+  enforced separately."
   [{:name "discover-app"
     :description "Verify the shadow-cljs nREPL is reachable, confirm the pair2 runtime preload landed, and report a health summary. Run this first every session. Returns :reason :runtime-not-preloaded when the preload entry is missing."
+    :typicalTokens 200
     :inputSchema {:type "object"
                   :properties {:build {:type "string"
                                        :description "shadow-cljs build id (default: app)"}}
                   :additionalProperties false}}
    {:name "eval-cljs"
     :description "Evaluate a ClojureScript form in the connected browser runtime via shadow-cljs's cljs-eval. Returns the EDN value."
+    :typicalTokens 500
     :inputSchema {:type "object"
                   :properties {:form  {:type "string" :description "The CLJS form to evaluate."}
                                :build {:type "string" :description "shadow-cljs build id (default: app)"}}
@@ -2158,6 +2168,7 @@
                   :additionalProperties false}}
    {:name "dispatch"
     :description "Fire a re-frame2 event tagged with :origin :pair. Default mode is queued dispatch. Set `sync` for dispatch-sync, `trace` for synchronous dispatch returning the assembled :rf/epoch-record."
+    :typicalTokens 300
     :inputSchema {:type "object"
                   :properties {:event {:type "string" :description "The event vector, e.g. [:cart/checkout]"}
                                :sync  {:type "boolean"}
@@ -2183,6 +2194,7 @@
                       "pass `cursor` back on the next call to resume. The window's upper bound is sticky across "
                       "pages — fresh epochs landing during pagination don't sneak in mid-iteration. A cursor "
                       "whose epoch-id has aged out of the runtime ring surfaces as `:reason :rf.mcp/cursor-stale`.")
+    :typicalTokens 2000
     :inputSchema {:type "object"
                   :properties {:ms    {:type "integer" :description "Window size in milliseconds (default 1000). Sticky across pagination — encoded into the cursor on the first call."}
                                :frame {:type "string"}
@@ -2209,6 +2221,7 @@
                       "back to consume the next page. The `:cursor` arg overrides `:since-id` when both are "
                       "supplied. A cursor whose epoch-id has aged out of the ring surfaces as "
                       "`:reason :rf.mcp/cursor-stale`.")
+    :typicalTokens 2000
     :inputSchema {:type "object"
                   :properties {:since-id {:type "string" :description "The last epoch id you've seen (omit to start fresh). Supplanted by :cursor when both are passed."}
                                :pred     {:type "object" :description "Filter map"}
@@ -2225,6 +2238,7 @@
                   :additionalProperties false}}
    {:name "tail-build"
     :description "Wait for a hot-reload to land by polling a probe form until its value changes. Returns once changed, or times out."
+    :typicalTokens 100
     :inputSchema {:type "object"
                   :properties {:probe   {:type "string" :description "CLJS form whose value should change after the reload"}
                                :wait-ms {:type "integer" :description "Max wait in ms (default 5000)"}
@@ -2264,6 +2278,7 @@
                       "Agent drills into the handle via `get-path` (or `snapshot {:path ...}` with a "
                       "non-elided sibling subpath). Pass `elision false` to bypass the walk and receive "
                       "the raw value.")
+    :typicalTokens 3000
     :inputSchema {:type "object"
                   :properties {:frames  {:description "Frames to snapshot. Pass \"all\" (default) or an array of frame-id strings like [\":rf/default\", \":stories\"]."
                                          :oneOf [{:type "string"}
@@ -2324,6 +2339,7 @@
                       "with a `:handle [:rf.elision/at <path>]` fetch handle, not the raw bytes. Drill "
                       "into a non-elided child by re-calling with a deeper `path`. Pass `elision false` "
                       "to bypass the walk and receive the raw value.")
+    :typicalTokens 500
     :inputSchema {:type "object"
                   :properties {:path  {:description (str "Path into app-db. EDN-encoded vector of keys "
                                                          "(e.g. \"[:cart :items 0 :sku]\") or a JSON array "
@@ -2355,6 +2371,7 @@
                       "agent host reconstructs via `(de-dupe.core/expand cache-map)`. Dedup is per-tick, not "
                       "per-stream — each notifications/progress frame carries its own cache, no cross-tick "
                       "references. Pass `dedup false` to skip.")
+    :typicalTokens 1000
     :inputSchema {:type "object"
                   :properties {:topic   {:type "string"
                                          :description "Topic name. Required."
@@ -2380,6 +2397,7 @@
                   :additionalProperties false}}
    {:name "unsubscribe"
     :description "Close the subscription with the given sub-id. Idempotent — closing an unknown sub-id returns :existed? false."
+    :typicalTokens 50
     :inputSchema {:type "object"
                   :properties {:sub-id {:type "string"
                                         :description "The uuid returned by `subscribe`."}

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/typical_tokens_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/typical_tokens_test.cljs
@@ -1,0 +1,37 @@
+(ns re-frame-pair2-mcp.typical-tokens-test
+  "Sanity check for rf2-6sddv — every tool descriptor in pair2-mcp's
+  `tool-descriptors` carries a positive-integer `:typicalTokens` hint
+  and that hint survives the `clj->js` projection in
+  `tool-descriptors-js` (so `tools/list` consumers see it on the wire
+  as `typicalTokens`).
+
+  `:typicalTokens` is informational only — a ballpark of the
+  response-payload size in tokens that AI clients use to budget calls
+  and pick size-conscious args (`max-tokens`, `cache`, `cursor`)
+  without trial-and-error. Not a cap; real budgets are enforced
+  elsewhere."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [applied-science.js-interop :as j]
+            [re-frame-pair2-mcp.tools :as tools]))
+
+(deftest every-descriptor-carries-positive-integer-typical-tokens
+  (testing "tool-descriptors: every entry has a positive-integer :typicalTokens"
+    (doseq [d tools/tool-descriptors]
+      (is (integer? (:typicalTokens d))
+          (str "missing :typicalTokens on " (:name d)))
+      (is (pos? (:typicalTokens d))
+          (str "non-positive :typicalTokens on " (:name d))))))
+
+(deftest typical-tokens-survives-js-projection
+  (testing "tool-descriptors-js surfaces typicalTokens to the wire"
+    (let [js-arr (tools/tool-descriptors-js)
+          n      (alength js-arr)]
+      (is (pos? n) "at least one descriptor exists")
+      (doseq [i (range n)]
+        (let [desc (aget js-arr i)
+              tt   (j/get desc :typicalTokens)
+              name (j/get desc :name)]
+          (is (number? tt)
+              (str "missing typicalTokens on tool " name))
+          (is (and (integer? tt) (pos? tt))
+              (str "non-positive-integer typicalTokens on tool " name)))))))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools.cljc
@@ -692,15 +692,17 @@
   agents tend to scan top-to-bottom — so we list categories in the
   documented IMPL-SPEC §7.2 order: dev, docs, testing, then write."
   [;; ---- Dev -------------------------------------------------------------
-   {:name        "get-story-instructions"
-    :category    :dev
-    :description "Return Story's authoring conventions in agent-friendly form (the seven reg-* macros, hard rules, lifecycle, snapshots)."
-    :inputSchema {:type "object" :properties {} :additionalProperties false}
-    :handler     tool-get-story-instructions}
+   {:name           "get-story-instructions"
+    :category       :dev
+    :description    "Return Story's authoring conventions in agent-friendly form (the seven reg-* macros, hard rules, lifecycle, snapshots)."
+    :typicalTokens  1500
+    :inputSchema    {:type "object" :properties {} :additionalProperties false}
+    :handler        tool-get-story-instructions}
 
-   {:name        "preview-variant"
-    :category    :dev
-    :description "Given a variant id, return the canvas state (app-db, assertions, rendered-hiccup, elapsed) + a sharable URL."
+   {:name           "preview-variant"
+    :category       :dev
+    :description    "Given a variant id, return the canvas state (app-db, assertions, rendered-hiccup, elapsed) + a sharable URL."
+    :typicalTokens  2000
     :inputSchema {:type "object"
                   :properties {:variant-id kw-or-string
                                :substrate kw-or-string
@@ -712,61 +714,69 @@
                   :additionalProperties false}
     :handler     tool-preview-variant}
 
-   {:name        "list-substrates"
-    :category    :dev
-    :description "What substrates can be used. Returns the set registered via `register-substrate!` (Reagent is canonical; UIx / Helix opt-in per host)."
-    :inputSchema {:type "object" :properties {} :additionalProperties false}
-    :handler     tool-list-substrates}
+   {:name           "list-substrates"
+    :category       :dev
+    :description    "What substrates can be used. Returns the set registered via `register-substrate!` (Reagent is canonical; UIx / Helix opt-in per host)."
+    :typicalTokens  100
+    :inputSchema    {:type "object" :properties {} :additionalProperties false}
+    :handler        tool-list-substrates}
 
    ;; ---- Docs ------------------------------------------------------------
-   {:name        "list-stories"
-    :category    :docs
-    :description "All registered stories, optionally filtered by tags. Each entry carries id, doc, tags, and child variant ids."
+   {:name           "list-stories"
+    :category       :docs
+    :description    "All registered stories, optionally filtered by tags. Each entry carries id, doc, tags, and child variant ids."
+    :typicalTokens  1500
     :inputSchema {:type "object"
                   :properties {:tags {:type "array" :items kw-or-string
                                       :description "Optional tag filter; story `:tags` set must intersect."}}
                   :additionalProperties false}
     :handler     tool-list-stories}
 
-   {:name        "get-story"
-    :category    :docs
-    :description "Return one story's full body (`:doc`, `:component`, `:decorators`, `:args`, ... + its variant ids)."
+   {:name           "get-story"
+    :category       :docs
+    :description    "Return one story's full body (`:doc`, `:component`, `:decorators`, `:args`, ... + its variant ids)."
+    :typicalTokens  1500
     :inputSchema {:type "object"
                   :properties {:story-id kw-or-string}
                   :required ["story-id"]
                   :additionalProperties false}
     :handler     tool-get-story}
 
-   {:name        "get-variant"
-    :category    :docs
-    :description "Return one variant's full body (the resolved EDN, with `:extends` already applied at registration time)."
+   {:name           "get-variant"
+    :category       :docs
+    :description    "Return one variant's full body (the resolved EDN, with `:extends` already applied at registration time)."
+    :typicalTokens  1000
     :inputSchema {:type "object"
                   :properties {:variant-id kw-or-string}
                   :required ["variant-id"]
                   :additionalProperties false}
     :handler     tool-get-variant}
 
-   {:name        "list-tags"
-    :category    :docs
-    :description "Canonical tags (`:dev :docs :test :screenshot :experimental :internal :agent`) + any custom tags registered by the project."
-    :inputSchema {:type "object" :properties {} :additionalProperties false}
-    :handler     tool-list-tags}
+   {:name           "list-tags"
+    :category       :docs
+    :description    "Canonical tags (`:dev :docs :test :screenshot :experimental :internal :agent`) + any custom tags registered by the project."
+    :typicalTokens  100
+    :inputSchema    {:type "object" :properties {} :additionalProperties false}
+    :handler        tool-list-tags}
 
-   {:name        "list-modes"
-    :category    :docs
-    :description "Registered modes (Chromatic-style saved tuples of args). Each entry is `{:id :doc :args}`."
-    :inputSchema {:type "object" :properties {} :additionalProperties false}
-    :handler     tool-list-modes}
+   {:name           "list-modes"
+    :category       :docs
+    :description    "Registered modes (Chromatic-style saved tuples of args). Each entry is `{:id :doc :args}`."
+    :typicalTokens  200
+    :inputSchema    {:type "object" :properties {} :additionalProperties false}
+    :handler        tool-list-modes}
 
-   {:name        "list-assertions"
-    :category    :docs
-    :description "The seven canonical `:rf.assert/*` events with payload arity + semantics, plus any project-registered assertion ids."
-    :inputSchema {:type "object" :properties {} :additionalProperties false}
-    :handler     tool-list-assertions}
+   {:name           "list-assertions"
+    :category       :docs
+    :description    "The seven canonical `:rf.assert/*` events with payload arity + semantics, plus any project-registered assertion ids."
+    :typicalTokens  500
+    :inputSchema    {:type "object" :properties {} :additionalProperties false}
+    :handler        tool-list-assertions}
 
-   {:name        "variant->edn"
-    :category    :docs
-    :description "Round-trippable EDN of a registered variant. Text result only (no structuredContent); use this when you want byte-stable EDN."
+   {:name           "variant->edn"
+    :category       :docs
+    :description    "Round-trippable EDN of a registered variant. Text result only (no structuredContent); use this when you want byte-stable EDN."
+    :typicalTokens  1000
     :inputSchema {:type "object"
                   :properties {:variant-id kw-or-string}
                   :required ["variant-id"]
@@ -774,9 +784,10 @@
     :handler     tool-variant->edn}
 
    ;; ---- Testing ---------------------------------------------------------
-   {:name        "run-variant"
-    :category    :testing
-    :description "Execute a variant's four-phase lifecycle (loaders → events → render → play); return the result map (`:frame :app-db :assertions :rendered-hiccup :elapsed-ms :passing?`)."
+   {:name           "run-variant"
+    :category       :testing
+    :description    "Execute a variant's four-phase lifecycle (loaders → events → render → play); return the result map (`:frame :app-db :assertions :rendered-hiccup :elapsed-ms :passing?`)."
+    :typicalTokens  2000
     :inputSchema {:type "object"
                   :properties {:variant-id kw-or-string
                                :substrate kw-or-string
@@ -788,9 +799,10 @@
                   :additionalProperties false}
     :handler     tool-run-variant}
 
-   {:name        "snapshot-identity"
-    :category    :testing
-    :description "Content-hash of (variant × resolved args × decorators × loaders × substrate × modes). Stable across hosts; key for visual-regression."
+   {:name           "snapshot-identity"
+    :category       :testing
+    :description    "Content-hash of (variant × resolved args × decorators × loaders × substrate × modes). Stable across hosts; key for visual-regression."
+    :typicalTokens  100
     :inputSchema {:type "object"
                   :properties {:variant-id kw-or-string
                                :substrate kw-or-string
@@ -799,18 +811,20 @@
                   :additionalProperties false}
     :handler     tool-snapshot-identity}
 
-   {:name        "run-a11y"
-    :category    :testing
-    :description "Read axe-core violations for a variant from `re-frame.story.ui.a11y/violations-by-frame`. The actual axe-core run is CLJS-only; this tool returns whatever the in-browser panel has accumulated."
+   {:name           "run-a11y"
+    :category       :testing
+    :description    "Read axe-core violations for a variant from `re-frame.story.ui.a11y/violations-by-frame`. The actual axe-core run is CLJS-only; this tool returns whatever the in-browser panel has accumulated."
+    :typicalTokens  500
     :inputSchema {:type "object"
                   :properties {:variant-id kw-or-string}
                   :required ["variant-id"]
                   :additionalProperties false}
     :handler     tool-run-a11y}
 
-   {:name        "read-failures"
-    :category    :testing
-    :description "Accumulated assertion failures for a variant frame (since the most recent `run-variant`). Returns `{:total :failures :passing?}`."
+   {:name           "read-failures"
+    :category       :testing
+    :description    "Accumulated assertion failures for a variant frame (since the most recent `run-variant`). Returns `{:total :failures :passing?}`."
+    :typicalTokens  500
     :inputSchema {:type "object"
                   :properties {:variant-id kw-or-string}
                   :required ["variant-id"]
@@ -818,9 +832,10 @@
     :handler     tool-read-failures}
 
    ;; ---- Write (v1.1, gated) --------------------------------------------
-   {:name        "register-variant"
-    :category    :write
-    :description "Register a variant programmatically. GATED behind `:rf.story-mcp/allow-writes?` (default false). Enables the self-healing loop: write story → run → read failures → fix."
+   {:name           "register-variant"
+    :category       :write
+    :description    "Register a variant programmatically. GATED behind `:rf.story-mcp/allow-writes?` (default false). Enables the self-healing loop: write story → run → read failures → fix."
+    :typicalTokens  100
     :inputSchema {:type "object"
                   :properties {:variant-id kw-or-string
                                :body {:oneOf [{:type "object"}
@@ -830,18 +845,20 @@
                   :additionalProperties false}
     :handler     tool-register-variant}
 
-   {:name        "unregister-variant"
-    :category    :write
-    :description "Unregister a variant. GATED behind `:rf.story-mcp/allow-writes?` (default false). Symmetric to `register-variant`."
+   {:name           "unregister-variant"
+    :category       :write
+    :description    "Unregister a variant. GATED behind `:rf.story-mcp/allow-writes?` (default false). Symmetric to `register-variant`."
+    :typicalTokens  100
     :inputSchema {:type "object"
                   :properties {:variant-id kw-or-string}
                   :required ["variant-id"]
                   :additionalProperties false}
     :handler     tool-unregister-variant}
 
-   {:name        "record-as-variant"
-    :category    :write
-    :description "Bridge the recorder's start → capture → snippet pipeline across the MCP boundary. Starts a recording against the source variant's frame, blocks for `:duration-ms`, stops, returns the `(reg-variant ...)` snippet `gen-play-snippet` emits. Optional `:write-back?` re-registers the variant with the captured `:play` slot — GATED behind `:rf.story-mcp/allow-writes?` (same gate as `register-variant`)."
+   {:name           "record-as-variant"
+    :category       :write
+    :description    "Bridge the recorder's start → capture → snippet pipeline across the MCP boundary. Starts a recording against the source variant's frame, blocks for `:duration-ms`, stops, returns the `(reg-variant ...)` snippet `gen-play-snippet` emits. Optional `:write-back?` re-registers the variant with the captured `:play` slot — GATED behind `:rf.story-mcp/allow-writes?` (same gate as `register-variant`)."
+    :typicalTokens  1500
     :inputSchema {:type "object"
                   :properties {:variant-id     kw-or-string
                                :duration-ms    {:type "integer" :minimum 0
@@ -862,14 +879,20 @@
 
 (defn tool-descriptors
   "Build the `tools/list` response payload: each tool's name +
-  description + inputSchema, in registry order. The MCP spec also
-  allows a `title` field; we omit it (the names are already
-  human-readable dash-separated forms)."
+  description + inputSchema + typicalTokens, in registry order. The
+  MCP spec also allows a `title` field; we omit it (the names are
+  already human-readable dash-separated forms).
+
+  `typicalTokens` (rf2-6sddv) is an informational hint — an integer
+  ballpark of the response payload size in tokens. AI clients use it
+  to budget calls and pick size-conscious args without trial-and-error.
+  Not a cap (the host enforces real budgets elsewhere); a hint only."
   []
-  (mapv (fn [{:keys [name description inputSchema]}]
-          {:name        name
-           :description description
-           :inputSchema inputSchema})
+  (mapv (fn [{:keys [name description inputSchema typicalTokens]}]
+          (cond-> {:name        name
+                   :description description
+                   :inputSchema inputSchema}
+            typicalTokens (assoc :typicalTokens typicalTokens)))
         tool-registry))
 
 (defn tool-by-name

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -92,6 +92,21 @@
       (is (every? #(not (contains? % :handler)) ds))
       (is (every? #(not (contains? % :category)) ds)))))
 
+(deftest typical-tokens-hint-on-every-tool
+  ;; rf2-6sddv — `:typicalTokens` is an informational ballpark of
+  ;; response-payload size in tokens; AI clients use it to budget calls.
+  ;; Not a cap. Required to be a positive integer on every tool.
+  (testing "registry: every tool carries a positive-integer :typicalTokens"
+    (doseq [t tools/tool-registry]
+      (is (integer? (:typicalTokens t))
+          (str "missing :typicalTokens on " (:name t)))
+      (is (pos? (:typicalTokens t))
+          (str "non-positive :typicalTokens on " (:name t)))))
+  (testing "tool-descriptors surfaces :typicalTokens to the wire"
+    (let [ds (tools/tool-descriptors)]
+      (is (every? #(integer? (:typicalTokens %)) ds))
+      (is (every? #(pos? (:typicalTokens %)) ds)))))
+
 (deftest registry-covers-impl-spec-7-2
   (testing "every tool from IMPL-SPEC §7.2 + §7.3 is present"
     (let [names (set (map :name tools/tool-registry))]


### PR DESCRIPTION
## Summary

- Every tool descriptor in `pair2-mcp` (10 tools) and `story-mcp` (17 tools) gains a `:typicalTokens <int>` slot.
- The hint surfaces in the `tools/list` JSON response as `typicalTokens` — an informational ballpark of the response-payload size in tokens.
- AI clients use it to budget calls and pick size-conscious args (`max-tokens`, `cache`, `cursor`) without trial-and-error.
- Informational only — real budgets are enforced separately (per-session cache, `max-tokens` knob, cursor pagination).

Picked values:

**pair2-mcp**: discover-app 200, eval-cljs 500, dispatch 300, trace-window 2000, watch-epochs 2000, tail-build 100, snapshot 3000, get-path 500, subscribe 1000, unsubscribe 50.

**story-mcp**: get-story-instructions 1500, preview-variant 2000, list-substrates 100, list-stories 1500, get-story 1500, get-variant 1000, list-tags 100, list-modes 200, list-assertions 500, variant->edn 1000, run-variant 2000, snapshot-identity 100, run-a11y 500, read-failures 500, register-variant 100, unregister-variant 100, record-as-variant 1500.

Per the bead, these are estimates — pair2-mcp values will firm up once `rf2-rvyzy` (cap enforcement) + `rf2-1wdzp` (diff encoding) + `rf2-u2029` (lazy summary) ship; story-mcp values were set against the current observed payloads.

## Test plan

- [x] `npm test` in `tools/pair2-mcp/` — 267 tests / 646 assertions, 0 failures. New `typical_tokens_test.cljs` verifies every descriptor carries a positive-integer hint and that `tool-descriptors-js`'s `clj->js` projection surfaces it as `typicalTokens` on the wire.
- [x] `clojure -M:test -n re-frame.story-mcp.tools-test` in `tools/story-mcp/` — 51 tests / 314 assertions, 0 failures. New `typical-tokens-hint-on-every-tool` deftest pins the contract on both `tool-registry` and the `tool-descriptors` wire projection.