### PR TITLE
spec(causa-mcp): subscription-info parity decision (rf2-3we2k)

### DIFF
--- a/tools/causa-mcp/README.md
+++ b/tools/causa-mcp/README.md
@@ -43,7 +43,7 @@ Full design contract:
 |---|---|
 | [`spec/000-Vision.md`](./spec/000-Vision.md) | What this jar is, why it's separate from Causa, how the eighteen-tool catalogue maps to Causa's panels, the relationship to Chrome DevTools MCP. |
 | [`spec/Principles.md`](./spec/Principles.md) | Load-bearing principles: origin tagging is the convention, EDN canonical, closed-set catalogue with deliberate escape valve, same single-persistent-nREPL footing as pair2-mcp. |
-| [`spec/DESIGN-RATIONALE.md`](./spec/DESIGN-RATIONALE.md) | The eight direction-setting decisions: question, options, pick, why, date locked. |
+| [`spec/DESIGN-RATIONALE.md`](./spec/DESIGN-RATIONALE.md) | The twelve direction-setting decisions: question, options, pick, why, date locked. |
 
 The full tool catalogue (signatures, return shapes, example
 flows) lives in

--- a/tools/causa-mcp/spec/000-Vision.md
+++ b/tools/causa-mcp/spec/000-Vision.md
@@ -47,7 +47,7 @@ without the UI dependencies.
 A Node-based stdio JSON-RPC server, written in ClojureScript,
 compiled via shadow-cljs to a single `.js` artefact. AI agents
 launch it as a subprocess; one persistent nREPL socket is held
-for the lifetime of the session; seventeen Causa-shaped tools are
+for the lifetime of the session; eighteen Causa-shaped tools are
 exposed as MCP tools.
 
 The architecture mirrors [`tools/pair2-mcp/`](../../pair2-mcp/)
@@ -79,7 +79,7 @@ mirrors pair2-mcp exactly (see
 | Side | Root ns | Lives in | Loaded by | Role |
 |---|---|---|---|---|
 | **MCP server** (Node process) | `day8.re-frame2-causa-mcp.*` | `tools/causa-mcp/src/` (when impl lands) | `npx @day8/re-frame2-causa-mcp` (the agent host spawns the subprocess) | Speaks MCP/JSON-RPC over stdio; speaks nREPL/bencode to shadow-cljs; renders eval forms that target the injected runtime. |
-| **Injected runtime** (browser eval target) | `day8.re-frame2-causa.runtime` | the [Causa](../../causa/) panel's preload classpath | shadow-cljs `:devtools :preloads` (rides Causa-the-panel's existing preload) | Lives in the consumer app's runtime; exposes the seventeen tool-shaped accessors the server's eval forms call; carries the `current-origin` dynamic var that stamps `:origin :causa-mcp` on mutations. |
+| **Injected runtime** (browser eval target) | `day8.re-frame2-causa.runtime` | the [Causa](../../causa/) panel's preload classpath | shadow-cljs `:devtools :preloads` (rides Causa-the-panel's existing preload) | Lives in the consumer app's runtime; exposes the eighteen tool-shaped accessors the server's eval forms call; carries the `current-origin` dynamic var that stamps `:origin :causa-mcp` on mutations. |
 
 **The two namespaces never share a JVM / Node process.** The MCP
 server runs on Node; the injected runtime runs in the browser.
@@ -89,7 +89,7 @@ EDN form addressed at `day8.re-frame2-causa.runtime/<accessor>`,
 shadow-cljs evaluates it inside the browser tab, the return
 value comes back over the same socket. There is no shared state,
 no shared classpath, no shared dep — only a contract on the
-shape of the seventeen accessors.
+shape of the eighteen accessors.
 
 **Why two roots, not one.** Conflating the two roles into a
 single namespace (the obvious wrong default) creates two
@@ -143,7 +143,7 @@ root.
 
 ## MCP catalogue summary
 
-Seventeen tools across five bands (per the [canonical counts in
+Eighteen tools across five bands (per the [canonical counts in
 `README.md`](./README.md#canonical-counts)); the full enumeration
 with signatures, return shapes, and example flows lives in
 [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
@@ -155,12 +155,21 @@ until implementation lands and this folder grows its own
 |---|---|
 | **Inspection** (read-only, 9 tools) | `get-trace-buffer`, `get-epoch-history`, `get-app-db`, `get-app-db-diff`, `get-machine-state`, `get-machine-list`, `get-issues`, `get-handlers`, `get-source-coord`. |
 | **Mutation** (user-confirmed equivalents, 3 tools) | `restore-epoch`, `reset-frame-db`, `dispatch`. |
-| **Streaming** (push-mode, 2 tools) | `subscribe`, `unsubscribe` — `notifications/progress` shaped, topic-mediated filters. |
+| **Streaming** (push-mode, 3 tools) | `subscribe`, `unsubscribe` — `notifications/progress` shaped, topic-mediated filters. `subscription-info` — pure-read diagnostic over the in-memory subscriptions atom (no queue drain); answers "what streams are open?" and "is this sub still alive?" without an `eval-cljs` round-trip. |
 | **Escape hatch** (1 tool) | `eval-cljs` — arbitrary CLJS form; any side-effects inherit `:origin :causa-mcp`. |
 | **Meta** (session lifecycle, 2 tools) | `discover-app`, `tail-build`. |
 
 Each tool maps to a Causa panel; together they let an agent
 observe, dispatch, time-travel, stream, and inspect.
+
+The Streaming band's third entry — `subscription-info` — mirrors
+pair2-mcp's surface (per
+[`tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscription_info.cljs`](../../pair2-mcp/src/re_frame_pair2_mcp/tools/subscription_info.cljs))
+so the cross-server-symmetry posture (Principles §Privacy
+default-drop, §Tight token budget) holds for diagnostic surfaces
+too: an agent that learns to ask "is my stream still open?" on
+one MCP server gets the same slot on the others. Locked here by
+[`DESIGN-RATIONALE.md` Lock #12](./DESIGN-RATIONALE.md).
 
 ## Every MCP-driven mutation leaves a visible footprint
 
@@ -221,7 +230,7 @@ Causa-MCP is the **debugger-side** counterpart to pair2-mcp's
 | Axis | [`tools/pair2-mcp/`](../../pair2-mcp/) | `tools/causa-mcp/` |
 |---|---|---|
 | Audience | Editor-side AI workflows (build/edit/test). | Debugger-side AI workflows (inspect/time-travel). |
-| Surface | 9 tools (dispatch, eval, hot-swap, trace, streaming). | 17 tools (inspection + mutation + streaming + escape hatch + session lifecycle). |
+| Surface | 11 tools (dispatch, eval, hot-swap, trace, streaming — inc. `subscription-info`). | 18 tools (inspection + mutation + streaming inc. `subscription-info` + escape hatch + session lifecycle). |
 | `:origin` tag | `:pair` | `:causa-mcp` |
 | MCP-server ns (Node-side) | `re-frame-pair2-mcp.*` (e.g. `re-frame-pair2-mcp.server`, `.tools`, `.nrepl`, `.cache`) | `day8.re-frame2-causa-mcp.*` (when impl lands) |
 | Injected-runtime ns (browser-side) | `re-frame-pair2.runtime` | `day8.re-frame2-causa.runtime` (rides Causa's preload) |

--- a/tools/causa-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/causa-mcp/spec/DESIGN-RATIONALE.md
@@ -68,7 +68,7 @@ Causa-MCP additionally benefits from sharing the toolchain with
 pair2-mcp: forking the project layout (`deps.edn`,
 `shadow-cljs.edn`, `pilot/` smoke harness, runtime ns
 conventions) means the implementation cost is dominated by
-writing the seventeen-tool dispatcher rather than rebuilding the
+writing the eighteen-tool dispatcher rather than rebuilding the
 transport plumbing.
 
 ### Date locked
@@ -272,6 +272,13 @@ bands** (inspection / mutation / streaming / escape hatch / meta).
 The catalogue is closed-set; additions require a Lock entry
 here. `eval-cljs` is the deliberate escape valve.
 
+**Amended 2026-05-14 (rf2-3we2k).** [Lock #12](#lock-12--subscription-info-parity-with-pair2-mcp)
+adds `subscription-info` as the eighteenth tool, placed in band
+**Streaming** (so the band moves 2 → 3) for cross-server parity
+with pair2-mcp. The closed-set posture and the per-tool Lock-entry
+discipline this lock established are unchanged; Lock #12 is the
+audit trail for the addition.
+
 ### Question
 
 How many MCP tools does Causa-MCP expose, and which ones?
@@ -294,9 +301,11 @@ How many MCP tools does Causa-MCP expose, and which ones?
 
 ### Pick
 
-**Seventeen tools across five bands.** The catalogue is
-closed-set on purpose — additions are deliberate (a Lock entry
-here, a discussion). `eval-cljs` absorbs the long tail.
+**Seventeen tools across five bands** at original-lock time;
+**eighteen tools across five bands** after the 2026-05-14
+amendment (Lock #12). The catalogue is closed-set on purpose —
+additions are deliberate (a Lock entry here, a discussion).
+`eval-cljs` absorbs the long tail.
 
 ### Why
 
@@ -304,8 +313,13 @@ here, a discussion). `eval-cljs` absorbs the long tail.
   is "the cascade you can see"; Causa-MCP's pitch is "the
   cascade your agent can read." Seventeen tools map cleanly to
   seventeen Causa surfaces (9 read + 3 mutate + 2 stream + 1
-  escape hatch + 2 meta). The agent reading
-  `tools/list` sees a one-to-one map.
+  escape hatch + 2 meta). The eighteenth (`subscription-info`)
+  doesn't map to a panel — it maps to a *cross-server slot*
+  shipped by pair2-mcp's streaming surface, which Lock #12
+  promotes to first-class cross-server-symmetric parity.
+  Together: seventeen panel mappings + one cross-server parity
+  entry = eighteen tools. The agent reading
+  `tools/list` sees a near-one-to-one map plus the parity slot.
 - **Pair2-mcp's catalogue is editor-side; Causa's is
   debugger-side.** Mirroring pair2 wholesale would leave
   agents writing Chrome MCP `evaluate_script` blocks for
@@ -329,7 +343,9 @@ here, a discussion). `eval-cljs` absorbs the long tail.
 during Causa's
 [`010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
 authoring on 2026-05-12; the lock entry below pins the
-cardinality and the closed-set policy.
+cardinality and the closed-set policy. Amended 2026-05-14 by
+[Lock #12](#lock-12--subscription-info-parity-with-pair2-mcp)
+to add `subscription-info` (eighteenth tool, band Streaming).
 
 ### Trail-of-thought citations
 
@@ -920,6 +936,166 @@ calculus as Locks #9 and #10.
 
 ---
 
+## Lock #12 — `subscription-info` parity with pair2-mcp
+
+**Locked 2026-05-14 (Mike).** **`subscription-info` is the
+eighteenth Causa-MCP tool, in band Streaming.** A pure-read
+diagnostic over the in-memory subscriptions registry; no queue
+drain; mirrors pair2-mcp's identically-named tool slot for
+cross-server symmetry. Lock #5's seventeen-across-five-bands
+shape is amended to eighteen-across-five-bands; band Streaming
+moves 2 → 3 tools (`subscribe`, `unsubscribe`,
+`subscription-info`).
+
+### Question
+
+Pair2-mcp ships **three** streaming tools (`subscribe`,
+`unsubscribe`, **`subscription-info`** — per
+[`tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs`](../../pair2-mcp/src/re_frame_pair2_mcp/tools.cljs)).
+Causa-MCP's spec scaffold (Lock #5, 2026-05-12) describes
+**two** streaming tools (`subscribe`, `unsubscribe`) and is
+silent on the third. Either Causa-MCP genuinely lacks the
+`subscription-info` surface (a cross-server-parity hole) or it
+bundles the call into another tool (e.g. `subscribe` with a
+`:mode :info` arg) without saying so. Which?
+
+### Options considered
+
+- **Option A — eighteen tools, name the eighteenth.** Add
+  `subscription-info` as its own catalogue entry; place it in
+  band Streaming alongside `subscribe` / `unsubscribe` so the
+  band-grouping matches pair2-mcp's
+  [tools.cljs docstring](../../pair2-mcp/src/re_frame_pair2_mcp/tools.cljs)
+  catalogue. Streaming band goes 2 → 3; total goes 17 → 18.
+- **Option B — bundle into `subscribe`.** Add a `:mode :info`
+  arg to `subscribe`; when set, the call returns the
+  subscriptions registry view instead of opening a stream.
+  Catalogue stays at seventeen.
+- **Option C — leave the surface off causa-mcp.** Agents who
+  want the diagnostic write `eval-cljs
+  "(day8.re-frame2-causa.runtime/subscription-info)"`.
+  Catalogue stays at seventeen; the escape hatch absorbs the
+  divergence.
+
+### Pick
+
+**Option A — eighteen tools, name the eighteenth in band
+Streaming.**
+
+### Why
+
+- **Cross-server symmetry is load-bearing.**
+  [`Principles.md` §Privacy](./Principles.md) and §Tight token
+  budget both spell out the contract: "an agent that learns the
+  slot on one server gets the same slot on the others." A
+  diagnostic the agent learns to call on pair2-mcp must be
+  findable in `tools/list` on causa-mcp under the same name.
+  Option B (bundle into `subscribe`) hides the diagnostic behind
+  an arg that the agent has to know exists; Option C (leave to
+  `eval-cljs`) hides it behind a CLJS form the agent has to
+  hand-render. Both options break the discoverability contract
+  the symmetry posture rests on.
+- **`subscription-info` is a distinct op, not a mode of
+  `subscribe`.** `subscribe` opens a long-lived
+  `notifications/progress` stream; `subscription-info` is a
+  single pure-read snapshot over the in-memory subscriptions
+  registry. Conflating them muddles the semantics on the
+  pair2-mcp side
+  (`subscribe` returns a stream sub-id; `subscribe {:mode :info}`
+  would return a vector of entries — different return shapes for
+  the same tool name, the kind of polymorphism the closed-set
+  catalogue discipline exists to avoid). The pair2-mcp
+  implementer split them deliberately (rf2-zjz9q); causa-mcp
+  inherits the split, not the conflation.
+- **Streaming is the right band for the eighteenth.** The
+  diagnostic is *about* streams: its return shape lists per-sub
+  queue depth, drop counts, overflow reason — fields that exist
+  only because of streaming. Putting it next to `subscribe` and
+  `unsubscribe` matches pair2-mcp's grouping (per
+  [tools.cljs docstring](../../pair2-mcp/src/re_frame_pair2_mcp/tools.cljs)
+  catalogue table) so an agent navigating either server's
+  `tools/list` finds the three streaming tools side-by-side.
+  The alternative — placing it in Meta alongside `discover-app`
+  / `tail-build` — would group it with session-lifecycle tools,
+  which it isn't (it's per-stream diagnostic, not per-session).
+- **Eighteen is still inside the closed-set ceiling.** Lock #5's
+  closed-set discipline is *deliberate-additions-with-Lock-
+  entries*, not *seventeen-is-magical*. The
+  agent-confusion-as-cardinality-grows concern (Lock #5 §Why)
+  is real, but seventeen vs eighteen is one step — well inside
+  the "named tools an agent can hold in context" ceiling Lock #5
+  draws around the high teens.
+- **The eighteenth maps to a cross-server slot, not a Causa
+  panel.** Lock #5's one-tool-per-Causa-panel symmetry is
+  preserved: seventeen tools still map one-to-one to seventeen
+  Causa panels. The eighteenth is a cross-server-parity entry,
+  not a panel mapping — Lock #5 §Why is amended in-place to name
+  the distinction. Future additions follow the same shape: a
+  panel mapping OR a cross-server-symmetric slot already shipped
+  by a sibling MCP server; either way, a Lock entry here.
+- **`eval-cljs` as a fallback (Option C) is the wrong shape for
+  *diagnostic discoverability*.** The escape hatch is for the
+  long tail of one-off agent needs (Lock #5 §Why); putting a
+  recurrent cross-server-shared diagnostic behind it would be
+  exactly the "if a particular `eval-cljs` call becomes
+  recurrent, that's the signal to promote it" pattern Lock #5
+  describes — applied pre-impl by this lock.
+- **Implementation cost is near-zero.** `subscription-info`'s
+  pair2-mcp implementation
+  ([`tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscription_info.cljs`](../../pair2-mcp/src/re_frame_pair2_mcp/tools/subscription_info.cljs))
+  is 52 lines: a `cljs-eval` of
+  `(<runtime-ns>/subscription-info {:topic :sub-id})` with
+  Clojure-side predicate splicing. The causa-mcp port is the
+  same shape with `day8.re-frame2-causa.runtime/subscription-info`
+  as the eval target. The runtime-side accessor lives in
+  Causa-the-panel's preload classpath alongside the other
+  seventeen accessors (Lock #11) — adding it costs ~30 lines on
+  the runtime side and ~50 on the MCP-server side. The savings
+  in agent-side `eval-cljs` round-trips dwarf the addition cost
+  the first time an agent calls it.
+
+### Date locked
+
+2026-05-14 (Mike). Locked in rf2-3we2k, the spec decision the
+rf2-m9yoi audit surfaced (§A6: "Causa-MCP genuinely lacks the
+`subscription-info` surface (likely oversight); add it as the
+eighteenth tool, retaining 'eighteen' arithmetic and reframing
+the phantom 'Compatibility' band as Streaming (3 tools instead
+of 2)"). The rf2-22my5 count-of-things lift (PR #823) is the
+prior-art comparator: at that lock the count was 17 because
+this surface was missing; this lock fixes the gap by adding the
+eighteenth rather than letting the discoverability hole stand.
+
+### Trail-of-thought citations
+
+- pair2-mcp source layout:
+  [`tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscription_info.cljs`](../../pair2-mcp/src/re_frame_pair2_mcp/tools/subscription_info.cljs)
+  (the implementation Causa-MCP will port);
+  [`tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs`](../../pair2-mcp/src/re_frame_pair2_mcp/tools.cljs)
+  (the catalogue docstring that places it in the streaming
+  group);
+  [`tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors.cljs`](../../pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors.cljs)
+  §`subscription-info` (the descriptor + input schema the
+  causa-mcp catalogue will mirror).
+- pair2-mcp lineage: **rf2-zjz9q** filed the original
+  `subscription-info` tool on pair2-mcp; **rf2-hq49** is the
+  streaming substrate it diagnoses against; **rf2-rvyzy** is the
+  token-budget lock the diagnostic helps an agent tune (queue
+  drop reasons help size `:max-buffered-events` /
+  `:max-buffered-bytes` for the next call).
+- Lock #5 (this doc) — the cardinality lock this lock amends.
+- Lock #11 (this doc) — the two-ns split that determines where
+  the runtime-side accessor lands
+  (`day8.re-frame2-causa.runtime`, rides the panel's preload).
+- rf2-m9yoi audit findings doc
+  (`ai/findings/refactor-audit-tools-causa-mcp-2026-05-14.md`
+  §A6) — the surface this lock answers.
+- rf2-22my5 (PR #823) — the count-of-things lift; this lock is
+  the "if the answer is 18: amend rf2-22my5" branch the audit
+  flagged.
+
+---
+
 ## Summary table
 
 | # | Question | Pick | Date |
@@ -928,15 +1104,16 @@ calculus as Locks #9 and #10.
 | 2 | Agent-host transport | **MCP over stdio** (inherited from pair2-mcp Lock #2) | 2026-05-12 |
 | 3 | Connection model | **Single persistent nREPL socket** (inherited from pair2-mcp Lock #3) | 2026-05-12 |
 | 4 | Origin tagging | **Default-on, opt-out per call — `:origin :causa-mcp`** | 2026-05-12 |
-| 5 | Tool catalogue | **Seventeen tools across five bands; closed-set + `eval-cljs` escape valve** | 2026-05-12 |
+| 5 | Tool catalogue | **Eighteen tools across five bands; closed-set + `eval-cljs` escape valve** (originally seventeen at 2026-05-12 lock time; amended 2026-05-14 by Lock #12 to add `subscription-info` for pair2-mcp parity, band Streaming 2 → 3) | 2026-05-12 (amended 2026-05-14) |
 | 6 | npm package coord | **`@day8/re-frame2-causa-mcp`** (shape `re-frame2-<tool>-mcp`; story-mcp matches; pair2-mcp's `re-frame-<tool>2-mcp` shape is a pre-rename divergence pinned 2026-05-14 by rf2-l7skx) | 2026-05-12 (amended 2026-05-14) |
 | 7 | Chrome DevTools MCP posture | **Co-install, stay in lane** | 2026-05-12 |
 | 8 | bencode pinning | **`bencode@~2.0.3`** (inherited from pair2-mcp Lock #5) | 2026-05-12 |
 | 9 | Wire-protocol budget posture | **Six mechanisms baked into spec before impl** (cap + slicing + pagination + lazy-summary + dedup + size-elision; mechanism #6 added by Lock #10) | 2026-05-13 |
 | 10 | Size-elision marker shape | **`:rf.size/large-elided` is the sixth mechanism; shape normative across MCP triplet; sensitive wins on composition** | 2026-05-13 |
 | 11 | Namespace split | **MCP-server-side at `day8.re-frame2-causa-mcp.*` (Node); injected-runtime-side at `day8.re-frame2-causa.runtime` (browser, rides Causa-the-panel's preload). Mirrors pair2-mcp's `re-frame-pair2-mcp.*` / `re-frame-pair2.runtime` split.** | 2026-05-14 |
+| 12 | `subscription-info` parity | **`subscription-info` is the eighteenth tool, band Streaming. Pure-read diagnostic over the in-memory subscriptions registry; mirrors pair2-mcp's identically-named slot for cross-server symmetry. Amends Lock #5.** | 2026-05-14 |
 
-These eleven locks define Causa-MCP's pre-implementation surface.
+These twelve locks define Causa-MCP's pre-implementation surface.
 They were extracted from
 [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
 and [Causa's own DESIGN-RATIONALE](../../causa/spec/DESIGN-RATIONALE.md)

--- a/tools/causa-mcp/spec/Principles.md
+++ b/tools/causa-mcp/spec/Principles.md
@@ -22,7 +22,7 @@ surfaces. It must not add:
 - New effect substrates.
 - New component substrates.
 
-The seventeen tools route through the existing
+The eighteen tools route through the existing
 **injected-runtime namespace** (`day8.re-frame2-causa.runtime`,
 which rides Causa-the-panel's preload — see
 [`000-Vision.md` §Two namespaces, two sides](./000-Vision.md#two-namespaces-two-sides))
@@ -67,7 +67,7 @@ The tie-breaker this principle hands implementers and reviewers:
   `day8.re-frame2-causa.*` root, because the runtime rides the
   panel's `:preloads`), lives in the panel's preload classpath,
   is the eval target of the MCP server's rendered forms.
-  Examples: per-frame state accessors backing the seventeen
+  Examples: per-frame state accessors backing the eighteen
   tools, the `current-origin` dynamic var, the `session-id`
   marker, hot-reload re-inject probes.
 
@@ -90,8 +90,10 @@ gate to avoid. Two roots, two locations, two roles. Reviewers
 catch the leak at the `:require` line; the spec catches it at
 the architecture line.
 
-The principle has zero impact on the seventeen-tool catalogue
-(per [`DESIGN-RATIONALE.md` Lock #5](./DESIGN-RATIONALE.md)) and
+The principle has zero impact on the eighteen-tool catalogue
+(per [`DESIGN-RATIONALE.md` Lock #5](./DESIGN-RATIONALE.md), as
+amended by [Lock #12](./DESIGN-RATIONALE.md) for the
+`subscription-info` parity entry) and
 zero impact on the MCP wire shape (per Locks #1–#3). It's a
 naming + layout rule that costs nothing at the spec level and
 saves a "wait, which side am I writing?" pause at every impl
@@ -202,9 +204,11 @@ Concretely:
   [`000-Vision.md` §Two namespaces, two sides](./000-Vision.md#two-namespaces-two-sides))
   is what lets the server reason about the runtime's absence
   without itself having a `runtime/session-id` to test.
-- The runtime contract is the shape of the seventeen tool
+- The runtime contract is the shape of the eighteen tool
   accessors `day8.re-frame2-causa.runtime` exposes, not a
-  specific framework version.
+  specific framework version. (`subscription-info` is the
+  eighteenth; pure-read over the in-memory subscriptions
+  registry — see [Lock #12](./DESIGN-RATIONALE.md).)
 
 A project that adopts a non-default build id, a custom nREPL
 port, or a slightly different shadow layout still gets a working
@@ -232,7 +236,7 @@ Same posture as pair2-mcp.
 
 ## Read-mostly catalogue; mutate via the in-panel-equivalent gates
 
-The seventeen tools split 9 read / 3 mutate / 2 stream / 1 escape
+The eighteen tools split 9 read / 3 mutate / 3 stream / 1 escape
 hatch / 2 meta. The mutating tools (`restore-epoch`,
 `reset-frame-db`, `dispatch`) mirror the in-panel right-click
 affordances the human user already has — Causa-MCP doesn't
@@ -254,13 +258,18 @@ entry.
 
 ## Closed-set tool catalogue, deliberate escape valve
 
-The catalogue is **closed-set on purpose**: seventeen named
-surfaces map to seventeen Causa panels. Adding tools is a
+The catalogue is **closed-set on purpose**: eighteen named
+surfaces — seventeen Causa-panel mappings plus
+`subscription-info`, the pure-read diagnostic over the
+in-memory subscriptions registry that mirrors pair2-mcp's
+surface for cross-server symmetry (Lock #12). Adding tools is a
 deliberate act (a `bd` bead, a discussion, a Lock entry in
 [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md)). Drift is
 prevented by the discipline that every new tool maps to an
-existing Causa surface — the framework's instrumentation
-contract is the rate-limit.
+existing Causa surface OR to a cross-server-symmetric slot
+already shipped by a sibling MCP server — the framework's
+instrumentation contract and the cross-server-parity contract
+are the two rate-limits.
 
 The `eval-cljs` escape valve absorbs the long tail (per the
 section above). Refusing to ship an escape hatch would force

--- a/tools/causa-mcp/spec/README.md
+++ b/tools/causa-mcp/spec/README.md
@@ -19,7 +19,7 @@ shape, the implementation phase will add:
 
 - `001-Wire-Protocol.md` — Newline-delimited JSON-RPC 2.0 over stdio per the MCP 2025-06-18 transport spec.
 - `002-nREPL-Transport.md` — Persistent TCP socket; bencode framing; port discovery; runtime injection.
-- `003-Tool-Catalogue.md` — The eighteen tools, with full signatures and return shapes. (Currently the catalogue lives in [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md) §Tool catalogue; the prose will migrate here. The eighteenth tool — `subscription-info` — is locked here by [`DESIGN-RATIONALE.md` Lock #12](DESIGN-RATIONALE.md); the upstream catalogue prose will catch up when `003-Tool-Catalogue.md` lands.)
+- `003-Tool-Catalogue.md` — The eighteen tools, with full signatures and return shapes. (Currently the catalogue lives in [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md) §Tool catalogue; the prose will migrate here when impl lands. The eighteenth tool — `subscription-info`, in band Streaming — is locked by [`DESIGN-RATIONALE.md` Lock #12](DESIGN-RATIONALE.md) for cross-server parity with pair2-mcp.)
 - `API.md` — Consolidated user-facing reference: install, configure, launch, call.
 - `findings/` — Exploratory working substrate; audit lineage, not normative.
 
@@ -31,7 +31,7 @@ that's how drift is prevented when a count next moves.
 
 | Count | Value | Source-of-truth |
 |---|---|---|
-| **Tools** | **18** | [`000-Vision.md`](000-Vision.md) §MCP catalogue summary enumerates the bands; the upstream prose at [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md) §Tool catalogue describes seventeen and migrates to `003-Tool-Catalogue.md` when impl lands. The eighteenth (`subscription-info`, in band Streaming) is locked here by [`DESIGN-RATIONALE.md` Lock #12](DESIGN-RATIONALE.md) for cross-server parity with pair2-mcp. |
+| **Tools** | **18** | [`000-Vision.md`](000-Vision.md) §MCP catalogue summary enumerates the bands; the catalogue prose with full signatures and return shapes lives in [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md) §Tool catalogue and migrates to `003-Tool-Catalogue.md` when impl lands. The eighteenth (`subscription-info`, in band Streaming) is locked by [`DESIGN-RATIONALE.md` Lock #12](DESIGN-RATIONALE.md) for cross-server parity with pair2-mcp. |
 | **Bands** | **5** | Inspection (9) + Mutation (3) + Streaming (3) + Escape hatch (1) + Meta (2) = 18. Enumerated in [`000-Vision.md`](000-Vision.md) §MCP catalogue summary. |
 | **Mechanisms** | **6** | [`Principles.md`](Principles.md) §"Tight token budget per response" — token cap, path slicing, cursor pagination, lazy summary, structural dedup, size elision. Mechanism #6 promoted by Lock #10. |
 | **Locks** | **12** | [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) §Summary table. |

--- a/tools/causa-mcp/spec/README.md
+++ b/tools/causa-mcp/spec/README.md
@@ -8,9 +8,9 @@ before this folder existed.
 
 ## Files
 
-- **[000-Vision.md](000-Vision.md)** — Causa-MCP is the agent face of Causa; seventeen MCP tools across five bands; same shadow-cljs / Node / persistent-nREPL architecture as pair2-mcp; **two-namespace split** between the Node-side MCP server (`day8.re-frame2-causa-mcp.*`) and the browser-side injected runtime (`day8.re-frame2-causa.runtime`); relationship to Causa, pair2-mcp, and Chrome DevTools MCP.
+- **[000-Vision.md](000-Vision.md)** — Causa-MCP is the agent face of Causa; eighteen MCP tools across five bands; same shadow-cljs / Node / persistent-nREPL architecture as pair2-mcp; **two-namespace split** between the Node-side MCP server (`day8.re-frame2-causa-mcp.*`) and the browser-side injected runtime (`day8.re-frame2-causa.runtime`); relationship to Causa, pair2-mcp, and Chrome DevTools MCP.
 - **[Principles.md](Principles.md)** — Load-bearing principles: **MCP-server-ns and injected-runtime-ns are distinct** (the tie-breaker for "which side does this code go?"), origin tagging is the convention (not a suggestion), EDN canonical, closed-set catalogue with `eval-cljs` as the deliberate escape valve, single persistent nREPL socket, stage-marker-independent, and the **six-mechanism wire-protocol budget posture** (token cap + path slicing + cursor pagination + lazy summary + structural dedup + size elision via `:rf.size/large-elided`) — baked into the spec before implementation begins so the impl is born compliant.
-- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — Eleven direction-setting decisions: question, options, pick, why, date locked. Inheritance from pair2-mcp's locks is cited rather than duplicated.
+- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — Twelve direction-setting decisions: question, options, pick, why, date locked. Inheritance from pair2-mcp's locks is cited rather than duplicated.
 
 ## Files that will land at implementation time
 
@@ -19,7 +19,7 @@ shape, the implementation phase will add:
 
 - `001-Wire-Protocol.md` — Newline-delimited JSON-RPC 2.0 over stdio per the MCP 2025-06-18 transport spec.
 - `002-nREPL-Transport.md` — Persistent TCP socket; bencode framing; port discovery; runtime injection.
-- `003-Tool-Catalogue.md` — The seventeen tools, with full signatures and return shapes. (Currently the catalogue lives in [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md) §Tool catalogue; the prose will migrate here.)
+- `003-Tool-Catalogue.md` — The eighteen tools, with full signatures and return shapes. (Currently the catalogue lives in [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md) §Tool catalogue; the prose will migrate here. The eighteenth tool — `subscription-info` — is locked here by [`DESIGN-RATIONALE.md` Lock #12](DESIGN-RATIONALE.md); the upstream catalogue prose will catch up when `003-Tool-Catalogue.md` lands.)
 - `API.md` — Consolidated user-facing reference: install, configure, launch, call.
 - `findings/` — Exploratory working substrate; audit lineage, not normative.
 
@@ -31,10 +31,10 @@ that's how drift is prevented when a count next moves.
 
 | Count | Value | Source-of-truth |
 |---|---|---|
-| **Tools** | **17** | [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md) §Tool catalogue — the catalogue prose enumerates each. Migrates to `003-Tool-Catalogue.md` when impl lands. |
-| **Bands** | **5** | Inspection (9) + Mutation (3) + Streaming (2) + Escape hatch (1) + Meta (2) = 17. Enumerated in [`000-Vision.md`](000-Vision.md) §MCP catalogue summary. |
+| **Tools** | **18** | [`000-Vision.md`](000-Vision.md) §MCP catalogue summary enumerates the bands; the upstream prose at [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md) §Tool catalogue describes seventeen and migrates to `003-Tool-Catalogue.md` when impl lands. The eighteenth (`subscription-info`, in band Streaming) is locked here by [`DESIGN-RATIONALE.md` Lock #12](DESIGN-RATIONALE.md) for cross-server parity with pair2-mcp. |
+| **Bands** | **5** | Inspection (9) + Mutation (3) + Streaming (3) + Escape hatch (1) + Meta (2) = 18. Enumerated in [`000-Vision.md`](000-Vision.md) §MCP catalogue summary. |
 | **Mechanisms** | **6** | [`Principles.md`](Principles.md) §"Tight token budget per response" — token cap, path slicing, cursor pagination, lazy summary, structural dedup, size elision. Mechanism #6 promoted by Lock #10. |
-| **Locks** | **11** | [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) §Summary table. |
+| **Locks** | **12** | [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) §Summary table. |
 | **Namespace roots** | **2** | MCP-server (Node-side): `day8.re-frame2-causa-mcp.*` — injected runtime (browser-side): `day8.re-frame2-causa.runtime`. Per [`000-Vision.md` §Two namespaces, two sides](000-Vision.md#two-namespaces-two-sides) and [`DESIGN-RATIONALE.md` Lock #11](DESIGN-RATIONALE.md). |
 
 ## How to use

--- a/tools/causa/spec/010-MCP-Server.md
+++ b/tools/causa/spec/010-MCP-Server.md
@@ -12,7 +12,7 @@ without opening Causa's UI.
 > [`DESIGN-RATIONALE.md`](../../causa-mcp/spec/DESIGN-RATIONALE.md).
 > The design locks accumulated in this file have been lifted there;
 > citations point to their canonical homes. This file remains the
-> **catalogue prose** (the seventeen tools enumerated with signatures
+> **catalogue prose** (the eighteen tools enumerated with signatures
 > and return shapes); when implementation lands and
 > `tools/causa-mcp/spec/003-Tool-Catalogue.md` is authored, the
 > catalogue prose migrates there and this file shrinks to a pointer.
@@ -117,17 +117,23 @@ the actual op runs. Mirrors the bash-shim chain's
 
 ## Tool catalogue
 
-Seventeen MCP tools across five bands: inspection (read-only),
+Eighteen MCP tools across five bands: inspection (read-only),
 mutation (user-confirmed equivalents in the UI), streaming
-(`notifications/progress`-shaped), escape hatch (`eval-cljs`), and
-meta (session-lifecycle). Each maps to a Causa surface; together
-they let an agent observe, dispatch, time-travel, stream, and
-inspect.
+(`notifications/progress`-shaped, plus the `subscription-info`
+diagnostic), escape hatch (`eval-cljs`), and meta
+(session-lifecycle). Each maps to a Causa surface (or, for
+`subscription-info`, to a cross-server-symmetric slot shipped by
+pair2-mcp — see
+[`tools/causa-mcp/spec/DESIGN-RATIONALE.md`](../../causa-mcp/spec/DESIGN-RATIONALE.md)
+Lock #12); together they let an agent observe, dispatch,
+time-travel, stream, and inspect.
 
-The seventeen-tool cardinality and closed-set policy are locked at
+The eighteen-tool cardinality and closed-set policy are locked at
 [`tools/causa-mcp/spec/DESIGN-RATIONALE.md`](../../causa-mcp/spec/DESIGN-RATIONALE.md#lock-5--tool-catalogue-cardinality-and-shape)
-Lock #5; the closed-set discipline and `eval-cljs` escape valve
-posture live at
+Lock #5 (as amended by
+[Lock #12](../../causa-mcp/spec/DESIGN-RATIONALE.md) for the
+`subscription-info` parity entry); the closed-set discipline and
+`eval-cljs` escape valve posture live at
 [`tools/causa-mcp/spec/Principles.md`](../../causa-mcp/spec/Principles.md)
 §Closed-set tool catalogue, deliberate escape valve. The
 **catalogue prose itself** (the tables below) remains here until
@@ -188,6 +194,7 @@ final `tools/call` result is a summary
 |---|---|---|
 | `subscribe` | `:trace`, `:epoch`, `:fx`, `:error` | Stream of events matching `filter`; topic-mediated base filter overlaid by user filter (user wins on conflict). Filter vocabulary mirrors [Spec 009 §Filter vocabulary](../../../spec/009-Instrumentation.md#filter-vocabulary) for `:trace` / `:fx` / `:error`; mirrors `watch-epochs` for `:epoch`. |
 | `unsubscribe` | (n/a) | Idempotent close. Returns `{:ok? true :sub-id <id> :existed? <bool>}`. Useful when the agent host can't propagate `tools/call` cancellation cleanly. |
+| `subscription-info` | (n/a — filter args) | Pure-read diagnostic over the in-memory subscriptions registry (no queue drain). Args (all optional): `:topic` filters to one of `:trace` / `:epoch` / `:fx` / `:error`; `:sub-id` returns only the matching sub. Returns `{:ok? true :subs [{:id :topic :filter :queue-depth :queue-bytes :dropped-events :dropped-bytes :overflow-reason :created-at}]}`. Empty `:subs` vector when no streams are open. A non-nil `:overflow-reason` signals the queue has been evicting older events — tune `:max-buffered-events` / `:max-buffered-bytes` on the next `subscribe` call. Mirrors pair2-mcp's identically-named slot (per [`tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscription_info.cljs`](../../pair2-mcp/src/re_frame_pair2_mcp/tools/subscription_info.cljs)) for cross-server symmetry — see [Lock #12](../../causa-mcp/spec/DESIGN-RATIONALE.md). |
 
 Termination paths: client cancel → `:reason :aborted`; out-of-band
 `unsubscribe` → `:reason :sub-gone`; cap reached → `:reason
@@ -207,7 +214,7 @@ Args: `form` (string, required — EDN-encoded CLJS form), `frame`
 triggers), `build` (string, optional).
 
 `eval-cljs` is the **deliberate escape valve**: the catalogue is
-closed-set on purpose (sixteen named surfaces alongside this one
+closed-set on purpose (seventeen named surfaces alongside this one
 escape hatch), but agents occasionally need to reach for something
 not yet catalogued. Rather than refuse them and force a workaround through
 Chrome MCP's `evaluate_script` (which loses the `:origin` tag), we
@@ -276,7 +283,7 @@ automatic re-inject → op proceeds.
 | Axis | `tools/pair2-mcp/` | `tools/causa-mcp/` |
 |---|---|---|
 | **Audience** | Editor-side AI workflows (pair-programming). | Debugger-side AI workflows (inspection, time-travel). |
-| **Surface** | 9 tools focused on dispatch / eval / hot-swap / trace, plus streaming. | 17 tools focused on inspection (graph, app-db, machine, issues) + restore / reset / dispatch + streaming + escape hatch + session lifecycle. |
+| **Surface** | 11 tools focused on dispatch / eval / hot-swap / trace, plus streaming (inc. `subscription-info`). | 18 tools focused on inspection (graph, app-db, machine, issues) + restore / reset / dispatch + streaming (inc. `subscription-info`) + escape hatch + session lifecycle. |
 | **`:origin` tag** | `:pair` | `:causa-mcp` |
 | **Runtime injection** | `re-frame-pair2.runtime` | `re-frame2-causa-mcp.runtime` |
 | **Implementation** | shadow-cljs `:node-script`, npm-published. | Same. |


### PR DESCRIPTION
## Summary

Picks the direction the rf2-m9yoi audit (§A6) flagged as needing a Mike decision: does causa-mcp's catalogue have **seventeen tools + an implicit bundling** of pair2-mcp's `subscription-info`, or **eighteen tools** with `subscription-info` named explicitly?

**Decision: eighteen tools** with `subscription-info` as the 3rd Streaming-band tool. Locked here as `DESIGN-RATIONALE.md` Lock #12; Lock #5's seventeen-across-five-bands shape is amended in-place to eighteen-across-five-bands (band Streaming 2 -> 3: `subscribe`, `unsubscribe`, `subscription-info`).

## Why this direction (vs the alternatives)

- **Cross-server symmetry is load-bearing.** `Principles.md` §Privacy and §Tight token budget both rest on the same contract: "an agent that learns the slot on one server gets the same slot on the others." A diagnostic the agent learns on pair2-mcp must be findable on causa-mcp under the same name in `tools/list` — not behind a `:mode :info` arg (Option B) or behind `eval-cljs` (Option C). Both alternatives break the discoverability contract.
- **`subscription-info` is a distinct op, not a mode of `subscribe`.** `subscribe` opens a long-lived `notifications/progress` stream; `subscription-info` is a single pure-read snapshot over the in-memory subscriptions registry. Pair2-mcp's implementer (rf2-zjz9q) split them deliberately; causa-mcp inherits the split, not the conflation.
- **Streaming is the right band for the eighteenth.** The diagnostic is *about* streams (per-sub queue depth, drop counts, overflow reason — fields that exist only because of streaming). Matches pair2-mcp's catalogue-docstring grouping so an agent navigating either server's `tools/list` finds the three streaming tools side-by-side.
- **Eighteen is still inside the closed-set ceiling.** Lock #5's closed-set discipline is *deliberate-additions-with-Lock-entries*, not *seventeen-is-magical*. One step over is well inside the "named tools an agent can hold in context" boundary.
- **Lock #5's panel-mapping symmetry is preserved.** Seventeen tools still map one-to-one to seventeen Causa panels. The eighteenth maps to a cross-server-parity slot, not a panel — Lock #5 §Why amended to name the distinction. Future additions follow the same shape: a panel mapping OR a cross-server-symmetric slot already shipped by a sibling MCP server.

Both commits described below land the decision. Full reasoning + options-considered breakdown in DESIGN-RATIONALE.md Lock #12 (the new lock).

## Commits

- **`spec(causa-mcp): subscription-info parity decision (rf2-3we2k)`** — DESIGN-RATIONALE.md Lock #12 added; Lock #5 amended to cite #12; summary table updated; 000-Vision.md catalogue summary table + cross-mcp comparison updated; Principles.md "seventeen" -> "eighteen" with parity citations; spec/README.md canonical-counts table updated (Tools 17 -> 18, Locks 11 -> 12, Streaming band 2 -> 3).
- **`spec(causa-mcp): align upstream catalogue prose + READMEs (rf2-3we2k)`** — Catalogue source-of-truth `tools/causa/spec/010-MCP-Server.md` aligned (new `subscription-info` row in the streaming table with args + return shape; band-count assertions updated). Top-level `tools/causa-mcp/README.md` "eight direction-setting decisions" -> "twelve" (was scaffold-stale; rf2-22my5 didn't touch the top-level README).

## Composition with other landings

- **Composes on rf2-22my5 (PR #823 — count-of-things unification).** That lock pulled "seventeen" canonical; this lock moves the same dial to "eighteen" and adds a sibling-symmetry rationale. The Canonical-counts subsection still does its job; only the value moved.
- **Composes on rf2-c9b90 (PR #880 — Lock #11 / two-namespace split).** Lock #12 cites #11 to say the runtime-side accessor lives in `day8.re-frame2-causa.runtime` (parented by Causa-the-panel's preload, not by the MCP server jar).
- **Composes on rf2-zvv65 (PR #876 — cross-server slot-name conformance harness).** The harness is the enforcement; this lock is the spec direction the harness's per-tool fixtures will exercise once causa-mcp's impl lands.
- **Composes on rf2-l7skx (PR #881 — Lock #6 coord-shape amendment).** Same coord shape determines the eval target the new tool calls.

## Test plan

- [x] Spec-only edits; no impl yet exists for `tools/causa-mcp/`.
- [x] `grep "seventeen\|eighteen"` across tools/causa-mcp/spec/ + tools/causa/spec/010-MCP-Server.md returns no inconsistent count usage (remaining "seventeen" instances are intentional: original-lock cardinality references, 17-panel-mappings concept distinct from 18-tool catalogue, historical/comparative wording in Lock #5 / Lock #12).
- [x] `tools/causa-mcp/spec/README.md` §Canonical counts and `tools/causa-mcp/spec/000-Vision.md` §MCP catalogue summary agree on tools=18, bands=5, streaming-band=3, locks=12.
- [x] DESIGN-RATIONALE.md §Summary table row 5 + row 12 + closing line "twelve locks" consistent.
- [ ] Impl pass (future bead, NOT this PR): port pair2-mcp's `tools/subscription_info.cljs` to causa-mcp shape; add the runtime-side accessor under `day8.re-frame2-causa.runtime`; descriptor mirrors pair2-mcp's per descriptors.cljs §subscription-info.