### PR TITLE
refactor(schemas): collapse :large? + :sensitive? walkers into parameterised walker (rf2-oghml)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -359,152 +359,49 @@
   [frame-id]
   (get @schemas-by-frame frame-id {}))
 
-;; ---- elision-declaration walker (rf2-nwv63) ------------------------------
+;; ---- per-slot flag walker (rf2-nwv63 / rf2-kj51z / rf2-oghml) ------------
 ;;
-;; Per Spec 009 §Size elision in traces, the schema-driven nomination
-;; path: any Malli slot carrying `:large? true` in its per-slot
-;; properties (per Spec-Schemas §`:rf/app-schema-meta` — the per-slot
-;; metadata vocabulary) is registered into the frame's
-;; `[:rf/elision :declarations]` slot with `:source :schema`. The
-;; framework's `rf/elide-wire-value` walker (rf2-v9tw2, downstream)
-;; consults this registry at every wire-boundary emit.
+;; Per Spec 009 §Size elision in traces and Spec 010 §`:sensitive?`, the
+;; schema-driven nomination path: any Malli slot carrying a per-slot flag
+;; (`:large? true` or `:sensitive? true`) in its per-slot properties
+;; (per Spec-Schemas §`:rf/app-schema-meta` — the per-slot metadata
+;; vocabulary) is registered into the frame's
+;; `[:rf/elision :declarations]` (`:large?`) or
+;; `[:rf/elision :sensitive-declarations]` (`:sensitive?`) slot with
+;; `:source :schema`. Both registries are sibling slots under the shared
+;; `[:rf/elision]` reserved root; flags compose orthogonally — a slot may
+;; carry either or both, and the validation walker resolves the conflict
+;; at emit time. Storing them separately keeps the per-flag query
+;; (`(get-in db [:rf/elision :sensitive-declarations <path>])`) O(1)
+;; without value-shape inspection.
 ;;
-;; This file owns the **walker** that maps a registered schema's EDN
-;; form to a `{path declaration}` map; the actual app-db write lives
-;; in `re-frame.elision` (rf2-v9tw2) so that file owns the unified
-;; registry surface across the schema / declared / runtime-flagged
-;; sources. The seam between the two is the late-bind hook
-;; `:schemas/frame-elision-declarations` (registered at the bottom
-;; of this file).
+;; This file owns the **walker** that maps a registered schema's EDN form
+;; to a `{path declaration}` map; the actual app-db write lives in
+;; `re-frame.elision` (rf2-v9tw2) so that file owns the unified registry
+;; surface across the schema / declared / runtime-flagged sources. The
+;; seam between the two is the per-flag late-bind hook registered at the
+;; bottom of this file.
 ;;
-;; The walker is **pure data** — it doesn't import malli.core. Malli
-;; EDN forms are vectors of the shape `[op props? children...]`; we
-;; pattern-match on shape. Per Spec 010 §The `:spec` value is opaque
-;; to re-frame, the framework MUST NOT call into the registered
-;; validator to introspect schema structure — we walk the EDN
-;; ourselves. This means the walker handles the **vector form**
-;; (`[:map [:k :string]]`) — the form `(rf/reg-app-schema ...)` users
-;; write. Non-vector Malli forms (schema objects, registry refs) are
-;; treated as opaque leaves; their internal `:large?` declarations
-;; are invisible to the walker (the same caveat applies to Malli's
-;; own schema-walking when introspection goes through `m/schema` ↔
-;; raw EDN — round-tripping a registry ref loses the slot metadata).
-
-(defn- schema-vector?
-  "True when `x` is a Malli vector form `[op props? children...]`."
-  [x]
-  (and (vector? x) (pos? (count x))))
-
-(defn- extract-props
-  "Pluck the per-slot properties map out of a Malli vector form. The
-  Malli convention: `[op {props} children...]` carries the map at
-  position 1; `[op children...]` (no props) has a child at position 1.
-  Return `nil` when no props are present."
-  [v]
-  (let [p (when (>= (count v) 2) (nth v 1))]
-    (when (map? p) p)))
-
-(defn- drop-op+props
-  "Return the children portion of a Malli vector form — drop the op
-  keyword and the optional props map."
-  [v]
-  (let [tail (subvec v 1)]
-    (if (and (seq tail) (map? (first tail)))
-      (subvec tail 1)
-      tail)))
-
-(defn- declaration-from-props
-  "Build a `:rf/elision-declaration` map from a slot's per-slot props,
-  or nil if `:large? true` is not set. Per Spec 009 §Size elision in
-  traces — the declaration shape is `{:large? bool :hint <str-or-nil>
-  :source :schema}`. The `:hint` is OPTIONAL (omitted from the map
-  when absent so the marker shape is minimal)."
-  [props]
-  (when (true? (:large? props))
-    (cond-> {:large? true
-             :source :schema}
-      (some? (:hint props)) (assoc :hint (:hint props)))))
-
-;; -- per-op recursion helpers --------------------------------------
-
-(declare walk-schema)
-
-(defn- walk-map-children
-  "For a `:map` form, walk every name-bearing child entry. A child
-  entry is `[k child-schema]` or `[k {props} child-schema]`. The
-  `:large?` flag may live in two places:
-
-    1. The slot's own props (one level above the child schema):
-         [:map [:user {:large? true} :string]]
-       — path is `(conj base k)`; the slot says \"this slot is large\".
-
-    2. The child schema's own props (one level inside):
-         [:map [:user [:string {:large? true}]]]
-       — path is `(conj base k)`; the schema says \"this value is
-       large by type\". Equivalent under the walker since the path
-       is the same.
-
-  We capture both; conflicts (slot props AND child props both
-  carry `:large?`) merge with slot-level winning per a left-to-
-  right semantics (slot props are more local to the path)."
-  [children base-path acc]
-  (reduce
-    (fn [acc child]
-      (if-not (and (vector? child) (>= (count child) 2))
-        acc
-        (let [k          (nth child 0)
-              maybe-prop (nth child 1)
-              has-prop?  (map? maybe-prop)
-              slot-props (when has-prop? maybe-prop)
-              child-tail (if has-prop?
-                           (when (>= (count child) 3) (nth child 2))
-                           maybe-prop)
-              slot-path  (conj base-path k)
-              slot-decl  (declaration-from-props slot-props)
-              acc'       (if slot-decl
-                           (assoc acc slot-path slot-decl)
-                           acc)]
-          (if (some? child-tail)
-            (walk-schema child-tail slot-path acc')
-            acc'))))
-    acc
-    children))
-
-(defn- walk-multi-children
-  "`:multi` and `:orn` carry name-bearing branches similarly to
-  `:map`. The branch's name is the dispatch value, NOT an app-db path
-  segment — so `:large?` on a `:multi` branch's slot props claims the
-  parent path (the `:multi` op's own `base-path`), not a child path.
-  We recurse into the branch schema at `base-path`."
-  [children base-path acc]
-  (reduce
-    (fn [acc child]
-      (cond
-        ;; [v schema] or [v props schema] branch — descend into schema
-        ;; at the SAME base-path (dispatch values aren't path segments).
-        (vector? child)
-        (let [maybe-prop (when (>= (count child) 2) (nth child 1))
-              has-prop?  (map? maybe-prop)
-              tail-idx   (if has-prop? 2 1)
-              tail       (when (> (count child) tail-idx) (nth child tail-idx))
-              branch-decl (when has-prop? (declaration-from-props maybe-prop))
-              acc'        (if branch-decl
-                            (assoc acc base-path branch-decl)
-                            acc)]
-          (if (some? tail) (walk-schema tail base-path acc') acc'))
-        :else acc))
-    acc
-    children))
-
-(defn- walk-positional-children
-  "For positional / nameless container ops (`:vector`, `:set`,
-  `:sequential`, `:maybe`, `:and`, `:or`, `:not`, `:tuple`, `:cat`,
-  `:catn`, etc.), descend into each child at the SAME `base-path` —
-  these ops don't introduce a new app-db path segment (a vector's
-  inner schema doesn't add a path key). `:large?` on the inner
-  schema's own props applies to the container's path."
-  [children base-path acc]
-  (reduce (fn [acc c] (walk-schema c base-path acc)) acc children))
+;; The walker is **pure data** — it doesn't import malli.core. Malli EDN
+;; forms are vectors of the shape `[op props? children...]`; we pattern-
+;; match on shape. Per Spec 010 §The `:spec` value is opaque to re-frame,
+;; the framework MUST NOT call into the registered validator to introspect
+;; schema structure — we walk the EDN ourselves. This means the walker
+;; handles the **vector form** (`[:map [:k :string]]`) — the form
+;; `(rf/reg-app-schema ...)` users write. Non-vector Malli forms (schema
+;; objects, registry refs) are treated as opaque leaves; their internal
+;; per-slot declarations are invisible to the walker (the same caveat
+;; applies to Malli's own schema-walking when introspection goes through
+;; `m/schema` ↔ raw EDN — round-tripping a registry ref loses the slot
+;; metadata).
+;;
+;; The walker is parameterised on the per-slot flag key (`:large?` /
+;; `:sensitive?`); both flags share identical structural recognition
+;; (`:map` name-bearing, `:multi`/`:orn`/`:catn`/`:altn` dispatch-bearing,
+;; positional combinators descend at the same base-path) so a single
+;; traversal serves every per-slot annotation under
+;; `:rf/app-schema-meta`. Future per-slot annotations (Spec-Schemas
+;; reserves additional slots) compose as one-line registrations.
 
 (def ^:private name-bearing-ops
   "Schema ops whose children carry name slots (the first element of a
@@ -517,42 +414,130 @@
   segment)."
   #{:multi :orn :catn :altn})
 
-(defn walk-schema
-  "Walk a Malli EDN schema form at `base-path`, populating `acc` with
-  `{path declaration}` entries for every `:large? true` slot found.
-  Pure; same input always produces the same output. Public so tools
-  and the rf2-v9tw2 elision-walker can re-use it.
+(defn- props-of
+  "Return the per-slot props map of a Malli vector form, or nil. Convention:
+  `[op {props} children...]` carries the map at position 1."
+  [v]
+  (let [p (when (and (vector? v) (>= (count v) 2)) (nth v 1))]
+    (when (map? p) p)))
 
-  Returns the accumulator map. Use `extract-large-paths-from-schema`
-  for the seeded-empty-accumulator entry point."
-  ([schema base-path]
-   (walk-schema schema base-path {}))
-  ([schema base-path acc]
+(defn- children-of
+  "Return the children portion of a Malli vector form — drop the op
+  keyword and the optional props map."
+  [v]
+  (let [tail (subvec v 1)]
+    (if (and (seq tail) (map? (first tail)))
+      (subvec tail 1)
+      tail)))
+
+(defn- decl-from-props
+  "Build a declaration map `{flag-key true :source :schema}` (plus
+  optional `:hint` propagated verbatim) from a slot's per-slot props,
+  or nil when `flag-key` is not set to `true`. Per Spec 009 §Size
+  elision in traces and Spec 010 §`:sensitive?` — `:hint` is optional
+  and omitted when absent so the marker shape stays minimal. The
+  `:source` slot records provenance so the unified registry merger
+  (`populate-*-declarations`) can apply the conflict-resolution rule:
+  app-declared beats schema beats runtime-flagged."
+  [flag-key props]
+  (when (true? (get props flag-key))
+    (cond-> {flag-key true
+             :source  :schema}
+      (some? (:hint props)) (assoc :hint (:hint props)))))
+
+(defn walk-flagged-schema
+  "Walk a Malli EDN schema form at `base-path`, populating `acc` with
+  `{path declaration}` entries for every slot whose per-slot props
+  carry `(flag-key → true)`. Pure; same input always produces the same
+  output. Used by the per-flag entry points
+  (`extract-large-paths-from-schema`, `extract-sensitive-paths-from-schema`).
+
+  `flag-key` is the per-slot annotation key (`:large?` or `:sensitive?`).
+
+  Structural rules:
+
+    - `:map` children are name-bearing — `[k schema]` / `[k {props} schema]`
+      — and the flag may live in the slot's own props (claims `(conj base k)`)
+      OR the child schema's own props (also claims `(conj base k)`, since
+      the path is the same).
+
+    - `:multi` / `:orn` / `:catn` / `:altn` children are dispatch-bearing —
+      `[v schema]` / `[v {props} schema]` — and the flag on a branch's
+      slot props claims the parent path (the op's `base-path`), not a
+      child path; dispatch values aren't path segments.
+
+    - Positional / nameless container ops (`:vector`, `:set`, `:sequential`,
+      `:maybe`, `:and`, `:or`, `:not`, `:tuple`, `:cat`, …) descend into
+      each child at the SAME `base-path` — these ops don't introduce a
+      new app-db path segment.
+
+    - Container-level props on the schema itself (the schema's OWN props,
+      not a parent slot's) claim `base-path`. Covers
+      `(rf/reg-app-schema [:user :pdf] [:string {:large? true}])` — the
+      reg-app-schema path IS where the marker fires.
+
+  Returns the accumulator map."
+  ([flag-key schema base-path]
+   (walk-flagged-schema flag-key schema base-path {}))
+  ([flag-key schema base-path acc]
    (cond
-     ;; Keyword schema (`:string`, `:int`, `:any`, registry-name kw,
-     ;; …) — no slot props on a bare keyword; nothing to nominate.
+     ;; Keyword schema (`:string`, `:int`, `:any`, registry-name kw, …)
+     ;; — no slot props on a bare keyword; nothing to nominate.
      (keyword? schema) acc
 
      ;; Vector form `[op props? children...]` — the structural case.
-     (schema-vector? schema)
-     (let [op    (nth schema 0)
-           props (extract-props schema)
-           ;; Container-level `:large?` (the schema's OWN props,
-           ;; not a parent slot's props) claims the base-path. This
-           ;; covers `(rf/reg-app-schema [:user :pdf] [:string {:large? true}])`
-           ;; — the reg-app-schema path IS where the marker fires.
-           acc'  (if-let [decl (declaration-from-props props)]
-                   (assoc acc base-path decl)
-                   acc)]
+     (and (vector? schema) (pos? (count schema)))
+     (let [op       (nth schema 0)
+           acc'     (if-let [decl (decl-from-props flag-key (props-of schema))]
+                      (assoc acc base-path decl)
+                      acc)
+           children (children-of schema)]
        (cond
          (contains? name-bearing-ops op)
-         (walk-map-children (drop-op+props schema) base-path acc')
+         (reduce
+           (fn [acc child]
+             (if-not (and (vector? child) (>= (count child) 2))
+               acc
+               (let [k          (nth child 0)
+                     maybe-prop (nth child 1)
+                     has-prop?  (map? maybe-prop)
+                     slot-path  (conj base-path k)
+                     tail       (if has-prop?
+                                  (when (>= (count child) 3) (nth child 2))
+                                  maybe-prop)
+                     acc        (if-let [d (and has-prop?
+                                                (decl-from-props flag-key maybe-prop))]
+                                  (assoc acc slot-path d)
+                                  acc)]
+                 (if (some? tail)
+                   (walk-flagged-schema flag-key tail slot-path acc)
+                   acc))))
+           acc'
+           children)
 
          (contains? dispatch-bearing-ops op)
-         (walk-multi-children (drop-op+props schema) base-path acc')
+         (reduce
+           (fn [acc child]
+             (if-not (vector? child)
+               acc
+               (let [maybe-prop (when (>= (count child) 2) (nth child 1))
+                     has-prop?  (map? maybe-prop)
+                     tail-idx   (if has-prop? 2 1)
+                     tail       (when (> (count child) tail-idx) (nth child tail-idx))
+                     acc        (if-let [d (and has-prop?
+                                                (decl-from-props flag-key maybe-prop))]
+                                  (assoc acc base-path d)
+                                  acc)]
+                 (if (some? tail)
+                   (walk-flagged-schema flag-key tail base-path acc)
+                   acc))))
+           acc'
+           children)
 
          :else
-         (walk-positional-children (drop-op+props schema) base-path acc')))
+         (reduce (fn [acc c] (walk-flagged-schema flag-key c base-path acc))
+                 acc'
+                 children)))
 
      ;; Anything else (schema object, fn schema, opaque leaf) —
      ;; not introspectable as data; skip.
@@ -560,168 +545,42 @@
 
 (defn extract-large-paths-from-schema
   "Walk a registered Malli schema form at `base-path` and return a
-  `{path declaration}` map for every `:large? true` slot found.
-  Convenience wrapper over `walk-schema` that seeds the empty
-  accumulator. Per Spec 009 §Size elision in traces — the
-  schema-driven nomination path.
+  `{path declaration}` map for every `:large? true` slot found. Per
+  Spec 009 §Size elision in traces — the schema-driven nomination path.
 
-  The returned declarations carry `:source :schema` per Spec 009 —
+  Returned declarations carry `:source :schema` per Spec 009 —
   introspection (`(get-in db [:rf/elision :declarations <path>])`)
   reports provenance so consumers know whether the elision claim
   came from the schema layer, an app fx, or the runtime auto-detect
   heuristic."
   [schema base-path]
-  (walk-schema schema base-path {}))
-
-;; ---- sensitive-declaration walker (rf2-kj51z) ----------------------------
-;;
-;; Parallel to the `:large?` walker above. Per Spec 010 §`:sensitive?`
-;; — privacy in schema-validation error traces (rf2-kj51z) and per
-;; Spec-Schemas §`:rf/app-schema-meta`, any Malli slot carrying
-;; `:sensitive? true` in its per-slot properties (or container-level
-;; props when the schema is registered at the path directly) declares
-;; that slot's value as sensitive. The schema-validation emit-site
-;; consults this walker on every failure to decide whether to redact
-;; the failing value before stamping the trace event.
-;;
-;; Implementation mirrors `extract-large-paths-from-schema` byte for
-;; byte — same structural recognition (`:map` name-bearing,
-;; `:multi`/`:orn`/`:catn`/`:altn` dispatch-bearing, positional
-;; combinators descend at the same base-path) so the two flags compose
-;; cleanly under the same Malli EDN shape.
-
-(defn- sensitive-declaration-from-props
-  "Build a `:rf/sensitive-declaration` map from a slot's per-slot props,
-  or nil if `:sensitive? true` is not set. Per Spec 010 §`:sensitive?`
-  and Spec 009 §Privacy — the declaration shape carries `:sensitive?
-  true`, `:source :schema`, plus an optional `:hint` propagated
-  verbatim from the slot's props (mirroring the `:large?` walker —
-  apps that want to attach context for a sensitive slot reuse the
-  same `:hint` key).
-
-  The `:source` slot is included so the unified registry write
-  (populate-sensitive-declarations below, plus the rf2-c1l4d follow-on
-  in re-frame.core) can apply the same conflict-resolution rule as
-  the `:large?` registry: app-declared sensitive paths beat schema-
-  derived ones, schema beats runtime-flagged (the latter is currently
-  unused for sensitivity but reserved for symmetry)."
-  [props]
-  (when (true? (:sensitive? props))
-    (cond-> {:sensitive? true
-             :source     :schema}
-      (some? (:hint props)) (assoc :hint (:hint props)))))
-
-(declare walk-sensitive-schema)
-
-(defn- walk-sensitive-map-children
-  [children base-path acc]
-  (reduce
-    (fn [acc child]
-      (if-not (and (vector? child) (>= (count child) 2))
-        acc
-        (let [k          (nth child 0)
-              maybe-prop (nth child 1)
-              has-prop?  (map? maybe-prop)
-              slot-props (when has-prop? maybe-prop)
-              child-tail (if has-prop?
-                           (when (>= (count child) 3) (nth child 2))
-                           maybe-prop)
-              slot-path  (conj base-path k)
-              slot-decl  (sensitive-declaration-from-props slot-props)
-              acc'       (if slot-decl
-                           (assoc acc slot-path slot-decl)
-                           acc)]
-          (if (some? child-tail)
-            (walk-sensitive-schema child-tail slot-path acc')
-            acc'))))
-    acc
-    children))
-
-(defn- walk-sensitive-multi-children
-  [children base-path acc]
-  (reduce
-    (fn [acc child]
-      (cond
-        (vector? child)
-        (let [maybe-prop  (when (>= (count child) 2) (nth child 1))
-              has-prop?   (map? maybe-prop)
-              tail-idx    (if has-prop? 2 1)
-              tail        (when (> (count child) tail-idx) (nth child tail-idx))
-              branch-decl (when has-prop? (sensitive-declaration-from-props maybe-prop))
-              acc'        (if branch-decl
-                            (assoc acc base-path branch-decl)
-                            acc)]
-          (if (some? tail) (walk-sensitive-schema tail base-path acc') acc'))
-        :else acc))
-    acc
-    children))
-
-(defn- walk-sensitive-positional-children
-  [children base-path acc]
-  (reduce (fn [acc c] (walk-sensitive-schema c base-path acc)) acc children))
-
-(defn walk-sensitive-schema
-  "Walk a Malli EDN schema form at `base-path`, populating `acc` with
-  `{path {:sensitive? true}}` entries for every `:sensitive? true`
-  slot found. Pure; same input always produces the same output.
-  Public so tools and validation emit-sites can re-use it.
-
-  Returns the accumulator map. Use `extract-sensitive-paths-from-schema`
-  for the seeded-empty-accumulator entry point."
-  ([schema base-path]
-   (walk-sensitive-schema schema base-path {}))
-  ([schema base-path acc]
-   (cond
-     (keyword? schema) acc
-
-     (schema-vector? schema)
-     (let [op    (nth schema 0)
-           props (extract-props schema)
-           acc'  (if-let [decl (sensitive-declaration-from-props props)]
-                   (assoc acc base-path decl)
-                   acc)]
-       (cond
-         (contains? name-bearing-ops op)
-         (walk-sensitive-map-children (drop-op+props schema) base-path acc')
-
-         (contains? dispatch-bearing-ops op)
-         (walk-sensitive-multi-children (drop-op+props schema) base-path acc')
-
-         :else
-         (walk-sensitive-positional-children (drop-op+props schema) base-path acc')))
-
-     :else acc)))
+  (walk-flagged-schema :large? schema base-path {}))
 
 (defn extract-sensitive-paths-from-schema
   "Walk a registered Malli schema form at `base-path` and return a
-  `{path {:sensitive? true}}` map for every `:sensitive? true` slot
-  found. Convenience wrapper over `walk-sensitive-schema` that seeds
-  the empty accumulator. Per Spec 010 §`:sensitive?` — privacy in
-  schema-validation error traces.
+  `{path {:sensitive? true ...}}` map for every `:sensitive? true` slot
+  found. Per Spec 010 §`:sensitive?` — privacy in schema-validation
+  error traces.
 
   Used by the validation emit-sites (`validate-app-db!` and the
-  per-step `validate-event!` / `validate-cofx!` /
-  `validate-sub-return!` helpers) to decide whether the failing slot's
-  value MUST be redacted before the trace event ships."
+  per-step `validate-event!` / `validate-cofx!` / `validate-sub-return!`
+  helpers) to decide whether the failing slot's value MUST be redacted
+  before the trace event ships."
   [schema base-path]
-  (walk-sensitive-schema schema base-path {}))
+  (walk-flagged-schema :sensitive? schema base-path {}))
 
 (defn schema-has-sensitive?
   "True when the registered schema declares ANY slot sensitive —
-  either:
+  either the schema's container-level props carry `:sensitive? true`,
+  or any nested `:sensitive? true` slot lives anywhere inside the
+  schema. Per Spec 010 §`:sensitive?` — privacy in schema-validation
+  error traces.
 
-    (a) the schema's container-level props carry `:sensitive? true`
-        (covers the whole registered slot); or
-    (b) any nested `:sensitive? true` slot lives anywhere inside the
-        schema.
-
-  Per Spec 010 §`:sensitive?` — privacy in schema-validation error
-  traces. The schema-validation emit-sites ship the WHOLE registered
-  slot's value (not just a failing leaf) in the trace's `:value` /
-  `:received` / `:explain` slots; a sensitive child slot still leaks
-  if the value rides verbatim. Conservative redaction — when any
-  slot in the schema is sensitive, the whole trace's value-bearing
-  slots are redacted.
+  The schema-validation emit-sites ship the WHOLE registered slot's
+  value (not just a failing leaf) in the trace's `:value` / `:received`
+  / `:explain` slots; a sensitive child slot still leaks if the value
+  rides verbatim. Conservative redaction — when any slot in the schema
+  is sensitive, the whole trace's value-bearing slots are redacted.
 
   Returns boolean. Pure; same input always produces the same output."
   [schema]
@@ -729,106 +588,53 @@
       seq
       boolean))
 
-;; ---- sensitive-declaration registry feeder (rf2-c1l4d) -------------------
+;; ---- per-flag registry feeders (rf2-v9tw2 / rf2-c1l4d) -------------------
 ;;
-;; Per the rf2-c1l4d follow-on: mirror the `:large?` walker's
-;; registry-population path for `:sensitive?`. The walker (above) is
-;; pure data; the framework hydrates a sibling slot in the unified
-;; elision registry — `app-db [:rf/elision :sensitive-declarations]`
-;; — at boot / on `reg-app-schema` re-registration so the schema-
-;; validation emit-site (and any future wire-boundary privacy walker)
-;; can consult one canonical map keyed by app-db path. Same shape,
-;; same idempotency, same conflict-resolution rule as the `:large?`
-;; sibling.
+;; Each `:rf/app-schema-meta` flag (`:large?`, `:sensitive?`) hydrates a
+;; sibling slot under `[:rf/elision]`:
 ;;
-;; Sibling slot rationale: `:declarations` already carries the
-;; `:large?` registry; `:sensitive-declarations` is the privacy
-;; sibling keyed by the same `[path → declaration]` map shape. Both
-;; live under the shared `[:rf/elision]` reserved root per Spec-
-;; Schemas §`:rf/elision-registry`. Two slots (not one merged map)
-;; because the two flags compose orthogonally — a slot may carry
-;; either or both, and the validation walker's composition rule
-;; (sensitive wins on the schema-validation emit site) reads both
-;; maps and resolves the conflict at emit time. Storing them
-;; separately keeps the per-flag query (`(get-in db [:rf/elision
-;; :sensitive-declarations <path>])`) O(1) without value-shape
-;; inspection.
+;;   :large?      → [:rf/elision :declarations]
+;;   :sensitive?  → [:rf/elision :sensitive-declarations]
+;;
+;; The `frame-*-declarations` fns aggregate per-flag declarations across
+;; every schema registered against a frame. The `populate-*` fns
+;; idempotently fold those declarations into a frame's app-db with the
+;; Spec 009 conflict-resolution rule applied: existing entries with
+;; `:source :declared` are preserved (declared beats schema); entries
+;; with `:source :schema` from a prior call are overwritten (hot-reload
+;; picks up `:hint` / flag flips); entries no longer claimed by any
+;; registered schema are NOT removed (a stale `:source :schema` entry
+;; persists until the next explicit clear).
+;;
+;; Both pairs are published via per-flag late-bind hooks at the bottom
+;; of this file so re-frame.core can call them without statically
+;; requiring the schemas artefact (per rf2-p7va — schemas is optional).
 
-(defn frame-sensitive-declarations
-  "Return the merged `{path declaration}` map for every `:sensitive? true`
-  slot in every app-schema registered against `frame-id`. Composes
-  `extract-sensitive-paths-from-schema` across the frame's schema set.
+(defn- frame-declarations
+  "Aggregate `extract-fn` across every schema registered against
+  `frame-id`, returning a `{path declaration}` map."
+  [extract-fn frame-id]
+  (reduce-kv
+    (fn [acc path m] (merge acc (extract-fn (:schema m) path)))
+    {}
+    (frame-schema-entries frame-id)))
 
-  Parallel to `frame-elision-declarations` (the `:large?` sibling).
-  This is the seam the framework's privacy-registry hydration (the
-  rf2-c1l4d follow-on in `re-frame.core`) reaches for at boot / on
-  hot reload — the schemas artefact owns the walker; the unified
-  registry write into `app-db [:rf/elision :sensitive-declarations]`
-  may live downstream once the rest of the privacy contract migrates
-  away from the schema-walked-per-emit model, OR may be invoked
-  directly via `populate-sensitive-declarations` below (the schemas
-  artefact ships both seams so the rf2-c1l4d landing site has a
-  choice — symmetry with `:large?`).
-
-  Each entry's value carries `:sensitive? true`, `:source :schema`,
-  and an optional `:hint` string when the slot's props declared one.
-
-  Per Spec 009 §Privacy / sensitive data in traces the conflict
-  resolution rule is: app-declared (via the privacy fx surface,
-  reserved for future use) beats schema, schema beats any future
-  runtime-flagged sensitivity. This fn returns ONLY the schema
-  layer; the downstream merger (populate-sensitive-declarations)
-  applies the conflict rule.
-
-  Arities:
-    (frame-sensitive-declarations)              ;; current frame
-    (frame-sensitive-declarations frame-id)     ;; explicit frame"
-  ([] (frame-sensitive-declarations (frame/current-frame)))
-  ([frame-id]
-   (reduce-kv
-     (fn [acc path m]
-       (merge acc (extract-sensitive-paths-from-schema (:schema m) path)))
-     {}
-     (frame-schema-entries frame-id))))
-
-(defn populate-sensitive-declarations
-  "Idempotent — given `db` (a frame's app-db) and a frame-id, return
-  `db` with `[:rf/elision :sensitive-declarations]` augmented by every
-  schema-derived sensitive-path declaration for that frame. Idempotent
-  in two senses:
-
-    1. Calling it twice in a row produces the same result the second
-       time (every schema-derived entry is the same map shape).
-    2. Existing entries with `:source :declared` (or any other
-       non-`:schema` source) are NEVER overwritten — the conflict
-       rule (declared beats schema) is preserved.
-
-  Existing entries with `:source :schema` from a prior call ARE
-  overwritten (so hot-reload of a schema picks up the new `:hint`
-  / `:sensitive?` flip). Entries no longer claimed by ANY registered
-  schema are NOT removed (a stale `:source :schema` slot for a path
-  whose schema dropped its `:sensitive?` flag persists until the
-  next explicit clear — symmetric with `populate-elision-declarations`
-  retention semantics).
-
-  Parallel to `populate-elision-declarations` (the `:large?` sibling).
-  Published via the `:schemas/populate-sensitive-declarations` late-
-  bind hook so re-frame.core can call it without statically requiring
-  the schemas artefact (per rf2-p7va — schemas is an optional dep)."
-  [db frame-id]
-  (let [schema-decls (frame-sensitive-declarations frame-id)]
+(defn- populate-declarations
+  "Idempotent — fold `frame-id`'s schema-derived declarations into `db`
+  at `registry-path`. Preserves `:source :declared` entries; overwrites
+  `:source :schema` entries. Returns `db` unchanged when the frame
+  carries no schema-derived declarations."
+  [db frame-id extract-fn registry-path]
+  (let [schema-decls (frame-declarations extract-fn frame-id)]
     (if (empty? schema-decls)
       db
-      (update-in db [:rf/elision :sensitive-declarations]
+      (update-in db registry-path
                  (fn [existing]
                    (reduce-kv
                      (fn [acc path decl]
-                       (let [existing-source (some-> (get acc path) :source)]
-                         (if (= existing-source :declared)
-                           ;; Preserve declared provenance — conflict
-                           ;; rule: declared beats schema.
-                           acc
-                           (assoc acc path decl))))
+                       (if (= :declared (some-> (get acc path) :source))
+                         acc
+                         (assoc acc path decl)))
                      (or existing {})
                      schema-decls))))))
 
@@ -837,70 +643,40 @@
   slot in every app-schema registered against `frame-id`. Composes
   `extract-large-paths-from-schema` across the frame's schema set.
 
-  This is the seam the framework's elision-registry hydration (per
-  rf2-v9tw2 in re-frame.core) reaches for at boot / on hot reload —
-  the schemas artefact owns the walker; the unified registry write
-  into `app-db [:rf/elision :declarations]` lives downstream so the
-  same write surface unifies schema / declared / runtime-flagged
-  sources.
-
-  Per Spec 009 §Conflict resolution rule, declared beats schema beats
-  runtime-flagged on the same path. This fn returns ONLY the schema
-  layer; the downstream merger applies the conflict rule.
-
   Arities:
     (frame-elision-declarations)              ;; current frame
     (frame-elision-declarations frame-id)     ;; explicit frame"
   ([] (frame-elision-declarations (frame/current-frame)))
-  ([frame-id]
-   (reduce-kv
-     (fn [acc path m]
-       (merge acc (extract-large-paths-from-schema (:schema m) path)))
-     {}
-     (frame-schema-entries frame-id))))
+  ([frame-id] (frame-declarations extract-large-paths-from-schema frame-id)))
 
 (defn populate-elision-declarations
-  "Idempotent — given `db` (a frame's app-db) and a frame-id, return
-  `db` with `[:rf/elision :declarations]` augmented by every
-  schema-derived large-path declaration for that frame. Idempotent
-  in two senses:
-
-    1. Calling it twice in a row produces the same result the second
-       time (every schema-derived entry is the same map shape).
-    2. Existing entries with `:source :declared` (or any other
-       non-`:schema` source) are NEVER overwritten — the conflict
-       rule (declared beats schema) is preserved.
-
-  Existing entries with `:source :schema` from a prior call ARE
-  overwritten (so hot-reload of a schema picks up the new `:hint`
-  / `:large?` flip). Entries no longer claimed by ANY registered
-  schema are NOT removed (a stale `:source :schema` slot for a path
-  whose schema dropped its `:large?` flag persists until the
-  next explicit `:rf.size/clear` — symmetric with `:rf.machines`
-  retention semantics; future work may add a sweep).
-
-  Per rf2-v9tw2 the actual call site lives in re-frame.core's
-  boot-time / reg-app-schema hook chain. This fn is published via
-  the `:schemas/populate-elision-declarations` late-bind hook so
-  re-frame.core can call it without statically requiring the
-  schemas artefact."
+  "Idempotent — fold the frame's schema-derived `:large?` declarations
+  into `db` at `[:rf/elision :declarations]`. See the per-flag registry-
+  feeder header above for the full conflict-resolution rule."
   [db frame-id]
-  (let [schema-decls (frame-elision-declarations frame-id)]
-    (if (empty? schema-decls)
-      db
-      (update-in db [:rf/elision :declarations]
-                 (fn [existing]
-                   (reduce-kv
-                     (fn [acc path decl]
-                       (let [existing-source (some-> (get acc path) :source)]
-                         (if (= existing-source :declared)
-                           ;; Preserve declared provenance — conflict
-                           ;; rule per Spec 009: declared beats schema.
-                           ;; Schema beats runtime-flagged (overwrite).
-                           acc
-                           (assoc acc path decl))))
-                     (or existing {})
-                     schema-decls))))))
+  (populate-declarations db frame-id
+                         extract-large-paths-from-schema
+                         [:rf/elision :declarations]))
+
+(defn frame-sensitive-declarations
+  "Return the merged `{path declaration}` map for every `:sensitive? true`
+  slot in every app-schema registered against `frame-id`. Composes
+  `extract-sensitive-paths-from-schema` across the frame's schema set.
+
+  Arities:
+    (frame-sensitive-declarations)              ;; current frame
+    (frame-sensitive-declarations frame-id)     ;; explicit frame"
+  ([] (frame-sensitive-declarations (frame/current-frame)))
+  ([frame-id] (frame-declarations extract-sensitive-paths-from-schema frame-id)))
+
+(defn populate-sensitive-declarations
+  "Idempotent — fold the frame's schema-derived `:sensitive?` declarations
+  into `db` at `[:rf/elision :sensitive-declarations]`. See the per-flag
+  registry-feeder header above for the full conflict-resolution rule."
+  [db frame-id]
+  (populate-declarations db frame-id
+                         extract-sensitive-paths-from-schema
+                         [:rf/elision :sensitive-declarations]))
 
 ;; ---- schema digest --------------------------------------------------------
 ;;


### PR DESCRIPTION
## Summary

The `:large?` walker (rf2-nwv63) and the `:sensitive?` walker (rf2-kj51z) in `implementation/schemas/src/re_frame/schemas.cljc` shared identical structural recognition (`:map` name-bearing, `:multi`/`:orn`/`:catn`/`:altn` dispatch-bearing, positional combinators descend at the same base-path) — the two walkers were byte-for-byte duplicates differing only in one predicate keyword.

This PR collapses them into a single parameterised `walk-flagged-schema` that accepts the per-slot flag key (`:large?` / `:sensitive?`) as a parameter. The per-flag entry points become one-line wrappers; the parallel `frame-*-declarations` / `populate-*-declarations` registry feeders are similarly collapsed behind a private `frame-declarations` + `populate-declarations` pair parameterised on the extract fn and the registry path.

Future per-slot annotations reserved under Spec-Schemas `:rf/app-schema-meta` now compose as one-line registrations against the same walker.

## LoC delta

- File: 1472 -> 1247 (-225 LoC overall)
- Walker section (the targeted region, lines ~362-833 before): ~472 LoC -> ~239 LoC (-233)
- Diff: +239 / -463 = net -224

## Surface preserved

All public APIs consumed externally (per repo-wide grep):

- `extract-large-paths-from-schema`
- `extract-sensitive-paths-from-schema`
- `schema-has-sensitive?`
- `frame-elision-declarations`, `populate-elision-declarations`
- `frame-sensitive-declarations`, `populate-sensitive-declarations`
- All per-flag late-bind hook registrations at the foot of the file

The multi-arity `walk-schema` / `walk-sensitive-schema` entry points (previously documented as public "so tools and the rf2-v9tw2 elision-walker can re-use it") are removed — no caller in `implementation/`, `tools/`, or tests referenced them; per the pre-alpha no-back-compat rule the convenience entry points (`walk-flagged-schema`) replace them.

## Test plan

- [x] `npm run test:cljs` — 1778 tests, 4937 assertions, 0 failures, 0 errors
- [x] `clojure -M:test` from `implementation/schemas/` — 116 tests, 310 assertions, 0 failures, 0 errors