### PR TITLE
refactor(mcp-base): move count-elided-markers to its own elision ns (rf2-9fz64)

### DIFF
--- a/tools/mcp-base/deps.edn
+++ b/tools/mcp-base/deps.edn
@@ -17,6 +17,8 @@
 ;;                        `:rf.mcp/*` and `:rf.size/*` namespaced
 ;;                        keywords, JSON-RPC error codes).
 ;;   - `sensitive.cljc` — spec/009 §Privacy default-suppress filter.
+;;   - `elision.cljc`   — wire-boundary elision-marker walker
+;;                        (`count-elided-markers`, rf2-9fz64).
 ;;   - `args.cljc`      — argument-coercion helpers (booleans, limits,
 ;;                        keyword reading) used by every MCP tool.
 ;;   - `diff_encode.cljc` — path-keyed structural diff for epoch

--- a/tools/mcp-base/src/re_frame/mcp_base/elision.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/elision.cljc
@@ -1,0 +1,61 @@
+(ns re-frame.mcp-base.elision
+  "Wire-boundary elision-marker walker (rf2-9fz64).
+
+  Per `spec/009` §Size elision in traces, the framework's
+  `rf/elide-wire-value` walker substitutes over-threshold leaves with
+  a `{:rf.size/large-elided {...}}` marker before the payload leaves
+  the runtime. Every MCP tool that returns a tree-typed payload
+  surfaces a scalar count of those substitutions on its response
+  envelope (the unqualified `:elided-large` slot — see
+  `vocab/elided-large-key` and Conventions §Cross-MCP indicator-field
+  vocabulary, MUST-level per rf2-2499j).
+
+  ## Why this ns
+
+  `vocab.cljc` is the constants catalogue — namespaced keys, JSON-RPC
+  codes, envelope-slot names. A runtime tree-walker is not a constant
+  and was crowding the catalogue's mandate. The walker lives here so
+  the elision concern has a clear home; sibling elision-side runtime
+  fns land here too as the vocabulary grows.
+
+  ## Cousin to `re-frame.mcp-base.sensitive`
+
+  `sensitive/strip-sensitive` returns `[kept dropped-count]` for the
+  `:dropped-sensitive` envelope slot; `count-elided-markers` returns
+  the integer for the `:elided-large` slot. Both indicators ride the
+  response envelope together per the cross-MCP indicator-field
+  parity (one without the other is the round-2 audit fix the
+  conformance gate enforces).
+
+  ## Cross-platform
+
+  Pure-data tree walk; loads identically into JVM (story-mcp /
+  causa-mcp) and CLJS (pair2-mcp). No transport, no runtime, no
+  framework dep — the walker only inspects the wire shape."
+  (:require [re-frame.mcp-base.vocab :as vocab]))
+
+(defn count-elided-markers
+  "Walk `v` and count every `{:rf.size/large-elided ...}` marker it
+  contains. The walker is shallow at the marker boundary — once a
+  marker is found, its body is NOT recursed into (marker bodies are
+  scalar metadata, not tree-shaped). Recurses through maps, vectors,
+  sets, and seqs; treats every other value as a leaf.
+
+  Returns an integer ≥ 0. Cheap on the common path (post-elision
+  payload with no markers ⇒ one full walk producing zero).
+
+  Counterpart to `re-frame.mcp-base.sensitive/strip-sensitive`'s
+  `dropped-count` return — both indicators ride the response envelope
+  per Conventions §Cross-MCP indicator-field vocabulary."
+  [v]
+  (cond
+    (and (map? v) (contains? v vocab/large-elided-key))
+    1
+
+    (map? v)
+    (reduce-kv (fn [n _k child] (+ n (count-elided-markers child))) 0 v)
+
+    (or (vector? v) (set? v) (seq? v))
+    (reduce (fn [n child] (+ n (count-elided-markers child))) 0 v)
+
+    :else 0))

--- a/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
@@ -174,34 +174,13 @@
   per Conventions §Cross-MCP indicator-field vocabulary. Omit the
   slot when the count is zero. Mirror of `[● ELIDED N]` on on-box
   dev-tool surfaces. Per Spec 009 §Size elision in traces —
-  Indicator field on tool responses (MUST-level)."
+  Indicator field on tool responses (MUST-level).
+
+  The walker that produces the count lives in
+  `re-frame.mcp-base.elision/count-elided-markers` — the count is a
+  runtime tree-walk, not a constant, so it sits alongside the key in
+  a sibling ns."
   :elided-large)
-
-(defn count-elided-markers
-  "Walk `v` and count every `{:rf.size/large-elided ...}` marker it
-  contains. The walker is shallow at the marker boundary — once a
-  marker is found, its body is NOT recursed into (marker bodies are
-  scalar metadata, not tree-shaped). Recurses through maps, vectors,
-  sets, and seqs; treats every other value as a leaf.
-
-  Returns an integer ≥ 0. Cheap on the common path (post-elision
-  payload with no markers ⇒ one full walk producing zero).
-
-  Counterpart to `re-frame.mcp-base.sensitive/strip-sensitive`'s
-  `dropped-count` return — both indicators ride the response envelope
-  per Conventions §Cross-MCP indicator-field vocabulary."
-  [v]
-  (cond
-    (and (map? v) (contains? v large-elided-key))
-    1
-
-    (map? v)
-    (reduce-kv (fn [n _k child] (+ n (count-elided-markers child))) 0 v)
-
-    (or (vector? v) (set? v) (seq? v))
-    (reduce (fn [n child] (+ n (count-elided-markers child))) 0 v)
-
-    :else 0))
 
 ;; ---------------------------------------------------------------------------
 ;; JSON-RPC 2.0 error codes (per §5.1; reused by MCP per the spec)

--- a/tools/mcp-base/test/re_frame/mcp_base/elision_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/elision_test.clj
@@ -1,0 +1,55 @@
+(ns re-frame.mcp-base.elision-test
+  "Pins the elision-marker walker (rf2-9fz64). The walker counts every
+  `{:rf.size/large-elided ...}` marker in a wire-bound payload — the
+  count rides the response envelope as the `:elided-large` slot
+  (Conventions §Cross-MCP indicator-field vocabulary, MUST-level per
+  rf2-2499j). A regression here is a drift in the envelope's elision-
+  indicator parity with `:dropped-sensitive`."
+  (:require [clojure.test :refer [deftest is]]
+            [re-frame.mcp-base.elision :as elision]))
+
+(deftest count-elided-markers-walks-the-payload
+  (let [marker {:rf.size/large-elided
+                {:path   [:user :pdf]
+                 :bytes  102400
+                 :type   :string
+                 :reason :declared
+                 :handle [:rf.elision/at [:user :pdf]]}}]
+    ;; Empty / leaf cases — nothing to count.
+    (is (= 0 (elision/count-elided-markers nil)))
+    (is (= 0 (elision/count-elided-markers {})))
+    (is (= 0 (elision/count-elided-markers [])))
+    (is (= 0 (elision/count-elided-markers "string")))
+    (is (= 0 (elision/count-elided-markers 42)))
+    (is (= 0 (elision/count-elided-markers {:ok? true :payload {:a 1 :b [2 3]}})))
+
+    ;; Marker counted at every depth and shape.
+    (is (= 1 (elision/count-elided-markers marker))
+        "Top-level single marker counts once.")
+    (is (= 1 (elision/count-elided-markers {:value marker}))
+        "Marker nested in a map counts once.")
+    (is (= 1 (elision/count-elided-markers [marker]))
+        "Marker nested in a vector counts once.")
+    (is (= 2 (elision/count-elided-markers {:a marker :b marker}))
+        "Sibling markers both count.")
+    (is (= 3 (elision/count-elided-markers
+               {:slice1 marker
+                :slice2 {:nested marker}
+                :slice3 [{:deep marker}]}))
+        "Markers at mixed depths all count.")
+
+    ;; The marker BODY is not recursed into (marker bodies carry
+    ;; `:handle` / `:path` / metadata, not another marker).
+    (let [body-with-collision {:rf.size/large-elided
+                               {:path [:a :b]
+                                :bytes 100
+                                :type :string
+                                :reason :declared
+                                :handle [:rf.elision/at [:a :b]]
+                                ;; A pathological marker-shaped value
+                                ;; lodged inside the body would still
+                                ;; only count the OUTER marker.
+                                :extra {:rf.size/large-elided
+                                        {:bytes 1}}}}]
+      (is (= 1 (elision/count-elided-markers body-with-collision))
+          "Marker body is opaque; nested marker-shape isn't double-counted."))))

--- a/tools/mcp-base/test/re_frame/mcp_base/vocab_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/vocab_test.clj
@@ -30,52 +30,6 @@
   (is (= :dropped-sensitive vocab/dropped-sensitive-key))
   (is (= :elided-large      vocab/elided-large-key)))
 
-(deftest count-elided-markers-walks-the-payload
-  (let [marker {:rf.size/large-elided
-                {:path   [:user :pdf]
-                 :bytes  102400
-                 :type   :string
-                 :reason :declared
-                 :handle [:rf.elision/at [:user :pdf]]}}]
-    ;; Empty / leaf cases — nothing to count.
-    (is (= 0 (vocab/count-elided-markers nil)))
-    (is (= 0 (vocab/count-elided-markers {})))
-    (is (= 0 (vocab/count-elided-markers [])))
-    (is (= 0 (vocab/count-elided-markers "string")))
-    (is (= 0 (vocab/count-elided-markers 42)))
-    (is (= 0 (vocab/count-elided-markers {:ok? true :payload {:a 1 :b [2 3]}})))
-
-    ;; Marker counted at every depth and shape.
-    (is (= 1 (vocab/count-elided-markers marker))
-        "Top-level single marker counts once.")
-    (is (= 1 (vocab/count-elided-markers {:value marker}))
-        "Marker nested in a map counts once.")
-    (is (= 1 (vocab/count-elided-markers [marker]))
-        "Marker nested in a vector counts once.")
-    (is (= 2 (vocab/count-elided-markers {:a marker :b marker}))
-        "Sibling markers both count.")
-    (is (= 3 (vocab/count-elided-markers
-               {:slice1 marker
-                :slice2 {:nested marker}
-                :slice3 [{:deep marker}]}))
-        "Markers at mixed depths all count.")
-
-    ;; The marker BODY is not recursed into (marker bodies carry
-    ;; `:handle` / `:path` / metadata, not another marker).
-    (let [body-with-collision {:rf.size/large-elided
-                               {:path [:a :b]
-                                :bytes 100
-                                :type :string
-                                :reason :declared
-                                :handle [:rf.elision/at [:a :b]]
-                                ;; A pathological marker-shaped value
-                                ;; lodged inside the body would still
-                                ;; only count the OUTER marker.
-                                :extra {:rf.size/large-elided
-                                        {:bytes 1}}}}]
-      (is (= 1 (vocab/count-elided-markers body-with-collision))
-          "Marker body is opaque; nested marker-shape isn't double-counted."))))
-
 (deftest jsonrpc-error-codes-pinned
   (is (= -32700 vocab/code-parse-error))
   (is (= -32600 vocab/code-invalid-request))

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -654,8 +654,11 @@
 ;; The mcp-base vocab ns (`tools/mcp-base/src/re_frame/mcp_base/vocab.cljc`)
 ;; reserves the two slot KEYS as constants (`dropped-sensitive-key`,
 ;; `elided-large-key`); the count-walker helper
-;; (`count-elided-markers`) lives next to them. Consumers import the
-;; ns to keep the key bytes byte-identical across servers.
+;; (`count-elided-markers`) lives in the sibling `elision` ns
+;; (`tools/mcp-base/src/re_frame/mcp_base/elision.cljc`) — a runtime
+;; tree-walker, not a constant, so it doesn't sit in the vocabulary
+;; catalogue. Consumers import either ns to keep the key bytes byte-
+;; identical across servers.
 ;; ---------------------------------------------------------------------------
 
 (def envelope-indicator-slots

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs
@@ -33,7 +33,7 @@
   controller`, which closes over the atom and returns the `terminate`
   + `poll` fns — the streaming-loop body reads top-down."
   (:require [applied-science.js-interop :as j]
-            [re-frame.mcp-base.vocab :as base-vocab]
+            [re-frame.mcp-base.elision :as base-elision]
             [re-frame-pair2-mcp.nrepl :as nrepl]
             [re-frame-pair2-mcp.tools.eval-form :as ef]
             [re-frame-pair2-mcp.tools.wire :as wire]
@@ -143,7 +143,7 @@
                             ov-reason      (:overflow-reason drain-resp)
                             [evts dropped] (sensitive/strip-sensitive
                                              (vec raw-evts) incl?)
-                            tick-elided    (base-vocab/count-elided-markers evts)
+                            tick-elided    (base-elision/count-elided-markers evts)
                             n              (count evts)
                             drain-delta    {:n           n
                                             :ev-dropped  ev-dropped

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire_pipeline.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire_pipeline.cljs
@@ -56,7 +56,7 @@
   `wire/with-indicators` onto their envelope — the per-tool tail
   collapses from a 20-line `let` of intermediate names to a 5-line
   pipeline call + envelope assembly."
-  (:require [re-frame.mcp-base.vocab :as base-vocab]
+  (:require [re-frame.mcp-base.elision :as base-elision]
             [re-frame-pair2-mcp.tools.dedup :as dedup]
             [re-frame-pair2-mcp.tools.sensitive :as sensitive]
             [re-frame-pair2-mcp.tools.snapshot-pipeline :as pipeline]))
@@ -79,7 +79,7 @@
         [sliced path-status]  (pipeline/slice-app-db-in-snapshot scrubbed path app-db-mode)
         diff-encoded          (pipeline/diff-encode-epochs-in-snapshot sliced mode)
         deduped               (pipeline/dedup-epochs-in-snapshot diff-encoded dedup?)
-        elided                (base-vocab/count-elided-markers deduped)
+        elided                (base-elision/count-elided-markers deduped)
         {summarised  :snapshot
          other-modes :resolved-modes} (pipeline/summarise-other-slices-in-snapshot
                                         deduped slice-modes slice-mode)
@@ -109,7 +109,7 @@
   (let [[kept dropped] (sensitive/strip-sensitive epochs incl?)
         encoded        (dedup/diff-encode-epochs kept mode)
         deduped        (dedup/dedup-value encoded dedup?)
-        elided         (base-vocab/count-elided-markers deduped)]
+        elided         (base-elision/count-elided-markers deduped)]
     {:value      deduped
      :indicators {:dropped dropped
                   :elided  elided
@@ -123,7 +123,7 @@
   Returns `{:value v :indicators {:elided N}}`."
   [v _opts]
   {:value      v
-   :indicators {:elided (base-vocab/count-elided-markers v)}})
+   :indicators {:elided (base-elision/count-elided-markers v)}})
 
 (defn run-wire-pipeline
   "Single named pipeline for every MCP tool that returns a tree-typed


### PR DESCRIPTION
## Summary

- `count-elided-markers` (a runtime tree-walker) moves out of the constants-only `vocab.cljc` into a new sibling ns `re-frame.mcp-base.elision`. The vocab ns's stated mandate is "Cross-MCP wire-vocabulary constants. One place to learn — and pin — the namespaced keys"; a tree-walker is not a constant and was crowding that mandate.
- New `elision` ns pairs the walker with its concern; sits cousin to `re-frame.mcp-base.sensitive` (which already houses `strip-sensitive`, the cousin walker producing the `:dropped-sensitive` indicator). Both indicators ride the envelope per Conventions §Cross-MCP indicator-field vocabulary (MUST-level, rf2-2499j).
- Test moved alongside (`elision_test.clj`); consumers updated; `vocab/elided-large-key` docstring gained a pointer to the walker's new home so the constants-side index keeps the discoverability link.

## Why `elision` over `sensitive`

- Walker body counts `:rf.size/large-elided` markers — purely elision-side, no sensitive-flow.
- `sensitive` ns's mandate is the spec/009 §Privacy default-suppress filter; mixing in an elision walker would broaden its scope.
- A dedicated `elision` ns gives the elision concern a home for sibling runtime fns to land later.

## Files touched

- `tools/mcp-base/src/re_frame/mcp_base/elision.cljc` — new ns hosting `count-elided-markers`.
- `tools/mcp-base/src/re_frame/mcp_base/vocab.cljc` — walker removed; `elided-large-key` docstring points at the new home.
- `tools/mcp-base/test/re_frame/mcp_base/elision_test.clj` — moved test.
- `tools/mcp-base/test/re_frame/mcp_base/vocab_test.clj` — test removed (now in elision_test).
- `tools/mcp-base/deps.edn` — header artefact table lists `elision.cljc`.
- `tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire_pipeline.cljs` — `:require` switched, 3 call-sites rebound to `base-elision/count-elided-markers`.
- `tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs` — `:require` switched, 1 call-site rebound.
- `tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj` — cross-reference comment updated to point at the new ns.

Caught by round-2 audit (rf2-n4q62, F1).

## Test plan

- [x] `tools/mcp-base` JVM tests — `clojure -M:test` (62 tests, 148 assertions, 0/0).
- [x] `implementation/` CLJS gate — `npm run test:cljs` (1818 tests, 5056 assertions, 0/0).
- [x] `python scripts/check_skill_mcp_drift.py` — exit 0, no drift.
- [x] `tools/mcp-conformance/wire-vocab` JVM tests — pre-existing failures (`:max-tokens` slot literal detection in story-mcp / pair2-mcp + indicator inline-emit checker) confirmed against origin/main baseline; unchanged by this PR.