### PR TITLE
refactor(ssr): polish cluster — 7 follow-on beads (rf2-cegm7)

### DIFF
--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -89,9 +89,14 @@
 
 (rf/reg-event-fx :rf/server-init
   {:doc       "Per-request server-side initialisation. Reads the request
-               cofx, dispatches setup events. Server only."
+               via the :rf.server/request cofx (Spec 011 §Request storage
+               substrate, rf2-afxhv), dispatches setup events. Server only."
    :platforms #{:server}}
-  (fn handler-rf-server-init [{:keys [db]} [_ request]]
+  [(rf/inject-cofx :rf.server/request)]
+  (fn handler-rf-server-init [{:keys [db rf.server/request]} _]
+    ;; `request` is the host-supplied HTTP request map (Ring shape under
+    ;; the bundled adapter); read URL/headers/cookies from here rather
+    ;; than from a positional event arg.
     {:db (assoc db :rf/route {:id :route/articles :params {}})
      :fx [[:rf.http/managed
            {:request    {:method :get :url "/api/articles"}
@@ -179,15 +184,23 @@
 ;;
 ;; The server flow:
 ;;   1. Accept request.
-;;   2. make-frame; :on-create dispatches :rf/server-init with the request.
-;;   3. Drain settles (HTTP fetches resolve via :rf.http/managed; the JVM
+;;   2. set-request! populates the per-frame slot for the :rf.server/request
+;;      cofx (Spec 011 §Request storage substrate).
+;;   3. make-frame; :on-create dispatches :rf/server-init (which reads
+;;      the request via the cofx).
+;;   4. Drain settles (HTTP fetches resolve via :rf.http/managed; the JVM
 ;;      transport uses java.net.http.HttpClient under the hood).
-;;   4. Render to string via the pure hiccup → HTML emitter.
-;;   5. Serialise app-db; ship in the HTML.
+;;   5. Render to string via the pure hiccup → HTML emitter.
+;;   6. Serialise app-db; ship in the HTML.
 
 #?(:clj
    (defn handle-request [request]
-     (let [f (rf/make-frame {:on-create [:rf/server-init request]})]
+     (let [fid (keyword "rf.frame" (str (gensym "")))
+           _   (ssr/set-request! fid request)
+           f   (rf/reg-frame fid
+                 {:doc       "ssr-example per-request frame"
+                  :platform  :server
+                  :on-create [:rf/server-init]})]
        (rf/with-frame f
          (let [final-db (rf/get-frame-db f)
                hiccup   ((rf/view :app/root))
@@ -293,9 +306,14 @@
                         :value [{:id "a" :title "Article A" :body "Body A"}
                                 {:id "b" :title "Article B" :body "Body B"}])))))
 
-     (let [f           (rf/make-frame {:on-create    [:rf/server-init {:uri "/articles"}]
-                                       :fx-overrides {:rf.http/managed :ssr.http/canned-articles}})
-           final-db    (rf/get-frame-db f)
+     (let [fid          (keyword "rf.frame" (str (gensym "")))
+           _            (ssr/set-request! fid {:uri "/articles"})
+           f            (rf/reg-frame fid
+                          {:doc          "ssr-example test frame"
+                           :platform     :server
+                           :on-create    [:rf/server-init]
+                           :fx-overrides {:rf.http/managed :ssr.http/canned-articles}})
+           final-db     (rf/get-frame-db f)
            ;; The root view's body invokes the articles-page render fn,
            ;; which calls (rf/subscribe-value [:articles]). Both run
            ;; INSIDE render-to-string's tree walk; with-frame binds

--- a/implementation/adapters/reagent/test/re_frame/adapter_render_to_string_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_render_to_string_cljs_test.cljs
@@ -1,0 +1,96 @@
+(ns re-frame.adapter-render-to-string-cljs-test
+  "Per rf2-8k0g3 — pin the `:rf.error/no-hiccup-emitter-bound` ex-info
+  shape and the post-(require re-frame.ssr) wiring.
+
+  The Reagent adapter's `:render-to-string` slot throws when no hiccup
+  emitter has been installed via `set-hiccup-emitter!`. The SSR
+  artefact (`re-frame.ssr`) registers itself through the
+  `:reagent/set-hiccup-emitter!` late-bind hook at ns-load, so the
+  common case — `(require '[re-frame.ssr])` then call
+  `(render-to-string ...)` — Just Works. This test pins two contracts:
+
+    1. The pre-wire failure: when the emitter is absent, calling
+       `render-to-string` throws an `ExceptionInfo` whose
+       `ex-message` is `:rf.error/no-hiccup-emitter-bound` and whose
+       `ex-data` carries `:reason` (string) and `:render-tree` (the
+       tree passed in).
+
+    2. The post-wire success: after `re-frame.ssr` has resolved the
+       late-bind hook and installed the emitter, `render-to-string`
+       returns an HTML string.
+
+  Sibling: re-frame.adapter.uix-render-to-string-cljs-test on the UIx
+  adapter (rf2-gc5v9) — same contract, different adapter.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            ;; Loading `re-frame.ssr` here is the canonical wiring path
+            ;; — its ns-load resolves the `:reagent/set-hiccup-emitter!`
+            ;; hook and installs the emitter (Spec 011 + rf2-uo7v).
+            [re-frame.ssr]))
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- with-cleared-emitter
+  "Run f with the adapter's hiccup-emitter forced to nil; restore
+  whatever was previously installed afterwards. The adapter exports
+  `set-hiccup-emitter!` (public per the adapter ns docstring); we use
+  it both to clear the slot and to restore it."
+  [f]
+  (let [;; Capture the currently-installed emitter by exercising
+        ;; render-to-string indirectly: the only public read is to call
+        ;; it. We can't peek; what we CAN do is snapshot the SSR-side
+        ;; render-to-string fn (which is what was installed) and put it
+        ;; back via set-hiccup-emitter! after the test. The fn lives in
+        ;; re-frame.ssr/render-to-string (re-exported from
+        ;; re-frame.ssr.emit/render-to-string).
+        ssr-emitter (resolve 're-frame.ssr/render-to-string)]
+    (reagent-adapter/set-hiccup-emitter! nil)
+    (try
+      (f)
+      (finally
+        (when ssr-emitter
+          (reagent-adapter/set-hiccup-emitter! @ssr-emitter))))))
+
+;; ---- test (1) — pre-wire failure: ex-info shape ----------------------------
+
+(deftest render-to-string-throws-with-no-emitter
+  (testing "rf2-8k0g3: (render-to-string [:div] {}) before the emitter is
+            installed throws ExceptionInfo whose ex-message is
+            ':rf.error/no-hiccup-emitter-bound' and whose ex-data carries
+            :reason + :render-tree"
+    (with-cleared-emitter
+      (fn []
+        (let [render-fn (:render-to-string reagent-adapter/adapter)
+              tree      [:div "smoke"]
+              thrown    (try
+                          (render-fn tree {})
+                          nil
+                          (catch :default e e))]
+          (is (some? thrown)
+              "render-to-string threw when no emitter was installed")
+          (is (= ":rf.error/no-hiccup-emitter-bound" (.-message thrown))
+              "ex-message names the error keyword")
+          (let [data (ex-data thrown)]
+            (is (some? data)
+                "the thrown value carries ex-data")
+            (is (string? (:reason data))
+                ":reason key is a string explaining the misconfiguration")
+            (is (= tree (:render-tree data))
+                ":render-tree key carries the tree the caller passed in")))))))
+
+;; ---- test (2) — post-wire success ------------------------------------------
+
+(deftest render-to-string-returns-html-after-ssr-require
+  (testing "rf2-8k0g3: with re-frame.ssr loaded (the canonical wiring path
+            via the :reagent/set-hiccup-emitter! late-bind hook), calling
+            render-to-string returns a non-throwing HTML string"
+    (let [render-fn (:render-to-string reagent-adapter/adapter)
+          html      (render-fn [:div "ok"] {})]
+      (is (string? html)
+          "render-to-string returns a string")
+      (is (clojure.string/includes? html "ok")
+          "the hiccup body reaches the rendered HTML")
+      (is (clojure.string/starts-with? html "<div")
+          "rendered HTML starts with the expected root tag"))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_render_to_string_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_render_to_string_cljs_test.cljs
@@ -1,0 +1,99 @@
+(ns re-frame.adapter.uix-render-to-string-cljs-test
+  "Per rf2-gc5v9 — pin the `:rf.error/no-hiccup-emitter-bound` ex-info
+  shape and the direct-install wiring on the UIx adapter.
+
+  Sibling: re-frame.adapter-render-to-string-cljs-test on the Reagent
+  adapter (rf2-8k0g3). Same contract — different substrate.
+
+  UIx ships its `:render-to-string` slot the same way the Reagent
+  adapter does: a private `hiccup-emitter` atom, a public
+  `set-hiccup-emitter!` installer, and a `render-to-string` fn that
+  throws when the emitter is nil. The contract surface is identical.
+
+  Difference vs the Reagent test: as of rf2-gc5v9, UIx does NOT publish
+  its `set-hiccup-emitter!` through a late-bind hook (rf2-4z7bp tracks
+  the parity gap). Until rf2-4z7bp lands, the SSR consumer under UIx
+  has to call `set-hiccup-emitter!` directly. This test pins the
+  shipped behaviour for both the throw path AND the direct-install
+  success path; when rf2-4z7bp publishes the hook, an additional test
+  asserting the post-(require re-frame.ssr) auto-wire can land here.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.adapter.uix :as uix-adapter]))
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- a-mock-emitter
+  "A toy hiccup → HTML emitter so the install-path test can exercise
+  set-hiccup-emitter! without dragging the full SSR artefact in. The
+  emitter is render-tree-agnostic — it returns a fixed marker so the
+  test asserts the wiring, not the rendering."
+  [render-tree _opts]
+  (str "<mock>" (pr-str render-tree) "</mock>"))
+
+(defn- with-cleared-emitter
+  "Run `f` with the adapter's hiccup-emitter forced to nil; restore
+  whatever was previously installed afterwards."
+  [f]
+  (let [;; Capture by snapshotting whatever fn the slot ends up
+        ;; producing post-test. The adapter's emitter atom is private;
+        ;; set-hiccup-emitter! is the public install surface.
+        prior-render-fn (:render-to-string uix-adapter/adapter)]
+    (uix-adapter/set-hiccup-emitter! nil)
+    (try
+      (f)
+      (finally
+        ;; The slot fn closes over the private atom — restoring is a
+        ;; no-op unless something was installed beforehand. The
+        ;; clear-then-restore dance keeps cross-test isolation intact.
+        ;; (We don't know what was installed; the next test that needs
+        ;; the emitter installs it fresh.)
+        (identity prior-render-fn)))))
+
+;; ---- test (1) — pre-wire failure: ex-info shape ----------------------------
+
+(deftest render-to-string-throws-with-no-emitter
+  (testing "rf2-gc5v9: (render-to-string [:div] {}) before the emitter is
+            installed throws ExceptionInfo whose ex-message is
+            ':rf.error/no-hiccup-emitter-bound' and whose ex-data carries
+            :reason + :render-tree"
+    (with-cleared-emitter
+      (fn []
+        (let [render-fn (:render-to-string uix-adapter/adapter)
+              tree      [:div "smoke"]
+              thrown    (try
+                          (render-fn tree {})
+                          nil
+                          (catch :default e e))]
+          (is (some? thrown)
+              "render-to-string threw when no emitter was installed")
+          (is (= ":rf.error/no-hiccup-emitter-bound" (.-message thrown))
+              "ex-message names the error keyword")
+          (let [data (ex-data thrown)]
+            (is (some? data)
+                "the thrown value carries ex-data")
+            (is (string? (:reason data))
+                ":reason key is a string explaining the misconfiguration")
+            (is (= tree (:render-tree data))
+                ":render-tree key carries the tree the caller passed in")))))))
+
+;; ---- test (2) — direct-install success path --------------------------------
+
+(deftest render-to-string-returns-html-after-direct-install
+  (testing "rf2-gc5v9: after (set-hiccup-emitter! emitter-fn), render-to-string
+            returns the emitter's output. Direct-install path — until
+            rf2-4z7bp publishes the UIx-side late-bind hook, this is the
+            canonical wiring surface."
+    (uix-adapter/set-hiccup-emitter! a-mock-emitter)
+    (let [render-fn (:render-to-string uix-adapter/adapter)
+          tree      [:div "ok"]
+          html      (render-fn tree {})]
+      (is (string? html)
+          "render-to-string returns a string after set-hiccup-emitter!")
+      (is (clojure.string/starts-with? html "<mock>")
+          "the installed emitter is what render-to-string invokes")
+      (is (clojure.string/includes? html (pr-str tree))
+          "the installed emitter received the render-tree the caller passed in"))
+    ;; Restore the slot to nil so subsequent tests don't see the mock.
+    (uix-adapter/set-hiccup-emitter! nil)))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -118,10 +118,11 @@
 
   Required opts:
 
-    :on-create   — the event vector dispatched at frame creation. The
-                   Ring request map is conj'd as the last arg so handlers
-                   can read it positionally (and via the
-                   `:rf.server/request` cofx once rf2-e825b lands).
+    :on-create   — the event vector dispatched at frame creation. Read
+                   the Ring request map from handlers via
+                   `(rf/inject-cofx :rf.server/request)` — Spec 011 §Request
+                   storage substrate (rf2-afxhv) names the cofx as the
+                   canonical read surface.
     :root-view   — either a hiccup vector (e.g. `[:app/root]`) OR a
                    0-arity fn returning hiccup. Rendered against the
                    per-request frame after the drain settles.

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -8,9 +8,18 @@
     - `resolve-head`           — active route's `:head` → map carrying the
                                  rendered fragment plus `:html-attrs` /
                                  `:body-attrs` bags for the host shell
-    - `on-create-with-request` — append request to caller's :on-create vec
 
-  Per Spec 011 §Request storage substrate + §Head/meta contract."
+  Per Spec 011 §Request storage substrate + §Head/meta contract.
+
+  Note (audit rf2-cegm7 A2 / rf2-j54ee): the prior `on-create-with-request`
+  helper conj'd the Ring request map onto the caller's `:on-create`
+  event vector as a fallback for handlers that pre-dated the
+  `:rf.server/request` cofx. The conj path is gone — Spec 011 names the
+  cofx as the canonical read surface; the positional-arg variant had a
+  subtle pitfall (a 1-vector `[:rf/server-init]` silently became
+  `[:rf/server-init {ring-request...}]` after the conj, so a handler that
+  forgot to destructure ended up with the request riding the unused-arg
+  slot). Pre-alpha: one canonical surface, no fallback."
   (:require [re-frame.core :as rf]
             [re-frame.trace :as trace]))
 
@@ -83,20 +92,15 @@
     (catch Throwable _
       {:head-html "" :html-attrs nil :body-attrs nil})))
 
-(defn on-create-with-request
-  "Conj the Ring request map onto the caller's :on-create event vector
-  so handlers can read it as an event arg. The `:rf.server/request`
-  cofx (rf2-e825b) is the canonical read path; this is the fallback
-  for handlers that don't inject the cofx and want the request as a
-  positional arg, matching the worked example in
-  examples/reagent/ssr/core.cljc.
-
+(defn validate-on-create!
+  "Validate the caller's :on-create event vector and return it verbatim.
   `:on-create` is required (per `handler-defaults/validate-handler-opts!`),
-  so a `nil` arg here is a programmer error — handled by the non-vector
-  arm. Audit rf2-cegm7 A3."
-  [on-create request]
+  so a non-vector here is a programmer error — surface it as an
+  ex-info rather than letting `reg-frame` produce an obscure failure
+  downstream. Audit rf2-cegm7 A3 / rf2-j54ee."
+  [on-create]
   (if (vector? on-create)
-    (conj on-create request)
+    on-create
     (throw (ex-info ":rf.error/invalid-on-create"
                     {:reason   ":on-create must be a vector (event)"
                      :received on-create}))))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -50,7 +50,11 @@
       (rf/reg-frame fid
         (cond-> {:doc       "ssr-ring per-request frame"
                  :platform  :server
-                 :on-create (lifecycle/on-create-with-request on-create request)}
+                 ;; Audit rf2-cegm7 A2 / rf2-j54ee: pass :on-create
+                 ;; verbatim. Handlers read the request via the
+                 ;; `:rf.server/request` cofx — the spec-documented
+                 ;; canonical surface.
+                 :on-create (lifecycle/validate-on-create! on-create)}
           fx-overrides (assoc :fx-overrides fx-overrides)
           ssr          (assoc :ssr           ssr)))
       {:frame-id fid}

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/shell.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/shell.clj
@@ -6,7 +6,8 @@
   pass an `:html-shell` option to override. The default exists so a
   first-time user gets a working SSR endpoint without writing string
   concatenation glue."
-  (:require [re-frame.ssr.html-helpers :as html]))
+  (:require [re-frame.ssr.constants :as constants]
+            [re-frame.ssr.html-helpers :as html]))
 
 (set! *warn-on-reflection* true)
 
@@ -14,6 +15,14 @@
   "The default HTML envelope. Returns a string wrapping the rendered
   body in a minimal-but-runnable document. Override via `:html-shell`
   in `ssr-handler` opts when you need custom <head> / scripts / styles.
+
+  The hydration-payload `<script>` is stamped with the id pinned in
+  `re-frame.ssr.constants/payload-script-id` (`\"__rf_payload\"`). The
+  CLJS bootstrap reads the payload via
+  `document.getElementById(\"__rf_payload\")` — same constant, both
+  sides (Spec 011 §Hydration payload script id, rf2-cegm7 CQ-3 / rf2-j54ee).
+  Custom `:html-shell` overrides MUST emit the payload `<script>` under
+  this id (or substitute their own bootstrap that reads a custom id).
 
   `<title>` is NOT emitted by the shell — the head fragment is the
   canonical source per Spec 011 §Head/meta contract (rf2-4dra9, rf2-3z841).
@@ -68,7 +77,11 @@
          "</head>"
          "<body" (html/attr-string body-attrs) ">"
          "<div id=\"" app-element-id "\">" body-html "</div>"
-         "<script id=\"__rf_payload\" type=\"application/edn\">"
+         ;; The id is pinned in `re-frame.ssr.constants/payload-script-id`
+         ;; — the contract between this server-side emit and the client-
+         ;; side bootstrap's `document.getElementById(...)` read. Per
+         ;; Spec 011 §Hydration payload script id (rf2-cegm7 CQ-3).
+         "<script id=\"" constants/payload-script-id "\" type=\"application/edn\">"
          payload-edn
          "</script>"
          (when script-src

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -82,7 +82,8 @@
 
   (rf/reg-event-fx :rf/server-init
     {:platforms #{:server}}
-    (fn [{:keys [db]} [_ request]]
+    [(rf/inject-cofx :rf.server/request)]
+    (fn [{:keys [db rf.server/request]} _]
       {:db (assoc db :request request)
        :fx [[:http/get {:url        "/api/articles"
                         :on-success [:articles/loaded]}]]}))
@@ -840,3 +841,53 @@
             "X-Secret-Header value IS on the wire response (header surface)")
         (is (some? audit-hdr)
             "X-Audit append-header reached the wire (multi-valued)")))))
+
+;; ===========================================================================
+;; rf2-hyk9j TC-3 — destroy-frame-failed trace surfaces on per-request teardown
+;; ===========================================================================
+;;
+;; Per audit rf2-asmj1 R6 / cluster rf2-sljs1, `destroy-frame-quietly!`
+;; emits a `:rf.ssr/destroy-frame-failed` warning trace when destroy
+;; throws. The behaviour shipped; no test pinned it.
+
+(deftest destroy-frame-quietly-emits-trace-on-throwing-destroy
+  (testing "rf2-hyk9j: a frame whose destroy throws → :rf.ssr/destroy-frame-failed
+            warning trace fires (audit rf2-asmj1 R6 / rf2-sljs1)
+
+            Most paths inside `destroy-frame!` swallow their own
+            exceptions (the on-destroy event runs through the router's
+            dispatch-sync which traces handler-exception; the late-bind
+            cleanup hooks funnel through `safe-call-hook!` which
+            swallows). To exercise destroy-quietly's catch arm we
+            simulate a hard runtime failure — `with-redefs` makes
+            `rf/destroy-frame` itself throw. This pins the wire
+            contract: when destroy throws for any reason, the trace
+            surfaces."
+    (let [destroy-quietly! (requiring-resolve
+                            're-frame.ssr.ring.lifecycle/destroy-frame-quietly!)
+          traces           (atom [])
+          f                :rf.frame/test-destroy-throws]
+      (rf/register-trace-cb! ::dfq (fn [ev] (swap! traces conj ev)))
+      (try
+        (with-redefs [rf/destroy-frame
+                      (fn [_] (throw (ex-info "synthetic destroy failure"
+                                              {:reason :test})))]
+          (destroy-quietly! f))
+        (finally
+          (rf/remove-trace-cb! ::dfq)))
+
+      (let [hits (filterv #(= :rf.ssr/destroy-frame-failed (:operation %)) @traces)]
+        (is (= 1 (count hits))
+            (str "expected one :rf.ssr/destroy-frame-failed trace; saw: "
+                 (pr-str (mapv :operation @traces))))
+        (when (seq hits)
+          (let [ev (first hits)]
+            (is (= :warning (:op-type ev)))
+            (is (= f (-> ev :tags :frame))
+                ":frame tag identifies the frame that failed to destroy")
+            (is (string? (-> ev :tags :reason))
+                ":reason carries the throwable's message")
+            (is (string? (-> ev :tags :ex-class))
+                ":ex-class carries the throwable's class name")
+            (is (= :warned-and-skipped (:recovery ev))
+                ":recovery names the policy")))))))

--- a/implementation/ssr/src/re_frame/ssr/constants.cljc
+++ b/implementation/ssr/src/re_frame/ssr/constants.cljc
@@ -1,0 +1,21 @@
+(ns re-frame.ssr.constants
+  "Reserved string constants the SSR runtime, host adapters, and CLJS
+  bootstrap all reference. Pinning these in one ns (rather than scattered
+  literal strings) makes the convention discoverable and renameable —
+  tooling that searches for the convention reads one var, not a regex
+  pattern across the codebase.
+
+  Per Spec 011 §Hydration payload script id (audit rf2-cegm7 CQ-3 /
+  rf2-j54ee).")
+
+(def ^:const payload-script-id
+  "The literal `id` the host-adapter HTML shell stamps onto the
+  hydration-payload `<script>` tag, AND the literal the client-side
+  bootstrap reads via `document.getElementById(...)`.
+
+  Spec 011 §Hydration payload script id pins this string as the
+  contract between server-shell-emit and client-bootstrap-read. A user
+  who overrides `:html-shell` MUST emit the payload `<script>` with
+  this id (or substitute their own bootstrap that reads a custom id;
+  the framework's bundled bootstrap reads only this id)."
+  "__rf_payload")

--- a/implementation/ssr/src/re_frame/ssr/request.cljc
+++ b/implementation/ssr/src/re_frame/ssr/request.cljc
@@ -40,7 +40,8 @@
   Per the rf2-gxgo7 split of re-frame.ssr."
   (:require [re-frame.late-bind :as late-bind]
             [re-frame.ssr.error-listener :as error-listener]
-            [re-frame.ssr.response :as response]))
+            [re-frame.ssr.response :as response]
+            [re-frame.trace :as trace]))
 
 (defonce
   ^{:doc "Per-frame storage for the active HTTP request. Keys are
@@ -125,14 +126,30 @@
   Per rf2-4dra9 (Spec 011 §Head/meta contract), also invokes any
   registered `:ssr/head-on-frame-destroyed` hook so `re-frame.ssr.head`
   can release its per-frame head-snapshot bookkeeping. Hook lookup is
-  late-bound so the call is a no-op when the head ns is absent."
+  late-bound so the call is a no-op when the head ns is absent.
+
+  Head-cleanup throws are caught + surfaced on the trace bus rather
+  than silently swallowed — mirrors the trace-on-catch pattern shipped
+  in `ssr-ring/lifecycle/destroy-frame-quietly!` (audit rf2-cegm7 CQ-2 /
+  rf2-j54ee). Vanishing destroy-time exceptions is exactly what the
+  R6 cluster was fixing; keep the symmetry."
   [frame-id]
   (error-listener/clear-pending-error-traces! frame-id)
   (swap! request-slots dissoc frame-id)
   (response/clear-response! frame-id)
   (when-let [head-cleanup! (late-bind/get-fn :ssr/head-on-frame-destroyed)]
     (try (head-cleanup! frame-id)
-         (catch #?(:clj Throwable :cljs :default) _ nil)))
+         (catch #?(:clj Throwable :cljs :default) t
+           (trace/emit! :warning :rf.ssr.head/cleanup-failed
+                        {:frame    frame-id
+                         :hook     :ssr/head-on-frame-destroyed
+                         :reason   (or #?(:clj  (.getMessage ^Throwable t)
+                                          :cljs (.-message t))
+                                       (str t))
+                         :ex-class #?(:clj  (.getName (class t))
+                                      :cljs (.-name (type t)))
+                         :recovery :warned-and-skipped})
+           nil)))
   nil)
 
 (defn request-cofx

--- a/implementation/ssr/test/re_frame/ssr_compatibility_checks_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_compatibility_checks_test.clj
@@ -13,7 +13,6 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.late-bind :as late-bind]
-            [re-frame.ssr :as ssr]
             [re-frame.ssr.test-fixture :as tf]))
 
 ;; Shared reset fixture lives in `re-frame.ssr.test-fixture` (rf2-i3qc0).
@@ -142,3 +141,102 @@
           (is (= "sha256:deadbeefcafef00d"             (-> ev :tags :expected)))
           (is (= "sha256:0000000000000000"             (-> ev :tags :actual)))
           (is (= :warned-and-applied                   (:recovery ev))))))))
+
+;; ===========================================================================
+;; SCALAR-form + missing-hook paths — rf2-ooj41
+;; ===========================================================================
+;;
+;; Per rf2-ooj41 (audit ssr coverage + robustness): the explicit-map form is
+;; covered above. The reference :rf/hydrate handler dispatches the SCALAR
+;; form `[:rf.ssr/check-version <server-value>]`; the fx then looks up the
+;; client-side "actual" via the `:rf2/runtime-version` /
+;; `:schemas/app-schemas-digest` late-bind hooks. When the hook is absent
+;; (host hasn't registered a version-stamp, schemas artefact not on the
+;; classpath), the fx emits `:rf.ssr/compatibility-check-skipped` rather
+;; than throwing. Pin both paths so a regression that silently drops
+;; either trace is caught.
+
+(deftest check-version-scalar-with-no-hook-emits-skipped
+  (testing "scalar form + absent :rf2/runtime-version hook → :rf.ssr/compatibility-check-skipped"
+    (rf/reg-event-fx ::probe-check-version-scalar-no-hook
+      {:platforms #{:client}}
+      (fn [_ _]
+        {:fx [[:rf.ssr/check-version "1.0.0"]]}))
+
+    (let [f      (rf/make-frame {:platform :client})
+          traces (capture-traces!
+                   (fn []
+                     (rf/dispatch-sync [::probe-check-version-scalar-no-hook]
+                                       {:frame f})))
+          hits   (traces-of traces :rf.ssr/compatibility-check-skipped)]
+      (is (= 1 (count hits))
+          (str "expected one :rf.ssr/compatibility-check-skipped trace; saw: "
+               (pr-str (mapv :operation traces))))
+      (when (seq hits)
+        (let [ev (first hits)]
+          (is (= :warning              (:op-type ev)))
+          (is (= :rf.ssr/check-version (-> ev :tags :check))
+              ":check tag identifies which compatibility fx skipped")
+          (is (= "1.0.0"               (-> ev :tags :expected))
+              "scalar value is the :expected (server-side) value")
+          (is (= :skipped              (:recovery ev))))))))
+
+(deftest check-version-scalar-with-hook-runs-comparison
+  (testing "scalar form + registered :rf2/runtime-version hook → compare; mismatch fires"
+    ;; Install the hook to return the client-side runtime version;
+    ;; remove after to keep the hook table clean for the next test.
+    (late-bind/set-fn! :rf2/runtime-version (constantly "2.0.0"))
+    (try
+      (rf/reg-event-fx ::probe-check-version-scalar-with-hook
+        {:platforms #{:client}}
+        (fn [_ _]
+          {:fx [[:rf.ssr/check-version "1.0.0"]]}))
+
+      (let [f      (rf/make-frame {:platform :client})
+            traces (capture-traces!
+                     (fn []
+                       (rf/dispatch-sync [::probe-check-version-scalar-with-hook]
+                                         {:frame f})))
+            hits   (traces-of traces :rf.ssr/version-mismatch)]
+        (is (empty? (traces-of traces :rf.ssr/compatibility-check-skipped))
+            "hook present → no skipped trace; the comparison ran")
+        (is (= 1 (count hits))
+            (str "expected one :rf.ssr/version-mismatch trace; saw: "
+                 (pr-str (mapv :operation traces))))
+        (when (seq hits)
+          (let [ev (first hits)]
+            (is (= "1.0.0" (-> ev :tags :expected))
+                "scalar arg is :expected (server side)")
+            (is (= "2.0.0" (-> ev :tags :actual))
+                ":actual sourced via the late-bind hook"))))
+      (finally
+        (swap! late-bind/hooks dissoc :rf2/runtime-version)))))
+
+(deftest check-schema-digest-scalar-with-no-hook-emits-skipped
+  (testing "scalar form + absent :schemas/app-schemas-digest hook → skipped"
+    ;; Test deps pull `re-frame.schemas` onto the classpath so its ns-load
+    ;; registers `:schemas/app-schemas-digest`; explicitly clear the hook
+    ;; for this test so we can pin the missing-hook path. Restore on exit.
+    (let [prior-hook (late-bind/get-fn :schemas/app-schemas-digest)]
+      (swap! late-bind/hooks dissoc :schemas/app-schemas-digest)
+      (try
+        (rf/reg-event-fx ::probe-check-digest-scalar-no-hook
+          {:platforms #{:client}}
+          (fn [_ _]
+            {:fx [[:rf.ssr/check-schema-digest "sha256:deadbeefcafef00d"]]}))
+
+        (let [f      (rf/make-frame {:platform :client})
+              traces (capture-traces!
+                       (fn []
+                         (rf/dispatch-sync [::probe-check-digest-scalar-no-hook]
+                                           {:frame f})))
+              hits   (traces-of traces :rf.ssr/compatibility-check-skipped)]
+          (is (= 1 (count hits)))
+          (when (seq hits)
+            (let [ev (first hits)]
+              (is (= :rf.ssr/check-schema-digest (-> ev :tags :check)))
+              (is (= "sha256:deadbeefcafef00d"   (-> ev :tags :expected)))
+              (is (= :skipped                    (:recovery ev))))))
+        (finally
+          (when prior-hook
+            (late-bind/set-fn! :schemas/app-schemas-digest prior-hook)))))))

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -32,7 +32,8 @@
             [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.ssr :as ssr]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.trace :as trace]))
 
 ;; The canonical reset-runtime fixture lives in `re-frame.ssr.test-fixture`
 ;; (rf2-i3qc0) — one source of truth for the registrar/side-channel/ns-
@@ -180,7 +181,7 @@
                                   (resolve-tree client-frame render-tree))
                   match-traces  (atom [])]
               (rf/register-trace-cb! ::match (fn [ev] (swap! match-traces conj ev)))
-              ((requiring-resolve 're-frame.ssr/verify-hydration!)
+              (ssr/verify-hydration!
                 client-frame client-hash-1)
               (rf/remove-trace-cb! ::match)
               (is (= server-hash client-hash-1)
@@ -202,7 +203,7 @@
                                      (resolve-tree client-frame render-tree))
                   mismatch-traces (atom [])]
               (rf/register-trace-cb! ::mismatch (fn [ev] (swap! mismatch-traces conj ev)))
-              ((requiring-resolve 're-frame.ssr/verify-hydration!)
+              (ssr/verify-hydration!
                 client-frame client-hash-2)
               (rf/remove-trace-cb! ::mismatch)
 
@@ -230,7 +231,7 @@
 (defn- get-response
   "Read the resolved :rf/response accumulator for a frame."
   [frame-id]
-  ((requiring-resolve 're-frame.ssr/get-response) frame-id))
+  (ssr/get-response frame-id))
 
 (deftest ssr-set-status-precedence
   (testing "two :rf.server/set-status fx → last write wins + :rf.warning/multiple-status-set"
@@ -412,7 +413,7 @@
 (deftest ssr-default-error-projector-no-such-handler
   (testing "routing's :rf.error/no-such-handler → default projector → 404"
     (rf/reg-route :route/home {:path "/"})
-    (let [project-error  (requiring-resolve 're-frame.ssr/project-error)
+    (let [project-error  ssr/project-error
           f              (rf/make-frame
                            {:platform :server
                             :ssr {:public-error-id   :rf.ssr/default-error-projector
@@ -450,7 +451,7 @@
       (fn [_ _]
         {:fx [[:dispatch [:load/article]]]}))
 
-    (let [project-error  (requiring-resolve 're-frame.ssr/project-error)
+    (let [project-error  ssr/project-error
           traces         (atom [])
           _              (rf/register-trace-cb! ::he (fn [ev] (swap! traces conj ev)))
           f              (rf/make-frame
@@ -477,7 +478,7 @@
 
 (deftest ssr-error-projector-dev-mode-includes-details
   (testing ":dev-error-detail? true puts the raw trace under :details"
-    (let [project-error (requiring-resolve 're-frame.ssr/project-error)
+    (let [project-error ssr/project-error
           f             (rf/make-frame
                           {:platform :server
                            :ssr {:public-error-id   :rf.ssr/default-error-projector
@@ -514,7 +515,7 @@
            :message "Custom 500"
            :retryable? false})))
 
-    (let [project-error (requiring-resolve 're-frame.ssr/project-error)
+    (let [project-error ssr/project-error
           f             (rf/make-frame
                           {:platform :server
                            :ssr {:public-error-id   :myapp/public-error
@@ -541,7 +542,7 @@
       (fn [_trace-event]
         (throw (ex-info "projector bug" {}))))
 
-    (let [project-error (requiring-resolve 're-frame.ssr/project-error)
+    (let [project-error ssr/project-error
           f             (rf/make-frame
                           {:platform :server
                            :ssr {:public-error-id   :myapp/buggy-projector
@@ -564,7 +565,7 @@
     (rf/reg-error-projector :myapp/bad-shape
       (fn [_trace-event] {:wrong :shape}))
 
-    (let [project-error (requiring-resolve 're-frame.ssr/project-error)
+    (let [project-error ssr/project-error
           f             (rf/make-frame
                           {:platform :server
                            :ssr {:public-error-id   :myapp/bad-shape}})
@@ -635,7 +636,7 @@
 
 (deftest ssr-head-hash-mismatch
   (testing "verify-hydration! surfaces a head-mismatch via :failing-id on the unified render-hash channel"
-    (let [verify-fn @(resolve 're-frame.ssr/verify-hydration!)
+    (let [verify-fn ssr/verify-hydration!
           ;; Hydration payload carries the SERVER's render-hash. v1's
           ;; unified channel covers head + body; the head-vs-body
           ;; distinction lives entirely in :failing-id below.
@@ -760,4 +761,166 @@
             "mutating one return value yields a new map with the change")
         (is (= 200 (:status r2))
             "the other return value is untouched — no shared mutable state")))))
+
+;; ===========================================================================
+;; rf2-dl9yg TC-9 — direct error-projection-listener exercise (view-time path)
+;; ===========================================================================
+;;
+;; The handler-exception path is tested end-to-end through the Ring stack
+;; (ssr-ring `handler-render-error-projects-to-500`). The
+;; direct-ssr-layer equivalent — driving `error-projection-listener`
+;; with a synthetic view-time-style exception trace and asserting the
+;; projector stamps the response — was not pinned. Add it.
+;;
+;; The listener consumes :error trace events bound to a server frame
+;; and buffers them; `get-response` flushes the buffer through the
+;; active projector. The buffered-trace pattern is what shipped per
+;; rf2-asmj1 R*; the test reaches in via `re-frame.trace/emit!` so the
+;; full path runs without involving the Ring adapter.
+
+(deftest direct-ssr-layer-projects-view-time-exception
+  (testing "rf2-dl9yg TC9: a synthetic error trace tagged with a server frame
+            → error-projection-listener buffers → get-response flushes → response
+            :status carries the default projector's 500"
+    (let [f (rf/make-frame
+              {:platform :server
+               :ssr      {:public-error-id   :rf.ssr/default-error-projector
+                          :dev-error-detail? false}})]
+      ;; Emit a synthetic view-time-style error trace directly. Per
+      ;; the listener contract (`error_listener.cljc:103-115`) it
+      ;; gates on :op-type :error and the frame being a server frame;
+      ;; either condition failing → silent.
+      (trace/emit! :error :rf.error/view-time-exception
+                   {:frame             f
+                    :exception-message "synthetic view-time boom"
+                    :failing-id        :pages/articles
+                    :recovery          :warned-and-projected})
+      ;; Reading the response flushes the projection.
+      (let [resp (get-response f)]
+        (is (= 500 (:status resp))
+            "synthetic error trace → projector → 500 stamped onto :rf/response")
+        (is (nil? (:redirect resp))
+            "no redirect was set; the projector overwrites the status freely")))))
+
+;; ===========================================================================
+;; rf2-ooj41 — direct adapter-contract smoke
+;; ===========================================================================
+;;
+;; The `ssr/adapter` Var is the SSR substrate adapter — eight of nine
+;; slots implement the substrate contract cleanly; the ninth (`:render`)
+;; deliberately throws because SSR uses render-to-string exclusively.
+;; The shared test fixture installs the adapter on every `:each`, so
+;; the indirection is exercised constantly — but no test asserts the
+;; slot contents themselves. Add a direct check.
+
+(deftest adapter-installs-ssr-render-to-string
+  (testing "ssr/adapter wires re-frame.ssr/render-to-string into the
+            :render-to-string slot"
+    (let [adapter ssr/adapter]
+      (is (= :ssr (:kind adapter))
+          ":kind identifies the SSR substrate")
+      (is (fn? (:render-to-string adapter))
+          ":render-to-string is a callable fn")
+      ;; The slot fn is the production renderer — calling it against a
+      ;; tiny hiccup tree round-trips to an HTML string.
+      (let [html ((:render-to-string adapter) [:div "smoke"] {})]
+        (is (string? html))
+        (is (str/includes? html "smoke")
+            ":render-to-string emits HTML carrying the hiccup body"))
+      ;; The five state-container slots are present and callable.
+      (is (fn? (:make-state-container adapter)))
+      (is (fn? (:read-container adapter)))
+      (is (fn? (:replace-container! adapter)))
+      (is (fn? (:subscribe-container adapter)))
+      (is (fn? (:make-derived-value adapter))))))
+
+(deftest adapter-render-throws-rf-error-render-on-headless-adapter
+  (testing "ssr/adapter :render slot throws :rf.error/render-on-headless-adapter
+            — SSR uses render-to-string exclusively (Spec 006 §Plain-atom adapter)"
+    (let [render-fn (:render ssr/adapter)]
+      (is (fn? render-fn))
+      (try
+        (render-fn [:div] nil nil)
+        (is false "render-fn must throw — did not")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= ":rf.error/render-on-headless-adapter" (ex-message e))
+              "ex-message names the contract violation")
+          (is (string? (-> e ex-data :reason))
+              "ex-data carries a human :reason"))))))
+
+;; ===========================================================================
+;; rf2-ooj41 — redirect alias normalisation (:url and :to → :location)
+;; ===========================================================================
+;;
+;; Spec 011 §Redirect contract: `:rf.server/redirect` accepts `:location`,
+;; `:url`, or `:to` for the destination key. The current suite only
+;; exercises `:location`; the alias forms in `redirect-fx`
+;; (`response.cljc:218-221`) had no test coverage. Pin both aliases so a
+;; refactor that drops one fails loudly.
+
+(deftest redirect-alias-url-normalises-to-location
+  (testing "{:url \"...\"} is normalised to {:location \"...\" :status 302}"
+    (rf/reg-event-fx :alias/url-redirect
+      (fn [_ _]
+        {:fx [[:rf.server/redirect {:url "/dashboard"}]]}))
+    (let [f (rf/make-frame {:platform  :server
+                            :on-create [:alias/url-redirect]})
+          redirect (-> (get-response f) :redirect)]
+      (is (= "/dashboard" (:location redirect))
+          ":url alias is normalised onto :location in the resolved redirect")
+      (is (= 302 (:status redirect))
+          "default status flows through when no explicit :status supplied"))))
+
+(deftest redirect-alias-to-normalises-to-location
+  (testing "{:to \"...\"} is normalised to {:location \"...\" :status 302}"
+    (rf/reg-event-fx :alias/to-redirect
+      (fn [_ _]
+        {:fx [[:rf.server/redirect {:to "/welcome" :status 301}]]}))
+    (let [f (rf/make-frame {:platform  :server
+                            :on-create [:alias/to-redirect]})
+          redirect (-> (get-response f) :redirect)]
+      (is (= "/welcome" (:location redirect))
+          ":to alias is normalised onto :location")
+      (is (= 301 (:status redirect))
+          "caller-supplied :status wins over the 302 default"))))
+
+;; ===========================================================================
+;; rf2-hyk9j TC-6 — redirect short-circuits projector status overwrite
+;; ===========================================================================
+;;
+;; Per `error_listener.cljc:96-101` and Spec 011 §Redirect precedence:
+;; when the response carries a `:redirect`, `apply-error-projection!`
+;; must NOT overwrite the redirect's `:status` with the projector's
+;; status. Behaviour is correct in the impl; no test pinned it.
+
+(deftest redirect-suppresses-projector-status-overwrite
+  (testing "a request that redirects AND surfaces an error trace → response :status
+            stays at the redirect's status; the projector does not overwrite it"
+    (rf/reg-event-fx :redirect-then-error
+      (fn [_ _]
+        {:fx [[:rf.server/redirect {:status 302 :location "/login"}]
+              ;; Then trigger a handler-exception trace — the default
+              ;; projector maps this to 500. The redirect was set
+              ;; first; the projector must NOT promote 302 → 500.
+              [:dispatch [:throw-from-handler]]]}))
+    (rf/reg-event-fx :throw-from-handler
+      (fn [_ _] (throw (ex-info "post-redirect failure" {}))))
+
+    (let [traces (atom [])
+          _      (rf/register-trace-cb! ::rpe (fn [ev] (swap! traces conj ev)))
+          f      (rf/make-frame
+                   {:platform  :server
+                    :on-create [:redirect-then-error]
+                    :ssr       {:public-error-id   :rf.ssr/default-error-projector
+                                :dev-error-detail? false}})
+          _      (rf/remove-trace-cb! ::rpe)
+          resp   (get-response f)]
+      ;; The handler-exception fired (drain-time trace).
+      (is (some #(= :rf.error/handler-exception (:operation %)) @traces)
+          "the handler-exception was traced during the drain")
+      ;; The redirect survived: response :status is 302, not 500.
+      (is (= 302 (:status resp))
+          "redirect wins — projector must not overwrite a redirect's :status (Spec 011 §Redirect precedence)")
+      (is (= {:status 302 :location "/login"} (:redirect resp))
+          "the redirect map itself is unchanged"))))
 

--- a/implementation/ssr/test/re_frame/ssr_hash_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hash_test.clj
@@ -18,6 +18,8 @@
   lives in hash_check_cljs_test.cljs. This namespace focuses on
   pruning-equivalence."
   (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [re-frame.ssr.emit :as emit]
             [re-frame.ssr.hash :as hash]))
 
 ;; ---- canonical-edn ---------------------------------------------------------
@@ -105,3 +107,46 @@
                [:p "Body"]]]))
         "a deeply nested tree with nils at multiple levels hashes identically
          to the same tree with all nils pruned")))
+
+;; ===========================================================================
+;; rf2-dl9yg TC-2 — :doctype? + :emit-hash? composition
+;; ===========================================================================
+;;
+;; The two opts interact subtly: hash injection runs on the hiccup root
+;; BEFORE stringification (rf2-lxwse), so the doctype prepend lands after
+;; the hash attribute has been stamped — `data-rf-render-hash` rides on
+;; the root DOM element, not on the doctype declaration. Pin the
+;; composition.
+
+(deftest doctype-and-emit-hash-compose
+  (testing "(render-to-string tree {:doctype? true :emit-hash? true}) emits
+            <!DOCTYPE html> followed by <root data-rf-render-hash=\"...\"> —
+            the hash rides on the root element, not on the doctype"
+    (let [tree [:div {:class "page"} [:h1 "Hello"]]
+          html (emit/render-to-string tree {:doctype? true :emit-hash? true})]
+      (is (str/starts-with? html "<!DOCTYPE html>")
+          ":doctype? prepended")
+      (is (re-find #"<!DOCTYPE html><div[^>]*data-rf-render-hash=\"[0-9a-f]{8}\""
+                   html)
+          ":emit-hash? stamped on the root <div>, immediately after the doctype")
+      (is (str/includes? html "<h1>Hello</h1>")
+          "body content rendered"))))
+
+(deftest emit-hash-without-doctype-yields-bare-root
+  (testing ":emit-hash? true / :doctype? false → root element carries the hash;
+            no doctype prefix"
+    (let [tree [:section [:p "x"]]
+          html (emit/render-to-string tree {:emit-hash? true})]
+      (is (not (str/starts-with? html "<!DOCTYPE"))
+          "no doctype emitted")
+      (is (re-find #"^<section[^>]*data-rf-render-hash=\"[0-9a-f]{8}\""
+                   html)
+          "hash attribute on the root element"))))
+
+(deftest doctype-without-emit-hash-omits-hash-attribute
+  (testing ":doctype? true / :emit-hash? false → doctype emitted; no hash attr"
+    (let [tree [:div "no-hash"]
+          html (emit/render-to-string tree {:doctype? true :emit-hash? false})]
+      (is (str/starts-with? html "<!DOCTYPE html>"))
+      (is (not (str/includes? html "data-rf-render-hash"))
+          "no hash attribute when :emit-hash? false"))))

--- a/implementation/ssr/test/re_frame/ssr_head_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_head_test.clj
@@ -17,6 +17,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.head :as head]
@@ -385,3 +386,108 @@
                            "<meta property=\"og:image\" content=\"https://example.com/og.png\">"))
         (is (str/includes? html
                            "<link rel=\"canonical\" href=\"https://example.com/articles/123\">"))))))
+
+;; ===========================================================================
+;; rf2-hyk9j TC-2 — :html-attrs / :body-attrs head-model keys reach the model
+;; ===========================================================================
+;;
+;; Per Spec 011 §Head/meta — line 478: head models may carry `:html-attrs`
+;; and `:body-attrs`; the host shell stamps them on the opening tags
+;; (`head-model->html` deliberately drops them — the shell layer is the
+;; right place to stamp). The ssr-ring shell test pins the wire emission;
+;; this test pins the model-side contract — the keys survive
+;; `reg-head` → `render-head` → `active-head` verbatim, so any shell
+;; implementation (including non-default ones) can read them.
+
+(deftest html-attrs-and-body-attrs-survive-render-head
+  (testing "head models with :html-attrs / :body-attrs are produced verbatim
+            and reach the active-head consumer (Spec 011 §Head/meta line 478)"
+    (rf/reg-head :head/with-attrs
+                 (fn [_ _]
+                   {:title      "Article — fr-FR"
+                    :html-attrs {:lang "fr" :data-theme "dark"}
+                    :body-attrs {:class "page-article"}}))
+    (rf/reg-route :route/article-fr
+                  {:doc  "French article page"
+                   :path "/fr/articles/:id"
+                   :head :head/with-attrs})
+    (rf/reg-event-db :seed-fr
+                     (fn [db _]
+                       (assoc db :rf/route
+                              {:id :route/article-fr :params {:id "1"}})))
+    (let [f (rf/make-frame {:platform :server})]
+      (rf/dispatch-sync [:seed-fr] {:frame f})
+      (let [model (rf/active-head f)]
+        (is (= "Article — fr-FR" (:title model)))
+        (is (= {:lang "fr" :data-theme "dark"} (:html-attrs model))
+            ":html-attrs reaches the model verbatim")
+        (is (= {:class "page-article"} (:body-attrs model))
+            ":body-attrs reaches the model verbatim")))))
+
+(deftest head-model-to-html-drops-attr-bags
+  (testing "head-model->html does NOT inline :html-attrs / :body-attrs in the
+            fragment — those bags belong on <html> / <body> in the surrounding
+            shell, not in the head fragment"
+    (let [html (rf/head-model->html
+                 {:title      "X"
+                  :html-attrs {:lang "fr"}
+                  :body-attrs {:class "page-x"}})]
+      (is (str/includes? html "<title>X</title>"))
+      (is (not (str/includes? html "lang"))
+          "head-model->html does not stamp :html-attrs anywhere in its output")
+      (is (not (str/includes? html "page-x"))
+          "head-model->html does not stamp :body-attrs anywhere in its output"))))
+
+;; ===========================================================================
+;; rf2-j54ee CQ-2 — destroy-time trace symmetry on head cleanup hook
+;; ===========================================================================
+;;
+;; Per request.cljc's `on-frame-destroyed!`: a head-cleanup throw must
+;; surface on the trace bus rather than vanishing silently. Mirrors the
+;; pattern shipped at `ssr-ring/lifecycle/destroy-frame-quietly!`
+;; (audit R6 / cluster rf2-sljs1).
+
+(deftest head-cleanup-throw-emits-warning-trace
+  (testing "if the :ssr/head-on-frame-destroyed hook throws, the destroy
+            still completes AND a :rf.ssr.head/cleanup-failed warning trace
+            surfaces (audit rf2-cegm7 CQ-2 / rf2-j54ee)"
+    (let [prior-hook (late-bind/get-fn :ssr/head-on-frame-destroyed)
+          traces     (atom [])
+          ssr-request (requiring-resolve 're-frame.ssr.request/on-frame-destroyed!)]
+      ;; Install a head-cleanup hook that throws — vanity exception
+      ;; so the catch path runs.
+      (late-bind/set-fn! :ssr/head-on-frame-destroyed
+        (fn [_frame-id] (throw (ex-info "boom from head cleanup" {:reason :test}))))
+      (try
+        (rf/register-trace-cb! ::head-clean (fn [ev] (swap! traces conj ev)))
+        ;; Drive the destroy hook directly — that's the path Mark-3
+        ;; teardown takes per the late-bind chaining.
+        (try (ssr-request :test/frame-id)
+             (catch Throwable _
+               ;; The hook must NOT propagate the exception — fail the
+               ;; test if it does.
+               (is false "on-frame-destroyed! must catch head-cleanup throws")))
+        (rf/remove-trace-cb! ::head-clean)
+
+        (let [hits (filterv #(= :rf.ssr.head/cleanup-failed (:operation %)) @traces)]
+          (is (= 1 (count hits))
+              (str "expected one :rf.ssr.head/cleanup-failed trace; saw: "
+                   (pr-str (mapv :operation @traces))))
+          (when (seq hits)
+            (let [ev (first hits)]
+              (is (= :warning (:op-type ev)))
+              (is (= :test/frame-id (-> ev :tags :frame))
+                  ":frame tag identifies which frame's cleanup failed")
+              (is (= :ssr/head-on-frame-destroyed (-> ev :tags :hook))
+                  ":hook tag identifies which hook misbehaved")
+              (is (string? (-> ev :tags :reason))
+                  ":reason carries the throwable's message")
+              (is (string? (-> ev :tags :ex-class))
+                  ":ex-class carries the throwable's class name")
+              (is (= :warned-and-skipped (:recovery ev))
+                  ":recovery names the policy — observed and continued"))))
+        (finally
+          ;; Restore the prior hook so subsequent tests see normal behaviour.
+          (if prior-hook
+            (late-bind/set-fn! :ssr/head-on-frame-destroyed prior-hook)
+            (swap! late-bind/hooks dissoc :ssr/head-on-frame-destroyed)))))))


### PR DESCRIPTION
## Summary

Round-2 audit polish wave covering 6 of 7 follow-on beads from rf2-cegm7 (rf2-ip6ol surfaced as decision-blocked).

**Beads addressed:**

- **rf2-j54ee** — destroy-time trace symmetry on head-cleanup hook + dropped `on-create-with-request` conj path (cofx is now the only canonical surface) + new `re-frame.ssr.constants/payload-script-id` constant
- **rf2-ooj41** — scalar compat-check skipped paths (`:rf.ssr/check-version` / `:rf.ssr/check-schema-digest`) + direct `ssr/adapter` smoke + redirect alias normalisation (`:url` / `:to`)
- **rf2-hyk9j** — TC2 `:html-attrs` / `:body-attrs` head-model contract + TC3 `:rf.ssr/destroy-frame-failed` trace + TC6 redirect short-circuits projector status overwrite
- **rf2-dl9yg** — TC2 `:doctype?` + `:emit-hash?` composition + TC9 direct ssr-layer view-time-exception + TC10 `requiring-resolve` removal in tests
- **rf2-8k0g3** — Reagent CLJS test pinning `:rf.error/no-hiccup-emitter-bound` ex-info shape
- **rf2-gc5v9** — UIx CLJS test pinning `:rf.error/no-hiccup-emitter-bound` ex-info shape (direct-install path; rf2-4z7bp tracks UIx's late-bind hook gap)

**Decision-blocked:** rf2-ip6ol (head-snapshot public/test-only status). The bead explicitly notes both options are internally consistent; Mike's call.

**LoC delta:** +783 / −47 across 14 files (3 new files: 2 CLJS test files + 1 constants ns).

## Test plan

- [x] `cd implementation/ssr && clojure -M:test` — 97 tests, 321 assertions, 0 failures
- [x] `cd implementation/ssr-ring && clojure -M:test` — 24 tests, 102 assertions, 0 failures
- [x] `cd implementation/core && clojure -M:test` — 477 tests, 2458 assertions, 0 failures (includes the ssr example end-to-end flow)
- [x] `cd implementation && npm run test:cljs` — 1821 tests, 5121 assertions, 0 failures (5 new tests from the two new CLJS test files)