### PR TITLE
refactor(core): consolidate privacy + sensitive? + redaction into re-frame.privacy ns (rf2-iwqu9)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -554,7 +554,7 @@
 ;; ---- privacy / spec / trace / emit / elision (Spec 009, 010) -------------
 
 (def with-redacted        privacy/with-redacted)
-(def sensitive?           trace/sensitive?)
+(def sensitive?           privacy/sensitive?)
 (def validate-at-boundary spec/validate-at-boundary)
 
 (def register-trace-cb!  trace/register-trace-cb!)

--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -31,6 +31,7 @@
   (:require [re-frame.frame :as frame]
             [re-frame.fx :as fx]
             [re-frame.late-bind :as late-bind]
+            [re-frame.privacy :as privacy]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.trace :as trace]))
 
@@ -423,11 +424,13 @@
 
 (def ^:private redacted-sentinel
   "The `:rf/redacted` privacy sentinel emitted by the walker for slots
-   matching the `:sensitive?` predicate. Per [009 §Privacy / sensitive
-   data in traces] — the existing surface; the walker is the single
-   normative emission site (rf2-isdwf wires the per-event `:sensitive?`
-   stamping that this walker consults)."
-  :rf/redacted)
+   matching the `:sensitive?` predicate. Re-exported from
+   `re-frame.privacy/redacted-sentinel` per rf2-iwqu9 so the in-handler
+   `with-redacted` interceptor and this wire-walker emit the same value
+   from a single source of truth. Per [009 §Privacy / sensitive data
+   in traces] — privacy owns the policy locus; the walker remains the
+   single normative emission site for the elision pathway."
+  privacy/redacted-sentinel)
 
 (defn- sensitive-decl?
   "Per-path `:sensitive?` predicate. Today the registry doesn't carry

--- a/implementation/core/src/re_frame/event_emit.cljc
+++ b/implementation/core/src/re_frame/event_emit.cljc
@@ -27,6 +27,7 @@
   (:require [re-frame.elision       :as elision]
             [re-frame.emit-substrate :as emit]
             [re-frame.late-bind     :as late-bind]
+            [re-frame.privacy       :as privacy]
             [re-frame.registrar     :as registrar]))
 
 ;; ---- listener registry ----------------------------------------------------
@@ -79,7 +80,7 @@
   [event event-id frame time outcome elapsed-ms]
   (when (seq @listeners)
     (let [handler-meta (registrar/lookup :event event-id)]
-      (when-not (or (:sensitive?        handler-meta)
+      (when-not (or (privacy/sensitive?-from-meta handler-meta)
                     (:rf.trace/no-emit? handler-meta))
         (let [elided-event (elision/elide-wire-value event {:frame frame})
               record       {:event      elided-event

--- a/implementation/core/src/re_frame/privacy.cljc
+++ b/implementation/core/src/re_frame/privacy.cljc
@@ -1,31 +1,45 @@
 (ns re-frame.privacy
-  "Per Spec 009 §Privacy / sensitive data in traces (lines 1149-1268,
-  resolved by rf2-a32kd; runtime implementation rf2-isdwf).
+  "Single policy locus for re-frame privacy / sensitive data / redaction
+  per Spec 009 §Privacy / sensitive data in traces (lines 1149-1268,
+  resolved by rf2-a32kd; runtime implementation rf2-isdwf; ns
+  consolidation rf2-iwqu9).
 
-  Two cooperating pieces:
+  This ns owns:
 
-  1. **Registration-time `:sensitive?` metadata key.** A boolean flag
-     on the `:rf/registration-metadata` map for any `reg-*` kind. The
-     registrar copies it onto the registry slot's stored meta; the
-     runtime hoists `:sensitive? true` to the top level of every trace
-     event emitted within the handler's execution scope. The plumbing
-     for the runtime stamp lives in `re-frame.trace` (the `:sensitive?`
-     slot of the `*handler-scope*` record, bound at every handler-scope
-     binding site per rf2-ryri7).
+  - **`redacted-sentinel`** — the single `:rf/redacted` sentinel; both
+    `with-redacted` (in-handler payload scrub) and
+    `re-frame.elision/elide-wire-value` (wire-walker substitution for
+    `:sensitive?` paths) emit this same value, sourced from here.
 
-  2. **`with-redacted` interceptor.** A positional interceptor that
-     overwrites named keys in the event payload with the sentinel
-     keyword `:rf/redacted` before the handler chain runs. The
-     handler body itself sees the UNREDACTED payload via the regular
-     `:event` coeffect slot (handlers need the real value to do their
-     work). The redaction is for the trace surface — every downstream
-     emit that copies the event vector (`:event/dispatched` already
-     fired by the time the interceptor `:before` runs, but the
-     handler's `:rf.trace/trigger-handler` cofx view of the event,
-     the `:event/db-changed` `:tags :app-db-before` / `:app-db-after`
-     when the corresponding paths exist in app-db, and any
-     `:rf.error/handler-exception` `:tags :event` slot the runtime
-     emits for a throw from this handler) picks up the redacted form.
+  - **Registration-meta readers**: `sensitive?-from-meta` reads the
+    boolean `:sensitive?` flag off a registrar slot's stored meta.
+    Every site that needs to know whether a not-yet-bound handler is
+    sensitive (the queue-time `:event/dispatched` emit in router, the
+    always-on event-emit listener fan-out, the handler-scope binding
+    in trace) reads through this single helper.
+
+  - **Public predicate**: `sensitive?` — does this trace event carry
+    a top-level `:sensitive? true` field? The filter-out reader every
+    off-box listener gates on.
+
+  - **`with-redacted` interceptor**: positional interceptor that
+    overwrites named keys in the event payload with `:rf/redacted`
+    before the handler chain runs. The handler body itself sees the
+    UNREDACTED payload via the regular `:event` coeffect slot; the
+    redaction is for the trace surface — every downstream emit that
+    copies the event vector (the handler's `:rf.trace/trigger-handler`
+    cofx view of the event, the `:event/db-changed` `:tags :app-db-before`
+    / `:app-db-after` slots when the corresponding paths exist in
+    app-db, and any `:rf.error/handler-exception` `:tags :event` slot
+    the runtime emits for a throw from this handler) picks up the
+    redacted form.
+
+  - **Registration-time warning**: `:rf.warning/sensitive-without-redaction`
+    fires when a registration declares `:sensitive? true` but the
+    positional interceptor chain has no `with-redacted` and the
+    registration metadata carries no `:no-redaction-needed?` opt-out.
+    One emit per `(kind, id)` pair (cached); the cache is reset on
+    every fresh registration cycle so re-declarations after fix re-fire.
 
   Composition: a handler carrying both `:sensitive? true` in its
   metadata-map AND `[(with-redacted [...])]` in its positional
@@ -35,12 +49,11 @@
   the in-place scrub. The conservative recommended pattern for new
   sensitive handlers is to declare both.
 
-  Registration-time warning: `:rf.warning/sensitive-without-redaction`
-  fires when a registration declares `:sensitive? true` but the
-  positional interceptor chain has no `with-redacted` and the
-  registration metadata carries no `:no-redaction-needed?` opt-out.
-  One emit per `(kind, id)` pair (cached); the cache is reset on
-  every fresh registration cycle so re-declarations after fix re-fire."
+  Architectural separation: **trace is the emission site, privacy is
+  the policy site.** `re-frame.trace` consults privacy when assembling
+  the `*handler-scope*` record (for the per-event `:sensitive?` hoist),
+  and `re-frame.elision` re-exports the sentinel from here so the
+  wire-walker and `with-redacted` emit the same value."
   (:require [re-frame.interceptor :as interceptor]
             [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace]))
@@ -53,10 +66,43 @@
   produce it as a payload value. Consumers wanting \"was this redacted?\"
   check `(= :rf/redacted v)`.
 
-  Mirrors the sentinel emitted by `re-frame.elision/elide-wire-value`
-  for sensitive-value substitution — same wire shape, two emit sites
-  (in-handler redaction here, wire-walker substitution there)."
+  Single source of truth: `with-redacted` (this ns) and the elision
+  wire-walker (`re-frame.elision/elide-wire-value`) both substitute
+  this same value; the walker re-exports through `(def redacted-sentinel
+  privacy/redacted-sentinel)` rather than declaring a duplicate."
   :rf/redacted)
+
+;; ---- registration-meta readers -------------------------------------------
+;;
+;; Single policy reading for the boolean `:sensitive?` flag on a registrar
+;; slot's stored meta. Three call sites consult this helper:
+;;   - `re-frame.router/emit-dispatched-trace!` — queue-time, before the
+;;     handler-scope binding exists.
+;;   - `re-frame.event-emit/dispatch-on-event!` — always-on event-emit
+;;     fan-out drops sensitive records before fan-out.
+;;   - `re-frame.trace/handler-scope-from-meta` — binds the
+;;     `*handler-scope*` `:sensitive?` slot for per-event hoist.
+;;
+;; Per Spec 009 §Privacy / sensitive data in traces — the meta-key shape
+;; is normative; this is its single reader.
+
+(defn sensitive?-from-meta
+  "True iff `meta` (a registrar slot's stored meta map) carries
+  `:sensitive? true`. Returns false on nil, missing key, or
+  non-boolean. Per Spec 009 §Privacy / sensitive data in traces."
+  [meta]
+  (true? (:sensitive? meta)))
+
+;; ---- public predicate ----------------------------------------------------
+
+(defn sensitive?
+  "Predicate: is `trace-event`'s top-level `:sensitive?` field truthy?
+  The framework-published predicate every trace consumer gates on.
+  Re-exported as `re-frame.core/sensitive?`. Per Spec 009 §Privacy /
+  sensitive data in traces."
+  [trace-event]
+  (and (map? trace-event)
+       (true? (:sensitive? trace-event))))
 
 ;; ---- helpers --------------------------------------------------------------
 

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -18,6 +18,7 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.performance :as performance
              #?@(:cljs [:include-macros true])]
+            [re-frame.privacy :as privacy]
             [re-frame.trace :as trace
              #?@(:cljs [:include-macros true])]))
 
@@ -914,7 +915,7 @@
   (let [event        (:event envelope)
         event-id     (when (vector? event) (first event))
         handler-meta (when event-id (registrar/lookup :event event-id))
-        sensitive?   (trace/sensitive?-from-meta handler-meta)
+        sensitive?   (privacy/sensitive?-from-meta handler-meta)
         no-emit?     (trace/no-emit?-from-meta handler-meta)]
     (when-not no-emit?
       (trace/emit! :event :event/dispatched

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -73,34 +73,28 @@
        :id           id
        :source-coord coord})))
 
-(defn sensitive?-from-meta
-  "True iff `meta` carries `:sensitive? true`. Used at queue-time
-  `:event/dispatched` emit, before the handler-scope binding exists.
-  Per Spec 009 §Privacy / sensitive data in traces."
-  [meta]
-  (true? (:sensitive? meta)))
-
 (defn no-emit?-from-meta
   "True iff `meta` carries `:rf.trace/no-emit? true`. Used at queue-time
   `:event/dispatched` emit, before the handler-scope binding exists.
-  Per Spec 009 §Trace-emission opt-out."
+  Per Spec 009 §Trace-emission opt-out.
+
+  Sibling reader for `:sensitive?` lives in `re-frame.privacy`
+  (`privacy/sensitive?-from-meta`) per rf2-iwqu9 — privacy owns the
+  policy-locus; trace owns the emit-locus."
   [meta]
   (true? (:rf.trace/no-emit? meta)))
-
-(defn sensitive?
-  "Predicate: is `trace-event`'s top-level `:sensitive?` field truthy?
-  The framework-published predicate every trace consumer gates on.
-  Per Spec 009 §Privacy / sensitive data in traces."
-  [trace-event]
-  (and (map? trace-event)
-       (true? (:sensitive? trace-event))))
 
 (defn handler-scope-from-meta
   "Build a HandlerScope from a registrar slot's `meta` for a handler
   about to execute. Computes the three meta-derived slots
   (`:trigger-handler` / `:sensitive?` / `:no-emit?`); leaves
   `:call-site` and `:dispatch-id` nil — `with-handler-scope` fills
-  them from the parent scope on bind. Per Spec 009 §Handler-scope."
+  them from the parent scope on bind. Per Spec 009 §Handler-scope.
+
+  The `:sensitive?` reading is inlined here to avoid a require cycle
+  with `re-frame.privacy` (privacy requires trace). The same boolean
+  shape is exposed as `re-frame.privacy/sensitive?-from-meta` for
+  every other consumer (router / event-emit) per rf2-iwqu9."
   [kind id meta]
   (->HandlerScope (trigger-handler-from-meta kind id meta)
                   nil

--- a/implementation/core/test/re_frame/sensitive_stamping_test.clj
+++ b/implementation/core/test/re_frame/sensitive_stamping_test.clj
@@ -23,7 +23,7 @@
   - Composition with walker: stamped event flows through
     `elide-wire-value` and the sensitive-drop wins.
   - `trace-buffer {:sensitive? false}` filter excludes sensitive events.
-  - `trace/sensitive?` predicate returns true on top-level-stamped events.
+  - `privacy/sensitive?` predicate returns true on top-level-stamped events.
 
   JVM-only — the dynamic-var binding mechanism is platform-agnostic."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
@@ -499,9 +499,11 @@
     (is (false? (rf/sensitive? {:tags {:sensitive? true}}))
         "nested :sensitive? inside :tags does NOT count — only the
          top-level field per Spec 009 line 1175"))
-  (testing "rf/sensitive? and re-frame.trace/sensitive? are the same fn
-   — re-frame.core re-exports from re-frame.trace via (def ...) (rf2-sqxjn)"
-    (is (identical? rf/sensitive? trace/sensitive?))))
+  (testing "rf/sensitive? and re-frame.privacy/sensitive? are the same fn
+   — re-frame.core re-exports from re-frame.privacy via (def ...)
+   (rf2-iwqu9 — moved from re-frame.trace, which retains no
+   sensitive? predicate; trace is the emit site, privacy the policy site)"
+    (is (identical? rf/sensitive? privacy/sensitive?))))
 
 ;; ---- composition with wire-elision walker --------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -23,8 +23,8 @@
   Causa shell (gated on `interop/debug-enabled?` in preload.cljs); the
   atom survives but is never read. CLJC so the JVM test corpus can
   cover the round-trip without a CLJS runtime."
-  (:require [re-frame.source-coords.editor-uri :as editor-uri]
-            [re-frame.trace :as trace]
+  (:require [re-frame.privacy :as privacy]
+            [re-frame.source-coords.editor-uri :as editor-uri]
             #?@(:cljs [[re-frame.core :as rf]
                        [re-frame.frame :as frame]])))
 
@@ -105,13 +105,14 @@
 
 (defn sensitive-event?
   "True iff the trace event `ev` carries `:sensitive? true` at the top
-  level. Thin alias over the framework-published `re-frame.trace/sensitive?`
-  predicate (re-exported as `re-frame.core/sensitive?`) — per rf2-sqxjn,
-  every consumer of `:sensitive?` (Causa, Story, story-mcp, pair2-mcp,
-  causa-mcp) composes against ONE framework primitive rather than
-  reimplementing the five-token check. Per Spec 009 §Privacy."
+  level. Thin alias over the framework-published `re-frame.privacy/sensitive?`
+  predicate (re-exported as `re-frame.core/sensitive?`) — per rf2-sqxjn
+  / rf2-iwqu9, every consumer of `:sensitive?` (Causa, Story,
+  story-mcp, pair2-mcp, causa-mcp) composes against ONE framework
+  primitive rather than reimplementing the five-token check. Per Spec
+  009 §Privacy."
   [ev]
-  (trace/sensitive? ev))
+  (privacy/sensitive? ev))
 
 (defn suppress-sensitive?
   "Should this trace event be suppressed by Causa's trace collector

--- a/tools/mcp-base/spec/README.md
+++ b/tools/mcp-base/spec/README.md
@@ -76,5 +76,5 @@ Two rules:
    `deps.edn` carries only `org.clojure/clojure`. If your primitive
    needs cheshire / re-frame.trace / shadow-cljs / js-interop, it
    belongs in its consumer, not here. (story-mcp's `sensitive.cljc`
-   ns keeps a thin local alias over `re-frame.trace/sensitive?` for
+   ns keeps a thin local alias over `re-frame.privacy/sensitive?` for
    code-review locality — the predicate itself lives here.)

--- a/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
@@ -26,7 +26,7 @@
   classpath); story-mcp / causa-mcp are JVM-side and DO have the
   framework primitive available. The predicate itself
   (`(and (map? ev) (true? (:sensitive? ev)))`) is conservative and
-  identical to `re-frame.trace/sensitive?`; per the spec the runtime
+  identical to `re-frame.privacy/sensitive?`; per the spec the runtime
   always stamps the literal boolean. Consumers that want to bind to
   the framework primitive (story-mcp does, for code-review locality)
   alias the surface in their own ns and delegate through here.")

--- a/tools/story/src/re_frame/story/config.cljc
+++ b/tools/story/src/re_frame/story/config.cljc
@@ -29,7 +29,7 @@
   true (the registration call); to `nil` when false. Production code
   that accidentally requires a stories ns sees the namespace load but
   with no registrations, every Story query returns empty."
-  (:require [re-frame.trace :as trace])
+  (:require [re-frame.privacy :as privacy])
   #?(:cljs (:require-macros [re-frame.story.config])))
 
 ;; ---- the compile-time flag -----------------------------------------------
@@ -214,13 +214,14 @@
 
 (defn sensitive-event?
   "True iff the trace event `ev` carries `:sensitive? true` at the top
-  level. Thin alias over the framework-published `re-frame.trace/sensitive?`
-  predicate (re-exported as `re-frame.core/sensitive?`) — per rf2-sqxjn,
-  every consumer of `:sensitive?` (Causa, Story, story-mcp, pair2-mcp,
-  causa-mcp) composes against ONE framework primitive rather than
-  reimplementing the five-token check. Per Spec 009 §Privacy."
+  level. Thin alias over the framework-published `re-frame.privacy/sensitive?`
+  predicate (re-exported as `re-frame.core/sensitive?`) — per rf2-sqxjn
+  / rf2-iwqu9, every consumer of `:sensitive?` (Causa, Story,
+  story-mcp, pair2-mcp, causa-mcp) composes against ONE framework
+  primitive rather than reimplementing the five-token check. Per Spec
+  009 §Privacy."
   [ev]
-  (trace/sensitive? ev))
+  (privacy/sensitive? ev))
 
 (defn suppress-sensitive?
   "Should this trace event be suppressed by a Story-registered


### PR DESCRIPTION
## Summary

Audit finding A6 from rf2-spr6q: the privacy / sensitive? / redaction surface was scattered across three namespaces with duplicate state and three different reading paths for the same `:sensitive?` meta-key.

This PR establishes a single policy locus in `re-frame.privacy`:

- **`redacted-sentinel`** stays here as the single source of truth. `re-frame.elision`'s private `redacted-sentinel` becomes a re-export from `privacy/redacted-sentinel` (was a literal duplicate at `elision.cljc:430`).
- **`sensitive?-from-meta`** moves from `re-frame.trace` into `re-frame.privacy`. Three callers (router queue-time emit, event-emit fan-out, trace's `handler-scope-from-meta`) now consult the same helper; trace's `handler-scope-from-meta` inlines its own read to avoid the require cycle (privacy is downstream of trace).
- **`sensitive?` predicate** (the public reader off a trace event's top-level `:sensitive?` field) moves from `re-frame.trace` to `re-frame.privacy`. `re-frame.core/sensitive?` re-exports from privacy now.
- `re-frame.trace` retains `no-emit?-from-meta` — that's a trace-emit opt-out concept, not a privacy concept.

Doc upgrade: privacy.cljc's ns docstring is rewritten to spell out the architectural separation — trace is the emission site, privacy is the policy site.

Tool consumers (`tools/causa`, `tools/story`, `tools/mcp-base`) migrated to `privacy/sensitive?`.

Pre-alpha: no back-compat shims. The removed `trace/sensitive?` and `trace/sensitive?-from-meta` vars are gone, not aliased.

## Test plan

- [x] `npm run test:cljs` — 1818 tests, 5054 assertions, 0 failures.
- [x] `clojure -M:test` in `implementation/core/` — 456 tests, 2439 assertions, 0 failures.
- [x] `npm run test:bundle-isolation` — PASS.
- [x] Late-bind drift test still passes (`:privacy/clear-suppression-cache!` directory entry unchanged).
- [x] `sensitive-stamping-test` updated assertion: `(identical? rf/sensitive? privacy/sensitive?)`.

## Files

- `implementation/core/src/re_frame/privacy.cljc` — adds `sensitive?-from-meta` + `sensitive?` predicate, rewrites ns docstring.
- `implementation/core/src/re_frame/trace.cljc` — removes `sensitive?-from-meta` + `sensitive?` predicate; `handler-scope-from-meta` inlines the `:sensitive?` read.
- `implementation/core/src/re_frame/elision.cljc` — `redacted-sentinel` now re-exports from privacy.
- `implementation/core/src/re_frame/router.cljc` — `:sensitive?` reader switches to privacy.
- `implementation/core/src/re_frame/event_emit.cljc` — `:sensitive?` reader switches to privacy.
- `implementation/core/src/re_frame/core.cljc` — `sensitive?` re-export switches to privacy.
- Tool consumers (`tools/causa`, `tools/story`, `tools/mcp-base`) migrated.

Net: 11 files, +131 / -82 = +49 LoC. Cost is a richer privacy ns docstring; net win is one answer to "where does the privacy policy live?".