### PR TITLE
refactor(error): extract type-of-value into shared re-frame.error ns (rf2-w4bby)

### DIFF
--- a/implementation/core/src/re_frame/error.cljc
+++ b/implementation/core/src/re_frame/error.cljc
@@ -1,0 +1,46 @@
+(ns re-frame.error
+  "Shared error-message helpers — short tag fns and reason-string
+  primitives used by error / warning trace emit sites across core and
+  the per-feature artefacts.
+
+  Per rf2-w4bby — extracts the byte-identical `type-of-value` helper
+  previously duplicated in `re-frame.spec` (core) and
+  `re-frame.schemas.validate` (schemas). Both call sites use it for
+  the same purpose: rendering a short type tag in the `:reason`
+  string of a `:rf.error/schema-validation-failure` trace event.
+
+  Lives in core because schemas depends on core (Spec 006 §Adapter
+  shipping convention as extended by rf2-p7va) — pushing the helper
+  down means the schemas-side validate.cljc can `:require` it without
+  inverting the dep direction. Apps that don't load the schemas
+  artefact still get the helper for free under `re-frame.spec`'s
+  boundary-validation interceptor.
+
+  Pure; no runtime state. Hot-path safe (single keyword cond cascade
+  with no allocation on the common branches).")
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn type-of-value
+  "Best-effort short tag for a value's type — surfaced inside the
+  `:reason` slot of a `:rf.error/schema-validation-failure` (or
+  similar) trace event. Returns a stable lowercase string for the
+  primitive Clojure shapes; falls back to `(str (type v))` for
+  anything else.
+
+  Stable contract — the eight enumerated tags
+  (`string` / `integer` / `number` / `boolean` / `keyword` / `map`
+  / `vector` / `nil`) are part of the framework's reason-string
+  vocabulary. Adding new fast-path tags is additive; renaming an
+  existing one breaks consumers' grep-pinned reason-string fixtures."
+  [v]
+  (cond
+    (string? v)  "string"
+    (integer? v) "integer"
+    (number? v)  "number"
+    (boolean? v) "boolean"
+    (keyword? v) "keyword"
+    (map? v)     "map"
+    (vector? v)  "vector"
+    (nil? v)     "nil"
+    :else        (str (type v))))

--- a/implementation/core/src/re_frame/spec.cljc
+++ b/implementation/core/src/re_frame/spec.cljc
@@ -54,7 +54,8 @@
   `:schemas/explain-with-registered-fn` late-bind hooks. When the
   schemas artefact is not on the classpath the hooks return nil and
   the interceptor falls through as a no-op."
-  (:require [re-frame.interceptor :as interceptor]
+  (:require [re-frame.error :as error]
+            [re-frame.interceptor :as interceptor]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
@@ -112,22 +113,6 @@
   trace surface itself reads."
   []
   interop/debug-enabled?)
-
-(defn- type-of-value
-  "Best-effort short tag for the failing value's type — surfaced in the
-  failure trace's `:reason` string. Mirrors the same private helper in
-  re-frame.schemas."
-  [v]
-  (cond
-    (string? v)  "string"
-    (integer? v) "integer"
-    (number? v)  "number"
-    (boolean? v) "boolean"
-    (keyword? v) "keyword"
-    (map? v)     "map"
-    (vector? v)  "vector"
-    (nil? v)     "nil"
-    :else        (str (type v))))
 
 ;; ---- :spec/validate-at-boundary -------------------------------------------
 ;;
@@ -230,7 +215,7 @@
                                           :reason     (str "Event " event-id
                                                            " payload failed boundary "
                                                            "schema " schema ", got "
-                                                           (type-of-value event) ".")
+                                                           (error/type-of-value event) ".")
                                           :recovery   :no-recovery})
                       ;; Per Spec 010 §Per-step recovery step 1: handler
                       ;; is not invoked. The handler-as-interceptor

--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -64,7 +64,8 @@
   `:event` (duplicate of `:received`) and `:malli-error` (duplicate of
   `:explain`) tags have been dropped — consumers reach for `:received`
   / `:value` / `:explain`."
-  (:require [re-frame.frame :as frame]
+  (:require [re-frame.error :as error]
+            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.schemas.storage :as storage]
             [re-frame.schemas.validator :as validator]
@@ -138,18 +139,6 @@
         (when (seq paths)
           (reduce common-prefix (first paths) (rest paths)))))))
 
-(defn- type-of-value [v]
-  (cond
-    (string? v)  "string"
-    (integer? v) "integer"
-    (number? v)  "number"
-    (boolean? v) "boolean"
-    (keyword? v) "keyword"
-    (map? v)     "map"
-    (vector? v)  "vector"
-    (nil? v)     "nil"
-    :else        (str (type v))))
-
 (defn- reason-string
   "Build the human-readable `:reason` slot for a schema-validation
   failure trace. Single template covering every emit-site:
@@ -175,10 +164,10 @@
     - `value`: the value that failed.
 
   Shape: \"<subject><id-or-path><slot-tail><pr-str schema>, got
-  <type-of-value>.\""
+  <error/type-of-value>.\""
   [subject id-or-path slot-tail schema value]
   (str subject id-or-path slot-tail (pr-str schema)
-       ", got " (type-of-value value) "."))
+       ", got " (error/type-of-value value) "."))
 
 (defn- run-validation
   "Shared core of the four meta-bearing validate-*! fns (event / cofx /


### PR DESCRIPTION
## Summary

Per rf2-whepe round-2 audit (rf2-w4bby): `implementation/core/src/re_frame/spec.cljc` and `implementation/schemas/src/re_frame/schemas/validate.cljc` carried a byte-identical 11-line private `type-of-value` helper. The cascade (`string?` / `integer?` / `number?` / `boolean?` / `keyword?` / `map?` / `vector?` / `nil?` / `:else (str (type v))`) was EXACTLY the same dispatch in both files. The core/spec.cljc docstring even acknowledged the mirror.

Both sites use the helper for the same purpose: rendering a short type tag in the `:reason` slot of a `:rf.error/schema-validation-failure` trace event.

This PR extracts the helper into a new `re-frame.error` ns under core:

- **New ns**: `implementation/core/src/re_frame/error.cljc` — reserved for short-form error-helpers (`type-of-value` today; the eventual `reason-string` factoring per round-1 Q6 tomorrow).
- **Consumers updated** (2):
  - `re-frame.spec` (`core/spec.cljc`) — boundary-validation interceptor.
  - `re-frame.schemas.validate` — `reason-string` helper inside `run-validation`.
- **Dep direction preserved**: schemas already depends on core (Spec 006 §Adapter shipping convention as extended by rf2-p7va for per-feature splits), so the helper goes in core. No inversion.
- Net: -11 LoC of duplication. Mechanical extract; closes the only cross-artefact byte-duplication round-2 surfaced.

## Test plan

- [x] `npm run test:cljs` (1822 tests / 5131 assertions — 0 failures)
- [x] `clojure -M:test` in `implementation/core` (489 tests / 2502 assertions — 0 failures)
- [x] `clojure -M:test` in `implementation/schemas` (179 tests / 497 assertions — 0 failures)
- [x] `npm run test:elision` — all sentinels PRESENT / ABSENT as expected