### PR TITLE
refactor(causa-mcp): Lock #9 Date-amended header re Lock #10 mechanism promotion (rf2-typcn)

### DIFF
--- a/tools/causa-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/causa-mcp/spec/DESIGN-RATIONALE.md
@@ -695,6 +695,16 @@ typical-token hint, its cap-reached behaviour, and its default
 forestall the same drift pair2-mcp is paying down. Pre-dates
 `tools/causa-mcp/src/` by design.
 
+### Date amended
+
+2026-05-13 (Mike). Same-day [Lock #10](#lock-10--size-elision-marker-shape-is-normative-across-mcp-servers)
+(rf2-knshj) promoted `:rf.size/large-elided` to mechanism #6 in
+[`004-Wire-Pipeline.md`](./004-Wire-Pipeline.md). The
+five-mechanism framing in §Pick and §Why bullets is historical
+(the lock as first written). The current normative count is six;
+see Lock #10 for the sixth mechanism and the summary table at
+line 1163.
+
 ### Trail-of-thought citations
 
 - pair2-mcp


### PR DESCRIPTION
## Summary

- Lock #9 in `tools/causa-mcp/spec/DESIGN-RATIONALE.md` headlines "Five normative mechanisms" and its §Pick / §Why bullets enumerate five — but same-day Lock #10 (rf2-knshj, 2026-05-13) promoted `:rf.size/large-elided` to mechanism #6 in `004-Wire-Pipeline.md`. The summary table at line 1163 already reads "Six mechanisms ... mechanism #6 added by Lock #10"; Lock #9's body wasn't amended.
- Adds a `### Date amended` subsection right after the existing `### Date locked`, matching Lock #5's precedent (which grew the same header when Lock #12 took the catalogue 17→18).
- §Pick and §Why bullets left intact as historical lock text — the amendment header is the lighter touch and preserves "the lock as first written".

Closes rf2-typcn.

## Test plan

- [x] `python scripts/check_doc_slugs.py` clean (the 3 broken anchors reported are pre-existing baseline on `origin/main`, unrelated to this edit).
- [x] Cold-read: Lock #9 now signals to readers that the five-mechanism framing is historical and points at Lock #10 + line 1163 for the current count.