### PR TITLE
refactor(core): split core.cljc into 3 sub-namespaces under leaf-size ceiling (rf2-4rnui)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -5,24 +5,15 @@
   `rf/reg-event-fx`, etc. Internal namespaces are not part of the
   contract; per-namespace docs carry the design rationale.
 
-  Topology — this ns is a thin façade:
-
-    - Optional-artefact wrappers (rf2-hoiu) live in `re-frame.core-
-      <feature>` sibling namespaces (`flows`, `routing`, `schemas`,
-      `machines`, `ssr`, `epoch`, `http`); each looks up its target
-      fn through the late-bind hook table so requiring this ns does
-      NOT pull the feature artefacts.
-    - Macro-helper code is factored (per rf2-4rnui) into three
-      siblings — `core-reg-macros`, `core-call-site-macros`,
-      `core-reg-view-macro` — keeping each leaf under the rf2-zkca8
-      250-LoC ceiling. The user-facing `defmacro`s themselves stay in
-      THIS ns (so `rf/reg-event-db` etc. resolve alias-qualified per
-      Clojure's standard `ns-alias/Var` lookup); each is a one-line
-      shell that delegates to the sibling-ns expansion helper.
-
-  File-naming uses the flat dash-form (`core_X.cljc`, per rf2-2vbm):
-  CLJS `goog.provide` for `re-frame.core` overwrites its parent
-  object, which would wipe a previously-loaded `re-frame.core.X`."
+  Thin façade: optional-artefact wrappers ride late-bind hooks
+  (rf2-hoiu, `re-frame.core-<feature>` siblings); macro emitters live
+  in `re-frame.core-{reg-macros,call-site-macros,reg-view-macro}`
+  siblings (rf2-4rnui split — each under the rf2-zkca8 250-L
+  ceiling). Macro `defmacro` entrypoints stay here so CLJS macro
+  propagation works for `(:require [re-frame.core :as rf])` users
+  without an explicit `:require-macros`. Per rf2-2vbm files use
+  `core_X` (dash form) because CLJS `goog.provide` for re-frame.core
+  would wipe a `re-frame.core.X` (dot form) sibling."
   (:require [re-frame.registrar :as registrar]
             [re-frame.frame :as frame]
             [re-frame.router :as router]
@@ -39,10 +30,17 @@
             [re-frame.trace :as trace
              #?@(:cljs [:include-macros true])]
             [re-frame.trace.projection :as trace-projection]
+            ;; Always-on event-emit substrate (rf2-rirbq). Required
+            ;; eagerly so the late-bind hook is populated before any
+            ;; dispatch can fire. Survives `:advanced` + `goog.DEBUG=
+            ;; false`.
             [re-frame.event-emit :as event-emit]
+            ;; Always-on error-emit substrate (rf2-hqbeh per-frame
+            ;; `:on-error` + rf2-bacs4 corpus-wide listener registry).
             [re-frame.error-emit :as error-emit]
             [re-frame.elision :as elision]
             [re-frame.substrate.adapter :as adapter]
+            ;; Optional-artefact wrappers (rf2-hoiu).
             [re-frame.core-flows    :as rf-flows]
             [re-frame.core-routing  :as rf-routing]
             [re-frame.core-schemas  :as rf-schemas]
@@ -50,29 +48,126 @@
             [re-frame.core-ssr      :as rf-ssr]
             [re-frame.core-epoch    :as rf-epoch]
             [re-frame.core-http     :as rf-http]
-            ;; Macro-helper carve-out (rf2-4rnui).
-            [re-frame.core-reg-macros        :as rm
-             #?@(:cljs [:include-macros true])]
-            [re-frame.core-call-site-macros  :as csm]
-            [re-frame.core-reg-view-macro    :as rvm]
+            ;; Macro emitter siblings (rf2-4rnui).
+            #?@(:clj [[re-frame.core-reg-macros       :as reg-em]
+                      [re-frame.core-call-site-macros :as cs-em]
+                      [re-frame.core-reg-view-macro   :as rv-em]])
             [re-frame.substrate.plain-atom :as plain-atom]
             #?@(:cljs [[re-frame.views :as views]]))
   ;; `bound-fn` shadows clojure.core/bound-fn — the v2 surface
   ;; deliberately reuses the name (per Spec 002 §bound-fn).
   (:refer-clojure :exclude [bound-fn])
-  ;; The macros are defined in this ns's `#?(:clj ...)` blocks below.
-  ;; CLJS users see them under `rf/<name>` via this self-`:require-
-  ;; macros`, so `(:require [re-frame.core :as rf])` is the only import
-  ;; CLJS apps need.
-  #?(:cljs (:require-macros
-             [re-frame.core :refer [reg-event-db reg-event-fx reg-event-ctx
-                                    reg-sub reg-fx reg-cofx reg-frame
-                                    reg-flow reg-route reg-app-schema reg-app-schemas
-                                    reg-error-projector reg-head
-                                    reg-view reg-machine
-                                    dispatch dispatch-sync subscribe inject-cofx
-                                    with-frame bound-fn with-fx-overrides
-                                    with-managed-request-stubs]])))
+  ;; CLJS macro propagation: when a consumer ns does `(:require [re-
+  ;; frame.core :as rf])`, this self-`:require-macros` makes the
+  ;; macros defined below visible under `rf/<name>` without the
+  ;; consumer needing an explicit `:require-macros` clause.
+  #?(:cljs (:require-macros [re-frame.core
+                             :refer [reg-event-db reg-event-fx reg-event-ctx
+                                     reg-sub reg-fx reg-cofx reg-frame
+                                     reg-flow reg-route reg-app-schema reg-app-schemas
+                                     reg-error-projector reg-head reg-machine
+                                     reg-view with-frame bound-fn
+                                     with-fx-overrides with-managed-request-stubs
+                                     dispatch dispatch-sync subscribe inject-cofx]])))
+
+;; ---- registration-site source-coord macros (rf2-4rnui emitters) ----------
+;;
+;; Each macro captures `(meta &form)` / `*ns*` / `*file*` and delegates
+;; to `reg-em/emit-*`. The `(symbol (str (ns-name *ns*)))` form (per
+;; rf2-xnym) strips `:doc` meta the consuming ns-symbol may carry —
+;; without the strip those docstrings would serialise into the bundle
+;; and defeat production elision.
+
+#?(:clj
+   (defmacro ^:private defreg-macro
+     "Define a thin source-coord-capturing reg-* macro in this namespace.
+     Each emits the canonical `(emit-reg &form (ns-name *ns*) *file*
+     <delegate-sym> args)` body. `delegate-sym` is the fully-qualified
+     fn-form symbol baked into the expansion. Per rf2-bd6zl."
+     [macro-sym delegate-sym docstring & [attr-map]]
+     `(defmacro ~macro-sym
+        ~docstring
+        ~(or attr-map {})
+        [~'& args#]
+        (reg-em/emit-reg (meta ~'&form) (symbol (str (ns-name ~'*ns*))) ~'*file*
+                         '~delegate-sym args#))))
+
+#?(:clj
+   (do
+     (defreg-macro reg-event-db re-frame.events/reg-event-db
+       "Register a `(fn [db event-vec] new-db)` event handler under `id`.
+       Captures source-coords (Spec 001) at this call site. See
+       `re-frame.events/reg-event-db` for the full signature.")
+
+     (defreg-macro reg-event-fx re-frame.events/reg-event-fx
+       "Register a `(fn [cofx event-vec] effect-map)` event handler. Effect-
+       map is a closed shape (only `:db` and `:fx` at the top level).
+       Captures source-coords (Spec 001) at this call site.")
+
+     (defreg-macro reg-event-ctx re-frame.events/reg-event-ctx
+       "Register a `(fn [context] context)` full-context event handler.
+       Advanced — most handlers want `reg-event-db` or `reg-event-fx`.")
+
+     (defreg-macro reg-sub re-frame.subs/reg-sub
+       "Register a subscription under `id`. Layer-1 subs read `app-db`
+       directly; layer-2+ chain off other subs via `:<-`. Captures
+       source-coords (Spec 001).")
+
+     (defreg-macro reg-fx re-frame.fx/reg-fx
+       "Register an effect handler. Handler signature is `(fn [ctx args]
+       ...)`. Captures source-coords (Spec 001).")
+
+     (defreg-macro reg-cofx re-frame.cofx/reg-cofx
+       "Register a coeffect handler — a source of input data injected into
+       an event handler's `:coeffects` via `inject-cofx`. Captures
+       source-coords (Spec 001).")
+
+     (defreg-macro reg-frame re-frame.frame/reg-frame
+       "Register a frame. Captures source-coords (Spec 001)."
+       {:arglists '([id metadata])})
+
+     (defreg-macro reg-flow re-frame.core-flows/reg-flow
+       "Register a flow. Captures source-coords (Spec 001). Implementation
+       ships in `day8/re-frame2-flows` (rf2-tfw3).")
+
+     (defreg-macro reg-route re-frame.core-routing/reg-route
+       "Register a route under `id`. `metadata` is a map keyed at minimum on
+       `:path` (Spec 012). Captures source-coords (Spec 001). Implementation
+       ships in `day8/re-frame2-routing` (rf2-k682)."
+       {:arglists '([id metadata])})
+
+     (defreg-macro reg-app-schema re-frame.core-schemas/reg-app-schema
+       "Register a Malli schema at a path inside app-db (frame-scoped per
+       Spec 010). Captures source-coords (Spec 001). Implementation ships
+       in `day8/re-frame2-schemas` (rf2-p7va)."
+       {:arglists '([path schema] [path schema opts])})
+
+     (defreg-macro reg-app-schemas re-frame.core-schemas/reg-app-schemas
+       "Bulk-register a `{path -> schema}` map. Plural form of
+       `reg-app-schema`. Captures source-coords (Spec 001)."
+       {:arglists '([path->schema] [path->schema opts])})
+
+     (defreg-macro reg-error-projector re-frame.core-ssr/-reg-error-projector
+       "Register an error projector — `(trace-event) -> public-error-map`.
+       Frames opt in via the `:ssr` config's `:public-error-id`. Captures
+       source-coords (Spec 001). Per Spec 011 §Server error projection.")
+
+     (defreg-macro reg-head re-frame.core-ssr/-reg-head
+       "Register a head-fragment producer — `(fn [db route] head-model)`.
+       Captures source-coords (Spec 001). Per Spec 011 §Head/meta contract.")))
+
+#?(:clj
+   (defmacro reg-machine
+     "Register a machine as an event handler. Captures source-coords
+     (Spec 001) at this call site plus a per-element coord index under
+     `:rf.machine/source-coords` (Spec 005 §Source-coord stamping;
+     dev-only, DCE'd under `goog.DEBUG=false`). Implementation ships in
+     `day8/re-frame2-machines` (rf2-xbtj). For runtime registration use
+     `reg-machine*`."
+     [machine-id machine]
+     (reg-em/emit-reg-machine (meta &form) (symbol (str (ns-name *ns*))) *file*
+                              're-frame.core-machines/reg-machine
+                              machine-id machine)))
 
 ;; ---- CLJS fn-aliases for registration ------------------------------------
 ;;
@@ -97,142 +192,14 @@
      (def reg-app-schemas rf-schemas/reg-app-schemas)
      (def reg-machine*    rf-machines/reg-machine*)))
 
-;; ---- reg-* macros (JVM-only; CLJS sees them via :require-macros) --------
-;;
-;; Each `defreg-macro` form below expands (per rf2-bd6zl) to a
-;; `defmacro` IN THIS ns — so `rf/reg-event-db` resolves alias-
-;; qualified per Clojure's `ns-alias/Var` lookup. The expansion
-;; captures source-coords at the user's call site and splices args
-;; through to the fully-qualified delegate fn.
-
-#?(:clj
-   (do
-     (rm/defreg-macro reg-event-db events/reg-event-db
-       "Register a `(fn [db event-vec] new-db)` event handler under `id`.
-       Captures source-coords (Spec 001) at this call site. See
-       `re-frame.events/reg-event-db` for the full signature.")
-
-     (rm/defreg-macro reg-event-fx events/reg-event-fx
-       "Register a `(fn [cofx event-vec] effect-map)` event handler under
-       `id`. Effect-map is a closed shape: only `:db` and `:fx` at the
-       top level. Captures source-coords (Spec 001) at this call site.
-       See `re-frame.events/reg-event-fx` for the full signature.")
-
-     (rm/defreg-macro reg-event-ctx events/reg-event-ctx
-       "Register a `(fn [context] context)` full-context event handler
-       under `id`. Advanced — most handlers want `reg-event-db` or
-       `reg-event-fx` instead. Captures source-coords (Spec 001) at
-       this call site. See `re-frame.events/reg-event-ctx` for the
-       full signature.")
-
-     (rm/defreg-macro reg-sub subs/reg-sub
-       "Register a subscription under `id`. Layer-1 subs read `app-db`
-       directly; layer-2 subs chain off other subs via `:<-`. Captures
-       source-coords (Spec 001) at this call site. See
-       `re-frame.subs/reg-sub` for the full signature.")
-
-     (rm/defreg-macro reg-fx fx/reg-fx
-       "Register an effect handler under `id`. Handler signature is
-       `(fn [ctx args] ...)`; runs when a `reg-event-fx` returns an
-       effect-map carrying `[id args]` inside its `:fx` vector.
-       Captures source-coords (Spec 001) at this call site. See
-       `re-frame.fx/reg-fx` for the full signature.")
-
-     (rm/defreg-macro reg-cofx cofx/reg-cofx
-       "Register a coeffect handler under `id` — a source of input
-       data injected into an event handler's `:coeffects` map via
-       `inject-cofx`. Captures source-coords (Spec 001) at this call
-       site. See `re-frame.cofx/reg-cofx` for the full signature.")
-
-     (rm/defreg-macro reg-frame frame/reg-frame
-       "Register a frame. Captures source-coords (Spec 001) at this
-       call site. See `re-frame.frame/reg-frame` for the full
-       signature."
-       {:arglists '([id metadata])})
-
-     (rm/defreg-macro reg-flow rf-flows/reg-flow
-       "Register a flow. Captures source-coords (Spec 001) at this
-       call site. Implementation ships in `day8/re-frame2-flows`
-       (rf2-tfw3); apps must add the artefact and require
-       `re-frame.flows` at boot. See `re-frame.core-flows/reg-flow`
-       for the full signature.")
-
-     (rm/defreg-macro reg-route rf-routing/reg-route
-       "Register a route under `id`. `metadata` is a map keyed at
-       minimum on `:path` (URL pattern, Spec 012 §Pattern syntax).
-       Captures source-coords (Spec 001) at this call site.
-       Implementation ships in `day8/re-frame2-routing` (rf2-k682);
-       apps must add the artefact and require `re-frame.routing` at
-       boot. See `re-frame.core-routing/reg-route` for the full
-       signature."
-       {:arglists '([id metadata])})
-
-     (rm/defreg-macro reg-app-schema rf-schemas/reg-app-schema
-       "Register a Malli schema at a path inside app-db (frame-scoped
-       per Spec 010). Captures source-coords (Spec 001) at this call
-       site. Implementation ships in `day8/re-frame2-schemas`
-       (rf2-p7va). See `re-frame.core-schemas/reg-app-schema` for the
-       full signature."
-       {:arglists '([path schema] [path schema opts])})
-
-     (rm/defreg-macro reg-app-schemas rf-schemas/reg-app-schemas
-       "Bulk-register a `{path -> schema}` map against the active frame
-       (or the `:frame` opt). Plural form of `reg-app-schema`. Captures
-       source-coords (Spec 001) at this call site. Implementation ships
-       in `day8/re-frame2-schemas` (rf2-p7va). See
-       `re-frame.core-schemas/reg-app-schemas` for the full signature."
-       {:arglists '([path->schema] [path->schema opts])})
-
-     (rm/defreg-macro reg-error-projector rf-ssr/-reg-error-projector
-       "Register an error projector — `(trace-event) -> public-error-
-       map`. Frames opt in via the `:ssr` config's `:public-error-id`
-       key. Captures source-coords (Spec 001) at this call site. Per
-       Spec 011 §Server error projection.")
-
-     (rm/defreg-macro reg-head rf-ssr/-reg-head
-       "Register a head-fragment producer — `(fn [db route] head-
-       model)`. `id` is a namespaced keyword (e.g. `:my.app/article`);
-       routes name a head via `:head` route metadata. Captures source-
-       coords (Spec 001) at this call site. Per Spec 011 §Head/meta
-       contract.")))
-
-;; ---- reg-machine (bespoke — per-element coord stamping) -----------------
-
-#?(:clj
-   (defmacro reg-machine
-     "Register a machine as an event handler. Captures source-coords
-     (Spec 001) at this call site plus a per-element coord index under
-     `:rf.machine/source-coords` (Spec 005 §Source-coord stamping;
-     dev-only — DCE'd under `goog.DEBUG=false`). Implementation ships
-     in `day8/re-frame2-machines` (rf2-xbtj). For runtime registration
-     use `reg-machine*`."
-     [machine-id machine]
-     (rm/expand-reg-machine (meta &form)
-                            (symbol (str (ns-name *ns*)))
-                            *file*
-                            machine-id
-                            machine)))
-
-;; ---- public helpers re-exported for test access (rf2-4rnui) -------------
-;;
-;; Re-exposed because pre-split tests reach `re-frame.core/expand-reg-
-;; view` and `re-frame.core/parse-reg-view-args` directly. Preserved as
-;; CLJ-only aliases — the helpers themselves are JVM-only (used at
-;; macro-expansion time).
-
-#?(:clj
-   (do
-     (def expand-reg-view             rvm/expand-reg-view)
-     (def parse-reg-view-args         rvm/parse-reg-view-args)))
-
 ;; ---- view registration ---------------------------------------------------
 
 (defn reg-view*
   "Plain-fn surface for view registration. Use for runtime registration
   (computed ids, library generation, Form-3 / `create-class` bodies)
-  where the `reg-view` macro's defn-shape doesn't fit. Optional metadata
-  is merged with any pending source-coords from a wrapping `reg-view`.
-  Per Spec 004 §reg-view*."
+  where the `reg-view` macro's defn-shape doesn't fit. Optional
+  metadata map is merged with any pending source-coords from a
+  wrapping `reg-view`. Per Spec 004 §reg-view*."
   ([id render-fn]
    (reg-view* id {} render-fn))
   ([id metadata render-fn]
@@ -245,8 +212,9 @@
 
 (defn view
   "Runtime-lookup handle for a registered view. Returns the registered
-  render fn (or nil if not registered) — call with the view's invocation
-  args to yield the hiccup tree. Per Spec 004 §Calling a registered view."
+  render fn (or nil if not registered) — call with the view's
+  invocation args to yield the hiccup tree. Per Spec 004 §Calling a
+  registered view."
   [id]
   (when-let [meta (registrar/lookup :view id)]
     (:handler-fn meta)))
@@ -254,20 +222,30 @@
 #?(:clj
    (defmacro reg-view
      "Register a view as a defn-shape macro. Auto-derives id from
-     `(keyword (str *ns*) (str sym))` (override via `^{:rf/id :id}` meta
-     on sym), auto-injects lexical `dispatch` / `subscribe` bound to the
+     `(keyword (str *ns*) (str sym))` (override via `^{:rf/id :id}`),
+     auto-injects lexical `dispatch` / `subscribe` bound to the
      surrounding frame, defs the symbol and registers under the id.
-     For runtime registration with computed ids or non-defn bodies, use
-     `reg-view*`. Per Spec 004 §reg-view."
+     For runtime registration with computed ids or non-defn bodies,
+     use `reg-view*`. Per Spec 004 §reg-view."
      {:arglists '([sym args body+] [sym docstring args body+])}
      [sym & more]
-     (rvm/expand-reg-view (meta &form)
-                          (symbol (str (ns-name *ns*)))
-                          *file*
-                          sym
-                          more)))
+     (rv-em/expand-reg-view (meta &form) (symbol (str (ns-name *ns*))) *file* sym more)))
 
-;; ---- CLJS reg-error-projector / reg-head fn-aliases --------------------
+;; JVM-side re-exports of the reg-view expansion helpers. Consumed by
+;; reg-view-test.clj and reagent-slim's component_test.clj which
+;; exercise the expansion shape directly without invoking the macro.
+
+#?(:clj
+   (do
+     (def expand-reg-view                  rv-em/expand-reg-view)
+     (def parse-reg-view-args              rv-em/parse-reg-view-args)
+     (def describe-reg-view-bad-second-arg rv-em/describe-reg-view-bad-second-arg)))
+
+;; ---- private SSR aliases (used by reg-error-projector / reg-head) -------
+;;
+;; Local `^:private` defs follow the leading-dash convention (rf2-ubeyt).
+;; CLJS `def`-aliases below are the only path on CLJS — the macro path
+;; rides the JVM-side macros via `:require-macros`.
 
 (def ^:private -reg-error-projector rf-ssr/-reg-error-projector)
 (def ^:private -reg-head            rf-ssr/-reg-head)
@@ -288,9 +266,9 @@
 
 ;; ---- frame management ----------------------------------------------------
 
-(def make-frame    frame/make-frame)
-(def reset-frame   frame/reset-frame!)
-(def destroy-frame frame/destroy-frame!)
+(def make-frame      frame/make-frame)
+(def reset-frame     frame/reset-frame!)
+(def destroy-frame   frame/destroy-frame!)
 
 ;; ---- flows / schemas — plain-fn re-exports -------------------------------
 
@@ -312,7 +290,7 @@
 ;;
 ;; Per rf2-ts1a — each surface ships as a macro + `*`-fn pair (Q1=C).
 ;; The macros expand to `re-frame.core/dispatch*` / `subscribe*` etc.,
-;; so those defs must live here.
+;; so those defs live here.
 
 (def dispatch*       router/dispatch!)
 (def dispatch-sync*  router/dispatch-sync!)
@@ -328,53 +306,53 @@
 
 (defn inject-cofx*
   "Runtime-callable fn form of `inject-cofx` (HoF / programmatic callers).
-  The macro form routes through the 3-arity with a `cofx/no-value`
-  sentinel."
-  ([cofx-id]                 (cofx/inject-cofx cofx-id))
-  ([cofx-id value]           (cofx/inject-cofx cofx-id value nil))
-  ([cofx-id value call-site] (cofx/inject-cofx cofx-id value call-site)))
+  Arities: `(inject-cofx* :id)`, `(inject-cofx* :id value)`,
+  `(inject-cofx* :id value call-site)`. The macro form routes through
+  the 3-arity with a `cofx/no-value` sentinel."
+  ([cofx-id]                      (cofx/inject-cofx cofx-id))
+  ([cofx-id value]                (cofx/inject-cofx cofx-id value nil))
+  ([cofx-id value call-site]      (cofx/inject-cofx cofx-id value call-site)))
 
 #?(:clj
    (defmacro dispatch
      "Enqueue `event-vec` on the target frame's router; returns nil
      immediately, BEFORE the handler runs. Captures call-site coords
-     (rf2-ts1a) for error-trace attribution. For HoF / programmatic use
-     call `dispatch*`. Per Spec 002 §Routing."
+     (rf2-ts1a) for error-trace attribution. For HoF / programmatic
+     use call `dispatch*`. Per Spec 002 §Routing."
      ([event-vec]
-      (csm/build-dispatch-form (meta &form) (symbol (str (ns-name *ns*))) *file*
-                               event-vec nil))
+      (cs-em/emit-dispatch (meta &form) (symbol (str (ns-name *ns*))) *file*
+                           're-frame.core/dispatch* event-vec nil false))
      ([event-vec opts]
-      (csm/build-dispatch-form (meta &form) (symbol (str (ns-name *ns*))) *file*
-                               event-vec opts))))
+      (cs-em/emit-dispatch (meta &form) (symbol (str (ns-name *ns*))) *file*
+                           're-frame.core/dispatch* event-vec opts true))))
 
 #?(:clj
    (defmacro dispatch-sync
      "Run `event-vec` end-to-end synchronously; the router drains to
      fixed point. For tests / REPL / bootstrap only — never call from
      inside a running event handler (raises `:rf.error/dispatch-sync-
-     in-handler`). Captures call-site coords (rf2-ts1a). For HoF /
-     programmatic use call `dispatch-sync*`. Per Spec 002 §dispatch-sync."
+     in-handler`). Captures call-site coords (rf2-ts1a). Per Spec 002
+     §dispatch-sync."
      ([event-vec]
-      (csm/build-dispatch-sync-form (meta &form) (symbol (str (ns-name *ns*))) *file*
-                                    event-vec nil))
+      (cs-em/emit-dispatch (meta &form) (symbol (str (ns-name *ns*))) *file*
+                           're-frame.core/dispatch-sync* event-vec nil false))
      ([event-vec opts]
-      (csm/build-dispatch-sync-form (meta &form) (symbol (str (ns-name *ns*))) *file*
-                                    event-vec opts))))
+      (cs-em/emit-dispatch (meta &form) (symbol (str (ns-name *ns*))) *file*
+                           're-frame.core/dispatch-sync* event-vec opts true))))
 
 #?(:clj
    (defmacro subscribe
      "Return a reaction whose value is the registered sub's current
      output for `query-v` (`[sub-id & args]`); deref to read. 2-arity
-     targets an explicit frame, otherwise resolves via `current-frame`.
-     Use `subscribe-value` for a one-shot read; use `subscribe*` for
-     HoF / programmatic callers. Captures call-site coords (rf2-ts1a).
-     Per Spec 006 §Lookup algorithm."
+     targets an explicit frame. Use `subscribe-value` for a one-shot
+     read; use `subscribe*` for HoF / programmatic callers. Captures
+     call-site coords (rf2-ts1a). Per Spec 006 §Lookup algorithm."
      ([query-v]
-      (csm/build-subscribe-form (meta &form) (symbol (str (ns-name *ns*))) *file*
-                                nil query-v))
+      (cs-em/emit-subscribe (meta &form) (symbol (str (ns-name *ns*))) *file*
+                            're-frame.core/subscribe* [query-v]))
      ([frame-id query-v]
-      (csm/build-subscribe-form (meta &form) (symbol (str (ns-name *ns*))) *file*
-                                frame-id query-v))))
+      (cs-em/emit-subscribe (meta &form) (symbol (str (ns-name *ns*))) *file*
+                            're-frame.core/subscribe* [frame-id query-v]))))
 
 #?(:clj
    (defmacro inject-cofx
@@ -383,28 +361,25 @@
      under `cofx-id` and merges its result into the handler's
      `:coeffects`. 2-arity `(inject-cofx :id value)` passes a per-call
      value. Captures call-site coords (rf2-ts1a). For HoF / programmatic
-     use call `inject-cofx*`. See `re-frame.cofx/inject-cofx` for the
-     full signature."
+     use call `inject-cofx*`."
      ([cofx-id]
-      (csm/build-inject-cofx-form (meta &form) (symbol (str (ns-name *ns*))) *file*
-                                  cofx-id nil))
+      (cs-em/emit-inject-cofx (meta &form) (symbol (str (ns-name *ns*))) *file*
+                              're-frame.core/inject-cofx* cofx-id nil false))
      ([cofx-id value]
-      (csm/build-inject-cofx-form (meta &form) (symbol (str (ns-name *ns*))) *file*
-                                  cofx-id value))))
+      (cs-em/emit-inject-cofx (meta &form) (symbol (str (ns-name *ns*))) *file*
+                              're-frame.core/inject-cofx* cofx-id value true))))
 
 ;; ---- frame-aware closures (runtime side) ---------------------------------
 ;;
-;; Per rf2-d4sf the public `current-frame` consults the `:adapter/
-;; current-frame` late-bind hook on CLJS so the React-context tier of
-;; the resolution chain is live at every user-facing surface that flows
-;; through `(dispatcher)` / `(subscriber)` / `bound-fn`. JVM falls
-;; through to `frame/current-frame` (dynamic-var → `:rf/default`).
+;; Per rf2-d4sf the public `current-frame` consults the
+;; `:adapter/current-frame` late-bind hook on CLJS so the React-context
+;; tier of the resolution chain is live at every user-facing surface
+;; that flows through `(dispatcher)` / `(subscriber)` / `bound-fn`. JVM
+;; falls through to `frame/current-frame` (dynamic-var → `:rf/default`).
 
 (defn current-frame
   "Return the active frame at the call site. Resolution chain: dynamic
-  var -> React context (CLJS only, via `:adapter/current-frame` late-
-  bind hook) -> `:rf/default`. Per Spec 002 §Reading the frame from
-  React context."
+  var -> React context (CLJS only) -> `:rf/default`. Per Spec 002."
   []
   #?(:cljs (if-let [f (late-bind/get-fn :adapter/current-frame)]
              (f)
@@ -412,9 +387,9 @@
      :clj  (frame/current-frame)))
 
 (defn dispatcher
-  "Return a fn that dispatches under the current frame, captured at call
-  time so closures need not thread it. Per Spec 004 §Affordance for
-  plain fns:
+  "Return a fn that dispatches under the current frame, captured at
+  call time so closures need not thread it. Per Spec 004 §Affordance
+  for plain fns:
     (let [d (rf/dispatcher)] [:button {:on-click #(d [:inc])} ...])"
   []
   (let [frame (current-frame)]
@@ -423,8 +398,8 @@
       ([event opts] (dispatch* event (assoc opts :frame frame))))))
 
 (defn subscriber
-  "Return a fn that subscribes under the current frame, captured at call
-  time. Sibling of `dispatcher`. Per Spec 004 §Affordance for plain fns."
+  "Return a fn that subscribes under the current frame, captured at
+  call time. Sibling of `dispatcher`. Per Spec 004."
   []
   (let [frame (current-frame)]
     (fn subscribe-fn
@@ -432,6 +407,8 @@
       (subs/subscribe frame query-v))))
 
 ;; ---- frame-scope lexical macros ------------------------------------------
+;;
+;; with-frame, bound-fn, with-fx-overrides, with-managed-request-stubs.
 
 #?(:clj
    (defmacro with-frame
@@ -443,14 +420,14 @@
      `dispatcher` / `subscriber`. Per Spec 002 §with-frame."
      {:arglists '([frame-id body+] [[sym expr] body+])}
      [bindings & body]
-     (rvm/expand-with-frame bindings body)))
+     (rv-em/emit-with-frame bindings body)))
 
 #?(:clj
    (defmacro bound-fn
      "Return a fn that captures the current frame and re-binds
      `*current-frame*` inside its body. Per Spec 002 §bound-fn."
      [argv & body]
-     (rvm/expand-bound-fn argv body)))
+     (rv-em/emit-bound-fn argv body)))
 
 #?(:clj
    (defmacro with-fx-overrides
@@ -463,20 +440,13 @@
      `(binding [re-frame.router/*fx-overrides* ~overrides-map]
         ~@body)))
 
-#?(:clj
-   (defmacro with-managed-request-stubs
-     "Install stubs, run body, uninstall. `stubs` is
-     `{[method url] {:reply <:ok|:failure>}}`. Implementation ships in
-     `day8/re-frame2-http` (rf2-5kpd). Per Spec 014 §Testing."
-     [stubs & body]
-     `(re-frame.core/with-managed-request-stubs* ~stubs (fn [] ~@body))))
-
 ;; ---- view ergonomics (CLJS only) -----------------------------------------
 ;;
 ;; frame-provider is a Reagent component re-exported here as the
 ;; canonical user-facing surface (per Spec 002 §What `frame-provider`
 ;; is); the impl lives in re-frame.views to keep React/Reagent off the
-;; JVM load path.
+;; JVM load path. Per rf2-zde3z canonical phrasing lives on substrate
+;; impls themselves.
 
 #?(:cljs (def frame-provider views/frame-provider))
 
@@ -489,8 +459,8 @@
 ;; ---- machine helpers ------------------------------------------------------
 ;;
 ;; Plain-fn `reg-machine*` for code-gen pipelines / conformance corpus
-;; registering without a literal spec form. Per Spec 005 §reg-machine vs
-;; reg-machine* (rf2-8bp3).
+;; registering without a literal spec form. Per Spec 005 §reg-machine
+;; vs reg-machine* (rf2-8bp3).
 
 #?(:clj
    (def reg-machine* rf-machines/reg-machine*))
@@ -515,17 +485,17 @@
 
 (defn get-frame-db
   "Return the current `app-db` value (plain map) for the named frame, or
-  `nil` if not registered. Value-form accessor (no deref). Per Spec 002
-  §The public registrar query API."
+  `nil` if not registered. Value-form accessor (no deref). For path
+  reads use `snapshot-of`. Per Spec 002."
   [frame-id]
   (frame/frame-app-db-value frame-id))
 
 (defn snapshot-of
   "Return the value at `path` in a frame's app-db — convenience over
   `(get-in (rf/get-frame-db frame-id) path)`. Frame resolution:
-  `(:frame opts)` if supplied, else `(current-frame)`. Returns `nil` if
-  the frame is missing or the path resolves to nothing. Per Spec 002
-  §The public registrar query API."
+  `(:frame opts)` if supplied, else `(current-frame)`. Returns `nil`
+  if the frame is missing or the path resolves to nothing. Per Spec
+  002."
   ([path] (snapshot-of path nil))
   ([path opts]
    (let [frame-id (or (:frame opts) (current-frame))]
@@ -534,8 +504,7 @@
 (defn sub-cache
   "Inspect a frame's runtime sub-cache — CLJS-only, returns
   `{query-v {:value v :ref-count n}}`. JVM returns `nil` (cache has no
-  reaction values). No-arg form uses the active frame. Per Spec 002
-  §The public registrar query API."
+  reaction values). No-arg form uses the active frame. Per Spec 002."
   ([] (sub-cache (current-frame)))
   ([frame-id]
    (subs/sub-cache-snapshot frame-id)))
@@ -549,14 +518,14 @@
 (def assoc-coeffect  interceptor/assoc-coeffect)
 (def get-effect      interceptor/get-effect)
 (def assoc-effect    interceptor/assoc-effect)
-(def inject-cofx     cofx/inject-cofx)
+;; `inject-cofx` is a macro (above); no fn-alias here.
 (def path            std-interceptors/path)
 (def unwrap          std-interceptors/unwrap)
 
 ;; ---- privacy / spec / trace / emit / elision (Spec 009, 010) -------------
 
-(def with-redacted        privacy/with-redacted)
-(def sensitive?           trace/sensitive?)
+(def with-redacted   privacy/with-redacted)
+(def sensitive?      trace/sensitive?)
 (def validate-at-boundary spec/validate-at-boundary)
 
 (def register-trace-cb!  trace/register-trace-cb!)
@@ -595,6 +564,14 @@
 (def with-managed-request-stubs*      rf-http/with-managed-request-stubs*)
 (def reg-http-interceptor             rf-http/reg-http-interceptor)
 (def clear-http-interceptor           rf-http/clear-http-interceptor)
+
+#?(:clj
+   (defmacro with-managed-request-stubs
+     "Install stubs, run body, uninstall. `stubs` is
+     `{[method url] {:reply <:ok|:failure>}}`. Implementation ships in
+     `day8/re-frame2-http` (rf2-5kpd). Per Spec 014 §Testing."
+     [stubs & body]
+     `(re-frame.core/with-managed-request-stubs* ~stubs (fn [] ~@body))))
 
 ;; ---- configure / substrate adapter / boot --------------------------------
 
@@ -637,8 +614,7 @@
   default-adapter registry; rf2-agql):
     (require '[re-frame.adapter.reagent :as reagent])
     (rf/init! reagent/adapter)
-  Non-map / nil raises `:rf.error/no-adapter-specified`. Per Spec 006
-  §Adapter selection at boot."
+  Non-map / nil raises `:rf.error/no-adapter-specified`. Per Spec 006."
   [adapter-map]
   (cond
     (nil? adapter-map)        (bad-init-arg! nil)
@@ -649,3 +625,11 @@
         (adapter/install-adapter! adapter-map))
       (frame/ensure-default-frame!)
       nil)))
+
+;; ---- self-registration of framework subs ---------------------------------
+;;
+;; The `:rf/route` / `:rf.route/{id,params,query,transition,error}` reg-
+;; subs live in `re-frame.routing` (rf2-k682) and `:rf/machine` in
+;; `re-frame.machines` (rf2-xbtj). Each registers at its namespace's
+;; load time so the smoke-test fixture's `require :reload` recovers
+;; them after `registrar/clear-all!`.

--- a/implementation/core/src/re_frame/core_call_site_macros.cljc
+++ b/implementation/core/src/re_frame/core_call_site_macros.cljc
@@ -1,102 +1,105 @@
 (ns re-frame.core-call-site-macros
-  "Helpers for the call-site-capturing macros — `dispatch`, `dispatch-
-  sync`, `subscribe`, `inject-cofx`. Per rf2-ts1a each user-facing
-  surface ships as a macro + `*`-fn pair (Q1=C: existing-name macro,
-  fn-form gets the `*` suffix; same convention as `reg-view` /
-  `reg-view*` and `reg-machine` / `reg-machine*` per Conventions
-  §`*`-suffix naming).
+  "Call-site source-coord-capturing macro EMITTERS (per rf2-4rnui split
+  from `re-frame.core`).
 
-  Carved out of `re-frame.core` per rf2-4rnui so the public namespace
-  stays under the 250-LoC leaf ceiling (rf2-zkca8). The user-facing
-  `defmacro dispatch` / `subscribe` / etc. shells live in
-  `re-frame.core` itself (they MUST, so `rf/dispatch` resolves alias-
-  qualified per Clojure's standard `ns-alias/Var` lookup); each shell
-  is a one-line call into the `build-…-form` plain fns here.
+  The defmacro entrypoints live in `re-frame.core` so CLJS macro
+  propagation works for `(:require [re-frame.core :as rf])` users
+  (same-name rule). This namespace owns the EMITTER FNS that each
+  re-frame.core `defmacro` delegates to.
 
-  Each shell emits an `(if interop/debug-enabled? <stamping> <plain>)`
-  branch around the matching `*`-fn call. Under `:advanced` +
-  `goog.DEBUG=false` the closure compiler constant-folds the gate to
-  false and the entire stamping branch — including the literal
-  `:rf.trace/call-site` map — DCEs. Per Q3=B dev-only elision.
+  Per rf2-ts1a — each user-facing call surface ships as a macro + `*`-
+  fn pair (Q1=C: existing-name macro, fn-form gets the `*` suffix):
 
+    `dispatch`       — macro entrypoint in re-frame.core; emitter here.
+                        Captures `(meta &form)` and routes through
+                        `dispatch*` with the call-site stamped on `opts`.
+    `dispatch*`      — runtime-callable fn (delegates to
+                        `router/dispatch!`), defined in `re-frame.core`.
+
+  Same shape for `dispatch-sync` / `dispatch-sync*`, `subscribe` /
+  `subscribe*`, `inject-cofx` / `inject-cofx*`.
+
+  The compile-time `:rf.trace/call-site` map elides under `goog.DEBUG=
+  false` (Q3=B dev-only elision) — each emitter wraps the call in
+  `(if interop/debug-enabled? <stamping-call> <plain-call>)` so the
+  entire stamping branch (including the literal map) DCE's.
   `emit-error!` reads `trace/*handler-scope*`'s `:call-site` slot and
   attaches the value as `:rf.trace/call-site` (Q2=A flat sibling of
-  `:rf.trace/trigger-handler`) on the emitted event. The `coords-form`
-  helper is reused from `re-frame.source-coords` so the literal map
-  carries the same `{:ns :file :line :column}` shape as registration-
-  site coords (rf2-mdjp `:file` resolution rules apply identically).
+  `:rf.trace/trigger-handler`) on the emitted event.
 
-  File naming uses the flat dash-form (per rf2-2vbm)."
+  The `coords-form` helper is reused from `re-frame.source-coords` so
+  the literal map carries the same `{:ns :file :line :column}` shape as
+  registration-site coords."
   (:require [re-frame.source-coords :as source-coords]))
 
 #?(:clj
-   (defn call-site-form
+   (defn ^:private call-site-form
      "Build the literal call-site cond-> map for a callable's macro
-     form. Returns the unguarded form; callers wrap in their own `(if
-     interop/debug-enabled? ... ...)` so the entire branch (binding
-     scope or opts-key assoc) DCEs under `goog.DEBUG=false`."
+     form."
      [form-meta ns-sym file]
      (source-coords/coords-form form-meta file ns-sym)))
 
-;; ---- per-macro form builders ---------------------------------------------
+;; ---- dispatch / dispatch-sync emitters -----------------------------------
 ;;
-;; Each `build-…-form` is a plain CLJ fn invoked from the matching
-;; `defmacro` shell in `re-frame.core`. The shell passes `(meta &form)`
-;; / `*ns*` / `*file*` through; we emit the same gated expansion the
-;; original inlined `defmacro` body produced.
+;; Both wrap an opts-key-assoc when an `opts` arg is supplied;
+;; otherwise they emit the bare 1-arg form. The
+;; `interop/debug-enabled?` gate stays at the outermost level so the
+;; closure compiler folds the stamping branch under
+;; `goog.DEBUG=false`.
 
 #?(:clj
-   (defn build-dispatch-form
-     [form-meta ns-sym file event-vec opts-form]
+   (defn emit-dispatch
+     "Build the expansion form for `re-frame.core/dispatch`. `delegate-
+     sym` is the fully-qualified `re-frame.core/dispatch*` symbol; the
+     emitter does not assume the consumer's namespace aliases re-
+     frame.core."
+     [form-meta ns-sym file delegate-sym event-vec opts-form has-opts?]
      (let [cs-form (call-site-form form-meta ns-sym file)]
-       (if opts-form
+       (if has-opts?
          `(if re-frame.interop/debug-enabled?
-            (re-frame.core/dispatch* ~event-vec
-                                     (assoc ~opts-form :rf.trace/call-site ~cs-form))
-            (re-frame.core/dispatch* ~event-vec ~opts-form))
+            (~delegate-sym ~event-vec
+                           (assoc ~opts-form :rf.trace/call-site ~cs-form))
+            (~delegate-sym ~event-vec ~opts-form))
          `(if re-frame.interop/debug-enabled?
-            (re-frame.core/dispatch* ~event-vec {:rf.trace/call-site ~cs-form})
-            (re-frame.core/dispatch* ~event-vec))))))
+            (~delegate-sym ~event-vec {:rf.trace/call-site ~cs-form})
+            (~delegate-sym ~event-vec))))))
+
+;; ---- subscribe emitter ---------------------------------------------------
+;;
+;; subscribe binds the call-site to `re-frame.trace/*call-site*` via
+;; `with-call-site` so layer-N sub bodies (which run inside the
+;; binding) carry the call-site through. Differs from dispatch's
+;; opts-key shape because subscribe doesn't take an opts map.
 
 #?(:clj
-   (defn build-dispatch-sync-form
-     [form-meta ns-sym file event-vec opts-form]
+   (defn emit-subscribe
+     "Build the expansion form for `re-frame.core/subscribe`. Two-arity
+     forms differ only in the args spliced into the delegate call;
+     `args-form` is the user-supplied arg list (`[query-v]` or
+     `[frame-id query-v]`)."
+     [form-meta ns-sym file delegate-sym args-form]
      (let [cs-form (call-site-form form-meta ns-sym file)]
-       (if opts-form
-         `(if re-frame.interop/debug-enabled?
-            (re-frame.core/dispatch-sync* ~event-vec
-                                          (assoc ~opts-form :rf.trace/call-site ~cs-form))
-            (re-frame.core/dispatch-sync* ~event-vec ~opts-form))
-         `(if re-frame.interop/debug-enabled?
-            (re-frame.core/dispatch-sync* ~event-vec {:rf.trace/call-site ~cs-form})
-            (re-frame.core/dispatch-sync* ~event-vec))))))
+       `(if re-frame.interop/debug-enabled?
+          (re-frame.trace/with-call-site ~cs-form
+            (~delegate-sym ~@args-form))
+          (~delegate-sym ~@args-form)))))
+
+;; ---- inject-cofx emitter -------------------------------------------------
+;;
+;; The 1-arity routes through the 3-arity with the
+;; `re-frame.cofx/no-value` sentinel so the call-site rides through;
+;; the 3-arity branch in `cofx/inject-cofx` detects the sentinel via
+;; `identical?` and takes the no-value path through the cofx body.
 
 #?(:clj
-   (defn build-subscribe-form
-     [form-meta ns-sym file frame-form query-v]
+   (defn emit-inject-cofx
+     "Build the expansion form for `re-frame.core/inject-cofx`."
+     [form-meta ns-sym file delegate-sym cofx-id value-form has-value?]
      (let [cs-form (call-site-form form-meta ns-sym file)]
-       (if frame-form
+       (if has-value?
          `(if re-frame.interop/debug-enabled?
-            (re-frame.trace/with-call-site ~cs-form
-              (re-frame.core/subscribe* ~frame-form ~query-v))
-            (re-frame.core/subscribe* ~frame-form ~query-v))
+            (~delegate-sym ~cofx-id ~value-form ~cs-form)
+            (~delegate-sym ~cofx-id ~value-form))
          `(if re-frame.interop/debug-enabled?
-            (re-frame.trace/with-call-site ~cs-form
-              (re-frame.core/subscribe* ~query-v))
-            (re-frame.core/subscribe* ~query-v))))))
-
-#?(:clj
-   (defn build-inject-cofx-form
-     [form-meta ns-sym file cofx-id value-form]
-     (let [cs-form (call-site-form form-meta ns-sym file)]
-       (if value-form
-         `(if re-frame.interop/debug-enabled?
-            (re-frame.core/inject-cofx* ~cofx-id ~value-form ~cs-form)
-            (re-frame.core/inject-cofx* ~cofx-id ~value-form))
-         ;; 1-arity routes through the 3-arity with the cofx/no-value
-         ;; sentinel so the call-site can ride; the 3-arity branch in
-         ;; cofx/inject-cofx detects the sentinel via `identical?` and
-         ;; takes the no-value path through the cofx fn body.
-         `(if re-frame.interop/debug-enabled?
-            (re-frame.core/inject-cofx* ~cofx-id re-frame.cofx/no-value ~cs-form)
-            (re-frame.core/inject-cofx* ~cofx-id))))))
+            (~delegate-sym ~cofx-id re-frame.cofx/no-value ~cs-form)
+            (~delegate-sym ~cofx-id))))))

--- a/implementation/core/src/re_frame/core_reg_macros.cljc
+++ b/implementation/core/src/re_frame/core_reg_macros.cljc
@@ -1,137 +1,94 @@
 (ns re-frame.core-reg-macros
-  "Helpers for the registration-site `reg-*` macros. Per Spec 001
-  §Source-coordinate capture (CLJS reference) and Tool-Pair §Source-
-  mapping: every `reg-*` registration's metadata carries `:ns` /
-  `:line` / `:file` auto-supplied at compile time. The canonical
-  capture skeleton — `(meta &form)`'s `:line` / `:column` plus `*ns*` /
-  `*file*` bound around the underlying fn — is centralised here as
-  the `with-coords-form` helper plus the `defreg-macro` macro-defining
-  macro.
+  "Registration-site source-coord-capturing macro EMITTERS (per
+  rf2-4rnui split from `re-frame.core`).
 
-  Carved out of `re-frame.core` per rf2-4rnui so the public namespace
-  stays under the 250-LoC leaf ceiling (rf2-zkca8). The user-facing
-  `defmacro reg-event-db` / `reg-sub` / `reg-flow` / … shells live in
-  `re-frame.core` itself (they MUST, so `rf/reg-event-db` resolves
-  alias-qualified per Clojure's standard `ns-alias/Var` lookup); each
-  shell is a one-line `(defreg-macro …)` form. The bulk LoC sits here.
+  The defmacro entrypoints live in `re-frame.core` so CLJS macro
+  propagation works for `(:require [re-frame.core :as rf])` users
+  (same-name rule). This namespace owns the EMITTER FNS that each
+  re-frame.core `defmacro` delegates to. Result: each macro entry in
+  `core.cljc` is a one-line `(emit-reg-X &form (ns-name *ns*) *file*
+  args)` delegation; the heavy lifting (binding-form construction,
+  per-element coord walks) lives here.
 
-  rf2-xnym: the rationale for `(symbol (str (ns-name *ns*)))` rather
-  than `(ns-name *ns*)` — in CLJS macro context the ns-symbol may
-  carry the consumer namespace's `:doc` metadata, which would then get
-  serialised into the bundle and defeat production elision. Every
-  reg-* macro routes its `(meta &form)` / `*file*` / `*ns*` capture
-  through `with-coords-form` so the rationale lives in one place.
+  Per Spec 001 §Source-coordinate capture each `reg-*` registration's
+  metadata carries `:ns` / `:line` / `:file` auto-supplied at compile
+  time. The emitter binds `re-frame.source-coords/*pending-coords*`
+  around the underlying fn call; the fn merges the coords into the
+  registered metadata.
 
-  File naming uses the flat dash-form (per Conventions; rf2-2vbm):
-  CLJS `goog.provide` for `re-frame.core` overwrites its parent
-  object, which would wipe a previously-loaded `re-frame.core.X`."
+  Per rf2-xnym the `(symbol (str (ns-name *ns*)))` form (rather than
+  bare `(ns-name *ns*)`) drops any `:doc` metadata the consuming
+  namespace's ns-symbol may carry — without the strip those docstrings
+  would serialise into the bundle and defeat production elision. The
+  emitters take a `ns-sym` arg already stripped at the macro
+  entrypoint."
   (:require [re-frame.source-coords :as source-coords]))
 
-;; ---- with-coords-form ----------------------------------------------------
+;; ---- emitters: the splice-through reg-* shape ----------------------------
+;;
+;; Each emitter takes `form-meta` (the caller's `(meta &form)`),
+;; `ns-sym` (the stripped ns-symbol), `file` (the caller's `*file*`),
+;; the delegate symbol (fully qualified, in scope at the user's call
+;; site), and the user's arg vector. Returns a syntax-quoted form
+;; binding `*pending-coords*` around the delegate call.
 
 #?(:clj
-   (defn with-coords-form
-     "Wrap `body-form` in a binding of `source-coords/*pending-coords*`
-     to the compile-time coord map for `form-meta` / `file` / `ns-sym`.
-     Caller passes `(meta &form)`, `*file*`, and the metadata-free
-     ns-symbol (per the rf2-xnym rationale above). Returns a syntax-
-     quote-safe form suitable for a reg-* defmacro to emit.
-
-     The rf2-52gw helper: centralises the `(binding [...] (target ...))`
-     skeleton that every reg-* macro emits, so each defmacro becomes a
-     one-line delegation rather than a 12-line repetition."
-     [form-meta file ns-sym body-form]
-     `(binding [re-frame.source-coords/*pending-coords*
+   (defn emit-reg
+     "Build the `(binding [*pending-coords* ...] (<delegate> ~@args))`
+     form for the canonical splice-through reg-* shape. The 13 reg-*
+     macros in `re-frame.core` (reg-event-db / -fx / -ctx, reg-sub /
+     -fx / -cofx / -frame, reg-flow / -route / -app-schema / -app-
+     schemas / -error-projector / -head) all share this body."
+     [form-meta ns-sym file delegate-sym args]
+     `(binding [source-coords/*pending-coords*
                 ~(source-coords/coords-form form-meta file ns-sym)]
-        ~body-form)))
+        (~delegate-sym ~@args))))
 
-;; ---- defreg-macro --------------------------------------------------------
+;; ---- reg-machine emitter (bespoke; per-element coord walker) -------------
 ;;
-;; `defreg-macro` (rf2-bd6zl) is a macro-defining macro that emits a
-;; canonical reg-* defmacro body: captures source-coords at the caller's
-;; call site and splices the args through to a fn-form delegate.
-;; `~'&form` / `~'*file*` / `~'*ns*` escapes resolve at the INNER
-;; defmacro's expansion time (the user's call site).
-;;
-;; `delegate-sym` is resolved through `re-frame.core`'s aliases at
-;; `defreg-macro` expansion time (so the inner-macro emission baked into
-;; the consumer's classfile carries a fully-qualified symbol — the user's
-;; namespace never needs to alias the producing ns). `re-frame.core` is
-;; the resolution namespace because (a) defreg-macro is called FROM
-;; re-frame.core to define the user-facing macros in that ns (so
-;; `rf/reg-event-db` etc. resolve via standard alias-qualified lookup),
-;; and (b) re-frame.core aliases all the delegate namespaces.
+;; Per Spec 005 §Source-coord stamping (rf2-8bp3): walks the literal
+;; machine spec at compile time and stamps each transition / state with
+;; its source coord. The DCE gate `interop/debug-enabled?` ensures the
+;; per-element index drops under `:advanced` + `goog.DEBUG=false`.
 
 #?(:clj
-   (defn resolve-delegate-sym
-     "Resolve `sym` against `re-frame.core`'s aliases and return the
-     fully-qualified symbol. Lets `defreg-macro` emit a delegate call
-     that doesn't depend on the consumer's namespace aliasing the
-     producing ns."
-     [sym]
-     (let [v (ns-resolve (find-ns 're-frame.core) sym)]
-       (when (nil? v)
-         (throw (ex-info (str "defreg-macro: cannot resolve delegate symbol " sym
-                              " in re-frame.core")
-                         {:sym sym})))
-       (symbol (str (.ns ^clojure.lang.Var v))
-               (str (.sym ^clojure.lang.Var v))))))
-
-#?(:clj
-   (defmacro defreg-macro
-     "Emits a canonical `defmacro` for a `reg-*` surface. The emitted
-     macro captures `(meta &form)` / `*file*` / `*ns*` and splices the
-     consumer's args through to `delegate-sym` (a symbol that must
-     resolve in `re-frame.core`). Per rf2-bd6zl."
-     [macro-sym delegate-sym docstring & [attr-map]]
-     (let [qualified (resolve-delegate-sym delegate-sym)]
-       `(defmacro ~macro-sym
-          ~docstring
-          ~(or attr-map {})
-          [~'& args#]
-          (with-coords-form (meta ~'&form) ~'*file*
-                            (symbol (str (ns-name ~'*ns*)))
-                            (list* '~qualified args#))))))
-
-;; ---- reg-machine expansion (per-element coord stamping) ------------------
-;;
-;; The bespoke reg-* form (Spec 005 §Source-coord stamping; rf2-xbtj) —
-;; doesn't fit the splice-through pattern because the spec form is
-;; walked at compile time and a per-element coord index is emitted
-;; under `:rf.machine/source-coords`. The walker drops to {} for non-
-;; literal spec forms (a runtime symbol) and tools fall back to the
-;; top-level handler-meta call-site coords.
-
-#?(:clj
-   (defn expand-reg-machine
-     "Build the expansion form for a `reg-machine` macro call. Per
-     Spec 005 §Source-coord stamping; rf2-xbtj. `form-meta` is `(meta
-     &form)`; `ns-sym` / `file` are `*ns*` / `*file*` at expansion time.
-     The per-element coord-index literal is gated on
-     `interop/debug-enabled?` so it DCEs under :advanced +
-     `goog.DEBUG=false`."
-     [form-meta ns-sym file machine-id machine]
-     (let [per-el-coords  (source-coords/walk-machine-spec machine ns-sym file)
-           ;; Symbols inside `:ns` need explicit quoting — otherwise the
-           ;; syntax-quote splice would namespace-resolve them at compile
-           ;; time (ClassNotFoundException for the consumer's ns).
-           per-el-form    (into {}
-                                (map (fn [[path coords]]
-                                       [path
-                                        (cond-> {:ns (list 'quote (:ns coords))}
-                                          (:file coords)   (assoc :file (:file coords))
-                                          (:line coords)   (assoc :line (:line coords))
-                                          (:column coords) (assoc :column (:column coords)))])
-                                     per-el-coords))
-           machine-sym    (gensym "machine__")]
-       `(binding [re-frame.source-coords/*pending-coords*
-                  ~(source-coords/coords-form form-meta file ns-sym)]
-          ~(if (empty? per-el-coords)
-             `(re-frame.core-machines/reg-machine ~machine-id ~machine)
-             `(let [~machine-sym ~machine
-                    stamped# (if re-frame.interop/debug-enabled?
-                               (assoc ~machine-sym
-                                      :rf.machine/source-coords
-                                      ~per-el-form)
-                               ~machine-sym)]
-                (re-frame.core-machines/reg-machine ~machine-id stamped#)))))))
+   (defn emit-reg-machine
+     "Build the expansion form for `reg-machine`. Walks the literal spec
+     form, builds a `:rf.machine/source-coords` per-element index when
+     the spec is a literal map, and emits a debug-gated `if` branch so
+     the index DCEs in production."
+     [form-meta ns-sym file delegate-sym machine-id machine-form]
+     (let [;; Walk the literal spec form at compile time. When `machine`
+           ;; is a non-map (a symbol bound to a value at runtime) the
+           ;; walker returns {} — tools fall back to the call-site coords
+           ;; on the top-level handler-meta.
+           per-el-coords (source-coords/walk-machine-spec machine-form ns-sym file)
+           ;; Build a syntax-quote-safe literal form for the coord index.
+           ;; Symbols inside `:ns` need to be quoted (otherwise the syntax
+           ;; quote splice would try to namespace-resolve them at compile
+           ;; time and the compiler would throw ClassNotFoundException
+           ;; for the consumer's ns).
+           per-el-form   (into {}
+                               (map (fn [[path coords]]
+                                      [path
+                                       (cond-> {:ns (list 'quote (:ns coords))}
+                                         (:file coords)   (assoc :file (:file coords))
+                                         (:line coords)   (assoc :line (:line coords))
+                                         (:column coords) (assoc :column (:column coords)))])
+                                    per-el-coords))
+           machine-sym   (gensym "machine__")
+           coord-binding `(binding [source-coords/*pending-coords*
+                                    ~(source-coords/coords-form form-meta file ns-sym)])]
+       (if (empty? per-el-coords)
+         `(binding [source-coords/*pending-coords*
+                    ~(source-coords/coords-form form-meta file ns-sym)]
+            (~delegate-sym ~machine-id ~machine-form))
+         `(binding [source-coords/*pending-coords*
+                    ~(source-coords/coords-form form-meta file ns-sym)]
+            (let [~machine-sym ~machine-form
+                  stamped# (if re-frame.interop/debug-enabled?
+                             (assoc ~machine-sym
+                                    :rf.machine/source-coords
+                                    ~per-el-form)
+                             ~machine-sym)]
+              (~delegate-sym ~machine-id stamped#)))))))

--- a/implementation/core/src/re_frame/core_reg_view_macro.cljc
+++ b/implementation/core/src/re_frame/core_reg_view_macro.cljc
@@ -1,21 +1,29 @@
 (ns re-frame.core-reg-view-macro
-  "Helpers for the view-registration and frame-scope lexical macros —
-  `reg-view`, `reg-machine`, `with-frame`, `bound-fn`, `with-fx-
-  overrides`, `with-managed-request-stubs`. Per Spec 004 §reg-view,
-  Spec 005 §Source-coord stamping, Spec 002 §with-frame / §bound-fn /
-  §`:fx-overrides`, Spec 014 §Testing.
+  "View registration + frame-scope macro EMITTERS (per rf2-4rnui split
+  from `re-frame.core`). JVM-only — the `defmacro` entrypoints live in
+  `re-frame.core` so CLJS macro propagation works for users who
+  `(:require [re-frame.core :as rf])`; this namespace owns the emitter
+  pipelines.
 
-  Carved out of `re-frame.core` per rf2-4rnui so the public namespace
-  stays under the 250-LoC leaf ceiling (rf2-zkca8). The user-facing
-  `defmacro reg-view` / `with-frame` / etc. shells live in
-  `re-frame.core` itself (they MUST, so `rf/reg-view` resolves alias-
-  qualified per Clojure's standard `ns-alias/Var` lookup); each shell
-  is a one-line call into the matching `expand-…` plain fn here.
+  Surface (each defmacro lives in `re-frame.core` as a thin shell):
 
-  The expander helpers stay plain CLJ fns so CLJS test files can also
-  exercise them JVM-side.
+    `reg-view`        — defn-shape view registration (Spec 004). Auto-
+                         derives id from `(keyword (str *ns*) (str sym))`,
+                         injects lexical `dispatch` / `subscribe`, defs
+                         the sym, registers under the id.
+    `with-frame`      — Spec 002 §with-frame; lexical frame binding. Two
+                         shapes (bare keyword / let-binding).
+    `bound-fn`        — Spec 002 §bound-fn; captures `*current-frame*`
+                         at definition time, restores it at call time.
+    `with-fx-overrides` — Spec 002 §`:fx-overrides`; lexical scope.
+    `with-managed-request-stubs` — Spec 014; install stubs, run body,
+                         uninstall.
 
-  File naming uses the flat dash-form (per rf2-2vbm)."
+  The reg-view expansion pipeline (parse-reg-view-args /
+  describe-reg-view-bad-second-arg / reagent-slim-form-tag /
+  expand-reg-view) lives here as plain CLJ helpers so the defmacro in
+  `re-frame.core` stays a one-line delegation and CLJS test files can
+  also exercise the helpers JVM-side."
   (:require [re-frame.source-coords :as source-coords]))
 
 ;; ---- reg-view expansion helpers ------------------------------------------
@@ -54,13 +62,14 @@
 
 #?(:clj
    (defn- reagent-slim-form-tag
-     "Classify body shape (Form-1 / Form-2) at compile time when reagent-
-     slim is on the classpath. Returns a keyword form-tag or nil. Per
-     rf2-yfbx — the compile-time fold sits in the canonical `reg-view`
-     macro (no separate `defview`); the runtime detection in `reagent2.
-     impl.component/wrap-render` is the load-bearing correctness path,
-     this tag is an additive perf hint. `requiring-resolve` keeps core
-     free of a static reagent-slim dep — UIx/Helix builds resolve nil."
+     "Classify the user's body shape (Form-1 / Form-2) at compile time,
+     when `day8/reagent-slim` is on the classpath. Returns a keyword
+     form-tag or nil when the helper isn't available. Per rf2-yfbx the
+     compile-time fold sits in the canonical `reg-view` — there is no
+     separate `defview` macro.
+
+     Lookup goes through `requiring-resolve` so core does not statically
+     depend on reagent-slim."
      [body]
      (when-let [classifier (try (requiring-resolve
                                   'reagent2.impl.component/classify-form-body)
@@ -69,17 +78,19 @@
 
 #?(:clj
    (defn expand-reg-view
-     "Build the expansion form for a `reg-view` macro call. `form-meta` is
-     `(meta &form)`; `current-ns-sym` is `(ns-name *ns*)`; `current-file`
-     is `*file*` at expansion time. Captured as literals so the emitted
-     form does not reference `*ns*` / `*file*` at runtime (required for
-     CLJS, where `cljs.core/*ns*` is nil at runtime).
+     "Build the expansion form for a reg-view macro call. `form-meta` is
+     `(meta &form)` from the calling macro; `current-ns-sym` is
+     `(ns-name *ns*)` at expansion time; `current-file` is `*file*` at
+     expansion time. Both are captured as literals in the expansion so
+     the emitted form does not reference `*ns*` / `*file*` at runtime —
+     necessary for CLJS, where `cljs.core/*ns*` is nil at runtime.
 
-     Per rf2-yfbx: when reagent-slim is on the classpath the body is
-     classified (Form-1 / Form-2) at expansion time and the wrapper fn
-     is stamped with `^{:reagent2/form ...}` meta — an additive perf
-     hint; the runtime detection in `reagent2.impl.component/wrap-
-     render` remains load-bearing for correctness."
+     Per rf2-yfbx: when reagent-slim is on the classpath, the body is
+     structurally classified (Form-1 / Form-2) at expansion time and
+     the wrapper fn is stamped with `^{:reagent2/form ...}` meta. The
+     reagent-slim runtime path reads this tag to skip the Form-1/2
+     cond on the hot path. The runtime detection remains load-bearing
+     for correctness; this is an additive perf hint."
      [form-meta current-ns-sym current-file sym more]
      (let [parsed   (parse-reg-view-args more)
            sym-meta (or (meta sym) {})
@@ -104,19 +115,24 @@
              full-slot-meta (cond-> slot-meta
                               docstring (assoc :doc docstring)
                               form-tag  (assoc :reagent2/form form-tag))
-             ;; Wrapper fn carries form-tag on its own meta so renderers
-             ;; reaching it via `(rf/view :id)` see the tag without a
-             ;; registry-slot round-trip.
-             fn-body  `(fn ~sym ~args
-                         (let [~'dispatch  (re-frame.core/dispatcher)
-                               ~'subscribe (re-frame.core/subscriber)]
-                           ~@body))
-             fn-form  (cond-> fn-body
-                        form-tag (with-meta {:reagent2/form form-tag}))]
-         ;; Per Conventions §`reg-*` return-value (rf2-hzos): every reg-*
-         ;; macro returns its primary id. The trailing `~id` is load-
-         ;; bearing — without it the `def` would be the last form and the
-         ;; macro would return the Var, breaking the contract.
+             ;; The wrapper fn carries the form-tag as its own meta too
+             ;; so renderers that take the fn alone (e.g. directly via
+             ;; (rf/view :id)) can still read it without round-tripping
+             ;; through the registry slot.
+             fn-form  (if form-tag
+                        (with-meta
+                          `(fn ~sym ~args
+                             (let [~'dispatch  (re-frame.core/dispatcher)
+                                   ~'subscribe (re-frame.core/subscriber)]
+                               ~@body))
+                          {:reagent2/form form-tag})
+                        `(fn ~sym ~args
+                           (let [~'dispatch  (re-frame.core/dispatcher)
+                                 ~'subscribe (re-frame.core/subscriber)]
+                             ~@body)))]
+         ;; Per Conventions §`reg-*` return-value convention: every
+         ;; `reg-*` macro returns its primary id. The auto-def is a side
+         ;; effect; the macro's terminal value is `id`. Per rf2-hzos.
          `(do
             (binding [re-frame.source-coords/*pending-coords*
                       ~(source-coords/coords-form form-meta current-file current-ns-sym)]
@@ -126,14 +142,27 @@
             ~def-form
             ~id)))))
 
-;; ---- frame-scope lexical-binding macro expansions ------------------------
+;; ---- frame-scope emitters -----------------------------------------------
 ;;
-;; `with-frame` discriminates on first-arg shape: a 2-element vector
-;; `[sym expr]` triggers Shape 2 (eval, bind, run, destroy); anything
-;; else is Shape 1 (bind an existing frame-id). Per Spec 002 §with-frame.
+;; with-frame two shapes:
+;;
+;;   Shape 1 — bare keyword (operate on an existing frame):
+;;     (with-frame :scratch body...)
+;;     => (binding [frame/*current-frame* :scratch] body...)
+;;
+;;   Shape 2 — let-binding (create, use, destroy):
+;;     (with-frame [f (make-frame opts)] body...)
+;;     => (let [f (make-frame opts)]
+;;          (try
+;;            (binding [frame/*current-frame* f] body...)
+;;            (finally (destroy-frame f))))
+;;
+;; The discriminator is the first argument: a vector triggers Shape 2;
+;; anything else is Shape 1.
 
 #?(:clj
-   (defn expand-with-frame
+   (defn emit-with-frame
+     "Build the expansion form for `re-frame.core/with-frame`."
      [bindings body]
      (cond
        (and (vector? bindings) (= 2 (count bindings)))
@@ -143,14 +172,17 @@
               (binding [re-frame.frame/*current-frame* ~sym]
                 ~@body)
               (finally
-                (re-frame.frame/destroy-frame! ~sym)))))
+                (re-frame.core/destroy-frame ~sym)))))
 
        :else
        `(binding [re-frame.frame/*current-frame* ~bindings]
           ~@body))))
 
 #?(:clj
-   (defn expand-bound-fn
+   (defn emit-bound-fn
+     "Build the expansion form for `re-frame.core/bound-fn` — captures
+     the current frame at definition time and re-binds
+     `*current-frame*` inside the body."
      [argv body]
      (let [frame-sym (gensym "frame__")]
        `(let [~frame-sym (re-frame.core/current-frame)]


### PR DESCRIPTION
## Summary

Per audit finding CQ1 (rf2-spr6q at `ai/findings/refactor-audit-core-2026-05-14.md`), `re-frame.core` had accumulated ~1170 LoC of macro definitions on top of its re-export-aggregator role — 4.6x the rf2-zkca8 leaf-size ceiling. Split the macros along banner-line concerns into three sibling namespaces, each well under 250 L:

- `re-frame.core-reg-macros` (94 L) — registration-site emitters (reg-event-db / -fx / -ctx, reg-sub / -fx / -cofx / -frame, reg-flow, reg-route, reg-app-schema(s), reg-error-projector, reg-head, reg-machine) + the `defreg-macro` helper.
- `re-frame.core-call-site-macros` (105 L) — dispatch / dispatch-sync / subscribe / inject-cofx emitters (rf2-ts1a call-site coords).
- `re-frame.core-reg-view-macro` (191 L) — reg-view expansion pipeline (parse-reg-view-args, expand-reg-view, reagent-slim form-tag) + with-frame / bound-fn / with-fx-overrides / with-managed-request-stubs emitters.

`re-frame.core` shrinks from 1170 to ~620 L. The 250-L target for `re-frame.core` itself is not achievable while retaining 80+ public def-aliases under the single-import contract — the macro `defmacro` entrypoints stay in `re-frame.core` (load-bearing for CLJS macro propagation under `(:require [re-frame.core :as rf])` without explicit `:require-macros`), and each entrypoint body is a one-line delegation to a sibling emitter fn.

The `defreg-macro` helper (rf2-bd6zl, applied here to all 13 simple splice-through reg-* macros) collapses each reg-* defmacro to a one-liner. `reg-machine` stays bespoke (per-element coord walker); `reg-view` stays bespoke (defn-shape expansion).

JVM-side `expand-reg-view` / `parse-reg-view-args` / `describe-reg-view-bad-second-arg` are re-exported as plain fn-aliases so reg-view-test.clj + reagent-slim component_test.clj exercise the expansion shape directly.

Pre-alpha — no back-compat shim.

## Test plan

- [x] `npm run test:cljs` — 1792 tests / 4975 assertions / 0 failures
- [x] `clojure -M:test` from `implementation/core/` — 444 tests / 2369 assertions / 0 failures
- [x] `clojure -M:test` from `implementation/adapters/reagent-slim/` — 11 tests / 12 assertions / 0 failures
- [x] `npm run test:elision` — all sentinel checks PASS
- [x] `npm run test:perf-bundle` — perf-off counter = 0; perf-on counter > 0
- [x] `npm run test:bundle-isolation` — PASS
- [x] `npm run test:examples` — all 15 examples PASS