### PR TITLE
cut(core): drop legacy-key-suggestion v1 strings from events.cljc (rf2-snkos)

### DIFF
--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -67,18 +67,6 @@
 ;; (NOT merged silently nor routed through the fx machinery) — silently
 ;; routing a top-level :dispatch was the v1 behaviour M-8 explicitly removes.
 
-(defn- legacy-key-suggestion
-  "Return a one-clause hint mapping a known legacy top-level key to its M-8
-  rewrite, or nil for an unrecognised key. Used to compose the :reason
-  string per Spec 009 §Style rubric for :reason strings."
-  [k]
-  (case k
-    :dispatch        "wrap as `:fx [[:dispatch event]]`"
-    :dispatch-later  "wrap as `:fx [[:dispatch-later {...}]]`"
-    :dispatch-n      "expand each event into `:fx [[:dispatch e1] [:dispatch e2] ...]`"
-    :http            "wrap as `:fx [[:http {...}]]`"
-    nil))
-
 (defn- police-effect-map-shape!
   "Emit :rf.error/effect-map-shape for each non-:db / non-:fx top-level key
   in `effects`. Per Spec migration M-8 the effect-map is closed at the top
@@ -89,12 +77,9 @@
                        (remove #{:db :fx})
                        (vec))]
     (doseq [k offending]
-      (let [v          (get effects k)
-            suggestion (legacy-key-suggestion k)
-            reason     (str "Effect-map for `" event-id "` returned top-level key `" k
-                            "`; only `:db` and `:fx` are allowed at the top level"
-                            (when suggestion (str " — " suggestion))
-                            ".")]
+      (let [v      (get effects k)
+            reason (str "Effect-map for `" event-id "` returned top-level key `" k
+                        "`; only `:db` and `:fx` are allowed at the top level.")]
         (trace/emit-error! :rf.error/effect-map-shape
                            {:failing-id    event-id
                             :event-id      event-id


### PR DESCRIPTION
## Summary

Drop the `legacy-key-suggestion` fn and its v1-key case table from `implementation/core/src/re_frame/events.cljc`. The fn mapped v1 top-level effect-map keys (`:dispatch`, `:dispatch-later`, `:dispatch-n`, `:http`) to inline migration hint strings embedded in the `:rf.error/effect-map-shape` `:reason` field.

Pre-alpha re-frame2 has no v1 back-compat. The migration skill (M-8) handles the rewrite, and the structured trace (the error keyword, `:offending-key`, `:event-id`, `:value`) already carries full diagnostic context.

## Changes

- Removed `legacy-key-suggestion` private fn (~10 LOC).
- Generalised the `:reason` string composed by `police-effect-map-shape!`: "only `:db` and `:fx` are allowed at the top level." No v1-key enumeration.
- Net: 3 insertions, 18 deletions in `events.cljc`.

## Test plan

- [x] `npm run test:cljs` — 1778 tests / 4937 assertions, 0 failures, 0 errors.
- Existing tests in `fx_test.clj` (`legacy-effect-map-key-is-policed`, `multiple-legacy-effect-map-keys-each-emit-a-trace`) assert `(string? :reason)` rather than the suggestion-string content, so they pass unchanged.
- Closes rf2-snkos.