### PR TITLE
fix(mcp-conformance): root cause of pair2-mcp flake (rf2-papcw)

### DIFF
--- a/tools/mcp-conformance/test/end-to-end-pair2.js
+++ b/tools/mcp-conformance/test/end-to-end-pair2.js
@@ -35,7 +35,9 @@ const SERVER = path.resolve(__dirname, '..', '..', 'pair2-mcp', 'out', 'server.j
 
 // Expected tools advertised by pair2-mcp's tools/list. Pinned exact so
 // accidental renames / additions / deletions surface here. Mirrors the
-// upstream stdio-roundtrip baseline (ten tools, post-rf2-tygdv).
+// upstream stdio-roundtrip baseline (eleven tools post-rf2-zjz9q, which
+// added `subscription-info` as a dedicated read-side wrapper around
+// `re-frame-pair2.runtime/subscription-info`).
 const EXPECTED_TOOLS = [
   'discover-app',
   'dispatch',
@@ -43,6 +45,7 @@ const EXPECTED_TOOLS = [
   'get-path',
   'snapshot',
   'subscribe',
+  'subscription-info',
   'tail-build',
   'trace-window',
   'unsubscribe',
@@ -194,6 +197,35 @@ async function main() {
       );
     }
     console.log('OK   tools/call subscribe (degraded) -> isError + nrepl-port-not-found');
+
+    // 3c. subscription-info — added by rf2-zjz9q as a dedicated MCP
+    // wrapper around `re-frame-pair2.runtime/subscription-info` so AI
+    // clients can list active streaming subscriptions without an
+    // eval-cljs round-trip. Pure-read tool, no required arguments —
+    // optional :topic / :sub-id filters narrow the result. In degraded
+    // mode it returns the same nrepl-port-not-found envelope as every
+    // other live-runtime tool; covering it here proves the dispatch
+    // table is wired and the descriptor reaches the SDK.
+    const subInfoResp = await client.callTool({
+      name: 'subscription-info',
+      arguments: {},
+    });
+    if (!subInfoResp.isError) {
+      throw new Error(
+        'subscription-info in degraded mode should isError; got: ' +
+          JSON.stringify(subInfoResp),
+      );
+    }
+    const subInfoText = subInfoResp.content?.[0]?.text || '';
+    if (!subInfoText.includes('nrepl-port-not-found')) {
+      throw new Error(
+        'subscription-info degraded text should mention :nrepl-port-not-found; got: ' +
+          subInfoText,
+      );
+    }
+    console.log(
+      'OK   tools/call subscription-info (degraded) -> isError + nrepl-port-not-found',
+    );
 
     // 4. Clean disconnect. The SDK closes the transport which kills
     // the child process. If the server hangs on shutdown the harness

--- a/tools/pair2-mcp/test/stdio-roundtrip.js
+++ b/tools/pair2-mcp/test/stdio-roundtrip.js
@@ -3,8 +3,8 @@
 //
 // This test does NOT need a live shadow-cljs nREPL — it exercises:
 //   - initialize handshake
-//   - tools/list (expects all ten tools: nine original + get-path under
-//     rf2-tygdv)
+//   - tools/list (expects all eleven tools: nine original + get-path
+//     under rf2-tygdv + subscription-info under rf2-zjz9q)
 //   - tools/call eval-cljs against an absent nREPL (expects graceful
 //     :nrepl-port-not-found degraded mode)
 //   - tools/call snapshot against an absent nREPL (same degraded mode —
@@ -83,9 +83,10 @@ function run() {
 
       notify('notifications/initialized', {});
 
-      // 2. tools/list — expect all ten tools (six original + snapshot
+      // 2. tools/list — expect all eleven tools (six original + snapshot
       // mega-op from rf2-x70e + subscribe/unsubscribe streaming pair
-      // from rf2-hq49 + get-path read-by-path primitive from rf2-tygdv).
+      // from rf2-hq49 + get-path read-by-path primitive from rf2-tygdv
+      // + subscription-info read-side wrapper from rf2-zjz9q).
       // rf2-7dvg cut inject-runtime in favour of a shadow-cljs
       // :preloads entry; see SKILL.md §Setup.
       const list = await call('tools/list', {});
@@ -97,6 +98,7 @@ function run() {
         'get-path',
         'snapshot',
         'subscribe',
+        'subscription-info',
         'tail-build',
         'trace-window',
         'unsubscribe',


### PR DESCRIPTION
## Summary

- Not a flake — a deterministic regression. rf2-zjz9q (`feat(pair2-mcp): subscription-info MCP tool`) added an eleventh tool to pair2-mcp's `tools/list` catalogue but missed updating the two test fixtures that pin the catalogue exact.
- The CI gate `MCP conformance tools/pair2-mcp (rf2-cum40)` (`tools/mcp-conformance/test/end-to-end-pair2.js`) was red on every commit since rf2-zjz9q landed. Reproduced locally on the first attempt — same failure every time, no timing dependence.
- Drift also reached the upstream sibling `tools/pair2-mcp/test/stdio-roundtrip.js`. Not on a CI runner today (pair2-mcp's `npm test` runs the cljs `:server-test` build), but it's still wired as an `npm run stdio-roundtrip` entry-point and pins the same baseline, so it gets the same fix to stay coherent.

## What changed

- `tools/mcp-conformance/test/end-to-end-pair2.js`: add `subscription-info` to `EXPECTED_TOOLS`; extend the canonical degraded-mode workflow with a `tools/call subscription-info` call asserting the same `isError + :nrepl-port-not-found` shape every other live-runtime tool returns when no nREPL is attached. Matches the existing patterns for `dispatch`, `watch-epochs`, `snapshot`, and `subscribe`.
- `tools/pair2-mcp/test/stdio-roundtrip.js`: add `subscription-info` to the pinned tool list and update the header / inline comments to reference the eleven-tool baseline + rf2-zjz9q lineage.

## Test plan

- [x] Reproduced the failure locally on `main` — `npm run test:pair2` in `tools/mcp-conformance/` fails with the exact catalogue mismatch the CI log shows (`got [...subscribe, subscription-info, tail-build...]` vs the pinned ten-tool baseline).
- [x] After the fix, `npm run test:pair2` runs to `PAIR2-MCP MCP-CLIENT CONFORMANCE GREEN` deterministically — verified 5/5 consecutive runs green.
- [x] `node test/stdio-roundtrip.js` in `tools/pair2-mcp` runs to `SERVER STDIO ROUND-TRIP GREEN` after the same fix.
- [x] `npm run test:pair2-live-overflow` still exits 0 with the SKIP marker (gating contract preserved: `$SHADOW_CLJS_NREPL_PORT` unset → SKIP, not fail).
- [x] Full `npm test` in `tools/mcp-conformance/` is green end-to-end (pair2 conformance + pair2 live-overflow SKIP + story conformance + causa SKIP).