### PR TITLE
spec(ssr): align Spec 011 + impl drift cluster + H8 hook grammar (rf2-l8fi6)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -108,6 +108,7 @@
                                              extension is additive."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.late-bind :as late-bind]
             [re-frame.ssr :as ssr]
             [re-frame.trace :as trace])
   (:import [java.net URLEncoder]
@@ -336,19 +337,59 @@
 
 ;; ---- payload construction ------------------------------------------------
 
+(def ^:private default-pattern-protocol-version
+  "The v1 pattern-protocol version stamp (per Spec-Schemas
+  §`:rf/hydration-payload` line 1839 — \"integer; v1 = 1\"). Used as the
+  terminal fallback in `resolve-version` so the canonical payload key
+  is always present (Malli `:int` slot, not `:optional`)."
+  1)
+
+(defn- resolve-version
+  "Pick the `:rf/version` value to ship in the hydration payload. The
+  resolution order is:
+
+    1. An explicit `:version` opt from the caller (host-supplied stamp;
+       wins so test fixtures and apps that ship their own version source
+       stay in control).
+    2. The framework-global `:rf2/runtime-version` late-bind hook — the
+       same source the client-side `:rf.ssr/check-version` fx reads. When
+       the host registers this hook at boot, both sides of the wire pin
+       the same value with no further wiring (per Spec 011 §The hydration
+       payload + §fx-input shape + Conventions §Late-bind hook key
+       grammar).
+    3. `default-pattern-protocol-version` (v1 = 1) — the canonical schema
+       slot is required (per Spec-Schemas §`:rf/hydration-payload`), so a
+       terminal numeric fallback is structurally necessary. The
+       check-version fx still no-ops cleanly on the client when neither
+       side has the hook registered (matched value → no mismatch).
+
+  Audit rf2-asmj1 S8 / cluster rf2-l8fi6: prior to this the adapter
+  hard-coded `(or version 1)` inline, which silently disagreed with
+  whatever the client-side `:rf2/runtime-version` hook returned and
+  defeated the version-mismatch check on every host that hadn't passed
+  `:version` explicitly. Threading both sides through the same hook
+  eliminates the silent-divergence trap; the terminal `1` is the v1
+  pattern-protocol stamp, named instead of inlined so the convention
+  travels back to Spec-Schemas via search."
+  [explicit-version]
+  (or explicit-version
+      (when-let [f (late-bind/get-fn :rf2/runtime-version)]
+        (f))
+      default-pattern-protocol-version))
+
 (defn- build-payload
   "Per Spec 011 §The hydration payload — emit the four canonical keys
   (`:rf/version`, `:rf/frame-id`, `:rf/app-db`, `:rf/render-hash`)
   plus the optional `:rf/schema-digest`. Schema-digest is supplied
   by the caller when their app participates in the schema-digest
-  check; nil otherwise. `:or` defaults at destructure don't fire
-  when an explicit nil flows in, so use `or` at the call site to
-  default the version."
+  check; nil otherwise. Version source-of-truth: `resolve-version`
+  above — caller opt wins, falling back to the `:rf2/runtime-version`
+  late-bind hook so server and client read from the same source."
   [frame-id app-db render-hash {:keys [version schema-digest payload-keys]}]
   (let [db-slice (if (seq payload-keys)
                    (select-keys app-db payload-keys)
                    app-db)]
-    (cond-> {:rf/version     (or version 1)
+    (cond-> {:rf/version     (resolve-version version)
              :rf/frame-id    frame-id
              :rf/app-db      db-slice
              :rf/render-hash render-hash}

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -61,7 +61,7 @@ The `:rf/hydration-payload` is **bounded** — it carries the minimum data the c
 
 | In payload | Purpose |
 |---|---|
-| `:rf/version` | Runtime version stamp; mismatches emit `:rf.ssr/version-mismatch`. |
+| `:rf/version` | Runtime version stamp; mismatches emit `:rf.ssr/version-mismatch`. **Server-side source-of-truth (host adapter):** the host adapter resolves the stamp in this order — (1) explicit `:version` opt passed to the payload builder; (2) the framework-global `:rf2/runtime-version` late-bind hook (the same source the client-side `:rf.ssr/check-version` fx reads, per [§The `:rf/hydrate` event](#the-rfhydrate-event) — both sides of the wire pin the same value when the host registers the hook at boot); (3) terminal fallback `1` (the v1 pattern-protocol stamp per [Spec-Schemas §`:rf/hydration-payload`](Spec-Schemas.md#rfhydration-payload)). Hosts that don't register `:rf2/runtime-version` (or pass `:version` explicitly) ship the terminal `1` — the check-version fx still no-ops cleanly because the client's lookup hits the same fallback. |
 | `:rf/frame-id` | The frame to hydrate into. |
 | `:rf/app-db` | The serialised app-db slice — server's authoritative state. **Replace** policy on hydrate. |
 | `:rf/schema-digest` (optional) | Hash of the server's registered `app-schema` set; mismatches emit `:rf.ssr/schema-digest-mismatch`. |
@@ -238,6 +238,17 @@ Streaming/chunked emission is out of initial scope — see [§Streaming SSR](#st
 Per [Spec 006 §Source-coord annotation](006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7--rf2-z9n1) (rf2-z7f7 / rf2-z9n1) every substrate adapter MUST inject `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` on the rendered root DOM element of each registered view. The JVM SSR emitter mirrors that contract string-side: when emitting HTML for a registered view (the `(registrar/lookup :view head)` branch in `emit-element`), the emitter walks the view's hiccup output, merges `:data-rf2-source-coord` into the root element's attrs map, and then proceeds with HTML emission as usual.
 
 The attribute value format is identical to the CLJS-side wrapper: `<ns>:<sym>:<line>:<col>`, derived from the registry id and the coords stamped onto the slot at `reg-view` macro-expansion time. The same documented exemption applies — fragments / non-DOM roots are skipped, and the JVM emitter resolves to the registry's `:rf/id` for those cases.
+
+**Exempt-keyword enumeration.** The "non-DOM root" exemption is closed-set: a hiccup vector is exempt from `:data-rf2-source-coord` (and from the `data-rf-render-hash` root injection per [§Hydration-mismatch detection](#hydration-mismatch-detection)) when its head keyword is one of:
+
+| Exempt head | Meaning |
+|---|---|
+| `:<>` | Fragment shorthand — no DOM element emitted; children are spliced into the parent. |
+| `:>` | Reagent-native interop head — children pass through to a React component, not a DOM tag. |
+
+A hiccup vector whose head is a Var-ref (`(fn? head)` — fn-headed component), a registered-view keyword (resolved via `(registrar/lookup :view head)`), or a `lazy-seq` is **passed through** the injection — the attribute lands on the eventual DOM root once the indirection resolves. The exemption is per-call: it only skips the *current* level. A registered view that returns `[:<> ...]` resolves to the fragment, so the source-coord injection no-ops (consistent with the CLJS-side wrapper).
+
+The same enumeration governs the `data-rf-render-hash` root-attrs injection (per rf2-lxwse): `:<>` and `:>` are the two skip-list heads; everything else either receives the injection directly or threads it through to the resolved root. Other-language ports MUST mirror the exemption against their substrate's analogous "no-DOM-element-emitted" heads — the contract is the closed-set above for the CLJS reference and `(no-DOM-element-emitted)` semantically for ports.
 
 Production-elision differs from CLJS: the JVM has no `goog.DEBUG` constant-fold concept. Hosts that want to suppress the annotation in production builds branch on the resolved frame's `:ssr` config (or on a host-supplied flag); the default is to emit, matching the dev-time semantics that the annotation exists to support.
 
@@ -592,6 +603,7 @@ The runtime ships a default projector (`:rf.ssr/default-error-projector`) implem
 | Internal `:operation` | Public `:status` | Public `:code` |
 |---|---|---|
 | `:rf.error/no-such-handler` (in routing context) | `404` | `:not-found` |
+| `:rf.error/no-such-route` (route-id not in registrar — per [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue)) | `404` | `:not-found` |
 | `:rf.error/schema-validation-failure` (`:where :event` or `:cofx-args`) | `400` | `:bad-request` |
 | `:rf.error/handler-exception` | `500` | `:internal-error` |
 | `:rf.error/sub-exception` | `500` | `:internal-error` |

--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -486,6 +486,26 @@ The single-import contract is preserved: users continue to write `rf/reg-flow` a
 
 Per [rf2-hoiu](#) the wrappers live in sibling namespaces rather than in `core.cljc` itself so `core.cljc` stays free of optional-artefact glue. Per [rf2-2vbm](#) the file naming uses `core_<feature>` rather than `core/<feature>` because CLJS goog.provide for `re-frame.core` overwrites its parent object.
 
+### Late-bind hook key grammar
+
+Every key published through the `re-frame.late-bind` hook registry follows a closed grammar so the namespace prefix is predictable and the table stays browsable. The full inventory lives at [`implementation/core/src/re_frame/late_bind/directory.cljc`](../implementation/core/src/re_frame/late_bind/directory.cljc) (the drift-test source of truth per rf2-asmj1 H8 / [rf2-l8fi6](#)); the grammar is:
+
+| Prefix shape | Producer | When to use | Example |
+|---|---|---|---|
+| `:<feature>/<surface>` | A single per-feature artefact ns | The default case: an optional artefact publishes its public-API impl behind a late-bind seam. `<feature>` matches the feature-id (the artefact name without the `re-frame2-` prefix). `<surface>` names the function — `<verb-noun>` shape, kebab-case, bang-suffixed only when the producer mutates process-level state per [§Naming: when does a surface carry `!`?](#naming-when-does-a-surface-carry-). | `:flows/reg-flow`, `:schemas/validate-app-db!`, `:machines/spawn-fx`, `:ssr/render-to-string`, `:epoch/settle!`, `:http/clear-all-in-flight!` |
+| `:adapter/<surface>` | Chained across every shipped CLJS adapter | Substrate-routed seams — each adapter ns registers a fn keyed by `:adapter/<surface>`; the runtime dispatches through `current-adapter` to pick the right one. The drift directory marks these `:chained? true` with `:producer-ns` as a vector of every adapter ns. | `:adapter/current-frame`, `:adapter/ratom`, `:adapter/wrap-view` |
+| `:rf2/<runtime-stamp>` | Core (or an artefact publishing a globally-visible runtime fact) | Runtime-static, framework-owned stamps that any artefact can read — version numbers, build flags, schema digests, etc. The `:rf2/` prefix marks the key as "framework-global, not feature-scoped." Used sparingly — most cross-feature plumbing should pick a feature prefix instead. | `:rf2/runtime-version` |
+
+**Rules.**
+
+1. The `<feature>` segment names a single artefact (`flows`, `schemas`, `machines`, `routing`, `http`, `ssr`, `epoch`, `reagent`, `views`, `subs`, `router`, `trace`, `event-emit`, `error-emit`, `privacy`). New artefacts pick a single-segment kebab-case feature-id that matches the producing namespace's last segment.
+2. Multi-word `<surface>` is kebab-case (`reg-flow`, `clear-all-in-flight!`, `render-to-string`, `app-schemas-digest`). The `:` between prefix and surface is the only separator; no dots inside the surface segment.
+3. **The drift test enforces directory ↔ producer-ns parity** (`implementation/core/test/re_frame/late_bind_drift_test.clj`). A `set-fn!` call site whose key isn't in the directory — or a directory entry whose key isn't reached by any `set-fn!` — fails CI. Add a hook = update both the producer ns AND the directory entry in a single change.
+4. The hook key is **stable across the artefact's lifecycle** — adapters / consumers reference it by string-spelled keyword, so renaming a hook key is a breaking change of the same magnitude as renaming a public fn.
+5. Hooks that fan out chronologically (callback-style listeners called in registration order rather than overwriting) are documented with `:chained? true` in the directory; this is an additive property of the same naming grammar.
+
+The grammar holds across every per-feature artefact split landed under the [rf2-5vjj](#) Strategy B rollout; new per-feature splits MUST mint hook keys under their own `<feature>` segment so the naming stays grep-friendly across the codebase.
+
 ### Naming convention
 
 The artefact-naming convention is `re-frame2-<thing>`, where `<thing>` is the feature-id (per Spec topic) or adapter name. The Maven group is `day8` for the CLJS reference's published artefacts.


### PR DESCRIPTION
## Summary

Spec drift cluster — closes rf2-l8fi6. Aligns Spec 011 with impl behaviour across four items from the rf2-asmj1 audit, plus the H8 late-bind-hook-grammar deferred from PR #939 (rf2-sljs1) because Conventions.md is hot-zone.

- **S6 (spec)** — Spec 011 §Source-coord annotation under SSR now enumerates the closed-set of exempt heads (`:<>`, `:>`) plus the pass-through rule for Var-refs / registered-view keywords / lazy-seqs. Same enumeration governs the `data-rf-render-hash` root-attrs injection per rf2-lxwse.

- **S7 (spec)** — Default projector mapping table adds `:rf.error/no-such-route` → 404 / `:not-found`, matching the impl at `error_projector.cljc:64,82` (was previously documented only on `:rf.error/no-such-handler`).

- **S8 (spec + impl)** — `ssr-ring/build-payload` now resolves `:rf/version` via a three-step chain: explicit `:version` opt → `:rf2/runtime-version` late-bind hook (same source the client-side `:rf.ssr/check-version` fx reads) → v1 terminal fallback. Spec 011 §Payload scope pins the order so server and client agree without per-host plumbing. Eliminates the silent-divergence trap where the adapter's hard-coded `1` disagreed with whatever the client-side hook returned.

- **H8 (Conventions)** — new §Late-bind hook key grammar documents the closed prefix set (`:<feature>/<surface>`, `:adapter/<surface>` chained, `:rf2/<runtime-stamp>` global) and the directory drift-test contract.

S2 (render-to-string `:frame`/`:props`) and S3 (canonical-edn nil pruning) already landed via PR #939 / rf2-6djjl — out of scope here.

## Test plan
- [x] `clojure -M:test` in `implementation/ssr/` → 82 tests, 267 assertions, 0 failures, 0 errors
- [x] `clojure -M:test` in `implementation/ssr-ring/` → 19 tests, 80 assertions, 0 failures, 0 errors
- [x] `mkdocs build` — no new warnings introduced by these edits (pre-existing nav warnings unchanged)