### PR TITLE
refactor(story): registrar + shell-state polish (rf2-uefbk)

### DIFF
--- a/tools/story/spec/009-Test-Mode.md
+++ b/tools/story/spec/009-Test-Mode.md
@@ -248,11 +248,17 @@ aggregation surface is the **test widget** that sits at the foot of
 the sidebar plus the **status dots** that render next to each
 testable variant row.
 
-Both surfaces read from one slot in the shell state — `:test-runs`,
-a `{variant-id → {:status :pass|:fail|:running|:pending, :passed,
-:failed, :skipped, :total, :ran-at-ms, :elapsed-ms}}` map. The
-`:test` mode pane and the chrome widget both write into it; the
-sidebar's per-variant row reads its dot's colour from it.
+Both surfaces read from one slot in the shell state —
+`[:tests :runs]`, a `{variant-id → {:status :pass|:fail|:running|
+:pending, :passed, :failed, :skipped, :total, :ran-at-ms, :elapsed-
+ms}}` map. The `:test` mode pane and the chrome widget both write
+into it; the sidebar's per-variant row reads its dot's colour from
+it.
+
+The full chrome-test-widget surface lives under one `:tests` sub-map
+of the shell state (rf2-uefbk): `[:tests :runs]` (above),
+`[:tests :watch-mode?]` (the eye-icon toggle), and `[:tests :content-
+hashes]` (the watch-mode detector's drift baseline).
 
 ### Surface
 
@@ -305,8 +311,8 @@ The widget's **Run all** button drives `run-variant` over every
 testable variant. Runs dispatch in parallel — each variant runs in
 its own frame per Spec 002 §Programmatic API, so concurrent runs
 don't cross-contaminate `app-db`. Per-variant runs from the
-`:test` pane's Re-run button fold into the same `:test-runs` slot,
-so the chrome widget and the pane stay in sync.
+`:test` pane's Re-run button fold into the same `[:tests :runs]`
+slot, so the chrome widget and the pane stay in sync.
 
 ### Test selectors
 
@@ -325,10 +331,11 @@ so the chrome widget and the pane stay in sync.
 Storybook 9's Vitest addon ships a watch-mode toggle (eye icon) that
 re-runs the changed stories on file save. Story's parity surface is
 the **watch chip** beneath the count chips. It toggles a boolean
-(`:test-watch-mode?`) in the shell state. When on, the shell's poll
-detector computes a snapshot-identity content-hash per testable
-variant and compares it against the recorded `:test-content-hashes`
-slot; any drift dispatches `sidebar/watch-rerun!` for the affected
+(`[:tests :watch-mode?]`) in the shell state. When on, the shell's
+poll detector computes a snapshot-identity content-hash per testable
+variant and compares it against the recorded
+`[:tests :content-hashes]` slot; any drift dispatches
+`sidebar/watch-rerun!` for the affected
 variants — the sidebar dots transit through `:running` to the new
 `:pass` / `:fail` exactly as if the user had clicked Re-run.
 
@@ -339,7 +346,7 @@ hash (per `re-frame.story.identity/snapshot-identity` + IMPL-SPEC
 produces a fresh hash. Cosmetic edits (docstring, `:source` coords)
 do not contribute.
 
-Toggle-off clears `:test-content-hashes` so the next toggle-on
+Toggle-off clears `[:tests :content-hashes]` so the next toggle-on
 seeds a fresh baseline from the current registry (no spurious
 re-run on toggle-on). Toggle-on without subsequent changes is a
 no-op once the baseline lands.
@@ -369,7 +376,8 @@ Per the rf2-9hc8 / rf2-rodx / rf2-qmjo / rf2-q0irb tetrad: the
 the foundation (the four-phase runtime, the seven canonical
 `:rf.assert/*` events, the `:assertions` record schema) and surface
 it. They do not register new artefact kinds; the only new shell-
-state slot is `:test-runs`, which is a pure derivation of
-`run-variant` results keyed by variant id. Removing them restores
+state surface is the `:tests` sub-map (`[:tests :runs]` /
+`[:tests :watch-mode?]` / `[:tests :content-hashes]`), which is a
+pure derivation of `run-variant` results keyed by variant id. Removing them restores
 the placeholder-equivalent empty pane and the dot-free sidebar
 without breaking any other surface.

--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -352,14 +352,6 @@
           (filter (fn [vid] (= (namespace vid) story-ns)))
           (ids :variant))))
 
-(defn variants-with-tag
-  "Return the variant ids whose `:tags` set contains `tag`."
-  [tag]
-  (->> (handlers :variant)
-       (filter (fn [[_ body]] (contains? (:tags body) tag)))
-       (map first)
-       set))
-
 (defn variants-with-tags
   "Return the variant ids whose `:tags` set intersects `query-tags`. Per
   IMPL-SPEC §3.2 — the public `variants-with-tags` wraps this."
@@ -372,6 +364,17 @@
          (map first)
          set)))
 
+(defn- query-tags-by
+  "Pure data → data: return the set of registered tag ids whose body
+  matches `pred`. Shared core of the `tags-by-axis` / `tags-without-
+  axis` / `tags-default-excluded` queries — each is a one-line predicate
+  over the same `{tag-id → tag-body}` scan."
+  [pred]
+  (->> (handlers :tag)
+       (filter (fn [[_ body]] (pred body)))
+       (map first)
+       set))
+
 (defn tags-by-axis
   "Return the set of registered tag ids whose body's `:axis` equals
   `axis-kw`. Per spec/001 §reg-tag the optional `:axis` slot groups
@@ -379,26 +382,17 @@
   parity). Tags registered without `:axis` are excluded from every
   axis-keyed result."
   [axis-kw]
-  (->> (handlers :tag)
-       (filter (fn [[_ body]] (= axis-kw (:axis body))))
-       (map first)
-       set))
+  (query-tags-by #(= axis-kw (:axis %))))
 
 (defn tags-without-axis
   "Return the set of registered tag ids whose body carries no `:axis`.
   The sidebar renders these in a trailing un-grouped facet row."
   []
-  (->> (handlers :tag)
-       (filter (fn [[_ body]] (nil? (:axis body))))
-       (map first)
-       set))
+  (query-tags-by #(nil? (:axis %))))
 
 (defn tags-default-excluded
   "Return the set of registered tag ids whose body's `:default-filter`
   is `:exclude`. The sidebar tag-filter pre-excludes variants carrying
   any of these at boot (e.g. `:internal` / `:experimental`)."
   []
-  (->> (handlers :tag)
-       (filter (fn [[_ body]] (= :exclude (:default-filter body))))
-       (map first)
-       set))
+  (query-tags-by #(= :exclude (:default-filter %))))

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -134,11 +134,11 @@
 
 ;; ---- watch-mode detector (rf2-z1h0f) -------------------------------------
 ;;
-;; The chrome-level test widget's eye-icon toggles `:test-watch-mode?`
-;; in the shell state. When on, this poll computes a snapshot-identity
-;; content-hash per testable variant, compares it against the recorded
-;; `:test-content-hashes` slot, and dispatches `sidebar/watch-rerun!`
-;; for the variants whose hash drifted.
+;; The chrome-level test widget's eye-icon toggles `[:tests :watch-
+;; mode?]` in the shell state. When on, this poll computes a snapshot-
+;; identity content-hash per testable variant, compares it against the
+;; recorded `[:tests :content-hashes]` slot, and dispatches
+;; `sidebar/watch-rerun!` for the variants whose hash drifted.
 ;;
 ;; Detection runs on the same 500ms cadence as the existing hot-reload
 ;; poll — both polls share `setInterval` for v1; v2 will wire to the
@@ -175,7 +175,7 @@
   (when (and config/enabled? (state/test-watch-mode? (state/get-state)))
     (let [current (compute-testable-content-hashes)
           shell   (state/get-state)
-          prev    (:test-content-hashes shell)
+          prev    (get-in shell [:tests :content-hashes])
           drifted (state/watch-mode-drift prev current)]
       ;; Always stamp the fresh hashes so the next poll diffs against
       ;; the post-drift baseline (rather than re-firing forever).

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -213,10 +213,10 @@
 ;; ---- pure: per-variant status dot (rf2-q0irb) ---------------------------
 
 (def status->dot-style-key
-  "Pure data → data: map a `:test-runs` status keyword to the styles
-  map key that renders its dot colour. The render-only mapping lives
-  next to the canonical statuses so both surfaces (sidebar dot, chrome
-  widget) can JVM-test the projection without booting Reagent."
+  "Pure data → data: map a `[:tests :runs]` status keyword to the
+  styles map key that renders its dot colour. The render-only mapping
+  lives next to the canonical statuses so both surfaces (sidebar dot,
+  chrome widget) can JVM-test the projection without booting Reagent."
   {:pass    :dot-pass
    :fail    :dot-fail
    :running :dot-running
@@ -279,7 +279,7 @@
           (str tag)]))]))
 
 (defn status-dot
-  "Render the per-variant status glyph. Variants not in `:test-runs`
+  "Render the per-variant status glyph. Variants not in `[:tests :runs]`
   (no recorded run AND not tagged `:test`/empty `:play`) skip the dot
   entirely — the row layout shifts left a few pixels but stays
   readable. Variants whose status is `:pending` show an empty-ring dot
@@ -377,7 +377,7 @@
 
 (defn- run-one-test!
   "Dispatch a single `run-variant` against `vid` and fold the result
-  into the shell-state `:test-runs` slot. Marks `:running` up front,
+  into the shell-state `[:tests :runs]` slot. Marks `:running` up front,
   records pass/fail/skip counts on resolve, and clears the slot on
   rejection. Shared between the chrome widget's 'Run all' button and
   the watch-mode auto-re-run (rf2-z1h0f).
@@ -426,9 +426,9 @@
   `run-variant` for the given seq of variant-ids whose snapshot-identity
   drifted since the last observation. Shares the same per-variant
   pipeline as 'Run all' — marks running, folds the result into
-  `:test-runs` — so the sidebar dots and chrome widget headline transit
-  through `:running` to the new `:pass` / `:fail` exactly as if the user
-  had clicked the button.
+  `[:tests :runs]` — so the sidebar dots and chrome widget headline
+  transit through `:running` to the new `:pass` / `:fail` exactly as
+  if the user had clicked the button.
 
   Called from `re-frame.story.ui.shell/detect-and-tick!` when watch
   mode is on and a drift is detected."
@@ -494,7 +494,7 @@
          (if any-run? "Running…" "Run all")]
         ;; rf2-z1h0f — watch-mode toggle. Eye glyph reads on/off; the
         ;; chip's aria-pressed reflects the boolean. Toggle-on seeds
-        ;; `:test-content-hashes` so the first detector tick after
+        ;; `[:tests :content-hashes]` so the first detector tick after
         ;; toggle-on doesn't fire a spurious re-run for every variant.
         [:div {:style (:watch-row styles)}
          [:button
@@ -525,7 +525,7 @@
   Per rf2-q0irb the sidebar carries two extra surfaces — the per-
   variant status dots (rendered inside each variant row when the
   variant is `:test`-tagged + `:play`-bearing) and the chrome-level
-  test widget at the foot. Both read from `:test-runs`; the widget
+  test widget at the foot. Both read from `[:tests :runs]`; the widget
   drives `run-variant` over the testable set on click."
   []
   (let [shell         @state/shell-state-atom
@@ -536,7 +536,7 @@
         visible       (state/filter-variants (:variants registry) tag-filter)
         grouped       (state/group-variants-by-story visible)
         workspaces    (:workspaces registry)
-        test-runs     (:test-runs shell)
+        test-runs     (get-in shell [:tests :runs])
         testable-set  (set (state/testable-variant-ids (:variants registry)))]
     [:nav {:style      (:wrap styles)
            :aria-label "Stories and workspaces"

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -12,9 +12,11 @@
   - `select-workspace`   — change the focused workspace id.
   - `toggle-tag-filter`  — flip a tag on/off in the filter set.
   - `set-active-modes`   — replace the active mode set.
-  - `set-cell-override`  — set a single arg override (scalar key or
-                           nested path; the nested-path arity backs the
-                           nested-schema controls walker, rf2-agshe).
+  - `set-cell-override`  — set a single arg override at a path
+                           `[arg-key & sub-path]`; the nested-path
+                           form backs the nested-schema controls
+                           walker (rf2-agshe). The `-scalar` wrapper
+                           handles the bare top-level arg-key case.
   - `clear-cell-overrides` — drop all overrides for the focused variant.
   - `filter-variants`    — pure fn: given a set of variant bodies + the
                            shell state, return the visible subset.
@@ -66,31 +68,34 @@
                            Unspecified → :dev (canvas). Persisted in
                            localStorage under `re-frame.story/active-
                            mode-tab/<variant-id>`.
-  - `:test-runs`        — {variant-id → run-state}. Per-variant test-run
-                           record fed both by the `:test` mode pane's
-                           Re-run button and by the chrome-level test
-                           widget's 'Run all'. Each run-state is one of:
-                              :pending  — no run recorded
-                              :running  — run in flight
-                              :pass     — last run: all assertions passed
-                              :fail     — last run: ≥1 assertion failed
-                           plus pass/fail/skip/total counts and timing.
-                           Powers both the chrome widget's aggregate
-                           summary and the sidebar's per-variant dots
-                           (rf2-q0irb).
-  - `:test-watch-mode?` — boolean. When true the chrome test widget's
-                           eye-icon toggle is on and the shell auto-
-                           re-runs testable variants whose snapshot
-                           identity drifted since the last observation
-                           (rf2-z1h0f). Default false — explicit re-run
-                           is the v1 contract; watch-mode is opt-in.
-  - `:test-content-hashes` — {variant-id → hex-hash} the last-observed
-                           snapshot-identity content hash per testable
-                           variant. The watch-mode detector compares the
-                           current registry's hashes against this slot;
-                           a delta triggers an auto-rerun for the
-                           affected variants. Empty when watch mode is
-                           off (the detector seeds it on toggle-on)."
+  - `:tests` — sub-map grouping every chrome-test-widget slot under
+               one root (rf2-uefbk). Holds:
+
+      `:runs`           — {variant-id → run-state}. Per-variant test-run
+                          record fed both by the `:test` mode pane's
+                          Re-run button and by the chrome-level test
+                          widget's 'Run all'. Each run-state is one of:
+                             :pending  — no run recorded
+                             :running  — run in flight
+                             :pass     — last run: all assertions passed
+                             :fail     — last run: ≥1 assertion failed
+                          plus pass/fail/skip/total counts and timing.
+                          Powers both the chrome widget's aggregate
+                          summary and the sidebar's per-variant dots
+                          (rf2-q0irb).
+      `:watch-mode?`    — boolean. When true the chrome test widget's
+                          eye-icon toggle is on and the shell auto-
+                          re-runs testable variants whose snapshot
+                          identity drifted since the last observation
+                          (rf2-z1h0f). Default false — explicit re-run
+                          is the v1 contract; watch-mode is opt-in.
+      `:content-hashes` — {variant-id → hex-hash} the last-observed
+                          snapshot-identity content hash per testable
+                          variant. The watch-mode detector compares the
+                          current registry's hashes against this slot;
+                          a delta triggers an auto-rerun for the
+                          affected variants. Empty when watch mode is
+                          off (the detector seeds it on toggle-on)."
   {:selected-variant    nil
    :selected-workspace  nil
    :tag-filter          #{}
@@ -102,9 +107,9 @@
    :pinned-snapshots    {}
    :panel-visibility    {:trace true :scrubber true :controls true :actions true}
    :active-mode-tab     {}
-   :test-runs           {}
-   :test-watch-mode?    false
-   :test-content-hashes {}})
+   :tests               {:runs           {}
+                         :watch-mode?    false
+                         :content-hashes {}}})
 
 ;; ---- pure transition fns (JVM-testable) ----------------------------------
 
@@ -174,55 +179,52 @@
   (assoc state :active-modes []))
 
 (defn group-modes-by-axis
-  "Build the toolbar's chip layout: `{axis [mode-id ...]}` for every
-  `:axis`-tagged mode plus an `::unaxed` bucket for axis-less modes.
-  Within each bucket the ids are sorted alphabetically. Pure data →
-  data; JVM-testable.
+  "Build the toolbar's chip layout. Pure data → data; JVM-testable.
 
   `id->body` is the `{mode-id → mode-body}` map from
-  `(registrar/handlers :mode)`. Returns a sorted-by-axis seq of
-  `[axis [mode-id ...]]` pairs — the `::unaxed` bucket always sorts
-  last so axis-tagged groups render left-to-right with the trailing
-  un-grouped chips on the right."
+  `(registrar/handlers :mode)`. Returns
+
+      {:axes   [[axis [mode-id ...]] ...]  ; sorted alphabetically by axis-name
+       :unaxed [mode-id ...]}              ; un-grouped modes, sorted alphabetically
+
+  — an explicit two-slot map (no sentinels). The caller renders the
+  axis-tagged groups left-to-right and the un-grouped chips at the
+  trailing edge. Within each bucket the ids are sorted alphabetically."
   [id->body]
   (let [axed   (->> id->body
                     (filter (fn [[_ b]] (some? (:axis b))))
                     (group-by (fn [[_ b]] (:axis b)))
                     (map (fn [[axis pairs]]
                            [axis (vec (sort (map first pairs)))]))
-                    (sort-by (fn [[axis _]] (str axis))))
+                    (sort-by (fn [[axis _]] (str axis)))
+                    vec)
         unaxed (->> id->body
                     (filter (fn [[_ b]] (nil? (:axis b))))
                     (map first)
                     sort
                     vec)]
-    (cond-> (vec axed)
-      (seq unaxed) (conj [::unaxed unaxed]))))
+    {:axes axed :unaxed unaxed}))
 
 (defn set-cell-override
-  "Set a single arg override for `variant-id`. The override may target
-  either a top-level arg-key (scalar arity) or a nested path within the
-  arg's value (vector arity — used by the nested Malli walker per
-  rf2-agshe). The vector arity is path-aware: the first element is the
-  top-level arg-key; the remaining elements address into the nested
-  value via `assoc-in` semantics.
+  "Set a single arg override for `variant-id`. `path` is a vector
+  `[arg-key & sub-path]` — the first element is the top-level arg-key,
+  the remaining elements address into the nested value via `assoc-in`
+  semantics. Used by the nested Malli walker per rf2-agshe.
 
-  - 3-arity:           `(set-cell-override state v k v)` — scalar override.
-  - vector-key arity:  `(set-cell-override state v [k & path] value)` —
-                       nested override. When `path` is empty the call is
-                       equivalent to the scalar form."
-  [state variant-id arg-key-or-path value]
-  (cond
-    (and (sequential? arg-key-or-path) (seq arg-key-or-path))
-    (let [[k & path] arg-key-or-path]
-      (assoc-in state (into [:cell-overrides variant-id k] path) value))
+  An empty path is a no-op (caller error; the state is returned
+  unchanged). For top-level scalar overrides use `set-cell-override-
+  scalar`, a thin wrapper that wraps the arg-key in a singleton vector."
+  [state variant-id path value]
+  (if (seq path)
+    (assoc-in state (into [:cell-overrides variant-id] path) value)
+    state))
 
-    (sequential? arg-key-or-path)
-    ;; Empty path — no-op (caller error; leave state untouched).
-    state
-
-    :else
-    (assoc-in state [:cell-overrides variant-id arg-key-or-path] value)))
+(defn set-cell-override-scalar
+  "Set a top-level arg override for `variant-id`. Thin wrapper around
+  `set-cell-override` for the scalar case (no nested walk). Equivalent
+  to `(set-cell-override state variant-id [arg-key] value)`."
+  [state variant-id arg-key value]
+  (set-cell-override state variant-id [arg-key] value))
 
 (defn clear-cell-overrides
   "Drop every override for `variant-id`."
@@ -403,10 +405,10 @@
 ;; ---- test-runs (rf2-q0irb) ----------------------------------------------
 ;;
 ;; Cross-variant aggregation surface: each variant's last `run-variant`
-;; outcome is folded into `:test-runs`. The chrome-level test widget
-;; reads it as a summary; the sidebar's per-variant rows read individual
-;; entries as a status dot. Both surfaces are pure derivations of this
-;; one slot.
+;; outcome is folded into `[:tests :runs]`. The chrome-level test
+;; widget reads it as a summary; the sidebar's per-variant rows read
+;; individual entries as a status dot. Both surfaces are pure
+;; derivations of this one slot.
 ;;
 ;; The test-mode pane's local `results-atom` (in
 ;; `re-frame.story.ui.test-mode.state`) keeps the full result-map
@@ -428,7 +430,7 @@
 (defn mark-test-running
   "Stamp `variant-id` as :running. Idempotent."
   [state variant-id]
-  (assoc-in state [:test-runs variant-id] {:status :running}))
+  (assoc-in state [:tests :runs variant-id] {:status :running}))
 
 (defn aggregate-summary
   "Walk `assertions` (the vector pulled off a `run-variant` result map)
@@ -465,7 +467,7 @@
      :all-passed? (and (pos? total) (zero? failed) (zero? skipped))}))
 
 (defn record-test-run
-  "Write the aggregate of a `run-variant` result into `:test-runs`.
+  "Write the aggregate of a `run-variant` result into `[:tests :runs]`.
 
   `summary` is the map returned by `aggregate-summary` —
   `{:total :passed :failed :skipped :all-passed?}` — extended with
@@ -479,7 +481,7 @@
                  (zero? (or total 0)) :pending
                  all-passed?          :pass
                  :else                :fail)]
-    (assoc-in state [:test-runs variant-id]
+    (assoc-in state [:tests :runs variant-id]
               {:status     status
                :total      (or total 0)
                :passed     (or passed 0)
@@ -491,14 +493,14 @@
 (defn clear-test-run
   "Drop the run record for `variant-id`."
   [state variant-id]
-  (update state :test-runs dissoc variant-id))
+  (update-in state [:tests :runs] dissoc variant-id))
 
 (defn variant-test-status
   "Return the canonical status keyword for `variant-id` (one of
   `test-run-statuses`). Variants with no recorded run read `:pending`.
   Pure data → data; JVM-testable."
   [state variant-id]
-  (or (get-in state [:test-runs variant-id :status])
+  (or (get-in state [:tests :runs variant-id :status])
       :pending))
 
 (defn test-summary
@@ -519,15 +521,17 @@
   `:all-passed?` — true only when every variant has a recorded green
   run; a sea of `:pending` reads as 'not green yet', not 'all green'."
   [state variant-ids]
-  (let [runs   (:test-runs state)
-        statuses (mapv (fn [vid] (or (get-in runs [vid :status]) :pending))
-                       variant-ids)
-        total    (count variant-ids)
-        n-of     (fn [k] (count (filter #(= % k) statuses)))
-        passed   (n-of :pass)
-        failed   (n-of :fail)
-        running  (n-of :running)
-        pending  (n-of :pending)]
+  (let [runs    (get-in state [:tests :runs])
+        ;; Single O(N) frequencies pass — read each variant's status
+        ;; once and bucket by keyword. Missing entries default to :pending.
+        buckets (frequencies
+                  (map (fn [vid] (or (get-in runs [vid :status]) :pending))
+                       variant-ids))
+        total   (count variant-ids)
+        passed  (get buckets :pass    0)
+        failed  (get buckets :fail    0)
+        running (get buckets :running 0)
+        pending (get buckets :pending 0)]
     {:total      total
      :passed     passed
      :failed     failed
@@ -566,7 +570,7 @@
 ;; `run-variant` for the variants whose identity changed. The detection
 ;; signal is the variant's snapshot-identity content-hash
 ;; (re-frame.story.identity/snapshot-identity); a delta against the
-;; recorded :test-content-hashes slot triggers the re-run.
+;; recorded [:tests :content-hashes] slot triggers the re-run.
 
 (defn set-test-watch-mode
   "Toggle/set the chrome-level watch-mode flag. When `on?` is true the
@@ -576,25 +580,25 @@
   → data; JVM-testable."
   [state on?]
   (if on?
-    (assoc state :test-watch-mode? true)
-    (-> state
-        (assoc :test-watch-mode? false)
-        (assoc :test-content-hashes {}))))
+    (assoc-in state [:tests :watch-mode?] true)
+    (update state :tests assoc
+            :watch-mode?    false
+            :content-hashes {})))
 
 (defn test-watch-mode?
   "Return `true` iff watch mode is currently on. Pure."
   [state]
-  (boolean (:test-watch-mode? state)))
+  (boolean (get-in state [:tests :watch-mode?])))
 
 (defn record-test-content-hashes
   "Stamp the current snapshot-identity content hashes for every testable
   variant. `id->hash` is `{variant-id → hex-string}`. The detector
   reads this slot on the next tick to decide which variants drifted."
   [state id->hash]
-  (assoc state :test-content-hashes (or id->hash {})))
+  (assoc-in state [:tests :content-hashes] (or id->hash {})))
 
 (defn watch-mode-drift
-  "Pure data → data: given the previous `:test-content-hashes` map and a
+  "Pure data → data: given the previous `[:tests :content-hashes]` map and a
   freshly-computed `current` `{variant-id → hex}` map, return the
   ordered vector of variant-ids whose hash differs from `prev` (i.e.
   the variants the watch-mode detector should re-run on this tick).

--- a/tools/story/src/re_frame/story/ui/test_mode/state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/state.cljs
@@ -49,7 +49,7 @@
 
 (defn- begin-run!
   "Mark the variant's slot as running. Returns nothing. Stamps the
-  shell-state `:test-runs` slot too so the chrome-level test widget
+  shell-state `[:tests :runs]` slot too so the chrome-level test widget
   and the sidebar's per-variant dot read `:running` while the run
   is in flight (rf2-q0irb)."
   [variant-id]
@@ -67,7 +67,7 @@
   has a stable read-surface that doesn't drift on a later
   unrelated dispatch.
 
-  Folds the run's aggregate into the shell-state `:test-runs` slot
+  Folds the run's aggregate into the shell-state `[:tests :runs]` slot
   too — the chrome-level test widget + sidebar dots read off that
   slot (rf2-q0irb)."
   [variant-id result]

--- a/tools/story/src/re_frame/story/ui/toolbar.cljs
+++ b/tools/story/src/re_frame/story/ui/toolbar.cljs
@@ -299,10 +299,10 @@
   `<header role=\"toolbar\">` landmark — the strip itself is a plain
   hiccup `<div>` so axe-core's region rule sees the landmark."
   []
-  (let [shell  @state/shell-state-atom
-        active (set (:active-modes shell))
-        modes  (registrar/handlers :mode)
-        groups (state/group-modes-by-axis modes)]
+  (let [shell    @state/shell-state-atom
+        active   (set (:active-modes shell))
+        modes    (registrar/handlers :mode)
+        {:keys [axes unaxed]} (state/group-modes-by-axis modes)]
     [:header
      {:style      (:strip styles)
       :role       "toolbar"
@@ -311,15 +311,22 @@
      (if (empty? modes)
        [:span {:style (:empty styles)} "no modes registered"]
        (doall
-         (for [[axis ids] groups]
-           ^{:key (str axis)}
-           [:span {:style (:axis-group styles)}
-            (when (not= axis :re-frame.story.ui.state/unaxed)
-              [axis-label axis])
-            [:span {:style (:chip-row styles)}
-             (for [mid ids]
-               ^{:key mid}
-               [chip mid (get modes mid) (contains? active mid)])]])))
+         (concat
+           (for [[axis ids] axes]
+             ^{:key (str axis)}
+             [:span {:style (:axis-group styles)}
+              [axis-label axis]
+              [:span {:style (:chip-row styles)}
+               (for [mid ids]
+                 ^{:key mid}
+                 [chip mid (get modes mid) (contains? active mid)])]])
+           (when (seq unaxed)
+             [^{:key "unaxed"}
+              [:span {:style (:axis-group styles)}
+               [:span {:style (:chip-row styles)}
+                (for [mid unaxed]
+                  ^{:key mid}
+                  [chip mid (get modes mid) (contains? active mid)])]]]))))
      [:span {:style (:spacer styles)}]
      ;; rf2-5fc15 — Test Codegen REC chip. Lives just before the reset
      ;; affordance so the chrome-wide recorder is reachable regardless of

--- a/tools/story/test/re_frame/story/ui/controls_nested_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/controls_nested_cljs_test.cljc
@@ -9,7 +9,8 @@
   Splits into two tiers:
 
   - **JVM + CLJS** (`state.cljc` is `.cljc`) — the path-aware
-    `set-cell-override` arity. Pure data → data.
+    `set-cell-override` fn (plus its `-scalar` wrapper). Pure data →
+    data.
   - **CLJS-only** (`controls.cljs` is CLJS-only — it depends on
     Reagent / DOM) — `infer-widget` widget-spec emission on every
     collection operator, plus `resolve-argtypes` integration with the
@@ -177,40 +178,43 @@
 
 ;; ---- JVM + CLJS: path-aware set-cell-override ---------------------------
 
-(deftest set-cell-override-scalar-arity-unchanged
-  (testing "3-arity with a bare key writes a top-level override"
+(deftest set-cell-override-scalar-wrapper
+  (testing "set-cell-override-scalar wraps the arg-key into a singleton
+            path and writes a top-level override"
     (let [s  state/default-shell-state
-          s1 (state/set-cell-override s :story.a/x :label "hi")]
+          s1 (state/set-cell-override-scalar s :story.a/x :label "hi")]
       (is (= "hi" (get-in s1 [:cell-overrides :story.a/x :label]))))))
 
-(deftest set-cell-override-path-arity-writes-nested
-  (testing "vector-key arity writes at the nested path"
+(deftest set-cell-override-writes-nested
+  (testing "a multi-element path writes at the nested location"
     (let [s  state/default-shell-state
           s1 (state/set-cell-override s :story.a/x [:meta :author] "ada")]
       (is (= "ada" (get-in s1 [:cell-overrides :story.a/x :meta :author]))))))
 
-(deftest set-cell-override-path-arity-deeply-nested
-  (testing "path can address depth ≥ 2"
+(deftest set-cell-override-deeply-nested
+  (testing "path can address depth ≥ 3"
     (let [s  state/default-shell-state
           s1 (state/set-cell-override s :story.a/x
                                       [:outer :inner :leaf] 42)]
       (is (= 42 (get-in s1 [:cell-overrides :story.a/x
                             :outer :inner :leaf]))))))
 
-(deftest set-cell-override-path-arity-with-index
-  (testing "path arity tolerates integer indices (vector slots)"
+(deftest set-cell-override-tolerates-integer-indices
+  (testing "vector indices are valid path elements (per assoc-in)"
     (let [s  state/default-shell-state
           s1 (state/set-cell-override s :story.a/x [:items 0] "x")]
       (is (= "x" (get-in s1 [:cell-overrides :story.a/x :items 0]))))))
 
-(deftest set-cell-override-singleton-vector-path-equivalent-to-scalar
-  (testing "a 1-element vector path is equivalent to the scalar arity"
+(deftest set-cell-override-singleton-path-equivalent-to-scalar-wrapper
+  (testing "a 1-element path produces the same result as the scalar wrapper"
     (let [s  state/default-shell-state
-          s1 (state/set-cell-override s :story.a/x [:label] "hi")]
-      (is (= "hi" (get-in s1 [:cell-overrides :story.a/x :label]))))))
+          via-path   (state/set-cell-override        s :story.a/x [:label] "hi")
+          via-scalar (state/set-cell-override-scalar s :story.a/x  :label  "hi")]
+      (is (= via-path via-scalar))
+      (is (= "hi" (get-in via-path [:cell-overrides :story.a/x :label]))))))
 
-(deftest set-cell-override-empty-vector-path-noop
-  (testing "an empty vector path leaves the state unchanged"
+(deftest set-cell-override-empty-path-noop
+  (testing "an empty path leaves the state unchanged"
     (let [s  state/default-shell-state
           s1 (state/set-cell-override s :story.a/x [] :ignored)]
       (is (= s s1)))))
@@ -218,7 +222,7 @@
 (deftest set-cell-override-roundtrip-deep-then-shallow
   (testing "shallow override at the same arg-key shadows deep entries"
     (let [s0 state/default-shell-state
-          s1 (state/set-cell-override s0 :story.a/x [:meta :author] "ada")
-          s2 (state/set-cell-override s1 :story.a/x :meta {:author "bob"})]
+          s1 (state/set-cell-override        s0 :story.a/x [:meta :author] "ada")
+          s2 (state/set-cell-override-scalar s1 :story.a/x  :meta {:author "bob"})]
       (is (= {:author "bob"}
              (get-in s2 [:cell-overrides :story.a/x :meta]))))))

--- a/tools/story/test/re_frame/story/ui/test_watch_mode_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_watch_mode_cljs_test.cljc
@@ -41,15 +41,15 @@
       (is (true? (state/test-watch-mode? s))))))
 
 (deftest set-test-watch-mode-toggle-off-clears-hashes
-  (testing "toggle-off resets :test-content-hashes so the next toggle-
-            on seeds fresh from the current registry"
+  (testing "toggle-off resets [:tests :content-hashes] so the next
+            toggle-on seeds fresh from the current registry"
     (let [seeded (-> state/default-shell-state
                      (state/set-test-watch-mode true)
                      (state/record-test-content-hashes
                        {:story.x/a "deadbeef"}))
           off    (state/set-test-watch-mode seeded false)]
       (is (false? (state/test-watch-mode? off)))
-      (is (= {} (:test-content-hashes off))))))
+      (is (= {} (get-in off [:tests :content-hashes]))))))
 
 ;; ---- pure: drift detection ----------------------------------------------
 
@@ -97,17 +97,17 @@
 ;; ---- pure: record-test-content-hashes ----------------------------------
 
 (deftest record-test-content-hashes-stamps-slot
-  (testing "record-test-content-hashes writes into :test-content-hashes"
+  (testing "record-test-content-hashes writes into [:tests :content-hashes]"
     (let [s (state/record-test-content-hashes state/default-shell-state
                                               {:story.x/a "aaaa"})]
-      (is (= {:story.x/a "aaaa"} (:test-content-hashes s))))))
+      (is (= {:story.x/a "aaaa"} (get-in s [:tests :content-hashes]))))))
 
 (deftest record-test-content-hashes-nil-clears
   (testing "nil input clears the slot — used by toggle-off"
     (let [s (-> state/default-shell-state
                 (state/record-test-content-hashes {:story.x/a "aaaa"})
                 (state/record-test-content-hashes nil))]
-      (is (= {} (:test-content-hashes s))))))
+      (is (= {} (get-in s [:tests :content-hashes]))))))
 
 ;; ---- CLJS-only: widget renders the watch toggle ------------------------
 
@@ -150,7 +150,7 @@
 
 #?(:cljs
    (deftest widget-renders-watch-toggle-on-when-flag-on
-     (testing "with :test-watch-mode? true the chip reads aria-pressed=
+     (testing "with [:tests :watch-mode?] true the chip reads aria-pressed=
                true and the data-state attribute reads 'on'"
        (story/reg-variant :story.x/a {:tags #{:test} :events []
                                       :play [[:rf.assert/path-equals [:c] 0]]})
@@ -196,8 +196,8 @@
        ;; Both variants stamp :running synchronously before the async
        ;; resolution lands.
        (let [s (state/get-state)]
-         (is (= :running (get-in s [:test-runs :story.x/a :status])))
-         (is (= :running (get-in s [:test-runs :story.x/b :status])))))))
+         (is (= :running (get-in s [:tests :runs :story.x/a :status])))
+         (is (= :running (get-in s [:tests :runs :story.x/b :status])))))))
 
 #?(:cljs
    (deftest watch-rerun-empty-seq-noop
@@ -208,4 +208,4 @@
                                       :play [[:rf.assert/path-equals [:c] 0]]})
        (sidebar/watch-rerun! [])
        (let [s (state/get-state)]
-         (is (nil? (get-in s [:test-runs :story.x/a])))))))
+         (is (nil? (get-in s [:tests :runs :story.x/a])))))))

--- a/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
@@ -36,9 +36,9 @@
 ;; ---- pure: state transitions --------------------------------------------
 
 (deftest mark-test-running-stamps-status
-  (testing "mark-test-running writes :running into :test-runs"
+  (testing "mark-test-running writes :running into [:tests :runs]"
     (let [s  (state/mark-test-running state/default-shell-state :story.x/a)]
-      (is (= :running (get-in s [:test-runs :story.x/a :status]))))))
+      (is (= :running (get-in s [:tests :runs :story.x/a :status]))))))
 
 (deftest record-test-run-pass
   (testing "a run with passed assertions records :pass + counts"
@@ -46,18 +46,18 @@
                                    {:total 3 :passed 3 :failed 0 :skipped 0
                                     :all-passed? true
                                     :ran-at-ms 100 :elapsed-ms 12})]
-      (is (= :pass (get-in s [:test-runs :story.x/a :status])))
-      (is (= 3     (get-in s [:test-runs :story.x/a :passed])))
-      (is (= 0     (get-in s [:test-runs :story.x/a :failed])))
-      (is (= 12    (get-in s [:test-runs :story.x/a :elapsed-ms]))))))
+      (is (= :pass (get-in s [:tests :runs :story.x/a :status])))
+      (is (= 3     (get-in s [:tests :runs :story.x/a :passed])))
+      (is (= 0     (get-in s [:tests :runs :story.x/a :failed])))
+      (is (= 12    (get-in s [:tests :runs :story.x/a :elapsed-ms]))))))
 
 (deftest record-test-run-fail
   (testing "a run with any failure records :fail"
     (let [s (state/record-test-run state/default-shell-state :story.x/a
                                    {:total 3 :passed 1 :failed 2 :skipped 0
                                     :all-passed? false})]
-      (is (= :fail (get-in s [:test-runs :story.x/a :status])))
-      (is (= 2     (get-in s [:test-runs :story.x/a :failed]))))))
+      (is (= :fail (get-in s [:tests :runs :story.x/a :status])))
+      (is (= 2     (get-in s [:tests :runs :story.x/a :failed]))))))
 
 (deftest record-test-run-empty-is-pending
   (testing "a run that recorded zero assertions reads :pending — the
@@ -66,14 +66,14 @@
     (let [s (state/record-test-run state/default-shell-state :story.x/a
                                    {:total 0 :passed 0 :failed 0 :skipped 0
                                     :all-passed? false})]
-      (is (= :pending (get-in s [:test-runs :story.x/a :status]))))))
+      (is (= :pending (get-in s [:tests :runs :story.x/a :status]))))))
 
 (deftest clear-test-run-drops-record
   (testing "clear-test-run removes the slot — the dot re-reads :pending"
     (let [s (-> state/default-shell-state
                 (state/mark-test-running :story.x/a)
                 (state/clear-test-run :story.x/a))]
-      (is (nil? (get-in s [:test-runs :story.x/a])))
+      (is (nil? (get-in s [:tests :runs :story.x/a])))
       (is (= :pending (state/variant-test-status s :story.x/a))))))
 
 (deftest variant-test-status-defaults-pending
@@ -283,8 +283,8 @@
        (let [shell (-> state/default-shell-state
                        (assoc :active-modes #{:dark}
                               :substrate :reagent)
-                       (state/set-cell-override :story.x/a :n 5)
-                       (state/set-cell-override :story.x/b :label "B"))
+                       (state/set-cell-override-scalar :story.x/a :n 5)
+                       (state/set-cell-override-scalar :story.x/b :label "B"))
              opts-a (sidebar/run-opts-for-variant shell :story.x/a)
              opts-b (sidebar/run-opts-for-variant shell :story.x/b)
              opts-c (sidebar/run-opts-for-variant shell :story.x/c)]

--- a/tools/story/test/re_frame/story/ui/toolbar_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/toolbar_cljs_test.cljc
@@ -146,26 +146,30 @@
 ;; ---- pure: group-modes-by-axis ------------------------------------------
 
 (deftest group-modes-by-axis-orders
-  (testing "axis groups sort by axis-name; un-axis bucket lands last"
-    (let [groups (state/group-modes-by-axis
-                   {:Mode.vp/mobile {:axis :viewport}
-                    :Mode.t/dark    {:axis :theme}
-                    :Mode.t/light   {:axis :theme}
-                    :Mode.misc/x    {}
-                    :Mode.misc/a    {}})
-          axes   (mapv first groups)]
-      ;; :theme < :viewport alphabetically; un-axed bucket trails.
-      (is (= [:theme :viewport :re-frame.story.ui.state/unaxed] axes))
-      (is (= [:Mode.t/dark :Mode.t/light] (second (nth groups 0))))
-      (is (= [:Mode.vp/mobile]            (second (nth groups 1))))
-      (is (= [:Mode.misc/a :Mode.misc/x]  (second (nth groups 2)))))))
+  (testing "axis groups sort by axis-name; un-axed bucket sits in its
+            own explicit `:unaxed` slot (no sentinel keyword)"
+    (let [{:keys [axes unaxed]}
+          (state/group-modes-by-axis
+            {:Mode.vp/mobile {:axis :viewport}
+             :Mode.t/dark    {:axis :theme}
+             :Mode.t/light   {:axis :theme}
+             :Mode.misc/x    {}
+             :Mode.misc/a    {}})]
+      ;; :theme < :viewport alphabetically.
+      (is (= [:theme :viewport] (mapv first axes)))
+      (is (= [:Mode.t/dark :Mode.t/light] (second (nth axes 0))))
+      (is (= [:Mode.vp/mobile]            (second (nth axes 1))))
+      ;; Un-axed modes land in their own slot, alphabetically sorted.
+      (is (= [:Mode.misc/a :Mode.misc/x] unaxed)))))
 
-(deftest group-modes-by-axis-no-unaxed-bucket-when-all-tagged
-  (testing "every mode tagged → no trailing unaxed bucket"
-    (let [groups (state/group-modes-by-axis
-                   {:Mode.t/dark  {:axis :theme}
-                    :Mode.t/light {:axis :theme}})]
-      (is (= [:theme] (mapv first groups))))))
+(deftest group-modes-by-axis-empty-unaxed-when-all-tagged
+  (testing "every mode tagged → :unaxed slot is empty (still present)"
+    (let [{:keys [axes unaxed]}
+          (state/group-modes-by-axis
+            {:Mode.t/dark  {:axis :theme}
+             :Mode.t/light {:axis :theme}})]
+      (is (= [:theme] (mapv first axes)))
+      (is (= [] unaxed)))))
 
 ;; ---- pure: URL parsing --------------------------------------------------
 

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -80,7 +80,7 @@
 
 (deftest cell-overrides-roundtrip
   (testing "cell overrides write + clear cleanly"
-    (state/swap-state! state/set-cell-override :story.x/y :label "hi")
+    (state/swap-state! state/set-cell-override-scalar :story.x/y :label "hi")
     (is (= "hi" (get-in (state/get-state)
                         [:cell-overrides :story.x/y :label])))
     (state/swap-state! state/clear-cell-overrides :story.x/y)

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -89,7 +89,7 @@
 (deftest cell-overrides-pure
   (testing "set + clear overrides work on the pure map"
     (let [s  state/default-shell-state
-          s1 (state/set-cell-override s :story.a/x :n 42)
+          s1 (state/set-cell-override-scalar s :story.a/x :n 42)
           s2 (state/clear-cell-overrides s1 :story.a/x)]
       (is (= 42 (get-in s1 [:cell-overrides :story.a/x :n])))
       (is (nil? (get-in s2 [:cell-overrides :story.a/x]))))))


### PR DESCRIPTION
## Summary

Per audit rf2-dd5ze cluster (RG2/RG3/US1/US2/US3/US4 — P2 polish bundle on `tools/story/src/re_frame/story/registrar.cljc` + `ui/state.cljc`).

### Registrar
- Drop the redundant `variants-with-tag` singular helper (every caller already goes through `variants-with-tags #{tag}`).
- Extract `query-tags-by` so `tags-by-axis` / `tags-without-axis` / `tags-default-excluded` reduce to a one-line predicate over a shared scan.

### Shell state
- Group chrome-test-widget slots under a single `:tests {:runs {} :watch-mode? false :content-hashes {}}` sub-map (was three top-level keys).
- Replace `group-modes-by-axis`'s `::unaxed`-sentinel vector return with an explicit `{:axes [...] :unaxed [...]}` map (no sentinels). Toolbar caller + tests updated.
- Normalise `set-cell-override` to vector-path only; add `set-cell-override-scalar` thin wrapper for bare top-level arg-keys.
- `test-summary` now uses a single `frequencies` pass (one O(N) walk replaces five `n-of` filters).

Spec doc `009-Test-Mode.md` updated to reference the new `[:tests :runs]` / `[:tests :watch-mode?]` / `[:tests :content-hashes]` slot paths.

Pre-alpha — no back-compat shims.

## Test plan

- [x] `cd tools/story && clojure -M:test` — 352 tests / 1033 assertions, 0 failures.
- [ ] Browser smoke (shadow-cljs story build) — not run in this slice; the shell + sidebar + toolbar render-side changes touch caller code that exercise the new fn signatures, all covered by the cljc test suite.

Closes rf2-uefbk.