### PR TITLE
refactor(machines): introduce frame/swap-frame-db! to collapse read/write call sites (rf2-0sypt)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -148,6 +148,24 @@
   (when-let [container (get-frame-db id)]
     (adapter/read-container container)))
 
+(defn swap-frame-db!
+  "Mutate the frame's app-db: read the current value, compute
+  `(apply f db args)`, and replace the container with the result. Returns
+  the new-db, or nil if the frame is not registered.
+
+  Models `swap!` over the substrate-managed reactive container. Under the
+  single-drainer invariant (Spec 002 §Single drainer per frame) the
+  read-then-replace is effectively atomic — `replace-container!` is the
+  only writer during fx drain. The helper is the canonical \"mutate the
+  frame's app-db\" surface; the read-container / replace-container dance
+  belongs here, not at every fx-handler call site."
+  [id f & args]
+  (when-let [container (get-frame-db id)]
+    (let [old-db (adapter/read-container container)
+          new-db (apply f old-db args)]
+      (adapter/replace-container! container new-db)
+      new-db)))
+
 ;; ---- frame presets (Spec 002 §Frame presets) ------------------------------
 ;;
 ;; A :preset key in metadata expands at registration time into a fixed

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx.cljc
@@ -33,8 +33,7 @@
             [re-frame.machines.lifecycle-fx.destroy :as destroy]
             [re-frame.machines.lifecycle-fx.registration :as registration]
             [re-frame.machines.lifecycle-fx.spawn :as spawn]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.adapter :as adapter]))
+            [re-frame.registrar :as registrar]))
 
 ;; ---- public-surface re-exports --------------------------------------------
 
@@ -83,8 +82,7 @@
   ([system-id]
    (machine-by-system-id system-id (frame/current-frame)))
   ([system-id frame-id]
-   (when-let [container (frame/get-frame-db frame-id)]
-     (get-in (adapter/read-container container) [:rf/system-ids system-id]))))
+   (get-in (frame/frame-app-db-value frame-id) [:rf/system-ids system-id])))
 
 ;; Framework-shipped subscriptions (`:rf/machine`, `:rf/machine-has-tag?`)
 ;; are registered in the public-façade `re-frame.machines` namespace so

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -30,7 +30,6 @@
             [re-frame.machines.lifecycle-fx.finalize :as finalize]
             [re-frame.machines.lifecycle-fx.teardown :as teardown]
             [re-frame.registrar :as registrar]
-            [re-frame.substrate.adapter :as adapter]
             [re-frame.trace :as trace]))
 
 (defn- emit-system-id-released!
@@ -56,14 +55,19 @@
   [frame-id actor-id]
   (when actor-id
     (finalize/abort-actor-in-flight-http! actor-id)
-    (when-let [container (frame/get-frame-db frame-id)]
-      (let [old-db (adapter/read-container container)
-            [new-db released-sid] (teardown/teardown-actor
-                                    old-db {:actor-id actor-id})]
-        (adapter/replace-container! container new-db)
-        (emit-system-id-released! frame-id released-sid actor-id)
+    ;; `teardown-actor` returns [new-db released-sid]; `swap-frame-db!`
+    ;; expects a fn returning the new-db only. Capture sid via a side
+    ;; channel so we keep a single read + single write.
+    (let [sid (volatile! nil)]
+      (when (frame/swap-frame-db! frame-id
+                                  (fn [db]
+                                    (let [[new-db released-sid]
+                                          (teardown/teardown-actor db {:actor-id actor-id})]
+                                      (vreset! sid released-sid)
+                                      new-db)))
+        (emit-system-id-released! frame-id @sid actor-id)
         (registrar/unregister! :event actor-id)
-        released-sid))))
+        @sid))))
 
 (defn- destroy-invoke-all-children!
   "Per rf2-6vmw — the declarative-`:invoke-all` exit-cascade form.
@@ -72,9 +76,8 @@
   join-state slot via the unified teardown projection (slot-prune only:
   nil actor-id)."
   [frame-id parent-id invoke-id]
-  (let [join-state (when-let [container (frame/get-frame-db frame-id)]
-                     (get-in (adapter/read-container container)
-                             [:rf/spawned parent-id invoke-id]))
+  (let [join-state (get-in (frame/frame-app-db-value frame-id)
+                           [:rf/spawned parent-id invoke-id])
         children   (when (map? join-state) (:children join-state))]
     (doseq [[child-id spawned-id] children]
       (trace/emit! :machine :rf.machine/destroyed
@@ -86,12 +89,11 @@
                     :reason     :explicit})        ;; rf2-gn80 D6 — discriminator
       (destroy-single-actor! frame-id spawned-id))
     ;; Clear the join-state slot via the unified projection (slot-only).
-    (when-let [container (frame/get-frame-db frame-id)]
-      (let [old-db (adapter/read-container container)
-            [new-db _] (teardown/teardown-actor
-                         old-db {:parent-id parent-id
-                                 :invoke-id invoke-id})]
-        (adapter/replace-container! container new-db)))
+    (frame/swap-frame-db! frame-id
+                          (fn [db]
+                            (first (teardown/teardown-actor
+                                     db {:parent-id parent-id
+                                         :invoke-id invoke-id}))))
     nil))
 
 (defn- destroy-single!
@@ -104,8 +106,7 @@
   (let [tracked?  (map? args)
         parent-id (when tracked? (:rf/parent-id args))
         invoke-id (when tracked? (:rf/invoke-id args))
-        container (frame/get-frame-db frame-id)
-        old-db    (when container (adapter/read-container container))
+        old-db    (frame/frame-app-db-value frame-id)
         actor-id  (if tracked?
                     (when old-db (get-in old-db [:rf/spawned parent-id invoke-id]))
                     args)
@@ -122,12 +123,12 @@
     ;; destroy) or the spawn was suppressed (SSR / platform gating).
     (when actor-id
       (finalize/abort-actor-in-flight-http! actor-id)
-      (when container
-        (let [[new-db _] (teardown/teardown-actor
-                           old-db {:actor-id  actor-id
-                                   :parent-id parent-id
-                                   :invoke-id invoke-id})]
-          (adapter/replace-container! container new-db)))
+      (frame/swap-frame-db! frame-id
+                            (fn [db]
+                              (first (teardown/teardown-actor
+                                       db {:actor-id  actor-id
+                                           :parent-id parent-id
+                                           :invoke-id invoke-id}))))
       (emit-system-id-released! frame-id released-sid actor-id)
       ;; Unregister the live handler. Last so any in-flight trace emit
       ;; against the actor still resolves before the slot disappears.

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -25,7 +25,6 @@
             [re-frame.machines.parallel :as parallel]
             [re-frame.machines.transition :as transition]
             [re-frame.registrar :as registrar]
-            [re-frame.substrate.adapter :as adapter]
             [re-frame.trace :as trace]))
 
 ;; ---- id allocation --------------------------------------------------------
@@ -117,15 +116,17 @@
   "Atomically install the spawned actor's initial snapshot, system-id
   binding, and runtime-owned spawn registry slot into the frame's
   app-db. Returns nil — the side-effect IS the value. Emits the
-  collision and system-id-bound traces when applicable."
-  [container frame-id db-after-alloc spec spawned-id
+  collision and system-id-bound traces when applicable.
+
+  `db-after-alloc` is the post-id-allocation db computed by the caller
+  (see `spawn-fx`); `swap-frame-db!`'s fn arg is discarded — the merge
+  is applied on top of `db-after-alloc` so the caller's counter bump
+  survives. Under Spec 002's single-drainer invariant the discarded
+  re-read is value-equal to the snapshot the caller already had."
+  [frame-id db-after-alloc spec spawned-id
    {:keys [system-id parent-id invoke-id track?]}]
   (let [initial-snap (when spec (compute-initial-snapshot spec))
-        existing     (when system-id (get-in db-after-alloc [:rf/system-ids system-id]))
-        new-db       (cond-> db-after-alloc
-                       spec      (assoc-in [:rf/machines spawned-id] initial-snap)
-                       system-id (assoc-in [:rf/system-ids system-id] spawned-id)
-                       track?    (assoc-in [:rf/spawned parent-id invoke-id] spawned-id))]
+        existing     (when system-id (get-in db-after-alloc [:rf/system-ids system-id]))]
     (when (and system-id existing (not= existing spawned-id))
       (trace/emit-error! :rf.error/system-id-collision
                          {:frame             frame-id
@@ -138,7 +139,12 @@
                                                   "; rebinding to " spawned-id
                                                   " (last-write-wins).")
                           :recovery          :warned-and-replaced}))
-    (adapter/replace-container! container new-db)
+    (frame/swap-frame-db! frame-id
+                          (fn [_db]
+                            (cond-> db-after-alloc
+                              spec      (assoc-in [:rf/machines spawned-id] initial-snap)
+                              system-id (assoc-in [:rf/system-ids system-id] spawned-id)
+                              track?    (assoc-in [:rf/spawned parent-id invoke-id] spawned-id))))
     (when system-id
       (trace/emit! :machine :rf.machine/system-id-bound
                    {:frame      frame-id
@@ -202,10 +208,9 @@
         ;; same id the snapshot install / registry bind will use. The
         ;; db-swap re-applies the increment to the (potentially-newer)
         ;; db at write time — for the JVM atom container the read is
-        ;; consistent because adapter/replace-container! is the only
-        ;; writer during fx drain.
-        container  (frame/get-frame-db frame-id)
-        old-db     (when container (adapter/read-container container))
+        ;; consistent because `frame/swap-frame-db!` is the only writer
+        ;; during fx drain (Spec 002 §Single drainer per frame).
+        old-db     (frame/frame-app-db-value frame-id)
         machine-id-for-alloc (or (:id-prefix args) (:machine-id args))
         [db-after-alloc spawned-id]
         (cond
@@ -232,8 +237,8 @@
     ;; from the frame's app-db (the hand-emitted-spawn fallback path),
     ;; `db-after-alloc` already carries the bumped counter — install the
     ;; snapshot on top of that.
-    (when container
-      (install-spawn! container frame-id db-after-alloc spec'' spawned-id
+    (when old-db
+      (install-spawn! frame-id db-after-alloc spec'' spawned-id
                       {:system-id system-id
                        :parent-id parent-id
                        :invoke-id invoke-id
@@ -273,10 +278,8 @@
         invoke-id  (:rf/invoke-id args)
         join-state (:join-state args)
         children   (:children join-state)]
-    (when-let [container (frame/get-frame-db frame-id)]
-      (let [old-db (adapter/read-container container)
-            new-db (assoc-in old-db [:rf/spawned parent-id invoke-id] join-state)]
-        (adapter/replace-container! container new-db)))
+    (frame/swap-frame-db! frame-id assoc-in
+                          [:rf/spawned parent-id invoke-id] join-state)
     (trace/emit! :machine :rf.machine.invoke-all/started
                  {:machine-id parent-id
                   :invoke-id  invoke-id

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -35,7 +35,6 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.machines.transition :as transition]
             [re-frame.subs :as subs]
-            [re-frame.substrate.adapter :as adapter]
             [re-frame.trace :as trace]))
 
 (defonce after-timers
@@ -174,9 +173,8 @@
                     :reason     :sub-changed
                     :sub-id     (first delay-key)})
       (cancel-after-timer-entry! frame-id k)
-      (when-let [container (frame/get-frame-db frame-id)]
-        (let [db   (adapter/read-container container)
-              snap (get-in db [:rf/machines parent-id])
+      (when-let [db (frame/frame-app-db-value frame-id)]
+        (let [snap (get-in db [:rf/machines parent-id])
               ;; Per Spec 005 §Per-region :after scoping (rf2-l67o): for
               ;; parallel-region machines the snapshot's :state is a map
               ;; of region-name → that region's state, and the invoke-id
@@ -297,9 +295,8 @@
         delay-key  (:delay-key args)
         epoch      (:epoch args)
         server?    (boolean (:server? args))
-        snapshot   (when-let [container (frame/get-frame-db frame-id)]
-                     (get-in (adapter/read-container container)
-                             [:rf/machines parent-id]))]
+        snapshot   (get-in (frame/frame-app-db-value frame-id)
+                           [:rf/machines parent-id])]
     ;; Initial state-entry scheduling — the :scheduled trace was already
     ;; emitted synchronously by apply-transition-once (the pure side). For
     ;; sub-vec delays, the fx layer's resolution may yield a different


### PR DESCRIPTION
## Summary

Closes rf2-0sypt (P0, from the round-2 machines audit).

The read-container / replace-container dance appeared 5 times across machines fx handlers (`lifecycle_fx/{destroy,spawn}.cljc`) plus 4 read-only sites (`lifecycle_fx.cljc`, `destroy.cljc`, `timer.cljc` x2). Each spelled as:

```clj
(when-let [container (frame/get-frame-db frame-id)]
  (let [old-db (adapter/read-container container)
        new-db (... transform ...)]
    (adapter/replace-container! container new-db)))
```

Adds `re-frame.frame/swap-frame-db!` modelled on `swap!` over the substrate-managed reactive container; pairs with the existing `frame/frame-app-db-value` (read). Under Spec 002's single-drainer invariant the read-then-replace is effectively atomic. The helper is the canonical "mutate the frame's app-db" surface; the adapter dance belongs here, not at every fx-handler call site.

## Sites swept

**5 write sites** to `frame/swap-frame-db!`:
- `destroy.cljc` :: `destroy-single-actor!`
- `destroy.cljc` :: `destroy-invoke-all-children!` slot clear
- `destroy.cljc` :: `destroy-single!`
- `spawn.cljc`   :: `install-spawn!`
- `spawn.cljc`   :: `invoke-all-init-fx`

**4 read sites** to `frame/frame-app-db-value`:
- `lifecycle_fx.cljc` :: `machine-by-system-id`
- `destroy.cljc`      :: `destroy-invoke-all-children!` join-state read
- `timer.cljc`        :: `on-sub-changed!` snapshot read
- `timer.cljc`        :: `after-schedule-fx` snapshot read

`adapter` require drops out of `destroy.cljc`, `spawn.cljc`, `timer.cljc`, `lifecycle_fx.cljc` — none reach through it any more.

### Notes

- `destroy-single-actor!` uses a volatile side channel to carry the `released-sid` out of the swap fn (`teardown-actor` returns `[new-db sid]` but `swap-frame-db!` expects a fn returning new-db only). This preserves the original single-read + single-write shape.
- `install-spawn!` passes a closure that discards its fresh-db arg and writes the caller's pre-computed `db-after-alloc` instead — preserving the exact existing behaviour where the pre-read drives the counter-bump merge.

## Test plan

- [x] `cd implementation/machines && clojure -M:test` — 359 assertions, 0 failures
- [x] `cd implementation/core && clojure -M:test` — 2439 assertions, 0 failures (helper exercised through machines integration)
- [x] `cd implementation && npm run test:cljs` — 5040 assertions, 0 failures