### PR TITLE
feat(story-mcp): stamp :origin :story-mcp on writes per Cross-Cutting-Designs (rf2-7dnct)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/config.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/config.cljc
@@ -45,6 +45,25 @@
   "Server `name` advertised in the `initialize` response's `serverInfo`."
   "re-frame2-story-mcp")
 
+;; ---- origin tag -----------------------------------------------------------
+
+(def ^:const origin
+  "The `:origin` value every story-mcp write carries per
+  [`spec/Cross-Cutting-Designs.md` §5 Origin tagging](../../../spec/Cross-Cutting-Designs.md).
+
+  The convention: every dispatching / writing surface picks one keyword
+  so post-mortem queries can answer 'who wrote / dispatched this?'.
+  Story-mcp doesn't ship `dispatch` (its surface is JVM-side, no event
+  bus access), but the `register-variant` and `record-as-variant`
+  writes stamp this value onto the registered variant body so
+  inspection of `(story/variant->edn vk)` reveals which variants came
+  from the MCP write surface.
+
+  Pinned here as `:const` so the single source of truth lives next to
+  the other server identity constants (`server-name`,
+  `protocol-version`)."
+  :story-mcp)
+
 ;; ---- write-surface gate ---------------------------------------------------
 
 (defonce

--- a/tools/story-mcp/src/re_frame/story_mcp/tools.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools.cljc
@@ -518,7 +518,12 @@
 
               :else
               (try
-                (let [id (story/reg-variant* vk body-v)]
+                ;; Stamp `:origin :story-mcp` per
+                ;; spec/Cross-Cutting-Designs.md §5 — every write
+                ;; surface tags its writes so post-mortem queries can
+                ;; identify which actor produced the registration.
+                (let [stamped (assoc body-v :origin config/origin)
+                      id      (story/reg-variant* vk stamped)]
                   (let [payload {:variant-id id :registered? true}]
                     (text-result (pr-edn payload) payload)))
                 (catch Throwable e
@@ -663,8 +668,14 @@
                   ;; captured :play body. We preserve the source variant's
                   ;; existing body keys (so :component, :args, :decorators
                   ;; survive) and overwrite :play with the captured events.
+                  ;; Stamp `:origin :story-mcp` per
+                  ;; spec/Cross-Cutting-Designs.md §5 — the write-back
+                  ;; produces a new variant body, and the origin tag
+                  ;; identifies the MCP write surface as its producer.
                   (try
-                    (let [new-body (assoc body :play events)
+                    (let [new-body (-> body
+                                       (assoc :play events)
+                                       (assoc :origin config/origin))
                           id       (story/reg-variant* target-vid new-body)
                           payload  (assoc base-payload
                                           :written-back?   true

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -597,6 +597,99 @@
       (is (re-find #":extends :story\.button/primary" snippet)))))
 
 ;; ---------------------------------------------------------------------------
+;; :origin :story-mcp stamping (rf2-7dnct)
+;;
+;; Per spec/Cross-Cutting-Designs.md §5 — every write surface tags its
+;; writes with a single `:origin` keyword so post-mortem queries can
+;; answer "who wrote this?". Story-mcp's `register-variant` and
+;; `record-as-variant` (write-back path) stamp `:origin :story-mcp` onto
+;; the registered variant body. The keyword value is pinned in
+;; `config/origin`; the registrar's open-shape variant schema admits
+;; the extra slot.
+;; ---------------------------------------------------------------------------
+
+(deftest origin-const-is-story-mcp
+  (testing "the origin keyword is `:story-mcp` per Cross-Cutting-Designs §5"
+    (is (= :story-mcp config/origin))))
+
+(deftest register-variant-stamps-origin-story-mcp
+  (testing "register-variant writes a body carrying :origin :story-mcp"
+    (config/set-allow-writes! true)
+    (let [r    (invoke "register-variant"
+                       {:variant-id "story.button/origin-map"
+                        :body       {:doc  "Origin-stamped via map body."
+                                     :args {:label "Stamped"}}})
+          body (story/variant->edn :story.button/origin-map)]
+      (is (success? r))
+      (is (= :story-mcp (:origin body))
+          "registered body must carry :origin :story-mcp")
+      ;; Caller-supplied keys survive alongside the stamp.
+      (is (= "Origin-stamped via map body." (:doc body)))
+      (is (= {:label "Stamped"} (:args body))))))
+
+(deftest register-variant-edn-string-body-stamps-origin
+  (testing "EDN-string body also lands :origin :story-mcp on the registered body"
+    (config/set-allow-writes! true)
+    (let [r    (invoke "register-variant"
+                       {:variant-id "story.button/origin-edn"
+                        :body       "{:doc \"Origin via EDN.\" :args {:label \"OK\"}}"})
+          body (story/variant->edn :story.button/origin-edn)]
+      (is (success? r))
+      (is (= :story-mcp (:origin body))))))
+
+(deftest register-variant-overrides-caller-supplied-origin
+  (testing "story-mcp owns the :origin slot — caller-supplied values are clobbered"
+    (config/set-allow-writes! true)
+    (let [r    (invoke "register-variant"
+                       {:variant-id "story.button/origin-override"
+                        :body       {:doc    "Caller tried to claim :app origin."
+                                     :origin :app}})
+          body (story/variant->edn :story.button/origin-override)]
+      (is (success? r))
+      (is (= :story-mcp (:origin body))
+          "the write surface owns the :origin slot; an agent cannot claim a different origin"))))
+
+(deftest record-as-variant-write-back-stamps-origin
+  (testing "record-as-variant write-back lands :origin :story-mcp on the new body"
+    (config/set-allow-writes! true)
+    (drive-events-during-recording [[:counter/inc]] 20)
+    (let [r    (invoke "record-as-variant"
+                       {:variant-id  "story.button/primary"
+                        :duration-ms 100
+                        :write-back? true})
+          body (story/variant->edn :story.button/primary)]
+      (is (success? r))
+      (is (true? (-> r :structuredContent :written-back?)))
+      (is (= :story-mcp (:origin body))
+          "write-back body must carry :origin :story-mcp")
+      ;; Pre-existing body keys + the captured :play slot still land.
+      (is (= "Primary button." (:doc body)))
+      (is (= [[:counter/inc]] (:play body))))))
+
+(deftest record-as-variant-write-back-new-id-stamps-origin
+  (testing ":new-variant-id write-back also carries :origin :story-mcp"
+    (config/set-allow-writes! true)
+    (drive-events-during-recording [[:counter/inc]] 20)
+    (let [r    (invoke "record-as-variant"
+                       {:variant-id     "story.button/primary"
+                        :new-variant-id "story.button/origin-recorded"
+                        :duration-ms    100
+                        :write-back?    true})
+          body (story/variant->edn :story.button/origin-recorded)]
+      (is (success? r))
+      (is (= :story-mcp (:origin body))))))
+
+(deftest record-as-variant-without-write-back-does-not-touch-source
+  (testing "without :write-back? the source variant is untouched (no :origin landed)"
+    ;; This pins the contract: the write happens only on the write-back
+    ;; branch. The :origin stamp is the marker of a write — its absence
+    ;; on a non-write-back call is the marker of a no-write.
+    (let [_    (invoke "record-as-variant" {:variant-id "story.button/primary"})
+          body (story/variant->edn :story.button/primary)]
+      (is (nil? (:origin body))
+          "no write happened, so no :origin stamp lands on the source body"))))
+
+;; ---------------------------------------------------------------------------
 ;; Server dispatcher (initialize, tools/list, tools/call, error paths)
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Per [`spec/Cross-Cutting-Designs.md` §5 Origin tagging](../blob/main/spec/Cross-Cutting-Designs.md), every dispatching / writing surface tags its emissions with a single `:origin` keyword so post-mortem queries can answer "who produced this artefact?". Line 87 of that spec claims story-mcp writes carry `:origin :story-mcp` — the implementation did not honour the claim before this PR.
- Both write sites in story-mcp now stamp `:origin :story-mcp` onto the variant body before `reg-variant*`:
  - `tool-register-variant` (`tools.cljc:521-527`)
  - `tool-record-as-variant` write-back branch (`tools.cljc:670-680`)
- The keyword value is pinned as `config/origin` so a single source of truth lives next to `server-name` / `protocol-version`. The Variant schema is open-shape (per `spec/007-Stories.md §Variant artefact contract`), so the extra slot validates without ceremony.
- story-mcp **owns** the `:origin` slot — caller-supplied values are clobbered. An agent cannot claim a different origin via the wire.
- `unregister!` is a delete (no body to stamp). `start-recording!` / `stop-recording!` mutate ephemeral session state (no persistent artefact); the persistent write produced by `record-as-variant` lands via `reg-variant*` in the write-back branch, which the stamp covers.
- Composes on top of rf2-zavp5 (token-budget cap) which just merged — no overlap with the wire-egress cap surface.

## Sites stamped

| Tool | Site | What gets stamped |
|---|---|---|
| `register-variant` | `tools.cljc:521-527` | Caller-supplied body |
| `record-as-variant` (write-back) | `tools.cljc:670-680` | Captured `:play` body |

## Test plan

- [x] `clojure -M:test` from `tools/story-mcp/` — 95 tests / 455 assertions / 0 failures, 0 errors
- [x] New tests pin: origin const value, stamp on map-body writes, stamp on EDN-string-body writes, override-protection contract, write-back stamp on same-id path, write-back stamp on `:new-variant-id` path, no-write contract (without `:write-back?` source body is untouched)

## References

- Audit: `ai/findings/refactor-audit-tools-story-mcp-2026-05-14.md` §S2
- Source bead: rf2-7dnct (P1)
- Discovered from: rf2-1sdzn (story-mcp audit)