### PR TITLE
refactor(causa): hoist private tag helper to panels.common-helpers (rf2-9btcl)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/common_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/common_helpers.cljc
@@ -7,3 +7,13 @@
   []
   #?(:clj  (System/currentTimeMillis)
      :cljs (.getTime (js/Date.))))
+
+(defn tag-of
+  "Pull a tag value off a trace event. Trace events nest per-event
+  metadata under `:tags`; the helper reads the slot defensively so
+  test fixtures that supply a flat shape (no `:tags`) also work.
+  Canonical tag-reader shared across every panel-helper that walks
+  the Causa trace buffer."
+  [ev k]
+  (or (get-in ev [:tags k])
+      (get ev k)))

--- a/tools/causa/src/day8/re_frame2_causa/panels/effects_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/effects_helpers.cljc
@@ -43,7 +43,8 @@
   fn runs under CLJ and CLJS. The CLJS-only surfaces (`rf/handlers`
   on a populated registrar) are read by the composite sub in
   `registry.cljs`; the result is handed to this ns as a plain map."
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [day8.re-frame2-causa.panels.common-helpers :as common]))
 
 ;; ---- design tokens (mirrors view tokens — kept here for tests) ----------
 ;;
@@ -112,13 +113,10 @@
   [events]
   (filterv fx-trace-event? (or events [])))
 
-(defn- tag
-  "Pull a tag value off a trace event. Trace events nest per-event
-  metadata under `:tags`; the helper reads the slot defensively so
-  test fixtures that supply a flat shape (no `:tags`) also work."
-  [ev k]
-  (or (get-in ev [:tags k])
-      (get ev k)))
+;; Re-export `tag-of` under the local name `tag` so existing call sites
+;; (`(tag ev :fx-id)`, etc.) keep working without churn. Body lives in
+;; `common-helpers`.
+(def ^:private tag common/tag-of)
 
 (defn- event-fx-id
   "The fx-id this event refers to. `:rf.fx/handled` and friends carry

--- a/tools/causa/src/day8/re_frame2_causa/panels/flows_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/flows_helpers.cljc
@@ -48,7 +48,8 @@
   fn runs under CLJ and CLJS. The CLJS-only surfaces (`rf/handlers`
   on a populated registrar) are read by the composite sub in
   `registry.cljs`; the result is handed to this ns as a plain map."
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [day8.re-frame2-causa.panels.common-helpers :as common]))
 
 ;; ---- design tokens (mirrors view tokens — kept here for tests) ----------
 ;;
@@ -103,13 +104,10 @@
   [events]
   (filterv flow-trace-event? (or events [])))
 
-(defn- tag
-  "Pull a tag value off a trace event. Trace events nest per-event
-  metadata under `:tags`; the helper reads the slot defensively so
-  test fixtures that supply a flat shape (no `:tags`) also work."
-  [ev k]
-  (or (get-in ev [:tags k])
-      (get ev k)))
+;; Re-export `tag-of` under the local name `tag` so existing call sites
+;; (`(tag ev :flow-id)`, etc.) keep working without churn. Body lives in
+;; `common-helpers`.
+(def ^:private tag common/tag-of)
 
 (defn- event-flow-id [ev] (tag ev :flow-id))
 (defn- event-dispatch-id [ev] (tag ev :dispatch-id))

--- a/tools/causa/src/day8/re_frame2_causa/panels/routes_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routes_helpers.cljc
@@ -71,7 +71,8 @@
   on a populated registrar, `rf/get-frame-db` on a frame) are read by
   the composite sub in `registry.cljs`; the result is handed to this
   ns as a plain map."
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [day8.re-frame2-causa.panels.common-helpers :as common]))
 
 ;; ---- canonical operation taxonomy ---------------------------------------
 
@@ -100,13 +101,10 @@
 
 ;; ---- defensive tag access -----------------------------------------------
 
-(defn- tag
-  "Pull a tag value off a trace event. Trace events nest per-event
-  metadata under `:tags`; the helper reads the slot defensively so
-  test fixtures that supply a flat shape (no `:tags`) also work."
-  [ev k]
-  (or (get-in ev [:tags k])
-      (get ev k)))
+;; Re-export `tag-of` under the local name `tag` so existing call sites
+;; (`(tag ev :route-id)`, etc.) keep working without churn. Body lives in
+;; `common-helpers`.
+(def ^:private tag common/tag-of)
 
 ;; ---- registered-route projection ----------------------------------------
 


### PR DESCRIPTION
## Summary

Three panel-helper namespaces (`effects_helpers`, `flows_helpers`, `routes_helpers`) each defined the same private defensive trace-event tag-reader:

```clj
(defn- tag [ev k] (or (get-in ev [:tags k]) (get ev k)))
```

Hoist the canonical version to `panels.common-helpers/tag-of` (public) alongside `now-ms` (rf2-jigkg) and re-export under the local name `tag` in each consumer via `(def ^:private tag common/tag-of)` — same re-export pattern rf2-jigkg established for `now-ms`. Nine call sites across the three files keep working unchanged; the redundant copies are gone.

Out of scope: `hydration_debugger_helpers.cljc`'s `tag-of` is a hiccup-tag accessor `(when (hiccup-vector? node) (first node))` — completely different signature and semantics, left alone.

Sites swept: 3 (effects, flows, routes). LoC delta: +28 / -24.

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 488 tests / 1363 assertions, 0 failures
- [x] `cd implementation && npm run test:cljs` — 1816 tests / 5040 assertions, 0 failures