### PR TITLE
docs(skills/re-frame2): privacy-elision + production-observability reference leaves (rf2-xas97)

### DIFF
--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -69,6 +69,13 @@ Full skill-disambiguation matrix lives at [`skills/README.md` §Skill routing �
 
 Patterns compose; a screen can use Forms on submit, RemoteData for the request, and WebSocket for a push.
 
+**Cross-cutting concerns** — orthogonal to pattern choice; load alongside the primary leaf when the trigger fires.
+
+| Concern | Cross-cutting leaf |
+|---|---|
+| Declaring a handler or schema slot as containing secrets / PII / large blobs | `reference/cross-cutting/privacy-and-elision.md` |
+| Wiring Datadog / Sentry / Honeycomb production listeners that survive `goog.DEBUG=false` | `reference/cross-cutting/production-observability.md` |
+
 ## Where the depth lives
 
 Load at most two leaves per task. If a task seems to need three, it likely spans patterns and should be broken up.
@@ -79,7 +86,7 @@ Load at most two leaves per task. If a task seems to need three, it likely spans
 
 **Tooling — `reference/tooling/`**: `stories.md`, `routing.md`, `story-recorder.md` (record canvas interactions as `:play`), `story-mcp-loop.md` (agent self-healing loop over MCP).
 
-**Cross-cutting — `reference/cross-cutting/`**: `testing.md` (with-frame, dispatch-sync, compute-sub), `api-cheatsheet.md`.
+**Cross-cutting — `reference/cross-cutting/`**: `testing.md` (with-frame, dispatch-sync, compute-sub), `api-cheatsheet.md`, `privacy-and-elision.md` (`:sensitive?` / `:large?` / `elide-wire-value` / `with-redacted`), `production-observability.md` (`register-event-emit-listener!` / `register-error-emit-listener!`).
 
 **Patterns — `patterns/`**: one leaf per canonical pattern (see table above). Each leaf opens with load triggers, the canonical mini-declaration, the re-frame2 features it uses, trade-offs, and the worked-example link. Cross-reference of pattern → example app: `examples-map.md`.
 

--- a/skills/re-frame2/reference/cross-cutting/privacy-and-elision.md
+++ b/skills/re-frame2/reference/cross-cutting/privacy-and-elision.md
@@ -1,0 +1,145 @@
+# Privacy and size elision
+
+re-frame2 has a **unified wire-boundary elision pass**: every tool that emits trace, listener, or snapshot data routes through one walker (`re-frame.elision/elide-wire-value`) that consults the active frame's `[:rf/elision]` registry. Two orthogonal flags compose: **`:sensitive?`** drops the record (privacy), **`:large?`** elides the value with a fetch-handle (bandwidth). **Sensitive wins**: when both match, the value collapses to `:rf/redacted` and no large-elision marker is emitted (the marker itself carries `:path` / `:bytes` / `:digest`).
+
+Authoring rule: if a handler touches a credential, PII, or auth token — flag it `:sensitive?`. If a schema slot can hold a payload bigger than ~16 KB (base64 blob, parsed PDF, large JSON tree) — flag it `:large?`. The framework handles the wire boundary; you do not hand-roll redaction.
+
+## When to load
+
+Authoring `reg-event-*` / `reg-app-schema` / custom listener code that touches secrets, credentials, PII, or values that might exceed ~16 KB on the wire — or wiring a HTTP forwarder / custom logger that emits app payloads off-box.
+
+## `:sensitive?` — handler-meta (the headline declaration)
+
+Boolean flag on `reg-event-*` metadata-map. Causes the **entire trace + event-emit record** to drop for any event handled by this handler. The off-box listener never sees it. Per rf2-6hklf: `event-emit/dispatch-on-event!` honours this BEFORE the elision walk — sensitive handlers short-circuit the listener fan-out.
+
+```clojure
+(rf/reg-event-fx :auth/login-submitted
+  {:doc       "User submitted the login form."
+   :sensitive? true}                                    ;; drops the whole record
+  [(rf/with-redacted [[:password]])]                    ;; AND scrubs the in-handler view
+  (fn [_ctx [_ {:keys [username password]}]]
+    {:fx [[:http {:method :post :url "/api/login" :body {:username username :password password}}]]}))
+```
+
+Verified: `re-frame.event-emit/dispatch-on-event!` short-circuits when `(:sensitive? (handler-meta ...))` is true (`event_emit.cljc:116-126`). The framework also hoists `:sensitive? true` to the top level of every trace event emitted within the handler's scope (`re-frame.trace/*current-sensitive?*` dynamic, `trace.cljc:245-267`).
+
+**Registration-time warning**: declaring `:sensitive? true` without `(rf/with-redacted ...)` in the interceptor chain emits `:rf.warning/sensitive-without-redaction` (once per `(kind, id)`). Opt out with `{:no-redaction-needed? true}` in the metadata-map when the event vector carries no payload to scrub.
+
+## `:large?` — schema-slot meta (size declaration)
+
+Per-slot Malli prop on `reg-app-schema` slots. Pre-populates the frame's `[:rf/elision :declarations]` registry at schema-registration time. Values at flagged paths emit the marker `:rf.size/large-elided` on the wire instead of their content.
+
+```clojure
+(rf/reg-app-schema [:user :profile]
+  [:map
+   [:id           :uuid]
+   [:display-name :string]
+   [:avatar-png   {:large? true :hint "base64 PNG, up to 2MB"} :string]
+   [:report-pdf   {:large? true} :string]])
+```
+
+Marker shape on the wire (Spec-Schemas `:rf/elision-marker`):
+
+```clojure
+{:rf.size/large-elided true
+ :path     [:user :profile :avatar-png]
+ :bytes    1923847
+ :source   :app-schema       ;; or :app-declared, :runtime-flagged
+ :hint     "base64 PNG, up to 2MB"
+ ;; :digest  "fnv1a32:..."   ;; only when :rf.size/include-digests? true
+ ;; :handle  {:frame :rf/default :path [...] :as-of-epoch 42}
+ }
+```
+
+Verified: schema-driven population at `implementation/schemas/src/re_frame/schemas.cljc:418-540` (`:large?` walker over `:map` / `:multi` / nested schemas); registry layout per `Spec-Schemas §:rf/elision-registry`.
+
+## `rf/elide-wire-value` — manual invocation
+
+For HTTP forwarders, custom loggers, or any consumer code that ships an app-db slice off-box. Same walker the framework's listeners use; **never hand-roll**.
+
+```clojure
+(:require [re-frame.core :as rf])
+
+(rf/elide-wire-value some-value)                     ;; defaults: off-box (drop large, drop sensitive)
+(rf/elide-wire-value v {:rf.size/include-large?     true   ;; pass large values through
+                        :rf.size/include-sensitive? true   ;; pass sensitive through (in-box only!)
+                        :rf.size/include-digests?   true   ;; compute the marker's :digest
+                        :rf.size/threshold-bytes    65536  ;; override the 16 KB default
+                        :frame :other-frame                ;; consult another frame's registry
+                        :path  [:slice :sub]               ;; root-context for the walk
+                        :as-of-epoch 42})                  ;; past-epoch handle on the marker
+```
+
+Off-box defaults (`include-large?` / `include-sensitive?` both `false`): large → marker, sensitive → `:rf/redacted`. Verified: `re-frame.elision/elide-wire-value` (`elision.cljc:443-540`); the **single normative emission site** for both sentinels — per-tool reimplementation is prohibited.
+
+## `rf/sensitive?` — public predicate
+
+For consumer-side code (custom listeners, error projectors, post-elision shippers) that needs a uniform "is this trace event flagged sensitive?" check. Returns true iff the trace event's top-level `:sensitive?` field is `true`. Per rf2-sqxjn — every framework consumer (Causa, Story, pair2-preload, pair2-mcp, story-mcp, causa-mcp) gates on this; consumer code should too rather than reach into `(:sensitive? ev)` directly.
+
+```clojure
+(rf/register-trace-cb! :my/listener
+  (fn [ev]
+    (when-not (rf/sensitive? ev)
+      (ship-off-box! ev))))
+```
+
+## `with-redacted` — per-call scrub
+
+Positional interceptor that overwrites named keys in the event vector's payload map with `:rf/redacted` before the handler chain runs. The **handler body sees the unredacted payload** via the regular `:event` coeffect (it needs the real value to do its work); every downstream trace emit (the `:rf.trace/trigger-handler` cofx view, `:event/db-changed` `:tags`, `:rf.error/handler-exception` `:tags :event`) sees the scrubbed form.
+
+```clojure
+(rf/reg-event-fx :auth/2fa-verify
+  {:sensitive? true}
+  [(rf/with-redacted [[:totp-code] [:remember-token]])]    ;; vector of get-in-style paths
+  (fn [_ctx [_ {:keys [user totp-code remember-token]}]]
+    ...))
+```
+
+Conventional event shape `[event-id payload-map & rest]` only — `with-redacted` is a no-op on non-conventional shapes (per `privacy.cljc:80-92`).
+
+## Composition: sensitive wins
+
+```
+event flagged :sensitive?     →  record DROPPED (no listener invocation)
+event payload at :large? path →  payload elided to :rf.size/large-elided marker
+BOTH                          →  :rf/redacted (sensitive wins; no marker emitted)
+```
+
+Reason: the `:rf.size/large-elided` marker itself carries `:path` / `:bytes` / `:digest`, which would leak the existence of a sensitive value. The walker short-circuits at the sensitive predicate (`elision.cljc:494-540`).
+
+## `:rf/elision` app-db reserved key
+
+The runtime owns `[:rf/elision]` in every frame's app-db; user code MUST NOT write there. Layout per Spec-Schemas `:rf/elision-registry`:
+
+```clojure
+{:rf/elision
+ {:declarations    {<path> {:large? bool :hint <str-or-nil> :source <kw> :sensitive? bool}}
+  :runtime-flagged {<path> {:bytes <int>}}
+  :sensitive-declarations { ... }}}            ;; per rf2-i6bmj
+}
+```
+
+`:declarations` is populated by `reg-app-schema` (`:large?` walker) and `:rf.size/declare-large` fx; `:runtime-flagged` is the auto-detect side-channel (see below); `:sensitive-declarations` mirrors the `:large?` registry for privacy paths. Causa's partition-reserved key list covers `:rf/elision` (per rf2-w1r29).
+
+## Auto-detect threshold
+
+Values whose `pr-str` form exceeds `:rf.size/threshold-bytes` (default **16 KB**) auto-flag at the leaf and emit the marker even without a declaration. The walker writes the path to `[:rf/elision :runtime-flagged]` so subsequent emits short-circuit on the registry hit rather than re-measuring.
+
+```clojure
+;; Process-level knob:
+(rf/configure :elision {:rf.size/threshold-bytes 65536})    ;; raise to 64 KB
+(rf/configure :elision {:rf.size/threshold-bytes 0})        ;; disable auto-detect
+```
+
+Per-call opt-out via the opts map (`:rf.size/include-large? true` passes large values through; see `rf/elide-wire-value` above). Verified: `elision.cljc:39-62` (knob), `elision.cljc:486-528` (auto-detect leaf-only walk; containers are walked, scalars/strings are measured).
+
+## Cross-references
+
+- Guide chapter: [`docs/guide/23-privacy-and-elision.md`](../../../../docs/guide/23-privacy-and-elision.md) — narrative walkthrough with worked examples.
+- Spec normative: [`spec/009-Instrumentation.md §Privacy / sensitive data in traces`](../../../../spec/009-Instrumentation.md) (lines 1149-1268), §Size elision in traces (line 1325).
+- Reserved namespace catalogue: [`spec/Conventions.md §Reserved namespaces`](../../../../spec/Conventions.md#reserved-namespaces-framework-owned) — `:rf.size/*`, `:rf/redacted`, `:rf/elision`.
+- Production listener composition: [`production-observability.md`](production-observability.md) — `:sensitive?` is honoured BEFORE elision at the listener boundary.
+
+---
+
+*Derived from `re-frame.elision`, `re-frame.privacy`, `re-frame.event-emit`, `re-frame.trace` @ main. Verified surfaces: `elide-wire-value` (elision.cljc:443), `with-redacted` (privacy.cljc:96), `sensitive?` (trace.cljc:255), `:large?` schema walker (schemas.cljc:418-540).*

--- a/skills/re-frame2/reference/cross-cutting/production-observability.md
+++ b/skills/re-frame2/reference/cross-cutting/production-observability.md
@@ -1,0 +1,138 @@
+# Production observability
+
+Production observability rides **two always-on listener APIs** that survive `goog.DEBUG=false` and `:advanced` compilation. They are **parallel to** (not a fallback from) the dev-only trace bus. The trace surface DCEs in CLJS production builds; `register-event-emit-listener!` and `register-error-emit-listener!` do not. Use them to ship event + error records to Datadog / Sentry / Honeycomb / a custom pipeline.
+
+Authoring rule: in production, you wire two listeners — one for events (success + error outcomes), one for errors (exception payloads). The framework already runs `elide-wire-value` against each record's `:event` vector before fan-out — listeners do **not** re-walk for privacy / size.
+
+## When to load
+
+Wiring a production observability shipper, writing a `register-event-emit-listener!` / `register-error-emit-listener!` body, or asking "what's the prod-survivable equivalent of `register-trace-cb!`?".
+
+## `register-event-emit-listener!` — one record per dispatched event
+
+Per rf2-rirbq. Fires once per event the runtime processes — NOT per sub, NOT per fx, NOT per `:event/db-changed`. Registration is idempotent (re-registering the same id replaces); listener exceptions are caught (cascade continues).
+
+```clojure
+(rf/register-event-emit-listener!
+  :datadog/events
+  (fn [event-record]
+    (datadog/track-event! event-record)))
+
+(rf/unregister-event-emit-listener! :datadog/events)
+```
+
+**Record shape (tight — Spec 009 §Event-emit listener):**
+
+```clojure
+{:event      [:cart/checkout {:items [...]}]      ;; the dispatched event vector (elided)
+ :event-id   :cart/checkout                        ;; (first event)
+ :frame      :rf/default                           ;; resolved frame-id
+ :time       1715600000000                         ;; emit timestamp (host clock, ms since epoch)
+ :outcome    :ok                                   ;; :ok | :error
+ :elapsed-ms 12}                                   ;; queue → settle, integer
+```
+
+No trace-bus keys (no `:dispatch-id`, `:parent-dispatch-id`, `:rf.trace/trigger-handler`, source coords) — those ride the dev-only trace surface. Verified: `re-frame.event-emit/dispatch-on-event!` (`event_emit.cljc:167-230`); record shape per the ns docstring §Record shape.
+
+**Handler-meta `:sensitive?` honoured BEFORE elision** (per rf2-6hklf): if the event's registered handler-meta carries `:sensitive? true`, `dispatch-on-event!` drops the record entirely — listeners are NOT invoked, regardless of which paths in the payload happen to match `[:rf/elision]` declarations. Sensitive at the handler boundary is the headline privacy filter.
+
+## `register-error-emit-listener!` — one record per runtime error
+
+Per rf2-bacs4. Fires once per `:rf.error/*` event the runtime emits through the error-emit substrate (handler exceptions today; the substrate is the normative seam for future `:rf.error/*` records). Independent of the per-frame `:on-error` policy fn (per rf2-hqbeh) — both fan out from the same emission site; one bad listener cannot affect the policy fn, and vice versa.
+
+```clojure
+(rf/register-error-emit-listener!
+  :sentry/errors
+  (fn [error-record]
+    (sentry/capture-exception
+      (:exception error-record)
+      {:tags {:event-id (:event-id error-record)
+              :frame    (:frame error-record)}})))
+
+(rf/unregister-error-emit-listener! :sentry/errors)
+```
+
+**Record shape (tight — Spec 009 §Error-emit listener):**
+
+```clojure
+{:error      :rf.error/handler-exception           ;; the error keyword
+ :event      [:cart/checkout {...}]                ;; the dispatched event vector (elided)
+ :event-id   :cart/checkout
+ :frame      :rf/default
+ :time       1715600000000                         ;; ms since epoch
+ :exception  #error{...}                           ;; the thrown exception object
+ :elapsed-ms 8}                                    ;; queue → throw, integer
+```
+
+Verified: `re-frame.error-emit/dispatch-on-error!` (`error_emit.cljc:171-230`); record shape per the ns docstring §Record shape.
+
+**Composition with per-frame `:on-error` policy** (rf2-hqbeh): the error-emit substrate runs the per-frame `:on-error` policy AND the corpus-wide listener registry from one emission site. Use `:on-error` for **in-app recovery** (retry, mark, navigate); use `register-error-emit-listener!` for **off-box observability**. They are independent — register both when you need both.
+
+## Triple-gate registration pattern
+
+The substrate is always-on; **registration sites** should belt-and-braces gate on explicit config + `goog.DEBUG=false` + a credential probe, so an accidental dev-bundle deploy with prod config doesn't quietly ship records to your back-end.
+
+```clojure
+(when (and (= "production" (:env config))
+           (not ^boolean re-frame.interop/debug-enabled?)
+           (:api-key config))
+  (rf/register-event-emit-listener!
+    :datadog/events
+    (fn [event-record]
+      (datadog/track-event! event-record)))
+  (rf/register-error-emit-listener!
+    :sentry/errors
+    (fn [error-record]
+      (sentry/capture-exception (:exception error-record)
+                                {:tags {:event-id (:event-id error-record)
+                                        :frame    (:frame error-record)}}))))
+```
+
+Three independent conditions: **config env tag** (the app knows it's production), **`goog.DEBUG=false`** (the bundle is the production bundle), **api-key present** (credentials wired). Skip any leg and you get the dev path. Pattern documented in `re-frame.event-emit` ns docstring §goog.DEBUG framing.
+
+## Why production has no trace bus
+
+`re-frame.trace/emit!` and the `register-trace-cb!` plumbing are gated by `re-frame.interop/debug-enabled?`. Under `:advanced` + `goog.DEBUG=false`, the Closure compiler DCEs the entire trace surface — registrations, the ring buffer, the per-event allocation, every `tag/value` map. The bundle savings (~12-15 KB gzipped) and per-event allocation savings are part of re-frame2's "production debugging is opt-out, not opt-in" stance.
+
+The two always-on listener APIs carve a minimal substrate that **survives** that elision: a tiny record shape, a `defonce` registry that hot reload won't blow away, fan-out gated on registry size (empty-map check short-circuits). Re-enable the full trace bus in production by flipping `:closure-defines {goog.DEBUG true}` if and only if the bundle cost is acceptable.
+
+Full rationale: [`docs/guide/22-trace-to-datadog.md`](../../../../docs/guide/22-trace-to-datadog.md) and [`spec/009-Instrumentation.md §What IS available in production`](../../../../spec/009-Instrumentation.md) (line 489).
+
+## Generic shipper recipe (Datadog / Sentry / Honeycomb)
+
+The record shapes are tight enough to ship verbatim — every observability vendor's wire format is a strict subset of "event-id + timestamp + tags + payload". The pattern:
+
+```clojure
+(rf/register-event-emit-listener!
+  :observability/events
+  (fn [{:keys [event-id event time outcome elapsed-ms frame]}]
+    (forward!
+      {:name      (str event-id)
+       :timestamp time
+       :tags      {:outcome outcome :frame frame}
+       :duration  elapsed-ms
+       :payload   event})))                  ;; already elided — large→marker, sensitive→:rf/redacted
+```
+
+`:payload` (the `:event` slot) has **already** been passed through `rf/elide-wire-value` with off-box defaults (`:rf.size/include-large? false`, `:rf.size/include-sensitive? false`) by the time your listener runs. Do not re-walk unless you want to **widen** the policy (e.g. `:rf.size/include-digests? true` for a debug pipeline). See [`privacy-and-elision.md`](privacy-and-elision.md) for the elision composition rules.
+
+Worked vendor recipes (Datadog tags, Sentry breadcrumbs, Honeycomb spans): [`docs/guide/22-trace-to-datadog.md`](../../../../docs/guide/22-trace-to-datadog.md).
+
+## Common gotchas
+
+- **Listeners block the drain step.** Bodies run synchronously after each event settles. Ship work to a background channel (`requestIdleCallback`, queueing fetch, `setTimeout 0`) if it can't fit inside the per-event wall-clock budget.
+- **Don't re-run elision unless widening.** The record already has off-box defaults applied. A listener that re-walks with defaults is a no-op; one that flips `:include-large?` / `:include-sensitive?` to `true` exposes data you'd otherwise hide.
+- **`:sensitive?` on the handler drops the listener record entirely — there's nothing to ship.** If you need an audit trail of sensitive events (without their payloads), that's a separate per-event `:sensitive?`-aware path; don't try to ship redacted records through the same channel.
+- **Listener exceptions are swallowed.** The cascade catches; sibling listeners still run. You will NOT see a thrown listener error in the console; log inside the listener body if you want visibility.
+- **Don't use `register-trace-cb!` for production observability.** It dies under `:advanced` + `goog.DEBUG=false`. The two `*-emit-listener!` surfaces are the prod-survivable channel.
+
+## Cross-references
+
+- Guide chapter: [`docs/guide/22-trace-to-datadog.md`](../../../../docs/guide/22-trace-to-datadog.md) — narrative walkthrough with vendor-specific recipes.
+- Spec normative: [`spec/009-Instrumentation.md §What IS available in production`](../../../../spec/009-Instrumentation.md) (line 489) — substrate contracts.
+- Privacy composition: [`privacy-and-elision.md`](privacy-and-elision.md) — `:sensitive?` short-circuits BEFORE elision; payload already walked at listener entry.
+- Per-frame `:on-error` policy: [`reference/fundamentals/frames.md`](../fundamentals/frames.md) §`:on-error` — in-app recovery, sibling to the corpus-wide error listener.
+
+---
+
+*Derived from `re-frame.event-emit` (rf2-rirbq) and `re-frame.error-emit` (rf2-bacs4) @ main. Verified surfaces: `register-event-emit-listener!` (event_emit.cljc:139), `register-error-emit-listener!` (error_emit.cljc:139); record shapes per each ns docstring §Record shape.*


### PR DESCRIPTION
## Summary

Closes the structural gap that left the re-frame2 authoring skill with **zero coverage** of the privacy + size-elision arc and the production observability listener APIs that landed this session — AI agents writing new re-frame2 code now reach for `:sensitive?` / `:large?` / `register-event-emit-listener!` by default.

Two new cross-cutting leaves under `skills/re-frame2/reference/cross-cutting/`:

- **`privacy-and-elision.md`** (145 lines / 9.5 KB) — `:sensitive?` handler-meta as the headline privacy flag (honoured BEFORE elision at the event-emit boundary per rf2-6hklf), `:large?` schema-slot meta with the `:rf.size/large-elided` marker shape, `rf/elide-wire-value` manual invocation, `rf/sensitive?` public predicate (rf2-sqxjn), `with-redacted` per-call scrubber, the sensitive-wins composition rule, the `:rf/elision` app-db reserved key layout, the 16 KB auto-detect threshold.

- **`production-observability.md`** (138 lines / 10 KB) — `register-event-emit-listener!` (rf2-rirbq) and `register-error-emit-listener!` (rf2-bacs4) with their tight record shapes, the triple-gate registration pattern, why the dev trace surface DCEs under `:advanced` + `goog.DEBUG=false`, and a vendor-generic shipper recipe.

Plus SKILL.md routing-table rows pointing at both leaves and an extended `Cross-cutting` line under §Where the depth lives.

Both leaves stay well under the rf2-zkca8 leaf-size ceiling (≤250 lines / ≤16 KB). No impl / spec changes — pure skill additions.

## Test plan

- [ ] `mkdocs build --strict` succeeds (no broken cross-links — all `../../../../docs/guide/*` and `../../../../spec/*` paths verified to resolve at the file level)
- [ ] Spot-read both leaves and SKILL.md changes for tone match with neighbouring `cross-cutting/testing.md` and `cross-cutting/api-cheatsheet.md`