### PR TITLE
perf(core): clear reflection warnings + gate (rf2-xzkub)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -18,6 +18,8 @@
             [re-frame.trace :as trace
              #?@(:cljs [:include-macros true])]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (def ^{:doc "Sentinel for `inject-cofx`'s 3-arity 'no-value' branch.
   Used by `re-frame.core/inject-cofx`'s macro form (rf2-ts1a) to thread
   a call-site through the no-value path without inventing a private

--- a/implementation/core/src/re_frame/conformance.cljc
+++ b/implementation/core/src/re_frame/conformance.cljc
@@ -33,6 +33,8 @@
   Builtins: :inc :dec :+ :- :* :/ :identity :conj :assoc :dissoc
             :item-amount :count")
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- builtins -------------------------------------------------------------
 
 (defn- builtin [k]

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -74,6 +74,8 @@
                                     with-frame bound-fn with-fx-overrides
                                     with-managed-request-stubs]])))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- CLJS fn-aliases for registration ------------------------------------
 ;;
 ;; Source-coord capture on CLJS rides the JVM-emitted macros above. The

--- a/implementation/core/src/re_frame/core_artefact.cljc
+++ b/implementation/core/src/re_frame/core_artefact.cljc
@@ -79,6 +79,8 @@
   every `defwrapper` spec."
   (:require [re-frame.late-bind]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 #?(:clj
    (defn- in-scope-ex-data
      "Filter `ex-data` to entries whose value-symbol appears in the

--- a/implementation/core/src/re_frame/core_call_site_macros.cljc
+++ b/implementation/core/src/re_frame/core_call_site_macros.cljc
@@ -29,6 +29,8 @@
   File naming uses the flat dash-form (per rf2-2vbm)."
   (:require [re-frame.source-coords :as source-coords]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 #?(:clj
    (defn call-site-form
      "Build the literal call-site cond-> map for a callable's macro

--- a/implementation/core/src/re_frame/core_epoch.cljc
+++ b/implementation/core/src/re_frame/core_epoch.cljc
@@ -25,6 +25,8 @@
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (def ^:private epoch-artefact
   {:error-keyword :rf.error/epoch-artefact-missing
    :maven         "day8/re-frame2-epoch"

--- a/implementation/core/src/re_frame/core_flows.cljc
+++ b/implementation/core/src/re_frame/core_flows.cljc
@@ -18,6 +18,8 @@
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (def ^:private flows-artefact
   {:error-keyword :rf.error/flows-artefact-missing
    :maven         "day8/re-frame2-flows"

--- a/implementation/core/src/re_frame/core_http.cljc
+++ b/implementation/core/src/re_frame/core_http.cljc
@@ -20,6 +20,8 @@
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (def ^:private http-artefact
   {:error-keyword :rf.error/http-artefact-missing
    :maven         "day8/re-frame2-http"

--- a/implementation/core/src/re_frame/core_machines.cljc
+++ b/implementation/core/src/re_frame/core_machines.cljc
@@ -25,6 +25,8 @@
             [re-frame.router :as router]
             [re-frame.subs :as subs]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (def ^:private machines-artefact
   {:error-keyword :rf.error/machines-artefact-missing
    :maven         "day8/re-frame2-machines"

--- a/implementation/core/src/re_frame/core_reg_macros.cljc
+++ b/implementation/core/src/re_frame/core_reg_macros.cljc
@@ -27,6 +27,8 @@
   object, which would wipe a previously-loaded `re-frame.core.X`."
   (:require [re-frame.source-coords :as source-coords]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- with-coords-form ----------------------------------------------------
 
 #?(:clj

--- a/implementation/core/src/re_frame/core_reg_view_macro.cljc
+++ b/implementation/core/src/re_frame/core_reg_view_macro.cljc
@@ -18,6 +18,8 @@
   File naming uses the flat dash-form (per rf2-2vbm)."
   (:require [re-frame.source-coords :as source-coords]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- reg-view expansion helpers ------------------------------------------
 
 #?(:clj
@@ -50,7 +52,7 @@
        (nil? x)
        "nothing"
        :else
-       (str "a " (some-> x type .getSimpleName) " — " (pr-str x)))))
+       (str "a " (.getSimpleName ^Class (type x)) " — " (pr-str x)))))
 
 #?(:clj
    (defn- reagent-slim-form-tag

--- a/implementation/core/src/re_frame/core_routing.cljc
+++ b/implementation/core/src/re_frame/core_routing.cljc
@@ -19,6 +19,8 @@
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (def ^:private routing-artefact
   {:error-keyword :rf.error/routing-artefact-missing
    :maven         "day8/re-frame2-routing"

--- a/implementation/core/src/re_frame/core_schemas.cljc
+++ b/implementation/core/src/re_frame/core_schemas.cljc
@@ -18,6 +18,8 @@
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (def ^:private schemas-artefact
   {:error-keyword :rf.error/schemas-artefact-missing
    :maven         "day8/re-frame2-schemas"

--- a/implementation/core/src/re_frame/core_ssr.cljc
+++ b/implementation/core/src/re_frame/core_ssr.cljc
@@ -21,6 +21,8 @@
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (def ^:private ssr-artefact
   {:error-keyword :rf.error/ssr-artefact-missing
    :maven         "day8/re-frame2-ssr"

--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -35,6 +35,8 @@
             [re-frame.substrate.adapter :as adapter]
             [re-frame.trace :as trace]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- configuration --------------------------------------------------------
 
 (def default-threshold-bytes

--- a/implementation/core/src/re_frame/emit_substrate.cljc
+++ b/implementation/core/src/re_frame/emit_substrate.cljc
@@ -17,6 +17,8 @@
 
   See Spec 009 §Production debugging for normative framing.")
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (defn make-listener-registry
   "Construct an isolated always-on listener registry. Returns a map:
 

--- a/implementation/core/src/re_frame/error_emit.cljc
+++ b/implementation/core/src/re_frame/error_emit.cljc
@@ -41,6 +41,8 @@
             [re-frame.frame         :as frame]
             [re-frame.late-bind     :as late-bind]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- listener registry ----------------------------------------------------
 
 (defonce ^:private listeners

--- a/implementation/core/src/re_frame/event_emit.cljc
+++ b/implementation/core/src/re_frame/event_emit.cljc
@@ -30,6 +30,8 @@
             [re-frame.privacy       :as privacy]
             [re-frame.registrar     :as registrar]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- listener registry ----------------------------------------------------
 
 (defonce ^:private listeners

--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -16,6 +16,8 @@
             [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- metadata-map mis-use detection (rf2-bbea) ----------------------------
 ;;
 ;; `reg-event-*`'s middle slot may be a metadata-map (open shape — `:doc`,

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -19,6 +19,8 @@
             [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- the frame record -----------------------------------------------------
 ;;
 ;; Per Spec 002 §What lives in a frame, a frame is a map with:

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -29,6 +29,8 @@
             [re-frame.trace :as trace
              #?@(:cljs [:include-macros true])]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- registration ---------------------------------------------------------
 
 (defn reg-fx

--- a/implementation/core/src/re_frame/interceptor.cljc
+++ b/implementation/core/src/re_frame/interceptor.cljc
@@ -11,6 +11,8 @@
   The chain runs :before in order, then the handler, then :after in
   reverse order.")
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (defn ->interceptor
   "Build an interceptor map from kwargs. The primitive entry point for
   custom interceptors.

--- a/implementation/core/src/re_frame/interop.clj
+++ b/implementation/core/src/re_frame/interop.clj
@@ -7,6 +7,8 @@
   test suites."
   (:import [java.util.concurrent Executor Executors ScheduledExecutorService TimeUnit ScheduledFuture]))
 
+(set! *warn-on-reflection* true)
+
 ;; ---- next-tick scheduling -------------------------------------------------
 
 (defonce ^:private executor (Executors/newSingleThreadExecutor))

--- a/implementation/core/src/re_frame/late_bind.cljc
+++ b/implementation/core/src/re_frame/late_bind.cljc
@@ -46,6 +46,8 @@
   `implementation/core/test/re_frame/late_bind_drift_test.clj`
   asserts the directory and the `set-fn!` call sites stay in sync.")
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (defonce
   ^{:doc "Map of hook-key → fn. Populated by the producing namespace at
    load time. The authoritative key inventory is

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -34,6 +34,8 @@
   and a free-floating prose comment; the drift check is the only
   source of truth.")
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (def hooks
   "Vector of hook-directory entries — see the ns docstring for shape.
 

--- a/implementation/core/src/re_frame/performance.cljc
+++ b/implementation/core/src/re_frame/performance.cljc
@@ -44,6 +44,8 @@
   true or false depending on whether timing instrumentation is wanted."
   #?(:cljs (:require-macros [re-frame.performance])))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- the compile-time flag -------------------------------------------------
 
 #?(:cljs

--- a/implementation/core/src/re_frame/privacy.cljc
+++ b/implementation/core/src/re_frame/privacy.cljc
@@ -58,6 +58,8 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- redaction sentinel ---------------------------------------------------
 
 (def redacted-sentinel

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -31,6 +31,8 @@
   (:require [re-frame.interop   :as interop]
             [re-frame.late-bind :as late-bind]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- the kind set ---------------------------------------------------------
 
 (def kinds

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -22,6 +22,8 @@
             [re-frame.trace :as trace
              #?@(:cljs [:include-macros true])]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- dispatch-id allocation -----------------------------------------------
 ;;
 ;; Per Spec 009 §Dispatch correlation: every dispatch is stamped with a
@@ -292,7 +294,7 @@
   :time/:exception/:elapsed-ms` record to corpus-wide listeners."
   [error event-id event frame ctx start-ms]
   (let [e          (:exception error)
-        msg        #?(:clj (.getMessage e) :cljs (.-message e))
+        msg        #?(:clj (.getMessage ^Throwable e) :cljs (.-message e))
         emit-event (or (:rf/redacted-event ctx) event)
         end-ms     (interop/now-ms)
         ;; Per rf2-bacs4 §Record shape: `:elapsed-ms` is an integer.

--- a/implementation/core/src/re_frame/source_coords.cljc
+++ b/implementation/core/src/re_frame/source_coords.cljc
@@ -26,6 +26,8 @@
   separately. Source-coord capture itself stays unconditional — the
   runtime cost is one map merge at registration time.")
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (def ^:dynamic *pending-coords*
   "Per-thread (per-call) source coords captured by a reg-* macro and
   consumed by the underlying registration fn. nil outside a macro

--- a/implementation/core/src/re_frame/source_coords/editor_uri.cljc
+++ b/implementation/core/src/re_frame/source_coords/editor_uri.cljc
@@ -80,6 +80,8 @@
   file. Missing `:file` → `nil` URI; the UI layer hides the button."
   (:require [clojure.string :as str]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- known schemes -------------------------------------------------------
 
 (def ^:const known-editors

--- a/implementation/core/src/re_frame/spec.cljc
+++ b/implementation/core/src/re_frame/spec.cljc
@@ -60,6 +60,8 @@
             [re-frame.registrar :as registrar]
             [re-frame.trace :as trace]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- warn-once cache (Spec 010 L147) -------------------------------------
 ;;
 ;; `:rf.warning/boundary-without-spec` fires at most once per handler-id —

--- a/implementation/core/src/re_frame/std_interceptors.cljc
+++ b/implementation/core/src/re_frame/std_interceptors.cljc
@@ -13,6 +13,8 @@
   (:require [re-frame.interceptor :as interceptor]
             [re-frame.trace :as trace]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- path -----------------------------------------------------------------
 ;;
 ;; Focus a handler on an app-db sub-slice. The handler sees and returns

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -37,6 +37,8 @@
             [re-frame.trace :as trace
              #?@(:cljs [:include-macros true])]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- registration ---------------------------------------------------------
 ;;
 ;; A sub registration carries:

--- a/implementation/core/src/re_frame/substrate/adapter.cljc
+++ b/implementation/core/src/re_frame/substrate/adapter.cljc
@@ -34,6 +34,8 @@
   (:require [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- adapter installation -------------------------------------------------
 
 (defonce ^:private installed-adapter (atom nil))

--- a/implementation/core/src/re_frame/substrate/plain_atom.cljc
+++ b/implementation/core/src/re_frame/substrate/plain_atom.cljc
@@ -12,6 +12,8 @@
   `(rf/init! plain-atom/adapter)` explicitly. The `adapter` var below
   is the public surface.")
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (defn- make-state-container [initial-value]
   (atom initial-value))
 

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -95,6 +95,8 @@
             #?(:clj  [clojure.test :as ctest]
                :cljs [cljs.test :as ctest :include-macros true])))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- registrar snapshot/restore -------------------------------------------
 
 (defn snapshot-registrar

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -12,6 +12,8 @@
             [re-frame.late-bind :as late-bind])
   #?(:cljs (:require-macros [re-frame.trace])))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- listener registry ----------------------------------------------------
 
 (defonce ^:private listeners (atom {}))    ;; id → fn (or nil for cleared)

--- a/implementation/core/src/re_frame/trace/projection.cljc
+++ b/implementation/core/src/re_frame/trace/projection.cljc
@@ -51,6 +51,8 @@
     projection so 'show me every fx in this cascade' becomes one slice
     of the returned record.")
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- bucketing ------------------------------------------------------------
 
 (def ^:private effect-op-types


### PR DESCRIPTION
## Summary

- Add `(set! *warn-on-reflection* true)` (gated `#?(:clj ...)` for `.cljc`) after every ns form across **39 core `.clj`/`.cljc` files**. Matches the pattern already in place at `implementation/ssr/src/re_frame/ssr/hash.cljc` and `implementation/ssr-ring/src/re_frame/ssr/ring.clj`.
- Fix the two reflection sites the gate surfaces:
  - `router.cljc:295` — `(.getMessage e)` on an unhinted Throwable; hint as `^Throwable` inside the `:clj` reader-conditional branch.
  - `core_reg_view_macro.cljc:53` — `(some-> x type .getSimpleName)`; the `(nil? x)` cond branch above already guards nil, so simplify to `(.getSimpleName ^Class (type x))`.

Closes the audit finding **PE7 from rf2-spr6q** — core was the last reference-impl artefact shipping without the JVM hygiene directive.

## Files gated (39)

`cofx`, `conformance`, `core`, `core_artefact`, `core_call_site_macros`, `core_epoch`, `core_flows`, `core_http`, `core_machines`, `core_reg_macros`, `core_reg_view_macro`, `core_routing`, `core_schemas`, `core_ssr`, `elision`, `emit_substrate`, `error_emit`, `event_emit`, `events`, `frame`, `fx`, `interceptor`, `interop` (the only `.clj`), `late_bind`, `late_bind/directory`, `performance`, `privacy`, `registrar`, `router`, `source_coords`, `source_coords/editor_uri`, `spec`, `std_interceptors`, `subs`, `substrate/adapter`, `substrate/plain_atom`, `test_support`, `trace`, `trace/projection`.

CLJS-only files (`adapter/context.cljs`, `interop.cljs`, `views.cljs`, `views/provider.cljs`, `views/source_coord_annotation.cljs`, `views/warn_once.cljs`) are unaffected — JS hosts have no reflection concept.

## Warnings fixed (2)

| Site | Cause | Fix |
| --- | --- | --- |
| `router.cljc:295` | `(.getMessage e)` — `e` is `(:exception error)`, untyped | `(.getMessage ^Throwable e)` inside the existing `#?(:clj ...)` reader-conditional |
| `core_reg_view_macro.cljc:53` | `(some-> x type .getSimpleName)` — `type` returns untyped Object | `(.getSimpleName ^Class (type x))` — the `(nil? x)` cond branch above already filters nil |

## Test plan

- [x] `clojure -M:test` from `implementation/core/` — **456 tests, 2439 assertions, 0 failures, 0 errors**
- [x] Compile produces **zero** reflection warnings under the new gate (`grep -iE "(reflection|boxed math|warning)"` on the test output is empty)

## Pre-alpha rule

No back-compat shims; the two fixes are minimal type hints, behaviour-preserving.