### PR TITLE
refactor(core): factor error_emit + event_emit into emit-substrate primitive (rf2-z5ffh)

### DIFF
--- a/implementation/core/src/re_frame/emit_substrate.cljc
+++ b/implementation/core/src/re_frame/emit_substrate.cljc
@@ -1,0 +1,59 @@
+(ns re-frame.emit-substrate
+  "Parameterised always-on emit substrate. Backs `re-frame.event-emit`
+  (rf2-rirbq) and `re-frame.error-emit` (rf2-bacs4 / rf2-hqbeh) — both
+  ship a `register / unregister / clear / fan-out` registry with
+  identical structure but distinct record shapes and short-circuit
+  conditions. Factored per rf2-z5ffh (audit finding EE1/A4 of
+  rf2-spr6q).
+
+  The substrate is always-on: no `goog.DEBUG` gating inside this
+  namespace. Listener-REGISTRATION sites SHOULD use `goog.DEBUG=false`
+  as a belt-and-braces gate around production-only listeners — see the
+  per-substrate ns docstrings.
+
+  Each listener invocation is try/catch wrapped so a buggy listener
+  cannot break the cascade or sibling listeners. The runtime does NOT
+  recursively emit through any emit-substrate on a listener throw.
+
+  See Spec 009 §Production debugging for normative framing."
+  (:require))
+
+(defn make-listener-registry
+  "Construct an isolated always-on listener registry. Returns a map:
+
+    {:listeners <atom of id->fn>
+     :register  (fn [id f] ...)        ;; returns id
+     :unregister (fn [id] ...)         ;; returns nil
+     :clear     (fn [] ...)            ;; returns nil
+     :fan-out   (fn [record] ...)}     ;; returns nil
+
+  Caller MUST hold the returned `:listeners` atom in a `defonce` (or
+  equivalent) so that hot reload of the consuming namespace does not
+  silently drop long-lived production listeners. The `make-` factory
+  itself produces a fresh atom on every call — pass an externally-held
+  `defonce` atom via `:listeners` to bind the surface to it.
+
+  `fan-out` short-circuits to nil when the registry is empty so the
+  per-emit hot-path cost reduces to one deref + an `empty?` check.
+  Listener exceptions are caught — the cascade does NOT abort and
+  sibling listeners still run."
+  [{:keys [listeners]}]
+  (let [reg (or listeners (atom {}))]
+    {:listeners  reg
+     :register   (fn register [id f]
+                   (swap! reg assoc id f)
+                   id)
+     :unregister (fn unregister [id]
+                   (swap! reg dissoc id)
+                   nil)
+     :clear      (fn clear []
+                   (reset! reg {})
+                   nil)
+     :fan-out    (fn fan-out [record]
+                   (let [snap @reg]
+                     (when (seq snap)
+                       (doseq [[_id f] snap]
+                         (try
+                           (f record)
+                           (catch #?(:clj Throwable :cljs :default) _ nil)))))
+                   nil)}))

--- a/implementation/core/src/re_frame/emit_substrate.cljc
+++ b/implementation/core/src/re_frame/emit_substrate.cljc
@@ -15,8 +15,7 @@
   cannot break the cascade or sibling listeners. The runtime does NOT
   recursively emit through any emit-substrate on a listener throw.
 
-  See Spec 009 §Production debugging for normative framing."
-  (:require))
+  See Spec 009 §Production debugging for normative framing.")
 
 (defn make-listener-registry
   "Construct an isolated always-on listener registry. Returns a map:

--- a/implementation/core/src/re_frame/error_emit.cljc
+++ b/implementation/core/src/re_frame/error_emit.cljc
@@ -1,132 +1,45 @@
 (ns re-frame.error-emit
   "Always-on error-emit substrate. Per rf2-hqbeh (per-frame `:on-error`
-  policy fan-out) and rf2-bacs4 (corpus-wide listener fan-out).
+  policy fan-out) and rf2-bacs4 (corpus-wide listener fan-out). Per
+  Spec 009 §What IS available in production §Error-handler policy.
 
-  ## Why this namespace exists
+  Survives `:advanced` + `goog.DEBUG=false`. Carries two independent
+  fan-out paths from one normative emission site (the router's
+  handler-exception path):
 
-  Spec 009's trace surface is compile-time elided in CLJS production
-  builds via `re-frame.interop/debug-enabled?` — see Spec 009 §Production
-  builds. The original `:on-error` integration rode the trace surface and
-  elided with it; production `:on-error` callbacks did not fire, defeating
-  the slot's framing as a runtime error-recovery surface. The bug surfaced
-  in rf2-hqbeh.
+    1. Corpus-wide listener registry (rf2-bacs4) — every fn
+       registered through [[register-error-emit-listener!]] receives
+       a tight error-record (Spec 009 §Record shape):
 
-  This namespace carves a small **always-on** delivery path that survives
-  `goog.DEBUG=false`. It runs alongside the trace surface — not through
-  it — so:
+         {:error      <kw>       ;; e.g. :rf.error/handler-exception
+          :event      <vector>    ;; dispatched event vector (elided)
+          :event-id   <kw>
+          :frame      <kw>
+          :time       <millis>
+          :exception  <ex>
+          :elapsed-ms <int>}
 
-    - Trace events still emit through `re-frame.trace/emit-error!` in dev
-      and on the JVM; that path remains gated and still elides in CLJS
-      prod, as documented.
-    - The per-frame `:on-error` policy fn fires through THIS path on
-      both dev and prod. The policy receives the structured error event
-      and may return a recovery map per Spec 009 §Error-handler policy.
-    - Corpus-wide listeners registered through
-      [[register-error-emit-listener!]] fire through THIS path on both
-      dev and prod. Each listener receives one tight error-record per
-      `:rf.error/*` event the runtime emits through this substrate.
-      Sibling to the event-emit listener surface (rf2-rirbq).
+       For off-box observability shippers (Sentry / Honeybadger /
+       Rollbar).
 
-  ## Two surfaces, one substrate
+    2. Per-frame `:on-error` policy fn (rf2-hqbeh) — the frame's
+       `:on-error` slot, when present, receives a structured error
+       event (`:operation` / `:tags` / `:recovery` shape) for in-app
+       recovery decisions.
 
-  The error-emit substrate carries two independent fan-out paths from
-  one normative emission site (the router's handler-exception path):
+  Both paths are independent (a buggy listener cannot block the
+  policy fn; a buggy policy fn cannot block listeners). Both are
+  try/catch wrapped per Spec 009 §1052.
 
-  | Surface                              | Consumer concern                 | Bead       |
-  |--------------------------------------|----------------------------------|------------|
-  | Per-frame `:on-error` policy fn      | In-app recovery / retry / mark   | rf2-hqbeh  |
-  | Corpus-wide listener registry        | Off-box observability shippers   | rf2-bacs4  |
-
-  Both paths are independent (one bad listener cannot affect the
-  policy fn; a policy-fn throw cannot affect listeners). Both paths
-  are wrapped in try/catch. Both paths are always-on; both survive
-  `:advanced` + `goog.DEBUG=false`.
-
-  ## Surface
-
-  - [[dispatch-on-error!]] — invoked by `router.cljc` on handler-
-    exception. Builds the tight error-record once, runs
-    `re-frame.elision/elide-wire-value` against `:event`, fans out
-    to BOTH the registered corpus-wide listeners AND the per-frame
-    `:on-error` policy. Each fan-out leg is independent and try/catch
-    wrapped per Spec 009 §1052.
-  - [[register-error-emit-listener!]]   — register a listener fn
-    under an id. Re-registering the same id replaces.
-  - [[unregister-error-emit-listener!]] — drop a listener by id.
-  - [[clear-error-emit-listeners!]]     — wipe the registry; test
-    isolation only.
-
-  ## Record shape (TIGHT — Spec 009)
-
-    {:error      <kw>        ;; e.g. :rf.error/handler-exception
-     :event      <vector>     ;; the dispatched event vector (elided)
-     :event-id   <kw>         ;; (first event)
-     :frame      <kw>         ;; resolved frame-id
-     :time       <millis>     ;; emit timestamp (host clock, ms since epoch)
-     :exception  <ex>         ;; the thrown exception object
-     :elapsed-ms <int>}       ;; wall-clock from queue → throw
-
-  No trace-bus keys (`:dispatch-id`, `:parent-dispatch-id`,
-  `:rf.trace/trigger-handler`, ...) — those ride the dev-only trace
-  surface and DCE under `:advanced` + `goog.DEBUG=false`. Listeners
-  that want them must run a `register-trace-cb!` listener too (dev-
-  only path).
-
-  ## goog.DEBUG framing
-
-  The substrate is always-on (no `goog.DEBUG` check inside this
-  namespace). Listener REGISTRATION sites SHOULD use `goog.DEBUG` as a
-  belt-and-braces gate alongside the user's explicit config flag, e.g.
-
-    (when (and (= \"production\" (:env config))
-               (not ^boolean re-frame.interop/debug-enabled?)
-               (:api-key config))
-      (rf/register-error-emit-listener!
-        :sentry/forward
-        (fn [error-record]
-          (sentry/capture-exception (:exception error-record)
-                                    {:tags {:event-id (:event-id error-record)
-                                            :frame    (:frame error-record)}}))))
-
-  Catches the 'accidentally deployed a dev bundle with prod config'
-  bug class — symmetric with rf2-rirbq's event-emit substrate.
-
-  ## Listener responsibilities
-
-  - Listeners are invoked synchronously after the handler exception is
-    surfaced. Keep bodies cheap; ship work to a background channel if
-    it cannot fit inside the drain step's wall-clock budget.
-  - Listeners receive an error-record whose `:event` vector has
-    ALREADY been passed through `re-frame.elision/elide-wire-value`
-    with off-box defaults (large values → `:rf.size/large-elided`
-    marker; sensitive values → `:rf/redacted`). Listeners SHOULD
-    NOT re-run elision unless they want to widen the policy.
-  - Exceptions raised by a listener are caught here; sibling
-    listeners still run and the per-frame `:on-error` policy fn
-    still fires. No retry, no recursive emit.
-
-  ## What this namespace deliberately does NOT do
-
-  - It does NOT allocate or push to the trace ring buffer.
-  - It does NOT fan out to `register-trace-cb!` listeners. Cross-frame
-    error observation through trace listeners remains a dev-only
-    surface (per Spec 009 §Subscription / consumption).
-  - It does NOT validate the return map's shape. Return-map validation
-    (`:rf.error/bad-on-error-return`) is itself a trace emission and
-    remains dev-side. Production callers should treat the policy fn's
-    return as advisory until the validation path is widened.
-  - It does NOT carry `:dispatch-id` / `:parent-dispatch-id` /
-    source-coord enrichment — those are trace-surface-only.
-
-  Per Spec 009 §Production debugging: this is the recommended way to
-  wire production error monitoring (Sentry, Honeybadger, Rollbar, …)
-  when full trace-surface preservation (`:closure-defines {goog.DEBUG
-  true}`) is undesirable for bundle-size reasons. Use the per-frame
-  `:on-error` slot for in-app recovery; use
-  [[register-error-emit-listener!]] for off-box observability."
-  (:require [re-frame.elision :as elision]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]))
+  Listener REGISTRATION sites SHOULD use `goog.DEBUG=false` as a
+  belt-and-braces gate alongside an explicit config flag. The
+  substrate proper carries no gate. Sibling to the event-emit
+  listener surface (rf2-rirbq); register both when forwarding to a
+  single hosted observability back-end."
+  (:require [re-frame.elision       :as elision]
+            [re-frame.emit-substrate :as emit]
+            [re-frame.frame         :as frame]
+            [re-frame.late-bind     :as late-bind]))
 
 ;; ---- listener registry ----------------------------------------------------
 
@@ -136,54 +49,26 @@
   ;; the consuming app registered at boot.
   (atom {}))
 
-(defn register-error-emit-listener!
-  "Register a listener `f` under `id`. The id can be any value usable
-  as a map key; re-registering under the same id replaces. `f`
-  receives a single error-record map (see ns docstring §Record
-  shape) and its return value is ignored. Returns `id`.
+(def ^:private registry
+  (emit/make-listener-registry {:listeners listeners}))
 
-  Always-on: the substrate is NOT gated on
-  `re-frame.interop/debug-enabled?`. Registration sites SHOULD still
-  use `goog.DEBUG=false` as a belt-and-braces gate around
-  production-only listeners — see the ns docstring §goog.DEBUG
-  framing.
+(def register-error-emit-listener!
+  "Register a listener `f` under `id`. Re-registering the same id
+  replaces. `f` receives a single error-record map (see ns docstring
+  §Record shape); its return value is ignored. Returns `id`. Per
+  rf2-bacs4."
+  (:register registry))
 
-  Per rf2-bacs4. Sibling of `rf/register-event-emit-listener!`
-  (rf2-rirbq); the two listener surfaces are independent — register
-  both when forwarding to a single hosted observability back-end."
-  [id f]
-  (swap! listeners assoc id f)
-  id)
+(def unregister-error-emit-listener!
+  "Drop the listener registered under `id`. Returns nil."
+  (:unregister registry))
 
-(defn unregister-error-emit-listener!
-  "Drop the listener registered under `id`. Returns nil. Per rf2-bacs4."
-  [id]
-  (swap! listeners dissoc id)
-  nil)
-
-(defn clear-error-emit-listeners!
+(def clear-error-emit-listeners!
   "Drop every registered listener. Test-isolation only; production
-  code should never call this. Returns nil. Per rf2-bacs4."
-  []
-  (reset! listeners {})
-  nil)
+  code should never call this. Returns nil."
+  (:clear registry))
 
-;; ---- fan-out --------------------------------------------------------------
-
-(defn- fan-out-listeners!
-  "Fan an elided error-record out to every registered listener.
-  Short-circuits to nil when the registry is empty so the per-error
-  hot-path cost reduces to one deref + an empty-map check. Listener
-  exceptions are caught — the cascade does NOT abort and sibling
-  listeners still run. Per rf2-bacs4."
-  [record]
-  (let [reg @listeners]
-    (when (seq reg)
-      (doseq [[_id f] reg]
-        (try
-          (f record)
-          (catch #?(:clj Throwable :cljs :default) _ nil)))))
-  nil)
+;; ---- emission -------------------------------------------------------------
 
 (defn- fire-on-error-policy!
   "Invoke the frame's `:on-error` policy fn with `error-event`. No-op
@@ -206,36 +91,21 @@
   enabled?`) — fires in CLJS production builds where the trace
   surface is elided.
 
-  Builds the tight error-record (Spec 009; rf2-bacs4 §Record shape)
-  ONCE, runs `re-frame.elision/elide-wire-value` against `:event`
-  with off-box defaults (large → `:rf.size/large-elided`;
-  sensitive → `:rf/redacted`), then fans out along two independent
-  paths:
+  Builds the tight error-record ONCE, runs
+  `re-frame.elision/elide-wire-value` against `:event` with off-box
+  defaults (large → `:rf.size/large-elided`; sensitive →
+  `:rf/redacted`), then fans out along two independent paths:
 
-    1. **Corpus-wide listener registry** (rf2-bacs4) — every fn
-       registered through [[register-error-emit-listener!]] receives
-       the elided tight record. Listener exceptions are caught;
-       siblings still run.
-
-    2. **Per-frame `:on-error` policy fn** (rf2-hqbeh) — the
-       frame's `:on-error` slot, when present, receives the
-       supplied `error-event` map (the legacy structured shape with
-       `:operation`/`:tags`/`:recovery` keys, used for in-app
-       recovery decisions). Policy-fn exceptions are caught per
+    1. Corpus-wide listener registry (rf2-bacs4) — emit-substrate
+       fan-out. Listener exceptions caught; siblings still run.
+    2. Per-frame `:on-error` policy fn (rf2-hqbeh) — receives the
+       supplied `error-event` map. Policy-fn exceptions caught per
        Spec 009 §1052.
 
-  Both fan-out paths are independent: a buggy listener cannot block
-  the policy fn, and a buggy policy fn cannot block listeners. The
-  runtime does NOT recursively invoke either path on its own
-  exception.
-
   Called by `router.cljc` from the handler-exception path. The
-  `start-ms` argument is the cascade-start wall-clock (already
-  captured for the event-emit substrate); the elapsed-ms is computed
-  here once at the substrate boundary, integer on both platforms per
-  the contract.
-
-  Returns nil."
+  `elapsed-ms` is the wall-clock from cascade-start to throw,
+  rounded to an integer at the substrate boundary per the contract
+  (mirrors rf2-ph8pa / rf2-rirbq). Returns nil."
   [error-kw event event-id frame-id exception elapsed-ms time error-event]
   (let [elided-event (elision/elide-wire-value event {:frame frame-id})
         record       {:error      error-kw
@@ -245,14 +115,13 @@
                       :time       time
                       :exception  exception
                       :elapsed-ms elapsed-ms}]
-    (fan-out-listeners! record)
+    ((:fan-out registry) record)
     (fire-on-error-policy! frame-id error-event))
   nil)
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
-;; `router.cljc` invokes `dispatch-on-error!` on the handler-exception
-;; path. It already statically `:require`s this namespace (per
+;; `router.cljc` already statically `:require`s this namespace (per
 ;; rf2-hqbeh; the substrate is a foundational always-on surface
 ;; alongside the router itself), so a late-bind hook isn't strictly
 ;; needed here. We publish one anyway for symmetry with rf2-rirbq's

--- a/implementation/core/src/re_frame/event_emit.cljc
+++ b/implementation/core/src/re_frame/event_emit.cljc
@@ -1,132 +1,33 @@
 (ns re-frame.event-emit
   "Always-on event-emit substrate for production observability
-  (Datadog, Sentry, Honeycomb, ...). Per rf2-rirbq / Spec 009 §What IS
-  available in production §Event-emit listener.
+  (Datadog, Sentry, Honeycomb, ...). Per rf2-rirbq / Spec 009
+  §What IS available in production §Event-emit listener.
 
-  ## Why this namespace exists
+  Survives `:advanced` + `goog.DEBUG=false`. Parallel to (not a
+  fallback for) the dev-only trace surface. One record per processed
+  event — NOT subs, NOT fxs, NOT `:event/db-changed`. Tight record
+  shape per Spec 009 §Event-emit listener §Record shape:
 
-  Spec 009's trace surface is compile-time elided in CLJS production
-  builds via `re-frame.interop/debug-enabled?` — see Spec 009
-  §Production builds. The chapter-22 recipe for forwarding events to a
-  hosted observability service used to ride `register-trace-cb!`; under
-  `:advanced` + `goog.DEBUG=false` that listener silently died with
-  the rest of the trace machinery. The escape hatches (flip
-  `goog.DEBUG=true` in prod, or fall back to the User Timing channel)
-  were unsatisfying — the first balloons the bundle and the second
-  drops the sensitive/large-elision composition that re-frame2
-  otherwise offers.
+    {:event       <vector>     ;; the dispatched event vector (elided)
+     :event-id    <kw>          ;; (first event)
+     :frame       <kw>          ;; resolved frame-id
+     :time        <millis>      ;; emit timestamp (host clock, ms)
+     :outcome     :ok | :error  ;; handler exception → :error
+     :elapsed-ms  <int>}        ;; wall-clock from queue → settle
 
-  This namespace carves a small **always-on** delivery path that
-  survives `goog.DEBUG=false`, *parallel* to (not a fallback for) the
-  trace surface. Two surfaces coexist:
+  Listener REGISTRATION sites SHOULD use `goog.DEBUG=false` as a
+  belt-and-braces gate alongside an explicit config flag. The
+  substrate proper carries no gate.
 
-    - Trace events (dev): `register-trace-cb!` listeners see every
-      `:event/dispatched`, `:event` (`:phase :run-start` /
-      `:run-end`), `:sub/run`, `:fx`, `:event/db-changed`,
-      `:rf.error/*`, etc. Production builds DCE the entire surface.
-    - Event-emit (always-on): `register-event-emit-listener!`
-      listeners see one record per processed *event* — NOT subs, NOT
-      fxs, NOT `:event/db-changed`, NOT registration metadata. The
-      record is intentionally tight (Spec 009 §Event-emit listener
-      §Record shape) so the hot-path cost is bounded and listeners
-      can ship the wire payload without further shaping. Production
-      builds preserve the surface.
-
-  ## Surface (tiny by design)
-
-  - [[register-event-emit-listener!]]   — register a listener fn under
-    an id. Re-registering the same id replaces.
-  - [[unregister-event-emit-listener!]] — drop a listener by id.
-  - [[clear-event-emit-listeners!]]     — wipe the registry; test
-    isolation only.
-  - [[dispatch-on-event!]]              — invoked by `router.cljc`
-    after each event settles. Builds the tight record, runs
-    `re-frame.elision/elide-wire-value` ONCE (with off-box defaults:
-    `:rf.size/include-large? false`, `:rf.size/include-sensitive?
-    false` — large values get the `:rf.size/large-elided` marker;
-    sensitive values get `:rf/redacted`), then fans the elided
-    record out to every registered listener. Each listener
-    invocation is wrapped in try/catch so a buggy listener cannot
-    break the cascade or other listeners. Published through the
-    late-bind hook `:event-emit/dispatch-on-event` so `router.cljc`
-    does NOT statically `:require` this namespace.
-
-  ## Record shape (TIGHT — Spec 009)
-
-    {:event       <vector>      ;; the dispatched event vector (elided)
-     :event-id    <kw>           ;; (first event)
-     :frame       <kw>           ;; resolved frame-id
-     :time        <millis>       ;; emit timestamp (host clock, ms since epoch)
-     :outcome     :ok | :error   ;; handler exception → :error
-     :elapsed-ms  <int>}         ;; wall-clock from queue → settle
-
-  No trace-bus keys (`:dispatch-id`, `:parent-dispatch-id`,
-  `:rf.trace/trigger-handler`, ...) — those ride the dev-only trace
-  surface and DCE under `:advanced` + `goog.DEBUG=false`.
-
-  ## goog.DEBUG framing
-
-  The substrate is always-on (no `goog.DEBUG` check inside this
-  namespace). Listener REGISTRATION sites SHOULD use `goog.DEBUG` as a
-  belt-and-braces gate alongside the user's explicit config flag, e.g.
-
-    (when (and (= \"production\" (:env config))
-               (not ^boolean re-frame.interop/debug-enabled?)
-               (:api-key config))
-      (rf/register-event-emit-listener!
-        :datadog/forward
-        (fn [event-record]
-          (datadog/track event-record))))
-
-  Catches the 'accidentally deployed a dev bundle with prod config'
-  bug class.
-
-  ## Listener responsibilities
-
-  - Listeners are invoked synchronously after each event settles. Keep
-    bodies cheap; ship work to a background channel if it cannot fit
-    inside the drain step's wall-clock budget.
-  - Listeners receive an event-record whose `:event` vector has
-    ALREADY been passed through `re-frame.elision/elide-wire-value`
-    with off-box defaults (large values → `:rf.size/large-elided`
-    marker; sensitive values → `:rf/redacted`). Listeners SHOULD
-    NOT re-run elision unless they want to widen the policy (e.g.
-    flip `:rf.size/include-digests? true` for a debug pipeline that
-    cares about content hashes).
-  - Exceptions raised by a listener are caught here; the other
-    listeners still run and the drain continues. No retry, no
-    recursive emit.
-
-  ## What this namespace deliberately does NOT do
-
-  - It does NOT push to the dev-only trace ring buffer.
-  - It does NOT carry `:dispatch-id` / `:parent-dispatch-id` /
-    source-coord enrichment — those are trace-surface-only.
-  - It does NOT emit per-sub, per-fx, or per-`:event/db-changed`
-    records — *only* events, per rf2-rirbq.
-  - It does NOT validate listener return values.
-
-  Per Spec 009 §Production debugging: the recommended way to wire
-  production *event* observability (Datadog, Honeycomb, custom
-  pipelines). For production *error* monitoring (Sentry, Rollbar,
-  Honeybadger, ...) prefer the parallel always-on substrate behind
-  the per-frame `:on-error` slot (per rf2-hqbeh /
-  `re-frame.error-emit`).
-
-  ## Handler-meta `:sensitive?` (rf2-6hklf)
-
-  Honoured at this boundary. If the event's registered handler-meta
-  carries `:sensitive? true`, `dispatch-on-event!` drops the record
-  entirely — listeners are NOT invoked. This matches the chapter-22
-  promise that flagging a handler `:sensitive?` is sufficient to keep
-  *every* one of its records out of production observability,
-  regardless of whether the payload happens to touch a sensitive
-  `:rf/elision`-registered app-db path. The narrower per-value
-  redaction (walker against `:rf/elision`) still applies to records
-  from non-sensitive handlers."
-  (:require [re-frame.elision  :as elision]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]))
+  Per rf2-6hklf: if the event's registered handler-meta carries
+  `:sensitive? true`, the record is dropped entirely (listeners are
+  NOT invoked). Per rf2-qsjda: `:rf.trace/no-emit? true` likewise
+  drops the record — framework-internal bookkeeping handlers
+  (Causa/Story) are not user-domain observable signal."
+  (:require [re-frame.elision       :as elision]
+            [re-frame.emit-substrate :as emit]
+            [re-frame.late-bind     :as late-bind]
+            [re-frame.registrar     :as registrar]))
 
 ;; ---- listener registry ----------------------------------------------------
 
@@ -136,99 +37,65 @@
   ;; the consuming app registered at boot.
   (atom {}))
 
-(defn register-event-emit-listener!
-  "Register a listener `f` under `id`. The id can be any value usable
-  as a map key; re-registering under the same id replaces. `f`
-  receives a single event-record map (see ns docstring §Record
-  shape) and its return value is ignored. Returns `id`.
+(def ^:private registry
+  (emit/make-listener-registry {:listeners listeners}))
 
-  Always-on: the substrate is NOT gated on
-  `re-frame.interop/debug-enabled?`. Registration sites SHOULD still
-  use `goog.DEBUG=false` as a belt-and-braces gate around
-  production-only listeners — see the ns docstring §goog.DEBUG
-  framing."
-  [id f]
-  (swap! listeners assoc id f)
-  id)
+(def register-event-emit-listener!
+  "Register a listener `f` under `id`. Re-registering the same id
+  replaces. `f` receives a single event-record map (see ns docstring
+  §Record shape); its return value is ignored. Returns `id`. Per
+  rf2-rirbq."
+  (:register registry))
 
-(defn unregister-event-emit-listener!
+(def unregister-event-emit-listener!
   "Drop the listener registered under `id`. Returns nil."
-  [id]
-  (swap! listeners dissoc id)
-  nil)
+  (:unregister registry))
 
-(defn clear-event-emit-listeners!
+(def clear-event-emit-listeners!
   "Drop every registered listener. Test-isolation only; production
   code should never call this. Returns nil."
-  []
-  (reset! listeners {})
-  nil)
+  (:clear registry))
+
+;; ---- emission -------------------------------------------------------------
 
 (defn dispatch-on-event!
   "Fan an elided event-record out to every registered listener.
-  Always-on (NOT gated by `re-frame.interop/debug-enabled?`) —
-  fires in CLJS production builds where the trace surface is
-  elided.
+  Always-on (NOT gated by `re-frame.interop/debug-enabled?`) — fires
+  in CLJS production builds where the trace surface is elided.
 
-  Short-circuits to a no-op when the registry is empty so the
-  per-event hot-path cost reduces to one deref + an empty-map
-  check.
+  Short-circuits to a no-op when the registry is empty (one deref +
+  empty-map check). Otherwise looks up the event's handler-meta and
+  drops the record when `:sensitive?` (rf2-6hklf) or
+  `:rf.trace/no-emit?` (rf2-qsjda) is set. Surviving records run
+  through `re-frame.elision/elide-wire-value` ONCE with off-box
+  defaults (large → `:rf.size/large-elided`; sensitive →
+  `:rf/redacted`), then fan out through the emit-substrate registry.
+  Listener exceptions are caught inside the registry's fan-out.
 
-  Builds the record from the supplied positional args, runs
-  `re-frame.elision/elide-wire-value` ONCE against the `:event`
-  vector with off-box defaults (large → `:rf.size/large-elided`;
-  sensitive → `:rf/redacted`), then fans the elided record out.
-
-  Listener exceptions are caught — the cascade does NOT abort
-  and sibling listeners still run. The runtime does NOT
-  recursively emit through this substrate on a listener throw.
-
-  Called by `router.cljc` once per processed event after the
-  cascade body settles (`:db` committed, flows run, `:fx`
-  walked). Published under the late-bind key
-  `:event-emit/dispatch-on-event` so the router does NOT
-  statically `:require` this namespace.
-
-  Per rf2-6hklf: if the event's registered handler-meta carries
-  `:sensitive? true`, the record is dropped entirely (listeners are
-  NOT invoked). The handler-meta lookup happens BEFORE the elision
-  walk so the sensitive-handler short-circuit costs no per-value
-  work.
-
-  Per rf2-qsjda: if the event's registered handler-meta carries
-  `:rf.trace/no-emit? true`, the record is also dropped. The flag
-  marks the handler as a framework-internal bookkeeping handler
-  (Spec 009 §Trace-emission opt-out) — its dispatches are not
-  user-domain observable signal. Production observability pipelines
-  should not see Causa/Story/etc. bookkeeping dispatches in their
-  event stream any more than they should see the trace events those
-  handlers suppress."
+  Called by `router.cljc` once per processed event after the cascade
+  body settles (`:db` committed, flows run, `:fx` walked). Published
+  under the late-bind key `:event-emit/dispatch-on-event` so the
+  router does NOT statically `:require` this namespace."
   [event event-id frame time outcome elapsed-ms]
-  (let [reg @listeners]
-    (when (seq reg)
-      (let [handler-meta (registrar/lookup :event event-id)]
-        (when-not (or (:sensitive?        handler-meta)
-                      (:rf.trace/no-emit? handler-meta))
-          (let [elided-event (elision/elide-wire-value event {:frame frame})
-                record       {:event      elided-event
-                              :event-id   event-id
-                              :frame      frame
-                              :time       time
-                              :outcome    outcome
-                              :elapsed-ms elapsed-ms}]
-            (doseq [[_id f] reg]
-              (try
-                (f record)
-                (catch #?(:clj Throwable :cljs :default) _ nil))))))))
+  (when (seq @listeners)
+    (let [handler-meta (registrar/lookup :event event-id)]
+      (when-not (or (:sensitive?        handler-meta)
+                    (:rf.trace/no-emit? handler-meta))
+        (let [elided-event (elision/elide-wire-value event {:frame frame})
+              record       {:event      elided-event
+                            :event-id   event-id
+                            :frame      frame
+                            :time       time
+                            :outcome    outcome
+                            :elapsed-ms elapsed-ms}]
+          ((:fan-out registry) record)))))
   nil)
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
-;; `router.cljc` invokes `dispatch-on-event!` once per processed
-;; event. To keep the substrate orthogonal to the trace surface
-;; (and to mirror how the rest of the late-bound surfaces ship),
-;; the router looks the fn up through the late-bind hook table at
-;; call time rather than `:require`ing this namespace directly.
-;; Per rf2-rirbq.
+;; `router.cljc` invokes `dispatch-on-event!` once per processed event.
+;; The router looks the fn up through the late-bind hook table at call
+;; time rather than `:require`ing this namespace directly. Per
+;; rf2-rirbq.
 
 (late-bind/set-fn! :event-emit/dispatch-on-event dispatch-on-event!)


### PR DESCRIPTION
## Summary

Per audit finding EE1/A4 of rf2-spr6q. `error_emit.cljc` (263 L) and `event_emit.cljc` (234 L) were ~75% parallel — `defonce` listener atom, `register/unregister/clear` fan-out, per-emit short-circuit on empty registry, try/catch wrapped listener invocation.

- New `re-frame.emit-substrate` ns exposes `make-listener-registry` returning a `{:listeners :register :unregister :clear :fan-out}` map. Caller passes its own `defonce` atom so hot-reload semantics survive.
- `event-emit` and `error-emit` become thin wrappers — registration fns are aliases for the registry surface; `dispatch-on-*` fns retain substrate-specific concerns (handler-meta gating for event-emit; tight error-record build + per-frame `:on-error` policy fan-out for error-emit).
- Trims ~200 L of design-history docstring per TR3 (one paragraph + spec link, normative concerns retained).

**LoC delta: 497 -> 292 (-205, -41%).** Pre-alpha, no back-compat needed; existing `event_emit_test` / `on_error_test` suites verify correctness.

The "third emit-substrate" (machine-lifecycle, frame-lifecycle, …) now becomes a single instantiation.

## Test plan

- [x] `npm run test:cljs` (node-runtime CLJS): 1792 tests, 4975 assertions, 0 failures / 0 errors
- [x] `clojure -M:test` from `implementation/core/` (JVM): 456 tests, 2436 assertions, 0 failures / 0 errors