### PR TITLE
fix(scripts): drift checker enumerates pair2-mcp tools post-split (rf2-u79gr)

### DIFF
--- a/scripts/check_skill_mcp_drift.py
+++ b/scripts/check_skill_mcp_drift.py
@@ -90,7 +90,11 @@ class Mapping:
 MAPPINGS: list[Mapping] = [
     Mapping(
         name="pair2-mcp <-> re-frame-pair2",
-        server_src=REPO_ROOT / "tools" / "pair2-mcp" / "src" / "re_frame_pair2_mcp" / "tools.cljs",
+        # Post rf2-vrbwx the eleven-tool catalogue lives in a dedicated
+        # `descriptors.cljs` leaf — the parent `tools.cljs` is now just a
+        # façade carrying the `case` dispatch (string match arms, no
+        # `{:name "..."}` literals). Point the gate at the catalogue.
+        server_src=REPO_ROOT / "tools" / "pair2-mcp" / "src" / "re_frame_pair2_mcp" / "tools" / "descriptors.cljs",
         host_prefix="re-frame-pair2",
         skill_md=REPO_ROOT / "skills" / "re-frame-pair2" / "SKILL.md",
     ),


### PR DESCRIPTION
## Summary

- **P0 unblock for main CI.** The `Verify skill ↔ MCP allowed-tools drift (rf2-flzdp)` gate has been red since #831 merged. The pair2-mcp `tools.cljs` split (rf2-vrbwx) moved the eleven-tool catalogue into `tools/descriptors.cljs`; the parent file became a thin façade. The drift script kept pointing at the façade, found `server=0 tools`, and reported all eleven skill entries as missing-in-server.
- **Fix.** Update the `MAPPINGS` entry for pair2-mcp to read `tools/descriptors.cljs` directly (the catalogue leaf). One-line path change in `scripts/check_skill_mcp_drift.py`.
- **Story-mcp.** Already clean — the apparent 12 / 5 split across the two skills is the deliberate authoring vs live-runtime partition from rf2-1v7tu HYBRID, with the cross-skill tools annotated as `intentional_server_only` in each mapping. No allow-list refresh needed.

## Local run

```
$ python scripts/check_skill_mcp_drift.py --verbose --ci
pair2-mcp <-> re-frame-pair2: server=11 tools, skill=11 allow-listed.
story-mcp <-> re-frame2: server=17 tools, skill=12 allow-listed.
story-mcp <-> re-frame-pair2: server=17 tools, skill=5 allow-listed.
causa-mcp <-> <tbd>: server src 'tools\causa-mcp\src\re_frame\causa_mcp\tools.cljc' missing -- skipping (optional).
No skill <-> MCP drift detected.
$ echo $?
0
```

## Test plan

- [x] `python scripts/check_skill_mcp_drift.py --verbose --ci` exits 0 locally
- [ ] `Verify skill ↔ MCP allowed-tools drift (rf2-flzdp)` CI gate goes green on this PR