### PR TITLE
refactor(machines): Result-unwrap macro/fn for terser call sites (rf2-25zjk)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -23,7 +23,8 @@
             [re-frame.machines.lifecycle-fx.join :as join]
             [re-frame.machines.lifecycle-fx.validation :as validation]
             [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.result :as result]
+            [re-frame.machines.result :as result
+             #?@(:cljs [:include-macros true])]
             [re-frame.machines.transition :as transition]
             [re-frame.trace :as trace]))
 
@@ -190,8 +191,8 @@
     (let [r (parallel/apply-initial-entry-cascade (:machine ctx) (:snapshot ctx))]
       (if (result/fail? r)
         r
-        (result/ok (dissoc (::result/snap r) :rf/bootstrap-pending?)
-                   (::result/fx r))))
+        (result/with-ok [snap fx] r
+          (result/ok (dissoc snap :rf/bootstrap-pending?) fx))))
     (result/ok (:snapshot ctx) [])))
 
 (defn- run-step
@@ -215,30 +216,30 @@
   only when every region's leaf is `:final?`. The pure-transition
   surface stays free of runtime-only metadata."
   [ctx step-result boot-fx]
-  (let [{next-snapshot ::result/snap fx ::result/fx} step-result
-        {:keys [machine machine-id frame-id db path snapshot inner-event]} ctx
-        merged-fx (vec (concat boot-fx fx))
-        finished? (or (and (not (parallel/parallel? machine))
-                           (transition/final-on-leaf? machine (:state next-snapshot)))
-                      (finalize/all-regions-final? machine (:state next-snapshot)))
-        new-db    (assoc-in db path next-snapshot)]
-    (trace/emit! :machine :rf.machine/transition
-                 {:machine-id machine-id
-                  :event      inner-event
-                  :before     snapshot
-                  :after      next-snapshot})
-    (when (not= snapshot next-snapshot)
-      (trace/emit! :rf.machine/snapshot-updated :rf.machine/snapshot-updated
+  (result/with-ok [next-snapshot fx] step-result
+    (let [{:keys [machine machine-id frame-id db path snapshot inner-event]} ctx
+          merged-fx (vec (concat boot-fx fx))
+          finished? (or (and (not (parallel/parallel? machine))
+                             (transition/final-on-leaf? machine (:state next-snapshot)))
+                        (finalize/all-regions-final? machine (:state next-snapshot)))
+          new-db    (assoc-in db path next-snapshot)]
+      (trace/emit! :machine :rf.machine/transition
                    {:machine-id machine-id
-                    :path       path
+                    :event      inner-event
                     :before     snapshot
-                    :after      next-snapshot
-                    :frame      frame-id}))
-    (if finished?
-      (finalize/finalize-machine machine machine-id frame-id
-                                 new-db next-snapshot inner-event merged-fx)
-      {:db new-db
-       :fx merged-fx})))
+                    :after      next-snapshot})
+      (when (not= snapshot next-snapshot)
+        (trace/emit! :rf.machine/snapshot-updated :rf.machine/snapshot-updated
+                     {:machine-id machine-id
+                      :path       path
+                      :before     snapshot
+                      :after      next-snapshot
+                      :frame      frame-id}))
+      (if finished?
+        (finalize/finalize-machine machine machine-id frame-id
+                                   new-db next-snapshot inner-event merged-fx)
+        {:db new-db
+         :fx merged-fx}))))
 
 (defn create-machine-handler
   "Returns a function suitable for registration with `reg-event-fx`.
@@ -291,17 +292,16 @@
             (if (result/fail? boot-result)
               (trace-action-failure! (:machine-id ctx) [:rf.machine/bootstrap]
                                      (:frame-id ctx)
-                                     (::result/info boot-result)
+                                     (result/info boot-result)
                                      "Machine initial-entry action threw.")
-              (let [post-boot-snap (::result/snap boot-result)
-                    boot-fx        (::result/fx boot-result)
-                    step-result    (run-step ctx post-boot-snap)]
-                (if (result/fail? step-result)
-                  (trace-action-failure! (:machine-id ctx) (:inner-event ctx)
-                                         (:frame-id ctx)
-                                         (::result/info step-result)
-                                         "Machine action threw.")
-                  (commit-or-finalize ctx step-result boot-fx))))))))))
+              (result/with-ok [post-boot-snap boot-fx] boot-result
+                (let [step-result (run-step ctx post-boot-snap)]
+                  (if (result/fail? step-result)
+                    (trace-action-failure! (:machine-id ctx) (:inner-event ctx)
+                                           (:frame-id ctx)
+                                           (result/info step-result)
+                                           "Machine action threw.")
+                    (commit-or-finalize ctx step-result boot-fx)))))))))))
 
 ;; ---- reg-machine* — plain-fn surface (rf2-8bp3) ---------------------------
 

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -31,7 +31,8 @@
   resolved single (or region) machine context, so the parallel layer
   is bypassed for the recursive macrostep call."
   (:require [clojure.set :as set]
-            [re-frame.machines.result :as result]
+            [re-frame.machines.result :as result
+             #?@(:cljs [:include-macros true])]
             [re-frame.machines.transition :as transition]))
 
 (defn parallel?
@@ -181,13 +182,13 @@
                 step-result (apply-initial-entry-cascade-single region-spec region-snap)]
             (if (result/fail? step-result)
               step-result
-              (let [{reg-snap ::result/snap reg-fx ::result/fx} step-result
-                    prefixed-fx (mapv (partial prefix-region-invoke-id rn) reg-fx)]
-                (recur (rest pending)
-                       (:data reg-snap)
-                       (:rf/spawn-counter reg-snap)
-                       (assoc new-states rn (:state reg-snap))
-                       (vec (concat acc-fx prefixed-fx)))))))))
+              (result/with-ok [reg-snap reg-fx] step-result
+                (let [prefixed-fx (mapv (partial prefix-region-invoke-id rn) reg-fx)]
+                  (recur (rest pending)
+                         (:data reg-snap)
+                         (:rf/spawn-counter reg-snap)
+                         (assoc new-states rn (:state reg-snap))
+                         (vec (concat acc-fx prefixed-fx))))))))))
     (apply-initial-entry-cascade-single machine initial-snapshot)))
 
 (declare machine-transition)
@@ -246,13 +247,13 @@
               step-result (machine-transition region-spec region-snap event)]
           (if (result/fail? step-result)
             step-result
-            (let [{reg-snap ::result/snap reg-fx ::result/fx} step-result
-                  prefixed-fx (mapv (partial prefix-region-invoke-id rn) reg-fx)]
-              (recur (rest pending)
-                     (:data reg-snap)
-                     (:rf/spawn-counter reg-snap)
-                     (assoc new-states rn (:state reg-snap))
-                     (vec (concat acc-fx prefixed-fx))))))))))
+            (result/with-ok [reg-snap reg-fx] step-result
+              (let [prefixed-fx (mapv (partial prefix-region-invoke-id rn) reg-fx)]
+                (recur (rest pending)
+                       (:data reg-snap)
+                       (:rf/spawn-counter reg-snap)
+                       (assoc new-states rn (:state reg-snap))
+                       (vec (concat acc-fx prefixed-fx)))))))))))
 
 (defn machine-transition
   "Pure function. Given a machine definition, current snapshot, and event,
@@ -260,7 +261,10 @@
   carrying the new snapshot and effects vector, or a `result/fail`
   carrying diagnostic info if any action / `:data`-fn threw. Use
   `result/ok?` / `result/fail?` to discriminate and the `::result/snap`
-  / `::result/fx` / `::result/info` keys to destructure.
+  / `::result/fx` / `::result/info` keys to destructure (or the
+  `result/with-ok` macro for the pair-destructure-after-fail-check
+  pattern, and the plain `result/snap` / `result/fx` / `result/info`
+  fns for single-slot reads).
 
   Per Spec 005 §Drain semantics §Level 3, this is the macrostep:
    1. Pick the matching transition for the event using deepest-wins

--- a/implementation/machines/src/re_frame/machines/result.cljc
+++ b/implementation/machines/src/re_frame/machines/result.cljc
@@ -24,7 +24,27 @@
 
   Use the constructors `ok` / `fail` and the predicates `ok?` / `fail?`.
   The `::snap` / `::fx` / `::info` keys are public so callers can
-  destructure with `::keys [snap fx]`.
+  destructure with `::keys [snap fx]` — or, for the common
+  pair-destructure-after-fail-check pattern, use the `with-ok` macro:
+
+      (if (fail? r)
+        (fail-with r ...)
+        (with-ok [snap fx] r
+          ...body using snap fx...))
+
+  Single-field reads have plain accessor fns `snap` / `fx` / `info` so
+  call sites don't need the `::result/` namespace prefix where only one
+  slot is wanted.
+
+  Rejected alternative — `defrecord Result [tag snap fx info]`: would let
+  callers destructure with bare `{:keys [snap fx]}`, BUT changes the
+  public key shape from `::tag` / `::snap` / `::fx` / `::info` (the
+  `:rf/*` single-root namespaced scheme per `spec/Conventions.md`) to
+  bare unqualified keys. External callers (`re-frame.machines/machine-
+  transition` is publicly re-exported; core's smoke / pattern-smoke
+  tests destructure via `::result/snap`) would all churn. The macro
+  preserves the namespaced-key contract while giving call sites the
+  ergonomic win.
 
   Bundle-isolation note: this ns is internal to the machines artefact.
   Nothing in `tools/` or `examples/` reaches into it; the public
@@ -64,3 +84,47 @@
   `:state-path`) before re-raising."
   [r extra]
   (assoc r ::info (merge (::info r) extra)))
+
+(defn snap
+  "Read the post-transition snapshot off an `:ok` Result. One-char-shorter
+  spelling of `(::result/snap r)` — same semantics. For pair destructures
+  use the `with-ok` macro."
+  [r]
+  (::snap r))
+
+(defn fx
+  "Read the emitted fx vector off an `:ok` Result. One-char-shorter
+  spelling of `(::result/fx r)` — same semantics. For pair destructures
+  use the `with-ok` macro."
+  [r]
+  (::fx r))
+
+(defn info
+  "Read the diagnostic info map off a `:fail` Result. One-char-shorter
+  spelling of `(::result/info r)` — same semantics."
+  [r]
+  (::info r))
+
+#?(:clj
+   (defmacro with-ok
+     "Pair-destructure an `:ok` Result's `::snap` and `::fx` slots into
+     `snap-sym` and `fx-sym`, evaluate `body` in their scope. The macro
+     captures the dominant call-site pattern across the engine — the
+     `(if (fail? r) ... (let [{snap ::result/snap fx ::result/fx} r] ...))`
+     dance — without churning the namespaced-key public-API contract.
+
+         (if (fail? cascade-r)
+           (fail-with cascade-r {...})
+           (with-ok [snap-after fx] cascade-r
+             ...body using snap-after, fx...))
+
+     `snap-sym` / `fx-sym` may be any local names — `_` discards. The
+     ok-vs-fail check is NOT performed here; this is destructure-only
+     sugar, intended to follow an explicit `(fail? r)` branch. Use the
+     plain `snap` / `fx` / `info` accessor fns for single-slot reads."
+     [[snap-sym fx-sym] r & body]
+     (let [r-sym (gensym "r")]
+       `(let [~r-sym  ~r
+              ~snap-sym (::snap ~r-sym)
+              ~fx-sym   (::fx ~r-sym)]
+          ~@body))))

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -20,7 +20,8 @@
   (Spec 005 §Conformance fixtures)."
   (:require [clojure.set :as set]
             [re-frame.machines.path-walk :as path-walk]
-            [re-frame.machines.result :as result]
+            [re-frame.machines.result :as result
+             #?@(:cljs [:include-macros true])]
             [re-frame.trace :as trace]))
 
 (defn- chase-ref
@@ -472,15 +473,15 @@
   (reduce
     (fn [acc aref]
       (if aref
-        (let [{::result/keys [snap fx]} acc
-              r (run-action machine snap aref event)]
-          (if (result/fail? r)
-            (reduced r)
-            (let [new-data (cond-> (:data snap)
-                             (contains? r :data) (merge (:data r)))
-                  new-snap (assoc snap :data new-data)
-                  new-fx   (vec (concat fx (or (:fx r) [])))]
-              (result/ok new-snap new-fx))))
+        (result/with-ok [snap fx] acc
+          (let [r (run-action machine snap aref event)]
+            (if (result/fail? r)
+              (reduced r)
+              (let [new-data (cond-> (:data snap)
+                               (contains? r :data) (merge (:data r)))
+                    new-snap (assoc snap :data new-data)
+                    new-fx   (vec (concat fx (or (:fx r) [])))]
+                (result/ok new-snap new-fx)))))
         acc))
     (result/ok snap [])
     action-refs))
@@ -700,7 +701,7 @@
                                  :invoke-id  invoke-id})]
     (if (result/fail? spawn-r)
       (reduced spawn-r)
-      (let [spawn-fx (::result/fx spawn-r)
+      (let [spawn-fx (result/fx spawn-r)
             s'       (apply-on-spawn machine s-alloc inv id)]
         [s' (into acc-fx spawn-fx)]))))
 
@@ -770,7 +771,7 @@
                                 :child-id   (:id child)})]
               (if (result/fail? r)
                 (reduced r)
-                (into acc (::result/fx r)))))
+                (into acc (result/fx r)))))
           []
           children-with-ids)]
     (if (result/fail? spawn-fxs-r)
@@ -993,27 +994,27 @@
       (result/fail-with cascade-r {:decl-path  (:decl-path cascade)
                                    :transition transition
                                    :state-path (:src-path cascade)})
-      (let [{snap-after ::result/snap fx ::result/fx} cascade-r
-            snap-final      (commit-snapshot machine snapshot snap-after cascade)
-            parent-id       (or (:rf/parent-id machine) :rf/transition-pure)
-            after-fx        (build-after-fx machine (:entered-pairs cascade)
-                                            (:internal? cascade) snap-final)
-            after-cancel-fx (build-after-cancel-fx parent-id (:exited-pairs cascade)
-                                                   (:internal? cascade))
-            destroy-fx      (build-destroy-fx parent-id (:exited-pairs cascade)
-                                              (:internal? cascade))
-            spawn-r         (run-spawn-phase machine event snap-final cascade)]
-        (if (result/fail? spawn-r)
-          (result/fail-with spawn-r {:decl-path  (:decl-path cascade)
-                                     :transition transition
-                                     :state-path (:src-path cascade)})
-          (let [{snap-after-spawns ::result/snap spawn-fx ::result/fx} spawn-r
-                all-fx (vec (concat fx
-                                    (or after-cancel-fx [])
-                                    (or destroy-fx [])
-                                    spawn-fx
-                                    (or after-fx [])))]
-            (result/ok snap-after-spawns all-fx)))))))
+      (result/with-ok [snap-after fx] cascade-r
+        (let [snap-final      (commit-snapshot machine snapshot snap-after cascade)
+              parent-id       (or (:rf/parent-id machine) :rf/transition-pure)
+              after-fx        (build-after-fx machine (:entered-pairs cascade)
+                                              (:internal? cascade) snap-final)
+              after-cancel-fx (build-after-cancel-fx parent-id (:exited-pairs cascade)
+                                                     (:internal? cascade))
+              destroy-fx      (build-destroy-fx parent-id (:exited-pairs cascade)
+                                                (:internal? cascade))
+              spawn-r         (run-spawn-phase machine event snap-final cascade)]
+          (if (result/fail? spawn-r)
+            (result/fail-with spawn-r {:decl-path  (:decl-path cascade)
+                                       :transition transition
+                                       :state-path (:src-path cascade)})
+            (result/with-ok [snap-after-spawns spawn-fx] spawn-r
+              (let [all-fx (vec (concat fx
+                                        (or after-cancel-fx [])
+                                        (or destroy-fx [])
+                                        spawn-fx
+                                        (or after-fx [])))]
+                (result/ok snap-after-spawns all-fx)))))))))
 
 (defn- pick-always-transition
   "Per Spec 005 §Eventless :always transitions: walk path leaf→root for
@@ -1080,7 +1081,7 @@
           (let [step-result (machine-transition-single machine snap args)]
             (if (result/fail? step-result)
               step-result
-              (let [{snap2 ::result/snap fx2 ::result/fx} step-result]
+              (result/with-ok [snap2 fx2] step-result
                 (recur (concat fx2 rest-pending)
                        accum
                        snap2
@@ -1156,47 +1157,47 @@
           (result/ok snapshot []))]
     (if (result/fail? result-after-event)
       result-after-event
-      (let [{snap-after-event ::result/snap fx-after-event ::result/fx} result-after-event
-            raised (drain-raises machine snap-after-event fx-after-event raise-limit)]
-        (if (result/fail? raised)
-          raised
-          (let [{snap-after-raise ::result/snap fx-after-raise ::result/fx} raised]
-            ;; Step 4: :always microstep loop. Track visited state-paths so that,
-            ;; on depth-limit abort, we can report the path AND fully roll back to
-            ;; the original input snapshot — the macrostep is atomic per Spec 005.
-            (loop [snap    snap-after-raise
-                   fx      fx-after-raise
-                   depth   0
-                   visited [(:state snap-after-raise)]]
-              (cond
-                (>= depth always-limit)
-                (do (trace/emit-error! :rf.error/machine-always-depth-exceeded
-                                       {:machine-id (:id machine)
-                                        :depth      depth
-                                        :path       visited
-                                        :recovery   :no-recovery})
-                    (result/ok snapshot []))
+      (result/with-ok [snap-after-event fx-after-event] result-after-event
+        (let [raised (drain-raises machine snap-after-event fx-after-event raise-limit)]
+          (if (result/fail? raised)
+            raised
+            (result/with-ok [snap-after-raise fx-after-raise] raised
+              ;; Step 4: :always microstep loop. Track visited state-paths so that,
+              ;; on depth-limit abort, we can report the path AND fully roll back to
+              ;; the original input snapshot — the macrostep is atomic per Spec 005.
+              (loop [snap    snap-after-raise
+                     fx      fx-after-raise
+                     depth   0
+                     visited [(:state snap-after-raise)]]
+                (cond
+                  (>= depth always-limit)
+                  (do (trace/emit-error! :rf.error/machine-always-depth-exceeded
+                                         {:machine-id (:id machine)
+                                          :depth      depth
+                                          :path       visited
+                                          :recovery   :no-recovery})
+                      (result/ok snapshot []))
 
-                :else
-                (let [snap-path (state-path (:state snap))
-                      always-m  (pick-always-transition machine snap-path snap)]
-                  (if (nil? always-m)
-                    ;; Macrostep fixed-point reached. Recompute the
-                    ;; active-configuration tag union on the committed snapshot
-                    ;; AFTER the new state is settled but BEFORE traces fire
-                    ;; (so the outer handler's `:rf.machine/transition` trace
-                    ;; carries the new tag set).
-                    (result/ok (commit-tags machine snap) fx)
-                    (let [step-result (apply-transition-once machine snap nil
-                                                              (:transition always-m))]
-                      (if (result/fail? step-result)
-                        step-result
-                        (let [{snap2 ::result/snap fx2 ::result/fx} step-result
-                              raised2 (drain-raises machine snap2 fx2 raise-limit)]
-                          (if (result/fail? raised2)
-                            raised2
-                            (let [{snap3 ::result/snap fx3 ::result/fx} raised2]
-                              (recur snap3
-                                     (vec (concat fx fx3))
-                                     (inc depth)
-                                     (conj visited (:state snap3))))))))))))))))))
+                  :else
+                  (let [snap-path (state-path (:state snap))
+                        always-m  (pick-always-transition machine snap-path snap)]
+                    (if (nil? always-m)
+                      ;; Macrostep fixed-point reached. Recompute the
+                      ;; active-configuration tag union on the committed snapshot
+                      ;; AFTER the new state is settled but BEFORE traces fire
+                      ;; (so the outer handler's `:rf.machine/transition` trace
+                      ;; carries the new tag set).
+                      (result/ok (commit-tags machine snap) fx)
+                      (let [step-result (apply-transition-once machine snap nil
+                                                                (:transition always-m))]
+                        (if (result/fail? step-result)
+                          step-result
+                          (result/with-ok [snap2 fx2] step-result
+                            (let [raised2 (drain-raises machine snap2 fx2 raise-limit)]
+                              (if (result/fail? raised2)
+                                raised2
+                                (result/with-ok [snap3 fx3] raised2
+                                  (recur snap3
+                                         (vec (concat fx fx3))
+                                         (inc depth)
+                                         (conj visited (:state snap3))))))))))))))))))))


### PR DESCRIPTION
## Summary

Introduce `result/with-ok` macro plus single-slot accessor fns
`result/snap` / `result/fx` / `result/info` in
`re-frame.machines.result`, then sweep 17 call sites across the engine
to use them.

- **Pair destructure** (13 sites) — the dominant `(if (fail? r) ...
  (let [{::result/keys [snap fx]} r] body))` pattern is now
  `(if (fail? r) ... (result/with-ok [snap fx] r body))`.
- **Single-slot reads** (4 sites) — `::result/info` / `::result/fx`
  reads become `(result/info r)` / `(result/fx r)`.
- **CLJS macro plumbing** — `:include-macros true` added to each
  consumer's `:require` of the result ns so CLJS sees the macro.

## Decision rationale

The bead (rf2-25zjk) listed three options. Picked **B** (macro) plus
single-field accessor fns, on the grounds that:

1. The macro captures the dominant fail-check-then-destructure pattern
   with intent-signaling sugar — `with-ok` reads "we expect ok here".
2. **Rejected `defrecord Result [tag snap fx info]`**: would let
   callers destructure `{:keys [snap fx]}` cleanly, BUT flips the
   public key shape from `::tag` / `::snap` / `::fx` / `::info` (the
   `:rf/*` namespaced scheme per `spec/Conventions.md`) to bare
   unqualified keys — every external destructure site (the publicly
   re-exported `re-frame.machines/machine-transition` surface; core's
   smoke/pattern_smoke/conformance test suites) would churn.
3. **Rejected tuple `unwrap-ok`** (bead option A): loses local names at
   the call site — doesn't fit sites that rebind `snap` to e.g.
   `snap-after`, `snap2`, `reg-snap`.
4. **Rejected status quo** (bead option C): 30+ repetitive sites.

## Test plan

- [x] `npm run test:cljs` — 1818 tests / 5056 assertions, 0 failures
- [x] `cd machines && clojure -M:test` — 124 tests / 359 assertions,
  0 failures (full conformance corpus included)

## Sites swept

- `implementation/machines/src/re_frame/machines/transition.cljc` —
  8 pair sites + 2 single-slot.
- `implementation/machines/src/re_frame/machines/parallel.cljc` —
  2 pair sites.
- `implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc` —
  3 pair sites + 2 single-slot.

Net LoC +5 across the three files (with-ok adds a wrapper level in
some cases; the macro itself is leaner per binding).