### PR TITLE
refactor(story-mcp): symmetric tools.recorder/descriptors vec (rf2-ridxf)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
@@ -144,29 +144,31 @@
                                          (select-keys (ex-data e)
                                                       [:rf.error :explain]))))))))))))
 
-(def descriptor
-  "Registry descriptor for `record-as-variant`. Listed in
-  `tools.write/descriptors` so the registry assembly stays in
-  IMPL-SPEC §7.3 order."
-  {:name           "record-as-variant"
-   :category       :write
-   :description    "Bridge the recorder's start → capture → snippet pipeline across the MCP boundary. Starts a recording against the source variant's frame, blocks for `:duration-ms`, stops, returns the `(reg-variant ...)` snippet `gen-play-snippet` emits. Optional `:write-back?` re-registers the variant with the captured `:play` slot — GATED behind `:rf.story-mcp/allow-writes?` (same gate as `register-variant`)."
-   :typicalTokens  1500
-   :inputSchema {:type "object"
-                 :properties (s/with-max-tokens
-                               {:variant-id     s/kw-or-string
-                                :duration-ms    {:type "integer" :minimum 0
-                                                 :description "Milliseconds to block between start and stop. Default 0. JVM-only (CLJS hosts no-op)."}
-                                :new-variant-id (assoc s/kw-or-string
-                                                  :description "When `:write-back?` is true, register the captured `:play` body under this id. Defaults to the source `:variant-id` (overwrites in place).")
-                                :doc            {:type "string"
-                                                 :description "Optional docstring embedded in the rendered snippet."}
-                                :extends        (assoc s/kw-or-string
-                                                  :description "Variant id embedded as `:extends` in the snippet. Defaults to the source `:variant-id`.")
-                                :alias          {:type "string"
-                                                 :description "Short ns alias for the rendered form (default \"story\")."}
-                                :write-back?    {:type "boolean"
-                                                 :description "When true, also re-register the variant with the captured `:play`. Requires `allow-writes?`."}})
-                 :required ["variant-id"]
-                 :additionalProperties false}
-   :handler     tool-record-as-variant})
+(def descriptors
+  "Registry descriptors for the recorder's MCP surface — the single
+  `record-as-variant` tool, presented as a vec so
+  `tools.registry/tool-registry` can `into cat` recorder alongside
+  every other category ns symmetrically. The tool is tail-of-write
+  per IMPL-SPEC §7.3."
+  [{:name           "record-as-variant"
+    :category       :write
+    :description    "Bridge the recorder's start → capture → snippet pipeline across the MCP boundary. Starts a recording against the source variant's frame, blocks for `:duration-ms`, stops, returns the `(reg-variant ...)` snippet `gen-play-snippet` emits. Optional `:write-back?` re-registers the variant with the captured `:play` slot — GATED behind `:rf.story-mcp/allow-writes?` (same gate as `register-variant`)."
+    :typicalTokens  1500
+    :inputSchema {:type "object"
+                  :properties (s/with-max-tokens
+                                {:variant-id     s/kw-or-string
+                                 :duration-ms    {:type "integer" :minimum 0
+                                                  :description "Milliseconds to block between start and stop. Default 0. JVM-only (CLJS hosts no-op)."}
+                                 :new-variant-id (assoc s/kw-or-string
+                                                   :description "When `:write-back?` is true, register the captured `:play` body under this id. Defaults to the source `:variant-id` (overwrites in place).")
+                                 :doc            {:type "string"
+                                                  :description "Optional docstring embedded in the rendered snippet."}
+                                 :extends        (assoc s/kw-or-string
+                                                   :description "Variant id embedded as `:extends` in the snippet. Defaults to the source `:variant-id`.")
+                                 :alias          {:type "string"
+                                                  :description "Short ns alias for the rendered form (default \"story\")."}
+                                 :write-back?    {:type "boolean"
+                                                  :description "When true, also re-register the variant with the captured `:play`. Requires `allow-writes?`."}})
+                  :required ["variant-id"]
+                  :additionalProperties false}
+    :handler     tool-record-as-variant}])

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc
@@ -27,13 +27,13 @@
   docs → testing → write. The recorder bridge
   (`record-as-variant`) lives in `tools.recorder` for leaf-size
   reasons (rf2-zkca8) but belongs at the tail of the write category
-  per IMPL-SPEC §7.3."
-  (-> []
-      (into cat [dev/descriptors
-                 docs/descriptors
-                 testing/descriptors
-                 write/descriptors])
-      (conj recorder/descriptor)))
+  per IMPL-SPEC §7.3 — `recorder/descriptors` is a one-element vec
+  so the assembly stays symmetric across every category ns."
+  (into [] cat [dev/descriptors
+                docs/descriptors
+                testing/descriptors
+                write/descriptors
+                recorder/descriptors]))
 
 (defn tool-descriptors
   "Build the `tools/list` response payload: each tool's name +

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
@@ -10,9 +10,9 @@
   The third write-surface tool, `record-as-variant` (the recorder
   bridge, rf2-luhdu), lives in `re-frame.story-mcp.tools.recorder` —
   it has enough body to warrant its own ns under the rf2-zkca8
-  leaf-size ceiling. The registry (`tools.registry/tool-registry`)
-  concatenates `recorder/descriptor` after `write/descriptors` so
-  IMPL-SPEC §7.3 order survives the file split."
+  leaf-size ceiling. That ns exposes its own `descriptors` vec which
+  `tools.registry/tool-registry` concatenates after `write/descriptors`
+  so IMPL-SPEC §7.3 order survives the file split."
   (:require [clojure.edn :as edn]
             [re-frame.mcp-base.args :as args]
             [re-frame.story :as story]


### PR DESCRIPTION
## Summary

Per round-2 audit rf2-w8jxf (R2-R1 win #3): `tools/story-mcp/.../tools/registry.cljc` built the canonical tool registry with an asymmetric concat — four category nses shipped a `descriptors` vec but `tools.recorder` shipped a single map named `descriptor`, requiring a trailing `conj recorder/descriptor` after the `into cat [.../descriptors]` reduction.

The "avoid a load-time cycle" justification on the old docstring didn't survive scrutiny — `descriptor` was a top-level def map; wrapping in a one-element vec changes nothing about loading.

- `tools/recorder.cljc`: `def descriptor {...}` -> `def descriptors [{...}]`.
- `tools/registry.cljc`: collapse to a single `into [] cat [dev/descriptors docs/descriptors testing/descriptors write/descriptors recorder/descriptors]`.
- `tools/write.cljc`: refresh the docstring note about recorder's split-out ns to reference the new symmetric `descriptors` vec.

Single-element vec construct/destructure is round-trip-stable; the descriptor map identity survives. Net delta: 38 insertions, 36 deletions (mostly indentation from the vec wrap + docstring touch-ups).

## Test plan

- [x] `cd tools/story-mcp && clojure -M:test` (85 tests, 439 assertions, 0 failures)
- [x] `cd implementation && npm run test:cljs` (1816 tests, 5040 assertions, 0 failures)
- [x] `python scripts/check_skill_mcp_drift.py` (exit 0)