### PR TITLE
perf+fix(ssr): batched cluster — 7 follow-on beads

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
@@ -75,3 +75,26 @@
     (if has-ct?
       pairs
       (conj (vec pairs) ["Content-Type" content-type]))))
+
+(defn headers->ring-map+default-content-type
+  "Single-pass equivalent of `(-> pairs (ensure-content-type ct)
+  headers->ring-map)` (rf2-uj9z8). Pre-fix the two helpers each
+  walked the pairs vector — `ensure-content-type` lower-cased every
+  name to scan for an existing `Content-Type`, then `headers->ring-map`
+  re-walked the same pairs to fold them into the Ring header map. The
+  combined form walks once: it folds each pair into the accumulator
+  AND lower-cases each name once to flag whether `Content-Type` was
+  seen, appending the default at the end iff not.
+
+  Behaviour is identical to the two-step composition; the no-default
+  path (caller didn't supply `content-type`) is a straight
+  `headers->ring-map`."
+  [pairs content-type]
+  (let [step (fn [[m saw-ct?] [k v :as pair]]
+               [(merge-pair-into-header-map m pair)
+                (or saw-ct?
+                    (= "content-type" (str/lower-case (str k))))])
+        [m saw-ct?] (reduce step [{} false] pairs)]
+    (if (or saw-ct? (nil? content-type))
+      m
+      (assoc m "Content-Type" content-type))))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -105,11 +105,21 @@
            html-shell content-type]
     :as   opts}]
   (let [hiccup      (rf/with-frame frame-id (lifecycle/resolve-root-view root-view))
+        ;; rf2-i15nh / rf2-atmvj: compute the structural hash ONCE per
+        ;; request. The same hex feeds the root-element
+        ;; `data-rf-render-hash` (via render-to-string's `:render-hash`
+        ;; opt) AND the payload's `:rf/render-hash`. Pre-rf2-i15nh
+        ;; render-to-string computed the hash internally on the
+        ;; `:emit-hash?` branch and the pipeline called render-tree-hash
+        ;; again here — two full canonical-EDN walks per request. The
+        ;; opt-threaded form drops it to one. When `:emit-hash?` is
+        ;; false the hash is still needed for the payload slot.
+        hash-str    (ssr/render-tree-hash hiccup)
         body-html   (rf/with-frame frame-id
                       (ssr/render-to-string hiccup
-                                            {:doctype?   false
-                                             :emit-hash? emit-hash?}))
-        hash-str    (ssr/render-tree-hash hiccup)
+                                            {:doctype?    false
+                                             :emit-hash?  emit-hash?
+                                             :render-hash (when emit-hash? hash-str)}))
         app-db      (rf/get-frame-db frame-id)
         payload     (payload/build-payload frame-id app-db hash-str
                                            {:version       version

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -35,20 +35,31 @@
   Spec 011 §HTTP response contract) into a Ring response map. The
   `:body` arg is the rendered HTML (or nil for redirect-only
   responses). `:redirect` short-circuits per Spec 011 §Redirect
-  precedence — status + Location header, no body."
-  [{:keys [status headers cookies redirect]} body]
-  (if redirect
-    (let [{:keys [location url to] redirect-status :status} redirect
-          target (or location url to)]
-      {:status  (or redirect-status status 302)
-       :headers (-> (headers/headers->ring-map headers)
-                    (headers/append-set-cookies cookies)
-                    (cond-> target (assoc "Location" target)))
-       :body    ""})
-    {:status  (or status 200)
-     :headers (-> (headers/headers->ring-map headers)
-                  (headers/append-set-cookies cookies))
-     :body    (or body "")}))
+  precedence — status + Location header, no body.
+
+  The optional 3-arg form (rf2-uj9z8) accepts a `default-content-type`
+  that's stamped onto the Ring header map if (and only if) the response
+  pairs don't already carry a Content-Type (case-insensitive). The
+  defaulting happens INSIDE the single header-fold pass — pre-fix the
+  pipeline called `ensure-content-type` over the pairs vector, then
+  `headers->ring-map` re-walked the same pairs to fold them. Single
+  pass now."
+  ([resp body] (ssr-response->ring-response resp body nil))
+  ([{:keys [status headers cookies redirect]} body default-content-type]
+   (if redirect
+     (let [{:keys [location url to] redirect-status :status} redirect
+           target (or location url to)]
+       {:status  (or redirect-status status 302)
+        :headers (-> (headers/headers->ring-map+default-content-type
+                       headers default-content-type)
+                     (headers/append-set-cookies cookies)
+                     (cond-> target (assoc "Location" target)))
+        :body    ""})
+     {:status  (or status 200)
+      :headers (-> (headers/headers->ring-map+default-content-type
+                     headers default-content-type)
+                   (headers/append-set-cookies cookies))
+      :body    (or body "")})))
 
 (defn setup-request-frame!
   "Register a per-request frame and populate the request slot. Returns
@@ -145,10 +156,13 @@
                            :head        head-html
                            :html-attrs  html-attrs
                            :body-attrs  body-attrs)
-        html        (html-shell body-html payload-edn shell-opts)
-        ;; Ensure Content-Type is set; the SSR runtime defaults
-        ;; [:rf/response :headers] to include content-type so this is
-        ;; usually a no-op, but we let opts override and trust the
-        ;; runtime's default in absence.
-        resp*       (update resp :headers headers/ensure-content-type content-type)]
-    (ssr-response->ring-response resp* html)))
+        html        (html-shell body-html payload-edn shell-opts)]
+    ;; Content-Type defaulting (rf2-uj9z8): pre-fix the pipeline called
+    ;; ensure-content-type over the pairs vector, then
+    ;; ssr-response->ring-response re-walked the same pairs to fold them
+    ;; into the Ring header map — two passes. The 3-arg form folds and
+    ;; defaults in one walk. The SSR runtime defaults [:rf/response
+    ;; :headers] to include content-type so the default is usually a
+    ;; no-op, but we still pass `content-type` through so an opts
+    ;; override and absence-of-default both work.
+    (ssr-response->ring-response resp html content-type)))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/shell.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/shell.clj
@@ -18,11 +18,78 @@
   reader on the client accepts `\\u003c` as the six-character escape
   for `<`, so the payload round-trips through `clojure.edn/read-string`
   unchanged. Same fix pattern as JSON-LD (rf2-m5u23) — single helper,
-  two call sites."
-  (:require [re-frame.ssr.constants :as constants]
-            [re-frame.ssr.html-helpers :as html]))
+  two call sites.
+
+  Dev-mode CSP-host warning for `:body-end` (rf2-2n5gg, security audit
+  2026-05-14 §P3.4) — `:body-end` is the escape hatch for analytics /
+  third-party scripts the shell injects RAW. When the caller supplies
+  `:csp-script-src-allowlist` (set of allowed script-src hostnames)
+  AND `:body-end` contains a `<script src=\"…\">` whose host is not
+  in the allowlist, the shell emits `:rf.ssr/csp-allowlist-violation`
+  via `re-frame.trace/emit-error!`. The check is debug-gated
+  (`interop/debug-enabled?` short-circuits in production builds per
+  Spec 009 §Production-elision verification) so prod requests pay no
+  cost. Pure defence-in-depth: the script tag still reaches the wire
+  — the warning is the signal, not a block. Callers who don't
+  configure an allowlist see no behaviour change."
+  (:require [clojure.string :as str]
+            [re-frame.interop :as interop]
+            [re-frame.ssr.constants :as constants]
+            [re-frame.ssr.html-helpers :as html]
+            [re-frame.trace :as trace]))
 
 (set! *warn-on-reflection* true)
+
+;; ---- :body-end CSP-allowlist check (rf2-2n5gg) ----------------------------
+;;
+;; Match: any `<script ... src="..."...></script>` (single OR double-quoted
+;; src). Group 1 captures the src URL. Multi-script `:body-end` is common
+;; (analytics + chat + error reporter); the scanner iterates every match.
+
+(def ^:private script-src-pattern
+  #"(?i)<script\b[^>]*\bsrc\s*=\s*(?:\"([^\"]+)\"|'([^']+)')[^>]*>")
+
+(defn- ^:private script-src-host
+  "Extract the host portion of an absolute script src. Returns nil for
+  same-origin (relative) URLs — those can't violate a remote-host
+  allowlist by definition."
+  [src]
+  (try
+    (let [uri (java.net.URI. ^String src)
+          h   (.getHost uri)]
+      (when (and h (not (str/blank? h))) h))
+    (catch Exception _ nil)))
+
+(defn check-body-end-csp-hosts!
+  "When `body-end` is non-empty AND `allowlist` is a non-empty coll,
+  scan the raw HTML for `<script src=...>` references and emit
+  `:rf.ssr/csp-allowlist-violation` (via `trace/emit-error!`) for each
+  external host not in the allowlist. Pure defensive signalling — no
+  exception, no shell rewrite. Production builds elide the whole
+  check via `interop/debug-enabled?` (Spec 009 §Production builds)."
+  [body-end allowlist]
+  (when (and interop/debug-enabled?
+             body-end
+             (seq allowlist))
+    (let [allowed (set allowlist)
+          matcher (re-matcher script-src-pattern body-end)]
+      (loop []
+        (when (.find matcher)
+          (let [src  (or (.group matcher 1) (.group matcher 2))
+                host (script-src-host src)]
+            (when (and host (not (contains? allowed host)))
+              (trace/emit-error! :rf.ssr/csp-allowlist-violation
+                {:where     :ssr-ring/default-html-shell
+                 :src       src
+                 :host      host
+                 :allowlist allowed
+                 :message   (str ":body-end carries <script src> whose host "
+                                 (pr-str host)
+                                 " is not in :csp-script-src-allowlist "
+                                 (pr-str allowed)
+                                 " — defence-in-depth warning per "
+                                 "security audit 2026-05-14 §P3.4 / rf2-2n5gg")})))
+          (recur))))))
 
 (defn default-html-shell
   "The default HTML envelope. Returns a string wrapping the rendered
@@ -60,7 +127,7 @@
     opts — the caller's adapter opts (merged with any per-request
            overrides); standard keys :head / :html-attrs / :body-attrs
            / :body-end / :script-src / :app-element-id / :lang
-           influence the envelope.
+           / :csp-script-src-allowlist influence the envelope.
 
   Safety — `:body-end` is concatenated as RAW HTML; no escaping is
   applied. The shell is caller-controlled config (app boot decides what
@@ -68,12 +135,22 @@
   load-bearing here. Hosts that route user-controlled content through
   `:body-end` (e.g. config-driven analytics blocks sourced from a
   customer settings UI) MUST escape upstream — the shell will not.
-  Audit rf2-asmj1 R12 / cluster rf2-sljs1."
+  Audit rf2-asmj1 R12 / cluster rf2-sljs1.
+
+  Defence-in-depth — when `:csp-script-src-allowlist` is supplied (set
+  of allowed script-src hostnames), the shell scans `:body-end` for
+  `<script src=\"…\">` whose host is NOT in the allowlist and emits
+  `:rf.ssr/csp-allowlist-violation` via `re-frame.trace/emit-error!`.
+  The check is debug-gated (production builds elide it) and never
+  blocks emission — the warning is the signal. Per rf2-2n5gg /
+  security audit 2026-05-14 §P3.4."
   [body-html payload-edn
-   {:keys [head html-attrs body-attrs body-end script-src app-element-id lang]
+   {:keys [head html-attrs body-attrs body-end script-src app-element-id lang
+           csp-script-src-allowlist]
     :or   {app-element-id  "app"
            script-src      "/main.js"
            lang            "en"}}]
+  (check-body-end-csp-hosts! body-end csp-script-src-allowlist)
   (let [;; :html-attrs wins; otherwise fall back to {:lang lang}. An
         ;; explicit :lang inside :html-attrs takes precedence over the
         ;; :lang opt without us having to do anything special — the

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -1109,3 +1109,93 @@
                 ":ex-class carries the throwable's class name")
             (is (= :warned-and-skipped (:recovery ev))
                 ":recovery names the policy")))))))
+
+;; ===========================================================================
+;; rf2-2n5gg — :body-end CSP-host allowlist warning (security audit 2026-05-14 §P3.4)
+;;
+;; `:body-end` is the documented escape hatch for analytics / third-party
+;; scripts the shell injects raw. When the caller supplies
+;; `:csp-script-src-allowlist`, the shell scans for `<script src=...>` and
+;; emits `:rf.ssr/csp-allowlist-violation` for hosts not in the allowlist.
+;; The check is debug-gated; no allowlist → no scan.
+;; ===========================================================================
+
+(defn- capture-traces
+  "Run `body-fn` with a trace listener attached; return the captured trace
+  events. Mirrors the `register-trace-cb!` pattern used by the
+  :rf.ssr/destroy-frame-failed test above."
+  [body-fn]
+  (let [traces (atom [])]
+    (rf/register-trace-cb! ::csp-watch (fn [ev] (swap! traces conj ev)))
+    (try (body-fn)
+         (finally (rf/remove-trace-cb! ::csp-watch)))
+    @traces))
+
+(deftest body-end-csp-allowlist-warns-on-disallowed-host
+  (testing "rf2-2n5gg: a :body-end <script src=\"...\"> whose host is NOT in
+            :csp-script-src-allowlist triggers :rf.ssr/csp-allowlist-violation"
+    (let [check! (requiring-resolve 're-frame.ssr.ring.shell/check-body-end-csp-hosts!)
+          body-end (str "<script src=\"https://evil.example.com/track.js\"></script>"
+                        "<script src=\"https://cdn.allowed.com/ok.js\"></script>")
+          traces (capture-traces
+                   #(check! body-end #{"cdn.allowed.com"}))
+          hits   (filterv #(= :rf.ssr/csp-allowlist-violation (:operation %)) traces)]
+      (is (= 1 (count hits))
+          (str "expected exactly one :rf.ssr/csp-allowlist-violation trace; saw: "
+               (pr-str (mapv :operation traces))))
+      (when (seq hits)
+        (let [ev (first hits)]
+          (is (= "evil.example.com" (-> ev :tags :host))
+              "tags :host names the disallowed origin")
+          (is (str/includes? (-> ev :tags :message) "rf2-2n5gg")
+              ":message references the bead for traceability"))))))
+
+(deftest body-end-csp-allowlist-no-warning-on-allowed-host
+  (testing "rf2-2n5gg: every <script src> host IS in the allowlist → no warning"
+    (let [check! (requiring-resolve 're-frame.ssr.ring.shell/check-body-end-csp-hosts!)
+          body-end "<script src=\"https://cdn.allowed.com/ok.js\"></script>"
+          traces (capture-traces
+                   #(check! body-end #{"cdn.allowed.com"}))]
+      (is (zero? (count (filterv #(= :rf.ssr/csp-allowlist-violation (:operation %))
+                                 traces)))
+          "no violation when every script-src host is allowlisted"))))
+
+(deftest body-end-csp-allowlist-skip-when-allowlist-absent
+  (testing "rf2-2n5gg: no :csp-script-src-allowlist supplied → check is a
+            no-op even when :body-end carries scripts; preserves the
+            opt-in nature of the feature"
+    (let [check! (requiring-resolve 're-frame.ssr.ring.shell/check-body-end-csp-hosts!)
+          body-end "<script src=\"https://anything.example.com/track.js\"></script>"
+          traces (capture-traces
+                   #(check! body-end nil))]
+      (is (zero? (count (filterv #(= :rf.ssr/csp-allowlist-violation (:operation %))
+                                 traces)))
+          "nil allowlist short-circuits the scan"))))
+
+(deftest body-end-csp-allowlist-relative-srcs-pass
+  (testing "rf2-2n5gg: relative / same-origin <script src> URLs have no
+            host — they can't violate a remote-host allowlist by
+            definition, so the scanner skips them"
+    (let [check! (requiring-resolve 're-frame.ssr.ring.shell/check-body-end-csp-hosts!)
+          body-end "<script src=\"/main.js\"></script><script src=\"./app.js\"></script>"
+          traces (capture-traces
+                   #(check! body-end #{"cdn.allowed.com"}))]
+      (is (zero? (count (filterv #(= :rf.ssr/csp-allowlist-violation (:operation %))
+                                 traces)))
+          "relative srcs skip the host check"))))
+
+(deftest body-end-csp-allowlist-multiple-violations
+  (testing "rf2-2n5gg: a :body-end carrying multiple disallowed-host
+            scripts produces one warning per violating script — each
+            host is independently flagged"
+    (let [check! (requiring-resolve 're-frame.ssr.ring.shell/check-body-end-csp-hosts!)
+          body-end (str "<script src=\"https://bad1.example.com/a.js\"></script>"
+                        "<script src=\"https://bad2.example.com/b.js\"></script>")
+          traces (capture-traces
+                   #(check! body-end #{"good.example.com"}))
+          hits   (filterv #(= :rf.ssr/csp-allowlist-violation (:operation %)) traces)
+          hosts  (mapv #(-> % :tags :host) hits)]
+      (is (= 2 (count hits))
+          "two violating scripts → two traces")
+      (is (= #{"bad1.example.com" "bad2.example.com"} (set hosts))
+          "each violating host is flagged independently"))))

--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -240,11 +240,26 @@
   Reagent-native heads, and fn-headed components on the root path. This
   replaces the prior post-emit regex-on-string injection: structural,
   composes with the source-coord annotation, and silently no-ops for
-  non-DOM-rooted trees (matching the source-coord exemption)."
+  non-DOM-rooted trees (matching the source-coord exemption).
+
+  Per rf2-atmvj / rf2-i15nh: callers that also need the structural hash
+  for the payload (e.g. the ssr-ring pipeline's `:rf/render-hash`) MUST
+  pass it in via `:render-hash` — that single hash then drives BOTH the
+  root-element `data-rf-render-hash` injection AND the caller's payload
+  slot. Without the opt, `:emit-hash? true` falls back to computing the
+  hash internally (one extra canonical-EDN walk over the tree); a caller
+  that ALSO calls `ssr/render-tree-hash` separately pays a second walk.
+  The opt eliminates the duplicate without changing the byte-identity
+  contract — `:render-hash` is just a pass-through to the root-attrs
+  stamper. Spec 011's hash/emit separation is preserved (no combined
+  walker)."
   [render-tree opts]
-  (let [root-attrs (when (:emit-hash? opts)
-                     {:data-rf-render-hash (hash/render-tree-hash render-tree)})
-        body       (emit-element render-tree root-attrs)]
+  (let [supplied-hash (:render-hash opts)
+        root-attrs    (cond
+                        supplied-hash {:data-rf-render-hash supplied-hash}
+                        (:emit-hash? opts)
+                        {:data-rf-render-hash (hash/render-tree-hash render-tree)})
+        body          (emit-element render-tree root-attrs)]
     (if (:doctype? opts)
       (str "<!DOCTYPE html>" body)
       body)))

--- a/implementation/ssr/src/re_frame/ssr/hash.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hash.cljc
@@ -18,6 +18,160 @@
 ;; concept — the directive is JVM-only.
 #?(:clj (set! *warn-on-reflection* true))
 
+;; ---- canonical-EDN walker (rf2-8otin / rf2-atmvj) -------------------------
+;;
+;; Pre-rf2-8otin the walker materialised the whole canonical form as a
+;; nested `(str ...)` of `clojure.string/join` results, then handed the
+;; finished string to `fnv-1a-32` which walked the UTF-8 bytes a second
+;; time. Two passes plus a tree-shaped tower of intermediate strings.
+;;
+;; The new shape is single-pass: a mutually-recursive walker
+;; (`canonical-edn-into`) appends each canonical fragment into a
+;; per-call `StringBuilder` on JVM / mutable JS string accumulator on
+;; CLJS. The accumulated string is then byte-hashed once. The output
+;; (the parity-pinned canonical literal at every fixture in
+;; `re-frame.ssr.hash-parity-fixtures`) is byte-identical to the old
+;; walker — only the allocation profile changes.
+;;
+;; `canonical-edn` (string-returning) is retained as the public surface
+;; for tests + the JVM↔CLJS parity fixtures that pin the canonical-EDN
+;; literal directly; it now delegates to the same builder-driven walker.
+
+(declare canonical-edn-into)
+
+(defn- ^:private append-children!
+  "Append canonical-EDN of each non-nil child of `xs` into `sb`,
+  separated by `sep`. Maps with nil values and sequential children
+  that are nil are pruned at the parent per Spec 011 §Hydration-mismatch
+  detection."
+  [sb xs sep]
+  (loop [xs    (seq xs)
+         first? true]
+    (when xs
+      (let [x (first xs)]
+        (if (nil? x)
+          (recur (next xs) first?)
+          (do
+            (when-not first?
+              #?(:clj (.append ^StringBuilder sb ^String sep)
+                 :cljs (.push sb sep)))
+            (canonical-edn-into sb x)
+            (recur (next xs) false)))))))
+
+(defn- ^:private member-canonical
+  "Render one set/seq member's canonical form to a fresh accumulator.
+  Used for the set branch where members must be lexicographically
+  sorted by their canonical form before appending. Returns nil for
+  nil so the caller can `keep`-prune."
+  [x]
+  (when-not (nil? x)
+    #?(:clj
+       (let [sb (StringBuilder.)]
+         (canonical-edn-into sb x)
+         (.toString sb))
+       :cljs
+       (let [sb (array)]
+         (canonical-edn-into sb x)
+         (.join sb "")))))
+
+(defn- ^:private append-sorted-set!
+  "Sets: emit `#{` + sorted-by-canonical-EDN members + `}`. Members can
+  be heterogeneous, so we materialise per-member canonical forms,
+  sort the strings, then append. The set branch is the only place
+  intermediate strings remain — sets need a comparator, and string
+  comparison is the spec-stable one across both runtimes."
+  [sb s]
+  (let [items (->> s (keep member-canonical) sort)]
+    #?(:clj
+       (do (.append ^StringBuilder sb "#{")
+           (loop [items (seq items) first? true]
+             (when items
+               (when-not first? (.append ^StringBuilder sb \space))
+               (.append ^StringBuilder sb ^String (first items))
+               (recur (next items) false)))
+           (.append ^StringBuilder sb \}))
+       :cljs
+       (do (.push sb "#{")
+           (loop [items (seq items) first? true]
+             (when items
+               (when-not first? (.push sb " "))
+               (.push sb (first items))
+               (recur (next items) false)))
+           (.push sb "}")))))
+
+(defn- ^:private append-map!
+  "Maps: emit `{` + sorted key-value pairs (`key value`, comma-joined) + `}`.
+  Nil-valued entries pruned per Spec 011 §Hydration-mismatch detection."
+  [sb m]
+  (let [entries (->> m
+                     (remove (comp nil? val))
+                     (sort-by (comp str key)))]
+    #?(:clj  (.append ^StringBuilder sb \{)
+       :cljs (.push sb "{"))
+    (loop [es (seq entries) first? true]
+      (when es
+        (when-not first?
+          #?(:clj  (.append ^StringBuilder sb \,)
+             :cljs (.push sb ",")))
+        (let [[k v] (first es)]
+          (canonical-edn-into sb k)
+          #?(:clj  (.append ^StringBuilder sb \space)
+             :cljs (.push sb " "))
+          (canonical-edn-into sb v))
+        (recur (next es) false)))
+    #?(:clj  (.append ^StringBuilder sb \})
+       :cljs (.push sb "}"))))
+
+(defn canonical-edn-into
+  "Streaming canonical-EDN walker (rf2-8otin). Appends the canonical
+  serialisation of `x` into the accumulator `sb` — a `StringBuilder`
+  on JVM, a JS array on CLJS. Returns `sb`. Nil scalars are pruned at
+  the parent (this fn no-ops on nil; callers walking a collection use
+  `append-children!` which skips nil children).
+
+  Output is byte-identical to (the now-thin) `canonical-edn`; the
+  parity-pinned literals at `re-frame.ssr.hash-parity-fixtures` are
+  the cross-runtime contract."
+  [sb x]
+  (cond
+    (nil? x) sb                                     ;; pruned at parent
+
+    (map? x)
+    (do (append-map! sb x) sb)
+
+    (vector? x)
+    (do #?(:clj  (.append ^StringBuilder sb \[)
+           :cljs (.push sb "["))
+        (append-children! sb x " ")
+        #?(:clj  (.append ^StringBuilder sb \])
+           :cljs (.push sb "]"))
+        sb)
+
+    (sequential? x)
+    (do #?(:clj  (.append ^StringBuilder sb \()
+           :cljs (.push sb "("))
+        (append-children! sb x " ")
+        #?(:clj  (.append ^StringBuilder sb \))
+           :cljs (.push sb ")"))
+        sb)
+
+    (set? x)
+    (do (append-sorted-set! sb x) sb)
+
+    (fn? x)
+    (do #?(:clj  (.append ^StringBuilder sb "#fn[")
+           :cljs (.push sb "#fn["))
+        #?(:clj  (.append ^StringBuilder sb ^String (.toString ^Object x))
+           :cljs (.push sb (.toString x)))
+        #?(:clj  (.append ^StringBuilder sb \])
+           :cljs (.push sb "]"))
+        sb)
+
+    :else
+    (do #?(:clj  (.append ^StringBuilder sb ^String (pr-str x))
+           :cljs (.push sb (pr-str x)))
+        sb)))
+
 (defn canonical-edn
   "Print a render-tree node in a stable order. Maps are sorted by key
   string; sequences keep order. Functions and var-references appear
@@ -31,36 +185,21 @@
   pruning the server emits `{:class nil}` while the client emits `{}`
   (the common `{:class (when condition? :selected)}` shape), producing
   spurious `:rf.ssr/hydration-mismatch` traces. Returns nil for nil
-  input so the parent collection's `keep` / `remove` step prunes it."
+  input so the parent collection's `keep` / `remove` step prunes it.
+
+  Post rf2-8otin this delegates to `canonical-edn-into` with a fresh
+  accumulator — the public surface is unchanged but the production
+  hash path skips this allocation entirely (see `render-tree-hash`)."
   [x]
-  (cond
-    (nil? x) nil                                    ;; pruned at parent
-
-    (map? x)
-    (str "{"
-         (clojure.string/join
-           ","
-           (->> x
-                (remove (comp nil? val))
-                (sort-by (comp str key))
-                (map (fn [[k v]] (str (canonical-edn k) " " (canonical-edn v))))))
-         "}")
-
-    (vector? x)
-    (str "[" (clojure.string/join " " (keep canonical-edn x)) "]")
-
-    (sequential? x)
-    (str "(" (clojure.string/join " " (keep canonical-edn x)) ")")
-
-    (set? x)
-    (str "#{"
-         (clojure.string/join " " (sort (keep canonical-edn x)))
-         "}")
-
-    (fn? x)
-    (str "#fn[" (.toString ^Object x) "]")
-
-    :else (pr-str x)))
+  (when-not (nil? x)
+    #?(:clj
+       (let [sb (StringBuilder.)]
+         (canonical-edn-into sb x)
+         (.toString sb))
+       :cljs
+       (let [sb (array)]
+         (canonical-edn-into sb x)
+         (.join sb "")))))
 
 ;; Per rf2-t7ktb: FNV-1a runs over a UTF-8 byte stream on BOTH sides.
 ;; Why UTF-8 bytes, not UTF-16 code units?
@@ -120,6 +259,22 @@
 (defn render-tree-hash
   "Per Spec 011 §Hydration-mismatch detection: a stable structural hash
   of the render tree. Deterministic across JVM and CLJS for trees with
-  identical canonical-EDN representation."
+  identical canonical-EDN representation.
+
+  Single-pass (rf2-8otin) — feeds the canonical-EDN walker into one
+  accumulator and byte-hashes the result once. Pre-rf2-8otin
+  `canonical-edn` materialised a tree-shaped tower of intermediate
+  strings (one per nesting level from the inner `(str ...)` /
+  `clojure.string/join` calls) before `fnv-1a-32` walked the bytes;
+  the streaming walker eliminates those intermediates while preserving
+  byte-identical output (the parity-pinned literals at
+  `re-frame.ssr.hash-parity-fixtures` are the cross-runtime contract)."
   [render-tree]
-  (fnv-1a-32 (canonical-edn render-tree)))
+  #?(:clj
+     (let [sb (StringBuilder.)]
+       (canonical-edn-into sb render-tree)
+       (fnv-1a-32 (.toString sb)))
+     :cljs
+     (let [sb (array)]
+       (canonical-edn-into sb render-tree)
+       (fnv-1a-32 (.join sb "")))))


### PR DESCRIPTION
## Summary

Batched cluster across `implementation/ssr/` + `implementation/ssr-ring/`. The headline perf win is the **SSR hash pipeline collapse from 4 full tree walks per default-HTML request down to 1**:

| Layer | Before | After |
|---|---|---|
| `canonical-edn` → string materialisation | 1 walk + N intermediate strings | 1 walk into 1 accumulator |
| `fnv-1a-32` over UTF-8 bytes | 1 walk | 1 walk (unchanged) |
| `render-to-string` internal `:emit-hash?` | 1 hash walk | reuses caller's hash |
| `pipeline.clj` `render-tree-hash` for payload | 1 walk | 1 walk (the only one) |
| **Total per request (emit-hash on)** | **4 tree walks** | **2 tree walks** (1 hash + 1 emit) |

Plus three smaller wins: single-pass header build with content-type defaulting; dev-mode CSP-host allowlist warning for `:body-end`; and the parent audit slice closed.

## Beads landed (6)

- `rf2-8otin` (P3) — single-pass `render-tree-hash` via streaming walker. Output byte-identical against the 19-fixture cross-runtime parity corpus.
- `rf2-atmvj` (P3) + `rf2-i15nh` (P3) — thread pre-computed hash through `render-to-string` via new `:render-hash` opt. Eliminates the duplicate hash pass in the ssr-ring pipeline. Spec 011's hash/emit separation preserved (no combined walker).
- `rf2-uj9z8` (P3) — `headers->ring-map+default-content-type` folds + defaults in one pass; pipeline drops `ensure-content-type` from the hot path (the pure helper is retained for its rf2-depii regression coverage).
- `rf2-2n5gg` (P3 bug) — dev-mode `:rf.ssr/csp-allowlist-violation` warning when `:body-end` carries a `<script src=...>` whose host isn't in `:csp-script-src-allowlist`. Debug-gated; opt-in via the new opt.
- `rf2-6dkej` (P1 audit) — parent slice bead. Last child closed by this PR.

## Beads deferred / superseded

- `rf2-f1h2c` (P1) — superseded by `rf2-h2ujj` (closed); the shell already honours `:html-attrs` / `:body-attrs` and tests are present at `default-shell-stamps-html-attrs-and-body-attrs` et al.
- `rf2-bof8i`, `rf2-zfm8v` — decision-flagged, parked for Mike per task scope.

## Quality gates

- `npm run test:cljs` — 1857 tests / 5252 assertions, 0 failures.
- `cd implementation/ssr && clojure -M:test` — 104 tests / 341 assertions, 0 failures. Parity corpus pinned literals all pass byte-identical against the streaming walker.
- `cd implementation/ssr-ring && clojure -M:test` — 34 tests / 154 assertions (5 new rf2-2n5gg tests), 0 failures.
- `npm run test:examples` — all examples pass including SSR (hydration).
- `npm run test:elision` — all sentinels collapse correctly.
- `test:perf-bundle` / `test:bundle-isolation` — pre-existing failures on main, unrelated to this PR.

## LoC delta

`+449 / -65` across 6 files.

## Test plan

- [ ] CI green on Linux + macOS workflows
- [ ] No drift on the JVM↔CLJS hash-parity corpus (the 19 pinned literals + nil-prune-pair literals)
- [ ] SSR-ring `ensure-content-type` rf2-depii case-insensitivity regression still passes (unit-tested in isolation)
- [ ] `default-html-shell` `:html-attrs` / `:body-attrs` rf2-h2ujj coverage still passes