### PR TITLE
refactor(causa): hoist perf-tier ladder to theme/, wire event-detail tier dot (rf2-6ja23)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -47,7 +47,8 @@
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-causa.theme.tokens
-             :refer [tokens mono-stack sans-stack]]))
+             :refer [tokens mono-stack sans-stack]]
+            [day8.re-frame2-causa.theme.perf-tier :as perf-tier]))
 
 ;; ---- pure helpers --------------------------------------------------------
 
@@ -127,14 +128,57 @@
                      :margin-top    "4px"}}
        "source • " handler-coord])]])
 
+(defn- tier-dot
+  "Render a perf-tier coloured dot + label for `duration-ms`. Per
+  `tools/causa/spec/007-UX-IA.md` §Colour system §Perf scale —
+  same ladder the Performance panel uses, hoisted into
+  `theme.perf-tier` per the rf2-6ja23 audit so every panel that
+  surfaces a per-node duration reads the same swatch / glyph / label.
+
+  Renders inline; the colour swatch carries the tier, the
+  `aria-label` carries the tier name + duration so the colour-blind
+  path doesn't need hue."
+  [duration-ms]
+  (when (number? duration-ms)
+    (let [tier   (perf-tier/classify-tier duration-ms)
+          colour (perf-tier/tier-colour tier)
+          glyph  (perf-tier/tier-glyph tier)
+          label  (perf-tier/tier-label tier)]
+      [:span {:data-testid (str "rf-causa-event-detail-tier-dot-" (name tier))
+              :aria-label  (str label " (" duration-ms "ms)")
+              :title       (str label " — " duration-ms "ms")
+              :style       {:display      "inline-flex"
+                            :align-items  "center"
+                            :gap          "6px"
+                            :margin-left  "8px"
+                            :color        colour
+                            :font-weight  600}}
+       [:span {:style {:font-size "12px"}} glyph]
+       [:span {:style {:font-family mono-stack
+                       :font-size   "11px"
+                       :color       (:text-secondary tokens)}}
+        (str duration-ms "ms")]])))
+
 (defn- handler-row
   "Second domino: the handler-ran emit. `ev` is the `:run-end` trace
-  event."
+  event.
+
+  ## Tier dot (rf2-6ja23)
+
+  When `:duration-ms` is present on the emit's `:tags`, render the
+  perf-tier coloured dot + label alongside the raw `:phase` text.
+  Same ladder as the Performance panel (`theme.perf-tier`); the
+  raw `:duration-ms` number is kept in the EDN dump for power users."
   [ev]
-  [domino-row {:label "handler" :tone :cyan}
-   [:div
-    [:div (format-edn (select-keys (:tags ev) [:phase :duration-ms]))]
-    (coord-line ev)]])
+  (let [duration-ms (get-in ev [:tags :duration-ms])]
+    [domino-row {:label "handler" :tone :cyan}
+     [:div
+      [:div {:style {:display     "flex"
+                     :align-items "center"
+                     :flex-wrap   "wrap"}}
+       [:span (format-edn (select-keys (:tags ev) [:phase :duration-ms]))]
+       (tier-dot duration-ms)]
+      (coord-line ev)]]))
 
 (defn- fx-row
   "Third domino: the `:event/do-fx` emit (the effects map about to be

--- a/tools/causa/src/day8/re_frame2_causa/panels/performance_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/performance_helpers.cljc
@@ -101,92 +101,60 @@
     - No re-render-counts-per-epoch projection; the row's render-count
       is the count of `:view/render` traces in the cascade, which is a
       cheap proxy until the epoch-record's `:renders` projection
-      surfaces.")
+      surfaces.
+
+  ## Tier ladder lives in `theme/perf_tier.cljc` (rf2-6ja23)
+
+  `classify-tier` / `tier-colour` / `tier-glyph` / `tier-label` /
+  `over-budget?` / `default-budget-ms` / `tier-order` are re-exported
+  here so the Performance panel's existing call-sites keep resolving
+  through `h/classify-tier` etc. The canonical definitions live in
+  `day8.re-frame2-causa.theme.perf-tier` so every other panel surface
+  that needs to colour a duration reads the same ladder. See that
+  ns's docstring for the audit ledger of who's wired and who's
+  blocked on the trace stream growing per-event `:duration-ms`."
+  (:require [day8.re-frame2-causa.theme.perf-tier :as perf-tier]))
 
 ;; ---- defaults ------------------------------------------------------------
 
 (def default-budget-ms
-  "Default budget threshold above which a cascade row carries the
-  over-budget warning marker. 16ms = one frame at 60fps — the v1
-  ergonomic default. The slot is sub-readable so a follow-on bead can
-  surface a slider in the panel header."
-  16)
+  "Re-export of `theme.perf-tier/default-budget-ms` (rf2-6ja23). The
+  canonical ladder lives in `theme/perf_tier.cljc`; this var is held
+  here so existing `performance_helpers/default-budget-ms` references
+  keep resolving."
+  perf-tier/default-budget-ms)
 
 (def tier-order
-  "Render order for the perf tiers when the panel renders a histogram
-  / chip row. Fastest first because the goal is 'mostly green'."
-  [:fast :medium :slow :blocking])
+  "Re-export of `theme.perf-tier/tier-order`."
+  perf-tier/tier-order)
 
 ;; ---- tier classification -------------------------------------------------
 
 (defn classify-tier
-  "Map a `duration-ms` (number) to one of the four perf tiers per
-  `tools/causa/spec/007-UX-IA.md` §Colour system:
-
-      <16ms     → :fast       one-frame-at-60fps
-      16-50ms   → :medium
-      50-100ms  → :slow
-      >=100ms   → :blocking   INP-blocking band
-
-  Boundaries are right-open at the lower edge (the next tier owns the
-  threshold value itself). Negative or nil durations classify as
-  `:fast` — a robust default for cascades whose `:time` deltas
-  collapse to zero (single-event cascades).
-
-  Pure data → keyword; JVM-testable."
+  "Re-export of `theme.perf-tier/classify-tier`. See that ns for the
+  ladder definition + boundary semantics."
   [duration-ms]
-  (cond
-    (not (number? duration-ms)) :fast
-    (< duration-ms 16)          :fast
-    (< duration-ms 50)          :medium
-    (< duration-ms 100)         :slow
-    :else                       :blocking))
+  (perf-tier/classify-tier duration-ms))
 
 (defn tier-colour
-  "Hex swatch per perf tier. Mirrors the spec/007-UX-IA.md §Colour
-  system §Perf scale. The strings are returned so the helper stays
-  pure (no token-map dependency)."
+  "Re-export of `theme.perf-tier/tier-colour`."
   [tier]
-  (case tier
-    :fast     "#4ADE80"  ; green
-    :medium   "#FBBF24"  ; yellow
-    :slow     "#FB923C"  ; orange
-    :blocking "#F87171"  ; red
-    "#6B7080"))           ; text-tertiary fallback
+  (perf-tier/tier-colour tier))
 
 (defn tier-glyph
-  "Single-character glyph paired with the tier colour per spec
-  §Colour is never alone. `●` for fast/medium (within-budget,
-  acceptable); `▲` for slow/blocking (over-budget, attention-needed).
-  Pure data → string; JVM-testable."
+  "Re-export of `theme.perf-tier/tier-glyph`."
   [tier]
-  (case tier
-    :fast     "●"
-    :medium   "●"
-    :slow     "▲"
-    :blocking "▲"
-    "○"))
+  (perf-tier/tier-glyph tier))
 
 (defn tier-label
-  "Human-readable label for a tier — used in the over-budget caption
-  and the chip-row tooltip."
+  "Re-export of `theme.perf-tier/tier-label`."
   [tier]
-  (case tier
-    :fast     "fast"
-    :medium   "medium"
-    :slow     "slow"
-    :blocking "blocking"
-    (str tier)))
+  (perf-tier/tier-label tier))
 
 (defn over-budget?
-  "True iff `duration-ms` is at or above `budget-ms`. nil / non-number
-  inputs are treated as within-budget so a malformed cascade record
-  doesn't false-flag. Pure data → bool; JVM-testable."
+  "Re-export of `theme.perf-tier/over-budget?`."
   [budget-ms duration-ms]
-  (boolean
-    (and (number? budget-ms)
-         (number? duration-ms)
-         (>= duration-ms budget-ms))))
+  (perf-tier/over-budget? budget-ms duration-ms))
 
 ;; ---- duration projection -------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/theme/perf_tier.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/theme/perf_tier.cljc
@@ -1,0 +1,149 @@
+(ns day8.re-frame2-causa.theme.perf-tier
+  "Shared perf-tier classification — the canonical duration→tier→colour
+  ladder per `tools/causa/spec/007-UX-IA.md` §Colour system §Perf scale.
+
+  ## Why this lives in `theme/` (rf2-6ja23)
+
+  Inspired by Vue DevTools 3's colour-coded lifecycle hook durations
+  (green ≤10ms / yellow >10ms / red >30ms). Spec/007-UX-IA.md
+  §'Colour system' defines four tiers — `:fast` / `:medium` / `:slow`
+  / `:blocking` (<16 / 16-50 / 50-100 / >100ms, where 100ms is the
+  INP-blocking threshold). Every node carrying a measurable duration
+  should surface the tier-coloured dot the same way: same hex, same
+  glyph shape, same label string.
+
+  Originally the tier helpers were buried in
+  `panels/performance_helpers.cljc` and used only by the Performance
+  panel. The audit bead rf2-6ja23 found that:
+
+    - `event_detail` already surfaces `:duration-ms` on the handler row
+      (as raw EDN text — no tier dot).
+    - Every other panel that will eventually show per-node durations
+      (`subscriptions` sub-run timings, `effects` fx-handler timings,
+      `machine_inspector` guard-eval timings, `time_travel` cascade
+      span, `causality_graph` cascade colour) is blocked on the trace
+      stream carrying per-event `:duration-ms`. Spec 009 L38: 'no
+      separate start/end pair, no :duration, no duration-ms tag'.
+
+  Hoisting the helpers to `theme/perf_tier.cljc` makes them
+  discoverable from anywhere in `panels/` without a cross-panel
+  require chain. The Performance panel re-exports from here (no
+  behaviour change) so existing call-sites keep working.
+
+  ## Audit ledger — panels that DO / DO NOT yet show tier dots
+
+  Last reviewed 2026-05-14 against the Phase 5 panel set.
+
+    Panel                Surface that should carry the tier-dot   Status
+    -----                --------------------------------------   ------
+    performance          cascade-row, breakdown-bar, tier-chip    LIVE
+    event_detail         handler-row :duration-ms slot            LIVE (rf2-6ja23)
+    subscriptions        per-sub :duration-ms (run timings)       blocked on trace-stream
+    effects              per-fx :duration-ms (handler timings)    blocked on trace-stream
+    machine_inspector    guard-eval :duration-ms                  blocked on trace-stream
+    causality_graph      cascade tier (already cascade-level)     follow-on bead
+    trace                per-event :duration-ms                   blocked on trace-stream
+    time_travel          cascade total wall-clock                 follow-on bead
+
+  'blocked on trace-stream' means the surface needs Spec 009 to grow
+  a per-event `:duration-ms` tag (or equivalent) before the tier-dot
+  can be wired in non-speculatively. The performance panel sidesteps
+  this by computing `(max :time) - (min :time)` across cascade
+  slices, which is a cheap proxy at the cascade level but doesn't
+  attribute per-handler / per-sub.
+
+  Hoisting to `theme/` is the audit's structural finding: the
+  classification ladder is design-system grade (one source of truth,
+  spec-anchored, JVM-portable), not panel-local.
+
+  ## Pure data, JVM-portable
+
+  Everything here is pure data → pure data. `.cljc` so the helpers
+  work from both the Performance panel's projection (Clojure-side
+  tests) and the view layer (ClojureScript runtime)."
+  {:no-doc true})
+
+;; ---- ladder --------------------------------------------------------------
+
+(def tier-order
+  "Render order for the perf tiers when a panel renders a histogram
+  or chip row. Fastest first because the goal is 'mostly green'."
+  [:fast :medium :slow :blocking])
+
+(defn classify-tier
+  "Map a `duration-ms` (number) to one of the four perf tiers per
+  `tools/causa/spec/007-UX-IA.md` §Colour system:
+
+      <16ms     → :fast       one-frame-at-60fps
+      16-50ms   → :medium
+      50-100ms  → :slow
+      >=100ms   → :blocking   INP-blocking band
+
+  Boundaries are right-open at the lower edge (the next tier owns the
+  threshold value itself). Negative / nil / non-numeric durations
+  classify as `:fast` — a robust default for cascades whose `:time`
+  deltas collapse to zero (single-event cascades).
+
+  Pure data → keyword; JVM-testable."
+  [duration-ms]
+  (cond
+    (not (number? duration-ms)) :fast
+    (< duration-ms 16)          :fast
+    (< duration-ms 50)          :medium
+    (< duration-ms 100)         :slow
+    :else                       :blocking))
+
+(defn tier-colour
+  "Hex swatch per perf tier. Mirrors `spec/007-UX-IA.md` §Colour
+  system §Perf scale. Returns hex strings so the helper stays pure
+  (no token-map dependency)."
+  [tier]
+  (case tier
+    :fast     "#4ADE80"  ; green
+    :medium   "#FBBF24"  ; yellow
+    :slow     "#FB923C"  ; orange
+    :blocking "#F87171"  ; red
+    "#6B7080"))           ; text-tertiary fallback
+
+(defn tier-glyph
+  "Single-character glyph paired with the tier colour per `spec/007-
+  UX-IA.md` §'Colour is never alone'. `●` for fast/medium (within-
+  budget, acceptable); `▲` for slow/blocking (over-budget, attention-
+  needed). Pure data → string; JVM-testable."
+  [tier]
+  (case tier
+    :fast     "●"
+    :medium   "●"
+    :slow     "▲"
+    :blocking "▲"
+    "○"))
+
+(defn tier-label
+  "Human-readable label for a tier — used in over-budget captions
+  and chip-row tooltips."
+  [tier]
+  (case tier
+    :fast     "fast"
+    :medium   "medium"
+    :slow     "slow"
+    :blocking "blocking"
+    (str tier)))
+
+;; ---- budget axis ---------------------------------------------------------
+
+(def default-budget-ms
+  "Default budget threshold above which a row carries the over-budget
+  warning marker. 16ms = one frame at 60fps — the v1 ergonomic
+  default. Sub-readable so a follow-on bead can surface a slider in
+  panel headers."
+  16)
+
+(defn over-budget?
+  "True iff `duration-ms` is at or above `budget-ms`. nil /
+  non-number inputs are treated as within-budget so a malformed
+  cascade record doesn't false-flag. Pure data → bool; JVM-testable."
+  [budget-ms duration-ms]
+  (boolean
+    (and (number? budget-ms)
+         (number? duration-ms)
+         (>= duration-ms budget-ms))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
@@ -102,10 +102,24 @@
 (defn- hiccup-seq
   "Walk a hiccup tree and emit every node (vectors only). Vectors
   whose first element is a function are invoked first so the walker
-  descends into the sub-tree they would render to."
+  descends into the sub-tree they would render to.
+
+  ## Recursive descent through fn-components (rf2-6ja23)
+
+  `[handler-row handler]` is a fn-component vector — the walker must
+  invoke `handler-row` to get the inner hiccup and then keep
+  descending. tree-seq alone only walks the structural children of
+  the original tree; without an `expand-fn-component` step in the
+  `children` lambda, deep testids inside fn-component vector bodies
+  (e.g. the `rf-causa-event-detail-tier-dot-*` span inside
+  `handler-row`) are unreachable."
   [tree]
-  (->> (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree))
-       (map expand-fn-component)))
+  (let [children (fn [node]
+                   (let [expanded (expand-fn-component node)]
+                     (when (or (vector? expanded) (seq? expanded))
+                       (seq expanded))))]
+    (->> (tree-seq (some-fn vector? seq?) children (expand-fn-component tree))
+         (map expand-fn-component))))
 
 (defn- find-by-testid
   "Find the first node in a hiccup tree whose attrs map has the given
@@ -375,3 +389,98 @@
             "no orphaned-state when the cascade is in the buffer")
         (is (zero? count*)
             "the suppressed-count is zero — nothing was dropped")))))
+
+;; ---- (6) handler-row perf-tier dot (rf2-6ja23) --------------------------
+;;
+;; The rf2-6ja23 audit hoists the perf-tier ladder into `theme/perf_tier.cljc`
+;; and wires the first cross-panel consumer: the handler row already
+;; surfaces `:duration-ms` (as raw EDN text); the audit adds a coloured
+;; dot + label so the eye picks up the tier the same way it does on the
+;; Performance panel.
+;;
+;; The tests below assert the dot renders for each tier's representative
+;; duration. The dot's testid carries the tier suffix
+;; (`rf-causa-event-detail-tier-dot-<tier>`) so the assertion is precise.
+
+(defn- cascade-evs-with-duration
+  "Variant of `cascade-evs` where the `:run-end` handler trace carries
+  a `:duration-ms` tag. The handler-row should render a perf-tier dot
+  matching `(classify-tier duration-ms)`."
+  [dispatch-id event-vec id-base duration-ms]
+  (mapv (fn [ev]
+          (if (= :run-end (get-in ev [:tags :phase]))
+            (assoc-in ev [:tags :duration-ms] duration-ms)
+            ev))
+        (cascade-evs dispatch-id event-vec id-base)))
+
+(deftest handler-row-renders-fast-tier-dot
+  (testing "handler :duration-ms 5ms classifies as :fast — green dot"
+    (seed-buffer! (cascade-evs-with-duration 300 [:counter/inc] 300 5))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 300])
+      (let [tree (event-detail/event-detail-view)]
+        (is (some? (find-by-testid tree "rf-causa-event-detail-tier-dot-fast"))
+            "fast-tier dot present alongside the :duration-ms text")
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-medium")))
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-slow")))
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-blocking")))))))
+
+(deftest handler-row-renders-medium-tier-dot
+  (testing "handler :duration-ms 30ms classifies as :medium — yellow dot"
+    (seed-buffer! (cascade-evs-with-duration 301 [:counter/inc] 310 30))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 301])
+      (let [tree (event-detail/event-detail-view)]
+        (is (some? (find-by-testid tree "rf-causa-event-detail-tier-dot-medium"))
+            "medium-tier dot present")
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-fast")))))))
+
+(deftest handler-row-renders-slow-tier-dot
+  (testing "handler :duration-ms 75ms classifies as :slow — orange triangle"
+    (seed-buffer! (cascade-evs-with-duration 302 [:counter/inc] 320 75))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 302])
+      (let [tree (event-detail/event-detail-view)]
+        (is (some? (find-by-testid tree "rf-causa-event-detail-tier-dot-slow"))
+            "slow-tier dot present")
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-fast")))
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-medium")))))))
+
+(deftest handler-row-renders-blocking-tier-dot
+  (testing "handler :duration-ms 250ms classifies as :blocking — red triangle"
+    (seed-buffer! (cascade-evs-with-duration 303 [:counter/inc] 330 250))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 303])
+      (let [tree (event-detail/event-detail-view)]
+        (is (some? (find-by-testid tree "rf-causa-event-detail-tier-dot-blocking"))
+            "blocking-tier dot present")
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-slow")))))))
+
+(deftest handler-row-omits-tier-dot-when-duration-ms-absent
+  (testing "without :duration-ms on the :run-end emit, no tier-dot
+            renders — the audit only wires the dot to nodes that
+            carry a measurable duration"
+    ;; The baseline `cascade-evs` builder leaves :duration-ms unset.
+    (seed-buffer! (cascade-evs 304 [:counter/inc] 340))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 304])
+      (let [tree (event-detail/event-detail-view)]
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-fast"))
+            "no tier-dot when :duration-ms is absent")
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-medium")))
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-slow")))
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-blocking")))))))
+
+(deftest handler-row-omits-tier-dot-when-duration-ms-is-non-numeric
+  (testing "a malformed :duration-ms tag (e.g. nil or a string) does
+            NOT render a tier-dot — the dot is gated on (number?
+            duration-ms) so the panel never surfaces a misleading
+            green dot for un-measurable nodes"
+    (seed-buffer! (cascade-evs-with-duration 305 [:counter/inc] 350 "not-a-number"))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 305])
+      (let [tree (event-detail/event-detail-view)]
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-fast")))
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-medium")))
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-slow")))
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-blocking")))))))

--- a/tools/causa/test/day8/re_frame2_causa/theme/perf_tier_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/theme/perf_tier_cljs_test.cljc
@@ -1,0 +1,135 @@
+(ns day8.re-frame2-causa.theme.perf-tier-cljs-test
+  "Pure-data tests for the shared perf-tier ladder (rf2-6ja23).
+
+  ## Why the `.cljc` + `_cljs_test` naming
+
+  Same dual-target pattern as `performance_helpers_cljs_test.cljc`:
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  ## What's under test
+
+  The ladder mirrors `spec/007-UX-IA.md` §Colour system §Perf scale:
+
+      :fast      <16ms       green   #4ADE80   ●
+      :medium    16-50ms     yellow  #FBBF24   ●
+      :slow      50-100ms    orange  #FB923C   ▲
+      :blocking  >=100ms     red     #F87171   ▲    INP threshold
+
+    1. `classify-tier` — boundaries 16ms / 50ms / 100ms (right-open at
+       the lower edge); nil / negative / non-numeric → :fast.
+    2. `tier-colour` / `tier-glyph` / `tier-label` — stable mappings,
+       fallbacks present.
+    3. `over-budget?` — at-or-above threshold semantics, nil guards.
+    4. `default-budget-ms` / `tier-order` — stable structural constants."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.theme.perf-tier :as perf-tier]))
+
+;; ---- (1) classification boundaries --------------------------------------
+
+(deftest classify-tier-spec-boundaries
+  (testing "fast < 16ms"
+    (is (= :fast (perf-tier/classify-tier 0)))
+    (is (= :fast (perf-tier/classify-tier 1)))
+    (is (= :fast (perf-tier/classify-tier 15)))
+    (is (= :fast (perf-tier/classify-tier 15.999))))
+  (testing "medium = [16, 50)"
+    (is (= :medium (perf-tier/classify-tier 16)))
+    (is (= :medium (perf-tier/classify-tier 30)))
+    (is (= :medium (perf-tier/classify-tier 49.999))))
+  (testing "slow = [50, 100)"
+    (is (= :slow (perf-tier/classify-tier 50)))
+    (is (= :slow (perf-tier/classify-tier 75)))
+    (is (= :slow (perf-tier/classify-tier 99.999))))
+  (testing "blocking >= 100"
+    (is (= :blocking (perf-tier/classify-tier 100)))
+    (is (= :blocking (perf-tier/classify-tier 500)))
+    (is (= :blocking (perf-tier/classify-tier 100000))))
+  (testing "nil / negative / non-numeric collapse to :fast"
+    (is (= :fast (perf-tier/classify-tier nil)))
+    (is (= :fast (perf-tier/classify-tier -5)))
+    (is (= :fast (perf-tier/classify-tier "not a number")))
+    (is (= :fast (perf-tier/classify-tier :keyword)))))
+
+;; ---- (2) colour + glyph + label -----------------------------------------
+
+(deftest tier-colour-mirrors-spec
+  (testing "perf-scale hex strings match tools/causa/spec/007-UX-IA.md §Colour system"
+    (is (= "#4ADE80" (perf-tier/tier-colour :fast)))      ; green
+    (is (= "#FBBF24" (perf-tier/tier-colour :medium)))    ; yellow
+    (is (= "#FB923C" (perf-tier/tier-colour :slow)))      ; orange
+    (is (= "#F87171" (perf-tier/tier-colour :blocking)))) ; red
+  (testing "unknown tier falls back to text-tertiary so the dot is
+            never invisible"
+    (is (= "#6B7080" (perf-tier/tier-colour :unknown)))
+    (is (= "#6B7080" (perf-tier/tier-colour nil)))))
+
+(deftest tier-glyph-pairs-shape-with-colour
+  (testing "Colour is never alone (spec/007-UX-IA.md §Colour is never alone)"
+    ;; Within-budget tiers — calm dot
+    (is (= "●" (perf-tier/tier-glyph :fast)))
+    (is (= "●" (perf-tier/tier-glyph :medium)))
+    ;; Over-budget tiers — attention triangle
+    (is (= "▲" (perf-tier/tier-glyph :slow)))
+    (is (= "▲" (perf-tier/tier-glyph :blocking))))
+  (testing "unknown tier falls back to the hollow-dot affordance"
+    (is (= "○" (perf-tier/tier-glyph :unknown)))
+    (is (= "○" (perf-tier/tier-glyph nil)))))
+
+(deftest tier-label-stable
+  (is (= "fast"     (perf-tier/tier-label :fast)))
+  (is (= "medium"   (perf-tier/tier-label :medium)))
+  (is (= "slow"     (perf-tier/tier-label :slow)))
+  (is (= "blocking" (perf-tier/tier-label :blocking)))
+  (testing "unknown tier still produces a printable label (str fallback)"
+    (is (= ":unknown" (perf-tier/tier-label :unknown)))
+    (is (= ""         (perf-tier/tier-label nil)))))
+
+(deftest tier-order-is-fastest-first
+  (is (= [:fast :medium :slow :blocking] perf-tier/tier-order)))
+
+;; ---- (3) over-budget? ----------------------------------------------------
+
+(deftest over-budget-honours-threshold
+  (testing "duration at or above budget is over-budget"
+    (is (true? (perf-tier/over-budget? 16 16)))
+    (is (true? (perf-tier/over-budget? 16 17)))
+    (is (true? (perf-tier/over-budget? 16 100))))
+  (testing "duration below budget is within-budget"
+    (is (false? (perf-tier/over-budget? 16 0)))
+    (is (false? (perf-tier/over-budget? 16 15.9))))
+  (testing "nil / non-number guards — both sides protected"
+    (is (false? (perf-tier/over-budget? nil 100)))
+    (is (false? (perf-tier/over-budget? 16 nil)))
+    (is (false? (perf-tier/over-budget? "16" 100)))
+    (is (false? (perf-tier/over-budget? 16 "100")))))
+
+;; ---- (4) defaults --------------------------------------------------------
+
+(deftest default-budget-is-one-frame-at-60fps
+  (testing "16ms — the one-frame-at-60fps target per spec/007 §Performance budget"
+    (is (= 16 perf-tier/default-budget-ms))))
+
+;; ---- (5) ladder consistency — colour ↔ glyph alignment -------------------
+
+(deftest within-budget-tiers-share-the-calm-dot
+  (testing "fast + medium share the calm-dot glyph — within-budget; the
+            colour carries the within-vs-warning signal"
+    (is (= (perf-tier/tier-glyph :fast) (perf-tier/tier-glyph :medium))))
+  (testing "slow + blocking share the attention triangle — over-budget"
+    (is (= (perf-tier/tier-glyph :slow) (perf-tier/tier-glyph :blocking)))))
+
+(deftest every-tier-has-a-colour-and-glyph
+  (testing "no nil drop-outs across the ladder — every tier resolves to
+            a printable swatch and shape"
+    (doseq [tier perf-tier/tier-order]
+      (is (string? (perf-tier/tier-colour tier))
+          (str "tier-colour returns a string for " tier))
+      (is (string? (perf-tier/tier-glyph tier))
+          (str "tier-glyph returns a string for " tier))
+      (is (string? (perf-tier/tier-label tier))
+          (str "tier-label returns a string for " tier)))))


### PR DESCRIPTION
## Summary

Per the rf2-6ja23 audit (causa ux — performance-tier colour-tag audit across panels):

- **Hoist the perf-tier ladder** from `panels/performance_helpers.cljc` into a new `day8.re-frame2-causa.theme.perf-tier` ns. The ladder (classify-tier / tier-colour / tier-glyph / tier-label / over-budget? / default-budget-ms / tier-order) is design-system grade — one source of truth, spec-anchored, JVM-portable — not panel-local.
- **performance_helpers.cljc re-exports** from the new ns so existing call-sites resolve unchanged. Zero behaviour change in the Performance panel.
- **Wire the first cross-panel consumer**: `event_detail` handler-row renders a perf-tier coloured dot + label when `:tags :duration-ms` is present. Gated on `(number? duration-ms)` so malformed tags never produce a misleading green dot. The raw `:duration-ms` stays in the EDN dump for power users.
- **Audit ledger in the new ns's docstring** names every panel surface that should carry the tier-dot, its status (LIVE / blocked on trace-stream / follow-on bead), and the structural prereq (per-event `:duration-ms` per Spec 009 L38) blocking the rest. Future panel-wiring beads land against the same ladder.

## Beads landed
- **rf2-6ja23** — perf-tier audit; ladder hoisted to `theme/`, event-detail handler-row tier-dot wired, audit ledger documented.

## Beads closed (already shipped)
- **rf2-mqm2d** — editor-protocol matrix extension for cursor/windsurf/zed shipped via #593; bead was still OPEN; closed.

## Beads deferred (with bd notes)
- **rf2-wm7z4** (Cmd-K command palette) — substantial new feature spanning every panel; warrants its own focused PR with palette infrastructure built first.
- **rf2-1o9cq** (v1.1 drop-in mode for non-re-frame2 apps) — already deferred to 2026-08-05; v1.1+ design-time decision.
- **rf2-3gn4f** (v1.1 opt-in localStorage conversation persistence) — already deferred to 2026-08-05; Lock 12 privacy-posture change requires Mike's call at v1.1 design time.
- **rf2-0us27** (v1.1 per-cascade structured export) — already deferred to 2026-08-05; Lock 4 serialisation/round-trip design question requires Mike's call at v1.1 design time.

## Test plan
- [x] `cd tools/causa && clojure -M:test` — 497 tests / 1423 assertions (was 488 / 1363), 0 failures
- [x] `cd implementation && npm run test:cljs` — 1837 tests, 0 failures
- [x] +9 theme.perf-tier ladder tests (boundaries, fallbacks, shape ↔ colour alignment)
- [x] +6 event-detail handler-row tier-dot tests (each tier + absent + non-numeric guards)
- [x] Test walker gains recursive descent through fn-component vectors so deep testids inside `[handler-row ...]` / `[domino-row ...]` bodies are reachable