### PR TITLE
refactor(spec): polish cluster — 4 follow-on beads

### DIFF
--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -277,7 +277,7 @@ The registration-shape accepted by `reg-flow`. Unlike the other kinds, `reg-flow
     ]])
 ```
 
-`:id`, `:inputs`, `:output`, `:path` are **required** at registration time; the base `:rf/registration-metadata` keys (`:doc`, `:spec`, `:ns`/`:line`/`:file`, `:tags`) compose additively. `reg-flow` rejects map shapes missing any required key with `:rf.error/flow-shape-invalid` (per [013 §The registration shape](013-Flows.md)).
+`:id`, `:inputs`, `:output`, `:path` are **required** at registration time; the base `:rf/registration-metadata` keys (`:doc`, `:spec`, `:ns`/`:line`/`:file`, `:tags`) compose additively. `reg-flow` rejects malformed maps with one of four distinct error keys — `:rf.error/flow-missing-id`, `:rf.error/flow-bad-inputs`, `:rf.error/flow-bad-output`, `:rf.error/flow-bad-path` — surfaced via [009 §Error contract](009-Instrumentation.md#error-contract); see also [013 §The registration shape](013-Flows.md).
 
 #### `:rf/app-schema-meta`
 

--- a/tools/machines-viz-mcp/spec/000-Vision.md
+++ b/tools/machines-viz-mcp/spec/000-Vision.md
@@ -1,0 +1,193 @@
+# 000-Vision: Machines-Viz MCP server
+
+Machines-Viz-MCP is the **agent face of Machines-Viz**. Where
+[`tools/machines-viz/`](../../machines-viz/) ships the
+`MachineChart` component plus a read-only viewer page for human
+debuggers and PR reviewers, this artefact ships an MCP server so
+AI agents (Claude Code, Cursor, Copilot, and any other host that
+speaks Model Context Protocol) can query the same registry —
+list registered machines, fetch a machine's transition table,
+encode a share-URL for a given machine + snapshot, render a
+chart to SVG or PNG — over stdio JSON-RPC, without opening a
+browser.
+
+This spec folder is the per-tool normative contract for
+`tools/machines-viz-mcp/`. It is a **load-bearing scaffold**
+stood up before implementation begins: the direction-setting
+calls (separate jar, MCP-over-stdio, share-URL encoding parity,
+read-only posture) are pinned here so consumers can plan against
+them. When implementation lands, this folder gets fleshed out
+with the four `tools/pair2-mcp/spec/`-shape files
+(`001-Wire-Protocol`, `002-nREPL-Transport`,
+`003-Tool-Catalogue`) parameterised for Machines-Viz.
+
+## Why a separate jar
+
+Machines-Viz-the-component is human-facing (React-flavoured CLJS
+embedded inside Causa, Story, or any host that wires it);
+Machines-Viz-MCP is agent-facing. They ship as distinct jars so
+the MCP server can be loaded without dragging the React /
+charting runtime into the agent's classpath; the two surfaces
+split:
+
+- **[`tools/machines-viz/`](../../machines-viz/)** —
+  `day8/re-frame2-machines-viz`. The `MachineChart` component +
+  read-only viewer page + share-URL encoder + PNG / SVG
+  exporters. Browser-side artefact.
+- **`tools/machines-viz-mcp/`** —
+  `day8/re-frame2-machines-viz-mcp`. The MCP server. Pulled by
+  `npm install`. Node-side artefact, attached over nREPL.
+
+Both consume the same re-frame2 instrumentation surface
+([Spec 009 trace bus](../../../spec/009-Instrumentation.md), the
+registrar query API for `:machine` definitions, machine snapshots
+at `[:rf/machines <id>]`) and the same share-URL encoding rules
+(per [`tools/machines-viz/spec/API.md`](../../machines-viz/spec/API.md)
+§Share-URL encoding). Neither depends on the other.
+
+The separation is the same shape `tools/causa/` /
+`tools/causa-mcp/` and `tools/story/` / `tools/story-mcp/` use: a
+human-facing rendering artefact and an agent-facing query surface
+ship as distinct jars so the agent jar can be loaded without the
+UI dependencies. Per the umbrella sketch in
+[`tools/README.md`](../../README.md) — "mirroring the causa /
+causa-mcp split."
+
+## What it is
+
+A Node-based stdio JSON-RPC server, written in ClojureScript,
+compiled via shadow-cljs to a single `.js` artefact. AI agents
+launch it as a subprocess; one persistent nREPL socket is held
+for the lifetime of the session; a small catalogue of
+machines-viz-shaped tools is exposed as MCP tools.
+
+The architecture mirrors [`tools/pair2-mcp/`](../../pair2-mcp/)
+and [`tools/causa-mcp/`](../../causa-mcp/) — the same baseline
+the agent triplet shares:
+
+- Same `@modelcontextprotocol/sdk` `StdioServerTransport`.
+- Same bencode-pinned nREPL bridge (per
+  [`tools/pair2-mcp/spec/002-nREPL-Transport.md`](../../pair2-mcp/spec/002-nREPL-Transport.md)).
+- Same port-discovery walk (`$SHADOW_CLJS_NREPL_PORT` → standard
+  shadow paths → `.nrepl-port`).
+- Same degraded-boot policy: tools return structured
+  `{:ok? false :reason ...}` errors rather than refusing to
+  start.
+- Same MCP verb-naming conformance (per
+  [`tools/mcp-conformance/NAMING.md`](../../mcp-conformance/NAMING.md)).
+
+Different tool catalogue. Different `:origin` tag
+(`:machines-viz-mcp`).
+
+## What it isn't
+
+- **Not** the component. The `MachineChart` React component lives
+  in [`tools/machines-viz/`](../../machines-viz/). The MCP
+  surface exposes the **data** the component would render plus
+  the **share-URL** an agent can paste into a PR description; it
+  does not render to the agent's session. Agents that want a
+  chart receive a share-URL (the user opens it) or an SVG / PNG
+  (a tool call returns the bytes).
+- **Not** an editor. Machines are authored in code via
+  `reg-machine`; this MCP queries what's already registered.
+  There is no `edit-machine` tool. Same posture
+  [`tools/machines-viz/spec/000-Vision.md`](../../machines-viz/spec/000-Vision.md)
+  §What it isn't takes for the component.
+- **Not** a session recorder. The share-URL encoding serialises
+  machine topology + a single current-state snapshot, **not** a
+  trace stream / epoch buffer / app-db slice. Per Causa
+  Lock #4 (session export forbidden), lifted into Machines-Viz
+  and inherited here.
+- **Not** a parallel registrar / dispatch / effect surface.
+  Machines-Viz-MCP is a downstream consumer of the framework's
+  instrumentation. If a query needs data the framework doesn't
+  emit, file a `bd` bead against
+  [`spec/009-Instrumentation.md`](../../../spec/009-Instrumentation.md) —
+  do not bolt a parallel surface onto this artefact.
+- **Not** part of any production bundle. The bundle-isolation
+  contract in [`tools/README.md`](../../README.md) holds:
+  nothing under `implementation/` may `:require` from
+  `tools/machines-viz-mcp/`.
+
+## Where it lives in the stack
+
+```
+              ┌────────────────────────────────┐
+              │  AI agent host                 │
+              │   (Claude Code, Cursor, …)     │
+              └────────────────┬───────────────┘
+                               │ stdio JSON-RPC
+                               ▼
+              ┌────────────────────────────────┐
+              │  tools/machines-viz-mcp/       │
+              │   • MCP tool dispatcher        │
+              │   • nREPL client (Node side)   │
+              │   • share-URL encoder shim     │
+              └────────────────┬───────────────┘
+                               │ nREPL
+                               ▼
+              ┌────────────────────────────────┐
+              │  Browser-side runtime          │
+              │   • reads registry             │
+              │   • reads [:rf/machines <id>]  │
+              │   • encodes share-URL (shared  │
+              │     codec from machines-viz)   │
+              └────────────────┬───────────────┘
+                               │
+                               ▼
+              ┌────────────────────────────────┐
+              │  implementation/machines + core│
+              │   • reg-machine + tables       │
+              │   • Spec 009 trace bus events  │
+              └────────────────────────────────┘
+```
+
+The arrow does not invert. Machines-Viz-MCP does not know about
+Causa-MCP or Story-MCP — it only knows the registrar query API
+and the machines-viz codec.
+
+## What the catalogue covers (sketch)
+
+The full catalogue lands in `003-Tool-Catalogue.md` when the
+implementation spec is fleshed out. The sketch — load-bearing for
+the separation decision and consumer planning, not the final
+shape:
+
+- **List / fetch.** Enumerate registered machines (across
+  frames); fetch one machine's transition table; fetch one
+  machine's current snapshot at `[:rf/machines <id>]`.
+- **Encode share-URL.** Wrap the canonical
+  `(machines-viz/encode-share-url chart-state)` (per
+  [`tools/machines-viz/spec/API.md`](../../machines-viz/spec/API.md)
+  §Share-URL encoding) so an agent can return a pasteable URL
+  to its caller.
+- **Export.** Return SVG or PNG bytes for a machine + snapshot
+  (calls the same exporters Machines-Viz ships; structured
+  content + `:size` band per
+  [`tools/mcp-base/`](../../mcp-base/) wire conventions).
+- **Subscribe (streaming).** Tail Spec 009
+  `:rf.machine/*` trace events for a given machine-id; mirrors
+  the streaming-band pattern from
+  [`tools/causa-mcp/spec/000-Vision.md`](../../causa-mcp/spec/000-Vision.md).
+- **Meta.** `discover-app` and `tail-build` parity with the
+  other servers (shared via `tools/mcp-base/`).
+
+## v1 vs. v1.1
+
+The v1 commitment matches the
+[`tools/machines-viz/spec/000-Vision.md`](../../machines-viz/spec/000-Vision.md)
+§v1.0 commitment: list + fetch + share-URL + export are the
+must-ship surfaces. Streaming subscribe and richer query shapes
+(transition-history bisection, parallel-region projection
+queries) are v1.1 candidates.
+
+## See also
+
+- [`tools/machines-viz/spec/000-Vision.md`](../../machines-viz/spec/000-Vision.md) — the component this MCP queries.
+- [`tools/causa-mcp/spec/000-Vision.md`](../../causa-mcp/spec/000-Vision.md) — sibling MCP surface; this artefact follows the same architecture template.
+- [`tools/pair2-mcp/spec/`](../../pair2-mcp/spec/) — the reference for the four-file `001 / 002 / 003 / API` shape this folder grows into when implementation lands.
+- [`tools/mcp-base/`](../../mcp-base/) — shared wire primitives.
+- [`tools/mcp-conformance/NAMING.md`](../../mcp-conformance/NAMING.md) — verb-naming conformance the catalogue must respect.
+- [`spec/005-StateMachines.md`](../../../spec/005-StateMachines.md) — the registry this MCP queries.
+- [`spec/009-Instrumentation.md`](../../../spec/009-Instrumentation.md) — the trace bus the streaming-subscribe tools tap.
+- [`tools/README.md`](../../README.md) — the umbrella that flagged this jar's existence pending the first cut.

--- a/tools/story/spec/000-Vision.md
+++ b/tools/story/spec/000-Vision.md
@@ -79,10 +79,12 @@ required by the
 - **A visual-regression service.** Story ships the `snapshot-identity`
   hook and emits stable iframes; pixel capture and diff happen
   downstream.
-- **A reimplementation of re-frame-10x.** Story embeds 10x's epoch
-  panel as a registered story panel (see
+- **A reimplementation of Causa.** Story embeds Causa's epoch
+  panel (Causa is the structural successor to re-frame-10x; see
+  [`tools/causa/spec/DESIGN-RATIONALE.md`](../../causa/spec/DESIGN-RATIONALE.md)
+  Lock #1) as a registered story panel (see
   [`003-Render-Shell.md`](003-Render-Shell.md) and
-  [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) §10x-embed). The two
+  [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) §causa-embed). The two
   artefacts share the epoch buffer.
 - **A statechart visualisation engine.** Story ships a one-line
   current-state indicator for active machines; full chart rendering
@@ -95,8 +97,8 @@ required by the
   code. See [`006-MCP-Surface.md`](006-MCP-Surface.md).
 - **A static-site generator.** Deferred to v2.
 - **A pixel-scrubbing UI.** BackstopJS-style before-after slider is
-  out of scope; the epoch scrubber inside 10x's embedded panel is the
-  equivalent in re-frame2's data-space.
+  out of scope; the epoch scrubber inside Causa's embedded panel is
+  the equivalent in re-frame2's data-space.
 
 ## Research lineage
 

--- a/tools/story/spec/003-Render-Shell.md
+++ b/tools/story/spec/003-Render-Shell.md
@@ -13,7 +13,7 @@ See [`007-Mode-Tabs.md`](007-Mode-Tabs.md) for the `:dev` / `:docs` /
 ## UI shell substrate
 
 Story's own UI shell (sidebar, control panel, trace ribbon, embedded
-10x panel, etc.) renders using **Reagent** at v1, sourced from
+Causa panel, etc.) renders using **Reagent** at v1, sourced from
 `implementation/adapters/reagent/`. The UI shell namespaces live under
 `tools.story.ui.*`.
 
@@ -201,7 +201,7 @@ tools/story/
 │           │   ├── variants_grid.cljs           ; :variants-grid layout
 │           │   ├── controls.cljs                ; auto-derived controls
 │           │   ├── multi_substrate.cljs         ; side-by-side substrate panes
-│           │   └── time_travel.cljs             ; epoch scrubber (10x embed adapter)
+│           │   └── time_travel.cljs             ; epoch scrubber (Causa embed adapter)
 │           ├── panels/
 │           │   ├── trace.cljs                   ; six-domino panel
 │           │   ├── a11y.cljs                    ; axe-core integration

--- a/tools/story/spec/004-Assertions.md
+++ b/tools/story/spec/004-Assertions.md
@@ -20,7 +20,7 @@ into `:assertions` (see below) rather than throwing.
 | `:rf.assert/dispatched?` | `[event-vec]` | Was this event dispatched against this frame? |
 | `:rf.assert/state-is` | `[machine-id state]` | Active state of `reg-machine` machine-id is state. |
 | `:rf.assert/no-warnings` | `[]` | No `:rf.warn/*` events seen during play. |
-| `:rf.assert/effect-emitted` | `[fx-id]` (optional `pred`) | Did the variant's drain emit fx-id? |
+| `:rf.assert/effect-emitted` | `[fx-id]` or `[fx-id pred]` | Did the variant's drain emit fx-id? See §`:rf.assert/effect-emitted` payload shape. |
 
 Each handler returns a map of the form:
 
@@ -55,6 +55,35 @@ result; the play-runner concatenates these into the variant's
 post-processes the `:assertions` list and translates failures into
 the host test framework's failure signal — `cljs.test`'s `is`,
 kaocha's reporter, etc.
+
+## `:rf.assert/effect-emitted` payload shape
+
+The only assertion whose payload carries an **optional second slot**.
+Both shapes are legal:
+
+- **`[fx-id]`** — the assertion **passes** iff `fx-id` was emitted at
+  least once during play (the variant's frame accumulates emitted
+  fx-ids into its per-frame `:emitted-fx` slot; see
+  [`002-Runtime.md`](002-Runtime.md) §`:rf.assert/effect-emitted`
+  under `force-fx-stub`).
+- **`[fx-id pred]`** — the assertion **passes** iff `fx-id` was
+  emitted **and** `(pred fx-id)` returns a truthy value. `pred` is a
+  unary fn whose single argument is the fx-id keyword that was
+  matched. Exceptions thrown by `pred` count as a `false` return; the
+  assertion records as failing rather than propagating.
+
+The optional `pred` slot is deliberately a unary fn over the fx-id
+keyword, not over the fx-args map. The play-runner's emitted-fx
+accumulator tracks **which fx-ids fired**, not the per-call fx-args
+payload — preserving arg-level granularity would require a parallel
+accumulator on the trace bus and was rejected as out of scope for v1
+(see [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) §record-not-throw
+for the same set-not-list trade-off the assertion family takes).
+
+Authors who need an argument-level assertion compose two checks: an
+`:rf.assert/effect-emitted` for the fx-id (set membership) plus an
+`:rf.assert/path-equals` against the slot in `app-db` the fx writes
+through.
 
 ## Play sequence execution
 

--- a/tools/story/spec/005-SOTA-Features.md
+++ b/tools/story/spec/005-SOTA-Features.md
@@ -1,7 +1,7 @@
 # Story — SOTA Features
 
 > The layout-debug overlay trio; a11y axe-core panel; per-variant QR
-> share; multi-substrate side-by-side rendering; the 10x epoch panel
+> share; multi-substrate side-by-side rendering; the Causa epoch panel
 > embed contract (stub); the v1.1 deferrals (perf ribbon, design
 > tokens); production elision under `:advanced` (`:rf.story/enabled?`
 > sentinel pattern). The contract Stage 6 implements + the production
@@ -82,29 +82,32 @@ Per Phase 2 §5.2 #6. Tiny implementation, high signal. Adds `qr-code`
 dep. Surfaces the share affordance: tap the QR on a phone, get the
 current variant URL with all cell-local overrides encoded.
 
-### 10x epoch panel embed (stub + contract)
+### Causa epoch panel embed (stub + contract)
 
-Story registers re-frame-10x's existing epoch panel as a story panel:
+Story registers Causa's existing epoch / time-travel panel as a story
+panel (Causa is the structural successor to re-frame-10x, per
+[`tools/causa/spec/DESIGN-RATIONALE.md`](../../causa/spec/DESIGN-RATIONALE.md)
+Lock #1):
 
 ```clojure
-(rf/reg-story-panel :rf.story/10x-epoch
-  {:doc       "re-frame-10x's epoch buffer for the active variant."
-   :title     "Epochs (10x)"
+(rf/reg-story-panel :rf.story/causa-epoch
+  {:doc       "Causa's epoch buffer for the active variant."
+   :title     "Epochs (Causa)"
    :placement :bottom
-   :render    :re-frame-10x.epoch-panel/view})
+   :render    :day8.re-frame2-causa.panels.time-travel/time-travel-view})
 ```
 
-The 10x epoch view is consumed from `day8/re-frame2-causa` (per the
+The view is consumed from `day8/re-frame2-causa` (per the
 `tools/causa/` alpha-phase line in
 [`tools/README.md`](../../README.md)). Story's panel is the
 **adapter**; Causa stays its own artefact, on its own release cadence.
 
-Story's `:rf.story/10x-epoch` registration ships with v1 but the panel
-only activates if `day8/re-frame2-causa` is on the classpath (per the
-late-bind hook in spec/002). If Causa is absent, the sidebar entry
-hides. The Causa artefact owns the actual view; Story owns the
+Story's `:rf.story/causa-epoch` registration ships with v1 but the
+panel only activates if `day8/re-frame2-causa` is on the classpath
+(per the late-bind hook in spec/002). If Causa is absent, the sidebar
+entry hides. The Causa artefact owns the actual view; Story owns the
 *integration*. See [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md)
-§10x-embed.
+§causa-embed.
 
 ### Test Codegen — record-as-`:play` (rf2-5fc15)
 
@@ -503,7 +506,7 @@ phase-2 SOTA adds that are cheap.
 | 5. Three-level args + auto-derived controls from Spec 010 schemas | Stages 2, 4 |
 | 6. MSW-shaped effect mocking via `force-fx-stub` decorator | Stage 2 |
 | 7. Six-domino trace panel per variant via `register-trace-cb!` | Stage 6 |
-| 8. re-frame-10x epoch panel embedded as `reg-story-panel` | Stage 6 |
+| 8. Causa epoch panel embedded as `reg-story-panel` | Stage 6 |
 | 9. Story portability — `run-variant` returns `{:frame :app-db :assertions :rendered-hiccup :elapsed-ms}` | Stage 3 |
 | 10. EDN-first variant artefact (no `:render` fn-slot, round-trippable) | Stage 2 |
 | 11. Inclusion tags (seven canonical + `!`-prefix removal) | Stage 2 |
@@ -513,7 +516,7 @@ phase-2 SOTA adds that are cheap.
 | `:variants-grid` workspace layout | Stage 4 |
 | Per-variant QR code in share menu | Stage 6 |
 | Multi-substrate side-by-side pane (substrate-failures inline) | Stage 6 |
-| 10x epoch panel embed (stub + contract) | Stage 6 |
+| Causa epoch panel embed (stub + contract) | Stage 6 |
 | Test Codegen — record canvas dispatches as `:play` (rf2-5fc15) | Stage 6 |
 
 ## v1.1 ship list (first follow-up)
@@ -538,7 +541,7 @@ phase-2 SOTA adds that are cheap.
 | Remote Storybook federation (multi-host composition) | Phase 1 §2.2 |
 | App-db snapshot diff (data-space visual regression) | Phase 2 §5.2 #7 |
 | oEmbed URLs for Notion / static-doc inlining | Phase 2 §5.2 #6 (deferred) |
-| BackstopJS-style pixel scrubber UI | Phase 2 §2.1 (out of scope; data-space scrubber via 10x suffices) |
+| BackstopJS-style pixel scrubber UI | Phase 2 §2.1 (out of scope; data-space scrubber via Causa suffices) |
 
 ## What we deliberately don't ship
 
@@ -558,7 +561,7 @@ list with reasoning; the short version:
 - **Statechart visualisation engine.** Deferred to
   `day8/re-frame2-machines-viz`.
 - **Pixel-scrubber UI (BackstopJS slider).** Data-space scrubber via
-  10x's epoch panel covers the same UX better.
+  Causa's epoch panel covers the same UX better.
 - **BackstopJS-style baseline storage.** Services handle baselines.
 - **First-party SSR rendering pipeline.** Owned by Spec 011 +
   `day8/re-frame2-ssr`.
@@ -566,5 +569,6 @@ list with reasoning; the short version:
   [`006-MCP-Surface.md`](006-MCP-Surface.md).
 - **Built-in pixel diff under `:test` tag.** Stories-as-tests are
   state-space tests, not pixel-space tests.
-- **Full re-frame-10x reimplementation.** Story embeds 10x's epoch
-  panel; does not own a parallel implementation.
+- **Full Causa reimplementation.** Story embeds Causa's epoch panel
+  (the structural successor to re-frame-10x); does not own a parallel
+  implementation.

--- a/tools/story/spec/006-MCP-Surface.md
+++ b/tools/story/spec/006-MCP-Surface.md
@@ -106,7 +106,7 @@ Summary as it pertains to the MCP surface:
    register from `install-canonical-vocabulary!`; third-party tooling
    (Causa's epoch view, future statechart-viz panels) registers from
    its own boot.
-5. **The 10x embed is the canonical late-bind example.** Stub view
+5. **The Causa embed is the canonical late-bind example.** Stub view
    ships with Story; Causa registers the live view under the same
    `:rf.story.panel/epoch-view` id when present; shell picks
    Causa's view automatically.

--- a/tools/story/spec/API.md
+++ b/tools/story/spec/API.md
@@ -111,7 +111,7 @@ into `:assertions` rather than throwing — see
 | `:rf.assert/dispatched?` | `[event-vec]` | Was this event dispatched against this frame? |
 | `:rf.assert/state-is` | `[machine-id state]` | Active state of `reg-machine` machine-id is state. |
 | `:rf.assert/no-warnings` | `[]` | No `:rf.warn/*` events seen during play. |
-| `:rf.assert/effect-emitted` | `[fx-id]` (optional `pred`) | Did the variant's drain emit fx-id? |
+| `:rf.assert/effect-emitted` | `[fx-id]` or `[fx-id pred]` | Did the variant's drain emit fx-id? `pred`, when present, is a unary fn `(pred fx-id) → truthy?` — see [`004-Assertions.md`](004-Assertions.md) §`:rf.assert/effect-emitted` payload shape. |
 
 ## Shell lifecycle
 

--- a/tools/story/spec/DESIGN-RATIONALE.md
+++ b/tools/story/spec/DESIGN-RATIONALE.md
@@ -149,36 +149,40 @@ registration call) and to `nil` in production. Compile-time flag is
 override to `false` for prod builds). See
 [`005-SOTA-Features.md`](005-SOTA-Features.md) §Production elision.
 
-### §10x-embed — embed via `reg-story-panel`
+### §causa-embed — embed via `reg-story-panel`
 
 **Decision.** Story does **not** reimplement an epoch UI. Story
-registers re-frame-10x's existing epoch panel as a story panel via:
+registers Causa's existing epoch / time-travel panel as a story panel
+via (Causa is the structural successor to re-frame-10x, per
+[`tools/causa/spec/DESIGN-RATIONALE.md`](../../causa/spec/DESIGN-RATIONALE.md)
+Lock #1):
 
 ```clojure
-(rf/reg-story-panel :rf.story/10x-epoch
-  {:doc       "re-frame-10x's epoch buffer for the active variant."
-   :title     "Epochs (10x)"
+(rf/reg-story-panel :rf.story/causa-epoch
+  {:doc       "Causa's epoch buffer for the active variant."
+   :title     "Epochs (Causa)"
    :placement :bottom
-   :render    :re-frame-10x.epoch-panel/view})
+   :render    :day8.re-frame2-causa.panels.time-travel/time-travel-view})
 ```
 
-The Causa epoch view is consumed from `day8/re-frame2-causa` (per the
-`tools/causa/` line in [`tools/README.md`](../../README.md)). Story's
-panel is the **adapter**; Causa stays its own artefact, on its own
-release cadence.
+The view is consumed from `day8/re-frame2-causa` (per the
+`tools/causa/` line in [`tools/README.md`](../../README.md)).
+Story's panel is the **adapter**; Causa stays its own artefact, on
+its own release cadence.
 
 **Rationale.** The epoch panel's UX (time-travel scrubber, app-db
-follower, event replay) is already best-in-class inside
-re-frame-10x. Reimplementing it inside Story would (a) double the
-implementation surface, (b) split the maintenance work, (c) drift
-over time. Embedding keeps one source of truth.
+follower, event replay) is already best-in-class inside Causa
+(carrying forward the design re-frame-10x established). Reimplementing
+it inside Story would (a) double the implementation surface, (b) split
+the maintenance work, (c) drift over time. Embedding keeps one source
+of truth.
 
-**Implication.** Story's `:rf.story/10x-epoch` registration ships
+**Implication.** Story's `:rf.story/causa-epoch` registration ships
 with v1 but the panel only activates if `day8/re-frame2-causa` is on
 the classpath (per the late-bind hook in spec/002). If Causa is
 absent, the sidebar entry hides. The Causa artefact owns the actual
 view; Story owns the *integration*. See
-[`005-SOTA-Features.md`](005-SOTA-Features.md) §10x epoch panel
+[`005-SOTA-Features.md`](005-SOTA-Features.md) §Causa epoch panel
 embed.
 
 ## Decisions surfaced during IMPL-SPEC drafting
@@ -244,12 +248,12 @@ Per Phase 2 §5.2 #5. Iff `re-com` or the host design system emits
 Style-Dictionary-shaped tokens. Stage 6 ships the panel; activation
 is conditional on token emission upstream.
 
-### §10x-embed-inert-without-causa — 10x embed registration ships in v1 but stays inert if 10x absent
+### §causa-embed-inert-without-causa — Causa embed registration ships in v1 but stays inert if Causa absent
 
-Per §10x-embed above. The `reg-story-panel` call is unconditional; the
-panel's `:render` resolves via late-bind to a hidden no-op if 10x
-isn't present. This keeps the user experience graceful when 10x isn't
-on the classpath.
+Per §causa-embed above. The `reg-story-panel` call is unconditional;
+the panel's `:render` resolves via late-bind to a hidden no-op if
+Causa isn't present. This keeps the user experience graceful when
+Causa isn't on the classpath.
 
 ## Phase-2 SOTA additions — tier choices
 
@@ -335,7 +339,7 @@ bundle weight of layout engines (`@xyflow/react`, `d3-hierarchy`,
 **Rejected.** BackstopJS's tactile pixel scrubber is a great UX for
 pixel visual regression.
 
-**Why.** Story's data-space scrubber via 10x's epoch panel covers
+**Why.** Story's data-space scrubber via Causa's epoch panel covers
 the same UX *better* for re-frame2 apps — scrub through events with
 `app-db` following, not through static pixels. Pixel scrubbing is a
 downstream visual-regression-service concern. Story does not host
@@ -376,13 +380,14 @@ on `:assertions` + `:app-db`. It does **not** capture or diff pixels.
 pixel-space tests. This is the
 [Spec 007 §Story-as-test-duality](../../../spec/007-Stories.md) lock.
 
-### Rejected: Full re-frame-10x reimplementation
+### Rejected: Full Causa reimplementation
 
-**Rejected (delegated).** Story embeds 10x's epoch panel; does not
-own a parallel implementation. See §10x-embed above.
+**Rejected (delegated).** Story embeds Causa's epoch panel (the
+structural successor to re-frame-10x); does not own a parallel
+implementation. See §causa-embed above.
 
-**Why.** 10x's UX is mature; replicating it would split maintenance
-and drift. The right primitive is "10x is a peer artefact, Story
+**Why.** Causa's UX is mature; replicating it would split maintenance
+and drift. The right primitive is "Causa is a peer artefact, Story
 integrates."
 
 ## Open items (deliberate punts)

--- a/tools/story/spec/Principles.md
+++ b/tools/story/spec/Principles.md
@@ -72,7 +72,7 @@ dispatch types, effect substrates, or component substrates.
 ## Reagent for the v1 UI shell
 
 The UI shell that Story renders (sidebar, canvas, controls, trace
-panel, embedded 10x panel) is built with Reagent at v1, sourced from
+panel, embedded Causa panel) is built with Reagent at v1, sourced from
 `implementation/adapters/reagent/`. Reasoning lives in
 [`003-Render-Shell.md`](003-Render-Shell.md) §UI shell substrate; the
 short version is:
@@ -110,14 +110,16 @@ the convention from `tools/machines-viz/` vs.
 
 ## Embed, don't reimplement
 
-For the epoch panel (re-frame-10x), the chart visualisation
-(machines-viz, future), and any other peer artefact: **embed via
-`reg-story-panel`; don't reimplement.** The
-[`003-Render-Shell.md`](003-Render-Shell.md) §Panel registration
-contract — five rules — is the embed protocol.
+For the epoch panel (Causa — the structural successor to
+re-frame-10x, per
+[`tools/causa/spec/DESIGN-RATIONALE.md`](../../causa/spec/DESIGN-RATIONALE.md)
+Lock #1), the chart visualisation (machines-viz, future), and any
+other peer artefact: **embed via `reg-story-panel`; don't
+reimplement.** The [`003-Render-Shell.md`](003-Render-Shell.md)
+§Panel registration contract — five rules — is the embed protocol.
 
-This keeps the maintenance surface bounded: 10x's UX evolves in 10x,
-not in Story; machines-viz evolves in its own jar.
+This keeps the maintenance surface bounded: Causa's UX evolves in
+Causa, not in Story; machines-viz evolves in its own jar.
 
 ## Record, don't throw
 

--- a/tools/story/spec/README.md
+++ b/tools/story/spec/README.md
@@ -7,7 +7,7 @@
 - **[002-Runtime.md](002-Runtime.md)** — Per-variant frame allocation; args-precedence resolution; decorator composition; four-phase loader lifecycle; `run-variant` / `reset-variant` / `watch-variant` / `snapshot-identity` / `destroy-variant!`.
 - **[003-Render-Shell.md](003-Render-Shell.md)** — The UI: sidebar, canvas, controls, workspaces, scrubber, trace; five workspace layouts; hot-reload decorator fingerprinting; `mount-shell!` / `unmount-shell!` / `active-shell`.
 - **[004-Assertions.md](004-Assertions.md)** — The seven canonical `:rf.assert/*` events with record-don't-throw semantics; play-sequence execution; `force-fx-stub` decorator.
-- **[005-SOTA-Features.md](005-SOTA-Features.md)** — Layout-debug overlays; a11y axe-core panel; per-variant QR share; multi-substrate side-by-side; 10x epoch embed stub; production elision under `:advanced`.
+- **[005-SOTA-Features.md](005-SOTA-Features.md)** — Layout-debug overlays; a11y axe-core panel; per-variant QR share; multi-substrate side-by-side; Causa epoch embed stub; production elision under `:advanced`.
 - **[006-MCP-Surface.md](006-MCP-Surface.md)** — The boundary between Story and `tools/story-mcp/`; surfaces Story exposes for the MCP jar; late-bind `reg-story-panel` for tooling embeds.
 - **[007-Mode-Tabs.md](007-Mode-Tabs.md)** — The render-shell's top-of-canvas `:dev` / `:docs` / `:test` switcher; the chrome-level primitive every 2026 component playground ships (rf2-9hc8).
 - **[008-Docs-Mode.md](008-Docs-Mode.md)** — The `:docs` mode pane — read-only AutoDocs-equivalent: header, prose, args, decorators, parameters, tags for the active variant (rf2-rodx).

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -246,17 +246,17 @@
 
 ;; ---- story-panel -------------------------------------------------------
 
-(deftest reg-story-panel-10x-shape
-  (testing "the canonical re-frame-10x embed registration"
-    (story/reg-story-panel :rf.story/epoch-10x
-      {:doc       "re-frame-10x's epoch buffer."
-       :title     "Epochs (10x)"
+(deftest reg-story-panel-causa-shape
+  (testing "the canonical Causa embed registration (per 005-SOTA-Features.md §Causa epoch panel embed)"
+    (story/reg-story-panel :rf.story/causa-epoch
+      {:doc       "Causa's epoch buffer."
+       :title     "Epochs (Causa)"
        :placement :bottom
-       :render    :re-frame-10x.epoch-panel/view})
-    (let [body (story/handler-meta :story-panel :rf.story/epoch-10x)]
-      (is (= "Epochs (10x)" (:title body)))
+       :render    :day8.re-frame2-causa.panels.time-travel/time-travel-view})
+    (let [body (story/handler-meta :story-panel :rf.story/causa-epoch)]
+      (is (= "Epochs (Causa)" (:title body)))
       (is (= :bottom (:placement body)))
-      (is (= :re-frame-10x.epoch-panel/view (:render body))))))
+      (is (= :day8.re-frame2-causa.panels.time-travel/time-travel-view (:render body))))))
 
 ;; ---- decorator (per-kind) ---------------------------------------------
 


### PR DESCRIPTION
## Summary

Batched four single-file spec-polish beads on disjoint surfaces, respecting the dispatch plan's hot-zone exclusions (spec/005, spec/API, spec/Conventions, spec/009, spec/010 untouched).

- **rf2-gffca** — `spec/Spec-Schemas.md`: replace stale single-key `:rf.error/flow-shape-invalid` reference with the four-key family that 009 actually documents (`flow-missing-id` / `flow-bad-inputs` / `flow-bad-output` / `flow-bad-path`).
- **rf2-fhg5l** — `tools/story/spec/*`: retire stale `re-frame-10x` prose in favour of Causa (the structural successor per Causa Lock #1). Renames the canonical embed example's id (`:rf.story/10x-epoch` → `:rf.story/causa-epoch`), points the `:render` keyword at the real `:day8.re-frame2-causa.panels.time-travel/time-travel-view` symbol Causa ships, renames `§10x-embed` / `§10x-embed-inert-without-causa` anchors, brings the test into lockstep.
- **rf2-7jjw1** — Scaffold `tools/machines-viz-mcp/spec/000-Vision.md` closing the forward-references from `tools/README.md` and the story-mcp / story specs; pins the direction-setting calls (separate jar, MCP-over-stdio, share-URL parity, read-only, no session export).
- **rf2-0m7p9** — `tools/story/spec/004-Assertions.md` + `API.md`: pin the `:rf.assert/effect-emitted` pred slot — unary fn over the fx-id keyword (not fx-args), exception-safe (throws default to false). Adds the `§:rf.assert/effect-emitted payload shape` subsection with the rationale and composition pattern for arg-level checks.

Deferred (per dispatch rules):

- `rf2-lb0mx` — touches spec/009 + spec/010 (shared-vocab batch territory).
- `rf2-ocp7a`, `rf2-9mdst` — spec/005-StateMachines.md (excluded; just batched in #1028).
- `rf2-cl8me` — spec/002-Frames.md (hot-zone); P4 v1.1-design-pass tracker; no urgent edit.
- `rf2-fa19u` — umbrella tracker awaiting fixtures landing.
- `rf2-mdoqh` — closed as superseded: Causa-MCP Lock #12 (rf2-3we2k, 2026-05-14) reconciled the count back to 18 with `list-subscriptions` as the eighteenth tool; `tools/causa/spec/010-MCP-Server.md` is internally consistent.

Hot files touched: none (deliberately disjoint from the documented hot-zone list).

LoC delta: +310 / -75 across 11 files (the +193 stub vision doc dominates; the four spec edits are surgical).

## Test plan

- [x] `python scripts/check_doc_slugs.py` exit 0
- [x] `python -m mkdocs build` warnings unchanged from main (119 → 119)
- [ ] CI: spec-only changes; no implementation tests touched. Story canonical-embed test renamed and updated to assert the new `:render` symbol and id.