### PR TITLE
refactor(pair2-mcp): collapse 3 boolean-arg parsers + parse-cache-arg into one table (rf2-c4fmh)

### DIFF
--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/cache.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/cache.cljs
@@ -70,7 +70,8 @@
   - **Disabled by default**: pass `cache true` (or the per-call MCP
     arg) to opt in. Default-off keeps the contract simple for
     callers who haven't yet learned the `:rf.mcp/cache-hit` shape.
-    See `parse-cache-arg`.
+    The arg is parsed by the shared
+    `re-frame-pair2-mcp.tools.args/parse-bool-arg` table (rf2-c4fmh).
   - **Per-tool opt-out**: streaming / progress-bearing tools
     (`subscribe`, `dispatch` with `:trace`) bypass the cache. Their
     return value is the result of an action, not a read.
@@ -95,7 +96,6 @@
   (rf2-obpa9), `:rf.mcp/summary` (rf2-tygdv), `:rf.size/large-elided`
   (rf2-urjnc). Agents that learned the family see one more slot."
   (:require [applied-science.js-interop :as j]
-            [clojure.string :as str]
             [re-frame-pair2-mcp.tools.registry :as registry]))
 
 ;; ---------------------------------------------------------------------------
@@ -256,28 +256,6 @@
                            :text (pr-str (cache-hit-payload
                                            (assoc entry :tool tool)
                                            via))}]}))
-
-;; ---------------------------------------------------------------------------
-;; Arg parsing — opt-in switch.
-;; ---------------------------------------------------------------------------
-
-(defn parse-cache-arg
-  "Resolve the per-call cache switch. Accepts boolean or stringified
-  boolean; default is FALSE (cache opt-in until agent hosts have been
-  taught the marker shape — same pattern as `dedup` before its
-  default flipped)."
-  [raw]
-  (cond
-    (nil? raw)         false
-    (true? raw)        true
-    (false? raw)       false
-    (= raw "true")     true
-    (= raw "false")    false
-    (= raw :true)      true
-    (= raw :false)     false
-    (and (string? raw) (= (str/lower-case raw) "true"))  true
-    (and (string? raw) (= (str/lower-case raw) "false")) false
-    :else              false))
 
 ;; ---------------------------------------------------------------------------
 ;; The wire-boundary entry-point.

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -45,8 +45,8 @@
 
   Each MCP tool returns `{:content [{:type \"text\" :text <edn-string>}]}`
   on success, or `{:isError true :content [...]}` on failure."
-  (:require [applied-science.js-interop :as j]
-            [re-frame-pair2-mcp.cache :as cache]
+  (:require [re-frame-pair2-mcp.cache :as cache]
+            [re-frame-pair2-mcp.tools.args :as args]
             [re-frame-pair2-mcp.tools.wire :as wire]
             [re-frame-pair2-mcp.tools.cap :as cap]
             [re-frame-pair2-mcp.tools.precheck :as precheck]
@@ -121,8 +121,7 @@
   (let [cap-opts    {:tool     name
                      :cap      (cap/max-tokens-arg args)
                      :strategy :truncate-with-marker}
-        enabled?    (cache/parse-cache-arg
-                      (when args (j/get args "cache")))
+        enabled?    (args/parse-bool-arg args :cache)
         cache-opts  {:tool     name
                      :args     args
                      :enabled? enabled?}

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/args.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/args.cljs
@@ -19,12 +19,62 @@
   convention: a path is an EDN-encoded vector of keys addressing a
   subtree. The vocabulary is shared across pair2-mcp / causa-mcp /
   story-mcp so agents recognise the surface once."
-  (:require [cljs.reader]
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader]
             [clojure.string :as str]
             [re-frame.mcp-base.args :as base-args]))
 
 (def valid-slices
   #{:app-db :sub-cache :machines :epochs :traces})
+
+;; ---------------------------------------------------------------------------
+;; Boolean-arg table (rf2-c4fmh).
+;;
+;; The four boolean MCP args shared across pair2-mcp tools each have one
+;; load-bearing knob: their default posture. Their accept-shapes —
+;; `true`/`false`, `"true"`/`"false"`/`"yes"`/`"no"`/`"1"`/`"0"` (case-
+;; insensitive), `:true`/`:false`, unrecognised ⇒ default — are
+;; identical and come from `re-frame.mcp-base.args/parse-boolean`
+;; (rf2-vw4sq). Per-arg micro-wrappers were redundant friction: an
+;; agent that learned `:dedup "yes"` worked, but `:cache "yes"` had
+;; previously default-falsed because cache.cljs hand-rolled a smaller
+;; parser. This table is the single source of truth for both the
+;; default posture AND the accept-shape contract.
+;;
+;; Defaults:
+;;
+;;   :dedup              true   — structural dedup wins shrink-by-default
+;;   :elision            true   — size-elision wins shrink-by-default
+;;   :cache              false  — per-call cache is opt-in until agent
+;;                                hosts have been taught the marker
+;;   :include-sensitive? false  — spec/009 MUST default-suppress
+;;
+;; Callers reach in via `parse-bool-arg`
+;; (`(args/parse-bool-arg raw-args :dedup)`). The dispatcher and per-
+;; tool bodies thread the raw JS args object through; nil-safety on
+;; the args object is centralised here.
+
+(def bool-args
+  "Cross-tool boolean MCP args + their default postures (rf2-c4fmh)."
+  {:dedup              {:default true}
+   :elision            {:default true}
+   :cache              {:default false}
+   :include-sensitive? {:default false}})
+
+(defn parse-bool-arg
+  "Resolve a boolean MCP arg by name. Returns the per-arg default from
+  `bool-args` when the slot is absent / nil / unrecognised; delegates
+  recognised-value parsing to
+  `re-frame.mcp-base.args/parse-boolean` (rf2-vw4sq) — the cross-MCP
+  accept-shape contract.
+
+  `args` may be a JS args object, `nil`, or `js/undefined` — all three
+  collapse to the table default."
+  [args k]
+  (let [default (get-in bool-args [k :default])
+        raw     (when (and args (not (undefined? args)))
+                  (j/get args (name k)))]
+    (base-args/parse-boolean raw default)))
 
 (defn ->frame-keyword
   "Coerce a frame-id string into a keyword. Accepts both bare names

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/dedup.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/dedup.cljs
@@ -46,7 +46,8 @@
   ### Opt-out
 
   `dedup` MCP arg (boolean). Default `true`. `false` skips dedup
-  entirely.
+  entirely. The arg is parsed by the shared
+  `re-frame-pair2-mcp.tools.args/parse-bool-arg` table (rf2-c4fmh).
 
   ### Idempotence on no-dedup-opportunity
 
@@ -81,13 +82,6 @@
 ;; ---------------------------------------------------------------------------
 ;; Structural dedup.
 ;; ---------------------------------------------------------------------------
-
-(defn parse-dedup-arg
-  "Normalise the `dedup` MCP arg into a boolean. Default `true` —
-  the budget-sensitive default fires dedup. Delegates to
-  `re-frame.mcp-base.args/parse-boolean` (rf2-vw4sq)."
-  [raw]
-  (base-args/parse-boolean raw true))
 
 (defn empty-payload?
   "True for values where dedup yields no win — nil, empty collections,

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/elision.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/elision.cljs
@@ -31,16 +31,9 @@
 
   ## `:elision` MCP arg
 
-  Boolean opt-out. Default `true`."
-  (:require [re-frame.mcp-base.args :as base-args]
-            [re-frame.mcp-base.vocab :as base-vocab]))
-
-(defn parse-elision-arg
-  "Normalise the `elision` MCP arg into a boolean. Default `true` —
-  least-surprise on the budget-sensitive default fires elision.
-  Delegates to `re-frame.mcp-base.args/parse-boolean` (rf2-vw4sq)."
-  [raw]
-  (base-args/parse-boolean raw true))
+  Boolean opt-out. Default `true`. The arg is parsed by the shared
+  `re-frame-pair2-mcp.tools.args/parse-bool-arg` table (rf2-c4fmh)."
+  (:require [re-frame.mcp-base.vocab :as base-vocab]))
 
 (defn elision-opts-edn
   "Render the elision opts map as an EDN string for inlining into a

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/get_path.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/get_path.cljs
@@ -28,7 +28,7 @@
   (let [build-id  (wire/arg-build raw-args)
         frame     (some-> (wire/arg raw-args :frame) args/->frame-keyword)
         path      (args/parse-path-arg (wire/arg raw-args :path))
-        elision?  (elision/parse-elision-arg (wire/arg raw-args :elision))]
+        elision?  (args/parse-bool-arg raw-args :elision)]
     (cond
       (nil? path)
       (js/Promise.resolve

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/sensitive.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/sensitive.cljs
@@ -11,16 +11,10 @@
   Opt-in escape hatch: an MCP arg of `:include-sensitive? true` (on
   any read/stream tool that surfaces trace-like data) removes the
   filter for that call. The default is off — apps that want sensitive
-  cascades visible to the pair tool configure the policy explicitly."
-  (:require [re-frame.mcp-base.sensitive :as base-sensitive]
-            [re-frame-pair2-mcp.tools.wire :as wire]))
-
-(defn include-sensitive?
-  "True iff the caller has opted in to forwarding `:sensitive? true`
-  events for this call. Default off. The arg name
-  `:include-sensitive?` is the cross-MCP convention (rf2-vw4sq)."
-  [args]
-  (boolean (wire/arg args :include-sensitive?)))
+  cascades visible to the pair tool configure the policy explicitly.
+  The arg is parsed by the shared
+  `re-frame-pair2-mcp.tools.args/parse-bool-arg` table (rf2-c4fmh)."
+  (:require [re-frame.mcp-base.sensitive :as base-sensitive]))
 
 (defn sensitive-event?
   "Delegates to `re-frame.mcp-base.sensitive/sensitive-event?`

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/snapshot.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/snapshot.cljs
@@ -16,14 +16,13 @@
             [re-frame-pair2-mcp.tools.probe :as probe]
             [re-frame-pair2-mcp.tools.args :as args]
             [re-frame-pair2-mcp.tools.dedup :as dedup]
-            [re-frame-pair2-mcp.tools.elision :as elision]
-            [re-frame-pair2-mcp.tools.sensitive :as sensitive]))
+            [re-frame-pair2-mcp.tools.elision :as elision]))
 
 (defn snapshot-tool [conn raw-args]
   (let [build-id    (wire/arg-build raw-args)
         frames      (args/parse-frames-arg (wire/arg raw-args :frames))
         include     (args/parse-include-arg (wire/arg raw-args :include))
-        incl?       (sensitive/include-sensitive? raw-args)
+        incl?       (args/parse-bool-arg raw-args :include-sensitive?)
         path        (args/parse-path-arg (wire/arg raw-args :path))
         mode        (dedup/parse-epochs-mode (wire/arg raw-args :epochs-mode))
         ;; Global lazy-summary mode (rf2-u2029): `:summary` (default)
@@ -32,8 +31,8 @@
         ;; `:modes` map takes precedence over the global mode.
         slice-mode  (args/parse-mode-arg (wire/arg raw-args :mode))
         slice-modes (args/parse-modes-arg (wire/arg raw-args :modes))
-        dedup?      (dedup/parse-dedup-arg (wire/arg raw-args :dedup))
-        elision?    (elision/parse-elision-arg (wire/arg raw-args :elision))
+        dedup?      (args/parse-bool-arg raw-args :dedup)
+        elision?    (args/parse-bool-arg raw-args :elision)
         opts        {:frames frames :include include}
         ;; Eval form composition (rf2-urjnc). The snapshot composer
         ;; returns a per-frame map; we wrap each frame's `:app-db`

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs
@@ -183,8 +183,8 @@
         poll-ms            (or (wire/arg raw-args :poll-ms) default-poll-ms)
         max-ms             (or (wire/arg raw-args :max-ms) 0)
         max-events         (or (wire/arg raw-args :max-events) 0)
-        incl?              (sensitive/include-sensitive? raw-args)
-        dedup?             (dedup/parse-dedup-arg (wire/arg raw-args :dedup))
+        incl?              (args/parse-bool-arg raw-args :include-sensitive?)
+        dedup?             (args/parse-bool-arg raw-args :dedup)
         {:keys [signal send-note progress-tk]} (parse-mcp-extra extra)]
     (cond
       (or (nil? topic)

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/trace_window.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/trace_window.cljs
@@ -12,23 +12,23 @@
   builds the eval form, awaits the runtime response, and routes the
   epoch vector through `run-wire-pipeline` with `:kind :epoch-vector`."
   (:require [re-frame-pair2-mcp.nrepl :as nrepl]
+            [re-frame-pair2-mcp.tools.args :as args]
             [re-frame-pair2-mcp.tools.eval-form :as ef]
             [re-frame-pair2-mcp.tools.wire :as wire]
             [re-frame-pair2-mcp.tools.wire-pipeline :as wp]
             [re-frame-pair2-mcp.tools.probe :as probe]
             [re-frame-pair2-mcp.tools.cursor :as cursor]
-            [re-frame-pair2-mcp.tools.dedup :as dedup]
-            [re-frame-pair2-mcp.tools.sensitive :as sensitive]))
+            [re-frame-pair2-mcp.tools.dedup :as dedup]))
 
-(defn trace-window-tool [conn args]
-  (let [ms        (or (wire/arg args :ms) 1000)
-        build-id  (wire/arg-build args)
-        frame     (some-> (wire/arg args :frame) keyword)
-        incl?     (sensitive/include-sensitive? args)
-        mode      (dedup/parse-epochs-mode (wire/arg args :epochs-mode))
-        dedup?    (dedup/parse-dedup-arg (wire/arg args :dedup))
-        limit     (cursor/parse-limit-arg (wire/arg args :limit))
-        cursor-in (cursor/decode-cursor (wire/arg args :cursor))]
+(defn trace-window-tool [conn raw-args]
+  (let [ms        (or (wire/arg raw-args :ms) 1000)
+        build-id  (wire/arg-build raw-args)
+        frame     (some-> (wire/arg raw-args :frame) keyword)
+        incl?     (args/parse-bool-arg raw-args :include-sensitive?)
+        mode      (dedup/parse-epochs-mode (wire/arg raw-args :epochs-mode))
+        dedup?    (args/parse-bool-arg raw-args :dedup)
+        limit     (cursor/parse-limit-arg (wire/arg raw-args :limit))
+        cursor-in (cursor/decode-cursor (wire/arg raw-args :cursor))]
     (if (= cursor-in ::cursor/malformed)
       (js/Promise.resolve
         (cursor/cursor-stale-result "trace-window" {:requested-id nil}))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/watch_epochs.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/watch_epochs.cljs
@@ -17,24 +17,24 @@
   builds the eval form, awaits the runtime response, and routes the
   matches vector through `run-wire-pipeline` with `:kind :epoch-vector`."
   (:require [re-frame-pair2-mcp.nrepl :as nrepl]
+            [re-frame-pair2-mcp.tools.args :as args]
             [re-frame-pair2-mcp.tools.eval-form :as ef]
             [re-frame-pair2-mcp.tools.wire :as wire]
             [re-frame-pair2-mcp.tools.wire-pipeline :as wp]
             [re-frame-pair2-mcp.tools.probe :as probe]
             [re-frame-pair2-mcp.tools.cursor :as cursor]
-            [re-frame-pair2-mcp.tools.dedup :as dedup]
-            [re-frame-pair2-mcp.tools.sensitive :as sensitive]))
+            [re-frame-pair2-mcp.tools.dedup :as dedup]))
 
-(defn watch-epochs-tool [conn args]
-  (let [build-id  (wire/arg-build args)
-        frame     (some-> (wire/arg args :frame) keyword)
-        since-id  (wire/arg args :since-id)
-        incl?     (sensitive/include-sensitive? args)
-        mode      (dedup/parse-epochs-mode (wire/arg args :epochs-mode))
-        dedup?    (dedup/parse-dedup-arg (wire/arg args :dedup))
-        limit     (cursor/parse-limit-arg (wire/arg args :limit))
-        pred-map  (when-let [p (wire/arg args :pred)] (js->clj p :keywordize-keys true))
-        cursor-in (cursor/decode-cursor (wire/arg args :cursor))]
+(defn watch-epochs-tool [conn raw-args]
+  (let [build-id  (wire/arg-build raw-args)
+        frame     (some-> (wire/arg raw-args :frame) keyword)
+        since-id  (wire/arg raw-args :since-id)
+        incl?     (args/parse-bool-arg raw-args :include-sensitive?)
+        mode      (dedup/parse-epochs-mode (wire/arg raw-args :epochs-mode))
+        dedup?    (args/parse-bool-arg raw-args :dedup)
+        limit     (cursor/parse-limit-arg (wire/arg raw-args :limit))
+        pred-map  (when-let [p (wire/arg raw-args :pred)] (js->clj p :keywordize-keys true))
+        cursor-in (cursor/decode-cursor (wire/arg raw-args :cursor))]
     (if (= cursor-in ::cursor/malformed)
       (js/Promise.resolve
         (cursor/cursor-stale-result "watch-epochs" {:requested-id nil}))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/args_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/args_test.cljs
@@ -1,0 +1,111 @@
+(ns re-frame-pair2-mcp.args-test
+  "Unit tests for the table-driven boolean-arg parser (rf2-c4fmh).
+
+  Pins the four boolean MCP args shared across pair2-mcp tools to the
+  single `args/bool-args` table:
+
+    :dedup              ⇒ default true
+    :elision            ⇒ default true
+    :cache              ⇒ default false
+    :include-sensitive? ⇒ default false
+
+  Accept-shape coverage (true/false bools, `\"true\"`/`\"yes\"`/`\"1\"`
+  string forms, `:true`/`:false` keywords, case-insensitivity,
+  unrecognised-falls-back-to-default) lives in
+  `re-frame.mcp-base.args-test/parse-boolean-*` — the cross-MCP base
+  parser this wrapper delegates to. These tests verify the table lookup
+  and the JS-args / nil handling on top."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [applied-science.js-interop :as j]
+            [re-frame-pair2-mcp.tools.args :as args]))
+
+(defn- args-js
+  "Build a JS args object from a CLJS map. Keys are coerced to strings —
+  the MCP wire ships JSON-object keys as strings."
+  [m]
+  (let [o #js {}]
+    (doseq [[k v] m]
+      (j/assoc! o (name k) v))
+    o))
+
+;; ---------------------------------------------------------------------------
+;; Table — every boolean MCP arg + its default lives here.
+;; ---------------------------------------------------------------------------
+
+(deftest bool-args-table-shape
+  ;; The four arg keys are catalogued; their default postures are the
+  ;; cross-MCP convention. Drift here = drift across consumers.
+  (is (= #{:dedup :elision :cache :include-sensitive?}
+         (set (keys args/bool-args))))
+  (is (true?  (get-in args/bool-args [:dedup              :default])))
+  (is (true?  (get-in args/bool-args [:elision            :default])))
+  (is (false? (get-in args/bool-args [:cache              :default])))
+  (is (false? (get-in args/bool-args [:include-sensitive? :default]))))
+
+;; ---------------------------------------------------------------------------
+;; parse-bool-arg — table lookup + JS-args extraction.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-bool-arg-absent-uses-table-default
+  ;; The absent slot resolves to whatever the table says.
+  (let [empty-args (args-js {})]
+    (is (true?  (args/parse-bool-arg empty-args :dedup)))
+    (is (true?  (args/parse-bool-arg empty-args :elision)))
+    (is (false? (args/parse-bool-arg empty-args :cache)))
+    (is (false? (args/parse-bool-arg empty-args :include-sensitive?)))))
+
+(deftest parse-bool-arg-nil-args-uses-table-default
+  ;; A nil args object collapses to the table default — the dispatcher
+  ;; can pass a missing args slot without a defensive guard.
+  (is (true?  (args/parse-bool-arg nil :dedup)))
+  (is (false? (args/parse-bool-arg nil :cache))))
+
+(deftest parse-bool-arg-undefined-args-uses-table-default
+  ;; JS undefined likewise collapses to the table default.
+  (is (true?  (args/parse-bool-arg js/undefined :dedup)))
+  (is (false? (args/parse-bool-arg js/undefined :cache))))
+
+(deftest parse-bool-arg-explicit-boolean-overrides-default
+  (let [on?  (args-js {:dedup false :cache true})
+        off? (args-js {:dedup true  :cache false})]
+    (is (false? (args/parse-bool-arg on?  :dedup)))
+    (is (true?  (args/parse-bool-arg on?  :cache)))
+    (is (true?  (args/parse-bool-arg off? :dedup)))
+    (is (false? (args/parse-bool-arg off? :cache)))))
+
+(deftest parse-bool-arg-string-forms-accepted-uniformly
+  ;; Pre-rf2-c4fmh, `:cache "yes"` default-falsed because cache.cljs
+  ;; hand-rolled a smaller parser. The unified table delegates to
+  ;; `base-args/parse-boolean` for every key, so `"yes"` flips on
+  ;; uniformly across all four args.
+  (let [a (args-js {:dedup              "no"
+                    :elision            "off"
+                    :cache              "yes"
+                    :include-sensitive? "1"})]
+    (is (false? (args/parse-bool-arg a :dedup)))
+    (is (false? (args/parse-bool-arg a :elision)))
+    (is (true?  (args/parse-bool-arg a :cache)))
+    (is (true?  (args/parse-bool-arg a :include-sensitive?)))))
+
+(deftest parse-bool-arg-case-insensitive-strings
+  (let [a (args-js {:cache "TRUE" :dedup "False"})]
+    (is (true?  (args/parse-bool-arg a :cache)))
+    (is (false? (args/parse-bool-arg a :dedup)))))
+
+(deftest parse-bool-arg-keyword-forms-accepted
+  (let [a (args-js {:cache :true :dedup :false})]
+    (is (true?  (args/parse-bool-arg a :cache)))
+    (is (false? (args/parse-bool-arg a :dedup)))))
+
+(deftest parse-bool-arg-unrecognised-falls-back-to-table-default
+  (let [a (args-js {:dedup "garbage" :cache "garbage"})]
+    (is (true?  (args/parse-bool-arg a :dedup)))    ; default true
+    (is (false? (args/parse-bool-arg a :cache)))))  ; default false
+
+(deftest parse-bool-arg-include-sensitive-name-is-stringified
+  ;; The keyword name carries a trailing `?`; the JS wire key is
+  ;; `"include-sensitive?"`. The name coercion in `parse-bool-arg`
+  ;; round-trips the `?` correctly — pin the contract so a future
+  ;; rename can't silently drift.
+  (let [a (args-js {:include-sensitive? "true"})]
+    (is (true? (args/parse-bool-arg a :include-sensitive?)))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/cache_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/cache_test.cljs
@@ -60,36 +60,9 @@
     (and (map? v) (contains? v :rf.mcp/cache-hit))))
 
 ;; ---------------------------------------------------------------------------
-;; parse-cache-arg — MCP-arg normalisation.
+;; `:cache` MCP-arg normalisation now lives on the shared table-driven
+;; parser — see `re-frame-pair2-mcp.args-test` (rf2-c4fmh).
 ;; ---------------------------------------------------------------------------
-
-(deftest parse-cache-arg-default-is-false
-  ;; Opt-in by default — least surprise for agent hosts that haven't
-  ;; been taught the marker shape.
-  (is (false? (cache/parse-cache-arg nil))))
-
-(deftest parse-cache-arg-booleans-pass-through
-  (is (true? (cache/parse-cache-arg true)))
-  (is (false? (cache/parse-cache-arg false))))
-
-(deftest parse-cache-arg-string-forms-accepted
-  ;; MCP wire ships JSON; clients sending `"true"` should get the
-  ;; opt-in.
-  (is (true? (cache/parse-cache-arg "true")))
-  (is (false? (cache/parse-cache-arg "false")))
-  (is (true? (cache/parse-cache-arg "TRUE")))
-  (is (false? (cache/parse-cache-arg "False"))))
-
-(deftest parse-cache-arg-keyword-forms-accepted
-  (is (true? (cache/parse-cache-arg :true)))
-  (is (false? (cache/parse-cache-arg :false))))
-
-(deftest parse-cache-arg-unknown-defaults-to-false
-  ;; Conservative default for unrecognised values — opt-in semantics
-  ;; should never sneak on accidentally.
-  (is (false? (cache/parse-cache-arg "garbage")))
-  (is (false? (cache/parse-cache-arg 42)))
-  (is (false? (cache/parse-cache-arg :other))))
 
 ;; ---------------------------------------------------------------------------
 ;; cacheable? — tool-allowlist guard.

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/dedup_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/dedup_test.cljs
@@ -10,11 +10,15 @@
   the agent host reconstructs via `de-dupe.core/expand`.
 
   Tests pin the public helpers directly from their owning namespaces:
-  `tools.dedup/parse-dedup-arg`, `tools.dedup/empty-payload?`,
-  `tools.dedup/dedup-value`, `test-utils/dedup-expand`,
+  `tools.dedup/empty-payload?`, `tools.dedup/dedup-value`,
+  `test-utils/dedup-expand`,
   `tools.snapshot-pipeline/dedup-epochs-in-snapshot`. A rename or
   signature change surfaces as a failing test rather than a silent
   contract drift.
+
+  `:dedup` MCP-arg normalisation lives on the shared table-driven
+  parser (`re-frame-pair2-mcp.tools.args/parse-bool-arg`, rf2-c4fmh);
+  see `re-frame-pair2-mcp.args-test` for the coverage.
 
   Live end-to-end coverage runs against a real shadow-cljs build via
   the existing stdio-roundtrip harness; this file pins the pure
@@ -24,34 +28,6 @@
             [re-frame-pair2-mcp.tools.dedup :as dedup]
             [re-frame-pair2-mcp.tools.snapshot-pipeline :as pipeline]
             [re-frame-pair2-mcp.test-utils :as tu]))
-
-;; ---------------------------------------------------------------------------
-;; parse-dedup-arg — MCP-arg normalisation.
-;; ---------------------------------------------------------------------------
-
-(deftest parse-dedup-default-is-true
-  (is (true? (dedup/parse-dedup-arg nil))))
-
-(deftest parse-dedup-booleans-pass-through
-  (is (true? (dedup/parse-dedup-arg true)))
-  (is (false? (dedup/parse-dedup-arg false))))
-
-(deftest parse-dedup-string-forms-accepted
-  ;; The MCP wire ships JSON; clients sending `"false"` should get
-  ;; the false reading rather than the budget-default true.
-  (is (false? (dedup/parse-dedup-arg "false")))
-  (is (true? (dedup/parse-dedup-arg "true"))))
-
-(deftest parse-dedup-keyword-forms-accepted
-  (is (false? (dedup/parse-dedup-arg :false)))
-  (is (true? (dedup/parse-dedup-arg :true))))
-
-(deftest parse-dedup-unknown-defaults-to-true
-  ;; Least-surprise on the budget-sensitive default: an unrecognised
-  ;; value gets the smaller-wire-payload behaviour, not the larger.
-  (is (true? (dedup/parse-dedup-arg "garbage")))
-  (is (true? (dedup/parse-dedup-arg 42)))
-  (is (true? (dedup/parse-dedup-arg :other))))
 
 ;; ---------------------------------------------------------------------------
 ;; empty-payload? — the no-op guard.

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/elision_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/elision_test.cljs
@@ -10,12 +10,16 @@
   ...}}` marker; the agent re-fetches via `get-path` with the handle's
   path.
 
-  Tests pin `parse-elision-arg` and `elision-opts-edn` directly from
+  Tests pin `elision-opts-edn` directly from
   `re-frame-pair2-mcp.tools.elision`. The downstream eval-form
   composers (`build-snapshot-form` / `build-get-path-form`) remain
   local fixtures because their source counterparts live inlined in
   the per-tool namespaces (`tools.snapshot` / `tools.get-path`) and
   aren't surfaced as standalone public fns.
+
+  `:elision` MCP-arg normalisation lives on the shared table-driven
+  parser (`re-frame-pair2-mcp.tools.args/parse-bool-arg`, rf2-c4fmh);
+  see `re-frame-pair2-mcp.args-test` for the coverage.
 
   Live end-to-end coverage runs against a real shadow-cljs build via
   the existing `test/stdio-roundtrip.js` harness — that's where the
@@ -24,37 +28,6 @@
   (:require [cljs.test :refer-macros [deftest is testing]]
             [cljs.reader]
             [re-frame-pair2-mcp.tools.elision :as elision]))
-
-;; ---------------------------------------------------------------------------
-;; parse-elision-arg — MCP-arg normalisation.
-;; ---------------------------------------------------------------------------
-
-(deftest parse-elision-default-is-true
-  ;; Default-on matches the dedup posture: shrink-by-default, opt out
-  ;; explicitly. An agent that hasn't been taught about elision still
-  ;; gets the smaller wire payload.
-  (is (true? (elision/parse-elision-arg nil))))
-
-(deftest parse-elision-booleans-pass-through
-  (is (true? (elision/parse-elision-arg true)))
-  (is (false? (elision/parse-elision-arg false))))
-
-(deftest parse-elision-string-forms-accepted
-  ;; The MCP wire ships JSON; clients sending `"false"` should get the
-  ;; false reading rather than the budget-default true.
-  (is (false? (elision/parse-elision-arg "false")))
-  (is (true? (elision/parse-elision-arg "true"))))
-
-(deftest parse-elision-keyword-forms-accepted
-  (is (false? (elision/parse-elision-arg :false)))
-  (is (true? (elision/parse-elision-arg :true))))
-
-(deftest parse-elision-unknown-defaults-to-true
-  ;; Least-surprise on the budget-sensitive default: an unrecognised
-  ;; value gets the smaller-wire-payload behaviour, not the larger.
-  (is (true? (elision/parse-elision-arg "garbage")))
-  (is (true? (elision/parse-elision-arg 42)))
-  (is (true? (elision/parse-elision-arg :other))))
 
 ;; ---------------------------------------------------------------------------
 ;; elision-opts-edn — EDN-render the walker's opts map for inlining.


### PR DESCRIPTION
## Summary

- Single table-driven boolean-arg parser in `tools/args.cljs`: `bool-args` maps each MCP arg keyword to its default posture, and `parse-bool-arg` resolves a JS args object through the table, delegating recognised-value parsing to `re-frame.mcp-base.args/parse-boolean` (the cross-MCP accept-shape contract from rf2-vw4sq).
- Fixes the `:cache` accept-shape drift flagged in the rf2-7hie3 audit §C1: `cache/parse-cache-arg` previously hand-rolled a smaller parser that default-falsed for `"yes"`/`"1"`/`"on"`, while `:dedup`/`:elision` accepted those forms.
- Removes `dedup/parse-dedup-arg`, `elision/parse-elision-arg`, `cache/parse-cache-arg`, `sensitive/include-sensitive?` — call sites switch to `args/parse-bool-arg`.
- Tests collapse the four parse-* blocks into one `args_test.cljs`. Per-tool test files keep their non-arg coverage (`cacheable?`, `empty-payload?`, `elision-opts-edn`, eval-form composers) untouched.

LoC delta: +219 / -179, net +40 (mostly the new args_test.cljs covering more cases than the four old blocks did individually — the parser shrinks from four micro-wrappers + parse-cache-arg's hand-rolled `cond` to one table + one lookup fn). Source delta is net negative.

Composed on top of rf2-47g8l (which moved descriptors but left parsers in place).

## Test plan

- [x] `npm test` from `tools/pair2-mcp/` — 292 tests, 715 assertions, 0 failures, 0 errors
- [x] New `re-frame-pair2-mcp.args-test` validates table shape + JS-args / nil / undefined handling + cross-arg accept-shape uniformity (the `:cache "yes"` drift fix)
- [ ] CI gates green on the PR