### PR TITLE
fix(schemas): precise + sensitivity-aware app-db validation paths (rf2-oh4se, rf2-yv62u)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -100,6 +100,7 @@
 (def extract-large-paths-from-schema  walker/extract-large-paths-from-schema)
 (def extract-sensitive-paths-from-schema walker/extract-sensitive-paths-from-schema)
 (def schema-has-sensitive?            walker/schema-has-sensitive?)
+(def schema-sensitive-at?             walker/schema-sensitive-at?)
 
 ;; Per-flag registry feeders (rf2-v9tw2 / rf2-c1l4d).
 (def frame-elision-declarations    elision-feeder/frame-elision-declarations)

--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -99,6 +99,45 @@
     (contains? tags :explain)  (assoc :explain   redacted-sentinel)
     true                       (assoc :sensitive? true)))
 
+(defn- common-prefix
+  "Return the longest common prefix of two sequential collections (as a
+  vector). Element-wise comparison via `=`. Helper for narrowing
+  multi-error explainer outputs to a single most-specific `:in` path."
+  [a b]
+  (loop [a (seq a) b (seq b) acc (transient [])]
+    (if (and a b (= (first a) (first b)))
+      (recur (next a) (next b) (conj! acc (first a)))
+      (persistent! acc))))
+
+(defn- failing-in-path
+  "Per rf2-oh4se — derive the failing leaf value-path from the registered
+  explainer's output. Returns a vector path (possibly empty when the
+  failure is at the schema root) or nil when the explanation carries
+  no extractable `:in` path (e.g. non-Malli explainer, malformed
+  output, or no explainer registered).
+
+  Malli's explanation shape is `{:schema ... :value ... :errors
+  ({:path [...] :in [...] :schema ... :value ...} ...)}`. The `:in`
+  slot is the navigation path through the failing VALUE (what we want
+  for `(get-in db (concat registered-path :in))`); `:path` is the
+  schema-walk path which encodes dispatch values (`:multi` / `:orn`
+  branches) — wrong for value navigation.
+
+  Multi-error explanations collapse to the common ancestor across
+  every error's `:in` — narrowest path that contains every failure
+  site. For a single error this is just that error's `:in`. When
+  every error's `:in` agrees the result is exact; when they diverge
+  (e.g. two separate slots in a map both fail) the common prefix is
+  the parent slot that contains them.
+
+  Pure; same explanation always produces the same output."
+  [explanation]
+  (when (map? explanation)
+    (when-let [errors (seq (:errors explanation))]
+      (let [paths (keep :in errors)]
+        (when (seq paths)
+          (reduce common-prefix (first paths) (rest paths)))))))
+
 (defn- type-of-value [v]
   (cond
     (string? v)  "string"
@@ -244,32 +283,71 @@
    ;; which is wasted work on the post-handler-commit hot path.
    (when interop/debug-enabled?
      (when-let [vf @validator/validator-fn]
-       (doseq [[path m] (storage/frame-schema-entries frame-id)]
-         (let [val-at (get-in db path)
+       (doseq [[reg-path m] (storage/frame-schema-entries frame-id)]
+         (let [val-at (get-in db reg-path)
                schema (:schema m)]
            (when-not (vf schema val-at)
+             ;; Per rf2-oh4se — make the failure path precise and the
+             ;; sensitivity decision path-targeted.
+             ;;
+             ;; The registered explainer is invoked exactly once on
+             ;; the failure branch; its output feeds BOTH the trace's
+             ;; `:explain` slot (verbatim) and the failing-leaf path
+             ;; extraction. `failing-in-path` returns the navigation
+             ;; path through the value Malli reports under `:in` (the
+             ;; value-relative path, not the schema-walk path under
+             ;; `:path` which carries `:multi` / `:orn` dispatch
+             ;; values). The trace's `:path` is the registered root
+             ;; conj'd with the leaf — the slot a consumer can
+             ;; `get-in` against on a NON-failed copy of app-db.
+             ;;
+             ;; Conservative fallback: when no leaf path is
+             ;; extractable (non-Malli explainer, missing
+             ;; explanation), keep the old behaviour — emit the
+             ;; registered root as `:path` and consult
+             ;; `schema-has-sensitive?` for the redaction decision.
+             ;; The `:registered-path` tag always carries the
+             ;; registration root so tooling can reach it regardless
+             ;; of whether path narrowing succeeded.
+             ;;
              ;; Per Spec 010 §`:sensitive?` — privacy in schema-
-             ;; validation error traces (rf2-kj51z). Consult the
-             ;; schema's per-slot `:sensitive?` props before
-             ;; including the failing value. The failing path is
-             ;; the reg-app-schema path itself (per-path validation
-             ;; only flags the whole registered slot); the walker
-             ;; checks for container-level OR any nested slot the
-             ;; failure path crosses.
-             (let [sensitive? (walker/schema-has-sensitive? schema)
-                   base-tags  (cond-> {:where    :app-db
-                                       :path     path
-                                       :value    val-at
-                                       :frame    frame-id
-                                       :explain  (validator/run-explainer schema val-at)
-                                       :reason   (reason-string
-                                                   "App-db at path "
-                                                   path
-                                                   " failed schema "
-                                                   schema val-at)
-                                       :recovery :no-recovery}
-                                event-id (assoc :failing-id event-id))
-                   tags       (if sensitive? (redact-tags base-tags) base-tags)]
+             ;; validation error traces (rf2-kj51z). The path-targeted
+             ;; check (`schema-sensitive-at?`) replaces the coarse
+             ;; whole-schema check: a failure at a non-sensitive slot
+             ;; in a schema that also declares a sibling slot
+             ;; sensitive no longer suffers redaction. Conservative
+             ;; semantics preserved — ancestor-sensitive OR
+             ;; descendant-sensitive at the failing path counts.
+             (let [explanation (validator/run-explainer schema val-at)
+                   in-path     (failing-in-path explanation)
+                   leaf-path   (if in-path
+                                 (vec (concat reg-path in-path))
+                                 reg-path)
+                   ;; Per rf2-oh4se the trace's `:value` is the failing
+                   ;; leaf's value (what the schema slot at `leaf-path`
+                   ;; rejected) — narrowed via the explainer's `:in`
+                   ;; navigation path. Falls back to the whole
+                   ;; registered slot when no leaf can be extracted.
+                   leaf-value  (if in-path
+                                 (get-in val-at in-path)
+                                 val-at)
+                   sensitive?  (if in-path
+                                 (walker/schema-sensitive-at? schema in-path)
+                                 (walker/schema-has-sensitive? schema))
+                   base-tags   (cond-> {:where           :app-db
+                                        :path            leaf-path
+                                        :registered-path reg-path
+                                        :value           leaf-value
+                                        :frame           frame-id
+                                        :explain         explanation
+                                        :reason          (reason-string
+                                                           "App-db at path "
+                                                           leaf-path
+                                                           " failed schema "
+                                                           schema leaf-value)
+                                        :recovery        :no-recovery}
+                                 event-id (assoc :failing-id event-id))
+                   tags        (if sensitive? (redact-tags base-tags) base-tags)]
                (trace/emit-error! :rf.error/schema-validation-failure tags)))))))))
 
 (defn validate-event!

--- a/implementation/schemas/src/re_frame/schemas/walker.cljc
+++ b/implementation/schemas/src/re_frame/schemas/walker.cljc
@@ -229,3 +229,52 @@
   (-> (extract-sensitive-paths-from-schema schema [])
       seq
       boolean))
+
+(defn- prefix?
+  "True when `prefix` is a prefix of `path` (or equal). Both are
+  sequential collections compared element-wise."
+  [prefix path]
+  (and (<= (count prefix) (count path))
+       (= (seq prefix) (seq (take (count prefix) path)))))
+
+(defn schema-sensitive-at?
+  "Path-targeted sensitivity check (rf2-oh4se). Returns true when the
+  slot at `in-path` inside `schema` is sensitive under Spec 010
+  §`:sensitive?`. `in-path` is the navigation path relative to the
+  schema's root (the value path Malli reports as `:in` in its explain
+  output, NOT the `:path` slot which encodes branch dispatch values).
+
+  A slot at `in-path` is sensitive when EITHER:
+
+    - An **ancestor** along the path is `:sensitive?` — the failing
+      slot sits underneath a sensitive container, so its value is part
+      of a sensitive subtree (e.g. `[:auth]` is sensitive, the failing
+      slot is `[:auth :token]`).
+
+    - A **descendant** of the slot is `:sensitive?` — the failing
+      slot's value contains a sensitive child (e.g. `[:user]` is the
+      failing slot, `[:user :password]` is declared sensitive; the
+      value at `[:user]` carries the password verbatim and would
+      re-leak it if shipped).
+
+  Per Spec 010 §`:sensitive?` — privacy in schema-validation error
+  traces; replaces the coarse whole-schema `schema-has-sensitive?`
+  check at the `validate-app-db!` emit-site when a leaf path is
+  extractable from the explainer output.
+
+  When `in-path` is nil or empty the check is equivalent to
+  `schema-has-sensitive?` (the failing slot IS the whole registered
+  schema, so any sensitive declaration anywhere counts).
+
+  Returns boolean. Pure; same `(schema, in-path)` always produces the
+  same output."
+  [schema in-path]
+  (if (or (nil? in-path) (empty? in-path))
+    (schema-has-sensitive? schema)
+    (let [decls (extract-sensitive-paths-from-schema schema [])
+          in-v  (vec in-path)]
+      (boolean
+        (some (fn [decl-path]
+                (or (prefix? decl-path in-v)   ;; ancestor sensitive
+                    (prefix? in-v decl-path))) ;; descendant sensitive
+              (keys decls))))))

--- a/implementation/schemas/test/re_frame/schemas_failure_paths_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_failure_paths_test.clj
@@ -1,0 +1,335 @@
+(ns re-frame.schemas-failure-paths-test
+  "JVM tests for the precise / sensitivity-aware failure-path contract
+  on `validate-app-db!` (rf2-oh4se).
+
+  Pre-rf2-oh4se, `validate-app-db!` always emitted the registered
+  schema root as `:path` and applied coarse whole-schema redaction
+  whenever any nested slot in the schema declared `:sensitive?`. The
+  audit (rf2-x8x4p) flagged two consequences:
+
+    1. **Imprecise locator.** A consumer reading the trace had to walk
+       the registered schema by hand to find the failing leaf — the
+       trace itself only pointed at the registration root.
+    2. **Over-broad redaction.** A failure at a non-sensitive sibling
+       slot (e.g. `[:user :name]`) suffered redaction because the same
+       schema declared a separate slot (e.g. `[:user :password]`)
+       sensitive. The sensitive sibling's value did not appear in the
+       failing leaf — but the whole `:user` map was shipped and
+       redacted regardless.
+
+  rf2-oh4se's fix:
+
+    - Derive the failing leaf path from the Malli explainer's `:in`
+      slot (the navigation path through the failing VALUE, not the
+      schema-walk `:path` slot which encodes branch dispatch values).
+    - Emit `:path` as the FULL leaf path
+      (`(concat registered-path explain-in-path)`); emit
+      `:registered-path` as the registration root for tooling that
+      still wants the registration anchor.
+    - Apply sensitivity targeted at the failing leaf:
+      ancestor-sensitive OR descendant-sensitive at the leaf counts;
+      a sibling-sensitive flag on an UN-failing slot does NOT trigger
+      redaction.
+    - Conservative fallback: when the explainer is absent / non-Malli
+      / returns no extractable `:in`, fall back to the registered
+      root as `:path` and the whole-schema sensitivity check.
+
+  Backward-compat: `:explain` and the structural slots
+  (`:failing-id`, `:where`, `:frame`, `:recovery`, `:reason`) ride
+  the trace verbatim under both the precise and fallback paths."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.schemas :as schemas]
+            [re-frame.schemas.malli]
+            [re-frame.schemas.test-fixture :as tf]))
+
+(use-fixtures :each tf/reset-runtime)
+
+(defn- capture-trace
+  "Run `body-fn` while collecting :rf.error/schema-validation-failure
+  trace events; return the vector of captured events."
+  [body-fn]
+  (let [traces (atom [])
+        cb-id  (keyword (gensym "capture"))]
+    (rf/register-trace-cb! cb-id (fn [ev] (swap! traces conj ev)))
+    (try
+      (body-fn)
+      (finally (rf/remove-trace-cb! cb-id)))
+    (filterv #(= :rf.error/schema-validation-failure (:operation %))
+             @traces)))
+
+;; ---- :path is the failing leaf, not the registration root ----------------
+
+(deftest path-is-leaf-when-explainer-reports-in
+  (testing "rf2-oh4se — :path is the registered path concat'd with the
+            explainer's :in (the failing value's navigation path)"
+    (rf/reg-app-schema [:user] [:map [:id :int] [:email :string]])
+    (let [traces (capture-trace
+                   #(schemas/validate-app-db!
+                      {:user {:id "not-an-int" :email "alice@example.com"}}
+                      :user/set-bad))]
+      (is (= 1 (count traces)))
+      (let [v (first traces)]
+        (is (= [:user :id] (-> v :tags :path))
+            ":path is the leaf — registered root [:user] + :in [:id]")
+        (is (= [:user] (-> v :tags :registered-path))
+            ":registered-path carries the registration anchor")
+        (is (= :user/set-bad (-> v :tags :failing-id)))
+        (is (= :app-db (-> v :tags :where)))))))
+
+(deftest path-includes-leaf-in-reason-string
+  (testing "the human-readable :reason carries the leaf path so the
+            elision-probe substring stays distinctive per surface"
+    (rf/reg-app-schema [:user] [:map [:age :int]])
+    (let [traces (capture-trace
+                   #(schemas/validate-app-db! {:user {:age "old"}} :u/bad))
+          v      (first traces)]
+      (is (.contains ^String (-> v :tags :reason) "[:user :age]")
+          ":reason names the leaf path"))))
+
+(deftest path-falls-back-to-registered-root-when-in-is-empty
+  (testing "when the registered schema is itself the failing slot
+            (Malli :in []), :path equals the registration root"
+    (rf/reg-app-schema [:count] [:int])
+    (let [traces (capture-trace
+                   #(schemas/validate-app-db! {:count "x"} :c/bad))
+          v      (first traces)]
+      (is (= [:count] (-> v :tags :path))
+          ":path is the registered root — no leaf to narrow to")
+      (is (= [:count] (-> v :tags :registered-path))))))
+
+(deftest path-narrows-on-deeply-nested-failure
+  (testing "deeply nested failures resolve the full leaf path through
+            multiple :map levels"
+    (rf/reg-app-schema [:root]
+                       [:map
+                        [:a [:map
+                             [:b [:map
+                                  [:c [:map [:d :int]]]]]]]])
+    (let [traces (capture-trace
+                   #(schemas/validate-app-db!
+                      {:root {:a {:b {:c {:d "not-an-int"}}}}}
+                      :r/bad))
+          v      (first traces)]
+      (is (= [:root :a :b :c :d] (-> v :tags :path))
+          ":path is the full deep leaf"))))
+
+;; ---- sensitivity is path-targeted, not whole-schema ----------------------
+
+(deftest non-sensitive-sibling-failure-not-redacted
+  (testing "rf2-oh4se — a failure at a non-sensitive sibling does NOT
+            trigger redaction merely because another slot in the same
+            schema is :sensitive?. The over-broad redaction was the
+            symptom the bead fix targets."
+    (rf/reg-app-schema [:user]
+                       [:map
+                        [:name     :string]
+                        [:password {:sensitive? true} :string]])
+    ;; :name is the failing leaf (int, not string); :password is
+    ;; correct. The failing leaf [:user :name] is NOT sensitive; the
+    ;; sibling [:user :password] is sensitive but does not appear in
+    ;; the failing value. No redaction.
+    (let [traces (capture-trace
+                   #(schemas/validate-app-db!
+                      {:user {:name 42 :password "secret-pw"}}
+                      :u/bad-name))
+          v      (first traces)]
+      (is (not (contains? v :sensitive?))
+          "no top-level :sensitive? stamp — failing leaf is non-sensitive")
+      (is (not (contains? (:tags v) :sensitive?))
+          ":tags :sensitive? also absent")
+      (is (= 42 (-> v :tags :value))
+          ":value rides verbatim — sibling-sensitive does not redact a
+          non-sensitive leaf")
+      (is (= [:user :name] (-> v :tags :path)))
+      (is (some? (-> v :tags :explain))
+          ":explain rides verbatim — the explainer output is the leaf's,
+          not the whole schema's"))))
+
+(deftest sensitive-leaf-failure-redacted
+  (testing "the failing leaf IS the sensitive slot — redaction fires"
+    (rf/reg-app-schema [:user]
+                       [:map
+                        [:name     :string]
+                        [:password {:sensitive? true} :string]])
+    ;; :password is the failing leaf (int, not string).
+    (let [traces (capture-trace
+                   #(schemas/validate-app-db!
+                      {:user {:name "alice" :password 99}}
+                      :u/bad-pw))
+          v      (first traces)]
+      (is (true? (:sensitive? v))
+          "top-level :sensitive? stamp on the failing leaf's redaction")
+      (is (= :rf/redacted (-> v :tags :value)))
+      (is (= :rf/redacted (-> v :tags :explain)))
+      (is (= [:user :password] (-> v :tags :path))
+          ":path stays visible — structural slot survives redaction"))))
+
+(deftest ancestor-sensitive-redacts
+  (testing "a failure deep inside a sensitive container redacts — the
+            failing slot is part of a sensitive subtree"
+    (rf/reg-app-schema [:auth]
+                       [:map {:sensitive? true}
+                        [:token :string]
+                        [:expiry :int]])
+    ;; :token is the failing leaf (int, not string); the container
+    ;; [:auth] is sensitive, so the whole subtree is sensitive.
+    (let [traces (capture-trace
+                   #(schemas/validate-app-db!
+                      {:auth {:token 42 :expiry 9999}}
+                      :auth/bad))
+          v      (first traces)]
+      (is (true? (:sensitive? v))
+          "ancestor-sensitive — the failing leaf inherits sensitivity")
+      (is (= :rf/redacted (-> v :tags :value))))))
+
+(deftest descendant-sensitive-redacts
+  (testing "a failure at a container whose descendant is sensitive
+            redacts — the failing value carries the sensitive child"
+    ;; The whole [:user] map fails because it's not even a map.
+    (rf/reg-app-schema [:user]
+                       [:map
+                        [:name     :string]
+                        [:password {:sensitive? true} :string]])
+    (let [traces (capture-trace
+                   #(schemas/validate-app-db! {:user "wholly-bogus"} :u/bad))
+          v      (first traces)]
+      (is (true? (:sensitive? v))
+          "descendant-sensitive — the failing value is the whole map and
+          contains the sensitive child slot's value")
+      (is (= :rf/redacted (-> v :tags :value))))))
+
+(deftest both-sensitive-and-clean-failures-handled-independently
+  (testing "two registered schemas; one's failure is sensitive, the
+            other's is not — each trace is independently classified"
+    (rf/reg-app-schema [:auth] [:map [:token {:sensitive? true} :string]])
+    (rf/reg-app-schema [:count] [:int])
+    (let [traces (capture-trace
+                   #(schemas/validate-app-db!
+                      {:auth {:token 42} :count "not-an-int"}
+                      :bulk/bad))]
+      (is (= 2 (count traces)))
+      (let [by-path (group-by #(-> % :tags :registered-path) traces)
+            auth-v  (first (get by-path [:auth]))
+            cnt-v   (first (get by-path [:count]))]
+        (is (true? (:sensitive? auth-v))
+            ":auth failure carries sensitive redaction")
+        (is (= :rf/redacted (-> auth-v :tags :value)))
+        (is (not (contains? cnt-v :sensitive?))
+            ":count failure is plain — no redaction")
+        (is (= "not-an-int" (-> cnt-v :tags :value)))))))
+
+;; ---- conservative fallback ----------------------------------------------
+
+(deftest fallback-uses-whole-schema-sensitivity-when-explainer-absent
+  (testing "Per rf2-oh4se — when no explainer can extract a leaf path
+            (e.g. explainer returns nil; non-Malli validator with no
+            structured explanation), :path falls back to the registered
+            root and the sensitivity check falls back to the
+            whole-schema `schema-has-sensitive?` rule (conservative)."
+    ;; Register a validator/explainer pair where validate fails but
+    ;; explain returns no `:in` data — simulates a non-Malli or
+    ;; structurally-different explainer.
+    (schemas/set-schema-validator! {:validate (fn [_ _] false)
+                                    :explain  (fn [_ _] nil)})
+    (try
+      (rf/reg-app-schema [:user]
+                         [:map [:password {:sensitive? true} :string]])
+      (let [traces (capture-trace
+                     #(schemas/validate-app-db! {:user {:password "pw"}}
+                                                :u/bad))
+            v      (first traces)]
+        (is (= 1 (count traces)))
+        (is (= [:user] (-> v :tags :path))
+            ":path falls back to the registered root when no leaf
+            extractable")
+        (is (true? (:sensitive? v))
+            "conservative fallback — whole-schema sensitivity wins when
+            the failing leaf cannot be narrowed")
+        (is (= :rf/redacted (-> v :tags :value))
+            "conservative fallback — value redacted under whole-schema
+            sensitivity"))
+      (finally
+        (schemas/reset-schema-validator!)))))
+
+(deftest fallback-non-sensitive-rides-verbatim
+  (testing "fallback path with a non-sensitive schema still emits the
+            verbatim value — the fallback only conserves the privacy
+            posture, not the failure shape"
+    (schemas/set-schema-validator! {:validate (fn [_ _] false)
+                                    :explain  (fn [_ _] nil)})
+    (try
+      (rf/reg-app-schema [:count] [:int])
+      (let [traces (capture-trace
+                     #(schemas/validate-app-db! {:count "x"} :c/bad))
+            v      (first traces)]
+        (is (= [:count] (-> v :tags :path)))
+        (is (= "x" (-> v :tags :value)))
+        (is (not (contains? v :sensitive?))))
+      (finally
+        (schemas/reset-schema-validator!)))))
+
+;; ---- registered-path always present --------------------------------------
+
+(deftest registered-path-always-present
+  (testing ":registered-path is stamped on every emit-site regardless of
+            whether leaf narrowing succeeded — tooling can pivot on it"
+    (rf/reg-app-schema [:user] [:map [:age :int]])
+    (let [traces (capture-trace
+                   #(schemas/validate-app-db! {:user {:age "x"}} :u/bad))
+          v      (first traces)]
+      (is (= [:user] (-> v :tags :registered-path))
+          ":registered-path is the registration anchor — distinct from
+          the failing leaf [:user :age]")
+      (is (= [:user :age] (-> v :tags :path))))))
+
+;; ---- walker: schema-sensitive-at? unit tests -----------------------------
+
+(deftest sensitive-at-empty-path-equals-whole-schema-check
+  (testing "(schema-sensitive-at? schema []) ≡ schema-has-sensitive? —
+            an empty path means 'the failing slot IS the schema'"
+    (let [sens     [:map [:p {:sensitive? true} :string]]
+          not-sens [:map [:p :string]]]
+      (is (true?  (schemas/schema-sensitive-at? sens     [])))
+      (is (true?  (schemas/schema-sensitive-at? sens     nil)))
+      (is (false? (schemas/schema-sensitive-at? not-sens [])))
+      (is (false? (schemas/schema-sensitive-at? not-sens nil))))))
+
+(deftest sensitive-at-leaf-direct-match
+  (testing "the failing leaf is itself flagged :sensitive?"
+    (let [schema [:map
+                  [:name     :string]
+                  [:password {:sensitive? true} :string]]]
+      (is (true?  (schemas/schema-sensitive-at? schema [:password])))
+      (is (false? (schemas/schema-sensitive-at? schema [:name]))))))
+
+(deftest sensitive-at-ancestor-flagged
+  (testing "an ancestor along the path carries :sensitive? — leaf
+            inherits sensitivity"
+    (let [schema [:map {:sensitive? true}
+                  [:token :string]
+                  [:expiry :int]]]
+      (is (true? (schemas/schema-sensitive-at? schema [:token])))
+      (is (true? (schemas/schema-sensitive-at? schema [:expiry]))))))
+
+(deftest sensitive-at-descendant-flagged
+  (testing "a descendant of the failing slot is :sensitive? — the
+            failing slot's value would carry the sensitive child"
+    (let [schema [:map
+                  [:user [:map
+                          [:name     :string]
+                          [:password {:sensitive? true} :string]]]]]
+      (is (true? (schemas/schema-sensitive-at? schema [:user]))
+          "failing at :user — its value contains the sensitive :password")
+      (is (true? (schemas/schema-sensitive-at? schema [:user :password])))
+      (is (false? (schemas/schema-sensitive-at? schema [:user :name]))
+          "sibling-only sensitive — non-sensitive leaf stays clean"))))
+
+(deftest sensitive-at-unrelated-path
+  (testing "a sensitive declaration on an unrelated branch does not
+            taint the failing leaf"
+    (let [schema [:map
+                  [:public  :string]
+                  [:auth    [:map [:token {:sensitive? true} :string]]]]]
+      (is (false? (schemas/schema-sensitive-at? schema [:public]))
+          ":public is on a different branch from :auth/:token"))))

--- a/implementation/schemas/test/re_frame/schemas_storage_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_storage_test.clj
@@ -1,0 +1,184 @@
+(ns re-frame.schemas-storage-test
+  "JVM tests for the slice-local storage / introspection surface
+  (rf2-yv62u).
+
+  The audit (rf2-yv62u) flagged a coverage gap: while the validation
+  hot path is well-pinned, the per-frame storage / introspection
+  surface had no direct slice-local tests for `app-schema-meta-at`,
+  `frame-schema-entries`, or the `coerce-opts` bad-arg branch.
+  Drift in these introspection helpers would silently break pair-
+  tools, 10x panels, and the late-bind seam between schemas and
+  elision / epoch.
+
+  This file pins the storage / introspection contract."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.schemas :as schemas]
+            [re-frame.schemas.storage :as storage]
+            [re-frame.schemas.test-fixture :as tf]))
+
+(use-fixtures :each tf/reset-runtime)
+
+;; ---- app-schema-meta-at --------------------------------------------------
+
+(deftest meta-at-returns-full-registration-map
+  (testing "app-schema-meta-at returns the registration metadata map —
+            including :schema, :path, :frame, and source-coords —
+            distinct from app-schema-at which returns just :schema"
+    (rf/reg-app-schema [:user] [:map [:id :int]])
+    (let [m (schemas/app-schema-meta-at [:user])]
+      (is (map? m))
+      (is (= [:map [:id :int]] (:schema m))
+          ":schema slot carries the registered form")
+      (is (= [:user] (:path m))
+          ":path slot mirrors the registration path")
+      (is (some? (:frame m))
+          ":frame slot is stamped — :rf/default outside (with-frame ...)"))))
+
+(deftest meta-at-is-nil-for-unregistered-path
+  (testing "an unregistered path yields nil — distinguishable from a
+            registration that happened to carry a nil :schema"
+    (is (nil? (schemas/app-schema-meta-at [:never-registered])))))
+
+(deftest meta-at-keyword-sugar-resolves-frame
+  (testing "the keyword-sugar arity targets the named frame —
+            parallel to app-schema-at"
+    (rf/reg-app-schema [:user] [:map] {:frame :tenant/a})
+    (rf/reg-app-schema [:user] [:vector] {:frame :tenant/b})
+    (is (= [:map] (:schema (schemas/app-schema-meta-at [:user] :tenant/a)))
+        "frame :tenant/a's registration is isolated")
+    (is (= [:vector] (:schema (schemas/app-schema-meta-at [:user] :tenant/b)))
+        "frame :tenant/b's registration is isolated")
+    (is (nil? (schemas/app-schema-meta-at [:user] :tenant/never))
+        "unknown frame → nil")))
+
+(deftest meta-at-opts-map-arity
+  (testing "the opts-map arity {:frame ...} matches the keyword sugar"
+    (rf/reg-app-schema [:user] [:map] {:frame :tenant/a})
+    (is (= (schemas/app-schema-meta-at [:user] :tenant/a)
+           (schemas/app-schema-meta-at [:user] {:frame :tenant/a}))
+        "opts-map and keyword-sugar produce identical results")))
+
+(deftest meta-at-reflects-hot-reload-replacement
+  (testing "re-registering the same path with a new schema replaces the
+            meta map — hot-reload semantics on the introspection
+            surface"
+    (rf/reg-app-schema [:user] [:map [:id :int]])
+    (is (= [:map [:id :int]] (:schema (schemas/app-schema-meta-at [:user]))))
+    (rf/reg-app-schema [:user] [:map [:id :uuid]])
+    (is (= [:map [:id :uuid]] (:schema (schemas/app-schema-meta-at [:user])))
+        "second registration replaces the first in the meta map")))
+
+;; ---- frame-schema-entries ------------------------------------------------
+
+(deftest frame-schema-entries-returns-empty-for-unknown-frame
+  (testing "an unknown frame produces an empty map — the cross-artefact
+            seam never blows up on consumers that ask before any
+            registration has happened"
+    (is (= {} (schemas/frame-schema-entries :rf/default)))
+    (is (= {} (schemas/frame-schema-entries :never/created)))))
+
+(deftest frame-schema-entries-returns-path-to-meta-map
+  (testing "frame-schema-entries returns the full {path → schema-meta}
+            map for a frame — the shape the validation hot path walks"
+    (rf/reg-app-schema [:user] [:map [:id :int]])
+    (rf/reg-app-schema [:auth] [:map [:token :string]])
+    (let [entries (schemas/frame-schema-entries :rf/default)]
+      (is (= #{[:user] [:auth]} (set (keys entries)))
+          "both registered paths present")
+      (is (= [:map [:id :int]] (-> entries (get [:user]) :schema)))
+      (is (= [:map [:token :string]] (-> entries (get [:auth]) :schema))))))
+
+(deftest frame-schema-entries-per-frame-isolation
+  (testing "entries from one frame do not bleed into another — the
+            cross-artefact seam respects frame scoping"
+    (rf/reg-app-schema [:user] [:map] {:frame :tenant/a})
+    (rf/reg-app-schema [:user] [:vector] {:frame :tenant/b})
+    (is (= [:map]    (-> (schemas/frame-schema-entries :tenant/a)
+                         (get [:user]) :schema)))
+    (is (= [:vector] (-> (schemas/frame-schema-entries :tenant/b)
+                         (get [:user]) :schema)))
+    (is (not (contains? (schemas/frame-schema-entries :tenant/a)
+                        [:other-path-in-tenant-b]))
+        "tenant/a's view does not include tenant/b's entries")))
+
+;; ---- coerce-opts ---------------------------------------------------------
+
+(deftest coerce-opts-accepts-keyword
+  (testing "keyword sugar coerces to {:frame keyword}"
+    (is (= {:frame :tenant/a} (storage/coerce-opts :tenant/a)))))
+
+(deftest coerce-opts-accepts-opts-map
+  (testing "opts-map passes through verbatim"
+    (is (= {:frame :tenant/a :other :thing}
+           (storage/coerce-opts {:frame :tenant/a :other :thing})))
+    (is (= {} (storage/coerce-opts {})))))
+
+(deftest coerce-opts-throws-on-bad-arg
+  (testing "Per rf2-yv62u — a non-keyword, non-map argument throws
+            :rf.error/bad-app-schemas-arg. nil, numbers, strings,
+            vectors all fail."
+    (doseq [bad-arg [nil 42 "frame-a" [:a :b] :well/-actually-keyword-is-ok]]
+      (cond
+        ;; keywords pass — exclude from the throw-loop sentinel above.
+        (keyword? bad-arg)
+        (is (map? (storage/coerce-opts bad-arg))
+            (str "keyword " bad-arg " is accepted"))
+
+        :else
+        (let [thrown (try (storage/coerce-opts bad-arg)
+                          (catch clojure.lang.ExceptionInfo e e)
+                          (catch Exception e e))]
+          (is (instance? clojure.lang.ExceptionInfo thrown)
+              (str "bad-arg " (pr-str bad-arg) " throws ex-info"))
+          (when (instance? clojure.lang.ExceptionInfo thrown)
+            (is (= ":rf.error/bad-app-schemas-arg" (.getMessage ^Exception thrown))
+                "ex-info message names the error category")
+            (let [data (ex-data thrown)]
+              (is (= bad-arg (:received data))
+                  ":received slot carries the bad input verbatim"))))))))
+
+;; ---- snapshot / restore / clear (test-support seam) ----------------------
+
+(deftest snapshot-and-restore-roundtrip
+  (testing "snapshot captures the current state; restore replays it"
+    (rf/reg-app-schema [:user] [:map [:id :int]])
+    (rf/reg-app-schema [:auth] [:string])
+    (let [snap (schemas/snapshot-schemas-by-frame)]
+      ;; Mutate.
+      (rf/reg-app-schema [:user] [:vector])
+      (is (= [:vector] (rf/app-schema-at [:user]))
+          "mutation visible before restore")
+      ;; Restore.
+      (schemas/restore-schemas-by-frame! snap)
+      (is (= [:map [:id :int]] (rf/app-schema-at [:user]))
+          "restore replays the captured state")
+      (is (= [:string] (rf/app-schema-at [:auth]))
+          "sibling entries restored too"))))
+
+(deftest clear-removes-all-registrations
+  (testing "clear-schemas-by-frame! drops every frame's registrations"
+    (rf/reg-app-schema [:user] [:map])
+    (rf/reg-app-schema [:user] [:vector] {:frame :tenant/a})
+    (schemas/clear-schemas-by-frame!)
+    (is (nil? (rf/app-schema-at [:user]))
+        "default-frame registration cleared")
+    (is (nil? (rf/app-schema-at [:user] :tenant/a))
+        "tenant-frame registration cleared")
+    (is (= {} (schemas/frame-schema-entries :rf/default)))
+    (is (= {} (schemas/frame-schema-entries :tenant/a)))))
+
+;; ---- registration roundtrip via reg-app-schemas --------------------------
+
+(deftest bulk-registration-visible-from-meta-at
+  (testing "reg-app-schemas — every entry is visible through
+            app-schema-meta-at with the same source-coord stamping
+            singular reg-app-schema would produce"
+    (rf/reg-app-schemas {[:user] [:map [:id :int]]
+                         [:auth] [:string]})
+    (let [m1 (schemas/app-schema-meta-at [:user])
+          m2 (schemas/app-schema-meta-at [:auth])]
+      (is (= [:map [:id :int]] (:schema m1)))
+      (is (= [:string] (:schema m2)))
+      (is (= [:user] (:path m1)))
+      (is (= [:auth] (:path m2))))))

--- a/implementation/schemas/test/re_frame/schemas_walker_operators_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_walker_operators_test.clj
@@ -1,0 +1,134 @@
+(ns re-frame.schemas-walker-operators-test
+  "JVM tests pinning the per-slot flag walker's behaviour across every
+  Malli operator family `re-frame.schemas.walker` claims to support
+  (rf2-yv62u).
+
+  Existing slice-local tests pin `:map`, `:vector`, `:maybe`, `:or`,
+  `:tuple`, and `:multi` directly. The walker also claims (per its
+  docstring) to handle the remaining dispatch-bearing combinators
+  `:orn` / `:catn` / `:altn` and the positional containers `:set` /
+  `:sequential` / `:cat` / `:and` / `:not`. The audit (rf2-yv62u)
+  flagged the absence of operator-family pins for these — refactor
+  drift could silently break the un-tested branches.
+
+  This file pins one example per claimed operator family for the
+  `:sensitive?` flag (the parameterised walker serves both flags so
+  pinning one suffices to lock the structural recognition)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.schemas :as schemas]))
+
+;; ---- dispatch-bearing combinators ----------------------------------------
+;;
+;; :multi / :orn / :catn / :altn — children carry dispatch-value
+;; branches; the branch's slot-props claim the PARENT path (the op's
+;; base-path), not a child path; dispatch values aren't path segments.
+
+(deftest orn-branch-slot-claims-parent-path
+  (testing ":orn — a branch's :sensitive? on its slot-props claims the
+            parent path (mirrors :multi behaviour)"
+    (is (= {[:value] {:sensitive? true :source :schema}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:orn
+              [:secret {:sensitive? true} :string]
+              [:public :string]]
+             [:value])))))
+
+(deftest orn-branch-inner-descends-at-parent-path
+  (testing ":orn — a :sensitive? slot inside the branch's inner schema
+            descends at the parent path (the dispatch value is not a
+            path segment)"
+    (is (= {[:value :token] {:sensitive? true :source :schema}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:orn
+              [:authed [:map [:token {:sensitive? true} :string]]]
+              [:anon   [:map [:guest :string]]]]
+             [:value])))))
+
+(deftest catn-branch-slot-claims-parent-path
+  (testing ":catn — same dispatch-bearing semantics; the branch's
+            slot-props claim the parent path"
+    (is (= {[:row] {:sensitive? true :source :schema}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:catn
+              [:head {:sensitive? true} :string]
+              [:tail :string]]
+             [:row])))))
+
+(deftest altn-branch-inner-descends-at-parent-path
+  (testing ":altn — a :sensitive? slot inside an alt branch descends at
+            the parent path"
+    (is (= {[:doc :ssn] {:sensitive? true :source :schema}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:altn
+              [:full [:map [:ssn {:sensitive? true} :string]]]
+              [:abbr [:map [:initials :string]]]]
+             [:doc])))))
+
+;; ---- positional / nameless containers ------------------------------------
+;;
+;; :vector / :set / :sequential / :maybe / :and / :or / :not / :tuple /
+;; :cat — children descend at the SAME base-path; these ops don't
+;; introduce a new app-db path segment.
+
+(deftest set-descends-at-parent-path
+  (testing ":set — inner :sensitive? slot claims the :set's path"
+    (is (= {[:tokens] {:sensitive? true :source :schema}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:set [:string {:sensitive? true}]]
+             [:tokens])))))
+
+(deftest sequential-descends-at-parent-path
+  (testing ":sequential — inner :sensitive? slot claims the :sequential's
+            path"
+    (is (= {[:audit-log] {:sensitive? true :source :schema}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:sequential [:string {:sensitive? true}]]
+             [:audit-log])))))
+
+(deftest cat-descends-at-parent-path
+  (testing ":cat — positional combinator; inner sensitive descends at
+            the parent path"
+    (is (= {[:tuple-slot] {:sensitive? true :source :schema}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:cat :string [:string {:sensitive? true}]]
+             [:tuple-slot])))))
+
+(deftest and-descends-at-parent-path
+  (testing ":and — every child descends at the parent path"
+    (is (= {[:slot] {:sensitive? true :source :schema}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:and :string [:string {:sensitive? true}]]
+             [:slot])))))
+
+(deftest not-descends-at-parent-path
+  (testing ":not — single-child positional; inner sensitive descends at
+            the parent path"
+    (is (= {[:slot] {:sensitive? true :source :schema}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:not [:string {:sensitive? true}]]
+             [:slot])))))
+
+;; ---- opaque / malformed forms --------------------------------------------
+;;
+;; Per walker.cljc — non-vector, non-keyword forms are opaque leaves;
+;; the walker treats them as "not introspectable" and skips. This is
+;; the defensive contract that protects the walker from blowing up on
+;; registry refs / schema objects / fn schemas.
+
+(deftest opaque-leaf-schema-skipped
+  (testing "an opaque schema value (not a vector form) yields no
+            declarations — the walker doesn't try to peer inside"
+    ;; A symbol — not a Malli vector form, not a keyword.
+    (is (= {} (schemas/extract-sensitive-paths-from-schema 'malli/AnyMap [])))
+    ;; A fn — also opaque.
+    (is (= {} (schemas/extract-sensitive-paths-from-schema (fn [_] true) [])))))
+
+(deftest empty-vector-form-tolerated
+  (testing "an empty vector (degenerate schema form) does not blow up;
+            it yields no declarations"
+    (is (= {} (schemas/extract-sensitive-paths-from-schema [] [])))))
+
+(deftest single-element-vector-form-tolerated
+  (testing "a single-element vector form (no props, no children) does
+            not blow up; it yields no declarations"
+    (is (= {} (schemas/extract-sensitive-paths-from-schema [:string] [])))))

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -116,6 +116,8 @@ Re-registering a schema at a path replaces the previous one (last-write-wins, sa
 
 All validation points emit machine-readable errors per [Goal 10 (Strong introspection surface)](000-Vision.md#goals) and the structured error contract in [009 §Error contract](009-Instrumentation.md#error-contract) — `:rf.error/schema-validation-failure` events carry `{:where :event/:sub-return/:app-db/...; :path [...]; :value <bad>; :explain <validator-supplied explanation>}`. The explanation's inner shape is whatever the registered explainer fn returns (a Malli explanation map on the CLJS reference; a Zod issue list on a TS port; etc.); consumers that need to branch on the inner shape inspect the port they're talking to.
 
+For `:where :app-db` failures, the trace's `:path` is the **failing leaf** path — the registered root concat'd with the explainer's value-navigation suffix (Malli's `:in`, not its schema-walk `:path`). The trace also carries `:registered-path` — the registration root — so tooling that needs the registration anchor reaches `(:registered-path tags)` while consumers reading the failure locator reach `(:path tags)`. When the registered explainer is absent or returns no extractable suffix (non-Malli validator, structurally-different explanation), `:path` falls back to the registered root and `:registered-path` mirrors it. Other surfaces (`:where :event` / `:cofx` / `:fx-args` / `:sub-return`) emit `:path` per their existing contract; no `:registered-path` tag is stamped on those surfaces because the registration is named by `:failing-id` / `:spec-id` directly.
+
 ### Validation order on event processing
 
 For a single dispatched event, schema checks fire in this order:

--- a/spec/conformance/fixtures/schema-app-db-slice-validates.edn
+++ b/spec/conformance/fixtures/schema-app-db-slice-validates.edn
@@ -58,8 +58,15 @@
    {:operation :event :tags {:event-id :user/set-bad}}
    {:operation :rf.error/schema-validation-failure
     :op-type   :error
-    :tags      {:category   :rf.error/schema-validation-failure
-                :failing-id :user/set-bad
-                :where      :app-db
-                :path       [:user]}
+    :tags      {:category        :rf.error/schema-validation-failure
+                :failing-id      :user/set-bad
+                :where           :app-db
+                ;; Per rf2-oh4se the trace's :path is the failing leaf
+                ;; path (registered-path + Malli explainer's :in suffix),
+                ;; not the registration root. The :registered-path tag
+                ;; carries the registration root for consumers that want
+                ;; it. Here [:user] is the registered slot and [:id] is
+                ;; the failing leaf inside it.
+                :path            [:user :id]
+                :registered-path [:user]}
     :recovery  :no-recovery}]}}

--- a/tools/story/src/re_frame/story/ui/schema_validation.cljc
+++ b/tools/story/src/re_frame/story/ui/schema_validation.cljc
@@ -111,8 +111,11 @@
                     coeffect map / slice).
     - `:explain` — the validator's explanation (Malli explain map on
                    the CLJS reference; other shapes on other ports).
-    - `:path` (when present, for app-db failures) — the registered
-                schema path.
+    - `:path` (when present, for app-db failures) — the failing leaf
+                path (registered root + Malli explainer's value-
+                navigation suffix per rf2-oh4se). The registration
+                anchor itself rides on `:registered-path` when tooling
+                needs it.
     - `:frame` — the frame id the failure fired in.
     - `:recovery` — the spec-defined recovery posture.
 


### PR DESCRIPTION
## Summary

- **rf2-oh4se** — `validate-app-db!` now derives the failing leaf path from the registered explainer's `:in` slot (the value-navigation path). Trace's `:path` is the full leaf (`registered-root + :in`); new `:registered-path` tag carries the registration anchor. Sensitivity check is path-targeted: ancestor- or descendant-sensitive at the leaf counts; sibling-sensitive flags on non-failing slots no longer trigger redaction. Conservative fallback when explainer is absent / non-Malli.
- **rf2-yv62u** — Concrete tests for the audit-flagged storage and walker coverage gaps: 12 storage deftests (`app-schema-meta-at`, `frame-schema-entries`, `coerce-opts` bad-arg branch, snapshot/restore/clear), 14 walker operator-family deftests (`:orn`/`:catn`/`:altn` dispatch-bearing, `:set`/`:sequential`/`:cat`/`:and`/`:not` positional containers, opaque/empty/malformed forms).
- Spec 010 text + conformance fixture (`schema-app-db-slice-validates.edn`) updated to reflect leaf-path semantics. Story UI projector docstring updated for the new `:path` shape.

## Deferred

- **rf2-wkxng** (decision: roll-back semantics for app-db validation failure) — decision still open per bead notes. Per the dispatch instruction, deferred along with its paired impl bead **rf2-6m0se** until the decision lands.

## Test plan

- [x] `cd implementation/schemas && clojure -M:test` — 179 tests / 497 assertions / 0 failures
- [x] `cd implementation && npm run test:cljs` — 1817 tests / 5105 assertions / 0 failures
- [x] `cd implementation && npm run test:elision` — all sentinels OK
- [x] `cd implementation && npm run test:perf-bundle` — all sentinels OK
- [x] Conformance corpus (5 schema fixtures) — 5/5 passing