### PR TITLE
refactor(pair2-mcp): polish tail — 4 follow-on beads (rf2-b05ld)

### DIFF
--- a/spec/Tool-Pair.md
+++ b/spec/Tool-Pair.md
@@ -541,6 +541,23 @@ The cross-MCP catalogue is normative and shared across the re-frame2 MCP triplet
 
 The framework owns the *data*; the wire-protocol layer owns the *packaging*. Findings docs and downstream Specs reaching for the mechanism catalogue link to the MCP-server homes above, not back into this Spec.
 
+#### MCP-side wire-marker vocabulary
+
+The mechanisms above emit a small family of namespaced wire markers — replacement envelopes that pair-shaped tools wrap a payload in when a budget / dedup / cache rule fires. Every marker rides as a top-level map keyed on a `:rf.mcp/*` or `:rf.size/*` keyword (per [Conventions.md §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned)); agent hosts pattern-match on the key to branch their UI / retry / drill-in flows. Each artefact's own Spec mentions a subset; the family in one place:
+
+| Marker key | Mechanism | Emitted by | Shape (top-level keys) |
+|---|---|---|---|
+| `:rf.mcp/overflow` | Wire-cap (rf2-rvyzy) | Post-eval cap step replaces an over-budget payload. | `:limit :reached`, `:token-count`, `:cap-tokens`, `:tool`, `:hint`. |
+| `:rf.mcp/summary` | Lazy-summary mode (rf2-u2029) | `snapshot` replaces each `:summary`-mode rich slice. | `:type`, `:keys`, `:count`, `:bytes`. |
+| `:rf.mcp/dedup-table` | Structural dedup (rf2-obpa9) | Every epoch / events vector emitter wraps post-encoded payload. | `:de-dupe.cache/cache-0`, `:de-dupe.cache/cache-1`, … (flat). |
+| `:rf.mcp/diff-from` | Diff-encoded `:db-after` (rf2-1wdzp) | Each epoch's `:db-after` is replaced with an intra-record diff. | `:rf.mcp/diff-from`, `:patches`. |
+| `:rf.mcp/cache-hit` | Per-session response cache (rf2-3rt1f / rf2-36xod) | Wire-boundary cache replaces a byte-identical re-emit. | `:hash`, `:unchanged-since`, `:tool`, `:via` (`:result-hash` / `:precheck`), `:hint`. |
+| `:rf.size/large-elided` | Size-elision walker (rf2-urjnc, rf2-9fz64) | `rf/elide-wire-value` substitutes over-threshold leaves. | `:path`, `:bytes`, `:type`, `:reason`, `:hint`, `:handle` (`[:rf.elision/at <path>]`). |
+| `:rf.mcp/cursor-stale` | Cursor pagination (rf2-kbqq3) | `trace-window` / `watch-epochs` refuse a cursor whose `:epoch-id` aged out of the ring. | `:reason :rf.mcp/cursor-stale`, `:tool`, `:requested-id`, `:head-id`. |
+| `:rf/redacted` | Privacy walker (`with-redacted`, spec/009 §Privacy) | The framework-side redact walker replaces named keys at emit time. | Scalar sentinel (no map shape). |
+
+Agents that learn the family see each new slot as one more case in the same pattern-match — the namespaced first key is the discriminator. New mechanisms add to the table; existing markers are stable (additive: new optional keys, never removed / renamed).
+
 ### Direct-read privacy posture for `sub-cache` and `get-path`
 
 Most Tool-Pair surfaces ride the trace bus (`register-trace-cb!` / `register-epoch-cb!`) or the event-emit substrate, where `:sensitive?` stamps and size markers are applied at the emit boundary. Two surfaces in the attachment table above do **not** ride that path: `(rf/sub-cache frame-id)` and the MCP-server `get-path` tool (a direct read-by-path against `(rf/get-frame-db frame-id)`). Both are **synchronous reads** of live runtime state — the sub-cache map, an arbitrary path into `app-db` — and the `:sensitive?` trace stamp protects only the *trace* surface. A direct read returns the live value untransformed unless the wire-egress boundary scrubs it.

--- a/tools/pair2-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/pair2-mcp/spec/003-Tool-Catalogue.md
@@ -97,6 +97,24 @@ vocabulary `[:rf.elision/at <path>]` are reserved per
 and [`Spec 009 §Size elision in traces`](../../../spec/009-Instrumentation.md);
 the shape is shared across pair2-mcp, story-mcp, and causa-mcp.
 
+## Universal: `:typicalTokens` on every tool descriptor
+
+Every MCP tool descriptor emitted by `tools/list` carries a
+`:typicalTokens` slot (rf2-6sddv) — an informational ballpark of the
+response-payload size in tokens that AI clients use to budget calls
+and pick size-conscious args (`max-tokens`, `cache`, `cursor`)
+without trial-and-error. The slot is a hint, not a contract: the
+real cap is the per-call wire-cap enforced by §Universal:
+wire-boundary token cap above. Worst-case-shape; narrowing on tool-
+specific args (`limit`, `path`, `:timing-ms` for watch-epochs) shrinks
+the actual payload roughly proportional to the match rate.
+
+Each entry lists its declared `:typicalTokens` value in the tool
+descriptor — read the body of each tool below to see the budget
+hint for that surface. The number lives alongside `:name`,
+`:description`, and `:inputSchema` in the JSON-RPC `tools/list`
+response.
+
 ## Universal: per-session response cache
 
 Every read tool — `snapshot`, `get-path`, `trace-window`,

--- a/tools/pair2-mcp/spec/Principles.md
+++ b/tools/pair2-mcp/spec/Principles.md
@@ -248,6 +248,18 @@ internals.
   callers that have already paginated or genuinely need the
   full payload). The knob surfaces in `tools/list` so clients
   can discover it.
+
+  The arg name is fixed cross-server: **`max-tokens`** as the
+  JSON-RPC `arguments` key (string, kebab-case — the wire
+  shape an agent host sends); **`:max-tokens`** as the parsed
+  CLJS keyword inside the runtime. The pairing is normative —
+  pair2-mcp, story-mcp, and causa-mcp all parse the same wire
+  slot to the same in-process key, so a forwarder that learned
+  one pairing on one server gets the same pairing on the
+  others. Per
+  [causa-mcp Wire-Pipeline §1 Token budget cap](../../causa-mcp/spec/004-Wire-Pipeline.md)
+  and
+  [TOKEN-BUDGETS.md](../../mcp-conformance/TOKEN-BUDGETS.md).
 - **Overflow shape**: a tool that would exceed the cap MUST NOT
   silently truncate. Instead it MUST return a structured
   overflow marker as the entire payload:
@@ -379,6 +391,34 @@ and a **cap-reached** behaviour note (the structured-overflow
 marker described above, optionally with tool-specific hint
 text). The hints surface in `list-tools` so the agent can
 plan ahead.
+
+**Catalogue-entry contract (normative).** Every tool entry in
+[`003-Tool-Catalogue.md`](003-Tool-Catalogue.md) MUST declare:
+
+1. **Which of the eight mechanisms apply** to the tool (cap,
+   path-slice, cursor, lazy-summary, dedup, elision, diff-
+   encode, streaming-budget). A tool that ships a tree-typed
+   payload but doesn't apply mechanisms 4 / 6 (lazy-summary /
+   size-elision) is the load-bearing exception that has to be
+   called out in the entry.
+2. **The `:typicalTokens` hint** — the worst-case ballpark in
+   tokens. AI clients budget calls and pick size-conscious
+   args (`max-tokens`, `cache`, `cursor`) without trial-and-
+   error using this slot.
+3. **The cap-reached behaviour** — what the tool returns when
+   the post-shrink payload would still trip the cap. Default
+   is `{:rf.mcp/overflow ...}` with the tool-specific hint
+   string; tools that paginate (`trace-window`, `watch-epochs`)
+   instead emit `:has-more? true` + `:next-cursor` and never
+   trip the cap on a single page.
+4. **The default mode / limit / dedup / elision values** for
+   every applicable knob. No tool ships without these slots.
+
+The contract aligns with causa-mcp
+[Wire-Pipeline §catalogue-entry contract](../../causa-mcp/spec/004-Wire-Pipeline.md);
+the two catalogues use the same hint-slot vocabulary so an
+agent's per-tool budget projections work uniformly across both
+servers.
 
 This is the load-bearing budget posture for pair2-mcp's
 agent-host workflow: keep the per-op cost predictable, push

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/nrepl.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/nrepl.cljs
@@ -127,14 +127,27 @@
 (defn- attach-handlers!
   "Wire up `data` / `error` / `close` on the freshly-connected socket.
   Resolves pending requests on matching `:done` status; logs errors;
-  marks the conn closed on disconnect."
+  marks the conn closed on disconnect.
+
+  The `data` handler folds the incoming chunk into the buffer AND
+  splits off any complete frames in a single `swap!` — two-swap
+  variants left a window where a second `data` callback (or a
+  Buffer.concat racing) could observe the freshly-accumulated bytes
+  but not yet the trimmed trailer, double-decoding the same frame.
+  One atomic swap closes that window."
   [conn-atom ^js socket]
   (j/call socket :on "data"
     (fn [chunk]
-      (let [conn (swap! conn-atom update :buf #(js/Buffer.concat #js [(or % (js/Buffer.alloc 0)) chunk]))
-            [frames rest] (decode-all-frames (:buf conn))]
-        (swap! conn-atom assoc :buf rest)
-        (doseq [frame (array-seq frames)]
+      (let [frames* (atom nil)
+            _       (swap! conn-atom
+                           (fn [c]
+                             (let [buf'           (js/Buffer.concat
+                                                    #js [(or (:buf c) (js/Buffer.alloc 0))
+                                                         chunk])
+                                   [frames rest'] (decode-all-frames buf')]
+                               (reset! frames* frames)
+                               (assoc c :buf rest'))))]
+        (doseq [frame (array-seq @frames*)]
           (let [id      (j/get frame "id")
                 resolve (get (:pending @conn-atom) id)]
             (when resolve
@@ -275,8 +288,19 @@
                         build-pr " " code-pr " {})")]
      (jvm-eval conn-atom wrapped opts))))
 
-(defn- read-edn-safe [s]
-  (try (edn/read-string s) (catch :default _ s)))
+(defn- read-edn-safe
+  "Best-effort EDN read of the nREPL value string. On parse failure we
+  return the raw string so the caller can decide what to do with the
+  unparseable shape — but we log to stderr first because a silent
+  drop-back hides genuine wire-shape regressions (a runtime that
+  shipped malformed EDN gets surfaced by inspection of the dev
+  console, not by a mute branch)."
+  [s]
+  (try
+    (edn/read-string s)
+    (catch :default e
+      (log! "read-edn-safe: parse failed —" (.-message e))
+      s)))
 
 (defn cljs-eval-value
   "Like cljs-eval but unwraps to the actual CLJS value. shadow's

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -94,16 +94,16 @@
 
 (defn- precheck-step
   "Step 0 — rf2-36xod cheap-hash short-circuit. For precheck-eligible
-  tools (cache enabled AND tool registers a precheck-frame), fetches
+  tools (cache enabled AND tool registers a precheck-target), fetches
   the runtime-side hash via one bencode round-trip and consults the
   cache. On a hit, writes the marker to `:result` (which trips
   subsequent steps' `:short-circuit?` predicates). On a miss, records
   the fetched hash in `:precheck-hash` so `apply-cache` can attach
   it to the future entry."
   [{:keys [conn name args cache-opts] :as ctx}]
-  (if-let [frame (and (:enabled? cache-opts)
-                      (precheck/precheck-frame name args))]
-    (-> (precheck/fetch-precheck-hash conn args frame)
+  (if-let [target (and (:enabled? cache-opts)
+                       (precheck/precheck-target name args))]
+    (-> (precheck/fetch-precheck-hash conn args target)
         (.then (fn [h]
                  (assoc ctx
                    :precheck-hash h

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/args.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/args.cljs
@@ -142,8 +142,14 @@
 (defn parse-frames-arg
   "Normalise the `frames` MCP arg into the form the runtime expects.
    Accepts `:all`, the string \"all\", a JS array of strings, or a CLJS
-   vector. Returns `:all` or a vector of keyword frame-ids. Returns
-   `:all` for nil / empty / unrecognised input — least-surprise."
+   vector. Returns `:all` or a vector of keyword frame-ids.
+
+   Unrecognised input (anything other than the four accepted shapes
+   above) collapses to `:all`. This is least-surprise on the
+   discovery path — an agent that typos `frames \"al\"` or passes a
+   scalar `frames 42` gets the broadest valid scope back, not a
+   silent empty page. Stricter validation would be a behaviour
+   change against the published contract; the catch-all is intentional."
   [raw]
   (cond
     (nil? raw) :all
@@ -200,15 +206,14 @@
   dropped rather than coerced to the global default (rf2-vw4sq)."
   [raw]
   (let [as-clj (cond
-                 (nil? raw)            nil
-                 (map? raw)            raw
-                 ;; JS object from the MCP wire.
-                 (and (some? raw)
-                      (not (array? raw))
-                      (not (string? raw))
-                      (not (boolean? raw))
-                      (not (number? raw)))
-                 (try (js->clj raw) (catch :default _ nil))
+                 (nil? raw)   nil
+                 (map? raw)   raw
+                 ;; JS object from the MCP wire. `object?` is the
+                 ;; cljs.core predicate — true for plain JS objects
+                 ;; (`{}`-shaped wire input) and false for arrays /
+                 ;; strings / booleans / numbers, which is exactly the
+                 ;; discriminator we want here.
+                 (object? raw) (try (js->clj raw) (catch :default _ nil))
                  :else nil)]
     (if-not (map? as-clj)
       {}

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/cap.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/cap.cljs
@@ -141,7 +141,21 @@
   `invoke` pipeline (rf2-3z0zi) already short-circuits before this
   fn runs in the orchestrated path, but the guard here makes the
   invariant local to `apply-cap` too — direct callers (tests, future
-  consumers) get the same skip."
+  consumers) get the same skip.
+
+  ## `:isError` is NOT a short-circuit (intentional asymmetry vs cache)
+
+  Unlike `cache/apply-cache` — which passes `:isError` through
+  untouched so a transient failure can't poison the cache —
+  `apply-cap` measures and (if over budget) wraps an `:isError`
+  result in `:rf.mcp/overflow` like any other payload. An error
+  response can itself carry an oversize `:message` blob (e.g. a
+  stack trace pretty-printed from a deep CLJS exception) and silent
+  over-budget egress would violate the rf2-rvyzy contract that
+  every response is the wire-cap-respecting marker OR a sub-cap
+  payload — never a verbatim over-budget body. The cache only
+  cares about identity; the cap cares about byte count, and an
+  error's bytes count just like a success's."
   [result-js {:keys [tool cap strategy]
               :or   {strategy :truncate-with-marker}}]
   (if (wire/marker? result-js)

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors_data.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors_data.cljs
@@ -65,7 +65,7 @@
                      "at the top level; opt back in with `include-sensitive? true`. Dropped count surfaces "
                      "as `:dropped-sensitive` on the result when non-zero. "
                      "Each epoch's :db-after is diff-encoded against its own :db-before by default (rf2-1wdzp) "
-                     "— pass `epochs-mode \"full\"` for the legacy full-pair shape (needed for time-travel restore). "
+                     "— pass `epochs-mode \"full\"` for the full-pair shape (the time-travel-restore mode) (needed for time-travel restore). "
                      "The epoch vector is structurally deduped by default (rf2-obpa9) — repeated subtrees "
                      "(notably the per-record `:db-before` reference) collapse to a `{:rf.mcp/dedup-table ...}` "
                      "wrapper; the agent host calls `(de-dupe.core/expand cache)` to reconstruct. Pass `dedup false` to skip. "
@@ -81,7 +81,7 @@
                               :limit knobs/limit-property
                               :cursor knobs/cursor-property
                               :epochs-mode {:type "string"
-                                            :description "How :db-after rides the wire: \"diff\" (default, intra-record structural diff against :db-before) or \"full\" (legacy full snapshot, opt-in for time-travel)."
+                                            :description "How :db-after rides the wire: \"diff\" (default, intra-record structural diff against :db-before) or \"full\" (complete :db-after snapshot — opt-in for time-travel restore, which needs the verbatim state)."
                                             :enum ["diff" "full"]}
                               :dedup knobs/dedup-property
                               :include-sensitive? {:type "boolean"
@@ -103,7 +103,7 @@
                      "Per spec/009 §Privacy this forwarder "
                      "default-drops items carrying `:sensitive? true`; opt back in with `include-sensitive? true`. "
                      "Each epoch's :db-after is diff-encoded against its own :db-before by default (rf2-1wdzp) "
-                     "— pass `epochs-mode \"full\"` for the legacy full-pair shape. "
+                     "— pass `epochs-mode \"full\"` for the full-pair shape (the time-travel-restore mode). "
                      "The matches vector is structurally deduped by default (rf2-obpa9); pass `dedup false` to skip. "
                      "Cursor pagination (rf2-kbqq3): the matches vector is bounded at `:limit` (default 50). "
                      "When more matches remain, `:next-cursor` is non-nil and `:has-more? true`; pass `cursor` "
@@ -154,7 +154,7 @@
                      "Path-slicing supersedes the slice-level mode for `:app-db`. "
                      "Diff-encoded epochs (rf2-1wdzp): each epoch in the `:epochs` slice has its `:db-after` "
                      "replaced with a structural diff against its own `:db-before` by default — pass "
-                     "`epochs-mode \"full\"` for legacy full-pair shape (opt-in for time-travel restore). "
+                     "`epochs-mode \"full\"` for full-pair shape (the time-travel-restore mode, which needs verbatim state). "
                      "Diff-encode runs before the lazy-summary so `bytes` hints reflect post-shrink cost. "
                      "Per spec/009 §Privacy the `:traces` and `:epochs` slices default-drop items carrying "
                      "`:sensitive? true`; opt back in with `include-sensitive? true`. App-db / sub-cache / "
@@ -209,7 +209,7 @@
                                         :additionalProperties {:type "string"
                                                                :enum ["summary" "full"]}}
                               :epochs-mode {:type "string"
-                                            :description "How :db-after rides the wire in the :epochs slice: \"diff\" (default, intra-record structural diff against :db-before) or \"full\" (legacy full snapshot, opt-in for time-travel)."
+                                            :description "How :db-after rides the wire in the :epochs slice: \"diff\" (default, intra-record structural diff against :db-before) or \"full\" (complete :db-after snapshot — opt-in for time-travel restore, which needs the verbatim state)."
                                             :enum ["diff" "full"]}
                               :dedup    knobs/dedup-property
                               :elision  knobs/elision-property

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/dispatch.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/dispatch.cljs
@@ -11,7 +11,7 @@
         build-id     (wire/arg-build args)
         sync?        (boolean (wire/arg args :sync))
         trace?       (boolean (wire/arg args :trace))
-        frame        (some-> (wire/arg args :frame) keyword)
+        frame        (wire/arg-keyword args :frame)
         fx-overrides (when-let [o (wire/arg args :fx-overrides)] (js->clj o :keywordize-keys true))]
     (cond
       (or (nil? event-str) (str/blank? event-str))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/precheck.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/precheck.cljs
@@ -27,10 +27,20 @@
             [re-frame-pair2-mcp.tools.wire :as wire]
             [re-frame-pair2-mcp.tools.args :as args]))
 
-(defn precheck-frame
-  "Resolve the frame to use for a single-frame precheck. Returns the
-  frame keyword (e.g. `:rf/default`) or nil if the tool isn't
-  precheck-eligible.
+(defn precheck-target
+  "Resolve the precheck target for a single-frame precheck. Returns a
+  tagged 2-tuple — one of:
+
+    [:explicit       <frame-keyword>]   — caller named a specific frame.
+    [:operating-frame nil]              — runtime resolves the frame.
+    nil                                 — tool not precheck-eligible.
+
+  Tagged-tuple dispatch supersedes the prior sentinel-keyword shape
+  (`:rf.mcp.cache/operating-frame`) — `precheck-form` dispatches on
+  the tag rather than pattern-matching against a magic keyword, and
+  the eligibility / runtime-resolution distinction is now type-level,
+  not value-level. Future targets (e.g. multi-frame combined-hash)
+  add a new tag without colliding with a reserved keyword.
 
   `snapshot` is eligible only when `:frames` resolves to a single frame
   (an explicit one-element vector or a single scalar). `:all` or a
@@ -47,7 +57,7 @@
       (cond
         ;; explicit single-frame vector
         (and (vector? frames) (= 1 (count frames)))
-        (first frames)
+        [:explicit (first frames)]
         ;; vector with multiple frames — not eligible
         (vector? frames)
         nil
@@ -61,40 +71,47 @@
     ;; the eval form computes the hash over whichever frame the runtime
     ;; picks. The hash still keys on (tool, args), so the cache slot is
     ;; consistent.
-    (or (some-> (wire/arg raw-args :frame) args/->frame-keyword)
-        :rf.mcp.cache/operating-frame)
+    (if-let [f (some-> (wire/arg raw-args :frame) args/->frame-keyword)]
+      [:explicit f]
+      [:operating-frame nil])
 
     ;; Other tools — not precheck-eligible yet.
     nil))
 
 (defn precheck-form
-  "The CLJS eval form for the runtime-side cheap hash. We hash the
-  full per-frame snapshot — `(hash db)` is O(n) on the persistent map
-  but the wire payload is a single integer, and the alternative
-  (running the full tool + transform pipeline) is strictly more
-  expensive. A cheaper O(1) hash kept at mutation time is the
-  follow-on optimisation (filed separately)."
-  [frame]
-  (cond
-    (= frame :rf.mcp.cache/operating-frame)
-    (ef/emit (ef/rt-call* 'hash (ef/rt-call 'snapshot)))
+  "The CLJS eval form for the runtime-side cheap hash. Dispatches on
+  the tag in `target` (`[:explicit <kw>]` / `[:operating-frame nil]`)
+  — the keyword sentinel of the prior shape is gone.
 
-    (keyword? frame)
+  We hash the full per-frame snapshot — `(hash db)` is O(n) on the
+  persistent map but the wire payload is a single integer, and the
+  alternative (running the full tool + transform pipeline) is strictly
+  more expensive. A cheaper O(1) hash kept at mutation time is the
+  follow-on optimisation (filed separately)."
+  [[tag frame :as _target]]
+  (case tag
+    :explicit
     (ef/emit (ef/rt-call* 'hash (ef/rt-call 'snapshot frame)))
 
-    :else nil))
+    :operating-frame
+    (ef/emit (ef/rt-call* 'hash (ef/rt-call 'snapshot)))
+
+    nil))
 
 (defn fetch-precheck-hash
   "Issue the one-bencode-round-trip eval to fetch the runtime-side
   hash. Returns a Promise resolving to an integer hash, or `nil` on
   any failure (the caller treats nil as 'no precheck — proceed').
 
+  `target` is the tagged tuple returned by `precheck-target` — see
+  that fn's docstring for the tag vocabulary.
+
   Errors are swallowed by design: a failed precheck must NEVER block
   the actual tool call. The worst case is we lose the optimisation
   for this call; the post-eval cache still catches the wire-bytes
   saving."
-  [conn raw-args frame]
-  (if-let [form (precheck-form frame)]
+  [conn raw-args target]
+  (if-let [form (precheck-form target)]
     (let [build-id (wire/arg-build raw-args)]
       (-> (nrepl/cljs-eval-value conn build-id form)
           (.then (fn [v]

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/sensitive.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/sensitive.cljs
@@ -76,11 +76,15 @@
 
 (defn scrub-snapshot-sensitive
   "Walk a snapshot's per-frame map and drop `:sensitive? true` items
-  from the `:traces` slice (and, defensively, `:epochs` — epoch
-  records may inherit the stamp). Returns `[scrubbed dropped-count]`.
-  Non-trace slices (:app-db, :sub-cache, :machines) pass through
-  unchanged — redaction of those payloads is the `with-redacted`
-  interceptor's job, not the forwarder's.
+  from the `:traces` and `:epochs` slices. Returns
+  `[scrubbed dropped-count]`. Non-trace slices (:app-db, :sub-cache,
+  :machines) pass through unchanged — redaction of those payloads is
+  the `with-redacted` interceptor's job, not the forwarder's.
+
+  Epoch-record stamping is current contract per rf2-isdwf — the
+  epoch assembler computes the rollup at record-assembly time and
+  the `sensitive-epoch?` defence-in-depth check matches against it.
+  Both vectors are scrubbed by the same union strip-fn.
 
   Thin delegate (rf2-zpmmr) to
   `re-frame.mcp-base.sensitive/scrub-snapshot` with the pair2-mcp

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs
@@ -62,26 +62,42 @@
    :dropped-sensitive 0
    :elided-large      0})
 
-(defn- merge-drain
+(defn drain-produced-output?
+  "Did this drain produce a tick the client should see? True iff the
+  drain delivered kept events OR reported queue-overflow drops — the
+  two shapes that surface as a `notifications/progress` tick.
+
+  Lifted to a named predicate (rather than inlining the OR at the
+  two call sites — `merge-drain`'s `tick?` gate and the poll loop's
+  emit gate) so the contract is single-sourced: any future change
+  to what counts as a tick (e.g. surfacing tick-elided-only drains)
+  lands here once, not at two sites that could drift."
+  [{:keys [n ev-dropped]}]
+  (or (pos? (or n 0)) (pos? (or ev-dropped 0))))
+
+(defn merge-drain
   "Pure state update — fold one drain's contributions into the rolling
   accumulators. The drain reports `:ev-dropped`/`:by-dropped` for
   queue-overflow eviction (rf2-ho4ve), `:dropped` for sensitive-strip,
   and `:tick-elided` for the count of `:rf.size/large-elided` markers
   on this batch. `:n` is the kept-event count after sensitive-strip.
 
-  A tick is counted whenever the drain produced kept events OR the
-  drain reported queue-overflow drops — both shapes should surface to
-  the client as `notifications/progress`."
-  [s {:keys [n ev-dropped by-dropped ov-reason dropped tick-elided]}]
-  (let [tick? (or (pos? n) (pos? ev-dropped))]
-    (cond-> s
-      tick?            (-> (update :tick      inc)
+  A tick is counted whenever `drain-produced-output?` returns true —
+  the predicate single-sources the gate.
+
+  Public (not `defn-`) so unit tests in `subscribe_test.cljs` can
+  pin the state-merge contract directly; the runtime contract surface
+  is otherwise nrepl-only."
+  [s {:keys [n ev-dropped by-dropped ov-reason dropped tick-elided] :as drain}]
+  (cond-> s
+    (drain-produced-output? drain)
+                       (-> (update :tick      inc)
                            (update :delivered + n))
-      (pos? ev-dropped)  (update :dropped-events    + ev-dropped)
-      (pos? by-dropped)  (update :dropped-bytes     + by-dropped)
-      ov-reason          (assoc  :overflow-reason   ov-reason)
-      (pos? dropped)     (update :dropped-sensitive + dropped)
-      (pos? tick-elided) (update :elided-large      + tick-elided))))
+    (pos? ev-dropped)  (update :dropped-events    + ev-dropped)
+    (pos? by-dropped)  (update :dropped-bytes     + by-dropped)
+    ov-reason          (assoc  :overflow-reason   ov-reason)
+    (pos? dropped)     (update :dropped-sensitive + dropped)
+    (pos? tick-elided) (update :elided-large      + tick-elided)))
 
 (defn- parse-mcp-extra
   "Pluck the three MCP-host slots the streaming loop needs out of the
@@ -152,7 +168,7 @@
                                             :dropped     dropped
                                             :tick-elided tick-elided}
                             s'             (swap! state merge-drain drain-delta)]
-                        (when (or (pos? n) (pos? ev-dropped))
+                        (when (drain-produced-output? drain-delta)
                           (when (and send-note progress-tk)
                             (emit/emit-progress-tick!
                               {:send-note   send-note
@@ -176,7 +192,7 @@
 
 (defn subscribe-tool [conn raw-args extra]
   (let [build-id           (wire/arg-build raw-args)
-        topic              (some-> (wire/arg raw-args :topic) keyword)
+        topic              (wire/arg-keyword raw-args :topic)
         filter-map         (args/parse-filter-arg (wire/arg raw-args :filter))
         max-buf-events     (wire/arg raw-args :max-buffered-events)
         max-buf-bytes      (wire/arg raw-args :max-buffered-bytes)

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscription_info.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscription_info.cljs
@@ -42,7 +42,7 @@
 
 (defn subscription-info-tool [conn args]
   (let [build-id (wire/arg-build args)
-        topic    (some-> (wire/arg args :topic) keyword)
+        topic    (wire/arg-keyword args :topic)
         sub-id   (wire/arg args :sub-id)
         form     (ef/emit
                    (ef/rt-let ['r    (ef/rt-call 'subscription-info)

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/tail_build.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/tail_build.cljs
@@ -3,11 +3,32 @@
   (:require [re-frame-pair2-mcp.nrepl :as nrepl]
             [re-frame-pair2-mcp.tools.wire :as wire]))
 
+(def ^:private default-wait-ms
+  "Default deadline for the probe to change after a hot-reload. Five
+  seconds is generous for a typical shadow-cljs incremental rebuild;
+  heavy ns reloads / first-time-load scenarios can override via the
+  `:wait-ms` MCP arg."
+  5000)
+
+(def ^:private probe-poll-ms
+  "Cadence at which we re-evaluate the probe form when waiting for
+  its value to change. 100ms = ~10 probes/sec — fine-grained enough
+  to land within ~100ms of the reload completing, cheap enough on
+  the nREPL socket to not flood it."
+  100)
+
+(def ^:private no-probe-soft-delay-ms
+  "When the caller passes no probe form, we resolve after a fixed
+  soft delay — matches the bash-shim's behaviour. 300ms is the
+  span empirical observation places shadow-cljs's bundle-swap cycle
+  within after the source-file save event fires."
+  300)
+
 (defn tail-build-tool [conn args]
   (let [build-id (wire/arg-build args)
-        wait-ms  (or (wire/arg args :wait-ms) 5000)
+        wait-ms  (or (wire/arg args :wait-ms) default-wait-ms)
         probe    (wire/arg args :probe)
-        poll-ms  100]
+        poll-ms  probe-poll-ms]
     (cond
       (nil? probe)
       ;; Soft delay — matches the bash version's behaviour when no probe
@@ -16,9 +37,13 @@
         (fn [resolve _]
           (js/setTimeout
             (fn []
-              (resolve (wire/ok-text {:ok? true :t (js/Date.now) :soft? true
-                                      :note "No probe supplied; waited a 300ms fixed delay."})))
-            300)))
+              (resolve (wire/ok-text {:ok?   true
+                                      :t     (js/Date.now)
+                                      :soft? true
+                                      :note  (str "No probe supplied; waited a "
+                                                  no-probe-soft-delay-ms
+                                                  "ms fixed delay.")})))
+            no-probe-soft-delay-ms)))
 
       :else
       (let [start (js/Date.now)]

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/trace_window.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/trace_window.cljs
@@ -23,7 +23,7 @@
 (defn trace-window-tool [conn raw-args]
   (let [ms        (or (wire/arg raw-args :ms) 1000)
         build-id  (wire/arg-build raw-args)
-        frame     (some-> (wire/arg raw-args :frame) keyword)
+        frame     (wire/arg-keyword raw-args :frame)
         incl?     (args/parse-bool-arg raw-args :include-sensitive?)
         mode      (dedup/parse-epochs-mode (wire/arg raw-args :epochs-mode))
         dedup?    (args/parse-bool-arg raw-args :dedup)

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/watch_epochs.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/watch_epochs.cljs
@@ -27,7 +27,7 @@
 
 (defn watch-epochs-tool [conn raw-args]
   (let [build-id  (wire/arg-build raw-args)
-        frame     (some-> (wire/arg raw-args :frame) keyword)
+        frame     (wire/arg-keyword raw-args :frame)
         since-id  (wire/arg raw-args :since-id)
         incl?     (args/parse-bool-arg raw-args :include-sensitive?)
         mode      (dedup/parse-epochs-mode (wire/arg raw-args :epochs-mode))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire.cljs
@@ -14,10 +14,19 @@
 ;; Config — build id.
 ;; ---------------------------------------------------------------------------
 
-(defn default-build-id []
-  (or (some-> (j/get-in js/process [:env :SHADOW_CLJS_BUILD_ID])
-              keyword)
-      :app))
+(def ^:private cached-default-build-id
+  "Cached at namespace load — the `SHADOW_CLJS_BUILD_ID` env var
+  doesn't change at runtime, and re-reading it on every tool
+  dispatch (11+ reads per call across `arg-build` and friends) is
+  wasted cycles. A delay defers the read until the first call —
+  important for shadow-cljs hot-reload paths where the file may
+  load before `js/process.env` is fully populated."
+  (delay
+    (or (some-> (j/get-in js/process [:env :SHADOW_CLJS_BUILD_ID])
+                keyword)
+        :app)))
+
+(defn default-build-id [] @cached-default-build-id)
 
 ;; ---------------------------------------------------------------------------
 ;; MCP result helpers.
@@ -55,8 +64,17 @@
   (let [v (j/get args (name k))]
     (when-not (or (nil? v) (undefined? v)) v)))
 
+(defn arg-keyword
+  "Pluck an arg slot and coerce to a keyword via `(some-> v keyword)`.
+  Returns nil when the slot is absent. Compresses the
+  `(some-> (wire/arg args :foo) keyword)` pattern that recurs across
+  the per-tool bodies (topic / frame plucks) — single source of truth
+  for the str→kw coercion shape callers don't need to spell out."
+  [args k]
+  (some-> (arg args k) keyword))
+
 (defn arg-build [args]
-  (or (some-> (arg args :build) keyword)
+  (or (arg-keyword args :build)
       (default-build-id)))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/invoke_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/invoke_test.cljs
@@ -203,9 +203,8 @@
 ;; hash matches the first, marker replaces it.
 ;;
 ;; `snapshot` with the default :all `frames` is precheck-ineligible —
-;; the precheck-frame returns nil and the precheck round-trip is
-;; skipped (sentinel `[nil nil]`). Perfect probe for the post-eval
-;; cache slot.
+;; the precheck-target returns nil and the precheck round-trip is
+;; skipped. Perfect probe for the post-eval cache slot.
 ;; ---------------------------------------------------------------------------
 
 (deftest result-hash-hit-when-precheck-ineligible

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/subscribe_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/subscribe_test.cljs
@@ -11,7 +11,8 @@
             [cljs.reader]
             [applied-science.js-interop :as j]
             [re-frame-pair2-mcp.tools.args :as args]
-            [re-frame-pair2-mcp.tools.eval-form :as ef]))
+            [re-frame-pair2-mcp.tools.eval-form :as ef]
+            [re-frame-pair2-mcp.tools.subscribe :as sub]))
 
 ;; The MCP-arg filter parser lives in
 ;; `re-frame-pair2-mcp.tools.args/parse-filter-arg`. Tests pin the
@@ -294,3 +295,118 @@
     (is (zero? (:dropped-events sub)))
     (is (zero? (:dropped-bytes sub)))
     (is (nil?  (:overflow-reason sub)))))
+
+;; ---------------------------------------------------------------------------
+;; merge-drain — pure state update for the streaming-loop accumulators
+;; (rf2-c0h8p). The fn lives in `tools/subscribe.cljs`; it's the
+;; single source of truth for how a drain's contributions fold into
+;; the rolling per-stream state map.
+;;
+;; The poll loop's emit-gate uses `drain-produced-output?` to decide
+;; whether to ship a `notifications/progress` tick — the predicate is
+;; pinned here too so a future change to "what counts as a tick"
+;; surfaces on both the merge-state and emit-gate sides as a single
+;; failing test.
+;; ---------------------------------------------------------------------------
+
+(def ^:private zero-state
+  "Same shape as `subscribe/initial-state` — locally redeclared so the
+  test pins the contract independently of a future rename / restructure
+  of the source-side default. A mismatch here is a meaningful contract
+  drift, not a parallel-fixture lie."
+  {:tick              0
+   :delivered         0
+   :dropped-events    0
+   :dropped-bytes     0
+   :overflow-reason   nil
+   :dropped-sensitive 0
+   :elided-large      0})
+
+(defn- drain
+  "Construct a drain-delta map. Defaults all counters to zero / nil so
+  tests only need to set the slots they care about."
+  [overrides]
+  (merge {:n 0 :ev-dropped 0 :by-dropped 0
+          :ov-reason nil :dropped 0 :tick-elided 0}
+         overrides))
+
+(deftest drain-produced-output?-kept-events
+  ;; Kept events ⇒ tick.
+  (is (true? (sub/drain-produced-output? (drain {:n 3})))))
+
+(deftest drain-produced-output?-only-overflow-drops
+  ;; Overflow drops alone ⇒ tick (the client still wants to see the drop).
+  (is (true? (sub/drain-produced-output? (drain {:ev-dropped 5})))))
+
+(deftest drain-produced-output?-empty-drain
+  ;; No kept events, no overflow drops ⇒ no tick.
+  (is (false? (sub/drain-produced-output? (drain {})))))
+
+(deftest drain-produced-output?-only-sensitive-drop
+  ;; A sensitive-strip alone (with no kept events) is NOT a tick — the
+  ;; runtime had nothing to ship the client. The indicator surfaces on
+  ;; the final summary, not on a no-content tick.
+  (is (false? (sub/drain-produced-output? (drain {:dropped 4})))))
+
+(deftest drain-produced-output?-only-tick-elided
+  ;; Elision count alone (no kept events, no overflow) ⇒ no tick. The
+  ;; count piggybacks on real ticks; an empty drain shouldn't ship.
+  (is (false? (sub/drain-produced-output? (drain {:tick-elided 7})))))
+
+(deftest merge-drain-empty-drain-is-identity
+  ;; The accumulator must not move when nothing changed — drives the
+  ;; `cond->` correctness on the no-tick branch.
+  (is (= zero-state (sub/merge-drain zero-state (drain {})))))
+
+(deftest merge-drain-counts-tick-on-kept-events
+  (let [s' (sub/merge-drain zero-state (drain {:n 4}))]
+    (is (= 1 (:tick s')))
+    (is (= 4 (:delivered s')))))
+
+(deftest merge-drain-counts-tick-on-overflow-only
+  ;; Overflow-only drain still increments tick (no `:delivered` move).
+  (let [s' (sub/merge-drain zero-state (drain {:ev-dropped 6 :by-dropped 100
+                                               :ov-reason :max-buffered-events}))]
+    (is (= 1 (:tick s')))
+    (is (zero? (:delivered s')))
+    (is (= 6   (:dropped-events s')))
+    (is (= 100 (:dropped-bytes s')))
+    (is (= :max-buffered-events (:overflow-reason s')))))
+
+(deftest merge-drain-accumulates-across-drains
+  ;; Two drains: the first counts a tick, the second another. Counters
+  ;; accumulate monotonically; tick counter increments per ticking drain.
+  (let [s1 (sub/merge-drain zero-state (drain {:n 2 :dropped 1}))
+        s2 (sub/merge-drain s1         (drain {:n 3 :tick-elided 4}))]
+    (is (= 2 (:tick s2)))
+    (is (= 5 (:delivered s2)))
+    (is (= 1 (:dropped-sensitive s2)))
+    (is (= 4 (:elided-large s2)))))
+
+(deftest merge-drain-no-tick-when-only-sensitive-dropped
+  ;; Sensitive strip drops events; the drain is empty by the time we
+  ;; merge it. Tick must NOT increment — the contract is "the client
+  ;; sees a tick iff kept events OR overflow drops". A sensitive-only
+  ;; drain has nothing to ship.
+  (let [s' (sub/merge-drain zero-state (drain {:dropped 3}))]
+    (is (zero? (:tick s')))
+    (is (zero? (:delivered s')))
+    (is (= 3   (:dropped-sensitive s')))))
+
+(deftest merge-drain-overflow-reason-latches-last
+  ;; If multiple drains report different overflow-reasons, the most
+  ;; recent wins — the runtime evicts oldest-first and the latest
+  ;; reason is the one currently in force.
+  (let [s1 (sub/merge-drain zero-state (drain {:ev-dropped 1
+                                               :ov-reason :max-buffered-events}))
+        s2 (sub/merge-drain s1         (drain {:by-dropped 100
+                                               :ev-dropped 1
+                                               :ov-reason :max-buffered-bytes}))]
+    (is (= :max-buffered-bytes (:overflow-reason s2)))))
+
+(deftest merge-drain-elided-large-accumulates
+  ;; Indicator slot: each ticking drain's `:tick-elided` adds to the
+  ;; rolling `:elided-large` total which surfaces on the final summary.
+  (let [s1 (sub/merge-drain zero-state (drain {:n 1 :tick-elided 2}))
+        s2 (sub/merge-drain s1         (drain {:n 1 :tick-elided 3}))]
+    (is (= 5 (:elided-large s2)))))


### PR DESCRIPTION
## Summary

Four follow-on beads landed atop the rf2-pair2-batch (#1016) polish cluster — all
on the `tools/pair2-mcp/` surface.

- **rf2-c0h8p** — merge-drain + drain-produced-output? unit tests (subscribe
  streaming loop). 11 tests pinning the state-merge contract; lifted both to
  public so the test ns can pin directly.
- **rf2-lhue6 / rf2-n5j96** — cosmetic polish / trivials cluster:
  - `merge-drain` exposed as public; `drain-produced-output?` predicate single-
    sources the tick-gate contract across the merge-state path and the emit gate.
  - `nrepl/attach-handlers!` data callback folds buf-concat + frame-split into
    one atomic `swap!` (NR1) — closed a race window where a second `data` event
    could double-decode the same frame.
  - `read-edn-safe` logs to stderr on catch (NR2) — silent parse failures now
    surface in the dev console.
  - `precheck/precheck-frame` → `precheck/precheck-target` returning a tagged
    2-tuple (`[:explicit <kw>]` / `[:operating-frame nil]`); sentinel keyword
    (`:rf.mcp.cache/operating-frame`) gone.
  - `wire/default-build-id` cached in a delay at namespace load — was 11+
    env-var reads per tool dispatch (T5).
  - New `wire/arg-keyword` helper folds the `(some-> (wire/arg ...) keyword)`
    pattern across five tool bodies (T18).
  - `args/parse-modes-arg` JS-object discriminator collapses to `object?` (ARGS1).
  - `args/parse-frames-arg` typo-swallow behaviour documented (ARGS3).
  - `tail-build` 300ms soft-delay + 100ms poll cadence lifted to named `def`s.

- **rf2-agcq2 / rf2-kaof4** — spec amendments:
  - `spec/Tool-Pair.md` adds a §MCP-side wire-marker vocabulary enumeration
    table — every `:rf.mcp/*` / `:rf.size/*` marker the MCP-server layer emits
    listed with mechanism, emit site, and top-level keys.
  - `tools/pair2-mcp/spec/003-Tool-Catalogue.md` adds §Universal
    `:typicalTokens` on every tool descriptor.
  - `descriptors_data.cljs`: drop "legacy" framing on `epochs-mode \"full\"`
    (it's the time-travel-restore mode, not legacy).
  - `sensitive.cljs`: trim the defensive ":epochs may inherit in future"
    parenthetical (rf2-isdwf made it current contract).
  - `cap.cljs`: document the intentional `:isError` pass-through asymmetry
    vs `cache/apply-cache`.

- **rf2-uebll** — lift causa-mcp wire-pipeline expansions back into pair2-mcp
  Principles per causa-mcp's DESIGN-RATIONALE.md Lock #9 §Why follow-up:
  - `max-tokens` / `:max-tokens` notation pin (the JSON-RPC arg name + parsed
    CLJS keyword pairing is fixed cross-server).
  - **Catalogue-entry contract** (normative) — every tool entry MUST declare
    which mechanisms apply, the `:typicalTokens` hint, the cap-reached
    behaviour, and the default knob values.

## Deferred (not in this PR)

- **rf2-e35a5** — elision walker returns `[v count]` from server. Medium-risk
  wire-shape change requiring careful design across snapshot + get-path eval
  forms; deserves its own focused bead session.
- **rf2-w92r8** — perf micro-benchmarks. Separate concerted effort to build
  the benchmark harness; data-driven by design.
- **rf2-9pe31** — O(1) cached app-db-hash accessor. Touches runtime preload
  + `frame.cljc`; disjoint surface from pair2-mcp polish, separate dispatch.
- **rf2-5ky6c** — coord rename for v1.0. Decision-blocked pre-v1.0 per
  causa-mcp Lock #6.

## Test plan

- [x] `cd implementation && npm run test:cljs` — 1818/1818 pass.
- [x] `cd implementation && npm run test:bundle-isolation` — pass.
- [x] `cd tools/pair2-mcp && npm test` — 325/325 pass (+11 new merge-drain
      tests on top of prior 314).
- [x] `python scripts/check_skill_mcp_drift.py` — clean.