### PR TITLE
fix(ssr): canonical-edn prunes nil per Spec 011 (rf2-6djjl)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/hash.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hash.cljc
@@ -15,26 +15,39 @@
   "Print a render-tree node in a stable order. Maps are sorted by key
   string; sequences keep order. Functions and var-references appear
   as their toString — stable enough for trees that re-render the same
-  view-fn from the same registry."
+  view-fn from the same registry.
+
+  Per Spec 011 §Hydration-mismatch detection: **nil pruned**. Two render
+  trees that differ only by absent-key vs nil-value are structurally
+  equivalent — `[:div {:class nil}]` and `[:div {}]` hash identically;
+  `[:p \"text\" nil]` and `[:p \"text\"]` hash identically. Without this
+  pruning the server emits `{:class nil}` while the client emits `{}`
+  (the common `{:class (when condition? :selected)}` shape), producing
+  spurious `:rf.ssr/hydration-mismatch` traces. Returns nil for nil
+  input so the parent collection's `keep` / `remove` step prunes it."
   [x]
   (cond
+    (nil? x) nil                                    ;; pruned at parent
+
     (map? x)
     (str "{"
          (clojure.string/join
            ","
-           (map (fn [[k v]] (str (canonical-edn k) " " (canonical-edn v)))
-                (sort-by (comp str key) x)))
+           (->> x
+                (remove (comp nil? val))
+                (sort-by (comp str key))
+                (map (fn [[k v]] (str (canonical-edn k) " " (canonical-edn v))))))
          "}")
 
     (vector? x)
-    (str "[" (clojure.string/join " " (map canonical-edn x)) "]")
+    (str "[" (clojure.string/join " " (keep canonical-edn x)) "]")
 
     (sequential? x)
-    (str "(" (clojure.string/join " " (map canonical-edn x)) ")")
+    (str "(" (clojure.string/join " " (keep canonical-edn x)) ")")
 
     (set? x)
     (str "#{"
-         (clojure.string/join " " (sort (map canonical-edn x)))
+         (clojure.string/join " " (sort (keep canonical-edn x)))
          "}")
 
     (fn? x)

--- a/implementation/ssr/test/re_frame/ssr_hash_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hash_test.clj
@@ -1,0 +1,107 @@
+(ns re-frame.ssr-hash-test
+  "Spec 011 §Hydration-mismatch detection — canonical-edn / render-tree-hash
+  contract. The hash crosses the wire between server and client of the same
+  implementation; any structural-equivalence rule the spec pins MUST be honoured
+  on both sides or apps see spurious `:rf.ssr/hydration-mismatch` traces.
+
+  Per Spec 011 §Hydration-mismatch detection (line 295):
+    'FNV-1a 32-bit over a canonical EDN serialisation of the render-tree
+     (depth-first traversal; attribute maps in sorted-key order; nil pruned).'
+
+  This file pins the **nil pruning** rule (rf2-6djjl). Without it, the
+  ubiquitous `{:class (when condition? :selected)}` shape produces
+  `{:class nil}` on one side and `{}` on the other, and the trees hash
+  differently despite being structurally equivalent.
+
+  The hash-stability and order-sensitivity rules are pinned in
+  smoke_test.clj `render-tree-hash-is-stable`; the JVM↔CLJS parity smoke
+  lives in hash_check_cljs_test.cljs. This namespace focuses on
+  pruning-equivalence."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.ssr.hash :as hash]))
+
+;; ---- canonical-edn ---------------------------------------------------------
+
+(deftest canonical-edn-prunes-nil-from-maps
+  (testing "map entries with nil values are pruned — {:class nil} ≡ {}"
+    (is (= (hash/canonical-edn {})
+           (hash/canonical-edn {:class nil}))
+        "lone nil-valued entry is pruned")
+    (is (= (hash/canonical-edn {:id "x"})
+           (hash/canonical-edn {:id "x" :class nil}))
+        "nil-valued entry pruned alongside live entries")
+    (is (= (hash/canonical-edn {:id "x"})
+           (hash/canonical-edn {:id "x" :class nil :title nil :hidden nil}))
+        "multiple nil-valued entries all pruned"))
+
+  (testing "nil map keys ARE preserved (the spec prunes nil VALUES, not keys)"
+    ;; Hiccup attribute maps don't have nil keys in practice, but the
+    ;; spec is explicit about pruning nil values — leaves keys alone.
+    (is (not= (hash/canonical-edn {})
+              (hash/canonical-edn {nil "x"}))
+        "nil-keyed entry is NOT pruned")))
+
+(deftest canonical-edn-prunes-nil-from-sequences
+  (testing "vectors: nil child elements are pruned"
+    (is (= (hash/canonical-edn [:p "text"])
+           (hash/canonical-edn [:p "text" nil]))
+        "trailing nil element pruned")
+    (is (= (hash/canonical-edn [:p "text"])
+           (hash/canonical-edn [:p nil "text" nil]))
+        "interior + trailing nil elements pruned"))
+
+  (testing "lists: nil child elements are pruned"
+    (is (= (hash/canonical-edn '(:p "text"))
+           (hash/canonical-edn '(:p "text" nil)))
+        "trailing nil element pruned in a list")))
+
+(deftest canonical-edn-returns-nil-for-nil
+  (testing "bare nil input — sentinel for parent pruning"
+    (is (nil? (hash/canonical-edn nil))
+        "canonical-edn returns nil for nil input — parent's keep/remove prunes it")))
+
+(deftest canonical-edn-non-nil-fast-path-unchanged
+  (testing "trees with no nil values produce byte-identical canonical EDN
+            to the pre-fix behaviour — important because the JVM↔CLJS
+            parity test (hash_check_cljs_test.cljs) pins '9d7457ef' for
+            [:div {:class \"x\"} [:p \"hi\"]]."
+    (is (= "[:div {:class \"x\"} [:p \"hi\"]]"
+           (hash/canonical-edn [:div {:class "x"} [:p "hi"]]))
+        "no-nil tree serialises to the pre-fix canonical form")))
+
+;; ---- render-tree-hash ------------------------------------------------------
+
+(deftest render-tree-hash-equates-nil-attr-with-absent-attr
+  (testing "{:class nil} and {} hash identically per Spec 011 §Hydration-mismatch"
+    (is (= (hash/render-tree-hash [:div {:class nil}])
+           (hash/render-tree-hash [:div {}]))
+        "the common (when condition? :class) shape no longer triggers spurious mismatch")
+    (is (= (hash/render-tree-hash [:div {:id "x" :class nil}])
+           (hash/render-tree-hash [:div {:id "x"}]))
+        "nil-valued attr pruned alongside live attrs")))
+
+(deftest render-tree-hash-equates-nil-child-with-absent-child
+  (testing "nil children are pruned — [:p \"text\" nil] ≡ [:p \"text\"]"
+    (is (= (hash/render-tree-hash [:p "text" nil])
+           (hash/render-tree-hash [:p "text"]))
+        "trailing nil child pruned")
+    (is (= (hash/render-tree-hash [:div [:p "a"] nil [:p "b"]])
+           (hash/render-tree-hash [:div [:p "a"] [:p "b"]]))
+        "interior nil child pruned")))
+
+(deftest render-tree-hash-prunes-nil-deeply
+  (testing "pruning is recursive — nil-pruning applies at every level"
+    (is (= (hash/render-tree-hash
+             [:section {:class "wrap"}
+              [:header {:role "banner" :hidden nil}
+               [:h1 "Title" nil]]
+              [:article {:class nil}
+               [:p "Body" nil]]])
+           (hash/render-tree-hash
+             [:section {:class "wrap"}
+              [:header {:role "banner"}
+               [:h1 "Title"]]
+              [:article {}
+               [:p "Body"]]]))
+        "a deeply nested tree with nils at multiple levels hashes identically
+         to the same tree with all nils pruned")))


### PR DESCRIPTION
## Summary

- **Bug:** `canonical-edn` did not prune nil — `[:div {:class nil}]` and `[:div {}]` hashed differently despite being structurally equivalent per Spec 011 §Hydration-mismatch detection. Symptom: spurious `:rf.ssr/hydration-mismatch` traces from the common `{:class (when condition? :selected)}` shape.
- **Fix:** In `re-frame.ssr.hash/canonical-edn` (post rf2-gxgo7 split), nil-input now returns nil (sentinel), map entries with nil values are removed before sorting, and sequential / set children are walked with `keep` so nil-returning recursive calls drop the child.
- **Parity preserved:** Trees with no nil values produce byte-identical canonical EDN. The JVM↔CLJS parity test (`hash_check_cljs_test.cljs`, pinning `9d7457ef` for `[:div {:class "x"} [:p "hi"]]`) is unaffected.

## Spec reference

[Spec 011 §Hydration-mismatch detection](../blob/main/spec/011-SSR.md#hydration-mismatch-detection) line 295:

> FNV-1a 32-bit over a canonical EDN serialisation of the render-tree (depth-first traversal; attribute maps in sorted-key order; **nil pruned**).

## Test plan

New ns `re-frame.ssr-hash-test` (7 tests, 16 assertions) pins:
- [x] map nil-value pruning — `{:class nil}` ≡ `{}`
- [x] sequence nil-child pruning — `[:p "text" nil]` ≡ `[:p "text"]`
- [x] nil sentinel — `(canonical-edn nil) ≡ nil`
- [x] non-nil fast path unchanged (byte-identical canonical form)
- [x] `render-tree-hash` agrees on attr-equivalence
- [x] `render-tree-hash` agrees on child-equivalence
- [x] deeply-nested pruning is recursive

Gates run locally:
- [x] `clojure -M:test` in `implementation/ssr/` — 76 tests, 235 assertions, 0/0
- [x] `clojure -M:test` in `implementation/core/` — 440 tests, 2309 assertions, 0/0
- [x] `npm run test:cljs` from `implementation/` — 1795 tests, 4975 assertions, 0/0 (JVM↔CLJS hash parity preserved)

## Notes

- Pre-alpha — no back-compat concern. Hash values change for previously-mismatching trees only; no apps depend on the pre-fix hashes.
- Disjoint with sibling rf2-afxhv (touches `ssr/request.cljc`).
- Closes rf2-6djjl.