### PR TITLE
refactor(adapters): extract React-shaped substrate-spine (rf2-3vwbx)

### DIFF
--- a/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
+++ b/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
@@ -15,236 +15,70 @@
   adapters consume, so a future mixed-substrate app's frame-provider
   chain composes across substrates.
 
-  Per rf2-2qit Decision 8 we target the Helix 0.2.x line. The eight
-  decisions transferred from rf2-3yij (the UIx adapter) carry over
-  unchanged — Helix is structurally similar to UIx (React + hooks; no
-  reactive-atom primitive)."
-  (:require ["react"             :as React]
-            ["react-dom/client"  :as react-dom-client]
-            [reagent.core        :as r]
+  Per rf2-2qit Decision 8 we target the Helix 0.2.x line.
+
+  Substrate-spine sharing (rf2-3vwbx). The container quartet, derived
+  value, render-root, render-to-string, frame-provider, use-subscribe,
+  flush-views!, source-coord wrapper, and warn-once-cache logic all
+  come from `re-frame.substrate.spine` — that ns hosts the
+  React-shaped-substrate spine UIx and Helix share byte-for-byte. The
+  Helix-specific configuration here is the gensym-prefix triple, the
+  substrate-name (\"Helix\") used in warn-once text, and the helix.hooks
+  use-memo*/use-callback* (which want JS-array deps; the spine passes
+  JS arrays unconditionally)."
+  (:require [reagent.core        :as r]
             [reagent.ratom       :as ratom]
-            [helix.core          :as helix]
             [helix.hooks         :as helix-hooks]
             [re-frame.frame      :as frame]
-            [re-frame.interop    :as interop]
             [re-frame.late-bind  :as late-bind]
-            [re-frame.subs       :as subs]
             [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.substrate.spine   :as spine]
             [re-frame.adapter.context :as adapter-context]))
 
-;; ---- container ------------------------------------------------------------
-;;
-;; Per Spec 006 §revertibility-constraints the container holds the
-;; frame's app-db value and *only* the frame's app-db value. Helix
-;; itself doesn't ship a reactive atom primitive (it is the
-;; minimal-React-wrapper niche per the rf2-2qit bead) so we lean on a
-;; plain `clojure.core/atom` and broadcast changes via `add-watch` —
-;; observably equivalent to the Reagent adapter's r/atom for the
-;; substrate contract surface (read, replace, subscribe). Reactive
-;; view-side hookup happens through `useSyncExternalStore` in
-;; `use-subscribe` below, not through Reagent reactions.
+;; ---- shared spine wiring --------------------------------------------------
 
-(defn- make-state-container [initial-value]
-  (atom initial-value))
+(def ^:private spine-fns
+  (spine/make-react-spine
+    {:substrate-name        "Helix"
+     :gensym-prefix-sub     "rf-helix-sub-"
+     :gensym-prefix-derived "rf-helix-derived-"
+     :gensym-prefix-use-sub "rf-helix-use-sub-"
+     :use-memo              helix-hooks/use-memo*
+     :use-callback          helix-hooks/use-callback*
+     :use-context           helix-hooks/use-context}))
 
-(defn- read-container [container]
-  @container)
+;; ---- public surface (Helix-named) -----------------------------------------
 
-(defn- replace-container! [container new-value]
-  (reset! container new-value)
-  nil)
-
-(defn- subscribe-container [container on-change]
-  (let [k (gensym "rf-helix-sub-")]
-    (add-watch container k (fn [_ _ prev nu] (on-change prev nu)))
-    (fn unsubscribe [] (remove-watch container k))))
-
-;; ---- derived value --------------------------------------------------------
-;;
-;; Helix has no reaction primitive (same shape as UIx). The substrate
-;; contract requires that (read-container) on a derived container
-;; deref a fresh value computed from the sources; subscribe-container
-;; on a derived container fires when any source changes. We satisfy
-;; both via a thin IDeref wrapper whose change-broadcasting fan-out is
-;; one watch per source.
-;;
-;; Equality-on-= is preserved by the core's sub-cache invalidation
-;; algorithm (Spec 006 §Invalidation algorithm Phase 2): the sub-cache
-;; only re-emits when the recomputed value differs from the cached one
-;; by =. The derived container itself does not memoise; per the same
-;; spec section that's the cache's job, not the substrate's.
-
-(defn- make-derived-value [source-containers compute-fn]
-  (let [recompute     (fn [] (apply compute-fn (map deref source-containers)))
-        watchers      (atom {})            ;; user-key → wrapper-fn
-        on-dispose-fns (atom [])
-        ;; Per-source wrapper keys we own so dispose can unwire them.
-        own-keys      (atom {})            ;; source → key
-        notify        (fn [prev nu]
-                        (when (not= prev nu)
-                          (doseq [[_ w] @watchers] (w prev nu))))]
-    ;; Wire one watch per source so the listener registry surface
-    ;; (subscribe-container) on the derived container fires whenever
-    ;; any source changes.
-    ;; Seed the baseline from the *derived* value at construction time,
-    ;; not the raw source. The watch callback compares prev-derived
-    ;; against the recomputed derived value; if we seeded from
-    ;; `(deref s)` (the raw source), the first source change would
-    ;; spuriously notify whenever the derived projection differs in
-    ;; identity from the raw source — e.g. `(odd? x)`, counts, `:k`
-    ;; lookups, projections — even when the derived value itself is `=`.
-    (let [prev-state (atom (recompute))]
-      (doseq [s source-containers]
-        (let [k (gensym "rf-helix-derived-")]
-          (swap! own-keys assoc s k)
-          (add-watch s k
-            (fn [_ _ _ _]
-              (let [new-derived (recompute)
-                    prev-derived @prev-state]
-                (reset! prev-state new-derived)
-                (notify prev-derived new-derived)))))))
-    (reify
-      IDeref
-      (-deref [_] (recompute))
-      ;; Watch surface — `(subscribe-container derived on-change)` rides
-      ;; on this through the standard core helper, and the sub-cache's
-      ;; per-entry recompute layer keys watches by gensym so the
-      ;; remove-watch path below stays clean.
-      IWatchable
-      (-add-watch [this k f]
-        (swap! watchers assoc k (fn [prev nu] (f k this prev nu)))
-        this)
-      (-remove-watch [_this k]
-        (swap! watchers dissoc k)
-        nil)
-      ;; Reagent's IDisposable — `interop/add-on-dispose!` calls into
-      ;; this protocol when wiring the sub-cache's slot teardown
-      ;; (per Spec 006 §subscription-cache). Adopting the Reagent
-      ;; protocol keeps the cache wiring substrate-agnostic at the
-      ;; call site — core does not branch on adapter type.
-      ratom/IDisposable
-      (dispose! [_]
-        (doseq [[s k] @own-keys] (remove-watch s k))
-        (reset! own-keys {})
-        (reset! watchers {})
-        (doseq [f @on-dispose-fns] (f))
-        (reset! on-dispose-fns []))
-      (add-on-dispose! [_ f]
-        (swap! on-dispose-fns conj f)))))
-
-;; ---- render ---------------------------------------------------------------
-;;
-;; Helix doesn't ship a `helix.dom/render-root` wrapper — Helix is the
-;; minimal-React-wrapper substrate. We call react-dom/client directly,
-;; which is also the path the UIx adapter takes for cross-version
-;; stability. createRoot + .render for fresh mounts; hydrateRoot for
-;; the SSR-hydrate path.
-
-(defn- render [render-tree mount-point opts]
-  (let [hydrate? (boolean (:hydrate? opts))
-        root     (if hydrate?
-                   (react-dom-client/hydrateRoot mount-point render-tree)
-                   (let [r (react-dom-client/createRoot mount-point)]
-                     (.render r render-tree)
-                     r))]
-    (fn unmount [] (.unmount root))))
-
-(defonce ^:private hiccup-emitter (atom nil))
-
-(defn set-hiccup-emitter!
+(def set-hiccup-emitter!
   "Install a render-tree → HTML fn for use by render-to-string. Idempotent.
   Helix itself doesn't render to string in browser bundles; SSR consumers
   install the hiccup emitter explicitly (mirroring the Reagent and UIx
   adapters)."
-  [f]
-  (reset! hiccup-emitter f))
+  (:set-hiccup-emitter! spine-fns))
 
-(defn- render-to-string [render-tree opts]
-  (if-let [emit @hiccup-emitter]
-    (emit render-tree opts)
-    (throw (ex-info ":rf.error/no-hiccup-emitter-bound"
-                    {:reason "use the plain-atom adapter on the JVM for SSR, or install via set-hiccup-emitter!"
-                     :render-tree render-tree}))))
-
-;; ---- context provider -----------------------------------------------------
-;;
-;; Per rf2-2qit Decision 2 we share the same React.createContext object
-;; with the Reagent and UIx adapters (it lives in
-;; re-frame.adapter.context). Helix components consume it via
-;; `helix-hooks/use-context`; the Provider is the same React Provider
-;; component the other adapters target.
-
-(defn use-current-frame
+(def use-current-frame
   "Helix hook returning the current frame keyword from the surrounding
   React context, or `:rf/default` when no frame-provider sits above.
+  Decision 2 mandates every React-shaped adapter resolves the same
+  context, so a Helix subtree under a Reagent or UIx frame-provider
+  sees the right frame and vice versa."
+  (:use-current-frame spine-fns))
 
-  This is the Helix counterpart of `re-frame.views/current-frame`'s
-  React-context tier — Decision 2 mandates every React-shaped adapter
-  resolves the *same* context, so a Helix subtree under a Reagent or
-  UIx frame-provider sees the right frame and vice versa."
-  []
-  (helix-hooks/use-context adapter-context/frame-context))
-
-(defn frame-provider
+(def frame-provider
   "User-facing component scoping `frame-kw` to its subtree. Wraps
-  children in the shared frame Context Provider — inside the subtree,
-  `(rf/dispatcher)` / `(rf/subscriber)` / `reg-view`-registered
-  descendants resolve to the named frame. Per Spec 002 §What
-  `frame-provider` is.
-
-  Reads `:frame` from props. When missing or `nil`, falls through to
-  `:rf/default` (per rf2-sixo — defensive default that matches the
-  no-provider behaviour and avoids breaking tooling-generated trees
-  that elide the prop).
-
-  Helix call shape:
+  children in the shared frame Context Provider. Helix call shape:
 
       ($ frame-provider {:frame :session
                          :children [($ header) ($ main)]})
 
-  Same surface as the Reagent and UIx variants, different rendering
-  substrate. The three adapters share one React Context (per rf2-3yij
-  Decision 2) so a subtree under any frame-provider sees the right
-  frame regardless of which substrate rendered the provider."
-  [{:keys [frame children]}]
-  (let [frame-kw (or frame :rf/default)]
-    (apply adapter-context/provider-element frame-kw
-           (if (sequential? children) children [children]))))
+  Per rf2-sixo: missing or `nil` `:frame` falls through to `:rf/default`.
+  The three React-shaped adapters share one React Context (per rf2-3yij
+  Decision 2 / rf2-2qit Decision 2) so a subtree under any
+  frame-provider sees the right frame regardless of which substrate
+  rendered the provider."
+  (:frame-provider spine-fns))
 
-(defn- register-context-provider [_frame-keyword]
-  ;; Same shape as the Reagent and UIx adapters: returns a built
-  ;; component (here, a React-element-producing fn). The arg is ignored
-  ;; because the frame keyword lives in the Provider's :value at render
-  ;; time (rf2-4y60), not in a build-time closure.
-  frame-provider)
-
-;; ---- subscription hook ----------------------------------------------------
-;;
-;; Per Spec 006 §subscription-cache and rf2-2qit Decision 1 (transferred
-;; from rf2-3yij), `use-subscribe` is the Helix-idiomatic hook surface
-;; for reading a sub. It wraps React.useSyncExternalStore so updates
-;; are scheduled by React's concurrent renderer rather than Reagent's
-;; per-component scheduler. Helix doesn't ship a use-syncExternalStore
-;; wrapper of its own (it is the minimal-React-wrapper niche), so we
-;; use React's hook directly — same path the UIx adapter takes.
-;;
-;; The hook:
-;;   1. Resolves the active frame via use-context (Decision 2).
-;;   2. Calls re-frame.subs/subscribe to build/cache the reaction.
-;;   3. Wires useSyncExternalStore — the snapshot is the deref of the
-;;      reaction; subscribe is add-watch on the underlying container.
-;;   4. On unmount the watch is removed and the sub's ref-count
-;;      decrements through the cache's deferred-dispose grace-period
-;;      (per Spec 006 §reference-counting-and-disposal).
-;;
-;; Per rf2-2qit Decision 3 there is no auto-injection: components
-;; written for Helix call `(use-subscribe [:foo])` directly, the way
-;; they would call any other React hook.
-
-(defn- subscribe-snapshot [reaction]
-  (when reaction @reaction))
-
-(defn use-subscribe
+(def use-subscribe
   "Helix hook that reads a re-frame subscription. Returns the current
   value; re-renders the calling component when the value changes.
 
@@ -256,177 +90,37 @@
   the React/Helix idiom — symmetric ergonomics to Reagent's
   `(rf/subscribe ...)` deref shape, asymmetric naming (hooks live in
   hook-named space)."
-  ([query-v]
-   (let [frame-kw (use-current-frame)]
-     (use-subscribe frame-kw query-v)))
-  ([frame-kw query-v]
-   (let [reaction (helix-hooks/use-memo* (fn [] (subs/subscribe frame-kw query-v))
-                                         #js [frame-kw query-v])
-         ;; The store-snapshot fn React calls on every render to detect
-         ;; tearing. Pure deref of the reaction.
-         get-snap (helix-hooks/use-callback* (fn [] (subscribe-snapshot reaction))
-                                             #js [reaction])
-         ;; The store-subscribe fn — React calls it once with a
-         ;; force-update callback; we wire that up to add-watch on the
-         ;; reaction's underlying container.
-         subscribe-fn (helix-hooks/use-callback*
-                        (fn [on-change]
-                          (let [k (gensym "rf-helix-use-sub-")]
-                            (when reaction
-                              (add-watch reaction k (fn [_ _ _ _] (on-change))))
-                            (fn unsubscribe []
-                              (when reaction (remove-watch reaction k)))))
-                        #js [reaction])]
-     (React/useSyncExternalStore subscribe-fn get-snap get-snap))))
+  (:use-subscribe spine-fns))
 
-;; ---- render flush for tests (rf2-2qit Decision 6) -------------------------
-;;
-;; `flush-views!` wraps React's `act()` so test code can drive a
-;; subscribe → re-render cycle synchronously. Tests that drive Helix
-;; components from a test runner call `(flush-views!)` after a dispatch
-;; to flush pending React effects before reading the DOM.
-
-(defn flush-views!
+(def flush-views!
   "Flush pending Helix renders synchronously. Wraps React's act() —
-  intended for test code only. Calls (act f) where f is the body
-  thunk; with no arg, calls (act (fn [] nil)) to flush pending effects.
+  intended for test code only. Calls (act f); with no arg, calls (act
+  (fn [] nil)) to flush pending effects. Returns nil. Resolves React's
+  act() across React 18 (in `react-dom/test-utils`) and React 19 (on
+  the React namespace directly).
 
   Per rf2-2qit Decision 6: the canonical test-flush hook for
-  Helix-based apps. Reagent has no analogous public surface — Reagent
-  tests rely on r/flush; Helix tests rely on this."
-  ([] (flush-views! (fn [] nil)))
-  ([f]
-   (when-let [act (or (.-act React)
-                      ;; React 18 moved act into react-dom/test-utils;
-                      ;; if not on React directly, swallow gracefully.
-                      nil)]
-     (act f))
-   nil))
+  Helix-based apps."
+  (:flush-views! spine-fns))
 
-;; ---- source-coord wrapper (rf2-2qit Decision 5; Spec 006 §Source-coord) --
-;;
-;; Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1) every
-;; React-shaped substrate adapter MUST inject
-;; `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` on each registered
-;; view's root DOM element when `interop/debug-enabled?` is true.
-;;
-;; The Reagent adapter walks hiccup output and merges the attr; the
-;; Helix adapter (like the UIx adapter) walks Helix's `$` output (a
-;; React element) and clones the root with the attr added —
-;; React.cloneElement preserves the original component, props, and
-;; children while letting us layer one extra prop on top.
-;;
-;; Production-elision contract (rf2-z7f7 / Spec 009): the entire branch
-;; sits inside `(when interop/debug-enabled? ...)` so the closure
-;; compiler constant-folds the wrapper away under :advanced +
-;; goog.DEBUG=false. The bundle-grep test confirms the
-;; `data-rf2-source-coord` literal is absent from production builds.
-
-(defn- format-source-coord
-  "Render captured registry coords as the attribute value shape
-  `<ns>:<sym>:<line>:<col>`. Mirrors re-frame.views/format-source-coord
-  so DOM output is identical across the three substrates."
-  [id coords]
-  (let [ns-part  (or (namespace id) "?")
-        sym-part (name id)
-        line     (:line coords)
-        col      (:column coords)]
-    (str ns-part ":" sym-part ":"
-         (if line (str line) "?")
-         ":"
-         (if col (str col) "?"))))
-
-(defonce ^:private warned-non-dom-roots (atom #{}))
-
-(defn clear-warned-non-dom-roots!
-  "Reset the warn-once cache for non-DOM-root warnings. Tests use this
-  between cases (via `reset-runtime-fixture` and the chained
-  `:adapter/clear-warn-once-caches!` hook) so a sibling test's first-
-  encounter warning cannot silently swallow a later test's same-id
-  warning. Per rf2-4edk — the cache is a process-wide `defonce` so
-  the user-facing warn-once UX is unchanged in production; test-time
-  clearing is the only effect."
-  []
-  (reset! warned-non-dom-roots #{})
-  nil)
-
-(defn- warn-non-dom-root!
-  "Emit a one-shot warning per id that a registered view's root is
-  exempt from source-coord injection — a Fragment, a function/class
-  component, or a non-element value. Pair tools fall back to the
-  registry's `:rf/id` for these cases (Spec 006 §Source-coord
-  annotation, Fragment exemption)."
-  [id type-tag]
-  (when-not (contains? @warned-non-dom-roots id)
-    (swap! warned-non-dom-roots conj id)
-    (when (exists? js/console)
-      (.warn js/console
-        (str "[re-frame] reg-view " id " — root element is "
-             (pr-str type-tag) " (Helix); data-rf2-source-coord skipped "
-             "(Spec 006 §Source-coord annotation: pair tools fall back to "
-             ":rf/id for non-DOM roots).")))))
-
-(defn- dom-element?
-  "True if the React element's `type` is a string (a DOM tag like
-  \"div\"). Function/class components and Fragments have non-string
-  `type`s and are exempt per Spec 006."
-  [react-element]
-  (and react-element
-       (some? (.-type react-element))
-       (string? (.-type react-element))))
-
-(defn- inject-source-coord-attr
-  "Wrap `out` (the user component's React element output) with a
-  cloneElement call that adds `:data-rf2-source-coord`. Non-element
-  outputs (nil, fragment, function-component head) emit a one-shot
-  warning per id and pass through unchanged. Per Spec 006 §Source-coord
-  annotation."
-  [id coord-attr out]
-  (cond
-    (dom-element? out)
-    (let [props        (.-props out)
-          existing     (when props (aget props "data-rf2-source-coord"))
-          merged-props (if existing
-                         #js {}
-                         #js {"data-rf2-source-coord" coord-attr})]
-      (if existing
-        out
-        (React/cloneElement out merged-props)))
-
-    :else
-    (do
-      (when (some? out)
-        (warn-non-dom-root! id (some-> out .-type)))
-      out)))
-
-(defn wrap-view
+(def wrap-view
   "Wrap a Helix-shape user component in a function component that
   injects `data-rf2-source-coord` on the rendered root DOM element
   (when `interop/debug-enabled?` is true). Returned fn has the same
   call signature as `user-fn` and is suitable for use as a Helix
-  component head.
+  component head. Production builds elide via `interop/debug-enabled?`
+  per Spec 009 §Production builds."
+  (:wrap-view spine-fns))
 
-  Per rf2-2qit Decision 5 + Spec 006 §Source-coord annotation: this is
-  the Helix-side equivalent of the Reagent adapter's
-  `inject-source-coord-attr` walk and the UIx adapter's `wrap-view`.
-  Production builds elide via `interop/debug-enabled?` per Spec 009
-  §Production builds."
-  [id metadata user-fn]
-  (let [coord-attr (when interop/debug-enabled?
-                     (format-source-coord id metadata))]
-    (fn wrapped-user-fn [& args]
-      (let [out (apply user-fn args)]
-        (if interop/debug-enabled?
-          (inject-source-coord-attr id coord-attr out)
-          out)))))
+(def clear-warned-non-dom-roots!
+  "Reset the warn-once cache for non-DOM-root warnings. Tests use this
+  between cases (via `reset-runtime-fixture` and the chained
+  `:adapter/clear-warn-once-caches!` hook) so a sibling test's
+  first-encounter warning cannot silently swallow a later test's same-id
+  warning. Per rf2-4edk."
+  (:clear-warned-non-dom-roots! spine-fns))
 
-;; ---- disposal -------------------------------------------------------------
-
-(defn- dispose-adapter! []
-  ;; Helix itself holds no reaction caches — view re-renders are React's
-  ;; concern. Watches on derived containers GC with the containers
-  ;; themselves. Nothing special to do here.
-  nil)
+;; ---- adapter Var ----------------------------------------------------------
 
 (def adapter
   "The Helix adapter map. Pass to `(rf/init! ...)` to install:
@@ -439,15 +133,15 @@
   and re-frame.adapter.uix. Per rf2-agql there is no default-adapter
   registry — adapter wiring is explicit at the call site."
   {:kind                      :helix
-   :make-state-container      make-state-container
-   :read-container            read-container
-   :replace-container!        replace-container!
-   :subscribe-container       subscribe-container
-   :make-derived-value        make-derived-value
-   :render                    render
-   :render-to-string          render-to-string
-   :register-context-provider register-context-provider
-   :dispose-adapter!          dispose-adapter!})
+   :make-state-container      (:make-state-container      spine-fns)
+   :read-container            (:read-container            spine-fns)
+   :replace-container!        (:replace-container!        spine-fns)
+   :subscribe-container       (:subscribe-container       spine-fns)
+   :make-derived-value        (:make-derived-value        spine-fns)
+   :render                    (:render                    spine-fns)
+   :render-to-string          (:render-to-string          spine-fns)
+   :register-context-provider (:register-context-provider spine-fns)
+   :dispose-adapter!          (:dispose-adapter!          spine-fns)})
 
 ;; Each late-bind hook below is routed through `(substrate-adapter/
 ;; current-adapter)` per rf2-0d35 via `substrate-adapter/route-hook!`
@@ -472,9 +166,9 @@
 ;;   :adapter/wrap-view — rf2-00li. Substrate-side source-coord
 ;;     injection via React.cloneElement (the inline hiccup-walk in
 ;;     views.cljs would mis-classify React-element output as a non-DOM
-;;     root). Production-elision: `wrap-view`'s body sits inside
-;;     `(when interop/debug-enabled? ...)` so closure-folds under
-;;     :advanced + goog.DEBUG=false (per Spec 009 §Production builds).
+;;     root). Production-elision: `wrap-view`'s body sits inside an
+;;     `interop/debug-enabled?` gate so closure-folds under :advanced +
+;;     goog.DEBUG=false (per Spec 009 §Production builds).
 (substrate-adapter/route-hook! adapter :adapter/current-frame
   adapter-context/function-component-current-frame
   #(frame/current-frame))
@@ -497,19 +191,14 @@
 (substrate-adapter/route-hook! adapter :adapter/wrap-view
   wrap-view)
 
-;; Per rf2-4edk: contribute a clear of THIS adapter's `warned-non-dom-roots`
-;; cache to the chained `:adapter/clear-warn-once-caches!` hook. The hook
-;; is chained — each adapter (helix, uix) and re-frame.views all contribute
-;; a clear-step; `reset-runtime-fixture` invokes the top of the chain and
-;; every contributor's reset runs (unlike `:adapter/current-frame` etc.
-;; this hook is NOT routed through the installed adapter — every loaded
-;; adapter's cache must clear because test bundles can mount different
-;; adapters across tests and each adapter's defonce persists). Production
-;; behaviour is unchanged: the warn-once `defonce` is still per-process
-;; for users; only test-time clearing is new.
-(let [previous (late-bind/get-fn :adapter/clear-warn-once-caches!)]
-  (late-bind/set-fn! :adapter/clear-warn-once-caches!
-    (fn helix-adapter-clear-warn-once-caches! []
-      (clear-warned-non-dom-roots!)
-      (when previous (previous))
-      nil)))
+;; Per rf2-4edk: contribute a clear of THIS adapter's warn-once cache to
+;; the chained `:adapter/clear-warn-once-caches!` hook. The hook is
+;; chained — each adapter (helix, uix) and re-frame.views all contribute
+;; a clear-step; `reset-runtime-fixture` invokes the top of the chain
+;; and every contributor's reset runs (unlike `:adapter/current-frame`
+;; etc. this hook is NOT routed through the installed adapter — every
+;; loaded adapter's cache must clear because test bundles can mount
+;; different adapters across tests and each adapter's defonce persists).
+;; Production behaviour is unchanged: the warn-once defonce is still
+;; per-process for users; only test-time clearing is new.
+(spine/install-clear-warn-once-step! clear-warned-non-dom-roots!)

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -15,228 +15,68 @@
   consumes, so a future mixed-substrate app's frame-provider chain
   composes across substrates.
 
-  Per rf2-3yij Decision 8 we target UIx 2.x (hooks-based)."
-  (:require ["react"          :as React]
-            ["react-dom/client" :as react-dom-client]
-            [reagent.core     :as r]
+  Per rf2-3yij Decision 8 we target UIx 2.x (hooks-based).
+
+  Substrate-spine sharing (rf2-3vwbx). The container quartet, derived
+  value, render-root, render-to-string, frame-provider, use-subscribe,
+  flush-views!, source-coord wrapper, and warn-once-cache logic all
+  come from `re-frame.substrate.spine` — that ns hosts the
+  React-shaped-substrate spine UIx and Helix share byte-for-byte. The
+  UIx-specific configuration here is the gensym-prefix triple, the
+  substrate-name (\"UIx\") used in warn-once text, and the uix.core
+  use-memo/use-callback (which UIx accepts as JS arrays just as the
+  spine passes them)."
+  (:require [reagent.core     :as r]
             [reagent.ratom    :as ratom]
             [uix.core         :as uix]
-            [uix.dom          :as uix-dom]
             [re-frame.frame   :as frame]
-            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
-            [re-frame.subs    :as subs]
             [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.substrate.spine   :as spine]
             [re-frame.adapter.context :as adapter-context]))
 
-;; ---- container ------------------------------------------------------------
-;;
-;; Per Spec 006 §revertibility-constraints the container holds the
-;; frame's app-db value and *only* the frame's app-db value. UIx itself
-;; doesn't ship a reactive atom primitive (its hook substrate is React
-;; state) so we lean on a plain `clojure.core/atom` and broadcast
-;; changes via `add-watch` — observably equivalent to the Reagent
-;; adapter's r/atom for the substrate contract surface (read, replace,
-;; subscribe). Reactive view-side hookup happens through
-;; `useSyncExternalStore` in `use-subscribe` below, not through Reagent
-;; reactions.
+;; ---- shared spine wiring --------------------------------------------------
 
-(defn- make-state-container [initial-value]
-  (atom initial-value))
+(def ^:private spine-fns
+  (spine/make-react-spine
+    {:substrate-name        "UIx"
+     :gensym-prefix-sub     "rf-uix-sub-"
+     :gensym-prefix-derived "rf-uix-derived-"
+     :gensym-prefix-use-sub "rf-uix-use-sub-"
+     :use-memo              uix/use-memo
+     :use-callback          uix/use-callback
+     :use-context           uix/use-context}))
 
-(defn- read-container [container]
-  @container)
+;; ---- public surface (UIx-named) -------------------------------------------
 
-(defn- replace-container! [container new-value]
-  (reset! container new-value)
-  nil)
-
-(defn- subscribe-container [container on-change]
-  (let [k (gensym "rf-uix-sub-")]
-    (add-watch container k (fn [_ _ prev nu] (on-change prev nu)))
-    (fn unsubscribe [] (remove-watch container k))))
-
-;; ---- derived value --------------------------------------------------------
-;;
-;; UIx has no reaction primitive. The substrate contract requires that
-;; (read-container) on a derived container deref a fresh value computed
-;; from the sources; subscribe-container on a derived container fires
-;; when any source changes. We satisfy both via a thin IDeref wrapper
-;; whose change-broadcasting fan-out is one watch per source.
-;;
-;; Equality-on-= is preserved by the core's sub-cache invalidation
-;; algorithm (Spec 006 §Invalidation algorithm Phase 2): the sub-cache
-;; only re-emits when the recomputed value differs from the cached one
-;; by =. The derived container itself does not memoise; per the same
-;; spec section that's the cache's job, not the substrate's.
-
-(defn- make-derived-value [source-containers compute-fn]
-  (let [recompute     (fn [] (apply compute-fn (map deref source-containers)))
-        watchers      (atom {})            ;; user-key → wrapper-fn
-        on-dispose-fns (atom [])
-        ;; Per-source wrapper keys we own so dispose can unwire them.
-        own-keys      (atom {})            ;; source → key
-        notify        (fn [prev nu]
-                        (when (not= prev nu)
-                          (doseq [[_ w] @watchers] (w prev nu))))]
-    ;; Wire one watch per source so the listener registry surface
-    ;; (subscribe-container) on the derived container fires whenever
-    ;; any source changes.
-    ;; Seed the baseline from the *derived* value at construction time,
-    ;; not the raw source. The watch callback compares prev-derived
-    ;; against the recomputed derived value; if we seeded from
-    ;; `(deref s)` (the raw source), the first source change would
-    ;; spuriously notify whenever the derived projection differs in
-    ;; identity from the raw source — e.g. `(odd? x)`, counts, `:k`
-    ;; lookups, projections — even when the derived value itself is `=`.
-    (let [prev-state (atom (recompute))]
-      (doseq [s source-containers]
-        (let [k (gensym "rf-uix-derived-")]
-          (swap! own-keys assoc s k)
-          (add-watch s k
-            (fn [_ _ _ _]
-              (let [new-derived (recompute)
-                    prev-derived @prev-state]
-                (reset! prev-state new-derived)
-                (notify prev-derived new-derived)))))))
-    (reify
-      IDeref
-      (-deref [_] (recompute))
-      ;; Watch surface — `(subscribe-container derived on-change)` rides
-      ;; on this through the standard core helper, and the sub-cache's
-      ;; per-entry recompute layer keys watches by gensym so the
-      ;; remove-watch path below stays clean.
-      IWatchable
-      (-add-watch [this k f]
-        (swap! watchers assoc k (fn [prev nu] (f k this prev nu)))
-        this)
-      (-remove-watch [_this k]
-        (swap! watchers dissoc k)
-        nil)
-      ;; Reagent's IDisposable — `interop/add-on-dispose!` calls into
-      ;; this protocol when wiring the sub-cache's slot teardown
-      ;; (per Spec 006 §subscription-cache and the rf2-3yij
-      ;; cross-substrate-cache decision). Adopting the Reagent
-      ;; protocol keeps the cache wiring substrate-agnostic at the
-      ;; call site — core does not branch on adapter type.
-      ratom/IDisposable
-      (dispose! [_]
-        (doseq [[s k] @own-keys] (remove-watch s k))
-        (reset! own-keys {})
-        (reset! watchers {})
-        (doseq [f @on-dispose-fns] (f))
-        (reset! on-dispose-fns []))
-      (add-on-dispose! [_ f]
-        (swap! on-dispose-fns conj f)))))
-
-;; ---- render ---------------------------------------------------------------
-;;
-;; UIx 2.x ships uix.dom/render-root (a thin wrapper over React 18's
-;; ReactDOM.createRoot + root.render). For interop with the existing
-;; reagent.dom.client/hydrate-root path we use react-dom/client
-;; directly — uix.dom doesn't expose hydrate-root in every version and
-;; the lower-level call is stable across UIx 2.x point releases.
-
-(defn- render [render-tree mount-point opts]
-  (let [hydrate? (boolean (:hydrate? opts))
-        root     (if hydrate?
-                   (react-dom-client/hydrateRoot mount-point render-tree)
-                   (let [r (react-dom-client/createRoot mount-point)]
-                     (.render r render-tree)
-                     r))]
-    (fn unmount [] (.unmount root))))
-
-(defonce ^:private hiccup-emitter (atom nil))
-
-(defn set-hiccup-emitter!
+(def set-hiccup-emitter!
   "Install a render-tree → HTML fn for use by render-to-string. Idempotent.
   UIx itself doesn't render to string in browser bundles; SSR consumers
   install the hiccup emitter explicitly (mirroring the Reagent adapter)."
-  [f]
-  (reset! hiccup-emitter f))
+  (:set-hiccup-emitter! spine-fns))
 
-(defn- render-to-string [render-tree opts]
-  (if-let [emit @hiccup-emitter]
-    (emit render-tree opts)
-    (throw (ex-info ":rf.error/no-hiccup-emitter-bound"
-                    {:reason "use the plain-atom adapter on the JVM for SSR, or install via set-hiccup-emitter!"
-                     :render-tree render-tree}))))
-
-;; ---- context provider -----------------------------------------------------
-;;
-;; Per rf2-3yij Decision 2 we share the same React.createContext object
-;; with the Reagent adapter (it lives in re-frame.adapter.context).
-;; UIx components consume it via `uix/use-context`; the Provider is the
-;; same React Provider component the Reagent adapter targets.
-
-(defn use-current-frame
+(def use-current-frame
   "UIx hook returning the current frame keyword from the surrounding
   React context, or `:rf/default` when no frame-provider sits above.
+  Decision 2 mandates every React-shaped adapter resolves the same
+  context, so a UIx subtree under a Reagent frame-provider sees the
+  right frame and vice versa."
+  (:use-current-frame spine-fns))
 
-  This is the UIx counterpart of `re-frame.views/current-frame`'s
-  React-context tier — Decision 2 mandates both adapters resolve the
-  same context, so a UIx subtree under a Reagent frame-provider sees
-  the right frame and vice versa."
-  []
-  (uix/use-context adapter-context/frame-context))
-
-(defn frame-provider
+(def frame-provider
   "User-facing component scoping `frame-kw` to its subtree. Wraps
-  children in the shared frame Context Provider — inside the subtree,
-  `(rf/dispatcher)` / `(rf/subscriber)` / `reg-view`-registered
-  descendants resolve to the named frame. Per Spec 002 §What
-  `frame-provider` is.
-
-  Reads `:frame` from props. When missing or `nil`, falls through to
-  `:rf/default` (per rf2-sixo — defensive default that matches the
-  no-provider behaviour and avoids breaking tooling-generated trees
-  that elide the prop).
-
-  UIx call shape:
+  children in the shared frame Context Provider. UIx call shape:
 
       ($ frame-provider {:frame :session
                          :children [($ header) ($ main)]})
 
-  Same surface as the Reagent and Helix variants, different rendering
-  substrate. The three adapters share one React Context (per rf2-3yij
+  Per rf2-sixo: missing or `nil` `:frame` falls through to `:rf/default`.
+  The three React-shaped adapters share one React Context (per rf2-3yij
   Decision 2) so a subtree under any frame-provider sees the right
   frame regardless of which substrate rendered the provider."
-  [{:keys [frame children]}]
-  (let [frame-kw (or frame :rf/default)]
-    (apply adapter-context/provider-element frame-kw
-           (if (sequential? children) children [children]))))
+  (:frame-provider spine-fns))
 
-(defn- register-context-provider [_frame-keyword]
-  ;; Same shape as the Reagent adapter: returns a built component
-  ;; (here, a React-element-producing fn). The arg is ignored because
-  ;; the frame keyword lives in the Provider's :value at render time
-  ;; (rf2-4y60), not in a build-time closure.
-  frame-provider)
-
-;; ---- subscription hook ----------------------------------------------------
-;;
-;; Per Spec 006 §subscription-cache and rf2-3yij Decision 1, `use-subscribe`
-;; is the UIx-idiomatic hook surface for reading a sub. It wraps
-;; React.useSyncExternalStore so updates are scheduled by React's
-;; concurrent renderer rather than Reagent's per-component scheduler.
-;;
-;; The hook:
-;;   1. Resolves the active frame via use-context (Decision 2).
-;;   2. Calls re-frame.subs/subscribe to build/cache the reaction.
-;;   3. Wires useSyncExternalStore — the snapshot is the deref of the
-;;      reaction; subscribe is add-watch on the underlying container.
-;;   4. On unmount the watch is removed and the sub's ref-count
-;;      decrements through the cache's deferred-dispose grace-period
-;;      (per Spec 006 §reference-counting-and-disposal).
-;;
-;; Per rf2-3yij Decision 3 there is no auto-injection: components
-;; written for UIx call `(use-subscribe [:foo])` directly, the way they
-;; would call any other React hook.
-
-(defn- subscribe-snapshot [reaction]
-  (when reaction @reaction))
-
-(defn use-subscribe
+(def use-subscribe
   "UIx hook that reads a re-frame subscription. Returns the current
   value; re-renders the calling component when the value changes.
 
@@ -248,178 +88,37 @@
   the React/UIx idiom — symmetric ergonomics to Reagent's
   `(rf/subscribe ...)` deref shape, asymmetric naming (hooks live in
   hook-named space)."
-  ([query-v]
-   (let [frame-kw (use-current-frame)]
-     (use-subscribe frame-kw query-v)))
-  ([frame-kw query-v]
-   (let [reaction (uix/use-memo
-                    (fn [] (subs/subscribe frame-kw query-v))
-                    [frame-kw query-v])
-         ;; The store-snapshot fn React calls on every render to detect
-         ;; tearing. Pure deref of the reaction.
-         get-snap (uix/use-callback
-                    (fn [] (subscribe-snapshot reaction))
-                    [reaction])
-         ;; The store-subscribe fn — React calls it once with a
-         ;; force-update callback; we wire that up to add-watch on the
-         ;; reaction's underlying container.
-         subscribe-fn (uix/use-callback
-                        (fn [on-change]
-                          (let [k (gensym "rf-uix-use-sub-")]
-                            (when reaction
-                              (add-watch reaction k (fn [_ _ _ _] (on-change))))
-                            (fn unsubscribe []
-                              (when reaction (remove-watch reaction k)))))
-                        [reaction])]
-     (React/useSyncExternalStore subscribe-fn get-snap get-snap))))
+  (:use-subscribe spine-fns))
 
-;; ---- render flush for tests (rf2-3yij Decision 6) -------------------------
-;;
-;; `flush-views!` wraps React's `act()` so test code can drive a
-;; subscribe → re-render cycle synchronously. Tests that drive UIx
-;; components from a test runner call `(flush-views!)` after a dispatch
-;; to flush pending React effects before reading the DOM.
-
-(defn flush-views!
+(def flush-views!
   "Flush pending UIx renders synchronously. Wraps React's act() —
-  intended for test code only. Calls (act f) where f is the body
-  thunk; with no arg, calls (act (fn [] nil)) to flush pending effects.
+  intended for test code only. Calls (act f); with no arg, calls (act
+  (fn [] nil)) to flush pending effects. Returns nil. Resolves React's
+  act() across React 18 (in `react-dom/test-utils`) and React 19 (on
+  the React namespace directly).
 
   Per rf2-3yij Decision 6: the canonical test-flush hook for UIx-based
-  apps. Reagent has no analogous public surface — Reagent tests rely
-  on r/flush; UIx tests rely on this."
-  ([] (flush-views! (fn [] nil)))
-  ([f]
-   (when-let [act (or (.-act React)
-                      ;; React 18 moved act into react-dom/test-utils;
-                      ;; if not on React directly, swallow gracefully.
-                      nil)]
-     (act f))
-   nil))
+  apps."
+  (:flush-views! spine-fns))
 
-;; ---- source-coord wrapper (rf2-3yij Decision 5; Spec 006 §Source-coord) --
-;;
-;; Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1) every
-;; React-shaped substrate adapter MUST inject
-;; `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` on each registered
-;; view's root DOM element when `interop/debug-enabled?` is true.
-;;
-;; The Reagent adapter walks hiccup output and merges the attr; the
-;; UIx adapter walks UIx's `$` output (a React element) and clones the
-;; root with the attr added — React.cloneElement preserves the original
-;; component, props, and children while letting us layer one extra prop
-;; on top.
-;;
-;; Production-elision contract (rf2-z7f7 / Spec 009): the entire branch
-;; sits inside `(when interop/debug-enabled? ...)` so the closure
-;; compiler constant-folds the wrapper away under :advanced +
-;; goog.DEBUG=false. The bundle-grep test confirms the
-;; `data-rf2-source-coord` literal is absent from production builds.
+(def wrap-view
+  "Wrap a UIx-shape user component in a function component that injects
+  `data-rf2-source-coord` on the rendered root DOM element (when
+  `interop/debug-enabled?` is true). Returned fn has the same call
+  signature as `user-fn` and is suitable for use as a UIx component
+  head. Production builds elide via `interop/debug-enabled?` per
+  Spec 009 §Production builds."
+  (:wrap-view spine-fns))
 
-(defn- format-source-coord
-  "Render captured registry coords as the attribute value shape
-  `<ns>:<sym>:<line>:<col>`. Mirrors re-frame.views/format-source-coord
-  so DOM output is identical across the two substrates."
-  [id coords]
-  (let [ns-part  (or (namespace id) "?")
-        sym-part (name id)
-        line     (:line coords)
-        col      (:column coords)]
-    (str ns-part ":" sym-part ":"
-         (if line (str line) "?")
-         ":"
-         (if col (str col) "?"))))
-
-(defonce ^:private warned-non-dom-roots (atom #{}))
-
-(defn clear-warned-non-dom-roots!
+(def clear-warned-non-dom-roots!
   "Reset the warn-once cache for non-DOM-root warnings. Tests use this
   between cases (via `reset-runtime-fixture` and the chained
-  `:adapter/clear-warn-once-caches!` hook) so a sibling test's first-
-  encounter warning cannot silently swallow a later test's same-id
-  warning. Per rf2-4edk — the cache is a process-wide `defonce` so
-  the user-facing warn-once UX is unchanged in production; test-time
-  clearing is the only effect."
-  []
-  (reset! warned-non-dom-roots #{})
-  nil)
+  `:adapter/clear-warn-once-caches!` hook) so a sibling test's
+  first-encounter warning cannot silently swallow a later test's same-id
+  warning. Per rf2-4edk."
+  (:clear-warned-non-dom-roots! spine-fns))
 
-(defn- warn-non-dom-root!
-  "Emit a one-shot warning per id that a registered view's root is
-  exempt from source-coord injection — a Fragment, a function/class
-  component, or a non-element value. Pair tools fall back to the
-  registry's `:rf/id` for these cases (Spec 006 §Source-coord
-  annotation, Fragment exemption)."
-  [id type-tag]
-  (when-not (contains? @warned-non-dom-roots id)
-    (swap! warned-non-dom-roots conj id)
-    (when (exists? js/console)
-      (.warn js/console
-        (str "[re-frame] reg-view " id " — root element is "
-             (pr-str type-tag) " (UIx); data-rf2-source-coord skipped "
-             "(Spec 006 §Source-coord annotation: pair tools fall back to "
-             ":rf/id for non-DOM roots).")))))
-
-(defn- dom-element?
-  "True if the React element's `type` is a string (a DOM tag like
-  \"div\"). Function/class components and Fragments have non-string
-  `type`s and are exempt per Spec 006."
-  [react-element]
-  (and react-element
-       (some? (.-type react-element))
-       (string? (.-type react-element))))
-
-(defn- inject-source-coord-attr
-  "Wrap `out` (the user component's React element output) with a
-  cloneElement call that adds `:data-rf2-source-coord`. Non-element
-  outputs (nil, fragment, function-component head) emit a one-shot
-  warning per id and pass through unchanged. Per Spec 006 §Source-coord
-  annotation."
-  [id coord-attr out]
-  (cond
-    (dom-element? out)
-    (let [props        (.-props out)
-          existing     (when props (aget props "data-rf2-source-coord"))
-          merged-props (if existing
-                         #js {}
-                         #js {"data-rf2-source-coord" coord-attr})]
-      (if existing
-        out
-        (React/cloneElement out merged-props)))
-
-    :else
-    (do
-      (when (some? out)
-        (warn-non-dom-root! id (some-> out .-type)))
-      out)))
-
-(defn wrap-view
-  "Wrap a UIx-shape user component in a function component that
-  injects `data-rf2-source-coord` on the rendered root DOM element
-  (when `interop/debug-enabled?` is true). Returned fn has the same
-  call signature as `user-fn` and is suitable for use as a UIx
-  component head.
-
-  Per rf2-3yij Decision 5 + Spec 006 §Source-coord annotation: this is
-  the UIx-side equivalent of the Reagent adapter's
-  `inject-source-coord-attr` walk. Production builds elide via
-  `interop/debug-enabled?` per Spec 009 §Production builds."
-  [id metadata user-fn]
-  (let [coord-attr (when interop/debug-enabled?
-                     (format-source-coord id metadata))]
-    (fn wrapped-user-fn [& args]
-      (let [out (apply user-fn args)]
-        (if interop/debug-enabled?
-          (inject-source-coord-attr id coord-attr out)
-          out)))))
-
-;; ---- disposal -------------------------------------------------------------
-
-(defn- dispose-adapter! []
-  ;; UIx itself holds no reaction caches — view re-renders are React's
-  ;; concern. Watches on derived containers GC with the containers
-  ;; themselves. Nothing special to do here.
-  nil)
+;; ---- adapter Var ----------------------------------------------------------
 
 (def adapter
   "The UIx adapter map. Pass to `(rf/init! ...)` to install:
@@ -432,15 +131,15 @@
   Per rf2-agql there is no default-adapter registry — adapter wiring
   is explicit at the call site."
   {:kind                      :uix
-   :make-state-container      make-state-container
-   :read-container            read-container
-   :replace-container!        replace-container!
-   :subscribe-container       subscribe-container
-   :make-derived-value        make-derived-value
-   :render                    render
-   :render-to-string          render-to-string
-   :register-context-provider register-context-provider
-   :dispose-adapter!          dispose-adapter!})
+   :make-state-container      (:make-state-container      spine-fns)
+   :read-container            (:read-container            spine-fns)
+   :replace-container!        (:replace-container!        spine-fns)
+   :subscribe-container       (:subscribe-container       spine-fns)
+   :make-derived-value        (:make-derived-value        spine-fns)
+   :render                    (:render                    spine-fns)
+   :render-to-string          (:render-to-string          spine-fns)
+   :register-context-provider (:register-context-provider spine-fns)
+   :dispose-adapter!          (:dispose-adapter!          spine-fns)})
 
 ;; Each late-bind hook below is routed through `(substrate-adapter/
 ;; current-adapter)` per rf2-0d35 via `substrate-adapter/route-hook!`
@@ -464,9 +163,9 @@
 ;;   :adapter/wrap-view — rf2-00li. Substrate-side source-coord
 ;;     injection via React.cloneElement (the inline hiccup-walk in
 ;;     views.cljs would mis-classify React-element output as a non-DOM
-;;     root). Production-elision: `wrap-view`'s body sits inside
-;;     `(when interop/debug-enabled? ...)` so closure-folds under
-;;     :advanced + goog.DEBUG=false (per Spec 009 §Production builds).
+;;     root). Production-elision: `wrap-view`'s body sits inside an
+;;     `interop/debug-enabled?` gate so closure-folds under :advanced +
+;;     goog.DEBUG=false (per Spec 009 §Production builds).
 (substrate-adapter/route-hook! adapter :adapter/current-frame
   adapter-context/function-component-current-frame
   #(frame/current-frame))
@@ -489,19 +188,14 @@
 (substrate-adapter/route-hook! adapter :adapter/wrap-view
   wrap-view)
 
-;; Per rf2-4edk: contribute a clear of THIS adapter's `warned-non-dom-roots`
-;; cache to the chained `:adapter/clear-warn-once-caches!` hook. The hook
-;; is chained — each adapter (helix, uix) and re-frame.views all contribute
-;; a clear-step; `reset-runtime-fixture` invokes the top of the chain and
-;; every contributor's reset runs (unlike `:adapter/current-frame` etc.
-;; this hook is NOT routed through the installed adapter — every loaded
-;; adapter's cache must clear because test bundles can mount different
-;; adapters across tests and each adapter's defonce persists). Production
-;; behaviour is unchanged: the warn-once `defonce` is still per-process
-;; for users; only test-time clearing is new.
-(let [previous (late-bind/get-fn :adapter/clear-warn-once-caches!)]
-  (late-bind/set-fn! :adapter/clear-warn-once-caches!
-    (fn uix-adapter-clear-warn-once-caches! []
-      (clear-warned-non-dom-roots!)
-      (when previous (previous))
-      nil)))
+;; Per rf2-4edk: contribute a clear of THIS adapter's warn-once cache to
+;; the chained `:adapter/clear-warn-once-caches!` hook. The hook is
+;; chained — each adapter (helix, uix) and re-frame.views all contribute
+;; a clear-step; `reset-runtime-fixture` invokes the top of the chain
+;; and every contributor's reset runs (unlike `:adapter/current-frame`
+;; etc. this hook is NOT routed through the installed adapter — every
+;; loaded adapter's cache must clear because test bundles can mount
+;; different adapters across tests and each adapter's defonce persists).
+;; Production behaviour is unchanged: the warn-once defonce is still
+;; per-process for users; only test-time clearing is new.
+(spine/install-clear-warn-once-step! clear-warned-non-dom-roots!)

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -23,13 +23,20 @@
   come from `re-frame.substrate.spine` — that ns hosts the
   React-shaped-substrate spine UIx and Helix share byte-for-byte. The
   UIx-specific configuration here is the gensym-prefix triple, the
-  substrate-name (\"UIx\") used in warn-once text, and the uix.core
-  use-memo/use-callback (which UIx accepts as JS arrays just as the
-  spine passes them)."
-  (:require [reagent.core     :as r]
-            [reagent.ratom    :as ratom]
-            [uix.core         :as uix]
-            [re-frame.frame   :as frame]
+  substrate-name (\"UIx\") used in warn-once text, and the runtime
+  hook fns from `uix.hooks.alpha`. We bind the runtime fns rather than
+  the `uix.core` namespace's `use-memo` / `use-callback` because those
+  are macros (with no runtime counterpart Var) — passing a macro
+  symbol as a config value yields `undefined` at runtime, which broke
+  every UIx-substrate example after rf2-3vwbx until it was fixed by
+  the `uix.hooks.alpha` switch. `uix.hooks.alpha/use-memo` and
+  `use-callback` are the runtime fns the `uix.core` macros themselves
+  expand to (they take JS-array deps — exactly what the spine passes)."
+  (:require [reagent.core      :as r]
+            [reagent.ratom     :as ratom]
+            [uix.core          :as uix]
+            [uix.hooks.alpha   :as uix-hooks]
+            [re-frame.frame    :as frame]
             [re-frame.late-bind :as late-bind]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.substrate.spine   :as spine]
@@ -43,8 +50,8 @@
      :gensym-prefix-sub     "rf-uix-sub-"
      :gensym-prefix-derived "rf-uix-derived-"
      :gensym-prefix-use-sub "rf-uix-use-sub-"
-     :use-memo              uix/use-memo
-     :use-callback          uix/use-callback
+     :use-memo              uix-hooks/use-memo
+     :use-callback          uix-hooks/use-callback
      :use-context           uix/use-context}))
 
 ;; ---- public surface (UIx-named) -------------------------------------------

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -1,0 +1,513 @@
+(ns re-frame.substrate.spine
+  "Shared substrate-spine helpers for React-shaped adapters that lack a
+  native reactive-atom primitive (UIx, Helix, and any future
+  minimal-React-wrapper substrate). Per rf2-3vwbx — the duplication
+  between UIx and Helix at the substrate-contract layer was byte-for-byte
+  identical modulo gensym prefixes, hook ns, and substrate-name strings.
+  This ns lifts the shared body into one place; the adapter ns wires its
+  per-substrate hooks via `make-react-spine`.
+
+  Scope. This ns provides:
+
+    * The plain-`atom` container quartet (make / read / replace / subscribe).
+    * `make-derived-value` (one watch per source; reifies Reagent's
+      `IDisposable`).
+    * React 18+ root renderer (createRoot + render, hydrateRoot for
+      hydrate).
+    * Late-bind hiccup-emitter atom + `render-to-string` thrower.
+    * The chained source-coord wrapper (`format-source-coord`,
+      `dom-element?`, `inject-source-coord-attr`, `warn-non-dom-root!`,
+      `clear-warned-non-dom-roots!`, `wrap-view`) parameterised on the
+      substrate-name string for the warning text.
+    * `flush-views!` with a correct `react-dom/test-utils` fallback
+      (subsumes rf2-jk7hr).
+    * A factory `make-react-spine` that produces the per-substrate
+      hook-based surfaces (`use-current-frame`, `use-subscribe`,
+      `frame-provider`, `register-context-provider`) given the
+      substrate's hook fns.
+
+  Reagent and reagent-slim do NOT use this ns: they have a native
+  reactive-atom primitive (`r/atom` + `ratom/make-reaction`) and a
+  Reagent-component-shaped frame-provider in `re-frame.views`, so the
+  shapes diverge from the React-hook-shaped contract here.
+
+  Per Spec 006 §CLJS reference — adapters using this spine remain
+  shape-compliant with the 9-fn substrate contract."
+  (:require ["react"             :as React]
+            ["react-dom/client"  :as react-dom-client]
+            [reagent.ratom       :as ratom]
+            [re-frame.interop    :as interop]
+            [re-frame.late-bind  :as late-bind]
+            [re-frame.subs       :as subs]
+            [re-frame.adapter.context :as adapter-context]))
+
+;; ---- container ------------------------------------------------------------
+;;
+;; Per Spec 006 §revertibility-constraints the container holds the
+;; frame's app-db value and *only* the frame's app-db value. React-only
+;; substrates (UIx, Helix) don't ship a reactive atom primitive (their
+;; hook substrate is React state) so we lean on a plain
+;; `clojure.core/atom` and broadcast changes via `add-watch` — observably
+;; equivalent to the Reagent adapter's r/atom for the substrate contract
+;; surface (read, replace, subscribe). Reactive view-side hookup happens
+;; through `useSyncExternalStore` in the spine's `use-subscribe` factory,
+;; not through Reagent reactions.
+
+(defn make-state-container [initial-value]
+  (atom initial-value))
+
+(defn read-container [container]
+  @container)
+
+(defn replace-container! [container new-value]
+  (reset! container new-value)
+  nil)
+
+(defn make-subscribe-container
+  "Return a `subscribe-container` fn that gensyms watch keys with the
+  given `gensym-prefix`. Parameterised on prefix only so warning logs /
+  test inspectors can attribute the watch back to its host substrate."
+  [gensym-prefix]
+  (fn subscribe-container [container on-change]
+    (let [k (gensym gensym-prefix)]
+      (add-watch container k (fn [_ _ prev nu] (on-change prev nu)))
+      (fn unsubscribe [] (remove-watch container k)))))
+
+;; ---- derived value --------------------------------------------------------
+;;
+;; React-only substrates have no reaction primitive. The substrate
+;; contract requires that (read-container) on a derived container deref
+;; a fresh value computed from the sources; subscribe-container on a
+;; derived container fires when any source changes. We satisfy both via
+;; a thin IDeref wrapper whose change-broadcasting fan-out is one watch
+;; per source.
+;;
+;; Equality-on-= is preserved by the core's sub-cache invalidation
+;; algorithm (Spec 006 §Invalidation algorithm Phase 2): the sub-cache
+;; only re-emits when the recomputed value differs from the cached one
+;; by =. The derived container itself does not memoise; per the same
+;; spec section that's the cache's job, not the substrate's.
+
+(defn make-derived-value-fn
+  "Return a `make-derived-value` fn that tags per-source watch keys with
+  the given `gensym-prefix`. The fn signature matches the substrate
+  contract: `(sources compute-fn) -> derived-container`."
+  [gensym-prefix]
+  (fn make-derived-value [source-containers compute-fn]
+    (let [recompute      (fn [] (apply compute-fn (map deref source-containers)))
+          watchers       (atom {})           ;; user-key → wrapper-fn
+          on-dispose-fns (atom [])
+          ;; Per-source wrapper keys we own so dispose can unwire them.
+          own-keys       (atom {})           ;; source → key
+          notify         (fn [prev nu]
+                           (when (not= prev nu)
+                             (doseq [[_ w] @watchers] (w prev nu))))]
+      ;; Wire one watch per source so the listener registry surface
+      ;; (subscribe-container) on the derived container fires whenever
+      ;; any source changes.
+      ;; Seed the baseline from the *derived* value at construction time,
+      ;; not the raw source. The watch callback compares prev-derived
+      ;; against the recomputed derived value; if we seeded from
+      ;; `(deref s)` (the raw source), the first source change would
+      ;; spuriously notify whenever the derived projection differs in
+      ;; identity from the raw source — e.g. `(odd? x)`, counts, `:k`
+      ;; lookups, projections — even when the derived value itself is `=`.
+      ;; (per rf2-66hb)
+      (let [prev-state (atom (recompute))]
+        (doseq [s source-containers]
+          (let [k (gensym gensym-prefix)]
+            (swap! own-keys assoc s k)
+            (add-watch s k
+              (fn [_ _ _ _]
+                (let [new-derived  (recompute)
+                      prev-derived @prev-state]
+                  (reset! prev-state new-derived)
+                  (notify prev-derived new-derived)))))))
+      (reify
+        IDeref
+        (-deref [_] (recompute))
+        ;; Watch surface — `(subscribe-container derived on-change)` rides
+        ;; on this through the standard core helper, and the sub-cache's
+        ;; per-entry recompute layer keys watches by gensym so the
+        ;; remove-watch path below stays clean.
+        IWatchable
+        (-add-watch [this k f]
+          (swap! watchers assoc k (fn [prev nu] (f k this prev nu)))
+          this)
+        (-remove-watch [_this k]
+          (swap! watchers dissoc k)
+          nil)
+        ;; Reagent's IDisposable — `interop/add-on-dispose!` calls into
+        ;; this protocol when wiring the sub-cache's slot teardown
+        ;; (per Spec 006 §subscription-cache). Adopting the Reagent
+        ;; protocol keeps the cache wiring substrate-agnostic at the
+        ;; call site — core does not branch on adapter type.
+        ratom/IDisposable
+        (dispose! [_]
+          (doseq [[s k] @own-keys] (remove-watch s k))
+          (reset! own-keys {})
+          (reset! watchers {})
+          (doseq [f @on-dispose-fns] (f))
+          (reset! on-dispose-fns []))
+        (add-on-dispose! [_ f]
+          (swap! on-dispose-fns conj f))))))
+
+;; ---- render ---------------------------------------------------------------
+;;
+;; React-only substrates call react-dom/client directly (UIx's uix.dom
+;; doesn't expose hydrate-root in every version; Helix ships no DOM
+;; wrapper at all). createRoot + .render for fresh mounts; hydrateRoot
+;; for the SSR-hydrate path. Both shapes return an unmount thunk.
+
+(defn render
+  "React 18+ root render. Returns an unmount thunk."
+  [render-tree mount-point opts]
+  (let [hydrate? (boolean (:hydrate? opts))
+        root     (if hydrate?
+                   (react-dom-client/hydrateRoot mount-point render-tree)
+                   (let [r (react-dom-client/createRoot mount-point)]
+                     (.render r render-tree)
+                     r))]
+    (fn unmount [] (.unmount root))))
+
+(defn make-hiccup-emitter-cell
+  "Return a fresh `(atom nil)` cell that will hold the substrate's
+  late-bound hiccup-emitter fn. Each adapter owns its own cell so
+  multiple adapters can coexist in a test bundle without clobbering each
+  other's emitter."
+  []
+  (atom nil))
+
+(defn set-hiccup-emitter!
+  "Install a render-tree → HTML fn into `emitter-cell`. Idempotent."
+  [emitter-cell f]
+  (reset! emitter-cell f))
+
+(defn make-render-to-string
+  "Return a `render-to-string` fn that reads its emitter from
+  `emitter-cell`. Throws `:rf.error/no-hiccup-emitter-bound` if no
+  emitter has been installed (the SSR artefact resolves the
+  `:reagent/set-hiccup-emitter!` late-bind hook to install one)."
+  [emitter-cell]
+  (fn render-to-string [render-tree opts]
+    (if-let [emit @emitter-cell]
+      (emit render-tree opts)
+      (throw (ex-info ":rf.error/no-hiccup-emitter-bound"
+                      {:reason      "use the plain-atom adapter on the JVM for SSR, or install via set-hiccup-emitter!"
+                       :render-tree render-tree})))))
+
+;; ---- context provider -----------------------------------------------------
+;;
+;; Per rf2-3yij / rf2-2qit Decision 2: every React-shaped adapter shares
+;; the same React.createContext object (it lives in
+;; re-frame.adapter.context). The provider component is identical across
+;; substrates — only `use-current-frame` (the read-side hook) varies, and
+;; only by which hook ns supplies `use-context`.
+
+(defn frame-provider
+  "User-facing component scoping `frame-kw` to its subtree. Wraps
+  children in the shared frame Context Provider — inside the subtree,
+  `(rf/dispatcher)` / `(rf/subscriber)` / `reg-view`-registered
+  descendants resolve to the named frame. Per Spec 002 §What
+  `frame-provider` is.
+
+  Reads `:frame` from props. When missing or `nil`, falls through to
+  `:rf/default` (per rf2-sixo — defensive default that matches the
+  no-provider behaviour and avoids breaking tooling-generated trees that
+  elide the prop)."
+  [{:keys [frame children]}]
+  (let [frame-kw (or frame :rf/default)]
+    (apply adapter-context/provider-element frame-kw
+           (if (sequential? children) children [children]))))
+
+(defn register-context-provider
+  "Substrate `:register-context-provider` slot. Same shape across all
+  React-shaped adapters: returns the `frame-provider` fn unchanged. The
+  frame-keyword arg is ignored because the frame keyword lives in the
+  Provider's :value at render time (rf2-4y60), not in a build-time
+  closure."
+  [_frame-keyword]
+  frame-provider)
+
+;; ---- render flush for tests ----------------------------------------------
+;;
+;; `flush-views!` wraps React's `act()` so test code can drive a
+;; subscribe → re-render cycle synchronously. React 18 ships `act` in
+;; `react-dom/test-utils`; React 19 promotes it onto the React namespace
+;; proper. Probe both — without the fallback, users on React 18.x get a
+;; silent no-op (subsumes rf2-jk7hr).
+
+(defn- resolve-act-fn
+  "Return React's act() if available, else nil. React 19 hosts act on
+  the React namespace directly; React 18 hosts it on react-dom/test-utils.
+  Mirrors the Reagent test harness's act-fn at
+  `adapters/reagent/test/re_frame/frame_provider_context_cljs_test.cljs:467`."
+  []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try
+        (let [tu (js/require "react-dom/test-utils")]
+          (.-act tu))
+        (catch :default _ nil))))
+
+(defn flush-views!
+  "Flush pending substrate renders synchronously. Wraps React's act() —
+  intended for test code only. Calls (act f); with no arg, calls (act
+  (fn [] nil)) to flush pending effects. Returns nil. No-op when act() is
+  not reachable in the current React build."
+  ([] (flush-views! (fn [] nil)))
+  ([f]
+   (when-let [act (resolve-act-fn)]
+     (act f))
+   nil))
+
+;; ---- source-coord wrapper (Spec 006 §Source-coord; rf2-z7f7 / rf2-z9n1) --
+;;
+;; Every React-shaped substrate adapter MUST inject
+;; `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` on each registered
+;; view's root DOM element when `interop/debug-enabled?` is true. The
+;; React-element-walking path uses `React.cloneElement` (rather than the
+;; hiccup-walk path views.cljs takes) because React elements are opaque
+;; — we can clone the root with the extra prop, but we cannot peek
+;; inside a fragment / function-component head.
+;;
+;; Production-elision contract (rf2-z7f7 / Spec 009): the entire branch
+;; sits inside `(when interop/debug-enabled? ...)` so the closure
+;; compiler constant-folds the wrapper away under :advanced +
+;; goog.DEBUG=false. Each adapter ships a bundle-grep elision test that
+;; confirms the `data-rf2-source-coord` literal is absent from
+;; production builds.
+
+(defn format-source-coord
+  "Render captured registry coords as the attribute value shape
+  `<ns>:<sym>:<line>:<col>`. Mirrors re-frame.views/format-source-coord
+  so DOM output is identical across substrates."
+  [id coords]
+  (let [ns-part  (or (namespace id) "?")
+        sym-part (name id)
+        line     (:line coords)
+        col      (:column coords)]
+    (str ns-part ":" sym-part ":"
+         (if line (str line) "?")
+         ":"
+         (if col (str col) "?"))))
+
+(defn make-warn-once-cache
+  "Return an `(atom #{})` for tracking per-id warn-once emission. Each
+  adapter owns its own cache so multiple adapters can coexist in test
+  bundles without clobbering each other's warn-once state."
+  []
+  (atom #{}))
+
+(defn make-clear-warned-fn
+  "Return a thunk that resets `cache-atom` to `#{}` and returns nil.
+  Tests use this between cases (via `reset-runtime-fixture` and the
+  chained `:adapter/clear-warn-once-caches!` hook) so a sibling test's
+  first-encounter warning cannot silently swallow a later test's same-id
+  warning. Per rf2-4edk."
+  [cache-atom]
+  (fn clear-warned-non-dom-roots! []
+    (reset! cache-atom #{})
+    nil))
+
+(defn make-warn-non-dom-root-fn
+  "Return a warn-once fn for use inside `inject-source-coord-attr`.
+  Parameterised on the substrate-name string so the warning text
+  attributes the host substrate. `cache-atom` is the per-adapter
+  warn-once set."
+  [cache-atom substrate-name]
+  (fn warn-non-dom-root! [id type-tag]
+    (when-not (contains? @cache-atom id)
+      (swap! cache-atom conj id)
+      (when (exists? js/console)
+        (.warn js/console
+          (str "[re-frame] reg-view " id " — root element is "
+               (pr-str type-tag) " (" substrate-name "); "
+               "data-rf2-source-coord skipped "
+               "(Spec 006 §Source-coord annotation: pair tools fall back to "
+               ":rf/id for non-DOM roots)."))))))
+
+(defn- dom-element?
+  "True if the React element's `type` is a string (a DOM tag like
+  \"div\"). Function/class components and Fragments have non-string
+  `type`s and are exempt per Spec 006."
+  [react-element]
+  (and react-element
+       (some? (.-type react-element))
+       (string? (.-type react-element))))
+
+(defn- inject-source-coord-attr
+  "Wrap `out` (the user component's React element output) with a
+  cloneElement call that adds `:data-rf2-source-coord`. Non-element
+  outputs (nil, fragment, function-component head) emit a one-shot
+  warning per id and pass through unchanged. Per Spec 006 §Source-coord
+  annotation."
+  [warn-fn id coord-attr out]
+  (cond
+    (dom-element? out)
+    (let [props    (.-props out)
+          existing (when props (aget props "data-rf2-source-coord"))]
+      (if existing
+        out
+        (React/cloneElement out #js {"data-rf2-source-coord" coord-attr})))
+
+    :else
+    (do
+      (when (some? out)
+        (warn-fn id (some-> out .-type)))
+      out)))
+
+(defn make-wrap-view
+  "Return a `wrap-view` fn parameterised on the substrate's per-adapter
+  `warn-fn` (typically built via `make-warn-non-dom-root-fn`). The
+  returned fn has the standard 3-arg shape `(id metadata user-fn) ->
+  wrapped-user-fn` and produces a function component that injects
+  `data-rf2-source-coord` on the rendered root DOM element when
+  `interop/debug-enabled?` is true. Production builds elide via
+  `interop/debug-enabled?` per Spec 009 §Production builds."
+  [warn-fn]
+  (fn wrap-view [id metadata user-fn]
+    (if interop/debug-enabled?
+      (let [coord-attr (format-source-coord id metadata)]
+        (fn wrapped-user-fn [& args]
+          (let [out (apply user-fn args)]
+            (inject-source-coord-attr warn-fn id coord-attr out))))
+      user-fn)))
+
+(defn install-clear-warn-once-step!
+  "Wire `clear-fn` into the chained `:adapter/clear-warn-once-caches!`
+  late-bind hook. The hook is chained — each adapter and re-frame.views
+  contribute a clear-step; `reset-runtime-fixture` invokes the top of
+  the chain and every contributor's reset runs. Per rf2-4edk."
+  [clear-fn]
+  (let [previous (late-bind/get-fn :adapter/clear-warn-once-caches!)]
+    (late-bind/set-fn! :adapter/clear-warn-once-caches!
+      (fn chained-clear-warn-once-caches! []
+        (clear-fn)
+        (when previous (previous))
+        nil))))
+
+;; ---- subscription hook ----------------------------------------------------
+;;
+;; Per Spec 006 §subscription-cache (rf2-3yij Decision 1 / rf2-2qit
+;; Decision 1) `use-subscribe` is the substrate-idiomatic hook surface
+;; for reading a sub. It wraps React.useSyncExternalStore so updates are
+;; scheduled by React's concurrent renderer rather than a per-component
+;; scheduler.
+;;
+;; The hook:
+;;   1. Resolves the active frame via use-context (Decision 2).
+;;   2. Calls re-frame.subs/subscribe to build/cache the reaction.
+;;   3. Wires useSyncExternalStore — the snapshot is the deref of the
+;;      reaction; subscribe is add-watch on the underlying container.
+;;   4. On unmount the watch is removed and the sub's ref-count
+;;      decrements through the cache's deferred-dispose grace-period
+;;      (per Spec 006 §reference-counting-and-disposal).
+;;
+;; Hook fns (`use-memo`, `use-callback`, `use-context`) differ between
+;; substrates by their deps-array convention — UIx accepts CLJS vectors,
+;; Helix wants JS arrays via `helix-hooks/use-memo*`. The factory below
+;; takes the hook fns as args so each adapter can supply the right pair.
+;; The hook fns supplied MUST already be the "wants-JS-array" variants
+;; for substrates that need them (e.g. `helix-hooks/use-memo*`); the
+;; spine passes the deps as a JS array always.
+
+(defn make-react-spine
+  "Build the per-substrate hook-shaped surfaces given the substrate's
+  config:
+
+      :substrate-name  — string used in warn-non-dom-root text (\"UIx\",
+                         \"Helix\", …)
+      :gensym-prefix-sub
+      :gensym-prefix-derived
+      :gensym-prefix-use-sub
+                       — gensym prefix strings per surface
+      :use-memo        — (fn [thunk js-deps]) returning the memoised
+                         value
+      :use-callback    — (fn [thunk js-deps]) returning the memoised
+                         fn
+      :use-context     — (fn [context]) returning the context value
+
+  Returns a map of surfaces:
+
+      {:make-state-container       …
+       :read-container             …
+       :replace-container!         …
+       :subscribe-container        …
+       :make-derived-value         …
+       :render                     …
+       :render-to-string           …
+       :register-context-provider  …
+       :dispose-adapter!           …
+       :set-hiccup-emitter!        …
+       :use-current-frame          …
+       :use-subscribe              …
+       :frame-provider             …
+       :flush-views!               …
+       :wrap-view                  …
+       :clear-warned-non-dom-roots! …}"
+  [{:keys [substrate-name
+           gensym-prefix-sub
+           gensym-prefix-derived
+           gensym-prefix-use-sub
+           use-memo
+           use-callback
+           use-context]}]
+  (let [warn-cache       (make-warn-once-cache)
+        clear-warned     (make-clear-warned-fn warn-cache)
+        warn-fn          (make-warn-non-dom-root-fn warn-cache substrate-name)
+        emitter-cell     (make-hiccup-emitter-cell)
+        subscribe-cont   (make-subscribe-container gensym-prefix-sub)
+        make-derived     (make-derived-value-fn gensym-prefix-derived)
+        wrap-view-fn     (make-wrap-view warn-fn)
+        use-current-frame
+        (fn use-current-frame []
+          (use-context adapter-context/frame-context))
+        ;; Two-arity body extracted so the 1-arg arm can call into it
+        ;; without a self-reference on the let-bound `use-subscribe`
+        ;; (CLJS let-bound fns cannot name themselves).
+        use-subscribe-2
+        (fn use-subscribe-2 [frame-kw query-v]
+          (let [reaction
+                (use-memo (fn [] (subs/subscribe frame-kw query-v))
+                          #js [frame-kw query-v])
+                ;; The store-snapshot fn React calls on every render to
+                ;; detect tearing. Pure deref of the reaction.
+                get-snap
+                (use-callback (fn [] (when reaction @reaction))
+                              #js [reaction])
+                ;; The store-subscribe fn — React calls it once with a
+                ;; force-update callback; we wire that up to add-watch
+                ;; on the reaction's underlying container.
+                subscribe-fn
+                (use-callback
+                  (fn [on-change]
+                    (let [k (gensym gensym-prefix-use-sub)]
+                      (when reaction
+                        (add-watch reaction k (fn [_ _ _ _] (on-change))))
+                      (fn unsubscribe []
+                        (when reaction (remove-watch reaction k)))))
+                  #js [reaction])]
+            (React/useSyncExternalStore subscribe-fn get-snap get-snap)))
+        use-subscribe
+        (fn use-subscribe
+          ([query-v] (use-subscribe-2 (use-current-frame) query-v))
+          ([frame-kw query-v] (use-subscribe-2 frame-kw query-v)))]
+    {:emitter-cell                emitter-cell
+     :warn-cache                  warn-cache
+     :make-state-container        make-state-container
+     :read-container              read-container
+     :replace-container!          replace-container!
+     :subscribe-container         subscribe-cont
+     :make-derived-value          make-derived
+     :render                      render
+     :render-to-string            (make-render-to-string emitter-cell)
+     :register-context-provider   register-context-provider
+     :dispose-adapter!            (fn dispose-adapter! [] nil)
+     :set-hiccup-emitter!         (fn set-it! [f]
+                                    (set-hiccup-emitter! emitter-cell f))
+     :use-current-frame           use-current-frame
+     :use-subscribe               use-subscribe
+     :frame-provider              frame-provider
+     :flush-views!                flush-views!
+     :wrap-view                   wrap-view-fn
+     :clear-warned-non-dom-roots! clear-warned}))


### PR DESCRIPTION
## Summary

Lift the byte-for-byte duplicated substrate spine from the UIx and Helix adapters into a new shared ns `re-frame.substrate.spine`. Per the round-2 audit findings (rf2-z3oab / rf2-0fgm8 / rf2-w0u2w), Helix and UIx ship ~280 LoC of identical substrate-spine body modulo gensym prefix, hook-ns name, and substrate-name strings.

### What moved

The spine ns hosts:

- plain-`atom` container quartet (`make-state-container` / `read-container` / `replace-container!` / `subscribe-container`)
- watch-based `make-derived-value` (parameterised on gensym prefix, reifies `IDeref` / `IWatchable` / `ratom/IDisposable`)
- React 18+ root render (`createRoot` / `hydrateRoot`)
- late-bind hiccup-emitter cell + `render-to-string` thrower
- `frame-provider` component + `register-context-provider`
- `flush-views!` with a correct `react-dom/test-utils` fallback (subsumes rf2-jk7hr)
- source-coord wrap suite (`format-source-coord` / `dom-element?` / `inject-source-coord-attr` / `warn-non-dom-root!` / `wrap-view`)
- chained `:adapter/clear-warn-once-caches!` installer
- a `make-react-spine` factory parameterised on `{:substrate-name :gensym-prefix-* :use-memo :use-callback :use-context}` returning all per-substrate surfaces

### What stayed adapter-local

- The 9-key adapter Var
- The `route-hook!` calls for `:adapter/current-frame`, `:adapter/ratom`, etc. (each adapter wires its own hook table)
- Public Var bindings (`use-subscribe`, `frame-provider`, `wrap-view`, `flush-views!`, `clear-warned-non-dom-roots!`, `set-hiccup-emitter!`) — pulled from the spine factory's return map so test imports and the public surface are unchanged

### rf2-jk7hr subsumed

The dead `(or (.-act React) nil)` fallback is replaced with a real probe across React 18 (`react-dom/test-utils`) and React 19 (on the `React` namespace directly), modelled on the Reagent test harness's `act-fn`. `flush-views!` now works on React 18.x as documented.

### Reagent and reagent-slim untouched

These adapters have a native `r/atom` + `ratom/make-reaction` and a Reagent-component-shaped frame-provider in `re-frame.views`; their substrate-contract shape diverges from the React-hook-shaped spine. The audit findings called out the UIx ↔ Helix pair as the dominant duplication; that 280-LoC body is eliminated here.

### LoC delta

| File | Before | After |
|---|---|---|
| `adapters/helix/src/re_frame/adapter/helix.cljs` | 516 | 204 |
| `adapters/uix/src/re_frame/adapter/uix.cljs`     | 508 | 201 |
| `core/src/re_frame/substrate/spine.cljs` (new)   | —   | 513 |

Net: `+680 / -784` (3 files; 104 LoC dropped). The 513 LoC spine consolidates ~620 LoC of previously-duplicated body into a single source of truth.

### Bonus: CQ-4 elision tightening

The audit's helix-side CQ-4 ("`coord-attr` outer-let does not DCE optimally") is incorporated: under `goog.DEBUG=false` the spine's `make-wrap-view` returns `user-fn` unchanged, eliminating both the wrapper-closure allocation AND the `coord-attr` `let` binding.

## Test plan

- [x] `npm run test:cljs` — 1817 tests, 5105 assertions, 0 failures / 0 errors
- [x] `npm run test:browser` — 1817 tests, 5030 assertions, 0 failures / 0 errors
- [x] `npm run test:elision` — all sentinels (incl. `data-rf2-source-coord`) ABSENT from `:advanced + goog.DEBUG=false` bundle
- [x] `npm run test:bundle-isolation` — PASS