### PR TITLE
fix(core): move side-effects out of swap-fn body in subs (rf2-3mww7)

### DIFF
--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -529,21 +529,32 @@
 (defn- dispose-entry-now!
   "Synchronous disposal: remove the cache slot for k iff its ref-count
   is still <= 0 (no resubscribe arrived) and dispose the reaction.
-  Idempotent — a second call is a no-op because the slot is gone."
+  Idempotent — a second call is a no-op because the slot is gone.
+
+  Per rf2-3mww7: the swap-fn body is pure — it returns the new cache
+  map and nothing else. The reaction to dispose is read from the
+  PRE-swap snapshot returned by `swap-vals!` and acted on AFTER the
+  CAS commits. `swap!` is allowed to retry on contention on the JVM,
+  so any side-effect (interop/dispose!) inside the swap-fn could fire
+  2+ times under concurrent invalidate + grace-fire."
   [cache k]
-  (let [reaction-to-dispose (atom nil)]
-    (swap! cache
-           (fn [m]
-             (if-let [entry (get m k)]
-               (if (<= (or (:ref-count entry) 0) 0)
-                 (do (reset! reaction-to-dispose (:reaction entry))
-                     (dissoc m k))
-                 ;; Resubscribe arrived between schedule and fire — keep entry.
-                 m)
-               m)))
-    (when-let [r @reaction-to-dispose]
-      (try (interop/dispose! r)
-           (catch #?(:clj Throwable :cljs :default) _ nil)))
+  (let [[old new] (swap-vals! cache
+                              (fn [m]
+                                (if-let [entry (get m k)]
+                                  (if (<= (or (:ref-count entry) 0) 0)
+                                    (dissoc m k)
+                                    ;; Resubscribe arrived between schedule
+                                    ;; and fire — keep entry.
+                                    m)
+                                  m)))]
+    ;; The slot was evicted by THIS call iff it was present in `old` and
+    ;; absent in `new`. A concurrent evictor (e.g. invalidate-sub-on-
+    ;; replace! or clear-subscription-cache!) that won the CAS race would
+    ;; have left the slot absent in `old` too, so we don't double-dispose.
+    (when (and (contains? old k) (not (contains? new k)))
+      (when-let [r (get-in old [k :reaction])]
+        (try (interop/dispose! r)
+             (catch #?(:clj Throwable :cljs :default) _ nil))))
     nil))
 
 (defn unsubscribe
@@ -564,25 +575,43 @@
    (when-let [cache (:sub-cache (frame/frame frame-id))]
      (let [k     (cache-key query-v)
            grace (grace-period-ms)
-           dropped-to-zero? (atom false)]
-       (swap! cache
-              (fn [m]
-                (if-let [entry (get m k)]
-                  (let [old-n (or (:ref-count entry) 1)
-                        n     (max 0 (dec old-n))]
-                    ;; Only trigger drop-to-zero on the 1→0 transition AND only
-                    ;; when no grace-period timer is already in flight. Calling
-                    ;; `unsubscribe` past zero (idempotent misuse — e.g. cleanup
-                    ;; in both a teardown hook and a `finally`) must not stack
-                    ;; new `pending-dispose` timers on top of the prior handle.
-                    (if (and (= 1 old-n)
-                             (zero? n)
-                             (nil? (:pending-dispose entry)))
-                      (do (reset! dropped-to-zero? true)
-                          (assoc m k (assoc entry :ref-count 0)))
-                      (assoc-in m [k :ref-count] n)))
-                  m)))
-       (when @dropped-to-zero?
+           ;; Per rf2-3mww7: the swap-fn body is pure — it returns only
+           ;; the new cache map. The drop-to-zero signal is read from
+           ;; the diff between `old` and `new` AFTER the CAS commits.
+           ;; `swap!` is allowed to retry on contention on the JVM, so
+           ;; a side-effecting `(reset! dropped-to-zero? true)` inside
+           ;; the swap-fn body could fire on a discarded retry whose
+           ;; CAS lost — leading to a spurious dispose schedule for
+           ;; a slot that was never actually transitioned by this call.
+           [old new] (swap-vals! cache
+                                 (fn [m]
+                                   (if-let [entry (get m k)]
+                                     (let [old-n (or (:ref-count entry) 1)
+                                           n     (max 0 (dec old-n))]
+                                       ;; Only trigger drop-to-zero on the 1→0
+                                       ;; transition AND only when no grace-period
+                                       ;; timer is already in flight. Calling
+                                       ;; `unsubscribe` past zero (idempotent
+                                       ;; misuse — e.g. cleanup in both a
+                                       ;; teardown hook and a `finally`) must not
+                                       ;; stack new `pending-dispose` timers on
+                                       ;; top of the prior handle.
+                                       (if (and (= 1 old-n)
+                                                (zero? n)
+                                                (nil? (:pending-dispose entry)))
+                                         (assoc m k (assoc entry :ref-count 0))
+                                         (assoc-in m [k :ref-count] n)))
+                                     m)))
+           ;; This swap drove the 1→0 transition (under no pending-dispose)
+           ;; iff the entry was present in both old and new AND old's
+           ;; ref-count was 1 AND new's ref-count is 0 AND old had no
+           ;; pending-dispose timer. Reading from the snapshots avoids
+           ;; the side-effect-in-swap-fn race.
+           dropped-to-zero? (and (contains? new k)
+                                 (= 1 (or (get-in old [k :ref-count]) 1))
+                                 (zero? (or (get-in new [k :ref-count]) 0))
+                                 (nil? (get-in old [k :pending-dispose])))]
+       (when dropped-to-zero?
          (if (zero? grace)
            ;; Grace = 0: dispose synchronously (the test/explicit-tear-down path).
            (dispose-entry-now! cache k)
@@ -591,21 +620,27 @@
            (let [handle (interop/set-timeout!
                           (fn []
                             (dispose-entry-now! cache k))
-                          grace)]
-             (swap! cache
-                    (fn [m]
-                      (if-let [entry (get m k)]
-                        ;; Only stash the handle if ref-count is still 0 —
-                        ;; a subscriber may have arrived between our swap!
-                        ;; above and set-timeout! returning.
-                        (if (<= (or (:ref-count entry) 0) 0)
-                          (assoc m k (assoc entry :pending-dispose handle))
-                          (do (try (interop/clear-timeout! handle)
-                                   (catch #?(:clj Throwable :cljs :default) _ nil))
-                              m))
-                        (do (try (interop/clear-timeout! handle)
-                                 (catch #?(:clj Throwable :cljs :default) _ nil))
-                            m)))))))
+                          grace)
+                 ;; Pure swap-fn: return the new map and a flag indicating
+                 ;; whether the handle was actually stashed. The clear-
+                 ;; timeout! side-effect runs AFTER the CAS commits so
+                 ;; a discarded retry can't double-clear a live timer.
+                 [_ new2] (swap-vals! cache
+                                      (fn [m]
+                                        (if-let [entry (get m k)]
+                                          (if (<= (or (:ref-count entry) 0) 0)
+                                            (assoc m k (assoc entry :pending-dispose handle))
+                                            ;; Subscriber arrived between our swap!
+                                            ;; above and set-timeout! returning —
+                                            ;; do NOT stash; we'll cancel post-swap.
+                                            m)
+                                          m)))]
+             ;; If the handle did NOT land on the entry, cancel it once,
+             ;; outside the swap. Reading from the post-swap snapshot
+             ;; (`new2`) means we make this decision exactly once.
+             (when-not (identical? handle (get-in new2 [k :pending-dispose]))
+               (try (interop/clear-timeout! handle)
+                    (catch #?(:clj Throwable :cljs :default) _ nil))))))
        nil))))
 
 ;; ---- hot-reload invalidation ---------------------------------------------
@@ -621,27 +656,36 @@
   (when (= kind :sub)
     (doseq [frame-id (frame/frame-ids)]
       (when-let [cache (:sub-cache (frame/frame frame-id))]
-        (let [evictions (atom [])
-              pending   (atom [])]
-          (swap! cache
-                 (fn [m]
-                   (let [hit-keys (->> (keys m)
-                                       (filter #(= id (first %))))]
-                     (doseq [k hit-keys]
-                       (when-let [r (get-in m [k :reaction])]
-                         (swap! evictions conj r))
-                       (when-let [h (get-in m [k :pending-dispose])]
-                         (swap! pending conj h)))
-                     (apply dissoc m hit-keys))))
+        ;; Per rf2-3mww7: the swap-fn body is pure — it returns only the
+        ;; new cache map. Reactions to dispose and timers to cancel are
+        ;; read from the diff between `old` and `new` AFTER the CAS
+        ;; commits. `swap!` is allowed to retry on contention on the
+        ;; JVM, so any side-effecting collector (`(swap! evictions
+        ;; conj ...)`) inside the swap-fn could double-conj — and then
+        ;; the post-swap `dispose!` loop would call dispose on the same
+        ;; reaction twice.
+        (let [[old new] (swap-vals! cache
+                                    (fn [m]
+                                      (let [hit-keys (->> (keys m)
+                                                          (filter #(= id (first %))))]
+                                        (apply dissoc m hit-keys))))
+              ;; The keys actually evicted by THIS swap are those present
+              ;; in `old` but absent in `new`. A concurrent evictor that
+              ;; won the CAS race would have removed its keys before our
+              ;; swap saw them, so the diff names ONLY the keys we own.
+              evicted-keys (filterv #(not (contains? new %))
+                                    (keys old))]
           ;; Cancel any pending grace-period timers for the evicted slots —
           ;; the reaction is being disposed now, so the deferred path
           ;; would fire against a stale closure.
-          (doseq [h @pending]
-            (try (interop/clear-timeout! h)
-                 (catch #?(:clj Throwable :cljs :default) _ nil)))
-          (doseq [r @evictions]
-            (try (interop/dispose! r)
-                 (catch #?(:clj Throwable :cljs :default) _ nil))))))))
+          (doseq [k evicted-keys]
+            (when-let [h (get-in old [k :pending-dispose])]
+              (try (interop/clear-timeout! h)
+                   (catch #?(:clj Throwable :cljs :default) _ nil))))
+          (doseq [k evicted-keys]
+            (when-let [r (get-in old [k :reaction])]
+              (try (interop/dispose! r)
+                   (catch #?(:clj Throwable :cljs :default) _ nil)))))))))
 
 (defonce ^:private _hot-reload-hook
   (do (registrar/add-replacement-hook! invalidate-sub-on-replace!)

--- a/implementation/core/test/re_frame/sub_cache_concurrency_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_concurrency_test.clj
@@ -1,0 +1,277 @@
+(ns re-frame.sub-cache-concurrency-test
+  "JVM-only concurrency tests for the sub-cache disposal path (rf2-3mww7).
+
+  The audit (rf2-spr6q, findings SU2 / SU6) identified a swap-fn
+  side-effect race in `subs/dispose-entry-now!`,
+  `subs/invalidate-sub-on-replace!`, and the `unsubscribe` 1→0
+  transition. Each placed side-effecting operations (collecting
+  reactions for disposal, resetting a `dropped-to-zero?` flag,
+  cancelling timers) **inside** the swap-fn body. `clojure.core/swap!`
+  is allowed to retry on CAS contention; under JVM concurrency a
+  retried swap-fn would replay those side-effects, leading to
+  double-dispose (and a potential NPE when the second `dispose!`
+  closed over a reaction already torn down).
+
+  CLJS is single-threaded so the race is invisible there. These tests
+  live in `.clj` (not `.cljc`) and target the JVM only.
+
+  The fix (in subs.cljc): the swap-fn body is pure — it returns only
+  the new cache map. Side-effects (disposal, timer cancel) run AFTER
+  the CAS commits, computed from the diff between the pre/post
+  snapshots returned by `swap-vals!`.
+
+  Each test stresses contention by driving thousands of iterations of
+  the contended path; failures accumulate into a counter and the test
+  asserts zero. The deterministic single-thread tests in
+  `sub_cache_test.clj` continue to pin the happy-path contract; this
+  namespace pins the contention contract.
+
+  Pattern follows `router_drain_race_test.clj` /
+  `concurrency_stress_test.clj`: per-scenario iteration count
+  (env-overridable), fixture as elsewhere, latched start so threads
+  race from the same gun."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.subs :as subs]
+            [re-frame.frame :as frame]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.registrar :as registrar]
+            [re-frame.interop :as interop]
+            [re-frame.substrate.plain-atom :as plain-atom])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (require 're-frame.machines :reload)
+  (try (test-fn)
+       (finally
+         (subs/configure! {:grace-period-ms 50}))))
+
+(use-fixtures :each reset-runtime)
+
+;; Test instrumentation: a counting `dispose!` proxy.
+;;
+;; We can't rely on `interop/dispose!`'s own dissoc-then-fire to detect
+;; double-`dispose!` calls — the second call finds no callbacks and is
+;; a silent no-op. Instead, the test wraps `interop/dispose!` with
+;; `with-redefs` to a per-reaction counter that bumps every time the
+;; sub-cache calls `dispose!`. A `counter > 1` for any reaction proves
+;; the swap-fn-side-effects race fired the dispose path more than once.
+;;
+;; A reaction-shaped object is just a deref-able; the sub-cache only
+;; calls `dispose!` on it (it doesn't deref, it doesn't read structure).
+(defn- bare-reaction []
+  (reify clojure.lang.IDeref (deref [_] nil)))
+
+;; ---- 1. Concurrent invalidate-sub-on-replace! does not double-dispose -----
+
+;; The race: N threads concurrently fire the replacement hook for the
+;; SAME sub id (representing N near-simultaneous re-registrations during
+;; hot-reload). Pre-fix, the swap-fn body's `(swap! evictions conj r)`
+;; could fire on a retried, discarded CAS attempt; the post-swap
+;; `dispose!` loop would then call `dispose!` twice on the same
+;; reaction. Post-fix, side-effects are derived from the diff between
+;; pre/post swap snapshots — only the CAS winner sees the slot
+;; transition from present to absent, so dispose fires exactly once.
+;;
+;; The replacement-hook fn is private; we drive it through the public
+;; `rf/reg-sub` path (re-registration fires the hook).
+(deftest invalidate-sub-on-replace-no-double-dispose
+  (testing "concurrent hot-reload of the same sub id disposes each cached reaction exactly once"
+    (let [dispose-calls   (atom {})         ;; reaction → call count
+          orig-dispose!   interop/dispose!
+          n-keys          50
+          n-replacers     8
+          cache           (:sub-cache (frame/frame :rf/default))
+          ks              (vec (for [i (range n-keys)] [:contended i]))
+          reactions-by-k  (atom {})]
+      ;; Register the sub once so subsequent re-registrations fire the
+      ;; replacement hook. The body is irrelevant; we never deref.
+      (rf/reg-sub :contended (fn [_db _q] nil))
+
+      ;; Manually populate cached entries with bare reactions we control,
+      ;; so we can count dispose! calls against each one.
+      (doseq [k ks]
+        (let [r (bare-reaction)]
+          (swap! reactions-by-k assoc k r)
+          (swap! dispose-calls assoc r 0)
+          (swap! cache assoc k {:reaction r
+                                :inputs   []
+                                :ref-count 0
+                                :on-dispose []
+                                :pending-dispose nil})))
+      (is (= n-keys (count @cache))
+          "all contended slots populated")
+
+      ;; Redef dispose! to count calls per reaction. Each call still
+      ;; delegates to the original (so on-dispose-callbacks state is
+      ;; maintained). The counter atom is read post-race; any reaction
+      ;; with count > 1 is a swap-fn-retry-double-dispose failure.
+      (with-redefs [interop/dispose!
+                    (fn [r]
+                      (swap! dispose-calls update r (fnil inc 0))
+                      (orig-dispose! r))]
+        (let [latch (CountDownLatch. 1)
+              threads (mapv (fn [_]
+                              (Thread.
+                                ^Runnable
+                                (fn []
+                                  (.await latch 5 TimeUnit/SECONDS)
+                                  ;; Re-register fires the replacement
+                                  ;; hook, which walks every frame's
+                                  ;; cache and evicts each [:contended _]
+                                  ;; slot.
+                                  (rf/reg-sub :contended (fn [_db _q] nil)))))
+                            (range n-replacers))]
+          (doseq [t threads] (.start t))
+          (.countDown latch)
+          (doseq [t threads] (.join t 10000))))
+
+      (let [counts (mapv #(get @dispose-calls (get @reactions-by-k %)) ks)
+            over   (filter #(> % 1) counts)
+            under  (filter #(< % 1) counts)]
+        (is (empty? over)
+            (str "no reaction may have dispose! called more than once across "
+                 n-replacers " concurrent hot-reloads; got over-dispose counts: "
+                 (vec over)))
+        (is (empty? under)
+            (str "every cached reaction must have dispose! called at least once; "
+                 "got " (count under) " slot(s) never disposed"))))))
+
+;; ---- 2. Concurrent dispose-entry-now! does not double-dispose -------------
+
+;; The race: M threads schedule grace-period disposal for the same set
+;; of keys (e.g. unsubscribe storms from React unmount churn). Each
+;; deferred timer fires `dispose-entry-now!` for its key. Pre-fix, the
+;; swap-fn body's `(reset! reaction-to-dispose ...)` could fire on a
+;; retried-and-discarded CAS attempt, after which the post-swap
+;; `dispose!` would call dispose on a reaction the WINNING swap had
+;; already cleared. Post-fix, we read the reaction-to-dispose from the
+;; pre-swap snapshot and only act when the slot transitioned from
+;; present to absent — i.e. when our CAS actually won.
+(deftest dispose-entry-now-no-double-dispose-under-contention
+  (testing "concurrent dispose-entry-now! calls dispose each reaction exactly once"
+    (let [n-keys          50
+          n-threads-per-k 6   ;; threads per key, ALL trying to dispose the same slot
+          cache           (:sub-cache (frame/frame :rf/default))
+          dispose-calls   (atom {})
+          orig-dispose!   interop/dispose!
+          ks              (vec (for [i (range n-keys)] [:contended i]))
+          reactions-by-k  (atom {})]
+      ;; Seed each slot with ref-count 0 (the precondition for
+      ;; dispose-entry-now! to actually evict). One CAS winner per key
+      ;; will succeed; n-threads-per-k - 1 losers must observe the slot
+      ;; already gone and NOT call dispose!.
+      (doseq [k ks]
+        (let [r (bare-reaction)]
+          (swap! reactions-by-k assoc k r)
+          (swap! dispose-calls assoc r 0)
+          (swap! cache assoc k {:reaction r
+                                :inputs   []
+                                :ref-count 0
+                                :on-dispose []
+                                :pending-dispose nil})))
+
+      ;; The fn is private — reach it via var resolution.
+      (let [dispose-fn @#'subs/dispose-entry-now!]
+        (with-redefs [interop/dispose!
+                      (fn [r]
+                        (swap! dispose-calls update r (fnil inc 0))
+                        (orig-dispose! r))]
+          (let [latch  (CountDownLatch. 1)
+                threads (vec
+                          (mapcat
+                            (fn [k]
+                              (mapv (fn [_]
+                                      (Thread.
+                                        ^Runnable
+                                        (fn []
+                                          (.await latch 5 TimeUnit/SECONDS)
+                                          (dispose-fn cache k))))
+                                    (range n-threads-per-k)))
+                            ks))]
+            (doseq [t threads] (.start t))
+            (.countDown latch)
+            (doseq [t threads] (.join t 10000)))))
+
+      (let [counts (mapv #(get @dispose-calls (get @reactions-by-k %)) ks)
+            over   (filter #(> % 1) counts)
+            under  (filter #(< % 1) counts)]
+        (is (empty? over)
+            (str "no reaction may have dispose! called more than once under "
+                 n-threads-per-k "-thread contention per key; got over-dispose "
+                 "counts: " (vec over)))
+        (is (empty? under)
+            (str "every slot must have dispose! called exactly once across the "
+                 "n-thread race; got " (count under) " slot(s) never disposed"))))))
+
+;; ---- 3. unsubscribe drop-to-zero is not spuriously triggered --------------
+
+;; The race: a single subscriber refs a sub, and N threads all call
+;; `unsubscribe` concurrently. Exactly one CAS winner drives the 1→0
+;; transition and disposes the slot (grace=0 sync path); the losers
+;; (who see ref-count already 0) must NOT dispose a second time.
+;; Pre-fix, the swap-fn body's `(reset! dropped-to-zero? true)` could
+;; fire on a discarded retry attempt, causing a second
+;; `dispose-entry-now!` to be invoked against an already-evicted slot
+;; — observable as a double dispose! call against the same reaction.
+;;
+;; This scenario is correctness-equivalent to the existing idempotent-
+;; unsubscribe contract pinned in sub_cache_test.clj, but here we
+;; assert it under CAS contention rather than serialised calls.
+(deftest unsubscribe-drop-to-zero-no-spurious-fire-under-contention
+  (testing "concurrent unsubscribe calls dispose exactly once per slot under contention"
+    (subs/configure! {:grace-period-ms 0})  ;; sync dispose so we can observe
+    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:seed])
+
+    (let [n-trials      200
+          n-threads     6
+          orig-dispose! interop/dispose!
+          per-trial     (atom [])]  ;; vec of dispose-call-count per trial
+      ;; Per-trial counter, fresh each iteration. Each trial:
+      ;;   - subscribe once → ref-count 1
+      ;;   - n-threads race to unsubscribe
+      ;;   - exactly one dispose! call must result
+      (dotimes [_ n-trials]
+        (let [trial-counter (atom 0)
+              dispose-proxy (fn [r]
+                              (swap! trial-counter inc)
+                              (orig-dispose! r))]
+          (with-redefs [interop/dispose! dispose-proxy]
+            (rf/subscribe [:n])  ;; ref-count 1
+            (let [latch (CountDownLatch. 1)
+                  threads (mapv (fn [_]
+                                  (Thread.
+                                    ^Runnable
+                                    (fn []
+                                      (.await latch 5 TimeUnit/SECONDS)
+                                      (rf/unsubscribe [:n]))))
+                                (range n-threads))]
+              (doseq [t threads] (.start t))
+              (.countDown latch)
+              (doseq [t threads] (.join t 5000))))
+          (swap! per-trial conj @trial-counter)))
+
+      (let [counts @per-trial
+            over   (filter #(> % 1) counts)
+            under  (filter #(< % 1) counts)]
+        (is (empty? over)
+            (str "no trial may dispose the cached reaction more than once "
+                 "across " n-threads " concurrent unsubscribes; got "
+                 (count over) " over-dispose trials. Sample counts: "
+                 (vec (take 20 over))))
+        (is (empty? under)
+            (str "every trial must dispose the cached reaction exactly once "
+                 "(grace=0); got " (count under) " trial(s) with zero "
+                 "disposes. Sample: " (vec (take 20 under)))))
+      (is (= n-trials (count @per-trial))
+          "all trials accounted for"))))


### PR DESCRIPTION
## Summary

P0 correctness fix per audit rf2-spr6q (findings SU2 / SU6). JVM-only race where `clojure.core/swap!` could retry a swap-fn that contained side-effects — under contention this fired the side-effect (disposal, timer cancel) 2+ times, with a potential NPE when the second `dispose!` closed over an already-torn-down reaction.

Three sites in `implementation/core/src/re_frame/subs.cljc`:

1. **`dispose-entry-now!`** — `(reset! reaction-to-dispose ...)` inside swap-fn body.
2. **`invalidate-sub-on-replace!`** — `(swap! evictions conj r)` / `(swap! pending conj h)` inside swap-fn body.
3. **`unsubscribe` 1→0 path** — `(reset! dropped-to-zero? true)` inside swap-fn body, plus a second `swap!` with `clear-timeout!` inside its body.

The bead named the first two; the third was the same bug shape on the same surface and is fixed here too. Pre-alpha: correctness-paramount, no half-done masterpiece.

Fix pattern: pure swap-fn returns only the new cache map; side-effects derive from the `[old new]` diff returned by `swap-vals!` and run AFTER the CAS commits. The CAS winner observes the slot transition; losers see no change and no-op.

## Test plan

- [x] `clojure -M:test` from `implementation/core/`: 440 tests, 2306 assertions, 0 failures, 0 errors.
- [x] `npm run test:cljs` from `implementation/`: 1778 tests, 4937 assertions, 0 failures, 0 errors.
- [x] New JVM-only regression test `implementation/core/test/re_frame/sub_cache_concurrency_test.clj` — three scenarios, one per fixed site. Each redefs `interop/dispose!` to a per-reaction counter and asserts no reaction is disposed more than once across N concurrent threads. Latched start so threads race from the same gun.

Closes rf2-3mww7.