### PR TITLE
feat(story-mcp): wire token-budget cap at invoke-tool egress (rf2-zavp5)

### DIFF
--- a/spec/Cross-Cutting-Designs.md
+++ b/spec/Cross-Cutting-Designs.md
@@ -54,7 +54,7 @@ This doc is an **inventory**, not a redefinition. Every entry below cites an own
 **Consumers.**
 - `tools/pair2-mcp/` — enforces the cap in `tools.cljs` at the `invoke` boundary; ten tools each declare their typical-token hint and cap-reached behaviour in their tool spec.
 - `tools/causa-mcp/` (planned impl) — adopts the same cap, the same override slot, the same overflow shape per its Principles lock #1.
-- `tools/story-mcp/` — exception: its surface is JVM-side; the cap mechanism is not yet ported but the per-tool budget discipline carries.
+- `tools/story-mcp/` — enforces the cap in `tools.cljc` at the `invoke-tool` egress (rf2-zavp5); seventeen tools each declare their typical-token hint and inherit the `:max-tokens` per-call override.
 
 **The result.** Cross-MCP, the token-cap shape is one decision applied uniformly. New MCP tools land against the catalogued cap (5K default), the catalogued override slot (`:max-tokens` per-call, `0` to disable), and the catalogued overflow marker shape (`{:rf.mcp/overflow {:limit :reached :token-count … :cap-tokens … :tool … :hint …}}`). The mechanisms above the cap (path slicing, lazy summary, dedup, pagination) shape the response so the cap rarely trips; the cap stays the backstop.
 

--- a/tools/story-mcp/src/re_frame/story_mcp/tools.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools.cljc
@@ -37,6 +37,7 @@
   (:require [clojure.edn :as edn]
             [clojure.set :as set]
             [clojure.string :as str]
+            [re-frame.mcp-base.overflow :as overflow]
             [re-frame.story :as story]
             [re-frame.story.assertions :as assertions]
             [re-frame.story.async :as async]
@@ -687,6 +688,20 @@
   {:type "string"
    :description "A Clojure keyword id, as a string. Either `:story.foo/bar` or `story.foo/bar` is accepted."})
 
+(def ^:private max-tokens-schema
+  "Recurring JSON-schema fragment — every tool accepts a per-call
+  `:max-tokens` override of the wire-boundary cap (rf2-rvyzy /
+  rf2-zavp5). `0` disables the cap; default is
+  `re-frame.mcp-base.overflow/default-max-tokens` (5000)."
+  {:type "integer" :minimum 0
+   :description "Per-call wire-boundary token cap. 0 disables; default 5000 (per `spec/Cross-Cutting-Designs.md §3`)."})
+
+(defn- with-max-tokens
+  "Inject the `:max-tokens` slot into a tool's `:properties` map. Every
+  tool inherits the slot so the cap is uniformly overrideable per call."
+  [props]
+  (assoc props :max-tokens max-tokens-schema))
+
 (def tool-registry
   "The full tool registry. Order matters for `tools/list` output —
   agents tend to scan top-to-bottom — so we list categories in the
@@ -696,7 +711,7 @@
     :category       :dev
     :description    "Return Story's authoring conventions in agent-friendly form (the seven reg-* macros, hard rules, lifecycle, snapshots)."
     :typicalTokens  1500
-    :inputSchema    {:type "object" :properties {} :additionalProperties false}
+    :inputSchema    {:type "object" :properties (with-max-tokens {}) :additionalProperties false}
     :handler        tool-get-story-instructions}
 
    {:name           "preview-variant"
@@ -704,12 +719,13 @@
     :description    "Given a variant id, return the canvas state (app-db, assertions, rendered-hiccup, elapsed) + a sharable URL."
     :typicalTokens  2000
     :inputSchema {:type "object"
-                  :properties {:variant-id kw-or-string
-                               :substrate kw-or-string
-                               :active-modes {:type "array" :items kw-or-string}
-                               :cell-overrides {:type "object"}
-                               :base-url {:type "string"
-                                          :description "Optional base URL for the share link (no default)."}}
+                  :properties (with-max-tokens
+                                {:variant-id kw-or-string
+                                 :substrate kw-or-string
+                                 :active-modes {:type "array" :items kw-or-string}
+                                 :cell-overrides {:type "object"}
+                                 :base-url {:type "string"
+                                            :description "Optional base URL for the share link (no default)."}})
                   :required ["variant-id"]
                   :additionalProperties false}
     :handler     tool-preview-variant}
@@ -718,7 +734,7 @@
     :category       :dev
     :description    "What substrates can be used. Returns the set registered via `register-substrate!` (Reagent is canonical; UIx / Helix opt-in per host)."
     :typicalTokens  100
-    :inputSchema    {:type "object" :properties {} :additionalProperties false}
+    :inputSchema    {:type "object" :properties (with-max-tokens {}) :additionalProperties false}
     :handler        tool-list-substrates}
 
    ;; ---- Docs ------------------------------------------------------------
@@ -727,8 +743,9 @@
     :description    "All registered stories, optionally filtered by tags. Each entry carries id, doc, tags, and child variant ids."
     :typicalTokens  1500
     :inputSchema {:type "object"
-                  :properties {:tags {:type "array" :items kw-or-string
-                                      :description "Optional tag filter; story `:tags` set must intersect."}}
+                  :properties (with-max-tokens
+                                {:tags {:type "array" :items kw-or-string
+                                        :description "Optional tag filter; story `:tags` set must intersect."}})
                   :additionalProperties false}
     :handler     tool-list-stories}
 
@@ -737,7 +754,7 @@
     :description    "Return one story's full body (`:doc`, `:component`, `:decorators`, `:args`, ... + its variant ids)."
     :typicalTokens  1500
     :inputSchema {:type "object"
-                  :properties {:story-id kw-or-string}
+                  :properties (with-max-tokens {:story-id kw-or-string})
                   :required ["story-id"]
                   :additionalProperties false}
     :handler     tool-get-story}
@@ -747,7 +764,7 @@
     :description    "Return one variant's full body (the resolved EDN, with `:extends` already applied at registration time)."
     :typicalTokens  1000
     :inputSchema {:type "object"
-                  :properties {:variant-id kw-or-string}
+                  :properties (with-max-tokens {:variant-id kw-or-string})
                   :required ["variant-id"]
                   :additionalProperties false}
     :handler     tool-get-variant}
@@ -756,21 +773,21 @@
     :category       :docs
     :description    "Canonical tags (`:dev :docs :test :screenshot :experimental :internal :agent`) + any custom tags registered by the project."
     :typicalTokens  100
-    :inputSchema    {:type "object" :properties {} :additionalProperties false}
+    :inputSchema    {:type "object" :properties (with-max-tokens {}) :additionalProperties false}
     :handler        tool-list-tags}
 
    {:name           "list-modes"
     :category       :docs
     :description    "Registered modes (Chromatic-style saved tuples of args). Each entry is `{:id :doc :args}`."
     :typicalTokens  200
-    :inputSchema    {:type "object" :properties {} :additionalProperties false}
+    :inputSchema    {:type "object" :properties (with-max-tokens {}) :additionalProperties false}
     :handler        tool-list-modes}
 
    {:name           "list-assertions"
     :category       :docs
     :description    "The seven canonical `:rf.assert/*` events with payload arity + semantics, plus any project-registered assertion ids."
     :typicalTokens  500
-    :inputSchema    {:type "object" :properties {} :additionalProperties false}
+    :inputSchema    {:type "object" :properties (with-max-tokens {}) :additionalProperties false}
     :handler        tool-list-assertions}
 
    {:name           "variant->edn"
@@ -778,7 +795,7 @@
     :description    "Round-trippable EDN of a registered variant. Text result only (no structuredContent); use this when you want byte-stable EDN."
     :typicalTokens  1000
     :inputSchema {:type "object"
-                  :properties {:variant-id kw-or-string}
+                  :properties (with-max-tokens {:variant-id kw-or-string})
                   :required ["variant-id"]
                   :additionalProperties false}
     :handler     tool-variant->edn}
@@ -789,12 +806,13 @@
     :description    "Execute a variant's four-phase lifecycle (loaders → events → render → play); return the result map (`:frame :app-db :assertions :rendered-hiccup :elapsed-ms :passing?`)."
     :typicalTokens  2000
     :inputSchema {:type "object"
-                  :properties {:variant-id kw-or-string
-                               :substrate kw-or-string
-                               :active-modes {:type "array" :items kw-or-string}
-                               :cell-overrides {:type "object"}
-                               :timeout-ms {:type "integer" :minimum 1
-                                            :description "JVM blocking timeout. Default 10000."}}
+                  :properties (with-max-tokens
+                                {:variant-id kw-or-string
+                                 :substrate kw-or-string
+                                 :active-modes {:type "array" :items kw-or-string}
+                                 :cell-overrides {:type "object"}
+                                 :timeout-ms {:type "integer" :minimum 1
+                                              :description "JVM blocking timeout. Default 10000."}})
                   :required ["variant-id"]
                   :additionalProperties false}
     :handler     tool-run-variant}
@@ -804,9 +822,10 @@
     :description    "Content-hash of (variant × resolved args × decorators × loaders × substrate × modes). Stable across hosts; key for visual-regression."
     :typicalTokens  100
     :inputSchema {:type "object"
-                  :properties {:variant-id kw-or-string
-                               :substrate kw-or-string
-                               :active-modes {:type "array" :items kw-or-string}}
+                  :properties (with-max-tokens
+                                {:variant-id kw-or-string
+                                 :substrate kw-or-string
+                                 :active-modes {:type "array" :items kw-or-string}})
                   :required ["variant-id"]
                   :additionalProperties false}
     :handler     tool-snapshot-identity}
@@ -816,7 +835,7 @@
     :description    "Read axe-core violations for a variant from `re-frame.story.ui.a11y/violations-by-frame`. The actual axe-core run is CLJS-only; this tool returns whatever the in-browser panel has accumulated."
     :typicalTokens  500
     :inputSchema {:type "object"
-                  :properties {:variant-id kw-or-string}
+                  :properties (with-max-tokens {:variant-id kw-or-string})
                   :required ["variant-id"]
                   :additionalProperties false}
     :handler     tool-run-a11y}
@@ -826,7 +845,7 @@
     :description    "Accumulated assertion failures for a variant frame (since the most recent `run-variant`). Returns `{:total :failures :passing?}`."
     :typicalTokens  500
     :inputSchema {:type "object"
-                  :properties {:variant-id kw-or-string}
+                  :properties (with-max-tokens {:variant-id kw-or-string})
                   :required ["variant-id"]
                   :additionalProperties false}
     :handler     tool-read-failures}
@@ -837,10 +856,11 @@
     :description    "Register a variant programmatically. GATED behind `:rf.story-mcp/allow-writes?` (default false). Enables the self-healing loop: write story → run → read failures → fix."
     :typicalTokens  100
     :inputSchema {:type "object"
-                  :properties {:variant-id kw-or-string
-                               :body {:oneOf [{:type "object"}
-                                              {:type "string"
-                                               :description "EDN-encoded variant body, parsed via clojure.edn/read-string."}]}}
+                  :properties (with-max-tokens
+                                {:variant-id kw-or-string
+                                 :body {:oneOf [{:type "object"}
+                                                {:type "string"
+                                                 :description "EDN-encoded variant body, parsed via clojure.edn/read-string."}]}})
                   :required ["variant-id" "body"]
                   :additionalProperties false}
     :handler     tool-register-variant}
@@ -850,7 +870,7 @@
     :description    "Unregister a variant. GATED behind `:rf.story-mcp/allow-writes?` (default false). Symmetric to `register-variant`."
     :typicalTokens  100
     :inputSchema {:type "object"
-                  :properties {:variant-id kw-or-string}
+                  :properties (with-max-tokens {:variant-id kw-or-string})
                   :required ["variant-id"]
                   :additionalProperties false}
     :handler     tool-unregister-variant}
@@ -860,19 +880,20 @@
     :description    "Bridge the recorder's start → capture → snippet pipeline across the MCP boundary. Starts a recording against the source variant's frame, blocks for `:duration-ms`, stops, returns the `(reg-variant ...)` snippet `gen-play-snippet` emits. Optional `:write-back?` re-registers the variant with the captured `:play` slot — GATED behind `:rf.story-mcp/allow-writes?` (same gate as `register-variant`)."
     :typicalTokens  1500
     :inputSchema {:type "object"
-                  :properties {:variant-id     kw-or-string
-                               :duration-ms    {:type "integer" :minimum 0
-                                                :description "Milliseconds to block between start and stop. Default 0. JVM-only (CLJS hosts no-op)."}
-                               :new-variant-id (assoc kw-or-string
-                                                 :description "When `:write-back?` is true, register the captured `:play` body under this id. Defaults to the source `:variant-id` (overwrites in place).")
-                               :doc            {:type "string"
-                                                :description "Optional docstring embedded in the rendered snippet."}
-                               :extends        (assoc kw-or-string
-                                                 :description "Variant id embedded as `:extends` in the snippet. Defaults to the source `:variant-id`.")
-                               :alias          {:type "string"
-                                                :description "Short ns alias for the rendered form (default \"story\")."}
-                               :write-back?    {:type "boolean"
-                                                :description "When true, also re-register the variant with the captured `:play`. Requires `allow-writes?`."}}
+                  :properties (with-max-tokens
+                                {:variant-id     kw-or-string
+                                 :duration-ms    {:type "integer" :minimum 0
+                                                  :description "Milliseconds to block between start and stop. Default 0. JVM-only (CLJS hosts no-op)."}
+                                 :new-variant-id (assoc kw-or-string
+                                                   :description "When `:write-back?` is true, register the captured `:play` body under this id. Defaults to the source `:variant-id` (overwrites in place).")
+                                 :doc            {:type "string"
+                                                  :description "Optional docstring embedded in the rendered snippet."}
+                                 :extends        (assoc kw-or-string
+                                                   :description "Variant id embedded as `:extends` in the snippet. Defaults to the source `:variant-id`.")
+                                 :alias          {:type "string"
+                                                  :description "Short ns alias for the rendered form (default \"story\")."}
+                                 :write-back?    {:type "boolean"
+                                                  :description "When true, also re-register the variant with the captured `:play`. Requires `allow-writes?`."}})
                   :required ["variant-id"]
                   :additionalProperties false}
     :handler     tool-record-as-variant}])
@@ -902,21 +923,133 @@
   [tool-name]
   (some (fn [t] (when (= tool-name (:name t)) t)) tool-registry))
 
+;; ---------------------------------------------------------------------------
+;; Wire-boundary token-budget cap (rf2-rvyzy / rf2-zavp5).
+;;
+;; Per `spec/Cross-Cutting-Designs.md §3 Token budgets` every MCP
+;; `tools/call` response is bounded at ~5,000 tokens by default. The cap
+;; is enforced HERE (at the wire egress, after the handler runs), not in
+;; each handler — that keeps tool bodies free of token-accounting noise
+;; and pins one cross-MCP shape. When the serialised response would
+;; exceed the cap, the payload is replaced with a structured
+;; `{:rf.mcp/overflow {...}}` marker emitted via
+;; `re-frame.mcp-base.overflow/overflow-payload`.
+;;
+;; Sized via `overflow/token-estimate` (the `(quot (count s) 4)` rule
+;; aligned with Anthropic's character→token rule-of-thumb). The cap is
+;; cumulative across every `:text` slot in the response's `:content`
+;; vector (multi-part responses share one budget, mirroring pair2-mcp).
+;;
+;; `:max-tokens` per-call override is read from `arguments`: integer
+;; cap, `0` disables (escape hatch when the caller has already
+;; paginated), absent ⇒ default. Lives on every tool's input schema
+;; via `with-max-tokens`.
+;; ---------------------------------------------------------------------------
+
+(def ^:private overflow-hints
+  "Tool-specific next-step hints for the overflow marker. Generic
+  fallback (from `mcp-base.overflow`) when a tool isn't listed.
+
+  Mirrors pair2-mcp's local hint table — the hint is the agent's
+  shortest path back into budget."
+  {"preview-variant"   "Tighten scope: drop `:cell-overrides` or pass a smaller `:active-modes`. The :app-db / :rendered-hiccup slots dominate; raise `max-tokens` (0 disables) if the full payload is genuinely needed."
+   "run-variant"       "Tighten scope: pass `:cell-overrides` to shrink the run, or omit `:active-modes`. The :app-db / :rendered-hiccup slots dominate; raise `max-tokens` (0 disables) if the full payload is genuinely needed."
+   "get-story"         "Story body is large — request `list-stories` for a slimmer overview, or raise `max-tokens` (0 disables)."
+   "get-variant"       "Variant body is large — request `variant->edn` if you want EDN-only, or raise `max-tokens` (0 disables)."
+   "variant->edn"      "Variant EDN body is large — narrow the variant or raise `max-tokens` (0 disables)."
+   "list-stories"      "Story registry is large — narrow with `:tags`, or raise `max-tokens` (0 disables)."
+   "read-failures"     "Failure log is large — assertions accumulator may be deep; clear with a fresh `run-variant`, or raise `max-tokens` (0 disables)."
+   "record-as-variant" "Captured event stream is large — shorten `:duration-ms`, or raise `max-tokens` (0 disables)."})
+
+(defn- max-tokens-arg
+  "Resolve the per-call cap from MCP arguments. Returns an integer cap
+  in tokens, or `nil` when the cap is disabled (`:max-tokens 0`).
+  Defaults to `overflow/default-max-tokens` when absent or not a number."
+  [arguments]
+  (let [raw (get arguments :max-tokens)]
+    (cond
+      (nil? raw)                  overflow/default-max-tokens
+      (and (integer? raw) (zero? raw)) nil
+      (integer? raw)              raw
+      :else                       overflow/default-max-tokens)))
+
+(defn- sum-text-tokens
+  "Sum `token-estimate` across every `:text` slot in the
+  `{:content [{:type \"text\" :text ...} ...]}` result. The serialised
+  response's wire size is dominated by these slots; the JSON envelope
+  is bounded and ignored."
+  [result]
+  (transduce (comp (map :text)
+                   (filter string?)
+                   (map overflow/token-estimate))
+             +
+             0
+             (:content result)))
+
+(defn- overflow-result
+  "Build a fresh result carrying the overflow marker, mirroring
+  pair2-mcp's `overflow-result`. Drops the over-budget payload entirely
+  and emits the structured marker as the sole `:text` slot.
+
+  The overflow marker is itself the response — `:isError` is NOT set
+  (an over-budget success is a signal to retry with narrower args, not
+  a tool-execution failure)."
+  [tool-name token-count cap]
+  (let [marker (overflow/overflow-payload
+                 {:tool        tool-name
+                  :token-count token-count
+                  :cap         cap
+                  :hint        (get overflow-hints tool-name)})]
+    {:content          [{:type "text" :text (pr-edn marker)}]
+     :structuredContent marker}))
+
+(defn- apply-cap
+  "Wire-boundary cap enforcement. Returns either `result` unchanged
+  (under the cap, or cap disabled via `:max-tokens 0`) or a fresh
+  result carrying the overflow marker.
+
+  Cap is cumulative across every `:text` slot in `:content`. Mirrors
+  pair2-mcp's `apply-cap` — the same `:truncate-with-marker` strategy
+  is the only one wired today; future strategies (path-slicing, lazy
+  summary) slot in here without touching tool bodies."
+  [result tool-name cap]
+  (cond
+    (nil? cap)        result
+    (nil? result)     result
+    :else
+    (let [tokens (sum-text-tokens result)]
+      (if (<= tokens cap)
+        result
+        (overflow-result tool-name tokens cap)))))
+
 (defn invoke-tool
   "Invoke `tool-name` with `arguments` (a map of keyword-keyed args).
   Returns the tool's result map, or nil if no such tool. The caller
   serialises the result into a `tools/call` JSON-RPC response.
 
+  ## Wire-boundary pipeline
+
+  1. Dispatch the handler with `arguments`.
+  2. `apply-cap` (rf2-rvyzy / rf2-zavp5) — when the serialised response
+     exceeds the per-call cap (`:max-tokens` arg, default
+     `overflow/default-max-tokens`, `0` disables), the payload is
+     replaced with a structured `{:rf.mcp/overflow ...}` marker. Per
+     `spec/Cross-Cutting-Designs.md §3 Token budgets`.
+
   Catches any throw from the handler and returns it as a tool-execution
   error (`isError: true`) per MCP §Error Handling — handlers SHOULD
   return error-results themselves, but this is the belt-and-braces
-  catch."
+  catch. The cap applies to error results too (large `:data` slots in
+  an `ex-data` blow-up shouldn't bypass the budget)."
   [tool-name arguments]
   (when-let [t (tool-by-name tool-name)]
-    (try
-      ((:handler t) (or arguments {}))
-      (catch Throwable e
-        (error-result (str "Tool handler threw: " (ex-message e))
-                      {:tool      tool-name
-                       :exception (.getName (class e))
-                       :data      (ex-data e)})))))
+    (let [args   (or arguments {})
+          cap    (max-tokens-arg args)
+          result (try
+                   ((:handler t) args)
+                   (catch Throwable e
+                     (error-result (str "Tool handler threw: " (ex-message e))
+                                   {:tool      tool-name
+                                    :exception (.getName (class e))
+                                    :data      (ex-data e)})))]
+      (apply-cap result tool-name cap))))

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -6,8 +6,11 @@
   registrar carries the seven canonical tags + the lifecycle machine,
   then register a small fixture story + variant so each tool has
   something to read."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.edn :as edn]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.mcp-base.overflow :as overflow]
+            [re-frame.mcp-base.vocab :as vocab]
             [re-frame.story :as story]
             [re-frame.story.recorder :as recorder]
             [re-frame.story-mcp.config :as config]
@@ -707,3 +710,74 @@
   (testing "--allow-writes flips the gate"
     (let [cfg (#'server/parse-args ["--allow-writes"])]
       (is (true? (:allow-writes? cfg))))))
+
+;; ---------------------------------------------------------------------------
+;; Wire-boundary token-budget cap (rf2-rvyzy / rf2-zavp5).
+;;
+;; The cap is applied at `invoke-tool` egress — the cumulative
+;; `:text`-slot byte count is compared against `:max-tokens` (default
+;; `overflow/default-max-tokens`; `0` disables). Over-budget responses
+;; are replaced with `{:rf.mcp/overflow {...}}` per the cross-MCP shape
+;; pinned in `re-frame.mcp-base.overflow/overflow-payload`.
+;; ---------------------------------------------------------------------------
+
+(defn- overflow-marker?
+  "Does `result` carry the `{:rf.mcp/overflow {:limit :reached ...}}`
+  marker shape? Both the structured-content and the text slot should
+  reflect it. The text slot prints via `pr-str` which renders the
+  namespaced key as the `#:rf.mcp{:overflow ...}` namespace-map form
+  (round-trippable EDN); `read-string`-ing it round-trips to the same
+  key. We check the structured shape and that the text slot is the
+  round-trippable EDN form."
+  [result]
+  (and (map? result)
+       (= :reached (get-in result [:structuredContent vocab/overflow-key :limit]))
+       (string? (-> result :content first :text))
+       (let [round-tripped (try (edn/read-string
+                                  (-> result :content first :text))
+                                (catch Throwable _ nil))]
+         (= :reached (get-in round-tripped [vocab/overflow-key :limit])))))
+
+(deftest cap-fires-when-response-exceeds-budget
+  (testing "get-story-instructions response is large enough to exceed a 1-token cap"
+    (let [r (tools/invoke-tool "get-story-instructions" {:max-tokens 1})]
+      (is (overflow-marker? r))
+      (let [body (get-in r [:structuredContent vocab/overflow-key])]
+        (is (= 1 (:cap-tokens body)))
+        (is (= "get-story-instructions" (:tool body)))
+        (is (pos? (:token-count body)))
+        (is (string? (:hint body)))))))
+
+(deftest cap-zero-disables-the-cap
+  (testing "`:max-tokens 0` bypasses the cap; the full payload returns intact"
+    (let [r (tools/invoke-tool "get-story-instructions" {:max-tokens 0})]
+      (is (not (overflow-marker? r)))
+      (is (clojure.string/includes? (-> r :content first :text)
+                                    "re-frame2-story authoring conventions"))))
+  (testing "default cap (no `:max-tokens` arg) leaves a small response intact"
+    (let [r (tools/invoke-tool "list-tags" {})]
+      (is (not (overflow-marker? r))))))
+
+(deftest cap-honours-default-when-omitted
+  (testing "absent `:max-tokens` falls back to `overflow/default-max-tokens` (5000)"
+    ;; A tiny payload like `list-tags` is well under 5K tokens; verify
+    ;; the cap does not trip on routine reads.
+    (let [r (tools/invoke-tool "list-tags" {})
+          tokens (#'tools/sum-text-tokens r)]
+      (is (not (overflow-marker? r)))
+      (is (< tokens overflow/default-max-tokens)))))
+
+(deftest cap-marker-shape-is-mcp-base-overflow
+  (testing "marker is byte-identical to mcp-base/overflow-payload's shape"
+    (let [r (tools/invoke-tool "get-story-instructions" {:max-tokens 1})
+          body (get-in r [:structuredContent vocab/overflow-key])]
+      (is (= #{:limit :token-count :cap-tokens :tool :hint}
+             (set (keys body)))))))
+
+(deftest every-tool-schema-accepts-max-tokens
+  (testing "every tool's input schema carries the `:max-tokens` slot"
+    (doseq [t tools/tool-registry]
+      (is (contains? (-> t :inputSchema :properties) :max-tokens)
+          (str "tool " (:name t) " missing :max-tokens slot"))
+      (is (= "integer" (-> t :inputSchema :properties :max-tokens :type))
+          (str "tool " (:name t) " :max-tokens slot is not integer-typed")))))


### PR DESCRIPTION
## Summary

Closes the catalogued gap in `spec/Cross-Cutting-Designs.md §3` — story-mcp was the cross-MCP exception (\"the cap mechanism is not yet ported but the per-tool budget discipline carries\"). Now it isn't.

- Wire `apply-cap` at `invoke-tool` egress (cumulative `:text`-slot token count → `{:rf.mcp/overflow {...}}` on over-budget, via `re-frame.mcp-base.overflow/overflow-payload`).
- Add `:max-tokens` per-call arg on every tool's input schema (default 5000; `0` disables). Threaded via a `with-max-tokens` helper so all 17 tools inherit the slot.
- Per-tool overflow hints mirror pair2-mcp's approach.
- Spec line 57 amended — story-mcp is no longer the exception.

## Test plan

- [x] `clojure -M:test` from `tools/story-mcp/` — 88 tests / 438 assertions pass.
- [x] New `cap-fires-when-response-exceeds-budget` test demonstrates the cap fires for a small `:max-tokens 1` against `get-story-instructions`.
- [x] New `cap-zero-disables-the-cap` test demonstrates `:max-tokens 0` bypasses.
- [x] New `cap-marker-shape-is-mcp-base-overflow` test pins the wire shape byte-identical to mcp-base's `overflow-payload`.
- [x] New `every-tool-schema-accepts-max-tokens` test enforces the slot on every tool's input schema.
- [x] Existing 83 tests unaffected — small fixture responses sit well under the default 5K cap.

## Bead

Closes rf2-zavp5. Discovered from rf2-1sdzn audit (`ai/findings/refactor-audit-tools-story-mcp-2026-05-14.md` P0 #3 / S4 / S6).