### PR TITLE
feat(core): :rf.trace/no-emit? event-meta opt-out (rf2-qsjda)

### DIFF
--- a/examples/reagent/counter_with_stories/elision_demo_cljs_test.cljs
+++ b/examples/reagent/counter_with_stories/elision_demo_cljs_test.cljs
@@ -26,7 +26,6 @@
             [re-frame.frame        :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
-            [re-frame.trace        :as trace]
             ;; Loading the demo ns fires its registrations against the
             ;; registrar — the tests then exercise the registered
             ;; handlers + the listener install/uninstall surface.
@@ -38,15 +37,13 @@
 
 (defn- before! []
   (reset! registrar-snapshot (test-support/snapshot-registrar))
-  ;; Causa (and any other on-classpath dev tools) register
-  ;; trace-cbs at preload time. Those callbacks dispatch their own
-  ;; events on every sensitive trace event — which would pollute
-  ;; the elision tests' deterministic listener-counts. Clear so
-  ;; each test runs against an empty trace-cb registry. The
-  ;; per-test isolation is fine; the next suite that needs
-  ;; Causa-installed trace-cbs re-installs them via its own
-  ;; fixture.
-  (trace/clear-trace-cbs!)
+  ;; Per rf2-qsjda: Causa's preload-time trace-cb registers its
+  ;; bookkeeping handlers with `:rf.trace/no-emit? true`, so the
+  ;; framework short-circuits emission for them and the collector
+  ;; never re-enters itself. The previous workaround that wiped
+  ;; the trace-cb registry per fixture (rf2-vw0to → rf2-nk01x
+  ;; tactical fix) is obsolete — Causa's cb runs as production
+  ;; preload wires it.
   (reset! frame/frames {})
   (try (rf/init! plain-atom/adapter) (catch :default _ nil))
   (frame/ensure-default-frame!)

--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -206,10 +206,13 @@
                ;; this scope; any trace event it emits carries the
                ;; cofx-handler-level sensitivity flag per Spec 009
                ;; "innermost in-scope handler" rule.
+               ;; Per rf2-qsjda: bind `*current-no-emit?*` symmetrically.
                (binding [trace/*current-trigger-handler*
                          (trace/trigger-handler-from-meta :cofx cofx-id meta)
                          trace/*current-sensitive?*
                          (trace/sensitive?-from-meta meta)
+                         trace/*current-no-emit?*
+                         (trace/no-emit?-from-meta meta)
                          trace/*current-call-site*
                          (or captured-cs trace/*current-call-site*)]
                  (-> (if valued?

--- a/implementation/core/src/re_frame/event_emit.cljc
+++ b/implementation/core/src/re_frame/event_emit.cljc
@@ -193,12 +193,22 @@
   `:sensitive? true`, the record is dropped entirely (listeners are
   NOT invoked). The handler-meta lookup happens BEFORE the elision
   walk so the sensitive-handler short-circuit costs no per-value
-  work."
+  work.
+
+  Per rf2-qsjda: if the event's registered handler-meta carries
+  `:rf.trace/no-emit? true`, the record is also dropped. The flag
+  marks the handler as a framework-internal bookkeeping handler
+  (Spec 009 §Trace-emission opt-out) — its dispatches are not
+  user-domain observable signal. Production observability pipelines
+  should not see Causa/Story/etc. bookkeeping dispatches in their
+  event stream any more than they should see the trace events those
+  handlers suppress."
   [event event-id frame time outcome elapsed-ms]
   (let [reg @listeners]
     (when (seq reg)
       (let [handler-meta (registrar/lookup :event event-id)]
-        (when-not (:sensitive? handler-meta)
+        (when-not (or (:sensitive?        handler-meta)
+                      (:rf.trace/no-emit? handler-meta))
           (let [elided-event (elision/elide-wire-value event {:frame frame})
                 record       {:event      elided-event
                               :event-id   event-id

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -314,10 +314,15 @@
         ;; wins" rule: when an event handler is sensitive but the fx
         ;; handler it dispatches to is not, the `:rf.fx/handled`
         ;; trace event reflects the FX handler's reading.
+        ;; Per rf2-qsjda: bind `*current-no-emit?*` to the fx
+        ;; handler's reading so the "innermost in-scope handler
+        ;; wins" rule applies to trace-emission opt-out too.
         (binding [trace/*current-trigger-handler*
                   (trace/trigger-handler-from-meta :fx fx-id meta)
                   trace/*current-sensitive?*
-                  (trace/sensitive?-from-meta meta)]
+                  (trace/sensitive?-from-meta meta)
+                  trace/*current-no-emit?*
+                  (trace/no-emit?-from-meta meta)]
           (let [ok? (try
                       ((:handler-fn meta) (cond-> {:frame frame-id}
                                             origin-event (assoc :event origin-event))

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -453,10 +453,22 @@
           ;; (the inner fx scope re-binds), :sub/run (sub recompute
           ;; re-binds to the sub's reading), :rf.error/* (every error
           ;; emit inside the chain).
+          ;;
+          ;; Per rf2-qsjda: also bind `*current-no-emit?*` from the
+          ;; handler's registration meta. When the handler carries
+          ;; `:rf.trace/no-emit? true`, every trace event produced
+          ;; inside the handler's scope short-circuits at `emit!` /
+          ;; `emit-error!` (no envelope allocation, no listener
+          ;; fan-out). The framework-level trace-emission opt-out
+          ;; (Spec 009 §Trace-emission opt-out) — covers the cascade
+          ;; from this binding through the interceptor chain, db
+          ;; commit, flows, and fx walk.
           (binding [trace/*current-trigger-handler*
                     (trace/trigger-handler-from-meta :event event-id handler-meta)
                     trace/*current-sensitive?*
-                    (trace/sensitive?-from-meta handler-meta)]
+                    (trace/sensitive?-from-meta handler-meta)
+                    trace/*current-no-emit?*
+                    (trace/no-emit?-from-meta handler-meta)]
             (let [;; Per rf2-rirbq: capture the wall-clock at the very
                   ;; start of cascade execution so the always-on
                   ;; event-emit substrate can report `:elapsed-ms` in
@@ -779,24 +791,35 @@
   in the drain). Look up the target handler's registration metadata
   directly and pass `:sensitive?` in the tags so `emit!` hoists it
   to the top level. When the handler is missing the field is omitted
-  (consumers treat absent as false)."
+  (consumers treat absent as false).
+
+  Per rf2-qsjda: same queue-time consideration applies for
+  `:rf.trace/no-emit?`. The handler-scope binding for
+  `*current-no-emit?*` doesn't exist yet at enqueue time, so we read
+  the flag directly off the target handler's registration meta and
+  short-circuit the `:event/dispatched` emit when set. Without this,
+  a Causa-style bookkeeping handler would have its enqueue trace
+  delivered to listeners (re-entering the consumer's trace-cb)
+  before the handler-scope binding ever took effect."
   [envelope sync?]
   (let [event        (:event envelope)
         event-id     (when (vector? event) (first event))
         handler-meta (when event-id (registrar/lookup :event event-id))
-        sensitive?   (trace/sensitive?-from-meta handler-meta)]
-    (trace/emit! :event :event/dispatched
-                 (cond-> {:event    event
-                          :frame    (:frame envelope)
-                          :origin   (:origin envelope)
-                          :source   (:source envelope)
-                          :sync?    sync?}
-                   sensitive?
-                   (assoc :sensitive? true)
-                   (:dispatch-id envelope)
-                   (assoc :dispatch-id (:dispatch-id envelope))
-                   (:parent-dispatch-id envelope)
-                   (assoc :parent-dispatch-id (:parent-dispatch-id envelope))))))
+        sensitive?   (trace/sensitive?-from-meta handler-meta)
+        no-emit?     (trace/no-emit?-from-meta handler-meta)]
+    (when-not no-emit?
+      (trace/emit! :event :event/dispatched
+                   (cond-> {:event    event
+                            :frame    (:frame envelope)
+                            :origin   (:origin envelope)
+                            :source   (:source envelope)
+                            :sync?    sync?}
+                     sensitive?
+                     (assoc :sensitive? true)
+                     (:dispatch-id envelope)
+                     (assoc :dispatch-id (:dispatch-id envelope))
+                     (:parent-dispatch-id envelope)
+                     (assoc :parent-dispatch-id (:parent-dispatch-id envelope)))))))
 
 (defn dispatch!
   "Append the event to the target frame's router queue. Per Spec 002:

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -247,10 +247,15 @@
   ;; per Spec 009 §Privacy line 1160 "the conventional use sites
   ;; are reg-event-* and reg-sub" — sub return values flow user
   ;; input into views and must be filterable.
+  ;; Per rf2-qsjda: bind `*current-no-emit?*` symmetrically — a sub
+  ;; whose registration carries `:rf.trace/no-emit? true` produces
+  ;; no `:sub/run` trace event (and no error trace if it throws).
   (binding [trace/*current-trigger-handler*
             (trace/trigger-handler-from-meta :sub query-id sub-meta)
             trace/*current-sensitive?*
-            (trace/sensitive?-from-meta sub-meta)]
+            (trace/sensitive?-from-meta sub-meta)
+            trace/*current-no-emit?*
+            (trace/no-emit?-from-meta sub-meta)]
     (trace/emit! :sub/run :sub/run
                  {:sub-id  query-id
                   :query-v query-v

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -266,6 +266,66 @@
   (and (map? trace-event)
        (true? (:sensitive? trace-event))))
 
+;; ---- *current-no-emit?* (rf2-qsjda) ---------------------------------------
+;;
+;; Per Spec 009 §Trace-emission opt-out: handlers whose registration meta
+;; carries `:rf.trace/no-emit? true` produce NO trace events. The flag is
+;; the framework-level escape hatch for trace-consuming integrations
+;; (Causa, Story, pair2-preload, …) whose own bookkeeping dispatches —
+;; emitted from inside a trace-cb — would otherwise re-enter the consumer
+;; through the trace-cb fan-out and form a cb-dispatch loop. (Originally
+;; landed by rf2-nk01x as a per-consumer Causa-side guard; this Var
+;; promotes the opt-out to the framework so any consumer can declare a
+;; handler internal-only without writing its own guard.)
+;;
+;; The runtime carries the in-scope handler's no-emit reading through the
+;; dynamic Var `*current-no-emit?*` — bound alongside `*current-trigger-
+;; handler*` (rf2-3nn8 / rf2-lf84g) and `*current-sensitive?*` (rf2-isdwf)
+;; at every handler-scope binding site (router, fx, cofx, subs, views).
+;; `emit!` and `emit-error!` read this Var and short-circuit (no envelope
+;; allocation, no listener fan-out, no buffer push) when bound true.
+;;
+;; The flag also rides the queue-time emit path: `emit-dispatched-trace!`
+;; in `router.cljc` reads the target handler's registration meta and
+;; suppresses the `:event/dispatched` emit when the meta carries
+;; `:rf.trace/no-emit? true` (mirrors the queue-time `:sensitive?` lookup
+;; per rf2-isdwf since the handler-scope binding doesn't exist yet at
+;; enqueue time).
+;;
+;; Cascade composition rule: the innermost in-scope handler's reading
+;; wins; the runtime does NOT transitively widen the flag across handler
+;; boundaries. A non-`:rf.trace/no-emit?` handler dispatched from inside
+;; a `:rf.trace/no-emit? true` handler emits normally — the inner binding
+;; rebinds to false and the inner cascade is visible.
+;;
+;; Production elision: when `interop/debug-enabled?` is false the whole
+;; trace surface compiles out via the outer `when` gate in `emit!`, so
+;; the Var read is dead code.
+
+(def ^:dynamic *current-no-emit?*
+  "Boolean. True when the in-scope handler's registration metadata
+  carries `:rf.trace/no-emit? true`. Bound alongside
+  `*current-trigger-handler*` and `*current-sensitive?*` at every
+  handler-scope binding site (router process-event, fx dispatcher,
+  cofx injector, sub recompute, view render). `emit!` and
+  `emit-error!` read this Var and short-circuit before envelope
+  allocation when bound true.
+
+  nil / false outside any handler's scope. Per rf2-qsjda and
+  Spec 009 §Trace-emission opt-out."
+  nil)
+
+(defn no-emit?-from-meta
+  "Read `:rf.trace/no-emit?` from a registrar slot's meta map. Returns
+  `true` iff the meta carries `:rf.trace/no-emit? true`; `false` for
+  every other shape (nil meta, absent key, falsy value).
+
+  Used by handler-scope binding sites to compute the value to bind
+  `*current-no-emit?*` to, and by `emit-dispatched-trace!` to gate
+  the queue-time `:event/dispatched` emit. Per rf2-qsjda."
+  [meta]
+  (true? (:rf.trace/no-emit? meta)))
+
 (defn trigger-handler-from-meta
   "Build a `:rf.trace/trigger-handler` value from a registrar meta map.
   `kind` is the registry kind (`:event`, `:sub`, `:fx`, `:cofx`, `:view`);
@@ -502,9 +562,24 @@
   behaviour. Success-path traces emitted inside a handler's scope
   (`:rf.fx/handled`, `:rf.machine/transition`, `:event/db-changed`,
   `:event/do-fx`, ...) carry the registration coord so tools can
-  jump-to-source from any trace event in a cascade, not just errors."
+  jump-to-source from any trace event in a cascade, not just errors.
+
+  Per rf2-qsjda: when `*current-no-emit?*` is bound true (the
+  in-scope handler's registration meta carries `:rf.trace/no-emit?
+  true`), the body short-circuits before envelope allocation — no
+  buffer push, no epoch-capture, no listener fan-out, no id-counter
+  bump. This is the framework-level opt-out for trace-consuming
+  integrations whose own bookkeeping handlers must not re-enter the
+  trace stream and form a cb-dispatch loop. Per Spec 009
+  §Trace-emission opt-out."
   [op operation tags]
   (when interop/debug-enabled?
+    ;; Per rf2-qsjda: short-circuit when the in-scope handler opted
+    ;; out of trace emission. Guard sits *inside* the outer
+    ;; `interop/debug-enabled?` gate (Spec 009 §Production builds
+    ;; mandates the outermost form be that gate alone — `(when
+    ;; (and X interop/debug-enabled?) ...)` defeats Closure DCE).
+   (when-not (true? *current-no-emit?*)
     (let [source       (:source tags)
           recovery     (:recovery tags)
           ;; Per Spec 009 §Required top-level fields: :source and
@@ -557,7 +632,7 @@
           (catch #?(:clj Throwable :cljs :default) _
             ;; Listeners that throw don't break the runtime; the stream
             ;; continues. Per Spec 009: listener failures are isolated.
-            nil))))))
+            nil)))))))
 
 (defn emit-error!
   "Emit a structured error trace event. Per Spec 009 §Error contract:
@@ -583,9 +658,23 @@
   Per rf2-g6ih4: when `*current-dispatch-id*` is bound (the error fires
   inside a drain), the in-flight cascade's id is merged into
   `:tags :dispatch-id` so consumers can correlate the error with the
-  rest of the cascade. Caller-supplied `:dispatch-id` wins."
+  rest of the cascade. Caller-supplied `:dispatch-id` wins.
+
+  Per rf2-qsjda: when `*current-no-emit?*` is bound true (the
+  in-scope handler's registration meta carries `:rf.trace/no-emit?
+  true`), the body short-circuits before envelope allocation —
+  symmetric with the success path in `emit!`. The framework-level
+  trace-emission opt-out applies to error traces too (a Causa-style
+  bookkeeping handler must not re-enter the consumer through error
+  emits any more than through success emits). Per Spec 009
+  §Trace-emission opt-out."
   [error-operation tags]
   (when interop/debug-enabled?
+   ;; Per rf2-qsjda: short-circuit when the in-scope handler opted
+   ;; out of trace emission. Guard sits *inside* the outer
+   ;; `interop/debug-enabled?` gate per Spec 009 §Production builds
+   ;; (the outer gate must stand alone for Closure DCE).
+   (when-not (true? *current-no-emit?*)
     (let [trigger    *current-trigger-handler*
           call-site  *current-call-site*
           cascade-id *current-dispatch-id*
@@ -615,7 +704,7 @@
       (doseq [[_ f] @listeners]
         (try
           (f event)
-          (catch #?(:clj Throwable :cljs :default) _ nil))))))
+          (catch #?(:clj Throwable :cljs :default) _ nil)))))))
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -220,13 +220,19 @@
         ;; trace event emitted during the view's render carries
         ;; the flag per Spec 009 §Privacy.
         view-sensitive?      (trace/sensitive?-from-meta metadata)
+        ;; Per rf2-qsjda: pre-compute the view's `:rf.trace/no-emit?`
+        ;; reading symmetrically. Every render binds it; when set,
+        ;; the `:view/render` emit and any in-render error emits
+        ;; short-circuit at `trace/emit!` / `trace/emit-error!`.
+        view-no-emit?        (trace/no-emit?-from-meta metadata)
         wrapped (with-meta
                   (fn frame-aware-view [& args]
                     (let [tok        (provider/reagent-component-token)
                           render-key [id tok]]
                       (binding [*render-key* render-key
                                 trace/*current-trigger-handler* view-trigger-handler
-                                trace/*current-sensitive?* view-sensitive?]
+                                trace/*current-sensitive?* view-sensitive?
+                                trace/*current-no-emit?* view-no-emit?]
                         (emit-render-trace! render-key)
                         ;; Per Spec 009 §Performance instrumentation
                         ;; (rf2-du3i): every render of a registered view

--- a/implementation/core/test/re_frame/trace_test.clj
+++ b/implementation/core/test/re_frame/trace_test.clj
@@ -560,3 +560,95 @@
 
       (rf/remove-trace-cb! ::throwing)
       (rf/remove-trace-cb! ::survivor))))
+
+;; ---- :rf.trace/no-emit? event-meta opt-out (rf2-qsjda) --------------------
+;;
+;; Per Spec 009 §Trace-emission opt-out: handlers whose registration meta
+;; carries `:rf.trace/no-emit? true` produce NO trace events. The flag is
+;; the framework-level escape hatch for trace-consuming integrations
+;; whose own bookkeeping dispatches — emitted from inside a trace-cb —
+;; would otherwise re-enter the consumer through the trace-cb fan-out
+;; and form a cb-dispatch loop. (See `re-frame.trace/*current-no-emit?*`
+;; for the runtime mechanism.)
+;;
+;; Covers:
+;;   - A handler WITH `:rf.trace/no-emit? true` produces no `:event/
+;;     dispatched`, no `:event :run-start` / `:run-end`, no
+;;     `:event/db-changed`, no in-cascade emits at all.
+;;   - A handler WITHOUT the flag emits normally — sanity baseline so
+;;     the no-emit test doesn't trivially pass on a broken framework.
+
+(deftest no-emit-handler-suppresses-every-cascade-trace
+  (testing "Handler registration meta `:rf.trace/no-emit? true` causes
+            the runtime to emit NO trace events for the dispatch — not
+            at queue time (`:event/dispatched`), not at run-start /
+            run-end, not on db-commit (`:event/db-changed`), not for
+            any in-cascade emit. Per Spec 009 §Trace-emission opt-out
+            and rf2-qsjda."
+    (rf/reg-event-db :rf2-qsjda/internal-bookkeeping
+                     {:rf.trace/no-emit? true}
+                     (fn [db _] (assoc db :bookkeeping/ran? true)))
+
+    (let [recorded (atom [])]
+      (rf/register-trace-cb! ::rec (fn [ev] (swap! recorded conj ev)))
+
+      (rf/dispatch-sync [:rf2-qsjda/internal-bookkeeping])
+
+      ;; Handler ran (db committed) but no traces were emitted.
+      (is (true? (:bookkeeping/ran? (rf/get-frame-db :rf/default)))
+          "the handler body still ran — :rf.trace/no-emit? opts out
+           of TRACE EMISSION, not handler execution")
+
+      ;; Sanity: no trace events for this dispatch at all. We assert
+      ;; on event-id / event-vec tags, since the trace stream might
+      ;; carry framework-level emits unrelated to our dispatch
+      ;; (e.g. registrar registration traces fired by the
+      ;; reg-event-db above).
+      (let [our-events
+            (filter
+              (fn [ev]
+                (let [tags (:tags ev)
+                      eid  (or (:event-id tags)
+                               (let [ev-vec (:event tags)]
+                                 (when (vector? ev-vec) (first ev-vec))))]
+                  (= :rf2-qsjda/internal-bookkeeping eid)))
+              @recorded)]
+        (is (empty? our-events)
+            (str "expected NO trace events for the :rf.trace/no-emit?
+                  handler's dispatch, got: "
+                 (vec (map (juxt :op-type :operation) our-events)))))
+
+      (rf/remove-trace-cb! ::rec))))
+
+(deftest no-emit-flag-absent-emits-normally
+  (testing "Baseline sanity: the SAME dispatch shape WITHOUT
+            `:rf.trace/no-emit? true` produces the normal cascade
+            traces (`:event/dispatched`, run-start, run-end,
+            `:event/db-changed`). Pins the opt-out as the difference."
+    (rf/reg-event-db :rf2-qsjda/normal
+                     {:doc "without :rf.trace/no-emit?"}
+                     (fn [db _] (assoc db :normal/ran? true)))
+
+    (let [recorded (atom [])]
+      (rf/register-trace-cb! ::rec (fn [ev] (swap! recorded conj ev)))
+
+      (rf/dispatch-sync [:rf2-qsjda/normal])
+
+      (let [our-events
+            (filter
+              (fn [ev]
+                (let [tags (:tags ev)
+                      eid  (or (:event-id tags)
+                               (let [ev-vec (:event tags)]
+                                 (when (vector? ev-vec) (first ev-vec))))]
+                  (= :rf2-qsjda/normal eid)))
+              @recorded)
+            ops (set (map :operation our-events))]
+        (is (contains? ops :event/dispatched)
+            ":event/dispatched fired for the un-flagged handler")
+        (is (contains? ops :event/db-changed)
+            ":event/db-changed fired for the un-flagged handler")
+        (is (contains? ops :event)
+            ":event (run-start / run-end) fired for the un-flagged handler"))
+
+      (rf/remove-trace-cb! ::rec))))

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -350,6 +350,28 @@ The shape is synchronous and side-effecting: the emit returns once every listene
 
 `emit!`'s body is wrapped in `(when re-frame.interop/debug-enabled? ...)`. `debug-enabled?` is an alias of `goog.DEBUG` on CLJS (default `true` in dev, `false` in `:advanced` production builds); when the constant is `false` the closure compiler eliminates the gated branch and the call becomes a no-op. See "Production builds" below for the full mechanism.
 
+### Trace-emission opt-out: `:rf.trace/no-emit?` event-meta
+
+Handlers (`reg-event-db` / `reg-event-fx` / `reg-event-ctx`, `reg-sub`, `reg-fx`, `reg-cofx`, view registrations) whose registration metadata carries `:rf.trace/no-emit? true` produce **no trace events**. The runtime short-circuits `emit!` / `emit-error!` / the queue-time `:event/dispatched` emit when the in-scope handler — or, for `:event/dispatched`, the target handler — opts out. The runtime binds `re-frame.trace/*current-no-emit?*` from the handler's meta alongside `*current-trigger-handler*` (per rf2-3nn8 / rf2-lf84g) and `*current-sensitive?*` (per rf2-isdwf); the gate sits inside the outer `interop/debug-enabled?` `when` so production elision is preserved.
+
+```clojure
+(rf/reg-event-db :rf.causa/note-trace-event
+  {:rf.trace/no-emit? true}                     ;; <- opt-out
+  (fn [db [_ event]]
+    (assoc db :trace-buffer (conj (:trace-buffer db []) event))))
+```
+
+The flag is the framework-level escape hatch for **trace-consuming integrations** whose own bookkeeping dispatches — emitted from inside a registered `trace-cb` — would otherwise re-enter the consumer through the trace-cb fan-out and form a cb-dispatch loop. Causa, Story, pair2-mcp, story-mcp, and causa-mcp all have the same risk shape; without the opt-out each consumer would need its own per-dispatch guard predicate (Causa carried one as `trace-bus/self-emitted?` between rf2-nk01x and rf2-qsjda). Promoting the gate to the framework lets any consumer mark a handler internal-only and trust the runtime to suppress the cascade.
+
+Semantics:
+
+- **What's suppressed.** `:event/dispatched` (queue-time, when the *target* handler's meta carries the flag), `:event :run-start` / `:run-end`, `:event/db-changed`, `:rf.fx/handled`, `:rf.machine/transition`, `:sub/run`, `:view/render`, and every `:rf.error/*` emit produced inside the handler's scope. The always-on event-emit substrate (`rf2-rirbq`) ALSO honours the flag and drops the per-event record for `:rf.trace/no-emit?`-flagged handlers — same boundary semantics as the `:sensitive?` short-circuit per rf2-6hklf, on the rationale that framework-internal bookkeeping handlers are not user-domain observable signal.
+- **What's NOT suppressed.** The handler body still runs — the opt-out applies to OBSERVABILITY (trace + event-emit), not handler execution. The dispatch is queued, drained, and committed normally; the handler's db effect is committed; its fx are walked.
+- **Cascade composition.** Innermost in-scope handler wins. A non-opt-out handler dispatched from inside a `:rf.trace/no-emit? true` handler emits normally — the inner binding rebinds to false and the inner cascade is visible. (Same composition rule as `:sensitive?`, per Spec 009 line 1177.)
+- **Production elision.** The trace-surface gate sits inside `interop/debug-enabled?` and DCEs out in `:advanced` production builds (the trace surface is dev-only by construction — production never emits trace events at all). The event-emit short-circuit survives production builds (event-emit is always-on per rf2-rirbq), so production listeners equally drop opt-out handler records.
+
+Per rf2-nk01x / rf2-qsjda and the framework `re-frame.trace/*current-no-emit?*` Var.
+
 ### Where trace emission lives
 
 The framework emits trace events from these call sites:

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -633,7 +633,18 @@
     ;; frame the trace targeted); `nil` falls under `:global`. Drives
     ;; the bottom-rail `[● REDACTED N]` indicator via the
     ;; `:rf.causa/suppressed-sensitive-count` sub — fully reactive.
+    ;;
+    ;; Per rf2-qsjda: `:rf.trace/no-emit? true` opts the handler out of
+    ;; framework trace emission. Without this, the dispatch fired by
+    ;; `trace-bus/collect-trace!` would itself emit `:event/dispatched`
+    ;; etc. back through the trace-cb fan-out, the collector would see
+    ;; its own self-emit, and the cascade would loop until
+    ;; `drain-depth-default` terminated it. The framework now
+    ;; short-circuits emission at the `emit!` / `emit-error!` /
+    ;; `emit-dispatched-trace!` gates — the predecessor Causa-side
+    ;; `self-emitted?` guard (rf2-nk01x) is obsolete.
     (rf/reg-event-db :rf.causa/note-sensitive-suppressed
+      {:rf.trace/no-emit? true}
       (fn [db [_ frame-id]]
         (update-in db [:suppressed-counters (or frame-id :global)]
                    (fnil inc 0))))
@@ -644,7 +655,11 @@
     ;; trace ring buffer also drops the REDACTED indicator state (the
     ;; "you missed N events" overhang disappears alongside the events
     ;; that produced it).
+    ;;
+    ;; Per rf2-qsjda: `:rf.trace/no-emit? true` (see
+    ;; `:rf.causa/note-sensitive-suppressed` above for the rationale).
     (rf/reg-event-db :rf.causa/reset-suppressed-counters
+      {:rf.trace/no-emit? true}
       (fn [db [_ frame-id]]
         (if frame-id
           (update db :suppressed-counters dissoc (or frame-id :global))
@@ -659,7 +674,11 @@
     ;; atom (process-global, not per-frame). Drives the
     ;; `:rf.causa/trace-buffer` sub via the standard reactive write
     ;; path — panels reading the buffer re-render immediately.
+    ;;
+    ;; Per rf2-qsjda: `:rf.trace/no-emit? true` (see
+    ;; `:rf.causa/note-sensitive-suppressed` above for the rationale).
     (rf/reg-event-db :rf.causa/note-trace-event
+      {:rf.trace/no-emit? true}
       (fn [db [_ event]]
         (let [depth (trace-bus/current-depth)
               buf   (get db :trace-buffer [])
@@ -670,7 +689,11 @@
     ;; Dispatched from `trace-bus/clear-buffer!` (CLJS) — clearing
     ;; the atom-side ring buffer must drop the app-db mirror in
     ;; lockstep so panels reading the buffer empty alongside.
+    ;;
+    ;; Per rf2-qsjda: `:rf.trace/no-emit? true` (see
+    ;; `:rf.causa/note-sensitive-suppressed` above for the rationale).
     (rf/reg-event-db :rf.causa/clear-trace-buffer
+      {:rf.trace/no-emit? true}
       (fn [db _event]
         (dissoc db :trace-buffer)))
 
@@ -679,7 +702,11 @@
     ;; depth!` (CLJS) when shrinking the depth would otherwise
     ;; leave the app-db mirror longer than the atom side. The
     ;; payload is the post-shrink vector.
+    ;;
+    ;; Per rf2-qsjda: `:rf.trace/no-emit? true` (see
+    ;; `:rf.causa/note-sensitive-suppressed` above for the rationale).
     (rf/reg-event-db :rf.causa/sync-trace-buffer
+      {:rf.trace/no-emit? true}
       (fn [db [_ buf]]
         (assoc db :trace-buffer (vec buf))))
 

--- a/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
@@ -90,81 +90,31 @@
       (subvec buffer' (- n depth))
       buffer')))
 
-;; ---- self-emit recognition (rf2-nk01x) ----------------------------------
-;;
-;; `collect-trace!` itself dispatches Causa's own bookkeeping events
-;; (`:rf.causa/note-sensitive-suppressed`, `:rf.causa/note-trace-event`)
-;; into `:rf/causa` whenever it processes a trace event. Those
-;; dispatches each produce their own `:event/dispatched` trace event
-;; (plus a short cascade of `:event/handled` / `:event/db-changed` /
-;; ... per Spec 002 §Dispatch lifecycle). The framework delivers EVERY
-;; emitted trace event back through `register-trace-cb!`, so the
-;; collector sees its own self-emit.
-;;
-;; Two loops result without a guard:
-;;
-;;   1. A `:sensitive?` event lands. `note-suppressed!` dispatches
-;;      `:rf.causa/note-sensitive-suppressed`. Because the dispatch
-;;      happens INSIDE the outer sensitive handler's scope, the
-;;      framework's `*current-sensitive?*` Var (re-frame.trace,
-;;      rf2-isdwf) is still bound true at the `emit-dispatched-trace!`
-;;      callsite, so `emit!` hoists `:sensitive? true` onto the
-;;      `:event/dispatched` trace event for `:rf.causa/note-sensitive-
-;;      suppressed` ITSELF. The collector sees that event as
-;;      `suppress-sensitive?`-true, fires `note-suppressed!` again, …
-;;      The framework's drain-depth limit (re-frame.router,
-;;      `drain-depth-default` = 100) terminates the cascade loudly, but
-;;      by then the suppressed-count has been inflated AND the
-;;      cascade-terminator emits `:rf.error/drain-depth-exceeded`.
-;;
-;;   2. Symmetric loop for `:rf.causa/note-trace-event` on non-sensitive
-;;      events — each non-sensitive trace event pushes to the buffer
-;;      AND dispatches the mirror event, whose own `:event/dispatched`
-;;      trace re-enters the collector, pushes to the buffer AGAIN, and
-;;      dispatches another mirror event, …
-;;
-;; Both loops resolve the same way: recognise the self-emitted trace
-;; events at the top of `collect-trace!` and short-circuit before any
-;; buffer push or dispatch. The self-emits are purely internal
-;; bookkeeping — they have no diagnostic value to a user inspecting the
-;; trace buffer or the REDACTED indicator, and counting them inflates
-;; both surfaces.
-
-(def ^:private causa-bookkeeping-event-ids
-  "Event ids dispatched by `collect-trace!` itself (plus the related
-  reset-* / clear-* paths under `trace-bus` and `config`). Trace
-  events scoped under these handlers are Causa's internal plumbing
-  and must NOT re-enter the collector — see the self-emit ns comment
-  above."
-  #{:rf.causa/note-sensitive-suppressed
-    :rf.causa/note-trace-event
-    :rf.causa/clear-trace-buffer
-    :rf.causa/reset-suppressed-counters
-    :rf.causa/sync-trace-buffer})
-
-(defn self-emitted?
-  "True iff `event` is a trace event scoped to one of Causa's own
-  bookkeeping dispatches (rf2-nk01x). Two recognised shapes:
-
-    1. `:event/dispatched` trace event for the bookkeeping event:
-       `:tags :event` is `[<bookkeeping-id> ...]`.
-    2. Any trace event emitted INSIDE the bookkeeping event's handler
-       scope: `:tags :event-id` is the bookkeeping id.
-
-  Pure-data + JVM-runnable so the guard's algebra is testable
-  without a CLJS runtime. Always returns a boolean (never nil)
-  so the predicate composes cleanly under `cond` + `false?`."
-  [event]
-  (if (map? event)
-    (let [tags          (:tags event)
-          event-id      (:event-id tags)
-          dispatched-id (let [ev (:event tags)]
-                          (when (vector? ev) (first ev)))]
-      (boolean (or (contains? causa-bookkeeping-event-ids event-id)
-                   (contains? causa-bookkeeping-event-ids dispatched-id))))
-    false))
-
 ;; ---- collector --------------------------------------------------------
+;;
+;; History (rf2-nk01x → rf2-qsjda):
+;;
+;;   `collect-trace!` dispatches Causa's own bookkeeping events
+;;   (`:rf.causa/note-sensitive-suppressed`, `:rf.causa/note-trace-event`,
+;;   …) into `:rf/causa` whenever it processes a trace event. The
+;;   framework delivers EVERY emitted trace event back through
+;;   `register-trace-cb!`, so the collector would otherwise see its own
+;;   self-emit and recurse — driving the per-frame `:suppressed-counters`
+;;   ever upwards on `:sensitive?` events and exploding the buffer on
+;;   non-sensitive events, until the framework's `drain-depth-default`
+;;   = 100 terminates the cascade with `:rf.error/drain-depth-exceeded`.
+;;
+;;   rf2-nk01x landed a Causa-side guard (a `self-emitted?` predicate
+;;   that short-circuited at the top of `collect-trace!` for trace events
+;;   whose `:tags :event-id` or dispatched id matched a Causa-bookkeeping
+;;   set). rf2-qsjda promoted the opt-out to the framework: the
+;;   bookkeeping handlers below carry `:rf.trace/no-emit? true` in their
+;;   registration metadata (see `registry.cljs`), and Spec 009
+;;   §Trace-emission opt-out gates `emit!` / `emit-error!` /
+;;   `emit-dispatched-trace!` on the flag. The runtime short-circuits
+;;   BEFORE emitting, so the collector never sees self-emits in the
+;;   first place. The per-consumer Causa-side guard becomes redundant
+;;   and `self-emitted?` is gone.
 
 (defn collect-trace!
   "Append a trace event to Causa's ring buffer. Registered with
@@ -195,27 +145,18 @@
   always installs it, but tests / hot-reload windows may emit
   trace events before the frame registers.
 
-  Per rf2-nk01x: trace events emitted by Causa's own bookkeeping
-  dispatches (`:rf.causa/note-sensitive-suppressed`, `:rf.causa/
-  note-trace-event`, …) short-circuit at the top of the body — see
-  `self-emitted?` and the ns comment above. Without this guard, a
-  single `:sensitive?` event would dispatch
-  `:rf.causa/note-sensitive-suppressed` which itself emits a
-  `:sensitive? true` trace event (inherited from
-  `*current-sensitive?*`) re-entering the collector and re-dispatching
-  the bookkeeping event, until the framework's drain-depth limit
-  terminates the cascade. The fix preserves a clean 1-bump-per-event
-  suppressed count and removes the need for tests to
-  `clear-trace-cbs!` per fixture."
+  Per rf2-qsjda (succeeds rf2-nk01x's Causa-side `self-emitted?`
+  guard): the bookkeeping handlers `:rf.causa/note-sensitive-suppressed`,
+  `:rf.causa/note-trace-event`, `:rf.causa/clear-trace-buffer`,
+  `:rf.causa/reset-suppressed-counters`, and `:rf.causa/sync-trace-buffer`
+  are registered with `:rf.trace/no-emit? true`. The framework
+  short-circuits trace emission for those dispatches at `emit!` /
+  `emit-error!` / `emit-dispatched-trace!`, so the collector never
+  sees the self-emits in the first place. No per-consumer guard
+  required."
   [event]
   (when interop/debug-enabled?
     (cond
-      ;; rf2-nk01x: drop Causa's own bookkeeping self-emits before any
-      ;; counter bump or buffer push. They are pure internal plumbing
-      ;; and re-entering the collector for them is the cb-dispatch loop.
-      (self-emitted? event)
-      nil
-
       (config/suppress-sensitive? event)
       (config/note-suppressed! (get-in event [:tags :frame]))
 

--- a/tools/causa/test/day8/re_frame2_causa/sensitive_trace_loop_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/sensitive_trace_loop_cljs_test.cljs
@@ -1,5 +1,6 @@
 (ns day8.re-frame2-causa.sensitive-trace-loop-cljs-test
-  "Loop-proof tests for the `:sensitive?` trace-callback path (rf2-nk01x).
+  "Loop-proof tests for the `:sensitive?` trace-callback path
+  (rf2-nk01x → rf2-qsjda).
 
   ## Why this file exists
 
@@ -26,11 +27,21 @@
        dispatches again, … until the JavaScript stack overflows or the
        framework's drain-depth limit truncates the cascade.
 
-  The fix is `trace-bus/self-emitted?`: a predicate that recognises
-  the bookkeeping self-emits and short-circuits `collect-trace!` for
-  them. The pure-data predicate is covered by the JVM `trace_bus_test`;
-  this CLJS file drives the END-TO-END loop scenario through real
-  `dispatch-sync` calls against the registered trace callback.
+  The fix evolved:
+
+    - rf2-nk01x landed a Causa-side `self-emitted?` predicate that
+      short-circuited `collect-trace!` for bookkeeping self-emits.
+    - rf2-qsjda promoted the opt-out to the framework: the bookkeeping
+      handlers carry `:rf.trace/no-emit? true` in their registration
+      metadata, and `re-frame.trace/emit!` / `emit-error!` /
+      `emit-dispatched-trace!` short-circuit on the flag (Spec 009
+      §Trace-emission opt-out). The collector never sees self-emits
+      because the framework never emits them.
+
+  This CLJS file drives the END-TO-END loop scenario through real
+  `dispatch-sync` calls against the registered trace callback. The
+  framework-level gate's pure-data tests live in
+  `re-frame.trace-test`.
 
   ## What the tests assert
 
@@ -158,8 +169,9 @@
 (deftest two-hundred-non-sensitive-dispatches-do-not-loop
   (testing "the symmetric loop for `:rf.causa/note-trace-event` (the
             non-sensitive mirror dispatch, rf2-iw5ym) is also closed —
-            self-emitted? recognises the bookkeeping event id and
-            short-circuits collect-trace! before the buffer push.
+            per rf2-qsjda the bookkeeping handlers carry
+            `:rf.trace/no-emit? true` so the framework short-circuits
+            emission for them before the collector ever sees the trace.
             Non-sensitive events land in the buffer cleanly with no
             re-entry inflation."
     (register-non-sensitive-event!)

--- a/tools/causa/test/day8/re_frame2_causa/trace_bus_test.clj
+++ b/tools/causa/test/day8/re_frame2_causa/trace_bus_test.clj
@@ -38,86 +38,15 @@
              (trace-bus/push buf 3 {:id 6}))
           "depth 3 retains 3 newest entries after the next push"))))
 
-;; ---- self-emitted? predicate (rf2-nk01x) --------------------------------
+;; ---- self-emit guard history (rf2-nk01x → rf2-qsjda) ----------------------
 ;;
-;; `collect-trace!`'s guard for Causa's own bookkeeping dispatches.
-;; Pure-data + JVM-runnable so the predicate's algebra is covered
-;; without a CLJS runtime. The integration coverage (`dispatch-sync`
-;; under a real cascade) lives in the CLJS sensitive_trace test.
-
-(deftest self-emitted?-recognises-bookkeeping-dispatched-trace
-  (testing ":event/dispatched trace events for Causa's own bookkeeping
-            event ids are self-emits"
-    (is (true? (trace-bus/self-emitted?
-                {:op-type :event :operation :event/dispatched
-                 :sensitive? true
-                 :tags {:event [:rf.causa/note-sensitive-suppressed :rf/default]
-                        :frame :rf/causa}}))
-        ":rf.causa/note-sensitive-suppressed dispatch trace is self-emit")
-    (is (true? (trace-bus/self-emitted?
-                {:op-type :event :operation :event/dispatched
-                 :tags {:event [:rf.causa/note-trace-event {:fake :event}]
-                        :frame :rf/causa}}))
-        ":rf.causa/note-trace-event dispatch trace is self-emit")
-    (is (true? (trace-bus/self-emitted?
-                {:op-type :event :operation :event/dispatched
-                 :tags {:event [:rf.causa/clear-trace-buffer]
-                        :frame :rf/causa}}))
-        ":rf.causa/clear-trace-buffer dispatch trace is self-emit")
-    (is (true? (trace-bus/self-emitted?
-                {:op-type :event :operation :event/dispatched
-                 :tags {:event [:rf.causa/reset-suppressed-counters]
-                        :frame :rf/causa}}))
-        ":rf.causa/reset-suppressed-counters dispatch trace is self-emit")
-    (is (true? (trace-bus/self-emitted?
-                {:op-type :event :operation :event/dispatched
-                 :tags {:event [:rf.causa/sync-trace-buffer []]
-                        :frame :rf/causa}}))
-        ":rf.causa/sync-trace-buffer dispatch trace is self-emit")))
-
-(deftest self-emitted?-recognises-handler-scoped-bookkeeping-trace
-  (testing "trace events emitted INSIDE the bookkeeping handler's scope
-            (with :tags :event-id pointing at the bookkeeping id) are
-            self-emits — this catches :event/handled, :event/db-changed,
-            :rf.fx/handled, etc., emitted under the handler's dynamic
-            binding"
-    (is (true? (trace-bus/self-emitted?
-                {:op-type :event :operation :event/db-changed
-                 :tags {:event-id :rf.causa/note-sensitive-suppressed
-                        :frame :rf/causa}})))
-    (is (true? (trace-bus/self-emitted?
-                {:op-type :event :operation :event/handled
-                 :tags {:event-id :rf.causa/note-trace-event
-                        :frame :rf/causa}})))))
-
-(deftest self-emitted?-rejects-non-bookkeeping-events
-  (testing "user-domain events are NOT self-emits"
-    (is (false? (trace-bus/self-emitted?
-                 {:op-type :event :operation :event/dispatched
-                  :sensitive? true
-                  :tags {:event [:auth/sign-in {:password "x"}]
-                         :frame :rf/default}}))
-        "a real :sensitive? event is NOT a self-emit")
-    (is (false? (trace-bus/self-emitted?
-                 {:op-type :event :operation :event/handled
-                  :tags {:event-id :user/click
-                         :frame :rf/default}}))
-        "a normal user event handled-trace is NOT a self-emit"))
-  (testing "non-:rf.causa/* re-frame internal events are NOT self-emits"
-    (is (false? (trace-bus/self-emitted?
-                 {:op-type :event :operation :event/dispatched
-                  :tags {:event [:rf.fx/dispatch [:user/foo]]}}))))
-  (testing "non-map / nil / bare values are not self-emits (no NPE)"
-    (is (false? (trace-bus/self-emitted? nil)))
-    (is (false? (trace-bus/self-emitted? :keyword)))
-    (is (false? (trace-bus/self-emitted? [:vector])))
-    (is (false? (trace-bus/self-emitted? {})))
-    (is (false? (trace-bus/self-emitted? {:tags {}}))))
-  (testing "shapes that look LIKE the bookkeeping events but aren't"
-    (is (false? (trace-bus/self-emitted?
-                 {:op-type :event :operation :event/dispatched
-                  :tags {:event [:user/note-sensitive-suppressed]}}))
-        "different ns, same suffix — must NOT match")
-    (is (false? (trace-bus/self-emitted?
-                 {:tags {:event-id :rf.causa/select-panel}}))
-        ":rf.causa/* but NOT a bookkeeping id")))
+;; rf2-nk01x introduced a Causa-side `self-emitted?` predicate to stop
+;; `collect-trace!` re-entering itself via its own bookkeeping dispatches'
+;; trace events. rf2-qsjda promoted the opt-out to the framework: the
+;; bookkeeping handlers in registry.cljs now carry `:rf.trace/no-emit?
+;; true`, and `re-frame.trace/emit!` / `emit-error!` / the queue-time
+;; `emit-dispatched-trace!` all short-circuit on the flag. The
+;; Causa-side `self-emitted?` predicate is obsolete and gone; the
+;; framework gate's tests live in `re-frame.trace-test`. The
+;; integration coverage of the closed loop under a real CLJS cascade
+;; remains in `sensitive_trace_loop_cljs_test.cljs`.


### PR DESCRIPTION
## Summary

Principled fix for the Causa preload cb-dispatch loop (succeeds rf2-nk01x's tactical Causa-side guard).

- New framework-level escape hatch: `:rf.trace/no-emit? true` in a handler's registration metadata short-circuits trace emission for every emit inside its scope — `:event/dispatched` (queue-time), `:event :run-start` / `:run-end`, `:event/db-changed`, `:rf.fx/handled`, `:sub/run`, `:view/render`, `:rf.error/*`.
- Implementation: `*current-no-emit?*` dynamic Var bound alongside `*current-trigger-handler*` / `*current-sensitive?*` at every handler-scope site (router, fx, cofx, subs, views); `emit!` / `emit-error!` check it inside the outer `interop/debug-enabled?` gate (DCE preserved); `emit-dispatched-trace!` reads the target handler's meta directly for the queue-time emit.
- The event-emit substrate honours the same flag (drop the per-event record alongside the existing `:sensitive?` short-circuit) so framework-internal bookkeeping handlers are invisible to both dev (trace) and production (event-emit) observability surfaces.
- Causa migration: bookkeeping handlers (`:rf.causa/note-sensitive-suppressed`, `:rf.causa/note-trace-event`, `:rf.causa/clear-trace-buffer`, `:rf.causa/reset-suppressed-counters`, `:rf.causa/sync-trace-buffer`) adopt the flag. `trace-bus/self-emitted?` and its JVM tests dropped — the framework closes the loop at root.
- Examples cleanup: `examples/reagent/counter_with_stories/elision_demo_cljs_test.cljs` loses its `(trace/clear-trace-cbs!)` workaround; Causa's preload-time cb runs as production wires it.
- Spec 009 §Emitting trace events gains a §Trace-emission opt-out subsection.

## Test plan

- [x] `npm run test:cljs` (1778 tests, 4937 assertions) — 0 failures, 0 errors
- [x] `npm run test:elision` — every gated branch elides under `goog.DEBUG=false`
- [x] `npm run test:bundle-isolation` — tools surfaces stay out of production bundle
- [x] `npm run test:perf-bundle` — perf-off bundle still drops the surface
- [x] `re-frame.sensitive-stamping-test` (JVM) — 25 tests, 82 assertions — unchanged
- [x] `day8.re-frame2-causa.trace-bus-test` (JVM) — 4 tests, 6 assertions — unchanged after `self-emitted?` removal
- [x] Two new tests in `re-frame.trace-test`: `no-emit-handler-suppresses-every-cascade-trace`, `no-emit-flag-absent-emits-normally`
- [x] `elision-demo-cljs-test` passes without `(trace/clear-trace-cbs!)` — Causa's preload-time cb live, no loop