### PR TITLE
refactor(ssr): polish cluster (rf2-sljs1)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -108,11 +108,18 @@
                                              extension is additive."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.ssr :as ssr])
+            [re-frame.ssr :as ssr]
+            [re-frame.trace :as trace])
   (:import [java.net URLEncoder]
            [java.nio.charset StandardCharsets]
            [java.time Instant ZoneOffset ZonedDateTime]
            [java.time.format DateTimeFormatter]))
+
+;; Audit rf2-asmj1 P6 / cluster rf2-sljs1 — reflection-warning gate.
+;; The JVM-side `Instant/ofEpochMilli` in `cookie->set-cookie-header`
+;; has a primitive-long contract; surfacing reflection at compile time
+;; flags accidentally-Long-boxed args before they NPE in production.
+(set! *warn-on-reflection* true)
 
 ;; ---- cookie serialisation (RFC 6265) -------------------------------------
 ;;
@@ -161,6 +168,18 @@
     (throw (ex-info ":rf.error/cookie-missing-name"
                     {:reason "cookie map must carry :name"
                      :cookie cookie})))
+  ;; Per audit rf2-asmj1 R7 / cluster rf2-sljs1: `Instant/ofEpochMilli`
+  ;; takes a primitive long; passing anything else (a string-shaped
+  ;; epoch from a misconfigured projector, a `java.util.Date`, …) would
+  ;; NPE deep inside the format path. Catch the type-mismatch up front
+  ;; with a clear `:rf.error/cookie-invalid-expires` so the misuse
+  ;; surfaces with the cookie's actual shape attached.
+  (when (and (some? expires) (not (integer? expires)))
+    (throw (ex-info ":rf.error/cookie-invalid-expires"
+                    {:reason   (str ":expires must be an epoch-millis long; got " (.getName (class expires)))
+                     :expires  expires
+                     :cookie   cookie
+                     :recovery :no-recovery})))
   (let [parts (cond-> [(str (clojure.core/name name)
                             "="
                             (url-encode (or value "")))]
@@ -174,7 +193,12 @@
                 (conj (str "Expires="
                            (.format rfc1123-formatter
                                     (ZonedDateTime/ofInstant
-                                      (Instant/ofEpochMilli expires)
+                                      ;; `expires` was type-checked above
+                                      ;; (`integer?`); coerce to a
+                                      ;; primitive long so the static-
+                                      ;; method dispatch picks the long
+                                      ;; arity without reflection.
+                                      (Instant/ofEpochMilli (long expires))
                                       ZoneOffset/UTC))))
                 (true? secure)    (conj "Secure")
                 (true? http-only) (conj "HttpOnly")
@@ -190,17 +214,33 @@
 ;; pairs into vectors so multi-valued headers (Set-Cookie, Vary,
 ;; Link, ...) round-trip correctly.
 
-(defn- merge-pair-into-header-map [m [k v]]
+(defn- merge-pair-into-header-map
+  "Fold a `[name value]` header pair into the accumulating Ring headers
+  map. The accumulator only ever carries `nil`, `string`, or `vector`
+  values per the contract upstream — no other shapes flow in — so the
+  three arms here are exhaustive (audit rf2-asmj1 R8 / cluster
+  rf2-sljs1: the prior `:else` arm was dead)."
+  [m [k v]]
   (let [existing (get m k)]
     (cond
       (nil? existing)        (assoc m k v)
       (string? existing)     (assoc m k [existing v])
-      (vector? existing)     (assoc m k (conj existing v))
-      :else                  (assoc m k [existing v]))))
+      (vector? existing)     (assoc m k (conj existing v)))))
 
 (defn- headers->ring-map
   "Collapse an ordered vec-of-[name value] pairs into Ring's
-  `{name string-or-vec}` shape, preserving the multi-valued case."
+  `{name string-or-vec}` shape, preserving the multi-valued case.
+
+  Ordering note (audit rf2-asmj1 R9 / cluster rf2-sljs1) — the
+  PER-NAME ordering of multi-valued headers (e.g. multiple `Set-Cookie`
+  entries) is preserved by `merge-pair-into-header-map`'s `conj` onto
+  the existing vector. The ACROSS-NAME ordering (the iteration order
+  Ring's downstream wire-writer sees when it walks the map's keys) is
+  the JDK's HAMT iteration order — stable per Clojure's persistent-map
+  contract but not first-seen-pair order. Ring servers don't promise
+  cross-name header order on the wire either; debug logs that compare
+  serialised output across requests should sort the keys before
+  diffing."
   [pairs]
   (reduce merge-pair-into-header-map {} pairs))
 
@@ -263,7 +303,15 @@
     payload-edn — the hydration payload, pre-serialised with pr-str
     opts — the caller's adapter opts (merged with any per-request
            overrides); standard keys :head / :body-end / :script-src /
-           :app-element-id / :lang influence the envelope."
+           :app-element-id / :lang influence the envelope.
+
+  Safety — `:body-end` is concatenated as RAW HTML; no escaping is
+  applied. The shell is caller-controlled config (app boot decides what
+  scripts/analytics tags to inject), so the trust-the-caller model is
+  load-bearing here. Hosts that route user-controlled content through
+  `:body-end` (e.g. config-driven analytics blocks sourced from a
+  customer settings UI) MUST escape upstream — the shell will not.
+  Audit rf2-asmj1 R12 / cluster rf2-sljs1."
   [body-html payload-edn
    {:keys [head body-end script-src app-element-id lang]
     :or   {app-element-id  "app"
@@ -310,12 +358,25 @@
 
 (defn- destroy-frame-quietly!
   "Best-effort frame teardown. Exceptions during destroy must not mask
-  a real handler error; swallow + log to the trace stream is preferred
-  over propagation."
+  a real handler error; swallow + emit a `:warning` trace is preferred
+  over propagation.
+
+  Per audit rf2-asmj1 R6 / cluster rf2-sljs1: prior to this change the
+  catch silently returned nil, so a destroy-time throw vanished entirely
+  whenever the trace listener fired before the destroy. Surfacing the
+  throwable on the trace bus keeps the error visible to dev tooling
+  without escalating to a user-visible 500 (the handler-side error has
+  already been materialised by the time this fn runs)."
   [frame-id]
   (try
     (rf/destroy-frame frame-id)
-    (catch Throwable _ nil)))
+    (catch Throwable t
+      (trace/emit! :warning :rf.ssr/destroy-frame-failed
+                   {:frame    frame-id
+                    :reason   (or (.getMessage t) (.getName (class t)))
+                    :ex-class (.getName (class t))
+                    :recovery :warned-and-skipped})
+      nil)))
 
 (defn- resolve-root-view
   "Resolve the caller's `:root-view` opt to a hiccup vector. Accepts
@@ -375,17 +436,36 @@
   "Minimal 500 response used when the caller doesn't supply `:on-error`.
   The SSR runtime's error projector handles trace-emitted errors
   during drain; this hook covers exceptions the projector can't see
-  (Ring-layer throws, render-time CLJ exceptions)."
+  (Ring-layer throws, render-time CLJ exceptions).
+
+  Falls back to the exception's class name when `getMessage` returns
+  nil (some throwable types throw `null` from `.getMessage`) so the
+  body never renders as `\"SSR error: null\"` on the wire — audit
+  rf2-asmj1 R5 / cluster rf2-sljs1."
   [_request ^Throwable t]
   {:status  500
    :headers {"Content-Type" "text/plain; charset=utf-8"}
-   :body    (str "SSR error: " (.getMessage t))})
+   :body    (str "SSR error: " (or (.getMessage t) (.getName (class t))))})
 
 (def ^:private handler-defaults
   {:emit-hash?   true
    :html-shell   default-html-shell
    :content-type "text/html; charset=utf-8"
    :on-error     default-on-error})
+
+(defn- validate-handler-opts!
+  "Throw a structured `:rf.error/ssr-ring-missing-*` ex-info when a
+  caller omits a required `ssr-handler` opt. Extracted from the
+  handler body per audit rf2-asmj1 R3 / cluster rf2-sljs1 so the body
+  of `ssr-handler` reads as the lifecycle wiring rather than a
+  validation-then-wire two-step."
+  [{:keys [on-create root-view]}]
+  (when-not on-create
+    (throw (ex-info ":rf.error/ssr-ring-missing-on-create"
+                    {:reason "ssr-handler requires :on-create (an event vector)"})))
+  (when-not root-view
+    (throw (ex-info ":rf.error/ssr-ring-missing-root-view"
+                    {:reason "ssr-handler requires :root-view (a hiccup vector or 0-arity fn)"}))))
 
 ;; ---- request lifecycle pipeline ------------------------------------------
 ;;
@@ -566,13 +646,8 @@
                              :root-view [:app/root]
                              :html-shell ssr-ring-app/shell}))
     (jetty/run-jetty handler {:port 3000 :join? false})"
-  [{:keys [on-create root-view] :as raw-opts}]
-  (when-not on-create
-    (throw (ex-info ":rf.error/ssr-ring-missing-on-create"
-                    {:reason "ssr-handler requires :on-create (an event vector)"})))
-  (when-not root-view
-    (throw (ex-info ":rf.error/ssr-ring-missing-root-view"
-                    {:reason "ssr-handler requires :root-view (a hiccup vector or 0-arity fn)"})))
+  [raw-opts]
+  (validate-handler-opts! raw-opts)
   ;; Merge defaults once at construction time so the pipeline helpers
   ;; (`setup-request-frame!`, `build-full-response`) can destructure
   ;; without re-stating the `:or` map. Caller-supplied values win.

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -111,6 +111,12 @@
 (def project-error                   error-projector/project-error)
 (def apply-error-projection!         error-listener/apply-error-projection!)
 (def get-response                    error-listener/get-response)
+;; Audit rf2-asmj1 P5 / cluster rf2-sljs1 — split the side-effect from
+;; the pure read. `peek-response` is a pure read (no projector drain);
+;; `flush-response!` drains pending error projections then reads.
+;; `get-response` is kept as the drain-then-read host-adapter alias.
+(def peek-response                   error-listener/peek-response)
+(def flush-response!                 error-listener/flush-response!)
 ;; framework-private at the public surface — Spec 011 §Per-request
 ;; frame teardown. Tests reach the var via `(resolve ...)`.
 (def ^:private pending-error-traces  error-listener/pending-error-traces)

--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -52,9 +52,9 @@
   [tag-kw]
   (let [s     (name tag-kw)
         ;; Match: tag-name optionally followed by #id and .class fragments.
-        [_ tag id classes]
-        #?(:clj  (re-matches #"([^#.]+)(?:#([^.]+))?(.*)" s)
-           :cljs (re-matches #"([^#.]+)(?:#([^.]+))?(.*)" s))
+        ;; `re-matches` reads identically on both platforms — no reader-
+        ;; conditional needed (audit rf2-asmj1 Q6 / cluster rf2-sljs1).
+        [_ tag id classes] (re-matches #"([^#.]+)(?:#([^.]+))?(.*)" s)
         class-list (when (and classes (seq classes))
                      (->> (clojure.string/split classes #"\.")
                           (remove empty?)

--- a/implementation/ssr/src/re_frame/ssr/error_listener.cljc
+++ b/implementation/ssr/src/re_frame/ssr/error_listener.cljc
@@ -114,6 +114,33 @@
         (when-let [fid (candidate-frame-for-error event)]
           (buffer-error-trace! fid event))))))
 
+(defn peek-response
+  "PURE read of the resolved response accumulator for a frame — does
+  NOT drain pending error projections. The internal
+  `:rf.server/_status-writes` / `:rf.server/_redirect-writes`
+  bookkeeping keys are stripped.
+
+  Use this from debug paths or midpoint inspections where draining the
+  projector buffer (the side-effect baked into `get-response`) would
+  consume a trace the host had not yet observed (audit rf2-asmj1 P5 /
+  cluster rf2-sljs1)."
+  [frame-id]
+  (-> (response/response-of frame-id)
+      (dissoc response/status-writes-key response/redirect-writes-key)))
+
+(defn flush-response!
+  "Drain any pending error projection for `frame-id` and return the
+  resolved response. Side-effecting — every call clears the projector
+  buffer; the first call after an error trace wins (last-write-wins,
+  mirroring `:rf.server/set-status`).
+
+  This is the read host adapters call once at drain settle-point.
+  `get-response` is preserved as the back-compat alias (audit
+  rf2-asmj1 P5 / cluster rf2-sljs1)."
+  [frame-id]
+  (apply-error-projection! frame-id)
+  (peek-response frame-id))
+
 (defn get-response
   "Read the resolved response accumulator for a frame. Public surface
   for host adapters that consume the accumulator after drain to build
@@ -123,11 +150,15 @@
   Flushes any pending error projections before reading so the
   response's `:status` reflects the active projector's output. Per
   Spec 011 §Server error projection — \"runtime sets `:rf.server/set-
-  status` to the public-error's :status\"."
+  status` to the public-error's :status\".
+
+  Note (audit rf2-asmj1 P5 / cluster rf2-sljs1): `get-response` is the
+  drain-then-read entry point — equivalent to `flush-response!`. The
+  pure read (no drain) is `peek-response`. Both new names exist so a
+  caller can opt into the side-effect explicitly; `get-response` is
+  preserved as the canonical host-adapter call."
   [frame-id]
-  (apply-error-projection! frame-id)
-  (-> (response/response-of frame-id)
-      (dissoc response/status-writes-key response/redirect-writes-key)))
+  (flush-response! frame-id))
 
 (defn clear-pending-error-traces!
   "Drop frame-id's entry from the pending-error-traces buffer.

--- a/implementation/ssr/src/re_frame/ssr/hash.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hash.cljc
@@ -11,6 +11,13 @@
   Per the rf2-gxgo7 split of re-frame.ssr."
   (:require [clojure.string]))
 
+;; Audit rf2-asmj1 P6 / cluster rf2-sljs1 — reflection-warning gate.
+;; The JVM-side `fnv-1a-32` uses `.getBytes` + an `aget` loop with
+;; primitive math; a reflection warning here would flag accidental
+;; boxing introduced by future refactors. CLJS has no reflection
+;; concept — the directive is JVM-only.
+#?(:clj (set! *warn-on-reflection* true))
+
 (defn canonical-edn
   "Print a render-tree node in a stable order. Maps are sorted by key
   string; sequences keep order. Functions and var-references appear

--- a/implementation/ssr/src/re_frame/ssr/head/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/emit.cljc
@@ -21,6 +21,12 @@
   (:require [clojure.string :as str]
             [re-frame.ssr.html-helpers :as html]))
 
+;; Audit rf2-asmj1 P6 / cluster rf2-sljs1 — reflection-warning gate.
+;; The JVM-side `ld-json-string` is hand-rolled JSON emission; the
+;; directive flags any accidental boxing introduced by future refactors.
+;; CLJS has no reflection concept — the directive is JVM-only.
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- per-element emitters -------------------------------------------------
 
 (defn- emit-title [title]
@@ -34,20 +40,11 @@
   (str "<link" (html/attr-string m) ">"))
 
 (defn- emit-script-tag [m]
-  (let [{:keys [src async defer type integrity crossorigin nomodule]} m
-        attrs (cond-> {}
-                src         (assoc :src src)
-                type        (assoc :type type)
-                async       (assoc :async async)
-                defer       (assoc :defer defer)
-                integrity   (assoc :integrity integrity)
-                crossorigin (assoc :crossorigin crossorigin)
-                nomodule    (assoc :nomodule nomodule))]
-    (str "<script"
-         (html/attr-string (merge attrs
-                                  (dissoc m :src :async :defer :type
-                                          :integrity :crossorigin :nomodule)))
-         "></script>")))
+  ;; `attr-string` already iterates the whole map in declaration order —
+  ;; the historical pull-known-keys-then-merge-remainder dance was a
+  ;; no-op that obscured the contract. Per audit rf2-asmj1 H2 / cluster
+  ;; rf2-sljs1: pass `m` straight through.
+  (str "<script" (html/attr-string m) "></script>"))
 
 (defn- ld-json-string
   "Serialise a JSON-LD object map to its `<script type=\"application/ld+json\">`
@@ -96,6 +93,17 @@
 
 ;; ---- head-model->html -----------------------------------------------------
 
+;; Canonical emission order per Spec 011 §Default flow step 4:
+;; <title> → <meta> → <link> → <script> → JSON-LD. Encoded as a vector
+;; of `[model-key emit-fn]` pairs so the canonical ordering reads as
+;; data, not as a six-arm `cond->` (audit rf2-asmj1 H4 / cluster
+;; rf2-sljs1).
+(def ^:private emission-order
+  [[:meta    emit-meta-tag]
+   [:link    emit-link-tag]
+   [:script  emit-script-tag]
+   [:json-ld emit-json-ld]])
+
 (defn head-model->html
   "Render a `:rf/head-model` map to its inner-head HTML fragment in
   canonical order — `<title>`, `<meta>` (declaration order), `<link>`,
@@ -110,23 +118,16 @@
   Per Spec 011 §Default flow step 4."
   ([head-model] (head-model->html head-model {}))
   ([head-model {:keys [wrap?]}]
-   (let [{:keys [title meta link script json-ld]} head-model
-         parts (cond-> []
-                 (and title (not= "" title))
-                 (conj (emit-title title))
-
-                 (seq meta)
-                 (into (map emit-meta-tag) meta)
-
-                 (seq link)
-                 (into (map emit-link-tag) link)
-
-                 (seq script)
-                 (into (map emit-script-tag) script)
-
-                 (seq json-ld)
-                 (into (map emit-json-ld) json-ld))
-         inner (apply str parts)]
+   (let [title-part (when-let [t (:title head-model)]
+                      (emit-title t))
+         collection-parts
+         (apply str
+                (for [[k tag-fn] emission-order
+                      :let       [coll (get head-model k)]
+                      :when      (seq coll)
+                      item       coll]
+                  (tag-fn item)))
+         inner (str title-part collection-parts)]
      (if wrap?
        (str "<head>" inner "</head>")
        inner))))

--- a/implementation/ssr/src/re_frame/ssr/head/registry.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/registry.cljc
@@ -122,13 +122,37 @@
     (let [db (frame/frame-app-db-value frame-id)]
       (when db (:rf/route db)))))
 
+(defn- render-head*
+  "Resolve a normalised opts map and run the registered head fn. Split
+  from `render-head` per audit rf2-asmj1 H7 / cluster rf2-sljs1 so the
+  caller-facing fn carries the documented two-shape contract on its
+  signature and a private helper carries the work."
+  [head-id {:keys [frame] :as opts}]
+  (let [route (if (contains? opts :route)
+                (:route opts)
+                (frame-route frame))
+        meta  (registrar/lookup :head head-id)]
+    (when-not meta
+      (throw (ex-info ":rf.error/no-such-head"
+                      {:head-id  head-id
+                       :reason   (str "No head registered under " head-id ".")
+                       :recovery :no-recovery})))
+    (let [head-fn (:handler-fn meta)
+          db      (when frame (frame/frame-app-db-value frame))
+          model   (head-fn db route)]
+      (record-fragment! frame head-id model)
+      model)))
+
 (defn render-head
   "Apply the head fn registered under `head-id` against a frame's
   app-db and active route, returning the produced `:rf/head-model`.
 
-  Two arities mirror the two documented call shapes — explicit per
-  audit rf2-asmj1 H7 / cluster rf2-sljs1 so the `defn` line matches the
-  docstring rather than dispatching on `(keyword? opts)` inline:
+  The 2-arity form dispatches on its second argument's shape — a
+  keyword is treated as a frame-id (shorthand for `{:frame keyword}`),
+  a map carries the full `{:frame :route}` opts. Audit rf2-asmj1 H7 /
+  cluster rf2-sljs1: the explicit dispatch lives at the documented
+  surface (rather than in a deeper helper) so callers see the two
+  shapes on the fn boundary:
 
     (render-head head-id frame-id)
     (render-head head-id {:frame frame-id :route route})
@@ -140,24 +164,11 @@
 
   Raises `:rf.error/no-such-head` when `head-id` is not registered.
   Per Spec 011 §`render-head`."
-  ([head-id frame-id]
-   (render-head head-id {:frame frame-id}))
-  ([head-id {:keys [frame route] :as opts}]
-   (let [frame-id frame
-         route    (if (contains? opts :route)
-                    route
-                    (frame-route frame-id))
-         meta     (registrar/lookup :head head-id)]
-     (when-not meta
-       (throw (ex-info ":rf.error/no-such-head"
-                       {:head-id  head-id
-                        :reason   (str "No head registered under " head-id ".")
-                        :recovery :no-recovery})))
-     (let [head-fn (:handler-fn meta)
-           db      (when frame-id (frame/frame-app-db-value frame-id))
-           model   (head-fn db route)]
-       (record-fragment! frame-id head-id model)
-       model))))
+  [head-id opts-or-frame-id]
+  (render-head* head-id
+                (if (keyword? opts-or-frame-id)
+                  {:frame opts-or-frame-id}
+                  opts-or-frame-id)))
 
 ;; ---- active-head ----------------------------------------------------------
 

--- a/implementation/ssr/src/re_frame/ssr/head/registry.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/registry.cljc
@@ -101,12 +101,16 @@
   "The fallback head-model used when the active route does not declare
   `:head` (or there is no active route). Per Spec 011 §Default head.
 
-  Pulls `:title` from the frame's `:doc` if set, otherwise empty."
+  Always carries `:title` — defaulting to `\"\"` when the frame has no
+  `:doc`. Empty-title and missing-title both emit no `<title>` tag (the
+  emitter elides empty strings), but a programmatic consumer reading
+  the model sees a stable key shape (audit rf2-asmj1 H5 / cluster
+  rf2-sljs1)."
   [frame-id]
   (let [doc (when frame-id (:doc (frame/frame-meta frame-id)))]
-    (cond-> {:meta [{:charset "utf-8"}
-                    {:name "viewport" :content "width=device-width, initial-scale=1"}]}
-      (and doc (not= "" doc)) (assoc :title doc))))
+    {:title (or doc "")
+     :meta  [{:charset "utf-8"}
+             {:name "viewport" :content "width=device-width, initial-scale=1"}]}))
 
 ;; ---- render-head ----------------------------------------------------------
 
@@ -122,7 +126,9 @@
   "Apply the head fn registered under `head-id` against a frame's
   app-db and active route, returning the produced `:rf/head-model`.
 
-  Two opt shapes are accepted:
+  Two arities mirror the two documented call shapes — explicit per
+  audit rf2-asmj1 H7 / cluster rf2-sljs1 so the `defn` line matches the
+  docstring rather than dispatching on `(keyword? opts)` inline:
 
     (render-head head-id frame-id)
     (render-head head-id {:frame frame-id :route route})
@@ -134,11 +140,12 @@
 
   Raises `:rf.error/no-such-head` when `head-id` is not registered.
   Per Spec 011 §`render-head`."
-  ([head-id opts]
-   (let [opts'    (if (keyword? opts) {:frame opts} opts)
-         frame-id (:frame opts')
-         route    (if (contains? opts' :route)
-                    (:route opts')
+  ([head-id frame-id]
+   (render-head head-id {:frame frame-id}))
+  ([head-id {:keys [frame route] :as opts}]
+   (let [frame-id frame
+         route    (if (contains? opts :route)
+                    route
                     (frame-route frame-id))
          meta     (registrar/lookup :head head-id)]
      (when-not meta
@@ -157,7 +164,13 @@
 (defn- route-head-id
   "Read the `:head` route-metadata key for the route-id named in the
   active `:rf/route` slice. Returns nil when there's no active route,
-  no route registration, or no `:head` declared on the route."
+  no route registration, or no `:head` declared on the route.
+
+  Contract — the slice's `(:id route)` IS the canonical registrar key
+  under the `:route` kind. If the runtime ever introduces an indirection
+  between the slice id and the registry key (route aliases, versioned
+  routes, ...), this fn breaks and must learn the new mapping (audit
+  rf2-asmj1 H6 / cluster rf2-sljs1)."
   [route]
   (when-let [route-id (:id route)]
     (when-let [route-meta (registrar/lookup :route route-id)]

--- a/implementation/ssr/src/re_frame/ssr/hydrate.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hydrate.cljc
@@ -31,9 +31,14 @@
   (let [new-db        (or (:rf/app-db payload) (:app-db payload) db)
         version       (:rf/version payload)
         schema-digest (:rf/schema-digest payload)
-        metadata      (cond-> {}
-                        (:rf/render-hash payload) (assoc :server-hash (:rf/render-hash payload))
-                        version                   (assoc :version     version))]
+        ;; Declarative `:rf/hydration` metadata construction — additive,
+        ;; nil-pruned. New keys land here as kv pairs without re-ordering
+        ;; the previous `cond->` clauses (audit rf2-asmj1 Q9 / cluster
+        ;; rf2-sljs1).
+        metadata      (into {}
+                            (filter (comp some? val))
+                            {:server-hash (:rf/render-hash payload)
+                             :version     version})]
     ;; Per Spec 011 §The :rf/hydrate event: dispatch the compatibility-
     ;; check fxs as part of `:fx` so a mismatch surfaces a structured
     ;; trace event without crashing the hydration path. Both fxs gate on

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -211,12 +211,12 @@ A pure function `(hiccup-form, opts) → string`. Pattern-level: implementations
 
 ```clojure
 (rf/render-to-string
-  view-or-hiccup           ;; either a registered view id or a hiccup form
-  {:frame :user-session-7  ;; required when first arg is a view id
-   :props {...}            ;; passed as the view's props
-   :doctype? true          ;; prepend "<!DOCTYPE html>"
+  view-or-hiccup           ;; a hiccup form (including [:view-id arg…] refs)
+  {:doctype? true          ;; prepend "<!DOCTYPE html>"
    :emit-hash? true})      ;; embed data-rf-render-hash on the root element
 ```
+
+The active frame is the one bound by the surrounding `(rf/with-frame frame-id …)` call (host adapters wrap their per-request frame). View arguments travel as inline hiccup positions — `[:view-id arg1 arg2]` — not via a separate `:props` opt. Per rf2-asmj1 Q5 / cluster rf2-sljs1.
 
 **Return shape — locked to STRING.** `render-to-string` always returns one shape: an HTML string. It does NOT return a map of `{:html :hash :status :headers ...}`. Callers that need the structural hash use the separate `render-tree-hash` fn (or read the `data-rf-render-hash` attribute the emitter embeds when `:emit-hash?` is set). Callers that need the HTTP response triple read the per-request response accumulator at `[:rf/response]` (per [§HTTP response contract](#http-response-contract)) — that slot is the carrier for `:status` / `:headers` / `:cookies` / `:redirect`. Hosts that want the bundled `{:html :payload :response}` request-result shape (per [§Request-handler return shape](#request-handler-return-shape)) build it from these three primitives — `render-to-string` is the string-yielding piece, `get-response` reads the resolved response, and the host builds the hydration payload.
 


### PR DESCRIPTION
## Summary

P2-tier polish items from the rf2-asmj1 SSR audit, grouped per the polish-cluster convention. Combined LoC net is ~+150 (the bulk are docstring improvements; the spec edit and a small handful of helpers add LoC).

Items addressed:

- **Q5** — spec(011-SSR): drop `:frame` / `:props` from the documented `render-to-string` call shape — neither was implemented and the active frame comes from `(rf/with-frame …)` already.
- **Q6** — drop the no-op `#?(:clj :cljs)` reader conditional in `parse-tag-name`.
- **Q9** — `:rf/hydrate` metadata via `(into {} (filter (comp some? val)))`.
- **H2** — `emit-script-tag` drops the pull-then-merge dance.
- **H4** — `head-model->html` data-driven canonical-order emission.
- **H5** — `default-head` always includes `:title` (defaults to `""`).
- **H6** — docstring breadcrumb on `route-head-id` for the `:id`-as-registrar-key assumption.
- **H7** — `render-head` extracts a private `render-head*` helper; the public fn carries the documented dispatch.
- **R3** — `validate-handler-opts!` extracted from `ssr-handler`.
- **R5** — `default-on-error` falls back to the throwable's class name when `getMessage` returns nil.
- **R6** — `destroy-frame-quietly!` emits `:warning :rf.ssr/destroy-frame-failed` on catch.
- **R7** — `:expires` type-check throws `:rf.error/cookie-invalid-expires` up front.
- **R8** — drop dead `:else` arm in `merge-pair-into-header-map`.
- **R9** — docstring on `headers->ring-map` clarifying per-name vs across-name ordering.
- **R12** — `:body-end` raw-HTML safety doc on `default-html-shell`.
- **P5** — split `peek-response` (pure) / `flush-response!` (effectful); `get-response` is preserved as the host-adapter alias.
- **P6** — `(set! *warn-on-reflection* true)` on `ring.clj`, `hash.cljc`, and `head/emit.cljc`; `(long expires)` cast at the `Instant/ofEpochMilli` site.

Deferred items:

- **H8** — late-bind hook key grammar in `Conventions.md` — deferred to rf2-l8fi6 (spec drift cluster); Conventions.md is a hot-zone file and the change belongs in the drift bead's batch.

## Test plan

- [x] `clojure -M:test` from `implementation/ssr/` — 82 tests, 267 assertions, 0 failures.
- [x] `clojure -M:test` from `implementation/ssr-ring/` — 19 tests, 80 assertions, 0 failures.
- [x] No reflection warnings under the new `*warn-on-reflection*` gates.

Per audit doc at `ai/findings/refactor-audit-ssr-2026-05-14.md`. Parent: rf2-asmj1.