### PR TITLE
test(flows): regression test for cycle-rollback on reg-flow replacement (rf2-cdh9h)

### DIFF
--- a/implementation/flows/deps.edn
+++ b/implementation/flows/deps.edn
@@ -50,7 +50,14 @@
                        day8/re-frame2-ssr     {:local/root "../ssr"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-         :main-opts   ["-m" "cognitect.test-runner"]}
+         ;; `-e :expected-fail` excludes deftests carrying the
+         ;; `^:expected-fail` metadata from the default test sweep. Such
+         ;; tests pin contracts whose backing fix has not yet landed
+         ;; (e.g. rf2-cdh9h pins the cycle-rollback-on-replacement
+         ;; contract; the sibling fix rf2-7csri is still open). Once the
+         ;; matching fix merges, drop the metadata from the test and the
+         ;; assertion flips back into the default sweep automatically.
+         :main-opts   ["-m" "cognitect.test-runner" "-e" ":expected-fail"]}
 
   ;; Clojars deploy (rf2-r382). Modeled on re-frame v1's release flow.
   ;; The release workflow runs `clojure -M:clein deploy` from this

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -138,6 +138,77 @@
     (is (not (contains? (get @flows/flows :rf/default) :b))
         "cycle-detection rolls back the partial registration of :b")))
 
+(deftest ^:expected-fail
+  reg-flow-replacement-that-introduces-cycle-preserves-prior-registration
+  ;; Regression for rf2-7csri (bug) / rf2-cdh9h (this test). Pinned per
+  ;; audit rf2-o3hok finding Exec#2 (TE2). The current `reg-flow` rollback
+  ;; path (flows.cljc:144-151) writes the new entry FIRST then runs cycle
+  ;; detection; on a cyclic re-registration the rollback dissocs by id,
+  ;; which DELETES the prior registration as well as the just-written
+  ;; one. A hot-reload that accidentally introduces a cycle therefore
+  ;; silently vacates the previously-working flow. The correct behaviour:
+  ;; detect the cycle on a PROSPECTIVE flow-map BEFORE mutating, and on
+  ;; failure leave the prior registration intact.
+  ;;
+  ;; This test is marked ^:expected-fail because rf2-7csri is not yet
+  ;; merged — the cognitect test-runner alias excludes :expected-fail
+  ;; selectors by default so CI stays green. Drop the metadata once the
+  ;; sibling fix lands.
+  (testing "a cyclic reg-flow REPLACEMENT must not silently delete the prior registration"
+    ;; Set up a non-cyclic two-flow graph where REPLACING :b is what
+    ;; closes the cycle. Cannot use a self-cycle on :b (topo-sort skips
+    ;; the `id = other` self-edge via `(not= id other)`), so we set
+    ;; :a's :inputs to point at :b's :path. After replacement of :b's
+    ;; inputs to point at :a's :path, the cycle :a → :b → :a closes.
+    ;;
+    ;; 1. :a reads [:b], writes [:a]. Currently no cycle because :b is
+    ;;    not yet registered.
+    (rf/reg-flow {:id     :a
+                  :inputs [[:b]]
+                  :output (fn [b] (str "A-from-B-" b))
+                  :path   [:a]})
+    (is (contains? (get @flows/flows :rf/default) :a)
+        "initial :a registers cleanly")
+
+    ;; 2. :b reads an unrelated path [:source], writes [:b]. Graph is
+    ;;    :b → :a (one-way), no cycle. The prior `reg-flow-detects-
+    ;;    cycles-at-registration` test pins the INITIAL-cycle case
+    ;;    (where :b at first registration closes the cycle). This test
+    ;;    pins the REPLACEMENT case — :b registers cleanly first, then
+    ;;    its replacement is what would close the cycle.
+    (let [original-b-output (fn [src] (str "B-of-" src))]
+      (rf/reg-flow {:id     :b
+                    :inputs [[:source]]
+                    :output original-b-output
+                    :path   [:b]})
+      (is (contains? (get @flows/flows :rf/default) :b)
+          "initial :b registers cleanly (reads [:source]; no cycle)")
+
+      ;; 3. RE-register :b with :inputs [[:a]]. :a already reads [:b],
+      ;;    so the prospective graph closes :a → :b → :a. Cycle
+      ;;    detection MUST reject the replacement.
+      (is (thrown? Throwable
+            (rf/reg-flow {:id     :b
+                          :inputs [[:a]]
+                          :output (fn [a] (str "B-from-A-" a))
+                          :path   [:b]}))
+          "the cyclic replacement of :b throws :rf.error/flow-cycle")
+
+      ;; 4. THE KEY ASSERTION: the prior :b is STILL in the registry —
+      ;;    not silently deleted. The bug today (flows.cljc:149) dissocs
+      ;;    by id on rollback, vacating the prior registration along
+      ;;    with the just-written one.
+      (is (contains? (get @flows/flows :rf/default) :b)
+          "after a failed cyclic replacement, the prior :b registration is preserved")
+      (let [b-after (get-in @flows/flows [:rf/default :b])]
+        (is (= [[:source]] (:inputs b-after))
+            "prior :b's :inputs are intact ([[:source]], not the rejected [[:a]])")
+        (is (identical? original-b-output (:output b-after))
+            "prior :b's :output fn has the SAME identity (not the rejected new fn)"))
+      ;; And the registrar slot — flow-id-keyed — must still resolve.
+      (is (some? (registrar/lookup :flow :b))
+          "the :flow registrar slot for :b is still populated"))))
+
 ;; ---------------------------------------------------------------------------
 ;; 2. Dirty-check / re-evaluation
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Pins the contract for sibling bead **rf2-7csri** (P0 bug). When `reg-flow` REPLACES an existing flow and the new definition introduces a cycle, the rollback path today silently deletes the prior registration along with the rejected new one — a hot-reload that accidentally closes a cycle vacates a previously-working flow.

The bug lives in `implementation/flows/src/re_frame/flows.cljc` lines 144-151: the atom + `:flow` registrar slot are mutated FIRST, then `topo-sort` runs; on failure the rollback dissocs by id, taking the prior entry with it. The fix in rf2-7csri is detect-before-write — run cycle detection on a prospective flow map BEFORE mutating.

This bead lands the regression test only. Test scenario:

1. Register `:a` reading `[:b]` writing `[:a]` (no cycle yet — `:b` not registered).
2. Register `:b` reading `[:source]` writing `[:b]` (clean: `:b -> :a`, one-way).
3. Re-register `:b` with `:inputs [[:a]]` — closes `:a -> :b -> :a`. MUST throw AND leave the prior `:b` intact.
4. Assert per-frame registry, `:inputs`, output-fn identity, and `:flow` registrar slot all hold the prior `:b`.

## Mechanics

- `^:expected-fail` metadata on the deftest + `-e :expected-fail` added to the `:test` alias's `:main-opts` exclude the test from the default sweep, so CI stays green until rf2-7csri merges.
- Once the fix lands, dropping the metadata flips the test back into the default sweep automatically.

## Test status

- Default sweep (`clojure -M:test` from `implementation/flows/`): **26 tests / 98 assertions / 0 failures** — unchanged.
- Forced inclusion (`clojure -X:test cognitect.test-runner.api/test :includes '[:expected-fail]'`): **1 test / 7 assertions / 4 failures** — the bug is demonstrated cleanly. The throw fires (cycle IS detected); the four post-rollback state assertions ALL fail because the rollback wiped the prior `:b`.

## Test plan

- [x] Default `clojure -M:test` sweep stays green
- [x] Forced inclusion surfaces 4 failures pinned to the bug surface
- [ ] When rf2-7csri merges: drop `^:expected-fail` metadata; assertions flip green

Audit lineage: rf2-o3hok finding **TE2** / **Exec#2**.