### PR TITLE
refactor(story-mcp): elide-app-db include? branch skips the no-op walk (rf2-brehq)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
@@ -149,16 +149,25 @@
 (defn elide-app-db
   "Run `app-db` through `re-frame.core/elide-wire-value` against
   `variant-id`'s frame registry. Returns the elided value, or the input
-  unchanged when `include?` is true. Nil-safe — a nil `app-db` short-
-  circuits (the walker treats nil as a non-elidable scalar, but we
-  pre-check to avoid the registry lookup on the empty-frame happy path)."
+  unchanged when `include?` is true.
+
+  Two short-circuits avoid pointless work:
+
+    - Nil-safe — a nil `app-db` returns immediately (the walker treats
+      nil as a non-elidable scalar, but we pre-check to avoid the
+      registry lookup on the empty-frame happy path).
+
+    - `include? true` returns the input unchanged. With both inclusion
+      knobs flipped on the walker yields `v` at every node (per
+      `elide-wire-value`'s composition rule: `sensitive?` and `large?`
+      both return `v` when their inclusion flag is true; no marker
+      emit, no `write-runtime-flagged!`, no warning). The walk is a
+      pure no-op — full traversal, zero edits — so we skip it. The
+      escape hatch should be free."
   [app-db variant-id include?]
   (cond
     (nil? app-db) app-db
-    include?      (rf/elide-wire-value app-db
-                                       {:frame                       variant-id
-                                        :rf.size/include-sensitive?  true
-                                        :rf.size/include-large?      true})
+    include?      app-db
     :else         (rf/elide-wire-value app-db {:frame variant-id})))
 
 (defn scrub-assertions

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -1044,6 +1044,55 @@
         (is (success? r))
         (is (= "TOPSECRET" (get-in s [:app-db :secret])))))))
 
+(deftest elide-app-db-include?-true-bypasses-walker
+  ;; rf2-brehq — the `include? true` branch of `helpers/elide-app-db`
+  ;; skips `elide-wire-value` entirely. Pins behavioural equivalence
+  ;; with the previous walking-then-no-edit implementation:
+  ;;
+  ;;   1. The return is the input db itself (`identical?`) — the walker
+  ;;      would have rebuilt every map / vector via `reduce-kv` and
+  ;;      `mapv`, breaking identity even though value would be
+  ;;      preserved. The bypass returns the original reference.
+  ;;
+  ;;   2. The return is value-equal to running the walker with both
+  ;;      inclusion knobs flipped (the previous behaviour). Future
+  ;;      refactors that reintroduce walker work on this branch will
+  ;;      still pass (2) but break (1) — the load-bearing perf invariant
+  ;;      this bead fixes.
+  ;;
+  ;; Calls `helpers/elide-app-db` directly so the test pins the helper's
+  ;; contract, not a downstream tool's composition of it. Avoids
+  ;; coupling to `run-variant`'s lifecycle behaviour.
+  (testing ":include? true returns the input ref unchanged AND matches walker-with-both-knobs-on"
+    (with-clean-frame [vid :story.button/primary]
+      (let [db {:public    "ok"
+                :secret    "TOPSECRET"
+                :nested    {:also-secret "DEEP"
+                            :public-leaf 42}
+                :coll      [:a :b :c]
+                :empty-map {}}]
+        ;; Populate the elision registry on vid's frame so the walker
+        ;; has something to consult — the bypass-equivalence proof only
+        ;; works if the walker WOULD have visited sensitive paths.
+        (seed-app-db! vid db)
+        (declare-sensitive! vid [:secret])
+        (declare-sensitive! vid [:nested :also-secret])
+        (let [frame-db (read-frame-db vid)
+              bypass   ((requiring-resolve 're-frame.story-mcp.tools.helpers/elide-app-db)
+                        frame-db vid true)
+              walked   (rf/elide-wire-value frame-db
+                                            {:frame                      vid
+                                             :rf.size/include-sensitive? true
+                                             :rf.size/include-large?     true})]
+          (is (identical? frame-db bypass)
+              "include? true returns the SAME object — no walker rebuild")
+          (is (= walked bypass)
+              "bypass output value-equals the previous walking-then-no-edit output")
+          (is (= "TOPSECRET" (get bypass :secret))
+              "top-level sensitive slot rides through")
+          (is (= "DEEP" (get-in bypass [:nested :also-secret]))
+              "nested sensitive slot rides through"))))))
+
 (deftest read-failures-strips-sensitive-assertion-records-by-default
   (testing "an assertion record stamped :sensitive? true is dropped at egress"
     (with-clean-frame [vid :story.button/primary]


### PR DESCRIPTION
## Summary

Per round-2 audit `rf2-w8jxf` (R2-H1 / win #2). The `include? true` branch of `helpers/elide-app-db` was passing `:rf.size/include-sensitive? true` + `:rf.size/include-large? true` into `elide-wire-value` — a walker that traverses the entire app-db but yields `v` unchanged at every node when both knobs are on. Pure cost, zero benefit. The escape hatch should be free.

Now: `include? true` returns `app-db` directly; the `include? false` branch still routes through the walker for the privacy-by-default contract.

## Contract verification

Re-read `re-frame.elision/walk` to confirm no other side-effects on the include path:

- `sensitive?` branch — `(if include-sensitive? v redacted-sentinel)`. With knob on, returns `v`. No side-effects.
- `large?` branch — `(if include-large? v (do (when auto-large? (write-runtime-flagged! ...) (trace/emit! :warning ...)) (->marker ...)))`. With knob on, returns `v` BEFORE the side-effecting `do`. No write, no warning.
- Otherwise — recurse into containers (every recursion ends in a `v`-unchanged terminal).

Safe.

## Regression test

`elide-app-db-include?-true-bypasses-walker` pins two invariants:

1. `(identical? frame-db (elide-app-db frame-db vid true))` — the bypass returns the SAME object (the walker rebuilds maps via `reduce-kv` + `assoc`, breaking identity even when value is preserved). If a future refactor reintroduces walker work on this branch, this assertion fires.
2. `(= walked bypass)` where `walked = (elide-wire-value ... {:include-sensitive? true :include-large? true})` — value-equal to the previous walking-then-no-edit output.

Db carries sensitive declarations at both top-level (`[:secret]`) and nested (`[:nested :also-secret]`) paths so the walker WOULD have visited.

## Perf note

~100 KB app-db on `:include-sensitive? true`: full walk (microseconds-per-node) eliminated. Followed by `pr-str` + cap measurement as before. Estimated savings on a ballpark 100 KB / few-hundred-node tree: O(node-count) walker dispatches per call, dominated by recursive `reduce-kv` and `mapv` allocations — savings scale linearly with db size, free on the escape-hatch path which had nothing to gain from the walk.

## Test plan

- [x] `cd tools/story-mcp && clojure -M:test` — green (87 tests, 453 assertions; including the new regression)
- [x] `cd implementation && npm run test:cljs` — green (1816 tests, 5040 assertions)