### PR TITLE
refactor(schemas): delete five dead late-bind hooks (rf2-5q7r0)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -148,31 +148,11 @@
    {:key         :schemas/extract-large-paths-from-schema
     :producer-ns 're-frame.schemas
     :design-bead "rf2-nwv63"
-    :description "Walk a Malli EDN form at a base-path; return {path declaration} entries for :large? true slots."}
-   {:key         :schemas/frame-elision-declarations
-    :producer-ns 're-frame.schemas
-    :design-bead "rf2-nwv63"
-    :description "Merged {path declaration} for every :large? slot in every app-schema registered against a frame."}
-   {:key         :schemas/populate-elision-declarations
-    :producer-ns 're-frame.schemas
-    :design-bead "rf2-nwv63"
-    :description "Idempotent: hydrate app-db [:rf/elision :declarations] from a frame's schema-derived large-path declarations."}
+    :description "Walk a Malli EDN form at a base-path; return {path declaration} entries for :large? true slots. Consumed by re-frame.elision per rf2-ynnq0 Option A (rf2-w3n5u impl)."}
    {:key         :schemas/extract-sensitive-paths-from-schema
     :producer-ns 're-frame.schemas
     :design-bead "rf2-kj51z"
-    :description "Walk a Malli EDN form at a base-path; return paths whose props carry :sensitive? true."}
-   {:key         :schemas/schema-has-sensitive?
-    :producer-ns 're-frame.schemas
-    :design-bead "rf2-kj51z"
-    :description "Predicate: does any sub-slot of the schema declare :sensitive? true?"}
-   {:key         :schemas/frame-sensitive-declarations
-    :producer-ns 're-frame.schemas
-    :design-bead "rf2-c1l4d"
-    :description "Merged {path declaration} for every :sensitive? slot in every app-schema registered against a frame."}
-   {:key         :schemas/populate-sensitive-declarations
-    :producer-ns 're-frame.schemas
-    :design-bead "rf2-c1l4d"
-    :description "Idempotent: hydrate app-db [:rf/elision :sensitive-declarations] from a frame's schema-derived sensitive-path declarations."}
+    :description "Walk a Malli EDN form at a base-path; return paths whose props carry :sensitive? true. Consumed by re-frame.elision per rf2-ynnq0 Option A (rf2-w3n5u impl)."}
 
    ;; ---- re-frame.machines (rf2-xbtj / rf2-8bp3) ------------------------------
    {:key         :machines/reg-machine

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -159,19 +159,20 @@
 (late-bind/set-fn! :schemas/set-schema-explainer! set-schema-explainer!)
 (late-bind/set-fn! :schemas/set-schema-printer!   set-schema-printer!)
 
-;; Elision-walker hooks (rf2-nwv63 / rf2-v9tw2) — published so
-;; re-frame.core's downstream registry-population code can hydrate
-;; `[:rf/elision :declarations]` at boot / on reg-app-schema without
-;; statically depending on the schemas artefact.
-(late-bind/set-fn! :schemas/extract-large-paths-from-schema extract-large-paths-from-schema)
-(late-bind/set-fn! :schemas/frame-elision-declarations      frame-elision-declarations)
-(late-bind/set-fn! :schemas/populate-elision-declarations   populate-elision-declarations)
-
-;; Sensitive-paths walker (rf2-kj51z / rf2-c1l4d).
+;; Schema-walker hooks consumed by `re-frame.elision` to feed the
+;; unified `[:rf/elision]` registry without statically depending on the
+;; schemas artefact. Per rf2-ynnq0 Option A — schemas owns the deep
+;; walker; the elision artefact owns the app-db write. The Path D impl
+;; (rf2-w3n5u) wires `re-frame.elision/populate-elision-from-schemas!`
+;; to consume these two hooks. The five sibling feeders that previously
+;; sat alongside (`:schemas/frame-elision-declarations`,
+;; `:schemas/populate-elision-declarations`, `:schemas/schema-has-
+;; sensitive?`, `:schemas/frame-sensitive-declarations`,
+;; `:schemas/populate-sensitive-declarations`) were deleted per
+;; rf2-5q7r0 — they had zero consumers in tree, and Option A makes the
+;; per-slot extract-* hooks the single surface elision needs.
+(late-bind/set-fn! :schemas/extract-large-paths-from-schema     extract-large-paths-from-schema)
 (late-bind/set-fn! :schemas/extract-sensitive-paths-from-schema extract-sensitive-paths-from-schema)
-(late-bind/set-fn! :schemas/schema-has-sensitive?               schema-has-sensitive?)
-(late-bind/set-fn! :schemas/frame-sensitive-declarations        frame-sensitive-declarations)
-(late-bind/set-fn! :schemas/populate-sensitive-declarations     populate-sensitive-declarations)
 
 ;; Test-support hooks (consumed by re-frame.test-support's
 ;; reset-runtime-fixture).


### PR DESCRIPTION
## Summary

The schemas artefact published seven late-bind hooks for the schema → elision-registry pipeline. Five had zero consumers anywhere in tree (grep across `implementation/`, `tools/`, `skills/` — only the directory catalogue and the publication site itself referenced them). Per **rf2-ynnq0 Option A (decided)** the elision artefact will own the `[:rf/elision]` registry write and consume schemas via the per-slot `extract-*` hooks. The five sibling feeders are surplus to that contract — **Path D (rf2-w3n5u)** wires `elision/populate-elision-from-schemas!` to call `:schemas/extract-large-paths-from-schema` (and the sensitive analogue) directly, which is the single integration seam Option A defines.

The underlying `elision-feeder.cljc` functions and `walker.cljc/schema-has-sensitive?` remain — they have JVM-test coverage and Path D will revisit them in its own commit. This bead is scoped to the late-bind hook surface (the public coupling point).

## Decision matrix

| hook | action | reason |
|------|--------|--------|
| `:schemas/extract-large-paths-from-schema` | KEEP | rf2-w3n5u Path D consumer |
| `:schemas/extract-sensitive-paths-from-schema` | KEEP | rf2-w3n5u Path D consumer |
| `:schemas/frame-elision-declarations` | DELETE | zero consumers; Option A doesn't need it |
| `:schemas/populate-elision-declarations` | DELETE | rf2-ynnq0 NOTES: explicit delete |
| `:schemas/schema-has-sensitive?` | DELETE | hook unused; fn stays (`validate.cljc` requires it directly) |
| `:schemas/frame-sensitive-declarations` | DELETE | zero consumers (parallel to elision sibling) |
| `:schemas/populate-sensitive-declarations` | DELETE | rf2-ynnq0 NOTES: explicit delete |

LoC delta: -34 / +15 across two files (`schemas.cljc`, `late_bind/directory.cljc`).

## Test plan

- [x] `cd implementation/schemas && clojure -M:test` — 133 tests / 383 assertions / 0 fail
- [x] `cd implementation/core && clojure -M:test -n re-frame.late-bind-drift-test` — 5 tests / 316 assertions / 0 fail (bidirectional publication ↔ directory consistency)
- [x] `cd implementation && npm run test:cljs` — 1816 tests / 5040 assertions / 0 fail

Closes rf2-5q7r0.