### PR TITLE
fix(story): counter-with-stories.stories-cljs-test crash root cause (rf2-y6u4m)

### DIFF
--- a/examples/reagent/counter_with_stories/stories_cljs_test.cljs
+++ b/examples/reagent/counter_with_stories/stories_cljs_test.cljs
@@ -46,9 +46,7 @@
   (frame/ensure-default-frame!)
   (machines/reset-timers!)
   (loaders/clear-watchers!)
-  (reset! assertions/warnings-accumulator          {})
-  (reset! assertions/emitted-fx-accumulator        {})
-  (reset! assertions/dispatched-events-accumulator {})
+  (reset! assertions/trace-accumulators {})
   ;; Always re-fire the Story registrations so each test starts with
   ;; a freshly-resolved registry (clears any leftover stories from
   ;; previous tests and ensures the lifecycle machine is freshly


### PR DESCRIPTION
## Summary

- `npm run test:cljs` on `origin/main` crashed at `counter-with-stories.stories-cljs-test`'s `before!` fixture with `No protocol method IReset.-reset! defined for type undefined`.
- Root cause: rf2-wfiy5 (#917) consolidated three module-level atoms in `re-frame.story.assertions` (`warnings-accumulator`, `emitted-fx-accumulator`, `dispatched-events-accumulator`) into one `trace-accumulators` atom. The refactor migrated the test fixture in `tools/story/test/` but missed the analogous fixture in `examples/reagent/counter_with_stories/stories_cljs_test.cljs`. With the old Vars gone, the three `(reset! assertions/<old-name> {})` calls resolved to undefined and crashed the suite the moment any test in this ns ran.
- Fix: replace the three resets with the single `(reset! assertions/trace-accumulators {})`, matching the in-tree migration applied in rf2-wfiy5.

Pre-alpha: no back-compat shim added — the consolidation refactor's contract was "migrate all callers", and this was a missed caller.

## Test plan

- [x] `npm run test:cljs` from `implementation/` — full suite passes (1813 tests, 5024 assertions, 0 failures / 0 errors). `counter-with-stories.stories-cljs-test` runs cleanly.
- [x] Before the fix, the same suite crashed with the IReset protocol error on line 49 of `stories_cljs_test.cljs`.