### PR TITLE
spec(story-mcp): correct tool-count drift in 001-Wire-Protocol.md (rf2-u7vjp)

### DIFF
--- a/tools/story-mcp/spec/001-Wire-Protocol.md
+++ b/tools/story-mcp/spec/001-Wire-Protocol.md
@@ -37,7 +37,7 @@ the contract is "tools only."
 | JSON-RPC method | Behaviour |
 |---|---|
 | `initialize` | Performs handshake; returns advertised capabilities + protocol version + server info. |
-| `tools/list` | Returns the full 16-tool registry (Dev / Docs / Testing / Write). |
+| `tools/list` | Returns the full 17-tool registry (Dev / Docs / Testing / Write). |
 | `tools/call` | Dispatches the named tool with `arguments`; returns content + structuredContent + optional `isError`. |
 | `ping` | Returns `{}`. Health check. |
 | `shutdown` | Cleanly stops the run-loop. |
@@ -99,7 +99,7 @@ Returns the tool registry verbatim — name, description, JSON-Schema
 input schema, optional output schema. Order is stable but not
 contractually relevant; agents iterate by name.
 
-The 16 tools are enumerated in
+The 17 tools are enumerated in
 [`002-Tool-Registry.md`](002-Tool-Registry.md).
 
 ## `tools/call`
@@ -146,7 +146,7 @@ Stage 7's tests cover each of these paths.
 
 ## Cross-references
 
-- [`002-Tool-Registry.md`](002-Tool-Registry.md) — the 16 tools.
+- [`002-Tool-Registry.md`](002-Tool-Registry.md) — the 17 tools.
 - [`003-Write-Surface-Gating.md`](003-Write-Surface-Gating.md) —
   how the gate fails (clean error, not no-op).
 - [`API.md`](API.md) — per-tool input/output shapes.


### PR DESCRIPTION
## Summary

`tools/story-mcp/spec/001-Wire-Protocol.md` said `16` in three places (methods table, `tools/list` paragraph, cross-references list); the registry actually ships **17** tools. Sibling `002-Tool-Registry.md` was already correct after rf2-luhdu landed `record-as-variant`; this PR brings 001 in lockstep.

Verified the count against `tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc` after the rf2-3ukix split:

- `tools.dev/descriptors` — 3 (`get-story-instructions`, `preview-variant`, `list-substrates`)
- `tools.docs/descriptors` — 7 (`list-stories`, `get-story`, `get-variant`, `list-tags`, `list-modes`, `list-assertions`, `variant->edn`)
- `tools.testing/descriptors` — 4 (`run-variant`, `snapshot-identity`, `run-a11y`, `read-failures`)
- `tools.write/descriptors` — 2 (`register-variant`, `unregister-variant`)
- `tools.recorder/descriptor` — 1 (`record-as-variant`)

Total: **17**.

Spec-only; no implementation change.

Closes rf2-u7vjp. Discovered from rf2-1sdzn (audit).

## Test plan

- [x] Visual diff of `001-Wire-Protocol.md` (three single-digit edits)
- [x] Cross-check vs. `registry.cljc` post-rf2-3ukix split
- [x] No other `16` references remain in the doc