### PR TITLE
fix(flows): resolve cycle-error data-shape drift (rf2-sny6o)

### DIFF
--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -62,12 +62,66 @@
                   (prefix? b-input a-path)))
             (:inputs b-flow)))))
 
+(defn- extract-cycle-path
+  "Given the dependency graph `id → #{deps...}` and the set of stuck
+  ids `remaining` (those Kahn's couldn't peel), return an ordered cycle
+  path with a CLOSING REPEAT — e.g. `[:a :b :a]` for the cycle
+  `:a → :b → :a`. Tools render this directly.
+
+  DFS from an arbitrary stuck node, following dependency edges within
+  `remaining`. When a node is revisited along the current path stack,
+  the slice `[stack-from-revisit ... current]` plus the revisited node
+  closes the cycle.
+
+  `remaining` is a set of stuck ids (NOT the live `remaining` map from
+  Kahn's loop — its values have been mutated as deps were peeled away,
+  so we read fresh dep edges from `graph`)."
+  [graph remaining]
+  ;; Deterministic pick: sort by hash so cycle reports are stable across
+  ;; runs without requiring flow-ids be mutually comparable (sort fails
+  ;; on mixed types). Hash collisions don't matter — we only need ONE
+  ;; cycle path, any pick produces a valid one.
+  (let [stuck-sorted (vec (sort-by hash remaining))
+        start        (first stuck-sorted)]
+    (loop [stack [start]
+           seen  #{start}]
+      (let [node (peek stack)
+            ;; Only follow edges into other stuck nodes — edges to
+            ;; already-peeled nodes can't be part of a remaining cycle.
+            next-dep (first (sort-by hash (filter remaining (graph node))))]
+        (cond
+          (nil? next-dep)
+          ;; Dead end within `remaining` — shouldn't happen because
+          ;; every stuck node has at least one stuck dep (that's why
+          ;; it's stuck), but defensively return the stack closed
+          ;; against itself.
+          (conj stack start)
+
+          (contains? seen next-dep)
+          ;; Cycle found. Slice the stack from the revisited node
+          ;; forward, then append the revisited node again to close.
+          ;; Pure-Clojure index search keeps this .cljc-portable.
+          (let [idx (loop [i 0]
+                      (cond
+                        (= i (count stack))      0
+                        (= (nth stack i) next-dep) i
+                        :else                    (recur (inc i))))]
+            (conj (subvec stack idx) next-dep))
+
+          :else
+          (recur (conj stack next-dep) (conj seen next-dep)))))))
+
 (defn- topo-sort
   "Kahn's algorithm — pure `loop`/`recur` over immutable state. Returns
   flows in evaluation order; throws `:rf.error/flow-cycle` if the graph
   is cyclic. `ready` is a vector used as a LIFO stack
   (`peek`/`pop`/`conj`); `remaining` is the live id→dep-set map; `order`
-  is the accumulating result."
+  is the accumulating result.
+
+  On cycle: ex-data carries `:cycle` — an ordered cycle path with a
+  closing repeat (e.g. `[:a :b :a]`) extracted via DFS through the
+  stuck nodes. Per Spec 013 §Cycle detection / Spec 009 §Error contract.
+  Tools (e.g. Causa) render this directly as the offending chain."
   [flow-map]
   (let [ids   (vec (keys flow-map))
         graph (into {}
@@ -95,7 +149,8 @@
           (recur ready' remaining' (conj order n)))
         (if (seq remaining)
           (throw (ex-info ":rf.error/flow-cycle"
-                          {:cycle (vec (keys remaining))}))
+                          {:cycle (extract-cycle-path graph
+                                                      (set (keys remaining)))}))
           order)))))
 
 ;; Note: `topo-sort` runs on every drain via `run-flows!`. A memo was

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -138,6 +138,57 @@
     (is (not (contains? (get @flows/flows :rf/default) :b))
         "cycle-detection rolls back the partial registration of :b")))
 
+(deftest reg-flow-cycle-error-carries-ordered-cycle-path
+  ;; Regression for rf2-sny6o. The cycle-error ex-data contract
+  ;; (per Spec 013 §Cycle detection / Spec 009 §Error contract) is:
+  ;; `:cycle` is an ordered vector of flow ids with a closing repeat
+  ;; — e.g. `[:a :b :a]` for the cycle :a → :b → :a. Pre-fix the impl
+  ;; threw `(vec (keys @remaining))` (an unordered subset of stuck
+  ;; nodes) which was useless for tooling rendering the offending
+  ;; chain. This test pins the resolved shape.
+  (testing "two-flow cycle: :cycle is [start ... start], length 3"
+    (rf/reg-flow {:id :a :inputs [[:b]] :output identity :path [:a]})
+    (let [ex (try
+               (rf/reg-flow {:id :b :inputs [[:a]] :output identity :path [:b]})
+               (catch Throwable t t))
+          data (ex-data ex)
+          cycle (:cycle data)]
+      (is (some? ex)        "registration threw")
+      (is (vector? cycle)   ":cycle is a vector")
+      (is (= 3 (count cycle))
+          "two-flow cycle has length 3 (n+1, including the closing repeat)")
+      (is (= (first cycle) (last cycle))
+          ":cycle closes on itself (first = last)")
+      (is (= #{:a :b} (set cycle))
+          ":cycle names both offending flow ids")
+      ;; Spec 013 example: {:cycle [:a :b :a]}. Either :a or :b may
+      ;; legally be the starting node (impl picks deterministically
+      ;; via sort-by hash; spec leaves the starting node
+      ;; implementation-defined) — assert one of the two valid
+      ;; closures.
+      (is (contains? #{[:a :b :a] [:b :a :b]} cycle)
+          "the cycle path is one of the two valid two-flow closures")))
+
+  (testing "three-flow cycle: :a → :b → :c → :a"
+    ;; Reset and build a longer chain. The reg-flow ordering matters
+    ;; because the cycle is detected on the registration that closes
+    ;; it — register :a, :b first (no cycle yet), then :c closes.
+    (reset! flows/flows {})
+    (reset! (deref (resolve 're-frame.flows/last-inputs)) {})
+    (rf/reg-flow {:id :a :inputs [[:b]] :output identity :path [:a]})
+    (rf/reg-flow {:id :b :inputs [[:c]] :output identity :path [:b]})
+    (let [ex (try
+               (rf/reg-flow {:id :c :inputs [[:a]] :output identity :path [:c]})
+               (catch Throwable t t))
+          cycle (:cycle (ex-data ex))]
+      (is (some? ex) "three-flow cycle registration threw")
+      (is (= 4 (count cycle))
+          "three-flow cycle has length 4 (n+1)")
+      (is (= (first cycle) (last cycle))
+          ":cycle closes on itself")
+      (is (= #{:a :b :c} (set (butlast cycle)))
+          "all three offending ids appear in the path"))))
+
 (deftest reg-flow-replacement-that-introduces-cycle-preserves-prior-registration
   ;; Regression for rf2-7csri (bug) / rf2-cdh9h (this test). Pinned per
   ;; audit rf2-o3hok finding Exec#2 (TE2). The bug: `reg-flow`'s former

--- a/spec/013-Flows.md
+++ b/spec/013-Flows.md
@@ -146,14 +146,16 @@ Flows form a static dependency graph derivable from their `:path` and `:inputs` 
 
 The runtime topologically sorts the registry by this dependency relation. The sort is **not memoised** in v1 — the per-frame flow map is tiny (a handful of nodes) and Kahn's algorithm over it is cheaper than the bookkeeping a memo would need. An earlier sketch carried a memoised topsort with explicit invalidation on every `reg-flow` / `clear-flow`; the memo was removed (per rf2-cd00) once measurement confirmed the unmemoised call is the cheapest correct option at the per-frame node counts v1 targets. Implementations that observe a real bottleneck in topsort cost MAY add a `core.memoize`-style cache keyed on the flow-registry identity, but the contract is just: deterministic order over the dependency graph each drain.
 
-**Cycle detection.** If A depends on B and B depends on A (any indirection), `reg-flow` throws `:rf.error/flow-cycle` at registration time with the cycle path in the error's `:tags`. The error fires before any snapshot is created — caught at registration, not at runtime.
+**Cycle detection.** If A depends on B and B depends on A (any indirection), `reg-flow` throws `:rf.error/flow-cycle` at registration time. The thrown `ex-info`'s `ex-data` carries `:cycle` — an ordered vector of flow ids with a **closing repeat** that names the offending chain (e.g. `[:a :b :a]` for the two-flow cycle `:a → :b → :a`). The error fires before any snapshot is created — caught at registration, not at runtime.
 
 ```clojure
 ;; This will throw at registration:
 (rf/reg-flow {:id :a :inputs [[:b]] :output identity :path [:a]})
 (rf/reg-flow {:id :b :inputs [[:a]] :output identity :path [:b]})
-;; → :rf.error/flow-cycle {:cycle [:a :b :a]}
+;; → ex-info ":rf.error/flow-cycle" {:cycle [:a :b :a]}
 ```
+
+The closing repeat is the contract: tools rendering the cycle (e.g. Causa) display the path verbatim. For an n-flow cycle the `:cycle` vector has `(inc n)` elements, with `(first cycle) = (last cycle)`. The starting node is implementation-defined (deterministic but unspecified) — multiple cycles can yield any one of them as the reported chain.
 
 Cycles can also form *during* flow registration if the new flow completes a cycle that was incomplete before it was registered. The detection runs every `reg-flow` call.
 


### PR DESCRIPTION
## Summary

Resolves three drifts between spec 013 and `implementation/flows/src/re_frame/flows.cljc`'s cycle-error ex-info contract, audited under rf2-o3hok.

| # | Pre-fix | Post-fix |
|---|---|---|
| 1 | Spec 013:149 said cycle path lives under `:tags`; impl placed it at top of ex-data. | Spec wording corrected — `:cycle` is on ex-data top-level (matches Spec 009:968). |
| 2 | Spec example `{:cycle [:a :b :a]}` (ordered path with closing repeat) vs impl returning `(vec (keys @remaining))` (unordered subset of stuck nodes). | Impl extracts a real ordered cycle path via DFS over stuck nodes. |
| 3 | Spec implied a path; impl produced a set-of-ids — Causa and similar tools could not render the offending chain. | Impl returns the closing-repeat path; spec restates the contract (length n+1, first = last, starting node implementation-defined). |

**Direction chosen: align impl to spec.** The spec's example is concrete and serves tooling. Cost is ~25 LoC for a DFS helper; the alternative (amend spec to match the useless set-shape) would force every tool to recompute the cycle path itself.

## Changes

- `implementation/flows/src/re_frame/flows.cljc`
  - New `extract-cycle-path` helper. DFS from a deterministic stuck node (sort-by hash for cljc portability), walks graph edges restricted to stuck nodes, slices the stack at the revisit point and appends the closing node.
  - `topo-sort` cycle branch now throws `ex-info` with `:cycle` as the closing-repeat path.
- `spec/013-Flows.md` §Cycle detection
  - Dropped the `:tags` reference (spec wording bug).
  - Restated the contract — closing repeat, vector length n+1, `(first = last)`, starting node implementation-defined.
- `implementation/flows/test/re_frame/flows_test.clj`
  - New `reg-flow-cycle-error-carries-ordered-cycle-path` deftest pinning two-flow and three-flow cycle shapes.

## Test plan

- [x] `clojure -M:test` from `implementation/flows/` — 28 tests, 115 assertions, 0 failures / 0 errors.
- [x] New regression asserts closing-repeat shape and id-set membership for n=2 and n=3 cycles.
- [x] Pre-existing `reg-flow-detects-cycles-at-registration` and `reg-flow-replacement-that-introduces-cycle-preserves-prior-registration` still pass.

## Notes

- Pre-alpha — no back-compat path needed.
- Closes rf2-sny6o.
- Spec 009 §Error contract row for `:rf.error/flow-cycle` (`:cycle (the offending flow ids)`) was already accurate enough to remain untouched; only the 013 wording bug needed correcting.