### PR TITLE
docs(skills/re-frame2): pattern openers surface 'managed external effect' umbrella (rf2-rjm7p)

### DIFF
--- a/skills/re-frame2/patterns/async-effect.md
+++ b/skills/re-frame2/patterns/async-effect.md
@@ -2,6 +2,8 @@
 
 The canonical "external work + dispatched reply" shape every async-effecting feature follows in re-frame2.
 
+This pattern is the *foundation* the **managed external effect** umbrella specialises. A managed effect (`:rf.http/managed`, `:rf.ws/*`, state-machine `:invoke`, `:rf.server/*`, `:rf.flow/*`) is an async effect with an eight-property contract layered on top — framework-owned lifecycle, structured failure taxonomy, retry/abort/teardown semantics, trace-bus observability. Author an ad-hoc async fx with this leaf; reach for [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) when authoring a *new* framework-owned surface (managed timers, managed background jobs, managed IndexedDB) that should inherit the umbrella's checklist.
+
 ## When to load this leaf
 
 Load when the task is:

--- a/skills/re-frame2/patterns/boot.md
+++ b/skills/re-frame2/patterns/boot.md
@@ -2,6 +2,8 @@
 
 Application boot as a chained-async sequence — the canonical state-machine shape for "read config → authenticate → load profile → hydrate → resolve route → ready".
 
+Boot is a composition of two **managed external effect** surfaces: state-machine `:invoke` (the per-phase actors) and `:rf.http/managed` (the per-phase fetches). Both surfaces inherit the eight-property umbrella contract — framework-owned lifecycle, structured failure taxonomy, retry/abort/teardown semantics, trace-bus observability — which is what lets the boot machine reason about per-phase failure uniformly. See [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) for the umbrella; this leaf names how to *sequence* the phases.
+
 > **Worked example:** `examples/reagent/boot/` ships the canonical machine — `:configuring → :loading-deps → :hydrating → :ready` with one `:invoke`'d loader and a fan-out `:invoke-all` parallel-load step.
 
 ## When to use this pattern

--- a/skills/re-frame2/patterns/forms.md
+++ b/skills/re-frame2/patterns/forms.md
@@ -2,6 +2,8 @@
 
 The standard form-lifecycle convention. A 7-key slice (or one machine region) carries the form runtime — **draft / submitted / submit-attempted? / status / errors / touched / submit-error** — and seven events drive the lifecycle (**initialise / edit-field / blur-field / submit / submit-success / submit-error / reset**). Per-field error visibility hinges on a single rule: show a field's error when the field is in `:touched` OR `:submit-attempted?` is `true`.
 
+Forms is an **app-side** lifecycle slice composed on top of a **managed external effect** — almost always `:rf.http/managed` for the submit. The slice carries draft/touched/errors; the submit fx is framework-owned. See [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) for the umbrella; the `:errors` vs `:submit-error` split here is exactly the seam where the umbrella's structured failure taxonomy hands off to app-level field-error UI.
+
 ## When to load this leaf
 
 The prompt mentions: a form, validation, "show errors after submit", inline field errors, `:disabled` while submitting, a login / signup / settings / editor screen, or any UI that collects user input and submits it. Also load this leaf when picking between the **slice form** (a key in `app-db`) and the **machine form** (`:form-region` of a `reg-machine`) — see §Common variations.

--- a/skills/re-frame2/patterns/long-running-work.md
+++ b/skills/re-frame2/patterns/long-running-work.md
@@ -2,6 +2,8 @@
 
 Cancellable spawn-and-join coordination via `:invoke-all` — one parent coordinates N parallel children that yield to the browser between chunks.
 
+State-machine `:invoke` / `:invoke-all` is one instance of the **managed external effect** umbrella — alongside `:rf.http/managed`, `:rf.ws/*`, `:rf.server/*`, and `:rf.flow/*`. The runtime owns child lifetime (spawn on entry, teardown on exit, abort on parent transition), failure classification under `:rf.machine/*`, and trace-bus observability — which is exactly what makes the spawn-and-join shape below correctness-by-construction. See [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) for the umbrella; this leaf names the *coordination* shape on top.
+
 ## When to load this leaf
 
 Load when the task is:

--- a/skills/re-frame2/patterns/managed-http.md
+++ b/skills/re-frame2/patterns/managed-http.md
@@ -2,6 +2,8 @@
 
 `:rf.http/managed` — the canonical HTTP fx for re-frame2. Two affordances on one registrar id: the **fx form** for direct use from event handlers, and the **machine-form wrapper** for `:invoke` from a parent state machine. The contract — args map, failure categories, retry, abort, reply addressing — is identical across both.
 
+`:rf.http/managed` is one instance of the **managed external effect** umbrella — alongside `:rf.ws/*`, state-machine `:invoke`, `:rf.server/*`, and `:rf.flow/*`. All five inherit the same eight-property contract (effect-as-data, framework-owned lifecycle, structured failure taxonomy, trace-bus observability, elision composition, built-in retry/abort/teardown, reply addressing, pair-tool override seam). See [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) for the umbrella; the rest of this leaf is HTTP-specific.
+
 > Managed-HTTP is **v1-optional** but shipped in the CLJS reference. It lives in `day8/re-frame2-http`; requiring `re-frame.http-managed` at app boot triggers its load-time registrations.
 
 ## When to use this pattern

--- a/skills/re-frame2/patterns/nine-states.md
+++ b/skills/re-frame2/patterns/nine-states.md
@@ -2,6 +2,8 @@
 
 A page-level rendering convention that makes every legal UI state explicit and testable. The page's render axes are modelled as **parallel regions** of a single `reg-machine`, each region's states carry **tags**, and one **selector sub** consults a **render-priority** table to pick the single render-model keyword the root view's `case` branches on.
 
+NineStates is the **rendering layer** that sits over the lifecycles produced by **managed external effects**. The `:data` region typically advances on replies from `:rf.http/managed`, `:rf.ws/*`, or an `:invoke`'d loader; the umbrella's framework-owned reply addressing and structured failure taxonomy is what makes the tag set (`:loading`, `:loaded`, `:error`, …) reliable enough to drive a priority table. See [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) for the underlying contract; this leaf names how a page renders across the lifecycle's cardinality.
+
 ## When to load this leaf
 
 The prompt mentions: "nine states", "empty / one / some / too-many", "loading vs error vs success render", "page-level rendering states", "render priority", or a page that needs to render the cardinality of its loaded data distinctly. Also load this leaf when the user wants to combine a data lifecycle with a form lifecycle and a read-only mode in one screen and is asking "where does each state go?".

--- a/skills/re-frame2/patterns/remote-data.md
+++ b/skills/re-frame2/patterns/remote-data.md
@@ -2,6 +2,8 @@
 
 The standard request-lifecycle convention. A 5-key slice (or one machine region) tracks **status / data / error / loaded-at / attempt**, and four events drive the lifecycle (**load / loaded / load-failed / reset**). The load-bearing distinction is `:loading` (truly empty, first fetch) vs `:fetching` (revalidate with existing data) — they look identical to a careless UI but feel very different to a user.
 
+RemoteData is the **app-side** lifecycle slice that sits on top of a **managed external effect** — typically `:rf.http/managed`, but the shape composes with any framework-owned surface (`:rf.ws/*` request-reply messages, state-machine `:invoke`'d loaders, `:rf.server/*` per-request fxs). See [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) for the umbrella; this leaf names what the *receiving* state looks like once the umbrella's reply lands.
+
 ## When to load this leaf
 
 The prompt mentions: fetching data from a server, an HTTP request lifecycle, a list/article/feed/profile that needs to load, "spinner vs revalidate", optimistic update, polling, or any feature whose `app-db` will hold "the result of a fetch". Also load this leaf when picking between the **slice form** (a key in `app-db`) and the **machine form** (`:data-region` of a `reg-machine`) — see §Common variations.

--- a/skills/re-frame2/patterns/stale-detection.md
+++ b/skills/re-frame2/patterns/stale-detection.md
@@ -2,6 +2,8 @@
 
 The cross-cutting epoch idiom re-frame2 uses to silently ignore async results from a superseded state. Capture an epoch, carry it through, check on receipt, suppress on mismatch.
 
+Stale-detection is the cross-cutting **correctness** idiom layered over **managed external effects** — `:rf.http/managed`, `:rf.ws/*`, state-machine `:invoke`, `:rf.server/*`, and `:rf.flow/*`. The umbrella's framework-owned reply addressing delivers the reply to the *originating* event id; this leaf names the epoch convention that decides whether the receiving state still wants it. See [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) for the umbrella.
+
 ## When to load this leaf
 
 Load when the task is:

--- a/skills/re-frame2/patterns/websocket.md
+++ b/skills/re-frame2/patterns/websocket.md
@@ -2,6 +2,8 @@
 
 Long-lived bidirectional connection lifecycle (WebSocket / SSE / WebRTC peer) modelled as a state machine that owns the socket actor.
 
+`:rf.ws/*` is one instance of the **managed external effect** umbrella — alongside `:rf.http/managed`, state-machine `:invoke`, `:rf.server/*`, and `:rf.flow/*`. The connection's lifecycle (issuance, reconnect, abort, teardown, structured failures under `:rf.ws/*`, trace-bus observability, wire-value elision) is framework-owned. See [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) for the eight-property shared contract; the rest of this leaf is WebSocket-specific.
+
 > **Status of the worked example:** `examples/reagent/websocket/` is in flight via rf2-yf97. Until it lands, the canonical declaration below is the source of truth.
 
 ## When to use this pattern


### PR DESCRIPTION
## Summary

Each Pattern-* leaf under `skills/re-frame2/patterns/` now opens by naming the **managed external effect** umbrella concept (`spec/Managed-Effects.md`) and cross-linking once.

- Direct-instance patterns (`managed-http`, `websocket`, `long-running-work`) name their surface as an instance of the umbrella.
- Composing patterns (`async-effect` as foundation; `remote-data`, `forms`, `nine-states` as app-side layers; `boot` as a composition of two surfaces; `stale-detection` as a cross-cutting idiom) frame their relation to the umbrella.

Closes the rf2-vg0hz audit gap #4 — AI agents authoring NEW managed-fx surfaces (managed timers, managed background jobs, managed IndexedDB) now have a single discoverable handle from any pattern leaf to the eight-property shared contract, instead of re-deriving ad-hoc shapes.

## Scope

- 9 files touched, all under `skills/re-frame2/patterns/`.
- ~3-5 line addition per file (18 insertions total).
- `SKILL.md` untouched (hot-zone for parallel agents).
- Lede preserved in each file; umbrella framing is a follow-on paragraph.

## Test plan

- [ ] Cross-link `../../../spec/Managed-Effects.md` resolves from each patterns leaf.
- [ ] Each opener references the umbrella exactly once.
- [ ] Tone matches existing pattern openers (one short paragraph, no buried lede).

Closes rf2-rjm7p.