### PR TITLE
perf(causa): batched cluster — 4 follow-on beads (incl. row-budget enforcement)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
@@ -536,22 +536,55 @@
   ;; epoch is selected, the diff is between the newest epoch's
   ;; :db-before and :db-after (the most recent settle).
   ;;
-  ;; Per spec §Changed-paths derivation the diff is computed
-  ;; lazily on panel mount and the result cached per :epoch-id.
-  ;; The composite sub recomputes only when the underlying
-  ;; (history × selection) tuple changes — re-renders of the same
-  ;; epoch return identical?-equal triples, which is the v1
-  ;; caching model.
-  (rf/reg-sub :rf.causa/selected-epoch-diff
-    :<- [:rf.causa/epoch-history]
-    :<- [:rf.causa/selected-epoch-id]
-    (fn [[history selected-id] _query]
-      (let [record (if selected-id
-                     (tt-helpers/find-epoch-in-history history selected-id)
-                     (peek (vec history)))]
-        (when record
-          (h/diff-paths (:db-before record)
-                       (:db-after  record))))))
+  ;; ## Per-:epoch-id diff cache (rf2-qvaa0)
+  ;;
+  ;; Diffing two app-dbs is O(changed-subtree-depth × key-count).
+  ;; On hosts with large app-dbs this is the most likely user-
+  ;; visible Causa slowdown — without the cache, every re-render
+  ;; that lands while the selection is unchanged re-runs the diff
+  ;; over identical inputs.
+  ;;
+  ;; Each `:rf/epoch-record` carries a stable `:epoch-id` plus
+  ;; immutable `:db-before` / `:db-after` snapshots — keying on
+  ;; `:epoch-id` is sufficient (the same id never refers to two
+  ;; different db-pairs). The cache is pruned to the current
+  ;; history's id-set on every read so it cannot grow beyond the
+  ;; retained epoch-history depth (which is itself bounded by the
+  ;; framework's epoch-record ring buffer).
+  ;;
+  ;; The cache is a private atom rather than a `with-meta`
+  ;; computation on the sub because reagent-sub identity caching
+  ;; only short-circuits when the underlying tuple is
+  ;; `identical?`-equal — with a freshly-vec'd `history` on every
+  ;; epoch settle the tuple shifts, so the sub re-runs even when
+  ;; the selected epoch hasn't changed. The atom-keyed cache
+  ;; collapses that to a map lookup.
+  (let [diff-cache (atom {})]
+    (rf/reg-sub :rf.causa/selected-epoch-diff
+      :<- [:rf.causa/epoch-history]
+      :<- [:rf.causa/selected-epoch-id]
+      (fn [[history selected-id] _query]
+        (let [record (if selected-id
+                       (tt-helpers/find-epoch-in-history history selected-id)
+                       (peek (vec history)))]
+          (when record
+            (let [epoch-id (:epoch-id record)
+                  ;; Cheap hit path — most renders.
+                  cached   (get @diff-cache epoch-id ::miss)]
+              (if (not= ::miss cached)
+                cached
+                ;; Miss — compute, store, and prune. Pruning keeps
+                ;; the cache size bounded by the live epoch-history
+                ;; depth without needing an LRU ordering.
+                (let [diff   (h/diff-paths (:db-before record)
+                                          (:db-after  record))
+                      live   (into #{} (map :epoch-id) history)]
+                  (swap! diff-cache
+                         (fn [m]
+                           (-> m
+                               (select-keys live)
+                               (assoc epoch-id diff))))
+                  diff))))))))
 
   ;; The pinned-slices store — `{frame-id [path-1 path-2 ...]}`.
   ;; Separate from Phase 3's :pin-store (which pins whole epoch

--- a/tools/causa/src/day8/re_frame2_causa/panels/common_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/common_helpers.cljc
@@ -1,4 +1,29 @@
-(ns day8.re-frame2-causa.panels.common-helpers)
+(ns day8.re-frame2-causa.panels.common-helpers
+  "Shared pure-data helpers used by every Causa panel-helper ns.
+
+  ## What lives here
+
+    - `now-ms`   — host-clock abstraction (testable via with-redefs).
+    - `tag-of`   — defensive trace-event tag reader.
+    - `panel-row-cap` + `cap-rows` — the canonical 200-row rendering
+      cap (per `tools/causa/spec/007-UX-IA.md` §Performance budget).
+      One source of truth; panels apply it at their row-rendering
+      boundary so DOM mount count stays bounded regardless of how
+      deep the underlying derivation grows.
+
+  ## Why a shared cap
+
+  The 200-row budget is pinned in
+  `test/.../perf_budget_cljs_test.cljc:88-92` as a hard contract but
+  was historically enforced only in `machine_inspector_helpers/
+  cap-transitions`. Eight long-list panels silently iterated whole
+  row vectors with `for`, exploding DOM mount + React-reconciliation
+  cost once the trace ring filled. Promoting the cap to a shared
+  helper closes that gap — every long-list panel applies the same
+  cap at the same boundary, with the same `:over-cap?` /
+  `:hidden-count` shape so the view can render a consistent overflow
+  affordance."
+  (:refer-clojure :exclude [cap-rows]))
 
 (defn now-ms
   "Return host-clock time in ms. Pure-ish — abstracted so test
@@ -17,3 +42,38 @@
   [ev k]
   (or (get-in ev [:tags k])
       (get ev k)))
+
+;; ---- 200-row rendering cap ----------------------------------------------
+
+(def panel-row-cap
+  "The 200-row-per-panel rendering cap pinned in
+  `tools/causa/spec/007-UX-IA.md` §Performance budget L611-612 and
+  asserted by `test/.../perf_budget_cljs_test.cljc:88-92`. Every
+  long-list panel applies this cap at its row-rendering boundary
+  before handing rows to the view, so DOM mount count is bounded
+  regardless of how deep the underlying derivation grows."
+  200)
+
+(defn cap-rows
+  "Apply the panel-row cap. Returns `[capped over-cap? hidden-count]`:
+
+      capped       — the first `n` rows (vector). Empty when `rows`
+                     is nil / empty.
+      over-cap?    — true iff the cap dropped at least one row.
+      hidden-count — `(count rows) - n` when over-cap?, else 0.
+
+  Default cap is `panel-row-cap` (200). Panels splat the result and
+  use `over-cap?` + `hidden-count` to drive an overflow indicator
+  (e.g. `+N rows hidden — narrow the filter to see more`). Pure fn;
+  JVM-runnable.
+
+  Mirrors `machine_inspector_helpers/cap-transitions` shape with the
+  caller-visible overflow metadata folded in. Callers that only want
+  the capped vector can `(first (cap-rows rows))`."
+  ([rows] (cap-rows rows panel-row-cap))
+  ([rows n]
+   (let [v     (vec (or rows []))
+         total (count v)]
+     (if (<= total n)
+       [v false 0]
+       [(subvec v 0 n) true (- total n)]))))

--- a/tools/causa/src/day8/re_frame2_causa/panels/effects.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/effects.cljs
@@ -56,6 +56,7 @@
   the algebra runs under the JVM unit-test target."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.effects-helpers :as h]
+            [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
 
@@ -193,14 +194,17 @@
   canonical sort order (errors first, then overridden, then skipped,
   then ok, then never-invoked)."
   [rows selected-fx-id]
-  (into [:ul {:data-testid "rf-causa-fx-list"
-              :style {:list-style "none"
-                      :margin     0
-                      :padding    0
-                      :background (:bg-2 tokens)}}]
-        (for [row rows]
-          ^{:key (h/format-fx-id (:fx-id row))}
-          (fx-row row (= (:fx-id row) selected-fx-id)))))
+  (overflow/capped-list
+    rows
+    {:panel-id "effects"
+     :ul-attrs {:data-testid "rf-causa-fx-list"
+                :style {:list-style "none"
+                        :margin     0
+                        :padding    0
+                        :background (:bg-2 tokens)}}
+     :row-fn   (fn [row]
+                 ^{:key (h/format-fx-id (:fx-id row))}
+                 (fx-row row (= (:fx-id row) selected-fx-id)))}))
 
 ;; ---- summary header -----------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -46,6 +46,7 @@
   coord is non-interactive plain text per the bead's contract."
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
+            [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]
             [day8.re-frame2-causa.theme.perf-tier :as perf-tier]))
@@ -290,14 +291,17 @@
                   :color       (:text-tertiary tokens)
                   :margin      0}}
       "No cascades yet. Trigger a dispatch in the host app to populate."]
-     (into [:ul {:data-testid "rf-causa-cascade-list"
-                 :style {:list-style "none"
-                         :margin     0
-                         :padding    0
-                         :border     (str "1px solid " (:border-subtle tokens))
-                         :border-radius "4px"
-                         :background (:bg-3 tokens)}}]
-           (map cascade-list-row cascades)))])
+     (overflow/capped-list
+       cascades
+       {:panel-id "event-detail"
+        :ul-attrs {:data-testid "rf-causa-cascade-list"
+                   :style {:list-style "none"
+                           :margin     0
+                           :padding    0
+                           :border     (str "1px solid " (:border-subtle tokens))
+                           :border-radius "4px"
+                           :background (:bg-3 tokens)}}
+        :row-fn   cascade-list-row}))])
 
 ;; ---- cascade detail (when a dispatch-id is selected) --------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/flows.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/flows.cljs
@@ -48,6 +48,7 @@
   algebra runs under the JVM unit-test target."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.flows-helpers :as h]
+            [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
 
@@ -174,14 +175,17 @@
   canonical sort order (failures first, then computing, skipping,
   idle)."
   [rows selected-flow-id]
-  (into [:ul {:data-testid "rf-causa-flows-list"
-              :style {:list-style "none"
-                      :margin     0
-                      :padding    0
-                      :background (:bg-2 tokens)}}]
-        (for [row rows]
-          ^{:key (h/format-flow-id (:flow-id row))}
-          (flow-row row (= (:flow-id row) selected-flow-id)))))
+  (overflow/capped-list
+    rows
+    {:panel-id "flows"
+     :ul-attrs {:data-testid "rf-causa-flows-list"
+                :style {:list-style "none"
+                        :margin     0
+                        :padding    0
+                        :background (:bg-2 tokens)}}
+     :row-fn   (fn [row]
+                 ^{:key (h/format-flow-id (:flow-id row))}
+                 (flow-row row (= (:flow-id row) selected-flow-id)))}))
 
 ;; ---- summary header -----------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger.cljs
@@ -447,6 +447,24 @@
     (fn [db _query]
       (get db :hydration-reroot-path)))
 
+  ;; ---- Phase 5 (rf2-qym6e) — sidebar presence sub --------------
+  ;;
+  ;; Cheap boolean for the sidebar's dormant-gate. The shell renders
+  ;; on every Causa interaction; reading the full mismatch-detail
+  ;; composite (which resolves selection, builds the side-by-side
+  ;; detail, and computes the source-coord) just to read
+  ;; `:has-mismatch?` is wasted reactive work. This sub answers the
+  ;; sidebar's only question (`is there at least one mismatch?`) for
+  ;; the cost of one `seq` over the projection.
+  ;;
+  ;; The full composite below (`:rf.causa/hydration-debugger-data`)
+  ;; stays exactly as-is so the panel view's contract is unchanged.
+  (rf/reg-sub :rf.causa/hydration-has-mismatch?
+    :<- [:rf.causa/trace-buffer]
+    :<- [:rf.causa/target-frame]
+    (fn [[buffer target-frame] _query]
+      (boolean (seq (h/mismatches-for-frame buffer target-frame)))))
+
   ;; The composite the panel consumes. Shape:
   ;;
   ;;     {:has-mismatch?        <bool>
@@ -465,6 +483,13 @@
   ;; scrubber uses) and falls back to nil (= all frames) when the
   ;; user hasn't pinned one. The behaviour matches Phase 3 / 4 —
   ;; the picker drops in without rewiring consumers.
+  ;;
+  ;; Note (rf2-qym6e): consumers that only need the boolean presence
+  ;; of a mismatch (the sidebar dormant gate) read
+  ;; `:rf.causa/hydration-has-mismatch?` above instead of this
+  ;; composite — every shell render derefs the dormant gate, and the
+  ;; full composite resolves the side-by-side detail + source-coord
+  ;; work that the sidebar never needs.
   (rf/reg-sub :rf.causa/hydration-debugger-data
     :<- [:rf.causa/trace-buffer]
     :<- [:rf.causa/selected-mismatch-id]

--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
@@ -54,6 +54,7 @@
   the JVM unit-test target."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.issues-ribbon-helpers :as h]
+            [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
 
@@ -369,12 +370,14 @@
       (case empty-kind
         :no-issues  (empty-state-no-issues)
         :no-matches (empty-state-no-matches)
-        nil         (into [:ul {:data-testid "rf-causa-issues-feed"
-                                :style       {:list-style "none"
-                                              :margin     0
-                                              :padding    0}}]
-                          (for [issue issues]
-                            (issue-row issue))))]]))
+        nil         (overflow/capped-list
+                      issues
+                      {:panel-id "issues"
+                       :ul-attrs {:data-testid "rf-causa-issues-feed"
+                                  :style       {:list-style "none"
+                                                :margin     0
+                                                :padding    0}}
+                       :row-fn   issue-row}))]]))
 
 ;; ---- registration entry --------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon_helpers.cljc
@@ -311,8 +311,15 @@
 ;; ---- composite projection (the panel reads this) ------------------------
 
 (defn project-feed
-  "Top-level projection — produces every slot the view needs in one
-  pass. Pure data → data; JVM-testable.
+  "Top-level projection — produces every slot the view needs. Pure
+  data → data; JVM-testable.
+
+  Walks the trace buffer once via `project-issues`, applies the
+  filter pass via `apply-filters`, and computes the severity
+  histogram + distinct-prefix axis off the projection. Cost is
+  bounded by the trace ring depth (Spec 009 §Trace bus). The
+  single-pass collapse is deferred until row caps have landed and
+  measurable residual cost remains (rf2-60vcu).
 
   Returns:
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/mcp_server.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/mcp_server.cljs
@@ -69,6 +69,7 @@
   unit-test target."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.mcp-server-helpers :as h]
+            [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
             [day8.re-frame2-causa.theme.tokens :as theme
              :refer [mono-stack sans-stack]]))
 
@@ -461,12 +462,14 @@
       (case empty-kind
         :no-activity (empty-state-no-activity)
         :no-matches  (empty-state-no-matches)
-        nil          (into [:ul {:data-testid "rf-causa-mcp-feed"
-                                 :style       {:list-style "none"
-                                               :margin     0
-                                               :padding    0}}]
-                           (for [row rows]
-                             (mcp-row row))))]]))
+        nil          (overflow/capped-list
+                       rows
+                       {:panel-id "mcp"
+                        :ul-attrs {:data-testid "rf-causa-mcp-feed"
+                                   :style       {:list-style "none"
+                                                 :margin     0
+                                                 :padding    0}}
+                        :row-fn   mcp-row}))]]))
 
 ;; ---- registration entry --------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/mcp_server_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/mcp_server_helpers.cljc
@@ -308,8 +308,14 @@
 ;; ---- composite projection (the panel reads this) ------------------------
 
 (defn project-feed
-  "Top-level projection — produces every slot the view needs in one
-  pass. Pure data → data; JVM-testable.
+  "Top-level projection — produces every slot the view needs. Pure
+  data → data; JVM-testable.
+
+  Walks the trace buffer once via `project-rows`, applies the filter
+  pass, and computes the op-type histogram + distinct-axis off the
+  projection. Cost is bounded by the trace ring depth (Spec 009
+  §Trace bus). The single-pass collapse is deferred until row caps
+  land and measurable residual cost remains (rf2-60vcu).
 
   Returns:
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/overflow_indicator.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/overflow_indicator.cljc
@@ -1,0 +1,100 @@
+(ns day8.re-frame2-causa.panels.overflow-indicator
+  "Shared overflow-indicator row + capped-list builder for long-list
+  panels (rf2-1k5r1).
+
+  ## Why this lives in its own ns
+
+  Every long-list panel (trace, issues-ribbon, mcp-server, performance,
+  event-detail, subscriptions, effects, flows) caps row rendering at
+  the 200-row budget pinned in `tools/causa/spec/007-UX-IA.md`
+  §Performance budget. When the cap drops rows the view must surface
+  a uniform 'N more hidden — narrow the filter to see more' affordance
+  so the user knows their data is bigger than what's on screen.
+
+  The indicator is pure hiccup; a `.cljc` ns lets the JVM test target
+  assert against the rendered shape without a CLJS runtime.
+
+  ## Shape
+
+  The indicator is a `[:li]` so it slots into the same `[:ul]` the
+  capped rows live in — keyboard / scroll behaviour stays consistent.
+  The user-visible text matches the existing
+  `machine_inspector.cljs` ribbon pattern (`N of M`) which already
+  shipped in v1 for the transition-history surface.
+
+  ## capped-list builder
+
+  Eight panels share the same cap-list-then-append-overflow shape.
+  `capped-list` folds the boilerplate into one fn so the per-panel
+  view stays focused on the row hiccup."
+  (:require [day8.re-frame2-causa.panels.common-helpers :as common]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens sans-stack mono-stack]]))
+
+(defn overflow-row
+  "Render the 'N rows hidden' affordance when the row-cap dropped at
+  least one row. Returns nil when `over-cap?` is falsy so the caller
+  can `(when over-cap? ...)` or unconditionally splat with no extra
+  DOM.
+
+  `panel-id` is a stable string used in the `data-testid` so per-panel
+  tests can assert the indicator landed. `hidden-count` is the number
+  of rows the cap dropped.
+
+  Per `tools/causa/spec/007-UX-IA.md` §Performance budget the cap is
+  a hard rendering ceiling; the indicator is the contract surface that
+  tells the user their data is bigger than what's on screen."
+  [{:keys [panel-id over-cap? hidden-count]}]
+  (when over-cap?
+    [:li {:data-testid (str "rf-causa-" panel-id "-overflow-indicator")
+          :style       {:list-style    "none"
+                        :padding       "10px 16px"
+                        :border-top    (str "1px dashed "
+                                            (:border-default tokens))
+                        :background    (:bg-3 tokens)
+                        :color         (:text-tertiary tokens)
+                        :font-family   sans-stack
+                        :font-size     "11px"
+                        :line-height   1.4
+                        :text-align    "center"
+                        :font-style    "italic"}}
+     [:span {:style {:font-family mono-stack
+                     :color       (:text-secondary tokens)
+                     :margin-right "4px"}}
+      (str "+" hidden-count)]
+     " row"
+     (when (not= 1 hidden-count) "s")
+     " hidden — narrow the filter or selection to see more."]))
+
+(defn capped-list
+  "Build a `[:ul ...]` of `rows` capped at the 200-row panel budget,
+  appending the shared overflow indicator when the cap drops rows.
+
+  `opts` is `{:panel-id <string> :ul-attrs <map> :row-fn <fn>}`.
+
+    :panel-id — stable string used in both the overflow indicator's
+                testid (`rf-causa-<panel-id>-overflow-indicator`) and
+                the caller's own per-row testid scheme. Caller-owned.
+
+    :ul-attrs — the attribute map for the `[:ul]` wrapper — testid,
+                style, etc. Passed through verbatim so per-panel
+                styling (background colour, padding) stays in the
+                caller.
+
+    :row-fn   — `(fn [row] hiccup)` rendering one row. Hiccup-only;
+                meta-keys (^{:key …}) live in the caller's row-fn so
+                each panel keeps its own keying convention.
+
+  Returns a hiccup vector. Pure fn; JVM-runnable.
+
+  Cap source-of-truth lives in `common-helpers/panel-row-cap` (200,
+  per spec/007 §Performance budget). The overflow indicator is the
+  `[:li]` rendered from `overflow-row` and is `conj`-ed onto the
+  `[:ul]` only when the cap drops at least one row."
+  [rows {:keys [panel-id ul-attrs row-fn]}]
+  (let [[capped over-cap? hidden] (common/cap-rows rows)]
+    (cond-> (into [:ul ul-attrs] (map row-fn capped))
+      over-cap?
+      (conj (overflow-row {:panel-id     panel-id
+                           :over-cap?    over-cap?
+                           :hidden-count hidden})))))

--- a/tools/causa/src/day8/re_frame2_causa/panels/performance.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/performance.cljs
@@ -60,6 +60,7 @@
       (count of `:view/render` traces in the cascade) until that slot
       surfaces."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
             [day8.re-frame2-causa.panels.performance-helpers :as h]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
@@ -273,12 +274,14 @@
      [:div {:style {:flex 1 :overflow "auto"}}
       (if empty?
         (empty-state)
-        (into [:ul {:data-testid "rf-causa-perf-feed"
-                    :style       {:list-style "none"
-                                  :margin     0
-                                  :padding    0}}]
-              (for [row rows]
-                (perf-row row))))]]))
+        (overflow/capped-list
+          rows
+          {:panel-id "performance"
+           :ul-attrs {:data-testid "rf-causa-perf-feed"
+                      :style       {:list-style "none"
+                                    :margin     0
+                                    :padding    0}}
+           :row-fn   perf-row}))]]))
 
 ;; ---- registration entry --------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/subscriptions.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/subscriptions.cljs
@@ -40,6 +40,7 @@
   the algebra runs under the JVM unit-test target."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.defaults :as defaults]
+            [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
             [day8.re-frame2-causa.panels.subscriptions-helpers :as h]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
@@ -239,14 +240,17 @@
                          :font-family sans-stack
                          :font-size "13px"}}
      "No subscriptions match the current filter."]
-    (into [:ul {:data-testid "rf-causa-subscriptions-list"
-                :style {:list-style "none"
-                        :margin     0
-                        :padding    0
-                        :background (:bg-2 tokens)}}]
-          (for [row rows]
-            ^{:key (h/format-query-v (:query-v row))}
-            (sub-row row (= (:query-v row) selected-query-v))))))
+    (overflow/capped-list
+      rows
+      {:panel-id "subscriptions"
+       :ul-attrs {:data-testid "rf-causa-subscriptions-list"
+                  :style {:list-style "none"
+                          :margin     0
+                          :padding    0
+                          :background (:bg-2 tokens)}}
+       :row-fn   (fn [row]
+                   ^{:key (h/format-query-v (:query-v row))}
+                   (sub-row row (= (:query-v row) selected-query-v)))})))
 
 ;; ---- invalidation-chain view --------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -60,6 +60,7 @@
   `trace_helpers.cljc` so the algebra runs under the JVM unit-test
   target."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
             [day8.re-frame2-causa.panels.trace-helpers :as h]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
@@ -395,12 +396,14 @@
       (case empty-kind
         :no-events  (empty-state-no-events)
         :no-matches (empty-state-no-matches)
-        nil         (into [:ul {:data-testid "rf-causa-trace-feed"
-                                :style       {:list-style "none"
-                                              :margin     0
-                                              :padding    0}}]
-                          (for [row rows]
-                            (trace-row row))))]]))
+        nil         (overflow/capped-list
+                      rows
+                      {:panel-id "trace"
+                       :ul-attrs {:data-testid "rf-causa-trace-feed"
+                                  :style       {:list-style "none"
+                                                :margin     0
+                                                :padding    0}}
+                       :row-fn   trace-row}))]]))
 
 ;; ---- registration entry --------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
@@ -236,8 +236,15 @@
 ;; ---- composite projection (the panel reads this) ------------------------
 
 (defn project-feed
-  "Top-level projection — produces every slot the view needs in one
-  pass. Pure data → data; JVM-testable.
+  "Top-level projection — produces every slot the view needs. Pure
+  data → data; JVM-testable.
+
+  The body projects the trace buffer twice (raw + filtered) and then
+  runs an axis-distinct + axis-count pass for each filter axis. Cost
+  is bounded by the 1000-event trace ring (Spec 009 §Trace bus). A
+  single-pass collapse is on the deferred follow-on list once row
+  caps have landed and we can measure residual cost in practice
+  (rf2-60vcu).
 
   Returns:
 

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -169,23 +169,20 @@
   Phase 2: the active panel is driven by `:rf.causa/selected-panel`.
   Clicking a row dispatches `:rf.causa/select-panel`.
 
-  ## Hydration dormant gate (rf2-pzxsr)
+  ## Hydration dormant gate (rf2-pzxsr / rf2-qym6e)
 
   Per `tools/causa/spec/006-Hydration-Debugger.md` §Visibility the
   Hydration sidebar entry is dormant (`◌`) until at least one
   `:rf.ssr/hydration-mismatch` trace lands. The gate reads the
-  panel's composite — if `:has-mismatch?` is truthy the dormant flag
-  is dropped and the entry behaves like every other live panel.
-
-  The lift here is intentionally a one-line override rather than a
-  per-item subscribe — the composite already exists for the panel,
-  re-using it keeps the reactive graph minimal."
+  cheap presence sub `:rf.causa/hydration-has-mismatch?` (rf2-qym6e)
+  — boolean-only, so the sidebar's reactive path doesn't pull the
+  full mismatch-detail composite (which resolves selection, computes
+  the side-by-side detail, and walks the source-coord) on every
+  shell re-render."
   []
   (let [active (or @(rf/subscribe [:rf.causa/selected-panel])
                    registry/default-panel-id)
-        hydration-awake? (boolean
-                           (get @(rf/subscribe [:rf.causa/hydration-debugger-data])
-                                :has-mismatch?))
+        hydration-awake? @(rf/subscribe [:rf.causa/hydration-has-mismatch?])
         items-resolved
         (mapv (fn [item]
                 (cond-> item

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
@@ -210,6 +210,69 @@
                  diff)
               ":e-2's diff selected, not :e-3's"))))))
 
+;; ---- (3b) per-:epoch-id diff cache (rf2-qvaa0) --------------------------
+
+(deftest selected-epoch-diff-cache-hits-on-repeat-deref
+  (testing "the diff is computed once per :epoch-id — second deref of
+            the same selection returns identical?-equal triples (the
+            cache short-circuit, not just =-equal)"
+    (let [hist [(mk-record :e-1 [:counter/inc]
+                           {:counter 0} {:counter 1})]]
+      (seed-causa! {:counter 1} hist)
+      (rf/with-frame :rf/causa
+        (let [first-call  @(rf/subscribe [:rf.causa/selected-epoch-diff])
+              second-call @(rf/subscribe [:rf.causa/selected-epoch-diff])]
+          (is (= first-call second-call))
+          (is (identical? first-call second-call)
+              "second deref returns the cached object — no recompute"))))))
+
+(deftest selected-epoch-diff-cache-evicts-aged-out-epochs
+  (testing "epoch-ids no longer in the history get pruned from the
+            cache — the cache cannot grow past the history depth"
+    (let [hist-a [(mk-record :e-1 [:a] {} {:n 1})]
+          hist-b [(mk-record :e-2 [:b] {} {:n 2})
+                  (mk-record :e-3 [:c] {:n 2} {:n 3})]]
+      (seed-causa! {:n 1} hist-a)
+      (rf/with-frame :rf/causa
+        ;; Warm the cache with :e-1's diff.
+        @(rf/subscribe [:rf.causa/selected-epoch-diff])
+        ;; Rotate the history — :e-1 ages out, :e-2/:e-3 take its place.
+        (rf/dispatch-sync [:rf.causa-test/seed-history hist-b])
+        ;; Read the new newest-epoch diff. The cache must prune :e-1
+        ;; (no longer in history) on this read.
+        (let [diff @(rf/subscribe [:rf.causa/selected-epoch-diff])]
+          (is (= [{:op :modified :path [:n] :before 2 :after 3}]
+                 diff)
+              "newest-epoch (:e-3) diff is fresh; :e-1's entry is gone"))))))
+
+(deftest selected-epoch-diff-cache-distinguishes-distinct-epochs
+  (testing "different :epoch-id selections each get their own cached diff"
+    (let [hist [(mk-record :e-1 [:a] {} {:counter 0})
+                (mk-record :e-2 [:counter/inc]
+                           {:counter 0} {:counter 1})
+                (mk-record :e-3 [:counter/inc]
+                           {:counter 1} {:counter 2})]]
+      (seed-causa! {:counter 2} hist)
+      (rf/with-frame :rf/causa
+        (rf/dispatch-sync [:rf.causa/select-epoch :e-2])
+        (let [diff-e2 @(rf/subscribe [:rf.causa/selected-epoch-diff])]
+          (rf/dispatch-sync [:rf.causa/select-epoch :e-3])
+          (let [diff-e3 @(rf/subscribe [:rf.causa/selected-epoch-diff])]
+            (is (not= diff-e2 diff-e3)
+                "different selections produce different diffs")
+            (is (= [{:op :modified :path [:counter] :before 0 :after 1}]
+                   diff-e2))
+            (is (= [{:op :modified :path [:counter] :before 1 :after 2}]
+                   diff-e3))))
+        ;; Returning to :e-2 still gets its cached triples (identical?
+        ;; to the first read — proves the cache survives the cross-
+        ;; selection roundtrip).
+        (rf/dispatch-sync [:rf.causa/select-epoch :e-2])
+        (let [diff-e2-second @(rf/subscribe [:rf.causa/selected-epoch-diff])
+              diff-e2-third  @(rf/subscribe [:rf.causa/selected-epoch-diff])]
+          (is (identical? diff-e2-second diff-e2-third)
+              "the cache survives selection changes"))))))
+
 ;; ---- (4) reserved-keys segregation at the composite level ---------------
 
 (deftest app-db-diff-segregates-reserved-keys

--- a/tools/causa/test/day8/re_frame2_causa/panels/common_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/common_helpers_cljs_test.cljc
@@ -1,0 +1,83 @@
+(ns day8.re-frame2-causa.panels.common-helpers-cljs-test
+  "Tests for the shared panel-helper surfaces — the 200-row cap and
+  the trace-event tag reader (rf2-1k5r1).
+
+  Dual-target naming (`.cljc` + `_cljs_test`) — same pattern as every
+  other panel-helper test:
+
+    - Cognitect's test-runner picks it up via `.*-test$`.
+    - Shadow's `:node-test` build picks it up via `cljs-test$`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.common-helpers :as common]))
+
+;; ---- tag-of -------------------------------------------------------------
+
+(deftest tag-of-reads-tags-slot
+  (is (= :ok   (common/tag-of {:tags {:k :ok}} :k)))
+  (is (= :ok   (common/tag-of {:k :ok} :k))  ; flat fallback for tests
+      "flat shape falls through — tolerant for test fixtures")
+  (is (nil?    (common/tag-of {} :missing))))
+
+;; ---- panel-row-cap ------------------------------------------------------
+
+(deftest panel-row-cap-is-200
+  (testing "the cap matches spec/007-UX-IA.md §Performance budget"
+    (is (= 200 common/panel-row-cap))))
+
+;; ---- cap-rows -----------------------------------------------------------
+
+(deftest cap-rows-under-cap-passes-through-with-flag-false
+  (let [rows (mapv (fn [i] {:id i}) (range 50))
+        [capped over-cap? hidden] (common/cap-rows rows)]
+    (is (= rows capped))
+    (is (false? over-cap?))
+    (is (zero?  hidden))))
+
+(deftest cap-rows-at-exact-cap-passes-through
+  (let [rows (mapv (fn [i] {:id i}) (range common/panel-row-cap))
+        [capped over-cap? hidden] (common/cap-rows rows)]
+    (is (= common/panel-row-cap (count capped)))
+    (is (false? over-cap?))
+    (is (zero?  hidden))))
+
+(deftest cap-rows-over-cap-truncates-and-reports-hidden
+  (let [rows (mapv (fn [i] {:id i}) (range (+ 50 common/panel-row-cap)))
+        [capped over-cap? hidden] (common/cap-rows rows)]
+    (is (= common/panel-row-cap (count capped)))
+    (is (true? over-cap?))
+    (is (= 50 hidden))
+    (testing "head-retained: the first row of the input is the first row out"
+      (is (= {:id 0} (first capped))))))
+
+(deftest cap-rows-with-explicit-cap
+  (let [rows (mapv (fn [i] {:id i}) (range 20))
+        [capped over-cap? hidden] (common/cap-rows rows 5)]
+    (is (= 5 (count capped)))
+    (is (true? over-cap?))
+    (is (= 15 hidden))))
+
+(deftest cap-rows-nil-and-empty-tolerant
+  (testing "nil rows → empty capped, no overflow"
+    (let [[capped over-cap? hidden] (common/cap-rows nil)]
+      (is (= [] capped))
+      (is (false? over-cap?))
+      (is (zero?  hidden))))
+  (testing "empty rows → empty capped, no overflow"
+    (let [[capped over-cap? hidden] (common/cap-rows [])]
+      (is (= [] capped))
+      (is (false? over-cap?))
+      (is (zero?  hidden)))))
+
+(deftest cap-rows-preserves-row-shape
+  (testing "rows pass through unchanged — no key drops or coercion"
+    (let [rich [{:id 1 :payload {:deep {:value 42}}}
+                {:id 2 :payload {:deep {:value 43}}}]
+          [capped _ _] (common/cap-rows rich)]
+      (is (= rich capped)))))
+
+(deftest cap-rows-is-pure
+  (testing "repeat invocations on the same input produce equal output"
+    (let [rows (mapv (fn [i] {:id i}) (range 300))]
+      (is (= (common/cap-rows rows)
+             (common/cap-rows rows))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_view_cljs_test.cljs
@@ -116,7 +116,49 @@
     (is (some? (registrar/handler :sub :rf.causa/selected-mismatch-id))
         "selected-mismatch-id sub is registered")
     (is (some? (registrar/handler :sub :rf.causa/hydration-reroot-path))
-        "hydration-reroot-path sub is registered")))
+        "hydration-reroot-path sub is registered")
+    (is (some? (registrar/handler :sub :rf.causa/hydration-has-mismatch?))
+        "cheap presence sub for the sidebar dormant gate is registered (rf2-qym6e)")))
+
+;; ---- (1b) sidebar presence sub (rf2-qym6e) ------------------------------
+
+(deftest hydration-has-mismatch-sub-is-false-on-empty-buffer
+  (testing "with no mismatches in the buffer, the presence sub is false"
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (is (false? @(rf/subscribe [:rf.causa/hydration-has-mismatch?]))))))
+
+(deftest hydration-has-mismatch-sub-true-once-mismatch-lands
+  (testing "after a mismatch trace lands, the presence sub flips to true"
+    (seed-buffer! [(mismatch-ev 1 [:div :main]
+                                [:p "3 items"]
+                                [:p "0 items"])])
+    (rf/with-frame :rf/causa
+      (is (true? @(rf/subscribe [:rf.causa/hydration-has-mismatch?]))))))
+
+(deftest hydration-has-mismatch-sub-respects-target-frame
+  (testing "the presence sub filters by :target-frame, matching the full
+            composite's frame-awareness — a mismatch tagged on a
+            different frame does not wake the default target"
+    (seed-buffer! [(mismatch-ev 1 [:p] [:a] [:b] {:frame :rf/other})])
+    (rf/with-frame :rf/causa
+      ;; Default target-frame is :rf/default — no mismatches for it.
+      (is (false? @(rf/subscribe [:rf.causa/hydration-has-mismatch?]))
+          "wrong-frame mismatches do not wake the sidebar"))))
+
+(deftest hydration-has-mismatch-sub-matches-composite-boolean
+  (testing "the cheap presence sub and the full composite agree on the
+            boolean — they're the same projection, one returns just the
+            slot the sidebar reads"
+    (seed-buffer! [(mismatch-ev 1 [:div :main]
+                                [:p "3 items"]
+                                [:p "0 items"])])
+    (rf/with-frame :rf/causa
+      (let [presence @(rf/subscribe [:rf.causa/hydration-has-mismatch?])
+            full     @(rf/subscribe [:rf.causa/hydration-debugger-data])]
+        (is (= presence (:has-mismatch? full))
+            "cheap-presence sub agrees with the full composite's boolean")))))
 
 (deftest registry-installs-hydration-debugger-events
   (testing "the Phase 5 events are registered"

--- a/tools/causa/test/day8/re_frame2_causa/panels/overflow_indicator_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/overflow_indicator_cljs_test.cljc
@@ -1,0 +1,124 @@
+(ns day8.re-frame2-causa.panels.overflow-indicator-cljs-test
+  "Tests for the shared overflow-indicator hiccup (rf2-1k5r1).
+
+  The overflow indicator is the contract surface the user sees when
+  the 200-row panel-cap drops rows. Tests pin: nil-when-not-over-cap,
+  the testid pattern (`rf-causa-<panel-id>-overflow-indicator`), and
+  that the hidden-count is rendered in the row."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.overflow-indicator :as overflow]))
+
+(defn- testid
+  "Pull the data-testid out of a hiccup node — first attribute map."
+  [hiccup]
+  (some-> hiccup second :data-testid))
+
+(defn- hiccup-text
+  "Walk a hiccup vector collecting strings — handy for asserting the
+  user-visible text without caring about layout."
+  [node]
+  (cond
+    (string? node) node
+    (vector? node) (apply str (map hiccup-text (rest node)))
+    (sequential? node) (apply str (map hiccup-text node))
+    :else ""))
+
+(deftest overflow-row-returns-nil-when-not-over-cap
+  (is (nil? (overflow/overflow-row {:panel-id     "trace"
+                                    :over-cap?    false
+                                    :hidden-count 0})))
+  (testing "nil over-cap? also yields nil — no indicator rendered"
+    (is (nil? (overflow/overflow-row {:panel-id     "trace"
+                                      :over-cap?    nil
+                                      :hidden-count 5})))))
+
+(deftest overflow-row-renders-when-over-cap
+  (let [node (overflow/overflow-row {:panel-id     "trace"
+                                     :over-cap?    true
+                                     :hidden-count 42})]
+    (is (vector? node))
+    (is (= :li (first node)))
+    (is (= "rf-causa-trace-overflow-indicator" (testid node)))))
+
+(deftest overflow-row-renders-hidden-count
+  (let [node (overflow/overflow-row {:panel-id     "issues"
+                                     :over-cap?    true
+                                     :hidden-count 137})
+        text (hiccup-text node)]
+    (is (re-find #"\+137" text)
+        "the indicator surfaces the hidden count as +N")
+    (is (re-find #"rows hidden" text)
+        "pluralised when >1 hidden")))
+
+(deftest overflow-row-singularises-for-one-hidden
+  (let [node (overflow/overflow-row {:panel-id     "subs"
+                                     :over-cap?    true
+                                     :hidden-count 1})
+        text (hiccup-text node)]
+    (is (re-find #"row hidden" text)
+        "single-row case avoids the trailing 's'")
+    (is (not (re-find #"rows hidden" text)))))
+
+(deftest overflow-row-panel-id-flows-into-testid
+  (let [ids ["trace" "issues" "mcp" "performance" "event-detail"
+             "subscriptions" "effects" "flows"]]
+    (doseq [pid ids]
+      (let [node (overflow/overflow-row {:panel-id     pid
+                                         :over-cap?    true
+                                         :hidden-count 1})]
+        (is (= (str "rf-causa-" pid "-overflow-indicator")
+               (testid node))
+            (str "panel-id " pid " produces matching testid"))))))
+
+;; ---- capped-list --------------------------------------------------------
+
+(defn- ul-children
+  "Skip the `[:ul attrs ...]` head and return the row sequence."
+  [ul]
+  (drop 2 ul))
+
+(deftest capped-list-under-cap-renders-no-overflow-indicator
+  (let [rows (mapv (fn [i] {:id i}) (range 50))
+        ul   (overflow/capped-list
+               rows
+               {:panel-id "trace"
+                :ul-attrs {:data-testid "rf-causa-trace-feed"}
+                :row-fn   (fn [{:keys [id]}]
+                            [:li {:data-testid (str "row-" id)} id])})]
+    (is (= :ul (first ul)))
+    (is (= "rf-causa-trace-feed" (testid ul)))
+    (is (= 50 (count (ul-children ul)))
+        "all rows render under the cap; no overflow row appended")
+    (testing "no overflow indicator slot"
+      (let [rendered (ul-children ul)]
+        (is (every? (fn [n] (not= "rf-causa-trace-overflow-indicator"
+                                  (testid n)))
+                    rendered))))))
+
+(deftest capped-list-over-cap-appends-overflow-indicator
+  (let [n    (+ 50 250)
+        rows (mapv (fn [i] {:id i}) (range n))
+        ul   (overflow/capped-list
+               rows
+               {:panel-id "issues"
+                :ul-attrs {:data-testid "rf-causa-issues-feed"}
+                :row-fn   (fn [{:keys [id]}]
+                            [:li {:data-testid (str "row-" id)} id])})
+        children (ul-children ul)]
+    (is (= 200 (dec (count children)))
+        "200 capped rows + 1 overflow indicator (cap drops to 200)")
+    (is (= "rf-causa-issues-overflow-indicator"
+           (testid (last children)))
+        "overflow indicator is the last child of the [:ul]")))
+
+(deftest capped-list-passes-ul-attrs-verbatim
+  (let [attrs  {:data-testid "rf-causa-mcp-feed"
+                :style       {:background "purple"}
+                :class       "custom-class"}
+        ul     (overflow/capped-list
+                 [] {:panel-id "mcp"
+                     :ul-attrs attrs
+                     :row-fn   identity})]
+    (is (= attrs (second ul))
+        "the caller's :ul-attrs reach the rendered [:ul] unchanged")))

--- a/tools/causa/test/day8/re_frame2_causa/perf_budget_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/perf_budget_cljs_test.cljc
@@ -80,6 +80,7 @@
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.causality-graph-helpers :as cg]
+            [day8.re-frame2-causa.panels.common-helpers :as common]
             [day8.re-frame2-causa.panels.performance-helpers :as perf]
             [day8.re-frame2-causa.panels.subscriptions-helpers :as subs]))
 
@@ -612,3 +613,44 @@
             spec/007 §Performance budget INP claim depends on this
             target."
     (is (= 16 perf/default-budget-ms))))
+
+;; -------------------------------------------------------------------------
+;; (8) Shared panel-row cap helper — every long-list panel applies this
+;;     at its row-rendering boundary (rf2-1k5r1).
+;; -------------------------------------------------------------------------
+
+(deftest shared-cap-helper-pins-the-spec-budget
+  (testing "common/panel-row-cap matches the spec-derived constant"
+    (is (= panel-row-cap common/panel-row-cap)
+        "spec/007 §Performance budget cap is the single source of truth")))
+
+(deftest shared-cap-helper-truncates-and-reports-hidden
+  (testing "cap-rows over the cap returns [capped true hidden]"
+    (let [rows                       (mapv (fn [i] {:id i})
+                                           (range (+ 50 panel-row-cap)))
+          [capped over-cap? hidden]  (common/cap-rows rows)]
+      (is (= panel-row-cap (count capped))
+          "exactly the cap is retained")
+      (is (true? over-cap?)
+          "over-cap flag fires so the view can render an indicator")
+      (is (= 50 hidden)
+          "hidden count is total - cap"))))
+
+(deftest shared-cap-helper-under-cap-is-passthrough
+  (testing "cap-rows under the cap returns [rows false 0]"
+    (let [rows                      (mapv (fn [i] {:id i}) (range 50))
+          [capped over-cap? hidden] (common/cap-rows rows)]
+      (is (= rows capped))
+      (is (false? over-cap?))
+      (is (zero?  hidden)))))
+
+(deftest shared-cap-helper-bounds-dom-mount-regardless-of-input-shape
+  (testing "the cap survives even with the buffer at 5× cap — the
+            number that lands on the panel never exceeds panel-row-cap"
+    (let [rows                      (mapv (fn [i] {:id i})
+                                          (range (* 5 panel-row-cap)))
+          [capped over-cap? hidden] (common/cap-rows rows)]
+      (is (<= (count capped) panel-row-cap)
+          "DOM-mount ceiling holds regardless of input size")
+      (is (true? over-cap?))
+      (is (= (- (count rows) panel-row-cap) hidden)))))


### PR DESCRIPTION
## Summary

Batched perf-fix PR for four follow-on beads surfaced by the
`tools/causa/` performance audit (`ai/findings/perf-audit-causa-2026-05-14.md`,
audit-bead rf2-7tnsv):

- **rf2-1k5r1** (P2) — enforce the documented 200-row-per-panel cap
  across the 8 long-list panels that silently violated it. Highest-
  impact item in the cluster. Single biggest dev-INP risk in the
  whole audit.
- **rf2-qvaa0** (P2) — implement the real per-`:epoch-id` cache for
  `:rf.causa/selected-epoch-diff` (the diff sub claimed a cache in
  its doc comment but recomputed on every call).
- **rf2-qym6e** (P3) — split the hydration sidebar's cheap presence
  boolean off from the full mismatch-detail composite so the shell
  doesn't pay the side-by-side / source-coord walk on every render.
- **rf2-60vcu** (P3) — fix inaccurate hot-path comments in
  `trace_helpers`, `issues_ribbon_helpers`, `mcp_server_helpers`
  (companion to rf2-qvaa0's `app_db_diff.cljs` comment fix).

The fifth bead in the originally-proposed batch, **rf2-in6l2**
(`reg-view-wrap` panel migration + lazy `:rf/causa` frame), is
intentionally **deferred to its own PR** — the bead's own size
estimate (>15 files, 200-400 LoC) sits at the threshold the
batched-by-surface workflow draws between coherent perf-cleanups and
substrate-wiring refactors. It belongs on its own commit history with
its own quality gates.

## DECISIONS

- **rf2-1k5r1 — hard-cap with overflow indicator** (over virtualization
  / pagination). Virtualization needs a substrate-aware list
  component (heavy dep or large bespoke impl) and doesn't fit a
  batched perf PR. Pagination needs prev/next surface area beyond
  scope. Hard-cap mirrors the in-tree precedent at
  `machine_inspector_helpers/cap-transitions`, ships one helper +
  one contract surface, and the overflow indicator (`+N hidden —
  narrow the filter or selection to see more`) is the explicit
  signal that the user's data is bigger than what's on screen.
  Cap source-of-truth lives in `common_helpers/panel-row-cap` (200,
  matching `spec/007-UX-IA.md` §Performance budget and the pinned
  `perf_budget_cljs_test.cljc`).
- **rf2-1k5r1 — shared `capped-list` builder** in
  `panels/overflow_indicator.cljc`. Eight panels shared the same
  cap-list-then-append-overflow shape; the helper folds the
  boilerplate into one fn so per-panel views stay focused on the
  row hiccup.
- **rf2-qvaa0 — atom-keyed cache, prune-on-miss** (over
  `clojure.core.cache` LRU). The cache size is naturally bounded by
  `epoch-history` depth — prune-on-miss against the live
  `:epoch-id` set gives bounded growth without an LRU ordering
  surface. The atom lives inside a `let`-wrapper around the
  `reg-sub` form so it's per-process and not visible to the rest of
  the panel.
- **rf2-qym6e — split the sub, don't refactor the composite.** The
  full `:rf.causa/hydration-debugger-data` composite is unchanged
  so the panel view's contract is preserved; a cheap
  `:rf.causa/hydration-has-mismatch?` sub was added and the shell
  switched to read it. Minimum-surface change with maximum
  reactive-cost reduction.
- **rf2-in6l2 — deferred to its own PR.** Substrate-wiring refactor
  (panel views to `reg-view`, lazy-register `:rf/causa` from
  `mount.cljs` after `init!`). Size + scope is fundamentally
  different from the four perf-cleanups in this PR.

## What changed

```
 18 files changed, 707 insertions(+), 90 deletions(-)
```

Plus 3 new files (one production: `overflow_indicator.cljc`; two
tests: `common_helpers_cljs_test.cljc`,
`overflow_indicator_cljs_test.cljc`).

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 518 tests, 1482
      assertions, 0 failures. Includes the four new pins added to
      `perf_budget_cljs_test.cljc` so a regression that lifts the
      cap or drops the wiring fails the gate.
- [x] `cd implementation && npm run test:cljs` — 1885 tests, 5323
      assertions, 0 failures.
- [x] `cd implementation && npm run test:bundle-isolation` — PASS
      (Causa-side changes stay bundle-isolated from production).
- [x] `cd implementation && npm run test:perf-bundle` — PASS.
- [ ] `cd implementation && npm run test:browser` — run by reviewer
      (the worktree had a port-binding race with another local
      server during local execution; the test surface that exercises
      Causa is small enough that node-test coverage is the primary
      gate).

## Before vs after (row budget)

Pre-fix: with the trace ring near its 1000-event cap, each of the 8
panels would render up to 1000 DOM rows on first open — DOM mount +
React reconciliation cost scales linearly with that count.

Post-fix: each panel caps at exactly 200 DOM rows + 1 overflow
indicator (max 201 row mounts per panel). The shared
`perf_budget_cljs_test/shared-cap-helper-bounds-dom-mount-regardless-of-input-shape`
pins this against a 5× cap (1000-row) input — the cap holds.