### PR TITLE
refactor(causa): hoist now-ms to panels.common-helpers (rf2-jigkg)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/common_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/common_helpers.cljc
@@ -1,0 +1,9 @@
+(ns day8.re-frame2-causa.panels.common-helpers)
+
+(defn now-ms
+  "Return host-clock time in ms. Pure-ish — abstracted so test
+  fixtures can stub via `with-redefs`. Cross-platform via
+  `#?(:clj ... :cljs ...)`."
+  []
+  #?(:clj  (System/currentTimeMillis)
+     :cljs (.getTime (js/Date.))))

--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon_helpers.cljc
@@ -64,7 +64,8 @@
                          `(- now-ms since-ms)` drop from the feed
 
   Each axis is independent; empty filters disable the axis."
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [day8.re-frame2-causa.panels.common-helpers :as common]))
 
 ;; ---- defaults ------------------------------------------------------------
 
@@ -240,15 +241,10 @@
         (keep project-issue)
         events))
 
-;; ---- now-ms (abstracted for test fixtures) ------------------------------
-
-(defn now-ms
-  "Return host-clock time in ms. Pure-ish — abstracted so test
-  fixtures can stub via `with-redefs`. Cross-platform via
-  `#?(:clj ... :cljs ...)`."
-  []
-  #?(:clj  (System/currentTimeMillis)
-     :cljs (.getTime (js/Date.))))
+;; Re-export `now-ms` so existing callers (registry.cljs thunks the
+;; `:rf.causa/issues-ribbon-feed` sub via `(issues-helpers/now-ms)`)
+;; keep working without churn. Body lives in `common-helpers`.
+(def now-ms common/now-ms)
 
 ;; ---- filter application -------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/mcp_server_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/mcp_server_helpers.cljc
@@ -85,7 +85,8 @@
   activity observed' empty state. This is simpler than a separate
   detector loop and matches the trace-bus-is-truth posture of
   every other Causa panel."
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [day8.re-frame2-causa.panels.common-helpers :as common]))
 
 ;; ---- the inferential origin colour --------------------------------------
 
@@ -222,16 +223,10 @@
         (keep project-row)
         events))
 
-;; ---- now-ms (abstracted for test fixtures) -------------------------------
-
-(defn now-ms
-  "Return host-clock time in ms. Pure-ish — abstracted so test
-  fixtures can stub via `with-redefs`. Cross-platform via
-  `#?(:clj ... :cljs ...)`. Mirrors the issues_ribbon_helpers /
-  trace_helpers convention."
-  []
-  #?(:clj  (System/currentTimeMillis)
-     :cljs (.getTime (js/Date.))))
+;; Re-export `now-ms` so existing callers (registry.cljs thunks the
+;; `:rf.causa/mcp-server-feed` sub via `(mcp-helpers/now-ms)`) keep
+;; working without churn. Body lives in `common-helpers`.
+(def now-ms common/now-ms)
 
 ;; ---- filter application -------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/schema_violation_timeline_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/schema_violation_timeline_helpers.cljc
@@ -53,7 +53,8 @@
   each row using the projection here — this ns hands the view a flat
   vector of `{:schema-id ... :violations [...]}` rows + pre-computed
   pixel positions for each dot."
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [day8.re-frame2-causa.panels.common-helpers :as common]))
 
 ;; ---- defaults ------------------------------------------------------------
 
@@ -261,23 +262,15 @@
 
 ;; ---- time-axis window projection ----------------------------------------
 
-(defn now-ms
-  "Return host-clock time in ms. Pure-ish — abstracted so test
-  fixtures can stub it via `with-redefs`. Cross-platform via
-  `#?(:clj ... :cljs ...)`."
-  []
-  #?(:clj  (System/currentTimeMillis)
-     :cljs (.getTime (js/Date.))))
-
 (defn default-window
   "Return the default time-axis window — the last
-  `default-window-ms` ms ending at `(now-ms)`. Per spec §Layout the
-  default is 60s. Pure data → `{:t0 :t1}`.
+  `default-window-ms` ms ending at `(common/now-ms)`. Per spec §Layout
+  the default is 60s. Pure data → `{:t0 :t1}`.
 
   Used by the registry's `:rf.causa/schema-timeline-window` sub when
   no window has been set explicitly."
   []
-  (let [t1 (now-ms)]
+  (let [t1 (common/now-ms)]
     {:t0 (- t1 default-window-ms)
      :t1 t1}))
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
@@ -234,15 +234,6 @@
     {}
     rows))
 
-;; ---- now-ms (abstracted for tests) --------------------------------------
-
-(defn now-ms
-  "Return host-clock time in ms. Pure-ish — abstracted so test
-  fixtures can stub via `with-redefs`."
-  []
-  #?(:clj  (System/currentTimeMillis)
-     :cljs (.getTime (js/Date.))))
-
 ;; ---- composite projection (the panel reads this) ------------------------
 
 (defn project-feed


### PR DESCRIPTION
## Summary

Closes rf2-jigkg. `(defn now-ms [] ...)` was defined identically in four
panel-helper namespaces under `tools/causa/`:

- `panels/issues_ribbon_helpers.cljc`
- `panels/mcp_server_helpers.cljc`
- `panels/schema_violation_timeline_helpers.cljc`
- `panels/trace_helpers.cljc`

This PR introduces `day8.re-frame2-causa.panels.common-helpers` as a new
home for shared pure-data primitives, hoists `now-ms` there, and updates
the four sites to drop their local copies.

- `issues_ribbon_helpers` and `mcp_server_helpers` keep an explicit
  `(def now-ms common/now-ms)` re-export because `registry.cljs` calls
  `issues-helpers/now-ms` / `mcp-helpers/now-ms` at lines 1229 and 1610.
  Re-export keeps `registry.cljs` untouched (rf2-e9s81 mid-flight).
- `schema_violation_timeline_helpers` now calls `common/now-ms` for its
  one internal use; no external callers.
- `trace_helpers`'s `now-ms` had no callers (internal or external); the
  local defn is simply deleted.

The new namespace is intentionally minimal — it will gain `tag` next via
rf2-9btcl.

## Test plan

- [x] `cd tools/causa && clojure -M:test` (488 tests, 1363 assertions, 0 failures, 0 errors)
- [x] `cd implementation && npm run test:cljs` (1818 tests, 5056 assertions, 0 failures, 0 errors)