### PR TITLE
test(flows): ship flow-frame-scoped.edn conformance fixture + capability claim (rf2-29ovh)

### DIFF
--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -126,6 +126,11 @@
     ;; the runtime emits the :rf.flow/* lifecycle events. Claimed so
     ;; `flow-lifecycle-emits-traces.edn` runs on CLJS too (rf2-efjs6).
     :flow/trace
+    ;; Spec 013 §Frame-scoping — same flow-id against two frames yields
+    ;; two independent definitions; clear-flow is frame-local; sibling
+    ;; frames' flows do not walk on cross-frame dispatches. Claimed so
+    ;; `flow-frame-scoped.edn` runs on CLJS too (rf2-29ovh).
+    :flow/frame-scoped
     :rf.http/managed})
 
 (def claimed-spec-versions

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -101,6 +101,11 @@
     ;; :rf.flow/skip, :rf.flow/cleared, :rf.flow/failed under :op-type
     ;; :flow. Claimed so `flow-lifecycle-emits-traces.edn` runs (rf2-efjs6).
     :flow/trace
+    ;; Spec 013 §Frame-scoping — same flow-id against two frames yields
+    ;; two independent definitions; clear-flow is frame-local; sibling
+    ;; frames' flows do not walk on cross-frame dispatches. Claimed so
+    ;; `flow-frame-scoped.edn` runs through the core corpus too (rf2-29ovh).
+    :flow/frame-scoped
     ;; Spec 014 — :rf.http/managed (rf2-z1mw)
     :rf.http/managed})
 

--- a/implementation/flows/test/re_frame/flows_conformance_test.clj
+++ b/implementation/flows/test/re_frame/flows_conformance_test.clj
@@ -47,10 +47,16 @@
        `:fixture/frame-config` (including any `:on-create` seed events).
        Re-registers because reset-runtime created a vanilla
        `:rf/default`; the fixture's `:on-create` cascade fires here.
-    5. Drives `:fixture/dispatches` through `rf/dispatch-sync` — the
-       flow walker fires post-drain per Spec 013 §Drain integration.
+    5. Drives `:fixture/dispatches` through `rf/dispatch-sync`. Dispatches
+       are either bare event vectors or envelope maps `{:event [...]
+       :frame <id> ...}` (the multi-frame shape per
+       `frame-multi-instance.edn`). The flow walker fires post-drain
+       per Spec 013 §Drain integration.
     6. Asserts each of:
-       - `:final-app-db` — submap match against `rf/get-frame-db`.
+       - `:final-app-db` — submap match against `rf/get-frame-db`
+         (single-frame; reads `:rf/default`).
+       - `:final-app-dbs` — `{frame-id db}` per-frame submap match
+         (multi-frame; per Spec 013 §Frame-scoping).
        - `:sub-values` — exact match per query.
        - `:expect-trace-stream` — order-preserving subset match against
          the captured `:op-type :flow` trace events (partial-match on
@@ -64,8 +70,14 @@
        - `:flow-graph-topology` — for each `flow-id #{dep-id ...}`
          entry, every dep is a registered flow whose `:path` overlaps
          the dependent's `:inputs`.
-       - `:flow-registry-after` — the set of flow ids in the
-         per-frame registry after the final dispatch.
+       - `:flow-registry-after` — the set of flow ids in the per-frame
+         registry after the final dispatch. Two shapes: a bare set
+         `#{ids}` reads `:rf/default`'s slot (single-frame), or a map
+         `{frame-id #{ids}}` reads each frame's slot (multi-frame).
+
+  Frame topology is declared via `:fixture/frames [{:id ... :on-create ...} ...]`
+  (multi-frame, per Spec 013 §Frame-scoping) OR `:fixture/frame-config`
+  (single-frame, configures `:rf/default`).
 
   ## Capability claim
 
@@ -174,7 +186,8 @@
     :flow/dirty-check
     :flow/toggle
     :flow/hot-reload
-    :flow/trace})
+    :flow/trace
+    :flow/frame-scoped})
 
 (def claimed-spec-versions
   "Fixture spec versions this runner claims to conform against. Matches
@@ -383,9 +396,13 @@
                         other-id))]))))
 
 (defn- flow-registry-ids
-  "Set of flow ids currently registered on the `:rf/default` frame."
-  []
-  (into #{} (keys (get @flows/flows :rf/default {}))))
+  "Set of flow ids currently registered on `frame-id` (default
+  `:rf/default`). The single-arg form preserves the original
+  single-frame contract; the two-arg form is used by multi-frame
+  fixtures (per Spec 013 §Frame-scoping)."
+  ([] (flow-registry-ids :rf/default))
+  ([frame-id]
+   (into #{} (keys (get @flows/flows frame-id {})))))
 
 ;; ---- single-fixture execution -------------------------------------------
 
@@ -398,20 +415,42 @@
           traces       (collect-traces fid)
           _            (realise-handlers fixture)
           frame-config (or (:fixture/frame-config fixture) {})
+          frames-spec  (:fixture/frames fixture)
           ;; `reset-runtime` already created :rf/default WITHOUT an
           ;; :on-create. `reg-frame` against an existing id is a
           ;; surgical update that does NOT re-fire :on-create (Spec 002).
           ;; Destroy first so the fixture's :on-create cascade fires
           ;; under its declared config.
+          ;;
+          ;; Multi-frame fixtures (per Spec 013 §Frame-scoping) declare
+          ;; `:fixture/frames [{:id ...} ...]` and the single `:rf/default`
+          ;; seam is bypassed. Single-frame fixtures keep the original
+          ;; shape (`:fixture/frame-config` configures `:rf/default`).
           _            (rf/destroy-frame :rf/default)
-          _            (rf/reg-frame :rf/default frame-config)
+          _            (if (seq frames-spec)
+                         (doseq [f frames-spec]
+                           (rf/reg-frame (:id f) (dissoc f :id)))
+                         (rf/reg-frame :rf/default frame-config))
           dispatches   (or (:fixture/dispatches fixture) [])]
+      ;; Dispatches may be a bare event vector (single-frame default) or
+      ;; an envelope map `{:event [...] :frame <id> ...}` (multi-frame,
+      ;; mirrors core's runner per spec/conformance/fixtures/frame-multi-instance.edn).
       (doseq [ev dispatches]
-        (rf/dispatch-sync ev))
+        (if (map? ev)
+          (let [{event :event :as opts} ev]
+            (rf/dispatch-sync event (dissoc opts :event)))
+          (rf/dispatch-sync ev)))
       ;; ---- assertion gathering -----------------------------------------
       (let [expect           (or (:fixture/expect fixture) {})
             expected-db      (:final-app-db expect)
+            ;; Multi-frame: `:final-app-dbs` is `{frame-id db}`; each db
+            ;; submap-matches against that frame's `get-frame-db`.
+            expected-dbs     (:final-app-dbs expect)
             final-db         (rf/get-frame-db :rf/default)
+            final-dbs        (when expected-dbs
+                               (into {}
+                                     (for [[fid _] expected-dbs]
+                                       [fid (rf/get-frame-db fid)])))
             sub-checks
             (doall
               (for [[query-v expected-val] (or (:sub-values expect) {})]
@@ -439,13 +478,23 @@
             actual-topo      (when expected-topo
                                (select-keys (flow-graph-deps)
                                             (keys expected-topo)))
-            ;; `:flow-registry-after` — strict set match.
+            ;; `:flow-registry-after` — strict set match. Two shapes:
+            ;;   #{ids}             — flow ids on `:rf/default` (single-frame).
+            ;;   {frame-id #{ids}}  — per-frame map (multi-frame, per
+            ;;                        Spec 013 §Frame-scoping).
             expected-after   (:flow-registry-after expect)
-            actual-after     (when (some? expected-after)
-                               (flow-registry-ids))]
+            actual-after     (cond
+                               (nil? expected-after) nil
+                               (map? expected-after)
+                               (into {}
+                                     (for [[fid _] expected-after]
+                                       [fid (flow-registry-ids fid)]))
+                               :else (flow-registry-ids))]
         (trace/clear-trace-cbs!)
         {:fixture-id        fid
-         :passed?           (and (or (nil? expected-db) (submap? expected-db final-db))
+         :passed?           (and (or (nil? expected-db)  (submap? expected-db final-db))
+                                 (or (nil? expected-dbs) (every? (fn [[fid db]] (submap? db (get final-dbs fid)))
+                                                                 expected-dbs))
                                  (every? #(= (:expected %) (:actual %)) sub-checks)
                                  (or (nil? stream-failures) (empty? stream-failures))
                                  (or (nil? emit-failures)   (empty? emit-failures))
@@ -454,6 +503,8 @@
                                  (or (nil? expected-after)  (= expected-after actual-after)))
          :final-db          final-db
          :expected-db       expected-db
+         :final-dbs         final-dbs
+         :expected-dbs      expected-dbs
          :sub-checks        sub-checks
          :stream-failures   stream-failures
          :emit-failures     emit-failures
@@ -536,6 +587,12 @@
             (when (not (submap? td (:final-db f)))
               (println "    expected app-db:" td)
               (println "    actual   app-db:" (:final-db f))))
+          (when-let [tds (:expected-dbs f)]
+            (doseq [[fid expected] tds]
+              (let [actual (get (:final-dbs f) fid)]
+                (when (not (submap? expected actual))
+                  (println "    expected app-db" fid ":" expected)
+                  (println "    actual   app-db" fid ":" actual)))))
           (doseq [sc (:sub-checks f)]
             (when (not= (:expected sc) (:actual sc))
               (println "    sub" (:query sc)

--- a/spec/conformance/fixtures/flow-frame-scoped.edn
+++ b/spec/conformance/fixtures/flow-frame-scoped.edn
@@ -1,0 +1,144 @@
+;; Conformance fixture: flow/frame-scoped
+;; Per Spec 013 §Frame-scoping — flows belong to one frame. The per-frame
+;; registry shape is `{frame-id {flow-id flow-map}}`; registration,
+;; evaluation, undo / time-travel, and `clear-flow`'s `dissoc-in` are
+;; all frame-local. Three normative consequences (Spec 013 lines 99-103)
+;; this fixture pins:
+;;
+;;   Contract 1 (sibling-frame isolation, lifted from "per-frame undo
+;;     / time-travel boundaries"). An event dispatched on one frame
+;;     walks ONLY that frame's flows; the sibling frame's app-db /
+;;     flow output are untouched. (`run-flows!` walks
+;;     `(get @flows frame-id)` only — per §Drain integration property
+;;     4 "Frame isolation".)
+;;
+;;   Contract 2 (same flow-id, multiple frames, independent
+;;     definitions). Registering `:compute` against `:left` with
+;;     `(fn [x] (* 2 x))` and against `:right` with `(fn [x] (* 100 x))`
+;;     produces two independent flows. Each frame's `run-flows!` walks
+;;     only its own slot of the registry; the same input value in each
+;;     frame yields a different output.
+;;
+;;   Contract 3 (`clear-flow` is frame-local). `(clear-flow :compute
+;;     {:frame :left})` removes the flow's definition from `:left`'s
+;;     slot and `dissoc-in`s its `:path` from `:left`'s app-db only.
+;;     `:right`'s `:compute` and its output are undisturbed.
+;;
+;; The flow body, registration, and clearing all flow through
+;; `:rf.fx/reg-flow` / `:rf.fx/clear-flow` so registration resolves to
+;; the dispatching frame (per Spec 013 §Dynamic toggle via fx — the
+;; reserved fxs register against the dispatching frame). Driving the
+;; fixture from per-frame dispatches is the canonical way to exercise
+;; the same flow-id against two frames with two independent definitions.
+
+{:fixture/id           :flow/frame-scoped
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/fx :flow/basic :flow/toggle :flow/frame-scoped}
+ :fixture/doc          "Flows are frame-scoped (Spec 013 §Frame-scoping). The same flow-id registered against two frames maintains two independent definitions; clearing it on one frame leaves the other intact; an event dispatched on one frame does not recompute the sibling frame's flows."
+
+ :fixture/registry
+ {:event {:tenant/init       {:doc "Seed :x on the dispatching frame."}
+          :tenant/reg-double {:doc "Register :compute on the dispatching frame; output = (* x 2)."}
+          :tenant/reg-cent   {:doc "Register :compute on the dispatching frame; output = (* x 100)."}
+          :tenant/set-x      {:doc "Mutate :x on the dispatching frame to drive a flow recompute."}
+          :tenant/clear      {:doc "Clear :compute on the dispatching frame."}}
+  :fx    {:rf.fx/reg-flow   {:doc "Reserved — register a flow at runtime, frame-scoped."
+                             :platforms #{:client :server}}
+          :rf.fx/clear-flow {:doc "Reserved — clear a flow at runtime, frame-scoped."
+                             :platforms #{:client :server}}}}
+
+ ;; Each frame's :on-create cascade fires :tenant/init, which seeds
+ ;; :x against the cascading frame. The fx-fired :rf.fx/reg-flow then
+ ;; registers :compute against the dispatching frame — different :body
+ ;; per frame, same flow-id, same :path.
+ :fixture/handlers
+ {:event {:tenant/init       [[:set [:x] 1]]
+          :tenant/reg-double [[:fx :rf.fx/reg-flow
+                               {:id     :compute
+                                :inputs [[:x]]
+                                :body   [[:fn :* [:event-arg 0] 2]]
+                                :path   [:result]}]]
+          :tenant/reg-cent   [[:fx :rf.fx/reg-flow
+                               {:id     :compute
+                                :inputs [[:x]]
+                                :body   [[:fn :* [:event-arg 0] 100]]
+                                :path   [:result]}]]
+          :tenant/set-x      [[:set [:x] [:event-arg 1]]]
+          :tenant/clear      [[:fx :rf.fx/clear-flow :compute]]}}
+
+ ;; Two frames; each seeds itself on creation. :tenant/init runs in
+ ;; each frame's :on-create cascade, so :x lands in both :left and
+ ;; :right's app-db independently.
+ :fixture/frames
+ [{:id :left  :on-create [:tenant/init]}
+  {:id :right :on-create [:tenant/init]}]
+
+ ;; Sequence (frames are isolated; flows fire on the next drain after
+ ;; their registering event):
+ ;;
+ ;;   1. {:event [:tenant/reg-double] :frame :left}
+ ;;        Registers :compute on :left (output = (* x 2)). First flow
+ ;;        evaluation lands on the NEXT :left drain.
+ ;;   2. {:event [:tenant/reg-cent] :frame :right}
+ ;;        Registers :compute on :right (output = (* x 100)). First
+ ;;        evaluation lands on the NEXT :right drain.
+ ;;   3. {:event [:tenant/set-x 5] :frame :left}
+ ;;        Mutates :left's :x to 5; :left's :compute fires → :left :result 10.
+ ;;        Critically, :right's :compute does NOT fire (frame isolation,
+ ;;        Contract 1). :right's :x still 1, :right's :result still NIL
+ ;;        because :right's :compute hasn't been driven yet.
+ ;;   4. {:event [:tenant/set-x 5] :frame :right}
+ ;;        Mutates :right's :x to 5; :right's :compute fires → :right :result 500.
+ ;;        Same input value as :left (both 5); independent definitions
+ ;;        yield different outputs (Contract 2): :left 10 vs :right 500.
+ ;;   5. {:event [:tenant/clear] :frame :left}
+ ;;        Clears :compute on :left. :left's registry no longer carries
+ ;;        :compute; :left's :result is dissoc'd. :right's :compute and
+ ;;        :right's :result are untouched (Contract 3).
+ :fixture/dispatches
+ [{:event [:tenant/reg-double] :frame :left}
+  {:event [:tenant/reg-cent]   :frame :right}
+  {:event [:tenant/set-x 5]    :frame :left}
+  {:event [:tenant/set-x 5]    :frame :right}
+  {:event [:tenant/clear]      :frame :left}]
+
+ :fixture/expect
+ ;; --- Contract 2: same flow-id, two frames, two independent outputs.
+ ;; Both frames carry :x 5 after dispatch (3) / (4); :left's output is
+ ;; (* 5 2) but cleared by step (5) so :left has no :result; :right's
+ ;; output is (* 5 100) = 500, untouched by :left's clear.
+ ;;
+ ;; --- Contract 1: sibling-frame isolation. :right's app-db is the
+ ;; product of :right's drains ONLY. Dispatch (3) on :left did not
+ ;; touch :right's :x (still 1 at that moment); dispatch (5) clearing
+ ;; on :left did not touch :right's :result.
+ ;;
+ ;; --- Contract 3: clear-flow is frame-local. After dispatch (5), the
+ ;; per-frame registry has :compute on :right but NOT on :left;
+ ;; :left's :result is dissoc'd from :left's app-db; :right's :result
+ ;; (500) is intact.
+ {:final-app-dbs
+  ;; :left has :x 5 (from step 3) and no :result (cleared in step 5).
+  ;; The submap matcher only checks declared keys; we declare :x to
+  ;; pin the value, but assert :result's absence via the registry
+  ;; channel and via :right's final-app-db (which still carries
+  ;; :result, proving the clear is frame-local).
+  {:left  {:x 5}
+   :right {:x 5 :result 500}}
+
+  ;; Per-frame registry shape — {frame-id #{flow-ids}}. After step 5:
+  ;;   :left  — :compute was cleared, slot empty.
+  ;;   :right — :compute remains.
+  :flow-registry-after
+  {:left  #{}
+   :right #{:compute}}
+
+  ;; Recompute counts pin the frame-isolated walker (Contract 1):
+  ;;   :left's :compute fired exactly once (step 3); step 5 cleared it.
+  ;;   :right's :compute fired exactly once (step 4); steps 3 and 5
+  ;;   dispatched on :left and did NOT walk :right's flows.
+  ;; The recompute aggregator currently keys by :flow-id only (not
+  ;; [:frame :flow-id]); both frames' :compute fire once each, so the
+  ;; total is 2.
+  :flow-recompute-counts
+  {:compute 2}}}


### PR DESCRIPTION
## Summary

Per audit rf2-0b2eh §TC-4: Spec 013 §Frame-scoping (lines 91-105) is a normative section with three contracts and Spec 013 line 268 plans `flow-frame-scoped.edn`, but neither shipped — the flows / core / cljs conformance runners all claimed the surface without proof.

This PR closes the gap.

## What ships

- `spec/conformance/fixtures/flow-frame-scoped.edn` (144 LoC) — fixture pinning the three Spec 013 §Frame-scoping contracts (registers `:compute` against `:left` and `:right` via `:rf.fx/reg-flow` with different bodies, drives per-frame dispatches, asserts per-frame app-dbs / registry / recompute counts).

- `implementation/flows/test/re_frame/flows_conformance_test.clj` — adds `:flow/frame-scoped` to `claimed-capabilities`. Extends the runner to support multi-frame fixtures (mirrors `conformance_test.clj`'s multi-frame seam): `:fixture/frames`, dispatch envelopes `{:event ... :frame ...}`, `:final-app-dbs` assertion channel, per-frame `:flow-registry-after {frame-id #{ids}}` shape.

- `implementation/core/test/re_frame/conformance_test.clj` and `implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs` — add `:flow/frame-scoped` so neither the core JVM corpus runner nor the CLJS strict-mode gate (rf2-a3q1r) trips on the new fixture.

## Three contracts pinned

1. **Sibling-frame isolation** (per-frame undo / time-travel boundaries). An event on `:left` walks ONLY `:left`'s flows. Pinned via `:flow-recompute-counts {:compute 2}` — would trip if `run-flows!` visited sibling frames on a cross-frame dispatch.

2. **Same flow-id, two frames, independent definitions.** `:compute` on `:left` outputs `(* x 2)`, on `:right` outputs `(* x 100)`. Both inputs set to 5; per-frame `:result` values pinned via `:final-app-dbs`.

3. **`clear-flow` is frame-local.** Clearing on `:left` removes `:left`'s registry slot and `dissoc-in`s `:left`'s `:result`; `:right`'s `:compute` and `:right`'s `:result 500` are pinned untouched.

## Test plan

- [x] `cd implementation/flows && clojure -M:test` — 37 tests / 138 assertions, 0 failures (all 7 flow fixtures pass including the new `:flow/frame-scoped`).
- [x] `cd implementation && npm run test:cljs` — 1816 tests / 5040 assertions, 0 failures.
- [x] Core JVM corpus runner picks up `flow-frame-scoped.edn` through the existing `flow-*.edn` discovery and passes.