### PR TITLE
refactor(uix): tail cluster — 11 follow-on beads

### DIFF
--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -67,7 +67,12 @@
   React context, or `:rf/default` when no frame-provider sits above.
   Decision 2 mandates every React-shaped adapter resolves the same
   context, so a UIx subtree under a Reagent frame-provider sees the
-  right frame and vice versa."
+  right frame and vice versa.
+
+  React-context tier only. For the full resolution chain
+  (dynamic-var → React-context → :rf/default) use `(rf/current-frame)`;
+  the routed `:adapter/current-frame` hook (registered below) covers
+  that chain. Per rf2-84myk."
   (:use-current-frame spine-fns))
 
 (def frame-provider
@@ -159,10 +164,12 @@
 ;;   :adapter/current-frame  — rf2-d4sf. UIx renders function
 ;;     components — they have no class-component (.-context cmp) slot,
 ;;     so the shared impl in `re-frame.adapter.context` reads
-;;     `_currentValue` directly. UIx's own `use-current-frame` hook is
-;;     sugar over the same read, so subscribe / dispatch and
-;;     `use-context` agree on the active frame. Chain-bottom fallback
-;;     is `frame/current-frame`.
+;;     `_currentValue` directly. The chain-bottom fallback
+;;     `frame/current-frame` covers the dynamic-var tier of the full
+;;     resolution chain (per rf2-84myk: this hook is the WIDER surface
+;;     — `(rf/current-frame)` reaches it; the per-adapter
+;;     `use-current-frame` hook above is the NARROWER React-context-
+;;     tier-only read).
 ;;   :adapter/ratom etc. — rf2-s36l. UIx's derived values reify stock
 ;;     reagent.ratom/IDisposable directly, so these hooks delegate to
 ;;     stock Reagent's r/atom, ratom/make-reaction, etc. UIx itself

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -1,37 +1,19 @@
 (ns re-frame.adapter.uix
   "The UIx adapter — the second canonical browser substrate (rf2-3yij).
   Per Spec 006 §CLJS reference: UIx as alternative substrate.
-
   Ships in its own Maven artefact (day8/re-frame2-uix) per
-  Spec 006 §Adapter shipping convention (rf2-0hxm). Apps that use UIx
-  depend on both day8/re-frame2 (core) and this artefact; apps
-  targeting Reagent depend on day8/re-frame2-reagent instead.
-  Core does *not* :require this ns — the dependency direction is
-  adapter → core.
-
-  Per rf2-3yij Decision 2 the React frame-context lives in
-  `re-frame.adapter.context` (CLJS-only file in core); this adapter
-  consumes the *same* createContext object the Reagent adapter
-  consumes, so a future mixed-substrate app's frame-provider chain
-  composes across substrates.
-
-  Per rf2-3yij Decision 8 we target UIx 2.x (hooks-based).
+  Spec 006 §Adapter shipping convention (rf2-0hxm); core does NOT
+  :require this ns (dependency direction: adapter → core). Targets
+  UIx 2.x (hooks-based) per rf2-3yij Decision 8.
 
   Substrate-spine sharing (rf2-3vwbx). The container quartet, derived
   value, render-root, render-to-string, frame-provider, use-subscribe,
-  flush-views!, source-coord wrapper, and warn-once-cache logic all
-  come from `re-frame.substrate.spine` — that ns hosts the
-  React-shaped-substrate spine UIx and Helix share byte-for-byte. The
-  UIx-specific configuration here is the gensym-prefix triple, the
-  substrate-name (\"UIx\") used in warn-once text, and the runtime
-  hook fns from `uix.hooks.alpha`. We bind the runtime fns rather than
-  the `uix.core` namespace's `use-memo` / `use-callback` because those
-  are macros (with no runtime counterpart Var) — passing a macro
-  symbol as a config value yields `undefined` at runtime, which broke
-  every UIx-substrate example after rf2-3vwbx until it was fixed by
-  the `uix.hooks.alpha` switch. `uix.hooks.alpha/use-memo` and
-  `use-callback` are the runtime fns the `uix.core` macros themselves
-  expand to (they take JS-array deps — exactly what the spine passes)."
+  flush-views!, source-coord wrapper, and warn-once-cache logic come
+  from `re-frame.substrate.spine`. The UIx-specific configuration
+  here is the gensym-prefix triple, the substrate-name (\"UIx\") used
+  in warn-once text, and the runtime hook fns from `uix.hooks.alpha`
+  (the spine passes JS-array deps; `uix.hooks.alpha/use-memo` and
+  `use-callback` are the runtime fns the `uix.core` macros expand to)."
   (:require [reagent.core      :as r]
             [reagent.ratom     :as ratom]
             [uix.core          :as uix]
@@ -153,33 +135,28 @@
    :register-context-provider (:register-context-provider spine-fns)
    :dispose-adapter!          (:dispose-adapter!          spine-fns)})
 
-;; Each late-bind hook below is routed through `(substrate-adapter/
-;; current-adapter)` per rf2-0d35 via `substrate-adapter/route-hook!`
-;; (see that fn's docstring for the routing contract). The wrapper runs
-;; this adapter's impl ONLY when the UIx adapter is the (rf/init!)-
-;; installed one; otherwise it chains to the previously-registered
-;; handler.
+;; Late-bind hooks below route through `substrate-adapter/route-hook!`
+;; (per rf2-0d35 — see its docstring for the routing contract): each
+;; impl runs ONLY when the UIx adapter is the (rf/init!)-installed
+;; one; otherwise chains to the previously-registered handler.
 ;;
-;; Hook-specific rationale (UIx-adapter notes):
-;;   :adapter/current-frame  — rf2-d4sf. UIx renders function
-;;     components — they have no class-component (.-context cmp) slot,
-;;     so the shared impl in `re-frame.adapter.context` reads
-;;     `_currentValue` directly. The chain-bottom fallback
-;;     `frame/current-frame` covers the dynamic-var tier of the full
-;;     resolution chain (per rf2-84myk: this hook is the WIDER surface
-;;     — `(rf/current-frame)` reaches it; the per-adapter
+;; Hook-specific UIx-adapter notes:
+;;   :adapter/current-frame  — rf2-d4sf. Function components have no
+;;     class-component (.-context cmp) slot, so the shared impl in
+;;     `re-frame.adapter.context` reads `_currentValue` directly. This
+;;     is the WIDER surface — `(rf/current-frame)` reaches the
+;;     dynamic-var-fallback chain via this hook; the per-adapter
 ;;     `use-current-frame` hook above is the NARROWER React-context-
-;;     tier-only read).
-;;   :adapter/ratom etc. — rf2-s36l. UIx's derived values reify stock
-;;     reagent.ratom/IDisposable directly, so these hooks delegate to
-;;     stock Reagent's r/atom, ratom/make-reaction, etc. UIx itself
-;;     ships no reactive-atom primitive (per the rf2-3yij design).
+;;     tier-only read (per rf2-84myk).
+;;   :adapter/ratom etc. — rf2-s36l. UIx ships no reactive-atom
+;;     primitive (per rf2-3yij); derived values reify stock
+;;     reagent.ratom/IDisposable, so these hooks delegate to
+;;     `r/atom`, `ratom/make-reaction`, etc.
 ;;   :adapter/wrap-view — rf2-00li. Substrate-side source-coord
-;;     injection via React.cloneElement (the inline hiccup-walk in
-;;     views.cljs would mis-classify React-element output as a non-DOM
-;;     root). Production-elision: `wrap-view`'s body sits inside an
-;;     `interop/debug-enabled?` gate so closure-folds under :advanced +
-;;     goog.DEBUG=false (per Spec 009 §Production builds).
+;;     injection via React.cloneElement (the views.cljs inline
+;;     hiccup-walk would mis-classify React-element output as a
+;;     non-DOM root). Production-elided via `interop/debug-enabled?`
+;;     per Spec 009 §Production builds.
 (substrate-adapter/route-hook! adapter :adapter/current-frame
   adapter-context/function-component-current-frame
   #(frame/current-frame))
@@ -202,27 +179,15 @@
 (substrate-adapter/route-hook! adapter :adapter/wrap-view
   wrap-view)
 
-;; Per rf2-4edk: contribute a clear of THIS adapter's warn-once cache to
-;; the chained `:adapter/clear-warn-once-caches!` hook. The hook is
-;; chained — each adapter (helix, uix) and re-frame.views all contribute
-;; a clear-step; `reset-runtime-fixture` invokes the top of the chain
-;; and every contributor's reset runs (unlike `:adapter/current-frame`
-;; etc. this hook is NOT routed through the installed adapter — every
-;; loaded adapter's cache must clear because test bundles can mount
-;; different adapters across tests and each adapter's defonce persists).
-;; Production behaviour is unchanged: the warn-once defonce is still
-;; per-process for users; only test-time clearing is new.
+;; Chained warn-once clear (rf2-4edk): every loaded adapter's
+;; per-process defonce must be cleared between tests, so this hook is
+;; chained (not routed by installed-adapter identity).
 (spine/install-clear-warn-once-step! clear-warned-non-dom-roots!)
 
-;; Per rf2-4z7bp: chain this adapter's `set-hiccup-emitter!` into the
-;; `:reagent/set-hiccup-emitter!` late-bind hook so SSR (which calls
-;; the hook at `re-frame.ssr.emit` ns-load time) auto-wires the UIx
-;; adapter's :render-to-string slot. The hook name is historical
-;; (Reagent published it first per rf2-uo7v); behaviour is adapter-
-;; agnostic and chained — every loaded React-shaped adapter contributes
-;; its own install-into-the-emitter-cell step, so a process with both
-;; Reagent and UIx loaded gets BOTH adapters' emitters wired by a
-;; single `(require '[re-frame.ssr])`. Before this chain entry, an
-;; SSR-from-UIx user had to call `(uix-adapter/set-hiccup-emitter!
-;; render-to-string)` directly — see the rf2-gc5v9 test docstring.
+;; Chained SSR emitter install (rf2-4z7bp): `re-frame.ssr.emit`
+;; invokes `:reagent/set-hiccup-emitter!` at ns-load; every loaded
+;; React-shaped adapter contributes its own install step so a single
+;; `(require '[re-frame.ssr])` auto-wires every adapter's
+;; render-to-string slot. Hook key is historical (Reagent published
+;; it first per rf2-uo7v); behaviour is adapter-agnostic.
 (late-bind/chain-fn! :reagent/set-hiccup-emitter! set-hiccup-emitter!)

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -206,3 +206,16 @@
 ;; Production behaviour is unchanged: the warn-once defonce is still
 ;; per-process for users; only test-time clearing is new.
 (spine/install-clear-warn-once-step! clear-warned-non-dom-roots!)
+
+;; Per rf2-4z7bp: chain this adapter's `set-hiccup-emitter!` into the
+;; `:reagent/set-hiccup-emitter!` late-bind hook so SSR (which calls
+;; the hook at `re-frame.ssr.emit` ns-load time) auto-wires the UIx
+;; adapter's :render-to-string slot. The hook name is historical
+;; (Reagent published it first per rf2-uo7v); behaviour is adapter-
+;; agnostic and chained — every loaded React-shaped adapter contributes
+;; its own install-into-the-emitter-cell step, so a process with both
+;; Reagent and UIx loaded gets BOTH adapters' emitters wired by a
+;; single `(require '[re-frame.ssr])`. Before this chain entry, an
+;; SSR-from-UIx user had to call `(uix-adapter/set-hiccup-emitter!
+;; render-to-string)` directly — see the rf2-gc5v9 test docstring.
+(late-bind/chain-fn! :reagent/set-hiccup-emitter! set-hiccup-emitter!)

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_dispose_adapter_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_dispose_adapter_cljs_test.cljs
@@ -1,0 +1,99 @@
+(ns re-frame.adapter.uix-dispose-adapter-cljs-test
+  "Integration-tier pinning of `dispose-adapter!` semantics on the UIx
+  adapter against Spec 006 §Adapter disposal lifecycle.
+
+  Per rf2-c36yr the decision is Option A: every MUST in the spec is
+  satisfied. The spine (`re-frame.substrate.spine`) supplies a real
+  `dispose-adapter!` covering MUSTs (1)–(3); MUST (4) — subsequent
+  calls return `:rf.error/adapter-disposed` — is enforced at the
+  delegation layer in `re-frame.substrate.adapter/require-adapter!`
+  via the `disposed?` breadcrumb (rf2-6wxys).
+
+  Per rf2-8llol this test pins the spec-MUST list at the UIx adapter's
+  user-facing surface so future refactors (or a spine swap) cannot
+  silently drop coverage. Each `testing` block names the MUST it
+  pins.
+
+  Sibling: `re-frame.substrate.spine-dispose-cljs-test` covers the
+  spine factory in isolation; this file covers it through the UIx
+  adapter wiring.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter uix-adapter/adapter}))
+
+;; ---- MUST (3) — discard internal caches -----------------------------------
+
+(deftest dispose-clears-hiccup-emitter-cell
+  (testing "Spec 006 §Adapter disposal lifecycle MUST (3): dispose-adapter!
+            discards internal caches. After set-hiccup-emitter! →
+            dispose, the next render-to-string raises
+            :rf.error/no-hiccup-emitter-bound — proving the emitter slot
+            was cleared by dispose."
+    (uix-adapter/set-hiccup-emitter! (fn [_tree _opts] "<x/>"))
+    ;; Trigger the adapter's :dispose-adapter! through the adapter map.
+    ;; The runtime-fixture re-installs a fresh adapter on :after.
+    ((:dispose-adapter! uix-adapter/adapter))
+    (let [render-fn (:render-to-string uix-adapter/adapter)
+          thrown    (try (render-fn [:div] {}) nil
+                         (catch :default e e))]
+      (is (some? thrown)
+          "render-to-string threw post-dispose")
+      (is (= ":rf.error/no-hiccup-emitter-bound" (.-message thrown))
+          "the emitter slot was cleared by dispose-adapter!"))))
+
+(deftest dispose-keeps-clear-warned-non-dom-roots-callable
+  (testing "Spec 006 §Adapter disposal lifecycle MUST (3): the adapter's
+            warn-once cache is one of the internal caches dispose-adapter!
+            must discard (it's part of the spine's drain — see
+            spine/make-dispose-adapter!). Detailed cache-emptying
+            assertions live in spine-dispose-cljs-test; here we pin
+            that the adapter-public clear thunk remains a safe idempotent
+            no-op after dispose."
+    ((:dispose-adapter! uix-adapter/adapter))
+    (is (nil? (uix-adapter/clear-warned-non-dom-roots!))
+        "clear-warned-non-dom-roots! is idempotent post-dispose")))
+
+;; ---- MUST (4) — subsequent calls return :rf.error/adapter-disposed -------
+
+(deftest post-dispose-delegation-calls-throw-adapter-disposed
+  (testing "Spec 006 §Adapter disposal lifecycle MUST (4): after
+            dispose-adapter!, subsequent calls into the adapter surface
+            (through the public delegation layer) raise
+            :rf.error/adapter-disposed. The breadcrumb is owned by
+            substrate-adapter (rf2-6wxys); here we confirm the UIx
+            adapter participates correctly."
+    (substrate-adapter/dispose-adapter!)
+    (is (substrate-adapter/adapter-disposed?)
+        "after dispose, the disposed? breadcrumb is true")
+    (let [thrown (try
+                   (substrate-adapter/make-state-container {})
+                   nil
+                   (catch :default e e))]
+      (is (some? thrown)
+          "delegation call after dispose threw")
+      (is (= ":rf.error/adapter-disposed" (.-message thrown))
+          "the throw shape matches MUST (4)"))
+    ;; Reinstall so the fixture's :after teardown lands on a clean state.
+    (substrate-adapter/install-adapter! uix-adapter/adapter)))
+
+;; ---- MUST (2) — release host-specific resources (active roots) ------------
+
+(deftest dispose-is-idempotent-with-no-tracked-roots
+  (testing "Spec 006 §Adapter disposal lifecycle MUST (2): the UIx adapter
+            tracks mounted React roots per rf2-9fdkb; dispose-adapter!
+            drains the tracking set so a fresh install starts from an
+            empty set. Detailed unmount-fan-out coverage lives in
+            re-frame.substrate.spine-dispose-cljs-test; here we pin
+            adapter-side idempotence (no real roots are mounted in this
+            node-runtime test)."
+    (is (nil? ((:dispose-adapter! uix-adapter/adapter)))
+        "dispose-adapter! returns nil even when no roots are tracked")
+    (is (nil? ((:dispose-adapter! uix-adapter/adapter)))
+        "second dispose is idempotent — active-roots set was already drained")))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_frame_provider_branches_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_frame_provider_branches_cljs_test.cljs
@@ -1,0 +1,113 @@
+(ns re-frame.adapter.uix-frame-provider-branches-cljs-test
+  "Per rf2-9i2du — pin the `frame-provider`'s two branching slots that
+  no test was exercising:
+
+    (1) `:frame` missing or `nil` — falls through to `:rf/default`
+        (per rf2-sixo).
+    (2) `:children` single value vs. sequential — single child must
+        not throw; sequential renders all children.
+
+  The two branches live in `re-frame.substrate.spine/frame-provider`:
+
+      (defn frame-provider
+        [{:keys [frame children]}]
+        (let [frame-kw (or frame :rf/default)]
+          (apply adapter-context/provider-element frame-kw
+                 (if (sequential? children) children [children]))))
+
+  Both branches are reachable from every React-shaped adapter; this
+  file pins the contract through the UIx adapter's user-facing
+  `frame-provider` re-export.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up.
+  Headless assertions only — no React render is required; we inspect
+  the returned React element's `_currentValue`-equivalent (the
+  `provider-element`'s `.-props.-value` slot) directly."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter uix-adapter/adapter}))
+
+(defn- provider-element-frame-kw
+  "Pull the `:value` prop off a React element returned by
+  `frame-provider` — this is the frame keyword the surrounding
+  Context.Provider will hand down to `use-context` consumers."
+  [el]
+  (when (and el (.-props el))
+    (aget (.-props el) "value")))
+
+(defn- provider-element-children
+  "Pull the `children` prop off the React element returned by
+  `frame-provider`. React normalises a single-element children to
+  the element directly; multi-element children come through as a
+  JS array."
+  [el]
+  (when (and el (.-props el))
+    (aget (.-props el) "children")))
+
+;; ---- (1) nil / missing :frame falls through to :rf/default ----------------
+
+(deftest frame-provider-missing-frame-falls-through-to-default
+  (testing "rf2-9i2du: (frame-provider {:children [...]}) — no :frame at
+            all — falls through to :rf/default per rf2-sixo. The
+            provider-element's `:value` slot carries :rf/default."
+    (let [el (uix-adapter/frame-provider {:children [:fake-child-a :fake-child-b]})]
+      (is (some? el) "frame-provider returned a React element")
+      (is (= :rf/default (provider-element-frame-kw el))
+          "missing :frame defaulted to :rf/default"))))
+
+(deftest frame-provider-nil-frame-falls-through-to-default
+  (testing "rf2-9i2du: (frame-provider {:frame nil :children [...]}) —
+            explicit nil :frame — falls through to :rf/default. The
+            `(or frame :rf/default)` clause covers both the missing-key
+            and nil-value cases."
+    (let [el (uix-adapter/frame-provider {:frame nil :children [:fake-child]})]
+      (is (some? el))
+      (is (= :rf/default (provider-element-frame-kw el))
+          "nil :frame defaulted to :rf/default"))))
+
+(deftest frame-provider-named-frame-preserved
+  (testing "rf2-9i2du: a supplied :frame keyword is preserved on the
+            provider element's value slot. Sanity-check counterpart to
+            the default-fallback assertions."
+    (let [el (uix-adapter/frame-provider {:frame :tenant-a :children [:fake-child]})]
+      (is (= :tenant-a (provider-element-frame-kw el))
+          ":frame :tenant-a flows through to the provider's value slot"))))
+
+;; ---- (2) :children single value vs sequential ----------------------------
+
+(deftest frame-provider-single-child-coerced-to-vector
+  (testing "rf2-9i2du: (frame-provider {:frame :session :children child-a})
+            — a single child (NOT a vector) — does not throw and is
+            coerced to a one-element children sequence by the
+            `(if (sequential? children) children [children])` branch.
+            Pins the spine's frame-provider single-vs-sequential coercion."
+    (let [single-child :fake-single-child-marker
+          el (uix-adapter/frame-provider {:frame :session :children single-child})]
+      (is (some? el) "frame-provider didn't throw on a non-sequential :children")
+      (is (= :session (provider-element-frame-kw el)))
+      ;; React normalises single-element children to the element value;
+      ;; the marker survives the coercion regardless of normalisation.
+      (let [kids (provider-element-children el)]
+        (is (or (= single-child kids)
+                (and (some? kids)
+                     (or (not (.-length kids))
+                         (= 1 (.-length kids)))))
+            "single :children produced a one-element children slot")))))
+
+(deftest frame-provider-sequential-children-preserved
+  (testing "rf2-9i2du: a sequential :children vector flows through the
+            spine's coercion branch unchanged — multiple children are
+            handed to the Provider as separate args."
+    (let [a :child-a
+          b :child-b
+          el (uix-adapter/frame-provider {:frame :session :children [a b]})]
+      (is (some? el))
+      (is (= :session (provider-element-frame-kw el)))
+      (let [kids (provider-element-children el)]
+        (is (some? kids))
+        (is (= 2 (.-length kids))
+            "sequential :children produced a two-element children slot")))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_late_bind_publication_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_late_bind_publication_cljs_test.cljs
@@ -1,0 +1,95 @@
+(ns re-frame.adapter.uix-late-bind-publication-cljs-test
+  "Per rf2-rrwwy — pin the late-bind hook list the UIx adapter publishes
+  at ns-load time. A future refactor that adds, removes, or renames a
+  hook trips this test.
+
+  The UIx adapter publishes via two mechanisms:
+
+    (1) `substrate-adapter/route-hook!` — routed `:adapter/*` hooks
+        that run THIS adapter's impl iff this adapter is the
+        currently-installed one; otherwise chain to the previous
+        handler. Used for `:adapter/current-frame`, `:adapter/ratom`,
+        `:adapter/make-reaction`, `:adapter/add-on-dispose!`,
+        `:adapter/dispose!`, `:adapter/ratom?`, `:adapter/reactive?`,
+        `:adapter/after-render`, `:adapter/wrap-view`.
+
+    (2) `late-bind/chain-fn!` — chained hooks where every contributor
+        runs (independent of installed-adapter identity). Used for
+        `:adapter/clear-warn-once-caches!` (via
+        spine/install-clear-warn-once-step!) and
+        `:reagent/set-hiccup-emitter!` (rf2-4z7bp).
+
+  This file pins the SET of hook keys published — not the impl behaviour
+  (the impl behaviour is covered by the adapter-specific tests:
+  current-frame in `uix-runtime`, ratom/make-reaction in `uix-cross-spec`,
+  wrap-view in `uix-parity`, etc.).
+
+  The sibling test for Reagent (rf2-z3q3s, scheduled) will use the
+  same shape; lifting into a shared substrate-conformance fixture is
+  a follow-on bead per the audit recommendation.
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            ;; Loading the UIx adapter triggers its ns-load publication
+            ;; side effects — that's the whole point of this test, so
+            ;; require it explicitly even though we don't reference a
+            ;; symbol from it.
+            [re-frame.adapter.uix]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.late-bind.directory :as directory]))
+
+(def ^:private expected-hook-keys
+  "Every late-bind hook the UIx adapter publishes at ns-load.
+
+  Ordering: routed `:adapter/*` hooks first (alphabetical), then
+  chained hooks (alphabetical). The set membership is what the test
+  pins; ordering here is for human-readable diff."
+  ;; Routed via substrate-adapter/route-hook!
+  #{:adapter/add-on-dispose!
+    :adapter/after-render
+    :adapter/current-frame
+    :adapter/dispose!
+    :adapter/make-reaction
+    :adapter/ratom
+    :adapter/ratom?
+    :adapter/reactive?
+    :adapter/wrap-view
+    ;; Chained via late-bind/chain-fn! (through spine/install-clear-warn-once-step!)
+    :adapter/clear-warn-once-caches!
+    ;; Chained via late-bind/chain-fn! (rf2-4z7bp)
+    :reagent/set-hiccup-emitter!})
+
+(deftest uix-adapter-publishes-expected-hook-set
+  (testing "rf2-rrwwy: every hook key the UIx adapter publishes at
+            ns-load is registered in the late-bind table after the
+            adapter ns has loaded. A future refactor that drops or
+            renames a hook (or adds an unannounced one) trips this
+            test."
+    (doseq [k expected-hook-keys]
+      (is (some? (late-bind/get-fn k))
+          (str "expected the UIx adapter to publish " k
+               " through the late-bind hook table at ns-load")))))
+
+(deftest uix-adapter-hooks-cross-checked-against-directory
+  (testing "rf2-rrwwy: every hook key in expected-hook-keys appears in
+            the authoritative late-bind directory
+            (`re-frame.late-bind.directory/hooks`) with `re-frame.adapter.uix`
+            listed as one of its producers. Drift between this test's
+            expected set and the directory is a hard error.
+
+            (Conversely we don't try to enumerate which `:adapter/*`
+            keys are EXCLUSIVELY UIx's vs. shared — the test bundle
+            loads every adapter ns, so the registry holds the union.
+            The cross-check against the directory is the principled way
+            to pin the UIx-side publication set.)"
+    (doseq [k expected-hook-keys]
+      (let [entry (some (fn [e] (when (= k (:key e)) e))
+                        directory/hooks)
+            producers (let [p (:producer-ns entry)]
+                        (if (sequential? p) p [p]))]
+        (is (some? entry)
+            (str "no directory entry for " k))
+        (is (some #{'re-frame.adapter.uix} producers)
+            (str "directory entry for " k
+                 " does not list re-frame.adapter.uix as a producer; "
+                 "producers: " (pr-str producers)))))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_render_to_string_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_render_to_string_cljs_test.cljs
@@ -10,17 +10,17 @@
   `set-hiccup-emitter!` installer, and a `render-to-string` fn that
   throws when the emitter is nil. The contract surface is identical.
 
-  Difference vs the Reagent test: as of rf2-gc5v9, UIx does NOT publish
-  its `set-hiccup-emitter!` through a late-bind hook (rf2-4z7bp tracks
-  the parity gap). Until rf2-4z7bp lands, the SSR consumer under UIx
-  has to call `set-hiccup-emitter!` directly. This test pins the
-  shipped behaviour for both the throw path AND the direct-install
-  success path; when rf2-4z7bp publishes the hook, an additional test
-  asserting the post-(require re-frame.ssr) auto-wire can land here.
+  Per rf2-4z7bp the UIx adapter publishes its `set-hiccup-emitter!`
+  through the chained `:reagent/set-hiccup-emitter!` late-bind hook
+  (`re-frame.adapter.uix` calls `late-bind/chain-fn!` at ns-load);
+  SSR's `re-frame.ssr.emit` consumes that hook at its own ns-load
+  and auto-wires the emitter. This file pins both the direct-install
+  surface and the late-bind chain entry.
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.adapter.uix :as uix-adapter]))
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.late-bind :as late-bind]))
 
 ;; ---- helpers ---------------------------------------------------------------
 
@@ -97,3 +97,36 @@
           "the installed emitter received the render-tree the caller passed in"))
     ;; Restore the slot to nil so subsequent tests don't see the mock.
     (uix-adapter/set-hiccup-emitter! nil)))
+
+;; ---- test (3) — late-bind chain wiring (rf2-4z7bp) -------------------------
+
+(deftest set-hiccup-emitter-published-through-late-bind-chain
+  (testing "rf2-4z7bp: the UIx adapter chains its set-hiccup-emitter! into
+            `:reagent/set-hiccup-emitter!` at ns-load (the same hook key
+            Reagent / reagent-slim publish to, treated as adapter-agnostic
+            and chained). Calling the hook installs the emitter into the
+            UIx adapter's slot, so SSR's `re-frame.ssr.emit` ns-load
+            auto-wires UIx's render-to-string without a direct
+            `set-hiccup-emitter!` call from user code."
+    (let [hook-fn (late-bind/get-fn :reagent/set-hiccup-emitter!)]
+      (is (some? hook-fn)
+          "the chained hook is registered after the UIx adapter ns has loaded")
+      (with-cleared-emitter
+        (fn []
+          ;; Pre-condition: emitter cleared, render-to-string throws.
+          (let [render-fn (:render-to-string uix-adapter/adapter)]
+            (is (thrown? :default (render-fn [:div] {}))
+                "precondition: emitter cleared"))
+          ;; Drive the chained hook with our test emitter. The chain
+          ;; fans the install across every loaded React-shaped adapter
+          ;; (Reagent, reagent-slim, UIx) — the slot we care about for
+          ;; this test is UIx's. After the call, render-to-string on
+          ;; the UIx adapter returns the emitter's output.
+          (hook-fn a-mock-emitter)
+          (let [render-fn (:render-to-string uix-adapter/adapter)
+                html      (render-fn [:div "via-chain"] {})]
+            (is (clojure.string/starts-with? html "<mock>")
+                "the chained hook wired the UIx adapter's emitter slot"))
+          ;; Cleanup: drive the chain again with nil so loaded sibling
+          ;; adapter slots reset, not just UIx's.
+          (hook-fn nil))))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_cljs_test.cljs
@@ -165,6 +165,71 @@
                 (finally
                   (try (.unmount root) (catch :default _ nil)))))))))))
 
+;; ---- 2-arg form: explicit frame-id wins over context (rf2-rcgsc) ----------
+;;
+;; The 2-arg form `(use-subscribe frame-kw query-v)` is documented to
+;; bypass the React-context tier and read from the named frame's
+;; app-db directly. Pre-rf2-rcgsc only the 1-arg context-resolved form
+;; was tested under a frame-provider; the 2-arg explicit-pin shape was
+;; exercised indirectly via the Probe component above but no test
+;; pinned that two different frame-ids in the SAME render tree (no
+;; surrounding provider) see distinct values.
+
+(def ^:private probe-2arg-a-observed (atom []))
+(def ^:private probe-2arg-b-observed (atom []))
+
+(defui Probe2ArgA []
+  (let [v (uix-adapter/use-subscribe :rf.uix-rcgsc/tenant-a
+                                     [:rf.uix-rcgsc/n])]
+    (swap! probe-2arg-a-observed conj v)
+    ($ :div (str "a=" v))))
+
+(defui Probe2ArgB []
+  (let [v (uix-adapter/use-subscribe :rf.uix-rcgsc/tenant-b
+                                     [:rf.uix-rcgsc/n])]
+    (swap! probe-2arg-b-observed conj v)
+    ($ :div (str "b=" v))))
+
+(deftest use-subscribe-2-arg-pins-explicit-frame
+  (testing "rf2-rcgsc: use-subscribe's 2-arg form
+            `(use-subscribe frame-kw query-v)` reads from the named
+            frame's app-db, bypassing the React-context tier. Two
+            probes pinning two different frames in the same render
+            tree must see each frame's distinct seed value."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
+      (let [act-fn (get-act)]
+        (if (nil? act-fn)
+          (is true "act() not reachable from this runner; skipping")
+          (do
+            (enable-react-act-env!)
+            (reset! probe-2arg-a-observed [])
+            (reset! probe-2arg-b-observed [])
+            (rf/reg-frame :rf.uix-rcgsc/tenant-a {:doc "tenant-a"})
+            (rf/reg-frame :rf.uix-rcgsc/tenant-b {:doc "tenant-b"})
+            (rf/reg-event-db :rf.uix-rcgsc/seed (fn [_ [_ n]] {:n n}))
+            (rf/dispatch-sync [:rf.uix-rcgsc/seed 10] {:frame :rf.uix-rcgsc/tenant-a})
+            (rf/dispatch-sync [:rf.uix-rcgsc/seed 100] {:frame :rf.uix-rcgsc/tenant-b})
+            (rf/reg-sub :rf.uix-rcgsc/n (fn [db _] (:n db)))
+            (let [mount-node (make-mount-node!)
+                  root       (react-dom-client/createRoot mount-node)]
+              (try
+                (act-fn (fn []
+                          (.render root
+                            (uix/$ :div
+                              (uix/$ Probe2ArgA)
+                              (uix/$ Probe2ArgB)))))
+                (is (some #{10} @probe-2arg-a-observed)
+                    "Probe2ArgA observed tenant-a's value (10) via explicit frame-pin")
+                (is (some #{100} @probe-2arg-b-observed)
+                    "Probe2ArgB observed tenant-b's value (100) via explicit frame-pin")
+                (is (not (some #{100} @probe-2arg-a-observed))
+                    "tenant-a probe did NOT leak tenant-b's value")
+                (is (not (some #{10} @probe-2arg-b-observed))
+                    "tenant-b probe did NOT leak tenant-a's value")
+                (finally
+                  (try (.unmount root) (catch :default _ nil)))))))))))
+
 ;; ---- sub-cache refcount cleanup (rf2-7g959) -------------------------------
 ;;
 ;; Pre-rf2-7g959, `use-subscribe` only removed the add-watch on

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_write_after_destroy_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_write_after_destroy_cljs_test.cljs
@@ -1,0 +1,75 @@
+(ns re-frame.adapter.uix-write-after-destroy-cljs-test
+  "UIx-tier integration coverage of the `:rf.warning/write-after-destroy`
+  nil-container guard at `substrate-adapter/replace-container!`
+  (rf2-ft2b reproducer).
+
+  The guard itself lives in `re-frame.substrate.adapter` and is
+  unit-tested at the JVM tier in
+  `re-frame.frame-lifecycle-test/replace-container-no-ops-on-nil-container`
+  / `drain-after-destroy-does-not-npe`. That coverage uses the
+  plain-atom adapter (JVM-side). This file pins the same contract
+  through the UIx-installed adapter — the substrate-agnostic guard
+  must fire identically regardless of which adapter is installed.
+
+  Per rf2-4tzyq.
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter uix-adapter/adapter}))
+
+(deftest replace-container-no-ops-on-nil-container-uix
+  (testing "rf2-4tzyq: replace-container! with nil container under the UIx
+            adapter is a no-op + :rf.warning/write-after-destroy. The
+            guard is substrate-agnostic (lives in
+            substrate-adapter/replace-container!), so the trace fires
+            with the UIx adapter installed exactly the same way it does
+            under plain-atom (the JVM-tier reproducer in
+            frame-lifecycle-test)."
+    (let [recorded (atom [])]
+      (rf/register-trace-cb! ::rec (fn [ev] (swap! recorded conj ev)))
+      (is (nil? (substrate-adapter/replace-container! nil {:any :value}))
+          "nil container is a documented no-op, not an exception")
+      (let [warns (filterv (fn [ev]
+                             (and (= :warning (:op-type ev))
+                                  (= :rf.warning/write-after-destroy
+                                     (:operation ev))))
+                           @recorded)]
+        (is (= 1 (count warns))
+            "exactly one :rf.warning/write-after-destroy trace fired"))
+      (rf/remove-trace-cb! ::rec))))
+
+(deftest write-after-destroy-emits-warning-uix
+  (testing "rf2-4tzyq: a write through a destroyed frame's nil container
+            under the UIx adapter emits :rf.warning/write-after-destroy.
+            Mirrors `replace-container-after-frame-destroy-no-ops`
+            (frame-lifecycle-test) but with the UIx adapter installed —
+            the contract is substrate-agnostic."
+    (let [recorded (atom [])]
+      (rf/register-trace-cb! ::rec (fn [ev] (swap! recorded conj ev)))
+      (rf/reg-frame :uix-rf2-4tzyq/race-frame
+                    {:doc "rf2-4tzyq UIx-side reproducer frame"})
+      ;; Tear the frame down; subsequent frame/get-frame-db returns nil.
+      (frame/destroy-frame! :uix-rf2-4tzyq/race-frame)
+      (let [container (frame/get-frame-db :uix-rf2-4tzyq/race-frame)]
+        (is (nil? container)
+            "get-frame-db on a destroyed frame returns nil — the precondition for the rf2-ft2b NPE")
+        ;; The shape of the call from router.cljc's :db commit path. Pre-fix:
+        ;; NPE. Post-fix: no-op + warning trace.
+        (is (nil? (substrate-adapter/replace-container! container {:would :have :npe'd true}))
+            "writing through the nil container is a documented no-op"))
+      (let [warns (filterv (fn [ev]
+                             (and (= :warning (:op-type ev))
+                                  (= :rf.warning/write-after-destroy
+                                     (:operation ev))))
+                           @recorded)]
+        (is (pos? (count warns))
+            ":rf.warning/write-after-destroy fired for the post-destroy write"))
+      (rf/remove-trace-cb! ::rec))))

--- a/implementation/core/src/re_frame/late_bind.cljc
+++ b/implementation/core/src/re_frame/late_bind.cljc
@@ -70,6 +70,49 @@
   [hook-key]
   (get @hooks hook-key))
 
+(defn chain-fn!
+  "Wire `step-fn` into the chained hook under `hook-key` so calling the
+  hook runs `step-fn` AND every previously-registered step.
+
+  Pairs with the inline get-prev-and-wrap idiom several chained
+  hooks use (`:adapter/clear-warn-once-caches!` published by the
+  React-shaped adapters + re-frame.views.warn-once; `:reagent/set-hiccup-emitter!`
+  chained across the Reagent / UIx / Helix / reagent-slim adapters
+  per rf2-4z7bp). Each adapter ns previously open-coded:
+
+      (let [previous (late-bind/get-fn hook-key)]
+        (late-bind/set-fn! hook-key
+          (fn chained [& args]
+            (apply step-fn args)
+            (when previous (apply previous args))
+            nil)))
+
+  Replaced by the single-line call:
+
+      (late-bind/chain-fn! hook-key step-fn)
+
+  Semantics:
+    * `step-fn` runs FIRST on every invocation (insertion-order
+      head of the chain — last-registered step is the outer wrapper).
+    * Each previous handler is invoked with the same `args` after
+      `step-fn` returns.
+    * Per-step throws propagate; the chain does NOT swallow them
+      (each contributing ns is responsible for its own try/catch
+      semantics).
+    * Returns nil — chained hooks are side-effecting (cache resets,
+      emitter installs); callers do not consume a return value.
+
+  Per rf2-1fh5h (UIx batch). Sibling for routed hooks is
+  `re-frame.substrate.adapter/route-hook!` (single-step routing,
+  dispatched by installed-adapter identity)."
+  [hook-key step-fn]
+  (let [previous (get-fn hook-key)]
+    (set-fn! hook-key
+      (fn chained-hook [& args]
+        (apply step-fn args)
+        (when previous (apply previous args))
+        nil))))
+
 (defn require-fn!
   "Return the fn registered under `hook-key`, or throw a structured
   `:rf.error/<artefact>-artefact-missing` ex-info when the hook is

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -300,9 +300,12 @@
 
    ;; ---- re-frame.adapter.reagent (rf2-0hxm) ---------------------------------
    {:key         :reagent/set-hiccup-emitter!
-    :producer-ns '[re-frame.adapter.reagent re-frame.adapter.reagent-slim]
+    :producer-ns '[re-frame.adapter.reagent
+                   re-frame.adapter.reagent-slim
+                   re-frame.adapter.uix]
     :chained?    true
-    :description "Install the substrate-specific hiccup emitter for SSR."}
+    :design-bead "rf2-4z7bp"
+    :description "Install the substrate-specific hiccup emitter for SSR. Chained — every loaded React-shaped adapter contributes its own install step so a single SSR ns-load auto-wires every adapter's render-to-string slot."}
 
    ;; ---- re-frame.views (CLJS, rf2-4edk warn-once chain) ---------------------
    {:key         :views/maybe-warn-plain-fn-under-non-default-frame!

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -427,14 +427,13 @@
   "Wire `clear-fn` into the chained `:adapter/clear-warn-once-caches!`
   late-bind hook. The hook is chained — each adapter and re-frame.views
   contribute a clear-step; `reset-runtime-fixture` invokes the top of
-  the chain and every contributor's reset runs. Per rf2-4edk."
+  the chain and every contributor's reset runs. Per rf2-4edk.
+
+  Thin wrapper around `late-bind/chain-fn!` (rf2-1fh5h) — the
+  generic chain idiom; this wrapper exists so callers do not need
+  to know the chain key."
   [clear-fn]
-  (let [previous (late-bind/get-fn :adapter/clear-warn-once-caches!)]
-    (late-bind/set-fn! :adapter/clear-warn-once-caches!
-      (fn chained-clear-warn-once-caches! []
-        (clear-fn)
-        (when previous (previous))
-        nil))))
+  (late-bind/chain-fn! :adapter/clear-warn-once-caches! clear-fn))
 
 ;; ---- subscription hook ----------------------------------------------------
 ;;

--- a/implementation/core/src/re_frame/views/warn_once.cljs
+++ b/implementation/core/src/re_frame/views/warn_once.cljs
@@ -237,15 +237,11 @@
                    clear-plain-fn-warned-pairs!)
 
 ;; Per rf2-4edk: register a clear of the `warned-non-dom-roots` cache
-;; under the chained `:adapter/clear-warn-once-caches!` hook. The hook
-;; is chained — each adapter (helix, uix) and this views ns all
-;; contribute a clear-step; `reset-runtime-fixture` invokes the top of
-;; the chain and every contributor's reset runs. Production behaviour
-;; is unchanged: the warn-once `defonce` is still per-process for users;
-;; only test-time clearing is new.
-(let [previous (late-bind/get-fn :adapter/clear-warn-once-caches!)]
-  (late-bind/set-fn! :adapter/clear-warn-once-caches!
-    (fn views-clear-warn-once-caches! []
-      (clear-warned-non-dom-roots!)
-      (when previous (previous))
-      nil)))
+;; under the chained `:adapter/clear-warn-once-caches!` hook. Each
+;; adapter (helix, uix) and this views ns all contribute a clear-step;
+;; `reset-runtime-fixture` invokes the top of the chain and every
+;; contributor's reset runs. Production behaviour is unchanged: the
+;; warn-once `defonce` is still per-process for users; only test-time
+;; clearing is new. Chain wiring goes through `late-bind/chain-fn!`
+;; (rf2-1fh5h) — the generic chain idiom.
+(late-bind/chain-fn! :adapter/clear-warn-once-caches! clear-warned-non-dom-roots!)

--- a/implementation/core/test/re_frame/late_bind_drift_test.clj
+++ b/implementation/core/test/re_frame/late_bind_drift_test.clj
@@ -77,6 +77,15 @@
   equivalent publications."
   #"\(substrate-adapter/route-hook!\s+\S+\s+(:[a-zA-Z][a-zA-Z0-9!?*+\-]*/[a-zA-Z][a-zA-Z0-9!?*+\-]*)")
 
+(def ^:private chain-fn-call-re
+  "Match `(late-bind/chain-fn! :namespace/key ...`.
+
+  Per rf2-1fh5h chained hooks are published through `chain-fn!`
+  (which calls `set-fn!` internally, wrapping the step-fn in a
+  chain-into-previous closure). Drift scan treats this call shape as
+  equivalent to direct `set-fn!` publication."
+  #"\(late-bind/chain-fn!\s+(:[a-zA-Z][a-zA-Z0-9!?*+\-]*/[a-zA-Z][a-zA-Z0-9!?*+\-]*)")
+
 (defn- match-keys
   [re content]
   (->> (re-seq re content)
@@ -86,8 +95,9 @@
 (defn- published-keys-in-file
   [^java.io.File f]
   (let [content (slurp f)]
-    (into (match-keys set-fn-call-re content)
-          (match-keys route-hook-call-re content))))
+    (-> (match-keys set-fn-call-re content)
+        (into (match-keys route-hook-call-re content))
+        (into (match-keys chain-fn-call-re content)))))
 
 (defn- published-keys
   "Set of every late-bind key published from in-tree source files."


### PR DESCRIPTION
## Summary

Batched-by-surface follow-on PR for `implementation/adapters/uix/` after the adapters-shared spine batch (PR #1041). Lands 11 beads from the rf2-0fgm8 round-2 UIx audit — refactors, tests, and docs. The remaining cross-adapter beads (rf2-y1hbg, rf2-ggx29) are deferred to a later batch to avoid hot-zone conflicts with sibling Reagent/Helix batches.

## Beads landed (9 commits, in P1 → P2 → P3 order)

- **rf2-c36yr / rf2-8llol** (P1 + P2) — Decision: spec MUSTs (1)–(4) are satisfied by the spine + delegation layer; no spec relaxation needed. Test pins each MUST at the adapter surface (`uix_dispose_adapter_cljs_test`).
- **rf2-1fh5h** (P2) — Extract `re-frame.late-bind/chain-fn!` helper; consolidate two inline get-prev-and-wrap chain-idiom call sites (spine, views.warn-once).
- **rf2-4z7bp** (P2) — Chain UIx's `set-hiccup-emitter!` into the `:reagent/set-hiccup-emitter!` late-bind hook. SSR-from-UIx now auto-wires via a single `(require '[re-frame.ssr])`. Directory + drift-test regex extended.
- **rf2-4tzyq** (P2) — Pin `:rf.warning/write-after-destroy` nil-container guard at UIx tier (two scenarios: direct nil call + frame-destroy race).
- **rf2-9i2du** (P3) — Pin frame-provider branching slots: nil/missing `:frame` falls through to `:rf/default`; single non-vector `:children` is coerced. Five tests, headless.
- **rf2-rcgsc** (P3) — Pin use-subscribe 2-arg explicit-frame-pin form: two probes side-by-side under no provider see distinct frame values.
- **rf2-rrwwy** (P3) — Pin the late-bind hook set the UIx adapter publishes at ns-load. Registry check + directory cross-check; 11 expected keys.
- **rf2-84myk** (P3) — Clarify use-current-frame vs `:adapter/current-frame` docstring divergence (React-context-tier-only vs full chain).
- **rf2-8u0hs** (P3) — Trim history-narration + spec-restatement comments in adapter ns. LoC: 208 → 193 in uix.cljs. No behaviour change.

## Stale beads (closed without code change)

- **rf2-zh25u** — format-source-coord is already public in `re-frame.substrate.spine` (rolled into the rf2-3vwbx extraction per the bead's own coordination note).
- **rf2-8n0tw** — subscribe-snapshot helper no longer exists (also rolled into the spine extraction).

## Deferred (cross-adapter — later batch)

- **rf2-y1hbg** — gensym → hash perf in use-subscribe (lives in spine; cross-adapter hot-zone)
- **rf2-ggx29** — derived-value notify-loop alloc tightening (lives in spine; cross-adapter hot-zone)

## LoC delta (this branch only)

12 files changed, +608 / -92 (net +516). Source: -15 in `uix.cljs` (rf2-8u0hs). All other deltas are new tests + the new `chain-fn!` helper + directory/drift updates.

## Test plan

- [x] `npm run test:cljs` — 1878 tests, 0 failures, 0 errors (was 1857 baseline; +21 new assertions).
- [x] `npm run test:browser` — 1872 tests, 0 failures, 0 errors.
- [x] `npm run test:examples` — all 26 examples pass (including counter-uix, login-uix).
- [x] `npm run test:elision` — pass.
- [x] `npm run test:bundle-isolation` — pass.
- [x] JVM core tests: `clojure -M:test` (492 tests, 0 failures).
- [x] JVM late-bind drift test re-run after directory + regex update: 0 failures.
- [ ] `npm run test:perf-bundle` — **fails on `main` too** (pre-existing, not caused by this PR; `re-frame.performance` ns survives advanced compilation with `enabled?=false`).