### PR TITLE
refactor(ssr): split head.cljc + extract shared HTML escape helpers (rf2-x7g10)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -14,40 +14,30 @@
   view's root DOM element so pair-tool consumers can map server-rendered
   HTML back to the `reg-view` call site.
 
+  HTML escape helpers (`escape-html`, `escape-attr`, `attr-string`) live
+  in `re-frame.ssr.html-helpers` — shared with the head/meta emitter per
+  rf2-x7g10. Public-surface aliases are re-exported below so consumers
+  who `:require [re-frame.ssr.emit :as emit]` keep seeing them at
+  `emit/escape-html` / `emit/escape-attr` / `emit/attr-string`.
+
   Per the rf2-gxgo7 split of re-frame.ssr."
   (:require [clojure.string]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.ssr.hash :as hash]
+            [re-frame.ssr.html-helpers :as html]
             #?(:cljs [re-frame.substrate.plain-atom :as plain-atom-cljs])))
 
-(defn escape-html [s]
-  (-> (str s)
-      (clojure.string/replace "&" "&amp;")
-      (clojure.string/replace "<" "&lt;")
-      (clojure.string/replace ">" "&gt;")
-      (clojure.string/replace "\"" "&quot;")
-      (clojure.string/replace "'" "&#39;")))
+;; ---- shared HTML helpers (rf2-x7g10) --------------------------------------
+;;
+;; Re-export the helpers so callers that `:require [re-frame.ssr.emit :as
+;; emit]` still resolve `emit/escape-html` etc. The producing ns is
+;; `re-frame.ssr.html-helpers` (shared with `re-frame.ssr.head.emit`); the
+;; entity-escape rules live there once.
 
-(defn escape-attr [s]
-  ;; Less aggressive — attributes don't need < > escaped, but " must
-  ;; be escaped if we use double-quoted values. We use double-quoted
-  ;; values, so escape " and &.
-  (-> (str s)
-      (clojure.string/replace "&" "&amp;")
-      (clojure.string/replace "\"" "&quot;")))
-
-(defn attr-string [attrs]
-  (if (empty? attrs)
-    ""
-    (str " " (clojure.string/join " "
-               (map (fn [[k v]]
-                      (cond
-                        (true? v)  (name k)             ;; boolean attrs
-                        (false? v) nil
-                        (nil? v)   nil
-                        :else      (str (name k) "=\"" (escape-attr v) "\"")))
-                    attrs)))))
+(def escape-html html/escape-html)
+(def escape-attr html/escape-attr)
+(def attr-string html/attr-string)
 
 ;; Per HTML5 spec, these elements are void — they self-close and have no
 ;; closing tag.

--- a/implementation/ssr/src/re_frame/ssr/head.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head.cljc
@@ -1,385 +1,68 @@
 (ns re-frame.ssr.head
-  "Head/meta contract — `reg-head`, `render-head`, `active-head`. Per
-  Spec 011 §Head/meta contract (rf2-4dra9).
+  "Head/meta contract façade — `reg-head`, `render-head`, `active-head`,
+  `head-model->html`, `head-snapshot`. Per Spec 011 §Head/meta contract
+  (rf2-4dra9).
 
   The server-rendered HTML must carry head metadata — `<title>`,
   `<meta>`, `<link>`, JSON-LD — on first byte; crawlers and link-
   unfurlers don't run JS. The pattern's commitment: **the head model
   is data derived from app-db**, not an imperative DOM API.
 
-  Public surface:
+  ---- file split (rf2-x7g10) ----
 
-    `reg-head`          — register a head-fragment producer `(fn [db
-                          route] head-model)` keyed by id (e.g.
-                          `:rf.ssr/title`, `:my.app/article`). New
-                          registry kind `:head` (Spec 001 §Registry
-                          model — already in the closed v1 set).
-    `render-head`       — given a head-id and a frame (and optionally
-                          an explicit route), invoke the head fn
-                          against the frame's app-db and the active
-                          route; record the produced model in the
-                          per-frame snapshot map; return the model.
-    `active-head`       — sugar — looks up the active route's `:head`
-                          metadata in the registrar; if set, calls
-                          `render-head`; otherwise returns the default
-                          head per Spec 011 §Default head.
-    `head-model->html`  — emit `<head>…</head>` (or the inner fragment)
-                          from a `:rf/head-model`. Canonical order:
-                          `<title>` first, then `<meta>` (declaration
-                          order), then `<link>`, then `<script>`, then
-                          JSON-LD `<script type=\"application/ld+json\">`.
-                          `:html-attrs` / `:body-attrs` are exposed on
-                          the returned record so a host shell can
-                          stamp them onto `<html>` / `<body>`.
-    `head-snapshot`     — read the per-frame `{head-id → last-produced
-                          fragment}` snapshot. Useful for tests +
-                          introspection. Cleared on frame destroy.
+  Pre-split this ns was 415 LoC carrying three concerns: the HTML
+  escape helpers (duplicated with `re-frame.ssr.emit`), the canonical-
+  order head-model emitter, and the registry + render + active +
+  per-frame snapshot + late-bind wiring. Per the rf2-x7g10 split
+  (audit rf2-asmj1 §H1/Q2):
 
-  Per-request frame lifecycle: the head-snapshot side-channel atom is
-  keyed by frame-id and cleared via the `:ssr/on-frame-destroyed`
-  late-bind hook (per Spec 011 §Per-request frame teardown / rf2-fcj33).
-  Head registrations under `:head` themselves are process-wide registry
-  entries (not per-frame state); cleanup applies only to the per-frame
-  snapshot, not to the registered fns."
-  (:require [clojure.string :as str]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]
-            [re-frame.source-coords :as source-coords]))
+    - `re-frame.ssr.html-helpers`   — shared HTML escape helpers
+                                      (`escape-html` / `escape-attr` /
+                                      `attr-string`); consumed by the
+                                      hiccup emitter AND the head emitter.
+    - `re-frame.ssr.head.emit`      — `head-model->html` and its
+                                      per-element emitters.
+    - `re-frame.ssr.head.registry`  — `reg-head`, `render-head`,
+                                      `active-head`, `default-head`,
+                                      `head-snapshots`,
+                                      `on-frame-destroyed!`.
+    - `re-frame.ssr.head`           — this façade. Re-exports the public
+                                      surface and publishes the late-bind
+                                      hooks so `(require 're-frame.ssr.head
+                                      :reload)` resurrects every
+                                      registration after a `clear-all!`.
 
-;; ---- HTML helpers (mirrors re-frame.ssr's escape/attr helpers) -------------
-;;
-;; head.cljc lives alongside ssr.cljc but is loaded after it; both produce
-;; HTML and share the same escape rules. We re-derive the helpers here
-;; (rather than depending on private symbols from ssr.cljc) so head.cljc
-;; remains a self-contained namespace whose contracts are visible at the
-;; public boundary.
+  Per the optional-artefact wrapper convention (Conventions.md
+  §Optional-artefact wrapper convention), each public surface is
+  reachable via `re-frame.core` through a late-bind hook so core never
+  statically `:require`s `re-frame.ssr.head`."
+  (:require [re-frame.late-bind :as late-bind]
+            [re-frame.ssr.head.emit :as head-emit]
+            [re-frame.ssr.head.registry :as registry]))
 
-(defn- escape-html [s]
-  (-> (str s)
-      (str/replace "&" "&amp;")
-      (str/replace "<" "&lt;")
-      (str/replace ">" "&gt;")
-      (str/replace "\"" "&quot;")
-      (str/replace "'" "&#39;")))
+;; ---- public-surface re-exports --------------------------------------------
 
-(defn- escape-attr [s]
-  (-> (str s)
-      (str/replace "&" "&amp;")
-      (str/replace "\"" "&quot;")))
+(def head-model->html    head-emit/head-model->html)
 
-(defn- attr-string
-  "Render an attribute map as ` k1=\"v1\" k2=\"v2\"`. Boolean true → bare
-  attribute name; false / nil → omitted. Mirrors the rules in
-  `re-frame.ssr/-attr-string`."
-  [attrs]
-  (if (empty? attrs)
-    ""
-    (str " "
-         (str/join " "
-                   (keep (fn [[k v]]
-                           (cond
-                             (true? v)  (name k)
-                             (false? v) nil
-                             (nil? v)   nil
-                             :else      (str (name k) "=\"" (escape-attr v) "\"")))
-                         attrs)))))
-
-;; ---- canonical-order emitter ----------------------------------------------
-;;
-;; Per Spec 011 §Default flow: emit `<title>` first, then `<meta>` (in
-;; declaration order), then `<link>`, then `<script>`, then JSON-LD
-;; `<script type=\"application/ld+json\">`. `:html-attrs` populate
-;; `<html>`; `:body-attrs` populate `<body>` — those are emitted by the
-;; host shell, not by this fn.
-;;
-;; The result is a *string* containing the inner-head fragment (no
-;; surrounding `<head>` / `</head>` tags by default — host shells can
-;; choose whether they wrap). For convenience the 2-arity form opts in
-;; to the surrounding `<head>` tags.
-
-(defn- emit-title [title]
-  (when (and title (not= "" title))
-    (str "<title>" (escape-html title) "</title>")))
-
-(defn- emit-meta-tag [m]
-  (str "<meta" (attr-string m) ">"))
-
-(defn- emit-link-tag [m]
-  (str "<link" (attr-string m) ">"))
-
-(defn- emit-script-tag [m]
-  (let [{:keys [src async defer type integrity crossorigin nomodule]} m
-        attrs (cond-> {}
-                src         (assoc :src src)
-                type        (assoc :type type)
-                async       (assoc :async async)
-                defer       (assoc :defer defer)
-                integrity   (assoc :integrity integrity)
-                crossorigin (assoc :crossorigin crossorigin)
-                nomodule    (assoc :nomodule nomodule))]
-    (str "<script" (attr-string (merge attrs (dissoc m :src :async :defer :type :integrity :crossorigin :nomodule))) "></script>")))
-
-(defn- ld-json-string
-  "Serialise a JSON-LD object map to its `<script type=\"application/ld+json\">`
-  body. CLJ uses a minimal printer (works for the spec's canonical shape:
-  strings, numbers, booleans, vectors, maps with string and/or keyword
-  keys). CLJS uses `js/JSON.stringify` via `clj->js`.
-
-  On the JVM side, keyword keys and keyword values are both serialised
-  to their fully-qualified name — `:my.app/foo` → `\"my.app/foo\"` — so
-  namespaces survive serialisation. The key and value handling are
-  symmetric; rf2-a50nz fixed an earlier asymmetry that quietly stripped
-  the namespace prefix off keys."
-  [x]
-  #?(:cljs (js/JSON.stringify (clj->js x))
-     :clj  (letfn [(emit [v]
-                     (cond
-                       (nil? v)     "null"
-                       (boolean? v) (if v "true" "false")
-                       (number? v)  (str v)
-                       (string? v)  (str "\""
-                                         (-> v
-                                             (str/replace "\\" "\\\\")
-                                             (str/replace "\"" "\\\""))
-                                         "\"")
-                       (keyword? v) (emit (if-let [ns (namespace v)]
-                                            (str ns "/" (name v))
-                                            (name v)))
-                       ;; Keyword keys delegate to the keyword branch above
-                       ;; so namespaces are preserved — fixes the asymmetric
-                       ;; key/value handling reported in rf2-a50nz.
-                       (map? v)     (str "{"
-                                         (str/join "," (map (fn [[k val]]
-                                                              (str (emit k)
-                                                                   ":"
-                                                                   (emit val)))
-                                                            v))
-                                         "}")
-                       (sequential? v) (str "[" (str/join "," (map emit v)) "]")
-                       :else (emit (str v))))]
-             (emit x))))
-
-(defn- emit-json-ld [m]
-  (str "<script type=\"application/ld+json\">"
-       (ld-json-string m)
-       "</script>"))
-
-(defn head-model->html
-  "Render a `:rf/head-model` map to its inner-head HTML fragment in
-  canonical order — `<title>`, `<meta>` (declaration order), `<link>`,
-  `<script>`, JSON-LD `<script type=\"application/ld+json\">`. The two
-  attribute-bag keys (`:html-attrs`, `:body-attrs`) are NOT emitted by
-  this fn — they're consumed by host shells that stamp them onto
-  `<html>` / `<body>`.
-
-  The 1-arity form returns the inner fragment (no surrounding `<head>`
-  tags); the 2-arity form with `{:wrap? true}` wraps in `<head>…</head>`.
-
-  Per Spec 011 §Default flow step 4."
-  ([head-model] (head-model->html head-model {}))
-  ([head-model {:keys [wrap?]}]
-   (let [{:keys [title meta link script json-ld]} head-model
-         parts (cond-> []
-                 (and title (not= "" title))
-                 (conj (emit-title title))
-
-                 (seq meta)
-                 (into (map emit-meta-tag) meta)
-
-                 (seq link)
-                 (into (map emit-link-tag) link)
-
-                 (seq script)
-                 (into (map emit-script-tag) script)
-
-                 (seq json-ld)
-                 (into (map emit-json-ld) json-ld))
-         inner (apply str parts)]
-     (if wrap?
-       (str "<head>" inner "</head>")
-       inner))))
-
-;; ---- per-frame snapshot ---------------------------------------------------
-;;
-;; A side-channel atom keyed by frame-id, mapping `head-id → last-produced
-;; head-model`. Cleared on per-request frame destroy via the
-;; `:ssr/on-frame-destroyed` hook (rf2-fcj33). Storage shape mirrors the
-;; pattern used by `re-frame.ssr/pending-error-traces` and
-;; `re-frame.ssr/request-slots` — the data is per-request bookkeeping
-;; that has no place in app-db (and must not ride the hydration payload
-;; to the client).
-
-(defonce
-  ^{:doc "Per-frame head snapshot. Keys are frame-ids; values are
-  `{head-id → head-model}` maps recording each render-head call's
-  output. Cleared on frame destroy. Inspectable via `head-snapshot`."}
-  head-snapshots
-  (atom {}))
-
-(defn- record-fragment!
-  "Stash the just-produced head-model under (frame-id, head-id) so
-  `head-snapshot` reflects the most recent render-head output."
-  [frame-id head-id head-model]
-  (when frame-id
-    (swap! head-snapshots assoc-in [frame-id head-id] head-model))
-  head-model)
-
-(defn head-snapshot
-  "Read the per-frame `{head-id → last-produced head-model}` snapshot.
-  Useful for tests and introspection. Returns `{}` for a frame that has
-  never seen a `render-head` call (or whose snapshot has been cleared
-  via the per-request frame teardown hook)."
-  ([frame-id]
-   (get @head-snapshots frame-id {})))
-
-(defn on-frame-destroyed!
-  "Clear the head-snapshot entry for `frame-id`. Wired into the
-  `:ssr/on-frame-destroyed` late-bind hook chain so per-request frames
-  release their head bookkeeping on destroy. Idempotent."
-  [frame-id]
-  (swap! head-snapshots dissoc frame-id)
-  nil)
-
-;; ---- reg-head -------------------------------------------------------------
-
-(defn reg-head
-  "Register a head-fragment producer under `id` (a namespaced keyword
-  such as `:my.app/article` or `:rf.ssr/title`).
-
-  `head-fn` signature is `(fn [db route] head-model)` — pure,
-  deterministic, no side-effects. Same shape and discipline as a sub.
-  `db` is the frame's app-db value (plain map, deref'd through the
-  substrate adapter); `route` is the `:rf/route` slice (or whatever
-  the caller passed to `render-head`).
-
-  Two arities:
-
-    (reg-head id           head-fn)
-    (reg-head id metadata  head-fn)
-
-  Returns `id` per the family-wide `reg-*` return-value convention
-  (Conventions.md §`reg-*` return-value convention).
-
-  Re-registering an existing id replaces the slot atomically. Per
-  Spec 011 §Mechanism — registered head function + route metadata."
-  ([id head-fn]
-   (reg-head id {} head-fn))
-  ([id metadata head-fn]
-   (registrar/register! :head id
-                        (assoc (source-coords/merge-coords metadata)
-                               :handler-fn head-fn))
-   id))
-
-;; ---- default head ---------------------------------------------------------
-;;
-;; Per Spec 011 §Default head when no route declares `:head`:
-;;
-;;   {:title (or (:doc (frame-meta frame-id)) "")
-;;    :meta [{:charset "utf-8"}
-;;           {:name "viewport" :content "width=device-width, initial-scale=1"}]}
-;;
-;; No registered head is required. The default is silent — no warning.
-
-(defn default-head
-  "The fallback head-model used when the active route does not declare
-  `:head` (or there is no active route). Per Spec 011 §Default head.
-
-  Pulls `:title` from the frame's `:doc` if set, otherwise empty."
-  [frame-id]
-  (let [doc (when frame-id (:doc (frame/frame-meta frame-id)))]
-    (cond-> {:meta [{:charset "utf-8"}
-                    {:name "viewport" :content "width=device-width, initial-scale=1"}]}
-      (and doc (not= "" doc)) (assoc :title doc))))
-
-;; ---- render-head ----------------------------------------------------------
-
-(defn- frame-route
-  "Read the `:rf/route` slice from a frame's app-db. nil-safe — a frame
-  whose app-db has never been initialised resolves to nil."
-  [frame-id]
-  (when frame-id
-    (let [db (frame/frame-app-db-value frame-id)]
-      (when db (:rf/route db)))))
-
-(defn render-head
-  "Apply the head fn registered under `head-id` against a frame's
-  app-db and active route, returning the produced `:rf/head-model`.
-
-  Two opt shapes are accepted:
-
-    (render-head head-id frame-id)
-    (render-head head-id {:frame frame-id :route route})
-
-  When `:route` is absent, the active route slice (`:rf/route`) is
-  read from the frame's app-db. The produced fragment is recorded in
-  the per-frame snapshot so `head-snapshot` reflects the most recent
-  render-head output.
-
-  Raises `:rf.error/no-such-head` when `head-id` is not registered.
-  Per Spec 011 §`render-head`."
-  ([head-id opts]
-   (let [opts'    (if (keyword? opts) {:frame opts} opts)
-         frame-id (:frame opts')
-         route    (if (contains? opts' :route)
-                    (:route opts')
-                    (frame-route frame-id))
-         meta     (registrar/lookup :head head-id)]
-     (when-not meta
-       (throw (ex-info ":rf.error/no-such-head"
-                       {:head-id  head-id
-                        :reason   (str "No head registered under " head-id ".")
-                        :recovery :no-recovery})))
-     (let [head-fn (:handler-fn meta)
-           db      (when frame-id (frame/frame-app-db-value frame-id))
-           model   (head-fn db route)]
-       (record-fragment! frame-id head-id model)
-       model))))
-
-;; ---- active-head ----------------------------------------------------------
-
-(defn- route-head-id
-  "Read the `:head` route-metadata key for the route-id named in the
-  active `:rf/route` slice. Returns nil when there's no active route,
-  no route registration, or no `:head` declared on the route."
-  [route]
-  (when-let [route-id (:id route)]
-    (when-let [route-meta (registrar/lookup :route route-id)]
-      (:head route-meta))))
-
-(defn active-head
-  "Sugar — look up the active route's `:head` metadata; if set, call
-  `render-head` and return the model. Otherwise return the `default-head`
-  per Spec 011 §Default head.
-
-  Two arities:
-
-    (active-head)            — uses the default frame `:rf/default`
-                               (matches the call shape in tools / dev
-                               consoles).
-    (active-head frame-id)   — explicit frame.
-
-  Returns the resolved head-model. Per Spec 011 §`render-head`."
-  ([] (active-head :rf/default))
-  ([frame-id]
-   (let [route   (frame-route frame-id)
-         head-id (route-head-id route)]
-     (if head-id
-       ;; The route declares an id but it may not be registered — surface
-       ;; that as :rf.error/no-such-head per Spec 011, but only when the
-       ;; route explicitly opts in. Routes without :head silently fall
-       ;; back to the default per Spec 011 §Default head.
-       (render-head head-id {:frame frame-id :route route})
-       (default-head frame-id)))))
+(def reg-head            registry/reg-head)
+(def render-head         registry/render-head)
+(def active-head         registry/active-head)
+(def default-head        registry/default-head)
+(def head-snapshot       registry/head-snapshot)
+(def on-frame-destroyed! registry/on-frame-destroyed!)
+;; framework-private: the test-fixture reset reaches into the atom by
+;; name. Kept as a façade re-export so external test code that grabs
+;; the var via `(resolve 're-frame.ssr.head/head-snapshots)` keeps
+;; working unchanged.
+(def head-snapshots      registry/head-snapshots)
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
-;; Per the optional-artefact wrapper convention (Conventions.md
-;; §Optional-artefact wrapper convention), each public surface is
-;; reachable via `re-frame.core` through a late-bind hook so core never
-;; statically `:require`s `re-frame.ssr.head`. Apps that don't depend
-;; on the SSR artefact see `:rf.error/ssr-artefact-missing` when they
-;; call into these surfaces.
+;; Late-bind hooks fire on ns load. Keeping them in the façade (rather
+;; than in the producing sub-ns) means that `(require 're-frame.ssr.head
+;; :reload)` — the canonical test-fixture reset shape — re-publishes
+;; every hook, regardless of which sub-ns happened to define the
+;; underlying fn.
 
 (late-bind/set-fn! :ssr/reg-head          reg-head)
 (late-bind/set-fn! :ssr/render-head       render-head)
@@ -394,10 +77,11 @@
 ;; ---- per-request frame teardown -------------------------------------------
 ;;
 ;; `re-frame.ssr/on-frame-destroyed!` (under the `:ssr/on-frame-destroyed`
-;; late-bind hook) clears `pending-error-traces` and `request-slots` per
-;; rf2-fcj33. The head ns adds per-frame head-snapshot cleanup; we
-;; surface our cleanup via a separate `:ssr.head/on-frame-destroyed`
-;; hook that `re-frame.ssr`'s teardown fn looks up and invokes.
+;; late-bind hook) clears `pending-error-traces`, `request-slots`, and
+;; `response-slots` per rf2-fcj33 + rf2-jbcmt. The head ns adds per-frame
+;; head-snapshot cleanup; we surface our cleanup via a separate
+;; `:ssr/head-on-frame-destroyed` hook that `re-frame.ssr`'s teardown
+;; fn looks up and invokes.
 ;;
 ;; Why a separate hook rather than wrapping `:ssr/on-frame-destroyed`?
 ;; Load order is unpredictable under the optional-artefact wrapper
@@ -407,9 +91,5 @@
 ;; `(late-bind/set-fn! :ssr/on-frame-destroyed ...)`. The keyed hook
 ;; sidesteps the ordering issue: ssr's fn invokes ours by key,
 ;; regardless of which ns loaded first.
-;;
-;; Hook key naming: `:ssr/head-on-frame-destroyed` (not
-;; `:ssr.head/on-frame-destroyed`) because the drift-detector regex
-;; only matches single-segment namespace components on late-bind keys.
 
 (late-bind/set-fn! :ssr/head-on-frame-destroyed on-frame-destroyed!)

--- a/implementation/ssr/src/re_frame/ssr/head/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/emit.cljc
@@ -1,0 +1,132 @@
+(ns re-frame.ssr.head.emit
+  "Canonical-order head-model → HTML fragment emitter. Per Spec 011
+  §Default flow step 4 and the rf2-x7g10 split of `re-frame.ssr.head`.
+
+  The emit half of the head/meta contract — pure functions that turn a
+  `:rf/head-model` map into the inner-head HTML fragment in canonical
+  order: `<title>` first, then `<meta>` (declaration order), then
+  `<link>`, then `<script>`, then JSON-LD
+  `<script type=\"application/ld+json\">`.
+
+  Public surface:
+
+    `head-model->html` — render a `:rf/head-model` map to its inner-head
+                         HTML fragment. The 2-arity form with
+                         `{:wrap? true}` wraps in `<head>…</head>`.
+
+  The other surfaces of the head/meta contract — `reg-head`,
+  `render-head`, `active-head`, `default-head`, the per-frame snapshot
+  bookkeeping, and the late-bind hook registrations — live in the
+  `re-frame.ssr.head` façade."
+  (:require [clojure.string :as str]
+            [re-frame.ssr.html-helpers :as html]))
+
+;; ---- per-element emitters -------------------------------------------------
+
+(defn- emit-title [title]
+  (when (and title (not= "" title))
+    (str "<title>" (html/escape-html title) "</title>")))
+
+(defn- emit-meta-tag [m]
+  (str "<meta" (html/attr-string m) ">"))
+
+(defn- emit-link-tag [m]
+  (str "<link" (html/attr-string m) ">"))
+
+(defn- emit-script-tag [m]
+  (let [{:keys [src async defer type integrity crossorigin nomodule]} m
+        attrs (cond-> {}
+                src         (assoc :src src)
+                type        (assoc :type type)
+                async       (assoc :async async)
+                defer       (assoc :defer defer)
+                integrity   (assoc :integrity integrity)
+                crossorigin (assoc :crossorigin crossorigin)
+                nomodule    (assoc :nomodule nomodule))]
+    (str "<script"
+         (html/attr-string (merge attrs
+                                  (dissoc m :src :async :defer :type
+                                          :integrity :crossorigin :nomodule)))
+         "></script>")))
+
+(defn- ld-json-string
+  "Serialise a JSON-LD object map to its `<script type=\"application/ld+json\">`
+  body. CLJ uses a minimal printer (works for the spec's canonical shape:
+  strings, numbers, booleans, vectors, maps with string and/or keyword
+  keys). CLJS uses `js/JSON.stringify` via `clj->js`.
+
+  On the JVM side, keyword keys and keyword values are both serialised
+  to their fully-qualified name — `:my.app/foo` → `\"my.app/foo\"` — so
+  namespaces survive serialisation. The key and value handling are
+  symmetric; rf2-a50nz fixed an earlier asymmetry that quietly stripped
+  the namespace prefix off keys."
+  [x]
+  #?(:cljs (js/JSON.stringify (clj->js x))
+     :clj  (letfn [(emit [v]
+                     (cond
+                       (nil? v)     "null"
+                       (boolean? v) (if v "true" "false")
+                       (number? v)  (str v)
+                       (string? v)  (str "\""
+                                         (-> v
+                                             (str/replace "\\" "\\\\")
+                                             (str/replace "\"" "\\\""))
+                                         "\"")
+                       (keyword? v) (emit (if-let [ns (namespace v)]
+                                            (str ns "/" (name v))
+                                            (name v)))
+                       ;; Keyword keys delegate to the keyword branch above
+                       ;; so namespaces are preserved — fixes the asymmetric
+                       ;; key/value handling reported in rf2-a50nz.
+                       (map? v)     (str "{"
+                                         (str/join "," (map (fn [[k val]]
+                                                              (str (emit k)
+                                                                   ":"
+                                                                   (emit val)))
+                                                            v))
+                                         "}")
+                       (sequential? v) (str "[" (str/join "," (map emit v)) "]")
+                       :else (emit (str v))))]
+             (emit x))))
+
+(defn- emit-json-ld [m]
+  (str "<script type=\"application/ld+json\">"
+       (ld-json-string m)
+       "</script>"))
+
+;; ---- head-model->html -----------------------------------------------------
+
+(defn head-model->html
+  "Render a `:rf/head-model` map to its inner-head HTML fragment in
+  canonical order — `<title>`, `<meta>` (declaration order), `<link>`,
+  `<script>`, JSON-LD `<script type=\"application/ld+json\">`. The two
+  attribute-bag keys (`:html-attrs`, `:body-attrs`) are NOT emitted by
+  this fn — they're consumed by host shells that stamp them onto
+  `<html>` / `<body>`.
+
+  The 1-arity form returns the inner fragment (no surrounding `<head>`
+  tags); the 2-arity form with `{:wrap? true}` wraps in `<head>…</head>`.
+
+  Per Spec 011 §Default flow step 4."
+  ([head-model] (head-model->html head-model {}))
+  ([head-model {:keys [wrap?]}]
+   (let [{:keys [title meta link script json-ld]} head-model
+         parts (cond-> []
+                 (and title (not= "" title))
+                 (conj (emit-title title))
+
+                 (seq meta)
+                 (into (map emit-meta-tag) meta)
+
+                 (seq link)
+                 (into (map emit-link-tag) link)
+
+                 (seq script)
+                 (into (map emit-script-tag) script)
+
+                 (seq json-ld)
+                 (into (map emit-json-ld) json-ld))
+         inner (apply str parts)]
+     (if wrap?
+       (str "<head>" inner "</head>")
+       inner))))

--- a/implementation/ssr/src/re_frame/ssr/head/registry.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/registry.cljc
@@ -1,0 +1,189 @@
+(ns re-frame.ssr.head.registry
+  "Head/meta contract — registry, render, active, default, per-frame
+  snapshot. Per Spec 011 §Head/meta contract (rf2-4dra9) and the
+  rf2-x7g10 split of `re-frame.ssr.head`.
+
+  Public surface (re-exported from the `re-frame.ssr.head` façade):
+
+    `reg-head`          — register a head-fragment producer
+                          `(fn [db route] head-model)` keyed by id.
+    `render-head`       — invoke a registered head fn against a frame's
+                          app-db + active route, record the produced
+                          model in the per-frame snapshot, return it.
+    `active-head`       — sugar — look up the active route's `:head`
+                          metadata; render or fall back to `default-head`.
+    `default-head`      — fallback head-model per Spec 011 §Default head.
+    `head-snapshot`     — read the per-frame `{head-id → head-model}`
+                          snapshot.
+    `head-snapshots`    — the side-channel atom (consumed by the
+                          test-fixture reset).
+    `on-frame-destroyed!` — clear the per-frame snapshot entry. Wired
+                          into the `:ssr.head/on-frame-destroyed` hook
+                          chained from `re-frame.ssr`'s teardown."
+  (:require [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.source-coords :as source-coords]))
+
+;; ---- per-frame snapshot ---------------------------------------------------
+;;
+;; A side-channel atom keyed by frame-id, mapping `head-id → last-produced
+;; head-model`. Cleared on per-request frame destroy via the
+;; `:ssr/on-frame-destroyed` hook (rf2-fcj33). Storage shape mirrors the
+;; pattern used by `re-frame.ssr/pending-error-traces` and
+;; `re-frame.ssr/request-slots` — the data is per-request bookkeeping
+;; that has no place in app-db (and must not ride the hydration payload
+;; to the client).
+
+(defonce
+  ^{:doc "Per-frame head snapshot. Keys are frame-ids; values are
+  `{head-id → head-model}` maps recording each render-head call's
+  output. Cleared on frame destroy. Inspectable via `head-snapshot`."}
+  head-snapshots
+  (atom {}))
+
+(defn- record-fragment!
+  "Stash the just-produced head-model under (frame-id, head-id) so
+  `head-snapshot` reflects the most recent render-head output."
+  [frame-id head-id head-model]
+  (when frame-id
+    (swap! head-snapshots assoc-in [frame-id head-id] head-model))
+  head-model)
+
+(defn head-snapshot
+  "Read the per-frame `{head-id → last-produced head-model}` snapshot.
+  Useful for tests and introspection. Returns `{}` for a frame that has
+  never seen a `render-head` call (or whose snapshot has been cleared
+  via the per-request frame teardown hook)."
+  ([frame-id]
+   (get @head-snapshots frame-id {})))
+
+(defn on-frame-destroyed!
+  "Clear the head-snapshot entry for `frame-id`. Wired into the
+  `:ssr/on-frame-destroyed` late-bind hook chain so per-request frames
+  release their head bookkeeping on destroy. Idempotent."
+  [frame-id]
+  (swap! head-snapshots dissoc frame-id)
+  nil)
+
+;; ---- reg-head -------------------------------------------------------------
+
+(defn reg-head
+  "Register a head-fragment producer under `id` (a namespaced keyword
+  such as `:my.app/article` or `:rf.ssr/title`).
+
+  `head-fn` signature is `(fn [db route] head-model)` — pure,
+  deterministic, no side-effects. Same shape and discipline as a sub.
+  `db` is the frame's app-db value (plain map, deref'd through the
+  substrate adapter); `route` is the `:rf/route` slice (or whatever
+  the caller passed to `render-head`).
+
+  Two arities:
+
+    (reg-head id           head-fn)
+    (reg-head id metadata  head-fn)
+
+  Returns `id` per the family-wide `reg-*` return-value convention
+  (Conventions.md §`reg-*` return-value convention).
+
+  Re-registering an existing id replaces the slot atomically. Per
+  Spec 011 §Mechanism — registered head function + route metadata."
+  ([id head-fn]
+   (reg-head id {} head-fn))
+  ([id metadata head-fn]
+   (registrar/register! :head id
+                        (assoc (source-coords/merge-coords metadata)
+                               :handler-fn head-fn))
+   id))
+
+;; ---- default head ---------------------------------------------------------
+
+(defn default-head
+  "The fallback head-model used when the active route does not declare
+  `:head` (or there is no active route). Per Spec 011 §Default head.
+
+  Pulls `:title` from the frame's `:doc` if set, otherwise empty."
+  [frame-id]
+  (let [doc (when frame-id (:doc (frame/frame-meta frame-id)))]
+    (cond-> {:meta [{:charset "utf-8"}
+                    {:name "viewport" :content "width=device-width, initial-scale=1"}]}
+      (and doc (not= "" doc)) (assoc :title doc))))
+
+;; ---- render-head ----------------------------------------------------------
+
+(defn- frame-route
+  "Read the `:rf/route` slice from a frame's app-db. nil-safe — a frame
+  whose app-db has never been initialised resolves to nil."
+  [frame-id]
+  (when frame-id
+    (let [db (frame/frame-app-db-value frame-id)]
+      (when db (:rf/route db)))))
+
+(defn render-head
+  "Apply the head fn registered under `head-id` against a frame's
+  app-db and active route, returning the produced `:rf/head-model`.
+
+  Two opt shapes are accepted:
+
+    (render-head head-id frame-id)
+    (render-head head-id {:frame frame-id :route route})
+
+  When `:route` is absent, the active route slice (`:rf/route`) is
+  read from the frame's app-db. The produced fragment is recorded in
+  the per-frame snapshot so `head-snapshot` reflects the most recent
+  render-head output.
+
+  Raises `:rf.error/no-such-head` when `head-id` is not registered.
+  Per Spec 011 §`render-head`."
+  ([head-id opts]
+   (let [opts'    (if (keyword? opts) {:frame opts} opts)
+         frame-id (:frame opts')
+         route    (if (contains? opts' :route)
+                    (:route opts')
+                    (frame-route frame-id))
+         meta     (registrar/lookup :head head-id)]
+     (when-not meta
+       (throw (ex-info ":rf.error/no-such-head"
+                       {:head-id  head-id
+                        :reason   (str "No head registered under " head-id ".")
+                        :recovery :no-recovery})))
+     (let [head-fn (:handler-fn meta)
+           db      (when frame-id (frame/frame-app-db-value frame-id))
+           model   (head-fn db route)]
+       (record-fragment! frame-id head-id model)
+       model))))
+
+;; ---- active-head ----------------------------------------------------------
+
+(defn- route-head-id
+  "Read the `:head` route-metadata key for the route-id named in the
+  active `:rf/route` slice. Returns nil when there's no active route,
+  no route registration, or no `:head` declared on the route."
+  [route]
+  (when-let [route-id (:id route)]
+    (when-let [route-meta (registrar/lookup :route route-id)]
+      (:head route-meta))))
+
+(defn active-head
+  "Sugar — look up the active route's `:head` metadata; if set, call
+  `render-head` and return the model. Otherwise return the `default-head`
+  per Spec 011 §Default head.
+
+  Two arities:
+
+    (active-head)            — uses the default frame `:rf/default`
+                               (matches the call shape in tools / dev
+                               consoles).
+    (active-head frame-id)   — explicit frame.
+
+  Returns the resolved head-model. Per Spec 011 §`render-head`."
+  ([] (active-head :rf/default))
+  ([frame-id]
+   (let [route   (frame-route frame-id)
+         head-id (route-head-id route)]
+     (if head-id
+       ;; The route declares an id but it may not be registered — surface
+       ;; that as :rf.error/no-such-head per Spec 011, but only when the
+       ;; route explicitly opts in. Routes without :head silently fall
+       ;; back to the default per Spec 011 §Default head.
+       (render-head head-id {:frame frame-id :route route})
+       (default-head frame-id)))))

--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -1,0 +1,59 @@
+(ns re-frame.ssr.html-helpers
+  "HTML escape + attribute-serialisation helpers shared by the SSR emitter
+  (`re-frame.ssr.emit`) and the head/meta emitter
+  (`re-frame.ssr.head.emit`). Per rf2-x7g10 (audit rf2-asmj1 §H1/Q2).
+
+  Pre-split, `re-frame.ssr.emit` and `re-frame.ssr.head` each carried a
+  line-for-line copy of `escape-html`, `escape-attr`, and `attr-string`.
+  The duplication was a hangover from when `head` shipped under a
+  different artefact; under one artefact they're local-deps. Both
+  callsites now `:require` this ns so the entity-escape rules change in
+  exactly one place.
+
+  Escape semantics:
+
+    - `escape-html`  — full text-node escaping: `& < > \" '`.
+    - `escape-attr`  — attribute-value escaping (we always emit double-
+                       quoted values, so only `&` and `\"` matter).
+    - `attr-string`  — render an attribute map as ` k1=\"v1\" k2=\"v2\"`.
+                       Boolean `true` → bare attribute name (`disabled`);
+                       `false` / `nil` → omitted entirely."
+  (:require [clojure.string :as str]))
+
+(defn escape-html
+  "Full text-node HTML escape: `& < > \" '`. Stringifies non-strings."
+  [s]
+  (-> (str s)
+      (str/replace "&" "&amp;")
+      (str/replace "<" "&lt;")
+      (str/replace ">" "&gt;")
+      (str/replace "\"" "&quot;")
+      (str/replace "'" "&#39;")))
+
+(defn escape-attr
+  "Attribute-value HTML escape. We always emit double-quoted attribute
+  values, so only `&` and `\"` need escaping — `<` / `>` are legal inside
+  attribute values per the HTML5 parser."
+  [s]
+  (-> (str s)
+      (str/replace "&" "&amp;")
+      (str/replace "\"" "&quot;")))
+
+(defn attr-string
+  "Render an attribute map as ` k1=\"v1\" k2=\"v2\"` (leading space when
+  non-empty; empty string when the map is empty). Boolean `true` emits
+  the bare attribute name (`disabled`); `false` and `nil` omit the
+  attribute entirely. All other values stringify and are `escape-attr`-
+  escaped."
+  [attrs]
+  (if (empty? attrs)
+    ""
+    (str " "
+         (str/join " "
+                   (keep (fn [[k v]]
+                           (cond
+                             (true? v)  (name k)
+                             (false? v) nil
+                             (nil? v)   nil
+                             :else      (str (name k) "=\"" (escape-attr v) "\"")))
+                         attrs)))))


### PR DESCRIPTION
## Summary

Per audit rf2-asmj1 §H1/Q2. Pre-split `head.cljc` was 415 LoC carrying three concerns AND duplicating the HTML escape helpers line-for-line with `ssr/emit.cljc`.

## Layout after split

- **`re-frame.ssr.html-helpers`** (59 L) — `escape-html`, `escape-attr`, `attr-string`. Consumed by the hiccup emitter AND the head emitter. Entity-escape rules change in exactly one place.
- **`re-frame.ssr.head.emit`** (132 L) — `head-model->html` + per-element emitters (title / meta / link / script / JSON-LD) in canonical order.
- **`re-frame.ssr.head.registry`** (189 L) — `reg-head`, `render-head`, `active-head`, `default-head`, the per-frame snapshot atom, and `on-frame-destroyed!`.
- **`re-frame.ssr.head`** (95 L) — façade. Public-surface re-exports + late-bind hook publishing.

Every leaf now ≤ 250 LoC (was 415 / over by 1.6×).

`emit.cljc` `:require`s `re-frame.ssr.html-helpers` and re-exports `escape-html` / `escape-attr` / `attr-string` as aliased `def`s so existing call-sites that resolve through `emit/...` keep working.

Public surface unchanged — the `rf/reg-head` / `rf/render-head` / `rf/active-head` / `rf/head-snapshot` / `rf/head-model->html` late-bind hooks publish from the façade, and the test-fixture-reset reach into `head/head-snapshots` resolves to the same atom via the façade alias.

Pre-alpha. No back-compat carry.

## Test plan

- [x] `clojure -M:test` from `implementation/ssr/` — 82 tests, 267 assertions, 0 failures
- [x] `npm run test:cljs` from `implementation/` — 1817 tests, 5050 assertions, 0 failures

Closes rf2-x7g10.