### PR TITLE
fix(ssr-ring): destructure :ssr opt to match documented name (rf2-8cx3y)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -435,7 +435,7 @@
                              :root-view [:app/root]
                              :html-shell ssr-ring-app/shell}))
     (jetty/run-jetty handler {:port 3000 :join? false})"
-  [{:keys [on-create root-view fx-overrides ssr-config emit-hash?
+  [{:keys [on-create root-view fx-overrides ssr emit-hash?
            version schema-digest payload-keys html-shell content-type
            on-error]
     :or   {emit-hash?    true
@@ -470,7 +470,7 @@
                        :platform  :server
                        :on-create (on-create-with-request on-create request)}
                 fx-overrides (assoc :fx-overrides fx-overrides)
-                ssr-config   (assoc :ssr           ssr-config)))
+                ssr          (assoc :ssr           ssr)))
             (catch Throwable t
               ;; reg-frame threw mid-drain. The frame may be registered
               ;; in the `frames` atom (see frame.cljc — `swap! frames`

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -359,6 +359,41 @@
             "each request's handler saw its own URI — no slot bleed")))))
 
 ;; ===========================================================================
+;; ssr-handler — :ssr opt reaches the per-request frame's :ssr metadata
+;;
+;; Regression (rf2-8cx3y): the docstring documented `:ssr` but the
+;; destructure read `:ssr-config`, so any caller passing
+;; `{:ssr {:dev-error-detail? true ...}}` had it silently dropped —
+;; `cond->` never asserted the key onto the per-request frame config,
+;; and the default projector ran regardless of the caller's intent.
+;; Pre-alpha: no back-compat — `:ssr` is now the canonical name and
+;; matches both `rf/make-frame`'s frame-config key and Spec 011.
+;; ===========================================================================
+
+(deftest handler-passes-through-ssr-opt-to-frame-meta
+  (testing ":ssr opt → per-request frame's :ssr metadata (rf2-8cx3y)"
+    (let [captured (atom :unset)]
+      (rf/reg-event-fx :init/capture-ssr-meta
+        {:platforms #{:server}}
+        (fn [{:keys [frame]} _]
+          (reset! captured (:ssr (rf/frame-meta frame)))
+          {}))
+
+      (rf/reg-view* :pages/blank-for-ssr-opt (fn [] [:div]))
+
+      (let [handler (ssr-ring/ssr-handler
+                      {:on-create [:init/capture-ssr-meta]
+                       :root-view [:pages/blank-for-ssr-opt]
+                       :ssr       {:dev-error-detail? true
+                                   :public-error-id   :myapp/projector}})]
+        (handler {:uri "/" :request-method :get})
+        (is (= {:dev-error-detail? true
+                :public-error-id   :myapp/projector}
+               @captured)
+            "the :ssr opt reaches the per-request frame's :ssr metadata
+             — the destructure matches the documented key")))))
+
+;; ===========================================================================
 ;; ssr-handler — payload-keys slice
 ;; ===========================================================================
 


### PR DESCRIPTION
## Summary

`ssr-handler`'s docstring documented `:ssr` as the per-frame SSR config opt but the destructure read `:ssr-config`, so any caller passing `{:ssr {:dev-error-detail? true ...}}` per the docs had it silently dropped. The `cond->` never asserted `:ssr` onto the per-request frame config, projector dev-mode never activated, and the default projector ran regardless of the caller's intent.

Per audit `rf2-asmj1` (`ai/findings/refactor-audit-ssr-2026-05-14.md`):

- `implementation/ssr-ring/src/re_frame/ssr/ring.clj:375` documents `:ssr`
- line 427 destructures `:ssr-config`
- line 453 plumbs `(assoc :ssr ssr-config)`

Pre-alpha — no back-compat. `:ssr` is the right name (matches `rf/make-frame`'s frame-config key and Spec 011 / Spec-Schemas `:ssr` on `:rf/frame-meta`). Renamed the destructure binding (and the cond-> branch) to `:ssr` in lockstep.

## Changes

- `ring.clj`: destructure `ssr` (was `ssr-config`); `cond-> ... ssr (assoc :ssr ssr)` (was `ssr-config (assoc :ssr ssr-config)`)
- `ring_test.clj`: new `handler-passes-through-ssr-opt-to-frame-meta` regression — caller passes `:ssr {...}`, on-create reads `(:ssr (rf/frame-meta frame))`, asserts the supplied map round-trips. Would fail before this fix.

## Test plan

- [x] `clojure -M:test` from `implementation/ssr-ring/` — 16 tests, 61 assertions, 0 failures, 0 errors
- [x] grep for residual `:ssr-config` / `ssr-config` symbols in repo — none
- [x] docstring already says `:ssr`; no doc update needed

Closes rf2-8cx3y.