### PR TITLE
refactor(flows): tighten validate-flow input/path well-formedness checks (rf2-gnl7q)

### DIFF
--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -39,6 +39,36 @@
   (atom {}))
 
 ;; ---- validation ----------------------------------------------------------
+;;
+;; Per Spec 013 §Flow shape: `:inputs` is a vector of app-db paths, `:path`
+;; is an app-db path. A path is a non-empty vector of scalar map keys. The
+;; prior validator only enforced `vector?` on each, so three classes of
+;; malformed input slipped through (per audit rf2-o3hok findings Q5 / TE4):
+;;
+;;   - `:inputs [:foo :bar]` (vector of bare keywords) — passed; then
+;;     topo's `prefix?` threw on `(count :foo)`.
+;;   - `:inputs [[:foo] :bar]` (mixed) — same path, same delayed boom.
+;;   - `:path []` — passed; `(prefix? [] anything)` is true, so the empty-
+;;     path flow silently became a depends-on prerequisite of EVERY other
+;;     flow in the frame (per Spec 013 §Dependency rule).
+;;
+;; The tightened validator rejects each malformation up front with a stable
+;; error id and ex-data that names the offending entries / elements so
+;; callers don't have to chase the failure into the topo / evaluator stack.
+
+(defn- valid-path-element?
+  "Path elements are scalar map keys: keyword, string, integer, symbol, or
+  boolean. Collections (vectors / maps / sets / seqs) are never the right
+  value for a `get-in` path step and almost always indicate a caller bug
+  (e.g. passing a bare keyword where a vector-of-paths was expected, then
+  wrapping it one level too many)."
+  [x]
+  (or (keyword? x) (string? x) (integer? x) (symbol? x) (boolean? x)))
+
+(defn- valid-path?
+  "A path is a non-empty vector of valid path elements."
+  [x]
+  (and (vector? x) (seq x) (every? valid-path-element? x)))
 
 (defn- validate-flow [flow]
   (cond
@@ -49,13 +79,36 @@
     (throw (ex-info ":rf.error/flow-bad-inputs"
                     {:flow flow :reason ":inputs must be a vector of paths"}))
 
+    (not (every? vector? (:inputs flow)))
+    (throw (ex-info ":rf.error/flow-bad-inputs"
+                    {:flow flow
+                     :reason ":inputs entries must each be a vector (app-db path)"
+                     :bad-entries (vec (remove vector? (:inputs flow)))}))
+
+    (not (every? valid-path? (:inputs flow)))
+    (throw (ex-info ":rf.error/flow-bad-inputs"
+                    {:flow flow
+                     :reason ":inputs entries must each be a non-empty vector of scalar keys (keyword / string / integer / symbol / boolean)"
+                     :bad-entries (vec (remove valid-path? (:inputs flow)))}))
+
     (not (fn? (:output flow)))
     (throw (ex-info ":rf.error/flow-bad-output"
                     {:flow flow :reason ":output must be a fn"}))
 
     (not (vector? (:path flow)))
     (throw (ex-info ":rf.error/flow-bad-path"
-                    {:flow flow :reason ":path must be a vector"}))))
+                    {:flow flow :reason ":path must be a vector"}))
+
+    (empty? (:path flow))
+    (throw (ex-info ":rf.error/flow-bad-path"
+                    {:flow flow
+                     :reason ":path must be non-empty (an empty :path would make this flow a depends-on prerequisite of every other flow per Spec 013 §Dependency rule)"}))
+
+    (not (every? valid-path-element? (:path flow)))
+    (throw (ex-info ":rf.error/flow-bad-path"
+                    {:flow flow
+                     :reason ":path elements must each be a scalar key (keyword / string / integer / symbol / boolean)"
+                     :bad-elements (vec (remove valid-path-element? (:path flow)))}))))
 
 ;; ---- registration --------------------------------------------------------
 

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -128,6 +128,147 @@
                  (rf/reg-flow {:id :bad :inputs [[:n]]
                                :output identity :path :not-a-vec})))))
 
+;; ---------------------------------------------------------------------------
+;; 1b. validate-flow well-formedness (rf2-gnl7q)
+;;
+;; Per audit rf2-o3hok findings Q5 / TE4 — the prior `validate-flow` only
+;; checked `(vector? (:inputs flow))` and `(vector? (:path flow))`, so:
+;;
+;;   - `:inputs [:foo :bar]` (vector of bare keywords, NOT vector-of-paths)
+;;     passed validation and then threw deep inside topo-sort's `prefix?`
+;;     when it called `(count :foo)`.
+;;   - `:inputs [[:foo] :bar]` (mixed) likewise passed, then exploded on
+;;     the bare-keyword entry.
+;;   - `:path []` passed; `(prefix? [] anything)` returns true, silently
+;;     making the empty-path flow a depends-on prerequisite of EVERY other
+;;     flow in the frame.
+;;
+;; These tests pin the tightened contract: each malformation is rejected
+;; up front with a stable error id (`:rf.error/flow-bad-inputs` or
+;; `:rf.error/flow-bad-path`) and ex-data that names the offending entries
+;; so callers can fix their flow map without a stack-trace scavenger hunt.
+
+(defn- flow-bad-inputs? [^Throwable t]
+  (= ":rf.error/flow-bad-inputs" (ex-message t)))
+
+(defn- flow-bad-path? [^Throwable t]
+  (= ":rf.error/flow-bad-path" (ex-message t)))
+
+(deftest reg-flow-rejects-bare-keyword-inputs
+  (testing ":inputs [:foo :bar] is rejected (vector of bare keywords, not vector-of-paths)"
+    ;; Pre-fix this would pass validate-flow and then throw with
+    ;; (count :foo) somewhere deep in topo's prefix?.
+    (let [ex (try
+               (rf/reg-flow {:id     :bad
+                             :inputs [:foo :bar]
+                             :output (fn [_ _] nil)
+                             :path   [:out]})
+               (catch Throwable t t))]
+      (is (some? ex) "registration threw")
+      (is (flow-bad-inputs? ex)
+          "error id is :rf.error/flow-bad-inputs")
+      (is (= [:foo :bar] (:bad-entries (ex-data ex)))
+          "ex-data names the offending entries (both bare keywords)"))))
+
+(deftest reg-flow-rejects-mixed-input-shapes
+  (testing ":inputs [[:foo] :bar] is rejected (one bare keyword among well-formed paths)"
+    (let [ex (try
+               (rf/reg-flow {:id     :bad
+                             :inputs [[:foo] :bar]
+                             :output (fn [_ _] nil)
+                             :path   [:out]})
+               (catch Throwable t t))]
+      (is (some? ex) "registration threw")
+      (is (flow-bad-inputs? ex)
+          "error id is :rf.error/flow-bad-inputs")
+      (is (= [:bar] (:bad-entries (ex-data ex)))
+          "only the bare-keyword entry is named — the vector entry is fine"))))
+
+(deftest reg-flow-rejects-empty-input-path
+  (testing ":inputs [[]] is rejected (empty path is not a meaningful app-db read)"
+    (let [ex (try
+               (rf/reg-flow {:id     :bad
+                             :inputs [[]]
+                             :output (fn [_] nil)
+                             :path   [:out]})
+               (catch Throwable t t))]
+      (is (some? ex) "registration threw")
+      (is (flow-bad-inputs? ex)
+          "error id is :rf.error/flow-bad-inputs"))))
+
+(deftest reg-flow-rejects-collection-input-elements
+  (testing ":inputs [[[:nested]]] is rejected (path step is a vector, not a scalar key)"
+    (let [ex (try
+               (rf/reg-flow {:id     :bad
+                             :inputs [[[:nested]]]
+                             :output (fn [_] nil)
+                             :path   [:out]})
+               (catch Throwable t t))]
+      (is (some? ex) "registration threw")
+      (is (flow-bad-inputs? ex)
+          "error id is :rf.error/flow-bad-inputs"))))
+
+(deftest reg-flow-rejects-empty-path
+  (testing ":path [] is rejected (would make this flow a prerequisite of every other flow)"
+    ;; Pre-fix: (prefix? [] anything) returns true, so an empty-path flow
+    ;; becomes depends-on for every other flow in the frame. Per Spec 013
+    ;; §Dependency rule this is never what the caller means.
+    (let [ex (try
+               (rf/reg-flow {:id     :bad
+                             :inputs [[:n]]
+                             :output identity
+                             :path   []})
+               (catch Throwable t t))]
+      (is (some? ex) "registration threw")
+      (is (flow-bad-path? ex)
+          "error id is :rf.error/flow-bad-path")
+      (is (re-find #"non-empty" (:reason (ex-data ex)))
+          "ex-data :reason mentions the non-empty requirement"))))
+
+(deftest reg-flow-rejects-collection-path-elements
+  (testing ":path [[:nested]] is rejected (path step is a vector, not a scalar key)"
+    (let [ex (try
+               (rf/reg-flow {:id     :bad
+                             :inputs [[:n]]
+                             :output identity
+                             :path   [[:nested]]})
+               (catch Throwable t t))]
+      (is (some? ex) "registration threw")
+      (is (flow-bad-path? ex)
+          "error id is :rf.error/flow-bad-path")
+      (is (= [[:nested]] (:bad-elements (ex-data ex)))
+          "ex-data names the offending element(s)"))))
+
+(deftest reg-flow-accepts-scalar-path-elements
+  (testing "scalar path elements (keyword / string / integer / symbol / boolean) all pass"
+    ;; Sanity check for valid-path-element?: each documented scalar key
+    ;; type round-trips through reg-flow without throwing. Tighter
+    ;; validation must not regress the common case.
+    (doseq [[label elt] [[:kw     :kw]
+                         [:string "str"]
+                         [:int    42]
+                         [:symbol 'sym]
+                         [:bool   true]]]
+      (let [flow-id (keyword "elt" (name label))]
+        (is (some? (rf/reg-flow {:id     flow-id
+                                 :inputs [[elt]]
+                                 :output identity
+                                 :path   [elt]}))
+            (str "scalar path element " (pr-str elt) " is accepted"))
+        (rf/clear-flow flow-id)))))
+
+(deftest reg-flow-accepts-empty-inputs-vector
+  (testing ":inputs [] is allowed (one-shot flow with no app-db dependencies)"
+    ;; The well-formedness checks reject malformed entries inside :inputs,
+    ;; but an empty :inputs vector itself remains valid — a zero-arg flow
+    ;; that fires once and stays put (no path can change to dirty it). Pin
+    ;; this so the new every?-based checks don't accidentally reject the
+    ;; legitimate empty-inputs case.
+    (is (some? (rf/reg-flow {:id     :constant
+                             :inputs []
+                             :output (fn [] 42)
+                             :path   [:k]})))))
+
 (deftest reg-flow-detects-cycles-at-registration
   (testing ":a depends on :b, :b depends on :a — registering the second throws"
     (rf/reg-flow {:id :a :inputs [[:b]] :output identity :path [:a]})


### PR DESCRIPTION
## Summary

Per audit `rf2-o3hok` findings Q5/TE4, `validate-flow` in `implementation/flows/src/re_frame/flows/registry.cljc` only checked `vector?` on `:inputs` and `:path`. Three classes of malformed input slipped through:

- `:inputs [:foo :bar]` (vector of bare keywords, NOT vector-of-paths) — passed validation, then topo's `prefix?` threw on `(count :foo)` with an opaque deep-stack error.
- `:inputs [[:foo] :bar]` (mixed) — same delayed boom on the bare-keyword entry.
- `:path []` (empty) — passed; `(prefix? [] anything)` returns `true`, so the empty-path flow silently became a depends-on prerequisite of EVERY other flow in the frame (per Spec 013 §Dependency rule).

## Validations added

- `every? vector?` on `:inputs` entries — rejects bare keywords / mixed shapes.
- `valid-path?` on each `:inputs` entry — non-empty vector of scalar map keys.
- `seq` on `:path` — rejects empty.
- `valid-path-element?` on `:path` elements — rejects collection-typed steps.

Each rejection throws `:rf.error/flow-bad-inputs` or `:rf.error/flow-bad-path` with ex-data carrying `:bad-entries` / `:bad-elements` so callers don't have to chase the failure into the topo / evaluator stack.

The `valid-path-element?` predicate accepts the documented scalar key types: keyword, string, integer, symbol, boolean.

## Test plan

- [x] `reg-flow-rejects-bare-keyword-inputs` — `:inputs [:foo :bar]` rejected with bad-inputs error id; ex-data names the offending entries.
- [x] `reg-flow-rejects-mixed-input-shapes` — `:inputs [[:foo] :bar]` rejected; only the bare-keyword entry named.
- [x] `reg-flow-rejects-empty-input-path` — `:inputs [[]]` rejected.
- [x] `reg-flow-rejects-collection-input-elements` — `:inputs [[[:nested]]]` rejected.
- [x] `reg-flow-rejects-empty-path` — `:path []` rejected with bad-path error id; ex-data :reason mentions non-empty.
- [x] `reg-flow-rejects-collection-path-elements` — `:path [[:nested]]` rejected; ex-data names the offending element.
- [x] `reg-flow-accepts-scalar-path-elements` — keyword / string / integer / symbol / boolean each round-trip.
- [x] `reg-flow-accepts-empty-inputs-vector` — legitimate zero-arg flow (`:inputs []`) still accepted.
- [x] `clojure -M:test` from `implementation/flows/` — 36 tests, 137 assertions, 0 failures, 0 errors.

Closes rf2-gnl7q.