### PR TITLE
refactor(schemas): drop coerce-opts dead nil? branch + ::unset sentinel polish (rf2-cn9uf)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -38,12 +38,14 @@
 
 (defn coerce-opts
   "Permit the keyword-only sugar `(app-schemas frame-id)` and the
-  opts-map form `(app-schemas {:frame frame-id})`."
+  opts-map form `(app-schemas {:frame frame-id})`. Every zero-arity
+  caller (`app-schema-at`, `app-schema-meta-at`, `app-schemas`,
+  `app-schemas-digest`) supplies `{}` explicitly — `nil` is not a
+  permitted argument."
   [opts-or-frame-id]
   (cond
     (keyword? opts-or-frame-id) {:frame opts-or-frame-id}
     (map?     opts-or-frame-id) opts-or-frame-id
-    (nil?     opts-or-frame-id) {}
     :else
     (throw (ex-info ":rf.error/bad-app-schemas-arg"
                     {:received opts-or-frame-id

--- a/implementation/schemas/src/re_frame/schemas/validator.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validator.cljc
@@ -185,18 +185,12 @@
   Last-write-wins on re-registration. Returns the validator that was
   installed (may be nil)."
   [validate-fn-or-map]
-  (cond
-    (map? validate-fn-or-map)
-    (let [{:keys [validate explain print]
-           :or   {validate ::unset
-                  explain  ::unset
-                  print    ::unset}} validate-fn-or-map]
-      (when-not (= ::unset validate) (reset! validator-fn validate))
-      (when-not (= ::unset explain)  (reset! explainer-fn  explain))
-      (when-not (= ::unset print)    (reset! printer-fn    print))
+  (if (map? validate-fn-or-map)
+    (let [m validate-fn-or-map]
+      (when (contains? m :validate) (reset! validator-fn (:validate m)))
+      (when (contains? m :explain)  (reset! explainer-fn (:explain m)))
+      (when (contains? m :print)    (reset! printer-fn   (:print m)))
       @validator-fn)
-
-    :else
     (do (reset! validator-fn validate-fn-or-map)
         @validator-fn)))
 


### PR DESCRIPTION
Closes rf2-cn9uf. Source: rf2-whepe round-2 audit (carried from round-1 Q3/Q4).

## Summary

Two micro-polish cleanups in the schemas validator/storage surface, net **-4 LoC**.

### 1. `storage.cljc` `coerce-opts`: drop dead `nil?` branch

Every zero-arity caller (`app-schema-at`, `app-schema-meta-at`, `app-schemas`, `app-schemas-digest`) explicitly supplies `{}` to the 1-ary entry — `nil` never reaches `coerce-opts`. Dropped the unreachable branch; docstring now states the precondition.

### 2. `validator.cljc` `set-schema-validator!` map arity: ::unset sentinel polish

Replaced the `{validate ::unset explain ::unset print ::unset}` `:or` sentinel trick with `(contains? m :validate)` etc. Reads cleaner; no namespaced sentinel; `nil` as a legitimate value (disable validation) is unambiguous.

```clojure
(when (contains? m :validate) (reset! validator-fn (:validate m)))
(when (contains? m :explain)  (reset! explainer-fn (:explain m)))
(when (contains? m :print)    (reset! printer-fn   (:print m)))
```

## Behavioural delta

Pre-alpha — no in-bounds caller affected. `coerce-opts` callers must pass `keyword | map`; `nil` was undefined behaviour that happened to map to `{}`, now throws `:rf.error/bad-app-schemas-arg` like any other bad arg. Map-arity of `set-schema-validator!` behaves identically.

## Test plan

- [x] `cd implementation/schemas && clojure -M:test` — 133 tests / 383 assertions, 0 failures
- [x] `cd implementation && npm run test:cljs` — 1816 tests / 5040 assertions, 0 failures