### PR TITLE
docs(Conventions): drop re-frame.core.legacy phantom-namespace row (rf2-bz8vr)

### DIFF
--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -552,7 +552,6 @@ For sub-namespaces of a facade namespace (the canonical case is `re-frame.core` 
 | `re-frame.core.ssr` | `re-frame.core-ssr` |
 | `re-frame.core.epoch` | `re-frame.core-epoch` |
 | `re-frame.core.http` | `re-frame.core-http` |
-| `re-frame.core.legacy` | `re-frame.core-legacy` |
 
 The user-facing alias `(:require [re-frame.core :as rf])` still resolves the documented symbols — `rf/reg-flow`, `rf/reg-machine`, etc. — via re-exports inside `re-frame.core` itself. The sub-namespace's existence is an implementation detail of the per-feature artefact (per [§Packaging conventions](#packaging-conventions)); the dash-form name is what makes the artefact loadable alongside core on the CLJS host.
 


### PR DESCRIPTION
## Summary

- Drops the `re-frame.core.legacy` -> `re-frame.core-legacy` row from the CLJS goog.provide-collision dash-form table in `spec/Conventions.md`.
- Phantom namespace: pre-alpha re-frame2 has no `re-frame.core.legacy` namespace. The row existed for v1-compat reasons that no longer apply.
- Surgical single-row removal; no replacement.

## Test plan

- [x] Grep confirms `re-frame.core.legacy` no longer referenced in `spec/Conventions.md`.
- [x] Surrounding dash-form table (flows, machines, routing, schemas, ssr, epoch, http) remains intact.

Closes rf2-bz8vr.