### PR TITLE
refactor(routing): polish cluster (CQ1/CQ2/CQ4/CQ7/A12) (rf2-z2k4k)

### DIFF
--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -80,28 +80,23 @@
 
 (defn- segment-end
   "Scan forward from index `j` in `pattern` (length `n`) until a
-  segment-boundary char (/, {, }, ?) is hit; return the index of that
-  boundary (or `n` if none). Pure helper shared by every pattern walker
-  in this namespace — replaces the four near-identical inline loops."
-  [^String pattern n j]
-  (loop [m j]
-    (cond
-      (>= m n) m
-      (let [c (.charAt pattern m)]
-        (or (= c \/) (= c \{) (= c \}) (= c \?))) m
-      :else (recur (inc m)))))
-
-(defn- segment-end-no-?
-  "Same as segment-end but treats only /, {, } as boundaries (no ?).
-  Used by pattern-shape's :else branch which classifies static segments
-  — those don't terminate at ?."
-  [^String pattern n j]
-  (loop [m j]
-    (cond
-      (>= m n) m
-      (let [c (.charAt pattern m)]
-        (or (= c \/) (= c \{) (= c \}))) m
-      :else (recur (inc m)))))
+  segment-boundary char is hit; return the index of that boundary (or
+  `n` if none). The boundary set is always {/, {, }}; the 4-arity
+  additionally treats `?` as a boundary when `?-boundary?` is truthy.
+  Pure helper shared by every pattern walker in this namespace —
+  replaces the four near-identical inline loops. The 3-arity (defaults
+  `?-boundary?` to true) suits param / splat scanners and compile-pattern;
+  pattern-shape's static-segment :else branch passes false so a `?`
+  inside a static segment doesn't truncate the static run."
+  ([^String pattern n j] (segment-end pattern n j true))
+  ([^String pattern n j ?-boundary?]
+   (loop [m j]
+     (cond
+       (>= m n) m
+       (let [c (.charAt pattern m)]
+         (or (= c \/) (= c \{) (= c \})
+             (and ?-boundary? (= c \?)))) m
+       :else (recur (inc m))))))
 
 (defn- pattern-shape
   "Walk a path pattern and tally segment shapes used by the rank tuple.
@@ -148,7 +143,7 @@
                            (recur (inc i) depth seen)
 
                            :else
-                           (recur (segment-end-no-? pattern n (inc i))
+                           (recur (segment-end pattern n (inc i) false)
                                   depth
                                   (cond-> seen
                                     (zero? depth) (-> (update :static inc)
@@ -441,88 +436,88 @@
   ([route-id path-params query-params] (route-url route-id path-params query-params nil))
   ([route-id path-params query-params fragment]
    (let [meta    (registrar/lookup :route route-id)
-         pattern (:path meta)
-         _ (when (nil? pattern)
-             (throw (ex-info ":rf.error/no-such-route" {:route-id route-id})))
-         n     (count pattern)
-         ;; Inner loop emits the body of an optional group whose params
-         ;; are all present. State threads as (loop [i parts]); returns
-         ;; [next-i parts'] when the group's '}' (and optional '?') is
-         ;; consumed.
-         emit-group
-         (fn emit-group [i parts]
-           (loop [i     i
-                  parts parts]
-             (let [c2 (.charAt ^String pattern i)]
-               (cond
-                 (= c2 \})
-                 (let [k (inc i)]
-                   [(if (and (< k n) (= \? (.charAt ^String pattern k))) (inc k) k)
-                    parts])
+         pattern (:path meta)]
+     (when (nil? pattern)
+       (throw (ex-info ":rf.error/no-such-route" {:route-id route-id})))
+     (let [n     (count pattern)
+           ;; Inner loop emits the body of an optional group whose params
+           ;; are all present. State threads as (loop [i parts]); returns
+           ;; [next-i parts'] when the group's '}' (and optional '?') is
+           ;; consumed.
+           emit-group
+           (fn emit-group [i parts]
+             (loop [i     i
+                    parts parts]
+               (let [c2 (.charAt ^String pattern i)]
+                 (cond
+                   (= c2 \})
+                   (let [k (inc i)]
+                     [(if (and (< k n) (= \? (.charAt ^String pattern k))) (inc k) k)
+                      parts])
 
-                 (= c2 \:)
-                 (let [start (inc i)
-                       end   (segment-end pattern n start)
-                       k     (keyword (subs pattern start end))]
-                   (recur end (conj parts (url-encode (get path-params k)))))
+                   (= c2 \:)
+                   (let [start (inc i)
+                         end   (segment-end pattern n start)
+                         k     (keyword (subs pattern start end))]
+                     (recur end (conj parts (url-encode (get path-params k)))))
 
-                 (= c2 \*)
-                 (let [start (inc i)
-                       end   (segment-end pattern n start)
-                       k     (keyword (subs pattern start end))]
-                   (recur end (conj parts (url-encode-splat (get path-params k)))))
+                   (= c2 \*)
+                   (let [start (inc i)
+                         end   (segment-end pattern n start)
+                         k     (keyword (subs pattern start end))]
+                     (recur end (conj parts (url-encode-splat (get path-params k)))))
 
-                 :else
-                 (recur (inc i) (conj parts (str c2)))))))
-         parts
-         (loop [i     0
-                parts []]
-           (if-not (< i n)
-             parts
-             (let [ch (.charAt ^String pattern i)]
-               (cond
-                 (= ch \{)
-                 (let [[after-end inner-names] (collect-param-names-in-group pattern (inc i))
-                       all-present? (every? #(some? (get path-params (keyword %))) inner-names)]
-                   (if all-present?
-                     (let [[i' parts'] (emit-group (inc i) parts)]
-                       (recur i' parts'))
-                     (recur after-end parts)))
+                   :else
+                   (recur (inc i) (conj parts (str c2)))))))
+           parts
+           (loop [i     0
+                  parts []]
+             (if-not (< i n)
+               parts
+               (let [ch (.charAt ^String pattern i)]
+                 (cond
+                   (= ch \{)
+                   (let [[after-end inner-names] (collect-param-names-in-group pattern (inc i))
+                         all-present? (every? #(some? (get path-params (keyword %))) inner-names)]
+                     (if all-present?
+                       (let [[i' parts'] (emit-group (inc i) parts)]
+                         (recur i' parts'))
+                       (recur after-end parts)))
 
-                 (= ch \:)
-                 (let [start (inc i)
-                       end   (segment-end pattern n start)
-                       k     (keyword (subs pattern start end))
-                       v     (or (get path-params k)
-                                 (throw (ex-info ":rf.error/missing-route-param"
-                                                 {:param k :route-id route-id})))]
-                   (recur end (conj parts (url-encode v))))
+                   (= ch \:)
+                   (let [start (inc i)
+                         end   (segment-end pattern n start)
+                         k     (keyword (subs pattern start end))
+                         v     (or (get path-params k)
+                                   (throw (ex-info ":rf.error/missing-route-param"
+                                                   {:param k :route-id route-id})))]
+                     (recur end (conj parts (url-encode v))))
 
-                 (= ch \*)
-                 (let [start (inc i)
-                       end   (segment-end pattern n start)
-                       k     (keyword (subs pattern start end))
-                       v     (or (get path-params k)
-                                 (throw (ex-info ":rf.error/missing-route-param"
-                                                 {:param k :route-id route-id})))]
-                   (recur end (conj parts (url-encode-splat v))))
+                   (= ch \*)
+                   (let [start (inc i)
+                         end   (segment-end pattern n start)
+                         k     (keyword (subs pattern start end))
+                         v     (or (get path-params k)
+                                   (throw (ex-info ":rf.error/missing-route-param"
+                                                   {:param k :route-id route-id})))]
+                     (recur end (conj parts (url-encode-splat v))))
 
-                 :else
-                 (recur (inc i) (conj parts (str ch)))))))
-         path-out (apply str parts)
-         qs (when (seq query-params)
-              (str "?"
-                   (clojure.string/join "&"
-                     (map (fn [[k v]]
-                            (str (url-encode (name k)) "="
-                                 (url-encode v)))
-                          query-params))))
-         ;; Per Spec 012 §Fragments §Programmatic navigation with
-         ;; fragments: the 4-arity emits `#fragment` when non-nil and
-         ;; non-empty. Empty-string fragments collapse to no fragment.
-         frag (when (and fragment (not= "" fragment))
-                (str "#" fragment))]
-     (str path-out qs frag))))
+                   :else
+                   (recur (inc i) (conj parts (str ch)))))))
+           path-out (apply str parts)
+           qs (when (seq query-params)
+                (str "?"
+                     (clojure.string/join "&"
+                       (map (fn [[k v]]
+                              (str (url-encode (name k)) "="
+                                   (url-encode v)))
+                            query-params))))
+           ;; Per Spec 012 §Fragments §Programmatic navigation with
+           ;; fragments: the 4-arity emits `#fragment` when non-nil and
+           ;; non-empty. Empty-string fragments collapse to no fragment.
+           frag (when (and fragment (not= "" fragment))
+                  (str "#" fragment))]
+       (str path-out qs frag)))))
 
 ;; ---- standard handlers ----------------------------------------------------
 
@@ -534,6 +529,22 @@
 ;; per-frame (each frame's :rf/route slice is independent and the URL it
 ;; remembers is its own). The map lives in app-db at
 ;; [:rf.route/scroll-positions]; helpers below work against a db value.
+;;
+;; LRU cap: the map is bounded so a long session over many URLs (SPAs that
+;; deep-link through ids — `/articles/:id`, `/users/:id`) can't grow it
+;; unboundedly. Recency is tracked under [:rf.route/scroll-positions-order];
+;; on each save the url is appended (or re-promoted) to the tail and any
+;; head entries beyond `scroll-positions-cap` are evicted from both the
+;; order vector and the position map. Tools and migrations that inspect
+;; [:rf.route/scroll-positions <url>] still see the raw [x y]; the order
+;; key is an internal LRU anchor.
+
+(def ^:private scroll-positions-cap
+  "Soft upper bound on tracked URLs in the per-frame scroll-positions map.
+  Sized for typical SPA navigation depth — large enough that real
+  Back-button restoration hits saved positions, small enough that the
+  per-frame app-db slice stays bounded over long sessions."
+  50)
 
 (defn lookup-scroll-position
   "Return the saved [x y] for url in this frame's app-db, or nil if none."
@@ -544,9 +555,22 @@
   "Pure: return db with the scroll position for url recorded under
   [:rf.route/scroll-positions url]. Used inside :db effect maps so
   scroll positions live under the frame boundary (Spec 012 §Multi-frame
-  routing)."
+  routing). The map is LRU-capped at `scroll-positions-cap` entries —
+  re-saving an existing url promotes it to most-recent; new saves past
+  the cap evict the least-recently-used entry."
   [db url xy]
-  (assoc-in db [:rf.route/scroll-positions url] xy))
+  (let [order   (or (:rf.route/scroll-positions-order db) [])
+        order'  (-> (filterv #(not= url %) order)
+                    (conj url))
+        over    (- (count order') scroll-positions-cap)
+        dropped (when (pos? over) (subvec order' 0 over))
+        order'' (if (pos? over) (subvec order' over) order')
+        positions  (as-> (or (:rf.route/scroll-positions db) {}) m
+                     (if dropped (apply dissoc m dropped) m)
+                     (assoc m url xy))]
+    (assoc db
+           :rf.route/scroll-positions       positions
+           :rf.route/scroll-positions-order order'')))
 
 (defn- route-descriptor
   "Build the {:id :params :query} descriptor used by :rf.nav/scroll's
@@ -1050,18 +1074,18 @@ unknown strategies as :preserve (no-op)."}
        (into [:a attrs] children))))
 
 (defn route-link-render-ssr
-   "JVM render fn for `:route/link`. Renders the `<a href=...>` shell
-   without the click-interception logic — server-side rendering has no
-   DOM events to intercept, so the anchor is emitted as-is and clicks
-   on the hydrated page run the CLJS render fn's on-click path. Per
-   Spec 011 the render tree is the contract; this is the JVM half of
-   that contract for the `:route/link` view."
-   [{:keys [to params query fragment] :as props} & children]
-   (let [url   (route-url to (or params {}) (or query {}) fragment)
-         attrs (-> props
-                   (dissoc :to :params :query :fragment :on-click)
-                   (assoc :href url))]
-     (into [:a attrs] children)))
+  "JVM render fn for `:route/link`. Renders the `<a href=...>` shell
+  without the click-interception logic — server-side rendering has no
+  DOM events to intercept, so the anchor is emitted as-is and clicks
+  on the hydrated page run the CLJS render fn's on-click path. Per
+  Spec 011 the render tree is the contract; this is the JVM half of
+  that contract for the `:route/link` view."
+  [{:keys [to params query fragment] :as props} & children]
+  (let [url   (route-url to (or params {}) (or query {}) fragment)
+        attrs (-> props
+                  (dissoc :to :params :query :fragment :on-click)
+                  (assoc :href url))]
+    (into [:a attrs] children)))
 
 #?(:cljs
    (def route-link

--- a/implementation/routing/test/re_frame/route_link_test.clj
+++ b/implementation/routing/test/re_frame/route_link_test.clj
@@ -38,7 +38,7 @@
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
-  ((requiring-resolve 're-frame.routing/reset-counters!))
+  (routing/reset-counters!)
   (test-fn))
 
 (use-fixtures :each reset-runtime)

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -56,7 +56,7 @@
   ;; ns-load; clear-all! wiped them. Reload to resurrect.
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  ((requiring-resolve 're-frame.routing/reset-counters!))
+  (routing/reset-counters!)
   (test-fn))
 
 (use-fixtures :each reset-runtime)
@@ -392,6 +392,48 @@
     (let [db1 (routing/save-scroll-position {} "/x" [5 50])]
       (is (= [5 50] (get-in db1 [:rf.route/scroll-positions "/x"]))
           "the saved [x y] lives at [:rf.route/scroll-positions <url>] in the db"))))
+
+;; ---- rf2-z2k4k: LRU cap on scroll-positions -------------------------------
+;;
+;; Per audit A12: long sessions deep-linking through `/articles/:id`-style
+;; routes can grow [:rf.route/scroll-positions] unboundedly. The map is
+;; LRU-bounded at `routing/scroll-positions-cap` (50). Re-saving a known
+;; url promotes it to most-recent; saves past the cap evict the LRU entry.
+
+(deftest scroll-position-lru-eviction-past-cap
+  (testing "save-scroll-position evicts the least-recently-used url
+            once the cap is exceeded; the cap is a soft upper bound, not
+            a strict per-call limit"
+    ;; Hammer 60 distinct urls. Cap is 50, so the first 10 should be gone
+    ;; and the last 50 should remain — in insertion order.
+    (let [db (reduce (fn [db i] (routing/save-scroll-position db (str "/u" i) [i i]))
+                     {}
+                     (range 60))
+          positions (:rf.route/scroll-positions db)]
+      (is (= 50 (count positions))
+          "exactly 50 entries remain — the cap holds")
+      (is (every? nil? (map #(routing/lookup-scroll-position db (str "/u" %))
+                            (range 10)))
+          "the first 10 (LRU) urls are evicted")
+      (is (every? some? (map #(routing/lookup-scroll-position db (str "/u" %))
+                             (range 10 60)))
+          "the most-recently-saved 50 urls all survive")))
+
+  (testing "re-saving an existing url promotes it to most-recent — it survives
+            an eviction wave that would otherwise drop it"
+    ;; Insert 50 urls (fills cap). Promote /u0 by re-saving. Insert one more.
+    ;; /u1 (now the LRU) should evict; /u0 should survive.
+    (let [db0 (reduce (fn [db i] (routing/save-scroll-position db (str "/u" i) [i i]))
+                      {}
+                      (range 50))
+          db1 (routing/save-scroll-position db0 "/u0" [999 999])  ;; promote
+          db2 (routing/save-scroll-position db1 "/u50" [50 50])]  ;; force evict
+      (is (= [999 999] (routing/lookup-scroll-position db2 "/u0"))
+          "the re-saved url survives and carries its new value")
+      (is (nil? (routing/lookup-scroll-position db2 "/u1"))
+          "/u1 — the new LRU after the promotion — was evicted instead")
+      (is (= 50 (count (:rf.route/scroll-positions db2)))
+          "cap is still 50"))))
 
 ;; ---- rf2-hra3: route-url missing-required-param raises clear error -------
 ;;


### PR DESCRIPTION
## Summary

Pre-alpha polish bundle for `implementation/routing/`. Per audit `ai/findings/refactor-audit-r2-routing-2026-05-14.md`. Six audit items addressed; one deferred with rationale.

### Per-item disposition

- **CQ1** (`route-url` underscore-binding throw) — done. The `(nil? pattern)` guard is lifted out of the binding form into a top-level `(when ...)`; the binding form then opens an inner `let` for the cursor / emit-group / parts state.
- **CQ2** (`segment-end-no-?` duplication) — done. Collapsed into a single `segment-end` with a 4-arity boolean (`?-boundary?`); the `pattern-shape` static-segment branch passes `false`. (rf2-uovh5 — the pattern-compile fusion that would absorb `segment-end` entirely — is still OPEN, so this collapse is worth shipping standalone.)
- **CQ4** (`reset-counters!` double-publish) — done. Dropped `(requiring-resolve 're-frame.routing/reset-counters!)` in `routing_test.clj:59` and `route_link_test.clj:41`; both files already `:require` the ns as `routing`, so direct `(routing/reset-counters!)` is shorter and gives a compile-time error on a stale ref. The CLJS test already used the direct form, and the `:routing/reset-counters!` late-bind hook stays in place for cross-artefact orchestration via `re-frame.test-support`.
- **CQ7** (`route-link-render-ssr` indent) — done. Normalised from 3-space to the file's 2-space indent.
- **A12** (`:rf.route/scroll-positions` unbounded growth) — done. LRU-cap at 50 entries. Recency is tracked under `[:rf.route/scroll-positions-order]` (a vector); each save appends-or-re-promotes the url to the tail and evicts head entries beyond the cap. The pinned storage shape at `[:rf.route/scroll-positions <url>]` -> `[x y]` is unchanged — the order key is an internal LRU anchor. Two new tests cover the eviction wave and the re-save promotion path.
- **S7** (`:validation-failed?` hardcoded `false`) — **decision: keep as-is, deferred to rf2-6iam6**. The key is firmly anchored by Spec 012 §URL changes are events (the `handle-url-change` example consumes it), the documented `match-url` return shape in API.md, and ~30 conformance fixture expects across `routing-match-url`, `route-ranking-precedence`, `routing-query-string-coercion`. Populating it for real is rf2-6iam6's job (`:params` / `:query` Malli validation, still OPEN, P1). Dropping the key would unwind spec text + fixtures + a public API row for a key that is correct-by-construction today (no schema validation runs, so `false` is faithful). Note added to the audit findings via the bead close.

### Touched files

- `implementation/routing/src/re_frame/routing.cljc` — five edits (CQ1, CQ2, CQ7, A12; A12 also adds the `scroll-positions-cap` def).
- `implementation/routing/test/re_frame/routing_test.clj` — CQ4 (drop resolve), A12 (two new LRU tests).
- `implementation/routing/test/re_frame/route_link_test.clj` — CQ4 (drop resolve).

LoC delta: +187 / -121 (net +66; most of the churn is the indent shift from CQ1's inner-`let` restructure — substantive net add is ~30 lines for A12's LRU policy + tests).

## Test plan

- [x] `cd implementation/routing && clojure -M:test` -> 38 tests, 142 assertions, 0/0
- [x] `cd implementation && npm run test:cljs` -> 1816 tests, 5040 assertions, 0/0