### PR TITLE
refactor(mcp-base): pin diff-encode patch grammar via Malli schema (rf2-rgg7d)

### DIFF
--- a/tools/mcp-base/deps.edn
+++ b/tools/mcp-base/deps.edn
@@ -25,6 +25,10 @@
 ;;                          records (rf2-1wdzp, used at the wire
 ;;                          boundary inside pair2-mcp; the encoding
 ;;                          contract is a cross-MCP convention).
+;;                          Pinned via Malli `patch-schema` /
+;;                          `patches-schema` at the encoder boundary
+;;                          (rf2-rgg7d) so a future tuple-grammar
+;;                          drift trips the dev-build gate.
 ;;   - `overflow.cljc`  — overflow-marker payload builder (rf2-rvyzy).
 ;;
 ;; What deliberately does NOT live here:
@@ -64,9 +68,23 @@
  :deps  {org.clojure/clojure {:mvn/version "1.12.0"}}
 
  :aliases
+ ;; metosin/malli is TEST-ONLY (rf2-rgg7d). mcp-base's runtime sources
+ ;; stay Malli-free at the dep boundary; the encoder's validation gate
+ ;; (`diff-encode/validate-patches!`) resolves `malli.core/validate` at
+ ;; runtime via `requiring-resolve` / `resolve` and soft-passes when
+ ;; Malli is absent. The test alias here puts Malli on the classpath so
+ ;; the diff-encode tests can hard-assert schema acceptance and
+ ;; rejection. Consumers (pair2-mcp, story-mcp, causa-mcp) bring Malli
+ ;; themselves via their implementation deps; production CLJS bundles
+ ;; can flip the goog-define `validate-patches?` to false to DCE the
+ ;; validation branch outright. Pinning the same version used by
+ ;; tools/mcp-conformance/wire-vocab so schema syntax stays aligned
+ ;; across the conformance gates.
  {:test {:extra-paths ["test"]
          :extra-deps  {io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}
+                       metosin/malli
+                       {:mvn/version "0.16.4"}}
          :main-opts   ["-m" "cognitect.test-runner"]}
 
   ;; Clojars deploy — mirrors tools/story-mcp/deps.edn.

--- a/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
@@ -42,8 +42,118 @@
   The `:rf.mcp/diff-from` marker key follows the same `:rf.mcp/*`
   namespace convention as `:rf.mcp/overflow` (rf2-rvyzy),
   `:rf.mcp/summary` (rf2-tygdv), and causa-mcp's `:rf.mcp/dedup-table`
-  (rf2-lwgg8 mechanism 5). Agents recognise the family once."
+  (rf2-lwgg8 mechanism 5). Agents recognise the family once.
+
+  ## Patch grammar pinned via Malli (rf2-rgg7d)
+
+  The patch tuple grammar is pinned as a Malli schema (`patch-schema`).
+  Each `collect-patches` emission is validated at the encoder boundary
+  inside `diff-encode-db-after` so a future encoder change that drifts
+  the tuple shape trips the dev-build gate before it reaches a consumer.
+
+  The schema is published as a public def for downstream Malli-based
+  decoders (causa-mcp's spec/004-Wire-Pipeline.md) and for the
+  cross-MCP wire-vocab conformance test
+  (`tools/mcp-conformance/wire-vocab`). Both today re-state the grammar
+  in their own source; pinning it here gives them a canonical home to
+  refer to once they switch to consume the schema directly.
+
+  Validation is soft-pass when Malli is not resolvable on the runtime
+  classpath: mcp-base does not pull Malli into its own deps (consumers
+  bring their own — pair2-mcp/story-mcp/causa-mcp all have Malli on the
+  classpath via the implementation deps or the story artefact). On
+  CLJS the validation branch sits behind a `goog-define`'d
+  `validate-patches?` flag so a production build with
+  `:closure-defines {re-frame.mcp-base.diff-encode/validate-patches?
+  false}` (typically alongside `goog.DEBUG false`) elides the branch
+  via Closure DCE. JVM consumers run validation unconditionally — JVM
+  paths are dev/server-side, the cost is invisible against the
+  surrounding tree-walk."
   (:require [re-frame.mcp-base.vocab :as vocab]))
+
+;; ---------------------------------------------------------------------------
+;; Patch grammar — the Malli schema pinned at the encoder boundary.
+;; ---------------------------------------------------------------------------
+
+(def patch-schema
+  "Malli schema for a single patch tuple emitted by `collect-patches`.
+
+  Shape:
+
+      [:or
+       [:tuple [:vector :any] [:= :assoc] :any]
+       [:tuple [:vector :any] [:= :dissoc]]]
+
+  - `[<path> :assoc <new-value>]` — a leaf is new or changed.
+  - `[<path> :dissoc]`            — a key disappeared.
+
+  `<path>` is a vector of keys reaching from the root of the
+  diffed value down to the leaf being assoc'd / dissoc'd; an empty
+  vector denotes the root (root replacement / no-op dissoc).
+
+  Published as a public def so downstream decoders (causa-mcp
+  spec/004-Wire-Pipeline.md, the cross-MCP wire-vocab conformance
+  test) can consume the canonical schema rather than re-stating the
+  grammar."
+  [:or
+   [:tuple [:vector :any] [:= :assoc] :any]
+   [:tuple [:vector :any] [:= :dissoc]]])
+
+(def patches-schema
+  "Malli schema for the full patch vector — a sequential of
+  `patch-schema`. Convenience alias used at the encoder boundary so
+  validation walks the whole emission once rather than once per
+  tuple."
+  [:sequential patch-schema])
+
+;; ---------------------------------------------------------------------------
+;; Validation gate — soft-pass when Malli is absent; goog-define-elidable
+;; on CLJS prod builds.
+;; ---------------------------------------------------------------------------
+
+#?(:cljs (goog-define ^boolean validate-patches?
+           ;; @define {boolean}
+           ;; Defaults to `true` (dev / test builds). Production CLJS
+           ;; builds set this to false via
+           ;; `:closure-defines {re-frame.mcp-base.diff-encode/validate-patches?
+           ;; false}` (typically alongside `goog.DEBUG false`); Closure
+           ;; DCE then prunes the validation branch from
+           ;; `diff-encode-db-after`.
+           true)
+   :clj  (def ^:const validate-patches?
+           "JVM-side: validation always on. JVM consumers (story-mcp,
+           causa-mcp) run on dev / server hosts where the tree-walk
+           cost is invisible against the surrounding diff. The
+           compile-time elision only meaningfully applies under CLJS
+           `:advanced`."
+           true))
+
+(defn- resolve-malli-validate
+  "Resolve `malli.core/validate` if Malli is on the classpath; return
+  `nil` otherwise. Mirrors `re-frame.epoch/resolve-malli-validate`
+  and `re-frame.http-encoding`'s resolve-pattern — keep mcp-base
+  Malli-free at its own dep boundary; downstream consumers provide
+  Malli on the runtime classpath."
+  []
+  #?(:clj  (try (requiring-resolve 'malli.core/validate)
+                (catch Throwable _ nil))
+     :cljs (try (resolve 'malli.core/validate)
+                (catch :default _ nil))))
+
+(defn- validate-patches!
+  "Validate `patches` against `patches-schema` and throw ex-info on
+  mismatch. No-op when Malli is not resolvable on the runtime
+  classpath (soft-pass — mirrors `re-frame.schemas.malli`'s default
+  validator). Called by `diff-encode-db-after` at the wire boundary."
+  [patches]
+  (when validate-patches?
+    (when-let [validate (resolve-malli-validate)]
+      (when-not (validate patches-schema patches)
+        (throw (ex-info "diff-encode patch grammar violated"
+                        {:rf.error/code  :rf.error/bad-diff-patches
+                         :schema         patches-schema
+                         :patches        patches})))))
+  nil)
 
 (declare collect-patches)
 
@@ -129,6 +239,7 @@
                (contains? epoch :db-after))
     epoch
     (let [patches (collect-patches (:db-before epoch) (:db-after epoch) [])]
+      (validate-patches! patches)
       (assoc epoch :db-after
              {vocab/diff-from-key :db-before
               :patches            patches}))))

--- a/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
@@ -2,6 +2,7 @@
   "Tests for the path-keyed structural diff used at the MCP wire
   boundary (rf2-1wdzp, shared across the triplet via rf2-vw4sq)."
   (:require [clojure.test :refer [deftest is testing]]
+            [malli.core :as m]
             [re-frame.mcp-base.diff-encode :as de]))
 
 ;; ---------------------------------------------------------------------------
@@ -124,3 +125,132 @@
         (is (= (dissoc enc :db-after :patches)
                (dissoc dec :db-after))
             "non-:db-after fields unchanged on decode")))))
+
+;; ---------------------------------------------------------------------------
+;; Patch grammar — Malli schema pin (rf2-rgg7d).
+;;
+;; The schema is published as `de/patch-schema` (single tuple) and
+;; `de/patches-schema` (sequential of tuples). The encoder boundary
+;; (`diff-encode-db-after`) validates emissions against it and throws
+;; `:rf.error/bad-diff-patches` ex-info on mismatch.
+;;
+;; These tests pin the grammar with positive and negative cases so a
+;; future encoder refactor that drifts the tuple shape — and a future
+;; consumer (causa-mcp's Malli-based decoder per spec/004-Wire-Pipeline.md,
+;; the cross-MCP wire-vocab conformance test) that re-states the
+;; grammar — both trip this gate before reaching the wire.
+;; ---------------------------------------------------------------------------
+
+(deftest patch-schema-accepts-well-formed-tuples
+  (testing "the two canonical 2- and 3-element tuple shapes"
+    (is (true? (m/validate de/patch-schema [[:a] :assoc 1]))
+        "assoc with scalar value")
+    (is (true? (m/validate de/patch-schema [[:a :b] :assoc {:x 1}]))
+        "assoc with map value")
+    (is (true? (m/validate de/patch-schema [[] :assoc {:whole :db}]))
+        "assoc at root (empty path)")
+    (is (true? (m/validate de/patch-schema [[:a] :dissoc]))
+        "dissoc at depth 1")
+    (is (true? (m/validate de/patch-schema [[:a :b :c] :dissoc]))
+        "dissoc at depth 3"))
+  (testing "values can be of any type"
+    (is (true? (m/validate de/patch-schema [[:a] :assoc nil]))
+        "assoc nil leaf")
+    (is (true? (m/validate de/patch-schema [[:a] :assoc [1 2 3]]))
+        "assoc vector leaf")
+    (is (true? (m/validate de/patch-schema [[:a] :assoc #{:tag}]))
+        "assoc set leaf")))
+
+(deftest patch-schema-rejects-malformed-tuples
+  (testing "wrong op keyword — only :assoc / :dissoc allowed"
+    (is (false? (m/validate de/patch-schema [[:a] :replace 1]))
+        ":replace is not in the grammar")
+    (is (false? (m/validate de/patch-schema [[:a] "assoc" 1]))
+        "string ops are rejected"))
+  (testing "wrong arity"
+    (is (false? (m/validate de/patch-schema [[:a] :assoc]))
+        ":assoc without value is invalid")
+    (is (false? (m/validate de/patch-schema [[:a] :dissoc :extra]))
+        ":dissoc with a trailing value is invalid")
+    (is (false? (m/validate de/patch-schema [[:a]]))
+        "missing op"))
+  (testing "path must be a vector"
+    (is (false? (m/validate de/patch-schema ['(:a) :assoc 1]))
+        "list path is rejected")
+    (is (false? (m/validate de/patch-schema [:a :assoc 1]))
+        "keyword path is rejected")
+    (is (false? (m/validate de/patch-schema [nil :dissoc]))
+        "nil path is rejected"))
+  (testing "non-tuple shapes"
+    (is (false? (m/validate de/patch-schema {:path [:a] :op :assoc :v 1}))
+        "map-shaped patch is rejected")
+    (is (false? (m/validate de/patch-schema nil))
+        "nil patch is rejected")))
+
+(deftest collect-patches-output-conforms-to-schema
+  ;; The factory's emission MUST validate against patches-schema for
+  ;; every shape combination the encoder is expected to produce. If a
+  ;; future refactor of collect-map-patches starts emitting a new
+  ;; tuple shape (e.g. an :update op), this test fails BEFORE the
+  ;; emission reaches a consumer.
+  (testing "added key, removed key, changed leaf, nested recursion, shape mismatch"
+    (let [cases [;; trivial equality — empty patches
+                 [{:a 1}                {:a 1}]
+                 ;; added
+                 [{:a 1}                {:a 1 :b 2}]
+                 ;; removed
+                 [{:a 1 :b 2}           {:a 1}]
+                 ;; changed leaf
+                 [{:a 1}                {:a 3}]
+                 ;; nested
+                 [{:u {:name "ada" :age 30}}
+                  {:u {:name "ada" :age 31 :role :admin}}]
+                 ;; root-level shape change
+                 [{:a 1}                [1 2 3]]
+                 ;; map → map containing vector leaf
+                 [{:a {:b 1}}           {:a [1 2 3]}]
+                 ;; many keys with mixed actions
+                 [{:keep 1 :change 2 :remove 3}
+                  {:keep 1 :change 99 :add 4}]]]
+      (doseq [[a b] cases]
+        (let [patches (de/collect-patches a b [])]
+          (is (true? (m/validate de/patches-schema patches))
+              (str "patches conform for case " (pr-str [a b])
+                   " — produced " (pr-str patches))))))))
+
+(deftest diff-encode-db-after-emits-schema-conformant-patches
+  ;; The encoder-boundary entry point. Whatever collect-patches
+  ;; produced flows out through diff-encode-db-after; its validation
+  ;; gate (`validate-patches!`) must accept the emission silently.
+  (let [epoch   {:db-before {:user {:name "ada" :age 30}
+                             :session :idle}
+                 :db-after  {:user {:name "ada" :age 31 :role :admin}
+                             :flags #{:beta}}}
+        encoded (de/diff-encode-db-after epoch)
+        patches (get-in encoded [:db-after :patches])]
+    (is (true? (m/validate de/patches-schema patches))
+        "encoded patches conform to patches-schema")
+    (is (pos? (count patches))
+        "non-trivial encode produced at least one patch")))
+
+(deftest diff-encode-db-after-throws-when-validation-disabled-elsewhere-noop
+  ;; The validation gate is `validate-patches!`. Calling it directly
+  ;; with malformed input throws; well-formed input is a silent no-op.
+  ;; This pins the boundary contract independently of the public
+  ;; encoder entry point.
+  (testing "well-formed patches return nil"
+    (is (nil? (#'de/validate-patches! [[[:a] :assoc 1]
+                                       [[:b] :dissoc]]))))
+  (testing "malformed patches throw :rf.error/bad-diff-patches"
+    (let [bad [[[:a] :replace 1]]]
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #"diff-encode patch grammar violated"
+            (#'de/validate-patches! bad)))
+      (try
+        (#'de/validate-patches! bad)
+        (is false "expected throw")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :rf.error/bad-diff-patches
+                 (:rf.error/code (ex-data e)))
+              "ex-info carries the reserved :rf.error/* code"))))))


### PR DESCRIPTION
## Summary

- Define `patch-schema` / `patches-schema` in `re-frame.mcp-base.diff-encode` as a public Malli schema for the patch tuple grammar emitted by `collect-patches`.
- Validate emissions at the encoder boundary inside `diff-encode-db-after`; gate behind a `goog-define`'d `validate-patches?` so production CLJS builds can DCE the branch via `:closure-defines`. JVM consumers run validation unconditionally.
- Soft-pass when Malli is not resolvable on the runtime classpath — mcp-base keeps Malli out of its runtime deps; consumers already bring it via their implementation deps. Malli is added as a TEST-ONLY dep so the test alias can hard-assert acceptance / rejection.

Closes rf2-rgg7d.

## Schema

```clojure
(def patch-schema
  [:or
   [:tuple [:vector :any] [:= :assoc] :any]
   [:tuple [:vector :any] [:= :dissoc]]])

(def patches-schema [:sequential patch-schema])
```

Matches the canonical shape the cross-MCP wire-vocab conformance test (`tools/mcp-conformance/wire-vocab`) already pins from its end; both can now point at this canonical home. Downstream Malli-based decoders (causa-mcp `spec/004-Wire-Pipeline.md`) can consume the schema directly rather than re-stating the grammar.

## Test plan

- [x] `cd tools/mcp-base && clojure -M:test` — 67 tests, 179 assertions, 0 failures (was 62/148; +5 new deftests, +31 assertions for positive / negative grammar cases, `collect-patches` output conformance, encoder-boundary conformance, and the `validate-patches!` ex-info contract).
- [x] `cd implementation && npm run test:cljs` — 1816 tests, 5040 assertions, 0 failures (mcp-base isn't on this gate's classpath; ran for due diligence).
- [x] `cd implementation && npm run test:bundle-isolation` — PASS. Bundle-isolation contract unaffected: mcp-base is a leaf artefact already isolated from implementation builds.
- [x] `cd tools/pair2-mcp && npm test` — 296 tests, 733 assertions, 0 failures. Confirms the CLJS consumer of `diff-encode` still round-trips; the `resolve`-based runtime check soft-passes on CLJS (matching the established pattern in `re-frame.schemas.malli` / `re-frame.http-encoding`).