### PR TITLE
fix(story): Run-all preserves per-variant cell-overrides (rf2-zq6sn)

### DIFF
--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -360,17 +360,36 @@
 
 ;; ---- chrome-level test widget (rf2-q0irb) -------------------------------
 
+(defn run-opts-for-variant
+  "Build the `run-variant` opts map for `vid` from the current shell
+  state, threading the per-variant cell-overrides through so a Run-all
+  reproduces the same effective-args as the canvas / docs / share /
+  workspace surfaces (rf2-zq6sn).
+
+  The cell-overrides slot is `{variant-id → override-map}` (state.cljc
+  §49); each variant must look up its OWN entry — passing a single
+  blanket map (or `nil`) for every variant drops the per-variant
+  controls the user set in the controls panel."
+  [shell vid]
+  {:active-modes   (:active-modes shell)
+   :cell-overrides (get-in shell [:cell-overrides vid])
+   :substrate      (:substrate shell)})
+
 (defn- run-one-test!
   "Dispatch a single `run-variant` against `vid` and fold the result
   into the shell-state `:test-runs` slot. Marks `:running` up front,
   records pass/fail/skip counts on resolve, and clears the slot on
   rejection. Shared between the chrome widget's 'Run all' button and
-  the watch-mode auto-re-run (rf2-z1h0f)."
+  the watch-mode auto-re-run (rf2-z1h0f).
+
+  Per rf2-zq6sn each variant's run threads its OWN cell-overrides
+  entry from shell state — same lookup the canvas / pane / share-url
+  paths perform. The shell-state snapshot is taken once per variant
+  so concurrent runs don't race against a swap-state! between the
+  read and the dispatch."
   [vid]
   (state/swap-state! state/mark-test-running vid)
-  (let [opts {:active-modes   (:active-modes (state/get-state))
-              :cell-overrides nil
-              :substrate      (:substrate (state/get-state))}]
+  (let [opts (run-opts-for-variant (state/get-state) vid)]
     (-> (runtime/run-variant vid opts)
         (async/then  (fn [result]
                        ;; The aggregate-summary helper lives in

--- a/tools/story/src/re_frame/story/ui/test_mode/state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/state.cljs
@@ -127,11 +127,17 @@
 (defn run-variant-pane!
   "Drive a fresh `reset-variant` against the variant's frame and
   swap the result into local state when it resolves. No-ops if
-  the slot already carries `:running?`."
+  the slot already carries `:running?`.
+
+  Per rf2-zq6sn the variant's run threads its OWN cell-overrides
+  entry from shell state — same lookup the canvas / sidebar /
+  share-url paths perform — so the test pane re-runs against the
+  same effective-args the user has been editing in the controls
+  panel."
   [variant-id]
   (let [shell @state/shell-state-atom
         opts  {:active-modes   (:active-modes shell)
-               :cell-overrides nil
+               :cell-overrides (get-in shell [:cell-overrides variant-id])
                :substrate      (:substrate shell)}]
     (begin-run! variant-id)
     (-> (runtime/reset-variant variant-id opts)

--- a/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
@@ -270,6 +270,34 @@
          (is (some? btn))
          (is (true? (get (second btn) :disabled)))))))
 
+;; ---- regression: per-variant cell-overrides threading (rf2-zq6sn) -------
+
+#?(:cljs
+   (deftest run-opts-threads-per-variant-cell-overrides
+     (testing "the chrome widget's Run-all path (run-opts-for-variant)
+               threads each variant's OWN cell-overrides entry from
+               shell state — the same lookup canvas / pane / share-url
+               perform. The pre-fix bug passed `:cell-overrides nil`
+               for every variant, dropping the user's controls-panel
+               edits on a Run-all (rf2-zq6sn)."
+       (let [shell (-> state/default-shell-state
+                       (assoc :active-modes #{:dark}
+                              :substrate :reagent)
+                       (state/set-cell-override :story.x/a :n 5)
+                       (state/set-cell-override :story.x/b :label "B"))
+             opts-a (sidebar/run-opts-for-variant shell :story.x/a)
+             opts-b (sidebar/run-opts-for-variant shell :story.x/b)
+             opts-c (sidebar/run-opts-for-variant shell :story.x/c)]
+         (testing ":story.x/a opts carry only :a's overrides"
+           (is (= {:n 5} (:cell-overrides opts-a)))
+           (is (= #{:dark} (:active-modes opts-a)))
+           (is (= :reagent (:substrate opts-a))))
+         (testing ":story.x/b opts carry only :b's overrides (NOT :a's)"
+           (is (= {:label "B"} (:cell-overrides opts-b))))
+         (testing "an unedited variant gets nil overrides (no leakage
+                   from sibling variants)"
+           (is (nil? (:cell-overrides opts-c))))))))
+
 #?(:clj
    (deftest jvm-only-summary-from-fixture
      (testing "JVM corpus exercises the pure summary helper without


### PR DESCRIPTION
## Summary

The chrome sidebar's "Run all" button built `:run-variant` opts with `:cell-overrides nil` for every variant, dropping the user's controls-panel edits whenever Run-all dispatched a fresh run. The test_mode pane's `run-variant-pane!` carried the same bug. Both surfaces now thread `(get-in shell [:cell-overrides variant-id])` per the canonical pattern already used by `canvas.cljs`, `share.cljs`, `workspace.cljc`, `multi_substrate.cljs`, and `shell.cljs`.

- Extract `run-opts-for-variant` as a small pure helper on `sidebar.cljs` so the per-variant threading is testable without spinning the runtime.
- Patch `test_mode/state.cljs/run-variant-pane!` so the re-run-this-pane button has the same effective-args as the canvas / sidebar / share paths.
- Regression test in `test_widget_cljs_test.cljc` asserts each variant's opts carry ONLY that variant's overrides — no cross-variant leakage, no nil drop. (The `:docs` pane still passes `nil` deliberately — its comment marks it read-only.)

Audit reference: rf2-dd5ze (SB2, P1 bug).

## Test plan

- [x] `clojure -M:test` from `tools/story/` — 348 tests, 1025 assertions, 0 failures, 0 errors
- [x] `npm run test:cljs` from `implementation/` — 1793 tests, 4980 assertions, 0 failures, 0 errors
- [x] New regression `run-opts-threads-per-variant-cell-overrides` asserts per-variant threading and absence of leakage