### PR TITLE
feat(story): v1.1 cluster — viewport + background reg-mode bundle (rf2-wk41)

### DIFF
--- a/tools/story/spec/010-Toolbar.md
+++ b/tools/story/spec/010-Toolbar.md
@@ -283,18 +283,21 @@ The Storybook 8 toolbar primitives map onto `reg-mode` as follows:
 
 | Storybook addon | re-frame2 form                                       | Axis            |
 |-----------------|------------------------------------------------------|-----------------|
-| Theme switcher  | `(reg-mode :M.theme/<name> {:axis :theme :args {:theme ...}})` | `:theme`   |
-| Viewport addon  | `(reg-mode :M.viewport/<name> {:axis :viewport :args {:viewport ...}})` | `:viewport` |
-| Locale switcher | `(reg-mode :M.locale/<name> {:axis :locale :args {:locale ...}})` | `:locale` |
-| Backgrounds     | `(reg-mode :M.bg/<name> {:axis :background :args {:background ...}})` | `:background` |
+| Theme switcher  | `(reg-mode :Mode.theme/<name> {:axis :theme :args {:theme ...}})` | `:theme`   |
+| Viewport addon  | `(reg-mode :Mode.viewport/<name> {:axis :viewport :args {:viewport ...}})` | `:viewport` |
+| Locale switcher | `(reg-mode :Mode.locale/<name> {:axis :locale :args {:locale ...}})` | `:locale` |
+| Backgrounds     | `(reg-mode :Mode.background/<name> {:axis :background :args {:background ...}})` | `:background` |
 
 Each is a **registered mode tuple**, not a separate primitive. rf2-wk41
 (Backgrounds + Viewport addon UX) ships canonical `reg-mode`
 registrations for the four standard viewports (mobile / tablet / desktop
 / ultra-wide) and the three standard backgrounds (light / dark /
 transparent), bundled as opt-in registrations a project pulls in
-with `(re-frame.story.modes.standard/register-all!)`. That's a v1.1
-UX-polish bead; the toolbar surface this spec specifies is v1.
+with `(re-frame.story.modes.standard/register-all!)`. The mode-ids
+follow the canonical `:Mode.<path>/<name>` grammar
+(`schemas/mode-id?`) — `:Mode.viewport/mobile` and
+`:Mode.background/dark` rather than the informal `:M.viewport/...`
+shorthand the table above sketched in early drafts.
 
 ## `with-mode` accessor — programmatic + reactive
 

--- a/tools/story/src/re_frame/story/modes/standard.cljc
+++ b/tools/story/src/re_frame/story/modes/standard.cljc
@@ -1,0 +1,130 @@
+(ns re-frame.story.modes.standard
+  "Canonical `reg-mode` registrations for the Storybook-parity addons —
+  viewports + backgrounds. Per spec/010 §Interaction with Storybook
+  addons (rf2-wk41 follow-on to the toolbar substrate rf2-p0mv).
+
+  Storybook 8 ships dedicated Backgrounds + Viewport addons as part of
+  its default install. Story's equivalent is **opt-in registrations**:
+  a project that wants the same chrome-level chips calls
+  `(re-frame.story.modes.standard/register-all!)` (or one of the
+  axis-scoped installers) at boot. Each registration is a plain
+  `reg-mode` tuple — the toolbar surface picks them up via
+  `(registrar/handlers :mode)` like any other mode.
+
+  ## Why opt-in, not auto-installed
+
+  Two reasons:
+
+  1. **No magic** — Story's canonical-vocabulary boot
+     (`install-canonical-vocabulary!`) installs only the tags, fx-stubs,
+     and panels that the framework itself depends on. Addon-style
+     registrations are author-owned content — they belong in the
+     project's `stories.cljs`, optionally delegated to this helper.
+  2. **Bundle isolation** — projects that don't want the viewport /
+     background chips in their toolbar should not pay the registry
+     cost. Opt-in installers keep the default install minimal.
+
+  ## Surface
+
+  - `register-viewports!` — register the four canonical viewports
+    (`:Mode.viewport/mobile` / `:tablet` / `:desktop` /
+    `:ultra-wide`).
+  - `register-backgrounds!` — register the three canonical backgrounds
+    (`:Mode.background/light` / `:dark` / `:transparent`).
+  - `register-all!`        — call both. Convenience.
+
+  Each installer is idempotent — re-registering a mode-id overwrites
+  the body (per `registrar/reg-mode*`), so calling these at hot-reload
+  time is safe.
+
+  ## Effective-args contract
+
+  Each canonical mode contributes a single arg key under its axis:
+
+  - viewport modes  → `:viewport <preset-keyword>` (e.g. `:mobile`)
+  - background modes → `:background <css-color-string>`
+
+  The keys are the bare arg names a story body / decorator can read
+  via the `:story/active-args` cofx (per spec/010 §with-mode
+  accessor). Projects that want richer payloads (e.g. exact pixel
+  dimensions for a viewport) wrap or replace this namespace's
+  registrations with their own."
+  (:require [re-frame.story.registrar :as registrar]))
+
+;; ---- viewport canonical set ----------------------------------------------
+;;
+;; Four-preset ladder matching Storybook's defaults (mobile / tablet /
+;; desktop / ultra-wide). Each is a `:axis :viewport` mode so the
+;; toolbar's single-select-within-axis semantics prevents two
+;; viewports being active simultaneously.
+
+(def viewports
+  "EDN map of canonical viewport mode-ids → bodies. Public so projects
+  can introspect / extend / replace specific entries before calling
+  `register-viewports!`.
+
+  Mode-id grammar is `:Mode.<path>/<name>` per `schemas/mode-id?`; the
+  Storybook-leaning short alias `:M.viewport/<name>` in spec/010's
+  example table is informal — the canonical ids live under
+  `Mode.viewport/` so they parse against the grammar."
+  {:Mode.viewport/mobile     {:doc  "Mobile viewport (375x667 — iPhone SE class)."
+                              :axis :viewport
+                              :args {:viewport :mobile}}
+   :Mode.viewport/tablet     {:doc  "Tablet viewport (768x1024 — iPad portrait)."
+                              :axis :viewport
+                              :args {:viewport :tablet}}
+   :Mode.viewport/desktop    {:doc  "Desktop viewport (1280x800 — laptop class)."
+                              :axis :viewport
+                              :args {:viewport :desktop}}
+   :Mode.viewport/ultra-wide {:doc  "Ultra-wide viewport (1920x1080 — desktop monitor)."
+                              :axis :viewport
+                              :args {:viewport :ultra-wide}}})
+
+(defn register-viewports!
+  "Register every canonical viewport mode. Idempotent — re-registering
+  a mode-id overwrites the body. Returns the set of mode-ids
+  registered."
+  []
+  (doseq [[id body] viewports]
+    (registrar/reg-mode* id body))
+  (set (keys viewports)))
+
+;; ---- background canonical set --------------------------------------------
+;;
+;; Three-preset set matching Storybook's defaults (light / dark /
+;; transparent). Each is `:axis :background` so they single-select
+;; within the axis like viewports.
+
+(def backgrounds
+  "EDN map of canonical background mode-ids → bodies. Public so
+  projects can introspect / extend / replace specific entries before
+  calling `register-backgrounds!`.
+
+  Same grammar note as `viewports` — ids live under
+  `Mode.background/` so they parse against `schemas/mode-id?`."
+  {:Mode.background/light       {:doc  "Light background — #ffffff."
+                                 :axis :background
+                                 :args {:background "#ffffff"}}
+   :Mode.background/dark        {:doc  "Dark background — #1e1e1e."
+                                 :axis :background
+                                 :args {:background "#1e1e1e"}}
+   :Mode.background/transparent {:doc  "Transparent background — `transparent`."
+                                 :axis :background
+                                 :args {:background "transparent"}}})
+
+(defn register-backgrounds!
+  "Register every canonical background mode. Idempotent. Returns the
+  set of mode-ids registered."
+  []
+  (doseq [[id body] backgrounds]
+    (registrar/reg-mode* id body))
+  (set (keys backgrounds)))
+
+;; ---- convenience ---------------------------------------------------------
+
+(defn register-all!
+  "Register every canonical viewport + background mode. The single
+  call a Storybook-parity project makes at boot to get the addon-style
+  chrome chips. Idempotent. Returns the union of registered mode-ids."
+  []
+  (into (register-viewports!) (register-backgrounds!)))

--- a/tools/story/test/re_frame/story/modes_standard_test.clj
+++ b/tools/story/test/re_frame/story/modes_standard_test.clj
@@ -1,0 +1,106 @@
+(ns re-frame.story.modes-standard-test
+  "Tests for `re-frame.story.modes.standard` — the canonical
+  viewport + background `reg-mode` bundle (rf2-wk41).
+
+  Pure-data registry — JVM-only is sufficient; the registrar runs on
+  both runtimes and there is no view layer to exercise."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story :as story]
+            [re-frame.story.modes.standard :as standard]
+            [re-frame.story.registrar :as registrar]
+            [re-frame.story.schemas :as schemas]
+            [malli.core :as m]))
+
+(defn reset-all! [test-fn]
+  (story/clear-all!)
+  (story/install-canonical-vocabulary!)
+  (test-fn))
+
+(use-fixtures :each reset-all!)
+
+;; ---- canonical-data shape -----------------------------------------------
+
+(deftest viewports-canonical-set
+  (testing "viewports map carries the four canonical preset ids"
+    (is (= #{:Mode.viewport/mobile
+             :Mode.viewport/tablet
+             :Mode.viewport/desktop
+             :Mode.viewport/ultra-wide}
+           (set (keys standard/viewports)))))
+  (testing "every viewport body sits on `:axis :viewport`"
+    (doseq [[id body] standard/viewports]
+      (is (= :viewport (:axis body))
+          (str id " missing :axis :viewport"))))
+  (testing "every viewport body contributes a `:viewport` arg"
+    (doseq [[_ body] standard/viewports]
+      (is (keyword? (:viewport (:args body)))))))
+
+(deftest backgrounds-canonical-set
+  (testing "backgrounds map carries the three canonical preset ids"
+    (is (= #{:Mode.background/light
+             :Mode.background/dark
+             :Mode.background/transparent}
+           (set (keys standard/backgrounds)))))
+  (testing "every background body sits on `:axis :background`"
+    (doseq [[id body] standard/backgrounds]
+      (is (= :background (:axis body))
+          (str id " missing :axis :background"))))
+  (testing "every background body contributes a string `:background` arg"
+    (doseq [[_ body] standard/backgrounds]
+      (is (string? (:background (:args body)))))))
+
+;; ---- schema conformance --------------------------------------------------
+
+(deftest every-canonical-body-validates-against-mode-schema
+  (testing "viewport bodies pass `:rf/mode` schema"
+    (doseq [[id body] standard/viewports]
+      (is (m/validate schemas/Mode body)
+          (str id " failed Mode schema"))))
+  (testing "background bodies pass `:rf/mode` schema"
+    (doseq [[id body] standard/backgrounds]
+      (is (m/validate schemas/Mode body)
+          (str id " failed Mode schema")))))
+
+;; ---- installer side-effects ---------------------------------------------
+
+(deftest register-viewports-installs-all
+  (testing "register-viewports! adds every canonical viewport to the registry"
+    (let [ids (standard/register-viewports!)]
+      (is (= (set (keys standard/viewports)) ids))
+      (doseq [id (keys standard/viewports)]
+        (is (registrar/registered? :mode id))))))
+
+(deftest register-backgrounds-installs-all
+  (testing "register-backgrounds! adds every canonical background to the registry"
+    (let [ids (standard/register-backgrounds!)]
+      (is (= (set (keys standard/backgrounds)) ids))
+      (doseq [id (keys standard/backgrounds)]
+        (is (registrar/registered? :mode id))))))
+
+(deftest register-all-installs-both-axes
+  (testing "register-all! installs every viewport + background"
+    (let [ids (standard/register-all!)]
+      (is (= (into (set (keys standard/viewports))
+                   (set (keys standard/backgrounds)))
+             ids))
+      (doseq [id ids]
+        (is (registrar/registered? :mode id))))))
+
+(deftest installers-are-idempotent
+  (testing "calling register-all! twice does not throw and leaves registry consistent"
+    (standard/register-all!)
+    (standard/register-all!)
+    (let [registered (set (keys (registrar/handlers :mode)))]
+      (is (every? registered (keys standard/viewports)))
+      (is (every? registered (keys standard/backgrounds))))))
+
+;; ---- toolbar interaction smoke ------------------------------------------
+
+(deftest registered-modes-appear-on-mode-registry
+  (testing "after register-all! the live registry exposes the canonical ids"
+    (standard/register-all!)
+    (let [snapshot (registrar/handlers :mode)]
+      (is (= (:axis (get snapshot :Mode.viewport/mobile)) :viewport))
+      (is (= (:axis (get snapshot :Mode.background/dark)) :background))
+      (is (= (:viewport (:args (get snapshot :Mode.viewport/tablet))) :tablet))
+      (is (= (:background (:args (get snapshot :Mode.background/transparent))) "transparent")))))


### PR DESCRIPTION
## Summary

Story v1.1 cluster pass (6 candidate beads). One landed; five deferred with detailed notes.

### Landed — rf2-wk41 — Backgrounds + Viewport addon UX

Storybook 8's Backgrounds + Viewport addons map onto Story's `reg-mode` primitive (per spec/010 §Interaction with Storybook addons). This ships a single opt-in installer at `re-frame.story.modes.standard/register-all!` that registers:

- **4 canonical viewports** — `:Mode.viewport/mobile` / `:tablet` / `:desktop` / `:ultra-wide` (each `:axis :viewport`, contributing a `:viewport` keyword arg)
- **3 canonical backgrounds** — `:Mode.background/light` / `:dark` / `:transparent` (each `:axis :background`, contributing a `:background` css-color arg)

The toolbar (rf2-xi9zk, already shipped) picks them up via `(registrar/handlers :mode)` and renders them as single-select-within-axis chip groups for free.

Three installers — `register-viewports!`, `register-backgrounds!`, `register-all!`. All idempotent, all axis-tagged for clean toolbar grouping. ~110 LoC src + ~110 LoC test.

Spec/010 §Interaction with Storybook addons table updated — earlier drafts used informal `:M.<path>/<name>` ids; corrected to the canonical `:Mode.<path>/<name>` grammar enforced by `schemas/mode-id?`.

### Deferred

- **rf2-rzm0e** — Vitest-class reporter UI. Substantial: canvas video capture + DOM snapshots + error overlays. Should split into 3 focused beads.
- **rf2-7ncf9** — Facet tag taxonomy. Needs Mike-decision on canonical axis vocabularies (what are the canonical `:status` values? do canonical-seven sit on an axis?).
- **rf2-n8dtz** — Command-K palette. Self-contained UI feature (~150-200 LoC); deserves its own focused PR rather than a cluster pass.
- **rf2-r770** — Causa cross-link panel. Cross-tool integration needs design-bead first (frame-id → sub-topology embedding contract).
- **rf2-k3y2f** — Bundle-size baseline measurement. Investigation task, not a code change; should pair with a dedicated CI-guard bead.

Detailed defer notes attached to each bead via `bd update --notes`.

## Test plan

- [x] `cd tools/story && clojure -M:test` — 360 tests / 1079 assertions, 0 failures
- [x] `cd implementation && npm run test:cljs` — 1845 tests / 5224 assertions, 0 failures
- [x] Schema validation: new viewport/background bodies all pass `schemas/Mode` via the new test
- [x] Idempotency: register-all! twice leaves a consistent registry

## Foundational status

This is the v1 UX-polish bead that builds on the v1 toolbar substrate (rf2-p0mv / rf2-xi9zk). Per spec/010 §Foundational status — toolbar surface = v1; this addon bundle = v1.1 follow-on (now v1-aligned).