### PR TITLE
refactor(schemas): drop requiring-resolve fallback for malli (rf2-qyfie)

### DIFF
--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -21,6 +21,12 @@
             [re-frame.registrar :as registrar]
             [re-frame.flows :as flows]
             [re-frame.schemas :as schemas]
+            ;; Per rf2-t0hq + rf2-qyfie — the Malli adapter ns must be
+            ;; required at boot to publish the late-bind hook the
+            ;; default validator routes through. The conformance corpus
+            ;; expects Malli-backed validation outcomes; absent the
+            ;; require the validator soft-passes (no failure traces).
+            [re-frame.schemas.malli]
             [re-frame.subs :as subs]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.trace :as trace]

--- a/implementation/schemas/deps.edn
+++ b/implementation/schemas/deps.edn
@@ -12,12 +12,12 @@
 ;;   {:deps {day8/re-frame2         {:mvn/version "..."}
 ;;           day8/re-frame2-schemas {:mvn/version "..."}}}
 ;;
-;; And, on CLJS, require `re-frame.schemas.malli` at app-boot to publish
-;; Malli's validate / explain into the late-bind hook table (rf2-t0hq).
+;; And require `re-frame.schemas.malli` at app-boot to publish Malli's
+;; validate / explain into the late-bind hook table (rf2-t0hq). Same
+;; pattern on CLJS and the JVM — rf2-qyfie removed the JVM
+;; `requiring-resolve` fallback so the contract is symmetrical.
 ;; Without that require the default validator soft-passes per Spec 010
-;; §Recommended soft-pass — even if Malli is on the classpath, the
-;; framework cannot reach it through CLJS's runtime resolve (which is
-;; a compile-time analyzer affordance only, not a runtime fn).
+;; §Recommended soft-pass even if Malli is on the classpath.
 ;;
 ;; Per Spec 006 §Adapter shipping convention (and the
 ;; rf2-p7va extension to per-feature splits): this artefact depends

--- a/implementation/schemas/src/re_frame/schemas/malli.cljc
+++ b/implementation/schemas/src/re_frame/schemas/malli.cljc
@@ -28,16 +28,14 @@
   to whatever's published; absent any publisher they soft-pass per the
   Spec 010 §Recommended soft-pass rule.
 
-  CLJS users opt in by requiring this namespace at app boot:
+  Users opt in by requiring this namespace at app boot — same pattern
+  on both CLJS and the JVM (rf2-qyfie removed the JVM `requiring-resolve`
+  fallback so the contract is symmetrical):
 
       (ns my-app.core
         (:require [re-frame.core :as rf]
                   [re-frame.schemas]         ;; load the schemas artefact
                   [re-frame.schemas.malli])) ;; publish Malli into the hook table
-
-  On the JVM the schemas artefact's `default-malli-validate` already
-  works via `requiring-resolve` — but loading this namespace at boot
-  is harmless and symmetrical (CLJS + JVM bundles look identical).
 
   Apps that want to drop the Malli surface entirely (per rf2-qnxf
   bundle audit) do NOT require this namespace and either:

--- a/implementation/schemas/src/re_frame/schemas/validator.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validator.cljc
@@ -44,54 +44,33 @@
   rf2-p7va substitute-validator pattern: the `re-frame.schemas.malli`
   adapter namespace publishes Malli's `validate` and `explain` into the
   late-bind hook table on ns-load. The default fns below consult the
-  table on every call. Apps opt in to Malli validation on CLJS by
-  requiring `re-frame.schemas.malli` at app boot.
-
-  On the JVM `requiring-resolve` still works as a no-require fallback
-  so existing JVM tests / apps keep working without an explicit
-  require of the adapter ns; the late-bind hook takes precedence when
-  the adapter ns IS loaded."
+  table on every call. Apps opt in to Malli validation by requiring
+  `re-frame.schemas.malli` at app boot — the same pattern on both
+  runtimes (no JVM-vs-CLJS asymmetry). When the adapter ns is not
+  loaded the default fns soft-pass per Spec 010 §Recommended soft-pass."
   (:require [re-frame.late-bind :as late-bind]))
 
 (defn- default-malli-validate
-  "The default validator — delegates to malli.core/validate via the
-  late-bind hook published by `re-frame.schemas.malli` (rf2-t0hq).
-
-  Lookup order:
-    1. Late-bind hook `:schemas/malli-validate` (published by
-       `re-frame.schemas.malli` when that namespace is loaded).
-    2. On the JVM only, fall back to `(requiring-resolve
-       'malli.core/validate)` so the JVM artefact tests / apps that
-       have Malli on the classpath but don't `:require
-       [re-frame.schemas.malli]` keep working.
-    3. Soft-pass — return true (per Spec 010 §Recommended soft-pass).
+  "The default validator — delegates to `malli.core/validate` via the
+  late-bind hook `:schemas/malli-validate` published by
+  `re-frame.schemas.malli` (rf2-t0hq). Soft-passes (returns true) when
+  the adapter ns is not loaded, per Spec 010 §Recommended soft-pass.
 
   Apps that want Malli-absent behaviour to be a hard fail register
   a stricter validator via `set-schema-validator!`."
   [schema value]
   (if-let [v (late-bind/get-fn :schemas/malli-validate)]
     (v schema value)
-    #?(:clj  (try
-               (if-let [v (requiring-resolve 'malli.core/validate)]
-                 (v schema value)
-                 true)
-               (catch Throwable _ true))
-       :cljs true)))
+    true))
 
 (defn- default-malli-explain
-  "The default explainer — delegates to malli.core/explain via the
-  late-bind hook published by `re-frame.schemas.malli` (rf2-t0hq).
-  Same lookup order as `default-malli-validate`. Returns the Malli
-  explanation map on fail; nil on conform / when Malli is not on the
-  classpath / when the adapter ns is not loaded."
+  "The default explainer — delegates to `malli.core/explain` via the
+  late-bind hook `:schemas/malli-explain` published by
+  `re-frame.schemas.malli` (rf2-t0hq). Returns nil when the adapter
+  ns is not loaded — the failure trace then omits the `:explain` key."
   [schema value]
-  (if-let [e (late-bind/get-fn :schemas/malli-explain)]
-    (e schema value)
-    #?(:clj  (try
-               (when-let [e (requiring-resolve 'malli.core/explain)]
-                 (e schema value))
-               (catch Throwable _ nil))
-       :cljs nil)))
+  (when-let [e (late-bind/get-fn :schemas/malli-explain)]
+    (e schema value)))
 
 (defn- canonicalise-schema-form
   "Per Spec 010 §Digest algorithm step 1 — normalise a schema EDN form for

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -84,6 +84,12 @@
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
+            ;; Per rf2-t0hq + rf2-qyfie — the Malli adapter ns must be
+            ;; required at boot to publish the late-bind hook the
+            ;; default validator routes through. The conformance corpus
+            ;; expects Malli-backed validation outcomes; absent the
+            ;; require the validator soft-passes (no failure traces).
+            [re-frame.schemas.malli]
             [re-frame.spec :as spec]
             [re-frame.subs :as subs]
             [re-frame.substrate.adapter :as substrate-adapter]

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -43,6 +43,12 @@
             [re-frame.registrar :as registrar]
             [re-frame.flows :as flows]
             [re-frame.schemas :as schemas]
+            ;; Per rf2-t0hq + rf2-qyfie — the Malli adapter ns must be
+            ;; required at boot to publish the late-bind hook the
+            ;; default validator routes through; absent the require,
+            ;; the validator soft-passes per Spec 010 §Recommended
+            ;; soft-pass.
+            [re-frame.schemas.malli]
             [re-frame.spec :as spec]
             [re-frame.substrate.plain-atom :as plain-atom]))
 

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -34,6 +34,14 @@
             [re-frame.flows :as flows]
             [re-frame.interop :as interop]
             [re-frame.schemas :as schemas]
+            ;; Per rf2-t0hq the default validator routes through the
+            ;; late-bind hook `:schemas/malli-validate`, which the
+            ;; `re-frame.schemas.malli` adapter ns publishes at load
+            ;; time. Per rf2-qyfie the JVM `requiring-resolve`
+            ;; fallback was removed — the require is now the canonical
+            ;; opt-in on both runtimes; without it the default
+            ;; validator soft-passes (Spec 010 §Recommended soft-pass).
+            [re-frame.schemas.malli]
             [re-frame.spec :as spec]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.trace :as trace]))


### PR DESCRIPTION
## Summary

Drops the JVM-only `requiring-resolve` fallback to Malli in `validator.cljc`'s `default-malli-validate` / `default-malli-explain` (per audit rf2-x8x4p Q2; bead rf2-qyfie). The fallback was dead in pre-alpha: the schemas artefact declares `metosin/malli` as a hard dep and `re-frame.schemas.malli` lives in the same artefact, so a JVM caller using schemas-with-Malli but NOT requiring the adapter ns was an asymmetric configuration with no spec rationale.

The default validator/explainer now consult only the late-bind hook `:schemas/malli-validate` / `:schemas/malli-explain` (published by `re-frame.schemas.malli` at ns-load). Absent the require they soft-pass per Spec 010 §Recommended soft-pass — same contract on CLJS and the JVM.

- `-10 LoC` in `validator.cljc`
- `-1` cross-platform invariant divergence
- `+1` symmetrical CLJS-and-JVM opt-in pattern

Composes on top of rf2-dgug5 (validator split), rf2-vlcqv, rf2-ovxwp, rf2-2l08g, rf2-0frdi, rf2-xssfv, rf2-wla45, rf2-s7s6j.

### Test fallout

JVM tests that previously relied on the `requiring-resolve` fallback now require the adapter ns explicitly, mirroring the CLJS test pattern:

- `implementation/schemas/test/re_frame/schemas_test.clj`
- `implementation/schemas/test/re_frame/schemas_sensitive_test.clj`
- `implementation/schemas/test/re_frame/schemas_conformance_test.clj`
- `implementation/core/test/re_frame/conformance_test.clj`

Tests that only exercise registration / walker / source-coords / digest paths don't need the require.

## Test plan

- [x] `clojure -M:test` from `implementation/schemas/` — 133 tests / 379 assertions, 0 failures
- [x] `clojure -M:test` from `implementation/core/` — 456 tests / 2439 assertions, 0 failures
- [x] `npm run test:cljs` from `implementation/` — 1817 tests / 5050 assertions, 0 failures