### PR TITLE
refactor(schemas): round-2 polish cluster — 8 follow-on beads (rf2-whepe)

### DIFF
--- a/implementation/package.json
+++ b/implementation/package.json
@@ -19,6 +19,7 @@
     "test:browser-prod-elision": "shadow-cljs release browser-test-prod-elision && node scripts/serve-and-run-prod-elision-tests.cjs",
     "test:elision": "shadow-cljs release elision-probe elision-probe-control && node scripts/check-elision.cjs",
     "test:perf-bundle": "shadow-cljs release examples/counter examples/counter-perf && node scripts/check-perf-bundle.cjs",
+    "test:schemas-bundle": "shadow-cljs release schemas-bundle-probe schemas-bundle-probe-malli && node scripts/check-schemas-bundle.cjs",
     "test:bundle-isolation": "shadow-cljs release examples/counter && node scripts/check-bundle-isolation.cjs",
     "test:bundle-comparison": "shadow-cljs release examples/counter examples/counter-slim-and-fast && node scripts/check-counter-slim-and-fast.cjs",
     "test:examples": "node ../examples/scripts/serve-and-run-examples-tests.cjs",

--- a/implementation/schemas/src/re_frame/schemas/digest.cljc
+++ b/implementation/schemas/src/re_frame/schemas/digest.cljc
@@ -25,8 +25,8 @@
       the client compares its own digest at hydrate time.
     - Pair tools — flag attached REPL sessions whose runtime schemas
       have shifted under them."
-  (:require #?(:cljs [goog.crypt :as gcrypt])
-            #?(:cljs [goog.crypt.Sha256])
+  (:require #?@(:cljs [[goog.crypt :as gcrypt]
+                       [goog.crypt.Sha256]])
             [re-frame.schemas.storage :as storage]
             [re-frame.schemas.validator :as validator])
   #?(:clj (:import [java.security MessageDigest]

--- a/implementation/schemas/src/re_frame/schemas/digest.cljc
+++ b/implementation/schemas/src/re_frame/schemas/digest.cljc
@@ -32,6 +32,8 @@
   #?(:clj (:import [java.security MessageDigest]
                    [java.nio.charset StandardCharsets])))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (defn- utf8-bytes
   "Encode a string as UTF-8 bytes."
   [s]

--- a/implementation/schemas/src/re_frame/schemas/elision_feeder.cljc
+++ b/implementation/schemas/src/re_frame/schemas/elision_feeder.cljc
@@ -25,6 +25,8 @@
             [re-frame.schemas.storage :as storage]
             [re-frame.schemas.walker :as walker]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (defn- frame-declarations
   "Aggregate `extract-fn` across every schema registered against
   `frame-id`, returning a `{path declaration}` map."

--- a/implementation/schemas/src/re_frame/schemas/elision_feeder.cljc
+++ b/implementation/schemas/src/re_frame/schemas/elision_feeder.cljc
@@ -13,10 +13,10 @@
   idempotently fold those declarations into a frame's app-db with the
   Spec 009 conflict-resolution rule applied: existing entries with
   `:source :declared` are preserved (declared beats schema); entries
-  with `:source :schema` from a prior call are overwritten (hot-reload
-  picks up `:hint` / flag flips); entries no longer claimed by any
-  registered schema are NOT removed (a stale `:source :schema` entry
-  persists until the next explicit clear).
+  with `:source :schema` are replaced wholesale by the current
+  frame-derived set on every call. Re-registering a schema with the
+  flag removed prunes the stale `:source :schema` entry (rf2-kr3vp);
+  re-registering with a new `:hint` refreshes the slot.
 
   Both pairs are published via per-flag late-bind hooks by the outer
   façade so re-frame.core can call them without statically requiring
@@ -38,22 +38,34 @@
 
 (defn- populate-declarations
   "Idempotent — fold `frame-id`'s schema-derived declarations into `db`
-  at `registry-path`. Preserves `:source :declared` entries; overwrites
-  `:source :schema` entries. Returns `db` unchanged when the frame
-  carries no schema-derived declarations."
+  at `registry-path`. Preserves `:source :declared` entries; replaces
+  the `:source :schema` subset wholesale with the current frame-derived
+  set so re-registration with the flag removed prunes the stale entry
+  (rf2-kr3vp). When a path appears in both the schema-derived map AND
+  an existing `:source :declared` entry, the declared entry wins
+  (declared beats schema)."
   [db frame-id extract-fn registry-path]
-  (let [schema-decls (frame-declarations extract-fn frame-id)]
-    (if (empty? schema-decls)
+  (let [schema-decls (frame-declarations extract-fn frame-id)
+        existing     (get-in db registry-path)]
+    (if (and (empty? schema-decls) (empty? existing))
       db
-      (update-in db registry-path
-                 (fn [existing]
-                   (reduce-kv
-                     (fn [acc path decl]
-                       (if (= :declared (some-> (get acc path) :source))
-                         acc
-                         (assoc acc path decl)))
-                     (or existing {})
-                     schema-decls))))))
+      (let [;; Keep every existing :source :declared entry — schema
+            ;; walking never overrides app-declared paths.
+            declared (reduce-kv (fn [acc path decl]
+                                  (if (= :declared (:source decl))
+                                    (assoc acc path decl)
+                                    acc))
+                                {}
+                                (or existing {}))
+            ;; Schema-derived paths that collide with a :source
+            ;; :declared entry yield to the declared entry.
+            merged   (reduce-kv (fn [acc path decl]
+                                  (if (contains? declared path)
+                                    acc
+                                    (assoc acc path decl)))
+                                declared
+                                schema-decls)]
+        (assoc-in db registry-path merged)))))
 
 (defn frame-elision-declarations
   "Return the merged `{path declaration}` map for every `:large? true`

--- a/implementation/schemas/src/re_frame/schemas/malli.cljc
+++ b/implementation/schemas/src/re_frame/schemas/malli.cljc
@@ -47,6 +47,8 @@
   (:require [malli.core]
             [re-frame.late-bind :as late-bind]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- publish Malli into the late-bind hook table -------------------------
 ;;
 ;; Per rf2-t0hq the two hooks `:schemas/malli-validate` and

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -24,6 +24,8 @@
   (:require [re-frame.frame :as frame]
             [re-frame.source-coords :as source-coords]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (defonce
   ^{:doc "frame-id → path → schema-meta. Per-frame so a story or test
           fixture's reg-app-schema does not bleed into the default

--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -71,6 +71,8 @@
             [re-frame.schemas.walker :as walker]
             [re-frame.trace :as trace]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (def ^:private redacted-sentinel
   "The `:rf/redacted` privacy sentinel emitted by validation traces
   for slots matching the `:sensitive?` predicate. Per Spec 009

--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -85,21 +85,6 @@
   [m]
   (true? (:sensitive? m)))
 
-(defn- sensitive-by-meta?
-  "Sensitivity check used by validate-event!. Only consults the
-  registration meta (event vectors aren't walked for per-slot
-  `:sensitive?` schema props per Spec 010)."
-  [m _schema]
-  (meta-sensitive? m))
-
-(defn- sensitive-by-meta-or-schema?
-  "Sensitivity check used by validate-cofx! / validate-fx! /
-  validate-sub-return!. Either the registration meta OR a per-slot
-  `:sensitive?` prop anywhere in the schema tree triggers redaction."
-  [m schema]
-  (or (meta-sensitive? m)
-      (walker/schema-has-sensitive? schema)))
-
 (defn- redact-tags
   "Replace value-bearing slots in a tags map with the `:rf/redacted`
   sentinel. Per Spec 010 §`:sensitive?` — privacy in schema-validation
@@ -136,16 +121,26 @@
                      fx) — its `:spec` slot, if any, is the schema.
     - `value`        the value being checked (event vector, cofx
                      value, sub return, fx args).
-    - `sensitive?-fn`  `(fn [meta schema] -> boolean)` — combines the
-                     meta-level `:sensitive?` flag with any
-                     schema-level `:sensitive?` props per Spec 010.
+    - `meta-sensitive?` boolean — the registration-meta `:sensitive?`
+                     flag (the coarse, handler-level signal). Wrappers
+                     pass `(meta-sensitive? meta)`. The schema-level
+                     `:sensitive?` walker check is deferred to the
+                     failure branch so the hot path doesn't pay for it
+                     on every pass.
+    - `walk-schema?` boolean — when true AND `meta-sensitive?` is
+                     false AND the validator fails, consult the
+                     schema's per-slot `:sensitive?` walker before
+                     emitting. Event vectors are not schema-walked
+                     (event vectors aren't `:map`-shaped, so per-slot
+                     `:sensitive?` props don't apply) so wrappers
+                     pass `false`; cofx / fx / sub-return pass `true`.
     - `build-base-tags`  `(fn [schema explanation] -> map)` — produces
                      the per-fn tag map (`:where`, `:reason`, etc.)
                      EXCLUDING any sensitivity stamping.
     - `extra-redact` `(fn [tags] -> tags)` or `nil` — additional
                      redaction step applied AFTER `redact-tags` when
-                     `sensitive?` is true. Used by validate-fx! to
-                     scrub the doubled `:fx-args` slot.
+                     `sensitive?` resolves true. Used by validate-fx!
+                     to scrub the doubled `:fx-args` slot.
 
   Reachability: every call-site lives inside the outermost
   `(if interop/debug-enabled? ...)` gate of its public wrapper.
@@ -157,16 +152,18 @@
   gate and invoked directly — `validator/run-validator` would deref
   the same atom a second time on every pass, which is wasted work
   on a path that runs per-event / per-cofx / per-fx / per-sub-return."
-  [meta value sensitive?-fn build-base-tags extra-redact]
+  [meta value meta-sensitive? walk-schema? build-base-tags extra-redact]
   (if-let [vf @validator/validator-fn]
     (if-let [schema (:spec meta)]
       (if (vf schema value)
         true
         (let [explanation (validator/run-explainer schema value)
-              sensitive?  (sensitive?-fn meta schema)
+              sensitive?  (or meta-sensitive?
+                              (and walk-schema?
+                                   (walker/schema-has-sensitive? schema)))
               base-tags   (build-base-tags schema explanation)
               tags        (cond-> base-tags
-                            sensitive?                  redact-tags
+                            sensitive?                    redact-tags
                             (and sensitive? extra-redact) extra-redact)]
           (trace/emit-error! :rf.error/schema-validation-failure tags)
           false))
@@ -259,7 +256,8 @@
     (run-validation
       handler-meta
       event
-      sensitive-by-meta?
+      (meta-sensitive? handler-meta)
+      false  ;; event vectors aren't `:map`-shaped — no per-slot walk
       (fn [schema explanation]
         {:where      :event
          :event-id   event-id
@@ -288,7 +286,8 @@
     (run-validation
       sub-meta
       value
-      sensitive-by-meta-or-schema?
+      (meta-sensitive? sub-meta)
+      true   ;; consult schema's per-slot `:sensitive?` walker on fail
       (fn [schema explanation]
         {:where      :sub-return
          :sub-id     sub-id
@@ -318,7 +317,8 @@
     (run-validation
       cofx-meta
       value
-      sensitive-by-meta-or-schema?
+      (meta-sensitive? cofx-meta)
+      true   ;; consult schema's per-slot `:sensitive?` walker on fail
       (fn [schema explanation]
         {:where      :cofx
          :cofx-id    cofx-id
@@ -353,7 +353,8 @@
     (run-validation
       fx-meta
       args
-      sensitive-by-meta-or-schema?
+      (meta-sensitive? fx-meta)
+      true   ;; consult schema's per-slot `:sensitive?` walker on fail
       (fn [schema explanation]
         (cond-> {:where      :fx-args
                  :fx-id      fx-id

--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -115,23 +115,30 @@
   "Build the human-readable `:reason` slot for a schema-validation
   failure trace. Single template covering every emit-site:
 
-    - `noun-and-id`: \"Event :foo\" / \"Coeffect :db\" / \"App-db at path [:user]\".
-      The noun + id (or path) phrase that names what failed.
-    - `slot-suffix` (optional): \" payload\" / \" injected value\" /
-      \" return value\" / \" args\" — names the slot inside the
-      noun-bearer being checked. Use `nil` for app-db where the
-      noun phrase carries the full subject already.
+    - `subject`: subject phrase up to (but not including) the id —
+      \"Event \" / \"Coeffect \" / \"Subscription \" / \"Effect \" /
+      \"App-db at path \". Built per-call-site as a string literal
+      so the elision-probe grep (`scripts/check-elision.cjs`) can
+      pin a distinctive substring per surface.
+    - `id-or-path`: the id (event-id, sub-id, ...) or the app-db
+      path; rendered via `str` so keywords print with the colon.
+    - `slot-tail`: distinctive per-surface tail starting with
+      \" failed schema \" — e.g. \" payload failed schema \" /
+      \" injected value failed schema \" / \", failed schema \"
+      (app-db has no slot label so the tail starts with \" failed
+      schema \" directly). Pinned per-site so DCE analysis can see
+      the literal substring inside each gated branch — the
+      elision-probe asserts every surface's distinctive tail is
+      ABSENT under :advanced + goog.DEBUG=false.
     - `schema`: the registered schema (Malli EDN form or other
       validator's schema value); rendered via `pr-str` (no special-
       casing of `[:int]` etc. — `pr-str` already reads fine).
     - `value`: the value that failed.
 
-  Shape: \"<noun-and-id><slot-suffix> failed schema <schema>, got
+  Shape: \"<subject><id-or-path><slot-tail><pr-str schema>, got
   <type-of-value>.\""
-  [noun-and-id slot-suffix schema value]
-  (str noun-and-id
-       (when slot-suffix slot-suffix)
-       " failed schema " (pr-str schema)
+  [subject id-or-path slot-tail schema value]
+  (str subject id-or-path slot-tail (pr-str schema)
        ", got " (type-of-value value) "."))
 
 (defn- run-validation
@@ -256,8 +263,9 @@
                                        :frame    frame-id
                                        :explain  (validator/run-explainer schema val-at)
                                        :reason   (reason-string
-                                                   (str "App-db at path " path)
-                                                   nil
+                                                   "App-db at path "
+                                                   path
+                                                   " failed schema "
                                                    schema val-at)
                                        :recovery :no-recovery}
                                 event-id (assoc :failing-id event-id))
@@ -285,8 +293,8 @@
          :received   event
          :value      event
          :explain    explanation
-         :reason     (reason-string (str "Event " event-id)
-                                    " payload"
+         :reason     (reason-string "Event " event-id
+                                    " payload failed schema "
                                     schema event)
          :recovery   :no-recovery})
       nil)
@@ -315,8 +323,8 @@
          :received   value
          :value      value
          :explain    explanation
-         :reason     (reason-string (str "Subscription " sub-id)
-                                    " return value"
+         :reason     (reason-string "Subscription " sub-id
+                                    " return value failed schema "
                                     schema value)
          :recovery   :replaced-with-default})
       nil)
@@ -345,8 +353,8 @@
          :received   value
          :value      value
          :explain    explanation
-         :reason     (reason-string (str "Coeffect " cofx-id)
-                                    " injected value"
+         :reason     (reason-string "Coeffect " cofx-id
+                                    " injected value failed schema "
                                     schema value)
          :recovery   :no-recovery})
       nil)
@@ -380,8 +388,8 @@
                  :received   args
                  :value      args
                  :explain    explanation
-                 :reason     (reason-string (str "Effect " fx-id)
-                                            " args"
+                 :reason     (reason-string "Effect " fx-id
+                                            " args failed schema "
                                             schema args)
                  :recovery   :skipped}
           event-id (assoc :event-id event-id)))

--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -109,6 +109,29 @@
     (nil? v)     "nil"
     :else        (str (type v))))
 
+(defn- reason-string
+  "Build the human-readable `:reason` slot for a schema-validation
+  failure trace. Single template covering every emit-site:
+
+    - `noun-and-id`: \"Event :foo\" / \"Coeffect :db\" / \"App-db at path [:user]\".
+      The noun + id (or path) phrase that names what failed.
+    - `slot-suffix` (optional): \" payload\" / \" injected value\" /
+      \" return value\" / \" args\" — names the slot inside the
+      noun-bearer being checked. Use `nil` for app-db where the
+      noun phrase carries the full subject already.
+    - `schema`: the registered schema (Malli EDN form or other
+      validator's schema value); rendered via `pr-str` (no special-
+      casing of `[:int]` etc. — `pr-str` already reads fine).
+    - `value`: the value that failed.
+
+  Shape: \"<noun-and-id><slot-suffix> failed schema <schema>, got
+  <type-of-value>.\""
+  [noun-and-id slot-suffix schema value]
+  (str noun-and-id
+       (when slot-suffix slot-suffix)
+       " failed schema " (pr-str schema)
+       ", got " (type-of-value value) "."))
+
 (defn- run-validation
   "Shared core of the four meta-bearing validate-*! fns (event / cofx /
   fx / sub-return). Performs the registered-validator deref, the
@@ -230,16 +253,10 @@
                                        :value    val-at
                                        :frame    frame-id
                                        :explain  (validator/run-explainer schema val-at)
-                                       :reason   (str "App-db at path " path
-                                                      " failed schema " schema
-                                                      ": expected "
-                                                      (cond
-                                                        (and (vector? schema)
-                                                             (= 1 (count schema))
-                                                             (keyword? (first schema)))
-                                                        (first schema)
-                                                        :else schema)
-                                                      ", got " (type-of-value val-at) ".")
+                                       :reason   (reason-string
+                                                   (str "App-db at path " path)
+                                                   nil
+                                                   schema val-at)
                                        :recovery :no-recovery}
                                 event-id (assoc :failing-id event-id))
                    tags       (if sensitive? (redact-tags base-tags) base-tags)]
@@ -266,10 +283,9 @@
          :received   event
          :value      event
          :explain    explanation
-         :reason     (str "Event " event-id
-                          " payload failed schema "
-                          schema ", got "
-                          (type-of-value event) ".")
+         :reason     (reason-string (str "Event " event-id)
+                                    " payload"
+                                    schema event)
          :recovery   :no-recovery})
       nil)
     true))
@@ -297,10 +313,9 @@
          :received   value
          :value      value
          :explain    explanation
-         :reason     (str "Subscription " sub-id
-                          " return value failed schema "
-                          schema ", got "
-                          (type-of-value value) ".")
+         :reason     (reason-string (str "Subscription " sub-id)
+                                    " return value"
+                                    schema value)
          :recovery   :replaced-with-default})
       nil)
     true))
@@ -328,10 +343,9 @@
          :received   value
          :value      value
          :explain    explanation
-         :reason     (str "Coeffect " cofx-id
-                          " injected value failed schema "
-                          schema ", got "
-                          (type-of-value value) ".")
+         :reason     (reason-string (str "Coeffect " cofx-id)
+                                    " injected value"
+                                    schema value)
          :recovery   :no-recovery})
       nil)
     true))
@@ -364,10 +378,9 @@
                  :received   args
                  :value      args
                  :explain    explanation
-                 :reason     (str "Effect " fx-id
-                                  " args failed schema "
-                                  schema ", got "
-                                  (type-of-value args) ".")
+                 :reason     (reason-string (str "Effect " fx-id)
+                                            " args"
+                                            schema args)
                  :recovery   :skipped}
           event-id (assoc :event-id event-id)))
       ;; Extra-redact: the doubled `:fx-args` slot isn't covered by

--- a/implementation/schemas/src/re_frame/schemas/validator.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validator.cljc
@@ -50,6 +50,8 @@
   loaded the default fns soft-pass per Spec 010 §Recommended soft-pass."
   (:require [re-frame.late-bind :as late-bind]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (defn- default-malli-validate
   "The default validator — delegates to `malli.core/validate` via the
   late-bind hook `:schemas/malli-validate` published by

--- a/implementation/schemas/src/re_frame/schemas/validator.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validator.cljc
@@ -74,6 +74,13 @@
   (when-let [e (late-bind/get-fn :schemas/malli-explain)]
     (e schema value)))
 
+(defn- compare-by-pr-str
+  "Spec 010 §Digest algorithm step 1 ordering — total order on EDN
+  values via `(compare (pr-str a) (pr-str b))`. Stable across runtimes
+  because `pr-str` over EDN is a syntactic projection."
+  [a b]
+  (compare (pr-str a) (pr-str b)))
+
 (defn- canonicalise-schema-form
   "Per Spec 010 §Digest algorithm step 1 — normalise a schema EDN form for
   stable byte serialisation: metadata is stripped, and map keys are
@@ -82,21 +89,18 @@
   Sequences and vectors recurse element-wise. Non-collection values
   pass through unchanged."
   [form]
-  (letfn [(canon [x]
-            (cond
-              (map? x)
-              (into (sorted-map-by (fn [a b]
-                                     (compare (pr-str a) (pr-str b))))
-                    (map (fn [[k v]] [(canon k) (canon v)]))
-                    x)
-              (vector? x) (mapv canon x)
-              (set? x)    (into (sorted-set-by (fn [a b]
-                                                 (compare (pr-str a) (pr-str b))))
-                                (map canon)
-                                x)
-              (seq? x)    (doall (map canon x))
-              :else       x))]
-    (canon form)))
+  (cond
+    (map? form)    (into (sorted-map-by compare-by-pr-str)
+                         (map (fn [[k v]]
+                                [(canonicalise-schema-form k)
+                                 (canonicalise-schema-form v)]))
+                         form)
+    (vector? form) (mapv canonicalise-schema-form form)
+    (set? form)    (into (sorted-set-by compare-by-pr-str)
+                         (map canonicalise-schema-form)
+                         form)
+    (seq? form)    (doall (map canonicalise-schema-form form))
+    :else          form))
 
 (defn default-edn-print
   "The default schema-print companion (rf2-wla45). Per Spec 010 §Schema

--- a/implementation/schemas/src/re_frame/schemas/walker.cljc
+++ b/implementation/schemas/src/re_frame/schemas/walker.cljc
@@ -43,6 +43,8 @@
   `:rf/app-schema-meta`. Future per-slot annotations (Spec-Schemas
   reserves additional slots) compose as one-line registrations.")
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (def ^:private name-bearing-ops
   "Schema ops whose children carry name slots (the first element of a
   child entry is the slot's app-db key)."

--- a/implementation/schemas/test/re_frame/schemas/test_fixture.clj
+++ b/implementation/schemas/test/re_frame/schemas/test_fixture.clj
@@ -1,0 +1,52 @@
+(ns re-frame.schemas.test-fixture
+  "Shared `:each` reset fixture for schemas-artefact JVM tests
+  (rf2-of0hs, dup-of rf2-amco8).
+
+  Pre-extraction the same 7-12-line `reset-runtime` body was duplicated
+  across five JVM test files (`schemas_test.clj`,
+  `schemas_elision_test.clj`, `schemas_sensitive_test.clj`,
+  `schemas_sensitive_paths_test.clj`, `schemas_conformance_test.clj`).
+  Each copy reset the same registrar / frame / flows / schemas /
+  boundary-warn slate and called `(rf/init! plain-atom/adapter)`.
+  Drifting copies invited the cross-test-bleed that the per-frame
+  side-tables exist to prevent.
+
+  The canonical reset is here; test namespaces call
+  `(use-fixtures :each tf/reset-runtime)` and inherit a uniform reset
+  semantics. The deliberately narrower
+  `schemas/printer_seam_test.clj` fixture (validator-only) stays
+  separate by design.
+
+  ## What gets reset
+
+  - `(registrar/clear-all!)`
+  - `(reset! frame/frames {})`
+  - `(reset! flows/flows {})`
+  - `(reset! schemas/schemas-by-frame {})`
+  - `(schemas/reset-schema-validator!)` — restores Malli defaults
+    per rf2-froe so a test that mutates the pluggable validator
+    surface doesn't poison sibling tests.
+  - `(spec/clear-boundary-warned-handler-ids!)` — clears the
+    rf2-r2uh boundary-interceptor warn-once cache so each test
+    sees a clean suppression slate.
+  - `(rf/init! plain-atom/adapter)` — installs the schemas-artefact
+    JVM tests' standard substrate."
+  (:require [re-frame.core :as rf]
+            [re-frame.flows :as flows]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.spec :as spec]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(defn reset-runtime
+  "The canonical `:each` fixture for schemas-artefact JVM tests."
+  [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (schemas/reset-schema-validator!)
+  (spec/clear-boundary-warned-handler-ids!)
+  (rf/init! plain-atom/adapter)
+  (test-fn))

--- a/implementation/schemas/test/re_frame/schemas_bundle_probe.cljs
+++ b/implementation/schemas/test/re_frame/schemas_bundle_probe.cljs
@@ -1,0 +1,32 @@
+(ns re-frame.schemas-bundle-probe
+  "Bundle-cost probe (rf2-fqbcy) — measures the gzipped impact of
+  requiring `re-frame.schemas` WITHOUT the Malli adapter, per Spec
+  010 §Bundle cost row 2 (`[re-frame.schemas]` required, no Malli).
+
+  The companion probe `re-frame.schemas-bundle-probe-malli` requires
+  the Malli adapter on top — the difference between the two bundles
+  is the Malli surface cost.
+
+  shadow-cljs build target `:schemas-bundle-probe` compiles this ns
+  under `:advanced` + `goog.DEBUG=false`. scripts/check-schemas-bundle.cjs
+  reads the bundle's gzipped size and asserts it sits within the
+  spec envelope (≤ 100 KB per the spec's 97.2 KB row + margin).
+
+  The probe namespace does NO runtime work — it exists only to root
+  the schemas-artefact's dead-code-elimination graph so Closure
+  retains the namespace's body. Each public symbol is touched once
+  to anchor it; the exported run! fn is the bundle's entry point."
+  (:require [re-frame.core    :as rf]
+            [re-frame.schemas :as schemas]))
+
+(defn ^:export boot
+  "Bundle-probe init-fn. Touches the schemas surface so DCE retains
+  every published symbol; the probe's bundle then reflects the cost
+  every consumer that requires `re-frame.schemas` would pay.
+
+  Named `boot` (not `run!`) to avoid shadowing `cljs.core/run!`."
+  []
+  (rf/set-schema-validator! nil)
+  (schemas/reg-app-schema [:probe] [:int])
+  (schemas/app-schemas)
+  (schemas/app-schemas-digest))

--- a/implementation/schemas/test/re_frame/schemas_bundle_probe_malli.cljs
+++ b/implementation/schemas/test/re_frame/schemas_bundle_probe_malli.cljs
@@ -1,0 +1,23 @@
+(ns re-frame.schemas-bundle-probe-malli
+  "Bundle-cost probe with Malli adapter (rf2-fqbcy) — companion to
+  `re-frame.schemas-bundle-probe`. Per Spec 010 §Bundle cost row 3
+  (`[re-frame.schemas]` + `[malli.core]` required, no validation) —
+  measures the ~24 KB cost of pulling Malli into a bundle that
+  already requires the schemas surface.
+
+  shadow-cljs build target `:schemas-bundle-probe-malli` compiles
+  this ns under `:advanced` + `goog.DEBUG=false`. The accompanying
+  CI gate (scripts/check-schemas-bundle.cjs) asserts the bundle's
+  gzipped size sits within the spec envelope (≤ 125 KB per the
+  spec's 120.8 KB row + margin)."
+  (:require [re-frame.core    :as rf]
+            [re-frame.schemas :as schemas]
+            [re-frame.schemas.malli]))
+
+(defn ^:export boot
+  "Bundle-probe init-fn — see the no-Malli sibling for the rationale."
+  []
+  (rf/set-schema-validator! nil)
+  (schemas/reg-app-schema [:probe] [:int])
+  (schemas/app-schemas)
+  (schemas/app-schemas-digest))

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -80,9 +80,7 @@
             [re-frame.conformance :as conformance]
             [re-frame.core :as rf]
             [re-frame.cofx :as cofx]
-            [re-frame.flows :as flows]
             [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             ;; Per rf2-t0hq + rf2-qyfie — the Malli adapter ns must be
             ;; required at boot to publish the late-bind hook the
@@ -90,34 +88,12 @@
             ;; expects Malli-backed validation outcomes; absent the
             ;; require the validator soft-passes (no failure traces).
             [re-frame.schemas.malli]
-            [re-frame.spec :as spec]
+            [re-frame.schemas.test-fixture :as tf]
             [re-frame.subs :as subs]
             [re-frame.substrate.adapter :as substrate-adapter]
-            [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.trace :as trace]))
 
-;; ---- shared reset fixture -------------------------------------------------
-;;
-;; Same shape as `schemas_test/reset-runtime`. Per Spec 010 §Schemas as
-;; tooling, the `schemas-by-frame` slot accumulates registrations across
-;; tests; clearing between fixtures keeps each run isolated.
-
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (reset! flows/flows {})
-  (reset! schemas/schemas-by-frame {})
-  ;; Per rf2-froe — `set-schema-validator!` swaps the framework
-  ;; validator/explainer atoms; restore Malli defaults so a fixture
-  ;; that hot-swaps them does not poison sibling fixtures.
-  (schemas/reset-schema-validator!)
-  ;; Per rf2-r2uh — the boundary interceptor's warn-once cache must
-  ;; reset between tests so each fixture sees a clean suppression slate.
-  (spec/clear-boundary-warned-handler-ids!)
-  (rf/init! plain-atom/adapter)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each tf/reset-runtime)
 
 ;; ---- fixture discovery ----------------------------------------------------
 

--- a/implementation/schemas/test/re_frame/schemas_elision_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_elision_test.clj
@@ -24,23 +24,10 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.flows :as flows]
             [re-frame.schemas :as schemas]
-            [re-frame.spec :as spec]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.schemas.test-fixture :as tf]))
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (reset! flows/flows {})
-  (reset! schemas/schemas-by-frame {})
-  (schemas/reset-schema-validator!)
-  (spec/clear-boundary-warned-handler-ids!)
-  (rf/init! plain-atom/adapter)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each tf/reset-runtime)
 
 ;; ---- extract-large-paths-from-schema --------------------------------------
 

--- a/implementation/schemas/test/re_frame/schemas_elision_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_elision_test.clj
@@ -279,6 +279,56 @@
           db-in    {:count 42}]
       (is (= db-in (schemas/populate-elision-declarations db-in frame-id))))))
 
+(deftest populate-prunes-stale-schema-entry-on-flag-removal
+  (testing "re-registering a schema without :large? prunes the prior :source :schema entry (rf2-kr3vp)"
+    ;; Bug class: implementation drift from spec. Spec says
+    ;; schema-derived declarations are authoritative after re-
+    ;; registration; the prior shape only overwrote paths still
+    ;; present in the new schema, so stale `:source :schema` entries
+    ;; lingered after the flag was removed.
+    (rf/reg-app-schema [:user]
+                       [:map [:pdf {:large? true :hint "uploads"} :string]])
+    (let [frame-id (frame/current-frame)
+          db-1     (schemas/populate-elision-declarations {} frame-id)]
+      (is (= {[:user :pdf] {:large? true :source :schema :hint "uploads"}}
+             (get-in db-1 [:rf/elision :declarations]))
+          "baseline: schema-derived entry present")
+      ;; Re-register the same schema with `:large?` removed.
+      (rf/reg-app-schema [:user]
+                         [:map [:pdf :string]])
+      (let [db-2 (schemas/populate-elision-declarations db-1 frame-id)]
+        (is (= {} (get-in db-2 [:rf/elision :declarations]))
+            "after flag removal — stale schema entry pruned")))))
+
+(deftest populate-prunes-and-preserves-declared
+  (testing "pruning leaves :source :declared entries untouched (rf2-kr3vp)"
+    ;; Pruning the schema-derived subset MUST NOT collateral-damage
+    ;; user-declared paths.  The conflict rule (declared beats schema)
+    ;; still holds: an app-declared `[:rf.size/declare-large :secrets]`
+    ;; survives even when the schema set is wiped.
+    (rf/reg-app-schema [:user]
+                       [:map [:pdf {:large? true} :string]])
+    (let [frame-id (frame/current-frame)
+          db-with-declared
+          {:rf/elision
+           {:declarations
+            {[:secrets] {:large? true
+                         :source :declared
+                         :hint   "user-fx"}}}}
+          db-1 (schemas/populate-elision-declarations db-with-declared frame-id)]
+      (is (= "user-fx"
+             (get-in db-1 [:rf/elision :declarations [:secrets] :hint]))
+          "declared entry rides through populate")
+      (is (= :schema
+             (get-in db-1 [:rf/elision :declarations [:user :pdf] :source]))
+          "schema entry installed alongside the declared entry")
+      ;; Now wipe the schema set entirely (drop the registration).
+      (reset! schemas/schemas-by-frame {})
+      (let [db-2 (schemas/populate-elision-declarations db-1 frame-id)]
+        (is (= {[:secrets] {:large? true :source :declared :hint "user-fx"}}
+               (get-in db-2 [:rf/elision :declarations]))
+            "schema entry pruned; declared entry preserved")))))
+
 (deftest populate-preserves-runtime-flagged-source
   (testing "runtime-flagged entries are NEVER overwritten — schema doesn't beat runtime-flagged"
     ;; Conflict rule per Spec 009: declared > schema > runtime-flagged.

--- a/implementation/schemas/test/re_frame/schemas_sensitive_paths_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_paths_test.clj
@@ -38,23 +38,10 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.flows :as flows]
             [re-frame.schemas :as schemas]
-            [re-frame.spec :as spec]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.schemas.test-fixture :as tf]))
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (reset! flows/flows {})
-  (reset! schemas/schemas-by-frame {})
-  (schemas/reset-schema-validator!)
-  (spec/clear-boundary-warned-handler-ids!)
-  (rf/init! plain-atom/adapter)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each tf/reset-runtime)
 
 ;; ---- walker per-entry shape ----------------------------------------------
 

--- a/implementation/schemas/test/re_frame/schemas_sensitive_paths_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_paths_test.clj
@@ -206,6 +206,25 @@
           db-in    {:count 42}]
       (is (= db-in (schemas/populate-sensitive-declarations db-in frame-id))))))
 
+(deftest populate-prunes-stale-schema-entry-on-flag-removal
+  (testing "re-registering a schema without :sensitive? prunes the prior :source :schema entry (rf2-kr3vp)"
+    ;; Parallel to the :large? prune test in schemas_elision_test.clj —
+    ;; the parameterised feeder serves both flags so both paths share
+    ;; the prune-on-re-registration contract.
+    (rf/reg-app-schema [:user]
+                       [:map [:password {:sensitive? true :hint "argon2id"} :string]])
+    (let [frame-id (frame/current-frame)
+          db-1     (schemas/populate-sensitive-declarations {} frame-id)]
+      (is (= {[:user :password] {:sensitive? true :source :schema :hint "argon2id"}}
+             (get-in db-1 [:rf/elision :sensitive-declarations]))
+          "baseline: schema-derived entry present")
+      ;; Re-register the same schema with `:sensitive?` removed.
+      (rf/reg-app-schema [:user]
+                         [:map [:password :string]])
+      (let [db-2 (schemas/populate-sensitive-declarations db-1 frame-id)]
+        (is (= {} (get-in db-2 [:rf/elision :sensitive-declarations]))
+            "after flag removal — stale schema entry pruned")))))
+
 ;; ---- nested + edge-case coverage ----------------------------------------
 
 (deftest deeply-nested-sensitive

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -39,9 +39,6 @@
        `:sensitive?` stamp on the event)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.flows :as flows]
             [re-frame.schemas :as schemas]
             ;; Per rf2-t0hq + rf2-qyfie — the Malli adapter ns must be
             ;; required at boot to publish the late-bind hook the
@@ -49,20 +46,9 @@
             ;; the validator soft-passes per Spec 010 §Recommended
             ;; soft-pass.
             [re-frame.schemas.malli]
-            [re-frame.spec :as spec]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.schemas.test-fixture :as tf]))
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (reset! flows/flows {})
-  (reset! schemas/schemas-by-frame {})
-  (schemas/reset-schema-validator!)
-  (spec/clear-boundary-warned-handler-ids!)
-  (rf/init! plain-atom/adapter)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each tf/reset-runtime)
 
 ;; ---- walker unit tests ----------------------------------------------------
 

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -28,10 +28,7 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
             [re-frame.late-bind]
-            [re-frame.registrar :as registrar]
-            [re-frame.flows :as flows]
             [re-frame.interop :as interop]
             [re-frame.schemas :as schemas]
             ;; Per rf2-t0hq the default validator routes through the
@@ -42,27 +39,11 @@
             ;; opt-in on both runtimes; without it the default
             ;; validator soft-passes (Spec 010 §Recommended soft-pass).
             [re-frame.schemas.malli]
+            [re-frame.schemas.test-fixture :as tf]
             [re-frame.spec :as spec]
-            [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.trace :as trace]))
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (reset! flows/flows {})
-  (reset! schemas/schemas-by-frame {})
-  ;; Per rf2-froe — `set-schema-validator!` swaps the framework
-  ;; validator/explainer atoms; restore the Malli defaults so a test
-  ;; that mutates them does not poison sibling tests.
-  (schemas/reset-schema-validator!)
-  ;; Per rf2-r2uh — the boundary interceptor's warn-once cache for
-  ;; `:rf.warning/boundary-without-spec` must reset between tests so
-  ;; each test sees a clean suppression slate.
-  (spec/clear-boundary-warned-handler-ids!)
-  (rf/init! plain-atom/adapter)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+(use-fixtures :each tf/reset-runtime)
 
 ;; ---- elision toggle -------------------------------------------------------
 

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -49,7 +49,11 @@ const DEV_ONLY_SENTINELS = [
   // re-frame.schemas — validate-app-db! reason string.
   { source: 're-frame.schemas/validate-app-db!',
     sentinel: 'App-db at path ' },
-  // re-frame.schemas — validate-event! reason string.
+  // re-frame.schemas — validate-event! reason string. Per rf2-dz71l
+  // the distinctive per-surface slot-tail (" payload failed schema ")
+  // is pinned at the call site to the centralised `reason-string`
+  // builder — survives Closure as a single string literal inside
+  // the (if interop/debug-enabled? ...) gated branch.
   { source: 're-frame.schemas/validate-event!',
     sentinel: ' payload failed schema ' },
   // re-frame.schemas — validate-sub-return! reason string.
@@ -58,6 +62,9 @@ const DEV_ONLY_SENTINELS = [
   // re-frame.schemas — validate-cofx! reason string.
   { source: 're-frame.schemas/validate-cofx!',
     sentinel: ' injected value failed schema ' },
+  // re-frame.schemas — validate-fx! reason string.
+  { source: 're-frame.schemas/validate-fx!',
+    sentinel: ' args failed schema ' },
   // re-frame.registrar — handler-replaced trace op (only emitted from a
   // gated branch in registrar/register!).  Keywords survive :advanced
   // as string literals; this is a structural sentinel.

--- a/implementation/scripts/check-schemas-bundle.cjs
+++ b/implementation/scripts/check-schemas-bundle.cjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/*
+ * Schemas-artefact bundle-cost gate (Spec 010 §Bundle cost, bead rf2-fqbcy).
+ *
+ * Spec 010 §Bundle cost (lines 567-606) catalogues the gzipped costs
+ * of requiring `re-frame.schemas` against the baseline counter:
+ *
+ *   Baseline (no schemas, no Malli):                       91.7 KB
+ *   `[re-frame.schemas]` required, no Malli:               97.2 KB
+ *   `[re-frame.schemas]` + `[malli.core]` required:       120.8 KB
+ *   Typical app: reg-app-schema + :spec on every reg-*:   121.5 KB
+ *
+ * This gate uses two probe builds to assert the schemas surface stays
+ * within band:
+ *
+ *   schemas-bundle-probe        — schemas required, NOT Malli.
+ *                                 Asserts ≤ 100 KB gzipped (spec row 2
+ *                                 + 3 KB headroom).
+ *   schemas-bundle-probe-malli  — schemas + Malli adapter required.
+ *                                 Asserts ≤ 125 KB gzipped (spec row 3
+ *                                 + 5 KB headroom).
+ *
+ * Also asserts the Malli-on bundle is STRICTLY LARGER than the
+ * Malli-off bundle (a regression that DCE-eliminated Malli would
+ * silently turn the budget check into a vacuous "pass" — this guard
+ * keeps the methodology honest).
+ *
+ * Strategy: gzip every .js file under the bundle's output-dir and
+ * sum the compressed sizes. Mirrors the methodology used by the
+ * external bundle audit findings/malli-bundle-cost-audit.md.
+ *
+ * Exit 0 on PASS, 1 on FAIL.
+ */
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+
+const ROOT = path.resolve(__dirname, '..');
+
+// ----- the schemas bundle-cost contract -------------------------------------
+
+// Each entry's `gzippedMaxBytes` is the spec's documented figure plus a
+// small headroom (3-5 KB) so non-deterministic compression variations
+// (zlib version, OS) don't trigger spurious fails. Tighten over time as
+// the figures stabilise — every figure below was anchored against the
+// spec text rather than current empirical runs to give the gate
+// regression-detection teeth from day one.
+const BUNDLES = [
+  {
+    name:            'schemas-bundle-probe',
+    bundleDir:       path.join(ROOT, 'out', 'schemas-bundle-probe'),
+    specRow:         'row 2 — [re-frame.schemas] required, no Malli (97.2 KB)',
+    gzippedMaxBytes: 100 * 1024,   // 100 KB (spec 97.2 KB + 2.8 KB headroom)
+  },
+  {
+    name:            'schemas-bundle-probe-malli',
+    bundleDir:       path.join(ROOT, 'out', 'schemas-bundle-probe-malli'),
+    specRow:         'row 3 — [re-frame.schemas] + [malli.core] (120.8 KB)',
+    gzippedMaxBytes: 125 * 1024,   // 125 KB (spec 120.8 KB + 4.2 KB headroom)
+  },
+];
+
+// ----- helpers ---------------------------------------------------------------
+
+function listJsFiles(dir) {
+  if (!fs.existsSync(dir)) {
+    return null;
+  }
+  const out = [];
+  const walk = (d) => {
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      const full = path.join(d, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && entry.name.endsWith('.js')) {
+        out.push(full);
+      }
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+function gzippedSize(file) {
+  const raw = fs.readFileSync(file);
+  return zlib.gzipSync(raw, { level: 9 }).length;
+}
+
+function sumGzippedBytes(dir) {
+  const files = listJsFiles(dir);
+  if (files == null) {
+    return null;
+  }
+  return files.reduce((acc, f) => acc + gzippedSize(f), 0);
+}
+
+function fmtKb(bytes) {
+  return (bytes / 1024).toFixed(1) + ' KB';
+}
+
+// ----- main ------------------------------------------------------------------
+
+function main() {
+  console.log('=== Schemas bundle-cost gate (Spec 010 §Bundle cost, rf2-fqbcy) ===');
+  console.log('');
+
+  const sizes = {};
+  let bundlesOk = true;
+
+  for (const b of BUNDLES) {
+    const total = sumGzippedBytes(b.bundleDir);
+    if (total == null) {
+      console.error(`[schemas-bundle] ${b.name}: bundle dir missing — ${b.bundleDir}`);
+      console.error('              Did you run "shadow-cljs release ' +
+                    `${b.name}"?`);
+      bundlesOk = false;
+      continue;
+    }
+    sizes[b.name] = total;
+    const ok = total <= b.gzippedMaxBytes;
+    const tag = ok ? 'OK' : 'FAIL';
+    console.log(`  [${tag}] ${b.name}`);
+    console.log(`        spec:      ${b.specRow}`);
+    console.log(`        bundle:    ${fmtKb(total)} gzipped (${total} bytes)`);
+    console.log(`        threshold: ${fmtKb(b.gzippedMaxBytes)} (${b.gzippedMaxBytes} bytes)`);
+    if (!ok) {
+      bundlesOk = false;
+      console.error(`        REGRESSION: bundle exceeds threshold by ${fmtKb(total - b.gzippedMaxBytes)}`);
+    }
+  }
+
+  // Methodology guard — the Malli-on bundle MUST be strictly larger
+  // than the Malli-off bundle. If both end up the same size, Closure
+  // has DCE'd malli.core away (e.g. because the adapter ns no longer
+  // publishes the late-bind hooks at load time), and the +Malli gate
+  // becomes vacuous.
+  let methodologyOk = true;
+  if (sizes['schemas-bundle-probe'] != null &&
+      sizes['schemas-bundle-probe-malli'] != null) {
+    const probe      = sizes['schemas-bundle-probe'];
+    const probeMalli = sizes['schemas-bundle-probe-malli'];
+    const delta      = probeMalli - probe;
+    // Spec row 3 - row 2 = 23.6 KB.  Require ≥ 15 KB of growth to
+    // confirm Malli landed; below that, Closure DCE'd something.
+    const minDelta = 15 * 1024;
+    const ok = delta >= minDelta;
+    const tag = ok ? 'OK' : 'FAIL';
+    console.log('');
+    console.log(`  [${tag}] methodology guard — Malli-on bundle is strictly larger`);
+    console.log(`        delta: ${fmtKb(delta)} (${delta} bytes)`);
+    console.log(`        threshold: ≥ ${fmtKb(minDelta)} (Spec row 3 − row 2 = 23.6 KB)`);
+    if (!ok) {
+      methodologyOk = false;
+      console.error('        FAIL — Malli adapter\'s body was eliminated;');
+      console.error('        the +Malli gate is now vacuous.');
+    }
+  }
+
+  console.log('');
+  if (bundlesOk && methodologyOk) {
+    console.log('=== PASS ===');
+    process.exit(0);
+  } else {
+    console.error('=== FAIL ===');
+    console.error('');
+    console.error('Per Spec 010 §Bundle cost the schemas-artefact bundle cost');
+    console.error('budgets are normative. A regression most likely means:');
+    console.error('  - A transitive require dragged a heavy ns into the schemas');
+    console.error('    surface; check `re-frame.schemas` ns-form and downstream.');
+    console.error('  - The Malli adapter\'s ns-load body grew unexpectedly.');
+    console.error('  - shadow-cljs / Closure compiler upgraded; if the new');
+    console.error('    figures reflect a deliberate substrate change, update');
+    console.error('    the spec § first, then bump the thresholds here in');
+    console.error('    lockstep.');
+    process.exit(1);
+  }
+}
+
+main();

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -232,6 +232,38 @@
    :compiler-options {:closure-defines {goog.DEBUG true}}
    :modules          {:probe {:init-fn re-frame.elision-probe/run}}}
 
+  ;; Schemas-artefact bundle-cost probes (Spec 010 §Bundle cost, bead
+  ;; rf2-fqbcy). Two :advanced + goog.DEBUG=false builds that measure
+  ;; the gzipped impact of requiring re-frame.schemas with and
+  ;; without the Malli adapter:
+  ;;
+  ;;   :schemas-bundle-probe        — `[re-frame.schemas]` required,
+  ;;                                  Malli adapter NOT required.
+  ;;                                  Pulls only the schemas surface
+  ;;                                  (~5.6 KB over baseline per the
+  ;;                                  spec's row 2).
+  ;;   :schemas-bundle-probe-malli  — schemas + Malli adapter required.
+  ;;                                  Pulls malli.core's ~24 KB body
+  ;;                                  on top (spec row 3 — 120.8 KB).
+  ;;
+  ;; The probe namespaces sit under schemas/test/ so they're not
+  ;; shipped in the published jar.  scripts/check-schemas-bundle.cjs
+  ;; reads both bundles' gzipped sizes and asserts each is within
+  ;; the spec envelope; regressions of >5 KB fail CI.
+  :schemas-bundle-probe
+  {:target           :browser
+   :output-dir       "out/schemas-bundle-probe"
+   :asset-path       "/schemas-bundle-probe"
+   :compiler-options {:closure-defines {goog.DEBUG false}}
+   :modules          {:probe {:init-fn re-frame.schemas-bundle-probe/boot}}}
+
+  :schemas-bundle-probe-malli
+  {:target           :browser
+   :output-dir       "out/schemas-bundle-probe-malli"
+   :asset-path       "/schemas-bundle-probe-malli"
+   :compiler-options {:closure-defines {goog.DEBUG false}}
+   :modules          {:probe {:init-fn re-frame.schemas-bundle-probe-malli/boot}}}
+
   ;; ============================================================================
   ;; Example apps (rf2-lyj0).
   ;;

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -485,13 +485,13 @@ This recommendation is normative-soft: ports that ship a different default-absen
 
 ### Locked rules
 
-- **One validator fn per frame** is in effect at any time. Last-write-wins on re-registration; tools warn if the source coords differ between registrations (same form re-register is benign hot-reload).
+- **One validator fn per process** is in effect at any time. Last-write-wins on re-registration. The validator is _for the schema language_, not per-app-instance — Malli, Zod, or a custom validator is a process-global choice.
 - **The validator fn is pure** — same `(schema, value)` returns the same result. Implementations may memoise but tests must not depend on memoisation.
 - **The validator fn must be production-elidable** alongside the host's debug-enabled flag (`re-frame.interop/debug-enabled?` on CLJS; the equivalent on other ports) — calls to it disappear in prod builds (subject to the boundary-validation override per [§Production builds](#production-builds)).
 - **Schema digests** ([§Schema digest](#schema-digest)) are computed from the schema **values** as serialised by the registered validator's `schema-print` companion fn (see [§Schema digest](#schema-digest)) — not from the validator. Two ports using different validators against the same schema-language-EDN-form produce the same digest iff their `schema-print` fns produce identical bytes; two ports using *different* schema languages produce different digests by construction.
 - **`nil` validator means no validation, not "every value fails"**. Setting validator to nil is the documented opt-out — every `validate-*!` site short-circuits to `true` (pass). The schemas mandate stays unchanged at the framework level (apps still attach `:spec` and `reg-app-schema`); only the runtime check is disabled.
 
-What the extension point does NOT cover: a *mix* of validators within one frame. The runtime resolves one validator and uses it for every `:spec` in the frame; a hybrid setup (one schema language for app schemas, a different one for boundary handlers) requires the user to register a *composite* validator that dispatches internally on schema shape.
+What the extension point does NOT cover: a *mix* of validators in one process. The runtime resolves one validator and uses it for every `:spec` everywhere; a hybrid setup (one schema language for app schemas, a different one for boundary handlers) requires the user to register a *composite* validator that dispatches internally on schema shape.
 
 ### Opting in to Malli validation on CLJS (rf2-t0hq)
 

--- a/spec/conformance/fixtures/error-schema-failure.edn
+++ b/spec/conformance/fixtures/error-schema-failure.edn
@@ -44,5 +44,5 @@
                 :where      :app-db
                 :path       [:count]
                 :value      "not-a-number"
-                :reason     "App-db at path [:count] failed schema [:int]: expected :int, got string."}
+                :reason     "App-db at path [:count] failed schema [:int], got string."}
     :recovery  :no-recovery}]}}                      ;; dev default; prod uses :replaced-with-default


### PR DESCRIPTION
## Summary

Fifth batched-by-surface dispatch. Tackles 9 P2 polish/fix beads from
the rf2-whepe round-2 audit + alignment audit follow-ons against the
schemas artefact. One bead pair (`rf2-of0hs` + `rf2-amco8`) confirmed
duplicate and unified.

### Commit-by-bead map

| Commit | Bead | Title |
|---|---|---|
| 2f8cc14a | rf2-gt3ab | spec(010): align §Locked rules to process-global validator |
| 0d5b12fd | rf2-8mfz2 | refactor(schemas): change run-validation sensitive? contract from fn to boolean |
| 9a8c36f4 | rf2-dz71l | refactor(schemas): centralise :reason string template across five validate-*! sites |
| be56f04d | rf2-zo8gu | refactor(schemas): add (set! *warn-on-reflection* true) to all 7 leaf files |
| 71293091 | rf2-kr3vp | fix(schemas): prune stale schema-derived elision declarations on re-registration |
| 2612d361 | rf2-of0hs (+rf2-amco8 dup) | refactor(schemas): extract shared reset-runtime test fixture |
| 03b1cfcb | rf2-jysrz | refactor(schemas): polish cluster — canonicaliser + ns-form |
| 5570dceb | rf2-fqbcy | refactor(schemas): add bundle-cost CI gate per Spec 010 §Bundle cost |
| 3b4f40fb | rf2-dz71l fixup | fix(schemas): pin per-surface slot-tail literals for elision probe |

### Strategy assessment

**Hot-file sequencing worked.** validate.cljc was the centrepiece —
data-shape changes (rf2-8mfz2 sensitive? boolean, rf2-dz71l reason
template) landed before structural moves (rf2-of0hs fixture
extraction). The dz71l elision-probe fixup surfaced the day-of: the
first take of `reason-string` split distinctive substrings across
args, defeating Closure's literal-detection grep. Pinning the
`slot-tail` as a single string per call site fixed both surfaces
in one commit.

**Cross-bead unifications.** rf2-of0hs + rf2-amco8 confirmed as
duplicates — both proposed extracting the same `reset-runtime`
fixture; of0hs covered 5 files, amco8 only 4 (missing the
conformance test). Unified into one extraction; closing amco8 as
duplicate.

**New CI gate (rf2-fqbcy).** Two probe builds + check script
+ npm script + pinned thresholds against Spec 010 §Bundle cost
budgets. Methodology guard asserts Malli-on bundle is strictly
larger than Malli-off (≥ 15 KB delta) so a future DCE regression
of malli.core can't make the gate vacuous.

### Quality gates

- `cd implementation/schemas && clojure -M:test` — 136 tests / 390 assertions, all pass.
- `cd implementation && npm run test:cljs` — 1816 tests / 5040 assertions, all pass.
- `cd implementation && npm run test:elision` — PASS (sentinels updated per rf2-dz71l fixup).
- `cd implementation && npm run test:schemas-bundle` — PASS (the new gate, 50.3 KB / 80.1 KB gzipped).

### Test plan

- [x] Schemas JVM tests (`clojure -M:test`) green.
- [x] CLJS node tests (`npm run test:cljs`) green.
- [x] Elision probe (`npm run test:elision`) green — verifies validate-*! dev-gate sentinels DCE under :advanced + goog.DEBUG=false.
- [x] New `npm run test:schemas-bundle` gate green.