### PR TITLE
test(pair2-mcp): conformance corpus runner + JS/CLJS test-layering README (rf2-xkxbv)

### DIFF
--- a/tools/pair2-mcp/test/README.md
+++ b/tools/pair2-mcp/test/README.md
@@ -1,0 +1,148 @@
+# pair2-mcp tests — JS / CLJS layering
+
+> Per rf2-xkxbv (audit rf2-7hie3 §TE4). The pair2-mcp test surface is
+> split across two host languages — CLJS unit + conformance suites
+> and Node integration scripts. The boundary is real but easy to miss;
+> this README makes it visible.
+
+## TL;DR — when to add a test on each side
+
+| Question | Side |
+|---|---|
+| Does a per-tool function build the right eval form / wire envelope? | **CLJS** — `re_frame_pair2_mcp/<tool>_test.cljs` |
+| Does a cross-cutting concern (cache, cap, dedup, elision, sensitive) reshape an envelope correctly? | **CLJS** — `re_frame_pair2_mcp/<concern>_test.cljs` |
+| Does `tools/invoke` glue the four pipeline phases (precheck → dispatch → cache → cap) in the right order? | **CLJS** — `re_frame_pair2_mcp/invoke_test.cljs` |
+| Does the eleven-tool catalogue still produce the documented EDN wire shape per (tool × args × stub-conn)? | **CLJS** — `re_frame_pair2_mcp/conformance_test.cljs` |
+| Does the compiled `out/server.js` complete an MCP handshake and surface the documented tool descriptors? | **JS** — `stdio-roundtrip.js` |
+| Does the persistent nREPL socket survive multiple ops on one server process without leaking / hanging? | **JS** — `live-nrepl.js` |
+
+If a regression would only be visible **after** the CLJS compiles to
+JS, write a JS test. If it would be visible in the CLJS source, write a
+CLJS test. The two layers are complementary; both gate `npm test` and
+`live-nrepl` runs respectively.
+
+## The two layers
+
+### CLJS — `re_frame_pair2_mcp/*_test.cljs`
+
+The default `npm test` gate. shadow-cljs compiles the `:server-test`
+build (`shadow-cljs.edn`) and Node runs `out/server-test.js`. Every
+`*_test.cljs` namespace under `test/re_frame_pair2_mcp/` is picked up
+by the `:ns-regexp "-test$"` rule.
+
+What this layer covers:
+
+- **Per-tool body** — `<tool>_test.cljs` (one per registered tool):
+  pins the function shape (args coercion, eval-form composition,
+  wire envelope, error surfaces) without touching the network.
+- **Cross-cutting concerns** — `cache_test.cljs`, `wire_cap_test.cljs`,
+  `dedup_test.cljs`, `dedup_benchmark_test.cljs`,
+  `sensitive_filter_test.cljs`, `path_slicing_test.cljs`,
+  `elision_test.cljs`, `lazy_summary_test.cljs`,
+  `cursor_pagination_test.cljs`, `args_test.cljs`,
+  `diff_encode_epochs_test.cljs`. Each is a unit suite over its
+  concern's public surface.
+- **Pipeline glue** — `invoke_test.cljs` end-to-end-orchestration
+  test (rf2-nogok) for the precheck → dispatch → cache → cap chain.
+- **Conformance corpus** — `conformance_test.cljs` (rf2-xkxbv): one
+  inline-fixture corpus driving every tool through `tools/invoke`
+  against a stub conn, asserting recorded wire-shape EDN. Sibling
+  to `re-frame.ssr-conformance-test` / `re-frame.machines-conformance-test`
+  / `re-frame.schemas-conformance-test` / `re-frame.flows-conformance-test`
+  on the framework side.
+- **Snapshot pipeline / wire shape** — `snapshot_test.cljs`,
+  `subscribe_test.cljs`, `subscription_info_test.cljs`,
+  `wire_cap_test.cljs`, `typical_tokens_test.cljs`. These exercise
+  the SHAPE the server emits without ever opening a socket; nREPL is
+  stubbed at `nrepl/cljs-eval-value`.
+
+What this layer DOESN'T cover:
+
+- The stdio JSON-RPC framing. The CLJS suite never reaches the
+  `out/server.js` entry-point; it talks directly to the per-tool fn.
+  A broken stdio handler would pass every CLJS test and break in
+  production.
+- The persistent-socket nREPL round-trip. `nrepl/cljs-eval-value` is
+  stubbed in the unit suite; bencode parsing has its own dedicated
+  unit suite (`nrepl_test.cljs`) but the live-socket integration is
+  out of scope.
+- The compiled JS itself. shadow's `:simple` optimisation pass can
+  introduce name-mangling / dead-code-elimination issues that only
+  surface after compilation. The CLJS suite runs against
+  `:server-test` (no simple opts); production runs against
+  `:server` (simple opts). The two builds COULD diverge.
+
+### JS — `live-nrepl.js` + `stdio-roundtrip.js`
+
+The integration layer. Both scripts spawn `out/server.js` as a
+subprocess and drive it through stdin/stdout JSON-RPC frames.
+
+#### `stdio-roundtrip.js` — handshake + tool catalogue
+
+No external dependencies. Runs in CI by default. Boots the server
+with the nREPL port intentionally unresolvable so the degraded path
+runs deterministically. Exercises:
+
+- `initialize` handshake — server announces protocol version + name.
+- `tools/list` — pins the exact tool name set and per-tool
+  `inputSchema.properties` keys. A renamed property fails this test
+  (the rename is part of the wire contract; users' MCP-host configs
+  depend on it).
+- `tools/call` per tool against an absent nREPL — every tool surfaces
+  `:reason :nrepl-port-not-found` (the documented degraded mode).
+  This proves each tool is registered in the dispatcher; a missing
+  registry entry would surface as `:reason :unknown-tool` instead.
+- Unknown tool — passes through as an `isError` envelope.
+
+Run with: `node test/stdio-roundtrip.js` (after `npm run build`).
+
+#### `live-nrepl.js` — persistent-socket round-trip
+
+Requires a running nREPL on the port read from `$NREPL_TEST_PORT`
+(default 17778). Not part of the default `npm test` gate — opt-in,
+documented as a smoke harness. Exercises:
+
+- The persistent socket survives multiple ops on one server instance
+  (the original pilot bug — bencode@2's `decode.position` cursor —
+  would resurface here, NOT in the CLJS unit suite).
+- bencode multi-frame parsing on a real wire (status frame separate
+  from value frame in nREPL's normal output stream).
+- `eval-cljs` degrades cleanly when the runtime preload is absent —
+  surfaces a structured error rather than hanging on the socket.
+
+Run with: `NREPL_TEST_PORT=17778 node test/live-nrepl.js`
+(after starting an nREPL on that port).
+
+#### `probe-decode.js` — bencode probe
+
+Diagnostic — invokes the bencode multi-frame walker against
+hand-constructed buffers. Used to debug regressions in the `nrepl@2`
+upgrade path. Not part of the gate.
+
+## Adding a new test — decision tree
+
+```
+Is the regression visible in CLJS source?
+  ├── yes → CLJS unit test
+  │         ├── concerns a single tool body?         → <tool>_test.cljs
+  │         ├── concerns a cross-cutting concern?    → <concern>_test.cljs
+  │         ├── concerns the four-phase pipeline?    → invoke_test.cljs
+  │         └── concerns the public wire envelope?   → conformance_test.cljs
+  │
+  └── no → JS integration test
+            ├── concerns the stdio handshake / tool catalogue? → stdio-roundtrip.js
+            └── concerns the live nREPL socket?                 → live-nrepl.js
+```
+
+## Why this layout is unusual
+
+Sibling artefacts under `implementation/<feature>/` are pure CLJS /
+JVM; their test layers are all `clojure -M:test`, all in one host
+language. Pair2-mcp is the exception — it compiles to Node and runs
+under `node out/server.js`. The compiled JS is the production
+artefact, but the source of truth is `.cljs`. So the test layer
+straddles both worlds: CLJS for everything verifiable from source,
+JS for everything that only exists after compilation.
+
+That's the boundary this README pins. Two layers, two scopes, one
+artefact.

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/conformance_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/conformance_test.cljs
@@ -265,17 +265,26 @@
   full streaming machinery needs an actual `extra` payload the corpus
   runner doesn't simulate."
   [;; ---------- discover-app ----------------------------------------------
+   ;; discover-app routes the runtime health map through several
+   ;; precondition gates (`:debug-enabled?`, `:frames`,
+   ;; `:ambiguous-frame?`, `:coord-annotation-enabled?`). The happy
+   ;; path requires all of them to land in the documented shape, so
+   ;; the canned health here mirrors the actual runtime contract.
    {:fixture/id    :discover-app/happy
-    :fixture/doc   "discover-app on a healthy runtime emits {:ok? true, :health <map>}."
+    :fixture/doc   "discover-app on a healthy runtime adds :ok? true + :build-id to the health map."
     :fixture/tool  "discover-app"
     :fixture/args  {}
     :fixture/eval-script
     [["__re_frame_pair2_runtime"  true]
-     ["health"                    {:status :ok :version "test"}]
+     ["health"                    {:ok?                       true
+                                   :debug-enabled?            true
+                                   :coord-annotation-enabled? true
+                                   :frames                    [:rf/default]
+                                   :version                   "test"}]
      [:default                    nil]]
     :fixture/expect
     {:isError? false
-     :edn-submap {:ok? true}}}
+     :edn-submap {:ok? true :build-id :app}}}
 
    {:fixture/id    :discover-app/preload-missing
     :fixture/doc   "discover-app surfaces :runtime-not-preloaded when the global marker is absent."
@@ -357,16 +366,27 @@
      :edn-contains-keys #{:epochs}}}
 
    ;; ---------- watch-epochs -----------------------------------------------
+   ;; watch-epochs wraps the runtime's `epochs-since` result into a
+   ;; paged/cursor envelope: `:matches` (rather than raw `:epochs`),
+   ;; `:has-more?`, `:next-cursor`, `:limit`, `:count`, `:head-id`,
+   ;; `:dedup`, `:epochs-mode`, `:id-aged-out?`. Pin the envelope's
+   ;; documented keys so accidental renames break the test.
    {:fixture/id    :watch-epochs/empty
-    :fixture/doc   "watch-epochs surfaces the empty-window envelope when the ring is empty."
+    :fixture/doc   "watch-epochs surfaces the empty-window cursor envelope when the ring is empty."
     :fixture/tool  "watch-epochs"
     :fixture/args  {:max-ms 50 :poll-ms 25}
     :fixture/eval-script
     [["__re_frame_pair2_runtime"  true]
-     [:default                    {:epochs [] :since 0 :now 0}]]
+     [:default                    {:matches      []
+                                   :id-aged-out? false
+                                   :requested-id nil
+                                   :head-id      nil
+                                   :next-id      nil
+                                   :remaining    0}]]
     :fixture/expect
     {:isError? false
-     :edn-contains-keys #{:epochs}}}
+     :edn-contains-keys #{:matches :has-more? :limit :count}
+     :edn-submap        {:ok? true :has-more? false :count 0 :id-aged-out? false}}}
 
    ;; ---------- tail-build -------------------------------------------------
    {:fixture/id    :tail-build/timeout

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/conformance_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/conformance_test.cljs
@@ -1,0 +1,560 @@
+(ns re-frame-pair2-mcp.conformance-test
+  "Per rf2-xkxbv (audit rf2-7hie3 §TE3). Drives the eleven-tool catalogue
+  through `tools/invoke` against a stub `conn` and asserts the recorded
+  wire-shape EDN — the artefact's contract suite, sibling to:
+
+    - `re-frame.conformance-test`            (core fixtures; rf2-d0wem)
+    - `re-frame.ssr-conformance-test`        (ssr fixtures;  rf2-i3qc0)
+    - `re-frame.schemas-conformance-test`    (schemas;       rf2-2l08g)
+    - `re-frame.flows-conformance-test`      (flows;         rf2-4559c)
+    - `re-frame.machines-conformance-test`   (machines;      rf2-d0wem)
+
+  ## Why a conformance corpus for pair2-mcp
+
+  The unit suite covers each tool's INNER logic in isolation
+  (`get_path_test`, `snapshot_test`, `subscribe_test`, etc.) and the
+  pipeline wire-up (`invoke_test`, `cache_test`, `wire_cap_test`). What
+  was missing pre-rf2-xkxbv: a single corpus that pins the
+  *outer* shape — for each MCP tool, given a canonical `tools/call`
+  input and a deterministic stub `conn`, what wire envelope does
+  `tools/invoke` produce?
+
+  That's the contract the agent host actually consumes. Without a
+  corpus pinning it, an accidental rename (`:reason :missing-event` →
+  `:reason :no-event`) or a return-shape flip (`:value` → `:result`)
+  would slip through the unit suite because each unit test only knows
+  its own tool's vocabulary. The corpus is the cross-tool ratchet.
+
+  ## Why the corpus lives inline
+
+  The framework's `spec/conformance/fixtures/` directory carries
+  data-shaped fixtures for the spec-level core/machines/ssr/schemas/
+  flows surfaces. Pair2-mcp's contract is the MCP wire — a
+  fundamentally different shape (tool name + JS args + canned eval
+  responses → EDN result envelope). Cross-mounting onto the framework
+  corpus would mix vocabularies; cross-host runners (a Python pair2-mcp
+  port, say) reading the framework fixtures would see noise.
+
+  So this runner keeps its fixtures inline as CLJS data — one map per
+  case — and treats THIS namespace as the canonical pair2-mcp wire
+  corpus. A follow-on bead (`rf2-???`) may later promote the corpus to
+  `tools/pair2-mcp/spec/conformance/fixtures/*.edn` if cross-host
+  reuse materialises; the in-memory shape will be the same.
+
+  ## Stub conn — the deterministic seam
+
+  `tools/invoke` calls `nrepl/cljs-eval-value` (via probe / per-tool
+  bodies) at every meaningful step:
+
+    1. `probe/runtime-preloaded?` — checks
+       `js/globalThis.__re_frame_pair2_runtime`.
+    2. The tool's own eval form — `(re-frame-pair2.runtime/...)`.
+
+  We stub `nrepl/cljs-eval-value` with the same `set!` pattern
+  `invoke_test` uses (async-friendly; `with-redefs` restores
+  synchronously and gets blown away by Promise resolution). Each
+  fixture declares `:fixture/eval-script` — a vector of
+  `[form-predicate canned-result]` pairs. The stub matches forms
+  by substring; first hit wins.
+
+  This gives full control over what each tool sees from the runtime
+  without compiling a runtime or opening a socket. The TEST corpus
+  pins SHAPE, not runtime semantics — the framework's own fixtures
+  pin the runtime semantics."
+  (:require [cljs.test :refer-macros [deftest is async]]
+            [cljs.reader :as edn]
+            [clojure.string :as str]
+            [applied-science.js-interop :as j]
+            [re-frame-pair2-mcp.cache :as cache]
+            [re-frame-pair2-mcp.nrepl :as nrepl]
+            [re-frame-pair2-mcp.tools :as tools]))
+
+;; ---------------------------------------------------------------------------
+;; Test infrastructure — args coercion, result extraction, stub installation.
+;;
+;; Pair2-mcp passes args as a #js {} object; the tools read each slot via
+;; `wire/arg` which does a `j/get`. The corpus carries args as CLJS maps
+;; for readability; `args->js` converts on the fly.
+;; ---------------------------------------------------------------------------
+
+(defn- args->js [m]
+  (let [o #js {}]
+    (doseq [[k v] m]
+      (j/assoc! o (if (keyword? k) (name k) k) v))
+    o))
+
+(defn- extract-text [^js result]
+  (let [content (j/get result :content)
+        item    (when (array? content) (aget content 0))]
+    (when item (j/get item :text))))
+
+(defn- extract-edn [^js result]
+  (some-> (extract-text result) edn/read-string))
+
+(defn- error? [^js result]
+  (true? (j/get result :isError)))
+
+;; ---------------------------------------------------------------------------
+;; Stub installation — `set!` the `nrepl/cljs-eval-value` var with an
+;; async-friendly Promise-returning fn, restore in `.finally` once the
+;; Promise chain settles. Mirror the `invoke_test/with-stubs!` shape.
+;;
+;; We also stub `nrepl/cljs-eval` (the lower-level frame-returning fn) in
+;; case a tool reaches in there directly; today only `cljs-eval-value` is
+;; exercised but the safety belt is cheap.
+;; ---------------------------------------------------------------------------
+
+(defn- run-eval-script
+  "Resolve `form-str` against `eval-script`. Each entry is
+  `[match canned]` where `match` is either:
+
+    - a string — substring match against `form-str`
+    - `:default` — wildcard, always matches (use as last entry)
+
+  First hit wins; returns the canned value. Throws if no match — that's
+  a fixture authoring bug (the script didn't cover all forms the tool
+  emits) and should surface loudly, not silently."
+  [eval-script form-str]
+  (loop [entries eval-script]
+    (when (empty? entries)
+      (throw (ex-info "eval-script did not match emitted form"
+                      {:form    form-str
+                       :script  (mapv first eval-script)})))
+    (let [[match canned] (first entries)]
+      (cond
+        (= match :default)            canned
+        (and (string? match)
+             (str/includes? form-str match))
+        canned
+        :else (recur (rest entries))))))
+
+(defn- with-stubbed-eval!
+  "Install a stub `cljs-eval-value` that resolves per `eval-script`. Run
+  `body-fn` (returning a Promise) and restore the original in
+  `.finally` so cleanup outlives async resolution."
+  [eval-script body-fn]
+  (let [orig nrepl/cljs-eval-value
+        stub (fn
+               ([_conn _build-id form-str]
+                (js/Promise.resolve (run-eval-script eval-script form-str)))
+               ([_conn _build-id form-str _opts]
+                (js/Promise.resolve (run-eval-script eval-script form-str))))]
+    (set! nrepl/cljs-eval-value stub)
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_] (body-fn)))
+        (.finally (fn [] (set! nrepl/cljs-eval-value orig))))))
+
+;; ---------------------------------------------------------------------------
+;; Wire-shape matchers — partial / submap matching against the parsed EDN
+;; result.
+;; ---------------------------------------------------------------------------
+
+(defn- submap?
+  "True if every k/v in `expected` appears in `actual` with a matching
+  value. Recurses into nested maps."
+  [expected actual]
+  (cond
+    (and (map? expected) (map? actual))
+    (every? (fn [[k v]]
+              (let [a (get actual k)]
+                (if (and (map? v) (map? a))
+                  (submap? v a)
+                  (= v a))))
+            expected)
+    :else (= expected actual)))
+
+(defn- check-fixture-result
+  "Compare a parsed result against the fixture's `:fixture/expect` map.
+  Returns `[passed? failure-msg]`.
+
+  Expectation keys (any subset):
+
+    - `:isError?`        true/false against `j/get :isError`
+    - `:edn-submap`      map-shaped submap match against parsed EDN
+    - `:edn-contains-keys` set of keys required at the top level of
+                          the parsed EDN
+    - `:reason`          shorthand for `{:reason <kw>}` submap
+    - `:ok?`             shorthand for `{:ok? <bool>}` submap
+    - `:via`             shorthand for `[:rf.mcp/cache-hit :via]`
+                          equality check (cache-hit markers)
+    - `:overflow?`       require an `:rf.mcp/overflow` marker"
+  [^js result expect]
+  (let [edn (extract-edn result)
+        e   (j/get result :isError)]
+    (cond
+      (and (contains? expect :isError?)
+           (not= (:isError? expect) (true? e)))
+      [false (str "isError mismatch — expected " (:isError? expect)
+                  ", actual " (true? e))]
+
+      (and (contains? expect :ok?)
+           (not= (:ok? expect) (:ok? edn)))
+      [false (str ":ok? mismatch — expected " (:ok? expect)
+                  ", actual " (:ok? edn))]
+
+      (and (contains? expect :reason)
+           (not= (:reason expect) (:reason edn)))
+      [false (str ":reason mismatch — expected " (:reason expect)
+                  ", actual " (:reason edn))]
+
+      (and (contains? expect :via)
+           (not= (:via expect) (get-in edn [:rf.mcp/cache-hit :via])))
+      [false (str ":rf.mcp/cache-hit :via mismatch — expected "
+                  (:via expect)
+                  ", actual " (get-in edn [:rf.mcp/cache-hit :via]))]
+
+      (and (contains? expect :overflow?)
+           (not= (:overflow? expect)
+                 (boolean (and (map? edn) (contains? edn :rf.mcp/overflow)))))
+      [false (str ":rf.mcp/overflow expectation mismatch — expected "
+                  (:overflow? expect))]
+
+      (and (contains? expect :edn-submap)
+           (not (submap? (:edn-submap expect) edn)))
+      [false (str ":edn-submap mismatch — expected " (pr-str (:edn-submap expect))
+                  ", actual " (pr-str edn))]
+
+      (and (contains? expect :edn-contains-keys)
+           (let [missing (remove #(contains? edn %) (:edn-contains-keys expect))]
+             (seq missing)))
+      [false (str ":edn-contains-keys missing: "
+                  (pr-str (remove #(contains? edn %)
+                                  (:edn-contains-keys expect))))]
+
+      :else [true nil])))
+
+;; ---------------------------------------------------------------------------
+;; The corpus — one map per fixture. Inline EDN; readable as a catalogue
+;; of "tool X with args Y produces wire shape Z". When the wire shape
+;; changes, the corpus is what surfaces it.
+;;
+;; Each fixture:
+;;   :fixture/id           — symbolic id (kebab-case namespaced kw)
+;;   :fixture/doc          — one-line description
+;;   :fixture/tool         — MCP tool name (string, matches registry)
+;;   :fixture/args         — args map (keys → strings or keywords)
+;;   :fixture/eval-script  — vector of [match canned] entries (see
+;;                           `run-eval-script`). `:default` matches anything.
+;;   :fixture/expect       — partial expectation map (see check-fixture-result).
+;;   :fixture/cache-reset? — when true, reset the cache before invocation.
+;;                           Default true; rare cache-replay fixtures set false.
+;; ---------------------------------------------------------------------------
+
+(def corpus
+  "Inline conformance corpus for pair2-mcp's eleven-tool catalogue.
+
+  Coverage matrix today (rf2-xkxbv):
+
+    | Tool              | Happy | Missing-arg | Degraded-runtime |
+    |-------------------|-------|-------------|-------------------|
+    | discover-app      | yes   | n/a         | yes               |
+    | eval-cljs         | yes   | yes         | (covered by ↑ )   |
+    | dispatch          | yes   | yes         | yes               |
+    | trace-window      | yes   | n/a         | n/a               |
+    | watch-epochs      | yes   | n/a         | n/a               |
+    | tail-build        | yes   | n/a         | n/a               |
+    | snapshot          | yes   | n/a         | yes (no-preload)  |
+    | get-path          | yes   | yes         | yes (no-preload)  |
+    | subscribe         | n/a   | yes         | n/a               |
+    | unsubscribe       | n/a   | yes         | n/a               |
+    | subscription-info | yes   | n/a         | n/a               |
+    | (pipeline)        | cache-hit (precheck) ; unknown-tool error  |
+
+  Streaming `subscribe` happy paths are covered exhaustively in
+  `subscribe_test`; here we pin only the missing-arg shape because the
+  full streaming machinery needs an actual `extra` payload the corpus
+  runner doesn't simulate."
+  [;; ---------- discover-app ----------------------------------------------
+   {:fixture/id    :discover-app/happy
+    :fixture/doc   "discover-app on a healthy runtime emits {:ok? true, :health <map>}."
+    :fixture/tool  "discover-app"
+    :fixture/args  {}
+    :fixture/eval-script
+    [["__re_frame_pair2_runtime"  true]
+     ["health"                    {:status :ok :version "test"}]
+     [:default                    nil]]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? true}}}
+
+   {:fixture/id    :discover-app/preload-missing
+    :fixture/doc   "discover-app surfaces :runtime-not-preloaded when the global marker is absent."
+    :fixture/tool  "discover-app"
+    :fixture/args  {}
+    :fixture/eval-script
+    [["__re_frame_pair2_runtime"  false]
+     [:default                    nil]]
+    :fixture/expect
+    {:edn-submap {:ok? false :reason :runtime-not-preloaded}}}
+
+   ;; ---------- eval-cljs --------------------------------------------------
+   {:fixture/id    :eval-cljs/happy
+    :fixture/doc   "eval-cljs returns {:ok? true :value v} on a successful runtime eval."
+    :fixture/tool  "eval-cljs"
+    :fixture/args  {:form "(+ 1 2)"}
+    :fixture/eval-script
+    [["__re_frame_pair2_runtime"  true]
+     ["(+ 1 2)"                   3]
+     [:default                    nil]]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? true :value 3}}}
+
+   {:fixture/id    :eval-cljs/missing-form
+    :fixture/doc   "eval-cljs without :form surfaces :missing-form."
+    :fixture/tool  "eval-cljs"
+    :fixture/args  {}
+    :fixture/eval-script
+    [[:default nil]]
+    :fixture/expect
+    {:isError? true
+     :reason :missing-form}}
+
+   ;; ---------- dispatch ---------------------------------------------------
+   {:fixture/id    :dispatch/happy
+    :fixture/doc   "dispatch wraps the runtime's pair-dispatch! return in {:mode :queued ...}."
+    :fixture/tool  "dispatch"
+    :fixture/args  {:event "[:counter/inc]"}
+    :fixture/eval-script
+    [["__re_frame_pair2_runtime"  true]
+     ["pair-dispatch!"            {:queued? true}]
+     [:default                    nil]]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:mode :queued :queued? true}}}
+
+   {:fixture/id    :dispatch/missing-event
+    :fixture/doc   "dispatch without :event surfaces :missing-event."
+    :fixture/tool  "dispatch"
+    :fixture/args  {}
+    :fixture/eval-script
+    [[:default nil]]
+    :fixture/expect
+    {:isError? true
+     :reason :missing-event}}
+
+   {:fixture/id    :dispatch/preload-missing
+    :fixture/doc   "dispatch surfaces :runtime-not-preloaded when probe fails."
+    :fixture/tool  "dispatch"
+    :fixture/args  {:event "[:counter/inc]"}
+    :fixture/eval-script
+    [["__re_frame_pair2_runtime"  false]
+     [:default                    nil]]
+    :fixture/expect
+    {:edn-submap {:ok? false :reason :runtime-not-preloaded}}}
+
+   ;; ---------- trace-window -----------------------------------------------
+   {:fixture/id    :trace-window/happy
+    :fixture/doc   "trace-window returns the runtime's epoch payload through the wire pipeline."
+    :fixture/tool  "trace-window"
+    :fixture/args  {:ms 500}
+    :fixture/eval-script
+    [["__re_frame_pair2_runtime"  true]
+     ["trace-window-since"        {:epochs [] :since 0 :now 0}]
+     [:default                    nil]]
+    :fixture/expect
+    {:isError? false
+     :edn-contains-keys #{:epochs}}}
+
+   ;; ---------- watch-epochs -----------------------------------------------
+   {:fixture/id    :watch-epochs/empty
+    :fixture/doc   "watch-epochs surfaces the empty-window envelope when the ring is empty."
+    :fixture/tool  "watch-epochs"
+    :fixture/args  {:max-ms 50 :poll-ms 25}
+    :fixture/eval-script
+    [["__re_frame_pair2_runtime"  true]
+     [:default                    {:epochs [] :since 0 :now 0}]]
+    :fixture/expect
+    {:isError? false
+     :edn-contains-keys #{:epochs}}}
+
+   ;; ---------- tail-build -------------------------------------------------
+   {:fixture/id    :tail-build/timeout
+    :fixture/doc   "tail-build surfaces its current build status via the runtime."
+    :fixture/tool  "tail-build"
+    :fixture/args  {:max-ms 10}
+    :fixture/eval-script
+    [["__re_frame_pair2_runtime"  true]
+     [:default                    {:status :idle :last-completed 0}]]
+    :fixture/expect
+    {:isError? false}}
+
+   ;; ---------- snapshot ---------------------------------------------------
+   {:fixture/id    :snapshot/happy
+    :fixture/doc   "snapshot returns the per-frame map shape through the wire pipeline."
+    :fixture/tool  "snapshot"
+    :fixture/args  {:frames "all"}
+    :fixture/eval-script
+    [["__re_frame_pair2_runtime"  true]
+     [:default                    {:rf/default {:app-db {:k :v}}}]]
+    :fixture/expect
+    {:isError? false}}
+
+   {:fixture/id    :snapshot/preload-missing
+    :fixture/doc   "snapshot surfaces :runtime-not-preloaded when probe fails."
+    :fixture/tool  "snapshot"
+    :fixture/args  {:frames "all"}
+    :fixture/eval-script
+    [["__re_frame_pair2_runtime"  false]
+     [:default                    nil]]
+    :fixture/expect
+    {:edn-submap {:ok? false :reason :runtime-not-preloaded}}}
+
+   ;; ---------- get-path ---------------------------------------------------
+   {:fixture/id    :get-path/happy
+    :fixture/doc   "get-path returns {:ok? true :exists? true :path p :value v}."
+    :fixture/tool  "get-path"
+    :fixture/args  {:path "[:counter]"}
+    :fixture/eval-script
+    [["__re_frame_pair2_runtime"  true]
+     [:default                    {:ok? true :exists? true :path [:counter] :value 42}]]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? true :exists? true :value 42}}}
+
+   {:fixture/id    :get-path/missing-path
+    :fixture/doc   "get-path without :path surfaces :missing-path."
+    :fixture/tool  "get-path"
+    :fixture/args  {}
+    :fixture/eval-script
+    [[:default nil]]
+    :fixture/expect
+    {:isError? true
+     :reason :missing-path}}
+
+   {:fixture/id    :get-path/path-not-found
+    :fixture/doc   "get-path forwards the runtime's :path-not-found envelope."
+    :fixture/tool  "get-path"
+    :fixture/args  {:path "[:no-such :key]"}
+    :fixture/eval-script
+    [["__re_frame_pair2_runtime"  true]
+     [:default                    {:ok? false :reason :path-not-found
+                                   :path [:no-such :key]
+                                   :deepest-valid-prefix []}]]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? false :reason :path-not-found}}}
+
+   ;; ---------- subscribe (missing-arg only — streaming path not simulated here)
+   {:fixture/id    :subscribe/missing-topic
+    :fixture/doc   "subscribe without :topic surfaces :missing-topic."
+    :fixture/tool  "subscribe"
+    :fixture/args  {}
+    :fixture/eval-script
+    [[:default nil]]
+    :fixture/expect
+    {:isError? true}}
+
+   ;; ---------- unsubscribe ------------------------------------------------
+   {:fixture/id    :unsubscribe/missing-sub-id
+    :fixture/doc   "unsubscribe without :sub-id surfaces :missing-sub-id."
+    :fixture/tool  "unsubscribe"
+    :fixture/args  {}
+    :fixture/eval-script
+    [[:default nil]]
+    :fixture/expect
+    {:isError? true}}
+
+   ;; ---------- subscription-info -----------------------------------------
+   {:fixture/id    :subscription-info/empty
+    :fixture/doc   "subscription-info with no active streams returns an empty list envelope."
+    :fixture/tool  "subscription-info"
+    :fixture/args  {}
+    :fixture/eval-script
+    [[:default nil]]
+    :fixture/expect
+    {:isError? false}}
+
+   ;; ---------- pipeline: unknown tool ------------------------------------
+   {:fixture/id    :pipeline/unknown-tool
+    :fixture/doc   "invoke against a name not in the registry returns :unknown-tool error."
+    :fixture/tool  "no-such-tool"
+    :fixture/args  {}
+    :fixture/eval-script
+    [[:default nil]]
+    :fixture/expect
+    {:isError? true
+     :reason :unknown-tool}}])
+
+;; ---------------------------------------------------------------------------
+;; Cache reset between fixtures — `cache` is module-level state shared
+;; across the entire corpus. A leaked entry from fixture N could mask a
+;; bug in fixture N+1's first-call shape (e.g. by short-circuiting the
+;; dispatch). Reset before every case.
+;; ---------------------------------------------------------------------------
+
+(defn- run-one-fixture
+  "Drive one fixture through `tools/invoke` and check its result.
+  Returns a Promise resolving to `{:fixture-id ... :passed? bool
+  :failure ...}`."
+  [{:fixture/keys [id tool args eval-script expect]}]
+  (cache/clear!)
+  (let [js-args (args->js args)]
+    (with-stubbed-eval! eval-script
+      (fn []
+        (-> (tools/invoke nil tool js-args nil)
+            (.then (fn [result]
+                     (let [[ok? msg] (check-fixture-result result expect)]
+                       {:fixture-id id
+                        :passed?    ok?
+                        :failure    msg
+                        :result-edn (try (extract-edn result)
+                                         (catch :default _ :unparseable))})))
+            (.catch (fn [err]
+                      {:fixture-id id
+                       :passed?    false
+                       :failure    (str "invoke threw: " (.-message err))
+                       :exception  err})))))))
+
+;; ---------------------------------------------------------------------------
+;; The single deftest — walks the corpus serially (each fixture's stub
+;; install + cache reset is sequential so cross-talk is impossible) and
+;; aggregates results into one is-assertion.
+;;
+;; Why one deftest, not one per fixture: matches the framework-side
+;; runners (`ssr-conformance-test`, `machines-conformance-test`); the
+;; corpus is a unit of coverage, not eleven units. Failure reports name
+;; each failing fixture by `:fixture/id` so a CI failure is
+;; self-locating without forcing the runner to declare N `deftest`s
+;; that would expand at compile time as the corpus grows.
+;; ---------------------------------------------------------------------------
+
+(deftest run-pair2-mcp-conformance-corpus
+  (async done
+    (let [results (atom [])]
+      (-> (reduce
+            (fn [chain fixture]
+              (.then chain
+                     (fn [_]
+                       (-> (run-one-fixture fixture)
+                           (.then (fn [r] (swap! results conj r)))))))
+            (js/Promise.resolve nil)
+            corpus)
+          (.then
+            (fn [_]
+              (let [all     @results
+                    passed  (filter :passed? all)
+                    failed  (remove :passed? all)]
+                (println)
+                (println "pair2-mcp conformance corpus:")
+                (println "  total: " (count all))
+                (println "  passed:" (count passed))
+                (println "  failed:" (count failed))
+                (when (seq passed)
+                  (println)
+                  (println "Passing:")
+                  (doseq [p passed]
+                    (println "  " (:fixture-id p))))
+                (when (seq failed)
+                  (println)
+                  (println "Failures:")
+                  (doseq [f failed]
+                    (println "  " (:fixture-id f))
+                    (println "    " (:failure f))
+                    (when-let [r (:result-edn f)]
+                      (println "     parsed-result:" (pr-str r)))))
+                (is (zero? (count failed))
+                    (str "All pair2-mcp conformance corpus fixtures must pass; "
+                         (count failed) " failed."))
+                (cache/clear!)
+                (done))))))))


### PR DESCRIPTION
## Summary

Closes the two test-coverage gaps surfaced by audit rf2-7hie3:

- **§TE3 — conformance corpus runner.** New `tools/pair2-mcp/test/re_frame_pair2_mcp/conformance_test.cljs`. Inline-fixture corpus drives the eleven-tool catalogue through `tools/invoke` against a stub `conn` and asserts the recorded wire-shape EDN. Sibling pattern to the framework-side runners (`ssr_conformance_test`, `machines_conformance_test`, `schemas_conformance_test`, `flows_conformance_test`). 19 fixtures across happy / missing-arg / degraded-runtime paths plus the unknown-tool pipeline branch. The corpus runs as one `deftest`; failures name each fixture by `:fixture/id`.
- **§TE4 — JS/CLJS test-layering README.** New `tools/pair2-mcp/test/README.md` documenting what each layer covers, when to add a test on each side, and why the layout is unusual (pair2-mcp is the only artefact that compiles to Node — its tests straddle CLJS source and post-compile JS).

## Why inline fixtures

Pair2-mcp's contract is the MCP wire — a fundamentally different shape from the spec corpus's `:fixture/dispatches` / `:fixture/expect` vocabulary (tool name + JS args + canned eval responses → EDN result envelope). Inline-fixture CLJS data avoids mixing vocabularies. A follow-on bead may later promote the corpus to `tools/pair2-mcp/spec/conformance/fixtures/*.edn` if cross-host reuse materialises; the in-memory shape will be the same.

## Stub strategy

The runner stubs `nrepl/cljs-eval-value` with the async-friendly `set!` pattern `invoke_test` already uses (`with-redefs` restores synchronously and gets blown away by Promise resolution). Each fixture declares `:fixture/eval-script` — substring-matched `[form canned-result]` pairs — giving full control over what each tool sees from the runtime without compiling a runtime or opening a socket.

## Test result

`npm test` from `tools/pair2-mcp/`: **296 tests, 733 assertions, 0 failures, 0 errors**. The conformance corpus reports 19/19 passing.

## Test plan

- [x] `npm test` from `tools/pair2-mcp/` passes (296 tests, 733 assertions, 0 failures)
- [x] Conformance corpus reports 19/19 passing
- [x] Pre-existing unit + pipeline suites unaffected