### PR TITLE
spec(causa-mcp): add Tool-Pair binding subsection for the 4 epoch-shaped tools (rf2-13qxw)

### DIFF
--- a/tools/causa-mcp/spec/000-Vision.md
+++ b/tools/causa-mcp/spec/000-Vision.md
@@ -165,6 +165,71 @@ Each tool maps to a Causa-side affordance (the seventeen panel
 mirrors plus the streaming-registry diagnostic); together they
 let an agent observe, dispatch, time-travel, stream, and inspect.
 
+## Tool-Pair binding — the four epoch-shaped tools
+
+Four of the eighteen tools route exclusively through
+[`spec/Tool-Pair.md`](../../../spec/Tool-Pair.md)'s time-travel
+surface — they are the **epoch-shaped tools**: `get-epoch-history`,
+`restore-epoch`, `get-app-db-diff`, and `subscribe :epoch`. The
+remaining fourteen consume Spec 009's trace bus, the registrar
+query API, or the per-frame `app-db` reader directly; only these
+four bind to Tool-Pair as their canonical contract source.
+
+This subsection pins **which Tool-Pair section each tool binds
+to**, ahead of `003-Tool-Catalogue.md`. When the catalogue lands
+the per-tool entries cite these bindings rather than re-deriving
+the contract; drift between the catalogue prose and Tool-Pair is
+caught here, not three documents later. The pattern mirrors how
+[`tools/pair2-mcp/spec/003-Tool-Catalogue.md`](../../pair2-mcp/spec/003-Tool-Catalogue.md)
+already cross-references its framework anchors.
+
+| Tool | Tool-Pair binding | What the binding pins |
+|---|---|---|
+| `get-epoch-history` | [§Time-travel: epoch snapshots and undo](../../../spec/Tool-Pair.md#time-travel-epoch-snapshots-and-undo) — Recording, Ordering, Bounded history, Query; [`:rf/epoch-record` schema](../../../spec/Spec-Schemas.md#rfepoch-record) | The vector shape returned by `(rf/epoch-history frame-id)`, the per-record key set (`:epoch-id`, `:frame`, `:committed-at`, `:event-id`, `:trigger-event`, `:db-before`, `:db-after`, `:trace-events`, `:sub-runs`, `:renders`, `:effects`), the oldest-first ordering, the default depth (50) and the `(rf/configure :epoch-history {:depth N})` knob. The MCP tool's `{:cursor ...}` pagination wraps the same vector; the budget mechanisms ride [§Wire-protocol mechanisms](../../../spec/Tool-Pair.md#wire-protocol-mechanisms-mcp-tool-layer-not-framework) and [`004-Wire-Pipeline.md`](./004-Wire-Pipeline.md). |
+| `restore-epoch` | [§Time-travel — Restore](../../../spec/Tool-Pair.md#time-travel-epoch-snapshots-and-undo); the six-row restore-failure table; [§Surface behaviour against destroyed frames](../../../spec/Tool-Pair.md#surface-behaviour-against-destroyed-frames) | The `(rf/restore-epoch frame-id epoch-id)` call shape, the `:rf.epoch/restored` success op, and the **closed-set** failure surface — `:rf.error/no-such-handler` (kind `:frame`), `:rf.epoch/restore-unknown-epoch`, `:rf.epoch/restore-schema-mismatch`, `:rf.epoch/restore-missing-handler`, `:rf.epoch/restore-version-mismatch`, `:rf.epoch/restore-during-drain`. The MCP tool's return shape (`{:ok? false :reason <op> :tags {...}}` on failure) is a structured projection of those six rows; new failure rows are additive and require a Spec-ulation increment on Tool-Pair *first*, the MCP tool *second*. |
+| `get-app-db-diff` | [§Time-travel — Recording](../../../spec/Tool-Pair.md#time-travel-epoch-snapshots-and-undo) (the `:db-before` / `:db-after` slots); [`:rf/epoch-record` schema](../../../spec/Spec-Schemas.md#rfepoch-record); [§Wire-protocol mechanisms — diff-encoded `:db-after`](../../../spec/Tool-Pair.md#wire-protocol-mechanisms-mcp-tool-layer-not-framework) | The two per-epoch app-db snapshots the tool diffs (`:db-before` is the value *before* the cascade ran, `:db-after` is the value *after* drain-settle). The diff envelope (path-keyed `:added` / `:removed` / `:changed` slots) is the MCP-server layer's concern, not the framework's; Tool-Pair pins the **inputs** to the diff. Sensitive paths in either snapshot ride [§Direct-read privacy posture](../../../spec/Tool-Pair.md#direct-read-privacy-posture-for-sub-cache-and-get-path) — `rf/elide-wire-value` scrubs at the wire boundary before the diff lands in the response. |
+| `subscribe :epoch` | [§Subscribing to assembled epoch records](../../../spec/Tool-Pair.md#subscribing-to-assembled-epoch-records); [§Surface behaviour against destroyed frames](../../../spec/Tool-Pair.md#surface-behaviour-against-destroyed-frames) (listener silencing) | The `register-epoch-cb!` listener contract — one callback per drain-settle, fully-shaped `:rf/epoch-record` per delivery, listener exceptions are caught and **not** auto-evicting, re-entrant dispatch from a callback is legal. The one-shot `:rf.epoch.cb/silenced-on-frame-destroy` trace lands on the agent's stream when an observed frame is destroyed; the MCP subscription bridges that trace through its envelope so the agent's loop terminates deterministically. The streaming byte+event budget lives in [`004-Wire-Pipeline.md`](./004-Wire-Pipeline.md). |
+
+**Why these four, not the other fourteen.** The remaining
+tools bind to different framework contracts: the inspection band
+(`get-app-db`, `get-handlers`, `get-machine-list`,
+`get-machine-state`, `get-issues`, `get-trace-buffer`,
+`get-source-coord`, `list-subscriptions`, `get-handler-source`)
+binds to Spec 002's registrar query API and Spec 009's trace
+buffer; the mutation band (`dispatch`, `reset-frame-db`,
+`hot-swap`) binds to Spec 002's dispatch / state-injection
+surfaces and Spec 001's hot-reload semantics; the streaming band
+otherwise (`subscribe :trace`, `subscribe :error`) binds to Spec
+009's listener API; the escape hatch (`eval-cljs`) binds to
+[§REPL-eval](../../../spec/Tool-Pair.md#repl-eval) only loosely;
+the meta band (`list-tools`, `session-info`) binds to nothing
+framework-side. Tool-Pair is the **time-travel** contract — and
+only four tools time-travel.
+
+**Sibling contracts that ride alongside, not through, Tool-Pair.**
+The runtime fxs `:rf.ssr/check-version` and
+`:rf.ssr/check-schema-digest` (per
+[Spec 011 §SSR fx surface](../../../spec/011-SSR.md), landed
+rf2-69ad2) supply the **schema-digest** value that
+`restore-epoch`'s `:rf.epoch/restore-schema-mismatch` row carries
+(`:schema-digest-recorded` / `:schema-digest-current`). Causa-MCP
+does not consume the SSR fxs directly — the digest reaches the
+tool through the `:rf.epoch/restore-schema-mismatch` trace — but
+agents debugging an SSR-hydration mismatch combine
+`get-epoch-history` (to read the recorded digest) with
+`restore-epoch`'s failure trace (to read the live digest) to
+isolate where the schema drifted. The binding cite stays on
+Tool-Pair's restore-failure table; the SSR fxs are a sibling
+producer of one of its fields, not a separate binding.
+
+**What changes when `003-Tool-Catalogue.md` lands.** Each of the
+four per-tool entries in the catalogue cites the binding row
+above and adds the MCP-specific wire shape (the input arg map,
+the response envelope, the error projection). The binding row
+itself remains in this Vision doc as the **single anchor** the
+catalogue points back to — Tool-Pair drift can be caught by
+reading this subsection alone, without re-folding the catalogue.
+
 ## Every MCP-driven mutation leaves a visible footprint
 
 The defining property of Causa-MCP — and a first-class


### PR DESCRIPTION
## Summary

Adds a §Tool-Pair binding subsection to `tools/causa-mcp/spec/000-Vision.md` naming the four epoch-shaped tools and the canonical Tool-Pair sections they bind to — ahead of `003-Tool-Catalogue.md`.

- `get-epoch-history` → Tool-Pair §Time-travel (Recording / Ordering / Bounded history / Query) + `:rf/epoch-record` schema
- `restore-epoch` → Tool-Pair §Time-travel — Restore + the six-row failure table + §Surface behaviour against destroyed frames
- `get-app-db-diff` → Tool-Pair §Time-travel `:db-before`/`:db-after` slots + §Wire-protocol mechanisms (diff-encoded) + §Direct-read privacy posture
- `subscribe :epoch` → Tool-Pair §Subscribing to assembled epoch records + listener-silencing trace

Also explains **why these four** (Tool-Pair is the time-travel contract; only four tools time-travel) and notes the SSR fxs (`:rf.ssr/check-version`, `:rf.ssr/check-schema-digest` per rf2-69ad2) as a **sibling producer** of the `:schema-digest-recorded`/`:schema-digest-current` field on the schema-mismatch failure row — not a separate binding.

Per audit rf2-m9yoi §S1 finding (P2). When `003-Tool-Catalogue.md` lands, each per-tool entry cites this binding row rather than re-deriving the contract; drift between catalogue and Tool-Pair gets caught here.

## Test plan

- [x] Spec-only change; no code touched.
- [x] All Tool-Pair anchor URLs verified against `spec/Tool-Pair.md` (`#time-travel-epoch-snapshots-and-undo`, `#surface-behaviour-against-destroyed-frames`, `#wire-protocol-mechanisms-mcp-tool-layer-not-framework`, `#direct-read-privacy-posture-for-sub-cache-and-get-path`, `#subscribing-to-assembled-epoch-records`, `#repl-eval`).
- [x] Cross-link to `Spec-Schemas.md#rfepoch-record` verified.
- [x] Tool-count framing ("eighteen tools", "fourteen" + "four") consistent with the canonical counts elsewhere in the doc.