### PR TITLE
perf(core): indexed-vec walk in execute-chain (no seq reverse) (rf2-qjn86)

### DIFF
--- a/implementation/core/src/re_frame/interceptor.cljc
+++ b/implementation/core/src/re_frame/interceptor.cljc
@@ -163,8 +163,14 @@
   reads :rf/interceptor-error after the chain ends and emits
   :rf.error/handler-exception (or similar)."
   [interceptors initial-context]
-  (let [;; Apply :before stages in order (short-circuits on first error).
-        ctx-after-befores (reduce invoke-before initial-context interceptors)
-        ;; Apply :after stages in reverse order (always runs for teardown).
-        ctx-after-afters  (reduce invoke-after ctx-after-befores (reverse interceptors))]
-    ctx-after-afters))
+  ;; Apply :before stages in order (short-circuits on first error).
+  (let [ctx-after-befores (reduce invoke-before initial-context interceptors)]
+    ;; Apply :after stages in reverse order (always runs for teardown).
+    ;; Indexed-vec backward walk avoids the per-dispatch lazy-seq allocation
+    ;; `(reverse interceptors)` would produce. `interceptors` is the
+    ;; declaration-order vector built by the registration factories.
+    (loop [i   (dec (count interceptors))
+           ctx ctx-after-befores]
+      (if (neg? i)
+        ctx
+        (recur (dec i) (invoke-after ctx (nth interceptors i)))))))


### PR DESCRIPTION
## Summary

`execute-chain`'s `:after` pass walked `(reverse interceptors)` via `reduce`, allocating a fresh lazy-seq on every dispatch. `invoke-after` runs unconditionally (teardown contract — runs even when a `:before` short-circuited or an `:after` already threw), so this allocation was paid on every drain step, including failure paths.

Replaced with a backward indexed-vec loop. `interceptors` is always a vector (`run-chain` in `router.cljc` builds `full-chain` via `(vec (concat ...))`), so `(nth interceptors i)` is O(1) and the right-to-left walk produces the identical `invoke-after` invocation sequence against the same accumulating context — zero behavioural change.

## Why

Round-2 audit `rf2-byut1` §PE-R2.1 (round-1 IC1 leftover): one allocation per dispatch eliminated. Tiny per-call cost, but `execute-chain` is on the unconditional drain-loop hot path, so the saving compounds across event volume.

## Test plan

- [x] `clojure -M:test -n re-frame.interceptor-test` (8 tests, 42 assertions, 0 failures) — existing `chain-composition` and `make-interceptor-via-primitive` deftests pin `:after`-in-reverse order across the happy path, single-`:after`-throws, multi-error preservation, and `:before`-short-circuit-with-teardown cases. Reverse-order invariant is already covered; no new test needed.
- [x] `npm run test:cljs` (1816 tests, 5040 assertions, 0 failures).
- [x] `npm run test:perf-bundle` PASS. Bundle delta: +49 chars perf-off, +49 chars perf-on (loop form serialises slightly larger than `reduce`; well within budget).

Originating audit: `rf2-byut1` §PE-R2.1 (round-1 IC1 leftover).