### PR TITLE
refactor(flows): rewrite topo-sort as pure loop/recur (rf2-xdej3)

### DIFF
--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -63,36 +63,40 @@
             (:inputs b-flow)))))
 
 (defn- topo-sort
-  "Kahn's algorithm. Returns flows in evaluation order. Throws on cycles."
+  "Kahn's algorithm — pure `loop`/`recur` over immutable state. Returns
+  flows in evaluation order; throws `:rf.error/flow-cycle` if the graph
+  is cyclic. `ready` is a vector used as a LIFO stack
+  (`peek`/`pop`/`conj`); `remaining` is the live id→dep-set map; `order`
+  is the accumulating result."
   [flow-map]
   (let [ids   (vec (keys flow-map))
         graph (into {}
                     (map (fn [id]
-                           (let [flow (flow-map id)
-                                 deps (->> ids
-                                           (filter (fn [other]
-                                                     (and (not= id other)
-                                                          (depends-on? flow (flow-map other)))))
-                                           set)]
-                             [id deps])))
-                    ids)
-        order (atom [])
-        ready (atom (into [] (filter #(empty? (graph %))) ids))
-        remaining (atom graph)]
-    (while (seq @ready)
-      (let [n (peek @ready)]
-        (swap! ready pop)
-        (swap! order conj n)
-        (doseq [m (keys @remaining)]
-          (when (contains? (@remaining m) n)
-            (swap! remaining update m disj n)
-            (when (empty? (@remaining m))
-              (swap! ready conj m))))
-        (swap! remaining dissoc n)))
-    (when (seq @remaining)
-      (throw (ex-info ":rf.error/flow-cycle"
-                      {:cycle (vec (keys @remaining))})))
-    @order))
+                           (let [flow (flow-map id)]
+                             [id (into #{}
+                                       (filter #(and (not= id %)
+                                                     (depends-on? flow (flow-map %))))
+                                       ids)])))
+                    ids)]
+    (loop [ready     (filterv #(empty? (graph %)) ids)
+           remaining graph
+           order     []]
+      (if-let [n (peek ready)]
+        (let [rem0 (dissoc remaining n)
+              [remaining' ready']
+              (reduce-kv (fn [[rem rdy] m m-deps]
+                           (if-not (contains? m-deps n)
+                             [rem rdy]
+                             (let [m-deps' (disj m-deps n)]
+                               [(assoc rem m m-deps')
+                                (cond-> rdy (empty? m-deps') (conj m))])))
+                         [rem0 (pop ready)]
+                         rem0)]
+          (recur ready' remaining' (conj order n)))
+        (if (seq remaining)
+          (throw (ex-info ":rf.error/flow-cycle"
+                          {:cycle (vec (keys remaining))}))
+          order)))))
 
 ;; Note: `topo-sort` runs on every drain via `run-flows!`. A memo was
 ;; trialled here and removed (rf2-cd00): the per-frame flow map is tiny


### PR DESCRIPTION
## Summary

Per audit `rf2-o3hok` finding Q1/PF1 — the cheapest 'good code looks like this' win in the artefact.

`topo-sort` (Kahn over the per-frame flow DAG, called on every event drain via `run-flows!`, plus once per `reg-flow` for cycle detection per `rf2-7csri`) was written with three local atoms (`order`, `ready`, `remaining`) under a `while` loop with `swap!`/`@deref` on every step. State that never escaped the function, reading as imperative scaffolding.

Rewrite as pure `loop`/`recur` over immutable state:
- `ready` — vector used as a LIFO stack (`peek`/`pop`/`conj`)
- `remaining` — the live `id → dep-set` map
- `order` — the accumulating result vector
- a single `reduce-kv` per emitted node drops the edge from every dependent and graduates any just-empty dep-set onto `ready`

## Behaviour preserved

- Same emission order (LIFO stack with `peek`/`pop`/`conj`; `reduce-kv` iteration over the `dissoc`'d remaining map preserves the previous `doseq (keys @remaining)` order).
- Same cycle-throw shape: `(ex-info ":rf.error/flow-cycle" {:cycle (vec (keys remaining))})`. The detect-before-write path from `rf2-7csri` (`reg-flow`'s prospective cycle check) calls `topo-sort` purely for its throw side-effect and continues to work unchanged.

## Cost

Per-call cost drops from ~6 `swap!` + 4 `@deref` per emitted node to zero atom allocation.

## LoC delta

`+30 / -26` (net +4) on `flows.cljc` — the body shrinks but the docstring is fuller; three atom decls and four `swap!` calls are gone.

## Test plan

- [x] `clojure -M:test` from `implementation/flows/` — 27 tests / 105 assertions, 0 failures
- [x] `npm run test:cljs` from `implementation/` — 1795 tests / 4975 assertions, 0 failures
- [x] Cycle-detection tests pass (initial cycle + cyclic replacement preserves prior registration per `rf2-cdh9h`)
- [x] Cascade + prefix-overlap topo-sort tests pass

Parent: `rf2-o3hok` (flows refactor audit).