### PR TITLE
refactor(core): uniform 'no adapter installed' throw across substrate delegation fns (rf2-zdfi1)

### DIFF
--- a/implementation/core/src/re_frame/substrate/adapter.cljc
+++ b/implementation/core/src/re_frame/substrate/adapter.cljc
@@ -88,14 +88,52 @@
 ;; ---- delegation helpers ---------------------------------------------------
 ;; These let other namespaces call adapter functions without knowing which
 ;; adapter is installed.
+;;
+;; Every delegation fn routes through `require-adapter!` so an app that
+;; calls into the runtime before `(rf/init! ...)` sees one uniform
+;; `:rf.error/no-adapter-installed` ex-info regardless of which surface
+;; it hit first (rf2-zdfi1). The earlier shape was a mix of
+;; `(ex-info "no adapter installed" {})` on `make-state-container` and
+;; silent NPEs on the other delegation fns — strictly worse than a
+;; structured throw because background-thread NPEs are hard to diagnose
+;; and the ex-info shape did not match the documented missing-artefact
+;; contract used elsewhere in core (see rf2-h824v + rf2-uchhp).
+
+(defn- require-adapter!
+  "Return the installed adapter spec map or throw a uniform
+  `:rf.error/no-adapter-installed` ex-info naming the offending
+  delegation surface via `where-sym` (rf2-zdfi1).
+
+  Shape matches the broader missing-fn throw contract (the
+  `re-frame.late-bind/require-fn!` helper, rf2-h824v, rf2-uchhp):
+
+    Message: \":rf.error/no-adapter-installed\"
+    ex-data: {:where    <where-sym>
+              :recovery :no-recovery
+              :reason   \"<where-sym> was called before (rf/init! ...);
+                         require an adapter ns and pass its `adapter`
+                         Var, e.g. (rf/init! reagent/adapter).\"}
+
+  `where-sym` is stamped on the throw so grep-for-symbol finds the
+  delegation site in user code. Private — callers in this ns thread
+  the symbol of the public surface they implement (e.g.
+  `'rf/make-state-container`)."
+  [where-sym]
+  (or @installed-adapter
+      (throw (ex-info ":rf.error/no-adapter-installed"
+                      {:where    where-sym
+                       :recovery :no-recovery
+                       :reason   (str where-sym " was called before (rf/init! ...);"
+                                      " require an adapter ns and pass its `adapter` Var,"
+                                      " e.g. (rf/init! reagent/adapter).")}))))
 
 (defn make-state-container [initial-value]
-  (let [a (or @installed-adapter
-              (throw (ex-info "no adapter installed" {})))]
+  (let [a (require-adapter! 'rf/make-state-container)]
     ((:make-state-container a) initial-value)))
 
 (defn read-container [container]
-  (let [a @installed-adapter] ((:read-container a) container)))
+  (let [a (require-adapter! 'rf/read-container)]
+    ((:read-container a) container)))
 
 (defn replace-container!
   "Write `new-value` into `container` via the installed adapter.
@@ -115,32 +153,45 @@
     (trace/emit! :warning :rf.warning/write-after-destroy
                  {:reason   "replace-container! called with nil container; the frame was likely destroyed mid-drain or before a scheduled write fired"
                   :recovery :no-recovery})
-    (let [a @installed-adapter] ((:replace-container! a) container new-value))))
+    (let [a (require-adapter! 'rf/replace-container!)]
+      ((:replace-container! a) container new-value))))
 
 (defn make-derived-value [source-containers compute-fn]
-  (let [a @installed-adapter]
+  (let [a (require-adapter! 'rf/make-derived-value)]
     ((:make-derived-value a) source-containers compute-fn)))
 
 (defn render [render-tree mount-point opts]
-  (let [a @installed-adapter] ((:render a) render-tree mount-point opts)))
+  (let [a (require-adapter! 'rf/render)]
+    ((:render a) render-tree mount-point opts)))
 
 (defn render-to-string [render-tree opts]
-  (let [a @installed-adapter] ((:render-to-string a) render-tree opts)))
+  (let [a (require-adapter! 'rf/render-to-string)]
+    ((:render-to-string a) render-tree opts)))
 
 (defn subscribe-container
-  "Optional — adapters may omit. Returns nil if the adapter doesn't
-  implement it; callers fall back to running invalidation inline within
-  replace-container! (per Spec 006)."
+  "Optional — adapters may omit. Returns nil if the installed adapter
+  doesn't implement it; callers fall back to running invalidation inline
+  within replace-container! (per Spec 006).
+
+  Calling this before `(rf/init! ...)` raises
+  `:rf.error/no-adapter-installed` (rf2-zdfi1) — the optional-fn nil
+  return is reserved for `adapter installed, fn absent`, not for `no
+  adapter installed at all`."
   [container on-change]
-  (let [a @installed-adapter
+  (let [a (require-adapter! 'rf/subscribe-container)
         f (:subscribe-container a)]
     (when f (f container on-change))))
 
 (defn register-context-provider
   "Optional. Returns the substrate's context-provider component for this
-  frame keyword, or nil if the substrate has no context concept."
+  frame keyword, or nil if the substrate has no context concept.
+
+  Calling this before `(rf/init! ...)` raises
+  `:rf.error/no-adapter-installed` (rf2-zdfi1) — the optional-fn nil
+  return is reserved for `adapter installed, fn absent`, not for `no
+  adapter installed at all`."
   [frame-keyword]
-  (let [a @installed-adapter
+  (let [a (require-adapter! 'rf/register-context-provider)
         f (:register-context-provider a)]
     (when f (f frame-keyword))))
 

--- a/implementation/core/test/re_frame/boot_test.clj
+++ b/implementation/core/test/re_frame/boot_test.clj
@@ -340,3 +340,73 @@
               "adapter B's :replace-container! was invoked by dispatch-sync (proves event commit routes through B, not the disposed A)"))
         (is (= 99 (rf/subscribe-value :rf/default [:n]))
             "registered :seed event + :n sub still work end-to-end under adapter B")))))
+
+;; ---- substrate delegation: uniform no-adapter-installed throw (rf2-zdfi1) -
+;;
+;; Per rf2-zdfi1 every substrate-delegation fn in
+;; `re-frame.substrate.adapter` throws ONE shape when no adapter is
+;; installed:
+;;
+;;   :rf.error/no-adapter-installed
+;;   {:where    'rf/<fn>            ;; the offending public-surface symbol
+;;    :recovery :no-recovery
+;;    :reason   "<where> was called before (rf/init! ...); ..."}
+;;
+;; Before rf2-zdfi1 only `make-state-container` threw structured ex-info;
+;; the other five required delegation fns (`read-container`,
+;; `replace-container!`, `make-derived-value`, `render`, `render-to-string`)
+;; plus the two optional fns (`subscribe-container`,
+;; `register-context-provider`) silently NPE'd on a nil adapter — strictly
+;; worse than a structured throw because background-thread NPEs are hard
+;; to diagnose and the ex-info shape did not match the documented
+;; missing-fn contract used elsewhere in core (rf2-h824v + rf2-uchhp).
+
+(defn- catch-no-adapter
+  "Invoke `thunk` with no adapter installed; return the caught
+  ExceptionInfo (or nil if nothing threw)."
+  [thunk]
+  (try (thunk) nil
+       (catch clojure.lang.ExceptionInfo e e)))
+
+(deftest substrate-delegation-uniform-no-adapter-throw
+  (testing "every substrate-delegation fn throws :rf.error/no-adapter-installed before (rf/init! ...)"
+    (is (nil? (adapter/current-adapter))
+        "precondition: cold start — no adapter installed")
+    (let [cases [['rf/make-state-container        #(adapter/make-state-container         {:k :v})]
+                 ['rf/read-container              #(adapter/read-container               ::dummy-container)]
+                 ['rf/replace-container!          #(adapter/replace-container!           ::dummy-container {:new :value})]
+                 ['rf/make-derived-value          #(adapter/make-derived-value           [::source]        (constantly 42))]
+                 ['rf/render                      #(adapter/render                       [:div]            ::mount-point {})]
+                 ['rf/render-to-string            #(adapter/render-to-string             [:div]            {})]
+                 ['rf/subscribe-container         #(adapter/subscribe-container          ::dummy-container (fn [_]))]
+                 ['rf/register-context-provider   #(adapter/register-context-provider    :rf/default)]]]
+      (doseq [[where-sym thunk] cases]
+        (let [thrown (catch-no-adapter thunk)]
+          (is (some? thrown)
+              (str where-sym " throws when called before (rf/init! ...)"))
+          (is (= ":rf.error/no-adapter-installed"
+                 (some-> thrown ex-message))
+              (str where-sym " ex-message carries the :rf.error/no-adapter-installed tag"))
+          (let [data (ex-data thrown)]
+            (is (= where-sym (:where data))
+                (str where-sym " ex-data :where echoes the offending public surface symbol"))
+            (is (= :no-recovery (:recovery data))
+                (str where-sym " ex-data :recovery is :no-recovery"))
+            (is (string? (:reason data))
+                (str where-sym " ex-data :reason is a string pointing at (rf/init! ...)"))
+            (is (re-find #"rf/init!" (str (:reason data)))
+                (str where-sym " ex-data :reason names rf/init! as the recovery action"))))))))
+
+(deftest replace-container-nil-container-skips-adapter-check
+  (testing "replace-container! with a nil container short-circuits via the rf2-ft2b warning trace and does NOT consult the adapter slot"
+    ;; Defense-in-depth nil-container guard is checked BEFORE the
+    ;; adapter lookup so a scheduled drain hitting a destroyed frame
+    ;; does not produce a misleading 'no-adapter-installed' throw — it
+    ;; correctly emits :rf.warning/write-after-destroy regardless of
+    ;; whether an adapter is installed.
+    (is (nil? (adapter/current-adapter))
+        "precondition: no adapter installed")
+    (is (nil? (adapter/replace-container! nil {:any :value}))
+        "replace-container! on nil container returns nil silently (no throw)")
+    (is (nil? (adapter/current-adapter))
+        "the nil-container path did not consult or modify the adapter slot")))


### PR DESCRIPTION
## Summary

Audit finding SUB3 from rf2-spr6q: `substrate/adapter.cljc` had inconsistent error reporting when no adapter was installed. Only `make-state-container` threw a structured `ex-info` (`"no adapter installed"` with empty data); the other five required delegation fns (`read-container`, `replace-container!`, `make-derived-value`, `render`, `render-to-string`) and the two optional fns (`subscribe-container`, `register-context-provider`) silently NPE'd on a `nil` adapter. Apps using the runtime before `(rf/init! ...)` saw different error shapes depending on which delegation fn they hit first.

This PR centralises the throw shape via a private `require-adapter!` helper. Every delegation fn now raises ONE uniform shape:

- **Message**: `":rf.error/no-adapter-installed"`
- **ex-data**: `{:where 'rf/<surface>, :recovery :no-recovery, :reason "<where> was called before (rf/init! ...); ..."}`

The skeleton matches `late-bind/require-fn!` (rf2-h824v, rf2-uchhp) — same `:where` / `:recovery` / `:reason` slots as the missing-artefact-throw contract used elsewhere in core.

## Sites migrated (8)

| Surface | Before | After |
|---|---|---|
| `make-state-container` | `ex-info "no adapter installed" {}` | uniform throw via `require-adapter!` |
| `read-container` | silent NPE | uniform throw |
| `replace-container!` | silent NPE (after `nil`-container guard) | uniform throw (nil-container guard preserved) |
| `make-derived-value` | silent NPE | uniform throw |
| `render` | silent NPE | uniform throw |
| `render-to-string` | silent NPE | uniform throw |
| `subscribe-container` | silent NPE | uniform throw |
| `register-context-provider` | silent NPE | uniform throw |

Optional-fn semantics preserved: `subscribe-container` and `register-context-provider` still return `nil` when the installed adapter omits the fn — the `nil` return is reserved for "adapter installed, fn absent", not "no adapter installed at all".

The `replace-container!` nil-container guard (rf2-ft2b) still runs before the adapter lookup so a scheduled drain hitting a destroyed frame emits `:rf.warning/write-after-destroy` regardless of whether an adapter is installed.

## Test plan

- [x] `substrate-delegation-uniform-no-adapter-throw` (new): locks the throw shape across all eight delegation fns
- [x] `replace-container-nil-container-skips-adapter-check` (new): locks the nil-container short-circuit with no adapter installed
- [x] `clojure -M:test` from `implementation/core/` — 442 tests / 2361 assertions / 0 failures / 0 errors
- [x] `npm run test:cljs` from `implementation/` — 1792 tests / 4975 assertions / 0 failures / 0 errors

Closes rf2-zdfi1.