### PR TITLE
refactor(machines): round-2 polish cluster — 8 P2 follow-on beads (rf2-2ukxv)

### DIFF
--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -1,63 +1,12 @@
-;; day8/re-frame2-machines — state-machine artefact (rf2-xbtj,
-;; second per-feature split per rf2-5vjj Strategy B).
+;; day8/re-frame2-machines — public façade for the state-machine
+;; artefact. Per Spec 005 §State machines.
 ;;
-;; Per Spec 005 §State machines the machine grammar
-;; (`reg-machine`, `create-machine-handler`, `machine-transition`,
-;; the `:rf/machine` framework sub, the `:rf.machine/spawn` /
-;; `:rf.machine/destroy` effect handlers) ships as a separate
-;; Maven artefact so apps that don't register any machines don't drag
-;; the namespace, the `:rf/machines` app-db slot's runtime support, or
-;; the machine-transition engine onto the classpath.
-;;
-;; Consumers add this artefact alongside the core artefact:
-;;
-;;   {:deps {day8/re-frame2          {:mvn/version "..."}
-;;           day8/re-frame2-machines {:mvn/version "..."}}}
-;;
-;; And require `re-frame.machines` in any namespace that calls
-;; `rf/reg-machine` or relies on the `:rf/machine` framework sub —
-;; loading the namespace registers its late-bind hooks and the
-;; `:rf.machine/spawn` / `:rf.machine/destroy` reserved fxs.
-;;
-;; Per Spec 006 §Adapter shipping convention (and the
-;; rf2-p7va extension to per-feature splits): this artefact depends on
-;; core; core never depends on this artefact. The cross-references
-;; from core to machines flow through `re-frame.late-bind` exactly as
-;; the schemas / router / flows hooks already do.
-;;
-;; ---- file split (rf2-5hnn) ------------------------------------------------
-;;
-;; This namespace was 3152 LoC pre-split; it's now a thin façade.
-;; The implementation is in four flat sub-namespaces (one each per
-;; cohesive responsibility, per the X.Y convention shared with
-;; `re-frame.story.runtime`, `re-frame.substrate.adapter`, and
-;; `re-frame.core.flows`):
-;;
-;;   - `re-frame.machines.transition` — pure single-machine engine
-;;     (deepest-wins resolution, LCA exit/entry cascade, `:raise` drain,
-;;     `:always` microstep loop). `apply-transition-once` extracted into
-;;     `build-after-fx` / `build-after-cancel-fx` / `build-destroy-fx` /
-;;     `handle-invoke-spawn` / `handle-invoke-all-spawn` per rf2-g1s1.
-;;   - `re-frame.machines.parallel` — parallel-region routing and the
-;;     public `machine-transition` dispatch (single vs parallel). The
-;;     bootstrap initial-entry cascade (`apply-initial-entry-cascade`)
-;;     also lives here because the parallel layer owns region
-;;     iteration.
-;;   - `re-frame.machines.timer` — wall-clock `:after` scheduling
-;;     (`:rf.machine/after-schedule` / `:rf.machine/after-cancel` fxs,
-;;     sub-driven re-resolution, the per-frame timer table).
-;;   - `re-frame.machines.lifecycle-fx` — registration boundary
-;;     (`create-machine-handler`, `reg-machine*`), live-lifecycle fxs
-;;     (`:rf.machine/spawn`, `:rf.machine/destroy`,
-;;     `:rf.machine/invoke-all-init`), and the query API (`machines`,
-;;     `machine-meta`, `machine-by-system-id`). `create-machine-handler`
-;;     decomposed into `validate-machine!` + `synthesise-initial-
-;;     snapshot` + the returned handler fn per rf2-f9tu.
-;;
-;; This façade re-exports the public surface of those sub-namespaces
-;; and performs the artefact's load-time side-effects: the
-;; `:rf.machine/*` fx registrations and the `late-bind/set-fn!` hook
-;; publications that `re-frame.core` reaches through.
+;; The implementation lives in `re-frame.machines.{transition, parallel,
+;; timer, lifecycle-fx}` (plus the `lifecycle_fx/*` sub-namespaces).
+;; This namespace re-exports their public surface and runs the
+;; artefact's load-time side-effects — registering the `:rf.machine/*`
+;; reserved fxs and publishing the `late-bind/set-fn!` hooks that
+;; `re-frame.core` reaches through.
 
 (ns re-frame.machines
   "State machines. Per Spec 005.

--- a/implementation/machines/src/re_frame/machines/path_walk.cljc
+++ b/implementation/machines/src/re_frame/machines/path_walk.cljc
@@ -91,13 +91,24 @@
   `prefix` is the vector of path elements from `path[0]` through
   `path[i]` inclusive, of length `i+1`. `node` is the state-node map
   at that prefix; when the prefix doesn't resolve (defensive), the
-  predicate is skipped and the walk continues toward the root."
+  predicate is skipped and the walk continues toward the root.
+
+  Per rf2-ogsrx the inclusive-prefix is taken via `subvec` (zero-copy
+  slice) rather than `(vec (take (inc i) path))` (lazy-seq + realise +
+  copy). On a depth-D path × P pickers per macrostep the walk now
+  allocates D×P subvec references rather than D×P fresh vectors. The
+  `path` argument is coerced to a vector once at the top so callers
+  may pass any seqable; downstream callers receiving the prefix may
+  rely on the vector contract (predicates often `(last prefix)` or
+  `conj` onto it)."
   [tree path predicate]
-  (loop [i (dec (count path))]
-    (when (>= i 0)
-      (let [prefix (vec (take (inc i) path))
-            node   (node-at* tree prefix)
-            hit    (when node (predicate prefix node))]
-        (if (some? hit)
-          hit
-          (recur (dec i)))))))
+  (let [path (if (vector? path) path (vec path))
+        n    (count path)]
+    (loop [i (dec n)]
+      (when (>= i 0)
+        (let [prefix (subvec path 0 (inc i))
+              node   (node-at* tree prefix)
+              hit    (when node (predicate prefix node))]
+          (if (some? hit)
+            hit
+            (recur (dec i))))))))

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -43,10 +43,12 @@
   ;; :after timers, partitioned per frame.
   ;;
   ;; Outer shape: {<frame-id> {<inner-key> <entry>}}.
-  ;; Inner key:   [<parent-id> <invoke-id-vec> <delay-key>] — multiple
-  ;;              delays per :after map have their own slot, and parallel-
-  ;;              region machines partition further on the region-prefixed
-  ;;              invoke-id.
+  ;; Inner key:   {:parent <parent-id> :invoke <invoke-id-vec>
+  ;;               :delay <delay-key>} — multiple delays per :after map
+  ;;              have their own slot, and parallel-region machines
+  ;;              partition further on the region-prefixed invoke-id.
+  ;;              Per rf2-gwznv the key is a map rather than a positional
+  ;;              tuple — readers no longer have to remember slot order.
   ;; Entry value:
   ;;   {:handle <opaque host-clock handle>
   ;;    :reaction <subscription reaction or nil>
@@ -74,10 +76,20 @@
   (atom {}))
 
 (defn- after-timer-key
-  "Inner-table key — frame-id is the OUTER key into `after-timers` and is
-  intentionally absent from this tuple."
+  "Inner-table key — frame-id is the OUTER key into `after-timers` and
+  is intentionally absent from this map.
+
+  Per rf2-gwznv the key is a `{:parent ... :invoke ... :delay ...}`
+  map rather than a positional tuple — readers no longer have to
+  remember slot order, and the scan in `after-cancel-fx` reads
+  `(:parent k)` / `(:invoke k)` rather than `(nth k 0)` / `(nth k 1)`.
+  The key is opaque to callers (used only as a `get-in` index into
+  `after-timers`'s inner map); the change is invisible outside this
+  file."
   [parent-id invoke-id delay-key]
-  [parent-id (vec invoke-id) delay-key])
+  {:parent parent-id
+   :invoke (vec invoke-id)
+   :delay  delay-key})
 
 (defn- classify-delay-source [delay-key]
   (cond
@@ -141,8 +153,7 @@
   Idempotent — a second call against the same `[frame-id k]` is a no-op."
   [frame-id k]
   (when-let [entry (get-in @after-timers [frame-id k])]
-    (let [[_ _ delay-key] k]
-      (release-entry-resources! frame-id entry delay-key))
+    (release-entry-resources! frame-id entry (:delay k))
     ;; Drop the inner-table entry; drop the outer-table entry if this was
     ;; the frame's last live timer so a frame that briefly held timers
     ;; doesn't leave a stale empty map behind.
@@ -319,17 +330,18 @@
   zombie watchers and releases timer slots promptly.
 
   Per rf2-ysa94 the scan is now bounded by the active frame's inner
-  table — siblings' timers in other frames are no longer walked. The
-  inner key is `[parent-id invoke-id-vec delay-key]`, so the only
-  cross-key axis we still iterate is `delay-key` (one entry per :after
-  map entry on the bearing state node — typically 1-3 entries)."
+  table — siblings' timers in other frames are no longer walked. Per
+  rf2-gwznv the inner key is `{:parent ... :invoke ... :delay ...}`,
+  so the only cross-key axis we still iterate is `:delay` (one entry
+  per :after map entry on the bearing state node — typically 1-3
+  entries)."
   [{:keys [frame]} args]
   (let [frame-id  (or frame :rf/default)
         parent-id (:rf/parent-id args)
         invoke-id (vec (:rf/invoke-id args))]
     (doseq [[k _entry] (get @after-timers frame-id)
-            :when (and (= parent-id (nth k 0))
-                       (= invoke-id (nth k 1)))]
+            :when (and (= parent-id (:parent k))
+                       (= invoke-id (:invoke k)))]
       (cancel-after-timer-entry! frame-id k))
     nil))
 
@@ -346,11 +358,9 @@
   ([]
    (doseq [[frame-id inner] @after-timers
            [k entry] inner]
-     (let [[_ _ delay-key] k]
-       (release-entry-resources! frame-id entry delay-key)))
+     (release-entry-resources! frame-id entry (:delay k)))
    (reset! after-timers {}))
   ([frame-id]
    (doseq [[k entry] (get @after-timers frame-id)]
-     (let [[_ _ delay-key] k]
-       (release-entry-resources! frame-id entry delay-key)))
+     (release-entry-resources! frame-id entry (:delay k)))
    (swap! after-timers dissoc frame-id)))

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -113,8 +113,18 @@
     [delay-key nil]
 
     (fn? delay-key)
+    ;; Per rf2-c1tnr the fn-form `:after` resolution used to silently
+    ;; swallow throws — a fn that NPE'd surfaced as
+    ;; `:rf.warning/no-clock-configured` downstream with no signal that
+    ;; the fn itself blew up. Now we emit `:rf.error/machine-after-fn-
+    ;; threw` on the exception path; the fn still falls through to no-
+    ;; clock-configured for recovery, but the exception is observable.
     (let [v (try (delay-key snapshot)
-                 (catch #?(:clj Throwable :cljs :default) _ nil))]
+                 (catch #?(:clj Throwable :cljs :default) e
+                   (trace/emit-error! :rf.error/machine-after-fn-threw
+                                      {:exception e
+                                       :recovery  :no-clock-configured})
+                   nil))]
       [v nil])
 
     (vector? delay-key)
@@ -123,7 +133,12 @@
     (let [reaction (subs/subscribe frame-id delay-key)
           v        (when reaction
                      (try @reaction
-                          (catch #?(:clj Throwable :cljs :default) _ nil)))]
+                          (catch #?(:clj Throwable :cljs :default) e
+                            (trace/emit-error! :rf.error/machine-after-sub-threw
+                                               {:exception e
+                                                :sub-id    (first delay-key)
+                                                :recovery  :no-clock-configured})
+                            nil)))]
       [v reaction])
 
     :else
@@ -265,12 +280,22 @@
                 watch-key (when (= :sub delay-source)
                             [::after-watch frame-id parent-id invoke-id delay-key])]
             (when (and reaction watch-key)
+              ;; Per rf2-c1tnr — surface `add-watch` exceptions rather
+              ;; than silently dropping them; the sub-changed re-resolution
+              ;; watcher won't fire if `add-watch` failed, so the author
+              ;; needs a signal that the dynamic-delay subscription is
+              ;; not actually wired up.
               (try
                 (add-watch reaction watch-key
                            (fn [_ _ old-v new-v]
                              (on-sub-changed! frame-id parent-id invoke-id
                                               delay-key state old-v new-v)))
-                (catch #?(:clj Throwable :cljs :default) _ nil)))
+                (catch #?(:clj Throwable :cljs :default) e
+                  (trace/emit-error! :rf.error/machine-after-watch-failed
+                                     {:exception  e
+                                      :machine-id parent-id
+                                      :sub-id     (first delay-key)
+                                      :recovery   :static-delay}))))
             (swap! after-timers assoc-in [frame-id k]
                    {:handle          handle
                     :reaction        reaction

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -428,10 +428,14 @@
   "Compute the absolute target path for a transition. Per Spec 005:
    - keyword target → sibling at decl-path's level (replace last element).
    - vector target → absolute path from root.
-   - nil target (internal transition) → source path unchanged."
+   - nil target (internal transition) → nil; the caller wraps the call
+     in `some->>` so the nil short-circuits the initial-cascade descent.
+
+  Per rf2-adwxh the explicit `(nil? target) nil` arm is dropped — when
+  target is neither vector nor keyword, the `cond` falls through to
+  nil, which is the documented internal-transition contract."
   [decl-path _source-path target]
   (cond
-    (nil? target)        nil
     (vector? target)     target
     (keyword? target)
     (let [parent (vec (drop-last decl-path))]
@@ -911,14 +915,20 @@
   interaction. Internal transitions preserve the input snapshot's
   `:state` unchanged."
   [machine snapshot snap-after cascade]
+  ;; Per rf2-adwxh: the `cond` has three arms — `internal?` (raw-target
+  ;; is nil; preserve current state), vector target (use the cascade-
+  ;; descended leaf as a vector), keyword target (collapse a single-
+  ;; element leaf to a keyword, else vectorise). A pre-rf2-adwxh `:else`
+  ;; arm was dead: `internal?` already covers the nil-raw-target case,
+  ;; and `:target` validation upstream rejects anything other than
+  ;; keyword/vector/nil.
   (let [{:keys [internal? raw-target target-leaf epoch-bumps?]} cascade
         new-state (cond
                     internal?             (:state snapshot)
                     (vector? raw-target)  (vec target-leaf)
                     (keyword? raw-target) (if (= 1 (count target-leaf))
                                             (first target-leaf)
-                                            (vec target-leaf))
-                    :else                 (denormalise-state target-leaf (:state snapshot)))]
+                                            (vec target-leaf)))]
     (cond
       internal?
       (assoc snap-after :state new-state)

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -863,11 +863,16 @@
         ;; Walk each path once; reuse the `[prefix node]` pair vectors
         ;; for both the cascade ref derivation AND the spawn/destroy fx
         ;; emission downstream (per audit §T6 #2 — eliminate the double
-        ;; nodes-along-path call).
+        ;; nodes-along-path call). `nodes-along-path` returns a vector, so
+        ;; `subvec` is one zero-copy slice — the prior `(vec (drop ...))`
+        ;; built a lazy seq, then realised it, then `vec`'d (three
+        ;; allocations). Per rf2-ijbg2.
         exited-pairs  (when-not internal?
-                        (vec (drop lca-len (nodes-along-path machine src-path))))
+                        (let [pairs (nodes-along-path machine src-path)]
+                          (subvec pairs (min lca-len (count pairs)))))
         entered-pairs (when-not internal?
-                        (vec (drop lca-len (nodes-along-path machine target-leaf))))
+                        (let [pairs (nodes-along-path machine target-leaf)]
+                          (subvec pairs (min lca-len (count pairs)))))
         exit-refs     (when-not internal?
                         (map (fn [[_ n]] (:exit n)) (reverse exited-pairs)))
         entry-refs    (when-not internal?

--- a/implementation/machines/test/re_frame/after_test.clj
+++ b/implementation/machines/test/re_frame/after_test.clj
@@ -22,9 +22,10 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.machines :as machines]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.machines :as machines]))
+            [re-frame.trace]))
 
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
@@ -276,3 +277,40 @@
             "parent transitioned via :after firing")
         (is (nil? (get-in (frame-db) [:rf/machines child-id]))
             "child machine destroyed via standard exit cascade")))))
+
+;; ---- fn-form :after exception observability (rf2-c1tnr) -------------------
+
+(deftest after-fn-form-throw-surfaces-trace
+  (testing "fn-form :after that throws emits :rf.error/machine-after-fn-threw"
+    ;; Pre-rf2-c1tnr the throw was silently caught and the resolution
+    ;; returned [nil nil], surfacing only as :rf.warning/no-clock-
+    ;; configured downstream with no signal that the fn itself blew up.
+    (let [captured (atom [])
+          listener (fn [ev] (swap! captured conj ev))
+          delay-fn (fn [_snapshot]
+                     (throw (ex-info "fn-form delay blew up" {:where :test})))]
+      (re-frame.trace/register-trace-cb! ::after-fn-trace listener)
+      (try
+        (rf/reg-machine :a/throws
+                        {:initial :idle
+                         :data    {:rf/after-epoch 0}
+                         :states  {:idle    {:on    {:go :running}}
+                                   :running {:after {delay-fn :timeout}}
+                                   :timeout {}}})
+        (rf/dispatch-sync [:a/throws [:go]])
+        (let [errors (filter #(= :rf.error/machine-after-fn-threw
+                                 (:operation %))
+                             @captured)]
+          (is (seq errors)
+              "fn-form throw surfaces as :rf.error/machine-after-fn-threw")
+          (is (every? #(= :error (:op-type %)) errors)
+              "the trace event has :op-type :error")
+          (when-let [first-err (first errors)]
+            (is (some? (-> first-err :tags :exception))
+                ":exception slot is populated under :tags")
+            ;; Per Spec 009 §Error event shape, `:recovery` is hoisted
+            ;; off `:tags` to the envelope top-level.
+            (is (= :no-clock-configured (:recovery first-err))
+                ":recovery hoisted to the envelope top-level")))
+        (finally
+          (re-frame.trace/remove-trace-cb! ::after-fn-trace))))))

--- a/implementation/machines/test/re_frame/after_test.clj
+++ b/implementation/machines/test/re_frame/after_test.clj
@@ -21,21 +21,12 @@
   exercised by machines_cljs_test.cljs."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace]))
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (defn- frame-db [] (rf/get-frame-db :rf/default))
 (defn- snapshot [machine-id] (get-in (frame-db) [:rf/machines machine-id]))

--- a/implementation/machines/test/re_frame/destroyed_trace_shape_test.clj
+++ b/implementation/machines/test/re_frame/destroyed_trace_shape_test.clj
@@ -1,0 +1,243 @@
+(ns re-frame.destroyed-trace-shape-test
+  "Per rf2-vgkdt and the rf2-2ukxv round-2 audit §TE-r2-3.
+
+  `:rf.machine/destroyed` is emitted at three distinct sites — each
+  for a different destroy class:
+
+    1. `destroy-invoke-all-children!` (lifecycle_fx/destroy.cljc):
+       per-child fire when an `:invoke-all` parent tears down its
+       children. The trace carries an extra `:child-id` slot keying
+       the join-state map but does NOT include `:system-id`.
+
+    2. `destroy-single!` (lifecycle_fx/destroy.cljc): the keyword /
+       tracked-map fire for an explicit `:rf.machine/destroy` fx or
+       the standard declarative-`:invoke` exit cascade. The trace
+       carries `:system-id` (resolved from the reverse-index BEFORE
+       teardown).
+
+    3. `finalize-machine` (lifecycle_fx/finalize.cljc): the auto-destroy
+       fire when a state-machine enters a `:final?` state. The trace
+       carries `:system-id` AND `:reason :rf.machine/finished`.
+
+  Tools (re-frame-10x, Causa, story-mcp) key on the trace's argument
+  map. If the three emission sites drift in their key-set shape, tools
+  that depend on the contract observe inconsistent payloads depending
+  on which path emitted. This file locks the shape independently of
+  which code-path emitted — the test runs the three paths against the
+  SAME tap and asserts:
+
+    - every fire's argument map is a subset of the canonical union
+      `{:frame :actor-id :system-id :parent-id :invoke-id :child-id
+        :reason}`,
+    - `:reason` is always present (the discriminator),
+    - `:frame` and `:actor-id` are always present (the common id pair),
+    - sites that don't have `:child-id` / `:system-id` simply omit
+      those slots (no nil-stamping)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.machines :as machines]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.machines :reload)
+  (machines/reset-timers!)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; Canonical key-set that the destroyed-trace emission sites are
+;; responsible for assembling. The trace framework auto-stamps
+;; envelope cascade keys (currently `:dispatch-id`) under `:tags` per
+;; Spec 009 §Cascade-id stamping; those keys are not part of the
+;; per-site contract.
+(def ^:private canonical-site-keys
+  #{:frame :actor-id :system-id :parent-id :invoke-id :child-id :reason})
+
+(def ^:private framework-stamped-keys
+  #{:dispatch-id})
+
+(def ^:private permitted-keys
+  (clojure.set/union canonical-site-keys framework-stamped-keys))
+
+(defn- destroyed-traces [captured]
+  (filter #(= :rf.machine/destroyed (:operation %)) @captured))
+
+(defn- record!
+  []
+  (let [a  (atom [])
+        id ::shape-listener]
+    (trace/register-trace-cb! id (fn [ev] (swap! a conj ev)))
+    [a #(trace/remove-trace-cb! id)]))
+
+(defn- assert-shape!
+  [traces label]
+  (is (seq traces)
+      (str label ": at least one :rf.machine/destroyed fired"))
+  (doseq [t traces]
+    (let [tags      (:tags t)
+          site-keys (remove framework-stamped-keys (keys tags))]
+      ;; (1) Every site-provided key is in the canonical contract —
+      ;; no drift. Framework-stamped envelope keys (:dispatch-id) are
+      ;; out of scope here.
+      (is (every? canonical-site-keys site-keys)
+          (str label ": trace tags must be a subset of canonical keys; saw "
+               (vec site-keys)))
+      ;; (2) Common id pair always present.
+      (is (contains? tags :frame)
+          (str label ": :frame is always emitted"))
+      (is (contains? tags :actor-id)
+          (str label ": :actor-id is always emitted"))
+      ;; (3) Reason discriminator always present.
+      (is (contains? tags :reason)
+          (str label ": :reason discriminator is always emitted"))
+      (is (#{:explicit :rf.machine/finished} (:reason tags))
+          (str label ": :reason is one of :explicit / :rf.machine/finished")))))
+
+;; ---- Site 1: destroy-invoke-all-children! ---------------------------------
+
+(deftest invoke-all-children-destroy-trace-shape
+  (testing "destroy-invoke-all-children! per-child traces carry :child-id and omit :system-id"
+    (let [[cap unreg] (record!)
+          child {:initial :running
+                 :data    {}
+                 :states  {:running {:on {:done :final}}
+                           :final   {:final? true}}}
+          parent {:initial :hydrating
+                  :states
+                  {:hydrating {:invoke-all
+                               {:children
+                                [{:id :a :machine-id :ia/child}
+                                 {:id :b :machine-id :ia/child}]
+                                :join              :all
+                                :on-child-done     :ia/asset-done
+                                :on-child-error    :ia/asset-failed
+                                :on-all-complete   [:go-done]
+                                :on-any-failed     [:ia/cancel]}
+                               :on {:go-done    :done
+                                    :ia/cancel  :idle}}
+                   :done {}
+                   :idle {}}}]
+      (try
+        (rf/reg-machine :ia/child child)
+        (rf/reg-machine :ia/parent parent)
+        (rf/dispatch-sync [:ia/parent [:rf.machine/spawned]])
+        ;; Force an :invoke-all teardown via re-entering :idle through
+        ;; an explicit destroy of the parent. Easier: drive the parent
+        ;; via :ia/cancel into :idle (the invoke-all exit cascade tears
+        ;; the children down through destroy-invoke-all-children!).
+        (rf/dispatch-sync [:ia/parent [:ia/cancel]])
+        (let [traces (destroyed-traces cap)
+              child-traces (filter #(contains? (:tags %) :child-id) traces)]
+          (assert-shape! traces "invoke-all-children")
+          (is (seq child-traces)
+              "at least one trace carries the :child-id discriminator (per-child path)")
+          (doseq [t child-traces]
+            (is (not (contains? (:tags t) :system-id))
+                "per-child fires omit :system-id (children weren't system-id-bound)")
+            (is (= :explicit (-> t :tags :reason)))))
+        (finally (unreg))))))
+
+;; ---- Site 2: destroy-single! ----------------------------------------------
+
+(deftest destroy-single-trace-shape
+  (testing "destroy-single! (declarative :invoke exit cascade) carries :system-id slot key"
+    (let [[cap unreg] (record!)
+          child {:initial :running
+                 :data    {}
+                 :states  {:running {}}}
+          parent {:initial :idle
+                  :states
+                  {:idle    {:on {:start :working}}
+                   :working {:invoke {:machine-id :ds/child}
+                             :on     {:stop :idle}}}}]
+      (try
+        (rf/reg-machine :ds/child child)
+        (rf/reg-machine :ds/parent parent)
+        (rf/dispatch-sync [:ds/parent [:start]])
+        ;; Exit the :invoke-bearing state — destroy-single! fires.
+        (rf/dispatch-sync [:ds/parent [:stop]])
+        (let [traces (destroyed-traces cap)]
+          (assert-shape! traces "destroy-single")
+          (doseq [t traces]
+            (is (contains? (:tags t) :system-id)
+                "destroy-single! always emits :system-id (even if nil for non-system-id-bound actors)")
+            (is (= :explicit (-> t :tags :reason)))))
+        (finally (unreg))))))
+
+;; ---- Site 3: finalize-machine ---------------------------------------------
+
+(deftest finalize-machine-trace-shape
+  (testing "finalize-machine (entering :final?) fires :reason :rf.machine/finished"
+    (let [[cap unreg] (record!)
+          child {:initial :running
+                 :data    {}
+                 :states  {:running {:on {:end :done}}
+                           :done    {:final? true}}}
+          parent {:initial :working
+                  :states  {:working {:invoke {:machine-id :fz/child}}}}]
+      (try
+        (rf/reg-machine :fz/child child)
+        (rf/reg-machine :fz/parent parent)
+        (rf/dispatch-sync [:fz/parent [:rf.machine/spawned]])
+        (let [spawned-id (get-in (rf/get-frame-db :rf/default)
+                                 [:rf/spawned :fz/parent [:working]])]
+          (rf/dispatch-sync [spawned-id [:end]]))
+        (let [traces (destroyed-traces cap)
+              finish-traces (filter #(= :rf.machine/finished (-> % :tags :reason)) traces)]
+          (assert-shape! traces "finalize-machine")
+          (is (seq finish-traces)
+              "at least one trace carries :reason :rf.machine/finished")
+          (doseq [t finish-traces]
+            (is (contains? (:tags t) :system-id)
+                "finalize-machine always emits :system-id")))
+        (finally (unreg))))))
+
+;; ---- Cross-site stability check -------------------------------------------
+
+(deftest no-key-drift-across-sites
+  (testing "every :rf.machine/destroyed across all three paths obeys the canonical key-set"
+    ;; This is a meta-check: drive all three paths against ONE listener
+    ;; (no per-site recording) and assert the union shape across them.
+    (let [[cap unreg] (record!)
+          child {:initial :running
+                 :data    {}
+                 :states  {:running {:on {:done :final}}
+                           :final   {:final? true}}}]
+      (try
+        ;; (a) destroy-single! via explicit fx
+        (rf/reg-machine :nd/standalone
+                        {:initial :running
+                         :data    {}
+                         :states  {:running {:on {:end :done}}
+                                   :done    {:final? true}}})
+        (rf/dispatch-sync [:nd/standalone [:end]])
+
+        ;; (b) finalize-machine via spawned child reaching :final?
+        (rf/reg-machine :nd/child child)
+        (rf/reg-machine :nd/parent
+                        {:initial :working
+                         :states  {:working {:invoke {:machine-id :nd/child}}}})
+        (rf/dispatch-sync [:nd/parent [:rf.machine/spawned]])
+        (let [spawned-id (get-in (rf/get-frame-db :rf/default)
+                                 [:rf/spawned :nd/parent [:working]])]
+          (rf/dispatch-sync [spawned-id [:done]]))
+
+        ;; Verify the union shape across both fires.
+        (let [traces (destroyed-traces cap)]
+          (assert-shape! traces "cross-site")
+          (is (<= 2 (count traces))
+              "at least two :rf.machine/destroyed fired across the two paths")
+          ;; All traces' key-sets are subsets of the union of canonical
+          ;; site keys + framework-stamped envelope keys.
+          (let [union (apply clojure.set/union (map (comp set keys :tags) traces))]
+            (is (every? permitted-keys union)
+                (str "union of all observed keys is permitted; "
+                     "observed extras: "
+                     (clojure.set/difference union permitted-keys)))))
+        (finally (unreg))))))

--- a/implementation/machines/test/re_frame/destroyed_trace_shape_test.clj
+++ b/implementation/machines/test/re_frame/destroyed_trace_shape_test.clj
@@ -35,21 +35,12 @@
       those slots (no nil-stamping)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]))
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; Canonical key-set that the destroyed-trace emission sites are
 ;; responsible for assembling. The trace framework auto-stamps

--- a/implementation/machines/test/re_frame/final_state_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/final_state_cljs_test.cljc
@@ -30,26 +30,14 @@
    [re-frame.core :as rf]
    [re-frame.machines :as machines]
    [re-frame.registrar :as registrar]
-   #?@(:clj  [[re-frame.frame :as frame]
-              [re-frame.substrate.plain-atom :as plain-atom]
-              [re-frame.trace :as trace]]
-       :cljs [[re-frame.adapter.reagent :as reagent-adapter]
-              [re-frame.test-support :as test-support]])))
+   [re-frame.test-support :as test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
 
-#?(:clj
-   (defn- reset-runtime [test-fn]
-     (registrar/clear-all!)
-     (reset! frame/frames {})
-     (trace/clear-trace-cbs!)
-     (rf/init! plain-atom/adapter)
-     (require 're-frame.machines :reload)
-     (machines/reset-timers!)
-     (test-fn)))
-
-#?(:clj  (use-fixtures :each reset-runtime)
-   :cljs (use-fixtures :each
-           (test-support/reset-runtime-fixture
-             {:adapter reagent-adapter/adapter})))
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter})))
 
 (defn- snapshot
   [machine-id]

--- a/implementation/machines/test/re_frame/initial_entry_test.clj
+++ b/implementation/machines/test/re_frame/initial_entry_test.clj
@@ -30,22 +30,12 @@
       shallowest-first (per Spec 005 §Initial cascading)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
-            [re-frame.machines :as machines]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]))
+            [re-frame.test-support :as test-support]))
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (trace/clear-trace-cbs!)
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (defn- snapshot
   [machine-id]

--- a/implementation/machines/test/re_frame/invoke_all_test.clj
+++ b/implementation/machines/test/re_frame/invoke_all_test.clj
@@ -18,20 +18,11 @@
   All tests run on the JVM through the plain-atom substrate."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.machines :as machines]))
+            [re-frame.test-support :as test-support]))
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (defn- frame-db []
   (rf/get-frame-db :rf/default))

--- a/implementation/machines/test/re_frame/invoke_data_fn_form_test.clj
+++ b/implementation/machines/test/re_frame/invoke_data_fn_form_test.clj
@@ -26,21 +26,12 @@
   the same fn-form per Spec 005 §Spec-spec keys (line 1818)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.machines :as machines]
-            [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]))
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (defn- snapshot
   [machine-id]

--- a/implementation/machines/test/re_frame/machine_source_coord_test.clj
+++ b/implementation/machines/test/re_frame/machine_source_coord_test.clj
@@ -42,20 +42,11 @@
   full path-tuple surface."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
 
-(defn reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (rf/init! plain-atom/adapter)
-  ;; Force machines to re-register its :rf/machine sub + late-bind hooks
-  ;; (registrar/clear-all! wiped them).
-  (require 're-frame.machines :reload)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; Helper: read the per-element index off a registered machine.
 (defn- per-element-coords [machine-id]

--- a/implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj
+++ b/implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj
@@ -25,22 +25,12 @@
   JVM-only — the dynamic-var binding is platform-agnostic."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.machines :as machines]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]))
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (trace/clear-trace-cbs!)
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (defn- record-traces
   [body-fn]

--- a/implementation/machines/test/re_frame/nested_validation_test.clj
+++ b/implementation/machines/test/re_frame/nested_validation_test.clj
@@ -24,20 +24,11 @@
   unambiguous."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.machines :as machines]))
+            [re-frame.test-support :as test-support]))
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (defn- registration-throws?
   "Try registering `machine` under `machine-id`. Returns the

--- a/implementation/machines/test/re_frame/parallel_test.clj
+++ b/implementation/machines/test/re_frame/parallel_test.clj
@@ -30,21 +30,13 @@
   (:require [clojure.edn :as edn]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
             [re-frame.machines :as machines]
             [re-frame.machines.result :as result]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (defn- snapshot [machine-id]
   (get-in (rf/get-frame-db :rf/default) [:rf/machines machine-id]))

--- a/implementation/machines/test/re_frame/spawn_registry_test.clj
+++ b/implementation/machines/test/re_frame/spawn_registry_test.clj
@@ -37,23 +37,11 @@
   the in-app-db slot directly."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.machines :as machines]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (rf/init! plain-atom/adapter)
-  ;; Re-evaluate machines.cljc so the `:rf/machine` sub, `:rf.machine/spawn` /
-  ;; `:rf.machine/destroy` reserved fxs, and the late-bind hook table get
-  ;; reinstalled after `clear-all!` wiped them.
-  (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (defn- snapshot
   "Read the snapshot for `machine-id` from the default frame's app-db."

--- a/implementation/machines/test/re_frame/tags_test.clj
+++ b/implementation/machines/test/re_frame/tags_test.clj
@@ -20,21 +20,13 @@
   (:require [clojure.edn :as edn]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
             [re-frame.machines :as machines]
             [re-frame.machines.result :as result]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (defn- snapshot [machine-id]
   (get-in (rf/get-frame-db :rf/default) [:rf/machines machine-id]))

--- a/implementation/machines/test/re_frame/timer_frame_scope_test.clj
+++ b/implementation/machines/test/re_frame/timer_frame_scope_test.clj
@@ -28,21 +28,13 @@
   the targeted frame."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
             [re-frame.machines :as machines]
             [re-frame.machines.timer :as timer]
-            [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.machines :reload)
-  (machines/reset-timers!)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- the machine under test -----------------------------------------------
 ;;

--- a/implementation/machines/test/re_frame/timer_frame_scope_test.clj
+++ b/implementation/machines/test/re_frame/timer_frame_scope_test.clj
@@ -83,8 +83,9 @@
           "the timer table partitions entries under the left frame")
       (is (contains? tt :iso/right)
           "the timer table partitions entries under the right frame")
-      ;; Inner keys: [<parent-id> <invoke-id-vec> <delay-key>]. Because the
-      ;; machine spec is identical the inner keys collide across frames —
+      ;; Inner keys (per rf2-gwznv): {:parent <parent-id> :invoke
+      ;; <invoke-id-vec> :delay <delay-key>}. Because the machine spec
+      ;; is identical the inner keys collide across frames —
       ;; pre-rf2-ysa94 the keying included the frame-id; post-rf2-ysa94
       ;; the frame-id is the OUTER key and the inner keys legitimately
       ;; coincide.
@@ -95,11 +96,11 @@
                  "the partitioning axis, not a discriminator inside the "
                  "inner key"))
         (is (every? (fn [k]
-                      (and (= :iso/m (nth k 0))
-                           (vector? (nth k 1))
-                           (= 3600000 (nth k 2))))
+                      (and (= :iso/m (:parent k))
+                           (vector? (:invoke k))
+                           (= 3600000 (:delay k))))
                     left-inner-keys)
-            "inner-key shape is [parent-id invoke-id-vec delay-key]")))
+            "inner-key shape is {:parent ... :invoke ... :delay ...}")))
 
     ;; 1-arity reset clears only the targeted frame.
     (machines/reset-timers! :iso/left)


### PR DESCRIPTION
## Summary

Eight P2 follow-on beads from the rf2-2ukxv round-2 audit and the
alignment audit, batched on the `implementation/machines` surface.
One commit per bead; ordered to minimise internal rebase against the
hot files (`transition.cljc`, `timer.cljc`, the `machines.cljc`
façade, the lifecycle-fx sub-namespaces, and the 12-file JVM test
tree).

| Commit | Bead | Class | Touched |
|---|---|---|---|
| \`7eaa8efd\` | rf2-ijbg2 | perf | \`transition.cljc\` (\`subvec\` for \`compute-cascade-paths\`) |
| \`1d5ec026\` | rf2-ogsrx | perf | \`path_walk.cljc\` (\`subvec\` prefixes leaf→root) |
| \`c3dc4a1a\` | rf2-adwxh | refactor | \`transition.cljc\` (drop dead \`:else\` / \`nil?\` arms) |
| \`4a639595\` | rf2-hghvc | refactor | \`machines.cljc\` head-comment trim |
| \`af0a67d5\` | rf2-gwznv | refactor | \`timer.cljc\` 3-tuple key → map |
| \`0301d891\` | rf2-c1tnr | fix | \`timer.cljc\` silent fn/sub/watch throws → \`:rf.error/\` traces + JVM test |
| \`3e2b03ed\` | rf2-vgkdt | test | new \`destroyed_trace_shape_test.clj\` (4 deftests, 15 new assertions) |
| \`2c94e621\` | rf2-no3jm | refactor | 13 JVM test files → \`test-support/reset-runtime-fixture\` |

Three beads from the original dispatch were deferred and remain
claimable:

- **rf2-3vps4** (split 972-LoC \`machines_cljs_test.cljs\`) — per audit
  guidance: substantial standalone work, ship as its own PR.
- **rf2-ujhzw** (normalize Spec 005 \`:invoke-all\` join-state shape) —
  three options listed in the bead; needs Mike's call before code-side
  changes.
- **rf2-fasdp** (snapshot compatibility checks at handler entry) —
  three options listed; behaviour decision before implementation.

## Test plan

- [x] \`cd implementation/machines && clojure -M:test\` — 132 tests / 422 assertions / 0 failures
- [x] \`cd implementation && npm run test:cljs\` — 1816 tests / 5040 assertions / 0 failures
- [x] rf2-c1tnr's new test fails pre-fix and passes post-fix (verified by reading: pre-fix the silent catch never emits the trace; \`(seq errors)\` would be empty)
- [x] rf2-vgkdt's tests pin the per-site shape AND the cross-site union
- [x] rf2-gwznv's timer-key shape assertion in \`timer_frame_scope_test.clj\` rewritten to the new map form