### PR TITLE
refactor(pair2-mcp): polish cluster — 8 follow-on beads (rf2-b05ld)

### DIFF
--- a/tools/pair2-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/pair2-mcp/spec/003-Tool-Catalogue.md
@@ -113,8 +113,29 @@ with a tiny marker:
  {:hash            <integer>
   :unchanged-since <ms-since-epoch>
   :tool            "<tool-name>"
+  :via             :result-hash | :precheck
   :hint            "<agent-host instruction string>"}}
 ```
+
+The `:via` slot tells the agent host which cache path produced
+the hit:
+
+- **`:result-hash`** (rf2-3rt1f) — the original post-eval path.
+  The tool ran server-side; the result's text was hashed; the
+  hash matched the stored entry for `(tool, args)`. The MCP
+  server saved the **wire bytes** but paid the full nREPL
+  round-trip and the local transform pipeline.
+- **`:precheck`** (rf2-36xod) — the pre-eval short-circuit. One
+  cheap bencode round-trip asked the runtime for
+  `(hash (re-frame-pair2.runtime/snapshot frame))`; the hash
+  matched the stored `:precheck-hash`. The MCP server saved
+  **both** the wire bytes AND the full tool eval + transform
+  pipeline. The tool body was never invoked.
+
+Same wire vocabulary, different cost saved. Agent hosts that
+diagnose latency / token usage can branch on `:via` — a
+`:precheck` hit is the cheapest possible response in the
+catalogue.
 
 The agent host already has the byte-identical bytes from the
 prior `tools/call`; re-shipping doubles the conversation cost

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -29,7 +29,7 @@
   or `tools/<tool>` files:
 
   - Concerns: `wire`, `probe`, `cap`, `dedup`, `elision`, `sensitive`,
-    `cursor`, `args`, `summary`, `snapshot-pipeline`.
+    `cursor`, `args`, `summary`, `snapshot-pipeline`, `boundary-step`.
   - Tools: `discover-app`, `eval-cljs`, `dispatch`, `trace-window`,
     `watch-epochs`, `tail-build`, `snapshot`, `get-path`, `subscribe`
     (+ `subscribe-emit`), `unsubscribe`, `subscription-info`.
@@ -45,8 +45,10 @@
 
   Each MCP tool returns `{:content [{:type \"text\" :text <edn-string>}]}`
   on success, or `{:isError true :content [...]}` on failure."
-  (:require [re-frame-pair2-mcp.cache :as cache]
+  (:require [applied-science.js-interop :as j]
+            [re-frame-pair2-mcp.cache :as cache]
             [re-frame-pair2-mcp.tools.args :as args]
+            [re-frame-pair2-mcp.tools.boundary-step :as bs]
             [re-frame-pair2-mcp.tools.wire :as wire]
             [re-frame-pair2-mcp.tools.cap :as cap]
             [re-frame-pair2-mcp.tools.precheck :as precheck]
@@ -75,74 +77,149 @@
     (js/Promise.resolve
       (wire/err-text {:ok? false :reason :unknown-tool :tool name}))))
 
-(defn invoke
-  "Dispatch a `tools/call` invocation to the right tool implementation.
-  Returns a Promise resolving to the MCP result object.
+;; ---------------------------------------------------------------------------
+;; Wire-boundary pipeline (rf2-3z0zi).
+;;
+;; Four steps thread through `boundary-step/run-step-pipeline`. Each
+;; step's `:run` receives the live context (carrying `:result` and
+;; `:precheck-hash`) and returns a Promise of the next context. The
+;; `:short-circuit?` predicates encode the per-step skip rules
+;; declaratively — no inline conditionals in the orchestrator.
+;;
+;; Adding a future step (request-level redaction, metrics, path-prefix
+;; slicing, per-call elision toggle) is one map-entry addition here
+;; plus the step's `:run` body. The orchestration loop and the test
+;; seam stay unchanged.
+;; ---------------------------------------------------------------------------
 
-  ## Wire-boundary pipeline
+(defn- precheck-step
+  "Step 0 — rf2-36xod cheap-hash short-circuit. For precheck-eligible
+  tools (cache enabled AND tool registers a precheck-frame), fetches
+  the runtime-side hash via one bencode round-trip and consults the
+  cache. On a hit, writes the marker to `:result` (which trips
+  subsequent steps' `:short-circuit?` predicates). On a miss, records
+  the fetched hash in `:precheck-hash` so `apply-cache` can attach
+  it to the future entry."
+  [{:keys [conn name args cache-opts] :as ctx}]
+  (if-let [frame (and (:enabled? cache-opts)
+                      (precheck/precheck-frame name args))]
+    (-> (precheck/fetch-precheck-hash conn args frame)
+        (.then (fn [h]
+                 (assoc ctx
+                   :precheck-hash h
+                   :result        (cache/precheck cache-opts h)))))
+    (js/Promise.resolve ctx)))
 
-  When the per-call `cache` arg is enabled, the invocation runs the
-  following:
+(defn- dispatch-step
+  "Step 1 — per-tool dispatch. Runs the actual tool implementation; its
+  Promise resolves to the JS-shape MCP result, which becomes the
+  context's `:result`."
+  [{:keys [conn name args extra] :as ctx}]
+  (-> (dispatch-tool* conn name args extra)
+      (.then (fn [result-js] (assoc ctx :result result-js)))))
 
-  0. `precheck/fetch-precheck-hash` (rf2-36xod) — for precheck-eligible
-     tools (`snapshot` single-frame; `get-path`) issue one cheap nREPL
-     eval `(hash (re-frame-pair2.runtime/snapshot frame))` and compare
-     to the stored `:precheck-hash` for `(tool, args)`. On a match,
-     short-circuit with `{:rf.mcp/cache-hit ... :via :precheck}` — the
-     tool eval is SKIPPED entirely. Saves the full pipeline cost. On a
-     miss (or for tools without precheck wiring), fall through.
+(defn- apply-cache-step
+  "Step 2 — rf2-3rt1f post-eval result-hash cache. On a hash match
+  replaces `:result` with the cache-hit marker; on a miss stores the
+  new hash (plus the precheck-hash from step 0 if present) and leaves
+  `:result` unchanged."
+  [{:keys [result cache-opts precheck-hash] :as ctx}]
+  (->> (cache/apply-cache result (assoc cache-opts :precheck-hash precheck-hash))
+       (assoc ctx :result)))
 
-  1. `cache/apply-cache` (rf2-3rt1f) — per-session response cache
-     keyed on a hash of the result's text payload. On a hit (same hash
-     for `(tool, args)` as the prior call) the full payload is replaced
-     with a tiny `{:rf.mcp/cache-hit ... :via :result-hash}` marker;
-     the agent host already has the byte-identical bytes from the prior
-     `tools/call`. Read-only tools only; `:isError` results bypass
-     entirely. See `cache/apply-cache` for the LRU policy. When a
-     precheck-hash was fetched in step 0, it's recorded alongside the
-     result hash so the NEXT call can short-circuit via the precheck
-     path.
+(defn- apply-cap-step
+  "Step 3 — rf2-rvyzy wire-boundary token-budget enforcement. When
+  `:result` exceeds the per-call cap, replaces it with the
+  `:rf.mcp/overflow` marker."
+  [{:keys [result cap-opts] :as ctx}]
+  (assoc ctx :result (cap/apply-cap result cap-opts)))
 
-  2. `cap/apply-cap` (rf2-rvyzy) — responses whose serialised size
-     exceeds the per-call cap (default 5,000 tokens, configurable via
-     the `max-tokens` MCP arg) are replaced with an
-     `{:rf.mcp/overflow ...}` marker. Silent truncation is not allowed;
-     see the `apply-cap` docstring for the pluggable-strategy design.
+(defn- isError? [result-js]
+  (and (some? result-js)
+       (boolean (j/get result-js :isError))))
+
+(def wire-boundary-pipeline
+  "The four-step wire-boundary pipeline. Order matters — see step
+  docstrings for the per-step semantics.
+
+  | Step              | When the step is skipped (`:short-circuit?`)        |
+  |-------------------|-----------------------------------------------------|
+  | `:precheck`       | never — runs unconditionally; produces a marker     |
+  |                   | result ONLY for eligible cacheable tools            |
+  | `:dispatch`       | a prior step already produced a `:result` (i.e.     |
+  |                   | precheck hit)                                       |
+  | `:apply-cache`    | `:isError` result (errors must not poison cache) OR |
+  |                   | result is already a wire-bounded marker             |
+  | `:apply-cap`      | result is a wire-bounded marker (cache-hit /        |
+  |                   | overflow are sub-cap by construction — rf2-gktyn)   |
 
   Cache before cap is the right order: a cache hit emits a sub-100-
   byte marker that's trivially under any reasonable cap, so flipping
-  the order would never change behaviour but would waste the
-  `sum-text-tokens` walk on the hit path.
+  the order would never change behaviour but would waste a token
+  walk on the hit path."
+  [{:name           :precheck
+    :run            precheck-step}
+   {:name           :dispatch
+    :run            dispatch-step
+    :short-circuit? (fn [{:keys [result]}] (some? result))}
+   {:name           :apply-cache
+    :run            apply-cache-step
+    :short-circuit? (fn [{:keys [result]}]
+                      (or (isError? result) (wire/marker? result)))}
+   {:name           :apply-cap
+    :run            apply-cap-step
+    :short-circuit? (fn [{:keys [result]}] (wire/marker? result))}])
+
+(defn invoke
+  "Dispatch a `tools/call` invocation through the wire-boundary
+  pipeline. Returns a Promise resolving to the MCP result object.
+
+  ## Wire-boundary pipeline
+
+  The four-step pipeline lives in `wire-boundary-pipeline` and is
+  threaded by `boundary-step/run-step-pipeline`:
+
+  0. **`:precheck`** (`precheck/fetch-precheck-hash`, rf2-36xod) —
+     for precheck-eligible tools, issue one cheap nREPL eval to
+     compute the runtime-side hash and compare to the stored
+     `:precheck-hash`. On a match, write the
+     `{:rf.mcp/cache-hit ... :via :precheck}` marker to `:result`
+     — the tool eval is SKIPPED entirely. Saves the full pipeline
+     cost. On a miss (or for tools without precheck wiring),
+     records the fetched hash in `:precheck-hash` for step 2 to
+     attach to the next entry.
+
+  1. **`:dispatch`** — per-tool implementation. Skipped if the
+     precheck step already produced a result.
+
+  2. **`:apply-cache`** (`cache/apply-cache`, rf2-3rt1f) —
+     post-eval per-session response cache keyed on a hash of the
+     result's text payload. On a hit the result is replaced with
+     `{:rf.mcp/cache-hit ... :via :result-hash}` — the agent host
+     already has the byte-identical bytes from the prior call. Read-
+     only tools only; `:isError` results bypass entirely; already-
+     marker results bypass entirely (a precheck hit is already the
+     cache-hit envelope). When a precheck-hash was fetched in step
+     0, it's recorded alongside the result hash so the NEXT call
+     can short-circuit via the precheck path.
+
+  3. **`:apply-cap`** (`cap/apply-cap`, rf2-rvyzy) — responses
+     whose serialised size exceeds the per-call cap (default 5,000
+     tokens, configurable via the `max-tokens` MCP arg) are replaced
+     with `{:rf.mcp/overflow ...}`. Silent truncation is not
+     allowed. Already-marker results bypass — the marker envelopes
+     are sub-cap by construction (rf2-gktyn).
 
   `extra` carries the MCP `extra` payload (signal + sendNotification +
   _meta.progressToken) for streaming tools. Non-streaming tools ignore
   it."
   [conn name args extra]
-  (let [cap-opts    {:tool     name
-                     :cap      (cap/max-tokens-arg args)
-                     :strategy :truncate-with-marker}
-        enabled?    (args/parse-bool-arg args :cache)
-        cache-opts  {:tool     name
-                     :args     args
-                     :enabled? enabled?}
-        ;; Step 0: precheck — only fetch a hash when cache is enabled
-        ;; AND the tool has precheck wiring. Otherwise resolve a
-        ;; sentinel pair `[nil nil]` immediately and skip the round-trip.
-        precheck-pr (if-let [frame (and enabled? (precheck/precheck-frame name args))]
-                      (-> (precheck/fetch-precheck-hash conn args frame)
-                          (.then (fn [h]
-                                   [h (cache/precheck cache-opts h)])))
-                      (js/Promise.resolve [nil nil]))]
-    (-> precheck-pr
-        (.then (fn [[h hit]]
-                 (if hit
-                   ;; Short-circuit — skip the tool entirely.
-                   hit
-                   ;; Miss / no precheck — run the tool and feed the
-                   ;; result + (any) precheck-hash into apply-cache.
-                   (-> (dispatch-tool* conn name args extra)
-                       (.then (fn [result]
-                                (cache/apply-cache
-                                  result
-                                  (assoc cache-opts :precheck-hash h))))))))
-        (.then (fn [result] (cap/apply-cap result cap-opts))))))
+  (let [enabled? (args/parse-bool-arg args :cache)
+        ctx      {:conn       conn
+                  :name       name
+                  :args       args
+                  :extra      extra
+                  :result     nil
+                  :cache-opts {:tool name :args args :enabled? enabled?}
+                  :cap-opts   {:tool name :cap (cap/max-tokens-arg args)}}]
+    (bs/run-and-extract wire-boundary-pipeline ctx)))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/boundary_step.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/boundary_step.cljs
@@ -1,0 +1,111 @@
+(ns re-frame-pair2-mcp.tools.boundary-step
+  "Pluggable wire-boundary step-pipeline (rf2-3z0zi).
+
+  ## Why a step-pipeline
+
+  `invoke` (in `tools.cljs`) drives every MCP `tools/call` through a
+  short, ordered sequence of phases:
+
+      precheck → dispatch → apply-cache → apply-cap
+
+  Before this ns landed the four phases were hardcoded inline in
+  `invoke` as a hand-threaded Promise chain. Each phase had its own
+  short-circuit rule (`apply-cache` skips `:isError`; `apply-cap`
+  skipped nothing). The ordering invariant was prose-only — the
+  `invoke` docstring described it; the impl had to be read top-to-
+  bottom to verify it.
+
+  This namespace is the round-2 parallel of round-1's named
+  wire-pipeline win (`tools/wire-pipeline.cljs`): the same lens
+  (turn an implicit ordering into named, declarative data) applied
+  one level up. Each step is a map:
+
+  ```clojure
+  {:name           :apply-cap
+   :run            (fn [ctx] Promise<ctx>)
+   :short-circuit? (fn [ctx] boolean)}
+  ```
+
+  - `:name`           — namespaced for tracing / errors.
+  - `:run`            — receives the live context map and returns a
+                        Promise of the next context. Side-effects (LRU
+                        writes, nREPL round-trips) are the step's own.
+  - `:short-circuit?` — optional predicate over the post-`:run`
+                        context. When truthy, the rest of the pipeline
+                        is skipped — the current `:result` is the
+                        final response. Pure on the context; cheap.
+
+  ## Context shape
+
+  ```clojure
+  {:conn          <nrepl-conn>
+   :name          \"<tool-name>\"
+   :args          <js-args>
+   :extra         <mcp-extra>
+   :result        <js-mcp-result or nil>
+   :precheck-hash <int or nil>}
+  ```
+
+  Every step receives this context. The `:result` slot is the running
+  payload — nil before `:dispatch` runs, populated thereafter. Steps
+  that produce a result write it; steps that consume it read it. The
+  `:precheck-hash` slot is the cheap-hash from rf2-36xod; the
+  `apply-cache` step consumes it to record on a miss.
+
+  ## Short-circuit semantics
+
+  Each step's `:short-circuit?` is checked BEFORE its `:run` — the
+  predicate decides 'should I bother running'. When truthy, the
+  step is skipped and the pipeline continues to the next step
+  (whose own predicate is then consulted).
+
+  `apply-cap`'s predicate fires on a `marker?` result (a cache-hit
+  or overflow envelope is already a wire-bounded marker — capping
+  it is wasted work). `apply-cache`'s predicate fires on an
+  `:isError` result (errors must not poison the cache).
+
+  Predicates are pure over the context's current `:result` slot —
+  no global state, no side effects. A skipped step leaves the
+  context unchanged.
+
+  ## Adding a step
+
+  Land a new step map in `tools.cljs`'s `wire-boundary-pipeline` def
+  and the orchestration picks it up. The four envisaged future steps
+  (request-level redaction, metrics emission, path-prefix slicing,
+  per-call elision toggle) plug in once at this layer."
+  (:require [re-frame-pair2-mcp.tools.wire :as wire]))
+
+(defn run-step-pipeline
+  "Thread `ctx` through `steps` in order. Each step's `:run` returns a
+  Promise of the next `ctx`. After every step, the `:short-circuit?`
+  predicate is consulted — when truthy, the rest of the pipeline is
+  skipped and `ctx` is returned as-is.
+
+  Returns a Promise of the final `ctx`. Caller extracts `:result` for
+  the MCP wire reply."
+  [steps ctx]
+  (reduce
+    (fn [pr {:keys [run short-circuit?] :as _step}]
+      (-> pr
+          (.then
+            (fn [ctx]
+              (if (and short-circuit? (short-circuit? ctx))
+                ctx
+                (run ctx))))))
+    (js/Promise.resolve ctx)
+    steps))
+
+(defn run-and-extract
+  "Convenience — run the pipeline and unwrap the `:result` slot.
+  Returns a Promise of the JS-shape MCP result.
+
+  An empty pipeline or a step that never sets `:result` returns an
+  `:unknown-tool` error envelope rather than `undefined` on the wire."
+  [steps ctx]
+  (-> (run-step-pipeline steps ctx)
+      (.then (fn [{:keys [name result]}]
+               (or result
+                   (wire/err-text {:ok?    false
+                                   :reason :pipeline-produced-no-result
+                                   :tool   name}))))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/cap.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/cap.cljs
@@ -48,7 +48,8 @@
     each tool's internals."
   (:require [applied-science.js-interop :as j]
             [re-frame.mcp-base.cap :as base-cap]
-            [re-frame.mcp-base.overflow :as base-overflow]))
+            [re-frame.mcp-base.overflow :as base-overflow]
+            [re-frame-pair2-mcp.tools.wire :as wire]))
 
 ;; `default-max-tokens` and `token-estimate` come from
 ;; `re-frame.mcp-base.overflow` (rf2-vw4sq) — the cap value and the
@@ -132,11 +133,21 @@
   `:truncate-with-marker` is wired; unknown strategies degrade safely.
 
   Adds pair2-mcp's `overflow-hints` table lookup before delegating to
-  `base-cap/apply-cap`."
+  `base-cap/apply-cap`.
+
+  Short-circuits on a wire-bounded marker (`:rf.mcp/cache-hit`,
+  `:rf.mcp/overflow` — rf2-gktyn). Such envelopes are sub-cap by
+  construction; the token-sum walk would be wasted work. The
+  `invoke` pipeline (rf2-3z0zi) already short-circuits before this
+  fn runs in the orchestrated path, but the guard here makes the
+  invariant local to `apply-cap` too — direct callers (tests, future
+  consumers) get the same skip."
   [result-js {:keys [tool cap strategy]
               :or   {strategy :truncate-with-marker}}]
-  (base-cap/apply-cap result-io result-js
-                      {:tool     tool
-                       :cap      cap
-                       :hint     (get overflow-hints tool)
-                       :strategy strategy}))
+  (if (wire/marker? result-js)
+    result-js
+    (base-cap/apply-cap result-io result-js
+                        {:tool     tool
+                         :cap      cap
+                         :hint     (get overflow-hints tool)
+                         :strategy strategy})))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/eval_form.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/eval_form.cljs
@@ -102,10 +102,25 @@
 
 (defn- emit-arg
   "Render a single arg / binding-value to source. DSL nodes recurse;
-  everything else (strings, keywords, numbers, maps, vectors, …)
-  `pr-str`'d as an EDN literal."
+  collections of nodes recurse element-wise; everything else
+  (strings, keywords, numbers, scalar maps, scalar vectors, …) is
+  `pr-str`'d as an EDN literal.
+
+  rf2-lbfzu — without the collection-recursion arm, a mixed
+  data-and-nodes vector like `(rt-call 'foo [bar (rt-raw \"x\")])`
+  would `pr-str` the whole vector including the `[::raw \"x\"]` IR
+  node, producing garbage source. The recursion lets callers mix
+  scalar data with IR nodes naturally; pure-scalar collections
+  still go through `pr-str` unchanged (no contains-node walk →
+  same byte-for-byte output)."
   [v]
-  (if (node? v) (emit v) (pr-str v)))
+  (cond
+    (node? v)   (emit v)
+    (and (vector? v) (some node? v))
+    (str "[" (str/join " " (map emit-arg v)) "]")
+    (and (list? v) (some node? v))
+    (str "(" (str/join " " (map emit-arg v)) ")")
+    :else       (pr-str v)))
 
 (defn- emit-name [n]
   ;; Binding names must be symbols — they appear verbatim in the source
@@ -141,7 +156,11 @@
                       ")"))
 
         ::call* (let [[_ qsym args] form]
-                  (str "(" (if (symbol? qsym) (str qsym) (str qsym))
+                  ;; rf2-lbfzu — `(str qsym)` handles both shapes
+                  ;; uniformly: a symbol prints as its fully-qualified
+                  ;; name, a string prints verbatim. The prior `if`
+                  ;; had two identical arms.
+                  (str "(" (str qsym)
                        (when (seq args)
                          (apply str (for [a args] (str " " (emit-arg a)))))
                        ")"))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/get_path.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/get_path.cljs
@@ -87,13 +87,22 @@
                             "  {:ok? true :exists? true :path path :value " elide-call "})"))))]
         (-> (probe/ensure-runtime! conn build-id)
             (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-            (.then (fn [v]
-                     (let [{:keys [value indicators]}
-                           (wp/run-wire-pipeline v {:kind :scalar-value})
+            (.then (fn [envelope]
+                     ;; rf2-6by5s — strip the `:value` slot off, run only
+                     ;; the literal value through the wire-pipeline, and
+                     ;; rebuild the envelope. The indicator count reflects
+                     ;; exactly what ships; `:path-not-found` results
+                     ;; (no `:value` slot) report zero elision — correct
+                     ;; by construction, not by accident of which keys
+                     ;; the walker happens to ignore.
+                     (let [ok?             (:ok? envelope)
+                           scalar          (when ok? (:value envelope))
+                           {:keys [indicators]}
+                                           (wp/run-wire-pipeline scalar {:kind :scalar-value})
                            {:keys [elided]} indicators]
                        (wire/ok-text (wire/with-indicators
-                                       (cond-> value
-                                         frame           (assoc :frame frame)
-                                         (:ok? value)    (assoc :elision elision?))
+                                       (cond-> envelope
+                                         frame (assoc :frame frame)
+                                         ok?   (assoc :elision elision?))
                                        {:elided elided})))))
             (.catch (fn [err] (probe/err->result :get-path-failed err))))))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/registry.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/registry.cljs
@@ -72,7 +72,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Handler shape — every registered handler is `(fn [conn args extra])`.
 ;; Per-tool fns that don't need `extra` (i.e. everything except `subscribe`)
-;; are wrapped inline at registration so the dispatcher can call all
+;; are adapted via `ignoring-extra` so the dispatcher can call all
 ;; handlers uniformly.
 ;;
 ;; Handlers in the registry are LATE-BINDING — they call the per-tool fn
@@ -80,8 +80,24 @@
 ;; time. The `invoke-test` suite (rf2-nogok) stubs per-tool fns by
 ;; `set!`-ing their vars and expects subsequent dispatches to hit the
 ;; replacement. A captured reference would freeze the original and
-;; break the seam.
+;; break the seam. `ignoring-extra` takes a NAMESPACE-QUALIFIED var
+;; (not a value) so the deref happens per-call — preserving the seam.
 ;; ---------------------------------------------------------------------------
+
+(defn- ignoring-extra
+  "Adapt a 2-arity per-tool fn `(fn [conn args])` into the registry's
+  3-arity convention `(fn [conn args _extra])`. Ten of the eleven
+  registered tools ignore `extra` (only `subscribe` consults it);
+  this adapter collapses the verbatim `(fn [conn args _extra]
+  (per-tool-fn conn args))` boilerplate at the call sites.
+
+  Callers wrap the per-tool fn in a `#(per-tool-fn %1 %2)` literal
+  so the namespaced-symbol lookup happens per-call. That preserves
+  the test seam (rf2-nogok): `(set! snapshot/snapshot-tool ...)`
+  updates the namespace's JS slot and the next dispatch finds the
+  replacement."
+  [f]
+  (fn [conn args _extra] (f conn args)))
 
 ;; ---------------------------------------------------------------------------
 ;; The catalogue — one entry per tool. ORDER matters: `tool-descriptors`
@@ -96,52 +112,53 @@
   `tools/list` descriptors, the `tools/call` dispatcher, and the
   per-tool cache opt-in. See ns docstring for the entry shape.
 
-  Each `:handler` is a thin late-binding wrapper around the per-tool fn
-  — `(fn [conn args _] (per-tool-fn conn args))` — so test seams that
-  `set!` the underlying var (rf2-nogok) take effect on the next
-  dispatch."
+  Each `:handler` is a thin late-binding wrapper around the per-tool
+  fn — `ignoring-extra` for the ten tools that ignore `extra`, or an
+  inline `(fn [conn args extra] ...)` for `subscribe`. Both shapes
+  resolve the underlying fn per-call so test seams that `set!` the
+  var (rf2-nogok) take effect on the next dispatch."
   [{:name       "discover-app"
-    :handler    (fn [conn args _extra] (discover-app/discover-app conn args))
+    :handler    (ignoring-extra #(discover-app/discover-app %1 %2))
     :cacheable? true
     :descriptor data/discover-app}
    {:name       "eval-cljs"
-    :handler    (fn [conn args _extra] (eval-cljs/eval-cljs-tool conn args))
+    :handler    (ignoring-extra #(eval-cljs/eval-cljs-tool %1 %2))
     :cacheable? false
     :descriptor data/eval-cljs}
    {:name       "dispatch"
-    :handler    (fn [conn args _extra] (dispatch/dispatch-tool conn args))
+    :handler    (ignoring-extra #(dispatch/dispatch-tool %1 %2))
     :cacheable? false
     :descriptor data/dispatch}
    {:name       "trace-window"
-    :handler    (fn [conn args _extra] (trace-window/trace-window-tool conn args))
+    :handler    (ignoring-extra #(trace-window/trace-window-tool %1 %2))
     :cacheable? true
     :descriptor data/trace-window}
    {:name       "watch-epochs"
-    :handler    (fn [conn args _extra] (watch-epochs/watch-epochs-tool conn args))
+    :handler    (ignoring-extra #(watch-epochs/watch-epochs-tool %1 %2))
     :cacheable? true
     :descriptor data/watch-epochs}
    {:name       "tail-build"
-    :handler    (fn [conn args _extra] (tail-build/tail-build-tool conn args))
+    :handler    (ignoring-extra #(tail-build/tail-build-tool %1 %2))
     :cacheable? false
     :descriptor data/tail-build}
    {:name       "snapshot"
-    :handler    (fn [conn args _extra] (snapshot/snapshot-tool conn args))
+    :handler    (ignoring-extra #(snapshot/snapshot-tool %1 %2))
     :cacheable? true
     :descriptor data/snapshot}
    {:name       "get-path"
-    :handler    (fn [conn args _extra] (get-path/get-path-tool conn args))
+    :handler    (ignoring-extra #(get-path/get-path-tool %1 %2))
     :cacheable? true
     :descriptor data/get-path}
    {:name       "subscribe"
-    :handler    (fn [conn args extra]  (subscribe/subscribe-tool conn args extra))
+    :handler    (fn [conn args extra] (subscribe/subscribe-tool conn args extra))
     :cacheable? false
     :descriptor data/subscribe}
    {:name       "unsubscribe"
-    :handler    (fn [conn args _extra] (unsubscribe/unsubscribe-tool conn args))
+    :handler    (ignoring-extra #(unsubscribe/unsubscribe-tool %1 %2))
     :cacheable? false
     :descriptor data/unsubscribe}
    {:name       "subscription-info"
-    :handler    (fn [conn args _extra] (subscription-info/subscription-info-tool conn args))
+    :handler    (ignoring-extra #(subscription-info/subscription-info-tool %1 %2))
     :cacheable? false
     :descriptor data/subscription-info}])
 

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire.cljs
@@ -58,3 +58,40 @@
 (defn arg-build [args]
   (or (some-> (arg args :build) keyword)
       (default-build-id)))
+
+;; ---------------------------------------------------------------------------
+;; Wire-bounded marker detection (rf2-gktyn, rf2-3z0zi).
+;;
+;; The `:rf.mcp/cache-hit` and `:rf.mcp/overflow` envelopes are
+;; replacement results emitted by the wire-boundary steps themselves.
+;; By construction they are sub-cap size — the cache-hit marker is
+;; ~100 bytes and the overflow marker is the cap-respecting
+;; replacement for an over-budget payload. Re-applying the cap walk
+;; to either is wasted work and the cache check on a hit-marker
+;; would compute a hash of the marker, not the original payload.
+;;
+;; Substring-match on the rendered text is the cheap detector — the
+;; markers always serialise with the namespaced key as the first
+;; key of the outer map, so a `starts-with?` on the trimmed text is
+;; fast and tight. False positives would require an agent-supplied
+;; payload that ALSO renders as `{:rf.mcp/...` at the top level —
+;; not a realistic shape for any tool's result.
+;; ---------------------------------------------------------------------------
+
+(def ^:private marker-prefixes
+  ["{:rf.mcp/cache-hit"
+   "{:rf.mcp/overflow"])
+
+(defn marker?
+  "Is `result-js` a wire-bounded `:rf.mcp/*` marker envelope?
+
+  Returns true for `:rf.mcp/cache-hit` and `:rf.mcp/overflow`
+  results — the two envelopes the cache + cap steps emit
+  themselves. Such envelopes are sub-cap by construction and must
+  not be re-walked by later boundary steps."
+  [result-js]
+  (let [content (when result-js (j/get result-js :content))
+        item    (when (array? content) (aget content 0))
+        text    (when item (j/get item :text))]
+    (and (string? text)
+         (boolean (some #(.startsWith text %) marker-prefixes)))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire_pipeline.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire_pipeline.cljs
@@ -42,10 +42,13 @@
                        → dedup → indicator-count. No summary; the
                        epoch shape is already bounded by the cursor
                        `:limit`.
-  - `:scalar-value`  — single value (`get-path`). The eval form
-                       already ran `re-frame.core/elide-wire-value`
-                       server-side, so the pipeline here is just
-                       indicator-count; the value passes through.
+  - `:scalar-value`  — the literal post-`get-in` value (`get-path`).
+                       The eval form already ran
+                       `re-frame.core/elide-wire-value` server-side,
+                       so the pipeline here is just indicator-count;
+                       the value passes through. The CALLER strips
+                       the value off its envelope and re-assembles
+                       afterwards — the arm walks only what ships.
 
   Each kind returns `{:value v :indicators {:dropped N :elided N
   :path-status M}}`. `:path-status` is the per-frame path-not-found
@@ -116,9 +119,17 @@
                   :count   (count encoded)}}))
 
 (defn- run-scalar-value
-  "Minimal pipeline for `get-path` results. The eval form already ran
-  `re-frame.core/elide-wire-value` server-side, so the pipeline here
-  is indicator-count only. The value passes through unchanged.
+  "Minimal pipeline for the literal post-`get-in` value. The eval form
+  already ran `re-frame.core/elide-wire-value` server-side, so the
+  pipeline here is indicator-count only. The value passes through
+  unchanged.
+
+  The contract is the SCALAR — the value the caller intends to ship
+  on the wire — NOT the envelope around it. `get-path` strips the
+  `:value` slot off its result map, runs it through here, and
+  rebuilds the envelope. That way the indicator count reflects only
+  what's actually being shipped — a `:path-not-found` envelope (no
+  `:value` slot) bypasses the walk entirely.
 
   Returns `{:value v :indicators {:elided N}}`."
   [v _opts]

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire_pipeline.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire_pipeline.cljs
@@ -142,12 +142,16 @@
   - `:slice-mode`   global `:summary` / `:full` mode for non-app-db slices.
   - `:slice-modes`  per-slice override map.
 
-  Unknown `:kind` is a programming error — the dispatch is closed
-  to four cases. Returns `{:value v :indicators {:elided 0}}` as a
-  defensive identity for an unrecognised kind."
+  Unknown `:kind` throws — the dispatch is closed to three cases and
+  silently degrading would mask a programmer typo / a new-payload
+  contributor who forgot to register the arm. The post-eval shrink
+  pipeline is a fixed surface; a dynamic-dispatch fallback has no
+  legitimate use."
   [payload {:keys [kind] :as opts}]
   (case kind
     :snapshot-map (run-snapshot-map payload opts)
     :epoch-vector (run-epoch-vector payload opts)
     :scalar-value (run-scalar-value payload opts)
-    {:value payload :indicators {:elided 0}}))
+    (throw (ex-info "run-wire-pipeline: unknown :kind"
+                    {:kind  kind
+                     :valid #{:snapshot-map :epoch-vector :scalar-value}}))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/eval_form_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/eval_form_test.cljs
@@ -150,3 +150,42 @@
         edn  (cljs.reader/read-string form)]
     (is (= 're-frame-pair2.runtime/snapshot-state (first edn)))
     (is (= opts (second edn)))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-lbfzu — `::call*` qsym handling + collection-recursion.
+;; ---------------------------------------------------------------------------
+
+(deftest rt-call*-symbol-qsym-emits-fully-qualified
+  ;; Symbol qsyms emit via `(str sym)` — the namespace prefix is
+  ;; included verbatim.
+  (is (= "(re-frame.core/elide-wire-value)"
+         (ef/emit (ef/rt-call* 're-frame.core/elide-wire-value)))))
+
+(deftest rt-call*-bare-symbol-emits-verbatim
+  ;; A bare symbol (no namespace) emits as just the name. The
+  ;; precheck-form's `(rt-call* 'hash ...)` relies on this.
+  (is (= "(hash)" (ef/emit (ef/rt-call* 'hash)))))
+
+(deftest rt-call*-string-qsym-emits-verbatim
+  ;; Round-2 dead-branch fix: the previous impl had
+  ;; `(if (symbol? qsym) (str qsym) (str qsym))` — both arms
+  ;; identical. Pin that a string qsym renders the same way the
+  ;; symbol does (verbatim, no auto-quoting), so a future caller
+  ;; can pass a pre-qualified string and get correct source.
+  (is (= "(some.ns/foo 1)"
+         (ef/emit (ef/rt-call* "some.ns/foo" 1)))))
+
+(deftest emit-arg-recurses-into-vectors-of-nodes
+  ;; rf2-lbfzu / EF3 — a vector mixing scalar data and IR nodes
+  ;; previously `pr-str`'d the whole vector, including the IR
+  ;; literal. Now the recursion walks element-wise.
+  (is (= "(re-frame-pair2.runtime/foo [1 bar])"
+         (ef/emit (ef/rt-call 'foo [1 (ef/rt-raw "bar")])))))
+
+(deftest emit-arg-passes-pure-scalar-vectors-unchanged
+  ;; Pure-scalar vectors still go through `pr-str` byte-for-byte —
+  ;; the recursion only triggers when the vector contains at least
+  ;; one IR node. Pin so the contains-node check doesn't change
+  ;; the output for the existing tool sites.
+  (is (= "(re-frame-pair2.runtime/foo [1 2 3])"
+         (ef/emit (ef/rt-call 'foo [1 2 3])))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/wire_cap_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/wire_cap_test.cljs
@@ -196,3 +196,44 @@
     (doseq [t tools-with-data-volume]
       (is (contains? cap/overflow-hints t)
           (str "Missing overflow hint for tool: " t)))))
+
+;; ---------------------------------------------------------------------------
+;; apply-cap short-circuits on wire-bounded markers (rf2-gktyn).
+;;
+;; Cache-hit and overflow envelopes are emitted by the cache + cap
+;; steps themselves; they are sub-cap by construction. Re-applying
+;; the token walk to a marker is wasted work — and worse, if the
+;; cap somehow tripped on a marker (it can't today, but a regression
+;; could lower the cap below the marker's size), the result would
+;; be an overflow OF an overflow.
+;; ---------------------------------------------------------------------------
+
+(deftest apply-cap-short-circuits-on-cache-hit-marker
+  ;; Construct a result that LOOKS like a cache-hit marker. apply-cap
+  ;; must pass it through identical, regardless of cap.
+  (let [marker  {:rf.mcp/cache-hit {:hash 42 :unchanged-since 0
+                                     :tool "snapshot" :via :result-hash
+                                     :hint "..."}}
+        r       (ok-text-result marker)
+        out     (cap/apply-cap r {:tool "snapshot" :cap 1})]
+    (is (identical? r out)
+        "marker passes through unchanged even under a 1-token cap")))
+
+(deftest apply-cap-short-circuits-on-overflow-marker
+  (let [marker  {:rf.mcp/overflow {:limit :reached :tool "snapshot"
+                                    :cap-tokens 100 :token-count 200
+                                    :hint "..."}}
+        r       (ok-text-result marker)
+        out     (cap/apply-cap r {:tool "snapshot" :cap 1})]
+    (is (identical? r out)
+        "overflow marker passes through unchanged — no recursion")))
+
+(deftest apply-cap-runs-walk-on-non-marker-payloads
+  ;; Negative — a normal map that doesn't open with the marker
+  ;; namespace MUST be subject to the cap walk.
+  (let [big   (apply str (repeat 8000 "x"))
+        r     (ok-text-result {:huge big})
+        out   (cap/apply-cap r {:tool "snapshot" :cap 500})
+        edn   (read-edn out)]
+    (is (contains? edn :rf.mcp/overflow)
+        "non-marker payload over budget is still capped")))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/with_indicators_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/with_indicators_test.cljs
@@ -1,0 +1,158 @@
+(ns re-frame-pair2-mcp.with-indicators-test
+  "Conformance gate for `wire/with-indicators` (rf2-n505f).
+
+  ## The MUST rule
+
+  Per `spec/Conventions.md` §Cross-MCP indicator-field vocabulary and
+  `spec/009-Instrumentation.md` §Indicator field on tool responses:
+
+  > Every tool that walks a tree-typed payload MUST carry the
+  > `:dropped-sensitive` and `:elided-large` slots on its response
+  > envelope WHEN their counts are non-zero, and MUST OMIT them when
+  > the counts are zero.
+
+  The pair2-mcp impl centralises this rule at `wire/with-indicators`
+  — five tool emit sites (`snapshot`, `get-path`, `trace-window`,
+  `watch-epochs`, `subscribe`) route their envelope-tail through
+  it. The MUST-level contract lives in one `cond->` form; this
+  conformance suite pins that contract so a future regression at
+  the choke-point — or at any caller that bypasses it — fails
+  loudly.
+
+  ## What's pinned
+
+  - **The choke-point**: `with-indicators` itself omits when zero,
+    emits when non-zero, treats nil as zero, and never confuses
+    the two slots.
+  - **The five emit sites**: each of the five tool source files
+    that walks a tree-typed payload references `with-indicators`.
+    A new tool that walks a payload but bypasses the helper would
+    only be caught by hand-review today; this test makes the bypass
+    a build failure.
+
+  Round-1 TE8 (rf2-zjqh8) flagged the missing test; rf2-n505f
+  promoted it to P0 after round-2 confirmed the choke-point had
+  stabilised."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as str]
+            [re-frame-pair2-mcp.tools.wire :as wire]))
+
+(def ^:private fs (js/require "fs"))
+(def ^:private path (js/require "path"))
+
+(defn- repo-root
+  "Walk upward from the test process's cwd until we find a directory
+  whose `tools/pair2-mcp/src` subdir exists. Robust against the test
+  runner's working directory (`tools/pair2-mcp` vs repo root)."
+  []
+  (loop [d (.cwd js/process)]
+    (cond
+      (.existsSync fs (.join path d "tools/pair2-mcp/src"))
+      (.join path d "tools/pair2-mcp")
+
+      (.existsSync fs (.join path d "src/re_frame_pair2_mcp"))
+      d
+
+      (= d (.dirname path d))
+      (throw (ex-info "Could not locate pair2-mcp root from cwd"
+                      {:cwd (.cwd js/process)}))
+
+      :else (recur (.dirname path d)))))
+
+(defn- read-source [rel-path]
+  (let [root (repo-root)
+        full (.join path root rel-path)]
+    (.toString (.readFileSync fs full))))
+
+;; ---------------------------------------------------------------------------
+;; The choke-point itself.
+;; ---------------------------------------------------------------------------
+
+(deftest with-indicators-omits-both-slots-when-zero
+  ;; The load-bearing MUST: zero counts produce no slot. An envelope
+  ;; that already had no indicators must come out unchanged.
+  (is (= {:foo :bar}
+         (wire/with-indicators {:foo :bar} {:dropped 0 :elided 0})))
+  (is (= {:foo :bar}
+         (wire/with-indicators {:foo :bar} {:dropped 0 :elided 0})))
+  (is (not (contains? (wire/with-indicators {} {:dropped 0 :elided 0})
+                      :dropped-sensitive)))
+  (is (not (contains? (wire/with-indicators {} {:dropped 0 :elided 0})
+                      :elided-large))))
+
+(deftest with-indicators-treats-nil-as-zero
+  ;; Defensive — a caller that doesn't compute an indicator (passes
+  ;; nil) gets the same "omit" treatment as an explicit zero.
+  (is (not (contains? (wire/with-indicators {} {:dropped nil :elided nil})
+                      :dropped-sensitive)))
+  (is (not (contains? (wire/with-indicators {} {:dropped nil :elided nil})
+                      :elided-large)))
+  (is (not (contains? (wire/with-indicators {} {})
+                      :dropped-sensitive))))
+
+(deftest with-indicators-emits-each-slot-independently-when-non-zero
+  ;; Dropped only.
+  (let [out (wire/with-indicators {:foo :bar} {:dropped 3 :elided 0})]
+    (is (= 3 (:dropped-sensitive out)))
+    (is (not (contains? out :elided-large))))
+  ;; Elided only.
+  (let [out (wire/with-indicators {:foo :bar} {:dropped 0 :elided 5})]
+    (is (= 5 (:elided-large out)))
+    (is (not (contains? out :dropped-sensitive))))
+  ;; Both — the common shape on a real tool response.
+  (let [out (wire/with-indicators {:foo :bar} {:dropped 3 :elided 5})]
+    (is (= 3 (:dropped-sensitive out)))
+    (is (= 5 (:elided-large out)))
+    (is (= :bar (:foo out)))))
+
+(deftest with-indicators-uses-the-unqualified-key-names
+  ;; The cross-MCP vocab (Conventions §Cross-MCP indicator-field
+  ;; vocabulary) is intentionally UNqualified — the slots ride
+  ;; alongside the tool's own envelope keys. A namespaced rename
+  ;; would split the contract across two vocabularies.
+  (let [out (wire/with-indicators {} {:dropped 1 :elided 1})]
+    (is (contains? out :dropped-sensitive))
+    (is (contains? out :elided-large))
+    (is (not (contains? out :rf.mcp/dropped-sensitive)))
+    (is (not (contains? out :rf.mcp/elided-large)))))
+
+;; ---------------------------------------------------------------------------
+;; Per-emit-site choke-point check.
+;;
+;; Each tool that walks a tree-typed payload MUST route its
+;; envelope-tail through `wire/with-indicators`. Today the five sites
+;; all use the helper; if a future tool adds a tree-walk and bypasses
+;; the helper, the omit-when-zero rule could regress silently. Grep
+;; each source file for the literal `with-indicators` reference.
+;; ---------------------------------------------------------------------------
+
+(defn- contains-with-indicators? [src]
+  (boolean (re-find #"wire/with-indicators|with-indicators" src)))
+
+(deftest snapshot-emit-site-routes-through-with-indicators
+  (let [src (read-source "src/re_frame_pair2_mcp/tools/snapshot.cljs")]
+    (is (contains-with-indicators? src)
+        "snapshot.cljs MUST route its envelope through wire/with-indicators")))
+
+(deftest get-path-emit-site-routes-through-with-indicators
+  (let [src (read-source "src/re_frame_pair2_mcp/tools/get_path.cljs")]
+    (is (contains-with-indicators? src)
+        "get_path.cljs MUST route its envelope through wire/with-indicators")))
+
+(deftest trace-window-emit-site-routes-through-with-indicators
+  (let [src (read-source "src/re_frame_pair2_mcp/tools/trace_window.cljs")]
+    (is (contains-with-indicators? src)
+        "trace_window.cljs MUST route its envelope through wire/with-indicators")))
+
+(deftest watch-epochs-emit-site-routes-through-with-indicators
+  (let [src (read-source "src/re_frame_pair2_mcp/tools/watch_epochs.cljs")]
+    (is (contains-with-indicators? src)
+        "watch_epochs.cljs MUST route its envelope through wire/with-indicators")))
+
+(deftest subscribe-emit-site-routes-through-with-indicators
+  ;; Subscribe emits indicators on each progress tick AND on the
+  ;; final result. Either site routes through with-indicators; the
+  ;; module-level grep is fine.
+  (let [src (read-source "src/re_frame_pair2_mcp/tools/subscribe_emit.cljs")]
+    (is (contains-with-indicators? src)
+        "subscribe_emit.cljs MUST route its envelope through wire/with-indicators")))


### PR DESCRIPTION
## Summary

Eight follow-on beads from the round-2 `tools/pair2-mcp` audit
(`rf2-b05ld`) — one commit per bead, sequenced structural → correctness
→ docs → test.

| # | Commit          | Bead       | P  | Title                                                       |
|---|-----------------|------------|----|-------------------------------------------------------------|
| 1 | a019a9bf        | rf2-3z0zi  | P1 | pluggable wire-boundary step-pipeline                       |
| 2 | 19c00390        | rf2-fwkrb  | P1 | `run-wire-pipeline` unknown-kind throws (not silent identity) |
| 3 | 7fbd4386        | rf2-gktyn  | P1 | `apply-cap` short-circuits on `:rf.mcp/*` markers           |
| 4 | 2984cd88        | rf2-6by5s  | P1 | `:scalar-value` walks scalar, not envelope                  |
| 5 | 0c74af58        | rf2-l3x7e  | P2 | registry `ignoring-extra` adapter                           |
| 6 | 533a5e41        | rf2-lbfzu  | P2 | eval-form `::call*` dead-branch + `emit-arg` collection-recursion |
| 7 | f0f47176        | rf2-6mddd  | P1 | docs `:via :precheck` / `:via :result-hash` in spec/003     |
| 8 | 33ae6456        | rf2-n505f  | P1 | conformance test for `with-indicators` omit-when-zero       |

### The under-appreciated win

Commit 1 (rf2-3z0zi) is the round-2 parallel of round-1's named
wire-pipeline win. `invoke` was a hand-threaded Promise chain
through four hardcoded phases; it's now a declarative
`{:name :run :short-circuit?}` step-pipeline. The four envisaged
future steps (request-level redaction, metrics emission,
path-prefix slicing, per-call elision toggle) plug in as one map
entry each instead of yet-another inline branch.

### Net delta (pair2-mcp only)

664 insertions, 109 deletions across 12 files. One new namespace
(`boundary_step.cljs`), one new test ns (`with_indicators_test.cljs`),
modifications to `tools.cljs`, `cap.cljs`, `eval_form.cljs`,
`get_path.cljs`, `registry.cljs`, `wire.cljs`, `wire_pipeline.cljs`,
`spec/003-Tool-Catalogue.md`, plus three test files.

### Deferred (explicit)

From the candidate list:

- **rf2-8cntr** — decision-blocked (Mike needs to clarify Spec 009
  `:elided-large` MUST scope). Excluded as per dispatch brief.
- **rf2-uebll** — touches `pair2-mcp/spec/Principles.md` which is
  conceptually a separate concern (cross-mcp pipeline-narrative
  surface, not the cluster's wire-boundary focus). Filed for a
  follow-on batch.

Out-of-cluster remaining beads (rf2-c0h8p, rf2-agcq2, rf2-e35a5,
rf2-w92r8, rf2-lhue6, rf2-kaof4, rf2-n5j96) are P2/P3 and naturally
form a second polish batch once this one merges.

## Test plan

- [x] `cd tools/pair2-mcp && npm test` — 313 tests / 764 assertions, 0 failures.
  (+17 assertions from this PR: 5 eval-form, 3 wire-cap, 9 with-indicators).
- [x] `cd implementation && npm run test:bundle-isolation` — PASS.
- [ ] Worktree-clobber status: clobbered at session start, escaped to
  `/c/Users/miket/code/rf2-pair2-batch-work` per brief's recovery
  protocol.