### PR TITLE
fix(story): include :decorators + view schema-digest in snapshot identity (rf2-9g48l)

### DIFF
--- a/tools/story/src/re_frame/story/identity.cljc
+++ b/tools/story/src/re_frame/story/identity.cljc
@@ -4,22 +4,30 @@
 
   Every variant has a stable **snapshot identity** — a content hash
   over the canonicalised `(variant × resolved-args × decorators ×
-  loaders × substrate × modes)` tuple. Visual-regression services
-  key against `[variant-id content-hash]` — when the body changes,
-  the hash changes; when it doesn't, the hash is stable across hosts
-  and runs.
+  loaders × substrate × modes × view-schema-digest)` tuple. Visual-
+  regression services key against `[variant-id content-hash]` — when
+  the body changes, the hash changes; when it doesn't, the hash is
+  stable across hosts and runs.
 
   ## What's in the hash
 
-  Per IMPL-SPEC §5.6 the hash includes:
+  Per spec/007 §Variant snapshot identity (lines 424-429) the hash
+  includes:
 
   - Variant id
-  - `:events`, `:play`, `:loaders` (in declared order; canonicalised)
-  - Effective `:args` (post-merge with story + active modes)
-  - Decorator id sequence + their ref-args
-  - Tag set
+  - `:events` and `:play` event vectors (in order)
+  - `:loaders` (in declared order; canonicalised)
+  - Effective `:args` (post-`:extends`-merge with story + active modes)
+  - Variant `:decorators` id sequence + their ref-args
+  - Variant `:tags` set
   - Parent story `:component` id
   - Parent story `:decorators`
+  - Parent story `:tags`
+  - The *registered* schema digest of the view (per spec/011
+    §`:rf/schema-digest`) — sourced via the `:schemas/app-schemas-digest`
+    late-bind hook so a schema change invalidates the snapshot identity.
+    When the schemas artefact is absent from the classpath the digest is
+    nil and the slot still participates in the hash (nil is stable).
   - Active substrate (when computing per-substrate identity)
   - Active modes (when computing per-mode identity)
 
@@ -42,7 +50,8 @@
   the first slot of the hashed structure, so future canonical-form
   revisions can introduce `:rf/snapshot-canonical-v2` without breaking
   v1 baselines."
-  (:require [re-frame.story.args      :as args]
+  (:require [re-frame.late-bind       :as late-bind]
+            [re-frame.story.args      :as args]
             [re-frame.story.registrar :as registrar]))
 
 ;; ---- canonicalisation ----------------------------------------------------
@@ -142,13 +151,17 @@
 (defn- variant-body-slice
   "Return the slice of the variant body that contributes to the snapshot
   identity. Excludes runtime-environmental keys (`:source` coords) and
-  Stage 4+ slots that don't yet exist (kept for forward compatibility)."
+  Stage 4+ slots that don't yet exist (kept for forward compatibility).
+
+  Per spec/007 §Variant snapshot identity the variant-level `:decorators`
+  participate in the hash — watch-mode auto-rerun keys off this identity
+  so a decorator-only edit MUST perturb it."
   [variant-id]
   (let [body (registrar/handler-meta :variant variant-id)]
     (when body
       (select-keys body
                    [:events :play :loaders :loaders-complete-when
-                    :tags :args->events :platforms :substrates]))))
+                    :tags :decorators :args->events :platforms :substrates]))))
 
 (defn- story-body-slice
   "Story-level slice that the variant inherits for identity purposes.
@@ -159,6 +172,22 @@
         body     (when story-id (registrar/handler-meta :story story-id))]
     (when body
       (select-keys body [:component :decorators :tags]))))
+
+(defn- view-schema-digest
+  "Return the *registered* schema digest of the view per spec/007 §Variant
+  snapshot identity (lines 424-429) and spec/011 §`:rf/schema-digest`.
+
+  Sourced via the `:schemas/app-schemas-digest` late-bind hook so this
+  ns does not statically `:require` the schemas artefact — in builds
+  where schemas is absent from the classpath the lookup returns nil
+  and the digest slot still participates in the hash (nil is stable
+  across runs). When schemas IS present, registering a new app-schema
+  or mutating an existing one perturbs the digest and therefore the
+  variant snapshot identity — exactly the invalidation visual-regression
+  baselines need on schema changes."
+  []
+  (when-let [f (late-bind/get-fn :schemas/app-schemas-digest)]
+    (f)))
 
 (defn snapshot-tuple
   "Build the canonical tuple that feeds `content-hash` for a variant.
@@ -171,19 +200,26 @@
 
   The tuple captures everything the visual-regression service treats
   as identity-determining. A change to ANY of these fields produces a
-  fresh hash; otherwise the hash is stable across runs."
+  fresh hash; otherwise the hash is stable across runs.
+
+  Per spec/007 §Variant snapshot identity the tuple includes the view's
+  registered schema-digest — sourced via the `:schemas/app-schemas-digest`
+  late-bind hook — so a schema change on the view invalidates the
+  visual-regression baseline."
   ([variant-id] (snapshot-tuple variant-id nil))
   ([variant-id {:keys [active-modes cell-overrides substrate] :as _opts}]
    (let [variant      (variant-body-slice variant-id)
          story        (story-body-slice variant-id)
          effective    (args/resolve-args variant-id
                                          {:active-modes   active-modes
-                                          :cell-overrides cell-overrides})]
+                                          :cell-overrides cell-overrides})
+         schema-digest (view-schema-digest)]
      {:rf/snapshot-canonical :rf/snapshot-canonical-v1
       :variant-id            variant-id
       :variant               variant
       :story                 story
       :effective-args        effective
+      :view-schema-digest    schema-digest
       :active-modes          (vec (or active-modes []))
       :substrate             substrate})))
 

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -146,9 +146,12 @@
 (defn- compute-testable-content-hashes
   "Walk the registered testable variants and return a `{variant-id →
   hex-hash}` map of snapshot-identity content hashes. The hash captures
-  the variant's `:play` / `:events` / `:loaders` slots plus the parent
-  story's slice (per `re-frame.story.identity` §What's in the hash),
-  so a change to any of those produces a fresh hash."
+  the variant's `:play` / `:events` / `:loaders` / `:decorators` /
+  `:tags` slots plus the parent story's slice and the view's registered
+  schema-digest (per `re-frame.story.identity` §What's in the hash —
+  spec/007 §Variant snapshot identity), so a change to any of those —
+  including a decorator-only edit or a view schema change — produces a
+  fresh hash."
   []
   (let [testable (state/testable-variant-ids (:variants (state/registry-snapshot)))
         shell    (state/get-state)

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -24,6 +24,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core            :as rf]
             [re-frame.frame           :as frame]
+            [re-frame.late-bind       :as late-bind]
             [re-frame.machines        :as machines]
             [re-frame.registrar       :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -274,6 +275,78 @@
           hu (-> (story/snapshot-identity :story.id-sub/v {:substrate :uix})
                  :content-hash)]
       (is (not= hr hu)))))
+
+(deftest snapshot-identity-changes-with-variant-decorators
+  (testing "Per spec/007 §Variant snapshot identity (lines 424-429) — a
+            variant-level :decorators change MUST perturb the content-hash.
+            Closes rf2-9g48l: watch-mode auto-rerun keys off this identity,
+            so a decorator-only edit was silently dropped before this fix."
+    (story/reg-decorator :centered
+      {:kind :hiccup
+       :wrap (fn [body _args] [:div.centered body])})
+    (story/reg-decorator :boxed
+      {:kind :hiccup
+       :wrap (fn [body _args] [:div.boxed body])})
+    (story/reg-story :story.id-dec
+      {:component :app/v})
+    (story/reg-variant :story.id-dec/v
+      {:events     []
+       :decorators [[:centered]]})
+    (let [h1 (-> (story/snapshot-identity :story.id-dec/v) :content-hash)]
+      (story/reg-variant :story.id-dec/v
+        {:events     []
+         :decorators [[:boxed]]})
+      (let [h2 (-> (story/snapshot-identity :story.id-dec/v) :content-hash)]
+        (is (not= h1 h2)
+            "swapping the variant's decorator must produce a fresh hash"))
+      (testing "adding a decorator to a previously-decoratorless variant also perturbs the hash"
+        (story/reg-variant :story.id-dec/v
+          {:events     []
+           :decorators []})
+        (let [h-empty (-> (story/snapshot-identity :story.id-dec/v) :content-hash)]
+          (story/reg-variant :story.id-dec/v
+            {:events     []
+             :decorators [[:centered]]})
+          (let [h-with (-> (story/snapshot-identity :story.id-dec/v) :content-hash)]
+            (is (not= h-empty h-with)
+                "appending a decorator must produce a fresh hash")))))))
+
+(deftest snapshot-identity-changes-with-view-schema-digest
+  (testing "Per spec/007 §Variant snapshot identity (line 429) — the
+            *registered* schema digest of the view (per spec/011
+            §:rf/schema-digest) participates in the hash. A schema change
+            on the view MUST invalidate the snapshot identity (and the
+            visual-regression baseline keyed off it). Closes rf2-9g48l:
+            the digest is sourced via the `:schemas/app-schemas-digest`
+            late-bind hook so identity.cljc does NOT statically :require
+            the schemas artefact."
+    (story/reg-story :story.id-sd
+      {:component :app/v})
+    (story/reg-variant :story.id-sd/v {:events []})
+    (let [prior (late-bind/get-fn :schemas/app-schemas-digest)]
+      (try
+        ;; Simulate a registered schema by installing a hook with a
+        ;; fixed digest value.
+        (late-bind/set-fn! :schemas/app-schemas-digest
+                           (fn [] "sha256:0000000000000001"))
+        (let [h1 (-> (story/snapshot-identity :story.id-sd/v) :content-hash)]
+          ;; Now simulate a schema change by mutating the hook's
+          ;; return value. The framework actually re-installs the hook
+          ;; each time schemas mutate; we model that here.
+          (late-bind/set-fn! :schemas/app-schemas-digest
+                             (fn [] "sha256:0000000000000002"))
+          (let [h2 (-> (story/snapshot-identity :story.id-sd/v) :content-hash)]
+            (is (not= h1 h2)
+                "a view schema-digest change must produce a fresh hash")))
+        (testing "when the schemas artefact is absent (no hook registered),
+                  the digest slot is nil and the hash is still stable"
+          (late-bind/set-fn! :schemas/app-schemas-digest nil)
+          (let [a (-> (story/snapshot-identity :story.id-sd/v) :content-hash)
+                b (-> (story/snapshot-identity :story.id-sd/v) :content-hash)]
+            (is (= a b)
+                "absent-hook path must be deterministic across calls")))
+        (finally
+          (late-bind/set-fn! :schemas/app-schemas-digest prior))))))
 
 (deftest snapshot-identity-canonical-key-stable
   (testing "the canonical-form key :rf/snapshot-canonical-v1 is included"


### PR DESCRIPTION
## Summary

Closes the P0 snapshot-identity drift surfaced by audit rf2-dd5ze. Per spec/007-Stories.md:424-429 the variant snapshot-identity hash MUST include the variant's `:decorators` slot and the view's *registered* schema-digest. The pre-fix `variant-body-slice` in `tools/story/src/re_frame/story/identity.cljc` selected only `[:events :play :loaders :loaders-complete-when :tags :args->events :platforms :substrates]` — `:decorators` was missing — and the view's schema-digest was never consulted at all.

Two silent correctness bugs were the consequence:

1. **Watch-mode auto-rerun missed decorator-only edits** — `tools/story/src/re_frame/story/ui/shell.cljs/compute-testable-content-hashes` keys watch-mode rerun off the snapshot identity, so a developer editing a `:hiccup` decorator that controls layout saw no re-run.
2. **Visual-regression keys returned stale baselines after a view-schema change** — `[variant-id content-hash]` lookups hit the prior baseline when the view's schema mutated.

## Changes

- `identity.cljc`
  - `variant-body-slice` now includes `:decorators`.
  - New private `view-schema-digest` looks up the digest via the `:schemas/app-schemas-digest` late-bind hook (the slot rf2-69ad2 just landed). `identity.cljc` does NOT statically `:require` the schemas artefact — when schemas is absent from the classpath the digest is nil and the slot still participates in the hash (nil is stable across runs).
  - `snapshot-tuple` adds a `:view-schema-digest` slot.
  - Ns docstring updated to match spec/007 §Variant snapshot identity verbatim.
- `shell.cljs`
  - `compute-testable-content-hashes` docstring updated to reflect the corrected hash inputs.
- `story_runtime_test.clj`
  - `snapshot-identity-changes-with-variant-decorators` — swapping a variant's decorator and adding a decorator each perturb the hash.
  - `snapshot-identity-changes-with-view-schema-digest` — mutating the `:schemas/app-schemas-digest` hook's return value perturbs the hash; absent-hook path is deterministic.

## Spec citations

- `spec/007-Stories.md:424-429` — the canonical list of hash inputs.
- `spec/011-SSR.md` — `:rf/schema-digest` (the late-bind hook landed in rf2-69ad2).

## Pre-alpha rule

No back-compat surface — the hash domain expands; any pre-existing baseline keyed off a content-hash will mismatch on next compute (which is the correct invalidation for the bug being fixed).

## Test plan

- [x] `clojure -M:test` from `tools/story/` — 326 tests, 969 assertions, 0 failures, 0 errors.
- [x] Targeted `clojure -M:test -n re-frame.story-runtime-test` — 35 tests, 87 assertions (added 2 tests, 4 assertions).