### PR TITLE
test(machines): loosen shape-pinning + wire conformance corpus into artefact CI (rf2-d0wem)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,9 +185,9 @@ jobs:
         working-directory: implementation/schemas
         run: clojure -M:test
 
-      - name: JVM tests (machines artefact, classpath probe)
+      - name: JVM tests (machines artefact)
         working-directory: implementation/machines
-        run: clojure -M:test || echo "no JVM-runnable tests in machines artefact (expected)"
+        run: clojure -M:test
 
       - name: JVM tests (routing artefact)
         working-directory: implementation/routing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -327,14 +327,18 @@ jobs:
             ${{ runner.os }}-clj-machines-
             ${{ runner.os }}-clj-
 
-      # The machines artefact's :test alias has no JVM-runnable tests of
-      # its own (the machine_cljs_test is CLJS-only). The job exists so
-      # the artefact's deps + classpath wiring stay green and any future
-      # JVM-runnable machine tests land here. Skip-on-empty is acceptable;
-      # the cognitect test-runner returns 0 when there are no test
-      # namespaces matching its pattern.
-      - name: Run JVM tests (machines artefact, classpath probe)
-        run: clojure -M:test || echo "no JVM-runnable tests in machines artefact (expected)"
+      # The machines artefact ships JVM-runnable test namespaces under
+      # implementation/machines/test/ — pure machine-transition tests
+      # (machine_transition_purity_test, after_test, invoke_all_test,
+      # spawn_registry_test, parallel_test, tags_test, initial_entry_test,
+      # …) plus the Mode B conformance corpus runner
+      # (machines_conformance_test) added per rf2-d0wem. The cognitect
+      # test-runner returns non-zero on any failure; the job MUST surface
+      # that so the gate is real. Earlier this step suffixed `|| echo …`
+      # to allow an empty test suite — now that JVM tests exist the
+      # fallback would mask failures, so it's removed.
+      - name: Run JVM tests (machines artefact)
+        run: clojure -M:test
 
   jvm-routing:
     name: JVM routing (clojure -M:test)

--- a/implementation/machines/test/re_frame/machine_transition_purity_test.clj
+++ b/implementation/machines/test/re_frame/machine_transition_purity_test.clj
@@ -58,22 +58,40 @@
           "two pure-call invocations from the same input produce the same next-snapshot")
       (is (= fx1 fx2)
           "two pure-call invocations from the same input produce the same effects vector")
-      ;; The spawn-id allocated by both calls must be byte-identical —
-      ;; pre-rf2-gr8q the second call would have produced `:http/post#2`.
-      (is (= [[:rf.machine/spawn {:machine-id    :http/post
-                                  :id-prefix     :http/post
-                                  :data          {:url "/api/login"}
-                                  :start         [:begin]
-                                  :rf/spawned-id :http/post#1
-                                  :rf/parent-id  :rf/transition-pure
-                                  :rf/invoke-id  [:authenticating]}]]
-             fx1)
-          "the spawn fx carries `:http/post#1` deterministically")
-      (is (= {:state            :authenticating
-              :data             {}
-              :rf/spawn-counter {:http/post 1}}
-             snap1)
-          "the in-snapshot counter advances; the snapshot now carries `:rf/spawn-counter`")))
+      ;; Per rf2-d0wem (informed by rf2-ra1he §TE1): assert only the
+      ;; load-bearing slots of the emitted spawn fx — the contract — and
+      ;; leave implementation-detail keys (`:id-prefix`, exact arg-map
+      ;; shape, the user-passed `:data` / `:start` echo) free to evolve
+      ;; without churning this test. The contract is:
+      ;;   - the fx-id is `:rf.machine/spawn`
+      ;;   - `:rf/spawned-id` is `:http/post#1` (allocator deterministic)
+      ;;   - `:rf/parent-id` is `:rf/transition-pure` (sentinel for the
+      ;;     pure-call surface)
+      ;;   - `:rf/invoke-id` is the state-path the spawn issued from
+      ;;     (`[:authenticating]`)
+      (is (= 1 (count fx1))
+          "exactly one effect emitted by the :submit transition")
+      (let [[[fx-id args]] fx1]
+        (is (= :rf.machine/spawn fx-id)
+            "the emitted fx is :rf.machine/spawn")
+        (is (= :http/post#1 (:rf/spawned-id args))
+            "the spawned-id is allocated deterministically as :http/post#1")
+        (is (= :rf/transition-pure (:rf/parent-id args))
+            "parent-id sentinel for the pure-call surface is :rf/transition-pure")
+        (is (= [:authenticating] (:rf/invoke-id args))
+            "invoke-id is the state-path the spawn issued from"))
+      ;; Snapshot: the load-bearing contract is that `:state` advanced and
+      ;; the in-snapshot counter bumped to 1 for the `:http/post` slot.
+      ;; The exact key-set of the snapshot map (e.g. whether the counter
+      ;; root is `:rf/spawn-counter` or evolves under refactor) is not
+      ;; load-bearing for this contract — assert the counter slot via
+      ;; `get-in`.
+      (is (= :authenticating (:state snap1))
+          "snapshot's :state advances to :authenticating")
+      (is (= {} (:data snap1))
+          "user-facing :data is unchanged (the :http/post :data is on the spawn fx, not in the parent snapshot)")
+      (is (= 1 (get-in snap1 [:rf/spawn-counter :http/post]))
+          "the in-snapshot counter advanced to 1 for the :http/post slot")))
 
   (testing "different input snapshots allocate independently — no shared module-level counter"
     ;; Two separate input snapshots, each starting at counter 0, both

--- a/implementation/machines/test/re_frame/machines_conformance_test.clj
+++ b/implementation/machines/test/re_frame/machines_conformance_test.clj
@@ -1,0 +1,328 @@
+(ns re-frame.machines-conformance-test
+  "Per rf2-d0wem (and rf2-ra1he §TE5). Drives every conformance-corpus
+  fixture whose `:fixture/calls` exercise `:machine-transition`
+  through `re-frame.machines/machine-transition` and `=`-checks the
+  result against the recorded `:expect-next-snapshot` /
+  `:expect-effects`.
+
+  The conformance corpus at `spec/conformance/fixtures/*.edn` is the
+  normative behaviour description for `machine-transition`. Pre-rf2-d0wem
+  only the core artefact's `re-frame.conformance-test` ran the corpus.
+  This namespace wires the machine-related Mode B fixtures into the
+  machines artefact's own CI gate, so the spec-defined invariants run
+  on every machines-touching PR (and any machines refactor that breaks a
+  fixture surfaces at the machines artefact's gate rather than only
+  downstream at core's).
+
+  Scope:
+    - Mode B fixtures only — `:fixture/calls` containing
+      `:call :machine-transition`. Mode A (dispatch-driven) fixtures
+      live downstream in the core artefact's runner, which has the
+      frame + dispatch loop.
+    - Pure-function assertions only — `:expect-next-snapshot` and
+      `:expect-effects` per `spec/conformance/README.md` §Mode B.
+    - No side-effects, no frame, no app-db. The machines artefact's
+      transition engine is JVM-runnable from arguments alone.
+
+  Capability tagging:
+    The conformance README §Capability tagging says conformance is
+    graded against the port's claimed capability list. For this Mode B
+    runner the practical capability set is everything the
+    `machine-transition` primitive covers — :fsm/flat, :fsm/hierarchical,
+    :fsm/parallel-regions, :fsm/eventless-always, :fsm/delayed-after,
+    :fsm/tags, :fsm/final-states, plus :actor/spawn-destroy and
+    :actor/invoke (both surface as spawn/destroy fx in the result
+    vector, no live actor needed). Anything else (e.g. :core/error,
+    :routing/*, :ssr/*) is core's surface and the fixture is skipped.
+
+  This is a per-artefact gate; the core artefact's runner exercises the
+  full corpus end-to-end through the dispatch loop. Both gates running
+  is intentional belt-and-braces."
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.java.io :as io]
+            [clojure.edn :as edn]
+            [clojure.string :as str]
+            [re-frame.conformance :as conformance]
+            [re-frame.machines :as machines]
+            [re-frame.machines.result :as result]))
+
+;; ---- fixture discovery ----------------------------------------------------
+
+(def fixtures-dir
+  "The corpus lives at `spec/conformance/fixtures/` at the repo root.
+  Tests run from `implementation/machines/`, so the relative path is
+  `../../spec/conformance/fixtures`."
+  (io/file "../../spec/conformance/fixtures"))
+
+(defn- load-fixture [file]
+  (try
+    ;; A handful of fixtures use `::name` (auto-resolved keyword) which
+    ;; pure `clojure.edn` cannot read without a *reader-resolver*. Match
+    ;; the core runner's translation so the fixture loads as bare data:
+    ;; rewrite `::name` → `:rf.machine.timer/name` (the only use in the
+    ;; corpus today, for synthetic timer events).
+    (let [raw   (slurp file)
+          fixed (str/replace raw #"::([a-zA-Z][a-zA-Z0-9_-]*)"
+                             ":rf.machine.timer/$1")]
+      (edn/read-string fixed))
+    (catch Throwable e
+      {:fixture/load-error (.getMessage e)
+       :fixture/file       (.getName file)})))
+
+(defn- has-machine-transition-call?
+  "True if any `:fixture/calls` entry uses `:call :machine-transition`."
+  [fixture]
+  (some (fn [c] (= :machine-transition (:call c)))
+        (or (:fixture/calls fixture) [])))
+
+(defn all-machine-transition-fixtures
+  "Every fixture file whose `:fixture/calls` contains at least one
+  `:machine-transition` call. Returns a vector of `[filename fixture]`
+  pairs in stable lex order."
+  []
+  (->> (file-seq fixtures-dir)
+       (filter #(.isFile %))
+       (filter #(str/ends-with? (.getName %) ".edn"))
+       (sort-by #(.getName %))
+       (map (fn [f] [(.getName f) (load-fixture f)]))
+       (filter (fn [[_ fx]]
+                 (and (not (:fixture/load-error fx))
+                      (has-machine-transition-call? fx))))
+       vec))
+
+;; ---- claimed capability set -----------------------------------------------
+;;
+;; Per `spec/conformance/README.md` §Capability tagging, the runner only
+;; executes fixtures whose `:fixture/capabilities` are a subset of the
+;; port's claimed list. For this Mode B runner the claim is the FSM /
+;; actor capability surface `machine-transition` covers — pure-function
+;; capabilities only. Anything that requires the dispatch loop, a frame,
+;; or app-db state (the schemas / SSR / routing / flow surfaces) is
+;; out-of-scope for this runner and the fixture is reported as skipped.
+
+(def claimed-capabilities
+  "Capabilities the pure machine-transition primitive covers.
+  Per rf2-d0wem this is the FSM/actor capability surface; any fixture
+  declaring capabilities outside this set is reported as skipped (it
+  belongs to core's downstream runner, not this Mode B gate)."
+  #{:fsm/flat
+    :fsm/hierarchical
+    :fsm/parallel-regions
+    :fsm/eventless-always
+    :fsm/delayed-after
+    :fsm/tags
+    :fsm/final-states
+    :actor/spawn-destroy
+    :actor/invoke
+    :actor/spawn-and-join
+    :actor/system-id
+    :actor/own-state
+    ;; :core/* tags appear on a few machine fixtures alongside the FSM
+    ;; capability they exercise (e.g. tags-round-trip-pr-str declares
+    ;; both :fsm/tags and :core/event-handler). For the Mode B subset
+    ;; the :core/* tags are no-ops — the call is pure — so we claim them
+    ;; here to avoid spurious skips.
+    :core/event-handler
+    :core/sub
+    :core/fx
+    :core/error
+    :core/trace
+    :core/frame})
+
+(def claimed-spec-versions
+  "Fixture spec versions this runner conforms against. Matches the core
+  runner's set (rf2-d0wem time)."
+  #{"1.0"})
+
+(defn- runnable-capability-set?
+  "True iff every capability the fixture declares is in `claimed-capabilities`."
+  [fixture]
+  (let [caps (or (:fixture/capabilities fixture) #{})]
+    (every? claimed-capabilities caps)))
+
+(defn- spec-version-claimed?
+  "True if the fixture's spec version (if any) is in `claimed-spec-versions`."
+  [fixture]
+  (let [v (:fixture/spec-version fixture)]
+    (or (nil? v) (contains? claimed-spec-versions v))))
+
+;; ---- machine-action body realisation --------------------------------------
+;;
+;; The conformance corpus describes machine action bodies in the
+;; handler-body DSL (see `spec/conformance/README.md` §Handler-body DSL).
+;; The DSL interpreter for VALUE forms lives in `re-frame.conformance`
+;; (already a dep of this artefact via core/src). The action-body
+;; reducer here is the same shape as `re-frame.conformance-test`'s
+;; `realise-machine-handlers` in core — duplicated here rather than
+;; reaching across artefacts because the core helper lives in
+;; core/test/, not core/src/, and the test-tree isn't on this
+;; artefact's classpath.
+
+(defn- realise-machine-action
+  "Build a `(fn [data event])` from a DSL body. The fn returns
+  `{:data <maybe-new-data> :fx <vec-of-fx>}` matching the action's
+  canonical 2-arity return shape per Spec 005 §Actions."
+  [steps]
+  (fn [data event]
+    (let [eval-value (requiring-resolve 're-frame.conformance/eval-value*)
+          final
+          (reduce
+            (fn [{:keys [data] :as ctx} step]
+              (case (first step)
+                :set    (let [[_ path v] step]
+                          (assoc ctx :data
+                                 (assoc-in data path (eval-value v ctx))))
+                :fx     (let [[_ a b] step]
+                          (update ctx :fx (fnil conj [])
+                                  [a (eval-value b ctx)]))
+                :throw  (throw (ex-info (str (second step))
+                                        {:from-fixture? true}))
+                ctx))
+            {:data data :event event :fx []}
+            steps)]
+      (cond-> {}
+        (not= data (:data final)) (assoc :data (:data final))
+        (seq (:fx final))         (assoc :fx (:fx final))))))
+
+(defn- realise-machine-guard
+  "Build a `(fn [data event])` from a DSL body — returns a boolean.
+  Per Spec 005 §Guards canonical 2-arity."
+  [steps]
+  (fn [data event]
+    (let [eval-value (requiring-resolve 're-frame.conformance/eval-value*)
+          step       (first steps)]
+      (when (and (vector? step) (= :fn (first step)))
+        (boolean (eval-value step {:data data :event event}))))))
+
+(defn- realise-machine-handlers
+  "Walk `:fixture/handlers :machine-action` + `:machine-guard` and produce
+  `{:actions {id fn} :guards {id fn} :on-spawn-actions {id fn}}`. The
+  `:on-spawn-actions` map mirrors `:machine-action` bodies realised as
+  on-spawn callbacks `(fn [data spawned-id] new-data)` — the corpus uses
+  the same DSL body for both surfaces (per `re-frame.conformance/realise-on-spawn-handler`)."
+  [fixture]
+  (let [handlers (or (:fixture/handlers fixture) {})]
+    {:actions
+     (into {}
+           (for [[id steps] (:machine-action handlers)]
+             [id (realise-machine-action steps)]))
+     :guards
+     (into {}
+           (for [[id steps] (:machine-guard handlers)]
+             [id (realise-machine-guard steps)]))
+     :on-spawn-actions
+     (into {}
+           (for [[id steps] (:machine-action handlers)]
+             [id (conformance/realise-on-spawn-handler steps)]))}))
+
+;; ---- single :machine-transition call --------------------------------------
+
+(defn- run-machine-transition-call
+  "Execute one `:machine-transition` call. Returns
+  `{:passed? bool :detail msg}` matching the core runner's contract."
+  [call realised]
+  (let [{:keys [actions guards on-spawn-actions]} realised
+        ;; Merge fixture-registered handlers into the definition's
+        ;; named-binding maps (same shape as core's run-call). Fixture
+        ;; bindings live alongside any short-names the def declares;
+        ;; the engine follows short-name → registered-id → fn through
+        ;; the combined map.
+        definition (-> (:definition call)
+                       (update :actions          #(merge actions %))
+                       (update :guards           #(merge guards %))
+                       (update :on-spawn-actions #(merge on-spawn-actions %)))
+        r          (try (machines/machine-transition definition
+                                                     (:snapshot call)
+                                                     (:event call))
+                        (catch Throwable e
+                          {::result/snap nil
+                           ::result/fx   [:error (.getMessage e)]}))
+        snap-out   (::result/snap r)
+        fx-out     (::result/fx r)
+        want-snap  (:expect-next-snapshot call)
+        want-fx    (or (:expect-effects call) [])
+        ok-snap?   (= want-snap snap-out)
+        ok-fx?     (= want-fx (vec fx-out))]
+    {:passed? (and ok-snap? ok-fx?)
+     :detail  (when-not (and ok-snap? ok-fx?)
+                (str "machine-transition\n"
+                     "    event:             " (:event call) "\n"
+                     "    expected snapshot: " want-snap "\n"
+                     "    actual   snapshot: " snap-out "\n"
+                     "    expected effects:  " want-fx "\n"
+                     "    actual   effects:  " fx-out))}))
+
+;; ---- fixture-level pass/fail ----------------------------------------------
+
+(defn- run-fixture
+  "Run every `:machine-transition` call in the fixture; return
+  `{:fixture-id ... :passed? bool :failures [detail ...]}`. Non-
+  `:machine-transition` calls in the same fixture are ignored — they
+  belong to other primitives that don't ship in this artefact."
+  [fixture]
+  (let [realised   (realise-machine-handlers fixture)
+        calls      (filter #(= :machine-transition (:call %))
+                           (or (:fixture/calls fixture) []))
+        results    (mapv #(run-machine-transition-call % realised) calls)
+        failures   (filterv (complement :passed?) results)]
+    {:fixture-id (:fixture/id fixture)
+     :calls-run  (count results)
+     :passed?    (empty? failures)
+     :failures   (mapv :detail failures)}))
+
+;; ---- the test entrypoint --------------------------------------------------
+
+(deftest run-machines-conformance-corpus
+  (let [results (atom [])]
+    (doseq [[fname fixture] (all-machine-transition-fixtures)]
+      (cond
+        (not (spec-version-claimed? fixture))
+        (swap! results conj {:fixture-id   (:fixture/id fixture)
+                             :fname        fname
+                             :skipped?     true
+                             :reason       "spec-version not in claimed set"
+                             :spec-version (:fixture/spec-version fixture)})
+
+        (not (runnable-capability-set? fixture))
+        (swap! results conj {:fixture-id   (:fixture/id fixture)
+                             :fname        fname
+                             :skipped?     true
+                             :reason       "capabilities outside Mode B claim"
+                             :capabilities (:fixture/capabilities fixture)})
+
+        :else
+        (swap! results conj (assoc (run-fixture fixture) :fname fname))))
+    (let [all     @results
+          run     (remove :skipped? all)
+          passed  (filter :passed? run)
+          failed  (remove :passed? run)
+          skipped (filter :skipped? all)]
+      (println)
+      (println "Machines conformance corpus (Mode B :machine-transition):")
+      (println "  total fixtures (filtered to :machine-transition calls):" (count all))
+      (println "  runnable:                                              " (count run))
+      (println "  passed:                                                " (count passed))
+      (println "  failed:                                                " (count failed))
+      (println "  skipped (out-of-scope for Mode B):                     " (count skipped))
+      (when (seq passed)
+        (println)
+        (println "Passing:")
+        (doseq [p passed]
+          (println "  " (:fixture-id p)
+                   "—" (:calls-run p) "call(s)")))
+      (when (seq skipped)
+        (println)
+        (println "Skipped:")
+        (doseq [s skipped]
+          (println "  " (:fixture-id s) "—" (:reason s)
+                   (or (:capabilities s) (:spec-version s)))))
+      (when (seq failed)
+        (println)
+        (println "Failures:")
+        (doseq [f failed]
+          (println "  " (:fixture-id f))
+          (doseq [d (:failures f)]
+            (println "    " d))))
+      (is (zero? (count failed))
+          (str "All Mode B :machine-transition fixtures must pass; "
+               (count failed) " failed.")))))


### PR DESCRIPTION
## Summary

Per `rf2-d0wem` (and `rf2-ra1he` §TE1 / §TE5): two test-coverage issues fixed together for the machines artefact.

### (1) Shape-pinning relaxation in `machine_transition_purity_test.clj`

The previous test asserted the full 8-key spawn-fx args map by literal `=`, plus the entire 3-key snapshot map by `=`. That pinned implementation-detail keys (`:id-prefix`, `:data`/`:start` echo, exact key-set; the `:rf/spawn-counter` root name) with no contract weight — refactors that touched spawn-args shape (e.g. unifying `:invoke` / `:invoke-all` desugar) churned the test for no good reason.

The new assertions read the load-bearing contract slots per-key:

  - `fx` contract: exactly one effect, `:rf.machine/spawn` fx-id, `:rf/spawned-id :http/post#1`, `:rf/parent-id :rf/transition-pure`, `:rf/invoke-id [:authenticating]`.
  - `snapshot` contract: `:state` advances to `:authenticating`, user-facing `:data` untouched, `[:rf/spawn-counter :http/post]` bumps to `1`.

I audited the rest of `implementation/machines/test/` for similar map-equality pinning on produced machine snapshots / spawn fx maps — `invoke_all_test`, `spawn_registry_test`, `after_test`, `tags_test`, `parallel_test`, `initial_entry_test` already use slot-level reads (`get-in` / `:state`-extraction). No other surface needed loosening.

### (2) Conformance corpus runner in machines artefact CI

`spec/conformance/fixtures/*.edn` is the normative behaviour description for `machine-transition`. Pre-`rf2-d0wem` only the core artefact's `re-frame.conformance-test` ran the corpus end-to-end through the dispatch loop. The machines artefact's own gate didn't drive the EDN fixtures — a machines-internal refactor breaking a fixture surfaced only at core's downstream gate.

New namespace `re-frame.machines-conformance-test` is a focused Mode B runner. It:

  - Walks `spec/conformance/fixtures/*.edn` and selects every fixture whose `:fixture/calls` contains `:call :machine-transition` (36 fixtures today — `machine-transition`, all `parallel-*`, all `hierarchical-*`, `after-*`, `always-*`, `tags-*`, `spawn-*`, `invoke-*`, `final-state-*`, `cross-actor-send`, `machine-actor-isolation`, `destroy-clears-snapshot`).
  - For each `:machine-transition` call: realises any `:fixture/handlers :machine-action` / `:machine-guard` bodies via `re-frame.conformance/eval-value*` (already a dep of this artefact via `core/src`), threads the realised handlers into the definition's named-binding maps, runs `re-frame.machines/machine-transition`, and `=`-compares the snapshot + effects against `:expect-next-snapshot` + `:expect-effects`.
  - Reports per-fixture pass/fail with detail on mismatch (event, expected/actual snapshot, expected/actual effects).
  - Skips fixtures whose declared capabilities lie outside the Mode B surface (none today — every `:machine-transition` fixture's caps are FSM/actor).

All 36 fixtures pass on the first try; the runner adds no expected-failure surface, only a gate.

### Workflow updates

`jvm-machines` step in `.github/workflows/test.yml` previously suffixed `|| echo "no JVM-runnable tests in machines artefact (expected)"` to tolerate an empty test suite. With JVM tests now landed in the machines artefact (purity, after, invoke-all, spawn-registry, parallel, tags, initial-entry, …) plus this new conformance runner, the fallback would mask real failures, so it's removed. Same change applied to the release workflow's machines step.

## Test plan

- [x] `cd implementation/machines && clojure -M:test` — runs the full machines artefact suite. 124 tests / 359 assertions, 0 failures, 0 errors.
- [x] Conformance runner reports 36/36 fixtures passing.
- [x] Loosened purity test still passes (15 assertions across 2 deftests).