### PR TITLE
rf2-zjqh8: land :elided-large emission + :dropped-sensitive parity (Conventions MUST-level pin)

### DIFF
--- a/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
@@ -14,7 +14,7 @@
   keys here, once, prevents per-consumer drift and gives a single
   search target when the vocabulary grows.
 
-  ## Two namespaces
+  ## Two namespaces plus envelope slots
 
   `:rf.mcp/*` — per-tool wire-mechanism markers (overflow, cursor,
                 dedup-table, diff-from, cache-hit, cursor-stale).
@@ -27,6 +27,13 @@
                  namespaces; Spec 009 §Size elision in traces). The
                  walker emits the marker; MCP servers re-emit it on
                  the wire.
+
+  Unqualified envelope slots — `:dropped-sensitive` /
+  `:elided-large` — ride alongside the tool's unqualified envelope
+  slots; they are scalar counters summarising the walker's
+  suppression count on a per-call basis. Per Conventions §Cross-MCP
+  indicator-field vocabulary and Spec 009 §Size elision in traces
+  (Indicator field on tool responses, MUST-level).
 
   ## JSON-RPC error codes
 
@@ -134,6 +141,67 @@
   "Framework opt: byte threshold above which an auto-detected leaf is
   elided. Per Spec 009 §Size elision in traces."
   :rf.size/threshold-bytes)
+
+;; ---------------------------------------------------------------------------
+;; Envelope indicator-field slots (Conventions §Cross-MCP indicator-field
+;; vocabulary; Spec 009 §Size elision in traces — Indicator field on tool
+;; responses). MUST-level pin per rf2-2499j: every tool that returns a
+;; structured response map and walks a tree-typed payload carries BOTH
+;; counts on the envelope (omit when zero, alongside the qualified wire
+;; markers `:rf/redacted` / `:rf.size/large-elided` at the leaf-
+;; substitution site).
+;;
+;; Unqualified keys — they ride alongside the tool's own unqualified
+;; envelope slots (`{:trace [...] :dropped-sensitive 3}`,
+;; `{:db {...} :elided-large 2}`). Mixing namespaced and unqualified
+;; envelope keys would split the response shape across two conventions
+;; and burn agent-host pattern-match budget for no information gain.
+;; The wire markers at the leaf-substitution site stay namespaced —
+;; they are addressable values the agent re-fetches; these counts are
+;; scalar summaries on the envelope.
+;; ---------------------------------------------------------------------------
+
+(def dropped-sensitive-key
+  "Envelope-slot key for the count of `:sensitive? true` leaves dropped
+  at the wire boundary. Unqualified per Conventions §Cross-MCP
+  indicator-field vocabulary. Omit the slot when the count is zero.
+  Mirror of `[● REDACTED N]` on on-box dev-tool surfaces."
+  :dropped-sensitive)
+
+(def elided-large-key
+  "Envelope-slot key for the count of leaves replaced with the
+  `:rf.size/large-elided` marker at the wire boundary. Unqualified
+  per Conventions §Cross-MCP indicator-field vocabulary. Omit the
+  slot when the count is zero. Mirror of `[● ELIDED N]` on on-box
+  dev-tool surfaces. Per Spec 009 §Size elision in traces —
+  Indicator field on tool responses (MUST-level)."
+  :elided-large)
+
+(defn count-elided-markers
+  "Walk `v` and count every `{:rf.size/large-elided ...}` marker it
+  contains. The walker is shallow at the marker boundary — once a
+  marker is found, its body is NOT recursed into (marker bodies are
+  scalar metadata, not tree-shaped). Recurses through maps, vectors,
+  sets, and seqs; treats every other value as a leaf.
+
+  Returns an integer ≥ 0. Cheap on the common path (post-elision
+  payload with no markers ⇒ one full walk producing zero).
+
+  Counterpart to `re-frame.mcp-base.sensitive/strip-sensitive`'s
+  `dropped-count` return — both indicators ride the response envelope
+  per Conventions §Cross-MCP indicator-field vocabulary."
+  [v]
+  (cond
+    (and (map? v) (contains? v large-elided-key))
+    1
+
+    (map? v)
+    (reduce-kv (fn [n _k child] (+ n (count-elided-markers child))) 0 v)
+
+    (or (vector? v) (set? v) (seq? v))
+    (reduce (fn [n child] (+ n (count-elided-markers child))) 0 v)
+
+    :else 0))
 
 ;; ---------------------------------------------------------------------------
 ;; JSON-RPC 2.0 error codes (per §5.1; reused by MCP per the spec)

--- a/tools/mcp-base/test/re_frame/mcp_base/vocab_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/vocab_test.clj
@@ -21,6 +21,61 @@
   (is (= :rf.size/include-digests?    vocab/include-digests-opt))
   (is (= :rf.size/threshold-bytes     vocab/threshold-bytes-opt)))
 
+(deftest envelope-indicator-slots-pinned
+  ;; Cross-MCP indicator-field vocabulary per Conventions §Cross-MCP
+  ;; indicator-field vocabulary (rf2-2499j). The two slots are
+  ;; **unqualified** — they ride the tool's own envelope, not under a
+  ;; reserved namespace. A drift to `:rf.size/elided-large` or
+  ;; `:elided-large?` is a wire-protocol break.
+  (is (= :dropped-sensitive vocab/dropped-sensitive-key))
+  (is (= :elided-large      vocab/elided-large-key)))
+
+(deftest count-elided-markers-walks-the-payload
+  (let [marker {:rf.size/large-elided
+                {:path   [:user :pdf]
+                 :bytes  102400
+                 :type   :string
+                 :reason :declared
+                 :handle [:rf.elision/at [:user :pdf]]}}]
+    ;; Empty / leaf cases — nothing to count.
+    (is (= 0 (vocab/count-elided-markers nil)))
+    (is (= 0 (vocab/count-elided-markers {})))
+    (is (= 0 (vocab/count-elided-markers [])))
+    (is (= 0 (vocab/count-elided-markers "string")))
+    (is (= 0 (vocab/count-elided-markers 42)))
+    (is (= 0 (vocab/count-elided-markers {:ok? true :payload {:a 1 :b [2 3]}})))
+
+    ;; Marker counted at every depth and shape.
+    (is (= 1 (vocab/count-elided-markers marker))
+        "Top-level single marker counts once.")
+    (is (= 1 (vocab/count-elided-markers {:value marker}))
+        "Marker nested in a map counts once.")
+    (is (= 1 (vocab/count-elided-markers [marker]))
+        "Marker nested in a vector counts once.")
+    (is (= 2 (vocab/count-elided-markers {:a marker :b marker}))
+        "Sibling markers both count.")
+    (is (= 3 (vocab/count-elided-markers
+               {:slice1 marker
+                :slice2 {:nested marker}
+                :slice3 [{:deep marker}]}))
+        "Markers at mixed depths all count.")
+
+    ;; The marker BODY is not recursed into (marker bodies carry
+    ;; `:handle` / `:path` / metadata, not another marker).
+    (let [body-with-collision {:rf.size/large-elided
+                               {:path [:a :b]
+                                :bytes 100
+                                :type :string
+                                :reason :declared
+                                :handle [:rf.elision/at [:a :b]]
+                                ;; A pathological marker-shaped value
+                                ;; lodged inside the body would still
+                                ;; only count the OUTER marker.
+                                :extra {:rf.size/large-elided
+                                        {:bytes 1}}}}]
+      (is (= 1 (vocab/count-elided-markers body-with-collision))
+          "Marker body is opaque; nested marker-shape isn't double-counted."))))
+
 (deftest jsonrpc-error-codes-pinned
   (is (= -32700 vocab/code-parse-error))
   (is (= -32600 vocab/code-invalid-request))

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -244,6 +244,34 @@
   [:map [:rf.size/large-elided ElisionMarkerBody]])
 
 ;; ---------------------------------------------------------------------------
+;; Envelope indicator-field slots (`:dropped-sensitive` / `:elided-large`).
+;; Per Conventions §Cross-MCP indicator-field vocabulary (rf2-2499j) and
+;; Spec 009 §Size elision in traces — Indicator field on tool responses
+;; (MUST-level). Unqualified keys riding the tool's own envelope; integer
+;; counters; omit when zero. These are NOT cross-server wire MARKERS
+;; (those are the `:rf.mcp/*` / `:rf.size/*` namespaced shapes above) —
+;; they are scalar envelope-level summaries of how many walker
+;; suppressions happened per call. The conformance contract: both slots
+;; ride alongside every tool that walks a tree-typed payload, the keys
+;; are unqualified (no namespace), and the values are non-negative
+;; integers.
+;; ---------------------------------------------------------------------------
+
+(def DroppedSensitive
+  "`{... :dropped-sensitive N}` envelope slot — integer count of leaves
+  the walker dropped because they matched `:sensitive? true`. Open map
+  so it composes with any tool's envelope shape; the load-bearing
+  claim is the slot KEY (`:dropped-sensitive`, unqualified) and the
+  value's `nat-int?` type."
+  [:map {:closed false} [:dropped-sensitive nat-int?]])
+
+(def ElidedLarge
+  "`{... :elided-large N}` envelope slot — integer count of leaves the
+  walker replaced with the `:rf.size/large-elided` marker. Same
+  shape contract as `:dropped-sensitive`."
+  [:map {:closed false} [:elided-large nat-int?]])
+
+;; ---------------------------------------------------------------------------
 ;; Canonical-marker index. The ordered set of cross-MCP markers; each
 ;; entry binds the schema, a description, and the per-server fixtures.
 ;; A new marker landing in the cross-server vocabulary MUST add an
@@ -517,3 +545,123 @@
                  "`canonical-markers` to include :story-mcp in "
                  ":servers, add a story-mcp fixture, and extend "
                  "`server-source-files`."))))))
+
+;; ---------------------------------------------------------------------------
+;; Envelope indicator-field gate (rf2-2499j MUST-level pin).
+;;
+;; Per Conventions §Cross-MCP indicator-field vocabulary and Spec 009
+;; §Size elision in traces — Indicator field on tool responses, tools
+;; that return structured response maps MUST carry an `:elided-large`
+;; count alongside the existing `:dropped-sensitive` count, one MUST-
+;; level row per consumer-facing tool that walks a tree-typed payload.
+;;
+;; Conformance contract:
+;;
+;; 1. Schema-level: both envelope slots validate as
+;;    `[:map {:closed false} [<slot> nat-int?]]`. Fixtures sourced from
+;;    each emitting server.
+;; 2. Source-text pin: every server in `:envelope-emitters` carries
+;;    BOTH the `:dropped-sensitive` literal AND the `:elided-large`
+;;    literal (parity — one without the other is the round-2 audit
+;;    must-fix this gate defends against).
+;; 3. story-mcp absence tripwire: today story-mcp does not walk any
+;;    tree-typed payload through `elide-wire-value` (it operates on
+;;    small, structured story/variant metadata that stays under the
+;;    wire-cap by construction); neither slot appears in its source.
+;;    When story-mcp adopts a walker, the reviewer adds it to
+;;    `:envelope-emitters` AND wires the parity emission — both at
+;;    once, per the MUST-level pin.
+;;
+;; The mcp-base vocab ns (`tools/mcp-base/src/re_frame/mcp_base/vocab.cljc`)
+;; reserves the two slot KEYS as constants (`dropped-sensitive-key`,
+;; `elided-large-key`); the count-walker helper
+;; (`count-elided-markers`) lives next to them. Consumers import the
+;; ns to keep the key bytes byte-identical across servers.
+;; ---------------------------------------------------------------------------
+
+(def envelope-indicator-slots
+  "Conformance contract for the two unqualified envelope-indicator
+  slots. Each entry pins the schema, per-server fixtures, and the set
+  of servers that emit the slot today. The two slots are siblings —
+  any server that emits one MUST emit the other (the MUST-level
+  parity is the round-2 audit fix this gate enforces)."
+  [{:slot     :dropped-sensitive
+    :schema   DroppedSensitive
+    :emitters #{:pair2-mcp}
+    :fixtures {:pair2-mcp-trace-window
+               {:ok? true :epochs [] :dropped-sensitive 3}
+               :pair2-mcp-snapshot
+               {:ok? true :snapshot {} :dropped-sensitive 1}}}
+
+   {:slot     :elided-large
+    :schema   ElidedLarge
+    :emitters #{:pair2-mcp}
+    :fixtures {:pair2-mcp-snapshot
+               {:ok? true :snapshot {} :elided-large 2}
+               :pair2-mcp-get-path
+               {:ok? true :exists? true :path [:user :pdf] :value
+                {:rf.size/large-elided
+                 {:path [:user :pdf]
+                  :bytes 102400
+                  :type :string
+                  :reason :declared
+                  :hint "User PDF; fetch via get-path."
+                  :handle [:rf.elision/at [:user :pdf]]}}
+                :elided-large 1}}}])
+
+(deftest envelope-indicator-fixtures-conform
+  (doseq [{:keys [slot schema fixtures]} envelope-indicator-slots
+          [fixture-name fixture-value]   fixtures]
+    (testing (str "envelope slot " slot " — fixture " fixture-name)
+      (is (m/validate schema fixture-value)
+          (str "Fixture " fixture-name " for " slot
+               " failed schema validation:\n"
+               (me/humanize (m/explain schema fixture-value)))))))
+
+(def ^:private envelope-emitter-source-files
+  "Source files that carry the envelope-slot emit sites per server.
+  Restricted to the actual tool source — the spec/docs files may
+  mention the slots without emitting them."
+  {:pair2-mcp ["tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs"]
+   :causa-mcp []          ;; impl not landed; spec mentions don't count
+   :story-mcp []})        ;; doesn't walk tree-typed payloads today
+
+(deftest envelope-slot-parity-in-pair2-mcp
+  ;; MUST-level pin (Conventions rf2-2499j, Spec 009 §Indicator field
+  ;; on tool responses): every server that emits one slot MUST emit
+  ;; the other. The round-2 alignment audit (rf2-zjqh8) caught
+  ;; pair2-mcp emitting only `:dropped-sensitive`; this gate locks
+  ;; in the parity so the regression can't return silently.
+  (let [files (get envelope-emitter-source-files :pair2-mcp)]
+    (is (seq files)
+        "No source files registered for pair2-mcp envelope emit sites.")
+    (doseq [rel files]
+      (let [src (read-source rel)]
+        (testing (str "pair2-mcp " rel " — :dropped-sensitive literal")
+          (is (str/includes? src ":dropped-sensitive")
+              (str ":dropped-sensitive literal missing from " rel)))
+        (testing (str "pair2-mcp " rel " — :elided-large literal")
+          (is (str/includes? src ":elided-large")
+              (str ":elided-large literal missing from " rel
+                   " — parity break per Conventions rf2-2499j.")))))))
+
+(deftest story-mcp-still-emits-zero-envelope-indicators
+  ;; Tripwire mirroring `story-mcp-still-emits-zero-cross-mcp-markers`.
+  ;; The day story-mcp adopts a tree-typed-payload walker (e.g. wires
+  ;; `elide-wire-value` over the `:app-db` slot in `preview-variant` /
+  ;; `run-variant`), both envelope slots MUST land together. This
+  ;; tripwire flips RED on the FIRST adoption so the reviewer can't
+  ;; merge half the parity.
+  (let [story-files ["tools/story-mcp/src/re_frame/story_mcp/tools.cljc"
+                     "tools/story-mcp/src/re_frame/story_mcp/protocol.cljc"]
+        slots       [":dropped-sensitive" ":elided-large"]]
+    (doseq [rel  story-files
+            slot slots]
+      (testing (str "story-mcp source " rel " — " slot " absence")
+        (is (not (str/includes? (read-source rel) slot))
+            (str slot " literal found in " rel
+                 ".\nIf story-mcp now walks a tree-typed payload, "
+                 "the OTHER envelope slot MUST land in the same commit "
+                 "(Conventions rf2-2499j MUST-level parity). Update "
+                 "`envelope-emitter-source-files` and "
+                 "`envelope-indicator-slots`."))))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -946,6 +946,17 @@
                     (let [[kept dropped] (strip-sensitive raw-epochs incl?)
                           encoded        (diff-encode-epochs kept mode)
                           deduped        (dedup-value encoded dedup?)
+                          ;; :elided-large parity per Conventions §Cross-MCP
+                          ;; indicator-field vocabulary (rf2-2499j). Count
+                          ;; `:rf.size/large-elided` markers riding the
+                          ;; post-pipeline payload — today trace-window does
+                          ;; not run `elide-wire-value` on epoch records
+                          ;; (the walker is wired on `snapshot` / `get-path`)
+                          ;; so the count is always 0 and the slot is
+                          ;; omitted; the parallel-counter scaffolding is
+                          ;; in place so future wiring lights up the slot
+                          ;; automatically.
+                          elided         (base-vocab/count-elided-markers deduped)
                           next-id        (:next-id v)
                           next-cursor    (encode-cursor
                                            (when next-id
@@ -967,7 +978,8 @@
                                         :has-more?   has-more?
                                         :estimated-remaining remaining
                                         :next-cursor next-cursor}
-                                 (pos? dropped) (assoc :dropped-sensitive dropped))))))))
+                                 (pos? dropped) (assoc :dropped-sensitive dropped)
+                                 (pos? elided)  (assoc :elided-large elided))))))))
             (.catch (fn [err] (err->result :trace-failed err))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -1031,6 +1043,12 @@
                           [kept dropped] (strip-sensitive matches incl?)
                           encoded        (diff-encode-epochs kept mode)
                           deduped        (dedup-value encoded dedup?)
+                          ;; :elided-large parity per Conventions §Cross-MCP
+                          ;; indicator-field vocabulary (rf2-2499j). Same
+                          ;; rationale as trace-window — no elision walk on
+                          ;; epoch records today; the scaffolding emits the
+                          ;; slot the moment a future revision wires it.
+                          elided         (base-vocab/count-elided-markers deduped)
                           next-id        (:next-id v)
                           next-cursor    (encode-cursor
                                            (when next-id
@@ -1053,7 +1071,8 @@
                                               :has-more?           (some? next-cursor)
                                               :estimated-remaining remaining
                                               :next-cursor         next-cursor)
-                                 (pos? dropped) (assoc :dropped-sensitive dropped))))))))
+                                 (pos? dropped) (assoc :dropped-sensitive dropped)
+                                 (pos? elided)  (assoc :elided-large elided))))))))
             (.catch (fn [err] (err->result :watch-failed err))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -1651,7 +1670,22 @@
                        response-mode  (cond
                                         path                  :path-sliced
                                         (= :full app-db-mode) :full
-                                        :else                 :summary)]
+                                        :else                 :summary)
+                       ;; :elided-large parity per Conventions §Cross-MCP
+                       ;; indicator-field vocabulary (rf2-2499j). The
+                       ;; snapshot eval form runs `re-frame.core/elide-
+                       ;; wire-value` server-side over each frame's
+                       ;; `:app-db` slice, substituting
+                       ;; `:rf.size/large-elided` markers in place of
+                       ;; declared / over-threshold leaves. Counting them
+                       ;; AFTER the dedup pass (where the rich slices
+                       ;; haven't yet been summarised) gives the agent
+                       ;; the real elision footprint of the call; the
+                       ;; later summary pass replaces non-app-db slices
+                       ;; with bounded markers, but its own bytes are
+                       ;; not elision-markers and so don't inflate the
+                       ;; count. Omitted when zero per Conventions.
+                       elided                (base-vocab/count-elided-markers deduped)]
                    (ok-text (cond-> {:ok?            true
                                      :frames         (if (= :all frames) :all (vec frames))
                                      :include        include
@@ -1663,7 +1697,8 @@
                                      :snapshot       summarised}
                               path                  (assoc :path path)
                               (seq path-status)     (assoc :path-not-found path-status)
-                              (pos? dropped)        (assoc :dropped-sensitive dropped))))))
+                              (pos? dropped)        (assoc :dropped-sensitive dropped)
+                              (pos? elided)         (assoc :elided-large elided))))))
         (.catch (fn [err] (err->result :snapshot-failed err))))))
 
 ;; ---------------------------------------------------------------------------
@@ -1740,9 +1775,19 @@
         (-> (ensure-runtime! conn build-id)
             (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
             (.then (fn [v]
-                     (ok-text (cond-> v
-                                frame     (assoc :frame frame)
-                                (:ok? v)  (assoc :elision elision?)))))
+                     ;; :elided-large indicator-field per Conventions
+                     ;; §Cross-MCP indicator-field vocabulary (rf2-2499j).
+                     ;; The eval form ran `re-frame.core/elide-wire-value`
+                     ;; over the resolved `:value` (when elision was
+                     ;; on), so the response may carry one or more
+                     ;; `:rf.size/large-elided` markers. Count them on
+                     ;; the envelope so the agent sees the elision
+                     ;; footprint without diffing the payload.
+                     (let [elided (base-vocab/count-elided-markers v)]
+                       (ok-text (cond-> v
+                                  frame          (assoc :frame frame)
+                                  (:ok? v)       (assoc :elision elision?)
+                                  (pos? elided)  (assoc :elided-large elided))))))
             (.catch (fn [err] (err->result :get-path-failed err))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -1894,6 +1939,21 @@
                               ;; tripped most recently.
                               overflow-reason*   (atom nil)
                               dropped-sensitive* (atom 0)
+                              ;; :elided-large parity per Conventions
+                              ;; §Cross-MCP indicator-field vocabulary
+                              ;; (rf2-2499j). Cumulative count of
+                              ;; `:rf.size/large-elided` markers across
+                              ;; every drain in the subscription's
+                              ;; lifetime. Today the subscribe path
+                              ;; doesn't run `elide-wire-value` on the
+                              ;; queued events (the walker is wired on
+                              ;; `snapshot` / `get-path`), so this stays
+                              ;; at zero and the slot is omitted; the
+                              ;; accumulator is in place so future
+                              ;; wiring lights up the slot automatically
+                              ;; on both the per-tick progress and the
+                              ;; final summary.
+                              elided-large*      (atom 0)
                               terminate
                               (fn [reason]
                                 ;; Drop the runtime subscription and
@@ -1920,7 +1980,9 @@
                                               @overflow-reason*
                                               (assoc :overflow-reason @overflow-reason*)
                                               (pos? @dropped-sensitive*)
-                                              (assoc :dropped-sensitive @dropped-sensitive*))))))))
+                                              (assoc :dropped-sensitive @dropped-sensitive*)
+                                              (pos? @elided-large*)
+                                              (assoc :elided-large @elided-large*))))))))
                               poll
                               (fn poll []
                                 (cond
@@ -1951,6 +2013,14 @@
                                                   ov-reason      (:overflow-reason drain-resp)
                                                   [evts dropped] (strip-sensitive
                                                                    (vec raw-evts) incl?)
+                                                  ;; :elided-large parity (rf2-2499j) — count
+                                                  ;; `:rf.size/large-elided` markers in the
+                                                  ;; post-strip event batch. Zero today
+                                                  ;; (subscribe path doesn't run the
+                                                  ;; elision walker); included for forward-
+                                                  ;; safety and to keep the slot riding
+                                                  ;; every tree-walking tool's envelope.
+                                                  tick-elided    (base-vocab/count-elided-markers evts)
                                                   n              (count evts)]
                                               (when (pos? ev-dropped)
                                                 (swap! dropped-events* + ev-dropped))
@@ -1960,6 +2030,8 @@
                                                 (reset! overflow-reason* ov-reason))
                                               (when (pos? dropped)
                                                 (swap! dropped-sensitive* + dropped))
+                                              (when (pos? tick-elided)
+                                                (swap! elided-large* + tick-elided))
                                               (when (or (pos? n) (pos? ev-dropped))
                                                 (swap! tick inc)
                                                 (swap! delivered + n)
@@ -1979,7 +2051,9 @@
                                                                          ov-reason
                                                                          (assoc :overflow-reason ov-reason)
                                                                          (pos? dropped)
-                                                                         (assoc :dropped-sensitive dropped)))
+                                                                         (assoc :dropped-sensitive dropped)
+                                                                         (pos? tick-elided)
+                                                                         (assoc :elided-large tick-elided)))
                                                                      ev-dropped
                                                                      by-dropped
                                                                      ov-reason)})


### PR DESCRIPTION
## Summary

Round-2 alignment audit (rf2-qi9v0) follow-up — Conventions §Cross-MCP indicator-field vocabulary (rf2-2499j) MUST-level pin. Tools that walk a tree-typed payload must emit `:elided-large` alongside `:dropped-sensitive`; the pin was stranded.

- **mcp-base/vocab.cljc** — adds `dropped-sensitive-key` / `elided-large-key` constants + `count-elided-markers` walker (single normative emission point for the slot keys + counter).
- **pair2-mcp/tools.cljs** — parallel `:elided-large` counter at every `:dropped-sensitive` emit site: `trace-window`, `watch-epochs`, `snapshot`, `get-path`, `subscribe` (per-tick progress + final summary). `snapshot` / `get-path` run `re-frame.core/elide-wire-value` server-side so the slot lights up immediately; the others scaffold the slot for forward-safety.
- **mcp-conformance/wire-vocab** — three new gates: schema-conformance over the slot shape, source-text parity pin (one slot without the other is the audit-must-fix this defends against), and a story-mcp absence tripwire so a future walker can't land half the parity.

Both slots stay omitted when zero per Conventions (no envelope-bloat on the common path).

## Test plan

- [x] `clojure -M:test` in `tools/mcp-base` — 62 tests / 148 assertions, all green
- [x] `clojure -M:test` in `tools/mcp-conformance/wire-vocab` — 9 tests / 153 assertions, all green
- [x] `npx shadow-cljs compile server-test && node out/server-test.js` in `tools/pair2-mcp` — 270 tests / 660 assertions, all green