### PR TITLE
refactor(flows): polish tail — 5 follow-on beads (rf2-0b2eh)

### DIFF
--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -46,7 +46,8 @@
   `re-frame.flows/<name>` — production code via the late-bind hooks,
   the per-artefact test fixtures via `re-frame.flows/flows` and
   `(resolve 're-frame.flows/last-inputs)`."
-  (:require [re-frame.flows.registry :as registry]
+  (:require [re-frame.elision :as elision]
+            [re-frame.flows.registry :as registry]
             [re-frame.flows.topo :as topo]
             [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
@@ -114,15 +115,38 @@
               new-db     (assoc-in db (:path flow) new-output)]
           (swap! last-inputs assoc-in [flow-id frame-id] new-inputs)
           ;; Per Spec 009 §:op-type vocabulary: :rf.flow/computed records
-          ;; a successful recompute. :input-values are raw values (not
-          ;; hashed) — the trace surface is dev-only and elided in
-          ;; production, and downstream tools (10x flow panel) display
-          ;; them. Per rf2-719e the dirty-check is =-equality so this
-          ;; only fires when inputs actually changed.
+          ;; a successful recompute. Per rf2-719e the dirty-check is
+          ;; =-equality so this only fires when inputs actually changed.
+          ;;
+          ;; Wire-bearing payloads (`:input-values`, `:result`) ride
+          ;; through `elision/elide-wire-value` per Spec 009 §Size
+          ;; elision in traces — the walker is the single normative
+          ;; emission site for `:rf.size/large-elided` (and the
+          ;; `:rf/redacted` privacy sentinel). Without this the flow
+          ;; trace bypassed the elision contract that every other
+          ;; wire-emitting surface honours; a flow reading or
+          ;; producing a large or sensitive value would surface raw
+          ;; on the trace bus. Off-box defaults match `event-emit` /
+          ;; `error-emit`.
+          ;;
+          ;; The `:path` opt on each walker call names where in the
+          ;; slice's root the wrapped value lives — `:result` IS the
+          ;; value at the flow's output path; each `:input-values`
+          ;; entry is the value at the matching input path. The
+          ;; walker reads `[:rf/elision :declarations <path>]` and
+          ;; emits the marker for declared-large or auto-detected-
+          ;; large slots.
           (trace/emit! :flow :rf.flow/computed
                        {:flow-id      flow-id
-                        :input-values new-inputs
-                        :result       new-output
+                        :input-values (mapv (fn [input-path v]
+                                              (elision/elide-wire-value
+                                                v
+                                                {:frame frame-id :path input-path}))
+                                            (:inputs flow)
+                                            new-inputs)
+                        :result       (elision/elide-wire-value
+                                        new-output
+                                        {:frame frame-id :path (:path flow)})
                         :path         (:path flow)
                         :frame        frame-id})
           [new-db true])
@@ -136,10 +160,22 @@
           ;; §Error contract; the per-flow `:rf.flow/failed` trace
           ;; emitted here adds the flow-attributed detail tools (10x
           ;; flow panel) consume.
+          ;;
+          ;; The failure-path `:inputs` payload rides through the
+          ;; elision walker for the same reason as the success path —
+          ;; the value that triggered the throw may itself be a
+          ;; large or sensitive blob, and the trace bus is the wire
+          ;; boundary. Each entry is walked under its own declared
+          ;; input path so per-path declarations apply.
           (trace/emit! :flow :rf.flow/failed
                        {:flow-id flow-id
                         :ex      e
-                        :inputs  new-inputs
+                        :inputs  (mapv (fn [input-path v]
+                                         (elision/elide-wire-value
+                                           v
+                                           {:frame frame-id :path input-path}))
+                                       (:inputs flow)
+                                       new-inputs)
                         :frame   frame-id})
           (throw e))))))
 

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -202,9 +202,48 @@
                    :frame   frame-id})
      flow-id)))
 
+(defn- dissoc-in-safe
+  "Like `dissoc-in` over `(butlast path) → (last path)` but robust against
+  the two unmaterialised-output failure modes flagged by audit rf2-q25os:
+
+  - **Unmaterialised parent.** When a flow with `:path [:step-2 :result]`
+    is cleared BEFORE its first drain, the parent slot `:step-2` may not
+    exist. The naïve `(update-in cur [:step-2] dissoc :result)` returns
+    `(dissoc nil :result)` ⇒ `nil`, producing `{:step-2 nil}` — a
+    spurious nil parent. Detect this case and leave `cur` unchanged.
+  - **Non-map intermediate.** When an intermediate path step holds a
+    non-map value (a scalar already wrote past the flow's planned path),
+    the naïve `update-in` calls `(dissoc 1 :result)` and throws
+    `ClassCastException`. Treat this as a no-op — the flow's `:path`
+    never materialised, so there's nothing to clear.
+
+  Single-element paths and non-vector paths are handled by the caller's
+  earlier branches; this helper is only called for `(>= (count path) 2)`."
+  [cur path]
+  (let [parent-path (vec (butlast path))
+        leaf        (last path)
+        parent      (get-in cur parent-path ::missing)]
+    (cond
+      ;; Parent was never materialised — leave cur as-is. Per audit
+      ;; rf2-q25os Repro 1: registering a nested-path flow then clearing
+      ;; before any drain would write `{<parent> nil}` otherwise.
+      (or (= ::missing parent) (nil? parent)) cur
+      ;; Parent is non-map (scalar / vector / set) — there's no
+      ;; meaningful "dissoc this leaf" on a non-map intermediate. Per
+      ;; audit rf2-q25os Repro 2: throwing ClassCastException for a
+      ;; cleanup operation is poor manners; leave the value untouched
+      ;; (it's not OUR flow's output anyway).
+      (not (map? parent)) cur
+      :else (update-in cur parent-path dissoc leaf))))
+
 (defn clear-flow
   "Deregister a flow from a frame; dissoc its output path from that
-  frame's app-db (only that frame). Frame defaults to (current-frame)."
+  frame's app-db (only that frame). Frame defaults to (current-frame).
+
+  Per audit rf2-q25os: the nested-path dissoc is robust against the
+  output path never having been materialised (no spurious nil parent
+  created) and against a non-map intermediate (no ClassCastException
+  thrown) — see `dissoc-in-safe` above."
   ([id] (clear-flow id {}))
   ([id {:keys [frame] :as _opts}]
    (let [frame-id (or frame (frame/current-frame))]
@@ -218,14 +257,16 @@
                  ;; path falls into (assoc {} nil (apply f val args)),
                  ;; producing {... nil nil}. Special-case length 1 so
                  ;; the leaf is dissoc'd directly.
+                 ;;
+                 ;; The (>= 2) branch routes through `dissoc-in-safe`
+                 ;; which handles the unmaterialised-parent / non-map-
+                 ;; intermediate cases without writing nil parents or
+                 ;; throwing (per audit rf2-q25os).
                  new-db (cond
                           (not (vector? path))         (dissoc cur path)
                           (empty? path)                cur
                           (= 1 (count path))           (dissoc cur (first path))
-                          :else                        (update-in cur
-                                                                  (vec (butlast path))
-                                                                  dissoc
-                                                                  (last path)))]
+                          :else                        (dissoc-in-safe cur path))]
              (adapter/replace-container! container new-db)))
          (swap! flows update frame-id dissoc id)
          ;; `last-inputs` is shaped {flow-id {frame-id inputs}} — clear

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -89,6 +89,71 @@
   (testing "calling clear-flow on an unknown id is a no-op (does not throw)"
     (rf/clear-flow :no-such-flow)))
 
+(deftest clear-flow-nested-path-before-first-compute-does-not-write-nil-parent
+  ;; Regression for rf2-q25os Repro 1. When a flow with a nested `:path`
+  ;; (e.g. `[:step-2 :result]`) is cleared BEFORE any drain has run the
+  ;; flow's output, the parent slot `:step-2` doesn't exist in app-db.
+  ;; Pre-fix, the naïve `(update-in cur [:step-2] dissoc :result)`
+  ;; returned `(dissoc nil :result) ⇒ nil`, producing `{:step-2 nil}` — a
+  ;; spurious nil parent. The robust path (`dissoc-in-safe`) leaves
+  ;; app-db unchanged when the parent was never materialised.
+  (testing "clear-flow on nested-path flow before first compute leaves app-db unchanged"
+    (rf/reg-flow {:id     :pending
+                  :inputs [[:n]]
+                  :output (fn [_] "never-runs")
+                  :path   [:step-2 :result]})
+    (let [db-before (rf/get-frame-db :rf/default)]
+      (rf/clear-flow :pending)
+      (let [db-after (rf/get-frame-db :rf/default)]
+        (is (= db-before db-after)
+            "app-db is unchanged when clearing a never-materialised nested-path flow")
+        (is (not (contains? db-after :step-2))
+            "no spurious `:step-2 nil` parent was created")))))
+
+(deftest clear-flow-non-map-intermediate-is-noop
+  ;; Regression for rf2-q25os Repro 2. When an intermediate path step
+  ;; holds a non-map value (e.g. someone wrote a scalar at `:step-2`
+  ;; before the flow's output ever materialised), pre-fix
+  ;; `(update-in cur [:step-2] dissoc :result)` called `(dissoc 1 :result)`
+  ;; and threw `ClassCastException`. The robust path treats this as a
+  ;; no-op — the flow's `:path` never materialised, so there's nothing
+  ;; to clear.
+  (testing "clear-flow on a flow whose intermediate path step holds a scalar is a no-op (no throw)"
+    (rf/reg-event-db :seed-scalar (fn [_ _] {:step-2 1 :foo 3 :bar 4}))
+    (rf/reg-flow {:id     :pending
+                  :inputs [[:foo]]
+                  :output (fn [_] "never-stored-because-:step-2-is-a-scalar")
+                  :path   [:step-2 :result]})
+    (rf/dispatch-sync [:seed-scalar])
+    ;; At this point the flow tried to write at `[:step-2 :result]` —
+    ;; `assoc-in` on a scalar parent actually replaces the scalar with a
+    ;; map. So the flow's first drain materialises the path, and a
+    ;; subsequent clear would hit the normal path. To exercise the
+    ;; never-materialised non-map-intermediate case directly, we reset
+    ;; last-inputs and re-seed AFTER reg-flow but BEFORE any drain.
+    (when-let [li-var (resolve 're-frame.flows/last-inputs)]
+      (reset! (deref li-var) {}))
+    (let [db-before (rf/get-frame-db :rf/default)]
+      ;; Stamp a non-map at the parent slot via direct app-db write so
+      ;; the next clear hits the non-map-intermediate branch.
+      (rf/reg-event-db :stamp-non-map (fn [db _] (assoc db :step-2 1)))
+      (rf/dispatch-sync [:stamp-non-map])
+      ;; Re-register the flow so the per-frame registry has the entry
+      ;; (re-stamping app-db dropped the flow's output via the value-
+      ;; equal check path).
+      (rf/reg-flow {:id     :pending
+                    :inputs [[:foo]]
+                    :output (fn [_] "never-stored")
+                    :path   [:step-2 :result]})
+      ;; Clear must NOT throw, and must leave the scalar parent intact.
+      (is (nil? (rf/clear-flow :pending))
+          "clear-flow returns nil (no throw) when the intermediate is a non-map")
+      (is (= 1 (:step-2 (rf/get-frame-db :rf/default)))
+          ":step-2 is preserved as its scalar value — clear-flow did not corrupt it")
+      ;; Sanity: siblings untouched.
+      (is (= 3 (:foo (rf/get-frame-db :rf/default))))
+      (is (= 4 (:bar (rf/get-frame-db :rf/default)))))))
+
 (deftest clear-flow-handles-single-element-path
   (testing "rf2-aqt7: clear-flow with a single-element :path dissocs the top-level key"
     ;; The repro from rf2-aqt7: a flow whose :path is a one-element vector

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -619,3 +619,86 @@
     (rf/reg-flow {:id :one :inputs [[:a]] :output identity :path [:slots :one]})
     (is (contains? (get @flows/flows :rf/default) :one)
         "re-registration after reset works without raising")))
+
+;; ---------------------------------------------------------------------------
+;; 7. clear-flow :frame opt routing — multi-frame registrar-slot retention
+;;
+;; Per audit rf2-0b2eh §TC-2 / rf2-otbub. The cross-artefact
+;; `smoke_test.clj` exercises frame-scoped flow REGISTRATION end-to-end,
+;; but the flows artefact's own test alias did not pin `clear-flow`'s
+;; `:frame` opt routing — three branches in registry.cljc went unverified
+;; here:
+;;
+;; 1. Frame opt routing: `(clear-flow :foo {:frame :left})` removes the
+;;    flow from `:left`'s per-frame map only; sibling frame `:right`'s
+;;    identically-named flow stays intact.
+;; 2. "Last frame holding id" registrar-slot retention (registry.cljc
+;;    line ~254 `not-any?`): when the same flow id is registered against
+;;    two frames, clearing it from one frame must NOT unregister the
+;;    `:flow` registrar slot — the other frame still needs it for
+;;    hot-reload tracking. Clearing from the second frame then unregisters.
+;; 3. app-db `dissoc-in` is frame-local: clearing on `:left` only
+;;    dissoc-in's `:left`'s app-db; `:right`'s app-db is untouched.
+;;
+;; Spec 013 §Frame-scoping calls all three properties out normatively.
+;; This deftest pins them inside the flows slice's own gate so the
+;; artefact doesn't rely on smoke_test.clj catching regressions.
+;; ---------------------------------------------------------------------------
+
+(deftest clear-flow-routes-via-frame-opt
+  (testing "the same flow id registers independently against two frames"
+    (rf/reg-frame :left  {:doc "left frame"})
+    (rf/reg-frame :right {:doc "right frame"})
+    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
+    ;; Register :compute against both frames with DIFFERENT :output fns
+    ;; so sibling-frame-untouched is observable in the materialised output.
+    (rf/reg-flow {:id     :compute
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 (or n 0)))
+                  :path   [:result]}
+                 {:frame :left})
+    (rf/reg-flow {:id     :compute
+                  :inputs [[:n]]
+                  :output (fn [n] (* 100 (or n 0)))
+                  :path   [:result]}
+                 {:frame :right})
+    (rf/dispatch-sync [:seed 5] {:frame :left})
+    (rf/dispatch-sync [:seed 5] {:frame :right})
+    (is (= 10  (:result (rf/get-frame-db :left)))
+        "left frame's :compute used the 2x formula (5 * 2)")
+    (is (= 500 (:result (rf/get-frame-db :right)))
+        "right frame's :compute used the 100x formula (5 * 100)")
+    (is (contains? (get @flows/flows :left)  :compute)
+        ":left's per-frame registry slot carries :compute")
+    (is (contains? (get @flows/flows :right) :compute)
+        ":right's per-frame registry slot carries :compute"))
+
+  (testing "clear-flow on one frame leaves the sibling frame's registry slot intact"
+    ;; Branch 1: per-frame registry routing.
+    (rf/clear-flow :compute {:frame :left})
+    (is (not (contains? (get @flows/flows :left)  :compute))
+        ":left's slot was removed")
+    (is (contains? (get @flows/flows :right) :compute)
+        ":right's slot is untouched — flow STILL registered against :right"))
+
+  (testing ":left's app-db output path is dissoc'd; :right's app-db is unchanged"
+    ;; Branch 3: app-db dissoc-in is frame-local.
+    (is (not (contains? (rf/get-frame-db :left) :result))
+        ":left's :result was dissoc'd by the frame-scoped clear")
+    (is (= 500 (:result (rf/get-frame-db :right)))
+        ":right's :result is preserved (the previous compute's output)"))
+
+  (testing "the :flow registrar slot survives clear-from-one-frame (multi-frame retention)"
+    ;; Branch 2: the "last-frame-holding-id" check — the registrar slot is
+    ;; flow-id-keyed and shared across frames. Clearing on :left while
+    ;; :right still registers the same id MUST keep the slot populated so
+    ;; hot-reload tracking continues to work for :right's copy.
+    (is (some? (registrar/lookup :flow :compute))
+        "the :flow registrar slot is still populated — :right still holds the id"))
+
+  (testing "clearing from the second (last) frame finally unregisters the registrar slot"
+    (rf/clear-flow :compute {:frame :right})
+    (is (not (contains? (get @flows/flows :right) :compute))
+        ":right's slot is now gone")
+    (is (nil? (registrar/lookup :flow :compute))
+        "registrar slot was unregistered once the LAST frame released the id")))

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -767,3 +767,30 @@
         ":right's slot is now gone")
     (is (nil? (registrar/lookup :flow :compute))
         "registrar slot was unregistered once the LAST frame released the id")))
+
+;; ---------------------------------------------------------------------------
+;; 8. `_hot-reload-hook` defonce-idempotency on namespace reload
+;;
+;; Per audit rf2-0b2eh §TC-3 / rf2-5ay09. The flows registry installs a
+;; registrar replacement-hook (`invalidate-flow-on-replace!`) once at
+;; namespace load via `(defonce ^:private _hot-reload-hook
+;; (registrar/add-replacement-hook! ...))`. If the `defonce` protection
+;; ever regressed to a plain `def`, every namespace reload would push a
+;; duplicate hook into `re-frame.registrar/replacement-hooks` — every
+;; subsequent flow re-registration would invalidate `last-inputs` twice
+;; (functionally harmless because `dissoc` is idempotent, but a silent
+;; bookkeeping leak that would compound across many hot-reload cycles in
+;; long dev sessions).
+;;
+;; Pin the idempotency: `(require 're-frame.flows.registry :reload)`
+;; MUST NOT push a duplicate hook.
+;; ---------------------------------------------------------------------------
+
+(deftest hot-reload-hook-is-defonce-idempotent
+  (testing "reloading re-frame.flows.registry does NOT install a duplicate replacement-hook"
+    (let [hooks-var (resolve 're-frame.registrar/replacement-hooks)
+          before    (count @(deref hooks-var))]
+      (require 're-frame.flows.registry :reload)
+      (let [after (count @(deref hooks-var))]
+        (is (= before after)
+            "the hook count is unchanged across a namespace reload — `defonce` guards the install")))))

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -13,6 +13,7 @@
   added for re-frame-10x v2's flow panel."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.elision :as elision]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
@@ -234,3 +235,83 @@
     (is (= 1 (count (by-op :rf.flow/skip))))
     (is (= 1 (count (by-op :rf.flow/cleared))))
     (is (zero? (count (by-op :rf.flow/failed))))))
+
+;; ---------------------------------------------------------------------------
+;; 7. Wire-bearing flow trace payloads ride through `elide-wire-value`
+;;    (rf2-vkqkk — pins Spec 009 §Size elision in traces / §Privacy contract
+;;    for the flow trace surface).
+;;
+;; `:rf.flow/computed` carries `:input-values` and `:result`; `:rf.flow/failed`
+;; carries `:inputs`. Per Spec 009 the wire-bearing payload of every tracer
+;; surface MUST pass through the elision walker (the single normative emission
+;; site for `:rf.size/large-elided` and `:rf/redacted`). Pre-fix, the flow
+;; tracer bypassed the walker — a flow reading or producing a large value
+;; surfaced raw on the trace bus while sibling tracers (event-emit, error-
+;; emit, dispatch trace) honoured the contract. These tests pin the routing.
+;; ---------------------------------------------------------------------------
+
+(deftest computed-trace-elides-large-result
+  (testing ":rf.flow/computed :result rides through elide-wire-value — declared-large path is elided"
+    ;; Seed the app-db with `merge` semantics so the elision declarations
+    ;; written by `declare-large-path!` survive the :init handler — a
+    ;; replacing handler (e.g. `(fn [_ _] {:n 1})`) would wipe the
+    ;; `:rf/elision` registry slot under the same key, masking the
+    ;; declaration before the flow's evaluate-time registry read.
+    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-flow {:id     :payload
+                  :inputs [[:n]]
+                  :output (fn [_] {:bytes "BIG"})
+                  :path   [:derived :blob]})
+    ;; Declare the flow's :path as a large-elision candidate. The walker
+    ;; consults `[:rf/elision :declarations <path>]` per frame.
+    (elision/declare-large-path! [:derived :blob])
+    (reset! *captured* [])
+    (rf/dispatch-sync [:init])
+    (let [ev   (last (by-op :rf.flow/computed))
+          tags (:tags ev)]
+      (is (some? ev) ":rf.flow/computed fired")
+      (is (elision/marker? (:result tags))
+          ":result is replaced by the `:rf.size/large-elided` marker")
+      (let [marker (:rf.size/large-elided (:result tags))]
+        (is (= [:derived :blob] (:path marker))
+            "marker carries the declared path")
+        (is (= :declared (:reason marker))
+            "marker carries :reason :declared for declared-large paths")))))
+
+(deftest failed-trace-elides-inputs
+  (testing ":rf.flow/failed :inputs rides through elide-wire-value"
+    ;; Register the flow that will throw; the input path is declared
+    ;; large so the walker substitutes the marker on emit.
+    (rf/reg-event-db :init (fn [db _] (merge db {:payload {:big "value"}})))
+    (rf/reg-flow {:id     :boom
+                  :inputs [[:payload]]
+                  :output (fn [_] (throw (ex-info "boom" {})))
+                  :path   [:doomed]})
+    (elision/declare-large-path! [:payload])
+    (reset! *captured* [])
+    (rf/dispatch-sync [:init])
+    (let [ev   (last (by-op :rf.flow/failed))
+          tags (:tags ev)
+          [first-input] (:inputs tags)]
+      (is (some? ev) ":rf.flow/failed fired")
+      (is (vector? (:inputs tags))
+          ":inputs vector preserves the per-input slot shape")
+      (is (elision/marker? first-input)
+          "the elided input-value is substituted with the wire marker"))))
+
+(deftest computed-trace-elision-no-op-when-no-declaration
+  (testing "absent any declaration, :input-values and :result pass through unchanged"
+    ;; Belt-and-braces against an over-eager rewrite — the walker must be
+    ;; a no-op on plain values not nominated for elision.
+    (rf/reg-event-db :init (fn [_ _] {:w 3 :h 4}))
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* w h))
+                  :path   [:rect :area]})
+    (reset! *captured* [])
+    (rf/dispatch-sync [:init])
+    (let [tags (:tags (last (by-op :rf.flow/computed)))]
+      (is (= [3 4] (:input-values tags))
+          ":input-values pass through unmodified")
+      (is (= 12 (:result tags))
+          ":result passes through unmodified"))))

--- a/spec/API.md
+++ b/spec/API.md
@@ -37,7 +37,7 @@
 | `reg-machine*` | Fn | `(reg-machine* machine-id machine-spec)` | v1 | 005 | Plain-fn surface beneath `reg-machine`. No source-coord walking. Use for code-gen pipelines, REPL workflows, or conformance harnesses that synthesise specs from data. |
 | `reg-app-schema` | M | `(reg-app-schema path schema)` / `(reg-app-schema path schema opts)` | v1 | 010 | |
 | `reg-app-schemas` | M | `(reg-app-schemas {path-1 schema-1, path-2 schema-2, ...})` / `(reg-app-schemas {…} opts)` — bulk plural form for feature-modular apps that register 5–20 paths against the same prefix (per Conventions §Feature-modularity prefix convention). Each entry routes through the singular `reg-app-schema` and is stamped with this call's source-coords. Returns the vector of paths registered (rf2-jzs9) | v1 | 010 | |
-| `reg-flow` | Fn | `(reg-flow flow)` / `(reg-flow id flow)` | v1 | 013 | |
+| `reg-flow` | Fn | `(reg-flow flow)` / `(reg-flow flow opts)` | v1 | 013 | `opts` is a map (currently `{:frame frame-id}`). The shipped surface is opts-map only — same shape as `dispatch` / `subscribe` / `clear-flow`. Returns the flow's `:id` (per Conventions §`reg-*` return-value convention). |
 | `reg-route` | M | `(reg-route id metadata)` | v1 | 012 | |
 | `reg-head` | M | `(reg-head id ?metadata head-fn)` | v1 | 011 | New registry kind `:head`; routes name a registered head via `:head` route metadata. Captures source-coords; under the optional-artefact wrapper convention the surface routes through the `:ssr/reg-head` late-bind hook. |
 | `reg-error-projector` | M | `(reg-error-projector id ?metadata projector-fn)` | v1 | 011 | New registry kind `:error-projector`; named per-frame via the frame's `:ssr {:public-error-id ...}` metadata (per `reg-frame` / `make-frame`). |
@@ -49,7 +49,7 @@
 | `clear-event` | Fn | `(clear-event)` / `(clear-event id)` | v1 (preserved) |
 | `clear-sub` | Fn | `(clear-sub)` / `(clear-sub id)` | v1 (preserved) |
 | `clear-fx` | Fn | `(clear-fx)` / `(clear-fx id)` | v1 (preserved) |
-| `clear-flow` | Fn | `(clear-flow)` / `(clear-flow id)` | v1 |
+| `clear-flow` | Fn | `(clear-flow id)` / `(clear-flow id opts)` | v1 |
 | `destroy-frame` | Fn | `(destroy-frame frame-id)` | v1 |
 | `reset-frame` | Fn | `(reset-frame frame-id)` | v1 |
 | `clear-subscription-cache!` | Fn | `(clear-subscription-cache! frame-id?)` | v1 (preserved) |
@@ -546,7 +546,7 @@ Removed in v2 (see [MIGRATION §M-21](MIGRATION.md#m-21-drop-debug-trim-v-on-cha
 
 ### `reg-flow` / `clear-flow` (Spec 013)
 
-`reg-flow` is rowed canonically in [§Registration](#registration); required flow-map keys are `:id`, `:inputs`, `:output`, `:path`. `clear-flow` is rowed canonically in [§Clearing registrations](#clearing-registrations) (`(clear-flow id)` deregisters and `dissoc-in`s on `:path`).
+`reg-flow` is rowed canonically in [§Registration](#registration); required flow-map keys are `:id`, `:inputs`, `:output`, `:path`. Both surfaces take an optional opts map (`{:frame frame-id}`) selecting the owning frame: `(reg-flow flow)` / `(reg-flow flow opts)` and `(clear-flow id)` / `(clear-flow id opts)`. `clear-flow` is rowed canonically in [§Clearing registrations](#clearing-registrations); it deregisters the flow from the named frame and `dissoc-in`s its `:path` from that frame's `app-db` only (per Spec 013 §Frame-scoping).
 
 Reserved fx-ids for runtime flow management via `:fx`:
 


### PR DESCRIPTION
## Summary

P2/P3 polish cluster from the rf2-0b2eh round-2 audit + alignment audit (rf2-q25os) follow-ons. Five beads landed; the round-1 wave (rf2-flows-batch / #1007) already shipped the bulk of the cluster.

- **rf2-vkqkk (P1)** — `:rf.flow/computed` / `:rf.flow/failed` payloads (`:input-values`, `:result`, `:inputs`) now ride through `elision/elide-wire-value` per Spec 009 §Size elision in traces. The flow tracer was the last wire-emitting surface bypassing the walker.
- **rf2-otbub (P2)** — Slice-local coverage for `clear-flow`'s `:frame` opt routing, multi-frame registrar-slot retention, and frame-local app-db dissoc.
- **rf2-q25os (P2)** — `clear-flow` nested-path robustness: never-materialised parent no longer writes spurious `{:parent nil}`; non-map intermediate no longer throws `ClassCastException`. Extract `dissoc-in-safe` helper.
- **rf2-5ay09 (P3)** — Pin `_hot-reload-hook` defonce-idempotency on `(require ... :reload)`.
- **rf2-awz6w (P3)** — API.md flow signatures aligned with shipped arities (`(reg-flow flow [opts])` / `(clear-flow id [opts])`).

## Decision-blocked beads explicitly skipped

- rf2-wyt97 / rf2-hrqvg — `:rf.flow/failed` cascade-abort vs. continue contract decision pending Mike.

## Surface

- `implementation/flows/src/re_frame/flows.cljc` — elision routing on the two trace emit sites.
- `implementation/flows/src/re_frame/flows/registry.cljc` — `dissoc-in-safe` + clear-flow robust nested-path branch.
- `implementation/flows/test/re_frame/flows_test.clj` — 3 new deftests (nested-path before-first-compute, non-map intermediate, multi-frame clear routing, hot-reload-hook idempotency).
- `implementation/flows/test/re_frame/flows_trace_test.clj` — 3 new deftests for the elision routing.
- `spec/API.md` — flow signature rows + §`reg-flow` / `clear-flow` (Spec 013) section.

## Test plan

- [x] `cd implementation/flows && clojure -M:test` — 44 tests, 165 assertions, 0 failures.
- [x] `cd implementation && npm run test:cljs` — 1817 tests, 5105 assertions, 0 failures.