### PR TITLE
spec(causa-mcp): subscription-info parity decision (rf2-3we2k)

### DIFF
--- a/tools/causa-mcp/README.md
+++ b/tools/causa-mcp/README.md
@@ -43,7 +43,7 @@ Full design contract:
 |---|---|
 | [`spec/000-Vision.md`](./spec/000-Vision.md) | What this jar is, why it's separate from Causa, how the eighteen-tool catalogue maps to Causa's panels, the relationship to Chrome DevTools MCP. |
 | [`spec/Principles.md`](./spec/Principles.md) | Load-bearing principles: origin tagging is the convention, EDN canonical, closed-set catalogue with deliberate escape valve, same single-persistent-nREPL footing as pair2-mcp. |
-| [`spec/DESIGN-RATIONALE.md`](./spec/DESIGN-RATIONALE.md) | The eight direction-setting decisions: question, options, pick, why, date locked. |
+| [`spec/DESIGN-RATIONALE.md`](./spec/DESIGN-RATIONALE.md) | The twelve direction-setting decisions: question, options, pick, why, date locked. |
 
 The full tool catalogue (signatures, return shapes, example
 flows) lives in

--- a/tools/causa-mcp/spec/000-Vision.md
+++ b/tools/causa-mcp/spec/000-Vision.md
@@ -47,7 +47,7 @@ without the UI dependencies.
 A Node-based stdio JSON-RPC server, written in ClojureScript,
 compiled via shadow-cljs to a single `.js` artefact. AI agents
 launch it as a subprocess; one persistent nREPL socket is held
-for the lifetime of the session; seventeen Causa-shaped tools are
+for the lifetime of the session; eighteen Causa-shaped tools are
 exposed as MCP tools.
 
 The architecture mirrors [`tools/pair2-mcp/`](../../pair2-mcp/)
@@ -79,7 +79,7 @@ mirrors pair2-mcp exactly (see
 | Side | Root ns | Lives in | Loaded by | Role |
 |---|---|---|---|---|
 | **MCP server** (Node process) | `day8.re-frame2-causa-mcp.*` | `tools/causa-mcp/src/` (when impl lands) | `npx @day8/re-frame2-causa-mcp` (the agent host spawns the subprocess) | Speaks MCP/JSON-RPC over stdio; speaks nREPL/bencode to shadow-cljs; renders eval forms that target the injected runtime. |
-| **Injected runtime** (browser eval target) | `day8.re-frame2-causa.runtime` | the [Causa](../../causa/) panel's preload classpath | shadow-cljs `:devtools :preloads` (rides Causa-the-panel's existing preload) | Lives in the consumer app's runtime; exposes the seventeen tool-shaped accessors the server's eval forms call; carries the `current-origin` dynamic var that stamps `:origin :causa-mcp` on mutations. |
+| **Injected runtime** (browser eval target) | `day8.re-frame2-causa.runtime` | the [Causa](../../causa/) panel's preload classpath | shadow-cljs `:devtools :preloads` (rides Causa-the-panel's existing preload) | Lives in the consumer app's runtime; exposes the eighteen tool-shaped accessors the server's eval forms call; carries the `current-origin` dynamic var that stamps `:origin :causa-mcp` on mutations. |
 
 **The two namespaces never share a JVM / Node process.** The MCP
 server runs on Node; the injected runtime runs in the browser.
@@ -89,7 +89,7 @@ EDN form addressed at `day8.re-frame2-causa.runtime/<accessor>`,
 shadow-cljs evaluates it inside the browser tab, the return
 value comes back over the same socket. There is no shared state,
 no shared classpath, no shared dep — only a contract on the
-shape of the seventeen accessors.
+shape of the eighteen accessors.
 
 **Why two roots, not one.** Conflating the two roles into a
 single namespace (the obvious wrong default) creates two
@@ -143,7 +143,7 @@ root.
 
 ## MCP catalogue summary
 
-Seventeen tools across five bands (per the [canonical counts in
+Eighteen tools across five bands (per the [canonical counts in
 `README.md`](./README.md#canonical-counts)); the full enumeration
 with signatures, return shapes, and example flows lives in
 [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
@@ -155,12 +155,13 @@ until implementation lands and this folder grows its own
 |---|---|
 | **Inspection** (read-only, 9 tools) | `get-trace-buffer`, `get-epoch-history`, `get-app-db`, `get-app-db-diff`, `get-machine-state`, `get-machine-list`, `get-issues`, `get-handlers`, `get-source-coord`. |
 | **Mutation** (user-confirmed equivalents, 3 tools) | `restore-epoch`, `reset-frame-db`, `dispatch`. |
-| **Streaming** (push-mode, 2 tools) | `subscribe`, `unsubscribe` — `notifications/progress` shaped, topic-mediated filters. |
+| **Streaming** (push-mode + diagnostic, 3 tools) | `subscribe`, `unsubscribe` — `notifications/progress` shaped, topic-mediated filters; `list-subscriptions` — request-response diagnostic enumerating open subs with queue stats (per [`DESIGN-RATIONALE.md` Lock #12](./DESIGN-RATIONALE.md)). |
 | **Escape hatch** (1 tool) | `eval-cljs` — arbitrary CLJS form; any side-effects inherit `:origin :causa-mcp`. |
 | **Meta** (session lifecycle, 2 tools) | `discover-app`, `tail-build`. |
 
-Each tool maps to a Causa panel; together they let an agent
-observe, dispatch, time-travel, stream, and inspect.
+Each tool maps to a Causa-side affordance (the seventeen panel
+mirrors plus the streaming-registry diagnostic); together they
+let an agent observe, dispatch, time-travel, stream, and inspect.
 
 ## Every MCP-driven mutation leaves a visible footprint
 
@@ -221,7 +222,7 @@ Causa-MCP is the **debugger-side** counterpart to pair2-mcp's
 | Axis | [`tools/pair2-mcp/`](../../pair2-mcp/) | `tools/causa-mcp/` |
 |---|---|---|
 | Audience | Editor-side AI workflows (build/edit/test). | Debugger-side AI workflows (inspect/time-travel). |
-| Surface | 9 tools (dispatch, eval, hot-swap, trace, streaming). | 17 tools (inspection + mutation + streaming + escape hatch + session lifecycle). |
+| Surface | 9 tools (dispatch, eval, hot-swap, trace, streaming). | 18 tools (inspection + mutation + streaming + escape hatch + session lifecycle). |
 | `:origin` tag | `:pair` | `:causa-mcp` |
 | MCP-server ns (Node-side) | `re-frame-pair2-mcp.*` (e.g. `re-frame-pair2-mcp.server`, `.tools`, `.nrepl`, `.cache`) | `day8.re-frame2-causa-mcp.*` (when impl lands) |
 | Injected-runtime ns (browser-side) | `re-frame-pair2.runtime` | `day8.re-frame2-causa.runtime` (rides Causa's preload) |

--- a/tools/causa-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/causa-mcp/spec/DESIGN-RATIONALE.md
@@ -68,7 +68,7 @@ Causa-MCP additionally benefits from sharing the toolchain with
 pair2-mcp: forking the project layout (`deps.edn`,
 `shadow-cljs.edn`, `pilot/` smoke harness, runtime ns
 conventions) means the implementation cost is dominated by
-writing the seventeen-tool dispatcher rather than rebuilding the
+writing the eighteen-tool dispatcher rather than rebuilding the
 transport plumbing.
 
 ### Date locked
@@ -267,10 +267,18 @@ proper home.
 
 ## Lock #5 — Tool catalogue cardinality and shape
 
-**Locked 2026-05-12 (Mike).** **Seventeen tools across five
-bands** (inspection / mutation / streaming / escape hatch / meta).
+**Locked 2026-05-12 (Mike).** **Eighteen tools across five bands**
+(inspection / mutation / streaming / escape hatch / meta).
 The catalogue is closed-set; additions require a Lock entry
 here. `eval-cljs` is the deliberate escape valve.
+
+**Amended 2026-05-14 (rf2-3we2k).** The original lock said
+"seventeen"; the rf2-m9yoi audit surfaced a `subscription-info`
+parity gap with pair2-mcp's impl (rf2-zjz9q). Lock #12 below
+adds the eighteenth tool (`list-subscriptions`) into the
+Streaming band and restates this lock's enumeration. The
+closed-set policy is unchanged; the cardinality grew by one
+load-bearing diagnostic.
 
 ### Question
 
@@ -294,16 +302,18 @@ How many MCP tools does Causa-MCP expose, and which ones?
 
 ### Pick
 
-**Seventeen tools across five bands.** The catalogue is
-closed-set on purpose — additions are deliberate (a Lock entry
-here, a discussion). `eval-cljs` absorbs the long tail.
+**Eighteen tools across five bands** (amended from seventeen by
+[Lock #12](#lock-12--subscription-info-parity-list-subscriptions-is-the-eighteenth-tool)
+on 2026-05-14). The catalogue is closed-set on purpose —
+additions are deliberate (a Lock entry here, a discussion).
+`eval-cljs` absorbs the long tail.
 
 ### Why
 
 - **One tool per Causa panel is the symmetry.** Causa's pitch
   is "the cascade you can see"; Causa-MCP's pitch is "the
-  cascade your agent can read." Seventeen tools map cleanly to
-  seventeen Causa surfaces (9 read + 3 mutate + 2 stream + 1
+  cascade your agent can read." Eighteen tools map cleanly to
+  eighteen Causa surfaces (9 read + 3 mutate + 3 stream + 1
   escape hatch + 2 meta). The agent reading
   `tools/list` sees a one-to-one map.
 - **Pair2-mcp's catalogue is editor-side; Causa's is
@@ -312,7 +322,7 @@ here, a discussion). `eval-cljs` absorbs the long tail.
   Causa-shaped questions (`get-app-db-diff`,
   `get-machine-list`, `get-issues`) — losing the `:origin` tag
   and the structured trace's filter vocabulary.
-- **Closed-set keeps the surface comprehensible.** Seventeen
+- **Closed-set keeps the surface comprehensible.** Eighteen
   named tools is at the upper edge of what an agent can hold in
   context comfortably. Beyond that, agent confusion (calling
   the wrong tool) starts to dominate; closed-set with an
@@ -331,6 +341,17 @@ during Causa's
 authoring on 2026-05-12; the lock entry below pins the
 cardinality and the closed-set policy.
 
+### Date amended
+
+2026-05-14 (Mike). The cardinality moved from seventeen to
+eighteen via [Lock #12](#lock-12--subscription-info-parity-list-subscriptions-is-the-eighteenth-tool)
+on the rf2-3we2k bead, which closed a parity gap with
+pair2-mcp's `subscription-info` impl by adding
+`list-subscriptions` (NAMING.md-conformant verb) to the
+Streaming band. The closed-set policy is unchanged; the
+amendment is an additive grow-by-one, locked through a
+deliberate Lock entry exactly as this lock's policy requires.
+
 ### Trail-of-thought citations
 
 - Causa
@@ -344,6 +365,9 @@ cardinality and the closed-set policy.
 - pair2-mcp's
   [Lock #4 — Tool catalogue cardinality](../../pair2-mcp/spec/DESIGN-RATIONALE.md#lock-4--tool-catalogue-cardinality)
   (the precedent at smaller cardinality).
+- [Lock #12](#lock-12--subscription-info-parity-list-subscriptions-is-the-eighteenth-tool)
+  (rf2-3we2k, 2026-05-14) — the amendment to eighteen and the
+  subscription-info-parity reasoning.
 
 ---
 
@@ -920,6 +944,199 @@ calculus as Locks #9 and #10.
 
 ---
 
+## Lock #12 — subscription-info parity: `list-subscriptions` is the eighteenth tool
+
+**Locked 2026-05-14 (Mike).** **`list-subscriptions` is the
+eighteenth Causa-MCP tool, living in the Streaming band
+alongside `subscribe` / `unsubscribe` (band cardinality grows
+from two to three).** The verb shape is `list-` per
+[`tools/mcp-conformance/NAMING.md`](../../mcp-conformance/NAMING.md);
+pair2-mcp's existing `subscription-info` impl (rf2-zjz9q) is
+the precedent **workflow**, not the precedent **name** — its
+bare-noun-with-`-info`-suffix shape is non-conformant verb-soup
+and Causa-MCP picks the catalogued verb first.
+
+### Question
+
+Causa-MCP's pre-impl catalogue was unified to seventeen tools
+(rf2-22my5, 2026-05-13). The rf2-m9yoi audit subsequently
+surfaced a parity gap: pair2-mcp's impl ships
+`subscription-info` (rf2-zjz9q) as a request-response diagnostic
+over its in-memory `subscriptions` atom — useful for
+"what streams are currently open?" /
+"is this specific sub still alive?" /
+"what's the queue depth on the apparently-quiet sub?" — but
+Causa-MCP's catalogue neither includes nor bundles it. Three
+directions:
+
+1. **Add the eighteenth tool.** Streaming band grows from two
+   to three (`subscribe` / `unsubscribe` / `list-subscriptions`);
+   the total moves from seventeen to eighteen.
+2. **Bundle into `subscribe` / `unsubscribe`.** Add a mode flag
+   (e.g. `{:mode :info}` on `subscribe`) that returns the
+   sub-info shape without opening a stream. The catalogue
+   stays at seventeen named tools; an extra prose paragraph
+   documents the bundled mode.
+3. **Push to `eval-cljs`.** Don't catalogue at all — agents
+   reach the diagnostic through the escape hatch when needed.
+
+### Pick
+
+**Direction 1 — eighteen tools, with `list-subscriptions` as
+the eighteenth.** The Streaming band cardinality moves from
+two (per [`000-Vision.md` §MCP catalogue summary](./000-Vision.md#mcp-catalogue-summary))
+to three; the catalogue total moves from seventeen to eighteen.
+The band split becomes **9 inspection + 3 mutation + 3 stream +
+1 escape hatch + 2 meta = 18**.
+
+### Why
+
+- **Cross-server symmetry is load-bearing.** Causa-MCP's
+  [`Principles.md` §"Privacy: default-drop `:sensitive?` events
+  at the MCP boundary"](./Principles.md#privacy-default-drop-sensitive-events-at-the-mcp-boundary)
+  declares: "an agent that learns the slot on one server gets
+  the same slot on the others." pair2-mcp's `subscription-info`
+  is in that "slot" today (rf2-zjz9q, sub-id / queue-depth /
+  queue-bytes / dropped-events / overflow-reason / created-at).
+  Direction 2's mode flag inverts the symmetry — an agent that
+  knows the slot on pair2-mcp doesn't get the same slot on
+  Causa-MCP. Direction 3 forces the agent through `eval-cljs`,
+  losing the per-tool token-budget contract (Lock #9 mechanism
+  #1 — every catalogue entry binds typical-token + cap-reached
+  behaviour; `eval-cljs` is the escape hatch, *not* the
+  diagnostic surface).
+- **The workflow recurs.** rf2-zjz9q's bead catalogues three
+  agent-surface workflows the diagnostic serves: (a) "the
+  streaming probe seems to have gone quiet" (confirm the sub
+  is still registered), (b) "this specific stream — is it
+  still alive?" (single-sub-id check), (c) "is the consumer
+  dead?" (read `:queue-depth` / `:overflow-reason` for
+  evidence). All three matter to Causa-MCP agents at least as
+  much as to pair2-mcp's — the Causa-MCP catalogue is
+  trace-bus-heavier, so streaming is more central to the
+  typical workflow, so a diagnostic over the streaming
+  registry earns its keep faster.
+- **Direction 2 (mode flag on `subscribe`) loses ergonomics.**
+  `subscribe` holds the `tools/call` open for the lifetime of
+  the subscription (per [`000-Vision.md`](./000-Vision.md) and
+  Lock #3); a mode flag for a request-response diagnostic
+  would mean `subscribe {:mode :info}` returns immediately
+  while `subscribe {:topic :trace ...}` streams indefinitely.
+  Same tool name, two unrelated lifecycles — confusing for the
+  agent, awkward for the dispatcher (the JSON-RPC reply shape
+  differs by mode), and the `:include-large?` / `:cursor` /
+  `:path` slot vocabulary on each mode would diverge. Two
+  named tools (`subscribe` for streaming, `list-subscriptions`
+  for diagnostic) keep the per-tool contract clean.
+- **Direction 3 (push to `eval-cljs`) loses the audit trail.**
+  An agent firing `eval-cljs '(deref subscriptions)'` skips the
+  catalogue's per-tool contract: no typical-token hint, no
+  cap-reached behaviour, no `:rf.mcp/overflow` marker, no
+  symmetric `:include-large?` / `:include-sensitive?` slot.
+  The whole point of catalogue surfaces over `eval-cljs` is
+  the contract — promoting a recurring workflow from
+  `eval-cljs` to its own catalogue entry is Lock #5's stated
+  policy ("if a particular `eval-cljs` pattern recurs, that's
+  the signal to promote it"). pair2-mcp's rf2-zjz9q already
+  surfaced that recurrence; Causa-MCP doesn't need to repeat
+  the experiment.
+- **`list-` is the conformant verb; pair2-mcp's name is the
+  precedent-by-workflow, not precedent-by-name.**
+  [`tools/mcp-conformance/NAMING.md`](../../mcp-conformance/NAMING.md)
+  catalogues `list-<things>` as "Collection enumeration — no
+  id, returns vector / set" with examples `list-stories`,
+  `list-substrates`, `list-tags`, etc. A diagnostic returning
+  a vector of subscription records (one per active sub) is a
+  textbook `list-<things>` shape — the filter axes (`:topic`,
+  `:sub-id`) narrow the enumeration but the return type is
+  still the collection. pair2-mcp's `subscription-info` is
+  non-conformant (no verb prefix from the table; `-info` is a
+  non-locked suffix), so spec-parity-by-name would propagate
+  verb drift. The Causa-MCP spec picks the conformant name
+  first; a follow-up bead may rename pair2-mcp's tool to match
+  (a published-artefact migration, separately tracked).
+- **Closed-set policy is unchanged.** Lock #5's closed-set
+  posture survives the cardinality bump: the eighteenth tool
+  is added through a deliberate Lock entry, the exact ceremony
+  Lock #5 requires. The escape valve (`eval-cljs`) absorbs the
+  long tail; growing the catalogue by one diagnostic doesn't
+  open the floodgates.
+- **The band stays coherent.** Streaming-band membership is
+  defined by "tools that operate on the streaming-subscription
+  registry" — `subscribe` opens, `unsubscribe` closes,
+  `list-subscriptions` enumerates. Three tools, one registry,
+  one mental model. No band re-organisation; no Inspection-vs-
+  Streaming ambiguity for the new tool (an enumeration of
+  open streaming subs is unambiguously a streaming-band
+  concern, not an inspection-band concern).
+
+### Tool sketch
+
+The full signature lands in `003-Tool-Catalogue.md` when impl
+ships; the spec-level contract is:
+
+- **Name**: `list-subscriptions`.
+- **Band**: Streaming (band cardinality 3 — sibling to
+  `subscribe` / `unsubscribe`).
+- **Args (all optional)**:
+  - `:topic` (keyword) — filter to a single topic
+    (`:trace` / `:epoch` / `:fx` / `:error`).
+  - `:sub-id` (string uuid) — return only the matching sub.
+  - `:build` (string, default `"app"`).
+  - The cross-server universals where applicable
+    (`:max-tokens`, `:include-large?`).
+- **Returns**: `{:ok? true :subs [{:id :topic :filter
+  :queue-depth :queue-bytes :dropped-events :dropped-bytes
+  :overflow-reason :created-at} ...]}`. Empty `:subs` vector
+  when no streams are open / filter matches nothing.
+- **Mechanisms**: mechanism 1 (token cap), mechanism 6
+  (size-elision walker on per-sub `:filter` slots if they
+  carry rich payloads). Mechanisms 2 / 3 / 4 / 5 are
+  inapplicable to the typical-load shape (a handful of subs,
+  each a small record).
+- **Origin**: read-only — no mutation, no `:origin :causa-mcp`
+  tag emission.
+
+### Date locked
+
+2026-05-14 (Mike). Locked in rf2-3we2k, surfaced by rf2-m9yoi
+(the audit that found the parity gap), upstream of rf2-22my5
+(the count unification that landed seventeen). The bead's
+verbatim framing was "17 + bundle, or 18 with subscription-info";
+this lock picks 18 with the conformant-verb name
+`list-subscriptions` rather than pair2-mcp's `subscription-info`.
+
+### Trail-of-thought citations
+
+- pair2-mcp's `subscription-info` impl (rf2-zjz9q):
+  [`tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscription_info.cljs`](../../pair2-mcp/src/re_frame_pair2_mcp/tools/subscription_info.cljs)
+  — the precedent workflow and return shape.
+- pair2-mcp's tool registration:
+  [`tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs`](../../pair2-mcp/src/re_frame_pair2_mcp/tools.cljs)
+  — confirms the impl ships in pair2-mcp's eleven-tool
+  registry even though its spec catalogue
+  (`003-Tool-Catalogue.md`) still enumerates nine. The
+  spec/impl drift on pair2-mcp's side is separately tracked
+  by rf2-m9yoi.
+- [`tools/mcp-conformance/NAMING.md` §The verb table](../../mcp-conformance/NAMING.md#the-verb-table)
+  — the `list-<things>` row catalogues the shape Causa-MCP
+  picks; the same file's "Causa-mcp (planned, ~17 tools)"
+  alignment table is updated by this revision to reflect the
+  eighteenth row.
+- Lock #5 (this doc) — the closed-set policy under which
+  this addition is admitted via a deliberate Lock entry.
+- Lock #9 mechanism #1 (this doc) — the per-tool
+  token-budget contract that `list-subscriptions` binds and
+  `eval-cljs` doesn't.
+- [`Principles.md` §"Privacy: default-drop `:sensitive?`
+  events at the MCP boundary"](./Principles.md#privacy-default-drop-sensitive-events-at-the-mcp-boundary)
+  — the cross-server symmetry posture quoted in the Why
+  section.
+- rf2-m9yoi (the audit that surfaced the gap).
+- rf2-3we2k (this lock).
+
+---
+
 ## Summary table
 
 | # | Question | Pick | Date |
@@ -928,15 +1145,16 @@ calculus as Locks #9 and #10.
 | 2 | Agent-host transport | **MCP over stdio** (inherited from pair2-mcp Lock #2) | 2026-05-12 |
 | 3 | Connection model | **Single persistent nREPL socket** (inherited from pair2-mcp Lock #3) | 2026-05-12 |
 | 4 | Origin tagging | **Default-on, opt-out per call — `:origin :causa-mcp`** | 2026-05-12 |
-| 5 | Tool catalogue | **Seventeen tools across five bands; closed-set + `eval-cljs` escape valve** | 2026-05-12 |
+| 5 | Tool catalogue | **Eighteen tools across five bands; closed-set + `eval-cljs` escape valve** (originally seventeen; amended 2026-05-14 by Lock #12) | 2026-05-12 (amended 2026-05-14) |
 | 6 | npm package coord | **`@day8/re-frame2-causa-mcp`** (shape `re-frame2-<tool>-mcp`; story-mcp matches; pair2-mcp's `re-frame-<tool>2-mcp` shape is a pre-rename divergence pinned 2026-05-14 by rf2-l7skx) | 2026-05-12 (amended 2026-05-14) |
 | 7 | Chrome DevTools MCP posture | **Co-install, stay in lane** | 2026-05-12 |
 | 8 | bencode pinning | **`bencode@~2.0.3`** (inherited from pair2-mcp Lock #5) | 2026-05-12 |
 | 9 | Wire-protocol budget posture | **Six mechanisms baked into spec before impl** (cap + slicing + pagination + lazy-summary + dedup + size-elision; mechanism #6 added by Lock #10) | 2026-05-13 |
 | 10 | Size-elision marker shape | **`:rf.size/large-elided` is the sixth mechanism; shape normative across MCP triplet; sensitive wins on composition** | 2026-05-13 |
 | 11 | Namespace split | **MCP-server-side at `day8.re-frame2-causa-mcp.*` (Node); injected-runtime-side at `day8.re-frame2-causa.runtime` (browser, rides Causa-the-panel's preload). Mirrors pair2-mcp's `re-frame-pair2-mcp.*` / `re-frame-pair2.runtime` split.** | 2026-05-14 |
+| 12 | subscription-info parity | **`list-subscriptions` is the eighteenth tool; lives in the Streaming band (3 tools: `subscribe` / `unsubscribe` / `list-subscriptions`); NAMING.md-conformant verb picked over pair2-mcp's `subscription-info` shape.** | 2026-05-14 |
 
-These eleven locks define Causa-MCP's pre-implementation surface.
+These twelve locks define Causa-MCP's pre-implementation surface.
 They were extracted from
 [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
 and [Causa's own DESIGN-RATIONALE](../../causa/spec/DESIGN-RATIONALE.md)

--- a/tools/causa-mcp/spec/Principles.md
+++ b/tools/causa-mcp/spec/Principles.md
@@ -22,7 +22,7 @@ surfaces. It must not add:
 - New effect substrates.
 - New component substrates.
 
-The seventeen tools route through the existing
+The eighteen tools route through the existing
 **injected-runtime namespace** (`day8.re-frame2-causa.runtime`,
 which rides Causa-the-panel's preload — see
 [`000-Vision.md` §Two namespaces, two sides](./000-Vision.md#two-namespaces-two-sides))
@@ -67,7 +67,7 @@ The tie-breaker this principle hands implementers and reviewers:
   `day8.re-frame2-causa.*` root, because the runtime rides the
   panel's `:preloads`), lives in the panel's preload classpath,
   is the eval target of the MCP server's rendered forms.
-  Examples: per-frame state accessors backing the seventeen
+  Examples: per-frame state accessors backing the eighteen
   tools, the `current-origin` dynamic var, the `session-id`
   marker, hot-reload re-inject probes.
 
@@ -90,12 +90,12 @@ gate to avoid. Two roots, two locations, two roles. Reviewers
 catch the leak at the `:require` line; the spec catches it at
 the architecture line.
 
-The principle has zero impact on the seventeen-tool catalogue
-(per [`DESIGN-RATIONALE.md` Lock #5](./DESIGN-RATIONALE.md)) and
-zero impact on the MCP wire shape (per Locks #1–#3). It's a
-naming + layout rule that costs nothing at the spec level and
-saves a "wait, which side am I writing?" pause at every impl
-PR.
+The principle has zero impact on the eighteen-tool catalogue
+(per [`DESIGN-RATIONALE.md` Lock #5](./DESIGN-RATIONALE.md), as
+amended by [Lock #12](./DESIGN-RATIONALE.md)) and zero impact on
+the MCP wire shape (per Locks #1–#3). It's a naming + layout
+rule that costs nothing at the spec level and saves a "wait,
+which side am I writing?" pause at every impl PR.
 
 Captured as Lock #11 in [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md).
 
@@ -202,7 +202,7 @@ Concretely:
   [`000-Vision.md` §Two namespaces, two sides](./000-Vision.md#two-namespaces-two-sides))
   is what lets the server reason about the runtime's absence
   without itself having a `runtime/session-id` to test.
-- The runtime contract is the shape of the seventeen tool
+- The runtime contract is the shape of the eighteen tool
   accessors `day8.re-frame2-causa.runtime` exposes, not a
   specific framework version.
 
@@ -232,7 +232,7 @@ Same posture as pair2-mcp.
 
 ## Read-mostly catalogue; mutate via the in-panel-equivalent gates
 
-The seventeen tools split 9 read / 3 mutate / 2 stream / 1 escape
+The eighteen tools split 9 read / 3 mutate / 3 stream / 1 escape
 hatch / 2 meta. The mutating tools (`restore-epoch`,
 `reset-frame-db`, `dispatch`) mirror the in-panel right-click
 affordances the human user already has — Causa-MCP doesn't
@@ -254,13 +254,19 @@ entry.
 
 ## Closed-set tool catalogue, deliberate escape valve
 
-The catalogue is **closed-set on purpose**: seventeen named
-surfaces map to seventeen Causa panels. Adding tools is a
-deliberate act (a `bd` bead, a discussion, a Lock entry in
-[`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md)). Drift is
-prevented by the discipline that every new tool maps to an
-existing Causa surface — the framework's instrumentation
-contract is the rate-limit.
+The catalogue is **closed-set on purpose**: eighteen named
+surfaces map to eighteen Causa-side affordances (seventeen panel
+mirrors plus `list-subscriptions`, the diagnostic that enumerates
+open streaming subscriptions — added by
+[`DESIGN-RATIONALE.md` Lock #12](./DESIGN-RATIONALE.md) on
+2026-05-14 to close the parity gap with pair2-mcp's
+`subscription-info` impl). Adding tools is a deliberate act (a
+`bd` bead, a discussion, a Lock entry in
+[`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md)) — Lock #12 is the
+example. Drift is prevented by the discipline that every new
+tool maps to an existing Causa surface or a load-bearing
+cross-server symmetry; the framework's instrumentation contract
+is the rate-limit.
 
 The `eval-cljs` escape valve absorbs the long tail (per the
 section above). Refusing to ship an escape hatch would force

--- a/tools/causa-mcp/spec/README.md
+++ b/tools/causa-mcp/spec/README.md
@@ -8,9 +8,9 @@ before this folder existed.
 
 ## Files
 
-- **[000-Vision.md](000-Vision.md)** — Causa-MCP is the agent face of Causa; seventeen MCP tools across five bands; same shadow-cljs / Node / persistent-nREPL architecture as pair2-mcp; **two-namespace split** between the Node-side MCP server (`day8.re-frame2-causa-mcp.*`) and the browser-side injected runtime (`day8.re-frame2-causa.runtime`); relationship to Causa, pair2-mcp, and Chrome DevTools MCP.
+- **[000-Vision.md](000-Vision.md)** — Causa-MCP is the agent face of Causa; eighteen MCP tools across five bands; same shadow-cljs / Node / persistent-nREPL architecture as pair2-mcp; **two-namespace split** between the Node-side MCP server (`day8.re-frame2-causa-mcp.*`) and the browser-side injected runtime (`day8.re-frame2-causa.runtime`); relationship to Causa, pair2-mcp, and Chrome DevTools MCP.
 - **[Principles.md](Principles.md)** — Load-bearing principles: **MCP-server-ns and injected-runtime-ns are distinct** (the tie-breaker for "which side does this code go?"), origin tagging is the convention (not a suggestion), EDN canonical, closed-set catalogue with `eval-cljs` as the deliberate escape valve, single persistent nREPL socket, stage-marker-independent, and the **six-mechanism wire-protocol budget posture** (token cap + path slicing + cursor pagination + lazy summary + structural dedup + size elision via `:rf.size/large-elided`) — baked into the spec before implementation begins so the impl is born compliant.
-- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — Eleven direction-setting decisions: question, options, pick, why, date locked. Inheritance from pair2-mcp's locks is cited rather than duplicated.
+- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — Twelve direction-setting decisions: question, options, pick, why, date locked. Inheritance from pair2-mcp's locks is cited rather than duplicated.
 
 ## Files that will land at implementation time
 
@@ -19,7 +19,7 @@ shape, the implementation phase will add:
 
 - `001-Wire-Protocol.md` — Newline-delimited JSON-RPC 2.0 over stdio per the MCP 2025-06-18 transport spec.
 - `002-nREPL-Transport.md` — Persistent TCP socket; bencode framing; port discovery; runtime injection.
-- `003-Tool-Catalogue.md` — The seventeen tools, with full signatures and return shapes. (Currently the catalogue lives in [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md) §Tool catalogue; the prose will migrate here.)
+- `003-Tool-Catalogue.md` — The eighteen tools, with full signatures and return shapes. (Currently the catalogue lives in [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md) §Tool catalogue; the prose will migrate here.)
 - `API.md` — Consolidated user-facing reference: install, configure, launch, call.
 - `findings/` — Exploratory working substrate; audit lineage, not normative.
 
@@ -31,10 +31,10 @@ that's how drift is prevented when a count next moves.
 
 | Count | Value | Source-of-truth |
 |---|---|---|
-| **Tools** | **17** | [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md) §Tool catalogue — the catalogue prose enumerates each. Migrates to `003-Tool-Catalogue.md` when impl lands. |
-| **Bands** | **5** | Inspection (9) + Mutation (3) + Streaming (2) + Escape hatch (1) + Meta (2) = 17. Enumerated in [`000-Vision.md`](000-Vision.md) §MCP catalogue summary. |
+| **Tools** | **18** | [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md) §Tool catalogue — the catalogue prose enumerates each. Migrates to `003-Tool-Catalogue.md` when impl lands. Eighteenth tool (`list-subscriptions`) added by [`DESIGN-RATIONALE.md` Lock #12](DESIGN-RATIONALE.md) on 2026-05-14 (rf2-3we2k). |
+| **Bands** | **5** | Inspection (9) + Mutation (3) + Streaming (3) + Escape hatch (1) + Meta (2) = 18. Enumerated in [`000-Vision.md`](000-Vision.md) §MCP catalogue summary. Streaming band grew from 2 to 3 via Lock #12. |
 | **Mechanisms** | **6** | [`Principles.md`](Principles.md) §"Tight token budget per response" — token cap, path slicing, cursor pagination, lazy summary, structural dedup, size elision. Mechanism #6 promoted by Lock #10. |
-| **Locks** | **11** | [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) §Summary table. |
+| **Locks** | **12** | [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) §Summary table. |
 | **Namespace roots** | **2** | MCP-server (Node-side): `day8.re-frame2-causa-mcp.*` — injected runtime (browser-side): `day8.re-frame2-causa.runtime`. Per [`000-Vision.md` §Two namespaces, two sides](000-Vision.md#two-namespaces-two-sides) and [`DESIGN-RATIONALE.md` Lock #11](DESIGN-RATIONALE.md). |
 
 ## How to use

--- a/tools/causa/spec/010-MCP-Server.md
+++ b/tools/causa/spec/010-MCP-Server.md
@@ -12,7 +12,7 @@ without opening Causa's UI.
 > [`DESIGN-RATIONALE.md`](../../causa-mcp/spec/DESIGN-RATIONALE.md).
 > The design locks accumulated in this file have been lifted there;
 > citations point to their canonical homes. This file remains the
-> **catalogue prose** (the seventeen tools enumerated with signatures
+> **catalogue prose** (the eighteen tools enumerated with signatures
 > and return shapes); when implementation lands and
 > `tools/causa-mcp/spec/003-Tool-Catalogue.md` is authored, the
 > catalogue prose migrates there and this file shrinks to a pointer.
@@ -117,17 +117,20 @@ the actual op runs. Mirrors the bash-shim chain's
 
 ## Tool catalogue
 
-Seventeen MCP tools across five bands: inspection (read-only),
+Eighteen MCP tools across five bands: inspection (read-only),
 mutation (user-confirmed equivalents in the UI), streaming
-(`notifications/progress`-shaped), escape hatch (`eval-cljs`), and
-meta (session-lifecycle). Each maps to a Causa surface; together
-they let an agent observe, dispatch, time-travel, stream, and
-inspect.
+(`notifications/progress`-shaped + the diagnostic),
+escape hatch (`eval-cljs`), and meta (session-lifecycle). Each
+maps to a Causa surface (or the cross-server symmetry posture);
+together they let an agent observe, dispatch, time-travel,
+stream, and inspect.
 
-The seventeen-tool cardinality and closed-set policy are locked at
+The eighteen-tool cardinality and closed-set policy are locked at
 [`tools/causa-mcp/spec/DESIGN-RATIONALE.md`](../../causa-mcp/spec/DESIGN-RATIONALE.md#lock-5--tool-catalogue-cardinality-and-shape)
-Lock #5; the closed-set discipline and `eval-cljs` escape valve
-posture live at
+Lock #5 (as amended by Lock #12 on 2026-05-14, which added
+`list-subscriptions` to close the parity gap with pair2-mcp's
+`subscription-info` impl); the closed-set discipline and
+`eval-cljs` escape valve posture live at
 [`tools/causa-mcp/spec/Principles.md`](../../causa-mcp/spec/Principles.md)
 §Closed-set tool catalogue, deliberate escape valve. The
 **catalogue prose itself** (the tables below) remains here until
@@ -184,17 +187,19 @@ final `tools/call` result is a summary
 `{:ok? true :sub-id <uuid> :delivered N :overflow N :ticks K :reason
 <terminated-reason>}`.
 
-| Tool | Topics | Returns |
+| Tool | Topics / Args | Returns |
 |---|---|---|
 | `subscribe` | `:trace`, `:epoch`, `:fx`, `:error` | Stream of events matching `filter`; topic-mediated base filter overlaid by user filter (user wins on conflict). Filter vocabulary mirrors [Spec 009 §Filter vocabulary](../../../spec/009-Instrumentation.md#filter-vocabulary) for `:trace` / `:fx` / `:error`; mirrors `watch-epochs` for `:epoch`. |
 | `unsubscribe` | (n/a) | Idempotent close. Returns `{:ok? true :sub-id <id> :existed? <bool>}`. Useful when the agent host can't propagate `tools/call` cancellation cleanly. |
+| `list-subscriptions` | `:topic` (keyword, optional), `:sub-id` (uuid string, optional) | Request-response (NOT streaming) diagnostic enumerating active subscriptions. Returns `{:ok? true :subs [{:id :topic :filter :queue-depth :queue-bytes :dropped-events :dropped-bytes :overflow-reason :created-at} ...]}`. Empty `:subs` when no streams are open / the filter matches nothing. Useful when a streaming probe seems to have gone quiet (confirm the sub is still registered; read `:queue-depth` / `:overflow-reason` for evidence of a dead consumer). Mirrors pair2-mcp's `subscription-info` workflow (rf2-zjz9q) under a NAMING.md-conformant verb (per [`tools/causa-mcp/spec/DESIGN-RATIONALE.md` Lock #12](../../causa-mcp/spec/DESIGN-RATIONALE.md)). |
 
-Termination paths: client cancel → `:reason :aborted`; out-of-band
-`unsubscribe` → `:reason :sub-gone`; cap reached → `:reason
-:max-ms-reached` or `:reason :max-events-reached`. Per-event matches
-inherit the same `:origin :causa-mcp` filter axis as the rest of the
-catalogue — an agent can subscribe to *just* its own mutation
-footprint via `subscribe {:topic :trace :filter {:origin :causa-mcp}}`.
+Termination paths (for `subscribe`): client cancel → `:reason
+:aborted`; out-of-band `unsubscribe` → `:reason :sub-gone`; cap
+reached → `:reason :max-ms-reached` or `:reason
+:max-events-reached`. Per-event matches inherit the same
+`:origin :causa-mcp` filter axis as the rest of the catalogue —
+an agent can subscribe to *just* its own mutation footprint via
+`subscribe {:topic :trace :filter {:origin :causa-mcp}}`.
 
 ### Escape hatch
 
@@ -207,7 +212,7 @@ Args: `form` (string, required — EDN-encoded CLJS form), `frame`
 triggers), `build` (string, optional).
 
 `eval-cljs` is the **deliberate escape valve**: the catalogue is
-closed-set on purpose (sixteen named surfaces alongside this one
+closed-set on purpose (seventeen named surfaces alongside this one
 escape hatch), but agents occasionally need to reach for something
 not yet catalogued. Rather than refuse them and force a workaround through
 Chrome MCP's `evaluate_script` (which loses the `:origin` tag), we
@@ -276,7 +281,7 @@ automatic re-inject → op proceeds.
 | Axis | `tools/pair2-mcp/` | `tools/causa-mcp/` |
 |---|---|---|
 | **Audience** | Editor-side AI workflows (pair-programming). | Debugger-side AI workflows (inspection, time-travel). |
-| **Surface** | 9 tools focused on dispatch / eval / hot-swap / trace, plus streaming. | 17 tools focused on inspection (graph, app-db, machine, issues) + restore / reset / dispatch + streaming + escape hatch + session lifecycle. |
+| **Surface** | 9 tools focused on dispatch / eval / hot-swap / trace, plus streaming. | 18 tools focused on inspection (graph, app-db, machine, issues) + restore / reset / dispatch + streaming (incl. `list-subscriptions` diagnostic) + escape hatch + session lifecycle. |
 | **`:origin` tag** | `:pair` | `:causa-mcp` |
 | **Runtime injection** | `re-frame-pair2.runtime` | `re-frame2-causa-mcp.runtime` |
 | **Implementation** | shadow-cljs `:node-script`, npm-published. | Same. |

--- a/tools/mcp-conformance/NAMING.md
+++ b/tools/mcp-conformance/NAMING.md
@@ -104,7 +104,7 @@ extension** to pair2-mcp / story-mcp.
 | `unregister-variant` | `unregister-` | Conformant. |
 | `record-as-variant` | `record-as-` | Conformant. |
 
-### Causa-mcp (planned, ~17 tools per `tools/causa/spec/010-MCP-Server.md`)
+### Causa-mcp (planned, 18 tools per `tools/causa-mcp/spec/`)
 
 | Tool | Verb shape | Notes |
 |---|---|---|
@@ -113,6 +113,7 @@ extension** to pair2-mcp / story-mcp.
 | `dispatch` | bare (universal) | Conformant. |
 | `tail-build` | `tail-` | Conformant. |
 | `subscribe` / `unsubscribe` | bare (universal pair) | Conformant. |
+| `list-subscriptions` | `list-` | Conformant — enumeration of active streaming subscriptions; the cross-server-symmetric counterpart to pair2-mcp's (non-conformant) `subscription-info`. Per [`tools/causa-mcp/spec/DESIGN-RATIONALE.md` Lock #12](../causa-mcp/spec/DESIGN-RATIONALE.md) (rf2-3we2k, 2026-05-14) — the eighteenth tool, picked under the conformant verb when pair2-mcp's drift was surfaced by audit rf2-m9yoi. |
 | `get-trace-buffer` | `get-` | Conformant — filter-addressed slice read. |
 | `get-epoch-history` | `get-` | Conformant — filter-addressed slice read. |
 | `get-app-db` | `get-` | Conformant. |


### PR DESCRIPTION
## Summary

- **Decision: 18 tools, `list-subscriptions` as the eighteenth.** New Lock #12 in `tools/causa-mcp/spec/DESIGN-RATIONALE.md` adds the eighteenth tool to the Streaming band (now 3: `subscribe` / `unsubscribe` / `list-subscriptions`); Lock #5 amended with date-amended subsection and forward link.
- **Why:** Cross-server symmetry is load-bearing — pair2-mcp ships `subscription-info` (rf2-zjz9q) as the streaming-registry diagnostic and Causa-MCP must offer the same slot. Direction 2 (mode flag on `subscribe`) inverts symmetry; Direction 3 (push to `eval-cljs`) loses the per-tool token-budget contract.
- **Verb pick:** `list-subscriptions` is the NAMING.md-conformant verb (`list-<things>`, "Collection enumeration"). pair2-mcp's `subscription-info` is verb-soup; Causa-MCP picks the conformant name first. A follow-up bead may rename pair2-mcp's tool (separately tracked; out of scope here).

## Scope

Updates seven spec files to ripple the count change consistently:

- `tools/causa-mcp/spec/DESIGN-RATIONALE.md` — new Lock #12 (full three-direction analysis, tool sketch, citations); Lock #5 amendment; summary table grows.
- `tools/causa-mcp/spec/000-Vision.md` — seventeen → eighteen (3 sites); MCP-catalogue-summary table; Compared-to-pair2-mcp row.
- `tools/causa-mcp/spec/Principles.md` — seventeen → eighteen (5 sites); band split 9/3/2/1/2 → 9/3/3/1/2; Closed-set section reframed.
- `tools/causa-mcp/spec/README.md` — canonical-counts table (Tools 17→18, Bands arithmetic, Locks 11→12); file descriptions follow.
- `tools/causa-mcp/README.md` — lock count 8→12.
- `tools/causa/spec/010-MCP-Server.md` — catalogue prose count; Streaming table grows `list-subscriptions` row with args/returns; Compared-to-pair2-mcp 17→18.
- `tools/mcp-conformance/NAMING.md` — Causa-mcp planned table 17→18 with `list-subscriptions` row + citation.

Pre-alpha; no back-compat; spec-as-artefact. The eighteenth tool is added through a deliberate Lock entry — the exact ceremony Lock #5's closed-set policy requires.

## Test plan

- [x] All count references in `tools/causa-mcp/spec/` ripple consistently (17→18 in normative prose; "seventeen" survives only in amendment-context and historical "originally seventeen" pin).
- [x] Lock #12 anchor at `#lock-12--subscription-info-parity-list-subscriptions-is-the-eighteenth-tool` resolves under GitHub-flavored slugify.
- [x] Lock #5 forward link to Lock #12 + Lock #12 back-link to Lock #5 form a cycle.
- [x] NAMING.md alignment table for causa-mcp reflects 18 rows (the new `list-subscriptions` slots between `subscribe`/`unsubscribe` and the `get-` block).
- [x] Streaming-band table in `tools/causa/spec/010-MCP-Server.md` carries the new tool's args / returns / cross-ref to Lock #12.
- [x] mkdocs build N/A — `/tools/` is not part of the published docs tree (mkdocs builds from `/spec/` + `/docs/`).

## Linked beads

- Resolves: rf2-3we2k
- Parent audit: rf2-m9yoi
- Amends: rf2-22my5 (the count unification this decision retargets to eighteen)
- pair2-mcp precedent: rf2-zjz9q (the `subscription-info` impl that motivated this parity)