### PR TITLE
fix(scripts): drift checker MAPPINGS post-rf2-47g8l registry move (rf2-0l82a)

### DIFF
--- a/scripts/check_skill_mcp_drift.py
+++ b/scripts/check_skill_mcp_drift.py
@@ -90,11 +90,11 @@ class Mapping:
 MAPPINGS: list[Mapping] = [
     Mapping(
         name="pair2-mcp <-> re-frame-pair2",
-        # Post rf2-vrbwx the eleven-tool catalogue lives in a dedicated
-        # `descriptors.cljs` leaf — the parent `tools.cljs` is now just a
-        # façade carrying the `case` dispatch (string match arms, no
-        # `{:name "..."}` literals). Point the gate at the catalogue.
-        server_src=REPO_ROOT / "tools" / "pair2-mcp" / "src" / "re_frame_pair2_mcp" / "tools" / "descriptors.cljs",
+        # Post rf2-47g8l the eleven-tool catalogue data lives in a dedicated
+        # `descriptors_data.cljs` leaf — the sibling `descriptors.cljs` is
+        # now a slim splicer/façade with no `{:name "..."}` literals. Point
+        # the gate at the data file.
+        server_src=REPO_ROOT / "tools" / "pair2-mcp" / "src" / "re_frame_pair2_mcp" / "tools" / "descriptors_data.cljs",
         host_prefix="re-frame-pair2",
         skill_md=REPO_ROOT / "skills" / "re-frame-pair2" / "SKILL.md",
     ),


### PR DESCRIPTION
## Summary

- **rf2-0l82a**: pair2-mcp drift gate has been red on main since #931 (rf2-47g8l) moved tool-descriptor data from `tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors.cljs` into a dedicated `descriptors_data.cljs` leaf. The drift script's MAPPINGS still pointed at the old file, which is now a slim splicer with zero `{:name \"...\"}` literals — so the gate enumerated 0 server tools and fired 11 phantom missing-in-server findings.
- One-line `server_src` update (plus refreshed comment) restores tool discovery.

## Verification

Locally:

```
$ python scripts/check_skill_mcp_drift.py --verbose --ci
pair2-mcp <-> re-frame-pair2: server=11 tools, skill=11 allow-listed.
```

Zero drift on the pair2-mcp mapping post-fix (matches the eleven-tool catalogue: discover-app, eval-cljs, dispatch, trace-window, watch-epochs, tail-build, snapshot, get-path, subscribe, unsubscribe, subscription-info).

The script still exits 1 on this branch — but exclusively for the **story-mcp** mapping, which is a separate breakage from rf2-3ukix (parent `tools.cljc` was split into per-category leaves under `tools/story-mcp/.../tools/`). That's tracked as companion bead **rf2-7qxji** — same gate, different fix shape (multi-file source), out of scope for this PR.

## Test plan

- [x] Local script run: pair2-mcp mapping reports `server=11 tools, skill=11 allow-listed.`, no drift findings.
- [ ] CI: `Verify skill ↔ MCP allowed-tools drift` step turns green on pair2-mcp mapping (still red overall pending rf2-7qxji).