### PR TITLE
feat(schemas): implement fx-args validation step (Spec 010 step 5) (rf2-xp2o3)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -237,7 +237,8 @@
   to the originator without a separate cofx-injection step."
   [frame-id [original-fx-id args] active-platform overrides origin-event]
   (let [fx-id (resolve-fx-with-overrides original-fx-id overrides)
-        resolved-meta (resolved-fx-meta original-fx-id fx-id overrides)]
+        resolved-meta (resolved-fx-meta original-fx-id fx-id overrides)
+        origin-event-id (when (vector? origin-event) (first origin-event))]
    ;; Per Spec 009 §Performance instrumentation (rf2-du3i): every fx
    ;; invocation — reserved or user-registered — runs inside a perf
    ;; bracket so prod builds with the perf flag enabled produce a
@@ -293,55 +294,80 @@
     ;; a second lookup.
     (if-let [meta resolved-meta]
       (if (fx-runs-on-platform? meta active-platform)
-        ;; Per rf2-3nn8 (error path) and rf2-lf84g (success path): bind
-        ;; `*current-trigger-handler*` for the duration of the fx
-        ;; handler's invocation AND for the success-path `:rf.fx/handled`
-        ;; emit that follows. Error traces emitted from inside the fx
-        ;; body (`:rf.error/fx-handler-exception` here and anything the
-        ;; body itself surfaces) carry the fx handler's source-coord;
-        ;; the success-path `:rf.fx/handled` emit picks up the same
-        ;; coord through `emit!`'s hoist of `*current-trigger-handler*`
-        ;; (the outer event handler's binding would otherwise stamp the
-        ;; event handler's coord onto the `:rf.fx/handled` event, which
-        ;; is not what consumers want — Story/Causa want jump-to-source
-        ;; to land on the fx handler's `reg-fx` site, not the event
-        ;; handler that produced the fx vector).
-        ;; Per rf2-isdwf: bind `*current-sensitive?*` to the fx
-        ;; handler's reading so any trace event emitted inside the
-        ;; fx body's scope (including the success `:rf.fx/handled`
-        ;; emit) carries the fx-handler-level sensitivity flag.
-        ;; Per Spec 009 §Privacy "innermost in-scope handler's flag
-        ;; wins" rule: when an event handler is sensitive but the fx
-        ;; handler it dispatches to is not, the `:rf.fx/handled`
-        ;; trace event reflects the FX handler's reading.
-        ;; Per rf2-qsjda: bind `*current-no-emit?*` to the fx
-        ;; handler's reading so the "innermost in-scope handler
-        ;; wins" rule applies to trace-emission opt-out too.
-        (binding [trace/*current-trigger-handler*
-                  (trace/trigger-handler-from-meta :fx fx-id meta)
-                  trace/*current-sensitive?*
-                  (trace/sensitive?-from-meta meta)
-                  trace/*current-no-emit?*
-                  (trace/no-emit?-from-meta meta)]
-          (let [ok? (try
-                      ((:handler-fn meta) (cond-> {:frame frame-id}
-                                            origin-event (assoc :event origin-event))
-                                          args)
-                      true
-                      (catch #?(:clj Throwable :cljs :default) e
-                        (let [msg (#?(:clj .getMessage :cljs .-message) e)]
-                          (trace/emit-error! :rf.error/fx-handler-exception
-                                             {:failing-id        fx-id
-                                              :fx-id             fx-id
-                                              :fx-args           args
-                                              :frame             frame-id
-                                              :exception         e
-                                              :exception-message msg
-                                              :reason            (str "Effect handler `" fx-id "` threw: " msg ".")
-                                              :recovery          :no-recovery}))
-                        false))]
-            (when ok?
-              (emit-handled! fx-id args frame-id))))
+        ;; Per Spec 010 §Validation order step 5 (rf2-xp2o3): before the
+        ;; fx handler runs, validate its args against any `:spec` on the
+        ;; fx's registration meta. The schemas artefact is optional — when
+        ;; absent or when no `:spec` is registered, the late-bind hook
+        ;; resolves nil and the call is a no-op (true / pass).
+        ;; On failure (returns false) the offending fx is skipped (per
+        ;; Spec 010 §Per-step recovery row 5: `:recovery :skipped`) and
+        ;; the walk continues with the next entry in the `:fx` vector —
+        ;; sibling fx are not impacted, the cascade does not halt.
+        ;; `validate-fx!` itself emits the `:rf.error/schema-validation-
+        ;; failure :where :fx-args` trace; this caller only honours the
+        ;; boolean.
+        (let [validate-fx! (late-bind/get-fn :schemas/validate-fx!)
+              fx-ok?       (if (and validate-fx! (:spec meta))
+                             (try
+                               (validate-fx! fx-id origin-event-id args meta)
+                               (catch #?(:clj Throwable :cljs :default) _ true))
+                             true)]
+        (if-not fx-ok?
+          ;; Schema validation failed — the offending fx is skipped.
+          ;; `validate-fx!` already emitted the structured error trace;
+          ;; do NOT emit `:rf.fx/handled` (the fx did not run) and do
+          ;; NOT emit a sibling warning (the schema-validation-failure
+          ;; trace IS the warning, per Spec 010).
+          nil
+          ;; Per rf2-3nn8 (error path) and rf2-lf84g (success path): bind
+          ;; `*current-trigger-handler*` for the duration of the fx
+          ;; handler's invocation AND for the success-path `:rf.fx/handled`
+          ;; emit that follows. Error traces emitted from inside the fx
+          ;; body (`:rf.error/fx-handler-exception` here and anything the
+          ;; body itself surfaces) carry the fx handler's source-coord;
+          ;; the success-path `:rf.fx/handled` emit picks up the same
+          ;; coord through `emit!`'s hoist of `*current-trigger-handler*`
+          ;; (the outer event handler's binding would otherwise stamp the
+          ;; event handler's coord onto the `:rf.fx/handled` event, which
+          ;; is not what consumers want — Story/Causa want jump-to-source
+          ;; to land on the fx handler's `reg-fx` site, not the event
+          ;; handler that produced the fx vector).
+          ;; Per rf2-isdwf: bind `*current-sensitive?*` to the fx
+          ;; handler's reading so any trace event emitted inside the
+          ;; fx body's scope (including the success `:rf.fx/handled`
+          ;; emit) carries the fx-handler-level sensitivity flag.
+          ;; Per Spec 009 §Privacy "innermost in-scope handler's flag
+          ;; wins" rule: when an event handler is sensitive but the fx
+          ;; handler it dispatches to is not, the `:rf.fx/handled`
+          ;; trace event reflects the FX handler's reading.
+          ;; Per rf2-qsjda: bind `*current-no-emit?*` to the fx
+          ;; handler's reading so the "innermost in-scope handler
+          ;; wins" rule applies to trace-emission opt-out too.
+          (binding [trace/*current-trigger-handler*
+                    (trace/trigger-handler-from-meta :fx fx-id meta)
+                    trace/*current-sensitive?*
+                    (trace/sensitive?-from-meta meta)
+                    trace/*current-no-emit?*
+                    (trace/no-emit?-from-meta meta)]
+            (let [ok? (try
+                        ((:handler-fn meta) (cond-> {:frame frame-id}
+                                              origin-event (assoc :event origin-event))
+                                            args)
+                        true
+                        (catch #?(:clj Throwable :cljs :default) e
+                          (let [msg (#?(:clj .getMessage :cljs .-message) e)]
+                            (trace/emit-error! :rf.error/fx-handler-exception
+                                               {:failing-id        fx-id
+                                                :fx-id             fx-id
+                                                :fx-args           args
+                                                :frame             frame-id
+                                                :exception         e
+                                                :exception-message msg
+                                                :reason            (str "Effect handler `" fx-id "` threw: " msg ".")
+                                                :recovery          :no-recovery}))
+                          false))]
+              (when ok?
+                (emit-handled! fx-id args frame-id))))))
         (trace/emit! :warning :rf.fx/skipped-on-platform
                      {:fx-id                fx-id
                       :frame                frame-id

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -81,6 +81,10 @@
    {:key         :schemas/validate-cofx!
     :producer-ns 're-frame.schemas
     :description "Validate a cofx map against the registered cofx schema."}
+   {:key         :schemas/validate-fx!
+    :producer-ns 're-frame.schemas
+    :design-bead "rf2-xp2o3"
+    :description "Validate an fx-handler's args against the registered fx schema (Spec 010 step 5)."}
    {:key         :schemas/validate-sub-return!
     :producer-ns 're-frame.schemas
     :description "Validate a subscription's return value against its schema."}

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -68,6 +68,7 @@
   (schemas/validate-app-db! {:user {:name 42}}    :probe/event)
   (schemas/validate-event!  :probe/event [:probe/event 1] {:spec :int})
   (schemas/validate-cofx!   :probe/cofx :probe/event {} {:spec :map})
+  (schemas/validate-fx!     :probe/fx :probe/event {} {:spec :map})
   (schemas/validate-sub-return! :probe/sub [:probe/sub] :foo {:spec :keyword}))
 
 ;; ---- registrar trace emit -------------------------------------------------

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -1115,6 +1115,74 @@
       true)
     true))
 
+(defn validate-fx!
+  "Per Spec 010 §Validation order step 5 — before an fx handler runs,
+  validate its args against any :spec on the fx's metadata.
+
+  Returns true on pass, false on fail. Failures emit
+  :rf.error/schema-validation-failure with :where :fx-args; per Spec 010
+  §Per-step recovery row 5 the caller is responsible for skipping the
+  offending fx only (recovery: :skipped) — sibling fx in the same `:fx`
+  vector continue to run, and downstream queued events still drain.
+
+  Per Spec 010 §`:sensitive?` privacy: redaction triggers when either
+  the fx's registration meta carries `:sensitive? true` or the schema
+  itself declares a `:sensitive?` slot anywhere in its tree. The
+  failing args value, the schema explanation, and the doubled `:value`
+  / `:received` slots are all redacted in the emitted tags.
+
+  Per Spec 009 §Production builds the entire body lives inside a
+  `(when interop/debug-enabled? ...)` gate so :advanced+goog.DEBUG=false
+  DCE-elides every reason string, every keyword, and every validator
+  call. Per Spec 010 §Non-Malli validators (rf2-froe) the validator is
+  pluggable; when none is registered this fn returns true."
+  [fx-id event-id args fx-meta]
+  ;; Outermost `interop/debug-enabled?` gate so :advanced + goog.DEBUG=false
+  ;; DCE-elides the entire body. The `@validator-fn` deref must live
+  ;; INSIDE the gate (atom deref is not a compile-time constant).
+  (if interop/debug-enabled?
+    (if @validator-fn
+      (if-let [schema (:spec fx-meta)]
+        (if (run-validator schema args)
+          true
+          (let [explanation (run-explainer schema args)
+                ;; Per Spec 010 §`:sensitive?` — privacy in
+                ;; schema-validation error traces (rf2-kj51z).
+                ;; Fx-meta or container-level schema-prop both
+                ;; trigger redaction.
+                sensitive? (or (meta-sensitive? fx-meta)
+                               (schema-has-sensitive? schema))
+                base-tags  (cond-> {:where       :fx-args
+                                    :fx-id       fx-id
+                                    :fx-args     args
+                                    :failing-id  fx-id
+                                    :spec-id     fx-id
+                                    :received    args
+                                    :value       args
+                                    :malli-error explanation
+                                    :explain     explanation
+                                    :reason      (str "Effect " fx-id
+                                                      " args failed schema "
+                                                      schema ", got "
+                                                      (type-of-value args) ".")
+                                    :recovery    :skipped}
+                             event-id (assoc :event-id event-id))
+                ;; When the fx args themselves are redacted, the
+                ;; doubled `:fx-args` slot must also be scrubbed —
+                ;; redact-tags handles `:value`/`:received`/`:explain`/
+                ;; `:malli-error`; explicitly clear `:fx-args` here so
+                ;; the redaction is symmetric with the cofx/event
+                ;; surfaces.
+                tags       (if sensitive?
+                             (assoc (redact-tags base-tags)
+                                    :fx-args redacted-sentinel)
+                             base-tags)]
+            (trace/emit-error! :rf.error/schema-validation-failure tags)
+            false))
+        true)
+      true)
+    true))
+
 ;; ---- public boundary-validation entry point (rf2-r2uh integration) -------
 ;;
 ;; The boundary-validation interceptor (`re-frame.spec/validate-at-boundary`,
@@ -1177,6 +1245,7 @@
 (late-bind/set-fn! :schemas/validate-event!      validate-event!)
 (late-bind/set-fn! :schemas/validate-sub-return! validate-sub-return!)
 (late-bind/set-fn! :schemas/validate-cofx!       validate-cofx!)
+(late-bind/set-fn! :schemas/validate-fx!         validate-fx!)
 (late-bind/set-fn! :schemas/frame-schema-entries frame-schema-entries)
 
 ;; Boundary-validation seam (rf2-r2uh integration).

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -29,6 +29,7 @@
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.flows :as flows]
             [re-frame.interop :as interop]
@@ -277,6 +278,161 @@
                                 (:operation %))
                             @traces))
             "no schema-validation-failure trace fires for a conforming cofx")))))
+
+;; ---- rf2-xp2o3 — fx-args validation (Spec 010 step 5) --------------------
+
+(deftest fx-args-validation-fires-and-skips-only-the-offending-fx
+  (testing "Per Spec 010 §step 5 (rf2-xp2o3): an fx whose args fail its :spec
+            emits :rf.error/schema-validation-failure :where :fx-args; the
+            offending fx is skipped, sibling fx in the same :fx vector
+            continue to run (recovery: :skipped)"
+    (let [bad-fx-calls  (atom 0)
+          good-fx-calls (atom 0)]
+      (rf/reg-fx :my/notify
+        {:spec [:map [:level :keyword] [:message :string]]}
+        (fn [_ctx _args] (swap! bad-fx-calls inc)))
+      (rf/reg-fx :my/log
+        (fn [_ctx _args] (swap! good-fx-calls inc)))
+      (rf/reg-event-fx :ui/announce
+        (fn [_ _]
+          {:fx [[:my/notify {:level "error"          ;; bad: needs keyword
+                             :message "boom"}]
+                [:my/log    "anything"]]}))           ;; sibling — must still run
+      (let [traces (atom [])]
+        (rf/register-trace-cb! ::fxv (fn [ev] (swap! traces conj ev)))
+        (rf/dispatch-sync [:ui/announce])
+        (rf/remove-trace-cb! ::fxv)
+        (is (= 0 @bad-fx-calls)
+            "the offending fx handler was skipped — its body did NOT run")
+        (is (= 1 @good-fx-calls)
+            "the sibling fx in the same :fx vector still ran (cascade continues)")
+        (let [violations (filter #(= :rf.error/schema-validation-failure
+                                     (:operation %))
+                                 @traces)]
+          (is (= 1 (count violations)))
+          (let [v (first violations)]
+            (is (= :fx-args (-> v :tags :where)))
+            (is (= :my/notify (-> v :tags :failing-id)))
+            (is (= :my/notify (-> v :tags :fx-id)))
+            (is (= :my/notify (-> v :tags :spec-id)))
+            (is (= :ui/announce (-> v :tags :event-id))
+                "the originating event-id threads through to the fx-args trace")
+            (is (= :skipped (:recovery v))
+                "fx-args failure recovery is :skipped per Spec 010 row 5")))
+        (let [handled (filter #(= :rf.fx/handled (:operation %)) @traces)]
+          (is (= 1 (count handled))
+              ":rf.fx/handled fires only for the sibling that actually ran"))))))
+
+(deftest fx-args-validation-passes-when-conforming
+  (testing "well-typed fx args flow through to the fx handler — no trace, handler runs"
+    (let [calls (atom 0)
+          seen (atom nil)]
+      (rf/reg-fx :my/email
+        {:spec [:map [:to :string]]}
+        (fn [_ctx args]
+          (swap! calls inc)
+          (reset! seen args)))
+      (rf/reg-event-fx :user/welcome
+        (fn [_ _]
+          {:fx [[:my/email {:to "alice@example.com"}]]}))
+      (let [traces (atom [])]
+        (rf/register-trace-cb! ::fxv2 (fn [ev] (swap! traces conj ev)))
+        (rf/dispatch-sync [:user/welcome])
+        (rf/remove-trace-cb! ::fxv2)
+        (is (= 1 @calls) "fx handler ran exactly once")
+        (is (= {:to "alice@example.com"} @seen) "fx handler saw the well-typed args")
+        (is (empty? (filter #(= :rf.error/schema-validation-failure
+                                (:operation %))
+                            @traces))
+            "no schema-validation-failure trace fires for a conforming fx-args")))))
+
+(deftest fx-args-validation-elides-when-debug-disabled
+  (testing "validate-fx! is a no-op when debug-enabled? is false (production)"
+    (let [calls (atom 0)]
+      (rf/reg-fx :strict/fx
+        {:spec [:map [:x :int]]}
+        (fn [_ctx _args] (swap! calls inc)))
+      (rf/reg-event-fx :strict/trigger
+        (fn [_ _]
+          {:fx [[:strict/fx {:x "not-an-int"}]]}))
+      (let [traces (atom [])]
+        (rf/register-trace-cb! ::fxv3 (fn [ev] (swap! traces conj ev)))
+        (with-redefs [interop/debug-enabled? false]
+          (rf/dispatch-sync [:strict/trigger]))
+        (rf/remove-trace-cb! ::fxv3)
+        (is (empty? (filter #(= :rf.error/schema-validation-failure
+                                (:operation %))
+                            @traces))
+            "no validation trace when debug-enabled? is false")
+        (is (= 1 @calls)
+            "fx handler runs anyway — production validation is elided")))))
+
+(deftest fx-args-validation-direct-call-shape
+  (testing "validate-fx! returns true on pass, false on fail; emits the canonical
+            :where :fx-args trace with the locked tag shape"
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::fxv4 (fn [ev] (swap! traces conj ev)))
+      ;; Direct call — exercises the validate-fx! fn itself, not the integration.
+      (is (true? (schemas/validate-fx! :my/fx :ev/origin {:x 1} {:spec [:map [:x :int]]}))
+          "well-typed args pass")
+      (is (false? (schemas/validate-fx! :my/fx :ev/origin {:x "bad"} {:spec [:map [:x :int]]}))
+          "malformed args fail")
+      (is (true? (schemas/validate-fx! :my/fx :ev/origin {:x 1} {}))
+          "no :spec → soft pass")
+      (rf/remove-trace-cb! ::fxv4)
+      (let [violations (filter #(= :rf.error/schema-validation-failure
+                                   (:operation %))
+                               @traces)]
+        (is (= 1 (count violations)))
+        (let [v (first violations)]
+          (is (= :fx-args   (-> v :tags :where)))
+          (is (= :my/fx     (-> v :tags :fx-id)))
+          (is (= :my/fx     (-> v :tags :failing-id)))
+          (is (= :my/fx     (-> v :tags :spec-id)))
+          (is (= :ev/origin (-> v :tags :event-id)))
+          (is (= {:x "bad"} (-> v :tags :fx-args)))
+          (is (= {:x "bad"} (-> v :tags :value)))
+          (is (= {:x "bad"} (-> v :tags :received)))
+          (is (= :skipped   (:recovery v))))))))
+
+(deftest fx-args-validation-redacts-when-sensitive
+  (testing "validate-fx! consults `:sensitive?` on the fx-meta AND on the schema
+            tree; on redaction it scrubs `:value`/`:received`/`:explain`/
+            `:malli-error`/`:fx-args` and stamps `:sensitive? true`"
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::fxv5 (fn [ev] (swap! traces conj ev)))
+      (is (false? (schemas/validate-fx! :my/secret
+                                        :ev/origin
+                                        {:token 42}
+                                        {:spec [:map [:token :string]]
+                                         :sensitive? true})))
+      (rf/remove-trace-cb! ::fxv5)
+      (let [violations (filter #(= :rf.error/schema-validation-failure
+                                   (:operation %))
+                               @traces)]
+        (is (= 1 (count violations)))
+        (let [v (first violations)]
+          ;; `:sensitive?` is hoisted from `:tags` to the top-level per
+          ;; Spec 009 §Trace-event field `:sensitive?` (rf2-isdwf).
+          (is (true? (:sensitive? v))
+              "top-level :sensitive? stamp consumers filter on")
+          (is (= :rf/redacted (-> v :tags :value)))
+          (is (= :rf/redacted (-> v :tags :received)))
+          (is (= :rf/redacted (-> v :tags :fx-args)))
+          (is (= :rf/redacted (-> v :tags :explain)))
+          (is (= :rf/redacted (-> v :tags :malli-error)))
+          ;; Non-redacted slots survive redaction.
+          (is (= :my/secret (-> v :tags :fx-id)))
+          (is (= :my/secret (-> v :tags :failing-id)))
+          (is (= :fx-args   (-> v :tags :where))))))))
+
+(deftest fx-args-validation-late-bind-hook-published
+  (testing "the :schemas/validate-fx! late-bind hook IS published — the
+            schemas artefact's contract surface includes this fn alongside
+            the four siblings"
+    (let [resolved (re-frame.late-bind/get-fn :schemas/validate-fx!)]
+      (is (some? resolved) "hook resolves to a fn when schemas is loaded")
+      (is (= schemas/validate-fx! resolved) "hook points at the public fn"))))
 
 ;; ---- error projector → :rf/public-error mapping --------------------------
 


### PR DESCRIPTION
## Summary

Implements the missing fifth `validate-*!` fn in the schemas artefact and wires it into the fx-dispatch path. Spec 010 §Validation order step 5 + §Per-step recovery row 5 are normative — this was the **single biggest spec/impl drift** identified in the rf2-x8x4p audit (`ai/findings/refactor-audit-schemas-2026-05-14.md` P0 #1 / S1).

Before: `grep ':where :fx-args'` returned zero hits anywhere; `validate-fx!` did not exist; the four published late-bind hooks (`:schemas/validate-event!` / `validate-cofx!` / `validate-app-db!` / `validate-sub-return!`) reflected the gap.

After: `:rf.error/schema-validation-failure :where :fx-args` fires whenever an fx's args fail its `:spec`. The offending fx is skipped (`:recovery :skipped`); sibling fx in the same `:fx` vector continue to run; downstream queued events still drain.

## Changes

- **`re-frame.schemas/validate-fx!`** — fifth validator, mirroring the four siblings' shape. Returns true on pass / no-schema / no-validator; false on fail. Locked tag shape: `:where :fx-args`, `:fx-id`, `:fx-args`, `:failing-id`, `:spec-id`, `:value`, `:received`, `:malli-error`, `:explain`, `:reason`, `:event-id`, `:recovery :skipped`. Honours the `:sensitive?` redaction contract (registration-meta OR schema-tree triggers; redacts `:value` / `:received` / `:fx-args` / `:explain` / `:malli-error`; hoists `:sensitive? true` per rf2-isdwf).
- **Late-bind hook** — `:schemas/validate-fx!` published alongside the four siblings and catalogued in `re-frame.late-bind.directory`.
- **`re-frame.fx/handle-one-fx` integration** — validation fires after the platform check, before the fx body runs. On failure: no `:rf.fx/handled` emit (fx did not run), no sibling warning (the schema-validation-failure trace IS the signal), continue with the next entry.
- **Tests** — six new deftests in `schemas_test.clj`:
  - integration via `dispatch-sync` confirming the offending fx is skipped while a sibling fx still runs;
  - well-typed pass-through;
  - production elision via `interop/debug-enabled? false`;
  - direct-call shape verification (all required tags present);
  - sensitive-redaction symmetry;
  - late-bind hook publication smoke.
- **`elision_probe.cljs`** exercises `validate-fx!` so the CLJS production-elision probe sees the validation site reach DCE in `:advanced` builds.

## Test plan

- [x] `clojure -M:test` from `implementation/schemas/` — 122 tests / 351 assertions / 0 failures
- [x] `clojure -M:test` from `implementation/core/` — 437 tests / 2301 assertions / 0 failures
- [x] `npm run test:cljs` from `implementation/` — 1778 tests / 4937 assertions / 0 failures
- [x] Direct `grep ':where :fx-args'` now hits the implementation, spec-compliant emission

Closes rf2-xp2o3.