### PR TITLE
fix(http): case-insensitive Content-Type lookup (rf2-6hbo8)

### DIFF
--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -98,6 +98,33 @@
 
 ;; ---- decode pipeline ------------------------------------------------------
 
+(defn content-type-of
+  "Per Spec 014 §Request envelope — HTTP header names are case-insensitive.
+  Scan `headers` for a `content-type` key in any casing, returning the
+  value (or nil). Tolerates keyword keys (rare, but used by some
+  middlewares); ignores non-string non-keyword keys.
+
+  Used by `decode-response-body` (response-side sniffing) and by the
+  transport's request-side clash check. The JVM transport additionally
+  normalises response headers to lower-case at the boundary
+  (`jvm-headers->map`) to match the CLJS Fetch path — this helper is the
+  belt to that braces: even a hand-constructed headers map with mixed
+  casing (e.g. an interceptor `:before` that synthesises headers) is
+  resolved correctly."
+  [headers]
+  (when (map? headers)
+    (reduce-kv
+      (fn [_ k v]
+        (let [k-str (cond
+                      (string? k)  k
+                      (keyword? k) (name k)
+                      :else        nil)]
+          (if (and k-str (= "content-type" (str/lower-case k-str)))
+            (reduced v)
+            nil)))
+      nil
+      headers)))
+
 (defn- sniff-decoder
   "Per Spec 014 §`:auto`: sniff the response Content-Type header."
   [content-type]
@@ -161,8 +188,7 @@
   "Per Spec 014 §Decoding. Returns the decoded value or throws an
   ex-info that the caller maps to `:rf.http/decode-failure`."
   [{:keys [body-text headers decode decode-supplied? request-id url sensitive?]}]
-  (let [content-type (or (get headers "content-type")
-                         (get headers "Content-Type"))
+  (let [content-type (content-type-of headers)
         decoder      (cond
                        (nil? decode)        :auto
                        (= :auto decode)     :auto

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -147,11 +147,20 @@
 
 #?(:clj
    (defn- jvm-headers->map
-     "Flatten Java HttpHeaders into a plain Clojure map of string->string."
+     "Flatten Java HttpHeaders into a plain Clojure map of string->string.
+
+     Header names are lower-cased at the boundary, matching the CLJS
+     Fetch path (`fetch-headers->map` consumes Fetch's `Headers` object,
+     which iterates with normalised lower-case names). Per Spec 014
+     §Request envelope, HTTP header names are case-insensitive — fixing
+     casing at the transport boundary keeps every downstream consumer
+     (decode sniffer, failure-map headers ridden by `:on-failure` reply
+     payloads, privacy redactor) on a single canonical shape across
+     hosts."
      [^java.net.http.HttpHeaders hh]
      (into {}
            (for [[k vs] (.map hh)]
-             [k (str/join "," vs)]))))
+             [(str/lower-case k) (str/join "," vs)]))))
 
 #?(:clj
    (defn- jvm-fetch
@@ -416,8 +425,7 @@
         [enc-body ct] (encoding/encode-body (encoding/realise-body (:body request))
                                             (:request-content-type request))
         headers  (cond-> (or (:headers request) {})
-                   (and ct (not (get (or (:headers request) {}) "content-type"))
-                        (not (get (or (:headers request) {}) "Content-Type")))
+                   (and ct (nil? (encoding/content-type-of (:headers request))))
                    (assoc "Content-Type" ct))
         ctx-no-handle (assoc ctx :url url)
         ;; CLJS: an internal AbortController backs the Fetch signal when

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -14,6 +14,7 @@
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.registrar :as registrar]
+            [re-frame.http-encoding :as http-encoding]
             [re-frame.http-managed :as http-managed]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.trace :as trace])
@@ -254,6 +255,75 @@
           (is (= :rf.http/decode-failure (:kind failure))
               "decode runs on 2xx; a thrown decoder surfaces as :rf.http/decode-failure"))
         (finally (stop-server! srv))))))
+
+;; ---- 5d. Content-Type lookup is case-insensitive (rf2-6hbo8) -------------
+;;
+;; Per Spec 014 §Request envelope, HTTP header names are case-insensitive.
+;; The old `decode-response-body` only checked the two literal spellings
+;; "content-type" and "Content-Type"; any other casing (e.g.
+;; "CONTENT-TYPE", "Content-type") returned nil and `sniff-decoder` fell
+;; through to :blob — JSON arriving as raw text.
+;;
+;; The CLJS Fetch path normalises (lower-case in `fetch-headers->map`) so
+;; the bug only manifested when a hand-constructed headers map reached
+;; `decode-response-body`. The fix is two-layered: the JVM transport
+;; (`jvm-headers->map`) lower-cases at the boundary so the JVM path matches
+;; the Fetch path, AND `http-encoding/content-type-of` performs a
+;; case-insensitive scan so any future code path that synthesises a
+;; headers map (interceptors, middleware, tests) decodes correctly.
+;;
+;; These unit tests exercise the helper and `decode-response-body`
+;; directly with mixed-case headers — they fail deterministically against
+;; the pre-fix code regardless of transport. (A full JVM transport e2e
+;; test would pass vacuously because `java.net.http.HttpHeaders.map()`
+;; already returns lower-case keys.)
+
+(deftest content-type-of-case-insensitive
+  (testing "lowercase key"
+    (is (= "application/json"
+           (http-encoding/content-type-of {"content-type" "application/json"}))))
+  (testing "canonical Title-Case key"
+    (is (= "application/json"
+           (http-encoding/content-type-of {"Content-Type" "application/json"}))))
+  (testing "all-caps key (the original bug — CONTENT-TYPE)"
+    (is (= "application/json"
+           (http-encoding/content-type-of {"CONTENT-TYPE" "application/json"}))))
+  (testing "mixed casing"
+    (is (= "application/json"
+           (http-encoding/content-type-of {"Content-type" "application/json"})))
+    (is (= "text/plain"
+           (http-encoding/content-type-of {"cOnTeNt-TyPe" "text/plain"}))))
+  (testing "keyword key (some middlewares use keywords)"
+    (is (= "application/json"
+           (http-encoding/content-type-of {:content-type "application/json"})))
+    (is (= "application/json"
+           (http-encoding/content-type-of {:Content-Type "application/json"}))))
+  (testing "absent / unrelated headers"
+    (is (nil? (http-encoding/content-type-of {})))
+    (is (nil? (http-encoding/content-type-of {"X-Foo" "bar"})))
+    (is (nil? (http-encoding/content-type-of nil)))
+    (is (nil? (http-encoding/content-type-of "not-a-map")))))
+
+(deftest decode-response-body-resolves-content-type-case-insensitively
+  (testing "JSON decode under :auto fires when Content-Type has non-canonical casing"
+    ;; This is the original bug: the response headers carry "CONTENT-TYPE"
+    ;; (or any non-canonical casing); the pre-fix code's two-spelling `get`
+    ;; returned nil; `sniff-decoder` fell through to :blob; the caller
+    ;; received the raw body string. Post-fix, the helper resolves the
+    ;; header regardless of casing and JSON decodes correctly.
+    (doseq [ct-key ["CONTENT-TYPE" "Content-type" "content-type" "Content-Type" "cOnTeNt-TyPe"]]
+      (testing (str "casing: " ct-key)
+        (let [decoded (http-encoding/decode-response-body
+                        {:body-text        "{\"ok\":true}"
+                         :headers          {ct-key "application/json"}
+                         :decode           :auto
+                         :decode-supplied? false
+                         :request-id       :test/req
+                         :url              "/test"
+                         :sensitive?       false})]
+          (is (= {:ok true} decoded)
+              (str "non-canonical Content-Type casing " (pr-str ct-key)
+                   " must sniff to :json, not :blob")))))))
 
 ;; ---- 6. retry exhaustion --------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Per Spec 014 §Request envelope, HTTP header names are case-insensitive. The pre-fix code in `http_encoding.cljc` and `http_transport.cljc` checked only two literal spellings (`"content-type"`, `"Content-Type"`); any other casing (e.g. `"CONTENT-TYPE"`, `"Content-type"`) returned nil and `sniff-decoder` fell through to `:blob` — JSON arriving as raw text.
- Two-layered fix: `http-encoding/content-type-of` performs a case-insensitive scan (used at both sites); `jvm-headers->map` lower-cases at the JVM transport boundary so the JVM path converges with the CLJS Fetch path (which Fetch's `Headers` already lower-cases).
- Both sites' bug fixed in a single commit.

## Why two layers

The boundary normalisation (`jvm-headers->map`) catches the actual JVM transport path and brings JVM into shape-parity with CLJS — downstream consumers (failure-map `:headers` on `:on-failure` payloads, privacy redactor, app code) see one canonical shape across hosts. The helper (`content-type-of`) catches the remaining surface: hand-constructed headers maps from interceptors, middleware, and tests; the request-side clash check on user-supplied headers; and any future alternative HTTP client transport that does not normalise.

(Note: the JDK's `java.net.http.HttpHeaders.map()` happens to return lower-case keys, so the in-tree JVM transport masked the response-side bug end-to-end. The helper-level tests fail deterministically against the pre-fix code.)

## Test plan

- [x] `cd implementation/http && clojure -M:test` — 136 tests, 385 assertions, 0 failures
- [x] `cd implementation && npm run test:cljs` — 1818 tests, 5056 assertions, 0 failures
- [x] New `content-type-of-case-insensitive` unit test (lower / canonical / all-caps / mixed / keyword / nil / non-map)
- [x] New `decode-response-body-resolves-content-type-case-insensitively` integrated test (five header casings)