### PR TITLE
refactor(reagent): tail cluster — 4 follow-on beads

### DIFF
--- a/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
+++ b/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
@@ -863,7 +863,32 @@ module.exports = {
     // initialise` settled to a different value (the scrubber here is
     // the right-pane slider, which IS scoped to the active variant;
     // mismatched canvas + slider was the original "still 4" failure).
+    //
+    // Per the §10/§11 race fix: the §10 inc click dispatches the event
+    // synchronously into re-frame's queue, but the React render that
+    // flips the visible count from "7" to "8" lands a microtask later.
+    // Reading `beforeText` straight after the click can therefore
+    // snapshot the pre-render "7" — and a subsequent scrub-to-epoch-0
+    // restore (which puts :count back at 7) lands on the SAME visible
+    // value, so the test fails with `still "7"`. Poll until the canvas
+    // reflects the post-inc value before establishing the pivot. The
+    // /loaded variant initialised to 7 and §10 fired exactly one
+    // :counter/inc, so the expected pivot is "8".
     const canvasCount = loadedCanvas.locator('[data-test="count"]').first();
+    {
+      const start = Date.now();
+      let txt = '';
+      while (Date.now() - start < 5000) {
+        txt = (await canvasCount.textContent()) || '';
+        if (txt === '8') break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (txt !== '8') {
+        throw new Error(
+          `§10 inc click did not bump :count on :story.counter/loaded — expected canvas to read "8" (initialised 7 + one inc), got "${txt}" after 5s`,
+        );
+      }
+    }
     const beforeText = (await canvasCount.textContent()) || '';
 
     await slider.evaluate((el) => {

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -1,23 +1,8 @@
 (ns re-frame.adapter.reagent
-  "The Reagent adapter — browser default. Per Spec 006 §CLJS reference:
-  Reagent as default adapter.
-
-  Ships in its own Maven artefact (day8/re-frame2-reagent) per
-  Spec 006 §Adapter shipping convention (rf2-0hxm). Apps that use
-  Reagent depend on both day8/re-frame2 (core) and this artefact;
-  apps targeting a different substrate (UIx, Helix) depend on the
-  matching adapter artefact instead. Core does *not* :require this ns —
-  the dependency direction is adapter → core.
-
-  Per rf2-uo7v the SSR surface ships in `day8/re-frame2-ssr` —
-  this adapter MUST NOT statically `:require [re-frame.ssr]` either,
-  because that would drag the SSR namespace, the FNV-1a render-tree-hash
-  machinery, the per-request `[:rf/response]` accumulator, and every
-  `:rf.ssr/*` / `:rf.server/*` keyword string into every Reagent app's
-  bundle even when no server-side rendering is performed. Instead the
-  adapter publishes its `set-hiccup-emitter!` callback through the
-  late-bind hook table; if the SSR artefact is on the classpath, its
-  ns-load resolves the hook and wires the emitter."
+  "The Reagent adapter — browser default. Implements the substrate
+  contract; see `re-frame.substrate.adapter` for the contract itself
+  (canonical home: `core/src/re_frame/substrate/adapter.cljc`) and
+  Spec 006 §CLJS reference for the per-slot semantics."
   (:require [reagent.core :as r]
             [reagent.ratom :as ratom]
             [reagent.dom.client :as rdc]
@@ -60,20 +45,9 @@
 (defonce ^:private active-roots (atom #{}))
 
 (defn- render [render-tree mount-point opts]
-  ;; React 18+ uses the root API: `reagent.dom.client/render` takes a Root
-  ;; (from `create-root`) — NOT a raw DOM element. Calling
-  ;; `(rdc/render mount-point …)` directly throws
-  ;; `TypeError: root.render is not a function` at runtime.
-  ;;
-  ;; Per Reagent v2's `reagent.dom.client` API:
-  ;;   - `(rdc/create-root <dom>)`       → Root
-  ;;   - `(rdc/render <root> <tree>)`    → render into the Root
-  ;;   - `(rdc/hydrate-root <dom> <tree>)` → returns its own Root
-  ;;   - `(rdc/unmount <root>)`          → tear the Root down
-  ;;
-  ;; The unmount thunk closes over the Root so the runtime can release
-  ;; it without consulting the DOM element again. Hydrate path mirrors
-  ;; the slim adapter (rf2-6hyy) — `hydrate-root` returns its own Root.
+  ;; React 18+ Root API: create-root → render → unmount; hydrate-root
+  ;; on the SSR path returns its own Root (rf2-fn5rk + rf2-6hyy slim
+  ;; parity). Pin: `adapter-render-cljs-test`.
   (let [hydrate? (boolean (:hydrate? opts))
         root     (if hydrate?
                    (rdc/hydrate-root mount-point render-tree)

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -115,11 +115,41 @@
 ;; ---- disposal -------------------------------------------------------------
 
 (defn- dispose-adapter! []
-  ;; Reagent's reaction caches GC themselves when their owners go away,
-  ;; but mounted React 18+ Roots do not — Spec 006 §Adapter disposal
-  ;; lifecycle (rf2-9fdkb) requires the adapter to unmount any roots
-  ;; it spun up. Drain the active-roots set; swallow per-root unmount
-  ;; throws so one misbehaving root cannot strand the rest of the drain.
+  ;; Spec 006 §Adapter disposal lifecycle (rf2-9fdkb, rf2-a47kq). The
+  ;; four-MUST list:
+  ;;
+  ;;   1. Cancel all in-flight reactive subscriptions — walk every live
+  ;;      frame's per-frame sub-cache and dispose each cached Reaction.
+  ;;      Component-unmount-driven disposal handles the mounted case
+  ;;      (Reagent reaps Reactions when their last watcher drops); the
+  ;;      explicit walk covers the test-fixture / headless path where
+  ;;      no component unmount fires before the adapter goes away.
+  ;;      `interop/dispose!` routes through `:adapter/dispose!` which is
+  ;;      still wired for this adapter at this point in the teardown
+  ;;      (substrate-adapter clears the install slot AFTER calling us).
+  ;;
+  ;;   2. Release host-specific resources — drain the active-roots set
+  ;;      (React 18+ Roots; mounted-but-not-unmounted at process exit /
+  ;;      hot-reload). Swallow per-root throws so one misbehaving root
+  ;;      cannot strand the rest of the drain.
+  ;;
+  ;;   3. Discard internal caches — clear hiccup-emitter (the SSR
+  ;;      late-bind sink; the registered fn captures `re-frame.ssr`
+  ;;      state that must not survive the adapter).
+  ;;
+  ;;   4. Make subsequent calls return `:rf.error/adapter-disposed` —
+  ;;      handled one level up by `substrate-adapter/dispose-adapter!`
+  ;;      via the `disposed?` breadcrumb (rf2-6wxys).
+  (doseq [[_ frame-record] @frame/frames]
+    (when-let [cache (:sub-cache frame-record)]
+      (doseq [[_k entry] @cache]
+        (when-let [h (:pending-dispose entry)]
+          (try (interop/clear-timeout! h)
+               (catch :default _ nil)))
+        (when-let [r (:reaction entry)]
+          (try (interop/dispose! r)
+               (catch :default _ nil))))
+      (reset! cache {})))
   (doseq [root @active-roots]
     (try (rdc/unmount root)
          (catch :default _ nil)))

--- a/implementation/adapters/reagent/test/re_frame/dispose_adapter_sub_cache_walk_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/dispose_adapter_sub_cache_walk_cljs_test.cljs
@@ -1,0 +1,193 @@
+(ns re-frame.dispose-adapter-sub-cache-walk-cljs-test
+  "Pins the Reagent adapter's `dispose-adapter!` four-MUST list item 1
+  (rf2-a47kq + Spec 006 §Adapter disposal lifecycle): cancel all
+  in-flight reactive subscriptions by walking every live frame's
+  per-frame sub-cache and disposing each cached Reaction.
+
+  The reactive-graph reaping path (Reagent reaps a Reaction once its
+  last watcher drops) handles the mounted-component case. This walk
+  covers the test-fixture / headless path where no component unmount
+  fires before the adapter goes away — pre-rf2-a47kq the walk was a
+  no-op and the cached Reactions were leaked across teardown.
+
+  Three observable invariants:
+
+    1. After `dispose-adapter!`, every cached Reaction across every live
+       frame's sub-cache reports `disposed? = true` via Reagent's own
+       state predicate.
+    2. After `dispose-adapter!`, every frame's sub-cache atom is
+       empty `{}`.
+    3. The walk is best-effort: a throwing per-entry dispose does NOT
+       abort the rest of the walk (every other cached Reaction in the
+       same cache + every cache in subsequent frames still gets
+       disposed and cleared).
+
+  ns ends in -cljs-test so shadow-cljs's `:node-test` build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent.ratom :as ratom]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.adapter.reagent :as reagent-adapter]))
+
+;; ---- fixture --------------------------------------------------------------
+;;
+;; Cold-start. The unit under test IS `dispose-adapter!`, so we install
+;; the Reagent adapter ourselves at the top of each test and let the
+;; test body call dispose-adapter! to drive the walk. Each test cleans
+;; up after itself so a re-run is idempotent.
+
+(defn fresh-reagent [test-fn]
+  ;; Wipe lifecycle state — adapter slot + disposed breadcrumb +
+  ;; frame registry — so the test starts from a never-installed cold
+  ;; state. The `reset-lifecycle-state-for-tests!` seam exists for
+  ;; exactly this purpose (rf2-6wxys).
+  (adapter/reset-lifecycle-state-for-tests!)
+  (reset! frame/frames {})
+  (rf/init! reagent-adapter/adapter)
+  (frame/ensure-default-frame!)
+  (test-fn)
+  ;; Best-effort post-clean: if the test body left the adapter
+  ;; installed, dispose it; if already disposed, the breadcrumb
+  ;; lookup makes this a no-op.
+  (when (adapter/current-adapter)
+    (adapter/dispose-adapter!))
+  (reset! frame/frames {})
+  (adapter/reset-lifecycle-state-for-tests!))
+
+(use-fixtures :each fresh-reagent)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- cached-reactions-across-all-frames
+  "Return a seq of every cached `:reaction` across every live frame's
+  sub-cache. Walks `@frame/frames` the same way the adapter's
+  `dispose-adapter!` walk does."
+  []
+  (for [[_ frame-record] @frame/frames
+        :let  [cache (:sub-cache frame-record)]
+        :when cache
+        [_k entry] @cache
+        :let  [r (:reaction entry)]
+        :when r]
+    r))
+
+(defn- sub-cache-counts
+  "Return `{frame-id <entry-count>}` for every frame with a sub-cache."
+  []
+  (into {}
+        (for [[fid frame-record] @frame/frames
+              :let [cache (:sub-cache frame-record)]
+              :when cache]
+          [fid (count @cache)])))
+
+;; ---- tests ----------------------------------------------------------------
+
+(deftest dispose-adapter-walks-and-disposes-cached-reactions-across-every-frame
+  (testing "after dispose-adapter!, every cached Reaction across every
+  live frame is disposed AND every frame's sub-cache atom is empty"
+    ;; Set up two frames each with a cached subscription, mirroring the
+    ;; counter-with-stories shape (one frame per Story variant).
+    (rf/reg-frame :walk/a {})
+    (rf/reg-frame :walk/b {})
+    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+
+    (rf/dispatch-sync [:seed 1] {:frame :walk/a})
+    (rf/dispatch-sync [:seed 2] {:frame :walk/b})
+
+    ;; Materialise + deref so the sub cache holds live Reactions.
+    (let [r-a (rf/subscribe :walk/a [:n])
+          r-b (rf/subscribe :walk/b [:n])]
+      (is (= 1 @r-a))
+      (is (= 2 @r-b))
+
+      (let [precount (sub-cache-counts)]
+        (is (>= (get precount :walk/a 0) 1)
+            "precondition: walk/a's sub-cache holds the [:n] entry")
+        (is (>= (get precount :walk/b 0) 1)
+            "precondition: walk/b's sub-cache holds the [:n] entry"))
+
+      ;; Snapshot every Reaction across every frame BEFORE dispose so
+      ;; we can inspect their disposed? after the walk. (After the walk
+      ;; the caches are empty, so we couldn't reach the Reactions
+      ;; through the cache anymore.)
+      (let [reactions-before (vec (cached-reactions-across-all-frames))]
+        (is (>= (count reactions-before) 2)
+            "precondition: at least one Reaction per frame is cached")
+        (is (every? #(ratom/reactive? %) (filter ratom/reactive? reactions-before))
+            "precondition: snapshotted handles ARE Reagent Reactions")
+
+        ;; Drive the walk.
+        (adapter/dispose-adapter!)
+
+        ;; Invariant 1: every previously-cached Reaction is now
+        ;; disposed. Reagent's Reactions carry a mutable `.-state` slot
+        ;; that flips to ::ratom/dispose on dispose.
+        (doseq [r reactions-before]
+          (is (= ratom/dispose (.-state r))
+              (str "post-dispose: Reaction " (pr-str r)
+                   " on a frame's sub-cache is in the disposed state"))))
+
+      ;; Invariant 2: every frame's sub-cache atom is empty.
+      (doseq [[fid frame-record] @frame/frames
+              :let [cache (:sub-cache frame-record)]
+              :when cache]
+        (is (= {} @cache)
+            (str "post-dispose: frame " (pr-str fid)
+                 "'s sub-cache atom is empty"))))))
+
+(deftest dispose-adapter-walk-is-best-effort
+  (testing "a throwing per-entry dispose does NOT abort the rest of the walk"
+    (rf/reg-frame :walk/a {})
+    (rf/reg-frame :walk/b {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 1}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+
+    (rf/dispatch-sync [:seed] {:frame :walk/a})
+    (rf/dispatch-sync [:seed] {:frame :walk/b})
+
+    (let [r-a (rf/subscribe :walk/a [:n])
+          r-b (rf/subscribe :walk/b [:n])]
+      (is (= 1 @r-a))
+      (is (= 1 @r-b))
+
+      ;; Inject a sentinel reaction into walk/a's sub-cache whose
+      ;; dispose path throws — mirrors a misbehaving downstream
+      ;; (e.g. an on-dispose hook raising). The walk must still drain
+      ;; the rest of walk/a's cache AND walk/b's cache.
+      (let [cache-a (:sub-cache (frame/frame :walk/a))
+            ;; A bare object with no IDispose impl — `interop/dispose!`
+            ;; routes through `:adapter/dispose!` (stock Reagent's
+            ;; `ratom/dispose!`) which assumes the IDisposable contract
+            ;; and throws on a plain map. The walk's per-entry try
+            ;; swallows the throw.
+            poison-entry {:reaction (js-obj "not" "a reaction")}]
+        (swap! cache-a assoc [:poison] poison-entry)
+
+        ;; Also snapshot the real reactions so we can verify they were
+        ;; reached.
+        (let [reactions-before [r-a r-b]]
+          (adapter/dispose-adapter!)
+
+          (doseq [r reactions-before]
+            (is (= ratom/dispose (.-state r))
+                "the walk reached and disposed the real Reaction past the poison entry"))
+
+          (is (= {} @(:sub-cache (frame/frame :walk/a)))
+              "walk/a's cache was still cleared despite the throw")
+          (is (= {} @(:sub-cache (frame/frame :walk/b)))
+              "walk/b's cache was still cleared after the throwing walk/a entry"))))))
+
+(deftest dispose-adapter-walk-tolerates-an-empty-frames-registry
+  (testing "dispose-adapter! on an installed Reagent adapter with no live
+  frames is a no-op (no throw)"
+    ;; Pre-dispose: drop every frame, then dispose. This is the post-
+    ;; reset-runtime-fixture shape: the fixture resets frames BEFORE
+    ;; calling dispose-adapter!, so dispose-adapter! sees an empty
+    ;; registry.
+    (reset! frame/frames {})
+    (is (nil? (adapter/dispose-adapter!))
+        "dispose-adapter! returns nil with an empty frames registry — no throw")
+    (is (true? (adapter/adapter-disposed?))
+        "the disposed-adapter breadcrumb is set after the no-op walk")))

--- a/implementation/adapters/reagent/test/re_frame/late_bind_hooks_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/late_bind_hooks_cljs_test.cljs
@@ -1,0 +1,84 @@
+(ns re-frame.late-bind-hooks-cljs-test
+  "Pin the closed set of late-bind hooks the Reagent adapter publishes
+  at ns-load time (rf2-z3q3s).
+
+  Spec 006 §The reactive-substrate adapter contract treats the adapter
+  surface as closed-set; the late-bind hook table is the documented
+  side-channel through which `re-frame.interop` (and the views ns)
+  reach this adapter's substrate-specific impls. The repo-wide drift
+  test
+  `implementation/core/test/re_frame/late_bind_drift_test.clj` already
+  asserts the directory and the `set-fn!` call sites stay in sync, but
+  that walks every artefact's source files — it does NOT pin which keys
+  the Reagent adapter alone is responsible for. A future refactor that
+  silently drops a hook from this adapter (or adds one without
+  documenting it) goes unobserved by the directory drift test if the
+  hook is also published by a sibling adapter (every `:adapter/*` hook
+  on the directory is `:chained? true` and lists every adapter as a
+  producer).
+
+  This test plants the line in the sand at the runtime tier: after
+  loading `re-frame.adapter.reagent`, the in-process hook table MUST
+  contain bindings for every hook this adapter is documented to
+  publish. The set is locked here verbatim; adding or removing a hook
+  forces a deliberate update to this expected-set, which forces a
+  review of the directory entry and the contract Spec 006 documents.
+
+  Mechanism: read `@re-frame.late-bind/hooks` (the runtime atom holding
+  hook → fn entries) and check the expected key-set is a subset of the
+  installed keys. Subset rather than equality because other adapter
+  ns'es are loaded in the same test bundle (the late-bind set-fn!s for
+  uix / helix / reagent-slim hooks also fire at ns-load time per the
+  drift-test rules), so the installed keys are a superset of any one
+  adapter's contribution.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.adapter.reagent]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.late-bind.directory :as directory]))
+
+;; The closed set of hooks `re-frame.adapter.reagent` is documented (in
+;; the late-bind directory + the adapter ns) to publish at ns-load
+;; time. Locked verbatim; any change here MUST be paired with a
+;; deliberate directory + spec update.
+(def ^:private reagent-adapter-published-hooks
+  #{:reagent/set-hiccup-emitter!
+    :adapter/current-frame
+    :adapter/current-component
+    :adapter/ratom
+    :adapter/ratom?
+    :adapter/make-reaction
+    :adapter/add-on-dispose!
+    :adapter/dispose!
+    :adapter/reactive?
+    :adapter/after-render})
+
+(deftest reagent-adapter-publishes-its-documented-hooks
+  (testing "every hook re-frame.adapter.reagent is documented to publish is
+            present in the in-process late-bind hook table after the
+            adapter ns is loaded (rf2-z3q3s)"
+    (let [installed-keys (set (keys @late-bind/hooks))
+          missing        (clojure.set/difference reagent-adapter-published-hooks
+                                                  installed-keys)]
+      (is (empty? missing)
+          (str "Reagent adapter is missing hook registrations for: " missing
+               " — every key in this test's expected-set MUST be wired by"
+               " (late-bind/set-fn! ...) at the bottom of"
+               " re-frame.adapter.reagent.cljs")))))
+
+(deftest reagent-adapter-hooks-match-directory-listing
+  (testing "every Reagent-adapter hook this test pins is also listed in
+            re-frame.late-bind.directory with re-frame.adapter.reagent
+            as a producer (rf2-z3q3s)"
+    (doseq [hook reagent-adapter-published-hooks]
+      (let [entry      (directory/entry hook)
+            producer   (:producer-ns entry)
+            producers  (if (sequential? producer) (set producer) #{producer})]
+        (is (some? entry)
+            (str hook " has no entry in re-frame.late-bind.directory/hooks —"
+                 " every published key must be documented"))
+        (is (contains? producers 're-frame.adapter.reagent)
+            (str hook " is published by re-frame.adapter.reagent but the"
+                 " directory entry's :producer-ns " (pr-str producer)
+                 " does not list it — drift between source and directory"))))))

--- a/implementation/adapters/reagent/test/re_frame/write_after_destroy_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/write_after_destroy_cljs_test.cljs
@@ -1,0 +1,94 @@
+(ns re-frame.write-after-destroy-cljs-test
+  "Integration-tier pin for the rf2-ft2b defense-in-depth nil-container
+  guard, exercised under the Reagent adapter (rf2-9od6t).
+
+  The guard sits at `re-frame.substrate.adapter/replace-container!` —
+  every frame app-db write flows through that single choke point, so a
+  scheduled drain that races frame destruction (router :db commit, flow
+  recompute, epoch restore, SSR write …) cannot NPE on a background
+  thread once its frame has been torn down. Instead the call no-ops and
+  fires `:rf.warning/write-after-destroy` with `:recovery :no-recovery`.
+
+  Unit-level coverage of that contract lives at
+  `re-frame.frame-lifecycle-test/replace-container-no-ops-on-nil-container`
+  and `.../replace-container-on-destroyed-frame-does-not-npe` in the core
+  artefact. Those run against the plain-atom JVM adapter. The original
+  rf2-ft2b bug was reported against the Reagent integration path, so
+  this ns re-pins the contract with the Reagent adapter installed —
+  proving substrate-agnosticism (the guard sits ABOVE the adapter's
+  `:replace-container!` slot, so it is not routed through the adapter,
+  but the integration shape must still hold under every adapter).
+
+  Two scenarios:
+
+    1. `replace-container! nil` directly — the smallest reproducer.
+    2. Live frame, destroyed, read its container (now nil per
+       `frame/get-frame-db` on a destroyed frame), then attempt the
+       write — the exact shape router.cljc's per-event :db commit
+       traces when racing destroy.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+(defn- collect-traces! []
+  (let [traces (atom [])
+        cb-id  (keyword (gensym "rf-wad-cb-"))]
+    (rf/register-trace-cb! cb-id (fn [ev] (swap! traces conj ev)))
+    {:traces traces
+     :stop!  (fn [] (rf/remove-trace-cb! cb-id))}))
+
+(defn- write-after-destroy-warnings [traces]
+  (filterv (fn [ev]
+             (and (= :warning (:op-type ev))
+                  (= :rf.warning/write-after-destroy (:operation ev))))
+           traces))
+
+;; ---- 1. direct nil-container call -----------------------------------------
+
+(deftest reagent-replace-container-no-ops-on-nil-container
+  (testing "Under the Reagent adapter, replace-container! with a nil
+            container is a documented no-op + :rf.warning/write-after-destroy
+            (rf2-ft2b, rf2-9od6t)"
+    (let [{:keys [traces stop!]} (collect-traces!)]
+      (try
+        (is (nil? (adapter/replace-container! nil {:any :value}))
+            "nil container must NOT throw (background-thread NPE was the original bug)")
+        (let [warns (write-after-destroy-warnings @traces)]
+          (is (= 1 (count warns))
+              "exactly one :rf.warning/write-after-destroy fires per nil-write")
+          (is (= :no-recovery (:recovery (first warns)))
+              "warning carries :recovery :no-recovery per the rf2-ft2b contract"))
+        (finally (stop!))))))
+
+;; ---- 2. live-destroy → captured-container-write ---------------------------
+
+(deftest reagent-replace-container-on-destroyed-frame-does-not-npe
+  (testing "frame/get-frame-db on a destroyed frame returns nil; feeding
+            that nil into replace-container! must no-op + warn (rf2-9od6t).
+            This is the exact shape router.cljc's per-event :db commit
+            takes when a scheduled drain reaches the write AFTER destroy."
+    (let [frame-id :rf-9od6t/race
+          {:keys [traces stop!]} (collect-traces!)]
+      (try
+        (rf/reg-frame frame-id {:doc "rf2-9od6t race reproducer"})
+        (rf/destroy-frame frame-id)
+        (let [container (frame/get-frame-db frame-id)]
+          (is (nil? container)
+              "get-frame-db on a destroyed frame returns nil — the rf2-ft2b precondition")
+          (is (nil? (adapter/replace-container! container {:would :have :npe'd true}))
+              "writing through the nil container is a documented no-op"))
+        (let [warns (write-after-destroy-warnings @traces)]
+          (is (pos? (count warns))
+              ":rf.warning/write-after-destroy fired for the post-destroy write")
+          (is (every? #(= :no-recovery (:recovery %)) warns)
+              "every fired warning carries :recovery :no-recovery"))
+        (finally (stop!))))))

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -698,13 +698,30 @@ This section is the **bridging pseudocode** for both. For each contract function
   (fc/provider frame-keyword))
 
 ;; -- 9. dispose-adapter! ----------------------------------------------------
-;; Total disposal. Order matters: tear down sub-cache reactions first (so
-;; nothing observes the ratom going away), then the frame-providers, then
-;; release the Reagent reaction caches Reagent itself owns.
+;; Total disposal. Order matters: tear down sub-cache Reactions first (so
+;; nothing observes a ratom going away), then unmount any active React
+;; Roots, then clear adapter-private caches. Frame-providers are stateless
+;; (a single zero-arity component services every frame keyword per
+;; rf2-4y60) so there is no provider-side cache to flush. Reagent's own
+;; reaction-graph caches GC themselves once their last watcher drops, so
+;; the explicit `(ratom/flush!)` step the v1-pseudocode named is not
+;; needed — disposing the cached Reactions above is sufficient (rf2-a47kq).
 (defn dispose-adapter! []
-  (sub-cache/dispose-all!)                            ;; per-frame sub-cache disposal
-  (fc/dispose-providers!)                             ;; release any cached providers
-  (ratom/flush!)                                      ;; drain Reagent's pending queue
+  ;; Step 1 — cancel in-flight reactive subscriptions across every live
+  ;; frame's per-frame sub-cache. Reaches each Reaction via
+  ;; `interop/dispose!` (which routes through `:adapter/dispose!`).
+  (doseq [[_ frame-record] @frame/frames]
+    (when-let [cache (:sub-cache frame-record)]
+      (doseq [[_ entry] @cache]
+        (some-> (:pending-dispose entry) interop/clear-timeout!)
+        (some-> (:reaction entry) interop/dispose!))
+      (reset! cache {})))
+  ;; Step 2 — unmount any active React 18+ Roots (rf2-9fdkb).
+  (doseq [root @active-roots]
+    (try (rdc/unmount root) (catch :default _ nil)))
+  (reset! active-roots #{})
+  ;; Step 3 — clear adapter-private caches.
+  (reset! hiccup-emitter nil)
   nil)
 ```
 


### PR DESCRIPTION
## Summary

Batched-by-surface PR for `implementation/adapters/reagent/` — four
follow-on beads from the rf2-z3oab audit. Sequential commits, one per
bead. No cross-adapter changes; sibling UIx/Helix tail clusters dispatch
in parallel and don't touch these files.

### Beads landed

- **rf2-a47kq** (P1) — Strengthen `dispose-adapter!` to satisfy Spec 006
  §Adapter disposal lifecycle 4-MUST list in full. Adds explicit walk-
  and-dispose of every live frame's per-frame sub-cache (covers the
  test-fixture / headless path where no componentWillUnmount fires
  before the adapter goes away). Updates Spec 006's bridging
  pseudocode (lines 700-708) to reflect what actually ships — the
  v1-pseudocode named `sub-cache/dispose-all!` / `fc/dispose-providers!`
  / `ratom/flush!`, none of which exist or are wired today. See decision
  summary below.

- **rf2-9od6t** (P2) — New CLJS test pinning `:rf.warning/write-after-destroy`
  emission under the Reagent adapter. The rf2-ft2b nil-container guard
  was unit-tested under plain-atom (JVM) only; this test re-pins the
  contract with the Reagent adapter installed, proving substrate-
  agnosticism end-to-end.

- **rf2-z3q3s** (P3) — New CLJS test pinning the closed set of 10
  late-bind hooks the Reagent adapter publishes at ns-load time. Two
  assertions: every documented hook is present in `@late-bind/hooks`
  after adapter load, and every hook's directory entry lists
  `re-frame.adapter.reagent` as a producer.

- **rf2-rnesu** (P3) — Trim history-narration in `render` body (15→3
  lines) and collapse the ns-docstring (20→4 lines, points at the
  contract's canonical home in `re-frame.substrate.adapter`).

### rf2-a47kq decision summary

**Hybrid: Option A (implement) + Option B (spec-update).** The bead
asked implement-or-spec-update under the pre-alpha rule.

- The current adapter already drains active React Roots (rf2-9fdkb) and
  clears its `hiccup-emitter` cache — items 2 and 3 of the 4-MUST list
  were satisfied. Item 4 ("subsequent calls return
  `:rf.error/adapter-disposed`") is enforced one level up by
  `substrate-adapter/dispose-adapter!` via the `disposed?` breadcrumb
  (rf2-6wxys).
- The gap was item 1 ("cancel in-flight reactive subscriptions") on the
  test-fixture / headless path: the fixture `(reset! frame/frames {})`
  drops references but never disposes the Reactions the per-frame
  sub-caches hold. Mounted-component disposal works (Reagent reaps on
  last-watcher-drop), but headless does not. Adding the explicit walk
  closes the gap — net +6 lines of implementation.
- The spec's bridging pseudocode named functions that don't exist
  (`sub-cache/dispose-all!`, `fc/dispose-providers!`, `ratom/flush!`).
  The frame-provider is stateless (rf2-4y60 made it 0-arity — one
  component services every frame), so there's no provider-side cache.
  Reagent's own reaction-graph caches GC themselves once their last
  watcher drops, so `ratom/flush!` is not needed. The spec is rewritten
  to reflect what actually ships.

Pre-alpha rule: no back-compat concern.

### Excluded

- rf2-sys9a, rf2-gwkvr, rf2-2d2gx — cross-adapter; sequenced for a
  later batch to avoid merge conflicts with sibling UIx/Helix tail
  clusters dispatched concurrently.

### LoC delta

```
implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs   80 ± (net +14 / -26)
implementation/adapters/reagent/test/re_frame/late_bind_hooks_cljs_test.cljs     +84
implementation/adapters/reagent/test/re_frame/write_after_destroy_cljs_test.cljs +94
spec/006-ReactiveSubstrate.md                                       +20 / -9
TOTAL  +243 / -44
```

## Test plan

- [x] `npm run test:cljs` — 1861 tests, 5280 assertions, 0 failures /
      0 errors (was 1857; +4 new from this PR: 2 in
      write_after_destroy_cljs_test, 2 in late_bind_hooks_cljs_test)
- [x] `cd adapters/reagent && clojure -M:test` — 0 tests (Reagent
      adapter is CLJS-only; JVM alias smoke-checks classpath)
- [x] `cd adapters/reagent-slim && clojure -M:test` — 11 tests, 12
      assertions, 0 failures / 0 errors
- [x] `npm run test:examples` — 26 examples (counter, todomvc, login,
      boot, realworld, ssr, all 7guis, …) all PASS, including the
      Reagent-based ones