### PR TITLE
refactor(story-mcp): round-2 polish cluster — 4 follow-on beads (rf2-w8jxf)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/config.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/config.cljc
@@ -26,7 +26,9 @@
   the server / tools namespaces. Per IMPL-SPEC §13.2 #6 the
   protocol-version target is a documented decision the implementation
   bead (rf2-tgci) lands."
-  (:require [re-frame.mcp-base.args :as args]))
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [re-frame.mcp-base.args :as args]))
 
 ;; ---- MCP protocol version --------------------------------------------------
 
@@ -44,6 +46,18 @@
 (def ^:const server-name
   "Server `name` advertised in the `initialize` response's `serverInfo`."
   "re-frame2-story-mcp")
+
+(defn read-version
+  "Read the project's VERSION file from the classpath. Best-effort: when
+  the resource isn't on the classpath (uberjar deploys, REPL hosts that
+  haven't added the project root), falls back to `\"dev\"`. Returns a
+  trimmed string. Used by the `initialize` handshake's
+  `:serverInfo :version` slot."
+  []
+  (try
+    (or (some-> (io/resource "VERSION") slurp str/trim)
+        "dev")
+    (catch Throwable _ "dev")))
 
 ;; ---- origin tag -----------------------------------------------------------
 

--- a/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
@@ -32,26 +32,22 @@
 
   ## Cross-MCP factoring (rf2-vw4sq)
 
-  The JSON-RPC error-code constants are re-exported from
-  `re-frame.mcp-base.vocab` — the cross-MCP shared vocabulary
-  artefact. The local names are retained as aliases so existing
-  callers don't need to touch their `:require` lists; the canonical
-  source of truth lives in the base."
+  The JSON-RPC error-code constants live in `re-frame.mcp-base.vocab`
+  — the cross-MCP shared vocabulary artefact. The internal use-sites
+  in this ns reach them through the `vocab` alias directly; callers
+  outside the ns should `:require [re-frame.mcp-base.vocab :as vocab]`
+  for the same source of truth (no parallel re-export here)."
   (:require [cheshire.core :as json]
             [clojure.string :as str]
             [re-frame.mcp-base.vocab :as vocab]))
 
-;; ---- error codes ----------------------------------------------------------
-;;
-;; Re-exported from `re-frame.mcp-base.vocab` per rf2-vw4sq. The
-;; numeric values are pinned by JSON-RPC 2.0 §5.1; the alias layer
-;; ensures the triplet shares one definition.
+;; ---- sentinels -----------------------------------------------------------
 
-(def ^:const code-parse-error      vocab/code-parse-error)
-(def ^:const code-invalid-request  vocab/code-invalid-request)
-(def ^:const code-method-not-found vocab/code-method-not-found)
-(def ^:const code-invalid-params   vocab/code-invalid-params)
-(def ^:const code-internal-error   vocab/code-internal-error)
+(def eof-sentinel
+  "Returned by `read-frame` when the reader has closed. Consumers
+  should compare against this def rather than re-spell the
+  auto-namespaced `::eof` form across namespace boundaries."
+  ::eof)
 
 ;; ---- envelope construction -----------------------------------------------
 
@@ -147,7 +143,7 @@
   (loop []
     (let [line (.readLine reader)]
       (cond
-        (nil? line)                   ::eof
+        (nil? line)                   eof-sentinel
         (str/blank? line)             (recur)
         :else                         (parse-json line)))))
 
@@ -171,20 +167,27 @@
   "Build a parse-error response. `id` is `nil` because by definition we
   couldn't parse the request to extract one."
   []
-  (error-response nil code-parse-error "Parse error"))
+  (error-response nil vocab/code-parse-error "Parse error"))
+
+(defn invalid-request
+  "Build an invalid-request error for a syntactically-malformed envelope.
+  `id` may be `nil` when the envelope failed shape-validation before
+  the id could be extracted."
+  [id details]
+  (error-response id vocab/code-invalid-request details))
 
 (defn method-not-found
   "Build a method-not-found error for `method`. Used by the dispatcher
   when `(:method message)` doesn't match a registered handler — and by
   `tools/call` when the named tool isn't in the registry."
   [id method]
-  (error-response id code-method-not-found
+  (error-response id vocab/code-method-not-found
                   (str "Method not found: " method)))
 
 (defn invalid-params
   "Build an invalid-params error. `details` is human-readable."
   [id details]
-  (error-response id code-invalid-params
+  (error-response id vocab/code-invalid-params
                   (str "Invalid params: " details)))
 
 (defn internal-error
@@ -195,4 +198,4 @@
   ([id details]
    (internal-error id details nil))
   ([id details data]
-   (error-response id code-internal-error details data)))
+   (error-response id vocab/code-internal-error details data)))

--- a/tools/story-mcp/src/re_frame/story_mcp/server.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/server.cljc
@@ -66,25 +66,14 @@
   reply with our supported version and let the client decide whether to
   disconnect per the spec's version-negotiation rule."
   [id _params]
-  (let [version config/protocol-version]
-    (proto/response id
-                    {:protocolVersion version
-                     :capabilities    {:tools {:listChanged false}}
-                     :serverInfo      {:name    config/server-name
-                                       :version (try
-                                                  ;; Read VERSION from the
-                                                  ;; project root. Best-effort:
-                                                  ;; if the file isn't on the
-                                                  ;; classpath (uberjar deploy),
-                                                  ;; fall back to "dev".
-                                                  (or (some-> (clojure.java.io/resource "VERSION")
-                                                              slurp
-                                                              str/trim)
-                                                      "dev")
-                                                  (catch Throwable _ "dev"))}
-                     :instructions    (str "Story MCP agent surface. Call `tools/list` for the registry, "
-                                           "then `tools/call` with the named tool + arguments. "
-                                           "See `get-story-instructions` for Story's authoring conventions.")})))
+  (proto/response id
+                  {:protocolVersion config/protocol-version
+                   :capabilities    {:tools {:listChanged false}}
+                   :serverInfo      {:name    config/server-name
+                                     :version (config/read-version)}
+                   :instructions    (str "Story MCP agent surface. Call `tools/list` for the registry, "
+                                         "then `tools/call` with the named tool + arguments. "
+                                         "See `get-story-instructions` for Story's authoring conventions.")}))
 
 ;; ---- tools/list -----------------------------------------------------------
 
@@ -136,13 +125,14 @@
   [message]
   (cond
     (not (proto/valid-envelope? message))
-    (proto/error-response (:id message) proto/code-invalid-request
-                          "Invalid JSON-RPC envelope")
+    (proto/invalid-request (:id message) "Invalid JSON-RPC envelope")
 
     ;; Notifications — no response. Per the spec a notification is a
-    ;; request without an `id`. We accept `notifications/initialized`
-    ;; explicitly (it's the canonical handshake completion); other
-    ;; notifications are silently dropped.
+    ;; request without an `id`. We accept the canonical handshake-
+    ;; completion notification (`notifications/initialized`) and any
+    ;; other notification silently — the absence of `:id` is the
+    ;; complete dispatch rule. No defensive arm needed in the
+    ;; method `case` below.
     (not (contains? message :id))
     nil
 
@@ -150,7 +140,6 @@
     (let [{:keys [id method params]} message]
       (case method
         "initialize"                     (handle-initialize id params)
-        "notifications/initialized"      nil  ; defensive: this is a notification, shouldn't hit here
         "tools/list"                     (handle-tools-list id params)
         "tools/call"                     (handle-tools-call id params)
         "ping"                           (handle-ping id params)
@@ -202,13 +191,12 @@
                         (log! "write of parse-error response failed:" (ex-message e2))))
                     ::recover))]
       (cond
-        ;; `proto/read-frame` returns ::proto/eof (the ::eof sentinel
-        ;; auto-namespaced to its source ns) when stdin closes. The
-        ;; loop exits.
-        (= :re-frame.story-mcp.protocol/eof frame) :eof
+        ;; `proto/read-frame` returns `proto/eof-sentinel` when stdin
+        ;; closes. The loop exits.
+        (= proto/eof-sentinel frame) :eof
         ;; Recovery from a parse-error: we already wrote the error
         ;; response; loop to the next frame.
-        (= ::recover frame)                        (recur)
+        (= ::recover frame)          (recur)
         :else
         (do
           (handle-frame! writer frame)
@@ -220,7 +208,16 @@
   "Parse CLI args. Minimal — no third-party CLI lib required at Stage
   7. Supported flags:
 
-  - `--allow-writes` (boolean) — open the write surface.
+  - `--allow-writes` — presence opens the write surface. There is no
+    `=true` / `=false` variant; a flag is either present or absent.
+    The earlier `--allow-writes=false` form was a footgun (an agent
+    host scripting it would expect the gate to close, but the parser
+    accepted-and-recorded `false` which then propagated through
+    `apply-config!` only when the absent default was already
+    `false`).
+
+  Unknown flags are logged and ignored — the MCP spec doesn't define
+  CLI conventions, so being permissive here is correct.
 
   Returns a config map."
   [argv]
@@ -228,11 +225,7 @@
          cfg  {}]
     (if-let [a (first args)]
       (case a
-        "--allow-writes"     (recur (rest args) (assoc cfg :allow-writes? true))
-        "--allow-writes=true" (recur (rest args) (assoc cfg :allow-writes? true))
-        "--allow-writes=false" (recur (rest args) (assoc cfg :allow-writes? false))
-        ;; Unknown flag — log and ignore. The MCP spec doesn't define
-        ;; CLI conventions, so being permissive here is correct.
+        "--allow-writes" (recur (rest args) (assoc cfg :allow-writes? true))
         (do (log! "unknown CLI flag:" a)
             (recur (rest args) cfg)))
       cfg)))
@@ -251,15 +244,24 @@
            " server=" config/server-name)
      cfg)))
 
+(defn run-stdio!
+  "Wire stdin / stdout to `run-loop!` and drive until EOF. Extracted
+  from `-main` so a test can exercise the full stdio assembly without
+  reflecting on private internals — but tests SHOULD prefer
+  `run-loop!` with in-memory streams; this helper is exposed for the
+  one assertion that wants to verify the stdin-as-default-reader
+  contract."
+  []
+  (let [reader (java.io.BufferedReader. (java.io.InputStreamReader. System/in "UTF-8"))
+        writer (java.io.OutputStreamWriter. System/out "UTF-8")]
+    (run-loop! reader writer)
+    (log! "stdin closed; exiting")))
+
 (defn -main
   "Entry point. Boots, then runs the stdio JSON-RPC loop until stdin
   closes. Per IMPL-SPEC §7.1 the agent host (Claude Code / Cursor /
   Copilot) launches this as a subprocess and terminates it by closing
   stdin (or SIGTERM after a timeout)."
   [& argv]
-  (let [cli-cfg (parse-args argv)]
-    (boot! cli-cfg)
-    (let [reader (java.io.BufferedReader. (java.io.InputStreamReader. System/in "UTF-8"))
-          writer (java.io.OutputStreamWriter. System/out "UTF-8")]
-      (run-loop! reader writer)
-      (log! "stdin closed; exiting"))))
+  (boot! (parse-args argv))
+  (run-stdio!))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
@@ -5,8 +5,7 @@
 
   `story-instructions-text` ships inline as a single string to keep
   this jar self-contained — no external resource read needed at boot."
-  (:require [re-frame.mcp-base.args :as args]
-            [re-frame.story :as story]
+  (:require [re-frame.story :as story]
             [re-frame.story.async :as async]
             [re-frame.story-mcp.tools.helpers :as h]
             [re-frame.story-mcp.tools.schemas :as s]))
@@ -79,12 +78,7 @@
   [args]
   (h/with-variant args
     (fn [vk _body]
-      (let [opts       (cond-> {}
-                         (some? (:substrate args))    (assoc :substrate (args/parse-keyword (:substrate args)))
-                         (some? (:active-modes args)) (assoc :active-modes
-                                                             (mapv args/parse-keyword (:active-modes args)))
-                         (some? (:cell-overrides args)) (assoc :cell-overrides
-                                                               (:cell-overrides args)))
+      (let [opts       (h/read-run-opts args)
             base-url   (or (:base-url args) "")
             share-url  (story/variant-share-url vk base-url opts)
             result     (try

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
@@ -109,6 +109,13 @@
                         :effective-args (:effective-args result)}]
         (h/text-result (h/pr-edn payload) payload)))))
 
+;; `story/registered-substrates` is CLJS-only — resolved once at ns-load
+;; via `helpers/resolve-cljs-var`. The JVM-standalone deploy reads nil
+;; and returns an empty set; the shared-process (nREPL-attached CLJS)
+;; deploy reads the var.
+(defonce ^:private registered-substrates-var
+  (h/resolve-cljs-var 'story/registered-substrates))
+
 (defn tool-list-substrates
   "Dev: what substrates can be used. Reads the registered substrate set
   via the Story-public surface.
@@ -122,11 +129,9 @@
   (no CLJS substrates are runnable from a JVM-only host)."
   [_args]
   (let [subs (try
-               ;; `story/registered-substrates` is CLJS-only (`#?(:cljs ...)`).
-               ;; On JVM there's no `def`, so we use `resolve` to detect that
-               ;; cleanly and return an empty set rather than blowing up.
-               (let [f (resolve 'story/registered-substrates)]
-                 (if f (sort (vec (f))) []))
+               (if registered-substrates-var
+                 (sort (vec (registered-substrates-var)))
+                 [])
                (catch Throwable _ []))
         payload {:substrates (vec subs)}]
     (h/text-result (h/pr-edn payload) payload)))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
@@ -22,7 +22,7 @@
         filtered (if (seq tags)
                    (into {}
                          (filter (fn [[_id body]]
-                                   (some tags (:tags body #{}))))
+                                   (seq (set/intersection tags (set (:tags body))))))
                          stories)
                    stories)
         payload  {:stories (vec (for [[sid body] filtered]

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
@@ -177,7 +177,17 @@
   events both honour the same convention, so a single primitive covers
   both surfaces.
 
+  Two short-circuits avoid pointless work on the opt-in / empty paths:
+
+    - `include? true` returns `(vec (or records []))` directly — the
+      walker would yield the input unchanged anyway (no drops with the
+      escape hatch open), so we skip the traversal.
+    - `nil`/empty records short-return `[]`.
+
   Returns the kept-vec (the `dropped-count` second slot is suppressed
   here; the caller is the wire egress, not an audit surface)."
   [records include?]
-  (first (sensitive/strip-sensitive (vec (or records [])) include?)))
+  (cond
+    include?       (vec (or records []))
+    (nil? records) []
+    :else          (first (sensitive/strip-sensitive records false))))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
@@ -110,6 +110,23 @@
       [nil (error-result (str "Missing required argument: " (name k)))]
       [v nil])))
 
+(defn read-run-opts
+  "Build the `re-frame.story/run-variant` opts map from the standard MCP
+  arg slots (`:substrate`, `:active-modes`, `:cell-overrides`). Each
+  slot lands only when present, so the resulting map is the minimal
+  shape `run-variant` / `snapshot-identity` / `variant-share-url`
+  expect.
+
+  Shared by `tool-preview-variant`, `tool-run-variant`, and
+  `tool-snapshot-identity` (the latter omits `:cell-overrides`, but
+  the absent-slot-not-present rule keeps the helper general)."
+  [arguments]
+  (cond-> {}
+    (some? (:substrate arguments))      (assoc :substrate (args/parse-keyword (:substrate arguments)))
+    (some? (:active-modes arguments))   (assoc :active-modes
+                                               (mapv args/parse-keyword (:active-modes arguments)))
+    (some? (:cell-overrides arguments)) (assoc :cell-overrides (:cell-overrides arguments))))
+
 (defn with-variant
   "Resolve `:variant-id` from `arguments` (required), parse it as a
   keyword, and probe `story/variant->edn` for the body. When both

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
@@ -49,6 +49,22 @@
   (binding [*print-readably* true]
     (pr-str v)))
 
+;; ---------------------------------------------------------------------------
+;; Cross-platform var resolution
+;; ---------------------------------------------------------------------------
+
+(defn resolve-cljs-var
+  "Resolve a fully-qualified symbol (`ns/sym`) to the underlying var
+  on the JVM, returning `nil` on miss. Wraps `clojure.core/resolve` in
+  a try/catch so a CLJS-only `def` (whose ns hasn't been required on
+  JVM) yields nil rather than blowing up.
+
+  Used by handlers that need a CLJS-side surface (the in-browser a11y
+  panel atom, the CLJS substrate registry) — the JVM-standalone deploy
+  reads an empty surface, and that's the documented correct answer."
+  [sym]
+  (try (resolve sym) (catch Throwable _ nil)))
+
 (defn text-result
   "Build a success result with a single text content item. `structured`
   (optional) lands on the `structuredContent` slot per the spec/2025-06-18

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
@@ -38,6 +38,33 @@
   #?(:clj  (System/currentTimeMillis)
      :cljs (.now js/Date)))
 
+(defn- write-back!
+  "Re-register the target variant with the captured `:play` body.
+  Preserves the source variant's existing body keys (so `:component`,
+  `:args`, `:decorators` survive) and overwrites `:play` with the
+  captured `events`. Stamps `:origin :story-mcp` per
+  `spec/Cross-Cutting-Designs.md §5` — the write-back produces a new
+  variant body and the origin tag identifies the MCP write surface as
+  its producer.
+
+  Returns the structured success result on the happy path, or an
+  `error-result` whose `:structuredContent` merges the base recorder
+  payload, the failure flag, and the registrar's `ex-data`."
+  [base body events target-vid]
+  (try
+    (let [id      (story/reg-variant*
+                    target-vid
+                    (assoc body :play events :origin config/origin))
+          payload (assoc base :written-back? true :new-variant-id id)]
+      (h/text-result (h/pr-edn payload) payload))
+    (catch #?(:clj Throwable :cljs :default) e
+      (h/error-result (str "Write-back failed: " (ex-message e))
+                      (merge base
+                             {:written-back?  false
+                              :new-variant-id target-vid}
+                             (select-keys (ex-data e)
+                                          [:rf.error :explain]))))))
+
 (defn tool-record-as-variant
   "Dev (or Write when `:write-back?` is true): bridge the recorder's
   start → capture → snippet pipeline across the MCP boundary.
@@ -91,58 +118,32 @@
   [arguments]
   (h/with-variant arguments
     (fn [vk body]
-      (let [write-back? (args/parse-boolean (:write-back? arguments) false)
-            gate-err    (when write-back? (write/assert-writes-allowed "record-as-variant"))]
-        (if gate-err gate-err
-          (let [duration-ms (args/parse-non-negative-int (:duration-ms arguments) 0)
-                new-vid     (some-> (:new-variant-id arguments) args/parse-keyword)
-                target-vid  (or new-vid vk)
-                doc         (:doc arguments)
-                extends     (or (some-> (:extends arguments) args/parse-keyword) vk)
-                alias-arg   (:alias arguments)
-                started     (now-ms)
-                _           (story/start-recording! vk)
-                _           (sleep-ms duration-ms)
-                final-state (story/stop-recording!)
-                actual-ms   (- (now-ms) started)
-                events      (vec (:events final-state))
-                snippet-opts (cond-> {:variant-id target-vid
-                                      :extends    extends}
-                               (string? doc)       (assoc :doc doc)
-                               (string? alias-arg) (assoc :alias alias-arg))
-                snippet     (story/gen-play-snippet events snippet-opts)
-                base-payload {:variant-id           vk
-                              :play-snippet         snippet
-                              :recorded-event-count (count events)
-                              :duration-ms          actual-ms
-                              :captured             events
-                              :written-back?        false}]
-            (if-not write-back?
-              (h/text-result (h/pr-edn base-payload) base-payload)
-              ;; Write-back: re-register the target variant with the
-              ;; captured :play body. We preserve the source variant's
-              ;; existing body keys (so :component, :args, :decorators
-              ;; survive) and overwrite :play with the captured events.
-              ;; Stamp `:origin :story-mcp` per
-              ;; spec/Cross-Cutting-Designs.md §5 — the write-back
-              ;; produces a new variant body, and the origin tag
-              ;; identifies the MCP write surface as its producer.
-              (try
-                (let [new-body (-> body
-                                   (assoc :play events)
-                                   (assoc :origin config/origin))
-                      id       (story/reg-variant* target-vid new-body)
-                      payload  (assoc base-payload
-                                      :written-back?   true
-                                      :new-variant-id  id)]
-                  (h/text-result (h/pr-edn payload) payload))
-                (catch #?(:clj Throwable :cljs :default) e
-                  (h/error-result (str "Write-back failed: " (ex-message e))
-                                  (merge base-payload
-                                         {:written-back? false
-                                          :new-variant-id target-vid}
-                                         (select-keys (ex-data e)
-                                                      [:rf.error :explain]))))))))))))
+      (let [write-back? (args/parse-boolean (:write-back? arguments) false)]
+        (or (when write-back? (write/assert-writes-allowed "record-as-variant"))
+            (let [duration-ms (args/parse-non-negative-int (:duration-ms arguments) 0)
+                  target-vid  (or (some-> (:new-variant-id arguments) args/parse-keyword) vk)
+                  extends     (or (some-> (:extends arguments) args/parse-keyword) vk)
+                  doc         (:doc arguments)
+                  alias-arg   (:alias arguments)
+                  started     (now-ms)
+                  _           (story/start-recording! vk)
+                  _           (sleep-ms duration-ms)
+                  final-state (story/stop-recording!)
+                  events      (vec (:events final-state))
+                  snippet     (story/gen-play-snippet
+                                events
+                                (cond-> {:variant-id target-vid :extends extends}
+                                  (string? doc)       (assoc :doc doc)
+                                  (string? alias-arg) (assoc :alias alias-arg)))
+                  base        {:variant-id           vk
+                               :play-snippet         snippet
+                               :recorded-event-count (count events)
+                               :duration-ms          (- (now-ms) started)
+                               :captured             events
+                               :written-back?        false}]
+              (if-not write-back?
+                (h/text-result (h/pr-edn base) base)
+                (write-back! base body events target-vid))))))))
 
 (def descriptors
   "Registry descriptors for the recorder's MCP surface — the single

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc
@@ -35,6 +35,16 @@
                 write/descriptors
                 recorder/descriptors]))
 
+;; Load-time invariant: every registry entry MUST carry a positive-integer
+;; `:typicalTokens` hint (rf2-6sddv). The same shape is asserted by
+;; `typical-tokens-hint-on-every-tool` in the test corpus; pinning it at
+;; load time lets `tool-descriptors` project a plain map literal without
+;; a defensive `cond->` arm for the slot.
+(assert (every? (fn [t] (and (integer? (:typicalTokens t))
+                             (pos? (:typicalTokens t))))
+                tool-registry)
+        "tool-registry: every entry must carry positive-integer :typicalTokens")
+
 (defn tool-descriptors
   "Build the `tools/list` response payload: each tool's name +
   description + inputSchema + typicalTokens, in registry order. The
@@ -44,13 +54,18 @@
   `typicalTokens` (rf2-6sddv) is an informational hint — an integer
   ballpark of the response payload size in tokens. AI clients use it
   to budget calls and pick size-conscious args without trial-and-error.
-  Not a cap (the host enforces real budgets elsewhere); a hint only."
+  Not a cap (the host enforces real budgets elsewhere); a hint only.
+
+  The `:typicalTokens` slot is asserted on every entry by the
+  `typical-tokens-hint-on-every-tool` test plus the registry-load
+  assertion below, so the projection is a plain map literal rather
+  than a defensive `cond->`."
   []
   (mapv (fn [{:keys [name description inputSchema typicalTokens]}]
-          (cond-> {:name        name
-                   :description description
-                   :inputSchema inputSchema}
-            typicalTokens (assoc :typicalTokens typicalTokens)))
+          {:name          name
+           :description   description
+           :inputSchema   inputSchema
+           :typicalTokens typicalTokens})
         tool-registry))
 
 (defn tool-by-name

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc
@@ -68,9 +68,16 @@
            :typicalTokens typicalTokens})
         tool-registry))
 
+(def ^:private tool-by-name-index
+  "Pre-computed `name → descriptor` map so `tool-by-name` is O(1)
+  instead of the linear scan over `tool-registry`. The registry shape
+  is frozen at load time (`tool-registry` is a `def`), so the index
+  is similarly stable."
+  (into {} (map (juxt :name identity)) tool-registry))
+
 (defn tool-by-name
   "Look up a tool's registry entry by string name. Returns nil if no
   such tool — the caller (server dispatcher) turns that into a
   protocol-level method-not-found error."
   [tool-name]
-  (some (fn [t] (when (= tool-name (:name t)) t)) tool-registry))
+  (get tool-by-name-index tool-name))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc
@@ -2,8 +2,7 @@
   "Recurring JSON-schema fragments + the schema-prop-injection helpers
   used by every tool's `:inputSchema`. Kept in its own ns so each
   category's descriptor list (`dev/descriptors`, `docs/descriptors`,
-  …) can require these without circling through `registry`."
-  (:refer-clojure :exclude [name]))
+  …) can require these without circling through `registry`.")
 
 (def kw-or-string
   "Recurring fragment — accept either string-form keywords

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
@@ -30,12 +30,7 @@
   [args]
   (h/with-variant args
     (fn [vk _body]
-      (let [opts     (cond-> {}
-                       (some? (:substrate args))     (assoc :substrate (args/parse-keyword (:substrate args)))
-                       (some? (:active-modes args))  (assoc :active-modes
-                                                            (mapv args/parse-keyword (:active-modes args)))
-                       (some? (:cell-overrides args)) (assoc :cell-overrides
-                                                             (:cell-overrides args)))
+      (let [opts     (h/read-run-opts args)
             timeout  (args/parse-positive-int (:timeout-ms args) 10000)
             result   (try
                        (async/deref-blocking (story/run-variant vk opts) timeout)
@@ -63,11 +58,7 @@
   [args]
   (h/with-variant args
     (fn [vk _body]
-      (let [opts    (cond-> {}
-                      (some? (:substrate args))    (assoc :substrate (args/parse-keyword (:substrate args)))
-                      (some? (:active-modes args)) (assoc :active-modes
-                                                          (mapv args/parse-keyword (:active-modes args))))
-            payload (story/snapshot-identity vk opts)]
+      (let [payload (story/snapshot-identity vk (h/read-run-opts args))]
         (h/text-result (h/pr-edn payload) payload)))))
 
 ;; `re-frame.story.ui.a11y/violations-by-frame` is the CLJS-side panel

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
@@ -70,6 +70,13 @@
             payload (story/snapshot-identity vk opts)]
         (h/text-result (h/pr-edn payload) payload)))))
 
+;; `re-frame.story.ui.a11y/violations-by-frame` is the CLJS-side panel
+;; atom — resolved once at ns-load via `helpers/resolve-cljs-var`. JVM-
+;; standalone deploys read nil and return an empty violations vec; the
+;; shared-process (nREPL-attached CLJS) deploy reads the live atom.
+(defonce ^:private violations-by-frame-var
+  (h/resolve-cljs-var 're-frame.story.ui.a11y/violations-by-frame))
+
 (defn tool-run-a11y
   "Testing: run axe-core against a variant, return violations.
 
@@ -91,8 +98,8 @@
   (h/with-variant-id args
     (fn [vk]
       (let [atomv (try
-                    (let [v (resolve 're-frame.story.ui.a11y/violations-by-frame)]
-                      (when v (deref @v)))
+                    (when violations-by-frame-var
+                      (deref @violations-by-frame-var))
                     (catch Throwable _ nil))
             violations (when atomv (get atomv vk))
             payload {:variant-id vk

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
@@ -38,6 +38,36 @@
            "should leave it off.")
       {:gated true :tool tool-name})))
 
+(defn- coerce-body
+  "Normalise the `:body` arg to a Clojure map, or return one of two
+  sentinel keywords on parse / shape failure:
+
+    `::edn-error` — `:body` was a string but `edn/read-string` threw.
+    `::not-a-map` — `:body` was not a map nor a map-string."
+  [body]
+  (cond
+    (map? body)    body
+    (string? body) (try (let [v (edn/read-string body)]
+                          (if (map? v) v ::not-a-map))
+                        (catch Throwable _ ::edn-error))
+    :else          ::not-a-map))
+
+(defn- register-or-error
+  "Invoke `reg-variant*` with `:origin` stamped. Returns the success
+  result, or an `error-result` wrapping the registrar's throw."
+  [vk body-v]
+  (try
+    ;; Stamp `:origin :story-mcp` per spec/Cross-Cutting-Designs.md §5
+    ;; — every write surface tags its writes so post-mortem queries
+    ;; can identify which actor produced the registration.
+    (let [id      (story/reg-variant* vk (assoc body-v :origin config/origin))
+          payload {:variant-id id :registered? true}]
+      (h/text-result (h/pr-edn payload) payload))
+    (catch Throwable e
+      (h/error-result (str "Registration failed: " (ex-message e))
+                      (merge {:variant-id vk}
+                             (select-keys (ex-data e) [:rf.error :explain]))))))
+
 (defn tool-register-variant
   "Write: programmatically register a variant. Gated behind
   `allow-writes?` per IMPL-SPEC §7.3.
@@ -46,44 +76,26 @@
     :variant-id  required — `:story.<path>/<variant>` keyword id.
     :body        required — the variant body (a map; will be read as
                  EDN via `clojure.edn/read-string` if a string is sent
-                 over the wire)."
+                 over the wire).
+
+  Pipeline (short-circuits at the first error-result):
+
+    gate → required-arg :variant-id → required-arg :body →
+    coerce-body → reg-variant* + stamp :origin."
   [arguments]
   (or (assert-writes-allowed "register-variant")
-      (let [[vid e1] (h/required-arg arguments :variant-id)
-            [body e2] (h/required-arg arguments :body)]
-        (cond
-          e1 e1
-          e2 e2
-          :else
-          (let [vk      (args/parse-keyword vid)
-                body-v  (cond
-                          (map? body)    body
-                          (string? body) (try
-                                           (edn/read-string body)
-                                           (catch Throwable _
-                                             ::edn-error))
-                          :else          nil)]
-            (cond
-              (= body-v ::edn-error)
-              (h/error-result (str "Could not parse :body as EDN. Send a map or a valid EDN string."))
+      (let [[vid err-vid]   (h/required-arg arguments :variant-id)
+            [body err-body] (when-not err-vid (h/required-arg arguments :body))]
+        (or err-vid err-body
+            (let [body-v (coerce-body body)]
+              (case body-v
+                ::edn-error
+                (h/error-result ":body must be a map or a valid EDN string.")
 
-              (not (map? body-v))
-              (h/error-result (str ":body must be a map; got " (some-> body-v class .getName)))
+                ::not-a-map
+                (h/error-result (str ":body must be a map; got " (some-> body class .getName)))
 
-              :else
-              (try
-                ;; Stamp `:origin :story-mcp` per
-                ;; spec/Cross-Cutting-Designs.md §5 — every write
-                ;; surface tags its writes so post-mortem queries can
-                ;; identify which actor produced the registration.
-                (let [stamped (assoc body-v :origin config/origin)
-                      id      (story/reg-variant* vk stamped)]
-                  (let [payload {:variant-id id :registered? true}]
-                    (h/text-result (h/pr-edn payload) payload)))
-                (catch Throwable e
-                  (h/error-result (str "Registration failed: " (ex-message e))
-                                  (merge {:variant-id vk}
-                                         (select-keys (ex-data e) [:rf.error :explain])))))))))))
+                (register-or-error (args/parse-keyword vid) body-v)))))))
 
 (defn tool-unregister-variant
   "Write: programmatically unregister a variant. Gated behind

--- a/tools/story-mcp/test/re_frame/story_mcp/protocol_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/protocol_test.clj
@@ -14,6 +14,7 @@
   separate (tools_test.clj covers those)."
   (:require [cheshire.core :as json]
             [clojure.test :refer [deftest is testing]]
+            [re-frame.mcp-base.vocab :as vocab]
             [re-frame.story-mcp.protocol :as proto]))
 
 ;; ---- envelope construction -----------------------------------------------
@@ -28,20 +29,20 @@
 
 (deftest error-envelope-shape
   (testing "error response carries jsonrpc/id/error"
-    (let [e (proto/error-response 42 proto/code-method-not-found "no such tool")]
+    (let [e (proto/error-response 42 vocab/code-method-not-found "no such tool")]
       (is (= "2.0" (:jsonrpc e)))
       (is (= 42 (:id e)))
-      (is (= proto/code-method-not-found (-> e :error :code)))
+      (is (= vocab/code-method-not-found (-> e :error :code)))
       (is (= "no such tool" (-> e :error :message)))
       (is (not (contains? (:error e) :data)))))
   (testing "error response carries optional :data"
-    (let [e (proto/error-response 1 proto/code-invalid-params "bad arg"
+    (let [e (proto/error-response 1 vocab/code-invalid-params "bad arg"
                                    {:offending "key"})]
       (is (= {:offending "key"} (-> e :error :data)))))
   (testing "id may be nil (parse-error before id is known)"
     (let [e (proto/parse-error)]
       (is (nil? (:id e)))
-      (is (= proto/code-parse-error (-> e :error :code))))))
+      (is (= vocab/code-parse-error (-> e :error :code))))))
 
 ;; ---- envelope validation -------------------------------------------------
 
@@ -105,9 +106,9 @@
       (is (= {:jsonrpc "2.0" :method "ping" :id 1} f)))))
 
 (deftest read-frame-eof-sentinel
-  (testing "EOF returns the protocol-namespaced ::eof keyword"
+  (testing "EOF returns proto/eof-sentinel"
     (let [r (reader-of "")]
-      (is (= :re-frame.story-mcp.protocol/eof (proto/read-frame r))))))
+      (is (= proto/eof-sentinel (proto/read-frame r))))))
 
 (deftest read-frame-propagates-parse-error
   (testing "malformed JSON throws (caller writes parse-error response)"
@@ -138,24 +139,24 @@
       (let [r (reader-of (.toString sw))]
         (is (= {:jsonrpc "2.0" :id 1 :result {}}     (proto/read-frame r)))
         (is (= {:jsonrpc "2.0" :id 2 :result {:n 7}} (proto/read-frame r)))
-        (is (= :re-frame.story-mcp.protocol/eof      (proto/read-frame r)))))))
+        (is (= proto/eof-sentinel                    (proto/read-frame r)))))))
 
 ;; ---- error-helpers --------------------------------------------------------
 
 (deftest method-not-found-includes-method-name
   (testing "method-not-found message names the offending method"
     (let [e (proto/method-not-found 9 "tools/quux")]
-      (is (= proto/code-method-not-found (-> e :error :code)))
+      (is (= vocab/code-method-not-found (-> e :error :code)))
       (is (re-find #"tools/quux" (-> e :error :message))))))
 
 (deftest invalid-params-renders-details
   (testing "invalid-params attaches detail string to message"
     (let [e (proto/invalid-params 5 "missing :variant-id")]
-      (is (= proto/code-invalid-params (-> e :error :code)))
+      (is (= vocab/code-invalid-params (-> e :error :code)))
       (is (re-find #"missing :variant-id" (-> e :error :message))))))
 
 (deftest internal-error-attaches-data
   (testing "internal-error optional :data lands on the error envelope"
     (let [e (proto/internal-error 3 "boom" {:trace "abc"})]
-      (is (= proto/code-internal-error (-> e :error :code)))
+      (is (= vocab/code-internal-error (-> e :error :code)))
       (is (= {:trace "abc"} (-> e :error :data))))))

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -766,18 +766,18 @@
   (let [resp (server/dispatch
                {:jsonrpc "2.0" :id 4 :method "tools/call"
                 :params {:name "unknown-tool" :arguments {}}})]
-    (is (= proto/code-method-not-found (-> resp :error :code))
+    (is (= vocab/code-method-not-found (-> resp :error :code))
         "an unknown tool yields a protocol-level method-not-found")))
 
 (deftest dispatch-malformed-envelope
   (testing "missing jsonrpc version yields invalid-request"
     (let [resp (server/dispatch {:method "tools/list" :id 5})]
-      (is (= proto/code-invalid-request (-> resp :error :code))))))
+      (is (= vocab/code-invalid-request (-> resp :error :code))))))
 
 (deftest dispatch-unknown-method
   (let [resp (server/dispatch
                {:jsonrpc "2.0" :id 6 :method "nope/whatever"})]
-    (is (= proto/code-method-not-found (-> resp :error :code)))
+    (is (= vocab/code-method-not-found (-> resp :error :code)))
     (is (re-find #"nope/whatever" (-> resp :error :message)))))
 
 (deftest dispatch-notification-no-response
@@ -827,7 +827,7 @@
       (let [out-lines (filter seq (clojure.string/split-lines (.toString sw)))
             frames    (mapv #(cheshire.core/parse-string % true) out-lines)]
         (is (= 2 (count frames)))
-        (is (= proto/code-parse-error (-> (nth frames 0) :error :code)))
+        (is (= vocab/code-parse-error (-> (nth frames 0) :error :code)))
         (is (= 9 (:id (nth frames 1))))))))
 
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Tenth batched-by-surface dispatch — `tools/story-mcp` round-2 cluster (rf2-w8jxf). Four P2 beads, each a focused commit:

| Bead | Title | Files | LoC |
|---|---|---|---|
| rf2-qkyka | post-split polish — scrub-assertions short-return, schemas refer-clojure, registry cond-> dead arm | tools/{helpers,registry,schemas}.cljc | +32 / -8 |
| rf2-uuh0x | polish leaves — protocol eof-sentinel, dispatch defensive arm, version-read, parse-args | protocol.cljc, server.cljc, config.cljc + 2 tests | +97 / -77 |
| rf2-yekgk | post-split polish — resolve-cljs-var helper, tool-by-name index, tag-filter rewrite | tools/{helpers,dev,docs,registry,testing}.cljc | +44 / -9 |
| rf2-8bfy7 | read-run-opts helper; pipeline-ify register / record-as-variant | tools/{helpers,dev,testing,write,recorder}.cljc | +122 / -107 |

Net: ~+295 / -201 across 12 unique files, four logically-independent commits.

### Highlights

- **`tools.cljc` façade was already dropped** by rf2-5rkki — the bead descriptions referenced it; the items map cleanly to the post-split per-category nses.
- **R2-T3 / TE3** (sum-text-tokens demotion) had already shipped — the test now reaches `base-cap/sum-text-tokens` directly. No-op for rf2-qkyka; scrubbed from the cluster.
- **rf2-yekgk T8** (move `canonical-assertion-docs` to tools/story) — out of scope; cross-artefact refactor deserves its own focused bead.
- **rf2-yekgk T13** (recorder catch unification) — audit R2-RE1 downgraded it post-split since `now-ms` / `sleep-ms` are cljc-aware; skipped.
- **rf2-uuh0x C2 / C3** — both audit findings were wrong: C2's `:as cfg` IS the return value; C3's `(def stage)` IS cited from spec docs. Skipped both with notes.
- **rf2-8bfy7 T12** (assert-writes-allowed tool-name threading) — already shipped in rf2-c52j0.
- **`proto/code-*` re-exports dropped**: server.cljc + tests now reach `vocab/code-*` directly. One source of truth.

## Test plan

- [x] `cd tools/story-mcp && clojure -M:test` — 87 tests, 453 assertions, green
- [x] `cd implementation && npm run test:cljs` — 1817 tests, 5105 assertions, green
- [x] `python scripts/check_skill_mcp_drift.py` — green