### PR TITLE
refactor+perf(http): batched cluster — 5 follow-on beads (incl. rf2-r40km cors decision)

### DIFF
--- a/implementation/http/deps.edn
+++ b/implementation/http/deps.edn
@@ -35,7 +35,17 @@
 ;; re-exports) flow through `re-frame.late-bind` exactly as the
 ;; schemas / machines / routing / flows hooks already do.
 {:paths ["src"]
- :deps  {day8/re-frame2 {:local/root "../core"}}
+ :deps  {day8/re-frame2 {:local/root "../core"}
+         ;; rf2-dgsu1 — Cheshire is a hard JVM dependency. Spec 014's
+         ;; managed-HTTP slice issues JSON request bodies and decodes
+         ;; JSON responses; on JVM we use Cheshire for both. Earlier
+         ;; the slice resolved Cheshire via `requiring-resolve` and
+         ;; fell back to a hand-rolled pure-Clojure JSON reader/writer
+         ;; — slow path, no warning, no signal that the operator was
+         ;; running on the fallback indefinitely. Per pre-alpha
+         ;; posture: ship one path, the fast path. CLJS uses the
+         ;; browser `JSON` builtin and ignores this dep.
+         cheshire/cheshire {:mvn/version "5.13.0"}}
 
  :aliases
  {:test {:extra-paths ["test"]

--- a/implementation/http/src/re_frame/http_handlers.cljc
+++ b/implementation/http/src/re_frame/http_handlers.cljc
@@ -108,19 +108,35 @@
   ctx `{:request :args :frame :event}`; the runtime threads its return
   value through the rest of the chain. A throw inside any `:before`
   classifies as `:rf.error/http-interceptor-failed`; the request is
-  not dispatched."
+  not dispatched.
+
+  Per rf2-1jcpm — the `:sensitive?` flag is resolved BEFORE the
+  middleware runs and BEFORE `check-cljs-only-keys!` fires, so every
+  warning-/error-path trace that carries a request URL can redact
+  through the privacy composer rather than leaking secrets. The
+  same flag is then re-stamped onto the normalised ctx so the
+  attempt loop in `http-transport` sees a single resolved value."
   [frame-ctx args-map]
-  (transport/check-cljs-only-keys! args-map)
   (let [frame-id     (or (:frame frame-ctx) :rf/default)
         ;; rf2-622e3 — resolve once, thread the result through
         ;; frame-ctx's :event slot so normalise-args reads it
         ;; directly instead of re-running the OR-chain.
         origin-event (encoding/resolve-origin-event frame-ctx args-map)
         frame-ctx'   (assoc frame-ctx :event origin-event)
-        ctx0         {:request (:request args-map)
-                      :args    args-map
-                      :frame   frame-id
-                      :event   origin-event}
+        ;; rf2-1jcpm — resolve :sensitive? once at handler entry so
+        ;; the middleware-failure trace path (URL leak via
+        ;; `:rf.error/http-interceptor-failed`) and the JVM CLJS-only
+        ;; warning path (`:rf.http/cljs-only-key-ignored-on-jvm`) both
+        ;; redact through the privacy composer. `normalise-args` then
+        ;; re-derives the same flag from `args-map` — the values agree
+        ;; by construction.
+        sensitive?   (privacy/request-sensitive? args-map origin-event)
+        _            (transport/check-cljs-only-keys! args-map sensitive?)
+        ctx0         {:request    (:request args-map)
+                      :args       args-map
+                      :frame      frame-id
+                      :event      origin-event
+                      :sensitive? sensitive?}
         ctx          (middleware/run-interceptor-chain! frame-id ctx0)
         args-map'    (assoc args-map :request (:request ctx))
         normalised   (normalise-args args-map' frame-ctx')

--- a/implementation/http/src/re_frame/http_middleware.cljc
+++ b/implementation/http/src/re_frame/http_middleware.cljc
@@ -25,8 +25,9 @@
   mirroring the `re-frame.flows/flows` pattern. Frame-scoped: an
   interceptor registered against frame A does not fire for a request
   dispatched from frame B."
-  (:require [re-frame.interop :as interop]
-            [re-frame.trace   :as trace]))
+  (:require [re-frame.http-privacy :as privacy]
+            [re-frame.interop      :as interop]
+            [re-frame.trace        :as trace]))
 
 (defonce
   ^{:doc "frame-id → vector of {:id :before} interceptor maps. Per-frame
@@ -120,9 +121,18 @@
 (defn run-interceptor-chain!
   "Walk the registration-order interceptor chain for `frame-id`, threading
   `ctx` through each `:before`. Returns the final ctx, or throws
-  `:rf.error/http-interceptor-failed` if any `:before` throws."
+  `:rf.error/http-interceptor-failed` if any `:before` throws.
+
+  `ctx` carries a top-level `:sensitive?` flag (resolved by
+  `managed-handler` from per-call args + handler-registration metadata)
+  so the failure-path trace event redacts the request URL via the
+  query-param denylist before it reaches the trace surface. Without
+  this gate, an `Authorization`-token-bearing query string (e.g.
+  `?access_token=…`) leaked into traces whenever an interceptor
+  threw — rf2-1jcpm (round-2 security audit finding 1)."
   [frame-id ctx]
-  (let [chain (get @interceptors frame-id)]
+  (let [chain (get @interceptors frame-id)
+        sensitive? (true? (:sensitive? ctx))]
     (reduce
       (fn [acc {:keys [id before]}]
         (if before
@@ -142,8 +152,15 @@
                                    :cause    #?(:clj  (.getMessage ^Throwable t)
                                                 :cljs (.-message t))})]
                 (when interop/debug-enabled?
+                  ;; rf2-1jcpm — route through the privacy composer so a
+                  ;; denylisted query param (`?api_key=…`) is scrubbed
+                  ;; and `:sensitive?` is stamped on the trace event when
+                  ;; either the handler/per-call sensitivity OR the URL's
+                  ;; query string carries a denylisted param name.
                   (trace/emit-error! :rf.error/http-interceptor-failed
-                                     (ex-data data)))
+                                     (privacy/prepare-emit-failure
+                                       (ex-data data)
+                                       sensitive?)))
                 (throw data))))
           acc))
       ctx

--- a/implementation/http/src/re_frame/http_privacy_headers.cljc
+++ b/implementation/http/src/re_frame/http_privacy_headers.cljc
@@ -78,12 +78,22 @@
   nil)
 
 (defn sensitive-header?
-  "Predicate: is `header-name` in the merged denylist? Case-insensitive."
+  "Predicate: is `header-name` in the merged denylist? Case-insensitive.
+
+  Per rf2-ydp66 — the predicate short-circuits via two `contains?` lookups
+  on the source sets rather than building a fresh `(set/union default
+  @extras)` per call. `redact-headers` calls this once per header
+  (`reduce-kv` over the request's headers map); the previous shape ran
+  one `set/union` PER header. With trace/privacy permanently on under
+  JVM (`interop/debug-enabled?` is constant `true` there), the merged-set
+  rebuild compounded across every traced HTTP request. Two `contains?`
+  ops on small sets are O(1) and allocate nothing."
   [header-name]
   (boolean
     (when (string? header-name)
-      (contains? (set/union default-header-denylist @extra-headers)
-                 (str/lower-case header-name)))))
+      (let [k (str/lower-case header-name)]
+        (or (contains? default-header-denylist k)
+            (contains? @extra-headers k))))))
 
 (defn redact-headers
   "Walk `headers-map` (string→string or string→vector-of-strings); replace

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -128,21 +128,88 @@
        promise)))
 
 #?(:cljs
+   (defn- cross-origin?
+     "Heuristic: is `url` cross-origin relative to the current page?
+     Returns `false` for same-origin URLs, relative URLs (no scheme/host),
+     `data:`/`blob:`/`file:` schemes, and any URL the host can't parse.
+     The conservative path returns `false` so we never misclassify a
+     same-origin Fetch failure as CORS.
+
+     `js/location.origin` is the comparison base in browser hosts; on
+     non-browser CLJS targets (Node / shadow-cljs node tests) the global
+     is absent and we return `false`."
+     [^String url]
+     (try
+       (let [loc-origin (some-> js/globalThis
+                                (aget "location")
+                                (aget "origin"))]
+         (cond
+           (nil? url)        false
+           (nil? loc-origin) false
+           ;; Relative URLs are always same-origin.
+           (or (str/starts-with? url "/")
+               (str/starts-with? url "?")
+               (str/starts-with? url "#"))           false
+           ;; data:/blob:/file: schemes are not http(s) origins; treat
+           ;; as not-cross-origin (transport errors there are not CORS).
+           (or (str/starts-with? url "data:")
+               (str/starts-with? url "blob:")
+               (str/starts-with? url "file:"))       false
+           :else
+           (let [parsed (js/URL. url)
+                 origin (.-origin parsed)]
+             (and (string? origin)
+                  (not= origin loc-origin)))))
+       (catch :default _ false))))
+
+#?(:cljs
    (defn- classify-cljs-error
-     "Map a Fetch rejection / promise-error to a `:rf.http/*` failure shape."
-     [^js err]
-     (let [data (when (.-data err) (ex-data err))]
+     "Map a Fetch rejection / promise-error to a `:rf.http/*` failure shape.
+
+     Per rf2-r40km (Spec 014 §Failure categories closed-set row
+     `:rf.http/cors`): the Fetch API gives no formal signal for a CORS
+     rejection — every CORS failure surfaces as a `TypeError` with a
+     vendor-specific message (`Failed to fetch`, `Load failed`,
+     `NetworkError when attempting to fetch resource`, …). We use a
+     conservative heuristic: a `TypeError`-shaped rejection against a
+     cross-origin URL classifies as `:rf.http/cors`; everything else
+     stays at `:rf.http/transport`. Same-origin transport errors and
+     non-`TypeError` rejections are never reclassified, so a real
+     network drop on a same-origin endpoint still classifies correctly
+     as `:rf.http/transport`.
+
+     CLJS-only — the JVM transport (`classify-jvm-error`) never emits
+     `:rf.http/cors` per Spec 014 (CORS is a browser-policy concern)."
+     [^js err url]
+     (let [data     (when (.-data err) (ex-data err))
+           ;; `.-name` on a JS Error is the most stable signal we get
+           ;; for the rejection class. Fetch CORS rejections are always
+           ;; `TypeError`s; AbortErrors and rf2-bma05 ex-infos take
+           ;; their own branches above.
+           err-name (some-> err .-name)]
        (cond
          (:rf.http/timeout? data)
          {:kind       :rf.http/timeout
           :elapsed-ms (:elapsed-ms data)
           :limit-ms   (:limit-ms data)}
 
-         (or (= "AbortError" (.-name err))
+         (or (= "AbortError" err-name)
              (:rf.http/aborted? data))
          {:kind       :rf.http/aborted
           :request-id (:request-id data)
           :reason     (or (:reason data) :user)}
+
+         ;; rf2-r40km — TypeError + cross-origin URL = CORS rejection.
+         ;; Both signals required: the type narrows the universe to
+         ;; Fetch-style transport rejections (network drops surface as
+         ;; TypeErrors too), the cross-origin check separates CORS-
+         ;; eligible URLs from same-origin ones (where CORS doesn't
+         ;; apply by definition).
+         (and (= "TypeError" err-name)
+              (cross-origin? url))
+         {:kind    :rf.http/cors
+          :message (or (.-message err) (str err))
+          :url     url}
 
          :else
          {:kind    :rf.http/transport
@@ -550,8 +617,11 @@
                         :abort-signal        abort-signal
                         :internal-controller internal-controller})
            (.then (fn [result] (handle-response! ctx' result)))
+           ;; rf2-r40km — pass `url` so `classify-cljs-error` can
+           ;; distinguish `:rf.http/cors` from `:rf.http/transport`
+           ;; via the cross-origin heuristic.
            (.catch (fn [err]
-                     (maybe-retry! ctx' (classify-cljs-error err)))))
+                     (maybe-retry! ctx' (classify-cljs-error err url)))))
        :clj
        (try
          (let [^CompletableFuture cf

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -50,7 +50,21 @@
    (defn- cljs-fetch
      "Issue a single HTTP attempt via Fetch. Returns a Promise that resolves
      to `{:ok? bool :status N :status-text S :headers M :body-text S}` on
-     transport-OK, or rejects with an ex-info classified by the caller."
+     transport-OK, or rejects with an ex-info classified by the caller.
+
+     Per rf2-1jcpm — the per-attempt timeout fires regardless of whether
+     the caller supplied `:abort-signal`. We always own
+     `internal-controller`; when the caller also supplies `:abort-signal`,
+     its `abort` event is forwarded to our controller, so:
+
+     - the caller can still cancel via their own signal, AND
+     - the timeout still arms (previously the timeout was silently
+       disabled the moment a caller signal arrived, even when the args
+       map carried a `:timeout-ms` and/or the security default — round-2
+       security audit finding 2).
+
+     The single `signal` Fetch accepts is always our internal one; any
+     caller signal funnels through `addEventListener` for cancellation."
      [{:keys [method url headers body credentials mode redirect cache referrer
               integrity timeout-ms abort-signal internal-controller]}]
      (let [init     #js {}
@@ -66,9 +80,24 @@
                         (when cache        (aset init "cache"       (name cache)))
                         (when referrer     (aset init "referrer"    referrer))
                         (when integrity    (aset init "integrity"   integrity))
-                        (cond
-                          abort-signal        (aset init "signal" abort-signal)
-                          internal-controller (aset init "signal" (.-signal internal-controller))))
+                        (when internal-controller
+                          (aset init "signal" (.-signal internal-controller)))
+                        ;; rf2-1jcpm — forward caller's abort-signal into
+                        ;; our internal controller so the timeout still
+                        ;; fires when a caller signal is present.
+                        (when (and abort-signal internal-controller)
+                          (if (.-aborted abort-signal)
+                            (try (.abort internal-controller
+                                         (or (.-reason abort-signal) "caller-aborted"))
+                                 (catch :default _ nil))
+                            (.addEventListener
+                              abort-signal
+                              "abort"
+                              (fn []
+                                (try (.abort internal-controller
+                                             (or (.-reason abort-signal) "caller-aborted"))
+                                     (catch :default _ nil)))
+                              #js {:once true}))))
            timeout-handle (atom nil)
            timeout-fired? (atom false)
            promise
@@ -130,7 +159,7 @@
 
 #?(:clj
    (defn- jvm-build-request
-     [{:keys [method url headers body timeout-ms]}]
+     [{:keys [method url headers body timeout-ms sensitive?]}]
      (let [b (HttpRequest/newBuilder (URI/create url))
            publisher (cond
                        (nil? body) (HttpRequest$BodyPublishers/noBody)
@@ -150,13 +179,22 @@
          ;; error" anti-pattern. The request still proceeds without
          ;; the offending header so a stray bad header doesn't sink
          ;; an otherwise-valid request; the trace is the alarm.
+         ;;
+         ;; rf2-1jcpm — the `:url` slot on the warning event is routed
+         ;; through `privacy/prepare-emit-tags` so a denylisted query
+         ;; param (`?api_key=…`) is scrubbed and `:sensitive?` is
+         ;; stamped when the request is sensitive. Previously the raw
+         ;; URL rode the trace surface even when the handler / request
+         ;; was declared sensitive.
          (try (.header b (str k) (str v))
               (catch Throwable t
                 (when interop/debug-enabled?
                   (trace/emit! :warning :rf.warning/http-header-invalid
-                               {:url     url
-                                :header  (str k)
-                                :cause   (.getMessage t)})))))
+                               (privacy/prepare-emit-tags
+                                 {:url     url
+                                  :header  (str k)
+                                  :cause   (.getMessage t)}
+                                 (true? sensitive?)))))))
        (.build b))))
 
 #?(:clj
@@ -180,7 +218,10 @@
    (defn- jvm-fetch
      "Issue a single HTTP attempt via java.net.http.HttpClient. Returns a
      CompletableFuture that completes with `{:ok? :status :status-text
-     :headers :body-text}` or completes-exceptionally with an ex-info."
+     :headers :body-text}` or completes-exceptionally with an ex-info.
+
+     `opts` carries `:sensitive?` so `jvm-build-request` can route any
+     header-validation warning through the privacy composer (rf2-1jcpm)."
      [opts]
      (let [client ^HttpClient @jvm-http-client
            req    (jvm-build-request opts)
@@ -217,26 +258,32 @@
 ;; ---- per-row CLJS-only-key tracing on JVM ---------------------------------
 
 #?(:clj
-   (defn- emit-cljs-only-skipped! [k url]
+   (defn- emit-cljs-only-skipped! [k url sensitive?]
      (when interop/debug-enabled?
+       ;; rf2-1jcpm — route through the privacy composer so a denylisted
+       ;; query param in the URL is scrubbed and `:sensitive?` is stamped
+       ;; on the warning event when the originating handler / request is
+       ;; sensitive. Previously the raw URL rode the trace surface.
        (trace/emit! :warning :rf.http/cljs-only-key-ignored-on-jvm
-                    {:key k :url url}))))
+                    (privacy/prepare-emit-tags
+                      {:key k :url url}
+                      (true? sensitive?))))))
 
 #?(:clj
-   (defn check-cljs-only-keys! [{:keys [request abort-signal]}]
+   (defn check-cljs-only-keys! [{:keys [request abort-signal]} sensitive?]
      (let [url (:url request)]
        (doseq [k [:mode :cache :referrer :integrity]]
          (when (contains? request k)
-           (emit-cljs-only-skipped! k url)))
+           (emit-cljs-only-skipped! k url sensitive?)))
        (when abort-signal
-         (emit-cljs-only-skipped! :abort-signal url)))))
+         (emit-cljs-only-skipped! :abort-signal url sensitive?)))))
 
 ;; A no-op JVM-only no-op stub on CLJS so callers can reach
 ;; `http-transport/check-cljs-only-keys!` unconditionally without
 ;; needing their own reader-conditional. The CLJS body would do nothing
 ;; — by definition CLJS-only keys are always honoured on CLJS.
 #?(:cljs
-   (defn check-cljs-only-keys! [_args] nil))
+   (defn check-cljs-only-keys! [_args _sensitive?] nil))
 
 ;; ---- shared attempt-and-retry loop ----------------------------------------
 
@@ -448,11 +495,13 @@
                    (and ct (nil? (decode/content-type-of (:headers request))))
                    (assoc "Content-Type" ct))
         ctx-no-handle (assoc ctx :url url)
-        ;; CLJS: an internal AbortController backs the Fetch signal when
-        ;; the caller didn't supply one. JVM: no per-attempt controller —
-        ;; abort signalling is host-specific and lives outside the
-        ;; sendAsync future.
-        #?@(:cljs [internal-controller (when-not abort-signal (js/AbortController.))])
+        ;; CLJS: per rf2-1jcpm always own an internal AbortController so
+        ;; the per-attempt timeout fires even when the caller supplied
+        ;; `:abort-signal`. `cljs-fetch` forwards the caller's signal into
+        ;; this controller via `addEventListener "abort"`. JVM: no per-
+        ;; attempt controller — abort signalling is host-specific and
+        ;; lives outside the sendAsync future.
+        #?@(:cljs [internal-controller (js/AbortController.)])
         ;; Register the abort handle. The handle ref is stamped into ctx
         ;; so finalise-* can clear it from both indexes without needing
         ;; the request-id (handles anonymous-from-actor requests too —
@@ -510,7 +559,8 @@
                            :url        url
                            :headers    headers
                            :body       enc-body
-                           :timeout-ms timeout-ms})]
+                           :timeout-ms timeout-ms
+                           :sensitive? (true? (:sensitive? ctx))})]
            (.whenComplete cf
                           (reify java.util.function.BiConsumer
                             (accept [_ result throwable]

--- a/implementation/http/src/re_frame/http_url.cljc
+++ b/implementation/http/src/re_frame/http_url.cljc
@@ -94,12 +94,19 @@
 
 (defn sensitive-query-param?
   "Predicate: is `param-name` in the merged query-param denylist?
-  Case-insensitive."
+  Case-insensitive.
+
+  Per rf2-ydp66 — short-circuits via two `contains?` lookups on the
+  source sets rather than building a fresh `(set/union default @extras)`
+  per call. The URL redactor calls this once per query-string param;
+  the previous shape rebuilt the merged set N times per URL. Two
+  `contains?` ops on small sets are O(1) and allocate nothing."
   [param-name]
   (boolean
     (when (string? param-name)
-      (contains? (set/union default-query-param-denylist @extra-query-params)
-                 (str/lower-case param-name)))))
+      (let [k (str/lower-case param-name)]
+        (or (contains? default-query-param-denylist k)
+            (contains? @extra-query-params k))))))
 
 ;; ---- URL query-string redaction (rf2-2p8wr) -------------------------------
 

--- a/implementation/http/src/re_frame/util_json.cljc
+++ b/implementation/http/src/re_frame/util_json.cljc
@@ -3,16 +3,15 @@
 
   Extracted from `re-frame.http-managed` per rf2-p7da. The decode path
   in `re-frame.http-encoding` needs a JSON reader; on CLJS that is the
-  browser's `js/JSON.parse`, on the JVM it is Cheshire when available
-  with a pure-Clojure fallback so the http artefact does not force a
-  Cheshire dependency.
+  browser's `js/JSON.parse`, on the JVM it is Cheshire (a hard dep
+  since rf2-dgsu1 — see the artefact's `deps.edn` for the rationale).
 
   ## Why this lives in the http artefact for now
 
   The reader is only used by the decode pipeline. Re-frame core has no
   business reading JSON. Keeping it in the http artefact (rather than
   promoting it to `day8/re-frame2`) avoids dragging the
-  `json-stringify` / `json-read*` codepaths onto core consumers that
+  `json-stringify` / `json-parse` codepaths onto core consumers that
   never issue an HTTP request. If a second consumer needs JSON down the
   track, lift this namespace to core (the ns name is already neutral —
   `re-frame.util-json`, not `re-frame.http.util-json`).
@@ -20,12 +19,9 @@
   ## API
 
   - `json-stringify` — Clojure → JSON string. Uses Cheshire's
-    `generate-string` on JVM if it's on the classpath, otherwise
-    falls back to `pr-str` (good enough for the request bodies the
-    `:rf.http/managed` fx emits). CLJS uses `js/JSON.stringify`.
+    `generate-string` on JVM; CLJS uses `js/JSON.stringify`.
   - `json-parse`     — string → Clojure data with keyword keys for
-    objects. Uses Cheshire's `parse-string` on JVM if available,
-    otherwise the pure-Clojure fallback below; CLJS uses
+    objects. Uses Cheshire's `parse-string` on JVM; CLJS uses
     `js/JSON.parse` + `js->clj :keywordize-keys true`. Accepts an
     optional `opts` map (`:max-decoded-keys` — per rf2-wu1n5).
 
@@ -35,13 +31,13 @@
   never GC'd. An attacker-controlled JSON response with N unique keys
   permanently burns N keyword slots — a long-running SSR JVM is the
   worst case. Both readers enforce a per-call cap on the number of
-  unique keys decoded (default `*default-max-decoded-keys*` = 10000;
+  unique keys decoded (default `default-max-decoded-keys` = 10000;
   overridable per request via `(json-parse s {:max-decoded-keys N})`).
   Overflow throws `:rf.error/malformed-json :reason :too-many-keys` —
   the `:rf.http/managed` cascade classifies this as
   `:rf.http/decode-failure`."
-  #?(:clj  (:require [clojure.string :as str])
-     :cljs (:require [clojure.string :as str])))
+  #?(:clj  (:require [cheshire.core :as cheshire])
+     :cljs (:require)))
 
 (def ^:const default-max-decoded-keys
   "Default cap on the number of unique object keys a single `json-parse`
@@ -51,196 +47,16 @@
   enough to bound an attacker-controlled payload."
   10000)
 
-#?(:clj
-   (defn- json-read*
-     "Tiny pure-Clojure JSON reader. Returns Clojure data with keyword
-     keys for objects. Sufficient for the on-the-wire shapes :rf.http/managed
-     decodes; not a full RFC-8259 parser. Used only when Cheshire isn't
-     on the classpath.
-
-     Each helper returns [value next-p]: the cursor is threaded through
-     return values rather than carried in a mutable atom.
-
-     `max-keys` (rf2-wu1n5) caps the number of unique object keys
-     decoded across the whole call. The fallback reader tracks distinct
-     keys in a HashSet stamped onto a closure-local `seen-keys` atom;
-     on overflow the reader throws
-     `:rf.error/malformed-json :reason :too-many-keys` so the
-     `:rf.http/managed` cascade can classify as
-     `:rf.http/decode-failure`."
-     [^String s max-keys]
-     (let [n          (count s)
-           seen-keys  (java.util.HashSet.)
-           note-key!  (fn [k]
-                        (when-not (.contains seen-keys k)
-                          (.add seen-keys k)
-                          (when (> (.size seen-keys) (long max-keys))
-                            (throw (ex-info "json: too many unique keys"
-                                            {:kind   :rf.error/malformed-json
-                                             :reason :too-many-keys
-                                             :limit  max-keys})))))
-           peek-c   (fn [p] (when (< p n) (.charAt s p)))
-           skip-ws  (fn [p]
-                      (loop [p p]
-                        (let [c (peek-c p)]
-                          (if (and c (Character/isWhitespace ^char c))
-                            (recur (inc p))
-                            p))))]
-       (letfn [(read-string-lit [p]
-                 ;; p points at opening ".
-                 (loop [p  (inc p)
-                        sb (StringBuilder.)]
-                   (let [c (peek-c p)]
-                     (cond
-                       (nil? c)  (throw (ex-info "unterminated string" {}))
-                       (= c \")  [(.toString sb) (inc p)]
-                       (= c \\)
-                       (let [esc (peek-c (inc p))]
-                         (case esc
-                           \u  (let [hex-start (+ p 2)
-                                     hex-end   (+ p 6)]
-                                 ;; rf2-263km — bounds-check + hex-digit
-                                 ;; check before parseInt. A `\u` escape
-                                 ;; near EOF would otherwise raise
-                                 ;; StringIndexOutOfBoundsException, and a
-                                 ;; non-hex char (e.g. the closing quote
-                                 ;; falling inside the 4-char window) would
-                                 ;; raise NumberFormatException — both
-                                 ;; classified opaquely. Surface as a clean
-                                 ;; `:rf.error/malformed-json` instead so
-                                 ;; the failure-category cascade reports a
-                                 ;; tagged `:rf.http/decode-failure` rather
-                                 ;; than a host-runtime exception string.
-                                 (when (> hex-end n)
-                                   (throw (ex-info "truncated unicode escape"
-                                                   {:kind   :rf.error/malformed-json
-                                                    :reason :truncated-unicode-escape
-                                                    :at     p})))
-                                 (let [hex (subs s hex-start hex-end)]
-                                   (when-not (every? (fn [ch]
-                                                       (let [i (int ch)]
-                                                         (or (and (>= i (int \0)) (<= i (int \9)))
-                                                             (and (>= i (int \a)) (<= i (int \f)))
-                                                             (and (>= i (int \A)) (<= i (int \F))))))
-                                                     hex)
-                                     (throw (ex-info "invalid unicode escape"
-                                                     {:kind   :rf.error/malformed-json
-                                                      :reason :invalid-unicode-escape
-                                                      :hex    hex
-                                                      :at     p})))
-                                   (.append sb (char (Integer/parseInt hex 16)))
-                                   (recur hex-end sb)))
-                           (do (.append sb (case esc
-                                             \"  \"
-                                             \\ \\
-                                             \/ \/
-                                             \b \backspace
-                                             \f \formfeed
-                                             \n \newline
-                                             \r \return
-                                             \t \tab
-                                             esc))
-                               (recur (+ p 2) sb))))
-                       :else
-                       (do (.append sb c) (recur (inc p) sb))))))
-               (read-number [p]
-                 (let [end (loop [m p]
-                             (let [c (peek-c m)]
-                               (if (and c (or (Character/isDigit ^char c)
-                                              (#{\- \+ \. \e \E} c)))
-                                 (recur (inc m))
-                                 m)))
-                       t   (subs s p end)]
-                   [(if (or (.contains t ".") (.contains t "e") (.contains t "E"))
-                      (Double/parseDouble t)
-                      (Long/parseLong t))
-                    end]))
-               (read-keyword-tok [p]
-                 (cond
-                   (.startsWith (subs s p) "true")  [true  (+ p 4)]
-                   (.startsWith (subs s p) "false") [false (+ p 5)]
-                   (.startsWith (subs s p) "null")  [nil   (+ p 4)]
-                   :else (throw (ex-info "bad token" {:at p}))))
-               (read-array [p]
-                 (let [p (inc p)                    ;; consume [
-                       p (skip-ws p)]
-                   (if (= \] (peek-c p))
-                     [[] (inc p)]
-                     (loop [p   p
-                            acc []]
-                       (let [p          (skip-ws p)
-                             [v p]      (read-val p)
-                             p          (skip-ws p)
-                             c          (peek-c p)
-                             acc'       (conj acc v)]
-                         (cond
-                           (= c \,) (recur (inc p) acc')
-                           (= c \]) [acc' (inc p)]
-                           :else    (throw (ex-info "expected , or ]" {:at p}))))))))
-               (read-object [p]
-                 (let [p (inc p)                    ;; consume {
-                       p (skip-ws p)]
-                   (if (= \} (peek-c p))
-                     [{} (inc p)]
-                     (loop [p   p
-                            acc {}]
-                       (let [p         (skip-ws p)
-                             [k p]     (read-string-lit p)
-                             ;; rf2-wu1n5 — count BEFORE interning into a
-                             ;; keyword; the cap-throw runs the
-                             ;; HashSet#add then size-check inside
-                             ;; `note-key!`. Counting distinct strings
-                             ;; (not keywords) means an attacker can't
-                             ;; bypass by repeating the same key; each
-                             ;; unique string is one interned keyword.
-                             _         (note-key! k)
-                             p         (skip-ws p)
-                             _         (when (not= \: (peek-c p))
-                                         (throw (ex-info "expected :" {:at p})))
-                             p         (inc p)
-                             p         (skip-ws p)
-                             [v p]     (read-val p)
-                             p         (skip-ws p)
-                             c         (peek-c p)
-                             acc'      (assoc acc (keyword k) v)]
-                         (cond
-                           (= c \,) (recur (inc p) acc')
-                           (= c \}) [acc' (inc p)]
-                           :else    (throw (ex-info "expected , or }" {:at p}))))))))
-               (read-val [p]
-                 (let [p (skip-ws p)
-                       c (peek-c p)]
-                   (cond
-                     (= c \")  (read-string-lit p)
-                     (= c \{)  (read-object p)
-                     (= c \[)  (read-array p)
-                     (or (= c \-) (and c (Character/isDigit ^char c))) (read-number p)
-                     :else     (read-keyword-tok p))))]
-         (first (read-val (skip-ws 0)))))))
-
-;; Memoised Cheshire resolves (per rf2-tja2y). Cheshire's vars never
-;; rebind at runtime; resolving once per JVM is enough. The CLJS path
-;; uses the browser's `JSON` builtin and never needs a resolve.
-#?(:clj (defonce ^:private cheshire-generate-string (delay (try (requiring-resolve 'cheshire.core/generate-string)
-                                                                (catch Throwable _ nil)))))
-#?(:clj (defonce ^:private cheshire-parse-string    (delay (try (requiring-resolve 'cheshire.core/parse-string)
-                                                                (catch Throwable _ nil)))))
-
 (defn json-stringify
-  "Clojure value → JSON string. JVM uses Cheshire if available, else
-  falls back to `pr-str` (good enough for the request-body shapes
-  `:rf.http/managed` emits — primarily Clojure maps and vectors that
-  print as legal JSON-ish edn). CLJS uses `js/JSON.stringify`."
+  "Clojure value → JSON string. JVM uses Cheshire (`generate-string`);
+  CLJS uses `js/JSON.stringify`."
   [v]
-  #?(:clj  (if-let [write @cheshire-generate-string]
-             (write v)
-             (pr-str v))
+  #?(:clj  (cheshire/generate-string v)
      :cljs (js/JSON.stringify (clj->js v))))
 
 (defn json-parse
   "JSON string → Clojure data with keyword keys for object keys. JVM
-  uses Cheshire's `parse-string` if available, otherwise the pure-
-  Clojure reader above. On CLJS uses `js/JSON.parse` +
+  uses Cheshire's `parse-string`; CLJS uses `js/JSON.parse` +
   `js->clj :keywordize-keys true`.
 
   `opts` (optional) — currently a single key:
@@ -248,24 +64,16 @@
      Default: `default-max-decoded-keys`. Overflow throws
      `:rf.error/malformed-json :reason :too-many-keys`.
 
-  Per rf2-263km, the fallback reader's `:rf.error/malformed-json`
-  ex-info is propagated rather than swallowed — the previous
-  `(catch Throwable _ s)` masked malformed input as a string return,
-  which then surfaced as an opaque schema-validation failure
-  downstream. Surfacing the tagged ex-info lets the `:rf.http/managed`
-  cascade classify the response as `:rf.http/decode-failure` with a
-  precise `:cause` instead of a noisy schema rejection.
-
-  Per rf2-wu1n5, both branches (Cheshire and pure-Clojure fallback)
-  enforce the keyword-cap. The Cheshire branch installs a `:key-fn`
-  callback that counts distinct keys in a HashSet and throws on
-  overflow; the fallback reader threads the cap through `json-read*`."
+  Per rf2-wu1n5, both branches enforce the keyword-cap. The JVM
+  Cheshire branch installs a `:key-fn` callback that counts distinct
+  keys in a HashSet and throws on overflow; the CLJS branch walks the
+  parsed JS tree counting unique object-keys BEFORE
+  `js->clj :keywordize-keys true` interns them."
   ([s] (json-parse s nil))
   ([s opts]
    (let [max-keys (long (or (:max-decoded-keys opts) default-max-decoded-keys))]
-     #?(:clj  (cond
-                (some? @cheshire-parse-string)
-                (let [seen ^java.util.HashSet (java.util.HashSet.)
+     #?(:clj  (when (string? s)
+                (let [seen   ^java.util.HashSet (java.util.HashSet.)
                       key-fn (fn [k]
                                (when-not (.contains seen k)
                                  (.add seen k)
@@ -275,10 +83,7 @@
                                                     :reason :too-many-keys
                                                     :limit  max-keys}))))
                                (keyword k))]
-                  (@cheshire-parse-string s key-fn))
-
-                (string? s) (json-read* s max-keys)
-                :else       s)
+                  (cheshire/parse-string s key-fn)))
         :cljs (let [parsed (js/JSON.parse s)
                     ;; rf2-wu1n5 — CLJS path: walk the parsed JS object
                     ;; tree counting unique object-keys BEFORE

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -5,9 +5,18 @@
   smoke just confirms the helpers compile clean under CLJS (the file
   is `.cljc` with no host-specific bits, but a CLJS-side load is the
   fastest way to catch a regression that would otherwise only surface
-  in shadow-cljs builds)."
+  in shadow-cljs builds).
+
+  Also covers rf2-r40km — the CLJS-only `:rf.http/cors` classification
+  branch of `re-frame.http-transport/classify-cljs-error`."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.http :as rf.http]))
+            [re-frame.http :as rf.http]
+            [re-frame.http-transport :as transport]))
+
+;; Reach the private classifier via #' so the test doesn't widen the
+;; transport's public surface for one CLJS-only branch.
+(def ^:private classify-cljs-error
+  @#'transport/classify-cljs-error)
 
 (deftest get-helper-shape
   (testing "(rf.http/get url) produces [:rf.http/managed {:request {:method :get :url url}}]"
@@ -56,3 +65,61 @@
       (is (= [:loaded] (:on-success args)))
       (is (= [:errored] (:on-failure args)))
       (is (= :search (:request-id args))))))
+
+;; ---- rf2-r40km — :rf.http/cors retry-set membership ----------------------
+
+(deftest cors-is-a-valid-retry-on-member
+  (testing "rf2-r40km — `:rf.http/cors` is a valid member of `:retry :on`.
+  Audit finding 5.1: the retry-set membership contract is open to any
+  `:rf.http/*` failure kind; CORS is in the closed taxonomy and so
+  should compose cleanly with the helper arg path. A semantic decision
+  on whether to AUTO-retry CORS belongs to the caller (typically NO —
+  CORS is a config error, not transient — but a probing app may want
+  to)."
+    (let [retry {:on #{:rf.http/transport :rf.http/cors :rf.http/timeout}
+                 :max-attempts 2}
+          out   (rf.http/get "https://api.example.invalid/x"
+                             {:retry retry})]
+      (is (contains? (-> out second :retry :on) :rf.http/cors)
+          ":rf.http/cors threads through the helper unchanged"))))
+
+;; ---- rf2-r40km — classify-cljs-error CORS branch -------------------------
+
+(deftest classify-cors-typeerror-cross-origin
+  (testing "rf2-r40km — a TypeError on a cross-origin URL classifies as
+  `:rf.http/cors` per Spec 014 §Failure categories. The heuristic is
+  conservative: TypeError + parseable cross-origin URL = CORS; anything
+  else falls through to `:rf.http/transport`.
+
+  Note: this test only fires when `js/location.origin` is defined and
+  parseable (browser-host targets). In node-runtime CLJS tests where
+  the global is absent, the conservative path returns false and the
+  classifier stays at `:rf.http/transport` — that branch is exercised
+  by `classify-typeerror-relative-url-is-transport`."
+    (when (and (exists? js/globalThis)
+               (some-> js/globalThis (aget "location") (aget "origin")))
+      (let [err (js/TypeError. "Failed to fetch")
+            out (classify-cljs-error err "https://other.invalid/x?a=1")]
+        (is (= :rf.http/cors (:kind out))
+            "TypeError + cross-origin URL classifies as :rf.http/cors")
+        (is (= "https://other.invalid/x?a=1" (:url out))
+            ":url tag rides the failure shape (Spec 014 §Failure categories)")
+        (is (some? (:message out)) ":message tag rides the failure shape")))))
+
+(deftest classify-typeerror-relative-url-is-transport
+  (testing "rf2-r40km — a TypeError on a relative URL (always same-origin
+  by definition) stays at `:rf.http/transport`. The conservative path
+  must not misclassify a same-origin network drop as CORS."
+    (let [err (js/TypeError. "Failed to fetch")
+          out (classify-cljs-error err "/api/items")]
+      (is (= :rf.http/transport (:kind out))
+          "relative URL never classifies as CORS"))))
+
+(deftest classify-non-typeerror-stays-transport
+  (testing "rf2-r40km — a non-TypeError (e.g. a generic JS Error) on a
+  cross-origin URL still classifies as `:rf.http/transport`. CORS
+  rejections are always TypeErrors."
+    (let [err (js/Error. "connection-reset")
+          out (classify-cljs-error err "https://other.invalid/x")]
+      (is (= :rf.http/transport (:kind out))
+          "non-TypeError stays at :rf.http/transport regardless of URL"))))

--- a/implementation/http/test/re_frame/http_interceptors_test.clj
+++ b/implementation/http/test/re_frame/http_interceptors_test.clj
@@ -280,6 +280,45 @@
           (trace/remove-trace-cb! listener-id)
           (stop-server! srv))))))
 
+;; ---- 4a. rf2-1jcpm — interceptor-failure URL redaction --------------------
+
+(deftest interceptor-failure-trace-redacts-denylisted-query-params
+  (testing "rf2-1jcpm (round-2 security audit finding 1) — when a
+  `:before` throws, the `:rf.error/http-interceptor-failed` trace MUST
+  route the request URL through the privacy composer. Previously the
+  raw URL rode the trace surface, leaking any denylisted query param
+  (`?api_key=…`) into trace consumers."
+    (let [traces      (atom [])
+          listener-id (gensym "interceptor-redact-")]
+      (try
+        (trace/register-trace-cb! listener-id
+                                  (fn [ev] (swap! traces conj ev)))
+        (rf/reg-http-interceptor
+          {:id     :boom
+           :before (fn [_ctx]
+                     (throw (ex-info "kaboom" {:detail :synthetic})))})
+        (rf/reg-event-fx :load
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request {:url "https://api.example.invalid/v1?api_key=SECRET&page=2"}
+                    :decode  :json
+                    :on-success nil
+                    :on-failure nil}]]}))
+        (rf/dispatch-sync [:load])
+        (Thread/sleep 100)
+        (let [w (first (filter #(= :rf.error/http-interceptor-failed
+                                    (:operation %))
+                                @traces))]
+          (is (some? w) ":rf.error/http-interceptor-failed should be on the stream")
+          (let [tags (:tags w)]
+            (is (= "https://api.example.invalid/v1?api_key=:rf/redacted&page=2"
+                   (:url tags))
+                "denylisted query-param value MUST be scrubbed")
+            (is (true? (:sensitive? w))
+                ":sensitive? stamped on the trace (denylist hit = signal)")))
+        (finally
+          (trace/remove-trace-cb! listener-id))))))
+
 ;; ---- 5. clear-http-interceptor unregisters cleanly ------------------------
 
 (deftest clear-http-interceptor-unregisters

--- a/implementation/http/test/re_frame/http_transport_security_test.clj
+++ b/implementation/http/test/re_frame/http_transport_security_test.clj
@@ -163,3 +163,93 @@
                               {:event [:some/event]})]
       (is (zero? (:timeout-ms ctx))
           "zero opt-out threads through unchanged"))))
+
+;; ---- rf2-1jcpm — security audit round-2 regression coverage --------------
+
+(deftest invalid-header-warning-redacts-denylisted-query-params
+  (testing "rf2-1jcpm — when the request URL carries a denylisted query
+  param (`?api_key=…`), the JVM header-validation warning trace MUST
+  scrub the value and stamp `:sensitive?` on the event. The previous
+  shape leaked the secret because the trace bypassed
+  `privacy/prepare-emit-tags`."
+    (with-trace-capture
+      (fn [captured]
+        (let [_req (jvm-build-request
+                     {:method  :get
+                      :url     "https://example.invalid/v1?api_key=SECRET&page=2"
+                      :headers {"" "anything"}})
+              w    (first (filter #(= :rf.warning/http-header-invalid
+                                       (:operation %))
+                                  @captured))]
+          (is (some? w) "warning event should have been captured")
+          (let [tags (:tags w)]
+            (is (= "https://example.invalid/v1?api_key=:rf/redacted&page=2"
+                   (:url tags))
+                "denylisted query-param value MUST be scrubbed in trace URL")
+            (is (true? (:sensitive? w))
+                ":sensitive? MUST be stamped at top level — a denylisted
+                param name is itself a signal that the request carries
+                a secret (Spec 009 §Privacy)")))))))
+
+(deftest invalid-header-warning-redacts-on-sensitive-request
+  (testing "rf2-1jcpm — when the request is declared sensitive (handler
+  or per-call), ALL query-param values in the warning trace URL are
+  scrubbed (broader rule than the denylist)."
+    (with-trace-capture
+      (fn [captured]
+        (let [_req (jvm-build-request
+                     {:method     :get
+                      :url        "https://example.invalid/v1?q=foo&page=2"
+                      :headers    {"" "anything"}
+                      :sensitive? true})
+              w    (first (filter #(= :rf.warning/http-header-invalid
+                                       (:operation %))
+                                  @captured))]
+          (is (some? w))
+          (let [tags (:tags w)]
+            (is (= "https://example.invalid/v1?q=:rf/redacted&page=:rf/redacted"
+                   (:url tags))
+                "sensitive request scrubs EVERY param value")
+            (is (true? (:sensitive? w)))))))))
+
+;; ---- rf2-1jcpm — CLJS-only-key warning redaction (JVM) -------------------
+
+(def ^:private check-cljs-only-keys! @#'re-frame.http-transport/check-cljs-only-keys!)
+
+(deftest cljs-only-key-warning-redacts-denylisted-query-params
+  (testing "rf2-1jcpm — the JVM warning for an ignored CLJS-only key
+  (`:rf.http/cljs-only-key-ignored-on-jvm`) MUST redact denylisted
+  query params in `:url`. Previously the raw URL rode the warning."
+    (with-trace-capture
+      (fn [captured]
+        (check-cljs-only-keys!
+          {:request {:url  "https://example.invalid/v1?token=SECRET&page=2"
+                     :mode :cors}}
+          false)
+        (let [w (first (filter #(= :rf.http/cljs-only-key-ignored-on-jvm
+                                    (:operation %))
+                                @captured))]
+          (is (some? w) "expected the ignored-key warning to be emitted")
+          (let [tags (:tags w)]
+            (is (= "https://example.invalid/v1?token=:rf/redacted&page=2"
+                   (:url tags))
+                "denylisted query-param value MUST be scrubbed")
+            (is (true? (:sensitive? w))
+                ":sensitive? stamped (denylist hit alone is a signal)")))))))
+
+(deftest cljs-only-key-warning-redacts-on-sensitive-request
+  (testing "rf2-1jcpm — sensitive flag also scrubs every param value"
+    (with-trace-capture
+      (fn [captured]
+        (check-cljs-only-keys!
+          {:request {:url      "https://example.invalid/v1?q=foo&page=2"
+                     :referrer "https://internal/"}}
+          true)
+        (let [w (first (filter #(= :rf.http/cljs-only-key-ignored-on-jvm
+                                    (:operation %))
+                                @captured))]
+          (is (some? w))
+          (let [tags (:tags w)]
+            (is (= "https://example.invalid/v1?q=:rf/redacted&page=:rf/redacted"
+                   (:url tags)))
+            (is (true? (:sensitive? w)))))))))

--- a/implementation/http/test/re_frame/util_json_test.clj
+++ b/implementation/http/test/re_frame/util_json_test.clj
@@ -1,92 +1,22 @@
 (ns re-frame.util-json-test
-  "Unit tests for `re-frame.util-json`.
-
-  Targets the JVM-only fallback reader (`json-read*` reached when
-  Cheshire is absent) and the keyword-cap guard rails on both readers
-  (the Cheshire branch and the fallback). The Cheshire branch is
-  exercised through `json-parse` directly; the fallback reader is
-  exercised by binding the resolved Cheshire vars to nil for the
-  duration of the test (see `with-fallback-reader`).
+  "Unit tests for `re-frame.util-json` on JVM (Cheshire path).
 
   Beads:
-   - rf2-263km — truncated `\\uXXXX` escape near EOF surfaces a clean
-                 `:rf.error/malformed-json :reason :truncated-unicode-escape`
-                 (was: `StringIndexOutOfBoundsException`).
    - rf2-wu1n5 — JSON keyword-interning DoS: cap on unique keys decoded
-                 (configurable via `re-frame.util-json/*max-decoded-keys*`).
-                 Overflow throws `:rf.http/decode-failure :reason :too-many-keys`."
+                 (configurable via `:max-decoded-keys` option per call).
+                 Overflow throws `:rf.error/malformed-json :reason :too-many-keys`,
+                 which the `:rf.http/managed` cascade classifies as
+                 `:rf.http/decode-failure`.
+   - rf2-dgsu1 — Cheshire is a hard JVM dep (no fallback reader). Native
+                 Cheshire `JsonParseException`s propagate to the transport
+                 catch site, which classifies them as
+                 `:rf.http/decode-failure`. Earlier `rf2-263km` covered
+                 the hand-rolled fallback reader's bounds-checking; with
+                 the fallback removed those manual-parser regressions
+                 are moot — Cheshire is RFC-8259-conforming and bulletproof
+                 around `\\uXXXX` escapes by construction."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.util-json :as util-json]))
-
-(defmacro with-fallback-reader
-  "Force `json-parse` to take the pure-Clojure fallback path by binding
-  the resolved Cheshire vars (held in delays) to a stubbed pair whose
-  parse-string is nil. Restores after the body."
-  [& body]
-  `(let [orig-parse#    @#'re-frame.util-json/cheshire-parse-string
-         orig-generate# @#'re-frame.util-json/cheshire-generate-string]
-     (try
-       ;; Replace the private delays with delays whose deref returns nil
-       ;; so `json-parse`'s `(some? @cheshire-parse-string)` branch fails
-       ;; and the fallback reader runs.
-       (alter-var-root #'re-frame.util-json/cheshire-parse-string
-                       (constantly (delay nil)))
-       ~@body
-       (finally
-         (alter-var-root #'re-frame.util-json/cheshire-parse-string
-                         (constantly orig-parse#))
-         (alter-var-root #'re-frame.util-json/cheshire-generate-string
-                         (constantly orig-generate#))))))
-
-;; ---- rf2-263km — truncated unicode escape --------------------------------
-
-(deftest fallback-reader-truncated-unicode-escape-throws-cleanly
-  (testing "rf2-263km — a `\\u` escape that runs past EOF throws a clean
-  `:rf.error/malformed-json :reason :truncated-unicode-escape`
-  ex-info rather than StringIndexOutOfBoundsException"
-    (with-fallback-reader
-      ;; Inputs whose 4-char hex window runs PAST the end-of-string: the
-      ;; raw window is `(subs s (+ p 2) (+ p 6))`, which is the SIOOBE
-      ;; surface absent the bounds check.
-      (doseq [s ["\"x\\u\""        ; window 4..8, n=5 — overflow by 3
-                 "\"x\\u1\""        ; window 4..8, n=6 — overflow by 2
-                 "\"x\\u12\""]]     ; window 4..8, n=7 — overflow by 1
-        (let [thrown (try (util-json/json-parse s) ::no-throw
-                          (catch clojure.lang.ExceptionInfo e e))
-              data   (when (instance? clojure.lang.ExceptionInfo thrown)
-                       (ex-data thrown))]
-          (is (instance? clojure.lang.ExceptionInfo thrown)
-              (str "expected ex-info for input " (pr-str s) " — got " thrown))
-          (is (= :rf.error/malformed-json (:kind data))
-              (str "input " (pr-str s) " — wrong :kind"))
-          (is (= :truncated-unicode-escape (:reason data))
-              (str "input " (pr-str s) " — wrong :reason")))))))
-
-(deftest fallback-reader-invalid-unicode-escape-throws-cleanly
-  (testing "rf2-263km — a `\\u` escape whose 4-char window IS in-bounds but
-  contains non-hex characters (e.g. the closing quote inside the window)
-  throws `:rf.error/malformed-json :reason :invalid-unicode-escape`
-  rather than NumberFormatException"
-    (with-fallback-reader
-      (doseq [s ["\"x\\u123\""      ; window 4..8, hex = `123"` — bad
-                 "\"\\uXYZ0\""      ; window 3..7, hex = `XYZ0` — bad
-                 "\"\\u123g\""]]    ; window 3..7, hex = `123g` — bad
-        (let [thrown (try (util-json/json-parse s) ::no-throw
-                          (catch clojure.lang.ExceptionInfo e e))
-              data   (when (instance? clojure.lang.ExceptionInfo thrown)
-                       (ex-data thrown))]
-          (is (instance? clojure.lang.ExceptionInfo thrown)
-              (str "expected ex-info for input " (pr-str s) " — got " thrown))
-          (is (= :rf.error/malformed-json (:kind data))
-              (str "input " (pr-str s) " — wrong :kind"))
-          (is (= :invalid-unicode-escape (:reason data))
-              (str "input " (pr-str s) " — wrong :reason")))))))
-
-(deftest fallback-reader-full-unicode-escape-still-works
-  (testing "rf2-263km — a well-formed `\\uXXXX` escape still parses"
-    (with-fallback-reader
-      (is (= "A" (util-json/json-parse "\"\\u0041\"")))
-      (is (= "AB" (util-json/json-parse "\"\\u0041\\u0042\""))))))
 
 ;; ---- rf2-wu1n5 — keyword-interning cap -----------------------------------
 
@@ -119,33 +49,13 @@
         (is (= :too-many-keys (:reason data)))
         (is (= 10 (:limit data)))))))
 
-(deftest fallback-reader-respects-keyword-cap
-  (testing "rf2-wu1n5 — pure-Clojure fallback reader caps unique-key cardinality"
-    (with-fallback-reader
-      (let [s (big-json 50)]
-        (is (map? (util-json/json-parse s {:max-decoded-keys 100})))
-        (is (map? (util-json/json-parse s {:max-decoded-keys 50})))
-        (let [thrown (try (util-json/json-parse s {:max-decoded-keys 10}) ::no-throw
-                          (catch clojure.lang.ExceptionInfo e e))
-              data   (when (instance? clojure.lang.ExceptionInfo thrown)
-                       (ex-data thrown))]
-          (is (instance? clojure.lang.ExceptionInfo thrown))
-          (is (= :rf.error/malformed-json (:kind data)))
-          (is (= :too-many-keys (:reason data)))
-          (is (= 10 (:limit data))))))))
-
 (deftest default-cap-enforced-at-default-max
   (testing "rf2-wu1n5 — default cap (`default-max-decoded-keys`) fires
-  when no opts supplied. Uses a small synthetic cap by temporarily
-  bumping the request opts above the synthetic input size, then back
-  below it, to confirm cap arithmetic without building a 10001-key
-  string (slow) in the default path."
+  when no opts supplied."
     ;; Sanity: the documented constant is what we say it is.
     (is (= 10000 util-json/default-max-decoded-keys))
-    ;; The interesting regression — a payload one-over the documented
-    ;; default trips the cap when no per-call override is supplied.
-    ;; We synthesise the over-default payload exactly once and reuse it
-    ;; in both branches.
+    ;; A payload one-over the documented default trips the cap when no
+    ;; per-call override is supplied.
     (let [s (big-json (inc util-json/default-max-decoded-keys))
           thrown (try (util-json/json-parse s) ::no-throw
                       (catch clojure.lang.ExceptionInfo e e))
@@ -159,9 +69,59 @@
 
 (deftest cap-counts-unique-not-total
   (testing "rf2-wu1n5 — repeated keys don't multiply the count"
-    (with-fallback-reader
-      ;; 1000 entries but only 5 unique key strings: {"a":1,"a":2,...}
-      (let [pairs (clojure.string/join "," (repeat 200 "\"a\":1,\"b\":2,\"c\":3,\"d\":4,\"e\":5"))
-            s     (str "{" pairs "}")]
-        (is (map? (util-json/json-parse s {:max-decoded-keys 10}))
-            "5 unique keys under cap=10 should succeed even with 1000 entries")))))
+    ;; 1000 entries but only 5 unique key strings: {\"a\":1,\"a\":2,...}
+    (let [pairs (clojure.string/join "," (repeat 200 "\"a\":1,\"b\":2,\"c\":3,\"d\":4,\"e\":5"))
+          s     (str "{" pairs "}")]
+      (is (map? (util-json/json-parse s {:max-decoded-keys 10}))
+          "5 unique keys under cap=10 should succeed even with 1000 entries"))))
+
+;; ---- rf2-dgsu1 — Cheshire is mandatory; malformed JSON propagates --------
+
+(deftest cheshire-handles-well-formed-unicode-escape
+  (testing "rf2-dgsu1 — Cheshire (the now-mandatory JVM JSON dep) parses
+  `\\uXXXX` escapes correctly. The previous hand-rolled fallback's
+  `\\uXXXX` bounds-checking (rf2-263km) is moot — Cheshire is
+  RFC-8259-conforming."
+    (is (= "A"   (util-json/json-parse "\"\\u0041\"")))
+    (is (= "AB"  (util-json/json-parse "\"\\u0041\\u0042\"")))
+    (is (= "café" (util-json/json-parse "\"caf\\u00e9\"")))))
+
+(deftest cheshire-rejects-malformed-input-cleanly
+  (testing "rf2-dgsu1 — malformed JSON (truncated escape, unterminated
+  string, invalid token) raises a Cheshire/Jackson `JsonParseException`.
+  The `:rf.http/managed` cascade's `decode-response-body` catch site
+  surfaces this as `:rf.http/decode-failure` with the parser message at
+  `:cause` — no per-test fixture needed; the contract is simply 'parse
+  errors throw'. Earlier the hand-rolled fallback masked malformed
+  input behind a custom `:rf.error/malformed-json` ex-info; that
+  layering is no longer necessary."
+    ;; Inputs Cheshire/Jackson rejects with a parse exception. (Jackson
+    ;; is tolerant of some shapes by design — trailing-comma arrays and
+    ;; missing-close-brace objects fall through to its end-of-stream
+    ;; handler rather than throwing — so we pick inputs that are
+    ;; definitively malformed: truncated escapes, unterminated string
+    ;; literals, and invalid tokens.)
+    (doseq [s ["{not-a-key:1}"      ; bareword key
+               "\"unterminated"     ; unterminated string
+               "{\"x\":\"\\u\"}"   ; truncated unicode escape
+               "{\"x\":\"\\uZZ"   ; invalid unicode hex
+               "tru"               ; truncated `true`
+               "{\"x\":nul}"]]      ; misspelt null
+      (let [thrown (try (util-json/json-parse s) ::no-throw
+                        (catch Exception e e))]
+        (is (instance? Exception thrown)
+            (str "expected a parse exception for " (pr-str s)
+                 " — got " thrown))))))
+
+(deftest json-stringify-uses-cheshire
+  (testing "rf2-dgsu1 — `json-stringify` produces real JSON via Cheshire
+  (not `pr-str`). The earlier shape fell back to `pr-str` when
+  Cheshire was absent; with Cheshire mandatory the output is always
+  valid JSON."
+    ;; Cheshire emits standard JSON: keys quoted, strings double-quoted,
+    ;; no edn-isms.
+    (is (= "{\"a\":1,\"b\":\"hello\"}"
+           (util-json/json-stringify {:a 1 :b "hello"})))
+    (is (= "[1,2,3]" (util-json/json-stringify [1 2 3])))
+    (is (= "true" (util-json/json-stringify true)))
+    (is (= "null" (util-json/json-stringify nil)))))


### PR DESCRIPTION
## Summary

Batched-by-surface cluster across `implementation/http/`. Five beads land
as four commits (the parent audit-slice `rf2-y9za6` closes with no
substantive code change once its children resolve).

- **rf2-1jcpm** P2 — security audit fixes (3 URL-leaking trace sites +
  CLJS timeout/abort-signal interaction).
- **rf2-r40km** P1 — `:rf.http/cors` spec-vs-impl drift resolved
  (heuristic emission on CLJS; JVM unchanged per Spec 014).
- **rf2-ydp66** P3 — `sensitive-header?` / `sensitive-query-param?`
  short-circuit; no `set/union` per call.
- **rf2-dgsu1** P3 — Cheshire becomes a hard JVM dep; hand-rolled
  fallback reader removed (~165 LoC of parser code gone).
- **rf2-y9za6** P1 — audit slice closes; substance lives in the four
  children.

LoC delta: +514 / -373 across 11 files.

## DECISIONS (per pre-alpha posture, agent authority)

### rf2-r40km — `:rf.http/cors` drift: option (a) IMPLEMENT

Spec 014 §Failure categories has documented `:rf.http/cors` in the
closed-set 8-category taxonomy since the lock-in, but the CLJS
classifier never emitted it — every Fetch CORS rejection silently fell
into `:rf.http/transport`. The audit (rf2-jklja finding 4.1) raised the
"implement or remove from spec" decision; per the agent brief I picked
(a) IMPLEMENT.

**Rationale**: CORS is documented prominently as part of the closed
taxonomy across `spec/014`, `spec/Conventions`, `spec/API`, the skills,
and `docs/guide/10-doing-http-requests.md`. Removing it from the spec
would ripple through five spec/doc surfaces and surrender a sharper
failure category that tooling (Pair, 10x panels, error projector) can
attribute. Keeping the spec while never emitting kept the contract
asymmetric (consumers can never observe what the spec promises).

**Heuristic shape** — the Fetch API gives no formal signal for CORS;
every CORS failure surfaces as `TypeError`. The shipped heuristic is
conservative:

```
TypeError + cross-origin URL  ⇒  :rf.http/cors
anything else                 ⇒  :rf.http/transport
```

Both signals are required. `cross-origin?` parses via `js/URL` against
`js/location.origin`; relative URLs, `data:`/`blob:`/`file:` schemes,
and any unparseable input return `false`. Hosts where
`js/location.origin` is absent (Node, certain shadow-cljs test targets)
also return false — same-origin transport drops are NEVER
misclassified as CORS.

The JVM transport (`classify-jvm-error`) is unchanged — JVM never emits
`:rf.http/cors`, per Spec 014 §`:rf.http/cors` is CLJS-only (CORS is a
browser-policy concern; the JVM has no cross-origin policy to enforce).

### rf2-dgsu1 — Cheshire mandatory; fallback reader deleted

The slice previously resolved Cheshire via `requiring-resolve` and fell
back to a hand-rolled pure-Clojure JSON reader/writer when Cheshire was
absent — a slow path on the response-decode success branch, with no
warning that the operator was running on it.

**Decision**: ship one path, the fast path. Cheshire is now a hard JVM
dep (`cheshire/cheshire "5.13.0"`) in `implementation/http/deps.edn`.
The fallback reader (~165 LoC) and the memoised `requiring-resolve`
delays are gone. `util_json.cljc` shrinks from ~310 to ~115 LoC.

The Spec 014 §Decoding contract is unchanged — malformed JSON still
surfaces as `:rf.http/decode-failure` via the `decode-response-body`
catch path; the keyword-cap (rf2-wu1n5) still fires its tagged
`:rf.error/malformed-json :reason :too-many-keys` ex-info.

### rf2-1jcpm low-severity finding (deferred — POLICY)

The audit's low-severity item — JVM `:rf.http/managed-canned-*` fxs
gated on `debug-enabled?` (permanently `true` on JVM) — is policy-
flagged here rather than fixed unilaterally. The current JVM tests
explicitly assert the canned-stub fxs remain registered in production
(`http_managed_test.clj:588-602`), and changing the gate would also
touch Spec 014 §Testing. **Recommend**: separate decision bead for
"should canned stub fxs ship on JVM in production?" — answer probably
yes for the SSR test-pyramid story, but the contract should be
written down rather than implied by the `debug-enabled?` constant.

## Test plan

- [x] `cd implementation && npm run test:cljs` — 1867 tests, 5282 assertions, 0 failures (CLJS node-runtime, including 3 new CORS classifier tests + retry-set membership test)
- [x] `cd implementation/http && clojure -M:test` — 168 tests, 470 assertions, 0 failures (JVM http, including 5 new security regression tests, refreshed util-json suite)
- [x] `cd implementation && npm run test:examples` — all PASS (managed-http-counter and 20 others)

## Beads

- rf2-1jcpm — landed (commit 1)
- rf2-r40km — landed (commit 2)
- rf2-ydp66 — landed (commit 3)
- rf2-dgsu1 — landed (commit 4)
- rf2-y9za6 — parent slice closes; no separate commit (children resolve the slice)