### PR TITLE
fix(schemas): single source of truth for reg-app-schema (rf2-0frdi)

### DIFF
--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -12,6 +12,15 @@
   the machine's :guards / :actions map) and NOT registered as standalone
   kinds. The kinds set below is the closed v1 list.
 
+  Per rf2-0frdi the `:app-schema` kind is RESERVED but the registrar
+  slot is intentionally **empty** — `reg-app-schema` writes only to the
+  schemas artefact's own per-frame side-table (`schemas/schemas-by-
+  frame`), which is the single source of truth. The kind keyword is
+  preserved for the test-support `:clear-kinds` interface and for
+  Spec 001 §Registry model continuity; tools introspecting app-db
+  schemas go through `schemas/app-schemas` / `schemas/app-schema-meta-at`
+  rather than `handlers :app-schema` / `handler-meta :app-schema`.
+
   ## Production elision
 
   The :rf.registry/* trace emit sites in this namespace are gated on

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -304,8 +304,13 @@
            (frame/ensure-default-frame!))
          (doseq [k clear-kinds]
            (registrar/clear-kind! k)
-           ;; Per-frame schema map is the authoritative store; clear it
-           ;; in lockstep when the caller asks for an :app-schema reset.
+           ;; Per rf2-0frdi `:app-schema` is no longer a registrar kind —
+           ;; the schemas artefact owns its own per-frame side-table. The
+           ;; `:clear-kinds [:app-schema]` opt is preserved as the test-
+           ;; support convention for "give me a clean app-schema slate";
+           ;; the registrar `clear-kind!` above is a no-op for this kind,
+           ;; and this branch dispatches the actual reset through the
+           ;; schemas clear-fn.
            (when (and (= k :app-schema) clear-fn)
              (clear-fn)))
          (when init-fn (init-fn))

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -1088,6 +1088,12 @@
       (rf/reg-error-projector :rf2-o1bp/err1 (fn [_ _] {}))
 
       ;; ---- :app-schema -------------------------------------------------
+      ;; Per rf2-0frdi reg-app-schema writes only to the schemas artefact's
+      ;; own per-frame side-table (`schemas/schemas-by-frame`), NOT to the
+      ;; registrar — same pattern as `:http-interceptor` above. The kind
+      ;; is registered for completeness; introspection of registered
+      ;; app-db schemas goes through `schemas/app-schemas` / `schemas/
+      ;; app-schema-meta-at` rather than `registry-summary` / `handler-ids`.
       (rf/reg-app-schema [:rf2-o1bp/path] :any)
 
       ;; ---- (1) registry-summary returns {kind → count} -------------------
@@ -1114,7 +1120,13 @@
           (is (= 1 (delta :error-projector))
               ":error-projector +1 (built-in :rf.ssr/default-error-projector
                was in baseline)")
-          (is (= 1 (delta :app-schema)) ":app-schema +1")))
+          ;; Per rf2-0frdi `:app-schema` is no longer a registrar kind —
+          ;; reg-app-schema writes only to the schemas artefact's per-
+          ;; frame side-table. Same as `:http-interceptor` above, the kind
+          ;; does NOT appear in registry-summary.
+          (is (= 0 (delta :app-schema))
+              ":app-schema +0 — reg-app-schema is owned by the schemas
+               artefact's side-table, not the registrar (rf2-0frdi)")))
 
       ;; ---- (2) handler-ids returns a set of ids per kind ----------------
       (testing "(rf/handler-ids kind) returns a set of ids"
@@ -1126,6 +1138,10 @@
               route-ids       (rf/handler-ids :route)
               flow-ids        (rf/handler-ids :flow)
               ep-ids          (rf/handler-ids :error-projector)
+              ;; Per rf2-0frdi `:app-schema` is owned by the schemas
+              ;; artefact's side-table — handler-ids on the registrar
+              ;; kind is empty. App-db schema introspection goes through
+              ;; `schemas/app-schemas` (returns `{path → schema}`).
               schema-ids      (rf/handler-ids :app-schema)]
           (is (set? event-ids) "handler-ids returns a set")
           (is (contains? event-ids :rf2-o1bp/evt1))
@@ -1139,7 +1155,9 @@
           (is (contains? route-ids :rf2-o1bp/route1))
           (is (contains? flow-ids :rf2-o1bp/flow1))
           (is (contains? ep-ids :rf2-o1bp/err1))
-          (is (contains? schema-ids [:rf2-o1bp/path]))))
+          (is (not (contains? schema-ids [:rf2-o1bp/path]))
+              "registrar handler-ids :app-schema is empty — schemas owns its
+               own side-table (rf2-0frdi)")))
 
       ;; ---- (3) handlers returns {id → metadata} per kind ----------------
       (testing "(rf/handlers kind) returns {id → metadata}"

--- a/implementation/core/test/re_frame/source_coords_test.clj
+++ b/implementation/core/test/re_frame/source_coords_test.clj
@@ -150,8 +150,13 @@
 
 (deftest source-coords-on-reg-app-schema
   (testing "reg-app-schema stamps :ns / :line / :file"
+    ;; Per rf2-0frdi the schemas artefact owns its own per-frame side-
+    ;; table — there is no registrar `:app-schema` slot. Source-coords
+    ;; introspection reads through `schemas/app-schema-meta-at` which
+    ;; returns the full meta map (including the stamped coords) for the
+    ;; `(frame-id, path)` entry.
     (rf/reg-app-schema [:rf2-k84s/reg-app-schema-sample] :int)
-    (assert-coords (rf/handler-meta :app-schema [:rf2-k84s/reg-app-schema-sample])
+    (assert-coords (schemas/app-schema-meta-at [:rf2-k84s/reg-app-schema-sample])
                    :app-schema [:rf2-k84s/reg-app-schema-sample])))
 
 (deftest source-coords-on-reg-error-projector

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -33,8 +33,10 @@
       (rf2-froe / rf2-t0hq).
     - `re-frame.schemas.storage`        — per-frame schema registry
       (`schemas-by-frame`, `reg-app-schema` / `reg-app-schemas`,
-      `app-schema-at` / `app-schemas`, `frame-schema-entries`,
-      snapshot/restore/clear) + the hot-reload replacement-hook seam.
+      `app-schema-at` / `app-schema-meta-at` / `app-schemas`,
+      `frame-schema-entries`, snapshot/restore/clear). Per rf2-0frdi
+      this is the single source of truth — there is no registrar
+      `:app-schema` slot.
     - `re-frame.schemas.walker`         — unified per-slot flag walker
       (rf2-nwv63 / rf2-kj51z / rf2-oghml) parameterised on the flag
       key, plus `extract-large-paths-from-schema`,
@@ -82,6 +84,7 @@
 (def reg-app-schema       storage/reg-app-schema)
 (def reg-app-schemas      storage/reg-app-schemas)
 (def app-schema-at        storage/app-schema-at)
+(def app-schema-meta-at   storage/app-schema-meta-at)
 (def app-schemas          storage/app-schemas)
 (def frame-schema-entries storage/frame-schema-entries)
 

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -3,24 +3,25 @@
 
   Per Spec 010 §Per-frame schemas. The registry shape is
     {frame-id {path schema-meta}}
-  mirroring `re-frame.flows`'s frame-scoping (rf2-lvwr). The registrar
-  (`:app-schema` kind) still receives a slot-per-path entry so source-
-  coords / hot-reload tooling can introspect a path's most-recent
-  registration; the per-frame map is the authoritative store the
-  validation hot path reads.
+  mirroring `re-frame.flows`'s frame-scoping (rf2-lvwr). The per-frame
+  atom is the **single source of truth** for `app-db` schemas — there is
+  no registrar `:app-schema` slot (resolved rf2-0frdi). Source-coords /
+  hot-reload / pair-tool introspection reads through `app-schema-meta-at`,
+  which returns the per-frame metadata map (including the registration's
+  `:ns` / `:line` / `:file` source-coords).
 
   Owns:
     - `schemas-by-frame` atom (the authoritative store).
     - `reg-app-schema` / `reg-app-schemas` registration entry points.
     - `app-schema-at` / `app-schemas` query entry points.
+    - `app-schema-meta-at` — meta-introspection (source-coords, etc.)
+      consumed by pair-tools and source-coord tests.
     - `frame-schema-entries` cross-artefact seam consumed by
       `re-frame.elision` / `re-frame.epoch` via the late-bind table.
     - `snapshot-schemas-by-frame` / `restore-schemas-by-frame!` /
       `clear-schemas-by-frame!` — test-support hooks consumed by
-      `re-frame.test-support`'s reset-runtime fixture.
-    - The hot-reload replacement-hook seam (`on-app-schema-registry-event!`)."
+      `re-frame.test-support`'s reset-runtime fixture."
   (:require [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
             [re-frame.source-coords :as source-coords]))
 
 (defonce
@@ -58,17 +59,18 @@
   Per Spec 010 §Per-frame schemas this registration is frame-scoped.
   The frame to register against comes from the optional :frame opt;
   default is (frame/current-frame) — usually :rf/default unless the
-  caller is inside a (with-frame ...) wrapper or a frame-provider."
+  caller is inside a (with-frame ...) wrapper or a frame-provider.
+
+  Per rf2-0frdi the schemas artefact owns its own per-frame side-table
+  (`schemas-by-frame`) — there is no registrar `:app-schema` slot. The
+  authoritative store is keyed by `(frame-id, path)` so that registrations
+  against frame A and frame B against the same path are independent
+  entries. Pair-tools and source-coord tests read via `app-schema-meta-at`."
   ([path schema] (reg-app-schema path schema {}))
   ([path schema opts]
    (let [frame-id (resolve-frame opts)
          meta     (source-coords/merge-coords
                     {:schema schema :path path :frame frame-id})]
-     ;; Stamp the registrar slot so source-coords / handler-meta /
-     ;; hot-reload tooling continue to see :app-schema entries. The
-     ;; registrar is per-process; the per-frame map is the
-     ;; authoritative store for validation.
-     (registrar/register! :app-schema path meta)
      (swap! schemas-by-frame assoc-in [frame-id path] meta)
      path)))
 
@@ -93,8 +95,8 @@
   `:frame` opt overrides the default `(frame/current-frame)` resolution
   for every entry in the map (you cannot mix frames in a single call).
   The singular form `reg-app-schema` remains available and is used
-  internally for each entry — every entry stamps its own registrar slot
-  with source-coords captured from this call site.
+  internally for each entry — every entry stamps its own per-frame side-
+  table entry with source-coords captured from this call site.
 
   Returns the vector of paths registered, in iteration order. Last-
   write-wins on duplicate paths inside the same map (map iteration
@@ -121,6 +123,30 @@
          frame-id (resolve-frame opts)]
      (when-let [m (get-in @schemas-by-frame [frame-id path])]
        (:schema m)))))
+
+(defn app-schema-meta-at
+  "Return the registration metadata map for a path in a frame, or nil.
+
+  Unlike `app-schema-at` (which returns just the `:schema` value), this
+  returns the full meta map stamped at `reg-app-schema` — including
+  source-coords (`:ns` / `:line` / `:file`), `:path`, `:schema`, and
+  `:frame`. Used by pair-tools, 10x panels, and source-coord tests that
+  need to introspect where a schema was registered.
+
+  Per rf2-0frdi this is the canonical replacement for the legacy
+  `(rf/handler-meta :app-schema path)` query — the registrar `:app-schema`
+  slot is no longer populated; the per-frame side-table is the single
+  source of truth.
+
+  Arities:
+    (app-schema-meta-at path)         ;; current frame (or :rf/default)
+    (app-schema-meta-at path opts)    ;; opts map; :frame names the frame
+                                      ;; (keyword sugar also accepted)"
+  ([path] (app-schema-meta-at path {}))
+  ([path opts-or-frame-id]
+   (let [opts     (coerce-opts opts-or-frame-id)
+         frame-id (resolve-frame opts)]
+     (get-in @schemas-by-frame [frame-id path]))))
 
 (defn app-schemas
   "Return every registered `app-schema-at` declaration for a frame as a
@@ -152,33 +178,15 @@
   [frame-id]
   (get @schemas-by-frame frame-id {}))
 
-;; ---- hot-reload invalidation ---------------------------------------------
+;; ---- hot-reload semantics ------------------------------------------------
 ;;
-;; When a frame is destroyed (or a schema is explicitly cleared via the
-;; registrar), drop its per-frame entry so the validation hot path
-;; doesn't keep walking dead schemas. Per Spec 001 §Hot-reload semantics
-;; the registrar's :app-schema slot is shared (path-keyed) across
-;; frames; replacement-hook fires on EVERY re-register, not only when
-;; we want to invalidate. We only act on :rf.registry/handler-cleared-
-;; equivalent paths (kind = :app-schema, no `:now` means cleared).
-
-(defn- on-app-schema-registry-event!
-  [{:keys [kind id was now]}]
-  (when (= kind :app-schema)
-    ;; A `register!` always supplies `now`; `unregister!` / `clear-kind!`
-    ;; produce no replacement-hook callback (they don't fire hooks). The
-    ;; registrar today only invokes hooks on replacement, so this hook
-    ;; sees re-registrations against the same path. Re-registering with
-    ;; an explicit :frame opt MAY be against a different frame — in
-    ;; which case we leave the prior frame's entry alone (it was
-    ;; registered separately) and the new frame's entry is updated by
-    ;; reg-app-schema directly. Nothing to do here today; the hook is
-    ;; published as the seam future invalidation work plugs into.
-    (let [_ was _ now])))
-
-(defonce ^:private _hot-reload-hook
-  (do (registrar/add-replacement-hook! on-app-schema-registry-event!)
-      :installed))
+;; Per rf2-0frdi the schemas artefact no longer participates in the
+;; registrar's replacement-hook stream — `reg-app-schema` writes only to
+;; `schemas-by-frame`. Re-registering a `(frame-id, path)` entry is an
+;; ordinary `swap!`: the new meta replaces the prior entry atomically, and
+;; the validation hot path (`frame-schema-entries`) picks up the new
+;; schema on its next read. There is nothing to invalidate elsewhere —
+;; the per-frame map IS the cache.
 
 ;; ---- test-support snapshot / restore -------------------------------------
 ;;

--- a/spec/001-Registration.md
+++ b/spec/001-Registration.md
@@ -95,7 +95,7 @@ The registrar is a `(kind, id) → metadata` map. The `kind` keyword identifies 
 | `:view` | Registered views | `reg-view` |
 | `:frame` | Registered frames | `reg-frame` (also `make-frame`) |
 | `:route` | Routes | `reg-route` (Spec 012) |
-| `:app-schema` | App-db schemas registered at paths | `reg-app-schema` (Spec 010) |
+| `:app-schema` | App-db schemas registered at paths — RESERVED kind; the registrar slot is intentionally empty (the schemas artefact owns its own per-frame side-table). Tools introspect via `schemas/app-schemas` / `schemas/app-schema-meta-at` rather than `handlers :app-schema`. | `reg-app-schema` (Spec 010) |
 | `:head` | Registered SSR head/meta functions (per [011 §Head/meta contract](011-SSR.md#headmeta-contract)) | `reg-head` (Spec 011) |
 | `:error-projector` | Registered SSR error projectors (internal trace event → public-error shape, per [011 §Server error projection](011-SSR.md#server-error-projection)) | `reg-error-projector` (Spec 011) |
 | `:flow` | Registered flows (computed-state declarations materialised into `app-db`, per [013 §The registration shape](013-Flows.md#the-registration-shape)) | `reg-flow` (Spec 013) |

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -59,7 +59,7 @@ Rather than one giant schema for the whole `app-db`, schemas are registered **at
 
 This fits re-frame's grain — code already accesses `app-db` via paths; schemas are similarly path-anchored. Composable. Hot-reload-friendly per slice. Tooling and agents can ask "what's the schema at path P?" and get a precise local answer.
 
-`reg-app-schema` returns its `path` argument — the primary id under which the schema registers in the `:app-schema` kind — per the family-wide [`reg-*` return-value convention](Conventions.md#reg--return-value-convention).
+`reg-app-schema` returns its `path` argument — the primary id under which the schema registers in the schemas artefact's per-frame side-table (`(frame-id, path) → schema-meta`); per [Spec 001 §Registry model](001-Registration.md#registry-model--the-canonical-kind-keyword-set) the `:app-schema` registry kind is RESERVED but the registrar slot is intentionally empty, so the schemas artefact owns the single source of truth — per the family-wide [`reg-*` return-value convention](Conventions.md#reg--return-value-convention).
 
 #### `reg-app-schemas` — bulk plural form
 

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -283,7 +283,7 @@ The registration-shape accepted by `reg-flow`. Unlike the other kinds, `reg-flow
 
 > **Layer:** Public
 
-The metadata stamped on the `:app-schema` registry slot by `reg-app-schema` (per [010 §`reg-app-schema`](010-Schemas.md)). The `:path` and `:schema` fields are runtime-stamped from the positional args — user code passes `(rf/reg-app-schema path schema)` rather than `(rf/reg-app-schema id {:path ... :schema ...})`.
+The metadata stamped on the schemas artefact's per-frame side-table entry by `reg-app-schema` (per [010 §`reg-app-schema`](010-Schemas.md); per [001 §Registry model](001-Registration.md#registry-model--the-canonical-kind-keyword-set) the `:app-schema` registry kind is RESERVED but the registrar slot is intentionally empty — the schemas artefact owns the single source of truth). The `:path` and `:schema` fields are runtime-stamped from the positional args — user code passes `(rf/reg-app-schema path schema)` rather than `(rf/reg-app-schema id {:path ... :schema ...})`.
 
 ```clojure
 (def AppSchemaMeta


### PR DESCRIPTION
## Summary

Per the schemas refactor audit (rf2-x8x4p / A5), `reg-app-schema` double-wrote schema metadata to BOTH the registrar (`:app-schema` slot, path-keyed) AND the schemas artefact's per-frame side-table (`schemas-by-frame`, frame-id × path keyed). The two stores diverged on re-registration against a different frame — the registrar saw the latest path-registration regardless of frame while the per-frame map kept the original frame's entry — leaving two distinct answers to *the schema at path P*.

**Direction:** drop the registrar `:app-schema` write (audit option a). The schemas artefact's per-frame side-table is the single source of truth. The kind keyword stays RESERVED in `registrar/kinds` for Spec 001 §Registry-model continuity and for the test-support `:clear-kinds [:app-schema]` convention, but the registrar slot is intentionally empty — mirrors the `:http-interceptor` precedent (its own per-frame store, not in `registry-summary`).

**Rationale for (a) over (b)** (composite key): no production tool (`tools/causa`, `tools/pair2-mcp`, `tools/story`) reads through `handler-meta :app-schema` — the only real consumers were three tests, all migrated. Per-frame side-table ownership is already the prevailing pattern (`http-interceptor`, schemas validation hot path, elision feeders).

## Changes

- `schemas/storage.cljc`: drop `registrar/register! :app-schema` write; drop the now-redundant replacement-hook; drop the registrar require. Add **`app-schema-meta-at`** — the canonical replacement for `(handler-meta :app-schema path)`, returning the full per-frame meta map (source-coords, `:path`, `:schema`, `:frame`).
- `schemas.cljc`: re-export `app-schema-meta-at` on the public façade.
- `registrar.cljc`: docstring note that `:app-schema` is reserved-but-empty.
- `test_support.cljc`: docstring note that `:clear-kinds [:app-schema]` routes through the schemas clear-fn; the registrar `clear-kind!` is a no-op for the now-empty slot.
- `core/source_coords_test.clj`: migrate `(rf/handler-meta :app-schema ...)` to `schemas/app-schema-meta-at`.
- `core/smoke_test.clj` (`registry-introspection-round-trip`): `:app-schema` delta is now +0; `handler-ids :app-schema` is empty; pattern matches the existing `:http-interceptor` narrative.
- Spec 001 §Registry model: note `:app-schema` is reserved-but-empty; tools introspect via `schemas/app-schemas` / `app-schema-meta-at`.
- Spec 010, Spec-Schemas: align prose with the new ownership.

## Test plan

- [x] `clojure -M:test` in `implementation/schemas/` — 123 tests, 352 assertions, 0/0
- [x] `clojure -M:test` in `implementation/core/` — 456 tests, 2436 assertions, 0/0
- [x] `npm run test:cljs` — 1793 tests, 4980 assertions, 0/0
- [x] `npm run test:bundle-isolation` — PASS

Closes rf2-0frdi.