### PR TITLE
refactor(causa): promote panel tokens to shared theme.tokens ns (rf2-rclvn)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot.cljs
@@ -48,36 +48,9 @@
   in place; the per-provider fetch lands as follow-on work."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [day8.re-frame2-causa.panels.ai-co-pilot-helpers :as h]))
-
-;; ---- design tokens (mirrors shell.cljs) ---------------------------------
-
-(def ^:private tokens
-  "Subset of shell.cljs's dark-theme tokens used by this panel. Kept
-  in sync manually for now per the panel convention — the v1.0
-  styling pass replaces these with CSS variables."
-  {:bg-1            "#15171B"
-   :bg-2            "#1B1E24"
-   :bg-3            "#232730"
-   :bg-active       "#2A2F3D"
-   :border-subtle   "#232730"
-   :border-default  "#2F3441"
-   :text-primary    "#E8EAF0"
-   :text-secondary  "#A8AEC0"
-   :text-tertiary   "#6B7080"
-   :accent-violet   "#7C5CFF"
-   :cyan            "#43C3D0"
-   :magenta         "#E879F9"
-   :yellow          "#FBBF24"
-   :red             "#F87171"})
-
-(def ^:private mono-stack
-  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
-  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
-
-(def ^:private sans-stack
-  "Inter stack per spec/007-UX-IA.md §Typography."
-  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+            [day8.re-frame2-causa.panels.ai-co-pilot-helpers :as h]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- view atoms ---------------------------------------------------------
 ;;

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
@@ -55,35 +55,9 @@
   changed' walker) — lives in `app_db_diff_helpers.cljc` so the
   algebra runs under the JVM unit-test target."
   (:require [re-frame.core :as rf]
-            [day8.re-frame2-causa.panels.app-db-diff-helpers :as h]))
-
-;; ---- design tokens (mirrors event_detail.cljs / time_travel.cljs) -------
-
-(def ^:private tokens
-  "Subset of shell.cljs's dark-theme tokens used by this panel."
-  {:bg-1            "#15171B"
-   :bg-2            "#1B1E24"
-   :bg-3            "#232730"
-   :bg-active       "#2A2F3D"
-   :border-subtle   "#232730"
-   :border-default  "#2F3441"
-   :text-primary    "#E8EAF0"
-   :text-secondary  "#A8AEC0"
-   :text-tertiary   "#6B7080"
-   :accent-violet   "#7C5CFF"
-   :cyan            "#43C3D0"
-   :green           "#4ADE80"
-   :yellow          "#FBBF24"
-   :red             "#F87171"
-   :magenta         "#E879F9"})
-
-(def ^:private mono-stack
-  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
-  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
-
-(def ^:private sans-stack
-  "Inter stack per spec/007-UX-IA.md §Typography."
-  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+            [day8.re-frame2-causa.panels.app-db-diff-helpers :as h]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- op-token resolution -------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/causality_graph.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/causality_graph.cljs
@@ -41,35 +41,9 @@
   `filter-to-cascade` — lives in `causality_graph_helpers.cljc` so
   the algebra runs under the JVM unit-test target."
   (:require [re-frame.core :as rf]
-            [day8.re-frame2-causa.panels.causality-graph-helpers :as h]))
-
-;; ---- design tokens (mirrors event_detail.cljs / time_travel.cljs) -------
-
-(def ^:private tokens
-  "Subset of shell.cljs's dark-theme tokens used by this panel."
-  {:bg-1            "#15171B"
-   :bg-2            "#1B1E24"
-   :bg-3            "#232730"
-   :bg-active       "#2A2F3D"
-   :border-subtle   "#232730"
-   :border-default  "#2F3441"
-   :text-primary    "#E8EAF0"
-   :text-secondary  "#A8AEC0"
-   :text-tertiary   "#6B7080"
-   :accent-violet   "#7C5CFF"
-   :cyan            "#43C3D0"
-   :green           "#4ADE80"
-   :yellow          "#FBBF24"
-   :red             "#F87171"
-   :magenta         "#E879F9"})
-
-(def ^:private mono-stack
-  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
-  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
-
-(def ^:private sans-stack
-  "Inter stack per spec/007-UX-IA.md §Typography."
-  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+            [day8.re-frame2-causa.panels.causality-graph-helpers :as h]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- pure helpers --------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/effects.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/effects.cljs
@@ -55,37 +55,9 @@
   `latest-override-per-fx`, ... — lives in `effects_helpers.cljc` so
   the algebra runs under the JVM unit-test target."
   (:require [re-frame.core :as rf]
-            [day8.re-frame2-causa.panels.effects-helpers :as h]))
-
-;; ---- design tokens (mirrors subscriptions.cljs / flows.cljs) ------------
-
-(def ^:private tokens
-  "Subset of shell.cljs's dark-theme tokens used by this panel. Kept
-  in sync manually for now — the v1.0 styling pass replaces these
-  with CSS variables across all panels."
-  {:bg-1            "#15171B"
-   :bg-2            "#1B1E24"
-   :bg-3            "#232730"
-   :bg-active       "#2A2F3D"
-   :border-subtle   "#232730"
-   :border-default  "#2F3441"
-   :text-primary    "#E8EAF0"
-   :text-secondary  "#A8AEC0"
-   :text-tertiary   "#6B7080"
-   :accent-violet   "#7C5CFF"
-   :cyan            "#43C3D0"
-   :green           "#4ADE80"
-   :yellow          "#FBBF24"
-   :red             "#F87171"
-   :magenta         "#E879F9"})
-
-(def ^:private mono-stack
-  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
-  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
-
-(def ^:private sans-stack
-  "Inter stack per spec/007-UX-IA.md §Typography."
-  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+            [day8.re-frame2-causa.panels.effects-helpers :as h]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- pure helpers -------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -45,37 +45,9 @@
   to-jump-to-editor hook (rf2-evgf5) is in flight; until it lands the
   coord is non-interactive plain text per the bead's contract."
   (:require [re-frame.core :as rf]
-            [re-frame.trace.projection :as projection]))
-
-;; ---- design tokens (mirrors shell.cljs) ---------------------------------
-
-(def ^:private tokens
-  "Subset of shell.cljs's dark-theme tokens used by this panel. Kept
-  in sync manually for now — the v1.0 styling pass replaces these
-  with CSS variables across all panels."
-  {:bg-1            "#15171B"
-   :bg-2            "#1B1E24"
-   :bg-3            "#232730"
-   :bg-active       "#2A2F3D"
-   :border-subtle   "#232730"
-   :border-default  "#2F3441"
-   :text-primary    "#E8EAF0"
-   :text-secondary  "#A8AEC0"
-   :text-tertiary   "#6B7080"
-   :accent-violet   "#7C5CFF"
-   :cyan            "#43C3D0"
-   :green           "#4ADE80"
-   :yellow          "#FBBF24"
-   :red             "#F87171"
-   :magenta         "#E879F9"})
-
-(def ^:private mono-stack
-  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
-  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
-
-(def ^:private sans-stack
-  "Inter stack per spec/007-UX-IA.md §Typography."
-  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+            [re-frame.trace.projection :as projection]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- pure helpers --------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/flows.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/flows.cljs
@@ -47,37 +47,9 @@
   cascade-dispatch-id`, ... — lives in `flows_helpers.cljc` so the
   algebra runs under the JVM unit-test target."
   (:require [re-frame.core :as rf]
-            [day8.re-frame2-causa.panels.flows-helpers :as h]))
-
-;; ---- design tokens (mirrors subscriptions.cljs / event_detail.cljs) ----
-
-(def ^:private tokens
-  "Subset of shell.cljs's dark-theme tokens used by this panel. Kept
-  in sync manually for now — the v1.0 styling pass replaces these
-  with CSS variables across all panels."
-  {:bg-1            "#15171B"
-   :bg-2            "#1B1E24"
-   :bg-3            "#232730"
-   :bg-active       "#2A2F3D"
-   :border-subtle   "#232730"
-   :border-default  "#2F3441"
-   :text-primary    "#E8EAF0"
-   :text-secondary  "#A8AEC0"
-   :text-tertiary   "#6B7080"
-   :accent-violet   "#7C5CFF"
-   :cyan            "#43C3D0"
-   :green           "#4ADE80"
-   :yellow          "#FBBF24"
-   :red             "#F87171"
-   :magenta         "#E879F9"})
-
-(def ^:private mono-stack
-  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
-  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
-
-(def ^:private sans-stack
-  "Inter stack per spec/007-UX-IA.md §Typography."
-  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+            [day8.re-frame2-causa.panels.flows-helpers :as h]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- pure helpers -------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger.cljs
@@ -63,35 +63,9 @@
   unit-test target."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
-            [day8.re-frame2-causa.panels.hydration-debugger-helpers :as h]))
-
-;; ---- design tokens (mirrors event_detail.cljs / causality_graph.cljs) ---
-
-(def ^:private tokens
-  "Subset of shell.cljs's dark-theme tokens used by this panel."
-  {:bg-1            "#15171B"
-   :bg-2            "#1B1E24"
-   :bg-3            "#232730"
-   :bg-active       "#2A2F3D"
-   :border-subtle   "#232730"
-   :border-default  "#2F3441"
-   :text-primary    "#E8EAF0"
-   :text-secondary  "#A8AEC0"
-   :text-tertiary   "#6B7080"
-   :accent-violet   "#7C5CFF"
-   :cyan            "#43C3D0"
-   :green           "#4ADE80"
-   :yellow          "#FBBF24"
-   :red             "#F87171"
-   :magenta         "#E879F9"})
-
-(def ^:private mono-stack
-  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
-  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
-
-(def ^:private sans-stack
-  "Inter stack per spec/007-UX-IA.md §Typography."
-  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+            [day8.re-frame2-causa.panels.hydration-debugger-helpers :as h]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- pure-data render helpers -------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
@@ -53,35 +53,9 @@
   lives in `issues_ribbon_helpers.cljc` so the algebra runs under
   the JVM unit-test target."
   (:require [re-frame.core :as rf]
-            [day8.re-frame2-causa.panels.issues-ribbon-helpers :as h]))
-
-;; ---- design tokens (mirrors event_detail.cljs / time_travel.cljs) -------
-
-(def ^:private tokens
-  "Subset of shell.cljs's dark-theme tokens used by this panel."
-  {:bg-1            "#15171B"
-   :bg-2            "#1B1E24"
-   :bg-3            "#232730"
-   :bg-active       "#2A2F3D"
-   :border-subtle   "#232730"
-   :border-default  "#2F3441"
-   :text-primary    "#E8EAF0"
-   :text-secondary  "#A8AEC0"
-   :text-tertiary   "#6B7080"
-   :accent-violet   "#7C5CFF"
-   :cyan            "#43C3D0"
-   :green           "#4ADE80"
-   :yellow          "#FBBF24"
-   :red             "#F87171"
-   :magenta         "#E879F9"})
-
-(def ^:private mono-stack
-  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
-  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
-
-(def ^:private sans-stack
-  "Inter stack per spec/007-UX-IA.md §Typography."
-  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+            [day8.re-frame2-causa.panels.issues-ribbon-helpers :as h]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- chip helpers -------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -74,37 +74,9 @@
   unit-test target. The view here is a thin renderer that reads the
   `:rf.causa/machine-inspector-data` composite sub."
   (:require [re-frame.core :as rf]
-            [day8.re-frame2-causa.panels.machine-inspector-helpers :as h]))
-
-;; ---- design tokens (mirrors routes.cljs / subscriptions.cljs) -----------
-
-(def ^:private tokens
-  "Subset of shell.cljs's dark-theme tokens used by this panel. Kept
-  in sync manually for now — the v1.0 styling pass replaces these
-  with CSS variables across all panels."
-  {:bg-1            "#15171B"
-   :bg-2            "#1B1E24"
-   :bg-3            "#232730"
-   :bg-active       "#2A2F3D"
-   :border-subtle   "#232730"
-   :border-default  "#2F3441"
-   :text-primary    "#E8EAF0"
-   :text-secondary  "#A8AEC0"
-   :text-tertiary   "#6B7080"
-   :accent-violet   "#7C5CFF"
-   :cyan            "#43C3D0"
-   :green           "#4ADE80"
-   :yellow          "#FBBF24"
-   :red             "#F87171"
-   :magenta         "#E879F9"})
-
-(def ^:private mono-stack
-  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
-  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
-
-(def ^:private sans-stack
-  "Inter stack per spec/007-UX-IA.md §Typography."
-  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+            [day8.re-frame2-causa.panels.machine-inspector-helpers :as h]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- machine picker -----------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/mcp_server.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/mcp_server.cljs
@@ -68,39 +68,23 @@
   `mcp_server_helpers.cljc` so the algebra runs under the JVM
   unit-test target."
   (:require [re-frame.core :as rf]
-            [day8.re-frame2-causa.panels.mcp-server-helpers :as h]))
+            [day8.re-frame2-causa.panels.mcp-server-helpers :as h]
+            [day8.re-frame2-causa.theme.tokens :as theme
+             :refer [mono-stack sans-stack]]))
 
-;; ---- design tokens (mirrors event_detail.cljs / issues_ribbon.cljs) -----
+;; ---- design tokens -------------------------------------------------------
+;;
+;; The shared dark-theme palette ships in
+;; `day8.re-frame2-causa.theme.tokens`. This panel extends it with one
+;; extra entry — the inferential `:causa-mcp-cyan` for `:origin
+;; :causa-mcp` events. The colour is pinned in `mcp_server_helpers`
+;; rather than the shared palette because it is awaiting a follow-on
+;; bead that promotes it to `spec/007-UX-IA.md` §Colour system (it is
+;; distinct from `:pair`'s indigo and from `:story` / `:test`'s
+;; lighter cyan).
 
 (def ^:private tokens
-  "Subset of shell.cljs's dark-theme tokens used by this panel."
-  {:bg-1            "#15171B"
-   :bg-2            "#1B1E24"
-   :bg-3            "#232730"
-   :bg-active       "#2A2F3D"
-   :border-subtle   "#232730"
-   :border-default  "#2F3441"
-   :text-primary    "#E8EAF0"
-   :text-secondary  "#A8AEC0"
-   :text-tertiary   "#6B7080"
-   :accent-violet   "#7C5CFF"
-   :cyan            "#43C3D0"
-   :green           "#4ADE80"
-   :yellow          "#FBBF24"
-   :red             "#F87171"
-   :magenta         "#E879F9"
-   ;; DECISION (b) — `:origin :causa-mcp` gets cyan #06B6D4. Distinct
-   ;; from :pair indigo (locked) and :story/:test cyan (#43C3D0).
-   ;; Follow-on bead promotes this to spec/007-UX-IA.md §Colour system.
-   :causa-mcp-cyan  h/causa-mcp-origin-colour})
-
-(def ^:private mono-stack
-  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
-  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
-
-(def ^:private sans-stack
-  "Inter stack per spec/007-UX-IA.md §Typography."
-  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+  (assoc theme/tokens :causa-mcp-cyan h/causa-mcp-origin-colour))
 
 ;; ---- chip helpers -------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/performance.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/performance.cljs
@@ -60,36 +60,9 @@
       (count of `:view/render` traces in the cascade) until that slot
       surfaces."
   (:require [re-frame.core :as rf]
-            [day8.re-frame2-causa.panels.performance-helpers :as h]))
-
-;; ---- design tokens (mirrors event_detail.cljs / issues_ribbon.cljs) -----
-
-(def ^:private tokens
-  "Subset of shell.cljs's dark-theme tokens used by this panel."
-  {:bg-1            "#15171B"
-   :bg-2            "#1B1E24"
-   :bg-3            "#232730"
-   :bg-active       "#2A2F3D"
-   :border-subtle   "#232730"
-   :border-default  "#2F3441"
-   :text-primary    "#E8EAF0"
-   :text-secondary  "#A8AEC0"
-   :text-tertiary   "#6B7080"
-   :accent-violet   "#7C5CFF"
-   :cyan            "#43C3D0"
-   :green           "#4ADE80"
-   :yellow          "#FBBF24"
-   :orange          "#FB923C"
-   :red             "#F87171"
-   :magenta         "#E879F9"})
-
-(def ^:private mono-stack
-  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
-  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
-
-(def ^:private sans-stack
-  "Inter stack per spec/007-UX-IA.md §Typography."
-  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+            [day8.re-frame2-causa.panels.performance-helpers :as h]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- tier chip helpers ---------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/routes.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routes.cljs
@@ -58,37 +58,9 @@
   target. The view here is a thin renderer that reads the
   `:rf.causa/routes-data` composite sub."
   (:require [re-frame.core :as rf]
-            [day8.re-frame2-causa.panels.routes-helpers :as h]))
-
-;; ---- design tokens (mirrors flows.cljs / subscriptions.cljs) ------------
-
-(def ^:private tokens
-  "Subset of shell.cljs's dark-theme tokens used by this panel. Kept
-  in sync manually for now — the v1.0 styling pass replaces these
-  with CSS variables across all panels."
-  {:bg-1            "#15171B"
-   :bg-2            "#1B1E24"
-   :bg-3            "#232730"
-   :bg-active       "#2A2F3D"
-   :border-subtle   "#232730"
-   :border-default  "#2F3441"
-   :text-primary    "#E8EAF0"
-   :text-secondary  "#A8AEC0"
-   :text-tertiary   "#6B7080"
-   :accent-violet   "#7C5CFF"
-   :cyan            "#43C3D0"
-   :green           "#4ADE80"
-   :yellow          "#FBBF24"
-   :red             "#F87171"
-   :magenta         "#E879F9"})
-
-(def ^:private mono-stack
-  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
-  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
-
-(def ^:private sans-stack
-  "Inter stack per spec/007-UX-IA.md §Typography."
-  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+            [day8.re-frame2-causa.panels.routes-helpers :as h]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- transition swatch --------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/schema_violation_timeline.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/schema_violation_timeline.cljs
@@ -40,35 +40,9 @@
   `schema_violation_timeline_helpers.cljc` so the algebra runs under
   the JVM unit-test target."
   (:require [re-frame.core :as rf]
-            [day8.re-frame2-causa.panels.schema-violation-timeline-helpers :as h]))
-
-;; ---- design tokens (mirrors event_detail.cljs / time_travel.cljs) -------
-
-(def ^:private tokens
-  "Subset of shell.cljs's dark-theme tokens used by this panel."
-  {:bg-1            "#15171B"
-   :bg-2            "#1B1E24"
-   :bg-3            "#232730"
-   :bg-active       "#2A2F3D"
-   :border-subtle   "#232730"
-   :border-default  "#2F3441"
-   :text-primary    "#E8EAF0"
-   :text-secondary  "#A8AEC0"
-   :text-tertiary   "#6B7080"
-   :accent-violet   "#7C5CFF"
-   :cyan            "#43C3D0"
-   :green           "#4ADE80"
-   :yellow          "#FBBF24"
-   :red             "#F87171"
-   :magenta         "#E879F9"})
-
-(def ^:private mono-stack
-  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
-  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
-
-(def ^:private sans-stack
-  "Inter stack per spec/007-UX-IA.md §Typography."
-  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+            [day8.re-frame2-causa.panels.schema-violation-timeline-helpers :as h]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- layout constants ----------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/subscriptions.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/subscriptions.cljs
@@ -39,37 +39,9 @@
   chain`, `status-counts` — lives in `subscriptions_helpers.cljc` so
   the algebra runs under the JVM unit-test target."
   (:require [re-frame.core :as rf]
-            [day8.re-frame2-causa.panels.subscriptions-helpers :as h]))
-
-;; ---- design tokens (mirrors event_detail.cljs / time_travel.cljs) --------
-
-(def ^:private tokens
-  "Subset of shell.cljs's dark-theme tokens used by this panel.
-  Kept in sync manually for now — the v1.0 styling pass replaces
-  these with CSS variables across all panels."
-  {:bg-1            "#15171B"
-   :bg-2            "#1B1E24"
-   :bg-3            "#232730"
-   :bg-active       "#2A2F3D"
-   :border-subtle   "#232730"
-   :border-default  "#2F3441"
-   :text-primary    "#E8EAF0"
-   :text-secondary  "#A8AEC0"
-   :text-tertiary   "#6B7080"
-   :accent-violet   "#7C5CFF"
-   :cyan            "#43C3D0"
-   :green           "#4ADE80"
-   :yellow          "#FBBF24"
-   :red             "#F87171"
-   :magenta         "#E879F9"})
-
-(def ^:private mono-stack
-  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
-  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
-
-(def ^:private sans-stack
-  "Inter stack per spec/007-UX-IA.md §Typography."
-  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+            [day8.re-frame2-causa.panels.subscriptions-helpers :as h]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- pure helpers --------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/time_travel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/time_travel.cljs
@@ -41,35 +41,9 @@
   All pure-data logic lives in `time_travel_helpers.cljc` for JVM
   testability. This ns is the thin view-only wrapper."
   (:require [re-frame.core :as rf]
-            [day8.re-frame2-causa.panels.time-travel-helpers :as h]))
-
-;; ---- design tokens (mirrors event_detail.cljs) ---------------------------
-
-(def ^:private tokens
-  "Subset of shell.cljs's dark-theme tokens used by this panel."
-  {:bg-1            "#15171B"
-   :bg-2            "#1B1E24"
-   :bg-3            "#232730"
-   :bg-active       "#2A2F3D"
-   :border-subtle   "#232730"
-   :border-default  "#2F3441"
-   :text-primary    "#E8EAF0"
-   :text-secondary  "#A8AEC0"
-   :text-tertiary   "#6B7080"
-   :accent-violet   "#7C5CFF"
-   :cyan            "#43C3D0"
-   :green           "#4ADE80"
-   :yellow          "#FBBF24"
-   :red             "#F87171"
-   :magenta         "#E879F9"})
-
-(def ^:private mono-stack
-  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
-  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
-
-(def ^:private sans-stack
-  "Inter stack per spec/007-UX-IA.md §Typography."
-  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+            [day8.re-frame2-causa.panels.time-travel-helpers :as h]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- view atoms ----------------------------------------------------------
 ;;

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -60,34 +60,9 @@
   `trace_helpers.cljc` so the algebra runs under the JVM unit-test
   target."
   (:require [re-frame.core :as rf]
-            [day8.re-frame2-causa.panels.trace-helpers :as h]))
-
-;; ---- design tokens (mirrors event_detail.cljs / issues_ribbon.cljs) -----
-
-(def ^:private tokens
-  {:bg-1            "#15171B"
-   :bg-2            "#1B1E24"
-   :bg-3            "#232730"
-   :bg-active       "#2A2F3D"
-   :border-subtle   "#232730"
-   :border-default  "#2F3441"
-   :text-primary    "#E8EAF0"
-   :text-secondary  "#A8AEC0"
-   :text-tertiary   "#6B7080"
-   :accent-violet   "#7C5CFF"
-   :cyan            "#43C3D0"
-   :green           "#4ADE80"
-   :yellow          "#FBBF24"
-   :red             "#F87171"
-   :magenta         "#E879F9"})
-
-(def ^:private mono-stack
-  "JetBrains Mono stack per spec/007-UX-IA.md §Typography."
-  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
-
-(def ^:private sans-stack
-  "Inter stack per spec/007-UX-IA.md §Typography."
-  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+            [day8.re-frame2-causa.panels.trace-helpers :as h]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- axis labelling -----------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -55,26 +55,8 @@
             [day8.re-frame2-causa.panels.subscriptions :as subscriptions]
             [day8.re-frame2-causa.panels.trace :as trace]
             [day8.re-frame2-causa.registry :as registry]
-            [day8.re-frame2-causa.open-in-editor :as open-in-editor]))
-
-;; ---- design tokens (dark theme per spec/007-UX-IA.md) --------------------
-
-(def ^:private tokens
-  "Colour + size tokens lifted from spec/007-UX-IA.md §Dark theme
-  tokens. Phase 1 uses inline styles so the foundation ships without
-  a CSS asset pipeline; the v1.0 styling pass replaces these with
-  CSS variables when the per-panel beads land."
-  {:bg-0          "#0E0F12"
-   :bg-1          "#15171B"
-   :bg-2          "#1B1E24"
-   :bg-active     "#2A2F3D"
-   :border-subtle "#232730"
-   :border-default "#2F3441"
-   :text-primary  "#E8EAF0"
-   :text-secondary "#A8AEC0"
-   :text-tertiary "#6B7080"
-   :accent-violet "#7C5CFF"
-   :magenta       "#E879F9"})
+            [day8.re-frame2-causa.open-in-editor :as open-in-editor]
+            [day8.re-frame2-causa.theme.tokens :refer [tokens]]))
 
 ;; ---- sidebar items -------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
@@ -1,0 +1,89 @@
+(ns day8.re-frame2-causa.theme.tokens
+  "Shared design tokens for the Causa shell + every panel view.
+
+  ## Single source of truth (rf2-rclvn)
+
+  Phase 1 / Phase 2 / Phase 3 panel views each carried a private copy
+  of the dark-theme palette plus the `mono-stack` + `sans-stack` font
+  defs. Drift had already started — `:orange` was unique to the
+  performance panel even though `spec/007-UX-IA.md` §Colour system
+  catalogues it as part of the canonical perf scale. One source of
+  truth — this ns — removes the duplication and makes the v1.0
+  CSS-variable migration a one-file change.
+
+  Per `tools/causa/spec/007-UX-IA.md` §Dark theme tokens. Phase 1 uses
+  inline styles so the foundation ships without a CSS asset pipeline;
+  the v1.0 styling pass replaces these with CSS variables.
+
+  ## How panels consume this
+
+      (:require [day8.re-frame2-causa.theme.tokens
+                 :refer [tokens mono-stack sans-stack]])
+
+  …then `(:bg-1 tokens)` / `mono-stack` resolve as if locally defined.
+  The `:refer` form keeps every existing use-site working without
+  rename churn.
+
+  ## What lives here
+
+  - **`tokens`** — the dark-theme palette. Keys are stable token
+    names; values are hex strings.
+  - **`mono-stack`** — the JetBrains Mono font stack for code /
+    EDN / mono-column rendering.
+  - **`sans-stack`** — the Inter font stack for chrome / labels /
+    prose.
+
+  ## What does not live here
+
+  Semantic-mapping tables that emit token *keywords* (e.g. an outcome
+  → `:green` table) live in each panel's `*_helpers.cljc` so the
+  pure-data side stays JVM-portable. The hex resolution happens here.
+
+  ## Causa-MCP origin colour
+
+  The inferential `:origin :causa-mcp` cyan (`#06B6D4`) lives in
+  `mcp_server_helpers.cljc/causa-mcp-origin-colour` per the comment
+  there — it is pinned to a follow-on spec bead and not (yet) a
+  palette-grade token. The mcp-server panel reaches for it directly
+  rather than rolling it into the shared palette."
+  {:no-doc true})
+
+(def tokens
+  "Dark-theme colour tokens lifted from `spec/007-UX-IA.md` §Dark theme
+  tokens. Phase 1 uses inline styles; the v1.0 styling pass replaces
+  these with CSS variables."
+  {;; ── surfaces ──
+   :bg-0           "#0E0F12"
+   :bg-1           "#15171B"
+   :bg-2           "#1B1E24"
+   :bg-3           "#232730"
+   :bg-active      "#2A2F3D"
+
+   ;; ── borders ──
+   :border-subtle  "#232730"
+   :border-default "#2F3441"
+
+   ;; ── text ──
+   :text-primary   "#E8EAF0"
+   :text-secondary "#A8AEC0"
+   :text-tertiary  "#6B7080"
+
+   ;; ── accents + semantic ──
+   :accent-violet  "#7C5CFF"
+   :cyan           "#43C3D0"
+   :green          "#4ADE80"
+   :yellow         "#FBBF24"
+   :orange         "#FB923C"
+   :red            "#F87171"
+   :magenta        "#E879F9"})
+
+(def mono-stack
+  "JetBrains Mono stack per spec/007-UX-IA.md §Typography. Used by
+  every panel's mono column (event vectors, EDN values, hashes,
+  paths)."
+  "JetBrains Mono, ui-monospace, SF Mono, Menlo, monospace")
+
+(def sans-stack
+  "Inter stack per spec/007-UX-IA.md §Typography. Used by chrome,
+  labels, prose, and every non-mono surface in the panels."
+  "Inter, system-ui, -apple-system, Segoe UI, sans-serif")


### PR DESCRIPTION
## Summary

- Promote the dark-theme palette + `mono-stack` / `sans-stack` font defs to a new `day8.re-frame2-causa.theme.tokens` ns. Single source of truth.
- Sweep `shell.cljs` + the 16 panel views to `:refer` from the shared ns; their private 12-15-entry hex maps + the two font-stack defs are gone.
- Lift `:orange "#FB923C"` — previously a private drift fragment in `performance.cljs` — into the canonical palette. The colour is documented in `spec/007-UX-IA.md` §Colour system as the perf-tier `slow` shade, so this is a one-line correction that binds spec to implementation.

## Net change

| | Lines |
| --- | --- |
| `tokens.cljc` (new) | +89 |
| 17 view files swept | -437 |
| **Total** | **-348 net LoC** |

The audit (rf2-imynx P1-1) had estimated ~600 LoC of raw duplication; the net delta after factoring in the new shared file is -348. Future re-themes are one-file changes.

## Notes

- `mcp_server.cljs` is the lone special case: it `assoc`s `:causa-mcp-cyan` onto the shared map at panel scope. That colour is pinned in `mcp_server_helpers.cljc` rather than the shared palette because it is awaiting a follow-on bead that promotes it to `spec/007-UX-IA.md` §Colour system (it is distinct from `:pair`'s locked indigo and from `:story` / `:test`'s lighter cyan).
- No back-compat shims; pre-alpha rule honoured.
- No `:as` rename churn at use-sites — `:refer [tokens mono-stack sans-stack]` keeps every existing `(:bg-1 tokens)` / `(tone tokens)` / `(get tokens ...)` reference working.
- The panel `*_helpers.cljc` files that emit token *keywords* (e.g. `outcome->token` → `:green`) are unchanged; the hex resolution still happens on the view side, just against the shared map now.

## Test plan

- [x] `clojure -M:test` from `tools/causa/` — 488 tests / 1363 assertions, 0 failures.
- [x] `npm run test:cljs` from `implementation/` — 1817 tests / 5105 assertions, 0 failures.
- [x] `npm run test:bundle-isolation` from `implementation/` — PASS.

Closes rf2-rclvn.