### PR TITLE
refactor(pair2-mcp): cleanup small smells per audit (rf2-ambfv)

### DIFF
--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/nrepl.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/nrepl.cljs
@@ -187,6 +187,13 @@
 
 (defn- new-id [] (str (random-uuid)))
 
+(def ^:private default-timeout-ms
+  "Per-op timeout when the caller doesn't override. 30s is generous
+  for shadow-cljs cljs-eval round-trips; heavy forms (e.g. a
+  trace-window walk over the full epoch ring under load) can pass
+  `:timeout-ms` for longer."
+  30000)
+
 (defn send-op!
   "Send a single nREPL op over the persistent socket. `op-map` is a
   bencode-able map like `{\"op\" \"eval\" \"code\" \"...\"}`. Returns a
@@ -194,20 +201,32 @@
   once a frame with `\"status\":[\"done\"]` arrives for this id.
 
   Auto-(re)connects if the socket has dropped. Caller manages the
-  reinjection sentinel — see `tools.cljs`."
-  [conn-atom op-map]
+  reinjection sentinel — see `tools.cljs`.
+
+  ## Options (rf2-ambfv)
+
+  Optional second arg:
+
+      :timeout-ms <ms>  per-op deadline. Defaults to
+                        `default-timeout-ms` (30s). Heavy forms can
+                        raise this rather than collapsing under the
+                        generic ceiling."
+  ([conn-atom op-map] (send-op! conn-atom op-map nil))
+  ([conn-atom op-map {:keys [timeout-ms]}]
   (-> (connect! conn-atom)
       (.then
         (fn [_]
           (js/Promise.
             (fn [resolve reject]
-              (let [id     (new-id)
-                    state  (atom {:out "" :err "" :status #{} :value nil :ex nil})
-                    timer  (js/setTimeout
-                             (fn []
-                               (swap! conn-atom update :pending dissoc id)
-                               (reject (js/Error. (str "nREPL op " (j/get op-map "op") " timed out after 30s"))))
-                             30000)
+              (let [id        (new-id)
+                    state     (atom {:out "" :err "" :status #{} :value nil :ex nil})
+                    deadline  (or timeout-ms default-timeout-ms)
+                    timer     (js/setTimeout
+                                (fn []
+                                  (swap! conn-atom update :pending dissoc id)
+                                  (reject (js/Error. (str "nREPL op " (j/get op-map "op")
+                                                          " timed out after " deadline "ms"))))
+                                deadline)
                     on-frame
                     (fn [^js frame]
                       (let [v   (j/get frame "value")
@@ -229,7 +248,7 @@
                 (let [op (j/assoc! (clj->js op-map) "id" id)
                       ^js sock (:socket @conn-atom)]
                   (.write sock (bencode/encode op))))))))
-      (.catch (fn [err] (js/Promise.reject err)))))
+      (.catch (fn [err] (js/Promise.reject err))))))
 
 ;; ---------------------------------------------------------------------------
 ;; nREPL → CLJS eval bridge (mirrors ops.clj's cljs-eval / cljs-eval-value).
@@ -237,20 +256,24 @@
 
 (defn jvm-eval
   "Evaluate a Clojure form on the JVM side of nREPL. Returns a Promise
-  resolving to a combined response map."
-  [conn-atom form-str]
-  (send-op! conn-atom {"op" "eval" "code" form-str}))
+  resolving to a combined response map. Optional `opts` passes
+  through to [[send-op!]] (e.g. `{:timeout-ms 60000}`)."
+  ([conn-atom form-str] (jvm-eval conn-atom form-str nil))
+  ([conn-atom form-str opts]
+   (send-op! conn-atom {"op" "eval" "code" form-str} opts)))
 
 (defn cljs-eval
   "Evaluate a ClojureScript form through shadow-cljs's `cljs-eval` API.
-  Returns a Promise resolving to a combined response map."
-  [conn-atom build-id form-str]
-  (let [build-pr  (if (keyword? build-id) (str build-id) (str ":" (name (or build-id :app))))
-        ;; pr-str CLJS form: use double-quote-escaped string literal.
-        code-pr   (pr-str form-str)
-        wrapped   (str "(shadow.cljs.devtools.api/cljs-eval "
-                       build-pr " " code-pr " {})")]
-    (jvm-eval conn-atom wrapped)))
+  Returns a Promise resolving to a combined response map. Optional
+  `opts` (e.g. `{:timeout-ms 60000}`) tunes the per-op deadline."
+  ([conn-atom build-id form-str] (cljs-eval conn-atom build-id form-str nil))
+  ([conn-atom build-id form-str opts]
+   (let [build-pr  (if (keyword? build-id) (str build-id) (str ":" (name (or build-id :app))))
+         ;; pr-str CLJS form: use double-quote-escaped string literal.
+         code-pr   (pr-str form-str)
+         wrapped   (str "(shadow.cljs.devtools.api/cljs-eval "
+                        build-pr " " code-pr " {})")]
+     (jvm-eval conn-atom wrapped opts))))
 
 (defn- read-edn-safe [s]
   (try (edn/read-string s) (catch :default _ s)))
@@ -262,9 +285,13 @@
   and read it as EDN.
 
   Returns a Promise resolving to the unwrapped value (or rejecting
-  with an Error if the eval threw or returned an error map)."
-  [conn-atom build-id form-str]
-  (-> (cljs-eval conn-atom build-id form-str)
+  with an Error if the eval threw or returned an error map). Optional
+  `opts` (e.g. `{:timeout-ms 60000}`) tunes the per-op deadline —
+  heavy forms (full-epoch-ring walks) can raise it past the 30s
+  default."
+  ([conn-atom build-id form-str] (cljs-eval-value conn-atom build-id form-str nil))
+  ([conn-atom build-id form-str opts]
+  (-> (cljs-eval conn-atom build-id form-str opts)
       (.then
         (fn [resp]
           (cond
@@ -287,4 +314,4 @@
                 (js/Promise.reject
                   (js/Error. (str "cljs eval error: " (:err outer))))
 
-                :else outer)))))))
+                :else outer))))))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/server.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/server.cljs
@@ -81,32 +81,60 @@
 ;; Server boot.
 ;; ---------------------------------------------------------------------------
 
+(defn build-server
+  "Build an MCP `Server` instance with `tools/list` wired to the static
+  descriptors and `tools/call` routed to `call-handler` (a `(req,
+  extra) → Promise<result>` fn). Shared by the success-path boot and
+  the degraded-mode boot (rf2-ambfv) so the two share one Server
+  shape — a future descriptor / capability change lands once."
+  [call-handler]
+  (let [Server          (j/get mcp-server :Server)
+        ListToolsSchema (j/get mcp-types :ListToolsRequestSchema)
+        CallToolSchema  (j/get mcp-types :CallToolRequestSchema)
+        server          (Server.
+                          #js {:name server-name :version server-version}
+                          #js {:capabilities #js {:tools #js {}}})]
+    (j/call server :setRequestHandler ListToolsSchema handle-list)
+    (j/call server :setRequestHandler CallToolSchema call-handler)
+    server))
+
 (defn boot!
   "Build the MCP server, register handlers, and return it. Exposed for
   tests so they can drive the dispatcher without taking over stdin/out."
   [conn]
-  (let [Server          (j/get mcp-server :Server)
-        ListToolsSchema (j/get mcp-types :ListToolsRequestSchema)
-        CallToolSchema  (j/get mcp-types :CallToolRequestSchema)
-        server (Server.
-                 #js {:name server-name :version server-version}
-                 #js {:capabilities #js {:tools #js {}}})]
-    (j/call server :setRequestHandler ListToolsSchema handle-list)
-    (j/call server :setRequestHandler CallToolSchema
-            (fn [req extra] (handle-call conn req extra)))
-    server))
+  (build-server (fn [req extra] (handle-call conn req extra))))
+
+(defn- connect-transport!
+  "Connect `server` to a fresh stdio transport. Logs `ready-msg` on
+  success; logs and exits on transport-connect failure."
+  [server ready-msg]
+  (let [StdioTransport (j/get mcp-stdio :StdioServerTransport)]
+    (-> (j/call server :connect (StdioTransport.))
+        (.then (fn [_] (log! ready-msg)))
+        (.catch (fn [err]
+                  (log! "transport.connect failed:" (.-message err))
+                  (js/process.exit 1))))))
+
+(defn- degraded-handler
+  "Build a `tools/call` handler that surfaces the boot-error structurally
+  on every call. Used when the nREPL port couldn't be resolved — the
+  MCP client can still discover tools and gets a typed error on first
+  invocation rather than a transport-level failure."
+  [boot-error]
+  (fn [_req]
+    (js/Promise.resolve
+      #js {:isError true
+           :content #js [#js {:type "text"
+                              :text (pr-str {:ok? false
+                                             :reason :nrepl-port-not-found
+                                             :hint   (-> boot-error ex-data :hint)})}]})))
 
 (defn main [& _args]
   (try
     (let [conn   (new-conn)
-          server (boot! conn)
-          StdioTransport (j/get mcp-stdio :StdioServerTransport)]
+          server (boot! conn)]
       (log! "starting stdio transport")
-      (-> (j/call server :connect (StdioTransport.))
-          (.then (fn [_] (log! "ready — awaiting MCP frames on stdin")))
-          (.catch (fn [err]
-                    (log! "transport.connect failed:" (.-message err))
-                    (js/process.exit 1)))))
+      (connect-transport! server "ready — awaiting MCP frames on stdin"))
     (catch :default e
       (log! "boot failed:" (.-message e))
       ;; Even on boot failure (e.g. nREPL port missing) we keep the
@@ -114,23 +142,5 @@
       ;; and surface a structured error from the first tool call. The
       ;; bash-shim chain had the same semantics — the error came back
       ;; as `{:ok? false :reason :nrepl-port-not-found}`.
-      (let [Server          (j/get mcp-server :Server)
-            ListToolsSchema (j/get mcp-types :ListToolsRequestSchema)
-            CallToolSchema  (j/get mcp-types :CallToolRequestSchema)
-            StdioTransport  (j/get mcp-stdio :StdioServerTransport)
-            server (Server. #js {:name server-name :version server-version}
-                            #js {:capabilities #js {:tools #js {}}})]
-        (j/call server :setRequestHandler ListToolsSchema handle-list)
-        (j/call server :setRequestHandler CallToolSchema
-          (fn [_req]
-            (js/Promise.resolve
-              #js {:isError true
-                   :content #js [#js {:type "text"
-                                      :text (pr-str {:ok? false
-                                                     :reason :nrepl-port-not-found
-                                                     :hint (-> e ex-data :hint)})}]})))
-        (-> (j/call server :connect (StdioTransport.))
-            (.then (fn [_] (log! "ready (degraded — no nREPL port)")))
-            (.catch (fn [err]
-                      (log! "transport.connect failed:" (.-message err))
-                      (js/process.exit 1))))))))
+      (let [server (build-server (degraded-handler e))]
+        (connect-transport! server "ready (degraded — no nREPL port)")))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/args.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/args.cljs
@@ -40,27 +40,25 @@
 (defn coerce-path-segment
   "Coerce one segment of a JS-array path argument.
 
-  Heuristic: an EDN-shaped string is parsed (`\":cart\"` ⇒ `:cart`,
-  `\"0\"` ⇒ `0`, `\"-1\"` ⇒ `-1`), but a bare identifier
-  (`\"items\"`, `\"bare-key\"`) stays a string — the default reader
-  would otherwise coerce it to a symbol, which is a different
-  `get-in` key. Trigger characters are the EDN literal openers `:`
-  (keyword), a leading digit, or `-`/`+` (signed number); anything
-  else falls through as a plain string."
+  Try `read-string`; on any failure (the bare identifier case —
+  `\"items\"` would otherwise read as a symbol, which is the wrong
+  `get-in` key) fall through as the original string. `read-string`
+  parses EDN literals (`\":cart\"` ⇒ `:cart`, `\"0\"` ⇒ `0`,
+  `\"-1\"` ⇒ `-1`) and rejects anything else, so the catch-fallback
+  IS the discriminator — no first-char heuristic needed."
   [s]
   (if-not (string? s)
     s
-    (let [trimmed   (str/trim s)
-          fc        (when (pos? (count trimmed)) (.charAt trimmed 0))
-          edn-shape (and fc
-                         (or (= ":" fc)
-                             (= "-" fc)
-                             (= "+" fc)
-                             (boolean (re-matches #"\d" fc))))]
-      (if edn-shape
-        (try (cljs.reader/read-string trimmed)
-             (catch :default _ s))
-        s))))
+    (let [trimmed (str/trim s)
+          parsed  (try (cljs.reader/read-string trimmed)
+                       (catch :default _ ::reader-fail))]
+      (cond
+        (= ::reader-fail parsed) s
+        ;; Symbols are the reader's "bare identifier" outcome — not a
+        ;; valid `get-in` key on a map keyed by strings or keywords;
+        ;; keep the original string instead so `{"items" ...}` works.
+        (symbol? parsed)         s
+        :else                    parsed))))
 
 (defn parse-path-arg
   "Normalise the `path` MCP arg into a CLJS vector suitable for

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/dedup.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/dedup.cljs
@@ -110,14 +110,8 @@
     (let [cache (dedup/de-dupe-eq v)]
       {base-vocab/dedup-table-key cache})))
 
-(defn dedup-expand
-  "Reverse `dedup-value`. Given a value possibly wrapped in the
-  `:rf.mcp/dedup-table` marker, reconstruct the original structure
-  via `de-dupe.core/expand`. Idempotent on already-expanded values
-  (the marker check returns the input unchanged when the wrapper
-  isn't present). Provided for round-trip parity and for the unit
-  tests; the agent host can call the same shape locally."
-  [v]
-  (if (and (map? v) (contains? v base-vocab/dedup-table-key))
-    (dedup/expand (get v base-vocab/dedup-table-key))
-    v))
+;; `dedup-expand` (the inverse of `dedup-value`) has moved to
+;; `re-frame-pair2-mcp.test-utils/dedup-expand` (rf2-ambfv). It's
+;; never called by the MCP server itself — only by tests asserting
+;; round-trip exactness. The agent host calls `de-dupe.core/expand`
+;; directly on the wire payload.

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs
@@ -44,13 +44,10 @@
             [re-frame-pair2-mcp.tools.subscribe-emit :as emit]))
 
 (def ^:private default-poll-ms 100)
-(def ^:private default-max-buffered-events 500)
-(def ^:private default-max-buffered-bytes
-  ;; ~5 MB — see runtime.cljs's identical default for the rationale.
-  ;; Mirrored here so the MCP server can fill in the slot before the
-  ;; nREPL call if the caller omits it; the runtime still applies the
-  ;; same default if the slot is `nil`.
-  5000000)
+;; `:max-buffered-events` / `:max-buffered-bytes` are NOT mirrored here
+;; (rf2-ambfv): the runtime applies its own defaults when the slot is
+;; nil, and mirroring forces a two-file sync on every runtime tweak
+;; (e.g. rf2-ho4ve raising the byte cap). Pass nil → runtime defaults.
 
 (def ^:private initial-state
   "The rolling per-stream accounting map (rf2-w5etd). Held inside one
@@ -181,10 +178,8 @@
   (let [build-id           (wire/arg-build raw-args)
         topic              (some-> (wire/arg raw-args :topic) keyword)
         filter-map         (args/parse-filter-arg (wire/arg raw-args :filter))
-        max-buf-events     (or (wire/arg raw-args :max-buffered-events)
-                               default-max-buffered-events)
-        max-buf-bytes      (or (wire/arg raw-args :max-buffered-bytes)
-                               default-max-buffered-bytes)
+        max-buf-events     (wire/arg raw-args :max-buffered-events)
+        max-buf-bytes      (wire/arg raw-args :max-buffered-bytes)
         poll-ms            (or (wire/arg raw-args :poll-ms) default-poll-ms)
         max-ms             (or (wire/arg raw-args :max-ms) 0)
         max-events         (or (wire/arg raw-args :max-events) 0)
@@ -203,10 +198,13 @@
       (let [subscribe-form
             (ef/emit
               (ef/rt-call 'subscribe!
-                          (cond-> {:topic               topic
-                                   :max-buffered-events max-buf-events
-                                   :max-buffered-bytes  max-buf-bytes}
-                            filter-map (assoc :filter filter-map))))]
+                          ;; Only inline slots the caller actually
+                          ;; supplied — the runtime applies its own
+                          ;; defaults for absent budget knobs (rf2-ambfv).
+                          (cond-> {:topic topic}
+                            max-buf-events (assoc :max-buffered-events max-buf-events)
+                            max-buf-bytes  (assoc :max-buffered-bytes  max-buf-bytes)
+                            filter-map     (assoc :filter              filter-map))))]
         (-> (probe/ensure-runtime! conn build-id)
             (.then (fn [_] (nrepl/cljs-eval-value conn build-id subscribe-form)))
             (.then

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscription_info.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscription_info.cljs
@@ -25,27 +25,30 @@
             [re-frame-pair2-mcp.tools.wire :as wire]
             [re-frame-pair2-mcp.tools.probe :as probe]))
 
+(defn- filter-form
+  "Build the per-sub `filterv` body — `subs` when no filters apply, a
+  one-predicate `filterv` when exactly one, an `and`-combined chain
+  when both. The form is composed Clojure-side (rf2-ambfv) so the
+  runtime never sees `(if nil ...)` no-op branches for absent
+  filters."
+  [topic sub-id]
+  (let [preds (cond-> []
+                topic  (conj (str "(= (:topic %) " (pr-str topic) ")"))
+                sub-id (conj (str "(= (:id %) "    (pr-str sub-id) ")")))]
+    (case (count preds)
+      0 "subs"
+      1 (str "(filterv #" (first preds) " subs)")
+      (str "(filterv #(and " (str/join " " preds) ") subs)"))))
+
 (defn subscription-info-tool [conn args]
   (let [build-id (wire/arg-build args)
         topic    (some-> (wire/arg args :topic) keyword)
         sub-id   (wire/arg args :sub-id)
-        ;; Build the filter chain Clojure-side (audit T19): only inline
-        ;; the predicates that actually apply, so the runtime sees the
-        ;; minimum form. The pre-DSL shape always shipped both `(if
-        ;; topic ... subs)` branches even when the slot was nil — wasted
-        ;; bytes the runtime then no-op'd.
-        preds    (cond-> []
-                   topic  (conj (str "(= (:topic %) " (pr-str topic) ")"))
-                   sub-id (conj (str "(= (:id %) "    (pr-str sub-id) ")")))
-        filtered (case (count preds)
-                   0 "subs"
-                   1 (str "(filterv #" (first preds) " subs)")
-                   (str "(filterv #(and " (str/join " " preds) ") subs)"))
         form     (ef/emit
                    (ef/rt-let ['r    (ef/rt-call 'subscription-info)
                                'subs (ef/rt-raw "(:subs r)")]
                               (ef/rt-raw
-                                (str "(assoc r :subs " filtered ")"))))]
+                                (str "(assoc r :subs " (filter-form topic sub-id) ")"))))]
     (-> (probe/ensure-runtime! conn build-id)
         (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
         (.then (fn [v] (wire/ok-text (if (map? v) v {:ok? true :subs []}))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/summary.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/summary.cljs
@@ -33,7 +33,11 @@
   over the top-level structure, no deep walk. The marker itself is
   bounded: long key lists are truncated to `summary-keys-cap` entries
   and flagged via `:keys-truncated? true` so the marker can never
-  blow the wire cap."
+  blow the wire cap.
+
+  Scalars are returned unchanged (rf2-ambfv): they already fit the
+  wire cap by definition, so wrapping them in a summary marker would
+  add tokens without saving any."
   [v]
   (cond
     (map? v)
@@ -60,10 +64,7 @@
     {:rf.mcp/summary {:type  :seq
                       :count (count v)
                       :bytes (count (pr-str v))}}
-    :else
-    {:rf.mcp/summary {:type  :scalar
-                      :value v
-                      :bytes (count (pr-str v))}}))
+    :else v))
 
 (defn deepest-valid-prefix
   "Walk `path` against `db` and return the deepest prefix that

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/dedup_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/dedup_test.cljs
@@ -11,7 +11,7 @@
 
   Tests pin the public helpers directly from their owning namespaces:
   `tools.dedup/parse-dedup-arg`, `tools.dedup/empty-payload?`,
-  `tools.dedup/dedup-value`, `tools.dedup/dedup-expand`,
+  `tools.dedup/dedup-value`, `test-utils/dedup-expand`,
   `tools.snapshot-pipeline/dedup-epochs-in-snapshot`. A rename or
   signature change surfaces as a failing test rather than a silent
   contract drift.
@@ -22,7 +22,8 @@
   reduction-ratio sanity check."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [re-frame-pair2-mcp.tools.dedup :as dedup]
-            [re-frame-pair2-mcp.tools.snapshot-pipeline :as pipeline]))
+            [re-frame-pair2-mcp.tools.snapshot-pipeline :as pipeline]
+            [re-frame-pair2-mcp.test-utils :as tu]))
 
 ;; ---------------------------------------------------------------------------
 ;; parse-dedup-arg — MCP-arg normalisation.
@@ -120,14 +121,14 @@
                  {:id 2 :payload shared}
                  {:id 3 :payload shared}]
         wrapped (dedup/dedup-value payload true)
-        restored (dedup/dedup-expand wrapped)]
+        restored (tu/dedup-expand wrapped)]
     (is (= payload restored))))
 
 (deftest round-trip-already-expanded-is-noop
   ;; A payload that was never deduped (caller passed `dedup false`)
   ;; round-trips identity through expand.
   (let [payload [{:a 1} {:b 2}]]
-    (is (= payload (dedup/dedup-expand payload)))))
+    (is (= payload (tu/dedup-expand payload)))))
 
 (deftest round-trip-nested-shared-subtrees
   ;; The load-bearing case: epoch slice where every record carries
@@ -144,13 +145,13 @@
                                    :patches [[[(keyword (str "k" i)) :v]
                                               :assoc (str "new-" i)]]}}))
         wrapped (dedup/dedup-value epochs true)
-        restored (dedup/dedup-expand wrapped)]
+        restored (tu/dedup-expand wrapped)]
     (is (= epochs restored))))
 
 (deftest round-trip-empty-collections-inside-payload
   (let [payload [{:items [] :state {}} {:items [] :state {}}]
         wrapped (dedup/dedup-value payload true)
-        restored (dedup/dedup-expand wrapped)]
+        restored (tu/dedup-expand wrapped)]
     (is (= payload restored))))
 
 (deftest round-trip-deeply-nested-uniform-records
@@ -162,7 +163,7 @@
                 :ui {:loading? false :error nil}}
         payload (vec (repeat 50 record))
         wrapped (dedup/dedup-value payload true)
-        restored (dedup/dedup-expand wrapped)]
+        restored (tu/dedup-expand wrapped)]
     (is (= payload restored))
     (is (= 50 (count restored)))))
 
@@ -210,7 +211,7 @@
                ") should be < 50% of raw (" raw-size
                "). Ratio: " (/ wrapped-size raw-size 1.0))))
     (testing "round-trip still reconstructs every epoch"
-      (let [restored (dedup/dedup-expand wrapped)]
+      (let [restored (tu/dedup-expand wrapped)]
         (is (= epochs restored))))))
 
 ;; ---------------------------------------------------------------------------
@@ -227,7 +228,7 @@
   ;; ships only the root entry; round-trip still exact.
   (let [payload [{:a 1} {:b 2} {:c 3}]
         wrapped (dedup/dedup-value payload true)
-        restored (dedup/dedup-expand wrapped)]
+        restored (tu/dedup-expand wrapped)]
     (is (= payload restored))))
 
 (deftest edge-case-one-big-repeated-subtree
@@ -237,7 +238,7 @@
                           [(keyword (str "k" i)) i]))
         payload (vec (repeat 20 shared))
         wrapped (dedup/dedup-value payload true)
-        restored (dedup/dedup-expand wrapped)]
+        restored (tu/dedup-expand wrapped)]
     (is (= payload restored))
     (is (= 20 (count restored)))
     (is (every? #(= shared %) restored))))
@@ -297,7 +298,7 @@
                    (fn [m fid fmap]
                      (assoc m fid
                             (if (contains? fmap :epochs)
-                              (update fmap :epochs dedup/dedup-expand)
+                              (update fmap :epochs tu/dedup-expand)
                               fmap)))
                    {}
                    wrapped)]

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/path_slicing_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/path_slicing_test.cljs
@@ -109,12 +109,15 @@
     (is (< (cap/token-estimate (pr-str marker)) 5000)
         "Marker for a 5k-entry map MUST still fit the wire cap")))
 
-(deftest tree-summary-scalar-keeps-the-value
-  ;; Scalars are cheap; summarising would lose information without
-  ;; saving any tokens.
-  (let [marker (:rf.mcp/summary (summary/tree-summary 42))]
-    (is (= :scalar (:type marker)))
-    (is (= 42 (:value marker)))))
+(deftest tree-summary-scalar-returns-value-unchanged
+  ;; rf2-ambfv: scalars already fit the wire cap by definition, so
+  ;; wrapping them in a summary marker would add tokens without saving
+  ;; any. The fn returns the scalar unchanged — no `:rf.mcp/summary`
+  ;; wrapper, no `:type :scalar` marker.
+  (is (= 42 (summary/tree-summary 42)))
+  (is (= "hello" (summary/tree-summary "hello")))
+  (is (= :a-keyword (summary/tree-summary :a-keyword)))
+  (is (nil? (summary/tree-summary nil))))
 
 ;; ---------------------------------------------------------------------------
 ;; deepest-valid-prefix — the error-recovery breadcrumb.

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/test_utils.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/test_utils.cljs
@@ -1,0 +1,26 @@
+(ns re-frame-pair2-mcp.test-utils
+  "Shared test helpers (rf2-ambfv).
+
+  Home for fns that only the test corpus uses but that conceptually
+  sit alongside the production code. Today's resident is
+  `dedup-expand` — the inverse of `tools.dedup/dedup-value`, useful
+  to assert round-trip exactness against an MCP-shaped wire payload
+  without growing the production surface.
+
+  Why not in `tools.dedup`: the agent host receives the deduped
+  payload and reconstructs locally via `de-dupe.core/expand` directly
+  — the MCP server never calls the inverse. Moving the helper here
+  keeps the production ns minimal and signals \"test-only\" by
+  location."
+  (:require [de-dupe.core :as dedup]
+            [re-frame.mcp-base.vocab :as base-vocab]))
+
+(defn dedup-expand
+  "Reverse `tools.dedup/dedup-value`. Given a value possibly wrapped in
+  the `:rf.mcp/dedup-table` marker, reconstruct the original structure
+  via `de-dupe.core/expand`. Idempotent on already-expanded values
+  (returns the input unchanged when the wrapper isn't present)."
+  [v]
+  (if (and (map? v) (contains? v base-vocab/dedup-table-key))
+    (dedup/expand (get v base-vocab/dedup-table-key))
+    v))


### PR DESCRIPTION
## Summary

Seven small surgical cleanups identified by the audit (rf2-7hie3, §T11/T26/T21/T19/T25/N3/S1). None individually justified a bead; together they're a meaningful polish pass on the post-split surface (rf2-vrbwx + cluster).

1. **`coerce-path-segment` heuristic** (args.cljs) — dropped the first-char EDN-trigger heuristic; `read-string` is tried unconditionally and falls through on catch. Symbols (bare identifiers) still fall back to the original string so `{"items" ...}` keys work.

2. **Stop mirroring `default-max-buffered-{bytes,events}`** (subscribe.cljs) — the runtime applies the same defaults when slots are nil; mirroring forced two-file sync on every runtime tweak. The `subscribe!` form now only inlines slots the caller supplied.

3. **`tree-summary` scalar arm** (summary.cljs) — return the scalar unchanged. A scalar already fits the wire cap; the `{:rf.mcp/summary {:type :scalar :value v}}` wrapper added tokens without saving any.

4. **`subscription-info` filter form** (subscription_info.cljs) — extracted `filter-form` helper; predicate chain built Clojure-side so the runtime never sees `(if nil ...)` no-op branches for absent filters.

5. **`dedup-expand` moved to test-utils** (dedup.cljs → test_utils.cljs) — the fn was `defn` but never called outside tests; the MCP server never reverses dedup (the agent host does).

6. **`send-op!` timeout configurable** (nrepl.cljs) — accept `:timeout-ms` opt (default 30s). Heavy forms can raise it. `jvm-eval`, `cljs-eval`, `cljs-eval-value` thread the opts through.

7. **server.cljs degraded-boot extraction** — extracted `build-server`, `connect-transport!`, `degraded-handler`. Success path and degraded fallback now share one Server shape.

## Test plan

- [x] `npm test` from `tools/pair2-mcp/` — 289 tests, 688 assertions, 0 failures, 0 errors.
- [x] `tree-summary` scalar-arm test updated to assert pass-through.
- [x] `dedup_test.cljs` updated to import `dedup-expand` from `test-utils`.

Closes rf2-ambfv.