### PR TITLE
docs(spec/002): :dispatch-n is gone (not deprecated) in v2 (rf2-cysya)

### DIFF
--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -590,7 +590,7 @@ The mechanism is symmetric with how event handlers receive their context: **fx h
   (fn [m event]
     (rf/dispatch event {:frame (:frame m)})))
 
-;; multiple dispatches are expressed via :fx (nested pairs) — :dispatch-n is deprecated
+;; multiple dispatches are expressed via :fx (nested pairs); the v1 :dispatch-n top-level key is gone
 ;; e.g., handler returns:
 ;;   {:fx [[:dispatch [:event-1]]
 ;;         [:dispatch [:event-2]]]}


### PR DESCRIPTION
## Summary

- Pre-alpha re-frame2 has no deprecation path; `:dispatch-n` was removed (per M-8), not soft-deprecated.
- The inline comment in the binary fx-handler example called `:dispatch-n` "deprecated", which implied the v1 top-level key still exists with a warning. Rewrite to: "the v1 `:dispatch-n` top-level key is gone."

Closes rf2-cysya.

## Test plan

- [x] `grep dispatch-n spec/002-Frames.md` — single hit, now reads "is gone".
- [ ] Spec render still parses (no fenced-block disturbance).