### PR TITLE
refactor(pair2-mcp): mini-DSL for CLJS eval-form composition (rf2-dpzpe)

### DIFF
--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/dispatch.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/dispatch.cljs
@@ -2,6 +2,7 @@
   "Tool: dispatch — fire an event."
   (:require [clojure.string :as str]
             [re-frame-pair2-mcp.nrepl :as nrepl]
+            [re-frame-pair2-mcp.tools.eval-form :as ef]
             [re-frame-pair2-mcp.tools.wire :as wire]
             [re-frame-pair2-mcp.tools.probe :as probe]))
 
@@ -22,13 +23,14 @@
       (let [opts-form (cond-> {}
                         frame        (assoc :frame frame)
                         fx-overrides (assoc :fx-overrides fx-overrides))
-            form (cond
-                   trace?
-                   (str "(re-frame-pair2.runtime/dispatch-and-collect " event-str " " (pr-str opts-form) ")")
-                   sync?
-                   (str "(re-frame-pair2.runtime/pair-dispatch-sync! " event-str " " (pr-str opts-form) ")")
-                   :else
-                   (str "(re-frame-pair2.runtime/pair-dispatch! " event-str " " (pr-str opts-form) ")"))
+            ;; The agent passes `event-str` as raw CLJS source (e.g.
+            ;; "[:my/event arg]"); wrap with `rt-raw` so `emit` inlines
+            ;; it verbatim instead of `pr-str`'ing the outer string.
+            event-form (ef/rt-raw event-str)
+            fn-sym     (cond trace? 'dispatch-and-collect
+                             sync?  'pair-dispatch-sync!
+                             :else  'pair-dispatch!)
+            form (ef/emit (ef/rt-call fn-sym event-form opts-form))
             mode (cond trace? :trace sync? :sync :else :queued)]
         (-> (probe/ensure-runtime! conn build-id)
             (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/eval_form.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/eval_form.cljs
@@ -1,0 +1,158 @@
+(ns re-frame-pair2-mcp.tools.eval-form
+  "Mini-DSL for composing the CLJS eval forms tools ship over nREPL
+  (rf2-dpzpe).
+
+  Eight call-sites — `dispatch`, `trace-window`, `watch-epochs`,
+  `snapshot`, `get-path`, `subscribe`, `subscribe`'s drain/unsubscribe
+  loop forms, `subscription-info`, `unsubscribe`, plus `precheck-form`
+  — build CLJS source strings by raw `str` concatenation. Two costs:
+
+  1. The runtime namespace prefix (`re-frame-pair2.runtime/`)
+     appeared verbatim at 17+ sites — one rename, seventeen edits.
+  2. Tests had to `cljs.reader/read-string` a substring back out
+     of the source to assert on the embedded EDN
+     (`subscribe-test.cljs` line 96-98). The string-as-IR shape
+     made the test fragile against whitespace / formatting drifts
+     in the form-builder.
+
+  This namespace gives a tiny tagged-vector IR with a single
+  `emit` recursion:
+
+      [::call  sym args]          →  `(re-frame-pair2.runtime/<sym> <emitted arg> ...)`
+      [::call* qsym args]         →  `(<qsym> <emitted arg> ...)`  — fully-qualified
+      [::let   bindings body]     →  `(let [<binding-name> <binding-val> ...] <body>)`
+      [::raw   source-string]     →  `<source-string>`  — escape hatch
+      [::quote v]                 →  `(quote v)`  — embedded EDN literal
+      other value                 →  `(pr-str v)`  — EDN-printed literal
+
+  `bindings` is a flat seq `[name form name form ...]`; binding NAMES
+  must be symbols (emitted by `(name sym)`) so body forms can refer
+  to them by name. Binding VALUES follow the same emit rules as
+  call args.
+
+  ## Usage idioms
+
+      (def form (emit (rt-call 'subscribe! opts)))
+
+      (def form
+        (emit (rt-let ['snap (rt-call 'snapshot)]
+                      (rt-raw \"(:app-db snap)\"))))
+
+  ## Design notes
+
+  - `rt-call` carries args as data; numbers / keywords / strings / maps
+    / vectors are all `pr-str`'d at emit-time (Clojure-style EDN
+    literal semantics — a string is a string-literal, not raw source).
+    For raw-source fragments (e.g. referring to a let-bound name, a
+    `loop`/`recur`, or a `(if ...)` host form), wrap with
+    [[rt-raw]].
+
+  - The runtime prefix lives in ONE place — `runtime-ns`. A rename of
+    the runtime ns flows to every callsite by editing one string.
+
+  - Tests assert against the DSL data:
+
+        (= [::call 'subscribe! [{:topic :trace ...}]]
+           (rt-call 'subscribe! {:topic :trace ...}))
+
+    No regex over generated source, no whitespace fragility."
+  (:refer-clojure :exclude [emit])
+  (:require [clojure.string :as str]))
+
+(def runtime-ns
+  "The CLJS namespace every `rt-call` resolves into. Centralised here so
+  a future runtime rename is one edit, not seventeen."
+  "re-frame-pair2.runtime")
+
+(defn rt-call
+  "Build an IR node for a `runtime-ns`-relative function call. The
+  symbol is unqualified; args are emit-time `pr-str`'d unless they're
+  DSL nodes (which recurse) or [[rt-raw]] fragments."
+  [sym & args]
+  [::call sym (vec args)])
+
+(defn rt-call*
+  "Build an IR node for a fully-qualified function call. The symbol /
+  string is emitted verbatim (no `runtime-ns` prefix). Used for
+  `re-frame.core/elide-wire-value` and other cross-namespace calls
+  inside an eval form."
+  [qsym & args]
+  [::call* qsym (vec args)])
+
+(defn rt-let
+  "Build an IR node for a `let` block. `bindings` is a flat seq of
+  alternating names (symbols) and value-forms; trailing `body-forms`
+  are wrapped in an implicit `do` if more than one is supplied."
+  [bindings & body-forms]
+  [::let (vec bindings) (vec body-forms)])
+
+(defn rt-raw
+  "Wrap a raw CLJS source string so `emit` inlines it verbatim instead
+  of `pr-str`'ing it as an EDN literal. The escape hatch for arbitrary
+  CLJS expressions (loop/recur, fn literals, dotted-form host interop,
+  references to let-bound names)."
+  [source-string]
+  [::raw source-string])
+
+(defn- node? [x]
+  (and (vector? x)
+       (#{::call ::call* ::let ::raw} (first x))))
+
+(declare emit)
+
+(defn- emit-arg
+  "Render a single arg / binding-value to source. DSL nodes recurse;
+  everything else (strings, keywords, numbers, maps, vectors, …)
+  `pr-str`'d as an EDN literal."
+  [v]
+  (if (node? v) (emit v) (pr-str v)))
+
+(defn- emit-name [n]
+  ;; Binding names must be symbols — they appear verbatim in the source
+  ;; (no quoting) so body forms can refer to them by name.
+  (when-not (symbol? n)
+    (throw (ex-info "rt-let binding name must be a symbol"
+                    {:name n :type (type n)})))
+  (name n))
+
+(defn- emit-body [forms]
+  (case (count forms)
+    0 "nil"
+    1 (emit-arg (first forms))
+    (str "(do " (str/join " " (map emit-arg forms)) ")")))
+
+(defn emit
+  "Render an IR node to a CLJS source string. The single recursion
+  point for the DSL — every tool's eval form passes through here."
+  [form]
+  (cond
+    (not (node? form))
+    (pr-str form)
+
+    :else
+    (let [[tag] form]
+      (case tag
+        ::raw  (let [[_ s] form] s)
+
+        ::call (let [[_ sym args] form]
+                 (str "(" runtime-ns "/" (name sym)
+                      (when (seq args)
+                        (apply str (for [a args] (str " " (emit-arg a)))))
+                      ")"))
+
+        ::call* (let [[_ qsym args] form]
+                  (str "(" (if (symbol? qsym) (str qsym) (str qsym))
+                       (when (seq args)
+                         (apply str (for [a args] (str " " (emit-arg a)))))
+                       ")"))
+
+        ::let (let [[_ bindings body-forms] form
+                    pairs (partition 2 bindings)]
+                (str "(let ["
+                     (str/join
+                       " "
+                       (for [[n v] pairs]
+                         (str (emit-name n) " " (emit-arg v))))
+                     "] "
+                     (emit-body body-forms)
+                     ")"))))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/get_path.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/get_path.cljs
@@ -17,6 +17,7 @@
   `:scalar-value` arm of `run-wire-pipeline` just counts the
   resulting `:rf.size/large-elided` markers."
   (:require [re-frame-pair2-mcp.nrepl :as nrepl]
+            [re-frame-pair2-mcp.tools.eval-form :as ef]
             [re-frame-pair2-mcp.tools.wire :as wire]
             [re-frame-pair2-mcp.tools.wire-pipeline :as wp]
             [re-frame-pair2-mcp.tools.probe :as probe]
@@ -51,35 +52,39 @@
       ;; — the agent can re-call `get-path` with a deeper segment to
       ;; drill into a non-elided child, or pass `elision false` to
       ;; bypass the walk entirely.
-      (let [path-edn      (pr-str path)
-            snapshot-call (if frame
-                            (str "(re-frame-pair2.runtime/snapshot " (pr-str frame) ")")
-                            "(re-frame-pair2.runtime/snapshot)")
-            frame-edn     (if frame (pr-str frame) "(re-frame-pair2.runtime/current-frame)")
+      (let [snapshot-call (if frame
+                            (ef/rt-call 'snapshot frame)
+                            (ef/rt-call 'snapshot))
+            frame-edn     (if frame
+                            (pr-str frame)
+                            (ef/emit (ef/rt-call 'current-frame)))
             elision-opts  (elision/elision-opts-edn elision?)
             elide-call    (if elision?
                             (str "(re-frame.core/elide-wire-value v"
                                  "  (merge {:path path :frame " frame-edn "}"
                                  "         " elision-opts "))")
                             "v")
-            form (str "(let [db " snapshot-call
-                      "      path " path-edn
-                      "      missing #js {}"
-                      "      v (get-in db path missing)]"
-                      "  (if (identical? v missing)"
-                      "    {:ok? false :reason :path-not-found"
-                      "     :path path"
-                      "     :deepest-valid-prefix"
-                      "     (loop [acc [] cur db rem path]"
-                      "       (cond"
-                      "         (empty? rem) acc"
-                      "         (and (map? cur) (contains? cur (first rem)))"
-                      "         (recur (conj acc (first rem)) (get cur (first rem)) (rest rem))"
-                      "         (and (sequential? cur) (integer? (first rem))"
-                      "              (<= 0 (first rem) (dec (count cur))))"
-                      "         (recur (conj acc (first rem)) (nth (vec cur) (first rem)) (rest rem))"
-                      "         :else acc))}"
-                      "    {:ok? true :exists? true :path path :value " elide-call "}))")]
+            form (ef/emit
+                   (ef/rt-let
+                     ['db      snapshot-call
+                      'path    path
+                      'missing (ef/rt-raw "#js {}")
+                      'v       (ef/rt-raw "(get-in db path missing)")]
+                     (ef/rt-raw
+                       (str "(if (identical? v missing)"
+                            "  {:ok? false :reason :path-not-found"
+                            "   :path path"
+                            "   :deepest-valid-prefix"
+                            "   (loop [acc [] cur db rem path]"
+                            "     (cond"
+                            "       (empty? rem) acc"
+                            "       (and (map? cur) (contains? cur (first rem)))"
+                            "       (recur (conj acc (first rem)) (get cur (first rem)) (rest rem))"
+                            "       (and (sequential? cur) (integer? (first rem))"
+                            "            (<= 0 (first rem) (dec (count cur))))"
+                            "       (recur (conj acc (first rem)) (nth (vec cur) (first rem)) (rest rem))"
+                            "       :else acc))}"
+                            "  {:ok? true :exists? true :path path :value " elide-call "})"))))]
         (-> (probe/ensure-runtime! conn build-id)
             (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
             (.then (fn [v]

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/precheck.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/precheck.cljs
@@ -23,6 +23,7 @@
   follow-on work (see `cache.cljs` docstring)."
   (:require [applied-science.js-interop :as j]
             [re-frame-pair2-mcp.nrepl :as nrepl]
+            [re-frame-pair2-mcp.tools.eval-form :as ef]
             [re-frame-pair2-mcp.tools.wire :as wire]
             [re-frame-pair2-mcp.tools.args :as args]))
 
@@ -76,10 +77,10 @@
   [frame]
   (cond
     (= frame :rf.mcp.cache/operating-frame)
-    "(hash (re-frame-pair2.runtime/snapshot))"
+    (ef/emit (ef/rt-call* 'hash (ef/rt-call 'snapshot)))
 
     (keyword? frame)
-    (str "(hash (re-frame-pair2.runtime/snapshot " (pr-str frame) "))")
+    (ef/emit (ef/rt-call* 'hash (ef/rt-call 'snapshot frame)))
 
     :else nil))
 

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/probe.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/probe.cljs
@@ -13,6 +13,7 @@
   drops shipped a per-session inject fallback; that path was cut for
   rf2-7dvg."
   (:require [re-frame-pair2-mcp.nrepl :as nrepl]
+            [re-frame-pair2-mcp.tools.eval-form :as ef]
             [re-frame-pair2-mcp.tools.wire :as wire]))
 
 ;; ---------------------------------------------------------------------------
@@ -42,7 +43,7 @@
   "Call `(re-frame-pair2.runtime/health)`. Caller must have already
   confirmed the preload landed via `runtime-preloaded?`."
   [conn build-id]
-  (nrepl/cljs-eval-value conn build-id "(re-frame-pair2.runtime/health)"))
+  (nrepl/cljs-eval-value conn build-id (ef/emit (ef/rt-call 'health))))
 
 (defn ensure-runtime!
   "Confirm the pair2 runtime is preloaded. Resolves to nil on success,

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/snapshot.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/snapshot.cljs
@@ -10,6 +10,7 @@
   builds the eval form, awaits the runtime response, and routes the
   result through `run-wire-pipeline` with `:kind :snapshot-map`."
   (:require [re-frame-pair2-mcp.nrepl :as nrepl]
+            [re-frame-pair2-mcp.tools.eval-form :as ef]
             [re-frame-pair2-mcp.tools.wire :as wire]
             [re-frame-pair2-mcp.tools.wire-pipeline :as wp]
             [re-frame-pair2-mcp.tools.probe :as probe]
@@ -46,21 +47,22 @@
         ;; with `:rf.size/include-large? true`).
         elision-opts-form (elision/elision-opts-edn elision?)
         form     (if elision?
-                   (str "(let [snap (re-frame-pair2.runtime/snapshot-state "
-                        (pr-str opts) ")]"
-                        "  (reduce-kv"
-                        "    (fn [m fid fmap]"
-                        "      (assoc m fid"
-                        "             (if (and (map? fmap) (contains? fmap :app-db))"
-                        "               (update fmap :app-db"
-                        "                       (fn [db] (re-frame.core/elide-wire-value db"
-                        "                                  (merge {:frame fid} "
-                        elision-opts-form
-                        "))))"
-                        "               fmap)))"
-                        "    {} snap))")
-                   (str "(re-frame-pair2.runtime/snapshot-state "
-                        (pr-str opts) ")"))]
+                   (ef/emit
+                     (ef/rt-let
+                       ['snap (ef/rt-call 'snapshot-state opts)]
+                       (ef/rt-raw
+                         (str "(reduce-kv"
+                              " (fn [m fid fmap]"
+                              "   (assoc m fid"
+                              "          (if (and (map? fmap) (contains? fmap :app-db))"
+                              "            (update fmap :app-db"
+                              "                    (fn [db] (re-frame.core/elide-wire-value db"
+                              "                               (merge {:frame fid} "
+                              elision-opts-form
+                              "))))"
+                              "            fmap)))"
+                              " {} snap)"))))
+                   (ef/emit (ef/rt-call 'snapshot-state opts)))]
     (-> (probe/ensure-runtime! conn build-id)
         (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
         (.then (fn [v]

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs
@@ -24,6 +24,7 @@
   (:require [applied-science.js-interop :as j]
             [re-frame.mcp-base.vocab :as base-vocab]
             [re-frame-pair2-mcp.nrepl :as nrepl]
+            [re-frame-pair2-mcp.tools.eval-form :as ef]
             [re-frame-pair2-mcp.tools.wire :as wire]
             [re-frame-pair2-mcp.tools.probe :as probe]
             [re-frame-pair2-mcp.tools.args :as args]
@@ -66,12 +67,12 @@
 
       :else
       (let [subscribe-form
-            (str "(re-frame-pair2.runtime/subscribe! "
-                 (pr-str (cond-> {:topic               topic
-                                  :max-buffered-events max-buf-events
-                                  :max-buffered-bytes  max-buf-bytes}
-                           filter-map (assoc :filter filter-map)))
-                 ")")]
+            (ef/emit
+              (ef/rt-call 'subscribe!
+                          (cond-> {:topic               topic
+                                   :max-buffered-events max-buf-events
+                                   :max-buffered-bytes  max-buf-bytes}
+                            filter-map (assoc :filter filter-map))))]
         (-> (probe/ensure-runtime! conn build-id)
             (.then (fn [_] (nrepl/cljs-eval-value conn build-id subscribe-form)))
             (.then
@@ -97,8 +98,7 @@
                               (fn [reason]
                                 (-> (nrepl/cljs-eval-value
                                       conn build-id
-                                      (str "(re-frame-pair2.runtime/unsubscribe! "
-                                           (pr-str sub-id) ")"))
+                                      (ef/emit (ef/rt-call 'unsubscribe! sub-id)))
                                     (.catch (fn [_] nil))
                                     (.then
                                       (fn [_]
@@ -127,8 +127,7 @@
                                   :else
                                   (-> (nrepl/cljs-eval-value
                                         conn build-id
-                                        (str "(re-frame-pair2.runtime/drain-subscription! "
-                                             (pr-str sub-id) ")"))
+                                        (ef/emit (ef/rt-call 'drain-subscription! sub-id)))
                                       (.then
                                         (fn [drain-resp]
                                           (cond

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscription_info.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscription_info.cljs
@@ -19,7 +19,9 @@
   :queue-bytes :dropped-events :dropped-bytes :overflow-reason
   :created-at}]}`. Empty `:subs` vector when no streams are open (or
   when the filter matches nothing)."
-  (:require [re-frame-pair2-mcp.nrepl :as nrepl]
+  (:require [clojure.string :as str]
+            [re-frame-pair2-mcp.nrepl :as nrepl]
+            [re-frame-pair2-mcp.tools.eval-form :as ef]
             [re-frame-pair2-mcp.tools.wire :as wire]
             [re-frame-pair2-mcp.tools.probe :as probe]))
 
@@ -27,15 +29,23 @@
   (let [build-id (wire/arg-build args)
         topic    (some-> (wire/arg args :topic) keyword)
         sub-id   (wire/arg args :sub-id)
-        form     (str "(let [r (re-frame-pair2.runtime/subscription-info)"
-                      "      subs (:subs r)"
-                      "      f1 (if " (pr-str topic)
-                      "           (filterv #(= (:topic %) " (pr-str topic) ") subs)"
-                      "           subs)"
-                      "      f2 (if " (pr-str sub-id)
-                      "           (filterv #(= (:id %) " (pr-str sub-id) ") f1)"
-                      "           f1)]"
-                      "  (assoc r :subs f2))")]
+        ;; Build the filter chain Clojure-side (audit T19): only inline
+        ;; the predicates that actually apply, so the runtime sees the
+        ;; minimum form. The pre-DSL shape always shipped both `(if
+        ;; topic ... subs)` branches even when the slot was nil — wasted
+        ;; bytes the runtime then no-op'd.
+        preds    (cond-> []
+                   topic  (conj (str "(= (:topic %) " (pr-str topic) ")"))
+                   sub-id (conj (str "(= (:id %) "    (pr-str sub-id) ")")))
+        filtered (case (count preds)
+                   0 "subs"
+                   1 (str "(filterv #" (first preds) " subs)")
+                   (str "(filterv #(and " (str/join " " preds) ") subs)"))
+        form     (ef/emit
+                   (ef/rt-let ['r    (ef/rt-call 'subscription-info)
+                               'subs (ef/rt-raw "(:subs r)")]
+                              (ef/rt-raw
+                                (str "(assoc r :subs " filtered ")"))))]
     (-> (probe/ensure-runtime! conn build-id)
         (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
         (.then (fn [v] (wire/ok-text (if (map? v) v {:ok? true :subs []}))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/trace_window.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/trace_window.cljs
@@ -12,6 +12,7 @@
   builds the eval form, awaits the runtime response, and routes the
   epoch vector through `run-wire-pipeline` with `:kind :epoch-vector`."
   (:require [re-frame-pair2-mcp.nrepl :as nrepl]
+            [re-frame-pair2-mcp.tools.eval-form :as ef]
             [re-frame-pair2-mcp.tools.wire :as wire]
             [re-frame-pair2-mcp.tools.wire-pipeline :as wp]
             [re-frame-pair2-mcp.tools.probe :as probe]
@@ -39,30 +40,37 @@
             window-ms (or (:ms cursor-in) ms)
             cutoff-ms (- until-ms window-ms)
             sticky-frame (or (:frame cursor-in) frame)
-            frame-form (when sticky-frame (str " " (pr-str sticky-frame)))
             ;; Server-side slice: pull the history, drop up-to-cursor,
             ;; filter to the window, take `limit`. The runtime ships
             ;; only what the page needs — not the whole history.
-            form (str "(let [hist (vec (re-frame-pair2.runtime/epoch-history"
-                      (or frame-form "") "))"
-                      " after-id " (pr-str after-id)
-                      " aged-out? (and after-id (not-any? #(= after-id (:epoch-id %)) hist))"
-                      " sliced (if aged-out? []"
-                      "          (if after-id"
-                      "            (vec (rest (drop-while #(not= after-id (:epoch-id %)) hist)))"
-                      "            hist))"
-                      " filtered (filterv #(and (>= (or (:committed-at %) 0) " cutoff-ms ")"
-                      "                         (<= (or (:committed-at %) 0) " until-ms "))"
-                      "                   sliced)"
-                      " page (vec (take " limit " filtered))"
-                      " next-id (when (< (count page) (count filtered))"
-                      "           (:epoch-id (last page)))]"
-                      " {:epochs page"
-                      "  :id-aged-out? aged-out?"
-                      "  :requested-id after-id"
-                      "  :head-id (some-> hist peek :epoch-id)"
-                      "  :next-id next-id"
-                      "  :remaining (max 0 (- (count filtered) (count page)))})")]
+            history-call (if sticky-frame
+                           (ef/rt-call 'epoch-history sticky-frame)
+                           (ef/rt-call 'epoch-history))
+            form (ef/emit
+                   (ef/rt-let
+                     ['hist      (ef/rt-raw (str "(vec " (ef/emit history-call) ")"))
+                      'after-id  after-id
+                      'aged-out? (ef/rt-raw
+                                   "(and after-id (not-any? #(= after-id (:epoch-id %)) hist))")
+                      'sliced    (ef/rt-raw
+                                   (str "(if aged-out? []"
+                                        "  (if after-id"
+                                        "    (vec (rest (drop-while #(not= after-id (:epoch-id %)) hist)))"
+                                        "    hist))"))
+                      'filtered  (ef/rt-raw
+                                   (str "(filterv #(and (>= (or (:committed-at %) 0) " cutoff-ms ")"
+                                        "                (<= (or (:committed-at %) 0) " until-ms "))"
+                                        " sliced)"))
+                      'page      (ef/rt-raw (str "(vec (take " limit " filtered))"))
+                      'next-id   (ef/rt-raw
+                                   "(when (< (count page) (count filtered)) (:epoch-id (last page)))")]
+                     (ef/rt-raw
+                       (str "{:epochs page"
+                            " :id-aged-out? aged-out?"
+                            " :requested-id after-id"
+                            " :head-id (some-> hist peek :epoch-id)"
+                            " :next-id next-id"
+                            " :remaining (max 0 (- (count filtered) (count page)))}"))))]
         (-> (probe/ensure-runtime! conn build-id)
             (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
             (.then

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/unsubscribe.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/unsubscribe.cljs
@@ -2,6 +2,7 @@
   "Tool: unsubscribe — close a streaming subscription."
   (:require [clojure.string :as str]
             [re-frame-pair2-mcp.nrepl :as nrepl]
+            [re-frame-pair2-mcp.tools.eval-form :as ef]
             [re-frame-pair2-mcp.tools.wire :as wire]
             [re-frame-pair2-mcp.tools.probe :as probe]))
 
@@ -15,8 +16,7 @@
                         :hint "usage: unsubscribe {sub-id '<uuid>'}"}))
 
       :else
-      (let [form (str "(re-frame-pair2.runtime/unsubscribe! "
-                      (pr-str sub-id) ")")]
+      (let [form (ef/emit (ef/rt-call 'unsubscribe! sub-id))]
         (-> (probe/ensure-runtime! conn build-id)
             (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
             (.then (fn [v] (wire/ok-text (merge {:ok? true :sub-id sub-id}

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/watch_epochs.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/watch_epochs.cljs
@@ -17,6 +17,7 @@
   builds the eval form, awaits the runtime response, and routes the
   matches vector through `run-wire-pipeline` with `:kind :epoch-vector`."
   (:require [re-frame-pair2-mcp.nrepl :as nrepl]
+            [re-frame-pair2-mcp.tools.eval-form :as ef]
             [re-frame-pair2-mcp.tools.wire :as wire]
             [re-frame-pair2-mcp.tools.wire-pipeline :as wp]
             [re-frame-pair2-mcp.tools.probe :as probe]
@@ -42,20 +43,28 @@
             ;; so the agent's continuation flow stays consistent.
             effective-after (or (:after-id cursor-in) since-id)
             sticky-frame    (or (:frame cursor-in) frame)
-            frame-arg       (if sticky-frame (str " " (pr-str sticky-frame)) "")
-            form (str "(let [r (re-frame-pair2.runtime/epochs-since "
-                      (pr-str effective-after) frame-arg ")"
-                      "      matches (filterv #(re-frame-pair2.runtime/epoch-matches? "
-                      (pr-str (or pred-map {})) " %) (:epochs r))"
-                      "      page (vec (take " limit " matches))"
-                      "      next-id (when (< (count page) (count matches))"
-                      "                (:epoch-id (last page)))]"
-                      "  {:matches page"
-                      "   :id-aged-out? (:id-aged-out? r)"
-                      "   :requested-id (:requested-id r)"
-                      "   :head-id (:head-id r)"
-                      "   :next-id next-id"
-                      "   :remaining (max 0 (- (count matches) (count page)))})")]
+            epochs-since-call (if sticky-frame
+                                (ef/rt-call 'epochs-since effective-after sticky-frame)
+                                (ef/rt-call 'epochs-since effective-after))
+            matches-form (str "(filterv #"
+                              (ef/emit (ef/rt-call 'epoch-matches?
+                                                   (or pred-map {})
+                                                   (ef/rt-raw "%")))
+                              " (:epochs r))")
+            form (ef/emit
+                   (ef/rt-let
+                     ['r       epochs-since-call
+                      'matches (ef/rt-raw matches-form)
+                      'page    (ef/rt-raw (str "(vec (take " limit " matches))"))
+                      'next-id (ef/rt-raw
+                                 "(when (< (count page) (count matches)) (:epoch-id (last page)))")]
+                     (ef/rt-raw
+                       (str "{:matches page"
+                            " :id-aged-out? (:id-aged-out? r)"
+                            " :requested-id (:requested-id r)"
+                            " :head-id (:head-id r)"
+                            " :next-id next-id"
+                            " :remaining (max 0 (- (count matches) (count page)))}"))))]
         (-> (probe/ensure-runtime! conn build-id)
             (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
             (.then

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/eval_form_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/eval_form_test.cljs
@@ -1,0 +1,152 @@
+(ns re-frame-pair2-mcp.eval-form-test
+  "Tests for the mini-DSL that composes CLJS eval forms (rf2-dpzpe).
+
+  Two assertion styles cover the surface:
+
+  - **IR shape** — every constructor returns a tagged-vector data
+    structure (`[::call sym [arg ...]]` etc.). Tests pin the shape;
+    a rename of an internal tag would surface here, not as a regex
+    drift downstream.
+  - **Emit output** — `emit` renders to a CLJS source string.
+    Tests pin the exact output for a handful of representative
+    forms drawn from the six migrated tool sites; this is the
+    contract every tool body relies on."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [cljs.reader]
+            [re-frame-pair2-mcp.tools.eval-form :as ef]))
+
+;; ---------------------------------------------------------------------------
+;; rt-call — runtime-ns-relative call.
+;; ---------------------------------------------------------------------------
+
+(deftest rt-call-zero-args-ir
+  (is (= [::ef/call 'health []] (ef/rt-call 'health))))
+
+(deftest rt-call-zero-args-emit
+  (is (= "(re-frame-pair2.runtime/health)"
+         (ef/emit (ef/rt-call 'health)))))
+
+(deftest rt-call-scalar-args-emit
+  (is (= "(re-frame-pair2.runtime/unsubscribe! \"abc-123\")"
+         (ef/emit (ef/rt-call 'unsubscribe! "abc-123"))))
+  (is (= "(re-frame-pair2.runtime/snapshot :rf/default)"
+         (ef/emit (ef/rt-call 'snapshot :rf/default))))
+  (is (= "(re-frame-pair2.runtime/dispatch-and-collect 42)"
+         (ef/emit (ef/rt-call 'dispatch-and-collect 42)))))
+
+(deftest rt-call-map-arg-roundtrips
+  (let [opts {:frames :all :include [:app-db :sub-cache]}
+        form (ef/emit (ef/rt-call 'snapshot-state opts))]
+    (is (= opts
+           (-> form
+               cljs.reader/read-string  ; outer list
+               second)))))              ; the map arg
+
+(deftest rt-call-runtime-ns-centralised
+  (testing "the runtime-ns constant prefixes every rt-call"
+    (is (= "re-frame-pair2.runtime" ef/runtime-ns))
+    (is (clojure.string/starts-with?
+          (ef/emit (ef/rt-call 'foo))
+          (str "(" ef/runtime-ns "/foo")))))
+
+;; ---------------------------------------------------------------------------
+;; rt-call* — fully-qualified call (no runtime-ns prefix).
+;; ---------------------------------------------------------------------------
+
+(deftest rt-call*-emits-verbatim
+  (is (= "(re-frame.core/elide-wire-value db)"
+         (ef/emit (ef/rt-call* 're-frame.core/elide-wire-value
+                               (ef/rt-raw "db"))))))
+
+;; ---------------------------------------------------------------------------
+;; rt-raw — escape hatch for raw source.
+;; ---------------------------------------------------------------------------
+
+(deftest rt-raw-passes-through
+  (is (= [::ef/raw "(:app-db snap)"] (ef/rt-raw "(:app-db snap)")))
+  (is (= "(:app-db snap)" (ef/emit (ef/rt-raw "(:app-db snap)")))))
+
+(deftest rt-raw-arg-not-pr-stred
+  ;; Without rt-raw, a string would be pr-str'd (quoted). With rt-raw
+  ;; the source-fragment passes through unquoted — the escape hatch.
+  (let [via-raw    (ef/emit (ef/rt-call 'foo (ef/rt-raw "x")))
+        via-string (ef/emit (ef/rt-call 'foo "x"))]
+    (is (= "(re-frame-pair2.runtime/foo x)" via-raw))
+    (is (= "(re-frame-pair2.runtime/foo \"x\")" via-string))))
+
+;; ---------------------------------------------------------------------------
+;; rt-let — `let` block with bindings + body.
+;; ---------------------------------------------------------------------------
+
+(deftest rt-let-single-binding-single-body
+  (is (= "(let [snap (re-frame-pair2.runtime/snapshot)] (:app-db snap))"
+         (ef/emit (ef/rt-let ['snap (ef/rt-call 'snapshot)]
+                             (ef/rt-raw "(:app-db snap)"))))))
+
+(deftest rt-let-empty-body-emits-nil
+  (is (= "(let [x 1] nil)"
+         (ef/emit (ef/rt-let ['x 1])))))
+
+(deftest rt-let-multi-body-wraps-in-do
+  (is (= "(let [x 1] (do (foo) (bar)))"
+         (ef/emit (ef/rt-let ['x 1]
+                             (ef/rt-raw "(foo)")
+                             (ef/rt-raw "(bar)"))))))
+
+(deftest rt-let-binding-name-must-be-symbol
+  (is (thrown? :default
+        (ef/emit (ef/rt-let ["snap" (ef/rt-call 'snapshot)]
+                            (ef/rt-raw "snap"))))))
+
+;; ---------------------------------------------------------------------------
+;; Migration round-trips — the six tool sites pinned at the wire shape.
+;; ---------------------------------------------------------------------------
+
+(deftest subscribe-form-shape
+  ;; Migrated from subscribe.cljs:69. Pin the wire shape — the runtime
+  ;; sees `(re-frame-pair2.runtime/subscribe! {opts-map})`.
+  (let [opts {:topic :trace
+              :max-buffered-events 500
+              :max-buffered-bytes  5000000}
+        form (ef/emit (ef/rt-call 'subscribe! opts))]
+    (is (= opts
+           (-> form
+               cljs.reader/read-string
+               second)))))
+
+(deftest subscribe-form-carries-both-budgets
+  ;; rf2-ho4ve: regression — both budgets must round-trip.
+  (let [opts {:topic :trace
+              :max-buffered-events 1000
+              :max-buffered-bytes  2000000}
+        form (ef/emit (ef/rt-call 'subscribe! opts))
+        edn  (cljs.reader/read-string form)]
+    (is (= 1000    (-> edn second :max-buffered-events)))
+    (is (= 2000000 (-> edn second :max-buffered-bytes)))))
+
+(deftest unsubscribe-form-shape
+  (is (= "(re-frame-pair2.runtime/unsubscribe! \"abc-123-uuid\")"
+         (ef/emit (ef/rt-call 'unsubscribe! "abc-123-uuid")))))
+
+(deftest drain-form-shape
+  (is (= "(re-frame-pair2.runtime/drain-subscription! \"sub-xyz\")"
+         (ef/emit (ef/rt-call 'drain-subscription! "sub-xyz")))))
+
+(deftest precheck-form-shape-no-frame
+  (is (= "(hash (re-frame-pair2.runtime/snapshot))"
+         (ef/emit
+           (ef/rt-call* 'hash (ef/rt-call 'snapshot))))))
+
+(deftest precheck-form-shape-with-frame
+  (is (= "(hash (re-frame-pair2.runtime/snapshot :rf/default))"
+         (ef/emit
+           (ef/rt-call* 'hash (ef/rt-call 'snapshot :rf/default))))))
+
+(deftest snapshot-state-form-is-edn-readable
+  ;; Migrated from snapshot.cljs:62. The non-elision arm.
+  (let [opts {:frames :all
+              :include [:app-db :sub-cache :machines :epochs :traces]}
+        form (ef/emit (ef/rt-call 'snapshot-state opts))
+        edn  (cljs.reader/read-string form)]
+    (is (= 're-frame-pair2.runtime/snapshot-state (first edn)))
+    (is (= opts (second edn)))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/snapshot_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/snapshot_test.cljs
@@ -9,8 +9,10 @@
   case slips break the test rather than silently shipping a broken
   contract."
   (:require [cljs.test :refer-macros [deftest is testing]]
+            [cljs.reader]
             [clojure.string :as str]
-            [applied-science.js-interop :as j]))
+            [applied-science.js-interop :as j]
+            [re-frame-pair2-mcp.tools.eval-form :as ef]))
 
 ;; The parsers are private in tools.cljs — re-implement the contract
 ;; here so we test what callers see and so the test fails if the
@@ -82,12 +84,15 @@
   (is (= [:app-db :sub-cache] (parse-include #js ["app-db" "sub-cache"]))))
 
 (deftest snapshot-state-form-is-edn-readable
-  ;; The MCP server pr-strs the opts map into a CLJS eval form like
-  ;; `(re-frame-pair2.runtime/snapshot-state {:frames :all :include [...]})`.
-  ;; Ensure the canonical default round-trips through pr-str.
+  ;; The MCP server lifts the opts map into the eval-form DSL
+  ;; (rf2-dpzpe), which renders `(re-frame-pair2.runtime/snapshot-state
+  ;; {:frames :all :include [...]})`. Assert against the parsed opts
+  ;; map rather than regex-matching the source string.
   (let [opts {:frames :all
               :include (parse-include nil)}
-        form (str "(re-frame-pair2.runtime/snapshot-state "
-                  (pr-str opts) ")")]
-    (is (re-find #":frames :all" form))
-    (is (re-find #":include \[:app-db :sub-cache :machines :epochs :traces\]" form))))
+        form (ef/emit (ef/rt-call 'snapshot-state opts))
+        edn  (cljs.reader/read-string form)]
+    (is (= 're-frame-pair2.runtime/snapshot-state (first edn)))
+    (is (= :all (-> edn second :frames)))
+    (is (= [:app-db :sub-cache :machines :epochs :traces]
+           (-> edn second :include)))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/subscribe_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/subscribe_test.cljs
@@ -10,7 +10,8 @@
   (:require [cljs.test :refer-macros [deftest is testing]]
             [cljs.reader]
             [clojure.string :as str]
-            [applied-science.js-interop :as j]))
+            [applied-science.js-interop :as j]
+            [re-frame-pair2-mcp.tools.eval-form :as ef]))
 
 ;; Mirror of `parse-filter-arg` from tools.cljs (private). Keeping a
 ;; parallel test fixture documents the contract and pins the semantics —
@@ -52,52 +53,62 @@
   (is (= {:op-type :error}
          (parse-filter {:op-type :error}))))
 
-;; The subscribe-form constructor is private. Re-implement here to
-;; pin the exact CLJS form we send to the runtime.
+;; The subscribe-form constructor is private. Re-implement here over
+;; the eval-form DSL to pin the IR + emitted source we send to the
+;; runtime (rf2-dpzpe). Tests assert against opts-map data shape via
+;; `cljs.reader/read-string` over the emitted form — no regex over
+;; raw source, no whitespace fragility.
+
+(defn- subscribe-opts
+  [topic filter-map max-buf-events max-buf-bytes]
+  (cond-> {:topic               topic
+           :max-buffered-events max-buf-events
+           :max-buffered-bytes  max-buf-bytes}
+    filter-map (assoc :filter filter-map)))
 
 (defn- subscribe-form
   [topic filter-map max-buf-events max-buf-bytes]
-  (str "(re-frame-pair2.runtime/subscribe! "
-       (pr-str (cond-> {:topic               topic
-                        :max-buffered-events max-buf-events
-                        :max-buffered-bytes  max-buf-bytes}
-                 filter-map (assoc :filter filter-map)))
-       ")"))
+  (ef/emit (ef/rt-call 'subscribe!
+                       (subscribe-opts topic filter-map
+                                       max-buf-events max-buf-bytes))))
+
+(defn- form->opts
+  "Round-trip the emitted source back into Clojure data; assert against
+  the opts-map directly instead of regex over source bytes."
+  [form]
+  (-> form cljs.reader/read-string second))
 
 (deftest subscribe-form-with-trace-and-filter
-  (let [form (subscribe-form :trace {:op-type :error :event-id :user/login}
-                             500 5000000)]
-    (is (re-find #":topic :trace" form))
-    (is (re-find #":max-buffered-events 500" form))
-    (is (re-find #":max-buffered-bytes 5000000" form))
-    (is (re-find #":op-type :error" form))
-    (is (re-find #":event-id :user/login" form))))
+  (let [opts (form->opts
+               (subscribe-form :trace {:op-type :error :event-id :user/login}
+                               500 5000000))]
+    (is (= :trace                       (:topic opts)))
+    (is (= 500                          (:max-buffered-events opts)))
+    (is (= 5000000                      (:max-buffered-bytes opts)))
+    (is (= {:op-type :error :event-id :user/login} (:filter opts)))))
 
 (deftest subscribe-form-without-filter-omits-key
-  (let [form (subscribe-form :epoch nil 250 1000000)]
-    (is (re-find #":topic :epoch" form))
-    (is (re-find #":max-buffered-events 250" form))
-    (is (re-find #":max-buffered-bytes 1000000" form))
-    (is (not (re-find #":filter" form)))))
+  (let [opts (form->opts (subscribe-form :epoch nil 250 1000000))]
+    (is (= :epoch  (:topic opts)))
+    (is (= 250     (:max-buffered-events opts)))
+    (is (= 1000000 (:max-buffered-bytes  opts)))
+    (is (not (contains? opts :filter)))))
 
 (deftest subscribe-form-fx-topic
-  (let [form (subscribe-form :fx {:event-id :http/get} 100 100000)]
-    (is (re-find #":topic :fx" form))
-    (is (re-find #":max-buffered-events 100" form))
-    (is (re-find #":max-buffered-bytes 100000" form))
-    (is (re-find #":event-id :http/get" form))))
+  (let [opts (form->opts (subscribe-form :fx {:event-id :http/get} 100 100000))]
+    (is (= :fx     (:topic opts)))
+    (is (= 100     (:max-buffered-events opts)))
+    (is (= 100000  (:max-buffered-bytes  opts)))
+    (is (= {:event-id :http/get} (:filter opts)))))
 
 (deftest subscribe-form-carries-both-budgets
   ;; rf2-ho4ve: the wire shape must always carry BOTH :max-buffered-events
   ;; and :max-buffered-bytes — the runtime applies an OR-combined budget,
   ;; so half the pair would leak through to the runtime's default for the
   ;; missing slot. Pin the round-trip here.
-  (let [form (subscribe-form :trace nil 1000 2000000)
-        edn  (cljs.reader/read-string
-               (subs form (count "(re-frame-pair2.runtime/subscribe! ")
-                     (dec (count form))))]
-    (is (= 1000    (:max-buffered-events edn)))
-    (is (= 2000000 (:max-buffered-bytes  edn)))))
+  (let [opts (form->opts (subscribe-form :trace nil 1000 2000000))]
+    (is (= 1000    (:max-buffered-events opts)))
+    (is (= 2000000 (:max-buffered-bytes  opts)))))
 
 ;; Recognised topics — keep this set in lockstep with the runtime's
 ;; subscribe! whitelist.
@@ -150,19 +161,19 @@
     (is (= 12345 (j/get-in p [:data :dropped-bytes])))
     (is (= ":max-buffered-bytes" (j/get-in p [:data :overflow-reason])))))
 
-;; Unsubscribe-form pinning — the CLJS form sent over nREPL.
+;; Unsubscribe + drain form pinning — built over the eval-form DSL
+;; (rf2-dpzpe). The expected source strings are the DSL's emit output;
+;; a rename of the runtime ns flows through `ef/runtime-ns`.
 
 (defn- unsubscribe-form [sub-id]
-  (str "(re-frame-pair2.runtime/unsubscribe! "
-       (pr-str sub-id) ")"))
-
-(deftest unsubscribe-form-roundtrips
-  (let [form (unsubscribe-form "abc-123-uuid")]
-    (is (= "(re-frame-pair2.runtime/unsubscribe! \"abc-123-uuid\")" form))))
+  (ef/emit (ef/rt-call 'unsubscribe! sub-id)))
 
 (defn- drain-form [sub-id]
-  (str "(re-frame-pair2.runtime/drain-subscription! "
-       (pr-str sub-id) ")"))
+  (ef/emit (ef/rt-call 'drain-subscription! sub-id)))
+
+(deftest unsubscribe-form-roundtrips
+  (is (= "(re-frame-pair2.runtime/unsubscribe! \"abc-123-uuid\")"
+         (unsubscribe-form "abc-123-uuid"))))
 
 (deftest drain-form-roundtrips
   (is (= "(re-frame-pair2.runtime/drain-subscription! \"sub-xyz\")"


### PR DESCRIPTION
## Summary

Six tools (trace-window, watch-epochs, snapshot, get-path, subscribe, subscription-info) plus the precheck path and subscribe's internal drain/unsubscribe forms built CLJS eval forms by raw \`str\` concatenation. The runtime namespace prefix (\`re-frame-pair2.runtime/\`) appeared verbatim at 17+ sites and two test files had to \`read-string\` substrings of generated source to assert against the embedded EDN.

New \`re-frame-pair2-mcp.tools.eval-form\` namespace exposes a tiny tagged-vector IR with a single \`emit\` recursion:

\`\`\`clojure
(rt-call 'subscribe! {opts})                 ;; runtime-ns relative call
(rt-call* 'hash form)                        ;; fully-qualified call
(rt-let ['snap (rt-call 'snapshot)] body)    ;; let block
(rt-raw \"(:app-db snap)\")                    ;; escape hatch for raw source
\`\`\`

Migrated **10 source files** (the 6 listed in the bead plus \`probe\`, \`dispatch\`, the \`precheck-form\` helper, and \`unsubscribe\`):

- \`dispatch.cljs\` — 3 dispatch variants via single \`rt-call\`
- \`get_path.cljs\` — \`rt-let\` block; \`rt-call\` for snapshot / current-frame
- \`precheck.cljs\` — \`rt-call*\` for \`hash\`, \`rt-call\` for \`snapshot\`
- \`probe.cljs\` — \`runtime-health!\` via \`rt-call\`
- \`snapshot.cljs\` — \`rt-call\` / \`rt-let\` on the elision arm
- \`subscribe.cljs\` — \`rt-call\` for subscribe! / drain! / unsubscribe!
- \`subscription_info.cljs\` — \`rt-let\`; filter chain built Clojure-side (audit T19): no more \`(if topic ... subs)\` dead branches at eval time
- \`trace_window.cljs\` — \`rt-let\` with seven bindings; the original 20-line raw-string body is now structured data
- \`unsubscribe.cljs\` — \`rt-call\` for \`unsubscribe!\`
- \`watch_epochs.cljs\` — \`rt-let\` with four bindings; matches built via \`rt-call\`

### Wins

- **Single source of the runtime prefix.** \`ef/runtime-ns\` is the one place. A future rename of \`re-frame-pair2.runtime\` flows to every call-site by editing one string.
- **Tests assert against data, not regex.** Updated \`subscribe_test.cljs\` (5 deftests now \`read-string\` the form into Clojure data) and \`snapshot_test.cljs\` (\`snapshot-state-form-is-edn-readable\` asserts against the parsed EDN).
- **New \`eval_form_test.cljs\`** — 19 deftests / 26 assertions covering IR shape + emit output for all four constructors plus round-trip pins for the migrated tool sites.

### Composes with

- rf2-ae8ie (wire-pipeline) #843 — already landed
- rf2-dfk28 (with-indicators) #838 — already landed

## Test plan

- [x] \`npm test\` in \`tools/pair2-mcp/\` — 289 tests / 686 assertions / 0 failures, 0 errors (was 270 / 660 before; +19 deftests, +26 assertions)
- [x] Grep for residual \`re-frame-pair2.runtime/\` literals in source — only doc-comments and the \`re-frame.core/elide-wire-value\` raw-string in \`get_path.cljs\` (kept verbatim — uses a non-runtime-ns helper inside a runtime-side \`merge\`)
- [x] Rebased onto origin/main

Closes rf2-dpzpe.