### PR TITLE
spec(causa-mcp): split MCP-server-ns from injected-runtime-ns (rf2-c9b90)

### DIFF
--- a/tools/causa-mcp/spec/000-Vision.md
+++ b/tools/causa-mcp/spec/000-Vision.md
@@ -58,12 +58,72 @@ exactly:
   [`tools/pair2-mcp/spec/002-nREPL-Transport.md`](../../pair2-mcp/spec/002-nREPL-Transport.md)).
 - Same port-discovery walk (`$SHADOW_CLJS_NREPL_PORT` → standard
   shadow paths → `.nrepl-port`).
-- Same runtime-injection footing: a small sentinel namespace
-  (`re-frame2-causa-mcp.runtime`) re-ships on browser reload.
+- Same **two-namespace split** between the Node-side MCP server
+  and the browser-side injected runtime (per
+  [§Two namespaces, two sides](#two-namespaces-two-sides) below);
+  a small sentinel namespace re-ships on browser reload.
 - Same degraded-boot policy: tools return structured
   `{:ok? false :reason ...}` errors rather than refusing to start.
 
 Different tool catalogue. Different `:origin` tag.
+
+## Two namespaces, two sides
+
+Causa-MCP's code lives on two sides of an stdio JSON-RPC pipe.
+Each side has its own namespace root; the spec keeps the two
+roles separate because the implementation will too. The split
+mirrors pair2-mcp exactly (see
+[`tools/pair2-mcp/`](../../pair2-mcp/)'s
+`re-frame-pair2-mcp.*` / `re-frame-pair2.runtime` split).
+
+| Side | Root ns | Lives in | Loaded by | Role |
+|---|---|---|---|---|
+| **MCP server** (Node process) | `day8.re-frame2-causa-mcp.*` | `tools/causa-mcp/src/` (when impl lands) | `npx @day8/re-frame2-causa-mcp` (the agent host spawns the subprocess) | Speaks MCP/JSON-RPC over stdio; speaks nREPL/bencode to shadow-cljs; renders eval forms that target the injected runtime. |
+| **Injected runtime** (browser eval target) | `day8.re-frame2-causa.runtime` | the [Causa](../../causa/) panel's preload classpath | shadow-cljs `:devtools :preloads` (rides Causa-the-panel's existing preload) | Lives in the consumer app's runtime; exposes the seventeen tool-shaped accessors the server's eval forms call; carries the `current-origin` dynamic var that stamps `:origin :causa-mcp` on mutations. |
+
+**The two namespaces never share a JVM / Node process.** The MCP
+server runs on Node; the injected runtime runs in the browser.
+They communicate exclusively via eval-form strings travelling
+over the bencode-framed nREPL bridge — the server **renders** an
+EDN form addressed at `day8.re-frame2-causa.runtime/<accessor>`,
+shadow-cljs evaluates it inside the browser tab, the return
+value comes back over the same socket. There is no shared state,
+no shared classpath, no shared dep — only a contract on the
+shape of the seventeen accessors.
+
+**Why two roots, not one.** Conflating the two roles into a
+single namespace (the obvious wrong default) creates two
+problems. (1) It forces the consumer app's preload classpath to
+pull in MCP-server code (the Node-side `@modelcontextprotocol/sdk`
+imports, the bencode wire format, the stdio plumbing) that has
+no business existing inside a browser bundle, even one gated by
+`:preloads` — the bundle-isolation rule
+([`tools/README.md`](../../README.md)) forbids it. (2) It muddles
+the question "is this op a server-side or runtime-side
+concern?" at code-review time — a question pair2-mcp's split
+already answers cleanly. Two roots, two locations, two roles.
+
+**Cross-side coupling is one-way.** The MCP server depends on
+the runtime's accessor signatures (the contract); the runtime is
+independent of the server (it can be loaded standalone via
+Causa-the-panel's preload without the MCP server running at all,
+which is exactly the position before `npx @day8/re-frame2-causa-mcp`
+is launched). The dependency arrow flows server → runtime
+contract.
+
+**Why the runtime lives under `day8.re-frame2-causa.*`.** Because
+the runtime is browser-side and rides Causa-the-panel's
+preload; the panel already owns `day8.re-frame2-causa.*` for the
+in-app surface. The MCP server's own code stays at
+`day8.re-frame2-causa-mcp.*` (matching the maven coord
+`day8/re-frame2-causa-mcp` and the npm coord
+`@day8/re-frame2-causa-mcp` per
+[`DESIGN-RATIONALE.md` Lock #6](./DESIGN-RATIONALE.md)).
+Pair2-mcp does the equivalent: server code under
+`re-frame-pair2-mcp.*`, injected runtime under
+`re-frame-pair2.runtime` — the runtime ns is parented by the
+**injected** artefact's root, not the **MCP-server** artefact's
+root.
 
 ## What it isn't
 
@@ -163,7 +223,8 @@ Causa-MCP is the **debugger-side** counterpart to pair2-mcp's
 | Audience | Editor-side AI workflows (build/edit/test). | Debugger-side AI workflows (inspect/time-travel). |
 | Surface | 9 tools (dispatch, eval, hot-swap, trace, streaming). | 17 tools (inspection + mutation + streaming + escape hatch + session lifecycle). |
 | `:origin` tag | `:pair` | `:causa-mcp` |
-| Runtime ns | `re-frame-pair2.runtime` | `re-frame2-causa-mcp.runtime` |
+| MCP-server ns (Node-side) | `re-frame-pair2-mcp.*` (e.g. `re-frame-pair2-mcp.server`, `.tools`, `.nrepl`, `.cache`) | `day8.re-frame2-causa-mcp.*` (when impl lands) |
+| Injected-runtime ns (browser-side) | `re-frame-pair2.runtime` | `day8.re-frame2-causa.runtime` (rides Causa's preload) |
 | Implementation | shadow-cljs `:node-script`, npm-published. | Same. |
 | MCP transport | stdio JSON-RPC 2.0. | Same. |
 

--- a/tools/causa-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/causa-mcp/spec/DESIGN-RATIONALE.md
@@ -210,10 +210,11 @@ with what discipline (default-on / default-off / mandatory)?
 point of every mutating tool (`dispatch`, `reset-frame-db`,
 `restore-epoch`) and at the boundary of `eval-cljs` (any
 dispatch the eval'd form triggers inherits the tag via the
-runtime install hook's
-`re-frame2-causa-mcp.runtime/current-origin` dynamic var). An
-agent that genuinely wants to simulate a user click passes
-`:origin :app` explicitly — the override is one keyword.
+**injected-runtime** install hook's
+`day8.re-frame2-causa.runtime/current-origin` dynamic var, per
+Lock #11's two-namespace split). An agent that genuinely wants
+to simulate a user click passes `:origin :app` explicitly — the
+override is one keyword.
 
 ### Why
 
@@ -729,6 +730,146 @@ catalogue contract".
 
 ---
 
+## Lock #11 — MCP-server-ns and injected-runtime-ns are distinct
+
+**Locked 2026-05-14 (Mike).** **The MCP-server-side code lives
+under `day8.re-frame2-causa-mcp.*` (Node-only); the
+injected-runtime-side code lives under
+`day8.re-frame2-causa.runtime` (browser-only, parented by
+Causa-the-panel's existing root and loaded via its `:preloads`
+classpath).** The two namespaces never share a process and never
+share a classpath; they communicate only via eval-form strings
+sent over the bencode-framed nREPL bridge.
+
+### Question
+
+Spec scaffold authoring (rf2-22my5, PR #823) shipped with a
+single namespace `re-frame2-causa-mcp.runtime` covering both the
+MCP-server's code and the browser-side runtime accessors the
+server eval-targets. The pair2-mcp template, on which the
+Causa-MCP architecture is explicitly modelled (Locks #1–#3, #8),
+splits the two cleanly into `re-frame-pair2-mcp.*` (Node-side,
+`tools/pair2-mcp/src/`) and `re-frame-pair2.runtime` (browser-side,
+`skills/re-frame-pair2/preload/`). Should Causa-MCP's spec follow
+the same split, or collapse the two into one (and document the
+dual role)?
+
+### Options considered
+
+- **Option A — split the namespaces.** Mirror pair2-mcp exactly:
+  Node-side server code at `day8.re-frame2-causa-mcp.*`,
+  browser-side injected runtime at `day8.re-frame2-causa.runtime`
+  (riding Causa-the-panel's `day8.re-frame2-causa.*` root because
+  the runtime is loaded by Causa's preload, not by a separate
+  MCP-only preload).
+- **Option B — collapse the namespaces.** Keep the single
+  `re-frame2-causa-mcp.runtime` ns and document the dual role:
+  "the same namespace is loaded server-side in the Node MCP
+  process and runtime-side in the consumer app's browser; the
+  runtime-side functions are gated by environment-detection".
+- **Option C — split differently.** Server-side at
+  `re-frame2-causa-mcp.*`, browser-side at
+  `re-frame2-causa.runtime` (drop the `day8.` Maven-style prefix
+  on both to match Causa-the-panel's pair2-mcp inheritance ns
+  shape).
+
+### Pick
+
+**Option A.** Two namespaces, two locations, two roles, parented
+exactly the way pair2-mcp parents its analogous pair:
+
+| Side | Root ns | Lives in | Loaded by |
+|---|---|---|---|
+| MCP server (Node) | `day8.re-frame2-causa-mcp.*` | `tools/causa-mcp/src/` | `npx @day8/re-frame2-causa-mcp` |
+| Injected runtime (browser) | `day8.re-frame2-causa.runtime` | Causa-the-panel preload | shadow-cljs `:devtools :preloads` |
+
+The `day8.` Maven-style prefix is kept on both because
+Causa-the-panel already uses `day8.re-frame2-causa.*` for its
+own browser-side code (per
+[`tools/causa/src/day8/re_frame2_causa/`](../../causa/src/day8/re_frame2_causa/))
+and the injected runtime rides the same preload as Causa-the-panel.
+The MCP server's own code is parented `day8.re-frame2-causa-mcp.*`
+matching the maven coord `day8/re-frame2-causa-mcp` (Lock #6) and
+the npm coord `@day8/re-frame2-causa-mcp` (Lock #6).
+
+### Why
+
+- **Bundle isolation is the load-bearing rule.** Per
+  [`tools/README.md`](../../README.md), MCP-server code must
+  never reach a consumer app's preload classpath. A single-ns
+  conflation forces the consumer's preload to pull
+  `@modelcontextprotocol/sdk` + the bencode framer + the
+  Node-side stdio plumbing into the browser bundle — wreckage
+  Causa-the-panel already pays lint gates to avoid. The split
+  enforces the isolation at the `:require` line rather than at
+  review time.
+- **Mirroring pair2-mcp is free architectural alignment.**
+  Pair2-mcp's `re-frame-pair2-mcp.*` / `re-frame-pair2.runtime`
+  split is the proven precedent (rf2-7dvg cut the inject step
+  in favour of `:preloads`, locking the two-ns shape). Causa-MCP
+  inheriting Locks #1–#3 + #8 from pair2-mcp implies the same
+  bundle-shape inheritance; collapsing the namespaces would
+  invert that inheritance silently.
+- **Reviewer/implementer ergonomics.** A code-review comment
+  asking "is this op a server-side or runtime-side concern?"
+  becomes mechanical on a two-ns layout: read the namespace,
+  done. On a single-ns layout, the answer requires reading the
+  whole function body and reasoning about which globals exist
+  in which environment.
+- **The runtime parented by Causa, not the MCP server, is the
+  right shape.** The runtime *is* a browser-side artefact; its
+  natural home is alongside the panel's other browser-side
+  preloads. Parenting it `day8.re-frame2-causa-mcp.*` would
+  suggest it ships *with* the MCP server (Node-side), which is
+  wrong: the runtime ships with Causa-the-panel, and the MCP
+  server's eval forms address it by name once it's already
+  loaded.
+- **Option C (drop the `day8.` prefix) was rejected** because
+  Causa-the-panel's own browser-side code uses
+  `day8.re-frame2-causa.*` (e.g. `day8.re-frame2-causa.preload`,
+  `day8.re-frame2-causa.trace-bus`); the injected runtime
+  sharing that root is what makes it a natural Causa-panel
+  preload. Pair2-mcp's choice to drop the day8 prefix
+  (`re-frame-pair2.runtime` instead of
+  `day8.re-frame-pair2.runtime`) was a pre-existing
+  inconsistency the Causa-MCP folder doesn't have to inherit;
+  Causa-the-panel's `day8.` prefix is the local convention.
+- **Option B (collapse and document dual role) was rejected**
+  because environment-detection at function-call time replaces
+  a static layout invariant with a runtime check. Static
+  layout is cheaper, lint-detectable, and impossible to break
+  by accident.
+
+### Date locked
+
+2026-05-14 (Mike). Locked in rf2-c9b90 (this revision),
+following the rf2-m9yoi audit which surfaced the conflation in
+the 2026-05-13 spec scaffold (rf2-22my5, PR #823). Pre-dates
+`tools/causa-mcp/src/` by design — the same "bake-before-impl"
+calculus as Locks #9 and #10.
+
+### Trail-of-thought citations
+
+- pair2-mcp source layout:
+  [`tools/pair2-mcp/src/re_frame_pair2_mcp/`](../../pair2-mcp/src/re_frame_pair2_mcp/)
+  (server-side: `server.cljs`, `tools.cljs`, `cache.cljs`,
+  `nrepl.cljs`) and
+  [`skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs`](../../../skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs)
+  (browser-side) — the precedent.
+- pair2-mcp Principles §"Tool consumes the framework" — names
+  `re-frame-pair2.runtime` as the injected-runtime ns, distinct
+  from the MCP-server-side code that consumes it.
+- Causa-the-panel ns layout:
+  [`tools/causa/src/day8/re_frame2_causa/`](../../causa/src/day8/re_frame2_causa/)
+  — the `day8.re-frame2-causa.*` umbrella the injected runtime
+  parents under.
+- [`tools/README.md`](../../README.md) §Bundle isolation — the
+  rule the split enforces.
+- rf2-m9yoi (the audit that surfaced the conflation in
+  rf2-22my5's spec scaffold).
+
+---
+
 ## Summary table
 
 | # | Question | Pick | Date |
@@ -743,8 +884,9 @@ catalogue contract".
 | 8 | bencode pinning | **`bencode@~2.0.3`** (inherited from pair2-mcp Lock #5) | 2026-05-12 |
 | 9 | Wire-protocol budget posture | **Six mechanisms baked into spec before impl** (cap + slicing + pagination + lazy-summary + dedup + size-elision; mechanism #6 added by Lock #10) | 2026-05-13 |
 | 10 | Size-elision marker shape | **`:rf.size/large-elided` is the sixth mechanism; shape normative across MCP triplet; sensitive wins on composition** | 2026-05-13 |
+| 11 | Namespace split | **MCP-server-side at `day8.re-frame2-causa-mcp.*` (Node); injected-runtime-side at `day8.re-frame2-causa.runtime` (browser, rides Causa-the-panel's preload). Mirrors pair2-mcp's `re-frame-pair2-mcp.*` / `re-frame-pair2.runtime` split.** | 2026-05-14 |
 
-These ten locks define Causa-MCP's pre-implementation surface.
+These eleven locks define Causa-MCP's pre-implementation surface.
 They were extracted from
 [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
 and [Causa's own DESIGN-RATIONALE](../../causa/spec/DESIGN-RATIONALE.md)

--- a/tools/causa-mcp/spec/Principles.md
+++ b/tools/causa-mcp/spec/Principles.md
@@ -23,9 +23,13 @@ surfaces. It must not add:
 - New component substrates.
 
 The seventeen tools route through the existing
-`re-frame2-causa-mcp.runtime` namespace via `cljs-eval`. Nothing
-new is registered against the framework; nothing new is
-introduced into a consumer app's runtime.
+**injected-runtime namespace** (`day8.re-frame2-causa.runtime`,
+which rides Causa-the-panel's preload — see
+[`000-Vision.md` §Two namespaces, two sides](./000-Vision.md#two-namespaces-two-sides))
+via `cljs-eval`. The MCP-server-side code (`day8.re-frame2-causa-mcp.*`,
+Node-only) is the *renderer* of those eval forms; nothing new is
+registered against the framework on the browser side, and the
+Node-side server is invisible to the consumer app's runtime.
 
 This is the
 [downstream-EPs-consume-foundation rule](../../../spec/Principles.md)
@@ -39,6 +43,62 @@ doesn't expose `:parent-frame`"), file a `bd` bead against
 or the relevant Causa spec. Don't bolt a parallel surface onto
 the MCP server.
 
+## MCP-server-ns and injected-runtime-ns are distinct
+
+Causa-MCP's code lives on two sides of an stdio JSON-RPC pipe;
+each side has its own namespace root, and **the spec calls them
+out separately so the implementation can too** (same posture as
+pair2-mcp's `re-frame-pair2-mcp.*` / `re-frame-pair2.runtime`
+split). The full table — including which side each ns lives in,
+what loads it, and what it's responsible for — is at
+[`000-Vision.md` §Two namespaces, two sides](./000-Vision.md#two-namespaces-two-sides).
+
+The tie-breaker this principle hands implementers and reviewers:
+
+- **MCP-server-side concern?** Code goes under
+  `day8.re-frame2-causa-mcp.*`, lives in `tools/causa-mcp/src/`,
+  ships only inside the Node-side `:node-script` artefact, is
+  never `:require`-d from a browser bundle. Examples: stdio
+  framing, bencode/nREPL bridge, port discovery, eval-form
+  rendering, the `subscribe` notification pump, agent-host
+  capability negotiation.
+- **Injected-runtime-side concern?** Code goes under
+  `day8.re-frame2-causa.runtime` (parented by Causa-the-panel's
+  `day8.re-frame2-causa.*` root, because the runtime rides the
+  panel's `:preloads`), lives in the panel's preload classpath,
+  is the eval target of the MCP server's rendered forms.
+  Examples: per-frame state accessors backing the seventeen
+  tools, the `current-origin` dynamic var, the `session-id`
+  marker, hot-reload re-inject probes.
+
+A surface that *needs* to straddle both sides — e.g. a wire
+schema, an MCP marker keyword like `:rf.mcp/overflow`, the
+verb catalogue at
+[`tools/mcp-conformance/NAMING.md`](../../mcp-conformance/NAMING.md) —
+is owned by the cross-cutting `tools/mcp-conformance/` spec
+folder, not duplicated into either ns.
+
+**Bundle isolation forbids the conflation.** Per
+[`tools/README.md`](../../README.md), nothing in `implementation/`
+or a consumer app's preload classpath may pull MCP-server code.
+If a single namespace held both roles, the consumer app's
+preload would pull the Node-side
+`@modelcontextprotocol/sdk` import + the bencode wire framer +
+the stdio plumbing — wreckage the
+[`tools/causa/`](../../causa/) artefact already pays the lint
+gate to avoid. Two roots, two locations, two roles. Reviewers
+catch the leak at the `:require` line; the spec catches it at
+the architecture line.
+
+The principle has zero impact on the seventeen-tool catalogue
+(per [`DESIGN-RATIONALE.md` Lock #5](./DESIGN-RATIONALE.md)) and
+zero impact on the MCP wire shape (per Locks #1–#3). It's a
+naming + layout rule that costs nothing at the spec level and
+saves a "wait, which side am I writing?" pause at every impl
+PR.
+
+Captured as Lock #11 in [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md).
+
 ## Origin tagging is the convention, not a suggestion
 
 Every Causa-MCP-driven side-effect on the trace bus carries
@@ -46,9 +106,12 @@ Every Causa-MCP-driven side-effect on the trace bus carries
 each mutating tool (`dispatch`, `reset-frame-db`,
 `restore-epoch`) and at the boundary of `eval-cljs` (any
 dispatch the eval'd form triggers inherits the tag — the
-runtime install hook reads
-`re-frame2-causa-mcp.runtime/current-origin` for the dynamic
-extent of the eval call).
+**injected-runtime** install hook reads
+`day8.re-frame2-causa.runtime/current-origin` for the dynamic
+extent of the eval call; the MCP-server side
+(`day8.re-frame2-causa-mcp.*`) renders the binding form, the
+browser side holds the dynamic var — see
+[`000-Vision.md` §Two namespaces, two sides](./000-Vision.md#two-namespaces-two-sides)).
 
 This is the **load-bearing differentiator** against generalist
 agent surfaces (Chrome DevTools MCP's `evaluate_script` is
@@ -129,12 +192,19 @@ Concretely:
   on every op (and via the `SHADOW_CLJS_BUILD_ID` env var).
 - Port discovery walks `$SHADOW_CLJS_NREPL_PORT` → standard
   shadow paths → `.nrepl-port`. Any of them satisfy the contract.
-- Runtime presence is marker-detected (the runtime exposes
-  `re-frame2-causa-mcp.runtime/session-id`); a missing sentinel
-  triggers automatic re-injection on the next op rather than a
-  failed boot.
-- The runtime contract is the shape of the seventeen tools, not
-  a specific framework version.
+- Injected-runtime presence is marker-detected (the runtime
+  exposes `day8.re-frame2-causa.runtime/session-id` from the
+  browser side); a missing sentinel triggers automatic
+  re-injection on the next op rather than a failed boot. The
+  detection happens MCP-server-side
+  (`day8.re-frame2-causa-mcp.*`); the marker lives in the
+  browser. The two-ns split (per
+  [`000-Vision.md` §Two namespaces, two sides](./000-Vision.md#two-namespaces-two-sides))
+  is what lets the server reason about the runtime's absence
+  without itself having a `runtime/session-id` to test.
+- The runtime contract is the shape of the seventeen tool
+  accessors `day8.re-frame2-causa.runtime` exposes, not a
+  specific framework version.
 
 A project that adopts a non-default build id, a custom nREPL
 port, or a slightly different shadow layout still gets a working

--- a/tools/causa-mcp/spec/README.md
+++ b/tools/causa-mcp/spec/README.md
@@ -8,9 +8,9 @@ before this folder existed.
 
 ## Files
 
-- **[000-Vision.md](000-Vision.md)** — Causa-MCP is the agent face of Causa; seventeen MCP tools across five bands; same shadow-cljs / Node / persistent-nREPL architecture as pair2-mcp; relationship to Causa, pair2-mcp, and Chrome DevTools MCP.
-- **[Principles.md](Principles.md)** — Load-bearing principles: origin tagging is the convention (not a suggestion), EDN canonical, closed-set catalogue with `eval-cljs` as the deliberate escape valve, single persistent nREPL socket, stage-marker-independent, and the **six-mechanism wire-protocol budget posture** (token cap + path slicing + cursor pagination + lazy summary + structural dedup + size elision via `:rf.size/large-elided`) — baked into the spec before implementation begins so the impl is born compliant.
-- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — Ten direction-setting decisions: question, options, pick, why, date locked. Inheritance from pair2-mcp's locks is cited rather than duplicated.
+- **[000-Vision.md](000-Vision.md)** — Causa-MCP is the agent face of Causa; seventeen MCP tools across five bands; same shadow-cljs / Node / persistent-nREPL architecture as pair2-mcp; **two-namespace split** between the Node-side MCP server (`day8.re-frame2-causa-mcp.*`) and the browser-side injected runtime (`day8.re-frame2-causa.runtime`); relationship to Causa, pair2-mcp, and Chrome DevTools MCP.
+- **[Principles.md](Principles.md)** — Load-bearing principles: **MCP-server-ns and injected-runtime-ns are distinct** (the tie-breaker for "which side does this code go?"), origin tagging is the convention (not a suggestion), EDN canonical, closed-set catalogue with `eval-cljs` as the deliberate escape valve, single persistent nREPL socket, stage-marker-independent, and the **six-mechanism wire-protocol budget posture** (token cap + path slicing + cursor pagination + lazy summary + structural dedup + size elision via `:rf.size/large-elided`) — baked into the spec before implementation begins so the impl is born compliant.
+- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — Eleven direction-setting decisions: question, options, pick, why, date locked. Inheritance from pair2-mcp's locks is cited rather than duplicated.
 
 ## Files that will land at implementation time
 
@@ -34,7 +34,8 @@ that's how drift is prevented when a count next moves.
 | **Tools** | **17** | [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md) §Tool catalogue — the catalogue prose enumerates each. Migrates to `003-Tool-Catalogue.md` when impl lands. |
 | **Bands** | **5** | Inspection (9) + Mutation (3) + Streaming (2) + Escape hatch (1) + Meta (2) = 17. Enumerated in [`000-Vision.md`](000-Vision.md) §MCP catalogue summary. |
 | **Mechanisms** | **6** | [`Principles.md`](Principles.md) §"Tight token budget per response" — token cap, path slicing, cursor pagination, lazy summary, structural dedup, size elision. Mechanism #6 promoted by Lock #10. |
-| **Locks** | **10** | [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) §Summary table. |
+| **Locks** | **11** | [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) §Summary table. |
+| **Namespace roots** | **2** | MCP-server (Node-side): `day8.re-frame2-causa-mcp.*` — injected runtime (browser-side): `day8.re-frame2-causa.runtime`. Per [`000-Vision.md` §Two namespaces, two sides](000-Vision.md#two-namespaces-two-sides) and [`DESIGN-RATIONALE.md` Lock #11](DESIGN-RATIONALE.md). |
 
 ## How to use
 


### PR DESCRIPTION
## Summary

- Splits `tools/causa-mcp/spec/`'s previously conflated `re-frame2-causa-mcp.runtime` namespace into two distinct roles, mirroring pair2-mcp's `re-frame-pair2-mcp.*` / `re-frame-pair2.runtime` pattern:
  - **MCP-server-ns** (Node-side process): `day8.re-frame2-causa-mcp.*`
  - **Injected-runtime-ns** (browser-side eval target): `day8.re-frame2-causa.runtime` (rides Causa-the-panel's preload)
- Adds a new top-level §"Two namespaces, two sides" to `000-Vision.md` (full table + rationale), a new §"MCP-server-ns and injected-runtime-ns are distinct" principle to `Principles.md`, and Lock #11 to `DESIGN-RATIONALE.md`.
- Updates the lingering conflated references (3 in `Principles.md`, 1 in `DESIGN-RATIONALE.md` Lock #4, 1 row in the Vision §"Relationship to `tools/pair2-mcp/`" comparison table).
- Spec-only; pre-`tools/causa-mcp/src/`. No impl conflict.

## Sections renamed / added

| File | Change |
|---|---|
| `000-Vision.md` | **New** §"Two namespaces, two sides" — full table (Side / Root ns / Lives in / Loaded by / Role), "Why two roots, not one", "Cross-side coupling is one-way", "Why the runtime lives under `day8.re-frame2-causa.*`". Updated bullet in §"What it is" architecture-mirror list and split the "Runtime ns" row in §"Relationship to pair2-mcp" into two rows. |
| `Principles.md` | **New** principle §"MCP-server-ns and injected-runtime-ns are distinct" (the tie-breaker for "which side does this code go?"). Updated 3 lingering conflated refs (in §"Tool consumes the framework", §"Origin tagging", §"Stage-marker-independent"). |
| `DESIGN-RATIONALE.md` | **New** Lock #11 — Q / Options A,B,C / Pick / Why / Date / Citations. Summary-table row added (10→11). Lock #4 prose ns-ref updated. |
| `README.md` | File descriptions surface the split; lock count 10→11; new "Namespace roots" canonical-count row. |

## Test plan

- [x] `git diff` is spec-only (`tools/causa-mcp/spec/`)
- [x] No `re-frame2-causa-mcp.runtime` references remain outside Lock #11's Question / Option-B prose (which deliberately describe the rejected state)
- [x] mkdocs is not affected (no `tools/causa-mcp/` entries in `mkdocs.yml`)
- [x] Bundle isolation rule from `tools/README.md` cited as the load-bearing reason; reviewers can catch ns-leaks at the `:require` line

Refs: rf2-m9yoi audit Q2; rf2-22my5 (spec scaffold being amended).