### PR TITLE
docs(skills/re-frame2): post-rf2-xas97 polish (rf2-dxins+kq61o+do6xx)

### DIFF
--- a/skills/re-frame2/reference/cross-cutting/privacy-and-elision.md
+++ b/skills/re-frame2/reference/cross-cutting/privacy-and-elision.md
@@ -53,6 +53,8 @@ Marker shape on the wire (Spec-Schemas `:rf/elision-marker`):
 
 Verified: schema-driven population at `implementation/schemas/src/re_frame/schemas.cljc:418-540` (`:large?` walker over `:map` / `:multi` / nested schemas); registry layout per `Spec-Schemas §:rf/elision-registry`.
 
+**Wrapper descent (rf2-b20zm).** The idiomatic Malli "optional but typed" shape `[:maybe [:string {:large? true}]]` works — the boot-walker descends a single-child `:maybe` wrapper that carries no props of its own and reads `:large?` / `:sensitive?` / `:hint` off the inner schema. An explicit outer props map (`[:maybe {:large? true} :string]`) still wins; no descent in that case. **`:and` / `:or` / `:enum` are NOT descended in v1** (conservative scope — merge / priority semantics across multi-child wrappers are TBD); put the flag on the outer schema or on a single-child `:maybe` inner.
+
 ## `rf/elide-wire-value` — manual invocation
 
 For HTTP forwarders, custom loggers, or any consumer code that ships an app-db slice off-box. Same walker the framework's listeners use; **never hand-roll**.
@@ -71,6 +73,16 @@ For HTTP forwarders, custom loggers, or any consumer code that ships an app-db s
 ```
 
 Off-box defaults (`include-large?` / `include-sensitive?` both `false`): large → marker, sensitive → `:rf/redacted`. Verified: `re-frame.elision/elide-wire-value` (`elision.cljc:443-540`); the **single normative emission site** for both sentinels — per-tool reimplementation is prohibited.
+
+The complete `:rf.size/*` opts-map vocabulary (per [Conventions §Reserved namespaces](../../../../spec/Conventions.md) and [API.md §`rf/elide-wire-value`](../../../../spec/API.md)):
+
+| Key | Default | Effect |
+|---|---|---|
+| `:rf.size/include-large?` | `false` | When `true`, large values flow through; when `false` (off-box default), they elide to `:rf.size/large-elided` markers. |
+| `:rf.size/include-sensitive?` | `false` | When `true`, sensitive values flow through the walker without drop (in-box only). Per rf2-11bot PR #758. |
+| `:rf.size/include-digests?` | `false` | When `true`, the marker carries a `sha256:<hex>` `:digest` slot. Off by default — computing it forces a full walk that negates the elision's cost-saving. |
+| `:rf.size/threshold-bytes` | `16384` | Auto-detect threshold: values whose `pr-str` exceeds this length flag at the leaf. `0` disables runtime auto-detect (only declared / schema entries elide). Process-wide knob via `(rf/configure :elision ...)`. |
+| `:rf.size/elision-policy` | n/a | Wrapper key — when a tool composes the four keys above as a nested policy map, this is its outer slot. The walker also accepts the four keys flat (the `rf/elide-wire-value` form shown above). |
 
 ## `rf/sensitive?` — public predicate
 

--- a/skills/re-frame2/reference/cross-cutting/production-observability.md
+++ b/skills/re-frame2/reference/cross-cutting/production-observability.md
@@ -68,6 +68,52 @@ Verified: `re-frame.error-emit/dispatch-on-error!` (`error_emit.cljc:171-230`); 
 
 **Composition with per-frame `:on-error` policy** (rf2-hqbeh): the error-emit substrate runs the per-frame `:on-error` policy AND the corpus-wide listener registry from one emission site. Use `:on-error` for **in-app recovery** (retry, mark, navigate); use `register-error-emit-listener!` for **off-box observability**. They are independent — register both when you need both.
 
+### `:on-error` shape and wiring (the in-app recovery slot)
+
+`:on-error` is a `reg-frame` metadata slot. The framework calls it with the structured error event AFTER emitting the trace and BEFORE applying the category's default recovery. It returns a closed-shape map telling the runtime how to proceed; `nil` defers to the category default.
+
+```clojure
+(rf/reg-frame :rf/default
+  {:doc "App-shell frame with monitoring + recovery."
+   :on-error
+   (fn handle-error [error-event]
+     ;; error-event is an :rf/trace-event with :op-type :error.
+     (case (:operation error-event)
+       :rf.error/handler-exception
+       {:recovery    :replaced-with-default
+        :replacement {:db (get-in error-event [:tags :db-before])}
+        :notes       "handler threw — rolled back to db-before"}
+
+       :rf.error/schema-validation-failure
+       {:recovery    :replaced-with-default
+        :replacement (get-in error-event [:tags :default-value])}
+
+       ;; default: defer to the category's documented recovery
+       nil))})
+```
+
+**Return-map contract** (closed shape, per [Spec 009 §Error-handler policy](../../../../spec/009-Instrumentation.md#error-handler-policy-on-error-per-frame)):
+
+```clojure
+{:recovery    <keyword>   ;; REQUIRED — one of :no-recovery, :replaced-with-default,
+                          ;; :skipped, :warned-and-replaced, :logged-and-skipped, :ignored
+ :replacement <value>     ;; OPTIONAL — only honoured when :recovery is :replaced-with-default;
+                          ;; shape is category-specific (effect-map for :handler-exception, etc.)
+ :notes       <string>}   ;; OPTIONAL — free-form; surfaced under :tags :notes on the augmented trace
+```
+
+**Production survival (rf2-hqbeh).** Unlike the rest of the trace surface, `:on-error` is NOT gated by `re-frame.interop/debug-enabled?` — it rides the same always-on error-emit substrate as `register-error-emit-listener!`. Registered policy fns fire on production handler exceptions; the substrate covers `:rf.error/handler-exception` today (the primary production-monitoring case). Each frame has at most one `:on-error` handler; re-registering the frame replaces the policy.
+
+**Composition rubric** — pick one, both, or neither:
+
+| Need | Surface | Why |
+|---|---|---|
+| In-app recovery (rollback, substitute, halt) | `:on-error` | Runs synchronously in the dispatch cascade; its return drives the runtime's next step. |
+| Off-box shipping (Sentry / Datadog) | `register-error-emit-listener!` | Cascade-independent; one bad listener cannot affect the policy fn (or vice versa). |
+| Both | Register both | The substrate fans out from one emission site; independent failure domains. The `:on-error` fn MAY return `nil` to forward-and-defer (per the [Spec 009 §Composition with libraries](../../../../spec/009-Instrumentation.md#error-handler-policy-on-error-per-frame) idiom) — letting the listener ship to the monitor while the runtime applies its default recovery. |
+
+A policy fn that throws does NOT recursively invoke itself — the runtime emits `:rf.error/on-error-policy-exception` and falls back to the category default. Listener exceptions are caught the same way (sibling listeners still run).
+
 ## Triple-gate registration pattern
 
 The substrate is always-on; **registration sites** should belt-and-braces gate on explicit config + `goog.DEBUG=false` + a credential probe, so an accidental dev-bundle deploy with prod config doesn't quietly ship records to your back-end.


### PR DESCRIPTION
Three small follow-on tweaks to the two cross-cutting leaves that landed with rf2-xas97 (privacy-and-elision.md + production-observability.md).

## rf2-dxins — :maybe wrapper-descent note (privacy-and-elision.md)

After rf2-b20zm PR #767 fixed the elision boot-walker to descend single-child `:maybe` wrappers, the idiomatic `[:maybe [:string {:large? true}]]` shape now works. Adds a 3-line ergonomic note pointing this out — and the conservative-v1 caveat that `:and` / `:or` / `:enum` are NOT descended.

## rf2-kq61o — :rf.size/* opts-map enumeration (privacy-and-elision.md)

Promotes the `:rf.size/*` keys from buried inside the `rf/elide-wire-value` code example to an explicit reference table. All five canonical keys with defaults, sourced from Conventions.md line 35 and API.md line 438:

- `:rf.size/include-large?` (false)
- `:rf.size/include-sensitive?` (false; per rf2-11bot PR #758)
- `:rf.size/include-digests?` (false)
- `:rf.size/threshold-bytes` (16384)
- `:rf.size/elision-policy` (wrapper key)

## rf2-do6xx — :on-error shape + wiring (production-observability.md)

The leaf already named the composition with the per-frame `:on-error` slot (rf2-hqbeh) but didn't show its shape. Adds:

- Canonical `reg-frame` snippet with the policy fn body.
- Closed-shape return-map contract (`{:recovery / :replacement / :notes}`) and the six recovery keywords.
- Production-survival note (rf2-hqbeh — `:on-error` rides the always-on error-emit substrate, not the trace surface).
- "Pick one, both, or neither" composition rubric covering `:on-error` (in-app recovery) + `register-error-emit-listener!` (off-box).

## Leaf size

Both leaves under the 250-line / 16KB ceiling:

- privacy-and-elision.md: 157 lines / 11465 bytes
- production-observability.md: 184 lines / 13363 bytes

## Test plan

- [ ] CI passes (docs-only change, no code paths exercised)
- [ ] Visual inspection of the two leaves