### PR TITLE
refactor(causa-mcp): round-2 polish cluster — 8 follow-on beads (rf2-c33xi)

### DIFF
--- a/tools/causa-mcp/spec/000-Vision.md
+++ b/tools/causa-mcp/spec/000-Vision.md
@@ -143,8 +143,7 @@ root.
 
 ## MCP catalogue summary
 
-Eighteen tools across five bands — Inspection (9) / Mutation (3)
-/ Streaming (3) / Escape hatch (1) / Meta (2) — per the
+Eighteen tools across five bands per the
 [canonical counts in `README.md`](./README.md#canonical-counts).
 
 **The band enumeration with tool names, signatures, return

--- a/tools/causa-mcp/spec/000-Vision.md
+++ b/tools/causa-mcp/spec/000-Vision.md
@@ -236,24 +236,20 @@ The defining property of Causa-MCP — and a first-class
 differentiator against generalist agent surfaces like Chrome
 DevTools MCP's `evaluate_script` — is that **every dispatch,
 every `reset-frame-db`, every `restore-epoch` issued through this
-server is tagged `:origin :causa-mcp` on the trace bus**. The
-agent driving the server leaves an audit trail; its mutations
-are filterable, separable from the user's, and distinguishable
-from `:app` / `:pair` / `:story` / `:test` mutations in the same
-session.
+server is tagged `:origin :causa-mcp` on the trace bus**. Chrome's
+`evaluate_script` is untagged; an agent that hand-rolls
+`js/window.dispatch(...)` is indistinguishable in the trace from
+a real user click. Causa-MCP's tag inversion makes the
+post-incident question "what did the agent do?" answerable via a
+single filter.
 
-Chrome's `evaluate_script` is untagged: an agent that hand-rolls
-`js/window.dispatch(...)` is **indistinguishable** in the trace
-from a real user click. Causa-MCP's tag inversion
-(`:origin :causa-mcp` by default; opt out at your peril) means a
-post-incident audit can ask "what did the agent do?" and get a
-complete, filterable answer via
-`get-trace-buffer {:filter {:origin :causa-mcp}}`.
-
-The origin tagging is **the convention**, not a suggestion —
-captured as a load-bearing principle in
-[`Principles.md`](./Principles.md) and locked in
-[`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md).
+The discipline (default-on, per-call opt-out, scope, the full
+`:app` / `:pair` / `:causa-mcp` / `:story` / `:test` vocabulary,
+worked trace-filter examples) lives in
+[`Principles.md` §"Origin tagging is the convention, not a
+suggestion"](./Principles.md#origin-tagging-is-the-convention-not-a-suggestion);
+the lock is
+[`DESIGN-RATIONALE.md` Lock #4](./DESIGN-RATIONALE.md#lock-4--origin-tagging-is-the-convention).
 
 ## Relationship to Causa
 
@@ -340,12 +336,12 @@ Captured as Lock #1 in [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md).
 
 ## Why a server, not an IDE plugin
 
-MCP is the agent-host's contract for tool integration. By
-implementing MCP over stdio, this artefact works with **every**
-MCP-capable host (Claude Code, Cursor, Copilot, etc.) without
-per-host plumbing.
-
-Captured as Lock #2 in [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md).
+MCP is the agent-host's contract for tool integration — one
+stdio JSON-RPC server works with every MCP-capable host (Claude
+Code, Cursor, Copilot, etc.) without per-host plumbing. The
+tie-breaker and the rejected alternatives live at
+[`Principles.md` §"MCP, not an IDE plugin"](./Principles.md#mcp-not-an-ide-plugin);
+captured as Lock #2 in [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md).
 
 ## Status
 

--- a/tools/causa-mcp/spec/000-Vision.md
+++ b/tools/causa-mcp/spec/000-Vision.md
@@ -350,8 +350,9 @@ Captured as Lock #2 in [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md).
 ## Status
 
 **Spec scaffold.** No source yet. The implementation work begins
-after Causa's panel ratifies; the four pair2-mcp-shape capability
-files (`001-Wire-Protocol`, `002-nREPL-Transport`,
+once [`tools/causa/`](../../causa/) ships its v1.0 panel; the four
+pair2-mcp-shape capability files (`001-Wire-Protocol`,
+`002-nREPL-Transport`,
 `003-Tool-Catalogue`, plus an `API.md`) land at that point. The
 locked design decisions accumulated to date live in
 [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md); the load-bearing

--- a/tools/causa-mcp/spec/000-Vision.md
+++ b/tools/causa-mcp/spec/000-Vision.md
@@ -289,7 +289,7 @@ Causa-MCP is the **debugger-side** counterpart to pair2-mcp's
 | Axis | [`tools/pair2-mcp/`](../../pair2-mcp/) | `tools/causa-mcp/` |
 |---|---|---|
 | Audience | Editor-side AI workflows (build/edit/test). | Debugger-side AI workflows (inspect/time-travel). |
-| Surface | 9 tools (dispatch, eval, hot-swap, trace, streaming). | 18 tools (inspection + mutation + streaming + escape hatch + session lifecycle). |
+| Surface | 10 tools (editor-side: discover/eval/dispatch/snapshot/trace + streaming pair). | 18 tools (inspection + mutation + streaming + escape hatch + meta). |
 | `:origin` tag | `:pair` | `:causa-mcp` |
 | MCP-server ns (Node-side) | `re-frame-pair2-mcp.*` (e.g. `re-frame-pair2-mcp.server`, `.tools`, `.nrepl`, `.cache`) | `day8.re-frame2-causa-mcp.*` (when impl lands) |
 | Injected-runtime ns (browser-side) | `re-frame-pair2.runtime` | `day8.re-frame2-causa.runtime` (rides Causa's preload) |

--- a/tools/causa-mcp/spec/004-Wire-Pipeline.md
+++ b/tools/causa-mcp/spec/004-Wire-Pipeline.md
@@ -360,7 +360,7 @@ declare which mechanisms apply, the **typical-token** hint, the
 **cap-reached** behaviour, and the default `:mode` /
 `:limit` / `:dedup?` values. No tool ships without these slots.
 
-### Streaming over batch (cross-cutting)
+## Streaming over batch (cross-cut)
 
 The `subscribe` stream returns one event per JSON-RPC
 `notifications/progress`, not a buffered batch. The cap applies

--- a/tools/causa-mcp/spec/004-Wire-Pipeline.md
+++ b/tools/causa-mcp/spec/004-Wire-Pipeline.md
@@ -114,8 +114,9 @@ posture (file header).
 The **5,000-token default** is the per-response budget. Every
 tool that returns to the agent MUST measure the rendered
 payload (post-EDN-encoding, post-JSON-wrap) against the cap
-before returning. Each call MAY override via a `:max-tokens`
-integer argument (server clamps to `[1, 50000]`).
+before returning. Each call MAY override via a `max-tokens`
+integer JSON-RPC argument (server clamps to `[500, 50000]`;
+the corresponding parsed CLJS keyword is `:max-tokens`).
 
 A tool that would exceed the cap MUST NOT silently truncate.
 Instead it MUST return a structured overflow marker at the top
@@ -201,7 +202,9 @@ integer id; the wire payload carries
 
 The dedup algorithm is the
 [`day8/de-dupe`](https://github.com/day8/de-dupe) substitution
-table — proven on re-frame-10x's epoch payloads. The agent
+table — originally proven on re-frame-10x's epoch payloads;
+re-applied here to re-frame2's structurally-similar trace and
+epoch shapes. The agent
 reconstructs the full structure with a one-pass walk
 substituting refs against the table. Dedup is **opt-out** per
 call (`:dedup? false`); on by default for trace-shaped

--- a/tools/causa-mcp/spec/004-Wire-Pipeline.md
+++ b/tools/causa-mcp/spec/004-Wire-Pipeline.md
@@ -19,11 +19,9 @@ principles for Causa-MCP (origin tagging, EDN canonical, closed-set
 catalogue, two-namespace split, etc.); the wire-pipeline rules
 below were split out into this file (rf2-erimb) because the section
 grew large enough to deserve its own scaffold — mirroring the
-pair2-mcp-shape capability files
-([`001-Wire-Protocol.md`](#),
-[`002-nREPL-Transport.md`](#),
-[`003-Tool-Catalogue.md`](#) — the latter three land at impl-pass
-time).
+pair2-mcp-shape capability files (`001-Wire-Protocol.md`,
+`002-nREPL-Transport.md`, `003-Tool-Catalogue.md` — the latter
+three land at impl-pass time).
 
 ## Privacy: default-drop `:sensitive?` events at the MCP boundary
 
@@ -224,7 +222,7 @@ matches the call-site shape:
 
 The earlier "3-5×" range in this section was vibes; the measured
 numbers above supersede it. Catalogue entries in
-[`003-Tool-Catalogue.md`](#) (when it lands) MUST cite the
+`003-Tool-Catalogue.md` (when it lands) MUST cite the
 regime-appropriate factor when declaring `:typical-tokens` —
 trace-bus-shaped tools use **~1.4×**, recurring-cascade tools
 use **~10×**, epoch-slice tools use **5-10×**.

--- a/tools/causa-mcp/spec/004-Wire-Pipeline.md
+++ b/tools/causa-mcp/spec/004-Wire-Pipeline.md
@@ -49,8 +49,7 @@ helper:
   tools) when non-zero.
 - **Opt-in**: per-call `:include-sensitive? true` MCP arg disables
   the gate. The arg name is fixed cross-server (pair2-mcp + story-mcp
-  + causa-mcp) so an agent that learns the slot on one server gets
-  the same slot on the others.
+  + causa-mcp) per the cross-server symmetry posture above.
 - **Scope**: only the trace-stream surface. Mutating ops (`dispatch`,
   `restore-epoch`, `reset-frame-db`) and read-mostly per-frame state
   ops (`get-app-db`, `get-app-db-diff`, `get-machine-state`) don't
@@ -60,9 +59,8 @@ helper:
 The wiring pattern (when implementation lands) mirrors
 [`tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs`](../../pair2-mcp/src/re_frame_pair2_mcp/tools.cljs)'s
 `strip-sensitive` helper + `:include-sensitive?` arg + descriptor
-slot on each affected tool. Cross-server symmetry is load-bearing —
-an agent that knows the slot on pair2-mcp gets the same slot on
-causa-mcp.
+slot on each affected tool — per the cross-server symmetry posture
+(file header).
 
 The trust boundary is the MCP stdio channel: data that crosses it
 reaches the agent host, and from there potentially the LLM provider.
@@ -108,8 +106,8 @@ documented.
 
 The wording below aligns deliberately with
 [`tools/pair2-mcp/spec/Principles.md`](../../pair2-mcp/spec/Principles.md)
-§Tight token budget per response so that an agent learning the
-slot on one server gets the same slot on the others.
+§Tight token budget per response — per the cross-server symmetry
+posture (file header).
 
 ### 1. Token budget cap
 

--- a/tools/causa-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/causa-mcp/spec/DESIGN-RATIONALE.md
@@ -679,7 +679,7 @@ typical-token hint, its cap-reached behaviour, and its default
   compress **~10×** (~90% reduction), epoch slices compress
   **5-10×** (already pinned at 89.5% by `dedup_test.cljs` for
   rf2-obpa9). The catalogue-entry contract in
-  [`003-Tool-Catalogue.md`](#) (when it lands) cites the
+  `003-Tool-Catalogue.md` (when it lands) cites the
   regime-appropriate factor per tool. Dedup is opt-out, not
   opt-in, so the default agent experience is the compressed
   wire.

--- a/tools/causa-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/causa-mcp/spec/DESIGN-RATIONALE.md
@@ -313,9 +313,9 @@ additions are deliberate (a Lock entry here, a discussion).
 - **One tool per Causa panel is the symmetry.** Causa's pitch
   is "the cascade you can see"; Causa-MCP's pitch is "the
   cascade your agent can read." Eighteen tools map cleanly to
-  eighteen Causa surfaces (9 read + 3 mutate + 3 stream + 1
-  escape hatch + 2 meta). The agent reading
-  `tools/list` sees a one-to-one map.
+  eighteen Causa surfaces (band split per
+  [`README.md` §Canonical counts](./README.md#canonical-counts)).
+  The agent reading `tools/list` sees a one-to-one map.
 - **Pair2-mcp's catalogue is editor-side; Causa's is
   debugger-side.** Mirroring pair2 wholesale would leave
   agents writing Chrome MCP `evaluate_script` blocks for

--- a/tools/causa-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/causa-mcp/spec/DESIGN-RATIONALE.md
@@ -333,6 +333,19 @@ additions are deliberate (a Lock entry here, a discussion).
   signal to promote it to its own catalogue entry — but the
   promotion is a deliberate Lock entry, not a silent merge.
 
+### Where future catalogue growth lands
+
+When a tool is promoted from `eval-cljs` recurrence (or from any
+other recurrent-workflow signal) to a named tool, the addition
+lands in `003-Tool-Catalogue.md` (once impl ships it) and a
+Lock-N entry pins the rationale. The canonical band-and-count
+fact is [`README.md` §Canonical counts](./README.md#canonical-counts);
+[`tools/causa/spec/010-MCP-Server.md`](../../causa/spec/010-MCP-Server.md)
+and the future `003-Tool-Catalogue.md` cite that subsection
+rather than restating the totals. Lock #12 is the worked
+example: catalogue grew by one, README's counts table moved,
+Lock entry landed.
+
 ### Date locked
 
 2026-05-12 (Mike). The seventeen-tool catalogue was assembled
@@ -663,9 +676,10 @@ typical-token hint, its cap-reached behaviour, and its default
   reserved `:rf.mcp/overflow` / `:rf.mcp/summary` keys are
   cross-server reservations, not Causa-MCP-private vocabulary.
   Where pair2-mcp's wording is silent (path slicing, structural
-  dedup, `:max-tokens` override, the overflow marker shape),
-  Causa-MCP's spec is the forward-locking site — a follow-up
-  alignment bead may lift the wording back into pair2-mcp.
+  dedup, `max-tokens` override, the overflow marker shape),
+  Causa-MCP's spec is the forward-locking site — the follow-up
+  alignment bead that lifts the wording back into pair2-mcp is
+  tracked at rf2-uebll.
 - **Structural dedup is the new mechanism.** Mechanisms 1–4 are
   refinements of pair2-mcp's three-axis discipline. Mechanism 5
   (`day8/de-dupe` substitution-table for trace bursts) is novel
@@ -718,8 +732,8 @@ line 1163.
   (recommendation #10, local-only) — the source-of-truth
   investigation that motivated baking before impl.
 - [`day8/de-dupe`](https://github.com/day8/de-dupe) — the
-  substitution-table substrate for mechanism 5; proven on
-  re-frame-10x's epoch payloads.
+  substitution-table substrate for mechanism 5; originally
+  proven on re-frame-10x's epoch payloads, re-applied here.
 - [Spec 009](../../../spec/009-Instrumentation.md) — the trace
   bus whose burst-shape mechanism 5 compresses.
 
@@ -750,9 +764,26 @@ mechanism in `Principles.md` before impl begins, on the same
 "bake-before-impl" calculus as Lock #9 — or wait until impl
 surfaces the same drift?
 
+### Options considered
+
+- **Option A — bake the sixth mechanism now.** Promote
+  `:rf.size/large-elided` to a named sixth mechanism in
+  `Principles.md` (now `004-Wire-Pipeline.md` post rf2-erimb)
+  alongside the first five. Bind every catalogue entry to
+  declare `:include-large?` / `:elided-large` slots.
+- **Option B — reference the marker without promoting it.**
+  Keep the existing in-line mention inside the streaming section
+  (the position after rf2-04ozp / PR #709) but leave the count
+  at "five mechanisms". The marker still ships; the spec just
+  doesn't name it as a peer mechanism.
+- **Option C — wait until impl.** Defer the promotion until
+  `tools/causa-mcp/src/` lands and the catalogue's per-tool
+  contract surfaces the same drift pair2-mcp paid down via
+  rf2-urjnc.
+
 ### Pick
 
-**Promote `:rf.size/large-elided` to mechanism #6 in
+**Option A — promote `:rf.size/large-elided` to mechanism #6 in
 `Principles.md`.** Bake the marker shape, the `:sensitive?`
 composition rule ("sensitive wins"), the `:include-large?`
 opt-out slot, the `:elided-large` indicator field, and the

--- a/tools/causa-mcp/spec/Principles.md
+++ b/tools/causa-mcp/spec/Principles.md
@@ -301,7 +301,7 @@ Highlights this doc relies on as principles:
   [`004-Wire-Pipeline.md` §"Tight token budget per response"](./004-Wire-Pipeline.md#tight-token-budget-per-response).
 - **Streaming**: the `subscribe` stream returns one event per JSON-RPC
   `notifications/progress`, with the cap applied per notification —
-  per [`004-Wire-Pipeline.md` §"Streaming over batch (cross-cutting)"](./004-Wire-Pipeline.md#streaming-over-batch-cross-cutting).
+  per [`004-Wire-Pipeline.md` §"Streaming over batch (cross-cut)"](./004-Wire-Pipeline.md#streaming-over-batch-cross-cut).
 
 The cross-server contract — default cap, override slot name
 (`max-tokens`), overflow marker key (`:rf.mcp/overflow`),

--- a/tools/causa-mcp/spec/Principles.md
+++ b/tools/causa-mcp/spec/Principles.md
@@ -232,8 +232,9 @@ Same posture as pair2-mcp.
 
 ## Read-mostly catalogue; mutate via the in-panel-equivalent gates
 
-The eighteen tools split 9 read / 3 mutate / 3 stream / 1 escape
-hatch / 2 meta. The mutating tools (`restore-epoch`,
+The catalogue is read-mostly — see
+[`README.md` §Canonical counts](./README.md#canonical-counts) for
+the band split. The mutating tools (`restore-epoch`,
 `reset-frame-db`, `dispatch`) mirror the in-panel right-click
 affordances the human user already has — Causa-MCP doesn't
 introduce a *new* mutation surface, it gives the agent the same

--- a/tools/causa-mcp/spec/findings/MUST-inventory.md
+++ b/tools/causa-mcp/spec/findings/MUST-inventory.md
@@ -1,0 +1,116 @@
+# MUST-inventory — Causa-MCP pre-impl
+
+**Bead**: rf2-g3u9f (parent audit rf2-c33xi).
+**Status**: pre-impl scaffold. Exploratory; not normative.
+**Substrate**: per [`tools/causa-mcp/spec/README.md`](../README.md)
+line 25 (`findings/` — exploratory working substrate; audit
+lineage, not normative).
+
+## Purpose
+
+Causa-MCP's spec scaffold names ~20 MUST-level invariants across
+[`Principles.md`](../Principles.md) and
+[`004-Wire-Pipeline.md`](../004-Wire-Pipeline.md). When
+`tools/causa-mcp/src/` lands and the impl pass authors the test
+corpus, every MUST needs a corresponding test. Today there is no
+inventory binding MUSTs to test-stubs — risk: the impl-pass
+corpus grows organically and misses one. Precedent: pair2-mcp's
+`:elided-large` parity bead (rf2-zjqh8) where the indicator MUST
+drifted between sites because no per-tool test pinned it.
+
+This doc is the forcing function. Every MUST below MUST surface
+as a named test (or named test cluster) once
+`tools/causa-mcp/test/` exists. New MUSTs added to the spec MUST
+land alongside an inventory row.
+
+The inventory is intentionally **pre-impl**: test names are
+sketched, not authoritative. When impl ships, the column
+"Planned test" gets sharpened against the actual deftest names
+and any inventory rows that didn't translate cleanly get
+audited.
+
+## Cross-server MUSTs (separate substrate)
+
+A subset of the MUSTs below are not Causa-MCP-private — they are
+cross-server reservations shared with pair2-mcp and story-mcp
+(token-cap shape, `:rf.mcp/overflow` envelope, `:sensitive?`
+default-drop, `:rf.size/large-elided` marker shape, the
+`max-tokens` arg name). Those land in
+[`tools/mcp-conformance/`](../../../mcp-conformance/) tests —
+tracked separately by rf2-zvv65. They appear in this inventory
+for completeness; the **test owner** column flags them.
+
+## Inventory
+
+| # | MUST | Source | Test owner | Planned test (pre-impl sketch) |
+|---|---|---|---|---|
+| 1 | Framework-published listener integrations (Causa-MCP server) MUST default-suppress `:sensitive? true` events | [004-Wire-Pipeline.md L32](../004-Wire-Pipeline.md) | Cross-server (rf2-zvv65) | `mcp-conformance/sensitive-default-drop-test` — Causa-MCP row |
+| 2 | Every tool surfacing trace-stream-shaped payloads (`get-trace-buffer`, `subscribe`, `get-epoch-history`) MUST apply the default-suppress filter at the MCP boundary before any data crosses into the agent surface | [004-Wire-Pipeline.md L39](../004-Wire-Pipeline.md) | Causa-MCP | `causa-mcp.tools.privacy/get-trace-buffer-drops-sensitive`; `subscribe-drops-sensitive`; `get-epoch-history-drops-sensitive` |
+| 3 | A tool that cannot answer inside the 5,000-token budget MUST trim, summarise, slice, paginate, or dedupe rather than over-spend | [004-Wire-Pipeline.md L74](../004-Wire-Pipeline.md) | Causa-MCP | `causa-mcp.tools.budget/no-tool-overspends-cap` (parameterised across every catalogue entry) |
+| 4 | Every catalogue entry (`003-Tool-Catalogue.md`) MUST declare which of the six mechanisms apply, with `:typical-tokens` and `:cap-reached` slots | [004-Wire-Pipeline.md L100, L359-363](../004-Wire-Pipeline.md) | Causa-MCP | `causa-mcp.catalogue/every-entry-declares-mechanism-set` (static-shape lint, runs against the registry-load step) |
+| 5 | Every tool that returns to the agent MUST measure the rendered payload (post-EDN-encoding, post-JSON-wrap) against the cap before returning | [004-Wire-Pipeline.md L115](../004-Wire-Pipeline.md) | Causa-MCP | `causa-mcp.tools.budget/every-tool-measures-pre-return` |
+| 6 | A tool that would exceed the cap MUST NOT silently truncate | [004-Wire-Pipeline.md L121](../004-Wire-Pipeline.md) | Causa-MCP | `causa-mcp.tools.budget/overflow-never-silent` (paired with #7) |
+| 7 | A tool exceeding the cap MUST return the structured overflow marker at the top of the payload | [004-Wire-Pipeline.md L122](../004-Wire-Pipeline.md) | Causa-MCP + cross-server (rf2-zvv65) | `causa-mcp.tools.budget/overflow-marker-shape`; `mcp-conformance/overflow-marker-cross-server` |
+| 8 | Tools returning rich nested values (`get-app-db`, `get-machine-state`, `get-epoch-history`) MUST accept an optional `:path` argument (EDN-encoded vector) | [004-Wire-Pipeline.md L141](../004-Wire-Pipeline.md) | Causa-MCP | `causa-mcp.tools.path/{get-app-db,get-machine-state,get-epoch-history}-accepts-path-arg` |
+| 9 | The default behaviour without a `:path` argument MUST be a tree-summary, not the full payload | [004-Wire-Pipeline.md L145](../004-Wire-Pipeline.md) | Causa-MCP | `causa-mcp.tools.path/default-mode-is-summary` (parameterised) |
+| 10 | Sequence-returning tools MUST accept `:cursor` (opaque string) and `:limit` (integer) | [004-Wire-Pipeline.md L158](../004-Wire-Pipeline.md) | Causa-MCP | `causa-mcp.tools.pagination/sequence-tools-accept-cursor-and-limit` (parameterised: `get-trace-buffer`, `get-epoch-history`, `list-subscriptions`, others) |
+| 11 | Sequence-returning responses MUST carry `:next-cursor` (opaque or nil) and `:remaining` (count/estimate) | [004-Wire-Pipeline.md L163](../004-Wire-Pipeline.md) | Causa-MCP | `causa-mcp.tools.pagination/response-shape` |
+| 12 | Tools returning rich nested values MUST expose a `:mode` argument with at least `:summary` (default), `:sample`, and `:full` | [004-Wire-Pipeline.md L184](../004-Wire-Pipeline.md) | Causa-MCP | `causa-mcp.tools.mode/exposes-summary-sample-full` (parameterised) |
+| 13 | `get-app-db-diff` in particular MUST default to changed-paths-with-cardinalities, not the nested diff | [004-Wire-Pipeline.md L189](../004-Wire-Pipeline.md) | Causa-MCP | `causa-mcp.tools.diff/default-shape-is-paths-with-cardinalities` |
+| 14 | Catalogue entries in `003-Tool-Catalogue.md` MUST cite the regime-appropriate compression factor when declaring `:typical-tokens` (~1.4× trace bursts; ~10× recurring cascades; 5-10× epoch slices) | [004-Wire-Pipeline.md L226](../004-Wire-Pipeline.md) | Causa-MCP | `causa-mcp.catalogue/dedup-factor-cited` (registry-load lint) |
+| 15 | Causa-MCP catalogue MUST declare the `:include-large?` slot, the `:elided-large` indicator field, and the default elision-policy on every tool emitting tree-typed payloads | [004-Wire-Pipeline.md L342](../004-Wire-Pipeline.md) | Causa-MCP + cross-server (rf2-zvv65) | `causa-mcp.tools.elision/every-tree-tool-declares-elision-slots`; cross-server marker-shape test in mcp-conformance |
+| 16 | Every tool entry MUST declare which mechanisms apply, `:typical-token` hint, `:cap-reached` behaviour, default `:mode` / `:limit` / `:dedup?` values (catalogue-entry contract) | [004-Wire-Pipeline.md L359-363](../004-Wire-Pipeline.md) | Causa-MCP | `causa-mcp.catalogue/entry-declares-all-required-slots` (the load-bearing scaffolding test) |
+| 17 | The size-elision walker (`re-frame.core/elide-wire-value`) is the single normative emission site — per-tool reimplementation is prohibited | [004-Wire-Pipeline.md L301-302](../004-Wire-Pipeline.md) | Causa-MCP + cross-server | `causa-mcp.tools.elision/walker-is-single-emission-site` (lint over the impl source — searches for marker keyword construction outside the walker call) |
+| 18 | The `:sensitive?` / `:large?` composition cascade `(and sensitive? large?) → ::drop` MUST hold — sensitive wins; no marker emitted when both predicates match | [004-Wire-Pipeline.md L277-291](../004-Wire-Pipeline.md), [DESIGN-RATIONALE Lock #10](../DESIGN-RATIONALE.md) | Cross-server (rf2-zvv65) + Causa-MCP | `mcp-conformance/elision-composition-sensitive-wins`; causa-mcp integration test exercising the cascade end-to-end |
+
+## Implicit MUSTs (not RFC-2119-cased but normatively binding)
+
+Some load-bearing invariants are spelled out without the literal
+"MUST" word. They behave like MUSTs for the impl pass and are
+catalogued for inventory completeness.
+
+| # | Invariant | Source | Test owner | Planned test |
+|---|---|---|---|---|
+| I1 | Every Causa-MCP-driven side-effect on the trace bus carries `:tags :origin :causa-mcp` (default-on, per-call opt-out) | [Principles.md §"Origin tagging is the convention"](../Principles.md), [Lock #4](../DESIGN-RATIONALE.md) | Causa-MCP | `causa-mcp.tools.origin/every-mutation-tagged-by-default`; `eval-cljs-inherits-origin-via-dynamic-var` |
+| I2 | MCP-server-side code (`day8.re-frame2-causa-mcp.*`) never reaches a consumer app's preload classpath; injected-runtime code lives under `day8.re-frame2-causa.runtime` | [Principles.md §"MCP-server-ns and injected-runtime-ns are distinct"](../Principles.md), [Lock #11](../DESIGN-RATIONALE.md) | Causa-MCP | `causa-mcp.bundle-isolation/server-ns-not-in-preload-classpath` (lint; mirrors `tools/causa/`'s analogous gate) |
+| I3 | Single persistent nREPL socket held for the lifetime of the session; subsequent ops reuse without reconnecting | [Principles.md §"Single persistent nREPL socket"](../Principles.md), [Lock #3](../DESIGN-RATIONALE.md) | Causa-MCP | `causa-mcp.nrepl/socket-is-persistent`; `subsequent-ops-reuse` |
+| I4 | If the nREPL port can't be resolved at startup, the server still boots and answers `tools/list`; every `tools/call` returns `{:ok? false :reason :nrepl-port-not-found}` | [Principles.md §"Degraded boot, not failed boot"](../Principles.md) | Causa-MCP | `causa-mcp.degraded-boot/boots-without-port`; `tools-call-returns-structured-error` |
+| I5 | If the runtime hasn't been preloaded, the first mutating/inspecting tool call returns `{:ok? false :reason :runtime-not-preloaded}` with a setup hint | [Principles.md §"Degraded boot, not failed boot"](../Principles.md) | Causa-MCP | `causa-mcp.degraded-boot/runtime-not-preloaded-shape` |
+
+## Out-of-spec MUSTs cited (not Causa-MCP-private)
+
+For completeness — references to upstream MUSTs Causa-MCP relies
+on but doesn't own. No test owned by `tools/causa-mcp/`; listed
+so the inventory is self-auditing.
+
+- The `:rf/elision-marker` schema shape: owned by
+  [`spec/Spec-Schemas.md`](../../../../spec/Spec-Schemas.md) +
+  [`spec/009-Instrumentation.md`](../../../../spec/009-Instrumentation.md).
+  Tests live with the schema spec.
+- `:rf.size/*` and `:rf.elision/*` reservations: owned by
+  [`spec/Conventions.md`](../../../../spec/Conventions.md). Test
+  is the namespace-reservation lint.
+- Tool-Pair epoch contracts (`get-epoch-history`,
+  `restore-epoch`, the six-row restore-failure surface,
+  `subscribe :epoch`): owned by
+  [`spec/Tool-Pair.md`](../../../../spec/Tool-Pair.md). Tests
+  live with the Tool-Pair conformance corpus.
+
+## Inventory hygiene
+
+When a new MUST lands in this folder's spec docs:
+
+1. Add a row above with the source cite, test owner, and planned
+   test name.
+2. If the MUST is cross-server (touches the shape of the wire on
+   pair2-mcp/story-mcp/causa-mcp), tag the row "Cross-server
+   (rf2-zvv65)" and file/cross-reference into
+   [`tools/mcp-conformance/`](../../../mcp-conformance/).
+3. When `tools/causa-mcp/test/` exists, replace the "Planned
+   test" sketch with the actual `deftest` name.
+4. When a MUST is removed/relaxed, strike through the row but
+   keep it in place — the inventory is also an audit trail.
+
+This file is **not** normative; the normative spec docs are.
+This file is a forcing function so the impl-pass test corpus
+covers every MUST without organic drift.


### PR DESCRIPTION
## Summary

Fourth batched-by-surface refactor cluster — eight P2/P3 follow-on beads from the rf2-c33xi round-2 audit on `tools/causa-mcp/spec/`. All edits are spec-doc; no CLJS code touched.

Commit-by-bead breakdown (eight commits, one per bead, ordered to sequence content-add fixes before dedup-style trims):

| Commit | Bead | Title |
|---|---|---|
| 04250611 | rf2-qd8f8 | Replace 5 `[Text](#)` placeholder links with backticks |
| 032c9366 | rf2-8opg3 | Promote 'Streaming over batch' to `##` header level |
| 59ff5bcc | rf2-wczo9 | Collapse verbatim 'learn the slot on one server' restatements |
| 96e199f4 | rf2-7lges | Fix pair2-mcp count + drift in summary table (000-Vision.md L292) |
| 7d9c9105 | rf2-qhw4r | P2 prose-and-notation cluster (Q4/Q5/Q7/A3/A5/P1-perf/P3-perf) |
| 4cd9a766 | rf2-w821y | Collapse Principles/Vision overlap |
| 4b67643e | rf2-remr6 | Collapse band-split restatements to cite README §Canonical counts |
| 56ad7b6c | rf2-g3u9f | File MUST-inventory ahead of impl |

## Highlights

- **rf2-g3u9f** stood up `tools/causa-mcp/spec/findings/MUST-inventory.md` — 18 explicit MUSTs + 5 implicit-but-binding invariants catalogued by source-line cite with planned-test sketches. The forcing function for the impl-pass test corpus.
- **rf2-qhw4r** filed rf2-uebll for the "lift causa-mcp's wire-pipeline expansions back into pair2-mcp Principles" follow-up the Lock #9 §Why bullet had promised but not filed.
- **rf2-qhw4r P3-perf** raised the `max-tokens` clamp lower-bound from `[1, 50000]` to `[500, 50000]` — `1` was unusable; `500` is a realistic floor for a responsive tool.
- **rf2-7lges** fixed three drift signals in one line of `000-Vision.md` (pair2-mcp tool count 9→10, removed nonexistent `hot-swap`, "session lifecycle" → "meta" band-vocab alignment).
- **rf2-8opg3** also caught: header rename meant updating the slug cite in `Principles.md` §"Wire pipeline" bullet to match the new `#streaming-over-batch-cross-cut` anchor.

## LoC delta

`+202 / -59` across `tools/causa-mcp/spec/` — net `+143`, largely the new MUST-inventory artefact. Excluding rf2-g3u9f the delta is `+86 / -59` (net `+27`).

## Quality gates

- `python scripts/check_doc_slugs.py` — 3 pre-existing broken anchors; **no new ones**.
- `python -m mkdocs build --strict` — 162 warnings (matching pre-existing baseline); **no regression**.

## Test plan

- [ ] Reviewer: skim each commit individually (each is a self-contained polish-grade edit).
- [ ] Reviewer: verify the MUST-inventory's source-line cites resolve (the 18 explicit MUSTs grep cleanly off the spec text; checked at file-time).
- [ ] No code changes — no impl-side tests apply.