### PR TITLE
refactor(http): round-2 polish cluster — 12 follow-on beads (rf2-jklja)

### DIFF
--- a/implementation/http/src/re_frame/http_decode.cljc
+++ b/implementation/http/src/re_frame/http_decode.cljc
@@ -76,26 +76,32 @@
 ;; Memoised resolves (per rf2-tja2y). The Malli vars never rebind at
 ;; runtime; resolving once per JVM / once per CLJS runtime is enough,
 ;; and the deref asymmetry (JVM `requiring-resolve` returns a Var,
-;; CLJS `resolve` returns the value directly) is normalised here so
-;; the call site is platform-uniform per rf2-exycf.
+;; CLJS `resolve` returns the value directly) is normalised behind
+;; the delays so the call sites in `malli-decode` invoke the cached
+;; fn directly (per rf2-exycf).
 ;;
-;; On CLJS `resolve` is the compile-time analyzer affordance — these
-;; delays evaluate once at first call; subsequent decodes share the
-;; cached fn.
+;; CLJS `resolve` is a compile-time macro that requires a literal
+;; quoted symbol — we cannot factor the symbol behind a runtime fn
+;; arg without breaking CLJS analysis. Each delay therefore inlines
+;; its symbol.
 
-(defn- resolve-fn
-  "Resolve `sym` to its var-deref'd function value (or nil if absent).
-  Threading the `#?(:clj :cljs)` here lets callers use the returned
-  value uniformly without further reader conditionals."
-  [sym]
-  #?(:clj  (try (some-> (requiring-resolve sym) deref)
-                (catch Throwable _ nil))
-     :cljs (try (some-> (resolve sym))
-                (catch :default _ nil))))
+(defonce ^:private malli-decode-fn
+  (delay #?(:clj  (try (some-> (requiring-resolve 'malli.core/decode) deref)
+                       (catch Throwable _ nil))
+            :cljs (try (resolve 'malli.core/decode)
+                       (catch :default _ nil)))))
 
-(defonce ^:private malli-decode-fn      (delay (resolve-fn 'malli.core/decode)))
-(defonce ^:private malli-transformer-fn (delay (resolve-fn 'malli.transform/json-transformer)))
-(defonce ^:private malli-validate-fn    (delay (resolve-fn 'malli.core/validate)))
+(defonce ^:private malli-transformer-fn
+  (delay #?(:clj  (try (some-> (requiring-resolve 'malli.transform/json-transformer) deref)
+                       (catch Throwable _ nil))
+            :cljs (try (resolve 'malli.transform/json-transformer)
+                       (catch :default _ nil)))))
+
+(defonce ^:private malli-validate-fn
+  (delay #?(:clj  (try (some-> (requiring-resolve 'malli.core/validate) deref)
+                       (catch Throwable _ nil))
+            :cljs (try (resolve 'malli.core/validate)
+                       (catch :default _ nil)))))
 
 (defn- malli-decode
   "Run a Malli schema's `decode` over `value`, falling back to plain

--- a/implementation/http/src/re_frame/http_decode.cljc
+++ b/implementation/http/src/re_frame/http_decode.cljc
@@ -1,0 +1,171 @@
+(ns re-frame.http-decode
+  "Response-body decoding for `:rf.http/managed`. Per Spec 014 §Decoding
+  / §`:auto` (rf2-5ijhk split).
+
+  Extracted from `re-frame.http-encoding` per rf2-5ijhk — the original
+  encoding namespace mixed five concerns; this sibling isolates the
+  decode pipeline (`content-type-of`, `sniff-decoder`, `malli-decode`,
+  `decode-response-body`).
+
+  Decoding maps the response `body-text` + `headers` + user-supplied
+  `:decode` to a Clojure value. The user's `:decode` can be:
+
+   - `:auto` / omitted — sniff the response Content-Type header
+                         (`:json` / `:text` / `:blob`).
+   - `:json` / `:text` / `:blob` / `:array-buffer` / `:form-data` —
+                         force a specific shape.
+   - A Malli schema     — JSON-parse then run `malli.core/decode` with
+                         the JSON-transformer, validating the result.
+   - A fn               — `(fn [body-text headers] decoded)`. Full
+                         control. Throws classify as
+                         `:rf.http/decode-failure`.
+
+  Malli decode requires `malli.core/decode` + optionally
+  `malli.transform/json-transformer` + `malli.core/validate`. They are
+  looked up via `requiring-resolve` (JVM) / `resolve` (CLJS) and
+  memoised in `defonce`d delays (rf2-tja2y) — the http artefact does
+  NOT depend on Malli at production-classpath time, so Malli-absent
+  apps still load the namespace; the decode call falls through to a
+  no-op (returns the parsed value) when Malli isn't on the classpath.
+
+  The schema-validation failure throws an ex-info with `:malli-error?
+  true`; the caller (`http-transport/handle-response!`) classifies as
+  `:rf.http/decode-failure :schema-validation-failure? true`."
+  (:require [clojure.string  :as str]
+            [re-frame.http-privacy :as privacy]
+            [re-frame.interop :as interop]
+            [re-frame.trace   :as trace]
+            [re-frame.util-json :as util-json]))
+
+(defn content-type-of
+  "Per Spec 014 §Request envelope — HTTP header names are case-insensitive.
+  Scan `headers` for a `content-type` key in any casing, returning the
+  value (or nil). Tolerates keyword keys (rare, but used by some
+  middlewares); ignores non-string non-keyword keys.
+
+  Used by `decode-response-body` (response-side sniffing) and by the
+  transport's request-side clash check. The JVM transport additionally
+  normalises response headers to lower-case at the boundary
+  (`jvm-headers->map`) to match the CLJS Fetch path — this helper is the
+  belt to that braces: even a hand-constructed headers map with mixed
+  casing (e.g. an interceptor `:before` that synthesises headers) is
+  resolved correctly."
+  [headers]
+  (when (map? headers)
+    (reduce-kv
+      (fn [_ k v]
+        (let [k-str (cond
+                      (string? k)  k
+                      (keyword? k) (name k)
+                      :else        nil)]
+          (if (and k-str (= "content-type" (str/lower-case k-str)))
+            (reduced v)
+            nil)))
+      nil
+      headers)))
+
+(defn- sniff-decoder
+  "Per Spec 014 §`:auto`: sniff the response Content-Type header."
+  [content-type]
+  (let [ct (some-> content-type str/lower-case)]
+    (cond
+      (and ct (str/includes? ct "application/json")) :json
+      (and ct (str/starts-with? ct "text/"))         :text
+      :else                                          :blob)))
+
+;; Memoised resolves (per rf2-tja2y). The Malli vars never rebind at
+;; runtime; resolving once per JVM / once per CLJS runtime is enough,
+;; and the deref asymmetry (JVM `requiring-resolve` returns a Var,
+;; CLJS `resolve` returns the value directly) is normalised here so
+;; the call site is platform-uniform per rf2-exycf.
+;;
+;; On CLJS `resolve` is the compile-time analyzer affordance — these
+;; delays evaluate once at first call; subsequent decodes share the
+;; cached fn.
+
+(defn- resolve-fn
+  "Resolve `sym` to its var-deref'd function value (or nil if absent).
+  Threading the `#?(:clj :cljs)` here lets callers use the returned
+  value uniformly without further reader conditionals."
+  [sym]
+  #?(:clj  (try (some-> (requiring-resolve sym) deref)
+                (catch Throwable _ nil))
+     :cljs (try (some-> (resolve sym))
+                (catch :default _ nil))))
+
+(defonce ^:private malli-decode-fn      (delay (resolve-fn 'malli.core/decode)))
+(defonce ^:private malli-transformer-fn (delay (resolve-fn 'malli.transform/json-transformer)))
+(defonce ^:private malli-validate-fn    (delay (resolve-fn 'malli.core/validate)))
+
+(defn- malli-decode
+  "Run a Malli schema's `decode` over `value`, falling back to plain
+  validate-or-throw if the transformer pipeline is unavailable. Throws
+  on failure so the caller can classify as `:rf.http/decode-failure`."
+  [schema value]
+  (let [decode      @malli-decode-fn
+        transformer @malli-transformer-fn
+        validate    @malli-validate-fn
+        decoded     (cond
+                      (and decode transformer) (decode schema value (transformer))
+                      decode                   (decode schema value nil)
+                      :else                    value)]
+    (when validate
+      (when-not (validate schema decoded)
+        (throw (ex-info "schema validation failed"
+                        {:schema schema :value decoded :malli-error? true}))))
+    decoded))
+
+(defn decode-response-body
+  "Per Spec 014 §Decoding. Returns the decoded value or throws an
+  ex-info that the caller maps to `:rf.http/decode-failure`."
+  [{:keys [body-text headers decode decode-supplied? request-id url sensitive?]}]
+  (let [content-type (content-type-of headers)
+        decoder      (cond
+                       (nil? decode)        :auto
+                       (= :auto decode)     :auto
+                       :else                decode)
+        resolved     (cond
+                       (= :auto decoder) (sniff-decoder content-type)
+                       :else             decoder)]
+    ;; Per Spec 014 §`:auto`: emit `:rf.warning/decode-defaulted` when
+    ;; the user did NOT supply `:decode` and we fell back to auto-
+    ;; sniffing. Per rf2-2p8wr the URL passes through
+    ;; `privacy/prepare-emit-tags`, which redacts denylisted query-
+    ;; string param values and stamps `:sensitive?` when applicable.
+    (when (and (not decode-supplied?)
+               (= :auto decoder)
+               interop/debug-enabled?)
+      (trace/emit! :warning :rf.warning/decode-defaulted
+                   (privacy/prepare-emit-tags
+                     {:request-id       request-id
+                      :url              url
+                      :content-type     content-type
+                      :resolved-decoder (if (keyword? resolved) resolved :auto)}
+                     (true? sensitive?))))
+    (cond
+      (fn? decoder)
+      (decoder body-text headers)
+
+      (= :json resolved)
+      (util-json/json-parse body-text)
+
+      (= :text resolved)
+      body-text
+
+      (= :blob resolved)
+      body-text
+
+      (= :array-buffer resolved)
+      body-text
+
+      (= :form-data resolved)
+      body-text
+
+      ;; Malli schema (or anything keyword-like that isn't recognised above).
+      (some? resolved)
+      (let [parsed (try (util-json/json-parse body-text)
+                        (catch #?(:clj Throwable :cljs :default) _ body-text))]
+        (malli-decode resolved parsed))
+
+      :else
+      body-text)))

--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -166,24 +166,6 @@
                         {:schema schema :value decoded :malli-error? true}))))
     decoded))
 
-(defn- maybe-emit-decode-defaulted!
-  "Per Spec 014 §`:auto`: emit `:rf.warning/decode-defaulted` when the
-  user did NOT supply `:decode`.
-
-  Per rf2-2p8wr: the URL passes through `privacy/prepare-emit-tags`,
-  which redacts denylisted query-string param values (and stamps
-  `:sensitive?` when the originating request was sensitive or when a
-  denylisted param name was present)."
-  [{:keys [decode-supplied? request-id url content-type resolved-decoder sensitive?]}]
-  (when (and (not decode-supplied?) interop/debug-enabled?)
-    (trace/emit! :warning :rf.warning/decode-defaulted
-                 (privacy/prepare-emit-tags
-                   {:request-id       request-id
-                    :url              url
-                    :content-type     content-type
-                    :resolved-decoder resolved-decoder}
-                   (true? sensitive?)))))
-
 (defn decode-response-body
   "Per Spec 014 §Decoding. Returns the decoded value or throws an
   ex-info that the caller maps to `:rf.http/decode-failure`."
@@ -196,16 +178,21 @@
         resolved     (cond
                        (= :auto decoder) (sniff-decoder content-type)
                        :else             decoder)]
-    (when (or (= :auto decoder) (and (not decode-supplied?) (= decode :auto)))
-      (maybe-emit-decode-defaulted!
-        {:decode-supplied? decode-supplied?
-         :request-id       request-id
-         :url              url
-         :content-type     content-type
-         :sensitive?       sensitive?
-         :resolved-decoder (cond
-                             (keyword? resolved) resolved
-                             :else               :auto)}))
+    ;; Per Spec 014 §`:auto`: emit `:rf.warning/decode-defaulted` when
+    ;; the user did NOT supply `:decode` and we fell back to auto-
+    ;; sniffing. Per rf2-2p8wr the URL passes through
+    ;; `privacy/prepare-emit-tags`, which redacts denylisted query-
+    ;; string param values and stamps `:sensitive?` when applicable.
+    (when (and (not decode-supplied?)
+               (= :auto decoder)
+               interop/debug-enabled?)
+      (trace/emit! :warning :rf.warning/decode-defaulted
+                   (privacy/prepare-emit-tags
+                     {:request-id       request-id
+                      :url              url
+                      :content-type     content-type
+                      :resolved-decoder (if (keyword? resolved) resolved :auto)}
+                     (true? sensitive?))))
     (cond
       (fn? decoder)
       (decoder body-text headers)

--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -6,26 +6,27 @@
   trivially testable and shared by the unified Fetch (CLJS) +
   `HttpClient` (JVM) transport in `re-frame.http-transport`.
 
-  Surfaces:
+  Surfaces (post-rf2-5ijhk split):
 
   - URL / query-string encoding: `url-encode`, `params->query`,
     `merge-params`.
-  - Body encoding: `realise-body`, `encode-body` (handles
+  - Request body encoding: `realise-body`, `encode-body` (handles
     `:request-content-type` :json / :form / :text / explicit string,
     plus heuristics for raw Clojure colls).
-  - Decode pipeline: `sniff-decoder`, `malli-decode`, `decode-response-
-    body`, `maybe-emit-decode-defaulted!`.
-  - `:accept` normalisation: `default-accept-fn`, `run-accept`.
-  - Failure / reply addressing: `failure-map`, `build-reply-event`.
+  - `:accept` normalisation: `run-accept` (and the inline default).
+  - Failure shape: `failure-map`.
+  - Reply addressing: `resolve-origin-event`, `build-reply-event`,
+    `dispatch-reply-via-late-bind!`.
   - Backoff: `compute-backoff-ms`.
 
-  Per Spec 014 §Body encoding, §Decoding, §`:auto`, §`:accept`,
-  §Failure categories, §Reply addressing, §Retry and backoff."
+  The response-side decode pipeline (`content-type-of`, `sniff-decoder`,
+  `malli-decode`, `decode-response-body`) lives in `re-frame.http-
+  decode` per rf2-5ijhk.
+
+  Per Spec 014 §Body encoding, §`:accept`, §Failure categories,
+  §Reply addressing, §Retry and backoff."
   (:require [clojure.string  :as str]
-            [re-frame.interop :as interop]
-            [re-frame.http-privacy :as privacy]
             [re-frame.late-bind :as late-bind]
-            [re-frame.trace   :as trace]
             [re-frame.util-json :as util-json])
   #?(:clj (:import [java.net URLEncoder])))
 
@@ -97,161 +98,22 @@
     ;; pass-through (Blob / FormData / ArrayBuffer / pre-encoded string)
     [body nil]))
 
-;; ---- decode pipeline ------------------------------------------------------
-
-(defn content-type-of
-  "Per Spec 014 §Request envelope — HTTP header names are case-insensitive.
-  Scan `headers` for a `content-type` key in any casing, returning the
-  value (or nil). Tolerates keyword keys (rare, but used by some
-  middlewares); ignores non-string non-keyword keys.
-
-  Used by `decode-response-body` (response-side sniffing) and by the
-  transport's request-side clash check. The JVM transport additionally
-  normalises response headers to lower-case at the boundary
-  (`jvm-headers->map`) to match the CLJS Fetch path — this helper is the
-  belt to that braces: even a hand-constructed headers map with mixed
-  casing (e.g. an interceptor `:before` that synthesises headers) is
-  resolved correctly."
-  [headers]
-  (when (map? headers)
-    (reduce-kv
-      (fn [_ k v]
-        (let [k-str (cond
-                      (string? k)  k
-                      (keyword? k) (name k)
-                      :else        nil)]
-          (if (and k-str (= "content-type" (str/lower-case k-str)))
-            (reduced v)
-            nil)))
-      nil
-      headers)))
-
-(defn- sniff-decoder
-  "Per Spec 014 §`:auto`: sniff the response Content-Type header."
-  [content-type]
-  (let [ct (some-> content-type str/lower-case)]
-    (cond
-      (and ct (str/includes? ct "application/json")) :json
-      (and ct (str/starts-with? ct "text/"))         :text
-      :else                                          :blob)))
-
-;; Memoised resolves (per rf2-tja2y). The Malli vars never rebind at
-;; runtime; resolving once per JVM / once per CLJS runtime is enough,
-;; and the deref asymmetry (JVM `requiring-resolve` returns a Var,
-;; CLJS `resolve` returns the value directly) is normalised here so
-;; the call site is platform-uniform per rf2-exycf.
-;;
-;; On CLJS `resolve` is the compile-time analyzer affordance — these
-;; delays evaluate once at first call; subsequent decodes share the
-;; cached fn.
-
-(defn- resolve-fn
-  "Resolve `sym` to its var-deref'd function value (or nil if absent).
-  Threading the `#?(:clj :cljs)` here lets callers use the returned
-  value uniformly without further reader conditionals."
-  [sym]
-  #?(:clj  (try (some-> (requiring-resolve sym) deref)
-                (catch Throwable _ nil))
-     :cljs (try (some-> (resolve sym))
-                (catch :default _ nil))))
-
-(defonce ^:private malli-decode-fn      (delay (resolve-fn 'malli.core/decode)))
-(defonce ^:private malli-transformer-fn (delay (resolve-fn 'malli.transform/json-transformer)))
-(defonce ^:private malli-validate-fn    (delay (resolve-fn 'malli.core/validate)))
-
-(defn- malli-decode
-  "Run a Malli schema's `decode` over `value`, falling back to plain
-  validate-or-throw if the transformer pipeline is unavailable. Throws
-  on failure so the caller can classify as `:rf.http/decode-failure`."
-  [schema value]
-  (let [decode      @malli-decode-fn
-        transformer @malli-transformer-fn
-        validate    @malli-validate-fn
-        decoded     (cond
-                      (and decode transformer) (decode schema value (transformer))
-                      decode                   (decode schema value nil)
-                      :else                    value)]
-    (when validate
-      (when-not (validate schema decoded)
-        (throw (ex-info "schema validation failed"
-                        {:schema schema :value decoded :malli-error? true}))))
-    decoded))
-
-(defn decode-response-body
-  "Per Spec 014 §Decoding. Returns the decoded value or throws an
-  ex-info that the caller maps to `:rf.http/decode-failure`."
-  [{:keys [body-text headers decode decode-supplied? request-id url sensitive?]}]
-  (let [content-type (content-type-of headers)
-        decoder      (cond
-                       (nil? decode)        :auto
-                       (= :auto decode)     :auto
-                       :else                decode)
-        resolved     (cond
-                       (= :auto decoder) (sniff-decoder content-type)
-                       :else             decoder)]
-    ;; Per Spec 014 §`:auto`: emit `:rf.warning/decode-defaulted` when
-    ;; the user did NOT supply `:decode` and we fell back to auto-
-    ;; sniffing. Per rf2-2p8wr the URL passes through
-    ;; `privacy/prepare-emit-tags`, which redacts denylisted query-
-    ;; string param values and stamps `:sensitive?` when applicable.
-    (when (and (not decode-supplied?)
-               (= :auto decoder)
-               interop/debug-enabled?)
-      (trace/emit! :warning :rf.warning/decode-defaulted
-                   (privacy/prepare-emit-tags
-                     {:request-id       request-id
-                      :url              url
-                      :content-type     content-type
-                      :resolved-decoder (if (keyword? resolved) resolved :auto)}
-                     (true? sensitive?))))
-    (cond
-      (fn? decoder)
-      (decoder body-text headers)
-
-      (= :json resolved)
-      (util-json/json-parse body-text)
-
-      (= :text resolved)
-      body-text
-
-      (= :blob resolved)
-      body-text
-
-      (= :array-buffer resolved)
-      body-text
-
-      (= :form-data resolved)
-      body-text
-
-      ;; Malli schema (or anything keyword-like that isn't recognised above).
-      (some? resolved)
-      (let [parsed (try (util-json/json-parse body-text)
-                        (catch #?(:clj Throwable :cljs :default) _ body-text))]
-        (malli-decode resolved parsed))
-
-      :else
-      body-text)))
-
 ;; ---- :accept normalisation ------------------------------------------------
 
-(defn- default-accept-fn
-  "Per Spec 014 §`:accept` — domain-failure normalisation. The default
-  `:accept` returns `{:ok decoded}` for 2xx, `{:failure ...}` otherwise."
-  [{:keys [status]}]
-  (fn [decoded]
-    (cond
-      (and (>= status 200) (< status 300))
-      {:ok decoded}
-
-      :else
-      {:failure {:kind :http-status :status status :body decoded}})))
-
 (defn run-accept
-  "Run the user's `:accept` fn (or the default) against `decoded`. Returns
-  `{:ok v}` or `{:failure m}`."
-  [accept-fn-or-nil decoded ctx]
-  (let [accept (or accept-fn-or-nil (default-accept-fn ctx))]
-    (accept decoded)))
+  "Per Spec 014 §`:accept` — domain-failure normalisation. Run the
+  user's `:accept` fn (or the default) against `decoded`. Returns
+  `{:ok v}` or `{:failure m}`.
+
+  Per rf2-5ijhk + audit finding 3.3 the default-accept shape is
+  inlined here (the earlier `default-accept-fn` allocated a fresh
+  closure per response even when the user didn't supply `:accept`)."
+  [accept-fn-or-nil decoded {:keys [status]}]
+  (if accept-fn-or-nil
+    (accept-fn-or-nil decoded)
+    (if (and (>= status 200) (< status 300))
+      {:ok decoded}
+      {:failure {:kind :http-status :status status :body decoded}})))
 
 ;; ---- failure shape --------------------------------------------------------
 

--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -309,13 +309,19 @@
 
 (defn compute-backoff-ms
   "Per Spec 014 §Retry and backoff. Returns the delay in ms before the
-  next attempt. `attempt` is the failing attempt number (1-based)."
+  next attempt. `attempt` is the failing attempt number (1-based).
+
+  Per Spec 014 line 250 — `:jitter true` adds random ±25% jitter to
+  each delay (offset uniformly in [-0.25 × capped, +0.25 × capped])."
   [{:keys [base-ms factor max-ms jitter] :or {base-ms 250 factor 2 max-ms 5000}} attempt]
-  (let [raw     (* base-ms (Math/pow factor (max 0 (dec attempt))))
-        capped  (min raw max-ms)
+  (let [raw      (* base-ms (Math/pow factor (max 0 (dec attempt))))
+        capped   (min raw max-ms)
+        ;; (- 1.0 (* 2.0 (rand))) is uniform in [-1.0, +1.0]; scaled by
+        ;; 0.25 × capped this yields a true ±25% offset matching the
+        ;; spec's stated range. (The earlier impl used (- 0.5 (rand)) ×
+        ;; 0.25 × capped which is only ±12.5%.)
         jittered (if jitter
-                   (let [j (* capped 0.25)
-                         offset (* j (- 0.5 (rand)))]
+                   (let [offset (* capped 0.25 (- 1.0 (* 2.0 (rand))))]
                      (max 0 (+ capped offset)))
                    capped)]
     (long jittered)))

--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -24,6 +24,7 @@
   (:require [clojure.string  :as str]
             [re-frame.interop :as interop]
             [re-frame.http-privacy :as privacy]
+            [re-frame.late-bind :as late-bind]
             [re-frame.trace   :as trace]
             [re-frame.util-json :as util-json])
   #?(:clj (:import [java.net URLEncoder])))
@@ -283,6 +284,23 @@
   (or (:event frame-ctx)
       (:rf.http/origin-event args-map)
       [:rf.http/managed]))
+
+(declare build-reply-event)
+
+(defn dispatch-reply-via-late-bind!
+  "Compose `build-reply-event` with a late-bind `:router/dispatch!` lookup
+  and fire the dispatch. The single truth point for 'how does http
+  dispatch its reply' — shared by `http-transport/dispatch-reply!` and
+  the canned-stub handlers in `http-machine-wrapper`. Per rf2-2utlm.
+
+  `args` is the same map `build-reply-event` consumes; `frame` (optional)
+  is threaded as `{:frame <id>}` onto the dispatch options when present.
+  No-op when the registered router is absent or `build-reply-event`
+  returns nil (silenced reply)."
+  [args frame]
+  (when-let [ev (build-reply-event args)]
+    (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+      (dispatch! ev (cond-> {} frame (assoc :frame frame))))))
 
 (defn build-reply-event
   "Per Spec 014 §Reply addressing. Returns the event vector to dispatch,

--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -134,34 +134,44 @@
       (and ct (str/starts-with? ct "text/"))         :text
       :else                                          :blob)))
 
+;; Memoised resolves (per rf2-tja2y). The Malli vars never rebind at
+;; runtime; resolving once per JVM / once per CLJS runtime is enough,
+;; and the deref asymmetry (JVM `requiring-resolve` returns a Var,
+;; CLJS `resolve` returns the value directly) is normalised here so
+;; the call site is platform-uniform per rf2-exycf.
+;;
+;; On CLJS `resolve` is the compile-time analyzer affordance — these
+;; delays evaluate once at first call; subsequent decodes share the
+;; cached fn.
+
+(defn- resolve-fn
+  "Resolve `sym` to its var-deref'd function value (or nil if absent).
+  Threading the `#?(:clj :cljs)` here lets callers use the returned
+  value uniformly without further reader conditionals."
+  [sym]
+  #?(:clj  (try (some-> (requiring-resolve sym) deref)
+                (catch Throwable _ nil))
+     :cljs (try (some-> (resolve sym))
+                (catch :default _ nil))))
+
+(defonce ^:private malli-decode-fn      (delay (resolve-fn 'malli.core/decode)))
+(defonce ^:private malli-transformer-fn (delay (resolve-fn 'malli.transform/json-transformer)))
+(defonce ^:private malli-validate-fn    (delay (resolve-fn 'malli.core/validate)))
+
 (defn- malli-decode
   "Run a Malli schema's `decode` over `value`, falling back to plain
   validate-or-throw if the transformer pipeline is unavailable. Throws
   on failure so the caller can classify as `:rf.http/decode-failure`."
   [schema value]
-  (let [decode #?(:clj  (try (requiring-resolve 'malli.core/decode)
-                             (catch Throwable _ nil))
-                  :cljs (try (resolve 'malli.core/decode)
-                             (catch :default _ nil)))
-        transformer #?(:clj  (try (requiring-resolve 'malli.transform/json-transformer)
-                                  (catch Throwable _ nil))
-                       :cljs (try (resolve 'malli.transform/json-transformer)
-                                  (catch :default _ nil)))
-        validate #?(:clj  (try (requiring-resolve 'malli.core/validate)
-                               (catch Throwable _ nil))
-                    :cljs (try (resolve 'malli.core/validate)
-                               (catch :default _ nil)))
-        decoded (cond
-                  (and decode transformer)
-                  #?(:clj  ((deref decode) schema value ((deref transformer)))
-                     :cljs (decode schema value (transformer)))
-                  decode
-                  #?(:clj  ((deref decode) schema value nil)
-                     :cljs (decode schema value nil))
-                  :else value)]
+  (let [decode      @malli-decode-fn
+        transformer @malli-transformer-fn
+        validate    @malli-validate-fn
+        decoded     (cond
+                      (and decode transformer) (decode schema value (transformer))
+                      decode                   (decode schema value nil)
+                      :else                    value)]
     (when validate
-      (when-not #?(:clj  ((deref validate) schema decoded)
-                   :cljs (validate schema decoded))
+      (when-not (validate schema decoded)
         (throw (ex-info "schema validation failed"
                         {:schema schema :value decoded :malli-error? true}))))
     decoded))

--- a/implementation/http/src/re_frame/http_handlers.cljc
+++ b/implementation/http/src/re_frame/http_handlers.cljc
@@ -1,0 +1,125 @@
+(ns re-frame.http-handlers
+  "The `:rf.http/managed` + `:rf.http/managed-abort` fx handler bodies.
+
+  Extracted from `re-frame.http-managed` per rf2-0eyp2 — the façade now
+  re-exports these and wires them into `fx/reg-fx` at load time, but
+  the handler logic lives here alongside the other per-concern siblings
+  (`http-encoding`, `http-registry`, `http-middleware`, `http-transport`,
+  `http-machine-wrapper`, `http-privacy`).
+
+  Two public fns:
+
+  - `managed-handler`       — `:rf.http/managed` body. Threads the
+                              request through the per-frame interceptor
+                              chain, normalises args, supersedes any
+                              prior in-flight request with the same
+                              `:request-id`, then dispatches to the
+                              shared attempt-and-retry loop in
+                              `http-transport`.
+  - `managed-abort-handler` — `:rf.http/managed-abort` body. Resolves
+                              the abort-fn through the in-flight
+                              registry and fires it; cleanup belongs
+                              to the abort-fn → `finalise-failure!`
+                              cascade per rf2-plngk."
+  (:require [re-frame.http-encoding  :as encoding]
+            [re-frame.http-middleware :as middleware]
+            [re-frame.http-privacy   :as privacy]
+            [re-frame.http-registry  :as registry]
+            [re-frame.http-transport :as transport]))
+
+(defn- normalise-args
+  "Validate + normalise the args map. Returns a context ready for the
+  per-host attempt loop.
+
+  `frame-ctx` carries the resolved `:event` (the originating event
+  vector) — `managed-handler` runs `encoding/resolve-origin-event`
+  once before calling here and stashes the result back into
+  `frame-ctx` as `:event`, so the resolution shape lives in exactly
+  one place per rf2-622e3."
+  [{:keys [request decode accept retry timeout-ms
+           on-success on-failure request-id abort-signal]
+    :or   {timeout-ms 30000}
+    :as   args-map}
+   frame-ctx]
+  (let [origin-event (:event frame-ctx)
+        frame        (or (:frame frame-ctx) :rf/default)
+        ;; rf2-wvkn — when the originating event-id is a spawned actor's
+        ;; address, capture it so the in-flight registry can index by
+        ;; actor-id alongside :request-id. The destroy cascade then has
+        ;; a key to walk on actor-destroy. Detection is structural —
+        ;; we look up the id in the frame's [:rf/spawned ...] runtime
+        ;; registry (per Spec 005 §Declarative :invoke); ordinary event
+        ;; handlers' dispatches yield nil and are not tracked.
+        actor-id     (registry/compute-actor-id frame origin-event)
+        ;; rf2-bma05 — compute the effective :sensitive? flag once and
+        ;; thread it through the attempt-and-retry loop. Three sources
+        ;; (OR-reduced): per-call args, per-request, and the originating
+        ;; handler's registration metadata. The flag rides every
+        ;; :rf.http/* trace event emitted within the cascade so
+        ;; consumers honour the privacy contract per Spec 009 §Privacy.
+        sensitive?   (privacy/request-sensitive? args-map origin-event)]
+    {:request           request
+     :decode            decode
+     :decode-supplied?  (some? decode)
+     :accept            accept
+     :retry             retry
+     :timeout-ms        timeout-ms
+     :origin-event      origin-event
+     :explicit-on-success
+     {:supplied? (contains? args-map :on-success)
+      :value     on-success}
+     :explicit-on-failure
+     {:supplied? (contains? args-map :on-failure)
+      :value     on-failure}
+     :request-id        request-id
+     :actor-id          actor-id
+     :abort-signal      abort-signal
+     :frame             frame
+     :attempt           1
+     :sensitive?        sensitive?}))
+
+(defn managed-handler
+  "The public `:rf.http/managed` fx body. `frame-ctx` carries `:frame`
+  and (when threaded by the runtime, per the do-fx 5-arity) `:event` —
+  the originating event vector used for default reply addressing per
+  Spec 014 §Reply addressing.
+
+  Per Spec 014 §Middleware (rf2-6y3q): before normalising args, the
+  per-frame interceptor chain is walked. Each `:before` transforms a
+  ctx `{:request :args :frame :event}`; the runtime threads its return
+  value through the rest of the chain. A throw inside any `:before`
+  classifies as `:rf.error/http-interceptor-failed`; the request is
+  not dispatched."
+  [frame-ctx args-map]
+  (transport/check-cljs-only-keys! args-map)
+  (let [frame-id     (or (:frame frame-ctx) :rf/default)
+        ;; rf2-622e3 — resolve once, thread the result through
+        ;; frame-ctx's :event slot so normalise-args reads it
+        ;; directly instead of re-running the OR-chain.
+        origin-event (encoding/resolve-origin-event frame-ctx args-map)
+        frame-ctx'   (assoc frame-ctx :event origin-event)
+        ctx0         {:request (:request args-map)
+                      :args    args-map
+                      :frame   frame-id
+                      :event   origin-event}
+        ctx          (middleware/run-interceptor-chain! frame-id ctx0)
+        args-map'    (assoc args-map :request (:request ctx))
+        normalised   (normalise-args args-map' frame-ctx')
+        request-id   (:request-id normalised)]
+    (when request-id (registry/supersede! request-id))
+    (transport/run-attempt! normalised)
+    nil))
+
+(defn managed-abort-handler
+  "Public `:rf.http/managed-abort` fx. Args is the request-id (any value).
+
+  Per rf2-plngk the in-flight cleanup is owned by `finalise-failure!`
+  (the abort-fn closure calls into it). The earlier shape pre-cleared
+  the registry here AND inside `finalise-failure!`, doubling the
+  `swap!` traffic per abort. Now the single source of truth lives at
+  the failure-finalise site; this handler only fires the abort-fn."
+  [_frame-ctx request-id]
+  (when-let [handle (registry/lookup-in-flight request-id)]
+    (try ((:abort-fn handle) :user)
+         (catch #?(:clj Throwable :cljs :default) _ nil)))
+  nil)

--- a/implementation/http/src/re_frame/http_machine_wrapper.cljc
+++ b/implementation/http/src/re_frame/http_machine_wrapper.cljc
@@ -44,6 +44,11 @@
             [re-frame.http-encoding :as encoding]
             [re-frame.late-bind    :as late-bind]))
 
+;; rf2-2utlm — the canned stubs delegate to `encoding/dispatch-reply-
+;; via-late-bind!`, the same helper `http-transport/dispatch-reply!`
+;; uses, so the build-reply-event + late-bind lookup pattern lives in
+;; one place.
+
 ;; ---- canned stub handlers (used by the registered :rf.http/managed-* fxs
 ;; AND the per-call stub fx-override that with-managed-request-stubs
 ;; installs). The fxs themselves are registered in the façade so they fire
@@ -57,34 +62,28 @@
 (defn canned-success-handler
   "Stub fx — synthesises a success reply per Spec 014 §Testing."
   [frame-ctx args-map]
-  (let [{:keys [on-success]} args-map
-        value (get args-map :value {:stubbed true})
-        reply {:kind :success :value value}
-        ev    (encoding/build-reply-event {:origin-event (encoding/resolve-origin-event frame-ctx args-map)
-                                           :explicit-on  {:supplied? (contains? args-map :on-success)
-                                                          :value     on-success}
-                                           :reply-payload reply
-                                           :kind          :success})]
-    (when ev
-      (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
-        (dispatch! ev (cond-> {} (:frame frame-ctx) (assoc :frame (:frame frame-ctx))))))
+  (let [value (get args-map :value {:stubbed true})]
+    (encoding/dispatch-reply-via-late-bind!
+      {:origin-event  (encoding/resolve-origin-event frame-ctx args-map)
+       :explicit-on   {:supplied? (contains? args-map :on-success)
+                       :value     (:on-success args-map)}
+       :reply-payload {:kind :success :value value}
+       :kind          :success}
+      (:frame frame-ctx))
     nil))
 
 (defn canned-failure-handler
   [frame-ctx args-map]
-  (let [{:keys [on-failure]} args-map
-        kind  (or (:kind args-map) :rf.http/transport)
-        tags  (or (:tags args-map) {})
-        failure (assoc tags :kind kind)
-        reply {:kind :failure :failure failure}
-        ev    (encoding/build-reply-event {:origin-event (encoding/resolve-origin-event frame-ctx args-map)
-                                           :explicit-on  {:supplied? (contains? args-map :on-failure)
-                                                          :value     on-failure}
-                                           :reply-payload reply
-                                           :kind          :failure})]
-    (when ev
-      (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
-        (dispatch! ev (cond-> {} (:frame frame-ctx) (assoc :frame (:frame frame-ctx))))))
+  (let [kind    (or (:kind args-map) :rf.http/transport)
+        tags    (or (:tags args-map) {})
+        failure (assoc tags :kind kind)]
+    (encoding/dispatch-reply-via-late-bind!
+      {:origin-event  (encoding/resolve-origin-event frame-ctx args-map)
+       :explicit-on   {:supplied? (contains? args-map :on-failure)
+                       :value     (:on-failure args-map)}
+       :reply-payload {:kind :failure :failure failure}
+       :kind          :failure}
+      (:frame frame-ctx))
     nil))
 
 ;; ---- with-managed-request-stubs ------------------------------------------

--- a/implementation/http/src/re_frame/http_managed.cljc
+++ b/implementation/http/src/re_frame/http_managed.cljc
@@ -277,20 +277,18 @@
 ;; namespace because the http artefact is optional (apps that don't
 ;; issue any managed-HTTP requests don't carry it). Publish entry
 ;; points through the late-bind hook registry; consumers look the fns
-;; up at call time. See re-frame.late-bind.
+;; up at call time. The contracts live in each sub-namespace's
+;; docstring (see e.g. `registry/abort-on-actor-destroy`,
+;; `middleware/reg-http-interceptor`); the listing below is alphabetical
+;; for scan-ability.
 
+(late-bind/set-fn! :http/abort-on-actor-destroy           abort-on-actor-destroy)
+(late-bind/set-fn! :http/clear-all-http-interceptors!     clear-all-http-interceptors!)
+(late-bind/set-fn! :http/clear-all-in-flight!             clear-all-in-flight!)
+(late-bind/set-fn! :http/clear-http-interceptor           clear-http-interceptor)
 (late-bind/set-fn! :http/install-managed-request-stubs!   install-managed-request-stubs!)
+(late-bind/set-fn! :http/reg-http-interceptor             reg-http-interceptor)
+(late-bind/set-fn! :http/register-managed-machine!        machine-wrapper/register-managed-machine!)
 (late-bind/set-fn! :http/uninstall-managed-request-stubs! uninstall-managed-request-stubs!)
 (late-bind/set-fn! :http/with-managed-request-stubs*      with-managed-request-stubs*)
-(late-bind/set-fn! :http/clear-all-in-flight!             clear-all-in-flight!)
-;; rf2-6y3q — per-frame request-side interceptor chain (Spec 014 §Middleware).
-(late-bind/set-fn! :http/reg-http-interceptor             reg-http-interceptor)
-(late-bind/set-fn! :http/clear-http-interceptor           clear-http-interceptor)
-(late-bind/set-fn! :http/clear-all-http-interceptors!     clear-all-http-interceptors!)
-;; rf2-wvkn — :invoke cancellation cascade (Spec 014 §Abort on actor destroy).
-(late-bind/set-fn! :http/abort-on-actor-destroy           abort-on-actor-destroy)
-;; rf2-ijm7 — register the machine-shape wrapper (skipped silently if
-;; the machines artefact isn't on the classpath; the fx surface is
-;; unaffected either way).
-(late-bind/set-fn! :http/register-managed-machine!        machine-wrapper/register-managed-machine!)
 (machine-wrapper/register-managed-machine!)

--- a/implementation/http/src/re_frame/http_managed.cljc
+++ b/implementation/http/src/re_frame/http_managed.cljc
@@ -218,10 +218,15 @@
     nil))
 
 (defn- managed-abort-handler
-  "Public `:rf.http/managed-abort` fx. Args is the request-id (any value)."
+  "Public `:rf.http/managed-abort` fx. Args is the request-id (any value).
+
+  Per rf2-plngk the in-flight cleanup is owned by `finalise-failure!`
+  (the abort-fn closure calls into it). The earlier shape pre-cleared
+  the registry here AND inside `finalise-failure!`, doubling the
+  `swap!` traffic per abort. Now the single source of truth lives at
+  the failure-finalise site; this handler only fires the abort-fn."
   [_frame-ctx request-id]
   (when-let [handle (registry/lookup-in-flight request-id)]
-    (registry/clear-in-flight! request-id)
     (try ((:abort-fn handle) :user)
          (catch #?(:clj Throwable :cljs :default) _ nil)))
   nil)

--- a/implementation/http/src/re_frame/http_managed.cljc
+++ b/implementation/http/src/re_frame/http_managed.cljc
@@ -45,7 +45,7 @@
   failure taxonomy, or any of the `:rf.http/*` keyword strings onto the
   classpath.
 
-  ## File split (rf2-3i9b, rf2-p7da)
+  ## File split (rf2-3i9b, rf2-p7da, rf2-0eyp2)
 
   This namespace was 1790 LoC pre-split; it's now a thin public façade.
   The implementation is in per-concern sibling namespaces (flat
@@ -54,7 +54,8 @@
 
    - `re-frame.http-encoding`       — URL/query/body encoding, decode
                                       pipeline, `:accept` normalisation,
-                                      failure-map / build-reply-event,
+                                      failure-map / build-reply-event /
+                                      `dispatch-reply-via-late-bind!`,
                                       backoff. All pure fns.
    - `re-frame.http-registry`       — in-flight request + actor-id
                                       indexes, supersede semantics,
@@ -67,6 +68,9 @@
                                       platform-specific fragments are
                                       gated with reader conditionals
                                       (rf2-921qy).
+   - `re-frame.http-handlers`      — `:rf.http/managed` /
+                                      `:rf.http/managed-abort` fx
+                                      handler bodies (rf2-0eyp2).
    - `re-frame.http-machine-wrapper`— machine-shape wrapper (rf2-ijm7),
                                       canned stub handlers,
                                       with-managed-request-stubs*.
@@ -81,13 +85,11 @@
   `:rf.http/*` fx registrations and the `late-bind/set-fn!` hook
   publications that `re-frame.core` reaches through."
   (:require [re-frame.fx                   :as fx]
-            [re-frame.http-encoding        :as encoding]
+            [re-frame.http-handlers        :as handlers]
             [re-frame.http-machine-wrapper :as machine-wrapper]
             [re-frame.http-middleware      :as middleware]
-            [re-frame.http-privacy         :as privacy]
             [re-frame.http-privacy-headers :as privacy-headers]
             [re-frame.http-registry        :as registry]
-            [re-frame.http-transport       :as transport]
             [re-frame.interop              :as interop]
             [re-frame.late-bind            :as late-bind]))
 
@@ -125,121 +127,22 @@
 (def clear-sensitive-headers!   privacy-headers/clear-sensitive-headers!)
 (def default-header-denylist    privacy-headers/default-header-denylist)
 
-;; ---- normalise-args + managed-handler -------------------------------------
-;;
-;; The fx entry point lives here in the façade — it threads the request
-;; through the per-frame interceptor chain (middleware), then dispatches
-;; to the shared attempt loop. Keeping this in the façade means the
-;; sub-namespaces don't need to know about each other (the transport
-;; doesn't `:require` middleware/registry-management; it just runs the
-;; attempt loop).
-
-(defn- normalise-args
-  "Validate + normalise the args map. Returns a context ready for the
-  per-host attempt loop.
-
-  `frame-ctx` carries the resolved `:event` (the originating event
-  vector) — `managed-handler` runs `encoding/resolve-origin-event`
-  once before calling here and stashes the result back into
-  `frame-ctx` as `:event`, so the resolution shape lives in exactly
-  one place per rf2-622e3."
-  [{:keys [request decode accept retry timeout-ms
-           on-success on-failure request-id abort-signal]
-    :or   {timeout-ms 30000}
-    :as   args-map}
-   frame-ctx]
-  (let [origin-event (:event frame-ctx)
-        frame        (or (:frame frame-ctx) :rf/default)
-        ;; rf2-wvkn — when the originating event-id is a spawned actor's
-        ;; address, capture it so the in-flight registry can index by
-        ;; actor-id alongside :request-id. The destroy cascade then has
-        ;; a key to walk on actor-destroy. Detection is structural —
-        ;; we look up the id in the frame's [:rf/spawned ...] runtime
-        ;; registry (per Spec 005 §Declarative :invoke); ordinary event
-        ;; handlers' dispatches yield nil and are not tracked.
-        actor-id     (registry/compute-actor-id frame origin-event)
-        ;; rf2-bma05 — compute the effective :sensitive? flag once and
-        ;; thread it through the attempt-and-retry loop. Three sources
-        ;; (OR-reduced): per-call args, per-request, and the originating
-        ;; handler's registration metadata. The flag rides every
-        ;; :rf.http/* trace event emitted within the cascade so
-        ;; consumers honour the privacy contract per Spec 009 §Privacy.
-        sensitive?   (privacy/request-sensitive? args-map origin-event)]
-    {:request           request
-     :decode            decode
-     :decode-supplied?  (some? decode)
-     :accept            accept
-     :retry             retry
-     :timeout-ms        timeout-ms
-     :origin-event      origin-event
-     :explicit-on-success
-     {:supplied? (contains? args-map :on-success)
-      :value     on-success}
-     :explicit-on-failure
-     {:supplied? (contains? args-map :on-failure)
-      :value     on-failure}
-     :request-id        request-id
-     :actor-id          actor-id
-     :abort-signal      abort-signal
-     :frame             frame
-     :attempt           1
-     :sensitive?        sensitive?}))
-
-(defn- managed-handler
-  "The public `:rf.http/managed` fx body. `frame-ctx` carries `:frame`
-  and (when threaded by the runtime, per the do-fx 5-arity) `:event` —
-  the originating event vector used for default reply addressing per
-  Spec 014 §Reply addressing.
-
-  Per Spec 014 §Middleware (rf2-6y3q): before normalising args, the
-  per-frame interceptor chain is walked. Each `:before` transforms a
-  ctx `{:request :args :frame :event}`; the runtime threads its return
-  value through the rest of the chain. A throw inside any `:before`
-  classifies as `:rf.error/http-interceptor-failed`; the request is
-  not dispatched."
-  [frame-ctx args-map]
-  (transport/check-cljs-only-keys! args-map)
-  (let [frame-id     (or (:frame frame-ctx) :rf/default)
-        ;; rf2-622e3 — resolve once, thread the result through
-        ;; frame-ctx's :event slot so normalise-args reads it
-        ;; directly instead of re-running the OR-chain.
-        origin-event (encoding/resolve-origin-event frame-ctx args-map)
-        frame-ctx'   (assoc frame-ctx :event origin-event)
-        ctx0         {:request (:request args-map)
-                      :args    args-map
-                      :frame   frame-id
-                      :event   origin-event}
-        ctx          (middleware/run-interceptor-chain! frame-id ctx0)
-        args-map'    (assoc args-map :request (:request ctx))
-        normalised   (normalise-args args-map' frame-ctx')
-        request-id   (:request-id normalised)]
-    (when request-id (registry/supersede! request-id))
-    (transport/run-attempt! normalised)
-    nil))
-
-(defn- managed-abort-handler
-  "Public `:rf.http/managed-abort` fx. Args is the request-id (any value).
-
-  Per rf2-plngk the in-flight cleanup is owned by `finalise-failure!`
-  (the abort-fn closure calls into it). The earlier shape pre-cleared
-  the registry here AND inside `finalise-failure!`, doubling the
-  `swap!` traffic per abort. Now the single source of truth lives at
-  the failure-finalise site; this handler only fires the abort-fn."
-  [_frame-ctx request-id]
-  (when-let [handle (registry/lookup-in-flight request-id)]
-    (try ((:abort-fn handle) :user)
-         (catch #?(:clj Throwable :cljs :default) _ nil)))
-  nil)
-
 ;; ---- registration ---------------------------------------------------------
+;;
+;; The `:rf.http/managed` and `:rf.http/managed-abort` fx handler bodies
+;; live in `re-frame.http-handlers` (per rf2-0eyp2). The façade only
+;; performs the `(fx/reg-fx ...)` registrations and the canned-stub
+;; registrations gated on `interop/debug-enabled?`. Apps that don't
+;; load `re-frame.http-managed` don't carry the handlers either —
+;; the registration site is the load-time anchor.
 
 (fx/reg-fx :rf.http/managed
            {:doc "Spec 014 — managed HTTP request."}
-           managed-handler)
+           handlers/managed-handler)
 
 (fx/reg-fx :rf.http/managed-abort
            {:doc "Spec 014 — abort an in-flight :rf.http/managed by request-id."}
-           managed-abort-handler)
+           handlers/managed-abort-handler)
 
 ;; The two canned-stub fxs are gated on `interop/debug-enabled?` so they
 ;; elide in production. Per Spec 014 §Testing — "Don't ship the canned-

--- a/implementation/http/src/re_frame/http_privacy.cljc
+++ b/implementation/http/src/re_frame/http_privacy.cljc
@@ -17,8 +17,8 @@
 
   - `re-frame.http-privacy-headers` — header denylist + `redact-headers`.
   - `re-frame.http-url` — query-param denylist + `redact-url` /
-    `redact-url-query-string` / `query-denylist-hit?` (and future home
-    of `url-encode` / `params->query` / `merge-params` per rf2-5ijhk).
+    `redact-url-query-string` (and future home of `url-encode` /
+    `params->query` / `merge-params` per rf2-5ijhk).
 
   Three cooperating mechanisms, mirroring Spec 009's `:sensitive?` /
   `with-redacted` split:
@@ -74,6 +74,41 @@
 
 ;; ---- trace-event redaction helpers ----------------------------------------
 
+(defn- redact-url-in
+  "Internal helper: if `m` carries a string `:url`, redact it and return
+  `[m' any-redacted?]`. The flag captures whether the query-string walk
+  scrubbed any param value — callers use this to stamp `:sensitive?`
+  on the trace event (a denylisted param name is itself a signal that
+  the request carries a secret) without re-walking the URL.
+
+  Per rf2-02vzz — fuses the redact + denylist-hit lookups so the URL's
+  query string is parsed exactly once per trace emit."
+  [m sensitive?]
+  (if (string? (:url m))
+    (let [[redacted any?] (url/redact-url-query-string (:url m) sensitive?)]
+      [(assoc m :url redacted) any?])
+    [m false]))
+
+(defn redact-request-tags-with-flag
+  "Like `redact-request-tags` but returns `[tags url-redacted?]` so
+  callers (`prepare-emit-tags`) can decide whether to stamp
+  `:sensitive?` without re-walking the URL. Per rf2-02vzz."
+  [tags sensitive?]
+  (let [[tags url-hit?] (redact-url-in tags sensitive?)
+        tags' (cond-> tags
+                ;; Always-on header redaction (denylist).
+                (map? (:headers tags))
+                (update :headers headers/redact-headers)
+
+                ;; Sensitive-request redaction — body becomes the sentinel.
+                (and sensitive? (contains? tags :body))
+                (assoc :body redacted-sentinel)
+
+                ;; Sensitive-request redaction — params (URL query string) too.
+                (and sensitive? (contains? tags :params))
+                (assoc :params redacted-sentinel))]
+    [tags' url-hit?]))
+
 (defn redact-request-tags
   "Given a tags map about to ride a `:rf.http/*` trace event, redact
   the request-side payload when `sensitive?` is true. Always redacts
@@ -84,23 +119,33 @@
 
   Idempotent and total: missing slots are left alone."
   [tags sensitive?]
-  (cond-> tags
-    ;; Always-on header redaction (denylist).
-    (map? (:headers tags))
-    (update :headers headers/redact-headers)
+  (first (redact-request-tags-with-flag tags sensitive?)))
 
-    ;; URL query-string redaction — always-on for denylisted params
-    ;; (rf2-2p8wr); when sensitive? true ALL params are scrubbed.
-    (string? (:url tags))
-    (update :url url/redact-url sensitive?)
+(defn redact-failure-with-flag
+  "Like `redact-failure` but returns `[failure url-redacted?]` so callers
+  (`prepare-emit-failure`, `prepare-emit-tags`) can decide whether to
+  stamp `:sensitive?` without re-walking the URL. Per rf2-02vzz."
+  [failure sensitive?]
+  (when failure
+    (let [[failure url-hit?] (redact-url-in failure sensitive?)
+          failure' (cond-> failure
+                     (map? (:headers failure))
+                     (update :headers headers/redact-headers)
 
-    ;; Sensitive-request redaction — body becomes the sentinel.
-    (and sensitive? (contains? tags :body))
-    (assoc :body redacted-sentinel)
+                     (and sensitive? (contains? failure :body))
+                     (assoc :body redacted-sentinel)
 
-    ;; Sensitive-request redaction — params (URL query string) too.
-    (and sensitive? (contains? tags :params))
-    (assoc :params redacted-sentinel)))
+                     (and sensitive? (contains? failure :body-text))
+                     (assoc :body-text redacted-sentinel)
+
+                     (and sensitive? (contains? failure :decoded))
+                     (assoc :decoded redacted-sentinel)
+
+                     ;; Accept-failure carries the user's domain failure-map at :detail
+                     ;; — opaque to us; redact wholesale when sensitive.
+                     (and sensitive? (contains? failure :detail))
+                     (assoc :detail redacted-sentinel))]
+      [failure' url-hit?])))
 
 (defn redact-failure
   "Given a failure map (per Spec 014 §Failure categories) about to ride
@@ -110,28 +155,7 @@
   param denylist (rf2-2p8wr) — denylisted param names are the signal."
   [failure sensitive?]
   (when failure
-    (cond-> failure
-      (map? (:headers failure))
-      (update :headers headers/redact-headers)
-
-      ;; URL query-string redaction — always-on for denylisted params
-      ;; (rf2-2p8wr); when sensitive? true ALL params are scrubbed.
-      (string? (:url failure))
-      (update :url url/redact-url sensitive?)
-
-      (and sensitive? (contains? failure :body))
-      (assoc :body redacted-sentinel)
-
-      (and sensitive? (contains? failure :body-text))
-      (assoc :body-text redacted-sentinel)
-
-      (and sensitive? (contains? failure :decoded))
-      (assoc :decoded redacted-sentinel)
-
-      ;; Accept-failure carries the user's domain failure-map at :detail
-      ;; — opaque to us; redact wholesale when sensitive.
-      (and sensitive? (contains? failure :detail))
-      (assoc :detail redacted-sentinel))))
+    (first (redact-failure-with-flag failure sensitive?))))
 
 (defn stamp-sensitive
   "Stamp the `:sensitive?` flag onto a tags map when `sensitive?` is true.
@@ -207,16 +231,22 @@
   - **Whether to stamp `:sensitive?`** OR-combines `sensitive?` with a
     denylist-hit check on `:url` / `:failure :url`. A denylisted query-
     param name alone is enough to stamp the event — the name is the
-    signal that the request carries a secret."
+    signal that the request carries a secret.
+
+  Per rf2-02vzz the redact + denylist-hit are computed in a single URL
+  walk: `redact-request-tags-with-flag` and `redact-failure-with-flag`
+  return the redacted shape paired with a flag telling us whether any
+  query-string value was scrubbed. Earlier the helpers ran two walks
+  per trace emit (denylist-hit then redact)."
   [tags sensitive?]
-  (let [denylist-hit? (or (url/query-denylist-hit? (:url tags))
-                          (url/query-denylist-hit? (get-in tags [:failure :url])))
-        stamp?        (or (true? sensitive?) denylist-hit?)]
-    (-> tags
-        (redact-request-tags (true? sensitive?))
-        (cond-> (contains? tags :failure)
-                (update :failure redact-failure (true? sensitive?)))
-        (stamp-sensitive stamp?))))
+  (let [s?                          (true? sensitive?)
+        [tags' tag-url-hit?]        (redact-request-tags-with-flag tags s?)
+        [tags'' fail-url-hit?]      (if (contains? tags :failure)
+                                      (let [[f' h?] (redact-failure-with-flag (:failure tags) s?)]
+                                        [(assoc tags' :failure f') h?])
+                                      [tags' false])
+        stamp?                      (or s? tag-url-hit? fail-url-hit?)]
+    (stamp-sensitive tags'' stamp?)))
 
 (defn prepare-emit-failure
   "Compose `redact-failure` + `stamp-sensitive` for an error-side trace
@@ -226,9 +256,13 @@
   Two distinct decisions per rf2-2p8wr — same split as `prepare-emit-
   tags`: URL redaction uses the explicit `sensitive?` arg; `:sensitive?`
   stamping OR-combines that arg with a query-param denylist hit on the
-  failure's `:url`."
+  failure's `:url`.
+
+  Per rf2-02vzz the URL walk happens once: `redact-failure-with-flag`
+  returns `[failure url-hit?]` so we don't re-parse the query string."
   [failure sensitive?]
-  (let [denylist-hit? (url/query-denylist-hit? (:url failure))
-        stamp?        (or (true? sensitive?) denylist-hit?)]
-    (-> (redact-failure failure (true? sensitive?))
-        (stamp-sensitive stamp?))))
+  (let [s?                  (true? sensitive?)
+        [failure' url-hit?] (redact-failure-with-flag failure s?)
+        stamp?              (or s? url-hit?)]
+    (when failure'
+      (stamp-sensitive failure' stamp?))))

--- a/implementation/http/src/re_frame/http_registry.cljc
+++ b/implementation/http/src/re_frame/http_registry.cljc
@@ -217,20 +217,19 @@
 
 (defn- spawned-actor-id?
   "Return true if `event-id` is currently bound somewhere under
-  `[:rf/spawned <parent> <invoke-id>]` in `db` — either as the leaf
-  value (declarative `:invoke`) or as a value in the `:children` map
-  of the join-state record (declarative `:invoke-all`)."
-  [db event-id]
-  (when (and event-id (map? db))
-    (some (fn [[_parent inner]]
-            (some (fn [[_invoke-id v]]
-                    (or (= v event-id)                      ;; :invoke leaf
-                        (and (map? v)                       ;; :invoke-all join state
-                             (some (fn [[_cid cid-val]]
-                                     (= cid-val event-id))
-                                   (:children v)))))
-                  inner))
-          (get db :rf/spawned))))
+  `[:rf/spawned <parent> <invoke-id>]` in `spawned` — either as the
+  leaf value (declarative `:invoke`) or as a value in the `:children`
+  map of the join-state record (declarative `:invoke-all`)."
+  [spawned event-id]
+  (some (fn [[_parent inner]]
+          (some (fn [[_invoke-id v]]
+                  (or (= v event-id)                      ;; :invoke leaf
+                      (and (map? v)                       ;; :invoke-all join state
+                           (some (fn [[_cid cid-val]]
+                                   (= cid-val event-id))
+                                 (:children v)))))
+                inner))
+        spawned))
 
 (defn compute-actor-id
   "Resolve the spawned-actor-id for the request at hand, given the frame
@@ -239,11 +238,21 @@
   currently registered in the frame's `[:rf/spawned ...]` slot, otherwise
   nil — meaning the request is NOT subject to actor-destroy cancellation
   (it was dispatched from an ordinary event handler, not from inside a
-  spawned actor)."
+  spawned actor).
+
+  Per rf2-hzn1a — fast path for the common case (no spawned actors).
+  Apps that don't use state machines never carry `:rf/spawned` in their
+  app-db; we still deref the db to check, but the seq-empty test short-
+  circuits before the O(parents × invokes) walk. This keeps the cost
+  on the no-machines hot path at one deref + one map lookup + one
+  seq-check, rather than a full structural walk against the (always
+  empty) registry."
   [frame-id origin-event]
   (let [event-id (when (vector? origin-event) (first origin-event))]
     (when (and event-id
                (not= event-id :rf.http/managed))
-      (let [db (frame/frame-app-db-value frame-id)]
-        (when (spawned-actor-id? db event-id)
-          event-id)))))
+      (let [db      (frame/frame-app-db-value frame-id)
+            spawned (when (map? db) (:rf/spawned db))]
+        (when (seq spawned)
+          (when (spawned-actor-id? spawned event-id)
+            event-id))))))

--- a/implementation/http/src/re_frame/http_registry.cljc
+++ b/implementation/http/src/re_frame/http_registry.cljc
@@ -97,7 +97,15 @@
      the per-host attempt loops. Both args are taken from the captured
      ctx + handle pair, so the cleanup is index-walks by identity and
      does not depend on `request-id` being non-nil. This arity covers
-     anonymous-request natural completion from inside spawned actors."
+     anonymous-request natural completion from inside spawned actors.
+
+  Per rf2-plngk this is THE single source of truth for in-flight
+  cleanup on per-request termination. The natural-completion sites
+  (`finalise-success!`, `finalise-failure!`, retry-clear in
+  `maybe-retry!`) call this directly; the abort sites
+  (`managed-abort-handler`, `abort-on-actor-destroy`) rely on the
+  abort-fn → `finalise-failure!` cascade to reach here. Idempotent
+  against already-gone state — the swap!s no-op on absent slots."
   ([request-id]
    (when request-id
      (let [handle (get @in-flight request-id)]
@@ -174,15 +182,20 @@
 
   Idempotent: invoking against an actor with no in-flight HTTP is a
   no-op. Tolerant of repeated invocations against the same actor —
-  the second call sees the already-cleared slot and does nothing."
+  the actor-side slot is cleared atomically first so a re-entry sees
+  an empty registry.
+
+  Per rf2-plngk the per-handle request-id cleanup is owned by
+  `clear-in-flight!` (called inside the abort-fn closure via
+  `finalise-failure!`). The earlier shape pre-walked the request-id
+  index here AND cleared inside `finalise-failure!`, doubling the
+  `swap!` traffic per actor destroy. The actor-side eager dissoc
+  remains: it pins the idempotency guarantee against re-entry, and
+  it's a single `swap!` regardless of handle count."
   [actor-id]
   (when actor-id
     (let [handles (get @actor-in-flight actor-id)]
-      ;; Atomically clear the slot first, so any in-flight failure
-      ;; dispatch path that observes the removal won't re-walk the
-      ;; same handles (the abort-fn closure also calls clear-in-flight!
-      ;; on its way through finalise-failure!, so we want a single
-      ;; source of truth for "is this still tracked").
+      ;; Atomically clear the slot first so a re-entry sees no handles.
       (swap! actor-in-flight dissoc actor-id)
       (doseq [handle handles]
         (when interop/debug-enabled?
@@ -195,10 +208,6 @@
                           :actor-id   actor-id
                           :url        (:url handle)}
                          (true? (:sensitive? handle)))))
-        ;; Remove from the request-id index too so the natural failure
-        ;; path doesn't try to clear a slot we already swept.
-        (when-let [rid (:request-id handle)]
-          (swap! in-flight dissoc rid))
         (try
           ((:abort-fn handle) :actor-destroyed)
           (catch #?(:clj Throwable :cljs :default) _ nil)))))

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -24,6 +24,7 @@
   and successful completion based on the failing attempt's failure
   category and the request's `:retry` config."
   (:require [clojure.string         :as str]
+            [re-frame.http-decode   :as decode]
             [re-frame.http-encoding :as encoding]
             [re-frame.http-privacy  :as privacy]
             [re-frame.http-registry :as registry]
@@ -378,7 +379,7 @@
 
       ok?
       (try
-        (let [decoded  (encoding/decode-response-body
+        (let [decoded  (decode/decode-response-body
                          {:body-text        body-text
                           :headers          headers
                           :decode           decode
@@ -423,7 +424,7 @@
         [enc-body ct] (encoding/encode-body (encoding/realise-body (:body request))
                                             (:request-content-type request))
         headers  (cond-> (or (:headers request) {})
-                   (and ct (nil? (encoding/content-type-of (:headers request))))
+                   (and ct (nil? (decode/content-type-of (:headers request))))
                    (assoc "Content-Type" ct))
         ctx-no-handle (assoc ctx :url url)
         ;; CLJS: an internal AbortController backs the Fetch signal when

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -28,7 +28,6 @@
             [re-frame.http-privacy  :as privacy]
             [re-frame.http-registry :as registry]
             [re-frame.interop       :as interop]
-            [re-frame.late-bind     :as late-bind]
             [re-frame.trace         :as trace])
   #?(:clj (:import [java.net URI]
                    [java.net.http HttpClient HttpRequest
@@ -233,14 +232,13 @@
            kind reply-payload frame]}]
   (let [explicit (case kind
                    :success explicit-on-success
-                   :failure explicit-on-failure)
-        ev (encoding/build-reply-event {:origin-event  origin-event
-                                        :explicit-on   explicit
-                                        :reply-payload reply-payload
-                                        :kind          kind})]
-    (when ev
-      (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
-        (dispatch! ev (cond-> {} frame (assoc :frame frame)))))))
+                   :failure explicit-on-failure)]
+    (encoding/dispatch-reply-via-late-bind!
+      {:origin-event  origin-event
+       :explicit-on   explicit
+       :reply-payload reply-payload
+       :kind          kind}
+      frame)))
 
 (defn- finalise-success! [ctx accepted]
   (registry/clear-in-flight! (:request-id ctx) (:handle ctx))

--- a/implementation/http/src/re_frame/http_url.cljc
+++ b/implementation/http/src/re_frame/http_url.cljc
@@ -190,21 +190,3 @@
   any-redacted? flag (e.g. inside a generic tag-walker)."
   [url-str sensitive?]
   (first (redact-url-query-string url-str sensitive?)))
-
-(defn query-denylist-hit?
-  "Return true iff `url-str` carries a query-string param whose name is
-  on the merged query-param denylist. The denylist-alone hit is itself
-  a signal that the request carries an auth secret (rf2-2p8wr) — the
-  `prepare-emit-*` composers use this to stamp `:sensitive?` even when
-  the originating handler was not declared sensitive."
-  [url-str]
-  (and (string? url-str)
-       (let [[_ q-and-f] (split-url-on-query url-str)
-             [q _]       (split-query-on-fragment q-and-f)]
-         (and (not (str/blank? q))
-              (boolean
-                (some (fn [pair]
-                        (let [eq-idx (str/index-of pair "=")
-                              pname  (if eq-idx (subs pair 0 eq-idx) pair)]
-                          (sensitive-query-param? pname)))
-                      (str/split q #"&")))))))

--- a/implementation/http/src/re_frame/util_json.cljc
+++ b/implementation/http/src/re_frame/util_json.cljc
@@ -142,17 +142,23 @@
                      :else     (read-keyword-tok p))))]
          (first (read-val (skip-ws 0)))))))
 
+;; Memoised Cheshire resolves (per rf2-tja2y). Cheshire's vars never
+;; rebind at runtime; resolving once per JVM is enough. The CLJS path
+;; uses the browser's `JSON` builtin and never needs a resolve.
+#?(:clj (defonce ^:private cheshire-generate-string (delay (try (requiring-resolve 'cheshire.core/generate-string)
+                                                                (catch Throwable _ nil)))))
+#?(:clj (defonce ^:private cheshire-parse-string    (delay (try (requiring-resolve 'cheshire.core/parse-string)
+                                                                (catch Throwable _ nil)))))
+
 (defn json-stringify
   "Clojure value → JSON string. JVM uses Cheshire if available, else
   falls back to `pr-str` (good enough for the request-body shapes
   `:rf.http/managed` emits — primarily Clojure maps and vectors that
   print as legal JSON-ish edn). CLJS uses `js/JSON.stringify`."
   [v]
-  #?(:clj  (let [write (try (requiring-resolve 'cheshire.core/generate-string)
-                            (catch Throwable _ nil))]
-             (if write
-               (write v)
-               (pr-str v)))
+  #?(:clj  (if-let [write @cheshire-generate-string]
+             (write v)
+             (pr-str v))
      :cljs (js/JSON.stringify (clj->js v))))
 
 (defn json-parse
@@ -161,11 +167,9 @@
   Clojure reader above. On CLJS uses `js/JSON.parse` +
   `js->clj :keywordize-keys true`."
   [s]
-  #?(:clj  (let [read (try (requiring-resolve 'cheshire.core/parse-string)
-                           (catch Throwable _ nil))]
-             (cond
-               read       (read s true)
-               (string? s) (try (json-read* s)
-                                (catch Throwable _ s))
-               :else      s))
+  #?(:clj  (cond
+             (some? @cheshire-parse-string) (@cheshire-parse-string s true)
+             (string? s)                    (try (json-read* s)
+                                                 (catch Throwable _ s))
+             :else                          s)
      :cljs (js->clj (js/JSON.parse s) :keywordize-keys true)))

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -14,6 +14,7 @@
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.registrar :as registrar]
+            [re-frame.http-decode :as http-decode]
             [re-frame.http-encoding :as http-encoding]
             [re-frame.http-managed :as http-managed]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -268,7 +269,7 @@
 ;; the bug only manifested when a hand-constructed headers map reached
 ;; `decode-response-body`. The fix is two-layered: the JVM transport
 ;; (`jvm-headers->map`) lower-cases at the boundary so the JVM path matches
-;; the Fetch path, AND `http-encoding/content-type-of` performs a
+;; the Fetch path, AND `http-decode/content-type-of` performs a
 ;; case-insensitive scan so any future code path that synthesises a
 ;; headers map (interceptors, middleware, tests) decodes correctly.
 ;;
@@ -281,28 +282,28 @@
 (deftest content-type-of-case-insensitive
   (testing "lowercase key"
     (is (= "application/json"
-           (http-encoding/content-type-of {"content-type" "application/json"}))))
+           (http-decode/content-type-of {"content-type" "application/json"}))))
   (testing "canonical Title-Case key"
     (is (= "application/json"
-           (http-encoding/content-type-of {"Content-Type" "application/json"}))))
+           (http-decode/content-type-of {"Content-Type" "application/json"}))))
   (testing "all-caps key (the original bug — CONTENT-TYPE)"
     (is (= "application/json"
-           (http-encoding/content-type-of {"CONTENT-TYPE" "application/json"}))))
+           (http-decode/content-type-of {"CONTENT-TYPE" "application/json"}))))
   (testing "mixed casing"
     (is (= "application/json"
-           (http-encoding/content-type-of {"Content-type" "application/json"})))
+           (http-decode/content-type-of {"Content-type" "application/json"})))
     (is (= "text/plain"
-           (http-encoding/content-type-of {"cOnTeNt-TyPe" "text/plain"}))))
+           (http-decode/content-type-of {"cOnTeNt-TyPe" "text/plain"}))))
   (testing "keyword key (some middlewares use keywords)"
     (is (= "application/json"
-           (http-encoding/content-type-of {:content-type "application/json"})))
+           (http-decode/content-type-of {:content-type "application/json"})))
     (is (= "application/json"
-           (http-encoding/content-type-of {:Content-Type "application/json"}))))
+           (http-decode/content-type-of {:Content-Type "application/json"}))))
   (testing "absent / unrelated headers"
-    (is (nil? (http-encoding/content-type-of {})))
-    (is (nil? (http-encoding/content-type-of {"X-Foo" "bar"})))
-    (is (nil? (http-encoding/content-type-of nil)))
-    (is (nil? (http-encoding/content-type-of "not-a-map")))))
+    (is (nil? (http-decode/content-type-of {})))
+    (is (nil? (http-decode/content-type-of {"X-Foo" "bar"})))
+    (is (nil? (http-decode/content-type-of nil)))
+    (is (nil? (http-decode/content-type-of "not-a-map")))))
 
 (deftest decode-response-body-resolves-content-type-case-insensitively
   (testing "JSON decode under :auto fires when Content-Type has non-canonical casing"
@@ -313,7 +314,7 @@
     ;; header regardless of casing and JSON decodes correctly.
     (doseq [ct-key ["CONTENT-TYPE" "Content-type" "content-type" "Content-Type" "cOnTeNt-TyPe"]]
       (testing (str "casing: " ct-key)
-        (let [decoded (http-encoding/decode-response-body
+        (let [decoded (http-decode/decode-response-body
                         {:body-text        "{\"ok\":true}"
                          :headers          {ct-key "application/json"}
                          :decode           :auto

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -31,7 +31,7 @@ If an implementation ships ONLY a subset (e.g., no JVM transport), it claims the
 
 ## Role
 
-`:rf.http/managed`, when an implementation ships it, is **framework-provided** — the implementation registers the fx; applications use it the way they'd use `:dispatch` or `:db`. This is what makes it a Spec rather than a convention: the public contract is locked, `:fx-overrides` target the same id across applications, pair tools introspect the same envelope, and Spec 010 schemas plug into the same decode pipeline universally.
+`:rf.http/managed`, when an implementation ships it, is **framework-provided** — the implementation registers the fx; applications use it the way they'd use `:dispatch` or `:db`. This is what makes it a Spec rather than a convention: the public contract is locked, `:fx-overrides` target the same id across applications, pair tools introspect the same envelope, and the same schema language Spec 010 standardises ([Malli on the CLJS reference](010-Schemas.md#default-validator-and-the-validator-fn-extension-point)) is consumed by the `:decode` pipeline universally.
 
 ## The shape
 
@@ -1129,7 +1129,7 @@ Per [Pattern-StaleDetection](Pattern-StaleDetection.md) and [§Reply addressing]
 - [Spec 005 §Delayed `:after` transitions](005-StateMachines.md#delayed-after-transitions) — the substrate semantic retry rides on; the machine fires a transition on the failure reply, optionally delays via `:after`, and re-issues the request from the next state's `:invoke`.
 - [Spec 005 §Spawn-and-join via `:invoke-all`](005-StateMachines.md#spawn-and-join-via-invoke-all) — multi-request semantic retry (refresh-then-retry, fan-out-with-conditional-retry) lives here.
 - [Spec 009 §Trace event envelope](009-Instrumentation.md) — trace envelope shape; `:rf.http/retry-attempt`, `:rf.warning/decode-defaulted`, and the `:rf.http/*` failure-category traces follow it.
-- [Spec 010 §Schemas](010-Schemas.md) — Malli decode integration; `:decode <schema>` runs through `010`'s decode pipeline.
+- [Spec 010 §Schemas](010-Schemas.md) — the schema language `:decode <schema>` consumes. Spec 010 standardises the schema-attachment surface (`:spec` metadata, `reg-app-schema`, `app-schemas-digest`) and the pluggable validator seam (Malli is the CLJS reference's default); the `:rf.http/managed` decode step parses the response body and applies the registered schema language's decode-or-validate primitive (on CLJS reference: `malli.core/decode` + `malli.transform/json-transformer`). There is no separate "Spec 010 decode pipeline" — the decode contract belongs to this Spec; Spec 010 provides the schema language.
 - [Pattern-Boot §Worked example — auth-machine and the retry-ownership boundary](Pattern-Boot.md#worked-example--auth-machine-and-the-retry-ownership-boundary) — the canonical end-to-end illustration of [§Boundary — transport vs semantic retry](#boundary--transport-vs-semantic-retry).
 - [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned) — the `:rf.http/*` namespace is reserved for this Spec.
 - [`re-frame-fetch-fx`](https://github.com/superstructor/re-frame-fetch-fx) — the inspiration; Spec 014 adds retry, accept-step, default-reply-addressing, schema-driven decode, JVM coverage, and stale-suppression on top.


### PR DESCRIPTION
## Summary

Eighth batched-by-surface refactor — 12-bead P2/P3 polish cluster on `implementation/http/`, dispatched from the rf2-jklja round-2 audit. All beads addressed in commit-per-bead form.

### Commits

| Bead   | P | Title |
|--------|---|-------|
| rf2-o8879 | P3 | drop dead `maybe-emit-decode-defaulted!` gate |
| rf2-86nht | P3 | jitter ±25% per Spec 014 line 250 (was ±12.5%) |
| rf2-y03ky | P3 | trim narration comments in late-bind block |
| rf2-tja2y / rf2-exycf | P3 | memoise `requiring-resolve` for malli + cheshire (fuses with CLJ/CLJS deref asymmetry) |
| rf2-02vzz | P2 | fuse URL redact + denylist-hit into single walk |
| rf2-hzn1a | P2 | `compute-actor-id` short-circuits when no spawned actors |
| rf2-2utlm | P2 | dedupe `dispatch-reply` across transport + canned stubs |
| rf2-plngk | P2 | pin `clear-in-flight!` ownership to finalise sites |
| rf2-1z21y | P2 | align Spec 014 decode wording (Spec 010 owns schema language, not a decode pipeline) |
| rf2-0eyp2 | P2 | extract handlers into `http-handlers` sibling |
| rf2-5ijhk | P2 | split `http-decode` out of `http-encoding` (was 355 → 217 LoC; new decode 171 LoC) |

(Plus a fix-up commit for the CLJS resolve-fn compilation issue introduced by rf2-tja2y / rf2-5ijhk — CLJS `resolve` is a compile-time macro that demands a literal quoted symbol.)

### Net diff

Against the merge base — 577 insertions, 448 deletions, 11 files. New siblings: `http_handlers.cljc` (125 LoC), `http_decode.cljc` (177 LoC). The pre-existing `http_encoding.cljc` drops from 355 to 217 LoC; `http_managed.cljc` (the public façade) drops to 200 LoC.

### Perf wins

- `compute-actor-id` early-out: apps without state machines pay a single deref + map lookup + seq-check per request instead of a full structural walk.
- `prepare-emit-tags` URL walk: one parse instead of two per retry-attempt, abort-on-actor-destroy, and decode-defaulted emit.
- `clear-in-flight!` ownership: saves N request-side `swap!`s on actor-destroy with N in-flight; saves one on user-initiated aborts.
- Malli / Cheshire resolves: ~4 `requiring-resolve` calls collapse to a single `defonce` delay per fn.
- `run-accept` default: inlined; no closure allocation per response.

## Test plan

- [x] `cd implementation/http && clojure -M:test` — 136 tests / 385 assertions
- [x] `cd implementation && npm run test:cljs` — 1817 tests / 5105 assertions
- [x] `npm run test:perf-bundle` — counter clean, counter-perf carries perf markers
- [x] `npm run test:bundle-isolation` — http symbols stay inside http; allow-list within budget