### PR TITLE
refactor(pair2-mcp): tests require fns directly from source (drop hand-copies) (rf2-eke0l)

### DIFF
--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/nrepl.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/nrepl.cljs
@@ -70,10 +70,13 @@
 ;; bencode framing — handle concatenated frames in one TCP packet.
 ;; ---------------------------------------------------------------------------
 
-(defn- decode-all-frames
+(defn decode-all-frames
   "Decode every complete bencode frame from `buf`. Returns
   `[js-array-of-frames trailing-buffer]`. Walks via the package's
-  `position` after-decode marker so multi-frame TCP chunks parse fully."
+  `position` after-decode marker so multi-frame TCP chunks parse fully.
+
+  Public so `nrepl_test.cljs` can pin the contract directly rather than
+  re-implementing a parallel walker."
   [^js buf]
   (let [frames (array)]
     (loop [^js b buf]

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/cursor_pagination_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/cursor_pagination_test.cljs
@@ -8,119 +8,87 @@
   runtime ring surfaces as a `:rf.mcp/cursor-stale` error rather than
   silently restarting.
 
-  These tests mirror the private helpers from `tools.cljs`
-  (`parse-limit-arg`, `encode-cursor`, `decode-cursor`,
-  `cursor-stale-result`) and exercise the full host-side pagination
-  logic by simulating the runtime form's output. The live runtime
-  call sits behind the nREPL eval boundary and is covered by the
-  stdio-roundtrip harness; this layer pins the cursor contract."
+  These tests pin the private helpers in
+  `re-frame-pair2-mcp.tools.cursor` directly (`parse-limit-arg`,
+  `encode-cursor`, `decode-cursor`, `cursor-stale-result`) and exercise
+  the full host-side pagination logic by simulating the runtime form's
+  output. The live runtime call sits behind the nREPL eval boundary
+  and is covered by the stdio-roundtrip harness; this layer pins the
+  cursor contract."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [cljs.reader]
-            [clojure.string :as str]
-            [applied-science.js-interop :as j]))
+            [re-frame-pair2-mcp.tools.cursor :as cursor]))
 
-;; ---------------------------------------------------------------------------
-;; Mirrors of the private cursor helpers. Keep in lockstep with tools.cljs.
-;; ---------------------------------------------------------------------------
+(def default-limit cursor/default-limit)
 
-(def ^:private default-limit 50)
-
-(defn- parse-limit-arg [raw]
-  (cond
-    (or (nil? raw) (undefined? raw)) default-limit
-    (number? raw) (max 1 (long raw))
-    (string? raw) (let [n (js/parseInt raw 10)]
-                    (if (and (number? n) (not (js/isNaN n)))
-                      (max 1 (long n))
-                      default-limit))
-    :else default-limit))
-
-(defn- encode-cursor [payload]
-  (when (and (map? payload) (some? (:after-id payload)))
-    (let [edn (pr-str payload)
-          buf (js/Buffer.from edn "utf8")]
-      (.toString buf "base64"))))
-
-(defn- decode-cursor [s]
-  (cond
-    (or (nil? s) (undefined? s)) nil
-    (not (string? s)) ::malformed
-    (str/blank? s)    nil
-    :else
-    (try
-      (let [buf (js/Buffer.from s "base64")
-            edn (.toString buf "utf8")
-            v   (cljs.reader/read-string edn)]
-        (if (and (map? v) (string? (:after-id v)))
-          v
-          ::malformed))
-      (catch :default _ ::malformed))))
+;; The `decode-cursor` impl returns the malformed sentinel keyword
+;; from the source ns; tests assert against that same value.
+(def malformed :re-frame-pair2-mcp.tools.cursor/malformed)
 
 ;; ---------------------------------------------------------------------------
 ;; parse-limit-arg — MCP-arg normalisation.
 ;; ---------------------------------------------------------------------------
 
 (deftest parse-limit-default-when-absent
-  (is (= default-limit (parse-limit-arg nil)))
-  (is (= default-limit (parse-limit-arg js/undefined))))
+  (is (= default-limit (cursor/parse-limit-arg nil)))
+  (is (= default-limit (cursor/parse-limit-arg js/undefined))))
 
 (deftest parse-limit-positive-integer-pass-through
-  (is (= 10 (parse-limit-arg 10)))
-  (is (= 1  (parse-limit-arg 1)))
-  (is (= 1000 (parse-limit-arg 1000))))
+  (is (= 10 (cursor/parse-limit-arg 10)))
+  (is (= 1  (cursor/parse-limit-arg 1)))
+  (is (= 1000 (cursor/parse-limit-arg 1000))))
 
 (deftest parse-limit-clamps-non-positive-to-one
-  (is (= 1 (parse-limit-arg 0)))
-  (is (= 1 (parse-limit-arg -5))))
+  (is (= 1 (cursor/parse-limit-arg 0)))
+  (is (= 1 (cursor/parse-limit-arg -5))))
 
 (deftest parse-limit-parses-numeric-string
-  (is (= 25 (parse-limit-arg "25"))))
+  (is (= 25 (cursor/parse-limit-arg "25"))))
 
 (deftest parse-limit-non-numeric-string-falls-back
-  (is (= default-limit (parse-limit-arg "bogus"))))
+  (is (= default-limit (cursor/parse-limit-arg "bogus"))))
 
 ;; ---------------------------------------------------------------------------
 ;; encode-cursor / decode-cursor — opaque round-trip.
 ;; ---------------------------------------------------------------------------
 
 (deftest encode-cursor-nil-when-no-after-id
-  (is (nil? (encode-cursor nil)))
-  (is (nil? (encode-cursor {})))
-  (is (nil? (encode-cursor {:v 1 :after-id nil}))))
+  (is (nil? (cursor/encode-cursor nil)))
+  (is (nil? (cursor/encode-cursor {})))
+  (is (nil? (cursor/encode-cursor {:v 1 :after-id nil}))))
 
 (deftest encode-cursor-returns-string-on-valid-payload
-  (let [c (encode-cursor {:v 1 :after-id "abc"})]
+  (let [c (cursor/encode-cursor {:v 1 :after-id "abc"})]
     (is (string? c))
     (is (pos? (count c)))))
 
 (deftest cursor-round-trip-preserves-payload
   (let [payload {:v 1 :after-id "epoch-42" :ms 5000 :until-ms 1234567890
                  :frame :rf/default}
-        encoded (encode-cursor payload)
-        decoded (decode-cursor encoded)]
+        encoded (cursor/encode-cursor payload)
+        decoded (cursor/decode-cursor encoded)]
     (is (= payload decoded))))
 
 (deftest decode-cursor-nil-on-nil-input
-  (is (nil? (decode-cursor nil)))
-  (is (nil? (decode-cursor "")))
-  (is (nil? (decode-cursor js/undefined))))
+  (is (nil? (cursor/decode-cursor nil)))
+  (is (nil? (cursor/decode-cursor "")))
+  (is (nil? (cursor/decode-cursor js/undefined))))
 
 (deftest decode-cursor-malformed-on-junk
-  (is (= ::malformed (decode-cursor "not-real-base64-edn-juzlblahHFGYbn")))
-  (is (= ::malformed (decode-cursor 12345)))
+  (is (= malformed (cursor/decode-cursor "not-real-base64-edn-juzlblahHFGYbn")))
+  (is (= malformed (cursor/decode-cursor 12345)))
   ;; base64 of "not-a-map" — decodes but isn't a map with :after-id
   (let [bogus (.toString (js/Buffer.from "[1 2 3]" "utf8") "base64")]
-    (is (= ::malformed (decode-cursor bogus)))))
+    (is (= malformed (cursor/decode-cursor bogus)))))
 
 (deftest decode-cursor-malformed-on-missing-after-id
   (let [bogus (.toString (js/Buffer.from "{:v 1}" "utf8") "base64")]
-    (is (= ::malformed (decode-cursor bogus)))))
+    (is (= malformed (cursor/decode-cursor bogus)))))
 
 (deftest cursor-is-opaque-on-wire
   ;; The agent has no business decoding the cursor — but the encoding
   ;; MUST be a self-contained string (no embedded JSON-confusing chars
   ;; that would break round-trip through bencode + JSON-RPC).
-  (let [c (encode-cursor {:v 1 :after-id "abc-def"})]
+  (let [c (cursor/encode-cursor {:v 1 :after-id "abc-def"})]
     (is (re-matches #"^[A-Za-z0-9+/=]+$" c))))
 
 ;; ---------------------------------------------------------------------------
@@ -200,9 +168,9 @@
                                           :until-ms 99999999
                                           :limit 10})
         ;; Cursor encodes "epoch-9"
-        cursor (encode-cursor {:v 1 :after-id (:next-id page-1)
-                               :until-ms 99999999 :ms nil :frame nil})
-        decoded (decode-cursor cursor)
+        cursor-str (cursor/encode-cursor {:v 1 :after-id (:next-id page-1)
+                                          :until-ms 99999999 :ms nil :frame nil})
+        decoded (cursor/decode-cursor cursor-str)
         ;; Second call resumes after "epoch-9"
         page-2 (runtime-form-output hist {:after-id (:after-id decoded)
                                           :cutoff-ms 0
@@ -218,12 +186,12 @@
   ;; Bead acceptance: "50-epoch ring; pagination over 5 batches returns
   ;; 50 distinct records in order."
   (let [hist (vec (for [n (range 50)] (make-epoch n)))
-        walk (loop [cursor   nil
-                    pages    []
-                    safety   10]
+        walk (loop [cursor-str nil
+                    pages      []
+                    safety     10]
                (if (zero? safety)
                  pages
-                 (let [decoded (decode-cursor cursor)
+                 (let [decoded (cursor/decode-cursor cursor-str)
                        after-id (:after-id decoded)
                        out (runtime-form-output hist {:after-id after-id
                                                       :cutoff-ms 0
@@ -231,8 +199,8 @@
                                                       :limit 10})
                        pages' (conj pages (:epochs out))]
                    (if-let [next-id (:next-id out)]
-                     (recur (encode-cursor {:v 1 :after-id next-id
-                                            :until-ms 99999999 :ms nil :frame nil})
+                     (recur (cursor/encode-cursor {:v 1 :after-id next-id
+                                                   :until-ms 99999999 :ms nil :frame nil})
                             pages'
                             (dec safety))
                      pages'))))
@@ -282,10 +250,10 @@
     (is (empty? (:epochs page-2)))))
 
 (deftest malformed-cursor-decodes-as-malformed-sentinel
-  ;; Caller passes garbage. Host translates ::malformed to the same
-  ;; :rf.mcp/cursor-stale error path as a true age-out.
-  (is (= ::malformed (decode-cursor "not-base64-edn")))
-  (is (= ::malformed (decode-cursor "AAAA"))))
+  ;; Caller passes garbage. Host translates malformed sentinel to the
+  ;; same :rf.mcp/cursor-stale error path as a true age-out.
+  (is (= malformed (cursor/decode-cursor "not-base64-edn")))
+  (is (= malformed (cursor/decode-cursor "AAAA"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Sticky window — fresh epochs don't sneak in mid-iteration.

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/dedup_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/dedup_test.cljs
@@ -9,119 +9,74 @@
   reference after diff-encoding) collapse into a flat cache map that
   the agent host reconstructs via `de-dupe.core/expand`.
 
-  These tests mirror the private dedup helpers from `tools.cljs`
-  (`parse-dedup-arg`, `empty-payload?`, `dedup-value`,
-  `dedup-expand`, `dedup-epochs-in-snapshot`). A rename or signature
-  change surfaces as a failing test rather than a silent contract
-  drift.
+  Tests pin the public helpers directly from their owning namespaces:
+  `tools.dedup/parse-dedup-arg`, `tools.dedup/empty-payload?`,
+  `tools.dedup/dedup-value`, `tools.dedup/dedup-expand`,
+  `tools.snapshot-pipeline/dedup-epochs-in-snapshot`. A rename or
+  signature change surfaces as a failing test rather than a silent
+  contract drift.
 
   Live end-to-end coverage runs against a real shadow-cljs build via
   the existing stdio-roundtrip harness; this file pins the pure
   transforms, the round-trip property, the wire shape, and the
   reduction-ratio sanity check."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [de-dupe.core :as dedup]))
-
-;; ---------------------------------------------------------------------------
-;; Mirrors of the private dedup helpers from tools.cljs. Keep in
-;; lockstep — sibling tests follow the same convention (CLJS private
-;; vars aren't reachable across namespaces without `#'` so we copy
-;; the surface and lean on regression coverage).
-;; ---------------------------------------------------------------------------
-
-(defn- parse-dedup-arg [raw]
-  (cond
-    (nil? raw)             true
-    (true? raw)            true
-    (false? raw)           false
-    (= raw "false")        false
-    (= raw :false)         false
-    (= raw "true")         true
-    (= raw :true)          true
-    :else                  true))
-
-(defn- empty-payload? [v]
-  (or (nil? v)
-      (and (coll? v) (empty? v))
-      (not (coll? v))))
-
-(defn- dedup-value [v enabled?]
-  (if (or (not enabled?) (empty-payload? v))
-    v
-    (let [cache (dedup/de-dupe-eq v)]
-      {:rf.mcp/dedup-table cache})))
-
-(defn- dedup-expand [v]
-  (if (and (map? v) (contains? v :rf.mcp/dedup-table))
-    (dedup/expand (:rf.mcp/dedup-table v))
-    v))
-
-(defn- dedup-epochs-in-snapshot [snapshot enabled?]
-  (cond
-    (or (not enabled?) (not (map? snapshot)))
-    snapshot
-    :else
-    (reduce-kv
-      (fn [m fid fmap]
-        (assoc m fid
-               (if (and (map? fmap) (contains? fmap :epochs))
-                 (update fmap :epochs dedup-value enabled?)
-                 fmap)))
-      {} snapshot)))
+            [re-frame-pair2-mcp.tools.dedup :as dedup]
+            [re-frame-pair2-mcp.tools.snapshot-pipeline :as pipeline]))
 
 ;; ---------------------------------------------------------------------------
 ;; parse-dedup-arg — MCP-arg normalisation.
 ;; ---------------------------------------------------------------------------
 
 (deftest parse-dedup-default-is-true
-  (is (true? (parse-dedup-arg nil))))
+  (is (true? (dedup/parse-dedup-arg nil))))
 
 (deftest parse-dedup-booleans-pass-through
-  (is (true? (parse-dedup-arg true)))
-  (is (false? (parse-dedup-arg false))))
+  (is (true? (dedup/parse-dedup-arg true)))
+  (is (false? (dedup/parse-dedup-arg false))))
 
 (deftest parse-dedup-string-forms-accepted
   ;; The MCP wire ships JSON; clients sending `"false"` should get
   ;; the false reading rather than the budget-default true.
-  (is (false? (parse-dedup-arg "false")))
-  (is (true? (parse-dedup-arg "true"))))
+  (is (false? (dedup/parse-dedup-arg "false")))
+  (is (true? (dedup/parse-dedup-arg "true"))))
 
 (deftest parse-dedup-keyword-forms-accepted
-  (is (false? (parse-dedup-arg :false)))
-  (is (true? (parse-dedup-arg :true))))
+  (is (false? (dedup/parse-dedup-arg :false)))
+  (is (true? (dedup/parse-dedup-arg :true))))
 
 (deftest parse-dedup-unknown-defaults-to-true
   ;; Least-surprise on the budget-sensitive default: an unrecognised
   ;; value gets the smaller-wire-payload behaviour, not the larger.
-  (is (true? (parse-dedup-arg "garbage")))
-  (is (true? (parse-dedup-arg 42)))
-  (is (true? (parse-dedup-arg :other))))
+  (is (true? (dedup/parse-dedup-arg "garbage")))
+  (is (true? (dedup/parse-dedup-arg 42)))
+  (is (true? (dedup/parse-dedup-arg :other))))
 
 ;; ---------------------------------------------------------------------------
 ;; empty-payload? — the no-op guard.
 ;; ---------------------------------------------------------------------------
 
 (deftest empty-payload-nil-is-empty
-  (is (true? (empty-payload? nil))))
+  (is (true? (dedup/empty-payload? nil))))
 
 (deftest empty-payload-empty-vector-is-empty
-  (is (true? (empty-payload? [])))
-  (is (true? (empty-payload? {})))
-  (is (true? (empty-payload? #{})))
-  (is (true? (empty-payload? '()))))
+  (is (true? (dedup/empty-payload? [])))
+  (is (true? (dedup/empty-payload? {})))
+  (is (true? (dedup/empty-payload? #{})))
+  (is (true? (dedup/empty-payload? '()))))
 
 (deftest empty-payload-scalars-are-empty
   ;; Scalars can't be deduped — the no-op guard catches them.
-  (is (true? (empty-payload? 42)))
-  (is (true? (empty-payload? :keyword)))
-  (is (true? (empty-payload? "string")))
-  (is (true? (empty-payload? true))))
+  (is (true? (dedup/empty-payload? 42)))
+  (is (true? (dedup/empty-payload? :keyword)))
+  (is (true? (dedup/empty-payload? "string")))
+  (is (true? (dedup/empty-payload? true))))
 
 (deftest empty-payload-non-empty-collections-fire-dedup
-  (is (false? (empty-payload? [1 2 3])))
-  (is (false? (empty-payload? {:a 1})))
-  (is (false? (empty-payload? #{:x})))
-  (is (false? (empty-payload? '(1 2)))))
+  (is (false? (dedup/empty-payload? [1 2 3])))
+  (is (false? (dedup/empty-payload? {:a 1})))
+  (is (false? (dedup/empty-payload? #{:x})))
+  (is (false? (dedup/empty-payload? '(1 2)))))
 
 ;; ---------------------------------------------------------------------------
 ;; dedup-value — the wire-boundary wrap.
@@ -130,19 +85,19 @@
 (deftest dedup-disabled-passes-through
   ;; opt-out: caller asks for the raw payload.
   (let [payload [{:a 1 :b 2} {:a 1 :b 2}]]
-    (is (= payload (dedup-value payload false)))))
+    (is (= payload (dedup/dedup-value payload false)))))
 
 (deftest dedup-empty-payload-passes-through
   ;; Empty / scalar inputs skip wrapping — the cache-of-one would
   ;; be a wire-size loss for trivial values.
-  (is (nil? (dedup-value nil true)))
-  (is (= [] (dedup-value [] true)))
-  (is (= {} (dedup-value {} true)))
-  (is (= 42 (dedup-value 42 true))))
+  (is (nil? (dedup/dedup-value nil true)))
+  (is (= [] (dedup/dedup-value [] true)))
+  (is (= {} (dedup/dedup-value {} true)))
+  (is (= 42 (dedup/dedup-value 42 true))))
 
 (deftest dedup-non-empty-collection-emits-marker
   (let [payload [{:a 1} {:b 2}]
-        wrapped (dedup-value payload true)]
+        wrapped (dedup/dedup-value payload true)]
     (is (map? wrapped))
     (is (contains? wrapped :rf.mcp/dedup-table))
     (is (map? (:rf.mcp/dedup-table wrapped))
@@ -152,7 +107,7 @@
   ;; The marker key matches causa-mcp's Principles §5 (Structural
   ;; dedup): `{:rf.mcp/dedup-table ...}`. Agents that learned the
   ;; slot on causa-mcp see the same slot here.
-  (let [wrapped (dedup-value [{:a 1} {:a 1}] true)]
+  (let [wrapped (dedup/dedup-value [{:a 1} {:a 1}] true)]
     (is (= [:rf.mcp/dedup-table] (vec (keys wrapped))))))
 
 ;; ---------------------------------------------------------------------------
@@ -164,15 +119,15 @@
         payload [{:id 1 :payload shared}
                  {:id 2 :payload shared}
                  {:id 3 :payload shared}]
-        wrapped (dedup-value payload true)
-        restored (dedup-expand wrapped)]
+        wrapped (dedup/dedup-value payload true)
+        restored (dedup/dedup-expand wrapped)]
     (is (= payload restored))))
 
 (deftest round-trip-already-expanded-is-noop
   ;; A payload that was never deduped (caller passed `dedup false`)
   ;; round-trips identity through expand.
   (let [payload [{:a 1} {:b 2}]]
-    (is (= payload (dedup-expand payload)))))
+    (is (= payload (dedup/dedup-expand payload)))))
 
 (deftest round-trip-nested-shared-subtrees
   ;; The load-bearing case: epoch slice where every record carries
@@ -188,14 +143,14 @@
                        :db-after  {:rf.mcp/diff-from :db-before
                                    :patches [[[(keyword (str "k" i)) :v]
                                               :assoc (str "new-" i)]]}}))
-        wrapped (dedup-value epochs true)
-        restored (dedup-expand wrapped)]
+        wrapped (dedup/dedup-value epochs true)
+        restored (dedup/dedup-expand wrapped)]
     (is (= epochs restored))))
 
 (deftest round-trip-empty-collections-inside-payload
   (let [payload [{:items [] :state {}} {:items [] :state {}}]
-        wrapped (dedup-value payload true)
-        restored (dedup-expand wrapped)]
+        wrapped (dedup/dedup-value payload true)
+        restored (dedup/dedup-expand wrapped)]
     (is (= payload restored))))
 
 (deftest round-trip-deeply-nested-uniform-records
@@ -206,8 +161,8 @@
                 :user {:id 7 :name "alice"}
                 :ui {:loading? false :error nil}}
         payload (vec (repeat 50 record))
-        wrapped (dedup-value payload true)
-        restored (dedup-expand wrapped)]
+        wrapped (dedup/dedup-value payload true)
+        restored (dedup/dedup-expand wrapped)]
     (is (= payload restored))
     (is (= 50 (count restored)))))
 
@@ -237,7 +192,7 @@
                                    :patches [[[(keyword (str "k" i))]
                                               :assoc (apply str (repeat 256 \y))]]}}))
         raw-size (count (pr-str epochs))
-        wrapped (dedup-value epochs true)
+        wrapped (dedup/dedup-value epochs true)
         wrapped-size (count (pr-str wrapped))]
     (testing "wrapped payload is much smaller than the raw vector"
       ;; Observability: print the actual ratio in the test log so the
@@ -255,7 +210,7 @@
                ") should be < 50% of raw (" raw-size
                "). Ratio: " (/ wrapped-size raw-size 1.0))))
     (testing "round-trip still reconstructs every epoch"
-      (let [restored (dedup-expand wrapped)]
+      (let [restored (dedup/dedup-expand wrapped)]
         (is (= epochs restored))))))
 
 ;; ---------------------------------------------------------------------------
@@ -264,15 +219,15 @@
 
 (deftest edge-case-empty-payload-is-noop
   ;; "empty payload (no-op)" — the wrapper short-circuits.
-  (is (nil? (dedup-value nil true)))
-  (is (= [] (dedup-value [] true))))
+  (is (nil? (dedup/dedup-value nil true)))
+  (is (= [] (dedup/dedup-value [] true))))
 
 (deftest edge-case-no-repeated-structure
   ;; "payload with no repeated structure (table empty)" — the cache
   ;; ships only the root entry; round-trip still exact.
   (let [payload [{:a 1} {:b 2} {:c 3}]
-        wrapped (dedup-value payload true)
-        restored (dedup-expand wrapped)]
+        wrapped (dedup/dedup-value payload true)
+        restored (dedup/dedup-expand wrapped)]
     (is (= payload restored))))
 
 (deftest edge-case-one-big-repeated-subtree
@@ -281,8 +236,8 @@
   (let [shared (into {} (for [i (range 100)]
                           [(keyword (str "k" i)) i]))
         payload (vec (repeat 20 shared))
-        wrapped (dedup-value payload true)
-        restored (dedup-expand wrapped)]
+        wrapped (dedup/dedup-value payload true)
+        restored (dedup/dedup-expand wrapped)]
     (is (= payload restored))
     (is (= 20 (count restored)))
     (is (every? #(= shared %) restored))))
@@ -312,7 +267,7 @@
                 :traces    []}})
 
 (deftest snapshot-dedup-wraps-each-frames-epochs
-  (let [wrapped (dedup-epochs-in-snapshot fixture-snapshot true)]
+  (let [wrapped (pipeline/dedup-epochs-in-snapshot fixture-snapshot true)]
     (testing ":epochs slot wrapped on every frame that has one"
       (doseq [[_fid fmap] wrapped]
         (let [eps (:epochs fmap)]
@@ -324,25 +279,25 @@
 
 (deftest snapshot-dedup-disabled-passes-through
   (is (= fixture-snapshot
-         (dedup-epochs-in-snapshot fixture-snapshot false))))
+         (pipeline/dedup-epochs-in-snapshot fixture-snapshot false))))
 
 (deftest snapshot-dedup-skips-frames-without-epochs-slice
   ;; The :include filter may exclude :epochs. Don't add one.
   (let [snap {:rf/default {:app-db {} :sub-cache {}}}
-        wrapped (dedup-epochs-in-snapshot snap true)]
+        wrapped (pipeline/dedup-epochs-in-snapshot snap true)]
     (is (not (contains? (:rf/default wrapped) :epochs)))))
 
 (deftest snapshot-dedup-non-map-passes-through
-  (is (nil? (dedup-epochs-in-snapshot nil true)))
-  (is (= :not-a-snap (dedup-epochs-in-snapshot :not-a-snap true))))
+  (is (nil? (pipeline/dedup-epochs-in-snapshot nil true)))
+  (is (= :not-a-snap (pipeline/dedup-epochs-in-snapshot :not-a-snap true))))
 
 (deftest snapshot-dedup-round-trips-per-frame
-  (let [wrapped (dedup-epochs-in-snapshot fixture-snapshot true)
+  (let [wrapped (pipeline/dedup-epochs-in-snapshot fixture-snapshot true)
         restored (reduce-kv
                    (fn [m fid fmap]
                      (assoc m fid
                             (if (contains? fmap :epochs)
-                              (update fmap :epochs dedup-expand)
+                              (update fmap :epochs dedup/dedup-expand)
                               fmap)))
                    {}
                    wrapped)]

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/diff_encode_epochs_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/diff_encode_epochs_test.cljs
@@ -5,182 +5,95 @@
   epoch slice), every `:rf/epoch-record` shipped over the wire has
   its `:db-after` replaced with a path-keyed structural diff against
   its own `:db-before` by default. The transform lives in
-  `tools.cljs` at the MCP wire boundary; opt-back-in to the legacy
-  full-pair shape via `epochs-mode \"full\"` on snapshot /
-  trace-window / watch-epochs.
+  `re-frame.mcp-base.diff-encode` at the cross-MCP boundary; the
+  pair2-mcp aliases (`tools.dedup/diff-encode-epochs`,
+  `tools.dedup/parse-epochs-mode`) re-export the surface and the
+  snapshot pipeline composes them via
+  `tools.snapshot-pipeline/diff-encode-epochs-in-snapshot`.
 
-  These tests mirror the private diff-encoding helpers from
-  `tools.cljs` (`collect-patches`, `apply-patches`,
-  `diff-encode-db-after`, `decode-db-after`, `diff-encode-epochs`,
-  `diff-encode-epochs-in-snapshot`, `parse-epochs-mode`). A rename or
-  signature change surfaces as a failing test rather than silent
-  contract drift.
+  Tests pin the public surfaces directly:
+  `re-frame.mcp-base.diff-encode/collect-patches`,
+  `re-frame.mcp-base.diff-encode/apply-patches`,
+  `re-frame.mcp-base.diff-encode/diff-encode-db-after`,
+  `re-frame.mcp-base.diff-encode/decode-db-after`,
+  `re-frame.mcp-base.diff-encode/diff-encode-epochs`,
+  `tools.snapshot-pipeline/diff-encode-epochs-in-snapshot`,
+  `tools.dedup/parse-epochs-mode`. A rename or signature change
+  surfaces as a failing test rather than silent contract drift.
 
   Live end-to-end coverage runs against a real shadow-cljs build
   with a populated `epoch-history`; this file pins the pure CLJS
   transforms and the round-trip property."
-  (:require [cljs.test :refer-macros [deftest is testing]]))
-
-;; ---------------------------------------------------------------------------
-;; Mirrors of the private diff helpers from tools.cljs. Keep in
-;; lockstep — sibling tests follow the same convention (CLJS private
-;; vars aren't reachable across namespaces without `#'` so we copy
-;; the surface and lean on regression coverage).
-;; ---------------------------------------------------------------------------
-
-(declare collect-patches)
-
-(defn- collect-map-patches [a b path]
-  (let [ks (into #{} (concat (keys a) (keys b)))]
-    (reduce
-      (fn [acc k]
-        (let [av (get a k ::absent)
-              bv (get b k ::absent)
-              p  (conj path k)]
-          (cond
-            (= bv ::absent) (conj acc [p :dissoc])
-            (= av ::absent) (conj acc [p :assoc bv])
-            (= av bv) acc
-            (and (map? av) (map? bv)) (into acc (collect-patches av bv p))
-            :else (conj acc [p :assoc bv]))))
-      []
-      ks)))
-
-(defn- collect-patches [a b path]
-  (cond
-    (= a b) []
-    (and (map? a) (map? b)) (collect-map-patches a b path)
-    :else [[path :assoc b]]))
-
-(defn- apply-patches [base patches]
-  (reduce
-    (fn [acc patch]
-      (let [[path op v] patch]
-        (cond
-          (empty? path) (if (= op :assoc) v acc)
-          (= op :assoc) (assoc-in acc path v)
-          (= op :dissoc)
-          (let [parent-path (vec (butlast path))
-                k           (last path)]
-            (if (empty? parent-path)
-              (dissoc acc k)
-              (update-in acc parent-path dissoc k)))
-          :else acc)))
-    base
-    patches))
-
-(defn- diff-encode-db-after [epoch]
-  (if-not (and (map? epoch)
-               (contains? epoch :db-before)
-               (contains? epoch :db-after))
-    epoch
-    (let [patches (collect-patches (:db-before epoch) (:db-after epoch) [])]
-      (assoc epoch :db-after
-             {:rf.mcp/diff-from :db-before
-              :patches          patches}))))
-
-(defn- decode-db-after [epoch]
-  (let [da (when (map? epoch) (:db-after epoch))]
-    (if-not (and (map? da)
-                 (= :db-before (:rf.mcp/diff-from da)))
-      epoch
-      (let [patches   (:patches da)
-            db-before (:db-before epoch)
-            rebuilt   (apply-patches db-before (or patches []))]
-        (assoc epoch :db-after rebuilt)))))
-
-(defn- diff-encode-epochs [epochs mode]
-  (if (= mode :full)
-    epochs
-    (mapv diff-encode-db-after epochs)))
-
-(defn- diff-encode-epochs-in-snapshot [snapshot mode]
-  (cond
-    (or (= mode :full) (not (map? snapshot)))
-    snapshot
-    :else
-    (reduce-kv
-      (fn [m fid fmap]
-        (assoc m fid
-               (if (and (map? fmap) (contains? fmap :epochs))
-                 (update fmap :epochs diff-encode-epochs mode)
-                 fmap)))
-      {} snapshot)))
-
-(defn- parse-epochs-mode [raw]
-  (cond
-    (nil? raw)         :diff
-    (= raw :full)      :full
-    (= raw "full")     :full
-    (= raw :diff)      :diff
-    (= raw "diff")     :diff
-    :else              :diff))
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.mcp-base.diff-encode :as diff]
+            [re-frame-pair2-mcp.tools.dedup :as dedup]
+            [re-frame-pair2-mcp.tools.snapshot-pipeline :as pipeline]))
 
 ;; ---------------------------------------------------------------------------
 ;; collect-patches — the encoder's path-keyed diff factory.
 ;; ---------------------------------------------------------------------------
 
 (deftest collect-patches-equal-maps-no-patches
-  (is (= [] (collect-patches {:a 1} {:a 1} []))))
+  (is (= [] (diff/collect-patches {:a 1} {:a 1} []))))
 
 (deftest collect-patches-added-key-emits-assoc
   (is (= [[[:b] :assoc 2]]
-         (collect-patches {:a 1} {:a 1 :b 2} []))))
+         (diff/collect-patches {:a 1} {:a 1 :b 2} []))))
 
 (deftest collect-patches-removed-key-emits-dissoc
   (is (= [[[:b] :dissoc]]
-         (collect-patches {:a 1 :b 2} {:a 1} []))))
+         (diff/collect-patches {:a 1 :b 2} {:a 1} []))))
 
 (deftest collect-patches-changed-leaf-emits-assoc
   (is (= [[[:a] :assoc 99]]
-         (collect-patches {:a 1} {:a 99} []))))
+         (diff/collect-patches {:a 1} {:a 99} []))))
 
 (deftest collect-patches-nested-change-emits-deep-path
-  (let [patches (collect-patches {:user {:auth {:token "abc"}}}
-                                  {:user {:auth {:token "xyz"}}}
-                                  [])]
+  (let [patches (diff/collect-patches {:user {:auth {:token "abc"}}}
+                                       {:user {:auth {:token "xyz"}}}
+                                       [])]
     (is (= [[[:user :auth :token] :assoc "xyz"]] patches))))
 
 (deftest collect-patches-non-map-replacement-at-root
   ;; Root-level swap from one shape to another wholly different shape.
   (is (= [[[] :assoc :replaced]]
-         (collect-patches {:a 1} :replaced []))))
+         (diff/collect-patches {:a 1} :replaced []))))
 
 (deftest collect-patches-vector-leaf-replaces-wholesale
   ;; Vectors are treated as leaves — element-wise diff doesn't help
   ;; for typical app-db vector values which are short.
   (is (= [[[:items] :assoc [3 2 1]]]
-         (collect-patches {:items [1 2 3]} {:items [3 2 1]} []))))
+         (diff/collect-patches {:items [1 2 3]} {:items [3 2 1]} []))))
 
 ;; ---------------------------------------------------------------------------
 ;; apply-patches — the decoder.
 ;; ---------------------------------------------------------------------------
 
 (deftest apply-patches-empty-list-is-identity
-  (is (= {:a 1 :b 2} (apply-patches {:a 1 :b 2} []))))
+  (is (= {:a 1 :b 2} (diff/apply-patches {:a 1 :b 2} []))))
 
 (deftest apply-patches-assoc-adds-or-changes-value
   (is (= {:a 1 :b 99}
-         (apply-patches {:a 1 :b 2} [[[:b] :assoc 99]]))))
+         (diff/apply-patches {:a 1 :b 2} [[[:b] :assoc 99]]))))
 
 (deftest apply-patches-dissoc-removes-key
   (is (= {:a 1}
-         (apply-patches {:a 1 :b 2} [[[:b] :dissoc]]))))
+         (diff/apply-patches {:a 1 :b 2} [[[:b] :dissoc]]))))
 
 (deftest apply-patches-root-assoc-replaces-value
   (is (= :other
-         (apply-patches {:a 1} [[[] :assoc :other]]))))
+         (diff/apply-patches {:a 1} [[[] :assoc :other]]))))
 
 (deftest apply-patches-deep-path-creates-or-updates
   (is (= {:a {:b {:c 99}}}
-         (apply-patches {:a {:b {:c 1}}} [[[:a :b :c] :assoc 99]]))))
+         (diff/apply-patches {:a {:b {:c 1}}} [[[:a :b :c] :assoc 99]]))))
 
 (deftest apply-patches-applies-in-order
   ;; Two patches against the same parent: order matters.
   (is (= {:a 1 :b 2}
-         (apply-patches {:a 1}
-                        [[[:b] :assoc 99]
-                         [[:b] :assoc 2]]))))
+         (diff/apply-patches {:a 1}
+                              [[[:b] :assoc 99]
+                               [[:b] :assoc 2]]))))
 
 ;; ---------------------------------------------------------------------------
 ;; diff-encode-db-after — the encoder shape.
@@ -198,14 +111,14 @@
                   :user {:id 7}}})
 
 (deftest diff-encode-db-after-replaces-db-after-with-marker
-  (let [enc (diff-encode-db-after fixture-epoch)
+  (let [enc (diff/diff-encode-db-after fixture-epoch)
         da  (:db-after enc)]
     (is (= :db-before (:rf.mcp/diff-from da))
         "Diff marker carries the source-slot key")
     (is (vector? (:patches da)))))
 
 (deftest diff-encode-db-after-leaves-db-before-untouched
-  (let [enc (diff-encode-db-after fixture-epoch)]
+  (let [enc (diff/diff-encode-db-after fixture-epoch)]
     (is (= (:db-before fixture-epoch) (:db-before enc))
         ":db-before stays the canonical reference")))
 
@@ -213,19 +126,19 @@
   ;; Synthetic / pruned epoch without :db-before can't be diffed —
   ;; pass-through is the correct posture.
   (let [partial-epoch {:epoch-id :ep-x :db-after {:foo 1}}]
-    (is (= partial-epoch (diff-encode-db-after partial-epoch)))))
+    (is (= partial-epoch (diff/diff-encode-db-after partial-epoch)))))
 
 (deftest diff-encode-db-after-non-map-passes-through
-  (is (= :not-an-epoch (diff-encode-db-after :not-an-epoch)))
-  (is (= nil (diff-encode-db-after nil))))
+  (is (= :not-an-epoch (diff/diff-encode-db-after :not-an-epoch)))
+  (is (= nil (diff/diff-encode-db-after nil))))
 
 ;; ---------------------------------------------------------------------------
 ;; Round-trip property: encode → decode → identity.
 ;; ---------------------------------------------------------------------------
 
 (deftest round-trip-single-key-change
-  (let [enc (diff-encode-db-after fixture-epoch)
-        dec (decode-db-after enc)]
+  (let [enc (diff/diff-encode-db-after fixture-epoch)
+        dec (diff/decode-db-after enc)]
     (is (= fixture-epoch dec)
         "encode→decode round-trips the full epoch unchanged")))
 
@@ -233,8 +146,8 @@
   ;; Degenerate case: no change. Patch list is empty; decoder returns
   ;; :db-before unchanged.
   (let [epoch (assoc fixture-epoch :db-after (:db-before fixture-epoch))
-        enc   (diff-encode-db-after epoch)
-        dec   (decode-db-after enc)]
+        enc   (diff/diff-encode-db-after epoch)
+        dec   (diff/decode-db-after enc)]
     (is (= epoch dec))
     (is (= [] (-> enc :db-after :patches)))))
 
@@ -245,8 +158,8 @@
   ;; MUST still reconstruct.
   (let [epoch {:db-before {:a 1 :b 2}
                :db-after  {:c 3 :d 4}}
-        enc   (diff-encode-db-after epoch)
-        dec   (decode-db-after enc)]
+        enc   (diff/diff-encode-db-after epoch)
+        dec   (diff/decode-db-after enc)]
     (is (= epoch dec))))
 
 (deftest round-trip-deeply-nested-leaf-change
@@ -262,8 +175,8 @@
                                                   :refresh "def"}}}
                             :wide wide
                             :cart {:items (vec (range 100))}}}
-        enc   (diff-encode-db-after epoch)
-        dec   (decode-db-after enc)]
+        enc   (diff/diff-encode-db-after epoch)
+        dec   (diff/decode-db-after enc)]
     (is (= epoch dec))
     ;; Efficiency check: encoded :db-after should be tiny relative to
     ;; the full db-after.
@@ -277,8 +190,8 @@
 (deftest round-trip-map-key-removal
   (let [epoch {:db-before {:a 1 :b 2 :c 3}
                :db-after  {:a 1 :c 3}}
-        enc   (diff-encode-db-after epoch)
-        dec   (decode-db-after enc)]
+        enc   (diff/diff-encode-db-after epoch)
+        dec   (diff/decode-db-after enc)]
     (is (= epoch dec))
     (is (= [[[:b] :dissoc]] (-> enc :db-after :patches))
         ":b was removed → surfaces as a :dissoc patch")))
@@ -288,14 +201,14 @@
   ;; Round-trip MUST reconstruct.
   (let [epoch {:db-before {:items [1 2 3]}
                :db-after  {:items [3 2 1]}}
-        enc   (diff-encode-db-after epoch)
-        dec   (decode-db-after enc)]
+        enc   (diff/diff-encode-db-after epoch)
+        dec   (diff/decode-db-after enc)]
     (is (= epoch dec))))
 
 (deftest round-trip-empty-maps
   (let [epoch {:db-before {} :db-after {}}
-        enc   (diff-encode-db-after epoch)
-        dec   (decode-db-after enc)]
+        enc   (diff/diff-encode-db-after epoch)
+        dec   (diff/decode-db-after enc)]
     (is (= epoch dec))
     (is (= [] (-> enc :db-after :patches)))))
 
@@ -303,8 +216,8 @@
   ;; A pathological app-db that's a scalar — rare but valid. The
   ;; encoder records the change as a root-level :assoc replacement.
   (let [epoch {:db-before 42 :db-after 99}
-        enc   (diff-encode-db-after epoch)
-        dec   (decode-db-after enc)]
+        enc   (diff/diff-encode-db-after epoch)
+        dec   (diff/decode-db-after enc)]
     (is (= epoch dec))))
 
 (deftest round-trip-value-changed-to-nil
@@ -312,8 +225,8 @@
   ;; emits an :assoc with the nil value (distinguishable from a
   ;; :dissoc which removes the key entirely).
   (let [epoch {:db-before {:k :v} :db-after {:k nil}}
-        enc   (diff-encode-db-after epoch)
-        dec   (decode-db-after enc)]
+        enc   (diff/diff-encode-db-after epoch)
+        dec   (diff/decode-db-after enc)]
     (is (= epoch dec))
     (is (contains? (:db-after dec) :k))
     (is (nil? (-> dec :db-after :k)))))
@@ -322,8 +235,8 @@
   ;; Two-axis change: one key removed, another added, deep in the tree.
   (let [epoch {:db-before {:user {:profile {:name "alice" :age 30}}}
                :db-after  {:user {:profile {:name "alice" :email "a@b"}}}}
-        enc   (diff-encode-db-after epoch)
-        dec   (decode-db-after enc)]
+        enc   (diff/diff-encode-db-after epoch)
+        dec   (diff/decode-db-after enc)]
     (is (= epoch dec))))
 
 ;; ---------------------------------------------------------------------------
@@ -332,14 +245,14 @@
 
 (deftest diff-encode-epochs-diff-mode-encodes-every-record
   (let [epochs [fixture-epoch fixture-epoch fixture-epoch]
-        enc    (diff-encode-epochs epochs :diff)]
+        enc    (diff/diff-encode-epochs epochs :diff)]
     (is (= 3 (count enc)))
     (doseq [e enc]
       (is (= :db-before (-> e :db-after :rf.mcp/diff-from))))))
 
 (deftest diff-encode-epochs-full-mode-pass-through
   (let [epochs [fixture-epoch fixture-epoch]
-        enc    (diff-encode-epochs epochs :full)]
+        enc    (diff/diff-encode-epochs epochs :full)]
     (is (= epochs enc)
         ":full mode is a no-op — agent gets the legacy shape")))
 
@@ -349,17 +262,17 @@
   ;; doesn't break decode.
   (let [e1 {:db-before {:a 1} :db-after {:a 2}}
         e2 {:db-before {:b 9} :db-after {:b 9 :c 7}}
-        enc (diff-encode-epochs [e1 e2] :diff)]
-    (is (= e1 (decode-db-after (first enc))))
-    (is (= e2 (decode-db-after (second enc))))
+        enc (diff/diff-encode-epochs [e1 e2] :diff)]
+    (is (= e1 (diff/decode-db-after (first enc))))
+    (is (= e2 (diff/decode-db-after (second enc))))
     ;; Reverse order — still decodable.
     (let [reversed (reverse enc)]
-      (is (= e2 (decode-db-after (first reversed))))
-      (is (= e1 (decode-db-after (second reversed)))))))
+      (is (= e2 (diff/decode-db-after (first reversed))))
+      (is (= e1 (diff/decode-db-after (second reversed)))))))
 
 (deftest diff-encode-epochs-empty-vector
-  (is (= [] (diff-encode-epochs [] :diff)))
-  (is (= [] (diff-encode-epochs [] :full))))
+  (is (= [] (diff/diff-encode-epochs [] :diff)))
+  (is (= [] (diff/diff-encode-epochs [] :full))))
 
 ;; ---------------------------------------------------------------------------
 ;; diff-encode-epochs-in-snapshot — the snapshot-tool integration.
@@ -378,7 +291,7 @@
                 :traces    []}})
 
 (deftest snapshot-diff-mode-encodes-every-frames-epochs
-  (let [enc (diff-encode-epochs-in-snapshot fixture-snapshot :diff)]
+  (let [enc (pipeline/diff-encode-epochs-in-snapshot fixture-snapshot :diff)]
     (testing ":epochs slice transformed on every frame"
       (doseq [[_fid fmap] enc]
         (doseq [ep (:epochs fmap)]
@@ -390,39 +303,39 @@
 
 (deftest snapshot-full-mode-passes-through
   (is (= fixture-snapshot
-         (diff-encode-epochs-in-snapshot fixture-snapshot :full))))
+         (pipeline/diff-encode-epochs-in-snapshot fixture-snapshot :full))))
 
 (deftest snapshot-skips-frames-without-epochs-slice
   ;; The :include filter may exclude :epochs. Don't add one.
   (let [snap {:rf/default {:app-db {} :sub-cache {} :machines {}}}
-        enc  (diff-encode-epochs-in-snapshot snap :diff)]
+        enc  (pipeline/diff-encode-epochs-in-snapshot snap :diff)]
     (is (not (contains? (:rf/default enc) :epochs)))))
 
 (deftest snapshot-non-map-passes-through
-  (is (nil? (diff-encode-epochs-in-snapshot nil :diff)))
-  (is (= :not-a-snap (diff-encode-epochs-in-snapshot :not-a-snap :diff))))
+  (is (nil? (pipeline/diff-encode-epochs-in-snapshot nil :diff)))
+  (is (= :not-a-snap (pipeline/diff-encode-epochs-in-snapshot :not-a-snap :diff))))
 
 ;; ---------------------------------------------------------------------------
 ;; parse-epochs-mode — MCP-arg normalisation.
 ;; ---------------------------------------------------------------------------
 
 (deftest parse-epochs-mode-default-is-diff
-  (is (= :diff (parse-epochs-mode nil))))
+  (is (= :diff (dedup/parse-epochs-mode nil))))
 
 (deftest parse-epochs-mode-strings-accepted
-  (is (= :diff (parse-epochs-mode "diff")))
-  (is (= :full (parse-epochs-mode "full"))))
+  (is (= :diff (dedup/parse-epochs-mode "diff")))
+  (is (= :full (dedup/parse-epochs-mode "full"))))
 
 (deftest parse-epochs-mode-keywords-accepted
-  (is (= :diff (parse-epochs-mode :diff)))
-  (is (= :full (parse-epochs-mode :full))))
+  (is (= :diff (dedup/parse-epochs-mode :diff)))
+  (is (= :full (dedup/parse-epochs-mode :full))))
 
 (deftest parse-epochs-mode-unknown-falls-back-to-diff
   ;; Least-surprise on the budget-sensitive default: an unrecognised
   ;; value gets the smaller-wire-payload behaviour, not the larger.
-  (is (= :diff (parse-epochs-mode "garbage")))
-  (is (= :diff (parse-epochs-mode 42)))
-  (is (= :diff (parse-epochs-mode :other))))
+  (is (= :diff (dedup/parse-epochs-mode "garbage")))
+  (is (= :diff (dedup/parse-epochs-mode 42)))
+  (is (= :diff (dedup/parse-epochs-mode :other))))
 
 ;; ---------------------------------------------------------------------------
 ;; Wire-size impact: 10-epoch window with a 1MB app-db, single-key
@@ -445,7 +358,7 @@
                                          (keyword (str "k" i))
                                          (apply str (repeat 1024 \y)))}))
         full-size (count (pr-str epochs))
-        diff-encoded (diff-encode-epochs epochs :diff)
+        diff-encoded (diff/diff-encode-epochs epochs :diff)
         diff-size (count (pr-str diff-encoded))]
     (testing "diff-encoded slice is much smaller than the full pair"
       ;; Full: 10 × ~2MB = ~20MB on the wire.
@@ -458,5 +371,5 @@
                ") should be << 60% of full (" full-size
                "). Ratio: " (/ diff-size full-size 1.0))))
     (testing "round-trip still reconstructs every epoch"
-      (let [decoded (mapv decode-db-after diff-encoded)]
+      (let [decoded (mapv diff/decode-db-after diff-encoded)]
         (is (= epochs decoded))))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/elision_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/elision_test.cljs
@@ -10,40 +10,20 @@
   ...}}` marker; the agent re-fetches via `get-path` with the handle's
   path.
 
-  These tests mirror the private elision helpers from `tools.cljs`
-  (`parse-elision-arg`, `elision-opts-edn`) and pin the eval-form
-  shape — the literal CLJS-source string sent over nREPL. A rename
-  or signature change on the walker / runtime surfaces, or a typo in
-  the inlined form, surfaces here as a failing test rather than a
-  silent contract drift discovered live.
+  Tests pin `parse-elision-arg` and `elision-opts-edn` directly from
+  `re-frame-pair2-mcp.tools.elision`. The downstream eval-form
+  composers (`build-snapshot-form` / `build-get-path-form`) remain
+  local fixtures because their source counterparts live inlined in
+  the per-tool namespaces (`tools.snapshot` / `tools.get-path`) and
+  aren't surfaced as standalone public fns.
 
   Live end-to-end coverage runs against a real shadow-cljs build via
   the existing `test/stdio-roundtrip.js` harness — that's where the
   walker actually fires and we verify the marker comes back as EDN.
   The CLJS layer here just pins the wiring."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [cljs.reader]))
-
-;; ---------------------------------------------------------------------------
-;; Mirrors of the private elision helpers from tools.cljs. Keep in
-;; lockstep — sibling tests follow the same convention (CLJS private
-;; vars aren't reachable across namespaces without `#'` so we copy
-;; the surface and lean on regression coverage).
-;; ---------------------------------------------------------------------------
-
-(defn- parse-elision-arg [raw]
-  (cond
-    (nil? raw)             true
-    (true? raw)            true
-    (false? raw)           false
-    (= raw "false")        false
-    (= raw :false)         false
-    (= raw "true")         true
-    (= raw :true)          true
-    :else                  true))
-
-(defn- elision-opts-edn [enabled?]
-  (pr-str {:rf.size/include-large? (not enabled?)}))
+            [cljs.reader]
+            [re-frame-pair2-mcp.tools.elision :as elision]))
 
 ;; ---------------------------------------------------------------------------
 ;; parse-elision-arg — MCP-arg normalisation.
@@ -53,28 +33,28 @@
   ;; Default-on matches the dedup posture: shrink-by-default, opt out
   ;; explicitly. An agent that hasn't been taught about elision still
   ;; gets the smaller wire payload.
-  (is (true? (parse-elision-arg nil))))
+  (is (true? (elision/parse-elision-arg nil))))
 
 (deftest parse-elision-booleans-pass-through
-  (is (true? (parse-elision-arg true)))
-  (is (false? (parse-elision-arg false))))
+  (is (true? (elision/parse-elision-arg true)))
+  (is (false? (elision/parse-elision-arg false))))
 
 (deftest parse-elision-string-forms-accepted
   ;; The MCP wire ships JSON; clients sending `"false"` should get the
   ;; false reading rather than the budget-default true.
-  (is (false? (parse-elision-arg "false")))
-  (is (true? (parse-elision-arg "true"))))
+  (is (false? (elision/parse-elision-arg "false")))
+  (is (true? (elision/parse-elision-arg "true"))))
 
 (deftest parse-elision-keyword-forms-accepted
-  (is (false? (parse-elision-arg :false)))
-  (is (true? (parse-elision-arg :true))))
+  (is (false? (elision/parse-elision-arg :false)))
+  (is (true? (elision/parse-elision-arg :true))))
 
 (deftest parse-elision-unknown-defaults-to-true
   ;; Least-surprise on the budget-sensitive default: an unrecognised
   ;; value gets the smaller-wire-payload behaviour, not the larger.
-  (is (true? (parse-elision-arg "garbage")))
-  (is (true? (parse-elision-arg 42)))
-  (is (true? (parse-elision-arg :other))))
+  (is (true? (elision/parse-elision-arg "garbage")))
+  (is (true? (elision/parse-elision-arg 42)))
+  (is (true? (elision/parse-elision-arg :other))))
 
 ;; ---------------------------------------------------------------------------
 ;; elision-opts-edn — EDN-render the walker's opts map for inlining.
@@ -86,7 +66,7 @@
   ;; is the walker's own switch (a `true` means pass through, a
   ;; `false` means emit the marker — the keyword surfaces from the
   ;; walker's API, not from our boolean).
-  (let [edn (elision-opts-edn true)
+  (let [edn (elision/elision-opts-edn true)
         parsed (cljs.reader/read-string edn)]
     (is (false? (:rf.size/include-large? parsed)))))
 
@@ -95,7 +75,7 @@
   ;; the walker passes the raw value through. (We also short-circuit
   ;; the walk entirely in the eval form when disabled — see the
   ;; snapshot-eval-form test below.)
-  (let [edn (elision-opts-edn false)
+  (let [edn (elision/elision-opts-edn false)
         parsed (cljs.reader/read-string edn)]
     (is (true? (:rf.size/include-large? parsed)))))
 
@@ -103,7 +83,7 @@
   ;; The EDN we ship over nREPL must be readable on the other side.
   ;; pr-str + read-string round-trips for the structure we emit.
   (doseq [enabled? [true false]]
-    (let [edn (elision-opts-edn enabled?)
+    (let [edn (elision/elision-opts-edn enabled?)
           parsed (cljs.reader/read-string edn)]
       (is (map? parsed))
       (is (contains? parsed :rf.size/include-large?)))))
@@ -128,7 +108,7 @@
   "Mirror of the snapshot-tool's eval-form composition. Two arms:
   elision on/off. Keep in lockstep with `snapshot-tool` in tools.cljs."
   [opts elision?]
-  (let [elision-opts-form (elision-opts-edn elision?)]
+  (let [elision-opts-form (elision/elision-opts-edn elision?)]
     (if elision?
       (str "(let [snap (re-frame-pair2.runtime/snapshot-state "
            (pr-str opts) ")]"
@@ -203,7 +183,7 @@
                         (str "(re-frame-pair2.runtime/snapshot " (pr-str frame) ")")
                         "(re-frame-pair2.runtime/snapshot)")
         frame-edn     (if frame (pr-str frame) "(re-frame-pair2.runtime/current-frame)")
-        elision-opts  (elision-opts-edn elision?)
+        elision-opts  (elision/elision-opts-edn elision?)
         elide-call    (if elision?
                         (str "(re-frame.core/elide-wire-value v"
                              "  (merge {:path path :frame " frame-edn "}"
@@ -314,6 +294,6 @@
   ;; is normative per the walker's docstring; a rename in the framework
   ;; surface needs a co-ordinated update here.
   (is (= "{:rf.size/include-large? false}"
-         (elision-opts-edn true)))
+         (elision/elision-opts-edn true)))
   (is (= "{:rf.size/include-large? true}"
-         (elision-opts-edn false))))
+         (elision/elision-opts-edn false))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/lazy_summary_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/lazy_summary_test.cljs
@@ -8,193 +8,76 @@
   `:epochs`, `:traces` — so a discovery snapshot ('I don't know which
   slice carries the answer') stays under the wire cap by construction.
 
-  These tests mirror the private helpers from `tools.cljs`
-  (`parse-mode-arg`, `parse-modes-arg`, `resolve-slice-mode`,
-  `summarise-other-slices-in-snapshot`) so the contract is pinned at
-  the unit level. A rename or signature drift surfaces as a failing
-  test rather than silent contract drift.
+  Tests pin the public helpers directly:
+  `tools.args/parse-mode-arg`, `tools.args/parse-modes-arg`,
+  `tools.snapshot-pipeline/resolve-slice-mode`,
+  `tools.snapshot-pipeline/summarise-other-slices-in-snapshot`,
+  `tools.summary/tree-summary`. A rename or signature drift surfaces
+  as a failing test rather than silent contract drift.
 
   Wire-byte / token-budget assertions appear at the end — the
   discovery-snapshot scenario MUST fit the 5,000-token cap."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [clojure.string :as str]))
-
-;; ---------------------------------------------------------------------------
-;; Mirrors of the private helpers. Keep in lockstep with `tools.cljs`.
-;; ---------------------------------------------------------------------------
-
-(def ^:private valid-slices
-  #{:app-db :sub-cache :machines :epochs :traces})
-
-(def ^:private summarisable-slices
-  #{:sub-cache :machines :epochs :traces})
-
-(def ^:private summary-keys-cap 64)
-
-(defn- token-estimate [s]
-  (quot (count s) 4))
-
-(defn- tree-summary [v]
-  (cond
-    (map? v)
-    (let [ks    (keys v)
-          n     (count ks)
-          shown (if (> n summary-keys-cap)
-                  (vec (take summary-keys-cap ks))
-                  (vec ks))]
-      {:rf.mcp/summary (cond-> {:type   :map
-                                :keys   shown
-                                :count  n
-                                :bytes  (count (pr-str v))}
-                         (> n summary-keys-cap)
-                         (assoc :keys-truncated? true))})
-    (vector? v)
-    {:rf.mcp/summary {:type  :vector
-                      :count (count v)
-                      :bytes (count (pr-str v))}}
-    (set? v)
-    {:rf.mcp/summary {:type  :set
-                      :count (count v)
-                      :bytes (count (pr-str v))}}
-    (sequential? v)
-    {:rf.mcp/summary {:type  :seq
-                      :count (count v)
-                      :bytes (count (pr-str v))}}
-    :else
-    {:rf.mcp/summary {:type  :scalar
-                      :value v
-                      :bytes (count (pr-str v))}}))
-
-(defn- parse-mode-arg [raw]
-  (cond
-    (nil? raw)                 :summary
-    (= raw :full)              :full
-    (= raw :summary)           :summary
-    (= raw "full")             :full
-    (= raw "summary")          :summary
-    :else                      :summary))
-
-(defn- parse-modes-arg [raw]
-  (let [as-clj (cond
-                 (nil? raw) nil
-                 (map? raw) raw
-                 (and (some? raw)
-                      (not (array? raw))
-                      (not (string? raw))
-                      (not (boolean? raw))
-                      (not (number? raw)))
-                 (try (js->clj raw) (catch :default _ nil))
-                 :else nil)
-        coerce-k (fn [k]
-                   (cond
-                     (keyword? k) k
-                     (string? k)
-                     (let [s (if (str/starts-with? k ":") (subs k 1) k)]
-                       (keyword s))
-                     :else nil))
-        coerce-v (fn [v]
-                   (cond
-                     (= v :summary)  :summary
-                     (= v :full)     :full
-                     (= v "summary") :summary
-                     (= v "full")    :full
-                     :else           nil))]
-    (if-not (map? as-clj)
-      {}
-      (reduce-kv
-        (fn [m k v]
-          (let [k' (coerce-k k)
-                v' (coerce-v v)]
-            (if (and k' (contains? valid-slices k') v')
-              (assoc m k' v')
-              m)))
-        {} as-clj))))
-
-(defn- resolve-slice-mode [slice slice-modes global-mode]
-  (let [m (or (get slice-modes slice) global-mode :summary)]
-    (case m
-      :full :full
-      :summary)))
-
-(defn- summarise-other-slices-in-snapshot [snapshot slice-modes global-mode]
-  (if-not (map? snapshot)
-    {:snapshot snapshot :resolved-modes {}}
-    (let [resolved (into {} (map (fn [s]
-                                   [s (resolve-slice-mode s slice-modes global-mode)]))
-                         summarisable-slices)
-          process-frame
-          (fn [frame-map]
-            (if-not (map? frame-map)
-              frame-map
-              (reduce-kv
-                (fn [m k v]
-                  (assoc m k
-                         (if (and (contains? summarisable-slices k)
-                                  (= :summary (get resolved k))
-                                  (some? v))
-                           (tree-summary v)
-                           v)))
-                {} frame-map)))
-          processed (reduce-kv (fn [m fid fmap]
-                                 (assoc m fid (process-frame fmap)))
-                               {} snapshot)]
-      {:snapshot processed :resolved-modes resolved})))
+            [re-frame-pair2-mcp.tools.args :as args]
+            [re-frame-pair2-mcp.tools.cap :as cap]
+            [re-frame-pair2-mcp.tools.snapshot-pipeline :as pipeline]
+            [re-frame-pair2-mcp.tools.summary :as summary]))
 
 ;; ---------------------------------------------------------------------------
 ;; parse-mode-arg — the input contract for the global `:mode` MCP arg.
 ;; ---------------------------------------------------------------------------
 
 (deftest parse-mode-arg-defaults-to-summary
-  (is (= :summary (parse-mode-arg nil)))
-  (is (= :summary (parse-mode-arg ""))))
+  (is (= :summary (args/parse-mode-arg nil)))
+  (is (= :summary (args/parse-mode-arg ""))))
 
 (deftest parse-mode-arg-accepts-string-and-keyword
-  (is (= :full (parse-mode-arg "full")))
-  (is (= :full (parse-mode-arg :full)))
-  (is (= :summary (parse-mode-arg "summary")))
-  (is (= :summary (parse-mode-arg :summary))))
+  (is (= :full (args/parse-mode-arg "full")))
+  (is (= :full (args/parse-mode-arg :full)))
+  (is (= :summary (args/parse-mode-arg "summary")))
+  (is (= :summary (args/parse-mode-arg :summary))))
 
 (deftest parse-mode-arg-unknown-defaults-to-summary
   ;; Budget-sensitive: an unknown value MUST default to the cheaper
   ;; mode rather than expand by accident.
-  (is (= :summary (parse-mode-arg "garbage")))
-  (is (= :summary (parse-mode-arg :nope))))
+  (is (= :summary (args/parse-mode-arg "garbage")))
+  (is (= :summary (args/parse-mode-arg :nope))))
 
 ;; ---------------------------------------------------------------------------
 ;; parse-modes-arg — per-slice override map.
 ;; ---------------------------------------------------------------------------
 
 (deftest parse-modes-arg-nil-is-empty
-  (is (= {} (parse-modes-arg nil))))
+  (is (= {} (args/parse-modes-arg nil))))
 
 (deftest parse-modes-arg-cljs-map-passes-through
   (is (= {:app-db :full :epochs :summary}
-         (parse-modes-arg {:app-db :full :epochs :summary}))))
+         (args/parse-modes-arg {:app-db :full :epochs :summary}))))
 
 (deftest parse-modes-arg-string-keys-coerced-to-slice-keywords
   (is (= {:app-db :full :sub-cache :summary}
-         (parse-modes-arg #js {"app-db" "full" "sub-cache" "summary"}))))
+         (args/parse-modes-arg #js {"app-db" "full" "sub-cache" "summary"}))))
 
 (deftest parse-modes-arg-edn-shaped-string-keys-strip-leading-colon
   (is (= {:app-db :full}
-         (parse-modes-arg #js {":app-db" "full"}))))
+         (args/parse-modes-arg #js {":app-db" "full"}))))
 
 (deftest parse-modes-arg-drops-unknown-slices
   (is (= {:app-db :full}
-         (parse-modes-arg #js {"app-db" "full" "garbage" "full"}))))
+         (args/parse-modes-arg #js {"app-db" "full" "garbage" "full"}))))
 
 (deftest parse-modes-arg-drops-unknown-mode-values
   ;; Unknown mode values fall through to the global default — the slice
   ;; doesn't appear in the override map at all.
   (is (= {}
-         (parse-modes-arg #js {"app-db" "garbage"})))
+         (args/parse-modes-arg #js {"app-db" "garbage"})))
   (is (= {:epochs :summary}
-         (parse-modes-arg #js {"app-db" "garbage" "epochs" "summary"}))))
+         (args/parse-modes-arg #js {"app-db" "garbage" "epochs" "summary"}))))
 
 (deftest parse-modes-arg-non-map-returns-empty
-  (is (= {} (parse-modes-arg "scalar")))
-  (is (= {} (parse-modes-arg 42)))
-  (is (= {} (parse-modes-arg true))))
+  (is (= {} (args/parse-modes-arg "scalar")))
+  (is (= {} (args/parse-modes-arg 42)))
+  (is (= {} (args/parse-modes-arg true))))
 
 ;; ---------------------------------------------------------------------------
 ;; resolve-slice-mode — per-slice precedence resolution.
@@ -202,28 +85,28 @@
 
 (deftest resolve-slice-mode-default-is-summary
   ;; Nothing pins the slice ⇒ summary.
-  (is (= :summary (resolve-slice-mode :app-db {} :summary)))
-  (is (= :summary (resolve-slice-mode :sub-cache {} :summary)))
-  (is (= :summary (resolve-slice-mode :epochs {} nil))))
+  (is (= :summary (pipeline/resolve-slice-mode :app-db {} :summary)))
+  (is (= :summary (pipeline/resolve-slice-mode :sub-cache {} :summary)))
+  (is (= :summary (pipeline/resolve-slice-mode :epochs {} nil))))
 
 (deftest resolve-slice-mode-global-mode-applies-to-every-slice
-  (is (= :full (resolve-slice-mode :app-db {} :full)))
-  (is (= :full (resolve-slice-mode :sub-cache {} :full)))
-  (is (= :full (resolve-slice-mode :epochs {} :full)))
-  (is (= :full (resolve-slice-mode :traces {} :full))))
+  (is (= :full (pipeline/resolve-slice-mode :app-db {} :full)))
+  (is (= :full (pipeline/resolve-slice-mode :sub-cache {} :full)))
+  (is (= :full (pipeline/resolve-slice-mode :epochs {} :full)))
+  (is (= :full (pipeline/resolve-slice-mode :traces {} :full))))
 
 (deftest resolve-slice-mode-per-slice-overrides-global
-  (is (= :full (resolve-slice-mode :app-db {:app-db :full} :summary))
+  (is (= :full (pipeline/resolve-slice-mode :app-db {:app-db :full} :summary))
       "Per-slice :full beats global :summary")
-  (is (= :summary (resolve-slice-mode :epochs {:epochs :summary} :full))
+  (is (= :summary (pipeline/resolve-slice-mode :epochs {:epochs :summary} :full))
       "Per-slice :summary beats global :full"))
 
 (deftest resolve-slice-mode-only-affects-named-slice
   ;; Per-slice override on :app-db shouldn't change :epochs resolution.
   (let [modes {:app-db :full}]
-    (is (= :full    (resolve-slice-mode :app-db modes :summary)))
-    (is (= :summary (resolve-slice-mode :epochs modes :summary)))
-    (is (= :summary (resolve-slice-mode :traces modes :summary)))))
+    (is (= :full    (pipeline/resolve-slice-mode :app-db modes :summary)))
+    (is (= :summary (pipeline/resolve-slice-mode :epochs modes :summary)))
+    (is (= :summary (pipeline/resolve-slice-mode :traces modes :summary)))))
 
 ;; ---------------------------------------------------------------------------
 ;; summarise-other-slices-in-snapshot — the load-bearing pipeline step.
@@ -250,7 +133,7 @@
 
 (deftest summary-default-replaces-every-rich-slice
   (let [{:keys [snapshot resolved-modes]}
-        (summarise-other-slices-in-snapshot fixture-snapshot {} :summary)
+        (pipeline/summarise-other-slices-in-snapshot fixture-snapshot {} :summary)
         rf-default (:rf/default snapshot)]
     (testing "resolved-modes echoes the per-slice mode"
       (is (= {:sub-cache :summary :machines :summary
@@ -278,7 +161,7 @@
 
 (deftest full-mode-leaves-every-slice-untouched
   (let [{:keys [snapshot resolved-modes]}
-        (summarise-other-slices-in-snapshot fixture-snapshot {} :full)]
+        (pipeline/summarise-other-slices-in-snapshot fixture-snapshot {} :full)]
     (is (= {:sub-cache :full :machines :full
             :epochs    :full :traces   :full}
            resolved-modes))
@@ -289,9 +172,9 @@
 (deftest per-slice-override-beats-global-mode
   (testing "global :summary, per-slice :full on :epochs"
     (let [{:keys [snapshot resolved-modes]}
-          (summarise-other-slices-in-snapshot fixture-snapshot
-                                              {:epochs :full}
-                                              :summary)
+          (pipeline/summarise-other-slices-in-snapshot fixture-snapshot
+                                                       {:epochs :full}
+                                                       :summary)
           rf-default (:rf/default snapshot)]
       (is (= :full    (:epochs    resolved-modes)))
       (is (= :summary (:sub-cache resolved-modes)))
@@ -301,9 +184,9 @@
           ":sub-cache stays summarised under global :summary")))
   (testing "global :full, per-slice :summary on :traces"
     (let [{:keys [snapshot resolved-modes]}
-          (summarise-other-slices-in-snapshot fixture-snapshot
-                                              {:traces :summary}
-                                              :full)
+          (pipeline/summarise-other-slices-in-snapshot fixture-snapshot
+                                                       {:traces :summary}
+                                                       :full)
           rf-default (:rf/default snapshot)]
       (is (= :summary (:traces    resolved-modes)))
       (is (= :full    (:sub-cache resolved-modes)))
@@ -317,7 +200,7 @@
   ;; Summarising an empty map yields {:type :map :count 0 :keys []
   ;; :bytes ~3} — the marker is small but distinguishable from the raw
   ;; empty value. Skip the marker for nil to avoid noise.
-  (let [{:keys [snapshot]} (summarise-other-slices-in-snapshot
+  (let [{:keys [snapshot]} (pipeline/summarise-other-slices-in-snapshot
                              fixture-snapshot {} :summary)
         stories (:stories snapshot)]
     (is (some? (-> stories :sub-cache :rf.mcp/summary)))
@@ -330,7 +213,7 @@
   ;; map has no entry for that slice. The summariser MUST NOT add one.
   (let [partial-snap {:rf/default {:app-db    {:k 1}
                                     :sub-cache {[:q] {:value 1}}}}
-        {:keys [snapshot]} (summarise-other-slices-in-snapshot
+        {:keys [snapshot]} (pipeline/summarise-other-slices-in-snapshot
                              partial-snap {} :summary)
         rf-default (:rf/default snapshot)]
     (is (not (contains? rf-default :machines)))
@@ -342,7 +225,7 @@
   ;; A pathological frame value (scalar where a map was expected)
   ;; passes through unchanged rather than crashing.
   (let [weird {:rf/default :not-a-map}
-        {:keys [snapshot]} (summarise-other-slices-in-snapshot
+        {:keys [snapshot]} (pipeline/summarise-other-slices-in-snapshot
                              weird {} :summary)]
     (is (= :not-a-map (:rf/default snapshot)))))
 
@@ -384,11 +267,11 @@
         ;; In the real pipeline, slice-app-db-in-snapshot runs upstream
         ;; and turns :app-db into a summary marker. Simulate that here.
         with-app-db-summary
-        (update-in fat [:rf/default :app-db] tree-summary)
-        {:keys [snapshot]} (summarise-other-slices-in-snapshot
+        (update-in fat [:rf/default :app-db] summary/tree-summary)
+        {:keys [snapshot]} (pipeline/summarise-other-slices-in-snapshot
                              with-app-db-summary {} :summary)
         wire (pr-str snapshot)
-        tokens (token-estimate wire)]
+        tokens (cap/token-estimate wire)]
     (is (< tokens 5000)
         (str "Discovery snapshot under :summary mode MUST fit the 5k-token cap. "
              "Got " tokens " tokens, " (count wire) " chars."))))
@@ -399,10 +282,10 @@
   ;; same fat snapshot under :full mode is dramatically larger.
   (let [fat (make-fat-snapshot)
         with-app-db-full fat
-        {:keys [snapshot]} (summarise-other-slices-in-snapshot
+        {:keys [snapshot]} (pipeline/summarise-other-slices-in-snapshot
                              with-app-db-full {} :full)
         wire (pr-str snapshot)
-        tokens (token-estimate wire)]
+        tokens (cap/token-estimate wire)]
     (is (> tokens 50000)
         (str "Full-mode discovery snapshot ships the raw payload — "
              "should be many multiples of the cap. Got " tokens " tokens."))))
@@ -413,16 +296,16 @@
   ;; underlying payload. The shrink factor is the load-bearing claim
   ;; the bead description ties acceptance to.
   (let [fat                (make-fat-snapshot)
-        with-app-db-summary (update-in fat [:rf/default :app-db] tree-summary)
+        with-app-db-summary (update-in fat [:rf/default :app-db] summary/tree-summary)
         with-app-db-full   fat
-        summary-wire (pr-str (:snapshot (summarise-other-slices-in-snapshot
+        summary-wire (pr-str (:snapshot (pipeline/summarise-other-slices-in-snapshot
                                           with-app-db-summary {} :summary)))
-        full-wire    (pr-str (:snapshot (summarise-other-slices-in-snapshot
+        full-wire    (pr-str (:snapshot (pipeline/summarise-other-slices-in-snapshot
                                           with-app-db-full {} :full)))
         ratio (/ (count full-wire) (count summary-wire))]
     (println (str "[rf2-u2029] discovery snapshot wire-size: "
-                  "summary=" (count summary-wire) " chars (~" (token-estimate summary-wire) " tokens), "
-                  "full=" (count full-wire) " chars (~" (token-estimate full-wire) " tokens), "
+                  "summary=" (count summary-wire) " chars (~" (cap/token-estimate summary-wire) " tokens), "
+                  "full=" (count full-wire) " chars (~" (cap/token-estimate full-wire) " tokens), "
                   "shrink=" (int ratio) "x"))
     (is (> ratio 50)
         (str "Lazy-summary MUST shrink the discovery snapshot by at "

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/nrepl_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/nrepl_test.cljs
@@ -4,32 +4,22 @@
   The hard bug we fixed during the pilot — bencode@2 storing the
   post-decode cursor on `bencode.decode.position` rather than the
   module-level export — is the kind of regression that's easy to
-  reintroduce, so the multi-frame walker gets a thorough test."
+  reintroduce, so the multi-frame walker gets a thorough test.
+
+  Tests pin `decode-all-frames` directly from
+  `re-frame-pair2-mcp.nrepl` — the source ns is the contract."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [applied-science.js-interop :as j]
-            ["bencode" :as bencode]))
-
-;; The actual `decode-all-frames` is private; re-implement the contract
-;; here so we test what callers see — and so the test breaks if the
-;; semantics drift.
+            ["bencode" :as bencode]
+            [re-frame-pair2-mcp.nrepl :as nrepl]))
 
 (defn- decode-all
+  "Wrap `nrepl/decode-all-frames` returning `[clj-vec rest-buf]`.
+  Source returns `[js-array rest-buf]` for hot-path perf; tests want a
+  CLJS vector to walk."
   [^js buf]
-  (let [frames (array)]
-    (loop [^js b buf]
-      (if (zero? (.-length b))
-        [(vec (array-seq frames)) b]
-        (let [decoded  (try (bencode/decode b "utf8") (catch :default _ nil))
-              consumed (or (j/get-in bencode [:decode :position])
-                           (j/get-in bencode [:decode :bytes])
-                           0)]
-          (cond
-            (nil? decoded)        [(vec (array-seq frames)) b]
-            (zero? consumed)      (do (.push frames decoded)
-                                      [(vec (array-seq frames)) (js/Buffer.alloc 0)])
-            :else
-            (do (.push frames decoded)
-                (recur (.slice b consumed)))))))))
+  (let [[js-frames rest] (nrepl/decode-all-frames buf)]
+    [(vec (array-seq js-frames)) rest]))
 
 (deftest single-frame-decodes
   (let [buf      (js/Buffer.from "d3:foo3:bare" "utf8")

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/path_slicing_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/path_slicing_test.cljs
@@ -10,196 +10,68 @@
     - The new `get-path` tool returns the value at a single path —
       a minimal primitive for targeted reads.
 
-  These tests mirror the private helpers from `tools.cljs`
-  (`parse-path-arg`, `coerce-path-segment`, `tree-summary`,
-  `deepest-valid-prefix`, `slice-app-db-in-snapshot`). A rename or
-  signature change surfaces as a failing test rather than a silent
-  contract drift.
+  Tests pin the public helpers directly from their owning namespaces:
+  `tools.args/parse-path-arg`, `tools.summary/tree-summary`,
+  `tools.summary/deepest-valid-prefix`,
+  `tools.snapshot-pipeline/slice-app-db-in-snapshot`,
+  `tools.cap/token-estimate`. A rename or signature change surfaces
+  as a failing test rather than a silent contract drift.
 
   Live end-to-end coverage of `get-path-tool` and the snapshot
   `:path` arg lives in `test/stdio-roundtrip.js` (degraded-mode
   dispatch) and the manual live-nREPL integration test."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [cljs.reader]
-            [clojure.string :as str]
-            [applied-science.js-interop :as j]))
-
-;; ---------------------------------------------------------------------------
-;; Mirrors of the private path-slicing helpers. Keep in lockstep with
-;; `tools.cljs`. (Private vars aren't accessible across ns boundaries
-;; in CLJS without `#'` and `:private false` — copying the surface
-;; here is the convention the sibling tests use.)
-;; ---------------------------------------------------------------------------
-
-(defn- token-estimate
-  "Mirror of `tools.cljs`'s `token-estimate` — `(quot (count s) 4)`."
-  [s]
-  (quot (count s) 4))
-
-(defn- coerce-path-segment [s]
-  (if-not (string? s)
-    s
-    (let [trimmed   (str/trim s)
-          fc        (when (pos? (count trimmed)) (.charAt trimmed 0))
-          edn-shape (and fc
-                         (or (= ":" fc)
-                             (= "-" fc)
-                             (= "+" fc)
-                             (boolean (re-matches #"\d" fc))))]
-      (if edn-shape
-        (try (cljs.reader/read-string trimmed)
-             (catch :default _ s))
-        s))))
-
-(defn- parse-path-arg [raw]
-  (cond
-    (nil? raw) nil
-    (vector? raw) raw
-    (sequential? raw) (vec raw)
-    (array? raw) (mapv coerce-path-segment (js->clj raw))
-    (string? raw)
-    (let [trimmed (str/trim raw)]
-      (cond
-        (str/blank? trimmed) nil
-        :else
-        (try
-          (let [parsed (cljs.reader/read-string trimmed)]
-            (cond
-              (vector? parsed)     parsed
-              (sequential? parsed) (vec parsed)
-              :else                [parsed]))
-          (catch :default _
-            [trimmed]))))
-    :else nil))
-
-(def ^:private summary-keys-cap 64)
-
-(defn- tree-summary [v]
-  (cond
-    (map? v)
-    (let [ks    (keys v)
-          n     (count ks)
-          shown (if (> n summary-keys-cap)
-                  (vec (take summary-keys-cap ks))
-                  (vec ks))]
-      {:rf.mcp/summary (cond-> {:type   :map
-                                :keys   shown
-                                :count  n
-                                :bytes  (count (pr-str v))}
-                         (> n summary-keys-cap)
-                         (assoc :keys-truncated? true))})
-    (vector? v)
-    {:rf.mcp/summary {:type  :vector
-                      :count (count v)
-                      :bytes (count (pr-str v))}}
-    (set? v)
-    {:rf.mcp/summary {:type  :set
-                      :count (count v)
-                      :bytes (count (pr-str v))}}
-    (sequential? v)
-    {:rf.mcp/summary {:type  :seq
-                      :count (count v)
-                      :bytes (count (pr-str v))}}
-    :else
-    {:rf.mcp/summary {:type  :scalar
-                      :value v
-                      :bytes (count (pr-str v))}}))
-
-(defn- deepest-valid-prefix [db path]
-  (loop [acc [] cur db remaining path]
-    (if (empty? remaining)
-      acc
-      (let [k (first remaining)]
-        (cond
-          (and (map? cur) (contains? cur k))
-          (recur (conj acc k) (get cur k) (rest remaining))
-
-          (and (sequential? cur) (integer? k) (<= 0 k (dec (count cur))))
-          (recur (conj acc k) (nth (vec cur) k) (rest remaining))
-
-          :else acc)))))
-
-(defn- slice-app-db-in-snapshot
-  ([snapshot path] (slice-app-db-in-snapshot snapshot path :summary))
-  ([snapshot path app-db-mode]
-   (if-not (map? snapshot)
-     [snapshot {}]
-     (let [status* (atom {})
-           missing (js-obj)
-           full?   (= :full app-db-mode)
-           process-frame
-           (fn [frame-id frame-map]
-             (if-not (and (map? frame-map) (contains? frame-map :app-db))
-               frame-map
-               (let [db (:app-db frame-map)]
-                 (cond
-                   ;; No path + summary mode: summarise.
-                   (and (nil? path) (not full?))
-                   (update frame-map :app-db tree-summary)
-                   ;; No path + full mode: full slice.
-                   (nil? path)
-                   frame-map
-                   (empty? path)
-                   frame-map
-                   :else
-                   (let [v (get-in db path missing)]
-                     (if (identical? v missing)
-                       (do (swap! status* assoc frame-id
-                                  {:exists? false
-                                   :deepest-valid-prefix (deepest-valid-prefix db path)})
-                           (assoc frame-map :app-db nil))
-                       (assoc frame-map :app-db v)))))))
-           processed (reduce-kv (fn [m fid fmap]
-                                  (assoc m fid (process-frame fid fmap)))
-                                {} snapshot)]
-       [processed @status*]))))
+            [re-frame-pair2-mcp.tools.args :as args]
+            [re-frame-pair2-mcp.tools.cap :as cap]
+            [re-frame-pair2-mcp.tools.snapshot-pipeline :as pipeline]
+            [re-frame-pair2-mcp.tools.summary :as summary]))
 
 ;; ---------------------------------------------------------------------------
 ;; parse-path-arg — the input-shape contract.
 ;; ---------------------------------------------------------------------------
 
 (deftest parse-path-arg-nil-is-nil
-  (is (nil? (parse-path-arg nil))))
+  (is (nil? (args/parse-path-arg nil))))
 
 (deftest parse-path-arg-blank-string-is-nil
-  (is (nil? (parse-path-arg "")))
-  (is (nil? (parse-path-arg "   "))))
+  (is (nil? (args/parse-path-arg "")))
+  (is (nil? (args/parse-path-arg "   "))))
 
 (deftest parse-path-arg-edn-vector-string
-  (is (= [:cart :items 0] (parse-path-arg "[:cart :items 0]")))
-  (is (= [:a :b :c] (parse-path-arg "[:a :b :c]"))))
+  (is (= [:cart :items 0] (args/parse-path-arg "[:cart :items 0]")))
+  (is (= [:a :b :c] (args/parse-path-arg "[:a :b :c]"))))
 
 (deftest parse-path-arg-edn-empty-vector-is-root
-  (is (= [] (parse-path-arg "[]"))))
+  (is (= [] (args/parse-path-arg "[]"))))
 
 (deftest parse-path-arg-cljs-vector-passes-through
-  (is (= [:a :b :c] (parse-path-arg [:a :b :c])))
-  (is (= [] (parse-path-arg []))))
+  (is (= [:a :b :c] (args/parse-path-arg [:a :b :c])))
+  (is (= [] (args/parse-path-arg []))))
 
 (deftest parse-path-arg-cljs-sequential-coerces-to-vector
-  (is (= [:a :b :c] (parse-path-arg (list :a :b :c)))))
+  (is (= [:a :b :c] (args/parse-path-arg (list :a :b :c)))))
 
 (deftest parse-path-arg-js-array-of-edn-strings
   ;; Each segment is parsed as EDN: keywords, integers, etc.
   (is (= [:cart :items 0]
-         (parse-path-arg #js [":cart" ":items" "0"]))))
+         (args/parse-path-arg #js [":cart" ":items" "0"]))))
 
 (deftest parse-path-arg-js-array-with-bare-strings-stays-strings
   ;; Non-EDN segments (bare strings) pass through as map keys.
   (is (= [:a "bare-key" :b]
-         (parse-path-arg #js [":a" "bare-key" ":b"]))))
+         (args/parse-path-arg #js [":a" "bare-key" ":b"]))))
 
 (deftest parse-path-arg-non-vector-edn-wraps-as-single-segment
   ;; A lone keyword string becomes a 1-segment path.
-  (is (= [:foo] (parse-path-arg ":foo")))
+  (is (= [:foo] (args/parse-path-arg ":foo")))
   ;; A bare integer string also becomes a 1-segment path.
-  (is (= [42] (parse-path-arg "42"))))
+  (is (= [42] (args/parse-path-arg "42"))))
 
 (deftest parse-path-arg-unparseable-string-is-single-string-segment
   ;; Pathological — EDN parser barfs; fall back to treating as one
   ;; map-key string segment rather than raising.
-  (is (= ["((("] (parse-path-arg "(((")))
-  (is (= ["[" "]"] (parse-path-arg #js ["[" "]"]))))
+  (is (= ["((("] (args/parse-path-arg "(((")))
+  (is (= ["[" "]"] (args/parse-path-arg #js ["[" "]"]))))
 
 ;; ---------------------------------------------------------------------------
 ;; tree-summary — the {:rf.mcp/summary ...} marker shape.
@@ -207,7 +79,7 @@
 
 (deftest tree-summary-map-records-top-level-keys-and-bytes
   (let [v {:a 1 :b 2 :nested {:deep {:value 42}}}
-        s (tree-summary v)
+        s (summary/tree-summary v)
         marker (:rf.mcp/summary s)]
     (is (= :map (:type marker)))
     (is (= #{:a :b :nested} (set (:keys marker))))
@@ -216,31 +88,31 @@
 
 (deftest tree-summary-vector-records-count
   (let [v [1 2 3 4 5]
-        marker (:rf.mcp/summary (tree-summary v))]
+        marker (:rf.mcp/summary (summary/tree-summary v))]
     (is (= :vector (:type marker)))
     (is (= 5 (:count marker)))))
 
 (deftest tree-summary-set-and-seq
-  (is (= :set (-> (tree-summary #{1 2 3}) :rf.mcp/summary :type)))
-  (is (= :seq (-> (tree-summary (list 1 2 3)) :rf.mcp/summary :type))))
+  (is (= :set (-> (summary/tree-summary #{1 2 3}) :rf.mcp/summary :type)))
+  (is (= :seq (-> (summary/tree-summary (list 1 2 3)) :rf.mcp/summary :type))))
 
 (deftest tree-summary-map-truncates-huge-key-lists
   ;; A 5k-entry map's key list alone would blow the cap. The summary
   ;; marker MUST stay bounded.
   (let [big-map (zipmap (map #(keyword (str "k" %)) (range 5000))
                         (repeat :_))
-        marker  (:rf.mcp/summary (tree-summary big-map))]
+        marker  (:rf.mcp/summary (summary/tree-summary big-map))]
     (is (= :map (:type marker)))
     (is (= 5000 (:count marker)))
-    (is (= summary-keys-cap (count (:keys marker))))
+    (is (= summary/summary-keys-cap (count (:keys marker))))
     (is (true? (:keys-truncated? marker)))
-    (is (< (token-estimate (pr-str marker)) 5000)
+    (is (< (cap/token-estimate (pr-str marker)) 5000)
         "Marker for a 5k-entry map MUST still fit the wire cap")))
 
 (deftest tree-summary-scalar-keeps-the-value
   ;; Scalars are cheap; summarising would lose information without
   ;; saving any tokens.
-  (let [marker (:rf.mcp/summary (tree-summary 42))]
+  (let [marker (:rf.mcp/summary (summary/tree-summary 42))]
     (is (= :scalar (:type marker)))
     (is (= 42 (:value marker)))))
 
@@ -251,34 +123,34 @@
 (deftest deepest-valid-prefix-walks-map-keys
   (let [db {:user {:auth {:token "abc"}}}]
     (is (= [:user :auth :token]
-           (deepest-valid-prefix db [:user :auth :token])))
+           (summary/deepest-valid-prefix db [:user :auth :token])))
     (is (= [:user :auth]
-           (deepest-valid-prefix db [:user :auth :missing])))
+           (summary/deepest-valid-prefix db [:user :auth :missing])))
     (is (= []
-           (deepest-valid-prefix db [:missing])))))
+           (summary/deepest-valid-prefix db [:missing])))))
 
 (deftest deepest-valid-prefix-walks-vector-indices
   (let [db {:items [:apple :banana :cherry]}]
     (is (= [:items 1]
-           (deepest-valid-prefix db [:items 1])))
+           (summary/deepest-valid-prefix db [:items 1])))
     (is (= [:items]
-           (deepest-valid-prefix db [:items 99])))
+           (summary/deepest-valid-prefix db [:items 99])))
     (is (= [:items]
            ;; non-integer key on a vector terminates the walk
-           (deepest-valid-prefix db [:items :nope])))))
+           (summary/deepest-valid-prefix db [:items :nope])))))
 
 (deftest deepest-valid-prefix-stops-at-scalar
   (let [db {:user {:name "alice"}}]
     ;; Walking past a string scalar stops at the scalar's parent.
     (is (= [:user :name]
-           (deepest-valid-prefix db [:user :name :char])))))
+           (summary/deepest-valid-prefix db [:user :name :char])))))
 
 (deftest deepest-valid-prefix-handles-nil-leaf
   ;; nil is a legitimate map value; the path that points at it is
   ;; "valid" up to the nil, but a further step terminates.
   (let [db {:k nil}]
-    (is (= [:k] (deepest-valid-prefix db [:k])))
-    (is (= [:k] (deepest-valid-prefix db [:k :anything])))))
+    (is (= [:k] (summary/deepest-valid-prefix db [:k])))
+    (is (= [:k] (summary/deepest-valid-prefix db [:k :anything])))))
 
 ;; ---------------------------------------------------------------------------
 ;; slice-app-db-in-snapshot — snapshot's `:app-db` post-processing.
@@ -299,7 +171,7 @@
                 :traces    []}})
 
 (deftest snapshot-without-path-summarises-app-db
-  (let [[out status] (slice-app-db-in-snapshot fixture-snapshot nil)]
+  (let [[out status] (pipeline/slice-app-db-in-snapshot fixture-snapshot nil :summary)]
     (is (empty? status) "No path-not-found entries when path is nil")
     (testing "every frame's :app-db is replaced with a summary marker"
       (let [marker-default (-> out :rf/default :app-db :rf.mcp/summary)]
@@ -316,9 +188,10 @@
       (is (= [] (-> out :rf/default :epochs))))))
 
 (deftest snapshot-with-path-returns-subtree
-  (let [[out status] (slice-app-db-in-snapshot
+  (let [[out status] (pipeline/slice-app-db-in-snapshot
                        fixture-snapshot
-                       [:user :profile])]
+                       [:user :profile]
+                       :summary)]
     (is (= {:name "alice"}
            (-> out :rf/default :app-db))
         "Subtree replaces the :app-db slice on the matching frame")
@@ -334,29 +207,31 @@
           "Matching frame doesn't appear in the path-not-found map"))))
 
 (deftest snapshot-with-vector-index-path
-  (let [[out _] (slice-app-db-in-snapshot
+  (let [[out _] (pipeline/slice-app-db-in-snapshot
                   fixture-snapshot
-                  [:cart :items 1 :sku])]
+                  [:cart :items 1 :sku]
+                  :summary)]
     (is (= "A2" (-> out :rf/default :app-db)))))
 
 (deftest snapshot-with-empty-path-returns-full-app-db
   ;; Root path is the agent opting in to the full slice.
-  (let [[out _] (slice-app-db-in-snapshot fixture-snapshot [])]
+  (let [[out _] (pipeline/slice-app-db-in-snapshot fixture-snapshot [] :summary)]
     (is (= {:user {:profile {:name "alice"}}
             :cart {:items [{:sku "A1"} {:sku "A2"}]
                    :total 42}}
            (-> out :rf/default :app-db)))))
 
 (deftest snapshot-path-not-found-attaches-deepest-prefix
-  (let [[_ status] (slice-app-db-in-snapshot
+  (let [[_ status] (pipeline/slice-app-db-in-snapshot
                      fixture-snapshot
-                     [:user :auth :token])]
+                     [:user :auth :token]
+                     :summary)]
     (is (= false (-> status :rf/default :exists?)))
     (is (= [:user] (-> status :rf/default :deepest-valid-prefix)))))
 
 (deftest snapshot-summarise-handles-empty-map
   (let [snap {:f1 {:app-db {} :sub-cache {} :machines {} :epochs [] :traces []}}
-        [out _] (slice-app-db-in-snapshot snap nil)
+        [out _] (pipeline/slice-app-db-in-snapshot snap nil :summary)
         marker (-> out :f1 :app-db :rf.mcp/summary)]
     (is (= :map (:type marker)))
     (is (= 0 (:count marker)))
@@ -367,8 +242,8 @@
   ;; In that case the frame map has no :app-db key at all; the
   ;; post-processor MUST NOT add one.
   (let [snap {:f1 {:sub-cache {} :epochs []}}
-        [out _] (slice-app-db-in-snapshot snap nil)
-        [out2 _] (slice-app-db-in-snapshot snap [:foo])]
+        [out _] (pipeline/slice-app-db-in-snapshot snap nil :summary)
+        [out2 _] (pipeline/slice-app-db-in-snapshot snap [:foo] :summary)]
     (is (not (contains? (:f1 out) :app-db)))
     (is (not (contains? (:f1 out2) :app-db)))))
 
@@ -388,9 +263,9 @@
                                   (range 5120)))   ;; ~5MB worth of map
         snap {:rf/default {:app-db big-app-db
                             :sub-cache {} :machines {} :epochs [] :traces []}}
-        [out _] (slice-app-db-in-snapshot snap nil)
+        [out _] (pipeline/slice-app-db-in-snapshot snap nil :summary)
         wire    (pr-str (-> out :rf/default :app-db))]
     (is (contains? (-> out :rf/default :app-db) :rf.mcp/summary))
-    (is (< (token-estimate wire) 5000)
+    (is (< (cap/token-estimate wire) 5000)
         (str "Summary marker MUST be under the 5k cap. Got "
-             (token-estimate wire) " tokens for serialised marker"))))
+             (cap/token-estimate wire) " tokens for serialised marker"))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/sensitive_filter_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/sensitive_filter_test.cljs
@@ -8,64 +8,39 @@
   the flag at the top level of every emitted trace event; the
   forwarder's job is to gate egress on it.
 
-  These tests mirror the private `sensitive-event?` / `strip-sensitive`
-  helpers from `tools.cljs` — a rename or signature change surfaces as
-  a failing test rather than a silent contract drift."
-  (:require [cljs.test :refer-macros [deftest is testing]]))
-
-;; ---------------------------------------------------------------------------
-;; Mirrors of the private helpers in tools.cljs. Keep in lockstep.
-;; ---------------------------------------------------------------------------
-
-(defn- sensitive-event? [ev]
-  (and (map? ev)
-       (true? (:sensitive? ev))))
-
-(defn- sensitive-epoch?
-  "Defense-in-depth (rf2-re2s3): an epoch record is sensitive if its
-  top-level `:sensitive?` is `true` OR if any constituent trace event
-  carries `:sensitive? true`. Mirrors the helper in tools.cljs."
-  [epoch]
-  (and (map? epoch)
-       (or (true? (:sensitive? epoch))
-           (boolean (some sensitive-event? (:trace-events epoch))))))
-
-(defn- strip-sensitive [items include?]
-  (cond
-    include?         [items 0]
-    (empty? items)   [items 0]
-    :else
-    (let [drop? (fn [x] (or (sensitive-event? x) (sensitive-epoch? x)))
-          kept  (filterv (complement drop?) items)
-          n     (- (count items) (count kept))]
-      [kept n])))
+  These tests pin `sensitive-event?` / `sensitive-epoch?` /
+  `strip-sensitive` / `scrub-snapshot-sensitive` directly from
+  `re-frame-pair2-mcp.tools.sensitive` — a rename or signature change
+  surfaces as a failing test rather than a silent contract drift."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame-pair2-mcp.tools.sensitive :as sensitive]))
 
 ;; ---------------------------------------------------------------------------
 ;; sensitive-event? — the boolean predicate.
 ;; ---------------------------------------------------------------------------
 
 (deftest sensitive-event-true-stamp-detected
-  (is (sensitive-event? {:operation :event/dispatched :sensitive? true})))
+  (is (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? true})))
 
 (deftest sensitive-event-false-stamp-passes
-  (is (not (sensitive-event? {:operation :event/dispatched :sensitive? false}))))
+  (is (not (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? false}))))
 
 (deftest sensitive-event-absent-stamp-passes
   ;; Per spec/009: "Consumers treat absent as `false`."
-  (is (not (sensitive-event? {:operation :event/dispatched}))))
+  (is (not (sensitive/sensitive-event? {:operation :event/dispatched}))))
 
 (deftest sensitive-event-non-true-truthy-passes
   ;; Conservative: only the literal `true` triggers the drop. A string
   ;; or non-boolean value passes through (the `:rf/trace-event` schema
   ;; types `:sensitive?` as a boolean — any other value is a contract
   ;; violation we surface rather than silently treat as sensitive).
-  (is (not (sensitive-event? {:operation :event/dispatched :sensitive? "true"})))
-  (is (not (sensitive-event? {:operation :event/dispatched :sensitive? :yes}))))
+  (is (not (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? "true"})))
+  (is (not (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? :yes}))))
 
 (deftest sensitive-event-non-map-input-passes
-  (is (not (sensitive-event? nil)))
-  (is (not (sensitive-event? [:sensitive? true])))
-  (is (not (sensitive-event? "anything"))))
+  (is (not (sensitive/sensitive-event? nil)))
+  (is (not (sensitive/sensitive-event? [:sensitive? true])))
+  (is (not (sensitive/sensitive-event? "anything"))))
 
 ;; ---------------------------------------------------------------------------
 ;; strip-sensitive — the default-suppress filter applied per batch.
@@ -76,7 +51,7 @@
               {:id 2 :sensitive? true}
               {:id 3}
               {:id 4 :sensitive? true}]
-        [kept dropped] (strip-sensitive evts false)]
+        [kept dropped] (sensitive/strip-sensitive evts false)]
     (is (= [{:id 1 :sensitive? false} {:id 3}] kept))
     (is (= 2 dropped))))
 
@@ -84,18 +59,18 @@
   (let [evts [{:id 1 :sensitive? true}
               {:id 2 :sensitive? false}
               {:id 3 :sensitive? true}]
-        [kept dropped] (strip-sensitive evts true)]
+        [kept dropped] (sensitive/strip-sensitive evts true)]
     (is (= evts kept))
     (is (zero? dropped))))
 
 (deftest strip-sensitive-empty-batch-zero-overhead
-  (let [[kept dropped] (strip-sensitive [] false)]
+  (let [[kept dropped] (sensitive/strip-sensitive [] false)]
     (is (= [] kept))
     (is (zero? dropped))))
 
 (deftest strip-sensitive-no-sensitive-events-zero-drop
   (let [evts [{:id 1} {:id 2 :sensitive? false} {:id 3}]
-        [kept dropped] (strip-sensitive evts false)]
+        [kept dropped] (sensitive/strip-sensitive evts false)]
     (is (= evts kept))
     (is (zero? dropped))))
 
@@ -103,7 +78,7 @@
   (let [evts [{:id 1 :sensitive? true}
               {:id 2 :sensitive? true}
               {:id 3 :sensitive? true}]
-        [kept dropped] (strip-sensitive evts false)]
+        [kept dropped] (sensitive/strip-sensitive evts false)]
     (is (= [] kept))
     (is (= 3 dropped))))
 
@@ -116,14 +91,14 @@
     (let [sensitive-batch [{:operation :event/dispatched
                             :tags      {:event-id :auth/sign-in}
                             :sensitive? true}]
-          [kept dropped] (strip-sensitive sensitive-batch false)]
+          [kept dropped] (sensitive/strip-sensitive sensitive-batch false)]
       (is (= [] kept) "sensitive event must NOT reach the agent surface by default")
       (is (= 1 dropped))))
   (testing "include-sensitive? true is the documented opt-in"
     (let [sensitive-batch [{:operation :event/dispatched
                             :tags      {:event-id :auth/sign-in}
                             :sensitive? true}]
-          [kept dropped] (strip-sensitive sensitive-batch true)]
+          [kept dropped] (sensitive/strip-sensitive sensitive-batch true)]
       (is (= sensitive-batch kept))
       (is (zero? dropped)))))
 
@@ -131,26 +106,6 @@
 ;; Snapshot scrubber — sensitive trace events stripped from per-frame
 ;; :traces / :epochs slices; other slices pass through unchanged.
 ;; ---------------------------------------------------------------------------
-
-(defn- scrub-snapshot-sensitive
-  [snapshot include?]
-  (if (or include? (not (map? snapshot)))
-    [snapshot 0]
-    (let [dropped (atom 0)
-          scrub-slice
-          (fn [items]
-            (let [[kept n] (strip-sensitive (vec items) false)]
-              (swap! dropped + n)
-              kept))
-          scrub-frame
-          (fn [frame-map]
-            (cond-> frame-map
-              (contains? frame-map :traces) (update :traces scrub-slice)
-              (contains? frame-map :epochs) (update :epochs scrub-slice)))
-          scrubbed (reduce-kv (fn [m k v]
-                                (assoc m k (if (map? v) (scrub-frame v) v)))
-                              {} snapshot)]
-      [scrubbed @dropped])))
 
 (deftest snapshot-scrubber-strips-sensitive-from-traces
   (let [snap {:rf/default
@@ -162,7 +117,7 @@
                :machines {}}
               :stories
               {:app-db {} :traces [{:id 10 :sensitive? true}]}}
-        [out dropped] (scrub-snapshot-sensitive snap false)]
+        [out dropped] (sensitive/scrub-snapshot-sensitive snap false)]
     (is (= 3 dropped))
     (is (= [{:id 1 :sensitive? false} {:id 3}]
            (get-in out [:rf/default :traces])))
@@ -179,7 +134,7 @@
                :sub-cache {:user/profile {:sensitive? true :data "x"}}
                :machines  {:auth {:state :idle}}
                :traces    [{:id 1}]}}
-        [out _] (scrub-snapshot-sensitive snap false)]
+        [out _] (sensitive/scrub-snapshot-sensitive snap false)]
     (is (= {:password "still-here" :sensitive? true}
            (get-in out [:rf/default :app-db])))
     (is (= {:user/profile {:sensitive? true :data "x"}}
@@ -190,12 +145,12 @@
 (deftest snapshot-scrubber-include-opt-in-passes-everything
   (let [snap {:rf/default {:traces [{:id 1 :sensitive? true}
                                     {:id 2 :sensitive? true}]}}
-        [out dropped] (scrub-snapshot-sensitive snap true)]
+        [out dropped] (sensitive/scrub-snapshot-sensitive snap true)]
     (is (= snap out))
     (is (zero? dropped))))
 
 (deftest snapshot-scrubber-non-map-input-passes-through
-  (let [[out dropped] (scrub-snapshot-sensitive nil false)]
+  (let [[out dropped] (sensitive/scrub-snapshot-sensitive nil false)]
     (is (nil? out))
     (is (zero? dropped))))
 
@@ -212,12 +167,12 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest sensitive-epoch-top-level-stamp-detected
-  (is (sensitive-epoch? {:epoch-id 1 :event-id :auth/sign-in :sensitive? true})))
+  (is (sensitive/sensitive-epoch? {:epoch-id 1 :event-id :auth/sign-in :sensitive? true})))
 
 (deftest sensitive-epoch-constituent-trace-event-detected
   ;; The top-level rollup is absent (older runtime), but a constituent
   ;; trace event carries the stamp — the egress guard must still drop.
-  (is (sensitive-epoch?
+  (is (sensitive/sensitive-epoch?
         {:epoch-id 2
          :event-id :auth/sign-in
          :trace-events [{:op-type :event :operation :run-start}
@@ -225,27 +180,27 @@
                          :sensitive? true}]})))
 
 (deftest sensitive-epoch-no-stamps-passes
-  (is (not (sensitive-epoch?
+  (is (not (sensitive/sensitive-epoch?
              {:epoch-id 3
               :event-id :cart/add
               :trace-events [{:op-type :event :operation :run-start}
                              {:op-type :event :operation :run-end}]}))))
 
 (deftest sensitive-epoch-empty-trace-events-passes
-  (is (not (sensitive-epoch? {:epoch-id 4 :trace-events []})))
-  (is (not (sensitive-epoch? {:epoch-id 5}))))
+  (is (not (sensitive/sensitive-epoch? {:epoch-id 4 :trace-events []})))
+  (is (not (sensitive/sensitive-epoch? {:epoch-id 5}))))
 
 (deftest sensitive-epoch-non-map-input-passes
-  (is (not (sensitive-epoch? nil)))
-  (is (not (sensitive-epoch? [:trace-events [{:sensitive? true}]])))
-  (is (not (sensitive-epoch? "anything"))))
+  (is (not (sensitive/sensitive-epoch? nil)))
+  (is (not (sensitive/sensitive-epoch? [:trace-events [{:sensitive? true}]])))
+  (is (not (sensitive/sensitive-epoch? "anything"))))
 
 (deftest sensitive-epoch-explicit-false-rollup-still-walks-trace-events
   ;; A `:sensitive? false` rollup at the top is the assembler's claim
   ;; that no constituent is sensitive. If a constituent disagrees we
   ;; trust the constituent — defense-in-depth means we drop on EITHER
   ;; signal, never silently overrule a sensitive constituent.
-  (is (sensitive-epoch?
+  (is (sensitive/sensitive-epoch?
         {:epoch-id 6
          :sensitive? false
          :trace-events [{:operation :run-end :sensitive? true}]})))
@@ -266,7 +221,7 @@
                 {:epoch-id 2
                  :event-id :auth/sign-in
                  :trace-events [{:operation :run-end :sensitive? true}]}]
-        [kept dropped] (strip-sensitive epochs false)]
+        [kept dropped] (sensitive/strip-sensitive epochs false)]
     (is (= 1 (count kept)))
     (is (= 1 (:epoch-id (first kept))))
     (is (= 1 dropped))))
@@ -275,7 +230,7 @@
   (let [epochs [{:epoch-id 1 :event-id :cart/add :trace-events [{:operation :run-end}]}
                 {:epoch-id 2 :event-id :cart/checkout :trace-events []}
                 {:epoch-id 3 :event-id :nav/route}]
-        [kept dropped] (strip-sensitive epochs false)]
+        [kept dropped] (sensitive/strip-sensitive epochs false)]
     (is (= epochs kept))
     (is (zero? dropped))))
 
@@ -296,7 +251,7 @@
                  :event-id :cart/add
                  :trace-events [{:operation :run-end}]}
                 {:epoch-id 4 :event-id :nav/route}]
-        [kept dropped] (strip-sensitive epochs false)]
+        [kept dropped] (sensitive/strip-sensitive epochs false)]
     (is (= [3 4] (mapv :epoch-id kept)))
     (is (= 2 dropped))))
 
@@ -305,6 +260,6 @@
   ;; epochs carrying sensitive constituents pass through unchanged.
   (let [epochs [{:epoch-id 1 :trace-events [{:operation :run-end :sensitive? true}]}
                 {:epoch-id 2 :sensitive? true}]
-        [kept dropped] (strip-sensitive epochs true)]
+        [kept dropped] (sensitive/strip-sensitive epochs true)]
     (is (= epochs kept))
     (is (zero? dropped))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/snapshot_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/snapshot_test.cljs
@@ -7,81 +7,43 @@
   test against a real shadow-cljs build. The CLJS layer here just
   pins the MCP-arg→runtime-opts translation so accidental renames or
   case slips break the test rather than silently shipping a broken
-  contract."
+  contract.
+
+  Tests require the public parsers directly from
+  `re-frame-pair2-mcp.tools.args` — the source ns is the contract."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [cljs.reader]
-            [clojure.string :as str]
-            [applied-science.js-interop :as j]
+            [re-frame-pair2-mcp.tools.args :as args]
             [re-frame-pair2-mcp.tools.eval-form :as ef]))
 
-;; The parsers are private in tools.cljs — re-implement the contract
-;; here so we test what callers see and so the test fails if the
-;; semantics drift. Mirror of `parse-frames-arg` and `parse-include-arg`.
-
-(def ^:private valid-slices
-  #{:app-db :sub-cache :machines :epochs :traces})
-
-(defn- ->frame-keyword [x]
-  (cond
-    (keyword? x) x
-    (string? x)
-    (let [s (if (str/starts-with? x ":") (subs x 1) x)]
-      (keyword s))
-    :else (keyword x)))
-
-(defn- parse-frames [raw]
-  (cond
-    (nil? raw) :all
-    (or (= raw :all) (= raw "all")) :all
-    (array? raw) (->> (js->clj raw) (mapv ->frame-keyword))
-    (sequential? raw) (mapv ->frame-keyword raw)
-    :else :all))
-
-(defn- parse-include [raw]
-  (let [full [:app-db :sub-cache :machines :epochs :traces]
-        coerce (fn [xs]
-                 (->> xs
-                      (map keyword)
-                      (filter valid-slices)
-                      vec))]
-    (cond
-      (nil? raw) full
-      (array? raw)
-      (let [v (coerce (js->clj raw))]
-        (if (seq v) v full))
-      (sequential? raw)
-      (let [v (coerce raw)]
-        (if (seq v) v full))
-      :else full)))
-
 (deftest frames-default-is-all
-  (is (= :all (parse-frames nil)))
-  (is (= :all (parse-frames "all"))))
+  (is (= :all (args/parse-frames-arg nil)))
+  (is (= :all (args/parse-frames-arg "all"))))
 
 (deftest frames-array-coerces-to-keywords
   (let [arr #js [":rf/default" ":stories"]]
-    (is (= [:rf/default :stories] (parse-frames arr)))))
+    (is (= [:rf/default :stories] (args/parse-frames-arg arr)))))
 
 (deftest frames-vector-coerces-to-keywords
   (is (= [:rf/default :stories]
-         (parse-frames [":rf/default" ":stories"]))))
+         (args/parse-frames-arg [":rf/default" ":stories"]))))
 
 (deftest include-default-is-full-slice-set
   (is (= [:app-db :sub-cache :machines :epochs :traces]
-         (parse-include nil)))
+         (args/parse-include-arg nil)))
   (is (= [:app-db :sub-cache :machines :epochs :traces]
-         (parse-include #js []))))
+         (args/parse-include-arg #js []))))
 
 (deftest include-filters-unknown-slices
   (testing "unknown slices fall away, known stay in order"
     (is (= [:app-db :epochs]
-           (parse-include #js ["app-db" "garbage" "epochs"]))))
+           (args/parse-include-arg #js ["app-db" "garbage" "epochs"]))))
   (testing "all-unknown falls back to the full list"
     (is (= [:app-db :sub-cache :machines :epochs :traces]
-           (parse-include #js ["garbage" "more-garbage"])))))
+           (args/parse-include-arg #js ["garbage" "more-garbage"])))))
 
 (deftest include-accepts-subset
-  (is (= [:app-db :sub-cache] (parse-include #js ["app-db" "sub-cache"]))))
+  (is (= [:app-db :sub-cache] (args/parse-include-arg #js ["app-db" "sub-cache"]))))
 
 (deftest snapshot-state-form-is-edn-readable
   ;; The MCP server lifts the opts map into the eval-form DSL
@@ -89,7 +51,7 @@
   ;; {:frames :all :include [...]})`. Assert against the parsed opts
   ;; map rather than regex-matching the source string.
   (let [opts {:frames :all
-              :include (parse-include nil)}
+              :include (args/parse-include-arg nil)}
         form (ef/emit (ef/rt-call 'snapshot-state opts))
         edn  (cljs.reader/read-string form)]
     (is (= 're-frame-pair2.runtime/snapshot-state (first edn)))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/subscribe_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/subscribe_test.cljs
@@ -9,49 +9,40 @@
   against a real shadow-cljs build."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [cljs.reader]
-            [clojure.string :as str]
             [applied-science.js-interop :as j]
+            [re-frame-pair2-mcp.tools.args :as args]
             [re-frame-pair2-mcp.tools.eval-form :as ef]))
 
-;; Mirror of `parse-filter-arg` from tools.cljs (private). Keeping a
-;; parallel test fixture documents the contract and pins the semantics —
-;; a rename in the source surfaces as a failing test rather than a
-;; silent contract drift.
-
-(defn- parse-filter [raw]
-  (cond
-    (nil? raw)    nil
-    (string? raw) (try (cljs.reader/read-string raw)
-                       (catch :default _
-                         {:invalid-filter-edn raw}))
-    (map? raw)    raw
-    :else         (js->clj raw :keywordize-keys true)))
+;; The MCP-arg filter parser lives in
+;; `re-frame-pair2-mcp.tools.args/parse-filter-arg`. Tests pin the
+;; public surface directly so a rename or signature change surfaces
+;; as a failing test rather than a silent contract drift.
 
 (deftest filter-arg-nil-passes-through
-  (is (nil? (parse-filter nil))))
+  (is (nil? (args/parse-filter-arg nil))))
 
 (deftest filter-arg-edn-string-reads
   (is (= {:op-type :error}
-         (parse-filter "{:op-type :error}"))))
+         (args/parse-filter-arg "{:op-type :error}"))))
 
 (deftest filter-arg-edn-string-with-touches-path
   (is (= {:touches-path [:cart :items]}
-         (parse-filter "{:touches-path [:cart :items]}"))))
+         (args/parse-filter-arg "{:touches-path [:cart :items]}"))))
 
 (deftest filter-arg-malformed-edn-surfaces-marker
   (is (= {:invalid-filter-edn "((("}
-         (parse-filter "(((")))) ;; unbalanced delimiters
+         (args/parse-filter-arg "(((")))) ;; unbalanced delimiters
 
 (deftest filter-arg-js-object-keywordises
   (let [obj #js {:op-type "error" :event-id "user/login"}
-        out (parse-filter obj)]
+        out (args/parse-filter-arg obj)]
     (is (map? out))
     (is (= "error" (:op-type out)))
     (is (= "user/login" (:event-id out)))))
 
 (deftest filter-arg-clj-map-passes-through
   (is (= {:op-type :error}
-         (parse-filter {:op-type :error}))))
+         (args/parse-filter-arg {:op-type :error}))))
 
 ;; The subscribe-form constructor is private. Re-implement here over
 ;; the eval-form DSL to pin the IR + emitted source we send to the

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/wire_cap_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/wire_cap_test.cljs
@@ -4,92 +4,23 @@
   Per `tools/pair2-mcp/spec/Principles.md` §\"Tight token budget per
   response\", every MCP `tools/call` response is bounded at ~5,000
   tokens by default. The cap is enforced at the wire boundary in
-  `tools.cljs`: any payload whose serialised size exceeds the cap is
-  replaced with a structured `{:rf.mcp/overflow ...}` marker.
+  `tools/cap.cljs`: any payload whose serialised size exceeds the cap
+  is replaced with a structured `{:rf.mcp/overflow ...}` marker.
 
-  These tests mirror the private wire-cap helpers from `tools.cljs`
-  (`token-estimate`, `max-tokens-arg`, `overflow-payload`,
-  `sum-text-tokens`, `apply-cap`). A rename or signature change
-  surfaces as a failing test rather than a silent contract drift.
+  Tests pin the public helpers directly from
+  `re-frame-pair2-mcp.tools.cap`: `token-estimate`, `max-tokens-arg`,
+  `overflow-payload`, `sum-text-tokens`, `apply-cap`,
+  `overflow-hints`, `overflow-hint-fallback`, `default-max-tokens`.
+  A rename or signature change surfaces as a failing test rather
+  than a silent contract drift.
 
   Live end-to-end coverage of `invoke` lives in
   `test/stdio-roundtrip.js`. The CLJS unit layer here pins the
   per-strategy semantics and the structured-marker shape."
   (:require [cljs.test :refer-macros [deftest is]]
             [cljs.reader]
-            [applied-science.js-interop :as j]))
-
-;; ---------------------------------------------------------------------------
-;; Mirrors of the private wire-cap helpers. Keep in lockstep with
-;; `tools.cljs`.
-;; ---------------------------------------------------------------------------
-
-(def ^:private default-max-tokens 5000)
-
-(defn- token-estimate [s]
-  (quot (count s) 4))
-
-(defn- max-tokens-arg [args]
-  (let [raw (when args (j/get args "max-tokens"))]
-    (cond
-      (or (nil? raw) (undefined? raw)) default-max-tokens
-      (and (number? raw) (zero? raw))  nil
-      (number? raw)                    (long raw)
-      :else                            default-max-tokens)))
-
-(def ^:private overflow-hints
-  {"snapshot"      "Narrow scope: pass `path [:k1 :k2]` to slice the :app-db slice, `frames` to a single frame, or `include` to a single slice (one of app-db, sub-cache, machines, epochs, traces). Default mode is :summary — drill down via `get-path` once you know the key."
-   "get-path"      "Narrow the path further — pass a deeper segment so the addressed subtree is smaller. Or call `snapshot` with no `path` first for a tree-summary, then re-aim."
-   "trace-window"  "Reduce `ms` to a smaller window, narrow with `frame`, or fetch incrementally via `watch-epochs` + `since-id`."
-   "watch-epochs"  "Narrow `pred` (e.g. `:event-id-prefix`, `:effects`), pass `frame`, or stream via `subscribe` with `max-events`."
-   "subscribe"     "Tighten `filter`, lower `max-buffered-events` / `max-buffered-bytes`, set `max-events` so each tick stays small."
-   "eval-cljs"     "Slice the value at the call-site (`get-in`, `take`, project to fewer keys) before returning."
-   "discover-app"  "Unusual — the health summary should be small. Inspect `(re-frame-pair2.runtime/health)` directly via `eval-cljs` with a projection."
-   "dispatch"      "Trace mode is returning a full epoch — re-run with `trace false` and read the epoch via `watch-epochs`/`snapshot` with a narrower path."})
-
-(def ^:private overflow-hint-fallback
-  "Response over budget. Re-call with narrower args, or raise `max-tokens` (0 disables the cap).")
-
-(defn- overflow-payload
-  [{:keys [tool token-count cap]}]
-  {:rf.mcp/overflow {:limit       :reached
-                     :token-count token-count
-                     :cap-tokens  cap
-                     :tool        tool
-                     :hint        (get overflow-hints tool overflow-hint-fallback)}})
-
-(defn- sum-text-tokens [result-js]
-  (let [content (j/get result-js :content)
-        n      (if (array? content) (.-length content) 0)]
-    (loop [i 0 sum 0]
-      (if (< i n)
-        (let [item (aget content i)
-              text (when item (j/get item :text))
-              t    (if (string? text) (token-estimate text) 0)]
-          (recur (inc i) (+ sum t)))
-        sum))))
-
-(defn- overflow-result [tool token-count cap]
-  #js {:content #js [#js {:type "text"
-                          :text (pr-str (overflow-payload
-                                          {:tool        tool
-                                           :token-count token-count
-                                           :cap         cap}))}]})
-
-(defn- apply-cap
-  [result-js {:keys [tool cap strategy]
-              :or   {strategy :truncate-with-marker}}]
-  (cond
-    (nil? cap)        result-js
-    (nil? result-js)  result-js
-    :else
-    (let [tokens (sum-text-tokens result-js)]
-      (if (<= tokens cap)
-        result-js
-        (case strategy
-          :truncate-with-marker
-          (overflow-result tool tokens cap)
-          (overflow-result tool tokens cap))))))
+            [applied-science.js-interop :as j]
+            [re-frame-pair2-mcp.tools.cap :as cap]))
 
 ;; ---------------------------------------------------------------------------
 ;; Helpers for building MCP result shapes inside tests.
@@ -114,29 +45,29 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest token-estimate-is-chars-div-4
-  (is (zero? (token-estimate "")))
-  (is (zero? (token-estimate "abc")))
-  (is (= 1 (token-estimate "abcd")))
-  (is (= 250 (token-estimate (big-string 1000))))
-  (is (= 5000 (token-estimate (big-string 20000)))))
+  (is (zero? (cap/token-estimate "")))
+  (is (zero? (cap/token-estimate "abc")))
+  (is (= 1 (cap/token-estimate "abcd")))
+  (is (= 250 (cap/token-estimate (big-string 1000))))
+  (is (= 5000 (cap/token-estimate (big-string 20000)))))
 
 ;; ---------------------------------------------------------------------------
 ;; max-tokens-arg — per-call override resolution.
 ;; ---------------------------------------------------------------------------
 
 (deftest max-tokens-arg-default-when-absent
-  (is (= default-max-tokens (max-tokens-arg #js {})))
-  (is (= default-max-tokens (max-tokens-arg nil))))
+  (is (= cap/default-max-tokens (cap/max-tokens-arg #js {})))
+  (is (= cap/default-max-tokens (cap/max-tokens-arg nil))))
 
 (deftest max-tokens-arg-zero-disables-cap
-  (is (nil? (max-tokens-arg #js {"max-tokens" 0}))))
+  (is (nil? (cap/max-tokens-arg #js {"max-tokens" 0}))))
 
 (deftest max-tokens-arg-positive-integer-passed-through
-  (is (= 1000 (max-tokens-arg #js {"max-tokens" 1000})))
-  (is (= 50000 (max-tokens-arg #js {"max-tokens" 50000}))))
+  (is (= 1000 (cap/max-tokens-arg #js {"max-tokens" 1000})))
+  (is (= 50000 (cap/max-tokens-arg #js {"max-tokens" 50000}))))
 
 (deftest max-tokens-arg-non-number-falls-back-to-default
-  (is (= default-max-tokens (max-tokens-arg #js {"max-tokens" "bogus"}))))
+  (is (= cap/default-max-tokens (cap/max-tokens-arg #js {"max-tokens" "bogus"}))))
 
 ;; ---------------------------------------------------------------------------
 ;; sum-text-tokens — sums every `:text` slot.
@@ -144,16 +75,16 @@
 
 (deftest sum-text-tokens-single-slot
   (let [r (ok-text-result {:hello "world"})]
-    (is (pos? (sum-text-tokens r)))
-    (is (= (token-estimate (read-text r)) (sum-text-tokens r)))))
+    (is (pos? (cap/sum-text-tokens r)))
+    (is (= (cap/token-estimate (read-text r)) (cap/sum-text-tokens r)))))
 
 (deftest sum-text-tokens-empty-content-is-zero
-  (is (zero? (sum-text-tokens #js {:content #js []}))))
+  (is (zero? (cap/sum-text-tokens #js {:content #js []}))))
 
 (deftest sum-text-tokens-aggregates-across-slots
   (let [r #js {:content #js [#js {:type "text" :text (big-string 4000)}
                               #js {:type "text" :text (big-string 4000)}]}]
-    (is (= 2000 (sum-text-tokens r)))))
+    (is (= 2000 (cap/sum-text-tokens r)))))
 
 ;; ---------------------------------------------------------------------------
 ;; apply-cap — the strategy entry point.
@@ -161,13 +92,13 @@
 
 (deftest apply-cap-passes-under-budget-payload-untouched
   (let [r (ok-text-result {:small :payload})
-        out (apply-cap r {:tool "snapshot" :cap default-max-tokens})]
+        out (cap/apply-cap r {:tool "snapshot" :cap cap/default-max-tokens})]
     (is (identical? r out))
     (is (= {:small :payload} (read-edn out)))))
 
 (deftest apply-cap-nil-cap-disables-enforcement
   (let [r (ok-text-result {:k (big-string 100000)})
-        out (apply-cap r {:tool "snapshot" :cap nil})]
+        out (cap/apply-cap r {:tool "snapshot" :cap nil})]
     (is (identical? r out))
     (is (not (contains? (read-edn out) :rf.mcp/overflow)))))
 
@@ -176,7 +107,7 @@
         ;; ~1000 tokens. Two of them ⇒ 2000+ tokens, over a 500 cap.
         big (apply str (repeat 4000 "x"))
         r   (ok-text-result {:huge big})
-        out (apply-cap r {:tool "snapshot" :cap 500})
+        out (cap/apply-cap r {:tool "snapshot" :cap 500})
         edn (read-edn out)]
     (is (contains? edn :rf.mcp/overflow))
     (let [marker (:rf.mcp/overflow edn)]
@@ -192,25 +123,25 @@
   ;; The replacement marker must fit; otherwise we recurse on overflow.
   (let [big (apply str (repeat 8000 "x"))
         r   (ok-text-result {:huge big})
-        out (apply-cap r {:tool "snapshot" :cap 500})]
-    (is (<= (sum-text-tokens out) 500)
+        out (cap/apply-cap r {:tool "snapshot" :cap 500})]
+    (is (<= (cap/sum-text-tokens out) 500)
         "The overflow marker itself must be under the cap")))
 
 (deftest apply-cap-unknown-tool-uses-fallback-hint
   (let [big (apply str (repeat 8000 "x"))
         r   (ok-text-result {:huge big})
-        out (apply-cap r {:tool "no-such-tool" :cap 500})
+        out (cap/apply-cap r {:tool "no-such-tool" :cap 500})
         edn (read-edn out)
         marker (:rf.mcp/overflow edn)]
     (is (= "no-such-tool" (:tool marker)))
-    (is (= overflow-hint-fallback (:hint marker)))))
+    (is (= cap/overflow-hint-fallback (:hint marker)))))
 
 (deftest apply-cap-unknown-strategy-degrades-safely
   ;; Unknown strategy must NOT throw and must NOT ship the over-budget
   ;; payload. It falls back to the marker, same as :truncate-with-marker.
   (let [big (apply str (repeat 8000 "x"))
         r   (ok-text-result {:huge big})
-        out (apply-cap r {:tool "snapshot" :cap 500 :strategy :unknown-strategy})
+        out (cap/apply-cap r {:tool "snapshot" :cap 500 :strategy :unknown-strategy})
         edn (read-edn out)]
     (is (contains? edn :rf.mcp/overflow))))
 
@@ -220,8 +151,8 @@
         ;; text is ~402 chars ⇒ 100 tokens.
         s    (apply str (repeat 400 "x"))
         r    (ok-text-result s)
-        toks (sum-text-tokens r)
-        out  (apply-cap r {:tool "snapshot" :cap toks})]
+        toks (cap/sum-text-tokens r)
+        out  (cap/apply-cap r {:tool "snapshot" :cap toks})]
     (is (identical? r out))))
 
 ;; ---------------------------------------------------------------------------
@@ -237,16 +168,16 @@
   (let [big-app-db (apply str (repeat (* 5 1024 1024) "x"))  ;; 5 MB
         snapshot {:rf/default {:app-db big-app-db}}
         r        (ok-text-result {:ok? true :snapshot snapshot})
-        out      (apply-cap r {:tool "snapshot" :cap default-max-tokens})
+        out      (cap/apply-cap r {:tool "snapshot" :cap cap/default-max-tokens})
         edn      (read-edn out)]
     (is (contains? edn :rf.mcp/overflow)
         "5MB payload MUST be replaced with overflow marker, not shipped raw")
-    (is (<= (sum-text-tokens out) default-max-tokens)
+    (is (<= (cap/sum-text-tokens out) cap/default-max-tokens)
         "Replacement payload MUST be under the cap")
     (let [marker (:rf.mcp/overflow edn)]
       (is (= :reached (:limit marker)))
       (is (= "snapshot" (:tool marker)))
-      (is (> (:token-count marker) (* 200 default-max-tokens))
+      (is (> (:token-count marker) (* 200 cap/default-max-tokens))
           "Token-count reflects the original oversized payload"))))
 
 ;; ---------------------------------------------------------------------------
@@ -263,5 +194,5 @@
                                  "subscribe" "eval-cljs" "discover-app"
                                  "dispatch"}]
     (doseq [t tools-with-data-volume]
-      (is (contains? overflow-hints t)
+      (is (contains? cap/overflow-hints t)
           (str "Missing overflow hint for tool: " t)))))


### PR DESCRIPTION
## Summary

Eleven `tools/pair2-mcp/test/` namespaces had prefixed each block with "Mirror of … private helpers in tools.cljs. Keep in lockstep" and re-implemented ~250 LoC of helpers. Tests pinned the mirror, not the source — a bug fix in `tools.cljs` didn't propagate.

This PR drops every hand-copy and wires each test through `:require :as` to the owning source ns. The source ns IS the contract; tests fail when source signatures drift, not after both have drifted in lockstep.

- Promoted `decode-all-frames` (`nrepl.cljs`) from `defn-` to `defn` so `nrepl_test` can require it. Every other lifted fn was already public after the rf2-vrbwx split.
- Replaced mirrors across `cursor_pagination_test`, `dedup_test`, `diff_encode_epochs_test`, `elision_test`, `lazy_summary_test`, `nrepl_test`, `path_slicing_test`, `sensitive_filter_test`, `snapshot_test`, `subscribe_test`, `wire_cap_test`.
- Left eval-form composer mirrors alone where rf2-dpzpe's mini-DSL keeps the source counterparts inlined per-tool rather than extracted to standalone public fns (`build-snapshot-form` / `build-get-path-form` in `elision_test`; `subscribe-opts` / `subscribe-form` / `unsubscribe-form` / `drain-form` in `subscribe_test`).

Net: -594 LoC removed from the test corpus.

## Test plan

- [x] `npm test` from `tools/pair2-mcp/`: **289 tests, 686 assertions, 0 failures, 0 errors**.

## Fns lifted

| Test ns                    | Source ns                                    | Lifted fns / vars                                                                                                                |
|----------------------------|----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
| cursor_pagination_test     | tools.cursor                                 | parse-limit-arg, encode-cursor, decode-cursor, default-limit                                                                     |
| dedup_test                 | tools.dedup, tools.snapshot-pipeline         | parse-dedup-arg, empty-payload?, dedup-value, dedup-expand, dedup-epochs-in-snapshot                                             |
| diff_encode_epochs_test    | re-frame.mcp-base.diff-encode, tools.dedup, tools.snapshot-pipeline | collect-patches, apply-patches, diff-encode-db-after, decode-db-after, diff-encode-epochs, parse-epochs-mode, diff-encode-epochs-in-snapshot |
| elision_test               | tools.elision                                | parse-elision-arg, elision-opts-edn                                                                                              |
| lazy_summary_test          | tools.args, tools.snapshot-pipeline, tools.summary, tools.cap | parse-mode-arg, parse-modes-arg, resolve-slice-mode, summarise-other-slices-in-snapshot, tree-summary, token-estimate |
| nrepl_test                 | nrepl                                        | decode-all-frames (newly public)                                                                                                 |
| path_slicing_test          | tools.args, tools.summary, tools.snapshot-pipeline, tools.cap | parse-path-arg, tree-summary, deepest-valid-prefix, slice-app-db-in-snapshot, token-estimate, summary-keys-cap |
| sensitive_filter_test      | tools.sensitive                              | sensitive-event?, sensitive-epoch?, strip-sensitive, scrub-snapshot-sensitive                                                    |
| snapshot_test              | tools.args                                   | parse-frames-arg, parse-include-arg                                                                                              |
| subscribe_test             | tools.args                                   | parse-filter-arg                                                                                                                 |
| wire_cap_test              | tools.cap                                    | token-estimate, max-tokens-arg, sum-text-tokens, apply-cap, overflow-hints, overflow-hint-fallback, default-max-tokens           |