### PR TITLE
docs(skills/retro2): :on-error analysis lens + out-of-scope clarification (rf2-lcc5x, rf2-56sp7)

### DIFF
--- a/skills/re-frame-pair-retro2/SKILL.md
+++ b/skills/re-frame-pair-retro2/SKILL.md
@@ -63,6 +63,8 @@ Deliver:
 
 **Activation precondition**: a `re-frame-pair2` session must be available as evidence — either occurring in this conversation, or supplied by the user as a recap / summary. If no pair-tool surface was exercised and the user has not described one, decline — there is nothing to retrospect on.
 
+**Story recorder-session retros are out of scope.** Retrospectives on a Story Test Codegen recording (rf2-5fc15 — clicks/fills captured as a `:play` body) are NOT this skill's concern. Those retros belong in `re-frame-pair2`'s variant-refinement workflow (the recorder output is a `:play` snippet to refine against a frame, not a pair-session friction trace). If the user asks to "retro on my recorded play sequence" or similar, decline and route to `re-frame-pair2`.
+
 Routing decisions (mid-session pair work, app-authoring without a live runtime, framework / spec feedback, app-bug help, vocabulary-only matches) follow the matrix at [`skills/README.md` §Skill routing — single source](../README.md#skill-routing--single-source) and §Disqualifiers.
 
 When in doubt, ask: *"Was there a `re-frame-pair2` session you want me to retrospect on? If you can paste a short recap I can work from that."* Decline rather than fabricate evidence.
@@ -86,7 +88,7 @@ Load [`../shared/retro-protocol.md`](../shared/retro-protocol.md) — the seven-
 5. **Generate improvements at the right layer** — skill wording, structured op, runtime surface, cross-platform behavior, validation/fixture, instrumentation, or an upstream `re-frame2` bead. Prefer proposals that remove repeated effort, not just this session's exact symptom. Offer options: no action / docs / tool change / pair2 bead / upstream re-frame2 bead.
 6. **Prioritize.** Favor high-impact, specific, evidence-supported, trust-improving ideas. Return 2-5; default mix is 1-3 grounded + 0-2 bolder.
 
-Load [`references/analysis-lenses.md`](references/analysis-lenses.md) when the session has multiple plausible causes or you want a sharper taxonomy. Load [`references/known-frictions.md`](references/known-frictions.md) when the session resembles a recurring class of pain and you want to sanity-check one-off vs pattern.
+Load [`references/analysis-lenses.md`](references/analysis-lenses.md) when the session has multiple plausible causes or you want a sharper taxonomy — including the `:on-error` policy lens when the session touched a frame's `:on-error` slot (inspecting it, hot-swapping it, or chasing why an error wasn't recovered the expected way). Load [`references/known-frictions.md`](references/known-frictions.md) when the session resembles a recurring class of pain and you want to sanity-check one-off vs pattern.
 
 ## Output format
 

--- a/skills/re-frame-pair-retro2/references/analysis-lenses.md
+++ b/skills/re-frame-pair-retro2/references/analysis-lenses.md
@@ -41,6 +41,30 @@ These signals are unique to or amplified by re-frame2's Tool-Pair surfaces. Watc
 - machine-snapshot version skew (`:rf/snapshot-version`) silently breaking restore after a hot reload
 - effect overrides (`:fx-overrides`) that lingered or leaked across experiments
 
+## `:on-error` policy lens
+
+Use when the session touched a frame's `:on-error` slot — inspecting it, hot-swapping it, or chasing why an error wasn't recovered the way the user expected. The pair2 skill's [`references/on-error.md`](../../re-frame-pair2/references/on-error.md) is the operational contract; this lens is the retrospective view that feeds policy-contract friction back into pair2 improvements.
+
+The slot's return shape is closed (`{:recovery :replacement :notes}` with a six-value `:recovery` enum). Most policy friction shows up as one of these patterns.
+
+Friction signals specific to `:on-error`:
+
+- a `:rf.error/bad-on-error-return` trace fired but the user (or the agent) did not notice — the runtime fell back to the category default silently and the user kept debugging the wrong symptom
+- a `:rf.error/on-error-policy-exception` trace fired (the policy fn threw) and the cascade halted without a clear next-best-action surfaced in the session
+- the policy returned the legacy `{:recovery :retried :retry-count N}` shape — `:retry-count` is not part of the contract and `:retried` is reserved for `:rf.http/retry-attempt`; the runtime rejects it
+- `:replacement` was set under a `:recovery` value other than `:replaced-with-default` (ignored by the runtime; may emit `:rf.warning/replacement-ignored-on-recovery`)
+- `:replacement` shape did not match the failing operation's normal return (effect-map for `:rf.error/handler-exception`, position-matched value for `:rf.error/schema-validation-failure`, etc.) — runtime rejected it as `:rf.error/bad-on-error-return`
+- `:replacement` was set on a non-substitutable category (registration-time failures, drain-depth-exceeded, `:rf.epoch/restore-*` rejections, `:rf.machine/*` registration-time rejections) — runtime cannot honour it
+- the user expected `:on-error` to fire in a CLJS production build but it didn't — pre-rf2-hqbeh builds gated `:on-error` behind `goog.DEBUG`; surface the dev/prod divergence and route the fix upstream (rf2-hqbeh territory) rather than working around it in the policy
+- the session reached into `re-frame.events` / `re-frame.registrar` to read the registered policy fn instead of using `(:on-error (rf/frame-meta <frame-id>))` — off-contract private-namespace reach-through per Tool-Pair §REPL-eval
+
+Routing the fix:
+
+- **pair2 skill** — the friction is that the agent didn't recognise the bad-return / policy-throw trace categories, or the inspection recipe was unclear → tighten `references/on-error.md`, add a recipe, or surface the trace categories more loudly in `references/errors.md`
+- **upstream re-frame2** — the friction is the runtime's behaviour itself (silent fallback, no warning trace, prod-elision of the slot, missing structured `:tags` on the bad-return trace) → file against `re-frame2`, cross-link to `spec/009-Instrumentation.md §Error-handler policy`
+
+When proposing improvements, prefer turning a silent runtime fallback into a louder warning the agent can route to the user, and prefer a recipe over a doc paragraph when the friction is "I didn't know how to inspect the registered policy at the REPL".
+
 ## Root-cause categories
 
 Map each finding to one primary cause:


### PR DESCRIPTION
## Summary

Two bundled changes to `skills/re-frame-pair-retro2`:

- **rf2-lcc5x** — `references/analysis-lenses.md` grows an `:on-error` policy lens that surfaces policy-contract friction observed during pair2 sessions: bad return shapes (`:rf.error/bad-on-error-return`), policy exceptions (`:rf.error/on-error-policy-exception`), the legacy `:retry-count` idiom, `:replacement`-shape mismatches, prod-elision of the slot (rf2-hqbeh territory), and off-contract private-namespace reach-through. Routing guidance splits the fix between the pair2 skill and upstream re-frame2. Closes the loop opened by rf2-bf409 (PR #629), which added `skills/re-frame-pair2/references/on-error.md`.
- **rf2-56sp7** — `SKILL.md` "When NOT to use this skill" gets a 1-line guard: Story Test Codegen recorder-session retros (rf2-5fc15) are out of scope; they belong in `re-frame-pair2`'s variant-refinement workflow, not retro2's pair-session retrospective lens. Sourced from `ai/findings/re-frame-pair-story-skill-investigation-2026-05-13.md` candidate #3 (per rf2-ncp5n).

SKILL.md analysis-workflow loading line also picks up a directed hint to load the `:on-error` lens when the session touched the slot.

## Leaf size

`analysis-lenses.md`: 99 -> 123 L; 6.3KB -> 9.4KB. Well under the 250L / 16KB ceiling.

## Test plan

- [x] Read SKILL.md routing reads naturally with the new "out of scope" paragraph
- [x] `:on-error` lens cross-link to `re-frame-pair2/references/on-error.md` resolves correctly
- [x] Leaf size remains under the 250L / 16KB ceiling
- [x] No edits outside `skills/re-frame-pair-retro2/`