### PR TITLE
refactor(machines): unify initial-snapshot helper (rf2-fgqs4)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -10,8 +10,10 @@
       `re-frame.machines.lifecycle-fx.validation`: parallel shape,
       `:invoke-all` shape, dropped `:timeout-ms` slots, guard/action
       ref resolution, final-state shape).
-    - `synthesise-initial-snapshot` — initial-state cascade, `:data` /
-      `:meta` seeding, tag union stamping (lazily, on first event).
+    - `parallel/build-initial-snapshot` (rf2-fgqs4) — initial-state
+      cascade, `:data` / `:meta` / `:rf/spawn-counter` seeding, tag union
+      stamping (lazily, on first event). Single source of truth shared
+      with the spawn path.
     - the returned handler fn — frame stamping, `intercept-invoke-all-
       event` branch (in `lifecycle-fx.join`), bootstrap-pending
       detection + initial-entry cascade, machine-transition dispatch,
@@ -28,46 +30,12 @@
             [re-frame.machines.transition :as transition]
             [re-frame.trace :as trace]))
 
-(defn- synthesise-initial-snapshot
-  "Build the lazily-synthesised initial snapshot for `machine` (rf2-f9tu).
-
-  Per Spec 005 §Initial-state cascading and §Parallel regions: for flat /
-  compound machines, descends the root `:initial` cascade to a leaf path;
-  for parallel-region machines, `:state` becomes a map of region-name →
-  that region's cascaded initial.
-
-  Per Spec 005 §Snapshot shape (`{:state :data :meta?}`): the spec's
-  optional `:meta` propagates onto the snapshot so the 3-arity ctx and
-  any downstream version-check see the same `:meta` the spec declares.
-
-  Per Spec 005 §State tags (rf2-ee0d) / §Tags compose across regions
-  (rf2-l67o): the initial tag union is stamped via
-  `commit-tags-parallel`; the slot is elided when the union is empty."
-  [machine]
-  (let [initial-state (cond
-                        (parallel/parallel? machine)
-                        (into {}
-                              (for [[rn region-body] (:regions machine)]
-                                [rn (parallel/region-initial-state region-body)]))
-
-                        :else
-                        (let [decl (:initial machine)]
-                          (transition/denormalise-state
-                            (transition/initial-cascade machine (transition/state-path decl))
-                            decl)))
-        initial    (cond-> {:state            initial-state
-                            :data             (or (:data machine) {})
-                            ;; Per rf2-gr8q: the spawn-id allocator lives
-                            ;; in-snapshot at `:rf/spawn-counter` so that
-                            ;; `machine-transition` is an honest pure
-                            ;; function. The slot is always present on
-                            ;; live snapshots (seeded here at registration
-                            ;; time); pure-call snapshots (the conformance
-                            ;; harness) may omit it — the reducer treats
-                            ;; absent slots as 0 via fnil-update.
-                            :rf/spawn-counter {}}
-                     (some? (:meta machine)) (assoc :meta (:meta machine)))]
-    (parallel/commit-tags-parallel machine initial)))
+;; Per rf2-fgqs4 the initial-snapshot builder lives in `parallel.cljc` as
+;; `build-initial-snapshot` — single source of truth for both the
+;; singleton-registration path (here) and the spawn path
+;; (`lifecycle-fx.spawn/install-spawn!`). The two used to drift: the spawn
+;; path silently omitted `:rf/spawn-counter` and `:meta`. See
+;; `parallel/build-initial-snapshot` for the canonical 6-step shape.
 
 ;; ---- handler factory ------------------------------------------------------
 
@@ -251,8 +219,9 @@
 
   Per rf2-f9tu the body is decomposed into:
     - `validation/validate-machine!` — every registration-time check.
-    - `synthesise-initial-snapshot` — initial-state cascade, `:data` /
-      `:meta` seeding, tag union stamping.
+    - `parallel/build-initial-snapshot` — initial-state cascade, `:data` /
+      `:meta` seeding, `:rf/spawn-counter` seeding, tag union stamping
+      (rf2-fgqs4 unified this with the spawn path).
     - the returned handler fn — frame stamping, intercept-invoke-all-
       event branch (in `lifecycle-fx.join`), bootstrap-pending detection
       + initial-entry cascade, machine-transition dispatch, action-failure
@@ -264,7 +233,7 @@
   event short-circuit branching off after step 1."
   [machine]
   (validation/validate-machine! machine)
-  ;; Per rf2-f9tu — `synthesise-initial-snapshot` runs lazily INSIDE the
+  ;; Per rf2-f9tu — `build-initial-snapshot` runs lazily INSIDE the
   ;; returned handler, not at registration time. The initial-state
   ;; computation reaches through `:initial` / `:states` / `:regions`;
   ;; running it at registration time would force every registered spec
@@ -273,7 +242,12 @@
   ;; `:initial` derives from a fn-form computed at dispatch time) to
   ;; satisfy the snapshot shape at reg-machine call time. The original
   ;; (pre-split) implementation deferred this work; preserve that.
-  (let [base-initial (delay (synthesise-initial-snapshot machine))]
+  ;;
+  ;; Pass `:bootstrap-pending? false` — the singleton path stamps the
+  ;; marker lazily inside `prepare-machine-ctx` (when `existing-snap` is
+  ;; nil); only the spawn path needs it stamped here.
+  (let [base-initial (delay (parallel/build-initial-snapshot
+                              machine {:bootstrap-pending? false}))]
     (fn [{:keys [db frame] :as _cofx} event]
       ;; Per Spec 009 §:op-type vocabulary: `:rf.machine/event-received`
       ;; fires at the top of the handler so consumers see the inbound

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -23,7 +23,6 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.machines.lifecycle-fx.registration :as registration]
             [re-frame.machines.parallel :as parallel]
-            [re-frame.machines.transition :as transition]
             [re-frame.registrar :as registrar]
             [re-frame.trace :as trace]))
 
@@ -85,32 +84,16 @@
                       invoke-id (assoc :rf/invoke-id invoke-id))]
       (assoc spec :data data'))))
 
-(defn- compute-initial-snapshot
-  "Build the spawned actor's initial snapshot — the same shape the
-  `synthesise-initial-snapshot` registration helper produces, but
-  stamped with `:rf/bootstrap-pending? true` so the actor's first event
-  triggers the initial-entry cascade.
-
-  Per rf2-0z73 the bootstrap-pending marker drives the cascade in the
-  handler; per Spec 005 §Parallel regions, parallel-region children get
-  the region-map state shape."
-  [spec]
-  (let [parallel-child? (parallel/parallel? spec)
-        initial-decl    (:initial spec)
-        initial-state   (cond
-                          parallel-child?
-                          (into {} (for [[rn region-body] (:regions spec)]
-                                     [rn (parallel/region-initial-state region-body)]))
-
-                          :else
-                          (transition/denormalise-state
-                            (transition/initial-cascade spec (transition/state-path initial-decl))
-                            initial-decl))]
-    (-> (parallel/commit-tags-parallel
-          spec
-          {:state initial-state
-           :data  (or (:data spec) {})})
-        (assoc :rf/bootstrap-pending? true))))
+;; Per rf2-fgqs4: the spawned actor's initial snapshot is built by
+;; `parallel/build-initial-snapshot` — the single source of truth shared
+;; with the singleton-registration path
+;; (`lifecycle-fx.registration/create-machine-handler`). Pre-rf2-fgqs4
+;; the spawn-path's local helper silently omitted `:rf/spawn-counter`
+;; (so an `:entry`-declared `:invoke` fell to `allocate-spawned-id`'s
+;; defensive `(fnil inc 0)` backstop) and `:meta` (so spawned actors
+;; that declared `:meta` couldn't introspect it from the snapshot).
+;; The spawn path passes `:bootstrap-pending? true` because the actor's
+;; first dispatch must fire the initial-entry cascade (rf2-0z73).
 
 (defn- install-spawn!
   "Atomically install the spawned actor's initial snapshot, system-id
@@ -125,7 +108,9 @@
   re-read is value-equal to the snapshot the caller already had."
   [frame-id db-after-alloc spec spawned-id
    {:keys [system-id parent-id invoke-id track?]}]
-  (let [initial-snap (when spec (compute-initial-snapshot spec))
+  (let [initial-snap (when spec
+                       (parallel/build-initial-snapshot
+                         spec {:bootstrap-pending? true}))
         existing     (when system-id (get-in db-after-alloc [:rf/system-ids system-id]))]
     (when (and system-id existing (not= existing spawned-id))
       (trace/emit-error! :rf.error/system-id-collision

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -93,6 +93,51 @@
       (dissoc snapshot :tags)
       (assoc snapshot :tags tags))))
 
+(defn build-initial-snapshot
+  "Build the freshly-derived initial snapshot for `machine` (rf2-fgqs4).
+  The single source of truth used by both the singleton-registration path
+  (`lifecycle-fx.registration/create-machine-handler`) and the spawn path
+  (`lifecycle-fx.spawn/install-spawn!`). Steps:
+
+   1. Compute `:state` — for parallel-region machines, a map of
+      region-name → that region's cascaded initial; for flat / compound
+      machines, the root `:initial` cascade denormalised to a leaf path.
+      Per Spec 005 §Initial-state cascading and §Parallel regions.
+   2. Seed `:data` — `(:data machine)` or `{}`.
+   3. Seed `:rf/spawn-counter {}` — per rf2-gr8q the in-snapshot
+      allocator MUST be present on live snapshots so
+      `:entry`-declared `:invoke`s allocate ids through the contract path
+      (not `allocate-spawned-id`'s defensive `(fnil inc 0)` backstop).
+   4. Propagate `:meta` when the spec declares it — per Spec 005 §Snapshot
+      shape, so the 3-arity ctx and downstream version checks see the
+      same `:meta` the spec declares. Spawned actors that declare `:meta`
+      MUST carry it through to the snapshot.
+   5. Stamp the initial tag union via `commit-tags-parallel` — per Spec
+      005 §State tags (rf2-ee0d) / §Tags compose across regions
+      (rf2-l67o); the slot is elided when the union is empty.
+   6. Optionally stamp `:rf/bootstrap-pending? true` (per rf2-0z73) when
+      `bootstrap-pending?` is truthy — the spawn path needs this so the
+      actor's first dispatch fires the initial-entry cascade. The
+      singleton-registration path stamps the marker lazily inside
+      `prepare-machine-ctx` instead (when `existing-snap` is nil), so it
+      passes `bootstrap-pending? false` here."
+  [machine {:keys [bootstrap-pending?]}]
+  (let [initial-state (if (parallel? machine)
+                        (into {}
+                              (for [[rn region-body] (:regions machine)]
+                                [rn (region-initial-state region-body)]))
+                        (let [decl (:initial machine)]
+                          (transition/denormalise-state
+                            (transition/initial-cascade machine (transition/state-path decl))
+                            decl)))
+        base          (cond-> {:state            initial-state
+                               :data             (or (:data machine) {})
+                               :rf/spawn-counter {}}
+                        (some? (:meta machine)) (assoc :meta (:meta machine)))
+        tagged        (commit-tags-parallel machine base)]
+    (cond-> tagged
+      bootstrap-pending? (assoc :rf/bootstrap-pending? true))))
+
 (defn- prefix-region-invoke-id
   "Per Spec 005 §Per-region `:invoke` / `:after` / `:always` scoping:
   spawn / destroy / after-schedule / after-cancel fxs emitted by a region

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -158,8 +158,9 @@
 ;; the snapshot's counter via update-in and the bumped value is the
 ;; allocated id.
 ;;
-;; `synthesise-initial-snapshot` (in re-frame.machines.lifecycle-fx)
-;; stamps `{:rf/spawn-counter {}}` on every freshly-registered machine's
+;; `build-initial-snapshot` (in re-frame.machines.parallel — unified per
+;; rf2-fgqs4 across the singleton-registration and spawn paths) stamps
+;; `{:rf/spawn-counter {}}` on every freshly-registered machine's
 ;; initial snapshot so the slot is always present for live runtime
 ;; spawns. Hand-built snapshots (the conformance fixtures) may omit the
 ;; key — the reducer uses `(fnil inc 0)` so absent slots default to 0.

--- a/implementation/machines/test/re_frame/initial_snapshot_unification_test.clj
+++ b/implementation/machines/test/re_frame/initial_snapshot_unification_test.clj
@@ -1,0 +1,137 @@
+(ns re-frame.initial-snapshot-unification-test
+  "Per rf2-fgqs4 — pinning tests for the unified `build-initial-snapshot`
+  helper in `re-frame.machines.parallel`. Pre-rf2-fgqs4 the spawn path
+  had its own `compute-initial-snapshot` that silently OMITTED two slots
+  the singleton-registration path stamped:
+
+    - `:rf/spawn-counter {}` — the in-snapshot id allocator (rf2-gr8q).
+      A spawned actor whose `:entry` declares an `:invoke` would fall
+      onto `allocate-spawned-id`'s defensive `(fnil inc 0)` backstop
+      instead of the contract path of reading from a present slot.
+
+    - `:meta` — per Spec 005 §Snapshot shape, a spec's optional `:meta`
+      propagates onto the snapshot so 3-arity ctx and downstream
+      version checks see the same `:meta` the spec declares. The spawn
+      path dropped it on the floor.
+
+  These tests pin the unified behaviour at both ends: the helper itself
+  (unit-level) and the end-to-end spawn path (integration-level).
+
+  Pre-fix the integration tests below FAIL on the spawn path; post-fix
+  they PASS on both paths."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.machines :as machines]
+            [re-frame.machines.parallel :as parallel]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.machines :reload)
+  (machines/reset-timers!)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+(defn- snapshot
+  "Read the snapshot for `machine-id` from the default frame's app-db."
+  [machine-id]
+  (get-in (rf/get-frame-db :rf/default) [:rf/machines machine-id]))
+
+;; ---- (1) `parallel/build-initial-snapshot` unit contract -------------------
+;;
+;; Pin the helper's shape directly. Both `:rf/spawn-counter` and `:meta`
+;; (when declared) are always present on the synthesised snapshot;
+;; `:rf/bootstrap-pending?` is opt-in via the option map.
+
+(deftest build-initial-snapshot-stamps-spawn-counter-and-meta
+  (testing "non-bootstrap call — singleton-registration shape"
+    (let [spec {:initial :idle
+                :data    {:counter 0}
+                :meta    {:schema-version 7}
+                :states  {:idle {}}}
+          snap (parallel/build-initial-snapshot spec {:bootstrap-pending? false})]
+      (is (contains? snap :rf/spawn-counter)
+          ":rf/spawn-counter MUST always be present on live snapshots (rf2-gr8q)")
+      (is (= {} (:rf/spawn-counter snap))
+          "starts empty — the slot exists so allocations go through the contract path")
+      (is (= {:schema-version 7} (:meta snap))
+          ":meta from the spec MUST propagate onto the snapshot (Spec 005 §Snapshot shape)")
+      (is (not (contains? snap :rf/bootstrap-pending?))
+          "the singleton path stamps :rf/bootstrap-pending? lazily in `prepare-machine-ctx`, not here")))
+  (testing "bootstrap call — spawn-path shape"
+    (let [spec {:initial :idle
+                :data    {:counter 0}
+                :meta    {:schema-version 7}
+                :states  {:idle {}}}
+          snap (parallel/build-initial-snapshot spec {:bootstrap-pending? true})]
+      (is (contains? snap :rf/spawn-counter)
+          "the spawn-path snapshot ALSO carries :rf/spawn-counter — pre-rf2-fgqs4 this slot was missing")
+      (is (= {} (:rf/spawn-counter snap)))
+      (is (= {:schema-version 7} (:meta snap))
+          "the spawn-path snapshot ALSO carries :meta — pre-rf2-fgqs4 this slot was missing")
+      (is (true? (:rf/bootstrap-pending? snap))
+          "the spawn path stamps the bootstrap marker so the actor's first dispatch fires the :entry cascade (rf2-0z73)")))
+  (testing ":meta absent from spec → :meta absent from snapshot"
+    (let [spec {:initial :idle :data {} :states {:idle {}}}
+          snap (parallel/build-initial-snapshot spec {:bootstrap-pending? true})]
+      (is (not (contains? snap :meta))
+          "no :meta in spec — the helper does not invent one"))))
+
+;; ---- (2) End-to-end spawn integration: :meta propagates --------------------
+;;
+;; A spawned actor whose spec declares `:meta` MUST carry that `:meta`
+;; on its initial snapshot at `[:rf/machines <spawned-id>]`. Pre-rf2-fgqs4
+;; the spawn-path helper silently dropped `:meta`, so any
+;; `^:rf.machine/wants-ctx` action introspecting `:meta` saw nil.
+
+(deftest spawned-actor-snapshot-carries-meta
+  (testing "a spawned actor whose spec declares :meta has it on its snapshot"
+    (let [child  {:initial :running
+                  :data    {}
+                  :meta    {:schema-version 7
+                            :user-tag       :probe}
+                  :states  {:running {}}}
+          parent {:initial :idle
+                  :states  {:idle    {:on {:start :working}}
+                            :working {:invoke {:machine-id :worker/proc}}}}]
+      (rf/reg-machine :worker/proc child)
+      (rf/reg-machine :sup/main parent)
+      (rf/dispatch-sync [:sup/main [:start]])
+      (let [spawned-id (get-in (rf/get-frame-db :rf/default)
+                               [:rf/spawned :sup/main [:working]])
+            child-snap (snapshot spawned-id)]
+        (is (= :worker/proc#1 spawned-id) "(precondition) spawn happened")
+        (is (some? child-snap) "(precondition) snapshot installed")
+        (is (= {:schema-version 7 :user-tag :probe} (:meta child-snap))
+            "spawned actor's snapshot carries the spec's :meta (rf2-fgqs4 fix)")))))
+
+;; ---- (3) End-to-end spawn integration: :rf/spawn-counter slot present ------
+;;
+;; A spawned actor's initial snapshot MUST carry `:rf/spawn-counter` so
+;; an `:entry`-declared `:invoke` on the actor's initial state goes
+;; through the contract path of `allocate-spawned-id` (reading from a
+;; present slot) rather than the defensive `(fnil inc 0)` backstop.
+;; Pre-rf2-fgqs4 the spawn-path snapshot lacked the slot entirely.
+
+(deftest spawned-actor-snapshot-carries-spawn-counter
+  (testing "a spawned actor's snapshot carries :rf/spawn-counter (rf2-gr8q contract)"
+    (let [child  {:initial :running
+                  :data    {}
+                  :states  {:running {}}}
+          parent {:initial :idle
+                  :states  {:idle    {:on {:start :working}}
+                            :working {:invoke {:machine-id :worker/proc}}}}]
+      (rf/reg-machine :worker/proc child)
+      (rf/reg-machine :sup/main parent)
+      (rf/dispatch-sync [:sup/main [:start]])
+      (let [spawned-id (get-in (rf/get-frame-db :rf/default)
+                               [:rf/spawned :sup/main [:working]])
+            child-snap (snapshot spawned-id)]
+        (is (some? child-snap) "(precondition) snapshot installed")
+        (is (contains? child-snap :rf/spawn-counter)
+            "spawned actor's snapshot carries :rf/spawn-counter (rf2-fgqs4 fix)")))))


### PR DESCRIPTION
## Summary

- Extract `parallel/build-initial-snapshot` as the single source of truth used by BOTH the singleton-registration path (`lifecycle-fx.registration/create-machine-handler`) and the spawn path (`lifecycle-fx.spawn/install-spawn!`).
- Closes two silent contract gaps where the spawn-path helper had drifted from the registration-path helper:
  - `:rf/spawn-counter {}` slot — pre-fix omitted by spawn path, leaving `:entry`-declared `:invoke`s on a spawned actor to fall onto `allocate-spawned-id`'s defensive `(fnil inc 0)` backstop instead of the contract path (rf2-gr8q).
  - `:meta` propagation — pre-fix omitted by spawn path, so `^:rf.machine/wants-ctx` actions on a spawned actor saw nil `:meta` even when the spec declared it.
- `:rf/bootstrap-pending?` is now opt-in (spawn path passes `true`, singleton path passes `false` and stamps the marker lazily in `prepare-machine-ctx`).
- Adds `initial-snapshot-unification-test` with three pinning tests: a unit-level test on the helper itself, and two integration tests asserting the spawned actor's snapshot carries `:meta` and `:rf/spawn-counter`.

## Test plan

- [x] `clojure -M:test` in `implementation/machines` — 127 tests / 373 assertions, 0 failures.
- [x] `npm run test:cljs` from `implementation` — 1816 tests / 5040 assertions, 0 failures.
- [x] Regression evidence: with the fix stashed and the test file's `parallel/build-initial-snapshot` reference commented out, the two integration tests FAIL with the expected reasons (`:meta` is nil on the spawned actor's snapshot; `:rf/spawn-counter` is absent from `{:state :running :data {…}}`). With the fix in place all tests pass.