### PR TITLE
refactor(mcp-base): pin :rf/redacted sentinel in vocab.cljc (rf2-rp5ta)

### DIFF
--- a/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
@@ -112,6 +112,23 @@
   path. Reserved per Conventions §Reserved namespaces. Per rf2-urjnc."
   :rf.size/large-elided)
 
+(def redacted-sentinel
+  "Literal value substituted **in-place** for a sensitive leaf by the
+  framework's `rf/elide-wire-value` walker and by the `with-redacted`
+  interceptor. Unlike `:rf.size/large-elided`, this is a **scalar
+  sentinel** — there is no map payload, no `:handle`, no re-fetch
+  affordance. The value is gone; the agent sees `:rf/redacted` and
+  MUST NOT attempt to recover it.
+
+  Per spec/Tool-Pair.md §Direct-read privacy posture: `elide-wire-value`
+  is the single normative emission site for this sentinel (sensitive)
+  and for `:rf.size/large-elided` (oversize). When both predicates
+  match at a leaf the **sensitive drop wins** — the size marker is
+  suppressed because its `:path` / `:bytes` / `:digest` slots would
+  leak metadata about the redacted value. Reserved per
+  Conventions §Reserved namespaces (`:rf/*` single-root scheme)."
+  :rf/redacted)
+
 (def elision-handle-key
   "First slot in the elision handle vector. The vector shape
   `[:rf.elision/at <path>]` is the cross-MCP convention for re-fetch

--- a/tools/mcp-base/test/re_frame/mcp_base/vocab_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/vocab_test.clj
@@ -15,6 +15,7 @@
 
 (deftest rf-size-elision-keys-pinned
   (is (= :rf.size/large-elided        vocab/large-elided-key))
+  (is (= :rf/redacted                 vocab/redacted-sentinel))
   (is (= :rf.elision/at               vocab/elision-handle-key))
   (is (= :rf.size/include-large?      vocab/include-large-opt))
   (is (= :rf.size/include-sensitive?  vocab/include-sensitive-opt))


### PR DESCRIPTION
## Summary

- Add `redacted-sentinel :rf/redacted` to `tools/mcp-base/src/re_frame/mcp_base/vocab.cljc` — the wire-boundary sentinel that `elide-wire-value` substitutes in-place for sensitive leaves.
- Pin the constant in `vocab_test.clj` so a rename is a loud wire-protocol break.

## Why

The vocab catalogue's opening doctrine: *"One place to learn — and pin — the namespaced keys that the agent learns once and recognises across every MCP tool in the re-frame2 triplet."* `spec/Tool-Pair.md` §Direct-read privacy posture (line 552) reserves `:rf/redacted` as the sensitive-drop sentinel emitted by `elide-wire-value` at the wire boundary, but `vocab.cljc` carried no constant for it — consumers pinned the literal keyword in-line. The catalogue mandate was violated by absence. Caught by `rf2-n4q62` round-2 audit (finding F8).

## Notes

`:rf/redacted` is distinct from `:rf.size/large-elided`: the former is a **scalar sentinel value** substituted in-place (no handle, no re-fetch — the value is gone); the latter is a **map marker** carrying `:bytes` / `:handle` for the agent to drill back via `get-path`. Docstring spells out the difference and the sensitive-drop-wins composition rule.

## Test plan

- [x] `cd tools/mcp-base && clojure -M:test` — 89 tests / 223 assertions, 0/0
- [x] `cd implementation && npm run test:cljs` — 1822 tests / 5131 assertions, 0/0
- [x] `cd implementation && npm run test:bundle-isolation` — PASS