### PR TITLE
refactor(mcp-base): lift apply-cap pipeline (rf2-eyelu)

### DIFF
--- a/tools/mcp-base/spec/README.md
+++ b/tools/mcp-base/spec/README.md
@@ -20,9 +20,11 @@ Five small namespaces under `re-frame.mcp-base.*`:
 |--------------|----------------------------------------------------------------|
 | `vocab`      | `:rf.mcp/*` / `:rf.size/*` marker keys + JSON-RPC error codes.  |
 | `sensitive`  | spec/009 §Privacy default-suppress filter (`sensitive-event?`, `strip-sensitive`, `scrub-snapshot`). |
+| `elision`    | Wire-boundary `:rf.size/large-elided` walker (`count-elided-markers`, rf2-9fz64). |
 | `args`       | Argument coercion helpers (`parse-boolean`, `parse-positive-int`, `parse-keyword`, `parse-mode`, …). |
 | `diff-encode` | Path-keyed structural diff for epoch records (rf2-1wdzp).      |
 | `overflow`   | Overflow-marker payload builder (rf2-rvyzy).                   |
+| `cap`        | Wire-boundary token-budget cap pipeline + `ResultIO` protocol (rf2-eyelu). |
 
 All `.cljc`, so consumers compile them under their own platform —
 pair2-mcp's shadow-cljs node build, story-mcp / causa-mcp's JVM

--- a/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
@@ -1,0 +1,192 @@
+(ns re-frame.mcp-base.cap
+  "Wire-boundary token-budget cap pipeline (rf2-rvyzy / rf2-eyelu).
+
+  Per `spec/Principles.md` §\"Tight token budget per response\", every
+  MCP `tools/call` response is bounded at ~5,000 tokens by default. When
+  the serialised response would exceed the cap, the wrapper replaces the
+  payload with a structured `{:rf.mcp/overflow {...}}` marker and emits
+  that instead. Silent truncation is unacceptable — it corrupts the
+  agent's conversation without telling the agent.
+
+  ## What this ns owns
+
+  `re-frame.mcp-base.overflow` owns the SHAPE of the overflow marker
+  (the `{:rf.mcp/overflow {:limit :reached :token-count … :cap-tokens
+  … :tool … :hint …}}` map). This ns owns the ALGORITHM that drives the
+  marker into a result:
+
+  1. Sum the cumulative `token-estimate` across every `:text` slot in
+     the result's `:content` vector.
+  2. Compare against the per-call cap (`:max-tokens` MCP arg, default
+     `overflow/default-max-tokens`, `0` disables).
+  3. Under-budget responses pass through unchanged; over-budget
+     responses are replaced with a fresh result carrying the marker.
+
+  Until rf2-eyelu this pipeline was duplicated near-identically in
+  pair2-mcp (CLJS, `#js {:content #js [...]}`-shaped results) and
+  story-mcp (CLJ, `{:content [...] :structuredContent ...}`-shaped
+  results). The only structural difference between the two
+  implementations was the SHAPE of the result map and the platform-
+  appropriate accessor used to read its `:text` slots. The algorithm
+  itself was a single design.
+
+  ## Per-server specialisation hook — the `ResultIO` protocol
+
+  Each consumer reifies `ResultIO` with two methods:
+
+  - `(content-texts io result)` ⇒ seq of strings, the `:text`-slot
+    values inside `result`'s content vector. The platform-specific
+    accessor (`:text` / `j/get :text`) lives behind this method.
+  - `(build-overflow-result io marker original-result)` ⇒ a fresh
+    result, shaped per the consumer's wire convention, carrying
+    `marker` as its sole content payload.
+
+  The hint table (`{tool-name hint-string}`) stays consumer-side — the
+  per-tool next-step prose is domain-specific. The cap value, token
+  rule, and marker shape are cross-MCP conventions and stay here.
+
+  ## Pluggable strategy
+
+  Today only `:truncate-with-marker` is wired — drop the payload, emit
+  the overflow marker. Future strategies (path-slicing rf2-tygdv, lazy
+  summary rf2-u2029, diff encoding rf2-rl7y) compose here without
+  rebuilding the per-consumer wrapper. Unknown strategies degrade
+  safely to `:truncate-with-marker` rather than throwing — the
+  wire-egress posture is to ALWAYS bound the response, never to ship
+  the over-budget payload.
+
+  ## Cross-platform
+
+  Pure CLJC. The `ResultIO` protocol resolves identically into the
+  JVM (story-mcp / causa-mcp) and CLJS (pair2-mcp) — `defprotocol`
+  reads the same way on both sides. mcp-base stays free of
+  platform-specific deps (`js-interop`, JVM reflection, etc); those
+  live in the consumer's IO instance."
+  (:require [re-frame.mcp-base.overflow :as overflow]))
+
+;; ---------------------------------------------------------------------------
+;; ResultIO — the per-server specialisation hook.
+;; ---------------------------------------------------------------------------
+
+(defprotocol ResultIO
+  "Per-consumer accessors over the MCP `tools/call` result shape. Each
+  MCP server (pair2-mcp, story-mcp, causa-mcp) reifies this protocol
+  once over its native result shape — `#js {:content #js [...]}` for
+  pair2-mcp's npm-SDK JS objects, `{:content [...]}` CLJ maps for
+  story-mcp / causa-mcp. The cap pipeline is then algorithm-only and
+  shape-agnostic."
+
+  (content-texts [_io result]
+    "Return a seq of strings, the `:text`-slot values from every entry
+    in `result`'s content vector. Non-string `:text` slots and entries
+    without a `:text` slot are skipped. Implementations stay nil-safe:
+    a nil `result` or empty content yields an empty seq.")
+
+  (build-overflow-result [_io marker original-result]
+    "Build a fresh result of the consumer's native shape carrying
+    `marker` as its sole content payload. `marker` is the
+    `{:rf.mcp/overflow {...}}` map built by
+    `overflow/overflow-payload`. `original-result` is provided for
+    implementations that need to preserve sibling slots (e.g.
+    `:isError` flags); the default-shape consumer ignores it. The
+    returned result MUST itself be under any reasonable cap — the
+    marker is a small fixed-shape payload, so this falls out
+    naturally."))
+
+;; ---------------------------------------------------------------------------
+;; max-tokens — per-call cap resolver.
+;; ---------------------------------------------------------------------------
+
+(defn max-tokens
+  "Resolve the per-call cap from an ALREADY-EXTRACTED raw value.
+  Returns the integer cap in tokens, `nil` when the cap is disabled
+  (caller passed `0`), or `overflow/default-max-tokens` when absent or
+  not a number.
+
+  Each consumer extracts the raw value from its platform-specific args
+  object — pair2-mcp uses `(j/get args \"max-tokens\")` against a JS
+  object; story-mcp uses `(get args :max-tokens)` against a CLJ map —
+  and feeds the result here. The coercion rules (zero disables,
+  non-number falls back to default) are the cross-MCP convention.
+
+  ## Disambiguation
+
+  - `nil` return ⇒ caller disabled the cap (`max-tokens 0`).
+    `apply-cap` skips enforcement entirely.
+  - `default-max-tokens` (5000) return ⇒ caller didn't supply a value
+    OR supplied an unrecognised value. The default applies.
+  - positive integer return ⇒ caller supplied a custom cap."
+  [raw]
+  (cond
+    (nil? raw)                       overflow/default-max-tokens
+    (and (number? raw) (zero? raw))  nil
+    (number? raw)                    (long raw)
+    :else                            overflow/default-max-tokens))
+
+;; ---------------------------------------------------------------------------
+;; sum-text-tokens — cumulative token count across the result's :text slots.
+;; ---------------------------------------------------------------------------
+
+(defn sum-text-tokens
+  "Sum `overflow/token-estimate` across every `:text` slot in `result`'s
+  content vector, accessed via `io`. The serialised response's wire size
+  is dominated by these slots; the JSON envelope is bounded and ignored.
+
+  Multi-part responses share one cumulative budget rather than per-key
+  — a single oversize slot or an aggregate of many small slots both
+  trip the cap."
+  [io result]
+  (transduce (comp (filter string?)
+                   (map overflow/token-estimate))
+             +
+             0
+             (content-texts io result)))
+
+;; ---------------------------------------------------------------------------
+;; apply-cap — the wire-boundary enforcement entry point.
+;; ---------------------------------------------------------------------------
+
+(defn apply-cap
+  "Wire-boundary cap enforcement. Returns either `result` unchanged
+  (when under the cap or cap disabled via `:max-tokens 0`) or a fresh
+  result carrying the overflow marker, built via
+  `build-overflow-result` against `io`.
+
+  `opts` keys:
+
+    :tool     — string tool name carried in the marker for the agent's
+                pattern match.
+    :cap      — integer cap in tokens, or `nil` to disable. Usually the
+                output of `max-tokens` against the consumer's
+                `:max-tokens` arg.
+    :hint     — string next-step hint embedded in the marker. The
+                consumer's per-tool hint table resolves this from
+                `tool`; absent ⇒ `overflow/overflow-hint-fallback`.
+    :strategy — `:truncate-with-marker` (default; today the only
+                wired option). Unknown values degrade safely to the
+                default — never throw, never ship the over-budget
+                payload.
+
+  Future strategies (path-slicing, lazy summary, diff encoding) slot
+  in here without touching the per-consumer wrapper or per-tool
+  handler."
+  [io result {:keys [tool cap hint strategy]
+              :or   {strategy :truncate-with-marker}}]
+  (cond
+    (nil? cap)    result
+    (nil? result) result
+    :else
+    (let [tokens (sum-text-tokens io result)]
+      (if (<= tokens cap)
+        result
+        (let [marker (overflow/overflow-payload
+                       {:tool        tool
+                        :token-count tokens
+                        :cap         cap
+                        :hint        hint})]
+          ;; Unknown strategy: degrade safely to truncate-with-marker.
+          ;; The pluggable shape is preserved so a future strategy can
+          ;; branch here without touching consumers.
+          (case strategy
+            :truncate-with-marker (build-overflow-result io marker result)
+            (build-overflow-result io marker result)))))))

--- a/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
@@ -1,0 +1,160 @@
+(ns re-frame.mcp-base.cap-test
+  "Unit tests for the cross-MCP cap pipeline (rf2-eyelu).
+
+  Exercises the algorithm via a mock `ResultIO` reifying the protocol
+  over CLJ maps. The per-server IO instances (pair2-mcp's JS-object
+  reify, story-mcp's CLJ-map reify) are exercised against the real
+  pipeline in their respective test suites; the unit tests here pin
+  the algorithm itself."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.mcp-base.cap :as cap]
+            [re-frame.mcp-base.overflow :as overflow]
+            [re-frame.mcp-base.vocab :as vocab]))
+
+;; ---------------------------------------------------------------------------
+;; Mock ResultIO — CLJ-map shape, mirrors story-mcp's runtime instance.
+;; ---------------------------------------------------------------------------
+
+(def map-io
+  "ResultIO over `{:content [{:type \"text\" :text \"...\"} ...]}` maps.
+  Mirrors story-mcp's runtime instance; story-mcp's tests exercise the
+  full registry-backed pipeline."
+  (reify cap/ResultIO
+    (content-texts [_ result]
+      (map :text (:content result)))
+    (build-overflow-result [_ marker _original]
+      {:content          [{:type "text" :text (pr-str marker)}]
+       :structuredContent marker})))
+
+(defn- ok-text-result [v]
+  {:content [{:type "text" :text (pr-str v)}]})
+
+(defn- big-string [n]
+  (apply str (repeat n "x")))
+
+;; ---------------------------------------------------------------------------
+;; max-tokens — per-call cap resolution.
+;; ---------------------------------------------------------------------------
+
+(deftest max-tokens-default-when-nil
+  (is (= overflow/default-max-tokens (cap/max-tokens nil))))
+
+(deftest max-tokens-zero-disables-cap
+  (is (nil? (cap/max-tokens 0))))
+
+(deftest max-tokens-positive-integer-passed-through
+  (is (= 1000 (cap/max-tokens 1000)))
+  (is (= 50000 (cap/max-tokens 50000))))
+
+(deftest max-tokens-non-number-falls-back-to-default
+  (is (= overflow/default-max-tokens (cap/max-tokens "bogus")))
+  (is (= overflow/default-max-tokens (cap/max-tokens :not-a-number)))
+  (is (= overflow/default-max-tokens (cap/max-tokens [1 2 3]))))
+
+(deftest max-tokens-coerces-double-to-long
+  (is (= 1000 (cap/max-tokens 1000.0)))
+  (is (integer? (cap/max-tokens 1000.0))))
+
+;; ---------------------------------------------------------------------------
+;; sum-text-tokens — sums every :text slot via ResultIO.
+;; ---------------------------------------------------------------------------
+
+(deftest sum-text-tokens-single-slot
+  (let [r (ok-text-result {:hello "world"})]
+    (is (pos? (cap/sum-text-tokens map-io r)))
+    (is (= (overflow/token-estimate (pr-str {:hello "world"}))
+           (cap/sum-text-tokens map-io r)))))
+
+(deftest sum-text-tokens-empty-content-is-zero
+  (is (zero? (cap/sum-text-tokens map-io {:content []})))
+  (is (zero? (cap/sum-text-tokens map-io {:content nil}))))
+
+(deftest sum-text-tokens-aggregates-across-slots
+  (let [r {:content [{:type "text" :text (big-string 4000)}
+                     {:type "text" :text (big-string 4000)}]}]
+    (is (= 2000 (cap/sum-text-tokens map-io r)))))
+
+(deftest sum-text-tokens-skips-non-string-slots
+  (let [r {:content [{:type "text" :text (big-string 4000)}
+                     {:type "image"}
+                     {:type "text"}]}]
+    (is (= 1000 (cap/sum-text-tokens map-io r)))))
+
+;; ---------------------------------------------------------------------------
+;; apply-cap — the strategy entry point.
+;; ---------------------------------------------------------------------------
+
+(deftest apply-cap-passes-under-budget-payload-untouched
+  (let [r   (ok-text-result {:small :payload})
+        out (cap/apply-cap map-io r {:tool "snapshot" :cap overflow/default-max-tokens})]
+    (is (identical? r out))))
+
+(deftest apply-cap-nil-cap-disables-enforcement
+  (let [r   (ok-text-result {:k (big-string 100000)})
+        out (cap/apply-cap map-io r {:tool "snapshot" :cap nil})]
+    (is (identical? r out))))
+
+(deftest apply-cap-nil-result-passes-through
+  (is (nil? (cap/apply-cap map-io nil {:tool "snapshot" :cap 5000}))))
+
+(deftest apply-cap-over-budget-emits-overflow-marker
+  (let [big (big-string 4000)
+        r   (ok-text-result {:huge big})
+        out (cap/apply-cap map-io r {:tool "snapshot" :cap 500 :hint "narrow scope"})
+        marker (:structuredContent out)
+        body   (get marker vocab/overflow-key)]
+    (is (contains? marker vocab/overflow-key))
+    (is (= :reached (:limit body)))
+    (is (= "snapshot" (:tool body)))
+    (is (= 500 (:cap-tokens body)))
+    (is (pos? (:token-count body)))
+    (is (> (:token-count body) 500))
+    (is (= "narrow scope" (:hint body)))))
+
+(deftest apply-cap-overflow-payload-is-itself-under-cap
+  (let [big (big-string 8000)
+        r   (ok-text-result {:huge big})
+        out (cap/apply-cap map-io r {:tool "snapshot" :cap 500})]
+    (is (<= (cap/sum-text-tokens map-io out) 500)
+        "The overflow marker itself must be under the cap")))
+
+(deftest apply-cap-absent-hint-uses-fallback
+  (let [big (big-string 8000)
+        r   (ok-text-result {:huge big})
+        out (cap/apply-cap map-io r {:tool "no-such-tool" :cap 500})
+        body (get-in out [:structuredContent vocab/overflow-key])]
+    (is (= overflow/overflow-hint-fallback (:hint body)))))
+
+(deftest apply-cap-unknown-strategy-degrades-safely
+  ;; Unknown strategy must NOT throw and must NOT ship the over-budget
+  ;; payload. It falls back to truncate-with-marker.
+  (let [big (big-string 8000)
+        r   (ok-text-result {:huge big})
+        out (cap/apply-cap map-io r {:tool "snapshot"
+                                     :cap 500
+                                     :strategy :unknown-strategy})
+        marker (:structuredContent out)]
+    (is (contains? marker vocab/overflow-key))
+    (is (= :reached (get-in marker [vocab/overflow-key :limit])))))
+
+(deftest apply-cap-at-cap-exact-boundary-passes
+  ;; <= cap passes; only > cap trips. Boundary check pins inclusive-low.
+  (let [s    (big-string 400)
+        r    (ok-text-result s)
+        toks (cap/sum-text-tokens map-io r)
+        out  (cap/apply-cap map-io r {:tool "snapshot" :cap toks})]
+    (is (identical? r out))))
+
+(deftest apply-cap-uses-result-io-build-fn
+  ;; Verify the build-overflow-result hook is what produces the new
+  ;; result — a custom IO can shape the result however it likes.
+  (let [marker-only-io (reify cap/ResultIO
+                         (content-texts [_ result] (map :text (:content result)))
+                         (build-overflow-result [_ marker _]
+                           {::custom-shape true :marker marker}))
+        big (big-string 8000)
+        r   (ok-text-result {:huge big})
+        out (cap/apply-cap marker-only-io r {:tool "snapshot" :cap 500})]
+    (is (true? (::custom-shape out))
+        "build-overflow-result is the sole producer of the over-cap shape")
+    (is (contains? (:marker out) vocab/overflow-key))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/cap.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/cap.cljs
@@ -1,5 +1,5 @@
 (ns re-frame-pair2-mcp.tools.cap
-  "Wire-boundary token-budget cap (rf2-rvyzy).
+  "Wire-boundary token-budget cap (rf2-rvyzy / rf2-eyelu).
 
   Per `spec/Principles.md` §\"Tight token budget per response\", every
   MCP `tools/call` response is bounded at ~5,000 tokens by default.
@@ -8,6 +8,21 @@
   a structured `{:rf.mcp/overflow {...}}` marker and emits that
   instead. Silent truncation is unacceptable — it corrupts the agent's
   conversation without telling the agent.
+
+  ## Pipeline ownership
+
+  The cap-enforcement ALGORITHM lives in `re-frame.mcp-base.cap`
+  (rf2-eyelu) — token-summing across `:text` slots, comparing against
+  the per-call cap, and building the overflow result. This ns supplies
+  the per-server specialisation:
+
+  - `result-io` reifies `mcp-base.cap/ResultIO` over pair2-mcp's
+    `#js {:content #js [...]}` shape (JS-native, npm MCP SDK).
+  - `overflow-hints` is the local hint table — the per-tool next-step
+    prose stays here because the surfaces are domain-specific.
+  - `max-tokens-arg` is the JS-side adapter that lifts the
+    `\"max-tokens\"` slot off the args object before delegating to the
+    base resolver.
 
   Design notes:
 
@@ -21,16 +36,18 @@
   - **Per-call override**: every tool accepts a `max-tokens` arg —
     integer cap, `0` disables (escape hatch for callers that have
     already paginated). Default `5000`.
-  - **Pluggable strategy**: `apply-cap` dispatches on a strategy
-    keyword. Today only `:truncate-with-marker` is implemented —
-    replace the payload with the overflow marker. Future strategies
-    (path-slicing rf2-tygdv, lazy summary rf2-u2029, diff encoding
-    rf2-rl7y, etc.) compose here without rebuilding the wrapper.
+  - **Pluggable strategy**: `base-cap/apply-cap` dispatches on a
+    strategy keyword. Today only `:truncate-with-marker` is
+    implemented — replace the payload with the overflow marker.
+    Future strategies (path-slicing rf2-tygdv, lazy summary
+    rf2-u2029, diff encoding rf2-rl7y, etc.) compose in the base
+    without rebuilding the wrapper here.
   - **Centralised**: applied as the final step in `invoke`. Per-tool
     functions are untouched; they emit the same shapes they always
     did. The wire-cap is a property of the egress boundary, not of
     each tool's internals."
   (:require [applied-science.js-interop :as j]
+            [re-frame.mcp-base.cap :as base-cap]
             [re-frame.mcp-base.overflow :as base-overflow]))
 
 ;; `default-max-tokens` and `token-estimate` come from
@@ -47,14 +64,14 @@
 (defn max-tokens-arg
   "Resolve the per-call cap from MCP args. Returns the integer cap in
   tokens, or `nil` when the cap is disabled (caller passed `0`).
-  Defaults to `default-max-tokens` when absent or not a number."
+  Defaults to `default-max-tokens` when absent or not a number.
+
+  Reads the JS-side `\"max-tokens\"` slot off the args object, then
+  delegates the coercion to `base-cap/max-tokens` (the cross-MCP
+  resolver)."
   [args]
   (let [raw (when args (j/get args "max-tokens"))]
-    (cond
-      (or (nil? raw) (undefined? raw)) default-max-tokens
-      (and (number? raw) (zero? raw))  nil
-      (number? raw)                    (long raw)
-      :else                            default-max-tokens)))
+    (base-cap/max-tokens (when (and (not (undefined? raw)) (some? raw)) raw))))
 
 (def overflow-hints
   "Tool-specific next-step hints for the overflow marker. Generic
@@ -73,68 +90,53 @@
 ;; touching the every-call-site `get overflow-hints` usage.
 (def overflow-hint-fallback base-overflow/overflow-hint-fallback)
 
-(defn overflow-payload
-  "Build the structured overflow marker. Shape lives in
-  `re-frame.mcp-base.overflow/overflow-payload` (rf2-vw4sq); per-tool
-  hint table stays local."
-  [{:keys [tool token-count cap]}]
-  (base-overflow/overflow-payload
-    {:tool        tool
-     :token-count token-count
-     :cap         cap
-     :hint        (get overflow-hints tool overflow-hint-fallback)}))
+(def ^:private result-io
+  "ResultIO reify over pair2-mcp's `#js {:content #js [...]}` shape
+  (npm MCP SDK). Reads `:text` slots via `js-interop` and builds the
+  overflow result with the same JS shape so the SDK can serialise it
+  as a `tools/call` reply unchanged."
+  (reify base-cap/ResultIO
+    (content-texts [_ result]
+      (let [content (j/get result :content)
+            n       (if (array? content) (.-length content) 0)]
+        ;; Lazy seq over the JS array's :text slots. `apply-cap`
+        ;; transduces with a `(filter string?)` upstream, so any
+        ;; missing slot passes through as nil and is dropped.
+        (loop [i 0 acc (transient [])]
+          (if (< i n)
+            (let [item (aget content i)
+                  text (when item (j/get item :text))]
+              (recur (inc i) (conj! acc text)))
+            (persistent! acc)))))
+    (build-overflow-result [_ marker _original]
+      #js {:content #js [#js {:type "text"
+                              :text (pr-str marker)}]})))
 
 (defn sum-text-tokens
   "Sum `token-estimate` across every `:text` slot in the MCP
   `{:content [{:type \"text\" :text ...} ...]}` result. The
   serialised response's wire size is dominated by these slots; the
-  JSON envelope is bounded and ignored."
-  [result-js]
-  (let [content (j/get result-js :content)
-        n      (if (array? content) (.-length content) 0)]
-    (loop [i 0 sum 0]
-      (if (< i n)
-        (let [item (aget content i)
-              text (when item (j/get item :text))
-              t    (if (string? text) (token-estimate text) 0)]
-          (recur (inc i) (+ sum t)))
-        sum))))
+  JSON envelope is bounded and ignored.
 
-(defn overflow-result
-  "Build a fresh MCP result carrying the overflow marker, preserving
-  the `:isError` flag of the original result (an over-budget error
-  stays an error; an over-budget success becomes a non-error overflow
-  signal — the marker is itself a structured response)."
-  [tool token-count cap]
-  #js {:content #js [#js {:type "text"
-                          :text (pr-str (overflow-payload
-                                          {:tool        tool
-                                           :token-count token-count
-                                           :cap         cap}))}]})
+  Delegates to `base-cap/sum-text-tokens` against pair2-mcp's
+  JS-shape `result-io`."
+  [result-js]
+  (base-cap/sum-text-tokens result-io result-js))
 
 (defn apply-cap
   "Wire-boundary cap enforcement. Returns either `result-js` unchanged
   (when under the cap or cap disabled) or a fresh result carrying the
   overflow marker.
 
-  Pluggable on `strategy`:
-  - `:truncate-with-marker` (default, today the only option): drop
-    the payload, emit `{:rf.mcp/overflow ...}` instead.
+  Pluggable on `strategy` — see `base-cap/apply-cap`. Today only
+  `:truncate-with-marker` is wired; unknown strategies degrade safely.
 
-  Future strategies — path-slicing (rf2-tygdv), lazy summary
-  (rf2-u2029), diff encoding (rf2-rl7y) — slot in here without
-  touching per-tool functions or the `invoke` glue."
+  Adds pair2-mcp's `overflow-hints` table lookup before delegating to
+  `base-cap/apply-cap`."
   [result-js {:keys [tool cap strategy]
               :or   {strategy :truncate-with-marker}}]
-  (cond
-    (nil? cap)        result-js
-    (nil? result-js)  result-js
-    :else
-    (let [tokens (sum-text-tokens result-js)]
-      (if (<= tokens cap)
-        result-js
-        (case strategy
-          :truncate-with-marker
-          (overflow-result tool tokens cap)
-          ;; Unknown strategy: degrade safely.
-          (overflow-result tool tokens cap))))))
+  (base-cap/apply-cap result-io result-js
+                      {:tool     tool
+                       :cap      cap
+                       :hint     (get overflow-hints tool)
+                       :strategy strategy}))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/cap.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/cap.cljc
@@ -1,5 +1,6 @@
 (ns re-frame.story-mcp.tools.cap
-  "Dispatcher + wire-boundary token-budget cap (rf2-rvyzy / rf2-zavp5).
+  "Dispatcher + wire-boundary token-budget cap (rf2-rvyzy / rf2-zavp5 /
+  rf2-eyelu).
 
   Per `spec/Cross-Cutting-Designs.md §3 Token budgets` every MCP
   `tools/call` response is bounded at ~5,000 tokens by default. The cap
@@ -7,8 +8,19 @@
   each handler — that keeps tool bodies free of token-accounting noise
   and pins one cross-MCP shape. When the serialised response would
   exceed the cap, the payload is replaced with a structured
-  `{:rf.mcp/overflow {...}}` marker emitted via
-  `re-frame.mcp-base.overflow/overflow-payload`.
+  `{:rf.mcp/overflow {...}}` marker.
+
+  ## Pipeline ownership
+
+  The cap-enforcement ALGORITHM lives in `re-frame.mcp-base.cap`
+  (rf2-eyelu) — token-summing across `:text` slots, comparing against
+  the per-call cap, and building the overflow result. This ns supplies
+  the per-server specialisation:
+
+  - `result-io` reifies `mcp-base.cap/ResultIO` over the story-mcp
+    result shape (`{:content [...] :structuredContent ...}` CLJ maps).
+  - `overflow-hints` is the local hint table — the per-tool next-step
+    prose stays here because the surfaces are domain-specific.
 
   Sized via `overflow/token-estimate` (the `(quot (count s) 4)` rule
   aligned with Anthropic's character→token rule-of-thumb). The cap is
@@ -19,7 +31,8 @@
   cap, `0` disables (escape hatch when the caller has already
   paginated), absent ⇒ default. Lives on every tool's input schema
   via `registry/with-max-tokens`."
-  (:require [re-frame.mcp-base.overflow :as overflow]
+  (:require [re-frame.mcp-base.cap :as base-cap]
+            [re-frame.mcp-base.overflow :as overflow]
             [re-frame.story-mcp.tools.helpers :as h]
             [re-frame.story-mcp.tools.registry :as registry]))
 
@@ -38,66 +51,17 @@
    "read-failures"     "Failure log is large — assertions accumulator may be deep; clear with a fresh `run-variant`, or raise `max-tokens` (0 disables)."
    "record-as-variant" "Captured event stream is large — shorten `:duration-ms`, or raise `max-tokens` (0 disables)."})
 
-(defn- max-tokens-arg
-  "Resolve the per-call cap from MCP arguments. Returns an integer cap
-  in tokens, or `nil` when the cap is disabled (`:max-tokens 0`).
-  Defaults to `overflow/default-max-tokens` when absent or not a number."
-  [arguments]
-  (let [raw (get arguments :max-tokens)]
-    (cond
-      (nil? raw)                  overflow/default-max-tokens
-      (and (integer? raw) (zero? raw)) nil
-      (integer? raw)              raw
-      :else                       overflow/default-max-tokens)))
-
-(defn sum-text-tokens
-  "Sum `token-estimate` across every `:text` slot in the
-  `{:content [{:type \"text\" :text ...} ...]}` result. The serialised
-  response's wire size is dominated by these slots; the JSON envelope
-  is bounded and ignored."
-  [result]
-  (transduce (comp (map :text)
-                   (filter string?)
-                   (map overflow/token-estimate))
-             +
-             0
-             (:content result)))
-
-(defn- overflow-result
-  "Build a fresh result carrying the overflow marker, mirroring
-  pair2-mcp's `overflow-result`. Drops the over-budget payload entirely
-  and emits the structured marker as the sole `:text` slot.
-
-  The overflow marker is itself the response — `:isError` is NOT set
-  (an over-budget success is a signal to retry with narrower args, not
-  a tool-execution failure)."
-  [tool-name token-count cap]
-  (let [marker (overflow/overflow-payload
-                 {:tool        tool-name
-                  :token-count token-count
-                  :cap         cap
-                  :hint        (get overflow-hints tool-name)})]
-    {:content          [{:type "text" :text (h/pr-edn marker)}]
-     :structuredContent marker}))
-
-(defn- apply-cap
-  "Wire-boundary cap enforcement. Returns either `result` unchanged
-  (under the cap, or cap disabled via `:max-tokens 0`) or a fresh
-  result carrying the overflow marker.
-
-  Cap is cumulative across every `:text` slot in `:content`. Mirrors
-  pair2-mcp's `apply-cap` — the same `:truncate-with-marker` strategy
-  is the only one wired today; future strategies (path-slicing, lazy
-  summary) slot in here without touching tool bodies."
-  [result tool-name cap]
-  (cond
-    (nil? cap)        result
-    (nil? result)     result
-    :else
-    (let [tokens (sum-text-tokens result)]
-      (if (<= tokens cap)
-        result
-        (overflow-result tool-name tokens cap)))))
+(def ^:private result-io
+  "ResultIO reify over story-mcp's CLJ-map result shape. The
+  `:structuredContent` slot mirrors the wire conventions docs (an
+  agent client that prefers JSON data reads it directly without
+  re-parsing the text)."
+  (reify base-cap/ResultIO
+    (content-texts [_ result]
+      (map :text (:content result)))
+    (build-overflow-result [_ marker _original]
+      {:content          [{:type "text" :text (h/pr-edn marker)}]
+       :structuredContent marker})))
 
 (defn invoke-tool
   "Invoke `tool-name` with `arguments` (a map of keyword-keyed args).
@@ -107,11 +71,11 @@
   ## Wire-boundary pipeline
 
   1. Dispatch the handler with `arguments`.
-  2. `apply-cap` (rf2-rvyzy / rf2-zavp5) — when the serialised response
-     exceeds the per-call cap (`:max-tokens` arg, default
-     `overflow/default-max-tokens`, `0` disables), the payload is
-     replaced with a structured `{:rf.mcp/overflow ...}` marker. Per
-     `spec/Cross-Cutting-Designs.md §3 Token budgets`.
+  2. `base-cap/apply-cap` (rf2-rvyzy / rf2-zavp5 / rf2-eyelu) — when
+     the serialised response exceeds the per-call cap (`:max-tokens`
+     arg, default `overflow/default-max-tokens`, `0` disables), the
+     payload is replaced with a structured `{:rf.mcp/overflow ...}`
+     marker. Per `spec/Cross-Cutting-Designs.md §3 Token budgets`.
 
   Catches any throw from the handler and returns it as a tool-execution
   error (`isError: true`) per MCP §Error Handling — handlers SHOULD
@@ -121,7 +85,7 @@
   [tool-name arguments]
   (when-let [t (registry/tool-by-name tool-name)]
     (let [args   (or arguments {})
-          cap    (max-tokens-arg args)
+          cap    (base-cap/max-tokens (get args :max-tokens))
           result (try
                    ((:handler t) args)
                    (catch Throwable e
@@ -129,4 +93,7 @@
                                      {:tool      tool-name
                                       :exception (.getName (class e))
                                       :data      (ex-data e)})))]
-      (apply-cap result tool-name cap))))
+      (base-cap/apply-cap result-io result
+                          {:tool tool-name
+                           :cap  cap
+                           :hint (get overflow-hints tool-name)}))))

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -9,6 +9,7 @@
   (:require [clojure.edn :as edn]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.mcp-base.cap :as base-cap]
             [re-frame.mcp-base.overflow :as overflow]
             [re-frame.mcp-base.vocab :as vocab]
             [re-frame.story :as story]
@@ -19,6 +20,19 @@
             [re-frame.story-mcp.tools.cap :as cap]
             [re-frame.story-mcp.tools.registry :as registry]
             [re-frame.substrate.plain-atom :as plain-atom]))
+
+;; ResultIO mirror over story-mcp's CLJ-map result shape — used by the
+;; cap-honours-default test to sum tokens without reaching into cap's
+;; private result-io reify. Mirrors the runtime IO instance in
+;; `re-frame.story-mcp.tools.cap/result-io` (rf2-eyelu) so a drift on
+;; the consumer's content-shape would be caught by the assertion
+;; sitting on this mirror.
+(def ^:private test-io
+  (reify base-cap/ResultIO
+    (content-texts [_ result] (map :text (:content result)))
+    (build-overflow-result [_ marker _]
+      {:content [{:type "text" :text (pr-str marker)}]
+       :structuredContent marker})))
 
 ;; ---- fixtures ------------------------------------------------------------
 
@@ -882,7 +896,7 @@
     ;; A tiny payload like `list-tags` is well under 5K tokens; verify
     ;; the cap does not trip on routine reads.
     (let [r (cap/invoke-tool "list-tags" {})
-          tokens (#'cap/sum-text-tokens r)]
+          tokens (base-cap/sum-text-tokens test-io r)]
       (is (not (overflow-marker? r)))
       (is (< tokens overflow/default-max-tokens)))))
 


### PR DESCRIPTION
## Summary

- **Audit finding F7 (round-2, P0):** The cap-enforcement algorithm — token-summing across `:text` slots, comparing against the per-call cap, building the overflow result — was duplicated near-identically in `tools/pair2-mcp/.../cap.cljs` (CLJS, JS-object results) and `tools/story-mcp/.../cap.cljc` (CLJ, CLJ-map results). The only structural difference was the SHAPE of the result map and the platform-appropriate accessor.
- Lift the algorithm into new `re-frame.mcp-base.cap` (CLJC) and parameterise via a `ResultIO` protocol with two methods: `content-texts` (seq of strings from the result's `:text` slots) and `build-overflow-result` (consumer-shaped result carrying the marker).
- Each consumer now ships an IO reify + its local hint table; the duplicated coercion / loop / cond chain is gone.

## Design — `ResultIO` protocol

```clojure
(defprotocol ResultIO
  (content-texts [_io result])
  (build-overflow-result [_io marker original-result]))
```

- pair2-mcp's IO reads `:text` via `js-interop` off `#js {:content #js [...]}`-shaped results and builds the same JS shape on overflow.
- story-mcp's IO reads `:text` via keyword-access off CLJ-map results and builds `{:content [...] :structuredContent marker}` on overflow.
- The per-tool hint table stays consumer-side (domain-specific prose); the cap value, token rule, and marker shape stay in mcp-base.

## LoC delta

Before:
- pair2-mcp/cap.cljs: 140
- story-mcp/cap.cljc: 132

After:
- pair2-mcp/cap.cljs: 142 (IO reify + thin wrappers preserving test surface)
- story-mcp/cap.cljc: 99
- mcp-base/cap.cljc: 192 (~50% docstrings; algorithm body ~50 LoC)
- mcp-base/cap_test.clj: 160

The duplicated **algorithm** — ~45 LoC across the two consumers — is single-sourced in mcp-base. File-LoC totals shift because of fresh docstrings and the protocol scaffold; the wire-protocol redundancy that the audit flagged is gone.

## Test plan

- [x] `cd tools/mcp-base && clojure -M:test` — 85 tests / 211 assertions / 0 failures
- [x] `cd tools/story-mcp && clojure -M:test` — 86 tests / 449 assertions / 0 failures
- [x] `cd implementation && npm run test:cljs` — 1816 tests / 5040 assertions / 0 failures (covers pair2-mcp's `wire_cap_test.cljs` + story-mcp end-to-end)
- [x] `cd implementation && npm run test:bundle-isolation` — counter example green; mcp-base does NOT leak into production bundle (`grep -c mcp_base out/.../main.js` ⇒ 0)