### PR TITLE
fix(flows): cycle-rollback restores prior registration on reg-flow replacement (rf2-7csri)

### DIFF
--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -133,22 +133,27 @@
   ([flow] (reg-flow flow {}))
   ([flow {:keys [frame] :as _opts}]
    (validate-flow flow)
-   (let [frame-id (or frame (frame/current-frame))
-         flow-id  (:id flow)]
-     ;; The :flow registrar slot keys on flow-id only — but stamp :frame
-     ;; into the metadata so introspection / hot-reload hooks can read
-     ;; the owning frame.
+   (let [frame-id     (or frame (frame/current-frame))
+         flow-id      (:id flow)
+         prior-frame  (get @flows frame-id)
+         ;; Per rf2-7csri: detect cycles on a PROSPECTIVE flow-map
+         ;; BEFORE mutating the atom or the registrar. The earlier
+         ;; write-then-rollback path silently deleted the prior
+         ;; registration along with the rejected one when a REPLACEMENT
+         ;; introduced a cycle — the rollback dissoc'd by flow-id,
+         ;; vacating the slot the prior entry was sharing. Now we run
+         ;; topo-sort on (prior-frame `assoc` new-entry) up-front; if it
+         ;; throws, nothing has been written and the prior registration
+         ;; stays intact.
+         prospective  (assoc prior-frame flow-id flow)]
+     (topo-sort prospective)
+     ;; Cycle check passed — commit. The :flow registrar slot keys on
+     ;; flow-id only; stamp :frame into the metadata so introspection
+     ;; / hot-reload hooks can read the owning frame.
      (registrar/register! :flow flow-id
                           (source-coords/merge-coords
                             (assoc flow :frame frame-id)))
      (swap! flows assoc-in [frame-id flow-id] flow)
-     ;; Cycle detection on this frame's flows only.
-     (try
-       (topo-sort (get @flows frame-id))
-       (catch #?(:clj Throwable :cljs :default) e
-         (swap! flows update frame-id dissoc flow-id)
-         (registrar/unregister! :flow flow-id)
-         (throw e)))
      ;; Per Spec 009 §:op-type vocabulary: :rf.flow/registered fires after
      ;; reg-flow successfully completes (including post-cycle-detection).
      ;; Tools observe this to track the flow population over hot reloads /

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -138,22 +138,16 @@
     (is (not (contains? (get @flows/flows :rf/default) :b))
         "cycle-detection rolls back the partial registration of :b")))
 
-(deftest ^:expected-fail
-  reg-flow-replacement-that-introduces-cycle-preserves-prior-registration
+(deftest reg-flow-replacement-that-introduces-cycle-preserves-prior-registration
   ;; Regression for rf2-7csri (bug) / rf2-cdh9h (this test). Pinned per
-  ;; audit rf2-o3hok finding Exec#2 (TE2). The current `reg-flow` rollback
-  ;; path (flows.cljc:144-151) writes the new entry FIRST then runs cycle
-  ;; detection; on a cyclic re-registration the rollback dissocs by id,
-  ;; which DELETES the prior registration as well as the just-written
-  ;; one. A hot-reload that accidentally introduces a cycle therefore
-  ;; silently vacates the previously-working flow. The correct behaviour:
-  ;; detect the cycle on a PROSPECTIVE flow-map BEFORE mutating, and on
-  ;; failure leave the prior registration intact.
-  ;;
-  ;; This test is marked ^:expected-fail because rf2-7csri is not yet
-  ;; merged — the cognitect test-runner alias excludes :expected-fail
-  ;; selectors by default so CI stays green. Drop the metadata once the
-  ;; sibling fix lands.
+  ;; audit rf2-o3hok finding Exec#2 (TE2). The bug: `reg-flow`'s former
+  ;; rollback path wrote the new entry FIRST then ran cycle detection;
+  ;; on a cyclic re-registration the rollback dissoc'd by id, which
+  ;; DELETED the prior registration as well as the just-written one. A
+  ;; hot-reload that accidentally introduced a cycle therefore silently
+  ;; vacated the previously-working flow. The fix (rf2-7csri) runs cycle
+  ;; detection on a PROSPECTIVE flow-map BEFORE mutating; on failure
+  ;; nothing is written and the prior registration stays intact.
   (testing "a cyclic reg-flow REPLACEMENT must not silently delete the prior registration"
     ;; Set up a non-cyclic two-flow graph where REPLACING :b is what
     ;; closes the cycle. Cannot use a self-cycle on :b (topo-sort skips


### PR DESCRIPTION
## Summary

Fixes the `reg-flow` rollback path so a cyclic REPLACEMENT no longer silently deletes the prior good registration.

The old path wrote the new entry first, then ran cycle detection, and on failure rolled back via `dissoc`-by-id — which vacated BOTH the just-rejected new entry AND the prior entry sharing that slot. A hot-reload that accidentally introduced a cycle therefore silently removed the previously-working flow.

The fix is detect-before-write: build a prospective flow-map (prior frame `assoc` new entry) and run `topo-sort` on it BEFORE touching the registrar or the flows atom. If the prospective map cycles, `topo-sort` throws, nothing has been written, and the prior registration is intact.

Per audit rf2-o3hok finding Exec#2.

## Changes

- `implementation/flows/src/re_frame/flows.cljc` — `reg-flow` now runs cycle detection on a prospective map before any mutation; on failure no state changes.
- `implementation/flows/test/re_frame/flows_test.clj` — drops the `^:expected-fail` metadata from the sibling regression test (`reg-flow-replacement-that-introduces-cycle-preserves-prior-registration`, pinned by rf2-cdh9h / PR #828); the assertion now runs in the default sweep and passes.

## Test plan

- [x] `clojure -M:test` in `implementation/flows/` — `Ran 27 tests containing 105 assertions. 0 failures, 0 errors.`
- [x] The previously `:expected-fail` regression test now passes (asserts the prior `:b` registration is preserved after a cyclic replacement attempt, including `:inputs` shape and `:output` fn identity).
- [x] Pre-existing `reg-flow-detects-cycles-at-registration` (initial-cycle case) still passes — same `topo-sort` rejection, now without write-then-rollback churn.