### PR TITLE
refactor(machines): unify destroy-cascade across 3 call-sites into teardown-actor helper (rf2-lha2t)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -21,55 +21,56 @@
   the declarative-`:invoke-all` exit-cascade form. The slot at
   `[:rf/spawned <parent-id> <invoke-id>]` holds a join-state map whose
   `:children` sub-map has every spawned child id. The handler iterates
-  `:children` and tears each one down, then clears the slot."
+  `:children` and tears each one down, then clears the slot.
+
+  Per rf2-lha2t the actor-teardown app-db dance lives in
+  `re-frame.machines.lifecycle-fx.teardown` — one helper, three (now
+  unified) call-sites."
   (:require [re-frame.frame :as frame]
             [re-frame.machines.lifecycle-fx.finalize :as finalize]
+            [re-frame.machines.lifecycle-fx.teardown :as teardown]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.trace :as trace]))
 
-(defn- find-system-id-for
-  "Walk the `:rf/system-ids` reverse index of `db` looking for the entry
-  whose value is `actor-id`. Returns the bound `:system-id` keyword or
-  nil."
-  [db actor-id]
-  (some (fn [[sid mid]]
-          (when (= mid actor-id) sid))
-        (get db :rf/system-ids)))
+(defn- emit-system-id-released!
+  "Per Spec 005 §Cancellation cascade D8 — fire the
+  `:rf.machine/system-id-released` trace when an actor's `:system-id`
+  binding was released as part of teardown. No-op when sid is nil."
+  [frame-id sid actor-id]
+  (when sid
+    (trace/emit! :machine :rf.machine/system-id-released
+                 {:frame      frame-id
+                  :system-id  sid
+                  :machine-id actor-id})))
 
 (defn- destroy-single-actor!
-  "Destroy a single spawned actor: dissoc the snapshot at
-  `[:rf/machines <id>]`, clear any `:system-id` binding pointing at it,
-  unregister the live event handler. Used by `destroy-machine-fx` for
-  the keyword-form legacy/imperative destroy AND iterated for each
-  child in an `:invoke-all` teardown.
+  "Destroy a single spawned actor against the frame's container: apply
+  the unified teardown projection (per
+  `re-frame.machines.lifecycle-fx.teardown`), abort in-flight
+  `:rf.http/managed` requests (rf2-wvkn), emit the
+  `:system-id-released` trace, and unregister the live event handler.
 
-  Per rf2-wvkn (Spec 005 §Cancellation cascade), also fires the
-  `:http/abort-on-actor-destroy` late-bind hook so any in-flight
-  `:rf.http/managed` requests the actor had issued are aborted."
+  Used by `destroy-machine-fx` for the keyword-form legacy/imperative
+  destroy AND iterated for each child in an `:invoke-all` teardown."
   [frame-id actor-id]
   (when actor-id
     (finalize/abort-actor-in-flight-http! actor-id)
     (when-let [container (frame/get-frame-db frame-id)]
-      (let [old-db       (adapter/read-container container)
-            released-sid (find-system-id-for old-db actor-id)
-            new-db       (cond-> old-db
-                           true         (update :rf/machines dissoc actor-id)
-                           released-sid (update :rf/system-ids dissoc released-sid))]
+      (let [old-db (adapter/read-container container)
+            [new-db released-sid] (teardown/teardown-actor
+                                    old-db {:actor-id actor-id})]
         (adapter/replace-container! container new-db)
-        (when released-sid
-          (trace/emit! :machine :rf.machine/system-id-released
-                       {:frame      frame-id
-                        :system-id  released-sid
-                        :machine-id actor-id}))
+        (emit-system-id-released! frame-id released-sid actor-id)
         (registrar/unregister! :event actor-id)
         released-sid))))
 
 (defn- destroy-invoke-all-children!
   "Per rf2-6vmw — the declarative-`:invoke-all` exit-cascade form.
   Resolves the children map from `[:rf/spawned parent-id invoke-id]`,
-  tears each child down via `destroy-single-actor!`, then prunes the
-  spawn registry slot under the lazy-allocation invariant."
+  tears each child down via `destroy-single-actor!`, then clears the
+  join-state slot via the unified teardown projection (slot-prune only:
+  nil actor-id)."
   [frame-id parent-id invoke-id]
   (let [join-state (when-let [container (frame/get-frame-db frame-id)]
                      (get-in (adapter/read-container container)
@@ -84,40 +85,31 @@
                     :child-id   child-id
                     :reason     :explicit})        ;; rf2-gn80 D6 — discriminator
       (destroy-single-actor! frame-id spawned-id))
-    ;; Clear the slot + lazy-allocation prune.
+    ;; Clear the join-state slot via the unified projection (slot-only).
     (when-let [container (frame/get-frame-db frame-id)]
       (let [old-db (adapter/read-container container)
-            new-db (cond-> old-db
-                     true (update-in [:rf/spawned parent-id]
-                                     dissoc invoke-id)
-                     (empty? (get-in old-db [:rf/spawned parent-id]))
-                     (update :rf/spawned dissoc parent-id))
-            new-db (cond-> new-db
-                     (empty? (get new-db :rf/spawned))
-                     (dissoc :rf/spawned))]
+            [new-db _] (teardown/teardown-actor
+                         old-db {:parent-id parent-id
+                                 :invoke-id invoke-id})]
         (adapter/replace-container! container new-db)))
     nil))
 
 (defn- destroy-single!
   "Per rf2-t07u — the keyword (legacy/imperative) form and the single-
   `:invoke` (tracked map) form of `:rf.machine/destroy`. Resolves the
-  actor-id (keyword direct OR via the `[:rf/spawned ...]` slot), tears
-  down its snapshot + system-id binding + handler, prunes the spawn
-  registry under the lazy-allocation invariant."
+  actor-id (keyword direct OR via the `[:rf/spawned ...]` slot), emits
+  the `:rf.machine/destroyed` trace, then applies the unified teardown
+  projection."
   [frame-id args]
   (let [tracked?  (map? args)
         parent-id (when tracked? (:rf/parent-id args))
         invoke-id (when tracked? (:rf/invoke-id args))
+        container (frame/get-frame-db frame-id)
+        old-db    (when container (adapter/read-container container))
         actor-id  (if tracked?
-                    (when-let [container (frame/get-frame-db frame-id)]
-                      (get-in (adapter/read-container container)
-                              [:rf/spawned parent-id invoke-id]))
+                    (when old-db (get-in old-db [:rf/spawned parent-id invoke-id]))
                     args)
-        released-sid
-        (when (and actor-id (frame/get-frame-db frame-id))
-          (find-system-id-for
-            (adapter/read-container (frame/get-frame-db frame-id))
-            actor-id))]
+        released-sid (teardown/find-system-id-for-actor old-db actor-id)]
     (trace/emit! :machine :rf.machine/destroyed
                  {:frame      frame-id
                   :actor-id   actor-id
@@ -130,28 +122,13 @@
     ;; destroy) or the spawn was suppressed (SSR / platform gating).
     (when actor-id
       (finalize/abort-actor-in-flight-http! actor-id)
-      (when-let [container (frame/get-frame-db frame-id)]
-        (let [old-db (adapter/read-container container)
-              new-db (cond-> old-db
-                       true          (update :rf/machines dissoc actor-id)
-                       released-sid  (update :rf/system-ids dissoc released-sid)
-                       tracked?      (update-in [:rf/spawned parent-id]
-                                                dissoc invoke-id))
-              ;; Tidy up the per-parent map if it just emptied — same
-              ;; lazy-allocation invariant as :rf/system-ids.
-              new-db (cond-> new-db
-                       (and tracked?
-                            (empty? (get-in new-db [:rf/spawned parent-id])))
-                       (update :rf/spawned dissoc parent-id))
-              new-db (cond-> new-db
-                       (and tracked? (empty? (get new-db :rf/spawned)))
-                       (dissoc :rf/spawned))]
+      (when container
+        (let [[new-db _] (teardown/teardown-actor
+                           old-db {:actor-id  actor-id
+                                   :parent-id parent-id
+                                   :invoke-id invoke-id})]
           (adapter/replace-container! container new-db)))
-      (when released-sid
-        (trace/emit! :machine :rf.machine/system-id-released
-                     {:frame      frame-id
-                      :system-id  released-sid
-                      :machine-id actor-id}))
+      (emit-system-id-released! frame-id released-sid actor-id)
       ;; Unregister the live handler. Last so any in-flight trace emit
       ;; against the actor still resolves before the slot disappears.
       (registrar/unregister! :event actor-id))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -27,8 +27,13 @@
 
   This namespace also owns `abort-actor-in-flight-http!` — the late-bind
   hook into the http-managed artefact (rf2-wvkn) — because both the
-  finalize cascade and the spawn-destroy teardowns invoke it."
+  finalize cascade and the spawn-destroy teardowns invoke it.
+
+  Per rf2-lha2t the actor-teardown app-db dance lives in
+  `re-frame.machines.lifecycle-fx.teardown` — one helper, three (now
+  unified) call-sites."
   (:require [re-frame.late-bind :as late-bind]
+            [re-frame.machines.lifecycle-fx.teardown :as teardown]
             [re-frame.machines.parallel :as parallel]
             [re-frame.machines.transition :as transition]
             [re-frame.registrar :as registrar]
@@ -173,13 +178,18 @@
               (assoc-in db (conj parent-path :data) new-parent-data)
               db))
           db)
-        ;; (4) Find the actor's `:system-id` binding (if any) BEFORE
-        ;; we mutate the reverse index — so we can release it after
-        ;; `:on-done` ran (D8) and emit the `:released` trace.
-        released-sid
-        (some (fn [[sid mid]]
-                (when (= mid machine-id) sid))
-              (get db-after-on-done :rf/system-ids))
+        ;; (4) Apply the unified teardown projection (per rf2-lha2t):
+        ;; dissoc the child's snapshot, release any `:system-id`
+        ;; reverse-index entry (D8 — after on-done ran), and clear the
+        ;; parent's `[:rf/spawned <parent-id> <invoke-id>]` slot with
+        ;; the lazy-allocation prune. Returns `[new-db released-sid]`;
+        ;; `released-sid` is resolved against db-after-on-done before
+        ;; the reverse index is mutated.
+        [db-after-destroy released-sid]
+        (teardown/teardown-actor db-after-on-done
+                                 {:actor-id  machine-id
+                                  :parent-id parent-id
+                                  :invoke-id invoke-id})
         ;; (5) Emit :rf.machine/destroyed with :reason :rf.machine/finished
         ;; (D6 enrichment) BEFORE the registrar unregister so any in-flight
         ;; trace consumers see the destroy signal while the handler still
@@ -190,32 +200,8 @@
                         :system-id  released-sid
                         :parent-id  parent-id
                         :invoke-id  invoke-id
-                        :reason     :rf.machine/finished})
-        ;; (6) Build the destroy-side db: dissoc the child's snapshot;
-        ;; clear the parent's [:rf/spawned <parent-id> <invoke-id>] slot
-        ;; (with lazy-allocation prune); clear [:rf/system-ids <sid>]
-        ;; (D8 — after on-done).
-        db-after-destroy
-        (cond-> db-after-on-done
-          true            (update :rf/machines dissoc machine-id)
-          released-sid    (update :rf/system-ids dissoc released-sid)
-          (and parent-id invoke-id)
-          (update-in [:rf/spawned parent-id] dissoc invoke-id)
-          (and parent-id invoke-id
-               (empty? (get-in db-after-on-done [:rf/spawned parent-id])))
-          (update :rf/spawned dissoc parent-id))
-        db-after-destroy
-        (cond-> db-after-destroy
-          (and parent-id invoke-id
-               (empty? (get db-after-destroy :rf/spawned)))
-          (dissoc :rf/spawned))
-        ;; Also clean up the :rf/system-ids slot if it just emptied.
-        db-after-destroy
-        (cond-> db-after-destroy
-          (and released-sid
-               (empty? (get db-after-destroy :rf/system-ids)))
-          (dissoc :rf/system-ids))]
-    ;; (7) Synchronous side effects: abort in-flight HTTP, emit
+                        :reason     :rf.machine/finished})]
+    ;; (6) Synchronous side effects: abort in-flight HTTP, emit
     ;; system-id-released trace (when applicable), unregister handler.
     (abort-actor-in-flight-http! machine-id)
     (when released-sid

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/teardown.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/teardown.cljc
@@ -1,0 +1,91 @@
+(ns re-frame.machines.lifecycle-fx.teardown
+  "Unified app-db teardown projection for spawned-actor destruction.
+
+  Per Spec 005 §Cancellation cascade — when a spawned actor is destroyed
+  (final-state auto-destroy, exit-cascade declarative-`:invoke` destroy,
+  iterated `:invoke-all` children-destroy, or keyword/imperative
+  destroy) the runtime applies a four-step app-db projection:
+
+    1. dissoc snapshot at `[:rf/machines actor-id]`
+    2. release `:rf/system-ids <sid>` reverse-index entry (if bound)
+    3. clear `[:rf/spawned parent-id invoke-id]` slot (declarative form)
+    4. prune the per-parent `[:rf/spawned parent-id]` map and the root
+       `:rf/spawned` slot if they just emptied (lazy-allocation
+       invariant: spawn ALLOCATES the maps lazily, so destroy mirrors
+       that by pruning when emptied — see Spec 005 §Spawning §Lazy
+       allocation).
+
+  `:rf/machines` and `:rf/system-ids` are NOT pruned when emptied: per
+  the `machine/destroy-machine-clears-system-id-index` conformance
+  fixture the runtime keeps those slots present-but-empty so callers
+  observing the app-db root see a stable shape.
+
+  Per audit rf2-ra1he §P0 #3 / §L2 / §L7 / §L8 / §L12 (rf2-lha2t): this
+  dance was previously inlined at three call-sites with subtle
+  order-of-operations divergence around the lazy-allocation prunes. The
+  unification lives here so contract changes (e.g. a `:rf/spawned` key
+  rename, an extra root to prune) touch one spot.
+
+  This namespace is PURE — it does not unregister handlers, abort
+  in-flight HTTP, or emit traces. Those are caller side effects whose
+  ordering relative to db mutation is contract (Spec 005 §Cancellation
+  cascade D6-D8: emit `:rf.machine/destroyed` BEFORE db mutation so
+  in-flight trace consumers see the destroy signal while the handler
+  still resolves; unregister the handler LAST).")
+
+(defn find-system-id-for-actor
+  "Walk the `:rf/system-ids` reverse index of `db` looking for the entry
+  whose value is `actor-id`. Returns the bound `:system-id` keyword or
+  nil. Cheap O(n) over the reverse index; n is typically <10."
+  [db actor-id]
+  (when actor-id
+    (some (fn [[sid mid]]
+            (when (= mid actor-id) sid))
+          (get db :rf/system-ids))))
+
+(defn teardown-actor
+  "Apply the unified app-db teardown projection to `db`. Returns a tuple
+  `[new-db released-sid]` where `released-sid` is the `:system-id`
+  keyword that was released (or nil — callers emit
+  `:rf.machine/system-id-released` against it when non-nil).
+
+  Args map:
+    :actor-id   — the spawned actor's event-handler key (nil ⇒ no
+                  snapshot or system-id-binding mutation, only
+                  spawn-slot prune)
+    :parent-id  — the spawning actor's id (declarative form only)
+    :invoke-id  — the absolute prefix-path the runtime stamped on the
+                  child at spawn time (declarative form only)
+
+  When `:parent-id` and `:invoke-id` are both supplied, the
+  `[:rf/spawned <parent-id> <invoke-id>]` slot is cleared and the
+  parent map / root are pruned under the lazy-allocation invariant
+  (matching how spawn ALLOCATES the maps lazily — see Spec 005
+  §Spawning §Lazy allocation). `:rf/machines` and `:rf/system-ids` are
+  NOT pruned when emptied (see ns docstring).
+
+  PURE: no trace emission, no handler unregistration, no HTTP abort —
+  those are caller side effects whose ordering relative to db mutation
+  is contract."
+  [db {:keys [actor-id parent-id invoke-id]}]
+  (let [released-sid (find-system-id-for-actor db actor-id)
+        track?       (and parent-id invoke-id)
+        ;; (1)+(2)+(3): the three primary slot mutations.
+        new-db       (cond-> db
+                       actor-id     (update :rf/machines dissoc actor-id)
+                       released-sid (update :rf/system-ids dissoc released-sid)
+                       track?       (update-in [:rf/spawned parent-id]
+                                                dissoc invoke-id))
+        ;; (4a): prune the per-parent :rf/spawned map if empty.
+        new-db       (cond-> new-db
+                       (and track?
+                            (empty? (get-in new-db [:rf/spawned parent-id])))
+                       (update :rf/spawned dissoc parent-id))
+        ;; (4b): prune the :rf/spawned root if empty (lazy-allocation
+        ;; mirror — :rf/machines and :rf/system-ids stay present per
+        ;; fixture contract).
+        new-db       (cond-> new-db
+                       (and (contains? new-db :rf/spawned)
+                            (empty? (get new-db :rf/spawned)))
+                       (dissoc :rf/spawned))]
+    [new-db released-sid]))


### PR DESCRIPTION
## Summary

Per audit [rf2-ra1he](../findings/machines-refactor-audit-2026-05-14.md) §P0 #3 / §L2 / §L7 / §L8 / §L12: the actor-teardown app-db dance was duplicated three times across `lifecycle_fx` with subtle order-of-operations divergence around the lazy-allocation prunes.

Extract a single `teardown-actor` helper into a new `re-frame.machines.lifecycle-fx.teardown` namespace. It returns `[new-db released-sid]` from a pure db value, and is consumed by all four destroy paths:

1. `finalize-machine` (final-state auto-destroy)
2. `destroy-single-actor!` (keyword/iterated destroy)
3. `destroy-single!` (declarative-`:invoke` / legacy destroy)
4. `destroy-invoke-all-children!` (`:invoke-all` join-slot prune — calls with nil actor-id for slot-only mutation)

Also extracted `find-system-id-for-actor` — the reverse-index lookup that appeared inlined three times — to the same namespace.

## Design notes

- The helper is **pure**: callers own trace emission, HTTP abort, and handler unregistration. Their ordering relative to db mutation is contract per Spec 005 §Cancellation cascade D6-D8: emit `:rf.machine/destroyed` BEFORE db mutation so in-flight trace consumers see the destroy signal; unregister the handler LAST.
- The new namespace has no app-db cycles with `finalize.cljc` (which `destroy.cljc` already requires for `abort-actor-in-flight-http!`).
- Pruning policy preserves the fixture-asserted invariant: `:rf/machines` and `:rf/system-ids` stay present-but-empty per the `machine/destroy-machine-clears-system-id-index` conformance fixture; only `:rf/spawned` is pruned to absent under the lazy-allocation rule (matching how spawn allocates the maps lazily).

## LoC delta

- `destroy.cljc`: 173 → 150 (-23)
- `finalize.cljc`: 228 → 214 (-14)
- `teardown.cljc`: +91 (new file; ~60 lines are docstring covering contract, ~30 lines code)
- Net: +54 LoC. The win is **single-source-of-truth on the teardown contract** — a future `:rf/spawned` key rename now touches one file, not three with risk of inconsistency.

## Unblocked by

- rf2-aa2rw (Result ADT — landed #846)
- rf2-3sbb6 (lifecycle_fx split — landed #834)

## Test plan

- [x] `clojure -M:test` from `implementation/machines/` — 119 tests / 332 assertions green
- [x] `npm run test:cljs` from `implementation/` — 1795 tests / 4975 assertions green (including all 111 conformance fixtures)
- [x] Spec 005 §Cancellation cascade D6-D8 ordering preserved: `:rf.machine/destroyed` emits before db mutation, `:system-id-released` emits after the reverse-index entry is gone, registrar unregistration happens last