### PR TITLE
feat(pair2-mcp): subscription-info MCP tool (rf2-zjz9q)

### DIFF
--- a/skills/re-frame-pair2/SKILL.md
+++ b/skills/re-frame-pair2/SKILL.md
@@ -25,6 +25,7 @@ allowed-tools:
   - mcp__re-frame-pair2__get-path
   - mcp__re-frame-pair2__subscribe
   - mcp__re-frame-pair2__unsubscribe
+  - mcp__re-frame-pair2__subscription-info
   # story-mcp — live-session tools only (rf2-1v7tu HYBRID). The
   # authoring-side surface (register-variant, get-variant,
   # preview-variant, list-stories, …) is allow-listed by the

--- a/skills/re-frame-pair2/references/mcp-transport.md
+++ b/skills/re-frame-pair2/references/mcp-transport.md
@@ -54,6 +54,7 @@ The server auto-discovers the nREPL port from (in order):
 | _(none — MCP-only)_                | `get-path`     | `{path: "[:cart :items 0 :sku]", frame: ":rf/default"}` — targeted-read primitive (rf2-tygdv). Returns `{ok? true :exists? true :value <subtree>}` or `{ok? false :reason :path-not-found :deepest-valid-prefix [...]}`. `:exists?` distinguishes a path that legitimately points at `nil` from a missing path. |
 | _(none — MCP-only, push-mode)_     | `subscribe`    | `{topic: "trace"\|"epoch"\|"fx"\|"error", filter: {...}, max-events: 0, max-ms: 0}` — emits `notifications/progress` ticks; resolves on cancel / `max-events` / `max-ms` / `unsubscribe`. See `references/streaming-subscriptions.md`. |
 | _(none — MCP-only)_                | `unsubscribe`  | `{sub-id: "<uuid>"}` — idempotent close. |
+| _(none — MCP-only)_                | `subscription-info` | `{}` (or `{topic: "epoch"}` / `{sub-id: "<uuid>"}`) — list active streaming subscriptions with `:queue-depth`, `:dropped-events`, `:overflow-reason` without draining queues. Diagnostic for "is my probe still alive?". |
 
 The `subscribe` / `unsubscribe` pair is the **push-mode** replacement for `watch-epochs`. Each batch of matching events arrives as a `notifications/progress` notification correlated by the call's `progressToken`; the tool's final result is a summary. Use `subscribe` whenever you want a live narration; fall back to `watch-epochs` (pull-mode) when the agent host doesn't surface progress notifications to the model.
 

--- a/skills/re-frame-pair2/references/recipes.md
+++ b/skills/re-frame-pair2/references/recipes.md
@@ -185,13 +185,13 @@ Fallback: `mcp__re-frame-pair2__watch-epochs {stream: true, pred: {"event-id-pre
 
 ### Inspect what's currently subscribed
 
-`re-frame-pair2.runtime/subscription-info` reports every open subscription's `{:id :topic :filter :queue-depth :queue-bytes :dropped-events :dropped-bytes :overflow-reason :created-at}` without draining the queues. To list active streams:
+The `subscription-info` MCP tool reports every open subscription's `{:id :topic :filter :queue-depth :queue-bytes :dropped-events :dropped-bytes :overflow-reason :created-at}` without draining the queues. To list active streams:
 
 ```
-mcp__re-frame-pair2__eval-cljs {form: "(re-frame-pair2.runtime/subscription-info)"}
+mcp__re-frame-pair2__subscription-info {}
 ```
 
-Use this when a streaming probe seems to have gone quiet — confirm it's still registered (and that its queue-depth isn't piling up against a dead consumer) before assuming the bus is dry.
+Optional filters: pass `topic` (`trace` / `epoch` / `fx` / `error`) to narrow, or `sub-id` to look up a specific stream. Use this when a streaming probe seems to have gone quiet — confirm it's still registered (and that its queue-depth isn't piling up against a dead consumer) before assuming the bus is dry.
 
 ## "Drive a Story variant from a pair2 session"
 

--- a/skills/re-frame-pair2/references/streaming-subscriptions.md
+++ b/skills/re-frame-pair2/references/streaming-subscriptions.md
@@ -164,10 +164,12 @@ mcp__re-frame-pair2__unsubscribe {sub-id: "<the uuid from the subscribe response
 
 ## Diagnostics — what's currently registered?
 
-`re-frame-pair2.runtime/subscription-info` reports every open subscription without draining its queue:
+The `subscription-info` MCP tool reports every open subscription without draining its queue:
 
 ```
-mcp__re-frame-pair2__eval-cljs {form: "(re-frame-pair2.runtime/subscription-info)"}
+mcp__re-frame-pair2__subscription-info {}
 ```
 
 Returns `{:ok? true :subs [{:id :topic :filter :queue-depth :queue-bytes :dropped-events :dropped-bytes :overflow-reason :created-at}]}`. Useful when a probe seems to have gone quiet — confirm the sub is still registered (and that `queue-depth` / `queue-bytes` isn't piling up against a dead consumer) before assuming the bus is dry. A non-nil `:overflow-reason` indicates the queue has been evicting older events to stay inside its budget.
+
+Optional filters: pass `topic` (one of `trace` / `epoch` / `fx` / `error`) to narrow to a single topic, or `sub-id` to look up a specific stream — e.g. `mcp__re-frame-pair2__subscription-info {topic: "epoch"}` or `mcp__re-frame-pair2__subscription-info {sub-id: "<uuid>"}`.

--- a/tools/pair2-mcp/README.md
+++ b/tools/pair2-mcp/README.md
@@ -37,6 +37,7 @@ cljs-eval compile.
 | `get-path`     | _(new — no bash equivalent)_ | Read a single value at `path` from a frame's app-db (rf2-tygdv). Minimal targeted-read primitive; server-side `get-in` so only the addressed subtree crosses the wire. Distinguishes a path that points at `nil` from a path that doesn't resolve, and attaches `deepest-valid-prefix` on misses so the agent can re-aim. |
 | `subscribe`    | _(new — no bash equivalent)_ | Streaming subscription on the trace / epoch bus (rf2-hq49). Push-mode replacement for `watch-epochs`; each matching event arrives as a `notifications/progress` notification. Topics: `trace`, `epoch`, `fx`, `error`. |
 | `unsubscribe`  | _(new — no bash equivalent)_ | Close a streaming subscription out-of-band. Idempotent — closing an unknown sub-id returns `:existed? false` rather than an error. |
+| `subscription-info` | _(new — no bash equivalent)_ | List active streaming subscriptions with per-sub queue depth, drop counts, and `:overflow-reason` (rf2-zjz9q). Diagnostic for "what streams are open?" / "is my probe still alive?" — wraps the runtime fn directly so AI clients don't need an `eval-cljs` round-trip. Optional `topic` / `sub-id` filters. |
 
 ## Quick start
 

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -18,6 +18,8 @@
   | subscribe     | Streaming trace/epoch channel — push-mode replacement for |
   |               | watch-epochs (rf2-hq49)                                   |
   | unsubscribe   | Close a streaming subscription                            |
+  | subscription-info | List active streaming subscriptions + queue stats     |
+  |               | (rf2-zjz9q)                                               |
 
   ## Diff-encoded epoch slice (rf2-1wdzp)
 
@@ -2012,6 +2014,47 @@
             (.catch (fn [err] (err->result :unsubscribe-failed err))))))))
 
 ;; ---------------------------------------------------------------------------
+;; Tool: subscription-info — list active streaming subscriptions (rf2-zjz9q).
+;;
+;; Wraps the `re-frame-pair2.runtime/subscription-info` diagnostic so AI
+;; clients don't need an `eval-cljs` round-trip just to ask "what
+;; streams are currently open?". One cheap nREPL eval — the runtime fn
+;; is a pure read over the in-memory `subscriptions` atom and does NOT
+;; drain queues. Useful when a streaming probe seems to have gone quiet
+;; (confirm the sub is still registered, check `:queue-depth` /
+;; `:overflow-reason` for evidence of a dead consumer).
+;;
+;; Args (all optional):
+;;   :topic   keyword or string — filter to a single topic
+;;            (`:trace` / `:epoch` / `:fx` / `:error`).
+;;   :sub-id  string uuid — return only the matching sub. Convenient
+;;            for "is this specific stream still alive?" checks.
+;;
+;; Returns `{:ok? true :subs [{:id :topic :filter :queue-depth
+;; :queue-bytes :dropped-events :dropped-bytes :overflow-reason
+;; :created-at}]}`. Empty `:subs` vector when no streams are open (or
+;; when the filter matches nothing).
+;; ---------------------------------------------------------------------------
+
+(defn- subscription-info-tool [conn args]
+  (let [build-id (arg-build args)
+        topic    (some-> (arg args :topic) keyword)
+        sub-id   (arg args :sub-id)
+        form     (str "(let [r (re-frame-pair2.runtime/subscription-info)"
+                      "      subs (:subs r)"
+                      "      f1 (if " (pr-str topic)
+                      "           (filterv #(= (:topic %) " (pr-str topic) ") subs)"
+                      "           subs)"
+                      "      f2 (if " (pr-str sub-id)
+                      "           (filterv #(= (:id %) " (pr-str sub-id) ") f1)"
+                      "           f1)]"
+                      "  (assoc r :subs f2))")]
+    (-> (ensure-runtime! conn build-id)
+        (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+        (.then (fn [v] (ok-text (if (map? v) v {:ok? true :subs []}))))
+        (.catch (fn [err] (err->result :subscription-info-failed err))))))
+
+;; ---------------------------------------------------------------------------
 ;; Tool descriptors — exposed via tools/list.
 ;;
 ;; Every descriptor gets a universal `max-tokens` property bolted on
@@ -2403,6 +2446,27 @@
                                         :description "The uuid returned by `subscribe`."}
                                :build  {:type "string"}}
                   :required ["sub-id"]
+                  :additionalProperties false}}
+   {:name "subscription-info"
+    :description (str "List active streaming subscriptions opened via `subscribe`, with per-sub queue depth, "
+                      "drop counts, and overflow-reason — without draining any queues. Diagnostic for "
+                      "'what streams are currently open?' and 'is my probe still alive?'. Wraps the "
+                      "`re-frame-pair2.runtime/subscription-info` runtime fn directly (no eval-cljs round-trip). "
+                      "Returns `{:ok? true :subs [{:id :topic :filter :queue-depth :queue-bytes "
+                      ":dropped-events :dropped-bytes :overflow-reason :created-at}]}` — one entry per "
+                      "currently-registered subscription. Empty `:subs` vector when no streams are open. "
+                      "Optional filters: `topic` (one of `:trace` / `:epoch` / `:fx` / `:error`) narrows to "
+                      "a single topic; `sub-id` returns only the matching sub. A non-nil `:overflow-reason` "
+                      "indicates the queue has been evicting older events to stay inside its budget — tune "
+                      "`max-buffered-events` / `max-buffered-bytes` on the next `subscribe` call.")
+    :typicalTokens 500
+    :inputSchema {:type "object"
+                  :properties {:topic  {:type "string"
+                                        :description "Optional filter — only return subs on this topic. One of trace, epoch, fx, error."
+                                        :enum ["trace" "epoch" "fx" "error"]}
+                               :sub-id {:type "string"
+                                        :description "Optional filter — only return the sub with this uuid."}
+                               :build  {:type "string"}}
                   :additionalProperties false}}])
 
 (defn tool-descriptors-js []
@@ -2424,6 +2488,7 @@
     "get-path"         (get-path-tool  conn args)
     "subscribe"        (subscribe-tool conn args extra)
     "unsubscribe"      (unsubscribe-tool conn args)
+    "subscription-info" (subscription-info-tool conn args)
     (js/Promise.resolve
       (err-text {:ok? false :reason :unknown-tool :tool name}))))
 

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/subscription_info_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/subscription_info_test.cljs
@@ -1,0 +1,49 @@
+(ns re-frame-pair2-mcp.subscription-info-test
+  "Unit tests for the `subscription-info` MCP tool (rf2-zjz9q).
+
+  The MCP server builds a CLJS form that calls
+  `re-frame-pair2.runtime/subscription-info` and optionally filters by
+  `:topic` / `:sub-id` server-side. The live end-to-end coverage runs
+  against a real shadow-cljs runtime; these tests pin the wire-form
+  shape and the descriptor contract so accidental renames or arg-name
+  slips break the test rather than silently shipping a broken tool."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [applied-science.js-interop :as j]
+            [re-frame-pair2-mcp.tools :as tools]))
+
+(deftest descriptor-present
+  (testing "`subscription-info` is registered in tool-descriptors"
+    (let [d (some #(when (= "subscription-info" (:name %)) %)
+                  tools/tool-descriptors)]
+      (is (some? d) "descriptor exists")
+      (is (string? (:description d)))
+      (is (integer? (:typicalTokens d)))
+      (is (pos? (:typicalTokens d)))
+      ;; Optional args — no `:required` slot.
+      (is (nil? (:required (:inputSchema d)))
+          "descriptor has no required args — both filters optional")
+      (let [props (:properties (:inputSchema d))]
+        (is (contains? props :topic))
+        (is (contains? props :sub-id))
+        (is (= ["trace" "epoch" "fx" "error"]
+               (:enum (:topic props)))
+            "topic enum lists the four runtime topics")))))
+
+(deftest descriptor-surfaces-on-tools-list
+  (testing "subscription-info shows up in tool-descriptors-js"
+    (let [arr   (tools/tool-descriptors-js)
+          names (set (for [i (range (alength arr))]
+                       (j/get (aget arr i) :name)))]
+      (is (contains? names "subscription-info")
+          "tool-descriptors-js includes subscription-info"))))
+
+(deftest dispatch-routes-unknown-tool-error
+  (testing "dispatch-tool* still surfaces :unknown-tool for typos"
+    ;; Sanity: confirm subscription-info ISN'T being matched by accident.
+    ;; (Direct dispatch-tool* would need a fake conn; we just inspect
+    ;; the descriptor wiring above. This test pins that the descriptor
+    ;; name uses the expected hyphen form, not snake_case.)
+    (let [d (some #(when (= "subscription-info" (:name %)) %)
+                  tools/tool-descriptors)]
+      (is (= "subscription-info" (:name d))
+          "name uses kebab-case, not subscription_info / subscriptionInfo"))))


### PR DESCRIPTION
## Summary

- Adds the `subscription-info` MCP tool to `tools/pair2-mcp/` — wraps the existing `re-frame-pair2.runtime/subscription-info` runtime fn so AI clients can list active streaming subscriptions (`:trace` / `:epoch` / `:fx` / `:error`) with per-sub queue depth, drop counts, and `:overflow-reason` without an `eval-cljs` round-trip.
- Optional `topic` / `sub-id` filters; server-side filter narrows the result before it crosses the wire. Pure read — does not drain queues.
- Skill references (`streaming-subscriptions.md`, `recipes.md`, `mcp-transport.md`) and `SKILL.md` allowed-tools updated to use the new tool surface instead of the eval-cljs form.
- Two-plus test coverage in `subscription_info_test.cljs` — descriptor presence, optional-args shape (no `:required`), `tools/list` projection, kebab-case name pin.

## Test plan

- [x] `npm test` in `tools/pair2-mcp/` (270 tests / 660 assertions, 0 failures, 0 errors)
- [x] `npm run build` (server compiles cleanly, 0 warnings)
- [x] New tests run as `re-frame-pair2-mcp.subscription-info-test`
- [ ] Manual live-runtime smoke once shipped (out of scope for this PR — covered by existing live nREPL integration patterns)