### PR TITLE
refactor(reagent-slim): polish cluster — 12 follow-on beads (rf2-bgnin)

### DIFF
--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -1,86 +1,35 @@
 (ns re-frame.adapter.reagent-slim
-  "The day8/reagent-slim adapter — drop-in replacement for the bridge
-  adapter `re-frame.adapter.reagent` (rf2-6hyy).
+  "The day8/reagent-slim adapter — emits the 9-key substrate map for
+  `re-frame.substrate.adapter`. Drop-in shape-compatible with the
+  bridge adapter `re-frame.adapter.reagent`; internals route through
+  the `reagent2.*` rewrite of Reagent (no stock-Reagent dep).
 
-  Per IMPL-SPEC §2.1 + §9 + §13.1: this adapter Var emits the same
-  9-key map shape `re-frame.substrate.adapter` consumes; signatures
-  match the bridge's signatures byte-for-byte. Internals swap from
-  `(:require [reagent.core ...] [reagent.ratom ...] [reagent.dom.client ...])`
-  to the rewrite's `reagent2.*` namespaces.
+  Usage:
 
-  Why a separate ns rather than overwriting `re-frame.adapter.reagent`:
-  the in-tree shadow-cljs build adds both `adapters/reagent/src` and
-  `adapters/reagent-slim/src` to the classpath at the same time. Two
-  namespaces with the same name would clash. At artefact-publication
-  time (per the deps.edn :main and IMPL-SPEC §13.1) the slim artefact
-  ships its own `re-frame.adapter.reagent` — consumers depend on
-  exactly one of {day8/re-frame2-reagent, day8/reagent-slim} so the
-  ns is single-source per app. Until the artefact split is
-  consummated, this `-slim` suffix lets both coexist in the monorepo.
+      (require '[re-frame.adapter.reagent-slim :as reagent-slim])
+      (rf/init! reagent-slim/adapter)
 
-  Public surface (signatures unchanged from the bridge):
+  Public surface:
 
-    adapter           — the substrate spec map (9-key contract)
-    set-hiccup-emitter! — wires SSR's render-to-string into :render-to-string
+    adapter             — the 9-key substrate spec map
+    set-hiccup-emitter! — wires SSR's render-to-string (rf2-uo7v)
 
-  Late-bind hooks installed at ns-load time (all routed through
-  `(substrate-adapter/current-adapter)` per rf2-0d35 so the active
-  adapter's impl wins in test bundles that load multiple adapter ns's):
+  Detail lives in:
 
-    :reagent/set-hiccup-emitter!  — set-hiccup-emitter! (SSR seam, rf2-uo7v)
-    :adapter/current-frame        — re-frame.views/current-frame (rf2-d4sf)
-    :adapter/current-component    — reagent2.core/current-component (rf2-wbnl)
-    :adapter/ratom                — reagent2.core/atom            (rf2-s36l)
-    :adapter/ratom?               — reagent2.ratom/IReactiveAtom?  (rf2-s36l)
-    :adapter/make-reaction        — reagent2.ratom/make-reaction   (rf2-s36l)
-    :adapter/add-on-dispose!      — reagent2.ratom/add-on-dispose! (rf2-s36l)
-    :adapter/dispose!             — reagent2.ratom/dispose!        (rf2-s36l)
-    :adapter/reactive?            — reagent2.ratom/reactive?       (rf2-s36l)
-    :adapter/after-render         — reagent2.core/after-render     (rf2-s36l)
+    DESIGN-RATIONALE.md — the why (separate-ns rationale, slim vs
+                          bridge split, render-path mechanics)
+    IMPL-SPEC.md §2.1   — the 9-key map contract
+    IMPL-SPEC.md §9     — late-bind hook table + per-hook routing
+    IMPL-SPEC.md §13.1  — artefact-publication shape
 
-  Interop is fully late-bound: this ns does NOT statically `:require`
-  stock Reagent anywhere. `re-frame.interop` reads ratom / reaction /
-  disposable surfaces through the hook table (per rf2-s36l), so the
-  slim Maven artefact (`day8/reagent-slim`) can be published without
-  a stock-Reagent dep — downstream consumers depending on
-  `reagent-slim` alone gain the ~25 KB gz saving. The in-tree
-  shadow-cljs build still pulls all adapter trees; that's the
-  monorepo configuration, not a shape requirement.
+  Late-bind hooks installed at ns-load time route through
+  `(substrate-adapter/current-adapter)` so the active adapter's impl
+  wins when multiple adapter ns'es are loaded into the same bundle
+  (test fixtures, story builds). See the `route-hook!` calls at the
+  bottom of this file.
 
-  The Reagent-slim adapter targets the same React-context Provider /
-  `(.-context cmp)` shape the bridge uses (per IMPL-SPEC §9.6),
-  so the views.cljs wiring works unchanged.
-
-  Render path (rf2-08t0 / rf2-s36l / rf2-u5p5):
-    - `wrap-render` returns hiccup per IMPL-SPEC §5.1; the React
-      `render` method converts that hiccup to a React element via
-      `reagent2.impl.template/as-element`, registered into
-      `reagent2.impl.component/set-as-element-fn!` at template's
-      ns-load time. Without that conversion React would reject the
-      CLJS vector with 'Objects are not valid as a React child'.
-    - `make-render-method` mirrors stock Reagent's
-      `reagent.impl.component` render path: the first render creates
-      the per-component render Reaction with a custom auto-run that
-      queues a React re-render (no synchronous recompute); each
-      subsequent render calls `(._run rea false)` directly so
-      deref-capture rewires the watching graph AND the user's render
-      fn executes with the latest state. A plain `@rea` would return
-      the cached prior state because `_handle-change` with a
-      fn-valued auto-run doesn't set `dirty?`.
-
-  Status: drop-in functional swap for the bridge. The
-  counter-slim-and-fast Playwright smoke (rf2-5lbx) runs as part of
-  the default suite — was `skip:`-parked behind rf2-s36l / rf2-u5p5
-  and is GREEN as of those merges.
-
-  Pre-release status: until the bridge is retired (post-1.0), apps
-  that want the rewrite explicitly opt in by requiring this ns.
-
-  Per rf2-uo7v the SSR surface ships in `day8/re-frame2-ssr` —
-  this adapter MUST NOT statically `:require [re-frame.ssr]`. Instead
-  it publishes its `set-hiccup-emitter!` callback through the
-  late-bind hook table; if the SSR artefact is on the classpath, its
-  ns-load resolves the hook and wires the emitter."
+  Pre-release: until the bridge is retired (post-1.0), apps opt in
+  to the rewrite by requiring this ns."
   (:require [reagent2.core             :as r]
             [reagent2.ratom            :as ratom]
             [reagent2.dom.client       :as rdc]

--- a/implementation/adapters/reagent-slim/src/reagent2/core.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/core.cljs
@@ -132,18 +132,15 @@
 
 (defn force-update
   "Force re-render of `this` component. Routes through React's
-  `forceUpdate` directly — bypasses any pending dirty-set dedup."
-  ([^js this]
-   (when-some [fu (.-forceUpdate this)]
-     (.call fu this)))
-  ([^js this _deep?]
-   ;; The `:deep?` arg in stock Reagent triggered a global re-render of
-   ;; the descendant tree. Under React 19 this isn't supported the
-   ;; same way (forceUpdate is per-component); we ignore the flag and
-   ;; force-update just `this`. Per the audit, no production caller
-   ;; actually relied on the deep behaviour.
-   (when-some [fu (.-forceUpdate this)]
-     (.call fu this))))
+  `forceUpdate` directly — bypasses any pending dirty-set dedup.
+
+  The stock-Reagent 2-arity `(force-update this deep?)` is dropped:
+  React 19 has no per-call deep-rerender API, and no audited caller
+  relied on it. Callers passing a second arg will see a CLJS arity
+  error at the call site — fail-fast over silent semantic divergence."
+  [^js this]
+  (when-some [fu (.-forceUpdate this)]
+    (.call fu this)))
 
 ;; ---------------------------------------------------------------------------
 ;; Render-time surfaces

--- a/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
@@ -90,16 +90,15 @@
 ;; ---------------------------------------------------------------------------
 ;; Void tags + boolean attributes (HTML5)
 ;;
-;; Lifted from re-frame.ssr/void-elements (ssr.cljc:81-83). Per §8.4 +
-;; rf2-6phn: bundle isolation forbids `:require` of the SSR artefact, so
-;; duplicate the static set. HTML5's void-tag list is functionally
-;; frozen; the maintenance cost is zero.
+;; Void-tag set is `reagent2.impl.template/void-tags` — shared with the
+;; React-element path (both ship in the same artefact). Boolean-attr
+;; set stays local; HTML5's list is fixed (no maintenance burden) and
+;; SSR is the only consumer.
+;;
+;; Per §8.4 + rf2-6phn: bundle isolation forbids `:require` of the SSR
+;; artefact (re-frame.ssr lives in day8/re-frame2-ssr), so we don't
+;; share with that — only with the in-artefact template path.
 ;; ---------------------------------------------------------------------------
-
-(def ^:private void-tags
-  "HTML5 elements that self-close and have no closing tag."
-  #{"area" "base" "br" "col" "embed" "hr" "img" "input" "link"
-    "meta" "param" "source" "track" "wbr"})
 
 (def ^:private boolean-attrs
   "HTML5 boolean attributes (post-lowercase form): emit name only
@@ -301,7 +300,7 @@
         children-pos (if has-props 2 1)
         children     (when (< children-pos n)
                        (subvec argv children-pos))
-        void?        (contains? void-tags tag-str)
+        void?        (contains? template/void-tags tag-str)
         dangerous    (when (map? user-attrs)
                        (:dangerouslySetInnerHTML user-attrs))]
     (.append sb "<")

--- a/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
@@ -292,12 +292,10 @@
   (let [head      (nth argv 0 nil)
         parsed    (template/parse-tag head)
         tag-str   (.-tag parsed)
-        n         (count argv)
-        first-arg (when (>= n 2) (nth argv 1 nil))
-        has-props (and (>= n 2) (or (nil? first-arg) (map? first-arg)))
+        [first-arg has-props children-pos] (template/hiccup-shape argv 1)
         user-attrs (when (and has-props (some? first-arg)) first-arg)
         attrs      (merge-shorthand parsed user-attrs)
-        children-pos (if has-props 2 1)
+        n          (count argv)
         children     (when (< children-pos n)
                        (subvec argv children-pos))
         void?        (contains? template/void-tags tag-str)
@@ -330,9 +328,7 @@
   "Emit a `:<>` fragment — children only, no surrounding markup."
   [^StringBuffer sb argv]
   (let [n         (count argv)
-        head      (when (>= n 2) (nth argv 1 nil))
-        has-props (and (>= n 2) (or (nil? head) (map? head)))
-        children-pos (if has-props 2 1)]
+        [_head _has-props children-pos] (template/hiccup-shape argv 1)]
     (when (< children-pos n)
       (emit-children sb (subvec argv children-pos)))))
 

--- a/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
@@ -247,29 +247,20 @@
 ;; so the SSR walker sees the same parsed shape the React walker does.
 ;; ---------------------------------------------------------------------------
 
-(defn- class-string
-  "Coerce a class-attribute value (string, keyword, coll) to its
-  HTML-string form."
-  [c]
-  (cond
-    (nil? c)  nil
-    (coll? c) (->> c (keep named->str) (str/join " "))
-    :else     (named->str c)))
-
 (defn- merge-shorthand
   "Merge HiccupTag's id/class shorthand into the user-supplied attrs.
   User :id wins over shorthand id; shorthand class is prepended to
   user :class (matches stock Reagent's behaviour). Returns nil when
-  the result has no entries (suppresses the empty `attrs` doseq)."
+  the result has no entries (suppresses the empty `attrs` doseq).
+
+  Class merging uses `template/class-names` (the same coercion the
+  React-element path uses) — both artefacts ship in the same bundle,
+  so deduplicating avoids drift on the keyword/coll/string handling."
   [parsed user-attrs]
   (let [id      (.-id parsed)
         s-class (.-className parsed)
         u-class-raw (or (:class user-attrs) (:className user-attrs))
-        u-class (class-string u-class-raw)
-        merged  (cond
-                  (and s-class u-class) (str s-class " " u-class)
-                  s-class                s-class
-                  :else                  u-class)
+        merged  (template/class-names s-class u-class-raw)
         base    (cond-> (or user-attrs {})
                   ;; Drop :className duplicate; we collapse into :class.
                   (contains? user-attrs :className) (dissoc :className))

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -49,32 +49,17 @@
             ["react" :as react]))
 
 ;; ---------------------------------------------------------------------------
-;; Hiccup → React element seam (rf2-08t0 / rf2-s36l Stage 4-E follow-up)
+;; Hiccup → React element seam
 ;;
-;; Per IMPL-SPEC §5.1 `wrap-render` returns raw hiccup. The class's
-;; React render() method MUST return a React element (or a primitive
-;; React renders directly) — returning a CLJS vector to React triggers
-;; the "Objects are not valid as a React child" error against the
-;; vector's first slot (which, for a `reg-view`-wrapped fn, is a
-;; MetaFn). The conversion lives in `reagent2.impl.template/as-element`
-;; — but that ns already requires this ns (for `fn-to-class`,
-;; `reagent-class?`, etc.), so we can't statically require template
-;; here without inducing a cycle.
-;;
-;; Same pattern as `re-frame.late-bind` (`implementation/core/src/
-;; re_frame/late_bind.cljc`): a defonce-d atom holds the hiccup → React
-;; element fn; `reagent2.impl.template` registers `as-element` at ns-
-;; load time via `set-as-element-fn!`. `make-render-method`'s return
-;; runs the deref through the registered fn; before the fn is
-;; registered (very early load order, or a hand-rolled test bundle
-;; that loads component without template) the raw hiccup falls through
-;; unchanged, matching the pre-fix shape.
+;; `wrap-render` returns raw hiccup (per IMPL-SPEC §5.1); React's
+;; render() MUST return a React element. The conversion lives in
+;; `reagent2.impl.template/as-element` — that ns already requires this
+;; one, so we can't static :require template here without a cycle.
+;; Same pattern as `re-frame.late-bind`: template registers its
+;; `as-element` at ns-load via `set-as-element-fn!`.
 ;; ---------------------------------------------------------------------------
 
-(defonce ^:private as-element-fn
-  ;; Lazy hook: reagent2.impl.template's ns-load registers its
-  ;; `as-element` here. Nil before that runs.
-  (atom nil))
+(defonce ^:private as-element-fn (atom nil))
 
 (defn set-as-element-fn!
   "Register the hiccup → React-element conversion fn. Called by
@@ -376,12 +361,9 @@
               (this-as this
                 (bind-and-call this #(f this))))))
 
-    ;; componentWillUnmount: always installed (even when the user
-    ;; spec has no :component-will-unmount) so the per-instance render
-    ;; Reaction can dispose its watch graph. Without this, Reactions
-    ;; the component subscribed to retain references to the (now-
-    ;; unmounted) component and prevent GC. Per IMPL-SPEC §3.4 +
-    ;; Stage 4-D wiring.
+    ;; componentWillUnmount: always installed (even without
+    ;; :component-will-unmount) so the per-instance render Reaction
+    ;; can dispose its watch graph and unblock GC. Per IMPL-SPEC §3.4.
     (let [user-fn (:component-will-unmount spec)]
       (set! (.-componentWillUnmount proto)
             (fn []
@@ -394,10 +376,7 @@
 
     (when-let [f (:component-did-update spec)]
       ;; React calls componentDidUpdate(prevProps, prevState, snapshot).
-      ;; We pass the user fn `(this prev-argv snapshot)` per IMPL-SPEC
-      ;; §6.6: prev-argv is reconstructed from prevProps.__rfArgv,
-      ;; snapshot is the value getSnapshotBeforeUpdate returned (stored
-      ;; on the instance via React's contract — passed as third arg).
+      ;; User fn signature: (this prev-argv snapshot) per IMPL-SPEC §6.6.
       (set! (.-componentDidUpdate proto)
             (fn [prev-props _prev-state snapshot]
               (this-as this
@@ -405,11 +384,8 @@
                   #(f this (prev-argv-from prev-props) snapshot))))))
 
     (when-let [f (:get-snapshot-before-update spec)]
-      ;; React calls getSnapshotBeforeUpdate(prevProps, prevState) right
-      ;; before commit. The return value is then passed as the third
-      ;; arg to componentDidUpdate (React's contract). User fn signature
-      ;; is `(fn [this prev-argv] ...)`; the returned value is the
-      ;; snapshot.
+      ;; User fn: (this prev-argv) → snapshot; React then threads
+      ;; snapshot as the third arg to componentDidUpdate.
       (set! (.-getSnapshotBeforeUpdate proto)
             (fn [prev-props _prev-state]
               (this-as this
@@ -417,38 +393,19 @@
                   #(f this (prev-argv-from prev-props)))))))
 
     (when-let [f (:component-did-catch spec)]
-      ;; React's error-boundary contract: a class with componentDidCatch
-      ;; (and optionally getDerivedStateFromError) catches errors thrown
-      ;; during render / lifecycle of any descendant.
-      ;;
-      ;; Per IMPL-SPEC §6.4: the rewrite ships the logging half only —
-      ;; user fns receive `(this error info)`. Apps that want stateful
-      ;; error boundaries pair this with a state-atom flipped from
-      ;; inside the callback (the user fn re-renders the boundary by
-      ;; calling reset! on a (reagent2.core/atom) cell).
-      ;;
-      ;; React 19 also requires getDerivedStateFromError for the
-      ;; boundary to actually re-render with fallback state. The
-      ;; rewrite installs a default that flips a `:cljsHasError`
-      ;; instance flag — apps that want boundary-rendered fallback
-      ;; check that flag in their :reagent-render.
+      ;; Error-boundary logging half — user fn: (this error info).
+      ;; Per IMPL-SPEC §6.4. Stateful fallback is the user's
+      ;; responsibility (reset! a state-atom from inside the callback).
       (set! (.-componentDidCatch proto)
             (fn [error info]
               (this-as this
                 (bind-and-call this
                   #(f this error info))))))
 
-    ;; getDerivedStateFromError is React's static-class-method counterpart
-    ;; to componentDidCatch. When the user supplies :component-did-catch
-    ;; we install a default getDerivedStateFromError that returns a state
-    ;; patch flagging the error — a marker user :reagent-render code can
-    ;; check via component state. The marker is `{__rfErrored true}`.
-    ;; Without this, React 19 will re-throw the error past this boundary
-    ;; (treating it as if no boundary existed) per the React 19 contract:
-    ;; a boundary needs at least one of getDerivedStateFromError or
-    ;; componentDidCatch to actually catch — but only
-    ;; getDerivedStateFromError is allowed to return new state for a
-    ;; fallback render. Per IMPL-SPEC §6.5.
+    ;; getDerivedStateFromError: React-19 requires it (paired with
+    ;; componentDidCatch) for the boundary to catch at all. Default
+    ;; flips a :cljsHasError marker user :reagent-render can check.
+    ;; Per IMPL-SPEC §6.5.
     (when (:component-did-catch spec)
       (set! (.-getDerivedStateFromError klass)
             (fn [_error]
@@ -462,107 +419,44 @@
 ;; ---------------------------------------------------------------------------
 ;; React class construction (per IMPL-SPEC §6.3 + §4.4)
 ;;
-;; The class extends React.Component. The constructor stashes the
-;; initial argv (read from props.__rfArgv) on the instance; render
-;; delegates to wrap-render with the user's :reagent-render fn.
-;;
-;; Reactive subscription wiring (Stage 4-D, per IMPL-SPEC §4.4 path 1):
-;; the render method runs the user's render fn inside a Reaction so
-;; that any RAtom / Reaction deref'd during render registers as a
-;; dependency. When a dep changes, the Reaction recomputes (which we
-;; ignore) and the watch fires, enqueueing this React component for
-;; re-render via `batching/queue-render!`.
-;;
-;; Per IMPL-SPEC §4.4 path 1 + Stage 4-A handoff: without this wiring,
-;; views render once and never update on dep change. The Reaction is
-;; per-component and lives on the instance as `cljsRenderRea`.
+;; The class extends React.Component via prototype chain. The
+;; constructor stashes the initial argv on the instance; the render
+;; method delegates to wrap-render and runs inside a per-component
+;; Reaction (reactive-subscription wiring, IMPL-SPEC §4.4 path 1).
 ;; ---------------------------------------------------------------------------
 
 (defn- make-render-method
-  "Build the React `render` method. Wraps the user's render fn with:
+  "Build the React `render` method. Runs the user's render fn inside a
+  per-component Reaction so deref'd RAtoms / Reactions register as
+  dependencies; on dep change the auto-run queues a React re-render
+  via `batching/queue-render!`. The Reaction is created lazily on
+  first render and cached on the instance as `.-cljsRenderRea`.
 
-    1. Form-1/2 detection via `wrap-render`.
-    2. *current-component* binding for the duration of the render.
-    3. mark-rendered to clear the dirty flag for the next dep-change cycle.
-    4. Per-component Reaction wrapping the render so deref'd RAtoms /
-       Reactions register as dependencies; on dep change the Reaction
-       schedules re-render via batching/queue-render!. Per IMPL-SPEC
-       §4.4 path 1 + Stage 4-D wiring.
-
-  The Reaction is created lazily on first render and cached on the
-  instance as `.-cljsRenderRea`. It returns the rendered React element;
-  on subsequent dep-driven recomputes it queues a forceUpdate via the
-  auto-run callback, and React's commit re-enters this render method
-  which forces a fresh `._run` of the Reaction (rf2-u5p5).
-
-  The shape mirrors stock Reagent's `reagent.impl.component`: a custom
-  auto-run callback that queues a React re-render (does NOT synchronously
-  recompute), and an explicit `._run rea false` on every render entry
-  past the first so the user's render fn sees the latest state. The
-  built-in `_handle-change → auto-run` path does not mark `dirty?`, so
-  a plain `@rea` after a dep change would return the cached prior state.
-  The explicit `._run` re-captures dependencies AND produces the current
-  hiccup. Per IMPL-SPEC §4.4 path 1 + the same call shape stock Reagent
-  uses (`(._run rat false)` at line 289 of upstream
-  `reagent.impl.component`)."
+  Per IMPL-SPEC §4.4 path 1 + §5.1. See DESIGN-RATIONALE for the
+  `(._run rea false)`-on-subsequent-renders shape (custom auto-run
+  doesn't mark dirty? so a plain @rea would return the cached prior
+  state)."
   [render-fn]
   (fn []
     (this-as ^js this
       ;; Re-stash argv from current props on every render entry so
-      ;; Form-2's cached render-fn sees fresh args. React-19-stable
-      ;; equivalent of the deprecated componentWillReceiveProps: a
-      ;; static getDerivedStateFromProps cannot side-effect on the
-      ;; instance, so we do the copy here at render entry instead
-      ;; (cheap; no DOM reads).
+      ;; Form-2's cached render-fn sees fresh args. Static
+      ;; getDerivedStateFromProps cannot side-effect on the instance,
+      ;; so the copy happens here.
       (copy-argv-from-props! this (.-props this))
       (binding [*current-component* this]
         (batching/mark-rendered this)
         (let [^js rea (.-cljsRenderRea this)
-              ;; Per rf2-u5p5: first-render path creates the Reaction
-              ;; with a custom auto-run callback that queues a React
-              ;; re-render on dep change. On subsequent renders the
-              ;; Reaction already exists — call `._run` directly to
-              ;; force a fresh deref-capture of the user's render fn so
-              ;; the watching graph rewires AND the hiccup reflects the
-              ;; current state. Without the explicit `._run`, a plain
-              ;; `@rea` returns the cached prior `state` because
-              ;; `_handle-change` with a fn-valued auto-run doesn't set
-              ;; `dirty?` (matching stock Reagent's kernel, which uses
-              ;; this same shape via `run-in-reaction`).
               hiccup (if (nil? rea)
                        (let [^js r (ratom/make-reaction
                                      #(wrap-render this render-fn)
                                      :auto-run
-                                     ;; Custom auto-run: don't synchronously
-                                     ;; recompute on dep change; instead queue
-                                     ;; a re-render of this React component.
-                                     ;; React drives the next render via its
-                                     ;; reconciler; the Reaction recomputes
-                                     ;; inside that next render via the
-                                     ;; explicit `._run` call below.
                                      (fn [_r]
                                        (batching/queue-render! this)))]
                          (set! (.-cljsRenderRea this) r)
-                         ;; First render: dirty? is true; -deref will
-                         ;; recompute via `._run this false` and return
-                         ;; the freshly captured state.
                          @r)
-                       ;; Subsequent render: re-run the Reaction so the
-                       ;; user's render fn executes with the latest
-                       ;; subscribed state. `_run` calls `deref-capture`
-                       ;; which rewires the watching graph and updates
-                       ;; the cached state. Mirrors stock Reagent
-                       ;; `reagent.impl.component`'s render path.
+                       ;; ._run re-captures deps AND produces fresh hiccup.
                        (._run rea false))]
-          ;; Per rf2-08t0: `wrap-render` (per IMPL-SPEC §5.1) returns
-          ;; raw hiccup; React's render() method MUST return a React
-          ;; element. Run the deref'd hiccup through the registered
-          ;; `as-element` conversion. Stock Reagent does the equivalent
-          ;; in `reagent.impl.component/wrap-render` itself
-          ;; (`(p/as-element compiler res)` at line 93 of the upstream
-          ;; extract); we keep the IMPL-SPEC §5.1 shape (wrap-render
-          ;; returns hiccup) and move the conversion to the render-
-          ;; method boundary instead.
           (->react-element hiccup))))))
 
 (defn- copy-argv-from-props!
@@ -578,24 +472,12 @@
   "Build a React component class from a Form-3 spec map. Validates
   the spec against the 7-key cap (per IMPL-SPEC §6.1) — any
   out-of-cap key throws `:rf.error/create-class-key-unsupported` at
-  this call time (registration time, not render time).
+  registration time (fail-fast, not render-time).
 
-  The returned class:
-
-    - extends React.Component (React-19 ES-class shape).
-    - has a `render` method that delegates to `wrap-render` over
-      the spec's `:reagent-render` fn. Form-1/Form-2 detection runs
-      inside `wrap-render`.
-    - has the cap's lifecycle methods plumbed per IMPL-SPEC §6.4.
-    - has `:display-name` set as the static `displayName` field.
-    - is tagged `cljsReagentClass = true` so `reagent-class?` returns
-      true.
-
-  Implementation note: in CLJS we cannot `(class Foo extends ... {...})`,
-  so we synthesise the class via a constructor fn whose prototype
-  chains to React.Component. The `render` method goes on the prototype;
-  the `displayName` / `getDerivedStateFromError` go on the class
-  (constructor-side static)."
+  Returned class extends React.Component (synthesised via prototype
+  chain — CLJS can't `(class Foo extends ...)` directly), carries the
+  cap's lifecycle methods (IMPL-SPEC §6.4), and is tagged
+  `cljsReagentClass = true` for `reagent-class?`."
   [spec]
   (validate-spec! spec)
   (let [render-fn (or (:reagent-render spec)

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -84,13 +84,24 @@
 
 (defn- ->react-element
   "Convert wrap-render's hiccup output to a React element via the
-  registered `as-element` fn. Pass-through when no fn is registered
-  (preserves the pre-rf2-08t0 shape for early-load / test paths that
-  don't require template)."
+  registered `as-element` fn. Unregistered → throw
+  `:rf.error/as-element-fn-unregistered` — honest failure over silent
+  pass-through (the pre-rf2-08t0 shape that reached React with a raw
+  CLJS vector and surfaced as 'Objects are not valid as a React
+  child'). The unregistered fallback is reachable only via a
+  hand-rolled bundle that requires component without template;
+  production load via reagent2.core pulls both."
   [hiccup]
   (if-let [f @as-element-fn]
     (f hiccup)
-    hiccup))
+    (throw (ex-info ":rf.error/as-element-fn-unregistered"
+             {:type     :rf.error/as-element-fn-unregistered
+              :hiccup   hiccup
+              :reason   (str "reagent2.impl.template/as-element was not"
+                             " registered before render. Require"
+                             " reagent2.impl.template (or reagent2.core)"
+                             " so its ns-load wires the as-element seam.")
+              :recovery :no-recovery}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Dynamic var: in-flight component instance

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -383,14 +383,17 @@
 
 (declare as-element)
 
-(defn- void-tag? [tag-str]
-  ;; Per HTML5 (and rf2-6phn): void elements that cannot have children.
-  ;; React rejects children passed to these, so we don't emit them.
-  ;; The list is fixed in HTML5 — no maintenance burden.
-  (case tag-str
-    ("area" "base" "br" "col" "embed" "hr" "img" "input" "link"
-     "meta" "param" "source" "track" "wbr") true
-    false))
+(def void-tags
+  "HTML5 elements that self-close and have no closing tag. React rejects
+  children passed to these; the SSR walker emits bare `<br>` etc. and
+  skips the close tag. The list is fixed in HTML5 — no maintenance
+  burden. Shared between template (React) and server (HTML string)
+  paths to keep one source of truth across the artefact."
+  #{"area" "base" "br" "col" "embed" "hr" "img" "input" "link"
+    "meta" "param" "source" "track" "wbr"})
+
+(defn- ^boolean void-tag? [tag-str]
+  (contains? void-tags tag-str))
 
 (defn- make-element
   "Construct a React element via React.createElement.

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -419,12 +419,16 @@
                            (as-element (nth argv first-child nil)))
 
       :else
-      (let [args (reduce-kv (fn [^js a k v]
-                              (when (>= k first-child)
-                                (.push a (as-element v)))
-                              a)
-                            #js [component js-props]
-                            argv)]
+      ;; Loop from first-child rather than reduce-kv over the whole
+      ;; argv (which would test the predicate at every k=0..first-child-1
+      ;; before the children start). Hot-path at large children counts
+      ;; (1000-row tables, dynamic lists).
+      (let [args #js [component js-props]
+            n    (count argv)]
+        (loop [i first-child]
+          (when (< i n)
+            (.push args (as-element (nth argv i nil)))
+            (recur (inc i))))
         (.apply (.-createElement react) nil args)))))
 
 (defn expand-seq

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -435,19 +435,24 @@
   "Expand a sequence of hiccup forms (e.g. `(map ...)` children) to a
   JS array of React elements. Per IMPL-SPEC §7.4 — emits a one-shot
   dev warning per surrounding component when a child vector lacks a
-  `:key` meta or `:key` in its prop map."
+  `:key` meta or `:key` in its prop map.
+
+  Single-pass: the DEBUG key-check runs inline with the as-element
+  conversion (was two passes over the same lazy seq); production
+  builds (`goog.DEBUG=false`) DCE the inner branch."
   [s]
-  (let [arr (into-array (map as-element s))]
-    (when ^boolean js/goog.DEBUG
-      (loop [items s]
-        (when-let [el (first items)]
+  (let [arr #js []]
+    (loop [items s]
+      (when-let [el (first items)]
+        (when ^boolean js/goog.DEBUG
           (when (and (vector? el)
-                     (not (get-react-key el)))
-            (when (exists? js/console)
-              (.warn js/console
-                     (str "[reagent-slim] each child in a list should have a unique"
-                          " :key prop; saw " (pr-str el)))))
-          (recur (rest items)))))
+                     (not (get-react-key el))
+                     (exists? js/console))
+            (.warn js/console
+                   (str "[reagent-slim] each child in a list should have a unique"
+                        " :key prop; saw " (pr-str el)))))
+        (.push arr (as-element el))
+        (recur (rest items))))
     arr))
 
 (defn- ^boolean hiccup-tag? [x]

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -265,7 +265,18 @@
 ;; (matching stock Reagent: `[:div.foo {:class "bar"}]` → "foo bar").
 ;; ---------------------------------------------------------------------------
 
-(defn- class-names
+(defn class-names
+  "Coerce a class-attribute value to its space-joined string form.
+
+  Shapes accepted:
+    - 0-arity: nil.
+    - 1-arity: nil / keyword / symbol / string / coll-of-those.
+    - 2-arity: two values; joined with a space when both are non-nil.
+
+  Returns nil when the result is empty (suppresses redundant
+  `class=\"\"` emissions at call sites). Shared between the template
+  (React-element) and server (HTML-string) paths — both artefacts
+  ship in the same bundle, so a single helper avoids drift."
   ([] nil)
   ([class]
    (if (coll? class)

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -458,6 +458,30 @@
 (defn- ^boolean hiccup-tag? [x]
   (or (keyword? x) (symbol? x) (string? x)))
 
+;; ---------------------------------------------------------------------------
+;; Shared hiccup-shape detection
+;;
+;; Five sites (native-element, fragment-element, emit-dom-vector,
+;; emit-fragment, plus the make-element consumer) ask the same shape
+;; question: "is the slot at `first-pos` a props map, and where do
+;; children start?" One helper, one shape — drift-proof.
+;; ---------------------------------------------------------------------------
+
+(defn hiccup-shape
+  "Inspect `argv` starting at index `first-pos`. Returns a 3-element
+  vector `[head has-props? first-child]` where:
+
+    - `head` is `(nth argv first-pos nil)`.
+    - `has-props?` is true when `head` is nil or a map (the
+      props-map slot is the conventional Reagent shape).
+    - `first-child` is the argv index where children begin
+      (`first-pos + 1` if a props map is present, else `first-pos`)."
+  [argv first-pos]
+  (let [head      (nth argv first-pos nil)
+        has-props (or (nil? head) (map? head))
+        first-child (+ first-pos (if has-props 1 0))]
+    [head has-props first-child]))
+
 (defn- native-element
   "Emit a DOM element. `parsed` is the parsed HiccupTag; `argv` the
   full hiccup vector; `first-pos` the index of the first arg position
@@ -469,13 +493,10 @@
   prop-conversion so the attr name flows through cached-prop-name."
   [^HiccupTag parsed argv first-pos]
   (let [component (.-tag parsed)
-        ;; The position of the prop map (if any).
-        head      (nth argv first-pos nil)
-        has-props (or (nil? head) (map? head))
+        [head has-props first-child] (hiccup-shape argv first-pos)
         props     (cond-> (when has-props head)
                     *source-coord* merge-source-coord-attr)
-        js-props  (or (convert-props props parsed) #js {})
-        first-child (+ first-pos (if has-props 1 0))]
+        js-props  (or (convert-props props parsed) #js {})]
     (when-some [key (get-react-key argv)]
       (set! (.-key js-props) key))
     (make-element argv component js-props first-child)))
@@ -531,12 +552,10 @@
   `[:<> & children]` or `[:<> {:key k} & children]`. Props map (if
   present) is JS-converted; only `:key` is meaningful on Fragments."
   [argv]
-  (let [head      (nth argv 1 nil)
-        has-props (or (nil? head) (map? head))
+  (let [[head has-props first-child] (hiccup-shape argv 1)
         js-props  (or (when (and has-props (some? head))
                         (convert-prop-value head))
-                      #js {})
-        first-child (+ 1 (if has-props 1 0))]
+                      #js {})]
     (when-some [key (get-react-key argv)]
       (set! (.-key js-props) key))
     (make-element argv (.-Fragment react) js-props first-child)))

--- a/implementation/adapters/reagent-slim/test/reagent2/core_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/core_cljs_test.cljs
@@ -1,0 +1,55 @@
+(ns reagent2.core-cljs-test
+  "Unit tests for `reagent2.core` user-facing surface (Stage 4-D, rf2-6hyy).
+
+  Covers the surfaces that don't have dedicated test files:
+
+    - force-update — routes .forceUpdate on `this`; 1-arity only
+      (the stock-Reagent 2-arity `[this deep?]` was dropped per
+      rf2-okpsr — :deep? has no React 19 analogue and no audited
+      caller relied on it).
+
+  Other reagent2.core surfaces are exercised through their dedicated
+  per-impl tests (component / template / ratom / batching / dom-throw).
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [reagent2.core :as r]))
+
+;; ---------------------------------------------------------------------------
+;; force-update — 1-arity routes .forceUpdate on `this`
+;; ---------------------------------------------------------------------------
+
+(defn- fake-react-instance
+  "Build a minimal stand-in for a mounted React class instance. Tracks
+  .forceUpdate invocations on the `calls` atom."
+  [calls]
+  (let [c #js {}]
+    (set! (.-forceUpdate c)
+          (fn [] (swap! calls conj :force-update)))
+    c))
+
+(deftest force-update-1-arity-calls-forceupdate
+  (testing "(force-update this) invokes .forceUpdate on the instance"
+    (let [calls (atom [])
+          this  (fake-react-instance calls)]
+      (r/force-update this)
+      (is (= [:force-update] @calls)
+          ".forceUpdate fired exactly once"))))
+
+(deftest force-update-no-throw-when-forceupdate-missing
+  (testing "missing .forceUpdate is a silent no-op (defensive against
+            stand-in instances that don't carry the React method)"
+    (let [bare #js {}]
+      ;; No throw expected — the when-some guard skips the call.
+      (r/force-update bare)
+      (is true "did not throw"))))
+
+(deftest force-update-is-strictly-1-arity
+  (testing "force-update declares a single 1-arity body (rf2-okpsr —
+            the stock-Reagent 2-arity `[this deep?]` was dropped). The
+            metadata `:arglists` is the canonical contract surface."
+    (let [arglists (-> #'r/force-update meta :arglists)]
+      (is (= 1 (count arglists))
+          ":arglists declares exactly one signature")
+      (is (= '[^js this] (first arglists))
+          ":arglists is [this] only"))))

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/component_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/component_cljs_test.cljs
@@ -27,6 +27,7 @@
   `react-dom/client` exposes a usable root in the node test target."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [reagent2.impl.component :as component]
+            [reagent2.impl.template :as template]
             ["react" :as react]))
 
 ;; ---------------------------------------------------------------------------
@@ -618,3 +619,56 @@
           c         (fake-instance [render-fn 9])
           out       (component/wrap-render c render-fn)]
       (is (= [:p.coord {:class "live"} 9] out)))))
+
+;; ---------------------------------------------------------------------------
+;; as-element-fn unregistered → throw (rf2-lijel + rf2-n9nlk)
+;;
+;; The make-render-method seam runs hiccup through the registered
+;; `reagent2.impl.template/as-element` fn before handing the result to
+;; React. If the seam is unregistered (a hand-rolled test bundle that
+;; requires component without template), the slim adapter throws
+;; `:rf.error/as-element-fn-unregistered` — fail-fast over the silent
+;; pass-through that surfaced the React \"Objects are not valid as a
+;; React child\" error the rf2-08t0 fix was about.
+;;
+;; Production load order via reagent2.core pulls template; template's
+;; ns-load calls set-as-element-fn!. The test paths below temporarily
+;; null the seam via set-as-element-fn! and then restore it.
+;; ---------------------------------------------------------------------------
+
+(defn- with-unregistered-as-element-fn
+  "Run `f` with the as-element seam nulled out. Restores
+  `reagent2.impl.template/as-element` (the production registrant) on
+  exit so subsequent tests see the live seam."
+  [f]
+  (try
+    (component/set-as-element-fn! nil)
+    (f)
+    (finally
+      (component/set-as-element-fn! template/as-element))))
+
+(deftest as-element-fn-unregistered-render-throws
+  (testing "render method throws :rf.error/as-element-fn-unregistered
+            when the as-element seam is null (rf2-lijel)"
+    (with-unregistered-as-element-fn
+      (fn []
+        (let [^js klass (component/create-class*
+                          {:reagent-render (fn [_this] [:div "x"])
+                           :display-name   "UnregisteredTest"})
+              render    (proto-method klass "render")
+              ;; Build an instance shell the render method can run
+              ;; against. We don't drive React; we call render directly
+              ;; with a synthesised `this`.
+              instance  #js {:props #js {:__rfArgv [(fn [_t] [:div "x"])]}
+                             :cljsArgv [(fn [_t] [:div "x"])]
+                             :cljsRenderRea nil}
+              thrown    (try
+                          (.call render instance)
+                          nil
+                          (catch :default e (ex-data e)))]
+          (is (= :rf.error/as-element-fn-unregistered (:type thrown))
+              ":type identifies the unregistered seam class")
+          (is (= :no-recovery (:recovery thrown))
+              ":recovery is :no-recovery — there is no fallback path")
+          (is (string? (:reason thrown))
+              ":reason carries an actionable message"))))))

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
@@ -162,6 +162,80 @@
     (is (= "pointer" (template/convert-prop-value :pointer)))))
 
 ;; ---------------------------------------------------------------------------
+;; warn-once-keyword-prop! — one-shot DEBUG warning contract
+;;
+;; Per IMPL-SPEC §7.2 D2: a keyword value on a non-HTML-attribute prop
+;; passes through unchanged AND fires a one-shot console.warn keyed on
+;; [k name-of-v]. The cache lives in a private defonce'd atom; tests
+;; use fresh (k, v-name) pairs each assertion to remain robust against
+;; cache state from sibling tests. js/console.warn is redirected via
+;; set! to count invocations.
+;; ---------------------------------------------------------------------------
+
+(defn- with-warn-spy
+  "Run `f` with js/console.warn redirected to record invocations onto
+  `calls` (an atom holding a vector of arg strings). Restores the
+  original on exit."
+  [calls f]
+  (let [orig (.-warn js/console)]
+    (try
+      (set! (.-warn js/console)
+            (fn [& args] (swap! calls conj (apply str args))))
+      (f)
+      (finally
+        (set! (.-warn js/console) orig)))))
+
+(deftest warn-once-keyword-prop-fires-on-non-html-attr
+  (testing "non-HTML prop name + keyword value triggers a console.warn
+            (the rf2-6hyy §7.2 D2 informational notice)"
+    (let [calls (atom [])]
+      (with-warn-spy calls
+        #(template/convert-prop-value :rf2-warn-test-k1 :rf2-v1))
+      (is (= 1 (count @calls))
+          "warn fired exactly once on first encounter")
+      (is (re-find #"keyword value" (first @calls))
+          "warn message names the offence shape")
+      (is (re-find #"rf2-warn-test-k1" (first @calls))
+          "warn message names the prop key")
+      (is (re-find #"rf2-v1" (first @calls))
+          "warn message names the keyword value"))))
+
+(deftest warn-once-keyword-prop-suppresses-repeat-same-pair
+  (testing "second call with same (k, v) does NOT re-warn — keyed on
+            [k name-of-v] so the cache deduplicates"
+    (let [calls (atom [])]
+      (with-warn-spy calls
+        (fn []
+          (template/convert-prop-value :rf2-warn-test-k2 :rf2-v2)
+          (template/convert-prop-value :rf2-warn-test-k2 :rf2-v2)
+          (template/convert-prop-value :rf2-warn-test-k2 :rf2-v2)))
+      (is (= 1 (count @calls))
+          "three calls with same pair: warn fired exactly once"))))
+
+(deftest warn-once-keyword-prop-fresh-pair-fires
+  (testing "different v under same k → fresh cache key → warn fires
+            (the cache discriminates on v-name as well as k)"
+    (let [calls (atom [])]
+      (with-warn-spy calls
+        (fn []
+          (template/convert-prop-value :rf2-warn-test-k3 :rf2-v3a)
+          (template/convert-prop-value :rf2-warn-test-k3 :rf2-v3b)))
+      (is (= 2 (count @calls))
+          "different v-name fired a separate warn"))))
+
+(deftest warn-once-keyword-prop-html-attr-no-warn
+  (testing "HTML-attribute prop name with keyword value stringifies
+            WITHOUT a warn — the warn fires only on the non-HTML path"
+    (let [calls (atom [])]
+      (with-warn-spy calls
+        (fn []
+          (template/convert-prop-value :class :rf2-warn-test-html)
+          (template/convert-prop-value :data-foo :rf2-warn-test-data)
+          (template/convert-prop-value :aria-label :rf2-warn-test-aria)))
+      (is (= 0 (count @calls))
+          "HTML-attribute paths stringified silently (no warn fired)"))))
+
+;; ---------------------------------------------------------------------------
 ;; as-element — primitive cases
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Batched-by-surface dispatch of the rf2-bgnin round-2 audit follow-ons for `implementation/adapters/reagent-slim`. 12 beads land as 12 atomic commits; all tests green.

### Beads landed

P1 (4):
- rf2-okpsr — drop `force-update` 2-arity (silent `:deep?` no-op)
- rf2-3j17y — test coverage for `force-update`
- rf2-vq6zz — dedup `class-names` (template) vs `class-string` (server)
- rf2-l22fv — fix `rf2-bgnin` spec citation (`008-Reactive-Substrate-Adapters.md` → `006-ReactiveSubstrate.md`)

P2 (8):
- rf2-as4iu — hoist void-tags set (template+server dedup)
- rf2-8lk3j — `make-element` multi-child path loops, not reduce-kv
- rf2-tg0o0 — `expand-seq` folds key-warning into single pass
- rf2-ffnwe — factor shared `hiccup-shape` detection helper (4 sites)
- rf2-lijel — `as-element-fn` unregistered → throw (not silent pass-through)
- rf2-n9nlk — test for `as-element-fn` unregistered throw
- rf2-au148 — trim provenance narration in `component.cljs` (-107 LoC)
- rf2-wpbv1 — slim `reagent_slim.cljs` ns docstring (-51 LoC)

### LoC delta

`+378 / -328` across 8 files (5 src + 3 test). Net `+50` (positive only because of new test coverage).

Per-file:
- `component.cljs`: 651 → 544 LoC (-107)
- `reagent_slim.cljs`: 234 → 183 LoC (-51)
- `template.cljs`: -15 line drift, plus +24 LoC for new shared helpers
- `server.cljs`: -15 LoC (class-string + void-tags duplication killed)
- 3 test files: +183 LoC of new coverage

## Test plan

- [x] `npm run test:cljs` — 1825 tests / 5119 assertions, 0 failures
- [x] `npm run test:browser` — 1825 tests / 5044 assertions, 0 failures (load-bearing for reagent-slim)
- [x] `clojure -M:test` in `adapters/reagent-slim/` — 11 tests / 12 assertions, 0 failures