### PR TITLE
feat(schemas): pluggable schema-print companion fn (rf2-wla45)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -300,6 +300,7 @@
 (def app-schemas-digest     rf-schemas/app-schemas-digest)
 (def set-schema-validator!  rf-schemas/set-schema-validator!)
 (def set-schema-explainer!  rf-schemas/set-schema-explainer!)
+(def set-schema-printer!    rf-schemas/set-schema-printer!)
 
 ;; ---- clearing ------------------------------------------------------------
 

--- a/implementation/core/src/re_frame/core_schemas.cljc
+++ b/implementation/core/src/re_frame/core_schemas.cljc
@@ -79,6 +79,25 @@
   {:hook :schemas/set-schema-explainer! :artefact schemas-artefact :on-absent :nil}
   ([explain-fn] :delegate))
 
+(defwrapper set-schema-printer!
+  "Register the schema-print companion — `(fn [schema-value]
+  canonical-string)` — the digest pipeline hashes (Spec 010 §Schema
+  digest line 491, rf2-wla45). Parallel to `set-schema-validator!`
+  and `set-schema-explainer!`: ports that ship a non-Malli schema
+  language register their own serialiser so the digest reflects the
+  validator's own contract rather than the framework's Malli-EDN
+  default.
+
+  The fn MUST be pure and cross-runtime deterministic — a CLJS
+  server and a CLJS client running the same schema set MUST produce
+  the same bytes (Spec 010 §Digest algorithm). Setting `nil` falls
+  back to the default EDN canonicaliser so the digest is never
+  undefined.
+
+  Returns nil when the schemas artefact is not on the classpath."
+  {:hook :schemas/set-schema-printer! :artefact schemas-artefact :on-absent :nil}
+  ([print-fn] :delegate))
+
 (defwrapper reg-app-schema
   "Fn-form delegate that performs the late-bind lookup for
   `reg-app-schema`. The `re-frame.core/reg-app-schema` macro (JVM) and

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -123,6 +123,10 @@
     :producer-ns 're-frame.schemas
     :design-bead "rf2-froe"
     :description "Install a pluggable schema-explainer fn paired with the validator."}
+   {:key         :schemas/set-schema-printer!
+    :producer-ns 're-frame.schemas
+    :design-bead "rf2-wla45"
+    :description "Install a pluggable schema-print companion fn (Spec 010 §Schema digest line 491). The digest pipeline hashes this fn's UTF-8 output; non-Malli ports register their own serialiser so digests reflect the registered validator's serialisation contract."}
    {:key         :schemas/validate-with-registered-fn
     :producer-ns 're-frame.schemas
     :design-bead "rf2-r2uh"

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -74,10 +74,12 @@
 (def schemas-by-frame storage/schemas-by-frame)
 (def validator-fn     validator/validator-fn)
 (def explainer-fn     validator/explainer-fn)
+(def printer-fn       validator/printer-fn)
 
-;; Validator / explainer (rf2-froe).
+;; Validator / explainer / printer (rf2-froe + rf2-wla45).
 (def set-schema-validator!   validator/set-schema-validator!)
 (def set-schema-explainer!   validator/set-schema-explainer!)
+(def set-schema-printer!     validator/set-schema-printer!)
 (def reset-schema-validator! validator/reset-schema-validator!)
 
 ;; Registration + per-frame query (Spec 010 §Per-frame schemas).
@@ -155,6 +157,7 @@
 (late-bind/set-fn! :schemas/app-schemas-digest    app-schemas-digest)
 (late-bind/set-fn! :schemas/set-schema-validator! set-schema-validator!)
 (late-bind/set-fn! :schemas/set-schema-explainer! set-schema-explainer!)
+(late-bind/set-fn! :schemas/set-schema-printer!   set-schema-printer!)
 
 ;; Elision-walker hooks (rf2-nwv63 / rf2-v9tw2) — published so
 ;; re-frame.core's downstream registry-population code can hydrate

--- a/implementation/schemas/src/re_frame/schemas/digest.cljc
+++ b/implementation/schemas/src/re_frame/schemas/digest.cljc
@@ -6,6 +6,18 @@
   frames produce equal digests iff their `{path → schema-value}` maps
   serialise byte-for-byte identically.
 
+  Per Spec 010 §Schema digest line 491 the per-schema serialisation
+  step routes through the registered validator's `schema-print`
+  companion fn — pluggable via `re-frame.schemas.validator/printer-fn`
+  (rf2-wla45). The default is `validator/default-edn-print` (the
+  Malli-EDN canonical `pr-str`); non-Malli ports register their own
+  serialiser via `set-schema-printer!` so the digest reflects the
+  registered validator's serialisation contract rather than the
+  framework's Malli-EDN default. The rest of the pipeline — SHA-256
+  per entry, `<path> <hex>\\n` line emission, lexicographic line sort,
+  `\"sha256:\" + first-16-hex` truncation — is fixed by spec and shared
+  across every port.
+
   Used by:
     - The epoch-restore schema-mismatch trace (epoch.cljc) — pinpoints
       when a frame's schema set drifted between record and restore.
@@ -15,48 +27,10 @@
       have shifted under them."
   (:require #?(:cljs [goog.crypt :as gcrypt])
             #?(:cljs [goog.crypt.Sha256])
-            [re-frame.schemas.storage :as storage])
+            [re-frame.schemas.storage :as storage]
+            [re-frame.schemas.validator :as validator])
   #?(:clj (:import [java.security MessageDigest]
                    [java.nio.charset StandardCharsets])))
-
-(defn- canonicalise-schema-form
-  "Normalise a Malli EDN schema form for stable byte serialisation:
-  metadata is stripped, and map-keys (the Malli `props` map's contents
-  in `[:map {k v ...} & children]`) are emitted in (compare a b) order
-  via `sort-by str`. The result is fed through `pr-str` to produce the
-  canonical UTF-8 byte sequence Spec 010 hashes."
-  [form]
-  (letfn [(canon [x]
-            (cond
-              (map? x)
-              ;; Sort keys lexicographically by their printed form so two
-              ;; equivalent maps with different insertion order serialise
-              ;; identically. Using a sorted-map preserves the order
-              ;; through pr-str.
-              (into (sorted-map-by (fn [a b]
-                                     (compare (pr-str a) (pr-str b))))
-                    (map (fn [[k v]] [(canon k) (canon v)]))
-                    x)
-              (vector? x) (mapv canon x)
-              (set? x)    (into (sorted-set-by (fn [a b]
-                                                 (compare (pr-str a) (pr-str b))))
-                                (map canon)
-                                x)
-              (seq? x)    (doall (map canon x))
-              :else       x))]
-    (canon form)))
-
-(defn- schema-print
-  "Serialise a schema value to a stable UTF-8 byte-source string. Per
-  Spec 010 §Digest algorithm step 1, the CLJS reference uses `pr-str`
-  over the Malli EDN form with map-key ordering normalised and metadata
-  stripped."
-  [schema-value]
-  (binding [*print-meta*       false
-            *print-readably*   true
-            *print-dup*        false
-            *print-namespace-maps* false]
-    (pr-str (canonicalise-schema-form schema-value))))
 
 (defn- utf8-bytes
   "Encode a string as UTF-8 bytes."
@@ -92,11 +66,14 @@
 
 (defn- digest-line
   "Per Spec 010 §Digest algorithm step 3 — emit one line per
-  `(path, schema-value)` of the form `<path-string> <hex-of-sha256>\\n`."
+  `(path, schema-value)` of the form `<path-string> <hex-of-sha256>\\n`.
+  The per-schema serialisation routes through the registered
+  `schema-print` companion (rf2-wla45) so non-Malli ports compute
+  digests against their own canonical bytes."
   [path schema-value]
   (str (pr-str path)
        " "
-       (sha256-hex (schema-print schema-value))
+       (sha256-hex (validator/run-printer schema-value))
        "\n"))
 
 (defn- compute-digest

--- a/implementation/schemas/src/re_frame/schemas/validator.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validator.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.schemas.validator
-  "Pluggable validator / explainer fns (rf2-froe).
+  "Pluggable validator / explainer / printer fns (rf2-froe + rf2-wla45).
 
   Per Spec 010 §Non-Malli validators — the validator-fn extension point.
   The framework never inspects the value stored in `:spec` directly;
@@ -9,9 +9,10 @@
   `(rf/set-schema-validator! some-other-fn)` (or `nil` for no-op) at
   boot before any reg-app-schema / :spec metadata lands.
 
-  Two fns are registered separately so the validate hot path stays
+  Three fns are registered separately so the validate hot path stays
   cheap (validate returns truthy/falsey; explain is only invoked on
-  the failure branch to populate the trace's `:explain` key):
+  the failure branch to populate the trace's `:explain` key; print is
+  only invoked when the digest pipeline serialises a schema):
 
     :validate (fn [schema value] truthy?)
               — same shape as Malli's `validate`. nil disables; the
@@ -21,8 +22,21 @@
               — same shape as Malli's `explain`. nil = no explanation
               attached to the failure trace.
 
-  A combined `(set-schema-validator! {:validate ... :explain ...})`
-  arity exists for callers who want to install both atomically.
+    :print    (fn [schema-value] canonical-string)
+              — per Spec 010 §Schema digest line 491, the registered
+              validator's `schema-print` companion. Serialises a
+              schema value to the byte-stable UTF-8 string the digest
+              pipeline hashes. The default mirrors the Malli-EDN
+              canonicalisation (sort-by-pr-str map keys, metadata
+              stripped, `pr-str`); ports that ship a non-EDN schema
+              language (a Zod / clojure.spec port) install their own
+              printer here so digests match the validator's own
+              serialisation contract. nil falls back to the default
+              EDN canonicaliser, which is the cross-runtime contract
+              every Malli-EDN-compatible port shares.
+
+  A combined `(set-schema-validator! {:validate ... :explain ... :print ...})`
+  arity exists for callers who want to install all three atomically.
 
   Per rf2-t0hq the CLJS default validator used to reach Malli through
   runtime `resolve` — but CLJS has no runtime resolve (the symbol is
@@ -79,6 +93,50 @@
                (catch Throwable _ nil))
        :cljs nil)))
 
+(defn- canonicalise-schema-form
+  "Per Spec 010 §Digest algorithm step 1 — normalise a schema EDN form for
+  stable byte serialisation: metadata is stripped, and map keys are
+  emitted in `(compare (pr-str a) (pr-str b))` order via sorted-maps /
+  sorted-sets so insertion order does not bleed into the printed bytes.
+  Sequences and vectors recurse element-wise. Non-collection values
+  pass through unchanged."
+  [form]
+  (letfn [(canon [x]
+            (cond
+              (map? x)
+              (into (sorted-map-by (fn [a b]
+                                     (compare (pr-str a) (pr-str b))))
+                    (map (fn [[k v]] [(canon k) (canon v)]))
+                    x)
+              (vector? x) (mapv canon x)
+              (set? x)    (into (sorted-set-by (fn [a b]
+                                                 (compare (pr-str a) (pr-str b))))
+                                (map canon)
+                                x)
+              (seq? x)    (doall (map canon x))
+              :else       x))]
+    (canon form)))
+
+(defn default-edn-print
+  "The default schema-print companion (rf2-wla45). Per Spec 010 §Schema
+  digest line 491 — serialise a schema value to the stable UTF-8
+  byte-source string the digest pipeline hashes. The default uses
+  `pr-str` over a canonicalised EDN form: map-keys emitted in
+  `compare-by-pr-str` order, metadata stripped, namespaced-map
+  printing disabled. This is the cross-runtime contract every
+  Malli-EDN-compatible port shares.
+
+  Ports that ship a non-EDN schema language register their own printer
+  via `set-schema-printer!`; the digest then reflects the registered
+  validator's serialisation contract rather than the framework's
+  Malli-EDN default."
+  [schema-value]
+  (binding [*print-meta*           false
+            *print-readably*       true
+            *print-dup*            false
+            *print-namespace-maps* false]
+    (pr-str (canonicalise-schema-form schema-value))))
+
 (defonce
   ^{:doc "The currently-registered validator fn — `(fn [schema value]
           truthy?)`. Default delegates to Malli; apps swap via
@@ -95,6 +153,20 @@
           explanation is attached."}
   explainer-fn
   (atom default-malli-explain))
+
+(defonce
+  ^{:doc "The currently-registered schema-print fn — `(fn [schema-value]
+          canonical-string)`. Per Spec 010 §Schema digest line 491,
+          the registered validator's `schema-print` companion. The
+          digest pipeline (`re-frame.schemas.digest`) hashes the
+          UTF-8 bytes of this fn's return value. Default is
+          `default-edn-print` (Malli-EDN canonicalisation); ports
+          that ship a non-EDN schema language swap in their own
+          serialiser via `set-schema-printer!`. nil falls back to
+          the default — the digest is never undefined for a present
+          schema set."}
+  printer-fn
+  (atom default-edn-print))
 
 (defn set-schema-validator!
   "Register the validator fn that every dev-time validation site routes
@@ -113,10 +185,16 @@
       falsey on fail. The explainer is left untouched (apps that want
       to also swap explanations call `set-schema-explainer!`).
 
-    (set-schema-validator! {:validate validate-fn :explain explain-fn})
-      Atomic swap of both fns at once. Either key may be `nil` to
-      disable the corresponding hot path. Keys not supplied leave the
-      existing registration in place.
+    (set-schema-validator! {:validate validate-fn
+                            :explain  explain-fn
+                            :print    print-fn})
+      Atomic swap of any subset at once. Per rf2-wla45 the `:print`
+      key registers the schema-print companion the digest pipeline
+      hashes (Spec 010 §Schema digest line 491). Any key may be `nil`
+      to disable the corresponding hot path (the printer falls back
+      to the default EDN canonicaliser; the digest is never
+      undefined for a present schema set). Keys not supplied leave
+      the existing registration in place.
 
   Per Spec 010 §Non-Malli validators the validator-fn must be pure
   (same `(schema, value)` returns the same result) and must be
@@ -130,11 +208,13 @@
   [validate-fn-or-map]
   (cond
     (map? validate-fn-or-map)
-    (let [{:keys [validate explain]
+    (let [{:keys [validate explain print]
            :or   {validate ::unset
-                  explain  ::unset}} validate-fn-or-map]
+                  explain  ::unset
+                  print    ::unset}} validate-fn-or-map]
       (when-not (= ::unset validate) (reset! validator-fn validate))
       (when-not (= ::unset explain)  (reset! explainer-fn  explain))
+      (when-not (= ::unset print)    (reset! printer-fn    print))
       @validator-fn)
 
     :else
@@ -153,14 +233,43 @@
   (reset! explainer-fn explain-fn)
   @explainer-fn)
 
+(defn set-schema-printer!
+  "Register the schema-print companion — `(fn [schema-value]
+  canonical-string)` — the digest pipeline hashes per Spec 010
+  §Schema digest line 491 (rf2-wla45). Parallel to
+  `set-schema-validator!` / `set-schema-explainer!`: the validator
+  surface is fully pluggable, and the digest contract is too —
+  non-Malli ports register their own serialiser so the digest
+  reflects the port's own validation contract rather than the
+  framework's Malli-EDN default.
+
+  The fn MUST be:
+    - Pure — same `schema-value` returns the same byte sequence.
+    - Deterministic across runtimes — a CLJS server and a CLJS
+      client running the same schema set MUST produce the same
+      bytes (Spec 010 §Digest algorithm cross-runtime guarantee).
+    - Defined for every schema value the registered validator
+      accepts.
+
+  Setting `nil` falls back to the default EDN canonicaliser
+  (`default-edn-print`) so the digest is never undefined for a
+  present schema set.
+
+  Last-write-wins. Returns the printer that was installed (the
+  default fn when nil was passed)."
+  [print-fn]
+  (reset! printer-fn (or print-fn default-edn-print))
+  @printer-fn)
+
 (defn reset-schema-validator!
-  "Reset the validator and explainer atoms back to the default Malli-
-  delegating fns. Test-support helper — restores the framework default
+  "Reset the validator, explainer, and printer atoms back to the
+  framework defaults. Test-support helper — restores the defaults
   after a test that called `set-schema-validator!` / `set-schema-
-  explainer!`."
+  explainer!` / `set-schema-printer!`."
   []
   (reset! validator-fn default-malli-validate)
-  (reset! explainer-fn default-malli-explain))
+  (reset! explainer-fn default-malli-explain)
+  (reset! printer-fn   default-edn-print))
 
 (defn run-validator
   "Hot-path entry — invoke the registered validator fn against a
@@ -180,3 +289,16 @@
   [schema value]
   (when-let [f @explainer-fn]
     (f schema value)))
+
+(defn run-printer
+  "Hot-path entry — invoke the registered schema-print companion (or
+  the default EDN canonicaliser when none is registered) against a
+  single schema value. Per Spec 010 §Schema digest line 491 — the
+  digest pipeline (`re-frame.schemas.digest`) hashes this fn's UTF-8
+  bytes (rf2-wla45). Never returns nil for a non-nil schema value:
+  a nil registration falls back to `default-edn-print` so the
+  cross-runtime digest contract holds even when the validator
+  surface is fully nilled out."
+  [schema-value]
+  (let [f (or @printer-fn default-edn-print)]
+    (f schema-value)))

--- a/implementation/schemas/test/re_frame/schemas/printer_seam_test.clj
+++ b/implementation/schemas/test/re_frame/schemas/printer_seam_test.clj
@@ -1,0 +1,145 @@
+(ns re-frame.schemas.printer-seam-test
+  "Pluggable schema-print companion fn (rf2-wla45).
+
+  Per Spec 010 §Schema digest line 491 — schema digests are computed
+  from the schema values as serialised by the registered validator's
+  `schema-print` companion fn. This file locks the pluggable surface
+  parallel to the rf2-froe `set-schema-validator!` / `set-schema-
+  explainer!` tests:
+
+    - The default printer matches the historical Malli-EDN
+      canonicaliser (digest values unchanged vs the pre-rf2-wla45
+      digest pipeline).
+    - `set-schema-printer!` swaps the printer atom; the digest
+      pipeline picks up the new bytes on the next call.
+    - Map-arity `(set-schema-validator! {:print fn})` swaps the
+      printer atomically alongside `:validate` / `:explain`.
+    - `set-schema-printer! nil` falls back to the default (the
+      digest is never undefined for a present schema set).
+    - `reset-schema-validator!` restores the default printer
+      alongside the validator/explainer defaults.
+
+  These contracts are what a non-Malli port (a Zod-port, a
+  clojure.spec port) needs to be able to plug into the digest
+  pipeline without re-implementing it."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.schemas :as schemas]
+            [re-frame.schemas.validator :as validator]))
+
+(defn- reset [test-fn]
+  ;; Per rf2-froe / rf2-wla45 — the validator/explainer/printer atoms
+  ;; are framework-wide; restore the defaults around each test so
+  ;; sibling tests are not poisoned.
+  (schemas/reset-schema-validator!)
+  (try (test-fn)
+       (finally (schemas/reset-schema-validator!))))
+
+(use-fixtures :each reset)
+
+(deftest default-printer-matches-historical-canonical-form
+  (testing "The default printer (`default-edn-print`) produces the pre-
+            rf2-wla45 canonical Malli-EDN bytes — sort-by-pr-str map
+            keys, metadata stripped, namespaced-map printing off,
+            `pr-str` over the canonicalised form. Locks the
+            backward-compatible default so existing pinned digest
+            literals (rf2-xssfv `digest_parity_fixtures.cljc`) keep
+            matching."
+    (is (= "[:map [:id :uuid]]"
+           (validator/run-printer [:map [:id :uuid]]))
+        "vector schema serialises as straightforward pr-str")
+    (is (= "[:map {:closed true, :title \"User\"} [:id :uuid]]"
+           (validator/run-printer
+             [:map (array-map :title "User" :closed true) [:id :uuid]]))
+        "map-keys in the props map sort by (compare (pr-str a) (pr-str b))
+         — :closed sorts before :title — regardless of insertion order")
+    (is (= "[:map [:id :uuid]]"
+           (validator/run-printer
+             ^{:doc "user-id"} [:map [:id :uuid]]))
+        "metadata is stripped (`:doc` does not appear in the printed bytes)")
+    (is (= ":int"
+           (validator/run-printer :int))
+        "primitive keyword schemas pass through pr-str unchanged")))
+
+(deftest set-schema-printer!-swaps-the-printer-atom
+  (testing "`set-schema-printer!` reaches the run-printer hot path on
+            the next call — the digest pipeline picks up the new bytes
+            without a restart."
+    (let [marker-printer (fn [_schema] "::SENTINEL::")]
+      (schemas/set-schema-printer! marker-printer)
+      (is (= "::SENTINEL::" (validator/run-printer [:map [:id :uuid]]))
+          "every schema serialises to the sentinel, regardless of shape")
+      (is (= "::SENTINEL::" (validator/run-printer :int))
+          "primitive keyword schemas route through the registered fn too"))))
+
+(deftest schema-print-swap-flips-the-digest-bytes
+  (testing "A printer swap changes the digest for a non-empty schema
+            set — the per-schema bytes are fed through the digest
+            pipeline so a different printer (returning different
+            bytes) MUST produce a different digest. This is the
+            cross-port distinction Spec 010 §Locked rules line 491
+            describes: 'two ports using *different* schema languages
+            produce different digests by construction'."
+    (schemas/reg-app-schema [:n] :int)
+    (let [default-digest (schemas/app-schemas-digest)]
+      (schemas/set-schema-printer! (fn [_schema] "::DIFFERENT::"))
+      (let [swapped-digest (schemas/app-schemas-digest)]
+        (is (not= default-digest swapped-digest)
+            "digest changes once the printer registers different bytes")))
+    ;; Restoring the default brings the digest back — the printer
+    ;; surface is purely a contract over the serialisation step.
+    (schemas/set-schema-printer! nil)
+    (is (= "sha256:5d955f1275ab1ae7"
+           (schemas/app-schemas-digest))
+        "set-schema-printer! nil restores the default — the digest matches
+         the rf2-xssfv `single-prim` literal byte-for-byte")))
+
+(deftest set-schema-validator!-map-arity-installs-printer
+  (testing "`(set-schema-validator! {:print fn})` swaps the printer
+            atom atomically alongside `:validate` / `:explain` — the
+            atomic-swap entry point is symmetrical across all three
+            fns (rf2-froe + rf2-wla45)."
+    (let [marker (fn [_] "::FROM-MAP-ARITY::")]
+      (schemas/set-schema-validator! {:print marker})
+      (is (= "::FROM-MAP-ARITY::" (validator/run-printer :int))
+          "the registered printer reaches the hot path"))))
+
+(deftest set-schema-printer!-nil-falls-back-to-default
+  (testing "Passing `nil` to `set-schema-printer!` reinstalls the
+            default EDN canonicaliser — the digest is never undefined
+            for a present schema set, even when the validator and
+            explainer have been nilled out (rf2-wla45 contract)."
+    (schemas/set-schema-printer! (fn [_] "::REPLACED::"))
+    (is (= "::REPLACED::" (validator/run-printer :int)))
+    (schemas/set-schema-printer! nil)
+    (is (= ":int" (validator/run-printer :int))
+        "nil printer falls back to default-edn-print; not 'no printer'")))
+
+(deftest reset-schema-validator!-restores-default-printer
+  (testing "`reset-schema-validator!` restores the framework defaults
+            for all three atoms — validator, explainer, AND printer.
+            Test-support call sites that previously only had to
+            worry about validator/explainer poisoning now also reset
+            the printer for free."
+    (schemas/set-schema-printer! (fn [_] "::POISONED::"))
+    (is (= "::POISONED::" (validator/run-printer :int)))
+    (schemas/reset-schema-validator!)
+    (is (= ":int" (validator/run-printer :int))
+        "reset restores the default EDN canonicaliser")))
+
+(deftest printer-only-affects-per-schema-bytes-not-pipeline-shape
+  (testing "The digest pipeline shape (line-sort, SHA-256, '\"sha256:\" +
+            16-hex' wire form) is fixed by Spec 010 §Digest algorithm
+            and does NOT route through the printer. A custom printer
+            that returns a constant still produces a well-formed wire
+            form — and the empty-set digest is unaffected because the
+            pipeline never invokes the printer (zero entries)."
+    (schemas/set-schema-printer! (fn [_] "::CONSTANT::"))
+    ;; Empty set — printer never called; the empty-set digest is
+    ;; the historical sha256:e3b0c44298fc1c14 (rf2-0z1z).
+    (is (= "sha256:e3b0c44298fc1c14"
+           (schemas/app-schemas-digest))
+        "empty schema set still produces the canonical empty-string SHA")
+    (schemas/reg-app-schema [:n] :int)
+    (let [d1 (schemas/app-schemas-digest)]
+      (is (re-matches #"^sha256:[0-9a-f]{16}$" d1)
+          "wire form is still '\"sha256:\" + 16-hex' regardless of printer"))))


### PR DESCRIPTION
## Summary

Per Spec 010 §Schema digest line 491 — schema digests are computed from the schema **values** as serialised by the registered validator's `schema-print` companion fn. The current digest pipeline used a schemas-internal Malli-EDN canonicaliser; a custom validator registered via `set-schema-validator!` could not supply its own `schema-print`, so a Zod or `clojure.spec` port would produce digests against re-frame2's hardcoded Malli-EDN bytes rather than the validator's own serialisation contract.

Closes the Spec 010 contract hole — pluggable validator now implies pluggable digest serialisation.

## Surface

- `re-frame.schemas.validator`
  - New `printer-fn` atom (parallel to `validator-fn` / `explainer-fn`).
  - New `default-edn-print` (the pre-rf2-wla45 canonicaliser, moved verbatim from `digest.cljc`).
  - New `set-schema-printer!` registration entry point (mirrors `set-schema-validator!` / `set-schema-explainer!`).
  - `set-schema-validator!` map-arity grows a `:print` key for atomic swap of all three fns.
  - `reset-schema-validator!` restores the printer default alongside validator/explainer.
  - New `run-printer` hot-path entry (digest pipeline calls this).
- `re-frame.schemas.digest`
  - `digest-line` now calls `validator/run-printer`; old internal `schema-print` / `canonicalise-schema-form` removed.
- `re-frame.schemas` (façade) — re-exports `printer-fn` / `set-schema-printer!`; publishes `:schemas/set-schema-printer!` late-bind hook.
- `re-frame.core-schemas` — `defwrapper` for `set-schema-printer!`.
- `re-frame.core` — `(def set-schema-printer! …)` re-export.
- `re-frame.late-bind.directory` — documents the new hook (drift gate registers the bead).

Default behaviour unchanged — the existing canonicalisation moved verbatim and is the registered default. The rf2-xssfv pinned digest literals (cross-runtime byte-identity vectors) continue to match.

## Test plan

- [x] `clojure -M:test` (schemas artefact) — 133 tests / 379 assertions, all pass. Includes 7 new tests in `re-frame.schemas.printer-seam-test` covering: default-printer canonical form, `set-schema-printer!` hot-path swap, digest-bytes flip on swap, map-arity install via `:print`, `nil` fallback to default, `reset-schema-validator!` covers printer, empty-set digest invariant under printer swap.
- [x] `clojure -M:test` (core artefact) — 456 tests / 2439 assertions, all pass. Late-bind drift test (`re-frame.late-bind-drift-test`) picks up the new `:schemas/set-schema-printer!` hook key.
- [x] `digest-parity-test` (JVM) — all rf2-xssfv pinned digest literals still match byte-for-byte (default printer unchanged).