### PR TITLE
refactor(http): unify origin-event resolution into single helper (rf2-622e3)

### DIFF
--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -239,6 +239,28 @@
 
 ;; ---- reply addressing -----------------------------------------------------
 
+(defn resolve-origin-event
+  "Per Spec 014 §Reply addressing — single source of truth for the
+  originating event vector used as the default reply target.
+
+  Resolution order:
+   1. `(:event frame-ctx)` — the originating event the runtime threads
+      through `do-fx`'s 5-arity (when the fx fired from inside an event
+      handler).
+   2. `(:rf.http/origin-event args-map)` — an explicit override on the
+      args map (machine-shape wrapper sets this when there is no
+      ambient event, e.g. spawn-time entry actions).
+   3. `[:rf.http/managed]` — synthetic fallback so the reply addressing
+      machinery (`build-reply-event`) always has a non-nil event-id.
+
+  Extracted from the three verbatim copies in `http-managed`
+  (`normalise-args`, `managed-handler`) and `http-machine-wrapper`
+  (`origin-event-from`) per rf2-622e3."
+  [frame-ctx args-map]
+  (or (:event frame-ctx)
+      (:rf.http/origin-event args-map)
+      [:rf.http/managed]))
+
 (defn build-reply-event
   "Per Spec 014 §Reply addressing. Returns the event vector to dispatch,
   or nil when silenced.

--- a/implementation/http/src/re_frame/http_machine_wrapper.cljc
+++ b/implementation/http/src/re_frame/http_machine_wrapper.cljc
@@ -49,12 +49,10 @@
 ;; installs). The fxs themselves are registered in the façade so they fire
 ;; only when the namespace is loaded — these handlers stay here so the
 ;; stub-handler below can reach them without circular requires.
-
-(defn- origin-event-from
-  [frame-ctx args-map]
-  (or (:event frame-ctx)
-      (:rf.http/origin-event args-map)
-      [:rf.http/managed]))
+;;
+;; rf2-622e3 — origin-event resolution lives in
+;; `encoding/resolve-origin-event` (single source of truth shared with
+;; `http-managed/managed-handler`).
 
 (defn canned-success-handler
   "Stub fx — synthesises a success reply per Spec 014 §Testing."
@@ -62,7 +60,7 @@
   (let [{:keys [on-success]} args-map
         value (get args-map :value {:stubbed true})
         reply {:kind :success :value value}
-        ev    (encoding/build-reply-event {:origin-event (origin-event-from frame-ctx args-map)
+        ev    (encoding/build-reply-event {:origin-event (encoding/resolve-origin-event frame-ctx args-map)
                                            :explicit-on  {:supplied? (contains? args-map :on-success)
                                                           :value     on-success}
                                            :reply-payload reply
@@ -79,7 +77,7 @@
         tags  (or (:tags args-map) {})
         failure (assoc tags :kind kind)
         reply {:kind :failure :failure failure}
-        ev    (encoding/build-reply-event {:origin-event (origin-event-from frame-ctx args-map)
+        ev    (encoding/build-reply-event {:origin-event (encoding/resolve-origin-event frame-ctx args-map)
                                            :explicit-on  {:supplied? (contains? args-map :on-failure)
                                                           :value     on-failure}
                                            :reply-payload reply

--- a/implementation/http/src/re_frame/http_managed.cljc
+++ b/implementation/http/src/re_frame/http_managed.cljc
@@ -81,6 +81,7 @@
   `:rf.http/*` fx registrations and the `late-bind/set-fn!` hook
   publications that `re-frame.core` reaches through."
   (:require [re-frame.fx                :as fx]
+            [re-frame.http-encoding     :as encoding]
             [re-frame.http-machine-wrapper :as machine-wrapper]
             [re-frame.http-middleware   :as middleware]
             [re-frame.http-privacy      :as privacy]
@@ -132,15 +133,19 @@
 
 (defn- normalise-args
   "Validate + normalise the args map. Returns a context ready for the
-  per-host attempt loop."
+  per-host attempt loop.
+
+  `frame-ctx` carries the resolved `:event` (the originating event
+  vector) — `managed-handler` runs `encoding/resolve-origin-event`
+  once before calling here and stashes the result back into
+  `frame-ctx` as `:event`, so the resolution shape lives in exactly
+  one place per rf2-622e3."
   [{:keys [request decode accept retry timeout-ms
            on-success on-failure request-id abort-signal]
     :or   {timeout-ms 30000}
     :as   args-map}
    frame-ctx]
-  (let [origin-event (or (:event frame-ctx)
-                         (:rf.http/origin-event args-map)
-                         [:rf.http/managed])
+  (let [origin-event (:event frame-ctx)
         frame        (or (:frame frame-ctx) :rf/default)
         ;; rf2-wvkn — when the originating event-id is a spawned actor's
         ;; address, capture it so the in-flight registry can index by
@@ -192,16 +197,18 @@
   [frame-ctx args-map]
   (transport/check-cljs-only-keys! args-map)
   (let [frame-id     (or (:frame frame-ctx) :rf/default)
-        origin-event (or (:event frame-ctx)
-                         (:rf.http/origin-event args-map)
-                         [:rf.http/managed])
+        ;; rf2-622e3 — resolve once, thread the result through
+        ;; frame-ctx's :event slot so normalise-args reads it
+        ;; directly instead of re-running the OR-chain.
+        origin-event (encoding/resolve-origin-event frame-ctx args-map)
+        frame-ctx'   (assoc frame-ctx :event origin-event)
         ctx0         {:request (:request args-map)
                       :args    args-map
                       :frame   frame-id
                       :event   origin-event}
         ctx          (middleware/run-interceptor-chain! frame-id ctx0)
         args-map'    (assoc args-map :request (:request ctx))
-        normalised   (normalise-args args-map' frame-ctx)
+        normalised   (normalise-args args-map' frame-ctx')
         request-id   (:request-id normalised)]
     (when request-id (registry/supersede! request-id))
     (transport/run-attempt! normalised)


### PR DESCRIPTION
## Summary

- Extract `encoding/resolve-origin-event` as the single source of truth for the `(or (:event frame-ctx) (:rf.http/origin-event args-map) [:rf.http/managed])` shape that appeared verbatim three times in the http artefact.
- `managed-handler` now resolves once and threads the result back through `frame-ctx`'s `:event` slot; `normalise-args` reads that slot directly instead of re-running the OR-chain (the value was previously computed twice per request).
- `http-machine-wrapper`'s private `origin-event-from` helper is deleted; `canned-success-handler` / `canned-failure-handler` call `encoding/resolve-origin-event` directly.

Per the rf2-wui5v audit P0 #2. Pre-alpha: no back-compat surface to preserve.

## Test plan

- [x] `clojure -M:test` from `implementation/http/` — 134 tests / 369 assertions, 0 failures, 0 errors.
- [x] `npm run test:cljs` from `implementation/` — 1795 tests / 4975 assertions, 0 failures, 0 errors.