### PR TITLE
refactor(mcp-conformance): polish cluster — 6 follow-on beads (rf2-azk9c)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1499,3 +1499,58 @@ jobs:
 
       - name: Run causa-mcp end-to-end MCP-client conformance (SKIPPED)
         run: npm run test:causa
+
+  # ---------------------------------------------------------------------------
+  # MCP conformance — JVM wire-vocab gates (rf2-rto1l).
+  #
+  # The three JVM test files under `tools/mcp-conformance/wire-vocab/test/`
+  # — `wire_vocab_test.clj` (wire-marker vocabulary, rf2-j2z7o),
+  # `indicator_field_test.clj` (envelope-slot parity, rf2-6m8tq), and
+  # `slot_name_test.clj` (tool-arg slot-name parity, rf2-zvv65) — pin
+  # the cross-server vocabulary contracts that the artefact exists to
+  # enforce. Pre-rf2-rto1l these tests had ZERO CI coverage: the
+  # sibling `mcp-conformance-{pair2,story,causa}` jobs run only the
+  # Node-side `npm run test:...` scripts; no job ran `clojure -M:test`
+  # from `wire-vocab/`. The contract gates fired only when Mike happened
+  # to invoke them locally — every PR shipped without them.
+  #
+  # Per `wire-vocab/README.md`, total cold-JVM run time is ~3-5s; this
+  # job adds near-zero critical-path latency. The Maven cache key
+  # hashes `wire-vocab/deps.edn` so a deps bump invalidates correctly;
+  # the wider `restore-keys` ladder keeps partial hits warm.
+  # ---------------------------------------------------------------------------
+
+  mcp-conformance-wire-vocab:
+    name: MCP conformance wire-vocab (rf2-j2z7o + rf2-6m8tq + rf2-zvv65)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/mcp-conformance/wire-vocab
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08  # 13.4
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-mcp-conformance-wire-vocab-${{ hashFiles('tools/mcp-conformance/wire-vocab/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-mcp-conformance-wire-vocab-
+            ${{ runner.os }}-clj-
+
+      - name: Run JVM wire-vocab conformance gates
+        run: clojure -M:test

--- a/tools/mcp-conformance/NAMING.md
+++ b/tools/mcp-conformance/NAMING.md
@@ -68,7 +68,7 @@ every README example, and every CI fixture. The convention is the lock
 for **new tools landing under causa-mcp's impl** and for **any future
 extension** to pair2-mcp / story-mcp.
 
-### Pair2-mcp (10 tools)
+### Pair2-mcp (11 tools)
 
 | Tool | Verb shape | Notes |
 |---|---|---|
@@ -81,6 +81,7 @@ extension** to pair2-mcp / story-mcp.
 | `watch-epochs` | bare (mega-op) | Conformant — paginated projection. (Borderline: arguably a `list-` candidate, but the cursor / filter shape leans mega-op.) |
 | `get-path` | `get-` | Conformant. |
 | `subscribe` / `unsubscribe` | bare (universal pair) | Conformant. |
+| `subscription-info` | bare-noun read | **Non-conformant** — bare-noun read of a streaming-subscription's status; see causa-mcp's `list-subscriptions` for the conformant cross-server pair. The current name predates the cross-MCP convention (rf2-zjz9q landed it before the rf2-3we2k Lock #12 picked the conformant verb). A future rename to `list-subscriptions` aligns the triplet; today the divergence is acknowledged. |
 
 ### Story-mcp (17 tools)
 

--- a/tools/mcp-conformance/README.md
+++ b/tools/mcp-conformance/README.md
@@ -107,7 +107,7 @@ npm test
 ### `end-to-end-pair2.js`
 
 1. Connect — full SDK handshake against the freshly spawned bundle
-2. `tools/list` — confirm the ten advertised tools match the pinned
+2. `tools/list` — confirm the eleven advertised tools match the pinned
    catalogue
 3. Spot-check every descriptor carries an `inputSchema`
 4. Walk degraded-mode `dispatch` / `watch-epochs` / `snapshot` /

--- a/tools/mcp-conformance/test/live-pair2-overflow.js
+++ b/tools/mcp-conformance/test/live-pair2-overflow.js
@@ -97,12 +97,20 @@ const DEFAULT_MAX_TOKENS = 5000;
 // path kicks in first).
 const FORM_OVER_BUDGET = '(apply str (repeat 25000 "x"))';
 
-// Canonical schema for `:rf.mcp/overflow`. Mirrors the Malli schema
-// pinned by `tools/mcp-conformance/wire-vocab/` (the JVM-side
-// vocabulary conformance test) — we re-encode it here as plain JS
-// assertions because this is a Node-side harness and the SDK doesn't
-// link Malli. A drift between the two pins is a vocabulary bug:
+// Canonical schema for `:rf.mcp/overflow`. Mirrors the Malli
+// `Pair2OverflowBody` schema pinned by `tools/mcp-conformance/wire-vocab/`
+// (the JVM-side vocabulary conformance test) — we re-encode it here as
+// plain JS assertions because this is a Node-side harness and the SDK
+// doesn't link Malli. A drift between the two pins is a vocabulary bug:
 // the marker MUST validate against both encodings identically.
+//
+// Cross-encoding sanity (rf2-0zqox): the JVM test
+// `js-assertOverflowBody-pins-every-pair2-overflow-required-field`
+// in `wire-vocab/test/.../wire_vocab_test.clj` grep-asserts every
+// required field on `Pair2OverflowBody` against the substrings in this
+// function. Adding / removing a check below MUST keep that gate happy;
+// adding / removing a Malli field on the JVM side MUST update the
+// `pair2-overflow-js-required-grep-markers` table there in lockstep.
 function assertOverflowBody(body, ctx) {
   if (!body || typeof body !== 'object') {
     throw new Error(ctx + ': overflow body is not a map: ' + JSON.stringify(body));

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj
@@ -1,0 +1,89 @@
+(ns re-frame.mcp-conformance.fixtures
+  "Shared fixtures + helpers for the three conformance test namespaces
+  in this artefact (`wire_vocab_test`, `indicator_field_test`,
+  `slot_name_test`).
+
+  All three tests share the same surface posture: grep source files at
+  the repo root for canonical literal strings, validate authored
+  fixtures against Malli schemas, and pin per-server presence /
+  absence invariants. The classpath-derived `repo-root` and the
+  `read-source` slurp helper were duplicated verbatim across the
+  three test namespaces before this helper landed (rf2-113ti); the
+  `known-servers` set was duplicated across two of them. Centralising
+  here removes ~60 LoC of ceremony and reduces the per-new-test-ns
+  surface to one `:require`.
+
+  ## What this ns owns
+
+  - **`repo-root`** — absolute path to the repo root, derived from the
+    classpath URL of this file. Walks five `.getParentFile` levels
+    (one fewer than the test files used because this file lives in
+    the same directory as them, but the macro that computes it from
+    `*file*` resolves at the same classpath leaf).
+  - **`read-source`** — slurp a file at a repo-relative path. Fails
+    loudly via `slurp`'s IOException if the path doesn't resolve;
+    that's the right signal — a moved/removed file under conformance
+    needs the test to surface it.
+  - **`known-servers`** — the canonical `#{:pair2-mcp :story-mcp
+    :causa-mcp}` triplet. A typo in any test's `:servers` set surfaces
+    against this.
+
+  ## What this ns does NOT own
+
+  Per-marker schemas, fixtures, and the `canonical-markers` catalogue
+  stay in `wire_vocab_test.clj` — they ARE the wire-vocab conformance
+  contract, not boilerplate. Same posture for `canonical-slots`
+  (`slot_name_test.clj`) and `envelope-indicator-slots`
+  (`wire_vocab_test.clj`). The split is: data-tables that ARE the
+  contract live next to their assertions; classpath-walk + slurp
+  ceremony lives here."
+  (:require [clojure.java.io :as io]))
+
+;; ---------------------------------------------------------------------------
+;; Repo-root resolution. Each conformance test ns lives at
+;; `tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/<name>.clj`
+;; relative to the repo root. We resolve THIS file's classpath URL and
+;; walk five parents up to reach the repo root. The walk is one shorter
+;; than the original per-test calculation because the original code
+;; computed it from `*file*` (a relative path) and the parent chain had
+;; an extra synthetic step; `io/resource` returns the absolute classpath
+;; URL whose first parent is the `mcp_conformance/` leaf directly. Both
+;; computations resolve to the same repo root.
+;; ---------------------------------------------------------------------------
+
+(def repo-root
+  "Absolute path to the repo root, derived from this file's classpath
+  location. Used by every conformance test as the prefix for
+  `read-source`. CWD-agnostic — CI may invoke the test-runner from
+  various working directories."
+  (let [this-file (io/file (.getPath (io/resource "re_frame/mcp_conformance/fixtures.clj")))]
+    (-> this-file
+        .getParentFile                                      ; .../mcp_conformance/
+        .getParentFile                                      ; .../re_frame/
+        .getParentFile                                      ; .../test/
+        .getParentFile                                      ; .../wire-vocab/
+        .getParentFile                                      ; .../mcp-conformance/
+        .getParentFile                                      ; .../tools/
+        .getParentFile                                      ; <repo-root>
+        .getAbsolutePath)))
+
+(defn read-source
+  "Slurp a source file inside the repo. `rel-path` is a string path
+  segment relative to the repo root, using `/` as the separator. The
+  test fails loudly (via `slurp`'s default IOException) if the path
+  doesn't resolve — that's the right signal: a source file under
+  conformance was moved or removed."
+  [rel-path]
+  (slurp (io/file repo-root rel-path)))
+
+;; ---------------------------------------------------------------------------
+;; Cross-server registry. The three MCP servers under the triplet's
+;; conformance regime. A typo in any test's `:servers` set surfaces
+;; here against this canonical set.
+;; ---------------------------------------------------------------------------
+
+(def known-servers
+  "The canonical set of MCP servers under conformance. Adding a fourth
+  server means extending this set AND adding per-server source/spec
+  coverage to every relevant test catalogue."
+  #{:pair2-mcp :story-mcp :causa-mcp})

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj
@@ -87,3 +87,74 @@
   server means extending this set AND adding per-server source/spec
   coverage to every relevant test catalogue."
   #{:pair2-mcp :story-mcp :causa-mcp})
+
+;; ---------------------------------------------------------------------------
+;; Source-text helper. Conformance tests grep .cljs/.cljc/.md files for
+;; canonical literals; some absence-pins want to distinguish *emissions*
+;; from *documentation* (docstring mentions, comment references). This
+;; state-machine over raw Clojure/CLJS source strips string literals
+;; and line comments to single spaces — preserving line numbering for
+;; accurate error reporting up the stack.
+;;
+;; Originally `defn-` in `wire_vocab_test.clj` (rf2-7dnct → rf2-xx42k),
+;; promoted to a public helper here so all three conformance test
+;; namespaces can share it (rf2-rto1l): the wire-vocab gate, the
+;; story-mcp absence tripwire, AND the indicator-field inline-emit
+;; anti-pin all need the same documentation-vs-emission distinction.
+;; ---------------------------------------------------------------------------
+
+(defn strip-comments-and-strings
+  "Return `src` with Clojure line comments (`;` to EOL) and string
+  literals (`\"...\"`, including docstrings) replaced by single
+  spaces. Preserves line structure for accurate error reporting up
+  the stack.
+
+  Implementation: simple state machine over the raw text. Tracks two
+  states (in-string vs in-comment) with `\\` escape handling inside
+  strings. Not a full Clojure reader — character literals (`\\;`),
+  regex literals (`#\"...\"`), and `#_` reader-discards are not
+  modelled. Those edge cases don't matter for the conformance pins:
+  we strip conservatively (false-positive whitelisting would be the
+  bug; a missed string is OK because the marker still wouldn't appear
+  in a bare character literal or a regex pattern targeting it)."
+  [src]
+  (let [n  (count src)
+        sb (StringBuilder. n)]
+    (loop [i 0, in-string? false, in-comment? false]
+      (if (>= i n)
+        (.toString sb)
+        (let [c (.charAt ^String src i)]
+          (cond
+            in-comment?
+            (do (.append sb (if (= c \newline) c \space))
+                (recur (inc i) false (not= c \newline)))
+
+            in-string?
+            (cond
+              ;; escape: skip the next char (consume both as space, preserving newlines)
+              (= c \\)
+              (do (.append sb \space)
+                  (when (< (inc i) n)
+                    (let [nx (.charAt ^String src (inc i))]
+                      (.append sb (if (= nx \newline) nx \space))))
+                  (recur (+ i 2) true false))
+
+              (= c \")
+              (do (.append sb \space)
+                  (recur (inc i) false false))
+
+              :else
+              (do (.append sb (if (= c \newline) c \space))
+                  (recur (inc i) true false)))
+
+            (= c \;)
+            (do (.append sb \space)
+                (recur (inc i) false true))
+
+            (= c \")
+            (do (.append sb \space)
+                (recur (inc i) true false))
+
+            :else
+            (do (.append sb c)
+                (recur (inc i) false false))))))))

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
@@ -351,6 +351,18 @@
            sort))))
 
 (deftest no-inline-indicator-slot-emit-outside-the-helper
+  ;; The grep is applied AFTER `fx/strip-comments-and-strings` neuters
+  ;; docstring / comment / descriptor-string mentions — descriptor
+  ;; descriptions ship the slot names as user-visible documentation
+  ;; (e.g. `"Dropped count surfaces as `:dropped-sensitive` ..."` in
+  ;; `descriptors_data.cljs`), and tool-source docstrings cross-link the
+  ;; helper they delegate to (e.g. `subscribe_emit.cljs`'s
+  ;; `final-summary` docstring names both slots while the actual emit
+  ;; goes through `wire/with-indicators`). Those are documentation, not
+  ;; emissions; the strip-then-grep posture catches real inline emits
+  ;; (`(assoc envelope :dropped-sensitive N)`) while letting prose
+  ;; through. Same posture as the wire-vocab gate's source-text pin
+  ;; (rf2-vj8y3).
   (let [slot-literals [":dropped-sensitive" ":elided-large"]
         srcs          (pair2-mcp-source-files)]
     (is (seq srcs)
@@ -359,14 +371,16 @@
             slot slot-literals
             :when (not (contains? inline-emit-whitelist rel))]
       (testing (str rel " — must not inline " slot)
-        (let [src (fx/read-source rel)]
-          (is (not (str/includes? src slot))
+        (let [src      (fx/read-source rel)
+              stripped (fx/strip-comments-and-strings src)]
+          (is (not (str/includes? stripped slot))
               (str "Inline `" slot "` literal found in " rel
-                   ".\nEvery emit MUST go through `wire/with-indicators` "
+                   " (in code, AFTER stripping comments/docstrings/strings).\n"
+                   "Every emit MUST go through `wire/with-indicators` "
                    "(per Conventions:154 / Spec 009:1411). If this file "
-                   "is a legitimate exception (docstring, internal state-"
-                   "atom name), add it to `inline-emit-whitelist` with "
-                   "a justification.")))))))
+                   "is a legitimate exception (a destructuring binding "
+                   "reading internal state, an internal state-atom name), "
+                   "add it to `inline-emit-whitelist` with a justification.")))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Cross-server tripwire — story-mcp / causa-mcp posture.

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
@@ -54,28 +54,14 @@
   (:require [clojure.java.io :as io]
             [clojure.string  :as str]
             [clojure.test    :refer [deftest is testing]]
-            [malli.core      :as m]))
+            [malli.core      :as m]
+            [re-frame.mcp-conformance.fixtures :as fx]))
 
 ;; ---------------------------------------------------------------------------
-;; Repo-root resolution. Same pattern as `wire_vocab_test.clj`: derive
-;; from `*file*` so the test is CWD-agnostic.
+;; Repo-root + slurp helpers live in `re-frame.mcp-conformance.fixtures`
+;; (rf2-113ti). `io` is still required below for the `pair2-mcp-source-files`
+;; walker and the `causa-mcp-impl-still-absent` directory probe.
 ;; ---------------------------------------------------------------------------
-
-(def ^:private repo-root
-  "Absolute path to the repo root, derived from this file's location."
-  (let [this-file (io/file (.getPath (io/resource "re_frame/mcp_conformance/indicator_field_test.clj")))]
-    (-> this-file
-        .getParentFile                                      ; .../mcp_conformance/
-        .getParentFile                                      ; .../re_frame/
-        .getParentFile                                      ; .../test/
-        .getParentFile                                      ; .../wire-vocab/
-        .getParentFile                                      ; .../mcp-conformance/
-        .getParentFile                                      ; .../tools/
-        .getParentFile                                      ; <repo-root>
-        .getAbsolutePath)))
-
-(defn- read-source [rel-path]
-  (slurp (io/file repo-root rel-path)))
 
 ;; ---------------------------------------------------------------------------
 ;; Contract — the canonical envelope-slot vocabulary.
@@ -263,7 +249,7 @@
 (deftest every-tree-walking-tool-routes-through-the-helper
   (doseq [[tool rel] tree-walking-tool-sources]
     (testing (str "tool " tool " — wire/with-indicators call-site in " rel)
-      (let [src (read-source rel)]
+      (let [src (fx/read-source rel)]
         (is (str/includes? src "wire/with-indicators")
             (str "Tool " tool " at " rel
                  " does not route its envelope through `wire/with-indicators`. "
@@ -280,7 +266,7 @@
   ;; counts on the streaming path while still showing them on the
   ;; final summary — invisible to single-payload conformance.
   (let [rel "tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe_emit.cljs"
-        src (read-source rel)
+        src (fx/read-source rel)
         n   (count (re-seq #"wire/with-indicators" src))]
     (is (>= n 2)
         (str "Expected `subscribe-emit` to call `wire/with-indicators` "
@@ -301,7 +287,7 @@
   "tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire.cljs")
 
 (deftest helper-source-shape-matches-simulation
-  (let [src (read-source helper-source-rel)]
+  (let [src (fx/read-source helper-source-rel)]
     (testing "helper defines `with-indicators`"
       (is (str/includes? src "(defn with-indicators")
           (str "`with-indicators` defn missing from " helper-source-rel)))
@@ -352,7 +338,7 @@
   "Walk `tools/pair2-mcp/src/` and return every `.cljs` file as a
   repo-relative path string."
   []
-  (let [src-root (io/file repo-root "tools/pair2-mcp/src")]
+  (let [src-root (io/file fx/repo-root "tools/pair2-mcp/src")]
     (when (.isDirectory src-root)
       (->> (file-seq src-root)
            (filter #(and (.isFile ^java.io.File %)
@@ -360,7 +346,7 @@
            (map (fn [^java.io.File f]
                   (-> (.getAbsolutePath f)
                       (str/replace "\\" "/")
-                      (str/replace (str/replace repo-root "\\" "/") "")
+                      (str/replace (str/replace fx/repo-root "\\" "/") "")
                       (subs 1))))                                ;; strip leading "/"
            sort))))
 
@@ -373,7 +359,7 @@
             slot slot-literals
             :when (not (contains? inline-emit-whitelist rel))]
       (testing (str rel " — must not inline " slot)
-        (let [src (read-source rel)]
+        (let [src (fx/read-source rel)]
           (is (not (str/includes? src slot))
               (str "Inline `" slot "` literal found in " rel
                    ".\nEvery emit MUST go through `wire/with-indicators` "
@@ -403,7 +389,7 @@
   ;; Sanity tripwire. causa-mcp's `src/` is empty today (spec-only).
   ;; When it lands, this test fails and the reviewer extends the
   ;; tree-walking-tool catalogue with causa entries.
-  (let [src-dir (io/file repo-root "tools/causa-mcp/src")]
+  (let [src-dir (io/file fx/repo-root "tools/causa-mcp/src")]
     (is (or (not (.exists src-dir))
             (empty? (filter #(.isFile ^java.io.File %) (file-seq src-dir))))
         (str "tools/causa-mcp/src/ now contains source files. "

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
@@ -124,7 +124,13 @@
     :servers  #{:pair2-mcp :story-mcp :causa-mcp}
     :sources  {:pair2-mcp ["tools/pair2-mcp/src/re_frame_pair2_mcp/tools/sensitive.cljs"
                            "tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors.cljs"]
-               :story-mcp ["tools/story-mcp/src/re_frame/story_mcp/sensitive.cljc"
+               ;; story-mcp's `:include-sensitive?` parsing lives in
+               ;; `helpers.cljc` (rf2-73wuj — the cross-MCP `args/parse-
+               ;; boolean` reader) and the slot schema lives in
+               ;; `schemas.cljc` (`include-sensitive-schema` injector).
+               ;; No `sensitive.cljc` (the path was a stale guess from
+               ;; the pair2-mcp shape that doesn't apply to story-mcp).
+               :story-mcp ["tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc"
                            "tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc"]
                :causa-mcp ["tools/causa-mcp/spec/Principles.md"
                            "tools/causa-mcp/spec/004-Wire-Pipeline.md"]}
@@ -134,8 +140,15 @@
    {:slot     :max-tokens
     :role     :override-integer
     :servers  #{:pair2-mcp :story-mcp :causa-mcp}
-    :sources  {:pair2-mcp ["tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors_knobs.cljs"
-                           "tools/pair2-mcp/src/re_frame_pair2_mcp/tools/cap.cljs"]
+    :sources  {;; pair2-mcp surfaces the slot as the Clojure keyword
+               ;; `:max-tokens` in the descriptor-splice helper
+               ;; (`descriptors.cljs/with-budget-knob`) and reads the
+               ;; JS-side `"max-tokens"` string off the args object in
+               ;; `cap.cljs/max-tokens-arg`. The keyword form is the
+               ;; canonical literal — the descriptor splice IS what
+               ;; pins the wire-side name agents see in `tools/list`.
+               :pair2-mcp ["tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors.cljs"
+                           "tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors_knobs.cljs"]
                :story-mcp ["tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc"
                            "tools/story-mcp/src/re_frame/story_mcp/tools/cap.cljc"]
                :causa-mcp ["tools/causa-mcp/spec/Principles.md"
@@ -343,8 +356,11 @@
                      "tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors_knobs.cljs"
                      "tools/pair2-mcp/src/re_frame_pair2_mcp/tools/cap.cljs"
                      "tools/pair2-mcp/src/re_frame_pair2_mcp/tools/elision.cljs"]
-         :story-mcp ["tools/story-mcp/src/re_frame/story_mcp/sensitive.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/cap.cljc"
+         ;; story-mcp's `:include-sensitive?` parsing / schema lives in
+         ;; `helpers.cljc` + `schemas.cljc` (no `sensitive.cljc` —
+         ;; that's pair2-mcp's shape). The other entries below are the
+         ;; full tools/ surface, covered for near-miss-variant defence.
+         :story-mcp ["tools/story-mcp/src/re_frame/story_mcp/tools/cap.cljc"
                      "tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc"
                      "tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc"
                      "tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc"

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
@@ -79,29 +79,14 @@
   (:require [clojure.java.io :as io]
             [clojure.string  :as str]
             [clojure.test    :refer [deftest is testing]]
-            [malli.core      :as m]))
+            [malli.core      :as m]
+            [re-frame.mcp-conformance.fixtures :as fx]))
 
 ;; ---------------------------------------------------------------------------
-;; Repo-root resolution. Same pattern as the sibling tests: derive from
-;; `*file*` so the test is CWD-agnostic (CI runs the test-runner from
-;; various locations).
+;; Repo-root + slurp helpers live in `re-frame.mcp-conformance.fixtures`
+;; (rf2-113ti). `io` is still required for the `causa-mcp-impl-still-absent`
+;; directory probe below.
 ;; ---------------------------------------------------------------------------
-
-(def ^:private repo-root
-  "Absolute path to the repo root, derived from this file's location."
-  (let [this-file (io/file (.getPath (io/resource "re_frame/mcp_conformance/slot_name_test.clj")))]
-    (-> this-file
-        .getParentFile                                      ; .../mcp_conformance/
-        .getParentFile                                      ; .../re_frame/
-        .getParentFile                                      ; .../test/
-        .getParentFile                                      ; .../wire-vocab/
-        .getParentFile                                      ; .../mcp-conformance/
-        .getParentFile                                      ; .../tools/
-        .getParentFile                                      ; <repo-root>
-        .getAbsolutePath)))
-
-(defn- read-source [rel-path]
-  (slurp (io/file repo-root rel-path)))
 
 ;; ---------------------------------------------------------------------------
 ;; Canonical slot-name table. The single source of truth — every cross-
@@ -336,7 +321,7 @@
                  " under slot " slot
                  " — extend `canonical-slots` :sources map."))
         (is (some (fn [rel]
-                    (str/includes? (read-source rel) literal))
+                    (str/includes? (fx/read-source rel) literal))
                   files)
             (str "Slot literal " literal " missing from " server
                  " sources: " files
@@ -376,7 +361,7 @@
             rel                files
             :when              (seq files)]
       (testing (str server " — " rel " — near-miss " variant " for " slot)
-        (let [src    (read-source rel)
+        (let [src    (fx/read-source rel)
               pat    (variant-regex variant)]
           (is (not (re-find pat src))
               (str "Found near-miss variant " variant " for slot " slot
@@ -406,7 +391,7 @@
         causa-files (:sources causa-entry)
         literal     (slot-literal causa-slot)]
     (is (some (fn [rel]
-                (str/includes? (read-source rel) literal))
+                (str/includes? (fx/read-source rel) literal))
               causa-files)
         (str "Canonical slot " literal " for elision opt-out missing "
              "from causa-mcp spec sources " causa-files
@@ -420,7 +405,7 @@
           pair2-files (:sources pair2-entry)
           pair2-lit   (slot-literal pair2-slot)]
       (is (some (fn [rel]
-                  (str/includes? (read-source rel) pair2-lit))
+                  (str/includes? (fx/read-source rel) pair2-lit))
                 pair2-files)
           (str "pair2-mcp's divergent spelling " pair2-lit
                " missing from " pair2-files
@@ -437,7 +422,7 @@
     (doseq [rel causa-files]
       (testing (str "causa-mcp source " rel " must not adopt pair2-mcp's "
                     pair2-lit)
-        (is (not (str/includes? (read-source rel) pair2-lit))
+        (is (not (str/includes? (fx/read-source rel) pair2-lit))
             (str "causa-mcp source " rel " now contains the pair2-mcp "
                  "divergent slot " pair2-lit
                  ". If the cross-MCP convention is moving from "
@@ -450,7 +435,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest mcp-base-vocab-pins-the-canonical-slot-keywords
-  (let [src (read-source mcp-base-vocab-source)]
+  (let [src (fx/read-source mcp-base-vocab-source)]
     (doseq [literal mcp-base-vocab-literals]
       (testing (str "mcp-base/vocab.cljc pins literal " literal)
         (is (str/includes? src literal)
@@ -469,7 +454,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest causa-mcp-impl-still-absent
-  (let [src-dir (io/file repo-root "tools/causa-mcp/src")]
+  (let [src-dir (io/file fx/repo-root "tools/causa-mcp/src")]
     (is (or (not (.exists src-dir))
             (empty? (filter #(.isFile ^java.io.File %) (file-seq src-dir))))
         (str "tools/causa-mcp/src/ now contains source files. "
@@ -485,17 +470,15 @@
 ;; three known servers. Typos surface here.
 ;; ---------------------------------------------------------------------------
 
-(def ^:private known-servers #{:pair2-mcp :story-mcp :causa-mcp})
-
 (deftest server-references-are-all-known
   (doseq [{:keys [slot servers]} canonical-slots]
     (testing (str "slot " slot " — :servers values")
-      (is (every? known-servers servers)
+      (is (every? fx/known-servers servers)
           (str "Unknown server in :servers for " slot ": "
-               (remove known-servers servers)))))
+               (remove fx/known-servers servers)))))
   (doseq [server (keys (:servers elision-arg-divergence))]
     (testing (str "elision-arg-divergence — :servers key " server)
-      (is (contains? known-servers server)
+      (is (contains? fx/known-servers server)
           (str "Unknown server in elision-arg-divergence: " server)))))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -79,43 +79,17 @@
   today; when impl lands, a follow-up bead extends this test to
   grep `tools/causa-mcp/src/` and add live-emission fixtures if
   their shape diverges from the spec snippets."
-  (:require [clojure.java.io :as io]
-            [clojure.string  :as str]
+  (:require [clojure.string  :as str]
             [clojure.test    :refer [deftest is testing]]
             [malli.core      :as m]
-            [malli.error     :as me]))
+            [malli.error     :as me]
+            [re-frame.mcp-conformance.fixtures :as fx]))
 
 ;; ---------------------------------------------------------------------------
-;; Locate the repo root from the test's classpath. The test runs from
-;; `tools/mcp-conformance/wire-vocab/`; the repo root is three levels
-;; up. We resolve it from `*file*` at load time so the test is
-;; CWD-agnostic (CI runs the test-runner from various locations).
+;; Repo-root + slurp helpers live in `re-frame.mcp-conformance.fixtures`
+;; (rf2-113ti). Shared across the three conformance test namespaces in
+;; this artefact.
 ;; ---------------------------------------------------------------------------
-
-(def ^:private repo-root
-  "Absolute path to the repo root, derived from this file's location.
-  `wire_vocab_test.clj` lives at
-  `tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/`.
-  Walk up six levels to reach the repo root."
-  (let [this-file (io/file (.getPath (io/resource "re_frame/mcp_conformance/wire_vocab_test.clj")))]
-    (-> this-file
-        .getParentFile                                      ; .../mcp_conformance/
-        .getParentFile                                      ; .../re_frame/
-        .getParentFile                                      ; .../test/
-        .getParentFile                                      ; .../wire-vocab/
-        .getParentFile                                      ; .../mcp-conformance/
-        .getParentFile                                      ; .../tools/
-        .getParentFile                                      ; <repo-root>
-        .getAbsolutePath)))
-
-(defn- read-source
-  "Slurp a source file inside the repo. `rel-path` is a string path
-  segment relative to the repo root, using `/` as the separator. The
-  test fails loudly (via `slurp`'s default IOException) if the path
-  doesn't resolve — that's the right signal: a source file under
-  conformance was moved or removed."
-  [rel-path]
-  (slurp (io/file repo-root rel-path)))
 
 (defn- strip-comments-and-strings
   "Return `src` with Clojure line comments (`;` to EOL) and string
@@ -558,7 +532,7 @@
             (str "No source files registered for " server
                  " — extend `server-source-files`."))
         (is (some (fn [rel]
-                    (str/includes? (read-source rel) literal))
+                    (str/includes? (fx/read-source rel) literal))
                   files)
             (str "Literal " literal " missing from " server
                  " sources: " files))))))
@@ -573,7 +547,7 @@
           variant       (near-miss-variants key)
           rel           files]
     (testing (str server " — " rel " — near-miss " variant)
-      (is (not (str/includes? (read-source rel) variant))
+      (is (not (str/includes? (fx/read-source rel) variant))
           (str "Found near-miss variant " variant " for " key
                " in " server "/" rel
                " — this is a vocabulary-drift bug. The canonical "
@@ -587,14 +561,12 @@
 ;; surfaces here.
 ;; ---------------------------------------------------------------------------
 
-(def ^:private known-servers #{:pair2-mcp :story-mcp :causa-mcp})
-
 (deftest server-references-are-all-known
   (doseq [{:keys [key servers]} canonical-markers]
     (testing (str "marker " key " — :servers values")
-      (is (every? known-servers servers)
+      (is (every? fx/known-servers servers)
           (str "Unknown server in :servers for " key ": "
-               (remove known-servers servers))))))
+               (remove fx/known-servers servers))))))
 
 (deftest story-mcp-still-emits-zero-cross-mcp-markers
   ;; Self-documenting tripwire: the day story-mcp adopts ANY of the
@@ -624,7 +596,7 @@
     (doseq [{:keys [key]} canonical-markers
             rel           story-files]
       (testing (str "story-mcp source " rel " — " key " absence")
-        (let [stripped (strip-comments-and-strings (read-source rel))]
+        (let [stripped (strip-comments-and-strings (fx/read-source rel))]
           (is (not (str/includes? stripped (marker-key->literal key)))
               (str key " literal found in " rel
                    " (in code, after stripping comments/docstrings).\n"
@@ -732,7 +704,7 @@
     (is (seq files)
         "No source files registered for pair2-mcp envelope emit sites.")
     (doseq [rel files]
-      (let [src (read-source rel)]
+      (let [src (fx/read-source rel)]
         (testing (str "pair2-mcp " rel " — :dropped-sensitive literal")
           (is (str/includes? src ":dropped-sensitive")
               (str ":dropped-sensitive literal missing from " rel)))
@@ -762,7 +734,7 @@
     (doseq [rel  story-files
             slot slots]
       (testing (str "story-mcp source " rel " — " slot " absence")
-        (is (not (str/includes? (read-source rel) slot))
+        (is (not (str/includes? (fx/read-source rel) slot))
             (str slot " literal found in " rel
                  ".\nIf story-mcp now walks a tree-typed payload, "
                  "the OTHER envelope slot MUST land in the same commit "

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -167,36 +167,57 @@
 ;; rule is what makes the vocabulary cross-server.
 ;; ---------------------------------------------------------------------------
 
-(def OverflowBody
-  "`{:rf.mcp/overflow {...}}` body — the token-budget overflow marker.
-
-  Per causa-mcp Principles §\"1. Token budget cap\" and pair2-mcp
-  `tools.cljs/overflow-payload`. The body carries the cap that was
-  hit, an `:cap-tokens` or `:cap` cap value (pair2-mcp uses
-  `:cap-tokens`; the spec example uses `:cap`), the over-budget
-  token count, a tool-specific next-step `:hint`, and a `:limit`
-  sentinel.
-
-  pair2-mcp's payload uses `:cap-tokens` / `:token-count` (snake-cased
-  with hyphens, no underscores) and adds `:tool` for the offending
-  tool name. causa-mcp's spec example uses `:cap` / `:would-be` plus
-  a `:continuation` block with `:cursor` + `:next-args`. The
-  conformance schema permits both — the load-bearing claim is the
-  top-level marker key and the kebab-case child names. Cap renames
-  (`cap-tokens` vs `cap_tokens`) trip the schema."
+(def Pair2OverflowBody
+  "pair2-mcp's `:rf.mcp/overflow` body shape (per
+  `mcp-base/overflow.cljc/overflow-payload`). Every emit carries
+  `:cap-tokens` + `:token-count` + `:tool` + `:hint` plus the `:limit
+  :reached` sentinel. Required-not-optional — an emit missing any of
+  these is a contract break, not a degenerate but tolerated marker."
   [:map
    {:closed false}
-   [:limit [:enum :reached]]                                   ;; pair2-mcp
-   [:tool   {:optional true} [:or :string :keyword]]           ;; pair2-mcp
-   [:cap-tokens   {:optional true} :int]                       ;; pair2-mcp form
-   [:cap          {:optional true} :int]                       ;; causa-mcp form
-   [:token-count  {:optional true} :int]                       ;; pair2-mcp form
-   [:would-be     {:optional true} :int]                       ;; causa-mcp form
-   [:hint         {:optional true} [:or :string :keyword]]
+   [:limit       [:enum :reached]]
+   [:tool        [:or :string :keyword]]
+   [:cap-tokens  :int]
+   [:token-count :int]
+   [:hint        [:or :string :keyword]]])
+
+(def CausaOverflowBody
+  "causa-mcp's `:rf.mcp/overflow` body shape (per
+  `tools/causa-mcp/spec/004-Wire-Pipeline.md` §\"1. Token budget cap\").
+  Every emit carries `:cap` + `:would-be` + `:hint` plus the `:limit
+  :reached` sentinel; `:continuation` is optional and only present when
+  the server can emit a resumable cursor."
+  [:map
+   {:closed false}
+   [:limit        [:enum :reached]]
+   [:cap          :int]
+   [:would-be     :int]
+   [:hint         [:or :string :keyword]]
    [:continuation {:optional true}
     [:map
      [:cursor    {:optional true} [:or :string :nil]]
      [:next-args {:optional true} [:maybe :map]]]]])
+
+(def OverflowBody
+  "`{:rf.mcp/overflow {...}}` body — the token-budget overflow marker.
+
+  Per causa-mcp `004-Wire-Pipeline.md` §\"1. Token budget cap\" and
+  pair2-mcp `mcp-base/overflow.cljc/overflow-payload`. The cross-server
+  contract pins TWO shapes, NOT one open map:
+
+  - **pair2-mcp shape:** `:limit :reached` + `:cap-tokens` +
+    `:token-count` + `:tool` + `:hint`. Hyphen-separated child names;
+    `:cap-tokens` is the cap, `:token-count` is the over-budget count.
+  - **causa-mcp shape:** `:limit :reached` + `:cap` + `:would-be` +
+    `:hint` (+ optional `:continuation` `:cursor` / `:next-args`).
+    Same posture, server-local naming.
+
+  An emit shaped as `{:rf.mcp/overflow {:limit :reached}}` alone is
+  NOT conformant — every required field on at least one of the two
+  shapes MUST be present. Cap renames (`cap-tokens` vs `cap_tokens`),
+  field renames (`hint` vs `next-step`), or empty bodies all trip the
+  schema. Per rf2-kn8cj (refactor-audit r2 of rf2-azk9c §F-VOCAB-2)."
+  [:or Pair2OverflowBody CausaOverflowBody])
 
 (def Overflow
   "`{:rf.mcp/overflow OverflowBody}` — the wrapper shape."
@@ -464,6 +485,47 @@
           (is (>= n 2)
               (str key " is multi-server (" servers
                    ") so >=2 fixtures required, got " n)))))))
+
+(deftest overflow-empty-body-is-rejected
+  ;; rf2-kn8cj (refactor-audit r2 of rf2-azk9c §F-VOCAB-2): the previous
+  ;; `OverflowBody` schema marked every slot except `:limit` `{:optional
+  ;; true}`, so an emit shaped as `{:rf.mcp/overflow {:limit :reached}}`
+  ;; alone validated. That under-constrained the cross-server contract:
+  ;; an emit MUST carry either pair2-mcp's shape (`:cap-tokens` +
+  ;; `:token-count` + `:tool` + `:hint`) OR causa-mcp's shape (`:cap` +
+  ;; `:would-be` + `:hint` + optional `:continuation`). The schema now
+  ;; encodes both as a `[:or ...]` of required-field shapes; this gate
+  ;; pins the regression directly.
+  (testing "empty body (only :limit :reached) fails validation"
+    (is (not (m/validate Overflow {:rf.mcp/overflow {:limit :reached}}))
+        "Overflow schema must reject an emit with only :limit :reached — both pair2 and causa shapes require more fields."))
+  (testing "missing-required-pair2 fields fail validation"
+    ;; pair2 shape lacks :token-count
+    (is (not (m/validate Overflow
+                         {:rf.mcp/overflow
+                          {:limit      :reached
+                           :tool       "snapshot"
+                           :cap-tokens 5000
+                           :hint       "..."}}))
+        "pair2-shape emit missing :token-count must fail"))
+  (testing "missing-required-causa fields fail validation"
+    ;; causa shape lacks :would-be
+    (is (not (m/validate Overflow
+                         {:rf.mcp/overflow
+                          {:limit :reached
+                           :cap   5000
+                           :hint  :switch-mode}}))
+        "causa-shape emit missing :would-be must fail"))
+  (testing "hybrid (cherry-picking fields across shapes) fails"
+    ;; Mixing pair2 :cap-tokens with causa :would-be — under-specified
+    ;; for both shapes; should not validate.
+    (is (not (m/validate Overflow
+                         {:rf.mcp/overflow
+                          {:limit      :reached
+                           :cap-tokens 5000
+                           :would-be   12400
+                           :hint       "..."}}))
+        "hybrid (cap-tokens + would-be) emit must fail")))
 
 ;; ---------------------------------------------------------------------------
 ;; Source-text vocabulary pin. The literal marker key MUST appear in

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -721,6 +721,83 @@
                "form is " (marker-key->literal key))))))
 
 ;; ---------------------------------------------------------------------------
+;; JS-vs-Malli `OverflowBody` cross-encoding sanity (rf2-0zqox).
+;;
+;; `test/live-pair2-overflow.js` hand-rolls `assertOverflowBody` as a JS
+;; re-encoding of `Pair2OverflowBody`. The two encodings must agree on
+;; the same contract — that's the whole point of pinning a vocabulary
+;; conformance gate; a drift between the encodings is a vocabulary bug
+;; (a marker shape the Malli side considers valid that the JS side
+;; rejects, or vice versa). Before this gate landed, divergence could
+;; ship silently: a tightening to `Pair2OverflowBody` (e.g. promoting
+;; `:cap-tokens` from optional to required, which rf2-kn8cj just did)
+;; could pass the Malli side while the JS side hadn't been updated.
+;;
+;; The gate works by slurping the JS file and grepping for every Malli
+;; required-field substring. A field added to the Malli schema MUST
+;; appear in the JS form's hand-rolled assertions; missing a field
+;; trips this gate. Drift in the OTHER direction (JS has a check the
+;; Malli schema doesn't) is handled by the Malli schema's reject set
+;; in `overflow-empty-body-is-rejected` — together the two gates pin
+;; the cross-encoding contract from both sides.
+;;
+;; Why grep, not parse-and-execute: pulling a JS parser onto the JVM
+;; classpath to evaluate `assertOverflowBody` against a fixture would
+;; be ~50× the dependency surface for a pin that's a five-field union
+;; today. The grep set is a curated whitelist — adding a Malli field
+;; means adding one entry here; the friction is correct.
+;; ---------------------------------------------------------------------------
+
+(def ^:private live-pair2-overflow-js-rel
+  "Relative path to the hand-rolled JS assertion. Single source of truth
+  — drift here surfaces against the slurp below."
+  "tools/mcp-conformance/test/live-pair2-overflow.js")
+
+(def ^:private pair2-overflow-js-required-grep-markers
+  "Substrings the JS `assertOverflowBody` MUST contain to pin every
+  required field on `Pair2OverflowBody`. Each entry is `[malli-field
+  js-substring]` — the field for error reporting, the substring as the
+  grep target. A field added to `Pair2OverflowBody` MUST add a row
+  here; a field removed from `Pair2OverflowBody` MUST remove a row.
+  Drift surfaces as a test failure naming the missing field."
+  [[":limit :reached"
+    "body[':limit'] !== ':reached'"]
+   [":cap-tokens : int"
+    "typeof body[':cap-tokens'] !== 'number'"]
+   [":token-count : int"
+    "typeof body[':token-count'] !== 'number'"]
+   [":tool : string|keyword"
+    "typeof body[':tool'] !== 'string'"]
+   [":hint : string|keyword"
+    "typeof body[':hint'] !== 'string'"]
+   ;; Cross-field invariant: a tripped cap MUST report token-count
+   ;; STRICTLY GREATER THAN cap-tokens. The JS form pins this as a
+   ;; numeric comparison; the Malli schema doesn't model cross-field
+   ;; relationships, so this grep is the only gate on the invariant.
+   ;; A future regression that emitted a degenerate overflow with
+   ;; `:token-count == :cap-tokens` would trip here.
+   ["token-count > cap-tokens invariant"
+    "body[':token-count'] <= body[':cap-tokens']"]])
+
+(deftest js-assertOverflowBody-pins-every-pair2-overflow-required-field
+  ;; The cross-encoding sanity gate. For every required field on the
+  ;; Malli `Pair2OverflowBody` schema, the JS `assertOverflowBody`
+  ;; function MUST carry a substring that asserts the same shape.
+  ;; Missing fields trip this gate with the field name in the error.
+  (let [js-src (fx/read-source live-pair2-overflow-js-rel)]
+    (doseq [[field grep-pattern] pair2-overflow-js-required-grep-markers]
+      (testing (str "JS assertOverflowBody pins field " field)
+        (is (str/includes? js-src grep-pattern)
+            (str "Field `" field
+                 "` (Malli `Pair2OverflowBody`) is not pinned by the "
+                 "JS `assertOverflowBody` in " live-pair2-overflow-js-rel
+                 ". Looked for substring: " (pr-str grep-pattern)
+                 ".\nIf you tightened `Pair2OverflowBody`, mirror the "
+                 "change in the JS assertion; if you loosened it, "
+                 "remove the entry from "
+                 "`pair2-overflow-js-required-grep-markers`."))))))
+
+;; ---------------------------------------------------------------------------
 ;; Server-coverage pin. The set of servers each marker is contracted
 ;; against is the *current* state; this test prints it on `--verbose`
 ;; so a reviewer sees the shape. It also asserts the only servers we

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -91,71 +91,10 @@
 ;; this artefact.
 ;; ---------------------------------------------------------------------------
 
-(defn- strip-comments-and-strings
-  "Return `src` with Clojure line comments (`;` to EOL) and string
-  literals (`\"...\"`, including docstrings) replaced by single
-  spaces. Preserves line structure for accurate error reporting up
-  the stack.
-
-  Used by the `story-mcp-still-emits-zero-cross-mcp-markers` tripwire
-  (and any other absence-pin that wants to distinguish *emissions*
-  from *documentation*). story-mcp re-uses mcp-base's overflow
-  machinery — the marker IS emitted on its wire, but not via an
-  inline literal in story-mcp's own source. Docstring/comment
-  references to `:rf.mcp/overflow` and `:rf.size/large-elided`
-  (rf2-7dnct introduced them, rf2-xx42k filed the drift) are
-  documentation, not emissions; this helper lets the absence-pin
-  ignore them.
-
-  Implementation: simple state machine over the raw text. Tracks two
-  states (in-string vs in-comment) with `\\` escape handling inside
-  strings. Not a full Clojure reader — character literals (`\\;`),
-  regex literals (`#\"...\"`), and `#_` reader-discards are not
-  modelled. Those edge cases don't matter for our pin: we strip
-  conservatively (false-positive whitelisting would be the bug; a
-  missed string is OK because the marker still wouldn't appear in a
-  bare character literal or a regex pattern targeting it)."
-  [src]
-  (let [n  (count src)
-        sb (StringBuilder. n)]
-    (loop [i 0, in-string? false, in-comment? false]
-      (if (>= i n)
-        (.toString sb)
-        (let [c (.charAt ^String src i)]
-          (cond
-            in-comment?
-            (do (.append sb (if (= c \newline) c \space))
-                (recur (inc i) false (not= c \newline)))
-
-            in-string?
-            (cond
-              ;; escape: skip the next char (consume both as space, preserving newlines)
-              (= c \\)
-              (do (.append sb \space)
-                  (when (< (inc i) n)
-                    (let [nx (.charAt ^String src (inc i))]
-                      (.append sb (if (= nx \newline) nx \space))))
-                  (recur (+ i 2) true false))
-
-              (= c \")
-              (do (.append sb \space)
-                  (recur (inc i) false false))
-
-              :else
-              (do (.append sb (if (= c \newline) c \space))
-                  (recur (inc i) true false)))
-
-            (= c \;)
-            (do (.append sb \space)
-                (recur (inc i) false true))
-
-            (= c \")
-            (do (.append sb \space)
-                (recur (inc i) true false))
-
-            :else
-            (do (.append sb c)
-                (recur (inc i) false false))))))))
+;; `strip-comments-and-strings` lives in
+;; `re-frame.mcp-conformance.fixtures` (rf2-rto1l) — promoted from a
+;; private defn here so all three conformance test namespaces can share
+;; the same documentation-vs-emission discrimination logic.
 
 ;; ---------------------------------------------------------------------------
 ;; Canonical schemas. Single source of truth.
@@ -663,7 +602,7 @@
           ;; literal as data after comment/string stripping.
           (seq emit-files)
           (is (some (fn [rel]
-                      (let [stripped (strip-comments-and-strings
+                      (let [stripped (fx/strip-comments-and-strings
                                        (fx/read-source rel))]
                         (str/includes? stripped literal)))
                     emit-files)
@@ -840,7 +779,7 @@
     (doseq [{:keys [key]} canonical-markers
             rel           story-files]
       (testing (str "story-mcp source " rel " — " key " absence")
-        (let [stripped (strip-comments-and-strings (fx/read-source rel))]
+        (let [stripped (fx/strip-comments-and-strings (fx/read-source rel))]
           (is (not (str/includes? stripped (marker-key->literal key)))
               (str key " literal found in " rel
                    " (in code, after stripping comments/docstrings).\n"

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -533,24 +533,69 @@
 ;; pluralised, mis-pluralised) MUST NOT appear. A rename in the
 ;; framework or in either server surfaces here — the schema is one
 ;; gate, the literal-occurrence pin is the second.
+;;
+;; The pin is split in two (rf2-vj8y3, refactor-audit r2 of rf2-azk9c
+;; §F-VOCAB-1 + F-VOCAB-3):
+;;
+;; - **emit-sources** — source files where the literal MUST appear as
+;;   actual data (not in a comment or docstring). Stripped via
+;;   `strip-comments-and-strings` before the grep. A rename in any of
+;;   these files MUST trip the test even if a docstring elsewhere still
+;;   carries the old form.
+;; - **doc-sources** — spec docs and prose-y descriptors where the
+;;   literal SHOULD appear for human readers. Looser — a `str/includes?`
+;;   against raw text suffices; documentation reorganisation may move
+;;   the mention around without tripping the gate.
+;;
+;; The pre-rf2-vj8y3 pin grepped `tools.cljs` + `Principles.md` +
+;; `003-Tool-Catalogue.md` with `some`, which passed because the spec
+;; docs prose-referenced every marker — even though four of five
+;; literals did not appear in any pair2-mcp source code AT ALL (they
+;; were imported via `re-frame.mcp-base.vocab/<key>`). A rename inside
+;; `mcp-base/vocab.cljc` (the canonical home of every literal) didn't
+;; trip the gate. The new emit-side pin closes that hole.
 ;; ---------------------------------------------------------------------------
 
-(def ^:private server-source-files
-  "Files we grep for marker literals, per server. The lists are
-  hand-curated — adding a new emission surface to a server requires
-  extending this map (which is the right friction: the conformance
-  contract knows where each server's wire boundary lives)."
-  {:pair2-mcp ["tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs"
-               "tools/pair2-mcp/spec/Principles.md"
+(def ^:private emit-source-files
+  "Per-server source files where the marker literal MUST appear as
+  DATA (not in a docstring/comment). The literal is `pr-str`'d on a
+  per-marker basis and grepped against the file's text AFTER
+  `strip-comments-and-strings` has neutered docstring/comment mentions.
+
+  For pair2-mcp the canonical literal home is `mcp-base/vocab.cljc` —
+  every wire marker keyword is declared once there (`overflow-key`,
+  `summary-key`, `dedup-table-key`, `diff-from-key`,
+  `large-elided-key`) and pair2-mcp consumes the symbol, not the
+  literal. A rename to ANY of those `def` values trips this pin
+  regardless of which pair2-mcp tool source emits the marker — which
+  is the right invariant; emit-sites that import from vocab.cljc
+  cannot drift independently of the canonical declaration.
+
+  causa-mcp has no `src/` today — the marker literals only appear in
+  its spec text. That's the doc-source gate's job; the emit-source set
+  is empty until impl lands."
+  {:pair2-mcp ["tools/mcp-base/src/re_frame/mcp_base/vocab.cljc"]
+   :causa-mcp []
+   :story-mcp []})
+
+(def ^:private doc-source-files
+  "Per-server prose-y sources where the marker literal SHOULD appear
+  for human readers (specs, descriptors, catalogues). Looser
+  match — a raw `str/includes?` suffices; docs may rearrange prose
+  without tripping the gate. Drift here means the docs lag, not that
+  the emit broke."
+  {:pair2-mcp ["tools/pair2-mcp/spec/Principles.md"
                "tools/pair2-mcp/spec/003-Tool-Catalogue.md"]
    :causa-mcp ["tools/causa-mcp/spec/Principles.md"
                "tools/causa-mcp/spec/004-Wire-Pipeline.md"
                "tools/causa-mcp/spec/DESIGN-RATIONALE.md"]
-   ;; story-mcp does not currently emit any cross-MCP wire markers
-   ;; (it uses its own :rf.story/* + :rf.assert/* + :rf.error/*
-   ;; vocabularies). When story-mcp adopts a marker, add a fixture
-   ;; AND extend this list — the test enforces both.
    :story-mcp []})
+
+(def ^:private all-source-files
+  "Union of emit-sources and doc-sources, by server. Used by the
+  near-miss anti-pin: we want to forbid near-miss spellings anywhere
+  in any conformance-tracked file, not just emit-sites."
+  (merge-with into emit-source-files doc-source-files))
 
 (defn- marker-key->literal
   "Render a marker key as the literal string that MUST appear in the
@@ -584,28 +629,88 @@
       (into [(str s "s")                                   ;; pluralised
              (str s "?")]))))                              ;; predicate form
 
-(deftest marker-literal-appears-in-every-contracted-server-source
+(deftest marker-literal-appears-in-every-contracted-server-emit-source
+  ;; The load-bearing pin: every marker literal each server is
+  ;; contracted to emit MUST appear as DATA (not docstring/comment) in
+  ;; at least one of the registered emit-source files. The
+  ;; `strip-comments-and-strings` walker is applied before the grep so
+  ;; a rename inside the canonical declaration site (pair2-mcp's
+  ;; `mcp-base/vocab.cljc`) trips the gate even if old docstrings still
+  ;; mention the prior name.
+  ;;
+  ;; story-mcp emits zero markers today — its servers entry is empty in
+  ;; `canonical-markers/:servers`, so this loop never iterates over it.
+  ;; causa-mcp's emit-source set is empty until `tools/causa-mcp/src/`
+  ;; lands; the `is (seq emit-files)` assertion fires loud when it
+  ;; does, forcing the reviewer to extend `emit-source-files`.
   (doseq [{:keys [key servers]} canonical-markers
           server                servers]
-    (testing (str "marker " key " literal in " server " sources")
-      (let [literal (marker-key->literal key)
-            files   (get server-source-files server)]
-        (is (seq files)
-            (str "No source files registered for " server
-                 " — extend `server-source-files`."))
+    (testing (str "marker " key " literal in " server " emit-sources")
+      (let [literal    (marker-key->literal key)
+            emit-files (get emit-source-files server)
+            doc-files  (get doc-source-files server)]
+        ;; A server with zero emit-sources AND zero doc-sources is a
+        ;; gap — either impl-not-landed (causa-mcp before src/ lands;
+        ;; the `causa-mcp-impl-still-absent` deftest in the sibling
+        ;; namespaces covers that posture explicitly) or a missing
+        ;; catalogue entry the reviewer must add.
+        (is (or (seq emit-files) (seq doc-files))
+            (str "No emit-sources or doc-sources registered for "
+                 server " — extend `emit-source-files` or "
+                 "`doc-source-files`."))
+        (cond
+          ;; pair2-mcp / impl-landed path: emit-sources MUST carry the
+          ;; literal as data after comment/string stripping.
+          (seq emit-files)
+          (is (some (fn [rel]
+                      (let [stripped (strip-comments-and-strings
+                                       (fx/read-source rel))]
+                        (str/includes? stripped literal)))
+                    emit-files)
+              (str "Literal " literal
+                   " missing from " server " EMIT-sources " emit-files
+                   " (checked AFTER stripping docstrings/comments). "
+                   "If the canonical declaration moved, update "
+                   "`emit-source-files`."))
+
+          ;; causa-mcp / impl-not-landed path: spec-text coverage only.
+          ;; Doc-sources are the looser pin — raw `str/includes?`.
+          :else
+          (is (some (fn [rel]
+                      (str/includes? (fx/read-source rel) literal))
+                    doc-files)
+              (str "Literal " literal " missing from " server
+                   " DOC-sources " doc-files
+                   ". (No emit-sources registered; spec-text coverage "
+                   "is the impl-not-landed stand-in.)")))))))
+
+(deftest marker-literal-appears-in-pair2-mcp-doc-sources
+  ;; Defence-in-depth: pair2-mcp's spec/descriptor docs SHOULD also
+  ;; carry each emitted-marker literal for human readers. Looser pin —
+  ;; raw `str/includes?` allows docstring mentions; the load-bearing
+  ;; check is the emit-source pin above. Drift here means the docs
+  ;; lag, not that the emit shape broke.
+  (doseq [{:keys [key servers]} canonical-markers
+          :when                 (contains? servers :pair2-mcp)]
+    (testing (str "marker " key " literal in pair2-mcp doc-sources")
+      (let [literal   (marker-key->literal key)
+            doc-files (get doc-source-files :pair2-mcp)]
         (is (some (fn [rel]
                     (str/includes? (fx/read-source rel) literal))
-                  files)
-            (str "Literal " literal " missing from " server
-                 " sources: " files))))))
+                  doc-files)
+            (str "Literal " literal
+                 " missing from pair2-mcp doc-sources " doc-files
+                 ". The docs may have re-organised the prose; either "
+                 "restore the mention or update `doc-source-files`."))))))
 
 (deftest no-near-miss-variants-appear-in-any-server-source
   ;; Defence-in-depth: a rename to a near-miss form (e.g. snake_case)
   ;; would slip past the literal-presence test if the canonical form
   ;; ALSO still appears somewhere. This test makes sure no near-miss
-  ;; co-exists alongside the canonical.
+  ;; co-exists alongside the canonical — across BOTH emit-sources AND
+  ;; doc-sources (drift in either is a vocabulary-drift bug).
   (doseq [{:keys [key]} canonical-markers
-          [server files] server-source-files
+          [server files] all-source-files
           variant       (near-miss-variants key)
           rel           files]
     (testing (str server " — " rel " — near-miss " variant)


### PR DESCRIPTION
## Summary

Six-bead polish cluster on `tools/mcp-conformance/`, all follow-ons from the rf2-azk9c round-2 audit (`ai/findings/refactor-audit-r2-tools-mcp-conformance-2026-05-14.md`). One commit per bead; each focused on one finding.

| Bead | Priority | Finding | Commit |
|---|---|---|---|
| rf2-113ti | P1 | F-DEDUP-1 + F-DEDUP-3 | Extract `repo-root` + `read-source` + `known-servers` to a shared `re-frame.mcp-conformance.fixtures` ns; reduces per-test-ns ceremony to one `:require`. |
| rf2-kn8cj | P1 | F-VOCAB-2 | Tighten `OverflowBody` Malli schema: split into `Pair2OverflowBody` + `CausaOverflowBody` with all-required fields; `[:or ...]` rejects empty-bodied markers. Regression deftest pins four reject scenarios. |
| rf2-vj8y3 | P0 | F-VOCAB-1 + F-VOCAB-3 | Split pair2-mcp source-text pin into `emit-source-files` (load-bearing, strip-then-grep against `mcp-base/vocab.cljc`) + `doc-source-files` (looser, raw grep). The previous pin passed because the spec docs prose-mentioned each marker — a rename in the canonical `vocab.cljc` declaration didn't trip the gate. |
| rf2-8n7q4 | P1 | F-DOC-1 | `NAMING.md` + `README.md` said pair2-mcp ships 10 tools; the conformance test pins 11 (`subscription-info` since rf2-zjz9q). Docs updated; `subscription-info` row added with non-conformant annotation pointing at causa-mcp's `list-subscriptions`. |
| rf2-0zqox | P1 | F-EMIT-1 | JVM gate that grep-asserts the JS `assertOverflowBody` carries every required `Pair2OverflowBody` field. Cross-encoding drift now surfaces with the field name; the inverse direction is covered by `overflow-empty-body-is-rejected` (rf2-kn8cj). |
| rf2-rto1l | P0 | F-CI-1 | New `mcp-conformance-wire-vocab` job in `.github/workflows/test.yml` runs `clojure -M:test` from `tools/mcp-conformance/wire-vocab/`. Three pre-existing red gates on main bundled as prerequisites (anti-pin strip-comments posture, stale story-mcp source path, `:max-tokens` literal location). |

## Test plan

- [x] `cd tools/mcp-conformance/wire-vocab && clojure -M:test` — 28 tests, 435 assertions, 0 failures, 0 errors
- [x] No production source touched — bundle-isolation contract holds by construction (changes are tests + workflow YAML + docs inside `tools/mcp-conformance/`)
- [x] CI runs the new `mcp-conformance-wire-vocab` job on push + PR
- [ ] CI verifies green on this PR

## Files touched

- `.github/workflows/test.yml` — `mcp-conformance-wire-vocab` job (5 steps)
- `tools/mcp-conformance/NAMING.md` — 10 → 11 tools; `subscription-info` row
- `tools/mcp-conformance/README.md` — "ten" → "eleven"
- `tools/mcp-conformance/test/live-pair2-overflow.js` — cross-encoding doc-comment pointing at the JVM gate
- `tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj` — new shared helpers ns
- `tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj` — schema tightening, emit/doc split, cross-encoding gate
- `tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj` — strip-then-grep posture
- `tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj` — stale source paths corrected

LoC delta: 6 commits, +508 / -110 across 8 files. The `fixtures.clj` extraction (+150) is offset by removal of duplicated boilerplate (-100); the schema-tightening + cross-encoding additions are the substantive growth.