### PR TITLE
refactor(helix): tail cluster — 3 follow-on beads

### DIFF
--- a/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
+++ b/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
@@ -72,10 +72,9 @@
                          :children [($ header) ($ main)]})
 
   Per rf2-sixo: missing or `nil` `:frame` falls through to `:rf/default`.
-  The three React-shaped adapters share one React Context (per rf2-3yij
-  Decision 2 / rf2-2qit Decision 2) so a subtree under any
-  frame-provider sees the right frame regardless of which substrate
-  rendered the provider."
+  The three React-shaped adapters share one React Context (per rf2-2qit
+  Decision 2) so a subtree under any frame-provider sees the right frame
+  regardless of which substrate rendered the provider."
   (:frame-provider spine-fns))
 
 (def use-subscribe

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_frame_context_corrupted_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_frame_context_corrupted_cljs_test.cljs
@@ -1,0 +1,115 @@
+(ns re-frame.adapter.helix-frame-context-corrupted-cljs-test
+  "Parity test for `:rf.error/frame-context-corrupted` under the Helix
+  adapter (rf2-n5obf).
+
+  The corruption-detection + recovery path lives in
+  `re-frame.adapter.context/function-component-current-frame` — the
+  shared impl Helix wires into its `:adapter/current-frame` slot per
+  rf2-d4sf. A non-keyword `_currentValue` on the shared frame-context
+  emits `:rf.error/frame-context-corrupted` (rf2-8q66) and falls
+  through to `:rf/default` (recovery `:replaced-with-default`).
+
+  Pre-rf2-n5obf, the test for this path ran only under the Reagent
+  adapter (see
+  `adapters/reagent/test/re_frame/frame_provider_context_cljs_test.cljs`
+  scenario-3). The Helix adapter wires through the *same* shared impl,
+  so the path itself is already covered — what this file pins is that
+  the Helix adapter's hook-routing keeps that path live. If the
+  `:adapter/current-frame` Var ever drifts (a refactor of the late-bind
+  hook table, the Helix adapter's `route-hook!` line, or the shared
+  fn's emit path), this parity test breaks the build.
+
+  Implementation note: the test pokes `.-_currentValue` directly. React
+  itself mutates this field as Provider boundaries are entered and
+  exited during render; outside a render frame we are free to set it
+  to test values and restore the original in `finally`.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.context :as adapter-context]
+            [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter helix-adapter/adapter}))
+
+;; ---- trace helpers --------------------------------------------------------
+
+(defn- collect-traces [k]
+  (let [traces (atom [])]
+    (rf/register-trace-cb! k (fn [ev] (swap! traces conj ev)))
+    traces))
+
+(defn- corruption-traces [traces]
+  (filter #(= :rf.error/frame-context-corrupted (:operation %)) @traces))
+
+;; ---- direct-call parity ----------------------------------------------------
+;;
+;; The shared `function-component-current-frame` resolves `_currentValue`
+;; off the frame-context. Helix's `:adapter/current-frame` hook (wired
+;; in helix.cljs by `route-hook!`) points at this fn. Probe the fn
+;; directly to assert the emit-and-recover contract under a Helix-
+;; installed runtime.
+
+(deftest direct-call-emits-error-and-recovers-under-helix
+  (testing "function-component-current-frame: corrupted _currentValue under Helix adapter"
+    (let [original (.-_currentValue ^js adapter-context/frame-context)
+          traces   (collect-traces ::direct-helix)]
+      (try
+        (testing "nil _currentValue: error trace fires; resolves to :rf/default"
+          (reset! traces [])
+          (set! (.-_currentValue ^js adapter-context/frame-context) nil)
+          (is (= :rf/default (adapter-context/function-component-current-frame))
+              "falls through to :rf/default (recovery preserved under Helix)")
+          (let [errs (corruption-traces traces)]
+            (is (= 1 (count errs))
+                "one :rf.error/frame-context-corrupted event fired")
+            (is (= :error (:op-type (first errs)))
+                ":op-type is :error per Spec 009 §Error contract")
+            (is (= :replaced-with-default (:recovery (first errs)))
+                ":recovery is :replaced-with-default — fall-through preserved")
+            (is (= :nil (-> errs first :tags :type))
+                ":tags :type names the corrupted shape")))
+        (testing "number _currentValue: error trace fires; resolves to :rf/default"
+          (reset! traces [])
+          (set! (.-_currentValue ^js adapter-context/frame-context) 42)
+          (is (= :rf/default (adapter-context/function-component-current-frame))
+              "falls through to :rf/default")
+          (let [errs (corruption-traces traces)]
+            (is (= 1 (count errs))
+                "one error trace per corrupted read")
+            (is (= :number (-> errs first :tags :type)))
+            (is (= 42 (-> errs first :tags :received))
+                ":tags :received echoes the offending value")))
+        (finally
+          (rf/remove-trace-cb! ::direct-helix)
+          (set! (.-_currentValue ^js adapter-context/frame-context) original))))))
+
+;; ---- adapter-routed parity -------------------------------------------------
+;;
+;; `rf/current-frame` (-> `frame/resolve-current-frame`) consults the
+;; `:adapter/current-frame` late-bind hook (rf2-d4sf). Under a Helix-
+;; installed runtime, this routes to `function-component-current-frame`.
+;; Corrupting `_currentValue` and calling the public seam exercises the
+;; rf2-d4sf wiring end-to-end: regression in the hook table, the Helix
+;; `route-hook!` line, or the chain-bottom fallback breaks this test.
+
+(deftest current-frame-recovers-under-helix
+  (testing "rf/current-frame: corrupted _currentValue → :rf/default under Helix"
+    (let [original (.-_currentValue ^js adapter-context/frame-context)
+          traces   (collect-traces ::routed-helix)]
+      (try
+        (reset! traces [])
+        (set! (.-_currentValue ^js adapter-context/frame-context) "")
+        (is (= :rf/default (rf/current-frame))
+            "adapter-routed read recovers to :rf/default under Helix")
+        (let [errs (corruption-traces traces)]
+          (is (= 1 (count errs))
+              "one :rf.error/frame-context-corrupted event fired through the Helix-routed path")
+          (is (= :empty-string (-> errs first :tags :type))
+              ":tags :type distinguishes empty-string from a populated string"))
+        (finally
+          (rf/remove-trace-cb! ::routed-helix)
+          (set! (.-_currentValue ^js adapter-context/frame-context) original))))))

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_frame_provider_children_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_frame_provider_children_cljs_test.cljs
@@ -1,0 +1,125 @@
+(ns re-frame.adapter.helix-frame-provider-children-cljs-test
+  "Unit coverage for the three branches of the Helix adapter's
+  `frame-provider` :children handling (rf2-uze2w).
+
+  `frame-provider` (shared spine — `re-frame.substrate.spine`, exposed
+  through `re-frame.adapter.helix`) accepts a props map with `:frame`
+  and `:children` keys and returns a React element wrapping the children
+  in the shared frame-context Provider. Three defensive branches:
+
+    1. `:children` sequential → splat directly into provider-element
+    2. `:children` non-sequential → wrap-in-vec then splat (defensive
+       cover for callers that pass a single element rather than a vec)
+    3. `:frame` nil / missing → fall through to `:rf/default` (per
+       rf2-sixo — tooling-generated trees that elide the prop)
+
+  Pre-rf2-uze2w none of these branches had explicit coverage. The
+  nil-fallback in particular matters because rf2-sixo's rationale is
+  precisely \"tooling broke and stopped passing the prop\" — a
+  regression here is exactly that failure mode.
+
+  Implementation note: `frame-provider` is a plain CLJS fn returning a
+  raw React element (NOT a defnc component head). The test calls it
+  directly and inspects the returned element's `.props.value` and
+  `.props.children` — no DOM needed, so this runs under `:node-test`.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ["react" :as React]
+            [re-frame.adapter.context :as adapter-context]
+            [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter helix-adapter/adapter}))
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- react-element?
+  "Cheap React-element shape probe — every React.createElement result
+  has the `$$typeof` Symbol marker and a `type` field."
+  [el]
+  (and (some? el)
+       (some? (.-$$typeof ^js el))
+       (some? (.-type ^js el))))
+
+(defn- provider-type?
+  "True iff `el` is a frame-context Provider element (i.e. its `type`
+  is the Provider object hanging off the shared frame-context)."
+  [el]
+  (identical? (.-type ^js el)
+              (.-Provider ^js adapter-context/frame-context)))
+
+(defn- props-value [el] (.-value (.-props ^js el)))
+(defn- props-children [el] (.-children (.-props ^js el)))
+
+(defn- leaf-element
+  "Build a trivial React element to act as a child in the assertions
+  below. `React.createElement(\"span\", null, label)`."
+  [label]
+  (React/createElement "span" nil label))
+
+;; ---- Branch 1: :children sequential ----------------------------------------
+
+(deftest frame-provider-children-sequential
+  (testing "sequential :children — vec of two elements — splats into Provider children"
+    (let [c1 (leaf-element "a")
+          c2 (leaf-element "b")
+          el (helix-adapter/frame-provider
+               {:frame :rf.helix-fp-test/seq
+                :children [c1 c2]})]
+      (is (react-element? el)
+          "frame-provider returns a React element")
+      (is (provider-type? el)
+          "the element's `type` is the shared frame-context Provider")
+      (is (= :rf.helix-fp-test/seq (props-value el))
+          ":value prop carries the requested frame keyword")
+      ;; React.createElement collapses 2+ children into a JS array on
+      ;; `.props.children`.
+      (let [kids (props-children el)]
+        (is (array? kids)
+            "two children land as a JS array on .props.children")
+        (is (= 2 (.-length kids))
+            "both children present")
+        (is (identical? c1 (aget kids 0)))
+        (is (identical? c2 (aget kids 1)))))))
+
+;; ---- Branch 2: :children non-sequential ------------------------------------
+
+(deftest frame-provider-children-single-non-sequential
+  (testing "non-sequential :children — single React element — wrap-in-vec then splat"
+    (let [only (leaf-element "solo")
+          el (helix-adapter/frame-provider
+               {:frame :rf.helix-fp-test/single
+                :children only})]
+      (is (react-element? el))
+      (is (provider-type? el))
+      (is (= :rf.helix-fp-test/single (props-value el)))
+      ;; The wrap-in-vec path passes `[only]` through `apply`, so a
+      ;; single child lands directly on `.props.children` (React's
+      ;; single-child shortcut — no array wrapper).
+      (let [kids (props-children el)]
+        (is (identical? only kids)
+            "single child lands directly on .props.children (no array wrapper)")))))
+
+;; ---- Branch 3: :frame nil / missing → :rf/default --------------------------
+
+(deftest frame-provider-frame-nil-falls-through-to-default
+  (testing "nil :frame — falls through to :rf/default (rf2-sixo)"
+    (let [c1 (leaf-element "x")
+          el (helix-adapter/frame-provider
+               {:frame nil
+                :children [c1]})]
+      (is (provider-type? el))
+      (is (= :rf/default (props-value el))
+          "nil :frame is replaced with :rf/default — the tooling-elided-prop fallback"))))
+
+(deftest frame-provider-frame-missing-key-falls-through-to-default
+  (testing "missing :frame key — destructured nil — falls through to :rf/default"
+    (let [c1 (leaf-element "y")
+          el (helix-adapter/frame-provider
+               {:children [c1]})]
+      (is (provider-type? el))
+      (is (= :rf/default (props-value el))
+          "no :frame key destructures to nil; same fall-through to :rf/default"))))


### PR DESCRIPTION
## Summary

Tail-cluster sweep for the Helix adapter (round-2 audit rf2-w0u2w). Three beads land:

- **rf2-hukfa** — refactor: fix stray `rf2-3yij` cite in the `frame-provider` docstring; Helix's parent is `rf2-2qit`. (No behaviour change.)
- **rf2-uze2w** — test: cover `frame-provider :children` branches (sequential / single non-sequential / nil-falls-through-to-`:rf/default`). Four new deftests against the public Helix surface, asserting on the returned raw React element's `.props.value` / `.props.children`. `:node-test`-compatible.
- **rf2-n5obf** — test: parity for `:rf.error/frame-context-corrupted` under the Helix adapter. Two new deftests: a direct call against `function-component-current-frame` after corrupting `_currentValue`, plus an end-to-end pass through `rf/current-frame` (which routes via `:adapter/current-frame` per rf2-d4sf). Pins the Helix adapter's hook-routing so a refactor of the late-bind hook table or `route-hook!` line breaks the build.

## Deferred — already resolved upstream

- **rf2-d14xw** + **rf2-7ws05** — both said "drop unused `[helix.core :as helix]` require". Inspection shows that require is already gone — removed by `rf2-3vwbx` (refactor: extract React-shaped substrate-spine into shared ns) at commit `e0a65944`, which lifted the byte-for-byte-duplicated spine from UIx + Helix into `re-frame.substrate.spine` and trimmed the imports as a side effect. Both beads will be closed as obsolete (resolved-upstream) — no commits in this PR.

## Out of scope (cross-adapter — later batch)

`rf2-gsh49`, `rf2-hzck5`, `rf2-g7bi4`, `rf2-2d2gx`, `rf2-gwkvr` — these touch shared / multi-adapter surfaces and were excluded to avoid merge-conflict with the sibling UIx + Reagent tail-cluster batches.

## Files

- `implementation/adapters/helix/src/re_frame/adapter/helix.cljs` — `-4 +3` (docstring fix only)
- `implementation/adapters/helix/test/re_frame/adapter/helix_frame_provider_children_cljs_test.cljs` — new (+125)
- `implementation/adapters/helix/test/re_frame/adapter/helix_frame_context_corrupted_cljs_test.cljs` — new (+115)

LoC delta: **+243 / -4**.

## Test plan

- [x] `npm run test:cljs` — 1863 tests, 0 failures
- [x] `clojure -A:test` from `implementation/adapters/helix/` — classpath probe (CLJS-only artefact; alias is classpath-only by design)
- [x] `npm run test:examples` — all Helix examples pass (counter-helix, login-helix; todomvc-helix not present in tree)
- [x] `npm run test:elision` — production-elision contract intact