### PR TITLE
refactor(story): unify snippet-generator indent helpers (rf2-zs0w4)

### DIFF
--- a/tools/story/src/re_frame/story/recorder.cljc
+++ b/tools/story/src/re_frame/story/recorder.cljc
@@ -79,6 +79,7 @@
   - `insert-assertion!`       — impure entrypoint for the picker UI."
   (:require [clojure.string :as str]
             [re-frame.story.config :as config]
+            [re-frame.story.review-dialog :as review-dialog]
             [re-frame.trace :as trace]))
 
 ;; ---------------------------------------------------------------------------
@@ -139,19 +140,24 @@
   round-trips through re-frame's registrar machinery."
   [events {:keys [variant-id doc extends alias]
            :or   {alias "story"}}]
-  (let [body-keys (cond-> []
-                    doc     (conj [:doc (pr-str doc)])
-                    extends (conj [:extends (pr-str extends)])
-                    true    (conj [:play
-                                   (if (seq events)
-                                     (str "["
-                                          (str/join "\n           "
-                                                    (map pr-str events))
-                                          "]")
-                                     "[]")]))
-        body-str  (->> body-keys
-                       (map (fn [[k v]] (str k " " v)))
-                       (str/join "\n   "))]
+  (let [;; The shared `indent-after` helper aligns events on continuation
+        ;; lines directly under the `[` of `:play [` — derived from the
+        ;; literal first-line prefix so the geometry is self-documenting.
+        ;; See `review-dialog/indent-after` for the unification rationale.
+        play-prefix "   :play ["
+        body-keys   (cond-> []
+                      doc     (conj [:doc (pr-str doc)])
+                      extends (conj [:extends (pr-str extends)])
+                      true    (conj [:play
+                                     (if (seq events)
+                                       (str "["
+                                            (str/join (review-dialog/indent-after play-prefix)
+                                                      (map pr-str events))
+                                            "]")
+                                       "[]")]))
+        body-str    (->> body-keys
+                         (map (fn [[k v]] (str k " " v)))
+                         (str/join "\n   "))]
     (str "(" alias "/reg-variant "
          (pr-str (or variant-id :story.recorded/example))
          "\n  {" body-str "})")))

--- a/tools/story/src/re_frame/story/review_dialog.cljc
+++ b/tools/story/src/re_frame/story/review_dialog.cljc
@@ -200,6 +200,46 @@
   (set-draft-id state (or (parse-variant-id-string s) s)))
 
 ;; ---------------------------------------------------------------------------
+;; Pure: snippet-format helpers
+;;
+;; The two save-as flows render multi-line EDN where successive items
+;; (event vectors / map kv pairs) align directly under the opening
+;; bracket/brace of their body key — e.g.
+;;
+;;     (story/reg-variant :id
+;;       {:play [[:counter/inc]
+;;               [:counter/dec]]})
+;;
+;; The continuation indent on the second line is geometric — N spaces
+;; that line `[:counter/dec]` up under `[:counter/inc]`. Pre-unification
+;; the recorder and save-variant carried separate hard-coded strings
+;; for that indent (`"\n           "` 11 spaces / `"\n            "` 12
+;; spaces), both off-by-one in opposite directions from the correct 10.
+;; The shared helper derives the indent from the rendered first-line
+;; prefix so the alignment is self-documenting and any future tweak to
+;; the wrapping shape stays consistent across flows.
+;; ---------------------------------------------------------------------------
+
+(defn indent-after
+  "Continuation indent that lines successive items up directly under
+  the character immediately following `prefix` on the previous line.
+  Returns `\"\\n<count(prefix) spaces>\"`. Pure data → string.
+
+  Used by `recorder/gen-play-snippet` and `save-variant/gen-variant-
+  snippet` to join multi-line EDN bodies. The argument is the literal
+  first-line text preceding the items (e.g. `\"   :play [\"` or
+  `\"   :args {\"`) — passing the rendered prefix verbatim keeps the
+  geometry obvious and breakage-resistant.
+
+  Example:
+
+      (str \"   :play [item1\" (indent-after \"   :play [\") \"item2]\")
+      ;; => \"   :play [item1\\n          item2]\"
+      ;;                  ^---------- item2 aligns under item1"
+  [prefix]
+  (str "\n" (apply str (repeat (count prefix) \space))))
+
+;; ---------------------------------------------------------------------------
 ;; CLJS-only: Reagent ratom factory + adapter glue
 ;;
 ;; The pure transitions above produce new state maps; the CLJS side

--- a/tools/story/src/re_frame/story/save_variant.cljc
+++ b/tools/story/src/re_frame/story/save_variant.cljc
@@ -81,15 +81,17 @@
 
 (defn- pr-args-map
   "Pretty-print an args map as a multi-line EDN form. Each top-level
-  key/value pair renders on its own line indented two columns under the
-  enclosing brace. Empty maps render as `{}`."
+  key/value pair renders on its own line, aligned directly under the
+  opening `{` of `:args {`. Empty maps render as `{}`. Uses the shared
+  `review-dialog/indent-after` helper so the continuation indent stays
+  in lockstep with the recorder's `gen-play-snippet`."
   [m]
   (if (empty? m)
     "{}"
     (str "{"
          (->> (sort-by (fn [[k _]] (str k)) m)
               (map (fn [[k v]] (str (pr-str k) " " (pr-str v))))
-              (str/join "\n            "))
+              (str/join (review-dialog/indent-after "   :args {")))
          "}")))
 
 (defn gen-variant-snippet

--- a/tools/story/test/re_frame/story_review_dialog_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_review_dialog_cljs_test.cljs
@@ -187,3 +187,14 @@
 (deftest copy-to-clipboard!-safe-on-node
   (testing "the shared copy helper is callable + no-ops without a clipboard API"
     (is (nil? (review-dialog/copy-to-clipboard! "anything")))))
+
+;; ---- indent-after (snippet-format helper, rf2-zs0w4) ---------------------
+
+(deftest indent-after-matches-prefix-width
+  (testing "indent-after returns \\n + N spaces equal to the prefix length"
+    (is (= "\n" (review-dialog/indent-after "")))
+    (is (= "\n          " (review-dialog/indent-after "   :play [")))
+    (is (= "\n          " (review-dialog/indent-after "   :args {")))
+    (is (= (review-dialog/indent-after "   :play [")
+           (review-dialog/indent-after "   :args {"))
+        "both flows' prefixes collapse to the same indent")))

--- a/tools/story/test/re_frame/story_review_dialog_test.clj
+++ b/tools/story/test/re_frame/story_review_dialog_test.clj
@@ -193,23 +193,25 @@
     (is (= "\n     " (review-dialog/indent-after "12345")))))
 
 (deftest indent-after-aligns-recorder-play-body
-  (testing "the indent lines events up under the `[` of `:play [` on the previous line"
+  (testing "the indent lines events up under the first item of `:play [` on the previous line"
     (let [prefix      "   :play ["
           first-line  (str prefix "[:counter/inc]")
           cont-indent (review-dialog/indent-after prefix)
           full        (str first-line cont-indent "[:counter/dec]")
           lines       (clojure.string/split full #"\n")
-          ;; column of '[' on line 1 = (count prefix) - 1 (the `[` is the last char of prefix)
-          line1-bracket-col (dec (count prefix))
-          ;; column of '[' on line 2 = the indent's space-count (count cont-indent) - 1 for `\n`
-          line2-bracket-col (dec (count cont-indent))]
+          ;; column of the first event char on line 1 = (count prefix)
+          ;; (the `[` of `:play [` is the last char of prefix; the next
+          ;; char — the first event's leading `[` — sits at index N.)
+          line1-event-col (count prefix)
+          ;; column of the first event char on line 2 = the indent's
+          ;; space-count, which equals (count cont-indent) - 1 for `\n`.
+          line2-event-col (dec (count cont-indent))]
       (is (= 2 (count lines)))
-      ;; bracket on line 1 is at the column where line 2's items begin
-      (is (= line1-bracket-col line2-bracket-col)
-          "second event's `[` aligns under first event's `[`"))))
+      (is (= line1-event-col line2-event-col)
+          "second event's leading char aligns under first event's leading char"))))
 
 (deftest indent-after-aligns-save-variant-args-map
-  (testing "the indent lines kv pairs up under the `{` of `:args {` on the previous line"
+  (testing "the indent lines kv pairs up under the first kv of `:args {` on the previous line"
     (let [prefix      "   :args {"
           first-line  (str prefix ":a 1")
           cont-indent (review-dialog/indent-after prefix)
@@ -219,7 +221,7 @@
           line2-first-kv-col (dec (count cont-indent))]
       (is (= 2 (count lines)))
       (is (= line1-first-kv-col line2-first-kv-col)
-          "second kv aligns under first kv"))))
+          "second kv's leading char aligns under first kv's leading char"))))
 
 (deftest indent-after-pure-and-deterministic
   (testing "the helper is pure — same input → same output"

--- a/tools/story/test/re_frame/story_review_dialog_test.clj
+++ b/tools/story/test/re_frame/story_review_dialog_test.clj
@@ -183,3 +183,49 @@
       (is (= :story.x/edited       (:draft-id s2)))
       (is (= :story.x/edited-again (:draft-id s3)))
       (is (= review-dialog/initial-state s4)))))
+
+;; ---- indent-after (snippet-format helper, rf2-zs0w4) ---------------------
+
+(deftest indent-after-shape
+  (testing "indent-after returns a newline followed by N spaces matching prefix width"
+    (is (= "\n" (review-dialog/indent-after "")))
+    (is (= "\n " (review-dialog/indent-after "x")))
+    (is (= "\n     " (review-dialog/indent-after "12345")))))
+
+(deftest indent-after-aligns-recorder-play-body
+  (testing "the indent lines events up under the `[` of `:play [` on the previous line"
+    (let [prefix      "   :play ["
+          first-line  (str prefix "[:counter/inc]")
+          cont-indent (review-dialog/indent-after prefix)
+          full        (str first-line cont-indent "[:counter/dec]")
+          lines       (clojure.string/split full #"\n")
+          ;; column of '[' on line 1 = (count prefix) - 1 (the `[` is the last char of prefix)
+          line1-bracket-col (dec (count prefix))
+          ;; column of '[' on line 2 = the indent's space-count (count cont-indent) - 1 for `\n`
+          line2-bracket-col (dec (count cont-indent))]
+      (is (= 2 (count lines)))
+      ;; bracket on line 1 is at the column where line 2's items begin
+      (is (= line1-bracket-col line2-bracket-col)
+          "second event's `[` aligns under first event's `[`"))))
+
+(deftest indent-after-aligns-save-variant-args-map
+  (testing "the indent lines kv pairs up under the `{` of `:args {` on the previous line"
+    (let [prefix      "   :args {"
+          first-line  (str prefix ":a 1")
+          cont-indent (review-dialog/indent-after prefix)
+          full        (str first-line cont-indent ":b 2")
+          lines       (clojure.string/split full #"\n")
+          line1-first-kv-col (count prefix)
+          line2-first-kv-col (dec (count cont-indent))]
+      (is (= 2 (count lines)))
+      (is (= line1-first-kv-col line2-first-kv-col)
+          "second kv aligns under first kv"))))
+
+(deftest indent-after-pure-and-deterministic
+  (testing "the helper is pure — same input → same output"
+    (is (= (review-dialog/indent-after "   :play [")
+           (review-dialog/indent-after "   :play [")))
+    ;; And the recorder + save-variant prefixes collapse to the same width
+    ;; (both keys are 4 chars; both bodies indent 3 + key + space + bracket = 10)
+    (is (= (review-dialog/indent-after "   :play [")
+           (review-dialog/indent-after "   :args {")))))


### PR DESCRIPTION
## Summary

- Extracts a shared `re-frame.story.review-dialog/indent-after` helper that derives the continuation indent from the literal first-line prefix.
- Replaces two divergent hard-coded indent strings — `recorder` used 11 spaces under `:play [`, `save-variant` used 12 spaces under `:args {` — both off-by-one in opposite directions from the geometrically correct 10.
- Adds JVM + CLJS tests for the helper (shape, alignment under both prefixes, purity, prefix-collapse identity).

## Magic-number resolution

Both flows now share one pure helper; the indent is computed from the prefix at the call site (`\"   :play [\"` / `\"   :args {\"`) rather than baked into a string literal. Net effect: the rendered EDN is correctly aligned in both flows, and future save-as-anything flows pick up the same helper.

## Audit reference

Resolves rf2-zs0w4. Audit findings R2 + SV1 (rf2-dd5ze P1 cluster).

## Test plan

- [x] `clojure -M:test` from `tools/story/` — 352 tests, 1032 assertions, 0 failures
- [x] `npm run test:cljs` from `implementation/` — 1818 tests, 5054 assertions, 0 failures
- [x] Existing recorder + save-variant snippet roundtrip tests pass unchanged (they exercise EDN read-back, not exact indent)