### PR TITLE
docs(skills): stress-test SKILL-REDIRECT.md anchor coupling (rf2-o2qrj)

### DIFF
--- a/SKILL-REDIRECT.md
+++ b/SKILL-REDIRECT.md
@@ -3,6 +3,28 @@
 Canonical pointer table for AI skills. Skills stay free of hardcoded URLs;
 this file owns them. Update once when a URL changes.
 
+<!--
+ANCHOR COUPLING — read before editing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Leaf skill files cite the bullet labels below as routing anchors, e.g.
+  `SKILL-REDIRECT.md` -> *EP - Frames (002)*
+  `SKILL-REDIRECT.md` -> *Pattern - WebSocket*
+
+If you rename a bullet label here, every leaf citing it goes stale silently.
+Before editing labels, run the drift checker from the repo root:
+
+    python3 scripts/check_skill_redirect_anchors.py
+
+It walks `skills/**/*.md`, extracts every `SKILL-REDIRECT.md -> *Label*`
+reference, and verifies the label matches a bullet below. Non-zero exit on
+drift, with each broken reference printed. Run it again after editing.
+
+When adding a new bullet, keep the format `- **Label** -> URL [tag] [tag]`;
+that's the shape the checker (and human readers) expects.
+-->
+
+
 ## Skill index — what to scan for
 
 Find your skill, scan the audience section for lines tagged with it.

--- a/scripts/check_skill_redirect_anchors.py
+++ b/scripts/check_skill_redirect_anchors.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Check that every `SKILL-REDIRECT.md -> *Label*` reference in the skills/ tree
+resolves to a real bullet label in the root SKILL-REDIRECT.md.
+
+Anchor coupling (rf2-o2qrj). SKILL-REDIRECT.md is the single coupling point for
+deep-dive routing from the AI skills. Leaf files cite its bullet labels (e.g.
+`SKILL-REDIRECT.md -> *EP - Frames (002)*`). If SKILL-REDIRECT.md is renamed,
+restructured, or a bullet label drifts, every leaf citation goes stale silently.
+
+Run from the repo root:
+    python3 scripts/check_skill_redirect_anchors.py
+
+Exits non-zero if any reference points at a label that does not exist in
+SKILL-REDIRECT.md. Run before any edit to SKILL-REDIRECT.md, and from CI to
+catch drift introduced by leaves.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import sys
+import pathlib
+
+
+REDIRECT_FILE = pathlib.Path("SKILL-REDIRECT.md")
+SKILLS_DIR = pathlib.Path("skills")
+
+# Bullet-label syntax in SKILL-REDIRECT.md is:
+#   - **Label** -> URL `[tag]` `[tag]`
+# Bold may be ** or __. Allow either.
+BULLET_LABEL_RE = re.compile(
+    r"^\s*-\s+(?:\*\*|__)(.+?)(?:\*\*|__)\s*(?:→|->)",
+    re.MULTILINE,
+)
+
+# Reference syntax in leaf files (any *.md under skills/):
+#   ... SKILL-REDIRECT.md -> *Label* ...           (single emphasis)
+#   ... SKILL-REDIRECT.md -> **Label** ...         (bold)
+#   ... `SKILL-REDIRECT.md` -> *Label* ...         (back-ticked redirect)
+# The label is the next *-delimited or **-delimited run after the arrow.
+# Arrow may be the Unicode -> (U+2192) or ASCII ->.
+REF_RE = re.compile(
+    r"SKILL-REDIRECT\.md`?\s*(?:→|->)\s*(?:\*\*|\*|__|_)([^*_\n`]+?)(?:\*\*|\*|__|_)",
+)
+
+# Some leaf refs trail a "section" qualifier on the same label, e.g.
+#   *EP - State machines (005)* §Cancellation cascade
+# The label proper is what's between the *s; the §Section is informational
+# and is NOT validated here (it would couple to the spec docs, not SKILL-REDIRECT).
+# So we just normalise the captured label by stripping a trailing " §..." if any.
+def normalise(label: str) -> str:
+    return re.split(r"\s*§", label, maxsplit=1)[0].strip()
+
+
+def main() -> int:
+    # Force UTF-8 output so we don't choke on the en-dash / arrow on Windows.
+    if hasattr(sys.stdout, "buffer"):
+        sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", line_buffering=True)
+
+    if not REDIRECT_FILE.exists():
+        print(f"ERROR: {REDIRECT_FILE} not found. Run from repo root.", file=sys.stderr)
+        return 2
+
+    redirect_text = REDIRECT_FILE.read_text(encoding="utf-8")
+    canonical = {m.group(1).strip() for m in BULLET_LABEL_RE.finditer(redirect_text)}
+
+    if not canonical:
+        print(f"ERROR: no bullet labels parsed out of {REDIRECT_FILE}.", file=sys.stderr)
+        return 2
+
+    refs = []  # (path, lineno, raw_label, normalised_label)
+    for path in sorted(SKILLS_DIR.rglob("*.md")):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), 1):
+            for m in REF_RE.finditer(line):
+                raw = m.group(1).strip()
+                refs.append((path, lineno, raw, normalise(raw)))
+
+    broken = [(p, ln, raw, norm) for (p, ln, raw, norm) in refs if norm not in canonical]
+    ok = len(refs) - len(broken)
+
+    print(f"SKILL-REDIRECT.md anchor coupling audit")
+    print(f"  canonical labels in SKILL-REDIRECT.md: {len(canonical)}")
+    print(f"  leaf references inspected:             {len(refs)}")
+    print(f"  references OK:                         {ok}")
+    print(f"  references BROKEN:                     {len(broken)}")
+
+    if broken:
+        print()
+        print("Broken references (label does not appear as a bullet in SKILL-REDIRECT.md):")
+        for path, ln, raw, norm in broken:
+            rel = path.as_posix()
+            print(f"  {rel}:{ln}  label={raw!r}  base={norm!r}")
+        print()
+        print("Fix options:")
+        print("  - Update SKILL-REDIRECT.md so the bullet label exactly matches the leaf ref.")
+        print("  - Update the leaf ref so it exactly matches a SKILL-REDIRECT.md bullet label.")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/re-frame2/reference/fundamentals/cofx.md
+++ b/skills/re-frame2/reference/fundamentals/cofx.md
@@ -107,7 +107,7 @@ Two notes on the cofx body:
 
 There is deliberately **no `cofx-from-sub` shortcut helper** in `re-frame.core` (rf2-gw8j closed as won't-ship, 2026-05-13). The five-line `reg-cofx` wrapper above is the canonical shape; collapsing it into a one-liner would imply that subscribing-inside-handlers is the rule and the wrap is the workaround, when it is the other way around.
 
-Narrative treatment of the same pattern (for humans): `SKILL-REDIRECT.md` → **Guide ch.05 §Reading a sub from a handler**.
+Narrative treatment of the same pattern (for humans): [`docs/guide/05-coeffects.md`](../../../../docs/guide/05-coeffects.md) §Reading a sub from a handler.
 
 ## Common gotchas
 


### PR DESCRIPTION
## Summary

Leaf skill files cite `SKILL-REDIRECT.md` bullet labels as routing anchors (e.g. `` `SKILL-REDIRECT.md` -> *EP - Frames (002)* ``). If a bullet label drifts, every leaf citing it goes stale silently. This bead audits the coupling, fixes a stray broken ref, and ships a drift detector.

- **`scripts/check_skill_redirect_anchors.py`** — walks `skills/**/*.md`, extracts every `SKILL-REDIRECT.md -> *Label*` reference, verifies the label matches a bullet in `SKILL-REDIRECT.md`. Exits non-zero on drift; prints `file:line` for each broken ref. Style-matches `scripts/check_doc_slugs.py`.
- **`SKILL-REDIRECT.md`** — anchor-coupling note pointing future editors at the checker.
- **`skills/re-frame2/reference/fundamentals/cofx.md:110`** — one broken ref fixed. Pre-fix the leaf cited `*Guide ch.05 §Reading a sub from a handler*`, which had no matching bullet in `SKILL-REDIRECT.md`. Reshaped to a direct relative link to `docs/guide/05-coeffects.md`, matching how every other leaf cites individual guide chapters (22-trace-to-datadog, 11-server-side, 23-privacy-and-elision).

## Audit result

| Metric | Count |
|---|---|
| Canonical bullet labels in `SKILL-REDIRECT.md` | 44 |
| Leaf references inspected (across `skills/**/*.md`) | 40 |
| References OK | 40 (39 pre-fix, +1 fixed) |
| References broken | 0 (1 pre-fix, -1 fixed) |

## Stress test (drift catches)

Renaming `EP — Frames (002)` to `EP — Framez (002)` in `SKILL-REDIRECT.md` immediately flips the checker red and lists all 4 leaves citing it (`event-state-cycle.md`, `events.md`, `frames.md`, `fx.md`). Restore => green.

## Test plan

- [x] `python3 scripts/check_skill_redirect_anchors.py` => green (40/40 OK)
- [x] Tamper test (rename a label) => exit 1 with every stale leaf reported
- [x] Restore => exit 0 again