### PR TITLE
refactor(spec/005): polish cluster — 4 follow-on beads

### DIFF
--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -973,6 +973,29 @@ For singleton machines the bootstrap fx flow out as part of the **first event's*
 
 **Migration note.** Pre-rf2-0z73, initial-state `:entry` actions did NOT fire on bootstrap. Generic child machines that needed to do work on spawn worked around it by declaring `:on :rf.machine/spawned :action :fire-request` on the initial state (the synthetic event the runtime dispatches per rf2-ijm7). Post-rf2-0z73 the canonical shape is `:entry :fire-request` — the `:rf.machine/spawned` workaround still works (it just resolves as a no-op transition through the standard `:on` lookup), but new code should prefer `:entry`.
 
+##### Synthetic bootstrap event vector — `[:rf.machine/bootstrap]` (rf2-pexjc)
+
+When the bootstrap cascade fires, the runtime synthesises a placeholder event vector `[:rf.machine/bootstrap]` and threads it through the action machinery as the "current event" — needed because action fns receive a 2-arity `(fn [data event] {...})` (or 3-arity `(fn [data event ctx] {...})` for the `^:rf.machine/wants-ctx` introspection slot per [§Dispatch rule — metadata opt-in](#dispatch-rule--metadata-opt-in-rfmachinewants-ctx)) and there is no user-dispatched event to thread on bootstrap.
+
+Most `:entry` actions ignore the event argument (it's the data argument they read from). Authors writing introspection-capable `:entry` actions — actions that read the event vector to decide what to do — observe `[:rf.machine/bootstrap]` on the bootstrap call, distinguishable from any user-dispatched event by the reserved `:rf.machine/*` namespace.
+
+```clojure
+;; Action reads the event head to log what triggered the entry.
+(rf/reg-machine :auth-flow
+  {:initial :requesting
+   :states {:requesting {:entry :log-entry}}
+   :actions {:log-entry ^:rf.machine/wants-ctx
+             (fn [data event _ctx]
+               (let [trigger (first event)]
+                 (println "entered :requesting via" trigger))
+               {})}})
+
+;; On bootstrap, prints: "entered :requesting via :rf.machine/bootstrap"
+;; On a later user-driven entry via `[:reset]`, prints: "entered :requesting via :reset"
+```
+
+The vector is **purely synthetic**: not user-dispatched, not registered as an event, never reaches a handler's `:on` map (the bootstrap cascade is `:entry`-only — there is no `:on :rf.machine/bootstrap` resolution; the synthetic vector exists solely so the `:entry` action's event-argument is non-`nil`). The name is reserved under the `:rf.machine/*` namespace (per [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned)); user code MUST NOT register a handler or dispatch this vector directly.
+
 ### Target resolution — vector vs keyword
 
 A transition's `:target` admits **two forms**:

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -1732,6 +1732,82 @@ Symmetry between singleton and spawned:
 
 Both are event handlers. Both addressable by `dispatch`. Both visible to `(handlers :event)`. Both readable through the framework-registered `:rf/machine` sub (per [§Subscribing to machines via `sub-machine`](#subscribing-to-machines-via-sub-machine)) — the actor-id is just the argument: `@(rf/sub-machine actor-id)`.
 
+### Spawn lifecycle — ordering (rf2-k0qb3)
+
+The spawn surface is composite: `:on-spawn`, `:rf.machine/spawn`, the synthetic `[:rf.machine/spawned]`, `:start`, and the spawned actor's initial-`:entry` cascade all participate. The individual pieces are spec'd in their own subsections; this section enumerates the **strict ordering** between them — what fires when, against what context, between the moment a parent state with `:invoke` is entered and the moment the spawned child processes its first user event.
+
+Two distinct "spawn" surfaces, easy to conflate:
+
+- **`:on-spawn` — advisory action on the parent's `:data`.** Declared inside the parent's `:invoke` / `:invoke-all` spec (or on a hand-emitted `:rf.machine/spawn`). Runs **inside the transition reducer at allocate-time** against the parent's `:data` with the freshly-allocated spawned-id — `(fn [parent-data spawned-id] new-parent-data)`. NOT a child-side event. Per rf2-t07u, advisory only: the runtime tracks the id in the spawn-registry at `[:rf/spawned <parent-id> <invoke-id>]` regardless.
+- **`[:rf.machine/spawned]` — synthetic event dispatched into the new child.** Emitted by the `:rf.machine/spawn` fx handler **only when the spawn args omit `:start`**, so generic child machines have a kick-off event to handle. Reaches the child as its first event, ahead of the initial-`:entry` cascade only in resolution order — see step 6 below. Per [§Synthetic `[:rf.machine/spawned]` on spawn (rf2-ijm7)](#synthetic-rfmachinespawned-on-spawn-rf2-ijm7).
+
+#### Ordering — singleton parent invoking a child
+
+For a parent state with `:invoke {:machine-id :child …}` (or for a hand-emitted `:rf.machine/spawn` from an action), the runtime fires the following steps in order. Steps 1–4 happen inside the **parent's** drain; steps 5–8 happen inside the **child's** drain (a separate event-handler boundary).
+
+1. **Parent enters the `:invoke`-bearing state.** The transition's entry cascade reaches the state-node; the desugared `:rf.invoke/spawn-<state>` action (per [§Desugaring rules](#desugaring-rules)) is appended to the cascade's action queue.
+2. **`:on-spawn` runs against the parent's `:data`.** The pure spawn-id allocator picks the next `<id-prefix>#<n>` against `:rf/spawn-counter` at the parent's snapshot root; the `:on-spawn` callback (when declared) folds the new id into `:data` via `(fn [parent-data id] new-parent-data)`. This step is **purely a `:data` update** — no fx is emitted by `:on-spawn` itself.
+3. **`:rf.machine/spawn` fx is emitted** into the parent transition's `:fx` vector with the allocated spawned-id, the resolved child `:data`, and (for declarative `:invoke`) the stamped `:rf/parent-id` / `:rf/invoke-id` keys.
+4. **Parent's drain commits.** The parent's post-action snapshot is written to `[:rf/machines <parent-id>]` and the `:fx` vector drains through the fx pipeline. Up to this point the child does NOT exist as an event handler.
+5. **`:rf.machine/spawn` fx handler runs.** The child's spec is resolved (registered `:machine-id` or inline `:definition`); `synthesise-initial-snapshot` produces the child's initial snapshot with `:rf/bootstrap-pending? true`, the runtime-stamped `:data` keys (`:rf/self-id`, `:rf/parent-id`, `:rf/invoke-id` — per [§Runtime stamps](#runtime-stamps-on-the-spawned-actors-data-rf2-ijm7)), and the user-supplied initial `:data` merged on top; the snapshot is installed at `[:rf/machines <spawned-id>]`; the child's event handler is registered at the spawned-id. The runtime spawn-registry slot at `[:rf/spawned <parent-id> <invoke-id>]` is written for the declarative-`:invoke` case.
+6. **Child's first event is dispatched** — `[<spawned-id> <:start arg>]` when the spawn args carried `:start`, otherwise the synthetic `[<spawned-id> [:rf.machine/spawned]]` (per rf2-ijm7). The two paths are mutually exclusive; the child receives exactly one of the two as its first event, never both.
+7. **Child's initial-entry cascade fires** (per [§Initial-state `:entry` fires on machine bootstrap (rf2-0z73)](#initial-state-entry-fires-on-machine-bootstrap-rf2-0z73)). For a flat child the single initial state's `:entry` runs; for a compound child every `:entry` along the initial chain runs shallowest-first. This cascade runs **before** the first event's `:on` lookup, so `:entry`-emitted `:fx` is concatenated ahead of the first event's transition fx. `:rf/bootstrap-pending?` is cleared by the same drain.
+8. **Child processes the first event.** The event vector arrived in step 6 is now resolved through the child's `:on` map (deepest-wins per [§Transition resolution](#transition-resolution--deepest-wins-with-parent-fallthrough)). For the synthetic `[:rf.machine/spawned]` path with no matching handler this resolves as a benign no-op (`:rf.warning/machine-unhandled-event` is NOT emitted for `:rf.machine/spawned` — it's the canonical kick-off shape).
+
+The same skeleton applies to `:invoke-all`'s N children (per [§Spawn-and-join via `:invoke-all`](#spawn-and-join-via-invoke-all)) with steps 2–5 fanning out once per child and a single join-bookkeeping write at `[:rf/spawned <parent-id> <invoke-all-id>]`.
+
+#### Worked walkthrough
+
+```clojure
+;; Parent
+{:authenticating
+ {:invoke {:machine-id :auth-flow
+           :data       (fn [snap _] {:credentials (-> snap :data :form)})
+           :on-spawn   (fn [d id] (assoc d :auth-actor id))}
+  :on     {:auth/succeeded :authenticated
+           :auth/failed    :idle}}}
+
+;; Child (registered separately)
+(rf/reg-machine :auth-flow
+  {:initial :running
+   :data    {}
+   :states {:running {:entry :fire-request
+                      :on    {:server-ok {:target :done}}}
+            :done    {:final? true :output-key :token}}
+   :actions {:fire-request (fn [data _] {:fx [[:http/post …]]})}})
+```
+
+Trace of a `[:submit]` event landing on the parent in `:idle`:
+
+1. Parent transitions `:idle → :authenticating`. Entry cascade reaches `:authenticating`.
+2. Allocator picks `:auth-flow#0`; `:on-spawn` writes `{:auth-actor :auth-flow#0}` into the parent's `:data`.
+3. Parent's `:fx` accumulates `[:rf.machine/spawn {:machine-id :auth-flow :rf/parent-id :login :rf/invoke-id [:authenticating] …}]`.
+4. Parent commits — `[:rf/machines :login]` updated; the spawn fx drains.
+5. Spawn fx synthesises `:auth-flow#0`'s initial snapshot at `[:rf/machines :auth-flow#0]` with `:state :running`, `:data {:rf/self-id :auth-flow#0 :rf/parent-id :login :rf/invoke-id [:authenticating] :credentials …}`, `:rf/bootstrap-pending? true`; the spawn-registry slot at `[:rf/spawned :login [:authenticating]]` is written to `:auth-flow#0`.
+6. Spawn-args lacked `:start`, so the synthetic `[:auth-flow#0 [:rf.machine/spawned]]` is dispatched.
+7. The child's drain runs the initial-entry cascade: `:running`'s `:entry :fire-request` action emits the HTTP fx. `:rf/bootstrap-pending?` clears.
+8. `[:rf.machine/spawned]` resolves through `:running`'s `:on` map — no match, no-op (no warning).
+
+The contract on the trace stream — every step above corresponds to a distinct externally-observable event:
+
+| Step | Trace |
+|---|---|
+| 1 | `:rf.machine/transition` (parent) |
+| 2 | (no separate trace — `:on-spawn` runs inside the transition reducer) |
+| 3 | (the fx is in the parent's `:fx` vector, visible as `:rf/fx` once the drain emits it) |
+| 4 | `:rf.machine.lifecycle/commit` (parent) |
+| 5 | `:rf.machine.lifecycle/spawned` (child) — per [009](009-Instrumentation.md) |
+| 6 | `:rf/event` (the synthetic kick-off) |
+| 7 | `:rf.machine.lifecycle/bootstrap` (child) + per-action traces |
+| 8 | `:rf.machine.event/unhandled-no-op` (the `:rf.machine/spawned` resolution, suppressed warning) |
+
+#### Why this matters
+
+The ordering is what lets two patterns compose without surprises:
+
+- **Initial-entry `:entry` actions can read the runtime-stamped `:data` keys.** Per step 5, the spawn-fx writes `:rf/self-id` / `:rf/parent-id` / `:rf/invoke-id` into the child's `:data` BEFORE step 7 fires the `:entry` cascade — so an `:entry` action can `(get data :rf/parent-id)` to address its parent without the parent having to thread the id through any other mechanism.
+- **`:start` is for handing the child a one-shot event payload.** When the child needs a specific first event (e.g. `[:begin "/some/url"]`), the parent supplies `:start`; when the child knows its job from initial `:data` alone, the parent omits `:start` and the synthetic `[:rf.machine/spawned]` is just a benign kick-off — the real work happens inside the initial-`:entry` cascade. New code prefers `:entry` over `:on :rf.machine/spawned` (per the rf2-0z73 note in the synthetic-event subsection).
+
 ### Spawning from inside an action (the common case)
 
 ```clojure

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -64,6 +64,40 @@ Stability invariants — every conformant implementation upholds these so snapsh
 
 See [Spec-Schemas §`:rf/machine-snapshot`](Spec-Schemas.md#rfmachine-snapshot).
 
+### Reserved snapshot-internal keys (rf2-33y0y)
+
+Beyond the user-facing `{:state :data :tags? :meta?}` shape above, the runtime stamps a **closed** set of `:rf/*`-prefixed slots inside the snapshot (some at the snapshot root, some inside `:data`, one inside `:meta`) to thread per-machine bookkeeping through pure transitions and the SSR-survivable persisted state. These slots are framework-owned: user code MUST NOT write under them; conformance fixtures that pin them MUST treat them as the runtime's by-product. The set is **fixed-and-additive** — existing names cannot be repurposed; new keys are added by Spec change.
+
+| Reserved key | Location | Value | When written / cleared |
+|---|---|---|---|
+| `:rf/spawn-counter` | snapshot root | `{<id-prefix> <int>}` per-prefix integer-counter map | Bumped by the pure spawn-id allocator on every `:invoke` / `:invoke-all` / hand-emitted `:rf.machine/spawn` so id sequencing is deterministic from the snapshot. Stamped as `{}` at snapshot synthesis; persists across `pr-str` / `read-string`. |
+| `:rf/bootstrap-pending?` | snapshot root | `true` (else absent) | Stamped at snapshot synthesis (singletons) and by the spawn-fx (spawned actors). The first event addressed to the machine runs the initial-entry cascade, then clears the slot via `dissoc`. NEVER `true` on a snapshot that has already processed an event. The slot survives `pr-str` round-trip so a snapshot persisted mid-bootstrap (the SSR boundary case) resumes correctly. Per [§Initial-state `:entry` fires on machine bootstrap (rf2-0z73)](#initial-state-entry-fires-on-machine-bootstrap-rf2-0z73). |
+| `:rf/finished?` | snapshot root | `true` (else absent) | **Transient.** Set by the lifecycle-handler boundary (NOT by `apply-transition-once`) when the post-transition snapshot's active leaf declares `:final? true` — or, for parallel-region machines, when every region's active leaf is `:final?`. The lifecycle handler reads it to fire `:on-done` + auto-destroy, then the snapshot is dissoc'd from `[:rf/machines <id>]`. Pure `machine-transition` calls (conformance corpus, JVM pure-fn tests) see snapshots free of this flag. Per [§Final states](#final-states-final--on-done--output-key) and rf2-gn80. |
+| `:rf/after-epoch` | inside `:data` | non-negative `int` | The wall-clock epoch counter for flat / compound machines, per [§Delayed `:after` transitions](#delayed-after-transitions). Bumped by `commit-snapshot` on any external transition whose entered / exited states declare `:after`. The synthetic `:rf.machine.timer/after-elapsed` event carries the epoch it was scheduled at; the runtime fires the transition iff the carried epoch equals the snapshot's current `:rf/after-epoch`. |
+| `:rf/after-epoch-by-region` | inside `:data` | `{<region-name> <non-negative int>}` | Per-region `:after`-timer epoch counter for parallel-region machines, per [§Per-region `:always` / `:after` / `:invoke` scoping](#per-region-always--after--invoke-scoping). Replaces `:rf/after-epoch` when `:type :parallel` — a sibling region's transition does not invalidate this region's in-flight timers via the shared `:data` slot. |
+| `:rf/self-id` | inside `:data` | `<spawned-machine-id>` keyword | Stamped by the spawn-fx on a spawned actor's initial `:data` so the actor knows its own address (e.g. for self-`:dispatch`). Equal to the gensym'd spawned id; absent on singleton-machine snapshots. Per rf2-ijm7. |
+| `:rf/parent-id` | inside `:data` | `<parent-machine-id>` keyword | Stamped by the spawn-fx on a declarative-`:invoke` / `:invoke-all` spawned actor's initial `:data`. The finalize-cascade reads it to locate the parent's snapshot for `:on-done`. Absent on hand-emitted (non-declarative) spawns. Per rf2-t07u. |
+| `:rf/invoke-id` | inside `:data` | `<vector-of-keywords>` — absolute prefix-path of the `:invoke`-bearing state node | Stamped by the spawn-fx on a declarative-`:invoke` / `:invoke-all` spawned actor's initial `:data`. Together with `:rf/parent-id` it addresses the runtime spawn-registry slot at `[:rf/spawned <parent-id> <invoke-id>]`. Per rf2-t07u. |
+| `:rf/invoke-all-id` | inside `:data` | `<vector-of-keywords>` — `:invoke-all`-bearing state's prefix-path | Stamped by the spawn-fx on each child of an `:invoke-all`. The finalize-cascade uses it to locate the parent's join bookkeeping at `[:rf/spawned <parent-id> <invoke-all-id>]`. Per rf2-6vmw. |
+| `:rf/invoke-all-child-id` | inside `:data` | child-machine-id keyword (the `:id` of the child in the parent's `:invoke-all` `:children` map) | Stamped alongside `:rf/invoke-all-id` so the finalize-cascade can mark exactly which child finished. Per rf2-6vmw. |
+| `:rf/snapshot-version` | inside `:meta` | `int` | Versioning slot for snapshot/definition compatibility (invariant 4 above). When a definition's transition shape changes incompatibly, the author bumps `:meta :rf/snapshot-version`; restore compares the snapshot's version against the definition's and emits `:rf.warning/machine-snapshot-version-mismatch` (or, on the epoch-restore path, `:rf.epoch/restore-version-mismatch`) on disagreement. Per [Spec-Schemas §`:rf/machine-snapshot`](Spec-Schemas.md#rfmachine-snapshot) and [Tool-Pair §Time-travel](Tool-Pair.md#time-travel). |
+
+**Persistence posture.** The transient slots are `:rf/bootstrap-pending?` (cleared on first event) and `:rf/finished?` (set transiently at the lifecycle-handler boundary; never persisted because the snapshot is dissoc'd on the same drain). All other slots ride the snapshot across `pr-str` / `read-string` and through SSR hydration ([011](011-SSR.md)) and Tool-Pair epoch replay.
+
+**Sibling vocabulary — runtime-stamped machine-spec keys (NOT snapshot-internal).** The runtime ALSO stamps a small set of `:rf/*` slots on the live machine-spec value (the runtime's record threaded through `apply-transition-once` and the lifecycle handlers) — these are NOT snapshot-internal and do NOT persist; they are reconstructed at handler-call time from the registrar and the dispatched event:
+
+- `:rf/frame` — the owning frame's id (defaulting to `:rf/default`)
+- `:rf/platform` — the active platform (`:client` / `:server`) per [011](011-SSR.md)
+- `:rf/parent-id` — the machine's own id (or the parent's id for spawned actors), used for trace addressing
+- `:rf/region` — present iff the spec is a synthetic region-machine of a `:type :parallel` parent; the region-name keyword scoping `:after`-epochs per [§Per-region scoping](#per-region-always--after--invoke-scoping)
+- `:rf/transition-pure` — the sentinel parent-id used by the pure-transition path so `intercept-invoke-all-event` (and analogous join-bookkeeping interceptors) recognises a no-op call and short-circuits without consulting `app-db`. Stamped only by callers exercising the pure-fn `machine-transition` (conformance corpus, JVM pure-fn tests, SSR machine-pure surface); absent during normal handler-driven drains.
+
+These spec-level keys are visible to the 3-arity `^:rf.machine/wants-ctx` introspection slot via the `ctx` argument's `:meta` projection where exposed.
+
+**Open-map invariant.** Snapshots are open maps: user `:data` keys at any depth are fine. The runtime-reserved set above is the **closed** subset of `:rf/*`-prefixed slots the runtime owns inside the snapshot. The migration agent flags any user write to `[:rf/machines <id> :data :rf/<reserved>]` or to `[:rf/machines <id> :rf/<reserved>]` as a collision.
+
+The same catalogue is mirrored in [Conventions §Reserved snapshot-internal keys (machine runtime)](Conventions.md#reserved-snapshot-internal-keys-machine-runtime) for cross-spec discoverability.
+
 ## Where snapshots live
 
 Every machine snapshot lives at a fixed reserved path: **`[:rf/machines <machine-id>]`** in the frame's `app-db`. The runtime owns this path; users do not pick a path per machine and `create-machine-handler` does not accept a `:path` key.

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -98,6 +98,26 @@ These spec-level keys are visible to the 3-arity `^:rf.machine/wants-ctx` intros
 
 The same catalogue is mirrored in [Conventions §Reserved snapshot-internal keys (machine runtime)](Conventions.md#reserved-snapshot-internal-keys-machine-runtime) for cross-spec discoverability.
 
+### Reserved synthetic events (rf2-cl7oi)
+
+The machine runtime emits a small **closed set** of synthetic event vectors that are not user-dispatched and do not come from `reg-event-*` — they are framework-generated and threaded through the standard dispatch pipeline so they appear in traces, conformance fixtures, and tooling exactly like any other event. User code MUST NOT register a handler for these names or hand-dispatch them; they are reserved for the runtime. The set is **fixed-and-additive** — existing names cannot be repurposed; new ones are added by Spec change.
+
+| Synthetic event vector | Source | Reaches | Purpose |
+|---|---|---|---|
+| `[:rf.machine/spawned]` | The `:rf.machine/spawn` fx handler (per [§Synthetic `[:rf.machine/spawned]` on spawn](#synthetic-rfmachinespawned-on-spawn-rf2-ijm7)) when the spawn args carry no `:start`. | The spawned actor — dispatched as `[<spawned-id> [:rf.machine/spawned]]` after the initial-entry cascade settles. | Generic-child kick-off shape. Machines that need to do work on spawn declare `:on :rf.machine/spawned` (pre-rf2-0z73) or `:entry :fire-request` on the initial state (canonical post-rf2-0z73; the synthetic event still flows and resolves as a no-op for non-handlers). |
+| `[:rf.machine/bootstrap]` | The bootstrap entry cascade (per [§Synthetic bootstrap event vector — `[:rf.machine/bootstrap]`](#synthetic-bootstrap-event-vector--rfmachinebootstrap-rf2-pexjc)). | The bootstrap `:entry` action(s) — threaded as the `event` argument to the cascade's action fns. Never reaches an `:on` map. | Placeholder event vector for the initial-entry cascade. Authors writing introspection-capable (`^:rf.machine/wants-ctx`) `:entry` actions observe this vector on bootstrap and use it to distinguish bootstrap from user-driven entry. |
+| `[:rf.machine.timer/after-elapsed <delay-key> <epoch>]` | `re-frame.machines.timer` (per [§Epoch-based stale detection](#epoch-based-stale-detection)). Scheduled via `:dispatch-later` at state entry for every `:after` entry; fires when the wall-clock window elapses. | The parent machine — dispatched as `[<machine-id> [:rf.machine.timer/after-elapsed <delay-key> <epoch>]]`. Handled by the machine handler's `:after`-dispatch path. | Wire format between `schedule-after-timer!` and `pick-after-transition`. `<delay-key>` is the literal `:after` map key (a `pos-int?`, a subscription vector, or the resolved fn-output) that identifies which `:after` entry's timer fired; `<epoch>` is the value of `:rf/after-epoch` (or, for parallel-region machines, the region's slot in `:rf/after-epoch-by-region`) captured at scheduling time. The handler compares the carried `<epoch>` to the snapshot's current value; on mismatch the timer is stale and silently dropped (per [§Epoch-based stale detection](#epoch-based-stale-detection)). |
+
+Conformance harnesses that dispatch these vectors directly (per the JVM pure-fn tests for `:after` timers) do so by emulating the runtime — they're exercising the same wire shape the runtime uses internally, not registering new handlers for these names.
+
+### Pure-call no-op shim (SSR / pure introspection)
+
+`re-frame.machines.join`'s `intercept-invoke-all-event` interceptor (the join-bookkeeping wiring per [§Spawn-and-join via `:invoke-all`](#spawn-and-join-via-invoke-all)) reads from `app-db` at `[:rf/spawned <parent-id> <invoke-all-id>]` to advance child-completion bookkeeping. When the interceptor is invoked through the **pure-call path** — exercising `machine-transition` directly without a live frame, i.e. the conformance corpus, JVM pure-fn tests, the SSR machine-pure surface — there is no `:rf/spawned` slot seeded in `app-db`, so the interceptor would either error or write spurious join-state.
+
+The contract: when no join-state is seeded for the active `(invoke-all-id, child-id)` pair, the interceptor returns its standard `{:db db :fx []}` shape (a no-op effect-map) and emits no trace. **Externally observable behaviour:** pure-call invocations of an `:invoke-all`-bearing machine do NOT advance join bookkeeping; they exercise the transition reducer only. Authors of pure-call test corpora can rely on this — driving the parent through a sequence of events under `machine-transition` will run every transition, action, and entry/exit cascade, but the parent's `:invoke-all` child-completion bookkeeping is unobserved (since the runtime spawn registry isn't in scope).
+
+The shim is keyed off the sentinel `:rf/transition-pure` parent-id stamp on the spec record (per the sibling-vocabulary list in [§Reserved snapshot-internal keys](#reserved-snapshot-internal-keys-rf2-33y0y)) — the pure-call path stamps the sentinel; live-frame invocations stamp the actual parent's id. The interceptor short-circuits on the sentinel without consulting `app-db`.
+
 ## Where snapshots live
 
 Every machine snapshot lives at a fixed reserved path: **`[:rf/machines <machine-id>]`** in the frame's `app-db`. The runtime owns this path; users do not pick a path per machine and `create-machine-handler` does not accept a `:path` key.


### PR DESCRIPTION
## Summary

Spec-only polish cluster on `spec/005-StateMachines.md` — the four
follow-on beads from the round-2 machines audit (rf2-2ukxv). Sequenced
content-add-only to avoid intra-PR rebase pain; no doc-gate regressions.

Beads (in commit order):

- **rf2-33y0y · spec(005): Reserved snapshot-internal `:rf/*` keys
  catalogue.** Promotes 005 to authoritative source for the closed-set
  catalogue of runtime-stamped slots inside a machine snapshot (the
  user-facing `{:state :data :tags? :meta?}` shape is what 005 owns per
  `Ownership.md`; Conventions has carried a mirror table since rf2-c1l4d
  and now cross-references back).
- **rf2-k0qb3 · spec(005): unified spawn lifecycle ordering
  subsection.** Enumerates the 8-step ordering from "parent enters
  `:invoke`-bearing state" through "child processes its first event" —
  the two surfaces (`:on-spawn` data-update inside the transition
  reducer, vs `[:rf.machine/spawned]` synthetic event reaching the
  child) are easy to conflate, the source of multiple round-2 audit
  confusions.
- **rf2-pexjc · spec(005): `[:rf.machine/bootstrap]` synthetic event.**
  Documents the placeholder event vector the runtime threads through
  the bootstrap entry cascade (impl has used it since `parallel.cljc`
  / `lifecycle_fx/registration.cljc` but the contract was undocumented
  — authors writing `^:rf.machine/wants-ctx` introspection `:entry`
  actions had no way to know what vector to expect).
- **rf2-cl7oi · spec(005): synthetic events catalogue + pure-call
  no-op shim.** New §Reserved synthetic events table catalogues
  `[:rf.machine/spawned]`, `[:rf.machine/bootstrap]`, and the
  `[:rf.machine.timer/after-elapsed <delay-key> <epoch>]` timer
  carrier (canonical in impl, previously labelled
  "implementation-internal" in spec). New §Pure-call no-op shim
  subsection pins the `intercept-invoke-all-event` no-op contract
  under the `:rf/transition-pure` sentinel path.

LoC delta: +153 / -0.

## Test plan

- [x] `python scripts/check_doc_slugs.py` exits 0
- [x] `python -m mkdocs build` succeeds; warning count unchanged
      from `origin/main` (119, all pre-existing guide/ + skills/
      links to `spec/` which mkdocs doesn't include)
- [x] Rebased clean onto current `origin/main` (no overlapping
      commits touched 005)