### PR TITLE
refactor(machines): src polish — 9 follow-on beads (rf2-2ukxv)

### DIFF
--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -58,6 +58,8 @@
             [re-frame.machines.transition :as transition]
             [re-frame.subs :as subs]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- public-surface re-exports --------------------------------------------
 ;;
 ;; These `def`s make the sub-namespace fns reachable as

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx.cljc
@@ -35,6 +35,8 @@
             [re-frame.machines.lifecycle-fx.spawn :as spawn]
             [re-frame.registrar :as registrar]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- public-surface re-exports --------------------------------------------
 
 (def create-machine-handler registration/create-machine-handler)

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -32,6 +32,8 @@
             [re-frame.registrar :as registrar]
             [re-frame.trace :as trace]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (defn- emit-system-id-released!
   "Per Spec 005 §Cancellation cascade D8 — fire the
   `:rf.machine/system-id-released` trace when an actor's `:system-id`

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -141,9 +141,8 @@
   `:invoke-all` children-iteration teardown
   (`destroy-invoke-all-children!`) per the `args` shape. See the ns
   docstring for the form semantics."
-  [{:keys [frame]} args]
-  (let [frame-id    (or frame :rf/default)
-        invoke-all? (and (map? args) (true? (:rf/invoke-all args)))]
+  [{frame-id :frame :or {frame-id :rf/default}} args]
+  (let [invoke-all? (and (map? args) (true? (:rf/invoke-all args)))]
     (if invoke-all?
       (destroy-invoke-all-children! frame-id
                                     (:rf/parent-id args)

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -39,6 +39,8 @@
             [re-frame.registrar :as registrar]
             [re-frame.trace :as trace]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- in-flight HTTP abort cascade (rf2-wvkn) ------------------------------
 ;;
 ;; Per Spec 005 §Cancellation cascade — in-flight `:rf.http/managed`

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -103,6 +103,108 @@
 
       :else false)))
 
+(defn- compute-resolution
+  "Pure. Given the post-bump `join-state'`, the join spec, and the
+  arriving child's `kind` (:done | :failed), decide whether the join
+  resolves and which kind of resolution. Returns a map:
+
+      {:resolved?        boolean
+       :fail-fired?      boolean
+       :success-fired?   boolean
+       :resolution-event <event-vec or nil>
+       :join-event-kw    <:on-all-complete | :on-some-complete | :on-any-failed | nil>}
+
+  - `:fail-fired?` iff the arriving child errored AND the spec declares
+    `:on-any-failed`.
+  - `:success-fired?` iff failure didn't fire AND the join condition is
+    met by `join-state'`.
+  - `:resolution-event` is the spec's event vector to dispatch into the
+    parent, or nil when neither path fires.
+  - `:join-event-kw` is the resolution kind (used by the
+    cancelled-on-join-resolution trace)."
+  [spec join-state' kind]
+  (let [fail-fired?    (and (= kind :failed)
+                            (vector? (:on-any-failed spec)))
+        success-fired? (and (not fail-fired?)
+                            (join-condition-met? spec join-state'))
+        all-join?      (= :all (:join spec :all))
+        resolution-event
+        (cond
+          fail-fired?    (:on-any-failed spec)
+          success-fired? (if all-join?
+                           (:on-all-complete spec)
+                           (:on-some-complete spec)))
+        join-event-kw
+        (cond
+          fail-fired?    :on-any-failed
+          success-fired? (if all-join? :on-all-complete :on-some-complete))]
+    {:resolved?        (boolean (or fail-fired? success-fired?))
+     :fail-fired?      fail-fired?
+     :success-fired?   success-fired?
+     :resolution-event resolution-event
+     :join-event-kw    join-event-kw}))
+
+(defn- emit-resolution-traces!
+  "Fire the post-resolution observability traces in order: any-failed,
+  all-completed, or some-completed."
+  [parent-id invoke-id spec join-state'' child-id child-extra
+   {:keys [fail-fired? success-fired?]}]
+  (when fail-fired?
+    (trace/emit! :machine :rf.machine.invoke-all/any-failed
+                 {:machine-id parent-id
+                  :invoke-id  invoke-id
+                  :failed-id  child-id
+                  :reason     child-extra
+                  :failed     (:failed join-state'')
+                  :done       (:done   join-state'')}))
+  (when success-fired?
+    (if (= :all (:join spec :all))
+      (trace/emit! :machine :rf.machine.invoke-all/all-completed
+                   {:machine-id parent-id
+                    :invoke-id  invoke-id
+                    :done       (:done join-state'')})
+      (trace/emit! :machine :rf.machine.invoke-all/some-completed
+                   {:machine-id parent-id
+                    :invoke-id  invoke-id
+                    :done       (:done join-state'')
+                    :join       (:join spec)}))))
+
+(defn- build-resolution-fx
+  "Build the fx vector to fire on resolution: per-survivor
+  `:rf.machine/destroy` (with one
+  `:rf.machine.invoke/cancelled-on-join-resolution` trace each) when
+  `:cancel-on-decision?` is true, followed by the join-event dispatch
+  carrying the decisive child's forwarded payload. Per Spec 005
+  §Spawn-and-join, the dispatched event shape is:
+
+      [<parent-id> [<resolution-event> <decisive-child-id> & <child-extra>]]"
+  [parent-id invoke-id spec join-state'' child-id child-extra
+   {:keys [resolved? resolution-event join-event-kw]}]
+  (let [cancel? (let [c (:cancel-on-decision? spec)]
+                  (if (nil? c) true (boolean c)))
+        cancel-fx
+        (when (and resolved? cancel?)
+          (let [completed-ids (into #{} (concat (:done   join-state'')
+                                                (:failed join-state'')))
+                survivors     (->> (:children join-state'')
+                                   (remove (fn [[cid _]]
+                                             (contains? completed-ids cid))))]
+            (doseq [[cid spawned-id] survivors]
+              (trace/emit! :machine :rf.machine.invoke/cancelled-on-join-resolution
+                           {:machine-id parent-id
+                            :invoke-id  invoke-id
+                            :child-id   cid
+                            :spawned-id spawned-id
+                            :join-event join-event-kw}))
+            (mapv (fn [[_ spawned-id]]
+                    [:rf.machine/destroy spawned-id])
+                  survivors)))
+        dispatch-fx
+        (when resolution-event
+          (let [inner (vec (concat resolution-event [child-id] child-extra))]
+            [[:dispatch [parent-id inner]]]))]
+    (vec (concat (or cancel-fx []) (or dispatch-fx [])))))
+
 (defn intercept-invoke-all-event
   "Per Spec 005 §Child completion protocol (rf2-6vmw). When the parent's
   handler receives an event whose inner event-id matches the active
@@ -151,77 +253,16 @@
               {:db db :fx []})
 
           :else
+          ;; Read 'compute resolution; emit traces; build fx; write back':
+          ;; the body is now three named acts plus an assoc-in.
           (let [join-state' (case kind
                               :done   (update join-state :done   (fnil conj #{}) child-id)
                               :failed (update join-state :failed (fnil conj #{}) child-id))
-                cancel?  (let [c (:cancel-on-decision? spec)]
-                           (if (nil? c) true (boolean c)))
-                fail-fired?
-                (and (= kind :failed)
-                     (vector? (:on-any-failed spec)))
-                success-fired?
-                (and (not fail-fired?)
-                     (join-condition-met? spec join-state'))
-                resolution-event
-                (cond
-                  fail-fired?    (:on-any-failed spec)
-                  success-fired? (cond
-                                   (= :all (:join spec :all)) (:on-all-complete spec)
-                                   :else                       (:on-some-complete spec)))
-                resolved? (boolean (or fail-fired? success-fired?))
-                join-state'' (assoc join-state' :resolved? resolved?)
-                _ (when fail-fired?
-                    (trace/emit! :machine :rf.machine.invoke-all/any-failed
-                                 {:machine-id parent-id
-                                  :invoke-id  invoke-id
-                                  :failed-id  child-id
-                                  :reason     child-extra
-                                  :failed     (:failed join-state'')
-                                  :done       (:done   join-state'')}))
-                _ (when (and success-fired? (= :all (:join spec :all)))
-                    (trace/emit! :machine :rf.machine.invoke-all/all-completed
-                                 {:machine-id parent-id
-                                  :invoke-id  invoke-id
-                                  :done       (:done join-state'')}))
-                _ (when (and success-fired? (not= :all (:join spec :all)))
-                    (trace/emit! :machine :rf.machine.invoke-all/some-completed
-                                 {:machine-id parent-id
-                                  :invoke-id  invoke-id
-                                  :done       (:done join-state'')
-                                  :join       (:join spec)}))
-                cancel-fx
-                (when (and resolved? cancel?)
-                  (let [completed-ids (into #{} (concat (:done join-state'')
-                                                        (:failed join-state'')))
-                        survivors     (->> (:children join-state'')
-                                           (remove (fn [[cid _]] (contains? completed-ids cid))))
-                        join-event-kw (cond
-                                        fail-fired?    :on-any-failed
-                                        (= :all (:join spec :all)) :on-all-complete
-                                        :else :on-some-complete)]
-                    (doseq [[cid spawned-id] survivors]
-                      (trace/emit! :machine :rf.machine.invoke/cancelled-on-join-resolution
-                                   {:machine-id parent-id
-                                    :invoke-id  invoke-id
-                                    :child-id   cid
-                                    :spawned-id spawned-id
-                                    :join-event join-event-kw}))
-                    (mapv (fn [[_ spawned-id]]
-                            [:rf.machine/destroy spawned-id])
-                          survivors)))
-                dispatch-fx
-                ;; Per Spec 005 §Spawn-and-join: append the decisive
-                ;; child's `& extra` onto the resolution event so the
-                ;; parent's join-event handler can read the forwarded
-                ;; payload directly off the event vector. The wrapped
-                ;; event shape becomes:
-                ;;   [<parent-id> [<resolution-event> <decisive-child-id> & <child-extra>]]
-                ;; where <decisive-child-id> is the child that tipped
-                ;; the join over the threshold (last :done for success,
-                ;; the failed child for :on-any-failed).
-                (when resolution-event
-                  (let [inner (vec (concat resolution-event [child-id] child-extra))]
-                    [[:dispatch [parent-id inner]]]))
-                fx (vec (concat (or cancel-fx []) (or dispatch-fx [])))
-                new-db (assoc-in db [:rf/spawned parent-id invoke-id] join-state'')]
-            {:db new-db :fx fx}))))))
+                resolution   (compute-resolution spec join-state' kind)
+                join-state'' (assoc join-state' :resolved? (:resolved? resolution))]
+            (emit-resolution-traces! parent-id invoke-id spec join-state''
+                                     child-id child-extra resolution)
+            (let [fx (build-resolution-fx parent-id invoke-id spec join-state''
+                                          child-id child-extra resolution)]
+              {:db (assoc-in db [:rf/spawned parent-id invoke-id] join-state'')
+               :fx fx})))))))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -120,6 +120,15 @@
     (when match
       (let [{:keys [invoke-id spec kind]} match
             child-id   (second inner-event)
+            ;; Per Spec 005 §Spawn-and-join: child dispatches
+            ;;   [<parent-id> [<event-kw> <child-id> & extra]]
+            ;; where `& extra` is the child's forwarded payload (terminal
+            ;; :data slice, error reason, etc). Capture it so the
+            ;; decisive child's payload can be appended onto the
+            ;; resolution event AND surfaced through the
+            ;; :rf.machine.invoke-all/any-failed trace's :reason key
+            ;; (Spec 005 §Trace events).
+            child-extra (vec (drop 2 inner-event))
             ;; Read the live join state from app-db (the seed was written
             ;; by :rf.machine/invoke-all-init on entry).
             join-state (get-in db [:rf/spawned parent-id invoke-id])]
@@ -166,6 +175,7 @@
                                  {:machine-id parent-id
                                   :invoke-id  invoke-id
                                   :failed-id  child-id
+                                  :reason     child-extra
                                   :failed     (:failed join-state'')
                                   :done       (:done   join-state'')}))
                 _ (when (and success-fired? (= :all (:join spec :all)))
@@ -200,8 +210,18 @@
                             [:rf.machine/destroy spawned-id])
                           survivors)))
                 dispatch-fx
+                ;; Per Spec 005 §Spawn-and-join: append the decisive
+                ;; child's `& extra` onto the resolution event so the
+                ;; parent's join-event handler can read the forwarded
+                ;; payload directly off the event vector. The wrapped
+                ;; event shape becomes:
+                ;;   [<parent-id> [<resolution-event> <decisive-child-id> & <child-extra>]]
+                ;; where <decisive-child-id> is the child that tipped
+                ;; the join over the threshold (last :done for success,
+                ;; the failed child for :on-any-failed).
                 (when resolution-event
-                  [[:dispatch (into [parent-id resolution-event] [])]])
+                  (let [inner (vec (concat resolution-event [child-id] child-extra))]
+                    [[:dispatch [parent-id inner]]]))
                 fx (vec (concat (or cancel-fx []) (or dispatch-fx [])))
                 new-db (assoc-in db [:rf/spawned parent-id invoke-id] join-state'')]
             {:db new-db :fx fx}))))))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -30,6 +30,8 @@
             [re-frame.machines.transition :as transition]
             [re-frame.trace :as trace]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (defn- find-active-invoke-all-in-tree
   "Helper for `find-active-invoke-all`. Given a machine-like map with
   `:states` (for a non-parallel machine, the machine itself; for a

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -304,7 +304,13 @@
   (set by the `reg-machine` macro) is merged into the registration
   metadata via the `reg-event-fx` defn's `merge-coords` call."
   [machine-id machine]
-  (let [handler-fn (create-machine-handler machine)]
+  ;; Per rf2-s83iu: install a per-machine region-machine cache before
+  ;; the machine value is threaded through the handler closure and
+  ;; published to the registrar. Re-registration replaces the machine
+  ;; map and its attached cache atom, so no separate invalidation step
+  ;; is needed.
+  (let [machine    (parallel/install-region-cache machine)
+        handler-fn (create-machine-handler machine)]
     (events/reg-event-fx machine-id
                          {:rf/machine? true
                           :rf/machine  machine}

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -30,6 +30,8 @@
             [re-frame.machines.transition :as transition]
             [re-frame.trace :as trace]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; Per rf2-fgqs4 the initial-snapshot builder lives in `parallel.cljc` as
 ;; `build-initial-snapshot` — single source of truth for both the
 ;; singleton-registration path (here) and the spawn path

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -167,9 +167,8 @@
       the runtime dispatches a synthetic `[<spawned-id>
       [:rf.machine/spawned]]` so generic child machines may declare a
       leaf-level `:on :rf.machine/spawned :target ...` transition."
-  [{:keys [frame]} args]
-  (let [frame-id   (or frame :rf/default)
-        ;; Per rf2-gr8q: prefer the pre-allocated id (declarative :invoke
+  [{frame-id :frame :or {frame-id :rf/default}} args]
+  (let [;; Per rf2-gr8q: prefer the pre-allocated id (declarative :invoke
         ;; routes through the transition reducer which bumps the parent
         ;; snapshot's `:rf/spawn-counter`). Hand-emitted spawn fxs carry
         ;; no pre-allocated id; the frame's app-db spawn-counter slot
@@ -257,9 +256,8 @@
   Subsequent `:on-child-done` / `:on-child-error` events arrive at the
   parent's `create-machine-handler` boundary and are intercepted by
   `intercept-invoke-all-event` (in `lifecycle-fx.join`)."
-  [{:keys [frame]} args]
-  (let [frame-id   (or frame :rf/default)
-        parent-id  (:rf/parent-id args)
+  [{frame-id :frame :or {frame-id :rf/default}} args]
+  (let [parent-id  (:rf/parent-id args)
         invoke-id  (:rf/invoke-id args)
         join-state (:join-state args)
         children   (:children join-state)]

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -26,6 +26,8 @@
             [re-frame.registrar :as registrar]
             [re-frame.trace :as trace]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- id allocation --------------------------------------------------------
 
 (defn- pre-allocated-actor-id

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/teardown.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/teardown.cljc
@@ -33,6 +33,8 @@
   in-flight trace consumers see the destroy signal while the handler
   still resolves; unregister the handler LAST).")
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (defn find-system-id-for-actor
   "Walk the `:rf/system-ids` reverse index of `db` looking for the entry
   whose value is `actor-id`. Returns the bound `:system-id` keyword or

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -22,6 +22,8 @@
   top-level dispatch."
   (:require [re-frame.machines.parallel :as parallel]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (defn- validate-no-invoke-timeout-ms!
   "Per rf2-3y3y / Spec 005 §Wall-clock timeouts on :invoke — use parent
   state's `:after`, the pre-release `:timeout-ms` / `:on-timeout` slots

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -42,15 +42,10 @@
   [machine]
   (= :parallel (:type machine)))
 
-(defn region-machine
-  "Build a synthetic single-machine spec for a region.
-
-  Inherits `:guards` / `:actions` / `:on-spawn-actions` from the parent so
-  region transitions can reference the parent's named guards / actions
-  without redeclaring them. Inherits `:rf/parent-id` / `:rf/platform` /
-  `:rf/frame` so the post-action `:rf.machine/spawn` / `:after-schedule`
-  fxs the region emits carry the parent's identity (the region name is
-  prepended onto the `:rf/invoke-id` separately)."
+(defn- build-region-machine
+  "Construct a synthetic single-machine spec for one region of
+  `parent-machine`. See `region-machine` for the contract — this is the
+  uncached compute path."
   [parent-machine region-name]
   (let [region-body (get-in parent-machine [:regions region-name])]
     (-> region-body
@@ -61,6 +56,41 @@
         (assoc :rf/platform       (:rf/platform parent-machine))
         (assoc :rf/frame          (:rf/frame parent-machine))
         (assoc :rf/region         region-name))))
+
+(defn region-machine
+  "Synthetic single-machine spec for a region of `parent-machine`.
+
+  Inherits `:guards` / `:actions` / `:on-spawn-actions` from the parent so
+  region transitions can reference the parent's named guards / actions
+  without redeclaring them. Inherits `:rf/parent-id` / `:rf/platform` /
+  `:rf/frame` so the post-action `:rf.machine/spawn` / `:after-schedule`
+  fxs the region emits carry the parent's identity (the region name is
+  prepended onto the `:rf/invoke-id` separately).
+
+  Per round-2 P-r2-1 (rf2-s83iu): region-specs are registration-time
+  data, not transition-time data. The result is memoised in metadata
+  on `parent-machine` itself — re-registration replaces the entire
+  machine map, so the old cache becomes garbage automatically and no
+  invalidation logic is needed. Per-region misses fall through to
+  `build-region-machine` and CAS the result into the metadata atom."
+  [parent-machine region-name]
+  (let [cache (-> parent-machine meta ::region-cache)]
+    (if-let [hit (and cache (get @cache region-name))]
+      hit
+      (let [built (build-region-machine parent-machine region-name)]
+        (when cache
+          (swap! cache assoc region-name built))
+        built))))
+
+(defn install-region-cache
+  "Attach an empty region-machine cache to `parent-machine`'s metadata.
+  Called at registration time for `:type :parallel` machines so the
+  hot-path `region-machine` lookups hit the cache instead of allocating
+  a fresh map per call."
+  [parent-machine]
+  (if (parallel? parent-machine)
+    (vary-meta parent-machine assoc ::region-cache (atom {}))
+    parent-machine))
 
 (defn region-initial-state
   "Compute the initial-state value for one region — applying that region's

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -164,24 +164,25 @@
 ;; EVERY state along that cascade fires its `:entry` shallowest-first.
 ;;
 ;; The cascade re-uses `apply-transition-once` by synthesising a
-;; "transition from the empty path to the initial leaf".
+;; "transition from the empty path to the initial leaf" — ghost-snap
+;; with `:state []` driving a synthetic transition whose `:target` is
+;; the initial leaf path.
 
-(defn- apply-initial-entry-cascade-single
-  "Bootstrap entry cascade for a flat / compound (non-parallel) machine.
-  Re-uses `apply-transition-once` by passing a snapshot whose `:state`
-  is the empty path `[]` and a synthetic transition whose `:target` is
-  the initial leaf path."
+(defn- bootstrap-step
+  "Single bootstrap step for one (flat or per-region) machine. Returns
+  a `result/ok` Result carrying the post-cascade snapshot + fx, or a
+  `result/fail` Result if any `:entry` action threw."
   [machine initial-snapshot]
   (let [original-state (:state initial-snapshot)
-        target-leaf    (transition/state-path original-state)
-        ghost-snap     (assoc initial-snapshot :state [])
-        boot-event     [:rf.machine/bootstrap]
         boot-target    (if (keyword? original-state)
                          original-state
-                         (vec target-leaf))
-        boot-transition {:target    boot-target
-                         :decl-path []}]
-    (transition/apply-transition-once machine ghost-snap boot-event boot-transition)))
+                         (vec (transition/state-path original-state)))]
+    (transition/apply-transition-once
+      machine
+      (assoc initial-snapshot :state [])
+      [:rf.machine/bootstrap]
+      {:target    boot-target
+       :decl-path []})))
 
 (defn apply-initial-entry-cascade
   "Synthesise the bootstrap entry cascade for `machine` against the
@@ -224,7 +225,7 @@
                                      :data  cur-data}
                               (some? cur-counter)
                               (assoc :rf/spawn-counter cur-counter))
-                step-result (apply-initial-entry-cascade-single region-spec region-snap)]
+                step-result (bootstrap-step region-spec region-snap)]
             (if (result/fail? step-result)
               step-result
               (result/with-ok [reg-snap reg-fx] step-result
@@ -234,7 +235,7 @@
                          (:rf/spawn-counter reg-snap)
                          (assoc new-states rn (:state reg-snap))
                          (vec (concat acc-fx prefixed-fx))))))))))
-    (apply-initial-entry-cascade-single machine initial-snapshot)))
+    (bootstrap-step machine initial-snapshot)))
 
 (declare machine-transition)
 

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -35,6 +35,8 @@
              #?@(:cljs [:include-macros true])]
             [re-frame.machines.transition :as transition]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (defn parallel?
   "True iff the machine declares `:type :parallel` (root-level only)."
   [machine]

--- a/implementation/machines/src/re_frame/machines/path_walk.cljc
+++ b/implementation/machines/src/re_frame/machines/path_walk.cljc
@@ -63,6 +63,8 @@
   (deepest-wins isn't 'a walk'; it's 'a walk in a specific direction
   with a specific tie-breaking semantics'). It lives in its own ns.")
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (defn- node-at*
   "Local inline of `transition/node-at` to avoid a require cycle. Walk
   `(:states tree)` down `path`, returning the leaf state-node or nil

--- a/implementation/machines/src/re_frame/machines/result.cljc
+++ b/implementation/machines/src/re_frame/machines/result.cljc
@@ -53,6 +53,8 @@
   rather than reading the `::tag` key by hand."
   (:refer-clojure :exclude [ok?]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (defn ok
   "Build a success Result carrying `snap` (post-transition snapshot) and
   `fx` (the emitted fx vector)."

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -323,9 +323,8 @@
   through the standard transition cascade.
 
   No-op under `:platform :server` (per Spec 005 §SSR mode)."
-  [{:keys [frame]} args]
-  (let [frame-id   (or frame :rf/default)
-        parent-id  (:rf/parent-id args)
+  [{frame-id :frame :or {frame-id :rf/default}} args]
+  (let [parent-id  (:rf/parent-id args)
         invoke-id  (:rf/invoke-id args)
         state      (:state args)
         delay-key  (:delay-key args)
@@ -360,9 +359,8 @@
   so the only cross-key axis we still iterate is `:delay` (one entry
   per :after map entry on the bearing state node — typically 1-3
   entries)."
-  [{:keys [frame]} args]
-  (let [frame-id  (or frame :rf/default)
-        parent-id (:rf/parent-id args)
+  [{frame-id :frame :or {frame-id :rf/default}} args]
+  (let [parent-id (:rf/parent-id args)
         invoke-id (vec (:rf/invoke-id args))]
     (doseq [[k _entry] (get @after-timers frame-id)
             :when (and (= parent-id (:parent k))

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -37,6 +37,8 @@
             [re-frame.subs :as subs]
             [re-frame.trace :as trace]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (defonce after-timers
   ;; Per Spec 005 §Delayed `:after` transitions and rf2-3y3y and the rf2-ysa94
   ;; frame-scoping refactor: runtime-owned timer-handle table for in-flight

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -1108,6 +1108,38 @@
                  snap
                  depth))))))
 
+(defn- emit-pick-traces!
+  "Fire the three pre-transition timer traces for a `pick-transition`
+  match — `:rf.machine.timer/stale-after`, `:rf.machine.timer/fired`
+  (guard-suppressed), and `:rf.machine.timer/fired` (success). Each
+  branch is mutually exclusive given the `match` shape, but we spell
+  them sequentially so listeners observe document order if a future
+  match shape lights up more than one. No-op when `match` is nil or
+  carries no relevant marker."
+  [match]
+  (when match
+    (when (:stale? match)
+      (trace/emit! :machine :rf.machine.timer/stale-after
+                   {:state           (:state match)
+                    :delay           (:delay match)
+                    :scheduled-epoch (:scheduled-epoch match)
+                    :current-epoch   (:current-epoch match)
+                    :recovery        :replaced-with-default}))
+    (when (:guard-suppressed? match)
+      (trace/emit! :machine :rf.machine.timer/fired
+                   {:state  (:state match)
+                    :delay  (:delay match)
+                    :epoch  (:epoch match)
+                    :fired? false}))
+    (when (and (not (:stale? match))
+               (not (:guard-suppressed? match))
+               (:delay match))
+      (trace/emit! :machine :rf.machine.timer/fired
+                   {:state  (last (:decl-path match))
+                    :delay  (:delay match)
+                    :epoch  (:epoch match)
+                    :fired? true}))))
+
 (defn machine-transition-single
   "Pure function. Single-machine (flat or compound) implementation of the
   macrostep. Per Spec 005 §Drain semantics §Level 3:
@@ -1134,28 +1166,7 @@
         ;; Trace timer firing / staleness / guard-suppression BEFORE
         ;; running the transition, so listeners see events in the order
         ;; they occurred.
-        _ (when (and match (:stale? match))
-            (trace/emit! :machine :rf.machine.timer/stale-after
-                         {:state           (:state match)
-                          :delay           (:delay match)
-                          :scheduled-epoch (:scheduled-epoch match)
-                          :current-epoch   (:current-epoch match)
-                          :recovery        :replaced-with-default}))
-        _ (when (and match (:guard-suppressed? match))
-            (trace/emit! :machine :rf.machine.timer/fired
-                         {:state  (:state match)
-                          :delay  (:delay match)
-                          :epoch  (:epoch match)
-                          :fired? false}))
-        _ (when (and match
-                     (not (:stale? match))
-                     (not (:guard-suppressed? match))
-                     (:delay match))
-            (trace/emit! :machine :rf.machine.timer/fired
-                         {:state  (last (:decl-path match))
-                          :delay  (:delay match)
-                          :epoch  (:epoch match)
-                          :fired? true}))
+        _ (emit-pick-traces! match)
         result-after-event
         (cond
           (and match (:stale? match))

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -24,6 +24,8 @@
              #?@(:cljs [:include-macros true])]
             [re-frame.trace :as trace]))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 (defn- chase-ref
   "Follow a keyword reference chain through the machine's named-bindings
   map until it hits a fn (or fails). Tolerates one level of indirection

--- a/implementation/machines/test/re_frame/invoke_all_test.clj
+++ b/implementation/machines/test/re_frame/invoke_all_test.clj
@@ -310,3 +310,104 @@
                                              :join           {:n 3}
                                              :on-child-done  :done
                                              :on-child-error :failed}}}})))))
+
+;; ---- decisive-child payload forwarding (rf2-4aop8) -----------------------
+
+(defn- mk-child-with-payload
+  "Like mk-child but the terminal-state dispatch carries an extra payload
+  argument so we can assert it forwards through the join resolution."
+  [parent-id done-event-kw error-event-kw payload]
+  {:initial :running
+   :data    {:id nil}
+   :actions {:dispatch-done
+             (fn [data _]
+               {:fx [[:dispatch [parent-id [done-event-kw (:id data) payload]]]]})
+             :dispatch-error
+             (fn [data _]
+               {:fx [[:dispatch [parent-id [error-event-kw (:id data) payload]]]]})
+             :record-id
+             (fn [data ev]
+               {:data (assoc data :id (second ev))})
+             :record-join-event
+             (fn [data ev]
+               {:data (assoc data :join-event ev)})}
+   :states
+   {:running {:on {:set-id {:action :record-id}
+                   :go     {:target :done   :action :dispatch-done}
+                   :fail   {:target :failed :action :dispatch-error}}}
+    :done   {}
+    :failed {}}})
+
+(deftest decisive-child-payload-forwards-into-join-event
+  (testing "the decisive child's & extra is appended onto the resolution event"
+    (let [child  (mk-child-with-payload :sup/pay :asset/loaded :asset/failed
+                                        {:bytes 4242 :status :ok})
+          parent {:initial :idle
+                  :actions {:record-payload
+                            (fn [data ev]
+                              {:data (assoc data :join-event ev)})}
+                  :states
+                  {:idle      {:on {:start :hydrating}}
+                   :hydrating
+                   {:invoke-all
+                    {:children        [{:id :a :machine-id :child/pa :start [:set-id :a]}]
+                     :join            :all
+                     :on-child-done   :asset/loaded
+                     :on-child-error  :asset/failed
+                     :on-all-complete [:hydrate/done]}
+                    :on    {:hydrate/done {:target :ready :action :record-payload}}}
+                   :ready {}}}]
+      (rf/reg-machine :child/pa child)
+      (rf/reg-machine :sup/pay parent)
+      (rf/dispatch-sync [:sup/pay [:start]])
+      (let [ids (get-in (frame-db) [:rf/spawned :sup/pay [:hydrating] :children])]
+        (rf/dispatch-sync [(:a ids) [:go]]))
+      (let [snap (snapshot :sup/pay)]
+        (is (= :ready (:state snap)) "parent reached :ready")
+        ;; The decisive-child payload (:a + {:bytes 4242 :status :ok})
+        ;; appears as trailing args on the dispatched join event:
+        ;;   [:hydrate/done :a {:bytes 4242 :status :ok}]
+        (is (= [:hydrate/done :a {:bytes 4242 :status :ok}]
+               (:join-event (:data snap)))
+            "resolution event carries decisive child-id and forwarded payload")))))
+
+(deftest any-failed-trace-carries-reason-payload
+  (testing ":rf.machine.invoke-all/any-failed trace carries :reason from decisive failure"
+    (let [traces (atom [])
+          child  (mk-child-with-payload :sup/fail-payload
+                                        :asset/loaded :asset/failed
+                                        {:reason :boom :http-status 503})
+          parent {:initial :idle
+                  :states
+                  {:idle      {:on {:start :hydrating}}
+                   :hydrating
+                   {:invoke-all
+                    {:children       [{:id :a :machine-id :child/fpa :start [:set-id :a]}
+                                      {:id :b :machine-id :child/fpb :start [:set-id :b]}]
+                     :join            :all
+                     :on-child-done   :asset/loaded
+                     :on-child-error  :asset/failed
+                     :on-all-complete [:hydrate/done]
+                     :on-any-failed   [:hydrate/failed]}
+                    :on    {:hydrate/done   :ready
+                            :hydrate/failed :error}}
+                   :ready {} :error {}}}]
+      (rf/reg-machine :child/fpa child)
+      (rf/reg-machine :child/fpb child)
+      (rf/reg-machine :sup/fail-payload parent)
+      (rf/register-trace-cb! ::any-failed-trace
+                             (fn [ev] (swap! traces conj ev)))
+      (try
+        (rf/dispatch-sync [:sup/fail-payload [:start]])
+        (let [ids (get-in (frame-db) [:rf/spawned :sup/fail-payload [:hydrating] :children])]
+          (rf/dispatch-sync [(:a ids) [:fail]]))
+        (let [any-failed (->> @traces
+                              (filter #(= :rf.machine.invoke-all/any-failed
+                                          (:operation %)))
+                              first)]
+          (is (some? any-failed) ":rf.machine.invoke-all/any-failed trace fired")
+          (is (= [{:reason :boom :http-status 503}]
+                 (:reason (:tags any-failed)))
+              ":reason key on trace carries decisive child's forwarded payload"))
+        (finally
+          (rf/remove-trace-cb! ::any-failed-trace))))))

--- a/implementation/machines/test/re_frame/invoke_all_test.clj
+++ b/implementation/machines/test/re_frame/invoke_all_test.clj
@@ -371,6 +371,70 @@
                (:join-event (:data snap)))
             "resolution event carries decisive child-id and forwarded payload")))))
 
+;; ---- late-completion safety net (rf2-1tt9q) -----------------------------
+;;
+;; intercept-invoke-all-event has a post-resolution branch (join.cljc:134-141)
+;; that fires when a child-done event arrives AFTER the join already
+;; resolved. The contract surface is the :rf.machine.invoke-all/late-completion
+;; trace — the return-value is a no-op {:db db :fx []}.
+;;
+;; To exercise the branch we use :cancel-on-decision? false so siblings
+;; survive past resolution and can fire their terminal-state dispatches.
+
+(deftest late-completion-after-resolution-emits-trace-and-is-no-op
+  (testing "child-done events arriving after join resolution emit late-completion trace"
+    (let [traces (atom [])
+          child  (mk-child :sup/late :asset/loaded :asset/failed)
+          ;; Parent stays in :hydrating across resolution by NOT
+          ;; declaring an :on for the resolution event. The runtime
+          ;; still dispatches it, but no transition fires — the join
+          ;; slot survives so late children flow through the
+          ;; :resolved? branch.
+          parent {:initial :idle
+                  :states
+                  {:idle      {:on {:start :hydrating}}
+                   :hydrating
+                   {:invoke-all
+                    {:children            [{:id :a :machine-id :child/la :start [:set-id :a]}
+                                           {:id :b :machine-id :child/lb :start [:set-id :b]}
+                                           {:id :c :machine-id :child/lc :start [:set-id :c]}]
+                     :join                :any
+                     :cancel-on-decision? false
+                     :on-child-done       :asset/loaded
+                     :on-child-error      :asset/failed
+                     :on-some-complete    [:race/won]}}}}]
+      (rf/reg-machine :child/la child)
+      (rf/reg-machine :child/lb child)
+      (rf/reg-machine :child/lc child)
+      (rf/reg-machine :sup/late parent)
+      (rf/register-trace-cb! ::late-cb
+                             (fn [ev] (swap! traces conj ev)))
+      (try
+        (rf/dispatch-sync [:sup/late [:start]])
+        (let [ids (get-in (frame-db) [:rf/spawned :sup/late [:hydrating] :children])]
+          ;; First child resolves the :any join.
+          (rf/dispatch-sync [(:a ids) [:go]])
+          (let [j (get-in (frame-db) [:rf/spawned :sup/late [:hydrating]])]
+            (is (true? (:resolved? j)) ":any resolved on first :go")
+            (is (= #{:a} (:done j))))
+          ;; Sibling b completes AFTER resolution — late-completion path.
+          (rf/dispatch-sync [(:b ids) [:go]])
+          (let [j (get-in (frame-db) [:rf/spawned :sup/late [:hydrating]])]
+            (is (= #{:a} (:done j))
+                "late-completion does NOT mutate :done")
+            (is (true? (:resolved? j)) ":resolved? stays true")))
+        (let [late-traces (->> @traces
+                               (filter #(= :rf.machine.invoke-all/late-completion
+                                           (:operation %))))]
+          (is (= 1 (count late-traces))
+              "exactly one late-completion trace fired")
+          (is (= :b (:child-id (:tags (first late-traces))))
+              "trace carries the late child's id")
+          (is (= :done (:kind (:tags (first late-traces))))
+              "trace carries the resolution kind"))
+        (finally
+          (rf/remove-trace-cb! ::late-cb))))))
+
 (deftest any-failed-trace-carries-reason-payload
   (testing ":rf.machine.invoke-all/any-failed trace carries :reason from decisive failure"
     (let [traces (atom [])

--- a/implementation/machines/test/re_frame/parallel_test.clj
+++ b/implementation/machines/test/re_frame/parallel_test.clj
@@ -304,3 +304,23 @@
       (rf/dispatch-sync [:par/storage [:no-match]])
       (is (some? (snapshot :par/storage))
           "snapshot synthesised at [:rf/machines :par/storage]"))))
+
+;; ---- 13. region-machine memoization (rf2-s83iu) ---------------------------
+
+(deftest region-machine-result-is-memoised-per-machine
+  (testing "region-machine returns identical-equal results across repeat calls for the same parent-machine"
+    (let [m {:type    :parallel
+             :data    {}
+             :regions {:a {:initial :one :states {:one {}}}
+                       :b {:initial :two :states {:two {}}}}}]
+      (rf/reg-machine :par/cache m)
+      (let [cached  (rf/machine-meta :par/cache)
+            first-a (re-frame.machines.parallel/region-machine cached :a)
+            again-a (re-frame.machines.parallel/region-machine cached :a)
+            first-b (re-frame.machines.parallel/region-machine cached :b)]
+        (is (identical? first-a again-a)
+            "second region-machine call returns the cached spec object")
+        (is (not (identical? first-a first-b))
+            "different regions yield different objects")
+        (is (= :a (:rf/region first-a)))
+        (is (= :b (:rf/region first-b)))))))

--- a/implementation/machines/test/re_frame/spawn_registry_test.clj
+++ b/implementation/machines/test/re_frame/spawn_registry_test.clj
@@ -228,3 +228,65 @@
         ;; either the same actor-id or nil after the user's destroy).
         (is (nil? (get-in db [:rf/machines :worker/proc#1]))
             "the spawned actor is gone")))))
+
+;; ---- (5) spawned actor's snapshot carries :rf/spawn-counter + :meta -------
+;;
+;; Per rf2-fgqs4 the unified build-initial-snapshot helper seeds
+;; :rf/spawn-counter {} and propagates :meta on every snapshot it
+;; builds — including spawned actors. Before rf2-fgqs4 the spawn path
+;; called a stripped-down builder that omitted both keys; the runtime
+;; then fell back to the defensive (fnil inc 0) backstop and the
+;; spawned child's :meta was dropped.
+
+(deftest spawned-actor-snapshot-carries-spawn-counter
+  (testing "a spawned actor's initial snapshot has :rf/spawn-counter {}"
+    (let [child  {:initial :running :data {} :states {:running {}}}
+          parent {:initial :idle
+                  :states  {:idle    {:on {:start :working}}
+                            :working {:invoke {:machine-id :worker/sc}}}}]
+      (rf/reg-machine :worker/sc child)
+      (rf/reg-machine :sup/sc parent)
+      (rf/dispatch-sync [:sup/sc [:start]])
+      (let [spawned-id (get-in (frame-db) [:rf/spawned :sup/sc [:working]])
+            snap       (get-in (frame-db) [:rf/machines spawned-id])]
+        (is (= {} (:rf/spawn-counter snap))
+            "spawned actor's initial snapshot seeds :rf/spawn-counter to {}")))))
+
+(deftest spawned-actor-snapshot-propagates-meta
+  (testing ":meta declared on the child spec flows through to the spawned snapshot"
+    (let [child  {:initial :running
+                  :data    {}
+                  :meta    {:foo :bar :version 7}
+                  :states  {:running {}}}
+          parent {:initial :idle
+                  :states  {:idle    {:on {:start :working}}
+                            :working {:invoke {:machine-id :worker/meta}}}}]
+      (rf/reg-machine :worker/meta child)
+      (rf/reg-machine :sup/meta parent)
+      (rf/dispatch-sync [:sup/meta [:start]])
+      (let [spawned-id (get-in (frame-db) [:rf/spawned :sup/meta [:working]])
+            snap       (get-in (frame-db) [:rf/machines spawned-id])]
+        (is (= {:foo :bar :version 7} (:meta snap))
+            "spec-declared :meta is propagated to the spawned actor's snapshot")))))
+
+(deftest grandchild-spawn-allocates-from-childs-snapshot-counter
+  (testing "a grandchild's id allocates from the child's :rf/spawn-counter, not the defensive fnil-inc backstop"
+    (let [grandchild {:initial :running :data {} :states {:running {}}}
+          child      {:initial :booting
+                      :states  {:booting {:invoke {:machine-id :grand/proc}}}}
+          parent     {:initial :idle
+                      :states  {:idle    {:on {:start :working}}
+                                :working {:invoke {:machine-id :child/wraps}}}}]
+      (rf/reg-machine :grand/proc grandchild)
+      (rf/reg-machine :child/wraps child)
+      (rf/reg-machine :sup/cascade parent)
+      (rf/dispatch-sync [:sup/cascade [:start]])
+      (let [child-id      (get-in (frame-db) [:rf/spawned :sup/cascade [:working]])
+            grandchild-id (get-in (frame-db) [:rf/spawned child-id [:booting]])
+            child-snap    (get-in (frame-db) [:rf/machines child-id])]
+        (is (= :child/wraps#1 child-id)
+            "child's id from parent's allocator")
+        (is (= :grand/proc#1 grandchild-id)
+            "grandchild's id allocated as <machine-id>#1 — deterministic form, NOT the fnil-inc backstop")
+        (is (= {:grand/proc 1} (:rf/spawn-counter child-snap))
+            "child's :rf/spawn-counter bumped on grandchild spawn")))))


### PR DESCRIPTION
## Summary

Batched src polish for the machines artefact — 9 follow-on beads off the rf2-2ukxv round-2 audit (and round-1 carryovers). One PR per the dispatcher's batched-by-surface protocol; all changes are bounded to `implementation/machines/src/` plus matching test files.

## Beads landed (9)

**Refactors (clarity / structure):**
- `rf2-uctfa` — destructure-default at top-line fx handlers (5 sites collapse the `(let [frame-id (or frame :rf/default)] …)` intermediate).
- `rf2-p8kq9` — `emit-pick-traces!` helper extracts three sandwiched `_` trace bindings from `machine-transition-single`.
- `rf2-nv9ey` — collapse `apply-initial-entry-cascade-single` into `bootstrap-step` (FLAT-MACHINE name dropped; helper retained since two callers).
- `rf2-0x4l7` — decompose the 100-LoC `intercept-invoke-all-event` main branch into three named acts: `compute-resolution`, `emit-resolution-traces!`, `build-resolution-fx`.

**Fixes (spec drift):**
- `rf2-4aop8` — forward decisive child payload through `:invoke-all` join resolution + carry `:reason` on the `any-failed` trace (Spec 005 §Spawn-and-join line 2366 / §Trace events line 2393).

**Perf / hygiene:**
- `rf2-q55id` — `(set! *warn-on-reflection* true)` across all 13 machines src files (zero surfaced warnings; `^Throwable` already in place).
- `rf2-s83iu` — memoise `region-machine` via per-machine metadata cache. Re-registration replaces the cache atomically — no separate invalidation path.

**Tests:**
- `rf2-1tt9q` — cover the `intercept-invoke-all-event` late-completion safety-net branch (uses `:cancel-on-decision? false` + omitted parent `:on`).
- `rf2-94kvf` — lock the rf2-fgqs4 contract: spawned snapshots seed `:rf/spawn-counter`, propagate `:meta`, and allocate grandchild ids deterministically through the in-snapshot counter.

## Deferred / not in this PR

- `rf2-nahfm` (run child `:exit` on all destroy paths) — touches multiple destroy entrypoints; warrants its own bead with conformance corpus coverage.

## Diff stats

17 files, +501 / −122 lines (a big chunk of that is the three new test deftests + the join.cljc decomposition).

## Test plan

- [x] `cd implementation/machines && clojure -M:test` — 139 tests / 442 assertions, 0 failures
- [x] `cd implementation && npm run test:cljs` — 1822 tests / 5131 assertions, 0 failures