### PR TITLE
refactor(core): lift resolve-current-frame into re-frame.frame (3 duplicates removed) (rf2-jj8xf)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -394,11 +394,11 @@
 
 ;; ---- frame-aware closures (runtime side) ---------------------------------
 ;;
-;; Per rf2-d4sf the public `current-frame` consults the `:adapter/
-;; current-frame` late-bind hook on CLJS so the React-context tier of
-;; the resolution chain is live at every user-facing surface that flows
-;; through `(dispatcher)` / `(subscriber)` / `bound-fn`. JVM falls
-;; through to `frame/current-frame` (dynamic-var → `:rf/default`).
+;; Per rf2-d4sf the public `current-frame` exposes the 3-tier resolution
+;; chain (dynamic var → React context → `:rf/default`) at every user-
+;; facing surface that flows through `(dispatcher)` / `(subscriber)` /
+;; `bound-fn`. The chain is single-sourced through
+;; `frame/resolve-current-frame` (rf2-jj8xf).
 
 (defn current-frame
   "Return the active frame at the call site. Resolution chain: dynamic
@@ -406,10 +406,7 @@
   bind hook) -> `:rf/default`. Per Spec 002 §Reading the frame from
   React context."
   []
-  #?(:cljs (if-let [f (late-bind/get-fn :adapter/current-frame)]
-             (f)
-             (frame/current-frame))
-     :clj  (frame/current-frame)))
+  (frame/resolve-current-frame))
 
 (defn dispatcher
   "Return a fn that dispatches under the current frame, captured at call

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -51,6 +51,30 @@
   []
   (or *current-frame* :rf/default))
 
+(defn resolve-current-frame
+  "Resolve the active frame at a no-explicit-frame call site. The
+  3-tier resolution chain — dynamic var → React context → `:rf/default` —
+  per Spec 002 §Reading the frame from React context and Spec 006
+  §Lookup algorithm.
+
+  Per rf2-d4sf, on CLJS this consults the `:adapter/current-frame`
+  late-bind hook so the React-context tier is LIVE — adapters publish
+  their React-context-aware impl through the hook at ns-load time.
+  When the hook is unbound (no adapter loaded yet, or JVM build) the
+  fallback is `current-frame` which honours the dynamic-var tier and
+  the `:rf/default` tier; the React-context tier silently no-ops in
+  that case.
+
+  This is the canonical 3-tier resolver — `subs/subscribe`,
+  `router/dispatch*`'s default-frame computation, and
+  `core/current-frame` all delegate here so the React-context tier is
+  single-sourced (rf2-jj8xf)."
+  []
+  #?(:cljs (if-let [f (late-bind/get-fn :adapter/current-frame)]
+             (f)
+             (current-frame))
+     :clj  (current-frame)))
+
 ;; ---- lookup ---------------------------------------------------------------
 
 (defn frame

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -98,16 +98,13 @@
         ;; referenced syntactically.
         call-site          (when interop/debug-enabled?
                              (:rf.trace/call-site opts))
-        ;; Per rf2-d4sf consult the `:adapter/current-frame` late-bind
-        ;; hook on CLJS so dispatch picks up the React-context tier of
-        ;; the resolution chain. Adapters publish the hook at ns-load
-        ;; time; when unbound (JVM build, or no adapter ns loaded yet)
-        ;; we fall back to `frame/current-frame` which honours the
-        ;; dynamic var and `:rf/default` only.
-        default-frame      #?(:cljs (if-let [f (late-bind/get-fn :adapter/current-frame)]
-                                      (f)
-                                      (frame/current-frame))
-                              :clj  (frame/current-frame))
+        ;; Per rf2-d4sf the 3-tier resolution chain (dynamic var →
+        ;; React context → `:rf/default`) is single-sourced through
+        ;; `frame/resolve-current-frame` (rf2-jj8xf) — the React-context
+        ;; tier consults the `:adapter/current-frame` late-bind hook on
+        ;; CLJS so dispatch picks it up; JVM and the no-adapter-loaded
+        ;; case fall through to the dynamic-var → `:rf/default` chain.
+        default-frame      (frame/resolve-current-frame)
         explicit-frame?    (some? (:frame opts))
         ;; Per rf2-o8m0: capture whether resolution fell through the entire
         ;; chain (dynamic var unbound, adapter context unresolvable, no

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -427,22 +427,6 @@
                            m))))))
     reaction))
 
-(defn- resolve-current-frame
-  "Resolve the active frame at a no-explicit-frame call site. On CLJS
-  consults the `:adapter/current-frame` late-bind hook (rf2-d4sf) so
-  the React-context tier of the 3-tier resolution chain (dynamic var
-  → React context → :rf/default) is LIVE — adapters publish their
-  React-context-aware impl through the hook at ns-load time. When the
-  hook is unbound (no adapter loaded yet, or JVM build) the fallback
-  is `re-frame.frame/current-frame` which honours the dynamic-var
-  tier and the `:rf/default` tier; the React-context tier silently
-  no-ops in that case."
-  []
-  #?(:cljs (if-let [f (late-bind/get-fn :adapter/current-frame)]
-             (f)
-             (frame/current-frame))
-     :clj  (frame/current-frame)))
-
 (defn subscribe
   "Per Spec 006 §Lookup algorithm. Returns the reaction for query-v;
   build-and-cache on miss; reuse on hit. The 1-arity form resolves
@@ -469,14 +453,14 @@
   `:rf.error/frame-destroyed`) carries the invocation coord."
   ([query-v]
    #?(:cljs
-      (let [frame-id (resolve-current-frame)]
+      (let [frame-id (frame/resolve-current-frame)]
         (when interop/debug-enabled?
           (when-let [warn! (late-bind/get-fn
                             :views/maybe-warn-plain-fn-under-non-default-frame!)]
             (warn! frame-id query-v)))
         (subscribe frame-id query-v))
       :clj
-      (subscribe (resolve-current-frame) query-v)))
+      (subscribe (frame/resolve-current-frame) query-v)))
   ([frame-id query-v]
    (let [frame-record (frame/frame frame-id)]
      (cond
@@ -531,7 +515,7 @@
   trace burst) past the call's observable lifetime.
 
   See also: `subscribe`, `unsubscribe`, `compute-sub`, `inject-cofx`."
-  ([query-v] (subscribe-value (resolve-current-frame) query-v))
+  ([query-v] (subscribe-value (frame/resolve-current-frame) query-v))
   ([frame-id query-v]
    (let [reaction (subscribe frame-id query-v)
          v        (when reaction @reaction)]
@@ -635,7 +619,7 @@
   subscribe imperatively should call unsubscribe when they're done
   to release the cache slot."
   ([query-v]
-   (unsubscribe (resolve-current-frame) query-v nil))
+   (unsubscribe (frame/resolve-current-frame) query-v nil))
   ([frame-id query-v]
    (unsubscribe frame-id query-v nil))
   ([frame-id query-v opts]


### PR DESCRIPTION
## Summary

Per audit rf2-spr6q SU4 — the '3-tier current-frame resolution' (dynamic var -> React context via `:adapter/current-frame` late-bind -> `:rf/default`) was duplicated in 3 places:

- `subs.cljc` — private `resolve-current-frame` defn (~14 LoC)
- `router.cljc` — inline in `build-envelope`'s `default-frame` binding (~10 LoC)
- `core.cljc` — public `current-frame` fn (~10 LoC)

Lifted into `re-frame.frame/resolve-current-frame` so the React-context tier consultation is single-sourced. Call-sites now delegate.

Public API surface unchanged: `core/current-frame` still returns the same value at the same call-sites; it is now a one-line wrapper.

## Test plan

- [x] `npm run test:cljs` — 1792 tests / 4975 assertions / 0 failures / 0 errors
- [x] `clojure -M:test` from `implementation/core/` — 456 tests / 2436 assertions / 0 failures / 0 errors

Closes rf2-jj8xf.