### PR TITLE
refactor(core): rename :path-stack to :rf/path-stack in path interceptor (rf2-mn0qc)

### DIFF
--- a/implementation/core/src/re_frame/std_interceptors.cljc
+++ b/implementation/core/src/re_frame/std_interceptors.cljc
@@ -32,13 +32,15 @@
       (fn [ctx]
         (-> ctx
             ;; Stash the original db on a stack (supports nested path
-            ;; interceptors).
-            (update :path-stack (fnil conj []) (:db (:coeffects ctx)))
+            ;; interceptors). Reserved-namespace slot per Spec
+            ;; Conventions §Reserved namespaces — framework keys on the
+            ;; interceptor context belong under :rf/...
+            (update :rf/path-stack (fnil conj []) (:db (:coeffects ctx)))
             (assoc-in [:coeffects :db]
                       (get-in (:db (:coeffects ctx)) path-vec))))
       :after
       (fn [ctx]
-        (let [stack       (:path-stack ctx [])
+        (let [stack       (:rf/path-stack ctx [])
               original-db (peek stack)
               new-stack   (pop stack)
               ;; The handler may or may not have produced a new :db;
@@ -46,7 +48,7 @@
               new-slice   (or (get-in ctx [:effects :db])
                               (get-in ctx [:coeffects :db]))]
           (-> ctx
-              (assoc :path-stack new-stack)
+              (assoc :rf/path-stack new-stack)
               (assoc-in [:effects :db]
                         (assoc-in original-db path-vec new-slice))))))))
 

--- a/implementation/core/test/re_frame/interceptor_test.clj
+++ b/implementation/core/test/re_frame/interceptor_test.clj
@@ -66,6 +66,53 @@
       (is (= :preserved (:other db))
           "keys outside the path are preserved"))))
 
+(deftest path-interceptor-uses-reserved-namespace
+  (testing "the path interceptor stashes its db-stack under :rf/path-stack
+            (reserved namespace per Spec Conventions §Reserved namespaces).
+            Regression for rf2-mn0qc."
+    (let [seen-keys (atom nil)]
+      ;; A spy interceptor sandwiched between `path` and the handler runs
+      ;; AFTER path's :before, so the context it sees must carry the stash
+      ;; under :rf/path-stack — not the bare :path-stack.
+      (rf/reg-event-db :path-ns/init (fn [_ _] {:foo {:bar 10}}))
+      (rf/reg-event-db :path-ns/inc
+                       [(rf/path :foo :bar)
+                        (interceptor/->interceptor
+                         :id     :path-ns/spy
+                         :before (fn [ctx]
+                                   (reset! seen-keys (set (keys ctx)))
+                                   ctx))]
+                       inc)
+      (rf/dispatch-sync [:path-ns/init])
+      (rf/dispatch-sync [:path-ns/inc])
+      (is (contains? @seen-keys :rf/path-stack)
+          "path interceptor stashes its stack under the reserved :rf/path-stack key")
+      (is (not (contains? @seen-keys :path-stack))
+          "the bare :path-stack key must NOT appear (reserved-namespace contract)")
+      (is (= 11 (get-in (rf/get-frame-db :rf/default) [:foo :bar]))
+          "the rename did not break the path interceptor's splice-back behaviour"))))
+
+(deftest path-interceptor-nesting
+  (testing "nested (path ...) interceptors compose correctly — the LIFO
+            stack semantics of :rf/path-stack mean an inner path's :after
+            restores the outer slice and the outer :after splices back into
+            the full app-db. Pins the stack semantics independent of the
+            slot-key rename (rf2-mn0qc)."
+    (rf/reg-event-db :path-nest/init (fn [_ _] {:a {:b {:c 7} :sib :keep}}))
+    (rf/reg-event-db :path-nest/inc
+                     ;; The outer `path` focuses to {:b {:c 7} :sib :keep};
+                     ;; the inner `path` focuses to 7. The handler returns 8.
+                     [(rf/path :a)
+                      (rf/path :b :c)]
+                     (fn [slice _] (inc slice)))
+    (rf/dispatch-sync [:path-nest/init])
+    (rf/dispatch-sync [:path-nest/inc])
+    (let [db (rf/get-frame-db :rf/default)]
+      (is (= 8 (get-in db [:a :b :c]))
+          "inner+outer path splice the inner slice back through both levels")
+      (is (= :keep (get-in db [:a :sib]))
+          "siblings under the outer focus are preserved"))))
+
 ;; ---- unwrap ---------------------------------------------------------------
 
 (deftest unwrap-interceptor


### PR DESCRIPTION
## Summary

- Per Spec Conventions §Reserved namespaces, framework slots on the interceptor context belong under `:rf/...`. The unwrap interceptor already uses `:rf/unwrap-stash`; the path interceptor was the lone offender.
- Renames the bare `:path-stack` slot to `:rf/path-stack` at three call-sites inside `std_interceptors.cljc`'s `path` interceptor (one `update`, two `(:rf/path-stack ctx ...)` reads, one `assoc`).
- Adds two regression tests in `interceptor_test.clj`:
  - `path-interceptor-uses-reserved-namespace` pins the slot key by spying on the live context between `path`'s `:before` and the handler — asserts `:rf/path-stack` is present and the bare `:path-stack` is NOT.
  - `path-interceptor-nesting` pins the LIFO stack semantics independently of the rename (nested `(path ...)` interceptors must compose).
- Audit finding SP1 from rf2-spr6q. Pre-alpha; no back-compat shim — `:path-stack` was never part of the documented public ctx contract.

Closes rf2-mn0qc.

## Test plan

- [x] `npm run test:cljs` — 1792 tests / 4975 assertions, 0 failures, 0 errors
- [x] `clojure -M:test` from `implementation/core/` — 442 tests / 2364 assertions, 0 failures, 0 errors
- [x] Regression tests confirm `:rf/path-stack` present and bare `:path-stack` absent on the live context
- [x] Nested path composition test passes (stack semantics intact)