### PR TITLE
refactor(reagent-slim): delete dead ratom diagnostic plumbing (rf2-1g36x)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
@@ -55,10 +55,6 @@
 
 (declare ^:dynamic *ratom-context*)
 
-(defonce ^boolean debug false)
-(defonce ^:private generation 0)
-(defonce ^:private -running (clojure.core/atom 0))
-
 (defn ^boolean reactive?
   "True if invoked inside a reactive context — i.e. inside the body of a
   Reaction or another deref-capturing scope. Reads the dynamic
@@ -66,12 +62,6 @@
   deref will subscribe (reactive) vs just snapshot (non-reactive)."
   []
   (some? *ratom-context*))
-
-(defn running
-  "Diagnostic: count of currently-running reactions when `debug` is true.
-  Returns 0 unless `debug` was set before any Reactions were created."
-  []
-  (+ @-running))
 
 ;; ---------------------------------------------------------------------------
 ;; Internal helpers
@@ -104,8 +94,6 @@
   no-longer-watched ratoms. Clears the dirty? flag on r."
   [f ^clj r]
   (set! (.-captured r) nil)
-  (when ^boolean js/goog.DEBUG
-    (set! (.-ratomGeneration r) (set! generation (inc generation))))
   (let [res (in-context r f)
         c   (.-captured r)]
     (set! (.-dirty? r) false)
@@ -124,20 +112,13 @@
         (set! (.-captured r) (array derefed))
         (.push c derefed)))))
 
-(defn- check-watches [old new]
-  (when debug
-    (swap! -running + (- (count new) (count old))))
-  new)
-
 (defn- add-w [^clj this key f]
-  (let [w (.-watches this)]
-    (set! (.-watches this) (check-watches w (assoc w key f)))
-    (set! (.-watchesArr this) nil)))
+  (set! (.-watches this) (assoc (.-watches this) key f))
+  (set! (.-watchesArr this) nil))
 
 (defn- remove-w [^clj this key]
-  (let [w (.-watches this)]
-    (set! (.-watches this) (check-watches w (dissoc w key)))
-    (set! (.-watchesArr this) nil)))
+  (set! (.-watches this) (dissoc (.-watches this) key))
+  (set! (.-watchesArr this) nil))
 
 (defn- notify-w [^clj this old new]
   (let [w   (.-watchesArr this)


### PR DESCRIPTION
## Summary

Per audit rf2-bgnin (CQ-2), removes six dead-code loci in
`implementation/adapters/reagent-slim/src/reagent2/ratom.cljs` inherited
from stock Reagent but never used by the slim adapter or anything that
consumes it (zero call sites repo-wide; grep-verified across `tools/`,
`examples/`, `skills/`, the UIx + Helix adapters, and tests):

- `defonce ^boolean debug false` (never reassigned)
- `defonce ^:private generation 0` (written in `deref-capture`, never read)
- `defonce ^:private -running (atom 0)` (only swapped under the
  always-false `debug`)
- `(defn running ...)` (public, zero call sites)
- `(defn- check-watches ...)` (only effect was the dead `-running` swap;
  inlined as direct `assoc`/`dissoc` at the two call sites in `add-w` /
  `remove-w`)
- `(set! (.-ratomGeneration r) ...)` in `deref-capture` (written, never read)

Aligns with IMPL-SPEC §2.3: ship only the surfaces audited codebases
exercise.

Net diff: -19 LoC (4 insertions, 23 deletions), one file.

## Test plan

- [x] `cd implementation && npm run test:cljs` — 1818 tests, 5056 assertions, 0 failures (includes `reagent2.ratom-cljs-test`, `reagent2.dom.client-cljs-test`, `reagent2.impl.batching-cljs-test`, `reagent2.impl.component-cljs-test`).
- [x] `cd implementation/adapters/reagent-slim && clojure -M:test` — 11 tests, 12 assertions, 0 failures.
- [x] Grep-verified zero external references to `running`, `debug`, `-running`, `generation`, `ratomGeneration`, `check-watches` after the change.