### PR TITLE
refactor(pair2-mcp): with-indicators helper for :dropped-sensitive / :elided-large envelope (rf2-dfk28)

### DIFF
--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/get_path.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/get_path.cljs
@@ -86,8 +86,9 @@
                      ;; the envelope so the agent sees the elision
                      ;; footprint without diffing the payload.
                      (let [elided (base-vocab/count-elided-markers v)]
-                       (wire/ok-text (cond-> v
-                                       frame          (assoc :frame frame)
-                                       (:ok? v)       (assoc :elision elision?)
-                                       (pos? elided)  (assoc :elided-large elided))))))
+                       (wire/ok-text (wire/with-indicators
+                                       (cond-> v
+                                         frame          (assoc :frame frame)
+                                         (:ok? v)       (assoc :elision elision?))
+                                       {:elided elided})))))
             (.catch (fn [err] (probe/err->result :get-path-failed err))))))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/snapshot.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/snapshot.cljs
@@ -95,17 +95,17 @@
                        ;; not elision-markers and so don't inflate the
                        ;; count. Omitted when zero per Conventions.
                        elided                (base-vocab/count-elided-markers deduped)]
-                   (wire/ok-text (cond-> {:ok?            true
-                                          :frames         (if (= :all frames) :all (vec frames))
-                                          :include        include
-                                          :mode           response-mode
-                                          :slice-modes    resolved-modes
-                                          :epochs-mode    mode
-                                          :dedup          dedup?
-                                          :elision        elision?
-                                          :snapshot       summarised}
-                                   path                  (assoc :path path)
-                                   (seq path-status)     (assoc :path-not-found path-status)
-                                   (pos? dropped)        (assoc :dropped-sensitive dropped)
-                                   (pos? elided)         (assoc :elided-large elided))))))
+                   (wire/ok-text (wire/with-indicators
+                                   (cond-> {:ok?            true
+                                            :frames         (if (= :all frames) :all (vec frames))
+                                            :include        include
+                                            :mode           response-mode
+                                            :slice-modes    resolved-modes
+                                            :epochs-mode    mode
+                                            :dedup          dedup?
+                                            :elision        elision?
+                                            :snapshot       summarised}
+                                     path                  (assoc :path path)
+                                     (seq path-status)     (assoc :path-not-found path-status))
+                                   {:dropped dropped :elided elided})))))
         (.catch (fn [err] (probe/err->result :snapshot-failed err))))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe_emit.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe_emit.cljs
@@ -37,20 +37,18 @@
   [{:keys [sub-id topic delivered tick dropped-events* dropped-bytes*
            overflow-reason* dropped-sensitive* elided-large* reason]}]
   (wire/ok-text
-    (cond-> {:ok?            true
-             :sub-id         sub-id
-             :topic          topic
-             :delivered      @delivered
-             :dropped-events @dropped-events*
-             :dropped-bytes  @dropped-bytes*
-             :ticks          @tick
-             :reason         reason}
-      @overflow-reason*
-      (assoc :overflow-reason @overflow-reason*)
-      (pos? @dropped-sensitive*)
-      (assoc :dropped-sensitive @dropped-sensitive*)
-      (pos? @elided-large*)
-      (assoc :elided-large @elided-large*))))
+    (wire/with-indicators
+      (cond-> {:ok?            true
+               :sub-id         sub-id
+               :topic          topic
+               :delivered      @delivered
+               :dropped-events @dropped-events*
+               :dropped-bytes  @dropped-bytes*
+               :ticks          @tick
+               :reason         reason}
+        @overflow-reason*
+        (assoc :overflow-reason @overflow-reason*))
+      {:dropped @dropped-sensitive* :elided @elided-large*})))
 
 (defn emit-progress-tick!
   "Build the per-tick progress payload and ship it via the MCP
@@ -65,17 +63,15 @@
              :params (progress-payload
                        progress-tk
                        tick
-                       (pr-str (cond-> {:sub-id         sub-id
-                                        :events         dedup-events
-                                        :dedup          dedup?
-                                        :dropped-events ev-dropped
-                                        :dropped-bytes  by-dropped}
-                                 ov-reason
-                                 (assoc :overflow-reason ov-reason)
-                                 (pos? dropped)
-                                 (assoc :dropped-sensitive dropped)
-                                 (pos? tick-elided)
-                                 (assoc :elided-large tick-elided)))
+                       (pr-str (wire/with-indicators
+                                 (cond-> {:sub-id         sub-id
+                                          :events         dedup-events
+                                          :dedup          dedup?
+                                          :dropped-events ev-dropped
+                                          :dropped-bytes  by-dropped}
+                                   ov-reason
+                                   (assoc :overflow-reason ov-reason))
+                                 {:dropped dropped :elided tick-elided}))
                        ev-dropped
                        by-dropped
                        ov-reason)})

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/trace_window.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/trace_window.cljs
@@ -93,17 +93,17 @@
                                               :frame    sticky-frame}))
                           has-more?      (some? next-cursor)
                           remaining      (or (:remaining v) 0)]
-                      (wire/ok-text (cond-> {:ok?         true
-                                             :window-ms   window-ms
-                                             :until-ms    until-ms
-                                             :count       (count encoded)
-                                             :limit       limit
-                                             :epochs-mode mode
-                                             :dedup       dedup?
-                                             :epochs      deduped
-                                             :has-more?   has-more?
-                                             :estimated-remaining remaining
-                                             :next-cursor next-cursor}
-                                      (pos? dropped) (assoc :dropped-sensitive dropped)
-                                      (pos? elided)  (assoc :elided-large elided))))))))
+                      (wire/ok-text (wire/with-indicators
+                                      {:ok?         true
+                                       :window-ms   window-ms
+                                       :until-ms    until-ms
+                                       :count       (count encoded)
+                                       :limit       limit
+                                       :epochs-mode mode
+                                       :dedup       dedup?
+                                       :epochs      deduped
+                                       :has-more?   has-more?
+                                       :estimated-remaining remaining
+                                       :next-cursor next-cursor}
+                                      {:dropped dropped :elided elided})))))))
             (.catch (fn [err] (probe/err->result :trace-failed err))))))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/watch_epochs.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/watch_epochs.cljs
@@ -84,15 +84,15 @@
                                                   :head-id       (:head-id v)
                                                   :id-aged-out?  (boolean aged-out?)}
                                            (:requested-id v) (assoc :requested-id (:requested-id v)))]
-                      (wire/ok-text (cond-> (assoc base
-                                                   :matches             deduped
-                                                   :limit               limit
-                                                   :count               (count encoded)
-                                                   :epochs-mode         mode
-                                                   :dedup               dedup?
-                                                   :has-more?           (some? next-cursor)
-                                                   :estimated-remaining remaining
-                                                   :next-cursor         next-cursor)
-                                      (pos? dropped) (assoc :dropped-sensitive dropped)
-                                      (pos? elided)  (assoc :elided-large elided))))))))
+                      (wire/ok-text (wire/with-indicators
+                                      (assoc base
+                                             :matches             deduped
+                                             :limit               limit
+                                             :count               (count encoded)
+                                             :epochs-mode         mode
+                                             :dedup               dedup?
+                                             :has-more?           (some? next-cursor)
+                                             :estimated-remaining remaining
+                                             :next-cursor         next-cursor)
+                                      {:dropped dropped :elided elided})))))))
             (.catch (fn [err] (probe/err->result :watch-failed err))))))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire.cljs
@@ -30,6 +30,25 @@
   #js {:isError true
        :content #js [#js {:type "text" :text (pr-str v)}]})
 
+(defn with-indicators
+  "Splice the cross-MCP indicator-field slots (`:dropped-sensitive`,
+  `:elided-large`) onto a tool's envelope map.
+
+  Centralises the MUST-level \"omit when zero\" rule from
+  [Conventions §Cross-MCP indicator-field vocabulary][1] and
+  [Spec 009 §Indicator field on tool responses][2]. Every tool that
+  walks a tree-typed payload (`snapshot`, `get-path`, `trace-window`,
+  `watch-epochs`, `subscribe`) routes its envelope-tail through here so
+  the rule lives in one place — drift across emit sites can no longer
+  silently violate the MUST.
+
+  [1]: spec/Conventions.md#cross-mcp-indicator-field-vocabulary-suppression-counters
+  [2]: spec/009-Instrumentation.md#size-elision-in-traces"
+  [envelope {:keys [dropped elided]}]
+  (cond-> envelope
+    (pos? (or dropped 0)) (assoc :dropped-sensitive dropped)
+    (pos? (or elided  0)) (assoc :elided-large      elided)))
+
 (defn arg
   "Extract an MCP tool argument by name. Returns nil if absent."
   [args k]


### PR DESCRIPTION
## Summary

- Extract `wire/with-indicators` helper that owns the MUST-level "omit when zero" rule from [Spec 009:1411](../blob/main/spec/009-Instrumentation.md) and [Conventions:154](../blob/main/spec/Conventions.md).
- Apply at all 5 emit sites (6 call sites): `trace-window`, `watch-epochs`, `snapshot`, `get-path`, `subscribe` (final-summary + per-tick progress) — each tool's envelope-tail now reads as one line.
- Centralises the rule so a future indicator slot (say `:dropped-redacted`) is added once, not five times.

Per audit `rf2-7hie3` (`ai/findings/refactor-audit-tools-pair2-mcp-2026-05-14.md`) §P0 #2 / T3.

## Test plan

- [x] `npm test` from `tools/pair2-mcp/` — 270 tests / 660 assertions, 0 failures, 0 errors.
- [x] All 6 emit sites updated; only `wire.cljs` still spells the `(pos? ...) (assoc :dropped-sensitive/elided-large ...)` form (the helper's body).
- [x] Spec citations carried in the helper docstring.

Closes rf2-dfk28.