### PR TITLE
refactor(story): move aggregate-summary fold to state.cljc (rf2-khmon)

### DIFF
--- a/tools/story/spec/009-Test-Mode.md
+++ b/tools/story/spec/009-Test-Mode.md
@@ -39,12 +39,17 @@ Three companion namespaces (split per rf2-8n2fz — see `pure.cljc`,
 ```clojure
 (re-frame.story.ui.test-mode.view/test-view variant-id)   ; CLJS Reagent component
 
-;; pure data → data (JVM-testable) — under re-frame.story.ui.test-mode.pure:
-(variant-has-tests? variant-id)
-  ; → boolean — true iff the variant body declares a non-empty :play
+;; pure data → data (JVM-testable) — under re-frame.story.ui.state:
 (aggregate-summary assertions)
   ; → {:total <n> :passed <n> :failed <n>
   ;    :skipped <n> :all-passed? <bool>}
+  ; Lives in shell-state (not test-mode.pure) per rf2-khmon so the
+  ; sidebar / chrome-level test widget can share one canonical fold
+  ; without a require cycle.
+
+;; pure data → data (JVM-testable) — under re-frame.story.ui.test-mode.pure:
+(variant-has-tests? variant-id)
+  ; → boolean — true iff the variant body declares a non-empty :play
 (assertion-row assertion)
   ; → {:assertion :rf.assert/path-equals
   ;    :status   :pass|:fail|:skip

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -392,32 +392,14 @@
   (let [opts (run-opts-for-variant (state/get-state) vid)]
     (-> (runtime/run-variant vid opts)
         (async/then  (fn [result]
-                       ;; The aggregate-summary helper lives in
-                       ;; `test-mode.pure` but we can't require that ns
-                       ;; here (cyclic: test-mode.state requires this
-                       ;; ns's parent shell-state, which would loop back
-                       ;; through sidebar's requires). Inline the same
-                       ;; six-line fold here — total / passed / failed /
-                       ;; skipped — and let `record-test-run` do the
-                       ;; rest. Two trivially-equal folds is cheaper
-                       ;; than threading another module.
-                       (let [assertions (or (:assertions result) [])
-                             skipped?   (fn [r] (= :rf.assert/skipped
-                                                   (:assertion r)))
-                             n-skip     (count (filter skipped? assertions))
-                             active     (remove skipped? assertions)
-                             n-pass     (count (filter :passed? active))
-                             n-fail     (- (count active) n-pass)
-                             total      (count assertions)
-                             summary    {:total       total
-                                         :passed      n-pass
-                                         :failed      n-fail
-                                         :skipped     n-skip
-                                         :all-passed? (and (pos? total)
-                                                           (zero? n-fail)
-                                                           (zero? n-skip))
-                                         :elapsed-ms  (:elapsed-ms result)
-                                         :ran-at-ms   nil}]
+                       ;; `state/aggregate-summary` is the canonical fold
+                       ;; (rf2-khmon); it lives in shell-state so both
+                       ;; this widget AND the `:test` mode pane share one
+                       ;; impl without a require cycle.
+                       (let [summary (-> (state/aggregate-summary
+                                           (:assertions result))
+                                         (assoc :elapsed-ms (:elapsed-ms result)
+                                                :ran-at-ms  nil))]
                          (state/swap-state! state/record-test-run vid summary))
                        nil))
         (async/catch* (fn [_]

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -430,10 +430,44 @@
   [state variant-id]
   (assoc-in state [:test-runs variant-id] {:status :running}))
 
+(defn aggregate-summary
+  "Walk `assertions` (the vector pulled off a `run-variant` result map)
+  and produce the aggregated pass/fail/skip counts:
+
+      {:total       <n>
+       :passed      <n>
+       :failed      <n>
+       :skipped     <n>
+       :all-passed? <bool>}
+
+  `:skipped` counts records carrying `:assertion :rf.assert/skipped` —
+  re-frame2's v1 runtime doesn't emit this id, but the slot stays open
+  so spec/004 additions flow through without a pane refactor.
+  `:all-passed?` is true iff `:total > 0 AND :failed = 0 AND :skipped = 0`.
+
+  Lives in `state.cljc` (not `test-mode.pure`) so both the test-mode
+  pane AND the sidebar / chrome-level test widget can call one
+  canonical fold without a require cycle (sidebar can't require
+  test-mode, which would loop back through shell-state). Pure data →
+  data; JVM-testable."
+  [assertions]
+  (let [items     (or assertions [])
+        skipped?  (fn [r] (= :rf.assert/skipped (:assertion r)))
+        skipped   (count (filter skipped? items))
+        active    (remove skipped? items)
+        passed    (count (filter :passed? active))
+        failed    (- (count active) passed)
+        total     (count items)]
+    {:total       total
+     :passed      passed
+     :failed      failed
+     :skipped     skipped
+     :all-passed? (and (pos? total) (zero? failed) (zero? skipped))}))
+
 (defn record-test-run
   "Write the aggregate of a `run-variant` result into `:test-runs`.
 
-  `summary` is the map returned by `test-mode.pure/aggregate-summary` —
+  `summary` is the map returned by `aggregate-summary` —
   `{:total :passed :failed :skipped :all-passed?}` — extended with
   optional `:ran-at-ms` and `:elapsed-ms`. A run that recorded zero
   assertions lands as `:pending` (rather than `:pass`/`:fail`) so the

--- a/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
+++ b/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
@@ -52,34 +52,11 @@
     (boolean (seq (:play vb)))))
 
 ;; ---- pure: aggregate-summary --------------------------------------------
-
-(defn aggregate-summary
-  "Walk `assertions` (the vector pulled off a `run-variant` result map)
-  and produce the aggregated pass/fail/skip counts:
-
-      {:total       <n>
-       :passed      <n>
-       :failed      <n>
-       :skipped     <n>
-       :all-passed? <bool>}
-
-  `:skipped` counts records carrying `:assertion :rf.assert/skipped` —
-  re-frame2's v1 runtime doesn't emit this id, but the slot stays open
-  so spec/004 additions flow through without a pane refactor.
-  `:all-passed?` is true iff `:total > 0 AND :failed = 0 AND :skipped = 0`."
-  [assertions]
-  (let [items     (or assertions [])
-        skipped?  (fn [r] (= :rf.assert/skipped (:assertion r)))
-        skipped   (count (filter skipped? items))
-        active    (remove skipped? items)
-        passed    (count (filter :passed? active))
-        failed    (- (count active) passed)
-        total     (count items)]
-    {:total       total
-     :passed      passed
-     :failed      failed
-     :skipped     skipped
-     :all-passed? (and (pos? total) (zero? failed) (zero? skipped))}))
+;;
+;; `aggregate-summary` lives in `re-frame.story.ui.state` (rf2-khmon) so
+;; the sidebar / chrome-level test widget can call one canonical fold
+;; without a require cycle. test-mode consumers call `state/aggregate-
+;; summary` directly.
 
 ;; ---- pure: assertion-row ------------------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/test_mode/state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/state.cljs
@@ -84,7 +84,7 @@
             :play-events   (vec play-events)
             :epoch-ids     epoch-ids
             :selected-step nil})
-    (let [summary (-> (pure/aggregate-summary (:assertions result))
+    (let [summary (-> (state/aggregate-summary (:assertions result))
                       (assoc :ran-at-ms  now
                              :elapsed-ms (:elapsed-ms result)))]
       (state/swap-state! state/record-test-run variant-id summary))))

--- a/tools/story/src/re_frame/story/ui/test_mode/view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/view.cljs
@@ -39,9 +39,10 @@
   namespaces:
 
   - `re-frame.story.ui.test-mode.pure`  — JVM-testable pure data → data
-    helpers (`variant-has-tests?`, `aggregate-summary`, `assertion-row`,
-    `play-step-statuses`, `epoch-id-slice`, `format-elapsed-ms`,
-    `format-timestamp-ms`).
+    helpers (`variant-has-tests?`, `assertion-row`, `play-step-statuses`,
+    `epoch-id-slice`, `format-elapsed-ms`, `format-timestamp-ms`). The
+    `aggregate-summary` fold lives in `re-frame.story.ui.state` so the
+    sidebar / chrome-level test widget can share it (rf2-khmon).
   - `re-frame.story.ui.test-mode.state` — CLJS-only `results-atom` +
     the `begin-run!` / `store-result!` / `select-step!` /
     `toggle-expanded!` / `run-variant-pane!` mutators.
@@ -53,6 +54,7 @@
   never invoke it — closure DCEs the lot."
   (:require [reagent.core                       :as r]
             [re-frame.story.ui.open-in-editor   :as open-in-editor]
+            [re-frame.story.ui.state            :as shell-state]
             [re-frame.story.ui.test-mode.pure   :as pure]
             [re-frame.story.ui.test-mode.state  :as state]))
 
@@ -288,7 +290,7 @@
   (let [slot   (get @state/results-atom variant-id)
         result (:result slot)]
     (when result
-      (let [summary (pure/aggregate-summary (:assertions result))
+      (let [summary (shell-state/aggregate-summary (:assertions result))
             {:keys [total passed failed skipped all-passed?]} summary
             pill-style (cond
                          (zero? total)  (:pill-empty styles)

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -381,7 +381,7 @@
 
 (deftest test-view-pure-helpers
   (testing "the pure section helpers run end-to-end in CLJS too"
-    (let [summary (test-mode-pure/aggregate-summary
+    (let [summary (state/aggregate-summary
                     [{:assertion :rf.assert/path-equals :passed? true}
                      {:assertion :rf.assert/sub-equals  :passed? false}])]
       (is (= 2 (:total summary)))

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -419,9 +419,9 @@
   (testing "variant-has-tests? returns false for an unknown variant-id"
     (is (not (test-mode/variant-has-tests? :story.tm/unknown)))))
 
-(deftest test-mode-aggregate-summary-counts-pass-fail-skip
+(deftest shell-state-aggregate-summary-counts-pass-fail-skip
   (testing "aggregate-summary tallies passed / failed / skipped"
-    (let [s (test-mode/aggregate-summary
+    (let [s (state/aggregate-summary
               [{:assertion :rf.assert/path-equals :passed? true}
                {:assertion :rf.assert/path-equals :passed? false}
                {:assertion :rf.assert/sub-equals  :passed? true}
@@ -433,19 +433,19 @@
       (is (false? (:all-passed? s)))))
   (testing "aggregate-summary's :all-passed? is true only when every
             non-skipped record passed AND no records were skipped"
-    (let [all-pass (test-mode/aggregate-summary
+    (let [all-pass (state/aggregate-summary
                      [{:assertion :rf.assert/path-equals :passed? true}
                       {:assertion :rf.assert/sub-equals  :passed? true}])]
       (is (true?  (:all-passed? all-pass)))
       (is (= 0   (:failed all-pass)))
       (is (= 0   (:skipped all-pass))))
-    (let [with-skip (test-mode/aggregate-summary
+    (let [with-skip (state/aggregate-summary
                       [{:assertion :rf.assert/path-equals :passed? true}
                        {:assertion :rf.assert/skipped     :passed? false}])]
       (is (false? (:all-passed? with-skip))
           "a skipped record disqualifies :all-passed?")))
   (testing "aggregate-summary on an empty vector returns zeros + :all-passed? false"
-    (let [s (test-mode/aggregate-summary [])]
+    (let [s (state/aggregate-summary [])]
       (is (= 0 (:total s)))
       (is (= 0 (:passed s)))
       (is (= 0 (:failed s)))
@@ -453,7 +453,7 @@
       (is (false? (:all-passed? s))
           "zero records = not 'all passed' (the variant ran nothing)")))
   (testing "aggregate-summary tolerates nil"
-    (let [s (test-mode/aggregate-summary nil)]
+    (let [s (state/aggregate-summary nil)]
       (is (= 0 (:total s)))
       (is (false? (:all-passed? s))))))
 


### PR DESCRIPTION
## Summary

- `sidebar.cljs:383-401` carried a 15-line verbatim copy of the `aggregate-summary` fold that lives in `test-mode.pure`. The inline note explains why: requiring `test-mode` would cycle (test-mode.state requires shell-state, which loops back through sidebar's requires).
- Per audit **rf2-dd5ze** SB1, the right fix is to consolidate. Move the canonical fold to `re-frame.story.ui.state` — both sidebar AND test-mode already require shell-state, neither would loop.
- Drop the inlined copy from sidebar. Retire `aggregate-summary` from `test-mode.pure`. Update `test-mode.state`, `test-mode.view`, the JVM + CLJS test corpora, and the `009-Test-Mode.md` surface listing to call `state/aggregate-summary` directly.

Pre-alpha — no back-compat shim. The fold has exactly one canonical home now.

Closes rf2-khmon.

## Test plan

- [x] `clojure -M:test` from `tools/story/` — 348 tests / 1025 assertions, 0 failures / 0 errors.