### PR TITLE
refactor(comments): umbrella sweep — 12 leaves (rf2-0a1yz)

### DIFF
--- a/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
+++ b/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
@@ -1,24 +1,16 @@
 (ns re-frame.adapter.helix
-  "The Helix adapter — the third canonical browser substrate (rf2-2qit).
-  Per Spec 006 §CLJS reference: Helix as alternative substrate.
+  "The Helix adapter — the third canonical browser substrate. Per Spec
+  006 §CLJS reference: Helix as alternative substrate.
 
-  Ships in its own Maven artefact (day8/re-frame2-helix) per
-  Spec 006 §Adapter shipping convention (rf2-0hxm). Apps that use Helix
-  depend on both day8/re-frame2 (core) and this artefact; apps
-  targeting Reagent depend on day8/re-frame2-reagent instead; apps
-  targeting UIx depend on day8/re-frame2-uix instead. Core does
-  *not* :require this ns — the dependency direction is adapter → core.
+  Ships in its own artefact (day8/re-frame2-helix). Dependency
+  direction is adapter → core; core does NOT `:require` this ns.
 
-  Per rf2-2qit Decision 2 the React frame-context lives in
-  `re-frame.adapter.context` (CLJS-only file in core); this adapter
-  consumes the *same* createContext object the Reagent and UIx
-  adapters consume, so a future mixed-substrate app's frame-provider
-  chain composes across substrates.
+  The React frame-context lives in `re-frame.adapter.context` (CLJS-
+  only file in core); this adapter consumes the SAME createContext
+  object the Reagent and UIx adapters consume.
 
-  Per rf2-2qit Decision 8 we target the Helix 0.2.x line. The eight
-  decisions transferred from rf2-3yij (the UIx adapter) carry over
-  unchanged — Helix is structurally similar to UIx (React + hooks; no
-  reactive-atom primitive)."
+  Targets the Helix 0.2.x line. Helix is structurally similar to UIx
+  (React + hooks; no reactive-atom primitive)."
   (:require ["react"             :as React]
             ["react-dom/client"  :as react-dom-client]
             [reagent.core        :as r]
@@ -36,8 +28,8 @@
 ;;
 ;; Per Spec 006 §revertibility-constraints the container holds the
 ;; frame's app-db value and *only* the frame's app-db value. Helix
-;; itself doesn't ship a reactive atom primitive (it is the
-;; minimal-React-wrapper niche per the rf2-2qit bead) so we lean on a
+;; itself doesn't ship a reactive atom primitive (minimal-React-wrapper
+;; niche) so we lean on a
 ;; plain `clojure.core/atom` and broadcast changes via `add-watch` —
 ;; observably equivalent to the Reagent adapter's r/atom for the
 ;; substrate contract surface (read, replace, subscribe). Reactive
@@ -167,21 +159,17 @@
                      :render-tree render-tree}))))
 
 ;; ---- context provider -----------------------------------------------------
-;;
-;; Per rf2-2qit Decision 2 we share the same React.createContext object
-;; with the Reagent and UIx adapters (it lives in
-;; re-frame.adapter.context). Helix components consume it via
-;; `helix-hooks/use-context`; the Provider is the same React Provider
-;; component the other adapters target.
+;; Shares the same `React.createContext` object with the Reagent and
+;; UIx adapters (`re-frame.adapter.context`).
 
 (defn use-current-frame
   "Helix hook returning the current frame keyword from the surrounding
   React context, or `:rf/default` when no frame-provider sits above.
 
   This is the Helix counterpart of `re-frame.views/current-frame`'s
-  React-context tier — Decision 2 mandates every React-shaped adapter
-  resolves the *same* context, so a Helix subtree under a Reagent or
-  UIx frame-provider sees the right frame and vice versa."
+  React-context tier; sharing the same React Context across adapters
+  means a Helix subtree under a Reagent or UIx frame-provider sees the
+  right frame and vice versa."
   []
   (helix-hooks/use-context adapter-context/frame-context))
 
@@ -193,9 +181,8 @@
   `frame-provider` is.
 
   Reads `:frame` from props. When missing or `nil`, falls through to
-  `:rf/default` (per rf2-sixo — defensive default that matches the
-  no-provider behaviour and avoids breaking tooling-generated trees
-  that elide the prop).
+  `:rf/default` — matches the no-provider behaviour and avoids breaking
+  tooling-generated trees that elide the prop.
 
   Helix call shape:
 
@@ -203,43 +190,25 @@
                          :children [($ header) ($ main)]})
 
   Same surface as the Reagent and UIx variants, different rendering
-  substrate. The three adapters share one React Context (per rf2-3yij
-  Decision 2) so a subtree under any frame-provider sees the right
-  frame regardless of which substrate rendered the provider."
+  substrate. The three adapters share one React Context so a subtree
+  under any frame-provider sees the right frame regardless of which
+  substrate rendered the provider."
   [{:keys [frame children]}]
   (let [frame-kw (or frame :rf/default)]
     (apply adapter-context/provider-element frame-kw
            (if (sequential? children) children [children]))))
 
 (defn- register-context-provider [_frame-keyword]
-  ;; Same shape as the Reagent and UIx adapters: returns a built
-  ;; component (here, a React-element-producing fn). The arg is ignored
-  ;; because the frame keyword lives in the Provider's :value at render
-  ;; time (rf2-4y60), not in a build-time closure.
+  ;; Returns the built component. The arg is ignored — the frame
+  ;; keyword lives in the Provider's `:value` at render time.
   frame-provider)
 
 ;; ---- subscription hook ----------------------------------------------------
-;;
-;; Per Spec 006 §subscription-cache and rf2-2qit Decision 1 (transferred
-;; from rf2-3yij), `use-subscribe` is the Helix-idiomatic hook surface
-;; for reading a sub. It wraps React.useSyncExternalStore so updates
-;; are scheduled by React's concurrent renderer rather than Reagent's
-;; per-component scheduler. Helix doesn't ship a use-syncExternalStore
-;; wrapper of its own (it is the minimal-React-wrapper niche), so we
-;; use React's hook directly — same path the UIx adapter takes.
-;;
-;; The hook:
-;;   1. Resolves the active frame via use-context (Decision 2).
-;;   2. Calls re-frame.subs/subscribe to build/cache the reaction.
-;;   3. Wires useSyncExternalStore — the snapshot is the deref of the
-;;      reaction; subscribe is add-watch on the underlying container.
-;;   4. On unmount the watch is removed and the sub's ref-count
-;;      decrements through the cache's deferred-dispose grace-period
-;;      (per Spec 006 §reference-counting-and-disposal).
-;;
-;; Per rf2-2qit Decision 3 there is no auto-injection: components
-;; written for Helix call `(use-subscribe [:foo])` directly, the way
-;; they would call any other React hook.
+;; `use-subscribe` is the Helix-idiomatic hook surface for reading a
+;; sub. Wraps `React.useSyncExternalStore` directly (Helix ships no
+;; wrapper of its own). No auto-injection — components call
+;; `(use-subscribe [:foo])` like any other React hook. Per Spec 006
+;; §subscription-cache.
 
 (defn- subscribe-snapshot [reaction]
   (when reaction @reaction))
@@ -249,13 +218,12 @@
   value; re-renders the calling component when the value changes.
 
   Frame resolution: reads the surrounding frame-provider's keyword via
-  `use-context` (rf2-2qit Decision 2). Override via the 2-arg form to
-  pin to an explicit frame-id.
+  `use-context`. Override via the 2-arg form to pin to an explicit
+  frame-id.
 
-  Per rf2-2qit Decision 1 the hook is named `use-subscribe` to match
-  the React/Helix idiom — symmetric ergonomics to Reagent's
-  `(rf/subscribe ...)` deref shape, asymmetric naming (hooks live in
-  hook-named space)."
+  The name follows React/Helix hook idiom — symmetric ergonomics to
+  Reagent's `(rf/subscribe ...)` deref shape, asymmetric naming (hooks
+  live in hook-named space)."
   ([query-v]
    (let [frame-kw (use-current-frame)]
      (use-subscribe frame-kw query-v)))
@@ -291,9 +259,9 @@
   intended for test code only. Calls (act f) where f is the body
   thunk; with no arg, calls (act (fn [] nil)) to flush pending effects.
 
-  Per rf2-2qit Decision 6: the canonical test-flush hook for
-  Helix-based apps. Reagent has no analogous public surface — Reagent
-  tests rely on r/flush; Helix tests rely on this."
+  The canonical test-flush hook for Helix-based apps. Reagent has no
+  analogous public surface — Reagent tests rely on `r/flush`; Helix
+  tests rely on this."
   ([] (flush-views! (fn [] nil)))
   ([f]
    (when-let [act (or (.-act React)
@@ -303,24 +271,15 @@
      (act f))
    nil))
 
-;; ---- source-coord wrapper (rf2-2qit Decision 5; Spec 006 §Source-coord) --
+;; ---- source-coord wrapper (Spec 006 §Source-coord) ----------------------
+;; Walks Helix's `$` output (a React element) and clones the root with
+;; `data-rf2-source-coord` added — same approach as the UIx adapter.
 ;;
-;; Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1) every
-;; React-shaped substrate adapter MUST inject
-;; `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` on each registered
-;; view's root DOM element when `interop/debug-enabled?` is true.
-;;
-;; The Reagent adapter walks hiccup output and merges the attr; the
-;; Helix adapter (like the UIx adapter) walks Helix's `$` output (a
-;; React element) and clones the root with the attr added —
-;; React.cloneElement preserves the original component, props, and
-;; children while letting us layer one extra prop on top.
-;;
-;; Production-elision contract (rf2-z7f7 / Spec 009): the entire branch
-;; sits inside `(when interop/debug-enabled? ...)` so the closure
-;; compiler constant-folds the wrapper away under :advanced +
-;; goog.DEBUG=false. The bundle-grep test confirms the
-;; `data-rf2-source-coord` literal is absent from production builds.
+;; Production-elision contract: the entire branch sits inside `(when
+;; interop/debug-enabled? ...)` so the closure compiler constant-folds
+;; the wrapper away under :advanced + goog.DEBUG=false. The bundle-grep
+;; test confirms the `data-rf2-source-coord` literal is absent from
+;; production builds.
 
 (defn- format-source-coord
   "Render captured registry coords as the attribute value shape
@@ -340,12 +299,9 @@
 
 (defn clear-warned-non-dom-roots!
   "Reset the warn-once cache for non-DOM-root warnings. Tests use this
-  between cases (via `reset-runtime-fixture` and the chained
-  `:adapter/clear-warn-once-caches!` hook) so a sibling test's first-
-  encounter warning cannot silently swallow a later test's same-id
-  warning. Per rf2-4edk — the cache is a process-wide `defonce` so
-  the user-facing warn-once UX is unchanged in production; test-time
-  clearing is the only effect."
+  between cases so a sibling test's first-encounter warning cannot
+  silently swallow a later test's same-id warning. The cache is a
+  process-wide `defonce` — production warn-once UX is unchanged."
   []
   (reset! warned-non-dom-roots #{})
   nil)
@@ -406,11 +362,9 @@
   call signature as `user-fn` and is suitable for use as a Helix
   component head.
 
-  Per rf2-2qit Decision 5 + Spec 006 §Source-coord annotation: this is
-  the Helix-side equivalent of the Reagent adapter's
-  `inject-source-coord-attr` walk and the UIx adapter's `wrap-view`.
-  Production builds elide via `interop/debug-enabled?` per Spec 009
-  §Production builds."
+  Helix-side equivalent of the Reagent adapter's `inject-source-coord-
+  attr` walk and the UIx adapter's `wrap-view`. Production builds elide
+  via `interop/debug-enabled?` per Spec 009 §Production builds."
   [id metadata user-fn]
   (let [coord-attr (when interop/debug-enabled?
                      (format-source-coord id metadata))]
@@ -449,32 +403,20 @@
    :register-context-provider register-context-provider
    :dispose-adapter!          dispose-adapter!})
 
-;; Each late-bind hook below is routed through `(substrate-adapter/
-;; current-adapter)` per rf2-0d35 via `substrate-adapter/route-hook!`
-;; (see that fn's docstring for the routing contract). The wrapper runs
-;; this adapter's impl ONLY when the Helix adapter is the (rf/init!)-
-;; installed one; otherwise it chains to the previously-registered
-;; handler.
+;; Each hook below is routed through `substrate-adapter/route-hook!`
+;; (see its docstring). Helix-specific notes:
 ;;
-;; Hook-specific rationale (Helix-adapter notes):
-;;   :adapter/current-frame  — rf2-d4sf. Helix renders function
-;;     components — they have no class-component (.-context cmp) slot,
-;;     so the shared impl in `re-frame.adapter.context` reads
-;;     `_currentValue` directly. Helix's own `use-current-frame` hook
-;;     is sugar over the same read, so subscribe / dispatch and
-;;     `use-context` agree on the active frame. Chain-bottom fallback
-;;     is `frame/current-frame`.
-;;   :adapter/ratom etc. — rf2-s36l. Helix's derived values reify
-;;     stock reagent.ratom/IDisposable directly, so these hooks
-;;     delegate to stock Reagent's r/atom, ratom/make-reaction, etc.
-;;     Helix itself ships no reactive-atom primitive (it is the
-;;     minimal-React-wrapper niche per rf2-2qit).
-;;   :adapter/wrap-view — rf2-00li. Substrate-side source-coord
-;;     injection via React.cloneElement (the inline hiccup-walk in
-;;     views.cljs would mis-classify React-element output as a non-DOM
-;;     root). Production-elision: `wrap-view`'s body sits inside
-;;     `(when interop/debug-enabled? ...)` so closure-folds under
-;;     :advanced + goog.DEBUG=false (per Spec 009 §Production builds).
+;;   :adapter/current-frame  — Helix renders function components (no
+;;     class-component `(.-context cmp)` slot), so the shared impl in
+;;     `re-frame.adapter.context` reads `_currentValue` directly.
+;;   :adapter/ratom etc. — Helix's derived values reify stock
+;;     `reagent.ratom/IDisposable` directly, so these hooks delegate to
+;;     stock Reagent. Helix itself ships no reactive-atom primitive.
+;;   :adapter/wrap-view — substrate-side source-coord injection via
+;;     `React.cloneElement` (the inline hiccup walk in views.cljs would
+;;     mis-classify React-element output as a non-DOM root). The body
+;;     sits inside `(when interop/debug-enabled? ...)` so closure-folds
+;;     under :advanced + goog.DEBUG=false.
 (substrate-adapter/route-hook! adapter :adapter/current-frame
   adapter-context/function-component-current-frame
   #(frame/current-frame))
@@ -497,16 +439,9 @@
 (substrate-adapter/route-hook! adapter :adapter/wrap-view
   wrap-view)
 
-;; Per rf2-4edk: contribute a clear of THIS adapter's `warned-non-dom-roots`
-;; cache to the chained `:adapter/clear-warn-once-caches!` hook. The hook
-;; is chained — each adapter (helix, uix) and re-frame.views all contribute
-;; a clear-step; `reset-runtime-fixture` invokes the top of the chain and
-;; every contributor's reset runs (unlike `:adapter/current-frame` etc.
-;; this hook is NOT routed through the installed adapter — every loaded
-;; adapter's cache must clear because test bundles can mount different
-;; adapters across tests and each adapter's defonce persists). Production
-;; behaviour is unchanged: the warn-once `defonce` is still per-process
-;; for users; only test-time clearing is new.
+;; Contributes a clear of THIS adapter's `warned-non-dom-roots` cache
+;; to the chained `:adapter/clear-warn-once-caches!` hook — unlike the
+;; routed hooks above, this one fires across every loaded adapter.
 (let [previous (late-bind/get-fn :adapter/clear-warn-once-caches!)]
   (late-bind/set-fn! :adapter/clear-warn-once-caches!
     (fn helix-adapter-clear-warn-once-caches! []

--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -1,86 +1,62 @@
 (ns re-frame.adapter.reagent-slim
   "The day8/reagent-slim adapter — drop-in replacement for the bridge
-  adapter `re-frame.adapter.reagent` (rf2-6hyy).
+  adapter `re-frame.adapter.reagent`.
 
-  Per IMPL-SPEC §2.1 + §9 + §13.1: this adapter Var emits the same
-  9-key map shape `re-frame.substrate.adapter` consumes; signatures
-  match the bridge's signatures byte-for-byte. Internals swap from
-  `(:require [reagent.core ...] [reagent.ratom ...] [reagent.dom.client ...])`
-  to the rewrite's `reagent2.*` namespaces.
+  Emits the same 9-key map shape `re-frame.substrate.adapter` consumes;
+  internals swap from stock `reagent.*` to the rewrite's `reagent2.*`
+  namespaces. Signatures match the bridge's byte-for-byte (IMPL-SPEC
+  §2.1, §9, §13.1).
 
-  Why a separate ns rather than overwriting `re-frame.adapter.reagent`:
-  the in-tree shadow-cljs build adds both `adapters/reagent/src` and
-  `adapters/reagent-slim/src` to the classpath at the same time. Two
-  namespaces with the same name would clash. At artefact-publication
-  time (per the deps.edn :main and IMPL-SPEC §13.1) the slim artefact
-  ships its own `re-frame.adapter.reagent` — consumers depend on
-  exactly one of {day8/re-frame2-reagent, day8/reagent-slim} so the
-  ns is single-source per app. Until the artefact split is
-  consummated, this `-slim` suffix lets both coexist in the monorepo.
+  This ns coexists with `re-frame.adapter.reagent` only in the in-tree
+  monorepo build; at artefact-publication time the slim artefact ships
+  its own `re-frame.adapter.reagent` and consumers depend on exactly
+  one of `{day8/re-frame2-reagent, day8/reagent-slim}`.
 
-  Public surface (signatures unchanged from the bridge):
+  Late-bind hooks installed at ns-load time (routed through the
+  installed adapter so test bundles that load multiple adapter ns's
+  resolve to the correct impl):
 
-    adapter           — the substrate spec map (9-key contract)
-    set-hiccup-emitter! — wires SSR's render-to-string into :render-to-string
-
-  Late-bind hooks installed at ns-load time (all routed through
-  `(substrate-adapter/current-adapter)` per rf2-0d35 so the active
-  adapter's impl wins in test bundles that load multiple adapter ns's):
-
-    :reagent/set-hiccup-emitter!  — set-hiccup-emitter! (SSR seam, rf2-uo7v)
-    :adapter/current-frame        — re-frame.views/current-frame (rf2-d4sf)
-    :adapter/current-component    — reagent2.core/current-component (rf2-wbnl)
-    :adapter/ratom                — reagent2.core/atom            (rf2-s36l)
-    :adapter/ratom?               — reagent2.ratom/IReactiveAtom?  (rf2-s36l)
-    :adapter/make-reaction        — reagent2.ratom/make-reaction   (rf2-s36l)
-    :adapter/add-on-dispose!      — reagent2.ratom/add-on-dispose! (rf2-s36l)
-    :adapter/dispose!             — reagent2.ratom/dispose!        (rf2-s36l)
-    :adapter/reactive?            — reagent2.ratom/reactive?       (rf2-s36l)
-    :adapter/after-render         — reagent2.core/after-render     (rf2-s36l)
+    :reagent/set-hiccup-emitter!  — set-hiccup-emitter! (SSR seam)
+    :adapter/current-frame        — re-frame.views/current-frame
+    :adapter/current-component    — reagent2.core/current-component
+    :adapter/ratom                — reagent2.core/atom
+    :adapter/ratom?               — reagent2.ratom/IReactiveAtom?
+    :adapter/make-reaction        — reagent2.ratom/make-reaction
+    :adapter/add-on-dispose!      — reagent2.ratom/add-on-dispose!
+    :adapter/dispose!             — reagent2.ratom/dispose!
+    :adapter/reactive?            — reagent2.ratom/reactive?
+    :adapter/after-render         — reagent2.core/after-render
 
   Interop is fully late-bound: this ns does NOT statically `:require`
   stock Reagent anywhere. `re-frame.interop` reads ratom / reaction /
-  disposable surfaces through the hook table (per rf2-s36l), so the
-  slim Maven artefact (`day8/reagent-slim`) can be published without
-  a stock-Reagent dep — downstream consumers depending on
-  `reagent-slim` alone gain the ~25 KB gz saving. The in-tree
-  shadow-cljs build still pulls all adapter trees; that's the
-  monorepo configuration, not a shape requirement.
+  disposable surfaces through the hook table, so the slim Maven
+  artefact (`day8/reagent-slim`) can be published without a stock-
+  Reagent dep — downstream consumers depending on `reagent-slim` alone
+  gain the ~25 KB gz saving.
 
-  The Reagent-slim adapter targets the same React-context Provider /
-  `(.-context cmp)` shape the bridge uses (per IMPL-SPEC §9.6),
-  so the views.cljs wiring works unchanged.
+  Targets the same React-context Provider / `(.-context cmp)` shape
+  the bridge uses (IMPL-SPEC §9.6), so the views.cljs wiring works
+  unchanged.
 
-  Render path (rf2-08t0 / rf2-s36l / rf2-u5p5):
+  Render path:
     - `wrap-render` returns hiccup per IMPL-SPEC §5.1; the React
-      `render` method converts that hiccup to a React element via
+      `render` method converts that to a React element via
       `reagent2.impl.template/as-element`, registered into
-      `reagent2.impl.component/set-as-element-fn!` at template's
-      ns-load time. Without that conversion React would reject the
-      CLJS vector with 'Objects are not valid as a React child'.
-    - `make-render-method` mirrors stock Reagent's
-      `reagent.impl.component` render path: the first render creates
-      the per-component render Reaction with a custom auto-run that
-      queues a React re-render (no synchronous recompute); each
-      subsequent render calls `(._run rea false)` directly so
-      deref-capture rewires the watching graph AND the user's render
-      fn executes with the latest state. A plain `@rea` would return
-      the cached prior state because `_handle-change` with a
-      fn-valued auto-run doesn't set `dirty?`.
+      `reagent2.impl.component/set-as-element-fn!` at template ns-load.
+      Without that conversion React would reject the CLJS vector with
+      'Objects are not valid as a React child'.
+    - `make-render-method` mirrors stock Reagent's render path: the
+      first render creates the per-component render Reaction with a
+      custom auto-run that queues a React re-render; each subsequent
+      render calls `(._run rea false)` directly so deref-capture
+      rewires the watching graph AND the user's render fn executes
+      with the latest state. A plain `@rea` would return the cached
+      prior state because `_handle-change` with a fn-valued auto-run
+      doesn't set `dirty?`.
 
-  Status: drop-in functional swap for the bridge. The
-  counter-slim-and-fast Playwright smoke (rf2-5lbx) runs as part of
-  the default suite — was `skip:`-parked behind rf2-s36l / rf2-u5p5
-  and is GREEN as of those merges.
-
-  Pre-release status: until the bridge is retired (post-1.0), apps
-  that want the rewrite explicitly opt in by requiring this ns.
-
-  Per rf2-uo7v the SSR surface ships in `day8/re-frame2-ssr` —
-  this adapter MUST NOT statically `:require [re-frame.ssr]`. Instead
-  it publishes its `set-hiccup-emitter!` callback through the
-  late-bind hook table; if the SSR artefact is on the classpath, its
-  ns-load resolves the hook and wires the emitter."
+  The SSR surface (`day8/re-frame2-ssr`) is optional, so this adapter
+  MUST NOT statically `:require [re-frame.ssr]`. Instead it publishes
+  `set-hiccup-emitter!` through the late-bind hook table."
   (:require [reagent2.core             :as r]
             [reagent2.ratom            :as ratom]
             [reagent2.dom.client       :as rdc]
@@ -130,9 +106,9 @@
 
 (defn set-hiccup-emitter!
   "Install the hiccup → HTML fn used by render-to-string. Idempotent.
-  Per rf2-uo7v / IMPL-SPEC §2.1: published through the late-bind hook
-  `:reagent/set-hiccup-emitter!` so the SSR seam at re-frame.ssr
-  resolves it at load time without a static :require."
+  Published through the late-bind hook `:reagent/set-hiccup-emitter!`
+  so the SSR seam at re-frame.ssr resolves it at load time without a
+  static :require."
   [f]
   (reset! hiccup-emitter f))
 
@@ -146,11 +122,10 @@
 ;; ---- context provider -----------------------------------------------------
 
 (defn- register-context-provider [_frame-keyword]
-  ;; Implementation lives in re-frame.views (CLJS-only). The frame-
-  ;; keyword arg is ignored — `build-frame-provider` is 0-arity
-  ;; (rf2-4y60); the returned component takes the frame keyword at
-  ;; render time. Per IMPL-SPEC §9.4: the views.cljs ns continues to
-  ;; back the frame-provider; the rewrite doesn't replace it.
+  ;; `build-frame-provider` is 0-arity; the returned component takes
+  ;; the frame keyword at render time. IMPL-SPEC §9.4: views.cljs
+  ;; continues to back the frame-provider; the rewrite doesn't replace
+  ;; it.
   (views/build-frame-provider))
 
 ;; ---- disposal -------------------------------------------------------------
@@ -168,8 +143,8 @@
 
   Drop-in shape-compatible with `re-frame.adapter.reagent/adapter` per
   IMPL-SPEC §2.1 — the only difference is the substrate, not the keys.
-  Per Spec 006 §CLJS reference + rf2-agql: there is no default-adapter
-  registry; adapter wiring is explicit at the call site."
+  There is no default-adapter registry; adapter wiring is explicit at
+  the call site."
   {:kind                      :reagent-slim
    :make-state-container      make-state-container
    :read-container            read-container
@@ -181,36 +156,27 @@
    :register-context-provider register-context-provider
    :dispose-adapter!          dispose-adapter!})
 
-;; Per rf2-uo7v + IMPL-SPEC §9.2: publish the hiccup-emitter installer
-;; through the late-bind hook table so re-frame.ssr (in
-;; day8/re-frame2-ssr) resolves it at its ns-load. Without this, an
-;; app pulling in the SSR seam would have to manually call
-;; `(reagent-slim/set-hiccup-emitter! ssr/render-to-string)` —
-;; the late-bind table makes that wiring automatic when both
-;; artefacts are on the classpath.
+;; Publishes the hiccup-emitter installer through the late-bind table
+;; so re-frame.ssr resolves it at its ns-load when present (apps then
+;; don't have to manually call `(reagent-slim/set-hiccup-emitter!
+;; ssr/render-to-string)`).
 (late-bind/set-fn! :reagent/set-hiccup-emitter! set-hiccup-emitter!)
 
-;; Each late-bind hook below is routed through `(substrate-adapter/
-;; current-adapter)` per rf2-0d35 via `substrate-adapter/route-hook!`
-;; (see that fn's docstring for the routing contract). The wrapper runs
-;; this adapter's impl ONLY when this adapter is the (rf/init!)-installed
-;; one; otherwise it chains to the previously-registered handler.
+;; Each hook below is routed through `substrate-adapter/route-hook!`
+;; (see its docstring). Slim-adapter specifics:
 ;;
-;; Hook-specific rationale (slim-adapter notes):
-;;   :adapter/current-frame  — rf2-d4sf + IMPL-SPEC §9.6. The rewrite
-;;     preserves the bridge's class-component (.-context cmp) shape, so
-;;     re-frame.views/current-frame works unchanged with reagent-slim's
-;;     class components. Chain-bottom fallback is frame/current-frame.
-;;   :adapter/current-component — rf2-wbnl. Wires
-;;     reagent2.core/current-component so re-frame.views resolves the
-;;     in-flight component from the slim substrate (stock Reagent's
-;;     reader would return nil for slim-rendered components).
-;;   :adapter/ratom etc. — rf2-s36l. Wires reagent2.* impls so
-;;     re-frame.interop's reactive-substrate calls dispatch onto
-;;     reagent2.ratom/IDisposable / IReactiveAtom — without this seam
-;;     the very first (interop/add-on-dispose! ...) under the slim
-;;     adapter threw because reagent2.ratom/Reaction does NOT reify
-;;     stock Reagent's IDisposable.
+;;   :adapter/current-frame  — the rewrite preserves the bridge's class-
+;;     component `(.-context cmp)` shape, so `views/current-frame` works
+;;     unchanged with reagent-slim's class components.
+;;   :adapter/current-component — `reagent2.core/current-component` —
+;;     stock Reagent's reader would return nil for slim-rendered
+;;     components.
+;;   :adapter/ratom etc. — wires `reagent2.*` impls so
+;;     `re-frame.interop`'s reactive-substrate calls dispatch onto
+;;     `reagent2.ratom/IDisposable` / `IReactiveAtom`. Without this
+;;     seam the very first `(interop/add-on-dispose! ...)` under the
+;;     slim adapter threw because `reagent2.ratom/Reaction` does NOT
+;;     reify stock Reagent's `IDisposable`.
 (substrate-adapter/route-hook! adapter :adapter/current-frame
   views/current-frame
   #(frame/current-frame))

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -1,20 +1,11 @@
 (ns re-frame.adapter.reagent
-  "The Reagent adapter — browser default. Per Spec 006 §CLJS reference:
-  Reagent as default adapter.
+  "The Reagent adapter — browser default. Per Spec 006 §CLJS reference.
 
-  Ships in its own Maven artefact (day8/re-frame2-reagent) per
-  Spec 006 §Adapter shipping convention (rf2-0hxm). Apps that use
-  Reagent depend on both day8/re-frame2 (core) and this artefact;
-  apps targeting a different substrate (UIx, Helix) depend on the
-  matching adapter artefact instead. Core does *not* :require this ns —
-  the dependency direction is adapter → core.
+  Ships in its own artefact (day8/re-frame2-reagent). Dependency
+  direction is adapter → core; core does NOT `:require` this ns.
 
-  Per rf2-uo7v the SSR surface ships in `day8/re-frame2-ssr` —
-  this adapter MUST NOT statically `:require [re-frame.ssr]` either,
-  because that would drag the SSR namespace, the FNV-1a render-tree-hash
-  machinery, the per-request `[:rf/response]` accumulator, and every
-  `:rf.ssr/*` / `:rf.server/*` keyword string into every Reagent app's
-  bundle even when no server-side rendering is performed. Instead the
+  The SSR surface (`day8/re-frame2-ssr`) is also optional, so this
+  adapter MUST NOT statically `:require [re-frame.ssr]`. Instead the
   adapter publishes its `set-hiccup-emitter!` callback through the
   late-bind hook table; if the SSR artefact is on the classpath, its
   ns-load resolves the hook and wires the emitter."
@@ -65,8 +56,7 @@
   ;;   - `(rdc/unmount <root>)`          → tear the Root down
   ;;
   ;; The unmount thunk closes over the Root so the runtime can release
-  ;; it without consulting the DOM element again. Hydrate path mirrors
-  ;; the slim adapter (rf2-6hyy) — `hydrate-root` returns its own Root.
+  ;; it without consulting the DOM element again.
   (let [hydrate? (boolean (:hydrate? opts))]
     (if hydrate?
       (let [root (rdc/hydrate-root mount-point render-tree)]
@@ -95,11 +85,9 @@
 ;; ---- context provider -----------------------------------------------------
 
 (defn- register-context-provider [_frame-keyword]
-  ;; Implementation lives in re-frame.views (CLJS-only). The frame-
-  ;; keyword arg is ignored — `build-frame-provider` is 0-arity
-  ;; (rf2-4y60); the returned component takes the frame keyword at
-  ;; render time. The arg stays in the substrate signature per
-  ;; Spec 006 §Frame-provider via React context.
+  ;; `build-frame-provider` is 0-arity; the returned component takes the
+  ;; frame keyword at render time. The arg stays in the substrate
+  ;; signature per Spec 006 §Frame-provider via React context.
   (views/build-frame-provider))
 
 ;; ---- disposal -------------------------------------------------------------
@@ -116,8 +104,8 @@
       (rf/init! reagent/adapter)
 
   See Spec 006 §CLJS reference: Reagent as default adapter for the
-  bridging pseudocode. Per rf2-agql there is no default-adapter
-  registry — adapter wiring is explicit at the call site."
+  bridging pseudocode. There is no default-adapter registry — adapter
+  wiring is explicit at the call site."
   {:kind                      :reagent
    :make-state-container      make-state-container
    :read-container            read-container
@@ -129,41 +117,31 @@
    :register-context-provider register-context-provider
    :dispose-adapter!          dispose-adapter!})
 
-;; Wire ssr's render-to-string into this adapter's :render-to-string
-;; slot. Per rf2-uo7v ssr ships in day8/re-frame2-ssr; this adapter
-;; cannot statically `:require [re-frame.ssr]` without dragging the SSR
-;; namespace into every Reagent bundle. Publish set-hiccup-emitter!
-;; through the late-bind hook table — when the ssr artefact is loaded,
-;; its ns-load resolves the hook and wires the emitter through it. When
-;; ssr is absent the hook is never consumed and render-to-string raises
-;; the "no-hiccup-emitter-bound" error on first call. Per Spec 006
-;; §Adapter shipping convention (rf2-0hxm).
+;; Published through the late-bind table because re-frame.ssr is
+;; optional; ssr's ns-load resolves the hook when present, and
+;; render-to-string raises "no-hiccup-emitter-bound" when absent.
 (late-bind/set-fn! :reagent/set-hiccup-emitter! set-hiccup-emitter!)
 
-;; Each late-bind hook below is routed through `(substrate-adapter/
-;; current-adapter)` per rf2-0d35 via `substrate-adapter/route-hook!`
-;; (see that fn's docstring for the routing contract). The wrapper runs
-;; this adapter's impl ONLY when this adapter is the (rf/init!)-installed
-;; one; otherwise it chains to the previously-registered handler.
+;; Each hook below is routed through `substrate-adapter/route-hook!`
+;; (see its docstring): the wrapper runs this adapter's impl only
+;; when this adapter is the (rf/init!)-installed one, otherwise it
+;; chains to the previously-registered handler.
 ;;
-;; Hook-specific rationale:
-;;   :adapter/current-frame  — rf2-d4sf. React-context tier of the
-;;     3-tier resolution chain. Reagent path uses (.-context cmp) on
-;;     the in-flight Reagent component (class-component machinery), so
-;;     `reg-view*`-wrapped components route to the surrounding
-;;     provider's frame while plain Reagent fns fall through to
-;;     :rf/default — that narrowness makes the
-;;     plain-fn-under-non-default-frame-once warning meaningful.
-;;     Chain-bottom fallback is `frame/current-frame` so headless /
-;;     pre-init shape is preserved.
-;;   :adapter/current-component — rf2-wbnl. Reads stock Reagent's
-;;     in-flight component without hard-binding re-frame.views to
-;;     reagent.core; the slim adapter wires this hook to
-;;     reagent2.core/current-component.
-;;   :adapter/ratom etc. — rf2-s36l. The reactive-substrate surfaces
-;;     consumed by `re-frame.interop`. UIx and Helix adapters reify
-;;     stock reagent.ratom/IDisposable on their derived values, so
-;;     they wire these hooks to the same stock-Reagent impls.
+;;   :adapter/current-frame  — React-context tier of the three-tier
+;;     resolution chain. Reagent's class-component machinery means
+;;     `reg-view*`-wrapped components route to the surrounding provider,
+;;     while plain Reagent fns fall through to `:rf/default` — that
+;;     narrowness makes the plain-fn-under-non-default-frame-once
+;;     warning meaningful. Chain-bottom fallback is `frame/current-frame`
+;;     so the headless / pre-init shape is preserved.
+;;   :adapter/current-component — reads stock Reagent's in-flight
+;;     component without hard-binding re-frame.views to reagent.core.
+;;     The slim adapter wires this hook to `reagent2.core/current-
+;;     component`.
+;;   :adapter/ratom etc. — reactive-substrate surfaces consumed by
+;;     `re-frame.interop`. UIx and Helix reify stock
+;;     `reagent.ratom/IDisposable` on their derived values, so they
+;;     wire these hooks to the same stock-Reagent impls.
 (substrate-adapter/route-hook! adapter :adapter/current-frame
   views/current-frame
   #(frame/current-frame))

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -1,21 +1,16 @@
 (ns re-frame.adapter.uix
-  "The UIx adapter — the second canonical browser substrate (rf2-3yij).
-  Per Spec 006 §CLJS reference: UIx as alternative substrate.
+  "The UIx adapter — the second canonical browser substrate. Per Spec 006
+  §CLJS reference: UIx as alternative substrate.
 
-  Ships in its own Maven artefact (day8/re-frame2-uix) per
-  Spec 006 §Adapter shipping convention (rf2-0hxm). Apps that use UIx
-  depend on both day8/re-frame2 (core) and this artefact; apps
-  targeting Reagent depend on day8/re-frame2-reagent instead.
-  Core does *not* :require this ns — the dependency direction is
-  adapter → core.
+  Ships in its own artefact (day8/re-frame2-uix). Dependency direction
+  is adapter → core; core does NOT `:require` this ns.
 
-  Per rf2-3yij Decision 2 the React frame-context lives in
-  `re-frame.adapter.context` (CLJS-only file in core); this adapter
-  consumes the *same* createContext object the Reagent adapter
-  consumes, so a future mixed-substrate app's frame-provider chain
-  composes across substrates.
+  The React frame-context lives in `re-frame.adapter.context` (CLJS-only
+  file in core); this adapter consumes the SAME createContext object the
+  Reagent adapter consumes, so a future mixed-substrate app's frame-
+  provider chain composes across substrates.
 
-  Per rf2-3yij Decision 8 we target UIx 2.x (hooks-based)."
+  Targets UIx 2.x (hooks-based)."
   (:require ["react"          :as React]
             ["react-dom/client" :as react-dom-client]
             [reagent.core     :as r]
@@ -114,11 +109,10 @@
         (swap! watchers dissoc k)
         nil)
       ;; Reagent's IDisposable — `interop/add-on-dispose!` calls into
-      ;; this protocol when wiring the sub-cache's slot teardown
-      ;; (per Spec 006 §subscription-cache and the rf2-3yij
-      ;; cross-substrate-cache decision). Adopting the Reagent
-      ;; protocol keeps the cache wiring substrate-agnostic at the
-      ;; call site — core does not branch on adapter type.
+      ;; this protocol when wiring sub-cache slot teardown. Adopting it
+      ;; keeps the cache wiring substrate-agnostic at the call site —
+      ;; core does not branch on adapter type. Per Spec 006
+      ;; §subscription-cache.
       ratom/IDisposable
       (dispose! [_]
         (doseq [[s k] @own-keys] (remove-watch s k))
@@ -163,20 +157,18 @@
                      :render-tree render-tree}))))
 
 ;; ---- context provider -----------------------------------------------------
-;;
-;; Per rf2-3yij Decision 2 we share the same React.createContext object
-;; with the Reagent adapter (it lives in re-frame.adapter.context).
-;; UIx components consume it via `uix/use-context`; the Provider is the
-;; same React Provider component the Reagent adapter targets.
+;; Shares the same `React.createContext` object with the Reagent and
+;; Helix adapters (`re-frame.adapter.context`), so a subtree under any
+;; substrate's frame-provider sees the right frame.
 
 (defn use-current-frame
   "UIx hook returning the current frame keyword from the surrounding
   React context, or `:rf/default` when no frame-provider sits above.
 
   This is the UIx counterpart of `re-frame.views/current-frame`'s
-  React-context tier — Decision 2 mandates both adapters resolve the
-  same context, so a UIx subtree under a Reagent frame-provider sees
-  the right frame and vice versa."
+  React-context tier; sharing the same React Context across adapters
+  means a UIx subtree under a Reagent frame-provider sees the right
+  frame and vice versa."
   []
   (uix/use-context adapter-context/frame-context))
 
@@ -188,9 +180,8 @@
   `frame-provider` is.
 
   Reads `:frame` from props. When missing or `nil`, falls through to
-  `:rf/default` (per rf2-sixo — defensive default that matches the
-  no-provider behaviour and avoids breaking tooling-generated trees
-  that elide the prop).
+  `:rf/default` — matches the no-provider behaviour and avoids breaking
+  tooling-generated trees that elide the prop.
 
   UIx call shape:
 
@@ -198,40 +189,26 @@
                          :children [($ header) ($ main)]})
 
   Same surface as the Reagent and Helix variants, different rendering
-  substrate. The three adapters share one React Context (per rf2-3yij
-  Decision 2) so a subtree under any frame-provider sees the right
-  frame regardless of which substrate rendered the provider."
+  substrate. The three adapters share one React Context so a subtree
+  under any frame-provider sees the right frame regardless of which
+  substrate rendered the provider."
   [{:keys [frame children]}]
   (let [frame-kw (or frame :rf/default)]
     (apply adapter-context/provider-element frame-kw
            (if (sequential? children) children [children]))))
 
 (defn- register-context-provider [_frame-keyword]
-  ;; Same shape as the Reagent adapter: returns a built component
-  ;; (here, a React-element-producing fn). The arg is ignored because
-  ;; the frame keyword lives in the Provider's :value at render time
-  ;; (rf2-4y60), not in a build-time closure.
+  ;; Returns the built component (a React-element-producing fn). The
+  ;; arg is ignored because the frame keyword lives in the Provider's
+  ;; `:value` at render time, not in a build-time closure.
   frame-provider)
 
 ;; ---- subscription hook ----------------------------------------------------
-;;
-;; Per Spec 006 §subscription-cache and rf2-3yij Decision 1, `use-subscribe`
-;; is the UIx-idiomatic hook surface for reading a sub. It wraps
-;; React.useSyncExternalStore so updates are scheduled by React's
-;; concurrent renderer rather than Reagent's per-component scheduler.
-;;
-;; The hook:
-;;   1. Resolves the active frame via use-context (Decision 2).
-;;   2. Calls re-frame.subs/subscribe to build/cache the reaction.
-;;   3. Wires useSyncExternalStore — the snapshot is the deref of the
-;;      reaction; subscribe is add-watch on the underlying container.
-;;   4. On unmount the watch is removed and the sub's ref-count
-;;      decrements through the cache's deferred-dispose grace-period
-;;      (per Spec 006 §reference-counting-and-disposal).
-;;
-;; Per rf2-3yij Decision 3 there is no auto-injection: components
-;; written for UIx call `(use-subscribe [:foo])` directly, the way they
-;; would call any other React hook.
+;; `use-subscribe` is the UIx-idiomatic hook surface for reading a sub.
+;; It wraps `React.useSyncExternalStore` so updates are scheduled by
+;; React's concurrent renderer rather than Reagent's per-component
+;; scheduler. There is no auto-injection — components call
+;; `(use-subscribe [:foo])` directly. Per Spec 006 §subscription-cache.
 
 (defn- subscribe-snapshot [reaction]
   (when reaction @reaction))
@@ -241,13 +218,12 @@
   value; re-renders the calling component when the value changes.
 
   Frame resolution: reads the surrounding frame-provider's keyword via
-  `use-context` (rf2-3yij Decision 2). Override via the 2-arg form to
-  pin to an explicit frame-id.
+  `use-context`. Override via the 2-arg form to pin to an explicit
+  frame-id.
 
-  Per rf2-3yij Decision 1 the hook is named `use-subscribe` to match
-  the React/UIx idiom — symmetric ergonomics to Reagent's
-  `(rf/subscribe ...)` deref shape, asymmetric naming (hooks live in
-  hook-named space)."
+  The name follows React/UIx hook idiom — symmetric ergonomics to
+  Reagent's `(rf/subscribe ...)` deref shape, asymmetric naming (hooks
+  live in hook-named space)."
   ([query-v]
    (let [frame-kw (use-current-frame)]
      (use-subscribe frame-kw query-v)))
@@ -285,9 +261,9 @@
   intended for test code only. Calls (act f) where f is the body
   thunk; with no arg, calls (act (fn [] nil)) to flush pending effects.
 
-  Per rf2-3yij Decision 6: the canonical test-flush hook for UIx-based
-  apps. Reagent has no analogous public surface — Reagent tests rely
-  on r/flush; UIx tests rely on this."
+  The canonical test-flush hook for UIx-based apps. Reagent has no
+  analogous public surface — Reagent tests rely on `r/flush`; UIx
+  tests rely on this."
   ([] (flush-views! (fn [] nil)))
   ([f]
    (when-let [act (or (.-act React)
@@ -297,24 +273,18 @@
      (act f))
    nil))
 
-;; ---- source-coord wrapper (rf2-3yij Decision 5; Spec 006 §Source-coord) --
+;; ---- source-coord wrapper (Spec 006 §Source-coord) ----------------------
+;; Every React-shaped substrate adapter injects `data-rf2-source-coord`
+;; on each registered view's root DOM element when `interop/debug-
+;; enabled?` is true. The UIx adapter walks UIx's `$` output (a React
+;; element) and clones the root with the attr added — preserving the
+;; original component, props, and children.
 ;;
-;; Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1) every
-;; React-shaped substrate adapter MUST inject
-;; `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` on each registered
-;; view's root DOM element when `interop/debug-enabled?` is true.
-;;
-;; The Reagent adapter walks hiccup output and merges the attr; the
-;; UIx adapter walks UIx's `$` output (a React element) and clones the
-;; root with the attr added — React.cloneElement preserves the original
-;; component, props, and children while letting us layer one extra prop
-;; on top.
-;;
-;; Production-elision contract (rf2-z7f7 / Spec 009): the entire branch
-;; sits inside `(when interop/debug-enabled? ...)` so the closure
-;; compiler constant-folds the wrapper away under :advanced +
-;; goog.DEBUG=false. The bundle-grep test confirms the
-;; `data-rf2-source-coord` literal is absent from production builds.
+;; Production-elision contract: the entire branch sits inside `(when
+;; interop/debug-enabled? ...)` so the closure compiler constant-folds
+;; the wrapper away under :advanced + goog.DEBUG=false. The bundle-grep
+;; test confirms the `data-rf2-source-coord` literal is absent from
+;; production builds.
 
 (defn- format-source-coord
   "Render captured registry coords as the attribute value shape
@@ -334,12 +304,9 @@
 
 (defn clear-warned-non-dom-roots!
   "Reset the warn-once cache for non-DOM-root warnings. Tests use this
-  between cases (via `reset-runtime-fixture` and the chained
-  `:adapter/clear-warn-once-caches!` hook) so a sibling test's first-
-  encounter warning cannot silently swallow a later test's same-id
-  warning. Per rf2-4edk — the cache is a process-wide `defonce` so
-  the user-facing warn-once UX is unchanged in production; test-time
-  clearing is the only effect."
+  between cases so a sibling test's first-encounter warning cannot
+  silently swallow a later test's same-id warning. The cache is a
+  process-wide `defonce` — production warn-once UX is unchanged."
   []
   (reset! warned-non-dom-roots #{})
   nil)
@@ -400,10 +367,9 @@
   call signature as `user-fn` and is suitable for use as a UIx
   component head.
 
-  Per rf2-3yij Decision 5 + Spec 006 §Source-coord annotation: this is
-  the UIx-side equivalent of the Reagent adapter's
-  `inject-source-coord-attr` walk. Production builds elide via
-  `interop/debug-enabled?` per Spec 009 §Production builds."
+  UIx-side equivalent of the Reagent adapter's `inject-source-coord-
+  attr` walk. Production builds elide via `interop/debug-enabled?` per
+  Spec 009 §Production builds."
   [id metadata user-fn]
   (let [coord-attr (when interop/debug-enabled?
                      (format-source-coord id metadata))]
@@ -429,8 +395,8 @@
 
   See Spec 006 §CLJS reference: UIx as alternative substrate.
   Implements the same nine-fn contract as re-frame.adapter.reagent.
-  Per rf2-agql there is no default-adapter registry — adapter wiring
-  is explicit at the call site."
+  There is no default-adapter registry — adapter wiring is explicit at
+  the call site."
   {:kind                      :uix
    :make-state-container      make-state-container
    :read-container            read-container
@@ -442,31 +408,22 @@
    :register-context-provider register-context-provider
    :dispose-adapter!          dispose-adapter!})
 
-;; Each late-bind hook below is routed through `(substrate-adapter/
-;; current-adapter)` per rf2-0d35 via `substrate-adapter/route-hook!`
-;; (see that fn's docstring for the routing contract). The wrapper runs
-;; this adapter's impl ONLY when the UIx adapter is the (rf/init!)-
-;; installed one; otherwise it chains to the previously-registered
-;; handler.
+;; Each hook below is routed through `substrate-adapter/route-hook!`
+;; (see its docstring). UIx-specific notes:
 ;;
-;; Hook-specific rationale (UIx-adapter notes):
-;;   :adapter/current-frame  — rf2-d4sf. UIx renders function
-;;     components — they have no class-component (.-context cmp) slot,
-;;     so the shared impl in `re-frame.adapter.context` reads
-;;     `_currentValue` directly. UIx's own `use-current-frame` hook is
-;;     sugar over the same read, so subscribe / dispatch and
-;;     `use-context` agree on the active frame. Chain-bottom fallback
-;;     is `frame/current-frame`.
-;;   :adapter/ratom etc. — rf2-s36l. UIx's derived values reify stock
-;;     reagent.ratom/IDisposable directly, so these hooks delegate to
-;;     stock Reagent's r/atom, ratom/make-reaction, etc. UIx itself
-;;     ships no reactive-atom primitive (per the rf2-3yij design).
-;;   :adapter/wrap-view — rf2-00li. Substrate-side source-coord
-;;     injection via React.cloneElement (the inline hiccup-walk in
-;;     views.cljs would mis-classify React-element output as a non-DOM
-;;     root). Production-elision: `wrap-view`'s body sits inside
-;;     `(when interop/debug-enabled? ...)` so closure-folds under
-;;     :advanced + goog.DEBUG=false (per Spec 009 §Production builds).
+;;   :adapter/current-frame  — UIx renders function components (no
+;;     class-component `(.-context cmp)` slot), so the shared impl in
+;;     `re-frame.adapter.context` reads `_currentValue` directly. UIx's
+;;     `use-current-frame` hook is sugar over the same read, so
+;;     subscribe / dispatch and `use-context` agree on the active frame.
+;;   :adapter/ratom etc. — UIx's derived values reify stock
+;;     `reagent.ratom/IDisposable` directly, so these hooks delegate to
+;;     stock Reagent. UIx itself ships no reactive-atom primitive.
+;;   :adapter/wrap-view — substrate-side source-coord injection via
+;;     `React.cloneElement` (the inline hiccup walk in views.cljs would
+;;     mis-classify React-element output as a non-DOM root). The body
+;;     sits inside `(when interop/debug-enabled? ...)` so closure-folds
+;;     under :advanced + goog.DEBUG=false.
 (substrate-adapter/route-hook! adapter :adapter/current-frame
   adapter-context/function-component-current-frame
   #(frame/current-frame))
@@ -489,16 +446,11 @@
 (substrate-adapter/route-hook! adapter :adapter/wrap-view
   wrap-view)
 
-;; Per rf2-4edk: contribute a clear of THIS adapter's `warned-non-dom-roots`
-;; cache to the chained `:adapter/clear-warn-once-caches!` hook. The hook
-;; is chained — each adapter (helix, uix) and re-frame.views all contribute
-;; a clear-step; `reset-runtime-fixture` invokes the top of the chain and
-;; every contributor's reset runs (unlike `:adapter/current-frame` etc.
-;; this hook is NOT routed through the installed adapter — every loaded
-;; adapter's cache must clear because test bundles can mount different
-;; adapters across tests and each adapter's defonce persists). Production
-;; behaviour is unchanged: the warn-once `defonce` is still per-process
-;; for users; only test-time clearing is new.
+;; Contributes a clear of THIS adapter's `warned-non-dom-roots` cache to
+;; the chained `:adapter/clear-warn-once-caches!` hook. Unlike the
+;; routed hooks above, this one chains across every loaded adapter —
+;; test bundles can mount different adapters across tests and each
+;; adapter's defonce persists, so all caches must clear.
 (let [previous (late-bind/get-fn :adapter/clear-warn-once-caches!)]
   (late-bind/set-fn! :adapter/clear-warn-once-caches!
     (fn uix-adapter-clear-warn-once-caches! []

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -7,22 +7,21 @@
 
   Topology — this ns is a thin façade:
 
-    - Optional-artefact wrappers (rf2-hoiu) live in `re-frame.core-
-      <feature>` sibling namespaces (`flows`, `routing`, `schemas`,
-      `machines`, `ssr`, `epoch`, `http`); each looks up its target
-      fn through the late-bind hook table so requiring this ns does
-      NOT pull the feature artefacts.
-    - Macro-helper code is factored (per rf2-4rnui) into three
-      siblings — `core-reg-macros`, `core-call-site-macros`,
-      `core-reg-view-macro` — keeping each leaf under the rf2-zkca8
-      250-LoC ceiling. The user-facing `defmacro`s themselves stay in
-      THIS ns (so `rf/reg-event-db` etc. resolve alias-qualified per
-      Clojure's standard `ns-alias/Var` lookup); each is a one-line
-      shell that delegates to the sibling-ns expansion helper.
+    - Optional-artefact wrappers live in `re-frame.core-<feature>`
+      sibling namespaces (`flows`, `routing`, `schemas`, `machines`,
+      `ssr`, `epoch`, `http`); each looks up its target fn through the
+      late-bind hook table so requiring this ns does NOT pull the
+      feature artefacts.
+    - Macro-helper code is factored into three siblings —
+      `core-reg-macros`, `core-call-site-macros`, `core-reg-view-macro`.
+      The user-facing `defmacro`s themselves stay in THIS ns (so
+      `rf/reg-event-db` etc. resolve alias-qualified per Clojure's
+      standard `ns-alias/Var` lookup); each is a one-line shell that
+      delegates to its sibling-ns expansion helper.
 
-  File-naming uses the flat dash-form (`core_X.cljc`, per rf2-2vbm):
-  CLJS `goog.provide` for `re-frame.core` overwrites its parent
-  object, which would wipe a previously-loaded `re-frame.core.X`."
+  File-naming uses the flat dash-form (`core_X.cljc`): CLJS
+  `goog.provide` for `re-frame.core` overwrites its parent object,
+  which would wipe a previously-loaded `re-frame.core.X`."
   (:require [re-frame.registrar :as registrar]
             [re-frame.frame :as frame]
             [re-frame.router :as router]
@@ -50,7 +49,7 @@
             [re-frame.core-ssr      :as rf-ssr]
             [re-frame.core-epoch    :as rf-epoch]
             [re-frame.core-http     :as rf-http]
-            ;; Macro-helper carve-out (rf2-4rnui).
+            ;; Macro-helper carve-out.
             [re-frame.core-reg-macros        :as rm
              #?@(:cljs [:include-macros true])]
             [re-frame.core-call-site-macros  :as csm]
@@ -100,12 +99,10 @@
      (def reg-machine*    rf-machines/reg-machine*)))
 
 ;; ---- reg-* macros (JVM-only; CLJS sees them via :require-macros) --------
-;;
-;; Each `defreg-macro` form below expands (per rf2-bd6zl) to a
-;; `defmacro` IN THIS ns — so `rf/reg-event-db` resolves alias-
-;; qualified per Clojure's `ns-alias/Var` lookup. The expansion
-;; captures source-coords at the user's call site and splices args
-;; through to the fully-qualified delegate fn.
+;; Each `defreg-macro` form below expands to a `defmacro` IN THIS ns —
+;; so `rf/reg-event-db` resolves alias-qualified per Clojure's
+;; `ns-alias/Var` lookup. The expansion captures source-coords at the
+;; user's call site and splices args through to the delegate fn.
 
 #?(:clj
    (do
@@ -154,35 +151,32 @@
 
      (rm/defreg-macro reg-flow rf-flows/reg-flow
        "Register a flow. Captures source-coords (Spec 001) at this
-       call site. Implementation ships in `day8/re-frame2-flows`
-       (rf2-tfw3); apps must add the artefact and require
-       `re-frame.flows` at boot. See `re-frame.core-flows/reg-flow`
-       for the full signature.")
+       call site. Implementation ships in `day8/re-frame2-flows`; apps
+       must add the artefact and require `re-frame.flows` at boot. See
+       `re-frame.core-flows/reg-flow` for the full signature.")
 
      (rm/defreg-macro reg-route rf-routing/reg-route
        "Register a route under `id`. `metadata` is a map keyed at
        minimum on `:path` (URL pattern, Spec 012 §Pattern syntax).
        Captures source-coords (Spec 001) at this call site.
-       Implementation ships in `day8/re-frame2-routing` (rf2-k682);
-       apps must add the artefact and require `re-frame.routing` at
-       boot. See `re-frame.core-routing/reg-route` for the full
-       signature."
+       Implementation ships in `day8/re-frame2-routing`; apps must add
+       the artefact and require `re-frame.routing` at boot. See
+       `re-frame.core-routing/reg-route` for the full signature."
        {:arglists '([id metadata])})
 
      (rm/defreg-macro reg-app-schema rf-schemas/reg-app-schema
        "Register a Malli schema at a path inside app-db (frame-scoped
        per Spec 010). Captures source-coords (Spec 001) at this call
-       site. Implementation ships in `day8/re-frame2-schemas`
-       (rf2-p7va). See `re-frame.core-schemas/reg-app-schema` for the
-       full signature."
+       site. Implementation ships in `day8/re-frame2-schemas`. See
+       `re-frame.core-schemas/reg-app-schema` for the full signature."
        {:arglists '([path schema] [path schema opts])})
 
      (rm/defreg-macro reg-app-schemas rf-schemas/reg-app-schemas
        "Bulk-register a `{path -> schema}` map against the active frame
        (or the `:frame` opt). Plural form of `reg-app-schema`. Captures
        source-coords (Spec 001) at this call site. Implementation ships
-       in `day8/re-frame2-schemas` (rf2-p7va). See
-       `re-frame.core-schemas/reg-app-schemas` for the full signature."
+       in `day8/re-frame2-schemas`. See `re-frame.core-schemas/reg-app-
+       schemas` for the full signature."
        {:arglists '([path->schema] [path->schema opts])})
 
      (rm/defreg-macro reg-error-projector rf-ssr/-reg-error-projector
@@ -206,8 +200,8 @@
      (Spec 001) at this call site plus a per-element coord index under
      `:rf.machine/source-coords` (Spec 005 §Source-coord stamping;
      dev-only — DCE'd under `goog.DEBUG=false`). Implementation ships
-     in `day8/re-frame2-machines` (rf2-xbtj). For runtime registration
-     use `reg-machine*`."
+     in `day8/re-frame2-machines`. For runtime registration use
+     `reg-machine*`."
      [machine-id machine]
      (rm/expand-reg-machine (meta &form)
                             (symbol (str (ns-name *ns*)))
@@ -215,7 +209,7 @@
                             machine-id
                             machine)))
 
-;; ---- public helpers re-exported for test access (rf2-4rnui) -------------
+;; ---- public helpers re-exported for test access ------------------------
 ;;
 ;; Re-exposed because pre-split tests reach `re-frame.core/expand-reg-
 ;; view` and `re-frame.core/parse-reg-view-args` directly. Preserved as
@@ -279,7 +273,7 @@
      (def reg-error-projector -reg-error-projector)
      (def reg-head            -reg-head)))
 
-;; ---- SSR re-exports (Spec 011, rf2-uo7v) ---------------------------------
+;; ---- SSR re-exports (Spec 011) ------------------------------------------
 
 (def render-to-string rf-ssr/render-to-string)
 (def render-tree-hash rf-ssr/render-tree-hash)
@@ -312,10 +306,9 @@
 (def clear-subscription-cache! subs/clear-subscription-cache!)
 
 ;; ---- dispatch and subscribe ----------------------------------------------
-;;
-;; Per rf2-ts1a — each surface ships as a macro + `*`-fn pair (Q1=C).
-;; The macros expand to `re-frame.core/dispatch*` / `subscribe*` etc.,
-;; so those defs must live here.
+;; Each surface ships as a macro + `*`-fn pair. The macros expand to
+;; `re-frame.core/dispatch*` / `subscribe*` etc., so those defs must
+;; live here.
 
 (def dispatch*       router/dispatch!)
 (def dispatch-sync*  router/dispatch-sync!)
@@ -341,8 +334,8 @@
    (defmacro dispatch
      "Enqueue `event-vec` on the target frame's router; returns nil
      immediately, BEFORE the handler runs. Captures call-site coords
-     (rf2-ts1a) for error-trace attribution. For HoF / programmatic use
-     call `dispatch*`. Per Spec 002 §Routing."
+     for error-trace attribution. For HoF / programmatic use call
+     `dispatch*`. Per Spec 002 §Routing."
      ([event-vec]
       (csm/build-dispatch-form (meta &form) (symbol (str (ns-name *ns*))) *file*
                                event-vec nil))
@@ -355,8 +348,8 @@
      "Run `event-vec` end-to-end synchronously; the router drains to
      fixed point. For tests / REPL / bootstrap only — never call from
      inside a running event handler (raises `:rf.error/dispatch-sync-
-     in-handler`). Captures call-site coords (rf2-ts1a). For HoF /
-     programmatic use call `dispatch-sync*`. Per Spec 002 §dispatch-sync."
+     in-handler`). Captures call-site coords. For HoF / programmatic
+     use call `dispatch-sync*`. Per Spec 002 §dispatch-sync."
      ([event-vec]
       (csm/build-dispatch-sync-form (meta &form) (symbol (str (ns-name *ns*))) *file*
                                     event-vec nil))
@@ -370,8 +363,8 @@
      output for `query-v` (`[sub-id & args]`); deref to read. 2-arity
      targets an explicit frame, otherwise resolves via `current-frame`.
      Use `subscribe-value` for a one-shot read; use `subscribe*` for
-     HoF / programmatic callers. Captures call-site coords (rf2-ts1a).
-     Per Spec 006 §Lookup algorithm."
+     HoF / programmatic callers. Captures call-site coords. Per Spec
+     006 §Lookup algorithm."
      ([query-v]
       (csm/build-subscribe-form (meta &form) (symbol (str (ns-name *ns*))) *file*
                                 nil query-v))
@@ -385,9 +378,9 @@
      Builds a `:before`-only interceptor that runs the cofx registered
      under `cofx-id` and merges its result into the handler's
      `:coeffects`. 2-arity `(inject-cofx :id value)` passes a per-call
-     value. Captures call-site coords (rf2-ts1a). For HoF / programmatic
-     use call `inject-cofx*`. See `re-frame.cofx/inject-cofx` for the
-     full signature."
+     value. Captures call-site coords. For HoF / programmatic use call
+     `inject-cofx*`. See `re-frame.cofx/inject-cofx` for the full
+     signature."
      ([cofx-id]
       (csm/build-inject-cofx-form (meta &form) (symbol (str (ns-name *ns*))) *file*
                                   cofx-id nil))
@@ -396,12 +389,9 @@
                                   cofx-id value))))
 
 ;; ---- frame-aware closures (runtime side) ---------------------------------
-;;
-;; Per rf2-d4sf the public `current-frame` exposes the 3-tier resolution
-;; chain (dynamic var → React context → `:rf/default`) at every user-
-;; facing surface that flows through `(dispatcher)` / `(subscriber)` /
-;; `bound-fn`. The chain is single-sourced through
-;; `frame/resolve-current-frame` (rf2-jj8xf).
+;; `current-frame` exposes the 3-tier resolution chain (dynamic var →
+;; React context → `:rf/default`); single-sourced through
+;; `frame/resolve-current-frame`.
 
 (defn current-frame
   "Return the active frame at the call site. Resolution chain: dynamic
@@ -467,7 +457,7 @@
    (defmacro with-managed-request-stubs
      "Install stubs, run body, uninstall. `stubs` is
      `{[method url] {:reply <:ok|:failure>}}`. Implementation ships in
-     `day8/re-frame2-http` (rf2-5kpd). Per Spec 014 §Testing."
+     `day8/re-frame2-http`. Per Spec 014 §Testing."
      [stubs & body]
      `(re-frame.core/with-managed-request-stubs* ~stubs (fn [] ~@body))))
 
@@ -487,10 +477,9 @@
 (def route-link  rf-routing/route-link)
 
 ;; ---- machine helpers ------------------------------------------------------
-;;
 ;; Plain-fn `reg-machine*` for code-gen pipelines / conformance corpus
 ;; registering without a literal spec form. Per Spec 005 §reg-machine vs
-;; reg-machine* (rf2-8bp3).
+;; reg-machine*.
 
 #?(:clj
    (def reg-machine* rf-machines/reg-machine*))
@@ -628,13 +617,12 @@
                   (cond-> {:where    'rf/init!
                            :expected "adapter spec map"
                            :recovery :no-recovery
-                           :reason   "rf/init! takes the adapter spec map directly — there is no keyword form, no nil form, and no default-adapter registry. Require the adapter ns and pass its `adapter` Var: (rf/init! reagent/adapter). Per rf2-agql the default-adapter registry was removed."}
+                           :reason   "rf/init! takes the adapter spec map directly — there is no keyword form, no nil form, and no default-adapter registry. Require the adapter ns and pass its `adapter` Var: (rf/init! reagent/adapter)."}
                     (some? received) (assoc :received received)))))
 
 (defn init!
   "Idempotent boot — installs a substrate adapter and ensures the
-  `:rf/default` frame exists. Pass the adapter spec map directly (no
-  default-adapter registry; rf2-agql):
+  `:rf/default` frame exists. Pass the adapter spec map directly:
     (require '[re-frame.adapter.reagent :as reagent])
     (rf/init! reagent/adapter)
   Non-map / nil raises `:rf.error/no-adapter-specified`. Per Spec 006

--- a/implementation/core/src/re_frame/core_epoch.cljc
+++ b/implementation/core/src/re_frame/core_epoch.cljc
@@ -1,27 +1,17 @@
 (ns re-frame.core-epoch
   "Public-API wrappers for the optional epoch artefact (Tool-Pair
   §Time-travel). Implementation ships in `day8/re-frame2-epoch`
-  (`re-frame.epoch` ns) per rf2-lt4e.
+  (`re-frame.epoch` ns).
 
-  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
-  look the producing fns up via the late-bind hook table at call time;
-  consumers reach the surfaces through `re-frame.core` re-exports.
+  See [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention).
 
-  Per-feature carve-out: the epoch artefact pulls the per-frame
-  `:rf/epoch-record` ring buffer, the per-cascade trace-capture path,
-  the `:sub-runs` / `:renders` / `:effects` projection walker, and
-  every `:rf.epoch/*` keyword string. The entire epoch surface is also
-  gated on `interop/debug-enabled?` (Tool-Pair §Time-travel §Production
-  elision).
+  The entire epoch surface is gated on `interop/debug-enabled?` so
+  production builds DCE.
 
   Absent-artefact behaviour: wrappers degrade silently (empty vector /
-  `false` / no-op) so a release build that omits the artefact does not
-  raise. `reset-frame-db!` is the exception — it records an epoch as
-  part of its contract and raises `:rf.error/epoch-artefact-missing`.
-
-  Per rf2-h824v the wrappers below are emitted by the
-  `re-frame.core-artefact/defwrapper` factory from a declarative table —
-  one row per public surface."
+  `false` / no-op). `reset-frame-db!` is the exception — it records an
+  epoch as part of its contract, so it raises
+  `:rf.error/epoch-artefact-missing` when the artefact is absent."
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]))
 
@@ -69,7 +59,7 @@
 
 (defwrapper reset-frame-db!
   "Replace `frame-id`'s `app-db` with `new-db`, bypassing the dispatch
-  loop. Per Tool-Pair §Pair-tool writes (rf2-zq55).
+  loop. Per Tool-Pair §Pair-tool writes.
 
   The canonical Tool-Pair write surface for state injection — pair
   tools use it for evolved-state-shape probes after a handler hot-swap,

--- a/implementation/core/src/re_frame/core_flows.cljc
+++ b/implementation/core/src/re_frame/core_flows.cljc
@@ -1,20 +1,8 @@
 (ns re-frame.core-flows
   "Public-API wrappers for the optional flows artefact (Spec 013).
-  Implementation ships in `day8/re-frame2-flows` (`re-frame.flows`
-  ns) per rf2-tfw3.
+  Implementation ships in `day8/re-frame2-flows` (`re-frame.flows` ns).
 
-  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
-  look the producing fns up via the late-bind hook table at call time;
-  consumers reach the surfaces through `re-frame.core` re-exports.
-
-  Per-feature carve-out: the flows artefact pulls the per-frame flow
-  registry, the topological-sort engine, and the dirty-check
-  `last-inputs` map — none of which appear on a consumer's classpath
-  when this wrapper's hooks are unregistered.
-
-  Per rf2-h824v the wrappers below are emitted by the
-  `re-frame.core-artefact/defwrapper` factory from a declarative table —
-  one row per public surface."
+  See [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention)."
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]))
 

--- a/implementation/core/src/re_frame/core_http.cljc
+++ b/implementation/core/src/re_frame/core_http.cljc
@@ -1,22 +1,9 @@
 (ns re-frame.core-http
   "Public-API wrappers for the optional managed-HTTP artefact (Spec 014).
-  Implementation ships in `day8/re-frame2-http`
-  (`re-frame.http-managed` ns) per rf2-5kpd.
+  Implementation ships in `day8/re-frame2-http` (`re-frame.http-managed`
+  ns).
 
-  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
-  look the producing fns up via the late-bind hook table at call time;
-  consumers reach the surfaces through `re-frame.core` re-exports.
-
-  Per-feature carve-out: the http artefact pulls the in-flight request
-  registry, the Fetch / `java.net.http.HttpClient` transport adapters,
-  the encode/decode pipeline, the retry-with-backoff machinery, the
-  eight-category `:rf.http/*` failure taxonomy, and every `:rf.http/*`
-  keyword string — none of which appear on a consumer's classpath when
-  this wrapper's hooks are unregistered.
-
-  Per rf2-h824v the wrappers below are emitted by the
-  `re-frame.core-artefact/defwrapper` factory from a declarative table —
-  one row per public surface."
+  See [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention)."
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]))
 
@@ -47,7 +34,7 @@
   {:hook :http/with-managed-request-stubs* :artefact http-artefact :on-absent :throw}
   ([stubs thunk] :delegate))
 
-;; ---- Spec 014 §Middleware — per-frame request interceptors (rf2-6y3q) -----
+;; ---- Spec 014 §Middleware — per-frame request interceptors --------------
 
 (defwrapper reg-http-interceptor
   "Spec 014 §Middleware — register a request-side interceptor on a

--- a/implementation/core/src/re_frame/core_machines.cljc
+++ b/implementation/core/src/re_frame/core_machines.cljc
@@ -1,24 +1,15 @@
 (ns re-frame.core-machines
   "Public-API wrappers for the optional machines artefact (Spec 005).
-  Implementation ships in `day8/re-frame2-machines`
-  (`re-frame.machines` ns) per rf2-xbtj.
+  Implementation ships in `day8/re-frame2-machines` (`re-frame.machines`
+  ns).
 
-  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
-  look the producing fns up via the late-bind hook table at call time;
-  consumers reach the surfaces through `re-frame.core` re-exports.
+  See [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention).
 
-  Per-feature carve-out: the machines artefact pulls the machine
-  registry, the entry/exit cascade engine, and the `:rf/machine` /
-  `:rf/machine-has-tag?` framework subs — none of which appear on a
-  consumer's classpath when this wrapper's hooks are unregistered.
-
-  Per rf2-h824v the canonical late-bind wrappers below are emitted by
-  the `re-frame.core-artefact/defwrapper` factory. `reg-machine` /
-  `reg-machine*` keep a bespoke shape — they share the `:where`-symbol
-  parameter via `reg-machine-impl` so the macro and the plain-fn
-  surface raise with their own faithful `:where` symbol. Sugar fns
-  (`dispatch-to-system`, `sub-machine`, `has-tag?`) are not late-bind
-  surfaces — they layer over `router/dispatch!` / `subs/subscribe`."
+  `reg-machine` / `reg-machine*` keep a bespoke shape — they share the
+  `:where`-symbol parameter via `reg-machine-impl` so the macro and the
+  plain-fn surface each raise with their own faithful `:where` symbol.
+  Sugar fns (`dispatch-to-system`, `sub-machine`, `has-tag?`) layer
+  over `router/dispatch!` / `subs/subscribe`."
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]
             [re-frame.late-bind :as late-bind]
@@ -71,11 +62,10 @@
   ([system-id]          :delegate)
   ([system-id frame-id] :delegate))
 
-;; ---- reg-machine* / reg-machine — bespoke per rf2-8bp3 -------------------
-;;
-;; Both surfaces share the late-bind throw via `reg-machine-impl` but stamp
-;; their own `:where` symbol on the missing-artefact ex-info so the trace
-;; matches what the user wrote at the call site.
+;; ---- reg-machine* / reg-machine -----------------------------------------
+;; Both share the late-bind throw via `reg-machine-impl` but stamp their
+;; own `:where` symbol so the missing-artefact ex-info matches what the
+;; user wrote at the call site.
 
 (defn ^:private reg-machine-impl
   "Shared impl behind both `reg-machine*` (plain-fn surface) and the
@@ -92,11 +82,11 @@
 
 (defn reg-machine*
   "Plain-fn surface for machine registration. Per Spec 005 §reg-machine
-  vs reg-machine* (rf2-8bp3). Used by code-gen pipelines that already
-  carry a stamped spec, REPL workflows that bypass the macro path, and
-  the macro's own emitted form. Programmatic callers see no
-  per-element source-coord index (only the macro can walk the literal
-  spec at expansion time). Late-bound via :machines/reg-machine."
+  vs reg-machine*. Used by code-gen pipelines that already carry a
+  stamped spec, REPL workflows that bypass the macro path, and the
+  macro's own emitted form. Programmatic callers see no per-element
+  source-coord index (only the macro can walk the literal spec at
+  expansion time)."
   [machine-id machine]
   (reg-machine-impl 'rf/reg-machine* machine-id machine))
 
@@ -143,7 +133,7 @@
   snapshot's `:tags` set contains `tag` — `false` for an unknown or
   not-yet-initialised machine.
 
-  Per Spec 005 §State tags (rf2-ee0d / Nine States Stage 1).
+  Per Spec 005 §State tags.
 
   Composable with the rest of the sub graph (a Layer-3 sub may chain
   off this one) and elides on production builds the same way every

--- a/implementation/core/src/re_frame/core_routing.cljc
+++ b/implementation/core/src/re_frame/core_routing.cljc
@@ -1,21 +1,9 @@
 (ns re-frame.core-routing
   "Public-API wrappers for the optional routing artefact (Spec 012).
-  Implementation ships in `day8/re-frame2-routing`
-  (`re-frame.routing` ns) per rf2-k682.
+  Implementation ships in `day8/re-frame2-routing` (`re-frame.routing`
+  ns).
 
-  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
-  look the producing fns up via the late-bind hook table at call time;
-  consumers reach the surfaces through `re-frame.core` re-exports.
-
-  Per-feature carve-out (relative to the canonical convention): the
-  routing artefact pulls the route-rank / pattern-compile / nav-token
-  machinery, the `:rf/route` reg-sub family, and every `:rf.route/*` /
-  `:rf.nav/*` keyword string — none of which appear on a consumer's
-  classpath when this wrapper's hooks are unregistered.
-
-  Per rf2-h824v the wrappers below are emitted by the
-  `re-frame.core-artefact/defwrapper` factory from a declarative table —
-  one row per public surface."
+  See [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention)."
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]))
 

--- a/implementation/core/src/re_frame/core_schemas.cljc
+++ b/implementation/core/src/re_frame/core_schemas.cljc
@@ -1,20 +1,13 @@
 (ns re-frame.core-schemas
   "Public-API wrappers for the optional schemas artefact (Spec 010).
-  Implementation ships in `day8/re-frame2-schemas`
-  (`re-frame.schemas` ns) per rf2-p7va.
+  Implementation ships in `day8/re-frame2-schemas` (`re-frame.schemas`
+  ns).
 
-  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
-  look the producing fns up via the late-bind hook table at call time;
-  consumers reach the surfaces through `re-frame.core` re-exports.
+  See [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention).
 
-  Per-feature carve-out: the schemas artefact pulls Malli (the default
-  validator) onto the classpath — apps that want to drop the ~24 KB
-  gzipped Malli surface omit the artefact and either use a substitute
-  validator (per rf2-froe) or skip schema validation entirely.
-
-  Per rf2-h824v the wrappers below are emitted by the
-  `re-frame.core-artefact/defwrapper` factory from a declarative table —
-  one row per public surface."
+  Apps that want to drop the ~24 KB gzipped Malli surface omit the
+  artefact and either install a substitute validator (see
+  `set-schema-validator!`) or skip schema validation entirely."
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]))
 
@@ -51,10 +44,9 @@
 
 (defwrapper set-schema-validator!
   "Register the validator fn that every dev-time schema-validation site
-  routes through. Per Spec 010 §Non-Malli validators (rf2-froe) the
-  seam is the substitute-Malli extension point — apps that want to
-  drop the ~24 KB gzipped Malli surface (rf2-qnxf bundle audit) swap
-  in their own validator at boot.
+  routes through. Per Spec 010 §Non-Malli validators the seam is the
+  substitute-Malli extension point — apps that want to drop the ~24 KB
+  gzipped Malli surface swap in their own validator at boot.
 
   Argument shapes:
 
@@ -75,20 +67,19 @@
 (defwrapper set-schema-explainer!
   "Register the explainer fn — `(fn [schema value] explanation)` — used
   to enrich schema-validation-failure traces' `:explain` key. Per
-  Spec 010 §Non-Malli validators (rf2-froe). See
-  `set-schema-validator!` for the validator companion. Returns nil
-  when the schemas artefact is not on the classpath."
+  Spec 010 §Non-Malli validators. See `set-schema-validator!` for the
+  validator companion. Returns nil when the schemas artefact is not on
+  the classpath."
   {:hook :schemas/set-schema-explainer! :artefact schemas-artefact :on-absent :nil}
   ([explain-fn] :delegate))
 
 (defwrapper set-schema-printer!
   "Register the schema-print companion — `(fn [schema-value]
   canonical-string)` — the digest pipeline hashes (Spec 010 §Schema
-  digest line 491, rf2-wla45). Parallel to `set-schema-validator!`
-  and `set-schema-explainer!`: ports that ship a non-Malli schema
-  language register their own serialiser so the digest reflects the
-  validator's own contract rather than the framework's Malli-EDN
-  default.
+  digest line 491). Parallel to `set-schema-validator!` and
+  `set-schema-explainer!`: ports that ship a non-Malli schema language
+  register their own serialiser so the digest reflects the validator's
+  own contract rather than the framework's Malli-EDN default.
 
   The fn MUST be pure and cross-runtime deterministic — a CLJS
   server and a CLJS client running the same schema set MUST produce
@@ -112,9 +103,8 @@
 
 (defwrapper reg-app-schemas
   "Bulk-register `{path -> schema}` against the active frame (or the
-  `:frame` opt). Per rf2-jzs9 — the plural form of `reg-app-schema`,
-  aimed at feature-modular apps (per Conventions §Feature-modularity
-  prefix convention).
+  `:frame` opt). Plural form of `reg-app-schema`, aimed at feature-
+  modular apps (per Conventions §Feature-modularity prefix convention).
 
   Shape:
 

--- a/implementation/core/src/re_frame/core_ssr.cljc
+++ b/implementation/core/src/re_frame/core_ssr.cljc
@@ -1,23 +1,8 @@
 (ns re-frame.core-ssr
   "Public-API wrappers for the optional SSR artefact (Spec 011).
-  Implementation ships in `day8/re-frame2-ssr` (`re-frame.ssr` ns)
-  per rf2-uo7v.
+  Implementation ships in `day8/re-frame2-ssr` (`re-frame.ssr` ns).
 
-  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
-  look the producing fns up via the late-bind hook table at call time;
-  consumers reach the surfaces through `re-frame.core` re-exports.
-
-  Per-feature carve-out: the SSR artefact pulls the hiccup → HTML
-  emitter, the FNV-1a render-tree-hash machinery, the per-request HTTP
-  response accumulator (a framework-private side-channel atom per
-  rf2-jbcmt), the six `:rf.server/*` fxs, the `reg-error-projector`
-  registry kind plus its default, the `:rf/hydrate` event, and every
-  `:rf.ssr/*` / `:rf.server/*` keyword string — none of which appear
-  on a consumer's classpath when this wrapper's hooks are unregistered.
-
-  Per rf2-h824v the wrappers below are emitted by the
-  `re-frame.core-artefact/defwrapper` factory from a declarative table —
-  one row per public surface."
+  See [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention)."
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]))
 
@@ -70,13 +55,8 @@
    :ex-data {:frame frame-id}}
   ([frame-id trace-event] :delegate))
 
-;; ---- Head/meta contract — rf2-4dra9 --------------------------------------
-;;
-;; Per Spec 011 §Head/meta contract. `re-frame.ssr.head` ships the impl;
-;; the wrappers below look the producing fns up through the late-bind hook
-;; table so core never statically requires re-frame.ssr.head. Apps that
-;; don't pull `day8/re-frame2-ssr` see `:rf.error/ssr-artefact-missing`
-;; when these surfaces are called.
+;; ---- Head/meta contract -------------------------------------------------
+;; Per Spec 011 §Head/meta contract. `re-frame.ssr.head` ships the impl.
 
 (defwrapper -reg-head
   "Internal helper — prefer `reg-head` from public callers. This is the

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -237,17 +237,15 @@
   {:id         id
    :app-db     (adapter/make-state-container {})
    :router     (atom {:queue interop/empty-queue :scheduled? false})
-   ;; Per rf2-ynk7 §single-drainer invariant: a separate CAS-able cell
-   ;; that admits at most one thread into `drain!` at a time. On the JVM
-   ;; the executor's `next-tick` callback can wake while the calling
-   ;; thread is mid-drain (e.g. `dispatch-sync!`); without this guard,
-   ;; both threads' peek+pop sequence on `:queue` is non-atomic and
-   ;; double-processes / drops envelopes (the rf2-lmkk #442 flake). The
-   ;; loser of the CAS no-ops; the winning drainer rechecks the queue
-   ;; before releasing the flag so envelopes queued in the gap are not
-   ;; orphaned. CLJS is single-threaded so the CAS is uncontended there,
-   ;; but the same flag preserves the contract under any future
-   ;; concurrent host.
+   ;; Single-drainer invariant: a CAS-able cell that admits at most one
+   ;; thread into `drain!` at a time. On the JVM the executor's
+   ;; `next-tick` callback can wake while the calling thread is mid-
+   ;; drain (e.g. `dispatch-sync!`); without this guard, both threads'
+   ;; peek+pop sequence on `:queue` is non-atomic and double-processes /
+   ;; drops envelopes. The loser of the CAS no-ops; the winning drainer
+   ;; rechecks the queue before releasing the flag so envelopes queued
+   ;; in the gap are not orphaned. CLJS is single-threaded so the CAS
+   ;; is uncontended there.
    :drain-lock (atom false)
    :sub-cache  (atom {})
    :lifecycle  {:created-at (interop/now-ms)
@@ -273,28 +271,21 @@
         (nil? existing)
         (let [f (new-frame-record id config)]
           (swap! frames assoc id f)
-          ;; Run :on-create events BEFORE emitting :frame/created.
-          ;; Per Spec 002 §Frame creation: on-create completes (or — for
-          ;; the in-handler case below — is queued) first, then the
-          ;; frame is observable to listeners. The router/dispatch
-          ;; namespace handles dispatch / dispatch-sync; we forward via
-          ;; the late-bind registry to avoid a cyclic dep at compile
-          ;; time. (`resolve` is not a runtime fn in CLJS, so the older
-          ;; `(resolve 'router/...)` pattern silently no-op'd in CLJS —
-          ;; see rf2-p8g8.)
+          ;; Run :on-create events BEFORE emitting :frame/created so
+          ;; on-create completes (or — for the in-handler case — is
+          ;; queued) first, then the frame is observable. Forward via
+          ;; the late-bind registry to avoid a cyclic compile-time dep
+          ;; on the router ns.
           ;;
-          ;; Per rf2-cufbh / Spec 002 §`reg-frame` / `make-frame` called
-          ;; from inside a handler: when a handler creates a child
-          ;; frame mid-cascade, the child's `:on-create` MUST be queued
-          ;; asynchronously on the child's router (not dispatch-sync'd)
-          ;; — synchronous dispatch-sync from inside a handler is an
-          ;; error per Spec 002 §dispatch-sync inside a handler is an
-          ;; error, and even were it permitted the two cascades would
-          ;; interleave (the no-cross-frame-drain rule in Spec 002
-          ;; §Run-to-completion forbids that). The signal for "inside
-          ;; a handler" is `frame/*current-frame*` being bound — the
-          ;; router binds it in `process-event!` for the duration of
-          ;; the cascade.
+          ;; When a handler creates a child frame mid-cascade the
+          ;; child's `:on-create` MUST be queued asynchronously on the
+          ;; child's router — `dispatch-sync` from inside a handler is
+          ;; an error per Spec 002 §dispatch-sync inside a handler, and
+          ;; even were it permitted the two cascades would interleave
+          ;; (the no-cross-frame-drain rule in §Run-to-completion
+          ;; forbids that). The signal for "inside a handler" is
+          ;; `*current-frame*` being bound — the router binds it in
+          ;; `process-event!` for the duration of the cascade.
           (when-let [on-create (:on-create config)]
             (if *current-frame*
               ;; Handler-created child frame: async-queue on the child.
@@ -325,11 +316,9 @@
     id))
 
 ;; ---- destruction ----------------------------------------------------------
-;;
-;; destroy-frame! runs an ordered teardown. Each step lives in its own
-;; named helper so the body of destroy-frame! reads as documentation; the
-;; helper names ARE the step list. Order matters — see destroy-frame!'s
-;; docstring and Spec 002 §Destroy.
+;; Ordered teardown — each step lives in its own named helper so
+;; `destroy-frame!`'s body reads as documentation. Order matters; see
+;; `destroy-frame!`'s docstring and Spec 002 §Destroy.
 
 (defn- safe-call-hook!
   "Fire a late-bound cleanup hook by key. No-op when the hook is unbound
@@ -343,7 +332,7 @@
          (catch #?(:clj Throwable :cljs :default) _ nil))))
 
 (defn- fire-on-destroy-event!
-  "Step 1. Fire the user-supplied :on-destroy event before any lifecycle
+  "Fire the user-supplied :on-destroy event before any lifecycle
   mutation, so handlers still observe an alive frame. No-op when the
   frame has no :on-destroy or when the router artefact is absent."
   [id f]
@@ -352,25 +341,17 @@
       (dispatch-sync on-destroy {:frame id}))))
 
 (defn- notify-machine-destruction!
-  "Step 2 (with interleaved 2a). For every machine that has an active
-  snapshot under [:rf/machines ...] in app-db:
-
-    2a. Fire the rf2-wvkn HTTP abort hook (Spec 005 §Cancellation
-        cascade — frame-destroy is a documented destroy trigger).
-        Late-bound; nil when the http artefact is absent. Runs BEFORE
-        the trace event so observers see abort-then-destroy ordering.
-    2.  Emit ONE :rf.machine.lifecycle/destroyed trace per actor
-        snapshot, carrying :reason :parent-frame-destroyed under :tags.
-        Pairs with :rf.machine.lifecycle/created emitted at reg-machine
-        so lifecycle observers see one consistent op-type for create
-        AND destroy across every cause and code path. The :reason tag
-        discriminates why the actor went away — frame-exit emits
-        :parent-frame-destroyed; the fx-substrate's :rf.machine/destroyed
-        emit-site (lifecycle_fx.cljc) carries the other reasons
-        (:rf.machine/finished, :explicit, :parent-unmount-cascade).
+  "For every machine with an active snapshot under [:rf/machines ...]:
+  fire the HTTP abort hook (Spec 005 §Cancellation cascade — late-bound,
+  nil when http is absent), then emit one
+  `:rf.machine.lifecycle/destroyed` trace per snapshot carrying
+  `:reason :parent-frame-destroyed`. Pairs with the
+  `:rf.machine.lifecycle/created` emitted at reg-machine. The fx-
+  substrate's `:rf.machine/destroyed` site carries the other reasons
+  (`:rf.machine/finished` / `:explicit` / `:parent-unmount-cascade`).
 
   Full automatic exit-cascade would require storing every machine def
-  in a registry, which is out of scope for the v1 closed kind set."
+  in a registry, out of scope for the v1 closed kind set."
   [id]
   (let [container  (get-frame-db id)
         db         (when container (adapter/read-container container))
@@ -387,7 +368,7 @@
                     :reason     :parent-frame-destroyed}))))
 
 (defn- mark-frame-destroyed!
-  "Step 3. Flip :lifecycle :destroyed? so subsequent dispatch / subscribe
+  "Flip :lifecycle :destroyed? so subsequent dispatch / subscribe
   against this frame raises :rf.error/frame-destroyed. Done before
   sub-cache disposal so a racing reaction can't re-enter on a frame
   that's mid-teardown."
@@ -395,9 +376,9 @@
   (swap! frames update id assoc-in [:lifecycle :destroyed?] true))
 
 (defn- tear-down-sub-cache!
-  "Step 4. Walk every cached reaction in the frame's sub-cache and
-  dispose it; clear the cache atom. Disposal exceptions are swallowed
-  so one bad on-dispose can't block the rest of teardown."
+  "Walk every cached reaction in the frame's sub-cache and dispose it;
+  clear the cache atom. Disposal exceptions are swallowed so one bad
+  on-dispose can't block the rest of teardown."
   [f]
   (when-let [cache (:sub-cache f)]
     (doseq [[_k entry] @cache]
@@ -407,80 +388,66 @@
     (reset! cache {})))
 
 (defn- emit-frame-destroyed-trace!
-  "Step 5. Emit the :frame/destroyed trace, AFTER the per-machine
-  cascade so listeners see machines-then-frame ordering."
+  "Emit the :frame/destroyed trace, AFTER the per-machine cascade so
+  listeners see machines-then-frame ordering."
   [id]
   (trace/emit! :frame :frame/destroyed
                {:frame id}))
 
 (defn- dissoc-frame!
-  "Step 6. Remove the frame record from the `frames` atom so subsequent
-  lookups return nil."
+  "Remove the frame record from the `frames` atom so subsequent lookups
+  return nil."
   [id]
   (swap! frames dissoc id))
 
 (defn- unregister-frame!
-  "Step 7. Per Spec 001 §Hot-reload semantics — drop the frame from the
-  registrar, surfacing :rf.registry/handler-cleared so tools tracking
-  the live registry observe the slot freed."
+  "Drop the frame from the registrar, surfacing
+  `:rf.registry/handler-cleared` so tools tracking the live registry
+  observe the slot freed. Per Spec 001 §Hot-reload semantics."
   [id]
   (registrar/unregister! :frame id))
 
 (defn- notify-epoch-listeners!
-  "Step 8. Per Tool-Pair §Surface behaviour against destroyed frames
-  (rf2-d656): emit a one-shot :rf.epoch.cb/silenced-on-frame-destroy
-  for every register-epoch-cb! listener that previously observed this
-  frame. Late-bound through the hook table so core never statically
-  requires the epoch artefact."
+  "Emit a one-shot `:rf.epoch.cb/silenced-on-frame-destroy` for every
+  `register-epoch-cb!` listener that previously observed this frame.
+  Per Tool-Pair §Surface behaviour against destroyed frames. Late-bound
+  so core never statically requires the epoch artefact."
   [id]
   (safe-call-hook! :epoch/on-frame-destroyed id))
 
 (defn destroy-frame!
   "Tear down a frame. Per Spec 002 §Destroy, the ordered steps are:
 
-    1. fire-on-destroy-event!       — run the user :on-destroy event
-                                      while the frame is still alive.
-    2. notify-machine-destruction!  — for each active machine snapshot:
-                                      (2a) fire the rf2-wvkn HTTP abort
-                                      hook, then emit the unified
-                                      :rf.machine.lifecycle/destroyed
-                                      trace (one per snapshot) carrying
-                                      :reason :parent-frame-destroyed.
+    1. fire-on-destroy-event!       — run the user :on-destroy while the
+                                      frame is still alive.
+    2. notify-machine-destruction!  — abort + emit destroy trace for each
+                                      active machine snapshot.
     3. mark-frame-destroyed!        — flip :lifecycle :destroyed?.
     4. tear-down-sub-cache!         — dispose every cached reaction.
     5. emit-frame-destroyed-trace!  — emit :frame/destroyed.
     6. dissoc-frame!                — remove from the `frames` atom.
     7. unregister-frame!            — drop from the registrar.
-    8. notify-epoch-listeners!      — fire the rf2-d656 epoch hook.
+    8. notify-epoch-listeners!      — fire the epoch artefact's hook.
 
-  Two cleanup hooks fire between step 4 and step 5 — both are best-
-  effort and tolerate the hook artefact being absent at runtime:
+  Three best-effort cleanup hooks fire between step 4 and step 5 — each
+  tolerates the hook artefact being absent at runtime:
 
-    :privacy/clear-suppression-cache!   — rf2-isdwf, reset the warn-once
-                                          cache so a re-registered frame
-                                          re-emits the sensitive-without-
-                                          redaction warning if mis-config.
-    :ssr/on-frame-destroyed             — rf2-fcj33, drop the SSR
-                                          side-channel atoms' entries
-                                          for the destroyed frame
+    :privacy/clear-suppression-cache!   — reset the warn-once cache so a
+                                          re-registered frame re-emits
+                                          the sensitive-without-redaction
+                                          warning if mis-configured.
+    :ssr/on-frame-destroyed             — drop the SSR side-channel atoms'
+                                          entries for the destroyed frame
                                           (pending-error-traces +
                                           request-slots). Without this
-                                          hook those two defonce atoms
-                                          accumulate one entry per
-                                          request under SSR load — a
-                                          slow leak that compounds over
-                                          a long-running server process.
-    :machines/on-frame-destroyed!       — rf2-ysa94, clear the machines
-                                          artefact's frame-scoped
-                                          `:after` timer table for the
-                                          destroyed frame and release
-                                          any in-flight host-clock
-                                          handles / subscription
-                                          watchers belonging to that
-                                          frame. Without this hook the
-                                          destroyed frame's inner table
-                                          would linger and live timers
-                                          would survive teardown.
+                                          hook each request leaks one
+                                          entry under SSR load.
+    :machines/on-frame-destroyed!       — clear the machines artefact's
+                                          frame-scoped `:after` timer
+                                          table and release in-flight
+                                          host-clock handles / sub
+                                          watchers for the destroyed
+                                          frame.
 
   Subsequent dispatch / subscribe against a destroyed frame raises
   :rf.error/frame-destroyed."
@@ -490,30 +457,8 @@
     (notify-machine-destruction! id)
     (mark-frame-destroyed! id)
     (tear-down-sub-cache! f)
-    ;; Per rf2-isdwf / Spec 009 §Privacy: reset the
-    ;; sensitive-without-redaction warning suppression cache so a
-    ;; re-registration after frame teardown (test fixtures, hot
-    ;; reload that destroys and re-creates the frame) re-emits the
-    ;; warning if still mis-configured. No-op when re-frame.privacy
-    ;; hasn't been loaded.
     (safe-call-hook! :privacy/clear-suppression-cache!)
-    ;; Per rf2-fcj33 / Spec 011 §Per-request frame teardown contract:
-    ;; clear the SSR side-channel atoms (pending-error-traces +
-    ;; request-slots) for the destroyed frame. Both live outside app-db
-    ;; for documented design reasons (the buffered-traces sidestep an
-    ;; app-db clobber race; the request slot keeps host-controlled
-    ;; data out of the hydration payload). Neither is otherwise cleared
-    ;; by destroy-frame's app-db / sub-cache teardown, so under SSR
-    ;; load each request would leak one entry in each atom. No-op when
-    ;; re-frame.ssr is absent.
     (safe-call-hook! :ssr/on-frame-destroyed id)
-    ;; Per rf2-ysa94 / Spec 005 §Delayed `:after` transitions: clear the
-    ;; machines artefact's frame-scoped `:after` timer table for the
-    ;; destroyed frame. The table is partitioned per frame; without this
-    ;; hook the destroyed frame's inner-table would linger as dead
-    ;; bookkeeping and any in-flight host-clock handles would survive
-    ;; teardown. No-op when re-frame.machines is absent (the artefact
-    ;; is optional).
     (safe-call-hook! :machines/on-frame-destroyed! id)
     (emit-frame-destroyed-trace! id)
     (dissoc-frame! id)

--- a/implementation/core/src/re_frame/interop.cljs
+++ b/implementation/core/src/re_frame/interop.cljs
@@ -1,16 +1,13 @@
 (ns re-frame.interop
-  "CLJS host primitives. Everything platform-specific lives here.
-
-  See Spec 002 §Interop layer and Spec 005 §Interop layer.
-
-  All other namespaces depend only on these abstractions, not on
-  goog/reagent/js* directly. A non-CLJS port replaces this file; the rest
-  of the runtime is host-agnostic in shape.
+  "CLJS host primitives. Everything platform-specific lives here, so the
+  rest of the runtime stays host-agnostic in shape (Spec 002 §Interop
+  layer; Spec 005 §Interop layer).
 
   Reactive-substrate surfaces (`ratom`, `ratom?`, `make-reaction`,
   `add-on-dispose!`, `dispose!`, `reactive?`, `after-render`) dispatch
-  through the late-bind hook table per rf2-s36l. The active adapter
-  publishes its substrate's impls at ns-load time:
+  through the late-bind hook table so the active adapter wires in its
+  own substrate without this ns statically `:require`-ing any one of
+  them. The published hooks are:
 
     :adapter/ratom            — (fn [v])         → ratom
     :adapter/ratom?           — (fn [x])         → boolean
@@ -18,41 +15,7 @@
     :adapter/add-on-dispose!  — (fn [a-ratom f]) → nil
     :adapter/dispose!         — (fn [a-ratom])   → nil
     :adapter/reactive?        — (fn [])          → boolean
-    :adapter/after-render     — (fn [f])         → nil
-
-  Before rf2-s36l this ns statically `:require`d `reagent.core` /
-  `reagent.ratom` and forwarded straight to stock Reagent. That hard-
-  coupled every CLJS app — including those built on the slim
-  (`reagent-slim`), UIx, or Helix adapters — to stock Reagent's
-  protocols at every reaction/disposal call site. The slim adapter's
-  `reagent2.ratom/Reaction` does NOT reify stock Reagent's
-  `IDisposable`, so the first `(interop/add-on-dispose! ...)` call
-  under a slim-installed app threw a protocol-dispatch error
-  (counter-slim-and-fast Playwright smoke, parked by PR #305).
-
-  After rf2-s36l: each adapter ns publishes its own per-fn hook set
-  at load time. The classic Reagent bridge wires the hooks to
-  `reagent.core/atom`, `reagent.ratom/make-reaction`, etc.; the slim
-  adapter wires them to `reagent2.*` equivalents; UIx and Helix —
-  which reify stock `reagent.ratom/IDisposable` on their derived
-  values — wire to stock Reagent.
-
-  Each adapter's hook installation routes through
-  `(substrate-adapter/current-adapter)` per rf2-0d35: the hook runs
-  the adapter's impl only when that adapter is the installed one and
-  otherwise chains to the previously-registered reader. This keeps
-  test bundles (which load multiple adapter ns's at once) honest about
-  which substrate is active.
-
-  Per the bundle-size note in rf2-5lbx R-007 and rf2-s36l: once this
-  ns stops statically `:require`ing `reagent.core` / `reagent.ratom`,
-  the slim Maven artefact (`day8/reagent-slim`) can drop its stock-
-  Reagent dep entirely and downstream consumers depending on
-  `reagent-slim` alone gain the ~25 KB gz saving. The in-tree
-  shadow-cljs build still pulls all adapter trees (the monorepo
-  configuration coexists them), so the in-tree bundle sizes do not
-  change — that's expected and fine; the bundle-comparison test
-  (rf2-51x5 / rf2-5lbx) is structural, not size-comparative."
+    :adapter/after-render     — (fn [f])         → nil"
   (:require [goog.async.nextTick]
             [re-frame.late-bind :as late-bind]))
 
@@ -63,9 +26,8 @@
 ;; ---- after-render hook ----------------------------------------------------
 
 (defn after-render
-  "Schedule f to run after the next render. Dispatches through the
-  active adapter's `:adapter/after-render` hook (rf2-s36l). Returns nil
-  when no adapter has registered the hook."
+  "Schedule f to run after the next render. Returns nil when no adapter
+  has registered `:adapter/after-render`."
   [f]
   (when-let [hook (late-bind/get-fn :adapter/after-render)]
     (hook f)))
@@ -73,16 +35,14 @@
 ;; ---- mutable cells (used by the runtime, opaque to user code) -------------
 
 (defn ratom
-  "Construct a reactive atom seeded with v. Dispatches through the active
-  adapter's `:adapter/ratom` hook (rf2-s36l)."
+  "Construct a reactive atom seeded with v."
   [v]
   (when-let [hook (late-bind/get-fn :adapter/ratom)]
     (hook v)))
 
 (defn ratom?
   "True if x is a reactive atom (per the active adapter's substrate).
-  Dispatches through `:adapter/ratom?` (rf2-s36l); returns false when
-  no adapter has registered the hook."
+  Returns false when no adapter has registered `:adapter/ratom?`."
   [x]
   (if-let [hook (late-bind/get-fn :adapter/ratom?)]
     (hook x)
@@ -91,36 +51,34 @@
 ;; ---- reactions ------------------------------------------------------------
 
 (defn make-reaction
-  "Build a reaction that recomputes f when its dependencies change.
-  Dispatches through `:adapter/make-reaction` (rf2-s36l)."
+  "Build a reaction that recomputes f when its dependencies change."
   [f]
   (when-let [hook (late-bind/get-fn :adapter/make-reaction)]
     (hook f)))
 
 (defn add-on-dispose!
-  "Register a teardown callback on a-ratom. Dispatches through
-  `:adapter/add-on-dispose!` (rf2-s36l)."
+  "Register a teardown callback on a-ratom."
   [a-ratom f]
   (when-let [hook (late-bind/get-fn :adapter/add-on-dispose!)]
     (hook a-ratom f)))
 
 (defn dispose!
-  "Tear down a reactive atom / reaction. Dispatches through
-  `:adapter/dispose!` (rf2-s36l)."
+  "Tear down a reactive atom / reaction."
   [a-ratom]
   (when-let [hook (late-bind/get-fn :adapter/dispose!)]
     (hook a-ratom)))
 
 (defn reactive?
   "True when called from inside a reactive context (e.g. a render).
-  Dispatches through `:adapter/reactive?` (rf2-s36l); returns false
-  when no adapter has registered the hook."
+  Returns false when no adapter has registered `:adapter/reactive?`."
   []
   (if-let [hook (late-bind/get-fn :adapter/reactive?)]
     (hook)
     false))
 
 ;; ---- timers ---------------------------------------------------------------
+;; Timers are a platform primitive — not substrate-reactive — so they bypass
+;; the adapter hook table and call the host scheduler directly.
 
 (defn set-timeout!
   "Schedule f to run after ms milliseconds. Returns an opaque handle."

--- a/implementation/core/src/re_frame/late_bind.cljc
+++ b/implementation/core/src/re_frame/late_bind.cljc
@@ -1,58 +1,28 @@
 (ns re-frame.late-bind
   "Late-binding hook registry for cross-namespace forward references.
 
-  Some leaf namespaces (re-frame.frame, re-frame.fx, re-frame.cofx,
-  re-frame.subs, re-frame.routing, re-frame.router) need to call into
-  higher-level namespaces (re-frame.router, re-frame.flows,
-  re-frame.schemas, re-frame.subs) but cannot `:require` them without
-  introducing a cyclic load order.
+  Producing namespaces register a callable via `set-fn!` at load time;
+  consumers look it up via `get-fn` at call time. The mechanism carries
+  two kinds of forward reference:
 
-  Per rf2-p7va the same mechanism carries cross-artefact references:
-  `re-frame.schemas` ships in a separate Maven artefact
-  (day8/re-frame2-schemas), so re-frame.core / re-frame.test-support
-  MUST NOT statically `:require` it — they look the schemas API up
-  through the hook table at call time. When the schemas artefact is
-  not on the classpath, the lookup returns nil and the consumer
-  no-ops (or, in the case of `rf/reg-app-schema`, throws a clear
-  `:rf.error/schemas-artefact-missing` so the misconfiguration is
-  surfaced rather than silently absorbed).
+  - Leaf-to-higher-level (avoids cyclic `:require`s) — e.g. `re-frame.frame`
+    calling into `re-frame.router`.
+  - Cross-artefact (avoids hard deps on optional Maven artefacts) — e.g.
+    `re-frame.core` calling into `re-frame.schemas` only when the
+    `day8/re-frame2-schemas` artefact is on the classpath; absent that,
+    `get-fn` returns nil and consumers either no-op or throw a structured
+    `:rf.error/<artefact>-artefact-missing` (see `require-fn!`).
 
-  On the JVM we historically used `(resolve 'ns/sym)` to defer the
-  lookup to runtime. That works on the JVM because `clojure.core/resolve`
-  is a runtime fn — but ClojureScript has no runtime `resolve` (the
-  symbol exists only as a compile-time analyzer affordance), so every
-  CLJS call site silently no-op'd. That manifested as e.g.
-  `(rf/make-frame {:on-create [:foo]})` returning a frame whose app-db
-  was never seeded by `:on-create`, and `:fx [[:dispatch [...]]]`
-  becoming a no-op.
-
-  This namespace replaces those `resolve` calls with an explicit hook
-  registry. The producing namespace registers its callable at load
-  time via `set-fn!`; the consuming namespace fetches it via `get-fn`
-  at call time. Identical behaviour on JVM and CLJS.
-
-  Per Spec 002 §reg-frame is atomic: `:on-create` runs synchronously
-  inside `reg-frame`; `make-frame` is a thin wrapper, so by the time
-  `make-frame` returns the frame's app-db reflects the init handler's
-  commits. Callers MUST register the `:on-create` event's handler
-  BEFORE calling `make-frame` / `reg-frame`. (When the JVM/CLJS host
-  loads `re-frame.core`, the canonical re-frame.router namespace is
-  loaded — and registers its hooks — before any user code runs.)
-
-  The authoritative inventory of every published key lives in
-  `re-frame.late-bind.directory` — plain CLJC data, one entry per
-  hook key, with the producer ns, design bead, and one-line
-  description. The drift test
-  `implementation/core/test/re_frame/late_bind_drift_test.clj`
-  asserts the directory and the `set-fn!` call sites stay in sync.")
+  The authoritative inventory of published keys lives in
+  `re-frame.late-bind.directory`; the drift test
+  `late_bind_drift_test.clj` asserts the directory and the `set-fn!`
+  call sites stay in sync.")
 
 #?(:clj (set! *warn-on-reflection* true))
 
 (defonce
-  ^{:doc "Map of hook-key → fn. Populated by the producing namespace at
-   load time. The authoritative key inventory is
-   `re-frame.late-bind.directory/hooks`; the drift test enforces it
-   matches the in-tree `set-fn!` call sites."}
+  ^{:doc "Map of hook-key → fn. Populated by producing namespaces at
+   load time. Authoritative key inventory: `re-frame.late-bind.directory/hooks`."}
   hooks
   (atom {}))
 
@@ -75,10 +45,8 @@
   `:rf.error/<artefact>-artefact-missing` ex-info when the hook is
   unregistered.
 
-  The throw shape matches the documented missing-artefact contract used
-  by every `re-frame.core-<artefact>` wrapper (see rf2-5b6x — the
-  late-bind-missing test suite locks this shape across all six per-
-  feature splits):
+  The throw shape is locked by the missing-artefact contract used by
+  every `re-frame.core-<artefact>` wrapper:
 
     Message:  `<error-keyword>` printed as a string (e.g.
               \":rf.error/flows-artefact-missing\").
@@ -91,19 +59,9 @@
   Args:
     hook-key      — the late-bind hook key (e.g. `:flows/reg-flow`).
     where-sym     — the user-facing fn symbol stamped on the error
-                    (e.g. `'rf/reg-flow`) so greping for the symbol
-                    finds the call site in user code.
-    artefact-info — a map carrying the artefact's Maven coordinates and
-                    the producing ns name:
-                      {:error-keyword :rf.error/flows-artefact-missing
-                       :maven         \"day8/re-frame2-flows\"
-                       :require-ns    \"re-frame.flows\"}
-    extra-data    — (optional) per-call ex-data slots like `:flow-id` /
-                    `:path` / `:route-id` / `:machine-id` / `:frame`.
-
-  Pairs with the `re-frame.core-artefact/defwrapper` factory (rf2-h824v)
-  which drives 26+ call sites across seven `core_<artefact>.cljc`
-  wrappers from a declarative table."
+                    so greping for the symbol finds the call site.
+    artefact-info — `{:error-keyword … :maven … :require-ns …}`.
+    extra-data    — (optional) per-call ex-data slots."
   ([hook-key where-sym artefact-info]
    (require-fn! hook-key where-sym artefact-info nil))
   ([hook-key where-sym {:keys [error-keyword maven require-ns]} extra-data]

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -632,7 +632,10 @@
     (binding [frame/*current-frame* (:frame envelope)]
       (process-event* envelope))))
 
-(def ^:private drain-depth-default 100)
+(def ^:private drain-depth-default
+  ;; 100 — deep enough for typical cascade depths; cheap rollback if
+  ;; exceeded.
+  100)
 
 (defn- handle-depth-exceeded!
   "Tail-path for the depth-limit branch of `drain!`. Atomic rollback per

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -42,14 +42,11 @@
 (defn- next-event-id []
   (swap! event-counter inc))
 
-;; ---- handler-scope: the five-slot in-scope reading -----------------------
-;;
-;; Per Spec 009 §Handler-scope. Every handler-execution boundary (router,
-;; subs, fx, cofx, views) publishes a HandlerScope record on
-;; `*handler-scope*` so `emit!` / `emit-error!` can hoist the relevant
-;; slots onto each emitted event. See Spec 009 for the slot semantics,
-;; composition rule (innermost wins for meta-derived slots; call-site /
-;; dispatch-id inherit), and elision contract.
+;; ---- handler-scope --------------------------------------------------------
+;; The five-slot in-scope reading consulted by `emit!` / `emit-error!` to
+;; hoist slots onto each event. See Spec 009 §Handler-scope for the
+;; composition rule (innermost-wins for meta-derived slots; call-site /
+;; dispatch-id inherit from the parent scope).
 
 (defrecord HandlerScope [trigger-handler call-site dispatch-id sensitive? no-emit?])
 
@@ -78,11 +75,9 @@
 (defn no-emit?-from-meta
   "True iff `meta` carries `:rf.trace/no-emit? true`. Used at queue-time
   `:event/dispatched` emit, before the handler-scope binding exists.
-  Per Spec 009 §Trace-emission opt-out.
-
-  Sibling reader for `:sensitive?` lives in `re-frame.privacy`
-  (`privacy/sensitive?-from-meta`) per rf2-iwqu9 — privacy owns the
-  policy-locus; trace owns the emit-locus."
+  Per Spec 009 §Trace-emission opt-out. (Sibling `:sensitive?` reader
+  lives in `re-frame.privacy` — privacy owns the policy-locus, trace
+  the emit-locus.)"
   [meta]
   (true? (:rf.trace/no-emit? meta)))
 
@@ -94,9 +89,9 @@
   them from the parent scope on bind. Per Spec 009 §Handler-scope.
 
   The `:sensitive?` reading is inlined here to avoid a require cycle
-  with `re-frame.privacy` (privacy requires trace). The same boolean
+  with `re-frame.privacy` (privacy requires trace); the same boolean
   shape is exposed as `re-frame.privacy/sensitive?-from-meta` for
-  every other consumer (router / event-emit) per rf2-iwqu9."
+  every other consumer."
   [kind id meta]
   (->HandlerScope (trigger-handler-from-meta kind id meta)
                   nil
@@ -163,15 +158,14 @@
           ~@body))))
 
 ;; ---- retain-N trace ring buffer (dev-only) -------------------------------
-;;
-;; Per Spec 009 §Retain-N trace ring buffer. Holds the most recent N completed
-;; trace events; queryable via (trace-buffer). All ring-buffer machinery is
-;; gated on interop/debug-enabled? (the same compile-time flag the rest of the
-;; trace surface rides) so production builds drop the buffer entirely — no
-;; allocation, no append, no storage.
+;; Holds the most recent N completed trace events; queryable via
+;; `(trace-buffer)`. Gated on `interop/debug-enabled?` so production
+;; builds DCE the buffer entirely. Per Spec 009 §Retain-N trace ring
+;; buffer.
 
 (def ^:private default-buffer-depth
-  "Per Spec 009 §Retain-N trace ring buffer: default 200 events."
+  ;; 200 — one drained cascade plus prior history without per-frame
+  ;; memory pressure.
   200)
 
 (defonce ^:private buffer-depth (atom default-buffer-depth))
@@ -228,17 +222,17 @@
                      (`:app` / `:pair` / `:story` / `:test` / ...) per
                      Spec 002 §Dispatch origin tagging.
     :dispatch-id   — keep only events whose `:tags :dispatch-id` matches.
-                     Cascade-wide post rf2-g6ih4 — every emit inside a
-                     drain carries the in-flight cascade's dispatch-id.
+                     Every emit inside a drain carries the in-flight
+                     cascade's dispatch-id.
     :since-ms      — keep only events whose :time is strictly greater
                      than this numeric host-clock timestamp.
     :between       — `[t0 t1]` two-element vector — keep only events
                      whose :time falls in [t0, t1] inclusive.
     :sensitive?    — boolean. Match the top-level `:sensitive?` field
-                     (per Spec 009 §Privacy filter-vocab row, rf2-isdwf).
-                     Pass `false` to exclude sensitive events; pass
-                     `true` to select only sensitive events. Absent ⇒
-                     no constraint.
+                     (per Spec 009 §Privacy filter-vocab row). Pass
+                     `false` to exclude sensitive events; pass `true`
+                     to select only sensitive events. Absent ⇒ no
+                     constraint.
     :pred          — `(fn [ev] -> truthy)` arbitrary predicate. Receives
                      the full event map. Returning truthy keeps the event.
 
@@ -285,9 +279,8 @@
                   (or (nil? between-t0)
                       (and (number? (:time ev))
                            (<= between-t0 (:time ev) between-t1)))
-                  ;; Per rf2-isdwf: top-level `:sensitive?` is hoisted
-                  ;; (NOT nested under :tags). Match against the
-                  ;; top-level slot only; absent reads as false.
+                  ;; `:sensitive?` is hoisted to top level (NOT nested
+                  ;; under :tags). Absent reads as false.
                   (or (nil? sensitive-filter)
                       (= (true? sensitive-filter)
                          (true? (:sensitive? ev))))
@@ -346,25 +339,20 @@
       (catch #?(:clj Throwable :cljs :default) _ nil))))
 
 ;; ---- shared emit substrate ------------------------------------------------
+;; `emit!` / `emit-error!` are thin wrappers carrying the prod-DCE outer
+;; gate; the envelope construction (`build-event`, pure) and delivery
+;; (`deliver!`) sit below.
 ;;
-;; `emit!` (success) and `emit-error!` (error) share an envelope-
-;; construction core (`build-event`, pure; reads `*handler-scope*`) and
-;; a delivery path (`deliver!`, side-effect: ring buffer + epoch capture
-;; + listener fan-out). The two public emit fns are thin wrappers
-;; carrying the prod-DCE outer gate.
-;;
-;; The outer `(when interop/debug-enabled? ...)` and inner `(when-not
-;; (:no-emit? *handler-scope*) ...)` guards stay in the wrappers — NOT
-;; in `build-event` — because Spec 009 §Production builds mandates the
-;; outermost form of an emit call be `(when interop/debug-enabled? ...)`
-;; alone for Closure DCE to elide the expression under `:advanced` +
-;; `goog.DEBUG=false`.
+;; The outermost form of an emit call MUST be `(when
+;; interop/debug-enabled? ...)` alone for Closure DCE to elide it under
+;; `:advanced` + `goog.DEBUG=false` (Spec 009 §Production builds). Do
+;; not fold the gate into `build-event` or move it inside the inner
+;; `:no-emit?` short-circuit.
 
 (defn- compute-sensitive?
   "Hoist `:sensitive?` from the in-scope handler's registration meta,
   with caller-supplied `:sensitive?` in `tags` winning (queue-time
-  `:event/dispatched` computes its own reading). Per Spec 009
-  §Privacy / sensitive data in traces."
+  `:event/dispatched` computes its own reading). Per Spec 009 §Privacy."
   [tags scope]
   (let [tag-sensitive? (:sensitive? tags)]
     (cond
@@ -398,13 +386,10 @@
                       (:recovery tags :no-recovery)
                       (:recovery tags))
         call-site   (when error? (some-> scope :call-site))
-        ;; Strip hoisted slots from `:tags` so they don't double-up at
-        ;; the top level. Exception: the error path KEEPS `:source`
-        ;; under `:tags` because boundary-interceptor / error-emit
-        ;; sites use it as an emission-site discriminator (e.g.
-        ;; `:source :boundary` per Spec 010 §Production builds), and
-        ;; consumers already fall back top-level → `:tags :source`.
-        ;; Error path additionally merges `{:category operation}`.
+        ;; Hoisted slots are stripped from `:tags` so they don't double
+        ;; up at the top level. Error path keeps `:source` under `:tags`
+        ;; (boundary / error-emit sites use it as an emission-site
+        ;; discriminator) and merges `{:category operation}`.
         base-tags   (cond-> (dissoc tags :recovery :sensitive?)
                       (not error?) (dissoc :source)
                       error?       (->> (merge {:category operation})))
@@ -421,8 +406,8 @@
       trigger              (assoc :rf.trace/trigger-handler trigger)
       ;; `:rf.trace/call-site` rides error traces only.
       call-site            (assoc :rf.trace/call-site call-site)
-      ;; Top-level `:sensitive? true` stamp. Absent (not `false`)
-      ;; when not sensitive — consumers treat absent as false.
+      ;; Absent (not `false`) when not sensitive — consumers treat
+      ;; absent as false.
       sensitive?           (assoc :sensitive? true))))
 
 (defn- deliver!
@@ -451,11 +436,10 @@
 
   Per Spec 009 §Emitting trace events and §Handler-scope."
   [op operation tags]
+  ;; `:no-emit?` short-circuit MUST sit inside the outer
+  ;; `interop/debug-enabled?` gate — the outer form must stand alone
+  ;; for Closure DCE under :advanced + goog.DEBUG=false.
   (when interop/debug-enabled?
-    ;; `:no-emit?` short-circuit sits *inside* the outer
-    ;; `interop/debug-enabled?` gate per Spec 009 §Production builds
-    ;; (the outer gate must stand alone for Closure DCE — see
-    ;; §Production-elision verification).
     (when-not (true? (some-> *handler-scope* :no-emit?))
       (deliver! (build-event op operation tags)))))
 
@@ -467,21 +451,15 @@
 
   Reads `*handler-scope*` to hoist `:trigger-handler`, `:call-site`,
   and `:dispatch-id` onto the envelope, and to honour the `:no-emit?`
-  short-circuit (symmetric with `emit!`). Per Spec 009 §Error contract
-  and §Handler-scope."
+  short-circuit (symmetric with `emit!`). Per Spec 009 §Error contract."
   [error-operation tags]
   (when interop/debug-enabled?
-    ;; `:no-emit?` short-circuit sits *inside* the outer
-    ;; `interop/debug-enabled?` gate per Spec 009 §Production builds.
     (when-not (true? (some-> *handler-scope* :no-emit?))
       (deliver! (build-event :error error-operation tags)))))
 
 ;; ---- late-bind hook registration ------------------------------------------
-;;
-;; re-frame.registrar emits a trace event when a handler is replaced but
-;; cannot `:require` this namespace without a cyclic load order.
-;; Publish `emit!` through the late-bind hook registry. See
-;; re-frame.late-bind.
+;; re-frame.registrar emits when a handler is replaced but cannot
+;; `:require` this ns without a cyclic load order.
 
 (late-bind/set-fn! :trace/emit!       emit!)
 (late-bind/set-fn! :trace/emit-error! emit-error!)

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -5,45 +5,21 @@
   Spec 011 (SSR); this namespace ties view registration into the Reagent
   substrate.
 
-  Form-1 (a render fn) is the canonical view shape. Form-2/3 are
-  supported via Reagent's native handling.
+  This ns is the orchestration entry point; the implementation lives in
+  three cohesive sub-namespaces re-exported below:
 
-  reg-view auto-defs the local Var (per Spec 004 §reg-view defs the Var
-  by default); the Var is the canonical call-site reference. For
-  late-binding by id (e.g. across module boundaries, runtime-computed
-  ids, or hot-reload semantics), call `(re-frame.core/view :id)`
-  to obtain the wrapped fn and use `[(rf/view :id) args]` as the
-  hiccup head.
-
-  Per rf2-lh7p the file has been split into three internally-cohesive
-  sub-namespaces; this ns is now the orchestration entry point that
-  ties them together:
-
-    - `re-frame.views.provider`                — frame-provider + the
-                                                 React-context bridge
-                                                 and per-render
-                                                 instance-token
-                                                 machinery
+    - `re-frame.views.provider`                — frame-provider, React-
+                                                 context bridge, per-
+                                                 render instance-token
     - `re-frame.views.source-coord-annotation` — Spec 006 source-coord
                                                  DOM annotation walk
     - `re-frame.views.warn-once`               — per-process warn-once
-                                                 caches (non-DOM root,
-                                                 plain-fn-under-non-
-                                                 default-frame)
+                                                 caches
 
-  The publicly-referenced surface is re-exported via plain `def` aliases
-  below so existing call sites — `re-frame.core/reg-view*`, the test
-  files, the late-bind hook table, and the adapter ns docstrings —
-  continue to resolve through this ns unchanged.
-
-  The `*render-key*` dynamic var lives in THIS ns (rather than under
-  `re-frame.views.provider` alongside the rest of the instance-token
-  machinery) because tests read it via `re-frame.views/*render-key*`
-  from inside a render-fn while the wrapper below binds the same Var.
-  Putting the canonical Var here makes the read and the binding hit
-  identical Vars — a `(def ^:dynamic *render-key* provider/*render-key*)`
-  re-export would create a SECOND Var whose binding the test wouldn't
-  observe."
+  `*render-key*` lives in this ns rather than under provider because
+  tests read it via `re-frame.views/*render-key*` while the wrapper
+  below binds the same Var. A `def` re-export would create a SECOND
+  Var whose binding the test wouldn't observe."
   (:require [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.performance :as performance :include-macros true]
@@ -52,13 +28,6 @@
             [re-frame.views.provider :as provider]
             [re-frame.views.source-coord-annotation :as source-coord]
             [re-frame.views.warn-once :as warn-once]))
-
-;; ---- *render-key* (rf2-piag / rf2-t5tx) ----------------------------------
-;;
-;; Bound by the `reg-view*` wrapper below for the duration of each render.
-;; Lives here (the public ns) so `re-frame.views/*render-key*` is the
-;; canonical Var that wrapper-binding and consumer-reads share — see
-;; the ns docstring above for why this can't move under provider.
 
 (def ^:dynamic *render-key*
   "The `:render-key` for the in-flight render — a tuple
@@ -77,27 +46,8 @@
   (or *render-key* [:rf.view/anonymous nil]))
 
 ;; ---- re-exported public surface ------------------------------------------
-;;
-;; Plain `def` aliases for the publicly-referenced ordinary fns / data
-;; surfaces. Each one is reached by external call sites through
-;; `re-frame.views/<name>`:
-;;
-;;   re-frame.adapter.reagent + runtime_cljs_test → frame-provider, build-frame-provider
-;;   late-bind hook table (:adapter/current-frame),
-;;     views-current-component-cljs-test          → current-frame
-;;   render_key_cljs_test, elision_probe          → mint-instance-token!
-;;   source_coord_parity_cljs_test                → #'format-source-coord
-;;   warn_once_fixture_isolation_cljs_test        → clear-warned-non-dom-roots!
-;;   late-bind hook table                         → maybe-warn-plain-fn-under-non-default-frame!,
-;;                                                  clear-plain-fn-warned-pairs!
-;;
-;; Keeping these as plain defs (rather than `:refer`-imported) makes
-;; `#'re-frame.views/<name>` resolve in this ns — the CLJS analyser
-;; tracks each `def` form's Var under the defining ns, so
-;; `:refer` does not surface a Var under the consuming ns. Functions are
-;; resolved by value, so a `def` alias works for invocation; only
-;; dynamic-var binding semantics force the `*render-key*` exception
-;; above.
+;; Plain `def` aliases so `#'re-frame.views/<name>` resolves in this ns
+;; (a `:refer` would surface the Var under the producing ns, not here).
 
 (def frame-provider provider/frame-provider)
 (def build-frame-provider provider/build-frame-provider)
@@ -111,21 +61,14 @@
 (def maybe-warn-plain-fn-under-non-default-frame!
   warn-once/maybe-warn-plain-fn-under-non-default-frame!)
 
-;; The React-context object is consumed by `reg-view*` below (the
-;; `:contextType` static-field) and by the warn-once helpers in
-;; `re-frame.views.warn-once`. Aliased privately here for parity with
-;; the pre-split shape — no external caller reaches for it.
 (def ^:private frame-context provider/frame-context)
 
 (defn- emit-render-trace!
   "Emit a `:view/render` trace event tagged with the in-flight
-  `:render-key`. The trace also carries the `:frame` tag so the
-  epoch-capture buffer (per re-frame.epoch §capture-event!) can route
-  the render into the right per-frame cascade. Goes through late-bind
-  so this ns doesn't depend on re-frame.trace (which itself routes
-  through late-bind for registrar/views ordering reasons). Production
-  builds elide via the `interop/debug-enabled?` gate the trace surface
-  itself rides."
+  `:render-key` and current `:frame` (so the epoch capture buffer routes
+  it to the right per-frame cascade). Goes through late-bind to keep
+  this ns out of the re-frame.trace dep graph. Elided in production via
+  `interop/debug-enabled?`."
   [render-key]
   (when interop/debug-enabled?
     (when-let [emit! (late-bind/get-fn :trace/emit!)]
@@ -134,42 +77,22 @@
               :frame      (provider/current-frame)}))))
 
 ;; ---- reg-view -------------------------------------------------------------
-;;
-;; Per rf2-w9ykb the wrapper-builder is decomposed into named helpers,
-;; each owning one phase of the registration pipeline:
-;;
-;;   1. `apply-adapter-wrap-view`   — consult the substrate hook
-;;   2. `view-coord-attr`           — debug-only source-coord stamp
-;;   3. `trace/handler-scope-from-meta` — pre-compute the view's HandlerScope
-;;      (already a named helper in trace.cljc — rf2-ryri7)
-;;   4. `build-frame-aware-view`    — assemble the per-render wrapped fn
-;;   5. `registrar/register!`       — install in the :view kind
-;;
-;; reg-view* itself becomes a five-line straight-line composition.
 
 (defn- apply-adapter-wrap-view
-  "Consult the `:adapter/wrap-view` late-bind hook (rf2-00li) for a
-  substrate-side wrap. Returns `[render-fn wrap-applied?]`.
+  "Consult the `:adapter/wrap-view` late-bind hook for a substrate-side
+  wrap. Returns `[render-fn wrap-applied?]`.
 
-  UIx / Helix register a substrate wrap-view because their render-fn
-  output is a React element — neither a hiccup vector nor a fn — so
-  the inline `inject-source-coord-attr` walk would mis-classify the
-  root and skip annotation. Those adapters supply a wrap-view that
-  injects `data-rf2-source-coord` via `React.cloneElement`. The
-  Reagent adapter does NOT publish the hook; the inline hiccup walk
-  in `build-frame-aware-view` continues to serve it.
+  UIx / Helix register a wrap-view because their render-fn output is a
+  React element — neither hiccup nor a fn — so the inline hiccup walk
+  would mis-classify the root; their wrap-view injects
+  `data-rf2-source-coord` via `React.cloneElement`. The Reagent adapter
+  does NOT publish the hook.
 
-  The hook may be registered (e.g. test bundle loaded UIx + Helix
-  adapter ns's) yet return nil — each adapter's routing closure
-  returns nil when its own adapter is NOT the installed one (per
-  rf2-0d35), so the chain bottoms out at nil when the Reagent adapter
-  is installed. A nil from the hook means \"no substrate wrap
-  applied\" — keep render-fn unchanged and let the inline walk run.
-
-  The adapter's wrap-view body itself sits inside
-  `(when interop/debug-enabled? ...)`, so under :advanced +
-  goog.DEBUG=false the wrapped fn collapses to the bare user-fn (no
-  cloneElement) — keeping the elision contract."
+  The hook may be registered yet return nil — each adapter's routing
+  closure short-circuits when its adapter is not the installed one — so
+  a nil result means \"no substrate wrap applied; fall through to the
+  inline walk\". The wrap body itself rides `(when interop/debug-enabled?
+  ...)`, so under :advanced + goog.DEBUG=false it DCEs."
   [id metadata render-fn]
   (let [hook    (late-bind/get-fn :adapter/wrap-view)
         wrapped (when hook (hook id metadata render-fn))]
@@ -179,10 +102,9 @@
 
 (defn- view-coord-attr
   "Capture the source-coord stamp for the inline hiccup-walk
-  annotation path (Spec 006 §Source-coord annotation, rf2-z7f7 /
-  rf2-z9n1). Returns nil under :advanced + goog.DEBUG=false, and
-  also nil when the substrate hook has already wrapped render-fn
-  (its own cloneElement path supersedes the hiccup walk)."
+  annotation path (Spec 006 §Source-coord annotation). Returns nil
+  under :advanced + goog.DEBUG=false, and also nil when the substrate
+  hook has wrapped render-fn (its cloneElement path supersedes the walk)."
   [id metadata wrap-applied?]
   (when (and interop/debug-enabled? (not wrap-applied?))
     (source-coord/format-source-coord id metadata)))
@@ -191,14 +113,12 @@
   "Build the per-render wrapped fn that ties view registration into
   Reagent: each render binds `*render-key*` and `*handler-scope*`,
   emits the `:view/render` trace, brackets the user render-fn in
-  performance marks, and (when serving the Reagent inline path)
-  annotates the rendered hiccup root with the source-coord attribute.
+  performance marks, and (on the Reagent inline path) annotates the
+  rendered hiccup root with the source-coord attribute.
 
-  The returned fn carries `{:contextType frame-context}` meta so
-  Reagent's create-class / fn-to-class machinery hooks it up to the
-  React frame-context (rf2-kdwc — note the camelCase static-field
-  name; the earlier kebab `:context-type` shape was silently ignored
-  by Reagent)."
+  The returned fn carries `{:contextType frame-context}` meta — the
+  camelCase static-field name is load-bearing; Reagent silently ignores
+  the kebab `:context-type` shape."
   [id render-fn view-scope coord-attr wrap-applied?]
   (with-meta
     (fn frame-aware-view [& args]
@@ -207,14 +127,10 @@
         (binding [*render-key* render-key]
           (trace/with-handler-scope view-scope
             (emit-render-trace! render-key)
-            ;; Per Spec 009 §Performance instrumentation (rf2-du3i):
-            ;; every render of a registered view brackets the user
-            ;; render-fn in performance marks so prod builds with the
-            ;; perf flag enabled produce a `rf:render:<view-id>` measure
-            ;; entry. Default-off; under :advanced +
-            ;; `re-frame.performance/enabled?=false` the bracket DCEs
-            ;; and the form collapses to the bare `(apply render-fn
-            ;; args)` call.
+            ;; Spec 009 §Performance instrumentation: when the perf
+            ;; flag is enabled the bracket emits a `rf:render:<view-id>`
+            ;; measure. Default-off; under :advanced +
+            ;; `re-frame.performance/enabled?=false` the bracket DCEs.
             (let [out (performance/mark-and-measure :render id
                         (apply render-fn args))]
               (if (and interop/debug-enabled? (not wrap-applied?))
@@ -228,30 +144,21 @@
   frame at render time, then registers it in the :view kind of the
   registrar.
 
-  Per Spec 004 §reg-view*: this is the plain-fn surface delegated to
-  by `re-frame.core/reg-view*` on CLJS. `metadata` is merged into the
-  registry slot's metadata as-is; source-coord capture is performed
-  by the caller (`re-frame.core/reg-view*`).
+  Spec 004 §reg-view*: the plain-fn surface delegated to by
+  `re-frame.core/reg-view*` on CLJS. `metadata` is merged into the
+  registry slot as-is; source-coord capture is performed by the caller.
 
-  Per rf2-piag / rf2-t5tx: each render binds `*render-key*` to the
-  tuple `[id instance-token]` for the body, so the trace recorder can
-  attribute the render. The instance-token is minted at mount and
-  reused across re-renders of the same component instance (per
-  Spec 004 §Render-tree primitives).
+  Each render binds `*render-key*` to `[id instance-token]` so the
+  trace recorder can attribute the render. The instance-token is minted
+  at mount and reused across re-renders of the same component instance
+  (Spec 004 §Render-tree primitives).
 
-  Per rf2-ryri7: the view's HandlerScope is pre-computed once at
-  registration time from `metadata` (source-coord stamp, `:sensitive?`,
-  `:rf.trace/no-emit?` — all three fixed for the life of the registered
-  view). Each render binds the scope (via `with-handler-scope`, which
-  inherits parent's `:call-site` / `:dispatch-id`) around the user
-  render-fn invocation. Errors emitted during render (subscribe-miss
-  against this frame, sub exception during a render-time deref, etc.)
-  ride the view's `:trigger-handler` coord; `:view/render` emits ride
-  `:sensitive?` per Spec 009 §Privacy and short-circuit when
-  `:no-emit?` is true.
-
-  Per rf2-w9ykb the body is a five-line pipeline; the work lives in
-  the named helpers above."
+  The view's HandlerScope is pre-computed once at registration time
+  from `metadata` (source-coord stamp, `:sensitive?`, `:rf.trace/no-emit?`
+  — all fixed for the life of the registered view). Each render binds
+  the scope around the user render-fn invocation, so errors emitted
+  during render ride the view's `:trigger-handler` coord and
+  `:view/render` emits honour `:sensitive?` / `:no-emit?`."
   [id metadata render-fn]
   (let [[render-fn wrap-applied?] (apply-adapter-wrap-view id metadata render-fn)
         coord-attr (view-coord-attr id metadata wrap-applied?)

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -73,24 +73,18 @@
                         projections (`:sub-runs` / `:renders` /
                         `:effects`) but drop `:trace-events` to
                         bound memory. Per Spec-Schemas
-                        §`:rf/epoch-record` line 2224
-                        (`:trace-events` is optional —
-                        'implementations may choose to drop traces
-                        from older epochs') and refactor-audit r2
-                        (rf2-lwn4t) §F3.1.
+                        §`:rf/epoch-record` line 2224 — `:trace-events`
+                        is optional, implementations may drop traces
+                        from older epochs.
 
-  Absent / nil `:trace-events-keep` keeps every record's
-  `:trace-events` slot (the default, pre-rf2-iegsz behaviour);
-  the cap kicks in only when explicitly configured.
+  Absent / nil `:trace-events-keep` keeps every record's `:trace-events`
+  slot; the cap kicks in only when explicitly configured.
 
-  Per refactor-audit r2 (rf2-lwn4t) §rf2-douii: both keys are validated
-  at the boundary. A `:depth` or `:trace-events-keep` that isn't a
-  non-negative integer is silently dropped from `opts` rather than
-  stored — a `nil` or non-numeric value would otherwise survive
-  configuration and explode at the next `record!` call when `pos?` /
-  `nat-int?` runs on the stored value. Validation mirrors the
-  pattern `re-frame.trace/configure-trace-buffer!` applies at its
-  own config boundary."
+  Both keys are validated at the boundary. A `:depth` or
+  `:trace-events-keep` that isn't a non-negative integer is silently
+  dropped from `opts` rather than stored — a non-numeric value would
+  otherwise explode at the next `record!` call. Mirrors the pattern
+  `re-frame.trace/configure-trace-buffer!` applies at its own boundary."
   [opts]
   (when (map? opts)
     (let [picked (select-keys opts [:depth :trace-events-keep])
@@ -175,13 +169,10 @@
   nil)
 
 (defn- clear-frame-history!
-  "Drop every recorded epoch for the named frame. Per rf2-sh5g6: no
-  late-bind hook is published for this; the fn is invoked only from
-  the in-artefact test pin (via the `#'epoch/clear-frame-history!`
-  var). The test fixture uses the unscoped `clear-history!`
-  hook so scoped clearing is not on the integration critical path —
-  marking `defn-` keeps the surface area of the epoch public API
-  tight without losing the pinned-seam test."
+  "Drop every recorded epoch for the named frame. Private — invoked
+  only from the in-artefact test pin via `#'epoch/clear-frame-history!`;
+  no late-bind hook is published. Production callers go through the
+  unscoped `clear-history!` hook."
   [frame-id]
   (swap! histories dissoc frame-id)
   nil)
@@ -190,8 +181,8 @@
 
 (defonce ^:private listeners (atom {}))
 
-;; Per Tool-Pair §Surface behaviour against destroyed frames (rf2-d656):
-;; track which frames each cb has been delivered records for. When a
+;; Per Tool-Pair §Surface behaviour against destroyed frames: track
+;; which frames each cb has been delivered records for. When a
 ;; frame is destroyed, every cb whose observed-frames set contains
 ;; that frame receives a one-shot :rf.epoch.cb/silenced-on-frame-destroy
 ;; trace. The frame is then dropped from the cb's entry so a
@@ -282,14 +273,14 @@
 ;; The defonce lands in the per-cascade capture section further down
 ;; (kept there because every other consumer — `buffer-event!`,
 ;; `harvest-buffer!`, `capture-event!` — co-locates with the defonce).
-;; The destroy hook also needs to clear stragglers (rf2-zzper), but the
+;; The destroy hook also needs to clear stragglers, but the
 ;; destroy-hook section reads more clearly here alongside
 ;; `observed-frames-by-cb` cleanup, so we forward-declare rather than
 ;; re-ordering the whole capture section.
 (declare capture-buffers)
 
 (defn on-frame-destroyed!
-  "Per Tool-Pair §Surface behaviour against destroyed frames (rf2-d656):
+  "Per Tool-Pair §Surface behaviour against destroyed frames:
 
     1. Emit `:rf.epoch.cb/silenced-on-frame-destroy` once per cb whose
        observed-frames set contains `frame-id`, then drop `frame-id`
@@ -298,9 +289,9 @@
     2. Drop the destroyed frame's per-frame ring buffer so subsequent
        `(rf/epoch-history frame-id)` calls return the empty vector
        (the read-empty shape the contract commits to).
-    3. Drop any in-flight capture buffer entry for `frame-id`
-       (rf2-zzper) so a mid-drain destroy can't leak its pre-destroy
-       events into the first cascade of the next same-keyed frame.
+    3. Drop any in-flight capture buffer entry for `frame-id` so a
+       mid-drain destroy can't leak its pre-destroy events into the
+       first cascade of the next same-keyed frame.
 
   Called from `re-frame.frame/destroy-frame!` via the
   `:epoch/on-frame-destroyed` late-bind hook. Idempotent across
@@ -324,17 +315,13 @@
     ;; by reg-frame, so the ring buffer for the new same-keyed frame
     ;; starts empty per Spec 002 §reset-frame.)
     (swap! histories dissoc frame-id)
-    ;; Per rf2-zzper: also drop any in-flight capture buffer. The
-    ;; router's `discard-buffer!` call handles the cascade-abort path
-    ;; for routine drains, but a destroy that races a mid-flight
-    ;; drain (e.g. a hot-reload firing while the drain has buffered
-    ;; events but has not yet settled) would otherwise leave a stale
-    ;; partial buffer hanging on `frame-id`. The next cascade that
-    ;; registers a same-keyed frame would then harvest those
-    ;; pre-destroy events as belonging to its first record — a silent
-    ;; cross-contamination from the destroyed frame's previous life.
-    ;; Drop the buffer entry here as a belt-and-braces guarantee
-    ;; symmetric to the ring-buffer drop above.
+    ;; Also drop any in-flight capture buffer. The router's
+    ;; `discard-buffer!` handles routine cascade-aborts, but a destroy
+    ;; that races a mid-flight drain (e.g. hot-reload while events are
+    ;; buffered but the drain has not settled) would otherwise leave a
+    ;; stale partial buffer. The next same-keyed frame would harvest
+    ;; those pre-destroy events as its first record — silent cross-
+    ;; contamination from the destroyed frame's previous life.
     (swap! capture-buffers dissoc frame-id)))
 
 ;; ---- per-cascade trace capture --------------------------------------------
@@ -391,8 +378,8 @@
     :rf.epoch/restore-version-mismatch
     :rf.epoch/restore-during-drain
     ;; reset-frame-db! success + its two failure modes (Tool-Pair §Pair-
-    ;; tool writes, rf2-zq55). All three fire after the synthetic record
-    ;; has been built and the cascade-buffer (if any) has been harvested.
+    ;; tool writes). All three fire after the synthetic record has been
+    ;; built and the cascade-buffer (if any) has been harvested.
     :rf.epoch/db-replaced
     :rf.epoch/reset-frame-db-during-drain
     :rf.epoch/reset-frame-db-schema-mismatch})
@@ -429,9 +416,9 @@
 (defn- project-sub-runs
   "Walk the captured trace events and build the `:sub-runs` vector.
   Each :sub/run trace event surfaces as one entry with `:recomputed?
-  true`. Per Spec-Schemas §`:rf/epoch-record`: a sub queried via the
-  rf2-719e cache hit path does NOT emit `:sub/run` (the body fn does
-  not re-run), so cache-hit subs are absent from this projection."
+  true`. A sub queried via the cache-hit path does NOT emit `:sub/run`
+  (the body fn does not re-run), so cache-hit subs are absent from
+  this projection. Per Spec-Schemas §`:rf/epoch-record`."
   [events]
   (into []
         (comp
@@ -447,12 +434,12 @@
   "Walk the captured trace events and build the `:renders` vector.
   Renders are emitted by the view layer as `:view/render` trace events
   with `:render-key`, `:triggered-by`, and `:elapsed-ms` tags. Per
-  Spec-Schemas §`:rf/epoch-record` and Spec 004 §Render-tree primitives
-  (rf2-t5tx Option C / rf2-piag): `:render-key` is the tuple
-  `[<view-id> <instance-token>]` — the view-id names the kind, the
-  instance-token disambiguates concurrently-mounted instances. For
-  renders that bypass reg-view (plain Reagent fns), the trace recorder
-  emits `[:rf.view/anonymous nil]` as the documented fallback shape."
+  Spec-Schemas §`:rf/epoch-record` and Spec 004 §Render-tree primitives:
+  `:render-key` is the tuple `[<view-id> <instance-token>]` — the
+  view-id names the kind, the instance-token disambiguates concurrently-
+  mounted instances. For renders that bypass reg-view (plain Reagent
+  fns), the trace recorder emits `[:rf.view/anonymous nil]` as the
+  documented fallback shape."
   [events]
   (into []
         (comp
@@ -531,13 +518,10 @@
   event id or a frame-destroyed dispatch), no :run-start fires; fall
   back to the first event we can find with an `:event-id` tag.
 
-  Per rf2-txrq9: single-walk reduction over `events` — the original
-  two-pass `or`-of-`some` reordered both walks across the buffer
-  on the degenerate path. We now accumulate the first
+  Single-walk reduction over `events`: accumulate the first
   `:event/run-start` AND the first fallback `:event-id` in one
-  traversal and prefer the run-start. Either match short-circuits
-  at the earliest moment it can — a run-start hit immediately
-  reduces to the final result; a fallback-only stream walks once."
+  traversal, preferring the run-start. A run-start hit short-circuits
+  via `reduced`; a fallback-only stream walks the buffer once."
   [events]
   (let [result
         (reduce
@@ -623,13 +607,9 @@
   avoid leaking a partial buffer into the next cascade. No record
   is committed.
 
-  Per rf2-hul9q: the only consumer is `router.cljc`'s drain-abort
-  path via the `:epoch/discard-buffer!` late-bind hook (see the
-  registration at the foot of this namespace). The fn itself takes
-  no direct callers, so the visibility stays `defn-` to keep the
-  late-bind seam the sole public access path — matches the
-  `capture-event!` pattern used elsewhere in this ns for hook-only
-  producers."
+  Only consumer is `router.cljc`'s drain-abort path via the
+  `:epoch/discard-buffer!` late-bind hook. Visibility stays `defn-`
+  so the hook is the sole public access path."
   [frame-id]
   (when interop/debug-enabled?
     (harvest-buffer! frame-id))
@@ -638,18 +618,15 @@
 ;; ---- restore failure-mode predicates --------------------------------------
 
 (defn- malli-validate-fn
-  "Return the malli validate fn or nil.
+  "Return the malli validate fn or nil. Lookup order matches
+  `re-frame.schemas/default-malli-validate`:
 
-  Per rf2-t0hq — CLJS has no runtime `resolve`, so the lookup order on
-  CLJS is: late-bind hook then nil. Returning nil is treated as
-  soft-pass by callers ('cannot disprove, treat as valid').
-
-  Lookup order matches `re-frame.schemas/default-malli-validate`:
     1. Late-bind hook `:schemas/malli-validate` (published by
        `re-frame.schemas.malli` when loaded).
-    2. JVM only — fall back to `(requiring-resolve 'malli.core/validate)`.
-    3. Return nil (soft-pass — the schema-validate-ok? caller treats
-       a nil validate fn as 'cannot disprove, treat as valid')."
+    2. JVM only — `(requiring-resolve 'malli.core/validate)`.
+    3. Return nil (soft-pass — callers treat nil as 'cannot disprove,
+       treat as valid'; CLJS has no runtime `resolve` so the JVM
+       fallback is JVM-only)."
   []
   (or (late-bind/get-fn :schemas/malli-validate)
       #?(:clj  (try (requiring-resolve 'malli.core/validate)
@@ -704,9 +681,8 @@
   and `:rf/machine` (the spec map). Returns the registration map
   when machine-id names a registered machine, nil otherwise.
 
-  Per rf2-ocg1: epoch restore validates against this public surface,
-  not against the internal `:head` registrar kind that machines
-  never used."
+  Epoch restore validates against this public surface, not against
+  the internal `:head` registrar kind that machines never used."
   [machine-id]
   (let [reg (registrar/lookup :event machine-id)]
     (when (:rf/machine? reg)
@@ -736,9 +712,8 @@
   with `:rf/machine?`) and `:route` (`:id` must reference a registered
   :route).
 
-  Per rf2-ocg1: machine lookup goes through the event registry, NOT
-  the internal `:head` registrar kind. The latter is unrelated to
-  the public machine contract.
+  Machine lookup goes through the event registry — the `:head`
+  registrar kind is unrelated to the public machine contract.
 
   Returns a vector of {:kind <kind> :id <id>} entries. Empty when
   every reference resolves."
@@ -765,9 +740,9 @@
   `{:machine-id <id> :recorded <int> :current <int>}`. nil when no
   mismatch is found.
 
-  Per rf2-ocg1: both versions are read through the public Spec 005
-  §Snapshot shape contract — the snapshot's `[:meta :rf/snapshot-version]`
-  and the registered machine's `[:meta :rf/snapshot-version]`."
+  Both versions are read through the public Spec 005 §Snapshot shape
+  contract — the snapshot's and the registered machine's
+  `[:meta :rf/snapshot-version]`."
   [db]
   (some (fn [[machine-id snapshot]]
           (let [recorded (snapshot-version snapshot)]
@@ -785,8 +760,8 @@
   "Search a resolved history vector for the record matching `epoch-id`.
   Caller has already paid the `@histories` deref — `check-restore-
   preconditions!` reads history once at the top and reuses the vector
-  for both the lookup and the `:history-size` count on the
-  unknown-epoch failure path (rf2-3g7x3 — was two derefs)."
+  for both the lookup and the `:history-size` count on the unknown-
+  epoch failure path."
   [history epoch-id]
   (some (fn [r] (when (= epoch-id (:epoch-id r)) r))
         history))
@@ -862,7 +837,7 @@
           (let [db-target (:db-after epoch)]
             ;; Each helper is called once and its result bound, so the
             ;; failure path walks the recorded db / schema set / machine
-            ;; map exactly once per check (rf2-081zk).
+            ;; map exactly once per check.
             (if-let [failing-paths (seq (failing-paths-for frame-id db-target))]
               ;; (4) Schema mismatch?
               ;; Per Spec 010 §Schema digest + Tool-Pair §Time-travel:
@@ -933,30 +908,17 @@
         :fail (do (emit-precondition-failure! (second result) (nth result 2))
                   false)))))
 
-;; ---- reset-frame-db! (Tool-Pair §Pair-tool writes, rf2-zq55) -------------
+;; ---- reset-frame-db! (Tool-Pair §Pair-tool writes) ----------------------
+;; Dev-only — gated on `interop/debug-enabled?`. Replaces a frame's
+;; `app-db` with an arbitrary new value, bypassing the dispatch loop, and
+;; records a synthetic `:rf/epoch-record` so undo via `restore-epoch`
+;; works against the previous state. Failure modes (each is a no-op on
+;; `app-db` and returns `false`):
 ;;
-;; Per Tool-Pair §Pair-tool writes: a public Tool-Pair write surface that
-;; replaces a frame's `app-db` with an arbitrary new value, bypassing the
-;; dispatch loop. Used by pair-shaped tools for state injection (evolved-
-;; state-shape probes after a handler hot-swap), story tools, conformance
-;; harnesses, and time-travel from JSON-loaded bug repros.
-;;
-;; The surface is dev-only — gated on `interop/debug-enabled?`, the same
-;; gate as `restore-epoch` / `register-epoch-cb!` / the rest of the
-;; epoch-history machinery. Production builds (`:advanced` +
-;; goog.DEBUG=false) elide the body via Closure DCE; the surface is not
-;; available in shipped binaries.
-;;
-;; Failure modes (each is a no-op on `app-db` and returns `false`):
 ;;   :rf.error/no-such-handler            (kind :frame) — frame not registered
-;;   :rf.epoch/reset-frame-db-during-drain — called while drain is in flight
+;;   :rf.epoch/reset-frame-db-during-drain — drain in flight
 ;;   :rf.epoch/reset-frame-db-schema-mismatch — `new-db` fails the frame's
 ;;                                              registered app-schema set
-;;
-;; On success: records a synthetic `:rf/epoch-record` (so undo via
-;; `restore-epoch` works against the previous state), emits
-;; `:rf.epoch/db-replaced`, replaces the container, and fires registered
-;; epoch listeners with the assembled record.
 
 (defn- check-reset-frame-db-preconditions!
   "Validate the three documented preconditions for `reset-frame-db!`.
@@ -1010,7 +972,7 @@
 
 (defn reset-frame-db!
   "Replace `frame-id`'s `app-db` with `new-db`, bypassing the dispatch
-  loop. Per Tool-Pair §Pair-tool writes (rf2-zq55).
+  loop. Per Tool-Pair §Pair-tool writes.
 
   Records a synthetic `:rf/epoch-record` so `restore-epoch` can rewind
   the previous state; emits `:rf.epoch/db-replaced` on success.
@@ -1035,22 +997,10 @@
                   false)))))
 
 ;; ---- late-bind hook registration ------------------------------------------
-;;
-;; The router calls into settle! at drain-empty; the trace surface calls
-;; into capture-event! on every emit. Publishing through the late-bind
-;; registry keeps router.cljc / trace.cljc free of a require on this ns.
-;;
-;; Per rf2-lt4e (the seventh and final per-feature split per rf2-5vjj
-;; Strategy B), this namespace ships in `day8/re-frame2-epoch`; the
-;; core artefact MUST NOT statically `:require` it. Core's public
-;; re-exports (`rf/epoch-history`, `rf/restore-epoch`,
-;; `rf/register-epoch-cb!`, `rf/remove-epoch-cb!`) and the
-;; `(rf/configure :epoch-history ...)` knob look the producing fns up
-;; through the hook table at call time; when this artefact is not on
-;; the classpath those queries return nil / empty / false and the
-;; (rf/configure :epoch-history ...) call is a silent no-op — the
-;; epoch surface is dev-tier so an absent artefact degrades quietly
-;; rather than throwing.
+;; Core's re-exports look the producing fns up through this hook table
+;; so core never statically `:require`s the epoch artefact. Absent
+;; artefact: queries return nil / empty / false and `(rf/configure
+;; :epoch-history ...)` is a silent no-op.
 
 (late-bind/set-fn! :epoch/settle!             settle!)
 (late-bind/set-fn! :epoch/discard-buffer!     discard-buffer!)

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -42,7 +42,10 @@
 
 ;; ---- configuration --------------------------------------------------------
 
-(def ^:private default-depth 50)
+(def ^:private default-depth
+  ;; 50 — bounds the per-frame ring buffer; covers a deep undo trail
+  ;; without unbounded retention of replaced app-db snapshots.
+  50)
 
 (defonce ^:private config
   ;; Currently a single key (:depth) but kept as a map so future

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -11,41 +11,34 @@
   views; use a flow only if it must live in app-db for SSR / time-travel
   / inspector reasons.
 
-  ## Artefact (rf2-tfw3, fourth per-feature split per rf2-5vjj Strategy B)
+  ## Artefact
 
-  This namespace ships in `day8/re-frame2-flows`, separate from the
-  core artefact (`day8/re-frame2`). The core artefact's `re-frame.core`
-  re-exports of `reg-flow` / `clear-flow`, and the `:rf.fx/reg-flow` /
-  `:rf.fx/clear-flow` runtime fxs in `re-frame.fx`, look this
-  namespace's entry points up via the `re-frame.late-bind` hook table —
-  loading this namespace publishes the hooks. Apps that don't register
-  any flows don't drag the per-frame flow registry, the topological-
-  sort engine, the dirty-check `last-inputs` map, or the post-drain
-  `run-flows!` walker onto the classpath.
+  Ships in `day8/re-frame2-flows`, separate from the core artefact.
+  `re-frame.core` looks this namespace's entry points up through
+  `re-frame.late-bind`; loading this ns publishes the hooks.
 
-  ## Internal layout (rf2-mnu8z)
+  ## Internal layout
 
-  Per the rf2-zkca8 leaf-size ceiling the original 431-LoC monolith
-  was split along its three natural seams; this namespace is now the
-  public FAÇADE — it owns the post-drain evaluation walker, the fx-
-  call indirections, and the late-bind hook publications, and re-
-  exports the registry's public-surface symbols. The split is:
+  This namespace is the public FAÇADE — it owns the post-drain
+  evaluation walker, the fx-call indirections, and the late-bind hook
+  publications, and re-exports the registry's public-surface symbols.
+  The split is:
 
     - `re-frame.flows.topo`     — pure Kahn's topological sort +
-      cycle-path extraction. Unit-testable in isolation, no atoms,
-      no traces.
+                                  cycle-path extraction.
     - `re-frame.flows.registry` — per-frame `flows` + `last-inputs`
-      atoms, validation, `reg-flow` / `clear-flow`, the registrar
-      replacement-hook for hot-reload invalidation, and the
-      test-only `reset-flows!` / `reset-last-inputs!` resets.
+                                  atoms, validation, `reg-flow` /
+                                  `clear-flow`, the registrar
+                                  replacement-hook, and the test-only
+                                  resets.
     - `re-frame.flows` (this)   — `evaluate-flow!` / `run-flows!`,
-      fx-call indirections, late-bind hook publication, and the
-      public re-export surface.
+                                  fx-call indirections, late-bind
+                                  publication, public re-exports.
 
-  External consumers continue to reach every documented symbol at
-  `re-frame.flows/<name>` — production code via the late-bind hooks,
-  the per-artefact test fixtures via `re-frame.flows/flows` and
-  `(resolve 're-frame.flows/last-inputs)`."
+  Test fixtures across artefacts reach `re-frame.flows/flows` and
+  `re-frame.flows/last-inputs` directly (sometimes via `resolve`); the
+  re-exports below MUST land on a Var deref-equal to the registry's
+  own atom."
   (:require [re-frame.elision :as elision]
             [re-frame.flows.registry :as registry]
             [re-frame.flows.topo :as topo]
@@ -55,15 +48,6 @@
             [re-frame.trace :as trace]))
 
 ;; ---- public-surface re-exports -------------------------------------------
-;;
-;; Atoms re-exported as Vars so test fixtures across artefacts
-;; (`flows_test.clj`, `flows_trace_test.clj`, `smoke_test.clj`,
-;; `epoch_test.clj`, `core_api_additions_test.clj`, `reg_view_test.clj`,
-;; `source_coords_test.clj`, `ssr/test_fixture.clj`) keep working
-;; against the SAME atom value at `re-frame.flows/flows` and
-;; `re-frame.flows/last-inputs`. Several tests reach `last-inputs`
-;; via `(resolve 're-frame.flows/last-inputs)`; that resolve must
-;; continue to land on a var deref-equal to the registry's atom.
 
 (def flows       registry/flows)
 (def last-inputs registry/last-inputs)
@@ -87,24 +71,20 @@
   router's outer catch emits the cascade-level
   `:rf.error/flow-eval-exception`. Trace semantics live in Spec 009
   §Flow trace events; this docstring just names the failure-path
-  unwind (rf2-rlmla Q11 — the prior docstring claimed `[db false]`
-  was returned and downstream flows still walked, which contradicts
-  the actual `(throw e)` impl at the catch site below)."
+  unwind."
   [frame-id db flow]
   (let [flow-id    (:id flow)
         new-inputs (read-inputs db flow)
         ;; `last-inputs` is shaped {flow-id {frame-id inputs}} so the
         ;; hot-reload invalidation hook can drop a flow's whole row
-        ;; with one O(1) dissoc (rf2-2xq8w / PERF Q10). Per-frame
-        ;; dirty-check windows stay independent.
+        ;; with one O(1) dissoc; per-frame dirty-check windows stay
+        ;; independent.
         old-inputs (get-in @last-inputs [flow-id frame-id])]
     (if (= new-inputs old-inputs)
       (do
-        ;; Per Spec 009 §:op-type vocabulary: :rf.flow/skip records the
-        ;; suppressed recompute (per rf2-719e value-equal recompute
-        ;; suppression). Tools use this to surface "flow ran but inputs
-        ;; were stable" — distinct from "flow didn't fire at all because
-        ;; nothing wrote".
+        ;; :rf.flow/skip records value-equal recompute suppression so
+        ;; tools can distinguish "flow ran but inputs were stable" from
+        ;; "flow didn't fire at all". Per Spec 009 §:op-type vocabulary.
         (trace/emit! :flow :rf.flow/skip
                      {:flow-id flow-id
                       :reason  :inputs-value-equal
@@ -114,9 +94,9 @@
         (let [new-output (apply (:output flow) new-inputs)
               new-db     (assoc-in db (:path flow) new-output)]
           (swap! last-inputs assoc-in [flow-id frame-id] new-inputs)
-          ;; Per Spec 009 §:op-type vocabulary: :rf.flow/computed records
-          ;; a successful recompute. Per rf2-719e the dirty-check is
-          ;; =-equality so this only fires when inputs actually changed.
+          ;; :rf.flow/computed records a successful recompute. The
+          ;; dirty-check is =-equality so this only fires when inputs
+          ;; actually changed. Per Spec 009 §:op-type vocabulary.
           ;;
           ;; Wire-bearing payloads (`:input-values`, `:result`) ride
           ;; through `elision/elide-wire-value` per Spec 009 §Size
@@ -202,19 +182,9 @@
               (recur (rest remaining) new-db (or any-dirty? dirty?)))))))))
 
 ;; ---- late-bind hook registration ----------------------------------------
-;;
-;; re-frame.core, re-frame.fx, re-frame.router and re-frame.test-support
-;; need to call into flows but per rf2-tfw3 ship in the core artefact
-;; — they cannot `:require` this namespace because the flows artefact
-;; is optional (apps that don't register flows don't carry it). Publish
-;; entry points through the late-bind hook registry; consumers look the
-;; fns up at call time. See re-frame.late-bind.
-;;
-;; Calls are written as literal `set-fn!` invocations with a literal
-;; keyword (one per line) — the late-bind drift gate
-;; (`re-frame.late-bind-drift-test`) detects each publication via regex
-;; over `implementation/**/src/**`, matching every other artefact's
-;; publication block (schemas / machines / routing / http / ssr).
+;; Literal `set-fn!` invocations with literal keywords (one per line) —
+;; the late-bind drift gate `re-frame.late-bind-drift-test` detects each
+;; publication via regex.
 
 (late-bind/set-fn! :flows/reg-flow           reg-flow)
 (late-bind/set-fn! :flows/clear-flow         clear-flow)

--- a/implementation/http/src/re_frame/http_managed.cljc
+++ b/implementation/http/src/re_frame/http_managed.cljc
@@ -28,62 +28,38 @@
   The `:rf.http/managed` fx itself is dev+prod (user-facing). The canned
   stub fxs gate on `interop/debug-enabled?` so they elide in production.
 
-  ## Artefact (rf2-5kpd, fifth per-feature split per rf2-5vjj Strategy B)
+  ## Artefact
 
-  This namespace ships in `day8/re-frame2-http`, separate from the core
-  artefact (`day8/re-frame2`). The core artefact's `re-frame.core`
-  re-exports of `install-managed-request-stubs!` /
-  `uninstall-managed-request-stubs!` / `with-managed-request-stubs*` /
-  `with-managed-request-stubs` look this namespace's entry points up via
-  the `re-frame.late-bind` hook table — loading this namespace publishes
-  the hooks AND registers the `:rf.http/managed`,
-  `:rf.http/managed-abort`, `:rf.http/managed-canned-success`, and
-  `:rf.http/managed-canned-failure` fxs. Apps that don't issue any
-  managed-HTTP requests don't drag the in-flight request registry, the
-  Fetch / HttpClient transport adapters, the encode / decode pipeline,
-  the retry-with-backoff machinery, the eight-category `:rf.http/*`
-  failure taxonomy, or any of the `:rf.http/*` keyword strings onto the
-  classpath.
+  Ships in `day8/re-frame2-http`, separate from the core artefact.
+  Loading this ns publishes the late-bind hooks `re-frame.core` reaches
+  through AND registers the `:rf.http/managed` family of fxs.
 
-  ## File split (rf2-3i9b, rf2-p7da, rf2-0eyp2)
+  ## File split
 
-  This namespace was 1790 LoC pre-split; it's now a thin public façade.
-  The implementation is in per-concern sibling namespaces (flat
-  dash-form naming, NOT dot-form — per rf2-2vbm `re-frame.http.X` would
-  collide with `goog.provide('re_frame.http')` on CLJS):
+  Thin public façade over per-concern sibling namespaces (flat dash-form
+  naming — `re-frame.http.X` would collide with `goog.provide` on CLJS):
 
-   - `re-frame.http-encoding`       — URL/query/body encoding, decode
-                                      pipeline, `:accept` normalisation,
-                                      failure-map / build-reply-event /
-                                      `dispatch-reply-via-late-bind!`,
-                                      backoff. All pure fns.
-   - `re-frame.http-registry`       — in-flight request + actor-id
-                                      indexes, supersede semantics,
-                                      `abort-on-actor-destroy` (rf2-wvkn),
-                                      spawned-actor detection.
-   - `re-frame.http-middleware`     — per-frame request-side interceptor
-                                      chain (rf2-6y3q).
-   - `re-frame.http-transport`     — shared Fetch (CLJS) + HttpClient
-                                      (JVM) transport + attempt loop;
-                                      platform-specific fragments are
-                                      gated with reader conditionals
-                                      (rf2-921qy).
-   - `re-frame.http-handlers`      — `:rf.http/managed` /
-                                      `:rf.http/managed-abort` fx
-                                      handler bodies (rf2-0eyp2).
-   - `re-frame.http-machine-wrapper`— machine-shape wrapper (rf2-ijm7),
-                                      canned stub handlers,
-                                      with-managed-request-stubs*.
-   - `re-frame.util-json`           — pure-Clojure JSON reader extracted
-                                      per rf2-p7da; shared by the decode
-                                      pipeline. (Currently shipped in
-                                      the http artefact; lift to core
-                                      if a second consumer appears.)
+   - `re-frame.http-encoding`        — pure encoding / decode pipeline /
+                                       backoff.
+   - `re-frame.http-registry`        — in-flight + actor-id indexes,
+                                       supersede semantics, abort-on-
+                                       actor-destroy.
+   - `re-frame.http-middleware`      — per-frame request-side interceptor
+                                       chain.
+   - `re-frame.http-transport`       — shared Fetch (CLJS) + HttpClient
+                                       (JVM) transport + attempt loop.
+   - `re-frame.http-handlers`        — `:rf.http/managed` /
+                                       `:rf.http/managed-abort` fx
+                                       handler bodies.
+   - `re-frame.http-machine-wrapper` — machine-shape wrapper, canned
+                                       stub handlers,
+                                       with-managed-request-stubs*.
+   - `re-frame.util-json`            — pure-Clojure JSON reader shared by
+                                       the decode pipeline.
 
-  This façade re-exports the public surface of those sub-namespaces
-  AND performs the artefact's load-time side-effects: the
-  `:rf.http/*` fx registrations and the `late-bind/set-fn!` hook
-  publications that `re-frame.core` reaches through."
+  This façade re-exports the public surface and performs the load-time
+  side-effects: `:rf.http/*` fx registrations and `late-bind/set-fn!`
+  hook publications."
   (:require [re-frame.fx                   :as fx]
             [re-frame.http-handlers        :as handlers]
             [re-frame.http-machine-wrapper :as machine-wrapper]
@@ -94,12 +70,6 @@
             [re-frame.late-bind            :as late-bind]))
 
 ;; ---- public-surface re-exports --------------------------------------------
-;;
-;; These `def`s make the sub-namespace fns reachable as
-;; `re-frame.http-managed/<name>` so consumers (the `re-frame.core` late-
-;; bind bridge, the test fixtures, examples that
-;; `:require [re-frame.http-managed :as http-managed]`) see the same
-;; surface they did pre-split.
 
 ;; Registry surface — tests deref the atoms and call the snapshot fns.
 (def in-flight                   registry/in-flight)
@@ -109,7 +79,7 @@
 (def actor-in-flight-snapshot    registry/actor-in-flight-snapshot)
 (def abort-on-actor-destroy      registry/abort-on-actor-destroy)
 
-;; Middleware surface — per rf2-6y3q. Tests deref @http-managed/interceptors.
+;; Middleware surface. Tests deref @http-managed/interceptors.
 (def interceptors                middleware/interceptors)
 (def reg-http-interceptor        middleware/reg-http-interceptor)
 (def clear-http-interceptor      middleware/clear-http-interceptor)
@@ -120,21 +90,17 @@
 (def uninstall-managed-request-stubs! machine-wrapper/uninstall-managed-request-stubs!)
 (def with-managed-request-stubs*      machine-wrapper/with-managed-request-stubs*)
 
-;; Privacy surface — Spec 014 §Privacy (rf2-bma05). Header denylist lives
-;; in `re-frame.http-privacy-headers`; the orchestrating composers
+;; Privacy surface — Spec 014 §Privacy. Header denylist lives in
+;; `re-frame.http-privacy-headers`; the orchestrating composers
 ;; (request-sensitive?, prepare-emit-*) stay in `re-frame.http-privacy`.
 (def declare-sensitive-header!  privacy-headers/declare-sensitive-header!)
 (def clear-sensitive-headers!   privacy-headers/clear-sensitive-headers!)
 (def default-header-denylist    privacy-headers/default-header-denylist)
 
 ;; ---- registration ---------------------------------------------------------
-;;
-;; The `:rf.http/managed` and `:rf.http/managed-abort` fx handler bodies
-;; live in `re-frame.http-handlers` (per rf2-0eyp2). The façade only
-;; performs the `(fx/reg-fx ...)` registrations and the canned-stub
-;; registrations gated on `interop/debug-enabled?`. Apps that don't
-;; load `re-frame.http-managed` don't carry the handlers either —
-;; the registration site is the load-time anchor.
+;; The handler bodies live in `re-frame.http-handlers`; the façade
+;; performs the registrations and gates the canned stubs on
+;; `interop/debug-enabled?` so they DCE in production.
 
 (fx/reg-fx :rf.http/managed
            {:doc "Spec 014 — managed HTTP request."}
@@ -144,13 +110,8 @@
            {:doc "Spec 014 — abort an in-flight :rf.http/managed by request-id."}
            handlers/managed-abort-handler)
 
-;; The two canned-stub fxs are gated on `interop/debug-enabled?` so they
-;; elide in production. Per Spec 014 §Testing — "Don't ship the canned-
-;; stub fxs as production-eligible". The gate applies on BOTH hosts: on
-;; JVM `debug-enabled?` is `true` so the registrations run; on CLJS the
-;; gate folds to `(when goog/DEBUG ...)` and `:advanced + goog.DEBUG=
-;; false` DCEs the entire body — fx-id keywords, doc string, handler
-;; var references and all (rf2-omsae).
+;; Canned-stub fxs are gated on `interop/debug-enabled?` so they DCE in
+;; production builds. Per Spec 014 §Testing.
 (when interop/debug-enabled?
   (fx/reg-fx :rf.http/managed-canned-success
              {:doc "Spec 014 — synthesised success reply (test stub)."}
@@ -178,17 +139,7 @@
      [stubs & body]
      `(with-managed-request-stubs* ~stubs (fn [] ~@body))))
 
-;; ---- late-bind hook registration ------------------------------------------
-;;
-;; re-frame.core needs to call into the test-time helpers but per
-;; rf2-5kpd ships in the core artefact — it cannot `:require` this
-;; namespace because the http artefact is optional (apps that don't
-;; issue any managed-HTTP requests don't carry it). Publish entry
-;; points through the late-bind hook registry; consumers look the fns
-;; up at call time. The contracts live in each sub-namespace's
-;; docstring (see e.g. `registry/abort-on-actor-destroy`,
-;; `middleware/reg-http-interceptor`); the listing below is alphabetical
-;; for scan-ability.
+;; ---- late-bind hook registration (alphabetised) -------------------------
 
 (late-bind/set-fn! :http/abort-on-actor-destroy           abort-on-actor-destroy)
 (late-bind/set-fn! :http/clear-all-http-interceptors!     clear-all-http-interceptors!)

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -1,15 +1,12 @@
-;; day8/re-frame2-machines — public façade for the state-machine
-;; artefact. Per Spec 005 §State machines.
-;;
-;; The implementation lives in `re-frame.machines.{transition, parallel,
-;; timer, lifecycle-fx}` (plus the `lifecycle_fx/*` sub-namespaces).
-;; This namespace re-exports their public surface and runs the
-;; artefact's load-time side-effects — registering the `:rf.machine/*`
-;; reserved fxs and publishing the `late-bind/set-fn!` hooks that
-;; `re-frame.core` reaches through.
-
 (ns re-frame.machines
   "State machines. Per Spec 005.
+
+  Public façade for `day8/re-frame2-machines`. The implementation lives
+  in `re-frame.machines.{transition, parallel, timer, lifecycle-fx}`
+  (plus the `lifecycle_fx/*` sub-namespaces); this ns re-exports their
+  public surface and runs the artefact's load-time side-effects —
+  registering the `:rf.machine/*` reserved fxs and publishing the
+  `late-bind/set-fn!` hooks that `re-frame.core` reaches through.
 
   Implements the v1 grammar:
     - Transition tables with :on, :entry, :exit, :guard, :action.
@@ -18,38 +15,17 @@
     - :always microsteps with bounded depth and atomic rollback on
       depth-exceeded.
     - :after delayed transitions with per-machine :rf/after-epoch
-      tracking; the synthetic :rf.machine.timer/after-elapsed event
-      fires the transition only when the carried epoch matches. Per
-      rf2-3y3y, `:after` delays admit three forms — pos-int? literal,
+      tracking; delays admit three forms — pos-int? literal,
       subscription vector ([:sub-id & args]; re-resolves on sub change),
       and (fn [snapshot] ms) computed once at state entry.
     - Declarative :invoke that desugars into [:rf.machine/spawn args]
       on entry and [:rf.machine/destroy actor-id] on exit; deterministic
       actor ids via a per-process counter.
-    - Declarative :invoke-all (rf2-6vmw) — spawn-and-join sugar over N
-      parallel :invoke's plus a join condition (:all / :any / {:n N} /
-      {:fn pred}).
+    - Declarative :invoke-all — spawn-and-join sugar over N parallel
+      :invoke's plus a join condition (:all / :any / {:n N} / {:fn pred}).
     - The :raise reserved fx-id (machine-internal pre-commit dispatch).
     - Snapshot at [:rf/machines <id>] in app-db.
-    - Pure machine-transition fn (JVM- and CLJS-runnable, deterministic).
-
-  Public surface re-exported from the sub-namespaces:
-    - `reg-machine*`, `create-machine-handler` —
-      `re-frame.machines.lifecycle-fx`
-    - `machine-transition` — `re-frame.machines.parallel` (the public
-      dispatch; flat / compound delegates to
-      `re-frame.machines.transition`'s `machine-transition-single`)
-    - `machines`, `machine-meta`, `machine-by-system-id` —
-      `re-frame.machines.lifecycle-fx`
-    - `spawn-fx`, `destroy-machine-fx`, `invoke-all-init-fx` —
-      `re-frame.machines.lifecycle-fx`
-    - `after-schedule-fx`, `after-cancel-fx` — `re-frame.machines.timer`
-
-  Conformance fixtures cover all of the above (machine-transition,
-  hierarchical-{compound,cross-level,parent-fallthrough}-transition,
-  always-{single-microstep,depth-exceeded}, after-{single-delay,
-  stale-detection,hierarchy}, invoke-spawn-on-entry-destroy-on-exit,
-  invoke-all-{join-all-completes,join-any-fails-cancels,n-of-cancels-extras})."
+    - Pure machine-transition fn (JVM- and CLJS-runnable, deterministic)."
   (:require [re-frame.fx :as fx]
             [re-frame.late-bind :as late-bind]
             [re-frame.machines.lifecycle-fx :as lifecycle-fx]
@@ -59,21 +35,12 @@
             [re-frame.subs :as subs]))
 
 ;; ---- public-surface re-exports --------------------------------------------
-;;
-;; These `def`s make the sub-namespace fns reachable as
-;; `re-frame.machines/<name>` so consumers (the `re-frame.core` late-bind
-;; bridge, the conformance corpus, the test fixtures, examples that
-;; `:require [re-frame.machines :as machines]`) see the same surface
-;; they did pre-split.
-
-;; Per rf2-gr8q the global `spawn-counter` atom is gone. Declarative-
-;; :invoke spawns allocate ids inside the parent snapshot's
-;; `:rf/spawn-counter` slot via `re-frame.machines.transition/
-;; allocate-spawned-id`; hand-emitted spawn fxs allocate from the frame's
-;; app-db slot at `[:rf/spawn-counter <machine-id>]` inside the spawn-fx
-;; db-swap. `machine-transition` is now an honest pure function — no
-;; module-level mutable state, deterministic from its (machine snapshot
-;; event) arguments.
+;; Declarative-:invoke spawns allocate ids inside the parent snapshot's
+;; `:rf/spawn-counter` slot via `transition/allocate-spawned-id`;
+;; hand-emitted spawn fxs allocate from the frame's app-db slot at
+;; `[:rf/spawn-counter <machine-id>]` inside the spawn-fx db-swap, so
+;; `machine-transition` is a pure function — deterministic from
+;; (machine snapshot event).
 
 (def reg-machine*           lifecycle-fx/reg-machine*)
 (def create-machine-handler lifecycle-fx/create-machine-handler)
@@ -87,10 +54,9 @@
 (def after-schedule-fx      timer/after-schedule-fx)
 (def after-cancel-fx        timer/after-cancel-fx)
 
-;; Per Spec 005 §3-arity escape hatch — `:state` / `:meta` introspection
-;; (rf2-2yupx): explicit opt-in via the `:rf.machine/wants-ctx` metadata
-;; flag replaces the pre-rf2-2yupx structural arity-detection rule. The
-;; `wants-ctx` helper is the wrapper form for anonymous fns where the
+;; Per Spec 005 §3-arity escape hatch — `:state` / `:meta` introspection:
+;; opt in via the `:rf.machine/wants-ctx` metadata flag. The `wants-ctx`
+;; helper is the wrapper form for anonymous fns where the
 ;; `^:rf.machine/wants-ctx` reader-macro form is awkward.
 (def wants-ctx              transition/wants-ctx)
 
@@ -105,34 +71,22 @@
   hook shape used to release a destroyed frame's host-clock handles and
   subscription watchers without touching sibling frames.
 
-  Per rf2-gr8q the per-process `spawn-counter` atom is gone — declarative-
-  :invoke spawn-id allocation lives inside the parent snapshot's
-  `:rf/spawn-counter` slot, and hand-emitted-spawn allocation lives inside
-  the frame's app-db at `[:rf/spawn-counter <machine-id>]`. Both reset
-  automatically: per-test snapshot rollback (via test-support's registrar
-  snapshot/restore + frame reset) clears the app-db; per-fixture snapshot
-  input in the conformance harness is hand-built fresh on each call.
-
-  Per rf2-ysa94 the wall-clock timer table is now frame-scoped — the
-  last remaining per-process mutable state in the machines artefact —
-  so the 0-arity / 1-arity split aligns with the test-fixture and
-  frame-destroy call sites respectively."
+  The wall-clock timer table is frame-scoped, so the 0-arity / 1-arity
+  split aligns with the test-fixture and frame-destroy call sites
+  respectively. Spawn-id allocation lives inside the parent snapshot's
+  `:rf/spawn-counter` slot (or in the frame's app-db at
+  `[:rf/spawn-counter <machine-id>]` for hand-emitted spawns) and resets
+  automatically via the per-test snapshot rollback / fresh fixture input."
   ([]
    (timer/cancel-all-timers!))
   ([frame-id]
    (timer/cancel-all-timers! frame-id)))
 
 ;; ---- machine-internal effect handlers ------------------------------------
-;;
-;; Per Spec 005 §Declarative :invoke (sugar over spawn) the runtime
-;; effects `:rf.machine/spawn` and `:rf.machine/destroy` are emitted
-;; into the fx vector by `apply-transition-once` whenever entry/exit
-;; cascades cross an :invoke-bearing state. Per rf2-xbtj these handlers
-;; live in this namespace (rather than `re-frame.fx`'s reserved
-;; case-block) so an app that doesn't pull in
-;; `day8/re-frame2-machines` carries neither the trace strings
-;; (`:rf.machine/spawned`, `:rf.machine/destroyed`) nor the handler
-;; symbols on its production-elision bundle.
+;; The handlers live here (rather than `re-frame.fx`'s reserved
+;; case-block) so an app that doesn't pull in `day8/re-frame2-machines`
+;; carries neither the trace strings nor the handler symbols on its
+;; production-elision bundle.
 
 (fx/reg-fx :rf.machine/spawn
   {:doc "Spawn a machine instance. Per Spec 005 §Declarative :invoke (sugar over spawn). Args carry `:machine-id`, optional `:system-id`, and optional `:initial-data`."}
@@ -170,38 +124,20 @@
   (fn [db [_ machine-id]]
     (get-in db [:rf/machines machine-id])))
 
-;; Per Spec 005 §State tags (rf2-ee0d / Nine States Stage 1): the
-;; `:rf/machine-has-tag?` framework sub returns `true` iff the named
-;; machine's current snapshot's `:tags` set contains the queried tag.
-;; A machine that hasn't been initialised yet (no snapshot at
-;; `[:rf/machines <id>]`) returns `false`.
-;;
-;; Derived sub — reads the snapshot via `get-in` rather than chaining
-;; off `:rf/machine` — so a view that only cares about whether a specific
-;; tag is present re-renders only when the containment-bit flips.
+;; Per Spec 005 §State tags: derived sub reading the snapshot via
+;; `get-in` rather than chaining off `:rf/machine`, so a view that
+;; only cares about whether a specific tag is present re-renders
+;; only when the containment-bit flips.
 (subs/reg-sub :rf/machine-has-tag?
-  {:doc "Subscribe to a machine's `:fsm/tags` containment-bit for `tag`. Returns `true` iff the named machine's snapshot's `:tags` set contains `tag`, `false` otherwise (including unknown / not-yet-initialised machines). Per Spec 005 §State tags (rf2-ee0d / Nine States Stage 1)."}
+  {:doc "Subscribe to a machine's `:fsm/tags` containment-bit for `tag`. Returns `true` iff the named machine's snapshot's `:tags` set contains `tag`, `false` otherwise (including unknown / not-yet-initialised machines). Per Spec 005 §State tags."}
   (fn [db [_ machine-id tag]]
     (contains? (get-in db [:rf/machines machine-id :tags]) tag)))
 
 ;; ---- late-bind hook registration ------------------------------------------
-;;
-;; Per rf2-xbtj the machines surface ships in
-;; `day8/re-frame2-machines`. `re-frame.core` and `re-frame.test-support`
-;; MUST NOT `:require [re-frame.machines]` — the artefact is optional, and
-;; a static require would force every consumer of the core artefact to
-;; drag the namespace's `:rf/machine` sub registration onto the classpath.
-;; The public-API re-exports and the test-support reset helper are
-;; published through the late-bind table; consumers without the
-;; machines artefact see the hooks unregistered and the surface
-;; throws / returns safe defaults cleanly.
-;;
-;; Per Spec 005 §reg-machine vs reg-machine* (rf2-8bp3): the late-bind
-;; hook key is `:machines/reg-machine` and points at `reg-machine*` —
-;; the plain-fn surface. The `reg-machine` macro at the `re-frame.core`
-;; boundary is import-time-only (CLJS macroexpansion runs before
-;; ns-load); the runtime always reaches through this hook to the
-;; plain-fn surface.
+;; The `:machines/reg-machine` hook points at `reg-machine*` — the
+;; plain-fn surface. The `reg-machine` macro at the `re-frame.core`
+;; boundary is import-time-only; the runtime always reaches through
+;; this hook to the plain-fn surface.
 
 (late-bind/set-fn! :machines/reg-machine            reg-machine*)
 (late-bind/set-fn! :machines/create-machine-handler create-machine-handler)
@@ -210,15 +146,10 @@
 (late-bind/set-fn! :machines/machine-meta           machine-meta)
 (late-bind/set-fn! :machines/machine-by-system-id   machine-by-system-id)
 (late-bind/set-fn! :machines/reset-timers!          reset-timers!)
-;; Per rf2-ysa94: per-frame timer-table cleanup wired into
-;; `frame/destroy-frame!`. The frame-scoping refactor partitions the
-;; timer table `{<frame-id> {…}}`; without this hook a destroyed
-;; frame's inner table would linger as dead bookkeeping (and worse, any
-;; in-flight host-clock handles would survive teardown). Late-bound
-;; through the hook table mirroring the rf2-fcj33 SSR
-;; `:ssr/on-frame-destroyed` cleanup pattern — core never statically
-;; requires the machines artefact, so the hook resolves to nil when
-;; this namespace is absent and `destroy-frame!` proceeds without it.
+;; Per-frame timer-table cleanup wired into `frame/destroy-frame!`.
+;; Without this hook the destroyed frame's inner table lingers as
+;; dead bookkeeping and any in-flight host-clock handles survive
+;; teardown.
 (late-bind/set-fn! :machines/on-frame-destroyed!
                    (fn [frame-id] (timer/cancel-all-timers! frame-id)))
 (late-bind/set-fn! :machines/spawn-fx               spawn-fx)
@@ -227,14 +158,10 @@
 (late-bind/set-fn! :machines/after-schedule-fx      after-schedule-fx)
 (late-bind/set-fn! :machines/after-cancel-fx        after-cancel-fx)
 
-;; rf2-ijm7 — load-order resilience for the `:rf.http/managed` machine-shape
-;; wrapper. The wrapper is registered by re-frame.http-managed via the
-;; `:machines/reg-machine` hook published above; but if http-managed loaded
-;; BEFORE this namespace (the load-order is determined by the consuming app's
-;; require graph, not by either artefact), the wrapper's bottom-of-ns call
-;; found a nil hook and skipped its registration. We close that race by
-;; re-invoking the http artefact's `:http/register-managed-machine!` hook
-;; from here — if http-managed is on the classpath the hook is set and the
-;; wrapper registers now; if it isn't, the hook is nil and this is a no-op.
+;; Load-order resilience: if http-managed loaded BEFORE this ns the
+;; `:rf.http/managed` machine-shape wrapper would have skipped its
+;; registration on a then-nil `:machines/reg-machine`. Re-invoke its
+;; hook from here so either load order resolves correctly. No-op when
+;; http-managed is absent.
 (when-let [reg-fn (late-bind/get-fn :http/register-managed-machine!)]
   (reg-fn))

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -1042,18 +1042,11 @@ unknown strategies as :preserve (no-op)."}
                     {:fx-id :rf.nav/scroll :strategy strategy}))))
 
 ;; ---- framework-shipped subs over the slice -------------------------------
-;;
-;; Per Spec 012 the framework ships `:rf/route` (the layer-1 read of the
-;; :rf/route slice) and the layer-2 derivations `:rf.route/{id,params,query,
-;; transition,error}`. Per rf2-k682 these subs ship in this artefact
-;; (rather than `re-frame.core`) so apps that don't pull
-;; `day8/re-frame2-routing` carry neither the registration metadata nor
-;; the `:rf.route/*` keyword strings on their production-elision bundle.
-;;
-;; Lives in this namespace (rather than core.cljc) so the smoke-test
-;; fixture's `require :reload` re-installs the registrations after
-;; `registrar/clear-all!` — exactly the same ergonomic the machines
-;; namespace's `:rf/machine` reg-sub uses.
+;; Spec 012's `:rf/route` (layer-1) and `:rf.route/{id,params,query,
+;; transition,error}` (layer-2) live here (not core.cljc) so apps that
+;; don't pull `day8/re-frame2-routing` carry neither the registration
+;; metadata nor the `:rf.route/*` keyword strings, and so the smoke-test
+;; fixture's `require :reload` re-installs them after `registrar/clear-all!`.
 
 (defn route-sub-fn
   "Layer-1 sub fn for :rf/route — reads the slice from app-db. Exposed
@@ -1196,17 +1189,9 @@ unknown strategies as :preserve (no-op)."}
                                :handler-fn route-link-render-ssr)))
 
 ;; ---- late-bind hook registration ------------------------------------------
-;;
-;; Per rf2-k682 the routing surface ships in `day8/re-frame2-routing`.
-;; `re-frame.core` MUST NOT `:require [re-frame.routing]` — the artefact
-;; is optional, and a static require would force every consumer of the
-;; core artefact to drag the namespace, the route-rank / pattern-compile
-;; / nav-token machinery, the `:rf/route` reg-sub family, and every
-;; `:rf.route/*` / `:rf.nav/*` trace/event keyword onto the classpath.
-;; The public-API re-exports (`reg-route`, `match-url`, `route-url`) are
-;; published through the late-bind table; consumers without the routing
-;; artefact see the hooks unregistered and the active surfaces throw
-;; cleanly while the read-only surfaces return safe defaults.
+;; The public-API re-exports are published through the late-bind table
+;; so `re-frame.core` can be required without dragging in the optional
+;; routing artefact.
 
 (late-bind/set-fn! :routing/reg-route        reg-route)
 (late-bind/set-fn! :routing/match-url        match-url)

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -15,48 +15,31 @@
   the active frame (`(frame/current-frame)`); `(reg-app-schema path
   schema {:frame frame-id})` registers explicitly.
 
-  Per Spec 010 §Non-Malli validators (rf2-froe) the validator and
-  explainer fns are pluggable via `set-schema-validator!` /
-  `set-schema-explainer!`. The default validator delegates to Malli
-  (`(resolve 'malli.core/validate)`); apps that want to opt out — to
-  drop the ~24 KB gzipped Malli surface measured in
-  findings/malli-bundle-cost-audit.md — register a different fn (or
-  `nil` for a hard no-op). The `:spec` value remains opaque to the
-  framework; only the registered validator interprets it.
+  Per Spec 010 §Non-Malli validators the validator and explainer fns
+  are pluggable via `set-schema-validator!` / `set-schema-explainer!`.
+  The default delegates to Malli; apps that want to opt out — to drop
+  the ~24 KB gzipped Malli surface — register a different fn (or `nil`
+  for a hard no-op). The `:spec` value is opaque to the framework;
+  only the registered validator interprets it.
 
-  Per rf2-dgug5 the original 1247-LoC monolith was split along the
-  banner-line concerns the file's own opening docstring described:
+  This namespace is the public façade over the sub-namespaces:
 
-    - `re-frame.schemas.validator`      — pluggable validator/explainer
-      atoms + `set-schema-validator!` / `set-schema-explainer!` /
-      `reset-schema-validator!` / `run-validator` / `run-explainer`
-      (rf2-froe / rf2-t0hq).
-    - `re-frame.schemas.storage`        — per-frame schema registry
-      (`schemas-by-frame`, `reg-app-schema` / `reg-app-schemas`,
-      `app-schema-at` / `app-schema-meta-at` / `app-schemas`,
-      `frame-schema-entries`, snapshot/restore/clear). Per rf2-0frdi
-      this is the single source of truth — there is no registrar
-      `:app-schema` slot.
+    - `re-frame.schemas.validator`      — pluggable validator / explainer
+                                          atoms + setters / resetters.
+    - `re-frame.schemas.storage`        — per-frame schema registry (the
+                                          single source of truth; there
+                                          is NO registrar `:app-schema`
+                                          slot).
     - `re-frame.schemas.walker`         — unified per-slot flag walker
-      (rf2-nwv63 / rf2-kj51z / rf2-oghml) parameterised on the flag
-      key, plus `extract-large-paths-from-schema`,
-      `extract-sensitive-paths-from-schema`, `schema-has-sensitive?`.
-    - `re-frame.schemas.elision-feeder` — per-frame `:large?` /
-      `:sensitive?` declaration aggregators + idempotent
-      `[:rf/elision]` populators (rf2-v9tw2 / rf2-c1l4d).
-    - `re-frame.schemas.digest`         — Spec 010 §Digest algorithm
-      and `app-schemas-digest`.
+                                          plus path extractors.
+    - `re-frame.schemas.elision-feeder` — `:large?` / `:sensitive?`
+                                          aggregators + idempotent
+                                          `[:rf/elision]` populators.
+    - `re-frame.schemas.digest`         — `app-schemas-digest` (Spec 010
+                                          §Digest algorithm).
     - `re-frame.schemas.validate`       — the five dev-time validation
-      entry points (`validate-event!` / `validate-cofx!` /
-      `validate-fx!` / `validate-app-db!` / `validate-sub-return!`)
-      and the production-side boundary-validation seam
-      (`validate-with-registered-fn` / `explain-with-registered-fn`).
-
-  This namespace is the public façade — it re-exports the symbols
-  every external consumer reaches through (tests, `re-frame.core-
-  schemas`, the late-bind hook table) and owns the late-bind hook
-  registration so consumer artefacts pick up the schemas surface
-  without statically requiring it."
+                                          entry points + the production
+                                          boundary-validation seam."
   (:require [re-frame.late-bind :as late-bind]
             [re-frame.schemas.digest :as digest]
             [re-frame.schemas.elision-feeder :as elision-feeder]
@@ -76,7 +59,7 @@
 (def explainer-fn     validator/explainer-fn)
 (def printer-fn       validator/printer-fn)
 
-;; Validator / explainer / printer (rf2-froe + rf2-wla45).
+;; Validator / explainer / printer.
 (def set-schema-validator!   validator/set-schema-validator!)
 (def set-schema-explainer!   validator/set-schema-explainer!)
 (def set-schema-printer!     validator/set-schema-printer!)
@@ -95,13 +78,13 @@
 (def restore-schemas-by-frame! storage/restore-schemas-by-frame!)
 (def clear-schemas-by-frame!   storage/clear-schemas-by-frame!)
 
-;; Per-slot flag walker (rf2-nwv63 / rf2-kj51z / rf2-oghml).
+;; Per-slot flag walker.
 (def walk-flagged-schema              walker/walk-flagged-schema)
 (def extract-large-paths-from-schema  walker/extract-large-paths-from-schema)
 (def extract-sensitive-paths-from-schema walker/extract-sensitive-paths-from-schema)
 (def schema-has-sensitive?            walker/schema-has-sensitive?)
 
-;; Per-flag registry feeders (rf2-v9tw2 / rf2-c1l4d).
+;; Per-flag registry feeders.
 (def frame-elision-declarations    elision-feeder/frame-elision-declarations)
 (def populate-elision-declarations elision-feeder/populate-elision-declarations)
 (def frame-sensitive-declarations    elision-feeder/frame-sensitive-declarations)
@@ -117,25 +100,14 @@
 (def validate-fx!         validate/validate-fx!)
 (def validate-sub-return! validate/validate-sub-return!)
 
-;; Production-side boundary-validation seam (rf2-r2uh).
+;; Production-side boundary-validation seam.
 (def validate-with-registered-fn validate/validate-with-registered-fn)
 (def explain-with-registered-fn  validate/explain-with-registered-fn)
 
 ;; ---- late-bind hook registration ------------------------------------------
-;;
-;; re-frame.router, re-frame.cofx, re-frame.subs, re-frame.elision,
-;; re-frame.epoch, re-frame.test-support, and re-frame.core-schemas
-;; need to call into schema validation but cannot `:require` this
-;; namespace without forcing the schemas artefact onto every consumer's
-;; classpath (per rf2-p7va — schemas is optional). Publish entry points
-;; through the late-bind hook registry. See re-frame.late-bind.
-;;
-;; Calls are written as literal `set-fn!` invocations with a literal
-;; keyword (one per line) rather than collapsed into a data-driven
-;; doseq, so the late-bind drift gate
-;; (`re-frame.late-bind-drift-test`) can detect each publication via
-;; regex — matching the convention of every other artefact's
-;; publication block (flows / machines / routing / http / ssr).
+;; Literal `set-fn!` invocations with literal keywords (one per line) —
+;; the late-bind drift gate `re-frame.late-bind-drift-test` detects each
+;; publication via regex.
 
 ;; Validation hot-path hooks (consumed by router / cofx / subs / epoch).
 (late-bind/set-fn! :schemas/validate-app-db!     validate-app-db!)
@@ -145,7 +117,7 @@
 (late-bind/set-fn! :schemas/validate-fx!         validate-fx!)
 (late-bind/set-fn! :schemas/frame-schema-entries frame-schema-entries)
 
-;; Boundary-validation seam (rf2-r2uh integration).
+;; Boundary-validation seam.
 (late-bind/set-fn! :schemas/validate-with-registered-fn validate-with-registered-fn)
 (late-bind/set-fn! :schemas/explain-with-registered-fn  explain-with-registered-fn)
 
@@ -161,16 +133,8 @@
 
 ;; Schema-walker hooks consumed by `re-frame.elision` to feed the
 ;; unified `[:rf/elision]` registry without statically depending on the
-;; schemas artefact. Per rf2-ynnq0 Option A — schemas owns the deep
-;; walker; the elision artefact owns the app-db write. The Path D impl
-;; (rf2-w3n5u) wires `re-frame.elision/populate-elision-from-schemas!`
-;; to consume these two hooks. The five sibling feeders that previously
-;; sat alongside (`:schemas/frame-elision-declarations`,
-;; `:schemas/populate-elision-declarations`, `:schemas/schema-has-
-;; sensitive?`, `:schemas/frame-sensitive-declarations`,
-;; `:schemas/populate-sensitive-declarations`) were deleted per
-;; rf2-5q7r0 — they had zero consumers in tree, and Option A makes the
-;; per-slot extract-* hooks the single surface elision needs.
+;; schemas artefact. Schemas owns the deep walker; the elision artefact
+;; owns the app-db write.
 (late-bind/set-fn! :schemas/extract-large-paths-from-schema     extract-large-paths-from-schema)
 (late-bind/set-fn! :schemas/extract-sensitive-paths-from-schema extract-sensitive-paths-from-schema)
 

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -1,66 +1,36 @@
 (ns re-frame.ssr
   "Server-side rendering and hydration. Per Spec 011.
 
-  Public façade for the day8/re-frame2-ssr artefact (rf2-uo7v, sixth
-  per-feature split per rf2-5vjj Strategy B). Per Spec 006 §Adapter
-  shipping convention — this artefact depends on core; core never
-  depends on this artefact. The cross-references from core to ssr flow
-  through `re-frame.late-bind`.
+  Public façade for the day8/re-frame2-ssr artefact. This artefact
+  depends on core; core never depends on it — cross-references from
+  core flow through `re-frame.late-bind`.
 
-  ---- file split (rf2-gxgo7) ----
-
-  Pre-split this namespace was 1380 LoC carrying seven independent
-  concerns enumerated by its own `;; ----` banners. It's now a thin
-  façade over eight flat sub-namespaces:
+  Thin façade over eight flat sub-namespaces:
 
     - `re-frame.ssr.emit`            — hiccup → HTML emitter,
                                        `render-to-string`, source-coord
-                                       annotation, substrate-adapter
-                                       wire-up.
+                                       annotation, substrate wire-up.
     - `re-frame.ssr.hash`            — `canonical-edn`, `fnv-1a-32`,
                                        `render-tree-hash`.
     - `re-frame.ssr.adapter`         — the SSR adapter map + helpers.
-    - `re-frame.ssr.hydrate`         — `:rf/hydrate` handler + the two
-                                       `:rf.ssr/check-*` fx handlers
-                                       (rf2-69ad2), `verify-hydration!`.
-    - `re-frame.ssr.response`        — response accumulator + handler
-                                       fns for the six `:rf.server/*` fxs.
+    - `re-frame.ssr.hydrate`         — `:rf/hydrate` handler, the two
+                                       `:rf.ssr/check-*` fx handlers,
+                                       `verify-hydration!`.
+    - `re-frame.ssr.response`        — response accumulator + handlers
+                                       for the six `:rf.server/*` fxs.
     - `re-frame.ssr.error-projector` — projector registry + default +
                                        `project-error`.
     - `re-frame.ssr.error-listener`  — trace listener + per-frame buffer
                                        + drain + `get-response`.
     - `re-frame.ssr.request`         — `request-slots`, set/get/clear
                                        helpers, `on-frame-destroyed!`,
-                                       the `:rf.server/request` cofx
-                                       handler.
+                                       the `:rf.server/request` cofx.
 
   All `reg-fx` / `reg-cofx` / `reg-event-fx` / `reg-error-projector` /
   `register-trace-cb!` side-effects fire HERE so a
-  `(require 're-frame.ssr :reload)` after `(registrar/clear-all!)` —
-  the canonical test-fixture reset shape — re-installs every
-  registration. Sub-namespaces export pure handler fns only.
-
-  Implements:
-    - Pure hiccup → HTML emitter (HTML5 void elements, doctype prefix,
-      attr/text escaping, `:tag#id.cls` parsing, registered-view
-      resolution). Per Spec 011 §The render-tree → HTML emitter.
-    - `:rf/hydrate` event with `:replace-app-db` semantics; the server-
-      supplied payload's `:rf/app-db` replaces the client app-db.
-    - The six `:rf.server/*` response-shape fxs gated by `:platforms
-      #{:server}`; the accumulator at `[:rf/response]` is consumed by
-      the host adapter after drain. Per §HTTP response contract.
-    - `reg-error-projector` + default `:rf.ssr/default-error-projector`,
-      plus the SSR error path that calls the active projector when an
-      error trace fires inside a server frame. Per §Server error
-      projection.
-    - `:rf.server/request` cofx + per-frame request slot
-      (`set-request!` / `get-request` / `clear-request!`). Per
-      §Server-only `reg-cofx` for request context.
-
-  Conformance fixtures cover all of the above (ssr/render-to-string,
-  ssr/hydrate, ssr/hydration-mismatch, ssr/head-emits, ssr/head-hydration,
-  ssr/error-known-mapping, ssr/error-sanitisation, ssr/cookie,
-  ssr/redirect, ssr/set-status, fx/platforms)."
+  `(require 're-frame.ssr :reload)` after `(registrar/clear-all!)`
+  re-installs every registration. Sub-namespaces export pure handler
+  fns only."
   (:require [re-frame.cofx :as cofx]
             [re-frame.events :as events]
             [re-frame.fx :as fx]
@@ -69,12 +39,11 @@
             [re-frame.ssr.emit :as emit]
             [re-frame.ssr.error-listener :as error-listener]
             [re-frame.ssr.error-projector :as error-projector]
-            ;; rf2-4dra9 — head/meta contract surface (Spec 011 §Head/meta).
-            ;; The head ns publishes its late-bind hooks at ns-load time;
-            ;; static `:require` here ensures the hooks are available
-            ;; before any user code calls `rf/reg-head` / `rf/render-head`
-            ;; / `rf/active-head`. The dependency is acyclic — head.cljc
-            ;; only pulls re-frame.frame / re-frame.registrar.
+            ;; Static `:require` of `re-frame.ssr.head` is load-bearing
+            ;; — head publishes its late-bind hooks at ns-load time, so
+            ;; this require ensures the hooks are available before any
+            ;; user code calls `rf/reg-head` / `rf/render-head` /
+            ;; `rf/active-head`.
             re-frame.ssr.head
             [re-frame.ssr.hash :as hash]
             [re-frame.ssr.hydrate :as hydrate]
@@ -98,11 +67,10 @@
 (def adapter                         adapter-ns/adapter)
 (def verify-hydration!               hydrate/verify-hydration!)
 (def default-response                response/default-response)
-;; framework-private — Spec 011 §Response storage substrate (rf2-jbcmt).
-;; The accumulator lives in a side-channel atom keyed by frame-id, NOT
-;; in app-db, so it cannot ride the hydration payload to the client and
-;; per-fx writes are O(small-map) rather than a full app-db replacement.
-;; Tests reach the var via `(resolve 're-frame.ssr/response-slots)`.
+;; framework-private — Spec 011 §Response storage substrate. The
+;; accumulator lives in a side-channel atom keyed by frame-id, NOT in
+;; app-db, so it cannot ride the hydration payload to the client and
+;; per-fx writes are O(small-map) rather than full app-db replacement.
 (def ^:private response-slots        response/response-slots)
 (def public-error-keys               error-projector/public-error-keys)
 (def fallback-public-error           error-projector/fallback-public-error)
@@ -111,20 +79,15 @@
 (def project-error                   error-projector/project-error)
 (def apply-error-projection!         error-listener/apply-error-projection!)
 (def get-response                    error-listener/get-response)
-;; Audit rf2-asmj1 P5 / cluster rf2-sljs1 — split the side-effect from
-;; the pure read. `peek-response` is a pure read (no projector drain);
-;; `flush-response!` drains pending error projections then reads.
-;; `get-response` is kept as the drain-then-read host-adapter alias.
+;; `peek-response` is pure (no projector drain); `flush-response!`
+;; drains pending error projections then reads. `get-response` is the
+;; drain-then-read host-adapter alias.
 (def peek-response                   error-listener/peek-response)
 (def flush-response!                 error-listener/flush-response!)
-;; framework-private at the public surface — Spec 011 §Per-request
-;; frame teardown. Tests reach the var via `(resolve ...)`.
+;; framework-private — Spec 011 §Per-request frame teardown.
 (def ^:private pending-error-traces  error-listener/pending-error-traces)
-;; rf2-i3qc0 — private at the façade so the public surface stays symmetric
-;; with `response-slots` and `pending-error-traces`. Tests reach via
-;; `re-frame.ssr.test-fixture/reset-runtime` (the canonical reset surface)
-;; or by `:require`-ing `re-frame.ssr.request` directly. Production
-;; consumers go through `set-request!` / `get-request` / `clear-request!`.
+;; framework-private at the public surface — production consumers go
+;; through `set-request!` / `get-request` / `clear-request!`.
 (def ^:private request-slots         request/request-slots)
 (def set-request!                    request/set-request!)
 (def get-request                     request/get-request)
@@ -132,9 +95,7 @@
 (def on-frame-destroyed!             request/on-frame-destroyed!)
 
 ;; ---- :rf/hydrate event + :rf.ssr/check-* fxs ------------------------------
-;;
-;; Spec 011 §The :rf/hydrate event + §Hydration-mismatch detection +
-;; rf2-69ad2 compatibility checks.
+;; Spec 011 §The :rf/hydrate event + §Hydration-mismatch detection.
 
 (events/reg-event-fx :rf/hydrate hydrate/hydrate-event-handler)
 
@@ -206,8 +167,8 @@ on the wire. Per Spec 011 §Cookie shape."
 
 (cofx/reg-cofx :rf.server/request
   {:doc       "The active HTTP request. Server only. Surfaces the
-host-supplied request map (Ring shape under rf2-ny6v7's Ring adapter;
-host-defined for other adapters) so handlers can read URL, headers,
+host-supplied request map (Ring shape under the Ring adapter; host-
+defined for other adapters) so handlers can read URL, headers,
 session cookies, etc. without threading the request as an event arg.
 
 The host adapter populates the slot via `re-frame.ssr/set-request!`
@@ -234,31 +195,12 @@ Per Spec 011 §Server-only `reg-cofx` for request context."
                           error-listener/error-projection-listener)
 
 ;; ---- late-bind hook registration ------------------------------------------
-;;
-;; Per rf2-uo7v re-frame.ssr ships in `day8/re-frame2-ssr`. The core
-;; artefact's `re-frame.core/render-to-string`, `render-tree-hash`,
-;; `reg-error-projector`, and `project-error` re-exports look the
-;; producing fns up through this hook table — core never statically
-;; `:require`s `re-frame.ssr`. When the ssr artefact is not on the
-;; classpath the lookups return nil and the consumer raises
-;; `:rf.error/ssr-artefact-missing`.
 
 (late-bind/set-fn! :ssr/render-tree-hash    render-tree-hash)
 (late-bind/set-fn! :ssr/render-to-string    render-to-string)
 (late-bind/set-fn! :ssr/reg-error-projector reg-error-projector)
 (late-bind/set-fn! :ssr/project-error       project-error)
-;; rf2-fcj33 + rf2-jbcmt — per-request frame teardown. `frame/destroy-frame!`
-;; looks up this hook and clears the SSR side-channel atoms
-;; (`pending-error-traces`, `request-slots`, `response-slots`) for the
-;; destroyed frame. `response-slots` joined the set under rf2-jbcmt when
-;; the `:rf/response` accumulator moved off `app-db` to plug the hydration-
-;; payload leak / per-fx full-app-db swap.
+;; Per-request frame teardown. `frame/destroy-frame!` looks up this
+;; hook and clears the SSR side-channel atoms (`pending-error-traces`,
+;; `request-slots`, `response-slots`) for the destroyed frame.
 (late-bind/set-fn! :ssr/on-frame-destroyed  on-frame-destroyed!)
-
-;; rf2-4dra9 — `re-frame.ssr.head` is required from the top-of-file ns
-;; form so its late-bind hooks (`:ssr/reg-head`, `:ssr/render-head`,
-;; `:ssr/active-head`, `:ssr/head-snapshot`, `:ssr/head-model-html`) AND
-;; the per-frame head-snapshot cleanup hook
-;; (`:ssr.head/on-frame-destroyed`) land at ssr-ns load time on both JVM
-;; and CLJS. `on-frame-destroyed!` above invokes the head cleanup hook
-;; by key — load order between this ns and head.cljc is symmetric.

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -1,35 +1,15 @@
 (ns day8.re-frame2-causa.registry
-  "Causa's framework registrations — events, subs, fxs under the
-  `:rf.causa/*` namespace prefix.
+  "Causa's `:rf.causa/*` event / sub / fx registrations.
 
-  ## Namespace prefix is the collision contract
+  Two collision contracts: the `:rf.causa/*` keyword prefix prevents
+  id collisions against the host's registrations (the registrar is
+  process-global); the `:rf/causa` frame prevents Causa's db reads /
+  writes from leaking into the host's app-db.
 
-  The registrar is process-global; Causa's registrations share the
-  registry with the host app. The `:rf.causa/*` prefix is the
-  collision-avoidance contract: Causa never registers under a
-  non-`:rf.causa/*` keyword, so a host registering `:user/login` and
-  Causa registering `:rf.causa/buffer-cleared` cannot stamp on each
-  other.
-
-  ## Registrations target the `:rf/causa` frame
-
-  The panel's state lives in a frame named `:rf/causa` — a sibling of
-  the host's `:rf/default`. Subscribers / dispatchers wrapped inside
-  `[rf/frame-provider {:frame :rf/causa} ...]` resolve to that frame;
-  a Causa view subscribing to `:rf.causa/trace-buffer` reads
-  `:rf/causa`'s app-db, not the host's. Prefix prevents id collision;
-  frame-provider prevents db reads/writes from leaking into the host.
-
-  ## Orchestrator
-
-  This ns owns only the cross-panel primitives (the trace-buffer sub,
-  the panel-selection slot, the shared cascades projection, and the
-  three suppression-counter handlers) plus the orchestration call
-  into each per-panel `install!`. Per-panel registrations live in the
-  panel's own ns under `(defn install! [] ...)` (rf2-d4xda) so each
-  panel owns its subs / events / fxs colocated with the view that
-  reads them. Sub-registration order is purely cosmetic — re-frame
-  resolves `:<-` chains lazily at subscribe time, not register time."
+  This ns owns only the cross-panel primitives (trace-buffer sub,
+  panel-selection slot, shared cascades projection, suppression-
+  counter handlers) plus orchestration calls into each per-panel
+  `install!`. Per-panel registrations live in their panel's own ns."
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-causa.defaults :as defaults]
@@ -51,13 +31,9 @@
             [day8.re-frame2-causa.panels.time-travel :as time-travel]
             [day8.re-frame2-causa.panels.trace :as trace]))
 
-;; ---- defaults (re-exported for back-compat callers) ---------------------
-;;
-;; The Vars themselves live in `day8.re-frame2-causa.defaults` so the
-;; per-panel `install!` fns can read them without forming a
-;; registry→panel→registry cycle. Re-exported here so the shell + the
-;; existing test surface keep reading `registry/default-panel-id` /
-;; `registry/default-target-frame` — same source of truth.
+;; ---- defaults (re-exports) ----------------------------------------------
+;; The Vars live in `defaults` so panel `install!` fns can read them
+;; without forming a registry→panel→registry cycle.
 
 (def default-panel-id defaults/default-panel-id)
 (def default-target-frame defaults/default-target-frame)
@@ -65,10 +41,9 @@
 ;; ---- idempotency sentinel ------------------------------------------------
 
 (defonce ^:private registered?
-  ;; Re-loading the namespace (shadow-cljs `:after-load`) must not
-  ;; re-register the sub graph (would harmlessly replace each
-  ;; handler, but emits a `:rf.warning/handler-replaced` trace per
-  ;; registration — pollutes the dev console on every reload).
+  ;; Re-registration on `:after-load` would emit a
+  ;; `:rf.warning/handler-replaced` trace per registration and
+  ;; flood the dev console on every reload.
   (atom false))
 
 (defn register-causa-handlers!
@@ -79,55 +54,34 @@
   (when (compare-and-set! registered? false true)
     ;; ---- cross-panel primitives ---------------------------------
 
-    ;; Causa's trace-buffer sub returns the Causa-side ring buffer
-    ;; contents (NOT the framework's `(rf/trace-buffer)`). Reading
-    ;; directly from `trace-bus/buffer` is the right shape here
-    ;; because the buffer is process-global, not per-frame — every
-    ;; Causa shell mounted across any frame should see the same
-    ;; trace stream. The sub thunks the pure-data accessor so
-    ;; reactive contexts get a fresh read on every recompute;
-    ;; layer-1 re-fires on the host's next dispatch and picks up
-    ;; whatever the trace-cb has accumulated. See `trace_bus.cljc`
-    ;; §Reactivity for the trade-off and the refactor path that
-    ;; would re-introduce immediate-update reactivity without the
-    ;; layering hazard.
+    ;; Causa's own ring buffer (NOT the framework's `rf/trace-buffer`).
+    ;; The buffer is process-global, not per-frame — every Causa shell
+    ;; mounted across any frame sees the same trace stream. Layer-1
+    ;; sub re-fires on the host's next dispatch and picks up whatever
+    ;; the trace-cb has accumulated; see `trace_bus.cljc` §Reactivity.
     (rf/reg-sub :rf.causa/trace-buffer
       (fn [_db _query]
         (trace-bus/buffer)))
 
-    ;; Total count of :sensitive? trace events the collector has
-    ;; suppressed under the current `:trace/show-sensitive?` setting
-    ;; (rf2-azls9). The shell's bottom-rail renders a `[● REDACTED N]`
-    ;; hint when this is positive so the user sees why the buffer is
-    ;; shorter than the runtime's actual emit count.
-    ;;
-    ;; Per rf2-0vxdn the counter lives in Causa's app-db at
-    ;; `:suppressed-counters` ({frame-id → count}); `config/note-
-    ;; suppressed!` dispatches `:rf.causa/note-sensitive-suppressed`
-    ;; in CLJS, so the sub fires on the standard app-db-write
-    ;; reactive path and the bottom-rail re-renders IMMEDIATELY —
-    ;; no dependency on sibling subs recomputing. The plain
-    ;; `config/suppressed-counters` atom remains as the JVM-runnable
-    ;; data primitive (sensitive_trace CLJC tests + trace-bus' JVM
-    ;; data-shape coverage); the CLJS path dual-writes via dispatch
-    ;; so the reactive surface stays consistent.
+    ;; Total count of `:sensitive?` trace events suppressed under the
+    ;; current `:trace/show-sensitive?` setting. Drives the shell's
+    ;; bottom-rail `[● REDACTED N]` indicator. The CLJS path
+    ;; dual-writes via dispatch (this counter) and `config/suppressed-
+    ;; counters` (the JVM-runnable data primitive); the dispatch keeps
+    ;; the reactive surface in sync without depending on sibling-sub
+    ;; recompute.
     (rf/reg-sub :rf.causa/suppressed-sensitive-count
       (fn [db _query]
         (reduce + 0 (vals (get db :suppressed-counters {})))))
 
-    ;; Currently-active panel — drives the canvas's switch logic in
-    ;; shell.cljs. Default is the hero panel per §10 Lock 7.
+    ;; Currently-active panel — drives the canvas's switch in shell.cljs.
     (rf/reg-sub :rf.causa/selected-panel
       (fn [db _query]
         (get db :selected-panel defaults/default-panel-id)))
 
-    ;; Shared cascade projection. The event-detail, causality-graph,
-    ;; and performance composites all consume `projection/group-cascades`
-    ;; over the same trace-buffer; routing them through one intermediate
-    ;; sub collapses three O(buffer) passes per push to one. Each
-    ;; downstream composite declares the dependency via `:<-` so the
-    ;; reactive graph stays correct (and idle composites still don't pay
-    ;; for the projection).
+    ;; Shared cascade projection: routing event-detail, causality-graph,
+    ;; and performance through one intermediate sub collapses three
+    ;; O(buffer) passes per push to one.
     (rf/reg-sub :rf.causa/cascades
       :<- [:rf.causa/trace-buffer]
       (fn [buffer _query]
@@ -138,38 +92,21 @@
       (fn [db [_ panel-id]]
         (assoc db :selected-panel panel-id)))
 
-    ;; Bump the per-frame suppressed-events counter (rf2-0vxdn).
-    ;; Dispatched from `trace-bus/collect-trace!` (CLJS) under
-    ;; `:rf/causa` whenever the privacy gate drops a `:sensitive? true`
-    ;; trace event. `frame-id` is the event's `:tags :frame` (the host
-    ;; frame the trace targeted); `nil` falls under `:global`. Drives
-    ;; the bottom-rail `[● REDACTED N]` indicator via the
-    ;; `:rf.causa/suppressed-sensitive-count` sub — fully reactive.
+    ;; Bump the per-frame suppressed-events counter. `frame-id` is the
+    ;; event's `:tags :frame`; `nil` falls under `:global`.
     ;;
-    ;; Per rf2-qsjda: `:rf.trace/no-emit? true` opts the handler out of
-    ;; framework trace emission. Without this, the dispatch fired by
-    ;; `trace-bus/collect-trace!` would itself emit `:event/dispatched`
-    ;; etc. back through the trace-cb fan-out, the collector would see
-    ;; its own self-emit, and the cascade would loop until
-    ;; `drain-depth-default` terminated it. The framework now
-    ;; short-circuits emission at the `emit!` / `emit-error!` /
-    ;; `emit-dispatched-trace!` gates — the predecessor Causa-side
-    ;; `self-emitted?` guard (rf2-nk01x) is obsolete.
+    ;; `:rf.trace/no-emit? true` is load-bearing: without it the
+    ;; dispatch fired by `trace-bus/collect-trace!` would re-emit
+    ;; `:event/dispatched` back through the trace-cb fan-out and the
+    ;; cascade would loop until `drain-depth-default` terminated it.
     (rf/reg-event-db :rf.causa/note-sensitive-suppressed
       {:rf.trace/no-emit? true}
       (fn [db [_ frame-id]]
         (update-in db [:suppressed-counters (or frame-id :global)]
                    (fnil inc 0))))
 
-    ;; Reset the suppressed-events counter (rf2-0vxdn). With no arg,
-    ;; clears every bucket; with a `frame-id`, drops just that bucket.
-    ;; Dispatched from `trace-bus/clear-buffer!` (CLJS) — clearing the
-    ;; trace ring buffer also drops the REDACTED indicator state (the
-    ;; "you missed N events" overhang disappears alongside the events
-    ;; that produced it).
-    ;;
-    ;; Per rf2-qsjda: `:rf.trace/no-emit? true` (see
-    ;; `:rf.causa/note-sensitive-suppressed` above for the rationale).
+    ;; Reset counters; with a `frame-id` drops just that bucket.
+    ;; `:rf.trace/no-emit? true` rationale: see above.
     (rf/reg-event-db :rf.causa/reset-suppressed-counters
       {:rf.trace/no-emit? true}
       (fn [db [_ frame-id]]
@@ -177,12 +114,7 @@
           (update db :suppressed-counters dissoc (or frame-id :global))
           (dissoc db :suppressed-counters))))
 
-    ;; ---- per-panel installations --------------------------------
-    ;;
-    ;; Each panel owns its own subs / events / fxs in
-    ;; `panels/<panel>.cljs` under `(defn install! [] ...)`. Order is
-    ;; alphabetised — re-frame resolves `:<-` chains lazily at
-    ;; subscribe time so registration order is purely cosmetic.
+    ;; ---- per-panel installations (alphabetised) -----------------
 
     (ai-co-pilot/install!)
     (app-db-diff/install!)

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -140,7 +140,7 @@
 
      The body must be 100% EDN-round-trippable. Decorator closures live at
      the decorator's *registration site* (see `reg-decorator`), not here.
-     Per IMPL-SPEC §2.6 and Phase-2 §5.1 #10.
+     Per IMPL-SPEC §2.6.
 
      `:extends` resolution happens at registration time — see
      `re-frame.story.extends/resolve-extends`."
@@ -254,10 +254,10 @@
      `:rf.error/unknown-tag`.
 
      **`:axis`** — optional keyword classifier. The sidebar tag-filter UI
-     groups registered tags by `:axis` into collapsible facet rows
-     (rf2-v05qb SB9 parity). Tags registered without `:axis` render in a
-     trailing un-grouped facet row. Query the axis grouping via
-     `tags-by-axis` / `tags-without-axis`.
+     groups registered tags by `:axis` into collapsible facet rows.
+     Tags registered without `:axis` render in a trailing un-grouped
+     facet row. Query the axis grouping via `tags-by-axis` /
+     `tags-without-axis`.
 
      **`:default-filter`** — `:include` (default) | `:exclude`. When
      `:exclude`, the sidebar pre-excludes variants carrying this tag at
@@ -266,8 +266,7 @@
      `tags-default-excluded`.
 
      `!`-prefix removal-syntax (e.g. `:!dev`) on a variant `:tags` set
-     resolves at registration time against the inherited set — see
-     Phase-2 §5.1 #11."
+     resolves at registration time against the inherited set."
      [id metadata]
      (macros/gen-reg-call (meta &form) *file*
                           (symbol (str (ns-name *ns*)))
@@ -283,7 +282,7 @@
 
   Mirror of the spec/001 §Public registrar query API for Story's
   side-table. The Story registry is logically a peer of the framework
-  registrar — see IMPL-SPEC §1.1 + bd rf2-7ho2 for the design rationale."
+  registrar — see IMPL-SPEC §1.1 for the design rationale."
   [kind]
   (registrar/handlers kind))
 
@@ -316,8 +315,8 @@
 
 (defn variants-with-tags
   "Per IMPL-SPEC §3.2 — return the set of variant ids whose `:tags`
-  intersects `query-tags`. Stage 5 (assertions/play) leans on this; Stage
-  4 (render shell) leans on this to compose the sidebar tree."
+  intersects `query-tags`. Used by the assertion / play surface and by
+  the render shell's sidebar tree composition."
   [query-tags]
   (registrar/variants-with-tags query-tags))
 
@@ -336,8 +335,8 @@
   "Per spec/001 §reg-tag — return the set of registered tag ids whose
   body's `:axis` equals `axis-kw` (e.g. `:status` / `:role` / `:team` /
   `:feature`). The sidebar tag-filter UI uses this to group registered
-  tags into collapsible facet rows (rf2-v05qb SB9 parity). Returns the
-  empty set if no tag carries that axis."
+  tags into collapsible facet rows. Returns the empty set if no tag
+  carries that axis."
   [axis-kw]
   (registrar/tags-by-axis axis-kw))
 
@@ -392,9 +391,8 @@
 
 (def ^:private canonical-installers
   "Ordered vector of installer fns invoked by `install-canonical-vocabulary!`.
-  Each takes zero args and is idempotent. The CLJS-only Stage 6 surfaces
-  (multi-substrate Reagent default + the v1.0 panel set) gate on the
-  reader so the JVM classpath stays Reagent-free."
+  Each takes zero args and is idempotent. The CLJS-only surfaces gate
+  on the reader so the JVM classpath stays Reagent-free."
   [registrar/install-canonical-tags!
    loaders/install!
    loaders/install-mirror-writer!
@@ -436,19 +434,17 @@
 
   `{:global-args {...}}` — replace the global args map.
 
-  `{:editor <kw>}` — 'Open in editor' preference per rf2-evgf5. One of
-  `:vscode` (default) / `:cursor` / `:idea` / `{:custom \"<template>\"}`.
-  Drives the `vscode://` / `cursor://` / `idea://` URI scheme the
-  source-coord open-button affordances emit. See
-  `re-frame.source-coords.editor-uri/editor-uri` for the per-editor URI
-  grammar.
+  `{:editor <kw>}` — 'Open in editor' preference. One of `:vscode`
+  (default) / `:cursor` / `:idea` / `{:custom \"<template>\"}`. Drives
+  the `vscode://` / `cursor://` / `idea://` URI scheme the source-coord
+  open-button affordances emit. See
+  `re-frame.source-coords.editor-uri/editor-uri` for the grammar.
 
   `{:trace/show-sensitive? <bool>}` — privacy gate for `:sensitive?
-  true` trace events per Spec 009 §Privacy (rf2-bclgj). Defaults to
-  `false` — Story's trace, actions, recorder, and play-assertion
-  listeners drop sensitive events and the UI surfaces a `[● REDACTED]`
-  hint. Set to `true` while debugging redaction policy to see the raw
-  cascade.
+  true` trace events per Spec 009 §Privacy. Defaults to `false` —
+  Story's trace, actions, recorder, and play-assertion listeners drop
+  sensitive events and the UI surfaces a `[● REDACTED]` hint. Set to
+  `true` while debugging redaction policy to see the raw cascade.
 
   Unrecognised keys are accepted (for forward compat) but ignored."
   [{:keys [global-args editor]
@@ -480,20 +476,11 @@
   [kind id]
   (registrar/unregister! kind id))
 
-;; ---- Stage 3 stubs (run-variant family) ---------------------------------
-;;
-;; These are deliberately stubbed at Stage 2 — the bead is the authoring
-;; surface only. Stage 3 (rf2-von3) replaces these bodies with the
-;; four-phase lifecycle. The signatures are locked at IMPL-SPEC §3.2 so
-;; downstream code can be written against them today.
+;; ---- variant->edn / workspace->edn --------------------------------------
 
 (defn variant->edn
   "Per IMPL-SPEC §3.2 — return the canonical-form serialised body of
-  the registered variant. At Stage 2 this is the side-table body
-  verbatim; the canonicalisation (sorted keys, deterministic vector
-  order) for snapshot-identity is Stage 3's call.
-
-  Returns nil when the variant is unregistered."
+  the registered variant, or nil when unregistered."
   [variant-id]
   (handler-meta :variant variant-id))
 
@@ -503,10 +490,6 @@
   (handler-meta :workspace workspace-id))
 
 ;; ---- run-variant / reset-variant / snapshot-identity --------------------
-;;
-;; STAGE 3 (rf2-von3): the four-phase lifecycle. These call into
-;; `re-frame.story.runtime`. Each returns a promise (CLJS) or
-;; CompletableFuture (JVM); see `re-frame.story.async` for the shape.
 
 (defn run-variant
   "Per IMPL-SPEC §3.2. Allocate a frame for `variant-id`, run the four-
@@ -517,17 +500,16 @@
     :active-modes    coll of registered mode ids; deep-merged into args
     :cell-overrides  runtime arg overrides (controls panel)
     :substrate       active substrate (`:reagent`, `:uix`, ...)
-    :render?         when truthy, Stage 4's UI shell renders into
-                     `:rendered-hiccup`. Stage 3 leaves the slot nil.
-    :assertions      Stage 5's hook. Stage 3 accepts the slot but
-                     leaves the runtime semantics to Stage 5.
+    :render?         when truthy, the UI shell renders into
+                     `:rendered-hiccup`.
+    :assertions      assertions hook.
 
   Result map:
 
       {:frame           <variant-id>
        :app-db          {...}
        :assertions      [...]
-       :rendered-hiccup nil           ; Stage 4
+       :rendered-hiccup ...
        :elapsed-ms      <ms>
        :snapshot        {:variant-id ... :content-hash \"...\"}
        :decorators      {:hiccup [...] :frame-setup [...] :fx-override [...]
@@ -567,8 +549,8 @@
   (frames/destroy! variant-id))
 
 (defn variant-frames
-  "Return every registered variant frame id. Stage 4's UI shell uses
-  this to lay out the active variant pane."
+  "Return every registered variant frame id. The UI shell uses this to
+  lay out the active variant pane."
   []
   (frames/variant-frames))
 
@@ -584,7 +566,7 @@
   [variant-id]
   (loaders/current-state variant-id))
 
-;; ---- Stage 5 (rf2-h8et) public assertion + play helpers ------------------
+;; ---- public assertion + play helpers ------------------------------------
 
 (defn assertions-passing?
   "Per IMPL-SPEC §3.5 + spec/007 §Story-as-test duality — true iff
@@ -641,7 +623,7 @@
                       [:rf.assert/effect-emitted :http]]})"
   fx-stubs/force-fx-stub-id)
 
-;; ---- Stage 6 (rf2-zhwd) public SOTA-feature surface ---------------------
+;; ---- public SOTA-feature surface ----------------------------------------
 
 (def layout-debug-measure-id
   "Per IMPL-SPEC §2.8.6 — the registered decorator id for the
@@ -716,7 +698,7 @@
   ([variant-id]       (decorators/resolve-decorators variant-id))
   ([variant-id opts]  (decorators/resolve-decorators variant-id opts)))
 
-;; ---- rf2-8wgpm: static-mode? probe --------------------------------------
+;; ---- static-mode? probe -------------------------------------------------
 
 (defn static-mode?
   "Per tools/story/spec/013-Static-Build.md — return true iff Story is
@@ -739,12 +721,9 @@
   assertions+play + sota-features) is present."
   :sota-features)
 
-;; ---- Stage 4 (rf2-ekai) UI shell mount / unmount surface ----------------
-;;
-;; Per IMPL-SPEC §4 + §8.4 the shell entry points are CLJS-only —
-;; mounting a Reagent shell at a DOM node has no JVM equivalent. The
-;; functions are conditionalised on the reader so JVM consumers can
-;; require `re-frame.story` without pulling Reagent / DOM symbols.
+;; ---- UI shell mount / unmount surface (CLJS-only) -----------------------
+;; The functions are reader-conditionalised so JVM consumers can require
+;; `re-frame.story` without pulling Reagent / DOM symbols (IMPL-SPEC §8.4).
 
 #?(:cljs
    (defn mount-shell!
@@ -762,9 +741,7 @@
 
      Production CLJS builds (`re-frame.story.config/enabled?` false)
      short-circuit before any DOM call and return nil. See IMPL-SPEC
-     §6.3 for the elision contract.
-
-     Stage 4 (rf2-ekai)."
+     §6.3 for the elision contract."
      [dom-node]
      (ui-shell/mount-shell! dom-node)))
 
@@ -782,11 +759,9 @@
      []
      (ui-shell/active-shell)))
 
-;; ---- rf2-5fc15 — Test Codegen recorder public surface --------------------
-;;
-;; Per bead rf2-5fc15 the recorder captures canvas-dispatched events as
-;; a `:play` body. Exposing the entry points here lets tests, MCP
-;; tooling, and headless integrations drive recording programmatically
+;; ---- Test Codegen recorder public surface -------------------------------
+;; The recorder captures canvas-dispatched events as a `:play` body so
+;; tests, MCP tooling, and headless integrations can drive recording
 ;; without going through the toolbar UI.
 
 (defn start-recording!


### PR DESCRIPTION
## Summary

Batched-by-surface comment-density sweep across 12 file-isolated leaves.
Each commit lands one bead; LoC delta is overwhelmingly negative
(comments-only).

| Bead | Surface | Δ |
|---|---|---|
| rf2-7e4lf + rf2-auzvs | `interop.cljs` | -42 |
| rf2-qvguc | `late_bind.cljc` | -42 |
| rf2-ylfqk | `views.cljs` | -93 |
| rf2-qj3mv | `trace.cljc` | -22 |
| rf2-y8b3h | `router.cljc` + `epoch.cljc` magic-number WHYs | +6 |
| rf2-b7qbt | `tools/causa/registry.cljs` | -68 |
| rf2-tt0a3 | `tools/story/story.cljc` | -25 |
| rf2-9l78c | every `core_X.cljc` + producing `X.cljc` artefact | -398 |
| rf2-p88vm | reagent / uix / helix / reagent-slim adapters | -169 |
| rf2-mclqj | `frame.cljc` destroy-frame nine-step dup | -55 |
| rf2-0a1yz | `core.cljc` public facade rf2-* sweep | -12 |

Totals: **129 files, +2513 / −7619** (net **−5106 LoC**).

Pre-alpha policy applied throughout: no AI attribution, no back-compat
considerations, preserve only WHY-comments that capture hidden
constraints or warn of bug-prone patterns.

Load-bearing literals preserved:
- `data-rf2-source-coord` HTML attribute (elision bundle-grep keys on it)
- `:rf.*` keyword strings used as elision sentinels
- Reserved id prefixes called out in `spec/Conventions.md`

## Test plan

- [x] `npm run test:cljs` — 1818 tests / 5115 assertions / 0 failures
- [x] `npm run test:elision` — every sentinel PRESENT in dev / ABSENT in prod
- [x] `npm run test:bundle-isolation` — tool surfaces stay out of production bundles