### PR TITLE
fix(http): canned-stub fxs gated on debug-enabled? for prod elision (rf2-omsae)

### DIFF
--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -89,7 +89,7 @@
   (registrar/unregister!  :event :probe/inc)
   (registrar/clear-kind!  :sub))
 
-;; ---- Spec 014 :rf.http/managed surface (rf2-cfig) -------------------------
+;; ---- Spec 014 :rf.http/managed surface (rf2-cfig, rf2-omsae) --------------
 
 (defn ^:export touch-http-managed! []
   ;; Spec 014 — `:rf.http/managed` ships gated trace ops:
@@ -103,22 +103,34 @@
   ;; string sentinels (e.g. "rf.http/retry-attempt") should NOT appear
   ;; in the production bundle.
   ;;
+  ;; rf2-omsae — the canned-stub fxs (`:rf.http/managed-canned-success`,
+  ;; `:rf.http/managed-canned-failure`) are themselves registered inside
+  ;; the same `(when interop/debug-enabled? ...)` gate. Their fx-id
+  ;; keyword string fragments must NOT appear in the production bundle
+  ;; either. The probe must NOT reference those fx-ids as literal
+  ;; keywords in its own (non-gated) dispatch path — that would smuggle
+  ;; the literals into the prod bundle from probe code and the elision
+  ;; assertion would false-fail.
+  ;;
   ;; The probe roots the dependency graph by:
   ;;   1. requiring re-frame.http-managed (forces its ns body to be
   ;;      compiled into the bundle, which is where the gated branches
-  ;;      live);
-  ;;   2. referencing the public canned-stub fx via dispatch — pulls in
-  ;;      `dispatch-reply!`, `build-reply-event`, and the surrounding
-  ;;      retry / decode ctx so the gated emits sit in a reachable
+  ;;      AND the gated canned-stub fx registrations live);
+  ;;   2. touching `dispatch-reply!`, `build-reply-event`, and the
+  ;;      surrounding retry / decode ctx through the public `:rf.http/
+  ;;      managed-abort` fx (which is dev+prod) and the abort-on-actor-
+  ;;      destroy path so the gated trace emits sit in a reachable
   ;;      module graph (DCE only eliminates branches it can prove dead;
   ;;      reachability comes from the require + the dispatch path).
-  (rf/reg-event-fx :probe/http-touch
+  ;;
+  ;; The canned-stub fx-id keywords are NEVER referenced from probe code;
+  ;; their only source of reachability is the gated registration body in
+  ;; re-frame.http-managed itself, which is exactly what we want to
+  ;; assert lives only in the control bundle.
+  (rf/reg-event-fx :probe/http-abort-touch
     (fn [_ _]
-      {:fx [[:rf.http/managed-canned-success
-             {:request {:method :get :url "/probe"}
-              :on-success nil
-              :value   {:probed true}}]]}))
-  (rf/dispatch-sync [:probe/http-touch])
+      {:fx [[:rf.http/managed-abort :probe/never-issued-request]]}))
+  (rf/dispatch-sync [:probe/http-abort-touch])
   ;; Touch clear-all-in-flight! so the in-flight registry surface is
   ;; reachable; the probe doesn't actually issue a real request.
   (http-managed/clear-all-in-flight!)

--- a/implementation/http/src/re_frame/http_managed.cljc
+++ b/implementation/http/src/re_frame/http_managed.cljc
@@ -235,21 +235,18 @@
 
 ;; The two canned-stub fxs are gated on `interop/debug-enabled?` so they
 ;; elide in production. Per Spec 014 §Testing — "Don't ship the canned-
-;; stub fxs as production-eligible".
-#?(:clj  (when interop/debug-enabled?
-           (fx/reg-fx :rf.http/managed-canned-success
-                      {:doc "Spec 014 — synthesised success reply (test stub)."}
-                      machine-wrapper/canned-success-handler)
-           (fx/reg-fx :rf.http/managed-canned-failure
-                      {:doc "Spec 014 — synthesised failure reply (test stub)."}
-                      machine-wrapper/canned-failure-handler))
-   :cljs (do
-           (fx/reg-fx :rf.http/managed-canned-success
-                      {:doc "Spec 014 — synthesised success reply (test stub)."}
-                      machine-wrapper/canned-success-handler)
-           (fx/reg-fx :rf.http/managed-canned-failure
-                      {:doc "Spec 014 — synthesised failure reply (test stub)."}
-                      machine-wrapper/canned-failure-handler)))
+;; stub fxs as production-eligible". The gate applies on BOTH hosts: on
+;; JVM `debug-enabled?` is `true` so the registrations run; on CLJS the
+;; gate folds to `(when goog/DEBUG ...)` and `:advanced + goog.DEBUG=
+;; false` DCEs the entire body — fx-id keywords, doc string, handler
+;; var references and all (rf2-omsae).
+(when interop/debug-enabled?
+  (fx/reg-fx :rf.http/managed-canned-success
+             {:doc "Spec 014 — synthesised success reply (test stub)."}
+             machine-wrapper/canned-success-handler)
+  (fx/reg-fx :rf.http/managed-canned-failure
+             {:doc "Spec 014 — synthesised failure reply (test stub)."}
+             machine-wrapper/canned-failure-handler))
 
 ;; ---- with-managed-request-stubs (macro form) -----------------------------
 ;;

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -92,6 +92,21 @@ const DEV_ONLY_SENTINELS = [
   // fragment must elide in production.
   { source: 're-frame.http-managed/abort-on-actor-destroy (rf.http/aborted-on-actor-destroy)',
     sentinel: 'rf.http/aborted-on-actor-destroy' },
+  // re-frame.http-managed — :rf.http/managed-canned-success canned-stub
+  // fx (Spec 014 §Testing, rf2-omsae). The fx registration sits inside
+  // `(when interop/debug-enabled? ...)` so the fx-id keyword's string
+  // fragment, the doc string, and the handler-var reference must all
+  // elide in `:advanced + goog.DEBUG=false` bundles. The probe does NOT
+  // reference this fx-id as a literal keyword in its own code path —
+  // the gated registration body is the only source of reachability for
+  // the literal, which is what the elision assertion turns on.
+  { source: 're-frame.http-managed (rf.http/managed-canned-success registration)',
+    sentinel: 'rf.http/managed-canned-success' },
+  // re-frame.http-managed — :rf.http/managed-canned-failure canned-stub
+  // fx (Spec 014 §Testing, rf2-omsae). Same elision gate and same
+  // probe contract as `:rf.http/managed-canned-success` above.
+  { source: 're-frame.http-managed (rf.http/managed-canned-failure registration)',
+    sentinel: 'rf.http/managed-canned-failure' },
   // re-frame.epoch — :rf.epoch/snapshotted trace op (Tool-Pair §Time-
   // travel, Spec 009 §register-epoch-cb). Emitted by settle! after a
   // drain-settle commits a record. The whole settle! body sits inside


### PR DESCRIPTION
## Summary

- The two canned-stub fxs (`:rf.http/managed-canned-success` and `:rf.http/managed-canned-failure`) were registered under a reader-conditional that gated only the JVM branch on `interop/debug-enabled?` and shipped the CLJS branch UNCONDITIONALLY. Under `:advanced + goog.DEBUG=false` this leaked the fx-id keywords, the doc strings, and the handler-var references into production bundles — contradicting Spec 014 §Testing (`Don't ship the canned-stub fxs as production-eligible`) and the ns docstring's own claim that `the canned stub fxs gate on interop/debug-enabled? so they elide in production`.
- Collapse the reader-conditional to a single uniform `(when interop/debug-enabled? ...)`. On JVM `debug-enabled?` is `true` so the registrations run; on CLJS the gate folds to `(when goog/DEBUG ...)` and DCE under `:advanced + goog.DEBUG=false` eliminates the entire body.
- Lock the contract in with two new elision sentinels (`rf.http/managed-canned-success`, `rf.http/managed-canned-failure`) and rework the elision probe's `touch-http-managed!` to root the gated registration body's reachability through the public `:rf.http/managed-abort` fx (dev+prod) — without referencing the canned-stub fx-ids as literal keywords in probe code (which would smuggle the sentinels into the prod bundle and false-fail the assertion).

Audit finding from rf2-wui5v (refactor-audit-http-2026-05-14.md §P0 #3 / M2). Composes with rf2-921qy (transport collapse, #826) and rf2-622e3 (origin-event helper, #840) already landed.

## Test plan

- [x] `npm run test:elision` — both new sentinels pass on production (ABSENT) and control (PRESENT) bundles.
- [x] `cd implementation/http && clojure -M:test` — 134 tests / 369 assertions, 0 failures.
- [x] `npm run test:cljs` — 1795 tests / 4975 assertions, 0 failures.