### PR TITLE
fix(core): path-interceptor regression test handler honours arity-2 contract (rf2-jfk2s)

### DIFF
--- a/implementation/core/test/re_frame/interceptor_test.clj
+++ b/implementation/core/test/re_frame/interceptor_test.clj
@@ -82,7 +82,10 @@
                          :before (fn [ctx]
                                    (reset! seen-keys (set (keys ctx)))
                                    ctx))]
-                       inc)
+                       ;; reg-event-db handlers receive (slice, event-vec);
+                       ;; `inc` is arity-1 so wrap it explicitly to honour
+                       ;; the (fn [db event] new-db) contract.
+                       (fn [slice _] (inc slice)))
       (rf/dispatch-sync [:path-ns/init])
       (rf/dispatch-sync [:path-ns/inc])
       (is (contains? @seen-keys :rf/path-stack)


### PR DESCRIPTION
## Summary

Unblocks main CI (red since #875 / rf2-mn0qc).

- `path-interceptor-uses-reserved-namespace` in `interceptor_test.clj` passed bare `inc` as a reg-event-db handler, but reg-event-db calls handlers as `(handler-fn slice event-vec)` (arity-2). `inc` is arity-1 and threw `ArityException` on the JVM. The chain's `:before` catch routed the exception to `:rf/interceptor-error`; path's `:after` then fell back to the unchanged `:coeffects :db` slice (= 10) and spliced THAT back, so the test saw 10 instead of the expected 11.
- The splice-back logic in `std_interceptors.cljc` is unchanged and correct — the fallback in path's `:after` is the right teardown behaviour when the handler errored.
- Fix: wrap `inc` explicitly to honour the `(fn [db event] new-db)` contract, matching the neighbouring `path-interceptor` test on line 56-58.

## Why it slipped past rf2-mn0qc's pre-merge run

The chain's `:before` catch records the `ArityException` as `:rf/interceptor-error`, and the runtime emits `:rf.error/handler-exception` as a TRACE event (not via clojure.test's failure path). The test only asserts on the db value, so the underlying error was silent-as-data. Locally `clojure -M:test` reports `0 failures, 0 errors` for the namespace but `1 failure` for the assertion at line 92.

## Test plan

- [x] `clojure -M:test --namespace re-frame.interceptor-test` — 8 tests / 42 assertions, 0 failures, 0 errors
- [x] Full core suite `clojure -M:test` from `implementation/core/` — 444 tests / 2369 assertions, 0 failures, 0 errors

Closes rf2-jfk2s.