### PR TITLE
refactor(http): tail polish — 5 follow-on beads from round-2 audit

### DIFF
--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -10,14 +10,23 @@
 
   - URL / query-string encoding: `url-encode`, `params->query`,
     `merge-params`.
-  - Request body encoding: `realise-body`, `encode-body` (handles
+  - Request body encoding: `encode-body` (handles
     `:request-content-type` :json / :form / :text / explicit string,
-    plus heuristics for raw Clojure colls).
+    plus heuristics for raw Clojure colls; the single thunk-realisation
+    site is inlined into `run-attempt!` per rf2-sz4n0).
   - `:accept` normalisation: `run-accept` (and the inline default).
-  - Failure shape: `failure-map`.
   - Reply addressing: `resolve-origin-event`, `build-reply-event`,
     `dispatch-reply-via-late-bind!`.
   - Backoff: `compute-backoff-ms`.
+
+  Per rf2-sz4n0 (round-2 http audit, findings 1.1, 1.2): two thin
+  one-liner helpers from the earlier split — `failure-map` (just
+  `(assoc tags :kind kind)`) and `realise-body` (just `(if (fn? body)
+  (body) body)`) — were inlined into their call sites. The earlier
+  shape required readers to trace into the helper to confirm it was a
+  plain `assoc` / `if`; the inline form reads as ordinary Clojure with
+  no behaviour loss. The third audit-flagged closure, `default-accept-
+  fn`, is folded into `run-accept` (see the docstring on `run-accept`).
 
   The response-side decode pipeline (`content-type-of`, `sniff-decoder`,
   `malli-decode`, `decode-response-body`) lives in `re-frame.http-
@@ -58,12 +67,6 @@
     url))
 
 ;; ---- body encoding --------------------------------------------------------
-
-(defn realise-body
-  "Per Spec 014 §Body encoding: if `:body` is a thunk, invoke it. Each
-  attempt re-invokes the thunk to obtain a fresh handle."
-  [body]
-  (if (fn? body) (body) body))
 
 (defn- form-encode-body
   "URL-encoded form body from a Clojure map."
@@ -114,14 +117,6 @@
     (if (and (>= status 200) (< status 300))
       {:ok decoded}
       {:failure {:kind :http-status :status status :body decoded}})))
-
-;; ---- failure shape --------------------------------------------------------
-
-(defn failure-map
-  "Build a failure map of the canonical shape per Spec 014 §Failure
-  categories: `{:kind <:rf.http/...> ...kind-tags...}`."
-  [kind tags]
-  (assoc tags :kind kind))
 
 ;; ---- reply addressing -----------------------------------------------------
 

--- a/implementation/http/src/re_frame/http_managed.cljc
+++ b/implementation/http/src/re_frame/http_managed.cljc
@@ -54,9 +54,13 @@
 
    - `re-frame.http-encoding`       — URL/query/body encoding, decode
                                       pipeline, `:accept` normalisation,
-                                      failure-map / build-reply-event /
+                                      build-reply-event /
                                       `dispatch-reply-via-late-bind!`,
-                                      backoff. All pure fns.
+                                      backoff. All pure fns. (The earlier
+                                      `failure-map` / `realise-body` /
+                                      `default-accept-fn` helpers were
+                                      inlined into their call sites per
+                                      rf2-sz4n0.)
    - `re-frame.http-registry`       — in-flight request + actor-id
                                       indexes, supersede semantics,
                                       `abort-on-actor-destroy` (rf2-wvkn),

--- a/implementation/http/src/re_frame/http_middleware.cljc
+++ b/implementation/http/src/re_frame/http_middleware.cljc
@@ -60,6 +60,11 @@
   order). Order is preserved across replace; first registration wins
   for position.
 
+  After `clear-http-interceptor` removes a slot, a subsequent
+  `reg-http-interceptor` of the same id is a fresh registration and
+  appends to the end of the chain — the prior position is forgotten on
+  clear (per Spec 014 §Chain order and frame scope, rf2-kg5nw).
+
   Throws `:rf.error/http-bad-interceptor` if the shape is invalid."
   [{:keys [frame id before] :as interceptor}]
   (when-not (valid-interceptor? interceptor)

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -105,20 +105,20 @@
      (let [data (when (.-data err) (ex-data err))]
        (cond
          (:rf.http/timeout? data)
-         (encoding/failure-map :rf.http/timeout
-                               {:elapsed-ms (:elapsed-ms data)
-                                :limit-ms   (:limit-ms data)})
+         {:kind       :rf.http/timeout
+          :elapsed-ms (:elapsed-ms data)
+          :limit-ms   (:limit-ms data)}
 
          (or (= "AbortError" (.-name err))
              (:rf.http/aborted? data))
-         (encoding/failure-map :rf.http/aborted
-                               {:request-id (:request-id data)
-                                :reason     (or (:reason data) :user)})
+         {:kind       :rf.http/aborted
+          :request-id (:request-id data)
+          :reason     (or (:reason data) :user)}
 
          :else
-         (encoding/failure-map :rf.http/transport
-                               {:message (or (.-message err) (str err))
-                                :cause   err})))))
+         {:kind    :rf.http/transport
+          :message (or (.-message err) (str err))
+          :cause   err}))))
 
 ;; ---- platform transport: JVM java.net.http.HttpClient ---------------------
 
@@ -191,14 +191,14 @@
        (cond
          (or (instance? java.net.http.HttpTimeoutException cause)
              (and msg (str/includes? (str/lower-case msg) "timed out")))
-         (encoding/failure-map :rf.http/timeout {:elapsed-ms nil :limit-ms nil :message msg})
+         {:kind :rf.http/timeout :elapsed-ms nil :limit-ms nil :message msg}
 
          (or (instance? java.util.concurrent.CancellationException cause)
              (and msg (str/includes? (str/lower-case msg) "abort")))
-         (encoding/failure-map :rf.http/aborted {:reason :user :message msg})
+         {:kind :rf.http/aborted :reason :user :message msg}
 
          :else
-         (encoding/failure-map :rf.http/transport {:message msg :cause cls})))))
+         {:kind :rf.http/transport :message msg :cause cls}))))
 
 ;; ---- per-row CLJS-only-key tracing on JVM ---------------------------------
 
@@ -254,10 +254,10 @@
     (dispatch-reply! (assoc ctx
                             :kind :failure
                             :reply-payload {:kind    :failure
-                                            :failure (encoding/failure-map :rf.http/accept-failure
-                                                                           {:detail     (:failure accepted)
-                                                                            :decoded    (:decoded ctx)
-                                                                            :request-id (:request-id ctx)})}))))
+                                            :failure {:kind       :rf.http/accept-failure
+                                                      :detail     (:failure accepted)
+                                                      :decoded    (:decoded ctx)
+                                                      :request-id (:request-id ctx)}}))))
 
 (defn- finalise-failure!
   "Final-failure dispatch (after retries exhausted or non-retriable).
@@ -363,19 +363,19 @@
     (cond
       (and (>= status 400) (< status 500))
       (maybe-retry! ctx
-                    (encoding/failure-map :rf.http/http-4xx
-                                          {:status      status
-                                           :status-text status-text
-                                           :body        body-text
-                                           :headers     headers}))
+                    {:kind        :rf.http/http-4xx
+                     :status      status
+                     :status-text status-text
+                     :body        body-text
+                     :headers     headers})
 
       (>= status 500)
       (maybe-retry! ctx
-                    (encoding/failure-map :rf.http/http-5xx
-                                          {:status      status
-                                           :status-text status-text
-                                           :body        body-text
-                                           :headers     headers}))
+                    {:kind        :rf.http/http-5xx
+                     :status      status
+                     :status-text status-text
+                     :body        body-text
+                     :headers     headers})
 
       ok?
       (try
@@ -393,11 +393,11 @@
           (let [d (ex-data e)]
             (maybe-retry!
               ctx
-              (encoding/failure-map :rf.http/decode-failure
-                                    {:body-text                  body-text
-                                     :cause                      #?(:clj (.getMessage ^Throwable e)
-                                                                    :cljs (.-message e))
-                                     :schema-validation-failure? (boolean (:malli-error? d))})))))
+              {:kind                       :rf.http/decode-failure
+               :body-text                  body-text
+               :cause                      #?(:clj (.getMessage ^Throwable e)
+                                              :cljs (.-message e))
+               :schema-validation-failure? (boolean (:malli-error? d))}))))
 
       :else
       ;; Non-2xx that didn't fall in 4xx/5xx (e.g., 1xx/3xx that the
@@ -405,11 +405,11 @@
       ;; the raw body-text.
       (finalise-failure!
         ctx
-        (encoding/failure-map :rf.http/http-4xx
-                              {:status      status
-                               :status-text status-text
-                               :body        body-text
-                               :headers     headers})))))
+        {:kind        :rf.http/http-4xx
+         :status      status
+         :status-text status-text
+         :body        body-text
+         :headers     headers}))))
 
 (defn run-attempt!
   "Issue one HTTP attempt, then dispatch reply or retry. Platform-specific
@@ -421,8 +421,11 @@
   (let [{:keys [request timeout-ms request-id actor-id abort-signal]} ctx
         method   (or (:method request) :get)
         url      (encoding/merge-params (:url request) (:params request))
-        [enc-body ct] (encoding/encode-body (encoding/realise-body (:body request))
-                                            (:request-content-type request))
+        ;; rf2-sz4n0 — `:body` may be a thunk (Spec 014 §Body encoding); each
+        ;; attempt re-invokes it to obtain a fresh handle. Single call site,
+        ;; inlined per the audit.
+        body     (let [b (:body request)] (if (fn? b) (b) b))
+        [enc-body ct] (encoding/encode-body body (:request-content-type request))
         headers  (cond-> (or (:headers request) {})
                    (and ct (nil? (decode/content-type-of (:headers request))))
                    (assoc "Content-Type" ct))
@@ -445,18 +448,18 @@
                                        (.abort internal-controller (clj->js reason)))
                                      (finalise-failure!
                                        ctx-no-handle
-                                       (encoding/failure-map :rf.http/aborted
-                                                             {:request-id request-id
-                                                              :reason     reason
-                                                              :actor-id   actor-id}))
+                                       {:kind       :rf.http/aborted
+                                        :request-id request-id
+                                        :reason     reason
+                                        :actor-id   actor-id})
                                      (catch :default _ nil))
                                    :clj
                                    (finalise-failure!
                                      ctx-no-handle
-                                     (encoding/failure-map :rf.http/aborted
-                                                           {:request-id request-id
-                                                            :reason     reason
-                                                            :actor-id   actor-id}))))
+                                     {:kind       :rf.http/aborted
+                                      :request-id request-id
+                                      :reason     reason
+                                      :actor-id   actor-id})))
                     :url url
                     ;; rf2-bma05 — propagate the :sensitive? flag onto
                     ;; the in-flight handle so the actor-destroy abort

--- a/implementation/http/test/re_frame/http_interceptors_test.clj
+++ b/implementation/http/test/re_frame/http_interceptors_test.clj
@@ -346,6 +346,83 @@
             "replaced :a's :before fired in :a's original position; no duplicate")
         (finally (stop-server! srv))))))
 
+;; ---- 6b. clear-then-reg lands at the end of the chain (rf2-kg5nw) --------
+;;
+;; Round-2 audit finding 5.5: re-registering an id replaces in place
+;; (test 6 above), but `clear-http-interceptor` followed by a fresh
+;; `reg-http-interceptor` of the same id has different semantics — the
+;; slot was *removed* by clear, so re-registering appends to the end.
+;; Spec 014 §Chain order covers replace-in-place but the clear+re-reg
+;; path was unpinned. Per the spec clarification landed in this bead,
+;; clear-then-reg lands at the end (the slot's prior index is forgotten
+;; on clear). Test pins that contract; a regression that started
+;; preserving position across clear would break the documented behaviour
+;; and surprise hot-reload tools that DO want a fresh end-of-chain slot.
+
+(deftest clear-then-reg-appends-to-end-of-chain
+  (testing "rf2-kg5nw — clear-http-interceptor followed by re-reg of the same
+            id appends to the end of the chain (the prior position is
+            forgotten on clear). Spec 014 §Chain order and frame scope."
+    (let [order (atom [])
+          {:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (write-response! ex 200 "application/json" "{}")))]
+      (try
+        ;; Register three interceptors in order: :a, :b, :c.
+        (rf/reg-http-interceptor
+          {:id :a :before (fn [ctx] (swap! order conj :a) ctx)})
+        (rf/reg-http-interceptor
+          {:id :b :before (fn [ctx] (swap! order conj :b) ctx)})
+        (rf/reg-http-interceptor
+          {:id :c :before (fn [ctx] (swap! order conj :c) ctx)})
+
+        ;; Clear :a — slot is removed entirely.
+        (rf/clear-http-interceptor :a)
+        ;; Re-register :a. Per the contract this is a FRESH registration,
+        ;; not a position-preserving replace — it appends to the end.
+        (rf/reg-http-interceptor
+          {:id :a :before (fn [ctx] (swap! order conj :a-fresh) ctx)})
+
+        ;; Confirm the chain order in the registry directly so the test
+        ;; pins the slot ordering before the dispatch ever runs.
+        (let [chain (get @http-managed/interceptors :rf/default)]
+          (is (= [:b :c :a] (mapv :id chain))
+              "after clear-then-reg, :a moved to the end (was first; now last)"))
+
+        (rf/reg-event-fx :kg5nw/load
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url (str "http://127.0.0.1:" port "/x")}
+                    :decode     :json
+                    :on-success nil}]]}))
+        (rf/dispatch-sync [:kg5nw/load])
+        (Thread/sleep 200)
+        (is (= [:b :c :a-fresh] @order)
+            "interceptors fired in the post-clear-then-reg order: :b, :c, :a (re-registered)")
+        (finally (stop-server! srv))))))
+
+(deftest clear-then-reg-distinguishes-from-replace-in-place
+  (testing "rf2-kg5nw regression guard — bare `reg-http-interceptor` of an
+            existing id replaces in place (test 6, position preserved),
+            while clear-then-reg appends to the end. These are deliberately
+            different paths; the test asserts they do NOT collapse into one."
+    ;; Register in order :a, :b.
+    (rf/reg-http-interceptor {:id :a :before identity})
+    (rf/reg-http-interceptor {:id :b :before identity})
+    (is (= [:a :b] (mapv :id (get @http-managed/interceptors :rf/default))))
+
+    ;; Bare re-reg of :a — replaces in place; order unchanged.
+    (rf/reg-http-interceptor {:id :a :before (fn [c] c)})
+    (is (= [:a :b] (mapv :id (get @http-managed/interceptors :rf/default)))
+        "bare re-reg preserves position (Spec 014 §Chain order, replace-in-place)")
+
+    ;; Clear-then-reg of :a — appends to end; order changes.
+    (rf/clear-http-interceptor :a)
+    (rf/reg-http-interceptor {:id :a :before (fn [c] c)})
+    (is (= [:b :a] (mapv :id (get @http-managed/interceptors :rf/default)))
+        "clear-then-reg lands at the end (rf2-kg5nw contract)")))
+
 ;; ---- 7. invalid interceptor shape raises ---------------------------------
 
 (deftest invalid-interceptor-shape-raises

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -11,6 +11,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.registrar :as registrar]
@@ -527,6 +528,78 @@
       (let [db (await-reply! #(some? (:result %)) 2000)]
         (is (= :success (get-in db [:result :kind])))
         (is (= [:hello :world] (get-in db [:result :value])))))))
+
+;; ---- 11b. canned-stub fxs gate on interop/debug-enabled? (rf2-ga3pv) ------
+;;
+;; Round-2 audit finding 5.4: http_managed.cljc:154 gates the canned-stub
+;; fx registrations on `interop/debug-enabled?`. On CLJS+advanced+
+;; goog.DEBUG=false the entire (when ...) body DCEs — fx-id keyword
+;; string fragments, doc strings, and handler var references all elide.
+;; The CLJS elision contract is already pinned by sentinels in
+;; scripts/check-elision.cjs (lines 102-116) which grep the production
+;; bundle for `rf.http/managed-canned-success` /
+;; `rf.http/managed-canned-failure`.
+;;
+;; This JVM-side test pins the GATE BEHAVIOUR directly — the
+;; complementary assertion to the bundle grep. It flips
+;; `interop/debug-enabled?` to false, clears + reloads
+;; `re-frame.http-managed`, and asserts the canned-stub fxs are NOT
+;; registered while the production-eligible `:rf.http/managed` and
+;; `:rf.http/managed-abort` ARE registered. A regression that moved the
+;; canned stubs outside the gate (or registered an additional dev-only
+;; fx without gating it) would fail here long before a CLJS bundle build
+;; could surface it.
+;;
+;; The fixture's `(require 're-frame.http-managed :reload)` restores
+;; the standard registrations between tests, so this test is hermetic.
+
+(deftest canned-stub-fxs-elide-when-debug-disabled
+  (testing "rf2-ga3pv — gate behaviour: under (binding [debug-enabled? false])
+            the canned-stub fx registrations do NOT happen. Production-
+            eligible :rf.http/managed and :rf.http/managed-abort still do."
+    (try
+      ;; Clear the registry so we're observing a fresh load.
+      (registrar/clear-all!)
+      ;; Flip the gate. interop/debug-enabled? is a plain `def`, so we
+      ;; alter-var-root to rebind for the duration of the namespace load.
+      (alter-var-root #'interop/debug-enabled? (constantly false))
+      ;; Force the http-managed ns body to re-evaluate so its load-time
+      ;; (when interop/debug-enabled? ...) gate reads the new value.
+      (require 're-frame.http-managed :reload)
+      ;; The two production-eligible fxs MUST be registered regardless of
+      ;; the gate — they are user-facing per Spec 014.
+      (is (some? (registrar/lookup :fx :rf.http/managed))
+          ":rf.http/managed is dev+prod — registered regardless of debug-enabled?")
+      (is (some? (registrar/lookup :fx :rf.http/managed-abort))
+          ":rf.http/managed-abort is dev+prod — registered regardless of debug-enabled?")
+      ;; The canned-stub fxs MUST NOT be registered when the gate is false
+      ;; — this is the load-bearing assertion for prod-bundle isolation.
+      (is (nil? (registrar/lookup :fx :rf.http/managed-canned-success))
+          ":rf.http/managed-canned-success MUST NOT be registered under debug-enabled? false")
+      (is (nil? (registrar/lookup :fx :rf.http/managed-canned-failure))
+          ":rf.http/managed-canned-failure MUST NOT be registered under debug-enabled? false")
+      (finally
+        ;; Restore the gate so the fixture's subsequent reload re-registers
+        ;; the canned stubs for the rest of the suite.
+        (alter-var-root #'interop/debug-enabled? (constantly true))
+        (require 're-frame.http-managed :reload)))))
+
+(deftest canned-stub-fxs-registered-under-debug-true
+  (testing "rf2-ga3pv companion — under debug-enabled? true (the default,
+            and the only value on JVM in production use) BOTH canned-stub
+            fxs are registered. This is the methodology check: the
+            negative assertion above would be vacuous if the gate-true
+            case didn't actually register the stubs."
+    ;; The standard fixture has just (require ...:reload)'d so debug-
+    ;; enabled? is true and the canned stubs are registered. Assert both
+    ;; are present so a refactor that mistakenly dropped a registration
+    ;; couldn't silently turn the elision assertion into a vacuous pass.
+    (is (true? interop/debug-enabled?)
+        "JVM baseline — debug-enabled? is true")
+    (is (some? (registrar/lookup :fx :rf.http/managed-canned-success))
+        ":rf.http/managed-canned-success registered under debug-enabled? true")
+    (is (some? (registrar/lookup :fx :rf.http/managed-canned-failure))
+        ":rf.http/managed-canned-failure registered under debug-enabled? true")))
 
 ;; ---- 12. decode reflection metadata ---------------------------------------
 

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -402,6 +402,54 @@
       (is (= :failure (get-in db [:reply :kind])))
       (is (= :rf.http/transport (get-in db [:reply :failure :kind]))))))
 
+;; ---- 8b. abort on unknown request-id is a silent no-op (rf2-kdwnq) -------
+;;
+;; Per http_handlers.cljc:113-125, `managed-abort-handler` resolves the
+;; abort-fn through the in-flight registry and fires it; a missing
+;; entry yields `nil` from `lookup-in-flight`, the `when-let` collapses,
+;; and the handler returns `nil` without dispatch / throw. The shape is
+;; correct (idempotent abort) but not asserted — a regression that
+;; throws here (e.g. someone changing `when-let` to `let`, or adding a
+;; precondition) would only surface as flake in apps that race
+;; abort-then-cleanup. Pin the no-op contract.
+
+(deftest jvm-managed-abort-unknown-request-id-is-silent-noop
+  (testing ":rf.http/managed-abort on a request-id never seen by the in-flight
+            registry completes without throwing and dispatches no reply
+            (no :on-failure, no trace error). Idempotent abort contract."
+    (let [reply-fired? (atom false)
+          traces       (atom [])
+          listener-id  ::kdwnq-trace]
+      (try
+        (trace/register-trace-cb! listener-id
+                                  (fn [ev] (swap! traces conj ev)))
+        ;; If a reply ever dispatches the test will catch it (silently
+        ;; ignored handler) — but the load-bearing assertion is that no
+        ;; throw escapes the abort fx.
+        (rf/reg-event-fx :kdwnq/abort-never-issued
+          (fn [_ _]
+            {:fx [[:rf.http/managed-abort :kdwnq/never-issued]]}))
+        (rf/reg-event-db :kdwnq/some-reply
+          (fn [db _]
+            (reset! reply-fired? true)
+            db))
+        ;; The call itself must not throw.
+        (is (nil? (rf/dispatch-sync [:kdwnq/abort-never-issued]))
+            "dispatch returns nil; abort handler is a silent no-op on unknown id")
+        ;; Idempotent — abort the same unknown id a second time.
+        (is (nil? (rf/dispatch-sync [:kdwnq/abort-never-issued]))
+            "second abort of the same unknown id is also a silent no-op")
+        ;; No reply ever fired (no :on-failure synthesised, no trace error).
+        (Thread/sleep 50)
+        (is (false? @reply-fired?)
+            "no reply event was dispatched — the registry knew nothing about the id")
+        (let [errors (filter #(= :error (:op-type %)) @traces)]
+          (is (empty? errors)
+              (str "no :rf.error/* trace fired for the abort no-op; saw: "
+                   (mapv :operation errors))))
+        (finally
+          (trace/remove-trace-cb! listener-id))))))
+
 ;; ---- 9. abort by request-id -----------------------------------------------
 
 (deftest jvm-abort-by-request-id

--- a/implementation/http/test/re_frame/http_privacy_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_test.clj
@@ -373,6 +373,84 @@
       ;; The orphan is not in the denylist and is preserved; api_key is redacted.
       (is (= "https://api.example.com/x?orphan&api_key=:rf/redacted" url)))))
 
+;; ---- 9b. redact-url-query-string — round-2 audit edge cases (rf2-e5h1b) --
+;;
+;; Hand-written split/walk parser territory: fragment-only URLs (no
+;; query), empty `?`-only query string, fragments alongside denylisted
+;; params, and sensitive-true with a fragment present. These cases are
+;; precisely where coverage matters most for a hand-rolled splitter.
+
+(deftest redact-url-fragment-only-no-query
+  (testing "URL with a fragment but no query string is returned unchanged"
+    (let [[url any?] (url/redact-url-query-string
+                       "https://api.example.com/x#section-3" false)]
+      (is (= "https://api.example.com/x#section-3" url))
+      (is (false? any?)))))
+
+(deftest redact-url-empty-query-string
+  (testing "URL with `?` but no params is returned unchanged"
+    (let [[url any?] (url/redact-url-query-string
+                       "https://api.example.com/x?" false)]
+      (is (= "https://api.example.com/x?" url))
+      (is (false? any?)))))
+
+(deftest redact-url-denylisted-param-with-fragment
+  (testing "denylisted param value redacted; fragment preserved verbatim"
+    (let [[url any?] (url/redact-url-query-string
+                       "https://api.example.com/x?api_key=SECRET#section-3" false)]
+      (is (= "https://api.example.com/x?api_key=:rf/redacted#section-3" url))
+      (is (true? any?)))))
+
+(deftest redact-url-empty-value-denylisted-param
+  (testing "denylisted param with empty value still has value slot replaced"
+    (let [[url any?] (url/redact-url-query-string
+                       "https://api.example.com/x?api_key=&page=2" false)]
+      (is (= "https://api.example.com/x?api_key=:rf/redacted&page=2" url))
+      (is (true? any?)
+          "the denylisted param itself is the signal — flag still set even when value is empty"))))
+
+(deftest redact-url-sensitive-true-preserves-fragment
+  (testing "sensitive? true redacts ALL params and still preserves the fragment"
+    (let [[url _] (url/redact-url-query-string
+                    "https://api.example.com/x?user_id=42&page=2#section-3" true)]
+      (is (= "https://api.example.com/x?user_id=:rf/redacted&page=:rf/redacted#section-3" url)))))
+
+(deftest redact-url-fragment-containing-equals-and-ampersand
+  (testing "characters inside a fragment that look like query separators are not parsed"
+    ;; The fragment is verbatim everything after the first `#` — even if it
+    ;; contains `=` or `&` that would look like query syntax. The splitter
+    ;; uses index-of `#`, not regex; this asserts the round-trip is clean.
+    (let [[url _] (url/redact-url-query-string
+                    "https://api.example.com/x?token=abc#k=v&also=x" false)]
+      (is (= "https://api.example.com/x?token=:rf/redacted#k=v&also=x" url)))))
+
+;; ---- 9c. redact-url convenience wrapper (rf2-e5h1b) ----------------------
+;;
+;; `redact-url` is the single-value form used inside generic tag walkers
+;; (`redact-url-in`) that don't need the any-redacted? flag. Pin the
+;; wrapper's shape so a refactor that swaps the underlying impl doesn't
+;; silently change the caller's reading.
+
+(deftest redact-url-wrapper-returns-string
+  (testing "redact-url returns only the redacted URL string (not the [url flag] tuple)"
+    (is (= "https://api.example.com/x?api_key=:rf/redacted&page=2"
+           (url/redact-url
+             "https://api.example.com/x?api_key=SECRET&page=2" false))
+        "denylist hit — value redacted")
+    (is (= "https://api.example.com/x?page=2"
+           (url/redact-url
+             "https://api.example.com/x?page=2" false))
+        "no denylist hit — unchanged")
+    (is (= "https://api.example.com/x?user_id=:rf/redacted&page=:rf/redacted"
+           (url/redact-url
+             "https://api.example.com/x?user_id=42&page=2" true))
+        "sensitive? true — all params redacted")
+    (is (nil? (url/redact-url nil false))
+        "nil input passes through")
+    (is (= "https://api.example.com/x#frag"
+           (url/redact-url "https://api.example.com/x#frag" false))
+        "fragment-only URL passes through")))
+
 ;; ---- 10. redact-request-tags integrates URL redaction --------------------
 
 (deftest redact-request-tags-redacts-url-denylist-always

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -514,6 +514,7 @@ The fn returns the (possibly-modified) ctx. The runtime threads its `:request` o
 ### Chain order and frame scope
 
 - **Registration order.** The chain runs in the order `reg-http-interceptor` calls were made on that frame. Re-registering an existing id replaces the slot **in place** — the position is preserved.
+- **Clear-then-re-register.** `clear-http-interceptor` removes the slot entirely; a subsequent `reg-http-interceptor` of the same id is a fresh registration and **appends to the end** of the chain. The position is *not* preserved across a clear — the slot's prior index is forgotten on clear. Tools that want to mutate-in-place (e.g. hot-reload) should call `reg-http-interceptor` directly without clearing first; tools that want a fresh end-of-chain slot use clear-then-reg explicitly.
 - **Per-frame.** An interceptor registered against frame A does NOT fire for a request dispatched from frame B. Multi-frame apps register independent chains per frame; the auth interceptor on the user-app frame doesn't leak into a hypothetical admin-app frame.
 - **`:before`-only in v1.** Response-side transforms (the moral equivalent of an `:after`) are out of scope for v1 — sticking with the request-side keeps the contract small. The `:after` slot is reserved for future extension; an interceptor map carrying `:after` registers cleanly today (the runtime ignores the key) and will compose with v2's response-side hook when it lands.
 


### PR DESCRIPTION
## Summary

Round-2 http audit follow-ons (rf2-jklja). 5 beads, batched-by-surface inside `implementation/http/`. Hot-file sequencing — one commit per bead.

- **rf2-sz4n0** — inline `failure-map` and `realise-body` into call sites; the audit-flagged third closure `default-accept-fn` had already landed inside `run-accept`. 11 call sites simplified, helper indirection gone. Pure refactor.
- **rf2-e5h1b** — 8 new redact-url edge-case tests: fragment-only URL, empty `?`-only query, denylisted-param-with-fragment, empty-value with denylisted param, sensitive-true preserves fragment, fragment containing `=`/`&`, plus the `redact-url` convenience-wrapper shape. Hand-written split/walk parser territory.
- **rf2-kdwnq** — pins `:rf.http/managed-abort` on unknown id as a silent no-op (no throw, idempotent, no reply, no trace error). The `when-let` collapse was correct but unasserted.
- **rf2-kg5nw** — decides + pins the clear-then-reg http-interceptor position contract: clear-then-reg lands at the **end** (slot's prior position is forgotten on clear). Spec 014 §Chain order + `reg-http-interceptor` docstring updated; two tests pin the contract (one walks the post-clear chain, one is a regression guard separating bare replace-in-place from clear-then-reg).
- **rf2-ga3pv** — JVM-side gate-behaviour test for the canned-stub fxs. Flips `interop/debug-enabled?` to false via `alter-var-root`, reloads `re-frame.http-managed`, asserts the canned-stub fxs are absent and the production-eligible fxs are present. Complements the existing CLJS bundle-grep elision check in `scripts/check-elision.cjs`.

LoC delta: 8 files, +349 / -65 (net +284, mostly test additions).

## Test plan

- [x] `cd implementation/http && clojure -M:test` — 148 tests / 416 assertions, 0 failures (was 136/385 pre-bead).
- [x] `cd implementation && npm run test:cljs` — 1822 tests / 5131 assertions, 0 failures.
- [x] `cd implementation && npm run test:bundle-isolation` — PASS (http section: all sentinels OK; consumer allow-list 2 hits as expected).
- [x] `cd implementation && npm run test:elision` — PASS (all 30 dev-only sentinels absent in prod bundle, present in control).

## Exclusions

- rf2-r40km is decision-blocked (CORS direction) and was excluded from this dispatch per the plan.