### PR TITLE
docs(skills): standardise SKILL.md description: field shape (rf2-ac4w9)

### DIFF
--- a/skills/re-frame-migration/SKILL.md
+++ b/skills/re-frame-migration/SKILL.md
@@ -10,10 +10,10 @@ description: >
   or any prompt referencing a v1 surface (re-frame.db, dispatch-with,
   reg-global-interceptor, reg-sub-raw, ^:flush-dom, re-frame.alpha,
   re-frame-test, old top-level :dispatch / :dispatch-n effect-map keys).
-  Do not use for: greenfield bootstrap (use `re-frame2-setup`), writing v2
-  application code (use `re-frame2`), live v2-app inspection
-  (use `re-frame-pair2`), or porting re-frame2 itself
-  (use `re-frame2-implementor`).
+  **Do not use** for: greenfield bootstrap (use `re-frame2-setup`),
+  writing v2 application code (use `re-frame2`), live v2-app inspection
+  (use `re-frame-pair2`), or porting re-frame2 itself (use
+  `re-frame2-implementor`).
 allowed-tools:
   - Bash(rg *)
   - Bash(rg -l *)

--- a/skills/re-frame2-implementor/SKILL.md
+++ b/skills/re-frame2-implementor/SKILL.md
@@ -10,9 +10,10 @@ description: >
   Trigger on phrasing like "port re-frame2", "implement re-frame2 in
   <language>", "second re-frame2 implementation", "implementor checklist",
   "conformance corpus", or any prompt about building re-frame2 itself.
-  Do not use for: writing apps on the CLJS reference (use `re-frame2`),
-  greenfield bootstrap (use `re-frame2-setup`), v1→v2 migration
-  (use `re-frame-migration`), or live-app inspection (use `re-frame-pair2`).
+  **Do not use** for: writing apps on the CLJS reference (use
+  `re-frame2`), greenfield bootstrap (use `re-frame2-setup`), v1→v2
+  migration (use `re-frame-migration`), or live-app inspection (use
+  `re-frame-pair2`).
 allowed-tools:
   - Bash(bd *)
   - Read

--- a/skills/re-frame2-setup/SKILL.md
+++ b/skills/re-frame2-setup/SKILL.md
@@ -11,8 +11,12 @@ description: >
   project", "scaffold re-frame2", "hello-world re-frame2 app", "new
   re-frame2 app", or a build failure on a freshly-scaffolded project that
   traces to missing `re-frame.core` / `re-frame.adapter.reagent` wiring.
-  Exits once the counter mounts. For full disqualifier list and routing
-  to sibling skills, see `skills/README.md` §Skill routing — single source.
+  Exits once the counter mounts. **Do not use** for writing app code
+  on an already-bootstrapped project (use `re-frame2`), v1→v2 migration
+  (use `re-frame-migration`), live-app inspection (use `re-frame-pair2`),
+  or porting re-frame2 itself (use `re-frame2-implementor`). For the
+  full disqualifier list and routing to sibling skills, see
+  `skills/README.md` §Skill routing — single source.
 allowed-tools:
   - Bash(clojure *)
   - Bash(npm *)

--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -1,6 +1,21 @@
 ---
 name: re-frame2
-description: Writes re-frame2 ClojureScript application code — events, subscriptions, effects, frames, state machines (reg-machine, parallel regions, tags, invoke), schemas, stories, routing, tests, and the canonical patterns (RemoteData, Forms, Boot, WebSocket, NineStates, ManagedHTTP, AsyncEffect, LongRunningWork, StaleDetection). Use whenever the user mentions re-frame2, reg-event-db, reg-event-fx, reg-sub, reg-fx, reg-cofx, reg-view, reg-machine, reg-route, reg-story, reg-app-schema, dispatch, subscribe, app-db, frames, regions, tags, the nine UI states, managed HTTP, RemoteData lifecycles, writing tests for a re-frame2 app, or state-machine-for-HTTP shapes — even when re-frame2 is not named explicitly. Authoring only (writing new code). Do not use for: live-app inspection (use re-frame-pair2), greenfield project bootstrap (use re-frame2-setup), v1→v2 migration (use re-frame-migration), or porting re-frame2 itself (use re-frame2-implementor).
+description: >
+  Writes re-frame2 ClojureScript application code — events, subscriptions,
+  effects, frames, state machines (reg-machine, parallel regions, tags,
+  invoke), schemas, stories, routing, tests, and the canonical patterns
+  (RemoteData, Forms, Boot, WebSocket, NineStates, ManagedHTTP,
+  AsyncEffect, LongRunningWork, StaleDetection). Use whenever the user
+  mentions re-frame2, reg-event-db, reg-event-fx, reg-sub, reg-fx,
+  reg-cofx, reg-view, reg-machine, reg-route, reg-story, reg-app-schema,
+  dispatch, subscribe, app-db, frames, regions, tags, the nine UI
+  states, managed HTTP, RemoteData lifecycles, writing tests for a
+  re-frame2 app, or state-machine-for-HTTP shapes — even when re-frame2
+  is not named explicitly. **Authoring only** (writing new code).
+  **Do not use** for: live-app inspection (use `re-frame-pair2`),
+  greenfield project bootstrap (use `re-frame2-setup`), v1→v2 migration
+  (use `re-frame-migration`), or porting re-frame2 itself (use
+  `re-frame2-implementor`).
 allowed-tools:
   - Read
   - Edit


### PR DESCRIPTION
## Summary

Align the SKILL.md `description:` frontmatter across all 7 skills to a common shape, modelled on `re-frame-pair2`'s description (the strongest false-activation guard in the corpus). Structural-only changes; no semantic intent altered.

## Canonical shape

(a) Primary verb-led role lead
(b) Explicit trigger phrasing
(c) Bolded precondition where applicable
(d) Bolded ``**Do not use**`` clause with sibling-skill pointers

## Skills touched

- `skills/re-frame2/SKILL.md` — converted scalar single-line description to folded `>` block; bolded `**Authoring only**` precondition and `**Do not use**` clause.
- `skills/re-frame-migration/SKILL.md` — bolded `**Do not use**` for parity with model.
- `skills/re-frame2-implementor/SKILL.md` — bolded `**Do not use**` for parity.
- `skills/re-frame2-setup/SKILL.md` — added bolded inline `**Do not use**` clause for shape parity while preserving the `skills/README.md` pointer as the single source for the full disqualifier list.

## Skills NOT touched (already canonical)

- `skills/re-frame-pair2/SKILL.md` — the model
- `skills/re-frame-pair-retro2/SKILL.md`
- `skills/re-frame2-improver/SKILL.md`

## Test plan

- [ ] Verify YAML frontmatter parses for all 7 SKILL.md files
- [ ] Verify `name:` fields remain ≤ 64 chars (all well under)
- [ ] Visual diff confirms only frontmatter `description:` regions changed, no body content touched