### PR TITLE
refactor(core): subscribe-value unsubscribes synchronously (rf2-zmufj)

### DIFF
--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -474,12 +474,26 @@
   so the read is part of the cofx contract rather than a side-effect
   inside the handler body.
 
-  See also: `subscribe`, `compute-sub`, `inject-cofx`."
+  Per rf2-zmufj: the teardown unsubscribe runs with `{:grace 0}` so
+  the one-shot read's whole lifetime — subscribe, deref, dispose —
+  completes in the calling tick. Without this, a fresh-sub call
+  would build, deref, then schedule a grace-period timer that fires
+  after the caller has moved on, leaking dispose side-effects
+  (`set-timeout!` + `clear-timeout!` + the post-grace `dispose!`
+  trace burst) past the call's observable lifetime.
+
+  See also: `subscribe`, `unsubscribe`, `compute-sub`, `inject-cofx`."
   ([query-v] (subscribe-value (resolve-current-frame) query-v))
   ([frame-id query-v]
    (let [reaction (subscribe frame-id query-v)
          v        (when reaction @reaction)]
-     (unsubscribe frame-id query-v)
+     ;; Per rf2-zmufj: force synchronous dispose for our own teardown so
+     ;; the one-shot read surface pays no deferred-dispose tax. The
+     ;; `{:grace 0}` opt overrides the configured grace-period for this
+     ;; call only — concurrent subscribers (if any) keep the slot alive
+     ;; via ref-count and are unaffected; this call's decrement only
+     ;; triggers disposal when it drove the 1→0 transition.
+     (unsubscribe frame-id query-v {:grace 0})
      v)))
 
 (defn compute-sub
@@ -558,15 +572,35 @@
 
   When grace-period is 0, disposal is synchronous — useful for tests.
 
+  The 3-arity form accepts an opts map. Per rf2-zmufj:
+
+      {:grace N}   — override the configured grace-period for THIS
+                     call only. `{:grace 0}` forces synchronous
+                     disposal on the 1→0 transition; useful for
+                     callers that want their unsubscribe observable
+                     in the same tick (e.g. `subscribe-value`'s
+                     internal teardown). When `:grace` is absent,
+                     the configured per-runtime grace-period is used.
+
   Reagent views auto-dispose via the reaction lifecycle and don't
   need to call this explicitly. Tests, REPL sessions, and tools that
   subscribe imperatively should call unsubscribe when they're done
   to release the cache slot."
-  ([query-v] (unsubscribe (resolve-current-frame) query-v))
+  ([query-v]
+   (unsubscribe (resolve-current-frame) query-v nil))
   ([frame-id query-v]
+   (unsubscribe frame-id query-v nil))
+  ([frame-id query-v opts]
    (when-let [cache (:sub-cache (frame/frame frame-id))]
      (let [k     (cache-key query-v)
-           grace (grace-period-ms)
+           ;; Per rf2-zmufj: an explicit `:grace` in opts overrides the
+           ;; per-runtime configured grace-period for this call only.
+           ;; `contains?` rather than `(:grace opts)` so `{:grace 0}`
+           ;; is honoured (0 is truthy in Clojure but reads better
+           ;; intent-wise to gate on presence).
+           grace (if (and (map? opts) (contains? opts :grace))
+                   (:grace opts)
+                   (grace-period-ms))
            ;; Per rf2-3mww7: the swap-fn body is pure — it returns only
            ;; the new cache map. The drop-to-zero signal is read from
            ;; the diff between `old` and `new` AFTER the CAS commits.

--- a/implementation/core/test/re_frame/sub_cache_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_test.clj
@@ -161,6 +161,84 @@
     (is (not (contains? (cache-keys) [:n]))
         "slot disposed synchronously")))
 
+;; ---- rf2-zmufj: subscribe-value teardown is synchronous -------------------
+;;
+;; subscribe-value's internal unsubscribe runs with `{:grace 0}` so the
+;; one-shot read's whole lifetime — subscribe, deref, dispose — completes
+;; in the calling tick. Pre-fix, even with the per-runtime grace-period
+;; set to 50ms, subscribe-value would schedule a deferred dispose timer
+;; whose callback fired AFTER the caller had moved on, leaking dispose
+;; side-effects past the call's observable lifetime.
+
+(deftest subscribe-value-disposes-synchronously
+  (testing "subscribe-value's teardown is synchronous regardless of the configured grace-period (rf2-zmufj)"
+    (subs/configure! {:grace-period-ms 60000})  ;; long grace; pre-fix this leaked
+    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:init])
+
+    ;; Pre-condition: no cache slot exists for [:n] yet.
+    (is (not (contains? (cache-keys) [:n]))
+        "no cache slot before subscribe-value")
+
+    ;; subscribe-value: builds the sub, derefs, and tears down. Per
+    ;; rf2-zmufj the teardown is synchronous — when this returns, the
+    ;; slot MUST already be evicted, with no pending-dispose handle.
+    (is (= 7 (rf/subscribe-value [:n])))
+    (is (not (contains? (cache-keys) [:n]))
+        "slot is disposed synchronously inside subscribe-value — no deferred timer")))
+
+(deftest subscribe-value-respects-concurrent-subscriber
+  (testing "subscribe-value's :grace 0 teardown only disposes when it drove 1→0 (rf2-zmufj)"
+    (subs/configure! {:grace-period-ms 60000})
+    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:init])
+
+    ;; Pin the slot with a reactive subscribe — ref-count = 1.
+    (let [pin (rf/subscribe [:n])]
+      (is (= 1 (entry-ref-count [:n])))
+
+      ;; subscribe-value runs: subscribe (ref-count → 2), deref,
+      ;; unsubscribe {:grace 0} (ref-count → 1). The decrement does NOT
+      ;; drive 1→0 — the pinning subscribe is still live — so the slot
+      ;; MUST survive untouched.
+      (is (= 7 (rf/subscribe-value [:n])))
+      (is (contains? (cache-keys) [:n])
+          "slot survives — the pinning subscriber kept ref-count > 0")
+      (is (= 1 (entry-ref-count [:n]))
+          "ref-count back to 1 after subscribe-value's paired inc/dec")
+      (is (not (pending-dispose? [:n]))
+          "no dispose was scheduled — the {:grace 0} teardown only fires on 1→0")
+
+      ;; Cleanup: release the pin so the fixture's grace-period reset
+      ;; doesn't leave a live slot behind. (Re-frame.core does not
+      ;; expose `dispose!` directly — the `unsubscribe` call below
+      ;; releases the imperative subscribe's ref-count.)
+      (rf/unsubscribe [:n])
+      ;; `pin` is no longer used after this point; binding kept above
+      ;; only to materialise the pinning subscribe — its reactive
+      ;; lifetime ends with the line above.
+      pin)))
+
+(deftest unsubscribe-with-grace-opt-overrides-configured-grace
+  (testing "(unsubscribe frame-id query-v {:grace 0}) disposes synchronously even when configured grace > 0"
+    (subs/configure! {:grace-period-ms 60000})
+    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:init])
+
+    (rf/subscribe [:n])
+    (is (= 1 (entry-ref-count [:n])))
+
+    ;; The {:grace 0} opt forces synchronous disposal for THIS call only
+    ;; — the per-runtime configured grace-period is unchanged.
+    (rf/unsubscribe :rf/default [:n] {:grace 0})
+    (is (not (contains? (cache-keys) [:n]))
+        "slot disposed synchronously despite configured grace=60000ms")
+    (is (= 60000 (:grace-period-ms (subs/current-config)))
+        "per-runtime grace-period-ms is unchanged — only THIS call was overridden")))
+
 ;; ---- clear-subscription-cache! cancels pending timers ---------------------
 
 (deftest clear-subscription-cache-cancels-pending

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -503,13 +503,13 @@ The **one-shot, non-reactive read** of a subscription's current value. `subscrib
 (subscribe-value frame-id query-v)                     ;; → value (explicit-frame form)
 ```
 
-Semantically, `subscribe-value` is `subscribe` + deref + immediate `unsubscribe`:
+Semantically, `subscribe-value` is `subscribe` + deref + immediate **synchronous** `unsubscribe`:
 
 ```
 subscribe-value(frame-id, query-v):
   r ← subscribe(frame-id, query-v)                     ;; cache hit OR miss; ref-count += 1
   v ← deref r                                          ;; current cached value
-  unsubscribe(frame-id, query-v)                       ;; ref-count -= 1; 1→0 schedules grace-period disposal
+  unsubscribe(frame-id, query-v, {:grace 0})           ;; ref-count -= 1; on 1→0, dispose synchronously
   return v
 ```
 
@@ -517,7 +517,7 @@ subscribe-value(frame-id, query-v):
 
 - **One-shot.** Each call subscribes, derefs once, and unsubscribes. The caller does **not** receive a deref-able reaction; the returned value is a plain immutable value of whatever the sub computes.
 - **Non-reactive.** The caller is not registered for re-render or change notification. A subsequent `app-db` mutation that would have invalidated the slot has no observable effect on the caller of `subscribe-value` — they got their value, they're done.
-- **No retention.** Each call's ref-count increment is paired with the immediate decrement. If the call was the *only* reader, the slot enters its grace-period on return; repeated `subscribe-value` calls in close succession over the same query benefit from the grace-period reuse (each call hits the still-live cached value rather than recomputing).
+- **Synchronous teardown** (per rf2-zmufj). The internal `unsubscribe` runs with `{:grace 0}` so the one-shot read's whole lifetime — subscribe, deref, and (if this call drove the 1→0 transition) dispose — completes in the calling tick. The caller never observes a deferred-dispose timer firing after `subscribe-value` has already returned. A concurrent reactive subscriber (a view holding `subscribe` on the same `query-v`) keeps the slot alive via ref-count; `subscribe-value`'s decrement only triggers synchronous disposal when it owned the last reference.
 - **Frame-resolution.** The 1-arg form resolves the current frame via the resolution chain (dynamic-var tier, React-context tier when an adapter has registered the `:adapter/current-frame` late-bind hook per [§Frame-provider via React context](#frame-provider-via-react-context), `:rf/default` fallback). The 2-arg form is explicit and bypasses the chain.
 - **Missing frame is not an error.** `subscribe-value` against a destroyed or never-created frame returns `nil` (and emits the same `:rf.warning/unknown-frame` trace `subscribe` does); it does NOT throw.
 - **Missing sub is not an error.** Per [§What happens when a sub references an unknown sub](#what-happens-when-a-sub-references-an-unknown-sub), an unregistered `query-v` emits `:rf.error/no-such-sub` (recovery `:replaced-with-default`) and yields `nil`; `subscribe-value` propagates the `nil`.
@@ -532,7 +532,14 @@ The **explicit teardown** of a `subscribe` call. `unsubscribe` decrements the ca
 ```clojure
 (unsubscribe query-v)                                  ;; → nil (uses the resolved current frame)
 (unsubscribe frame-id query-v)                         ;; → nil (explicit-frame form)
+(unsubscribe frame-id query-v {:grace 0})              ;; → nil (explicit-frame + opts; per rf2-zmufj)
 ```
+
+**Opts map** (3-arity only). The optional opts map accepts:
+
+| Key      | Type    | Effect                                                                                                                                                                                                          |
+|----------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `:grace` | non-neg int | Override the configured `grace-period-ms` for **this call only**. `{:grace 0}` forces synchronous disposal on the 1→0 transition — used by `subscribe-value`'s internal teardown (per rf2-zmufj). Absent → use the per-runtime configured grace. |
 
 **Contract MUSTs.**
 
@@ -541,10 +548,10 @@ The **explicit teardown** of a `subscribe` call. `unsubscribe` decrements the ca
 - **Idempotent past zero.** Calling `unsubscribe` after ref-count has already reached 0 is a no-op — the count floors at 0, and an already-scheduled grace-period timer is **not** restarted. A second `unsubscribe` from the same path (cleanup hook + `finally` block both running) does not stack disposal timers or accidentally disposed-twice the slot.
 - **No-op past disposal.** Calling `unsubscribe` after the slot has already been disposed (the grace-period elapsed and the slot was removed from `F.sub-cache`) is a no-op — `unsubscribe` returns `nil` without trace emission. There is no "double-free" failure mode.
 - **Missing frame is not an error.** `unsubscribe` against a destroyed or never-created frame returns `nil` (and emits the same `:rf.warning/unknown-frame` trace `subscribe` does); it does NOT throw.
-- **Frame-resolution.** The 1-arg form resolves the current frame via the resolution chain (dynamic-var tier, React-context tier when an adapter has registered the `:adapter/current-frame` late-bind hook per [§Frame-provider via React context](#frame-provider-via-react-context), `:rf/default` fallback). The 2-arg form is explicit.
-- **Composes with grace-period reuse.** When `unsubscribe` triggers the 1 → 0 transition, the slot enters its grace-period rather than disposing immediately. A `subscribe` (or another `subscribe-value`) arriving within the window cancels the timer and reuses the cached value; this is exactly the mechanism that makes back-to-back `subscribe-value` calls cheap.
+- **Frame-resolution.** The 1-arg form resolves the current frame via the resolution chain (dynamic-var tier, React-context tier when an adapter has registered the `:adapter/current-frame` late-bind hook per [§Frame-provider via React context](#frame-provider-via-react-context), `:rf/default` fallback). The 2-arg and 3-arg forms are explicit.
+- **Composes with grace-period reuse.** When `unsubscribe` (the no-opts form) triggers the 1 → 0 transition, the slot enters its grace-period rather than disposing immediately. A `subscribe` arriving within the window cancels the timer and reuses the cached value. The `{:grace 0}` opts form opts out of this — the slot disposes synchronously on the 1→0 transition; it is the path `subscribe-value` uses internally (per rf2-zmufj).
 
-**Composability with `subscribe-value`.** `subscribe-value` internally invokes `subscribe` then `unsubscribe`; the user does NOT call `unsubscribe` for a `subscribe-value` call — the pairing is internal. Users only call `unsubscribe` for the `subscribe` calls they made themselves.
+**Composability with `subscribe-value`.** `subscribe-value` internally invokes `subscribe` then `unsubscribe` with `{:grace 0}` — the teardown is synchronous, not deferred (per rf2-zmufj). The user does NOT call `unsubscribe` for a `subscribe-value` call — the pairing is internal. Users only call `unsubscribe` for the `subscribe` calls they made themselves.
 
 **Why explicit teardown exists alongside the grace-period.** The grace-period handles the *automatic* case: a view unmounts, the reaction disposes, the underlying `unsubscribe` fires from the reaction's on-dispose hook, the slot drains. Explicit `unsubscribe` is the imperative-callers' equivalent: tools, REPL sessions, machine actions, and tests that took out a subscription without an enclosing reaction lifecycle to manage it. The two paths funnel into the same ref-count decrement and the same grace-period scheduling — there is one disposal algorithm, two arrival surfaces.
 


### PR DESCRIPTION
## Summary

Audit finding SU3 from rf2-spr6q: `subscribe-value`'s teardown scheduled a grace-period timer. For a fresh sub this triggered build + deref + grace-schedule + `set-timeout!` + `clear-timeout!` + dispose, where the timer fires AFTER the test/REPL caller has moved on — leaking dispose side-effects past the call's observable lifetime.

- Adds a 3-arity `unsubscribe` accepting an opts map: `(unsubscribe frame-id query-v {:grace N})`. `{:grace 0}` forces synchronous disposal on the 1→0 transition for THIS call only.
- `subscribe-value` uses `{:grace 0}` for its internal teardown so the one-shot read's whole lifetime (subscribe, deref, dispose) completes in the calling tick.
- Spec 006 updated to match — `subscribe-value`'s pseudo-code shows the `{:grace 0}` form; the `unsubscribe` contract lists the new opts row.
- Three regression deftests in `sub_cache_test.clj` pin: (1) synchronous teardown despite long configured grace, (2) concurrent subscriber unaffected (only 1→0 disposes), (3) `{:grace 0}` overrides per-runtime config without mutating it.

Pre-alpha: no back-compat concern. Composes on top of rf2-3mww7 (swap-fn race fix #829).

## Test plan

- [x] `clojure -M:test` from `implementation/core/` — 447 tests / 2380 assertions, 0 failures.
- [x] `npm run test:cljs` from `implementation/` — 1792 tests / 4975 assertions, 0 failures.