### PR TITLE
spec(schemas): drop duplicate :event / :malli-error trace slots (rf2-4fbsd)

### DIFF
--- a/implementation/core/src/re_frame/spec.cljc
+++ b/implementation/core/src/re_frame/spec.cljc
@@ -217,20 +217,19 @@
                       ;; with debug-enabled? flipped off — exactly the
                       ;; surface the rf2-r2uh tests exercise.
                       (trace/emit-error! :rf.error/schema-validation-failure
-                                         {:where       :event
-                                          :event-id    event-id
-                                          :failing-id  event-id
-                                          :spec-id     event-id
-                                          :received    event
-                                          :event       event
-                                          :malli-error explanation
-                                          :explain     explanation
-                                          :source      :boundary
-                                          :reason      (str "Event " event-id
-                                                            " payload failed boundary "
-                                                            "schema " schema ", got "
-                                                            (type-of-value event) ".")
-                                          :recovery    :no-recovery})
+                                         {:where      :event
+                                          :event-id   event-id
+                                          :failing-id event-id
+                                          :spec-id    event-id
+                                          :received   event
+                                          :value      event
+                                          :explain    explanation
+                                          :source     :boundary
+                                          :reason     (str "Event " event-id
+                                                           " payload failed boundary "
+                                                           "schema " schema ", got "
+                                                           (type-of-value event) ".")
+                                          :recovery   :no-recovery})
                       ;; Per Spec 010 §Per-step recovery step 1: handler
                       ;; is not invoked. The handler-as-interceptor
                       ;; checks :rf/skip-handler? in its :before slot

--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -56,7 +56,14 @@
   The `:value`, `:received`, and `:explain` slots are redacted; the
   structural / categorical slots (`:path`, `:failing-id`, `:spec-id`,
   `:reason`) are kept — consumers need them to locate the broken slot
-  without leaking user data."
+  without leaking user data.
+
+  Per rf2-4fbsd the emit-sites carry two slots for the failing value
+  (`:value` and `:received`, per Spec 010 §`:sensitive?`) and one slot
+  for the registered explainer's output (`:explain`). The earlier
+  `:event` (duplicate of `:received`) and `:malli-error` (duplicate of
+  `:explain`) tags have been dropped — consumers reach for `:received`
+  / `:value` / `:explain`."
   (:require [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.schemas.storage :as storage]
@@ -100,12 +107,10 @@
   correctly. Idempotent — safe to call on an already-redacted map."
   [tags]
   (cond-> tags
-    (contains? tags :value)       (assoc :value       redacted-sentinel)
-    (contains? tags :received)    (assoc :received    redacted-sentinel)
-    (contains? tags :explain)     (assoc :explain     redacted-sentinel)
-    (contains? tags :malli-error) (assoc :malli-error redacted-sentinel)
-    (contains? tags :event)       (assoc :event       redacted-sentinel)
-    true                          (assoc :sensitive?  true)))
+    (contains? tags :value)    (assoc :value     redacted-sentinel)
+    (contains? tags :received) (assoc :received  redacted-sentinel)
+    (contains? tags :explain)  (assoc :explain   redacted-sentinel)
+    true                       (assoc :sensitive? true)))
 
 (defn- type-of-value [v]
   (cond
@@ -246,19 +251,18 @@
       event
       sensitive-by-meta?
       (fn [schema explanation]
-        {:where       :event
-         :event-id    event-id
-         :failing-id  event-id
-         :spec-id     event-id
-         :received    event
-         :event       event
-         :malli-error explanation
-         :explain     explanation
-         :reason      (str "Event " event-id
-                           " payload failed schema "
-                           schema ", got "
-                           (type-of-value event) ".")
-         :recovery    :no-recovery})
+        {:where      :event
+         :event-id   event-id
+         :failing-id event-id
+         :spec-id    event-id
+         :received   event
+         :value      event
+         :explain    explanation
+         :reason     (str "Event " event-id
+                          " payload failed schema "
+                          schema ", got "
+                          (type-of-value event) ".")
+         :recovery   :no-recovery})
       nil)
     true))
 
@@ -276,20 +280,19 @@
       value
       sensitive-by-meta-or-schema?
       (fn [schema explanation]
-        {:where       :sub-return
-         :sub-id      sub-id
-         :failing-id  sub-id
-         :spec-id     sub-id
-         :query-v     query-v
-         :received    value
-         :value       value
-         :malli-error explanation
-         :explain     explanation
-         :reason      (str "Subscription " sub-id
-                           " return value failed schema "
-                           schema ", got "
-                           (type-of-value value) ".")
-         :recovery    :replaced-with-default})
+        {:where      :sub-return
+         :sub-id     sub-id
+         :failing-id sub-id
+         :spec-id    sub-id
+         :query-v    query-v
+         :received   value
+         :value      value
+         :explain    explanation
+         :reason     (str "Subscription " sub-id
+                          " return value failed schema "
+                          schema ", got "
+                          (type-of-value value) ".")
+         :recovery   :replaced-with-default})
       nil)
     true))
 
@@ -307,20 +310,19 @@
       value
       sensitive-by-meta-or-schema?
       (fn [schema explanation]
-        {:where       :cofx
-         :cofx-id     cofx-id
-         :event-id    event-id
-         :failing-id  event-id
-         :spec-id     cofx-id
-         :received    value
-         :value       value
-         :malli-error explanation
-         :explain     explanation
-         :reason      (str "Coeffect " cofx-id
-                           " injected value failed schema "
-                           schema ", got "
-                           (type-of-value value) ".")
-         :recovery    :no-recovery})
+        {:where      :cofx
+         :cofx-id    cofx-id
+         :event-id   event-id
+         :failing-id event-id
+         :spec-id    cofx-id
+         :received   value
+         :value      value
+         :explain    explanation
+         :reason     (str "Coeffect " cofx-id
+                          " injected value failed schema "
+                          schema ", got "
+                          (type-of-value value) ".")
+         :recovery   :no-recovery})
       nil)
     true))
 
@@ -343,26 +345,26 @@
       args
       sensitive-by-meta-or-schema?
       (fn [schema explanation]
-        (cond-> {:where       :fx-args
-                 :fx-id       fx-id
-                 :fx-args     args
-                 :failing-id  fx-id
-                 :spec-id     fx-id
-                 :received    args
-                 :value       args
-                 :malli-error explanation
-                 :explain     explanation
-                 :reason      (str "Effect " fx-id
-                                   " args failed schema "
-                                   schema ", got "
-                                   (type-of-value args) ".")
-                 :recovery    :skipped}
+        (cond-> {:where      :fx-args
+                 :fx-id      fx-id
+                 :fx-args    args
+                 :failing-id fx-id
+                 :spec-id    fx-id
+                 :received   args
+                 :value      args
+                 :explain    explanation
+                 :reason     (str "Effect " fx-id
+                                  " args failed schema "
+                                  schema ", got "
+                                  (type-of-value args) ".")
+                 :recovery   :skipped}
           event-id (assoc :event-id event-id)))
       ;; Extra-redact: the doubled `:fx-args` slot isn't covered by
-      ;; the generic `redact-tags` (which only knows :value /
-      ;; :received / :explain / :malli-error / :event). Scrub it
-      ;; here so the redaction is symmetric across all four
-      ;; meta-bearing validate-*! surfaces.
+      ;; the generic `redact-tags` (which only knows `:value` /
+      ;; `:received` / `:explain` — the value-bearing slots Spec 010
+      ;; §`:sensitive?` blesses). Scrub `:fx-args` here so the
+      ;; redaction is symmetric across all four meta-bearing
+      ;; validate-*! surfaces.
       (fn [tags] (assoc tags :fx-args redacted-sentinel)))
     true))
 

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -11,8 +11,8 @@
 
     1. The failing value (`:value` / `:received`) is replaced with the
        framework-reserved `:rf/redacted` sentinel.
-    2. The Malli explainer output (`:explain` / `:malli-error`) is
-       redacted — it carries the failing value verbatim.
+    2. The Malli explainer output (`:explain`) is redacted — it
+       carries the failing value verbatim.
     3. The trace event's TOP-LEVEL `:sensitive?` field is stamped
        `true` so consumers route on it. (Per Spec 009 §Trace-event
        field: `:sensitive?` at the top level, rf2-isdwf — the
@@ -262,14 +262,16 @@
           (is (some? v))
           (is (true? (:sensitive? v))
               "top-level :sensitive? stamp present — consumers filter on this (per Spec 009 hoist)")
-          (is (= :rf/redacted (-> v :tags :event))
-              ":event slot — the event vector — is the redacted sentinel")
           (is (= :rf/redacted (-> v :tags :received))
-              ":received — duplicate of the event — also redacted")
+              ":received — the event vector — is the redacted sentinel")
+          (is (= :rf/redacted (-> v :tags :value))
+              ":value — failing-value mirror — also redacted")
           (is (= :rf/redacted (-> v :tags :explain))
               ":explain — Malli explanation re-leaks the values")
-          (is (= :rf/redacted (-> v :tags :malli-error))
-              ":malli-error — duplicate of explain — also redacted")
+          (is (not (contains? (:tags v) :event))
+              ":event slot is gone (rf2-4fbsd) — consumers reach for :received")
+          (is (not (contains? (:tags v) :malli-error))
+              ":malli-error slot is gone (rf2-4fbsd) — consumers reach for :explain")
           ;; Structural slots survive.
           (is (= :event (-> v :tags :where)))
           (is (= :auth/sign-in (-> v :tags :event-id)))
@@ -296,8 +298,11 @@
         (is (not (contains? (:tags v) :sensitive?))
             ":tags :sensitive? also absent — the stamp lives at top-level only")
         (is (= [:user/register {:email "carol@example.com" :age "no"}]
-               (-> v :tags :event))
-            ":event rides verbatim")))))
+               (-> v :tags :received))
+            ":received rides verbatim")
+        (is (= [:user/register {:email "carol@example.com" :age "no"}]
+               (-> v :tags :value))
+            ":value rides verbatim")))))
 
 ;; ---- redaction at cofx validation site -----------------------------------
 

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -406,7 +406,8 @@
 (deftest fx-args-validation-redacts-when-sensitive
   (testing "validate-fx! consults `:sensitive?` on the fx-meta AND on the schema
             tree; on redaction it scrubs `:value`/`:received`/`:explain`/
-            `:malli-error`/`:fx-args` and stamps `:sensitive? true`"
+            `:fx-args` and stamps `:sensitive? true`. Per rf2-4fbsd the
+            earlier `:malli-error` duplicate slot is gone."
     (let [traces (atom [])]
       (rf/register-trace-cb! ::fxv5 (fn [ev] (swap! traces conj ev)))
       (is (false? (schemas/validate-fx! :my/secret
@@ -428,7 +429,8 @@
           (is (= :rf/redacted (-> v :tags :received)))
           (is (= :rf/redacted (-> v :tags :fx-args)))
           (is (= :rf/redacted (-> v :tags :explain)))
-          (is (= :rf/redacted (-> v :tags :malli-error)))
+          (is (not (contains? (:tags v) :malli-error))
+              ":malli-error slot is gone (rf2-4fbsd)")
           ;; Non-redacted slots survive redaction.
           (is (= :my/secret (-> v :tags :fx-id)))
           (is (= :my/secret (-> v :tags :failing-id)))
@@ -493,7 +495,7 @@
     (let [trace-event {:operation :rf.error/schema-validation-failure
                        :op-type   :error
                        :tags      {:where :event :event-id :user/register
-                                   :event [:user/register {:age "no"}]}
+                                   :received [:user/register {:age "no"}]}
                        :recovery  :no-recovery}
           public      (default-error-projector trace-event)]
       (is (= 400 (:status public)))
@@ -1002,7 +1004,12 @@
           (is (= :api/strict (-> v :tags :spec-id)))
           (is (= :boundary (-> v :tags :source))
               ":source :boundary tags this as the boundary emission")
-          (is (= [:api/strict "not-an-int"] (-> v :tags :event)))
+          (is (= [:api/strict "not-an-int"] (-> v :tags :received))
+              ":received carries the failing event vector verbatim")
+          (is (= [:api/strict "not-an-int"] (-> v :tags :value))
+              ":value mirrors :received per Spec 010 §`:sensitive?`")
+          (is (not (contains? (:tags v) :event))
+              ":event slot is gone (rf2-4fbsd) — consumers reach for :received")
           (is (string? (-> v :tags :reason))
               ":reason carries a human-readable explanation per Spec 009 §Style rubric")
           (is (= :no-recovery (:recovery v))


### PR DESCRIPTION
## Summary

The four meta-bearing `validate-*!` emit-sites (event / cofx / fx / sub-return) and the boundary-validation interceptor (`re-frame.spec`) historically wrote each failing value into two slots and each Malli explanation into two slots:

- `:event` — duplicate of `:received` (event payload)
- `:malli-error` — duplicate of `:explain` (Malli explanation)

Both duplicates were undocumented in Spec 010 §`:sensitive?` (which blesses `:value` / `:received` / `:explain` only) and unblessed by Spec-Schemas's `SchemaValidationTags`. Per the rf2-x8x4p audit (Q10 / S6) and the pre-alpha no-back-compat rule, **drop** both — consumers reach for `:received` / `:value` / `:explain`.

### Direction & rationale

**Drop, not document.** The slots were pure data duplicates; the spec was already silent on them, so removing them aligns impl with spec rather than back-filling docs for an avoidable smell.

### Behavioural change

- `redact-tags` collapses from 5 cases to 3.
- Each `validate-*!` emit-site loses the doubled `:event` / `:malli-error` keys.
- `validate-event!` now also carries `:value` (it had `:received` + `:event` but no `:value`), so every meta-bearing emit-site uniformly carries `:received` + `:value` + `:explain`.
- `re-frame.spec/validate-at-boundary` mirrors the same shape so dev-step-1 and boundary surfaces stay symmetric.

## Test plan

- [x] `clojure -M:test` in `implementation/schemas`: 133 tests, 383 assertions, 0 failures.
- [x] `clojure -M:test` in `implementation/core`: 456 tests, 2439 assertions, 0 failures.
- [x] Schemas conformance corpus runner: 5/5 fixtures pass.
- [x] Tests pin the new contract: each redaction site now asserts `(not (contains? (:tags v) :event))` / `(not (contains? (:tags v) :malli-error))` so the drop can't silently regress.