### PR TITLE
refactor(schemas): collapse double-deref of validator-fn in hot path (rf2-1o6ax)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -151,11 +151,16 @@
   `(if interop/debug-enabled? ...)` gate of its public wrapper.
   Closure's reachability proof under :advanced + goog.DEBUG=false
   finds every call-site dead and DCEs this fn — along with every
-  literal reason string and tag keyword passed through it."
+  literal reason string and tag keyword passed through it.
+
+  Per rf2-1o6ax the registered validator-fn is deref'd ONCE at the
+  gate and invoked directly — `validator/run-validator` would deref
+  the same atom a second time on every pass, which is wasted work
+  on a path that runs per-event / per-cofx / per-fx / per-sub-return."
   [meta value sensitive?-fn build-base-tags extra-redact]
-  (if @validator/validator-fn
+  (if-let [vf @validator/validator-fn]
     (if-let [schema (:spec meta)]
-      (if (validator/run-validator schema value)
+      (if (vf schema value)
         true
         (let [explanation (validator/run-explainer schema value)
               sensitive?  (sensitive?-fn meta schema)
@@ -203,12 +208,17 @@
    ;; keyword, validator deref, and trace call. The `@validator-fn`
    ;; check is a runtime atom deref and must NOT be combined into the
    ;; gate predicate (the deref defeats Closure's reachability proof).
+   ;;
+   ;; Per rf2-1o6ax the validator-fn is deref'd ONCE outside the doseq
+   ;; and invoked directly per entry; `validator/run-validator` would
+   ;; re-deref the atom on every iteration (2N derefs for N entries),
+   ;; which is wasted work on the post-handler-commit hot path.
    (when interop/debug-enabled?
-     (when @validator/validator-fn
+     (when-let [vf @validator/validator-fn]
        (doseq [[path m] (storage/frame-schema-entries frame-id)]
          (let [val-at (get-in db path)
                schema (:schema m)]
-           (when-not (validator/run-validator schema val-at)
+           (when-not (vf schema val-at)
              ;; Per Spec 010 §`:sensitive?` — privacy in schema-
              ;; validation error traces (rf2-kj51z). Consult the
              ;; schema's per-slot `:sensitive?` props before


### PR DESCRIPTION
## Summary

- Bind `@validator/validator-fn` ONCE at the gate via `if-let` / `when-let` in `run-validation` and `validate-app-db!`, then invoke the bound fn directly. Previously the outer guard deref + `validator/run-validator`s inner deref were two derefs per pass — and in `validate-app-db!`s `doseq` over N registered app-schemas, 1 + N derefs per committed handler.
- `validator/run-validator` keeps its public shape; the boundary-validation seam (`validate-with-registered-fn`) still routes through it (single, necessary deref).
- No API change. Single-deref-and-bind reads locally and the contract no longer recurses into the atom.

## Numbers

- N registered app-schemas in a frame: `validate-app-db!` was `1 + N` derefs per committed handler → now `1` deref total at the gate (eliminates N).
- Per event / cofx / fx / sub-return validation: was 2 derefs → now 1 deref (eliminates 1 per pass).
- LoC delta: +15 / -5 (most of the diff is docstring + inline comment explaining the rf2-1o6ax invariant).

## Test plan

- [x] `cd implementation/schemas && clojure -M:test` — 133 tests / 383 assertions, 0 failures.
- [x] `cd implementation && npm run test:cljs` — 1818 tests / 5056 assertions, 0 failures.
- [x] `cd implementation && npm run test:elision` — full production-elision probe PASSES.