### PR TITLE
refactor(causa): round-2 polish cluster — 10 follow-on beads (rf2-imynx)

### DIFF
--- a/tools/causa/spec/API.md
+++ b/tools/causa/spec/API.md
@@ -72,27 +72,32 @@ test harnesses, and Settings UIs.
 ;; Programmatically swap the theme (useful for editor-driven palette sync).
 ```
 
-### `day8.re-frame2-causa.panels`
+### `day8.re-frame2-causa.panels.*`
 
-Each panel exports its `Panel` component for embedding (per
-[`008-Embedding-Contract.md`](./008-Embedding-Contract.md)):
+Each panel exports its `*-view` component for embedding (per
+[`008-Embedding-Contract.md`](./008-Embedding-Contract.md)). The
+embedding contract names the public symbol `Panel`; the present
+impl exports under `*-view`. Promoting to a capital-`Panel` alias
+is the open decision tracked under the embedding-facade bead — the
+canonical symbol list as of today is:
 
 ```clojure
-day8.re-frame2-causa.panels.event-detail/Panel
-day8.re-frame2-causa.panels.causality/Panel
-day8.re-frame2-causa.panels.causality-strip/Panel
-day8.re-frame2-causa.panels.event-log/Panel
-day8.re-frame2-causa.panels.app-db/Panel
-day8.re-frame2-causa.panels.subscriptions/Panel
-day8.re-frame2-causa.panels.effects/Panel
-day8.re-frame2-causa.panels.trace/Panel
-day8.re-frame2-causa.panels.machine/Panel
-day8.re-frame2-causa.panels.flow/Panel
-day8.re-frame2-causa.panels.performance/Panel
-day8.re-frame2-causa.panels.schema-timeline/Panel
-day8.re-frame2-causa.panels.issues/Panel
-day8.re-frame2-causa.panels.hydration/Panel
-day8.re-frame2-causa.panels.routing/Panel
+day8.re-frame2-causa.panels.event-detail/event-detail-view
+day8.re-frame2-causa.panels.causality-graph/causality-graph-view
+day8.re-frame2-causa.panels.time-travel/time-travel-view
+day8.re-frame2-causa.panels.app-db-diff/app-db-diff-view
+day8.re-frame2-causa.panels.subscriptions/subscriptions-view
+day8.re-frame2-causa.panels.effects/effects-view
+day8.re-frame2-causa.panels.trace/trace-view
+day8.re-frame2-causa.panels.machine-inspector/machine-inspector-view
+day8.re-frame2-causa.panels.flows/flows-view
+day8.re-frame2-causa.panels.routes/routes-view
+day8.re-frame2-causa.panels.performance/performance-view
+day8.re-frame2-causa.panels.schema-violation-timeline/schema-violation-timeline-view
+day8.re-frame2-causa.panels.issues-ribbon/issues-ribbon-view
+day8.re-frame2-causa.panels.hydration-debugger/hydration-debugger-view
+day8.re-frame2-causa.panels.mcp-server/mcp-server-view
+day8.re-frame2-causa.panels.ai-co-pilot/ai-co-pilot-view
 ```
 
 Each accepts the props map specified in

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -138,7 +138,7 @@
 ;; `:sensitive?` is rarely set on those, but we keep the bucket so a
 ;; count is never lost).
 ;;
-;; Per rf2-0vxdn the counter is also mirrored into Causa's app-db at
+;; The counter is also mirrored into Causa's app-db at
 ;; `[:rf/causa db :suppressed-counters]` via dispatch (CLJS-only) so
 ;; the `:rf.causa/suppressed-sensitive-count` sub fires on the
 ;; standard reactive write path — the `[● REDACTED N]` indicator
@@ -162,32 +162,27 @@
   `suppress-sensitive?` returned true. `frame-id` may be `nil` /
   absent — those count under `:global`.
 
-  Per rf2-0vxdn: in CLJS, also dispatches
-  `:rf.causa/note-sensitive-suppressed` so the bottom-rail's
-  `[● REDACTED N]` indicator updates IMMEDIATELY via the reactive
-  sub-graph (the event handler updates the active frame's app-db
-  `:suppressed-counters` slot; the sub reads off the same db). The
-  atom-bump stays as the JVM-runnable data primitive
-  (`sensitive_trace` CLJC tests assert it directly); the dispatch
-  is the reactive surface for CLJS.
+  In CLJS, also dispatches `:rf.causa/note-sensitive-suppressed`
+  so the bottom-rail's `[● REDACTED N]` indicator updates
+  IMMEDIATELY via the reactive sub-graph (the event handler updates
+  the active frame's app-db `:suppressed-counters` slot; the sub
+  reads off the same db). The atom-bump stays as the JVM-runnable
+  data primitive (CLJC tests assert it directly); the dispatch is
+  the reactive surface for CLJS.
 
-  Per rf2-higwg: the dispatch follows the active frame chain rather
-  than binding to `:rf/causa` explicitly. The shell's bottom-rail
-  is a plain Reagent fn (not `reg-view`-registered) so its
-  subscribe resolves through the chain to `:rf/default` — the
-  framework emits the `:rf.warning/plain-fn-under-non-default-
-  frame-once` warning on first render but the routing falls
-  through cleanly. Pairing the dispatch's write target with the
-  read's read target (both chain-resolved) keeps the indicator
-  reactive without requiring an explicit `reg-frame :rf/causa` at
-  preload time (which would fail — `reg-frame` needs a substrate
-  adapter installed via `rf/init!`, and the preload runs at
-  ns-load time before that).
+  The dispatch follows the active frame chain rather than binding
+  to `:rf/causa` explicitly. The shell's bottom-rail is a plain
+  Reagent fn (not `reg-view`-registered) so its subscribe resolves
+  through the chain to `:rf/default`. Pairing the dispatch's write
+  target with the read's read target (both chain-resolved) keeps
+  the indicator reactive without requiring an explicit `reg-frame
+  :rf/causa` at preload time (which would fail — `reg-frame` needs
+  a substrate adapter installed via `rf/init!`, and the preload
+  runs at ns-load time before that).
 
   Guarded on `:rf/default`'s existence so JVM / pre-`init!` callers
-  (`sensitive_trace_cljs_test`'s fixture has no frames registered)
-  bump the atom without emitting an `:rf.error/frame-destroyed`
-  trace into the bus."
+  (test fixtures with no frames registered) bump the atom without
+  emitting an `:rf.error/frame-destroyed` trace into the bus."
   [frame-id]
   (let [k (or frame-id :global)]
     (swap! suppressed-counters update k (fnil inc 0)))
@@ -213,10 +208,9 @@
   With a `frame-id`, clears just that bucket. Called from
   `trace-bus/clear-buffer!` and from test fixtures.
 
-  Per rf2-0vxdn: in CLJS, also dispatches
-  `:rf.causa/reset-suppressed-counters` into `:rf/causa` so the
-  reactive copy in Causa's app-db drops in lockstep with the atom.
-  Guarded on the frame existing — `reset-suppressed-count!` is
+  In CLJS, also dispatches `:rf.causa/reset-suppressed-counters`
+  into `:rf/causa` so the reactive copy in Causa's app-db drops in
+  lockstep with the atom. Guarded on the frame existing — this is
   called from test fixtures before any frame is registered."
   ([]
    (reset! suppressed-counters {})

--- a/tools/causa/src/day8/re_frame2_causa/keybinding.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/keybinding.cljs
@@ -32,25 +32,28 @@
   ;; means the value survives shadow-cljs `:after-load` reloads.
   (atom false))
 
+(defn- ctrl-shift-key?
+  "True when `event` is a Ctrl+Shift keydown (no Meta, no Alt) whose
+  key payload satisfies `match?`, a `(fn [key code] truthy)` predicate
+  over `KeyboardEvent.key` and `KeyboardEvent.code`. Factored so new
+  global shortcuts can drop in without re-stating the modifier checks."
+  [event match?]
+  (let [^js e event]
+    (and (.-ctrlKey e)
+         (.-shiftKey e)
+         (not (.-metaKey e))
+         (not (.-altKey e))
+         (match? (.-key e) (.-code e)))))
+
 (defn- causa-toggle-key?
   "True when `event` is a Ctrl+Shift+C keydown. Checks the C key via
   both `key` (\"C\" / \"c\") and `code` (\"KeyC\"); some IME-active
   contexts only populate `code`."
   [event]
-  (let [^js e event
-        k         (.-key e)
-        code      (.-code e)
-        ctrl?     (.-ctrlKey e)
-        shift?    (.-shiftKey e)
-        meta?     (.-metaKey e)
-        alt?      (.-altKey e)]
-    (and ctrl?
-         shift?
-         (not meta?)
-         (not alt?)
-         (or (= "C" k)
-             (= "c" k)
-             (= "KeyC" code)))))
+  (ctrl-shift-key?
+    event
+    (fn [k code]
+      (or (= "C" k) (= "c" k) (= "KeyC" code)))))
 
 (defn- copilot-toggle-key?
   "True when `event` is a Ctrl+Shift+/ keydown. Per spec/009-AI-
@@ -58,20 +61,10 @@
   (\"/\" / \"?\") and `code` (\"Slash\") — the Shift modifier shifts
   the printable character on most layouts."
   [event]
-  (let [^js e event
-        k         (.-key e)
-        code      (.-code e)
-        ctrl?     (.-ctrlKey e)
-        shift?    (.-shiftKey e)
-        meta?     (.-metaKey e)
-        alt?      (.-altKey e)]
-    (and ctrl?
-         shift?
-         (not meta?)
-         (not alt?)
-         (or (= "/" k)
-             (= "?" k)
-             (= "Slash" code)))))
+  (ctrl-shift-key?
+    event
+    (fn [k code]
+      (or (= "/" k) (= "?" k) (= "Slash" code)))))
 
 (defn- handle-keydown [^js event]
   (cond

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_helpers.cljc
@@ -215,10 +215,14 @@
 
 ;; ---- pin store -----------------------------------------------------------
 
-(defn pins-for-frame
-  "Return the pin vector for `frame-id` in `store`, or `[]` when none.
-  The pin store is `{frame-id [path-1 path-2 ...]}`. Vector order is
-  the user's drag-reorder order."
+(defn slice-pins-for-frame
+  "Return the slice-path pin vector for `frame-id` in `store`, or `[]`
+  when none. The slice-pin store is `{frame-id [path-1 path-2 ...]}`;
+  vector order is the user's drag-reorder order. Sibling helper
+  `time-travel-helpers/epoch-pins-for-frame` returns the per-frame
+  epoch-pin vector for the Time-Travel scrubber; both helpers
+  destructure a different `store` shape so they aren't
+  interchangeable."
   [store frame-id]
   (vec (get store frame-id [])))
 
@@ -262,7 +266,7 @@
   Pure data → data. JVM-runnable."
   [store frame-id db]
   (mapv (fn [path] {:path path :value (get-in db path)})
-        (pins-for-frame store frame-id)))
+        (slice-pins-for-frame store frame-id)))
 
 ;; ---- 'Show me when this changed' walker ---------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/causality_graph_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/causality_graph_helpers.cljc
@@ -49,8 +49,8 @@
   on; the v1 layout does not run a force-directed pass. Per the spec
   §Performance — re-layout runs incrementally — but the v1 helper is
   a stable O(n) pass over the cascade vector. The full incremental-
-  layout pass lands in rf2-xxx once the panel's perf budget is
-  measured against a real cascade stream."
+  layout pass lands once the panel's perf budget is measured against
+  a real cascade stream."
   (:require [clojure.set :as set]))
 
 ;; ---- layout constants ----------------------------------------------------
@@ -283,10 +283,10 @@
   layout is deterministic over a fixed input.
 
   Per spec §Layout the v1 horizontal axis is *frame swimlanes*. The
-  v1 helper collapses every cascade onto the same swimlane (rf2-4rqs1
-  scope); the cross-frame swimlane assignment lands when the frame
-  picker / Spec 002 §Cross-frame fx surface is wired into the
-  buffer (rf2-xxx — out of Phase 4 scope)."
+  v1 helper collapses every cascade onto the same swimlane; the
+  cross-frame swimlane assignment lands when the frame picker /
+  Spec 002 §Cross-frame fx surface is wired into the buffer (out
+  of v1 scope)."
   [roots children level-of all-ids]
   (let [;; Walk in BFS order from the roots; pure-data so the encounter
         ;; index is stable.
@@ -331,7 +331,7 @@
     plus the outer margin.
 
   Pure data → data. Deterministic given the same input — callers can
-  diff two layouts for animation hooks (rf2-xxx)."
+  diff two layouts for animation hooks (out of v1 scope)."
   [{:keys [nodes arrows roots] :as _graph}]
   (let [children  (children-by-parent arrows)
         all-ids   (map :dispatch-id nodes)
@@ -397,7 +397,7 @@
   `:parent`, plus every descendant walked down through `:children`.
 
   Pure data → id-set. Used by `filter-to-cascade` and by the
-  spec §Find root cause affordance (rf2-xxx)."
+  spec §Find root cause affordance."
   [{:keys [nodes arrows] :as _graph} dispatch-id]
   (when dispatch-id
     (let [parent-by-id (into {} (map (juxt :dispatch-id :parent)) nodes)

--- a/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger.cljs
@@ -34,7 +34,7 @@
        buffer carrying no mismatch traces; the explicit 'hydration
        happened' signal (a `:rf.ssr/hydration-complete` trace, or the
        `[:rf/hydration :server-hash]` slot on app-db) lands when the
-       SSR artefact integration deepens (rf2-xxx). Until then the
+       SSR artefact integration deepens. Until then the
        'No SSR in this app' state is the default; the
        'SSR present, no mismatches' state is reached by the user via
        the panel's `show clean state` affordance (a checkbox in the

--- a/tools/causa/src/day8/re_frame2_causa/panels/performance.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/performance.cljs
@@ -54,7 +54,7 @@
       Trace panel will share that effect once both panels are live).
     - No drag-zoom horizontal ribbon. v1 ships the row view; the
       ribbon canvas is follow-on work alongside the time-axis
-      synchronisation with the Trace panel (rf2-xxx).
+      synchronisation with the Trace panel.
     - No re-render-counts-per-epoch projection from the epoch-record's
       `:renders` slot. The row's render-count is a cheap proxy
       (count of `:view/render` traces in the cascade) until that slot

--- a/tools/causa/src/day8/re_frame2_causa/panels/time_travel_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/time_travel_helpers.cljc
@@ -56,7 +56,7 @@
   empirically — '~10 surfaces a UI-density problem; 32 is the cliff at
   which the user is using pins as session-export, which Lock #4 says
   no'). Configurable via Settings → `pin-store-capacity` once Settings
-  ships (rf2-xxx); until then, callers may override via the 3-arity
+  ships; until then, callers may override via the 3-arity
   form of `pin-snapshot`."
   32)
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/time_travel_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/time_travel_helpers.cljc
@@ -201,10 +201,16 @@
                       pin))
                   (or pins [])))))
 
-(defn pins-for-frame
-  "Return the pin vector for `frame-id`, or `[]` when none. Pure-data
-  accessor — useful both for tests and for the sub-projection that
-  flattens the per-frame map into the view's flat chip list."
+(defn epoch-pins-for-frame
+  "Return the epoch-pin vector for `frame-id`, or `[]` when none. The
+  per-frame pin store holds time-travel epoch pins — 4-tuples of
+  `{:epoch-id :frame-db :dispatch-id :label}`. Sibling helper
+  `app-db-diff-helpers/slice-pins-for-frame` returns the per-frame
+  slice-path pin vector for the App-DB-Diff panel; both helpers
+  destructure a different `store` shape so they aren't
+  interchangeable. Pure-data accessor — useful both for tests and for
+  the sub-projection that flattens the per-frame map into the view's
+  flat chip list."
   [store frame-id]
   (vec (get store frame-id [])))
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -3,7 +3,7 @@
 
   Per `tools/causa/spec/000-Vision.md` L89 (panel-inventory row) the
   Trace panel is the raw-event ribbon — every trace event in the
-  buffer renders as one timestamped row, filterable along the 9-axis
+  buffer renders as one timestamped row, filterable along the 13-axis
   vocabulary documented in `spec/009-Instrumentation.md` §Filter
   vocabulary. Where the Issues ribbon collapses the stream to
   issues only, this panel surfaces every op-type so a programmer

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
@@ -5,7 +5,7 @@
 
   The panel view in `trace.cljs` paints a scrollable, timestamped
   ribbon of raw trace events and dispatches into the Causa frame.
-  The *logic* — applying the 9-axis filter vocabulary from Spec 009
+  The *logic* — applying the 13-axis filter vocabulary from Spec 009
   §Filter vocabulary, projecting raw events into row shape,
   enumerating per-axis distinct values for the chip rows, and
   classifying the empty state — is pure data → data. Splitting the
@@ -15,11 +15,11 @@
 
   ## Substrate (per `spec/009-Instrumentation.md` §Filter vocabulary)
 
-  The Trace panel is the UI consumer of the canonical 9-axis filter
+  The Trace panel is the UI consumer of the canonical 13-axis filter
   vocabulary documented in Spec 009 §Filter vocabulary (the algebra
   itself is implemented in `re-frame.trace/trace-buffer` and exposed
-  pure-data via `day8.re-frame2-causa.trace-bus/filter-events` per
-  rf2-qi8au). Where the Issues ribbon collapses the stream to issues
+  pure-data via `day8.re-frame2-causa.trace-bus/filter-events`).
+  Where the Issues ribbon collapses the stream to issues
   only, the Trace panel surfaces the *raw* stream — every op-type,
   every operation — so a programmer can grep across the full
   vocabulary.
@@ -48,7 +48,7 @@
   (:require [clojure.string :as str]
             [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
-;; ---- the canonical 9-axis vocabulary ------------------------------------
+;; ---- the canonical 13-axis vocabulary -----------------------------------
 
 (def filter-axes
   "The canonical filter-vocabulary axes Spec 009 §Filter vocabulary
@@ -198,7 +198,7 @@
   (boolean (seq (normalise-filters filters))))
 
 (defn apply-filters
-  "Apply the 9-axis filter vocabulary to `events`. Pure data →
+  "Apply the 13-axis filter vocabulary to `events`. Pure data →
   vector; JVM-testable. Delegates to `trace-bus/filter-events` so
   the algebra stays in lockstep with the framework's canonical
   filter. Returns a vector in chronological order (oldest first)."
@@ -250,7 +250,7 @@
        :any-filter?       <bool>
        :empty-kind        <:no-events / :no-matches / nil>}
 
-  `events` is the raw trace-buffer. `filters` is the 9-axis filter
+  `events` is the raw trace-buffer. `filters` is the 13-axis filter
   map (per Spec 009 §Filter vocabulary).
 
   `:empty-kind` discriminates the two empty-state branches:

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
@@ -45,8 +45,7 @@
   Empty / nil values disable an axis. Composition is AND-wise — the
   canonical `trace-bus/filter-events` does the work; this ns adds
   the panel's projection + per-axis chip enumeration on top."
-  (:require #?(:clj  [clojure.string :as str]
-               :cljs [clojure.string :as str])
+  (:require [clojure.string :as str]
             [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
 ;; ---- the canonical 9-axis vocabulary ------------------------------------

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -218,7 +218,7 @@
       :<- [:rf.causa/pin-store]
       :<- [:rf.causa/target-frame]
       (fn [[pin-store target-frame] _query]
-        (tt-helpers/pins-for-frame pin-store target-frame)))
+        (tt-helpers/epoch-pins-for-frame pin-store target-frame)))
 
     ;; Composite for the panel — one read produces every slot the
     ;; view needs. Mirrors the Phase-2 `:rf.causa/event-detail`

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -63,10 +63,10 @@
 (def default-target-frame
   "The host frame Causa's time-travel scrubber inspects by default.
   Per spec/002-Time-Travel.md §Cross-frame scrubbing the scrubber is
-  per-frame — the frame picker (rf2-xxx, not Phase 3 scope) lets
-  the user pick a different host frame. Until that picker lands the
-  scrubber is hard-bound to :rf/default — the canonical host frame
-  per Tool-Pair §Frame naming.
+  per-frame — once a frame picker ships it lets the user pick a
+  different host frame. Until then the scrubber is hard-bound to
+  :rf/default — the canonical host frame per Tool-Pair §Frame
+  naming.
 
   Note this is the *host*'s frame, not :rf/causa — Causa's own
   state (selection, pin store) lives in :rf/causa via the shell's
@@ -180,8 +180,8 @@
     ;; ---- Phase 3 (rf2-t53ze) — Time Travel scrubber subs ---------
 
     ;; Target frame the scrubber inspects. Hard-bound to :rf/default
-    ;; until the frame picker (rf2-xxx) lands; the sub abstracts so
-    ;; the picker can drop in without rewiring every consumer.
+    ;; until a frame picker lands; the sub abstracts so the picker can
+    ;; drop in without rewiring every consumer.
     (rf/reg-sub :rf.causa/target-frame
       (fn [db _query]
         (get db :target-frame default-target-frame)))
@@ -739,9 +739,9 @@
               ;; pinned every mismatch surfaces. The view's header
               ;; reads :target-frame to label the active filter.
               ;;
-              ;; Phase 5 ships with target-frame = :rf/default (the
-              ;; canonical host frame); cross-frame swimlanes ride a
-              ;; follow-on bead (rf2-xxx) once the picker lands.
+              ;; The default surface ships with target-frame =
+              ;; :rf/default (the canonical host frame); cross-frame
+              ;; swimlanes ride a follow-on once a picker lands.
               summary           (hd-helpers/mismatch-list-summary
                                   buffer target-frame)
               has-mismatch?     (boolean (seq summary))
@@ -890,7 +890,7 @@
         (let [latest-epoch    (peek (vec history))
               sub-runs        (:sub-runs latest-epoch)
               ;; v1 has no first-class :changed-paths slot on the
-              ;; epoch-record yet (rf2-xxx will surface it); fall
+              ;; epoch-record yet (a follow-on will surface it); fall
               ;; back to nil so the chain shows every layer-1 input
               ;; path it knows about.
               changed-paths   (:changed-paths latest-epoch)

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -2,145 +2,36 @@
   "Causa's framework registrations — events, subs, fxs under the
   `:rf.causa/*` namespace prefix.
 
-  ## Why the namespace prefix matters (rf2-tijr Option C)
+  ## Namespace prefix is the collision contract
 
-  Per rf2-tijr the registrar is process-global; Causa's registrations
-  share the registry with the host app. The `:rf.causa/*` prefix is the
+  The registrar is process-global; Causa's registrations share the
+  registry with the host app. The `:rf.causa/*` prefix is the
   collision-avoidance contract: Causa never registers under a
   non-`:rf.causa/*` keyword, so a host registering `:user/login` and
   Causa registering `:rf.causa/buffer-cleared` cannot stamp on each
   other.
 
-  ## Why the registrations target the `:rf/causa` frame
+  ## Registrations target the `:rf/causa` frame
 
-  Per rf2-tijr Option C the panel's state lives in a frame named
-  `:rf/causa` — a sibling of the host's `:rf/default`. Subscribers /
-  dispatchers wrapped inside `[rf/frame-provider {:frame :rf/causa}
-  ...]` resolve to that frame; a Causa view subscribing to
-  `:rf.causa/trace-buffer` reads `:rf/causa`'s app-db, not the host's.
+  The panel's state lives in a frame named `:rf/causa` — a sibling of
+  the host's `:rf/default`. Subscribers / dispatchers wrapped inside
+  `[rf/frame-provider {:frame :rf/causa} ...]` resolve to that frame;
+  a Causa view subscribing to `:rf.causa/trace-buffer` reads
+  `:rf/causa`'s app-db, not the host's. Prefix prevents id collision;
+  frame-provider prevents db reads/writes from leaking into the host.
 
-  Even though the registrar is process-global, each registered handler
-  operates *against the active frame's db* — so the registry namespace
-  prefix and the frame isolation work together: prefix prevents id
-  collision, frame-provider prevents db reads/writes from leaking into
-  the host.
+  ## Catalogue
 
-  ## Phase 2 scope (rf2-op3bz)
-
-  Phase 1 (rf2-n6x4q) shipped only `:rf.causa/trace-buffer`. Phase 2
-  adds the event-detail panel's wiring:
-
-    - `:rf.causa/selected-panel`           sub — current panel-id
-    - `:rf.causa/select-panel`             event-db — set current panel
-    - `:rf.causa/selected-dispatch-id`     sub — focused cascade
-    - `:rf.causa/event-detail`             sub — projected cascade
-    - `:rf.causa/select-dispatch-id`       event-db — set focused
-    - `:rf.causa/clear-selected-dispatch-id` event-db — clear focus
-
-  ## Phase 3 scope (rf2-t53ze) — Time Travel panel
-
-  Adds the scrubber's wiring against the framework's epoch-history
-  surface. The panel's :selected-epoch-id holds the *view* selection
-  (per spec §The passive-scrubbing rule — scrubbing rebases panels;
-  rewind is opt-in). :pinned-snapshots is the per-frame pin store
-  (per spec §Pinned snapshots, Lock 4 session-scoped).
-
-    - `:rf.causa/epoch-history`            sub — :rf.causa/target-frame's history
-    - `:rf.causa/selected-epoch-id`        sub — view's selected epoch
-    - `:rf.causa/pinned-snapshots`         sub — vector of chip states
-    - `:rf.causa/time-travel`              sub — composite for the panel
-    - `:rf.causa/select-epoch`             event-db — set view selection (passive)
-    - `:rf.causa/clear-selected-epoch`     event-db — drop view selection
-    - `:rf.causa/pin-current`              event — eager-copy a pin
-    - `:rf.causa/unpin`                    event-db — drop a pin
-    - `:rf.causa/rename-pin`               event-db — rewrite a pin's :label
-    - `:rf.causa/reset-to-epoch`           event-fx — restore-epoch via fx
-    - `:rf.causa/reset-to-pinned`          event-fx — reset-frame-db! via fx
-
-  Two effects route the framework writes — `:rf.causa.fx/restore-epoch`
-  and `:rf.causa.fx/reset-frame-db!`. They are reg-fx'd thin
-  delegations to `rf/restore-epoch` / `rf/reset-frame-db!`. The
-  indirection lets test fixtures stub the writes and assert the
-  correct framework call site is reached (Reset to pinned uses
-  reset-frame-db!, not restore-epoch, per spec §Why reset-frame-db!
-  not restore-epoch).
-
-  ## Phase 4 scope (rf2-4rqs1) — Causality Graph panel
-
-  Reuses the Phase 2 / Phase 3 surface (trace-buffer, selected-
-  dispatch-id, selected-epoch-id) and adds one composite sub that
-  projects + lays out the graph data the panel consumes:
-
-    - `:rf.causa/causality-graph-data` sub — composite
-
-  No new events are required: the graph reuses
-  `:rf.causa/select-dispatch-id` (shared with the event-detail hero
-  per spec §10 Lock 7) and `:rf.causa/clear-selected-epoch` for the
-  cascade-filter affordance.
-
-  ## Phase 5 scope (rf2-jps1o) — App-DB Diff panel
-
-  Slice-centric app-db inspector. Reads the host frame's `app-db`
-  via `rf/get-frame-db` + the target-frame's epoch-history; produces
-  the `[op path before after]` diff triples the view consumes.
-
-  Subs:
-
-    - `:rf.causa/target-frame-db`          sub — host frame's app-db
-    - `:rf.causa/selected-epoch-diff`      sub — composite over
-                                              :rf.causa/selected-
-                                              epoch-id +
-                                              :rf.causa/epoch-history
-    - `:rf.causa/pinned-slices-store`      sub — per-frame slice pins
-    - `:rf.causa/pinned-slices`            sub — live derefs for
-                                              the current target-frame
-    - `:rf.causa/focused-slice-path`       sub — 'Show me when' focus
-    - `:rf.causa/show-me-when-this-changed-result`
-                                           sub — composite
-    - `:rf.causa/app-db-diff`              sub — composite for the view
-
-  Events:
-
-    - `:rf.causa/pin-slice`                event-db
-    - `:rf.causa/unpin-slice`              event-db
-    - `:rf.causa/reorder-pinned-slices`    event-db
-    - `:rf.causa/focus-slice-path`         event-db
-    - `:rf.causa/clear-slice-focus`        event-db
-    - `:rf.causa/copy-value-to-clipboard`  event-fx
-    - `:rf.causa/copy-path-to-clipboard`   event-fx
-
-  Effect:
-
-    - `:rf.causa.fx/copy-to-clipboard`     fx — writes via the
-                                              browser clipboard API
-                                              (no-op on non-browser
-                                              targets)
-
-  ## Phase 5+ scope (rf2-r9f9u) — Machine Inspector panel
-
-  Folds `(rf/machines)` + the live `:rf/machine` snapshots + the
-  trace-buffer's `:rf.machine/transition` slice into the data shape
-  the panel renders.
-
-  Subs:
-
-    - `:rf.causa/registered-machines`        sub — vector of ids
-    - `:rf.causa/machine-snapshots`          sub — {id snapshot}
-    - `:rf.causa/selected-machine-id`        sub — picker focus
-    - `:rf.causa/machine-inspector-data`     sub — composite
-
-  Events:
-
-    - `:rf.causa/select-machine-id`          event-db
-    - `:rf.causa/clear-machine-selection`    event-db
-    - `:rf.causa/set-registered-machines-override-for-test` event-db
-    - `:rf.causa/set-machine-snapshots-override-for-test`   event-db
-
-  No new fxs — the panel is read-only at v1 (share-affordance,
-  source-coord jumps live in `tools/machines-viz/` per Spec 003
-  §Embedding posture and require its impl to land first).
-
-  Subsequent panel beads add their own per-panel events / subs / fxs."
+  The registrar wires the full Causa surface: trace-buffer, selected-
+  panel / dispatch-id, the event-detail / causality-graph / time-
+  travel / app-db-diff / machine-inspector / schema-violation-timeline
+  / hydration-debugger / issues-ribbon / effects / flows / routes /
+  subscriptions / trace / mcp-server / performance / co-pilot
+  composites, and the small mutating event-db / event-fx surface that
+  drives the pins, scrubbing, slice focus, clipboard copy, restore-
+  epoch and reset-frame-db! effects. See the inline section markers
+  below — and the per-panel `*-helpers` namespaces for the data
+  primitives the composites consume."
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-causa.config :as config]
@@ -191,20 +82,11 @@
 ;; is process-global, not per-frame — every Causa shell mounted across
 ;; any frame should see the same trace stream. The sub thunks the
 ;; pure-data accessor so reactive contexts get a fresh read on every
-;; recompute.
-;;
-;; History (rf2-iw5ym → rf2-e9s81): rf2-iw5ym briefly mirrored the
-;; buffer into Causa's app-db at `:trace-buffer` so the sub would
-;; re-fire IMMEDIATELY on every push. That path proved untenable —
-;; `:rf/causa` is not registered at preload time (no substrate
-;; adapter installed yet) and chain-resolving to `:rf/default`
-;; consumed drain-depth headroom on every emitted trace event AND
-;; polluted the host's app-db with `:trace-buffer` noise. rf2-e9s81
-;; reverts to the pre-iw5ym shape (sub thunks the atom; layer-1 re-
-;; fires on the host's next dispatch, picking up whatever the trace-
-;; cb has accumulated). See `trace_bus.cljc` §Reactivity for the
-;; trade-off and the wider refactor that would re-introduce
-;; immediate-update reactivity without the layering hazard.
+;; recompute; layer-1 re-fires on the host's next dispatch and picks
+;; up whatever the trace-cb has accumulated. See `trace_bus.cljc`
+;; §Reactivity for the trade-off and the refactor path that would
+;; re-introduce immediate-update reactivity without the layering
+;; hazard.
 (defonce ^:private registered?
   ;; Idempotency sentinel. Re-loading the namespace (shadow-cljs
   ;; `:after-load`) must not re-register the sub (would harmlessly
@@ -688,14 +570,6 @@
         (if frame-id
           (update db :suppressed-counters dissoc (or frame-id :global))
           (dissoc db :suppressed-counters))))
-
-    ;; Per rf2-e9s81 (supersedes rf2-iw5ym):
-    ;; `:rf.causa/note-trace-event` / `:rf.causa/clear-trace-buffer`
-    ;; / `:rf.causa/sync-trace-buffer` were removed when the trace-
-    ;; buffer reactive surface reverted to the pre-iw5ym shape (sub
-    ;; thunks the atom; layer-1 re-fires on the host's next dispatch).
-    ;; See `trace_bus.cljc` §Reactivity for the trade-off + the
-    ;; planned wider refactor.
 
     (rf/reg-event-db :rf.causa/select-dispatch-id
       (fn [db [_ dispatch-id]]

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -1363,12 +1363,11 @@
 
     ;; ---- Phase 5 (rf2-argrj) — Trace panel ------------------------------
     ;;
-    ;; The Trace panel is the UI consumer of the canonical 9-axis filter
+    ;; The Trace panel is the UI consumer of the canonical 13-axis filter
     ;; vocabulary documented in spec/009-Instrumentation.md §Filter
-    ;; vocabulary (rf2-97ah0). Where the Issues ribbon collapses the
-    ;; stream to issues only, this panel surfaces the raw stream so a
-    ;; programmer can grep across every op-type / operation / source /
-    ;; origin / frame / etc.
+    ;; vocabulary. Where the Issues ribbon collapses the stream to issues
+    ;; only, this panel surfaces the raw stream so a programmer can grep
+    ;; across every op-type / operation / source / origin / frame / etc.
     ;;
     ;; Shape of `:rf.causa/trace-feed`:
     ;;
@@ -1381,7 +1380,7 @@
     ;;      :any-filter?  <bool>
     ;;      :empty-kind   <:no-events / :no-matches / nil>}
 
-    ;; The current 9-axis filter map. Each axis is independent; the
+    ;; The current 13-axis filter map. Each axis is independent; the
     ;; helper's `normalise-filters` drops nil / empty values before
     ;; applying — the view sets axis = nil to clear an axis.
     (rf/reg-sub :rf.causa/trace-filters

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -255,6 +255,18 @@
       (fn [db _query]
         (get db :selected-dispatch-id)))
 
+    ;; Shared cascade projection. The event-detail, causality-graph,
+    ;; and performance composites all consume `projection/group-cascades`
+    ;; over the same trace-buffer; routing them through one intermediate
+    ;; sub collapses three O(buffer) passes per push to one. Each
+    ;; downstream composite declares the dependency via `:<-` so the
+    ;; reactive graph stays correct (and idle composites still don't pay
+    ;; for the projection).
+    (rf/reg-sub :rf.causa/cascades
+      :<- [:rf.causa/trace-buffer]
+      (fn [buffer _query]
+        (projection/group-cascades buffer)))
+
     ;; Event-detail composite — produces everything the panel needs in
     ;; one read so the view stays a thin renderer. Shape:
     ;;
@@ -268,18 +280,17 @@
     ;; Per spec/007-UX-IA.md §Performance budget the panel renders at
     ;; most ~200 cascades; the projection is O(n) over the buffer.
     (rf/reg-sub :rf.causa/event-detail
-      ;; Signal layer: depend on the trace-buffer sub +
-      ;; selected-dispatch-id sub so this composite recomputes when
-      ;; either changes. The `:<-` chain is the only sub-registration
-      ;; form in v2 (per Spec 002 §Subscriptions composing —
-      ;; reg-sub-raw is dropped; see `re-frame.subs/parse-reg-sub-args`).
-      :<- [:rf.causa/trace-buffer]
+      ;; Signal layer: depend on the shared `:rf.causa/cascades`
+      ;; projection + selected-dispatch-id so this composite recomputes
+      ;; when either changes. The `:<-` chain is the only sub-
+      ;; registration form in v2 (per Spec 002 §Subscriptions composing
+      ;; — reg-sub-raw is dropped; see `re-frame.subs/parse-reg-sub-args`).
+      :<- [:rf.causa/cascades]
       :<- [:rf.causa/selected-dispatch-id]
-      (fn [[buffer selected-id] _query]
-        (let [cascades (projection/group-cascades buffer)
-              by-id    (when selected-id
-                         (some #(when (= selected-id (:dispatch-id %)) %)
-                               cascades))]
+      (fn [[cascades selected-id] _query]
+        (let [by-id (when selected-id
+                      (some #(when (= selected-id (:dispatch-id %)) %)
+                            cascades))]
           {:cascades             cascades
            :selected-dispatch-id selected-id
            :selected-cascade     by-id})))
@@ -373,13 +384,19 @@
     ;; The composite recomputes when any of its signals change — the
     ;; reactive surface is the same as the event-detail composite.
     (rf/reg-sub :rf.causa/causality-graph-data
+      ;; The graph still depends on the raw `trace-buffer` for the
+      ;; `enrich-cascades` walk (it surfaces `:event/dispatched` traces
+      ;; that aren't preserved in the projected cascade vector). The
+      ;; cascade vector itself is read from the shared
+      ;; `:rf.causa/cascades` projection so the O(buffer) `group-
+      ;; cascades` pass happens once per push instead of three times.
+      :<- [:rf.causa/cascades]
       :<- [:rf.causa/trace-buffer]
       :<- [:rf.causa/selected-dispatch-id]
       :<- [:rf.causa/selected-epoch-id]
       :<- [:rf.causa/epoch-history]
-      (fn [[buffer selected-id selected-epoch-id history] _query]
-        (let [cascades         (projection/group-cascades buffer)
-              enriched         (cg-helpers/enrich-cascades cascades buffer)
+      (fn [[cascades buffer selected-id selected-epoch-id history] _query]
+        (let [enriched         (cg-helpers/enrich-cascades cascades buffer)
               graph            (cg-helpers/project-cascades-to-graph enriched)
               ;; When Time Travel's selected-epoch resolves to a
               ;; cascade-id, filter the graph to that cascade family.
@@ -1458,11 +1475,10 @@
         (get db :performance-budget-ms perf-helpers/default-budget-ms)))
 
     (rf/reg-sub :rf.causa/performance-data
-      :<- [:rf.causa/trace-buffer]
+      :<- [:rf.causa/cascades]
       :<- [:rf.causa/performance-budget-ms]
-      (fn [[buffer budget-ms] _query]
-        (let [cascades (projection/group-cascades buffer)]
-          (perf-helpers/project-feed cascades budget-ms))))
+      (fn [[cascades budget-ms] _query]
+        (perf-helpers/project-feed cascades budget-ms)))
 
     ;; Set the over-budget threshold. Pass nil to reset to default.
     (rf/reg-event-db :rf.causa/set-performance-budget-ms

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -1,11 +1,8 @@
 (ns day8.re-frame2-causa.shell
   "The Causa shell — empty-pane layout per tools/causa/spec/007-UX-IA.md.
-
-  Phase 1 (rf2-n6x4q) shipped the *structure* without the panels; per
-  Phase 2 (rf2-op3bz) the hero `:event-detail` panel is now live. The
-  remaining sidebar slots still render the 'Coming soon — rf2-xxx'
-  stub; their live panel views land in subsequent beads under
-  rf2-5aw5v.
+  Every sidebar entry routes to a live panel view fn through `canvas`'s
+  case-switch; an unrecognised id falls through to a defensive
+  `unknown-panel` branch.
 
   ## Layout
 
@@ -83,38 +80,30 @@
 
 (def ^:private sidebar-items
   "The sidebar's panel list. Per spec/007-UX-IA.md §Sidebar groups —
-  three groups, divider-separated. Phase 2 (rf2-op3bz) lit up
-  `:event-detail`; Phase 3 (rf2-t53ze) adds `:time-travel`. Remaining
-  items still render the Phase 1 stub when selected."
-  [{:id :event-detail :label "Event detail" :bead "rf2-op3bz" :live? true}
-   {:id :time-travel  :label "Time travel"  :bead "rf2-t53ze" :live? true}
-   {:id :app-db       :label "App-db"        :bead "rf2-jps1o" :live? true}
-   {:id :causality    :label "Causality"     :bead "rf2-4rqs1" :live? true}
-   {:id :subs         :label "Subscriptions" :bead "rf2-x0f5v" :live? true}
+  three groups, divider-separated. Every panel is live; the
+  Hydration entry carries `:dormant?` until the first
+  `:rf.ssr/hydration-mismatch` trace lands (per spec/006-Hydration-
+  Debugger.md §Visibility)."
+  [{:id :event-detail :label "Event detail"}
+   {:id :time-travel  :label "Time travel"}
+   {:id :app-db       :label "App-db"}
+   {:id :causality    :label "Causality"}
+   {:id :subs         :label "Subscriptions"}
    ;; ── effects panel begin ──
-   {:id :fx           :label "Effects"       :bead "rf2-ts41u" :live? true}
+   {:id :fx           :label "Effects"}
    ;; ── effects panel end ──
-   {:id :trace        :label "Trace"         :bead "rf2-argrj" :live? true}
-   {:id :machines     :label "Machines"      :bead "rf2-r9f9u" :live? true}
-   {:id :flows        :label "Flows"         :bead "rf2-83irn" :live? true}
-   {:id :routes       :label "Routes"        :bead "rf2-6blai" :live? true}
-   {:id :performance  :label "Performance"   :bead "rf2-75121" :live? true}
-   {:id :issues       :label "Issues"        :bead "rf2-d1p4o" :live? true}
-   {:id :schemas      :label "Schemas"       :bead "rf2-htffa" :live? true}
-   ;; Phase 5 (rf2-pzxsr). Per spec/006-Hydration-Debugger.md §Visibility
-   ;; the panel is dormant until at least one :rf.ssr/hydration-mismatch
-   ;; trace lands. The sidebar entry's `:dormant?` flag drives the `◌`
-   ;; marker; once a mismatch fires the entry lights up and the entry
-   ;; behaves like every other live panel.
-   {:id :hydration    :label "Hydration"     :bead "rf2-pzxsr" :live? true :dormant? true}
+   {:id :trace        :label "Trace"}
+   {:id :machines     :label "Machines"}
+   {:id :flows        :label "Flows"}
+   {:id :routes       :label "Routes"}
+   {:id :performance  :label "Performance"}
+   {:id :issues       :label "Issues"}
+   {:id :schemas      :label "Schemas"}
+   {:id :hydration    :label "Hydration"    :dormant? true}
    ;; ── mcp-server panel begin ──
-   ;; rf2-81qjj — DECISION (a): a dedicated MCP entry in the sidebar
-   ;; surfaces 'what is the agent doing' in one place. Placed adjacent
-   ;; to Co-pilot since both are AI / agent surfaces, per spec/007-UX-
-   ;; IA.md §Sidebar groups (third group is the AI surfaces).
-   {:id :mcp-server   :label "MCP"           :bead "rf2-81qjj" :live? true}
+   {:id :mcp-server   :label "MCP"}
    ;; ── mcp-server panel end ──
-   {:id :copilot      :label "Co-pilot"      :bead "rf2-rccf3" :live? true}])
+   {:id :copilot      :label "Co-pilot"}])
 
 ;; ---- regions -------------------------------------------------------------
 
@@ -169,7 +158,7 @@
   marker instead of `○` until activity wakes it. The dormant fn
   passes `dormant?` here so the visibility gate is one place; the
   parent decides per-row what 'awake' means."
-  [{:keys [id label live? dormant?]} active?]
+  [{:keys [id label dormant?]} active?]
   [:li {:data-testid (str "rf-causa-sidebar-item-" (name id))
         :on-click    #(rf/dispatch [:rf.causa/select-panel id])
         :style       {:padding         "6px 16px"
@@ -178,8 +167,7 @@
                       :color           (cond
                                          active?  (:text-primary tokens)
                                          dormant? (:text-tertiary tokens)
-                                         live?    (:text-secondary tokens)
-                                         :else    (:text-tertiary tokens))
+                                         :else    (:text-secondary tokens))
                       :font-weight     (if active? 600 400)}}
    [:span {:style {:margin-right "8px"
                    :color        (if active?
@@ -189,14 +177,7 @@
       active?  "◉"
       dormant? "◌"   ; per spec/006-Hydration-Debugger.md §Visibility
       :else    "○")]
-   label
-   (when (and (not active?) live? (not dormant?))
-     [:span {:style {:margin-left "8px"
-                     :color       (:accent-violet tokens)
-                     :font-size   "10px"
-                     :text-transform "uppercase"
-                     :letter-spacing "0.5px"}}
-      "live"])])
+   label])
 
 (defn- sidebar
   "Sidebar (192px) — panel navigation + density toggle. Per spec/007-
@@ -244,42 +225,29 @@
              ^{:key id}
              [sidebar-item item (= id active)]))]))
 
-(defn- stub-panel
-  "Phase 1 'Coming soon' placeholder still used by every non-hero
-  sidebar item until its own bead lands."
-  [{:keys [label bead]}]
-  [:main {:style {:flex             1
-                  :overflow         "auto"
-                  :padding          "24px"
-                  :background       (:bg-2 tokens)
-                  :color            (:text-primary tokens)
-                  :font-family      "Inter, system-ui, -apple-system, Segoe UI, sans-serif"}}
-   [:div {:style {:max-width "640px"}}
-    [:h1 {:style {:font-size "16px" :font-weight 600 :margin "0 0 12px 0"
-                  :color     (:text-primary tokens)}}
-     label]
-    [:p {:style {:font-size "14px" :line-height 1.5
-                 :color     (:text-secondary tokens)
-                 :margin    "0 0 16px 0"}}
-     "Coming soon — this panel ships under "
-     [:code {:style {:font-family "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace"
-                     :font-size   "13px"
-                     :color       (:accent-violet tokens)}}
-      bead]
-     " of the rf2-5aw5v Causa epic."]]])
+(defn- unknown-panel
+  "Defensive fallback for `:rf.causa/selected-panel` carrying an id
+  that isn't in the canvas's case table. Every sidebar entry maps to
+  a live panel; this branch only fires if the host writes an
+  unrecognised id via direct dispatch."
+  [selected]
+  [:main {:style {:flex        1
+                  :overflow    "auto"
+                  :padding     "24px"
+                  :background  (:bg-2 tokens)
+                  :color       (:text-primary tokens)
+                  :font-family "Inter, system-ui, -apple-system, Segoe UI, sans-serif"}}
+   [:p {:style {:font-size "14px" :color (:text-secondary tokens)}}
+    "Unknown panel: " [:code (pr-str selected)]]])
 
 (defn- canvas
-  "Canvas — renders the active panel's content. Phase 2 mounts the
-  live `:event-detail` panel; every other slot still renders the
-  Phase 1 'Coming soon' stub.
-
-  The match is on `:rf.causa/selected-panel`. When a row dispatches
+  "Canvas — renders the active panel's content. The match is on
+  `:rf.causa/selected-panel`. When a row dispatches
   `:rf.causa/select-panel <id>` the registry sets `:selected-panel`
   on the `:rf/causa` frame's app-db and this canvas recomputes."
   []
   (let [selected (or @(rf/subscribe [:rf.causa/selected-panel])
-                     registry/default-panel-id)
-        item     (some #(when (= (:id %) selected) %) sidebar-items)]
+                     registry/default-panel-id)]
     (case selected
       :event-detail [event-detail/event-detail-view]
       :time-travel  [time-travel/time-travel-view]
@@ -304,8 +272,7 @@
       ;; canvas; the rail still lives in the shell's right margin per
       ;; spec/007-UX-IA.md §The five regions item 4.
       :copilot      [ai-co-pilot/ai-co-pilot-view]
-      [stub-panel (or item {:label "Unknown panel"
-                            :bead  "rf2-xxx"})])))
+      [unknown-panel selected])))
 
 (defn- bottom-rail
   "Bottom rail (40px) — time-travel scrubber + frame info + issues

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -112,9 +112,9 @@
   causality strip + frame picker + global actions (Issues badge,
   epoch counter, command palette, help, close).
 
-  Phase 1 stub: brand mark + version label + close-affordance text.
-  Live causality strip / frame picker / Issues badge land with their
-  respective panel beads (rf2-xxx)."
+  v1 stub: brand mark + version label + close-affordance text.
+  Live causality strip / frame picker / Issues badge land as
+  follow-on work."
   [_props]
   [:div {:style {:display          "flex"
                  :align-items      "center"
@@ -302,7 +302,7 @@
                       :color            (:text-tertiary tokens)
                       :font-family      "Inter, system-ui, -apple-system, Segoe UI, sans-serif"
                       :font-size        "12px"}}
-     [:span "◀◀  ────●────  ▶▶  (scrubber — rf2-xxx)"]
+     [:span "◀◀  ────●────  ▶▶  (scrubber)"]
      (when (pos? redacted-count)
        [:span {:data-testid "rf-causa-redacted-indicator"
                :title       (str "Spec 009 §Privacy: " redacted-count

--- a/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
@@ -37,7 +37,7 @@
   opts in via `(causa-config/configure! {:trace/show-sensitive?
   true})`.
 
-  ## Reactivity (rf2-iw5ym → rf2-e9s81)
+  ## Reactivity
 
   The buffer is held in a plain atom (`buffer-state` below). The
   `:rf.causa/trace-buffer` sub (in `registry.cljs`) thunks
@@ -51,27 +51,12 @@
   the host's next dispatch, indistinguishable from native trace-
   rate UI cadence on every example app the foundation ships.
 
-  History — rf2-iw5ym originally added a parallel write path
-  (`:rf.causa/note-trace-event` dispatch) so the sub would
-  re-fire IMMEDIATELY on every push (no dependency on a sibling
-  sub recomputing). That parallel path picked `:rf/causa` as its
-  write target, but `:rf/causa` is never registered in production
-  (the preload runs at ns-load time, BEFORE the host's
-  `rf/init!` installs a substrate adapter — `reg-frame` fails in
-  that window) so the dispatch silently no-op'd and step 5 of
-  `examples/.../causa.spec.cjs` went red. rf2-higwg patched the
-  parallel suppressed-counter path to chain-resolve to
-  `:rf/default`; rf2-e9s81 tried the same for the trace buffer
-  but exposed two failure modes (conformance fixtures saw the
-  trace-cb's dispatches consume drain-depth headroom and
-  pollute their `:rf/default` app-db with `:trace-buffer`
-  noise). The conclusion: an architecturally clean
-  reactive-on-every-push surface requires either reg-view-
-  wrapping Causa's panels (so plain-fn subscribes route to
-  `:rf/causa` via the React-context tier) or a fixed-frame
-  sub mechanism — both wider refactors filed for follow-up.
-  Until then, the layer-1 + host-driven recompute path
-  delivers the same UX without the layering hazards."
+  An architecturally clean reactive-on-every-push surface would
+  require either reg-view-wrapping Causa's panels (so plain-fn
+  subscribes route to `:rf/causa` via the React-context tier) or a
+  fixed-frame sub mechanism — both wider refactors filed for follow-
+  up. Until then, the layer-1 + host-driven recompute path delivers
+  the same UX without the layering hazards."
   (:require [re-frame.interop :as interop]
             [day8.re-frame2-causa.config :as config]))
 

--- a/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
@@ -154,20 +154,20 @@
   []
   @buffer-depth)
 
-;; ---- consumer-side filter (rf2-qi8au) -----------------------------------
+;; ---- consumer-side filter ------------------------------------------------
 ;;
 ;; Causa's panels slice the buffer by the same filter vocabulary the
 ;; framework exposes on `(rf/trace-buffer opts)` per Spec 009 §Retain-N
-;; trace ring buffer (rf2-97ah0 extended the vocab with nine axes —
-;; :severity / :event-id / :handler-id / :source / :origin / :dispatch-id /
-;; :since-ms / :between / :pred — on top of the original :operation /
-;; :op-type / :since / :frame). The framework's filter is private inside
-;; `trace-buffer`; consumers wanting the same algebra against a buffer
-;; they hold themselves (Causa's deeper ring; a snapshot lifted out of a
-;; session) would otherwise duplicate the predicate. `filter-events`
-;; exposes that algebra as a pure-data fn against an arbitrary event
-;; vector, locking the consumer contract: when Causa panels begin
-;; slicing the buffer, they use the same vocabulary the framework does.
+;; trace ring buffer + §Filter vocabulary — the 13-axis vocabulary
+;; (:operation / :op-type / :since / :frame / :severity / :event-id /
+;; :handler-id / :source / :origin / :dispatch-id / :since-ms / :between
+;; / :pred). The framework's filter is private inside `trace-buffer`;
+;; consumers wanting the same algebra against a buffer they hold
+;; themselves (Causa's deeper ring; a snapshot lifted out of a session)
+;; would otherwise duplicate the predicate. `filter-events` exposes that
+;; algebra as a pure-data fn against an arbitrary event vector, locking
+;; the consumer contract: when Causa panels begin slicing the buffer,
+;; they use the same vocabulary the framework does.
 ;;
 ;; Pure-data + JVM-runnable so the JVM test suite can drive every axis
 ;; without booting a CLJS runtime. No atoms, no interop, no swap!.
@@ -180,15 +180,13 @@
   filter algebra so Causa-side consumers slice the buffer using the
   same vocabulary the framework exposes.
 
-  Recognised keys (per Spec 009 §Retain-N trace ring buffer + rf2-97ah0):
+  Recognised keys (the 13-axis vocabulary per Spec 009 §Retain-N
+  trace ring buffer + §Filter vocabulary):
 
-    Pre-rf2-97ah0:
       :operation     — keep events with this :operation value.
       :op-type       — keep events with this :op-type value.
       :since         — keep events whose :id is strictly greater.
       :frame         — keep events whose :frame (top-level or :tags) matches.
-
-    rf2-97ah0 extensions:
       :severity      — keep events whose :op-type matches the tier
                        (:error / :warning / :info). Synonym for :op-type
                        restricted to those three values.
@@ -198,7 +196,7 @@
                        from :tags by emit!) matches.
       :origin        — keep events whose :tags :origin matches.
       :dispatch-id   — keep events whose :tags :dispatch-id matches
-                       (cascade-wide per rf2-g6ih4).
+                       (cascade-wide).
       :since-ms      — keep events whose :time is strictly greater than
                        this host-clock timestamp.
       :between       — `[t0 t1]` two-element vector — keep events whose
@@ -207,8 +205,8 @@
 
   Returns `events` unchanged (as a vector) when `opts` is empty or nil.
 
-  Per rf2-qi8au — locks the consumer contract against the framework's
-  filter vocabulary."
+  Locks the consumer contract against the framework's filter
+  vocabulary."
   ([events] (filter-events events nil))
   ([events opts]
    (if (empty? opts)

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_helpers_cljs_test.cljc
@@ -265,8 +265,8 @@
     (is (= [[:c] [:a] [:b]] (get s1 :rf/default))
         "user-supplied permutation overwrites the previous order")))
 
-(deftest pins-for-frame-defaults-to-empty
-  (is (= [] (h/pins-for-frame {} :rf/default))))
+(deftest slice-pins-for-frame-defaults-to-empty
+  (is (= [] (h/slice-pins-for-frame {} :rf/default))))
 
 (deftest live-pinned-slices-derefs-against-current-db
   (testing "live-pinned-slices projects per-pin :path + current :value"

--- a/tools/causa/test/day8/re_frame2_causa/panels/causality_graph_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/causality_graph_cljs_test.cljc
@@ -234,7 +234,7 @@
 (deftest layout-deterministic-over-the-same-input
   (testing "two runs of compute-layout over identical input yield identical
             positions — required so the panel can diff layouts for the
-            animation hook (rf2-xxx)"
+            animation hook"
     (let [trace  (concat (cascade-events 0   100 [:a])
                          (cascade-events 100 200 [:b] 100)
                          (cascade-events 200 300 [:c] 200))

--- a/tools/causa/test/day8/re_frame2_causa/preload_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/preload_cljs_test.cljs
@@ -30,7 +30,7 @@
   ring-buffer manipulation. Neither the DOM nor a substrate's React-
   context tier is exercised. Browser-side concerns (mount, keydown
   listener, shell render) live in browser-test files filed under
-  subsequent panel beads (rf2-xxx) — keeping the foundation's tests
+  per-panel browser tests — keeping the foundation's tests
   on node-test keeps them fast and host-portable."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -88,6 +88,7 @@
   [:rf.causa/active-route-slice
    :rf.causa/active-route-slice-override
    :rf.causa/app-db-diff
+   :rf.causa/cascades
    :rf.causa/causality-graph-data
    :rf.causa/effects-data
    :rf.causa/epoch-history
@@ -241,9 +242,8 @@
           (str "expected :fx handler for " fx-id)))))
 
 (deftest registry-counts-match-bead
-  (testing "registry holds exactly 64 subs + 60 events + 3 fxs (rf2-5zl7l;
-            +2 events for rf2-0vxdn; -3 events for rf2-e9s81)"
-    (is (= 64 (count all-sub-names)))
+  (testing "registry holds exactly 65 subs + 60 events + 3 fxs"
+    (is (= 65 (count all-sub-names)))
     (is (= 60 (count all-event-names)))
     (is (= 3  (count all-fx-names)))))
 
@@ -257,6 +257,25 @@
       (is (identical? h1 (registrar/handler :sub :rf.causa/selected-panel)))
       (is (identical? e1 (registrar/handler :event :rf.causa/select-panel)))
       (is (identical? f1 (registrar/handler :fx :rf.causa.fx/restore-epoch))))))
+
+(deftest registers-every-canonical-rf-causa-sub
+  ;; Holistic subscribe-side smoke. The handler-resolution smokes above
+  ;; assert that the registrar holds a handler for each id; this test
+  ;; takes the subscriber's view — `(rf/subscribe [q-v])` returns a
+  ;; non-nil reaction for every canonical sub-id once the registrar has
+  ;; run. The two smokes catch different drift: handler-resolution
+  ;; catches a missing registration; subscribe-resolution catches a sub
+  ;; whose subscribe path throws (e.g. a downstream `install!` that
+  ;; depends on a not-yet-registered upstream).
+  (testing "every :rf.causa/* sub-id resolves through rf/subscribe after
+            register-causa-handlers! runs (panel migrations should not
+            silently drop a registration from the orchestrator)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (doseq [q-v all-sub-names]
+        (is (some? (rf/subscribe [q-v]))
+            (str q-v " must resolve through rf/subscribe after
+                 register-causa-handlers!"))))))
 
 ;; ---- (2) high-value sub contracts: defaults on a fresh frame ------------
 

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -10,7 +10,7 @@
 
     1. The `canvas` panel-routing `case` — a 16-arm switch from
        `:rf.causa/selected-panel` to a per-panel view fn. A typo on
-       one arm silently routes to the `stub-panel` fallback. The
+       one arm silently routes to the `unknown-panel` fallback. The
        arm count + each arm's mapping is asserted here.
 
     2. The bottom-rail `[● REDACTED N]` indicator (rf2-azls9). The
@@ -212,22 +212,19 @@
           (is (= expected-fn (first rendered))
               (str "panel " panel-id " — first element is the expected view fn")))))))
 
-(deftest canvas-routes-unknown-panel-id-to-stub-panel
+(deftest canvas-routes-unknown-panel-id-to-fallback
   (testing "an unknown :rf.causa/selected-panel value falls through to
-            stub-panel (per spec/007-UX-IA.md §The default landing
-            view — every non-arm goes to the 'Coming soon' stub)"
+            the defensive `unknown-panel` branch (every sidebar entry
+            now routes to a live panel; the fallback only fires if a
+            host writes an unrecognised id via direct dispatch)"
     (causa-setup!)
     (rf/with-frame :rf/causa
       (select-panel! :rf.causa.test/unknown-panel-id)
       (let [rendered (#'shell/canvas)]
-        ;; stub-panel is private — assert by its rendered hallmark.
         (is (vector? rendered) "canvas always returns a hiccup vector")
-        (is (re-find #"Coming soon"
-                     (text-nodes rendered))
-            "the stub-panel's 'Coming soon' copy is on screen")
         (is (re-find #"Unknown panel"
                      (text-nodes rendered))
-            "stub-panel uses the {:label \"Unknown panel\"} fallback")))))
+            "the fallback labels the selection as unknown")))))
 
 (deftest canvas-defaults-to-event-detail-when-selection-unset
   (testing "Lock 7 — :event-detail is the default landing panel.


### PR DESCRIPTION
## Summary

Batched-by-surface dispatch of the 10 round-2 audit follow-on beads for `tools/causa/` (parent audit: rf2-imynx). One PR, ten commits — one per bead, sequenced so the hot-file work on `registry.cljs` (perf → docstring trim) runs in lock-step without intra-PR conflict.

The batch covers all P1/P2/P3 follow-ons that don't depend on the big P0 install! migration (rf2-d4xda). The three explicitly-deferred beads — rf2-d4xda (16-panel migration), rf2-rclvn (theme tokens hoist), rf2-it8lz (core.cljs facade — decision-blocked) — are NOT touched here.

## Beads delivered (10)

| Commit | Bead | One-line outcome |
|---|---|---|
| 27494f80 | **rf2-lztqr** (P1) | Share `group-cascades` projection across event-detail / causality-graph / performance composites via new `:rf.causa/cascades` intermediate sub — 3× O(buffer) work per trace push → 1×. |
| 8333c589 | **rf2-vd4sb** (P2) | Trim bead-historical narrative from `registry.cljs` ns docstring (140L of per-Phase enumerations → contract paragraph), `trace_bus.cljc` (drop the rf2-iw5ym→rf2-e9s81 reactivity lineage), and `config.cljc` (drop rf2-0vxdn / rf2-higwg from `note-suppressed!` + `reset-suppressed-count!`). |
| 2a8e589d | **rf2-0pjuv** (P2) | Collapse the redundant CLJC reader-conditional in `trace_helpers.cljc` (both branches were `[clojure.string :as str]`). |
| dc5a2e1b | **rf2-w5wcn** (P3) | Refresh '9-axis' / 'nine axes' → '13-axis' across `trace_helpers.cljc`, `trace.cljs`, `registry.cljs`, `trace_bus.cljc`; flatten the trace-bus filter Pre/Extensions split to a single 13-key enumeration. |
| 10a1cda3 | **rf2-qcw0q** (P2) | Factor `ctrl-shift-key?` predicate in `keybinding.cljs`. `causa-toggle-key?` + `copilot-toggle-key?` collapse from 9-line near-twins to 4-liners over the shared modifier predicate. |
| 22d61fee | **rf2-9uhjs** (P2) | Drop dead `stub-panel` + `:bead` / `:live?` sidebar slots in `shell.cljs` (every panel is live; the "LIVE" badge was repetitive UX noise). Replace `stub-panel` fallback with a defensive `unknown-panel` branch; update shell test. |
| a2f17997 | **rf2-3n49j** (P2) | Sweep 15 `rf2-xxx` placeholder TODOs across `tools/causa/` — none had a real bead in `bd` (no frame-picker bead, no scrubber bead). Rephrase each site without the marker. |
| 4f120f04 | **rf2-t15wb** (P2) | Rename clashing `pins-for-frame` helpers: `time-travel-helpers/pins-for-frame` → `epoch-pins-for-frame`, `app-db-diff-helpers/pins-for-frame` → `slice-pins-for-frame`. Different store shapes; not interchangeable. |
| 39e98072 | **rf2-blj8b** (P2) | Align `tools/causa/spec/API.md` panel-export list with the actual panel symbols today (16 panels, `*-view` symbols — not 15 panels, `Panel` symbols). Note the embedding-facade decision is open under rf2-it8lz. |
| 3df4aa12 | **rf2-tyuos** (P2) | Add holistic `rf/subscribe`-based registration smoke test (distinct from the existing `registrar/handler`-based smoke). Add `:rf.causa/cascades` to `all-sub-names`; bump count 64 → 65. |

## Test plan

- [x] `cd implementation && npm run test:cljs` — 1817 tests / 5105 assertions / 0 failures
- [x] `cd tools/causa && clojure -M:test` — 488 tests / 1363 assertions / 0 failures
- [x] `cd implementation && npm run test:bundle-isolation` — PASS
- [x] `python scripts/check_skill_mcp_drift.py` — exit 0