### PR TITLE
fix(mcp-conformance): wire_vocab gate ignores comment/docstring mentions (rf2-xx42k)

### DIFF
--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -116,6 +116,72 @@
   [rel-path]
   (slurp (io/file repo-root rel-path)))
 
+(defn- strip-comments-and-strings
+  "Return `src` with Clojure line comments (`;` to EOL) and string
+  literals (`\"...\"`, including docstrings) replaced by single
+  spaces. Preserves line structure for accurate error reporting up
+  the stack.
+
+  Used by the `story-mcp-still-emits-zero-cross-mcp-markers` tripwire
+  (and any other absence-pin that wants to distinguish *emissions*
+  from *documentation*). story-mcp re-uses mcp-base's overflow
+  machinery — the marker IS emitted on its wire, but not via an
+  inline literal in story-mcp's own source. Docstring/comment
+  references to `:rf.mcp/overflow` and `:rf.size/large-elided`
+  (rf2-7dnct introduced them, rf2-xx42k filed the drift) are
+  documentation, not emissions; this helper lets the absence-pin
+  ignore them.
+
+  Implementation: simple state machine over the raw text. Tracks two
+  states (in-string vs in-comment) with `\\` escape handling inside
+  strings. Not a full Clojure reader — character literals (`\\;`),
+  regex literals (`#\"...\"`), and `#_` reader-discards are not
+  modelled. Those edge cases don't matter for our pin: we strip
+  conservatively (false-positive whitelisting would be the bug; a
+  missed string is OK because the marker still wouldn't appear in a
+  bare character literal or a regex pattern targeting it)."
+  [src]
+  (let [n  (count src)
+        sb (StringBuilder. n)]
+    (loop [i 0, in-string? false, in-comment? false]
+      (if (>= i n)
+        (.toString sb)
+        (let [c (.charAt ^String src i)]
+          (cond
+            in-comment?
+            (do (.append sb (if (= c \newline) c \space))
+                (recur (inc i) false (not= c \newline)))
+
+            in-string?
+            (cond
+              ;; escape: skip the next char (consume both as space, preserving newlines)
+              (= c \\)
+              (do (.append sb \space)
+                  (when (< (inc i) n)
+                    (let [nx (.charAt ^String src (inc i))]
+                      (.append sb (if (= nx \newline) nx \space))))
+                  (recur (+ i 2) true false))
+
+              (= c \")
+              (do (.append sb \space)
+                  (recur (inc i) false false))
+
+              :else
+              (do (.append sb (if (= c \newline) c \space))
+                  (recur (inc i) true false)))
+
+            (= c \;)
+            (do (.append sb \space)
+                (recur (inc i) false true))
+
+            (= c \")
+            (do (.append sb \space)
+                (recur (inc i) true false))
+
+            :else
+            (do (.append sb c)
+                (recur (inc i) false false))))))))
+
 ;; ---------------------------------------------------------------------------
 ;; Canonical schemas. Single source of truth.
 ;;
@@ -530,21 +596,32 @@
 
 (deftest story-mcp-still-emits-zero-cross-mcp-markers
   ;; Self-documenting tripwire: the day story-mcp adopts ANY of the
-  ;; cross-MCP markers, this test flips RED — at which point the
-  ;; reviewer adds story-mcp to the `:servers` set on the affected
-  ;; marker, adds a fixture, and extends `server-source-files`. That's
-  ;; the right friction; conformance is not free.
+  ;; cross-MCP markers as an INLINE EMISSION, this test flips RED —
+  ;; at which point the reviewer adds story-mcp to the `:servers` set
+  ;; on the affected marker, adds a fixture, and extends
+  ;; `server-source-files`. That's the right friction; conformance is
+  ;; not free.
+  ;;
+  ;; Comment- and docstring-only mentions are stripped before the
+  ;; check (via `strip-comments-and-strings`). story-mcp re-uses
+  ;; mcp-base's overflow / elision machinery; its tools.cljc
+  ;; documents `:rf.mcp/overflow` and `:rf.size/large-elided` in
+  ;; docstrings without inline-emitting either. Documentation is not
+  ;; an emission — this tripwire fires only on bare-code occurrences
+  ;; (rf2-xx42k).
   (let [story-files ["tools/story-mcp/src/re_frame/story_mcp/tools.cljc"
                      "tools/story-mcp/src/re_frame/story_mcp/protocol.cljc"]]
     (doseq [{:keys [key]} canonical-markers
             rel           story-files]
       (testing (str "story-mcp source " rel " — " key " absence")
-        (is (not (str/includes? (read-source rel) (marker-key->literal key)))
-            (str key " literal found in " rel
-                 ".\nIf story-mcp now emits this marker, update "
-                 "`canonical-markers` to include :story-mcp in "
-                 ":servers, add a story-mcp fixture, and extend "
-                 "`server-source-files`."))))))
+        (let [stripped (strip-comments-and-strings (read-source rel))]
+          (is (not (str/includes? stripped (marker-key->literal key)))
+              (str key " literal found in " rel
+                   " (in code, after stripping comments/docstrings).\n"
+                   "If story-mcp now emits this marker, update "
+                   "`canonical-markers` to include :story-mcp in "
+                   ":servers, add a story-mcp fixture, and extend "
+                   "`server-source-files`.")))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Envelope indicator-field gate (rf2-2499j MUST-level pin).


### PR DESCRIPTION
## Summary

The `story-mcp-still-emits-zero-cross-mcp-markers` tripwire in `wire_vocab_test.clj` was tripped by documentation references — post-rf2-7dnct, `tools/story-mcp/src/re_frame/story_mcp/tools.cljc` carries `:rf.mcp/overflow` and `:rf.size/large-elided` mentions in docstrings and `;;` comment blocks documenting that the wire-boundary cap routes through `re-frame.mcp-base.overflow/overflow-payload`. story-mcp does NOT inline-emit either marker; the literal occurrences are documentation, not emissions.

## Direction

Of the two options spelled out in the bead (whitelist comment/docstring mentions in the gate vs. promote story-mcp into the `:servers` set), this PR takes the gate-side fix. Rationale:

- The tripwire's spirit is "did story-mcp start inline-emitting a cross-MCP marker?" — documentation references are categorically NOT emissions, regardless of which server they live in. A text-class filter is more general than a per-file whitelist.
- The sibling `indicator_field_test.clj` already proves the alternative (per-file `inline-emit-whitelist`) is workable but verbose. The text-class approach reads cleaner: "comments and strings aren't code, so absence-check excludes them" needs no per-file justification rows.

## Change

- Add `strip-comments-and-strings` — a small state machine that zeroes out Clojure line comments (`;` to EOL) and string literals (including docstrings), preserving line structure for error reporting.
- Wire it into `story-mcp-still-emits-zero-cross-mcp-markers` only. The other source-text pins (`marker-literal-appears...`, `no-near-miss-variants...`) keep their full-text view: a typo in a docstring is still a vocabulary-drift bug worth catching.

## Test plan

Run `clojure -M:test` from `tools/mcp-conformance/wire-vocab/`:

**Before this PR (on origin/main):** 4 failures + 2 errors. The 4 failures included two `story-mcp-still-emits-zero-cross-mcp-markers` rows (one for `:rf.mcp/overflow`, one for `:rf.size/large-elided`).

**With this PR:** 2 failures + 2 errors. The two story-mcp tripwire rows pass. The remaining failures (`no-inline-indicator-slot-emit-outside-the-helper` x 2 in `indicator_field_test.clj`, `no-near-miss-variants-in-server-tool-sources` / `canonical-slot-literal-appears-in-every-contracted-server` in `slot_name_test.clj` re: missing `sensitive.cljc`) are pre-existing and out of scope for this bead.

Closes rf2-xx42k. Filed from rf2-6m8tq (#866).