### PR TITLE
docs(skills/re-frame-migration): M-50 with-overrides → with-fx-overrides (rf2-pm2km)

### DIFF
--- a/skills/re-frame-migration/reference/auto-call-site-rewrites.md
+++ b/skills/re-frame-migration/reference/auto-call-site-rewrites.md
@@ -6,7 +6,7 @@ For the *why* of each rule, see [`MIGRATION.md`](../../../spec/MIGRATION.md). Th
 
 ## Contents
 
-- Dep-coord and namespace rewrites (M-0, M-1, M-38, M-23, M-25, M-52)
+- Dep-coord and namespace rewrites (M-0, M-1, M-38, M-23, M-25, M-50, M-52)
 - Effect-map consolidation (M-8)
 - Dispatch-shape rewrites (M-4, M-9, M-16)
 
@@ -110,6 +110,24 @@ body...
 ```
 
 v2's `dispatch-sync` is already settle-by-default, so the macro added nothing on the synchronicity axis; the registrar snapshot/restore half is covered by the per-test fixture every v2 suite installs.
+
+### M-50 — `with-overrides` → `with-fx-overrides`
+
+```clojure
+;; SEARCH
+(rf/with-overrides {<override-map>}
+  body...)
+(re-frame.core/with-overrides {<override-map>}
+  body...)
+
+;; REWRITE — rename the macro; body and override-map shape unchanged
+(rf/with-fx-overrides {<override-map>}
+  body...)
+(re-frame.core/with-fx-overrides {<override-map>}
+  body...)
+```
+
+Mechanical name-rename only. The macro's `binding` over `re-frame.router/*fx-overrides*`, the override-map shape, precedence rules, and composition with `with-frame` are unchanged — three names (macro / `:fx-overrides` opt key / `*fx-overrides*` dynvar) now share the `fx-overrides` stem. Cross-ref: rf2-mozsm; see [MIGRATION.md §M-50](../../../spec/MIGRATION.md#m-50-with-overrides-macro-renamed-to-with-fx-overrides).
 
 ---
 

--- a/skills/re-frame-migration/reference/breaking-changes.md
+++ b/skills/re-frame-migration/reference/breaking-changes.md
@@ -67,6 +67,7 @@ A one-page index keyed to v1 trigger surfaces. The author asks *"is `X` covered 
 | Machine `:tags` slot and `:rf/machine-has-tag?` sub | M-47 | — | Additive. No user-side action. |
 | `:type :parallel` machines with map-shaped `:state` | M-48 | — | Additive. No user-side action. |
 | Snapshot `:state` reader pattern-matching against the third arm (map) | M-49 | — | Additive; widens to a third arm. Readers that pattern-match exhaustively on `:state` may need to widen the dispatch. |
+| `(rf/with-overrides ...)` test-support macro | **M-50** | A | Mechanical rename to `with-fx-overrides`. Body, override-map shape, and composition with `with-frame` are unchanged — only the macro name moves, for symmetry with the `:fx-overrides` opt key and `*fx-overrides*` dynvar. |
 | Unary `reg-fx` handler `(fn [args] ...)` | **M-51** | A | Mechanical: `(fn [args] body)` → `(fn [_ args] body)`. The unary back-compat path is cut; the runtime invokes every fx with two args. Async handlers should additionally capture `(rf/dispatcher)` for frame-aware callbacks. |
 | `(ts/run-test-sync ...)` / `(re-frame-test/run-test-sync ...)` | **M-52** | A | Removed. Hoist body to inline `dispatch-sync` calls under the standard `reset-runtime-fixture` (or `with-fresh-registrar` for ad-hoc bracketing). v2's `dispatch-sync` is already settle-by-default; the macro was pure migration tax. |
 


### PR DESCRIPTION
## Summary

The `re-frame-migration` skill mentioned M-50 in the Type A summary list (`breaking-changes.md` L101) but had no actual row in the breaking-changes table for it, and no SEARCH/REWRITE shape in `auto-call-site-rewrites.md`. Migration agents walking the skill would have missed the `with-overrides` → `with-fx-overrides` rename from rf2-mozsm (#595).

- `breaking-changes.md`: add the M-50 row between M-49 and M-51 (Type A; mechanical rename).
- `auto-call-site-rewrites.md`: add the SEARCH/REWRITE shape after M-52 (its sibling test-support macro rewrite); update the Contents index to list M-50.

Body, override-map shape, precedence rules, and composition with `with-frame` are unchanged — only the macro name moves. Cross-links to `spec/MIGRATION.md` §M-50 and rf2-mozsm for rationale.

Touches only `skills/re-frame-migration/`. Disjoint from current in-flight work.

## Test plan

- [x] `breaking-changes.md` table row inserted with correct rule type (A) and one-line summary
- [x] `auto-call-site-rewrites.md` SEARCH/REWRITE block uses the rf-aliased and fully-qualified shapes
- [x] Cross-reference link to MIGRATION.md anchor matches the GitHub slug for the §M-50 header
- [x] Contents list at top of `auto-call-site-rewrites.md` updated