### PR TITLE
refactor(core): round-2 polish cluster — 4 follow-on beads (rf2-byut1)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -14,6 +14,7 @@
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.frame :as frame]
+            [re-frame.fx :as fx]
             [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace
              #?@(:cljs [:include-macros true])]))
@@ -29,16 +30,18 @@
 
 ;; ---- the platform predicate -----------------------------------------------
 ;;
-;; Mirror of `re-frame.fx/fx-runs-on-platform?`. Per Spec 011 §634-642 the
-;; `:platforms` metadata applies to BOTH `reg-fx` AND `reg-cofx`; a cofx
-;; tagged `:platforms #{:client}` must no-op when injected on a server-
-;; side frame (the SSR contract — request-cofx like browser locale,
-;; localStorage, navigator-info etc. would otherwise blow up under JVM
-;; render or produce nonsense values).
+;; Per Spec 011 §634-642 the `:platforms` metadata applies to BOTH
+;; `reg-fx` AND `reg-cofx`; a cofx tagged `:platforms #{:client}` must
+;; no-op when injected on a server-side frame (the SSR contract —
+;; request-cofx like browser locale, localStorage, navigator-info etc.
+;; would otherwise blow up under JVM render or produce nonsense
+;; values).
+;;
+;; Single definition lives in `re-frame.fx/runs-on-platform?` (rf2-4ymm0
+;; SP6); we alias it here so internal call sites read in the cofx
+;; vocabulary.
 
-(defn- cofx-runs-on-platform? [meta active-platform]
-  (let [platforms (:platforms meta #{:client :server})]
-    (contains? platforms active-platform)))
+(def ^:private cofx-runs-on-platform? fx/runs-on-platform?)
 
 (defn- active-platform-for-frame
   "Resolve the active platform for a cofx injection. Mirrors the resolution
@@ -250,16 +253,17 @@
 ;; ---- standard cofx --------------------------------------------------------
 
 (reg-cofx :db
-  {:doc "Inject the frame's current `app-db` value under `:coeffects :db`. Pre-populated by the drain loop before the interceptor chain runs; explicit `(inject-cofx :db)` is rarely needed and is a no-op. Exists for symmetry with `:event`."}
+  {:doc "Inject the frame's current `app-db` value under `:coeffects :db`. Pre-populated by the runtime before the interceptor chain runs; explicit `(inject-cofx :db)` is a no-op. Registered for symmetry with `:event` and so `(handlers :cofx)` enumerates the standard cofx."}
   (fn [ctx]
-    ;; The drain loop has already populated :coeffects :db with the frame's
-    ;; current app-db value before invoking the chain — so this cofx is
-    ;; usually a no-op. It exists for symmetry with `:event`.
+    ;; The runtime pre-populates :coeffects :db with the frame's current
+    ;; app-db value before invoking the chain — so this cofx is a no-op.
+    ;; Registered for symmetry with `:event`.
     ctx))
 
 (reg-cofx :event
-  {:doc "Inject the dispatched event vector under `:coeffects :event`. Pre-populated by the dispatch envelope before the chain runs; explicit `(inject-cofx :event)` is a no-op."}
+  {:doc "Inject the dispatched event vector under `:coeffects :event`. Pre-populated by the runtime before the interceptor chain runs; explicit `(inject-cofx :event)` is a no-op. Registered for symmetry with `:db` and so `(handlers :cofx)` enumerates the standard cofx."}
   (fn [ctx]
-    ;; Same as :db — the dispatch envelope wires the event into :coeffects
-    ;; before the chain runs.
+    ;; The runtime pre-populates :coeffects :event with the dispatched
+    ;; event vector before invoking the chain — so this cofx is a no-op.
+    ;; Registered for symmetry with `:db`.
     ctx))

--- a/implementation/core/src/re_frame/core_reg_view_macro.cljc
+++ b/implementation/core/src/re_frame/core_reg_view_macro.cljc
@@ -147,6 +147,19 @@
               (finally
                 (re-frame.frame/destroy-frame! ~sym)))))
 
+       ;; Shape 2 disambiguator: a vector that is NOT 2-element is
+       ;; almost certainly a typo of the binding form (e.g. `[]` or
+       ;; `[f x y]`). Reject at compile time per Spec 002 §with-frame —
+       ;; falling through to Shape 1 would silently bind
+       ;; `*current-frame*` to a vector value, producing a confusing
+       ;; runtime error far from the call site.
+       (vector? bindings)
+       (throw (ex-info
+                (str "with-frame: vector binding must be [sym expr] (Shape 2). "
+                     "Got " (count bindings) " element"
+                     (when-not (= 1 (count bindings)) "s") ".")
+                {:got bindings :count (count bindings)}))
+
        :else
        `(binding [re-frame.frame/*current-frame* ~bindings]
           ~@body))))

--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -71,25 +71,34 @@
 (defn- police-effect-map-shape!
   "Emit :rf.error/effect-map-shape for each non-:db / non-:fx top-level key
   in `effects`. Per Spec migration M-8 the effect-map is closed at the top
-  level. Returns the list of offending keys (which the caller drops)."
+  level. Returns the list of offending keys (which the caller drops).
+
+  Hot-path short-circuit (rf2-4ymm0 EV4): the well-shaped case is the
+  overwhelming majority — handlers return `{}`, `{:db ...}`, `{:fx ...}`,
+  or `{:db ... :fx ...}`. Allocating an `offending` vector per dispatch
+  for the every-key-walks-the-closed-set check is wasted work. Pre-check
+  via `every?` (no allocation), and fall through to the doseq/vec build
+  only when at least one key is offending."
   [effects event]
-  (let [event-id (when (vector? event) (first event))
-        offending (->> (keys effects)
-                       (remove #{:db :fx})
-                       (vec))]
-    (doseq [k offending]
-      (let [v      (get effects k)
-            reason (str "Effect-map for `" event-id "` returned top-level key `" k
-                        "`; only `:db` and `:fx` are allowed at the top level.")]
-        (trace/emit-error! :rf.error/effect-map-shape
-                           {:failing-id    event-id
-                            :event-id      event-id
-                            :event         event
-                            :offending-key k
-                            :value         v
-                            :reason        reason
-                            :recovery      :logged-and-skipped})))
-    offending))
+  (if (every? #{:db :fx} (keys effects))
+    nil
+    (let [event-id (when (vector? event) (first event))
+          offending (->> (keys effects)
+                         (remove #{:db :fx})
+                         (vec))]
+      (doseq [k offending]
+        (let [v      (get effects k)
+              reason (str "Effect-map for `" event-id "` returned top-level key `" k
+                          "`; only `:db` and `:fx` are allowed at the top level.")]
+          (trace/emit-error! :rf.error/effect-map-shape
+                             {:failing-id    event-id
+                              :event-id      event-id
+                              :event         event
+                              :offending-key k
+                              :value         v
+                              :reason        reason
+                              :recovery      :logged-and-skipped})))
+      offending)))
 
 ;; ---- handler-as-interceptor wrappers --------------------------------------
 ;;

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -108,9 +108,22 @@
 
 ;; ---- the platform predicate -----------------------------------------------
 
-(defn- fx-runs-on-platform? [meta active-platform]
+(defn runs-on-platform?
+  "Does the `:platforms` metadata permit `active-platform`?
+
+  Per Spec 011 §634-642 the `:platforms` slot applies symmetrically to
+  `reg-fx` AND `reg-cofx`. Default is `#{:client :server}` (both
+  permitted). The same predicate body answered both questions —
+  re-frame.cofx aliases this fn so the contract has one definition
+  (rf2-4ymm0 SP6)."
+  [meta active-platform]
   (let [platforms (:platforms meta #{:client :server})]
     (contains? platforms active-platform)))
+
+;; Local alias kept for internal call sites' readability — `(fx-runs-on-
+;; platform? meta plat)` reads better at `do-fx` than `(runs-on-platform?
+;; meta plat)` where the fx-vs-cofx context is implicit.
+(def ^:private fx-runs-on-platform? runs-on-platform?)
 
 ;; ---- do-fx ----------------------------------------------------------------
 

--- a/implementation/core/src/re_frame/performance.cljc
+++ b/implementation/core/src/re_frame/performance.cljc
@@ -67,38 +67,35 @@
 
 ;; ---- name builder (used by the macro expansion at the call site) ----------
 
-#?(:clj
-   (defn build-name
-     "Build a `rf:<bucket>:<id>` entry name from the bucket keyword and
-     the registered id keyword/symbol/string. Stable shape across every
-     emit site so consumers filter on the `rf:` prefix without parsing
-     per-bucket shapes.
+(defn build-name
+  "Build a `rf:<bucket>:<id>` entry name from the bucket keyword and the
+  registered id keyword/symbol/string. Stable shape across every emit
+  site so consumers filter on the `rf:` prefix without parsing per-
+  bucket shapes.
 
-     Per Spec 009 §Performance instrumentation §Naming convention."
-     [bucket id]
-     (str "rf:" (name bucket) ":"
-          (cond
-            (keyword? id) (if-let [n (namespace id)]
-                            (str n "/" (name id))
-                            (name id))
-            (symbol? id)  (str id)
-            :else         (str id)))))
+  Per Spec 009 §Performance instrumentation §Naming convention.
 
-#?(:cljs
-   (defn build-name
-     "Build a `rf:<bucket>:<id>` entry name. Mirror of the JVM fn above
-     so it is callable at runtime when the gate is on (the macro
-     embeds a call to it inside the gated branch). At expansion time
-     under :advanced + enabled?=false, every call to this fn lives
-     inside the gated dead branch and DCEs."
-     [bucket id]
-     (str "rf:" (name bucket) ":"
-          (cond
-            (keyword? id) (if-let [n (namespace id)]
-                            (str n "/" (name id))
-                            (name id))
-            (symbol? id)  (str id)
-            :else         (str id)))))
+  Two scopes use this fn:
+
+    1. The CLJS macro body, expanded at compile time on the JVM — it
+       emits `(build-name ~bucket ~id)` inside the gated branch. The
+       call is JVM-runnable so test fixtures can predict the entry name
+       without booting CLJS.
+    2. CLJS runtime callers reached when the perf gate is on (the
+       call lives inside the gated branch). Under `:advanced +
+       enabled?=false` the entire branch DCEs and this fn vanishes
+       from the production bundle.
+
+  The body is pure data-shaping with no platform-specific calls — the
+  pre-rf2-4ymm0 JVM/CLJS twins held identical bodies."
+  [bucket id]
+  (str "rf:" (name bucket) ":"
+       (cond
+         (keyword? id) (if-let [n (namespace id)]
+                         (str n "/" (name id))
+                         (name id))
+         (symbol? id)  (str id)
+         :else         (str id))))
 
 ;; ---- the macro -------------------------------------------------------------
 

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -202,18 +202,22 @@
       Return the full `{id metadata}` map for kind, or `{}` if the kind
       has no registrations.
     (handlers kind pred-fn)
-      Same shape, filtered: only entries for which `(pred-fn id meta)`
+      Same shape, filtered: only entries for which `(pred-fn meta)`
       returns truthy are included. Returns `{}` when no entry matches.
       Tools (storybook resolvers, registry browsers, agent introspection)
       use this to narrow the result to a per-namespace, per-source-file,
       or per-marker subset without re-walking the registry map themselves.
 
-  Per Spec 001 §The public registrar query API."
+  Per Spec 001 §The public registrar query API. The predicate's
+  argument is the metadata-map only — the registration id is reachable
+  from the metadata's `:ns` / `:line` / `:file` / `:doc` / `:tags` /
+  custom slots (id-by-keyword filtering composes via the caller's own
+  `filter` over the result map's keys when needed)."
   ([kind]
    (get @kind->id->metadata kind {}))
   ([kind pred-fn]
    (into {}
-         (filter (fn [[id meta]] (pred-fn id meta)))
+         (filter (fn [[_id meta]] (pred-fn meta)))
          (get @kind->id->metadata kind {}))))
 
 (defn handler-meta

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -101,8 +101,12 @@
   new fn on the next lookup).
 
   When this is a re-registration, every replacement-hook fires and a
-  :rf.registry/handler-replaced trace event is emitted (per Spec 009).
-  Hooks run AFTER the swap so listeners observe the new state."
+  :rf.registry/handler-replaced trace event is emitted on EVERY
+  re-registration (per Spec 001 §Hot-reload trace surface + Spec 009 —
+  devtools refresh their view from this event). The trace's `:tags`
+  carry `:different-fn?` so tooling can branch idempotent reloads from
+  real fn-identity changes without re-emitting through a separate
+  surface — `(rf2-6w7zn)`."
   [kind id metadata]
   (when-not (valid-kind? kind)
     (throw (ex-info (str "re-frame2: unknown registry kind: " kind)
@@ -110,8 +114,7 @@
   (let [previous (get-in @kind->id->metadata [kind id])]
     (swap! kind->id->metadata assoc-in [kind id] metadata)
     (cond
-      ;; Re-registration path — fire hooks and emit handler-replaced when
-      ;; the handler-fn actually changed.
+      ;; Re-registration path — fire hooks and emit handler-replaced.
       previous
       (let [different? (not= (:handler-fn previous) (:handler-fn metadata))]
         ;; Hot-reload notifications. Hooks run isolated — listener failures
@@ -122,19 +125,21 @@
           (try (f {:kind kind :id id :was previous :now metadata
                    :different-fn? different?})
                (catch #?(:clj Throwable :cljs :default) _ nil)))
-        ;; Only trace when the handler-fn actually changed — idempotent
-        ;; re-registrations (same fn instance, common during ns reload of
-        ;; static defs) would otherwise spam the trace stream.
-        ;; The interop/debug-enabled? gate is OUTERMOST so :advanced +
-        ;; goog.DEBUG=false can constant-fold the entire branch (per
-        ;; Spec 009 §Production builds).  Inverting this — for example,
-        ;; `(when (and different? interop/debug-enabled?) ...)` —
-        ;; defeats the constant-fold because Closure can't statically
-        ;; rule out `different?`.
+        ;; Per Spec 001 §Hot-reload trace surface (rf2-6w7zn): emit
+        ;; `:rf.registry/handler-replaced` on EVERY re-registration —
+        ;; not only when the handler-fn changes. Kinds like `:frame`
+        ;; replace the slot without rotating `:handler-fn`, so a
+        ;; `different?`-gated emit dropped legitimate re-registration
+        ;; events on the floor. The `:different-fn?` tag is preserved
+        ;; for tools that want to suppress idempotent-reload noise on
+        ;; their side.
+        ;;
+        ;; The `interop/debug-enabled?` gate stays OUTERMOST so
+        ;; `:advanced + goog.DEBUG=false` constant-folds the entire
+        ;; branch (per Spec 009 §Production builds).
         (when interop/debug-enabled?
-          (when different?
-            (emit! :rf.registry/handler-replaced
-                   {:kind kind :id id :different-fn? true}))))
+          (emit! :rf.registry/handler-replaced
+                 {:kind kind :id id :different-fn? different?})))
       ;; First-time registration — emit handler-registered per Spec 009
       ;; §:op-type vocabulary. Hot-reload tools (10x, re-frame-pair) use
       ;; this to track when fresh ids appear in the registry.

--- a/implementation/core/test/re_frame/core_api_additions_test.clj
+++ b/implementation/core/test/re_frame/core_api_additions_test.clj
@@ -122,6 +122,28 @@
       (is (= {:counter 42} @captured-db)
           "the body observed the on-create-seeded app-db"))))
 
+(deftest with-frame-rejects-vector-bindings-with-wrong-arity
+  (testing "(with-frame [...] body) with vector-but-not-2-count raises at compile time (rf2-4ymm0 CQ4)"
+    ;; `macroexpand` wraps macro-side ex-infos in a Compiler$CompilerException;
+    ;; call the expansion helper directly so we observe the structured throw
+    ;; that fires at compile time when the user types `with-frame []`.
+    (require 're-frame.core-reg-view-macro)
+    (let [expand (resolve 're-frame.core-reg-view-macro/expand-with-frame)]
+      ;; Empty vector — easy typo of Shape 2 to omit both sides.
+      (let [e (try (expand [] '((do nil))) nil
+                   (catch clojure.lang.ExceptionInfo e e))]
+        (is (some? e) "[] must throw")
+        (is (re-find #"with-frame: vector binding must be \[sym expr\]"
+                     (.getMessage ^Throwable e))
+            "the message carries the structured reason"))
+      ;; 3-element vector — typo of `[sym expr]` with extra tail.
+      (let [e (try (expand '[f g h] '((do nil))) nil
+                   (catch clojure.lang.ExceptionInfo e e))]
+        (is (some? e) "[f g h] must throw")
+        (is (re-find #"with-frame: vector binding must be \[sym expr\]"
+                     (.getMessage ^Throwable e))
+            "the message carries the structured reason")))))
+
 ;; ===========================================================================
 ;; rf2-ewku — (rf/handlers kind pred-fn) filter arity
 ;; ===========================================================================

--- a/implementation/core/test/re_frame/core_api_additions_test.clj
+++ b/implementation/core/test/re_frame/core_api_additions_test.clj
@@ -135,29 +135,34 @@
       (is (contains? all :hf/two)))))
 
 (deftest handlers-2-arity-filters
-  (testing "(handlers kind pred-fn) filters by (pred id meta)"
+  (testing "(handlers kind pred-fn) filters by (pred meta) — metadata-only"
+    ;; Per Spec 001 §The query API + API.md the predicate sees the
+    ;; metadata-map only. Id-namespace filters ride a user-tag the
+    ;; caller stamps onto the slot (or compose via `filter` over the
+    ;; returned map's keys).
     (rf/reg-event-db :hf.alpha/one (fn [db _] db))
     (rf/reg-event-db :hf.alpha/two (fn [db _] db))
     (rf/reg-event-db :hf.beta/one  (fn [db _] db))
+    (registrar/register! :event :hf.alpha/one
+      (assoc (rf/handler-meta :event :hf.alpha/one) :rf/group :alpha))
+    (registrar/register! :event :hf.alpha/two
+      (assoc (rf/handler-meta :event :hf.alpha/two) :rf/group :alpha))
     (let [alpha-only (rf/handlers :event
-                                  (fn [id _meta]
-                                    (= "hf.alpha" (namespace id))))]
+                                  (fn [m] (= :alpha (:rf/group m))))]
       (is (= #{:hf.alpha/one :hf.alpha/two}
              (set (keys alpha-only)))
           "only :hf.alpha/* survives the predicate")
       (is (not (contains? alpha-only :hf.beta/one))
           ":hf.beta/one is filtered out"))))
 
-(deftest handlers-2-arity-pred-receives-id-and-meta
-  (testing "the pred-fn receives [id meta], so meta keys can drive the filter"
+(deftest handlers-2-arity-pred-receives-meta
+  (testing "the pred-fn receives the metadata-map only"
     (rf/reg-event-db :hf/marked   (fn [db _] db))
     (rf/reg-event-db :hf/unmarked (fn [db _] db))
     ;; Re-register :hf/marked with extra meta on the slot.
     (registrar/register! :event :hf/marked
       (assoc (rf/handler-meta :event :hf/marked) :rf/marker? true))
-    (let [marked (rf/handlers :event
-                              (fn [_id m]
-                                (:rf/marker? m)))]
+    (let [marked (rf/handlers :event (fn [m] (:rf/marker? m)))]
       (is (= #{:hf/marked} (set (keys marked)))
           "only handlers whose metadata satisfies the pred survive"))))
 

--- a/implementation/core/test/re_frame/core_artefact_test.clj
+++ b/implementation/core/test/re_frame/core_artefact_test.clj
@@ -1,0 +1,171 @@
+(ns re-frame.core-artefact-test
+  "Direct unit coverage for the `re-frame.core-artefact/defwrapper`
+  absent-policy branches.
+
+  Per the rf2-o7ayf audit (rf2-byut1 round-2 core review): the
+  optional-artefact factory underpins ~ 30 wrapper fns across
+  `core_<artefact>.cljc` (flows, routing, schemas, machines, ssr, epoch,
+  http). Higher-level tests caught downstream symptoms (a wrapper used
+  in an integration test would surface when the producing artefact was
+  missing), but the absent-policy branches at the factory level had no
+  direct coverage. This file locks each policy branch (`:throw`,
+  `:nil`, `:false`, `:empty-vec`, `:empty-map`, literal value) against
+  the late-bind registry.
+
+  Coverage:
+    - `:throw`     — `late-bind/require-fn!` raises the structured
+                     :rf.error/<artefact>-artefact-missing ex-info with
+                     the documented slots (:where, :reason, :recovery).
+    - `:nil`       — returns nil when the hook is unregistered;
+                     delegates to the hook when registered.
+    - `:false`     — returns false when absent.
+    - `:empty-vec` — returns [] when absent.
+    - `:empty-map` — returns {} when absent.
+    - literal      — returns the literal value when absent.
+    - `:ex-data`   — symbol values resolve in the arity's locals and
+                     ride the throw's ex-data."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core-artefact :refer [defwrapper]]
+            [re-frame.late-bind :as late-bind]))
+
+;; ---- fixture --------------------------------------------------------------
+
+;; Each test installs its own hook(s); reset between tests so a stale
+;; registration from one test doesn't leak into the next.
+
+(defn- reset-late-bind [test-fn]
+  ;; The `late-bind/hooks` registry is a defonce atom; snapshot and
+  ;; restore around the test so each test installs its own hooks
+  ;; without leaking into siblings or wiping framework registrations.
+  (let [snap @late-bind/hooks
+        test-keys [:test/throw-hook :test/nil-hook :test/false-hook
+                   :test/empty-vec-hook :test/empty-map-hook
+                   :test/literal-hook :test/ex-data-hook]]
+    (doseq [k test-keys] (swap! late-bind/hooks dissoc k))
+    (try (test-fn)
+         (finally (reset! late-bind/hooks snap)))))
+
+(use-fixtures :each reset-late-bind)
+
+;; ---- the artefact descriptor used across the wrappers below --------------
+
+(def ^:private test-artefact
+  {:error-keyword :rf.error/test-artefact-missing
+   :maven         "test/artefact"
+   :require-ns    "re-frame.test-fake-artefact"})
+
+;; ---- :throw policy --------------------------------------------------------
+
+(defwrapper throw-wrapper
+  "Test wrapper — :on-absent :throw."
+  {:hook :test/throw-hook :artefact test-artefact :on-absent :throw}
+  ([] :delegate)
+  ([x] :delegate))
+
+(deftest throw-policy-raises-structured-ex-info
+  (testing ":on-absent :throw raises :rf.error/<artefact>-artefact-missing"
+    (let [e (try (throw-wrapper) nil
+                 (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? e) "the wrapper threw")
+      (let [data (ex-data e)]
+        (is (= 'rf/throw-wrapper (:where data))
+            ":where stamps the user-facing fn name (default rf/<name>)")
+        (is (= :no-recovery (:recovery data))
+            ":recovery is :no-recovery for the missing-artefact branch")
+        (is (re-find #"test/artefact" (:reason data))
+            ":reason mentions the Maven artefact coordinates")
+        (is (re-find #"re-frame.test-fake-artefact" (:reason data))
+            ":reason mentions the producing ns name")
+        (is (= ":rf.error/test-artefact-missing"
+               (.getMessage ^Throwable e))
+            "the exception message is the :error-keyword printed as a string")))))
+
+(deftest throw-policy-delegates-when-hook-registered
+  (testing ":throw delegates to the hook fn when registered"
+    (late-bind/set-fn! :test/throw-hook (fn ([] :zero) ([x] [:one x])))
+    (is (= :zero (throw-wrapper)))
+    (is (= [:one 42] (throw-wrapper 42)))))
+
+;; ---- :nil policy ----------------------------------------------------------
+
+(defwrapper nil-wrapper
+  "Test wrapper — :on-absent :nil."
+  {:hook :test/nil-hook :artefact test-artefact :on-absent :nil}
+  ([] :delegate))
+
+(deftest nil-policy-returns-nil-when-absent
+  (testing ":on-absent :nil returns nil when the hook is unregistered"
+    (is (nil? (nil-wrapper)))))
+
+(deftest nil-policy-delegates-when-present
+  (testing ":on-absent :nil delegates when the hook is registered"
+    (late-bind/set-fn! :test/nil-hook (fn [] :present))
+    (is (= :present (nil-wrapper)))))
+
+;; ---- :false policy --------------------------------------------------------
+
+(defwrapper false-wrapper
+  "Test wrapper — :on-absent :false."
+  {:hook :test/false-hook :artefact test-artefact :on-absent :false}
+  ([] :delegate))
+
+(deftest false-policy-returns-false-when-absent
+  (is (false? (false-wrapper))))
+
+(deftest false-policy-delegates-when-present
+  (late-bind/set-fn! :test/false-hook (fn [] :really))
+  (is (= :really (false-wrapper))))
+
+;; ---- :empty-vec policy ---------------------------------------------------
+
+(defwrapper empty-vec-wrapper
+  "Test wrapper — :on-absent :empty-vec."
+  {:hook :test/empty-vec-hook :artefact test-artefact :on-absent :empty-vec}
+  ([] :delegate))
+
+(deftest empty-vec-policy-returns-empty-vec
+  (is (= [] (empty-vec-wrapper))))
+
+(deftest empty-vec-policy-delegates-when-present
+  (late-bind/set-fn! :test/empty-vec-hook (fn [] [:a :b]))
+  (is (= [:a :b] (empty-vec-wrapper))))
+
+;; ---- :empty-map policy ---------------------------------------------------
+
+(defwrapper empty-map-wrapper
+  "Test wrapper — :on-absent :empty-map."
+  {:hook :test/empty-map-hook :artefact test-artefact :on-absent :empty-map}
+  ([] :delegate))
+
+(deftest empty-map-policy-returns-empty-map
+  (is (= {} (empty-map-wrapper))))
+
+(deftest empty-map-policy-delegates-when-present
+  (late-bind/set-fn! :test/empty-map-hook (fn [] {:k :v}))
+  (is (= {:k :v} (empty-map-wrapper))))
+
+;; ---- literal-value policy ------------------------------------------------
+
+(defwrapper literal-wrapper
+  "Test wrapper — :on-absent literal value (a sentinel keyword)."
+  {:hook :test/literal-hook :artefact test-artefact :on-absent :rf/sentinel}
+  ([] :delegate))
+
+(deftest literal-policy-returns-the-literal-when-absent
+  (is (= :rf/sentinel (literal-wrapper))))
+
+;; ---- :ex-data sym scoping -----------------------------------------------
+
+(defwrapper ex-data-wrapper
+  "Test wrapper — :ex-data carries a symbol that resolves in the arity locals."
+  {:hook :test/ex-data-hook :artefact test-artefact :on-absent :throw
+   :ex-data {:item-id id}}
+  ([id] :delegate))
+
+(deftest ex-data-symbol-rides-the-throw
+  (testing ":ex-data symbol values resolve in the arity's local scope"
+    (let [e (try (ex-data-wrapper :my-id) nil
+                 (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? e))
+      (is (= :my-id (:item-id (ex-data e)))
+          ":item-id rides the throw's ex-data, sourced from the local"))))

--- a/implementation/core/test/re_frame/emit_substrate_test.clj
+++ b/implementation/core/test/re_frame/emit_substrate_test.clj
@@ -1,0 +1,119 @@
+(ns re-frame.emit-substrate-test
+  "Direct unit coverage for `re-frame.emit-substrate/make-listener-registry`.
+
+  Per the rf2-o7ayf audit (rf2-byut1 round-2 core review): the
+  substrate factory underpins BOTH `re-frame.event-emit` and
+  `re-frame.error-emit` — bugs at this layer fan out across the
+  always-on emit surface (Spec 009 §What IS available in production).
+  Higher-level tests caught downstream symptoms; this file locks the
+  contract directly.
+
+  Coverage:
+    1. `:register` returns the id and the listener is reachable.
+    2. `:unregister` drops a single listener; siblings unaffected.
+    3. `:clear` drops every listener.
+    4. `:fan-out` invokes every listener with the record argument.
+    5. `:fan-out` short-circuits on empty registry (no deref-then-doseq
+       cost when no one is listening).
+    6. Listener exceptions are caught — the cascade continues and
+       sibling listeners still fire.
+    7. An externally-held `:listeners` atom is used as the backing
+       store (the hot-reload-survives contract — consumers
+       `defonce` their atom and pass it through).
+    8. Idempotent re-register on the same id replaces the listener fn."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.emit-substrate :as emit]))
+
+(defn- fresh-registry [] (emit/make-listener-registry {}))
+
+(deftest register-installs-listener
+  (testing ":register stores the listener and returns the id"
+    (let [{:keys [register fan-out]} (fresh-registry)
+          seen (atom [])
+          ret  (register :alpha (fn [r] (swap! seen conj r)))]
+      (is (= :alpha ret) ":register returns the id")
+      (fan-out {:rec 1})
+      (is (= [{:rec 1}] @seen) "the listener received the fan-out record"))))
+
+(deftest unregister-drops-only-target
+  (testing ":unregister removes a single listener; siblings keep firing"
+    (let [{:keys [register unregister fan-out]} (fresh-registry)
+          a-seen (atom 0)
+          b-seen (atom 0)]
+      (register :alpha (fn [_] (swap! a-seen inc)))
+      (register :beta  (fn [_] (swap! b-seen inc)))
+      (fan-out {})
+      (is (= 1 @a-seen)) (is (= 1 @b-seen))
+      (unregister :alpha)
+      (fan-out {})
+      (is (= 1 @a-seen) ":alpha was dropped")
+      (is (= 2 @b-seen) ":beta still fires"))))
+
+(deftest clear-drops-every-listener
+  (testing ":clear removes every registration"
+    (let [{:keys [register clear fan-out listeners]} (fresh-registry)
+          seen (atom 0)]
+      (register :alpha (fn [_] (swap! seen inc)))
+      (register :beta  (fn [_] (swap! seen inc)))
+      (is (= 2 (count @listeners)))
+      (clear)
+      (is (= {} @listeners) ":clear empties the listener atom")
+      (fan-out {})
+      (is (zero? @seen) "no listener fired after :clear"))))
+
+(deftest fan-out-invokes-every-listener-with-record
+  (testing ":fan-out walks every registered listener with the record argument"
+    (let [{:keys [register fan-out]} (fresh-registry)
+          captured (atom [])]
+      (register :one (fn [r] (swap! captured conj [:one r])))
+      (register :two (fn [r] (swap! captured conj [:two r])))
+      (fan-out {:k :v})
+      (is (= 2 (count @captured)) "both listeners fired")
+      (is (every? #(= {:k :v} (second %)) @captured)
+          "each listener saw the same record"))))
+
+(deftest fan-out-empty-registry-is-noop
+  (testing ":fan-out short-circuits when the registry is empty"
+    ;; Hot-path cost reduces to one deref + `empty?` when no listener
+    ;; is registered. We can't measure the cost directly; we DO assert
+    ;; that calling fan-out without any listeners is exception-free
+    ;; (catches a future regression where the doseq runs on nil).
+    (let [{:keys [fan-out]} (fresh-registry)]
+      (is (nil? (fan-out {:any :record}))
+          "fan-out returns nil on empty"))))
+
+(deftest fan-out-listener-exception-isolated
+  (testing "a buggy listener throws — the cascade continues; siblings still fire"
+    (let [{:keys [register fan-out]} (fresh-registry)
+          after-bad (atom 0)
+          before-bad (atom 0)]
+      (register :before (fn [_] (swap! before-bad inc)))
+      (register :bad    (fn [_] (throw (ex-info "boom" {}))))
+      (register :after  (fn [_] (swap! after-bad inc)))
+      (is (nil? (fan-out {}))
+          "fan-out swallows listener exceptions and returns nil")
+      (is (= 1 @before-bad) "the :before listener fired")
+      (is (= 1 @after-bad)  "the :after listener fired despite :bad throwing"))))
+
+(deftest external-listeners-atom-is-honoured
+  (testing "an externally-supplied `:listeners` atom is the backing store"
+    ;; Production consumers `defonce` their atom and pass it through so
+    ;; hot reload of the consuming ns doesn't drop registrations.
+    (let [external (atom {})
+          {:keys [register listeners]} (emit/make-listener-registry
+                                          {:listeners external})]
+      (is (identical? external listeners)
+          "the surfaced :listeners atom IS the externally-supplied one")
+      (register :hello (fn [_] :ok))
+      (is (contains? @external :hello)
+          "registration writes through to the external atom"))))
+
+(deftest reregister-replaces
+  (testing "re-registering the same id replaces the listener fn"
+    (let [{:keys [register fan-out]} (fresh-registry)
+          seen (atom [])]
+      (register :only (fn [_] (swap! seen conj :v1)))
+      (register :only (fn [_] (swap! seen conj :v2)))
+      (fan-out {})
+      (is (= [:v2] @seen)
+          "only the second registration fires — first was replaced"))))

--- a/implementation/core/test/re_frame/trace_test.clj
+++ b/implementation/core/test/re_frame/trace_test.clj
@@ -339,13 +339,39 @@
           (is (keyword? (:frame (:tags (find-op events :frame :frame/destroyed))))))
 
         ;; ---- :registry op-type ---------------------------------------------
-        (testing ":registry :rf.registry/handler-replaced fires when a handler-fn changes on re-reg"
+        (testing ":registry :rf.registry/handler-replaced fires on EVERY re-registration (rf2-6w7zn)"
+          ;; Per Spec 001 §Hot-reload trace surface the emit is
+          ;; unconditional on re-registration — the prior `different-fn?`
+          ;; gate dropped events for kinds like `:frame` whose slot
+          ;; replacement need not rotate `:handler-fn`. Tools branch on
+          ;; the `:different-fn?` tag (preserved below) to suppress
+          ;; idempotent reload noise on their side.
           (is (has-op? events :registry :rf.registry/handler-replaced)
               "expected :registry :rf.registry/handler-replaced")
-          (let [t (:tags (find-op events :registry :rf.registry/handler-replaced))]
-            (is (keyword? (:kind t)))
-            (is (some?    (:id t)))
-            (is (true?    (:different-fn? t)))))
+          ;; The flow re-registers BOTH `:test/main` (a frame, same
+          ;; handler-fn) and `:inc` (an event, different fn body) so
+          ;; both events fire. Find the `:inc` event explicitly so the
+          ;; `:different-fn?` assertion targets the real fn-change case.
+          (let [different-events (filterv (fn [ev]
+                                            (and (= :registry (:op-type ev))
+                                                 (= :rf.registry/handler-replaced
+                                                    (:operation ev))
+                                                 (true? (get-in ev [:tags :different-fn?]))))
+                                          events)
+                idempotent-events (filterv (fn [ev]
+                                             (and (= :registry (:op-type ev))
+                                                  (= :rf.registry/handler-replaced
+                                                     (:operation ev))
+                                                  (false? (get-in ev [:tags :different-fn?]))))
+                                           events)]
+            (is (seq different-events)
+                "expected at least one handler-replaced with :different-fn? true")
+            (is (seq idempotent-events)
+                "expected at least one handler-replaced with :different-fn? false (frame re-reg)")
+            (let [t (:tags (first different-events))]
+              (is (keyword? (:kind t)))
+              (is (some?    (:id t)))
+              (is (true?    (:different-fn? t))))))
 
         ;; ---- :machine op-type ----------------------------------------------
         (testing ":machine :rf.machine/transition fires on a machine event"


### PR DESCRIPTION
## Summary

Round-9 batched-by-surface dispatch against `implementation/core`. Four
P2 follow-on beads from the rf2-byut1 round-2 audit, one commit per
bead in one PR.

### Commits

| Bead | Commit | Title |
|---|---|---|
| rf2-rk169 | 341ab00a | align rf/handlers predicate contract with metadata-only spec |
| rf2-6w7zn | c1c80380 | emit :rf.registry/handler-replaced on every re-registration |
| rf2-4ymm0 | a82ccd6a | P2 polish bundle — CQ4/EV4/PF1/SP6/CFX3 |
| rf2-o7ayf | 5a926dcf | direct unit coverage for emit-substrate + core-artefact factory |

### Per-bead notes

**rf2-rk169 — handlers predicate (metadata-only).** Spec (API.md row
156, 001 §The query API, 002 §The public registrar query API) describes
the `pred-fn` as applied to each metadata-map. The impl called it as
`(pred-fn id meta)` — non-portable. Pre-alpha: switch to the spec'd
shape, update the lone existing test to use `(fn [m] ...)`.

**rf2-6w7zn — handler-replaced on every re-registration.** Spec 001
§Hot-reload trace surface mandates emit on every re-registration so
devtools refresh from the event. The impl gated on
`(not= (:handler-fn previous) (:handler-fn metadata))`, dropping legitimate
events for kinds like `:frame` whose slot replacement need not rotate
`:handler-fn`. Emit unconditionally; keep `:different-fn?` in `:tags`
so tooling can branch idempotent reloads.

**rf2-4ymm0 — P2 polish bundle.** Selected items from the 23-item
bundle, scoped to `implementation/core` to avoid spec hot-zone risk
(spec/Conventions.md, spec/Spec-Schemas.md, spec/001-Registration.md
are sequential per the dispatch rules):
- **CQ4** — `with-frame` rejects vector bindings of wrong arity
  (correctness; prevents silent fall-through to Shape 1 with vector
  `*current-frame*` value)
- **EV4** — `police-effect-map-shape!` short-circuits on well-shaped
  maps via `every? #{:db :fx}` pre-check
- **PF1** — collapse `build-name` JVM/CLJS twins into one CLJC defn
  (bodies were identical)
- **SP6** — shared `runs-on-platform?` helper across fx/cofx
- **CFX3** — align `:db` / `:event` standard-cofx docstrings

Skipped (hot-zone): SP3/SP9 (`:event/kind` → `:rf.event/kind`),
CFX1 (`::cofx/no-value` → `:rf.cofx/no-value`).

**rf2-o7ayf — audit → tests.** Audit recommended direct unit tests for
`emit_substrate/make-listener-registry` and `core_artefact/defwrapper`
absent-policy branches — both underpin multiple public surfaces, both
had only indirect coverage.
- `emit_substrate_test.clj` (9 tests): register / unregister / clear /
  fan-out / empty-noop / listener-exception isolation / external atom /
  re-register-replaces.
- `core_artefact_test.clj` (12 tests): every `:on-absent` policy
  (`:throw` / `:nil` / `:false` / `:empty-vec` / `:empty-map` /
  literal), `:ex-data` symbol scoping, structured throw shape.

### LoC delta

10 files changed, 487 insertions(+), 99 deletions(-) — net +388 LoC,
driven by the +290 LoC of new tests (rf2-o7ayf).

## Test plan

- [x] `clojure -M:test` from `implementation/core` — 477 tests, 2461
  assertions, all passing (was 456 before; +21 new tests)
- [x] `npm run test:cljs` — 1817 tests, 5105 assertions, all passing
- [x] `npm run test:elision` — every sentinel PRESENT