### PR TITLE
refactor(story-mcp): thread tool-name through assert-writes-allowed (rf2-c52j0)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
@@ -92,7 +92,7 @@
   (h/with-variant arguments
     (fn [vk body]
       (let [write-back? (args/parse-boolean (:write-back? arguments) false)
-            gate-err    (when write-back? (write/assert-writes-allowed))]
+            gate-err    (when write-back? (write/assert-writes-allowed "record-as-variant"))]
         (if gate-err gate-err
           (let [duration-ms (args/parse-non-negative-int (:duration-ms arguments) 0)
                 new-vid     (some-> (:new-variant-id arguments) args/parse-keyword)

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
@@ -22,8 +22,13 @@
 
 (defn assert-writes-allowed
   "Returns nil when writes are allowed; an error-result otherwise. The
-  caller short-circuits on the non-nil branch."
-  []
+  caller short-circuits on the non-nil branch. Threads `tool-name` (the
+  caller's MCP tool name, sans namespace) through to the error's
+  `:structuredContent :tool` slot so agents inspecting a gated-error
+  payload see the tool that actually tripped the gate — not a hardcoded
+  string. Three callers today: `register-variant`, `unregister-variant`,
+  and `record-as-variant` (via the recorder ns)."
+  [tool-name]
   (when-not (config/writes-allowed?)
     (h/error-result
       (str "Write surface disabled. Set `:rf.story-mcp/allow-writes?` "
@@ -31,7 +36,7 @@
            "`-Drf.story-mcp.allow-writes=true` JVM property) to enable. "
            "Per IMPL-SPEC §7.3 the write surface is dev-only; CI runs "
            "should leave it off.")
-      {:gated true :tool "register-variant"})))
+      {:gated true :tool tool-name})))
 
 (defn tool-register-variant
   "Write: programmatically register a variant. Gated behind
@@ -43,7 +48,7 @@
                  EDN via `clojure.edn/read-string` if a string is sent
                  over the wire)."
   [arguments]
-  (or (assert-writes-allowed)
+  (or (assert-writes-allowed "register-variant")
       (let [[vid e1] (h/required-arg arguments :variant-id)
             [body e2] (h/required-arg arguments :body)]
         (cond
@@ -84,7 +89,7 @@
   "Write: programmatically unregister a variant. Gated behind
   `allow-writes?`."
   [arguments]
-  (or (assert-writes-allowed)
+  (or (assert-writes-allowed "unregister-variant")
       (h/with-variant-id arguments
         (fn [vk]
           (let [had? (some? (story/variant->edn vk))]

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -480,6 +480,31 @@
     (is (true? (-> r :structuredContent :unregistered?)))
     (is (nil? (story/variant->edn :story.button/primary)))))
 
+(deftest gated-error-tool-slot-pins-caller
+  ;; Regression for rf2-c52j0. Pre-fix, `assert-writes-allowed` hardcoded
+  ;; `:tool "register-variant"` in its error payload, so the two other
+  ;; callers (`unregister-variant`, `record-as-variant`) returned a gated
+  ;; error whose `:structuredContent :tool` slot LIED about its origin.
+  ;; This test pins the slot to the actual tool name at each callsite so
+  ;; the lie cannot regress.
+  (testing "gated error's :structuredContent :tool matches the invoking tool"
+    (is (false? (config/writes-allowed?))
+        "fixture must leave the gate closed for this test")
+    (let [r (invoke "register-variant" {:variant-id "story.button/danger"
+                                        :body {:doc "x"}})]
+      (is (error? r))
+      (is (true? (-> r :structuredContent :gated)))
+      (is (= "register-variant" (-> r :structuredContent :tool))))
+    (let [r (invoke "unregister-variant" {:variant-id "story.button/primary"})]
+      (is (error? r))
+      (is (true? (-> r :structuredContent :gated)))
+      (is (= "unregister-variant" (-> r :structuredContent :tool))))
+    (let [r (invoke "record-as-variant" {:variant-id  "story.button/primary"
+                                         :write-back? true})]
+      (is (error? r))
+      (is (true? (-> r :structuredContent :gated)))
+      (is (= "record-as-variant" (-> r :structuredContent :tool))))))
+
 ;; ---------------------------------------------------------------------------
 ;; record-as-variant (rf2-luhdu)
 ;;


### PR DESCRIPTION
## Summary

`tools/story-mcp/.../tools/write.cljc` `assert-writes-allowed` hardcoded `:tool "register-variant"` in the error's `:structuredContent` payload, but was called from three sites. Two of three callsites produced gated errors whose structured-content claimed the wrong tool tripped the gate:

- `tool-register-variant` — correct (matched the hardcoded string)
- `tool-unregister-variant` — LIED
- `tool-record-as-variant` (recorder.cljc) — LIED

This thread the tool-name through as a parameter and passes the actual MCP tool name at each of the three callsites, so an agent inspecting a gated-error payload's `:tool` slot now sees ground truth.

Per round-2 audit rf2-w8jxf (findings R2-W1; carryover from round-1 T12). Closes rf2-c52j0.

## Changes

- `tools/story-mcp/.../tools/write.cljc` — `assert-writes-allowed` takes `tool-name` and uses it for the `:tool` slot; `tool-register-variant` and `tool-unregister-variant` updated to pass their own names.
- `tools/story-mcp/.../tools/recorder.cljc` — `tool-record-as-variant` updated to pass `"record-as-variant"` to the gate.
- `tools/story-mcp/test/.../tools_test.clj` — new regression test `gated-error-tool-slot-pins-caller` that pins the `:tool` slot to the invoking tool for all three callers when the gate is closed.

## Test plan

- [x] `cd tools/story-mcp && clojure -M:test` — 86 tests, 449 assertions, 0 failures, 0 errors.
- [x] `cd implementation && npm run test:cljs` — 1816 tests, 5040 assertions, 0 failures, 0 errors.
- [x] `python scripts/check_skill_mcp_drift.py` — exit 0.