### PR TITLE
refactor(pair2-mcp): subscribe-tool one-atom state + named controller (rf2-w5etd)

### DIFF
--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs
@@ -20,7 +20,18 @@
   so the AI client knows which budget to tune.
 
   Per-tick progress-payload composition + final-summary envelope live
-  in `re-frame-pair2-mcp.tools.subscribe-emit` (rf2-vrbwx)."
+  in `re-frame-pair2-mcp.tools.subscribe-emit` (rf2-vrbwx).
+
+  ## Internal shape (rf2-w5etd)
+
+  All rolling per-stream accounting lives in a single `state` atom
+  holding a map `{:tick :delivered :dropped-events :dropped-bytes
+  :overflow-reason :dropped-sensitive :elided-large}`. The poll loop
+  applies one `swap!` per drain (merging the drain's contributions
+  into the accumulators) rather than 5-7 separate ones. Termination,
+  poll-step, and per-tick emission are factored into `make-stream-
+  controller`, which closes over the atom and returns the `terminate`
+  + `poll` fns — the streaming-loop body reads top-down."
   (:require [applied-science.js-interop :as j]
             [re-frame.mcp-base.vocab :as base-vocab]
             [re-frame-pair2-mcp.nrepl :as nrepl]
@@ -41,6 +52,131 @@
   ;; same default if the slot is `nil`.
   5000000)
 
+(def ^:private initial-state
+  "The rolling per-stream accounting map (rf2-w5etd). Held inside one
+  atom for the lifetime of a `subscribe-tool` call; merged once per
+  drain. Indicator slots (`:dropped-sensitive`, `:elided-large`) feed
+  `wire/with-indicators` at terminal-summary emit time."
+  {:tick              0
+   :delivered         0
+   :dropped-events    0
+   :dropped-bytes     0
+   :overflow-reason   nil
+   :dropped-sensitive 0
+   :elided-large      0})
+
+(defn- merge-drain
+  "Pure state update — fold one drain's contributions into the rolling
+  accumulators. The drain reports `:ev-dropped`/`:by-dropped` for
+  queue-overflow eviction (rf2-ho4ve), `:dropped` for sensitive-strip,
+  and `:tick-elided` for the count of `:rf.size/large-elided` markers
+  on this batch. `:n` is the kept-event count after sensitive-strip.
+
+  A tick is counted whenever the drain produced kept events OR the
+  drain reported queue-overflow drops — both shapes should surface to
+  the client as `notifications/progress`."
+  [s {:keys [n ev-dropped by-dropped ov-reason dropped tick-elided]}]
+  (let [tick? (or (pos? n) (pos? ev-dropped))]
+    (cond-> s
+      tick?            (-> (update :tick      inc)
+                           (update :delivered + n))
+      (pos? ev-dropped)  (update :dropped-events    + ev-dropped)
+      (pos? by-dropped)  (update :dropped-bytes     + by-dropped)
+      ov-reason          (assoc  :overflow-reason   ov-reason)
+      (pos? dropped)     (update :dropped-sensitive + dropped)
+      (pos? tick-elided) (update :elided-large      + tick-elided))))
+
+(defn- parse-mcp-extra
+  "Pluck the three MCP-host slots the streaming loop needs out of the
+  JS `extra` object: the abort signal, the progress-notification
+  emitter, and the progress token correlating ticks to this
+  `tools/call`."
+  [extra]
+  {:signal      (some-> extra (j/get :signal))
+   :send-note   (some-> extra (j/get :sendNotification))
+   :progress-tk (some-> extra (j/get :_meta) (j/get :progressToken))})
+
+(defn- make-stream-controller
+  "Build the `terminate` + `poll` fns over a shared `state` atom and
+  the per-call context. Returns `{:state :terminate :poll}` so the
+  caller's body reads top-down — controller built, then `(poll)`
+  invoked.
+
+  Both fns close over the same atom. `terminate` issues the
+  runtime-side `unsubscribe!`, then `resolve`s the outer `tools/call`
+  Promise with the final-summary envelope. `poll` runs the drain →
+  state-merge → progress-emit → reschedule cycle until termination
+  triggers (client abort, max-events reached, or sub-gone)."
+  [{:keys [conn build-id sub-id topic resolve state
+           signal send-note progress-tk poll-ms max-events
+           incl? dedup?]}]
+  (let [terminate
+        (fn terminate [reason]
+          (-> (nrepl/cljs-eval-value
+                conn build-id
+                (ef/emit (ef/rt-call 'unsubscribe! sub-id)))
+              (.catch (fn [_] nil))
+              (.then
+                (fn [_]
+                  (resolve
+                    (emit/final-summary
+                      {:sub-id sub-id :topic topic
+                       :state  @state :reason reason}))))))
+        poll
+        (fn poll []
+          (cond
+            (and signal (.-aborted signal))
+            (terminate :aborted)
+
+            (and (pos? max-events)
+                 (>= (:delivered @state) max-events))
+            (terminate :max-events-reached)
+
+            :else
+            (-> (nrepl/cljs-eval-value
+                  conn build-id
+                  (ef/emit (ef/rt-call 'drain-subscription! sub-id)))
+                (.then
+                  (fn [drain-resp]
+                    (if (:gone? drain-resp)
+                      (terminate :sub-gone)
+                      (let [raw-evts       (:events drain-resp)
+                            ev-dropped     (:dropped-events  drain-resp 0)
+                            by-dropped     (:dropped-bytes   drain-resp 0)
+                            ov-reason      (:overflow-reason drain-resp)
+                            [evts dropped] (sensitive/strip-sensitive
+                                             (vec raw-evts) incl?)
+                            tick-elided    (base-vocab/count-elided-markers evts)
+                            n              (count evts)
+                            drain-delta    {:n           n
+                                            :ev-dropped  ev-dropped
+                                            :by-dropped  by-dropped
+                                            :ov-reason   ov-reason
+                                            :dropped     dropped
+                                            :tick-elided tick-elided}
+                            s'             (swap! state merge-drain drain-delta)]
+                        (when (or (pos? n) (pos? ev-dropped))
+                          (when (and send-note progress-tk)
+                            (emit/emit-progress-tick!
+                              {:send-note   send-note
+                               :progress-tk progress-tk
+                               :sub-id      sub-id}
+                              dedup?
+                              {:tick         (:tick s')
+                               :dedup-events (dedup/dedup-value evts dedup?)
+                               :ev-dropped   ev-dropped
+                               :by-dropped   by-dropped
+                               :ov-reason    ov-reason
+                               :dropped      dropped
+                               :tick-elided  tick-elided})))
+                        (js/setTimeout poll poll-ms)))))
+                (.catch
+                  (fn [_err]
+                    ;; nREPL hiccup — back off and try again rather
+                    ;; than collapsing the stream.
+                    (js/setTimeout poll (* 2 poll-ms)))))))]
+    {:state state :terminate terminate :poll poll}))
+
 (defn subscribe-tool [conn raw-args extra]
   (let [build-id           (wire/arg-build raw-args)
         topic              (some-> (wire/arg raw-args :topic) keyword)
@@ -54,9 +190,7 @@
         max-events         (or (wire/arg raw-args :max-events) 0)
         incl?              (sensitive/include-sensitive? raw-args)
         dedup?             (dedup/parse-dedup-arg (wire/arg raw-args :dedup))
-        progress-tk        (some-> extra (j/get :_meta) (j/get :progressToken))
-        send-note          (some-> extra (j/get :sendNotification))
-        signal             (some-> extra (j/get :signal))]
+        {:keys [signal send-note progress-tk]} (parse-mcp-extra extra)]
     (cond
       (or (nil? topic)
           (not (#{:trace :epoch :fx :error} topic)))
@@ -82,100 +216,15 @@
                   (let [sub-id (:sub-id subscribe-resp)]
                     (js/Promise.
                       (fn [resolve _reject]
-                        ;; Eight atoms wrap the rolling per-stream
-                        ;; accounting. T13 (audit) flags the shape as a
-                        ;; future map-atom refactor; deliberately
-                        ;; preserved here so the rf2-vrbwx split is a
-                        ;; pure rearrange.
-                        (let [tick               (atom 0)
-                              delivered          (atom 0)
-                              dropped-events*    (atom 0)
-                              dropped-bytes*     (atom 0)
-                              overflow-reason*   (atom nil)
-                              dropped-sensitive* (atom 0)
-                              elided-large*      (atom 0)
-                              terminate
-                              (fn [reason]
-                                (-> (nrepl/cljs-eval-value
-                                      conn build-id
-                                      (ef/emit (ef/rt-call 'unsubscribe! sub-id)))
-                                    (.catch (fn [_] nil))
-                                    (.then
-                                      (fn [_]
-                                        (resolve
-                                          (emit/final-summary
-                                            {:sub-id             sub-id
-                                             :topic              topic
-                                             :delivered          delivered
-                                             :tick               tick
-                                             :dropped-events*    dropped-events*
-                                             :dropped-bytes*     dropped-bytes*
-                                             :overflow-reason*   overflow-reason*
-                                             :dropped-sensitive* dropped-sensitive*
-                                             :elided-large*      elided-large*
-                                             :reason             reason}))))))
-                              poll
-                              (fn poll []
-                                (cond
-                                  (and signal (.-aborted signal))
-                                  (terminate :aborted)
-
-                                  (and (pos? max-events)
-                                       (>= @delivered max-events))
-                                  (terminate :max-events-reached)
-
-                                  :else
-                                  (-> (nrepl/cljs-eval-value
-                                        conn build-id
-                                        (ef/emit (ef/rt-call 'drain-subscription! sub-id)))
-                                      (.then
-                                        (fn [drain-resp]
-                                          (cond
-                                            (:gone? drain-resp)
-                                            (terminate :sub-gone)
-
-                                            :else
-                                            (let [raw-evts       (:events drain-resp)
-                                                  ev-dropped     (:dropped-events  drain-resp 0)
-                                                  by-dropped     (:dropped-bytes   drain-resp 0)
-                                                  ov-reason      (:overflow-reason drain-resp)
-                                                  [evts dropped] (sensitive/strip-sensitive
-                                                                   (vec raw-evts) incl?)
-                                                  tick-elided    (base-vocab/count-elided-markers evts)
-                                                  n              (count evts)]
-                                              (when (pos? ev-dropped)
-                                                (swap! dropped-events* + ev-dropped))
-                                              (when (pos? by-dropped)
-                                                (swap! dropped-bytes* + by-dropped))
-                                              (when ov-reason
-                                                (reset! overflow-reason* ov-reason))
-                                              (when (pos? dropped)
-                                                (swap! dropped-sensitive* + dropped))
-                                              (when (pos? tick-elided)
-                                                (swap! elided-large* + tick-elided))
-                                              (when (or (pos? n) (pos? ev-dropped))
-                                                (swap! tick inc)
-                                                (swap! delivered + n)
-                                                (when (and send-note progress-tk)
-                                                  (emit/emit-progress-tick!
-                                                    {:send-note   send-note
-                                                     :progress-tk progress-tk
-                                                     :sub-id      sub-id}
-                                                    dedup?
-                                                    {:tick         @tick
-                                                     :dedup-events (dedup/dedup-value evts dedup?)
-                                                     :ev-dropped   ev-dropped
-                                                     :by-dropped   by-dropped
-                                                     :ov-reason    ov-reason
-                                                     :dropped      dropped
-                                                     :tick-elided  tick-elided})))
-                                              (js/setTimeout poll poll-ms)))))
-                                      (.catch
-                                        (fn [_err]
-                                          ;; nREPL hiccup — back off
-                                          ;; and try again rather than
-                                          ;; collapsing the stream.
-                                          (js/setTimeout poll (* 2 poll-ms)))))))]
+                        (let [{:keys [terminate poll]}
+                              (make-stream-controller
+                                {:conn        conn        :build-id    build-id
+                                 :sub-id      sub-id      :topic       topic
+                                 :resolve     resolve     :state       (atom initial-state)
+                                 :signal      signal      :send-note   send-note
+                                 :progress-tk progress-tk :poll-ms     poll-ms
+                                 :max-events  max-events  :incl?       incl?
+                                 :dedup?      dedup?})]
                           (when (pos? max-ms)
                             (js/setTimeout #(terminate :max-ms-reached) max-ms))
                           (poll))))))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe_emit.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe_emit.cljs
@@ -1,7 +1,11 @@
 (ns re-frame-pair2-mcp.tools.subscribe-emit
   "Per-tick progress-payload composition + final-summary envelope for
   the `subscribe` tool. Split out of `tools/subscribe.cljs` (rf2-vrbwx)
-  so the streaming-loop body stays under the leaf-size ceiling."
+  so the streaming-loop body stays under the leaf-size ceiling.
+
+  Post-rf2-w5etd: `final-summary` takes a `:state` map (the deref'd
+  rolling accumulators) rather than seven separate atoms, matching the
+  one-atom shape held by the streaming-loop controller."
   (:require [re-frame-pair2-mcp.tools.wire :as wire]))
 
 (defn progress-payload
@@ -33,22 +37,28 @@
 
 (defn final-summary
   "The terminal `ok-text` result emitted when the subscription ends —
-  client cancel, unsubscribe, max-events / max-ms hit, or sub-gone."
-  [{:keys [sub-id topic delivered tick dropped-events* dropped-bytes*
-           overflow-reason* dropped-sensitive* elided-large* reason]}]
-  (wire/ok-text
-    (wire/with-indicators
-      (cond-> {:ok?            true
-               :sub-id         sub-id
-               :topic          topic
-               :delivered      @delivered
-               :dropped-events @dropped-events*
-               :dropped-bytes  @dropped-bytes*
-               :ticks          @tick
-               :reason         reason}
-        @overflow-reason*
-        (assoc :overflow-reason @overflow-reason*))
-      {:dropped @dropped-sensitive* :elided @elided-large*})))
+  client cancel, unsubscribe, max-events / max-ms hit, or sub-gone.
+
+  `state` is the deref'd rolling accumulators map (see
+  `subscribe/initial-state`); `wire/with-indicators` splices the
+  `:dropped-sensitive` / `:elided-large` counters onto the envelope
+  per the cross-MCP indicator-field convention."
+  [{:keys [sub-id topic state reason]}]
+  (let [{:keys [tick delivered dropped-events dropped-bytes
+                overflow-reason dropped-sensitive elided-large]} state]
+    (wire/ok-text
+      (wire/with-indicators
+        (cond-> {:ok?            true
+                 :sub-id         sub-id
+                 :topic          topic
+                 :delivered      delivered
+                 :dropped-events dropped-events
+                 :dropped-bytes  dropped-bytes
+                 :ticks          tick
+                 :reason         reason}
+          overflow-reason
+          (assoc :overflow-reason overflow-reason))
+        {:dropped dropped-sensitive :elided elided-large}))))
 
 (defn emit-progress-tick!
   "Build the per-tick progress payload and ship it via the MCP


### PR DESCRIPTION
## Summary

Cleans up the streaming-path engine per the refactor audit (rf2-7hie3 → rf2-w5etd):

- **One-atom state.** Seven flat-list accumulator atoms (`tick`, `delivered`, `dropped-events*`, `dropped-bytes*`, `overflow-reason*`, `dropped-sensitive*`, `elided-large*`) collapsed into a single `state` atom holding a map. The poll loop now folds each drain into the accumulators via one `swap! state merge-drain` rather than five separate `swap!`s; `final-summary` reads the deref'd map directly instead of seven atom-derefs.
- **Named controller.** The `terminate` / `poll` mutual recursion is now `make-stream-controller {:state :terminate :poll}`. The streaming-loop body reads top-down: build controller, then `(poll)`. The `letfn` chain that previously placed `(poll)` ~80 LoC after its `(fn poll [...])` definition is gone.
- **`parse-mcp-extra` helper.** The three `j/get` chains over the MCP `extra` object (signal / sendNotification / progressToken) lifted into a named helper — the only place the tool touches `extra`.
- **Indicator helper.** `wire/with-indicators` from rf2-dfk28 already centralises the indicator-field splicing; the new state shape feeds it through `final-summary` (no new helper needed).

## Test plan

- [x] `npm test` from `tools/pair2-mcp/` — 289 tests, 686 assertions, 0 failures.
- [x] Leaf-size: `subscribe.cljs` 231L / 11.5KB, `subscribe_emit.cljs` 88L / 4.3KB. Both well under the 250L / 16KB ceiling.

Closes rf2-w5etd.