### PR TITLE
refactor(core): tail polish — 4 follow-on beads (rf2-byut1)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -86,6 +86,31 @@
     (when-not (get-in f [:lifecycle :destroyed?])
       f)))
 
+(defn frame-disposed-for-drain?
+  "Per rf2-68kok / Spec 002 §Frame disposal mid-drain: predicate used
+  by the router's drain loop to interrupt a pass when the frame was
+  destroyed mid-cycle. True when EITHER:
+
+    (a) The frame record still exists but `:destroyed?` is flipped
+        (post-step-3 of `destroy-frame!`, before step-6 dissoc), OR
+    (b) The frame record is absent from the `frames` atom (post-step-6
+        of `destroy-frame!` — the dissoc step has run).
+
+  Returns false when `id` is registered and not destroyed. Calling for
+  a never-registered `id` returns true — that case is benign for the
+  drain-loop caller (a drain cannot run on a frame that was never
+  registered), but the predicate is named `*-for-drain?` to make the
+  intended seam explicit and avoid suggesting general
+  destroyed-vs-never-registered discrimination."
+  [id]
+  (if-let [f (get @frames id)]
+    (true? (get-in f [:lifecycle :destroyed?]))
+    ;; Absent from the atom — destroy-frame!'s step 6 ran, OR the id
+    ;; was never registered. The drain-loop caller only consults this
+    ;; while a pass is already in flight, so the latter case cannot
+    ;; arise from that seam.
+    true))
+
 (defn frame-meta
   "Per Spec 002 §The public registrar query API and Spec-Schemas
   §`:rf/frame-meta`: return the effective metadata map for a frame as a

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -248,16 +248,36 @@
         (nil? existing)
         (let [f (new-frame-record id config)]
           (swap! frames assoc id f)
-          ;; Run :on-create events synchronously BEFORE emitting :frame/created.
-          ;; Per Spec 002 §Frame creation: on-create completes first, then
-          ;; the frame is observable to listeners. The router/dispatch
-          ;; namespace handles dispatch-sync; we forward via the late-bind
-          ;; registry to avoid a cyclic dep at compile time. (`resolve` is
-          ;; not a runtime fn in CLJS, so the older `(resolve 'router/...)`
-          ;; pattern silently no-op'd in CLJS — see rf2-p8g8.)
+          ;; Run :on-create events BEFORE emitting :frame/created.
+          ;; Per Spec 002 §Frame creation: on-create completes (or — for
+          ;; the in-handler case below — is queued) first, then the
+          ;; frame is observable to listeners. The router/dispatch
+          ;; namespace handles dispatch / dispatch-sync; we forward via
+          ;; the late-bind registry to avoid a cyclic dep at compile
+          ;; time. (`resolve` is not a runtime fn in CLJS, so the older
+          ;; `(resolve 'router/...)` pattern silently no-op'd in CLJS —
+          ;; see rf2-p8g8.)
+          ;;
+          ;; Per rf2-cufbh / Spec 002 §`reg-frame` / `make-frame` called
+          ;; from inside a handler: when a handler creates a child
+          ;; frame mid-cascade, the child's `:on-create` MUST be queued
+          ;; asynchronously on the child's router (not dispatch-sync'd)
+          ;; — synchronous dispatch-sync from inside a handler is an
+          ;; error per Spec 002 §dispatch-sync inside a handler is an
+          ;; error, and even were it permitted the two cascades would
+          ;; interleave (the no-cross-frame-drain rule in Spec 002
+          ;; §Run-to-completion forbids that). The signal for "inside
+          ;; a handler" is `frame/*current-frame*` being bound — the
+          ;; router binds it in `process-event!` for the duration of
+          ;; the cascade.
           (when-let [on-create (:on-create config)]
-            (when-let [dispatch-sync (late-bind/get-fn :router/dispatch-sync!)]
-              (dispatch-sync on-create {:frame id})))
+            (if *current-frame*
+              ;; Handler-created child frame: async-queue on the child.
+              (when-let [dispatch (late-bind/get-fn :router/dispatch!)]
+                (dispatch on-create {:frame id}))
+              ;; Top-level (no in-flight cascade): synchronous, as before.
+              (when-let [dispatch-sync (late-bind/get-fn :router/dispatch-sync!)]
+                (dispatch-sync on-create {:frame id}))))
           (trace/emit! :frame :frame/created
                        {:frame id :config config})
           id)

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -724,12 +724,41 @@
         (swap! router update :queue pop)
         envelope))))
 
+(defn- handle-drain-interrupted!
+  "Per rf2-68kok / Spec 002 §Edge cases worth pinning §Frame disposal
+  mid-drain: the drain-loop detected the frame was destroyed before
+  the next dequeue. Drop the remaining queue ONCE, clear `:scheduled?`,
+  and emit a single `:rf.frame/drain-interrupted` lifecycle trace
+  carrying `:dropped-count` (per Spec 009 §`:rf.frame/drain-interrupted`
+  and Spec-Schemas §DrainInterruptedTags).
+
+  In-flight events are not affected — they have already been dequeued
+  and `process-event!` ran them to completion before this check fires
+  (run-to-completion per Spec 002 §Rules rule 1). Only events still
+  in the queue at the moment of the check are dropped.
+
+  The check fires AFTER `process-event!` returns and BEFORE the next
+  `take-event!` — same seam as `handle-depth-exceeded!`."
+  [frame-id router]
+  (let [dropped (count (:queue @router))]
+    (swap! router assoc :queue interop/empty-queue :scheduled? false)
+    (trace/emit! :frame :rf.frame/drain-interrupted
+                 {:frame         frame-id
+                  :dropped-count dropped})))
+
 (defn- run-one-pass!
   "Process events from the queue to fixed point or until `drain-depth` is
   exceeded. Returns `::settled` when the queue empties cleanly or
-  `::halt` when the depth limit is reached (the depth-exceeded handler
-  has already cleared the queue and the `:scheduled?` flag in that
-  case).
+  `::halt` when the depth limit is reached OR the frame was destroyed
+  mid-pass (the depth-exceeded / drain-interrupted handler has already
+  cleared the queue and the `:scheduled?` flag in either halt case).
+
+  Per rf2-68kok / Spec 002 §Frame disposal mid-drain: the destroyed-
+  frame check fires BEFORE each dequeue, so an in-flight event runs to
+  completion (run-to-completion per Spec 002 §Rules rule 1) but events
+  still in the queue at the check point are dropped, with one
+  `:rf.frame/drain-interrupted` lifecycle trace emitted carrying the
+  dropped count.
 
   Each pass takes its pre-cascade `db-before` snapshot from the caller
   so the epoch settle callback (Tool-Pair §Time-travel) sees the right
@@ -740,6 +769,20 @@
     (cond
       (>= depth drain-depth)
       (do (handle-depth-exceeded! frame-id router db-before depth last-event)
+          ::halt)
+
+      ;; Per rf2-68kok: destroyed-frame check fires BEFORE the next
+      ;; dequeue. A handler in the just-completed event may have
+      ;; called `destroy-frame!` on its own frame; the spec calls for
+      ;; interrupting the drain at this exact seam — drop the
+      ;; remaining queue, emit one `:rf.frame/drain-interrupted`
+      ;; lifecycle event, halt. The just-completed event already ran
+      ;; in full (run-to-completion). Skip the epoch settle on
+      ;; interrupt — destroy-frame's `:epoch/on-frame-destroyed` hook
+      ;; covers epoch cleanup and a half-cascade settle record would
+      ;; mislead time-travel consumers.
+      (frame/frame-disposed-for-drain? frame-id)
+      (do (handle-drain-interrupted! frame-id router)
           ::halt)
 
       :else

--- a/implementation/core/src/re_frame/std_interceptors.cljc
+++ b/implementation/core/src/re_frame/std_interceptors.cljc
@@ -42,17 +42,25 @@
                       (get-in (:db (:coeffects ctx)) path-vec))))
       :after
       (fn [ctx]
+        ;; Per rf2-rwlj2: the splice-back only fires when the handler
+        ;; actually emitted a `:db` effect. If the handler returned no
+        ;; `:db`, the slice didn't change and we MUST NOT synthesise a
+        ;; `:db` effect — downstream tools rely on "no `:db` effect = no
+        ;; DB write" (the docstring contract). The original code
+        ;; unconditionally wrote `:db`, which was idempotent at the
+        ;; value level (same `original-db` re-spliced with the same
+        ;; pre-handler slice) but allocated a fresh map per path-walk-
+        ;; step and produced a spurious `:db` effect from a no-`:db`
+        ;; handler.
         (let [stack       (:rf/path-stack ctx [])
               original-db (peek stack)
               new-stack   (pop stack)
-              ;; The handler may or may not have produced a new :db;
-              ;; if it didn't, the slice didn't change.
-              new-slice   (or (get-in ctx [:effects :db])
-                              (get-in ctx [:coeffects :db]))]
-          (-> ctx
-              (assoc :rf/path-stack new-stack)
-              (assoc-in [:effects :db]
-                        (assoc-in original-db path-vec new-slice))))))))
+              handler-emitted-db? (contains? (:effects ctx) :db)]
+          (cond-> (assoc ctx :rf/path-stack new-stack)
+            handler-emitted-db?
+            (assoc-in [:effects :db]
+                      (assoc-in original-db path-vec
+                                (get-in ctx [:effects :db])))))))))
 
 ;; ---- unwrap ---------------------------------------------------------------
 ;;

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -336,6 +336,145 @@
           (is (< run-end-idx created-idx)
               ":on-create's :run-end precedes :frame/created — frame is fully booted before listeners observe it"))))))
 
+;; ---- rf2-68kok — destroy-frame interrupts active drain on next dequeue --
+;;
+;; Per Spec 002 §Edge cases worth pinning §Frame disposal mid-drain: the
+;; drain loop checks `(:destroyed? (:lifecycle frame))` before each
+;; dequeue; on detect it stops, drops the remaining queue, and emits one
+;; `:rf.frame/drain-interrupted` with the dropped count. In-flight events
+;; finish (run-to-completion); only events not yet dequeued are dropped.
+
+(deftest destroy-from-handler-interrupts-drain-and-emits-interrupted
+  (testing "a handler that destroys its own frame mid-drain stops the
+            drain, drops the remaining queue, and emits exactly one
+            :rf.frame/drain-interrupted carrying the dropped count.
+            The just-completed event runs to completion (run-to-
+            completion); only later queued events are dropped"
+    (rf/reg-frame :drain-int/worker {:doc "rf2-68kok drain-interrupt frame"})
+    (let [ran (atom [])
+          traces (atom [])]
+      ;; Plain mutator — runs whenever the drain dequeues.
+      (rf/reg-event-db :drain-int/tick
+        (fn [db _]
+          (swap! ran conj :tick)
+          (update db :n (fnil inc 0))))
+      ;; Handler that destroys its own frame mid-cascade. The first
+      ;; tick has already run; destroy mid-drain MUST interrupt the
+      ;; remainder.
+      (rf/reg-event-fx :drain-int/self-destruct
+        (fn [_ _]
+          (swap! ran conj :self-destruct)
+          ;; Call destroy-frame! directly — bypasses the
+          ;; `dispatch-sync-in-handler` policy that would otherwise
+          ;; bite us if we tried to dispatch destruction through the
+          ;; router. Spec 002 says destroy-frame interrupts the
+          ;; ACTIVE drain; the trigger can be anything.
+          (frame/destroy-frame! :drain-int/worker)
+          {}))
+      (rf/register-trace-cb! ::drain-int (fn [ev] (swap! traces conj ev)))
+      ;; Sync-drain a sequence: two ticks, the self-destruct, then two
+      ;; more ticks. The first two ticks AND the self-destruct must run;
+      ;; the two trailing ticks must be dropped with one
+      ;; :rf.frame/drain-interrupted emitted.
+      ;;
+      ;; Note: the seed event of `dispatch-sync!` is the self-destruct;
+      ;; pre-seed the queue with the other events as plain async
+      ;; dispatches first. dispatch-sync's drain runs against the front-
+      ;; seeded queue and drains to settled (or interrupted).
+      (rf/dispatch [:drain-int/tick] {:frame :drain-int/worker})
+      (rf/dispatch [:drain-int/tick] {:frame :drain-int/worker})
+      (rf/dispatch [:drain-int/tick] {:frame :drain-int/worker})
+      (rf/dispatch [:drain-int/tick] {:frame :drain-int/worker})
+      ;; Now sync-drain the self-destruct AT THE FRONT — it runs first,
+      ;; destroys the frame, and the remaining 4 ticks (still queued)
+      ;; must be dropped.
+      (rf/dispatch-sync [:drain-int/self-destruct] {:frame :drain-int/worker})
+      (rf/remove-trace-cb! ::drain-int)
+
+      ;; The self-destruct ran first (dispatch-sync seeds at the front);
+      ;; the trailing ticks did NOT run.
+      (is (= [:self-destruct] @ran)
+          "the only handler that ran was the self-destruct seed itself")
+
+      ;; The frame is gone.
+      (is (nil? (frame/frame :drain-int/worker))
+          "destroy-frame! removed the frame from the registry")
+
+      ;; Exactly one :rf.frame/drain-interrupted trace fired carrying
+      ;; the dropped count (4 ticks queued before the seed).
+      (let [interrupts (filterv (fn [ev]
+                                  (= :rf.frame/drain-interrupted (:operation ev)))
+                                @traces)]
+        (is (= 1 (count interrupts))
+            "exactly one :rf.frame/drain-interrupted trace")
+        (let [ev (first interrupts)]
+          (is (= :frame (:op-type ev))
+              ":op-type is :frame (lifecycle family, not :error)")
+          (is (= :drain-int/worker (:frame (:tags ev)))
+              ":tags carries the destroyed frame id")
+          (is (= 4 (:dropped-count (:tags ev)))
+              ":dropped-count reflects the 4 trailing ticks left in the queue"))))))
+
+(deftest destroy-from-handler-in-flight-event-still-completes
+  (testing "the in-flight event finishes (run-to-completion) — destroy
+            interrupts AFTER the current handler returns, not in
+            the middle of it"
+    (rf/reg-frame :rtc/worker {})
+    (let [completed (atom false)]
+      ;; This handler:
+      ;;   (a) destroys the frame partway through
+      ;;   (b) keeps running — does more work after the destroy call
+      ;;   (c) sets the completion flag at the very end
+      ;; Per run-to-completion, ALL of (a)-(c) must observe in order;
+      ;; the drain interrupt only fires AFTER this handler returns.
+      (rf/reg-event-fx :rtc/work-then-destroy
+        (fn [_ _]
+          (frame/destroy-frame! :rtc/worker)
+          ;; Post-destroy bookkeeping still runs inside this handler.
+          (reset! completed true)
+          {}))
+      (rf/dispatch-sync [:rtc/work-then-destroy] {:frame :rtc/worker})
+      (is (true? @completed)
+          "handler ran to completion AFTER calling destroy-frame!"))))
+
+(deftest destroy-from-different-thread-also-interrupts-drain-on-next-pass
+  (testing "if another thread (or the same thread between passes)
+            destroys the frame, the next pass's destroyed-check fires
+            and interrupts the drain just the same"
+    (rf/reg-frame :cross-thread/worker {})
+    (let [traces (atom [])
+          captured-tick (atom [])]
+      (rf/reg-event-db :cross-thread/tick (fn [db _] db))
+      (rf/register-trace-cb! ::xt (fn [ev] (swap! traces conj ev)))
+      ;; Capture the executor's tick so we can land destroy BETWEEN
+      ;; the async dispatch and the actual drain.
+      (with-redefs [interop/next-tick (fn [f] (swap! captured-tick conj f) nil)]
+        (rf/dispatch [:cross-thread/tick] {:frame :cross-thread/worker})
+        (rf/dispatch [:cross-thread/tick] {:frame :cross-thread/worker})
+        (rf/dispatch [:cross-thread/tick] {:frame :cross-thread/worker})
+        ;; All 3 in queue, drain captured (not yet run).
+        )
+      ;; Destroy BEFORE the drain runs. drain-try!'s outer guard
+      ;; (`when frame-record`) catches this case and never enters
+      ;; the drain loop at all — that's the existing rf2-dpny
+      ;; contract and our new interrupt-handler doesn't fire here
+      ;; (the drain pass never starts).
+      (frame/destroy-frame! :cross-thread/worker)
+      ;; Run captured ticks. Pre-destroy drain-try! sees nil
+      ;; frame-record and short-circuits without emitting
+      ;; :rf.frame/drain-interrupted (the drain never started).
+      (doseq [tick @captured-tick] (tick))
+      (rf/remove-trace-cb! ::xt)
+      ;; The pre-existing rf2-dpny contract: NO trace at all from the
+      ;; drain itself. The interrupt trace only fires when a drain
+      ;; pass actually STARTED on a live frame and then detected
+      ;; destruction mid-pass.
+      (let [interrupts (filter #(= :rf.frame/drain-interrupted (:operation %))
+                               @traces)]
+        (is (zero? (count interrupts))
+            "no :rf.frame/drain-interrupted — the drain never started
+             on the already-destroyed frame")))))
+
 ;; ---- rf2-cufbh — child-frame :on-create is queued asynchronously --------
 ;;
 ;; Per Spec 002 §`reg-frame` / `make-frame` called from inside a handler:

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -351,8 +351,9 @@
             The just-completed event runs to completion (run-to-
             completion); only later queued events are dropped"
     (rf/reg-frame :drain-int/worker {:doc "rf2-68kok drain-interrupt frame"})
-    (let [ran (atom [])
-          traces (atom [])]
+    (let [ran           (atom [])
+          traces        (atom [])
+          captured-tick (atom [])]
       ;; Plain mutator — runs whenever the drain dequeues.
       (rf/reg-event-db :drain-int/tick
         (fn [db _]
@@ -372,23 +373,32 @@
           (frame/destroy-frame! :drain-int/worker)
           {}))
       (rf/register-trace-cb! ::drain-int (fn [ev] (swap! traces conj ev)))
-      ;; Sync-drain a sequence: two ticks, the self-destruct, then two
-      ;; more ticks. The first two ticks AND the self-destruct must run;
-      ;; the two trailing ticks must be dropped with one
-      ;; :rf.frame/drain-interrupted emitted.
+      ;; Pre-seed the queue with 4 plain async dispatches, then sync-
+      ;; drain the self-destruct AT THE FRONT — it runs first, destroys
+      ;; the frame, and the remaining 4 ticks (still queued) must be
+      ;; dropped, with exactly one :rf.frame/drain-interrupted emitted.
       ;;
-      ;; Note: the seed event of `dispatch-sync!` is the self-destruct;
-      ;; pre-seed the queue with the other events as plain async
-      ;; dispatches first. dispatch-sync's drain runs against the front-
-      ;; seeded queue and drains to settled (or interrupted).
-      (rf/dispatch [:drain-int/tick] {:frame :drain-int/worker})
-      (rf/dispatch [:drain-int/tick] {:frame :drain-int/worker})
-      (rf/dispatch [:drain-int/tick] {:frame :drain-int/worker})
-      (rf/dispatch [:drain-int/tick] {:frame :drain-int/worker})
-      ;; Now sync-drain the self-destruct AT THE FRONT — it runs first,
-      ;; destroys the frame, and the remaining 4 ticks (still queued)
-      ;; must be dropped.
-      (rf/dispatch-sync [:drain-int/self-destruct] {:frame :drain-int/worker})
+      ;; Per rf2-68kok JVM-vs-CLJS race fix: the JVM `interop/next-tick`
+      ;; runs on a separate single-thread executor; without redef'ing it
+      ;; the async drain races the main thread and may drain the 4 ticks
+      ;; BEFORE `dispatch-sync` reaches the drain-lock — leaving an empty
+      ;; queue and yielding `:dropped-count 0`. CLJS `next-tick` is a
+      ;; microtask in the same JS task and cannot run until the test's
+      ;; synchronous stack unwinds, so the race is JVM-only. Capturing
+      ;; the scheduled drains via `with-redefs` makes the ordering
+      ;; deterministic on both platforms — by the time `dispatch-sync`
+      ;; runs, the 4 ticks are still in the queue and no async drainer
+      ;; has touched the drain-lock. The captured drains are discarded
+      ;; (the frame is destroyed before any of them would dequeue, and
+      ;; rf2-dpny says a drain on an already-destroyed frame is a silent
+      ;; no-op — the existing `destroy-from-different-thread-also-…`
+      ;; test pins that contract separately).
+      (with-redefs [interop/next-tick (fn [f] (swap! captured-tick conj f) nil)]
+        (rf/dispatch [:drain-int/tick] {:frame :drain-int/worker})
+        (rf/dispatch [:drain-int/tick] {:frame :drain-int/worker})
+        (rf/dispatch [:drain-int/tick] {:frame :drain-int/worker})
+        (rf/dispatch [:drain-int/tick] {:frame :drain-int/worker})
+        (rf/dispatch-sync [:drain-int/self-destruct] {:frame :drain-int/worker}))
       (rf/remove-trace-cb! ::drain-int)
 
       ;; The self-destruct ran first (dispatch-sync seeds at the front);

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -336,6 +336,130 @@
           (is (< run-end-idx created-idx)
               ":on-create's :run-end precedes :frame/created — frame is fully booted before listeners observe it"))))))
 
+;; ---- rf2-cufbh — child-frame :on-create is queued asynchronously --------
+;;
+;; Per Spec 002 §`reg-frame` / `make-frame` called from inside a handler:
+;; when a handler spawns a child frame, the child's `:on-create` MUST be
+;; dispatched (queued on the child's router) rather than dispatch-sync'd.
+;; Synchronous dispatch from inside a handler is an error (per Spec 002
+;; §dispatch-sync inside a handler is an error), and the no-cross-frame-
+;; drain rule (Spec 002 §Run-to-completion) forbids interleaving the two
+;; cascades anyway.
+;;
+;; These tests pin both halves of the contract:
+;;
+;;   (1) top-level reg-frame (no in-flight handler) — `:on-create` is
+;;       dispatch-sync'd, the cascade settles before reg-frame returns
+;;       (already covered by `reg-frame-on-create-runs-synchronously`
+;;       above; the rf2-cufbh test below adds the negative-axis pin —
+;;       no async-queue residue under the top-level path).
+;;   (2) handler-created reg-frame — `:on-create` is dispatched
+;;       asynchronously. The child frame's :on-create handler does NOT
+;;       run before the parent handler returns; it runs on a later
+;;       drain cycle for the child's router.
+
+(deftest child-frame-on-create-is-async-when-created-from-handler
+  (testing "reg-frame called inside a handler queues the child's :on-create
+            asynchronously on the child's router — Spec 002 §reg-frame /
+            make-frame called from inside a handler"
+    (let [event-order  (atom [])
+          captured-tick (atom [])]
+      (rf/reg-event-db :child/boot
+        (fn [db _]
+          (swap! event-order conj :child/boot-ran)
+          (assoc db :child-booted? true)))
+      (rf/reg-event-fx :parent/spawn-child
+        (fn [_ _]
+          (swap! event-order conj :parent/before-reg-frame)
+          (rf/reg-frame :child {:on-create [:child/boot]})
+          (swap! event-order conj :parent/after-reg-frame)
+          {}))
+      ;; Capture the child's next-tick so we can deterministically inspect
+      ;; the queue state at the moment the parent handler returns.
+      (with-redefs [interop/next-tick (fn [f] (swap! captured-tick conj f) nil)]
+        (rf/dispatch-sync [:parent/spawn-child])
+
+        ;; The parent's handler body ran end-to-end, but the child's
+        ;; :on-create handler did NOT run inline.
+        (is (= [:parent/before-reg-frame :parent/after-reg-frame]
+               @event-order)
+            ":child/boot is NOT in the order — it was queued, not dispatch-sync'd")
+
+        ;; The child frame exists; its app-db reflects the pre-:on-create
+        ;; state (fresh {}, not the booted shape).
+        (let [child (frame/frame :child)]
+          (is (some? child) ":child frame is registered")
+          (is (= {} (rf/get-frame-db :child))
+              "child app-db is still {} — :on-create has not yet drained")
+          ;; The child's router queue holds exactly the :on-create event.
+          (let [queue (:queue @(:router child))]
+            (is (= 1 (count queue))
+                "child router has the :on-create envelope queued")
+            (is (= [:child/boot] (-> queue first :event))
+                "queued event is :child/boot"))))
+
+      ;; Now run the captured tick — the child's drain fires and
+      ;; :child/boot runs on the child's drain cycle, after the parent
+      ;; cascade settled.
+      (doseq [tick @captured-tick] (tick))
+      (is (= [:parent/before-reg-frame
+              :parent/after-reg-frame
+              :child/boot-ran]
+             @event-order)
+          ":child/boot ran AFTER the parent cascade settled, on the
+           child's own drain cycle")
+      (is (true? (:child-booted? (rf/get-frame-db :child)))
+          "child app-db reflects :on-create commit once the child drain fires"))))
+
+(deftest top-level-reg-frame-on-create-still-runs-synchronously
+  (testing "Top-level reg-frame (NOT inside a handler) still dispatch-sync's
+            :on-create — the rf2-cufbh fix preserves the fast path"
+    (let [order (atom [])]
+      (rf/reg-event-db :top/init
+        (fn [_ _]
+          (swap! order conj :top/init-ran)
+          {:initialised? true}))
+      ;; No in-flight handler; *current-frame* is nil. :on-create must run
+      ;; synchronously, before reg-frame returns.
+      (rf/reg-frame :top {:on-create [:top/init]})
+      (is (= [:top/init-ran] @order)
+          ":top/init ran inside reg-frame (synchronous top-level path)")
+      (is (true? (:initialised? (rf/get-frame-db :top)))
+          "top-level app-db reflects :on-create commit by reg-frame return"))))
+
+(deftest child-frame-via-make-frame-also-async-from-handler
+  (testing "make-frame from inside a handler also queues :on-create
+            asynchronously — it shares the reg-frame code path"
+    (let [order         (atom [])
+          captured-tick (atom [])
+          child-id      (atom nil)]
+      (rf/reg-event-db :sub-actor/boot
+        (fn [db _]
+          (swap! order conj :sub-actor/boot-ran)
+          (assoc db :booted? true)))
+      (rf/reg-event-fx :parent/spawn-sub-actor
+        (fn [_ _]
+          (swap! order conj :parent/before-make-frame)
+          (reset! child-id (rf/make-frame {:on-create [:sub-actor/boot]}))
+          (swap! order conj :parent/after-make-frame)
+          {}))
+      (with-redefs [interop/next-tick (fn [f] (swap! captured-tick conj f) nil)]
+        (rf/dispatch-sync [:parent/spawn-sub-actor])
+        (is (= [:parent/before-make-frame :parent/after-make-frame] @order)
+            ":sub-actor/boot did not run inline")
+        (is (some? @child-id) "make-frame returned a gensym'd id")
+        (is (= {} (rf/get-frame-db @child-id))
+            "child app-db is still empty before its own drain runs"))
+      ;; Drain the child's tick.
+      (doseq [tick @captured-tick] (tick))
+      (is (= [:parent/before-make-frame
+              :parent/after-make-frame
+              :sub-actor/boot-ran]
+             @order)
+          ":sub-actor/boot ran on the child's own drain cycle")
+      (is (true? (:booted? (rf/get-frame-db @child-id)))
+          "child app-db reflects :on-create commit after its drain"))))
+
 ;; ---- Spec 002 §Frame presets — closed v1 expansion table -----------------
 ;;
 ;; Presets expand at registration time into a fixed bundle of metadata

--- a/implementation/core/test/re_frame/interceptor_test.clj
+++ b/implementation/core/test/re_frame/interceptor_test.clj
@@ -116,6 +116,72 @@
       (is (= :keep (get-in db [:a :sib]))
           "siblings under the outer focus are preserved"))))
 
+;; Per rf2-rwlj2 / Round-2 audit finding CQ-R2.5: the `:after` arm of
+;; `path` only writes `:effects :db` when the handler actually produced
+;; one. When the handler emits no `:db` effect (an `:fx`-only handler
+;; under `reg-event-fx`, or any handler that returns `{}`), the path
+;; interceptor passes through cleanly — no spurious `:db` effect, no
+;; allocation. Pins the "no `:db` effect = no DB write" contract.
+;;
+;; Source: std_interceptors.cljc — :after arm gates the splice-back on
+;; `(contains? (:effects ctx) :db)`.
+
+(deftest path-interceptor-passes-through-when-handler-emits-no-db
+  (testing "(path ...) does NOT synthesise a :db effect when the handler
+            emits none — `:fx`-only handlers stay `:fx`-only through
+            the path interceptor"
+    (let [final-ctx (atom nil)]
+      (rf/reg-event-db :path-noop/init
+                       (fn [_ _] {:foo {:bar 10} :other :preserved}))
+      ;; A `reg-event-fx` handler that emits ONLY `:fx`, no `:db`.
+      ;; Pre-fix the path interceptor would have spliced the unchanged
+      ;; slice back into `:effects :db` regardless — producing a
+      ;; spurious DB write the handler never asked for.
+      (rf/reg-event-fx :path-noop/fx-only
+                       [(rf/path :foo :bar)
+                        ;; Sandwich-spy that captures the effects map
+                        ;; produced by the handler-side chain — i.e.
+                        ;; AFTER the handler ran and BEFORE the path
+                        ;; interceptor's :after re-runs.
+                        (interceptor/->interceptor
+                          :id    :path-noop/spy
+                          :after (fn [ctx]
+                                   (reset! final-ctx ctx)
+                                   ctx))]
+                       (fn [_cofx _ev]
+                         ;; No `:db` in the returned effect map.
+                         {:fx []}))
+      (rf/dispatch-sync [:path-noop/init])
+      (rf/dispatch-sync [:path-noop/fx-only])
+
+      ;; The spy's view sits between the handler and `path`'s :after —
+      ;; if the handler emitted no `:db`, neither does the chain at
+      ;; this point.
+      (is (not (contains? (:effects @final-ctx) :db))
+          "handler that returned no :db produced no :db effect mid-chain")
+
+      ;; Final app-db value is unchanged — the handler asked for
+      ;; nothing and got nothing.
+      (let [db (rf/get-frame-db :rf/default)]
+        (is (= 10 (get-in db [:foo :bar]))
+            "slice value is preserved when handler emits no :db effect")
+        (is (= :preserved (:other db))
+            "the path didn't touch the rest of app-db either")))))
+
+(deftest path-interceptor-still-splices-back-when-handler-emits-db
+  (testing "(path ...) still splices when the handler DOES emit :db —
+            rf2-rwlj2 fix preserves the happy path"
+    (rf/reg-event-db :path-emit/init (fn [_ _] {:foo {:bar 10}}))
+    (rf/reg-event-fx :path-emit/inc
+                     [(rf/path :foo :bar)]
+                     (fn [{:keys [db]} _]
+                       ;; Explicitly emit `:db` (the slice + 1).
+                       {:db (inc db)}))
+    (rf/dispatch-sync [:path-emit/init])
+    (rf/dispatch-sync [:path-emit/inc])
+    (is (= 11 (get-in (rf/get-frame-db :rf/default) [:foo :bar]))
+        "handler that emits :db still gets its slice spliced back")))
+
 ;; ---- unwrap ---------------------------------------------------------------
 
 (deftest unwrap-interceptor

--- a/implementation/core/test/re_frame/test_support_test.clj
+++ b/implementation/core/test/re_frame/test_support_test.clj
@@ -5,6 +5,11 @@
     - dispatch-sequence
     - assert-state
 
+  Plus rf2-j9phb (TE-R2.2): explicit hook-cascade coverage for
+  `reset-runtime-fixture` — pins that every row in the late-bind
+  reset-hook-table is fired exactly once per fixture invocation, so a
+  future refactor that drops a row breaks loudly rather than silently.
+
   The fixture machinery (snapshot-registrar / with-fresh-registrar /
   reset-runtime-fixture) is exercised transitively by the rest of the
   test suite — these tests pin the helper *signatures* and the
@@ -14,6 +19,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.flows :as flows]
+            [re-frame.late-bind :as late-bind]
             [re-frame.schemas :as schemas]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -142,4 +148,217 @@
                        (ts/assert-state [:n] 0 {:frame :rf/default})))]
       (is (= [:pass :pass] outcomes)
           ":rf/default and the named frame each carry their own state"))))
+
+;; ---- rf2-j9phb (TE-R2.2) — reset-runtime-fixture hook-cascade coverage ----
+;;
+;; The fixture's per-test reset drives an inline table
+;; (`test_support.cljc/reset-hook-table`) of nine late-bind hook keys
+;; across two phases (`:pre-dispose` and `:post-dispose`). The pure-shape
+;; refactor that landed via rf2-d7vw8 made the call-set explicit — but
+;; the call-set is still implicit: a future change that drops a row
+;; silently breaks the contract that "no hook gets dropped". This test
+;; pins the contract by REPLACING each registered hook with a counting
+;; sentinel, running one fixture invocation, and asserting each
+;; sentinel fired exactly once.
+;;
+;; Mechanism:
+;;   1. Snapshot the late-bind hooks atom.
+;;   2. Replace each of the nine known reset-hook-table keys with a
+;;      sentinel that increments a per-key counter atom. (Replace
+;;      regardless of whether the producer registered it on the test
+;;      classpath — the sentinel ensures the fixture's hook walk
+;;      actually hit it.)
+;;   3. Invoke the fixture's per-test body with a no-op test-fn so the
+;;      fixture itself fires all the hooks.
+;;   4. Assert each counter is exactly 1.
+;;   5. Restore the late-bind atom from the snapshot.
+;;
+;; Why this exists per round-2 audit rf2-byut1 §TE-R2.2: the existing
+;; test suite exercises the fixture transitively (50+ test files use
+;; `use-fixtures :each`), so a dropped hook would eventually surface
+;; as cross-test pollution. But that's a noisy long-range signal;
+;; this test catches the regression at the immediate seam.
+
+(def ^:private reset-hook-expected-counts
+  "Per-fixture-invocation call count for every reset-hook-table key.
+
+  Most keys fire exactly once: the fixture's `run-reset-hooks!` walks
+  the table in `:pre-dispose` then `:post-dispose` phase order, hitting
+  each row once.
+
+  `:flows/reset-flows!` is the documented exception: it fires twice —
+  once mid-body (via `:pre-dispose`) and once in the `finally` block,
+  per the fixture docstring step 10 (\"Resets `frame/frames` back to
+  `{}` for symmetry, and (when their artefacts are loaded)
+  `flows/flows` and `schemas/schemas-by-frame`\"). The two-fire shape
+  is load-bearing — symmetric pre-test and post-test reset so a
+  failing test leaves no residue for the next. Pin the count here so a
+  refactor that drops EITHER call site (or unifies them into one) is
+  surfaced as a regression."
+  {:flows/reset-flows!              2  ;; pre + finally (symmetry)
+   :flows/reset-last-inputs!        1
+   :schemas/clear-by-frame!         1
+   :machines/reset-timers!          1
+   :routing/reset-counters!         1
+   :http/clear-all-in-flight!       1
+   :epoch/clear-history!            1
+   :epoch/clear-epoch-cbs!          1
+   :adapter/clear-warn-once-caches! 1})
+
+(deftest reset-runtime-fixture-fires-every-hook-the-documented-number-of-times
+  (testing "every row in reset-hook-table fires the documented number of
+            times per fixture call — once for most, twice for
+            `:flows/reset-flows!` (pre-test + finally symmetry per the
+            fixture docstring step 10)"
+    (let [snapshot      @late-bind/hooks
+          call-counts   (atom (zipmap (keys reset-hook-expected-counts)
+                                      (repeat 0)))
+          orig-restore  (late-bind/get-fn :schemas/restore-by-frame!)]
+      (try
+        ;; Install sentinels for every reset-hook-table key.
+        (doseq [k (keys reset-hook-expected-counts)]
+          (late-bind/set-fn! k (fn [& _]
+                                 (swap! call-counts update k inc)
+                                 nil)))
+        ;; The fixture also calls :schemas/snapshot-by-frame /
+        ;; :schemas/restore-by-frame! around the test body. We don't
+        ;; count those (they're not part of the reset-hook-table
+        ;; cascade — they're independent snapshot/restore plumbing per
+        ;; the fixture's docstring). Replace `:schemas/restore-by-frame!`
+        ;; with a benign stub so the test-body's finally clause doesn't
+        ;; depend on the production restore.
+        (late-bind/set-fn! :schemas/restore-by-frame! (fn [_snap] nil))
+        (late-bind/set-fn! :schemas/snapshot-by-frame (fn [] nil))
+
+        (let [fixture (ts/reset-runtime-fixture {:adapter plain-atom/adapter})]
+          (fixture (fn [] :ran)))
+
+        (doseq [[k expected] reset-hook-expected-counts]
+          (is (= expected (get @call-counts k))
+              (str k " fired " expected " time(s) per fixture invocation")))
+        (finally
+          ;; Restore the late-bind atom so subsequent tests inherit the
+          ;; producer's real fns. Reset the registrar / frames so the
+          ;; test that follows starts clean.
+          (reset! late-bind/hooks snapshot)
+          ;; Restore the schemas restore-fn we displaced (in case the
+          ;; snapshot didn't capture it).
+          (when orig-restore
+            (late-bind/set-fn! :schemas/restore-by-frame! orig-restore)))))))
+
+(deftest reset-runtime-fixture-pre-dispose-fires-before-adapter-dispose
+  (testing "the `:pre-dispose` phase fires BEFORE adapter dispose and
+            the `:post-dispose` phase fires AFTER — phase ordering is
+            load-bearing per the fixture docstring"
+    ;; Capture invocation order, not just counts. The test asserts
+    ;; the relative ordering of one pre-dispose hook (:flows/reset-flows!),
+    ;; the adapter dispose (observed via a sentinel registered on the
+    ;; adapter), and one post-dispose hook (:epoch/clear-history!).
+    (let [snapshot @late-bind/hooks
+          order    (atom [])]
+      (try
+        (late-bind/set-fn! :flows/reset-flows!
+                           (fn [] (swap! order conj :pre)))
+        (late-bind/set-fn! :epoch/clear-history!
+                           (fn [] (swap! order conj :post)))
+        ;; The adapter's dispose call lands between the two phases —
+        ;; we don't have a clean late-bind hook on dispose itself, so
+        ;; instead we register a one-shot watch on the adapter atom:
+        ;; install + the immediate dispose flips the value twice.
+        ;; Simpler: just observe the two flows reset calls (pre-test +
+        ;; finally) on `:flows/reset-flows!` themselves and assert
+        ;; `:pre` and `:post` interleave the way the docstring
+        ;; describes — `:epoch/clear-history!` runs AFTER the first
+        ;; flows reset and BEFORE the finally flows reset.
+        (let [fixture (ts/reset-runtime-fixture {:adapter plain-atom/adapter})]
+          (fixture (fn [] :ran)))
+        ;; Expected: pre (flows pre-dispose) → post (epoch post-dispose) →
+        ;; pre (flows finally).
+        (is (= [:pre :post :pre] @order)
+            "pre-dispose runs before post-dispose; the finally-block
+             flows reset is the third event")
+        (finally
+          (reset! late-bind/hooks snapshot))))))
+
+;; ---- rf2-j9phb (TE-R2.3) — destroy-frame! hook-cascade coverage -----------
+;;
+;; The other half of the round-2 audit finding. `destroy-frame!`'s
+;; rf2-ggkay refactor factored four cleanup-hook fires through the
+;; `safe-call-hook!` helper:
+;;
+;;   :privacy/clear-suppression-cache!  — privacy warn-once cache reset
+;;   :ssr/on-frame-destroyed            — SSR side-channel atoms cleanup
+;;   :machines/on-frame-destroyed!      — machines timer-table cleanup
+;;   :epoch/on-frame-destroyed          — fired via notify-epoch-listeners!
+;;
+;; Same shape as TE-R2.2: register a sentinel under each key, destroy a
+;; frame, assert all four fired exactly once.
+
+(def ^:private destroy-frame-hook-keys
+  "The four destroy-frame! cleanup-hook keys. Each fires through
+  `frame/safe-call-hook!` (rf2-ggkay) inside the destroy cascade.
+  Mirrored here so the assertion visits each by name."
+  [:privacy/clear-suppression-cache!
+   :ssr/on-frame-destroyed
+   :machines/on-frame-destroyed!
+   :epoch/on-frame-destroyed])
+
+(deftest destroy-frame-fires-every-cleanup-hook-exactly-once
+  (testing "every cleanup-hook in destroy-frame! fires exactly once
+            per destruction (rf2-j9phb / TE-R2.3)"
+    (let [snapshot    @late-bind/hooks
+          call-counts (atom (zipmap destroy-frame-hook-keys (repeat 0)))]
+      (try
+        ;; Install sentinels.
+        (doseq [k destroy-frame-hook-keys]
+          (late-bind/set-fn! k (fn [& _]
+                                 (swap! call-counts update k inc)
+                                 nil)))
+        ;; Register and destroy a frame. The destroy cascade walks all
+        ;; four cleanup hooks exactly once.
+        (rf/reg-frame :rf2-j9phb/target {})
+        (frame/destroy-frame! :rf2-j9phb/target)
+
+        (doseq [k destroy-frame-hook-keys]
+          (is (= 1 (get @call-counts k))
+              (str k " fired exactly once during destroy-frame!")))
+        (finally
+          (reset! late-bind/hooks snapshot))))))
+
+(deftest destroy-frame-cleanup-hooks-receive-frame-id
+  (testing "cleanup hooks that take the destroyed frame's id receive it
+            correctly — :ssr / :machines / :epoch all pass the id"
+    ;; :privacy/clear-suppression-cache! is zero-arg; the other three
+    ;; receive the destroyed id. Pin that arg shape so a future refactor
+    ;; that swaps positional → varargs (or drops the id) breaks loudly.
+    (let [snapshot   @late-bind/hooks
+          captured-args (atom {})]
+      (try
+        (late-bind/set-fn! :privacy/clear-suppression-cache!
+                           (fn []
+                             (swap! captured-args assoc
+                                    :privacy/clear-suppression-cache!
+                                    ::called-zero-arg)))
+        (doseq [k [:ssr/on-frame-destroyed
+                   :machines/on-frame-destroyed!
+                   :epoch/on-frame-destroyed]]
+          (late-bind/set-fn! k (fn [id]
+                                 (swap! captured-args assoc k id))))
+        (rf/reg-frame :rf2-j9phb/arg-target {})
+        (frame/destroy-frame! :rf2-j9phb/arg-target)
+
+        (is (= ::called-zero-arg
+               (get @captured-args :privacy/clear-suppression-cache!))
+            "privacy hook is zero-arg")
+        (is (= :rf2-j9phb/arg-target
+               (get @captured-args :ssr/on-frame-destroyed))
+            "ssr hook receives the destroyed frame id")
+        (is (= :rf2-j9phb/arg-target
+               (get @captured-args :machines/on-frame-destroyed!))
+            "machines hook receives the destroyed frame id")
+        (is (= :rf2-j9phb/arg-target
+               (get @captured-args :epoch/on-frame-destroyed))
+            "epoch hook receives the destroyed frame id")
+        (finally
+          (reset! late-bind/hooks snapshot))))))
 


### PR DESCRIPTION
## Summary

Tail-polish batch on `implementation/core/`: 4 P1 follow-on beads from the round-2 audit (rf2-byut1) and the spec-vs-implementation drift audit (rf2-4jci1). Two correctness fixes, one cleanup, one test-coverage seam.

| Bead | Type | What it does |
|---|---|---|
| **rf2-rwlj2** | fix | `std_interceptors/path`'s `:after` arm no longer synthesises a spurious `:db` effect when the handler emits no `:db`. Gate the splice-back on `(contains? (:effects ctx) :db)`. Drops one allocation per path-walk-step and restores the "no `:db` effect = no DB write" contract the docstring already described. |
| **rf2-cufbh** | fix | `reg-frame` / `make-frame` called from inside a handler now queue the child's `:on-create` asynchronously on the child router (via `:router/dispatch!`) rather than `dispatch-sync`'ing it. Spec 002 §`reg-frame` / `make-frame` called from inside a handler is explicit on this; the prior code violated both the dispatch-sync-in-handler policy and the no-cross-frame-drain rule. Top-level (no in-flight cascade) keeps the synchronous fast path. |
| **rf2-68kok** | fix | The drain loop now interrupts an active pass on the next dequeue when the frame was destroyed mid-cascade. Drops the remaining queue once, emits a single `:rf.frame/drain-interrupted` lifecycle event with `:dropped-count`. Run-to-completion is preserved — the in-flight event runs in full before the check fires. New `frame/frame-disposed-for-drain?` predicate covers both intermediate destroy states (`:destroyed?` flipped, record dissoc'd). Existing rf2-dpny "destroy-before-drain = silent no-op" contract is unchanged. |
| **rf2-j9phb** | test | Explicit coverage for the two recently-data-driven cleanup cascades: `reset-runtime-fixture` (rf2-d7vw8) and `destroy-frame!`'s 4 cleanup-hook fires (rf2-ggkay). Sentinel hooks pin per-key call counts + arg shapes, so a future refactor that drops a row breaks loudly at the immediate seam rather than via cross-test pollution. |

LoC delta: `+664 / -20` across 6 files (3 src, 3 test).

Hot-zone touches: `frame.cljc`, `router.cljc`, `std_interceptors.cljc`, `test_support_test.clj` (mostly additive — sequential-only per the dispatch rules).

## Test plan

- [x] `cd implementation/core && clojure -M:test` — 489 tests / 2505 assertions / 0 failures
- [x] `cd implementation && npm run test:cljs` — 1817 tests / 5105 assertions / 0 failures
- [x] `cd implementation && npm run test:elision` — DCE probe passes (all sentinels PRESENT in dev, ABSENT in prod where expected)
- [x] Branch rebased on current `origin/main` before push.