### PR TITLE
refactor(adapters): cross-adapter helpers — 8 follow-on beads

### DIFF
--- a/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
+++ b/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
@@ -174,7 +174,7 @@
 (substrate-adapter/route-hook! adapter :adapter/ratom
   r/atom)
 (substrate-adapter/route-hook! adapter :adapter/ratom?
-  (fn ratom?-impl [x] (satisfies? ratom/IReactiveAtom ^js x))
+  (fn ratom?-impl [x] (satisfies? ratom/IReactiveAtom x))
   (constantly false))
 (substrate-adapter/route-hook! adapter :adapter/make-reaction
   ratom/make-reaction)

--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -168,7 +168,7 @@
 (substrate-adapter/route-hook! adapter :adapter/ratom
   r/atom)
 (substrate-adapter/route-hook! adapter :adapter/ratom?
-  (fn ratom?-impl [x] (satisfies? ratom/IReactiveAtom ^js x))
+  (fn ratom?-impl [x] (satisfies? ratom/IReactiveAtom x))
   (constantly false))
 (substrate-adapter/route-hook! adapter :adapter/make-reaction
   ratom/make-reaction)

--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -67,7 +67,9 @@
   ;; The bridge mounted into a raw DOM container directly; under the
   ;; rewrite we explicitly create a React-19 root once and reuse it.
   ;; The unmount thunk closes over the root to call its .unmount.
-  (let [hydrate? (boolean (:hydrate? opts))]
+  ;; Per rf2-gwkvr: Spec 006 §`render` types `:hydrate?` as a boolean;
+  ;; no defensive coercion.
+  (let [hydrate? (:hydrate? opts)]
     (if hydrate?
       (let [root (rdc/hydrate-root mount-point render-tree)]
         (fn unmount [] (rdc/unmount root)))

--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -91,7 +91,7 @@
   (if-let [emit @hiccup-emitter]
     (emit render-tree opts)
     (throw (ex-info ":rf.error/no-hiccup-emitter-bound"
-                    {:reason      "use the plain-atom adapter on the JVM for SSR, or install via set-hiccup-emitter!"
+                    {:reason      "require re-frame.ssr (the SSR ns-load resolves the :reagent/set-hiccup-emitter! late-bind hook automatically), or call set-hiccup-emitter! directly"
                      :render-tree render-tree}))))
 
 ;; ---- context provider -----------------------------------------------------

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -74,7 +74,7 @@
   (if-let [emit @hiccup-emitter]
     (emit render-tree opts)
     (throw (ex-info ":rf.error/no-hiccup-emitter-bound"
-                    {:reason "use the plain-atom adapter on the JVM for SSR, or install via set-hiccup-emitter!"
+                    {:reason "require re-frame.ssr (the SSR ns-load resolves the :reagent/set-hiccup-emitter! late-bind hook automatically), or call set-hiccup-emitter! directly"
                      :render-tree render-tree}))))
 
 ;; ---- context provider -----------------------------------------------------

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -47,8 +47,9 @@
 (defn- render [render-tree mount-point opts]
   ;; React 18+ Root API: create-root → render → unmount; hydrate-root
   ;; on the SSR path returns its own Root (rf2-fn5rk + rf2-6hyy slim
-  ;; parity). Pin: `adapter-render-cljs-test`.
-  (let [hydrate? (boolean (:hydrate? opts))
+  ;; parity). Pin: `adapter-render-cljs-test`. Per rf2-gwkvr: Spec 006
+  ;; §`render` types `:hydrate?` as a boolean; no defensive coercion.
+  (let [hydrate? (:hydrate? opts)
         root     (if hydrate?
                    (rdc/hydrate-root mount-point render-tree)
                    (let [r (rdc/create-root mount-point)]

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -194,7 +194,7 @@
 (substrate-adapter/route-hook! adapter :adapter/ratom
   r/atom)
 (substrate-adapter/route-hook! adapter :adapter/ratom?
-  (fn ratom?-impl [x] (satisfies? ratom/IReactiveAtom ^js x))
+  (fn ratom?-impl [x] (satisfies? ratom/IReactiveAtom x))
   (constantly false))
 (substrate-adapter/route-hook! adapter :adapter/make-reaction
   ratom/make-reaction)

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -163,7 +163,7 @@
 (substrate-adapter/route-hook! adapter :adapter/ratom
   r/atom)
 (substrate-adapter/route-hook! adapter :adapter/ratom?
-  (fn ratom?-impl [x] (satisfies? ratom/IReactiveAtom ^js x))
+  (fn ratom?-impl [x] (satisfies? ratom/IReactiveAtom x))
   (constantly false))
 (substrate-adapter/route-hook! adapter :adapter/make-reaction
   ratom/make-reaction)

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -371,13 +371,16 @@
   (fn warn-non-dom-root! [id type-tag]
     (when-not (contains? @cache-atom id)
       (swap! cache-atom conj id)
-      (when (exists? js/console)
-        (.warn js/console
-          (str "[re-frame] reg-view " id " — root element is "
-               (pr-str type-tag) " (" substrate-name "); "
-               "data-rf2-source-coord skipped "
-               "(Spec 006 §Source-coord annotation: pair tools fall back to "
-               ":rf/id for non-DOM roots)."))))))
+      ;; Per rf2-g7bi4: `js/console` is universally present in modern
+      ;; browsers and Node; React-shaped substrates target React 18+
+      ;; which targets those runtimes. The historical
+      ;; `(when (exists? js/console) ...)` guard is dead.
+      (.warn js/console
+        (str "[re-frame] reg-view " id " — root element is "
+             (pr-str type-tag) " (" substrate-name "); "
+             "data-rf2-source-coord skipped "
+             "(Spec 006 §Source-coord annotation: pair tools fall back to "
+             ":rf/id for non-DOM roots).")))))
 
 (defn- dom-element?
   "True if the React element's `type` is a string (a DOM tag like

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -249,7 +249,7 @@
     (if-let [emit @emitter-cell]
       (emit render-tree opts)
       (throw (ex-info ":rf.error/no-hiccup-emitter-bound"
-                      {:reason      "use the plain-atom adapter on the JVM for SSR, or install via set-hiccup-emitter!"
+                      {:reason      "require re-frame.ssr (the SSR ns-load resolves the :reagent/set-hiccup-emitter! late-bind hook automatically), or call set-hiccup-emitter! directly"
                        :render-tree render-tree})))))
 
 ;; ---- context provider -----------------------------------------------------

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -188,7 +188,10 @@
   root from the cell before calling `.unmount`. Per rf2-9fdkb."
   [active-roots-cell]
   (fn render [render-tree mount-point opts]
-    (let [hydrate? (boolean (:hydrate? opts))
+    ;; Per rf2-gwkvr: Spec 006 §`render` types `:hydrate?` as a boolean;
+    ;; non-bool truthy values are undefined-behaviour. No defensive
+    ;; `boolean` coercion.
+    (let [hydrate? (:hydrate? opts)
           root     (if hydrate?
                      (react-dom-client/hydrateRoot mount-point render-tree)
                      (let [r (react-dom-client/createRoot mount-point)]

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -99,9 +99,12 @@
           on-dispose-fns (atom [])
           ;; Per-source wrapper keys we own so dispose can unwire them.
           own-keys       (atom {})           ;; source → key
+          ;; Per rf2-ggx29: iterate the watcher fns via `run!` over
+          ;; `vals` rather than `doseq` over map-entries. Skips one
+          ;; map-entry seq allocation per source-change notification.
           notify         (fn [prev nu]
                            (when (not= prev nu)
-                             (doseq [[_ w] @watchers] (w prev nu))))]
+                             (run! (fn [w] (w prev nu)) (vals @watchers))))]
       ;; Wire one watch per source so the listener registry surface
       ;; (subscribe-container) on the derived container fires whenever
       ;; any source changes.

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -508,6 +508,20 @@
         active-roots-cell  (make-active-roots-cell)
         subscribe-cont     (make-subscribe-container gensym-prefix-sub)
         make-derived       (make-derived-value-fn gensym-prefix-derived)
+        ;; Per rf2-y1hbg: precompute the `use-subscribe` watch-key
+        ;; keyword namespace once (outside the render hot path). The
+        ;; per-reaction key derives from `(hash reaction)` so the
+        ;; subscribe-fn closure pays one hash + one keyword intern per
+        ;; reaction-identity change — no process-wide gensym counter
+        ;; tick per render.
+        use-sub-watch-ns   (let [s gensym-prefix-use-sub
+                                 n (count s)]
+                             ;; Strip the trailing "-" the gensym prefix
+                             ;; carried so the keyword namespace reads
+                             ;; cleanly (`:rf-uix-use-sub/<hash>`).
+                             (if (and (pos? n) (= "-" (subs s (dec n))))
+                               (subs s 0 (dec n))
+                               s))
         wrap-view-fn       (make-wrap-view warn-fn)
         render-fn          (make-render active-roots-cell)
         dispose-fn         (make-dispose-adapter!
@@ -536,7 +550,13 @@
                 subscribe-fn
                 (use-callback
                   (fn [on-change]
-                    (let [k (gensym gensym-prefix-use-sub)]
+                    ;; Per rf2-y1hbg: hash-of-reaction-identity keyword
+                    ;; rather than a fresh `gensym` per call. The
+                    ;; per-reaction key is stable for the reaction's
+                    ;; lifetime, sidesteps the process-wide gensym
+                    ;; counter, and remains unique across distinct
+                    ;; reactions.
+                    (let [k (keyword use-sub-watch-ns (str (hash reaction)))]
                       (when reaction
                         (add-watch reaction k (fn [_ _ _ _] (on-change))))
                       (fn unsubscribe []


### PR DESCRIPTION
## Summary

Wave 5 cross-adapter cluster — substrate-spine + adapter shared bits.
All three React-shaped adapter tails (UIx, Reagent, Helix) have landed;
this PR sweeps eight follow-on beads through the shared spine and four
adapter ns'es in one batched-by-surface refactor.

## Beads landed (6 with code changes + 2 closed as resolved-by-prior-work)

Spine first:

- **rf2-y1hbg** (P3, perf) — \`use-subscribe\` add-watch key is now a
  hash-of-reaction-identity keyword rather than a fresh \`gensym\` per call.
  Sidesteps the process-wide CLJS gensym counter; lifts the prefix-to-keyword-namespace
  work outside the inner closure (computed once in \`make-react-spine\`'s let).
- **rf2-ggx29** (P3, perf) — \`make-derived-value\` notify-loop walks watcher
  fns via \`run!\` over \`vals\` rather than \`doseq\` over map-entries.
  One map-entry seq allocation removed per source-change notification.

Cross-adapter trims:

- **rf2-2d2gx** (P3) — drop wrong \`^js\` hint on \`IReactiveAtom\` \`satisfies?\`
  predicate across all four React-shaped adapters. \`^js\` is the externs-inference
  hint for raw JS objects; \`satisfies?\` on a protocol contributes nothing from it.
- **rf2-g7bi4** (P3) — drop dead \`(when (exists? js/console) ...)\` guard in
  \`warn-non-dom-root!\`. React-shaped substrates target React 18+ (modern browsers
  and Node where \`js/console\` is universally present). Guard is dead.

Defensive-coercion drop:

- **rf2-gwkvr** (P2) — drop \`(boolean (:hydrate? opts))\` defensive coercion
  across the spine (covers UIx + Helix), Reagent adapter, and reagent-slim adapter.
  Spec 006 §\`render\` types \`:hydrate?\` as a boolean; non-bool truthy values are
  undefined-behaviour per the spec. Pre-alpha rule: drop defensive bridges.

Reason-text fix:

- **rf2-sys9a** (P1, fix) — the CLJS \`render-to-string\` slot threw
  \`:rf.error/no-hiccup-emitter-bound\` with a \`:reason\` text steering users
  toward the JVM plain-atom adapter (wrong: CLJS context) and pre-rf2-uo7v
  SSR guidance (wrong: SSR moved to \`day8/re-frame2-ssr\`). Replace text
  across spine + Reagent + reagent-slim with: "require re-frame.ssr (the
  SSR ns-load resolves the \`:reagent/set-hiccup-emitter!\` late-bind hook
  automatically), or call set-hiccup-emitter! directly".

Closed as resolved-by-prior-work (rf2-3vwbx already extracted the relevant code):

- **rf2-gsh49** — source-coord-wrap helpers extraction. The substrate-spine
  cluster refactor (rf2-3vwbx) already lifted \`format-source-coord\`,
  \`dom-element?\`, \`inject-source-coord-attr\`, \`warn-non-dom-root!\`,
  \`make-wrap-view\`, the warn-once-cache, and the chained
  \`:adapter/clear-warn-once-caches!\` registration into
  \`re-frame.substrate.spine\`. UIx and Helix consume them through
  \`make-react-spine\`; no duplication remains.
- **rf2-hzck5** — dead \`(or x nil)\` wrapping in \`flush-views!\`
  act-resolution. The rf2-3vwbx refactor replaced the dead-fallback
  shape with a proper \`resolve-act-fn\` chain (React.act → react-dom/test-utils.act)
  in the spine. The pattern no longer exists.

## LoC delta

5 files changed, +52 / -20 (net +32; most additions are inline rationale
comments per bead).

## Test plan

- [x] \`cd implementation && npm run test:cljs\` — 1917 tests, 0 failures
- [x] \`cd implementation/adapters/uix && clojure -M:test\`
- [x] \`cd implementation/adapters/reagent && clojure -M:test\`
- [x] \`cd implementation/adapters/reagent-slim && clojure -M:test\` — 11 tests pass
- [x] \`cd implementation/adapters/helix && clojure -M:test\`
- [x] \`cd implementation && npm run test:elision\` — pass
- [x] \`cd implementation && npm run test:examples\` — all examples pass