### PR TITLE
refactor(story): variants-of uses namespace lookup not string-prefix (rf2-ixb0a)

### DIFF
--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -340,14 +340,17 @@
 (defn variants-of
   "Return the variant ids whose story is `story-id`. Cheap O(N) scan
   over the variant side-table — fine for dev-time use; if perf becomes
-  a concern Stage 3 indexes."
+  a concern Stage 3 indexes.
+
+  Per spec/007 §Canonical id grammar a story `:story.foo` has nil
+  namespace and name `\"story.foo\"`; its variants `:story.foo/empty`
+  carry namespace `\"story.foo\"`. So variant membership is just
+  `(= (namespace vid) (name story-id))` — no string surgery."
   [story-id]
-  (let [prefix (str (subs (str story-id) 1) "/")]   ; ":story.foo" → "story.foo/"
-    (->> (ids :variant)
-         (filter (fn [vid] (let [s (str vid)]      ; ":story.foo/empty"
-                             (and (>= (count s) (inc (count prefix)))
-                                  (= (subs s 1 (inc (count prefix))) prefix)))))
-         set)))
+  (let [story-ns (name story-id)]
+    (into #{}
+          (filter (fn [vid] (= (namespace vid) story-ns)))
+          (ids :variant))))
 
 (defn variants-with-tag
   "Return the variant ids whose `:tags` set contains `tag`."

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -410,6 +410,31 @@
     (is (= #{:story.foo/a :story.foo/b} (story/variants-of :story.foo)))
     (is (= #{:story.bar/c}              (story/variants-of :story.bar)))))
 
+(deftest variants-of-empty-when-no-children
+  (testing "variants-of returns empty set when the story has no registered variants"
+    (is (= #{} (story/variants-of :story.no-variants)))
+    (story/reg-variant :story.other/x {:events []})
+    (is (= #{} (story/variants-of :story.no-variants)))))
+
+(deftest variants-of-rejects-nested-namespace
+  (testing "variants-of must NOT return variants of a deeper-namespaced story
+            — guards against the old string-prefix shape where
+            `:story.foo.bar/x` was a structurally-suspect 'prefix match' of
+            `:story.foo`. The namespace-equality check rules it out by
+            construction."
+    (story/reg-variant :story.foo/a     {:events []})
+    (story/reg-variant :story.foo.bar/x {:events []})
+    (story/reg-variant :story.foo.bar/y {:events []})
+    (is (= #{:story.foo/a}                       (story/variants-of :story.foo)))
+    (is (= #{:story.foo.bar/x :story.foo.bar/y}  (story/variants-of :story.foo.bar)))))
+
+(deftest variants-of-short-and-bare-story
+  (testing "variants-of works for the bare `:story` root and short names"
+    (story/reg-variant :story/root {:events []})
+    (story/reg-variant :story.a/v  {:events []})
+    (is (= #{:story/root} (story/variants-of :story)))
+    (is (= #{:story.a/v}  (story/variants-of :story.a)))))
+
 (deftest variants-with-tags-intersection
   (testing "variants-with-tags returns variants whose :tags intersects the query"
     (story/reg-variant :story.tag/a {:events [] :tags #{:dev :test}})


### PR DESCRIPTION
## Summary

- `registrar.cljc` `variants-of` previously stringified the story id, computed a `<ns>/` prefix, then for each variant id stringified it and did two `subs` calls + a length guard. Three `subs` per candidate per call.
- Rewritten to use the canonical id grammar directly: a story `:story.foo` has nil namespace and name `"story.foo"`; its variants `:story.foo/empty` carry namespace `"story.foo"`. So variant membership is just `(= (namespace vid) (name story-id))` — one namespace call per candidate, no string surgery, intent legible on first read.
- Three new regression tests added covering empty result, nested-namespace rejection (the latent prefix-confusion trap), and the bare `:story` root.

LoC delta: +35 / -7 across 2 files (registrar.cljc + story_test.clj).

Audit: rf2-dd5ze (RG1 — P1 clarity + perf).

## Test plan

- [x] `clojure -M:test` from `tools/story/` — 348 tests, 1025 assertions, 0 failures, 0 errors.
- [x] New tests cover: empty story, nested namespace (`:story.foo.bar/x` is NOT a variant of `:story.foo`), bare `:story` root, short names.