### PR TITLE
refactor(http): split http-privacy.cljc into three siblings (rf2-8vofn)

### DIFF
--- a/implementation/http/src/re_frame/http.cljc
+++ b/implementation/http/src/re_frame/http.cljc
@@ -76,7 +76,8 @@
 
   See Spec 014 for the canonical args-map shape."
   (:refer-clojure :exclude [get])
-  (:require [re-frame.http-privacy :as privacy]))
+  (:require [re-frame.http-privacy-headers :as privacy-headers]
+            [re-frame.http-url             :as http-url]))
 
 ;; Privacy surface — Spec 014 §Privacy (rf2-bma05). Re-exported here so
 ;; users who alias `re-frame.http :as rf.http` get a uniform call site
@@ -84,14 +85,14 @@
 (def declare-sensitive-header!
   "Spec 014 §Privacy — extend the header-denylist with an app-specific
   sensitive header. Names stored lower-cased; matching is case-insensitive.
-  See `re-frame.http-privacy/declare-sensitive-header!`."
-  privacy/declare-sensitive-header!)
+  See `re-frame.http-privacy-headers/declare-sensitive-header!`."
+  privacy-headers/declare-sensitive-header!)
 
 (def clear-sensitive-headers!
   "Spec 014 §Privacy — reset the app-extended header-denylist (defaults
   remain). Test-only; production code should not need this.
-  See `re-frame.http-privacy/clear-sensitive-headers!`."
-  privacy/clear-sensitive-headers!)
+  See `re-frame.http-privacy-headers/clear-sensitive-headers!`."
+  privacy-headers/clear-sensitive-headers!)
 
 (def declare-sensitive-query-param!
   "Spec 014 §Privacy (rf2-2p8wr) — extend the query-string-param denylist
@@ -100,15 +101,15 @@
   have the *value* redacted (preserving param name + position) in every
   `:rf.http/*` trace event regardless of the originating handler's
   `:sensitive?` flag.
-  See `re-frame.http-privacy/declare-sensitive-query-param!`."
-  privacy/declare-sensitive-query-param!)
+  See `re-frame.http-url/declare-sensitive-query-param!`."
+  http-url/declare-sensitive-query-param!)
 
 (def clear-sensitive-query-params!
   "Spec 014 §Privacy (rf2-2p8wr) — reset the app-extended query-param
   denylist (defaults remain). Test-only; production code should not
   need this.
-  See `re-frame.http-privacy/clear-sensitive-query-params!`."
-  privacy/clear-sensitive-query-params!)
+  See `re-frame.http-url/clear-sensitive-query-params!`."
+  http-url/clear-sensitive-query-params!)
 
 (defn- build
   "Build a `[:rf.http/managed args-map]` fx vector for the given verb,

--- a/implementation/http/src/re_frame/http_managed.cljc
+++ b/implementation/http/src/re_frame/http_managed.cljc
@@ -80,15 +80,16 @@
   AND performs the artefact's load-time side-effects: the
   `:rf.http/*` fx registrations and the `late-bind/set-fn!` hook
   publications that `re-frame.core` reaches through."
-  (:require [re-frame.fx                :as fx]
-            [re-frame.http-encoding     :as encoding]
+  (:require [re-frame.fx                   :as fx]
+            [re-frame.http-encoding        :as encoding]
             [re-frame.http-machine-wrapper :as machine-wrapper]
-            [re-frame.http-middleware   :as middleware]
-            [re-frame.http-privacy      :as privacy]
-            [re-frame.http-registry     :as registry]
-            [re-frame.http-transport    :as transport]
-            [re-frame.interop           :as interop]
-            [re-frame.late-bind         :as late-bind]))
+            [re-frame.http-middleware      :as middleware]
+            [re-frame.http-privacy         :as privacy]
+            [re-frame.http-privacy-headers :as privacy-headers]
+            [re-frame.http-registry        :as registry]
+            [re-frame.http-transport       :as transport]
+            [re-frame.interop              :as interop]
+            [re-frame.late-bind            :as late-bind]))
 
 ;; ---- public-surface re-exports --------------------------------------------
 ;;
@@ -117,10 +118,12 @@
 (def uninstall-managed-request-stubs! machine-wrapper/uninstall-managed-request-stubs!)
 (def with-managed-request-stubs*      machine-wrapper/with-managed-request-stubs*)
 
-;; Privacy surface — Spec 014 §Privacy (rf2-bma05).
-(def declare-sensitive-header!  privacy/declare-sensitive-header!)
-(def clear-sensitive-headers!   privacy/clear-sensitive-headers!)
-(def default-header-denylist    privacy/default-header-denylist)
+;; Privacy surface — Spec 014 §Privacy (rf2-bma05). Header denylist lives
+;; in `re-frame.http-privacy-headers`; the orchestrating composers
+;; (request-sensitive?, prepare-emit-*) stay in `re-frame.http-privacy`.
+(def declare-sensitive-header!  privacy-headers/declare-sensitive-header!)
+(def clear-sensitive-headers!   privacy-headers/clear-sensitive-headers!)
+(def default-header-denylist    privacy-headers/default-header-denylist)
 
 ;; ---- normalise-args + managed-handler -------------------------------------
 ;;

--- a/implementation/http/src/re_frame/http_privacy.cljc
+++ b/implementation/http/src/re_frame/http_privacy.cljc
@@ -9,21 +9,30 @@
   redacting known-sensitive slots before the value reaches the trace
   surface.
 
+  This namespace is the orchestrating seam — the sensitivity resolver
+  (`request-sensitive?` / `handler-sensitive?`) and the trace-event
+  composers (`prepare-emit-tags` / `prepare-emit-failure` and the
+  redact-* / stamp-sensitive primitives they compose). The two leaf
+  surfaces it draws on live in sibling namespaces:
+
+  - `re-frame.http-privacy-headers` — header denylist + `redact-headers`.
+  - `re-frame.http-url` — query-param denylist + `redact-url` /
+    `redact-url-query-string` / `query-denylist-hit?` (and future home
+    of `url-encode` / `params->query` / `merge-params` per rf2-5ijhk).
+
   Three cooperating mechanisms, mirroring Spec 009's `:sensitive?` /
   `with-redacted` split:
 
-  1. **Header denylist** (this namespace) — a canonical set of always-
-     sensitive header names. Redacted in trace events regardless of
-     the handler / request `:sensitive?` flag, because the headers'
-     names themselves declare them sensitive (an `Authorization` header
-     leaking would be a leak even if the surrounding handler was not
-     declared sensitive).
+  1. **Header denylist** (`re-frame.http-privacy-headers`) — a canonical
+     set of always-sensitive header names. Redacted in trace events
+     regardless of the handler / request `:sensitive?` flag, because
+     the headers' names themselves declare them sensitive.
 
-  2. **Query-param denylist** (this namespace, rf2-2p8wr) — a canonical
-     set of always-sensitive query-string parameter names (e.g.
-     `api_key`, `access_token`, `auth`). URLs carrying these params
-     are redacted **inline** in every `:rf.http/*` trace event that
-     carries a `:url` slot, regardless of the handler / request
+  2. **Query-param denylist** (`re-frame.http-url`, rf2-2p8wr) — a
+     canonical set of always-sensitive query-string parameter names
+     (e.g. `api_key`, `access_token`, `auth`). URLs carrying these
+     params are redacted **inline** in every `:rf.http/*` trace event
+     that carries a `:url` slot, regardless of the handler / request
      `:sensitive?` flag. Same rationale as the header denylist: the
      param name itself is the signal.
 
@@ -44,21 +53,6 @@
   — the presence of a denylisted query param is itself a signal that
   the request carries an auth secret.
 
-  ## Defaults and extensibility
-
-  `default-header-denylist` covers the canonical surface (Authorization,
-  Cookie, Set-Cookie, X-API-Key, X-Auth-Token, Proxy-Authorization,
-  Authentication, WWW-Authenticate, X-CSRF-Token, X-XSRF-Token,
-  X-Session-Token, Proxy-Authenticate). Apps extend via
-  `(declare-sensitive-header! \"X-My-Auth\")` — names are
-  case-insensitive; the registry stores lower-cased.
-
-  `default-query-param-denylist` covers the canonical query-string-auth
-  surface (api_key, apikey, access_token, auth, token, key, secret,
-  password, session, signature, sig). Apps extend via
-  `(declare-sensitive-query-param! \"my_token\")` — names are
-  case-insensitive; the registry stores lower-cased.
-
   ## Production elision
 
   The redact / stamp helpers all gate on `interop/debug-enabled?` at
@@ -67,133 +61,9 @@
   moot. The denylist atoms themselves ship in production (they're
   app-readable state — `declare-sensitive-*!` writes through), but no
   walker runs against them without the trace surface."
-  (:require [clojure.set :as set]
-            [clojure.string :as str]
+  (:require [re-frame.http-privacy-headers :as headers]
+            [re-frame.http-url :as url]
             [re-frame.registrar :as registrar]))
-
-;; ---- header denylist ------------------------------------------------------
-
-(def default-header-denylist
-  "Canonical always-sensitive HTTP header names, lower-cased. These are
-  redacted in `:rf.http/*` trace events regardless of the handler's
-  `:sensitive?` flag — the header names themselves are the signal.
-
-  Drawn from the OWASP Authentication Cheatsheet plus common bearer-
-  scheme headers used by SaaS APIs. Apps extend at boot via
-  `declare-sensitive-header!` for app-specific tokens (e.g.
-  `X-Honeycomb-Team`, `X-Stripe-Signature`)."
-  #{"authorization"
-    "proxy-authorization"
-    "cookie"
-    "set-cookie"
-    "x-api-key"
-    "x-auth-token"
-    "x-session-token"
-    "x-csrf-token"
-    "x-xsrf-token"
-    "authentication"
-    "www-authenticate"
-    "proxy-authenticate"})
-
-(defonce
-  ^{:doc "App-extended denylist. Augments `default-header-denylist`.
-  Names stored lower-cased. Cleared by `clear-sensitive-headers!` for
-  test ergonomics."}
-  extra-headers
-  (atom #{}))
-
-(defn declare-sensitive-header!
-  "Declare a header name as sensitive. Stored lower-cased; matching is
-  case-insensitive when the redactor consults the merged set. Returns
-  the new merged set (defaults ∪ extras)."
-  [header-name]
-  (when (string? header-name)
-    (swap! extra-headers conj (str/lower-case header-name)))
-  (set/union default-header-denylist @extra-headers))
-
-(defn clear-sensitive-headers!
-  "Reset the app-extended header denylist to empty (default denylist
-  remains). Test-only — invoked by reset fixtures alongside
-  `clear-all-in-flight!` and `clear-all-http-interceptors!`."
-  []
-  (reset! extra-headers #{})
-  nil)
-
-(defn sensitive-header?
-  "Predicate: is `header-name` in the merged denylist? Case-insensitive."
-  [header-name]
-  (boolean
-    (when (string? header-name)
-      (contains? (set/union default-header-denylist @extra-headers)
-                 (str/lower-case header-name)))))
-
-;; ---- query-param denylist (rf2-2p8wr) -------------------------------------
-
-(def default-query-param-denylist
-  "Canonical always-sensitive HTTP query-string parameter names, lower-
-  cased. URLs carrying these params have the *values* redacted in
-  `:rf.http/*` trace events regardless of the handler's `:sensitive?`
-  flag — the param names themselves are the signal (mirrors the header
-  denylist contract).
-
-  Drawn from common API-key / bearer-token idioms in older REST APIs,
-  webhook receivers, and signed-URL schemes. Apps extend at boot via
-  `declare-sensitive-query-param!` for app-specific param names (e.g.
-  `\"shop_token\"`, `\"hmac\"`)."
-  #{"api_key"
-    "apikey"
-    "api-key"
-    "access_token"
-    "accesstoken"
-    "auth"
-    "auth_token"
-    "authtoken"
-    "key"
-    "token"
-    "secret"
-    "password"
-    "passwd"
-    "session"
-    "session_id"
-    "sessionid"
-    "signature"
-    "sig"
-    "hmac"})
-
-(defonce
-  ^{:doc "App-extended query-param denylist. Augments
-  `default-query-param-denylist`. Names stored lower-cased. Cleared by
-  `clear-sensitive-query-params!` for test ergonomics."}
-  extra-query-params
-  (atom #{}))
-
-(defn declare-sensitive-query-param!
-  "Declare a query-string parameter name as sensitive. Stored lower-
-  cased; matching is case-insensitive when the redactor consults the
-  merged set. Returns the new merged set (defaults ∪ extras)."
-  [param-name]
-  (when (string? param-name)
-    (swap! extra-query-params conj (str/lower-case param-name)))
-  (set/union default-query-param-denylist @extra-query-params))
-
-(defn clear-sensitive-query-params!
-  "Reset the app-extended query-param denylist to empty (default
-  denylist remains). Test-only — invoked by reset fixtures alongside
-  `clear-sensitive-headers!`."
-  []
-  (reset! extra-query-params #{})
-  nil)
-
-(defn sensitive-query-param?
-  "Predicate: is `param-name` in the merged query-param denylist?
-  Case-insensitive."
-  [param-name]
-  (boolean
-    (when (string? param-name)
-      (contains? (set/union default-query-param-denylist @extra-query-params)
-                 (str/lower-case param-name)))))
-
-;; ---- redaction sentinel ---------------------------------------------------
 
 (def redacted-sentinel
   "The framework-reserved redaction sentinel per Spec 009 §Privacy. Sits
@@ -202,114 +72,83 @@
   check `(= :rf/redacted v)`."
   :rf/redacted)
 
-(def ^:private redacted-url-token
-  "Inline string form of the `:rf/redacted` sentinel suitable for splicing
-  into a URL string. Trace consumers parsing the URL still see a structural
-  token they can detect (`:rf%2Fredacted` once URL-encoded into the wire
-  string we serialise). The unencoded form is `:rf/redacted` — identical
-  text to the keyword's `pr-str` — chosen so a human inspecting a trace
-  event reads the same sentinel they see in any other redacted slot."
-  ":rf/redacted")
+;; ---- trace-event redaction helpers ----------------------------------------
 
-(defn redact-headers
-  "Walk `headers-map` (string→string or string→vector-of-strings); replace
-  values whose key matches the merged header denylist with
-  `:rf/redacted`. Returns a new map; nil/empty input returns the input
-  unchanged. Case-insensitive on header names."
-  [headers-map]
-  (cond
-    (nil? headers-map) headers-map
-    (not (map? headers-map)) headers-map
-    :else
-    (reduce-kv
-      (fn [acc k v]
-        (assoc acc k
-               (if (sensitive-header? (if (keyword? k) (name k) (str k)))
-                 redacted-sentinel
-                 v)))
-      {}
-      headers-map)))
+(defn redact-request-tags
+  "Given a tags map about to ride a `:rf.http/*` trace event, redact
+  the request-side payload when `sensitive?` is true. Always redacts
+  denylisted headers regardless of `sensitive?` — the header denylist
+  is unconditional. URL query-string values whose param name is in the
+  query-param denylist (rf2-2p8wr) are always redacted regardless of
+  `sensitive?` — denylisted param names are themselves the signal.
 
-;; ---- URL query-string redaction (rf2-2p8wr) -------------------------------
+  Idempotent and total: missing slots are left alone."
+  [tags sensitive?]
+  (cond-> tags
+    ;; Always-on header redaction (denylist).
+    (map? (:headers tags))
+    (update :headers headers/redact-headers)
 
-(defn- split-url-on-query
-  "Split `url-str` into `[base query-string]`. `query-string` is nil
-  when the URL has no `?`. Preserves URL fragments (`#…`) on the
-  query-string side so the redactor can put them back verbatim."
-  [url-str]
-  (let [qidx (str/index-of url-str "?")]
-    (if (nil? qidx)
-      [url-str nil]
-      [(subs url-str 0 qidx)
-       (subs url-str (inc qidx))])))
+    ;; URL query-string redaction — always-on for denylisted params
+    ;; (rf2-2p8wr); when sensitive? true ALL params are scrubbed.
+    (string? (:url tags))
+    (update :url url/redact-url sensitive?)
 
-(defn- split-query-on-fragment
-  "Split `query-and-fragment` on the first `#` so the fragment can be
-  preserved verbatim past the redaction step. Returns `[query fragment]`
-  where `fragment` includes the leading `#` or is nil."
-  [query-and-fragment]
-  (if (nil? query-and-fragment)
-    [nil nil]
-    (let [fidx (str/index-of query-and-fragment "#")]
-      (if (nil? fidx)
-        [query-and-fragment nil]
-        [(subs query-and-fragment 0 fidx)
-         (subs query-and-fragment fidx)]))))
+    ;; Sensitive-request redaction — body becomes the sentinel.
+    (and sensitive? (contains? tags :body))
+    (assoc :body redacted-sentinel)
 
-(defn- redact-query-param
-  "Given a single `name=value` pair (string), return the redacted form:
-  `name=:rf/redacted` if the param is denylisted OR `force-all?` is
-  true; the pair unchanged otherwise. Tolerates malformed pairs (no
-  `=`, empty value)."
-  [pair force-all?]
-  (let [eq-idx (str/index-of pair "=")
-        [pname _pvalue] (if eq-idx
-                          [(subs pair 0 eq-idx) (subs pair (inc eq-idx))]
-                          [pair nil])]
-    (if (or force-all? (sensitive-query-param? pname))
-      (str pname "=" redacted-url-token)
-      pair)))
+    ;; Sensitive-request redaction — params (URL query string) too.
+    (and sensitive? (contains? tags :params))
+    (assoc :params redacted-sentinel)))
 
-(defn redact-url-query-string
-  "Redact denylisted query-string parameter values in `url-str`.
+(defn redact-failure
+  "Given a failure map (per Spec 014 §Failure categories) about to ride
+  a `:rf.http/*` trace event, redact response-side payload slots when
+  `sensitive?` is true. Always redacts headers via the denylist; always
+  redacts URL query-string values whose param name is in the query-
+  param denylist (rf2-2p8wr) — denylisted param names are the signal."
+  [failure sensitive?]
+  (when failure
+    (cond-> failure
+      (map? (:headers failure))
+      (update :headers headers/redact-headers)
 
-  When `sensitive?` is true, redacts **every** param value (the broader
-  rule per Spec 014 §Privacy — a sensitive request leaks nothing).
-  When `sensitive?` is false, redacts only values whose param name is
-  in the merged query-param denylist.
+      ;; URL query-string redaction — always-on for denylisted params
+      ;; (rf2-2p8wr); when sensitive? true ALL params are scrubbed.
+      (string? (:url failure))
+      (update :url url/redact-url sensitive?)
 
-  The redaction shape preserves param name + position; only the value
-  is replaced with the framework-reserved `:rf/redacted` text token
-  (e.g. `?api_key=SECRET&page=2` → `?api_key=:rf/redacted&page=2`).
-  Fragment portion (`#…`) preserved verbatim.
+      (and sensitive? (contains? failure :body))
+      (assoc :body redacted-sentinel)
 
-  Returns `[redacted-url any-redacted?]` where `any-redacted?` is true
-  iff at least one param value was redacted (the caller uses this to
-  decide whether to stamp `:sensitive?` per the denylist-is-signal
-  rule). Nil / non-string / no-query inputs return `[url-str false]`."
-  [url-str sensitive?]
-  (cond
-    (not (string? url-str))
-    [url-str false]
+      (and sensitive? (contains? failure :body-text))
+      (assoc :body-text redacted-sentinel)
 
-    :else
-    (let [[base query-and-fragment] (split-url-on-query url-str)
-          [query fragment]          (split-query-on-fragment query-and-fragment)]
-      (if (str/blank? query)
-        [url-str false]
-        (let [pairs    (str/split query #"&")
-              redacted (mapv (fn [p] (redact-query-param p (true? sensitive?)))
-                             pairs)
-              changed? (boolean (some true? (map not= pairs redacted)))
-              rebuilt  (str base "?" (str/join "&" redacted) (or fragment ""))]
-          [rebuilt changed?])))))
+      (and sensitive? (contains? failure :decoded))
+      (assoc :decoded redacted-sentinel)
 
-(defn redact-url
-  "Convenience wrapper around `redact-url-query-string` that returns only
-  the redacted URL string. Use when the caller does not need the
-  any-redacted? flag (e.g. inside a generic tag-walker)."
-  [url-str sensitive?]
-  (first (redact-url-query-string url-str sensitive?)))
+      ;; Accept-failure carries the user's domain failure-map at :detail
+      ;; — opaque to us; redact wholesale when sensitive.
+      (and sensitive? (contains? failure :detail))
+      (assoc :detail redacted-sentinel))))
+
+(defn stamp-sensitive
+  "Stamp the `:sensitive?` flag onto a tags map when `sensitive?` is true.
+
+  Per Spec 009 §Privacy the canonical contract is that `:sensitive?`
+  rides at the **top level** of the trace event. Both `re-frame.trace/emit!`
+  and `re-frame.trace/emit-error!` (per rf2-isdwf) consult a
+  caller-supplied `:sensitive?` slot in tags and hoist it to top-level,
+  dissoc'ing it from tags — so we stamp into tags here and let core do
+  the hoist. Consumers always read `(:sensitive? ev)` at the top level,
+  per the spec contract.
+
+  When `sensitive?` is false the slot is OMITTED (not stamped to false)
+  per Spec 009 line 1176: \"Consumers treat absent as false.\""
+  [tags sensitive?]
+  (cond-> tags
+    sensitive? (assoc :sensitive? true)))
 
 ;; ---- per-request / per-handler :sensitive? --------------------------------
 
@@ -348,101 +187,7 @@
       (true? (get-in args-map [:request :sensitive?]))
       (handler-sensitive? origin-event)))
 
-;; ---- trace-event redaction helpers ----------------------------------------
-
-(defn redact-request-tags
-  "Given a tags map about to ride a `:rf.http/*` trace event, redact
-  the request-side payload when `sensitive?` is true. Always redacts
-  denylisted headers regardless of `sensitive?` — the header denylist
-  is unconditional. URL query-string values whose param name is in the
-  query-param denylist (rf2-2p8wr) are always redacted regardless of
-  `sensitive?` — denylisted param names are themselves the signal.
-
-  Idempotent and total: missing slots are left alone."
-  [tags sensitive?]
-  (cond-> tags
-    ;; Always-on header redaction (denylist).
-    (map? (:headers tags))
-    (update :headers redact-headers)
-
-    ;; URL query-string redaction — always-on for denylisted params
-    ;; (rf2-2p8wr); when sensitive? true ALL params are scrubbed.
-    (string? (:url tags))
-    (update :url redact-url sensitive?)
-
-    ;; Sensitive-request redaction — body becomes the sentinel.
-    (and sensitive? (contains? tags :body))
-    (assoc :body redacted-sentinel)
-
-    ;; Sensitive-request redaction — params (URL query string) too.
-    (and sensitive? (contains? tags :params))
-    (assoc :params redacted-sentinel)))
-
-(defn redact-failure
-  "Given a failure map (per Spec 014 §Failure categories) about to ride
-  a `:rf.http/*` trace event, redact response-side payload slots when
-  `sensitive?` is true. Always redacts headers via the denylist; always
-  redacts URL query-string values whose param name is in the query-
-  param denylist (rf2-2p8wr) — denylisted param names are the signal."
-  [failure sensitive?]
-  (when failure
-    (cond-> failure
-      (map? (:headers failure))
-      (update :headers redact-headers)
-
-      ;; URL query-string redaction — always-on for denylisted params
-      ;; (rf2-2p8wr); when sensitive? true ALL params are scrubbed.
-      (string? (:url failure))
-      (update :url redact-url sensitive?)
-
-      (and sensitive? (contains? failure :body))
-      (assoc :body redacted-sentinel)
-
-      (and sensitive? (contains? failure :body-text))
-      (assoc :body-text redacted-sentinel)
-
-      (and sensitive? (contains? failure :decoded))
-      (assoc :decoded redacted-sentinel)
-
-      ;; Accept-failure carries the user's domain failure-map at :detail
-      ;; — opaque to us; redact wholesale when sensitive.
-      (and sensitive? (contains? failure :detail))
-      (assoc :detail redacted-sentinel))))
-
-(defn stamp-sensitive
-  "Stamp the `:sensitive?` flag onto a tags map when `sensitive?` is true.
-
-  Per Spec 009 §Privacy the canonical contract is that `:sensitive?`
-  rides at the **top level** of the trace event. Both `re-frame.trace/emit!`
-  and `re-frame.trace/emit-error!` (per rf2-isdwf) consult a
-  caller-supplied `:sensitive?` slot in tags and hoist it to top-level,
-  dissoc'ing it from tags — so we stamp into tags here and let core do
-  the hoist. Consumers always read `(:sensitive? ev)` at the top level,
-  per the spec contract.
-
-  When `sensitive?` is false the slot is OMITTED (not stamped to false)
-  per Spec 009 line 1176: \"Consumers treat absent as false.\""
-  [tags sensitive?]
-  (cond-> tags
-    sensitive? (assoc :sensitive? true)))
-
-(defn- query-denylist-hit?
-  "Return true iff `url-str` carries a query-string param whose name is
-  on the merged query-param denylist. The denylist-alone hit is itself
-  a signal that the request carries an auth secret (rf2-2p8wr) — the
-  prepare-emit-* composers use this to stamp `:sensitive?` even when
-  the originating handler was not declared sensitive."
-  [url-str]
-  (and (string? url-str)
-       (let [[_ q-and-f] (split-url-on-query url-str)
-             [q _]       (split-query-on-fragment q-and-f)]
-         (and (not (str/blank? q))
-              (boolean
-                (some (fn [pair]
-                        (let [eq-idx (str/index-of pair "=")
-                              pname  (if eq-idx (subs pair 0 eq-idx) pair)]
-                          (sensitive-query-param? pname)))
-                      (str/split q #"&")))))))
+;; ---- trace-event composers ------------------------------------------------
 
 (defn prepare-emit-tags
   "Compose `redact-request-tags` + `stamp-sensitive` for a request-side
@@ -464,8 +209,8 @@
     param name alone is enough to stamp the event — the name is the
     signal that the request carries a secret."
   [tags sensitive?]
-  (let [denylist-hit? (or (query-denylist-hit? (:url tags))
-                          (query-denylist-hit? (get-in tags [:failure :url])))
+  (let [denylist-hit? (or (url/query-denylist-hit? (:url tags))
+                          (url/query-denylist-hit? (get-in tags [:failure :url])))
         stamp?        (or (true? sensitive?) denylist-hit?)]
     (-> tags
         (redact-request-tags (true? sensitive?))
@@ -483,7 +228,7 @@
   stamping OR-combines that arg with a query-param denylist hit on the
   failure's `:url`."
   [failure sensitive?]
-  (let [denylist-hit? (query-denylist-hit? (:url failure))
+  (let [denylist-hit? (url/query-denylist-hit? (:url failure))
         stamp?        (or (true? sensitive?) denylist-hit?)]
     (-> (redact-failure failure (true? sensitive?))
         (stamp-sensitive stamp?))))

--- a/implementation/http/src/re_frame/http_privacy_headers.cljc
+++ b/implementation/http/src/re_frame/http_privacy_headers.cljc
@@ -1,0 +1,105 @@
+(ns re-frame.http-privacy-headers
+  "HTTP header denylist for Spec 014 §Privacy (rf2-bma05).
+
+  HTTP request / response headers are the canonical bearer-token surface
+  (Authorization, Cookie, Set-Cookie, X-API-Key, …). The header denylist
+  defined here is unconditional: matching headers are redacted in every
+  `:rf.http/*` trace event regardless of the handler / request
+  `:sensitive?` flag, because the header names themselves declare them
+  sensitive (an `Authorization` header leaking would be a leak even if
+  the surrounding handler was not declared sensitive).
+
+  `default-header-denylist` covers the canonical surface. Apps extend
+  via `(declare-sensitive-header! \"X-My-Auth\")` — names are
+  case-insensitive; the registry stores lower-cased.
+
+  ## Production elision
+
+  Like the rest of the privacy machinery, the redactor here gates on
+  `interop/debug-enabled?` at its call sites (same gate as
+  `trace/emit!`). In production builds the trace surface elides
+  entirely; this namespace's walker never runs. The denylist atom
+  itself ships in production (it's app-readable state —
+  `declare-sensitive-header!` writes through)."
+  (:require [clojure.set :as set]
+            [clojure.string :as str]))
+
+;; The framework-reserved redaction sentinel per Spec 009 §Privacy. Sits
+;; in the `:rf/` reserved-keyword namespace so apps cannot legitimately
+;; produce it as a payload value. Held here (not just in
+;; `re-frame.http-privacy`) so this leaf namespace doesn't depend on its
+;; orchestrating parent.
+(def ^:private redacted-sentinel :rf/redacted)
+
+(def default-header-denylist
+  "Canonical always-sensitive HTTP header names, lower-cased. These are
+  redacted in `:rf.http/*` trace events regardless of the handler's
+  `:sensitive?` flag — the header names themselves are the signal.
+
+  Drawn from the OWASP Authentication Cheatsheet plus common bearer-
+  scheme headers used by SaaS APIs. Apps extend at boot via
+  `declare-sensitive-header!` for app-specific tokens (e.g.
+  `X-Honeycomb-Team`, `X-Stripe-Signature`)."
+  #{"authorization"
+    "proxy-authorization"
+    "cookie"
+    "set-cookie"
+    "x-api-key"
+    "x-auth-token"
+    "x-session-token"
+    "x-csrf-token"
+    "x-xsrf-token"
+    "authentication"
+    "www-authenticate"
+    "proxy-authenticate"})
+
+(defonce
+  ^{:doc "App-extended denylist. Augments `default-header-denylist`.
+  Names stored lower-cased. Cleared by `clear-sensitive-headers!` for
+  test ergonomics."}
+  extra-headers
+  (atom #{}))
+
+(defn declare-sensitive-header!
+  "Declare a header name as sensitive. Stored lower-cased; matching is
+  case-insensitive when the redactor consults the merged set. Returns
+  the new merged set (defaults ∪ extras)."
+  [header-name]
+  (when (string? header-name)
+    (swap! extra-headers conj (str/lower-case header-name)))
+  (set/union default-header-denylist @extra-headers))
+
+(defn clear-sensitive-headers!
+  "Reset the app-extended header denylist to empty (default denylist
+  remains). Test-only — invoked by reset fixtures alongside
+  `clear-all-in-flight!` and `clear-all-http-interceptors!`."
+  []
+  (reset! extra-headers #{})
+  nil)
+
+(defn sensitive-header?
+  "Predicate: is `header-name` in the merged denylist? Case-insensitive."
+  [header-name]
+  (boolean
+    (when (string? header-name)
+      (contains? (set/union default-header-denylist @extra-headers)
+                 (str/lower-case header-name)))))
+
+(defn redact-headers
+  "Walk `headers-map` (string→string or string→vector-of-strings); replace
+  values whose key matches the merged header denylist with
+  `:rf/redacted`. Returns a new map; nil/empty input returns the input
+  unchanged. Case-insensitive on header names."
+  [headers-map]
+  (cond
+    (nil? headers-map) headers-map
+    (not (map? headers-map)) headers-map
+    :else
+    (reduce-kv
+      (fn [acc k v]
+        (assoc acc k
+               (if (sensitive-header? (if (keyword? k) (name k) (str k)))
+                 redacted-sentinel
+                 v)))
+      {}
+      headers-map)))

--- a/implementation/http/src/re_frame/http_url.cljc
+++ b/implementation/http/src/re_frame/http_url.cljc
@@ -1,0 +1,210 @@
+(ns re-frame.http-url
+  "URL handling for the http artefact — query-string redaction surface
+  (Spec 014 §Privacy, rf2-2p8wr) plus the query-param denylist.
+
+  This namespace owns URLs end-to-end for the http artefact. Today it
+  hosts the redaction half (split, walk, redact, denylist). When the
+  http-encoding split lands (rf2-5ijhk), `url-encode`, `params->query`,
+  and `merge-params` move here too — making `http-url` the single
+  authority for URL parsing, building, and scrubbing across the artefact.
+
+  ## Query-param denylist (rf2-2p8wr)
+
+  `default-query-param-denylist` covers the canonical query-string-auth
+  surface (api_key, apikey, access_token, auth, token, key, secret,
+  password, session, signature, sig). Apps extend via
+  `(declare-sensitive-query-param! \"my_token\")` — names are
+  case-insensitive; the registry stores lower-cased.
+
+  ## Redaction shape
+
+  URLs carrying denylisted params have the *value* redacted in every
+  `:rf.http/*` trace event regardless of the originating handler's
+  `:sensitive?` flag — the param name itself is the signal. When the
+  request is sensitive (per the resolver in `re-frame.http-privacy`),
+  **all** query params are redacted (the broader rule). Fragments are
+  preserved verbatim past the redaction step.
+
+  ## Production elision
+
+  Like the rest of the privacy machinery, redact / stamp helpers gate
+  on `interop/debug-enabled?` at their call sites (same gate as
+  `trace/emit!`). The denylist atom itself ships in production
+  (app-readable state — `declare-sensitive-query-param!` writes
+  through), but no walker runs without the trace surface."
+  (:require [clojure.set :as set]
+            [clojure.string :as str]))
+
+;; ---- query-param denylist (rf2-2p8wr) -------------------------------------
+
+(def default-query-param-denylist
+  "Canonical always-sensitive HTTP query-string parameter names, lower-
+  cased. URLs carrying these params have the *values* redacted in
+  `:rf.http/*` trace events regardless of the handler's `:sensitive?`
+  flag — the param names themselves are the signal (mirrors the header
+  denylist contract).
+
+  Drawn from common API-key / bearer-token idioms in older REST APIs,
+  webhook receivers, and signed-URL schemes. Apps extend at boot via
+  `declare-sensitive-query-param!` for app-specific param names (e.g.
+  `\"shop_token\"`, `\"hmac\"`)."
+  #{"api_key"
+    "apikey"
+    "api-key"
+    "access_token"
+    "accesstoken"
+    "auth"
+    "auth_token"
+    "authtoken"
+    "key"
+    "token"
+    "secret"
+    "password"
+    "passwd"
+    "session"
+    "session_id"
+    "sessionid"
+    "signature"
+    "sig"
+    "hmac"})
+
+(defonce
+  ^{:doc "App-extended query-param denylist. Augments
+  `default-query-param-denylist`. Names stored lower-cased. Cleared by
+  `clear-sensitive-query-params!` for test ergonomics."}
+  extra-query-params
+  (atom #{}))
+
+(defn declare-sensitive-query-param!
+  "Declare a query-string parameter name as sensitive. Stored lower-
+  cased; matching is case-insensitive when the redactor consults the
+  merged set. Returns the new merged set (defaults ∪ extras)."
+  [param-name]
+  (when (string? param-name)
+    (swap! extra-query-params conj (str/lower-case param-name)))
+  (set/union default-query-param-denylist @extra-query-params))
+
+(defn clear-sensitive-query-params!
+  "Reset the app-extended query-param denylist to empty (default
+  denylist remains). Test-only — invoked by reset fixtures alongside
+  `clear-sensitive-headers!`."
+  []
+  (reset! extra-query-params #{})
+  nil)
+
+(defn sensitive-query-param?
+  "Predicate: is `param-name` in the merged query-param denylist?
+  Case-insensitive."
+  [param-name]
+  (boolean
+    (when (string? param-name)
+      (contains? (set/union default-query-param-denylist @extra-query-params)
+                 (str/lower-case param-name)))))
+
+;; ---- URL query-string redaction (rf2-2p8wr) -------------------------------
+
+(def ^:private redacted-url-token
+  "Inline string form of the `:rf/redacted` sentinel suitable for splicing
+  into a URL string. Trace consumers parsing the URL still see a structural
+  token they can detect (`:rf%2Fredacted` once URL-encoded into the wire
+  string we serialise). The unencoded form is `:rf/redacted` — identical
+  text to the keyword's `pr-str` — chosen so a human inspecting a trace
+  event reads the same sentinel they see in any other redacted slot."
+  ":rf/redacted")
+
+(defn- split-url-on-query
+  "Split `url-str` into `[base query-string]`. `query-string` is nil
+  when the URL has no `?`. Preserves URL fragments (`#…`) on the
+  query-string side so the redactor can put them back verbatim."
+  [url-str]
+  (let [qidx (str/index-of url-str "?")]
+    (if (nil? qidx)
+      [url-str nil]
+      [(subs url-str 0 qidx)
+       (subs url-str (inc qidx))])))
+
+(defn- split-query-on-fragment
+  "Split `query-and-fragment` on the first `#` so the fragment can be
+  preserved verbatim past the redaction step. Returns `[query fragment]`
+  where `fragment` includes the leading `#` or is nil."
+  [query-and-fragment]
+  (if (nil? query-and-fragment)
+    [nil nil]
+    (let [fidx (str/index-of query-and-fragment "#")]
+      (if (nil? fidx)
+        [query-and-fragment nil]
+        [(subs query-and-fragment 0 fidx)
+         (subs query-and-fragment fidx)]))))
+
+(defn- redact-query-param
+  "Given a single `name=value` pair (string), return the redacted form:
+  `name=:rf/redacted` if the param is denylisted OR `force-all?` is
+  true; the pair unchanged otherwise. Tolerates malformed pairs (no
+  `=`, empty value)."
+  [pair force-all?]
+  (let [eq-idx (str/index-of pair "=")
+        [pname _pvalue] (if eq-idx
+                          [(subs pair 0 eq-idx) (subs pair (inc eq-idx))]
+                          [pair nil])]
+    (if (or force-all? (sensitive-query-param? pname))
+      (str pname "=" redacted-url-token)
+      pair)))
+
+(defn redact-url-query-string
+  "Redact denylisted query-string parameter values in `url-str`.
+
+  When `sensitive?` is true, redacts **every** param value (the broader
+  rule per Spec 014 §Privacy — a sensitive request leaks nothing).
+  When `sensitive?` is false, redacts only values whose param name is
+  in the merged query-param denylist.
+
+  The redaction shape preserves param name + position; only the value
+  is replaced with the framework-reserved `:rf/redacted` text token
+  (e.g. `?api_key=SECRET&page=2` → `?api_key=:rf/redacted&page=2`).
+  Fragment portion (`#…`) preserved verbatim.
+
+  Returns `[redacted-url any-redacted?]` where `any-redacted?` is true
+  iff at least one param value was redacted (the caller uses this to
+  decide whether to stamp `:sensitive?` per the denylist-is-signal
+  rule). Nil / non-string / no-query inputs return `[url-str false]`."
+  [url-str sensitive?]
+  (cond
+    (not (string? url-str))
+    [url-str false]
+
+    :else
+    (let [[base query-and-fragment] (split-url-on-query url-str)
+          [query fragment]          (split-query-on-fragment query-and-fragment)]
+      (if (str/blank? query)
+        [url-str false]
+        (let [pairs    (str/split query #"&")
+              redacted (mapv (fn [p] (redact-query-param p (true? sensitive?)))
+                             pairs)
+              changed? (boolean (some true? (map not= pairs redacted)))
+              rebuilt  (str base "?" (str/join "&" redacted) (or fragment ""))]
+          [rebuilt changed?])))))
+
+(defn redact-url
+  "Convenience wrapper around `redact-url-query-string` that returns only
+  the redacted URL string. Use when the caller does not need the
+  any-redacted? flag (e.g. inside a generic tag-walker)."
+  [url-str sensitive?]
+  (first (redact-url-query-string url-str sensitive?)))
+
+(defn query-denylist-hit?
+  "Return true iff `url-str` carries a query-string param whose name is
+  on the merged query-param denylist. The denylist-alone hit is itself
+  a signal that the request carries an auth secret (rf2-2p8wr) — the
+  `prepare-emit-*` composers use this to stamp `:sensitive?` even when
+  the originating handler was not declared sensitive."
+  [url-str]
+  (and (string? url-str)
+       (let [[_ q-and-f] (split-url-on-query url-str)
+             [q _]       (split-query-on-fragment q-and-f)]
+         (and (not (str/blank? q))
+              (boolean
+                (some (fn [pair]
+                        (let [eq-idx (str/index-of pair "=")
+                              pname  (if eq-idx (subs pair 0 eq-idx) pair)]
+                          (sensitive-query-param? pname)))
+                      (str/split q #"&")))))))

--- a/implementation/http/test/re_frame/http_privacy_integration_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_integration_test.clj
@@ -14,7 +14,8 @@
             [re-frame.flows :as flows]
             [re-frame.registrar :as registrar]
             [re-frame.http-managed :as http-managed]
-            [re-frame.http-privacy :as privacy]
+            [re-frame.http-privacy-headers :as privacy-headers]
+            [re-frame.http-url :as http-url]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.trace :as trace])
   (:import [com.sun.net.httpserver HttpServer HttpHandler HttpExchange]
@@ -34,8 +35,8 @@
   (require 're-frame.http-managed :reload)
   ((requiring-resolve 're-frame.machines/reset-timers!))
   (http-managed/clear-all-in-flight!)
-  (privacy/clear-sensitive-headers!)
-  (privacy/clear-sensitive-query-params!)
+  (privacy-headers/clear-sensitive-headers!)
+  (http-url/clear-sensitive-query-params!)
   (trace/clear-trace-cbs!)
   (t))
 
@@ -234,7 +235,7 @@
 
 (deftest app-extended-denylist-redacts-custom-header
   (testing "declare-sensitive-header! extends redaction to app-defined names"
-    (privacy/declare-sensitive-header! "X-Honeycomb-Team")
+    (privacy-headers/declare-sensitive-header! "X-Honeycomb-Team")
     (let [srv (start-server!
                 (fn [^HttpExchange ex]
                   (-> ex .getResponseHeaders (.set "X-Honeycomb-Team" "hc-token"))
@@ -350,7 +351,7 @@
 
 (deftest app-extended-query-param-denylist-redacts-failure-url
   (testing "declare-sensitive-query-param! extends URL redaction to app-defined params"
-    (privacy/declare-sensitive-query-param! "shop_token")
+    (http-url/declare-sensitive-query-param! "shop_token")
     (let [srv (start-server!
                 (fn [^HttpExchange ex]
                   (write-response! ex 500 "text/plain" "boom")))

--- a/implementation/http/test/re_frame/http_privacy_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_test.clj
@@ -1,24 +1,32 @@
 (ns re-frame.http-privacy-test
-  "Unit tests for `re-frame.http-privacy` — Spec 014 §Privacy (rf2-bma05).
+  "Unit tests for `re-frame.http-privacy` and its sibling leaves —
+  Spec 014 §Privacy (rf2-bma05).
 
   Covers:
-   - Header denylist (default set, case-insensitive, app-extensible).
-   - `redact-headers` walks a map and replaces sensitive header values.
-   - `request-sensitive?` reads per-call, per-request, and handler-meta.
+   - Header denylist (default set, case-insensitive, app-extensible) —
+     `re-frame.http-privacy-headers`.
+   - `redact-headers` walks a map and replaces sensitive header values —
+     `re-frame.http-privacy-headers`.
+   - Query-param denylist + URL redaction — `re-frame.http-url`.
+   - `request-sensitive?` reads per-call, per-request, and handler-meta —
+     `re-frame.http-privacy`.
    - `redact-request-tags` / `redact-failure` / `stamp-sensitive` /
-     `prepare-emit-tags` / `prepare-emit-failure` compose correctly.
+     `prepare-emit-tags` / `prepare-emit-failure` compose correctly —
+     `re-frame.http-privacy`.
 
   Integration with the trace surface (sensitive HTTP requests emitting
   redacted trace events end-to-end) is covered in
   `re-frame.http-privacy-integration-test`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.http-privacy :as privacy]
+            [re-frame.http-privacy-headers :as headers]
+            [re-frame.http-url :as url]
             [re-frame.registrar :as registrar]))
 
 (defn- reset-runtime [t]
   (registrar/clear-all!)
-  (privacy/clear-sensitive-headers!)
-  (privacy/clear-sensitive-query-params!)
+  (headers/clear-sensitive-headers!)
+  (url/clear-sensitive-query-params!)
   (t))
 
 (use-fixtures :each reset-runtime)
@@ -27,46 +35,46 @@
 
 (deftest default-header-denylist-covers-canonical-set
   (testing "the default denylist contains the canonical bearer / auth surface"
-    (is (contains? privacy/default-header-denylist "authorization"))
-    (is (contains? privacy/default-header-denylist "cookie"))
-    (is (contains? privacy/default-header-denylist "set-cookie"))
-    (is (contains? privacy/default-header-denylist "x-api-key"))
-    (is (contains? privacy/default-header-denylist "x-auth-token"))
-    (is (contains? privacy/default-header-denylist "x-csrf-token"))
-    (is (contains? privacy/default-header-denylist "proxy-authorization"))))
+    (is (contains? headers/default-header-denylist "authorization"))
+    (is (contains? headers/default-header-denylist "cookie"))
+    (is (contains? headers/default-header-denylist "set-cookie"))
+    (is (contains? headers/default-header-denylist "x-api-key"))
+    (is (contains? headers/default-header-denylist "x-auth-token"))
+    (is (contains? headers/default-header-denylist "x-csrf-token"))
+    (is (contains? headers/default-header-denylist "proxy-authorization"))))
 
 (deftest sensitive-header-is-case-insensitive
   (testing "header-name match ignores case"
-    (is (privacy/sensitive-header? "Authorization"))
-    (is (privacy/sensitive-header? "AUTHORIZATION"))
-    (is (privacy/sensitive-header? "authorization"))
-    (is (privacy/sensitive-header? "Cookie"))
-    (is (privacy/sensitive-header? "X-API-Key"))))
+    (is (headers/sensitive-header? "Authorization"))
+    (is (headers/sensitive-header? "AUTHORIZATION"))
+    (is (headers/sensitive-header? "authorization"))
+    (is (headers/sensitive-header? "Cookie"))
+    (is (headers/sensitive-header? "X-API-Key"))))
 
 (deftest non-sensitive-headers-pass
   (testing "ordinary headers are not in the denylist"
-    (is (not (privacy/sensitive-header? "Content-Type")))
-    (is (not (privacy/sensitive-header? "Accept")))
-    (is (not (privacy/sensitive-header? "User-Agent")))
-    (is (not (privacy/sensitive-header? "X-Request-Id")))))
+    (is (not (headers/sensitive-header? "Content-Type")))
+    (is (not (headers/sensitive-header? "Accept")))
+    (is (not (headers/sensitive-header? "User-Agent")))
+    (is (not (headers/sensitive-header? "X-Request-Id")))))
 
 (deftest declare-sensitive-header-extends-denylist
   (testing "app-extended denylist composes with defaults"
-    (privacy/declare-sensitive-header! "X-Honeycomb-Team")
-    (is (privacy/sensitive-header? "X-Honeycomb-Team"))
-    (is (privacy/sensitive-header? "x-honeycomb-team"))
+    (headers/declare-sensitive-header! "X-Honeycomb-Team")
+    (is (headers/sensitive-header? "X-Honeycomb-Team"))
+    (is (headers/sensitive-header? "x-honeycomb-team"))
     ;; defaults still apply
-    (is (privacy/sensitive-header? "Authorization"))
-    (privacy/clear-sensitive-headers!)
-    (is (not (privacy/sensitive-header? "X-Honeycomb-Team")))
+    (is (headers/sensitive-header? "Authorization"))
+    (headers/clear-sensitive-headers!)
+    (is (not (headers/sensitive-header? "X-Honeycomb-Team")))
     ;; defaults survive the clear
-    (is (privacy/sensitive-header? "Authorization"))))
+    (is (headers/sensitive-header? "Authorization"))))
 
 (deftest sensitive-header-tolerates-non-string
   (testing "nil / non-string is not sensitive"
-    (is (not (privacy/sensitive-header? nil)))
-    (is (not (privacy/sensitive-header? :keyword)))
-    (is (not (privacy/sensitive-header? 42)))))
+    (is (not (headers/sensitive-header? nil)))
+    (is (not (headers/sensitive-header? :keyword)))
+    (is (not (headers/sensitive-header? 42)))))
 
 ;; ---- 2. redact-headers ----------------------------------------------------
 
@@ -76,22 +84,22 @@
              "Content-Type"  "application/json"
              "Cookie"        "session=secret"
              "X-Request-Id"  "req-42"}
-          r (privacy/redact-headers m)]
+          r (headers/redact-headers m)]
       (is (= :rf/redacted (get r "Authorization")))
       (is (= :rf/redacted (get r "Cookie")))
       (is (= "application/json" (get r "Content-Type")))
       (is (= "req-42" (get r "X-Request-Id"))))))
 
 (deftest redact-headers-handles-empty-and-nil
-  (is (nil? (privacy/redact-headers nil)))
-  (is (= {} (privacy/redact-headers {}))))
+  (is (nil? (headers/redact-headers nil)))
+  (is (= {} (headers/redact-headers {}))))
 
 (deftest redact-headers-handles-mixed-case-keys
   (testing "header-name match ignores case on the map key"
     (let [m {"AUTHORIZATION" "Bearer xyz"
              "set-cookie"    "id=1"
              "Set-cookie"    "id=2"}
-          r (privacy/redact-headers m)]
+          r (headers/redact-headers m)]
       (is (= :rf/redacted (get r "AUTHORIZATION")))
       (is (= :rf/redacted (get r "set-cookie")))
       (is (= :rf/redacted (get r "Set-cookie"))))))
@@ -244,55 +252,55 @@
 
 (deftest default-query-param-denylist-covers-canonical-set
   (testing "the default denylist contains the canonical query-string-auth surface"
-    (is (contains? privacy/default-query-param-denylist "api_key"))
-    (is (contains? privacy/default-query-param-denylist "access_token"))
-    (is (contains? privacy/default-query-param-denylist "token"))
-    (is (contains? privacy/default-query-param-denylist "auth"))
-    (is (contains? privacy/default-query-param-denylist "key"))
-    (is (contains? privacy/default-query-param-denylist "secret"))
-    (is (contains? privacy/default-query-param-denylist "password"))
-    (is (contains? privacy/default-query-param-denylist "signature"))
-    (is (contains? privacy/default-query-param-denylist "session"))))
+    (is (contains? url/default-query-param-denylist "api_key"))
+    (is (contains? url/default-query-param-denylist "access_token"))
+    (is (contains? url/default-query-param-denylist "token"))
+    (is (contains? url/default-query-param-denylist "auth"))
+    (is (contains? url/default-query-param-denylist "key"))
+    (is (contains? url/default-query-param-denylist "secret"))
+    (is (contains? url/default-query-param-denylist "password"))
+    (is (contains? url/default-query-param-denylist "signature"))
+    (is (contains? url/default-query-param-denylist "session"))))
 
 (deftest sensitive-query-param-is-case-insensitive
   (testing "param-name match ignores case"
-    (is (privacy/sensitive-query-param? "api_key"))
-    (is (privacy/sensitive-query-param? "API_KEY"))
-    (is (privacy/sensitive-query-param? "Api_Key"))
-    (is (privacy/sensitive-query-param? "access_token"))
-    (is (privacy/sensitive-query-param? "ACCESS_TOKEN"))))
+    (is (url/sensitive-query-param? "api_key"))
+    (is (url/sensitive-query-param? "API_KEY"))
+    (is (url/sensitive-query-param? "Api_Key"))
+    (is (url/sensitive-query-param? "access_token"))
+    (is (url/sensitive-query-param? "ACCESS_TOKEN"))))
 
 (deftest non-sensitive-query-params-pass
   (testing "ordinary query params are not in the denylist"
-    (is (not (privacy/sensitive-query-param? "page")))
-    (is (not (privacy/sensitive-query-param? "limit")))
-    (is (not (privacy/sensitive-query-param? "q")))
-    (is (not (privacy/sensitive-query-param? "id")))
-    (is (not (privacy/sensitive-query-param? "user_id")))))
+    (is (not (url/sensitive-query-param? "page")))
+    (is (not (url/sensitive-query-param? "limit")))
+    (is (not (url/sensitive-query-param? "q")))
+    (is (not (url/sensitive-query-param? "id")))
+    (is (not (url/sensitive-query-param? "user_id")))))
 
 (deftest declare-sensitive-query-param-extends-denylist
   (testing "app-extended denylist composes with defaults"
-    (privacy/declare-sensitive-query-param! "shop_token")
-    (is (privacy/sensitive-query-param? "shop_token"))
-    (is (privacy/sensitive-query-param? "SHOP_TOKEN"))
+    (url/declare-sensitive-query-param! "shop_token")
+    (is (url/sensitive-query-param? "shop_token"))
+    (is (url/sensitive-query-param? "SHOP_TOKEN"))
     ;; defaults still apply
-    (is (privacy/sensitive-query-param? "api_key"))
-    (privacy/clear-sensitive-query-params!)
-    (is (not (privacy/sensitive-query-param? "shop_token")))
+    (is (url/sensitive-query-param? "api_key"))
+    (url/clear-sensitive-query-params!)
+    (is (not (url/sensitive-query-param? "shop_token")))
     ;; defaults survive the clear
-    (is (privacy/sensitive-query-param? "api_key"))))
+    (is (url/sensitive-query-param? "api_key"))))
 
 (deftest sensitive-query-param-tolerates-non-string
   (testing "nil / non-string is not sensitive"
-    (is (not (privacy/sensitive-query-param? nil)))
-    (is (not (privacy/sensitive-query-param? :keyword)))
-    (is (not (privacy/sensitive-query-param? 42)))))
+    (is (not (url/sensitive-query-param? nil)))
+    (is (not (url/sensitive-query-param? :keyword)))
+    (is (not (url/sensitive-query-param? 42)))))
 
 ;; ---- 9. redact-url-query-string (rf2-2p8wr) -------------------------------
 
 (deftest redact-url-denylist-replaces-sensitive-values
   (testing "denylisted query-param values become :rf/redacted; non-denylisted preserved"
-    (let [[url any?] (privacy/redact-url-query-string
+    (let [[url any?] (url/redact-url-query-string
                        "https://api.example.com/users?api_key=SECRET&page=2"
                        false)]
       (is (= "https://api.example.com/users?api_key=:rf/redacted&page=2" url))
@@ -300,7 +308,7 @@
 
 (deftest redact-url-sensitive-true-redacts-everything
   (testing "when sensitive? true, ALL params are redacted (broader rule)"
-    (let [[url any?] (privacy/redact-url-query-string
+    (let [[url any?] (url/redact-url-query-string
                        "https://api.example.com/users?user_id=42&page=2&sort=asc"
                        true)]
       (is (= "https://api.example.com/users?user_id=:rf/redacted&page=:rf/redacted&sort=:rf/redacted"
@@ -309,39 +317,39 @@
 
 (deftest redact-url-no-query-string-unchanged
   (testing "URL with no query string returns unchanged"
-    (let [[url any?] (privacy/redact-url-query-string
+    (let [[url any?] (url/redact-url-query-string
                        "https://api.example.com/users/42" false)]
       (is (= "https://api.example.com/users/42" url))
       (is (false? any?)))))
 
 (deftest redact-url-no-denylist-hit-unchanged
   (testing "URL with no denylisted params returns unchanged when not sensitive"
-    (let [[url any?] (privacy/redact-url-query-string
+    (let [[url any?] (url/redact-url-query-string
                        "https://api.example.com/users?page=2&limit=10" false)]
       (is (= "https://api.example.com/users?page=2&limit=10" url))
       (is (false? any?)))))
 
 (deftest redact-url-preserves-fragment
   (testing "fragment is preserved verbatim after the redacted query string"
-    (let [[url _] (privacy/redact-url-query-string
+    (let [[url _] (url/redact-url-query-string
                     "https://api.example.com/x?token=abc&page=2#section-3" false)]
       (is (= "https://api.example.com/x?token=:rf/redacted&page=2#section-3" url)))))
 
 (deftest redact-url-empty-value-redacted
   (testing "param with empty value still has the value slot replaced"
-    (let [[url _] (privacy/redact-url-query-string
+    (let [[url _] (url/redact-url-query-string
                     "https://api.example.com/x?token=&page=2" false)]
       (is (= "https://api.example.com/x?token=:rf/redacted&page=2" url)))))
 
 (deftest redact-url-handles-url-encoded-values
   (testing "URL-encoded special chars in values are replaced wholesale, not parsed"
-    (let [[url _] (privacy/redact-url-query-string
+    (let [[url _] (url/redact-url-query-string
                     "https://api.example.com/x?api_key=a%20b%26c&page=2" false)]
       (is (= "https://api.example.com/x?api_key=:rf/redacted&page=2" url)))))
 
 (deftest redact-url-multiple-denylist-hits
   (testing "all denylisted params in a URL are redacted"
-    (let [[url any?] (privacy/redact-url-query-string
+    (let [[url any?] (url/redact-url-query-string
                        "https://api.example.com/x?api_key=A&token=B&page=2&secret=C" false)]
       (is (= "https://api.example.com/x?api_key=:rf/redacted&token=:rf/redacted&page=2&secret=:rf/redacted"
              url))
@@ -349,18 +357,18 @@
 
 (deftest redact-url-app-extended-denylist
   (testing "app-extended denylist applies on URL redaction"
-    (privacy/declare-sensitive-query-param! "shop_token")
-    (let [[url _] (privacy/redact-url-query-string
+    (url/declare-sensitive-query-param! "shop_token")
+    (let [[url _] (url/redact-url-query-string
                     "https://api.example.com/x?shop_token=abc&page=2" false)]
       (is (= "https://api.example.com/x?shop_token=:rf/redacted&page=2" url)))))
 
 (deftest redact-url-tolerates-non-string
-  (is (= [nil false] (privacy/redact-url-query-string nil false)))
-  (is (= [42 false] (privacy/redact-url-query-string 42 false))))
+  (is (= [nil false] (url/redact-url-query-string nil false)))
+  (is (= [42 false] (url/redact-url-query-string 42 false))))
 
 (deftest redact-url-handles-malformed-pair
   (testing "param without `=` is not crashed on"
-    (let [[url _] (privacy/redact-url-query-string
+    (let [[url _] (url/redact-url-query-string
                     "https://api.example.com/x?orphan&api_key=SECRET" false)]
       ;; The orphan is not in the denylist and is preserved; api_key is redacted.
       (is (= "https://api.example.com/x?orphan&api_key=:rf/redacted" url)))))


### PR DESCRIPTION
## Summary

- `http-privacy.cljc` was 489 LoC, ~95% over the 250-line leaf-size ceiling (rf2-zkca8 / commit 09f53791). Split into three siblings each well under budget.
- **`re-frame.http-privacy-headers`** (105 LoC, leaf) — header denylist + `redact-headers`.
- **`re-frame.http-url`** (210 LoC, leaf) — query-param denylist + URL query-string redaction (`redact-url`, `redact-url-query-string`, `query-denylist-hit?`). Future home of `url-encode` / `params->query` / `merge-params` when rf2-5ijhk lands.
- **`re-frame.http-privacy`** (234 LoC, orchestrator) — sensitivity resolver + trace-event composers (`prepare-emit-tags`, `prepare-emit-failure`).

Consumers updated directly (no re-export indirection in `http-privacy`):
- `http_managed.cljc`: header re-exports now point at `http-privacy-headers`.
- `http.cljc`: facade re-exports split — header surface to `privacy-headers/*`, query-param surface to `http-url/*`.
- `http_transport.cljc` / `http_encoding.cljc` / `http_registry.cljc` unchanged — only consume composers, which stayed.
- Tests (`http_privacy_test.clj`, `http_privacy_integration_test.clj`) updated with split aliases.

LoC distribution: 489 → 234 + 210 + 105 (total 549; +60 LoC for the two new ns docstrings + duplicated `redacted-sentinel` private in headers leaf to keep it dependency-free).

Coordination note for rf2-5ijhk (http-encoding split, still OPEN): the new `http-url` ns is the intended home for `url-encode`, `params->query`, `merge-params` per the bead's Option-2 hint — that move is now a straight cut into a sibling that already owns URL handling.

## Test plan

- [x] `cd implementation/http && clojure -M:test` — JVM gate green (136 tests / 385 assertions, 0 failures).
- [x] `cd implementation && npm run test:cljs` — cljs node-test green (1816 tests / 5040 assertions, 0 failures).
- [x] `cd implementation && npm run test:bundle-isolation` — counter-example bundle passes; no privacy / URL symbols leaking past the eight-tool allow-list.