### PR TITLE
fix(ssr): ld-json-string preserves keyword namespaces in map keys (rf2-a50nz)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/head.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head.cljc
@@ -123,8 +123,14 @@
 (defn- ld-json-string
   "Serialise a JSON-LD object map to its `<script type=\"application/ld+json\">`
   body. CLJ uses a minimal printer (works for the spec's canonical shape:
-  strings, numbers, booleans, vectors, maps with string keys). CLJS uses
-  `js/JSON.stringify` via `clj->js`."
+  strings, numbers, booleans, vectors, maps with string and/or keyword
+  keys). CLJS uses `js/JSON.stringify` via `clj->js`.
+
+  On the JVM side, keyword keys and keyword values are both serialised
+  to their fully-qualified name — `:my.app/foo` → `\"my.app/foo\"` — so
+  namespaces survive serialisation. The key and value handling are
+  symmetric; rf2-a50nz fixed an earlier asymmetry that quietly stripped
+  the namespace prefix off keys."
   [x]
   #?(:cljs (js/JSON.stringify (clj->js x))
      :clj  (letfn [(emit [v]
@@ -140,9 +146,12 @@
                        (keyword? v) (emit (if-let [ns (namespace v)]
                                             (str ns "/" (name v))
                                             (name v)))
+                       ;; Keyword keys delegate to the keyword branch above
+                       ;; so namespaces are preserved — fixes the asymmetric
+                       ;; key/value handling reported in rf2-a50nz.
                        (map? v)     (str "{"
                                          (str/join "," (map (fn [[k val]]
-                                                              (str (emit (if (keyword? k) (name k) k))
+                                                              (str (emit k)
                                                                    ":"
                                                                    (emit val)))
                                                             v))

--- a/implementation/ssr/test/re_frame/ssr_head_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_head_test.clj
@@ -258,6 +258,26 @@
       (is (str/includes? html "\"@type\":\"Article\""))
       (is (str/includes? html "\"headline\":\"Hello\"")))))
 
+(deftest head-model->html-json-ld-preserves-keyword-namespaces
+  (testing "rf2-a50nz — keyword map keys retain their namespace when
+            serialised; the printer's key and value handling are symmetric.
+            A user supplying `{:my.app/key \"value\"}` must see
+            `\"my.app/key\":\"value\"` in the rendered JSON-LD."
+    (let [html (rf/head-model->html
+                 {:json-ld [{:my.app/key "value"
+                             :unqualified "v2"}]})]
+      (is (str/includes? html "\"my.app/key\":\"value\"")
+          "namespaced keyword key preserves its namespace")
+      (is (str/includes? html "\"unqualified\":\"v2\"")
+          "unqualified keyword key still serialises as a bare name"))
+    (testing "keyword values continue to preserve namespace (regression
+              guard against accidental asymmetry resurfacing)"
+      (let [html (rf/head-model->html
+                   {:json-ld [{"@type" :schema/Article
+                               :my.app/headline :my.app/hello}]})]
+        (is (str/includes? html "\"@type\":\"schema/Article\""))
+        (is (str/includes? html "\"my.app/headline\":\"my.app/hello\""))))))
+
 (deftest head-model->html-empty-model
   (testing "an empty / minimal model emits nothing (no orphan tags)"
     (is (= "" (rf/head-model->html {})))


### PR DESCRIPTION
## Summary

- `re-frame.ssr.head/ld-json-string` had asymmetric keyword handling on the JVM branch: keyword *values* preserved their namespace, but keyword *keys* were stripped via a bare `(name k)` call. A user supplying `{:my.app/key \"value\"}` in a `:json-ld` slot got `{\"key\":\"value\"}` in the rendered `<script type=\"application/ld+json\">` body — silently losing the `my.app/` prefix.
- Fix delegates keyword-key serialisation to the same `emit` branch that already handles keyword values (lines 140-142). The map branch now calls `(emit k)` unconditionally; strings, keywords, and other types each fall through to their proper branch.
- The spec's canonical JSON-LD example (Spec 011 §Head/meta) uses string keys, so the conformance corpus never tripped this. Per audit rf2-asmj1 §H3.

## Decision

Preserve the namespace — the symmetric choice. The keyword-value branch already does this; the key branch was the asymmetric outlier. Stripping namespace would have been the alternative but: (a) it silently discards information the caller put in the data, (b) it breaks the principle that `{:my.app/x \"y\"}` should round-trip in a way users would expect from `pr-str` / `clj->js`, and (c) it diverges from how keyword values are already handled in the same fn. Pre-alpha — no back-compat constraint to keep the old behaviour.

## Test plan

- [x] `clojure -M:test` from `implementation/ssr/` — 78 tests / 241 assertions / 0 failures
- [x] New regression test `head-model->html-json-ld-preserves-keyword-namespaces` pins:
  - namespaced keyword key → `\"my.app/key\":\"value\"`
  - unqualified keyword key → bare `\"unqualified\":\"v2\"`
  - keyword value asymmetry guard — preserves namespace as before