### PR TITLE
refactor(reagent-slim): fold double render-method install (rf2-e0yhj)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -497,6 +497,13 @@
   [render-fn]
   (fn []
     (this-as ^js this
+      ;; Re-stash argv from current props on every render entry so
+      ;; Form-2's cached render-fn sees fresh args. React-19-stable
+      ;; equivalent of the deprecated componentWillReceiveProps: a
+      ;; static getDerivedStateFromProps cannot side-effect on the
+      ;; instance, so we do the copy here at render entry instead
+      ;; (cheap; no DOM reads).
+      (copy-argv-from-props! this (.-props this))
       (binding [*current-component* this]
         (batching/mark-rendered this)
         (let [^js rea (.-cljsRenderRea this)
@@ -602,31 +609,9 @@
     (set! (.-cljsReagentClass klass) true)
 
     ;; render delegates to wrap-render over the user's :reagent-render.
+    ;; make-render-method's body re-stashes argv from props at render
+    ;; entry, so a single install is sufficient.
     (set! (.. klass -prototype -render) (make-render-method render-fn))
-
-    ;; Static UNSAFE_componentWillReceiveProps replacement: React 19 +
-    ;; class components receive new props through the standard
-    ;; props update; render reads .-cljsArgv via a small re-stash on
-    ;; each render's first call. We set a getDerivedStateFromProps
-    ;; that copies props.__rfArgv onto a per-instance side-channel
-    ;; readable by render. This is the React-19-stable way to keep
-    ;; the argv current across re-renders without using deprecated
-    ;; lifecycles.
-    ;;
-    ;; However, getDerivedStateFromProps is a static method that
-    ;; returns a state patch — it cannot side-effect on the instance.
-    ;; The pragmatic shape: re-copy from props at the top of render
-    ;; (cheap; no DOM reads). Done in make-render-method's body via
-    ;; this small helper installed onto render itself:
-    (let [^js user-render (.. klass -prototype -render)
-          wrapped         (fn []
-                            (this-as ^js this
-                              ;; Re-stash argv from current props on every
-                              ;; render entry so Form-2's cached render-fn
-                              ;; sees fresh args.
-                              (copy-argv-from-props! this (.-props this))
-                              (.call user-render this)))]
-      (set! (.. klass -prototype -render) wrapped))
 
     (install-lifecycle! klass spec)
     klass))


### PR DESCRIPTION
## Summary

- `create-class*` was installing the prototype `.render` twice. First via `make-render-method`, then immediately overwriting it with a thin wrapper that called `copy-argv-from-props!` before delegating. The first install was wasted (overwritten on the very next line).
- Between the two install sites sat a 15-line comment narrating a `getDerivedStateFromProps` design path that was not taken — pure history.
- Fold `(copy-argv-from-props! this (.-props this))` as the first form inside `make-render-method`'s `this-as` block so the method produces the final render fn directly. Single install site remains. Wrapper behaviour preserved verbatim, just inlined one level deeper.

Net: -15 LoC (9 insertions, 24 deletions).

Per audit rf2-bgnin (`ai/findings/refactor-audit-r2-adapter-reagent-slim-2026-05-14.md`, CQ-1).

## Test plan

- [x] `npm run test:cljs` — 1816 tests, 0 failures, 0 errors
- [x] `clojure -M:test` in `implementation/adapters/reagent-slim` — 11 tests, 0 failures, 0 errors
- [x] `npm run test:browser` — 1816 tests, 0 failures, 0 errors (component install is exercised by `reagent2.impl.component-cljs-test` render-then-update cycles)