### PR TITLE
refactor(core): collapse 7 core_* artefact-wrappers into factory + per-artefact tables (rf2-h824v)

### DIFF
--- a/implementation/core/src/re_frame/core_artefact.cljc
+++ b/implementation/core/src/re_frame/core_artefact.cljc
@@ -1,0 +1,171 @@
+(ns re-frame.core-artefact
+  "Factory for the optional-artefact wrapper convention (rf2-h824v).
+
+  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention):
+  each per-feature carve-out (`flows`, `routing`, `schemas`, `machines`,
+  `ssr`, `epoch`, `http`) ships its public-API in a sibling
+  `re-frame.core-<artefact>` namespace whose fns look the producing impl
+  up through the late-bind hook registry at call time. Apps that omit
+  the artefact see either a silent safe-default (nil / [] / false) or
+  a structured `:rf.error/<artefact>-artefact-missing` ex-info,
+  depending on the surface's contract.
+
+  Pre-rf2-h824v the seven `core_<artefact>.cljc` files carried ~740 LoC
+  of structurally-identical late-bind boilerplate — 26 `ex-info`
+  literals each spelling the same skeleton. This namespace replaces
+  the boilerplate with a single `defwrapper` macro driven by a
+  declarative per-row spec, paired with the `late-bind/require-fn!`
+  helper (rf2-uchhp) that centralises the throw shape.
+
+  ## `defwrapper` shape
+
+  Each wrapper is one `defwrapper` form: a name, a docstring (or
+  metadata map carrying `:doc` / `:arglists`), a spec map, and a series
+  of arity bodies:
+
+  ```
+  (defwrapper clear-flow
+    \"Per Spec 013 §Lifecycle: clear a flow from a frame's registry.
+    Late-bound via :flows/clear-flow.\"
+    {:hook      :flows/clear-flow
+     :where     'rf/clear-flow
+     :artefact  flows-artefact
+     :on-absent :throw
+     :ex-data   {:flow-id id}}
+    ([id]      [id {}])     ;; shorter arity — recurse with these args
+    ([id opts] :delegate))  ;; primary arity — call the hook fn
+  ```
+
+  ### Spec map keys
+
+  | Key          | Required? | Meaning                                                                                  |
+  |--------------|-----------|------------------------------------------------------------------------------------------|
+  | `:hook`      | yes       | late-bind hook key (e.g. `:flows/clear-flow`)                                            |
+  | `:where`     | no        | quoted user-facing fn symbol (e.g. `'rf/clear-flow`) stamped on the missing-artefact throw. Defaults to `'rf/<name>` (the common case) |
+  | `:artefact`  | yes       | symbol resolving to an `artefact-info` map (see below) — typically a `def` in the same ns |
+  | `:on-absent` | yes       | absent-fn policy — `:throw` / `:nil` / `:false` / `:empty-vec` / `:empty-map`, or any literal value |
+  | `:ex-data`   | no        | extra ex-data slots merged onto the throw map (only meaningful when `:on-absent :throw`). Symbol values resolve in the arity's local scope and are dropped from shorter arities that don't bind the symbol |
+  | `:arglists`  | no        | passed through to the public fn's `:arglists` metadata (for variadic forms)              |
+
+  `:ex-data` is a map literal whose values are symbols that resolve in
+  the arity's local scope (the arglist's bindings). Example:
+  `{:flow-id id, :path path}`.
+
+  ### Arity body kinds
+
+  | Body               | Emits                                                            |
+  |--------------------|------------------------------------------------------------------|
+  | `:delegate`        | `(if-let [f (late-bind/get-fn :hook)] (f a b ...) <on-absent>)` for `:nil`/`:false`/`:empty-vec`; via `late-bind/require-fn!` for `:throw` |
+  | `:apply`           | same as `:delegate` but `(apply f args)` — for variadic arglists |
+  | `[expr expr ...]`  | recursion form — emits `(<name> expr expr ...)`                  |
+
+  ### `artefact-info` map shape
+
+  ```
+  (def flows-artefact
+    {:error-keyword :rf.error/flows-artefact-missing
+     :maven         \"day8/re-frame2-flows\"
+     :require-ns    \"re-frame.flows\"})
+  ```
+
+  These three slots feed the reason-string template used by
+  `late-bind/require-fn!`:
+
+      \"<where-sym> requires <maven> on the classpath; add it to deps and
+       require <require-ns> at app boot.\"
+
+  Convention: each `core_<artefact>.cljc` declares a private
+  `<artefact>-artefact` at the top of the file and threads it through
+  every `defwrapper` spec."
+  (:require [re-frame.late-bind]))
+
+#?(:clj
+   (defn- in-scope-ex-data
+     "Filter `ex-data` to entries whose value-symbol appears in the
+     arity's `args`. Lets a single spec-level `:ex-data` map scope
+     itself correctly across multi-arity wrappers where shorter arities
+     bind fewer locals (e.g. `active-head []` vs `active-head [frame-id]`)."
+     [ex-data args]
+     (let [arg-set (set (remove #{'&} args))]
+       (into {}
+             (filter (fn [[_ v]]
+                       (or (not (symbol? v))
+                           (contains? arg-set v))))
+             ex-data))))
+
+#?(:clj
+   (defn- build-body
+     "Emit the body form for one arity. `args` is the parsed arglist
+     (vector of symbols, possibly with `&`); `body-kind` is the user's
+     literal — `:delegate`, `:apply`, or a vector recursion-args form.
+
+     `on-absent` is the value the wrapper returns when the late-bind
+     hook is unregistered. Accepts a few sugar keywords (`:throw` /
+     `:nil` / `:false` / `:empty-vec` / `:empty-map`) or any literal
+     value (e.g. `0`, `:rf/default`). `:throw` routes through
+     `late-bind/require-fn!` with the structured missing-artefact
+     ex-info shape."
+     [name-sym {:keys [hook where artefact on-absent ex-data]} args body-kind]
+     (let [call-args (vec (remove #{'&} args))
+           absent    (case on-absent
+                       :throw     nil    ;; require-fn! throws — no else-branch
+                       :nil       nil
+                       :false     false
+                       :empty-vec []
+                       :empty-map {}
+                       on-absent)]
+       (cond
+         ;; Recursion: a literal vector of args to pass to the public surface.
+         (vector? body-kind)
+         `(~name-sym ~@body-kind)
+
+         ;; Direct hook call — throw on absent via require-fn!.
+         (= :throw on-absent)
+         (let [extra (not-empty (in-scope-ex-data ex-data args))]
+           (if (= :apply body-kind)
+             `(apply (re-frame.late-bind/require-fn! ~hook ~where ~artefact ~extra)
+                     ~(last args))
+             `((re-frame.late-bind/require-fn! ~hook ~where ~artefact ~extra)
+               ~@call-args)))
+
+         ;; Direct hook call — silent absent-default.
+         :else
+         (if (= :apply body-kind)
+           `(if-let [f# (re-frame.late-bind/get-fn ~hook)]
+              (apply f# ~(last args))
+              ~absent)
+           `(if-let [f# (re-frame.late-bind/get-fn ~hook)]
+              (f# ~@call-args)
+              ~absent))))))
+
+#?(:clj
+   (defn- build-arity
+     [name-sym spec [arglist body-kind]]
+     (list arglist (build-body name-sym spec arglist body-kind))))
+
+#?(:clj
+   (defmacro defwrapper
+     "See ns docstring. Emits a `defn` whose body delegates to the
+     late-bind hook table per the declarative spec.
+
+     Shape: `(defwrapper name docstring-or-attr-map spec & arity-forms)`.
+     Each arity-form is `(arglist body-kind)` where body-kind is
+     `:delegate`, `:apply`, or `[recursion-args ...]`.
+
+     When `:where` is omitted from the spec, it defaults to
+     `'rf/<name>` — the common case. Wrappers whose public-facing
+     symbol differs from the defn name (e.g. `-reg-error-projector` is
+     surfaced as `rf/reg-error-projector`) supply `:where` explicitly."
+     [name-sym docstring-or-attrs spec & arity-forms]
+     (let [attrs (cond
+                   (map? docstring-or-attrs)    docstring-or-attrs
+                   (string? docstring-or-attrs) {:doc docstring-or-attrs}
+                   :else (throw (ex-info "defwrapper: expected docstring or attr-map"
+                                         {:got docstring-or-attrs})))
+           attrs (cond-> attrs
+                   (:arglists spec) (assoc :arglists (:arglists spec)))
+           spec    (update spec :where #(or % (list 'quote (symbol "rf" (str name-sym)))))
+           arities (map #(build-arity name-sym spec %) arity-forms)]
+       `(defn ~name-sym
+          ~attrs
+          ~@arities))))

--- a/implementation/core/src/re_frame/core_epoch.cljc
+++ b/implementation/core/src/re_frame/core_epoch.cljc
@@ -17,51 +17,55 @@
   Absent-artefact behaviour: wrappers degrade silently (empty vector /
   `false` / no-op) so a release build that omits the artefact does not
   raise. `reset-frame-db!` is the exception — it records an epoch as
-  part of its contract and raises `:rf.error/epoch-artefact-missing`."
-  (:require [re-frame.late-bind :as late-bind]))
+  part of its contract and raises `:rf.error/epoch-artefact-missing`.
 
-(defn epoch-history
+  Per rf2-h824v the wrappers below are emitted by the
+  `re-frame.core-artefact/defwrapper` factory from a declarative table —
+  one row per public surface."
+  (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
+                                        :cljs [:refer-macros [defwrapper]])]))
+
+(def ^:private epoch-artefact
+  {:error-keyword :rf.error/epoch-artefact-missing
+   :maven         "day8/re-frame2-epoch"
+   :require-ns    "re-frame.epoch"})
+
+(defwrapper epoch-history
   "Return the vector of `:rf/epoch-record` values for the frame, oldest-
   first. Empty vector when the frame has no recorded epochs, when the
   ring buffer's depth is 0 (recording disabled), or when the
   `day8/re-frame2-epoch` artefact is not on the classpath. Late-bound
   via `:epoch/epoch-history`."
-  [frame-id]
-  (if-let [f (late-bind/get-fn :epoch/epoch-history)]
-    (f frame-id)
-    []))
+  {:hook :epoch/epoch-history :artefact epoch-artefact :on-absent :empty-vec}
+  ([frame-id] :delegate))
 
-(defn restore-epoch
+(defwrapper restore-epoch
   "Rewind the named frame's `app-db` to the named epoch's `:db-after`.
   Per Tool-Pair §Time-travel: returns `true` on success, `false` on any
   of the six documented failure modes (each emits a structured
   `:rf.epoch/*` error trace and leaves `app-db` unchanged) and `false`
   when the `day8/re-frame2-epoch` artefact is not on the classpath.
   Late-bound via `:epoch/restore-epoch`."
-  [frame-id epoch-id]
-  (if-let [f (late-bind/get-fn :epoch/restore-epoch)]
-    (f frame-id epoch-id)
-    false))
+  {:hook :epoch/restore-epoch :artefact epoch-artefact :on-absent :false}
+  ([frame-id epoch-id] :delegate))
 
-(defn register-epoch-cb!
+(defwrapper register-epoch-cb!
   "Register a callback fired once per drain-settle with the assembled
   `:rf/epoch-record`. Per Spec 009 §`register-epoch-cb!`. Same-id
   registrations replace; listener exceptions are isolated. Returns the
   id. No-op (returns nil) when the `day8/re-frame2-epoch` artefact is
   not on the classpath. Late-bound via `:epoch/register-epoch-cb`."
-  [id f]
-  (when-let [g (late-bind/get-fn :epoch/register-epoch-cb)]
-    (g id f)))
+  {:hook :epoch/register-epoch-cb :artefact epoch-artefact :on-absent :nil}
+  ([id f] :delegate))
 
-(defn remove-epoch-cb!
+(defwrapper remove-epoch-cb!
   "Remove the listener registered under id. No-op when the
   `day8/re-frame2-epoch` artefact is not on the classpath. Late-bound
   via `:epoch/remove-epoch-cb`."
-  [id]
-  (when-let [f (late-bind/get-fn :epoch/remove-epoch-cb)]
-    (f id)))
+  {:hook :epoch/remove-epoch-cb :artefact epoch-artefact :on-absent :nil}
+  ([id] :delegate))
 
-(defn reset-frame-db!
+(defwrapper reset-frame-db!
   "Replace `frame-id`'s `app-db` with `new-db`, bypassing the dispatch
   loop. Per Tool-Pair §Pair-tool writes (rf2-zq55).
 
@@ -88,10 +92,5 @@
   caller's invariant is 'undo works after this call').
 
   Returns `true` on success, `false` on any failure."
-  [frame-id new-db]
-  (if-let [f (late-bind/get-fn :epoch/reset-frame-db!)]
-    (f frame-id new-db)
-    (throw (ex-info ":rf.error/epoch-artefact-missing"
-                    {:where    'rf/reset-frame-db!
-                     :recovery :no-recovery
-                     :reason   "rf/reset-frame-db! requires day8/re-frame2-epoch on the classpath; add it to deps and require re-frame.epoch at app boot."}))))
+  {:hook :epoch/reset-frame-db! :artefact epoch-artefact :on-absent :throw}
+  ([frame-id new-db] :delegate))

--- a/implementation/core/src/re_frame/core_flows.cljc
+++ b/implementation/core/src/re_frame/core_flows.cljc
@@ -10,32 +10,32 @@
   Per-feature carve-out: the flows artefact pulls the per-frame flow
   registry, the topological-sort engine, and the dirty-check
   `last-inputs` map — none of which appear on a consumer's classpath
-  when this wrapper's hooks are unregistered."
-  (:require [re-frame.late-bind :as late-bind]))
+  when this wrapper's hooks are unregistered.
 
-(defn clear-flow
+  Per rf2-h824v the wrappers below are emitted by the
+  `re-frame.core-artefact/defwrapper` factory from a declarative table —
+  one row per public surface."
+  (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
+                                        :cljs [:refer-macros [defwrapper]])]))
+
+(def ^:private flows-artefact
+  {:error-keyword :rf.error/flows-artefact-missing
+   :maven         "day8/re-frame2-flows"
+   :require-ns    "re-frame.flows"})
+
+(defwrapper clear-flow
   "Per Spec 013 §Lifecycle: clear a flow from a frame's registry and
   vacate its output path. Late-bound via :flows/clear-flow."
-  ([id] (clear-flow id {}))
-  ([id opts]
-   (if-let [f (late-bind/get-fn :flows/clear-flow)]
-     (f id opts)
-     (throw (ex-info ":rf.error/flows-artefact-missing"
-                     {:where    'rf/clear-flow
-                      :flow-id  id
-                      :recovery :no-recovery
-                      :reason   "rf/clear-flow requires day8/re-frame2-flows on the classpath; add it to deps and require re-frame.flows at app boot."})))))
+  {:hook :flows/clear-flow :artefact flows-artefact :on-absent :throw
+   :ex-data {:flow-id id}}
+  ([id]      [id {}])
+  ([id opts] :delegate))
 
-(defn reg-flow
+(defwrapper reg-flow
   "Fn-form delegate that performs the late-bind lookup for `reg-flow`.
   The `re-frame.core/reg-flow` macro (JVM) and the CLJS `def`-alias both
   route here, so the late-bind logic and the missing-artefact error
   message live in one place."
-  ([flow] (reg-flow flow {}))
-  ([flow opts]
-   (if-let [f (late-bind/get-fn :flows/reg-flow)]
-     (f flow opts)
-     (throw (ex-info ":rf.error/flows-artefact-missing"
-                     {:where    'rf/reg-flow
-                      :recovery :no-recovery
-                      :reason   "rf/reg-flow requires day8/re-frame2-flows on the classpath; add it to deps and require re-frame.flows at app boot."})))))
+  {:hook :flows/reg-flow :artefact flows-artefact :on-absent :throw}
+  ([flow]      [flow {}])
+  ([flow opts] :delegate))

--- a/implementation/core/src/re_frame/core_http.cljc
+++ b/implementation/core/src/re_frame/core_http.cljc
@@ -12,47 +12,42 @@
   the encode/decode pipeline, the retry-with-backoff machinery, the
   eight-category `:rf.http/*` failure taxonomy, and every `:rf.http/*`
   keyword string — none of which appear on a consumer's classpath when
-  this wrapper's hooks are unregistered."
-  (:require [re-frame.late-bind :as late-bind]))
+  this wrapper's hooks are unregistered.
 
-(defn install-managed-request-stubs!
+  Per rf2-h824v the wrappers below are emitted by the
+  `re-frame.core-artefact/defwrapper` factory from a declarative table —
+  one row per public surface."
+  (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
+                                        :cljs [:refer-macros [defwrapper]])]))
+
+(def ^:private http-artefact
+  {:error-keyword :rf.error/http-artefact-missing
+   :maven         "day8/re-frame2-http"
+   :require-ns    "re-frame.http-managed"})
+
+(defwrapper install-managed-request-stubs!
   "Spec 014 §Testing — install per-call fx-overrides for `:rf.http/managed`
   that synthesise the configured replies. Late-bound via
   `:http/install-managed-request-stubs!`."
-  [stubs]
-  (if-let [f (late-bind/get-fn :http/install-managed-request-stubs!)]
-    (f stubs)
-    (throw (ex-info ":rf.error/http-artefact-missing"
-                    {:where    'rf/install-managed-request-stubs!
-                     :recovery :no-recovery
-                     :reason   "rf/install-managed-request-stubs! requires day8/re-frame2-http on the classpath; add it to deps and require re-frame.http-managed at app boot."}))))
+  {:hook :http/install-managed-request-stubs! :artefact http-artefact :on-absent :throw}
+  ([stubs] :delegate))
 
-(defn uninstall-managed-request-stubs!
+(defwrapper uninstall-managed-request-stubs!
   "Spec 014 §Testing — remove the per-call fx-override installed by
   `install-managed-request-stubs!`. Late-bound via
   `:http/uninstall-managed-request-stubs!`."
-  []
-  (if-let [f (late-bind/get-fn :http/uninstall-managed-request-stubs!)]
-    (f)
-    (throw (ex-info ":rf.error/http-artefact-missing"
-                    {:where    'rf/uninstall-managed-request-stubs!
-                     :recovery :no-recovery
-                     :reason   "rf/uninstall-managed-request-stubs! requires day8/re-frame2-http on the classpath; add it to deps and require re-frame.http-managed at app boot."}))))
+  {:hook :http/uninstall-managed-request-stubs! :artefact http-artefact :on-absent :throw}
+  ([] :delegate))
 
-(defn with-managed-request-stubs*
+(defwrapper with-managed-request-stubs*
   "Function form: install stubs, run thunk, uninstall. Late-bound via
   `:http/with-managed-request-stubs*`."
-  [stubs thunk]
-  (if-let [f (late-bind/get-fn :http/with-managed-request-stubs*)]
-    (f stubs thunk)
-    (throw (ex-info ":rf.error/http-artefact-missing"
-                    {:where    'rf/with-managed-request-stubs*
-                     :recovery :no-recovery
-                     :reason   "rf/with-managed-request-stubs* requires day8/re-frame2-http on the classpath; add it to deps and require re-frame.http-managed at app boot."}))))
+  {:hook :http/with-managed-request-stubs* :artefact http-artefact :on-absent :throw}
+  ([stubs thunk] :delegate))
 
 ;; ---- Spec 014 §Middleware — per-frame request interceptors (rf2-6y3q) -----
 
-(defn reg-http-interceptor
+(defwrapper reg-http-interceptor
   "Spec 014 §Middleware — register a request-side interceptor on a
   frame's `:rf.http/managed` middleware chain. The interceptor map
   shape is `{:frame <frame-id> :id <kw> :before (fn [ctx] ctx')}`.
@@ -65,26 +60,16 @@
 
   Late-bound via `:http/reg-http-interceptor`. When the http artefact
   is absent the call raises `:rf.error/http-artefact-missing`."
-  [interceptor]
-  (if-let [f (late-bind/get-fn :http/reg-http-interceptor)]
-    (f interceptor)
-    (throw (ex-info ":rf.error/http-artefact-missing"
-                    {:where    'rf/reg-http-interceptor
-                     :recovery :no-recovery
-                     :reason   "rf/reg-http-interceptor requires day8/re-frame2-http on the classpath; add it to deps and require re-frame.http-managed at app boot."}))))
+  {:hook :http/reg-http-interceptor :artefact http-artefact :on-absent :throw}
+  ([interceptor] :delegate))
 
-(defn clear-http-interceptor
+(defwrapper clear-http-interceptor
   "Spec 014 §Middleware — clear an HTTP interceptor by id from a frame's
   chain. Single-arity clears on `:rf/default`; two-arity targets the
   named frame.
 
   Late-bound via `:http/clear-http-interceptor`. When the http artefact
   is absent the call raises `:rf.error/http-artefact-missing`."
-  ([id] (clear-http-interceptor :rf/default id))
-  ([frame id]
-   (if-let [f (late-bind/get-fn :http/clear-http-interceptor)]
-     (f frame id)
-     (throw (ex-info ":rf.error/http-artefact-missing"
-                     {:where    'rf/clear-http-interceptor
-                      :recovery :no-recovery
-                      :reason   "rf/clear-http-interceptor requires day8/re-frame2-http on the classpath; add it to deps and require re-frame.http-managed at app boot."})))))
+  {:hook :http/clear-http-interceptor :artefact http-artefact :on-absent :throw}
+  ([id]       [:rf/default id])
+  ([frame id] :delegate))

--- a/implementation/core/src/re_frame/core_machines.cljc
+++ b/implementation/core/src/re_frame/core_machines.cljc
@@ -10,51 +10,53 @@
   Per-feature carve-out: the machines artefact pulls the machine
   registry, the entry/exit cascade engine, and the `:rf/machine` /
   `:rf/machine-has-tag?` framework subs — none of which appear on a
-  consumer's classpath when this wrapper's hooks are unregistered."
-  (:require [re-frame.late-bind :as late-bind]
+  consumer's classpath when this wrapper's hooks are unregistered.
+
+  Per rf2-h824v the canonical late-bind wrappers below are emitted by
+  the `re-frame.core-artefact/defwrapper` factory. `reg-machine` /
+  `reg-machine*` keep a bespoke shape — they share the `:where`-symbol
+  parameter via `reg-machine-impl` so the macro and the plain-fn
+  surface raise with their own faithful `:where` symbol. Sugar fns
+  (`dispatch-to-system`, `sub-machine`, `has-tag?`) are not late-bind
+  surfaces — they layer over `router/dispatch!` / `subs/subscribe`."
+  (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
+                                        :cljs [:refer-macros [defwrapper]])]
+            [re-frame.late-bind :as late-bind]
             [re-frame.router :as router]
             [re-frame.subs :as subs]))
 
-(defn create-machine-handler
+(def ^:private machines-artefact
+  {:error-keyword :rf.error/machines-artefact-missing
+   :maven         "day8/re-frame2-machines"
+   :require-ns    "re-frame.machines"})
+
+(defwrapper create-machine-handler
   "Build an event-fx handler from a machine spec. Per Spec 005
   §Registration. Late-bound via :machines/create-machine-handler."
-  [machine]
-  (if-let [f (late-bind/get-fn :machines/create-machine-handler)]
-    (f machine)
-    (throw (ex-info ":rf.error/machines-artefact-missing"
-                    {:where    'rf/create-machine-handler
-                     :recovery :no-recovery
-                     :reason   "rf/create-machine-handler requires day8/re-frame2-machines on the classpath; add it to deps and require re-frame.machines at app boot."}))))
+  {:hook :machines/create-machine-handler :artefact machines-artefact :on-absent :throw}
+  ([machine] :delegate))
 
-(defn machine-transition
+(defwrapper machine-transition
   "Pure (machine, snapshot, event) -> [snapshot fx]. Per Spec 005
   §Drain semantics §Level 3. Late-bound via :machines/machine-transition."
-  [machine snapshot event]
-  (if-let [f (late-bind/get-fn :machines/machine-transition)]
-    (f machine snapshot event)
-    (throw (ex-info ":rf.error/machines-artefact-missing"
-                    {:where    'rf/machine-transition
-                     :recovery :no-recovery
-                     :reason   "rf/machine-transition requires day8/re-frame2-machines on the classpath; add it to deps and require re-frame.machines at app boot."}))))
+  {:hook :machines/machine-transition :artefact machines-artefact :on-absent :throw}
+  ([machine snapshot event] :delegate))
 
-(defn machines
+(defwrapper machines
   "Return a sequence of registered machine ids. Per Spec 005
   §Querying machines. Returns `[]` when the machines artefact is not
   on the classpath."
-  []
-  (if-let [f (late-bind/get-fn :machines/machines)]
-    (f)
-    []))
+  {:hook :machines/machines :artefact machines-artefact :on-absent :empty-vec}
+  ([] :delegate))
 
-(defn machine-meta
+(defwrapper machine-meta
   "Return the registered machine spec map for machine-id, or nil. Per
   Spec 005 §Querying machines. Returns nil when the machines artefact
   is not on the classpath."
-  [machine-id]
-  (when-let [f (late-bind/get-fn :machines/machine-meta)]
-    (f machine-id)))
+  {:hook :machines/machine-meta :artefact machines-artefact :on-absent :nil}
+  ([machine-id] :delegate))
 
-(defn machine-by-system-id
+(defwrapper machine-by-system-id
   "Look up the spawned-machine id currently bound to `system-id` in the
   active frame's `[:rf/system-ids]` reverse index, or nil. The optional
   `frame-id` arg targets an explicit frame; without it, resolution uses
@@ -63,12 +65,15 @@
 
   Per Spec 005 §Named addressing via :system-id. Returns nil when the
   machines artefact is not on the classpath."
-  ([system-id]
-   (when-let [f (late-bind/get-fn :machines/machine-by-system-id)]
-     (f system-id)))
-  ([system-id frame-id]
-   (when-let [f (late-bind/get-fn :machines/machine-by-system-id)]
-     (f system-id frame-id))))
+  {:hook :machines/machine-by-system-id :artefact machines-artefact :on-absent :nil}
+  ([system-id]          :delegate)
+  ([system-id frame-id] :delegate))
+
+;; ---- reg-machine* / reg-machine — bespoke per rf2-8bp3 -------------------
+;;
+;; Both surfaces share the late-bind throw via `reg-machine-impl` but stamp
+;; their own `:where` symbol on the missing-artefact ex-info so the trace
+;; matches what the user wrote at the call site.
 
 (defn ^:private reg-machine-impl
   "Shared impl behind both `reg-machine*` (plain-fn surface) and the
@@ -76,14 +81,12 @@
   arg lets each user-facing surface stamp its own symbol on the
   missing-artefact error trace so `:where` matches what the user
   wrote at the call site."
-  [where-sym reason machine-id machine]
-  (if-let [f (late-bind/get-fn :machines/reg-machine)]
-    (f machine-id machine)
-    (throw (ex-info ":rf.error/machines-artefact-missing"
-                    {:where      where-sym
-                     :machine-id machine-id
-                     :recovery   :no-recovery
-                     :reason     reason}))))
+  [where-sym machine-id machine]
+  ((late-bind/require-fn! :machines/reg-machine
+                          where-sym
+                          machines-artefact
+                          {:machine-id machine-id})
+   machine-id machine))
 
 (defn reg-machine*
   "Plain-fn surface for machine registration. Per Spec 005 §reg-machine
@@ -93,10 +96,7 @@
   per-element source-coord index (only the macro can walk the literal
   spec at expansion time). Late-bound via :machines/reg-machine."
   [machine-id machine]
-  (reg-machine-impl
-    'rf/reg-machine*
-    "rf/reg-machine* requires day8/re-frame2-machines on the classpath; add it to deps and require re-frame.machines at app boot."
-    machine-id machine))
+  (reg-machine-impl 'rf/reg-machine* machine-id machine))
 
 (defn reg-machine
   "Fn-form delegate the `re-frame.core/reg-machine` macro routes through
@@ -109,10 +109,9 @@
   (macro) or `rf/reg-machine*` (plain fn). It is public only because
   the macro emits a reference to it."
   [machine-id machine]
-  (reg-machine-impl
-    'rf/reg-machine
-    "rf/reg-machine requires day8/re-frame2-machines on the classpath; add it to deps and require re-frame.machines at app boot."
-    machine-id machine))
+  (reg-machine-impl 'rf/reg-machine machine-id machine))
+
+;; ---- sugar surfaces — not late-bind wrappers -----------------------------
 
 (defn dispatch-to-system
   "Sugar: dispatch `event` to the spawned-machine bound to `system-id`

--- a/implementation/core/src/re_frame/core_routing.cljc
+++ b/implementation/core/src/re_frame/core_routing.cljc
@@ -11,51 +11,46 @@
   routing artefact pulls the route-rank / pattern-compile / nav-token
   machinery, the `:rf/route` reg-sub family, and every `:rf.route/*` /
   `:rf.nav/*` keyword string — none of which appear on a consumer's
-  classpath when this wrapper's hooks are unregistered."
-  (:require [re-frame.late-bind :as late-bind]))
+  classpath when this wrapper's hooks are unregistered.
 
-(defn match-url
+  Per rf2-h824v the wrappers below are emitted by the
+  `re-frame.core-artefact/defwrapper` factory from a declarative table —
+  one row per public surface."
+  (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
+                                        :cljs [:refer-macros [defwrapper]])]))
+
+(def ^:private routing-artefact
+  {:error-keyword :rf.error/routing-artefact-missing
+   :maven         "day8/re-frame2-routing"
+   :require-ns    "re-frame.routing"})
+
+(defwrapper match-url
   "Per Spec 012 §Bidirectional URL ↔ params. Match a URL against
   registered routes; return `{:route-id :params :query
   :validation-failed?}` for the first match, or `nil` if no route
   matches. Late-bound via :routing/match-url."
-  [url]
-  (if-let [f (late-bind/get-fn :routing/match-url)]
-    (f url)
-    (throw (ex-info ":rf.error/routing-artefact-missing"
-                    {:where    'rf/match-url
-                     :recovery :no-recovery
-                     :reason   "rf/match-url requires day8/re-frame2-routing on the classpath; add it to deps and require re-frame.routing at app boot."}))))
+  {:hook :routing/match-url :artefact routing-artefact :on-absent :throw}
+  ([url] :delegate))
 
-(defn route-url
+(defwrapper route-url
   "Per Spec 012 §Bidirectional URL ↔ params. Inverse of `match-url` —
   build a URL string from a route-id + path-params (and optional
   query-params). Late-bound via :routing/route-url."
-  ([route-id path-params] (route-url route-id path-params {}))
-  ([route-id path-params query-params]
-   (if-let [f (late-bind/get-fn :routing/route-url)]
-     (f route-id path-params query-params)
-     (throw (ex-info ":rf.error/routing-artefact-missing"
-                     {:where    'rf/route-url
-                      :route-id route-id
-                      :recovery :no-recovery
-                      :reason   "rf/route-url requires day8/re-frame2-routing on the classpath; add it to deps and require re-frame.routing at app boot."})))))
+  {:hook :routing/route-url :artefact routing-artefact :on-absent :throw
+   :ex-data {:route-id route-id}}
+  ([route-id path-params]              [route-id path-params {}])
+  ([route-id path-params query-params] :delegate))
 
-(defn reg-route
+(defwrapper reg-route
   "Fn-form delegate that performs the late-bind lookup for `reg-route`.
   The `re-frame.core/reg-route` macro (JVM) and the CLJS `def`-alias
   both route here, so the late-bind logic and the missing-artefact
   error message live in one place."
-  [id metadata]
-  (if-let [f (late-bind/get-fn :routing/reg-route)]
-    (f id metadata)
-    (throw (ex-info ":rf.error/routing-artefact-missing"
-                    {:where    'rf/reg-route
-                     :route-id id
-                     :recovery :no-recovery
-                     :reason   "rf/reg-route requires day8/re-frame2-routing on the classpath; add it to deps and require re-frame.routing at app boot."}))))
+  {:hook :routing/reg-route :artefact routing-artefact :on-absent :throw
+   :ex-data {:route-id id}}
+  ([id metadata] :delegate))
 
-(defn route-link
+(defwrapper route-link
   "Per Spec 012 §Linking from views and API.md `route-link` row.
   Registered view at `:route/link` — renders an `<a href=...>` from a
   registered route id and intercepts plain primary-button clicks to
@@ -74,11 +69,6 @@
   `reg-view*`); the JVM hook publishes the SSR-side render fn. Either
   way `[rf/route-link ...]` in a `.cljc` render tree renders correctly
   on both platforms."
-  {:arglists '([props & children])}
-  [& args]
-  (if-let [f (late-bind/get-fn :routing/route-link)]
-    (apply f args)
-    (throw (ex-info ":rf.error/routing-artefact-missing"
-                    {:where    'rf/route-link
-                     :recovery :no-recovery
-                     :reason   "rf/route-link requires day8/re-frame2-routing on the classpath; add it to deps and require re-frame.routing at app boot."}))))
+  {:hook :routing/route-link :artefact routing-artefact :on-absent :throw
+   :arglists '([props & children])}
+  ([& args] :apply))

--- a/implementation/core/src/re_frame/core_schemas.cljc
+++ b/implementation/core/src/re_frame/core_schemas.cljc
@@ -10,38 +10,44 @@
   Per-feature carve-out: the schemas artefact pulls Malli (the default
   validator) onto the classpath — apps that want to drop the ~24 KB
   gzipped Malli surface omit the artefact and either use a substitute
-  validator (per rf2-froe) or skip schema validation entirely."
-  (:require [re-frame.late-bind :as late-bind]))
+  validator (per rf2-froe) or skip schema validation entirely.
 
-(defn app-schema-at
+  Per rf2-h824v the wrappers below are emitted by the
+  `re-frame.core-artefact/defwrapper` factory from a declarative table —
+  one row per public surface."
+  (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
+                                        :cljs [:refer-macros [defwrapper]])]))
+
+(def ^:private schemas-artefact
+  {:error-keyword :rf.error/schemas-artefact-missing
+   :maven         "day8/re-frame2-schemas"
+   :require-ns    "re-frame.schemas"})
+
+(defwrapper app-schema-at
   "Return the registered schema for a path in a frame, or nil. Per Spec
   010 §Schemas as a tooling and agent surface. Returns nil when the
   schemas artefact is not on the classpath."
-  ([path] (app-schema-at path {}))
-  ([path opts]
-   (when-let [f (late-bind/get-fn :schemas/app-schema-at)]
-     (f path opts))))
+  {:hook :schemas/app-schema-at :artefact schemas-artefact :on-absent :nil}
+  ([path]      [path {}])
+  ([path opts] :delegate))
 
-(defn app-schemas
+(defwrapper app-schemas
   "Return every registered `app-schema-at` declaration for a frame as a
   `{path → schema}` map. Per Spec 010 §Per-frame schemas. Returns `{}`
   when the schemas artefact is not on the classpath."
-  ([] (app-schemas {}))
-  ([opts-or-frame-id]
-   (if-let [f (late-bind/get-fn :schemas/app-schemas)]
-     (f opts-or-frame-id)
-     {})))
+  {:hook :schemas/app-schemas :artefact schemas-artefact :on-absent :empty-map}
+  ([]                 [{}])
+  ([opts-or-frame-id] :delegate))
 
-(defn app-schemas-digest
+(defwrapper app-schemas-digest
   "Return a stable digest of the registered schemas for a frame. Per
   Spec 010 §Digest algorithm. Returns `nil` when the schemas artefact
   is not on the classpath."
-  ([] (app-schemas-digest {}))
-  ([opts-or-frame-id]
-   (when-let [f (late-bind/get-fn :schemas/app-schemas-digest)]
-     (f opts-or-frame-id))))
+  {:hook :schemas/app-schemas-digest :artefact schemas-artefact :on-absent :nil}
+  ([]                 [{}])
+  ([opts-or-frame-id] :delegate))
 
-(defn set-schema-validator!
+(defwrapper set-schema-validator!
   "Register the validator fn that every dev-time schema-validation site
   routes through. Per Spec 010 §Non-Malli validators (rf2-froe) the
   seam is the substitute-Malli extension point — apps that want to
@@ -61,36 +67,29 @@
   this fn replaces them. Returns nil when the schemas artefact is
   not on the classpath (apps that don't want schemas don't need to
   pull `day8/re-frame2-schemas`)."
-  [validate-fn-or-map]
-  (when-let [f (late-bind/get-fn :schemas/set-schema-validator!)]
-    (f validate-fn-or-map)))
+  {:hook :schemas/set-schema-validator! :artefact schemas-artefact :on-absent :nil}
+  ([validate-fn-or-map] :delegate))
 
-(defn set-schema-explainer!
+(defwrapper set-schema-explainer!
   "Register the explainer fn — `(fn [schema value] explanation)` — used
   to enrich schema-validation-failure traces' `:explain` key. Per
   Spec 010 §Non-Malli validators (rf2-froe). See
   `set-schema-validator!` for the validator companion. Returns nil
   when the schemas artefact is not on the classpath."
-  [explain-fn]
-  (when-let [f (late-bind/get-fn :schemas/set-schema-explainer!)]
-    (f explain-fn)))
+  {:hook :schemas/set-schema-explainer! :artefact schemas-artefact :on-absent :nil}
+  ([explain-fn] :delegate))
 
-(defn reg-app-schema
+(defwrapper reg-app-schema
   "Fn-form delegate that performs the late-bind lookup for
   `reg-app-schema`. The `re-frame.core/reg-app-schema` macro (JVM) and
   the CLJS `def`-alias both route here, so the late-bind logic and the
   missing-artefact error message live in one place."
-  ([path schema] (reg-app-schema path schema {}))
-  ([path schema opts]
-   (if-let [f (late-bind/get-fn :schemas/reg-app-schema)]
-     (f path schema opts)
-     (throw (ex-info ":rf.error/schemas-artefact-missing"
-                     {:where    'rf/reg-app-schema
-                      :path     path
-                      :recovery :no-recovery
-                      :reason   "rf/reg-app-schema requires day8/re-frame2-schemas on the classpath; add it to deps and require re-frame.schemas at app boot."})))))
+  {:hook :schemas/reg-app-schema :artefact schemas-artefact :on-absent :throw
+   :ex-data {:path path}}
+  ([path schema]      [path schema {}])
+  ([path schema opts] :delegate))
 
-(defn reg-app-schemas
+(defwrapper reg-app-schemas
   "Bulk-register `{path -> schema}` against the active frame (or the
   `:frame` opt). Per rf2-jzs9 — the plural form of `reg-app-schema`,
   aimed at feature-modular apps (per Conventions §Feature-modularity
@@ -106,11 +105,6 @@
   Returns the vector of paths registered. See `re-frame.schemas/reg-app-schemas`
   for full semantics and the singular-form fallback when deterministic
   ordering matters."
-  ([path->schema] (reg-app-schemas path->schema {}))
-  ([path->schema opts]
-   (if-let [f (late-bind/get-fn :schemas/reg-app-schemas)]
-     (f path->schema opts)
-     (throw (ex-info ":rf.error/schemas-artefact-missing"
-                     {:where    'rf/reg-app-schemas
-                      :recovery :no-recovery
-                      :reason   "rf/reg-app-schemas requires day8/re-frame2-schemas on the classpath; add it to deps and require re-frame.schemas at app boot."})))))
+  {:hook :schemas/reg-app-schemas :artefact schemas-artefact :on-absent :throw}
+  ([path->schema]      [path->schema {}])
+  ([path->schema opts] :delegate))

--- a/implementation/core/src/re_frame/core_ssr.cljc
+++ b/implementation/core/src/re_frame/core_ssr.cljc
@@ -8,15 +8,25 @@
   consumers reach the surfaces through `re-frame.core` re-exports.
 
   Per-feature carve-out: the SSR artefact pulls the hiccup → HTML
-  emitter, the FNV-1a render-tree-hash machinery, the per-request
-  `[:rf/response]` accumulator, the six `:rf.server/*` fxs, the
-  `reg-error-projector` registry kind plus its default, the
-  `:rf/hydrate` event, and every `:rf.ssr/*` / `:rf.server/*` keyword
-  string — none of which appear on a consumer's classpath when this
-  wrapper's hooks are unregistered."
-  (:require [re-frame.late-bind :as late-bind]))
+  emitter, the FNV-1a render-tree-hash machinery, the per-request HTTP
+  response accumulator (a framework-private side-channel atom per
+  rf2-jbcmt), the six `:rf.server/*` fxs, the `reg-error-projector`
+  registry kind plus its default, the `:rf/hydrate` event, and every
+  `:rf.ssr/*` / `:rf.server/*` keyword string — none of which appear
+  on a consumer's classpath when this wrapper's hooks are unregistered.
 
-(defn render-to-string
+  Per rf2-h824v the wrappers below are emitted by the
+  `re-frame.core-artefact/defwrapper` factory from a declarative table —
+  one row per public surface."
+  (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
+                                        :cljs [:refer-macros [defwrapper]])]))
+
+(def ^:private ssr-artefact
+  {:error-keyword :rf.error/ssr-artefact-missing
+   :maven         "day8/re-frame2-ssr"
+   :require-ns    "re-frame.ssr"})
+
+(defwrapper render-to-string
   "Render a hiccup tree to an HTML string. Per Spec 011 §The render-tree
   → HTML emitter. Delegates to the installed substrate adapter's
   :render-to-string slot — for the plain-atom adapter (JVM/SSR) that
@@ -24,55 +34,39 @@
   reagent.dom.server. opts may carry :doctype? to prepend '<!DOCTYPE html>'
   and :emit-hash? to inject data-rf-render-hash on the root element.
   Late-bound via :ssr/render-to-string."
-  ([render-tree] (render-to-string render-tree {}))
-  ([render-tree opts]
-   (if-let [f (late-bind/get-fn :ssr/render-to-string)]
-     (f render-tree opts)
-     (throw (ex-info ":rf.error/ssr-artefact-missing"
-                     {:where    'rf/render-to-string
-                      :recovery :no-recovery
-                      :reason   "rf/render-to-string requires day8/re-frame2-ssr on the classpath; add it to deps and require re-frame.ssr at app boot."})))))
+  {:hook :ssr/render-to-string :artefact ssr-artefact :on-absent :throw}
+  ([render-tree]      [render-tree {}])
+  ([render-tree opts] :delegate))
 
-(defn render-tree-hash
+(defwrapper render-tree-hash
   "Stable structural hash of a render tree (FNV-1a 32-bit, lowercase
   hex). Identical output on JVM and CLJS for the same canonical-EDN
   representation. Per Spec 011 §Hydration-mismatch detection. Late-bound
   via :ssr/render-tree-hash."
-  [render-tree]
-  (if-let [f (late-bind/get-fn :ssr/render-tree-hash)]
-    (f render-tree)
-    (throw (ex-info ":rf.error/ssr-artefact-missing"
-                    {:where    'rf/render-tree-hash
-                     :recovery :no-recovery
-                     :reason   "rf/render-tree-hash requires day8/re-frame2-ssr on the classpath; add it to deps and require re-frame.ssr at app boot."}))))
+  {:hook :ssr/render-tree-hash :artefact ssr-artefact :on-absent :throw}
+  ([render-tree] :delegate))
 
-(defn -reg-error-projector
+;; -reg-error-projector / -reg-head carry an explicit `:where` because the
+;; wrapper-name leads with `-` (private-helper convention) but the user-
+;; facing surface drops it (`rf/reg-error-projector` / `rf/reg-head`); the
+;; defwrapper default would otherwise stamp the throw with the `-` form.
+
+(defwrapper -reg-error-projector
   "Internal helper — prefer `reg-error-projector` from public callers.
   This is the fn-form delegate the public macro / CLJS alias forward to.
   Late-bound via :ssr/reg-error-projector."
-  ([id projector-fn]
-   (-reg-error-projector id {} projector-fn))
-  ([id metadata projector-fn]
-   (if-let [f (late-bind/get-fn :ssr/reg-error-projector)]
-     (f id metadata projector-fn)
-     (throw (ex-info ":rf.error/ssr-artefact-missing"
-                     {:where    'rf/reg-error-projector
-                      :id       id
-                      :recovery :no-recovery
-                      :reason   "rf/reg-error-projector requires day8/re-frame2-ssr on the classpath; add it to deps and require re-frame.ssr at app boot."})))))
+  {:hook :ssr/reg-error-projector :where 'rf/reg-error-projector
+   :artefact ssr-artefact :on-absent :throw :ex-data {:id id}}
+  ([id projector-fn]          [id {} projector-fn])
+  ([id metadata projector-fn] :delegate))
 
-(defn project-error
+(defwrapper project-error
   "Apply the active error projector for frame-id to the trace event.
   Returns a :rf/public-error map. Per Spec 011 §Server error projection.
   Late-bound via :ssr/project-error."
-  [frame-id trace-event]
-  (if-let [f (late-bind/get-fn :ssr/project-error)]
-    (f frame-id trace-event)
-    (throw (ex-info ":rf.error/ssr-artefact-missing"
-                    {:where    'rf/project-error
-                     :frame    frame-id
-                     :recovery :no-recovery
-                     :reason   "rf/project-error requires day8/re-frame2-ssr on the classpath; add it to deps and require re-frame.ssr at app boot."}))))
+  {:hook :ssr/project-error :artefact ssr-artefact :on-absent :throw
+   :ex-data {:frame frame-id}}
+  ([frame-id trace-event] :delegate))
 
 ;; ---- Head/meta contract — rf2-4dra9 --------------------------------------
 ;;
@@ -82,22 +76,16 @@
 ;; don't pull `day8/re-frame2-ssr` see `:rf.error/ssr-artefact-missing`
 ;; when these surfaces are called.
 
-(defn -reg-head
+(defwrapper -reg-head
   "Internal helper — prefer `reg-head` from public callers. This is the
   fn-form delegate the public macro / CLJS alias forward to. Late-bound
   via :ssr/reg-head."
-  ([id head-fn]
-   (-reg-head id {} head-fn))
-  ([id metadata head-fn]
-   (if-let [f (late-bind/get-fn :ssr/reg-head)]
-     (f id metadata head-fn)
-     (throw (ex-info ":rf.error/ssr-artefact-missing"
-                     {:where    'rf/reg-head
-                      :id       id
-                      :recovery :no-recovery
-                      :reason   "rf/reg-head requires day8/re-frame2-ssr on the classpath; add it to deps and require re-frame.ssr at app boot."})))))
+  {:hook :ssr/reg-head :where 'rf/reg-head
+   :artefact ssr-artefact :on-absent :throw :ex-data {:id id}}
+  ([id head-fn]          [id {} head-fn])
+  ([id metadata head-fn] :delegate))
 
-(defn render-head
+(defwrapper render-head
   "Apply the head fn registered under `head-id` against a frame's
   app-db and active route. Returns the produced `:rf/head-model`. Per
   Spec 011 §Head/meta contract. Late-bound via :ssr/render-head.
@@ -106,16 +94,11 @@
 
     (render-head head-id frame-id)
     (render-head head-id {:frame frame-id :route route})"
-  [head-id opts]
-  (if-let [f (late-bind/get-fn :ssr/render-head)]
-    (f head-id opts)
-    (throw (ex-info ":rf.error/ssr-artefact-missing"
-                    {:where    'rf/render-head
-                     :head-id  head-id
-                     :recovery :no-recovery
-                     :reason   "rf/render-head requires day8/re-frame2-ssr on the classpath; add it to deps and require re-frame.ssr at app boot."}))))
+  {:hook :ssr/render-head :artefact ssr-artefact :on-absent :throw
+   :ex-data {:head-id head-id}}
+  ([head-id opts] :delegate))
 
-(defn active-head
+(defwrapper active-head
   "Look up the active route's `:head` metadata; if set, call
   `render-head` and return the model. Otherwise return the
   default head per Spec 011 §Default head. Late-bound via
@@ -125,33 +108,16 @@
 
     (active-head)            — uses the default frame `:rf/default`.
     (active-head frame-id)"
-  ([]
-   (if-let [f (late-bind/get-fn :ssr/active-head)]
-     (f)
-     (throw (ex-info ":rf.error/ssr-artefact-missing"
-                     {:where    'rf/active-head
-                      :recovery :no-recovery
-                      :reason   "rf/active-head requires day8/re-frame2-ssr on the classpath; add it to deps and require re-frame.ssr at app boot."}))))
-  ([frame-id]
-   (if-let [f (late-bind/get-fn :ssr/active-head)]
-     (f frame-id)
-     (throw (ex-info ":rf.error/ssr-artefact-missing"
-                     {:where    'rf/active-head
-                      :frame    frame-id
-                      :recovery :no-recovery
-                      :reason   "rf/active-head requires day8/re-frame2-ssr on the classpath; add it to deps and require re-frame.ssr at app boot."})))))
+  {:hook :ssr/active-head :artefact ssr-artefact :on-absent :throw
+   :ex-data {:frame frame-id}}
+  ([]         :delegate)
+  ([frame-id] :delegate))
 
-(defn head-model->html
+(defwrapper head-model->html
   "Render a `:rf/head-model` map to its inner-head HTML fragment in
   canonical order. Per Spec 011 §Default flow step 4. Late-bound via
   :ssr/head-model-html (the hook key drops the user-facing fn's
   `->` decoration for late-bind naming hygiene)."
-  ([head-model]
-   (head-model->html head-model {}))
-  ([head-model opts]
-   (if-let [f (late-bind/get-fn :ssr/head-model-html)]
-     (f head-model opts)
-     (throw (ex-info ":rf.error/ssr-artefact-missing"
-                     {:where    'rf/head-model->html
-                      :recovery :no-recovery
-                      :reason   "rf/head-model->html requires day8/re-frame2-ssr on the classpath; add it to deps and require re-frame.ssr at app boot."})))))
+  {:hook :ssr/head-model-html :artefact ssr-artefact :on-absent :throw}
+  ([head-model]      [head-model {}])
+  ([head-model opts] :delegate))

--- a/implementation/core/src/re_frame/late_bind.cljc
+++ b/implementation/core/src/re_frame/late_bind.cljc
@@ -67,3 +67,49 @@
   pattern is `(when-let [f (late-bind/get-fn ...)] (f args))`)."
   [hook-key]
   (get @hooks hook-key))
+
+(defn require-fn!
+  "Return the fn registered under `hook-key`, or throw a structured
+  `:rf.error/<artefact>-artefact-missing` ex-info when the hook is
+  unregistered.
+
+  The throw shape matches the documented missing-artefact contract used
+  by every `re-frame.core-<artefact>` wrapper (see rf2-5b6x — the
+  late-bind-missing test suite locks this shape across all six per-
+  feature splits):
+
+    Message:  `<error-keyword>` printed as a string (e.g.
+              \":rf.error/flows-artefact-missing\").
+    ex-data:  {:where    <where-sym>            ;; user-facing fn symbol
+               :recovery :no-recovery
+               :reason   \"<where-sym> requires <maven> on the classpath;
+                          add it to deps and require <require-ns> at app boot.\"
+               & extra}                          ;; per-call slots
+
+  Args:
+    hook-key      — the late-bind hook key (e.g. `:flows/reg-flow`).
+    where-sym     — the user-facing fn symbol stamped on the error
+                    (e.g. `'rf/reg-flow`) so greping for the symbol
+                    finds the call site in user code.
+    artefact-info — a map carrying the artefact's Maven coordinates and
+                    the producing ns name:
+                      {:error-keyword :rf.error/flows-artefact-missing
+                       :maven         \"day8/re-frame2-flows\"
+                       :require-ns    \"re-frame.flows\"}
+    extra-data    — (optional) per-call ex-data slots like `:flow-id` /
+                    `:path` / `:route-id` / `:machine-id` / `:frame`.
+
+  Pairs with the `re-frame.core-artefact/defwrapper` factory (rf2-h824v)
+  which drives 26+ call sites across seven `core_<artefact>.cljc`
+  wrappers from a declarative table."
+  ([hook-key where-sym artefact-info]
+   (require-fn! hook-key where-sym artefact-info nil))
+  ([hook-key where-sym {:keys [error-keyword maven require-ns]} extra-data]
+   (or (get @hooks hook-key)
+       (throw (ex-info (str error-keyword)
+                       (merge {:where    where-sym
+                               :recovery :no-recovery
+                               :reason   (str where-sym " requires " maven
+                                              " on the classpath; add it to deps and require "
+                                              require-ns " at app boot.")}
+                              extra-data))))))


### PR DESCRIPTION
## Summary

Per audit finding P0 #1 from rf2-spr6q (see `ai/findings/refactor-audit-core-2026-05-14.md`). The seven `core_<artefact>.cljc` wrappers (flows / http / machines / routing / schemas / ssr / epoch) shipped 26 structurally-identical `ex-info :rf.error/X-artefact-missing` literals — each spelling the same skeleton with one substitution. This PR replaces the boilerplate with a single declarative-table factory.

- **`re-frame.late-bind/require-fn!`** (rf2-uchhp / audit A5): centralises the missing-artefact throw shape — takes `hook-key` + `where-sym` + `artefact-info` + optional `extra-data` and either returns the registered fn or throws the documented structured ex-info.
- **`re-frame.core-artefact`** (new ns) ships **`defwrapper`** — a declarative-spec macro that emits a `defn` whose body delegates to the late-bind hook table. Each wrapper row is a `(name docstring spec & arity-forms)` shape. Arity bodies are `:delegate`, `:apply`, or a vector recursion-args form.
- Each `core_<artefact>.cljc` file rewritten as a ~5-row declarative table. Spec keys: `:hook`, `:on-absent` (`:throw` / `:nil` / `:false` / `:empty-vec` / `:empty-map` or any literal), `:ex-data` (auto-scoped per-arity by symbol filtering), `:artefact`, optional `:where` (defaults to `'rf/<name>`).
- `core_machines.cljc` keeps `reg-machine` / `reg-machine*` / `reg-machine-impl` bespoke (share `:where`-symbol parameter so each user-facing surface raises faithfully). Sugar fns (`dispatch-to-system`, `sub-machine`, `has-tag?`) stay as plain `defn` — they're not late-bind wrappers.

### LoC delta

| Surface                    | Before | After | Delta |
|----------------------------|--------|-------|-------|
| 7 wrapper files (sum)      |   653L |  569L |  -84L |
| `late_bind.cljc`           |    70L |  101L |  +31L |
| `core_artefact.cljc` (new) |     0L |  147L | +147L |
| **Total**                  |  723L  |  817L |  +94L |

Net **+94 LoC absolute** — the audit's -450L estimate was optimistic; preserving docstrings dominates. The structural win is: **26 ex-info literals → ONE template** inside `require-fn!`, and adding a new wrapper is now a one-row addition.

### Pre-alpha contract: zero behaviour change

The 11 documented test cases across the six per-artefact `late-bind-missing-test` suites (rf2-5b6x) lock the missing-artefact ex-info shape — `:where` / `:recovery` / `:reason` / `:flow-id` / `:path` / `:route-id` / `:machine-id` / `:frame` / `:id` slots all preserved byte-identical.

Pairs with **rf2-bd6zl** (defreg-macro for the 14 reg-* defmacros, already in `main`).

## Test plan

- [x] `npm run test:cljs` — 1795 tests / 4975 assertions pass
- [x] `clojure -M:test` in `implementation/core` — 440 / 2309 (one pre-existing schemas drift failure from rf2-dgug5 unrelated to this work)
- [x] per-artefact JVM tests (flows / routing / machines / schemas / ssr / http / epoch) all pass green
- [x] `npm run test:bundle-isolation` — pass
- [x] `npm run test:perf-bundle` — pass
- [x] `npm run test:elision` — pass