### PR TITLE
docs(skills/re-frame2-implementor): reconcile cardinal rule 3 vs phase 2 EP order (rf2-jgy35)

### DIFF
--- a/skills/re-frame2-implementor/reference/cardinal-rules.md
+++ b/skills/re-frame2-implementor/reference/cardinal-rules.md
@@ -14,7 +14,7 @@ Decisions made under Phase 1 (host language, substrate, scope, identity primitiv
 
 ## 3. Implement in dependency order
 
-EP 001 (Registration) → 002 (Frames + events + effects + subs) → 006 (Reactive substrate) → 004 (Views) are the foundation. The optional EPs (005, 007–014) sit downstream and can be deferred or skipped per Phase 1 scope.
+EP 001 (Registration) → 002 (Frames + events + effects + subs) → 006 (Reactive substrate) → 004 (Views) → 009 (Instrumentation) are the foundation. Acceptance gate 1 — running the `:core/*` conformance fixtures — sits at the end of this cluster; 009 is in the foundation because `:core/trace` and `:core/error` fixtures exercise it. The optional EPs (005, 007–008, 010–014) sit downstream and can be deferred or skipped per Phase 1 scope.
 
 ## 4. Substrate-agnostic phrasing in code and docs
 


### PR DESCRIPTION
## Summary

- Rule 3 in `skills/re-frame2-implementor/reference/cardinal-rules.md` listed the foundation EPs as `001 → 002 → 006 → 004`, omitting `009` (Instrumentation).
- Every other reference to the dependency order — `SKILL.md` one-liner (rule 3 + Phase 2 paragraph), `reference/phase-2-impl-order.md` walking order, `spec/design.md`, `spec/authoring-prompt.md`, `reference/kickoff-prompt.md` — already includes `009` in the foundation cluster because the `:core/trace` and `:core/error` conformance fixtures exercise it before acceptance gate 1.
- Update Rule 3 to match (`001 → 002 → 006 → 004 → 009`) and add a one-sentence note explaining why `009` is part of the foundation, not optional. Resolves drift; the phase-2-impl-order leaf was the source of truth.

## Test plan

- [x] Internal consistency: grep for the EP order across the skill confirms every callsite now reads `001 → 002 → 006 → 004 → 009`.
- [x] No code changes — docs-only edit in `skills/re-frame2-implementor/reference/cardinal-rules.md`.