### PR TITLE
feat(routing): register :rf.route/with-nav-token universal fx (rf2-5kskw)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -276,7 +276,7 @@
                 :fx-args args
                 :frame   frame-id}))
 
-(defn- handle-one-fx
+(defn handle-one-fx
   "Process one [fx-id args] pair. Falls into one of three buckets:
    1. Reserved fx-id with runtime handling (:dispatch, :dispatch-later, :rf.fx/...).
    2. User-registered fx looked up via registrar.
@@ -292,7 +292,14 @@
   `origin-event` (when supplied) is the originating event vector, threaded
   through to the user-registered fx handler's ctx so handlers like
   `:rf.http/managed` (Spec 014 §Reply addressing) can address replies back
-  to the originator without a separate cofx-injection step."
+  to the originator without a separate cofx-injection step.
+
+  Public so that fx wrappers (per Spec 012 §Navigation tokens
+  `:rf.route/with-nav-token`, and any future single-fx re-entry helper)
+  can route a single inner fx entry through the same machinery as the
+  outer walk — without re-emitting the `:event/do-fx` boundary marker
+  that `do-fx` terminates each walk with. `do-fx` remains the entry
+  point for the whole `:fx` vector."
   [frame-id [original-fx-id args] active-platform overrides origin-event]
   (let [fx-id (resolve-fx-with-overrides original-fx-id overrides)
         resolved-meta (resolved-fx-meta original-fx-id fx-id overrides)

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -30,10 +30,16 @@
     :rf.route/navigate                  programmatic
     :rf.route/handle-url-change         pop-state / initial / SSR
     :rf.route/continue / cancel         pending-nav protocol
-    :rf.test/simulate-http-resolution   test-only nav-token check"
+    :rf.test/simulate-http-resolution   test-only nav-token check
+
+  Effects:
+    :rf.nav/push-url    :rf.nav/replace-url    :rf.nav/scroll
+    :rf.route/with-nav-token            stale-result suppression wrapper"
   (:require [re-frame.registrar :as registrar]
             [re-frame.events :as events]
+            [re-frame.frame :as frame]
             [re-frame.fx :as fx]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.router :as router]
             [re-frame.source-coords :as source-coords]
@@ -900,6 +906,91 @@
     #?(:cljs (.replaceState js/window.history nil "" url)
        :clj  (trace/emit! :fx :rf.fx/skipped-on-platform
                           {:fx-id :rf.nav/replace-url :url url}))))
+
+;; ---- :rf.route/with-nav-token --------------------------------------------
+;;
+;; Per Spec 012 §Navigation tokens §Threading and §Trace events, and the
+;; `:rf.fx/with-nav-token-args` schema in Spec-Schemas.md. The fx wraps an
+;; async-completion fx entry (`:do`) with a stale-result check: at fire
+;; time, the carried `:nav-token` is compared against the current
+;; `:rf/route :nav-token` in app-db; on match, the inner fx entry is
+;; dispatched through the regular fx machinery (so `:dispatch`,
+;; `:dispatch-later`, `:rf.http/managed`, etc all flow through); on
+;; mismatch, the inner fx is suppressed and the runtime emits
+;; `:rf.route.nav-token/stale-suppressed` with the canonical tags
+;; (`:carried-token`, `:current-token`, `:event-id`) — the handler does
+;; NOT run (no `:db` write, no `:fx`, no transition).
+;;
+;; This is the production-grade staleness-suppression path; the
+;; `:rf.test/simulate-http-resolution` event above is its test-only
+;; conformance-fixture stand-in (used where the fixture DSL can't
+;; emit an effect-map of its own).
+
+(defn- inner-fx-event-id
+  "Best-effort extraction of an `event-id` from an `:do` fx entry. For
+  the canonical `[:dispatch [<event-id> args...]]` shape the event-id is
+  the head of the inner vector; for any other fx entry we fall back to
+  the outer fx-id (e.g. `:rf.http/managed`) so the `:event-id` tag still
+  identifies what was suppressed."
+  [do-entry]
+  (when (vector? do-entry)
+    (let [[fx-id args] do-entry]
+      (cond
+        (and (= :dispatch fx-id) (vector? args) (seq args))
+        (first args)
+
+        :else
+        fx-id))))
+
+(fx/reg-fx :rf.route/with-nav-token
+  {:doc  "Per Spec 012 §Navigation tokens. Threads the carried
+`:nav-token` against the current `:rf/route :nav-token`. Match → run
+`:do` (any fx entry); mismatch → suppress and emit
+`:rf.route.nav-token/stale-suppressed`."
+   ;; Inline Malli schema per Spec-Schemas.md §`:rf.fx/with-nav-token-args`.
+   ;; Inline rather than a registered schema-id so validation works in
+   ;; consumers that don't pre-register the keyword in their Malli
+   ;; registry; the registered-id form remains available to apps that
+   ;; want to centralise schemas (per Spec 010 §Schema registration).
+   :spec [:map
+          [:do        [:vector :any]]
+          [:nav-token :any]]}
+  (fn [{:keys [frame] :as _ctx} args]
+    ;; Destructure `:do` via `get` rather than `:keys` so the binding name
+    ;; doesn't shadow `clojure.core/do` inside the body. Per Spec 012
+    ;; §Threading the `:do` slot is the wrapped fx entry to perform.
+    (let [do-entry        (get args :do)
+          nav-token       (get args :nav-token)
+          frame-id        (or frame :rf/default)
+          frame-record    (frame/frame frame-id)
+          db              (frame/frame-app-db-value frame-id)
+          current         (get-in db [:rf/route :nav-token])]
+      (cond
+        (= nav-token current)
+        ;; Token matches — route the inner fx entry through
+        ;; `fx/handle-one-fx`. Routing it through the same machinery means
+        ;; `:dispatch`, `:dispatch-later`, `:rf.http/managed`, et al. all
+        ;; work uniformly. `handle-one-fx` rather than `do-fx` so the
+        ;; cascade's single `:event/do-fx` boundary marker stays on the
+        ;; outer walk (the inner re-entry must not double-emit it — the
+        ;; epoch projection's six-domino bucketing keys off that marker
+        ;; per `trace/projection.cljc`). The active-platform resolution
+        ;; mirrors `router/run-fx-effects!` so a server-only or
+        ;; client-only inner fx skips with the standard
+        ;; `:rf.fx/skipped-on-platform` trace.
+        (let [active-platform (or (get-in frame-record [:config :platform])
+                                  interop/platform)]
+          (fx/handle-one-fx frame-id do-entry active-platform {} nil))
+
+        :else
+        ;; Stale — suppress. Same trace shape as
+        ;; `:rf.test/simulate-http-resolution` so a single conformance
+        ;; assertion covers both production and test paths.
+        (trace/emit-error! :rf.route.nav-token/stale-suppressed
+                           {:carried-token nav-token
+                            :current-token current
+                            :event-id      (inner-fx-event-id do-entry)
+                            :recovery      :replaced-with-default})))))
 
 (fx/reg-fx :rf.nav/scroll
   {:platforms #{:client}

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -206,6 +206,91 @@
                 @traces)
           "expected :rf.route.nav-token/stale-suppressed trace for the A response"))))
 
+(deftest with-nav-token-fx-suppresses-stale-do-and-commits-fresh
+  (testing ":rf.route/with-nav-token fx: stale `:do` is suppressed; fresh `:do` runs"
+    ;; Per Spec 012 §Navigation tokens §Threading: a user event handler
+    ;; emits an `:fx` entry of the form
+    ;;
+    ;;   [:rf.route/with-nav-token {:do        [:dispatch [<ev> args...]]
+    ;;                              :nav-token <captured-token>}]
+    ;;
+    ;; …and the runtime threads the carried token against the current
+    ;; `:rf/route :nav-token`. Match → the inner fx runs (canonically a
+    ;; `:dispatch` to the success continuation). Mismatch → the inner fx
+    ;; is suppressed and `:rf.route.nav-token/stale-suppressed` emits.
+    ;;
+    ;; This test pins both branches via the production fx (no use of
+    ;; the test-only `:rf.test/simulate-http-resolution` event). The
+    ;; `:article/loaded` continuation is the user-facing handler the
+    ;; wrapped dispatch would commit through; we observe it via the
+    ;; resulting app-db slice.
+    (rf/reg-route :route/article {:path   "/articles/:id"
+                                  :params [:map [:id :string]]})
+    (rf/reg-event-db :article/loaded
+                     (fn [db [_ id payload]]
+                       (assoc db :article {:id id :payload payload})))
+    ;; Bridge event: a real :on-success handler. Carries the token it
+    ;; captured at request time and re-emits an `:rf.route/with-nav-token`
+    ;; fx entry. The runtime then either dispatches `[:article/loaded ...]`
+    ;; (match) or suppresses (mismatch).
+    (rf/reg-event-fx :article/loaded-via-nav-token
+                     (fn [_ctx [_ {:keys [carried-token id payload]}]]
+                       {:fx [[:rf.route/with-nav-token
+                              {:do        [:dispatch [:article/loaded id payload]]
+                               :nav-token carried-token}]]}))
+
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::with-nav-token-fx
+                             (fn [ev] (swap! traces conj ev)))
+
+      ;; 1. Land on :route/article id="A" — nav-token allocates to "nav-1".
+      (rf/dispatch-sync [:rf/url-changed "/articles/A"])
+      (is (= "nav-1" (get-in (rf/get-frame-db :rf/default)
+                             [:rf/route :nav-token]))
+          "first navigation got nav-1")
+
+      ;; 2. Before A's async :on-success lands, navigate to id="B" — "nav-2".
+      (rf/dispatch-sync [:rf/url-changed "/articles/B"])
+      (is (= "nav-2" (get-in (rf/get-frame-db :rf/default)
+                             [:rf/route :nav-token]))
+          "second navigation advanced the epoch to nav-2")
+
+      ;; 3. A's stale :on-success arrives carrying "nav-1" via the fx
+      ;; wrapper. Current is "nav-2"; the inner :dispatch must be
+      ;; suppressed and the trace must fire.
+      (rf/dispatch-sync [:article/loaded-via-nav-token
+                         {:carried-token "nav-1"
+                          :id            "A"
+                          :payload       "A-payload"}])
+
+      ;; 4. B's fresh :on-success arrives carrying "nav-2"; matches
+      ;; current; inner :dispatch fires; :article/loaded commits.
+      (rf/dispatch-sync [:article/loaded-via-nav-token
+                         {:carried-token "nav-2"
+                          :id            "B"
+                          :payload       "B-payload"}])
+
+      (rf/remove-trace-cb! ::with-nav-token-fx)
+
+      (is (= {:id "B" :payload "B-payload"}
+             (:article (rf/get-frame-db :rf/default)))
+          "fresh :do ran end-to-end; stale :do was suppressed before commit")
+
+      (is (some (fn [ev]
+                  (and (= :rf.route.nav-token/stale-suppressed (:operation ev))
+                       (= "nav-1" (-> ev :tags :carried-token))
+                       (= "nav-2" (-> ev :tags :current-token))
+                       (= :article/loaded (-> ev :tags :event-id))))
+                @traces)
+          "stale :do produced :rf.route.nav-token/stale-suppressed with the inner dispatch's event-id")
+
+      ;; Negative: no spurious suppressed-trace for the fresh path.
+      (is (= 1 (count (filter (fn [ev]
+                                (= :rf.route.nav-token/stale-suppressed
+                                   (:operation ev)))
+                              @traces)))
+          "exactly one stale-suppressed trace fired — the fresh :do did NOT trip the validation"))))
+
 ;; ---- Spec 012 §Scroll restoration -----------------------------------------
 
 (deftest routing-scroll-metadata-preserved


### PR DESCRIPTION
## Summary

Registers `:rf.route/with-nav-token` as a universal-platform fx, closing the gap between Spec 012 §Navigation tokens (which documents the wrapper as canonical) and the implementation (which shipped only the test-only `:rf.test/simulate-http-resolution` event). Users were left to hand-roll the staleness compare from app-db — defeating the contract.

## Contract

`{:fx [[:rf.route/with-nav-token {:do <fx-entry> :nav-token <captured>}]]}`

- **Match** (carried `:nav-token` equals `:rf/route :nav-token`) — routes the inner fx entry through `fx/handle-one-fx`, so `:dispatch`, `:dispatch-later`, `:rf.http/managed`, etc. all flow through the same machinery; per-frame fx-overrides still apply.
- **Mismatch** — emits `:rf.route.nav-token/stale-suppressed` with the canonical `{:carried-token :current-token :event-id}` tags; the inner fx does NOT run (no `:db` write, no `:fx`, no transition).

`event-id` is best-effort extracted: `[:dispatch [ev args...]]` → `ev`; any other fx entry → the outer fx-id (e.g. `:rf.http/managed`), so the trace still identifies what was suppressed.

## Implementation notes

- `re-frame.fx/handle-one-fx` promoted from `defn-` → `defn`. The inner re-entry MUST NOT call `do-fx` because `do-fx` terminates each walk with `:event/do-fx` — the epoch projection's six-domino bucketing keys off that marker (per `trace/projection.cljc`); a duplicate emission would corrupt cascade records.
- Inline Malli `:spec` on the fx meta (`:rf.fx/with-nav-token-args` shape) so validation works in consumers that don't pre-register the schema id.
- Active-platform resolution inside the fx mirrors `router/run-fx-effects!` (frame's `[:config :platform]` override → `interop/platform`), so a server-only / client-only inner fx skips with the standard `:rf.fx/skipped-on-platform` trace.

## Test plan

- [x] `clojure -M:test` under `implementation/routing` — 38 tests / 141 assertions, all green (added `with-nav-token-fx-suppresses-stale-do-and-commits-fresh`)
- [x] `npm run test:cljs` — 1816 tests / 5040 assertions, all green
- [x] `clojure -M:test` under `implementation/core` — 456 tests / 2439 assertions, all green (covers `handle-one-fx` promotion)
- [x] `clojure -M:test` under `implementation/machines`, `http`, `ssr` — all green

Closes rf2-5kskw.