### PR TITLE
docs(spec): drop :frame {:optional true} on :rf/app-schema-meta (rf2-1y44d)

### DIFF
--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -292,7 +292,7 @@ The metadata stamped on the schemas artefact's per-frame side-table entry by `re
    [:map
     [:path         [:vector :any]]                                           ;; runtime-stamped from positional arg; the app-db path the schema validates
     [:schema       :any]                                                     ;; runtime-stamped; the Malli (or equivalent) schema value
-    [:frame        {:optional true} :keyword]                                ;; the frame the schema registers against (default: (current-frame))
+    [:frame        :keyword]                                                 ;; runtime-stamped; the frame the schema registers against (`(:frame opts)` ?? `(current-frame)`)
     ]])
 ```
 


### PR DESCRIPTION
## Summary

`spec/Spec-Schemas.md §:rf/app-schema-meta` declares `:frame {:optional true}`, but `reg-app-schema` (`implementation/schemas/src/re_frame/schemas/storage.cljc:71-75`) always stamps `:frame frame-id` via `(:frame opts)` ?? `(frame/current-frame)`. Per Spec 010 §Per-frame schemas, `:frame` is required — the slot records which frame owns the registration. Drop the `{:optional true}` marker and align the inline comment with the runtime-stamping style used by the `:path`/`:schema` rows above.

One line in `spec/Spec-Schemas.md`.

## Test plan
- [x] `python scripts/check_doc_slugs.py` — 3 known pre-existing broken anchors; no new ones.