### PR TITLE
docs(skills/retro2): trim §Working style to design.md (rf2-k5aff)

### DIFF
--- a/skills/re-frame-pair-retro2/SKILL.md
+++ b/skills/re-frame-pair-retro2/SKILL.md
@@ -69,13 +69,9 @@ Routing decisions (mid-session pair work, app-authoring without a live runtime, 
 
 When in doubt, ask: *"Was there a `re-frame-pair2` session you want me to retrospect on? If you can paste a short recap I can work from that."* Decline rather than fabricate evidence.
 
-## Working style (short form)
+## Working style
 
-- **Evidence over vibes.** Cite concrete moments: retries, clarifications, fallbacks, stale outputs, empty outputs, waits, manual workarounds.
-- **Symptom vs cause.** *"We had to retry the attach three times"* is the symptom; *"discovery was brittle on this platform"* is the likely cause.
-- **Direct and indirect friction.** The user says something was frustrating *or* you see repeated commands, repeated explanations, fallback to lower-level tools, manual reconstruction, hidden prerequisites, partial results, confusing contracts.
-- **Positive gaps too.** What almost worked? What required too much expert knowledge? What capability existed but was undiscoverable? What should have been the default?
-- **Be creatively ambitious after diagnosis.** Start with grounded fixes; then ask what would make this workflow feel nearly automatic or hard to misuse. Include 1-2 higher-upside ideas when warranted, even if they reshape the workflow rather than patching a local symptom. Label speculative ideas clearly.
+Diagnostic posture rules (evidence over vibes; symptom vs cause; direct/indirect friction; positive gaps; creatively ambitious *after* diagnosis) live in [`spec/design.md` §8 Working style](spec/design.md#8-working-style-meta-process). Apply them per finding.
 
 ## Analysis workflow
 

--- a/skills/re-frame-pair-retro2/spec/design.md
+++ b/skills/re-frame-pair-retro2/spec/design.md
@@ -143,7 +143,19 @@ The `description` triggers on two canonical paths: (a) **explicit pull** — ret
 - **Forcing every retro into a code contribution** — L2 again; diagnosis is the deliverable.
 - **Pressuring the user to file anything** — L2 again.
 
-## 8. Why this design diverges from `re-frame-pair2`
+## 8. Working style (meta-process)
+
+The pillars in §2 govern *what* the skill delivers; the rules below govern *how* the AI conducts the retro conversation. They lock the diagnostic posture so the skill doesn't degenerate into vibes-driven editorialising or solutionism.
+
+- **Evidence over vibes.** Cite concrete moments: retries, clarifications, fallbacks, stale outputs, empty outputs, waits, manual workarounds. Re-states pillar 2 as an operational rule per finding.
+- **Symptom vs cause.** *"We had to retry the attach three times"* is the symptom; *"discovery was brittle on this platform"* is the likely cause. The skill names both; the bead targets the cause.
+- **Direct and indirect friction.** Direct = the user says something was frustrating. Indirect = repeated commands, repeated explanations, fallback to lower-level tools, manual reconstruction, hidden prerequisites, partial results, confusing contracts. Both count as evidence.
+- **Positive gaps too.** What almost worked? What required too much expert knowledge? What capability existed but was undiscoverable? What should have been the default? Negative-space evidence is as load-bearing as failure evidence.
+- **Be creatively ambitious after diagnosis.** Start with grounded fixes; then ask what would make this workflow feel nearly automatic or hard to misuse. Include 1-2 higher-upside ideas when warranted, even if they reshape the workflow rather than patching a local symptom. Operationalises pillar 4 + L6.
+
+SKILL.md cross-links here rather than reciting these rules inline — keeps the orchestrator lean per rf2-zkca8's leaf-size ceiling.
+
+## 9. Why this design diverges from `re-frame-pair2`
 
 - **No structured-op catalogue.** This skill doesn't operate on a live app; it operates on a session transcript.
 - **No `allowed-tools` block in frontmatter.** The skill is conversational; the AI's tools are the default Read/Edit/Write/Grep/Glob set plus `bd create` when filing is opt-in.
@@ -151,7 +163,7 @@ The `description` triggers on two canonical paths: (a) **explicit pull** — ret
 - **`agents/openai.yaml` is included.** The skill is portable across LLM hosts; the openai config carries the routing for non-Claude hosts.
 - **No `scripts/` directory.** The skill doesn't ship runtime tooling.
 
-## 9. Open questions (deferred to Mike)
+## 10. Open questions (deferred to Mike)
 
 ### OQ1 — Should the skill ship a "session capture" helper?
 


### PR DESCRIPTION
## Summary

- Moves the meta-process content of `skills/re-frame-pair-retro2/SKILL.md` §Working style into `spec/design.md` §8 Working style (meta-process).
- Replaces the SKILL.md section with a one-line cross-link, keeping the orchestrator lean.
- SKILL.md size: 132L / 11317B → 128L / 10550B (well under rf2-zkca8's ≤500L / ≤16KB leaf ceiling).

## Why

§Working style was 30 lines partly duplicating the pillar list (esp. *Evidence over vibes*). The rules belong with the design rationale, not in the orchestrator. design.md §8 now ties each rule back to its pillar / locked decision, and SKILL.md links there.

Closes rf2-k5aff.