### PR TITLE
cut(examples/realworld): drop legacy sub-name aliases (rf2-up009)

### DIFF
--- a/examples/reagent/realworld/article_editor.cljs
+++ b/examples/reagent/realworld/article_editor.cljs
@@ -364,17 +364,6 @@
               (when (contains? tags tag) render))
             render-priority))))
 
-;; Legacy sub names kept as thin adapters over the machine so existing
-;; tests and any external callers still resolve. Prefer the tag queries
-;; and the render selector in new code.
-(rf/reg-sub :editor/status
-  :<- [:rf/machine :ui/article-editor]
-  (fn [snap _] (get-in snap [:state :lifecycle])))
-
-(rf/reg-sub :editor/mode
-  :<- [:rf/machine :ui/article-editor]
-  (fn [snap _] (get-in snap [:state :mode])))
-
 ;; ============================================================================
 ;; VIEWS
 ;; ============================================================================

--- a/examples/reagent/realworld/test/realworld/article_editor_test.cljs
+++ b/examples/reagent/realworld/test/realworld/article_editor_test.cljs
@@ -26,15 +26,15 @@
     (rf/dispatch-sync [:editor/initialise] {:frame f})
     ;; The :mode region starts at :create; the :lifecycle region starts
     ;; at :idle.
-    (assert (= :create (rf/compute-sub [:editor/mode] (rf/get-frame-db f))))
-    (assert (= :idle   (rf/compute-sub [:editor/status] (rf/get-frame-db f))))
+    (assert (true? (rf/compute-sub [:rf/machine-has-tag? :ui/article-editor :mode/create] (rf/get-frame-db f))))
+    (assert (true? (rf/compute-sub [:rf/machine-has-tag? :ui/article-editor :lifecycle/idle] (rf/get-frame-db f))))
     (rf/dispatch-sync [:editor/edit-field :title "Hello"] {:frame f})
     (rf/dispatch-sync [:editor/edit-field :description "Short"] {:frame f})
     (rf/dispatch-sync [:editor/edit-field :body "Body"] {:frame f})
     (rf/dispatch-sync [:editor/submit] {:frame f})
     ;; A successful submit advances :mode → :edit and :lifecycle → :saved.
-    (assert (= :saved (rf/compute-sub [:editor/status] (rf/get-frame-db f))))
-    (assert (= :edit  (rf/compute-sub [:editor/mode] (rf/get-frame-db f))))
+    (assert (true? (rf/compute-sub [:rf/machine-has-tag? :ui/article-editor :lifecycle/saved] (rf/get-frame-db f))))
+    (assert (true? (rf/compute-sub [:rf/machine-has-tag? :ui/article-editor :mode/edit] (rf/get-frame-db f))))
     (assert (false? (rf/compute-sub [:editor/dirty?] (rf/get-frame-db f))))))
 
 (defn editor-can-leave-test []


### PR DESCRIPTION
## Summary

The article-editor in the realworld example carried two legacy v1-shape
sub-name aliases (`:editor/status` and `:editor/mode`) kept as thin
adapters over the `:ui/article-editor` parallel machine. Pre-alpha:
there are no external callers of an example, so drop them.

- Deleted the two `reg-sub` shims in `examples/reagent/realworld/article_editor.cljs`.
- Updated the in-tree test (`article_editor_test.cljs`) to query the
  machine's tag union directly via `:rf/machine-has-tag?` — the canonical
  pattern (matches what `websocket/connection_test.cljs` does).

## Test plan

- [x] `npm run test:examples` — `realworld (Conduit) — Spec 014 demo` PASS
- [x] Grep confirms no remaining references to `:editor/status` / `:editor/mode` in `examples/reagent/realworld/`

Bead: rf2-up009. Source: `ai/findings/sweep-backcompat-cuts-2026-05-13.md` §S7 / B-7.