### PR TITLE
refactor(machines): introduce Result ADT (rf2-aa2rw)

### DIFF
--- a/docs/guide/08-state-machines.md
+++ b/docs/guide/08-state-machines.md
@@ -340,18 +340,20 @@ Because `machine-transition` is pure — and guards / actions are inline-or-name
 ```clojure
 (deftest login-flow
   (let [s0 {:state :idle :data {:attempts 0 :error nil}}
-        [s1 _fx] (rf/machine-transition login-flow s0
-                                        [:auth.login/submit {:email "a@b.com"
-                                                             :password "..."}])]
+        {s1 ::result/snap} (rf/machine-transition login-flow s0
+                                                  [:auth.login/submit {:email "a@b.com"
+                                                                       :password "..."}])]
     (is (= :submitting (:state s1)))
 
     ;; attempts has already hit the retry limit; the :under-retry-limit guard
     ;; rejects the first clause, the second clause's :locked-out wins.
-    (let [[s2 _fx] (rf/machine-transition login-flow
-                                          {:state :submitting :data {:attempts 3}}
-                                          [:auth.login/failure {:message "wrong creds"}])]
+    (let [{s2 ::result/snap} (rf/machine-transition login-flow
+                                                    {:state :submitting :data {:attempts 3}}
+                                                    [:auth.login/failure {:message "wrong creds"}])]
       (is (= :locked-out (:state s2))))))
 ```
+
+`machine-transition` returns a `re-frame.machines.result/Result` map — destructure `::result/snap` and `::result/fx` (or use `result/ok?` / `result/fail?` to discriminate). Per rf2-aa2rw the engine surfaces action / `:data`-fn throws via `result/fail` rather than the old `[::action-failed info]` sentinel.
 
 JVM-side. No browser, no network, no mocks. Each test runs in microseconds; you can have hundreds. This is the testing experience for *flows that are non-trivial* — exactly the case where unit testing usually gets hard.
 

--- a/docs/guide/13-testing.md
+++ b/docs/guide/13-testing.md
@@ -174,15 +174,15 @@ Three levels of machine testing, in order of unit-cost:
 ```clojure
 (deftest login-flow-happy-path
   (let [s0 {:state :idle :data {:attempts 0 :error nil}}
-        [s1 _fx] (rf/machine-transition login-flow s0
-                                        [:auth.login/submit {:email "a@b.c"
-                                                             :password "..."}])]
+        {s1 ::result/snap} (rf/machine-transition login-flow s0
+                                                  [:auth.login/submit {:email "a@b.c"
+                                                                       :password "..."}])]
     (is (= :submitting (:state s1)))))
 
 (deftest login-flow-lockout
   (let [snap {:state :submitting :data {:attempts 3}}
-        [s _fx] (rf/machine-transition login-flow snap
-                                       [:auth.login/failure {:message "wrong"}])]
+        {s ::result/snap} (rf/machine-transition login-flow snap
+                                                 [:auth.login/failure {:message "wrong"}])]
     (is (= :locked-out (:state s)))))
 ```
 

--- a/examples/reagent/state_machine_walkthrough/core.cljc
+++ b/examples/reagent/state_machine_walkthrough/core.cljc
@@ -19,6 +19,7 @@
             ;; registers its late-bind hooks so rf/reg-machine and
             ;; rf/machine-transition resolve.
             [re-frame.machines]
+            [re-frame.machines.result :as result]
             ;; Managed-HTTP ships in day8/re-frame2-http.
             ;; The login flow's `:auth.login/login-attempt` action
             ;; dispatches `:rf.http/managed` (overridden in tests via
@@ -211,9 +212,10 @@
   frame, no app-db. The chapter's first test."
   []
   (let [s0 {:state :idle :data {:attempts 0 :error nil}}
-        [s1 fx1] (rf/machine-transition login-flow s0
-                                        [:auth.login/submit
-                                         {:email "a@b.com" :password "secret"}])]
+        {s1 ::result/snap fx1 ::result/fx}
+        (rf/machine-transition login-flow s0
+                               [:auth.login/submit
+                                {:email "a@b.com" :password "secret"}])]
     (assert (= :submitting (:state s1))
             (str "expected :submitting, got " (:state s1)))
     ;; Entering :submitting fires the :issue-request action's :fx.
@@ -221,8 +223,8 @@
     (assert (= :rf.http/managed (ffirst fx1))
             (str "expected :rf.http/managed fx-id, got " (ffirst fx1)))
 
-    (let [[s2 _] (rf/machine-transition login-flow s1
-                                        [:auth.login/success {:value {:token "t"}}])]
+    (let [{s2 ::result/snap} (rf/machine-transition login-flow s1
+                                                    [:auth.login/success {:value {:token "t"}}])]
       (assert (= :authed (:state s2))
               (str "expected :authed, got " (:state s2))))
     :ok))
@@ -235,10 +237,11 @@
   first counter value at which the guard rejects."
   []
   (let [snapshot {:state :submitting :data {:attempts 3 :error nil}}
-        [s _fx] (rf/machine-transition login-flow snapshot
-                                       [:auth.login/failure
-                                        {:failure {:kind :rf.http/http-4xx
-                                                   :message "bad creds"}}])]
+        {s ::result/snap}
+        (rf/machine-transition login-flow snapshot
+                               [:auth.login/failure
+                                {:failure {:kind :rf.http/http-4xx
+                                           :message "bad creds"}}])]
     (assert (= :locked-out (:state s))
             (str "expected :locked-out at attempts=3, got " (:state s)))
     :ok))

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_runtime_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_runtime_cljs_test.cljs
@@ -137,7 +137,7 @@
              {:red    {:on {:tick {:target :green}}}
               :green  {:on {:tick {:target :yellow}}}
               :yellow {:on {:tick {:target :red}}}}}
-          [s _] (machines/machine-transition m {:state :red :data {}} [:tick])]
+          {s :re-frame.machines.result/snap} (machines/machine-transition m {:state :red :data {}} [:tick])]
       (is (= :green (:state s))))))
 
 ;; ---- error paths ----------------------------------------------------------

--- a/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
@@ -270,7 +270,7 @@
              {:red    {:on {:tick {:target :green}}}
               :green  {:on {:tick {:target :yellow}}}
               :yellow {:on {:tick {:target :red}}}}}
-          [s _] (machines/machine-transition m {:state :red :data {}} [:tick])]
+          {s :re-frame.machines.result/snap} (machines/machine-transition m {:state :red :data {}} [:tick])]
       (is (= :green (:state s))))))
 
 ;; ---- error paths ----------------------------------------------------------

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_runtime_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_runtime_cljs_test.cljs
@@ -137,7 +137,7 @@
              {:red    {:on {:tick {:target :green}}}
               :green  {:on {:tick {:target :yellow}}}
               :yellow {:on {:tick {:target :red}}}}}
-          [s _] (machines/machine-transition m {:state :red :data {}} [:tick])]
+          {s :re-frame.machines.result/snap} (machines/machine-transition m {:state :red :data {}} [:tick])]
       (is (= :green (:state s))))))
 
 ;; ---- error paths ----------------------------------------------------------

--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -687,6 +687,9 @@
                        "    expected: " (pr-str want) "\n"
                        "    actual:   " (pr-str out)))})
 
+    ;; Per rf2-aa2rw the engine returns a `re-frame.machines.result/Result`;
+    ;; destructure `::snap` / `::fx` by keyword literal so we don't have to
+    ;; add a require on the result ns from this fixture-runner.
     :machine-transition
     (let [actions-by-id  (or (:actions fixture-machines) {})
           guards-by-id   (or (:guards  fixture-machines) {})
@@ -695,13 +698,16 @@
                              (update :actions          #(merge actions-by-id %))
                              (update :guards           #(merge guards-by-id %))
                              (update :on-spawn-actions #(merge on-spawn-by-id %)))
-          [snap-out fx-out]
-          (try (machines/machine-transition definition (:snapshot call) (:event call))
-               (catch :default e [nil [:error (ex-message e)]]))
-          want-snap (:expect-next-snapshot call)
-          want-fx   (or (:expect-effects call) [])
-          ok-snap?  (= want-snap snap-out)
-          ok-fx?    (= want-fx (vec fx-out))]
+          r             (try (machines/machine-transition definition (:snapshot call) (:event call))
+                             (catch :default e
+                               {:re-frame.machines.result/snap nil
+                                :re-frame.machines.result/fx   [:error (ex-message e)]}))
+          snap-out      (:re-frame.machines.result/snap r)
+          fx-out        (:re-frame.machines.result/fx r)
+          want-snap     (:expect-next-snapshot call)
+          want-fx       (or (:expect-effects call) [])
+          ok-snap?      (= want-snap snap-out)
+          ok-fx?        (= want-fx (vec fx-out))]
       {:passed? (and ok-snap? ok-fx?)
        :detail  (when (not (and ok-snap? ok-fx?))
                   (str "machine-transition\n"

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -753,7 +753,10 @@
                        "    expected: " (pr-str want) "\n"
                        "    actual:   " (pr-str out)))})
 
-    ;; pure machine-transition call (used by fsm fixtures).
+    ;; pure machine-transition call (used by fsm fixtures). Per
+    ;; rf2-aa2rw the engine returns a `re-frame.machines.result/Result`
+    ;; — we destructure `::snap` / `::fx` directly to avoid a static
+    ;; require on the machines artefact from the conformance test ns.
     :machine-transition
     (let [machine-transition (requiring-resolve 're-frame.machines/machine-transition)
           actions-by-id (or (:actions fixture-machines) {})
@@ -767,13 +770,16 @@
                             (update :actions #(merge actions-by-id %))
                             (update :guards  #(merge guards-by-id %))
                             (update :on-spawn-actions #(merge on-spawn-by-id %)))
-          [snap-out fx-out]
-          (try (machine-transition definition (:snapshot call) (:event call))
-               (catch Throwable e [nil [:error (.getMessage e)]]))
-          want-snap (:expect-next-snapshot call)
-          want-fx   (or (:expect-effects call) [])
-          ok-snap?  (= want-snap snap-out)
-          ok-fx?    (= want-fx (vec fx-out))]
+          r             (try (machine-transition definition (:snapshot call) (:event call))
+                             (catch Throwable e
+                               {:re-frame.machines.result/snap nil
+                                :re-frame.machines.result/fx   [:error (.getMessage e)]}))
+          snap-out      (:re-frame.machines.result/snap r)
+          fx-out        (:re-frame.machines.result/fx r)
+          want-snap     (:expect-next-snapshot call)
+          want-fx       (or (:expect-effects call) [])
+          ok-snap?      (= want-snap snap-out)
+          ok-fx?        (= want-fx (vec fx-out))]
       {:passed? (and ok-snap? ok-fx?)
        :detail  (when (not (and ok-snap? ok-fx?))
                   (str "machine-transition\n"

--- a/implementation/core/test/re_frame/pattern_smoke_test.clj
+++ b/implementation/core/test/re_frame/pattern_smoke_test.clj
@@ -15,6 +15,7 @@
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.machines :as machines]
+            [re-frame.machines.result :as result]
             [re-frame.substrate.plain-atom :as plain-atom]))
 
 (defn- reset-runtime [test-fn]
@@ -238,7 +239,7 @@
           :failed         {:on {:ws/connect {:target :connecting
                                              :action :reset-retry}}}}}
         step (fn [snap event]
-               (first (machines/machine-transition machine snap event)))]
+               (::result/snap (machines/machine-transition machine snap event)))]
     ;; Happy path: disconnected → connecting → authenticating → connected.
     (let [s1 (step {:state :disconnected :data {:retries 0 :max-retries 2}}
                    [:ws/connect])
@@ -281,11 +282,11 @@
                            :timeout {}}}]
     (testing "match → commit (timer fires with the carried epoch)"
       (let [s0 {:state :idle :data {:rf/after-epoch 0}}
-            s1 (first (machines/machine-transition machine s0 [:fetch]))
+            s1 (::result/snap (machines/machine-transition machine s0 [:fetch]))
             captured-epoch (get-in s1 [:data :rf/after-epoch])]
         (is (= :loading (:state s1)))
         (is (= 1 captured-epoch) "epoch advances on entry to :after-bearing state")
-        (let [s2 (first (machines/machine-transition
+        (let [s2 (::result/snap (machines/machine-transition
                           machine s1
                           [:rf.machine.timer/after-elapsed 5000 captured-epoch]))]
           (is (= :timeout (:state s2)) "matching epoch → transition commits"))))
@@ -295,14 +296,14 @@
       ;; The original timer fires carrying epoch 1 against current epoch 3.
       (let [traces (atom [])
             s0 {:state :idle :data {:rf/after-epoch 0}}
-            s1 (first (machines/machine-transition machine s0 [:fetch]))      ;; epoch 1
+            s1 (::result/snap (machines/machine-transition machine s0 [:fetch]))      ;; epoch 1
             captured 1
-            s2 (first (machines/machine-transition machine s1 [:cancel]))     ;; epoch 2
-            s3 (first (machines/machine-transition machine s2 [:fetch]))]     ;; epoch 3
+            s2 (::result/snap (machines/machine-transition machine s1 [:cancel]))     ;; epoch 2
+            s3 (::result/snap (machines/machine-transition machine s2 [:fetch]))]     ;; epoch 3
         (is (= :loading (:state s3)))
         (is (= 3 (get-in s3 [:data :rf/after-epoch])))
         (rf/register-trace-cb! ::stale (fn [ev] (swap! traces conj ev)))
-        (let [s4 (first (machines/machine-transition
+        (let [s4 (::result/snap (machines/machine-transition
                           machine s3
                           [:rf.machine.timer/after-elapsed 5000 captured]))]
           (rf/remove-trace-cb! ::stale)
@@ -351,7 +352,7 @@
                    :yielding      {:after {0 :processing}}
                    :complete      {}}}
         step (fn [snap event]
-               (first (machines/machine-transition machine snap event)))]
+               (::result/snap (machines/machine-transition machine snap event)))]
     (let [s0 {:state :idle :data (:data machine)}
           ;; :start runs :start-job, enters :processing (chunk 1: items
           ;; 0..1 squared), :always → :checking-done → :yielding.

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -10,6 +10,7 @@
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.machines :as machines]
+            [re-frame.machines.result :as result]
             [re-frame.routing :as routing]
             ;; Pull http-managed in so its late-bind hooks (in particular
             ;; :http/reg-http-interceptor) are published — the
@@ -488,9 +489,9 @@
              {:red    {:on {:tick {:target :green}}}
               :green  {:on {:tick {:target :yellow}}}
               :yellow {:on {:tick {:target :red}}}}}]
-      (let [[s1 _] (machines/machine-transition m {:state :red :data {}} [:tick])]
+      (let [{s1 ::result/snap} (machines/machine-transition m {:state :red :data {}} [:tick])]
         (is (= :green (:state s1))))
-      (let [[s2 _] (machines/machine-transition m {:state :green :data {}} [:tick])]
+      (let [{s2 ::result/snap} (machines/machine-transition m {:state :green :data {}} [:tick])]
         (is (= :yellow (:state s2)))))))
 
 (deftest machine-always-microstep
@@ -505,7 +506,7 @@
               :idle     {}}}
           ;; Even with a no-op event (no match in :on), :always is checked
           ;; and the guard passes — transition to :authed.
-          [s _] (machines/machine-transition m {:state :checking :data {:authed? true}} [:noop])]
+          {s ::result/snap} (machines/machine-transition m {:state :checking :data {:authed? true}} [:noop])]
       (is (= :authed (:state s))))))
 
 (deftest machine-raise-pre-commit
@@ -522,7 +523,7 @@
              {:idle {:on {:start {:target :busy :action :start}
                           :bump  {:action :bump}}}
               :busy {:on {:bump {:action :bump}}}}}
-          [s fx] (machines/machine-transition m {:state :idle :data {:n 0}} [:start])]
+          {s ::result/snap fx ::result/fx} (machines/machine-transition m {:state :idle :data {:n 0}} [:start])]
       ;; Two raised :bump events should have been processed pre-commit;
       ;; final data :n should be 2.
       (is (= 2 (:n (:data s))))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -23,6 +23,7 @@
             [re-frame.machines.lifecycle-fx.join :as join]
             [re-frame.machines.lifecycle-fx.validation :as validation]
             [re-frame.machines.parallel :as parallel]
+            [re-frame.machines.result :as result]
             [re-frame.machines.transition :as transition]
             [re-frame.trace :as trace]))
 
@@ -90,8 +91,8 @@
     event))
 
 (defn- trace-action-failure!
-  "Emit `:rf.error/machine-action-exception` for an `[::transition/action-
-  failed info]` step-result. Returns `{}` so the handler short-circuits."
+  "Emit `:rf.error/machine-action-exception` for a `result/fail` Result's
+  `::result/info` map. Returns `{}` so the handler short-circuits."
   [machine-id event frame-id info reason]
   (let [ex         (:exception info)
         ex-msg     #?(:clj  (when ex (.getMessage ^Throwable ex))
@@ -113,11 +114,6 @@
                         :reason            reason
                         :recovery          :no-recovery})
     {}))
-
-(defn- action-failed?
-  [step-result]
-  (and (vector? step-result)
-       (= ::transition/action-failed (first step-result))))
 
 (defn create-machine-handler
   "Returns a function suitable for registration with `reg-event-fx`.
@@ -196,29 +192,32 @@
             ;; user event. Bootstrap fx flow OUT of the handler ahead of
             ;; any fx the user event produces — entry happens-before user
             ;; event handling.
-            [boot-snap boot-fx :as boot-result]
+            boot-result
             (if (and needs-bootstrap? (not intercepted))
               (parallel/apply-initial-entry-cascade machine snapshot)
-              [snapshot []])
-            boot-failed?     (action-failed? boot-result)
+              (result/ok snapshot []))
+            boot-failed?     (result/fail? boot-result)
             post-boot-snap   (when-not boot-failed?
-                               (dissoc boot-snap :rf/bootstrap-pending?))]
+                               (dissoc (::result/snap boot-result)
+                                       :rf/bootstrap-pending?))
+            boot-fx          (when-not boot-failed?
+                               (::result/fx boot-result))]
         (cond
           intercepted
           intercepted
 
           boot-failed?
           (trace-action-failure! machine-id [:rf.machine/bootstrap] frame-id
-                                 (second boot-result)
+                                 (::result/info boot-result)
                                  "Machine initial-entry action threw.")
 
           :else
           (let [step-result (parallel/machine-transition machine post-boot-snap inner-event)]
-            (if (action-failed? step-result)
+            (if (result/fail? step-result)
               (trace-action-failure! machine-id inner-event frame-id
-                                     (second step-result)
+                                     (::result/info step-result)
                                      "Machine action threw.")
-              (let [[next-snapshot fx] step-result
+              (let [{next-snapshot ::result/snap fx ::result/fx} step-result
                     merged-fx (vec (concat boot-fx fx))
                     ;; Per Spec 005 §Final states (rf2-gn80): recompute
                     ;; the finality flag at the lifecycle-handler

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -31,6 +31,7 @@
   resolved single (or region) machine context, so the parallel layer
   is bypassed for the recursive macrostep call."
   (:require [clojure.set :as set]
+            [re-frame.machines.result :as result]
             [re-frame.machines.transition :as transition]))
 
 (defn parallel?
@@ -138,9 +139,9 @@
 
 (defn apply-initial-entry-cascade
   "Synthesise the bootstrap entry cascade for `machine` against the
-  freshly-synthesised `initial-snapshot`. Returns `[new-snapshot fx-vec]`,
-  or the `[:re-frame.machines.transition/action-failed info]` sentinel
-  if any `:entry` action threw.
+  freshly-synthesised `initial-snapshot`. Returns a `result/ok` Result
+  carrying the new snapshot + fx, or a `result/fail` Result if any
+  `:entry` action threw.
 
   For parallel-region machines (`:type :parallel`), iterates regions in
   declaration order, threading shared `:data` sequentially through regions
@@ -168,7 +169,7 @@
                                    (assoc :data  cur-data))
                          (some? cur-counter)
                          (assoc :rf/spawn-counter cur-counter))]
-            [(commit-tags-parallel machine merged) acc-fx])
+            (result/ok (commit-tags-parallel machine merged) acc-fx))
 
           :else
           (let [rn          (first pending)
@@ -178,10 +179,9 @@
                               (some? cur-counter)
                               (assoc :rf/spawn-counter cur-counter))
                 step-result (apply-initial-entry-cascade-single region-spec region-snap)]
-            (if (and (vector? step-result)
-                     (= :re-frame.machines.transition/action-failed (first step-result)))
+            (if (result/fail? step-result)
               step-result
-              (let [[reg-snap reg-fx] step-result
+              (let [{reg-snap ::result/snap reg-fx ::result/fx} step-result
                     prefixed-fx (mapv (partial prefix-region-invoke-id rn) reg-fx)]
                 (recur (rest pending)
                        (:data reg-snap)
@@ -195,6 +195,8 @@
 (defn- parallel-machine-transition
   "Pure function. Given a parallel-region machine, current snapshot, and
   event, broadcast the event to each region and merge the results.
+  Returns a `result/ok` Result on success or a `result/fail` Result if
+  any region's action threw.
 
   Per Spec 005 §Transition broadcast: each region resolves the event
   through its own active state's deepest-wins lookup; resolved regions
@@ -232,7 +234,7 @@
                                 (some? cur-counter)
                                 (assoc :rf/spawn-counter cur-counter))
               merged-tagged   (commit-tags-parallel machine merged)]
-          [merged-tagged acc-fx])
+          (result/ok merged-tagged acc-fx))
 
         :else
         (let [rn          (first pending)
@@ -242,10 +244,9 @@
                             (some? cur-counter)
                             (assoc :rf/spawn-counter cur-counter))
               step-result (machine-transition region-spec region-snap event)]
-          (if (and (vector? step-result)
-                   (= :re-frame.machines.transition/action-failed (first step-result)))
+          (if (result/fail? step-result)
             step-result
-            (let [[reg-snap reg-fx] step-result
+            (let [{reg-snap ::result/snap reg-fx ::result/fx} step-result
                   prefixed-fx (mapv (partial prefix-region-invoke-id rn) reg-fx)]
               (recur (rest pending)
                      (:data reg-snap)
@@ -255,7 +256,11 @@
 
 (defn machine-transition
   "Pure function. Given a machine definition, current snapshot, and event,
-  return [new-snapshot effects].
+  return a `re-frame.machines.result/Result` — either a `result/ok`
+  carrying the new snapshot and effects vector, or a `result/fail`
+  carrying diagnostic info if any action / `:data`-fn threw. Use
+  `result/ok?` / `result/fail?` to discriminate and the `::result/snap`
+  / `::result/fx` / `::result/info` keys to destructure.
 
   Per Spec 005 §Drain semantics §Level 3, this is the macrostep:
    1. Pick the matching transition for the event using deepest-wins

--- a/implementation/machines/src/re_frame/machines/result.cljc
+++ b/implementation/machines/src/re_frame/machines/result.cljc
@@ -1,0 +1,66 @@
+(ns re-frame.machines.result
+  "One result type for the machine-transition engine. Per rf2-aa2rw / rf2-ra1he §P0 #2.
+
+  The engine's pure surface (`apply-transition-once`, `machine-transition-
+  single`, `parallel-machine-transition`, `apply-initial-entry-cascade`,
+  and the public `machine-transition`) returns a Result map — either an
+  `:ok` with the post-transition snapshot + emitted fx, or a `:fail`
+  carrying diagnostic info about the action / `:data`-fn that threw.
+
+  Pre-refactor this concept was spelled three different ways across the
+  engine — `[::action-failed info]` vector sentinel, a
+  `{:rf.machine/action-failure ...}` map shape inside `run-action`, and a
+  `[:ok | :fail]` mini-ADT inside `materialise-data`. Six call-sites
+  spelled the same `(if (and (vector? r) (= ::action-failed (first r))) ...)`
+  disambiguation guard. This namespace replaces all three with one shape.
+
+  ## Shape
+
+      ;; success
+      {::tag :ok ::snap <snapshot> ::fx <fx-vec>}
+
+      ;; failure
+      {::tag :fail ::info <diagnostic-map>}
+
+  Use the constructors `ok` / `fail` and the predicates `ok?` / `fail?`.
+  The `::snap` / `::fx` / `::info` keys are public so callers can
+  destructure with `::keys [snap fx]`.
+
+  Bundle-isolation note: this ns is internal to the machines artefact.
+  Nothing in `tools/` or `examples/` reaches into it; the public
+  `re-frame.machines/machine-transition` surface returns Result values
+  directly but consumers should use the predicates and accessors here
+  rather than reading the `::tag` key by hand."
+  (:refer-clojure :exclude [ok?]))
+
+(defn ok
+  "Build a success Result carrying `snap` (post-transition snapshot) and
+  `fx` (the emitted fx vector)."
+  [snap fx]
+  {::tag :ok ::snap snap ::fx fx})
+
+(defn fail
+  "Build a failure Result carrying `info` (a diagnostic map describing
+  which action / `:data`-fn threw, with keys like `:action-ref`,
+  `:exception`, `:invoke-id`, `:decl-path`, `:transition`, `:state-path`)."
+  [info]
+  {::tag :fail ::info info})
+
+(defn ok?
+  "True iff `r` is an `:ok` Result."
+  [r]
+  (and (map? r) (= :ok (::tag r))))
+
+(defn fail?
+  "True iff `r` is a `:fail` Result."
+  [r]
+  (and (map? r) (= :fail (::tag r))))
+
+(defn fail-with
+  "Build a failure Result by `merge`ing `extra` over the existing
+  `:fail` Result's `::info` map. Used by the outer cascade (transition,
+  spawn) to enrich the inner failure (run-action / materialise-data) with
+  the transition-level context (`:decl-path`, `:transition`,
+  `:state-path`) before re-raising."
+  [r extra]
+  (assoc r ::info (merge (::info r) extra)))

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -19,6 +19,7 @@
   can be loaded and exercised on the JVM by the conformance fixtures
   (Spec 005 §Conformance fixtures)."
   (:require [clojure.set :as set]
+            [re-frame.machines.result :as result]
             [re-frame.trace :as trace]))
 
 (defn- chase-ref
@@ -431,48 +432,51 @@
 (defn- common-prefix-length [a b]
   (count (take-while true? (map = a b))))
 
-;; Sentinel: when an action throws, run-action returns this map instead of
-;; an effects map. collect-actions / apply-transition-once / machine-transition
-;; propagate it; the outer event handler converts it into a no-:db return so
-;; the cascade halts without committing a snapshot. Per Spec 005 §Errors and
-;; Cross-Spec-Interactions §11 — Machine action throws.
-(defn- action-failure?
-  [x]
-  (and (map? x) (contains? x :rf.machine/action-failure)))
+;; When an action throws, `run-action` returns a `result/fail` carrying
+;; `{:action-ref :exception}`. `collect-actions` propagates the failure;
+;; `apply-transition-once` / `machine-transition-single` enrich it with
+;; transition-level context; the outer event handler converts it into a
+;; no-`:db` return so the cascade halts without committing a snapshot.
+;; Per Spec 005 §Errors and Cross-Spec-Interactions §11 — Machine action
+;; throws.
 
-(defn- run-action [machine snap action-ref event]
+(defn- run-action
+  "Run one action ref and return either a plain effects map (success) or a
+  `result/fail` Result (the action threw). Successful actions may return
+  `nil` (treated as `{}`)."
+  [machine snap action-ref event]
   (if action-ref
     (let [f (resolve-action machine action-ref)]
       (try
-        (let [result (call-action f snap event)]
-          (or result {}))
+        (let [r (call-action f snap event)]
+          (or r {}))
         (catch #?(:clj Throwable :cljs :default) e
-          {:rf.machine/action-failure
-           {:action-ref action-ref
-            :exception  e}})))
+          (result/fail {:action-ref action-ref
+                        :exception  e}))))
     {}))
 
 (defn- collect-actions
   "Walk action-refs in order, calling each with snap+event and threading
   the resulting :data updates forward (so each action sees the previous
-  one's data). Returns [final-snapshot fx-vec], or
-  [::action-failed failure-info] if any action threw — per Spec 005
-  §Errors, the cascade halts on the first throw and the snapshot does
-  not commit."
+  one's data). Returns a `result/ok` carrying `[final-snapshot fx-vec]`,
+  or the `result/fail` Result the first throwing action produced — per
+  Spec 005 §Errors, the cascade halts on the first throw and the
+  snapshot does not commit."
   [machine snap event action-refs]
   (reduce
-    (fn [[s fx] aref]
+    (fn [acc aref]
       (if aref
-        (let [r (run-action machine s aref event)]
-          (if (action-failure? r)
-            (reduced [::action-failed (:rf.machine/action-failure r)])
-            (let [new-data   (cond-> (:data s)
-                               (contains? r :data) (merge (:data r)))
-                  new-snap   (assoc s :data new-data)
-                  new-fx     (vec (concat fx (or (:fx r) [])))]
-              [new-snap new-fx])))
-        [s fx]))
-    [snap []]
+        (let [{::result/keys [snap fx]} acc
+              r (run-action machine snap aref event)]
+          (if (result/fail? r)
+            (reduced r)
+            (let [new-data (cond-> (:data snap)
+                             (contains? r :data) (merge (:data r)))
+                  new-snap (assoc snap :data new-data)
+                  new-fx   (vec (concat fx (or (:fx r) [])))]
+              (result/ok new-snap new-fx))))
+        acc))
+    (result/ok snap [])
     action-refs))
 
 ;; ---- apply-transition-once helpers (extracted per rf2-g1s1) ---------------
@@ -489,15 +493,17 @@
   and rf2-h131, `:data` admits a fn form `(fn [snap ev] data)` so the spawn's
   initial data can depend on the parent snapshot at the moment of entry. The
   fn runs against the post-action snapshot (any :action :data writes are
-  visible). Returns `[:ok data]` or `[:fail exception]` — caller surfaces
-  the failure through the `::action-failed` sentinel."
+  visible). Returns `[::ok-data <materialised-data>]` on success, or a
+  `result/fail` Result carrying `{:exception <e>}` if the fn threw —
+  caller stamps `:action-ref` / `:invoke-id` / `:child-id` onto the
+  Result before propagating."
   [d snap event]
   (if (fn? d)
     (try
-      [:ok (d snap event)]
+      [::ok-data (d snap event)]
       (catch #?(:clj Throwable :cljs :default) e
-        [:fail e]))
-    [:ok d]))
+        (result/fail {:exception e})))
+    [::ok-data d]))
 
 (defn- build-after-fx
   "Per Spec 005 §SSR mode and Cross-Spec-Interactions §4 (Machines × SSR):
@@ -613,8 +619,9 @@
   `:rf/invoke-id` / `:rf/spawned-id` so the spawn-fx handler can bind the
   runtime-owned spawn-registry slot (rf2-t07u Option A revised).
 
-  Returns `[snap-after acc-fx']` for the reducer; `[:rf.machine/action-failed
-  info]` (wrapped in `reduced`) if the `:data` fn throws."
+  Returns `[snap-after acc-fx']` for the reducer; a `reduced` wrapper
+  around a `result/fail` Result (stamped with `:action-ref :rf.invoke/data-fn`
+  and `:invoke-id`) if the `:data` fn throws."
   [machine parent-id s acc-fx prefix n event]
   (let [inv         (:invoke n)
         machine-id  (:machine-id inv)
@@ -626,17 +633,16 @@
         (if (:invoke-id inv)
           [s (:invoke-id inv)]
           (allocate-spawned-id s machine-id))
-        [mat-status mat-data]
+        mat-result
         (if (contains? inv :data)
           (materialise-data (:data inv) s-after-alloc event)
-          [:ok nil])]
-    (if (= :fail mat-status)
+          [::ok-data nil])]
+    (if (result/fail? mat-result)
       (reduced
-        [::action-failed
-         {:action-ref :rf.invoke/data-fn
-          :exception  mat-data
-          :invoke-id  invoke-id}])
-      (let [inv'        (if (contains? inv :data)
+        (result/fail-with mat-result {:action-ref :rf.invoke/data-fn
+                                      :invoke-id  invoke-id}))
+      (let [mat-data    (second mat-result)
+            inv'        (if (contains? inv :data)
                           (assoc inv :data mat-data)
                           inv)
             spawn-args  (-> inv'
@@ -673,9 +679,10 @@
 
   Per Spec 005 §Spec-spec keys (rf2-h131): each child invoke-spec admits
   the same `:data` fn-form as a single `:invoke`. Materialisation may
-  throw; surface via the `::action-failed` sentinel.
+  throw; surface via a `result/fail` Result.
 
-  Returns `[snap-after acc-fx']` for the reducer."
+  Returns `[snap-after acc-fx']` for the reducer; a `reduced` wrapper
+  around a `result/fail` Result if any child's `:data` fn throws."
   [machine parent-id s acc-fx prefix n event]
   (let [inv-all     (:invoke-all n)
         children    (:children inv-all)
@@ -708,17 +715,22 @@
                       :rf/invoke-id invoke-id
                       :join-state   join-state}]
         ;; Build per-child spawn-args, materialising any `:data` fn-form
-        ;; (rf2-h131). Materialisation may throw — collect a
-        ;; `[:fail e child-id]` sentinel so the reducer short-circuits.
+        ;; (rf2-h131). Materialisation may throw — short-circuit with a
+        ;; `result/fail` Result (stamped with `:child-id`).
         child-spawn-build
         (reduce
           (fn [acc child]
-            (let [[mat-status mat-data] (if (contains? child :data)
-                                          (materialise-data (:data child) s event)
-                                          [:ok nil])]
-              (if (= :fail mat-status)
-                (reduced [:fail mat-data (:id child)])
-                (let [machine-id (:machine-id child)
+            (let [mat-result (if (contains? child :data)
+                               (materialise-data (:data child) s event)
+                               [::ok-data nil])]
+              (if (result/fail? mat-result)
+                (reduced
+                  (result/fail-with mat-result
+                                    {:action-ref :rf.invoke-all/data-fn
+                                     :invoke-id  invoke-id
+                                     :child-id   (:id child)}))
+                (let [mat-data   (second mat-result)
+                      machine-id (:machine-id child)
                       spawned-id (:rf/spawned-id child)
                       child'     (if (contains? child :data)
                                    (assoc child :data mat-data)
@@ -733,14 +745,8 @@
                   (conj acc [:rf.machine/spawn spawn-args])))))
           []
           children')]
-    (if (and (vector? child-spawn-build)
-             (= :fail (first child-spawn-build)))
-      (reduced
-        [::action-failed
-         {:action-ref :rf.invoke-all/data-fn
-          :exception  (second child-spawn-build)
-          :invoke-id  invoke-id
-          :child-id   (nth child-spawn-build 2)}])
+    (if (result/fail? child-spawn-build)
+      (reduced child-spawn-build)
       (let [child-spawn-fxs child-spawn-build
             s' (reduce
                  (fn [snap child]
@@ -782,7 +788,8 @@
 
 (defn apply-transition-once
   "Apply one transition (exit cascade → action → entry cascade → state
-  change). Returns [new-snapshot fx-vec].
+  change). Returns a `result/ok` Result carrying the new snapshot + fx,
+  or a `result/fail` Result if any action or `:data` fn threw.
 
   Per Spec 005 §Entry/exit cascading along the LCA:
    1. Compute LCA of source-path and target-leaf-path.
@@ -826,13 +833,12 @@
                             (map (fn [[_ n]] (:entry n)))))
         action-refs  [(:action transition)]
         all-refs     (concat exit-refs action-refs entry-refs)
-        result       (collect-actions machine snapshot event all-refs)]
-    (if (and (vector? result) (= ::action-failed (first result)))
-      [::action-failed (assoc (second result)
-                              :decl-path  decl-path
-                              :transition transition
-                              :state-path src-path)]
-      (let [[snap-after fx] result
+        cascade      (collect-actions machine snapshot event all-refs)]
+    (if (result/fail? cascade)
+      (result/fail-with cascade {:decl-path  decl-path
+                                 :transition transition
+                                 :state-path src-path})
+      (let [{snap-after ::result/snap fx ::result/fx} cascade
             ;; Per rf2-t07u (Option A revised) — the runtime carries
             ;; `[prefix-path node]` pairs through here so spawn / destroy
             ;; fx emissions can identify each `:invoke`-bearing state by
@@ -882,6 +888,11 @@
             after-fx        (build-after-fx machine entered-pairs internal? snap-final)
             after-cancel-fx (build-after-cancel-fx parent-id exited-pairs internal?)
             destroy-fx      (build-destroy-fx parent-id exited-pairs internal?)
+            ;; The spawn reducer's accumulator is the live `[s acc-fx]`
+            ;; pair the inner `handle-invoke-spawn` / `-all-spawn`
+            ;; helpers thread; a `reduced` from those helpers short-
+            ;; circuits to a `result/fail` Result, so the final value
+            ;; here is either the pair or the failure map.
             spawn-result
             (if internal?
               [snap-final []]
@@ -898,12 +909,10 @@
                     [s acc-fx]))
                 [snap-final []]
                 entered-pairs))]
-        (if (and (vector? spawn-result)
-                 (= ::action-failed (first spawn-result)))
-          [::action-failed (assoc (second spawn-result)
-                                  :decl-path  decl-path
-                                  :transition transition
-                                  :state-path src-path)]
+        (if (result/fail? spawn-result)
+          (result/fail-with spawn-result {:decl-path  decl-path
+                                          :transition transition
+                                          :state-path src-path})
           (let [[snap-after-spawns spawn-fx] spawn-result
                 all-fx (vec (concat fx
                                     (or after-cancel-fx [])
@@ -918,7 +927,7 @@
             ;; JVM pure-fn tests) stays free of transient runtime
             ;; metadata. The pure function returns the canonical
             ;; `{:state :data}` shape regardless of finality.
-            [snap-after-spawns all-fx]))))))
+            (result/ok snap-after-spawns all-fx)))))))
 
 (defn- pick-always-transition
   "Per Spec 005 §Eventless :always transitions: walk path leaf→root
@@ -960,7 +969,9 @@
 (defn- drain-raises
   "Drain the :raise queue inside fx-vec. Each :raise becomes an inline
   recursive machine-transition-single call; non-:raise fx pass through to
-  the accumulator. Returns [new-snapshot accum-fx]."
+  the accumulator. Returns a `result/ok` Result carrying the post-drain
+  `[snap accum-fx]`, or a `result/fail` Result if any recursive step
+  failed."
   [machine snapshot fx-vec depth-limit]
   (loop [pending fx-vec
          accum   []
@@ -971,10 +982,10 @@
       (do (trace/emit-error! :rf.error/machine-raise-depth-exceeded
                              {:machine-id (:id machine) :depth depth
                               :recovery :no-recovery})
-          [snap accum])
+          (result/ok snap accum))
 
       (empty? pending)
-      [snap accum]
+      (result/ok snap accum)
 
       :else
       (let [[fx-id args] (first pending)
@@ -982,10 +993,9 @@
         (case fx-id
           :raise
           (let [step-result (machine-transition-single machine snap args)]
-            (if (and (vector? step-result)
-                     (= ::action-failed (first step-result)))
+            (if (result/fail? step-result)
               step-result
-              (let [[snap2 fx2] step-result]
+              (let [{snap2 ::result/snap fx2 ::result/fx} step-result]
                 (recur (concat fx2 rest-pending)
                        accum
                        snap2
@@ -1008,10 +1018,12 @@
       `:always`; apply, drain raises, loop.
    5. Commit (return) the snapshot once `:always` reaches fixed point.
 
-  Bounded by `:raise-depth-limit` and `:always-depth-limit` (both default
-  16). Parallel-region routing lives in `re-frame.machines.parallel`'s
-  `machine-transition` — the dispatch checks `parallel?` and either
-  broadcasts across regions or falls through to this fn."
+  Returns a `result/ok` Result on success or a `result/fail` Result if
+  any action or `:data`-fn threw. Bounded by `:raise-depth-limit` and
+  `:always-depth-limit` (both default 16). Parallel-region routing lives
+  in `re-frame.machines.parallel`'s `machine-transition` — the dispatch
+  checks `parallel?` and either broadcasts across regions or falls
+  through to this fn."
   [machine snapshot event]
   (let [always-limit (get machine :always-depth-limit always-depth-limit-default)
         raise-limit  (get machine :raise-depth-limit  raise-depth-limit-default)
@@ -1045,10 +1057,10 @@
         result-after-event
         (cond
           (and match (:stale? match))
-          [snapshot []]
+          (result/ok snapshot [])
 
           (and match (:guard-suppressed? match))
-          [snapshot []]
+          (result/ok snapshot [])
 
           match
           (apply-transition-once
@@ -1056,47 +1068,50 @@
             (assoc (:transition match) :decl-path (:decl-path match)))
 
           :else
-          [snapshot []])]
-    (if (and (vector? result-after-event)
-             (= ::action-failed (first result-after-event)))
+          (result/ok snapshot []))]
+    (if (result/fail? result-after-event)
       result-after-event
-      (let [[snap-after-event fx-after-event] result-after-event
-            [snap-after-raise fx-after-raise]
-            (drain-raises machine snap-after-event fx-after-event raise-limit)]
-        ;; Step 4: :always microstep loop. Track visited state-paths so that,
-        ;; on depth-limit abort, we can report the path AND fully roll back to
-        ;; the original input snapshot — the macrostep is atomic per Spec 005.
-        (loop [snap    snap-after-raise
-               fx      fx-after-raise
-               depth   0
-               visited [(:state snap-after-raise)]]
-          (cond
-            (>= depth always-limit)
-            (do (trace/emit-error! :rf.error/machine-always-depth-exceeded
-                                   {:machine-id (:id machine)
-                                    :depth      depth
-                                    :path       visited
-                                    :recovery   :no-recovery})
-                [snapshot []])
+      (let [{snap-after-event ::result/snap fx-after-event ::result/fx} result-after-event
+            raised (drain-raises machine snap-after-event fx-after-event raise-limit)]
+        (if (result/fail? raised)
+          raised
+          (let [{snap-after-raise ::result/snap fx-after-raise ::result/fx} raised]
+            ;; Step 4: :always microstep loop. Track visited state-paths so that,
+            ;; on depth-limit abort, we can report the path AND fully roll back to
+            ;; the original input snapshot — the macrostep is atomic per Spec 005.
+            (loop [snap    snap-after-raise
+                   fx      fx-after-raise
+                   depth   0
+                   visited [(:state snap-after-raise)]]
+              (cond
+                (>= depth always-limit)
+                (do (trace/emit-error! :rf.error/machine-always-depth-exceeded
+                                       {:machine-id (:id machine)
+                                        :depth      depth
+                                        :path       visited
+                                        :recovery   :no-recovery})
+                    (result/ok snapshot []))
 
-            :else
-            (let [snap-path (state-path (:state snap))
-                  always-m  (pick-always-transition machine snap-path snap)]
-              (if (nil? always-m)
-                ;; Macrostep fixed-point reached. Recompute the
-                ;; active-configuration tag union on the committed snapshot
-                ;; AFTER the new state is settled but BEFORE traces fire
-                ;; (so the outer handler's `:rf.machine/transition` trace
-                ;; carries the new tag set).
-                [(commit-tags machine snap) fx]
-                (let [step-result (apply-transition-once machine snap nil
-                                                          (:transition always-m))]
-                  (if (and (vector? step-result)
-                           (= ::action-failed (first step-result)))
-                    step-result
-                    (let [[snap2 fx2] step-result
-                          [snap3 fx3] (drain-raises machine snap2 fx2 raise-limit)]
-                      (recur snap3
-                             (vec (concat fx fx3))
-                             (inc depth)
-                             (conj visited (:state snap3))))))))))))))
+                :else
+                (let [snap-path (state-path (:state snap))
+                      always-m  (pick-always-transition machine snap-path snap)]
+                  (if (nil? always-m)
+                    ;; Macrostep fixed-point reached. Recompute the
+                    ;; active-configuration tag union on the committed snapshot
+                    ;; AFTER the new state is settled but BEFORE traces fire
+                    ;; (so the outer handler's `:rf.machine/transition` trace
+                    ;; carries the new tag set).
+                    (result/ok (commit-tags machine snap) fx)
+                    (let [step-result (apply-transition-once machine snap nil
+                                                              (:transition always-m))]
+                      (if (result/fail? step-result)
+                        step-result
+                        (let [{snap2 ::result/snap fx2 ::result/fx} step-result
+                              raised2 (drain-raises machine snap2 fx2 raise-limit)]
+                          (if (result/fail? raised2)
+                            raised2
+                            (let [{snap3 ::result/snap fx3 ::result/fx} raised2]
+                              (recur snap3
+                                     (vec (concat fx fx3))
+                                     (inc depth)
+                                     (conj visited (:state snap3))))))))))))))))))

--- a/implementation/machines/test/re_frame/machine_transition_purity_test.clj
+++ b/implementation/machines/test/re_frame/machine_transition_purity_test.clj
@@ -1,8 +1,8 @@
 (ns re-frame.machine-transition-purity-test
   "Per rf2-gr8q. Locks in the contract that `machine-transition` is an
   honest pure function — identical (machine, snapshot, event) triples
-  produce identical [next-snapshot effects] pairs INCLUDING the spawn-id
-  sequencing inside emitted `:rf.machine/spawn` fx maps.
+  produce identical Result values (snapshot + effects vector) INCLUDING
+  the spawn-id sequencing inside emitted `:rf.machine/spawn` fx maps.
 
   Pre-rf2-gr8q the spawn-id allocator was a module-level
   `(defonce spawn-counter (atom {}))` keyed on `[frame-id machine-id]`
@@ -22,8 +22,8 @@
 
    1. **Identical args → identical results.** Call
       `machine-transition` twice with the SAME arguments and assert
-      the returned pair (snapshot + effects vector) is `=` to the
-      first call's pair.
+      the returned Result (snapshot + effects vector) is `=` to the
+      first call's Result.
 
    2. **No global state.** The two calls happen in arbitrary order;
       neither alters any module-level state that the other observes.
@@ -31,7 +31,8 @@
       counter 0 still allocates `:worker#1`, not `:worker#3`.
   "
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.machines :as machines]))
+            [re-frame.machines :as machines]
+            [re-frame.machines.result :as result]))
 
 (def auth-flow-spec
   "A tiny declarative-`:invoke` machine. On `[:submit]` from `:idle` it
@@ -48,11 +49,11 @@
              :authenticated  {}}})
 
 (deftest machine-transition-is-pure
-  (testing "identical args produce identical [next-snapshot effects] pairs"
+  (testing "identical args produce identical Result values"
     (let [snap     {:state :idle :data {}}
           event    [:submit]
-          [snap1 fx1] (machines/machine-transition auth-flow-spec snap event)
-          [snap2 fx2] (machines/machine-transition auth-flow-spec snap event)]
+          {snap1 ::result/snap fx1 ::result/fx} (machines/machine-transition auth-flow-spec snap event)
+          {snap2 ::result/snap fx2 ::result/fx} (machines/machine-transition auth-flow-spec snap event)]
       (is (= snap1 snap2)
           "two pure-call invocations from the same input produce the same next-snapshot")
       (is (= fx1 fx2)
@@ -80,8 +81,8 @@
     ;; produced `:http/post#2` because the atom carried over.
     (let [snap-a {:state :idle :data {:tag :a}}
           snap-b {:state :idle :data {:tag :b}}
-          [_ fx-a] (machines/machine-transition auth-flow-spec snap-a [:submit])
-          [_ fx-b] (machines/machine-transition auth-flow-spec snap-b [:submit])]
+          {fx-a ::result/fx} (machines/machine-transition auth-flow-spec snap-a [:submit])
+          {fx-b ::result/fx} (machines/machine-transition auth-flow-spec snap-b [:submit])]
       (is (= :http/post#1 (-> fx-a first second :rf/spawned-id))
           "first snapshot's spawn is :http/post#1")
       (is (= :http/post#1 (-> fx-b first second :rf/spawned-id))
@@ -95,7 +96,7 @@
     (let [snap     {:state            :idle
                     :data             {}
                     :rf/spawn-counter {:http/post 3}}
-          [snap' fx] (machines/machine-transition auth-flow-spec snap [:submit])]
+          {snap' ::result/snap fx ::result/fx} (machines/machine-transition auth-flow-spec snap [:submit])]
       (is (= :http/post#4 (-> fx first second :rf/spawned-id))
           "spawn allocates :http/post#4 — bump of the pre-existing 3")
       (is (= {:http/post 4} (:rf/spawn-counter snap'))
@@ -113,6 +114,6 @@
                                        :join     :all}
                                       :on        {:done :ready}}
                           :ready     {}}}
-          [snap' _fx] (machines/machine-transition spec {:state :idle :data {}} [:start])]
+          {snap' ::result/snap} (machines/machine-transition spec {:state :idle :data {}} [:start])]
       (is (= {:worker 3} (:rf/spawn-counter snap'))
           "three :worker children bumped the slot to 3"))))

--- a/implementation/machines/test/re_frame/parallel_test.clj
+++ b/implementation/machines/test/re_frame/parallel_test.clj
@@ -32,6 +32,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.machines :as machines]
+            [re-frame.machines.result :as result]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]))
 
@@ -206,7 +207,7 @@
                                :states  {:x {:tags #{:right/x} :on {:flip :y}}
                                          :y {:tags #{:right/y}}}}}}
           initial {:state {:left :a :right :x} :data {} :tags #{:left/a :right/x}}
-          [snap1 fx1] (machines/machine-transition m initial [:flip])]
+          {snap1 ::result/snap fx1 ::result/fx} (machines/machine-transition m initial [:flip])]
       (is (= {:left :b :right :y} (:state snap1))
           "pure transition broadcasts to both regions")
       (is (= #{:left/b :right/y} (:tags snap1))

--- a/implementation/machines/test/re_frame/tags_test.clj
+++ b/implementation/machines/test/re_frame/tags_test.clj
@@ -22,6 +22,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.machines :as machines]
+            [re-frame.machines.result :as result]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]))
 
@@ -152,11 +153,11 @@
              :states  {:a {:tags #{:start} :on {:next :b}}
                        :b {:tags #{:middle :transient} :on {:next :c}}
                        :c {:tags #{:end}}}}
-          [snap1 _] (machines/machine-transition m {:state :a :data {}} [:next])]
+          {snap1 ::result/snap} (machines/machine-transition m {:state :a :data {}} [:next])]
       (is (= :b (:state snap1)))
       (is (= #{:middle :transient} (:tags snap1))
           ":tags stamped on the pure-transition output")
-      (let [[snap2 _] (machines/machine-transition m snap1 [:next])]
+      (let [{snap2 ::result/snap} (machines/machine-transition m snap1 [:next])]
         (is (= :c (:state snap2)))
         (is (= #{:end} (:tags snap2))))))
 
@@ -165,7 +166,7 @@
              :data    {}
              :states  {:a {:on {:next :b}}
                        :b {}}}
-          [snap _]  (machines/machine-transition m {:state :a :data {}} [:next])]
+          {snap ::result/snap}  (machines/machine-transition m {:state :a :data {}} [:next])]
       (is (= :b (:state snap)))
       (is (not (contains? snap :tags))
           "empty tag union elided on pure-transition output"))))

--- a/implementation/machines/test/re_frame/three_arity_guards_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/three_arity_guards_cljs_test.cljc
@@ -58,6 +58,7 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.machines :as machines]
+   [re-frame.machines.result :as result]
    #?@(:cljs [[re-frame.core :as rf]
               [re-frame.adapter.reagent :as reagent-adapter]
               [re-frame.test-support :as test-support]])))
@@ -215,8 +216,8 @@
                         true)
              machine  (machine-with-guard guard)
              snapshot {:state :idle :data {:bumps 0} :meta {:user-tag :probe}}
-             [snap-after _fx] (machines/machine-transition
-                                machine snapshot [:go])]
+             {snap-after ::result/snap} (machines/machine-transition
+                                          machine snapshot [:go])]
          (is (= :gone (:state snap-after))
              "the transition fired (guard returned true), so we landed at :gone")
          (is (= 1 (get-in snap-after [:data :bumps]))
@@ -242,8 +243,8 @@
                         {:data (assoc data :saw-ctx? (some? ctx))})
              machine  (machine-with-action action)
              snapshot {:state :idle :data {:bumps 0} :meta {:user-tag :probe}}
-             [snap-after _fx] (machines/machine-transition
-                                machine snapshot [:go])]
+             {snap-after ::result/snap} (machines/machine-transition
+                                          machine snapshot [:go])]
          (is (= :gone (:state snap-after)))
          (is (true? (get-in snap-after [:data :saw-ctx?]))
              "the 3-arity action's ctx was non-nil and its return value
@@ -266,8 +267,8 @@
                transition fires and reaches :gone."
        (let [machine  (machine-with-guard (constantly true))
              snapshot {:state :idle :data {:bumps 0} :meta {:user-tag :probe}}
-             [snap-after _fx] (machines/machine-transition
-                                machine snapshot [:go])]
+             {snap-after ::result/snap} (machines/machine-transition
+                                          machine snapshot [:go])]
          (is (= :gone (:state snap-after))
              "(constantly true) returns true regardless of how many args
               it's called with — transition fires either way; the
@@ -290,8 +291,8 @@
                          (= 0 (:bumps data ::missing)))
              machine   (machine-with-guard guard)
              snapshot  {:state :idle :data {:bumps 0} :meta {:user-tag :probe}}
-             [snap-after _fx] (machines/machine-transition
-                                machine snapshot [:go])]
+             {snap-after ::result/snap} (machines/machine-transition
+                                          machine snapshot [:go])]
          (is (= :gone (:state snap-after))
              "transition fired — guard saw data + event correctly")
          (is (or (nil? @seen-rest)
@@ -310,8 +311,8 @@
                         true)
              machine  (machine-with-guard guard)
              snapshot {:state :idle :data {:bumps 0} :meta {:user-tag :probe}}
-             [snap-after _fx] (machines/machine-transition
-                                machine snapshot [:go])]
+             {snap-after ::result/snap} (machines/machine-transition
+                                          machine snapshot [:go])]
          (is (= :gone (:state snap-after)))
          (is (= 1 (get-in snap-after [:data :bumps])))
          (let [{:keys [data event argc]} @seen]


### PR DESCRIPTION
## Summary

Per rf2-ra1he §P0 #2 audit: the machine engine spelled the action-failure / success disambiguation three different ways across six call-sites. This bead introduces a single `re-frame.machines.result` ADT and collapses every site to one shape.

**Before** — three parallel micro-ADTs for one logical concept:
- `[::action-failed info]` vector sentinel (six call-sites in `transition.cljc`, `parallel.cljc`, `registration.cljc`)
- `{:rf.machine/action-failure ...}` map shape inside `run-action`
- `[:ok | :fail]` mini-ADT inside `materialise-data`

Each failure call-site spelled the same disambiguation guard:
```clojure
(if (and (vector? r) (= ::action-failed (first r))) ...)
```

**After** — one Result type:
```clojure
(result/ok snap fx)             ;; {::tag :ok ::snap snap ::fx fx}
(result/fail info)              ;; {::tag :fail ::info info}
(result/ok? r) / (result/fail? r)
```

Each call-site is now:
```clojure
(if (result/fail? r)
  (handle-fail (::result/info r))
  (let [{::result/keys [snap fx]} r] ...))
```

The new namespace is 66 LoC. Engine internals threading Result:
- `run-action` / `collect-actions` / `materialise-data`
- `apply-transition-once` (two failure-propagation sites — action cascade and spawn cascade)
- `handle-invoke-spawn` / `handle-invoke-all-spawn`
- `drain-raises` / `machine-transition-single`
- `apply-initial-entry-cascade` / `parallel-machine-transition`
- the public `re-frame.machines/machine-transition` surface

Pre-alpha, no back-compat: the public `machine-transition` now returns a Result map. Tests that destructured `[snap fx]` switch to `{::result/snap ::result/fx}` destructuring. That update covers the machines + core test trees, the three runtime-adapter cljs tests (reagent / uix / helix), the JVM + CLJS conformance fixture runners, the state-machine-walkthrough example, and the `docs/guide/08-state-machines.md` + `13-testing.md` code samples.

## Test plan

- [x] `clojure -M:test` in `implementation/machines/` — 119 tests / 332 assertions / 0 failures
- [x] `clojure -M:test` in `implementation/core/` — 440 tests / 2309 assertions / 0 failures
- [x] `npm run test:cljs` from `implementation/` — 1795 tests / 4975 assertions / 0 failures
- [x] `npm run test:bundle-isolation` — PASS (Result ns is internal; nothing in tools/ reaches into it)
- [x] No remaining `::action-failed` keyword or `:rf.machine/action-failure` map shape in `implementation/machines/src/` (only narrative references in the new `result.cljc` docstring explaining what was replaced)