### PR TITLE
fix(ssr): invoke root-view once per request, share result (rf2-6t36h)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -317,30 +317,23 @@
     (rf/destroy-frame frame-id)
     (catch Throwable _ nil)))
 
-(defn- render-body
-  "Render the root view against the per-request frame. Wrapped here so
-  view-time exceptions can be projected through the SSR error path
-  per Spec 011 §View-time exceptions. Returns the HTML string."
-  [frame-id root-view emit-hash?]
-  (rf/with-frame frame-id
-    (let [hiccup (cond
-                   (vector? root-view) root-view
-                   (fn?     root-view) (root-view)
-                   :else
-                   (throw (ex-info ":rf.error/invalid-root-view"
-                                   {:reason   "root-view must be a hiccup vector or a 0-arity fn"
-                                    :received root-view})))]
-      (ssr/render-to-string hiccup {:doctype?   false
-                                    :emit-hash? emit-hash?}))))
-
-(defn- render-hash-for
-  "Compute the structural render-tree hash. Mirrors render-body's
-  root-view resolution so the payload's :rf/render-hash matches the
-  data-rf-render-hash embedded in the wire HTML."
-  [frame-id root-view]
-  (rf/with-frame frame-id
-    (let [hiccup (if (fn? root-view) (root-view) root-view)]
-      (ssr/render-tree-hash hiccup))))
+(defn- resolve-root-view
+  "Resolve the caller's `:root-view` opt to a hiccup vector. Accepts
+  either a hiccup vector directly OR a 0-arity fn that returns hiccup.
+  Per rf2-6t36h this MUST run exactly once per request — the fn-form
+  branch is not guaranteed to be idempotent (unsorted-map iteration,
+  gensym'd keys, time-of-day props can all vary between calls) and any
+  variance between two invocations produces a hash mismatch on the wire
+  vs the payload, firing a spurious `:rf.ssr/hydration-mismatch` on a
+  perfectly successful hydration. Resolve once, thread the result."
+  [root-view]
+  (cond
+    (vector? root-view) root-view
+    (fn?     root-view) (root-view)
+    :else
+    (throw (ex-info ":rf.error/invalid-root-view"
+                    {:reason   "root-view must be a hiccup vector or a 0-arity fn"
+                     :received root-view}))))
 
 (defn- resolve-head-html
   "Resolve the active route's `:head` against `frame-id` (or the default
@@ -515,8 +508,20 @@
               (ssr-response->ring-response response nil)
 
               :else
-              (let [body-html   (render-body frame-id root-view emit-hash?)
-                    hash-str    (render-hash-for frame-id root-view)
+              ;; rf2-6t36h: resolve root-view EXACTLY ONCE per request.
+              ;; Both the wire HTML (via render-to-string + its embedded
+              ;; data-rf-render-hash) and the payload's :rf/render-hash
+              ;; must derive from the same hiccup tree, otherwise a
+              ;; non-idempotent fn-form root-view produces two trees and
+              ;; the on-client mismatch check fires on a successful
+              ;; hydration. `with-frame` binds *current-frame* for the
+              ;; view-time subscribes / view-registry lookups.
+              (let [hiccup      (rf/with-frame frame-id (resolve-root-view root-view))
+                    body-html   (rf/with-frame frame-id
+                                  (ssr/render-to-string hiccup
+                                                        {:doctype?   false
+                                                         :emit-hash? emit-hash?}))
+                    hash-str    (ssr/render-tree-hash hiccup)
                     payload     (build-payload frame-id app-db hash-str
                                                {:version       version
                                                 :schema-digest schema-digest

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -293,6 +293,91 @@
       (is (str/includes? (:body response) "caught: boom-2")))))
 
 ;; ===========================================================================
+;; ssr-handler — fn-form :root-view invoked exactly once per request (rf2-6t36h)
+;;
+;; The fn-form branch of `:root-view` is not guaranteed to be idempotent —
+;; unsorted-map iteration order, gensym'd react keys, and time-of-day
+;; props all vary between calls. Pre-rf2-6t36h the adapter invoked the
+;; root-view fn twice per request (once for the wire HTML / its embedded
+;; data-rf-render-hash, once for the payload's :rf/render-hash). Two
+;; non-identical trees → two non-equal hashes → spurious
+;; :rf.ssr/hydration-mismatch on the client for an otherwise successful
+;; hydration.
+;;
+;; These tests pin the contract: ONE invocation per request, and the wire
+;; hash equals the payload hash even when the fn is technically
+;; non-idempotent.
+;; ===========================================================================
+
+(deftest fn-form-root-view-invoked-exactly-once-per-request
+  (testing "rf2-6t36h: a 0-arity fn :root-view fires exactly once per request"
+    (let [call-count (atom 0)]
+      (rf/reg-event-fx :init/ok-once
+        {:platforms #{:server}}
+        (fn [_ _] {}))
+
+      (rf/reg-view* :pages/once
+        (fn [] [:div.page "once"]))
+
+      (let [handler  (ssr-ring/ssr-handler
+                       {:on-create [:init/ok-once]
+                        :root-view (fn []
+                                     (swap! call-count inc)
+                                     [:pages/once])})
+            response (handler {:uri "/once" :request-method :get})]
+        (is (= 200 (:status response)))
+        (is (= 1 @call-count)
+            "fn-form :root-view must be invoked exactly once per request
+             (rf2-6t36h: was 2 — once for wire HTML, once for hash)")))))
+
+(deftest fn-form-root-view-non-idempotent-still-hashes-consistently
+  (testing "rf2-6t36h: a non-idempotent fn-form :root-view produces a wire
+            hash that matches the payload hash — the same tree is used for
+            both, so the client mismatch check does NOT fire spuriously"
+    (let [counter (atom 0)]
+      (rf/reg-event-fx :init/ok-noni
+        {:platforms #{:server}}
+        (fn [_ _] {}))
+
+      ;; A view fn that produces a DIFFERENT tree on every call — its
+      ;; key includes a monotonic counter. Pre-rf2-6t36h the wire HTML
+      ;; would carry hash(tree_1) and the payload would carry
+      ;; hash(tree_2); they would differ and the client's hydration
+      ;; verifier would fire a spurious mismatch.
+      (rf/reg-view* :pages/noni
+        (fn [n] [:div {:data-call n} "noni"]))
+
+      (let [handler  (ssr-ring/ssr-handler
+                       {:on-create [:init/ok-noni]
+                        :root-view (fn []
+                                     [:pages/noni (swap! counter inc)])})
+            response (handler {:uri "/noni" :request-method :get})
+            body     (:body response)
+            wire-hash (second (re-find #"data-rf-render-hash=\"([0-9a-f]{8})\""
+                                       body))
+            payload-edn (second (re-find
+                                  #"<script id=\"__rf_payload\"[^>]*>(.*?)</script>"
+                                  body))
+            ;; Payload EDN uses the `#:rf{...}` namespace-map shorthand
+            ;; (pr-str's default rendering for a map whose keys all share
+            ;; the `:rf/` namespace) — so `:rf/render-hash` collapses to
+            ;; `:render-hash` inside that block. Match either rendering
+            ;; so the test is robust against the pr-str-shape choice.
+            payload-hash (second (re-find
+                                   #":(?:rf/)?render-hash \"([0-9a-f]{8})\""
+                                   payload-edn))]
+        (is (= 200 (:status response)))
+        (is (some? wire-hash)
+            "data-rf-render-hash present on wire root element")
+        (is (some? payload-hash)
+            ":rf/render-hash present in hydration payload")
+        (is (= wire-hash payload-hash)
+            "rf2-6t36h: wire hash MUST equal payload hash — both derive
+             from the same single invocation of the fn-form root-view")
+        (is (= 1 @counter)
+            "side-effect counter confirms the fn was invoked exactly once")))))
+
+;; ===========================================================================
 ;; ssr-handler — Ring → :rf.server/request cofx (rf2-afxhv)
 ;;
 ;; The canonical Ring-adapter ↔ cofx boundary. Per Spec 011 §Request


### PR DESCRIPTION
## Summary

Pre-rf2-6t36h the Ring host adapter resolved `:root-view` **twice per request** — once in `render-body` (for the wire HTML and its embedded `data-rf-render-hash`) and again in `render-hash-for` (for the hydration payload's `:rf/render-hash`).

For a fn-form `:root-view` this caused:

- **2x cost.** View-time setup, hiccup allocation, and any subscribe reads inside the fn ran twice per request.
- **Correctness gap.** A non-idempotent fn (unsorted-map iteration order, gensym'd react keys, time-of-day props, ...) produces two distinct trees, hence two distinct hashes, hence a spurious `:rf.ssr/hydration-mismatch` on a perfectly successful hydration.

## Fix

Resolve the root-view **exactly once** in the handler, thread the single hiccup tree into both `render-to-string` and `render-tree-hash`. The two helpers (`render-body` / `render-hash-for`) collapse into the call site; a single `resolve-root-view` helper carries the dispatch on the `:root-view` shape (vector pass-through vs fn invocation, with structured throw for everything else).

```clojure
(let [hiccup    (rf/with-frame frame-id (resolve-root-view root-view))
      body-html (rf/with-frame frame-id
                  (ssr/render-to-string hiccup {:doctype? false :emit-hash? emit-hash?}))
      hash-str  (ssr/render-tree-hash hiccup)
      ...])
```

## Tests added

Both tests fail on pre-fix code (call-count = 2, wire-hash != payload-hash):

- `fn-form-root-view-invoked-exactly-once-per-request` — a side-effect counter inside the fn-form root-view pins the invocation count at 1.
- `fn-form-root-view-non-idempotent-still-hashes-consistently` — a monotonically-counting view fn confirms the wire-embedded `data-rf-render-hash` equals the payload's `:rf/render-hash` even when the fn is technically non-idempotent. This is the regression bite for the spurious hydration-mismatch.

## Risk

Low — pure refactor that removes duplication. The vector-form `:root-view` path is unchanged. The fn-form path now matches its documented contract: invoked once per request, against the per-request frame.

## Test plan

- [x] `clojure -M:test` from `implementation/ssr-ring/` — 19 tests, 80 assertions, 0 failures
- [x] `clojure -M:test` from `implementation/ssr/` — 76 tests, 236 assertions, 0 failures
- [x] `npm run test:cljs` from `implementation/` — 1795 tests, 4975 assertions, 0 failures

Closes rf2-6t36h.