### PR TITLE
cut(machines): rename :machines/reset-counters! → :machines/reset-timers! (rf2-p8usn)

### DIFF
--- a/examples/reagent/counter_with_stories/stories_cljs_test.cljs
+++ b/examples/reagent/counter_with_stories/stories_cljs_test.cljs
@@ -44,7 +44,7 @@
   (reset! frame/frames {})
   (try (rf/init! plain-atom/adapter) (catch :default _ nil))
   (frame/ensure-default-frame!)
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (loaders/clear-watchers!)
   (reset! assertions/warnings-accumulator          {})
   (reset! assertions/emitted-fx-accumulator        {})

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -184,9 +184,9 @@
    {:key         :machines/machine-by-system-id
     :producer-ns 're-frame.machines
     :description "Look up a live machine instance by its system id."}
-   {:key         :machines/reset-counters!
+   {:key         :machines/reset-timers!
     :producer-ns 're-frame.machines
-    :description "Reset the machine spawn-counter (test isolation)."}
+    :description "Cancel in-flight `:after` wall-clock timers (test isolation)."}
    {:key         :machines/spawn-fx
     :producer-ns 're-frame.machines
     :description "Effect handler for :rf.machine/spawn."}

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -64,10 +64,9 @@
             ;; cancels in-flight `:after` wall-clock timers through the
             ;; late-bind hook table when the artefact is loaded, no-ops
             ;; when not. Per rf2-gr8q the per-process spawn-counter atom
-            ;; was replaced by in-snapshot allocation; the same late-
-            ;; bind hook name (`:machines/reset-counters!`) is preserved
-            ;; for fixture back-compat but now resets only the wall-
-            ;; clock-timer table.
+            ;; was replaced by in-snapshot allocation; the late-bind
+            ;; hook `:machines/reset-timers!` now resets only the
+            ;; wall-clock-timer table.
             ;; re-frame.schemas (Spec 010) ships as a separate artefact
             ;; (day8/re-frame2-schemas, rf2-p7va). The reset fixture
             ;; touches the per-frame schema registry through the
@@ -258,10 +257,9 @@
          ;; the hook returns nil and this is a no-op (correct: there is
          ;; no timer state to clear). Per rf2-xbtj — machines ships in
          ;; day8/re-frame2-machines. Per rf2-gr8q — the spawn-counter
-         ;; atom is gone; this hook now resets only the timer table.
-         ;; The hook name is preserved for fixture-surface back-compat.
-         (when-let [reset-counters! (late-bind/get-fn :machines/reset-counters!)]
-           (reset-counters!))
+         ;; atom is gone; this hook resets only the timer table.
+         (when-let [reset-timers! (late-bind/get-fn :machines/reset-timers!)]
+           (reset-timers!))
          ;; Late-bind: when the routing artefact is loaded, reset the
          ;; route registration counter so reg-index is deterministic
          ;; across fixture runs. When it isn't, the hook returns nil

--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -233,7 +233,7 @@
   ;; 3. Reset id-allocators so the routing / machine fixtures see
   ;;    deterministic counters.
   (routing/reset-counters!)
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   ;; 4. Drop the in-flight HTTP request registry between fixtures.
   (http-managed/clear-all-in-flight!)
   ;; 5. Dispose the currently-installed adapter (if any) and re-install

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -204,7 +204,7 @@
   ;; are stable across runs (the routing/machine fixtures assert against
   ;; literal "nav-1" / "nav-2" / ":http/post#1" strings).
   ((requiring-resolve 're-frame.routing/reset-counters!))
-  ((requiring-resolve 're-frame.machines/reset-counters!))
+  ((requiring-resolve 're-frame.machines/reset-timers!))
   ;; Spec 014 — drop the in-flight request registry between fixtures.
   ((requiring-resolve 're-frame.http-managed/clear-all-in-flight!)))
 

--- a/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
@@ -48,7 +48,7 @@
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
   (require 're-frame.http-managed :reload)
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (http-managed/clear-all-in-flight!)
   (t))
 

--- a/implementation/http/test/re_frame/http_helpers_integration_test.clj
+++ b/implementation/http/test/re_frame/http_helpers_integration_test.clj
@@ -29,7 +29,7 @@
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
   (require 're-frame.http-managed :reload)
-  ((requiring-resolve 're-frame.machines/reset-counters!))
+  ((requiring-resolve 're-frame.machines/reset-timers!))
   (http-managed/clear-all-in-flight!)
   (t))
 

--- a/implementation/http/test/re_frame/http_managed_machine_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_managed_machine_cljs_test.cljs
@@ -33,7 +33,7 @@
   (test-support/reset-runtime-fixture
     {:adapter reagent-adapter/adapter
      :init-fn (fn []
-                (machines/reset-counters!)
+                (machines/reset-timers!)
                 (http-managed/clear-all-in-flight!))}))
 
 (defn- snapshot [machine-id]

--- a/implementation/http/test/re_frame/http_managed_machine_test.clj
+++ b/implementation/http/test/re_frame/http_managed_machine_test.clj
@@ -53,7 +53,7 @@
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
   (require 're-frame.http-managed :reload)
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (http-managed/clear-all-in-flight!)
   (t))
 

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -33,7 +33,7 @@
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
   (require 're-frame.http-managed :reload)
-  ((requiring-resolve 're-frame.machines/reset-counters!))
+  ((requiring-resolve 're-frame.machines/reset-timers!))
   (http-managed/clear-all-in-flight!)
   (t))
 

--- a/implementation/http/test/re_frame/http_privacy_integration_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_integration_test.clj
@@ -32,7 +32,7 @@
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
   (require 're-frame.http-managed :reload)
-  ((requiring-resolve 're-frame.machines/reset-counters!))
+  ((requiring-resolve 're-frame.machines/reset-timers!))
   (http-managed/clear-all-in-flight!)
   (privacy/clear-sensitive-headers!)
   (privacy/clear-sensitive-query-params!)

--- a/implementation/machines/deps.edn
+++ b/implementation/machines/deps.edn
@@ -25,7 +25,7 @@
 ;; from core to machines (e.g. `re-frame.core`'s `reg-machine` /
 ;; `create-machine-handler` / `machine-transition` re-exports,
 ;; `re-frame.test-support`'s reset-runtime fixture's
-;; `(machines/reset-counters!)` step) flow through `re-frame.late-bind`
+;; `(machines/reset-timers!)` step) flow through `re-frame.late-bind`
 ;; exactly as the schemas / router / flows hooks already do.
 {:paths ["src"]
  :deps  {day8/re-frame2 {:local/root "../core"}}

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -138,7 +138,7 @@
 (def after-schedule-fx      timer/after-schedule-fx)
 (def after-cancel-fx        timer/after-cancel-fx)
 
-(defn reset-counters!
+(defn reset-timers!
   "Cancel every in-flight `:after` timer the runtime is currently tracking.
 
   Per rf2-gr8q the per-process `spawn-counter` atom is gone — declarative-
@@ -149,14 +149,7 @@
   snapshot/restore + frame reset) clears the app-db; per-fixture snapshot
   input in the conformance harness is hand-built fresh on each call. The
   only remaining per-process state this fn resets is the wall-clock timer
-  table in `re-frame.machines.timer`.
-
-  The fn name (and the `:machines/reset-counters!` late-bind hook key)
-  is kept for back-compat with the test-support fixture and the small
-  set of test namespaces that call it directly. Conceptually the name
-  is now slightly stale — \"reset wall-clock timers\" would be more
-  accurate — but renaming would churn the fixture surface; the
-  semantics-preserving rename is deferred."
+  table in `re-frame.machines.timer`."
   []
   (timer/cancel-all-timers!))
 
@@ -247,7 +240,7 @@
 (late-bind/set-fn! :machines/machines               machines)
 (late-bind/set-fn! :machines/machine-meta           machine-meta)
 (late-bind/set-fn! :machines/machine-by-system-id   machine-by-system-id)
-(late-bind/set-fn! :machines/reset-counters!        reset-counters!)
+(late-bind/set-fn! :machines/reset-timers!          reset-timers!)
 (late-bind/set-fn! :machines/spawn-fx               spawn-fx)
 (late-bind/set-fn! :machines/destroy-machine-fx     destroy-machine-fx)
 (late-bind/set-fn! :machines/invoke-all-init-fx     invoke-all-init-fx)

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -289,7 +289,7 @@
 
 (defn cancel-all-timers!
   "Cancel every in-flight :after timer the runtime is currently tracking
-  and reset the timer table. Used by `reset-counters!` in fixture
+  and reset the timer table. Used by `reset-timers!` in fixture
   teardown."
   []
   (doseq [[_ entry] @after-timers]

--- a/implementation/machines/test/re_frame/after_test.clj
+++ b/implementation/machines/test/re_frame/after_test.clj
@@ -31,7 +31,7 @@
   (reset! frame/frames {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.machines :reload)
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (test-fn))
 
 (use-fixtures :each reset-runtime)

--- a/implementation/machines/test/re_frame/final_state_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/final_state_cljs_test.cljc
@@ -43,7 +43,7 @@
      (trace/clear-trace-cbs!)
      (rf/init! plain-atom/adapter)
      (require 're-frame.machines :reload)
-     (machines/reset-counters!)
+     (machines/reset-timers!)
      (test-fn)))
 
 #?(:clj  (use-fixtures :each reset-runtime)

--- a/implementation/machines/test/re_frame/initial_entry_test.clj
+++ b/implementation/machines/test/re_frame/initial_entry_test.clj
@@ -42,7 +42,7 @@
   (trace/clear-trace-cbs!)
   (rf/init! plain-atom/adapter)
   (require 're-frame.machines :reload)
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (test-fn))
 
 (use-fixtures :each reset-runtime)

--- a/implementation/machines/test/re_frame/invoke_all_test.clj
+++ b/implementation/machines/test/re_frame/invoke_all_test.clj
@@ -28,7 +28,7 @@
   (reset! frame/frames {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.machines :reload)
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (test-fn))
 
 (use-fixtures :each reset-runtime)

--- a/implementation/machines/test/re_frame/invoke_data_fn_form_test.clj
+++ b/implementation/machines/test/re_frame/invoke_data_fn_form_test.clj
@@ -37,7 +37,7 @@
   (reset! frame/frames {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.machines :reload)
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (test-fn))
 
 (use-fixtures :each reset-runtime)

--- a/implementation/machines/test/re_frame/machine_transition_purity_test.clj
+++ b/implementation/machines/test/re_frame/machine_transition_purity_test.clj
@@ -10,7 +10,7 @@
   pure / deterministic but the allocator was a side effect: a second
   identical call returned different spawn-ids (`:worker#2` vs the first
   call's `:worker#1`). The conformance corpus only worked because the
-  per-fixture `reset-counters!` zeroed the atom between fixtures.
+  per-fixture reset zeroed the atom between fixtures.
 
   Post-rf2-gr8q the counter lives inside the snapshot at
   `:rf/spawn-counter` (a per-machine-id integer map); each spawn bumps

--- a/implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj
+++ b/implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj
@@ -37,7 +37,7 @@
   (trace/clear-trace-cbs!)
   (rf/init! plain-atom/adapter)
   (require 're-frame.machines :reload)
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (test-fn))
 
 (use-fixtures :each reset-runtime)

--- a/implementation/machines/test/re_frame/nested_validation_test.clj
+++ b/implementation/machines/test/re_frame/nested_validation_test.clj
@@ -34,7 +34,7 @@
   (reset! frame/frames {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.machines :reload)
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (test-fn))
 
 (use-fixtures :each reset-runtime)

--- a/implementation/machines/test/re_frame/parallel_test.clj
+++ b/implementation/machines/test/re_frame/parallel_test.clj
@@ -40,7 +40,7 @@
   (reset! frame/frames {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.machines :reload)
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (test-fn))
 
 (use-fixtures :each reset-runtime)

--- a/implementation/machines/test/re_frame/spawn_registry_test.clj
+++ b/implementation/machines/test/re_frame/spawn_registry_test.clj
@@ -50,7 +50,7 @@
   ;; `:rf.machine/destroy` reserved fxs, and the late-bind hook table get
   ;; reinstalled after `clear-all!` wiped them.
   (require 're-frame.machines :reload)
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (test-fn))
 
 (use-fixtures :each reset-runtime)

--- a/implementation/machines/test/re_frame/tags_test.clj
+++ b/implementation/machines/test/re_frame/tags_test.clj
@@ -30,7 +30,7 @@
   (reset! frame/frames {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.machines :reload)
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (test-fn))
 
 (use-fixtures :each reset-runtime)

--- a/tools/story/test/re_frame/story_assertions_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_assertions_cljs_test.cljs
@@ -28,7 +28,7 @@
   (rf/reg-sub :rf/machine
               (fn [db [_ machine-id]]
                 (get-in db [:rf/machines machine-id])))
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (loaders/clear-watchers!)
   (reset! assertions/warnings-accumulator          {})
   (reset! assertions/emitted-fx-accumulator        {})

--- a/tools/story/test/re_frame/story_assertions_test.clj
+++ b/tools/story/test/re_frame/story_assertions_test.clj
@@ -38,7 +38,7 @@
   (try (rf/init! plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
   (require 're-frame.machines :reload)
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (loaders/clear-watchers!)
   (config/set-global-args! {})
   ;; Clear per-frame assertion accumulators between tests.

--- a/tools/story/test/re_frame/story_fx_stubs_test.clj
+++ b/tools/story/test/re_frame/story_fx_stubs_test.clj
@@ -38,7 +38,7 @@
   (try (rf/init! plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
   (require 're-frame.machines :reload)
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (loaders/clear-watchers!)
   (config/set-global-args! {})
   (reset! assertions/warnings-accumulator          {})

--- a/tools/story/test/re_frame/story_layout_debug_test.clj
+++ b/tools/story/test/re_frame/story_layout_debug_test.clj
@@ -34,7 +34,7 @@
   (try (rf/init! plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
   (require 're-frame.machines :reload)
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (loaders/clear-watchers!)
   (config/set-global-args! {})
   (layout-debug/reset-wrap-counter!)

--- a/tools/story/test/re_frame/story_play_test.clj
+++ b/tools/story/test/re_frame/story_play_test.clj
@@ -35,7 +35,7 @@
   (try (rf/init! plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
   (require 're-frame.machines :reload)
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (loaders/clear-watchers!)
   (config/set-global-args! {})
   (reset! assertions/warnings-accumulator          {})

--- a/tools/story/test/re_frame/story_runtime_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_runtime_cljs_test.cljs
@@ -48,7 +48,7 @@
   (rf/reg-sub :rf/machine
               (fn [db [_ machine-id]]
                 (get-in db [:rf/machines machine-id])))
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (loaders/clear-watchers!)
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!))

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -54,7 +54,7 @@
   ;; Re-require machines so its `reg-sub :rf/machine` survives the
   ;; registrar/clear-all! call. Mirrors the machines test fixtures.
   (require 're-frame.machines :reload)
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (loaders/clear-watchers!)
   (config/set-global-args! {})
   ;; Re-install the canonical vocabulary (tags + lifecycle machine).

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -40,7 +40,7 @@
   (try (rf/init! plain-atom/adapter)
        (catch clojure.lang.ExceptionInfo _ nil))
   (require 're-frame.machines :reload)
-  (machines/reset-counters!)
+  (machines/reset-timers!)
   (loaders/clear-watchers!)
   (config/set-global-args! {})
   (state/reset-shell-state!)


### PR DESCRIPTION
## Summary

Hard rename of `:machines/reset-counters!` → `:machines/reset-timers!` (and the underlying `reset-counters!` fn → `reset-timers!`). The old name was stale: per rf2-gr8q the per-process spawn-counter atom is gone, and the only state the call now resets is the wall-clock-timer table. Pre-alpha — no back-compat shim.

## Changes

- `machines.cljc`: `defn reset-timers!` + late-bind hook key `:machines/reset-timers!`; dropped the self-confessed-stale comment block.
- `machines/timer.cljc`: docstring reference.
- `machines/deps.edn`: header-comment reference.
- `core/late_bind/directory.cljc`: directory entry key + description (was misleading — said "spawn-counter").
- `core/test_support.cljc`: comments + reset-runtime fixture call sites.
- 24 test files across `implementation/machines/test/`, `implementation/http/test/`, `implementation/core/test/`, `tools/story/test/`, `examples/reagent/`.

`:routing/reset-counters!` (a different hook) is unchanged — out of scope.

## Test plan

- [x] `npm run test:cljs` (1778 tests, 4937 assertions, 0 failures)
- [x] `implementation/machines clojure -M:test` (119 tests, 332 assertions)
- [x] `implementation/http clojure -M:test` (134 tests, 369 assertions)
- [x] `implementation/core clojure -M:test` (437 tests, 2298 assertions)
- [x] `tools/story clojure -M:test` (324 tests, 965 assertions)