### PR TITLE
refactor(machines): tail polish — 4 follow-on beads (rf2-2ukxv)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -27,6 +27,7 @@
   `re-frame.machines.lifecycle-fx.teardown` — one helper, three (now
   unified) call-sites."
   (:require [re-frame.frame :as frame]
+            [re-frame.machines.lifecycle-fx.exit-cascade :as exit-cascade]
             [re-frame.machines.lifecycle-fx.finalize :as finalize]
             [re-frame.machines.lifecycle-fx.teardown :as teardown]
             [re-frame.machines.lifecycle-fx.traces :as traces]
@@ -35,16 +36,27 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 (defn- destroy-single-actor!
-  "Destroy a single spawned actor against the frame's container: apply
-  the unified teardown projection (per
+  "Destroy a single spawned actor against the frame's container: run
+  the active configuration's `:exit` cascade (rf2-nahfm), apply the
+  unified teardown projection (per
   `re-frame.machines.lifecycle-fx.teardown`), abort in-flight
   `:rf.http/managed` requests (rf2-wvkn), emit the
   `:system-id-released` trace, and unregister the live event handler.
 
   Used by `destroy-machine-fx` for the keyword-form legacy/imperative
-  destroy AND iterated for each child in an `:invoke-all` teardown."
+  destroy AND iterated for each child in an `:invoke-all` teardown.
+
+  Per Spec 005 §Declarative `:invoke` §Composition with explicit
+  `:entry` / `:exit`: the actor's `:exit` action runs BEFORE the
+  teardown clears the snapshot, so `:exit`-time side effects (HTTP
+  requests, logs, dispatches) execute against the live snapshot."
   [frame-id actor-id]
   (when actor-id
+    ;; (rf2-nahfm) Run the active configuration's `:exit` cascade
+    ;; BEFORE any teardown work. This fires `:exit`-emitted fx via
+    ;; do-fx and writes any `:data` updates back to the snapshot —
+    ;; both transient (the snapshot is dissoc'd two steps later).
+    (exit-cascade/run-child-exit! frame-id actor-id)
     (finalize/abort-actor-in-flight-http! actor-id)
     ;; `teardown-actor` returns [new-db released-sid]; `swap-frame-db!`
     ;; expects a fn returning the new-db only. Capture sid via a side
@@ -117,6 +129,9 @@
     ;; the spawn slot was already cleared (e.g. by an earlier explicit
     ;; destroy) or the spawn was suppressed (SSR / platform gating).
     (when actor-id
+      ;; (rf2-nahfm) Run the active configuration's `:exit` cascade
+      ;; BEFORE the teardown projection clears the snapshot.
+      (exit-cascade/run-child-exit! frame-id actor-id)
       (finalize/abort-actor-in-flight-http! actor-id)
       (frame/swap-frame-db! frame-id
                             (fn [db]

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -29,21 +29,10 @@
   (:require [re-frame.frame :as frame]
             [re-frame.machines.lifecycle-fx.finalize :as finalize]
             [re-frame.machines.lifecycle-fx.teardown :as teardown]
-            [re-frame.registrar :as registrar]
-            [re-frame.trace :as trace]))
+            [re-frame.machines.lifecycle-fx.traces :as traces]
+            [re-frame.registrar :as registrar]))
 
 #?(:clj (set! *warn-on-reflection* true))
-
-(defn- emit-system-id-released!
-  "Per Spec 005 §Cancellation cascade D8 — fire the
-  `:rf.machine/system-id-released` trace when an actor's `:system-id`
-  binding was released as part of teardown. No-op when sid is nil."
-  [frame-id sid actor-id]
-  (when sid
-    (trace/emit! :machine :rf.machine/system-id-released
-                 {:frame      frame-id
-                  :system-id  sid
-                  :machine-id actor-id})))
 
 (defn- destroy-single-actor!
   "Destroy a single spawned actor against the frame's container: apply
@@ -67,7 +56,7 @@
                                           (teardown/teardown-actor db {:actor-id actor-id})]
                                       (vreset! sid released-sid)
                                       new-db)))
-        (emit-system-id-released! frame-id @sid actor-id)
+        (traces/emit-system-id-released! frame-id @sid actor-id)
         (registrar/unregister! :event actor-id)
         @sid))))
 
@@ -82,13 +71,15 @@
                            [:rf/spawned parent-id invoke-id])
         children   (when (map? join-state) (:children join-state))]
     (doseq [[child-id spawned-id] children]
-      (trace/emit! :machine :rf.machine/destroyed
-                   {:frame      frame-id
-                    :actor-id   spawned-id
-                    :parent-id  parent-id
-                    :invoke-id  invoke-id
-                    :child-id   child-id
-                    :reason     :explicit})        ;; rf2-gn80 D6 — discriminator
+      ;; rf2-gn80 D6 — `:reason :explicit` discriminates "the parent cascade
+      ;; tore the child down" from `:rf.machine/finished` (the auto-destroy
+      ;; on `:final?`). Per-child fires omit `:system-id` (the join-state's
+      ;; children aren't system-id-bound through the parent's slot).
+      (traces/emit-destroyed! {:frame     frame-id
+                               :actor-id  spawned-id
+                               :parent-id parent-id
+                               :invoke-id invoke-id
+                               :child-id  child-id})
       (destroy-single-actor! frame-id spawned-id))
     ;; Clear the join-state slot via the unified projection (slot-only).
     (frame/swap-frame-db! frame-id
@@ -113,13 +104,15 @@
                     (when old-db (get-in old-db [:rf/spawned parent-id invoke-id]))
                     args)
         released-sid (teardown/find-system-id-for-actor old-db actor-id)]
-    (trace/emit! :machine :rf.machine/destroyed
-                 {:frame      frame-id
-                  :actor-id   actor-id
-                  :system-id  released-sid
-                  :parent-id  parent-id
-                  :invoke-id  invoke-id
-                  :reason     :explicit})              ;; rf2-gn80 D6 — discriminator
+    ;; rf2-gn80 D6 — `:reason :explicit` discriminates "an action / fx
+    ;; tore the actor down" from `:rf.machine/finished` (the auto-destroy
+    ;; on `:final?`). Always stamp `:system-id` (nil when not bound) per
+    ;; the destroyed-trace-shape contract for the `destroy-single!` site.
+    (traces/emit-destroyed! {:frame     frame-id
+                             :actor-id  actor-id
+                             :system-id released-sid
+                             :parent-id parent-id
+                             :invoke-id invoke-id})
     ;; Tracked-form destroy with no resolved actor-id is a benign no-op:
     ;; the spawn slot was already cleared (e.g. by an earlier explicit
     ;; destroy) or the spawn was suppressed (SSR / platform gating).
@@ -131,7 +124,7 @@
                                        db {:actor-id  actor-id
                                            :parent-id parent-id
                                            :invoke-id invoke-id}))))
-      (emit-system-id-released! frame-id released-sid actor-id)
+      (traces/emit-system-id-released! frame-id released-sid actor-id)
       ;; Unregister the live handler. Last so any in-flight trace emit
       ;; against the actor still resolves before the slot disappears.
       (registrar/unregister! :event actor-id))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/exit_cascade.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/exit_cascade.cljc
@@ -1,0 +1,113 @@
+(ns re-frame.machines.lifecycle-fx.exit-cascade
+  "Destroy-time `:exit` cascade runner (rf2-nahfm).
+
+  Per Spec 005 §Declarative `:invoke` §Composition with explicit
+  `:entry` / `:exit`: when an `:invoke`-spawned actor is destroyed, the
+  user's `:exit` action gets to read the actor's final snapshot before
+  the auto-destroy clears it. Per §Final states §Composition with
+  `:entry` / `:exit`: a final state's `:exit` runs from the auto-
+  destroy teardown, same ordering convention.
+
+  Pre-rf2-nahfm the four destroy entry-points — explicit
+  `:rf.machine/destroy`, declarative-`:invoke` exit-cascade destroy,
+  `:invoke-all` per-child teardown, and final-state auto-destroy —
+  each tore the actor's snapshot down WITHOUT firing the active
+  configuration's `:exit` actions. This namespace centralises the fix
+  so every destroy path runs through `run-child-exit!`.
+
+  The pure exit cascade (path resolution + action collection) lives in
+  `re-frame.machines.parallel/run-active-exit-cascade` (which dispatches
+  flat/compound to `re-frame.machines.transition`, and parallel to the
+  per-region reduce). This file is the side-effect wrapper that:
+    1. resolves the actor's snapshot from the frame's app-db,
+    2. resolves the actor's machine spec from the registrar,
+    3. runs the pure cascade,
+    4. writes the post-cascade snapshot back to app-db so any caller
+       reading the snapshot AFTER `:exit` (e.g. `finalize-machine`'s
+       `:on-done` projection — though that read happens before this
+       runs, the write here is for tools observing the snapshot
+       between `:exit` and teardown),
+    5. fires the cascade's fx vector through `re-frame.fx/do-fx` so
+       `:exit`-time side effects (HTTP requests, dispatches, logs)
+       actually run,
+    6. surfaces a `:rf.error/machine-action-exception` trace if any
+       `:exit` action threw (consistent with the standard exit-cascade
+       failure handling in `apply-transition-once`).
+
+  Idempotent / safe to call when the actor has no live snapshot or no
+  registered machine spec — both reduce to a benign no-op (the destroy
+  proceeds as before)."
+  (:require [re-frame.fx :as fx]
+            [re-frame.frame :as frame]
+            [re-frame.machines.parallel :as parallel]
+            [re-frame.machines.result :as result]
+            [re-frame.registrar :as registrar]
+            [re-frame.trace :as trace]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn- resolve-machine-spec
+  "Look up `actor-id`'s machine spec via the registrar's `:rf/machine`
+  metadata (per `re-frame.machines.lifecycle-fx/machine-meta`). Returns
+  nil if no machine is registered under `actor-id` — the actor was
+  already torn down, or the destroy targets a non-machine event id."
+  [actor-id]
+  (when actor-id
+    (let [m (registrar/lookup :event actor-id)]
+      (when (:rf/machine? m)
+        (:rf/machine m)))))
+
+(defn run-child-exit!
+  "Run the destroy-time `:exit` cascade for the actor identified by
+  `actor-id` in frame `frame-id`. No-op when the actor has no live
+  snapshot at `[:rf/machines actor-id]` or no registered machine spec.
+
+  On a successful cascade: writes the post-cascade snapshot back to
+  app-db (so callers reading the snapshot between `:exit` and the
+  teardown projection see `:exit`-time `:data` writes) and fires the
+  emitted fx vector via `re-frame.fx/do-fx`. On a thrown action,
+  surfaces a `:rf.error/machine-action-exception` trace (matching the
+  standard transition-time exit-cascade failure category) and skips
+  the fx fire — fail-soft, the destroy proceeds.
+
+  Returns nil. Per Spec 005 §Final states §Composition with `:entry` /
+  `:exit` — `:exit` runs BEFORE the auto-destroy teardown; per
+  §Declarative `:invoke` §Composition — `:exit` reads the actor's
+  final snapshot before clearing."
+  [frame-id actor-id]
+  (when actor-id
+    (let [db       (frame/frame-app-db-value frame-id)
+          snapshot (when db (get-in db [:rf/machines actor-id]))
+          machine  (resolve-machine-spec actor-id)]
+      (when (and snapshot machine)
+        (let [r (parallel/run-active-exit-cascade machine snapshot)]
+          (if (result/fail? r)
+            ;; Match `apply-transition-once`'s exit-cascade failure
+            ;; trace shape — same category, with a destroy-time
+            ;; discriminator so consumers can disambiguate.
+            (trace/emit-error! :rf.error/machine-action-exception
+                               {:machine-id actor-id
+                                :frame      frame-id
+                                :phase      :rf.machine/destroy-exit
+                                :reason     "An :exit action threw during destroy-time cascade."
+                                :recovery   :skipped
+                                :info       (result/info r)})
+            (result/with-ok [new-snap exit-fx] r
+              ;; (4) Write the post-exit snapshot back. The write is
+              ;; transient — the unified teardown projection runs
+              ;; immediately after this and dissocs `[:rf/machines
+              ;; actor-id]`. Tools that observe the app-db between
+              ;; `:exit` and teardown see the `:exit`-time `:data`
+              ;; writes; the production-runtime cost is one extra
+              ;; swap-frame-db! per destroy.
+              (when (not= snapshot new-snap)
+                (frame/swap-frame-db! frame-id
+                                      (fn [d] (assoc-in d [:rf/machines actor-id] new-snap))))
+              ;; (5) Fire the `:exit`-emitted fx via the standard fx
+              ;; interpreter. Use the frame's `:platform` (defaults to
+              ;; :client) so platform-gated fx behave consistently with
+              ;; transition-time fx fires.
+              (when (seq exit-fx)
+                (let [platform (or (:platform (frame/frame-meta frame-id)) :client)]
+                  (fx/do-fx frame-id (vec exit-fx) platform))))))))
+    nil))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -36,6 +36,7 @@
             [re-frame.machines.lifecycle-fx.teardown :as teardown]
             [re-frame.machines.lifecycle-fx.traces :as traces]
             [re-frame.machines.parallel :as parallel]
+            [re-frame.machines.result :as result]
             [re-frame.machines.transition :as transition]
             [re-frame.registrar :as registrar]
             [re-frame.trace :as trace]))
@@ -116,6 +117,39 @@
     _inner-event   — the event that caused the finish (for diagnostics)
     extra-fx       — the fx vector from the transition (passed through)"
   [machine machine-id frame-id db next-snapshot _inner-event extra-fx]
+  ;; (rf2-nahfm) Run the actor's active configuration `:exit` cascade
+  ;; FIRST so the final state's `:exit` actions fire from the auto-
+  ;; destroy teardown (Spec 005 §Final states §Composition with
+  ;; `:entry` / `:exit`). The cascade is pure — it returns a new
+  ;; snapshot + fx vector; we project the `:data` writes onto
+  ;; `next-snapshot` so `:on-done`'s `result` computation observes
+  ;; them, and we append `exit-fx` to the returned `:fx` so any
+  ;; `:exit`-emitted dispatches / HTTP / etc. run.
+  ;;
+  ;; If any `:exit` action threw, we emit the standard exit-cascade
+  ;; failure trace and proceed with the pre-cascade snapshot (fail-
+  ;; soft — the destroy must complete to keep the registrar +
+  ;; spawn-slot consistent).
+  (let [exit-result   (parallel/run-active-exit-cascade machine next-snapshot)
+        exit-ok?      (result/ok? exit-result)
+        next-snapshot (if exit-ok? (result/snap exit-result) next-snapshot)
+        exit-fx       (if exit-ok? (vec (result/fx exit-result)) [])
+        db            (if exit-ok?
+                        ;; Project the post-`:exit` snapshot back into
+                        ;; the db so any reader between `:exit` and the
+                        ;; teardown projection (e.g. `:on-done` reading
+                        ;; the child via `(:rf/machines)`) sees the
+                        ;; final state's writes.
+                        (assoc-in db [:rf/machines machine-id] next-snapshot)
+                        db)
+        _             (when (not exit-ok?)
+                        (trace/emit-error! :rf.error/machine-action-exception
+                                           {:machine-id machine-id
+                                            :frame      frame-id
+                                            :phase      :rf.machine/destroy-exit
+                                            :reason     "An :exit action threw during destroy-time cascade."
+                                            :recovery   :skipped
+                                            :info       (result/info exit-result)}))]
   (let [child-data (:data next-snapshot)
         ;; Resolve the final state-node so we can extract `:output-key`.
         final-node (cond
@@ -209,4 +243,7 @@
     (traces/emit-system-id-released! frame-id released-sid machine-id)
     (registrar/unregister! :event machine-id)
     {:db db-after-destroy
-     :fx extra-fx}))
+     ;; rf2-nahfm — append the destroy-time `:exit` cascade's fx to
+     ;; the transition's fx vector so any `:exit`-emitted dispatches /
+     ;; HTTP / etc. fire as part of the same epoch.
+     :fx (vec (concat extra-fx exit-fx))})))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -34,6 +34,7 @@
   unified) call-sites."
   (:require [re-frame.late-bind :as late-bind]
             [re-frame.machines.lifecycle-fx.teardown :as teardown]
+            [re-frame.machines.lifecycle-fx.traces :as traces]
             [re-frame.machines.parallel :as parallel]
             [re-frame.machines.transition :as transition]
             [re-frame.registrar :as registrar]
@@ -196,21 +197,16 @@
         ;; (D6 enrichment) BEFORE the registrar unregister so any in-flight
         ;; trace consumers see the destroy signal while the handler still
         ;; resolves.
-        _ (trace/emit! :machine :rf.machine/destroyed
-                       {:frame      frame-id
-                        :actor-id   machine-id
-                        :system-id  released-sid
-                        :parent-id  parent-id
-                        :invoke-id  invoke-id
-                        :reason     :rf.machine/finished})]
+        _ (traces/emit-destroyed! {:frame     frame-id
+                                   :actor-id  machine-id
+                                   :system-id released-sid
+                                   :parent-id parent-id
+                                   :invoke-id invoke-id
+                                   :reason    :rf.machine/finished})]
     ;; (6) Synchronous side effects: abort in-flight HTTP, emit
     ;; system-id-released trace (when applicable), unregister handler.
     (abort-actor-in-flight-http! machine-id)
-    (when released-sid
-      (trace/emit! :machine :rf.machine/system-id-released
-                   {:frame      frame-id
-                    :system-id  released-sid
-                    :machine-id machine-id}))
+    (traces/emit-system-id-released! frame-id released-sid machine-id)
     (registrar/unregister! :event machine-id)
     {:db db-after-destroy
      :fx extra-fx}))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/traces.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/traces.cljc
@@ -1,0 +1,57 @@
+(ns re-frame.machines.lifecycle-fx.traces
+  "Shared trace-emit helpers for the actor-destroy cascade.
+
+  Per Spec 009 §`:op-type` vocabulary, `:rf.machine/destroyed` and
+  `:rf.machine/system-id-released` ARE the contract surface that tools
+  (Causa, story-mcp, re-frame-10x) key on for the actor-destroy signal.
+  Independent emission sites = independent chances to drift in the
+  argument-map keys; rf2-ur63f / round-2 audit Trace-r2-3 consolidates
+  the three `:rf.machine/destroyed` sites and the two
+  `:rf.machine/system-id-released` sites into a single home so a key
+  rename is one-edit-touches-all.
+
+  This namespace is the natural home (rather than `teardown.cljc`)
+  because `teardown.cljc` is the unified pure app-db projection
+  (rf2-lha2t) — it deliberately emits NO traces so the projection stays
+  a value→value function. These helpers ARE side effects, so they live
+  separately."
+  (:require [re-frame.trace :as trace]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn emit-destroyed!
+  "Fire `:rf.machine/destroyed` against the canonical argument map.
+
+  Per the rf2-vgkdt destroyed-trace-shape contract (assertion test in
+  `re-frame.destroyed-trace-shape-test`), the permitted site-provided
+  keys are `#{:frame :actor-id :system-id :parent-id :invoke-id
+  :child-id :reason}`. Callers pass only the slots their site populates
+  — `nil` values are stamped through, matching pre-consolidation
+  behaviour (e.g. `destroy-single!` always stamps `:system-id`, even
+  when nil; `destroy-invoke-all-children!` per-child fires omit
+  `:system-id` by NOT passing the key).
+
+  `reason` is the discriminator — `:explicit` for direct-destroy
+  cascades, `:rf.machine/finished` for final-state auto-destroy."
+  [{:keys [frame actor-id system-id parent-id invoke-id child-id reason]
+    :or {reason :explicit}
+    :as args}]
+  (trace/emit! :machine :rf.machine/destroyed
+               (cond-> {:frame    frame
+                        :actor-id actor-id
+                        :reason   reason}
+                 (contains? args :system-id) (assoc :system-id system-id)
+                 (contains? args :parent-id) (assoc :parent-id parent-id)
+                 (contains? args :invoke-id) (assoc :invoke-id invoke-id)
+                 (contains? args :child-id)  (assoc :child-id  child-id))))
+
+(defn emit-system-id-released!
+  "Per Spec 005 §Cancellation cascade D8 — fire
+  `:rf.machine/system-id-released` when an actor's `:system-id` binding
+  was released as part of teardown. No-op when `sid` is nil."
+  [frame-id sid actor-id]
+  (when sid
+    (trace/emit! :machine :rf.machine/system-id-released
+                 {:frame      frame-id
+                  :system-id  sid
+                  :machine-id actor-id})))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -172,7 +172,7 @@
                     (walk (conj path k) (:states n)))))]
         (walk [] (:states region-body))))))
 
-(defn walk-state-nodes
+(defn- walk-state-nodes
   "Yield `[state-key state-node]` pairs for every node under `:states`,
   recursing through `:states` maps. Used by the registration-time
   validators.

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -92,7 +92,7 @@
     (vary-meta parent-machine assoc ::region-cache (atom {}))
     parent-machine))
 
-(defn region-initial-state
+(defn- region-initial-state
   "Compute the initial-state value for one region — applying that region's
   `:initial` cascade through any compound chain. Returns the region's
   state value (keyword for flat regions, vector path for compound regions)."
@@ -113,7 +113,7 @@
     #{}
     state-map))
 
-(defn commit-tags-parallel
+(defn- commit-tags-parallel
   "Variant of `commit-tags` that dispatches on `(:type machine)`. For
   parallel-region machines, recomputes the union across every region.
   For flat/compound machines, defers to the standard `compute-tags`."

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -361,3 +361,31 @@
   (if (parallel? machine)
     (parallel-machine-transition machine snapshot event)
     (transition/machine-transition-single machine snapshot event)))
+
+;; ---- destroy-time exit cascade (rf2-nahfm) --------------------------------
+;;
+;; Per Spec 005 §Final states §Composition with `:entry` / `:exit` and
+;; §Declarative `:invoke` §Composition: the active configuration's
+;; `:exit` actions run BEFORE the destroy cascade tears the snapshot
+;; down. The single-machine helper lives in `re-frame.machines.transition`
+;; (`run-active-exit-cascade`); for parallel-region machines every
+;; region's active leaf path contributes its own exit cascade, ordered
+;; by region declaration via `reduce-regions` so the broadcast invariant
+;; (shared `:data` threading, per-region fx prefix) holds during destroy
+;; the same way it holds during transition.
+
+(defn run-active-exit-cascade
+  "Synthesise the destroy-time exit cascade for `machine` against its
+  active `snapshot`. For parallel-region machines, runs the exit cascade
+  for every region in declaration order via `reduce-regions` (the
+  per-region step delegates to `transition/run-active-exit-cascade`).
+  For flat / compound machines, drops straight into the single-machine
+  helper.
+
+  Returns a `re-frame.machines.result/Result` carrying the post-cascade
+  snapshot + accumulated fx, or a `result/fail` if any region's `:exit`
+  action threw."
+  [machine snapshot]
+  (if (parallel? machine)
+    (reduce-regions machine snapshot transition/run-active-exit-cascade)
+    (transition/run-active-exit-cascade machine snapshot)))

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -216,57 +216,94 @@
       {:target    boot-target
        :decl-path []})))
 
+;; ---- parallel-region broadcast invariant (rf2-vqubp) ----------------------
+;;
+;; Per Spec 005 §Parallel regions, every reducer that broadcasts ONE
+;; per-region computation across a parallel-region machine MUST:
+;;   - iterate regions in declaration order (declaration order = the
+;;     order in which `:regions` was authored; falls back to state-map
+;;     key order when the spec has been mutated post-registration),
+;;   - thread shared `:data` sequentially through regions so a later
+;;     region's step sees earlier regions' writes,
+;;   - thread the in-snapshot `:rf/spawn-counter` (rf2-gr8q) so any
+;;     declarative `:invoke` fired in a region bumps the SAME shared
+;;     counter,
+;;   - run each region as a synthetic single-machine spec via
+;;     `region-machine`,
+;;   - prefix per-region fx with the region name via
+;;     `prefix-region-invoke-id` so per-region `[:rf/spawned ...]` /
+;;     `:after`-epoch tracking slots stay distinct from siblings,
+;;   - short-circuit to a `result/fail` if any region's step fails,
+;;   - commit `:tags` via `commit-tags-parallel` AFTER every region has
+;;     transitioned, since `:tags` is the union across active leaves.
+;;
+;; `reduce-regions` names this invariant once — every broadcast
+;; reducer in the parallel layer delegates here.
+
+(defn- reduce-regions
+  "Apply `step-fn` to each region of `parent-machine` in declaration
+  order, threading `:data` + `:rf/spawn-counter` between regions and
+  prefixing per-region fx with the region name. `step-fn` receives the
+  synthetic region-spec and the per-region snapshot
+  (`{:state ... :data ... ?:rf/spawn-counter ...}`) and returns a
+  `re-frame.machines.result/Result`.
+
+  Returns a `result/ok` Result carrying the merged snapshot (post-
+  `commit-tags-parallel`) + accumulated fx, or the first region's
+  `result/fail` (cascade short-circuits).
+
+  This helper assumes `parent-machine` is `:type :parallel`. Flat /
+  compound callers run their step directly — the broadcast invariant
+  doesn't apply."
+  [parent-machine snapshot step-fn]
+  (let [state-map   (:state snapshot)
+        ordered     (filterv #(contains? state-map %)
+                             (or (vec (keys (:regions parent-machine)))
+                                 (vec (keys state-map))))]
+    (loop [pending     ordered
+           cur-data    (:data snapshot)
+           cur-counter (:rf/spawn-counter snapshot)
+           new-states  state-map
+           acc-fx      []]
+      (if (empty? pending)
+        (let [merged (cond-> (-> snapshot
+                                 (assoc :state new-states)
+                                 (assoc :data  cur-data))
+                       (some? cur-counter)
+                       (assoc :rf/spawn-counter cur-counter))]
+          (result/ok (commit-tags-parallel parent-machine merged) acc-fx))
+        (let [rn          (first pending)
+              region-spec (region-machine parent-machine rn)
+              region-snap (cond-> {:state (get state-map rn)
+                                   :data  cur-data}
+                            (some? cur-counter)
+                            (assoc :rf/spawn-counter cur-counter))
+              step-result (step-fn region-spec region-snap)]
+          (if (result/fail? step-result)
+            step-result
+            (result/with-ok [reg-snap reg-fx] step-result
+              (let [prefixed-fx (mapv (partial prefix-region-invoke-id rn) reg-fx)]
+                (recur (rest pending)
+                       (:data reg-snap)
+                       (:rf/spawn-counter reg-snap)
+                       (assoc new-states rn (:state reg-snap))
+                       (vec (concat acc-fx prefixed-fx)))))))))))
+
 (defn apply-initial-entry-cascade
   "Synthesise the bootstrap entry cascade for `machine` against the
   freshly-synthesised `initial-snapshot`. Returns a `result/ok` Result
   carrying the new snapshot + fx, or a `result/fail` Result if any
   `:entry` action threw.
 
-  For parallel-region machines (`:type :parallel`), iterates regions in
-  declaration order, threading shared `:data` sequentially through regions
-  (matching `parallel-machine-transition`'s broadcast semantics — a later
-  region's `:entry` sees earlier regions' `:data` writes). Each region's
-  fx is prefixed with the region name via `prefix-region-invoke-id` so
-  per-region tracking slots stay distinct."
+  For parallel-region machines (`:type :parallel`), delegates to
+  `reduce-regions` so the per-region step sees the broadcast invariant
+  (declaration-order iteration, threaded `:data` + `:rf/spawn-counter`,
+  per-region fx-prefix, `commit-tags-parallel` on commit). For flat /
+  compound machines, runs `bootstrap-step` directly — the broadcast
+  invariant doesn't apply."
   [machine initial-snapshot]
   (if (parallel? machine)
-    (let [state-map     (:state initial-snapshot)
-          region-names  (vec (keys (:regions machine)))
-          ordered       (filterv #(contains? state-map %) region-names)]
-      ;; Per rf2-gr8q: thread `:rf/spawn-counter` across regions so any
-      ;; entry-cascade :invoke fires through the shared in-snapshot
-      ;; allocator and the final merged snapshot carries the bumped value.
-      (loop [pending     ordered
-             cur-data    (:data initial-snapshot)
-             cur-counter (:rf/spawn-counter initial-snapshot)
-             new-states  state-map
-             acc-fx      []]
-        (cond
-          (empty? pending)
-          (let [merged (cond-> (-> initial-snapshot
-                                   (assoc :state new-states)
-                                   (assoc :data  cur-data))
-                         (some? cur-counter)
-                         (assoc :rf/spawn-counter cur-counter))]
-            (result/ok (commit-tags-parallel machine merged) acc-fx))
-
-          :else
-          (let [rn          (first pending)
-                region-spec (region-machine machine rn)
-                region-snap (cond-> {:state (get state-map rn)
-                                     :data  cur-data}
-                              (some? cur-counter)
-                              (assoc :rf/spawn-counter cur-counter))
-                step-result (bootstrap-step region-spec region-snap)]
-            (if (result/fail? step-result)
-              step-result
-              (result/with-ok [reg-snap reg-fx] step-result
-                (let [prefixed-fx (mapv (partial prefix-region-invoke-id rn) reg-fx)]
-                  (recur (rest pending)
-                         (:data reg-snap)
-                         (:rf/spawn-counter reg-snap)
-                         (assoc new-states rn (:state reg-snap))
-                         (vec (concat acc-fx prefixed-fx))))))))))
+    (reduce-regions machine initial-snapshot bootstrap-step)
     (bootstrap-step machine initial-snapshot)))
 
 (declare machine-transition)
@@ -279,59 +316,20 @@
 
   Per Spec 005 §Transition broadcast: each region resolves the event
   through its own active state's deepest-wins lookup; resolved regions
-  transition, undeclined regions stay put. The :data slot is shared —
+  transition, undeclined regions stay put. The `:data` slot is shared —
   each region's actions see the prior region's `:data` writes in
-  declaration order.
+  declaration order. Per rf2-vqubp the broadcast invariant lives in
+  `reduce-regions`; this function closes over `event` to produce a
+  unary step-fn the helper can apply per region.
 
   For the synthetic `[:rf.machine.timer/after-elapsed ...]` event,
   delivery is region-scoped — the broadcast routes to the bearing region
   only, identified by the region-name prefix on the in-flight timer's
   invoke-id."
   [machine snapshot event]
-  (let [state-map  (:state snapshot)
-        region-names (vec (keys state-map))
-        ordered-regions
-        (->> (or (keys (:regions machine)) region-names)
-             (filter (fn [rn] (contains? state-map rn)))
-             (vec))]
-    ;; Per rf2-gr8q: thread the snapshot's `:rf/spawn-counter` through each
-    ;; region's transition so declarative `:invoke` inside a region bumps
-    ;; the SAME counter the rest of the machine shares. Region snapshots
-    ;; carry the slot in/out alongside `:state` + `:data`, matching the
-    ;; round-trip pattern already used for `:data`.
-    (loop [pending    ordered-regions
-           cur-data   (:data snapshot)
-           cur-counter (:rf/spawn-counter snapshot)
-           new-states state-map
-           acc-fx     []]
-      (cond
-        (empty? pending)
-        (let [final-state-map (into {} (for [rn region-names] [rn (get new-states rn)]))
-              merged          (cond-> (-> snapshot
-                                          (assoc :state final-state-map)
-                                          (assoc :data  cur-data))
-                                (some? cur-counter)
-                                (assoc :rf/spawn-counter cur-counter))
-              merged-tagged   (commit-tags-parallel machine merged)]
-          (result/ok merged-tagged acc-fx))
-
-        :else
-        (let [rn          (first pending)
-              region-spec (region-machine machine rn)
-              region-snap (cond-> {:state (get state-map rn)
-                                   :data  cur-data}
-                            (some? cur-counter)
-                            (assoc :rf/spawn-counter cur-counter))
-              step-result (machine-transition region-spec region-snap event)]
-          (if (result/fail? step-result)
-            step-result
-            (result/with-ok [reg-snap reg-fx] step-result
-              (let [prefixed-fx (mapv (partial prefix-region-invoke-id rn) reg-fx)]
-                (recur (rest pending)
-                       (:data reg-snap)
-                       (:rf/spawn-counter reg-snap)
-                       (assoc new-states rn (:state reg-snap))
-                       (vec (concat acc-fx prefixed-fx)))))))))))
+  (reduce-regions machine snapshot
+                  (fn [region-spec region-snap]
+                    (machine-transition region-spec region-snap event))))
 
 (defn machine-transition
   "Pure function. Given a machine definition, current snapshot, and event,

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -814,6 +814,53 @@
   (let [node (node-at machine (state-path state))]
     (final-state-node? node)))
 
+;; ---- destroy-time exit cascade (rf2-nahfm) --------------------------------
+;;
+;; Per Spec 005 §Declarative `:invoke` §Composition with explicit `:entry`
+;; / `:exit` and §Final states §Composition with `:entry` / `:exit`: when
+;; a spawned actor is torn down, its active configuration's `:exit`
+;; actions run BEFORE the teardown clears the snapshot. That covers
+;; every destroy entry-point — explicit `:rf.machine/destroy`,
+;; declarative-`:invoke` exit-cascade destroy, `:invoke-all` per-child
+;; teardown, and final-state auto-destroy.
+;;
+;; `run-active-exit-cascade` is the single helper the destroy path
+;; reaches for. It returns the post-cascade snapshot + fx so the caller
+;; can (a) apply any `:exit`-time `:data` writes to the snapshot the
+;; teardown observes (e.g. `:on-done` reads), and (b) surface the fx
+;; the `:exit` action emitted. Parallel-region machines run an exit
+;; cascade per region; the dispatcher lives in `re-frame.machines.parallel`
+;; so this layer stays parallel-agnostic.
+
+(defn run-active-exit-cascade
+  "Synthesise the destroy-time exit cascade for `machine` against its
+  active `snapshot`. Walks the active state's full path leaf→root and
+  collects every node's `:exit` action-ref (shallowest-first reversed,
+  matching how `compute-cascade-paths` orders the exit cascade with
+  `lca-len = 0`). Runs them via `collect-actions`.
+
+  Returns a `re-frame.machines.result/Result` — a `result/ok` carrying
+  the post-cascade snapshot + accumulated fx, or a `result/fail` if any
+  `:exit` action threw. Callers (destroy / finalize / invoke-all child
+  teardown) emit a `[:rf.machine/bootstrap-exit]` synthetic event so
+  3-arity `:exit` fns that introspect the event see a discriminator
+  distinguishing destroy-time exit from transition-driven exit.
+
+  This is the SINGLE entry-point — every destroy path threads through
+  here so a spec change to destroy-time `:exit` semantics is one-edit-
+  touches-all. Per Spec 005 §Final states §Composition: the final
+  state's `:exit` runs from the auto-destroy teardown — same ordering
+  convention as the user's `:exit` running before the auto-destroy for
+  ordinary `:invoke`-bearing states."
+  [machine snapshot]
+  (let [path        (state-path (:state snapshot))
+        active-pairs (nodes-along-path machine path)
+        ;; Leaf→root: exit cascade reverses `nodes-along-path` (which
+        ;; returns shallowest-first), matching `compute-cascade-paths`'s
+        ;; `(map ... (reverse exited-pairs))` ordering.
+        exit-refs   (keep (fn [[_ n]] (:exit n)) (reverse active-pairs))]
+    (collect-actions machine snapshot [:rf.machine/destroy-exit] (vec exit-refs))))
+
 ;; ---- apply-transition-once: cascade phases --------------------------------
 ;;
 ;; Per Spec 005 §Entry/exit cascading along the LCA, one transition flows

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -40,7 +40,7 @@
                              nil)
       :else                nil)))
 
-(defn resolve-guard
+(defn- resolve-guard
   "Look up a guard reference. If keyword, follow the chain in the machine's
   :guards map. If a fn, use directly."
   [machine guard]
@@ -174,7 +174,7 @@
   (keyword (namespace machine-id)
            (str (name machine-id) "#" n)))
 
-(defn allocate-spawned-id
+(defn- allocate-spawned-id
   "Pure allocator. Given a snapshot and the spawned actor's machine-id,
   return `[snap' spawned-id]` where snap' carries the bumped counter at
   `[:rf/spawn-counter <machine-id>]` and spawned-id is
@@ -282,7 +282,7 @@
         nodes (nodes-along-path machine path)]
     (transduce (keep (fn [[_ n]] (node-tags n))) set/union #{} nodes)))
 
-(defn commit-tags
+(defn- commit-tags
   "Stamp the active-configuration tag union onto `snapshot` at `:tags`.
   Per Spec 005 §State tags §Snapshot shape change: the slot is OPTIONAL
   — when the union is empty, the runtime elides the key entirely to

--- a/implementation/machines/test/re_frame/destroy_exit_cascade_test.clj
+++ b/implementation/machines/test/re_frame/destroy_exit_cascade_test.clj
@@ -1,0 +1,195 @@
+(ns re-frame.destroy-exit-cascade-test
+  "Per rf2-nahfm — every destroy path runs the child's active configuration
+  `:exit` cascade BEFORE teardown. Pre-rf2-nahfm the four destroy entry-
+  points each cleared the actor's snapshot WITHOUT firing the `:exit`
+  actions Spec 005 §Declarative `:invoke` §Composition with explicit
+  `:entry` / `:exit` and §Final states §Composition with `:entry` /
+  `:exit` promise.
+
+  The four destroy paths exercised here:
+    1. Explicit `[:rf.machine/destroy actor-id]` fx (keyword form)
+       fired from an action.
+    2. Declarative `:invoke` exit-cascade destroy (tracked-map form,
+       fired by `apply-transition-once` when the exit cascade crosses
+       an `:invoke`-bearing state).
+    3. `:invoke-all` per-child teardown (parent cascade tears children
+       down through `destroy-invoke-all-children!`).
+    4. Final-state auto-destroy (child enters `:final?`; `finalize-
+       machine` runs the cascade).
+
+  For each path we assert:
+    - the child's `:exit` action's side effect ran (we use an atom side
+      channel since `:exit` actions are pure fns whose `:fx` we'd
+      otherwise route through `do-fx` — the atom write captures `:exit`
+      fired regardless of whether `:fx` interpretation happened).
+    - the `:exit` action's `:data` write was visible somewhere
+      observable (different per-path: finalize → projected into the
+      pre-teardown snapshot read by `:on-done`; destroy → projected
+      into the snapshot at `[:rf/machines actor-id]` before the
+      teardown projection clears it — observable to any trace consumer
+      reading the db between `:exit` and `:rf.machine/destroyed`)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- (1) explicit [:rf.machine/destroy actor-id] -------------------------
+
+(deftest exit-fires-on-explicit-destroy
+  (testing "explicit `[:rf.machine/destroy actor-id]` fires the active leaf's :exit"
+    (let [exit-fired (atom 0)
+          ;; Define a child machine whose active state's :exit increments
+          ;; an external counter — proves the :exit action ran.
+          _ (rf/reg-machine :ne/standalone
+              {:initial :running
+               :data    {}
+               :states  {:running {:exit (fn [_ _] (swap! exit-fired inc) {})}}})
+          _ (rf/reg-machine :ne/destroyer
+              {:initial :armed
+               :data    {}
+               :states
+               {:armed {:on {:fire {:action (fn [_ _] {:fx [[:rf.machine/destroy :ne/standalone]]})}}}}})]
+      ;; Bring the standalone machine to life by dispatching ANY event
+      ;; (the first dispatch fires the bootstrap cascade per rf2-pexjc).
+      (rf/dispatch-sync [:ne/standalone [:rf.machine/noop]])
+      (is (zero? @exit-fired) "no :exit yet — actor still alive")
+      (rf/dispatch-sync [:ne/destroyer [:fire]])
+      (is (= 1 @exit-fired)
+          ":exit fired exactly once during explicit destroy"))))
+
+;; ---- (2) declarative :invoke exit-cascade destroy ------------------------
+
+(deftest exit-fires-on-invoke-exit-cascade-destroy
+  (testing "parent's :invoke exit cascade fires the child's active :exit"
+    (let [exit-fired   (atom 0)
+          last-data    (atom nil)
+          _ (rf/reg-machine :ne/invoke-child
+              {:initial :working
+               :data    {:counter 0}
+               :states  {:working {:exit (fn [data _]
+                                            (swap! exit-fired inc)
+                                            (reset! last-data data)
+                                            {})}}})
+          _ (rf/reg-machine :ne/invoke-parent
+              {:initial :idle
+               :data    {}
+               :states
+               {:idle    {:on {:start :working}}
+                :working {:invoke {:machine-id :ne/invoke-child}
+                          :on     {:stop :idle}}}})]
+      (rf/dispatch-sync [:ne/invoke-parent [:start]])     ;; spawns child
+      (is (zero? @exit-fired) "no :exit yet — child still alive")
+      (rf/dispatch-sync [:ne/invoke-parent [:stop]])      ;; parent exits :working → child destroyed
+      (is (= 1 @exit-fired)
+          "child's :exit fired exactly once during the parent's exit cascade")
+      ;; The spawn pipeline stamps :rf/parent-id / :rf/invoke-id /
+      ;; :rf/self-id onto the spawned child's :data; the user-supplied
+      ;; :counter slot is the bit we care about. Asserting on the
+      ;; full :data would couple this test to the spawn-stamp shape.
+      (is (= 0 (:counter @last-data))
+          "child's :exit saw its live snapshot's :data (incl :counter) before teardown"))))
+
+;; ---- (3) :invoke-all per-child teardown ----------------------------------
+
+(deftest exit-fires-on-invoke-all-children-teardown
+  (testing ":invoke-all parent exit fires every child's active :exit"
+    (let [exits  (atom [])
+          _ (rf/reg-machine :ne/ia-child
+              {:initial :working
+               :data    {}
+               :states  {:working {:on   {:done :final}
+                                   :exit (fn [_ _]
+                                           (swap! exits conj :working-exit)
+                                           {})}
+                         :final   {:final? true}}})
+          _ (rf/reg-machine :ne/ia-parent
+              {:initial :hydrating
+               :data    {}
+               :states
+               {:hydrating {:invoke-all
+                            {:children
+                             [{:id :a :machine-id :ne/ia-child}
+                              {:id :b :machine-id :ne/ia-child}]
+                             :join              :all
+                             :on-child-done     :ia/asset-done
+                             :on-child-error    :ia/asset-failed
+                             :on-all-complete   [:go-done]
+                             :on-any-failed     [:ia/cancel]}
+                            :on {:go-done    :done
+                                 :ia/cancel  :idle}}
+                :done {}
+                :idle {}}})]
+      (rf/dispatch-sync [:ne/ia-parent [:rf.machine/spawned]])
+      (is (empty? @exits) "no :exit yet — children still running")
+      (rf/dispatch-sync [:ne/ia-parent [:ia/cancel]])     ;; parent → :idle cancels invoke-all
+      (is (= [:working-exit :working-exit] @exits)
+          "each child's active-state :exit fired once during the invoke-all teardown"))))
+
+;; ---- (4) final-state auto-destroy ----------------------------------------
+
+(deftest exit-fires-on-final-state-auto-destroy
+  (testing "child entering :final? fires the final state's :exit before auto-destroy"
+    (let [exit-fired (atom 0)
+          seen-data  (atom nil)
+          _ (rf/reg-machine :ne/final-child
+              {:initial :running
+               :data    {:counter 7}
+               :states
+               {:running {:on {:finish {:target :done
+                                        :action (fn [data _]
+                                                  {:data (update data :counter inc)})}}}
+                :done    {:final?     true
+                          :output-key :counter
+                          :exit       (fn [data _]
+                                        (swap! exit-fired inc)
+                                        (reset! seen-data data)
+                                        {})}}})
+          _ (rf/reg-machine :ne/final-parent
+              {:initial :working
+               :data    {}
+               :states
+               {:working {:invoke {:machine-id :ne/final-child
+                                   :on-done    (fn [data result]
+                                                 (assoc data :received result))}}}})]
+      (rf/dispatch-sync [:ne/final-parent [:rf.machine/spawned]])
+      (is (zero? @exit-fired) "no :exit yet — child still running")
+      ;; Drive the child to :final?.
+      (let [spawned-id (get-in (rf/get-frame-db :rf/default)
+                               [:rf/spawned :ne/final-parent [:working]])]
+        (is (some? spawned-id))
+        (rf/dispatch-sync [spawned-id [:finish]]))
+      (is (= 1 @exit-fired)
+          "final state's :exit fired exactly once during auto-destroy")
+      (is (= {:counter 8} (select-keys @seen-data [:counter]))
+          ":exit saw the final state's :data (post-transition snapshot)")
+      ;; :on-done received the :output-key slot computed PRE-:exit
+      ;; (per Spec 005 — :exit reads, doesn't write, the output slot).
+      ;; Our :exit doesn't mutate :counter so this is just a sanity
+      ;; check that the existing :on-done contract still holds.
+      (is (= 8 (get-in (get-in (rf/get-frame-db :rf/default)
+                               [:rf/machines :ne/final-parent])
+                       [:data :received]))
+          ":on-done still received the :output-key slot — contract preserved"))))
+
+;; ---- regression: :exit fx surfaces ---------------------------------------
+
+(deftest exit-fx-fires-on-destroy
+  (testing ":exit-emitted :fx fires through the standard fx interpreter on destroy"
+    (let [fx-fired   (atom 0)
+          _ (rf/reg-fx :ne/test-fx (fn [_ _] (swap! fx-fired inc)))
+          _ (rf/reg-machine :ne/fx-emitter
+              {:initial :running
+               :data    {}
+               :states  {:running {:exit (fn [_ _] {:fx [[:ne/test-fx nil]]})}}})
+          _ (rf/reg-machine :ne/fx-killer
+              {:initial :armed
+               :data    {}
+               :states
+               {:armed {:on {:fire {:action (fn [_ _] {:fx [[:rf.machine/destroy :ne/fx-emitter]]})}}}}})]
+      (rf/dispatch-sync [:ne/fx-emitter [:rf.machine/noop]])
+      (rf/dispatch-sync [:ne/fx-killer [:fire]])
+      (is (= 1 @fx-fired)
+          ":exit-emitted :fx fired through the fx interpreter (rf2-nahfm — destroy path uses do-fx)"))))

--- a/implementation/machines/test/re_frame/reduce_regions_test.clj
+++ b/implementation/machines/test/re_frame/reduce_regions_test.clj
@@ -1,0 +1,148 @@
+(ns re-frame.reduce-regions-test
+  "Pure-fn unit test for `re-frame.machines.parallel/reduce-regions` —
+  the broadcast invariant for parallel-region machines (rf2-vqubp).
+
+  Asserts the four threading properties the helper encodes:
+   1. Regions iterate in declaration order (the order `:regions` was
+      authored).
+   2. A later region's step sees earlier regions' `:data` writes.
+   3. The shared `:rf/spawn-counter` (rf2-gr8q) threads in/out across
+      regions — bumps in one region are visible to the next.
+   4. Per-region fx is prefixed via `prefix-region-invoke-id` so the
+      `[:rf/spawned ...]` slot key stays unique per region.
+
+  And the contract:
+   5. A `result/fail` from any region short-circuits the reduce — later
+      regions don't run and the failure propagates verbatim.
+
+  The helper is a `defn-` so the test reaches in via the var to invoke
+  it directly. This isolates the reduce-regions semantics from the
+  bootstrap-step / machine-transition step-fns the two production
+  callers supply."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.machines.parallel :as parallel]
+            [re-frame.machines.result :as result]))
+
+(def ^:private reduce-regions
+  ;; Reach in to the private helper. Per rf2-vqubp this test isolates
+  ;; the broadcast invariant from the two production step-fns.
+  #'parallel/reduce-regions)
+
+(defn- two-region-spec
+  "Synthetic parallel-region spec — :a authored before :b."
+  []
+  {:type    :parallel
+   :regions {:a {:initial :a/idle
+                 :states  {:a/idle {}}}
+             :b {:initial :b/idle
+                 :states  {:b/idle {}}}}})
+
+(defn- snapshot
+  ([state]      (snapshot state {} nil))
+  ([state data] (snapshot state data nil))
+  ([state data counter]
+   (cond-> {:state state :data data}
+     (some? counter) (assoc :rf/spawn-counter counter))))
+
+;; ---- (1) declaration order -------------------------------------------------
+
+(deftest iterates-regions-in-declaration-order
+  (testing "step-fn receives regions in `:regions` declaration order"
+    (let [machine (two-region-spec)
+          calls   (atom [])
+          step    (fn [region-spec region-snap]
+                    (swap! calls conj (:rf/region region-spec))
+                    (result/ok region-snap []))
+          snap    (snapshot {:a :a/idle :b :b/idle})
+          r       (reduce-regions machine snap step)]
+      (is (result/ok? r))
+      (is (= [:a :b] @calls)
+          "region :a fires before region :b — declaration order"))))
+
+;; ---- (2) :data threads forward --------------------------------------------
+
+(deftest later-region-sees-earlier-region-data-writes
+  (testing "region :b's step sees the `:data` value :a's step wrote"
+    (let [machine (two-region-spec)
+          seen-data-by-b (atom nil)
+          step    (fn [region-spec region-snap]
+                    (case (:rf/region region-spec)
+                      :a (result/ok (assoc-in region-snap [:data :written-by] :a) [])
+                      :b (do (reset! seen-data-by-b (:data region-snap))
+                             (result/ok region-snap []))))
+          snap    (snapshot {:a :a/idle :b :b/idle} {:seed 1})
+          r       (reduce-regions machine snap step)]
+      (is (result/ok? r))
+      (is (= {:seed 1 :written-by :a} @seen-data-by-b)
+          ":b's step sees :a's :data write merged into the shared :data slot")
+      (is (= {:seed 1 :written-by :a} (:data (result/snap r)))
+          "merged snapshot carries the final :data after all regions ran"))))
+
+;; ---- (3) :rf/spawn-counter threads in/out ----------------------------------
+
+(deftest spawn-counter-threads-across-regions
+  (testing ":rf/spawn-counter bump in :a is visible to :b and carries through"
+    (let [machine (two-region-spec)
+          seen-counter-by-b (atom nil)
+          step    (fn [region-spec region-snap]
+                    (case (:rf/region region-spec)
+                      :a (result/ok (assoc region-snap :rf/spawn-counter {:ix 5}) [])
+                      :b (do (reset! seen-counter-by-b (:rf/spawn-counter region-snap))
+                             (result/ok (assoc region-snap :rf/spawn-counter {:ix 5 :iy 7}) []))))
+          snap    (snapshot {:a :a/idle :b :b/idle} {} {})
+          r       (reduce-regions machine snap step)]
+      (is (result/ok? r))
+      (is (= {:ix 5} @seen-counter-by-b)
+          ":b's region-snap carries :a's bumped counter")
+      (is (= {:ix 5 :iy 7} (:rf/spawn-counter (result/snap r)))
+          "merged snapshot carries the final counter after all regions ran")))
+
+  (testing "absent :rf/spawn-counter stays absent (no defensive seeding)"
+    (let [machine (two-region-spec)
+          step    (fn [_ region-snap] (result/ok region-snap []))
+          snap    (snapshot {:a :a/idle :b :b/idle})            ;; no :rf/spawn-counter
+          r       (reduce-regions machine snap step)]
+      (is (result/ok? r))
+      (is (not (contains? (result/snap r) :rf/spawn-counter))
+          "no :rf/spawn-counter slot is fabricated when the input snapshot had none"))))
+
+;; ---- (4) per-region fx prefix ---------------------------------------------
+
+(deftest per-region-fx-is-prefixed-with-region-name
+  (testing ":rf/invoke-id on emitted fx is prepended with the region name"
+    (let [machine (two-region-spec)
+          step    (fn [region-spec region-snap]
+                    (let [rn (:rf/region region-spec)]
+                      (result/ok region-snap
+                                 [[:rf.machine/spawn {:rf/invoke-id [rn :child]}]])))
+          snap    (snapshot {:a :a/idle :b :b/idle})
+          r       (reduce-regions machine snap step)]
+      (is (result/ok? r))
+      ;; Each region's step emits an :invoke-id starting with its own
+      ;; region name; reduce-regions prepends the region name AGAIN
+      ;; (the standard prefix-region-invoke-id rule) so the final fx
+      ;; carries `[rn rn :child]`.
+      (is (= [[:rf.machine/spawn {:rf/invoke-id [:a :a :child]}]
+              [:rf.machine/spawn {:rf/invoke-id [:b :b :child]}]]
+             (result/fx r))
+          "per-region fx is prefixed with that region's name"))))
+
+;; ---- (5) short-circuit on failure -----------------------------------------
+
+(deftest result-fail-short-circuits
+  (testing "if region :a's step fails, region :b's step does NOT run"
+    (let [machine (two-region-spec)
+          b-ran?  (atom false)
+          fail-r  (result/fail {:reason :test-failure})
+          step    (fn [region-spec _region-snap]
+                    (case (:rf/region region-spec)
+                      :a fail-r
+                      :b (do (reset! b-ran? true)
+                             (result/ok {:state :b/idle :data {}} []))))
+          snap    (snapshot {:a :a/idle :b :b/idle})
+          r       (reduce-regions machine snap step)]
+      (is (result/fail? r))
+      (is (false? @b-ran?)
+          "later region's step never runs when an earlier region fails")
+      (is (= :test-failure (-> (result/info r) :reason))
+          "the failure propagates verbatim — caller sees the offending region's diagnostic"))))


### PR DESCRIPTION
## Summary

Tail batch of the rf2-2ukxv round-2 machines audit (companion to #1004 + #1024). Four beads, all under `implementation/machines/`:

- **rf2-ur63f** — Consolidate `:rf.machine/destroyed` + `:rf.machine/system-id-released` trace emit sites into a new `lifecycle_fx/traces.cljc`. Three independent destroyed-emit sites + two independent system-id-released sites collapsed into two helpers — the Spec 009 trace shape is one-edit-touches-all. `teardown.cljc` deliberately stays trace-free (it owns the pure app-db projection).

- **rf2-vqubp** — Extract `reduce-regions` from `parallel.cljc`. The parallel-region broadcast invariant (declaration-order iteration, `:data` threading, `:rf/spawn-counter` threading, per-region fx-prefix, fail short-circuit, `commit-tags-parallel` on commit) had no named home — `apply-initial-entry-cascade` and `parallel-machine-transition` each re-encoded it. New pure-fn unit test (`reduce_regions_test.clj`) exercises every property in isolation.

- **rf2-qw5at** — `defn` → `defn-` privacy audit. Six symbols had no cross-ns reference; flipped to private: `transition/resolve-guard`, `transition/allocate-spawned-id`, `transition/commit-tags`, `parallel/region-initial-state`, `parallel/commit-tags-parallel`, `validation/walk-state-nodes`. Behaviour-preserving.

- **rf2-nahfm** — Fix: run child's active configuration `:exit` cascade on ALL destroy paths. Spec 005 promises that `:exit` runs before auto-destroy across explicit `:rf.machine/destroy`, `:invoke` exit-cascade, `:invoke-all` per-child teardown, and final-state auto-destroy — none of the four paths actually did this. New `transition/run-active-exit-cascade` (pure) + `parallel/run-active-exit-cascade` (parallel dispatcher) + `lifecycle_fx/exit_cascade.cljc` (side-effect wrapper firing `:exit`-emitted `:fx` via `do-fx`, fail-soft on throwing `:exit`). Finalize integrates pure exit-fx into the returned `:fx`. Five regression tests cover each destroy path.

## Test plan

- [x] `cd implementation/machines && clojure -M:test` — 149 tests / 470 assertions, all green
- [x] `cd implementation && npm run test:cljs` — 1822 tests / 5131 assertions, all green
- [x] Rebased clean on `origin/main`

Closes rf2-ur63f, rf2-vqubp, rf2-qw5at, rf2-nahfm.