### PR TITLE
refactor(machines.timer): frame-scope after-timers atom (rf2-ysa94)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -372,6 +372,17 @@
                                           request under SSR load — a
                                           slow leak that compounds over
                                           a long-running server process.
+    :machines/on-frame-destroyed!       — rf2-ysa94, clear the machines
+                                          artefact's frame-scoped
+                                          `:after` timer table for the
+                                          destroyed frame and release
+                                          any in-flight host-clock
+                                          handles / subscription
+                                          watchers belonging to that
+                                          frame. Without this hook the
+                                          destroyed frame's inner table
+                                          would linger and live timers
+                                          would survive teardown.
 
   Subsequent dispatch / subscribe against a destroyed frame raises
   :rf.error/frame-destroyed."
@@ -401,6 +412,16 @@
     ;; through the hook table; no-op when re-frame.ssr is absent.
     (when-let [ssr-cleanup! (late-bind/get-fn :ssr/on-frame-destroyed)]
       (try (ssr-cleanup! id)
+           (catch #?(:clj Throwable :cljs :default) _ nil)))
+    ;; Per rf2-ysa94 / Spec 005 §Delayed `:after` transitions: clear the
+    ;; machines artefact's frame-scoped `:after` timer table for the
+    ;; destroyed frame. The table is partitioned per frame; without this
+    ;; hook the destroyed frame's inner-table would linger as dead
+    ;; bookkeeping and any in-flight host-clock handles would survive
+    ;; teardown. Late-bound through the hook table — no-op when
+    ;; re-frame.machines is absent (the artefact is optional).
+    (when-let [machines-cleanup! (late-bind/get-fn :machines/on-frame-destroyed!)]
+      (try (machines-cleanup! id)
            (catch #?(:clj Throwable :cljs :default) _ nil)))
     (emit-frame-destroyed-trace! id)
     (dissoc-frame! id)

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -191,6 +191,9 @@
    {:key         :machines/reset-timers!
     :producer-ns 're-frame.machines
     :description "Cancel in-flight `:after` wall-clock timers (test isolation)."}
+   {:key         :machines/on-frame-destroyed!
+    :producer-ns 're-frame.machines
+    :description "Per-frame `:after` timer-table cleanup hook called from frame/destroy-frame! (rf2-ysa94)."}
    {:key         :machines/spawn-fx
     :producer-ns 're-frame.machines
     :description "Effect handler for :rf.machine/spawn."}

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -146,7 +146,15 @@
 (def wants-ctx              transition/wants-ctx)
 
 (defn reset-timers!
-  "Cancel every in-flight `:after` timer the runtime is currently tracking.
+  "Cancel in-flight `:after` timers.
+
+  0-arity: every frame's timers — the fixture-teardown shape used by
+  `re-frame.test-support`'s `reset-runtime` and per-feature artefact test
+  fixtures. Clears the entire frame-scoped table.
+
+  1-arity: just the given frame's timers — the `frame/destroy-frame!`
+  hook shape used to release a destroyed frame's host-clock handles and
+  subscription watchers without touching sibling frames.
 
   Per rf2-gr8q the per-process `spawn-counter` atom is gone — declarative-
   :invoke spawn-id allocation lives inside the parent snapshot's
@@ -154,11 +162,16 @@
   the frame's app-db at `[:rf/spawn-counter <machine-id>]`. Both reset
   automatically: per-test snapshot rollback (via test-support's registrar
   snapshot/restore + frame reset) clears the app-db; per-fixture snapshot
-  input in the conformance harness is hand-built fresh on each call. The
-  only remaining per-process state this fn resets is the wall-clock timer
-  table in `re-frame.machines.timer`."
-  []
-  (timer/cancel-all-timers!))
+  input in the conformance harness is hand-built fresh on each call.
+
+  Per rf2-ysa94 the wall-clock timer table is now frame-scoped — the
+  last remaining per-process mutable state in the machines artefact —
+  so the 0-arity / 1-arity split aligns with the test-fixture and
+  frame-destroy call sites respectively."
+  ([]
+   (timer/cancel-all-timers!))
+  ([frame-id]
+   (timer/cancel-all-timers! frame-id)))
 
 ;; ---- machine-internal effect handlers ------------------------------------
 ;;
@@ -248,6 +261,17 @@
 (late-bind/set-fn! :machines/machine-meta           machine-meta)
 (late-bind/set-fn! :machines/machine-by-system-id   machine-by-system-id)
 (late-bind/set-fn! :machines/reset-timers!          reset-timers!)
+;; Per rf2-ysa94: per-frame timer-table cleanup wired into
+;; `frame/destroy-frame!`. The frame-scoping refactor partitions the
+;; timer table `{<frame-id> {…}}`; without this hook a destroyed
+;; frame's inner table would linger as dead bookkeeping (and worse, any
+;; in-flight host-clock handles would survive teardown). Late-bound
+;; through the hook table mirroring the rf2-fcj33 SSR
+;; `:ssr/on-frame-destroyed` cleanup pattern — core never statically
+;; requires the machines artefact, so the hook resolves to nil when
+;; this namespace is absent and `destroy-frame!` proceeds without it.
+(late-bind/set-fn! :machines/on-frame-destroyed!
+                   (fn [frame-id] (timer/cancel-all-timers! frame-id)))
 (late-bind/set-fn! :machines/spawn-fx               spawn-fx)
 (late-bind/set-fn! :machines/destroy-machine-fx     destroy-machine-fx)
 (late-bind/set-fn! :machines/invoke-all-init-fx     invoke-all-init-fx)

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -18,9 +18,12 @@
   as `:rf.machine.timer/stale-after`, epoch-match drives the transition
   through the standard cascade.
 
-  A per-frame timer table tracks live handles so cancellation (state
-  exit) and subscription-driven re-resolution can clear them. The epoch
-  mechanism backstops correctness; explicit cancellation via
+  A frame-scoped timer table tracks live handles so cancellation (state
+  exit) and subscription-driven re-resolution can clear them. Per
+  rf2-ysa94 the table is partitioned per frame (`{<frame-id> {<inner-key>
+  <entry>}}`), so concurrent frames in the same process — the common
+  test-fixture and SSR-load shape — observe disjoint timer state. The
+  epoch mechanism backstops correctness; explicit cancellation via
   `:rf.machine/after-cancel` is an optimisation that promptly releases
   the host-clock handle.
 
@@ -36,10 +39,16 @@
             [re-frame.trace :as trace]))
 
 (defonce after-timers
-  ;; Per Spec 005 §Delayed `:after` transitions and rf2-3y3y. Runtime-owned
-  ;; timer-handle table for in-flight :after timers. Keyed by
-  ;; [frame-id parent-id invoke-id delay-key] so multiple delays per
-  ;; :after map have their own slot. Value:
+  ;; Per Spec 005 §Delayed `:after` transitions and rf2-3y3y and the rf2-ysa94
+  ;; frame-scoping refactor: runtime-owned timer-handle table for in-flight
+  ;; :after timers, partitioned per frame.
+  ;;
+  ;; Outer shape: {<frame-id> {<inner-key> <entry>}}.
+  ;; Inner key:   [<parent-id> <invoke-id-vec> <delay-key>] — multiple
+  ;;              delays per :after map have their own slot, and parallel-
+  ;;              region machines partition further on the region-prefixed
+  ;;              invoke-id.
+  ;; Entry value:
   ;;   {:handle <opaque host-clock handle>
   ;;    :reaction <subscription reaction or nil>
   ;;    :sub-watcher-key <key passed to add-watch>
@@ -47,12 +56,29 @@
   ;;    :epoch <int>
   ;;    :state <state-keyword>
   ;;    :delay-source <:literal | :sub | :fn>}
+  ;;
+  ;; Frame-scoping the outer key (rf2-ysa94) was the last process-global
+  ;; piece of state in the machines artefact (per the rf2-ra1he audit, §TM4).
+  ;; Two consequences:
+  ;;   (1) Two frames running concurrently see strictly disjoint inner
+  ;;       tables — no cross-frame contamination of timer handles, no
+  ;;       chance that one frame's `reset-timers!` clobbers another's
+  ;;       in-flight handles.
+  ;;   (2) `after-cancel-fx` (state-exit cleanup) scans only the active
+  ;;       frame's inner map rather than every frame's combined entries —
+  ;;       O(timers-this-frame) instead of O(timers-all-frames).
+  ;;
   ;; Cancellation (state exit + sub re-resolution) clears the entry and
-  ;; releases the handle / detaches the watcher.
+  ;; releases the handle / detaches the watcher. Frame-teardown clears the
+  ;; entire inner map via the `:machines/on-frame-destroyed!` late-bind
+  ;; hook invoked from `frame/destroy-frame!`.
   (atom {}))
 
-(defn- after-timer-key [frame-id parent-id invoke-id delay-key]
-  [frame-id parent-id (vec invoke-id) delay-key])
+(defn- after-timer-key
+  "Inner-table key — frame-id is the OUTER key into `after-timers` and is
+  intentionally absent from this tuple."
+  [parent-id invoke-id delay-key]
+  [parent-id (vec invoke-id) delay-key])
 
 (defn- classify-delay-source [delay-key]
   (cond
@@ -94,21 +120,39 @@
 
 (declare schedule-after-timer!)
 
+(defn- release-entry-resources!
+  "Best-effort release of the host-clock handle, sub-reaction watcher, and
+  subscription registration belonging to a single timer-table entry. Pure
+  side-effect; the caller owns the swap that removes the entry from the
+  outer atom. Tolerates partial-state entries (the watcher / reaction
+  slots are nil for literal- and fn-form delays)."
+  [frame-id entry delay-key]
+  (when-let [h (:handle entry)]
+    (try (interop/clear-timeout! h)
+         (catch #?(:clj Throwable :cljs :default) _ nil)))
+  (when (and (:reaction entry) (:sub-watcher-key entry))
+    (try (remove-watch (:reaction entry) (:sub-watcher-key entry))
+         (catch #?(:clj Throwable :cljs :default) _ nil))
+    (when (and (vector? delay-key) frame-id)
+      (try (subs/unsubscribe frame-id delay-key)
+           (catch #?(:clj Throwable :cljs :default) _ nil)))))
+
 (defn- cancel-after-timer-entry!
-  "Cancel and clear a single :after timer-table entry. Idempotent."
-  [k]
-  (when-let [entry (get @after-timers k)]
-    (when-let [h (:handle entry)]
-      (try (interop/clear-timeout! h)
-           (catch #?(:clj Throwable :cljs :default) _ nil)))
-    (when (and (:reaction entry) (:sub-watcher-key entry))
-      (try (remove-watch (:reaction entry) (:sub-watcher-key entry))
-           (catch #?(:clj Throwable :cljs :default) _ nil))
-      (let [[frame-id _ _ delay-key] k]
-        (when (and (vector? delay-key) frame-id)
-          (try (subs/unsubscribe frame-id delay-key)
-               (catch #?(:clj Throwable :cljs :default) _ nil)))))
-    (swap! after-timers dissoc k)))
+  "Cancel and clear a single :after timer-table entry under `frame-id`.
+  Idempotent — a second call against the same `[frame-id k]` is a no-op."
+  [frame-id k]
+  (when-let [entry (get-in @after-timers [frame-id k])]
+    (let [[_ _ delay-key] k]
+      (release-entry-resources! frame-id entry delay-key))
+    ;; Drop the inner-table entry; drop the outer-table entry if this was
+    ;; the frame's last live timer so a frame that briefly held timers
+    ;; doesn't leave a stale empty map behind.
+    (swap! after-timers
+           (fn [m]
+             (let [inner (dissoc (get m frame-id) k)]
+               (if (empty? inner)
+                 (dissoc m frame-id)
+                 (assoc m frame-id inner)))))))
 
 (defn- on-sub-changed!
   "Watch callback invoked when a subscription-vector delay's value
@@ -120,8 +164,8 @@
   caught by the epoch invariant when the new timer fires."
   [frame-id parent-id invoke-id delay-key state old-v new-v]
   (when-not (= old-v new-v)
-    (let [k (after-timer-key frame-id parent-id invoke-id delay-key)
-          prior-entry (get @after-timers k)
+    (let [k (after-timer-key parent-id invoke-id delay-key)
+          prior-entry (get-in @after-timers [frame-id k])
           prior-ms    (:resolved-ms prior-entry)]
       (trace/emit! :machine :rf.machine.timer/cancelled-on-resolution
                    {:machine-id parent-id
@@ -129,7 +173,7 @@
                     :delay      prior-ms
                     :reason     :sub-changed
                     :sub-id     (first delay-key)})
-      (cancel-after-timer-entry! k)
+      (cancel-after-timer-entry! frame-id k)
       (when-let [container (frame/get-frame-db frame-id)]
         (let [db   (adapter/read-container container)
               snap (get-in db [:rf/machines parent-id])
@@ -171,8 +215,8 @@
   [frame-id parent-id invoke-id state delay-key epoch server? snapshot
    {:keys [emit-scheduled-trace?]}]
   (let [delay-source (classify-delay-source delay-key)
-        k            (after-timer-key frame-id parent-id invoke-id delay-key)]
-    (cancel-after-timer-entry! k)
+        k            (after-timer-key parent-id invoke-id delay-key)]
+    (cancel-after-timer-entry! frame-id k)
     (cond
       server?
       ;; Pure-side already emitted :skipped-on-server; no-op here.
@@ -218,7 +262,7 @@
                              (on-sub-changed! frame-id parent-id invoke-id
                                               delay-key state old-v new-v)))
                 (catch #?(:clj Throwable :cljs :default) _ nil)))
-            (swap! after-timers assoc k
+            (swap! after-timers assoc-in [frame-id k]
                    {:handle          handle
                     :reaction        reaction
                     :sub-watcher-key watch-key
@@ -275,28 +319,41 @@
   handles and any subscription watchers attached to the prior visit's
   timers. The epoch-mismatch invariant backstops correctness if a timer
   fires before this fx runs; this handler is the fast-path that prevents
-  zombie watchers and releases timer slots promptly."
+  zombie watchers and releases timer slots promptly.
+
+  Per rf2-ysa94 the scan is now bounded by the active frame's inner
+  table — siblings' timers in other frames are no longer walked. The
+  inner key is `[parent-id invoke-id-vec delay-key]`, so the only
+  cross-key axis we still iterate is `delay-key` (one entry per :after
+  map entry on the bearing state node — typically 1-3 entries)."
   [{:keys [frame]} args]
   (let [frame-id  (or frame :rf/default)
         parent-id (:rf/parent-id args)
         invoke-id (vec (:rf/invoke-id args))]
-    (doseq [[k _entry] @after-timers
-            :when (and (= frame-id  (nth k 0))
-                       (= parent-id (nth k 1))
-                       (= invoke-id (nth k 2)))]
-      (cancel-after-timer-entry! k))
+    (doseq [[k _entry] (get @after-timers frame-id)
+            :when (and (= parent-id (nth k 0))
+                       (= invoke-id (nth k 1)))]
+      (cancel-after-timer-entry! frame-id k))
     nil))
 
 (defn cancel-all-timers!
   "Cancel every in-flight :after timer the runtime is currently tracking
-  and reset the timer table. Used by `reset-timers!` in fixture
-  teardown."
-  []
-  (doseq [[_ entry] @after-timers]
-    (when-let [h (:handle entry)]
-      (try (interop/clear-timeout! h)
-           (catch #?(:clj Throwable :cljs :default) _ nil)))
-    (when (and (:reaction entry) (:sub-watcher-key entry))
-      (try (remove-watch (:reaction entry) (:sub-watcher-key entry))
-           (catch #?(:clj Throwable :cljs :default) _ nil))))
-  (reset! after-timers {}))
+  and reset the timer table.
+
+  0-arity: every frame's timers (fixture teardown — `reset-timers!`).
+  1-arity: just the given frame's timers (`frame/destroy-frame!` hook).
+
+  Per rf2-ysa94 the timer table is partitioned per frame; the 1-arity
+  variant releases the destroyed frame's host-clock handles and
+  subscription watchers without touching sibling frames' state."
+  ([]
+   (doseq [[frame-id inner] @after-timers
+           [k entry] inner]
+     (let [[_ _ delay-key] k]
+       (release-entry-resources! frame-id entry delay-key)))
+   (reset! after-timers {}))
+  ([frame-id]
+   (doseq [[k entry] (get @after-timers frame-id)]
+     (let [[_ _ delay-key] k]
+       (release-entry-resources! frame-id entry delay-key)))
+   (swap! after-timers dissoc frame-id)))

--- a/implementation/machines/test/re_frame/timer_frame_scope_test.clj
+++ b/implementation/machines/test/re_frame/timer_frame_scope_test.clj
@@ -1,0 +1,163 @@
+(ns re-frame.timer-frame-scope-test
+  "Per rf2-ysa94: regression test for the frame-scoping of
+  `re-frame.machines.timer/after-timers` — the last process-global atom
+  in the machines artefact prior to this refactor.
+
+  Pre-rf2-ysa94 the table was a single flat map keyed by
+  `[frame-id parent-id invoke-id delay-key]`. Two consequences (the
+  rf2-ra1he audit §TM4 motivation):
+
+    1. Frame isolation broken under concurrent fixture runs. A
+       `reset-timers!` call from one test fixture cleared sibling test
+       fixtures' entries via `(reset! after-timers {})`.
+
+    2. `after-cancel-fx` did a linear scan over the entire atom on every
+       state-exit-with-:after — O(timers-all-frames) instead of
+       O(timers-this-frame).
+
+  Post-rf2-ysa94 the table is `{<frame-id> {<inner-key> <entry>}}` and
+  the public API gains a 1-arity `reset-timers!` / `cancel-all-timers!`
+  for per-frame teardown. The destroy-frame hook
+  `:machines/on-frame-destroyed!` releases a destroyed frame's timers
+  without disturbing siblings.
+
+  The assertions below exercise both the structural invariant (entries
+  partition by frame-id) and the behaviour: two frames scheduling timers
+  under OVERLAPPING `[parent-id invoke-id delay-key]` tuples observe
+  independent lifecycles, and 1-arity reset / frame-destroy clears only
+  the targeted frame."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.machines :as machines]
+            [re-frame.machines.timer :as timer]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.machines :reload)
+  (machines/reset-timers!)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- the machine under test -----------------------------------------------
+;;
+;; The same machine spec is registered once and dispatched against two
+;; sibling frames. The :loading state carries a long-delay :after that
+;; the host clock will not fire during the test — the entry simply
+;; lingers in the timer table so we can read it back. The synchronous
+;; pure-side transition emits the :rf.machine/after-schedule fx; the fx
+;; handler in `re-frame.machines.timer` installs the host-clock handle
+;; under [<frame-id> [<parent-id> <invoke-id-vec> <delay-key>]].
+
+(def ^:private spec
+  {:initial :idle
+   :data    {:rf/after-epoch 0}
+   :states
+   {:idle    {:on {:fetch :loading}}
+    :loading {:after {3600000 :timeout}
+              :on    {:loaded :ready}}
+    :timeout {}
+    :ready   {}}})
+
+;; ---- regression: two frames' timers stay disjoint ------------------------
+
+(deftest two-frames-with-overlapping-timer-ids-stay-isolated
+  (testing "schedule + cancellation on one frame must not perturb the other's table"
+    (rf/reg-machine :iso/m spec)
+    (rf/reg-frame :iso/left  {:doc "left frame — timer-isolation regression"})
+    (rf/reg-frame :iso/right {:doc "right frame — timer-isolation regression"})
+
+    ;; Drive each frame into :loading; the pure side emits one
+    ;; `:rf.machine/after-schedule` fx and the timer fx handler installs
+    ;; one inner-table entry per frame.
+    (rf/dispatch-sync [:iso/m [:fetch]] {:frame :iso/left})
+    (rf/dispatch-sync [:iso/m [:fetch]] {:frame :iso/right})
+
+    (let [tt @timer/after-timers]
+      (is (contains? tt :iso/left)
+          "the timer table partitions entries under the left frame")
+      (is (contains? tt :iso/right)
+          "the timer table partitions entries under the right frame")
+      ;; Inner keys: [<parent-id> <invoke-id-vec> <delay-key>]. Because the
+      ;; machine spec is identical the inner keys collide across frames —
+      ;; pre-rf2-ysa94 the keying included the frame-id; post-rf2-ysa94
+      ;; the frame-id is the OUTER key and the inner keys legitimately
+      ;; coincide.
+      (let [left-inner-keys  (set (keys (get tt :iso/left)))
+            right-inner-keys (set (keys (get tt :iso/right)))]
+        (is (= left-inner-keys right-inner-keys)
+            (str "inner keys are identical across frames — frame-id is "
+                 "the partitioning axis, not a discriminator inside the "
+                 "inner key"))
+        (is (every? (fn [k]
+                      (and (= :iso/m (nth k 0))
+                           (vector? (nth k 1))
+                           (= 3600000 (nth k 2))))
+                    left-inner-keys)
+            "inner-key shape is [parent-id invoke-id-vec delay-key]")))
+
+    ;; 1-arity reset clears only the targeted frame.
+    (machines/reset-timers! :iso/left)
+    (let [tt @timer/after-timers]
+      (is (not (contains? tt :iso/left))
+          "1-arity reset-timers! drops the left frame's entire inner table")
+      (is (contains? tt :iso/right)
+          "the right frame's table survives a sibling-frame's reset"))))
+
+;; ---- regression: destroy-frame clears just the destroyed frame's timers --
+
+(deftest destroy-frame-clears-only-the-destroyed-frames-timers
+  (testing "the :machines/on-frame-destroyed! late-bind hook releases just the destroyed frame's entries"
+    (rf/reg-machine :ds/m spec)
+    (rf/reg-frame :ds/keep    {:doc "survives"})
+    (rf/reg-frame :ds/discard {:doc "destroyed"})
+    (rf/dispatch-sync [:ds/m [:fetch]] {:frame :ds/keep})
+    (rf/dispatch-sync [:ds/m [:fetch]] {:frame :ds/discard})
+    (is (and (contains? @timer/after-timers :ds/keep)
+             (contains? @timer/after-timers :ds/discard))
+        "preconditions: both frames have entries")
+    (rf/destroy-frame :ds/discard)
+    (is (not (contains? @timer/after-timers :ds/discard))
+        ":machines/on-frame-destroyed! hook clears the destroyed frame's entries")
+    (is (contains? @timer/after-timers :ds/keep)
+        "destroy-frame on the discarded frame must not touch the survivor's entries")))
+
+;; ---- regression: 0-arity reset still clears everything --------------------
+
+(deftest zero-arity-reset-timers-clears-every-frame
+  (testing "0-arity reset-timers! preserves its pre-rf2-ysa94 contract"
+    (rf/reg-machine :iso0/m spec)
+    (rf/reg-frame :iso0/a {})
+    (rf/reg-frame :iso0/b {})
+    (rf/dispatch-sync [:iso0/m [:fetch]] {:frame :iso0/a})
+    (rf/dispatch-sync [:iso0/m [:fetch]] {:frame :iso0/b})
+    (is (seq @timer/after-timers) "preconditions: both frames have entries")
+    (machines/reset-timers!)
+    (is (= {} @timer/after-timers)
+        "0-arity clears the whole table — the fixture-teardown shape")))
+
+;; ---- regression: after-cancel-fx no longer scans across frames -----------
+
+(deftest after-cancel-fx-scoped-to-active-frame
+  (testing "exiting an :after-bearing state in one frame must not cancel sibling frames' timers"
+    (rf/reg-machine :sc/m spec)
+    (rf/reg-frame :sc/A {})
+    (rf/reg-frame :sc/B {})
+    (rf/dispatch-sync [:sc/m [:fetch]] {:frame :sc/A})
+    (rf/dispatch-sync [:sc/m [:fetch]] {:frame :sc/B})
+    (is (and (contains? @timer/after-timers :sc/A)
+             (contains? @timer/after-timers :sc/B))
+        "both frames installed a timer entry on :loading entry")
+    ;; Exiting :loading (via :loaded → :ready) on frame :sc/A emits
+    ;; :rf.machine/after-cancel; after-cancel-fx must clear only the
+    ;; active frame's matching entries.
+    (rf/dispatch-sync [:sc/m [:loaded]] {:frame :sc/A})
+    (is (not (contains? @timer/after-timers :sc/A))
+        "frame A's timer table is empty after the state exit")
+    (is (contains? @timer/after-timers :sc/B)
+        "frame B's table is untouched by frame A's :rf.machine/after-cancel")))


### PR DESCRIPTION
## Summary

Per the rf2-ra1he audit (§TM4): `re-frame.machines.timer/after-timers` was the last process-global mutable state in the machines artefact. This refactor partitions the timer table per frame.

- **Outer table** now `{<frame-id> {<inner-key> <entry>}}`; inner key drops `frame-id` and becomes `[parent-id invoke-id-vec delay-key]`.
- **`reset-timers!`** / **`cancel-all-timers!`** gain a 1-arity (per-frame) variant alongside the existing 0-arity (all frames, fixture-teardown shape).
- **`after-cancel-fx`** scans only the active frame's inner table — O(timers-this-frame) instead of the prior O(timers-all-frames) linear scan over the whole atom.
- **`:machines/on-frame-destroyed!`** late-bind hook wired into `frame/destroy-frame!` so a destroyed frame's host-clock handles + subscription watchers are released automatically. Mirrors the rf2-fcj33 `:ssr/on-frame-destroyed` cleanup pattern; late-bound so core remains free of a static dep on the optional machines artefact.

Pre-alpha — no back-compat layer; the keying change is internal to `re-frame.machines.timer` and the public `reset-timers!` API gains an arity, doesn't lose one.

## Test plan

- [x] New regression test `implementation/machines/test/re_frame/timer_frame_scope_test.clj` covering the three invariants:
  - two frames with overlapping `[parent-id invoke-id delay-key]` tuples stay isolated;
  - 1-arity `reset-timers!` clears only the targeted frame;
  - 0-arity `reset-timers!` still wipes everything (fixture-teardown contract preserved);
  - `destroy-frame` clears only the destroyed frame's entries via the new late-bind hook;
  - `after-cancel-fx` on one frame does not touch a sibling frame's timer table.
- [x] `clojure -M:test` (`implementation/machines/`) — 123 tests, 352 assertions, 0 failures.
- [x] `clojure -M:test` (`implementation/http/`) — 134 tests, 369 assertions, 0 failures (http exercises the timer-table via the managed-machine fixture).
- [x] `clojure -M:test` (`implementation/core/`) — 440 tests, 2312 assertions, 0 failures (touches `frame/destroy-frame!`).
- [x] `late-bind-drift-test` green — new hook entry added to the directory.