### PR TITLE
perf(core): specialise layer-1 sub memo to avoid per-recompute vector allocation (rf2-sxacg)

### DIFF
--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -211,8 +211,10 @@
 (defn- validate-and-trace
   "Run the user's sub body fn once and project the result through the
   trace + performance + validate + error-recovery layer. Called by the
-  memo wrapper (`make-memoised-body`) on a true recompute — the memo
-  path skips this entire function when input is `=` to last-seen.
+  memo wrapper (`make-layer-1-memoised-body` for layer-1 subs,
+  `make-layer-n-memoised-body` for layer-2+) on a true recompute —
+  the memo path skips this entire function when input is `=` to
+  last-seen.
 
   Concerns folded in here, in order:
 
@@ -276,25 +278,63 @@
              :recovery          :replaced-with-default}))
         nil))))
 
-(defn- make-memoised-body
-  "Build the compute fn passed to `adapter/make-derived-value` — a
-  closure over a `volatile!` sentinel pair that enforces the Spec 006
-  §No-op via value equality (rf2-719e) discipline.
+;; ---- memoisation wrappers ------------------------------------------------
+;;
+;; Per Spec 006 §No-op via value equality (rf2-719e). Reagent's auto-run
+;; reaction unconditionally invokes the compute fn on any source-watch
+;; fire, then dedups *downstream notification* by `=`. That's one level
+;; too late for the spec — the body fn itself must NOT re-run when the
+;; resolved input value is `=` to the last-seen. The memo wrappers
+;; compare the inputs against the previous invocation and short-circuit
+;; to the memoised return value when equal. Reagent's dependency
+;; tracking still observes every `deref` because the wrapper *is* the
+;; compute fn — only the user's body (and the trace+validate+perf+
+;; recovery layer that brackets it) is suppressed.
+;;
+;; Per rf2-sxacg: the layer-1 path is specialised to a fixed-arity-1
+;; wrapper that compares the db value directly. This skips the
+;; varargs-seq allocation that `(fn [& in-vals])` would force on every
+;; recompute, and replaces the seq-vs-seq `=` walk with a direct value
+;; compare. Every layer-1 sub × every dispatch that touches it pays
+;; this — it's the hottest allocation in the artefact (per the
+;; rf2-spr6q audit, SU1/PE1).
 
-  Reagent's auto-run reaction unconditionally invokes the compute fn
-  on any source-watch fire, then dedups *downstream notification* by
-  `=`. That's one level too late for the spec — the body fn itself
-  must NOT re-run when the resolved input value is `=` to the
-  last-seen. This wrapper compares `in-vals` against the previous
-  invocation and short-circuits to the memoised return value when
-  equal. Reagent's dependency tracking still observes every `deref`
-  because the wrapper *is* the compute fn — only the user's body
-  (and the trace+validate+perf+recovery layer that brackets it) is
-  suppressed.
+(defn- make-layer-1-memoised-body
+  "Specialised memo wrapper for layer-1 subs (which read app-db
+  directly). Fixed-arity-1 — avoids the varargs-seq allocation that a
+  `(fn [& in-vals])` form would force on every reaction recompute, and
+  compares the db value to the last-seen scalar (no seq-vs-seq walk).
 
-  Returns a `(fn [& in-vals])`. When `body-fn` is nil (the unknown-sub
-  path — see `compute-and-cache!`) the wrapper yields nil on every
-  call without touching the memo cells."
+  Returns a `(fn [db])`. When `body-fn` is nil (the unknown-sub path
+  — see `compute-and-cache!`) the wrapper yields nil on every call
+  without touching the memo cells.
+
+  The `::unset` sentinel guarantees the first invocation always
+  recomputes (the sentinel is never `=` to any db value)."
+  [body-fn query-id query-v frame-id sub-meta]
+  (let [last-db     (volatile! ::unset)
+        last-result (volatile! nil)]
+    (fn [db]
+      (when body-fn
+        (if (= @last-db db)
+          @last-result
+          (let [computed (validate-and-trace
+                           body-fn (list db) query-id query-v
+                           frame-id [] sub-meta)]
+            (vreset! last-db db)
+            (vreset! last-result computed)
+            computed))))))
+
+(defn- make-layer-n-memoised-body
+  "Memo wrapper for layer-2+ subs (which chain off one or more upstream
+  subs). Varargs — the input arity matches the count of `:<-` entries
+  on the registration, and the wrapper compares the seq of input
+  values against the last-seen seq.
+
+  Returns a `(fn [& in-vals])`. When `body-fn` is nil the wrapper
+  yields nil on every call without touching the memo cells.
+
+  See `make-layer-1-memoised-body` for the layer-1 specialisation."
   [body-fn query-id query-v frame-id input-signals sub-meta]
   (let [last-in-vals (volatile! ::unset)
         last-result  (volatile! nil)]
@@ -317,8 +357,12 @@
   The compute fn handed to the substrate adapter is built in two
   layers, each named:
 
-    - `make-memoised-body` — Spec 006 §No-op via value equality
-      (rf2-719e). Wraps the user's body in a `=`-skipping memo.
+    - `make-layer-1-memoised-body` / `make-layer-n-memoised-body` —
+      Spec 006 §No-op via value equality (rf2-719e). Wraps the user's
+      body in a `=`-skipping memo. The layer-1 form is fixed-arity-1
+      and compares the db scalar directly (per rf2-sxacg — avoids
+      per-recompute varargs-seq allocation); layer-2+ keeps the
+      vec-of-inputs shape.
     - `validate-and-trace`  — Spec 009 :sub/run trace emit, Spec 009
       perf bracket (rf2-du3i), Spec 010 step 6 validation (rf2-wcam),
       and Spec 009 error contract (`:replaced-with-default` on throw).
@@ -338,12 +382,16 @@
                                            {:query-v query-v :frame frame-id}))
         body-fn       (:handler-fn sub-meta)
         input-signals (:input-signals sub-meta)
+        layer-1?      (empty? input-signals)
         ;; Resolve inputs: layer-1 → frame's app-db; layer-2+ → recursive subs.
-        inputs        (if (empty? input-signals)
+        inputs        (if layer-1?
                         [(frame/get-frame-db frame-id)]
                         (mapv (fn [input-q] (subscribe frame-id input-q)) input-signals))
-        memoised-body (make-memoised-body
-                        body-fn query-id query-v frame-id input-signals sub-meta)
+        memoised-body (if layer-1?
+                        (make-layer-1-memoised-body
+                          body-fn query-id query-v frame-id sub-meta)
+                        (make-layer-n-memoised-body
+                          body-fn query-id query-v frame-id input-signals sub-meta))
         reaction      (adapter/make-derived-value inputs memoised-body)
         cache         (:sub-cache (frame/frame frame-id))
         k             (cache-key query-v)]

--- a/implementation/core/test/re_frame/sub_memo_layer_1_test.clj
+++ b/implementation/core/test/re_frame/sub_memo_layer_1_test.clj
@@ -1,0 +1,166 @@
+(ns re-frame.sub-memo-layer-1-test
+  "Regression tests for the layer-1 sub memoisation contract — Spec 006
+  §No-op via value equality (rf2-719e), with the layer-1 specialisation
+  per rf2-sxacg.
+
+  The layer-1 path is specialised to a fixed-arity-1 wrapper that
+  compares the db value directly (no varargs-seq alloc, no seq-vs-seq
+  `=` walk). These tests pin the result-equivalence contract: the
+  specialised wrapper must short-circuit on `=` inputs exactly like the
+  generic wrapper, must recompute on `not=` inputs, and must hand the
+  body fn the same `(db, query-v)` shape it always received.
+
+  Microbench note: the alloc-per-recompute saving is one ArraySeq/Cons
+  per layer-1 recompute (the varargs collection vec/seq the
+  `(fn [& in-vals])` form would force). For an app with N layer-1
+  subs × M dispatches that touch each, the saving is N×M allocations
+  per drain cycle. Specialisation is correctness-preserving — the
+  contract is `=` on inputs; we just compare scalars rather than
+  one-element seqs."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.subs :as subs]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (require 're-frame.machines :reload)
+  (try (test-fn)
+       (finally
+         (subs/configure! {:grace-period-ms 50}))))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- result-equivalence — the contract pin --------------------------------
+
+(deftest layer-1-memo-skips-recompute-on-equal-db
+  (testing "two consecutive derefs against the same db value run the body once"
+    (subs/configure! {:grace-period-ms 0})
+    (let [runs (atom 0)]
+      (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+      (rf/reg-sub :n (fn [db _] (swap! runs inc) (:n db)))
+      (rf/dispatch-sync [:seed])
+      (let [r (rf/subscribe [:n])]
+        (is (= 7 @r))
+        (is (= 1 @runs) "first deref runs the body")
+        ;; Second deref against the unchanged db — memo MUST short-circuit.
+        (is (= 7 @r))
+        (is (= 1 @runs)
+            "second deref against same db does NOT re-invoke the body")
+        ;; Third deref — still no change.
+        (is (= 7 @r))
+        (is (= 1 @runs))))))
+
+(deftest layer-1-memo-recomputes-on-changed-db
+  (testing "deref after an app-db change runs the body again"
+    (subs/configure! {:grace-period-ms 0})
+    (let [runs (atom 0)]
+      (rf/reg-event-db :seed   (fn [_ _]      {:n 0}))
+      (rf/reg-event-db :update (fn [db [_ v]] (assoc db :n v)))
+      (rf/reg-sub :n (fn [db _] (swap! runs inc) (:n db)))
+      (rf/dispatch-sync [:seed])
+      (let [r (rf/subscribe [:n])]
+        (is (= 0 @r))
+        (is (= 1 @runs))
+        (rf/dispatch-sync [:update 1])
+        (is (= 1 @r))
+        (is (= 2 @runs) "body re-runs when the db value changed")
+        (rf/dispatch-sync [:update 2])
+        (is (= 2 @r))
+        (is (= 3 @runs))))))
+
+(deftest layer-1-memo-value-equal-but-not-identical-skips
+  (testing "two `=`-but-not-`identical?` db values still short-circuit
+            — the contract is value equality, not identity"
+    (subs/configure! {:grace-period-ms 0})
+    (let [runs (atom 0)]
+      ;; Two events that produce structurally-equal but non-identical maps.
+      ;; `(assoc db :touched true)` would change the value; instead replace
+      ;; with a fresh map that equals the old one.
+      (rf/reg-event-db :seed   (fn [_ _] {:n 42 :other :a}))
+      (rf/reg-event-db :reseed (fn [_ _] {:n 42 :other :a}))  ;; new map, =
+      (rf/reg-sub :n (fn [db _] (swap! runs inc) (:n db)))
+      (rf/dispatch-sync [:seed])
+      (let [r (rf/subscribe [:n])]
+        (is (= 42 @r))
+        (is (= 1 @runs))
+        (rf/dispatch-sync [:reseed])
+        ;; New db map but `=` to the prior one — memo skips the body.
+        (is (= 42 @r))
+        (is (= 1 @runs)
+            "value-equal db short-circuits the memo (no body re-run)")))))
+
+(deftest layer-1-body-receives-db-and-query-v
+  (testing "the body fn still receives the canonical (db, query-v) shape
+            under the specialised wrapper — no shape regression"
+    (subs/configure! {:grace-period-ms 0})
+    (let [captured (atom nil)]
+      (rf/reg-event-db :seed (fn [_ _] {:n 99}))
+      (rf/reg-sub :n (fn [db query-v]
+                       (reset! captured [db query-v])
+                       (:n db)))
+      (rf/dispatch-sync [:seed])
+      (let [r (rf/subscribe [:n :arg1 :arg2])]
+        (is (= 99 @r))
+        (let [[db query-v] @captured]
+          (is (= {:n 99} db) "body receives the full db value")
+          (is (= [:n :arg1 :arg2] query-v) "body receives the full query-v"))))))
+
+(deftest layer-1-memo-handles-nil-and-false
+  (testing "nil and false db values are not confused with the ::unset
+            sentinel — the body runs once for each, memo skips on
+            repeat"
+    (subs/configure! {:grace-period-ms 0})
+    (let [runs (atom 0)]
+      (rf/reg-event-db :seed-nil   (fn [_ _] nil))
+      (rf/reg-event-db :seed-false (fn [_ _] false))
+      (rf/reg-event-db :seed-map   (fn [_ _] {:n 1}))
+      (rf/reg-sub :v (fn [db _] (swap! runs inc) db))
+
+      (rf/dispatch-sync [:seed-nil])
+      (let [r (rf/subscribe [:v])]
+        (is (nil? @r))
+        (is (= 1 @runs) "first deref against nil db runs body once")
+        (is (nil? @r))
+        (is (= 1 @runs) "repeat deref against nil db skips memo")
+
+        (rf/dispatch-sync [:seed-false])
+        (is (= false @r))
+        (is (= 2 @runs) "transition nil → false re-runs body")
+        (is (= false @r))
+        (is (= 2 @runs) "repeat deref against false db skips memo")
+
+        (rf/dispatch-sync [:seed-map])
+        (is (= {:n 1} @r))
+        (is (= 3 @runs) "transition false → map re-runs body")))))
+
+;; ---- equivalence with layer-2+ -------------------------------------------
+;;
+;; Belt-and-braces: the specialisation is correctness-preserving relative
+;; to a layer-2 sub with one upstream that just reads app-db.
+
+(deftest layer-1-and-layer-2-produce-the-same-stream-of-values
+  (testing "a layer-1 sub and a layer-2 sub chained off it produce the
+            same stream of values across N db updates"
+    (subs/configure! {:grace-period-ms 0})
+    (rf/reg-event-db :seed   (fn [_ _]      {:n 0}))
+    (rf/reg-event-db :update (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-sub :n        (fn [db _] (:n db)))
+    (rf/reg-sub :n-via-l2 :<- [:n] (fn [n _] n))
+    (rf/dispatch-sync [:seed])
+    (let [r1 (rf/subscribe [:n])
+          r2 (rf/subscribe [:n-via-l2])]
+      (doseq [v (range 1 6)]
+        (rf/dispatch-sync [:update v])
+        (is (= v @r1 @r2)
+            (str "layer-1 and layer-2 agree at v=" v))))))


### PR DESCRIPTION
## Summary

Per audit rf2-spr6q §SU1/PE1 (the layer-1 sub memo path is the hottest allocation in the artefact).

- Split `make-memoised-body` into two specialised wrappers:
  - `make-layer-1-memoised-body` — fixed-arity-1, compares the db value scalar-to-scalar. No varargs-seq allocation, no seq-vs-seq `=` walk.
  - `make-layer-n-memoised-body` — varargs (the prior shape) for layer-2+ where arity tracks the `:<-` chain length.
- Branch in `compute-and-cache!` on `layer-1?` (i.e. `(empty? input-signals)`) to wire the right wrapper.

Every layer-1 sub × every dispatch that touches it pays the saving — one ArraySeq/Cons per recompute, plus a cheaper compare op.

## Behaviour

No spec change. Contract is preserved: memo skips on `=`-equivalent inputs, recomputes on `not=`. `nil` and `false` db values are correctly distinguished from the `::unset` sentinel. The body fn still receives `(db, query-v)` exactly as before.

## Test plan

- [x] New `sub-memo-layer-1-test` namespace: memo skip on equal db, recompute on changed db, value-equal-but-not-identical db skips, body shape preserved, nil/false handling, layer-1 vs layer-2 stream-equivalence.
- [x] `clojure -M:test` in `implementation/core/`: 456 tests, 0 failures.
- [x] `npm run test:cljs` from `implementation/`: 1792 tests, 0 failures.