### PR TITLE
docs(spec/001): drop v1 back-compat lead-in from §middle slot (rf2-df986)

### DIFF
--- a/spec/001-Registration.md
+++ b/spec/001-Registration.md
@@ -54,7 +54,7 @@ Per-kind extensions (e.g., `:on-create` on `reg-frame`, `:path` on `reg-route`) 
 
 ### Allowed forms of the middle slot
 
-For backwards-compatibility with re-frame v1, the middle slot of `reg-event-*` is either:
+The middle slot of `reg-event-*` is either:
 
 1. **A vector of interceptors** (the interceptor chain):
    ```clojure


### PR DESCRIPTION
## Summary

- `spec/001-Registration.md` §Allowed forms of the middle slot opened with "For backwards-compatibility with re-frame v1, the middle slot of `reg-event-*` is either: …".
- Pre-alpha re-frame2 has no v1 back-compat. The positional, optional-meta-map grammar is the right grammar — not a retention.
- Drop the lead-in; the slot now stands on its own terms.

Closes rf2-df986.

## Test plan
- [x] Surgical one-line prose edit; no code/test impact.