### PR TITLE
refactor(core): consolidate 5 *current-* dynamic Vars into *handler-scope* record (rf2-ryri7)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -15,7 +15,8 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.frame :as frame]
             [re-frame.source-coords :as source-coords]
-            [re-frame.trace :as trace]))
+            [re-frame.trace :as trace
+             #?@(:cljs [:include-macros true])]))
 
 (def ^{:doc "Sentinel for `inject-cofx`'s 3-arity 'no-value' branch.
   Used by `re-frame.core/inject-cofx`'s macro form (rf2-ts1a) to thread
@@ -201,20 +202,20 @@
            (let [frame-id        (interceptor/get-coeffect ctx :frame)
                  active-platform (active-platform-for-frame frame-id)]
              (if (cofx-runs-on-platform? meta active-platform)
-               ;; Per rf2-isdwf: bind `*current-sensitive?*` to the
-               ;; cofx handler's reading. The cofx body runs inside
-               ;; this scope; any trace event it emits carries the
-               ;; cofx-handler-level sensitivity flag per Spec 009
-               ;; "innermost in-scope handler" rule.
-               ;; Per rf2-qsjda: bind `*current-no-emit?*` symmetrically.
-               (binding [trace/*current-trigger-handler*
-                         (trace/trigger-handler-from-meta :cofx cofx-id meta)
-                         trace/*current-sensitive?*
-                         (trace/sensitive?-from-meta meta)
-                         trace/*current-no-emit?*
-                         (trace/no-emit?-from-meta meta)
-                         trace/*current-call-site*
-                         (or captured-cs trace/*current-call-site*)]
+               ;; Per rf2-ryri7: publish the cofx handler's HandlerScope.
+               ;; `:trigger-handler` / `:sensitive?` / `:no-emit?` come
+               ;; from the cofx's registration meta per Spec 009's
+               ;; "innermost in-scope handler" rule. `:call-site` is
+               ;; either the macro-captured site (when reached via the
+               ;; `inject-cofx` macro) or inherited from the parent
+               ;; scope's call-site — `handler-scope-from-meta` returns
+               ;; nil for `:call-site` and `inherit-scope` (run by
+               ;; `with-handler-scope`) carries the parent's value
+               ;; through; when `captured-cs` is non-nil, override
+               ;; explicitly via `assoc`.
+               (trace/with-handler-scope
+                 (cond-> (trace/handler-scope-from-meta :cofx cofx-id meta)
+                   captured-cs (assoc :call-site captured-cs))
                  (-> (if valued?
                        ((:handler-fn meta) ctx value)
                        ((:handler-fn meta) ctx))
@@ -228,8 +229,14 @@
                                        :recovery             :skipped}
                                 valued? (assoc :cofx-value value)))
                  ctx)))
-           (binding [trace/*current-call-site*
-                     (or captured-cs trace/*current-call-site*)]
+           ;; No registered cofx — emit the `:rf.error/no-such-cofx`
+           ;; trace. When the cofx was reached via its macro form
+           ;; (`captured-cs` non-nil), override the parent scope's
+           ;; call-site; when reached via the fn form, `captured-cs`
+           ;; is nil and the parent's call-site rides through. Per
+           ;; rf2-ryri7.
+           (trace/with-call-site (or captured-cs
+                                     (some-> trace/*handler-scope* :call-site))
              (let [event (interceptor/get-coeffect ctx :event)]
                (trace/emit-error! :rf.error/no-such-cofx
                                   (cond-> {:cofx-id  cofx-id

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -45,7 +45,8 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.source-coords :as source-coords]
             [re-frame.interop :as interop]
-            [re-frame.trace :as trace]
+            [re-frame.trace :as trace
+             #?@(:cljs [:include-macros true])]
             [re-frame.trace.projection :as trace-projection]
             ;; Always-on event-emit substrate (rf2-rirbq). Required
             ;; eagerly so the `:event-emit/dispatch-on-event` late-
@@ -628,9 +629,9 @@
 ;; false` (Q3=B dev-only elision) — the macro expansion is
 ;; `(if interop/debug-enabled? <stamping-call> <plain-call>)` so the
 ;; entire stamping branch (including the literal map) DCE's. emit-error!
-;; reads `trace/*current-call-site*` and attaches the value as
-;; `:rf.trace/call-site` (Q2=A flat sibling of `:rf.trace/trigger-handler`)
-;; on the emitted event.
+;; reads `trace/*handler-scope*`'s `:call-site` slot and attaches the
+;; value as `:rf.trace/call-site` (Q2=A flat sibling of
+;; `:rf.trace/trigger-handler`) on the emitted event.
 
 (def dispatch*       router/dispatch!)
 (def dispatch-sync*  router/dispatch-sync!)
@@ -726,13 +727,13 @@
      ([query-v]
       (let [cs-form (call-site-form (meta &form) (symbol (str (ns-name *ns*))) *file*)]
         `(if re-frame.interop/debug-enabled?
-           (binding [re-frame.trace/*current-call-site* ~cs-form]
+           (re-frame.trace/with-call-site ~cs-form
              (re-frame.core/subscribe* ~query-v))
            (re-frame.core/subscribe* ~query-v))))
      ([frame-id query-v]
       (let [cs-form (call-site-form (meta &form) (symbol (str (ns-name *ns*))) *file*)]
         `(if re-frame.interop/debug-enabled?
-           (binding [re-frame.trace/*current-call-site* ~cs-form]
+           (re-frame.trace/with-call-site ~cs-form
              (re-frame.core/subscribe* ~frame-id ~query-v))
            (re-frame.core/subscribe* ~frame-id ~query-v))))))
 

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -26,7 +26,8 @@
             [re-frame.performance :as performance
              #?@(:cljs [:include-macros true])]
             [re-frame.source-coords :as source-coords]
-            [re-frame.trace :as trace]))
+            [re-frame.trace :as trace
+             #?@(:cljs [:include-macros true])]))
 
 ;; ---- registration ---------------------------------------------------------
 
@@ -203,13 +204,13 @@
   trace stream.
 
   Per rf2-lf84g: when called inside the fx-handler's
-  `*current-trigger-handler*` binding (the user-registered fx branch),
-  `emit!` hoists the fx handler's registration coord onto the emitted
-  event's `:rf.trace/trigger-handler` slot — so consumers can jump to
-  the fx's `reg-fx` site from the success trace. Reserved fx-id calls
+  `*handler-scope*` binding (the user-registered fx branch), `emit!`
+  hoists the fx handler's registration coord onto the emitted event's
+  `:rf.trace/trigger-handler` slot — so consumers can jump to the fx's
+  `reg-fx` site from the success trace. Reserved fx-id calls
   (`:dispatch`, `:dispatch-later`, `:rf.fx/reg-flow`, `:rf.fx/clear-flow`)
   emit outside any fx-handler binding; the outer event handler's
-  binding (if any) stamps the event handler's coord instead, which is
+  scope (if any) stamps the event handler's coord instead, which is
   the right attribution for those — they don't have their own
   registration site."
   [fx-id args frame-id]
@@ -319,36 +320,24 @@
           ;; NOT emit a sibling warning (the schema-validation-failure
           ;; trace IS the warning, per Spec 010).
           nil
-          ;; Per rf2-3nn8 (error path) and rf2-lf84g (success path): bind
-          ;; `*current-trigger-handler*` for the duration of the fx
-          ;; handler's invocation AND for the success-path `:rf.fx/handled`
-          ;; emit that follows. Error traces emitted from inside the fx
-          ;; body (`:rf.error/fx-handler-exception` here and anything the
-          ;; body itself surfaces) carry the fx handler's source-coord;
-          ;; the success-path `:rf.fx/handled` emit picks up the same
-          ;; coord through `emit!`'s hoist of `*current-trigger-handler*`
-          ;; (the outer event handler's binding would otherwise stamp the
-          ;; event handler's coord onto the `:rf.fx/handled` event, which
-          ;; is not what consumers want — Story/Causa want jump-to-source
-          ;; to land on the fx handler's `reg-fx` site, not the event
-          ;; handler that produced the fx vector).
-          ;; Per rf2-isdwf: bind `*current-sensitive?*` to the fx
-          ;; handler's reading so any trace event emitted inside the
-          ;; fx body's scope (including the success `:rf.fx/handled`
-          ;; emit) carries the fx-handler-level sensitivity flag.
-          ;; Per Spec 009 §Privacy "innermost in-scope handler's flag
-          ;; wins" rule: when an event handler is sensitive but the fx
-          ;; handler it dispatches to is not, the `:rf.fx/handled`
-          ;; trace event reflects the FX handler's reading.
-          ;; Per rf2-qsjda: bind `*current-no-emit?*` to the fx
-          ;; handler's reading so the "innermost in-scope handler
-          ;; wins" rule applies to trace-emission opt-out too.
-          (binding [trace/*current-trigger-handler*
-                    (trace/trigger-handler-from-meta :fx fx-id meta)
-                    trace/*current-sensitive?*
-                    (trace/sensitive?-from-meta meta)
-                    trace/*current-no-emit?*
-                    (trace/no-emit?-from-meta meta)]
+          ;; Per rf2-ryri7: publish the fx handler's HandlerScope —
+          ;; `:trigger-handler` (rf2-3nn8 / rf2-lf84g) for the fx
+          ;; handler's invocation AND for the success-path
+          ;; `:rf.fx/handled` emit that follows; `:sensitive?`
+          ;; (rf2-isdwf) and `:no-emit?` (rf2-qsjda) per the
+          ;; Spec 009 "innermost handler wins" rule. Errors emitted
+          ;; from inside the fx body (`:rf.error/fx-handler-exception`
+          ;; here and anything the body itself surfaces) carry the fx
+          ;; handler's source-coord; the success-path `:rf.fx/handled`
+          ;; emit picks up the same coord through `emit!`'s hoist of
+          ;; `*handler-scope*` — the outer event handler's scope would
+          ;; otherwise stamp the event handler's coord onto the
+          ;; `:rf.fx/handled` event (Story/Causa want jump-to-source to
+          ;; land on the fx handler's `reg-fx` site, not the event
+          ;; handler that produced the fx vector). `:call-site` /
+          ;; `:dispatch-id` are inherited from the outer scope.
+          (trace/with-handler-scope
+            (trace/handler-scope-from-meta :fx fx-id meta)
             (let [ok? (try
                         ((:handler-fn meta) (cond-> {:frame frame-id}
                                               origin-event (assoc :event origin-event))

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -18,7 +18,8 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.performance :as performance
              #?@(:cljs [:include-macros true])]
-            [re-frame.trace :as trace]))
+            [re-frame.trace :as trace
+             #?@(:cljs [:include-macros true])]))
 
 ;; ---- dispatch-id allocation -----------------------------------------------
 ;;
@@ -28,10 +29,11 @@
 ;; an fx handler running in do-fx), the new dispatch's :parent-dispatch-id
 ;; is the in-flight event's :dispatch-id.
 ;;
-;; The in-flight dispatch is tracked by `re-frame.trace/*current-dispatch-id*`
-;; (per rf2-g6ih4 — moved from this ns so `trace/emit!` can read it and
+;; The in-flight dispatch's id is tracked through
+;; `re-frame.trace/*handler-scope*`'s `:dispatch-id` slot (per rf2-g6ih4 —
+;; the scope-bundle Var lives in `trace` so `trace/emit!` can read it and
 ;; stamp every trace event emitted inside the cascade with the cascade-
-;; wide id). `process-event!` binds the Var around the inner
+;; wide id). `process-event!` binds the scope around the inner
 ;; `process-event*`; child dispatches read it both to populate
 ;; `:parent-dispatch-id` here AND to ride on every emit inside the
 ;; cascade.
@@ -84,7 +86,8 @@
                         under `goog.DEBUG=false` advanced builds."
   [event opts]
   (let [dispatch-id        (when interop/debug-enabled? (next-dispatch-id))
-        parent-dispatch-id (when interop/debug-enabled? trace/*current-dispatch-id*)
+        parent-dispatch-id (when interop/debug-enabled?
+                             (some-> trace/*handler-scope* :dispatch-id))
         ;; Per rf2-ts1a: read the macro-stamped `:rf.trace/call-site`
         ;; only when interop/debug-enabled?. Wrap the read itself in
         ;; the gate so the closure compiler can DCE the keyword
@@ -176,7 +179,7 @@
   surface (rf2-3nn8): when a handler is in scope, `emit-error!` /
   `emit!` hoists the triggering handler's source-coord automatically.
   When no handler is in scope (the async-callback case the warning is
-  primarily aimed at) `*current-trigger-handler*` is unbound and the
+  primarily aimed at) `*handler-scope*`'s `:trigger-handler` is nil and the
   field is omitted — `dispatch` is a fn, not a macro, so the call site
   cannot be stamped without changing the public API. Documented
   limitation; tools that need call-site attribution capture it
@@ -395,12 +398,13 @@
   the interceptor chain, then commit :db, run flows, and walk :fx in
   source order. Per Spec 002 §Drain-loop pseudocode.
 
-  This is the inner of `process-event!`; the outer wraps it in a binding
-  of `trace/*current-dispatch-id*` so (a) child dispatches issued from
-  within fx handlers inherit the in-flight dispatch's id as their
-  `:parent-dispatch-id`, and (b) every trace event emitted inside the
-  cascade carries the cascade's `:dispatch-id` under `:tags` (per
-  Spec 009 §Dispatch correlation and rf2-g6ih4)."
+  This is the inner of `process-event!`; the outer wraps it in a
+  `trace/*handler-scope*` binding (via `trace/with-dispatch-id+call-site`)
+  so (a) child dispatches issued from within fx handlers inherit the
+  in-flight dispatch's id as their `:parent-dispatch-id`, and (b) every
+  trace event emitted inside the cascade carries the cascade's
+  `:dispatch-id` under `:tags` (per Spec 009 §Dispatch correlation and
+  rf2-g6ih4)."
   [envelope]
   (let [{:keys [event frame]} envelope
         event-id              (first event)
@@ -435,40 +439,22 @@
                                 :recovery :replaced-with-default}))
 
           :else
-          ;; Per rf2-3nn8: bind `*current-trigger-handler*` for the
-          ;; duration of this event's interceptor chain + post-chain
-          ;; phases (db commit, flows, fx walk) so every error trace
-          ;; emitted within the scope carries the triggering handler's
-          ;; source-coord. The trace/trigger-handler-from-meta helper
-          ;; returns nil when no source-coord was stamped (programmatic
-          ;; registration / REPL eval); the binding is then nil and
-          ;; the field is omitted from any emitted error event.
-          ;;
-          ;; Per rf2-isdwf: also bind `*current-sensitive?*` from the
-          ;; handler's registration meta. `emit!`/`emit-error!` hoist
-          ;; `:sensitive? true` onto every trace event produced inside
-          ;; this scope (Spec 009 §Privacy). The interceptor chain,
-          ;; db commit, flows, fx walk all ride this binding —
-          ;; covering :event/db-changed, :event/do-fx, :rf.fx/handled
-          ;; (the inner fx scope re-binds), :sub/run (sub recompute
-          ;; re-binds to the sub's reading), :rf.error/* (every error
+          ;; Per rf2-ryri7: publish the event handler's HandlerScope —
+          ;; `:trigger-handler` (rf2-3nn8 error path / rf2-lf84g success
+          ;; path) so every trace emitted inside the cascade carries the
+          ;; triggering handler's source-coord; `:sensitive?` (rf2-isdwf)
+          ;; so emits inside the scope get a top-level `:sensitive? true`
+          ;; stamp per Spec 009 §Privacy; `:no-emit?` (rf2-qsjda) so
+          ;; trace emission short-circuits when the handler opts out.
+          ;; `:call-site` and `:dispatch-id` are inherited from the parent
+          ;; scope (bound by `process-event!` outer wrapper) per
+          ;; `inherit-scope`. Scope covers the interceptor chain, db
+          ;; commit, flows, and fx walk — covering :event/db-changed,
+          ;; :event/do-fx, :rf.fx/handled (the inner fx scope re-binds),
+          ;; :sub/run (sub recompute re-binds), :rf.error/* (every error
           ;; emit inside the chain).
-          ;;
-          ;; Per rf2-qsjda: also bind `*current-no-emit?*` from the
-          ;; handler's registration meta. When the handler carries
-          ;; `:rf.trace/no-emit? true`, every trace event produced
-          ;; inside the handler's scope short-circuits at `emit!` /
-          ;; `emit-error!` (no envelope allocation, no listener
-          ;; fan-out). The framework-level trace-emission opt-out
-          ;; (Spec 009 §Trace-emission opt-out) — covers the cascade
-          ;; from this binding through the interceptor chain, db
-          ;; commit, flows, and fx walk.
-          (binding [trace/*current-trigger-handler*
-                    (trace/trigger-handler-from-meta :event event-id handler-meta)
-                    trace/*current-sensitive?*
-                    (trace/sensitive?-from-meta handler-meta)
-                    trace/*current-no-emit?*
-                    (trace/no-emit?-from-meta handler-meta)]
+          (trace/with-handler-scope
+            (trace/handler-scope-from-meta :event event-id handler-meta)
             (let [;; Per rf2-rirbq: capture the wall-clock at the very
                   ;; start of cascade execution so the always-on
                   ;; event-emit substrate can report `:elapsed-ms` in
@@ -543,12 +529,17 @@
 (defn- process-event!
   "Wrap process-event* in two dynamic bindings:
 
-   1. `trace/*current-dispatch-id*` — so child dispatches issued from
-      within an fx handler inherit this event's `:dispatch-id` as their
-      `:parent-dispatch-id`, AND so every trace event emitted inside
-      the cascade (sub runs, fx-handled, machine transitions, errors)
-      rides the cascade's `:dispatch-id` under `:tags`. Per Spec 009
-      §Dispatch correlation and rf2-g6ih4.
+   1. `trace/*handler-scope*` — set with the cascade's `:dispatch-id`
+      and the envelope's `:call-site`, inheriting the rest from parent.
+      Per rf2-ryri7 (consolidation of `*current-dispatch-id*` per
+      rf2-g6ih4 and `*current-call-site*` per rf2-ts1a) — child
+      dispatches issued from within an fx handler inherit this event's
+      `:dispatch-id` as their `:parent-dispatch-id`, every trace event
+      emitted inside the cascade (sub runs, fx-handled, machine
+      transitions, errors) rides the cascade's `:dispatch-id` under
+      `:tags`, and any error emitted inside the chain attaches the
+      call-site to the event as `:rf.trace/call-site` (nil for fn-form
+      dispatch). Per Spec 009 §Dispatch correlation.
 
    2. `frame/*current-frame*` — bound to the envelope's `:frame` for
       the duration of the handler chain. Per Spec 002 §Dispatch
@@ -566,19 +557,11 @@
       a fresh stack with no dynamic binding. Use `(rf/dispatcher)`
       (capture-at-call-time), `:fx [[:dispatch ...]]` (fx-walker
       threads the frame), or `:dispatch-later` (frame captured in
-      closure) for those paths. Per rf2-l5q3.
-
-   3. `trace/*current-call-site*` — bound to the envelope's `:call-site`
-      (when supplied by the `dispatch` / `dispatch-sync` macro per
-      rf2-ts1a). Errors emitted while the handler chain runs (handler
-      exception, no-such-cofx, no-such-fx, schema validation failure,
-      ...) read the Var and attach the call-site to the event as
-      `:rf.trace/call-site`. nil for fn-form dispatch (`dispatch*`)."
+      closure) for those paths. Per rf2-l5q3."
   [envelope]
-  (binding [trace/*current-dispatch-id*  (:dispatch-id envelope)
-            frame/*current-frame*        (:frame envelope)
-            trace/*current-call-site*    (:call-site envelope)]
-    (process-event* envelope)))
+  (trace/with-dispatch-id+call-site (:dispatch-id envelope) (:call-site envelope)
+    (binding [frame/*current-frame* (:frame envelope)]
+      (process-event* envelope))))
 
 (def ^:private drain-depth-default 100)
 
@@ -841,7 +824,7 @@
        ;; envelope's call-site so the error event carries it. Reading
        ;; the call-site through the envelope (already gated) avoids a
        ;; second `(:rf.trace/call-site opts)` keyword reference here.
-       (binding [trace/*current-call-site* (:call-site envelope)]
+       (trace/with-call-site (:call-site envelope)
          (trace/emit-error! :rf.error/frame-destroyed
                             {:frame (:frame envelope) :event event}))
 
@@ -947,7 +930,7 @@
          call-site    (:call-site envelope)]
      (cond
        (nil? frame-record)
-       (binding [trace/*current-call-site* call-site]
+       (trace/with-call-site call-site
          (trace/emit-error! :rf.error/frame-destroyed
                             {:frame (:frame envelope) :event event
                              :recovery :no-recovery}))
@@ -968,7 +951,7 @@
        ;; Per Spec 002 §dispatch-sync: nesting dispatch-sync inside the
        ;; SAME frame's running drain (sync or async) is an error — the
        ;; event would interleave with the outer handler's run-to-completion.
-       (binding [trace/*current-call-site* call-site]
+       (trace/with-call-site call-site
          (trace/emit-error! :rf.error/dispatch-sync-in-handler
                             {:frame    (:frame envelope)
                              :event    event

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -34,7 +34,8 @@
             [re-frame.performance :as performance
              #?@(:cljs [:include-macros true])]
             [re-frame.source-coords :as source-coords]
-            [re-frame.trace :as trace]))
+            [re-frame.trace :as trace
+             #?@(:cljs [:include-macros true])]))
 
 ;; ---- registration ---------------------------------------------------------
 ;;
@@ -231,30 +232,21 @@
      exception emit :rf.error/sub-exception and yield nil (recovery
      :replaced-with-default)."
   [body-fn in-vals query-id query-v frame-id input-signals sub-meta]
-  ;; Per rf2-3nn8 / rf2-lf84g (success-path widening) / rf2-npm2p
-  ;; (sub-recompute scope coverage): bind `*current-trigger-handler*` to
-  ;; the sub's own source-coord for the `:sub/run` success-trace emit,
-  ;; the body-fn invocation, and the validation step so every trace
-  ;; fired during the recompute (success path: `:sub/run`; error path:
-  ;; `:rf.error/sub-exception`, schema-validation failures, transitive
-  ;; sub misses) carries the in-flight sub's coord.
-  ;;
-  ;; Per Spec 009 §:rf.trace/trigger-handler table row "Inside a sub
-  ;; recompute (body fn)": carries the sub's coord. The emit MUST sit
-  ;; inside the binding for the sub's coord to ride the success trace.
-  ;; Per rf2-isdwf: bind `*current-sensitive?*` to the sub's reading
-  ;; per Spec 009 §Privacy line 1160 "the conventional use sites
-  ;; are reg-event-* and reg-sub" — sub return values flow user
-  ;; input into views and must be filterable.
-  ;; Per rf2-qsjda: bind `*current-no-emit?*` symmetrically — a sub
-  ;; whose registration carries `:rf.trace/no-emit? true` produces
-  ;; no `:sub/run` trace event (and no error trace if it throws).
-  (binding [trace/*current-trigger-handler*
-            (trace/trigger-handler-from-meta :sub query-id sub-meta)
-            trace/*current-sensitive?*
-            (trace/sensitive?-from-meta sub-meta)
-            trace/*current-no-emit?*
-            (trace/no-emit?-from-meta sub-meta)]
+  ;; Per rf2-ryri7: publish the sub's HandlerScope for the duration
+  ;; of `:sub/run` emit + body-fn invocation + validation step. Spec
+  ;; 009 §:rf.trace/trigger-handler table row "Inside a sub recompute
+  ;; (body fn)" — the sub's source-coord rides every emit (success
+  ;; path: `:sub/run`; error path: `:rf.error/sub-exception`,
+  ;; schema-validation failures, transitive sub misses). The emit MUST
+  ;; sit inside the scope for the sub's coord to ride the success
+  ;; trace. `:sensitive?` (rf2-isdwf) per Spec 009 §Privacy — sub
+  ;; return values flow user input into views and must be filterable.
+  ;; `:no-emit?` (rf2-qsjda) — a sub whose registration carries
+  ;; `:rf.trace/no-emit? true` produces no `:sub/run` trace event
+  ;; (and no error trace if it throws). `:call-site` / `:dispatch-id`
+  ;; are inherited from the outer scope per `inherit-scope`.
+  (trace/with-handler-scope
+    (trace/handler-scope-from-meta :sub query-id sub-meta)
     (trace/emit! :sub/run :sub/run
                  {:sub-id  query-id
                   :query-v query-v
@@ -423,10 +415,10 @@
 
   Per rf2-ts1a: this is the runtime-callable fn form. The macro form
   `re-frame.core/subscribe` captures `(meta &form)` and delegates here
-  through `re-frame.core/subscribe*`, binding `trace/*current-call-site*`
-  for the duration so any error emitted inside the synchronous miss
-  path (`:rf.error/no-such-sub`, `:rf.error/frame-destroyed`) carries
-  the invocation coord."
+  through `re-frame.core/subscribe*`, wrapping the call in
+  `trace/with-call-site` for the duration so any error emitted inside
+  the synchronous miss path (`:rf.error/no-such-sub`,
+  `:rf.error/frame-destroyed`) carries the invocation coord."
   ([query-v]
    #?(:cljs
       (let [frame-id (resolve-current-frame)]

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -31,7 +31,8 @@
   (it documents inter-cascade lineage). Per Spec 009 §Dispatch correlation
   and rf2-g6ih4."
   (:require [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]))
+            [re-frame.late-bind :as late-bind])
+  #?(:cljs (:require-macros [re-frame.trace])))
 
 ;; ---- listener registry ----------------------------------------------------
 
@@ -61,270 +62,84 @@
 (defn- next-event-id []
   (swap! event-counter inc))
 
-;; ---- trigger-handler (rf2-3nn8 / rf2-lf84g) -------------------------------
+;; ---- handler-scope: the consolidated bundle (rf2-ryri7) -------------------
 ;;
-;; Per Spec 009 §Trace correlation: a trace event MAY carry a
-;; `:rf.trace/trigger-handler` field naming the handler whose execution
-;; produced the event. Originally introduced (rf2-3nn8) for the error
-;; path; widened (rf2-lf84g) to ride success-path traces too — every
-;; event emitted inside a handler's execution scope carries the slot.
-;; The field is OPTIONAL — it is present when an in-scope handler can
-;; be identified (event handler running, sub recomputing, fx handler
-;; dispatching, cofx injecting, view rendering) and absent when no
-;; handler is in scope (e.g. outermost-dispatch
-;; `:rf.error/no-such-handler`, registration-time emits).
+;; Every handler-execution boundary (the router's `process-event!`, the
+;; sub recompute path, the fx dispatcher, the cofx injector, the view
+;; render wrapper) needs to publish the same five-slot "reading" to the
+;; trace stream so `emit!` / `emit-error!` can hoist the relevant pieces
+;; onto each emitted event. The five slots are:
 ;;
-;; The runtime carries the in-scope handler through the dynamic Var
-;; `*current-trigger-handler*`. Runtime boundaries (the router's
-;; `process-event!`, the sub recompute path, the fx dispatcher, the
-;; cofx injector, the view render wrapper) bind the Var around the
-;; user code they run; `emit!` and `emit-error!` read the Var and
-;; hoist its value to the top-level `:rf.trace/trigger-handler` slot
-;; on the emitted event when bound.
+;;   :trigger-handler  — registration coord of the in-scope handler
+;;                       (rf2-3nn8 error path / rf2-lf84g success path).
+;;                       Shape `{:kind :id :source-coord {:ns :file :line
+;;                       :column}}` or nil when no source-coord is stamped.
 ;;
-;; Shape (locked, per rf2-3nn8):
+;;   :call-site        — compile-time invocation site of the surface that
+;;                       reached the runtime through its macro form
+;;                       (`dispatch`, `dispatch-sync`, `subscribe`,
+;;                       `inject-cofx`). Shape `{:ns :file :line :column}`
+;;                       or nil for fn-form callers. Per rf2-ts1a.
 ;;
-;;   {:kind         <kw>                  ;; :event / :sub / :fx / :cofx / :view
-;;    :id           <kw>                  ;; the registered handler's id
-;;    :source-coord {:ns     <sym>
-;;                   :file   <string>
-;;                   :line   <int>
-;;                   :column <int>}}      ;; or nil when no source-coord captured
+;;   :dispatch-id      — cascade-wide correlation id. Set once on entry
+;;                       to the drain (router process-event!) and rides
+;;                       every event emitted inside the run-to-completion
+;;                       drain. Per Spec 009 §Dispatch correlation and
+;;                       rf2-g6ih4.
 ;;
-;; The field is NOT elided in production — unlike `:rf.assert/*` which
-;; is dev-only, `:rf.error/*` traces ride into prod builds and the
-;; trigger-handler coord rides with them. Per Spec 009 §Production
-;; builds the broader trace surface is dev-only via `interop/debug-
-;; enabled?`; this Var sits inside that gate and naturally elides with
-;; the surrounding error emit when prod-elided.
+;;   :sensitive?       — boolean. True when the in-scope handler's
+;;                       registration meta carries `:sensitive? true`.
+;;                       Emitted events get a top-level `:sensitive? true`
+;;                       stamp; absent reads as false (Spec 009 line 1176).
+;;                       Per rf2-isdwf.
+;;
+;;   :no-emit?         — boolean. True when the in-scope handler's
+;;                       registration meta carries `:rf.trace/no-emit?
+;;                       true`. `emit!` / `emit-error!` short-circuit
+;;                       (no envelope allocation, no listener fan-out)
+;;                       when bound true. Per Spec 009 §Trace-emission
+;;                       opt-out and rf2-qsjda.
+;;
+;; The five slots were originally five sibling dynamic Vars
+;; (`*current-trigger-handler*`, `*current-call-site*`,
+;; `*current-dispatch-id*`, `*current-sensitive?*`, `*current-no-emit?*`)
+;; bound side-by-side at every handler-scope site. Per rf2-ryri7 they are
+;; consolidated into one record `HandlerScope` bound to one Var
+;; `*handler-scope*`: one binding-frame allocation per scope (instead of
+;; five), one Var to mock in tests, one record-field edit when a sixth
+;; concern lands.
+;;
+;; Composition rule: the innermost handler-scope binding wins for the
+;; meta-derived slots (`:trigger-handler` / `:sensitive?` / `:no-emit?`)
+;; per Spec 009. The `:call-site` and `:dispatch-id` slots are inherited
+;; from the parent scope unless the new scope explicitly overrides them
+;; — call-site originates at macro expansion time and rides through
+;; nested scopes; dispatch-id is allocated once per cascade and survives
+;; the handler-chain → sub recompute → fx → cofx descent. The
+;; constructor and binding macros handle inheritance automatically.
+;;
+;; Production elision: the whole trace surface compiles out via the outer
+;; `(when interop/debug-enabled? ...)` gate in `emit!` / `emit-error!`, so
+;; all `*handler-scope*` reads are dead code under :advanced + goog.DEBUG=
+;; false. The `:trigger-handler` slot is NOT elided in error traces (which
+;; survive into production via `error-emit/dispatch-on-error!`).
 
-(def ^:dynamic *current-trigger-handler*
-  "The handler currently in scope for trace emission. Bound by each
-  runtime boundary (router, subs, fx, cofx, views). When bound, both
-  `emit!` (success path) and `emit-error!` (error path) attach the
-  value to the emitted event under the top-level
-  `:rf.trace/trigger-handler` slot. nil outside any handler's scope.
+(defrecord HandlerScope [trigger-handler call-site dispatch-id sensitive? no-emit?])
 
-  Shape: `{:kind <kw> :id <kw> :source-coord {:ns :file :line :column}?}`.
+(def ^:dynamic *handler-scope*
+  "The HandlerScope record currently in scope for trace emission.
+  Bound by `with-handler-scope` (and its variants) at every handler-
+  execution boundary (router, subs, fx, cofx, views) and at every
+  partial-binding site (dispatch error emits, subscribe/inject-cofx
+  macros). nil at top of stack — registration-time emits, outermost-
+  dispatch lookup failures, async-callback emits all see nil and emit
+  events without the hoisted handler-scope slots.
 
-  Per rf2-3nn8 (error path) and rf2-lf84g (success path)."
+  Per rf2-ryri7. Replaces five sibling dynamic Vars: *current-trigger-
+  handler* (rf2-3nn8 / rf2-lf84g), *current-call-site* (rf2-ts1a),
+  *current-dispatch-id* (rf2-g6ih4), *current-sensitive?* (rf2-isdwf),
+  *current-no-emit?* (rf2-qsjda)."
   nil)
-
-;; ---- call-site (rf2-ts1a) -------------------------------------------------
-;;
-;; Complement to `*current-trigger-handler*` (rf2-3nn8). Where the trigger-
-;; handler names the registration site of the in-scope handler, the call-site
-;; names the **invocation line** of the specific callable that's about to
-;; emit (or has just emitted) an error — e.g. the `(rf/dispatch [:bad-event])`
-;; line, the `(rf/subscribe [:bad-sub])` line, the `(rf/inject-cofx :missing)`
-;; line. With both pieces, tooling renders two clickable links per error:
-;; "handler defined at X:142" (trigger-handler) and "failed call at Y:147"
-;; (call-site).
-;;
-;; The call-site is captured at compile time by the macro form of the
-;; callable (per Q1=C: existing-name macro + `*` fn variant; `dispatch` is
-;; the macro, `dispatch*` is the runtime-callable fn). The macro binds this
-;; Var around the underlying `*`-fn call; `emit-error!` reads the Var and
-;; hoists the value to the top-level `:rf.trace/call-site` slot on the
-;; emitted event (Q2=A: flat sibling of `:rf.trace/trigger-handler`).
-;;
-;; For dispatched events the binding happens not at the macro call site but
-;; later, when the router's drain pulls the envelope out of the queue:
-;; `dispatch*` stamps the call-site onto the envelope, and `process-event!`
-;; binds this Var from the envelope before invoking the handler chain so
-;; any error emitted inside the chain carries it.
-;;
-;; For interceptors (`inject-cofx`) the call-site is captured by the
-;; macro into the interceptor's closure; the `:before` body binds the Var
-;; before calling the cofx fn.
-;;
-;; Elision (Q3=B): dev-only. The macros omit the call-site map entirely
-;; when `goog.DEBUG=false` so the compiled-out call becomes `(dispatch*
-;; event-vec)` — identical to the fn-form path. The closure compiler
-;; constant-folds the dead branch and the map literal DCE's.
-
-(def ^:dynamic *current-call-site*
-  "The compile-time-captured call site of the surface (`dispatch`,
-  `dispatch-sync`, `subscribe`, `inject-cofx`) about to emit (or just
-  emitted) an error. Bound by each surface's macro form around the
-  underlying `*`-fn invocation; `emit-error!` reads the Var and attaches
-  the value to the emitted event under `:rf.trace/call-site`. nil when
-  the surface was reached through its fn form (`dispatch*` etc.) or when
-  no surface is in scope.
-
-  Shape: `{:ns <sym> :file <string> :line <int> :column <int>}` — the
-  same shape as `:source-coord` under `:rf.trace/trigger-handler`, but
-  carries the **invocation** line rather than the registration line.
-
-  Per rf2-ts1a (Q1=C macro+fn pair, Q2=A flat key, Q3=B dev-only elision)."
-  nil)
-
-;; ---- *current-dispatch-id* (rf2-g6ih4) ------------------------------------
-;;
-;; Per Spec 009 §Dispatch correlation: `:dispatch-id` is a **cascade-wide**
-;; correlation key. It is allocated when a dispatch is enqueued (per
-;; `router.cljc`) and rides on every trace event emitted **inside** that
-;; dispatch's run-to-completion drain — `:event/dispatched` itself,
-;; `:event/db-changed`, `:rf.fx/handled`, `:sub/run`, `:rf.machine/transition`,
-;; `:rf.error/*`, every emit produced while processing the event.
-;;
-;; The runtime carries the in-flight cascade's id through the dynamic Var
-;; `*current-dispatch-id*` (mirror of `*current-trigger-handler*` per
-;; rf2-3nn8). `router.cljc` binds the Var around `process-event*` so every
-;; downstream emit — including emits produced by user handler code, by
-;; substrate code reacting to a `:db` commit, by fx handlers walking the
-;; `:fx` vector — sees the cascade's id. `emit!` reads the Var and merges
-;; it into the emitted event's `:tags` map when bound and not already
-;; present. Callers that explicitly supply `:dispatch-id` in tags win
-;; (e.g. `emit-dispatched-trace!` stamps its own id; child dispatches
-;; emitted by fx handlers are themselves `:event/dispatched` events with
-;; their own freshly-allocated `:dispatch-id`).
-;;
-;; `:parent-dispatch-id` remains scoped to `:event/dispatched` only — it
-;; documents cascade-from-cascade lineage (which cascade caused this
-;; one), which is per-event-dispatch, not per-trace-event.
-;;
-;; Production elision: when `interop/debug-enabled?` is false the whole
-;; trace surface compiles out via the outer `when` gate in `emit!`, so
-;; the Var read is dead code.
-
-(def ^:dynamic *current-dispatch-id*
-  "The id of the cascade currently being processed by `router.cljc`'s
-  drain. Bound by `router.cljc` around `process-event*` to the in-flight
-  dispatch's `:dispatch-id`. `emit!` reads the Var and merges it into
-  the emitted event's `:tags` when bound and not already present.
-
-  nil outside any drain (e.g. emits produced at registration time, at
-  frame creation, by user code outside a handler).
-
-  Per Spec 009 §Dispatch correlation and rf2-g6ih4."
-  nil)
-
-;; ---- *current-sensitive?* (rf2-isdwf) -------------------------------------
-;;
-;; Per Spec 009 §Privacy / sensitive data in traces (lines 1149-1268):
-;; every trace event emitted inside the scope of a handler whose
-;; registration carries `:sensitive? true` in its metadata MUST be
-;; stamped with `:sensitive? true` at the top level of the emitted
-;; event. The runtime carries the in-scope handler's sensitivity
-;; reading through the dynamic Var `*current-sensitive?*` — bound
-;; alongside `*current-trigger-handler*` (rf2-3nn8 / rf2-lf84g) at
-;; every handler-scope binding site (router, fx, cofx, subs, views).
-;;
-;; `emit!` and `emit-error!` read this Var and hoist `:sensitive? true`
-;; to the emitted event's TOP LEVEL (per Spec 009 line 1175 — the
-;; stamp rides alongside `:source` / `:recovery`, not under `:tags`,
-;; so a single keyword read tells consumers to filter).
-;;
-;; Cascade composition rule (Spec 009 line 1177): the innermost
-;; in-scope handler's reading wins; the runtime does NOT transitively
-;; widen the flag across handler boundaries. Tools that want "every
-;; trace event in a sensitive cascade" group by `:dispatch-id` and
-;; OR-reduce.
-;;
-;; Production elision: when `interop/debug-enabled?` is false the
-;; whole trace surface compiles out via the outer `when` gate in
-;; `emit!`, so the Var read is dead code.
-
-(def ^:dynamic *current-sensitive?*
-  "Boolean. True when the in-scope handler's registration metadata
-  carries `:sensitive? true`. Bound alongside `*current-trigger-handler*`
-  at every handler-scope binding site (router process-event, fx
-  dispatcher, cofx injector, sub recompute, view render). `emit!` and
-  `emit-error!` read this Var and stamp the emitted trace event's
-  top-level `:sensitive?` field when true.
-
-  nil / false outside any handler's scope (registration-time emits,
-  outermost-dispatch lookup failures, async-callback emits). The
-  field is OMITTED from the trace event when the Var reads falsy —
-  consumers treat absent as false.
-
-  Per Spec 009 §Privacy and rf2-isdwf."
-  nil)
-
-(defn sensitive?-from-meta
-  "Read `:sensitive?` from a registrar slot's meta map. Returns
-  `true` iff the meta carries `:sensitive? true`; `false` for every
-  other shape (nil meta, absent key, falsy value).
-
-  Used by handler-scope binding sites to compute the value to bind
-  `*current-sensitive?*` to. Per rf2-isdwf."
-  [meta]
-  (true? (:sensitive? meta)))
-
-(defn sensitive?
-  "Predicate: is `trace-event`'s top-level `:sensitive?` field truthy?
-
-  The framework-published predicate every consumer (Causa, Story,
-  pair2-preload, pair2-mcp, story-mcp, causa-mcp) gates on. Replaces
-  the per-consumer `(and (map? ev) (true? (:sensitive? ev)))` private
-  helper.
-
-  Per Spec 009 §Privacy / sensitive data in traces and rf2-isdwf
-  (audit G5)."
-  [trace-event]
-  (and (map? trace-event)
-       (true? (:sensitive? trace-event))))
-
-;; ---- *current-no-emit?* (rf2-qsjda) ---------------------------------------
-;;
-;; Per Spec 009 §Trace-emission opt-out: handlers whose registration meta
-;; carries `:rf.trace/no-emit? true` produce NO trace events. The flag is
-;; the framework-level escape hatch for trace-consuming integrations
-;; (Causa, Story, pair2-preload, …) whose own bookkeeping dispatches —
-;; emitted from inside a trace-cb — would otherwise re-enter the consumer
-;; through the trace-cb fan-out and form a cb-dispatch loop. (Originally
-;; landed by rf2-nk01x as a per-consumer Causa-side guard; this Var
-;; promotes the opt-out to the framework so any consumer can declare a
-;; handler internal-only without writing its own guard.)
-;;
-;; The runtime carries the in-scope handler's no-emit reading through the
-;; dynamic Var `*current-no-emit?*` — bound alongside `*current-trigger-
-;; handler*` (rf2-3nn8 / rf2-lf84g) and `*current-sensitive?*` (rf2-isdwf)
-;; at every handler-scope binding site (router, fx, cofx, subs, views).
-;; `emit!` and `emit-error!` read this Var and short-circuit (no envelope
-;; allocation, no listener fan-out, no buffer push) when bound true.
-;;
-;; The flag also rides the queue-time emit path: `emit-dispatched-trace!`
-;; in `router.cljc` reads the target handler's registration meta and
-;; suppresses the `:event/dispatched` emit when the meta carries
-;; `:rf.trace/no-emit? true` (mirrors the queue-time `:sensitive?` lookup
-;; per rf2-isdwf since the handler-scope binding doesn't exist yet at
-;; enqueue time).
-;;
-;; Cascade composition rule: the innermost in-scope handler's reading
-;; wins; the runtime does NOT transitively widen the flag across handler
-;; boundaries. A non-`:rf.trace/no-emit?` handler dispatched from inside
-;; a `:rf.trace/no-emit? true` handler emits normally — the inner binding
-;; rebinds to false and the inner cascade is visible.
-;;
-;; Production elision: when `interop/debug-enabled?` is false the whole
-;; trace surface compiles out via the outer `when` gate in `emit!`, so
-;; the Var read is dead code.
-
-(def ^:dynamic *current-no-emit?*
-  "Boolean. True when the in-scope handler's registration metadata
-  carries `:rf.trace/no-emit? true`. Bound alongside
-  `*current-trigger-handler*` and `*current-sensitive?*` at every
-  handler-scope binding site (router process-event, fx dispatcher,
-  cofx injector, sub recompute, view render). `emit!` and
-  `emit-error!` read this Var and short-circuit before envelope
-  allocation when bound true.
-
-  nil / false outside any handler's scope. Per rf2-qsjda and
-  Spec 009 §Trace-emission opt-out."
-  nil)
-
-(defn no-emit?-from-meta
-  "Read `:rf.trace/no-emit?` from a registrar slot's meta map. Returns
-  `true` iff the meta carries `:rf.trace/no-emit? true`; `false` for
-  every other shape (nil meta, absent key, falsy value).
-
-  Used by handler-scope binding sites to compute the value to bind
-  `*current-no-emit?*` to, and by `emit-dispatched-trace!` to gate
-  the queue-time `:event/dispatched` emit. Per rf2-qsjda."
-  [meta]
-  (true? (:rf.trace/no-emit? meta)))
 
 (defn trigger-handler-from-meta
   "Build a `:rf.trace/trigger-handler` value from a registrar meta map.
@@ -335,7 +150,7 @@
   meta map per `re-frame.source-coords/merge-coords`).
 
   Returns nil when no source-coord keys are present on `meta` — the
-  Var stays unbound and the error event omits the field. That covers
+  slot stays unbound and the error event omits the field. That covers
   the programmatic-registration path (the underlying registration fns
   called directly without the macro wrapping) where coords would be
   meaningless framework-internal positions.
@@ -351,6 +166,129 @@
       {:kind         kind
        :id           id
        :source-coord coord})))
+
+(defn sensitive?-from-meta
+  "Read `:sensitive?` from a registrar slot's meta map. Returns
+  `true` iff the meta carries `:sensitive? true`; `false` for every
+  other shape (nil meta, absent key, falsy value).
+
+  Per rf2-isdwf. Used by `handler-scope-from-meta` and by
+  `emit-dispatched-trace!` (queue-time `:event/dispatched` emit, before
+  the handler-scope binding exists)."
+  [meta]
+  (true? (:sensitive? meta)))
+
+(defn no-emit?-from-meta
+  "Read `:rf.trace/no-emit?` from a registrar slot's meta map. Returns
+  `true` iff the meta carries `:rf.trace/no-emit? true`; `false` for
+  every other shape (nil meta, absent key, falsy value).
+
+  Per rf2-qsjda. Used by `handler-scope-from-meta` and by
+  `emit-dispatched-trace!` to gate the queue-time `:event/dispatched`
+  emit (mirrors `sensitive?-from-meta`, same rationale: handler-scope
+  binding doesn't exist yet at enqueue time)."
+  [meta]
+  (true? (:rf.trace/no-emit? meta)))
+
+(defn sensitive?
+  "Predicate: is `trace-event`'s top-level `:sensitive?` field truthy?
+
+  The framework-published predicate every consumer (Causa, Story,
+  pair2-preload, pair2-mcp, story-mcp, causa-mcp) gates on. Replaces
+  the per-consumer `(and (map? ev) (true? (:sensitive? ev)))` private
+  helper.
+
+  Per Spec 009 §Privacy / sensitive data in traces and rf2-isdwf
+  (audit G5)."
+  [trace-event]
+  (and (map? trace-event)
+       (true? (:sensitive? trace-event))))
+
+(defn handler-scope-from-meta
+  "Build a HandlerScope from a registrar slot's meta map for a handler
+  about to execute. The three meta-derived slots (`:trigger-handler` /
+  `:sensitive?` / `:no-emit?`) are computed; `:call-site` and
+  `:dispatch-id` are nil — `with-handler-scope` fills them from the
+  parent scope on bind.
+
+  `kind` is the registry kind (`:event`, `:sub`, `:fx`, `:cofx`, `:view`);
+  `id` is the registered handler's id; `meta` is the registrar slot's
+  metadata.
+
+  Pre-compute this at registration time (views) when meta is fixed, or
+  inline at boundary time (router/fx/cofx/subs) when meta resolves per
+  dispatch. Per rf2-ryri7."
+  [kind id meta]
+  (->HandlerScope (trigger-handler-from-meta kind id meta)
+                  nil
+                  nil
+                  (true? (:sensitive? meta))
+                  (true? (:rf.trace/no-emit? meta))))
+
+(defn inherit-scope
+  "Merge `parent`'s `:call-site` and `:dispatch-id` into `new-scope` for
+  any slot where `new-scope`'s value is nil. The meta-derived slots
+  (`:trigger-handler` / `:sensitive?` / `:no-emit?`) on `new-scope` are
+  preserved as-is — Spec 009's innermost-handler-wins rule. Returns a
+  HandlerScope. Per rf2-ryri7."
+  [new-scope parent]
+  (if (nil? parent)
+    new-scope
+    (cond-> new-scope
+      (nil? (:call-site new-scope))   (assoc :call-site   (:call-site parent))
+      (nil? (:dispatch-id new-scope)) (assoc :dispatch-id (:dispatch-id parent)))))
+
+#?(:clj
+   (defmacro with-handler-scope
+     "Bind `*handler-scope*` to `scope` (a HandlerScope record) for the
+     duration of `body`. Inherits `:call-site` and `:dispatch-id` from
+     the parent scope where `scope`'s slots are nil. Per rf2-ryri7.
+
+     Usage at every handler-execution boundary (router, fx, cofx, subs,
+     views):
+
+         (trace/with-handler-scope (trace/handler-scope-from-meta :event id meta)
+           (run-chain ...))"
+     [scope & body]
+     `(binding [*handler-scope* (inherit-scope ~scope *handler-scope*)]
+        ~@body)))
+
+#?(:clj
+   (defmacro with-call-site
+     "Bind `*handler-scope*` with `:call-site` set to `cs`, inheriting
+     the rest from the parent scope. For surface macros (`subscribe`,
+     `inject-cofx`) and for synchronous error emits in `dispatch!` /
+     `dispatch-sync!` that stamp the envelope's call-site before
+     emitting `:rf.error/frame-destroyed` etc.
+
+     Per rf2-ryri7 (replaces `(binding [*current-call-site* cs] ...)`)."
+     [cs & body]
+     `(let [cs# ~cs
+            parent# *handler-scope*]
+        (binding [*handler-scope* (if parent#
+                                    (assoc parent# :call-site cs#)
+                                    (->HandlerScope nil cs# nil false false))]
+          ~@body))))
+
+#?(:clj
+   (defmacro with-dispatch-id+call-site
+     "Bind `*handler-scope*` with `:dispatch-id` and `:call-site` set,
+     inheriting the rest from the parent. Used by `router/process-event!`
+     to publish the cascade's `:dispatch-id` and the envelope's
+     `:call-site` once on entry to the drain.
+
+     Per rf2-ryri7 (replaces the dispatch-id + call-site pair of bindings
+     that wrapped `process-event*` pre-consolidation)."
+     [dispatch-id call-site & body]
+     `(let [did# ~dispatch-id
+            cs# ~call-site
+            parent# *handler-scope*]
+        (binding [*handler-scope* (if parent#
+                                    (assoc parent#
+                                           :dispatch-id did#
+                                           :call-site   cs#)
+                                    (->HandlerScope nil cs# did# false false))]
+          ~@body))))
 
 ;; ---- retain-N trace ring buffer (dev-only) -------------------------------
 ;;
@@ -535,19 +473,19 @@
       (capture event)
       (catch #?(:clj Throwable :cljs :default) _ nil))))
 
-;; ---- shared emit substrate (rf2-xwp6o) -----------------------------------
+;; ---- shared emit substrate (rf2-xwp6o, rf2-ryri7) -------------------------
 ;;
 ;; `emit!` (success path) and `emit-error!` (error path) share an identical
 ;; envelope-construction core and an identical delivery path. The shared
-;; pieces live in `build-event` (pure construction; reads the four
-;; handler-scope dynamic Vars internally) and `deliver!` (side-effect
+;; pieces live in `build-event` (pure construction; reads the handler-scope
+;; bundle internally via `*handler-scope*`) and `deliver!` (side-effect
 ;; dispatch: ring buffer push + epoch capture + listener fan-out). The
 ;; two public emit fns reduce to ~8-line wrappers carrying the prod-DCE
 ;; outer gate.
 ;;
 ;; The outer `(when interop/debug-enabled? ...)` and inner `(when-not
-;; *current-no-emit?* ...)` guards stay in the wrappers — NOT in
-;; `build-event` — because Spec 009 §Production builds mandates the
+;; (:no-emit? *handler-scope*) ...)` guards stay in the wrappers — NOT
+;; in `build-event` — because Spec 009 §Production builds mandates the
 ;; outermost form of an emit call be `(when interop/debug-enabled? ...)`
 ;; alone for Closure DCE to elide the whole expression in `:advanced`
 ;; builds with `goog.DEBUG=false`.
@@ -558,11 +496,11 @@
   `:sensitive? true`. Caller-supplied `:sensitive?` in tags wins (e.g.
   `emit-dispatched-trace!` computes its own reading at queue time,
   before the handler-scope binding exists)."
-  [tags]
+  [tags scope]
   (let [tag-sensitive? (:sensitive? tags)]
     (cond
       (some? tag-sensitive?) (true? tag-sensitive?)
-      :else                  (true? *current-sensitive?*))))
+      :else                  (true? (some-> scope :sensitive?)))))
 
 (defn- stamp-cascade-id
   "Per rf2-g6ih4: stamp the cascade's :dispatch-id on every event
@@ -576,26 +514,28 @@
     base-tags))
 
 (defn- build-event
-  "Assemble the trace envelope. Pure construction — reads the four
-  handler-scope dynamic Vars (`*current-trigger-handler*`,
-  `*current-call-site*`, `*current-dispatch-id*`, `*current-sensitive?*`)
-  and returns the map. No side-effects. Op-type discriminates the
-  divergent top-level hoists between success and error paths:
+  "Assemble the trace envelope. Pure construction — reads
+  `*handler-scope*` once and pulls the four hoist-relevant slots
+  (`:trigger-handler` / `:call-site` / `:dispatch-id` / `:sensitive?`)
+  from the record. No side-effects. Op-type discriminates the divergent
+  top-level hoists between success and error paths:
 
     - success (op-type ≠ :error): hoists `:source` and `:recovery` from
       tags when present; `:rf.trace/call-site` is NOT read (success
       traces don't carry it).
     - error (op-type = :error): always stamps `:recovery` (defaulting
       to `:no-recovery`); hoists `:rf.trace/call-site` from
-      `*current-call-site*` when bound; merges `{:category operation}`
-      into tags.
+      `*handler-scope*`'s `:call-site` slot when set; merges
+      `{:category operation}` into tags.
 
   The shared core — id, time, tags+, trigger-handler, sensitive? — is
-  identical across both paths. Per rf2-xwp6o."
+  identical across both paths. Per rf2-xwp6o (factor) and rf2-ryri7
+  (single-Var read)."
   [op-type operation tags]
-  (let [trigger     *current-trigger-handler*
-        cascade-id  *current-dispatch-id*
-        sensitive?  (compute-sensitive? tags)
+  (let [scope       *handler-scope*
+        trigger     (some-> scope :trigger-handler)
+        cascade-id  (some-> scope :dispatch-id)
+        sensitive?  (compute-sensitive? tags scope)
         error?      (= op-type :error)
         ;; Source and recovery are caller-supplied through `tags` on
         ;; the success path; on the error path `:recovery` defaults
@@ -604,7 +544,7 @@
         recovery    (if error?
                       (:recovery tags :no-recovery)
                       (:recovery tags))
-        call-site   (when error? *current-call-site*)
+        call-site   (when error? (some-> scope :call-site))
         ;; Per Spec 009 §Required top-level fields: :source and
         ;; :recovery (when present) live at the top level of the
         ;; trace event, NOT inside :tags. Strip them from base-tags
@@ -669,29 +609,31 @@
   the envelope (origin of the trigger — :ui :timer :http :repl
   :machine). Tags retain everything else.
 
-  Per rf2-g6ih4: when `*current-dispatch-id*` is bound (the runtime is
-  inside a drain processing a dispatch), the in-flight cascade's id is
-  merged into `:tags :dispatch-id`. Callers that supply their own
-  `:dispatch-id` in tags win (the only such caller in the framework is
-  `:event/dispatched`, which stamps its own freshly-allocated id).
+  Per rf2-g6ih4: when `*handler-scope*` is bound with a non-nil
+  `:dispatch-id` (the runtime is inside a drain processing a dispatch),
+  the in-flight cascade's id is merged into `:tags :dispatch-id`.
+  Callers that supply their own `:dispatch-id` in tags win (the only
+  such caller in the framework is `:event/dispatched`, which stamps
+  its own freshly-allocated id).
 
-  Per rf2-lf84g: when `*current-trigger-handler*` is bound (the emit
-  fires inside a handler's execution scope — event / sub / fx / cofx /
-  view), the handler's registration coord rides on the emitted event
-  under the top-level `:rf.trace/trigger-handler` slot. Mirrors the
-  error path (`emit-error!`) — same field, same shape, same elision
-  behaviour. Success-path traces emitted inside a handler's scope
+  Per rf2-lf84g: when `*handler-scope*` is bound with a non-nil
+  `:trigger-handler` (the emit fires inside a handler's execution
+  scope — event / sub / fx / cofx / view), the handler's registration
+  coord rides on the emitted event under the top-level
+  `:rf.trace/trigger-handler` slot. Mirrors the error path
+  (`emit-error!`) — same field, same shape, same elision behaviour.
+  Success-path traces emitted inside a handler's scope
   (`:rf.fx/handled`, `:rf.machine/transition`, `:event/db-changed`,
   `:event/do-fx`, ...) carry the registration coord so tools can
   jump-to-source from any trace event in a cascade, not just errors.
 
-  Per rf2-qsjda: when `*current-no-emit?*` is bound true (the
-  in-scope handler's registration meta carries `:rf.trace/no-emit?
-  true`), the body short-circuits before envelope allocation — no
-  buffer push, no epoch-capture, no listener fan-out, no id-counter
-  bump. This is the framework-level opt-out for trace-consuming
-  integrations whose own bookkeeping handlers must not re-enter the
-  trace stream and form a cb-dispatch loop. Per Spec 009
+  Per rf2-qsjda: when the in-scope `*handler-scope*` carries
+  `:no-emit? true` (the handler's registration meta carries
+  `:rf.trace/no-emit? true`), the body short-circuits before envelope
+  allocation — no buffer push, no epoch-capture, no listener fan-out,
+  no id-counter bump. This is the framework-level opt-out for trace-
+  consuming integrations whose own bookkeeping handlers must not
+  re-enter the trace stream and form a cb-dispatch loop. Per Spec 009
   §Trace-emission opt-out."
   [op operation tags]
   (when interop/debug-enabled?
@@ -700,7 +642,7 @@
     ;; `interop/debug-enabled?` gate (Spec 009 §Production builds
     ;; mandates the outermost form be that gate alone — `(when
     ;; (and X interop/debug-enabled?) ...)` defeats Closure DCE).
-    (when-not (true? *current-no-emit?*)
+    (when-not (true? (some-> *handler-scope* :no-emit?))
       (deliver! (build-event op operation tags)))))
 
 (defn emit-error!
@@ -709,41 +651,43 @@
   `:op-type` is :error, and `:tags` includes `:category`, `:exception`,
   `:where`, etc.
 
-  Per rf2-3nn8: when `*current-trigger-handler*` is bound (a handler is
-  currently in scope — event handler running, sub recomputing, fx
-  handler dispatching, cofx injecting, view rendering), the value is
-  hoisted to the top-level `:rf.trace/trigger-handler` slot on the
-  emitted event. Absent when no handler is in scope (e.g. outermost-
-  dispatch `:rf.error/no-such-handler`).
+  Per rf2-3nn8: when `*handler-scope*` is bound with a non-nil
+  `:trigger-handler` (a handler is currently in scope — event handler
+  running, sub recomputing, fx handler dispatching, cofx injecting,
+  view rendering), the value is hoisted to the top-level
+  `:rf.trace/trigger-handler` slot on the emitted event. Absent when
+  no handler is in scope (e.g. outermost-dispatch
+  `:rf.error/no-such-handler`).
 
-  Per rf2-ts1a: when `*current-call-site*` is bound (the error fires
-  inside the body of a surface that was reached through its macro form
-  — `dispatch`, `dispatch-sync`, `subscribe`, `inject-cofx`), the
-  compile-time-captured call site is hoisted to the top-level
-  `:rf.trace/call-site` slot on the emitted event. Absent when the
-  surface was reached through its fn form (`dispatch*` etc.) or when
-  no surface is in scope.
+  Per rf2-ts1a: when `*handler-scope*` is bound with a non-nil
+  `:call-site` (the error fires inside the body of a surface that was
+  reached through its macro form — `dispatch`, `dispatch-sync`,
+  `subscribe`, `inject-cofx`), the compile-time-captured call site is
+  hoisted to the top-level `:rf.trace/call-site` slot on the emitted
+  event. Absent when the surface was reached through its fn form
+  (`dispatch*` etc.) or when no surface is in scope.
 
-  Per rf2-g6ih4: when `*current-dispatch-id*` is bound (the error fires
-  inside a drain), the in-flight cascade's id is merged into
-  `:tags :dispatch-id` so consumers can correlate the error with the
-  rest of the cascade. Caller-supplied `:dispatch-id` wins.
+  Per rf2-g6ih4: when `*handler-scope*` is bound with a non-nil
+  `:dispatch-id` (the error fires inside a drain), the in-flight
+  cascade's id is merged into `:tags :dispatch-id` so consumers can
+  correlate the error with the rest of the cascade. Caller-supplied
+  `:dispatch-id` wins.
 
-  Per rf2-qsjda: when `*current-no-emit?*` is bound true (the
-  in-scope handler's registration meta carries `:rf.trace/no-emit?
-  true`), the body short-circuits before envelope allocation —
-  symmetric with the success path in `emit!`. The framework-level
-  trace-emission opt-out applies to error traces too (a Causa-style
-  bookkeeping handler must not re-enter the consumer through error
-  emits any more than through success emits). Per Spec 009
-  §Trace-emission opt-out."
+  Per rf2-qsjda: when the in-scope `*handler-scope*` carries
+  `:no-emit? true` (the handler's registration meta carries
+  `:rf.trace/no-emit? true`), the body short-circuits before envelope
+  allocation — symmetric with the success path in `emit!`. The
+  framework-level trace-emission opt-out applies to error traces too
+  (a Causa-style bookkeeping handler must not re-enter the consumer
+  through error emits any more than through success emits). Per
+  Spec 009 §Trace-emission opt-out."
   [error-operation tags]
   (when interop/debug-enabled?
     ;; Per rf2-qsjda: short-circuit when the in-scope handler opted
     ;; out of trace emission. Guard sits *inside* the outer
     ;; `interop/debug-enabled?` gate per Spec 009 §Production builds
     ;; (the outer gate must stand alone for Closure DCE).
-    (when-not (true? *current-no-emit?*)
+    (when-not (true? (some-> *handler-scope* :no-emit?))
       (deliver! (build-event :error error-operation tags)))))
 
 ;; ---- late-bind hook registration ------------------------------------------

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -48,7 +48,7 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.performance :as performance :include-macros true]
             [re-frame.registrar :as registrar]
-            [re-frame.trace :as trace]
+            [re-frame.trace :as trace :include-macros true]
             [re-frame.views.provider :as provider]
             [re-frame.views.source-coord-annotation :as source-coord]
             [re-frame.views.warn-once :as warn-once]))
@@ -206,48 +206,41 @@
         render-fn          (if wrap-applied? wrapped-by-adapter render-fn)
         coord-attr (when (and interop/debug-enabled? (not wrap-applied?))
                      (source-coord/format-source-coord id metadata))
-        ;; Per rf2-3nn8: capture the view's `:rf.trace/trigger-handler`
-        ;; value once at registration time (the registrar `metadata` map
-        ;; carries the source-coord stamp) so each render binds it via
-        ;; the dynamic Var around the user render-fn invocation. Errors
-        ;; emitted during render (subscribe-miss against this frame,
-        ;; sub exception during a render-time deref, etc.) inherit the
-        ;; view's coord as the in-scope trigger handler.
-        view-trigger-handler (trace/trigger-handler-from-meta :view id metadata)
-        ;; Per rf2-isdwf: pre-compute the view's `:sensitive?`
-        ;; reading once at registration time (same idiom as
-        ;; `view-trigger-handler`). Every render binds it; any
-        ;; trace event emitted during the view's render carries
-        ;; the flag per Spec 009 §Privacy.
-        view-sensitive?      (trace/sensitive?-from-meta metadata)
-        ;; Per rf2-qsjda: pre-compute the view's `:rf.trace/no-emit?`
-        ;; reading symmetrically. Every render binds it; when set,
-        ;; the `:view/render` emit and any in-render error emits
-        ;; short-circuit at `trace/emit!` / `trace/emit-error!`.
-        view-no-emit?        (trace/no-emit?-from-meta metadata)
+        ;; Per rf2-ryri7: pre-compute the view's HandlerScope once at
+        ;; registration time. The registrar `metadata` map carries the
+        ;; source-coord stamp, `:sensitive?`, and `:rf.trace/no-emit?`
+        ;; readings — all three derive from meta and are fixed for the
+        ;; life of the registered view. Each render binds the scope
+        ;; (via `with-handler-scope`, which inherits parent's
+        ;; `:call-site` / `:dispatch-id`) around the user render-fn
+        ;; invocation. Errors emitted during render (subscribe-miss
+        ;; against this frame, sub exception during a render-time
+        ;; deref, etc.) ride the view's `:trigger-handler` coord;
+        ;; `:view/render` emits ride `:sensitive?` per Spec 009
+        ;; §Privacy and short-circuit when `:no-emit?` is true.
+        view-scope (trace/handler-scope-from-meta :view id metadata)
         wrapped (with-meta
                   (fn frame-aware-view [& args]
                     (let [tok        (provider/reagent-component-token)
                           render-key [id tok]]
-                      (binding [*render-key* render-key
-                                trace/*current-trigger-handler* view-trigger-handler
-                                trace/*current-sensitive?* view-sensitive?
-                                trace/*current-no-emit?* view-no-emit?]
-                        (emit-render-trace! render-key)
-                        ;; Per Spec 009 §Performance instrumentation
-                        ;; (rf2-du3i): every render of a registered view
-                        ;; brackets the user render-fn in performance
-                        ;; marks so prod builds with the perf flag
-                        ;; enabled produce a `rf:render:<view-id>`
-                        ;; measure entry. Default-off; under :advanced +
-                        ;; `re-frame.performance/enabled?=false` the
-                        ;; bracket DCEs and the form collapses to the
-                        ;; bare `(apply render-fn args)` call.
-                        (let [out (performance/mark-and-measure :render id
-                                    (apply render-fn args))]
-                          (if (and interop/debug-enabled? (not wrap-applied?))
-                            (source-coord/inject-source-coord-attr id coord-attr out)
-                            out)))))
+                      (binding [*render-key* render-key]
+                        (trace/with-handler-scope view-scope
+                          (emit-render-trace! render-key)
+                          ;; Per Spec 009 §Performance instrumentation
+                          ;; (rf2-du3i): every render of a registered
+                          ;; view brackets the user render-fn in
+                          ;; performance marks so prod builds with the
+                          ;; perf flag enabled produce a
+                          ;; `rf:render:<view-id>` measure entry.
+                          ;; Default-off; under :advanced +
+                          ;; `re-frame.performance/enabled?=false` the
+                          ;; bracket DCEs and the form collapses to the
+                          ;; bare `(apply render-fn args)` call.
+                          (let [out (performance/mark-and-measure :render id
+                                      (apply render-fn args))]
+                            (if (and interop/debug-enabled? (not wrap-applied?))
+                              (source-coord/inject-source-coord-attr id coord-attr out)
+                              out))))))
                   {:contextType frame-context})]
     (registrar/register! :view id (assoc metadata :handler-fn wrapped))
     wrapped))

--- a/implementation/core/test/re_frame/trace_test.clj
+++ b/implementation/core/test/re_frame/trace_test.clj
@@ -568,8 +568,8 @@
 ;; the framework-level escape hatch for trace-consuming integrations
 ;; whose own bookkeeping dispatches — emitted from inside a trace-cb —
 ;; would otherwise re-enter the consumer through the trace-cb fan-out
-;; and form a cb-dispatch loop. (See `re-frame.trace/*current-no-emit?*`
-;; for the runtime mechanism.)
+;; and form a cb-dispatch loop. (See `re-frame.trace/*handler-scope*`'s
+;; `:no-emit?` slot for the runtime mechanism, per rf2-ryri7.)
 ;;
 ;; Covers:
 ;;   - A handler WITH `:rf.trace/no-emit? true` produces no `:event/


### PR DESCRIPTION
## Summary

Per audit `rf2-spr6q` (A2 / RT2): the five `*current-...*` dynamic Vars (`*current-trigger-handler*`, `*current-call-site*`, `*current-dispatch-id*`, `*current-sensitive?*`, `*current-no-emit?*`) were conceptually one bundle — "what is the in-scope handler's reading?" — fragmented into five sibling Vars + five compute-from-meta helpers + five binding-form copies across five files.

Consolidate into a single `HandlerScope` record bound to one Var `*handler-scope*`:

- `(trace/handler-scope-from-meta kind id meta)` — constructor for handler-execution boundaries.
- `(trace/with-handler-scope scope & body)` — covers the five handler-execution boundaries (router, fx, cofx, subs, views). Inherits `:call-site` / `:dispatch-id` from parent.
- `(trace/with-call-site cs & body)` — for surface macros (`subscribe`, `inject-cofx`) and synchronous error emits in `dispatch!` / `dispatch-sync!` (carries the envelope's call-site for `:rf.error/frame-destroyed` etc.).
- `(trace/with-dispatch-id+call-site did cs & body)` — for `router/process-event!`'s outer wrapper.

## Benefits

- **Perf**: one `pushThreadBindings` frame allocation per scope instead of five — across every dispatch + sub recompute + fx call + cofx inject + view render.
- **Extensibility**: future "sixth handler-scope concern" lands in one record-field edit + one helper + one emit hoist (today: 5 site touchups + 1 Var def + 1 helper + 5 hoists).
- **Test ergonomics**: tests that want to assert "the trace event emitted inside this fx call carries the fx handler's sensitivity reading" now mock one Var, not five.
- **LoC**: net -91 across the 8 touched files (trace.cljc absorbs the record/macro primitives; binding sites collapse from 6 lines to 1).

## Test plan

- [x] `clojure -M:test` from `implementation/core/` — 440 tests, 2309 assertions, 0 failures, 0 errors.
- [x] `npm run test:cljs` — 1795 tests, 4975 assertions, 0 failures, 0 errors.
- [x] `npm run test:elision` — production-build elision contract holds (dev sentinels present in dev bundle; absent in prod bundle).
- [x] `npm run test:bundle-isolation` — tools-bundle isolation contract holds.
- [x] `npm run test:perf-bundle` — perf-bundle gating unchanged.
- [x] `clojure -M:test` from `implementation/machines/` — 119 tests, 332 assertions, 0 failures, 0 errors.

Closes rf2-ryri7.