### PR TITLE
fix(ssr): :rf/response accumulator side-channel storage (privacy + perf) (rf2-jbcmt)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -282,7 +282,7 @@
    {:key         :ssr/on-frame-destroyed
     :producer-ns 're-frame.ssr
     :design-bead "rf2-fcj33"
-    :description "Clear the SSR side-channel atoms (pending-error-traces + request-slots) for a destroyed frame, per Spec 011 §Per-request frame teardown contract. Also invokes `:ssr/head-on-frame-destroyed` (if registered) so the head ns can release per-frame snapshot bookkeeping (rf2-4dra9)."}
+    :description "Clear the SSR side-channel atoms (pending-error-traces, request-slots, response-slots) for a destroyed frame, per Spec 011 §Per-request frame teardown contract. The response-slots entry joined under rf2-jbcmt when the `:rf/response` accumulator moved off `app-db` to plug a hydration-payload leak + per-fx full-app-db swap. Also invokes `:ssr/head-on-frame-destroyed` (if registered) so the head ns can release per-frame snapshot bookkeeping (rf2-4dra9)."}
 
    ;; ---- re-frame.ssr.head (rf2-4dra9 — head/meta contract) ------------------
    {:key         :ssr/reg-head

--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -10,6 +10,17 @@
   response shape; the host adapter wires that shape to a real HTTP
   server.
 
+  Privacy note (rf2-jbcmt): the response accumulator is **side-channel
+  storage** — Spec 011 §Response storage substrate locks it in a
+  framework-private atom keyed by frame-id, NOT in `app-db`. Consequence
+  for this adapter: the hydration payload built from `app-db` cannot
+  carry server-only response data (Set-Cookie auth tokens, internal
+  `X-*` headers, redirect targets) by accident — the boundary is
+  enforced at the storage layer rather than via `:payload-keys`
+  filtering on every host endpoint. `build-payload` below ships the
+  app-db slice exactly because the accumulator is structurally outside
+  app-db.
+
   This namespace ships that adapter for Ring (https://github.com/ring-clojure).
   Ring is the canonical Clojure HTTP-server abstraction; the
   request/response maps documented at the Ring Concepts wiki page

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -23,6 +23,14 @@
   (reset! frame/frames {})
   (reset! flows/flows {})
   (reset! schemas/schemas-by-frame {})
+  (reset! ssr/request-slots {})
+  ;; Framework-private SSR side-channel atoms (per Spec 011 §Per-request
+  ;; frame teardown — response-slots joined under rf2-jbcmt). Reach via
+  ;; resolve so process-wide stale entries can't bleed across fixtures.
+  (when-let [v (resolve 're-frame.ssr/response-slots)]
+    (reset! @v {}))
+  (when-let [v (resolve 're-frame.ssr/pending-error-traces)]
+    (reset! @v {}))
   (rf/init! ssr/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
@@ -501,3 +509,124 @@
         (is (not @wrapped-called))
         (is (= 200 (:status ssr-response)))
         (is (str/includes? (:body ssr-response) "<!DOCTYPE html>"))))))
+
+;; ===========================================================================
+;; hydration-payload-omits-rf-response-accumulator (rf2-jbcmt)
+;;
+;; Privacy regression — per Spec 011 §Response storage substrate the HTTP
+;; response accumulator MUST NOT ride `app-db`. Earlier drafts stored the
+;; accumulator at `[:rf/response]` in the request frame's app-db; without
+;; explicit `:payload-keys` filtering, the hydration payload at
+;; `build-payload` shipped the whole app-db (with the accumulator's
+;; server-only Set-Cookie / X-* headers / redirect locations) onto the
+;; client wire. The rf2-jbcmt fix moved storage to a framework-private
+;; side-channel atom keyed by frame-id (`re-frame.ssr/response-slots`)
+;; so the accumulator can NEVER reach the hydration payload — the
+;; privacy boundary is self-enforcing at the storage layer rather than
+;; caller-vigilance at every host adapter.
+;;
+;; This test exercises a full login-flow shape (set-status + secret
+;; header + leak-probe cookie + append-header) and asserts:
+;;   (a) the hydration payload script tag contains the public app-db,
+;;   (b) the payload's serialised contents do NOT contain `:rf/response`,
+;;   (c) the payload's serialised contents do NOT contain the secret
+;;       values (cookie auth token, internal header value),
+;;   (d) the Set-Cookie and X-Secret-Header DO appear on response headers
+;;       (the wire shape — i.e. they reach the wire via the response
+;;       headers, NOT via the hydration payload).
+;; ===========================================================================
+
+(deftest hydration-payload-omits-rf-response-accumulator
+  (testing "rf2-jbcmt: the :rf/response accumulator is side-channel — it
+            never appears in the hydration payload, even when a login-shape
+            request sets server-only cookies / headers / status"
+    (rf/reg-event-fx :auth/login
+      {:platforms #{:server}}
+      (fn [{:keys [db]} _]
+        {:db (assoc db :public/article-title "Public Title"
+                       :public/user-id "u-42")
+         :fx [;; A login-flow shape — every public surface of the
+              ;; response API touched, with server-only PII /
+              ;; auth-token values to leak-probe.
+              [:rf.server/set-status 200]
+              [:rf.server/set-cookie {:name      "session"
+                                      :value     "SUPER_SECRET_AUTH_TOKEN_xyz"
+                                      :http-only true
+                                      :secure    true
+                                      :same-site :lax
+                                      :path      "/"}]
+              [:rf.server/delete-cookie {:name "stale-session" :path "/"}]
+              [:rf.server/set-header {:name  "X-Secret-Header"
+                                      :value "INTERNAL_ONLY_VALUE_abc"}]
+              [:rf.server/append-header {:name  "X-Audit"
+                                         :value "v1"}]
+              [:rf.server/append-header {:name  "X-Audit"
+                                         :value "v2"}]]}))
+
+    (rf/reg-view* :pages/dashboard
+      (fn [] [:div.page [:h1 "Public dashboard"]]))
+
+    (let [handler   (ssr-ring/ssr-handler
+                      {:on-create [:auth/login]
+                       :root-view [:pages/dashboard]})
+          response  (handler {:uri            "/dashboard"
+                              :request-method :get
+                              :headers        {"user-agent" "rf2-jbcmt-leak-probe"}})
+          body      (:body response)
+          ;; The payload script tag's contents are EDN per the default
+          ;; html-shell — `<script id="__rf_payload" type="application/edn">
+          ;; ...edn... </script>`.
+          payload-m (re-find #"<script id=\"__rf_payload\"[^>]*>(.*?)</script>"
+                             body)
+          payload-edn (when payload-m (second payload-m))]
+
+      ;; (sanity) the request reached 200 — drain settled cleanly.
+      (is (= 200 (:status response)))
+
+      ;; (a) Public state IS on the wire — the payload carries the app-db slice.
+      (is (some? payload-edn)
+          "hydration payload script tag is present in the body")
+      (is (str/includes? payload-edn "Public Title")
+          "payload's app-db carries the public state (sanity)")
+      (is (str/includes? payload-edn "u-42")
+          "payload's app-db carries the public user id (sanity)")
+
+      ;; (b) The :rf/response accumulator key itself MUST NOT appear in
+      ;; the payload — the side-channel substrate guarantees this.
+      (is (not (str/includes? payload-edn ":rf/response"))
+          "rf2-jbcmt: payload does NOT carry :rf/response — the accumulator
+           lives in a framework-private side-channel atom, not in app-db")
+
+      ;; (c) The server-only secret values MUST NOT appear in the payload.
+      ;; This is the regression-bite assertion: pre-rf2-jbcmt these strings
+      ;; rode the wire as part of `[:rf/response :cookies ...]` /
+      ;; `[:rf/response :headers ...]` inside the app-db slice.
+      (is (not (str/includes? payload-edn "SUPER_SECRET_AUTH_TOKEN_xyz"))
+          "rf2-jbcmt: the Set-Cookie auth token does NOT leak into the
+           hydration payload")
+      (is (not (str/includes? payload-edn "INTERNAL_ONLY_VALUE_abc"))
+          "rf2-jbcmt: the internal X-Secret-Header value does NOT leak
+           into the hydration payload")
+      (is (not (str/includes? payload-edn "stale-session"))
+          "rf2-jbcmt: even delete-cookie metadata stays server-side")
+
+      ;; (d) The wire response DOES carry the Set-Cookie + X-Secret-Header.
+      ;; The privacy contract is "side-channel only" — the values reach
+      ;; the wire as response headers (where they're supposed to be), and
+      ;; ONLY as response headers (NOT also via the payload).
+      (let [headers    (:headers response)
+            set-cookie (or (get headers "Set-Cookie")
+                           (get headers "set-cookie"))
+            secret-hdr (or (get headers "X-Secret-Header")
+                           (get headers "x-secret-header"))
+            audit-hdr  (or (get headers "X-Audit")
+                           (get headers "x-audit"))]
+        (is (some? set-cookie)
+            "Set-Cookie header IS on the wire response (the place it belongs)")
+        (let [sc-str (if (vector? set-cookie) (str/join "; " set-cookie) (str set-cookie))]
+          (is (str/includes? sc-str "session=SUPER_SECRET_AUTH_TOKEN_xyz")
+              "the session cookie's auth token IS in the Set-Cookie response header"))
+        (is (= "INTERNAL_ONLY_VALUE_abc" secret-hdr)
+            "X-Secret-Header value IS on the wire response (header surface)")
+        (is (some? audit-hdr)
+            "X-Audit append-header reached the wire (multi-valued)")))))

--- a/implementation/ssr/deps.edn
+++ b/implementation/ssr/deps.edn
@@ -8,14 +8,16 @@
 ;; `:rf.server/set-header` / `:rf.server/append-header` /
 ;; `:rf.server/set-cookie` / `:rf.server/delete-cookie` /
 ;; `:rf.server/redirect` server-only fx family, the per-request HTTP
-;; response accumulator at `[:rf/response]`, the `reg-error-projector`
-;; surface plus its built-in `:rf.ssr/default-error-projector`, the
-;; runtime's SSR error path, and the `data-rf2-source-coord` annotation
-;; on registered-view roots — ships as a separate Maven artefact so
-;; apps that don't render server-side don't drag the namespace, the
-;; HTML emitter, the FNV-1a hash machinery, the response-accumulator
-;; bookkeeping, the projector registry kind, or any of the
-;; `:rf.ssr/*` / `:rf.server/*` trace strings onto the classpath.
+;; response accumulator (a framework-private side-channel atom keyed on
+;; frame-id per rf2-jbcmt — Spec 011 §Response storage substrate), the
+;; `reg-error-projector` surface plus its built-in
+;; `:rf.ssr/default-error-projector`, the runtime's SSR error path, and
+;; the `data-rf2-source-coord` annotation on registered-view roots —
+;; ships as a separate Maven artefact so apps that don't render server-
+;; side don't drag the namespace, the HTML emitter, the FNV-1a hash
+;; machinery, the response-accumulator bookkeeping, the projector
+;; registry kind, or any of the `:rf.ssr/*` / `:rf.server/*` trace
+;; strings onto the classpath.
 ;;
 ;; Consumers add this artefact alongside the core artefact:
 ;;
@@ -25,10 +27,11 @@
 ;; And require `re-frame.ssr` in any namespace that calls
 ;; `rf/render-to-string`, `rf/render-tree-hash`, `rf/reg-error-projector`,
 ;; `rf/project-error`, dispatches `:rf/hydrate`, or relies on the
-;; `:rf.server/*` fxs / `[:rf/response]` accumulator — loading the
-;; namespace registers the six `:rf.server/*` fxs, the `:rf/hydrate`
-;; handler, and publishes the late-bind hooks (`:ssr/render-tree-hash`)
-;; and the plain-atom adapter's `:render-to-string` slot.
+;; `:rf.server/*` fxs / the per-request response accumulator (read via
+;; `re-frame.ssr/get-response`) — loading the namespace registers the
+;; six `:rf.server/*` fxs, the `:rf/hydrate` handler, and publishes the
+;; late-bind hooks (`:ssr/render-tree-hash`) and the plain-atom adapter's
+;; `:render-to-string` slot.
 ;;
 ;; Per Spec 006 §Adapter shipping convention (and the
 ;; rf2-p7va extension to per-feature splits): this artefact depends on

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -97,8 +97,13 @@
 (def ^:private fnv-1a-32             hash/fnv-1a-32)
 (def adapter                         adapter-ns/adapter)
 (def verify-hydration!               hydrate/verify-hydration!)
-(def response-path                   response/response-path)
 (def default-response                response/default-response)
+;; framework-private — Spec 011 §Response storage substrate (rf2-jbcmt).
+;; The accumulator lives in a side-channel atom keyed by frame-id, NOT
+;; in app-db, so it cannot ride the hydration payload to the client and
+;; per-fx writes are O(small-map) rather than a full app-db replacement.
+;; Tests reach the var via `(resolve 're-frame.ssr/response-slots)`.
+(def ^:private response-slots        response/response-slots)
 (def public-error-keys               error-projector/public-error-keys)
 (def fallback-public-error           error-projector/fallback-public-error)
 (def default-error-projector-fn      error-projector/default-error-projector-fn)
@@ -232,9 +237,12 @@ Per Spec 011 §Server-only `reg-cofx` for request context."
 (late-bind/set-fn! :ssr/render-to-string    render-to-string)
 (late-bind/set-fn! :ssr/reg-error-projector reg-error-projector)
 (late-bind/set-fn! :ssr/project-error       project-error)
-;; rf2-fcj33 — per-request frame teardown. `frame/destroy-frame!` looks up
-;; this hook and clears the SSR side-channel atoms (`pending-error-traces`,
-;; `request-slots`) for the destroyed frame.
+;; rf2-fcj33 + rf2-jbcmt — per-request frame teardown. `frame/destroy-frame!`
+;; looks up this hook and clears the SSR side-channel atoms
+;; (`pending-error-traces`, `request-slots`, `response-slots`) for the
+;; destroyed frame. `response-slots` joined the set under rf2-jbcmt when
+;; the `:rf/response` accumulator moved off `app-db` to plug the hydration-
+;; payload leak / per-fx full-app-db swap.
 (late-bind/set-fn! :ssr/on-frame-destroyed  on-frame-destroyed!)
 
 ;; rf2-4dra9 — `re-frame.ssr.head` is required from the top-of-file ns

--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -187,7 +187,9 @@
 (defn render-to-string
   "Pure hiccup → HTML string. Per Spec 011 §The render-tree → HTML
   emitter. Returns a STRING. The structural hash (`render-tree-hash`)
-  and HTTP response (`[:rf/response]`) are separate surfaces.
+  and the HTTP response accumulator (`re-frame.ssr/get-response`, backed
+  by the framework-private `response-slots` side-channel atom per
+  rf2-jbcmt — Spec 011 §Response storage substrate) are separate surfaces.
 
   Implements HTML5 void elements, :tag#id.cls parsing, boolean attrs,
   text/attr escaping, registered-view resolution, var-reference

--- a/implementation/ssr/src/re_frame/ssr/request.cljc
+++ b/implementation/ssr/src/re_frame/ssr/request.cljc
@@ -39,7 +39,8 @@
 
   Per the rf2-gxgo7 split of re-frame.ssr."
   (:require [re-frame.late-bind :as late-bind]
-            [re-frame.ssr.error-listener :as error-listener]))
+            [re-frame.ssr.error-listener :as error-listener]
+            [re-frame.ssr.response :as response]))
 
 (defonce
   ^{:doc "Per-frame storage for the active HTTP request. Keys are
@@ -93,27 +94,33 @@
 ;; ---- per-request frame teardown (rf2-fcj33) -------------------------------
 ;;
 ;; Per Spec 011 §Per-request frame teardown contract. The SSR runtime owns
-;; two side-channel `defonce` atoms keyed by frame-id — `pending-error-
-;; traces` (per-frame buffer of captured error trace events, in
-;; `re-frame.ssr.error-projector`) and `request-slots` (per-frame
-;; HTTP-request map, here). Both live outside app-db (see the rationale
-;; comments above each defonce) and so are NOT cleared by the frame's
-;; app-db / sub-cache teardown in `frame/destroy-frame!`.
+;; three side-channel `defonce` atoms keyed by frame-id —
+;; `pending-error-traces` (per-frame buffer of captured error trace events,
+;; in `re-frame.ssr.error-listener`), `request-slots` (per-frame HTTP-request
+;; map, here), and `response-slots` (per-frame HTTP response accumulator,
+;; in `re-frame.ssr.response` — rf2-jbcmt moved this off `app-db`). All three
+;; live outside app-db (see the rationale comments above each defonce) and
+;; so are NOT cleared by the frame's app-db / sub-cache teardown in
+;; `frame/destroy-frame!`.
 ;;
 ;; This fn is the cleanup hook. Wired into `frame/destroy-frame!` via the
 ;; `:ssr/on-frame-destroyed` late-bind key — `core` calls it from its
 ;; ordered teardown step list when the SSR artefact is on the classpath;
 ;; the hook resolves to nil and the destroy proceeds without it when the
 ;; SSR artefact is absent. Idempotent: tolerates a frame-id with no slot
-;; in either atom.
+;; in any of the three atoms.
 
 (defn on-frame-destroyed!
   "Per Spec 011 §Per-request frame teardown contract (rf2-fcj33). Drop
-  the per-frame entries in `pending-error-traces` and `request-slots`
-  for `frame-id`. Called from `frame/destroy-frame!` via the
-  `:ssr/on-frame-destroyed` late-bind hook. Idempotent — a second call
-  against the same frame-id sees both atoms already cleared and does
-  nothing.
+  the per-frame entries in `pending-error-traces`, `request-slots`, and
+  `response-slots` for `frame-id`. Called from `frame/destroy-frame!`
+  via the `:ssr/on-frame-destroyed` late-bind hook. Idempotent — a
+  second call against the same frame-id sees the atoms already cleared
+  and does nothing.
+
+  Per rf2-jbcmt the `response-slots` side-channel was added to plug the
+  `:rf/response` hydration-payload leak / per-fx full-app-db swap; this
+  hook releases that slot symmetrically with the request slot.
 
   Per rf2-4dra9 (Spec 011 §Head/meta contract), also invokes any
   registered `:ssr/head-on-frame-destroyed` hook so `re-frame.ssr.head`
@@ -122,6 +129,7 @@
   [frame-id]
   (error-listener/clear-pending-error-traces! frame-id)
   (swap! request-slots dissoc frame-id)
+  (response/clear-response! frame-id)
   (when-let [head-cleanup! (late-bind/get-fn :ssr/head-on-frame-destroyed)]
     (try (head-cleanup! frame-id)
          (catch #?(:clj Throwable :cljs :default) _ nil)))

--- a/implementation/ssr/src/re_frame/ssr/response.cljc
+++ b/implementation/ssr/src/re_frame/ssr/response.cljc
@@ -2,10 +2,34 @@
   "HTTP response accumulator + handler fns for the six `:rf.server/*`
   server-side fxs. Per Spec 011 §HTTP response contract.
 
-  The runtime owns a per-request response accumulator at `[:rf/response]`
-  in the request frame's app-db. Standard server-only fx populate the
-  slot during the drain; the host adapter consumes the resolved value
-  after drain to build the wire response.
+  The runtime owns a per-request response accumulator in a
+  framework-private side-channel atom keyed by frame-id — `response-slots`
+  below. Standard server-only fx populate the slot during the drain;
+  the host adapter consumes the resolved value after drain to build the
+  wire response.
+
+  Storage substrate (rf2-jbcmt). Per Spec 011 §Response storage substrate
+  the accumulator MUST NOT ride `app-db`. The substrate symmetry with
+  `request-slots` is intentional:
+
+  - **Privacy.** `app-db` is the hydration payload's source (the
+    `:rf/app-db` slice ships to the client on bootstrap). The response
+    accumulator routinely carries server-only data — `Set-Cookie`
+    headers (auth tokens, session ids), internal `X-*` headers, redirect
+    URLs that may encode internal hostnames or secrets. Storing the
+    accumulator in `app-db` would default-leak that surface onto the
+    wire and force every host adapter to remember a defensive
+    `(dissoc :rf/response)` before serialising the payload — a privacy
+    boundary that's a constant caller-vigilance burden is a leak waiting
+    to happen. Side-channel storage makes the boundary self-enforcing.
+  - **Perf.** Pre-rf2-jbcmt every `:rf.server/*` fx swapped the WHOLE
+    app-db container (`read-container → assoc → replace-container!`)
+    just to update the accumulator. For a 7-fx response shape (typical
+    login flow: `set-status` + 2× `set-cookie` + 3× `set-header` +
+    `redirect`), that's seven full-app-db replacements per request —
+    each one allocating a fresh container value with one key changed.
+    The side-channel swap is O(small-map): one atom CAS against a
+    `{frame-id → response-map}` table.
 
   Default shape (Spec 011 §HTTP response contract):
 
@@ -29,16 +53,24 @@
   depends on the projector's drain — `response-of` here is the pure
   read used both internally and by the listener module.
 
+  `clear-response!` is called by `re-frame.ssr.request/on-frame-destroyed!`
+  via the `:ssr/on-frame-destroyed` late-bind hook (rf2-fcj33) so the
+  slot is released on per-request frame teardown.
+
   Per the rf2-gxgo7 split of re-frame.ssr."
   (:require [clojure.string]
-            [re-frame.frame :as frame]
-            [re-frame.substrate.adapter :as adapter]
             [re-frame.trace :as trace]))
 
-(def response-path
-  "App-db path holding the per-request HTTP response accumulator.
-  Per Spec 011 §HTTP response contract."
-  [:rf/response])
+(defonce
+  ^{:doc "Per-frame storage for the HTTP response accumulator. Keys are
+  frame-ids; values are the accumulator map (`{:status :headers :cookies
+  :redirect ...}` plus internal `:rf.server/_status-writes` /
+  `:rf.server/_redirect-writes` bookkeeping). Framework-private —
+  not stored in `app-db` so the accumulator never rides the hydration
+  payload to the client (Spec 011 §Response storage substrate, rf2-jbcmt).
+  Cleared per-frame by the `:ssr/on-frame-destroyed` hook (rf2-fcj33)."}
+  response-slots
+  (atom {}))
 
 (def status-writes-key   :rf.server/_status-writes)
 (def redirect-writes-key :rf.server/_redirect-writes)
@@ -53,7 +85,7 @@
    :redirect nil})
 
 (defn ensure-response
-  "Return resp with defaults applied. nil-tolerant — a frame whose app-db
+  "Return resp with defaults applied. nil-tolerant — a frame whose slot
   has never been touched by an :rf.server/* fx still resolves to the
   default response shape."
   [resp]
@@ -62,21 +94,28 @@
     (default-response)))
 
 (defn swap-response!
-  "Mutate the response accumulator in the frame's app-db with f. Returns
-  the post-swap response map. No-op when the frame is unknown / destroyed
-  (an explicit trace fires elsewhere; we don't double-trace here)."
+  "Mutate the response accumulator slot for `frame-id` with `f`. Returns
+  the post-swap response map. The substrate is a side-channel atom keyed
+  on frame-id (rf2-jbcmt) — O(small-map) swap, no app-db ping-pong."
   [frame-id f]
-  (when-let [container (frame/get-frame-db frame-id)]
-    (let [before (adapter/read-container container)
-          after  (update before :rf/response #(f (ensure-response %)))]
-      (adapter/replace-container! container after)
-      (:rf/response after))))
+  (let [next-resp (-> (swap! response-slots
+                             update frame-id #(f (ensure-response %)))
+                      (get frame-id))]
+    next-resp))
 
 (defn response-of
   "Read the current response accumulator (with defaults applied)."
   [frame-id]
-  (when-let [container (frame/get-frame-db frame-id)]
-    (ensure-response (:rf/response (adapter/read-container container)))))
+  (ensure-response (get @response-slots frame-id)))
+
+(defn clear-response!
+  "Drop `frame-id`'s response slot. Called from
+  `re-frame.ssr.request/on-frame-destroyed!` via the
+  `:ssr/on-frame-destroyed` late-bind hook (rf2-fcj33). Idempotent —
+  tolerates a frame-id with no slot."
+  [frame-id]
+  (swap! response-slots dissoc frame-id)
+  frame-id)
 
 ;; ---- header helpers ------------------------------------------------------
 

--- a/implementation/ssr/test/re_frame/ssr_compatibility_checks_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_compatibility_checks_test.clj
@@ -24,6 +24,11 @@
   (reset! frame/frames {})
   (reset! flows/flows {})
   (reset! schemas/schemas-by-frame {})
+  (reset! ssr/request-slots {})
+  (when-let [v (resolve 're-frame.ssr/response-slots)]
+    (reset! @v {}))
+  (when-let [v (resolve 're-frame.ssr/pending-error-traces)]
+    (reset! @v {}))
   (rf/init! ssr/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr    :reload)

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -42,6 +42,16 @@
   (reset! frame/frames {})
   (reset! flows/flows {})
   (reset! schemas/schemas-by-frame {})
+  ;; SSR side-channel atoms keyed on frame-id (per Spec 011 §Per-request
+  ;; frame teardown contract). The response-slots and pending-error-traces
+  ;; vars are framework-private (^:private at the façade); resolve them
+  ;; reflectively so process-wide stale entries from prior tests can't bleed
+  ;; into this one. request-slots is public; reset directly.
+  (reset! ssr/request-slots {})
+  (when-let [v (resolve 're-frame.ssr/response-slots)]
+    (reset! @v {}))
+  (when-let [v (resolve 're-frame.ssr/pending-error-traces)]
+    (reset! @v {}))
   (rf/init! ssr/adapter)
   ;; Framework registrations happen at namespace-load time in
   ;; routing.cljc / ssr.cljc / machines.cljc; clear-all! wiped them, so

--- a/implementation/ssr/test/re_frame/ssr_head_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_head_test.clj
@@ -31,12 +31,15 @@
   (reset! schemas/schemas-by-frame {})
   (reset! head/head-snapshots {})
   (reset! ssr/request-slots {})
-  ;; The defonce-backed `pending-error-traces` atom in re-frame.ssr is
-  ;; private; reach it reflectively. Resetting between tests prevents
-  ;; the load-test downstream from inheriting stale entries left by
-  ;; earlier suites — the ssr-head tests themselves don't drive any
-  ;; error-projection path, but the defonce atom is process-wide.
+  ;; The defonce-backed `pending-error-traces` and `response-slots` atoms
+  ;; in re-frame.ssr are framework-private; reach them reflectively.
+  ;; Resetting between tests prevents the load-test downstream from
+  ;; inheriting stale entries left by earlier suites — the ssr-head
+  ;; tests themselves don't drive any error-projection or response-fx
+  ;; path, but the defonce atoms are process-wide.
   (when-let [v (resolve 're-frame.ssr/pending-error-traces)]
+    (reset! @v {}))
+  (when-let [v (resolve 're-frame.ssr/response-slots)]
     (reset! @v {}))
   (rf/init! ssr/adapter)
   ;; Resurrect ns-load-time registrations after clear-all!.

--- a/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
@@ -34,6 +34,10 @@
   (reset! flows/flows {})
   (reset! schemas/schemas-by-frame {})
   (reset! ssr/request-slots {})
+  (when-let [v (resolve 're-frame.ssr/response-slots)]
+    (reset! @v {}))
+  (when-let [v (resolve 're-frame.ssr/pending-error-traces)]
+    (reset! @v {}))
   (rf/init! ssr/adapter)
   ;; Namespace-load-time registrations get wiped by clear-all!; reload
   ;; so :rf/hydrate, :rf.server/* fxs, AND the :rf.server/request cofx

--- a/implementation/ssr/test/re_frame/ssr_source_coord_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_source_coord_test.clj
@@ -30,6 +30,11 @@
   (reset! frame/frames {})
   (reset! flows/flows {})
   (reset! schemas/schemas-by-frame {})
+  (reset! ssr/request-slots {})
+  (when-let [v (resolve 're-frame.ssr/response-slots)]
+    (reset! @v {}))
+  (when-let [v (resolve 're-frame.ssr/pending-error-traces)]
+    (reset! @v {}))
   (when-let [li-var (resolve 're-frame.flows/last-inputs)]
     (reset! (deref li-var) {}))
   (rf/init! ssr/adapter)

--- a/implementation/ssr/test/re_frame/ssr_teardown_load_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_teardown_load_test.clj
@@ -13,8 +13,10 @@
 
     1. The frame record (app-db, router queue, drain-lock, sub-cache,
        lifecycle, config) — owned by `re-frame.frame/frames`.
-    2. `:rf/response` accumulator — inside the frame's app-db; rides with
-       the frame.
+    2. HTTP response accumulator — owned by
+       `re-frame.ssr/response-slots`, a defonce side-channel atom keyed
+       by frame-id (rf2-jbcmt moved this off app-db to plug a hydration-
+       payload leak + per-fx full-app-db swap).
     3. Per-frame pending-error-traces buffer — owned by
        `re-frame.ssr/pending-error-traces`, a defonce side-channel atom
        keyed by frame-id.
@@ -32,9 +34,9 @@
        leftover per-request frames). Verifies the frame record itself
        releases.
     b. After every iteration, the SSR side-channel atoms
-       (`pending-error-traces`, `request-slots`) are back to baseline.
-       Verifies the `:ssr/on-frame-destroyed` hook (rf2-fcj33) fires and
-       clears both slots.
+       (`pending-error-traces`, `request-slots`, `response-slots`) are
+       back to baseline. Verifies the `:ssr/on-frame-destroyed` hook
+       (rf2-fcj33 / rf2-jbcmt) fires and clears every slot.
     c. After a triggered GC, the JVM heap delta is small relative to
        the total bytes the test churned — proves no large object graph
        is retained past frame destruction.
@@ -63,6 +65,13 @@
   (reset! frame/frames {})
   (reset! flows/flows {})
   (reset! schemas/schemas-by-frame {})
+  (reset! ssr/request-slots {})
+  ;; Framework-private SSR side-channel atoms — reach via resolve so
+  ;; process-wide stale entries can't bleed across fixtures.
+  (when-let [v (resolve 're-frame.ssr/response-slots)]
+    (reset! @v {}))
+  (when-let [v (resolve 're-frame.ssr/pending-error-traces)]
+    (reset! @v {}))
   (rf/init! ssr/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
@@ -93,6 +102,21 @@
   with the private-deref above."
   []
   @ssr/request-slots)
+
+(defn- response-slots-atom
+  "Return the `re-frame.ssr/response-slots` atom. It's `^:private` at the
+  façade (per Spec 011 §Response storage substrate, rf2-jbcmt — the
+  accumulator's framework-private side-channel slot) so we resolve the
+  Var reflectively, like `pending-error-traces`."
+  []
+  (deref (or (resolve 're-frame.ssr/response-slots)
+             (throw (ex-info "Cannot resolve re-frame.ssr/response-slots — ns layout changed?"
+                             {})))))
+
+(defn- response-slots-snapshot
+  "Snapshot the current value of the per-frame response-accumulator atom."
+  []
+  @(response-slots-atom))
 
 (defn- non-default-frame-ids
   "Every frame-id currently registered, minus `:rf/default`. Per-request
@@ -142,11 +166,18 @@
 
 (defn- install-registry!
   "Register the events + view the load test uses. Called once per test;
-  the runtime reset between tests wipes everything."
+  the runtime reset between tests wipes everything.
+
+  `:load-test/server-init` fires `:rf.server/set-header` so each request
+  writes to `response-slots` — exercises the side-channel that needs
+  cleanup on frame destroy (per Spec 011 §Response storage substrate,
+  rf2-jbcmt)."
   []
-  (rf/reg-event-db :load-test/server-init
-    (fn [db [_ {:keys [i]}]]
-      (assoc db :i i :rf/route {:id :route/load})))
+  (rf/reg-event-fx :load-test/server-init
+    {:platforms #{:server}}
+    (fn [{:keys [db]} [_ {:keys [i]}]]
+      {:db (assoc db :i i :rf/route {:id :route/load})
+       :fx [[:rf.server/set-header {:name "X-Load-Test" :value (str i)}]]}))
   (rf/reg-view* :load-test/page
     (fn []
       [:div.page
@@ -177,6 +208,7 @@
         baseline-frames        (count (non-default-frame-ids))
         baseline-pending       (count (pending-error-traces-snapshot))
         baseline-requests      (count (request-slots-snapshot))
+        baseline-responses     (count (response-slots-snapshot))
         baseline-heap          (heap-bytes)
         start-ns               (System/nanoTime)]
     (dotimes [i n] (one-request! i))
@@ -185,20 +217,23 @@
           end-frames     (count (non-default-frame-ids))
           end-pending    (count (pending-error-traces-snapshot))
           end-requests   (count (request-slots-snapshot))
+          end-responses  (count (response-slots-snapshot))
           duration-ms    (/ (- end-ns start-ns) 1e6)]
-      {:n                 n
-       :duration-ms       duration-ms
-       :req-per-sec       (long (/ n (/ duration-ms 1e3)))
-       :baseline-frames   baseline-frames
-       :end-frames        end-frames
-       :baseline-pending  baseline-pending
-       :end-pending       end-pending
-       :baseline-requests baseline-requests
-       :end-requests      end-requests
-       :baseline-heap-mb  (/ baseline-heap 1024.0 1024.0)
-       :end-heap-mb       (/ end-heap 1024.0 1024.0)
-       :heap-delta-mb     (/ (- end-heap baseline-heap) 1024.0 1024.0)
-       :bytes-per-req     (long (/ (- end-heap baseline-heap) (max 1 n)))})))
+      {:n                  n
+       :duration-ms        duration-ms
+       :req-per-sec        (long (/ n (/ duration-ms 1e3)))
+       :baseline-frames    baseline-frames
+       :end-frames         end-frames
+       :baseline-pending   baseline-pending
+       :end-pending        end-pending
+       :baseline-requests  baseline-requests
+       :end-requests       end-requests
+       :baseline-responses baseline-responses
+       :end-responses      end-responses
+       :baseline-heap-mb   (/ baseline-heap 1024.0 1024.0)
+       :end-heap-mb        (/ end-heap 1024.0 1024.0)
+       :heap-delta-mb      (/ (- end-heap baseline-heap) 1024.0 1024.0)
+       :bytes-per-req      (long (/ (- end-heap baseline-heap) (max 1 n)))})))
 
 ;; ---- the test -------------------------------------------------------------
 
@@ -229,6 +264,15 @@
                "the hook isn't wired into frame/destroy-frame! — and "
                "this test intentionally omits clear-request! so the "
                "destroy hook is the ONLY release path."))
+      (is (= 0 (:end-responses result))
+          (str "response-slots leaked across destroy-frame! — "
+               "end-count " (:end-responses result) " > 0; the "
+               ":ssr/on-frame-destroyed hook didn't clear the slot. "
+               "Per Spec 011 §Response storage substrate (rf2-jbcmt) "
+               "the accumulator is a per-frame side-channel atom whose "
+               "release path is the destroy-frame! teardown hook; each "
+               "request fires :rf.server/set-header so the slot is "
+               "populated then must be cleared."))
 
       ;; (c) Heap delta. Each request allocates ~a few KB of transient
       ;; state — frame record, drain ctx, render-tree, response map,

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -341,7 +341,7 @@ The `:platforms #{:server}` gate on the cofx itself is orthogonal to substrate c
 
 ### HTTP response contract
 
-SSR is **not just HTML + state** — it is a full HTTP response. The runtime owns a per-request **response accumulator** at `:rf/response` in the request frame's effect-layer; the canonical shape is registered as `:rf/response` in [Spec-Schemas](Spec-Schemas.md#rfresponse). Standard server-only fx populate the slot during the drain; the host adapter consumes the resolved value to build the wire response.
+SSR is **not just HTML + state** — it is a full HTTP response. The runtime owns a per-request **response accumulator** keyed on the request frame's frame-id; the canonical shape is registered as `:rf/response` in [Spec-Schemas](Spec-Schemas.md#rfresponse). Standard server-only fx populate the slot during the drain; the host adapter consumes the resolved value (via `re-frame.ssr/get-response`) to build the wire response.
 
 The accumulator's default shape:
 
@@ -351,6 +351,15 @@ The accumulator's default shape:
  :cookies  []
  :redirect nil}
 ```
+
+#### Response storage substrate
+
+The response accumulator's **storage substrate** is normative for the same reasons as the request slot's ([§Request storage substrate](#request-storage-substrate)) — getting it wrong has direct privacy and performance consequences (rf2-jbcmt).
+
+- **MUST NOT ride `app-db`.** The response accumulator MUST NOT be stored under any key in `app-db` — neither the request frame's nor any other frame's. `app-db` is the **hydration payload's source** ([§Payload scope](#payload-scope-canonical-boundary), `:rf/app-db`): every value in it is a candidate to ship to the client on bootstrap. The response accumulator routinely carries server-only data — `Set-Cookie` headers (auth tokens, session ids), internal `X-*` headers, redirect URLs that may encode internal hostnames — whose leakage to the client is a security incident. The hydration boundary must remain shippable-without-redaction; storing the accumulator in `app-db` would default-leak that surface onto the wire and force every host adapter to remember a defensive `(dissoc :rf/response)` before serialising the payload. A privacy boundary that's a constant caller-vigilance burden is a leak waiting to happen; side-channel storage makes the boundary self-enforcing.
+- **MUST use a framework-private side-channel keyed on frame-id.** The substrate is **per-frame** so two simultaneous per-request frames (the canonical SSR shape under concurrent load) carry independent accumulators that cannot bleed into each other. The slot is **framework-private** — not a public app-db key, not a registered subscription — read exclusively by the runtime (via `re-frame.ssr/get-response`) and written exclusively by the six `:rf.server/*` fxs and the projector's status-stamp. The CLJS reference uses a `defonce` atom keyed by frame-id (mirroring `request-slots` and `pending-error-traces`); a JVM-only port may equivalently use a `ConcurrentHashMap`; any other-language port chooses its own concurrent-map shape. The **contract** is what's pinned — *not* the data structure: per-frame isolation, framework-private access, and exclusion from `app-db`.
+- **Per-fx writes MUST be O(small-map).** A naïve implementation that stored the accumulator in `app-db` paid a full app-db replacement on every `:rf.server/*` fx (`read-container → assoc → replace-container!`); for a 7-fx response shape (typical login flow: `set-status` + 2× `set-cookie` + 3× `set-header` + `redirect`), that's seven full-app-db replacements per request. The side-channel substrate's swap is O(small-map): one atom CAS against a `{frame-id → response-map}` table. The contract is the algorithmic class — per-fx response writes scale with the response shape, not with app-db size.
+- **Runtime MUST clear the slot on frame teardown.** Per [§Per-request frame teardown contract](#per-request-frame-teardown-contract) the slot MUST be released when the request frame is destroyed. The CLJS reference clears via the `:ssr/on-frame-destroyed` late-bind hook (rf2-fcj33) — the same hook that drops the request slot and the pending-error-trace buffer.
 
 #### Standard fx
 
@@ -760,7 +769,7 @@ The framework owns the following per-frame allocation sites; **all MUST be relea
 | `app-db` (the frame's state container) | `re-frame.frame`           | per-frame, on the frame record                   | the frame record is dropped (`dissoc-frame!`) |
 | router queue + drain-lock            | `re-frame.frame`           | per-frame, on the frame record                   | the frame record is dropped                   |
 | sub-cache                            | `re-frame.subs`            | per-frame, on the frame record                   | `tear-down-sub-cache!` disposes every cached reaction; the cache atom is reset to `{}` |
-| `:rf/response` accumulator           | `re-frame.ssr`             | inside the frame's `app-db`                      | rides with the app-db on the frame record     |
+| HTTP response accumulator            | `re-frame.ssr`             | `defonce` atom keyed by frame-id, side-channel (rf2-jbcmt) | the `:ssr/on-frame-destroyed` hook (rf2-fcj33) drops the slot |
 | pending error-trace buffer           | `re-frame.ssr`             | `defonce` atom keyed by frame-id, side-channel   | the `:ssr/on-frame-destroyed` hook (rf2-fcj33) drops the slot |
 | per-frame HTTP request slot          | `re-frame.ssr`             | `defonce` atom keyed by frame-id, side-channel   | the `:ssr/on-frame-destroyed` hook (rf2-fcj33) drops the slot; host adapters MAY also clear inline via `clear-request!` |
 | epoch ring buffer                    | `re-frame.epoch`           | `defonce` atom keyed by frame-id                 | the `:epoch/on-frame-destroyed` hook (rf2-d656) drops the slot |
@@ -814,6 +823,10 @@ Earlier drafts of [§Head/meta contract](#headmeta-contract) carried a deferral 
 ### `:rf.ssr/check-version` and `:rf.ssr/check-schema-digest` are framework-registered (rf2-69ad2)
 
 Per [§The `:rf/hydrate` event](#the-rfhydrate-event) the reference `:rf/hydrate` handler dispatches `:rf.ssr/check-version` and (when payload carries a digest) `:rf.ssr/check-schema-digest`. Both fxs are registered by `re-frame.ssr` at ns-load time with `:platforms #{:client}`; version-mismatch emits `:rf.ssr/version-mismatch`, schema-digest-mismatch emits `:rf.ssr/schema-digest-mismatch`. Earlier drafts named both events in normative prose but registered neither — a silent `:rf.error/no-such-handler` trace at hydration time was the visible symptom. The two-handler set is locked; apps that want app-specific checks register additional handlers, they don't replace these.
+
+### HTTP response accumulator stored in a side-channel atom, not in app-db (rf2-jbcmt)
+
+Per [§Response storage substrate](#response-storage-substrate) the per-request HTTP response accumulator MUST live in a framework-private side-channel atom keyed by frame-id (mirroring `request-slots` and `pending-error-traces`), NOT under any path in `app-db`. Earlier drafts pinned the accumulator at the `[:rf/response]` app-db path; the rf2-jbcmt audit (parent rf2-asmj1) identified two failures of that placement: (a) the hydration payload at `ssr-ring/build-payload` ships the whole app-db by default, so the response accumulator — including `Set-Cookie` auth tokens and internal `X-*` headers — defaulted to riding the wire to the client; (b) every `:rf.server/*` fx swapped the whole app-db container (read → assoc → replace) to update the accumulator, allocating a fresh app-db value per fx call. Moving the substrate to a side-channel atom makes the privacy boundary self-enforcing (the accumulator cannot be misconfigured into the payload) and reduces per-fx writes to an O(small-map) atom CAS. The CLJS reference's `re-frame.ssr/response-slots` is `^:private`; tests reach it via `(resolve 're-frame.ssr/response-slots)` for between-fixture reset.
 
 ### SSR ships in a separate Maven artefact (`day8/re-frame2-ssr`)
 

--- a/spec/conformance/fixtures/cross-spec-route-not-found-ssr-status.edn
+++ b/spec/conformance/fixtures/cross-spec-route-not-found-ssr-status.edn
@@ -51,16 +51,16 @@
 
  :fixture/expect
  ;; Submap match: the :rf/route slice carries the not-found marker, the
- ;; on-match analytics ran, and :rf/response carries the projector's
- ;; locked 404 status.
+ ;; on-match analytics ran. Per rf2-jbcmt the response accumulator lives
+ ;; in a framework-private side-channel atom (re-frame.ssr/response-slots),
+ ;; NOT in app-db — the projector's locked 404 status is asserted via
+ ;; :ssr/public-error below.
  {:final-app-db
   {:rf/route    {:id     :rf.route/not-found
                  :params {:url "/missing"}
                  :query  {}
                  :error  nil}
-   :analytics   {:last-404 true}
-   :rf/response {:status   404
-                 :redirect nil}}
+   :analytics   {:last-404 true}}
 
   :trace-emissions
   [{:operation :event :tags {:event-id :rf/server-init}}

--- a/spec/conformance/fixtures/cross-spec-ssr-machine-error.edn
+++ b/spec/conformance/fixtures/cross-spec-ssr-machine-error.edn
@@ -56,8 +56,10 @@
 
  :fixture/expect
  ;; Machine snapshot was NOT committed — no :rf/machines slot in app-db.
- ;; The error projector ran and stamped :status 500 onto :rf/response.
- {:final-app-db {:rf/response {:status 500 :redirect nil}}
+ ;; Per rf2-jbcmt the response accumulator lives in a framework-private
+ ;; side-channel atom, NOT in app-db — the projector's locked 500 status
+ ;; is asserted via :ssr/public-error below.
+ {:final-app-db {}
 
   :trace-emissions
   [{:operation :event :tags {:event-id :rf/server-init}}

--- a/spec/conformance/fixtures/ssr-cookie.edn
+++ b/spec/conformance/fixtures/ssr-cookie.edn
@@ -33,16 +33,11 @@
  :fixture/dispatches []
 
  :fixture/expect
- ;; Submap match — assert the framework-populated :rf/response slot
- ;; carries the cookie. Other keys (status defaults, headers) tolerated.
- {:final-app-db
-  {:rf/response {:cookies [{:name      "session"
-                            :value     "abc123"
-                            :max-age   3600
-                            :secure    true
-                            :http-only true
-                            :same-site :lax
-                            :path      "/"}]}}
+ ;; Submap match. Per rf2-jbcmt the :rf/response accumulator lives in a
+ ;; framework-private side-channel atom (re-frame.ssr/response-slots),
+ ;; NOT in app-db — so the fixture pins the cookie shape via
+ ;; :ssr/request-result rather than :final-app-db.
+ {:final-app-db {}
 
   :ssr/request-result
   {:response {:status  200

--- a/spec/conformance/fixtures/ssr-error-known-mapping.edn
+++ b/spec/conformance/fixtures/ssr-error-known-mapping.edn
@@ -38,14 +38,12 @@
 
  :fixture/expect
  {;; The runtime's error-projection listener writes :status 404 to the
-  ;; response accumulator. This is what asserting the PROJECTOR's
-  ;; output (rather than a user-stub-rolled fx call) looks like:
-  ;; the :rf/response slot reflects the public-error's :status because
-  ;; the projector ran, not because the fixture body emits
-  ;; :rf.server/set-status.
-  :final-app-db
-  {:rf/response {:status 404
-                 :redirect nil}}
+  ;; response accumulator (a framework-private side-channel atom keyed
+  ;; on frame-id, per rf2-jbcmt — Spec 011 §Response storage substrate).
+  ;; The accumulator is NOT in app-db, so :final-app-db carries no
+  ;; assertion on it; the projector's output is pinned via
+  ;; :ssr/public-error below.
+  :final-app-db {}
 
   ;; The internal trace records :rf.error/no-such-handler.
   :trace-emissions

--- a/spec/conformance/fixtures/ssr-error-sanitisation.edn
+++ b/spec/conformance/fixtures/ssr-error-sanitisation.edn
@@ -37,10 +37,12 @@
  :fixture/expect
  {;; The runtime's error-projection listener writes :status 500 to the
   ;; response accumulator (the locked generic-500 from the default
-  ;; projector). This is the projector's output reaching the wire.
-  :final-app-db
-  {:rf/response {:status 500
-                 :redirect nil}}
+  ;; projector). The accumulator is a framework-private side-channel
+  ;; atom keyed on frame-id (rf2-jbcmt) — NOT in app-db — so the
+  ;; projector's output is pinned via :ssr/public-error below; the
+  ;; final app-db is empty (the throw aborted the handler before any
+  ;; user-visible state could land).
+  :final-app-db {}
 
   ;; Internal trace event preserves full detail (for monitoring).
   :trace-emissions

--- a/spec/conformance/fixtures/ssr-redirect.edn
+++ b/spec/conformance/fixtures/ssr-redirect.edn
@@ -27,12 +27,12 @@
  :fixture/dispatches []                                              ;; the :on-create cascade is sufficient
 
  :fixture/expect
- ;; Submap match — assert the framework-populated :rf/response slot
- ;; carries the redirect AND the redirect's :status flowed through to
- ;; the top-level :status (per Spec 011 §Redirect precedence).
- {:final-app-db
-  {:rf/response {:status   302
-                 :redirect {:status 302 :location "/login"}}}
+ ;; Submap match. Per rf2-jbcmt the :rf/response accumulator lives in a
+ ;; framework-private side-channel atom (re-frame.ssr/response-slots),
+ ;; NOT in app-db — so the redirect shape is asserted via
+ ;; :ssr/request-result. Spec 011 §Redirect precedence: the redirect's
+ ;; :status flows through to the response :status.
+ {:final-app-db {}
 
   :ssr/request-result
   {:html     :absent                                                 ;; redirect truncates the body

--- a/spec/conformance/fixtures/ssr-set-status.edn
+++ b/spec/conformance/fixtures/ssr-set-status.edn
@@ -30,11 +30,12 @@
  :fixture/dispatches []
 
  :fixture/expect
- ;; Submap match — extra app-db keys (e.g. the framework-populated
- ;; :rf/response accumulator) are tolerated. We assert :page here AND
- ;; the :rf/response slot's :status so the runtime fx visibly fires.
- {:final-app-db {:page :not-found
-                 :rf/response {:status 404}}
+ ;; Submap match. Per rf2-jbcmt the :rf/response accumulator lives in a
+ ;; framework-private side-channel atom (re-frame.ssr/response-slots),
+ ;; NOT in app-db — so the fixture pins the response shape via
+ ;; :ssr/request-result and only the application-visible :page slot on
+ ;; :final-app-db.
+ {:final-app-db {:page :not-found}
 
   :ssr/request-result
   {:response {:status 404


### PR DESCRIPTION
## Summary

- Move the per-request HTTP response accumulator off `app-db` into a framework-private side-channel atom `re-frame.ssr/response-slots` keyed by frame-id, mirroring `request-slots` and `pending-error-traces`. Closes privacy leak: server-only Set-Cookie auth tokens, `X-*` headers, redirect targets no longer ride the hydration payload to the client. Closes perf cost: per-fx writes drop from full-app-db replacement (`read → assoc → replace`) to an O(small-map) atom CAS.
- Spec 011 gains §Response storage substrate; the per-request frame teardown table gains a `response-slots` row; §Resolved decisions gets the rf2-jbcmt entry. The `:ssr/on-frame-destroyed` late-bind hook (rf2-fcj33) now clears the new slot symmetrically with the request and pending-error-trace slots.
- New ssr-ring privacy regression `hydration-payload-omits-rf-response-accumulator` drives a login shape (status + secret cookie + secret header + append-header) and asserts: payload has public state; payload does NOT contain `:rf/response` or any secret values; response headers DO carry Set-Cookie / X-Secret-Header on the wire (where they belong). ssr_teardown_load_test extended with `response-slots-snapshot` probe + end-counts assertion.

Pre-alpha: NO back-compat. The seven conformance fixtures that asserted on `[:rf/response]` in `:final-app-db` move their assertions to `:ssr/public-error` / `:ssr/request-result`; the `re-frame.ssr/response-path` re-export is removed; tests reach the framework-private `response-slots` via `(resolve ...)` (same shape as `pending-error-traces`).

Parent audit: rf2-asmj1 (§Q13 / R11 / A3).

## Test plan

- [x] ssr JVM: 76 tests / 236 assertions / 0 failures (incl. load test ~9000 req/sec, response-slots returns to baseline)
- [x] ssr-ring JVM: 16 tests / 72 assertions / 0 failures (incl. new `hydration-payload-omits-rf-response-accumulator` privacy regression)
- [x] core JVM: 440 tests / 2309 assertions / 0 failures (conformance fixtures still pass with `:rf/response` dropped from `:final-app-db`)