### PR TITLE
feat(ssr-ring): default-html-shell honours :html-attrs / :body-attrs from head model (rf2-h2ujj)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -5,7 +5,9 @@
 
     - `destroy-frame-quietly!` — best-effort frame teardown
     - `resolve-root-view`      — hiccup-vec OR 0-arity fn → hiccup
-    - `resolve-head-html`      — active route's `:head` → HTML fragment
+    - `resolve-head`           — active route's `:head` → map carrying the
+                                 rendered fragment plus `:html-attrs` /
+                                 `:body-attrs` bags for the host shell
     - `on-create-with-request` — append request to caller's :on-create vec
 
   Per Spec 011 §Request storage substrate + §Head/meta contract."
@@ -54,19 +56,32 @@
                     {:reason   "root-view must be a hiccup vector or a 0-arity fn"
                      :received root-view}))))
 
-(defn resolve-head-html
+(defn resolve-head
   "Resolve the active route's `:head` against `frame-id` (or the default
-  head when the route doesn't declare one). Returns the inner-head HTML
-  fragment as a string. Exceptions during resolution degrade gracefully
-  to an empty string so a buggy head fn can't take down the request —
-  the trace surface still carries the throw for monitoring.
+  head when the route doesn't declare one). Returns a map:
 
-  Per Spec 011 §Head/meta contract (rf2-4dra9)."
+    {:head-html  \"<title>…</title><meta …>…\"   ;; inner-head fragment
+     :html-attrs {…} or nil                       ;; stamped on <html>
+     :body-attrs {…} or nil}                      ;; stamped on <body>
+
+  The two attribute bags ride alongside the rendered fragment because
+  `head-model->html` deliberately drops them (Spec 011 §Default flow
+  step 4: `:html-attrs` populate `<html>`; `:body-attrs` populate
+  `<body>` — the host shell stamps them, not the head emitter).
+
+  Exceptions during resolution degrade gracefully — empty fragment,
+  no attrs — so a buggy head fn can't take down the request. The trace
+  surface still carries the throw for monitoring.
+
+  Per Spec 011 §Head/meta contract (rf2-4dra9, rf2-h2ujj)."
   [frame-id]
   (try
     (let [model (rf/active-head frame-id)]
-      (rf/head-model->html model))
-    (catch Throwable _ "")))
+      {:head-html  (rf/head-model->html model)
+       :html-attrs (:html-attrs model)
+       :body-attrs (:body-attrs model)})
+    (catch Throwable _
+      {:head-html "" :html-attrs nil :body-attrs nil})))
 
 (defn on-create-with-request
   "Conj the Ring request map onto the caller's :on-create event vector

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -86,13 +86,25 @@
                                             :schema-digest schema-digest
                                             :payload-keys  payload-keys})
         payload-edn (pr-str payload)
-        ;; rf2-4dra9: resolve the active route's :head (or
-        ;; default-head fallback) and pass the rendered fragment as
-        ;; the :head opt. Callers that supplied an explicit :head opt
-        ;; take precedence — they chose to bypass route-driven head
-        ;; resolution.
-        head-html   (or (:head opts) (lifecycle/resolve-head-html frame-id))
-        shell-opts  (assoc opts :head head-html)
+        ;; rf2-4dra9 / rf2-h2ujj: resolve the active route's :head
+        ;; (or default-head fallback). The head fragment goes through
+        ;; the shell as the :head opt; the :html-attrs / :body-attrs
+        ;; bags ride alongside so the shell can stamp them on <html>
+        ;; / <body> per Spec 011 §Default flow step 4.
+        ;;
+        ;; Callers that supplied an explicit :head string take
+        ;; precedence — they chose to bypass route-driven head
+        ;; resolution, and an explicit string carries no attr-bag
+        ;; sidechannel (an explicit head opt is the escape hatch for
+        ;; bespoke fragments).
+        {:keys [head-html html-attrs body-attrs]}
+        (if (:head opts)
+          {:head-html (:head opts) :html-attrs nil :body-attrs nil}
+          (lifecycle/resolve-head frame-id))
+        shell-opts  (assoc opts
+                           :head        head-html
+                           :html-attrs  html-attrs
+                           :body-attrs  body-attrs)
         html        (html-shell body-html payload-edn shell-opts)
         ;; Ensure Content-Type is set; the SSR runtime defaults
         ;; [:rf/response :headers] to include content-type so this is

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/shell.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/shell.clj
@@ -5,7 +5,8 @@
   `<head>`, asset-hash-pinned `<script>` tags, JSON-LD blocks, ...)
   pass an `:html-shell` option to override. The default exists so a
   first-time user gets a working SSR endpoint without writing string
-  concatenation glue.")
+  concatenation glue."
+  (:require [re-frame.ssr.html-helpers :as html]))
 
 (set! *warn-on-reflection* true)
 
@@ -21,12 +22,23 @@
   resolved head fragment threaded in as the `:head` opt. Emitting one
   here would produce two `<title>` tags per document — malformed HTML.
 
+  `<html>` / `<body>` attributes — the active head model's
+  `:html-attrs` / `:body-attrs` bags (Spec 011 §Head/meta — line 478)
+  are threaded in through opts by the pipeline and stamped onto the
+  opening tags via the shared `re-frame.ssr.html-helpers/attr-string`
+  serialiser (boolean `true` → bare attribute name; `false` / `nil` →
+  omitted; all other values are `escape-attr`-escaped). When
+  `:html-attrs` is absent OR omits `:lang`, the `:lang` opt is the
+  fallback so existing callers keep working. When `:html-attrs`
+  supplies `:lang`, it wins.
+
   Args:
     body-html — the string returned by re-frame.ssr/render-to-string
     payload-edn — the hydration payload, pre-serialised with pr-str
     opts — the caller's adapter opts (merged with any per-request
-           overrides); standard keys :head / :body-end / :script-src /
-           :app-element-id / :lang influence the envelope.
+           overrides); standard keys :head / :html-attrs / :body-attrs
+           / :body-end / :script-src / :app-element-id / :lang
+           influence the envelope.
 
   Safety — `:body-end` is concatenated as RAW HTML; no escaping is
   applied. The shell is caller-controlled config (app boot decides what
@@ -36,23 +48,31 @@
   customer settings UI) MUST escape upstream — the shell will not.
   Audit rf2-asmj1 R12 / cluster rf2-sljs1."
   [body-html payload-edn
-   {:keys [head body-end script-src app-element-id lang]
+   {:keys [head html-attrs body-attrs body-end script-src app-element-id lang]
     :or   {app-element-id  "app"
            script-src      "/main.js"
            lang            "en"}}]
-  (str "<!DOCTYPE html>"
-       "<html lang=\"" lang "\">"
-       "<head>"
-       "<meta charset=\"utf-8\">"
-       (or head "")
-       "</head>"
-       "<body>"
-       "<div id=\"" app-element-id "\">" body-html "</div>"
-       "<script id=\"__rf_payload\" type=\"application/edn\">"
-       payload-edn
-       "</script>"
-       (when script-src
-         (str "<script src=\"" script-src "\"></script>"))
-       (or body-end "")
-       "</body>"
-       "</html>"))
+  (let [;; :html-attrs wins; otherwise fall back to {:lang lang}. An
+        ;; explicit :lang inside :html-attrs takes precedence over the
+        ;; :lang opt without us having to do anything special — the
+        ;; bag is used verbatim.
+        html-attr-bag (if (seq html-attrs)
+                        (cond-> html-attrs
+                          (not (contains? html-attrs :lang)) (assoc :lang lang))
+                        {:lang lang})]
+    (str "<!DOCTYPE html>"
+         "<html" (html/attr-string html-attr-bag) ">"
+         "<head>"
+         "<meta charset=\"utf-8\">"
+         (or head "")
+         "</head>"
+         "<body" (html/attr-string body-attrs) ">"
+         "<div id=\"" app-element-id "\">" body-html "</div>"
+         "<script id=\"__rf_payload\" type=\"application/edn\">"
+         payload-edn
+         "</script>"
+         (when script-src
+           (str "<script src=\"" script-src "\"></script>"))
+         (or body-end "")
+         "</body>"
+         "</html>")))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -583,6 +583,115 @@
            (no shell fallback)"))))
 
 ;; ===========================================================================
+;; default-html-shell — :html-attrs / :body-attrs honoured (rf2-h2ujj).
+;;
+;; Per Spec 011 §Head/meta (line 478, line 516): the head model carries
+;; `:html-attrs` / `:body-attrs` bags; the host shell stamps them on the
+;; opening `<html>` / `<body>` tags. Serialisation goes through the
+;; shared `re-frame.ssr.html-helpers/attr-string` helper — boolean `true`
+;; → bare attribute name, `false` / `nil` → omitted, all other values
+;; `escape-attr`-escaped (`&` and `"` only, since the bag is emitted
+;; inside double-quoted attribute values).
+;; ===========================================================================
+
+(defn- register-attrs-app! [head-model]
+  (rf/reg-head :head/with-attrs (fn [_db _route] head-model))
+  (rf/reg-route :route/with-attrs
+                {:doc  "Route exercising :html-attrs / :body-attrs"
+                 :path "/"
+                 :head :head/with-attrs})
+  (rf/reg-event-db :init/seed-attrs-route
+    (fn [db _] (assoc db :rf/route {:id :route/with-attrs})))
+  (rf/reg-view* :pages/blank-attrs (fn [] [:div])))
+
+(deftest default-shell-stamps-html-attrs-and-body-attrs
+  (testing "head model with :html-attrs + :body-attrs → both bags reach
+            the wire on the opening tags; :html-attrs :lang wins over the
+            :lang opt (Spec 011 §Head/meta line 478, line 516)."
+    (register-attrs-app! {:html-attrs {:lang "fr" :data-theme "dark"}
+                          :body-attrs {:class "page-article"}})
+
+    (let [handler  (ssr-ring/ssr-handler
+                     {:on-create [:init/seed-attrs-route]
+                      :root-view [:pages/blank-attrs]})
+          response (handler {:uri "/" :request-method :get})
+          body     (:body response)]
+      (is (= 200 (:status response)))
+      (is (str/includes? body "<html lang=\"fr\" data-theme=\"dark\">")
+          ":html-attrs stamped on <html> verbatim; :lang in the bag
+           takes precedence over the :lang opt default")
+      (is (str/includes? body "<body class=\"page-article\">")
+          ":body-attrs stamped on <body>"))))
+
+(deftest default-shell-html-and-body-bare-when-attrs-absent
+  (testing "head model with no :html-attrs / :body-attrs → <html> falls
+            back to the :lang opt (default \"en\"); <body> is bare. This
+            is the pre-rf2-h2ujj shape and the default for routes that
+            don't opt in."
+    (register-attrs-app! {:title "T"}) ; no attr bags
+
+    (let [handler  (ssr-ring/ssr-handler
+                     {:on-create [:init/seed-attrs-route]
+                      :root-view [:pages/blank-attrs]})
+          response (handler {:uri "/" :request-method :get})
+          body     (:body response)]
+      (is (= 200 (:status response)))
+      (is (str/includes? body "<html lang=\"en\">")
+          ":html-attrs absent → :lang opt fallback (default \"en\")")
+      (is (str/includes? body "<body>")
+          ":body-attrs absent → <body> emitted bare"))))
+
+(deftest default-shell-html-attrs-fills-missing-lang-from-opt
+  (testing ":html-attrs present but :lang absent → :lang opt fills it in.
+            The bag still wins for every other attribute it declares."
+    (register-attrs-app! {:html-attrs {:data-theme "dark"}})
+
+    (let [handler  (ssr-ring/ssr-handler
+                     {:on-create [:init/seed-attrs-route]
+                      :root-view [:pages/blank-attrs]
+                      :lang      "ja"})
+          response (handler {:uri "/" :request-method :get})
+          body     (:body response)]
+      (is (= 200 (:status response)))
+      (is (str/includes? body "lang=\"ja\"")
+          ":lang opt (\"ja\") fills in for :html-attrs missing :lang")
+      (is (str/includes? body "data-theme=\"dark\"")
+          ":html-attrs :data-theme reaches <html>"))))
+
+(deftest default-shell-attr-string-handles-booleans-and-nil
+  (testing "attr-string serialisation contract — boolean true → bare
+            attribute name, boolean false / nil → omitted, other values
+            → escape-attr-escaped (`&` and `\"`). Mixed valid + invalid
+            values in one bag exercise every branch."
+    (register-attrs-app! {:html-attrs {:lang        "en"
+                                       :data-flag   true     ; bare
+                                       :data-off    false    ; omitted
+                                       :data-nil    nil      ; omitted
+                                       :data-quote  "a \"b\" c"  ; escaped
+                                       :data-amp    "x & y"}      ; escaped
+                          :body-attrs {:class       "ok"
+                                       :data-hidden false}})
+
+    (let [handler  (ssr-ring/ssr-handler
+                     {:on-create [:init/seed-attrs-route]
+                      :root-view [:pages/blank-attrs]})
+          response (handler {:uri "/" :request-method :get})
+          body     (:body response)]
+      (is (= 200 (:status response)))
+      (is (str/includes? body "data-flag")
+          "boolean true → bare attribute name on <html>")
+      (is (not (str/includes? body "data-off"))
+          "boolean false → attribute omitted entirely from <html>")
+      (is (not (str/includes? body "data-nil"))
+          "nil → attribute omitted entirely from <html>")
+      (is (str/includes? body "data-quote=\"a &quot;b&quot; c\"")
+          "\" escaped to &quot; in attribute values")
+      (is (str/includes? body "data-amp=\"x &amp; y\"")
+          "& escaped to &amp; in attribute values")
+      (is (str/includes? body "<body class=\"ok\">")
+          "<body> opens with :class only — :data-hidden false omitted"))))
+
+;; ===========================================================================
 ;; ssr-middleware — match? predicate
 ;; ===========================================================================
 


### PR DESCRIPTION
## Summary

Spec 011 §Head/meta (line 478, line 516) carries `:html-attrs` / `:body-attrs` on the head model and locks the contract: "the host shell stamps them onto `<html>` / `<body>`." `head-model->html` drops them by design; the host shell is the consumer. The bundled `default-html-shell` was ignoring both — a silent contract violation discoverable only by reading raw HTML output.

Three-step fix, all inside `ssr-ring`:

- `lifecycle/resolve-head-html` → `lifecycle/resolve-head` returns `{:head-html :html-attrs :body-attrs}`. Attrs ride alongside because the head emitter strips them.
- `pipeline/build-full-response` destructures and threads `:html-attrs` / `:body-attrs` through `shell-opts`. Explicit `:head` opt still wins (escape hatch); explicit `:head` carries no attr-bag sidechannel.
- `shell/default-html-shell` stamps both bags via the shared `re-frame.ssr.html-helpers/attr-string` (boolean `true` → bare attr, `false`/`nil` → omitted, other values `escape-attr`-escaped). `:lang` opt still works as fallback when `:html-attrs` is absent or omits `:lang`; an explicit `:lang` inside the bag wins.

LoC: +192 / -36 across four files (193 net), well in line with the bead's ~15 + ~30 estimate after factoring in the shared `resolve-head` refactor.

## Test plan

- [x] `cd implementation/ssr-ring && clojure -M:test` — 23 tests, 96 assertions, 0 failures (4 new tests added for this surface)
- [x] `cd implementation && npm run test:cljs` — 1816 tests, 5040 assertions, 0 failures

New tests pin:

- attrs present → both bags stamped; bag's `:lang` beats the opt
- attrs absent → `<html lang="en">` fallback, `<body>` bare
- `:html-attrs` without `:lang` → opt fills it in
- boolean true / false / nil / quote / amp values exercise every `attr-string` branch

Closes rf2-h2ujj.