### PR TITLE
refactor(epoch): on-frame-destroyed! — restructure so indentation matches scope (rf2-7ndq5)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -169,6 +169,19 @@
   (when frame-id
     (swap! observed-frames-by-cb update cb-id (fnil conj #{}) frame-id)))
 
+(defn- drop-frame-from-cb-observations
+  "Drop `frame-id` from every cb's observed-frames set in `m`. When a
+  cb's set goes empty as a result, drop the cb entry entirely so the
+  map doesn't accrete keys to empty sets."
+  [m frame-id]
+  (reduce-kv (fn [acc cb-id frames]
+               (let [frames' (disj frames frame-id)]
+                 (if (empty? frames')
+                   (dissoc acc cb-id)
+                   (assoc acc cb-id frames'))))
+             {}
+             m))
+
 (defn- notify-listeners! [record]
   (let [frame-id (:frame record)]
     (doseq [[id f] @listeners]
@@ -205,16 +218,8 @@
       (doseq [cb-id silenced-cbs]
         (trace/emit! :rf.epoch.cb :rf.epoch.cb/silenced-on-frame-destroy
                      {:frame  frame-id
-                      :cb-id  cb-id}))
-      (swap! observed-frames-by-cb
-             (fn [m]
-               (reduce-kv (fn [acc cb-id frames]
-                            (let [frames' (disj frames frame-id)]
-                              (if (empty? frames')
-                                (dissoc acc cb-id)
-                                (assoc acc cb-id frames'))))
-                          {}
-                          m))))
+                      :cb-id  cb-id})))
+    (swap! observed-frames-by-cb drop-frame-from-cb-observations frame-id)
     ;; Drop the per-frame ring buffer; epoch-history returns [] from
     ;; here on. (`reset-frame :app/main` calls destroy-frame! followed
     ;; by reg-frame, so the ring buffer for the new same-keyed frame


### PR DESCRIPTION
## Summary

In `on-frame-destroyed!` (`implementation/epoch/src/re_frame/epoch.cljc`), the parens balanced such that `(swap! histories dissoc frame-id)` sat **inside** the `when` but **outside** the `let` body, while its indentation matched the `(let` keyword's column. A reader scanning the form would think it was inside the `let` body; it wasn't. The indentation lied about scope.

Restructure (option 2 from the bead): close the `let` after its single side-effect (the `doseq` emit-loop), then place both `(swap! observed-frames-by-cb ...)` and `(swap! histories ...)` at `when` body level. Indentation now tells the truth — let body at col 6, when body siblings at col 4.

Lift the `reduce-kv` block into a private helper `drop-frame-from-cb-observations` so the `swap!` call reads as intent (\"drop frame from observations\") rather than as an inline `reduce-kv` mechanism. The helper carries its own docstring explaining the \"drop empty cb entries\" invariant.

Behaviour unchanged.

## Test plan

- [x] `cd implementation/epoch && clojure -M:test` — 62 tests, 244 assertions, 0 failures
- [x] `cd implementation && npm run test:cljs` — 1816 tests, 5040 assertions, 0 failures

Closes rf2-7ndq5.