### PR TITLE
perf(ssr): byte-level fnv-1a-32 JVM fast path (rf2-t7ktb)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/hash.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hash.cljc
@@ -8,8 +8,25 @@
   Same algorithm both sides → byte-identical hashes for byte-identical
   canonical EDN.
 
-  Per the rf2-gxgo7 split of re-frame.ssr."
-  (:require [clojure.string]))
+  Per the rf2-gxgo7 split of re-frame.ssr.
+
+  ## Byte-level fast path (rf2-t7ktb)
+
+  FNV-1a is defined over a byte stream. Both runtimes encode the
+  canonical-EDN string as UTF-8 bytes before hashing — `.getBytes
+  StandardCharsets/UTF_8` on JVM, `goog.crypt/stringToUtf8ByteArray` on
+  CLJS. Operating on UTF-8 bytes (rather than UTF-16 code units) keeps
+  JVM and CLJS byte-identical for the full Unicode range and lets the
+  JVM hot loop run over a primitive `byte-array` with `aget`, avoiding
+  per-character `.charAt` boxing overhead. For ASCII inputs (the common
+  SSR case) a UTF-8 byte equals the UTF-16 code unit so this change is
+  a pure refactor; for non-ASCII inputs the byte stream is the only
+  cross-runtime stable representation. The CLJS↔JVM parity smoke
+  (`hash_check_cljs_test.cljs`) pins `9d7457ef` for the ASCII fixture
+  `[:div {:class \"x\"} [:p \"hi\"]]` and continues to hold."
+  (:require #?(:cljs [goog.crypt :as gcrypt])
+            [clojure.string])
+  #?(:clj (:import [java.nio.charset StandardCharsets])))
 
 (defn canonical-edn
   "Print a render-tree node in a stable order. Maps are sorted by key
@@ -56,30 +73,51 @@
     :else (pr-str x)))
 
 (defn fnv-1a-32
-  "FNV-1a 32-bit hash of a string. Returns the lowercase-hex form, no
-  prefix. Stable on JVM and CLJS — uses unchecked 32-bit multiply on
-  both sides (CLJS via Math.imul, JVM via long-multiply-then-mask).
-  Output bytes are byte-identical for byte-identical input strings."
+  "FNV-1a 32-bit hash of a string, output as lowercase 8-char hex (no
+  prefix). Both runtimes hash the UTF-8 byte encoding of the input so
+  output is byte-identical across JVM and CLJS for any Unicode input.
+
+  - JVM: encodes via `String.getBytes(UTF_8)` and loops over the
+    primitive `byte-array` with `aget`. The byte is unsigned via
+    `(bit-and b 0xff)`; the 32-bit truncation comes from
+    `(bit-and 0xffffffff (unchecked-multiply ...))` matching the
+    pre-rf2-t7ktb arithmetic exactly — only the iteration source
+    moved from `.charAt`-by-`.charAt` to `aget` over a byte array.
+  - CLJS: encodes via `goog.crypt/stringToUtf8ByteArray` (returns a
+    JS array of unsigned bytes 0..255) and loops over it with `aget`.
+    `Math.imul` provides the 32-bit signed multiply; the final
+    `unsigned-bit-shift-right h 0` lifts the result back to unsigned
+    for hex formatting.
+
+  Per rf2-t7ktb — byte-level fast path replaces a char-by-char loop
+  that walked `.charAt` / `.charCodeAt`. The JVM hot loop now runs
+  over a primitive byte array (measured ~3-5x faster on medium-sized
+  canonical-EDN inputs); the CLJS path matches the same byte stream
+  so the JVM↔CLJS parity pin (`hash_check_cljs_test.cljs`) holds."
   [s]
-  (let [offset 2166136261              ;; FNV offset basis
-        prime  16777619]               ;; FNV prime
-    (loop [i 0
-           h offset]
-      (if (>= i (count s))
-        ;; Convert h to unsigned 32-bit and emit lowercase 8-char hex.
-        ;; JS's bitwise ops are 32-bit SIGNED; the `>>> 0` idiom forces
-        ;; unsigned. JVM bit-and-with-0xffffffff suffices.
-        #?(:clj  (format "%08x" (bit-and h 0xffffffff))
-           :cljs (let [u (unsigned-bit-shift-right h 0)
-                       hex (.toString u 16)]
-                   (.padStart hex 8 "0")))
-        (let [c (#?(:clj int :cljs .charCodeAt) (.charAt s i) #?(:cljs 0))
-              x (bit-xor h c)
-              ;; Guaranteed 32-bit multiply.
-              p #?(:clj  (bit-and 0xffffffff
-                                  (unchecked-multiply x prime))
-                   :cljs (js/Math.imul x prime))]
-          (recur (inc i) p))))))
+  #?(:clj
+     (let [^bytes bs (.getBytes ^String s StandardCharsets/UTF_8)
+           len      (alength bs)]
+       (loop [i 0
+              h 2166136261]                                       ;; FNV offset basis
+         (if (>= i len)
+           (format "%08x" (bit-and h 0xffffffff))
+           (recur (unchecked-inc-int i)
+                  (bit-and 0xffffffff
+                           (unchecked-multiply
+                             (bit-xor h (bit-and (aget bs i) 0xff))
+                             16777619))))))                       ;; FNV prime
+     :cljs
+     (let [bs  (gcrypt/stringToUtf8ByteArray s)
+           len (alength bs)]
+       (loop [i 0
+              h 2166136261]                                       ;; FNV offset basis
+         (if (>= i len)
+           (let [u   (unsigned-bit-shift-right h 0)
+                 hex (.toString u 16)]
+             (.padStart hex 8 "0"))
+           (recur (inc i)
+                  (js/Math.imul (bit-xor h (aget bs i)) 16777619)))))))
 
 (defn render-tree-hash
   "Per Spec 011 §Hydration-mismatch detection: a stable structural hash


### PR DESCRIPTION
## Summary

The hot loop in `re-frame.ssr.hash/fnv-1a-32` now hashes the **UTF-8 byte
encoding** of the input string rather than walking it code-unit-by-code-
unit via `.charAt` / `.charCodeAt`.

- **JVM**: `String.getBytes(UTF_8)` + `aget` over the primitive byte
  array. The 32-bit arithmetic (`(bit-and 0xffffffff (unchecked-multiply ...))`)
  is unchanged — only the iteration source moved from `.charAt`-by-`.charAt`
  to `aget` over a primitive byte array. Avoids per-character `String.charAt`
  bounds-check + boxing overhead in the inner loop. Per audit rf2-asmj1
  §Q11/P3, ~3-5x faster on medium-sized canonical-EDN inputs.
- **CLJS**: `goog.crypt/stringToUtf8ByteArray` + `aget` matches the same
  byte stream so the JVM↔CLJS parity invariant holds for the **full
  Unicode range**, not just ASCII. (Previously both sides walked UTF-16
  code units, which agreed with each other for the BMP but diverged from
  the byte-level definition of FNV-1a.)

For ASCII inputs (the common SSR case) a UTF-8 byte equals the UTF-16
code unit, so the hash is **bit-identical** to the pre-fix output.

## Byte-identity invariant

The Spec 010 / Spec 011 / rf2-1q9de cross-runtime parity invariant is
preserved:

- `hash_check_cljs_test.cljs` pins `9d7457ef` for `[:div {:class "x"} [:p "hi"]]`
  → CLJS still emits `9d7457ef` ✓
- The JVM REPL produces `9d7457ef` for the same input ✓
- `ssr_hash_test.clj` (the nil-pruning rules) passes unchanged ✓

## Test plan

- [x] `clojure -M:test` in `implementation/ssr/` → 78 tests / 241 assertions, 0 failures
- [x] `npm run test:cljs` in `implementation/` → 1809 tests / 5011 assertions, 0 failures
- [x] `hash-check-cljs-test/jvm-cljs-hash-parity` — CLJS hash `9d7457ef` matches the JVM hash for the pinned fixture
- [x] JVM REPL: `(render-tree-hash [:div {:class "x"} [:p "hi"]])` → `"9d7457ef"`

## Refs

- Closes rf2-t7ktb
- Builds on rf2-gxgo7 (ssr-namespace split) and rf2-6djjl (canonical-EDN nil pruning)
- Audit source: rf2-asmj1 §Q11/P3