### PR TITLE
cut(core): drop historical narration about removed v1 surfaces (rf2-dvery)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -307,8 +307,8 @@
             (set! (.-cljsRenderFn c) out)
             (apply out args))
 
-          ;; Legacy seq-as-fragment shape — coerce to a vector for
-          ;; React's children-of-a-fragment handling.
+          ;; Seq-as-fragment shape — coerce to a vector for React's
+          ;; children-of-a-fragment handling.
           (seq? out) (vec out)
 
           ;; Anything else (a React element, a primitive) flows

--- a/implementation/core/src/re_frame/adapter/context.cljs
+++ b/implementation/core/src/re_frame/adapter/context.cljs
@@ -171,9 +171,7 @@
   library mutating `_currentValue`, or a Provider authored with a
   non-keyword value. The runtime emits
   `:rf.error/frame-context-corrupted` and falls through to
-  `:rf/default` (recovery `:replaced-with-default`); apps see the
-  same observable behaviour as before, plus a structured trace event
-  for diagnosis."
+  `:rf/default` (recovery `:replaced-with-default`)."
   []
   (or frame/*current-frame*
       (let [v (.-_currentValue ^js frame-context)]
@@ -181,8 +179,7 @@
             ;; Corrupted branch: value is not a frame keyword and not
             ;; a non-empty string — covers nil, false, numbers, empty
             ;; strings, and JS objects. Emit the structured error and
-            ;; fall through. Behaviour identical to pre-rf2-8q66 —
-            ;; observable only.
+            ;; fall through.
             (do (emit-frame-context-corrupted! v)
                 nil)))
       :rf/default))

--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -241,11 +241,11 @@
 ;; ---- standard cofx --------------------------------------------------------
 
 (reg-cofx :db
-  {:doc "Inject the frame's current `app-db` value under `:coeffects :db`. Pre-populated by the drain loop before the interceptor chain runs; explicit `(inject-cofx :db)` is rarely needed and is a no-op. Exists for symmetry with `:event` and v1 idioms."}
+  {:doc "Inject the frame's current `app-db` value under `:coeffects :db`. Pre-populated by the drain loop before the interceptor chain runs; explicit `(inject-cofx :db)` is rarely needed and is a no-op. Exists for symmetry with `:event`."}
   (fn [ctx]
     ;; The drain loop has already populated :coeffects :db with the frame's
     ;; current app-db value before invoking the chain — so this cofx is
-    ;; usually a no-op. It exists for symmetry with v1.
+    ;; usually a no-op. It exists for symmetry with `:event`.
     ctx))
 
 (reg-cofx :event

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -250,9 +250,7 @@
 ;;
 ;; Per Spec 004 §reg-view: defn-shape macro. The expander lives here as
 ;; plain CLJ helpers so the defmacro stays a one-line delegation and
-;; CLJS test files can also exercise the helpers JVM-side. Per rf2-4lc9o
-;; the helpers were consolidated here when the legacy
-;; `re-frame.views-macros` import path was cut.
+;; CLJS test files can also exercise the helpers JVM-side.
 
 #?(:clj
    (defn parse-reg-view-args
@@ -819,10 +817,7 @@
 ;;            (finally (destroy-frame f))))
 ;;
 ;; The discriminator is the first argument: a vector triggers Shape 2;
-;; anything else is Shape 1. The fn-form `(with-frame frame-id thunk)`
-;; is no longer supported — callers wanting a thunk-style wrapper should
-;; write `(with-frame :foo (thunk))` (the thunk call sits inside the
-;; macro body, identical semantics) or call `binding` directly.
+;; anything else is Shape 1.
 
 #?(:clj
    (defmacro with-frame
@@ -847,13 +842,6 @@
        :else
        `(binding [frame/*current-frame* ~bindings]
           ~@body))))
-
-;; Note: the `bound-dispatcher` / `bound-subscriber` aliases were cut
-;; under rf2-knz3l — they were pure aliases for `dispatcher` /
-;; `subscriber` whose `bound-` prefix added redundant noise (the verb-
-;; form names already imply capture-at-call-time semantics). Callers
-;; that need an async-safe dispatch / subscribe closure call
-;; `(rf/dispatcher)` / `(rf/subscriber)` directly.
 
 ;; `bound-fn` (below) is the macro-form sibling of `dispatcher` /
 ;; `subscriber`: captures `*current-frame*` at definition time and

--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -64,8 +64,7 @@
 ;; The runtime polices this contract: any non-:db / non-:fx top-level key
 ;; emits a structured :rf.error/effect-map-shape trace per Spec 009 §Error
 ;; contract, with :recovery :logged-and-skipped. The offending key is dropped
-;; (NOT merged silently nor routed through the fx machinery) — silently
-;; routing a top-level :dispatch was the v1 behaviour M-8 explicitly removes.
+;; (NOT merged silently nor routed through the fx machinery).
 
 (defn- police-effect-map-shape!
   "Emit :rf.error/effect-map-shape for each non-:db / non-:fx top-level key

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -280,10 +280,10 @@
         (clear-flow! args {:frame frame-id}))
       (emit-handled! fx-id args frame-id))
 
-    ;; Per rf2-xbtj the `:rf.machine/spawn` and `:rf.machine/destroy`
-    ;; machine fx-ids are no longer reserved here — they are registered
-    ;; by re-frame.machines (day8/re-frame2-machines) via the regular
-    ;; reg-fx path and arrive here through the registrar default below.
+    ;; The `:rf.machine/spawn` and `:rf.machine/destroy` machine fx-ids
+    ;; are registered by re-frame.machines (day8/re-frame2-machines) via
+    ;; the regular reg-fx path and arrive here through the registrar
+    ;; default below.
 
     ;; Default: user-registered fx — OR a synthesised meta carrying a
     ;; function-value override (per `resolved-fx-meta` above; the

--- a/implementation/core/src/re_frame/interceptor.cljc
+++ b/implementation/core/src/re_frame/interceptor.cljc
@@ -9,12 +9,11 @@
 
   The 'context' is a map with :coeffects (inputs) and :effects (outputs).
   The chain runs :before in order, then the handler, then :after in
-  reverse order (the standard interceptor pattern from Pedestal / re-frame v1).")
+  reverse order.")
 
 (defn ->interceptor
-  "Build an interceptor map from kwargs. The primitive for custom
-  interceptors — v2 trims the v1 stdlib helpers in favour of this one
-  entry point.
+  "Build an interceptor map from kwargs. The primitive entry point for
+  custom interceptors.
 
   Kwargs:
     :id      keyword name (default `:unnamed`); appears in error traces.

--- a/implementation/core/src/re_frame/std_interceptors.cljc
+++ b/implementation/core/src/re_frame/std_interceptors.cljc
@@ -2,13 +2,10 @@
   "Standard interceptors. Per Spec 002 / API.md §Standard interceptors and
   Spec 001 §Hot-reload semantics M-21.
 
-  v2 ships THREE specific helpers plus the ->interceptor primitive:
+  Ships THREE specific helpers plus the ->interceptor primitive:
     inject-cofx — in re-frame.cofx (cofx-registry lookup)
     path        — focus a handler on an app-db sub-slice (this ns)
     unwrap      — assert [id payload-map] event shape (this ns)
-
-  v2 DROPS five v1 helpers (per M-21):
-    debug, trim-v, on-changes, enrich, after.
 
   The principle: keep helpers that do specific, non-trivial work; drop
   those that are just (->interceptor :before f) or (->interceptor :after f)

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -25,8 +25,7 @@
   the cached value is reused.
 
   This is the only disposal algorithm — there are no pluggable lifecycle
-  policies. The v1 alpha namespace exposed `:safe`, `:no-cache`,
-  `:reactive`, and `:forever` lifecycles; v2 does not (rf2-7cb2 / rf2-s9dn)."
+  policies."
   (:require [re-frame.registrar :as registrar]
             [re-frame.frame :as frame]
             [re-frame.substrate.adapter :as adapter]
@@ -337,9 +336,8 @@
   `:rf.error/no-such-sub` and build a nil-yielding reaction, but
   DO NOT store it in the cache. The miss is transient — a later
   registration (boot order, lazy load) must let the next subscribe
-  build a fresh reaction against the real body. v1 had the same
-  semantic by virtue of not caching the nil path; v2 preserves it
-  by branching here on nil meta."
+  build a fresh reaction against the real body. We achieve this by
+  branching here on nil meta."
   [frame-id query-v]
   (let [query-id      (first query-v)
         sub-meta      (registrar/lookup :sub query-id)

--- a/implementation/http/src/re_frame/http_machine_wrapper.cljc
+++ b/implementation/http/src/re_frame/http_machine_wrapper.cljc
@@ -188,13 +188,9 @@
    :initial :requesting
    :states
    {:requesting
-    ;; Per rf2-0z73: initial-state `:entry` actions fire on spawn as
-    ;; part of the bootstrap cascade — the canonical re-frame2 shape
-    ;; for "do this when the actor first runs". Pre-rf2-0z73 this
-    ;; entry-on-spawn was emulated via `:on :rf.machine/spawned
-    ;; :action :fire-request` (the synthetic event spawn-fx dispatches
-    ;; when no explicit `:start` was supplied); that workaround is no
-    ;; longer needed.
+    ;; Initial-state `:entry` actions fire on spawn as part of the
+    ;; bootstrap cascade — the canonical re-frame2 shape for "do this
+    ;; when the actor first runs".
     {:entry :fire-request
      :on    {:rf.http/succeeded  {:target :succeeded :action :record-value}
              :rf.http/failed     {:target :failed    :action :record-failure}}}

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -235,11 +235,11 @@
 ;; throws / returns safe defaults cleanly.
 ;;
 ;; Per Spec 005 §reg-machine vs reg-machine* (rf2-8bp3): the late-bind
-;; hook key is `:machines/reg-machine` (the legacy slot name) and points
-;; at `reg-machine*` — the plain-fn surface. The `reg-machine` macro at
-;; the `re-frame.core` boundary is import-time-only (CLJS macroexpansion
-;; runs before ns-load); the runtime always reaches through this hook to
-;; the plain-fn surface.
+;; hook key is `:machines/reg-machine` and points at `reg-machine*` —
+;; the plain-fn surface. The `reg-machine` macro at the `re-frame.core`
+;; boundary is import-time-only (CLJS macroexpansion runs before
+;; ns-load); the runtime always reaches through this hook to the
+;; plain-fn surface.
 
 (late-bind/set-fn! :machines/reg-machine            reg-machine*)
 (late-bind/set-fn! :machines/create-machine-handler create-machine-handler)


### PR DESCRIPTION
## Summary

Pre-alpha — comments narrating removed surfaces (`bound-dispatcher`/`bound-subscriber` aliases, fn-form `with-frame`, `re-frame.views-macros` path, `:rf.machine/*` legacy reservation, pre-v2 `v1 stdlib` interceptors, `v1 alpha` sub lifecycles, `pre-rf2-0z73` workaround, etc.) are noise. Cut the bury-the-dead narration; kept comments that explain a CURRENT design choice or an active code branch.

11 sites cut across 11 files, **-26 LoC net** (54 deletions, 28 insertions). 

## Sites cut

- `core.cljc` — `bound-dispatcher`/`bound-subscriber` aliases note; with-frame fn-form no-longer-supported note; views-macros legacy import-path note.
- `fx.cljc` — machine fx-ids no-longer-reserved-here, reframed as positive statement of current registration path.
- `events.cljc` — trailing "silently routing was the v1 behaviour" clause.
- `interceptor.cljc` — "Pedestal / re-frame v1" reference; "v2 trims the v1 stdlib helpers" phrasing.
- `std_interceptors.cljc` — "v2 DROPS five v1 helpers" block.
- `subs.cljc` — "v1 alpha namespace exposed :safe/:no-cache/..." block; "v1 had the same semantic / v2 preserves it" clause.
- `cofx.cljc` — "v1 idioms" / "symmetry with v1" references.
- `adapter/context.cljs` — "pre-rf2-8q66" / "observable behaviour as before" history.
- `http_machine_wrapper.cljc` — "Pre-rf2-0z73 entry-on-spawn was emulated via ..." workaround narration.
- `machines.cljc` — "(the legacy slot name)" editorial parenthetical.
- `reagent-slim/component.cljs` — "Legacy seq-as-fragment shape" relabel.

## Kept

Comments that explain a CURRENT design choice or active code branch:

- `flows.cljc` — memo trialled-and-removed, explains current unmemoised topo-sort.
- `events.cljc` (top) — effect-map shape policing rationale (M-8 is actively policed).
- `schemas.cljc` — rf2-t0hq late-bind pattern explains current Malli reach.
- `reagent-slim/core.cljs` — React-19-removed-surface shims describing themselves.
- `core.cljc` (top) — `core_X` naming choice for CLJS goog.provide.
- `machines.cljc` (top + façade) — file-split architectural overview.
- `transition.cljc` — three-arity vs variadic branch fixing a previously-buggy CLJS check (the current branch IS the fix).
- `subs.cljc` — refcount disposal & deferred-grace explanation (current algorithm).
- Substrate-adapter chain comments — "previously-registered handler" describes the current chain, not history.

## Test plan

- [x] `npm run test:cljs` — 1778 tests, 4937 assertions, 0 failures, 0 errors.
- [ ] CI gates (browser, elision probe, perf-bundle, bundle-isolation) run automatically.