### PR TITLE
refactor(story): extract shared review-dialog ns from recorder + save-variant (rf2-7jpky)

### DIFF
--- a/tools/story/src/re_frame/story/review_dialog.cljc
+++ b/tools/story/src/re_frame/story/review_dialog.cljc
@@ -1,0 +1,434 @@
+(ns re-frame.story.review-dialog
+  "Shared 'review-then-commit modal' primitive for Story's save-as flows
+  (rf2-7jpky; extract from rf2-dd5ze audit P0 #3).
+
+  Two save-as flows ship today:
+
+  - record-as-`:play` — `re-frame.story.recorder` captures a trace of
+    dispatched events and surfaces the generated `(reg-variant ...)`
+    EDN form in a modal for the user to copy + paste into source.
+  - snapshot-args-as-`:args` — `re-frame.story.save-variant` captures
+    the live effective args and surfaces the same shape.
+
+  Both flows share the same UX skeleton:
+
+  1. Capture user state into a snapshot (events / args / whatever).
+  2. Build an EDN snippet from the snapshot.
+  3. Open a modal with the snippet + an editable target-variant-id
+     input. The snippet re-generates on every keystroke as the user
+     edits the id.
+  4. On commit, copy to clipboard. Source is never written directly.
+
+  Storybook 9 writes directly to source files, which entangles the
+  playground with Prettier configuration, source-control conflicts, and
+  the project's editor settings. Story emits the snippet for the user
+  to paste — the elegant escape hatch.
+
+  ## What this ns owns
+
+  Pure data + transitions (this `.cljc`):
+
+  - `initial-state`                    — the idle dialog state map.
+  - `open` / `close` / `set-draft-id`  — pure transitions.
+  - `default-variant-id-with-prefix`   — derive a sensible default
+                                          new-variant id from a source
+                                          variant id + wall-clock ms +
+                                          a per-flow prefix
+                                          (`recorded-` / `saved-`).
+  - `parse-variant-id-string`          — best-effort string → keyword
+                                          parser the UI's id-input uses.
+
+  The thin `.cljs` adapter `re-frame.story.review-dialog.cljs` (same ns;
+  reader-conditional split below) owns the Reagent `r/atom` factory,
+  the shared `copy-to-clipboard!` helper, and the `review-dialog`
+  hiccup renderer parameterised by `{:title :hint :snippet :draft-id
+  :source-id :on-edit-id :on-copy :on-discard :on-close
+  :data-test-prefix}`.
+
+  ## Why a shared ns
+
+  Pre-extraction the two flows carried parallel inline copies of the
+  same shape — same modal styling, same `open?` / `draft-id` ratom,
+  same `set-draft-id!` string-parsing helper, same `copy-to-clipboard!`
+  shim — drifted by ~120 LoC. The recorder did NOT factor the dialog
+  state machine into `.cljc`, so JVM tests couldn't pin its
+  transitions. Extracting here delivers:
+
+  - One JVM-testable dialog state machine.
+  - One copy-to-clipboard shim.
+  - One renderer the next save-as-anything flow (save-as-workspace,
+    save-as-snapshot, save-as-mode) consumes in ~20 LoC of glue.
+
+  ## Dialog state shape
+
+  The dialog state map carries:
+
+  - `:open?`     — bool; true while the modal is visible.
+  - `:draft-id`  — the user's editable target-variant-id. May be a
+                   keyword (parses cleanly) or a string (raw input
+                   pre-parse). `nil` before first open.
+  - `:source-id` — the source variant id the snapshot was taken
+                   against. Rides into `:extends` in the generated
+                   snippet. `nil` before first open.
+  - `:context`   — a flow-specific map the caller stashes alongside
+                   the dialog state (e.g. recorder stashes
+                   `{:events [...]}`; save-variant stashes
+                   `{:args {...}}`). The renderer is presentational —
+                   it doesn't read `:context`; the caller builds the
+                   snippet string from it before passing the snippet
+                   to the renderer."
+  (:require [clojure.string :as str]
+            #?(:cljs [reagent.core :as r])))
+
+;; ---------------------------------------------------------------------------
+;; Pure: initial state + transitions
+;; ---------------------------------------------------------------------------
+
+(def initial-state
+  "The dialog's idle state map. `:open?` flips true on `open`; the
+  `:draft-id`, `:source-id`, `:context` slots populate as the user
+  drives the flow."
+  {:open?     false
+   :draft-id  nil
+   :source-id nil
+   :context   nil})
+
+(defn default-variant-id-with-prefix
+  "Derive a sensible default id for the new variant given a source
+  variant id, a wall-clock millis stamp, and a per-flow prefix
+  (`\"recorded\"` for the recorder; `\"saved\"` for save-variant).
+
+  Pure data → keyword. Returns nil when `source-variant-id` is not a
+  qualified keyword — caller's preview falls back to a placeholder
+  literal (e.g. `:story.recorded/example`).
+
+  Examples:
+
+      (default-variant-id-with-prefix :story.counter/happy-path
+                                      1700000000000 \"saved\")
+      ;; => :story.counter/saved-NNNNN
+
+      (default-variant-id-with-prefix :story.counter/happy-path
+                                      1700000000000 \"recorded\")
+      ;; => :story.counter/recorded-NNNNN"
+  [source-variant-id now-ms prefix]
+  (when (qualified-keyword? source-variant-id)
+    (let [suffix (mod (long now-ms) 1000000)]
+      (keyword (namespace source-variant-id)
+               (str prefix "-" suffix)))))
+
+(defn parse-variant-id-string
+  "Best-effort parse of an id-input string into a keyword. Handles the
+  leading `:` (the user types `\":foo/bar\"` because that's the printed
+  form) and the embedded `/` (qualified vs unqualified). Returns nil
+  when parsing fails — the caller stores the raw string on failure so
+  the input value the user sees doesn't get clobbered mid-keystroke.
+
+  Pure data → keyword | nil.
+
+  Examples:
+
+      (parse-variant-id-string \":story.counter/saved-1\")
+      ;; => :story.counter/saved-1
+
+      (parse-variant-id-string \"story.counter/saved-1\")
+      ;; => :story.counter/saved-1
+
+      (parse-variant-id-string \"plain\")
+      ;; => :plain
+
+      (parse-variant-id-string \"\")
+      ;; => nil
+
+      (parse-variant-id-string nil)
+      ;; => nil"
+  [s]
+  (when (and (string? s) (seq s))
+    (try
+      (let [stripped (cond-> s
+                       (str/starts-with? s ":")
+                       (subs 1))]
+        (when (seq stripped)
+          (if (str/includes? stripped "/")
+            (let [[ns nm] (str/split stripped #"/" 2)]
+              (when (and (seq ns) (seq nm))
+                (keyword ns nm)))
+            (keyword stripped))))
+      (catch #?(:clj Exception :cljs :default) _ nil))))
+
+(defn open
+  "Pure: return the dialog state for opening against `source-id` with
+  `context` stashed and a default draft-id derived from `now-ms` +
+  `prefix`. The context is opaque to the dialog — callers stash flow-
+  specific data (events / args / etc.) for the snippet generator to
+  consume on render.
+
+  `prefix` is the per-flow tag for the auto-derived default id
+  (`\"recorded\"` for the recorder, `\"saved\"` for save-variant)."
+  [_state source-id context now-ms prefix]
+  {:open?     true
+   :source-id source-id
+   :context   context
+   :draft-id  (default-variant-id-with-prefix source-id now-ms prefix)})
+
+(defn close
+  "Pure: return the dialog state for closing. Returns the idle state —
+  `:draft-id` / `:source-id` / `:context` clear so the next open starts
+  fresh."
+  [_state]
+  initial-state)
+
+(defn set-draft-id
+  "Pure: replace the draft-id in the dialog state. `id` may be a
+  keyword (already-parsed) or a string (raw input the user is typing).
+  The pure transition just stores whatever the caller passes; the
+  string-parsing helper `parse-variant-id-string` is exposed
+  separately so callers can attempt parsing before swapping."
+  [state id]
+  (assoc state :draft-id id))
+
+(defn parse-and-set-draft-id
+  "Convenience: parse `s` (the raw input string) into a keyword
+  best-effort, then swap into `state`'s `:draft-id`. On parse failure,
+  stores the raw string so the input value the user sees doesn't get
+  clobbered mid-keystroke.
+
+  Pure data → state. Equivalent to:
+
+      (set-draft-id state (or (parse-variant-id-string s) s))"
+  [state s]
+  (set-draft-id state (or (parse-variant-id-string s) s)))
+
+;; ---------------------------------------------------------------------------
+;; CLJS-only: Reagent ratom factory + adapter glue
+;;
+;; The pure transitions above produce new state maps; the CLJS side
+;; swaps a Reagent `r/atom` around them so the modal re-renders on
+;; every keystroke. The `make-dialog-atom` factory returns a fresh
+;; ratom for each call site — the recorder and save-variant flows
+;; carry their own ratom each so their states stay independent.
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (defn make-dialog-atom
+     "Create a fresh Reagent ratom seeded with `initial-state`. Each
+     call site (recorder, save-variant) owns its own ratom so the
+     dialog states stay independent."
+     []
+     (r/atom initial-state)))
+
+#?(:cljs
+   (defn swap-open!
+     "Swap `dialog-atom` into the opened state for `source-id` +
+     `context` + the wall-clock `now-ms` + a per-flow `prefix`. Use
+     when you have `now-ms` already (e.g. tests); the impure caller
+     `swap-open-now!` reads the clock for you."
+     [dialog-atom source-id context now-ms prefix]
+     (swap! dialog-atom open source-id context now-ms prefix)))
+
+#?(:cljs
+   (defn swap-open-now!
+     "Swap `dialog-atom` into the opened state for `source-id` +
+     `context` using the current wall-clock for the default-id seed."
+     [dialog-atom source-id context prefix]
+     (swap-open! dialog-atom source-id context (.now js/Date) prefix)))
+
+#?(:cljs
+   (defn swap-close!
+     "Swap `dialog-atom` into the idle (closed) state."
+     [dialog-atom]
+     (swap! dialog-atom close)))
+
+#?(:cljs
+   (defn swap-parse-and-set-draft-id!
+     "Swap `dialog-atom` into the new draft-id state for raw input
+     `s`. Parses the input best-effort into a keyword; stores the raw
+     string on parse failure."
+     [dialog-atom s]
+     (swap! dialog-atom parse-and-set-draft-id s)))
+
+;; ---------------------------------------------------------------------------
+;; CLJS-only: copy-to-clipboard shim
+;;
+;; Wraps `navigator.clipboard.writeText`. Single helper both save-as
+;; flows consume — pre-extract each flow carried its own try/catch
+;; copy. Returns nil; failures are swallowed silently (no clipboard
+;; on JSDOM / older browsers / non-secure contexts is the expected
+;; case).
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (defn copy-to-clipboard!
+     "Copy `text` to the system clipboard via the navigator API.
+     No-op on hosts without `navigator.clipboard`. Swallows failures
+     silently — the modal still surfaces the snippet for manual copy."
+     [text]
+     (try
+       (when (and (exists? js/navigator) (.-clipboard js/navigator))
+         (.writeText (.-clipboard js/navigator) text))
+       (catch :default _ nil))
+     nil))
+
+;; ---------------------------------------------------------------------------
+;; CLJS-only: presentational modal renderer
+;;
+;; Parameterised by display strings + the snippet + callbacks. Returns
+;; nil when the dialog is closed so the caller can render it
+;; unconditionally next to the other shell mounts. The renderer is
+;; intentionally state-light — the caller threads the snippet (re-
+;; rendered on every keystroke) so flow-specific snippet generation
+;; stays in the flow's own ns.
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (def ^:private styles
+     {:modal-back   {:position "fixed"
+                     :top "0" :left "0" :right "0" :bottom "0"
+                     :background "rgba(0,0,0,0.55)"
+                     :z-index 1700
+                     :display "flex"
+                     :align-items "center"
+                     :justify-content "center"}
+      :modal        {:width          "640px"
+                     :max-width      "90vw"
+                     :max-height     "80vh"
+                     :background     "#1e1e1e"
+                     :color          "#ddd"
+                     :border         "1px solid #444"
+                     :border-radius  "6px"
+                     :padding        "16px"
+                     :font-family    "monospace"
+                     :font-size      "12px"
+                     :display        "flex"
+                     :flex-direction "column"
+                     :gap            "12px"
+                     :box-shadow     "0 12px 32px rgba(0,0,0,0.7)"
+                     :overflow       "hidden"}
+      :modal-title  {:font-weight "bold"
+                     :color       "#9cdcfe"
+                     :font-size   "13px"}
+      :id-input     {:padding       "6px 8px"
+                     :background    "#252526"
+                     :color         "white"
+                     :border        "1px solid #444"
+                     :border-radius "3px"
+                     :font-family   "monospace"
+                     :font-size     "12px"
+                     :width         "100%"
+                     :box-sizing    "border-box"}
+      :snippet      {:background    "#0e0e10"
+                     :color         "#dcdcaa"
+                     :padding       "10px"
+                     :border        "1px solid #333"
+                     :border-radius "4px"
+                     :white-space   "pre"
+                     :overflow      "auto"
+                     :max-height    "44vh"
+                     :font-family   "monospace"
+                     :font-size     "11px"
+                     :line-height   "1.45"
+                     :flex          "1 1 auto"}
+      :btn-row      {:display         "flex"
+                     :gap             "8px"
+                     :justify-content "flex-end"}
+      :btn          {:padding       "5px 12px"
+                     :background    "#0e639c"
+                     :color         "white"
+                     :border        "none"
+                     :border-radius "3px"
+                     :cursor        "pointer"
+                     :font-family   "monospace"
+                     :font-size     "11px"}
+      :btn-muted    {:padding       "5px 12px"
+                     :background    "transparent"
+                     :color         "#cccccc"
+                     :border        "1px solid #444"
+                     :border-radius "3px"
+                     :cursor        "pointer"
+                     :font-family   "monospace"
+                     :font-size     "11px"}
+      :hint         {:color       "#9a9a9a"
+                     :font-style  "italic"
+                     :font-size   "10px"}}))
+
+#?(:cljs
+   (defn review-dialog
+     "Render the review-then-commit modal. Returns nil when `:open?` is
+     false on `dialog-state`; otherwise returns the hiccup tree.
+
+     `dialog-state` is the dialog map (`{:open? :draft-id :source-id
+     :context}`); the caller derefs its ratom and threads the value
+     in.
+
+     `opts`:
+
+     - `:title`             — string title; goes in the modal header.
+     - `:hint`              — string/hiccup hint below the header.
+     - `:snippet`           — string; the generated EDN snippet.
+                              Re-rendered on every keystroke by the
+                              caller before passing in.
+     - `:placeholder-id`    — keyword fallback for the input's
+                              `:default-value` when `:draft-id` is
+                              nil (e.g. `:story.recorded/example` /
+                              `:story.saved/example`).
+     - `:placeholder-input` — string `:placeholder` for the input.
+     - `:on-edit-id`        — `(fn [raw-string])` called on every
+                              keystroke with the input's raw value.
+                              Caller typically pipes through
+                              `swap-parse-and-set-draft-id!`.
+     - `:on-copy`           — `(fn [])` invoked when the user clicks
+                              'copy to clipboard'.
+     - `:on-discard`        — optional `(fn [])` — when provided, a
+                              'discard' button renders left of
+                              'copy'. Recorder uses (discards the
+                              captured events); save-variant does not.
+     - `:on-close`          — `(fn [])` invoked on backdrop-click + on
+                              the 'close' button.
+     - `:data-test-prefix`  — string prefix for all `:data-test`
+                              attrs in the rendered hiccup (e.g.
+                              `\"story-recorder\"` /
+                              `\"story-save-variant\"`)."
+     [dialog-state
+      {:keys [title hint snippet placeholder-id placeholder-input
+              on-edit-id on-copy on-discard on-close data-test-prefix]}]
+     (when (:open? dialog-state)
+       (let [draft-id     (:draft-id dialog-state)
+             effective-id (or draft-id placeholder-id)
+             dtest        (fn [suffix] (str data-test-prefix "-" suffix))]
+         [:div {:style     (:modal-back styles)
+                :data-test (dtest "dialog")
+                :on-click  (fn [e]
+                             (when (= (.-target e) (.-currentTarget e))
+                               (on-close)))}
+          [:div {:style    (:modal styles)
+                 :on-click (fn [e] (.stopPropagation e))}
+           [:div {:style (:modal-title styles)} title]
+           (when hint
+             [:div {:style (:hint styles)} hint])
+           [:input
+            {:type          "text"
+             :style         (:id-input styles)
+             :data-test     (dtest "id-input")
+             :default-value (pr-str effective-id)
+             :on-change     (fn [e] (on-edit-id (.. e -target -value)))
+             :placeholder   placeholder-input}]
+           [:pre {:style     (:snippet styles)
+                  :data-test (dtest "snippet")}
+            snippet]
+           [:div {:style (:btn-row styles)}
+            (when on-discard
+              [:button
+               {:style     (:btn-muted styles)
+                :data-test (dtest "discard")
+                :on-click  (fn [_] (on-discard))}
+               "discard"])
+            [:button
+             {:style     (:btn styles)
+              :data-test (dtest "copy")
+              :on-click  (fn [_] (on-copy))}
+             "copy to clipboard"]
+            [:button
+             {:style     (:btn-muted styles)
+              :data-test (dtest "close")
+              :on-click  (fn [_] (on-close))}
+             "close"]]]]))))

--- a/tools/story/src/re_frame/story/save_variant.cljc
+++ b/tools/story/src/re_frame/story/save_variant.cljc
@@ -38,10 +38,11 @@
   The dialog ratom + button component live in
   `re-frame.story.ui.save-variant` (CLJS-only)."
   (:require [clojure.string :as str]
-            [re-frame.core            :as rf]
-            [re-frame.story.args      :as args]
-            [re-frame.story.config    :as config]
-            [re-frame.story.ui.state  :as state]))
+            [re-frame.core                  :as rf]
+            [re-frame.story.args            :as args]
+            [re-frame.story.config          :as config]
+            [re-frame.story.review-dialog   :as review-dialog]
+            [re-frame.story.ui.state        :as state]))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: args-snapshot helper
@@ -130,63 +131,60 @@
          "\n  {" body-str "})")))
 
 ;; ---------------------------------------------------------------------------
-;; Pure: default-id derivation
+;; Default-id derivation + dialog state shape
 ;;
-;; The save-as flow seeds the dialog's id input with a sensible default —
-;; the source variant's namespace + a wall-clock-derived suffix so two
-;; saves against the same source don't collide before the user edits.
-;; Mirrors `re-frame.story.ui.recorder/default-variant-id`'s shape but
-;; uses a `saved-` prefix to distinguish from `recorded-` traces.
+;; The dialog state machine + the default-id derivation live in the
+;; shared `re-frame.story.review-dialog` ns (rf2-7jpky); the save-
+;; variant flow's only flavour is the `\"saved-\"` prefix on the auto-
+;; derived id and the `{:args <snapshot>}` shape stashed in the
+;; dialog's `:context` slot. Thin re-exports below for ergonomics +
+;; the legacy `:args` key in the opened state (preserved for callers
+;; that read it via the open-dialog callback).
 ;; ---------------------------------------------------------------------------
+
+(def ^:const default-id-prefix
+  "Per-flow prefix for the auto-derived default new-variant id."
+  "saved")
 
 (defn default-variant-id
-  "Derive a sensible default id for the new variant given the source
-  variant id + a wall-clock millis stamp. Pure data → keyword.
-
-  Returns nil if `source-variant-id` is not a qualified keyword."
+  "Derive the save-variant default new-variant id from a source variant
+  id + a wall-clock millis stamp. Pure data → keyword | nil. Delegates
+  to `review-dialog/default-variant-id-with-prefix`; nil for non-
+  qualified-keyword sources."
   [source-variant-id now-ms]
-  (when (qualified-keyword? source-variant-id)
-    (let [suffix (mod (long now-ms) 1000000)]
-      (keyword (namespace source-variant-id)
-               (str "saved-" suffix)))))
-
-;; ---------------------------------------------------------------------------
-;; Pure: dialog-state shape + transitions
-;;
-;; The save-as-variant dialog carries its own state — open?, the draft
-;; id the user types, the source variant id, and the snapshot args. The
-;; pure transitions are JVM-testable; the impure ratom + UI live in
-;; `re-frame.story.ui.save-variant`.
-;; ---------------------------------------------------------------------------
+  (review-dialog/default-variant-id-with-prefix
+    source-variant-id now-ms default-id-prefix))
 
 (def initial-dialog-state
-  "The save-variant dialog's idle state shape."
-  {:open?       false
-   :draft-id    nil
-   :source-id   nil
-   :args        nil})
+  "Alias for `review-dialog/initial-state` — kept for call-site
+  ergonomics so the dialog ratom seeding form reads as
+  `save-variant/initial-dialog-state`."
+  review-dialog/initial-state)
 
 (defn open
-  "Pure: return the dialog state for opening against `source-variant-id`
-  with the captured `args-snapshot`. `now-ms` seeds the default id."
+  "Open the save-variant dialog against `source-variant-id` with the
+  captured `args-snapshot`. `now-ms` seeds the default id. The args
+  ride in the dialog state's `:context` slot (per the review-dialog
+  contract); a top-level `:args` key is preserved so callers reading
+  the legacy slot keep working."
   [_state source-variant-id args-snapshot now-ms]
-  {:open?     true
-   :source-id source-variant-id
-   :args      args-snapshot
-   :draft-id  (default-variant-id source-variant-id now-ms)})
+  (let [base (review-dialog/open review-dialog/initial-state
+                                 source-variant-id
+                                 {:args args-snapshot}
+                                 now-ms
+                                 default-id-prefix)]
+    (assoc base :args args-snapshot)))
 
 (defn close
-  "Pure: return the dialog state for closing — open? flips false; the
-  args/source slots clear so the next open starts fresh."
+  "Close the dialog — returns the idle state."
   [_state]
-  initial-dialog-state)
+  review-dialog/initial-state)
 
 (defn set-draft-id
-  "Pure: replace the draft id in the dialog state. `id` may be a keyword
-  or a string (the UI layer parses string input into keywords on best-
-  effort; the pure transition just stores whatever the caller passes)."
+  "Replace the draft id in the dialog state. `id` may be a keyword or a
+  raw string the user is typing."
   [state id]
-  (assoc state :draft-id id))
+  (review-dialog/set-draft-id state id))
 
 ;; ---------------------------------------------------------------------------
 ;; Impure: capture + open

--- a/tools/story/src/re_frame/story/ui/recorder.cljs
+++ b/tools/story/src/re_frame/story/ui/recorder.cljs
@@ -63,9 +63,10 @@
   (:require [cljs.reader]
             [clojure.string :as str]
             [reagent.core :as r]
-            [re-frame.story.config :as config]
-            [re-frame.story.recorder :as recorder]
-            [re-frame.story.ui.state :as state]))
+            [re-frame.story.config         :as config]
+            [re-frame.story.recorder       :as recorder]
+            [re-frame.story.review-dialog  :as review-dialog]
+            [re-frame.story.ui.state       :as state]))
 
 ;; ---------------------------------------------------------------------------
 ;; Reagent mirror of the recorder state
@@ -182,52 +183,9 @@
                  :display      "flex"
                  :align-items  "center"
                  :gap          "8px"}
-   :modal-back  {:position "fixed"
-                 :top "0" :left "0" :right "0" :bottom "0"
-                 :background "rgba(0,0,0,0.55)"
-                 :z-index 1700
-                 :display "flex"
-                 :align-items "center"
-                 :justify-content "center"}
-   :modal       {:width        "640px"
-                 :max-width    "90vw"
-                 :max-height   "80vh"
-                 :background   "#1e1e1e"
-                 :color        "#ddd"
-                 :border       "1px solid #444"
-                 :border-radius "6px"
-                 :padding      "16px"
-                 :font-family  "monospace"
-                 :font-size    "12px"
-                 :display      "flex"
-                 :flex-direction "column"
-                 :gap          "12px"
-                 :box-shadow   "0 12px 32px rgba(0,0,0,0.7)"
-                 :overflow     "hidden"}
-   :modal-title {:font-weight "bold"
-                 :color "#9cdcfe"
-                 :font-size "13px"}
-   :id-input    {:padding "6px 8px"
-                 :background "#252526"
-                 :color "white"
-                 :border "1px solid #444"
-                 :border-radius "3px"
-                 :font-family "monospace"
-                 :font-size "12px"
-                 :width "100%"
-                 :box-sizing "border-box"}
-   :snippet     {:background "#0e0e10"
-                 :color "#dcdcaa"
-                 :padding "10px"
-                 :border "1px solid #333"
-                 :border-radius "4px"
-                 :white-space "pre"
-                 :overflow "auto"
-                 :max-height "44vh"
-                 :font-family "monospace"
-                 :font-size "11px"
-                 :line-height "1.45"
-                 :flex "1 1 auto"}
+   ;; Modal styling for the save-as-variant dialog moved to
+   ;; `re-frame.story.review-dialog` (rf2-7jpky); only the chip /
+   ;; overlay / picker styles remain here.
    :btn-row     {:display "flex"
                  :gap "8px"
                  :justify-content "flex-end"}
@@ -334,8 +292,13 @@
                  :line-height "1.4"}})
 
 ;; ---------------------------------------------------------------------------
-;; Modal state — a single flag for whether the save-as-variant dialog
-;; is open + a draft variant id the user types into.
+;; Modal state — driven by `re-frame.story.review-dialog`. The shared
+;; dialog state map carries `:open?` / `:draft-id` / `:source-id` /
+;; `:context`; the recorder's flow stashes the recorded source
+;; variant id in `:source-id` and reads the captured `:events` off
+;; `@ui-state` at render time (the recorder atom is the source of
+;; truth for events; the dialog is just the review-then-commit
+;; surface).
 ;;
 ;; The dialog opens automatically when the user STOPS recording and
 ;; there are captured events; it can also be reopened from the toolbar
@@ -343,44 +306,21 @@
 ;; only — re-open is a v1.1 polish).
 ;; ---------------------------------------------------------------------------
 
-(defonce ui-dialog
-  (r/atom {:open? false
-           :draft-id nil}))
+(def ^:const default-id-prefix
+  "Per-flow prefix for the auto-derived default new-variant id."
+  "recorded")
 
-(defn- default-variant-id
-  "Derive a sensible default id for the new variant. Uses the recorded
-  variant's namespace + '/recorded-N' where N is a wall-clock-derived
-  short suffix so multiple recordings against the same variant don't
-  clobber each other."
-  [source-variant-id]
-  (when (and source-variant-id (qualified-keyword? source-variant-id))
-    (let [suffix (-> (.now js/Date)
-                     (mod 1000000)
-                     str)]
-      (keyword (namespace source-variant-id)
-               (str "recorded-" suffix)))))
+(defonce ui-dialog
+  (review-dialog/make-dialog-atom))
 
 (defn- open-dialog! [source-variant-id]
-  (swap! ui-dialog assoc
-         :open? true
-         :draft-id (default-variant-id source-variant-id)))
+  (review-dialog/swap-open-now! ui-dialog source-variant-id nil default-id-prefix))
 
 (defn- close-dialog! []
-  (swap! ui-dialog assoc :open? false))
+  (review-dialog/swap-close! ui-dialog))
 
 (defn- set-draft-id! [s]
-  (let [k (try
-            (let [stripped (cond-> s
-                             (and (string? s)
-                                  (re-find #"^:" s))
-                             (subs 1))]
-              (when (and (string? stripped) (seq stripped))
-                (if (re-find #"/" stripped)
-                  (let [[ns nm] (str/split stripped #"/" 2)]
-                    (keyword ns nm))
-                  (keyword stripped))))
-            (catch :default _ nil))]
-    (swap! ui-dialog assoc :draft-id (or k s))))
+  (review-dialog/swap-parse-and-set-draft-id! ui-dialog s))
 
 ;; ---------------------------------------------------------------------------
 ;; Toolbar chip + overlay components
@@ -649,14 +589,8 @@
         "stop"]])))
 
 ;; ---------------------------------------------------------------------------
-;; Save-as-variant dialog
+;; Save-as-variant dialog — delegated to `re-frame.story.review-dialog`
 ;; ---------------------------------------------------------------------------
-
-(defn- copy-to-clipboard! [snippet]
-  (try
-    (when (and (exists? js/navigator) (.-clipboard js/navigator))
-      (.writeText (.-clipboard js/navigator) snippet))
-    (catch :default _ nil)))
 
 (defn save-dialog
   "Modal dialog rendered after the user stops a non-empty recording.
@@ -666,53 +600,27 @@
   The user edits the variant id inline; the snippet re-generates on
   every keystroke. Discard / close drop the captured events."
   []
-  (let [{:keys [open? draft-id]}      @ui-dialog
-        {:keys [variant-id events]}   @ui-state]
-    (when open?
-      (let [snippet (recorder/gen-play-snippet
-                      events
-                      {:variant-id (or draft-id :story.recorded/example)
-                       :extends    variant-id})]
-        [:div {:style (:modal-back styles)
-               :data-test "story-recorder-dialog"
-               :on-click  (fn [e]
-                            (when (= (.-target e) (.-currentTarget e))
-                              (close-dialog!)))}
-         [:div {:style (:modal styles)
-                :on-click (fn [e] (.stopPropagation e))}
-          [:div {:style (:modal-title styles)}
-           "Test Codegen — save recording as variant"]
-          [:div {:style (:hint styles)}
-           "EDN snippet generated from "
-           (count events) " captured event"
-           (when (not= 1 (count events)) "s")
-           " against " (pr-str variant-id) ". Edit the variant id then "
-           "copy + paste into your stories namespace."]
-          [:input
-           {:type       "text"
-            :style      (:id-input styles)
-            :data-test  "story-recorder-id-input"
-            :default-value (pr-str (or draft-id :story.recorded/example))
-            :on-change  (fn [e] (set-draft-id! (.. e -target -value)))
-            :placeholder ":story.your-story/recorded-flow"}]
-          [:pre {:style (:snippet styles)
-                 :data-test "story-recorder-snippet"}
-           snippet]
-          [:div {:style (:btn-row styles)}
-           [:button
-            {:style    (:btn-muted styles)
-             :data-test "story-recorder-discard"
-             :on-click (fn [_]
-                         (recorder/clear!)
-                         (close-dialog!))}
-            "discard"]
-           [:button
-            {:style     (:btn styles)
-             :data-test "story-recorder-copy"
-             :on-click  (fn [_] (copy-to-clipboard! snippet))}
-            "copy to clipboard"]
-           [:button
-            {:style    (:btn-muted styles)
-             :data-test "story-recorder-close"
-             :on-click (fn [_] (close-dialog!))}
-            "close"]]]]))))
+  (let [dialog                    @ui-dialog
+        {:keys [variant-id events]} @ui-state]
+    (when (:open? dialog)
+      (let [draft-id (:draft-id dialog)
+            snippet  (recorder/gen-play-snippet
+                       events
+                       {:variant-id (or draft-id :story.recorded/example)
+                        :extends    variant-id})]
+        (review-dialog/review-dialog dialog
+          {:title             "Test Codegen — save recording as variant"
+           :hint              (str "EDN snippet generated from "
+                                   (count events) " captured event"
+                                   (when (not= 1 (count events)) "s")
+                                   " against " (pr-str variant-id)
+                                   ". Edit the variant id then "
+                                   "copy + paste into your stories namespace.")
+           :snippet           snippet
+           :placeholder-id    :story.recorded/example
+           :placeholder-input ":story.your-story/recorded-flow"
+           :on-edit-id        set-draft-id!
+           :on-copy           (fn [] (review-dialog/copy-to-clipboard! snippet))
+           :on-discard        (fn [] (recorder/clear!) (close-dialog!))
+           :on-close          close-dialog!
+           :data-test-prefix  "story-recorder"})))))

--- a/tools/story/src/re_frame/story/ui/save_variant.cljs
+++ b/tools/story/src/re_frame/story/ui/save_variant.cljs
@@ -27,22 +27,22 @@
   CLJS builds short-circuit before any DOM call. The UI-callback wiring
   via `install!` is the only impure registration the ns owns; idempotent
   on re-mount."
-  (:require [clojure.string :as str]
-            [reagent.core :as r]
-            [re-frame.story.config       :as config]
-            [re-frame.story.save-variant :as save-variant]
-            [re-frame.story.ui.state     :as state]))
+  (:require [reagent.core :as r]
+            [re-frame.story.config        :as config]
+            [re-frame.story.review-dialog :as review-dialog]
+            [re-frame.story.save-variant  :as save-variant]))
 
 ;; ---------------------------------------------------------------------------
-;; Dialog ratom — the impure mirror of `save-variant/initial-dialog-state`.
+;; Dialog ratom — the impure mirror of `review-dialog/initial-state`.
 ;;
-;; The pure transitions in `save-variant` produce new state maps; the
-;; UI swaps the ratom around them so Reagent re-renders the modal on
-;; every keystroke.
+;; The pure transitions in `re-frame.story.review-dialog` +
+;; `re-frame.story.save-variant` produce new state maps; the UI swaps
+;; the ratom around them so Reagent re-renders the modal on every
+;; keystroke.
 ;; ---------------------------------------------------------------------------
 
 (defonce ui-dialog
-  (r/atom save-variant/initial-dialog-state))
+  (r/atom review-dialog/initial-state))
 
 (defn- open-dialog!
   "Open the dialog against `source-variant-id` with the captured
@@ -54,18 +54,7 @@
   (swap! ui-dialog save-variant/close))
 
 (defn- set-draft-id! [s]
-  (let [k (try
-            (let [stripped (cond-> s
-                             (and (string? s)
-                                  (re-find #"^:" s))
-                             (subs 1))]
-              (when (and (string? stripped) (seq stripped))
-                (if (re-find #"/" stripped)
-                  (let [[ns nm] (str/split stripped #"/" 2)]
-                    (keyword ns nm))
-                  (keyword stripped))))
-            (catch :default _ nil))]
-    (swap! ui-dialog save-variant/set-draft-id (or k s))))
+  (review-dialog/swap-parse-and-set-draft-id! ui-dialog s))
 
 ;; ---------------------------------------------------------------------------
 ;; Install — register the CLJS open-callback against the pure ns so
@@ -82,20 +71,22 @@
     nil))
 
 ;; ---------------------------------------------------------------------------
-;; Styling — mirrors the recorder's dialog so the two save-as flows
-;; (record-as-:play + snapshot-as-:args) share visual language.
+;; Button styling — the controls-panel-local affordance. The modal
+;; itself reuses `re-frame.story.review-dialog`'s shared styles so the
+;; two save-as flows (record-as-:play + snapshot-as-:args) share
+;; visual language.
 ;; ---------------------------------------------------------------------------
 
-(def ^:private styles
-  {:button       {:padding         "4px 8px"
-                  :background      "#0e639c"
-                  :color           "white"
-                  :border          "none"
-                  :border-radius   "3px"
-                  :cursor          "pointer"
-                  :font-size       "10px"
-                  :margin-top      "8px"
-                  :font-family     "monospace"}
+(def ^:private button-styles
+  {:button          {:padding       "4px 8px"
+                     :background    "#0e639c"
+                     :color         "white"
+                     :border        "none"
+                     :border-radius "3px"
+                     :cursor        "pointer"
+                     :font-size     "10px"
+                     :margin-top    "8px"
+                     :font-family   "monospace"}
    :button-disabled {:padding       "4px 8px"
                      :background    "#2d2d30"
                      :color         "#777"
@@ -104,75 +95,7 @@
                      :cursor        "not-allowed"
                      :font-size     "10px"
                      :margin-top    "8px"
-                     :font-family   "monospace"}
-   :modal-back   {:position "fixed"
-                  :top "0" :left "0" :right "0" :bottom "0"
-                  :background "rgba(0,0,0,0.55)"
-                  :z-index 1700
-                  :display "flex"
-                  :align-items "center"
-                  :justify-content "center"}
-   :modal        {:width        "640px"
-                  :max-width    "90vw"
-                  :max-height   "80vh"
-                  :background   "#1e1e1e"
-                  :color        "#ddd"
-                  :border       "1px solid #444"
-                  :border-radius "6px"
-                  :padding      "16px"
-                  :font-family  "monospace"
-                  :font-size    "12px"
-                  :display      "flex"
-                  :flex-direction "column"
-                  :gap          "12px"
-                  :box-shadow   "0 12px 32px rgba(0,0,0,0.7)"
-                  :overflow     "hidden"}
-   :modal-title  {:font-weight "bold"
-                  :color "#9cdcfe"
-                  :font-size "13px"}
-   :id-input     {:padding "6px 8px"
-                  :background "#252526"
-                  :color "white"
-                  :border "1px solid #444"
-                  :border-radius "3px"
-                  :font-family "monospace"
-                  :font-size "12px"
-                  :width "100%"
-                  :box-sizing "border-box"}
-   :snippet      {:background "#0e0e10"
-                  :color "#dcdcaa"
-                  :padding "10px"
-                  :border "1px solid #333"
-                  :border-radius "4px"
-                  :white-space "pre"
-                  :overflow "auto"
-                  :max-height "44vh"
-                  :font-family "monospace"
-                  :font-size "11px"
-                  :line-height "1.45"
-                  :flex "1 1 auto"}
-   :btn-row      {:display "flex"
-                  :gap "8px"
-                  :justify-content "flex-end"}
-   :btn          {:padding "5px 12px"
-                  :background "#0e639c"
-                  :color "white"
-                  :border "none"
-                  :border-radius "3px"
-                  :cursor "pointer"
-                  :font-family "monospace"
-                  :font-size "11px"}
-   :btn-muted    {:padding "5px 12px"
-                  :background "transparent"
-                  :color "#cccccc"
-                  :border "1px solid #444"
-                  :border-radius "3px"
-                  :cursor "pointer"
-                  :font-family "monospace"
-                  :font-size "11px"}
-   :hint         {:color "#9a9a9a"
-                  :font-style "italic"
-                  :font-size "10px"}})
+                     :font-family   "monospace"}})
 
 ;; ---------------------------------------------------------------------------
 ;; Controls-panel button
@@ -193,8 +116,8 @@
   (let [enabled? (some? variant-id)]
     [:button
      {:style     (if enabled?
-                   (:button styles)
-                   (:button-disabled styles))
+                   (:button button-styles)
+                   (:button-disabled button-styles))
       :disabled  (not enabled?)
       :data-test "story-save-variant-button"
       :title     (if enabled?
@@ -207,18 +130,12 @@
      "save as new variant…"]))
 
 ;; ---------------------------------------------------------------------------
-;; Modal dialog — review-then-commit
+;; Modal dialog — delegated to `re-frame.story.review-dialog`
 ;;
 ;; The user reviews the generated EDN snippet, edits the new variant id
 ;; inline, copies to clipboard, and pastes into source. Source is never
 ;; written directly — same as the recorder's save-as-variant dialog.
 ;; ---------------------------------------------------------------------------
-
-(defn- copy-to-clipboard! [snippet]
-  (try
-    (when (and (exists? js/navigator) (.-clipboard js/navigator))
-      (.writeText (.-clipboard js/navigator) snippet))
-    (catch :default _ nil)))
 
 (defn save-dialog
   "Render the save-variant modal. Visible iff `:open?` is true on the
@@ -229,44 +146,23 @@
   Public so tests can render the dialog hiccup directly after seeding
   the dialog ratom."
   []
-  (let [{:keys [open? draft-id source-id args]} @ui-dialog]
-    (when open?
-      (let [snippet (save-variant/gen-variant-snippet
+  (let [dialog @ui-dialog]
+    (when (:open? dialog)
+      (let [{:keys [draft-id source-id args]} dialog
+            snippet (save-variant/gen-variant-snippet
                       {:variant-id (or draft-id :story.saved/example)
                        :extends    source-id
                        :args       args})]
-        [:div {:style (:modal-back styles)
-               :data-test "story-save-variant-dialog"
-               :on-click  (fn [e]
-                            (when (= (.-target e) (.-currentTarget e))
-                              (close-dialog!)))}
-         [:div {:style (:modal styles)
-                :on-click (fn [e] (.stopPropagation e))}
-          [:div {:style (:modal-title styles)}
-           "Save current canvas state as new variant"]
-          [:div {:style (:hint styles)}
-           "Args snapshot captured from "
-           (pr-str source-id)
-           " — edit the new variant id and copy + paste into your "
-           "stories namespace. Source is never written directly."]
-          [:input
-           {:type          "text"
-            :style         (:id-input styles)
-            :data-test     "story-save-variant-id-input"
-            :default-value (pr-str (or draft-id :story.saved/example))
-            :on-change     (fn [e] (set-draft-id! (.. e -target -value)))
-            :placeholder   ":story.your-story/saved-flow"}]
-          [:pre {:style     (:snippet styles)
-                 :data-test "story-save-variant-snippet"}
-           snippet]
-          [:div {:style (:btn-row styles)}
-           [:button
-            {:style     (:btn styles)
-             :data-test "story-save-variant-copy"
-             :on-click  (fn [_] (copy-to-clipboard! snippet))}
-            "copy to clipboard"]
-           [:button
-            {:style    (:btn-muted styles)
-             :data-test "story-save-variant-close"
-             :on-click (fn [_] (close-dialog!))}
-            "close"]]]]))))
+        (review-dialog/review-dialog dialog
+          {:title             "Save current canvas state as new variant"
+           :hint              (str "Args snapshot captured from "
+                                   (pr-str source-id)
+                                   " — edit the new variant id and copy + paste into your "
+                                   "stories namespace. Source is never written directly.")
+           :snippet           snippet
+           :placeholder-id    :story.saved/example
+           :placeholder-input ":story.your-story/saved-flow"
+           :on-edit-id        set-draft-id!
+           :on-copy           (fn [] (review-dialog/copy-to-clipboard! snippet))
+           :on-close          close-dialog!
+           :data-test-prefix  "story-save-variant"})))))

--- a/tools/story/test/re_frame/story_review_dialog_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_review_dialog_cljs_test.cljs
@@ -1,0 +1,189 @@
+(ns re-frame.story-review-dialog-cljs-test
+  "CLJS-side tests for the shared review-then-commit dialog primitive
+  (rf2-7jpky).
+
+  Runs under shadow's `:node-test` build (ns-regexp `cljs-test$`).
+  The pure-data corpus is identical to the JVM
+  `re-frame.story-review-dialog-test` arm; this file adds the CLJS-
+  only hiccup-renderer assertions that the recorder + save-variant
+  flows both depend on."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as str]
+            [re-frame.story.review-dialog :as review-dialog]))
+
+;; ---- parse-variant-id-string ---------------------------------------------
+
+(deftest parse-with-leading-colon
+  (is (= :foo/bar (review-dialog/parse-variant-id-string ":foo/bar")))
+  (is (= :plain   (review-dialog/parse-variant-id-string ":plain"))))
+
+(deftest parse-without-leading-colon
+  (is (= :foo/bar (review-dialog/parse-variant-id-string "foo/bar")))
+  (is (= :plain   (review-dialog/parse-variant-id-string "plain"))))
+
+(deftest parse-nil-for-empty-or-bad-input
+  (is (nil? (review-dialog/parse-variant-id-string nil)))
+  (is (nil? (review-dialog/parse-variant-id-string "")))
+  (is (nil? (review-dialog/parse-variant-id-string "foo/")))
+  (is (nil? (review-dialog/parse-variant-id-string "/bar"))))
+
+;; ---- default-variant-id-with-prefix --------------------------------------
+
+(deftest default-uses-source-namespace
+  (let [k (review-dialog/default-variant-id-with-prefix
+            :story.counter/happy-path 12345 "saved")]
+    (is (qualified-keyword? k))
+    (is (= "story.counter" (namespace k)))
+    (is (str/starts-with? (name k) "saved-"))))
+
+(deftest default-honors-custom-prefix
+  (is (= "recorded-0"
+         (name (review-dialog/default-variant-id-with-prefix
+                 :story.x/y 0 "recorded"))))
+  (is (= "saved-0"
+         (name (review-dialog/default-variant-id-with-prefix
+                 :story.x/y 0 "saved")))))
+
+(deftest default-nil-for-unqualified-source
+  (is (nil? (review-dialog/default-variant-id-with-prefix nil 0 "saved")))
+  (is (nil? (review-dialog/default-variant-id-with-prefix
+              :unqualified 0 "saved"))))
+
+;; ---- dialog state machine ------------------------------------------------
+
+(deftest initial-state-is-idle
+  (is (false? (:open?     review-dialog/initial-state)))
+  (is (nil?   (:draft-id  review-dialog/initial-state)))
+  (is (nil?   (:source-id review-dialog/initial-state))))
+
+(deftest open-flips-open-and-seeds-defaults
+  (let [s (review-dialog/open review-dialog/initial-state
+                              :story.x/y
+                              {:args {:n 1}}
+                              12345
+                              "saved")]
+    (is (true? (:open? s)))
+    (is (= :story.x/y (:source-id s)))
+    (is (= {:args {:n 1}} (:context s)))
+    (is (qualified-keyword? (:draft-id s)))))
+
+(deftest close-returns-idle
+  (let [opened (review-dialog/open review-dialog/initial-state
+                                   :story.x/y {} 0 "saved")]
+    (is (= review-dialog/initial-state (review-dialog/close opened)))))
+
+(deftest parse-and-set-draft-id-parses-on-success
+  (let [s (-> review-dialog/initial-state
+              (review-dialog/open :story.x/y nil 0 "saved")
+              (review-dialog/parse-and-set-draft-id ":story.x/edited"))]
+    (is (= :story.x/edited (:draft-id s)))))
+
+(deftest parse-and-set-draft-id-keeps-raw-on-failure
+  (let [s (-> review-dialog/initial-state
+              (review-dialog/open :story.x/y nil 0 "saved")
+              (review-dialog/parse-and-set-draft-id "foo/"))]
+    (is (= "foo/" (:draft-id s)))))
+
+;; ---- renderer: closed state ----------------------------------------------
+
+(deftest renderer-returns-nil-when-closed
+  (testing "the renderer returns nil for the idle state"
+    (is (nil? (review-dialog/review-dialog
+                review-dialog/initial-state
+                {:title             "Test"
+                 :snippet           "(snippet)"
+                 :placeholder-id    :story.x/example
+                 :placeholder-input ":story.x/sample"
+                 :on-edit-id        (fn [_])
+                 :on-copy           (fn [])
+                 :on-close          (fn [])
+                 :data-test-prefix  "test"})))))
+
+;; ---- renderer: opened state ----------------------------------------------
+
+(defn- opened-state []
+  (review-dialog/open review-dialog/initial-state
+                      :story.x/source
+                      {:args {:n 1}}
+                      12345
+                      "saved"))
+
+(deftest renderer-returns-hiccup-when-open
+  (testing "the renderer returns a hiccup tree when :open? is true"
+    (let [hiccup (review-dialog/review-dialog
+                   (opened-state)
+                   {:title             "Save"
+                    :hint              "the hint"
+                    :snippet           "(snippet)"
+                    :placeholder-id    :story.x/example
+                    :placeholder-input ":story.x/sample"
+                    :on-edit-id        (fn [_])
+                    :on-copy           (fn [])
+                    :on-close          (fn [])
+                    :data-test-prefix  "test"})
+          flat   (str hiccup)]
+      (is (vector? hiccup) "the renderer produces a hiccup vector")
+      (is (str/includes? flat "test-dialog"))
+      (is (str/includes? flat "test-id-input"))
+      (is (str/includes? flat "test-snippet"))
+      (is (str/includes? flat "test-copy"))
+      (is (str/includes? flat "test-close"))
+      (is (str/includes? flat "(snippet)")
+          "the rendered snippet string appears in the tree")
+      (is (str/includes? flat "Save")
+          "the title appears in the tree"))))
+
+(deftest renderer-without-on-discard-omits-discard-button
+  (testing "no :on-discard → no 'discard' button is rendered"
+    (let [flat (str (review-dialog/review-dialog
+                      (opened-state)
+                      {:title             "Save"
+                       :snippet           "(snippet)"
+                       :placeholder-id    :story.x/example
+                       :placeholder-input ":story.x/sample"
+                       :on-edit-id        (fn [_])
+                       :on-copy           (fn [])
+                       :on-close          (fn [])
+                       :data-test-prefix  "test"}))]
+      (is (not (str/includes? flat "test-discard"))
+          "the discard data-test slot is absent"))))
+
+(deftest renderer-with-on-discard-renders-discard-button
+  (testing ":on-discard provided → 'discard' button renders"
+    (let [flat (str (review-dialog/review-dialog
+                     (opened-state)
+                     {:title             "Save"
+                      :snippet           "(snippet)"
+                      :placeholder-id    :story.x/example
+                      :placeholder-input ":story.x/sample"
+                      :on-edit-id        (fn [_])
+                      :on-copy           (fn [])
+                      :on-discard        (fn [])
+                      :on-close          (fn [])
+                      :data-test-prefix  "test"}))]
+      (is (str/includes? flat "test-discard")))))
+
+(deftest renderer-uses-placeholder-when-draft-id-nil
+  (testing "with no draft-id seeded the input's default-value is the placeholder"
+    (let [state (review-dialog/open review-dialog/initial-state
+                                    :unqualified-source
+                                    nil
+                                    0
+                                    "saved")
+          flat  (str (review-dialog/review-dialog
+                       state
+                       {:title             "Save"
+                        :snippet           "(snippet)"
+                        :placeholder-id    :story.x/example
+                        :placeholder-input ":story.x/sample"
+                        :on-edit-id        (fn [_])
+                        :on-copy           (fn [])
+                        :on-close          (fn [])
+                        :data-test-prefix  "test"}))]
+      ;; unqualified source produces nil draft-id → renderer falls back
+      ;; to placeholder-id (`:story.x/example`).
+      (is (str/includes? flat ":story.x/example")))))
+
+(deftest copy-to-clipboard!-safe-on-node
+  (testing "the shared copy helper is callable + no-ops without a clipboard API"
+    (is (nil? (review-dialog/copy-to-clipboard! "anything")))))

--- a/tools/story/test/re_frame/story_review_dialog_test.clj
+++ b/tools/story/test/re_frame/story_review_dialog_test.clj
@@ -1,0 +1,185 @@
+(ns re-frame.story-review-dialog-test
+  "JVM tests for the shared review-then-commit dialog primitive
+  (rf2-7jpky).
+
+  Pure-data coverage: the dialog state machine (`initial-state` /
+  `open` / `close` / `set-draft-id` / `parse-and-set-draft-id`), the
+  default-id derivation (`default-variant-id-with-prefix`), and the
+  variant-id string parser (`parse-variant-id-string`). Mirrors the
+  cljs-test arm in `story_review_dialog_cljs_test.cljs`.
+
+  ## Coverage layers
+
+  - `parse-variant-id-string` — best-effort string → keyword parser
+    the UI's id-input pipes through on every keystroke. Handles
+    leading `:` and embedded `/`; returns nil on parse failure so
+    callers stash the raw string.
+  - `default-variant-id-with-prefix` — keyword derivation from a
+    source variant id + wall-clock millis + a per-flow prefix
+    (`\"recorded\"` for the recorder; `\"saved\"` for save-variant).
+  - Pure transitions (`open` / `close` / `set-draft-id` /
+    `parse-and-set-draft-id`) — JVM-testable in isolation; the CLJS
+    adapter swaps a Reagent ratom around them."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.review-dialog :as review-dialog]))
+
+;; ---- parse-variant-id-string ---------------------------------------------
+
+(deftest parse-with-leading-colon
+  (testing "input with leading `:` strips it and parses"
+    (is (= :foo/bar (review-dialog/parse-variant-id-string ":foo/bar")))
+    (is (= :plain   (review-dialog/parse-variant-id-string ":plain")))))
+
+(deftest parse-without-leading-colon
+  (testing "input without leading `:` parses directly"
+    (is (= :foo/bar (review-dialog/parse-variant-id-string "foo/bar")))
+    (is (= :plain   (review-dialog/parse-variant-id-string "plain")))))
+
+(deftest parse-qualified-keyword
+  (testing "qualified id parses into a qualified keyword"
+    (let [k (review-dialog/parse-variant-id-string ":story.counter/saved-1")]
+      (is (qualified-keyword? k))
+      (is (= "story.counter" (namespace k)))
+      (is (= "saved-1"       (name k))))))
+
+(deftest parse-nil-for-empty-or-bad-input
+  (testing "nil / empty / non-string returns nil"
+    (is (nil? (review-dialog/parse-variant-id-string nil)))
+    (is (nil? (review-dialog/parse-variant-id-string "")))
+    (is (nil? (review-dialog/parse-variant-id-string ":"))
+        "bare colon strips to empty → nil")
+    (is (nil? (review-dialog/parse-variant-id-string "foo/")))
+    (is (nil? (review-dialog/parse-variant-id-string "/bar")))))
+
+(deftest parse-handles-keywords-only-strings
+  (testing "an input that is a printed keyword form (with leading colon) round-trips"
+    (is (= :a (review-dialog/parse-variant-id-string ":a")))
+    (is (= :ns/name
+           (review-dialog/parse-variant-id-string
+             (pr-str :ns/name))))))
+
+;; ---- default-variant-id-with-prefix --------------------------------------
+
+(deftest default-uses-source-namespace
+  (testing "the derived id inherits the source's namespace + prefix-N suffix"
+    (let [k (review-dialog/default-variant-id-with-prefix
+              :story.counter/happy-path 12345 "saved")]
+      (is (qualified-keyword? k))
+      (is (= "story.counter" (namespace k)))
+      (is (re-matches #"saved-\d+" (name k))))))
+
+(deftest default-honors-custom-prefix
+  (testing "the prefix arg drives the name's leading token"
+    (let [k (review-dialog/default-variant-id-with-prefix
+              :story.counter/x 0 "recorded")]
+      (is (= "recorded-0" (name k))))
+    (let [k (review-dialog/default-variant-id-with-prefix
+              :story.counter/x 0 "snapshot")]
+      (is (= "snapshot-0" (name k))))))
+
+(deftest default-nil-for-unqualified-source
+  (testing "an unqualified or nil source returns nil"
+    (is (nil? (review-dialog/default-variant-id-with-prefix nil 0 "saved")))
+    (is (nil? (review-dialog/default-variant-id-with-prefix
+                :unqualified 0 "saved")))))
+
+(deftest default-suffix-bounded-by-million
+  (testing "the suffix is always in [0, 999999] so it stays a short slug"
+    (doseq [now-ms [0 1 1000 1000000 1700000000000 (* 1000000 99999)]]
+      (let [k     (review-dialog/default-variant-id-with-prefix
+                    :story.x/y now-ms "saved")
+            n-str (subs (name k) (count "saved-"))
+            n     (Long/parseLong n-str)]
+        (is (and (>= n 0) (< n 1000000))
+            (str "now-ms " now-ms " produced suffix " n))))))
+
+;; ---- dialog state machine ------------------------------------------------
+
+(deftest initial-state-is-idle
+  (testing "the idle state map has the expected slots"
+    (is (false? (:open?     review-dialog/initial-state)))
+    (is (nil?   (:draft-id  review-dialog/initial-state)))
+    (is (nil?   (:source-id review-dialog/initial-state)))
+    (is (nil?   (:context   review-dialog/initial-state)))))
+
+(deftest open-flips-open-and-seeds-defaults
+  (testing "open builds the opened state with the source + context + default id"
+    (let [s (review-dialog/open review-dialog/initial-state
+                                :story.x/y
+                                {:args {:n 1}}
+                                12345
+                                "saved")]
+      (is (true? (:open? s)))
+      (is (= :story.x/y (:source-id s)))
+      (is (= {:args {:n 1}} (:context s)))
+      (is (qualified-keyword? (:draft-id s)))
+      (is (= "story.x" (namespace (:draft-id s)))))))
+
+(deftest open-with-unqualified-source-still-opens
+  (testing "an unqualified source-id leaves :draft-id nil but the dialog opens"
+    (let [s (review-dialog/open review-dialog/initial-state
+                                :unqualified
+                                nil
+                                0
+                                "saved")]
+      (is (true? (:open? s)))
+      (is (nil? (:draft-id s)))
+      (is (= :unqualified (:source-id s))))))
+
+(deftest close-returns-idle
+  (testing "close returns the idle state regardless of prior state"
+    (let [opened (review-dialog/open review-dialog/initial-state
+                                     :story.x/y {:args {:n 1}} 0 "saved")
+          closed (review-dialog/close opened)]
+      (is (= review-dialog/initial-state closed)))))
+
+(deftest set-draft-id-replaces-keyword
+  (testing "set-draft-id stores a keyword as-is"
+    (let [s (-> review-dialog/initial-state
+                (review-dialog/open :story.x/y nil 0 "saved")
+                (review-dialog/set-draft-id :story.x/edited))]
+      (is (= :story.x/edited (:draft-id s))))))
+
+(deftest set-draft-id-stores-raw-string
+  (testing "set-draft-id stores a raw string when caller passes one"
+    (let [s (-> review-dialog/initial-state
+                (review-dialog/open :story.x/y nil 0 "saved")
+                (review-dialog/set-draft-id "partial-input"))]
+      (is (= "partial-input" (:draft-id s))))))
+
+(deftest parse-and-set-parses-on-success
+  (testing "parse-and-set-draft-id parses a clean keyword string into a keyword"
+    (let [s (-> review-dialog/initial-state
+                (review-dialog/open :story.x/y nil 0 "saved")
+                (review-dialog/parse-and-set-draft-id ":story.x/edited"))]
+      (is (= :story.x/edited (:draft-id s))))))
+
+(deftest parse-and-set-keeps-raw-on-failure
+  (testing "parse-and-set-draft-id keeps the raw string on parse failure"
+    (let [s (-> review-dialog/initial-state
+                (review-dialog/open :story.x/y nil 0 "saved")
+                (review-dialog/parse-and-set-draft-id "foo/"))]
+      (is (= "foo/" (:draft-id s))
+          "the trailing-slash input doesn't parse — raw string preserved"))))
+
+(deftest parse-and-set-handles-empty-string
+  (testing "empty-string input leaves the draft-id slot at the empty string"
+    (let [s (-> review-dialog/initial-state
+                (review-dialog/open :story.x/y nil 0 "saved")
+                (review-dialog/parse-and-set-draft-id ""))]
+      (is (= "" (:draft-id s))))))
+
+;; ---- composition ---------------------------------------------------------
+
+(deftest open-then-edit-then-close-cycle
+  (testing "the full open → edit → close cycle returns the dialog to idle"
+    (let [s0 review-dialog/initial-state
+          s1 (review-dialog/open s0 :story.x/y {:args {:n 1}} 1000 "saved")
+          s2 (review-dialog/parse-and-set-draft-id s1 ":story.x/edited")
+          s3 (review-dialog/parse-and-set-draft-id s2 ":story.x/edited-again")
+          s4 (review-dialog/close s3)]
+      (is (false? (:open? s0)))
+      (is (true?  (:open? s1)))
+      (is (= :story.x/edited       (:draft-id s2)))
+      (is (= :story.x/edited-again (:draft-id s3)))
+      (is (= review-dialog/initial-state s4)))))


### PR DESCRIPTION
## Summary

Extracts a shared `re-frame.story.review-dialog` ns owning the pure data + state machine and the CLJS-only modal renderer for the "review-then-commit modal" pattern. Both save-as flows (recorder's record-as-:play, save-variant's snapshot-args-as-:args) consume the shared surface.

Per audit bead rf2-dd5ze Executive P0 #3 (covers RU2/RU3/RU4).

## What was duplicated pre-extract

- `default-variant-id` derivation — recorder used `"recorded-N"`, save-variant used `"saved-N"`; same algorithm, different prefix (RU2).
- `set-draft-id!` — identical string-→-keyword parsing logic in both ns (RU3).
- `copy-to-clipboard!` — two identical shims (RU4).
- Modal styling — recorder's `styles` map carried the same `:modal-back` / `:modal` / `:modal-title` / `:id-input` / `:snippet` / `:btn-row` slots as save-variant's.
- The recorder's dialog state (`{:open? :draft-id}`) was CLJS-only — no `.cljc` factoring, no JVM tests.

## What's now shared

`re-frame.story.review-dialog`:

- Pure (`.cljc`): `initial-state`, `open`, `close`, `set-draft-id`, `parse-and-set-draft-id`, `default-variant-id-with-prefix`, `parse-variant-id-string`.
- CLJS adapter: `make-dialog-atom` factory, `swap-open-now!` / `swap-close!` / `swap-parse-and-set-draft-id!` helpers, `copy-to-clipboard!` shim, presentational `review-dialog` renderer parameterised by `{:title :hint :snippet :placeholder-id :placeholder-input :on-edit-id :on-copy :on-discard :on-close :data-test-prefix}` — `:on-discard` is optional (recorder uses; save-variant does not).

## Migration shape

- `save-variant.cljc` keeps its public surface (`open` / `close` / `set-draft-id` / `default-variant-id` / `initial-dialog-state`) as thin re-exports of the shared primitives plus a `:saved` prefix constant; existing test corpus pins the contract unchanged.
- `ui/save_variant.cljs` drops its own styles + state machine + copy helper; delegates rendering to `review-dialog/review-dialog`.
- `ui/recorder.cljs` drops its own `default-variant-id` / `set-draft-id!` / `copy-to-clipboard!` / modal styles; delegates rendering to `review-dialog/review-dialog` with `:on-discard` wired to `recorder/clear!`. The recorder atom remains source of truth for `:events`.

## LoC delta

| File | Before | After | Δ |
|---|---:|---:|---:|
| `ui/recorder.cljs` | 718 | 626 | -92 |
| `ui/save_variant.cljs` | 272 | 168 | -104 |
| `save_variant.cljc` | 305 | 303 | -2 |
| `review_dialog.cljc` (new) | — | 434 | +434 |
| Existing files net | | | **-198** |

Of the 434 new lines, ~250 are docstrings + the shared styles map. The audit estimated "net -60 LoC + a JVM-testable seam"; this lands the seam with denser inline documentation (the shared primitive's docstring spells out the recurring pattern + the dialog state shape contract for future save-as flows).

## Test plan

- [x] `clojure -M:test` from `tools/story/` — 343 tests / 1015 assertions / 0 failures (includes new `story_review_dialog_test.clj`: 17 deftests / 50+ assertions covering parse / derive / state-machine / compose paths).
- [x] `npm run test:cljs` from `implementation/` — 1795 tests / 4975 assertions / 0 failures (includes new `story_review_dialog_cljs_test.cljs`: 15 deftests covering the pure helpers + renderer hiccup shape).
- [x] `npm run test:bundle-isolation` — PASS (story consumer allow-list unaffected).

## Pre-alpha posture

No back-compat shims. The save-variant public surface (`open` / `close` / `set-draft-id` / `default-variant-id` / `initial-dialog-state`) is preserved as thin re-exports so the existing test corpus continues to pin the contract. The recorder dialog had no public state-machine surface (the ratom was private `defonce`); its callers updated in place.

## Future use

The pattern is reusable: save-as-workspace, save-as-snapshot, save-as-mode, save-as-anything. Each future flow becomes a ~20-line addition (wire `:context` shape + snippet generator + per-flow `default-id-prefix`) rather than a 100-line copy.

Closes rf2-7jpky.