### PR TITLE
spec(causa-mcp): refresh 010-MCP-Server forward-references (rf2-l373o)

### DIFF
--- a/tools/causa/spec/010-MCP-Server.md
+++ b/tools/causa/spec/010-MCP-Server.md
@@ -12,7 +12,7 @@ without opening Causa's UI.
 > [`DESIGN-RATIONALE.md`](../../causa-mcp/spec/DESIGN-RATIONALE.md).
 > The design locks accumulated in this file have been lifted there;
 > citations point to their canonical homes. This file remains the
-> **catalogue prose** (the eighteen tools enumerated with signatures
+> **catalogue prose** (the seventeen tools enumerated with signatures
 > and return shapes); when implementation lands and
 > `tools/causa-mcp/spec/003-Tool-Catalogue.md` is authored, the
 > catalogue prose migrates there and this file shrinks to a pointer.
@@ -129,10 +129,10 @@ The seventeen-tool cardinality and closed-set policy are locked at
 Lock #5; the closed-set discipline and `eval-cljs` escape valve
 posture live at
 [`tools/causa-mcp/spec/Principles.md`](../../causa-mcp/spec/Principles.md)
-�Closed-set tool catalogue, deliberate escape valve. The
+§Closed-set tool catalogue, deliberate escape valve. The
 **catalogue prose itself** (the tables below) remains here until
 implementation lands and migrates it to
-`tools/causa-mcp/spec/003-Tool-Catalogue.md`.: harmonise tool count between prose and table (rf2-mdoqh))
+`tools/causa-mcp/spec/003-Tool-Catalogue.md`.
 
 ### Inspection (read-only)
 
@@ -666,7 +666,7 @@ The projection consumes three inputs, indexed once per call:
 
 - **`events`** — the raw trace-buffer slice exposed by
   `(rf/trace-buffer)`, per
-  [Spec 009 §Trace bus](../../../spec/009-Instrumentation.md). Each
+  [Spec 009 §The trace event model](../../../spec/009-Instrumentation.md#the-trace-event-model). Each
   event MUST carry `:id`, `:time`, `:op-type`, `:operation`, and
   `:tags`; the projection consults `[:tags :origin]`, `[:tags :tool]`,
   `[:tags :event]`, `[:tags :reason]`, `[:tags :sub-id]`,
@@ -787,9 +787,10 @@ The MCP server's per-tool spec scaffold now lives at
   EDN canonical; closed-set catalogue with `eval-cljs` escape valve;
   stage-marker-independent; degraded boot).
 - [`DESIGN-RATIONALE.md`](../../causa-mcp/spec/DESIGN-RATIONALE.md)
-  — eight locks (implementation language, transport, connection
+  — ten locks (implementation language, transport, connection
   model, origin tagging, catalogue cardinality, npm coord, Chrome
-  MCP posture, bencode pin) with question / options / pick / why /
+  MCP posture, bencode pin, wire-protocol budget posture,
+  size-elision marker shape) with question / options / pick / why /
   date locked.
 
 The four pair2-mcp-shape capability files


### PR DESCRIPTION
## Summary

- Audit forward-references in `tools/causa/spec/010-MCP-Server.md` following the wave of Causa-MCP spec landings.
- Fix four stale or broken cross-references; all others verified accurate.

## What changed

- Drop stale "eighteen tools" claim in the spec-scope front-matter (canonical count is seventeen per rf2-mdoqh).
- Repair `§Closed-set tool catalogue, deliberate escape valve` cross-link — a mangled `§` glyph and a stray "harmonise tool count between prose and table (rf2-mdoqh))" fragment from an earlier botched edit.
- Bump the DESIGN-RATIONALE summary in §Spec scope from "eight locks" to "ten locks" and add the two missing entries (wire-protocol budget posture per rf2-lwgg8; size-elision marker shape per rf2-knshj).
- Point the `Spec 009 §Trace bus` reference at the actual heading `§The trace event model`, with anchor — the canonical phrasing used elsewhere in the codebase.

## Audit results

~27 distinct forward-references audited:

- 4 broken/stale (fixed above)
- 23 verified accurate (all `causa-mcp/spec/` files exist; all `Lock #N` anchors map to their headings; all causa-internal section anchors resolve; all Spec 009 anchors resolve; pair2-mcp/spec/ shape files referenced for the "will land at implementation time" forward-promise match the actual pair2-mcp folder layout — `001-Wire-Protocol.md`, `002-nREPL-Transport.md`, `003-Tool-Catalogue.md`, plus `API.md`).

## Test plan

- [x] `mkdocs build --strict` not affected (file isn't in MkDocs nav; spec/ tree builds independently if at all).
- [x] All edited cross-references resolve to existing files and headings.
- [x] No new content added — only repair to stale/broken references.