### PR TITLE
spec(011+012+014): add §Open questions / §Resolved decisions trailers (rf2-d1mph)

### DIFF
--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -793,6 +793,32 @@ Implementation costs: chunked HTTP response handling, framework integration with
 
 An implementation that wants streaming can layer it on the existing emitter without framework changes.
 
+## Resolved decisions
+
+### `:replace-app-db` is the locked hydration merge policy
+
+Per [§The `:rf/hydrate` event](#the-rfhydrate-event) the client's `:rf/hydrate` handler replaces `app-db` with the server's serialised slice; earlier sketches considered a merge policy that would have preserved client-side pre-seeded state. The merge variant was rejected because the hydration contract is small and tractable only if the server is authoritative for the initial client `app-db` — a merge policy makes "did the server's value win?" undecidable at every key. Apps that want client-only seeded state run it after the hydration event, not before.
+
+### Sub-cache warmups out of scope for v1 `:rf/hydration-payload`
+
+Per [§Hydration of non-state runtime artefacts](#hydration-of-non-state-runtime-artefacts), `:rf/hydration-payload` carries `:rf/app-db` only. Adding sub-cache warmups requires the client to know the same sub-graph topology the server used and adds wire bytes plus serialisation complexity. The first read is the warmup. `:rf/sub-warmups` remains an optional additive payload field in [Spec-Schemas §`:rf/hydration-payload`](Spec-Schemas.md#rfhydration-payload); a future iteration can land it without breaking the contract.
+
+### Per-request frame teardown contract added (rf2-fcj33)
+
+Per [§Per-request frame teardown contract](#per-request-frame-teardown-contract) the framework now documents every per-frame allocation site that `destroy-frame!` MUST release, including two `re-frame.ssr` `defonce` side-channel atoms (pending error-trace buffer, per-frame HTTP request slot). Both are released via the `:ssr/on-frame-destroyed` `re-frame.late-bind` hook; the contract for side-channel atoms keyed by frame-id is locked. The load test at `implementation/ssr/test/re_frame/ssr_teardown_load_test.clj` (2000-request synthetic SSR loop) verifies the heap delta and side-channel atom sizes return to baseline.
+
+### Head/meta surface is live, not deferred (rf2-4dra9)
+
+Earlier drafts of [§Head/meta contract](#headmeta-contract) carried a deferral banner pointing to rf2-gr0n; the contract was normative-looking prose but the impl was absent. The decision in rf2-4dra9 landed the impl: `reg-head` registers under a `:head` registry kind; routes name a `:head` in route metadata; `render-head` computes the head model; `active-head` is sugar for the active route. The SSR emitter wraps body output with `<head>...</head>` from the model when a frame's active route declares `:head`. Head-vs-body mismatch detection piggy-backs on the unified `:rf/render-hash` via the `:failing-id` discriminator.
+
+### `:rf.ssr/check-version` and `:rf.ssr/check-schema-digest` are framework-registered (rf2-69ad2)
+
+Per [§The `:rf/hydrate` event](#the-rfhydrate-event) the reference `:rf/hydrate` handler dispatches `:rf.ssr/check-version` and (when payload carries a digest) `:rf.ssr/check-schema-digest`. Both fxs are registered by `re-frame.ssr` at ns-load time with `:platforms #{:client}`; version-mismatch emits `:rf.ssr/version-mismatch`, schema-digest-mismatch emits `:rf.ssr/schema-digest-mismatch`. Earlier drafts named both events in normative prose but registered neither — a silent `:rf.error/no-such-handler` trace at hydration time was the visible symptom. The two-handler set is locked; apps that want app-specific checks register additional handlers, they don't replace these.
+
+### SSR ships in a separate Maven artefact (`day8/re-frame2-ssr`)
+
+Per the abstract's CLJS-reference artefact statement, the SSR surface (`re-frame.ssr` namespace, the six `:rf.server/*` per-request fxs, the `reg-error-projector` registry kind, the FNV-1a render-tree hash, the `data-rf2-source-coord` annotation, the SSR error-projection trace listener) ships in a separate Maven artefact, not the core. Apps that don't render server-side build an `:advanced` bundle clean of every `re-frame.ssr` / `:rf.ssr/*` / `:rf.server/*` symbol and trace string. The per-feature artefact split (rf2-uo7v under Strategy B from rf2-5vjj) was chosen over a single-jar build with build-time elision because the optional-dependency boundary is cleaner to communicate and the static-classpath cost-of-presence is zero. See [MIGRATION §M-32](MIGRATION.md#m-32-ssr--hydration-spec-011-ships-in-a-separate-artefact--day8re-frame2-ssr).
+
 ## Cross-references
 
 - [011-SSR.md](011-SSR.md) — the goal-level statement and rationale.

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -964,6 +964,32 @@ The story / devcard / SSR cases all benefit:
 - URL-state-as-source-of-truth (URL canonical, `app-db` derives) — currently the inverse: `app-db` canonical, URL derives.
 - Declarative redirect rules in route metadata — currently redirects are interceptors.
 
+## Resolved decisions
+
+### `:rf.route.nav-token/*` trace-operation namespace (rf2-o39mn)
+
+The two nav-token trace operations — `:rf.route.nav-token/allocated` and `:rf.route.nav-token/stale-suppressed` (per [§Navigation tokens — stale-result suppression](#navigation-tokens--stale-result-suppression)) — live under `:rf.route.nav-token/*`. An earlier carve-out grandfathered the bare `:route.nav-token/*` prefix as the sole framework trace-operation namespace outside `:rf.*` (per the now-removed paragraph in [Conventions](Conventions.md)); rf2-o39mn closed that single-bit-of-difference exception, mechanically renaming all 91 occurrences across spec, conformance fixtures, implementation, docs, skills, and tools. The Conventions single-root rule (every framework-owned keyword sits under `:rf.*`) now holds without exception.
+
+### Default frame is URL-bound; non-default frames opt in
+
+Per [§Multi-frame routing](#multi-frame-routing) the default frame (`:rf/default`) is **URL-bound** by default; non-default frames are not. Non-default frames opt into URL binding via `(rf/reg-frame :my-frame {:url-bound? true})`; the runtime enforces "only one frame can own the URL at a time" (re-registering a second `:url-bound? true` frame emits `:rf.error/duplicate-url-binding`). This was chosen over a "first frame to dispatch `:rf.route/navigate` wins" rule because explicit declaration is auditable at registration time and matches the story / devcard / per-test-fixture / SSR-per-request use cases without surprise.
+
+### State-first, URL-second update order is locked
+
+Per [§Pattern-level contract](#pattern-level-contract), navigation runs state changes first, then the URL update, then `:on-match` dispatches and the scroll effect. The order is locked: if the URL update fails (browser denies, user is offline) the state is still consistent. An earlier alternative — URL-first — was rejected because the `app-db` becomes the source of truth for what URL the runtime *intends*; the `:rf.nav/push-url` fx is a downstream sync.
+
+### Three-enum scroll strategy (`:top`, `:restore`, `:preserve`)
+
+Per [§Scroll restoration](#scroll-restoration) the canonical scroll-strategy contract is the closed three-enum set. A custom scroll-strategy registry was considered but deferred to [§Open questions](#open-questions) — the three enums cover the documented cases (default-to-top on new navigation, restore on back/forward, preserve on intra-page transitions) and host-specific strategies layer additively via the map-form opt-in. Locking the enum keeps tools' enumeration of scroll behaviour decidable.
+
+### `:rf.route/not-found` is the single canonical reserved id
+
+Per [§Route-not-found — `:rf.route/not-found` (canonical)](#route-not-found--rfroutenot-found-canonical) the framework names exactly one reserved route id for unmatched URLs. Earlier sketches considered per-host customisation of the reserved id; the single-id rule was chosen because tools, conformance fixtures, and the `:rf.warning/no-not-found-route` trace event all depend on it. Apps that want per-error-kind visual treatment branch inside the `:rf.route/not-found` view on `:reason`.
+
+### Run-to-completion enforced for navigation cascades
+
+Per [§Pattern-level contract](#pattern-level-contract) the `:rf.route/navigate` cascade — state update, URL push, `:on-match` dispatches, scroll effect — settles inside a single drain. This matches [Spec 002 §Run-to-completion dispatch](002-Frames.md#run-to-completion-dispatch-drain-semantics) and was chosen over a multi-drain cascade so that subscribers see a consistent post-navigation state in one render pass rather than visible intermediate states.
+
 ## Cross-references
 
 - [000-Vision §Working design implications](000-Vision.md#working-design-implications) — "routing is state plus events."

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -1064,6 +1064,62 @@ Adjacent surfaces that are first-class re-frame2 commitments but live in their o
 - **HTTP/2 server push.** Not a re-frame2 concern; the platform handles it transparently.
 - **Response-side interceptors (`:after`).** v1's middleware contract is request-side only ([§Middleware](#middleware), rf2-6y3q). Apps that want to project / log / retry on response paths use `:accept` (domain-failure normalisation) and the trace stream; a future `:after` slot composes additively when it lands.
 
+## Open questions
+
+### Response-side middleware composition
+
+Per [§Middleware](#middleware) (rf2-6y3q) v1 ships request-side middleware only. A response-side `:after` slot — composing additively with `:accept` and `:before` — would let apps project / log / retry on response paths without per-event boilerplate. Deferred until the request-side surface settles in practice and the composition order with `:accept` is decided.
+
+### App-extensible query-param denylist
+
+Per [§2. Query-param denylist (always-on)](#2-query-param-denylist-always-on-rf2-2p8wr) (rf2-2p8wr) the always-on query-string denylist is a fixed framework-owned set. An extensible registration surface (`rf.http/declare-sensitive-query-param!` parallel to the header denylist) is a natural addition — deferred until a real app surfaces a query-param-auth pattern outside the default set.
+
+### Streaming responses (`:rf.http/streaming`)
+
+Per [§What Spec 014 does NOT cover](#what-spec-014-does-not-cover) streaming responses (chunked HTTP, server-sent events) ship in a sibling spec. The per-chunk event model is a different shape from the single-reply `:rf.http/managed` contract and needs its own envelope; the contract here remains the request → single-reply shape.
+
+### Pluggable backoff strategy
+
+Per [§Retry and backoff](#retry-and-backoff) v1 ships a fixed exponential-with-jitter backoff. Pluggable backoff (per-call strategy fn, registered named strategies, host-customisable defaults) is an additive surface — deferred until apps surface a real need that the default doesn't cover.
+
+## Resolved decisions
+
+### `:rf.http/managed` is the canonical framework-provided fx
+
+Per [§Implementation status](#implementation-status) `:rf.http/managed` is the locked v1 surface: args-map shape, failure categories, reply addressing, retry semantics, abort surface, schema-reflection metadata, and trace events are all locked across implementations. This was chosen over a "convention" (every app rolls its own HTTP fx) so `:fx-overrides` target the same id across applications, pair tools introspect the same envelope, Spec 010 schemas plug into the same decode pipeline, and conformance fixtures key off the canonical surface.
+
+### Failure categories are a closed set
+
+Per [§Failure categories (closed set)](#failure-categories-closed-set) the failure taxonomy under `:rf.http/*` (`:transport`, `:cors`, `:timeout`, `:http-4xx`, `:http-5xx`, `:decode-failure`, `:accept-failure`, `:aborted`) is closed for v1. Additions require a Spec change. Apps that want domain-level discrimination layer `:accept` (per [§`:accept` — domain-failure normalisation](#accept--domain-failure-normalisation)) — they don't extend the framework's failure taxonomy. This keeps the `:rf.http/*` trace vocabulary decidable for tools and the [Spec 009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue) finite.
+
+### `:rf.http/cors` is CLJS-only
+
+Per [§Failure categories (closed set)](#failure-categories-closed-set) the `:rf.http/cors` row is CLJS-only — JVM transports never emit it. CORS is a browser-policy concern; the JVM has no cross-origin policy to enforce. The asymmetry is documented so tools that consume the trace stream don't assume the row exists on every host.
+
+### Request-side middleware only in v1 (rf2-6y3q)
+
+Per [§Middleware](#middleware) (rf2-6y3q) the v1 middleware contract is per-frame request-side only — the interceptor chain sits between the user's args and the transport, not between the transport and the reply. The request-side cases (Bearer token, correlation-id, base-URL rewrite) all surfaced as the high-frequency pattern; response-side composition is deferred to [§Open questions](#open-questions). The request-side surface ships first because its shape is settled.
+
+### Frame-aware reply dispatch (rf2-wvkn)
+
+Per [§Frame awareness](#frame-awareness) every `:rf.http/managed` reply dispatch inherits the originating frame; replies route to the right frame even when the request was issued from a non-default frame (story variant, per-test fixture, SSR per-request). The frame-capture discipline matches [Pattern-AsyncEffect](Pattern-AsyncEffect.md) and is universal across the async-effect surface.
+
+### Actor-destroy aborts in-flight requests (rf2-wvkn)
+
+Per [§Aborts](#aborts) (rf2-wvkn) `:rf.http/managed` requests issued from inside a spawned state-machine actor are aborted automatically when the actor is destroyed. The actor-id-keyed in-flight map (per [§Abort on actor destroy](#abort-on-actor-destroy)) is the reverse index; `actor-in-flight-snapshot` is the test-only inspection helper. This was chosen over "orphan the request and ignore the reply" because orphaned requests waste transport quota and the reply path's frame-target may no longer exist — both costs grow under retries.
+
+### Privacy honoured via `:sensitive?` on HTTP trace events (rf2-bma05)
+
+Per [§Privacy](#privacy) (rf2-bma05) the `:rf.http/*` trace events honour the [Spec 009 §`:sensitive?`](009-Instrumentation.md#privacy--sensitive-data-in-traces) contract: per-call, per-request, and per-handler `:sensitive?` flags OR-reduce; the framework redacts request/response bodies and a 12-name header denylist (`authorization`, `cookie`, `set-cookie`, etc.). Headers were chosen as the always-on default surface because they carry the highest-value secrets (auth tokens) across the largest fraction of apps. Apps register their own sensitive headers via `rf.http/declare-sensitive-header!`.
+
+### Query-string denylist is always-on (rf2-2p8wr)
+
+Per [§2. Query-param denylist (always-on)](#2-query-param-denylist-always-on-rf2-2p8wr) (rf2-2p8wr) the framework redacts denylisted query-string parameter values in `:url` slots **regardless** of the effective `:sensitive?` flag. Param-name and position are preserved; the value is replaced inline with the `:rf/redacted` text token. Always-on was chosen over flag-gated because query-string-auth patterns (older REST APIs, webhooks) leak through `:rf.warning/decode-defaulted` and similar URL-carrying traces even when the dispatching event isn't `:sensitive?` — the redaction must run unconditionally for the URL slot to be safe.
+
+### Stale-suppression piggy-backs on the epoch carry
+
+Per [Pattern-StaleDetection](Pattern-StaleDetection.md) and [§Reply addressing](#reply-addressing) managed requests inherit the dispatching event's epoch carry; replies that arrive after a newer navigation / actor restart are suppressed at the dispatch site. The same epoch idiom is used by `:after` timers (per [Spec 005 §Epoch-based stale detection](005-StateMachines.md#epoch-based-stale-detection)) and route nav-tokens (per [Spec 012 §Navigation tokens](012-Routing.md#navigation-tokens--stale-result-suppression)); the recurring pattern is documented in [Pattern-StaleDetection](Pattern-StaleDetection.md).
+
 ## Cross-references
 
 - [Pattern-AsyncEffect](Pattern-AsyncEffect.md) — generic six-step async shape; Spec 014 specialises it.


### PR DESCRIPTION
## Summary

Bring Specs 011, 012, 014 into line with the `§Open questions` + `§Resolved decisions` trailer convention already carried by every other Spec doc.

- **011-SSR** — `§Open questions` already existed (Streaming SSR). Adds `§Resolved decisions` cataloguing six landed decisions: locked `:replace-app-db` hydration merge policy; sub-cache warmups out of scope for v1 `:rf/hydration-payload`; per-request frame teardown contract (rf2-fcj33); live `reg-head` / `render-head` / `active-head` surface (rf2-4dra9); framework-registered `:rf.ssr/check-version` + `:rf.ssr/check-schema-digest` (rf2-69ad2); separate-Maven-artefact split (`day8/re-frame2-ssr`).
- **012-Routing** — `§Open questions` already existed. Adds `§Resolved decisions` including the `:rf.route.nav-token/*` rename that closed the grandfathered carve-out (rf2-o39mn); default-frame URL binding + non-default `:url-bound?` opt-in; state-first / URL-second update order; three-enum scroll strategy; canonical `:rf.route/not-found` reserved id; run-to-completion navigation cascade.
- **014-HTTPRequests** — neither trailer existed; adds both. `§Open questions` covers response-side middleware composition, app-extensible query-param denylist, streaming responses (`:rf.http/streaming`), pluggable backoff. `§Resolved decisions` catalogues the locked `:rf.http/managed` framework-provided fx; closed eight-category `:rf.http/*` failure taxonomy; CLJS-only `:rf.http/cors`; request-side middleware only (rf2-6y3q); frame-aware reply dispatch + actor-destroy aborts (rf2-wvkn); `:sensitive?` honouring with 12-name header denylist (rf2-bma05); always-on query-string denylist (rf2-2p8wr); epoch-carry stale-suppression.

Structural — no normative content moves; each new section summarises an existing contract anchor and links rationale back to it. Trailer order matches the canonical pattern used by 008, 009, 010, 013, etc. (`Open questions` → `Resolved decisions` → `Cross-references`).

Source: rf2-d1mph; audit ai/findings/sweep-spec-completeness-2026-05-13.md BC-14.

## Test plan

- [ ] Visual review of new sections — verify each item maps to an existing contract anchor and reads as historical-decision rationale (not new normative content).
- [ ] Anchor links (`#the-rfhydrate-event`, `#failure-categories-closed-set`, `#multi-frame-routing`, `#navigation-tokens--stale-result-suppression`, `#per-request-frame-teardown-contract`, `#headmeta-contract`, `#abort-on-actor-destroy`, etc.) all resolve in the GitHub-rendered preview.
- [ ] `mkdocs build --strict` from repo root succeeds (run by reviewer if desired).