### PR TITLE
refactor(epoch): collapse double-walk on restore failure path (rf2-081zk)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -739,9 +739,11 @@
 
           :else
           (let [db-target (:db-after epoch)]
-            (cond
+            ;; Each helper is called once and its result bound, so the
+            ;; failure path walks the recorded db / schema set / machine
+            ;; map exactly once per check (rf2-081zk).
+            (if-let [failing-paths (seq (failing-paths-for frame-id db-target))]
               ;; (4) Schema mismatch?
-              (not (schema-validate-ok? frame-id db-target))
               ;; Per Spec 010 §Schema digest + Tool-Pair §Time-travel:
               ;; the trace carries both the digest pinned on the
               ;; epoch record (recorded) and the current frame's
@@ -753,27 +755,25 @@
                 :epoch-id               epoch-id
                 :schema-digest-recorded (:schema-digest epoch)
                 :schema-digest-current  (current-schema-digest frame-id)
-                :failing-paths          (failing-paths-for frame-id db-target)}]
+                :failing-paths          (vec failing-paths)}]
 
-              ;; (5) Missing handler referenced from db?
-              (seq (missing-references db-target))
-              [:fail :rf.epoch/restore-missing-handler
-               {:frame    frame-id
-                :epoch-id epoch-id
-                :missing  (missing-references db-target)}]
+              (if-let [missing (seq (missing-references db-target))]
+                ;; (5) Missing handler referenced from db?
+                [:fail :rf.epoch/restore-missing-handler
+                 {:frame    frame-id
+                  :epoch-id epoch-id
+                  :missing  (vec missing)}]
 
-              ;; (6) Machine snapshot version drift?
-              (some? (machine-version-mismatch db-target))
-              (let [{:keys [machine-id recorded current]} (machine-version-mismatch db-target)]
-                [:fail :rf.epoch/restore-version-mismatch
-                 {:frame            frame-id
-                  :epoch-id         epoch-id
-                  :machine-id       machine-id
-                  :version-recorded recorded
-                  :version-current  current}])
+                (if-let [{:keys [machine-id recorded current]} (machine-version-mismatch db-target)]
+                  ;; (6) Machine snapshot version drift?
+                  [:fail :rf.epoch/restore-version-mismatch
+                   {:frame            frame-id
+                    :epoch-id         epoch-id
+                    :machine-id       machine-id
+                    :version-recorded recorded
+                    :version-current  current}]
 
-              :else
-              [:ok epoch])))))))
+                  [:ok epoch])))))))))
 
 (defn- perform-restore!
   "Carry out the actual `app-db` rewind once preconditions have passed.


### PR DESCRIPTION
## Summary

- `check-restore-preconditions!` (`implementation/epoch/src/re_frame/epoch.cljc`) called three helpers twice on the failure path — once to test, once to extract data for the failure tags. Each helper walks the recorded db, the schema set, or the machine map; the duplicate walk was pure waste.
- Restructure the inner `cond` as a chain of `if-let` so each helper is called once and its result bound. Wire shapes are byte-identical (`:failing-paths` / `:missing` / `:machine-id` etc.).

Walks per failure path:

| check                       | before | after |
| --------------------------- | ------ | ----- |
| `failing-paths-for`         | 2      | 1     |
| `missing-references`        | 2      | 1     |
| `machine-version-mismatch`  | 2      | 1     |

LoC delta: ±23 / ±23 (same line count, restructured).

Closes rf2-081zk.

## Test plan

- [x] `clojure -M:test` in `implementation/epoch/` — 63 tests, 249 assertions, 0 failures
- [x] `npm run test:cljs` in `implementation/` — 1816 tests, 5040 assertions, 0 failures