### PR TITLE
refactor(pair2-mcp): name the wire-pipeline as parameterised fn (rf2-ae8ie)

### DIFF
--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/get_path.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/get_path.cljs
@@ -9,10 +9,16 @@
   `(get-in app-db path)` server-side so only the addressed subtree
   crosses the wire.
 
-  Path vocabulary mirrors `get-in`: a vector of keys / indices."
-  (:require [re-frame.mcp-base.vocab :as base-vocab]
-            [re-frame-pair2-mcp.nrepl :as nrepl]
+  Path vocabulary mirrors `get-in`: a vector of keys / indices.
+
+  Post-eval shrink pipeline lives in
+  `re-frame-pair2-mcp.tools.wire-pipeline` (rf2-ae8ie). The eval form
+  ran `re-frame.core/elide-wire-value` server-side already; the
+  `:scalar-value` arm of `run-wire-pipeline` just counts the
+  resulting `:rf.size/large-elided` markers."
+  (:require [re-frame-pair2-mcp.nrepl :as nrepl]
             [re-frame-pair2-mcp.tools.wire :as wire]
+            [re-frame-pair2-mcp.tools.wire-pipeline :as wp]
             [re-frame-pair2-mcp.tools.probe :as probe]
             [re-frame-pair2-mcp.tools.args :as args]
             [re-frame-pair2-mcp.tools.elision :as elision]))
@@ -77,18 +83,12 @@
         (-> (probe/ensure-runtime! conn build-id)
             (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
             (.then (fn [v]
-                     ;; :elided-large indicator-field per Conventions
-                     ;; §Cross-MCP indicator-field vocabulary (rf2-2499j).
-                     ;; The eval form ran `re-frame.core/elide-wire-value`
-                     ;; over the resolved `:value` (when elision was
-                     ;; on), so the response may carry one or more
-                     ;; `:rf.size/large-elided` markers. Count them on
-                     ;; the envelope so the agent sees the elision
-                     ;; footprint without diffing the payload.
-                     (let [elided (base-vocab/count-elided-markers v)]
+                     (let [{:keys [value indicators]}
+                           (wp/run-wire-pipeline v {:kind :scalar-value})
+                           {:keys [elided]} indicators]
                        (wire/ok-text (wire/with-indicators
-                                       (cond-> v
-                                         frame          (assoc :frame frame)
-                                         (:ok? v)       (assoc :elision elision?))
+                                       (cond-> value
+                                         frame           (assoc :frame frame)
+                                         (:ok? value)    (assoc :elision elision?))
                                        {:elided elided})))))
             (.catch (fn [err] (probe/err->result :get-path-failed err))))))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/snapshot.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/snapshot.cljs
@@ -3,33 +3,37 @@
 
   Many investigate-X workflows chain 5-10 reads; each is a bencode
   round-trip plus Claude-think latency. This op composes the existing
-  per-slice readers server-side and returns a per-frame map."
-  (:require [re-frame.mcp-base.vocab :as base-vocab]
-            [re-frame-pair2-mcp.nrepl :as nrepl]
+  per-slice readers server-side and returns a per-frame map.
+
+  Post-eval shrink pipeline lives in
+  `re-frame-pair2-mcp.tools.wire-pipeline` (rf2-ae8ie). This tool body
+  builds the eval form, awaits the runtime response, and routes the
+  result through `run-wire-pipeline` with `:kind :snapshot-map`."
+  (:require [re-frame-pair2-mcp.nrepl :as nrepl]
             [re-frame-pair2-mcp.tools.wire :as wire]
+            [re-frame-pair2-mcp.tools.wire-pipeline :as wp]
             [re-frame-pair2-mcp.tools.probe :as probe]
             [re-frame-pair2-mcp.tools.args :as args]
             [re-frame-pair2-mcp.tools.dedup :as dedup]
             [re-frame-pair2-mcp.tools.elision :as elision]
-            [re-frame-pair2-mcp.tools.sensitive :as sensitive]
-            [re-frame-pair2-mcp.tools.snapshot-pipeline :as pipeline]))
+            [re-frame-pair2-mcp.tools.sensitive :as sensitive]))
 
 (defn snapshot-tool [conn raw-args]
-  (let [build-id   (wire/arg-build raw-args)
-        frames     (args/parse-frames-arg (wire/arg raw-args :frames))
-        include    (args/parse-include-arg (wire/arg raw-args :include))
-        incl?      (sensitive/include-sensitive? raw-args)
-        path       (args/parse-path-arg (wire/arg raw-args :path))
-        mode       (dedup/parse-epochs-mode (wire/arg raw-args :epochs-mode))
+  (let [build-id    (wire/arg-build raw-args)
+        frames      (args/parse-frames-arg (wire/arg raw-args :frames))
+        include     (args/parse-include-arg (wire/arg raw-args :include))
+        incl?       (sensitive/include-sensitive? raw-args)
+        path        (args/parse-path-arg (wire/arg raw-args :path))
+        mode        (dedup/parse-epochs-mode (wire/arg raw-args :epochs-mode))
         ;; Global lazy-summary mode (rf2-u2029): `:summary` (default)
         ;; replaces every rich slice with a tree-summary marker;
         ;; `:full` ships the full payload. Per-slice override via
         ;; `:modes` map takes precedence over the global mode.
         slice-mode  (args/parse-mode-arg (wire/arg raw-args :mode))
         slice-modes (args/parse-modes-arg (wire/arg raw-args :modes))
-        dedup?     (dedup/parse-dedup-arg (wire/arg raw-args :dedup))
-        elision?   (elision/parse-elision-arg (wire/arg raw-args :elision))
-        opts       {:frames frames :include include}
+        dedup?      (dedup/parse-dedup-arg (wire/arg raw-args :dedup))
+        elision?    (elision/parse-elision-arg (wire/arg raw-args :elision))
+        opts        {:frames frames :include include}
         ;; Eval form composition (rf2-urjnc). The snapshot composer
         ;; returns a per-frame map; we wrap each frame's `:app-db`
         ;; slice with `re-frame.core/elide-wire-value` so large /
@@ -60,52 +64,32 @@
     (-> (probe/ensure-runtime! conn build-id)
         (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
         (.then (fn [v]
-                 (let [app-db-mode (pipeline/resolve-slice-mode :app-db slice-modes slice-mode)
-                       [scrubbed dropped]    (sensitive/scrub-snapshot-sensitive v incl?)
-                       [sliced path-status]  (pipeline/slice-app-db-in-snapshot scrubbed path app-db-mode)
-                       diff-encoded          (pipeline/diff-encode-epochs-in-snapshot sliced mode)
-                       deduped               (pipeline/dedup-epochs-in-snapshot diff-encoded dedup?)
-                       ;; Lazy-summary default for non-app-db rich
-                       ;; slices (rf2-u2029). Runs LAST in the pipeline
-                       ;; so summary `:bytes` hints reflect the
-                       ;; post-shrink wire cost of each slice.
-                       {summarised :snapshot
-                        other-modes :resolved-modes} (pipeline/summarise-other-slices-in-snapshot
-                                                       deduped slice-modes slice-mode)
-                       resolved-modes (assoc other-modes :app-db
-                                             (cond
-                                               path :path-sliced
-                                               :else app-db-mode))
-                       response-mode  (cond
-                                        path                  :path-sliced
-                                        (= :full app-db-mode) :full
-                                        :else                 :summary)
-                       ;; :elided-large parity per Conventions §Cross-MCP
-                       ;; indicator-field vocabulary (rf2-2499j). The
-                       ;; snapshot eval form runs `re-frame.core/elide-
-                       ;; wire-value` server-side over each frame's
-                       ;; `:app-db` slice, substituting
-                       ;; `:rf.size/large-elided` markers in place of
-                       ;; declared / over-threshold leaves. Counting them
-                       ;; AFTER the dedup pass (where the rich slices
-                       ;; haven't yet been summarised) gives the agent
-                       ;; the real elision footprint of the call; the
-                       ;; later summary pass replaces non-app-db slices
-                       ;; with bounded markers, but its own bytes are
-                       ;; not elision-markers and so don't inflate the
-                       ;; count. Omitted when zero per Conventions.
-                       elided                (base-vocab/count-elided-markers deduped)]
+                 (let [{:keys [value indicators]}
+                       (wp/run-wire-pipeline v
+                                             {:kind        :snapshot-map
+                                              :incl?       incl?
+                                              :mode        mode
+                                              :dedup?      dedup?
+                                              :path        path
+                                              :slice-mode  slice-mode
+                                              :slice-modes slice-modes})
+                       {:keys [dropped elided path-status
+                               resolved-modes app-db-mode]} indicators
+                       response-mode (cond
+                                       path                  :path-sliced
+                                       (= :full app-db-mode) :full
+                                       :else                 :summary)]
                    (wire/ok-text (wire/with-indicators
-                                   (cond-> {:ok?            true
-                                            :frames         (if (= :all frames) :all (vec frames))
-                                            :include        include
-                                            :mode           response-mode
-                                            :slice-modes    resolved-modes
-                                            :epochs-mode    mode
-                                            :dedup          dedup?
-                                            :elision        elision?
-                                            :snapshot       summarised}
-                                     path                  (assoc :path path)
-                                     (seq path-status)     (assoc :path-not-found path-status))
+                                   (cond-> {:ok?         true
+                                            :frames      (if (= :all frames) :all (vec frames))
+                                            :include     include
+                                            :mode        response-mode
+                                            :slice-modes resolved-modes
+                                            :epochs-mode mode
+                                            :dedup       dedup?
+                                            :elision     elision?
+                                            :snapshot    value}
+                                     path              (assoc :path path)
+                                     (seq path-status) (assoc :path-not-found path-status))
                                    {:dropped dropped :elided elided})))))
         (.catch (fn [err] (probe/err->result :snapshot-failed err))))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/trace_window.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/trace_window.cljs
@@ -5,10 +5,15 @@
   items (default 50). When more remain, `:next-cursor` is non-nil. The
   cursor encodes a sticky `:until-ms` so subsequent pages see the same
   window the first call did — fresh epochs landing during pagination
-  don't sneak in mid-iteration."
-  (:require [re-frame.mcp-base.vocab :as base-vocab]
-            [re-frame-pair2-mcp.nrepl :as nrepl]
+  don't sneak in mid-iteration.
+
+  Post-eval shrink pipeline lives in
+  `re-frame-pair2-mcp.tools.wire-pipeline` (rf2-ae8ie). This tool body
+  builds the eval form, awaits the runtime response, and routes the
+  epoch vector through `run-wire-pipeline` with `:kind :epoch-vector`."
+  (:require [re-frame-pair2-mcp.nrepl :as nrepl]
             [re-frame-pair2-mcp.tools.wire :as wire]
+            [re-frame-pair2-mcp.tools.wire-pipeline :as wp]
             [re-frame-pair2-mcp.tools.probe :as probe]
             [re-frame-pair2-mcp.tools.cursor :as cursor]
             [re-frame-pair2-mcp.tools.dedup :as dedup]
@@ -62,48 +67,41 @@
             (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
             (.then
               (fn [v]
-                (let [v             (if (map? v) v {})
-                      aged-out?     (:id-aged-out? v)
-                      raw-epochs    (vec (:epochs v))]
+                (let [v          (if (map? v) v {})
+                      aged-out?  (:id-aged-out? v)
+                      raw-epochs (vec (:epochs v))]
                   (if aged-out?
                     (cursor/cursor-stale-result "trace-window"
                                                 {:requested-id (:requested-id v)
                                                  :head-id      (:head-id v)})
-                    (let [[kept dropped] (sensitive/strip-sensitive raw-epochs incl?)
-                          encoded        (dedup/diff-encode-epochs kept mode)
-                          deduped        (dedup/dedup-value encoded dedup?)
-                          ;; :elided-large parity per Conventions §Cross-MCP
-                          ;; indicator-field vocabulary (rf2-2499j). Count
-                          ;; `:rf.size/large-elided` markers riding the
-                          ;; post-pipeline payload — today trace-window does
-                          ;; not run `elide-wire-value` on epoch records
-                          ;; (the walker is wired on `snapshot` / `get-path`)
-                          ;; so the count is always 0 and the slot is
-                          ;; omitted; the parallel-counter scaffolding is
-                          ;; in place so future wiring lights up the slot
-                          ;; automatically.
-                          elided         (base-vocab/count-elided-markers deduped)
-                          next-id        (:next-id v)
-                          next-cursor    (cursor/encode-cursor
-                                           (when next-id
-                                             {:v        1
-                                              :after-id next-id
-                                              :ms       window-ms
-                                              :until-ms until-ms
-                                              :frame    sticky-frame}))
-                          has-more?      (some? next-cursor)
-                          remaining      (or (:remaining v) 0)]
+                    (let [{:keys [value indicators]}
+                          (wp/run-wire-pipeline raw-epochs
+                                                {:kind   :epoch-vector
+                                                 :incl?  incl?
+                                                 :mode   mode
+                                                 :dedup? dedup?})
+                          {:keys [dropped elided count]} indicators
+                          next-id     (:next-id v)
+                          next-cursor (cursor/encode-cursor
+                                        (when next-id
+                                          {:v        1
+                                           :after-id next-id
+                                           :ms       window-ms
+                                           :until-ms until-ms
+                                           :frame    sticky-frame}))
+                          has-more?   (some? next-cursor)
+                          remaining   (or (:remaining v) 0)]
                       (wire/ok-text (wire/with-indicators
-                                      {:ok?         true
-                                       :window-ms   window-ms
-                                       :until-ms    until-ms
-                                       :count       (count encoded)
-                                       :limit       limit
-                                       :epochs-mode mode
-                                       :dedup       dedup?
-                                       :epochs      deduped
-                                       :has-more?   has-more?
+                                      {:ok?                 true
+                                       :window-ms           window-ms
+                                       :until-ms            until-ms
+                                       :count               count
+                                       :limit               limit
+                                       :epochs-mode         mode
+                                       :dedup               dedup?
+                                       :epochs              value
+                                       :has-more?           has-more?
                                        :estimated-remaining remaining
-                                       :next-cursor next-cursor}
+                                       :next-cursor         next-cursor}
                                       {:dropped dropped :elided elided})))))))
             (.catch (fn [err] (probe/err->result :trace-failed err))))))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/watch_epochs.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/watch_epochs.cljs
@@ -10,10 +10,15 @@
   current ring, `:next-cursor` rides the response — the agent calls
   back with the cursor to consume the remainder. The cursor is the
   opaque sibling of the `:since-id` arg; both can be used, but
-  `:cursor` takes precedence (it carries sticky pred/frame state)."
-  (:require [re-frame.mcp-base.vocab :as base-vocab]
-            [re-frame-pair2-mcp.nrepl :as nrepl]
+  `:cursor` takes precedence (it carries sticky pred/frame state).
+
+  Post-eval shrink pipeline lives in
+  `re-frame-pair2-mcp.tools.wire-pipeline` (rf2-ae8ie). This tool body
+  builds the eval form, awaits the runtime response, and routes the
+  matches vector through `run-wire-pipeline` with `:kind :epoch-vector`."
+  (:require [re-frame-pair2-mcp.nrepl :as nrepl]
             [re-frame-pair2-mcp.tools.wire :as wire]
+            [re-frame-pair2-mcp.tools.wire-pipeline :as wp]
             [re-frame-pair2-mcp.tools.probe :as probe]
             [re-frame-pair2-mcp.tools.cursor :as cursor]
             [re-frame-pair2-mcp.tools.dedup :as dedup]
@@ -61,34 +66,32 @@
                     (cursor/cursor-stale-result "watch-epochs"
                                                 {:requested-id (or (:requested-id v) effective-after)
                                                  :head-id      (:head-id v)})
-                    (let [matches        (vec (:matches v))
-                          [kept dropped] (sensitive/strip-sensitive matches incl?)
-                          encoded        (dedup/diff-encode-epochs kept mode)
-                          deduped        (dedup/dedup-value encoded dedup?)
-                          ;; :elided-large parity per Conventions §Cross-MCP
-                          ;; indicator-field vocabulary (rf2-2499j). Same
-                          ;; rationale as trace-window — no elision walk on
-                          ;; epoch records today; the scaffolding emits the
-                          ;; slot the moment a future revision wires it.
-                          elided         (base-vocab/count-elided-markers deduped)
-                          next-id        (:next-id v)
-                          next-cursor    (cursor/encode-cursor
-                                           (when next-id
-                                             {:v        1
-                                              :after-id next-id
-                                              :ms       nil
-                                              :until-ms nil
-                                              :frame    sticky-frame}))
-                          remaining      (or (:remaining v) 0)
-                          base           (cond-> {:ok?           true
-                                                  :head-id       (:head-id v)
-                                                  :id-aged-out?  (boolean aged-out?)}
-                                           (:requested-id v) (assoc :requested-id (:requested-id v)))]
+                    (let [matches (vec (:matches v))
+                          {:keys [value indicators]}
+                          (wp/run-wire-pipeline matches
+                                                {:kind   :epoch-vector
+                                                 :incl?  incl?
+                                                 :mode   mode
+                                                 :dedup? dedup?})
+                          {:keys [dropped elided count]} indicators
+                          next-id     (:next-id v)
+                          next-cursor (cursor/encode-cursor
+                                        (when next-id
+                                          {:v        1
+                                           :after-id next-id
+                                           :ms       nil
+                                           :until-ms nil
+                                           :frame    sticky-frame}))
+                          remaining   (or (:remaining v) 0)
+                          base        (cond-> {:ok?          true
+                                               :head-id      (:head-id v)
+                                               :id-aged-out? (boolean aged-out?)}
+                                        (:requested-id v) (assoc :requested-id (:requested-id v)))]
                       (wire/ok-text (wire/with-indicators
                                       (assoc base
-                                             :matches             deduped
+                                             :matches             value
                                              :limit               limit
-                                             :count               (count encoded)
+                                             :count               count
                                              :epochs-mode         mode
                                              :dedup               dedup?
                                              :has-more?           (some? next-cursor)

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire_pipeline.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire_pipeline.cljs
@@ -1,0 +1,153 @@
+(ns re-frame-pair2-mcp.tools.wire-pipeline
+  "Named wire-shrink pipeline (rf2-ae8ie). One fn per call-site —
+  every tool that returns a payload over the MCP wire routes it
+  through `run-wire-pipeline`, parameterised by the payload kind.
+
+  ## Why a named pipeline
+
+  Before this ns each tool body re-derived its own subset of the
+  shrink steps inline in its `let` binding. The ordering invariant
+  (dedup-BEFORE-summary · elision-count-AFTER-dedup-BEFORE-summary ·
+  summary-BEFORE-cap) lived implicitly in `snapshot-tool`'s
+  let-sequence; the abbreviated trace-window / watch-epochs / get-path
+  pipelines each re-derived their own subset. Three local-obvious
+  copies of one rule cost nothing — until the rule changes. A named
+  pipeline encodes the invariant once; a future step (say a
+  `with-redacted` walker) lands here once instead of in three places.
+
+  ## Ordering invariant
+
+  The full pipeline runs in this order:
+
+      sensitive-strip
+        → path-slice          (snapshot only — :app-db sliced before summary)
+        → diff-encode         (epoch records)
+        → dedup               (structural sharing across the wire)
+        → indicator-count     (count :rf.size/large-elided markers AFTER
+                               dedup so the count reflects the elision
+                               footprint of the post-shrink payload)
+        → summary             (lazy-summary for non-app-db rich slices)
+
+  Cap is NOT part of the pipeline — it runs at the `invoke` boundary
+  on the rendered envelope. Indicator-counting runs INSIDE this ns;
+  the envelope-tail splice (`wire/with-indicators`) runs in the tool
+  body around the pipeline result.
+
+  ## Payload kinds
+
+  - `:snapshot-map`  — per-frame snapshot map (`snapshot-tool`).
+                       Full pipeline including path-slice + summary.
+  - `:epoch-vector`  — vector of epoch records (`trace-window`,
+                       `watch-epochs`). sensitive-strip → diff-encode
+                       → dedup → indicator-count. No summary; the
+                       epoch shape is already bounded by the cursor
+                       `:limit`.
+  - `:scalar-value`  — single value (`get-path`). The eval form
+                       already ran `re-frame.core/elide-wire-value`
+                       server-side, so the pipeline here is just
+                       indicator-count; the value passes through.
+
+  Each kind returns `{:value v :indicators {:dropped N :elided N
+  :path-status M}}`. `:path-status` is the per-frame path-not-found
+  map on `:snapshot-map` calls when `:path` was supplied and at
+  least one frame's path didn't resolve; empty / absent otherwise.
+
+  Tools call this once and splice the result through
+  `wire/with-indicators` onto their envelope — the per-tool tail
+  collapses from a 20-line `let` of intermediate names to a 5-line
+  pipeline call + envelope assembly."
+  (:require [re-frame.mcp-base.vocab :as base-vocab]
+            [re-frame-pair2-mcp.tools.dedup :as dedup]
+            [re-frame-pair2-mcp.tools.sensitive :as sensitive]
+            [re-frame-pair2-mcp.tools.snapshot-pipeline :as pipeline]))
+
+(defn- run-snapshot-map
+  "Full snapshot pipeline. Sequences:
+
+    scrub-sensitive
+      → slice-app-db (path-slice or full)
+      → diff-encode-epochs
+      → dedup-epochs
+      → count elision markers (after dedup, before summary)
+      → summarise other slices
+
+  Returns `{:value snapshot :indicators {:dropped N :elided N
+  :path-status M :resolved-modes M}}`."
+  [snapshot {:keys [incl? mode dedup? path slice-mode slice-modes]}]
+  (let [app-db-mode           (pipeline/resolve-slice-mode :app-db slice-modes slice-mode)
+        [scrubbed dropped]    (sensitive/scrub-snapshot-sensitive snapshot incl?)
+        [sliced path-status]  (pipeline/slice-app-db-in-snapshot scrubbed path app-db-mode)
+        diff-encoded          (pipeline/diff-encode-epochs-in-snapshot sliced mode)
+        deduped               (pipeline/dedup-epochs-in-snapshot diff-encoded dedup?)
+        elided                (base-vocab/count-elided-markers deduped)
+        {summarised  :snapshot
+         other-modes :resolved-modes} (pipeline/summarise-other-slices-in-snapshot
+                                        deduped slice-modes slice-mode)
+        resolved-modes        (assoc other-modes :app-db
+                                     (cond
+                                       path :path-sliced
+                                       :else app-db-mode))]
+    {:value      summarised
+     :indicators {:dropped        dropped
+                  :elided         elided
+                  :path-status    path-status
+                  :resolved-modes resolved-modes
+                  :app-db-mode    app-db-mode}}))
+
+(defn- run-epoch-vector
+  "Abbreviated pipeline for vectors of epoch records (`trace-window`,
+  `watch-epochs`). The cursor `:limit` bounds the input; no summary
+  pass — the epoch shape is already bounded.
+
+  Sequences: strip-sensitive → diff-encode → dedup → count.
+
+  Returns `{:value deduped :indicators {:dropped N :elided N
+  :count <pre-dedup-encoded-count>}}`. `:count` is the raw
+  post-encode count tools surface as the `:count` slot on the
+  envelope."
+  [epochs {:keys [incl? mode dedup?]}]
+  (let [[kept dropped] (sensitive/strip-sensitive epochs incl?)
+        encoded        (dedup/diff-encode-epochs kept mode)
+        deduped        (dedup/dedup-value encoded dedup?)
+        elided         (base-vocab/count-elided-markers deduped)]
+    {:value      deduped
+     :indicators {:dropped dropped
+                  :elided  elided
+                  :count   (count encoded)}}))
+
+(defn- run-scalar-value
+  "Minimal pipeline for `get-path` results. The eval form already ran
+  `re-frame.core/elide-wire-value` server-side, so the pipeline here
+  is indicator-count only. The value passes through unchanged.
+
+  Returns `{:value v :indicators {:elided N}}`."
+  [v _opts]
+  {:value      v
+   :indicators {:elided (base-vocab/count-elided-markers v)}})
+
+(defn run-wire-pipeline
+  "Single named pipeline for every MCP tool that returns a tree-typed
+  payload. Dispatches on `:kind`; returns `{:value v :indicators M}`.
+
+  Encodes the wire-shrink ordering invariant once — see the namespace
+  docstring for the full ordering and per-kind step list.
+
+  Opts:
+
+  - `:kind`         one of `:snapshot-map`, `:epoch-vector`, `:scalar-value`.
+  - `:incl?`        sensitive opt-in flag (true ⇒ no drop).
+  - `:mode`         epochs-mode keyword (`:diff` / `:full`).
+  - `:dedup?`       boolean — run structural dedup at the wire boundary.
+  - `:path`         path vector (snapshot path-slicing).
+  - `:slice-mode`   global `:summary` / `:full` mode for non-app-db slices.
+  - `:slice-modes`  per-slice override map.
+
+  Unknown `:kind` is a programming error — the dispatch is closed
+  to four cases. Returns `{:value v :indicators {:elided 0}}` as a
+  defensive identity for an unrecognised kind."
+  [payload {:keys [kind] :as opts}]
+  (case kind
+    :snapshot-map (run-snapshot-map payload opts)
+    :epoch-vector (run-epoch-vector payload opts)
+    :scalar-value (run-scalar-value payload opts)
+    {:value payload :indicators {:elided 0}}))


### PR DESCRIPTION
## Summary

- New `tools/wire_pipeline.cljs` defines `run-wire-pipeline` — a single named pipeline parameterised by `:kind`. Encodes the wire-shrink ordering invariant (sensitive-strip → path-slice → diff-encode → dedup → indicator-count → summary) once instead of three times across four tool bodies.
- Four tool bodies migrated: `snapshot` (`:snapshot-map`), `trace-window` + `watch-epochs` (`:epoch-vector`), `get-path` (`:scalar-value`). Each tool body's post-eval `let` collapses from a 15-20-line orchestration to a 5-line pipeline call + envelope splice.
- Public surface unchanged. Composes cleanly with `wire/with-indicators` (rf2-dfk28).

Per the audit at `ai/findings/refactor-audit-tools-pair2-mcp-2026-05-14.md` §Strongest design-taste opinion / T6 / A2 — \"the wire-pipeline as a named, parameterised function is the most under-appreciated improvement.\"

## Test plan

- [x] `npm test` from `tools/pair2-mcp/` — 270 tests / 660 assertions / 0 failures / 0 errors
- [x] `npm run build` clean — 0 warnings