### PR TITLE
refactor(schemas): batched cluster — 4 follow-on beads (incl. rf2-wkxng decision)

### DIFF
--- a/examples/reagent/boot/schema.cljs
+++ b/examples/reagent/boot/schema.cljs
@@ -112,14 +112,19 @@
 ;; SCHEMA REGISTRATION
 ;; ============================================================================
 
-(rf/reg-app-schema [:rf/machines :app/boot] BootSnapshot)
+;; Per rf2-wkxng / rf2-6m0se the runtime rolls back post-commit on a
+;; failing app-db schema. The slots below are absent (nil) before the
+;; boot machine writes them; every registration is wrapped in :maybe
+;; so the validator passes during the staging/loading phases.
+
+(rf/reg-app-schema [:rf/machines :app/boot] [:maybe BootSnapshot])
 
 ;; The :invoke-all children stage their payloads into [:boot/staging]
 ;; before signalling completion to the parent. The :enter-hydrating
 ;; action reads the staging slot and promotes each payload into the
 ;; canonical top-level slot below. Registered here so the staging
 ;; writes are schema-validated like every other slice.
-(rf/reg-app-schema [:boot/staging] BootStagingSlice)
+(rf/reg-app-schema [:boot/staging] [:maybe BootStagingSlice])
 
 ;; The boot machine writes its final payloads into top-level app-db
 ;; slices on entering `:hydrating`. These are the slices the main app

--- a/examples/reagent/counter_with_stories/elision_demo.cljs
+++ b/examples/reagent/counter_with_stories/elision_demo.cljs
@@ -110,16 +110,15 @@
 ;; top-level props and writes a `{:large? true :source :schema}`
 ;; entry into `[:rf/elision :declarations]`.
 ;;
-;; We deliberately do NOT wrap the schema in `:maybe` — a `:maybe`
-;; wrapper would push `:large?` past the walker's top-level-props
-;; check. The slot is allowed to be `nil` at runtime because the
-;; default schema validator soft-passes (Spec 010 §Recommended
-;; soft-pass); the optional-value semantic lives in the schema's
-;; ABSENCE from app-db before the user clicks the upload button,
-;; not in a `:maybe` wrapper.
+;; Per rf2-wkxng / rf2-6m0se the runtime now ROLLS BACK on a post-
+;; commit app-db schema failure — the slot may be `nil` (when the
+;; user hasn't uploaded yet), so the schema MUST permit nil. We
+;; wrap with `:maybe`; the `:large? true` flag lives on the inner
+;; `:string` slot so the walker still surfaces it under the
+;; `[:user/avatar-pdf]` registered path.
 (rf/reg-app-schema [:user/avatar-pdf]
-                   [:string {:large? true
-                             :hint   "Avatar PDF blob"}])
+                   [:maybe [:string {:large? true
+                                     :hint   "Avatar PDF blob"}]])
 
 ;; ============================================================================
 ;; EVENTS  (Spec 009 §`:sensitive?` + §`with-redacted`)

--- a/examples/reagent/counter_with_stories/elision_demo_cljs_test.cljs
+++ b/examples/reagent/counter_with_stories/elision_demo_cljs_test.cljs
@@ -24,6 +24,7 @@
             [re-frame.core         :as rf]
             [re-frame.event-emit   :as event-emit]
             [re-frame.frame        :as frame]
+            [re-frame.late-bind    :as late-bind]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             ;; Loading the demo ns fires its registrations against the
@@ -45,9 +46,25 @@
   ;; tactical fix) is obsolete — Causa's cb runs as production
   ;; preload wires it.
   (reset! frame/frames {})
+  ;; Per rf2-wkxng / rf2-6m0se: clear cross-namespace schemas from
+  ;; the per-frame registry before re-registering this demo's
+  ;; declarations. Sibling test namespaces (auth-flow story tests,
+  ;; nine-states.core, Conduit) register schemas against :rf/default
+  ;; at ns-load; the post-commit validation rollback would otherwise
+  ;; fire on every dispatch in this file against those unrelated
+  ;; schemas.
+  (when-let [clear! (late-bind/get-fn :schemas/clear-by-frame!)]
+    (clear!))
   (try (rf/init! plain-atom/adapter) (catch :default _ nil))
   (frame/ensure-default-frame!)
   (event-emit/clear-event-emit-listeners!)
+  ;; Re-register this demo's app-db schema. The demo namespace's
+  ;; ns-load `reg-app-schema` call ran once at module load; the
+  ;; preceding `(clear!)` step wiped it. Re-stamping it here keeps
+  ;; the schema-driven elision branch (test 3) working.
+  (rf/reg-app-schema [:user/avatar-pdf]
+                     [:maybe [:string {:large? true
+                                       :hint   "Avatar PDF blob"}]])
   ;; Re-run the schema-driven elision-registry boot population
   ;; against the post-init frame. The demo ns's `reg-app-schema`
   ;; call lives in registry-meta land; the per-frame `[:rf/elision

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_dispatch_frame_capture_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_dispatch_frame_capture_cljs_test.cljs
@@ -24,6 +24,7 @@
   (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace]
             [re-frame.adapter.helix :as helix-adapter]
             [re-frame.substrate.adapter :as substrate-adapter]
@@ -38,6 +39,15 @@
 (defn- before! []
   (reset! registrar-snapshot (test-support/snapshot-registrar))
   (reset! frame/frames {})
+  ;; Per rf2-wkxng / rf2-6m0se: clear the per-frame schema registry so
+  ;; ns-load `reg-app-schema` calls from sibling test namespaces (e.g.
+  ;; the elision demo's `:user/avatar-pdf` schema) don't fire post-
+  ;; commit validation rollbacks against this test's frames. The
+  ;; canonical `reset-runtime-fixture` includes this clear via the
+  ;; `:schemas/clear-by-frame!` late-bind hook; the ad-hoc fixture
+  ;; here mirrors that step.
+  (when-let [clear! (late-bind/get-fn :schemas/clear-by-frame!)]
+    (clear!))
   (substrate-adapter/dispose-adapter!)
   (trace/clear-trace-cbs!)
   (substrate-adapter/install-adapter! helix-adapter/adapter)

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_dispatch_frame_capture_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_dispatch_frame_capture_cljs_test.cljs
@@ -24,6 +24,7 @@
   (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.substrate.adapter :as substrate-adapter]
@@ -38,6 +39,11 @@
 (defn- before! []
   (reset! registrar-snapshot (test-support/snapshot-registrar))
   (reset! frame/frames {})
+  ;; Per rf2-wkxng / rf2-6m0se: clear the per-frame schema registry so
+  ;; ns-load `reg-app-schema` calls from sibling test namespaces don't
+  ;; fire post-commit validation rollbacks against this test's frames.
+  (when-let [clear! (late-bind/get-fn :schemas/clear-by-frame!)]
+    (clear!))
   (substrate-adapter/dispose-adapter!)
   (trace/clear-trace-cbs!)
   (substrate-adapter/install-adapter! uix-adapter/adapter)

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -515,6 +515,15 @@
     ;; teardown. No-op when re-frame.machines is absent (the artefact
     ;; is optional).
     (safe-call-hook! :machines/on-frame-destroyed! id)
+    ;; Per rf2-wkxng / rf2-6m0se: drop every schema registered against
+    ;; the destroyed frame so a re-registered frame starts with a
+    ;; clean schema slate. Without this hook, orphan app-db schemas
+    ;; from a prior `reg-frame` cycle persist and re-fire under the
+    ;; rollback contract — manifesting as spurious rollbacks against
+    ;; paths the new frame's :on-create never wrote. No-op when
+    ;; re-frame.schemas is absent (the artefact is optional per
+    ;; rf2-p7va).
+    (safe-call-hook! :schemas/on-frame-destroyed! id)
     (emit-frame-destroyed-trace! id)
     (dissoc-frame! id)
     (unregister-frame! id)

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -116,6 +116,10 @@
    {:key         :schemas/clear-by-frame!
     :producer-ns 're-frame.schemas
     :description "Clear the schema registry entries for a frame (test isolation)."}
+   {:key         :schemas/on-frame-destroyed!
+    :producer-ns 're-frame.schemas
+    :design-bead "rf2-6m0se"
+    :description "Drop the destroyed frame's app-db schema entries (consumed by frame/destroy-frame!)."}
    {:key         :schemas/set-schema-validator!
     :producer-ns 're-frame.schemas
     :design-bead "rf2-froe"

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -340,36 +340,89 @@
     (trace/emit-error! :rf.error/handler-exception tags)))
 
 (defn- run-post-commit-validation!
-  "Per Spec 010: validate app-db against registered schemas after each
-  commit. Failures emit :rf.error/schema-validation-failure but don't
-  roll back (recovery is :no-recovery by default).
+  "Per Spec 010 §Per-step recovery row 4 (rf2-wkxng / rf2-6m0se): validate
+  app-db against registered schemas after each commit. Returns the
+  validator's boolean conjunction — true when every registered schema
+  for the frame conformed (or the schemas artefact isn't loaded / no
+  validator is installed); false when at least one schema failed.
+
+  Failures emit :rf.error/schema-validation-failure (one per failing
+  entry) with `:rollback? true` and `:recovery :no-recovery` stamped
+  in the tag — the caller restores the pre-handler app-db on a false
+  return.
 
   Per Spec 010 §Per-frame schemas the validation walks the schemas
   registered against THIS dispatch's frame only — sibling frames'
-  schemas don't fire here."
+  schemas don't fire here.
+
+  Defensive truth-coercion: a host-thrown validator (e.g. a buggy
+  user-supplied :schemas/set-schema-validator! fn) is caught and
+  treated as `true` (no rollback) — the validator is failing on
+  itself, not on a user schema, and a hard abort here would mask the
+  actual app-db state from the rest of the cascade. Real schema
+  failures route through the in-band false return."
   [db-after event-id frame]
-  (when-let [validate (late-bind/get-fn :schemas/validate-app-db!)]
+  (if-let [validate (late-bind/get-fn :schemas/validate-app-db!)]
     (try
-      (validate db-after event-id frame)
-      (catch #?(:clj Throwable :cljs :default) _ nil))))
+      ;; nil-coerce: pre-rf2-6m0se the fn returned nil on success.
+      ;; Treat nil as true (don't roll back) so a hosted port that
+      ;; still ships the older contract keeps working.
+      (let [r (validate db-after event-id frame)]
+        (if (nil? r) true r))
+      (catch #?(:clj Throwable :cljs :default) _ true))
+    true))
 
 (defn- commit-db-effect!
   "Apply :db atomically: replace the app-db container, emit the
   :event/db-changed trace, then run post-commit schema validation.
+  Returns true when the commit is durable (no :db effect, or all
+  schemas conformed); false when post-commit validation rejected the
+  new state and the container has been **rolled back** to the
+  pre-handler value (per Spec 010 §Per-step recovery row 4 /
+  rf2-wkxng / rf2-6m0se).
+
+  On rollback, a second :event/db-changed trace is emitted for the
+  restored state with `:phase :rollback` so listeners (subs, 10x,
+  pair-tools) observe the post-rollback app-db without ambiguity —
+  the trace stream's load-bearing ordering is `:db-changed (post-
+  handler) → :rf.error/schema-validation-failure → :db-changed
+  (post-rollback)`, mirroring the depth-exceeded pattern (the error
+  trace fires AFTER the container is back at its pre-handler value,
+  so a trace listener that reads app-db sees the rolled-back state).
+  Subscriptions whose inputs changed re-fire on the second commit so
+  the UI never settles on a non-conforming snapshot.
 
   Per Spec 009 §The `with-redacted` interceptor (line 1225): the
   `:event/db-changed` trace event MUST surface the scrubbed event
   vector under `:tags :event` when `with-redacted` ran on the
   handler's chain. The interceptor stashes `:rf/redacted-event`
   on the context; we read it through and emit the scrubbed form."
-  [effects event-id event frame ctx]
-  (when (contains? effects :db)
+  [effects event-id event frame ctx db-before]
+  (if (contains? effects :db)
     (let [container  (frame/get-frame-db frame)
+          new-db     (:db effects)
           emit-event (or (:rf/redacted-event ctx) event)]
-      (adapter/replace-container! container (:db effects))
+      (adapter/replace-container! container new-db)
       (trace/emit! :event :event/db-changed
                    {:event-id event-id :event emit-event :frame frame})
-      (run-post-commit-validation! (:db effects) event-id frame))))
+      (if (run-post-commit-validation! new-db event-id frame)
+        true
+        (do
+          ;; Roll back: restore the pre-handler container value, then
+          ;; emit a second :event/db-changed with :phase :rollback so
+          ;; subs / listeners see the restored state on the trace
+          ;; stream. The error trace from validate-app-db! has
+          ;; already fired between the two commits — consumers see
+          ;; (in order): forward commit, schema-failure error,
+          ;; rollback commit.
+          (adapter/replace-container! container db-before)
+          (trace/emit! :event :event/db-changed
+                       {:event-id event-id
+                        :event    emit-event
+                        :frame    frame
+                        :phase    :rollback})
+          false)))
+    true))
 
 (defn- run-flows!
   "Per Spec 013 §Drain integration: run flows after :db commits and
@@ -480,15 +533,24 @@
   "Settle the cascade: surface any chain exception, commit :db, run
   flows, then walk :fx in source order. Per Spec 002 §Drain-loop
   pseudocode. Trace ordering is load-bearing — :event/db-changed
-  precedes flow evaluation, which precedes :fx walking."
+  precedes flow evaluation, which precedes :fx walking.
+
+  Per Spec 010 §Per-step recovery row 4 (rf2-wkxng / rf2-6m0se): a
+  post-commit `:db` schema-validation failure rolls the container
+  back to the pre-handler value AND treats the dispatch as failed —
+  flows do NOT evaluate and `:fx` does NOT walk. The pre-handler db
+  is read from `(get-in final-ctx [:coeffects :db])` (assemble-
+  initial-ctx stamps it there). Downstream queued events still drain
+  per run-to-completion (handled by `drain-loop!`'s outer pass)."
   [final-ctx event-id event frame frame-record fx-overrides start-ms]
-  (let [effects (:effects final-ctx)
-        error   (:rf/interceptor-error final-ctx)]
+  (let [effects   (:effects final-ctx)
+        error     (:rf/interceptor-error final-ctx)
+        db-before (get-in final-ctx [:coeffects :db])]
     (when error
       (emit-handler-exception! error event-id event frame final-ctx start-ms))
-    (commit-db-effect! effects event-id event frame final-ctx)
-    (run-flows! frame event)
-    (run-fx-effects! effects frame frame-record fx-overrides event)
+    (when (commit-db-effect! effects event-id event frame final-ctx db-before)
+      (run-flows! frame event)
+      (run-fx-effects! effects frame frame-record fx-overrides event))
     error))
 
 (defn- emit-cascade-trailers!

--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -430,9 +430,14 @@
       (registrar/register!
         :view id
         {:handler-fn (conformance/realise-view-handler steps)}))
-    ;; app-schema registrations
-    (doseq [[path schema] (get-in fixture [:fixture/registry :app-schema])]
-      (rf/reg-app-schema path schema))
+    ;; NOTE: app-schema registrations are intentionally NOT registered here
+    ;; — see `realise-app-schemas!` below. Per rf2-wkxng / rf2-6m0se,
+    ;; `destroy-frame!` now drops the frame's app-db schemas (parity with
+    ;; the machines / SSR / privacy destroy hooks). Schemas registered
+    ;; before the runner's destroy+reg-frame cycle would be cleared by
+    ;; the new hook; the runner registers them after `destroy-frame` and
+    ;; before `reg-frame` so the :on-create cascade fires with the
+    ;; fixture's declared schema slate.
     ;; machine registrations
     (let [machine-registry (get-in fixture [:fixture/registry :machine] {})]
       (when (seq machine-registry)
@@ -445,6 +450,16 @@
                              (update :guards           #(merge guards %))
                              (update :on-spawn-actions #(merge on-spawn-actions %)))]
               (reg-machine machine-id merged))))))))
+
+(defn- realise-app-schemas!
+  "Register the fixture's app-db schemas. Called AFTER the runner's
+  destroy-frame step (so the new `:schemas/on-frame-destroyed!` hook
+  doesn't wipe them) and BEFORE `reg-frame` (so the :on-create cascade
+  validates the seeded state against the schemas). Per rf2-wkxng /
+  rf2-6m0se."
+  [fixture]
+  (doseq [[path schema] (get-in fixture [:fixture/registry :app-schema])]
+    (rf/reg-app-schema path schema)))
 
 (defn- collect-traces [fixture-id]
   (let [traces (atom [])]
@@ -766,6 +781,12 @@
           ;; reg-frame against an existing id is a surgical update; destroy
           ;; first so :on-create fires when re-registered.
           _            (rf/destroy-frame :rf/default)
+          ;; Per rf2-wkxng / rf2-6m0se: register schemas AFTER the
+          ;; destroy (the new `:schemas/on-frame-destroyed!` hook drops
+          ;; the frame's schema entries on destroy) and BEFORE the
+          ;; re-create so the :on-create cascade validates against the
+          ;; fixture's declared slate.
+          _            (realise-app-schemas! fixture)
           _            (cond
                          (seq frames-spec)
                          (doseq [f frames-spec]

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -439,11 +439,6 @@
       ((requiring-resolve 're-frame.registrar/register!)
        :view id
        {:handler-fn (conformance/realise-view-handler steps)}))
-    ;; app-schema registrations — fixture's :fixture/registry :app-schema
-    ;; is a {path schema} map. Per Spec 010, validation runs after each
-    ;; :db commit.
-    (doseq [[path schema] (get-in fixture [:fixture/registry :app-schema])]
-      (rf/reg-app-schema path schema))
     ;; Per rf2-msd4: machine registrations. The fixture's
     ;; :fixture/registry :machine is a {machine-id <machine-spec>} map; the
     ;; spec's :actions / :guards / :on-spawn-actions slots may reference
@@ -831,6 +826,14 @@
           ;; re-fire :on-create per Spec 002. We destroy first so :on-create
           ;; fires when re-registered with the fixture's config.
           _            (rf/destroy-frame :rf/default)
+          ;; app-schema registrations — fixture's :fixture/registry :app-schema
+          ;; is a {path schema} map. Per Spec 010 validation runs after each
+          ;; :db commit. Must be registered AFTER destroy-frame (which wipes
+          ;; the per-frame schema side-table via the rf2-wkxng /
+          ;; rf2-6m0se on-frame-destroyed! hook) and BEFORE reg-frame so
+          ;; the fixture's :on-create event runs with schemas in place.
+          _            (doseq [[path schema] (get-in fixture [:fixture/registry :app-schema])]
+                         (rf/reg-app-schema path schema))
           _            (cond
                          (seq frames-spec)
                          ;; Multi-frame fixture: register each declared frame.

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -94,6 +94,7 @@
 (def snapshot-schemas-by-frame storage/snapshot-schemas-by-frame)
 (def restore-schemas-by-frame! storage/restore-schemas-by-frame!)
 (def clear-schemas-by-frame!   storage/clear-schemas-by-frame!)
+(def on-frame-destroyed!       storage/on-frame-destroyed!)
 
 ;; Per-slot flag walker (rf2-nwv63 / rf2-kj51z / rf2-oghml).
 (def walk-flagged-schema              walker/walk-flagged-schema)
@@ -145,6 +146,9 @@
 (late-bind/set-fn! :schemas/validate-cofx!       validate-cofx!)
 (late-bind/set-fn! :schemas/validate-fx!         validate-fx!)
 (late-bind/set-fn! :schemas/frame-schema-entries frame-schema-entries)
+;; Frame-destroy cleanup hook (consumed by frame/destroy-frame!,
+;; mirrors :machines/on-frame-destroyed! and :ssr/on-frame-destroyed).
+(late-bind/set-fn! :schemas/on-frame-destroyed!  on-frame-destroyed!)
 
 ;; Boundary-validation seam (rf2-r2uh integration).
 (late-bind/set-fn! :schemas/validate-with-registered-fn validate-with-registered-fn)

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -215,3 +215,20 @@
   and by `reset-runtime-fixture`'s `:clear-kinds [:app-schema]` path."
   []
   (reset! schemas-by-frame {}))
+
+(defn on-frame-destroyed!
+  "Per Spec 002 §Destroy: drop every schema registered against the
+  destroyed frame so a subsequent `reg-frame` of the same id starts
+  with a clean schema slate. Called from `frame/destroy-frame!`
+  through the `:schemas/on-frame-destroyed!` late-bind hook
+  (mirrors the `:machines/on-frame-destroyed!` /
+  `:ssr/on-frame-destroyed` cleanup contract).
+
+  Without this cleanup, schemas registered against a destroyed
+  frame would persist and re-fire when the frame is re-registered
+  — under the rf2-wkxng / rf2-6m0se rollback contract that
+  manifests as spurious rollbacks against orphan paths the new
+  frame's :on-create never wrote. Idempotent — a missing frame
+  entry is a no-op `dissoc`."
+  [frame-id]
+  (swap! schemas-by-frame dissoc frame-id))

--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -251,18 +251,32 @@
   event-id (optional) names the handler whose commit prompted the
   failure — surfaced as :failing-id in the error tags.
 
+  Returns:
+    true   — every registered schema conformed (or no validator /
+             no schemas registered for the frame / debug elided).
+    false  — at least one schema failed; a trace event was emitted
+             for every failing entry. The router consumes this signal
+             to roll back the :db effect to the pre-handler value
+             (per Spec 010 §Per-step recovery row 4 / rf2-wkxng /
+             rf2-6m0se).
+
   Structurally distinct from the four meta-bearing validate-*! fns
-  (event / cofx / fx / sub-return): walks N schemas via doseq, has
-  no single `:spec`-on-meta lookup, and emits per failure without
-  returning a true/false pass flag. Does not share the
-  `run-validation` shape."
+  (event / cofx / fx / sub-return): walks N schemas via doseq, has no
+  single `:spec`-on-meta lookup, and emits a trace per failure (rather
+  than at-most-one). Returns a single boolean conjoining every entry's
+  result so the caller can decide rollback deterministically — but
+  every failing schema is still surfaced as its own trace so consumers
+  see the full set."
   ([db] (validate-app-db! db nil (frame/current-frame)))
   ([db event-id] (validate-app-db! db event-id (frame/current-frame)))
   ([db event-id frame-id]
    ;; Per Spec 009 §Production builds the entire body lives inside a
-   ;; `(when interop/debug-enabled? ...)` gate as the OUTERMOST form so
-   ;; :advanced + goog.DEBUG=false DCE-elides every reason string,
-   ;; keyword, validator deref, and trace call. The `@validator-fn`
+   ;; `(if interop/debug-enabled? ... true)` gate as the OUTERMOST form
+   ;; so :advanced + goog.DEBUG=false DCE-elides every reason string,
+   ;; keyword, validator deref, and trace call. Production builds
+   ;; return `true` unconditionally — the rollback path is dev-only
+   ;; (post-commit validation is gated by debug-enabled?, so no
+   ;; failure is observable to roll back against). The `@validator-fn`
    ;; check is a runtime atom deref and must NOT be combined into the
    ;; gate predicate (the deref defeats Closure's reachability proof).
    ;;
@@ -270,74 +284,91 @@
    ;; and invoked directly per entry; `validator/run-validator` would
    ;; re-deref the atom on every iteration (2N derefs for N entries),
    ;; which is wasted work on the post-handler-commit hot path.
-   (when interop/debug-enabled?
-     (when-let [vf @validator/validator-fn]
-       (doseq [[reg-path m] (storage/frame-schema-entries frame-id)]
-         (let [val-at (get-in db reg-path)
-               schema (:schema m)]
-           (when-not (vf schema val-at)
-             ;; Per rf2-oh4se — make the failure path precise and the
-             ;; sensitivity decision path-targeted.
-             ;;
-             ;; The registered explainer is invoked exactly once on
-             ;; the failure branch; its output feeds BOTH the trace's
-             ;; `:explain` slot (verbatim) and the failing-leaf path
-             ;; extraction. `failing-in-path` returns the navigation
-             ;; path through the value Malli reports under `:in` (the
-             ;; value-relative path, not the schema-walk path under
-             ;; `:path` which carries `:multi` / `:orn` dispatch
-             ;; values). The trace's `:path` is the registered root
-             ;; conj'd with the leaf — the slot a consumer can
-             ;; `get-in` against on a NON-failed copy of app-db.
-             ;;
-             ;; Conservative fallback: when no leaf path is
-             ;; extractable (non-Malli explainer, missing
-             ;; explanation), keep the old behaviour — emit the
-             ;; registered root as `:path` and consult
-             ;; `schema-has-sensitive?` for the redaction decision.
-             ;; The `:registered-path` tag always carries the
-             ;; registration root so tooling can reach it regardless
-             ;; of whether path narrowing succeeded.
-             ;;
-             ;; Per Spec 010 §`:sensitive?` — privacy in schema-
-             ;; validation error traces (rf2-kj51z). The path-targeted
-             ;; check (`schema-sensitive-at?`) replaces the coarse
-             ;; whole-schema check: a failure at a non-sensitive slot
-             ;; in a schema that also declares a sibling slot
-             ;; sensitive no longer suffers redaction. Conservative
-             ;; semantics preserved — ancestor-sensitive OR
-             ;; descendant-sensitive at the failing path counts.
-             (let [explanation (validator/run-explainer schema val-at)
-                   in-path     (failing-in-path explanation)
-                   leaf-path   (if in-path
-                                 (vec (concat reg-path in-path))
-                                 reg-path)
-                   ;; Per rf2-oh4se the trace's `:value` is the failing
-                   ;; leaf's value (what the schema slot at `leaf-path`
-                   ;; rejected) — narrowed via the explainer's `:in`
-                   ;; navigation path. Falls back to the whole
-                   ;; registered slot when no leaf can be extracted.
-                   leaf-value  (if in-path
-                                 (get-in val-at in-path)
-                                 val-at)
-                   sensitive?  (if in-path
-                                 (walker/schema-sensitive-at? schema in-path)
-                                 (walker/schema-has-sensitive? schema))
-                   base-tags   (cond-> {:where           :app-db
-                                        :path            leaf-path
-                                        :registered-path reg-path
-                                        :value           leaf-value
-                                        :frame           frame-id
-                                        :explain         explanation
-                                        :reason          (reason-string
-                                                           "App-db at path "
-                                                           leaf-path
-                                                           " failed schema "
-                                                           schema leaf-value)
-                                        :recovery        :no-recovery}
-                                 event-id (assoc :failing-id event-id))
-                   tags        (if sensitive? (redact-tags base-tags) base-tags)]
-               (trace/emit-error! :rf.error/schema-validation-failure tags)))))))))
+   (if interop/debug-enabled?
+     (if-let [vf @validator/validator-fn]
+       ;; reduce + atomic short-circuit replaced doseq so we can emit
+       ;; a trace per failure (full surface for consumers) AND return
+       ;; a single conjoined boolean (single signal for the rollback
+       ;; gate). Pass-state stays `true` only when every entry passed.
+       (loop [entries (seq (storage/frame-schema-entries frame-id))
+              ok?     true]
+         (if-let [[reg-path m] (first entries)]
+           (let [val-at (get-in db reg-path)
+                 schema (:schema m)]
+             (if (vf schema val-at)
+               (recur (next entries) ok?)
+               (do
+                 ;; Per rf2-oh4se — make the failure path precise and
+                 ;; the sensitivity decision path-targeted.
+                 ;;
+                 ;; The registered explainer is invoked exactly once
+                 ;; on the failure branch; its output feeds BOTH the
+                 ;; trace's `:explain` slot (verbatim) and the
+                 ;; failing-leaf path extraction. `failing-in-path`
+                 ;; returns the navigation path through the value
+                 ;; Malli reports under `:in` (the value-relative
+                 ;; path, not the schema-walk path under `:path` which
+                 ;; carries `:multi` / `:orn` dispatch values). The
+                 ;; trace's `:path` is the registered root conj'd with
+                 ;; the leaf — the slot a consumer can `get-in`
+                 ;; against on a NON-failed copy of app-db.
+                 ;;
+                 ;; Conservative fallback: when no leaf path is
+                 ;; extractable (non-Malli explainer, missing
+                 ;; explanation), keep the old behaviour — emit the
+                 ;; registered root as `:path` and consult
+                 ;; `schema-has-sensitive?` for the redaction decision.
+                 ;; The `:registered-path` tag always carries the
+                 ;; registration root so tooling can reach it
+                 ;; regardless of whether path narrowing succeeded.
+                 ;;
+                 ;; Per Spec 010 §`:sensitive?` — privacy in schema-
+                 ;; validation error traces (rf2-kj51z). The path-
+                 ;; targeted check (`schema-sensitive-at?`) replaces
+                 ;; the coarse whole-schema check: a failure at a
+                 ;; non-sensitive slot in a schema that also declares
+                 ;; a sibling slot sensitive no longer suffers
+                 ;; redaction. Conservative semantics preserved —
+                 ;; ancestor-sensitive OR descendant-sensitive at the
+                 ;; failing path counts.
+                 ;;
+                 ;; Per rf2-wkxng / rf2-6m0se the trace's tag carries
+                 ;; `:rollback? true` (consistent with depth-exceeded;
+                 ;; reuses the existing `:recovery :no-recovery`
+                 ;; vocabulary rather than minting a new enum value).
+                 ;; The router consumes the loop's final boolean to
+                 ;; perform the actual container restoration.
+                 (let [explanation (validator/run-explainer schema val-at)
+                       in-path     (failing-in-path explanation)
+                       leaf-path   (if in-path
+                                     (vec (concat reg-path in-path))
+                                     reg-path)
+                       leaf-value  (if in-path
+                                     (get-in val-at in-path)
+                                     val-at)
+                       sensitive?  (if in-path
+                                     (walker/schema-sensitive-at? schema in-path)
+                                     (walker/schema-has-sensitive? schema))
+                       base-tags   (cond-> {:where           :app-db
+                                            :path            leaf-path
+                                            :registered-path reg-path
+                                            :value           leaf-value
+                                            :frame           frame-id
+                                            :explain         explanation
+                                            :reason          (reason-string
+                                                               "App-db at path "
+                                                               leaf-path
+                                                               " failed schema "
+                                                               schema leaf-value)
+                                            :rollback?       true
+                                            :recovery        :no-recovery}
+                                     event-id (assoc :failing-id event-id))
+                       tags        (if sensitive? (redact-tags base-tags) base-tags)]
+                   (trace/emit-error! :rf.error/schema-validation-failure tags)
+                   (recur (next entries) false)))))
+           ok?))
+       true)
+     true)))
 
 (defn validate-event!
   "Per Spec 010 §Validation order step 1 — before an event handler runs,

--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -92,12 +92,24 @@
   "Replace value-bearing slots in a tags map with the `:rf/redacted`
   sentinel. Per Spec 010 §`:sensitive?` — privacy in schema-validation
   error traces. Stamps `:sensitive? true` so consumers filter
-  correctly. Idempotent — safe to call on an already-redacted map."
+  correctly. Idempotent — safe to call on an already-redacted map.
+
+  The four redacted slots (`:value`, `:received`, `:explain`,
+  `:fx-args`) are the canonical set per the Spec 010 §`:sensitive?`
+  redaction-shape list. `:fx-args` is the per-surface doubled-id
+  name carried only on `:where :fx-args` emissions; the
+  `contains?` guard makes the clause a no-op on the other three
+  meta-bearing surfaces (event / cofx / sub-return) whose tag maps
+  don't carry the slot. Per rf2-nijom this replaces the previous
+  fx-only `extra-redact` lambda — the redaction is now symmetric
+  with the other value-bearing slots, and the schema lists them
+  canonically."
   [tags]
   (cond-> tags
     (contains? tags :value)    (assoc :value     redacted-sentinel)
     (contains? tags :received) (assoc :received  redacted-sentinel)
     (contains? tags :explain)  (assoc :explain   redacted-sentinel)
+    (contains? tags :fx-args)  (assoc :fx-args   redacted-sentinel)
     true                       (assoc :sensitive? true)))
 
 (defn- common-prefix
@@ -197,10 +209,6 @@
     - `build-base-tags`  `(fn [schema explanation] -> map)` — produces
                      the per-fn tag map (`:where`, `:reason`, etc.)
                      EXCLUDING any sensitivity stamping.
-    - `extra-redact` `(fn [tags] -> tags)` or `nil` — additional
-                     redaction step applied AFTER `redact-tags` when
-                     `sensitive?` resolves true. Used by validate-fx!
-                     to scrub the doubled `:fx-args` slot.
 
   Reachability: every call-site lives inside the outermost
   `(if interop/debug-enabled? ...)` gate of its public wrapper.
@@ -211,8 +219,15 @@
   Per rf2-1o6ax the registered validator-fn is deref'd ONCE at the
   gate and invoked directly — `validator/run-validator` would deref
   the same atom a second time on every pass, which is wasted work
-  on a path that runs per-event / per-cofx / per-fx / per-sub-return."
-  [meta value meta-sensitive? walk-schema? build-base-tags extra-redact]
+  on a path that runs per-event / per-cofx / per-fx / per-sub-return.
+
+  Per rf2-nijom this primitive no longer carries an `extra-redact`
+  escape hatch — the four canonical redacted slots
+  (`:value`, `:received`, `:explain`, `:fx-args`) all live on the
+  central `redact-tags` cond->. The fx-args clause is a no-op on
+  the other three surfaces (their base-tags don't contain the
+  slot), so a single redactor covers every meta-bearing emit site."
+  [meta value meta-sensitive? walk-schema? build-base-tags]
   (if-let [vf @validator/validator-fn]
     (if-let [schema (:spec meta)]
       (if (vf schema value)
@@ -222,9 +237,7 @@
                               (and walk-schema?
                                    (walker/schema-has-sensitive? schema)))
               base-tags   (build-base-tags schema explanation)
-              tags        (cond-> base-tags
-                            sensitive?                    redact-tags
-                            (and sensitive? extra-redact) extra-redact)]
+              tags        (cond-> base-tags sensitive? redact-tags)]
           (trace/emit-error! :rf.error/schema-validation-failure tags)
           false))
       true)
@@ -394,8 +407,7 @@
          :reason     (reason-string "Event " event-id
                                     " payload failed schema "
                                     schema event)
-         :recovery   :no-recovery})
-      nil)
+         :recovery   :no-recovery}))
     true))
 
 (defn validate-sub-return!
@@ -424,8 +436,7 @@
          :reason     (reason-string "Subscription " sub-id
                                     " return value failed schema "
                                     schema value)
-         :recovery   :replaced-with-default})
-      nil)
+         :recovery   :replaced-with-default}))
     true))
 
 (defn validate-cofx!
@@ -454,8 +465,7 @@
          :reason     (reason-string "Coeffect " cofx-id
                                     " injected value failed schema "
                                     schema value)
-         :recovery   :no-recovery})
-      nil)
+         :recovery   :no-recovery}))
     true))
 
 (defn validate-fx!
@@ -467,9 +477,11 @@
   continue to run, and downstream queued events still drain. Returns
   true/false per the `run-validation` contract.
 
-  The doubled `:fx-args` slot in the emitted tags is scrubbed via
-  `run-validation`'s extra-redact step so the redaction is symmetric
-  with the cofx/event surfaces (which don't carry a doubled-id slot)."
+  Per rf2-nijom the per-surface `:fx-args` slot is redacted by the
+  central `redact-tags` cond->; the lambda escape hatch that used to
+  do this here is gone, and Spec 010 §`:sensitive?` now lists
+  `:fx-args` alongside `:value` / `:received` / `:explain` as the
+  canonical redacted slots."
   [fx-id event-id args fx-meta]
   (if interop/debug-enabled?
     (run-validation
@@ -490,14 +502,7 @@
                                             " args failed schema "
                                             schema args)
                  :recovery   :skipped}
-          event-id (assoc :event-id event-id)))
-      ;; Extra-redact: the doubled `:fx-args` slot isn't covered by
-      ;; the generic `redact-tags` (which only knows `:value` /
-      ;; `:received` / `:explain` — the value-bearing slots Spec 010
-      ;; §`:sensitive?` blesses). Scrub `:fx-args` here so the
-      ;; redaction is symmetric across all four meta-bearing
-      ;; validate-*! surfaces.
-      (fn [tags] (assoc tags :fx-args redacted-sentinel)))
+          event-id (assoc :event-id event-id))))
     true))
 
 ;; ---- public boundary-validation entry point (rf2-r2uh integration) -------

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -324,10 +324,31 @@
               meta    (get fx-registry id {})
               handler (conformance/realise-fx-handler id body helpers)]
           (rf/reg-fx id (assoc meta :handler-fn handler) handler))))
-    ;; ---- app-schemas (Spec 010 §step 4 — the baseline `:schemas/runtime`
-    ;; surface) ---------------------------------------------------------
-    (doseq [[path schema] (get-in fixture [:fixture/registry :app-schema])]
-      (rf/reg-app-schema path schema))))
+    ;; NOTE: app-schemas are intentionally NOT registered here — see
+    ;; `realise-app-schemas` below. Per rf2-wkxng / rf2-6m0se,
+    ;; `destroy-frame!` now drops the frame's app-db schemas
+    ;; (parity with the machines / SSR / privacy destroy hooks), so
+    ;; schema registration must follow the runner's destroy+reg-frame
+    ;; cycle. Event / sub / cofx / fx registrations are global on
+    ;; the registrar and survive destroy-frame, so they continue to
+    ;; live here so `:on-create` can fire against them.
+    nil))
+
+(defn- realise-app-schemas
+  "Register the fixture's app-db schemas. Called AFTER the runner's
+  destroy+reg-frame cycle so the new frame's slate carries exactly
+  the fixture's declarations and nothing else.
+
+  Per rf2-wkxng / rf2-6m0se the destroy step now drops every schema
+  registered against the frame (parity with the machines / SSR /
+  privacy destroy hooks). Pre-fix the runner relied on the leak —
+  registering app-schemas inside `realise-handlers` BEFORE
+  `destroy-frame` and counting on the schemas to survive. With the
+  leak closed, app-schema registration is sequenced explicitly
+  after `reg-frame`."
+  [fixture]
+  (doseq [[path schema] (get-in fixture [:fixture/registry :app-schema])]
+    (rf/reg-app-schema path schema)))
 
 ;; ---- trace capture -------------------------------------------------------
 
@@ -432,6 +453,15 @@
           ;; Destroy first so the fixture's :on-create cascade fires
           ;; under its declared frame config.
           _            (rf/destroy-frame :rf/default)
+          ;; Per rf2-wkxng / rf2-6m0se: register app-db schemas
+          ;; AFTER the destroy step (the new
+          ;; `:schemas/on-frame-destroyed!` hook drops the frame's
+          ;; schemas on destroy, so registering them BEFORE the
+          ;; destroy would leak them through). Schemas must also
+          ;; precede `reg-frame` so the :on-create cascade fires
+          ;; with the schemas in place — the on-create's db commit
+          ;; will trigger validate-app-db! against the new slate.
+          _            (realise-app-schemas fixture)
           _            (rf/reg-frame :rf/default frame-config)
           dispatches   (or (:fixture/dispatches fixture) [])]
       (doseq [ev dispatches]

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -112,7 +112,99 @@
         (is (= 1 (count violations))
             "the malformed :n/break commit fires exactly one schema trace")
         (is (= :n/break (-> violations first :tags :failing-id))
-            ":failing-id names the handler whose commit prompted the failure")))))
+            ":failing-id names the handler whose commit prompted the failure")
+        (is (true? (-> violations first :tags :rollback?))
+            "Per rf2-wkxng / rf2-6m0se the trace carries :rollback? true")))))
+
+;; ---- rf2-wkxng / rf2-6m0se — app-db rollback on schema-validation failure --
+
+(deftest app-db-rollback-restores-pre-handler-value-on-failure
+  (testing "Per Spec 010 §Per-step recovery row 4 (rf2-wkxng / rf2-6m0se):
+            a post-handler app-db schema-validation failure rolls back
+            :db to the pre-handler value. The dispatch is treated as
+            failed; the bad commit does NOT stand."
+    (rf/reg-app-schema [:n] [:int])
+    (rf/reg-event-db :n/init  (fn [_ _]  {:n 0}))
+    (rf/reg-event-db :n/ok    (fn [db _] (assoc db :n 42)))
+    (rf/reg-event-db :n/break (fn [db _] (assoc db :n "boom")))
+    (rf/dispatch-sync [:n/init])
+    (is (= {:n 0} (rf/get-frame-db (rf/current-frame)))
+        "baseline post-init state")
+    (rf/dispatch-sync [:n/ok])
+    (is (= {:n 42} (rf/get-frame-db (rf/current-frame)))
+        "well-typed commit is durable")
+    (rf/dispatch-sync [:n/break])
+    (is (= {:n 42} (rf/get-frame-db (rf/current-frame)))
+        "malformed commit was ROLLED BACK to the pre-handler value
+         (was {:n 42} before :n/break; would be {:n \"boom\"} without
+         rollback)")))
+
+(deftest app-db-rollback-skips-fx-on-failure
+  (testing "Per rf2-wkxng / rf2-6m0se: on rollback the dispatch is
+            'treated as failed' — :fx does NOT walk. Sibling fx that
+            would have fired do not run."
+    (let [fx-calls (atom [])]
+      (rf/reg-fx :test/note (fn [v] (swap! fx-calls conj v)))
+      (rf/reg-app-schema [:n] [:int])
+      (rf/reg-event-fx :n/init
+        (fn [_ _] {:db {:n 0}}))
+      (rf/reg-event-fx :n/break-with-fx
+        (fn [_ _] {:db {:n "boom"}    ;; bad commit
+                   :fx [[:test/note :should-not-fire]]}))
+      (rf/dispatch-sync [:n/init])
+      (rf/dispatch-sync [:n/break-with-fx])
+      (is (= {:n 0} (rf/get-frame-db (rf/current-frame)))
+          "db rolled back")
+      (is (empty? @fx-calls)
+          "sibling fx did not walk — dispatch treated as failed"))))
+
+(deftest app-db-rollback-emits-second-db-changed-with-phase-rollback
+  (testing "Per rf2-wkxng / rf2-6m0se: rollback emits a second
+            :event/db-changed trace stamped :phase :rollback so
+            listeners observe the restored state without ambiguity.
+            Trace ordering: forward db-changed → schema-failure error
+            → rollback db-changed."
+    (rf/reg-app-schema [:n] [:int])
+    (rf/reg-event-db :n/init  (fn [_ _]  {:n 0}))
+    (rf/reg-event-db :n/break (fn [db _] (assoc db :n "boom")))
+    (let [events (atom [])]
+      (rf/register-trace-cb! ::ord
+        (fn [ev] (when (#{:event/db-changed
+                          :rf.error/schema-validation-failure}
+                        (:operation ev))
+                   (swap! events conj
+                          [(:operation ev)
+                           (-> ev :tags :phase)]))))
+      (rf/dispatch-sync [:n/init])
+      (reset! events [])
+      (rf/dispatch-sync [:n/break])
+      (rf/remove-trace-cb! ::ord)
+      ;; Three emissions in this exact order: forward commit (no phase),
+      ;; schema-failure error (no phase slot), rollback commit (phase
+      ;; :rollback).
+      (is (= [[:event/db-changed                     nil]
+              [:rf.error/schema-validation-failure   nil]
+              [:event/db-changed                     :rollback]]
+             @events)
+          "trace ordering: forward commit → schema-failure → rollback commit"))))
+
+(deftest validate-app-db-returns-boolean
+  (testing "Per rf2-wkxng / rf2-6m0se: validate-app-db! returns true on
+            conform (or no schemas / no validator), false on any
+            failure. The router consumes this to decide rollback."
+    (rf/reg-app-schema [:n] [:int])
+    (with-redefs [interop/debug-enabled? true]
+      (is (true?  (schemas/validate-app-db! {:n 42}))
+          "conforming value returns true")
+      (is (false? (schemas/validate-app-db! {:n "boom"}))
+          "non-conforming value returns false")
+      (is (true?  (schemas/validate-app-db! {:n 42} :some/handler))
+          "conforming + event-id arity returns true")
+      (is (false? (schemas/validate-app-db! {:n "boom"} :some/handler))
+          "non-conforming + event-id arity returns false"))
+    (with-redefs [interop/debug-enabled? false]
+      (is (true? (schemas/validate-app-db! {:n "boom"} :some/handler))
+          "production mode (debug-enabled? false) returns true unconditionally"))))
 
 ;; ---- rf2-jwm4 — event-payload validation ---------------------------------
 

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -138,7 +138,7 @@ A failure at any step aborts the dispatch with a structured error.
 | 1. Event-vector | The dispatched event vector doesn't conform to the handler's `:spec`. | Handler is **not invoked**; emit `:rf.error/schema-validation-failure` with `:where :event`. The cascade stops at this event; downstream events in the queue continue. |
 | 2. Cofx | A cofx's injected value doesn't conform to its `:spec`. | Handler is **not invoked**; emit with `:where :cofx`; same cascade behaviour as step 1. |
 | 3. Handler exception | A registered handler throws. | `:rf.error/handler-exception` (per [009](009-Instrumentation.md)); cascade halts. |
-| 4. `app-db` path | The post-handler `app-db` value at a registered schema-bound path doesn't conform. | Emit with `:where :app-db`. The `:db` effect is **rolled back** (the pre-handler value is restored) and the dispatch is treated as failed. |
+| 4. `app-db` path | The post-handler `app-db` value at a registered schema-bound path doesn't conform. | Emit with `:where :app-db`; the trace tag carries `:rollback? true` and `:recovery :no-recovery`. The `:db` effect is **rolled back** (the pre-handler value is restored) and the dispatch is treated as failed — flows do **not** evaluate and `:fx` does **not** walk for this dispatch. Downstream queued events still drain (per run-to-completion). |
 | 5. Fx-args | A registered fx's args map doesn't conform to its `:spec`. | The **offending fx is skipped**; emit with `:where :fx-args`, `:fx-id`, `:fx-args`. Other fx in the same `:fx` vector continue to run (per the run-to-completion drain — fx are independent). The cascade does **not** halt; downstream events in the queue still drain. The skipped-fx outcome is `:recovery :skipped`, mirroring `:rf.fx/skipped-on-platform`. |
 | 6. Sub return-value | A schema'd sub's computed value doesn't conform. | Emit with `:where :sub-return`. Default recovery: `:replaced-with-default` — the sub returns `nil` to its consumer; views see no value. Strict mode re-raises. |
 
@@ -315,8 +315,9 @@ Path-of-failure (`:tags :path`), failing handler id (`:tags :failing-id`), schem
              :explain    :rf/redacted      ;; Malli explanation redacted (re-leaks)
              :sensitive? true              ;; consumers route on this
              :reason     "App-db at path [:auth :token] failed schema ..."
-             :failing-id :auth/init-bad}
- :recovery :no-recovery}
+             :failing-id :auth/init-bad
+             :rollback?  true              ;; :db rolled back to pre-handler value
+             :recovery   :no-recovery}}    ;; dispatch failed; no auto-replacement
 ```
 
 **Composition with `:large?`** (per [009 §Unified wire-elision surface](009-Instrumentation.md#privacy--sensitive-data-in-traces)). A slot carrying both `:sensitive? true` and `:large? true` redacts on sensitivity — the schema-validation emit site never produces a `:rf.size/large-elided` marker for a sensitive value (the marker itself would leak `:path` / `:bytes` / `:digest`). The validation emit-site mirrors the `rf/elide-wire-value` walker's composition rule.

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -294,9 +294,10 @@ Per [009 §Privacy / sensitive data in traces](009-Instrumentation.md#privacy--s
 
 - Replace `:value` (the failing value) and `:received` (if present) with the framework-reserved sentinel keyword `:rf/redacted` (per [009 §`with-redacted` interceptor](009-Instrumentation.md#the-with-redacted-interceptor) — same sentinel, same reserved-keyword guarantee).
 - Replace `:explain` with `:rf/redacted` — the Malli explainer output carries the failing value verbatim under `:value` / `:errors[].value` and re-leaks it. Tools that want a structural error description without the value reach for the path (`:tags :path`) and the schema's id (`:tags :spec-id`).
+- Replace `:fx-args` with `:rf/redacted` on `:where :fx-args` emissions only — this slot is a per-surface doubled-id name for the failing value (semantically equivalent to `:received` on the fx surface; see Spec-Schemas `:rf.fx/handled`). Without redaction the fx-args slot would re-leak the value the `:value` / `:received` redactions just scrubbed.
 - Stamp `:sensitive? true` in the trace event's `:tags` map. Consumers route on `(get-in trace-event [:tags :sensitive?])` until top-level hoisting lands (rf2-isdwf is in flight in core; once landed, the runtime promotes `:tags :sensitive?` to the top-level `:sensitive?` slot per [009 §Trace-event field: `:sensitive?` at the top level](009-Instrumentation.md#trace-event-field-sensitive-at-the-top-level) — the schemas-side emit-site does not need to be revisited).
 
-Path-of-failure (`:tags :path`), failing handler id (`:tags :failing-id`), schema id (`:tags :spec-id`), and the human-readable `:reason` string remain unredacted — these are structural / categorical signals that do not carry user data, and consumers need them to locate the broken slot. Only the value-bearing slots (`:value`, `:received`, `:explain`) are redacted.
+Path-of-failure (`:tags :path`), failing handler id (`:tags :failing-id`), schema id (`:tags :spec-id`), and the human-readable `:reason` string remain unredacted — these are structural / categorical signals that do not carry user data, and consumers need them to locate the broken slot. Only the value-bearing slots (`:value`, `:received`, `:explain`, plus `:fx-args` on the fx surface) are redacted.
 
 ```clojure
 ;; Failing app-db at a sensitive slot:

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -637,7 +637,8 @@ Common keys (`:category`, `:failing-id`, `:reason`, `:frame`) are inherited from
    [:where       [:enum :event :sub-return :app-db :fx-args :cofx :cofx-args :on-create]]
    [:path        {:optional true} [:vector :any]]
    [:value       {:optional true} :any]
-   [:explain     {:optional true} :any]])              ;; Malli explanation shape
+   [:explain     {:optional true} :any]                ;; Malli explanation shape
+   [:rollback?   {:optional true} :boolean]])          ;; (:where :app-db only) true when :db was rolled back to pre-handler value
 
 (def DrainDepthExceededTags
   [:map

--- a/spec/conformance/fixtures/error-schema-failure.edn
+++ b/spec/conformance/fixtures/error-schema-failure.edn
@@ -31,9 +31,11 @@
  [[:counter/set-bad]]
 
  :fixture/expect
- ;; In dev mode, default recovery is :no-recovery — the cascade halts and
- ;; the offending app-db update IS still applied (validation runs after the
- ;; handler returns); production default is :replaced-with-default.
+ ;; Per Spec 010 §Per-step recovery row 4 (rf2-wkxng / rf2-6m0se):
+ ;; recovery is :no-recovery AND the :db effect is rolled back to the
+ ;; pre-handler value. The trace tag carries :rollback? true so
+ ;; consumers see both signals (the trace fires; the bad commit does
+ ;; not stand).
  {:trace-emissions
   [{:operation :event :tags {:event-id :counter/init}}
    {:operation :event :tags {:event-id :counter/set-bad}}
@@ -44,5 +46,6 @@
                 :where      :app-db
                 :path       [:count]
                 :value      "not-a-number"
+                :rollback?  true
                 :reason     "App-db at path [:count] failed schema [:int], got string."}
-    :recovery  :no-recovery}]}}                      ;; dev default; prod uses :replaced-with-default
+    :recovery  :no-recovery}]}}

--- a/spec/conformance/fixtures/schema-app-db-slice-validates.edn
+++ b/spec/conformance/fixtures/schema-app-db-slice-validates.edn
@@ -3,8 +3,10 @@
 ;; the slice at the registered path AFTER the handler's :db effect commits.
 ;; A handler that violates the slice's shape triggers
 ;; :rf.error/schema-validation-failure with :where :app-db and the
-;; offending :path. Recovery defaults to :no-recovery in dev (the bad
-;; commit is observable) — production switches to :replaced-with-default.
+;; offending :path. Per Spec 010 §Per-step recovery row 4 (rf2-wkxng /
+;; rf2-6m0se) the :db effect is ROLLED BACK to the pre-handler value
+;; and the dispatch is treated as failed; the trace tag carries
+;; :rollback? true and :recovery :no-recovery.
 ;;
 ;; This fixture pairs with error-schema-failure.edn (same surface, different
 ;; framing): error-schema-failure focuses on the error trace shape; this
@@ -43,11 +45,13 @@
   [:user/set-bad]]
 
  :fixture/expect
- ;; Final app-db reflects the bad commit — recovery is :no-recovery, so the
- ;; offending :db effect IS still applied; the trace records the violation.
- {:final-app-db {:user {:id "not-an-int" :email "carol@example.com"}}
+ ;; Final app-db reflects the LAST WELL-TYPED commit — per rf2-wkxng /
+ ;; rf2-6m0se the malformed :user/set-bad commit is rolled back to the
+ ;; pre-handler value ({:id 2 :email "bob@example.com"}, set by
+ ;; :user/set-good).
+ {:final-app-db {:user {:id 2 :email "bob@example.com"}}
 
-  :sub-values   {[:user] {:id "not-an-int" :email "carol@example.com"}}
+  :sub-values   {[:user] {:id 2 :email "bob@example.com"}}
 
   :trace-emissions
   [{:operation :event :tags {:event-id :user/init}}


### PR DESCRIPTION
## Summary

Batched cluster of four follow-on beads against `implementation/schemas/`. Sequenced inside the PR:

1. **rf2-5zfdn** (P2 audit, no code) — perf audit. Findings filed at `ai/findings/perf-audit-schemas-2026-05-14.md` (local-only). No low-hanging fix lifted in; the audit's recommendations (digest cache, schema-derivative precomputation) require structural changes to `storage.cljc`'s contract and are deferred. The other beads in this cluster are higher-priority correctness work.
2. **rf2-wkxng** (P1 decision) — spec/impl alignment for app-db schema-validation rollback.
3. **rf2-6m0se** (P1 impl) — implements the rollback.
4. **rf2-nijom** (P2 refactor) — drops the `validate-fx!` extra-redact lambda.

## DECISION (rf2-wkxng)

**Spec wins; impl rolls back.**

Spec 010 §Per-step recovery row 4 is normative: *"Roll back the `:db` effect; treat dispatch as failed."* The implementation had drifted to `:recovery :no-recovery` with no rollback — the trace fired but the malformed commit stood. Pre-alpha rationale: post-commit validation that silently lets a broken `:db` stand defeats the schema's purpose; by the time the trace fires, every downstream sub has already seen the bad value and re-rendered against it. The rolled-back contract gives apps a deterministic post-condition (dispatch succeeded AND app-db conforms, OR dispatch failed AND app-db is the pre-handler value).

The alternative (loosen the spec to `:no-recovery`) was the simpler-and-honest move from the bead body, but pre-alpha is the right time to take the more correct/complete behaviour.

### Implementation notes

- `validate-app-db!` now returns a boolean (true on conform / no validator / no schemas; false on any failure). Still emits one trace per failing entry.
- `commit-db-effect!` captures the pre-handler `:db` from `(get-in final-ctx [:coeffects :db])`, replaces the container, runs validation, and on a false return restores the pre-handler value plus emits a second `:event/db-changed` with `:phase :rollback`.
- `commit-and-flow!` skips flows AND `:fx` on a failing commit. *Treat dispatch as failed* is total. Downstream queue still drains.
- Trace tag carries `:rollback? true` alongside `:recovery :no-recovery` (consistent with `:rf.error/drain-depth-exceeded`; no new `:recovery` enum value).
- New `:schemas/on-frame-destroyed!` late-bind hook (mirrors `:machines/on-frame-destroyed!` / `:ssr/on-frame-destroyed`) — destroyed frames now drop their schema entries. Without this, schemas leaked across frame destroy/recreate cycles and re-fired as spurious rollbacks under the new contract.

### Fallout

- Three ad-hoc CLJS test fixtures (`helix_dispatch_frame_capture`, `uix_dispatch_frame_capture`, `elision_demo_cljs_test`) now clear `schemas-by-frame` via `:schemas/clear-by-frame!` — they used `(reset! frame/frames {})` directly and were leaking ns-load schemas into unrelated tests. Pre-rollback the leaks fired traces that no one was looking at; post-rollback they manifest as failing dispatches.
- Two example schemas wrap their slot registrations in `:maybe` (`boot/schema.cljs`, `counter_with_stories/elision_demo.cljs`) — the slots are absent (nil) before the driving handler writes them; the schemas already declared this absence semantically and just hadn't captured it under the validator.
- Two conformance fixtures updated to reflect rollback semantics; two conformance runners (`schemas_conformance_test.clj`, `conformance_corpus_cljs_test.cljs`) now register schemas AFTER the runner's `destroy-frame` step.

## Beads landed (4)

- `rf2-5zfdn` — perf audit (read-only, no code; findings local-only)
- `rf2-wkxng` — decision recorded + spec alignment (commit 1)
- `rf2-6m0se` — rollback impl (commit 2)
- `rf2-nijom` — extra-redact refactor (commit 3)

## LoC delta

`+475 / -153` across 18 files (~+322 net). Breakdown:
- Spec text: 5 files, ~+50/-20
- Core router + frame + late-bind directory: 3 files, ~+115/-15
- Schemas namespace (storage / validate / public API): 3 files, ~+115/-100 (most of the delta is updated docstrings)
- Tests + fixtures: 5 files, ~+155/-15
- Examples: 2 files, ~+25/-3

## Gates run

- `npm run test:cljs` — 1863 tests, 5279 assertions, 0 failures
- JVM schemas `cd implementation/schemas && clojure -M:test` — 183 tests, 509 assertions, 0 failures
- `npm run test:examples` — all 27 examples PASS (incl. boot, causa, conduit, todomvc, 7guis, state-machines, ssr, routing)

## Test plan

- [x] `npm run test:cljs`
- [x] `cd implementation/schemas && clojure -M:test`
- [x] `npm run test:examples`
- [ ] Browser tests (`npm run test:browser`) — not run locally (no Playwright in this dispatch); CI gate will exercise