### PR TITLE
test(schemas): pin app-schemas-digest cross-runtime byte-identity (rf2-xssfv)

### DIFF
--- a/implementation/schemas/test/re_frame/schemas/digest_parity_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas/digest_parity_cljs_test.cljs
@@ -1,0 +1,64 @@
+(ns re-frame.schemas.digest-parity-cljs-test
+  "CLJS side of the app-schemas-digest cross-runtime byte-identity
+  parity smoke (rf2-xssfv).
+
+  Spec 010 §Digest algorithm pins the digest as byte-identical between
+  CLJS and JVM runtimes: `'cross-runtime reproducible — a CLJS server
+  and a CLJS client running the same schema set produce the same
+  digest, byte-for-byte'`. The empty-set vector was pinned at
+  rf2-0z1z; this file extends the corpus and locks the CLJS pipeline
+  (`goog.crypt.Sha256` + `goog.crypt/stringToUtf8ByteArray` +
+  `byteArrayToHex`) to the same literals the JVM pipeline
+  (`java.security.MessageDigest` + `String#getBytes(UTF_8)`) pins.
+
+  Pattern mirrors `re-frame.source-coord-parity-cljs-test` (rf2-1q9de)
+  — both runtimes consume the SAME fixture map (loaded from a shared
+  `.cljc` fixtures namespace) and pin the SAME canonical literal. The
+  literal IS the cross-host byte-comparison point. The companion JVM
+  test lives at `re-frame.schemas.digest-parity-test` and pins the
+  same literals against the same fixtures."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.schemas.digest-parity-fixtures :as fixtures]))
+
+;; ---- pinned-literal vectors -----------------------------------------------
+
+(deftest cljs-digest-matches-canonical-literal
+  (testing "Per Spec 010 §Digest algorithm — every canonical fixture
+            hashes to its pinned `\"sha256:\" + 16-hex` literal under
+            the CLJS digest pipeline. Byte-identity with the JVM-side
+            literal is what locks the cross-runtime invariant."
+    (doseq [{:keys [label input expected rationale]} fixtures/all-fixtures]
+      (let [actual (fixtures/compute-digest input)]
+        (is (= expected actual)
+            (str "CLJS digest for fixture " (pr-str label) " — "
+                 rationale
+                 " — expected " (pr-str expected) ", got " (pr-str actual)))))))
+
+;; ---- equality-invariant pairs --------------------------------------------
+
+(deftest cljs-digest-honours-equality-invariants
+  (testing "Spec 010 §Digest algorithm structural invariants — order-
+            independence (paths, props) and metadata stripping — every
+            fixture pair MUST produce byte-identical digests under
+            the CLJS pipeline."
+    (doseq [{:keys [label input-a input-b rationale]} fixtures/invariant-pairs]
+      (let [da (fixtures/compute-digest input-a)
+            db (fixtures/compute-digest input-b)]
+        (is (= da db)
+            (str "CLJS invariant pair " (pr-str label) " — "
+                 rationale
+                 " — input-a → " (pr-str da)
+                 ", input-b → " (pr-str db)))))))
+
+;; ---- corpus distinctness sanity ------------------------------------------
+
+(deftest cljs-fixture-literals-pairwise-distinct
+  (testing "The pinned-literal corpus is pairwise distinct — no two
+            fixtures collide on the 16-hex prefix. The CLJS-side check
+            is redundant with the JVM-side check (they read the same
+            `def`s) but cheap; an accidental edit that introduced a
+            duplicate would fail both."
+    (let [literals (mapv :expected fixtures/all-fixtures)]
+      (is (= (count literals) (count (set literals)))
+          (str "Fixture literals must be pairwise distinct — got "
+               (pr-str literals))))))

--- a/implementation/schemas/test/re_frame/schemas/digest_parity_fixtures.cljc
+++ b/implementation/schemas/test/re_frame/schemas/digest_parity_fixtures.cljc
@@ -1,0 +1,184 @@
+(ns re-frame.schemas.digest-parity-fixtures
+  "Shared fixtures for the JVM↔CLJS app-schemas-digest byte-identity
+  parity tests (rf2-xssfv).
+
+  Spec 010 §Digest algorithm pins the digest as cross-runtime
+  byte-identical: a CLJS server and a CLJS client running the same
+  schema set MUST produce the same `\"sha256:\" + 16-hex` string —
+  byte-for-byte. The empty-set vector (`sha256:e3b0c44298fc1c14`) was
+  pinned at rf2-0z1z; this namespace extends the corpus to multi-
+  schema, nested, with-props, primitive, and metadata-stripped cases
+  so port implementations (and future refactors of the digest
+  pipeline) can self-check against a wider surface.
+
+  Strategy mirrors `re-frame.source-coord-parity-test` /
+  `re-frame.source-coord-parity-cljs-test` (rf2-1q9de) — both runtimes
+  consume the SAME fixture map and pin the SAME expected literal. The
+  literal IS the cross-host byte-comparison point; if either runtime's
+  digest pipeline diverges from the canonical bytes, that runtime's
+  test fails. The fixtures live in a .cljc namespace so the JVM and
+  CLJS test files load the same `def`s.
+
+  Wire-form review: every entry is `\"sha256:\" + 16 lowercase hex
+  chars` per Spec 010 §Digest algorithm. The 16-hex prefix is the
+  first 64 bits of the SHA-256 over the canonical concatenation
+  (line-sorted `<path-string> <sha256-hex>\\n`)."
+  (:require [re-frame.schemas.digest]))
+
+;; ---- the parity test entry point ------------------------------------------
+;;
+;; `compute-digest` is private; both runtimes reach it via `#'`. The
+;; helper indirection keeps the runtime-specific var-deref out of the
+;; per-fixture assertions.
+
+(def compute-digest-var
+  "The private digest-from-map function under test. Both runtimes deref
+  the same symbol; the value is byte-identical when fed byte-identical
+  inputs."
+  #'re-frame.schemas.digest/compute-digest)
+
+(defn compute-digest
+  "Run the private digest pipeline against a `path->schema` map.
+  Returns the canonical `\"sha256:\" + 16-hex` wire form."
+  [path->schema]
+  (compute-digest-var path->schema))
+
+;; ---- the canonical corpus -------------------------------------------------
+;;
+;; Each fixture is a `{:label, :input, :expected, :rationale}` map. The
+;; input is fed directly to `compute-digest`; the expected string is
+;; the canonical literal both runtimes MUST produce. The corpus covers:
+;;
+;;   * empty-set      — already pinned at rf2-0z1z; carried here for
+;;                      single-source-of-truth.
+;;   * single-prim    — one path, primitive keyword schema (`:int`).
+;;   * single-vector  — one path, vector schema (`[:int]`).
+;;   * multi-schema   — two paths, vector schemas.
+;;   * nested-paths   — three paths into a nested app-db shape.
+;;   * with-props     — Malli `[:map {:closed true ...} & children]`
+;;                      shape — exercises the map-key sort inside the
+;;                      canonical form.
+;;   * primitive-bool — confirms a non-int primitive keyword schema
+;;                      hashes to a distinct value.
+
+(def empty-set
+  {:label     "empty-set"
+   :input     {}
+   :expected  "sha256:e3b0c44298fc1c14"
+   :rationale "SHA-256 of the empty string — the lines list collapses
+              to an empty concatenation. Carried from rf2-0z1z."})
+
+(def single-prim
+  {:label     "single-prim"
+   :input     {[:n] :int}
+   :expected  "sha256:5d955f1275ab1ae7"
+   :rationale "One path, keyword primitive schema. Smallest non-empty
+              fixture — tests the single-line code path."})
+
+(def single-vector
+  {:label     "single-vector"
+   :input     {[:user] [:map [:id :uuid]]}
+   :expected  "sha256:7217a35f9e8d1b08"
+   :rationale "One path, vector Malli schema. Pins the bare-`[:map ...]`
+              canonical form."})
+
+(def multi-schema
+  {:label     "multi-schema"
+   :input     {[:user]  [:map [:id :uuid]]
+               [:todos] [:vector :string]}
+   :expected  "sha256:d2ffa3677b377e60"
+   :rationale "Two paths, vector schemas. Exercises the lexicographic
+              line-sort (Spec 010 §Digest algorithm step 4)."})
+
+(def nested-paths
+  {:label     "nested-paths"
+   :input     {[:app :settings :theme] [:enum :light :dark]
+               [:app :user :name]      :string
+               [:app :user :age]       [:int {:min 0 :max 150}]}
+   :expected  "sha256:09ec6b6ec7e9e058"
+   :rationale "Three paths into a nested app-db shape. Exercises long
+              paths and a schema-props map (`{:min 0 :max 150}`) that
+              the canonical-form's sort-by-pr-str map-key ordering
+              must serialise stably."})
+
+(def with-props
+  {:label     "with-props"
+   :input     {[:user] [:map {:closed true :title "User"} [:id :uuid] [:name :string]]}
+   :expected  "sha256:414f163e837264ca"
+   :rationale "Malli `[:map {props} & children]` shape. Exercises the
+              inner-map sort over `{:closed true :title \"User\"}` —
+              insertion-order independence is pinned by the
+              `props-order-independent` test below."})
+
+(def primitive-bool
+  {:label     "primitive-bool"
+   :input     {[:flag] :boolean}
+   :expected  "sha256:9ceab11cd54a81ef"
+   :rationale "Distinct primitive keyword (`:boolean`) — confirms the
+              digest moves on a primitive-type change, locking the
+              `not= digest` invariant for the keyword-primitive
+              surface."})
+
+(def all-fixtures
+  "All canonical fixtures in label-order. Test files iterate this list
+  so adding a fixture requires no edits to the per-runtime test code."
+  [empty-set
+   single-prim
+   single-vector
+   multi-schema
+   nested-paths
+   with-props
+   primitive-bool])
+
+;; ---- invariant fixtures (input pairs that MUST hash identically) ---------
+;;
+;; The structural invariants from Spec 010 §Digest algorithm — order
+;; independence (path-level and props-level) and metadata stripping —
+;; aren't pinned to a literal here; instead they're asserted as
+;; equality between two distinct inputs. The expected hash is whatever
+;; both inputs produce (it will be the same string by construction,
+;; and both runtimes will compute the same string).
+
+(def path-order-pair
+  {:label "path-order-independent"
+   :input-a {[:user]  [:map [:id :uuid]]
+             [:todos] [:vector :string]}
+   :input-b {[:todos] [:vector :string]
+             [:user]  [:map [:id :uuid]]}
+   :rationale "Spec 010 §Digest algorithm step 4 — the lines list is
+               lexicographically sorted before final hashing, so the
+               registration / insertion order of paths in the
+               `path->schema` map is digest-irrelevant."})
+
+(def props-order-pair
+  {:label   "props-order-independent"
+   :input-a {[:user] [:map (array-map :closed true :title "User") [:id :uuid]]}
+   :input-b {[:user] [:map (array-map :title "User" :closed true) [:id :uuid]]}
+   :rationale "Spec 010 §Digest algorithm step 1 — the canonical form
+               sorts map-keys by `(compare (pr-str a) (pr-str b))`, so
+               the insertion order of keys inside a schema-props map
+               is digest-irrelevant."})
+
+(def metadata-stripped-pair
+  {:label   "metadata-stripped"
+   :input-a {[:user] [:map [:id :uuid]]}
+   :input-b {[:user] (with-meta [:map [:id :uuid]] {:doc "user-id"})}
+   :rationale "Spec 010 §Digest algorithm step 1 — the canonical form
+               binds `*print-meta* false`, so metadata attached to a
+               schema value does NOT alter the digest."})
+
+(def metadata-stripped-inner-pair
+  {:label   "metadata-stripped-inner"
+   :input-a {[:user] [:map {:closed true} [:id :uuid]]}
+   :input-b {[:user] [:map (with-meta {:closed true} {:annot :x}) [:id :uuid]]}
+   :rationale "Metadata stripping applies recursively — metadata on a
+               nested props map is dropped too, not just metadata on
+               the outermost schema."})
+
+(def invariant-pairs
+  "All equality-invariant fixture pairs. Each MUST produce identical
+  digests across both inputs and across both runtimes."
+  [path-order-pair
+   props-order-pair
+   metadata-stripped-pair
+   metadata-stripped-inner-pair])

--- a/implementation/schemas/test/re_frame/schemas/digest_parity_test.clj
+++ b/implementation/schemas/test/re_frame/schemas/digest_parity_test.clj
@@ -1,0 +1,87 @@
+(ns re-frame.schemas.digest-parity-test
+  "JVM side of the app-schemas-digest cross-runtime byte-identity
+  parity smoke (rf2-xssfv).
+
+  Spec 010 §Digest algorithm pins the digest as byte-identical between
+  CLJS and JVM runtimes: `'cross-runtime reproducible — a CLJS server
+  and a CLJS client running the same schema set produce the same
+  digest, byte-for-byte'`. Before this file the only digest vector
+  pinned to a literal was the empty-set case (`sha256:e3b0c44298fc1c14`,
+  rf2-0z1z); a multi-schema regression that flipped the JVM digest by
+  one byte while leaving the empty-set untouched (e.g. a sort-order
+  bug in `canonicalise-schema-form`) would have shipped silently. The
+  audit at rf2-x8x4p (TE6 / S7) called this out and rf2-xssfv pins the
+  vectors.
+
+  Pattern mirrors `re-frame.source-coord-parity-test` (rf2-1q9de) —
+  both runtimes consume the SAME fixture map (loaded from a shared
+  `.cljc` fixtures namespace) and pin the SAME canonical literal. The
+  literal IS the cross-host byte-comparison point. The companion CLJS
+  test lives at `re-frame.schemas.digest-parity-cljs-test` and pins
+  the same literals against the same fixtures.
+
+  Strategy: `compute-digest` is private; both runtimes reach it via
+  `#'re-frame.schemas.digest/compute-digest`. The shared fixtures
+  namespace dereferences the var once and exposes it as
+  `compute-digest`, so per-fixture assertions are runtime-agnostic."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.schemas.digest-parity-fixtures :as fixtures]))
+
+;; ---- pinned-literal vectors -----------------------------------------------
+;;
+;; Each fixture in `fixtures/all-fixtures` carries a canonical literal
+;; — the `\"sha256:\" + 16-hex` wire form the digest MUST produce. Both
+;; runtimes pin the same literal; if either runtime drifts, that
+;; runtime's test fails on the specific fixture.
+
+(deftest jvm-digest-matches-canonical-literal
+  (testing "Per Spec 010 §Digest algorithm — every canonical fixture
+            hashes to its pinned `\"sha256:\" + 16-hex` literal under
+            the JVM digest pipeline. Byte-identity with the CLJS-side
+            literal is what locks the cross-runtime invariant."
+    (doseq [{:keys [label input expected rationale]} fixtures/all-fixtures]
+      (let [actual (fixtures/compute-digest input)]
+        (is (= expected actual)
+            (str "JVM digest for fixture " (pr-str label) " — "
+                 rationale
+                 " — expected " (pr-str expected) ", got " (pr-str actual)))))))
+
+;; ---- equality-invariant pairs --------------------------------------------
+;;
+;; Order independence (paths, props) and metadata stripping are
+;; structural invariants from Spec 010 §Digest algorithm. The two
+;; inputs MUST hash to the same digest; we don't pin which digest, only
+;; that they agree. The CLJS counterpart pins the same invariants.
+
+(deftest jvm-digest-honours-equality-invariants
+  (testing "Spec 010 §Digest algorithm structural invariants — order-
+            independence (paths, props) and metadata stripping — every
+            fixture pair MUST produce byte-identical digests under
+            the JVM pipeline."
+    (doseq [{:keys [label input-a input-b rationale]} fixtures/invariant-pairs]
+      (let [da (fixtures/compute-digest input-a)
+            db (fixtures/compute-digest input-b)]
+        (is (= da db)
+            (str "JVM invariant pair " (pr-str label) " — "
+                 rationale
+                 " — input-a → " (pr-str da)
+                 ", input-b → " (pr-str db)))))))
+
+;; ---- corpus distinctness sanity ------------------------------------------
+;;
+;; If two of the canonical fixtures hashed to the same digest, the
+;; pinned literals would still match (per-fixture) but the corpus
+;; would have lost discriminating power. Confirm the literals are
+;; pairwise distinct.
+
+(deftest jvm-fixture-literals-pairwise-distinct
+  (testing "The pinned-literal corpus is pairwise distinct — no two
+            fixtures collide on the 16-hex prefix. A collision here
+            would not be wrong (the spec doesn't forbid hash
+            collisions) but it would mean the corpus failed to
+            discriminate between the schema sets, defeating the
+            point of pinning."
+    (let [literals (mapv :expected fixtures/all-fixtures)]
+      (is (= (count literals) (count (set literals)))
+          (str "Fixture literals must be pairwise distinct — got "
+               (pr-str literals))))))


### PR DESCRIPTION
## Summary

- Pin app-schemas-digest cross-runtime byte-identity (rf2-xssfv). Spec 010 §Digest algorithm requires byte-identical digests across CLJS and JVM; before this PR only the empty-set vector (`sha256:e3b0c44298fc1c14`, rf2-0z1z) was pinned. The audit at rf2-x8x4p (TE6 / S7) called out the gap.
- Mirror the SSR source-coord-parity pattern (rf2-1q9de): a shared `.cljc` fixtures namespace publishes the canonical literals; the JVM-side `digest_parity_test.clj` and CLJS-side `digest_parity_cljs_test.cljs` independently pin the same strings. The literal IS the cross-host byte-comparison point.
- Corpus: 7 canonical-literal fixtures (empty-set, single-prim, single-vector, multi-schema, nested-paths, with-props, primitive-bool) + 4 equality-invariant pairs (path-order, props-order, metadata-stripped outer/inner). Adds 6 new tests / 24 new assertions across JVM + CLJS.

## Test plan

- [x] `clojure -M:test` in `implementation/schemas/` — 126 tests, 364 assertions, 0 failures (3 new JVM tests, 12 new assertions)
- [x] `npm run test:cljs` from `implementation/` — 1812 tests, 5023 assertions, 0 failures; new `re-frame.schemas.digest-parity-cljs-test` ns picked up by `:node-test` build
- [x] Both runtimes produce byte-identical 16-hex digests for every pinned fixture
