### PR TITLE
refactor(causa-mcp): Principles "Tool verbs" enum lists 18 with list-subscriptions

### DIFF
--- a/tools/causa-mcp/spec/Principles.md
+++ b/tools/causa-mcp/spec/Principles.md
@@ -341,9 +341,10 @@ filter-addressed slice reads (`get-trace-buffer`, `get-epoch-history`,
 `get-app-db`, `get-app-db-diff`, `get-machine-state`,
 `get-machine-list`, `get-issues`, `get-handlers`, `get-source-coord`)
 plus the mutating triple (`restore-epoch`, `reset-frame-db`,
-`dispatch`), the streaming pair, the escape hatch, and the meta tools
-(`discover-app`, `tail-build`). All are conformant to the canonical
-table.
+`dispatch`), the streaming triple (`subscribe`, `unsubscribe`,
+`list-subscriptions`), the escape hatch, and the meta tools
+(`discover-app`, `tail-build`). All eighteen are conformant to the
+canonical table.
 
 This pin is **load-bearing for the impl pass**: when
 `tools/causa-mcp/src/` lands and the catalogue prose migrates from


### PR DESCRIPTION
## Summary

- Updates `tools/causa-mcp/spec/Principles.md` §"Tool verbs follow the cross-MCP convention" to enumerate **18** tools (was 17) and call the streaming band a **triple** (was "pair").
- `list-subscriptions` was added by Lock #12 (rf2-3we2k, 2026-05-14); this section drifted out of step. README.md canonical counts (Inspection 9 / Mutation 3 / Streaming 3 / Escape hatch 1 / Meta 2 = 18) and the NAMING.md Causa-mcp alignment table already carry the eighteen-tool shape — this brings Principles.md into line.
- New enumeration explicitly names the streaming triple (`subscribe`, `unsubscribe`, `list-subscriptions`) and asserts "All eighteen are conformant to the canonical table."

## Scope

Single file, four lines. Historical references to the original "seventeen" (Lock #5's Options considered, the dated lock amendment trail in DESIGN-RATIONALE.md) stay untouched — those are accurate records of prior state.

## Test plan

- [x] `python scripts/check_doc_slugs.py` — 3 pre-existing broken anchors unchanged; no new breakage.
- [x] Manual count: 9 (get-*) + 3 (mutate triple) + 3 (streaming triple) + 1 (eval-cljs) + 2 (meta) = 18.

Closes rf2-wmsjc.