### PR TITLE
refactor(pair2-mcp): unify tool-name registry across descriptors + dispatcher + cacheable (rf2-47g8l)

### DIFF
--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/cache.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/cache.cljs
@@ -95,7 +95,8 @@
   (rf2-obpa9), `:rf.mcp/summary` (rf2-tygdv), `:rf.size/large-elided`
   (rf2-urjnc). Agents that learned the family see one more slot."
   (:require [applied-science.js-interop :as j]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [re-frame-pair2-mcp.tools.registry :as registry]))
 
 ;; ---------------------------------------------------------------------------
 ;; LRU state — module-level atom; one MCP server process = one session.
@@ -282,18 +283,15 @@
 ;; The wire-boundary entry-point.
 ;; ---------------------------------------------------------------------------
 
-(def ^:private cacheable-tools
-  "Tools whose return value is a read of state — re-asking with the
-  same args against unchanged state legitimately returns the same
-  bytes. Action tools (`dispatch`, `eval-cljs`, `tail-build`) and
-  streaming tools (`subscribe`, `unsubscribe`) are excluded — their
-  return value is the result of an action, not a read."
-  #{"snapshot" "get-path" "trace-window" "watch-epochs" "discover-app"})
+(def cacheable?
+  "Predicate — should this tool ever consult the cache?
 
-(defn cacheable?
-  "Predicate — should this tool ever consult the cache?"
-  [tool]
-  (contains? cacheable-tools tool))
+  Forwarded to `registry/cacheable?` (rf2-47g8l) — the cacheable-bool
+  is stored on each entry in the single-source-of-truth registry, so
+  cache.cljs doesn't redeclare the allowlist. Keeping the name here
+  preserves the call-site vocabulary (`cache/cacheable?`) for existing
+  tests and for the `apply-cache` / `precheck` use sites below."
+  registry/cacheable?)
 
 (defn apply-cache
   "Wire-boundary cache check (rf2-3rt1f match-after-eval path). Returns

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -21,7 +21,7 @@
   | subscription-info | List active streaming subscriptions + queue stats     |
   |               | (rf2-zjz9q)                                               |
 
-  ## Per-tool / per-concern layout (rf2-vrbwx)
+  ## Per-tool / per-concern layout (rf2-vrbwx, rf2-47g8l)
 
   This namespace is the public façade — `invoke` glue, internal
   dispatch, and re-exported descriptor surface. The eleven tool bodies
@@ -33,9 +33,12 @@
   - Tools: `discover-app`, `eval-cljs`, `dispatch`, `trace-window`,
     `watch-epochs`, `tail-build`, `snapshot`, `get-path`, `subscribe`
     (+ `subscribe-emit`), `unsubscribe`, `subscription-info`.
-  - Descriptors: `descriptors-knobs` (the universal knob property defs
-    + the `with-*-knob` splicers) and `descriptors` (the catalogue of
-    eleven tool descriptors + `tool-descriptors-js`).
+  - Descriptors: `descriptors-knobs` (universal knob property data),
+    `descriptors-data` (per-tool descriptor maps), `descriptors`
+    (`tool-descriptors-js` + the knob splicers).
+  - Registry (rf2-47g8l): `registry` — the single map binding name →
+    descriptor + handler + cacheable?; the three downstream views are
+    derived from it.
   - Precheck: `precheck` (the rf2-36xod cheap-hash short-circuit).
 
   ## Result shape
@@ -47,17 +50,7 @@
             [re-frame-pair2-mcp.tools.wire :as wire]
             [re-frame-pair2-mcp.tools.cap :as cap]
             [re-frame-pair2-mcp.tools.precheck :as precheck]
-            [re-frame-pair2-mcp.tools.discover-app :as discover-app]
-            [re-frame-pair2-mcp.tools.eval-cljs :as eval-cljs]
-            [re-frame-pair2-mcp.tools.dispatch :as dispatch]
-            [re-frame-pair2-mcp.tools.trace-window :as trace-window]
-            [re-frame-pair2-mcp.tools.watch-epochs :as watch-epochs]
-            [re-frame-pair2-mcp.tools.tail-build :as tail-build]
-            [re-frame-pair2-mcp.tools.snapshot :as snapshot]
-            [re-frame-pair2-mcp.tools.get-path :as get-path]
-            [re-frame-pair2-mcp.tools.subscribe :as subscribe]
-            [re-frame-pair2-mcp.tools.unsubscribe :as unsubscribe]
-            [re-frame-pair2-mcp.tools.subscription-info :as subscription-info]
+            [re-frame-pair2-mcp.tools.registry :as registry]
             [re-frame-pair2-mcp.tools.descriptors :as descriptors]))
 
 ;; Re-export the descriptor catalogue + JS-shape builder. Tests
@@ -70,20 +63,15 @@
 (defn- dispatch-tool*
   "Route a `tools/call` to the per-tool implementation. Unknown tools
   resolve to an isError result rather than throwing — keeps the server
-  loop simple."
+  loop simple.
+
+  Lookup is a single `(get registry/handler-for name)` — the registry
+  is the only place tool names are enumerated (rf2-47g8l). Every
+  registered handler is a uniform 3-arity `(fn [conn args extra])`; the
+  registry adapts 2-arity per-tool handlers internally."
   [conn name args extra]
-  (case name
-    "discover-app"      (discover-app/discover-app conn args)
-    "eval-cljs"         (eval-cljs/eval-cljs-tool conn args)
-    "dispatch"          (dispatch/dispatch-tool conn args)
-    "trace-window"      (trace-window/trace-window-tool conn args)
-    "watch-epochs"      (watch-epochs/watch-epochs-tool conn args)
-    "tail-build"        (tail-build/tail-build-tool conn args)
-    "snapshot"          (snapshot/snapshot-tool conn args)
-    "get-path"          (get-path/get-path-tool conn args)
-    "subscribe"         (subscribe/subscribe-tool conn args extra)
-    "unsubscribe"       (unsubscribe/unsubscribe-tool conn args)
-    "subscription-info" (subscription-info/subscription-info-tool conn args)
+  (if-let [handler (get registry/handler-for name)]
+    (handler conn args extra)
     (js/Promise.resolve
       (wire/err-text {:ok? false :reason :unknown-tool :tool name}))))
 

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors.cljs
@@ -1,309 +1,48 @@
 (ns re-frame-pair2-mcp.tools.descriptors
-  "MCP `tools/list` descriptors for every pair2-mcp tool (rf2-vrbwx).
+  "MCP `tools/list` descriptor builder (rf2-vrbwx, rf2-47g8l).
 
-  Catalogue-shaped leaf: this file is the eleven-tool source of truth
-  for the `tools/list` wire contract. Splitting it per-tool would force
-  readers to chase across files when comparing descriptor shapes; per
-  rf2-zkca8's carve-out for catalogue-shaped leaves, the file is
-  permitted to exceed the standard ≤250-line ceiling.
+  The descriptor *data* lives in `descriptors-data.cljs`; the *catalogue
+  index* (name → descriptor + handler + cacheable?) lives in
+  `registry.cljs` — the single source of truth that drives both the
+  `tools/list` surface here and the `tools/call` dispatcher in
+  `tools.cljs`.
 
-  Universal knobs (`max-tokens`, `cache`) are spliced via
-  `descriptors-knobs/with-budget-knob` and `with-cache-knob` inside
-  `tool-descriptors-js`. Per-tool knobs (limit, cursor, dedup, elision)
-  reach in by name.
+  This file's only job is to surface that data to JS, splicing the
+  universal `max-tokens` and `cache` knobs onto every descriptor via
+  the `with-*-knob` composers below. Splicers live here (rather than in
+  `descriptors-knobs.cljs`) so they can consult `registry/cacheable?`
+  without dragging the property-data ns into a circular require chain
+  with the registry."
+  (:require [re-frame-pair2-mcp.tools.descriptors-knobs :as knobs]
+            [re-frame-pair2-mcp.tools.registry :as registry]))
 
-  Each entry carries `:name`, `:description`, `:inputSchema`, and
-  `:typicalTokens` (rf2-6sddv) — an informational ballpark of the
-  response-payload size in tokens that AI clients use to budget
-  calls and pick size-conscious args (`max-tokens`, `cache`,
-  `cursor`) without trial-and-error. Hint only; the real cap is
-  enforced separately."
-  (:require [re-frame-pair2-mcp.tools.descriptors-knobs :as knobs]))
+;; Re-export — `tools.cljs` and tests reach for the bare descriptor
+;; vector via this façade name.
+(def tool-descriptors registry/tool-descriptors)
 
-(def tool-descriptors
-  [{:name "discover-app"
-    :description "Verify the shadow-cljs nREPL is reachable, confirm the pair2 runtime preload landed, and report a health summary. Run this first every session. Returns :reason :runtime-not-preloaded when the preload entry is missing."
-    :typicalTokens 200
-    :inputSchema {:type "object"
-                  :properties {:build {:type "string"
-                                       :description "shadow-cljs build id (default: app)"}}
-                  :additionalProperties false}}
-   {:name "eval-cljs"
-    :description "Evaluate a ClojureScript form in the connected browser runtime via shadow-cljs's cljs-eval. Returns the EDN value."
-    :typicalTokens 500
-    :inputSchema {:type "object"
-                  :properties {:form  {:type "string" :description "The CLJS form to evaluate."}
-                               :build {:type "string" :description "shadow-cljs build id (default: app)"}}
-                  :required ["form"]
-                  :additionalProperties false}}
-   {:name "dispatch"
-    :description "Fire a re-frame2 event tagged with :origin :pair. Default mode is queued dispatch. Set `sync` for dispatch-sync, `trace` for synchronous dispatch returning the assembled :rf/epoch-record."
-    :typicalTokens 300
-    :inputSchema {:type "object"
-                  :properties {:event {:type "string" :description "The event vector, e.g. [:cart/checkout]"}
-                               :sync  {:type "boolean"}
-                               :trace {:type "boolean"}
-                               :frame {:type "string" :description "Operating frame (e.g. :stories)"}
-                               :fx-overrides {:type "object"
-                                              :description "Per-call fx redirects, e.g. {:http :stub-http}"}
-                               :build {:type "string"}}
-                  :required ["event"]
-                  :additionalProperties false}}
-   {:name "trace-window"
-    :description (str "Return the :rf/epoch-records added in the last N ms for the operating frame. "
-                      "Per spec/009 §Privacy this forwarder default-drops items carrying `:sensitive? true` "
-                      "at the top level; opt back in with `include-sensitive? true`. Dropped count surfaces "
-                      "as `:dropped-sensitive` on the result when non-zero. "
-                      "Each epoch's :db-after is diff-encoded against its own :db-before by default (rf2-1wdzp) "
-                      "— pass `epochs-mode \"full\"` for the legacy full-pair shape (needed for time-travel restore). "
-                      "The epoch vector is structurally deduped by default (rf2-obpa9) — repeated subtrees "
-                      "(notably the per-record `:db-before` reference) collapse to a `{:rf.mcp/dedup-table ...}` "
-                      "wrapper; the agent host calls `(de-dupe.core/expand cache)` to reconstruct. Pass `dedup false` to skip. "
-                      "Cursor pagination (rf2-kbqq3): the response is bounded at `:limit` records (default 50). "
-                      "When more remain, `:next-cursor` carries an opaque continuation token and `:has-more? true`; "
-                      "pass `cursor` back on the next call to resume. The window's upper bound is sticky across "
-                      "pages — fresh epochs landing during pagination don't sneak in mid-iteration. A cursor "
-                      "whose epoch-id has aged out of the runtime ring surfaces as `:reason :rf.mcp/cursor-stale`.")
-    :typicalTokens 2000
-    :inputSchema {:type "object"
-                  :properties {:ms    {:type "integer" :description "Window size in milliseconds (default 1000). Sticky across pagination — encoded into the cursor on the first call."}
-                               :frame {:type "string"}
-                               :limit knobs/limit-property
-                               :cursor knobs/cursor-property
-                               :epochs-mode {:type "string"
-                                             :description "How :db-after rides the wire: \"diff\" (default, intra-record structural diff against :db-before) or \"full\" (legacy full snapshot, opt-in for time-travel)."
-                                             :enum ["diff" "full"]}
-                               :dedup knobs/dedup-property
-                               :include-sensitive? {:type "boolean"
-                                                    :description "Opt back in to forwarding `:sensitive? true` items. Default false."}
-                               :build {:type "string"}}
-                  :additionalProperties false}}
-   {:name "watch-epochs"
-    :description (str "Pull-mode poll: returns the epochs matching `pred` that landed after `since-id`. "
-                      "Call repeatedly to live-watch. Predicate keys: :event-id, :event-id-prefix, :effects, "
-                      ":touches-path, :sub-ran, :render, :origin, :frame, :timing-ms. "
-                      ":timing-ms (rf2-r3azh) is a server-side wall-clock filter — accepts a number (sugar for "
-                      "`>= N`) or a comparison string (`\">100\"`, `\"<=50\"`, `\">=100\"`, `\"<200\"`, `\"=42\"`). "
-                      "Compares against the cascade's elapsed-ms derived from the `:event/run-start` / "
-                      "`:event/run-end` trace pair. The filter rides server-side so non-matching epochs "
-                      "never cross the wire — typicalTokens above is the worst case, narrowing on :timing-ms "
-                      "(e.g. only :>100ms epochs) shrinks the payload roughly proportional to the match rate. "
-                      "Per spec/009 §Privacy this forwarder "
-                      "default-drops items carrying `:sensitive? true`; opt back in with `include-sensitive? true`. "
-                      "Each epoch's :db-after is diff-encoded against its own :db-before by default (rf2-1wdzp) "
-                      "— pass `epochs-mode \"full\"` for the legacy full-pair shape. "
-                      "The matches vector is structurally deduped by default (rf2-obpa9); pass `dedup false` to skip. "
-                      "Cursor pagination (rf2-kbqq3): the matches vector is bounded at `:limit` (default 50). "
-                      "When more matches remain, `:next-cursor` is non-nil and `:has-more? true`; pass `cursor` "
-                      "back to consume the next page. The `:cursor` arg overrides `:since-id` when both are "
-                      "supplied. A cursor whose epoch-id has aged out of the ring surfaces as "
-                      "`:reason :rf.mcp/cursor-stale`.")
-    :typicalTokens 2000
-    :inputSchema {:type "object"
-                  :properties {:since-id {:type "string" :description "The last epoch id you've seen (omit to start fresh). Supplanted by :cursor when both are passed."}
-                               :pred     {:type "object" :description "Filter map"}
-                               :frame    {:type "string"}
-                               :limit    knobs/limit-property
-                               :cursor   knobs/cursor-property
-                               :epochs-mode {:type "string"
-                                             :description "How :db-after rides the wire: \"diff\" (default) or \"full\" (legacy, opt-in for time-travel restore)."
-                                             :enum ["diff" "full"]}
-                               :dedup    knobs/dedup-property
-                               :include-sensitive? {:type "boolean"
-                                                    :description "Opt back in to forwarding `:sensitive? true` items. Default false."}
-                               :build    {:type "string"}}
-                  :additionalProperties false}}
-   {:name "tail-build"
-    :description "Wait for a hot-reload to land by polling a probe form until its value changes. Returns once changed, or times out."
-    :typicalTokens 100
-    :inputSchema {:type "object"
-                  :properties {:probe   {:type "string" :description "CLJS form whose value should change after the reload"}
-                               :wait-ms {:type "integer" :description "Max wait in ms (default 5000)"}
-                               :build   {:type "string"}}
-                  :additionalProperties false}}
-   {:name "snapshot"
-    :description (str "Coarse-grained per-frame state read in one round-trip — the mega-op for investigate-X workflows. "
-                      "Returns a map keyed by frame-id whose values carry the requested slices: "
-                      ":app-db, :sub-cache, :machines, :epochs, :traces. "
-                      "Server-side composition over the existing per-slice runtime readers. "
-                      "Prefer this over chaining 5-10 individual reads. "
-                      "Lazy-summary default (rf2-u2029): each rich slice in the response is replaced with a "
-                      "`{:rf.mcp/summary {:type :map|:vector :keys [...] :count N :bytes ~B}}` marker by "
-                      "default — keeps a discovery snapshot under the wire cap by construction. Agents drill "
-                      "into the slice they actually need via `mode \"full\"` (every slice expands), per-slice "
-                      "`modes {\"app-db\": \"full\"}` (one slice expands), or — for the :app-db slice only — "
-                      "the `path` arg (rf2-tygdv: returns the addressed subtree). "
-                      "Path slicing (rf2-tygdv): the `:app-db` slice supports a `path` arg (an EDN-encoded "
-                      "vector of keys, e.g. \"[:cart :items 0]\"). With `path`, returns the addressed subtree. "
-                      "Path-slicing supersedes the slice-level mode for `:app-db`. "
-                      "Diff-encoded epochs (rf2-1wdzp): each epoch in the `:epochs` slice has its `:db-after` "
-                      "replaced with a structural diff against its own `:db-before` by default — pass "
-                      "`epochs-mode \"full\"` for legacy full-pair shape (opt-in for time-travel restore). "
-                      "Diff-encode runs before the lazy-summary so `bytes` hints reflect post-shrink cost. "
-                      "Per spec/009 §Privacy the `:traces` and `:epochs` slices default-drop items carrying "
-                      "`:sensitive? true`; opt back in with `include-sensitive? true`. App-db / sub-cache / "
-                      "machines slices pass through unchanged — payload redaction is the `with-redacted` "
-                      "interceptor's job, not the forwarder's. "
-                      "Each frame's `:epochs` slice is structurally deduped (rf2-obpa9) after diff-encoding — "
-                      "repeated subtrees (notably the per-record `:db-before` reference) collapse to a "
-                      "`{:rf.mcp/dedup-table ...}` wrapper; agent host reconstructs via `de-dupe.core/expand`. "
-                      "Pass `dedup false` to skip. "
-                      "Size-elision (rf2-urjnc): each frame's `:app-db` slice is run through "
-                      "`re-frame.core/elide-wire-value` server-side before crossing the wire — declared / "
-                      "schema-`:large?` paths and over-threshold leaves are substituted with a "
-                      "`{:rf.size/large-elided {:path [...] :handle [:rf.elision/at <path>] ...}}` marker. "
-                      "Agent drills into the handle via `get-path` (or `snapshot {:path ...}` with a "
-                      "non-elided sibling subpath). Pass `elision false` to bypass the walk and receive "
-                      "the raw value.")
-    :typicalTokens 3000
-    :inputSchema {:type "object"
-                  :properties {:frames  {:description "Frames to snapshot. Pass \"all\" (default) or an array of frame-id strings like [\":rf/default\", \":stories\"]."
-                                         :oneOf [{:type "string"}
-                                                 {:type "array" :items {:type "string"}}]}
-                               :include {:type "array"
-                                         :description "Slices to include. Defaults to all five. Recognised: app-db, sub-cache, machines, epochs, traces."
-                                         :items {:type "string"
-                                                 :enum ["app-db" "sub-cache" "machines" "epochs" "traces"]}}
-                               :path    {:description (str "Path into the :app-db slice. EDN-encoded vector of keys "
-                                                           "(e.g. \"[:cart :items 0]\") or a JSON array of segment "
-                                                           "strings. When supplied, the :app-db slice in the result "
-                                                           "is the subtree at the path. Out-of-range paths surface "
-                                                           "as `:path-not-found` per-frame with deepest-valid-prefix "
-                                                           "attached. Path-slicing supersedes the slice-level mode "
-                                                           "for :app-db. When absent, the :app-db slice respects "
-                                                           "the resolved mode (default :summary).")
-                                         :oneOf [{:type "string"}
-                                                 {:type "array" :items {:type "string"}}]}
-                               :mode    {:type "string"
-                                         :description (str "Global lazy-summary mode (rf2-u2029). "
-                                                           "\"summary\" (default) replaces every rich slice "
-                                                           "(:app-db when no `path`, :sub-cache, :machines, :epochs, :traces) "
-                                                           "with a `{:rf.mcp/summary ...}` marker — top-level keys, "
-                                                           "count, and approximate bytes. \"full\" expands every "
-                                                           "slice to its raw payload (legacy pre-rf2-u2029 behaviour). "
-                                                           "Per-slice override via `modes` takes precedence.")
-                                         :enum ["summary" "full"]}
-                               :modes   {:type "object"
-                                         :description (str "Per-slice mode override (rf2-u2029) — a map "
-                                                           "{slice-name: \"summary\"|\"full\"}. Recognised slices: "
-                                                           "app-db, sub-cache, machines, epochs, traces. Slices not "
-                                                           "listed fall back to the global `mode` arg (default \"summary\"). "
-                                                           "Example: `{\"app-db\": \"full\", \"epochs\": \"summary\"}` — "
-                                                           "expand the live state, summarise the history.")
-                                         :additionalProperties {:type "string"
-                                                                :enum ["summary" "full"]}}
-                               :epochs-mode {:type "string"
-                                             :description "How :db-after rides the wire in the :epochs slice: \"diff\" (default, intra-record structural diff against :db-before) or \"full\" (legacy full snapshot, opt-in for time-travel)."
-                                             :enum ["diff" "full"]}
-                               :dedup    knobs/dedup-property
-                               :elision  knobs/elision-property
-                               :include-sensitive? {:type "boolean"
-                                                    :description "Opt back in to forwarding `:sensitive? true` items in the :traces / :epochs slices. Default false."}
-                               :build   {:type "string" :description "shadow-cljs build id (default: app)"}}
-                  :additionalProperties false}}
-   {:name "get-path"
-    :description (str "Read a single value at `path` from a frame's app-db. Minimal primitive for "
-                      "targeted reads — the agent already knows the path. Server-side `(get-in db path)`; "
-                      "only the addressed subtree crosses the wire. Returns "
-                      "`{:ok? true :exists? true :path [...] :value <subtree>}` on success or "
-                      "`{:ok? false :reason :path-not-found :path [...] :deepest-valid-prefix [...]}` "
-                      "when the path doesn't resolve. The deepest-valid-prefix lets the agent re-aim "
-                      "without a binary search. Use this when `snapshot`'s summary mode (default) "
-                      "tells you which key carries the answer. "
-                      "Size-elision (rf2-urjnc): the resolved value is run through "
-                      "`re-frame.core/elide-wire-value` server-side — a declared / schema-`:large?` "
-                      "slot or an over-threshold leaf returns a `{:rf.size/large-elided ...}` marker "
-                      "with a `:handle [:rf.elision/at <path>]` fetch handle, not the raw bytes. Drill "
-                      "into a non-elided child by re-calling with a deeper `path`. Pass `elision false` "
-                      "to bypass the walk and receive the raw value.")
-    :typicalTokens 500
-    :inputSchema {:type "object"
-                  :properties {:path  {:description (str "Path into app-db. EDN-encoded vector of keys "
-                                                         "(e.g. \"[:cart :items 0 :sku]\") or a JSON array "
-                                                         "of segment strings (each parsed as EDN — bare "
-                                                         "strings stay as map-key strings).")
-                                       :oneOf [{:type "string"}
-                                               {:type "array" :items {:type "string"}}]}
-                               :frame   {:type "string"
-                                         :description "Frame-id (e.g. \":rf/default\"). Defaults to the operating frame."}
-                               :elision knobs/elision-property
-                               :build   {:type "string"}}
-                  :required ["path"]
-                  :additionalProperties false}}
-   {:name "subscribe"
-    :description (str "Open a streaming subscription on the trace or epoch bus. Push-mode replacement for watch-epochs. "
-                      "Long-running tools/call — emits each batch of matching events as a notifications/progress notification "
-                      "(correlated via the call's progressToken), and resolves with a summary when the client cancels or an "
-                      "unsubscribe op fires. Topics: 'trace' (raw trace stream), 'epoch' (assembled :rf/epoch-records), "
-                      "'fx' (trace stream filtered to :op-type :fx), 'error' (trace stream filtered to :op-type :error). "
-                      "Filter vocab depends on topic — :trace/:fx/:error accept the (rf/trace-buffer) filter map "
-                      "(:operation :op-type :frame :severity :event-id :handler-id :source :origin :dispatch-id :since-ms :between); "
-                      ":epoch accepts the epoch-matches? predicate map (:event-id :event-id-prefix :effects :touches-path "
-                      ":sub-ran :render :origin :frame :timing-ms). :timing-ms (rf2-r3azh) is a server-side wall-clock "
-                      "filter — number (sugar for `>= N`) or comparison string (`\">100\"`, `\"<=50\"`, …). "
-                      "Pass `filter` either as a JSON object or as an EDN-encoded string. "
-                      "Per spec/009 §Privacy this forwarder default-drops events carrying `:sensitive? true` at the top "
-                      "level; opt back in with `include-sensitive? true`. Dropped count surfaces as `:dropped-sensitive` "
-                      "on each progress payload (when non-zero) and the final summary. "
-                      "Each progress payload's `:events` vector is structurally deduped by default (rf2-obpa9) — "
-                      "shared subtrees across the tick collapse to a `{:rf.mcp/dedup-table ...}` wrapper; "
-                      "agent host reconstructs via `(de-dupe.core/expand cache-map)`. Dedup is per-tick, not "
-                      "per-stream — each notifications/progress frame carries its own cache, no cross-tick "
-                      "references. Pass `dedup false` to skip.")
-    :typicalTokens 1000
-    :inputSchema {:type "object"
-                  :properties {:topic   {:type "string"
-                                         :description "Topic name. Required."
-                                         :enum ["trace" "epoch" "fx" "error"]}
-                               :filter  {:description "Filter map (JSON object) or EDN string. Vocab depends on topic."
-                                         :oneOf [{:type "object"}
-                                                 {:type "string"}]}
-                               :max-buffered-events {:type "integer"
-                                                     :description "Runtime-side queue cap in EVENTS. Default 500. On overflow the OLDEST events are evicted (drop-oldest FIFO) and reported as `:dropped-events` / `:overflow-reason :max-buffered-events` on the next progress tick. OR-combined with :max-buffered-bytes — whichever trips first evicts."}
-                               :max-buffered-bytes  {:type "integer"
-                                                     :description "Runtime-side queue cap in BYTES (pr-str char count). Default 5_000_000 (~5 MB). Same drop-oldest policy; reports `:dropped-bytes` / `:overflow-reason :max-buffered-bytes`. Sized to fit the 5,000-token wire-cap posture across a normal poll cadence."}
-                               :poll-ms {:type "integer"
-                                         :description "Server poll cadence in ms. Default 100."}
-                               :max-ms  {:type "integer"
-                                         :description "Hard upper-bound on how long the subscription stays open, ms. 0 = unbounded (close on cancel only). Default 0."}
-                               :max-events {:type "integer"
-                                            :description "Terminate after this many events have been delivered. 0 = unbounded. Default 0."}
-                               :dedup    knobs/dedup-property
-                               :include-sensitive? {:type "boolean"
-                                                    :description "Opt back in to forwarding `:sensitive? true` items. Default false."}
-                               :build   {:type "string"}}
-                  :required ["topic"]
-                  :additionalProperties false}}
-   {:name "unsubscribe"
-    :description "Close the subscription with the given sub-id. Idempotent — closing an unknown sub-id returns :existed? false."
-    :typicalTokens 50
-    :inputSchema {:type "object"
-                  :properties {:sub-id {:type "string"
-                                        :description "The uuid returned by `subscribe`."}
-                               :build  {:type "string"}}
-                  :required ["sub-id"]
-                  :additionalProperties false}}
-   {:name "subscription-info"
-    :description (str "List active streaming subscriptions opened via `subscribe`, with per-sub queue depth, "
-                      "drop counts, and overflow-reason — without draining any queues. Diagnostic for "
-                      "'what streams are currently open?' and 'is my probe still alive?'. Wraps the "
-                      "`re-frame-pair2.runtime/subscription-info` runtime fn directly (no eval-cljs round-trip). "
-                      "Returns `{:ok? true :subs [{:id :topic :filter :queue-depth :queue-bytes "
-                      ":dropped-events :dropped-bytes :overflow-reason :created-at}]}` — one entry per "
-                      "currently-registered subscription. Empty `:subs` vector when no streams are open. "
-                      "Optional filters: `topic` (one of `:trace` / `:epoch` / `:fx` / `:error`) narrows to "
-                      "a single topic; `sub-id` returns only the matching sub. A non-nil `:overflow-reason` "
-                      "indicates the queue has been evicting older events to stay inside its budget — tune "
-                      "`max-buffered-events` / `max-buffered-bytes` on the next `subscribe` call.")
-    :typicalTokens 500
-    :inputSchema {:type "object"
-                  :properties {:topic  {:type "string"
-                                        :description "Optional filter — only return subs on this topic. One of trace, epoch, fx, error."
-                                        :enum ["trace" "epoch" "fx" "error"]}
-                               :sub-id {:type "string"
-                                        :description "Optional filter — only return the sub with this uuid."}
-                               :build  {:type "string"}}
-                  :additionalProperties false}}])
+(defn with-budget-knob
+  "Splice `max-tokens` into a tool descriptor's inputSchema.properties.
+  No-op if the descriptor already declares it (forward-compat)."
+  [desc]
+  (let [props (get-in desc [:inputSchema :properties])]
+    (if (contains? props :max-tokens)
+      desc
+      (assoc-in desc [:inputSchema :properties :max-tokens]
+                knobs/max-tokens-property))))
+
+(defn with-cache-knob
+  "Splice `cache` into a tool descriptor's inputSchema.properties — but
+  only for the read tools that consult `cache/apply-cache`. Action and
+  streaming tools don't list the knob because it has no effect there
+  (bypassed in `registry/cacheable?`)."
+  [desc]
+  (let [name  (:name desc)
+        props (get-in desc [:inputSchema :properties])]
+    (if (or (contains? props :cache)
+            (not (registry/cacheable? name)))
+      desc
+      (assoc-in desc [:inputSchema :properties :cache]
+                knobs/cache-property))))
 
 (defn tool-descriptors-js []
-  (clj->js (mapv (comp knobs/with-cache-knob knobs/with-budget-knob) tool-descriptors)))
+  (clj->js (mapv (comp with-cache-knob with-budget-knob) tool-descriptors)))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors_data.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors_data.cljs
@@ -1,0 +1,330 @@
+(ns re-frame-pair2-mcp.tools.descriptors-data
+  "MCP `tools/list` descriptor data — one `def` per tool.
+
+  Catalogue-shaped leaf: the descriptor maps live here as named
+  vars so `tools/registry.cljs` can reference each by symbol (one
+  registry entry per tool, descriptor included by name) without
+  forcing the registry to inline ~280 lines of descriptor blobs.
+
+  Per rf2-zkca8's carve-out for catalogue-shaped leaves, this file
+  is permitted to exceed the standard ≤250-line ceiling — splitting
+  it per-tool would force readers to chase across eleven files when
+  comparing descriptor shapes.
+
+  Universal knobs (`max-tokens`, `cache`) are spliced via
+  `descriptors-knobs/with-budget-knob` and `with-cache-knob` inside
+  `descriptors/tool-descriptors-js`, not at the def site. Per-tool
+  knobs (limit, cursor, dedup, elision) reach in by name below.
+
+  Each entry carries `:name`, `:description`, `:inputSchema`, and
+  `:typicalTokens` (rf2-6sddv) — an informational ballpark of the
+  response-payload size in tokens that AI clients use to budget
+  calls and pick size-conscious args (`max-tokens`, `cache`,
+  `cursor`) without trial-and-error. Hint only; the real cap is
+  enforced separately."
+  (:require [re-frame-pair2-mcp.tools.descriptors-knobs :as knobs]))
+
+(def discover-app
+  {:name "discover-app"
+   :description "Verify the shadow-cljs nREPL is reachable, confirm the pair2 runtime preload landed, and report a health summary. Run this first every session. Returns :reason :runtime-not-preloaded when the preload entry is missing."
+   :typicalTokens 200
+   :inputSchema {:type "object"
+                 :properties {:build {:type "string"
+                                      :description "shadow-cljs build id (default: app)"}}
+                 :additionalProperties false}})
+
+(def eval-cljs
+  {:name "eval-cljs"
+   :description "Evaluate a ClojureScript form in the connected browser runtime via shadow-cljs's cljs-eval. Returns the EDN value."
+   :typicalTokens 500
+   :inputSchema {:type "object"
+                 :properties {:form  {:type "string" :description "The CLJS form to evaluate."}
+                              :build {:type "string" :description "shadow-cljs build id (default: app)"}}
+                 :required ["form"]
+                 :additionalProperties false}})
+
+(def dispatch
+  {:name "dispatch"
+   :description "Fire a re-frame2 event tagged with :origin :pair. Default mode is queued dispatch. Set `sync` for dispatch-sync, `trace` for synchronous dispatch returning the assembled :rf/epoch-record."
+   :typicalTokens 300
+   :inputSchema {:type "object"
+                 :properties {:event {:type "string" :description "The event vector, e.g. [:cart/checkout]"}
+                              :sync  {:type "boolean"}
+                              :trace {:type "boolean"}
+                              :frame {:type "string" :description "Operating frame (e.g. :stories)"}
+                              :fx-overrides {:type "object"
+                                             :description "Per-call fx redirects, e.g. {:http :stub-http}"}
+                              :build {:type "string"}}
+                 :required ["event"]
+                 :additionalProperties false}})
+
+(def trace-window
+  {:name "trace-window"
+   :description (str "Return the :rf/epoch-records added in the last N ms for the operating frame. "
+                     "Per spec/009 §Privacy this forwarder default-drops items carrying `:sensitive? true` "
+                     "at the top level; opt back in with `include-sensitive? true`. Dropped count surfaces "
+                     "as `:dropped-sensitive` on the result when non-zero. "
+                     "Each epoch's :db-after is diff-encoded against its own :db-before by default (rf2-1wdzp) "
+                     "— pass `epochs-mode \"full\"` for the legacy full-pair shape (needed for time-travel restore). "
+                     "The epoch vector is structurally deduped by default (rf2-obpa9) — repeated subtrees "
+                     "(notably the per-record `:db-before` reference) collapse to a `{:rf.mcp/dedup-table ...}` "
+                     "wrapper; the agent host calls `(de-dupe.core/expand cache)` to reconstruct. Pass `dedup false` to skip. "
+                     "Cursor pagination (rf2-kbqq3): the response is bounded at `:limit` records (default 50). "
+                     "When more remain, `:next-cursor` carries an opaque continuation token and `:has-more? true`; "
+                     "pass `cursor` back on the next call to resume. The window's upper bound is sticky across "
+                     "pages — fresh epochs landing during pagination don't sneak in mid-iteration. A cursor "
+                     "whose epoch-id has aged out of the runtime ring surfaces as `:reason :rf.mcp/cursor-stale`.")
+   :typicalTokens 2000
+   :inputSchema {:type "object"
+                 :properties {:ms    {:type "integer" :description "Window size in milliseconds (default 1000). Sticky across pagination — encoded into the cursor on the first call."}
+                              :frame {:type "string"}
+                              :limit knobs/limit-property
+                              :cursor knobs/cursor-property
+                              :epochs-mode {:type "string"
+                                            :description "How :db-after rides the wire: \"diff\" (default, intra-record structural diff against :db-before) or \"full\" (legacy full snapshot, opt-in for time-travel)."
+                                            :enum ["diff" "full"]}
+                              :dedup knobs/dedup-property
+                              :include-sensitive? {:type "boolean"
+                                                   :description "Opt back in to forwarding `:sensitive? true` items. Default false."}
+                              :build {:type "string"}}
+                 :additionalProperties false}})
+
+(def watch-epochs
+  {:name "watch-epochs"
+   :description (str "Pull-mode poll: returns the epochs matching `pred` that landed after `since-id`. "
+                     "Call repeatedly to live-watch. Predicate keys: :event-id, :event-id-prefix, :effects, "
+                     ":touches-path, :sub-ran, :render, :origin, :frame, :timing-ms. "
+                     ":timing-ms (rf2-r3azh) is a server-side wall-clock filter — accepts a number (sugar for "
+                     "`>= N`) or a comparison string (`\">100\"`, `\"<=50\"`, `\">=100\"`, `\"<200\"`, `\"=42\"`). "
+                     "Compares against the cascade's elapsed-ms derived from the `:event/run-start` / "
+                     "`:event/run-end` trace pair. The filter rides server-side so non-matching epochs "
+                     "never cross the wire — typicalTokens above is the worst case, narrowing on :timing-ms "
+                     "(e.g. only :>100ms epochs) shrinks the payload roughly proportional to the match rate. "
+                     "Per spec/009 §Privacy this forwarder "
+                     "default-drops items carrying `:sensitive? true`; opt back in with `include-sensitive? true`. "
+                     "Each epoch's :db-after is diff-encoded against its own :db-before by default (rf2-1wdzp) "
+                     "— pass `epochs-mode \"full\"` for the legacy full-pair shape. "
+                     "The matches vector is structurally deduped by default (rf2-obpa9); pass `dedup false` to skip. "
+                     "Cursor pagination (rf2-kbqq3): the matches vector is bounded at `:limit` (default 50). "
+                     "When more matches remain, `:next-cursor` is non-nil and `:has-more? true`; pass `cursor` "
+                     "back to consume the next page. The `:cursor` arg overrides `:since-id` when both are "
+                     "supplied. A cursor whose epoch-id has aged out of the ring surfaces as "
+                     "`:reason :rf.mcp/cursor-stale`.")
+   :typicalTokens 2000
+   :inputSchema {:type "object"
+                 :properties {:since-id {:type "string" :description "The last epoch id you've seen (omit to start fresh). Supplanted by :cursor when both are passed."}
+                              :pred     {:type "object" :description "Filter map"}
+                              :frame    {:type "string"}
+                              :limit    knobs/limit-property
+                              :cursor   knobs/cursor-property
+                              :epochs-mode {:type "string"
+                                            :description "How :db-after rides the wire: \"diff\" (default) or \"full\" (legacy, opt-in for time-travel restore)."
+                                            :enum ["diff" "full"]}
+                              :dedup    knobs/dedup-property
+                              :include-sensitive? {:type "boolean"
+                                                   :description "Opt back in to forwarding `:sensitive? true` items. Default false."}
+                              :build    {:type "string"}}
+                 :additionalProperties false}})
+
+(def tail-build
+  {:name "tail-build"
+   :description "Wait for a hot-reload to land by polling a probe form until its value changes. Returns once changed, or times out."
+   :typicalTokens 100
+   :inputSchema {:type "object"
+                 :properties {:probe   {:type "string" :description "CLJS form whose value should change after the reload"}
+                              :wait-ms {:type "integer" :description "Max wait in ms (default 5000)"}
+                              :build   {:type "string"}}
+                 :additionalProperties false}})
+
+(def snapshot
+  {:name "snapshot"
+   :description (str "Coarse-grained per-frame state read in one round-trip — the mega-op for investigate-X workflows. "
+                     "Returns a map keyed by frame-id whose values carry the requested slices: "
+                     ":app-db, :sub-cache, :machines, :epochs, :traces. "
+                     "Server-side composition over the existing per-slice runtime readers. "
+                     "Prefer this over chaining 5-10 individual reads. "
+                     "Lazy-summary default (rf2-u2029): each rich slice in the response is replaced with a "
+                     "`{:rf.mcp/summary {:type :map|:vector :keys [...] :count N :bytes ~B}}` marker by "
+                     "default — keeps a discovery snapshot under the wire cap by construction. Agents drill "
+                     "into the slice they actually need via `mode \"full\"` (every slice expands), per-slice "
+                     "`modes {\"app-db\": \"full\"}` (one slice expands), or — for the :app-db slice only — "
+                     "the `path` arg (rf2-tygdv: returns the addressed subtree). "
+                     "Path slicing (rf2-tygdv): the `:app-db` slice supports a `path` arg (an EDN-encoded "
+                     "vector of keys, e.g. \"[:cart :items 0]\"). With `path`, returns the addressed subtree. "
+                     "Path-slicing supersedes the slice-level mode for `:app-db`. "
+                     "Diff-encoded epochs (rf2-1wdzp): each epoch in the `:epochs` slice has its `:db-after` "
+                     "replaced with a structural diff against its own `:db-before` by default — pass "
+                     "`epochs-mode \"full\"` for legacy full-pair shape (opt-in for time-travel restore). "
+                     "Diff-encode runs before the lazy-summary so `bytes` hints reflect post-shrink cost. "
+                     "Per spec/009 §Privacy the `:traces` and `:epochs` slices default-drop items carrying "
+                     "`:sensitive? true`; opt back in with `include-sensitive? true`. App-db / sub-cache / "
+                     "machines slices pass through unchanged — payload redaction is the `with-redacted` "
+                     "interceptor's job, not the forwarder's. "
+                     "Each frame's `:epochs` slice is structurally deduped (rf2-obpa9) after diff-encoding — "
+                     "repeated subtrees (notably the per-record `:db-before` reference) collapse to a "
+                     "`{:rf.mcp/dedup-table ...}` wrapper; agent host reconstructs via `de-dupe.core/expand`. "
+                     "Pass `dedup false` to skip. "
+                     "Size-elision (rf2-urjnc): each frame's `:app-db` slice is run through "
+                     "`re-frame.core/elide-wire-value` server-side before crossing the wire — declared / "
+                     "schema-`:large?` paths and over-threshold leaves are substituted with a "
+                     "`{:rf.size/large-elided {:path [...] :handle [:rf.elision/at <path>] ...}}` marker. "
+                     "Agent drills into the handle via `get-path` (or `snapshot {:path ...}` with a "
+                     "non-elided sibling subpath). Pass `elision false` to bypass the walk and receive "
+                     "the raw value.")
+   :typicalTokens 3000
+   :inputSchema {:type "object"
+                 :properties {:frames  {:description "Frames to snapshot. Pass \"all\" (default) or an array of frame-id strings like [\":rf/default\", \":stories\"]."
+                                        :oneOf [{:type "string"}
+                                                {:type "array" :items {:type "string"}}]}
+                              :include {:type "array"
+                                        :description "Slices to include. Defaults to all five. Recognised: app-db, sub-cache, machines, epochs, traces."
+                                        :items {:type "string"
+                                                :enum ["app-db" "sub-cache" "machines" "epochs" "traces"]}}
+                              :path    {:description (str "Path into the :app-db slice. EDN-encoded vector of keys "
+                                                          "(e.g. \"[:cart :items 0]\") or a JSON array of segment "
+                                                          "strings. When supplied, the :app-db slice in the result "
+                                                          "is the subtree at the path. Out-of-range paths surface "
+                                                          "as `:path-not-found` per-frame with deepest-valid-prefix "
+                                                          "attached. Path-slicing supersedes the slice-level mode "
+                                                          "for :app-db. When absent, the :app-db slice respects "
+                                                          "the resolved mode (default :summary).")
+                                        :oneOf [{:type "string"}
+                                                {:type "array" :items {:type "string"}}]}
+                              :mode    {:type "string"
+                                        :description (str "Global lazy-summary mode (rf2-u2029). "
+                                                          "\"summary\" (default) replaces every rich slice "
+                                                          "(:app-db when no `path`, :sub-cache, :machines, :epochs, :traces) "
+                                                          "with a `{:rf.mcp/summary ...}` marker — top-level keys, "
+                                                          "count, and approximate bytes. \"full\" expands every "
+                                                          "slice to its raw payload (legacy pre-rf2-u2029 behaviour). "
+                                                          "Per-slice override via `modes` takes precedence.")
+                                        :enum ["summary" "full"]}
+                              :modes   {:type "object"
+                                        :description (str "Per-slice mode override (rf2-u2029) — a map "
+                                                          "{slice-name: \"summary\"|\"full\"}. Recognised slices: "
+                                                          "app-db, sub-cache, machines, epochs, traces. Slices not "
+                                                          "listed fall back to the global `mode` arg (default \"summary\"). "
+                                                          "Example: `{\"app-db\": \"full\", \"epochs\": \"summary\"}` — "
+                                                          "expand the live state, summarise the history.")
+                                        :additionalProperties {:type "string"
+                                                               :enum ["summary" "full"]}}
+                              :epochs-mode {:type "string"
+                                            :description "How :db-after rides the wire in the :epochs slice: \"diff\" (default, intra-record structural diff against :db-before) or \"full\" (legacy full snapshot, opt-in for time-travel)."
+                                            :enum ["diff" "full"]}
+                              :dedup    knobs/dedup-property
+                              :elision  knobs/elision-property
+                              :include-sensitive? {:type "boolean"
+                                                   :description "Opt back in to forwarding `:sensitive? true` items in the :traces / :epochs slices. Default false."}
+                              :build   {:type "string" :description "shadow-cljs build id (default: app)"}}
+                 :additionalProperties false}})
+
+(def get-path
+  {:name "get-path"
+   :description (str "Read a single value at `path` from a frame's app-db. Minimal primitive for "
+                     "targeted reads — the agent already knows the path. Server-side `(get-in db path)`; "
+                     "only the addressed subtree crosses the wire. Returns "
+                     "`{:ok? true :exists? true :path [...] :value <subtree>}` on success or "
+                     "`{:ok? false :reason :path-not-found :path [...] :deepest-valid-prefix [...]}` "
+                     "when the path doesn't resolve. The deepest-valid-prefix lets the agent re-aim "
+                     "without a binary search. Use this when `snapshot`'s summary mode (default) "
+                     "tells you which key carries the answer. "
+                     "Size-elision (rf2-urjnc): the resolved value is run through "
+                     "`re-frame.core/elide-wire-value` server-side — a declared / schema-`:large?` "
+                     "slot or an over-threshold leaf returns a `{:rf.size/large-elided ...}` marker "
+                     "with a `:handle [:rf.elision/at <path>]` fetch handle, not the raw bytes. Drill "
+                     "into a non-elided child by re-calling with a deeper `path`. Pass `elision false` "
+                     "to bypass the walk and receive the raw value.")
+   :typicalTokens 500
+   :inputSchema {:type "object"
+                 :properties {:path  {:description (str "Path into app-db. EDN-encoded vector of keys "
+                                                        "(e.g. \"[:cart :items 0 :sku]\") or a JSON array "
+                                                        "of segment strings (each parsed as EDN — bare "
+                                                        "strings stay as map-key strings).")
+                                      :oneOf [{:type "string"}
+                                              {:type "array" :items {:type "string"}}]}
+                              :frame   {:type "string"
+                                        :description "Frame-id (e.g. \":rf/default\"). Defaults to the operating frame."}
+                              :elision knobs/elision-property
+                              :build   {:type "string"}}
+                 :required ["path"]
+                 :additionalProperties false}})
+
+(def subscribe
+  {:name "subscribe"
+   :description (str "Open a streaming subscription on the trace or epoch bus. Push-mode replacement for watch-epochs. "
+                     "Long-running tools/call — emits each batch of matching events as a notifications/progress notification "
+                     "(correlated via the call's progressToken), and resolves with a summary when the client cancels or an "
+                     "unsubscribe op fires. Topics: 'trace' (raw trace stream), 'epoch' (assembled :rf/epoch-records), "
+                     "'fx' (trace stream filtered to :op-type :fx), 'error' (trace stream filtered to :op-type :error). "
+                     "Filter vocab depends on topic — :trace/:fx/:error accept the (rf/trace-buffer) filter map "
+                     "(:operation :op-type :frame :severity :event-id :handler-id :source :origin :dispatch-id :since-ms :between); "
+                     ":epoch accepts the epoch-matches? predicate map (:event-id :event-id-prefix :effects :touches-path "
+                     ":sub-ran :render :origin :frame :timing-ms). :timing-ms (rf2-r3azh) is a server-side wall-clock "
+                     "filter — number (sugar for `>= N`) or comparison string (`\">100\"`, `\"<=50\"`, …). "
+                     "Pass `filter` either as a JSON object or as an EDN-encoded string. "
+                     "Per spec/009 §Privacy this forwarder default-drops events carrying `:sensitive? true` at the top "
+                     "level; opt back in with `include-sensitive? true`. Dropped count surfaces as `:dropped-sensitive` "
+                     "on each progress payload (when non-zero) and the final summary. "
+                     "Each progress payload's `:events` vector is structurally deduped by default (rf2-obpa9) — "
+                     "shared subtrees across the tick collapse to a `{:rf.mcp/dedup-table ...}` wrapper; "
+                     "agent host reconstructs via `(de-dupe.core/expand cache-map)`. Dedup is per-tick, not "
+                     "per-stream — each notifications/progress frame carries its own cache, no cross-tick "
+                     "references. Pass `dedup false` to skip.")
+   :typicalTokens 1000
+   :inputSchema {:type "object"
+                 :properties {:topic   {:type "string"
+                                        :description "Topic name. Required."
+                                        :enum ["trace" "epoch" "fx" "error"]}
+                              :filter  {:description "Filter map (JSON object) or EDN string. Vocab depends on topic."
+                                        :oneOf [{:type "object"}
+                                                {:type "string"}]}
+                              :max-buffered-events {:type "integer"
+                                                    :description "Runtime-side queue cap in EVENTS. Default 500. On overflow the OLDEST events are evicted (drop-oldest FIFO) and reported as `:dropped-events` / `:overflow-reason :max-buffered-events` on the next progress tick. OR-combined with :max-buffered-bytes — whichever trips first evicts."}
+                              :max-buffered-bytes  {:type "integer"
+                                                    :description "Runtime-side queue cap in BYTES (pr-str char count). Default 5_000_000 (~5 MB). Same drop-oldest policy; reports `:dropped-bytes` / `:overflow-reason :max-buffered-bytes`. Sized to fit the 5,000-token wire-cap posture across a normal poll cadence."}
+                              :poll-ms {:type "integer"
+                                        :description "Server poll cadence in ms. Default 100."}
+                              :max-ms  {:type "integer"
+                                        :description "Hard upper-bound on how long the subscription stays open, ms. 0 = unbounded (close on cancel only). Default 0."}
+                              :max-events {:type "integer"
+                                           :description "Terminate after this many events have been delivered. 0 = unbounded. Default 0."}
+                              :dedup    knobs/dedup-property
+                              :include-sensitive? {:type "boolean"
+                                                   :description "Opt back in to forwarding `:sensitive? true` items. Default false."}
+                              :build   {:type "string"}}
+                 :required ["topic"]
+                 :additionalProperties false}})
+
+(def unsubscribe
+  {:name "unsubscribe"
+   :description "Close the subscription with the given sub-id. Idempotent — closing an unknown sub-id returns :existed? false."
+   :typicalTokens 50
+   :inputSchema {:type "object"
+                 :properties {:sub-id {:type "string"
+                                       :description "The uuid returned by `subscribe`."}
+                              :build  {:type "string"}}
+                 :required ["sub-id"]
+                 :additionalProperties false}})
+
+(def subscription-info
+  {:name "subscription-info"
+   :description (str "List active streaming subscriptions opened via `subscribe`, with per-sub queue depth, "
+                     "drop counts, and overflow-reason — without draining any queues. Diagnostic for "
+                     "'what streams are currently open?' and 'is my probe still alive?'. Wraps the "
+                     "`re-frame-pair2.runtime/subscription-info` runtime fn directly (no eval-cljs round-trip). "
+                     "Returns `{:ok? true :subs [{:id :topic :filter :queue-depth :queue-bytes "
+                     ":dropped-events :dropped-bytes :overflow-reason :created-at}]}` — one entry per "
+                     "currently-registered subscription. Empty `:subs` vector when no streams are open. "
+                     "Optional filters: `topic` (one of `:trace` / `:epoch` / `:fx` / `:error`) narrows to "
+                     "a single topic; `sub-id` returns only the matching sub. A non-nil `:overflow-reason` "
+                     "indicates the queue has been evicting older events to stay inside its budget — tune "
+                     "`max-buffered-events` / `max-buffered-bytes` on the next `subscribe` call.")
+   :typicalTokens 500
+   :inputSchema {:type "object"
+                 :properties {:topic  {:type "string"
+                                       :description "Optional filter — only return subs on this topic. One of trace, epoch, fx, error."
+                                       :enum ["trace" "epoch" "fx" "error"]}
+                              :sub-id {:type "string"
+                                       :description "Optional filter — only return the sub with this uuid."}
+                              :build  {:type "string"}}
+                 :additionalProperties false}})

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors_knobs.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors_knobs.cljs
@@ -1,13 +1,13 @@
 (ns re-frame-pair2-mcp.tools.descriptors-knobs
-  "Tool-descriptor knob properties + the `with-*-knob` splicers that
-  attach them.
+  "Tool-descriptor knob properties — the schema fragments that get
+  spliced into per-tool descriptors via the `with-*-knob` composers
+  in `descriptors.cljs`.
 
   Each tool descriptor exposes a stable schema via `tools/list`. A
   handful of knobs are universal (wire-cap, cache) and pinned here so
   every descriptor inherits the same shape via composition rather than
   via copy-paste."
-  (:require [re-frame-pair2-mcp.cache :as cache]
-            [re-frame-pair2-mcp.tools.cap :as cap]))
+  (:require [re-frame-pair2-mcp.tools.cap :as cap]))
 
 (def max-tokens-property
   {:type        "integer"
@@ -106,26 +106,8 @@
                      "(dispatch, eval-cljs, tail-build) and streaming "
                      "tools (subscribe) bypass.")})
 
-(defn with-budget-knob
-  "Splice `max-tokens` into a tool descriptor's inputSchema.properties.
-  No-op if the descriptor already declares it (forward-compat)."
-  [desc]
-  (let [props (get-in desc [:inputSchema :properties])]
-    (if (contains? props :max-tokens)
-      desc
-      (assoc-in desc [:inputSchema :properties :max-tokens]
-                max-tokens-property))))
-
-(defn with-cache-knob
-  "Splice `cache` into a tool descriptor's inputSchema.properties — but
-  only for the read tools that consult `cache/apply-cache`. Action
-  tools and streaming tools don't list the knob because it has no
-  effect there (bypassed in `cache/cacheable?`)."
-  [desc]
-  (let [name  (:name desc)
-        props (get-in desc [:inputSchema :properties])]
-    (if (or (contains? props :cache)
-            (not (cache/cacheable? name)))
-      desc
-      (assoc-in desc [:inputSchema :properties :cache]
-                cache-property))))
+;; `with-budget-knob` and `with-cache-knob` splicers live in
+;; `descriptors.cljs` — they consume `registry/cacheable?` and the
+;; descriptor data, so siting them at the assembly boundary keeps
+;; this ns property-data-only and breaks the otherwise-circular
+;; descriptors-knobs ↔ registry require chain.

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/registry.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/registry.cljs
@@ -1,0 +1,183 @@
+(ns re-frame-pair2-mcp.tools.registry
+  "Single source of truth for the pair2-mcp tool catalogue (rf2-47g8l).
+
+  ## Why one registry
+
+  Before this ns landed, three places enumerated the tool list with no
+  compile-time validation they agreed:
+
+  - `tool-descriptors` in `descriptors.cljs` — the `tools/list` surface.
+  - `dispatch-tool*` in `tools.cljs` — the `tools/call` dispatcher.
+  - `cacheable-tools` in `cache.cljs` — the per-tool cache opt-in.
+
+  A new tool added to the dispatcher without a descriptor silently
+  vanished from `tools/list`; a tool added to the descriptor without a
+  `cacheable-tools` entry silently no-op'd the `:cache` knob. The drift
+  was always *possible* and only caught (at best) by hand-review.
+
+  ## What's here
+
+  One ordered vector — `tools` — whose entries bundle every fact about
+  a tool that any consumer needs:
+
+  ```clojure
+  {:name        \"snapshot\"          ;; MCP wire name
+   :handler     snapshot-handler      ;; (fn [conn args extra] => Promise)
+   :cacheable?  true                  ;; per-session response cache opt-in
+   :descriptor  {...}}                ;; tools/list inputSchema + doc
+  ```
+
+  Generators emit the three downstream views from this one source:
+
+  - `tool-descriptors` — `(mapv :descriptor tools)` (consumed by
+    `descriptors.cljs` for the wire surface).
+  - `handler-for`     — `{name handler}` lookup (consumed by
+    `tools.cljs/dispatch-tool*`).
+  - `cacheable?`      — predicate over registered names (consumed by
+    `cache.cljs` and `descriptors-knobs.cljs`).
+
+  ## Handler arity convention
+
+  Every registered handler is a 3-arity fn `(fn [conn args extra])`.
+  Only the streaming `subscribe` tool actually consults `extra` (the
+  MCP `signal` + `sendNotification` + `_meta.progressToken` payload);
+  the rest accept it for shape uniformity and ignore it. This is the
+  single shape the dispatcher invokes — there is no second arity.
+
+  ## Adding a new tool
+
+  Land *one* map entry in the `tools` vector below — name, handler,
+  cacheable flag, descriptor. The three downstream views update
+  automatically; drift is structurally impossible. Per-tool ns provides
+  the handler implementation as before.
+
+  ## Layout
+
+  This file owns the catalogue **data** only — handler implementations
+  and descriptor knob splicers live in the per-tool / per-concern
+  files. Registry is the index, not the implementation."
+  (:require [re-frame-pair2-mcp.tools.discover-app :as discover-app]
+            [re-frame-pair2-mcp.tools.eval-cljs :as eval-cljs]
+            [re-frame-pair2-mcp.tools.dispatch :as dispatch]
+            [re-frame-pair2-mcp.tools.trace-window :as trace-window]
+            [re-frame-pair2-mcp.tools.watch-epochs :as watch-epochs]
+            [re-frame-pair2-mcp.tools.tail-build :as tail-build]
+            [re-frame-pair2-mcp.tools.snapshot :as snapshot]
+            [re-frame-pair2-mcp.tools.get-path :as get-path]
+            [re-frame-pair2-mcp.tools.subscribe :as subscribe]
+            [re-frame-pair2-mcp.tools.unsubscribe :as unsubscribe]
+            [re-frame-pair2-mcp.tools.subscription-info :as subscription-info]
+            [re-frame-pair2-mcp.tools.descriptors-data :as data]))
+
+;; ---------------------------------------------------------------------------
+;; Handler shape — every registered handler is `(fn [conn args extra])`.
+;; Per-tool fns that don't need `extra` (i.e. everything except `subscribe`)
+;; are wrapped inline at registration so the dispatcher can call all
+;; handlers uniformly.
+;;
+;; Handlers in the registry are LATE-BINDING — they call the per-tool fn
+;; on each invocation rather than capturing a direct reference at load
+;; time. The `invoke-test` suite (rf2-nogok) stubs per-tool fns by
+;; `set!`-ing their vars and expects subsequent dispatches to hit the
+;; replacement. A captured reference would freeze the original and
+;; break the seam.
+;; ---------------------------------------------------------------------------
+
+;; ---------------------------------------------------------------------------
+;; The catalogue — one entry per tool. ORDER matters: `tool-descriptors`
+;; preserves it for the `tools/list` wire surface so AI hosts see a
+;; stable listing (discover-app first, mega-ops in the middle, streaming
+;; tools last). Don't shuffle without checking the `typical_tokens_test`
+;; and `subscription_info_test` order-sensitive expectations.
+;; ---------------------------------------------------------------------------
+
+(def tools
+  "The eleven-tool catalogue. Single source of truth for the
+  `tools/list` descriptors, the `tools/call` dispatcher, and the
+  per-tool cache opt-in. See ns docstring for the entry shape.
+
+  Each `:handler` is a thin late-binding wrapper around the per-tool fn
+  — `(fn [conn args _] (per-tool-fn conn args))` — so test seams that
+  `set!` the underlying var (rf2-nogok) take effect on the next
+  dispatch."
+  [{:name       "discover-app"
+    :handler    (fn [conn args _extra] (discover-app/discover-app conn args))
+    :cacheable? true
+    :descriptor data/discover-app}
+   {:name       "eval-cljs"
+    :handler    (fn [conn args _extra] (eval-cljs/eval-cljs-tool conn args))
+    :cacheable? false
+    :descriptor data/eval-cljs}
+   {:name       "dispatch"
+    :handler    (fn [conn args _extra] (dispatch/dispatch-tool conn args))
+    :cacheable? false
+    :descriptor data/dispatch}
+   {:name       "trace-window"
+    :handler    (fn [conn args _extra] (trace-window/trace-window-tool conn args))
+    :cacheable? true
+    :descriptor data/trace-window}
+   {:name       "watch-epochs"
+    :handler    (fn [conn args _extra] (watch-epochs/watch-epochs-tool conn args))
+    :cacheable? true
+    :descriptor data/watch-epochs}
+   {:name       "tail-build"
+    :handler    (fn [conn args _extra] (tail-build/tail-build-tool conn args))
+    :cacheable? false
+    :descriptor data/tail-build}
+   {:name       "snapshot"
+    :handler    (fn [conn args _extra] (snapshot/snapshot-tool conn args))
+    :cacheable? true
+    :descriptor data/snapshot}
+   {:name       "get-path"
+    :handler    (fn [conn args _extra] (get-path/get-path-tool conn args))
+    :cacheable? true
+    :descriptor data/get-path}
+   {:name       "subscribe"
+    :handler    (fn [conn args extra]  (subscribe/subscribe-tool conn args extra))
+    :cacheable? false
+    :descriptor data/subscribe}
+   {:name       "unsubscribe"
+    :handler    (fn [conn args _extra] (unsubscribe/unsubscribe-tool conn args))
+    :cacheable? false
+    :descriptor data/unsubscribe}
+   {:name       "subscription-info"
+    :handler    (fn [conn args _extra] (subscription-info/subscription-info-tool conn args))
+    :cacheable? false
+    :descriptor data/subscription-info}])
+
+;; ---------------------------------------------------------------------------
+;; Derived views — generated once at load time from `tools`. Consumers
+;; reach for these instead of redeclaring the names.
+;; ---------------------------------------------------------------------------
+
+(def tool-descriptors
+  "Ordered vector of just the `:descriptor` payload from each entry.
+  Consumed by `descriptors.cljs/tool-descriptors-js` (which composes
+  the universal knob splicers over this) and by tests that pin the
+  `tools/list` shape."
+  (mapv :descriptor tools))
+
+(def handler-for
+  "`{tool-name handler}` lookup. The dispatcher in `tools.cljs` reaches
+  in here by name; unknown names return `nil` and the dispatcher emits
+  the `:unknown-tool` error envelope."
+  (into {} (map (juxt :name :handler)) tools))
+
+(def ^:private cacheable-set
+  "Materialised set of tool names whose `:cacheable?` is truthy.
+  Built once at load time so `cacheable?` is an O(1) membership test."
+  (into #{} (comp (filter :cacheable?) (map :name)) tools))
+
+(defn cacheable?
+  "Predicate — should this tool consult the per-session response cache?
+
+  True for read tools whose return value is a function of state
+  (`snapshot`, `get-path`, `trace-window`, `watch-epochs`,
+  `discover-app`). False for action tools (`dispatch`, `eval-cljs`,
+  `tail-build`) and streaming tools (`subscribe`, `unsubscribe`,
+  `subscription-info`) — their return value is the result of an
+  action, not a read of state.
+
+  Unknown names return false."
+  [tool]
+  (contains? cacheable-set tool))


### PR DESCRIPTION
## Summary

Single source of truth for the pair2-mcp tool catalogue. Closes rf2-47g8l (P1).

Before, three places enumerated the eleven-tool list with no compile-time validation they agreed:

- `tool-descriptors` (`descriptors.cljs`) — the `tools/list` surface
- `dispatch-tool*` (`tools.cljs`) — the `tools/call` dispatcher
- `cacheable-tools` (`cache.cljs`) — the per-tool cache opt-in

A new tool added to the dispatcher without a descriptor entry silently vanished from `tools/list`; a descriptor without a `cacheable-tools` entry silently no-op'd the `:cache` knob.

## Shape

One ordered vector — `registry/tools` — binds every fact about a tool any consumer needs:

```clojure
{:name "snapshot" :handler ... :cacheable? true :descriptor {...}}
```

The three downstream views are derived from it:

- `tool-descriptors`  ← `(mapv :descriptor tools)`
- `handler-for`       ← `{name handler}` lookup, replaces the `case` dispatch
- `cacheable?`        ← O(1) membership over the registry-derived set

Future tool additions land in one map literal — drift is structurally impossible.

## Layout (rf2-vrbwx + rf2-47g8l)

- `registry.cljs`         — single source of truth + derived views
- `descriptors_data.cljs` — per-tool descriptor data (one named `def` per tool)
- `descriptors_knobs.cljs` — universal-knob property data only
- `descriptors.cljs`      — knob splicers + `tool-descriptors-js`
- `cache.cljs`            — `cacheable?` forwards to `registry/cacheable?`
- `tools.cljs`            — dispatch via `(get registry/handler-for name)`

## Notes

- Pre-alpha: cache.cljs's local `cacheable-tools` set is gone; `cache/cacheable?` remains as a thin forwarder to preserve the call-site vocabulary (tests + internal call sites continue to read `cache/cacheable?`).
- Knob splicers (`with-budget-knob`, `with-cache-knob`) moved from `descriptors_knobs.cljs` to `descriptors.cljs` to break what would otherwise be a `descriptors-knobs` ↔ `registry` require cycle. `descriptors-knobs` is now property-data-only.
- Registry handlers are deliberately late-binding (`(fn [conn args _] (per-tool-fn conn args))`) so the `invoke-test` (rf2-nogok) `set!`-on-var stubbing seam continues to work.

## Test plan

- [x] `npm test` from `tools/pair2-mcp` — all 297 tests / 719 assertions pass
- [x] Compile clean — 0 warnings, no unused requires left behind
- [x] `tools/list` surface unchanged on the wire (re-export name preserved)