### PR TITLE
refactor(machines): walk-path-leaf-to-root abstraction unifying 4 deepest-wins pickers (rf2-tjhhp)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -26,6 +26,7 @@
   routes every inbound event through it before the machine's normal `:on`
   lookup."
   (:require [re-frame.machines.parallel :as parallel]
+            [re-frame.machines.path-walk :as path-walk]
             [re-frame.machines.transition :as transition]
             [re-frame.trace :as trace]))
 
@@ -33,21 +34,19 @@
   "Helper for `find-active-invoke-all`. Given a machine-like map with
   `:states` (for a non-parallel machine, the machine itself; for a
   region of a parallel machine, the region body) and a path inside
-  that tree, walk leaf→root looking for an `:invoke-all`-bearing state
-  whose `:on-child-done` or `:on-child-error` matches inner-event-id."
+  that tree, walk leaf→root for an `:invoke-all`-bearing state whose
+  `:on-child-done` or `:on-child-error` matches inner-event-id (the
+  deepest-wins rule named in `path-walk/walk-path-leaf-to-root`)."
   [tree path inner-event-id]
-  (loop [i (dec (count path))]
-    (when (>= i 0)
-      (let [prefix (vec (take (inc i) path))
-            n      (transition/node-at tree prefix)
-            ia     (:invoke-all n)]
+  (path-walk/walk-path-leaf-to-root
+    tree path
+    (fn [prefix n]
+      (when-let [ia (:invoke-all n)]
         (cond
-          (and ia (= inner-event-id (:on-child-done ia)))
+          (= inner-event-id (:on-child-done ia))
           {:invoke-id prefix :spec ia :kind :done}
-          (and ia (= inner-event-id (:on-child-error ia)))
-          {:invoke-id prefix :spec ia :kind :failed}
-          :else
-          (recur (dec i)))))))
+          (= inner-event-id (:on-child-error ia))
+          {:invoke-id prefix :spec ia :kind :failed})))))
 
 (defn- find-active-invoke-all
   "Walk the snapshot's `:state` path leaf→root looking for an

--- a/implementation/machines/src/re_frame/machines/path_walk.cljc
+++ b/implementation/machines/src/re_frame/machines/path_walk.cljc
@@ -1,0 +1,103 @@
+(ns re-frame.machines.path-walk
+  "Deepest-wins path walking. Per Spec 005 §Transition resolution.
+
+  ## Why this namespace exists
+
+  The state-machine runtime's most important resolution rule is
+  **deepest-wins**: when an event arrives or an `:always` is evaluated
+  at some leaf, the runtime walks from the leaf toward the root, asking
+  each ancestor state-node along the way whether it declares a matching
+  transition. The first match wins; ancestors above that match never
+  see the event.
+
+  Spec 005 spells this rule out for `:on`, for `:always`, for `:after`,
+  and for `:invoke-all` join-event interception — four surfaces, one
+  rule. Before this namespace existed, the rule was implemented four
+  times across two files as the same `(loop [i (dec (count path))] ...
+  (recur (dec i)))` shape, each picker re-deriving the boundary
+  arithmetic and the prefix-construction by hand.
+
+  Naming the rule once, in one place, lets the pickers read as their
+  own intent: 'pick the deepest `:on` match', 'pick the deepest
+  `:always` whose guard passes', etc., delegating the walk mechanics
+  to `walk-path-leaf-to-root`. New pickers (e.g. per-state error
+  handlers, if ever added) inherit the rule for free.
+
+  ## Surface
+
+      (walk-path-leaf-to-root tree path predicate)
+
+  Walks `path` from leaf toward root. At each step, calls
+  `(predicate prefix node)` where `prefix` is the inclusive-prefix
+  vector (a `[:root :child :grandchild]`-shape path of length `i+1`,
+  starting at full `path` and shortening by one element per step) and
+  `node` is the state-node located at that prefix inside `tree`.
+  Returns the first non-`nil` result of `predicate`, or `nil` if no
+  level matched.
+
+  `tree` is anything carrying a `:states` map of nested state-nodes
+  — typically the runtime machine spec itself, or (for a parallel
+  parent) a region body. The internal descent matches
+  `transition/node-at`'s semantics exactly; this ns inlines the
+  descent to avoid a cycle (transition requires path-walk; path-walk
+  must not require transition).
+
+  The predicate's return value IS the caller's hit shape — typically a
+  map like `{:transition t :decl-path prefix}` — keeping the picker's
+  semantics out of this primitive.
+
+  ## Trace hook (future)
+
+  Per the rf2-tjhhp note: this primitive paves the way for a
+  `pick-trace` instrumentation that Causa wants — 'the runtime checked
+  these states in this order before settling on the deepest match'.
+  When that lands, the trace will hang off this single fn rather than
+  fan out across four pickers.
+
+  ## Why not also root→leaf?
+
+  The inverse direction (root→leaf descent to a known absolute path,
+  as in `find-invoke-spec-at`) is a different operation — it walks to
+  a known target rather than seeking a deepest match. Treating it as
+  the same primitive with a direction flag obscured the unifying rule
+  (deepest-wins isn't 'a walk'; it's 'a walk in a specific direction
+  with a specific tie-breaking semantics'). It lives in its own ns.")
+
+(defn- node-at*
+  "Local inline of `transition/node-at` to avoid a require cycle. Walk
+  `(:states tree)` down `path`, returning the leaf state-node or nil
+  if path doesn't resolve."
+  [tree path]
+  (loop [m (:states tree)
+         p path]
+    (cond
+      (empty? p) nil
+      :else
+      (let [n (get m (first p))]
+        (cond
+          (nil? n) nil
+          (= 1 (count p)) n
+          :else (recur (:states n) (rest p)))))))
+
+(defn walk-path-leaf-to-root
+  "Walk `path` leaf→root through `tree`'s `:states` map. For each
+  inclusive-prefix `[prefix node]` pair (deepest first), call
+  `(predicate prefix node)`. Return the FIRST non-`nil` predicate
+  result, or `nil` if every level returned `nil` (or had no node).
+
+  Per Spec 005 §Transition resolution — deepest-wins with parent
+  fallthrough. The named home for the rule in code.
+
+  `prefix` is the vector of path elements from `path[0]` through
+  `path[i]` inclusive, of length `i+1`. `node` is the state-node map
+  at that prefix; when the prefix doesn't resolve (defensive), the
+  predicate is skipped and the walk continues toward the root."
+  [tree path predicate]
+  (loop [i (dec (count path))]
+    (when (>= i 0)
+      (let [prefix (vec (take (inc i) path))
+            node   (node-at* tree prefix)
+            hit    (when node (predicate prefix node))]
+        (if (some? hit)
+          hit
+          (recur (dec i)))))))

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -19,6 +19,7 @@
   can be loaded and exercised on the JVM by the conformance fixtures
   (Spec 005 §Conformance fixtures)."
   (:require [clojure.set :as set]
+            [re-frame.machines.path-walk :as path-walk]
             [re-frame.machines.result :as result]
             [re-frame.trace :as trace]))
 
@@ -319,9 +320,10 @@
 (defn- pick-after-transition
   "Per Spec 005 §Delayed :after transitions. The synthetic event
   [:rf.machine.timer/after-elapsed delay-key carried-epoch] arrives.
-  Walk path leaf→root for an :after table containing delay-key. If the
-  carried epoch matches the snapshot's current :rf/after-epoch, evaluate
-  the transition's :guard (if any).
+  Walk path leaf→root for an :after table containing delay-key (the
+  deepest-wins rule named in `path-walk/walk-path-leaf-to-root`). If
+  the carried epoch matches the snapshot's current `:rf/after-epoch`,
+  evaluate the transition's :guard (if any).
 
   Returns one of:
     nil — no matching :after entry; benign (timer carried from a state
@@ -342,79 +344,76 @@
   (return nil); non-matching is surfaced as stale."
   [machine path event snapshot]
   (let [[_ delay-key carried-epoch] event
-        current-epoch (get-in snapshot (after-epoch-path machine))]
-    (loop [i (dec (count path))]
-      (if (neg? i)
-        (when (not= carried-epoch current-epoch)
-          {:stale?          true
-           :state           (last path)
-           :delay           delay-key
-           :scheduled-epoch carried-epoch
-           :current-epoch   current-epoch})
-        (let [prefix (vec (take (inc i) path))
-              n      (node-at machine prefix)
-              t      (get-in n [:after delay-key])]
-          (cond
-            (nil? t)
-            (recur (dec i))
-
-            (not= carried-epoch current-epoch)
-            {:stale?         true
-             :state          (last prefix)
-             :delay          delay-key
-             :scheduled-epoch carried-epoch
-             :current-epoch   current-epoch}
-
-            :else
-            (let [tspec (if (keyword? t) {:target t} t)
-                  guard-ref (:guard tspec)
-                  pass?
-                  (if guard-ref
-                    (let [g (resolve-guard machine guard-ref)]
-                      (boolean (call-guard g snapshot event)))
-                    true)]
-              (if pass?
-                {:transition tspec
-                 :decl-path  prefix
-                 :delay      delay-key
-                 :epoch      carried-epoch}
-                ;; Guard returned false. Per Spec 005 §Multi-stage
-                ;; interaction with :guard: the timer is "fired and
-                ;; discarded" — no transition, no epoch advance; sibling
-                ;; :after timers continue.
-                {:guard-suppressed? true
-                 :state             (last prefix)
-                 :delay             delay-key
-                 :epoch             carried-epoch}))))))))
+        current-epoch (get-in snapshot (after-epoch-path machine))
+        stale?        (not= carried-epoch current-epoch)
+        hit
+        (path-walk/walk-path-leaf-to-root
+          machine path
+          (fn [prefix n]
+            (when-let [t (get-in n [:after delay-key])]
+              (if stale?
+                {:stale?          true
+                 :state           (last prefix)
+                 :delay           delay-key
+                 :scheduled-epoch carried-epoch
+                 :current-epoch   current-epoch}
+                (let [tspec     (if (keyword? t) {:target t} t)
+                      guard-ref (:guard tspec)
+                      pass?     (if guard-ref
+                                  (let [g (resolve-guard machine guard-ref)]
+                                    (boolean (call-guard g snapshot event)))
+                                  true)]
+                  (if pass?
+                    {:transition tspec
+                     :decl-path  prefix
+                     :delay      delay-key
+                     :epoch      carried-epoch}
+                    ;; Guard returned false. Per Spec 005 §Multi-stage
+                    ;; interaction with :guard: the timer is "fired and
+                    ;; discarded" — no transition, no epoch advance;
+                    ;; sibling :after timers continue.
+                    {:guard-suppressed? true
+                     :state             (last prefix)
+                     :delay             delay-key
+                     :epoch             carried-epoch}))))))]
+    (cond
+      hit    hit
+      ;; No `:after` table matched along any level of the path. If the
+      ;; epoch is stale the timer carried in from a state we've since
+      ;; exited — surface it so the lifecycle can emit
+      ;; `:rf.machine.timer/stale-after`. (Matching epoch + no table is
+      ;; a benign no-op — return nil.)
+      stale? {:stale?          true
+              :state           (last path)
+              :delay           delay-key
+              :scheduled-epoch carried-epoch
+              :current-epoch   current-epoch}
+      :else  nil)))
 
 (defn- pick-transition
   "Walk path leaf→root looking for a transition that matches event-id and
   whose guard passes. Per Spec 005 §Transition resolution — deepest-wins
-  with parent fallthrough.
+  with parent fallthrough (the rule named in `path-walk/walk-path-leaf-
+  to-root`).
 
   Special-cases the synthetic :rf.machine.timer/after-elapsed event by
   delegating to pick-after-transition."
   [machine path event snapshot]
   (let [event-id (first event)]
-    (cond
-      (= :rf.machine.timer/after-elapsed event-id)
+    (if (= :rf.machine.timer/after-elapsed event-id)
       (pick-after-transition machine path event snapshot)
-
-      :else
-      (loop [i (dec (count path))]
-        (when (>= i 0)
-          (let [prefix (vec (take (inc i) path))
-                n      (node-at machine prefix)
-                cands  (normalise-on-clause
-                         (or (get-in n [:on event-id])
-                             (get-in n [:on :*])))
-                hit    (some (fn [t]
-                               (let [g (resolve-guard machine (:guard t))]
-                                 (when (call-guard g snapshot event) t)))
-                             cands)]
-            (if hit
-              {:transition hit :decl-path prefix}
-              (recur (dec i)))))))))
+      (path-walk/walk-path-leaf-to-root
+        machine path
+        (fn [prefix n]
+          (let [cands (normalise-on-clause
+                        (or (get-in n [:on event-id])
+                            (get-in n [:on :*])))
+                hit   (some (fn [t]
+                              (let [g (resolve-guard machine (:guard t))]
+                                (when (call-guard g snapshot event) t)))
+                            cands)]
+            (when hit
+              {:transition hit :decl-path prefix})))))))
 
 (defn- target-path
   "Compute the absolute target path for a transition. Per Spec 005:
@@ -930,26 +929,25 @@
             (result/ok snap-after-spawns all-fx)))))))
 
 (defn- pick-always-transition
-  "Per Spec 005 §Eventless :always transitions: walk path leaf→root
-  for an :always whose guard passes. Returns {:transition t :decl-path p}
-  or nil."
+  "Per Spec 005 §Eventless :always transitions: walk path leaf→root for
+  an `:always` whose guard passes (the deepest-wins rule named in
+  `path-walk/walk-path-leaf-to-root`). Returns
+  `{:transition t :decl-path p}` or nil."
   [machine path snapshot]
-  (loop [i (dec (count path))]
-    (when (>= i 0)
-      (let [prefix (vec (take (inc i) path))
-            n      (node-at machine prefix)
-            always (:always n)
+  (path-walk/walk-path-leaf-to-root
+    machine path
+    (fn [prefix n]
+      (let [always (:always n)
             always (cond
-                     (nil? always)     []
-                     (vector? always)  always
-                     :else             [always])
+                     (nil? always)    []
+                     (vector? always) always
+                     :else            [always])
             hit    (some (fn [t]
                            (let [g (resolve-guard machine (:guard t))]
                              (when (call-guard g snapshot nil) t)))
                          always)]
-        (if hit
-          {:transition (assoc hit :decl-path prefix) :decl-path prefix}
-          (recur (dec i)))))))
+        (when hit
+          {:transition (assoc hit :decl-path prefix) :decl-path prefix})))))
 
 (def ^:private always-depth-limit-default 16)
 (def ^:private raise-depth-limit-default  16)


### PR DESCRIPTION
## Summary

Names Spec 005's most important runtime invariant — the **deepest-wins resolution rule** — in code, in one place. Per findings rf2-ra1he §T5 (the audit's "strongest design-taste opinion" / "under-appreciated win").

Before: the same `(loop [i (dec (count path))] ... (recur (dec i)))` walk-leaf-to-root-for-first-match shape was implemented **four times** across two files, each picker re-deriving the boundary arithmetic by hand.

After: one named primitive — `re-frame.machines.path-walk/walk-path-leaf-to-root` — in its own namespace, with a docstring that names the rule and points back at Spec 005 §Transition resolution. The four pickers now read as their own intent and delegate the walk mechanics.

## Migrated pickers (all four)

- `transition/pick-after-transition` — :after table containing delay-key
- `transition/pick-transition` — :on event-id or :\*
- `transition/pick-always-transition` — :always whose guard passes
- `lifecycle_fx.join/find-active-invoke-all-in-tree` — :invoke-all matching :on-child-done / :on-child-error

## Wins beyond LoC

- **Names Spec 005's deepest-wins rule in code.** One place to look it up; one docstring carrying the why.
- **Disappears the `(dec i)` off-by-one bug class** — new pickers can no longer get the boundary wrong; they inherit it.
- **Paves the way for `pick-trace` instrumentation** Causa wants ("the runtime checked these states in this order before settling on the deepest match") — single fn to instrument, not four scattered loops.
- **New pickers inherit the rule for free** — e.g. per-state `:on-error` handlers, if ever added.

## Why not `find-invoke-spec-at`?

The bead called it out as a "Bonus 5th — inverse direction, but same primitive with a direction flag". On close reading it isn't a deepest-wins walk at all — it descends to a known absolute path and reads `:invoke`. Forcing it into the same primitive with a direction flag would obscure the unifying rule (deepest-wins is a leaf→root walk with a specific tie-breaking semantics, not "any directional walk"). Left in place; the trade-off is captured in the `path-walk` namespace docstring under "Why not also root→leaf?".

## Pre-alpha decision: NO require cycle

The new `path-walk` ns inlines a small local `node-at*` rather than requiring `transition` (which already requires `path-walk`). Two short loop/recurs in the codebase, one named `node-at` and one named `node-at*` — identical semantics — is the price of keeping `path-walk` a no-dep leaf module. Future refactor could move `node-at` into `path-walk` and have `transition` re-export, but that's churn well beyond this bead.

## LoC delta

- New `path_walk.cljc`: 103L (mostly docstring naming the rule)
- `transition.cljc`: 158 lines touched, net −3 LoC across 3 pickers
- `join.cljc`: 23 lines touched, net −8 LoC

Net delta excluding the new ns's docstring: ~−30 LoC across the four pickers, matching the bead's estimate.

## Test plan

- [x] `clojure -M:test` from `implementation/machines/` — 119 tests, 332 assertions, 0 failures, 0 errors
- [x] `npm run test:cljs` from `implementation/` — 1795 tests, 4975 assertions, 0 failures, 0 errors

## Discovered from

- rf2-ra1he §T5 — P1 audit: state-machine code review (the "strongest design-taste opinion")

## Sibling work (context)

- rf2-aa2rw (Result ADT) — landed in #846. The picker fns returning failure now use Result. Compatible.
- rf2-3sbb6 — lifecycle_fx.cljc split (post-split, `find-active-invoke-all-in-tree` lives in `lifecycle_fx/join.cljc`).
- rf2-lha2t — destroy-cascade unification. Disjoint surface.