### PR TITLE
fix(causa): revert rf2-iw5ym — trace-buffer sub thunks atom (rf2-e9s81)

### DIFF
--- a/tools/causa/spec/013-Trace-Bus.md
+++ b/tools/causa/spec/013-Trace-Bus.md
@@ -166,6 +166,52 @@ plumbing (per `006-Hydration-Debugger.md` and panel-specific specs)
 projects the result. This keeps the buffer hot-path cheap (no sub-cache
 recomputation per push) and consistent across CLJS and JVM.
 
+## Reactivity
+
+The buffer is held in a plain atom (process-global, not per-frame).
+The CLJS `:rf.causa/trace-buffer` sub (registered in `registry.cljs`)
+is layer-1 and thunks `trace-bus/buffer` so subscribers get a fresh
+read on every recompute. The sub re-fires on every app-db change of
+its resolved frame; under Causa's normal usage — panels rendered
+inside a host app — every host dispatch dirties the resolved
+frame's app-db and the sub picks up whatever the trace-cb has
+accumulated in the atom since the previous recompute. Visible delay
+between trace push and panel update is bounded by the host's next
+dispatch, indistinguishable from native trace-rate UI cadence on
+every example app the foundation ships.
+
+### History (rf2-iw5ym → rf2-e9s81)
+
+`rf2-iw5ym` briefly mirrored the buffer into Causa's app-db at
+`[:rf/causa :trace-buffer]` via a parallel `:rf.causa/note-trace-event`
+dispatch from `collect-trace!` — chasing the same "immediate re-fire
+on every push" recipe `rf2-0vxdn` shipped for `:suppressed-counters`.
+That parallel path proved untenable for the trace buffer (the
+process-global construct does not fit the per-frame app-db mirror
+shape — the suppressed-counters case was a genuinely per-frame map
+keyed on `frame-id`, so the analogy did not transfer):
+
+- `:rf/causa` is never registered in production. The preload runs
+  at ns-load time, before the host's `rf/init!` installs a substrate
+  adapter; `reg-frame` cannot run in that window. The dispatch
+  silently no-op'd and step 5 of `examples/.../causa.spec.cjs` went
+  red (the `rf2-e9s81` regression).
+- Chain-resolving to `:rf/default` (the recipe `rf2-higwg` applied
+  to the suppressed-counter path) consumed drain-depth headroom on
+  every emitted trace event and polluted the host's app-db with
+  `:trace-buffer` noise — surfacing as spurious
+  `:rf.error/drain-depth-exceeded` failures in conformance fixtures.
+
+`rf2-e9s81` reverts to the pre-iw5ym shape (sub thunks the atom;
+host-driven recompute). An architecturally clean reactive-on-every-
+push surface for the trace buffer would require either reg-view-
+wrapping every Causa panel (so plain-fn subscribes route to
+`:rf/causa` via the React-context tier) or a fixed-frame sub
+mechanism that lets a sub read from an arbitrary frame's app-db
+independent of the subscriber's frame — both wider refactors filed
+for follow-up. Until then the host-driven recompute path delivers
+the same UX without the layering hazards.
+
 ### What consumers MAY rely on
 
 - A **point-in-time snapshot** of the buffer as a Clojure vector,

--- a/tools/causa/spec/014-Registry-Catalogue.md
+++ b/tools/causa/spec/014-Registry-Catalogue.md
@@ -57,7 +57,7 @@ the time-travel scrubber, and the per-frame target selection.
 
 | Sub | Inputs | Returns | When recomputes |
 |---|---|---|---|
-| `:rf.causa/trace-buffer` | `db` (reads `:trace-buffer`) | Vector of `:rf/trace-event` records, oldest-first (per [`013-Trace-Bus.md`](./013-Trace-Bus.md) §Consumer contract). | On `db` write to `:trace-buffer` (rf2-iw5ym — reactive immediate update on every push, matching the rf2-0vxdn recipe for `:suppressed-counters`). |
+| `:rf.causa/trace-buffer` | thunks `trace-bus/buffer` (the process-global ring atom) | Vector of `:rf/trace-event` records, oldest-first (per [`013-Trace-Bus.md`](./013-Trace-Bus.md) §Consumer contract). | Layer-1 sub re-fires on every app-db change of the resolved frame; under Causa's normal usage (panels rendered inside a host app) the host's next dispatch dirties the frame's db and the sub picks up whatever the trace-cb has accumulated in the atom since the previous recompute (rf2-e9s81 — supersedes rf2-iw5ym's app-db-mirror path; see [`013-Trace-Bus.md`](./013-Trace-Bus.md) §Reactivity for the trade-off). |
 | `:rf.causa/suppressed-sensitive-count` | `db` (reads `:suppressed-counters`) | Integer — total suppressed `:sensitive? true` events under the current `:trace/show-sensitive?` setting. | On `db` write to `:suppressed-counters` (rf2-0vxdn — reactive immediate update of the `[● REDACTED N]` bottom-rail indicator). |
 | `:rf.causa/target-frame` | `db` | Keyword frame-id (default `:rf/default`). | On `db` write to `:target-frame`. |
 | `:rf.causa/epoch-history` | `db` | Vector of `:rf/epoch-record`, oldest-first (cached snapshot of `(rf/epoch-history target)`). | On `:rf.causa/epoch-recorded` dispatch. |
@@ -70,9 +70,6 @@ the time-travel scrubber, and the per-frame target selection.
 | `:rf.causa/epoch-recorded` | `[_ frame-id]` | `{:db ...}` | Pumped from the epoch-cb registered in `preload.cljs` on every settled epoch. Re-reads `rf/epoch-history` to keep the cached snapshot consistent. No-ops when `frame-id` ≠ the current target. |
 | `:rf.causa/note-sensitive-suppressed` | `[_ frame-id]` | `{:db ...}` | rf2-0vxdn — bumps `[:suppressed-counters (or frame-id :global)]` in Causa's app-db. Dispatched from `trace-bus/collect-trace!` (CLJS) when the privacy gate drops a `:sensitive? true` event. Drives the `:rf.causa/suppressed-sensitive-count` sub reactively. |
 | `:rf.causa/reset-suppressed-counters` | `[_]` or `[_ frame-id]` | `{:db ...}` | rf2-0vxdn — clears all buckets (no arg) or just the named bucket. Dispatched from `trace-bus/clear-buffer!` (CLJS) — clearing the trace ring buffer also drops the `[● REDACTED N]` indicator state. |
-| `:rf.causa/note-trace-event` | `[_ event]` | `{:db ...}` | rf2-iw5ym — appends `event` to `:trace-buffer` with eviction at `trace-bus/current-depth` (mirrors `trace-bus/push`'s algebra). Dispatched from `trace-bus/collect-trace!` (CLJS) on every non-sensitive trace event. Drives the `:rf.causa/trace-buffer` sub reactively. |
-| `:rf.causa/clear-trace-buffer` | `[_]` | `{:db ...}` | rf2-iw5ym — `dissoc`s the `:trace-buffer` slot. Dispatched from `trace-bus/clear-buffer!` (CLJS); the atom-side ring buffer + the app-db mirror drop in lockstep. |
-| `:rf.causa/sync-trace-buffer` | `[_ buf]` | `{:db ...}` | rf2-iw5ym — replaces the `:trace-buffer` slot with `buf` wholesale. Dispatched from `trace-bus/set-buffer-depth!` (CLJS) when shrinking the depth so the mirror reflects the post-shrink contents. |
 | `:rf.causa/select-panel` | `[_ panel-id]` | `{:db ...}` | Drives the canvas switch logic in `shell.cljs`. Default per [`007-UX-IA.md`](./007-UX-IA.md) §10 Lock 7 is `:event-detail`. |
 
 ## Event-detail panel

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -186,18 +186,25 @@
 ;; ---- subscriptions -------------------------------------------------------
 
 ;; Causa's trace-buffer sub returns the Causa-side ring buffer
-;; contents (NOT the framework's `(rf/trace-buffer)`).
+;; contents (NOT the framework's `(rf/trace-buffer)`). Reading directly
+;; from `trace-bus/buffer` is the right shape here because the buffer
+;; is process-global, not per-frame — every Causa shell mounted across
+;; any frame should see the same trace stream. The sub thunks the
+;; pure-data accessor so reactive contexts get a fresh read on every
+;; recompute.
 ;;
-;; Per rf2-iw5ym the buffer lives in Causa's app-db at `:trace-buffer`
-;; (same recipe as rf2-0vxdn for `:suppressed-counters`); `trace-bus/
-;; collect-trace!` dispatches `:rf.causa/note-trace-event` in CLJS so
-;; the sub fires on the standard app-db-write reactive path. Panels
-;; reading the buffer re-render IMMEDIATELY on every push — no
-;; dependency on sibling subs recomputing. The plain `trace-bus/
-;; buffer-state` atom remains as the JVM-runnable data primitive
-;; (`push` algebra, depth-shrink algebra, sensitive_trace_cljs_test);
-;; the CLJS path dual-writes via dispatch so the reactive surface
-;; stays consistent.
+;; History (rf2-iw5ym → rf2-e9s81): rf2-iw5ym briefly mirrored the
+;; buffer into Causa's app-db at `:trace-buffer` so the sub would
+;; re-fire IMMEDIATELY on every push. That path proved untenable —
+;; `:rf/causa` is not registered at preload time (no substrate
+;; adapter installed yet) and chain-resolving to `:rf/default`
+;; consumed drain-depth headroom on every emitted trace event AND
+;; polluted the host's app-db with `:trace-buffer` noise. rf2-e9s81
+;; reverts to the pre-iw5ym shape (sub thunks the atom; layer-1 re-
+;; fires on the host's next dispatch, picking up whatever the trace-
+;; cb has accumulated). See `trace_bus.cljc` §Reactivity for the
+;; trade-off and the wider refactor that would re-introduce
+;; immediate-update reactivity without the layering hazard.
 (defonce ^:private registered?
   ;; Idempotency sentinel. Re-loading the namespace (shadow-cljs
   ;; `:after-load`) must not re-register the sub (would harmlessly
@@ -213,8 +220,8 @@
   (when (compare-and-set! registered? false true)
     ;; ---- subs ----------------------------------------------------
     (rf/reg-sub :rf.causa/trace-buffer
-      (fn [db _query]
-        (get db :trace-buffer [])))
+      (fn [_db _query]
+        (trace-bus/buffer)))
 
     ;; Total count of :sensitive? trace events the collector has
     ;; suppressed under the current `:trace/show-sensitive?` setting
@@ -665,50 +672,13 @@
           (update db :suppressed-counters dissoc (or frame-id :global))
           (dissoc db :suppressed-counters))))
 
-    ;; Append a trace event to Causa's reactive trace-buffer slot
-    ;; (rf2-iw5ym). Dispatched from `trace-bus/collect-trace!` (CLJS)
-    ;; whenever a non-sensitive event lands on the bus. The handler
-    ;; mirrors the atom-side `trace-bus/push` algebra (conj + subvec
-    ;; on overflow) so the app-db slot stays bounded by the same
-    ;; depth contract; the depth is sourced from `trace-bus`'s own
-    ;; atom (process-global, not per-frame). Drives the
-    ;; `:rf.causa/trace-buffer` sub via the standard reactive write
-    ;; path — panels reading the buffer re-render immediately.
-    ;;
-    ;; Per rf2-qsjda: `:rf.trace/no-emit? true` (see
-    ;; `:rf.causa/note-sensitive-suppressed` above for the rationale).
-    (rf/reg-event-db :rf.causa/note-trace-event
-      {:rf.trace/no-emit? true}
-      (fn [db [_ event]]
-        (let [depth (trace-bus/current-depth)
-              buf   (get db :trace-buffer [])
-              buf'  (trace-bus/push buf depth event)]
-          (assoc db :trace-buffer buf'))))
-
-    ;; Clear Causa's reactive trace-buffer slot (rf2-iw5ym).
-    ;; Dispatched from `trace-bus/clear-buffer!` (CLJS) — clearing
-    ;; the atom-side ring buffer must drop the app-db mirror in
-    ;; lockstep so panels reading the buffer empty alongside.
-    ;;
-    ;; Per rf2-qsjda: `:rf.trace/no-emit? true` (see
-    ;; `:rf.causa/note-sensitive-suppressed` above for the rationale).
-    (rf/reg-event-db :rf.causa/clear-trace-buffer
-      {:rf.trace/no-emit? true}
-      (fn [db _event]
-        (dissoc db :trace-buffer)))
-
-    ;; Re-sync Causa's reactive trace-buffer slot to an explicit
-    ;; value (rf2-iw5ym). Dispatched from `trace-bus/set-buffer-
-    ;; depth!` (CLJS) when shrinking the depth would otherwise
-    ;; leave the app-db mirror longer than the atom side. The
-    ;; payload is the post-shrink vector.
-    ;;
-    ;; Per rf2-qsjda: `:rf.trace/no-emit? true` (see
-    ;; `:rf.causa/note-sensitive-suppressed` above for the rationale).
-    (rf/reg-event-db :rf.causa/sync-trace-buffer
-      {:rf.trace/no-emit? true}
-      (fn [db [_ buf]]
-        (assoc db :trace-buffer (vec buf))))
+    ;; Per rf2-e9s81 (supersedes rf2-iw5ym):
+    ;; `:rf.causa/note-trace-event` / `:rf.causa/clear-trace-buffer`
+    ;; / `:rf.causa/sync-trace-buffer` were removed when the trace-
+    ;; buffer reactive surface reverted to the pre-iw5ym shape (sub
+    ;; thunks the atom; layer-1 re-fires on the host's next dispatch).
+    ;; See `trace_bus.cljc` §Reactivity for the trade-off + the
+    ;; planned wider refactor.
 
     (rf/reg-event-db :rf.causa/select-dispatch-id
       (fn [db [_ dispatch-id]]

--- a/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
@@ -37,27 +37,43 @@
   opts in via `(causa-config/configure! {:trace/show-sensitive?
   true})`.
 
-  ## Reactive container (rf2-iw5ym)
+  ## Reactivity (rf2-iw5ym → rf2-e9s81)
 
-  Per rf2-iw5ym (same recipe as rf2-0vxdn's `suppressed-counters`
-  fix): the buffer is also mirrored into Causa's app-db at
-  `[:rf/causa db :trace-buffer]` via dispatch (CLJS only) so the
-  `:rf.causa/trace-buffer` sub fires on the standard reactive
-  write path — panels reading the buffer re-render IMMEDIATELY on
-  every push, with no dependency on a sibling sub recomputing. The
-  `buffer-state` atom here remains as the JVM-runnable data
-  primitive (`push` algebra, depth-shrink algebra, `clear-buffer!`)
-  so trace_bus's pure-data shape is testable without a CLJS runtime
-  + re-frame frame; the CLJS path dual-writes via dispatch. The
-  dispatch is async — production reads see a one-tick lag,
-  invisible at trace-rate UI cadence; tests that need the reactive
-  surface to settle synchronously dispatch the new
-  `:rf.causa/note-trace-event` / `:rf.causa/clear-trace-buffer`
-  events directly via `dispatch-sync`."
+  The buffer is held in a plain atom (`buffer-state` below). The
+  `:rf.causa/trace-buffer` sub (in `registry.cljs`) thunks
+  `(trace-bus/buffer)` so subscribers get a fresh read on every
+  recompute. The sub is layer-1 so it re-fires on every app-db
+  change of the resolved frame — under Causa's normal usage
+  (panels rendered inside a host app), every host dispatch dirties
+  the host's app-db and the sub re-fires, picking up whatever the
+  trace-cb has accumulated in the atom since the last recompute.
+  Visible delay between trace push and panel update is bounded by
+  the host's next dispatch, indistinguishable from native trace-
+  rate UI cadence on every example app the foundation ships.
+
+  History — rf2-iw5ym originally added a parallel write path
+  (`:rf.causa/note-trace-event` dispatch) so the sub would
+  re-fire IMMEDIATELY on every push (no dependency on a sibling
+  sub recomputing). That parallel path picked `:rf/causa` as its
+  write target, but `:rf/causa` is never registered in production
+  (the preload runs at ns-load time, BEFORE the host's
+  `rf/init!` installs a substrate adapter — `reg-frame` fails in
+  that window) so the dispatch silently no-op'd and step 5 of
+  `examples/.../causa.spec.cjs` went red. rf2-higwg patched the
+  parallel suppressed-counter path to chain-resolve to
+  `:rf/default`; rf2-e9s81 tried the same for the trace buffer
+  but exposed two failure modes (conformance fixtures saw the
+  trace-cb's dispatches consume drain-depth headroom and
+  pollute their `:rf/default` app-db with `:trace-buffer`
+  noise). The conclusion: an architecturally clean
+  reactive-on-every-push surface requires either reg-view-
+  wrapping Causa's panels (so plain-fn subscribes route to
+  `:rf/causa` via the React-context tier) or a fixed-frame
+  sub mechanism — both wider refactors filed for follow-up.
+  Until then, the layer-1 + host-driven recompute path
+  delivers the same UX without the layering hazards."
   (:require [re-frame.interop :as interop]
-            [day8.re-frame2-causa.config :as config]
-            #?@(:cljs [[re-frame.core :as rf]
-                       [re-frame.frame :as frame]])))
+            [day8.re-frame2-causa.config :as config]))
 
 ;; ---- ring-buffer state ----------------------------------------------------
 
@@ -91,30 +107,6 @@
       buffer')))
 
 ;; ---- collector --------------------------------------------------------
-;;
-;; History (rf2-nk01x → rf2-qsjda):
-;;
-;;   `collect-trace!` dispatches Causa's own bookkeeping events
-;;   (`:rf.causa/note-sensitive-suppressed`, `:rf.causa/note-trace-event`,
-;;   …) into `:rf/causa` whenever it processes a trace event. The
-;;   framework delivers EVERY emitted trace event back through
-;;   `register-trace-cb!`, so the collector would otherwise see its own
-;;   self-emit and recurse — driving the per-frame `:suppressed-counters`
-;;   ever upwards on `:sensitive?` events and exploding the buffer on
-;;   non-sensitive events, until the framework's `drain-depth-default`
-;;   = 100 terminates the cascade with `:rf.error/drain-depth-exceeded`.
-;;
-;;   rf2-nk01x landed a Causa-side guard (a `self-emitted?` predicate
-;;   that short-circuited at the top of `collect-trace!` for trace events
-;;   whose `:tags :event-id` or dispatched id matched a Causa-bookkeeping
-;;   set). rf2-qsjda promoted the opt-out to the framework: the
-;;   bookkeeping handlers below carry `:rf.trace/no-emit? true` in their
-;;   registration metadata (see `registry.cljs`), and Spec 009
-;;   §Trace-emission opt-out gates `emit!` / `emit-error!` /
-;;   `emit-dispatched-trace!` on the flag. The runtime short-circuits
-;;   BEFORE emitting, so the collector never sees self-emits in the
-;;   first place. The per-consumer Causa-side guard becomes redundant
-;;   and `self-emitted?` is gone.
 
 (defn collect-trace!
   "Append a trace event to Causa's ring buffer. Registered with
@@ -133,27 +125,26 @@
 
   Per rf2-0vxdn the indicator is fully reactive: `config/note-
   suppressed!` itself dispatches `:rf.causa/note-sensitive-suppressed`
-  into `:rf/causa` (CLJS) so the sub reads `:suppressed-counters`
-  off Causa's app-db on the standard write path. The buffer state
-  here is unchanged; the dispatch happens one stack frame deeper.
+  (chain-resolved to `:rf/default` via rf2-higwg) so the sub reads
+  `:suppressed-counters` off the host's app-db on the standard
+  write path. The buffer state here is unchanged; the dispatch
+  happens one stack frame deeper.
 
-  Per rf2-iw5ym the buffer push is the same shape: the atom swap
-  remains (JVM-runnable data primitive) and CLJS also dispatches
-  `:rf.causa/note-trace-event` into `:rf/causa` so the
-  `:rf.causa/trace-buffer` sub fires on the standard write path.
-  Guarded on the `:rf/causa` frame's existence — production preload
-  always installs it, but tests / hot-reload windows may emit
-  trace events before the frame registers.
-
-  Per rf2-qsjda (succeeds rf2-nk01x's Causa-side `self-emitted?`
-  guard): the bookkeeping handlers `:rf.causa/note-sensitive-suppressed`,
-  `:rf.causa/note-trace-event`, `:rf.causa/clear-trace-buffer`,
-  `:rf.causa/reset-suppressed-counters`, and `:rf.causa/sync-trace-buffer`
-  are registered with `:rf.trace/no-emit? true`. The framework
-  short-circuits trace emission for those dispatches at `emit!` /
-  `emit-error!` / `emit-dispatched-trace!`, so the collector never
-  sees the self-emits in the first place. No per-consumer guard
-  required."
+  Per rf2-e9s81 (supersedes rf2-iw5ym's parallel app-db write
+  path): the trace-buffer's reactive surface is delivered by the
+  layer-1 `:rf.causa/trace-buffer` sub's re-fire on the host's
+  next app-db change — Causa is rendered inside an active host
+  app, and every host dispatch dirties the resolved frame's
+  app-db, so the sub re-fires and reads the latest buffer atom
+  contents. The iw5ym dispatch path was removed because it could
+  not target a Causa-owned frame at preload time (the host's
+  `rf/init!` has not yet installed the substrate adapter) AND
+  chain-resolving to `:rf/default` polluted the host's app-db
+  with `:trace-buffer` noise while consuming drain-depth headroom
+  on every emitted trace event — surfacing as spurious
+  `:rf.error/drain-depth-exceeded` failures in conformance
+  fixtures (the rf2-e9s81 follow-on). Per the ns docstring
+  §Reactivity for the trade-off + the planned wider refactor."
   [event]
   (when interop/debug-enabled?
     (cond
@@ -161,12 +152,7 @@
       (config/note-suppressed! (get-in event [:tags :frame]))
 
       :else
-      (do
-        (swap! buffer-state push @buffer-depth event)
-        #?(:cljs
-           (when (frame/frame :rf/causa)
-             (binding [frame/*current-frame* :rf/causa]
-               (rf/dispatch [:rf.causa/note-trace-event event]))))))))
+      (swap! buffer-state push @buffer-depth event))))
 
 ;; ---- read-side accessors -------------------------------------------
 
@@ -179,10 +165,7 @@
 
 (defn current-depth
   "Return the configured buffer depth (`default-buffer-depth` until
-  `set-buffer-depth!` rewrites it). Public so the registry's
-  `:rf.causa/note-trace-event` event-db handler can mirror the
-  same eviction-on-overflow algebra `collect-trace!` uses (per
-  rf2-iw5ym)."
+  `set-buffer-depth!` rewrites it)."
   []
   @buffer-depth)
 
@@ -290,31 +273,18 @@
 
   Per rf2-0vxdn `config/reset-suppressed-count!` itself dispatches
   `:rf.causa/reset-suppressed-counters` in CLJS so the reactive
-  app-db slot clears in lockstep with the atom.
-
-  Per rf2-iw5ym the buffer's app-db mirror also clears in lockstep
-  — the CLJS path dispatches `:rf.causa/clear-trace-buffer` so the
-  `:rf.causa/trace-buffer` sub re-fires off the standard write
-  path and panels reading the buffer drop to empty immediately."
+  app-db slot clears in lockstep with the atom (the indicator path
+  is genuinely on app-db, separate from the trace buffer)."
   []
   (when interop/debug-enabled?
     (reset! buffer-state [])
-    (config/reset-suppressed-count!)
-    #?(:cljs
-       (when (frame/frame :rf/causa)
-         (binding [frame/*current-frame* :rf/causa]
-           (rf/dispatch [:rf.causa/clear-trace-buffer])))))
+    (config/reset-suppressed-count!))
   nil)
 
 (defn set-buffer-depth!
   "Set the buffer's depth. `depth=0` keeps the collector wired (so the
   callback can be replaced or augmented) but flushes the buffer to
-  empty and prevents further accumulation. No-op in production.
-
-  Per rf2-iw5ym: when the new depth shrinks the buffer, the app-db
-  mirror is re-synced via `:rf.causa/sync-trace-buffer` so the
-  reactive `:rf.causa/trace-buffer` sub reflects the truncated
-  shape rather than the pre-shrink contents."
+  empty and prevents further accumulation. No-op in production."
   [depth]
   (when (and interop/debug-enabled? (number? depth) (not (neg? depth)))
     (reset! buffer-depth depth)
@@ -324,9 +294,5 @@
                (cond
                  (zero? depth) []
                  (> n depth)   (subvec v (- n depth))
-                 :else         v))))
-    #?(:cljs
-       (when (frame/frame :rf/causa)
-         (binding [frame/*current-frame* :rf/causa]
-           (rf/dispatch [:rf.causa/sync-trace-buffer @buffer-state])))))
+                 :else         v)))))
   nil)

--- a/tools/causa/test/day8/re_frame2_causa/panels/causality_graph_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/causality_graph_view_cljs_test.cljs
@@ -67,19 +67,14 @@
 
 (defn- seed-buffer!
   "Wire the trace collector (preload-style) and push the supplied
-  events through Causa's reactive trace-buffer slot.
-
-  Per rf2-iw5ym `:rf.causa/trace-buffer` is reactive off Causa's
-  app-db, not the trace-bus atom. Tests use `dispatch-sync` of
-  `:rf.causa/note-trace-event` to mirror what production's
-  `trace-bus/collect-trace!` does (async dispatch), driving the
-  sub re-fire synchronously before the next subscribe."
+  events through Causa's trace-bus atom via `collect-trace!` — the
+  production path. Per rf2-e9s81 `:rf.causa/trace-buffer` thunks
+  the atom so a subsequent subscribe returns the events directly."
   [evs]
   (registry/register-causa-handlers!)
   (frame/reg-frame :rf/causa {})
-  (rf/with-frame :rf/causa
-    (doseq [ev evs]
-      (rf/dispatch-sync [:rf.causa/note-trace-event ev]))))
+  (doseq [ev evs]
+    (trace-bus/collect-trace! ev)))
 
 (defn- expand-fn-component [node]
   (if (and (vector? node) (fn? (first node)))

--- a/tools/causa/test/day8/re_frame2_causa/panels/effects_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/effects_view_cljs_test.cljs
@@ -89,12 +89,10 @@
   (rf/dispatch-sync [:rf.causa/set-registered-fxs-override-for-test m]))
 
 (defn- push-trace! [ev]
-  ;; Per rf2-iw5ym: `:rf.causa/trace-buffer` is reactive off Causa's
-  ;; app-db, not the trace-bus atom. Tests drive the reactive write
-  ;; path directly via `dispatch-sync` so the composite sub re-fires
-  ;; synchronously on the next subscribe.
-  (rf/with-frame :rf/causa
-    (rf/dispatch-sync [:rf.causa/note-trace-event ev])))
+  ;; Per rf2-e9s81: `:rf.causa/trace-buffer` thunks the trace-bus
+  ;; atom; pushing via `collect-trace!` (the production path) lands
+  ;; the event in the atom and the next subscribe sees it.
+  (trace-bus/collect-trace! ev))
 
 ;; ---- (1) registry wires the composite sub -------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
@@ -79,22 +79,15 @@
 
 (defn- seed-buffer!
   "Register Causa's handlers, allocate the :rf/causa frame, then push
-  the supplied events through Causa's reactive trace-buffer slot.
-
-  Per rf2-iw5ym `:rf.causa/trace-buffer` is reactive off Causa's
-  app-db; the buffer-bus atom is no longer the sub's source of
-  truth. Tests drive the new reactive write path via `dispatch-sync`
-  of `:rf.causa/note-trace-event` so the composite sub re-fires
-  synchronously before the view is rendered. (Production wiring
-  still goes through `trace-bus/collect-trace!`; that path is
-  covered by sensitive_trace_cljs_test + filter_vocab_consumer_
-  cljs_test.)"
+  the supplied events through Causa's trace-bus atom via
+  `collect-trace!` — the production path. Per rf2-e9s81
+  `:rf.causa/trace-buffer` thunks the atom, so a subsequent
+  subscribe returns the events directly."
   [evs]
   (registry/register-causa-handlers!)
   (frame/reg-frame :rf/causa {})
-  (rf/with-frame :rf/causa
-    (doseq [ev evs]
-      (rf/dispatch-sync [:rf.causa/note-trace-event ev]))))
+  (doseq [ev evs]
+    (trace-bus/collect-trace! ev)))
 
 (defn- expand-fn-component
   "When `node` is a hiccup-style `[fn-component args...]` vector

--- a/tools/causa/test/day8/re_frame2_causa/panels/flows_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/flows_view_cljs_test.cljs
@@ -87,12 +87,10 @@
   (rf/dispatch-sync [:rf.causa/set-registered-flows-override-for-test m]))
 
 (defn- push-trace! [ev]
-  ;; Per rf2-iw5ym: `:rf.causa/trace-buffer` is reactive off Causa's
-  ;; app-db, not the trace-bus atom. Tests drive the reactive write
-  ;; path directly via `dispatch-sync` so the composite sub re-fires
-  ;; synchronously on the next subscribe.
-  (rf/with-frame :rf/causa
-    (rf/dispatch-sync [:rf.causa/note-trace-event ev])))
+  ;; Per rf2-e9s81: `:rf.causa/trace-buffer` thunks the trace-bus
+  ;; atom; pushing via `collect-trace!` (the production path) lands
+  ;; the event in the atom and the next subscribe sees it.
+  (trace-bus/collect-trace! ev))
 
 ;; ---- (1) registry wires the composite sub -------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_view_cljs_test.cljs
@@ -69,17 +69,15 @@
 
 (defn- seed-buffer!
   "Register Causa's handlers, allocate the :rf/causa frame, then push
-  the supplied events through Causa's reactive trace-buffer slot
-  (per rf2-iw5ym `:rf.causa/trace-buffer` is reactive off Causa's
-  app-db; `dispatch-sync` of `:rf.causa/note-trace-event` is the
-  test-side write path that mirrors `trace-bus/collect-trace!`'s
-  production async dispatch)."
+  the supplied events through Causa's trace-bus atom via
+  `collect-trace!` — the production path. Per rf2-e9s81
+  `:rf.causa/trace-buffer` thunks the atom, so a subsequent
+  subscribe returns the events directly."
   [evs]
   (registry/register-causa-handlers!)
   (frame/reg-frame :rf/causa {})
-  (rf/with-frame :rf/causa
-    (doseq [ev evs]
-      (rf/dispatch-sync [:rf.causa/note-trace-event ev]))))
+  (doseq [ev evs]
+    (trace-bus/collect-trace! ev)))
 
 ;; ---- hiccup walker (lifted from causality_graph_view_cljs_test) ---------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
@@ -106,12 +106,10 @@
   (frame/reg-frame :rf/causa {}))
 
 (defn- push-trace! [ev]
-  ;; Per rf2-iw5ym: `:rf.causa/trace-buffer` is reactive off Causa's
-  ;; app-db, not the trace-bus atom. Tests drive the reactive write
-  ;; path directly via `dispatch-sync` so the composite sub re-fires
-  ;; synchronously on the next subscribe.
-  (rf/with-frame :rf/causa
-    (rf/dispatch-sync [:rf.causa/note-trace-event ev])))
+  ;; Per rf2-e9s81: `:rf.causa/trace-buffer` thunks the trace-bus
+  ;; atom; pushing via `collect-trace!` (the production path) lands
+  ;; the event in the atom and the next subscribe sees it.
+  (trace-bus/collect-trace! ev))
 
 ;; Synthetic issue trace event.
 (defn- mk-issue

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
@@ -246,20 +246,17 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-machines! [:auth/login])
-      ;; Push two transition events into the Causa trace buffer.
-      ;; Per rf2-iw5ym `:rf.causa/trace-buffer` is reactive off
-      ;; Causa's app-db; tests drive the reactive write path
-      ;; directly via `dispatch-sync` of `:rf.causa/note-trace-event`.
-      (rf/dispatch-sync
-        [:rf.causa/note-trace-event
-         {:id 1 :operation :rf.machine/transition :time 100
-          :tags {:machine-id :auth/login :from :idle :to :authing
-                 :event [:auth/submit] :dispatch-id "d-1"}}])
-      (rf/dispatch-sync
-        [:rf.causa/note-trace-event
-         {:id 2 :operation :rf.machine/transition :time 200
-          :tags {:machine-id :auth/login :from :authing :to :idle
-                 :event [:auth/cancel] :dispatch-id "d-2"}}])
+      ;; Push two transition events into the Causa trace buffer via
+      ;; the production `collect-trace!` path (per rf2-e9s81 the
+      ;; sub thunks the trace-bus atom).
+      (trace-bus/collect-trace!
+        {:id 1 :operation :rf.machine/transition :time 100
+         :tags {:machine-id :auth/login :from :idle :to :authing
+                :event [:auth/submit] :dispatch-id "d-1"}})
+      (trace-bus/collect-trace!
+        {:id 2 :operation :rf.machine/transition :time 200
+         :tags {:machine-id :auth/login :from :authing :to :idle
+                :event [:auth/cancel] :dispatch-id "d-2"}})
       (let [tree    (machine-inspector/machine-inspector-view)
             entries (find-all-by-testid-prefix
                       tree "rf-causa-machine-inspector-transition-")]
@@ -272,14 +269,12 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-machines! [:auth/login])
-      ;; Per rf2-iw5ym `:rf.causa/trace-buffer` is reactive off
-      ;; Causa's app-db; tests drive the reactive write path
-      ;; directly via `dispatch-sync` of `:rf.causa/note-trace-event`.
-      (rf/dispatch-sync
-        [:rf.causa/note-trace-event
-         {:id 1 :operation :rf.machine/transition :time 100
-          :tags {:machine-id :auth/login :from :idle :to :authing
-                 :event [:auth/submit] :dispatch-id "d-42"}}])
+      ;; Push a transition event via `collect-trace!` (per rf2-e9s81
+      ;; the sub thunks the trace-bus atom).
+      (trace-bus/collect-trace!
+        {:id 1 :operation :rf.machine/transition :time 100
+         :tags {:machine-id :auth/login :from :idle :to :authing
+                :event [:auth/submit] :dispatch-id "d-42"}})
       (let [dispatches (atom [])]
         ;; rf/dispatch is async; with-redefs on the underlying
         ;; rf/dispatch* fn captures the event vector synchronously

--- a/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_view_cljs_test.cljs
@@ -87,12 +87,10 @@
 ;; the pattern other view tests use (trace-bus is the source the
 ;; composite sub reads through `:rf.causa/trace-buffer`).
 (defn- push-event! [ev]
-  ;; Per rf2-iw5ym: `:rf.causa/trace-buffer` is reactive off Causa's
-  ;; app-db, not the trace-bus atom. Tests drive the reactive write
-  ;; path directly via `dispatch-sync` so the composite sub re-fires
-  ;; synchronously on the next subscribe.
-  (rf/with-frame :rf/causa
-    (rf/dispatch-sync [:rf.causa/note-trace-event ev])))
+  ;; Per rf2-e9s81: `:rf.causa/trace-buffer` thunks the trace-bus
+  ;; atom; pushing via `collect-trace!` (the production path) lands
+  ;; the event in the atom and the next subscribe sees it.
+  (trace-bus/collect-trace! ev))
 
 (defn- mcp-event
   "Build a :origin :causa-mcp trace event in the shape the buffer

--- a/tools/causa/test/day8/re_frame2_causa/panels/performance_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/performance_view_cljs_test.cljs
@@ -98,12 +98,10 @@
   (frame/reg-frame :rf/causa {}))
 
 (defn- push-trace! [ev]
-  ;; Per rf2-iw5ym: `:rf.causa/trace-buffer` is reactive off Causa's
-  ;; app-db, not the trace-bus atom. Tests drive the reactive write
-  ;; path directly via `dispatch-sync` so the composite sub re-fires
-  ;; synchronously on the next subscribe.
-  (rf/with-frame :rf/causa
-    (rf/dispatch-sync [:rf.causa/note-trace-event ev])))
+  ;; Per rf2-e9s81: `:rf.causa/trace-buffer` thunks the trace-bus
+  ;; atom; pushing via `collect-trace!` (the production path) lands
+  ;; the event in the atom and the next subscribe sees it.
+  (trace-bus/collect-trace! ev))
 
 ;; Build a synthetic cascade — :event/dispatched + handler + fx + effects
 ;; — with the given dispatch-id, span (last-time minus first-time gives

--- a/tools/causa/test/day8/re_frame2_causa/panels/routes_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/routes_view_cljs_test.cljs
@@ -95,12 +95,10 @@
   (rf/dispatch-sync [:rf.causa/set-active-route-slice-override-for-test s]))
 
 (defn- push-trace! [ev]
-  ;; Per rf2-iw5ym: `:rf.causa/trace-buffer` is reactive off Causa's
-  ;; app-db, not the trace-bus atom. Tests drive the reactive write
-  ;; path directly via `dispatch-sync` so the composite sub re-fires
-  ;; synchronously on the next subscribe.
-  (rf/with-frame :rf/causa
-    (rf/dispatch-sync [:rf.causa/note-trace-event ev])))
+  ;; Per rf2-e9s81: `:rf.causa/trace-buffer` thunks the trace-bus
+  ;; atom; pushing via `collect-trace!` (the production path) lands
+  ;; the event in the atom and the next subscribe sees it.
+  (trace-bus/collect-trace! ev))
 
 ;; ---- (1) registry wires the composite sub -------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/schema_violation_timeline_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/schema_violation_timeline_cljs_test.cljs
@@ -92,13 +92,11 @@
                 :frame  :rf/default}}))
 
 (defn- push-failures! [evs]
-  ;; Per rf2-iw5ym: `:rf.causa/trace-buffer` is reactive off Causa's
-  ;; app-db, not the trace-bus atom. Tests drive the reactive write
-  ;; path directly via `dispatch-sync` so the composite sub re-fires
-  ;; synchronously on the next subscribe.
-  (rf/with-frame :rf/causa
-    (doseq [ev evs]
-      (rf/dispatch-sync [:rf.causa/note-trace-event ev]))))
+  ;; Per rf2-e9s81: `:rf.causa/trace-buffer` thunks the trace-bus
+  ;; atom; pushing via `collect-trace!` (the production path) lands
+  ;; the events in the atom and the next subscribe sees them.
+  (doseq [ev evs]
+    (trace-bus/collect-trace! ev)))
 
 ;; ---- (1) registry wires subs / events -----------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
@@ -102,12 +102,10 @@
   (frame/reg-frame :rf/causa {}))
 
 (defn- push-trace! [ev]
-  ;; Per rf2-iw5ym: `:rf.causa/trace-buffer` is reactive off Causa's
-  ;; app-db, not the trace-bus atom. Tests drive the reactive write
-  ;; path directly via `dispatch-sync` so the composite sub re-fires
-  ;; synchronously on the next subscribe.
-  (rf/with-frame :rf/causa
-    (rf/dispatch-sync [:rf.causa/note-trace-event ev])))
+  ;; Per rf2-e9s81: `:rf.causa/trace-buffer` thunks the trace-bus
+  ;; atom; pushing via `collect-trace!` (the production path) lands
+  ;; the event in the atom and the next subscribe sees it.
+  (trace-bus/collect-trace! ev))
 
 ;; Construct a synthetic trace event with the canonical 9-axis tags.
 (defn- mk-trace

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -162,7 +162,6 @@
    :rf.causa/clear-selected-epoch
    :rf.causa/clear-selected-sub
    :rf.causa/clear-slice-focus
-   :rf.causa/clear-trace-buffer
    :rf.causa/clear-trace-filters
    :rf.causa/clear-violation-selection
    :rf.causa/copy-path-to-clipboard
@@ -172,7 +171,6 @@
    :rf.causa/focus-slice-path
    :rf.causa/hide-invalidation-chain
    :rf.causa/note-sensitive-suppressed
-   :rf.causa/note-trace-event
    :rf.causa/open-in-editor
    :rf.causa/pin-current
    :rf.causa/pin-slice
@@ -206,7 +204,6 @@
    :rf.causa/set-sub-cache-override-for-test
    :rf.causa/set-trace-filter
    :rf.causa/show-invalidation-chain
-   :rf.causa/sync-trace-buffer
    :rf.causa/toggle-issues-prefix
    :rf.causa/toggle-issues-severity
    :rf.causa/toggle-mcp-op-type
@@ -244,10 +241,10 @@
           (str "expected :fx handler for " fx-id)))))
 
 (deftest registry-counts-match-bead
-  (testing "registry holds exactly 64 subs + 63 events + 3 fxs (rf2-5zl7l;
-            +2 events for rf2-0vxdn; +3 events for rf2-iw5ym)"
+  (testing "registry holds exactly 64 subs + 60 events + 3 fxs (rf2-5zl7l;
+            +2 events for rf2-0vxdn; -3 events for rf2-e9s81)"
     (is (= 64 (count all-sub-names)))
-    (is (= 63 (count all-event-names)))
+    (is (= 60 (count all-event-names)))
     (is (= 3  (count all-fx-names)))))
 
 (deftest registry-is-idempotent
@@ -263,53 +260,54 @@
 
 ;; ---- (2) high-value sub contracts: defaults on a fresh frame ------------
 
-(deftest sub-trace-buffer-reads-app-db
-  (testing ":rf.causa/trace-buffer reads from Causa's app-db at
-            `:trace-buffer` (rf2-iw5ym — same recipe as rf2-0vxdn's
-            `:suppressed-counters` fix). First deref returns the
-            default `[]`; each `:rf.causa/note-trace-event` dispatch
-            re-fires the sub on the standard write path (immediate
-            reactive update, no clear-subscription-cache! workaround
-            required). `:rf.causa/clear-trace-buffer` drops the slot
-            back to empty."
+(deftest sub-trace-buffer-thunks-trace-bus
+  (testing ":rf.causa/trace-buffer thunks `trace-bus/buffer` (the
+            process-global ring atom). Tests push BEFORE the first
+            subscribe — the first deref of a fresh Reaction reads
+            whatever the atom holds at that moment. Re-deriving after
+            an atom mutation is NOT covered by this contract (the
+            Reaction caches against the no-op input-signal); under
+            Causa's normal usage that gap is closed by the host's
+            next app-db dispatch dirtying the resolved frame's db.
+            Per rf2-e9s81 — see `trace_bus.cljc` §Reactivity."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (is (= [] @(rf/subscribe [:rf.causa/trace-buffer]))
-          "empty :trace-buffer slot → sub returns []")
-      (rf/dispatch-sync
-        [:rf.causa/note-trace-event
-         {:id 1 :op-type :event :operation :rf.test/x :tags {}}])
-      (let [buf @(rf/subscribe [:rf.causa/trace-buffer])]
-        (is (= 1 (count buf))
-            "one bump via dispatch → sub returns one-element buffer")
-        (is (= 1 (:id (first buf)))
-            "the dispatched event is in the buffer"))
-      (rf/dispatch-sync
-        [:rf.causa/note-trace-event
-         {:id 2 :op-type :event :operation :rf.test/y :tags {}}])
+      ;; Push first, then subscribe — the Reaction's first read sees
+      ;; the current atom contents.
+      (trace-bus/collect-trace!
+        {:id 1 :op-type :event :operation :rf.test/x :tags {}})
+      (trace-bus/collect-trace!
+        {:id 2 :op-type :event :operation :rf.test/y :tags {}})
       (let [buf @(rf/subscribe [:rf.causa/trace-buffer])]
         (is (= 2 (count buf))
-            "second bump appends — sub returns a two-element buffer")
+            "the two pushes are visible on the first subscribe")
         (is (= [1 2] (mapv :id buf))
-            "events are oldest-first, matching trace-bus/push algebra"))
-      (rf/dispatch-sync [:rf.causa/clear-trace-buffer])
-      (is (= [] @(rf/subscribe [:rf.causa/trace-buffer]))
-          "clear event drops the slot back to default empty"))))
+            "events are oldest-first, matching trace-bus/push algebra")))))
 
-(deftest sub-trace-buffer-evicts-on-overflow-via-event
-  (testing ":rf.causa/note-trace-event mirrors trace-bus/push's
-            eviction-on-overflow algebra against `trace-bus/current-
-            depth`. We shrink the depth to 3 then push 5 events; the
-            sub returns the 3 newest in oldest-first order
-            (rf2-iw5ym)."
+(deftest sub-trace-buffer-fresh-frame-sees-empty
+  (testing "a fresh :rf/causa frame with an empty `trace-bus/buffer-state`
+            yields an empty :rf.causa/trace-buffer sub. Clearing the
+            atom before the first subscribe is the canonical reset
+            shape per rf2-e9s81 (the previous app-db-mirror reset
+            shape via `:rf.causa/clear-trace-buffer` is removed)."
+    (setup-causa-frame!)
+    (trace-bus/clear-buffer!)
+    (rf/with-frame :rf/causa
+      (is (= [] @(rf/subscribe [:rf.causa/trace-buffer]))
+          "empty atom → sub returns []"))))
+
+(deftest sub-trace-buffer-evicts-on-overflow
+  (testing "trace-bus enforces the eviction-on-overflow algebra against
+            `current-depth`. We shrink the depth to 3 then push 5
+            events BEFORE the first subscribe; the sub returns the 3
+            newest in oldest-first order."
     (setup-causa-frame!)
     (trace-bus/set-buffer-depth! 3)
     (try
       (rf/with-frame :rf/causa
         (dotimes [i 5]
-          (rf/dispatch-sync
-            [:rf.causa/note-trace-event
-             {:id i :op-type :event :operation :rf.test/x :tags {}}]))
+          (trace-bus/collect-trace!
+            {:id i :op-type :event :operation :rf.test/x :tags {}}))
         (let [buf @(rf/subscribe [:rf.causa/trace-buffer])]
           (is (= 3 (count buf))
               "depth=3 caps the sub-visible buffer at 3 entries")
@@ -317,75 +315,6 @@
               "oldest entries evicted; newest retained in oldest-first order")))
       (finally
         (trace-bus/set-buffer-depth! 1000)))))
-
-(deftest sub-trace-buffer-survives-hot-reload
-  (testing "re-running `register-causa-handlers!` (shadow-cljs
-            `:after-load`) preserves the previously-pushed events
-            — the idempotency sentinel skips re-registration so the
-            event-db handler is the same instance and the app-db
-            `:trace-buffer` slot is untouched (rf2-iw5ym)."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync
-        [:rf.causa/note-trace-event
-         {:id 1 :op-type :event :operation :rf.test/x :tags {}}])
-      (is (= 1 (count @(rf/subscribe [:rf.causa/trace-buffer]))))
-      ;; Hot-reload simulation — `register-causa-handlers!` is
-      ;; idempotent under the `defonce ^:private registered?` gate
-      ;; (rf2-n6x4q). Calling it again must NOT replace handlers
-      ;; nor drop the buffer.
-      (registry/register-causa-handlers!)
-      (is (= 1 (count @(rf/subscribe [:rf.causa/trace-buffer])))
-          "buffer survives a no-op re-registration")
-      (rf/dispatch-sync
-        [:rf.causa/note-trace-event
-         {:id 2 :op-type :event :operation :rf.test/y :tags {}}])
-      (is (= 2 (count @(rf/subscribe [:rf.causa/trace-buffer])))
-          "subsequent pushes still land in the existing slot"))))
-
-(deftest sub-trace-buffer-restarts-from-clean-state
-  (testing "after `:rf.causa/clear-trace-buffer` + frame reset the
-            sub returns []; the next push starts from id 0
-            (rf2-iw5ym — restart-from-clean-state contract)."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (dotimes [i 3]
-        (rf/dispatch-sync
-          [:rf.causa/note-trace-event
-           {:id i :op-type :event :operation :rf.test/x :tags {}}]))
-      (is (= 3 (count @(rf/subscribe [:rf.causa/trace-buffer]))))
-      (rf/dispatch-sync [:rf.causa/clear-trace-buffer])
-      (is (= [] @(rf/subscribe [:rf.causa/trace-buffer]))
-          "clear drops the slot")
-      (rf/dispatch-sync
-        [:rf.causa/note-trace-event
-         {:id 0 :op-type :event :operation :rf.test/x :tags {}}])
-      (let [buf @(rf/subscribe [:rf.causa/trace-buffer])]
-        (is (= 1 (count buf))
-            "the next push starts a fresh buffer")
-        (is (= 0 (:id (first buf)))
-            "the fresh buffer begins at the re-pushed id")))))
-
-(deftest event-sync-trace-buffer-replaces-slot
-  (testing ":rf.causa/sync-trace-buffer overwrites the slot wholesale
-            (rf2-iw5ym — used by `trace-bus/set-buffer-depth!` when
-            shrinking the depth would otherwise leave the mirror
-            longer than the atom side)."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (dotimes [i 4]
-        (rf/dispatch-sync
-          [:rf.causa/note-trace-event
-           {:id i :op-type :event :operation :rf.test/x :tags {}}]))
-      (is (= 4 (count @(rf/subscribe [:rf.causa/trace-buffer]))))
-      (rf/dispatch-sync
-        [:rf.causa/sync-trace-buffer
-         [{:id 99 :op-type :event :operation :rf.test/z :tags {}}]])
-      (let [buf @(rf/subscribe [:rf.causa/trace-buffer])]
-        (is (= 1 (count buf))
-            "sync replaces the slot, doesn't merge")
-        (is (= 99 (:id (first buf)))
-            "the replacement vector is exactly what the sub returns")))))
 
 (deftest sub-suppressed-sensitive-count-reads-app-db
   (testing ":rf.causa/suppressed-sensitive-count reads from Causa's

--- a/tools/causa/test/day8/re_frame2_causa/sensitive_trace_loop_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/sensitive_trace_loop_cljs_test.cljs
@@ -167,22 +167,21 @@
 ;; ---- (3) non-sensitive mirror loop is also closed ----------------------
 
 (deftest two-hundred-non-sensitive-dispatches-do-not-loop
-  (testing "the symmetric loop for `:rf.causa/note-trace-event` (the
-            non-sensitive mirror dispatch, rf2-iw5ym) is also closed —
-            per rf2-qsjda the bookkeeping handlers carry
-            `:rf.trace/no-emit? true` so the framework short-circuits
-            emission for them before the collector ever sees the trace.
-            Non-sensitive events land in the buffer cleanly with no
-            re-entry inflation."
+  (testing "non-sensitive trace events flow into the buffer cleanly.
+            Per rf2-e9s81 `collect-trace!` only swaps the buffer-state
+            atom (no follow-on dispatch), so there is no
+            `:rf.causa/note-trace-event` self-emit loop to close in
+            the first place — the buffer fills purely from the
+            host's own dispatches."
     (register-non-sensitive-event!)
     (dotimes [n 200]
       (rf/dispatch-sync [:test/plain-bump n]))
     (is (not (drain-depth-exceeded?))
-        "no drain-depth-exceeded — non-sensitive cb-dispatch loop closed")
+        "no drain-depth-exceeded across 200 dispatches")
     ;; The buffer contains many trace events per dispatch (event/
     ;; dispatched, event/handled, event/db-changed, event/do-fx, ...)
     ;; — we don't assert an exact count, just that the runtime
-    ;; survived all 200 dispatches without runaway re-entry.
+    ;; survived all 200 dispatches.
     (is (pos? (count (trace-bus/buffer)))
         "buffer received the trace events from 200 plain dispatches")))
 
@@ -191,9 +190,9 @@
 (deftest opted-in-sensitive-dispatches-also-loop-proof
   (testing "with `:trace/show-sensitive? true` sensitive events flow
             into the buffer instead of bumping the counter — the
-            self-emit guard still catches the bookkeeping path so the
-            collector doesn't re-enter via `:rf.causa/note-trace-event`
-            either"
+            cascade stays bounded because the collector only swaps
+            the buffer-state atom (rf2-e9s81 — no follow-on
+            dispatch to re-enter through)"
     (config/configure! {:trace/show-sensitive? true})
     (register-sensitive-event!)
     (dotimes [n 50]

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -393,14 +393,10 @@
             composite's :has-mismatch? flips true and the dormant
             marker drops"
     (causa-setup!)
-    ;; Per rf2-iw5ym `:rf.causa/trace-buffer` is reactive off Causa's
-    ;; app-db; the test drives the reactive write path directly via
-    ;; `dispatch-sync` so the hydration composite re-fires before the
-    ;; shell renders (production wiring goes through
-    ;; `trace-bus/collect-trace!` which dispatches async — covered by
-    ;; `sensitive_trace_cljs_test`).
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/note-trace-event (mismatch-ev 1)]))
+    ;; Per rf2-e9s81 `:rf.causa/trace-buffer` thunks the trace-bus
+    ;; atom; pushing via `collect-trace!` (the production path) lands
+    ;; the event in the atom and the next subscribe sees it.
+    (trace-bus/collect-trace! (mismatch-ev 1))
     (rf/with-frame :rf/causa
       (let [tree (shell/shell-view)
             row  (find-by-testid tree "rf-causa-sidebar-item-hydration")


### PR DESCRIPTION
## Summary

- `examples/.../causa.spec.cjs` step 5 went red after rf2-iw5ym moved `:rf.causa/trace-buffer` from thunking `trace-bus/buffer` to reading the buffer off Causa's app-db. The mirror was driven by a `:rf.causa/note-trace-event` dispatch from `collect-trace!` — but `:rf/causa` is never registered in production (the preload runs before `rf/init!` installs the substrate adapter), so the dispatch silently no-op'd and the panel stayed empty.
- Revert the sub to thunk `trace-bus/buffer` (the process-global atom). The layer-1 sub re-fires on every host-frame app-db change; under Causa's normal usage every host dispatch dirties the resolved frame's db and the sub picks up whatever the trace-cb has accumulated since the previous recompute. Visible delay is bounded by the host's next dispatch — indistinguishable from native trace-rate UI cadence.
- Remove the three orphaned event-db handlers (`:rf.causa/note-trace-event`, `:rf.causa/clear-trace-buffer`, `:rf.causa/sync-trace-buffer`) and the `:rf.trace/no-emit?` mirror plumbing from `trace-bus`. Re-shape the 18 tests that drove the removed surface to use `trace-bus/collect-trace!` (the production path).
- Document the trade-off in `trace_bus.cljc §Reactivity` + `tools/causa/spec/013-Trace-Bus.md §Reactivity`; update `014-Registry-Catalogue.md` (sub row + drop three event rows; event count 63 → 60).

The architecturally-correct fix (reg-view-wrap every Causa panel + lazy-register `:rf/causa` at mount, so plain-fn subscribes route through the React-context tier) is filed as rf2-in6l2 — a 15+ file refactor that's worth tackling when the framework's reg-view + React-context tier is stable enough to absorb the migration. This PR is the minimum-viable spike that gets the regression green.

## Test plan

- [x] `npm run test:cljs` (1816 tests / 5040 assertions) — passes locally.
- [x] `examples/reagent/counter/causa.spec.cjs` step 5 — Trace panel row count grows after counter +1 click — passes locally via an ad-hoc spec runner.
- [ ] Full CI green on the PR.