### PR TITLE
refactor(mcp-base): round-2 polish cluster — 5 follow-on beads (rf2-n4q62)

### DIFF
--- a/tools/mcp-base/src/re_frame/mcp_base/args.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/args.cljc
@@ -36,6 +36,34 @@
                          :else default))
     :else            default))
 
+(defn- parse-int*
+  "Shared helper for `parse-positive-int` / `parse-non-negative-int`.
+  `floor` is the lower clamp (1 for positive, 0 for non-negative); the
+  three input arms (int / number / string + try/catch) are identical
+  across both call sites."
+  [raw default floor]
+  (cond
+    (nil? raw)
+    default
+
+    (integer? raw)
+    (max floor (long raw))
+
+    (number? raw)
+    (max floor (long raw))
+
+    (string? raw)
+    #?(:clj (try
+              (max floor (Long/parseLong (str/trim raw)))
+              (catch NumberFormatException _ default))
+       :cljs (let [n (js/parseInt raw 10)]
+               (if (and (number? n) (not (js/isNaN n)))
+                 (max floor (long n))
+                 default)))
+
+    :else
+    default))
+
 (defn parse-positive-int
   "Normalise a possibly-string MCP arg into a positive integer. Accepts
   ints (passed through, clamped to ≥1), strings (parsed; non-numeric
@@ -45,54 +73,13 @@
   The `default` is the convention's documented cap (e.g. 50 for cursor
   pagination, 5000 for token caps)."
   [raw default]
-  (cond
-    (nil? raw)
-    default
-
-    (integer? raw)
-    (max 1 (long raw))
-
-    (number? raw)
-    (let [n (long raw)]
-      (if (zero? n) 1 (max 1 n)))
-
-    (string? raw)
-    #?(:clj (try
-              (max 1 (Long/parseLong (str/trim raw)))
-              (catch NumberFormatException _ default))
-       :cljs (let [n (js/parseInt raw 10)]
-               (if (and (number? n) (not (js/isNaN n)))
-                 (max 1 (long n))
-                 default)))
-
-    :else
-    default))
+  (parse-int* raw default 1))
 
 (defn parse-non-negative-int
   "Like `parse-positive-int` but admits zero (useful when zero means
   \"disabled\" — e.g. max-tokens=0 disables the cap)."
   [raw default]
-  (cond
-    (nil? raw)
-    default
-
-    (integer? raw)
-    (max 0 (long raw))
-
-    (number? raw)
-    (max 0 (long raw))
-
-    (string? raw)
-    #?(:clj (try
-              (max 0 (Long/parseLong (str/trim raw)))
-              (catch NumberFormatException _ default))
-       :cljs (let [n (js/parseInt raw 10)]
-               (if (and (number? n) (not (js/isNaN n)))
-                 (max 0 (long n))
-                 default)))
-
-    :else
-    default))
+  (parse-int* raw default 0))
 
 (defn parse-keyword
   "Read a keyword from an agent-supplied argument. MCP arguments

--- a/tools/mcp-base/src/re_frame/mcp_base/args.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/args.cljc
@@ -113,12 +113,15 @@
   keywords (passthrough if recognised), or nil. Unrecognised values
   fall back to `default`.
 
+  String inputs route through `parse-keyword` so a leading `:` is
+  stripped (consistency with `parse-keyword` — `\":diff\"` and
+  `\"diff\"` both resolve to `:diff` when `:diff` is recognised).
+
   `recognised` is a set of accepted keywords (e.g. `#{:diff :full}`)."
   [raw default recognised]
   (cond
-    (nil? raw)              default
-    (contains? recognised raw)   raw
-    (and (string? raw)
-         (contains? recognised (keyword raw)))
-    (keyword raw)
-    :else                   default))
+    (nil? raw)                 default
+    (contains? recognised raw) raw
+    (string? raw)              (let [kw (parse-keyword raw)]
+                                 (if (contains? recognised kw) kw default))
+    :else                      default))

--- a/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
@@ -162,32 +162,41 @@
   Recurses into sub-maps; vectors and scalars are treated as leaves
   (replaced wholesale via `:assoc` rather than re-diffed element-wise
   — element-wise vector diff doesn't shrink the wire for the typical
-  app-db where vector values are short)."
+  app-db where vector values are short).
+
+  Two-pass: walks `b` once to emit `:assoc` patches for added /
+  changed keys (recursing on map/map pairs), then walks `a` once to
+  emit `:dissoc` patches for keys absent from `b`. Avoids the
+  intermediate key-union set the naive single-pass form would
+  allocate per call — non-trivial on the hot app-db diff path."
   [a b path]
-  (let [ks (into #{} (concat (keys a) (keys b)))]
-    (reduce
-      (fn [acc k]
-        (let [av (get a k ::absent)
-              bv (get b k ::absent)
-              p  (conj path k)]
-          (cond
-            ;; Key removed.
-            (= bv ::absent)
-            (conj acc [p :dissoc])
-            ;; Key added.
-            (= av ::absent)
-            (conj acc [p :assoc bv])
-            ;; Unchanged — skip.
-            (= av bv)
-            acc
-            ;; Both maps: recurse.
-            (and (map? av) (map? bv))
-            (into acc (collect-patches av bv p))
-            ;; Otherwise: leaf replacement.
-            :else
-            (conj acc [p :assoc bv]))))
-      []
-      ks)))
+  (let [after-assocs
+        (reduce-kv
+          (fn [acc k bv]
+            (let [av (get a k ::absent)
+                  p  (conj path k)]
+              (cond
+                ;; Key added.
+                (= av ::absent)
+                (conj acc [p :assoc bv])
+                ;; Unchanged — skip.
+                (= av bv)
+                acc
+                ;; Both maps: recurse.
+                (and (map? av) (map? bv))
+                (into acc (collect-patches av bv p))
+                ;; Otherwise: leaf replacement.
+                :else
+                (conj acc [p :assoc bv]))))
+          []
+          b)]
+    (reduce-kv
+      (fn [acc k _av]
+        (if (contains? b k)
+          acc
+          (conj acc [(conj path k) :dissoc])))
+      after-assocs
+      a)))
 
 (defn collect-patches
   "Patch-list factory. Two maps recurse via `collect-map-patches`; any

--- a/tools/mcp-base/src/re_frame/mcp_base/elision.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/elision.cljc
@@ -49,11 +49,10 @@
   per Conventions §Cross-MCP indicator-field vocabulary."
   [v]
   (cond
-    (and (map? v) (contains? v vocab/large-elided-key))
-    1
-
     (map? v)
-    (reduce-kv (fn [n _k child] (+ n (count-elided-markers child))) 0 v)
+    (if (contains? v vocab/large-elided-key)
+      1
+      (reduce-kv (fn [n _k child] (+ n (count-elided-markers child))) 0 v))
 
     (or (vector? v) (set? v) (seq? v))
     (reduce (fn [n child] (+ n (count-elided-markers child))) 0 v)

--- a/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
@@ -61,7 +61,7 @@
       [kept n])))
 
 (defn scrub-snapshot
-  "Walk a per-frame snapshot map and apply `strip-sensitive` to every
+  "Walk a per-frame snapshot map and apply a strip-fn to every
   `:traces` / `:epochs` slice. Returns `[scrubbed-snapshot
   total-dropped]`. Non-map slices and non-snapshot inputs pass
   through unchanged.
@@ -71,22 +71,35 @@
   are LEFT ALONE — app-db payload redaction is `with-redacted`'s job
   at write-time, not the forwarder's job at read-time. Re-asserted
   by the snapshot-scrubber tests in every MCP that emits per-frame
-  snapshots."
-  [snapshot include?]
-  (if (or include? (not (map? snapshot)))
-    [snapshot 0]
-    (let [dropped (volatile! 0)
-          scrub-slice
-          (fn [items]
-            (let [[kept n] (strip-sensitive (vec items) false)]
-              (vswap! dropped + n)
-              kept))
-          scrub-frame
-          (fn [frame-map]
-            (cond-> frame-map
-              (contains? frame-map :traces) (update :traces scrub-slice)
-              (contains? frame-map :epochs) (update :epochs scrub-slice)))
-          scrubbed (reduce-kv (fn [m k v]
-                                (assoc m k (if (map? v) (scrub-frame v) v)))
-                              {} snapshot)]
-      [scrubbed @dropped])))
+  snapshots.
+
+  ## Strip-fn parameter (rf2-zpmmr)
+
+  Two-arity form `[snapshot include?]` uses the base
+  `strip-sensitive` predicate (spec/009 §Privacy stamp check).
+  Three-arity form `[snapshot include? strip-fn]` accepts a custom
+  strip-fn matching the `[items include?] => [kept dropped]`
+  contract — pair2-mcp passes its union predicate that also catches
+  the epoch-level `:sensitive?` rollup (`sensitive-event? OR
+  sensitive-epoch?`). The default arity preserves the
+  trace-event-only filter for story-mcp / causa-mcp consumers."
+  ([snapshot include?]
+   (scrub-snapshot snapshot include? strip-sensitive))
+  ([snapshot include? strip-fn]
+   (if (or include? (not (map? snapshot)))
+     [snapshot 0]
+     (let [dropped (volatile! 0)
+           scrub-slice
+           (fn [items]
+             (let [[kept n] (strip-fn (vec items) false)]
+               (vswap! dropped + n)
+               kept))
+           scrub-frame
+           (fn [frame-map]
+             (cond-> frame-map
+               (contains? frame-map :traces) (update :traces scrub-slice)
+               (contains? frame-map :epochs) (update :epochs scrub-slice)))
+           scrubbed (reduce-kv (fn [m k v]
+                                 (assoc m k (if (map? v) (scrub-frame v) v)))
+                               {} snapshot)]
+       [scrubbed @dropped]))))

--- a/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
@@ -106,6 +106,17 @@
   (is (= :diff (args/parse-mode "diff" :diff #{:diff :full})))
   (is (= :full (args/parse-mode "full" :diff #{:diff :full}))))
 
+(deftest parse-mode-strips-leading-colon
+  ;; Regression pin (rf2-wnyy9 / round-2 F2): `parse-mode` must accept
+  ;; agent-supplied `":diff"` the same way `parse-keyword` accepts
+  ;; `":foo"`. Before the fix this silently default-fell-back — the
+  ;; agent saw `:diff` returned but the value was the function's
+  ;; default, not a recognised match.
+  (is (= :diff (args/parse-mode ":diff" :full #{:diff :full})))
+  (is (= :full (args/parse-mode ":full" :diff #{:diff :full})))
+  (is (= :rf/foo (args/parse-mode ":rf/foo" :default #{:rf/foo :rf/bar}))
+      "namespaced keywords also strip the leading colon"))
+
 (deftest parse-mode-nil-returns-default
   (is (= :diff (args/parse-mode nil :diff #{:diff :full}))))
 

--- a/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
@@ -60,6 +60,28 @@
 (deftest apply-patches-dissoc-at-root-via-direct-path
   (is (= {:a 1} (de/apply-patches {:a 1 :b 2} [[[:b] :dissoc]]))))
 
+(deftest apply-patches-applies-in-order-for-same-path
+  ;; Regression pin (rf2-cwqc8 / round-2 F18): when two patches target
+  ;; the same path, the later one wins — `reduce` over the patch
+  ;; sequence applies them in order so a later `:assoc` overrides an
+  ;; earlier one, and a `:dissoc` after an `:assoc` clears the value.
+  ;; pair2-mcp's diff_encode_epochs_test pinned this; the base's own
+  ;; test set didn't. Mirror the contract here so any future encoder
+  ;; refactor that flips the iteration order trips this gate before
+  ;; reaching the consumers.
+  (testing "later :assoc overrides earlier :assoc at same path"
+    (is (= {:a 99}
+           (de/apply-patches {} [[[:a] :assoc 1]
+                                 [[:a] :assoc 99]]))))
+  (testing ":dissoc after :assoc clears the value"
+    (is (= {}
+           (de/apply-patches {} [[[:a] :assoc 1]
+                                 [[:a] :dissoc]]))))
+  (testing ":assoc after :dissoc reinstates the value"
+    (is (= {:a 7}
+           (de/apply-patches {:a 1} [[[:a] :dissoc]
+                                     [[:a] :assoc 7]])))))
+
 ;; ---------------------------------------------------------------------------
 ;; diff-encode-db-after / decode-db-after — round-trip.
 ;; ---------------------------------------------------------------------------

--- a/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
@@ -143,3 +143,39 @@
   (let [[out dropped] (sensitive/scrub-snapshot nil false)]
     (is (nil? out))
     (is (zero? dropped))))
+
+(deftest scrub-snapshot-handles-lazy-seq-slice-values
+  ;; Regression pin (rf2-cwqc8 / round-2 F17): `:traces` and `:epochs`
+  ;; arrive as vectors in the typical runtime emission, but the
+  ;; instrumentation API doesn't guarantee that — a slice composed via
+  ;; `concat` / `map` / `filter` produces a lazy seq. The `(vec items)`
+  ;; wrap inside `scrub-slice` normalises before `strip-sensitive`
+  ;; runs; this test pins the contract so a future refactor that
+  ;; removes the wrap doesn't silently break the lazy-input case.
+  (let [snap   {:rf/default
+                {:traces (map identity [{:id 1 :sensitive? false}
+                                        {:id 2 :sensitive? true}
+                                        {:id 3}])
+                 :epochs (filter (constantly true)
+                                 [{:event-id :foo}
+                                  {:event-id :auth/sign-in :sensitive? true}])}}
+        [out dropped] (sensitive/scrub-snapshot snap false)]
+    (is (= 2 dropped))
+    (is (= [{:id 1 :sensitive? false} {:id 3}]
+           (get-in out [:rf/default :traces])))
+    (is (= [{:event-id :foo}]
+           (get-in out [:rf/default :epochs])))))
+
+(deftest scrub-snapshot-strip-fn-arity-delegates-to-custom-predicate
+  ;; rf2-zpmmr: the three-arity form admits a caller-supplied strip-fn
+  ;; matching the `[items include?] => [kept dropped]` contract. Pin
+  ;; the contract so a future refactor of the helper can't silently
+  ;; drop the delegation.
+  (let [strip-by-id-2 (fn [items _include?]
+                        (let [kept (filterv #(not= 2 (:id %)) items)
+                              n    (- (count items) (count kept))]
+                          [kept n]))
+        snap          {:rf/default {:traces [{:id 1} {:id 2} {:id 3} {:id 2}]}}
+        [out dropped] (sensitive/scrub-snapshot snap false strip-by-id-2)]
+    (is (= 2 dropped))
+    (is (= [{:id 1} {:id 3}] (get-in out [:rf/default :traces])))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/sensitive.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/sensitive.cljs
@@ -75,27 +75,18 @@
       [kept n])))
 
 (defn scrub-snapshot-sensitive
-  "Walk a snapshot's per-frame map and drop `:sensitive? true` items from
-  the `:traces` slice (and, defensively, `:epochs` — epoch records may
-  inherit the stamp in future runtime revisions per spec/009). Returns
-  `[scrubbed dropped-count]`. The non-trace slices (:app-db, :sub-cache,
-  :machines) pass through unchanged — redaction of those payloads is
-  the `with-redacted` interceptor's job, not the forwarder's."
+  "Walk a snapshot's per-frame map and drop `:sensitive? true` items
+  from the `:traces` slice (and, defensively, `:epochs` — epoch
+  records may inherit the stamp). Returns `[scrubbed dropped-count]`.
+  Non-trace slices (:app-db, :sub-cache, :machines) pass through
+  unchanged — redaction of those payloads is the `with-redacted`
+  interceptor's job, not the forwarder's.
+
+  Thin delegate (rf2-zpmmr) to
+  `re-frame.mcp-base.sensitive/scrub-snapshot` with the pair2-mcp
+  union strip-fn (`strip-sensitive`, which gates both
+  `sensitive-event?` and `sensitive-epoch?`). Story-mcp /
+  causa-mcp use the base helper's two-arity form, which defaults to
+  the trace-event-only filter."
   [snapshot include?]
-  (if (or include? (not (map? snapshot)))
-    [snapshot 0]
-    (let [dropped (atom 0)
-          scrub-slice
-          (fn [items]
-            (let [[kept n] (strip-sensitive (vec items) false)]
-              (swap! dropped + n)
-              kept))
-          scrub-frame
-          (fn [frame-map]
-            (cond-> frame-map
-              (contains? frame-map :traces) (update :traces scrub-slice)
-              (contains? frame-map :epochs) (update :epochs scrub-slice)))
-          scrubbed (reduce-kv (fn [m k v]
-                                (assoc m k (if (map? v) (scrub-frame v) v)))
-                              {} snapshot)]
-      [scrubbed @dropped])))
+  (base-sensitive/scrub-snapshot snapshot include? strip-sensitive))


### PR DESCRIPTION
## Summary

Batched round-2 polish cluster on `tools/mcp-base/` surfaced by the
audit in `ai/findings/refactor-audit-r2-tools-mcp-base-2026-05-14.md`
(rf2-n4q62). Five beads land here as one commit each, sequenced from
isolated nits → parametrisation → tests-against-the-new-surface.

| Commit | Bead | P | Title |
|---|---|---|---|
| `8f549f99` | rf2-1vcej | P3 | perf nits — diff-encode (drop key-union set) + elision (collapse `map?` arms) |
| `b62a0122` | rf2-njbup | P3 | collapse `parse-positive-int` / `parse-non-negative-int` via shared helper |
| `d318de6d` | rf2-wnyy9 | P2 | `parse-mode` strips leading `:` (parity with `parse-keyword`; fixes F2/F3 + regression pin F16) |
| `5add3854` | rf2-zpmmr | P2 | parametrise `scrub-snapshot` with explicit strip-fn; pair2-mcp `scrub-snapshot-sensitive` collapses to one-line delegate |
| `dbbf09c2` | rf2-cwqc8 | P2 | fill test gaps — scrub-snapshot lazy-seq input, scrub-snapshot strip-fn arity, apply-patches same-path order |

Net delta: +184 / -113 across 8 files (heavy on test additions; net
source LoC reduction across the rest).

## Highlights

- **`parse-mode` correctness fix.** Before: `parse-mode \":diff\" :full #{:diff :full}` silently returned `:full` (the default), masquerading as success when the caller's default happened to match. Now routes the string arm through `parse-keyword`, accepting `\":diff\"` and `\"diff\"` interchangeably.
- **`scrub-snapshot` parametrisation.** New three-arity form admits a caller-supplied strip-fn; pair2-mcp's near-duplicate `scrub-snapshot-sensitive` (with its mistaken `atom` for single-threaded scrub) collapses to a one-line delegate. The base helper retains its correct `volatile!`.
- **`collect-map-patches` allocation drop.** No longer materialises an intermediate key-union set; two-pass walk over `b` then `a` is allocation-cheaper on the hot app-db diff path.
- **`parse-int*` shared helper.** Two near-identical parser bodies (~24 LoC duplication) collapse to one helper + two one-line delegates.

## Test plan

- [x] `cd tools/mcp-base && clojure -M:test` — 71 tests / 190 assertions / 0 failures (was 67/179 pre-batch).
- [x] `cd implementation && npm run test:cljs` — 1816 tests / 5040 assertions / 0 failures (includes pair2-mcp + story-mcp consumers).
- [x] `cd implementation && npm run test:bundle-isolation` — PASS (mcp-base is leaf; isolation invariant preserved).