### PR TITLE
docs(skills): add 'skill-internal meta-doc' header to all spec/*.md (rf2-gsz0r)

### DIFF
--- a/skills/re-frame-migration/spec/authoring-prompt.md
+++ b/skills/re-frame-migration/spec/authoring-prompt.md
@@ -1,5 +1,7 @@
 # re-frame-migration — Authoring Prompt
 
+> **Skill-internal meta-doc.** Design rationale + author notes for the `re-frame-migration` skill itself — not part of the user-facing or AI-facing skill contract. Not loaded during normal skill operation; exists to re-author the skill from inputs. For the skill contract, see [`SKILL.md`](../SKILL.md).
+
 A self-contained prompt that re-authors the `re-frame-migration` skill from this `spec/` folder alone. Drop into a fresh Claude Code session in the re-frame2 repo root.
 
 ## The prompt

--- a/skills/re-frame-migration/spec/design.md
+++ b/skills/re-frame-migration/spec/design.md
@@ -1,5 +1,7 @@
 # re-frame-migration — Design
 
+> **Skill-internal meta-doc.** Design rationale + author notes for the `re-frame-migration` skill itself — not part of the user-facing or AI-facing skill contract. Not loaded during normal skill operation; exists to re-author the skill from inputs. For the skill contract, see [`SKILL.md`](../SKILL.md).
+
 The design rationale and locked decisions for the `re-frame-migration` skill. A future agent could re-author this skill from this folder alone.
 
 ## 1. Goal

--- a/skills/re-frame-migration/spec/inputs.md
+++ b/skills/re-frame-migration/spec/inputs.md
@@ -1,5 +1,7 @@
 # re-frame-migration — Inputs
 
+> **Skill-internal meta-doc.** Design rationale + author notes for the `re-frame-migration` skill itself — not part of the user-facing or AI-facing skill contract. Not loaded during normal skill operation; exists to re-author the skill from inputs. For the skill contract, see [`SKILL.md`](../SKILL.md).
+
 The canonical inputs the skill leans on. A re-authoring pass needs these to reproduce the leaves.
 
 ## 1. Primary input — `spec/MIGRATION.md`

--- a/skills/re-frame-pair-retro2/spec/authoring-prompt.md
+++ b/skills/re-frame-pair-retro2/spec/authoring-prompt.md
@@ -1,5 +1,7 @@
 # re-frame-pair-retro2 — Authoring Prompt
 
+> **Skill-internal meta-doc.** Design rationale + author notes for the `re-frame-pair-retro2` skill itself — not part of the user-facing or AI-facing skill contract. Not loaded during normal skill operation; exists to re-author the skill from inputs. For the skill contract, see [`SKILL.md`](../SKILL.md).
+
 A self-contained prompt that re-authors the `re-frame-pair-retro2` skill from this `spec/` folder alone. Drop into a fresh Claude Code session in the re-frame2 repo root.
 
 ## The prompt

--- a/skills/re-frame-pair-retro2/spec/design.md
+++ b/skills/re-frame-pair-retro2/spec/design.md
@@ -1,5 +1,7 @@
 # re-frame-pair-retro2 — Design
 
+> **Skill-internal meta-doc.** Design rationale + author notes for the `re-frame-pair-retro2` skill itself — not part of the user-facing or AI-facing skill contract. Not loaded during normal skill operation; exists to re-author the skill from inputs. For the skill contract, see [`SKILL.md`](../SKILL.md).
+
 The design rationale and locked decisions for the `re-frame-pair-retro2` skill. A future agent could re-author this skill from this folder alone.
 
 ## 1. Goal

--- a/skills/re-frame-pair-retro2/spec/inputs.md
+++ b/skills/re-frame-pair-retro2/spec/inputs.md
@@ -1,5 +1,7 @@
 # re-frame-pair-retro2 — Inputs
 
+> **Skill-internal meta-doc.** Design rationale + author notes for the `re-frame-pair-retro2` skill itself — not part of the user-facing or AI-facing skill contract. Not loaded during normal skill operation; exists to re-author the skill from inputs. For the skill contract, see [`SKILL.md`](../SKILL.md).
+
 The canonical inputs the skill leans on. A re-authoring pass needs these to reproduce the leaves.
 
 ## 1. Primary input — the user's recent session transcript

--- a/skills/re-frame-pair2/spec/authoring-prompt.md
+++ b/skills/re-frame-pair2/spec/authoring-prompt.md
@@ -1,5 +1,7 @@
 # re-frame-pair2 — Authoring Prompt
 
+> **Skill-internal meta-doc.** Design rationale + author notes for the `re-frame-pair2` skill itself — not part of the user-facing or AI-facing skill contract. Not loaded during normal skill operation; exists to re-author the skill from inputs. For the skill contract, see [`SKILL.md`](../SKILL.md).
+
 A self-contained prompt that re-authors the `re-frame-pair2` skill from this `spec/` folder alone. Drop into a fresh Claude Code session in the re-frame2 repo root.
 
 ## The prompt

--- a/skills/re-frame-pair2/spec/design.md
+++ b/skills/re-frame-pair2/spec/design.md
@@ -1,5 +1,7 @@
 # re-frame-pair2 — Design
 
+> **Skill-internal meta-doc.** Design rationale + author notes for the `re-frame-pair2` skill itself — not part of the user-facing or AI-facing skill contract. Not loaded during normal skill operation; exists to re-author the skill from inputs. For the skill contract, see [`SKILL.md`](../SKILL.md).
+
 The design rationale and locked decisions for the `re-frame-pair2` skill. A future agent could re-author this skill from this folder alone.
 
 ## 1. Goal

--- a/skills/re-frame-pair2/spec/inputs.md
+++ b/skills/re-frame-pair2/spec/inputs.md
@@ -1,5 +1,7 @@
 # re-frame-pair2 — Inputs
 
+> **Skill-internal meta-doc.** Design rationale + author notes for the `re-frame-pair2` skill itself — not part of the user-facing or AI-facing skill contract. Not loaded during normal skill operation; exists to re-author the skill from inputs. For the skill contract, see [`SKILL.md`](../SKILL.md).
+
 The canonical inputs the skill leans on. A re-authoring pass needs these to reproduce the leaves.
 
 ## 1. Primary input — re-frame2's Tool-Pair contract

--- a/skills/re-frame2-implementor/spec/authoring-prompt.md
+++ b/skills/re-frame2-implementor/spec/authoring-prompt.md
@@ -1,5 +1,7 @@
 # re-frame2-implementor — Authoring Prompt
 
+> **Skill-internal meta-doc.** Design rationale + author notes for the `re-frame2-implementor` skill itself — not part of the user-facing or AI-facing skill contract. Not loaded during normal skill operation; exists to re-author the skill from inputs. For the skill contract, see [`SKILL.md`](../SKILL.md).
+
 A self-contained prompt that re-authors the `re-frame2-implementor` skill from this `spec/` folder alone. Drop into a fresh Claude Code session in the re-frame2 repo root.
 
 ## The prompt

--- a/skills/re-frame2-implementor/spec/design.md
+++ b/skills/re-frame2-implementor/spec/design.md
@@ -1,5 +1,7 @@
 # re-frame2-implementor — Design
 
+> **Skill-internal meta-doc.** Design rationale + author notes for the `re-frame2-implementor` skill itself — not part of the user-facing or AI-facing skill contract. Not loaded during normal skill operation; exists to re-author the skill from inputs. For the skill contract, see [`SKILL.md`](../SKILL.md).
+
 The design rationale and locked decisions for the `re-frame2-implementor` skill. A future agent could re-author this skill from this folder alone.
 
 ## 1. Goal

--- a/skills/re-frame2-implementor/spec/inputs.md
+++ b/skills/re-frame2-implementor/spec/inputs.md
@@ -1,5 +1,7 @@
 # re-frame2-implementor — Inputs
 
+> **Skill-internal meta-doc.** Design rationale + author notes for the `re-frame2-implementor` skill itself — not part of the user-facing or AI-facing skill contract. Not loaded during normal skill operation; exists to re-author the skill from inputs. For the skill contract, see [`SKILL.md`](../SKILL.md).
+
 The canonical inputs the skill leans on. A re-authoring pass needs these to reproduce the leaves.
 
 ## 1. Primary input — the `spec/` corpus

--- a/skills/re-frame2-setup/spec/authoring-prompt.md
+++ b/skills/re-frame2-setup/spec/authoring-prompt.md
@@ -1,5 +1,7 @@
 # re-frame2-setup — Authoring Prompt
 
+> **Skill-internal meta-doc.** Design rationale + author notes for the `re-frame2-setup` skill itself — not part of the user-facing or AI-facing skill contract. Not loaded during normal skill operation; exists to re-author the skill from inputs. For the skill contract, see [`SKILL.md`](../SKILL.md).
+
 A self-contained prompt that re-authors the `re-frame2-setup` skill from this `spec/` folder alone. Drop into a fresh Claude Code session in the re-frame2 repo root.
 
 ## The prompt

--- a/skills/re-frame2-setup/spec/design.md
+++ b/skills/re-frame2-setup/spec/design.md
@@ -1,5 +1,7 @@
 # re-frame2-setup — Design
 
+> **Skill-internal meta-doc.** Design rationale + author notes for the `re-frame2-setup` skill itself — not part of the user-facing or AI-facing skill contract. Not loaded during normal skill operation; exists to re-author the skill from inputs. For the skill contract, see [`SKILL.md`](../SKILL.md).
+
 The design rationale and locked decisions for the `re-frame2-setup` skill. A future agent could re-author this skill from this folder alone.
 
 ## 1. Goal

--- a/skills/re-frame2-setup/spec/inputs.md
+++ b/skills/re-frame2-setup/spec/inputs.md
@@ -1,5 +1,7 @@
 # re-frame2-setup — Inputs
 
+> **Skill-internal meta-doc.** Design rationale + author notes for the `re-frame2-setup` skill itself — not part of the user-facing or AI-facing skill contract. Not loaded during normal skill operation; exists to re-author the skill from inputs. For the skill contract, see [`SKILL.md`](../SKILL.md).
+
 The canonical inputs the skill leans on. A re-authoring pass needs these to reproduce the leaves.
 
 ## 1. Primary inputs — the canonical greenfield artefacts

--- a/skills/re-frame2/spec/authoring-prompt.md
+++ b/skills/re-frame2/spec/authoring-prompt.md
@@ -1,5 +1,7 @@
 # re-frame2 — Authoring Prompt
 
+> **Skill-internal meta-doc.** Design rationale + author notes for the `re-frame2` skill itself — not part of the user-facing or AI-facing skill contract. Not loaded during normal skill operation; exists to re-author the skill from inputs. For the skill contract, see [`SKILL.md`](../SKILL.md).
+
 A self-contained prompt that re-authors the `re-frame2` skill from this `spec/` folder alone. Drop into a fresh Claude Code session in the re-frame2 repo root.
 
 ## The prompt

--- a/skills/re-frame2/spec/design.md
+++ b/skills/re-frame2/spec/design.md
@@ -1,5 +1,7 @@
 # re-frame2 — Design
 
+> **Skill-internal meta-doc.** Design rationale + author notes for the `re-frame2` skill itself — not part of the user-facing or AI-facing skill contract. Not loaded during normal skill operation; exists to re-author the skill from inputs. For the skill contract, see [`SKILL.md`](../SKILL.md).
+
 The design rationale and locked decisions for the `re-frame2` skill. A future agent could re-author this skill from this folder alone.
 
 ## 1. Goal

--- a/skills/re-frame2/spec/inputs.md
+++ b/skills/re-frame2/spec/inputs.md
@@ -1,5 +1,7 @@
 # re-frame2 — Inputs
 
+> **Skill-internal meta-doc.** Design rationale + author notes for the `re-frame2` skill itself — not part of the user-facing or AI-facing skill contract. Not loaded during normal skill operation; exists to re-author the skill from inputs. For the skill contract, see [`SKILL.md`](../SKILL.md).
+
 The canonical inputs the skill leans on. A re-authoring pass needs these to reproduce the leaves.
 
 ## 1. Primary input — `implementation/**`


### PR DESCRIPTION
## Summary

Adds a brief blockquote header at the top of every `skills/*/spec/*.md` file disambiguating them as skill-internal meta-docs (design rationale + author notes used to re-author each skill), distinct from the framework `spec/` tree (which IS the contract).

- Each skill has `spec/design.md`, `spec/authoring-prompt.md`, and `spec/inputs.md`. These are meta-docs for re-authoring the skill, NOT user-facing guidance — an over-eager agent could read them speculatively.
- New header is 1 line (blockquote), points readers to `SKILL.md` for the actual skill contract.
- Affects 18 files across 6 skills: `re-frame-migration`, `re-frame-pair-retro2`, `re-frame-pair2`, `re-frame2`, `re-frame2-implementor`, `re-frame2-setup`.

Source: `ai/findings/sweep-skills-best-practice-2026-05-13.md` §CC-4 / B-skill-spec-meta-marker.

Closes rf2-gsz0r.

## Test plan

- [x] All 18 `skills/*/spec/*.md` files modified (verified via `git status`)
- [x] No other files touched
- [x] Each header references the correct skill name in its own folder