### PR TITLE
spec(causa-mcp): cite bands table (drop restatements) (rf2-g2ytz)

### DIFF
--- a/tools/causa-mcp/spec/000-Vision.md
+++ b/tools/causa-mcp/spec/000-Vision.md
@@ -143,21 +143,23 @@ root.
 
 ## MCP catalogue summary
 
-Eighteen tools across five bands (per the [canonical counts in
-`README.md`](./README.md#canonical-counts)); the full enumeration
-with signatures, return shapes, and example flows lives in
-[`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
-until implementation lands and this folder grows its own
-`003-Tool-Catalogue.md` (the pair2-mcp-shape companion to
-`Principles.md` and `DESIGN-RATIONALE.md`). The short list:
+Eighteen tools across five bands — Inspection (9) / Mutation (3)
+/ Streaming (3) / Escape hatch (1) / Meta (2) — per the
+[canonical counts in `README.md`](./README.md#canonical-counts).
 
-| Band | Tools |
-|---|---|
-| **Inspection** (read-only, 9 tools) | `get-trace-buffer`, `get-epoch-history`, `get-app-db`, `get-app-db-diff`, `get-machine-state`, `get-machine-list`, `get-issues`, `get-handlers`, `get-source-coord`. |
-| **Mutation** (user-confirmed equivalents, 3 tools) | `restore-epoch`, `reset-frame-db`, `dispatch`. |
-| **Streaming** (push-mode + diagnostic, 3 tools) | `subscribe`, `unsubscribe` — `notifications/progress` shaped, topic-mediated filters; `list-subscriptions` — request-response diagnostic enumerating open subs with queue stats (per [`DESIGN-RATIONALE.md` Lock #12](./DESIGN-RATIONALE.md)). |
-| **Escape hatch** (1 tool) | `eval-cljs` — arbitrary CLJS form; any side-effects inherit `:origin :causa-mcp`. |
-| **Meta** (session lifecycle, 2 tools) | `discover-app`, `tail-build`. |
+**The band enumeration with tool names, signatures, return
+shapes, and example flows lives upstream at
+[`tools/causa/spec/010-MCP-Server.md` §Tool catalogue](../../causa/spec/010-MCP-Server.md#tool-catalogue).**
+Cite that section; do not restate it here. The five band
+subsections (Inspection / Mutation / Streaming / Escape hatch /
+Meta) carry the per-tool detail; the eighteenth-tool addition
+(`list-subscriptions` in the Streaming band) is locked at
+[`DESIGN-RATIONALE.md` Lock #12](./DESIGN-RATIONALE.md).
+
+When implementation lands and this folder grows its own
+`003-Tool-Catalogue.md` (the pair2-mcp-shape companion to
+`Principles.md` and `DESIGN-RATIONALE.md`), the catalogue prose
+migrates here and `010-MCP-Server.md` shrinks to a pointer.
 
 Each tool maps to a Causa-side affordance (the seventeen panel
 mirrors plus the streaming-registry diagnostic); together they

--- a/tools/causa-mcp/spec/README.md
+++ b/tools/causa-mcp/spec/README.md
@@ -32,7 +32,7 @@ that's how drift is prevented when a count next moves.
 | Count | Value | Source-of-truth |
 |---|---|---|
 | **Tools** | **18** | [`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md) §Tool catalogue — the catalogue prose enumerates each. Migrates to `003-Tool-Catalogue.md` when impl lands. Eighteenth tool (`list-subscriptions`) added by [`DESIGN-RATIONALE.md` Lock #12](DESIGN-RATIONALE.md) on 2026-05-14 (rf2-3we2k). |
-| **Bands** | **5** | Inspection (9) + Mutation (3) + Streaming (3) + Escape hatch (1) + Meta (2) = 18. Enumerated in [`000-Vision.md`](000-Vision.md) §MCP catalogue summary. Streaming band grew from 2 to 3 via Lock #12. |
+| **Bands** | **5** | Inspection (9) + Mutation (3) + Streaming (3) + Escape hatch (1) + Meta (2) = 18. Band enumeration with tool names lives at [`tools/causa/spec/010-MCP-Server.md` §Tool catalogue](../../causa/spec/010-MCP-Server.md#tool-catalogue) — the five band subsections carry the per-tool detail. Migrates to `003-Tool-Catalogue.md` when impl lands. Streaming band grew from 2 to 3 via Lock #12. |
 | **Mechanisms** | **6** | [`Principles.md`](Principles.md) §"Tight token budget per response" — token cap, path slicing, cursor pagination, lazy summary, structural dedup, size elision. Mechanism #6 promoted by Lock #10. |
 | **Locks** | **12** | [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) §Summary table. |
 | **Namespace roots** | **2** | MCP-server (Node-side): `day8.re-frame2-causa-mcp.*` — injected runtime (browser-side): `day8.re-frame2-causa.runtime`. Per [`000-Vision.md` §Two namespaces, two sides](000-Vision.md#two-namespaces-two-sides) and [`DESIGN-RATIONALE.md` Lock #11](DESIGN-RATIONALE.md). |


### PR DESCRIPTION
## Summary

Per audit rf2-m9yoi P0 #1 — the bands table at `tools/causa-mcp/spec/000-Vision.md` §MCP catalogue summary restated the upstream tool catalogue and **drifted**: 17 tools and a phantom 'Compatibility' band vs. the source-of-truth at `tools/causa/spec/010-MCP-Server.md` §Tool catalogue, which carries all 18 tools post-Lock #12 across five band subsections (Inspection 9 / Mutation 3 / Streaming 3 / Escape hatch 1 / Meta 2).

The migration plan (catalogue prose moves from `010-MCP-Server.md` → `tools/causa-mcp/spec/003-Tool-Catalogue.md` when implementation lands) is sound; today's both-restate stance is the drift's cause.

Per the bead's recommended **Option B**: keep `010-MCP-Server.md` canonical until migration; cite from this folder.

## Changes

- `tools/causa-mcp/spec/000-Vision.md` §MCP catalogue summary — replaced the restated bands table with a citation pointer at `tools/causa/spec/010-MCP-Server.md#tool-catalogue`. The five band subsections (Inspection / Mutation / Streaming / Escape hatch / Meta) carry the per-tool detail upstream. The eighteenth-tool addition (`list-subscriptions` in Streaming) is cited at `DESIGN-RATIONALE.md` Lock #12.
- `tools/causa-mcp/spec/README.md` §Canonical counts — updated the **Bands** row source-of-truth from the now-citation `000-Vision.md` section to the upstream `010-MCP-Server.md` §Tool catalogue, matching the **Tools** row's posture.

## Why this is right

- **No new restatement.** The bands count (5) and per-band cardinalities (9/3/3/1/2 = 18) remain visible at-a-glance in both `000-Vision.md` and `README.md` (these are *counts*, not the table); the *tool names* live only at the source-of-truth.
- **Source-of-truth verified.** `tools/causa/spec/010-MCP-Server.md` §Tool catalogue reflects all 18 tools post-Lock #12 — five band subsections with full tool signatures, return shapes, example flows.
- **Migration-ready.** When `003-Tool-Catalogue.md` lands, only two pointers need updating (both in `causa-mcp/spec/`); `010-MCP-Server.md` shrinks to its own pointer at that time per the existing plan.

## Test plan

- [x] Spec-only change; no code touched.
- [x] Source-of-truth (`tools/causa/spec/010-MCP-Server.md` §Tool catalogue) verified to enumerate all 18 tools across five band subsections.
- [x] `mkdocs build --strict` — not applicable; `tools/causa-mcp/spec/` is not in the docs build.

Closes rf2-g2ytz.