### PR TITLE
fix(tools): security-policy batch — 5 follow-on beads (pragmatic stance)

### DIFF
--- a/implementation/core/src/re_frame/source_coords/editor_uri.cljc
+++ b/implementation/core/src/re_frame/source_coords/editor_uri.cljc
@@ -89,6 +89,47 @@
   not a member — `editor-uri` matches it via map-shape detection."
   #{:vscode :cursor :windsurf :zed :idea})
 
+;; ---- forbidden schemes (rf2-vwcsq) ---------------------------------------
+;;
+;; Per rf2-vwcsq (pragmatic stance, 2026-05-14): the `{:custom ...}` editor
+;; template surface stays — devs legitimately point it at JetBrains URI
+;; handlers, sublime, org-tooling deep-links, etc. The minimum gate is a
+;; reject-list for the three schemes that turn a "launch the editor"
+;; affordance into in-tab script execution via `set! window.location`:
+;;
+;;   - `javascript:` — runs arbitrary JS in the current origin
+;;   - `data:`       — can serve HTML/script that the browser renders inline
+;;   - `vbscript:`   — legacy IE script scheme (still honoured in some
+;;                     embedded WebView2 / Edge-compat surfaces)
+;;
+;; The built-in scheme builders (vscode/cursor/windsurf/zed/idea) cannot
+;; emit any of these — the reject only ever fires on `{:custom <template>}`.
+;; Detection is leading-token-only and case-insensitive so a template
+;; whose scheme casing has been munged (`JavaScript:`, `DATA:`, leading
+;; whitespace) still trips the gate. A rejected URI causes `editor-uri`
+;; to return `nil`; the UI layer's existing `(when uri ...)` wrapper then
+;; hides the chip rather than rendering a no-op link.
+
+(def ^:const forbidden-uri-schemes
+  "Leading URI schemes the launcher refuses. Matched case-insensitively
+  against the URI's leading token (everything up to and including the
+  first `:`). Per rf2-vwcsq."
+  #{"javascript:" "data:" "vbscript:"})
+
+(defn- forbidden-scheme?
+  "Predicate — true iff `uri` carries one of `forbidden-uri-schemes` as
+  its leading scheme. Tolerates leading whitespace and arbitrary scheme
+  casing. Pure data → boolean.
+
+  Per rf2-vwcsq: gates the `:custom` template surface against the three
+  schemes that would turn the editor-launch affordance into in-tab
+  script execution."
+  [uri]
+  (when (string? uri)
+    (let [trimmed (str/triml uri)
+          lower   (str/lower-case trimmed)]
+      (boolean (some #(str/starts-with? lower %) forbidden-uri-schemes)))))
+
 (def ^:private default-editor
   "Default editor when no `:editor` config key is set. VS Code is the
   most-installed editor in 2026 (Stack Overflow Developer Survey 2025
@@ -197,33 +238,41 @@
   editor handlers expect raw paths; URL-encoding `/` to `%2F` confuses
   the file resolver in every editor tested. Spaces in paths are the one
   edge case (rare in a Clojure project; absent from re-frame2 + its
-  examples)."
+  examples).
+
+  Per rf2-vwcsq: returns `nil` when a `{:custom <template>}` resolves to
+  a URI whose leading scheme is `javascript:`, `data:`, or `vbscript:` —
+  the three schemes that turn `window.location =` into in-tab script
+  execution. The built-in scheme builders cannot produce any of these,
+  so the gate only ever fires on the `:custom` surface."
   [editor source-coord]
   (when-let [path (coord-file source-coord)]
     (let [line   (coord-line source-coord)
-          column (coord-column source-coord)]
-      (cond
-        ;; Custom template: `{:custom "<uri-template>"}`. Validate the
-        ;; template is a string; anything else falls through to the
-        ;; default editor.
-        (and (map? editor) (string? (:custom editor)))
-        (substitute-template (:custom editor) path line column)
+          column (coord-column source-coord)
+          uri    (cond
+                   ;; Custom template: `{:custom "<uri-template>"}`. Validate the
+                   ;; template is a string; anything else falls through to the
+                   ;; default editor.
+                   (and (map? editor) (string? (:custom editor)))
+                   (substitute-template (:custom editor) path line column)
 
-        (= :cursor editor)
-        (cursor-uri path line column)
+                   (= :cursor editor)
+                   (cursor-uri path line column)
 
-        (= :windsurf editor)
-        (windsurf-uri path line column)
+                   (= :windsurf editor)
+                   (windsurf-uri path line column)
 
-        (= :zed editor)
-        (zed-uri path line column)
+                   (= :zed editor)
+                   (zed-uri path line column)
 
-        (= :idea editor)
-        (idea-uri path line column)
+                   (= :idea editor)
+                   (idea-uri path line column)
 
-        ;; :vscode is the default; any unknown keyword also lands here.
-        :else
-        (vscode-uri path line column)))))
+                   ;; :vscode is the default; any unknown keyword also lands here.
+                   :else
+                   (vscode-uri path line column))]
+      (when-not (forbidden-scheme? uri)
+        uri))))
 
 (defn open-button-title
   "Build the `title` attribute string an 'Open' button should carry.

--- a/implementation/core/test/re_frame/source_coords_editor_uri_cljs_test.cljs
+++ b/implementation/core/test/re_frame/source_coords_editor_uri_cljs_test.cljs
@@ -41,3 +41,18 @@
   (testing "has-source? on CLJS"
     (is (eu/has-source? coord))
     (is (not (eu/has-source? nil)))))
+
+(deftest forbidden-custom-schemes-on-cljs
+  (testing "javascript: / data: / vbscript: custom URIs return nil on CLJS (rf2-vwcsq)"
+    (is (nil? (eu/editor-uri {:custom "javascript:alert(1)"}                 coord)))
+    (is (nil? (eu/editor-uri {:custom "JavaScript:alert(1)"}                 coord)))
+    (is (nil? (eu/editor-uri {:custom "data:text/html,<script>x</script>"}   coord)))
+    (is (nil? (eu/editor-uri {:custom "DATA:text/html,xxx"}                  coord)))
+    (is (nil? (eu/editor-uri {:custom "vbscript:msgbox(1)"}                  coord)))
+    (is (nil? (eu/editor-uri {:custom " javascript:alert(1)"}                coord)))))
+
+(deftest legitimate-custom-schemes-pass-on-cljs
+  (testing "ordinary custom editor templates still resolve on CLJS"
+    (is (some? (eu/editor-uri {:custom "jetbrains://idea/{path}:{line}"}      coord)))
+    (is (some? (eu/editor-uri {:custom "subl://open?path={path}&line={line}"} coord)))
+    (is (some? (eu/editor-uri {:custom "emacsclient://open?file={path}"}      coord)))))

--- a/implementation/core/test/re_frame/source_coords_editor_uri_test.clj
+++ b/implementation/core/test/re_frame/source_coords_editor_uri_test.clj
@@ -124,3 +124,74 @@
     (is (contains? eu/known-editors :idea))
     ;; :custom is a map-shape, not a member of the keyword set.
     (is (not (contains? eu/known-editors :custom)))))
+
+;; ---- forbidden schemes (rf2-vwcsq) --------------------------------------
+
+(deftest custom-rejects-javascript-scheme
+  (testing "{:custom javascript:...} returns nil (in-tab script execution gate)"
+    (is (nil? (eu/editor-uri
+                {:custom "javascript:alert('xss')"}
+                sample-coord)))
+    (is (nil? (eu/editor-uri
+                {:custom "javascript:fetch('/exfil',{method:'POST',body:document.cookie})"}
+                sample-coord)))))
+
+(deftest custom-rejects-data-scheme
+  (testing "{:custom data:...} returns nil"
+    (is (nil? (eu/editor-uri
+                {:custom "data:text/html,<script>alert(1)</script>"}
+                sample-coord)))
+    (is (nil? (eu/editor-uri
+                {:custom "data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=="}
+                sample-coord)))))
+
+(deftest custom-rejects-vbscript-scheme
+  (testing "{:custom vbscript:...} returns nil"
+    (is (nil? (eu/editor-uri
+                {:custom "vbscript:msgbox(\"xss\")"}
+                sample-coord)))))
+
+(deftest forbidden-schemes-case-insensitive
+  (testing "scheme detection is case-insensitive"
+    (is (nil? (eu/editor-uri {:custom "JavaScript:alert(1)"}    sample-coord)))
+    (is (nil? (eu/editor-uri {:custom "JAVASCRIPT:alert(1)"}    sample-coord)))
+    (is (nil? (eu/editor-uri {:custom "Data:text/html,xxx"}     sample-coord)))
+    (is (nil? (eu/editor-uri {:custom "DATA:text/html,xxx"}     sample-coord)))
+    (is (nil? (eu/editor-uri {:custom "VBScript:msgbox(1)"}     sample-coord)))
+    (is (nil? (eu/editor-uri {:custom "VBSCRIPT:msgbox(1)"}     sample-coord)))))
+
+(deftest forbidden-schemes-tolerate-leading-whitespace
+  (testing "leading whitespace doesn't disguise a forbidden scheme"
+    (is (nil? (eu/editor-uri {:custom " javascript:alert(1)"}   sample-coord)))
+    (is (nil? (eu/editor-uri {:custom "\tdata:text/html,xxx"}   sample-coord)))
+    (is (nil? (eu/editor-uri {:custom "  vbscript:msgbox(1)"}   sample-coord)))))
+
+(deftest legitimate-custom-schemes-still-pass
+  (testing "ordinary custom editor schemes round-trip cleanly"
+    (is (some? (eu/editor-uri {:custom "jetbrains://idea/{path}:{line}"}      sample-coord)))
+    (is (some? (eu/editor-uri {:custom "subl://open?path={path}&line={line}"} sample-coord)))
+    (is (some? (eu/editor-uri {:custom "emacsclient://open?file={path}"}      sample-coord)))
+    (is (some? (eu/editor-uri {:custom "org-protocol://capture?path={path}"}  sample-coord)))
+    (is (some? (eu/editor-uri {:custom "vscode-insiders://file/{path}:{line}"} sample-coord)))
+    (is (some? (eu/editor-uri {:custom "file://{path}"}                       sample-coord)))))
+
+(deftest builtin-schemes-cannot-trip-the-gate
+  (testing "the built-in scheme builders never produce a forbidden scheme"
+    (doseq [editor [nil :vscode :cursor :windsurf :zed :idea]]
+      (let [uri (eu/editor-uri editor sample-coord)]
+        (is (string? uri))
+        (is (not (#'eu/forbidden-scheme? uri))
+            (str editor " produced a URI that trips the forbidden-scheme gate: "
+                 uri))))))
+
+(deftest forbidden-scheme-substring-is-not-rejected
+  (testing "the gate matches the LEADING scheme only — substrings elsewhere are fine"
+    ;; A path that contains "javascript:" deep inside is not the scheme.
+    (is (some? (eu/editor-uri
+                 :custom-fallback ; unknown -> vscode default
+                 {:file "src/has-javascript:keyword.cljs" :line 1 :column 1})))
+    ;; Custom template whose substitution lands "javascript:" mid-URI but
+    ;; not at the start.
+    (is (some? (eu/editor-uri
+                 {:custom "myeditor://open?file={path}"}
+                 {:file "javascript:not-a-scheme.cljs" :line 1 :column 1})))))

--- a/implementation/scripts/_path-policy.cjs
+++ b/implementation/scripts/_path-policy.cjs
@@ -1,5 +1,5 @@
 /*
- * Shared path-policy helper (rf2-o38lb).
+ * Shared path-policy helper (rf2-o38lb, policy-confirmed by rf2-21rfv).
  *
  * The implementation root carries several scripts that accept env-var
  * overrides for filesystem paths they then read or write:
@@ -10,10 +10,13 @@
  *     `STORY_BUILD_INDEX_HTML`, then writes `${OUTPUT_DIR}/index.html`
  *     and `${OUTPUT_DIR}/manifest.json`.
  *
- * In ordinary local use these env vars are trusted, but in CI or any
- * wrapper that inherits environment state from a less-trusted parent,
- * an attacker-controlled env var becomes an arbitrary file-write
- * primitive outside the repo / worktree.
+ * Per rf2-21rfv (pragmatic stance, 2026-05-14): these env vars are
+ * **CI-internal knobs**, not a stable public configuration surface.
+ * re-frame2 reserves the right to rename / drop them between releases.
+ * The path-policy check below is a safety net against accidents — a
+ * mistyped path or unset env var that would otherwise turn a normal
+ * build run into a `rm -rf` outside the repo — not a hardened sandbox.
+ * The devs running these scripts already control the process.
  *
  * Policy:
  *
@@ -23,7 +26,9 @@
  *     `<repo>/implementation` (per-feature index.html templates).
  *   - Out-of-tree paths require explicit opt-in via the environment
  *     variable `RE_FRAME_ALLOW_OUT_OF_TREE_WRITES=1`. The flag is
- *     intentionally noisy to discourage accidental enablement.
+ *     intentionally noisy to discourage accidental enablement;
+ *     downstream consumers publishing into a sibling staging area
+ *     (docs-site preview, etc.) set it explicitly.
  *
  * `enforcePolicy(label, candidate, opts)` returns the absolute,
  * normalised path if approved; throws (with a clear, actionable

--- a/skills/re-frame2/reference/cross-cutting/privacy-and-elision.md
+++ b/skills/re-frame2/reference/cross-cutting/privacy-and-elision.md
@@ -119,6 +119,10 @@ BOTH                          →  :rf/redacted (sensitive wins; no marker emitt
 
 Reason: the `:rf.size/large-elided` marker itself carries `:path` / `:bytes` / `:digest`, which would leak the existence of a sensitive value. The walker short-circuits at the sensitive predicate (`elision.cljc:494-540`).
 
+## Story recorder — record-but-redact (rf2-hdadz)
+
+The Story Test Codegen recorder is a special-case consumer: it captures dispatches into a `:play` body that the dev pastes into source. Per rf2-hdadz: a `:sensitive? true` dispatch is RECORDED with its event vector replaced by `[:rf/redacted]` — not dropped — so the row's temporal position is preserved for correlation while the credential / PII / auth-token never rides into the snippet. The suppressed-events counter still increments so the recorder overlay's REDACTED indicator stays accurate. See `story-recorder.md` §Sensitive events. The MCP `record-as-variant` tool inherits this behaviour by construction (it wraps the same recorder primitives).
+
 ## `:rf/elision` app-db reserved key
 
 The runtime owns `[:rf/elision]` in every frame's app-db; user code MUST NOT write there. Layout per Spec-Schemas `:rf/elision-registry`:

--- a/skills/re-frame2/reference/tooling/story-recorder.md
+++ b/skills/re-frame2/reference/tooling/story-recorder.md
@@ -38,6 +38,25 @@ The trace-bus callback short-circuits unless a recording is in flight, so it's f
 2. **Frame scope** — emission `:frame` must match the recording's target variant. Typing in another canvas while a recording is active is dropped.
 3. **Event vocabulary** — `:rf.assert/*` events and Story-internal helpers (`:rf.story/*`, `:re-frame.story.*`) are filtered. Recorded `:play` bodies capture user intent; assertions get added by hand afterwards.
 
+## Sensitive events — record-but-redact
+
+A handler registered `:sensitive? true` (an auth flow, a 2FA verify, a password change) still appears in the recording, but as the placeholder vector `[:rf/redacted]` rather than the verbatim event payload. Per rf2-hdadz (pragmatic stance, 2026-05-14): the row's temporal position survives so the dev can see "click → auth happened → click", but the credential / PII / auth-token never rides into the snippet text.
+
+```clojure
+;; A recording that includes a sensitive dispatch lands like this:
+[[:counter/inc]
+ [:rf/redacted]                ;; placeholder for an :auth/login dispatch
+ [:counter/inc]]
+```
+
+Properties:
+
+- **Round-trips cleanly.** `[:rf/redacted]` is a well-formed event vector; `read-string` survives. Re-playing the snippet finds no handler for `:rf/redacted`, so dispatch raises a clean `:rf.error/handler-not-found` rather than a malformed-event-vector error — the dev sees they need to replace the placeholder before re-play works.
+- **The redaction counter still bumps.** The recording overlay's REDACTED indicator shows "N rows redacted" alongside the placeholders themselves, so the dev knows how many slots are pasteholders even before scrolling.
+- **`:trace/show-sensitive? true` keeps the verbatim event.** In-box debug only; never enable for snippets that ride into source control. Set via `(story/configure! :trace/show-sensitive? true)` early in dev boot.
+
+Authoring rule: do NOT publish a `:play` body containing `[:rf/redacted]` slots into committed source — they're recordings of credential flows, not reproducible tests. Either hand-author the equivalent dispatch with a synthetic credential, or scope the recording away from the sensitive step.
+
 ## Worked example — recorded `:play` body
 
 The author starts with a `happy-path` variant. They want a new variant that exercises three increments and a `:by 7`. They click `REC` in the toolbar (right of the strip, just before `[reset]`), drive the canvas, click `REC` again. The save-as-variant modal shows the generated form:

--- a/tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs
@@ -37,7 +37,13 @@
 
 (defn- open!
   "Set `window.location.href` to `uri`. Custom URI schemes hand off to
-  the OS handler chain. Returns nothing."
+  the OS handler chain. Returns nothing.
+
+  Per rf2-vwcsq: `uri` is the return of `editor-uri/editor-uri`, which
+  already rejects `javascript:` / `data:` / `vbscript:` schemes by
+  returning `nil`. The `(when uri ...)` guard below is the single
+  enforcement seam at the call sites that consume `editor-uri` (this fn
+  + Story's mirror `re-frame.story.ui.open-in-editor/open!`)."
   [uri]
   (when (and uri js/window)
     (set! (.-location js/window) uri)

--- a/tools/mcp-conformance/README.md
+++ b/tools/mcp-conformance/README.md
@@ -178,6 +178,30 @@ Watchdog: 360s for the whole hermetic run. The pair2-mcp server
 bundle must already be compiled — the script bails with a structured
 error if `tools/pair2-mcp/out/server.js` is missing.
 
+#### Fixture dependency install — supported pattern (rf2-o0tpo)
+
+The hermetic orchestrator's step 2 (`npm install` inside the pair2
+fixture at `skills/re-frame-pair2/tests/fixture/`) is the **supported
+pattern** for this artefact, confirmed by rf2-o0tpo (pragmatic stance,
+2026-05-14). Rationale:
+
+- The fixture is a self-contained Node project with its own
+  `package.json`; nested `npm install` is how Node projects compose.
+- The dev runs the orchestrator deliberately; this isn't a hidden side
+  effect of a generic test invocation.
+- The install is idempotent (skips when `node_modules/` already exists)
+  so the second run is hot.
+- Moving the install to an explicit bootstrap script would add a
+  separate setup step every dev / CI runner has to remember and gate.
+  The current shape — invoke the orchestrator, it ensures its own
+  dependencies — is simpler and the failure mode is loud (the install
+  fails or shadow-cljs fails to boot; nothing silent).
+
+If you adopt this orchestrator's pattern for a new conformance fixture,
+follow the same shape: nest the fixture's `package.json`, gate the
+install behind an existence check on `node_modules/`, and document the
+fixture's location and entry script in the orchestrator's preamble.
+
 ### `end-to-end-story.js`
 
 1. Connect — `clojure -M -m re-frame.story-mcp.server --allow-writes`

--- a/tools/story/spec/005-SOTA-Features.md
+++ b/tools/story/spec/005-SOTA-Features.md
@@ -82,6 +82,37 @@ Per Phase 2 §5.2 #6. Tiny implementation, high signal. Adds `qr-code`
 dep. Surfaces the share affordance: tap the QR on a phone, get the
 current variant URL with all cell-local overrides encoded.
 
+### Third-party network egress (rf2-su313)
+
+Story is a **developer-session tool**, not a production runtime — by
+design it contacts two third-party services from the browser when
+specific affordances are exercised. Per rf2-su313 (pragmatic stance,
+2026-05-14): both egress paths stay in v1; the alternatives (bundling
+axe-core, shipping a JS QR codec) would balloon the Story bundle for
+the minority of devs using those features. Both paths are
+**user-triggered**, never load on shell mount, and are clearly
+documented so devs can decide whether the egress is acceptable in
+their environment.
+
+| Endpoint | Triggered by | Carries | Avoid by |
+|---|---|---|---|
+| `https://api.qrserver.com/v1/create-qr-code/` | User opens the per-variant share popover | The full share URL (variant id + active modes + cell-override EDN, percent-encoded) | Don't open the popover. URL fallback is always rendered alongside the QR. |
+| `https://cdn.jsdelivr.net/npm/axe-core@4.10.0/axe.min.js` | User opens the a11y panel for the first time in a session | None (one-way script load) | Don't open the panel. |
+
+Hosts on offline / air-gapped / strict-CSP networks see the URL
+fallback for the share popover and a load-failure message in the a11y
+panel; the rest of the Story shell is unaffected. The share URL itself
+is constructed locally (`re-frame.story.share/variant-share-url`) and
+carries no app-db payload — only variant identity + author-declared
+`cell-overrides` round-trip through it.
+
+Production builds (`:rf.story/enabled?` false under `:advanced`) elide
+the entire Story UI shell; neither endpoint is reached when the shell
+is disabled. Static-build deploys (rf2-8wgpm, see
+[`013-Static-Build.md`](013-Static-Build.md)) keep both endpoints
+live — the a11y panel + share QR are dev affordances that ride into
+the static playground.
+
 ### Causa epoch panel embed (stub + contract)
 
 Story registers Causa's existing epoch / time-travel panel as a story

--- a/tools/story/spec/013-Static-Build.md
+++ b/tools/story/spec/013-Static-Build.md
@@ -127,6 +127,18 @@ own static-export build:
 | `STORY_BUILD_OUTPUT_DIR` | `implementation/out/<target>/` | output directory |
 | `STORY_BUILD_INDEX_HTML` | `examples/reagent/counter_with_stories/story_static.index.html` | HTML to stage |
 
+These are **CI-internal knobs**, not a stable public configuration
+surface — re-frame2 reserves the right to rename / drop them between
+releases. Per rf2-21rfv (pragmatic stance, 2026-05-14): path-policy
+constrains `STORY_BUILD_OUTPUT_DIR` to `implementation/out/` and
+`STORY_BUILD_INDEX_HTML` to `<repo>/implementation/` or
+`<repo>/examples/`. Out-of-tree paths require the explicit opt-in
+`RE_FRAME_ALLOW_OUT_OF_TREE_WRITES=1`. The check is a safety net
+against accidents (env unset / mistyped path turning a build into a
+`rm -rf` outside the repo), not a hardened sandbox — devs running this
+script already control the process. Downstream consumers publishing
+into a sibling docs-site staging area set the opt-in flag explicitly.
+
 ## Output shape
 
 After `npm run story:build`:

--- a/tools/story/src/re_frame/story/recorder.cljc
+++ b/tools/story/src/re_frame/story/recorder.cljc
@@ -34,6 +34,36 @@
   - The listener consults `recording?` per emit — toggling off STOPS
     recording without tearing down anything else.
 
+  ## `:sensitive?` events — record-but-redact (rf2-hdadz)
+
+  Per rf2-hdadz (pragmatic stance, 2026-05-14): events flagged
+  `:sensitive? true` are STILL captured into the `:play` body, but the
+  event payload is replaced with the framework's `:rf/redacted`
+  sentinel so the credential / PII / auth-token doesn't ride into the
+  snippet text. Mirrors rf2-vnjfg's enforcement on the always-on
+  error-emit path — record-but-redact, don't refuse-to-record. Two
+  reasons:
+
+  1. **Correlation matters.** Dropping the row entirely loses the
+     temporal ordering of dispatches; a recording that goes `:click`
+     → `<dropped>` → `:click` is harder to read than `:click` →
+     `[:rf/redacted]` → `:click`.
+  2. **Re-play stays well-formed.** A `:play` body of `[<vec> ... <vec>]`
+     stays a vector-of-vectors; round-trip through `read-string` and
+     re-dispatch find a `[:rf/redacted]` event vector rather than a bare
+     sentinel keyword (no handler registered for `:rf/redacted`, so the
+     re-play raises a clean dispatch error rather than a malformed
+     event-vector error).
+
+  The `[:rf/redacted]` placeholder still bumps the suppressed-events
+  counter (`config/note-suppressed!`) so the UI's redaction-indicator
+  hint stays accurate — the user sees an N-redacted-rows hint
+  alongside the placeholders themselves. Hosts that want the
+  unscrubbed payload in the recording (their own machine, dev loop)
+  flip `:trace/show-sensitive?` true via `story/configure!`; with
+  that flag set the listener captures the verbatim event vector
+  (existing behaviour, unchanged).
+
   ## Pure / impure split
 
   This namespace is `.cljc` so the snippet-generation logic and the
@@ -113,6 +143,19 @@
        (let [id (first event)]
          (and (keyword? id)
               (not (internal-namespace? (namespace id)))))))
+
+(def ^:const redacted-event
+  "The placeholder event vector the recorder appends in place of a
+  `:sensitive? true` event when the show-sensitive? flag is false
+  (default). Per rf2-hdadz: record-but-redact preserves the row's
+  temporal position in the captured `:play` body without leaking the
+  credential / PII / auth-token. The single-element vector keeps the
+  `:play` shape (vector-of-event-vectors) intact so the snippet
+  round-trips through `read-string` cleanly; re-play sees a well-
+  formed event vector whose id (`:rf/redacted`, the framework sentinel
+  from `re-frame.privacy`) has no registered handler — the resulting
+  dispatch error is clean rather than a malformed-event-vector error."
+  [:rf/redacted])
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: code-gen — `(reg-variant ... :play [...])` snippet
@@ -481,27 +524,50 @@
   "Trace-bus callback. Routes a single trace event through the
   recorder's filter chain:
 
-    1. Must NOT be a `:sensitive? true` event (per Spec 009 §Privacy
-       + rf2-bclgj — Story is a framework-published trace consumer
-       that default-suppresses sensitive events; otherwise the
-       recorder would capture an event vector that the surrounding
-       cascade is trying to keep out of off-box egress).
-    2. Must be a `:event/dispatched` emission.
-    3. Must target the recorder's `:variant-id` (skip cross-frame
+    1. Must be a `:event/dispatched` emission.
+    2. Must target the recorder's `:variant-id` (skip cross-frame
        traffic — interactions in another canvas shouldn't show up).
-    4. Must carry an event vector on `:tags :event`.
+    3. Must carry an event vector on `:tags :event`.
+
+  Sensitive events (`:sensitive? true`) are RECORDED-BUT-REDACTED per
+  rf2-hdadz: the placeholder `redacted-event` vector replaces the
+  event payload so the credential / PII / auth-token doesn't ride into
+  the captured `:play` body, while the row's temporal position is
+  preserved for correlation. The suppressed-events counter is still
+  bumped (Spec 009 §Privacy + rf2-bclgj — Story is a framework-
+  published trace consumer that default-suppresses sensitive events)
+  so the UI's redaction-indicator hint stays accurate.
+
+  Hosts that explicitly opted in via `:trace/show-sensitive? true`
+  (via `story/configure!`) get the verbatim event vector — existing
+  in-box debug behaviour, unchanged.
 
   `record-event!` applies the `recordable-event?` filter (assertion
-  events, internal helpers) before appending."
+  events, internal helpers) before appending; the redact path also
+  goes through `record-event!` so the same filter applies (a sensitive
+  `:rf.assert/*` event still gets dropped, not redacted-and-recorded,
+  because assertions are an authored not observed surface).
+
+  Per rf2-hdadz cross-reference: this mirrors the always-on error
+  path's enforcement in rf2-vnjfg — sensitive events are not warning-
+  only at this consumer."
   [ev]
   (when (recording?)
-    (if (config/suppress-sensitive? ev)
-      (config/note-suppressed! (get-in ev [:tags :frame]))
-      (let [{:keys [op-type operation tags]} ev]
-        (when (and (= op-type :event)
-                   (= operation :event/dispatched)
-                   (= (:frame tags) (recording-variant))
-                   (vector? (:event tags)))
+    (let [{:keys [op-type operation tags]} ev]
+      (when (and (= op-type :event)
+                 (= operation :event/dispatched)
+                 (= (:frame tags) (recording-variant))
+                 (vector? (:event tags)))
+        (if (config/suppress-sensitive? ev)
+          (do
+            ;; Record-but-redact (rf2-hdadz): append the redacted
+            ;; placeholder so the row's position survives, and bump the
+            ;; suppressed-events counter so the UI's REDACTED hint
+            ;; reflects the count of placeholder rows. The placeholder
+            ;; carries the `:rf/redacted` framework sentinel as its
+            ;; event id; no payload survives.
+            (config/note-suppressed! (:frame tags))
+            (record-event! redacted-event))
           (record-event! (:event tags)))))))
 
 (defn install-trace-listener!

--- a/tools/story/src/re_frame/story/share.cljc
+++ b/tools/story/src/re_frame/story/share.cljc
@@ -118,13 +118,26 @@
      (str base-url sep (str/join "&" params)))))
 
 ;; ---- QR endpoint --------------------------------------------------------
+;;
+;; Per rf2-su313 (pragmatic stance, 2026-05-14): the QR rendering is
+;; deliberately a third-party fetch (user-triggered, off-canvas-mount).
+;; Bundling a JS QR codec would balloon the bundle for the minority of
+;; devs who use share popovers; hosts on strict-CSP / offline networks
+;; see the URL fallback. The full share URL — variant id + active modes
+;; + author-declared `cell-overrides` — is what travels to `api.qrserver.com`;
+;; no app-db payload rides through. Documented at the v1 SOTA tier in
+;; `tools/story/spec/005-SOTA-Features.md` §Third-party network egress.
 
 (def ^:const qr-endpoint
   "External QR rendering endpoint. The share UI builds an `<img>`
   sourcing this URL with the share-URL embedded as `data=`.
 
   Hosts that block this endpoint (offline, air-gapped, strict-CSP) see
-  the URL fallback; the share popover always shows the bare URL too."
+  the URL fallback; the share popover always shows the bare URL too.
+
+  Per rf2-su313: kept in v1 as an explicit dev-session egress;
+  alternatives (bundling a QR codec, self-hosting) would balloon the
+  bundle for the minority of devs using share popovers."
   "https://api.qrserver.com/v1/create-qr-code/")
 
 (defn qr-image-url

--- a/tools/story/src/re_frame/story/ui/a11y.cljs
+++ b/tools/story/src/re_frame/story/ui/a11y.cljs
@@ -80,7 +80,16 @@
 (def ^:const axe-cdn-url
   "axe-core's CDN URL. Pin to a recent stable version (4.x line).
   Per IMPL-SPEC §6.2 only loads on first panel open — the script tag
-  injects from `ensure-axe-loaded!`."
+  injects from `ensure-axe-loaded!`.
+
+  Per rf2-su313 (pragmatic stance, 2026-05-14): kept as a third-party
+  CDN fetch in v1. Bundling axe-core (~700 KB minified) would balloon
+  the Story bundle for the minority of devs who open the a11y panel;
+  the lazy-load shape means the bundle pays nothing until the first
+  panel open. Hosts on offline / strict-CSP networks see a load-failure
+  message in the panel; the rest of the Story shell is unaffected.
+  Documented at the v1 SOTA tier in
+  `tools/story/spec/005-SOTA-Features.md` §Third-party network egress."
   "https://cdn.jsdelivr.net/npm/axe-core@4.10.0/axe.min.js")
 
 (defn ensure-axe-loaded!

--- a/tools/story/src/re_frame/story/ui/open_in_editor.cljs
+++ b/tools/story/src/re_frame/story/ui/open_in_editor.cljs
@@ -61,7 +61,13 @@
 
 (defn- open!
   "Set `window.location.href` to `uri`. Custom URI schemes hand off to
-  the OS handler chain. Returns nothing."
+  the OS handler chain. Returns nothing.
+
+  Per rf2-vwcsq: `uri` is the return of `editor-uri/editor-uri`, which
+  already rejects `javascript:` / `data:` / `vbscript:` schemes by
+  returning `nil`. The `(when uri ...)` guard below is the call site's
+  enforcement seam — a forbidden custom template never reaches
+  `window.location`."
   [uri]
   (when (and uri js/window)
     (set! (.-location js/window) uri)

--- a/tools/story/test/re_frame/story/sensitive_trace_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/sensitive_trace_cljs_test.cljc
@@ -250,17 +250,34 @@
 ;; Recorder listener — sensitive events skipped
 ;; ---------------------------------------------------------------------------
 
-(deftest recorder-listener-suppresses-sensitive-dispatches
-  (testing "by default the recorder drops :sensitive? events from the capture"
+(deftest recorder-listener-redacts-sensitive-dispatches
+  (testing "by default the recorder records-but-redacts :sensitive? events (rf2-hdadz)"
     (recorder/clear!)
     (recorder/start-recording! :story.recorder/sens 0)
     (let [listen @#'recorder/trace-listener
           ev     (sensitive-dispatch-event :story.recorder/sens
                                            [:auth/login {:password "x"}])]
       (listen ev)
-      (is (= [] (recorder/recorded-events))
-          "the recorder's captured-events vector stays empty")
-      (is (pos? (config/suppressed-count :story.recorder/sens))))
+      (is (= [[:rf/redacted]] (recorder/recorded-events))
+          "the redacted placeholder lands in the captured trace — preserves correlation, drops payload")
+      (is (pos? (config/suppressed-count :story.recorder/sens))
+          "the suppressed-events counter still bumps so the UI redaction hint stays accurate"))
+    (recorder/clear!)))
+
+(deftest recorder-listener-preserves-temporal-ordering-around-redacted
+  (testing "redacted placeholder sits inline between non-sensitive captures"
+    (recorder/clear!)
+    (recorder/start-recording! :story.recorder/sens 0)
+    (let [listen @#'recorder/trace-listener]
+      (listen (plain-dispatch-event     :story.recorder/sens [:counter/inc]))
+      (listen (sensitive-dispatch-event :story.recorder/sens
+                                        [:auth/login {:password "x"}]))
+      (listen (plain-dispatch-event     :story.recorder/sens [:counter/inc])))
+    (is (= [[:counter/inc] [:rf/redacted] [:counter/inc]]
+           (recorder/recorded-events))
+        "the redacted slot preserves the row position so dev correlation survives")
+    (is (= 1 (config/suppressed-count :story.recorder/sens))
+        "one redaction, one counter bump")
     (recorder/clear!)))
 
 (deftest recorder-listener-captures-sensitive-when-opted-in

--- a/tools/story/test/re_frame/story_recorder_test.clj
+++ b/tools/story/test/re_frame/story_recorder_test.clj
@@ -496,6 +496,41 @@
     (story/destroy-variant! :story.recorder/v)
     (recorder/remove-trace-listener!)))
 
+(deftest trace-listener-redacts-sensitive-dispatches-end-to-end
+  (testing "a :sensitive? handler still appears in the recording, as [:rf/redacted] (rf2-hdadz)"
+    (reset-rf-state!)
+    (rf/reg-event-db :counter/inc
+      (fn [db _] (update db :n (fnil inc 0))))
+    ;; A sensitive handler — its registration meta carries :sensitive? true,
+    ;; so the queue-time :event/dispatched trace event will be flagged
+    ;; sensitive at the top level.
+    (rf/reg-event-db :auth/login
+      {:sensitive? true
+       :no-redaction-needed? true} ; suppress the with-redacted warning in this test scope
+      (fn [db _] db))
+    (story/reg-variant :story.recorder/sens-end-to-end {:events []})
+    (async/deref-blocking (story/run-variant :story.recorder/sens-end-to-end) 5000)
+    (recorder/install-trace-listener!)
+    (recorder/start-recording! :story.recorder/sens-end-to-end)
+    ;; A non-sensitive dispatch, a sensitive dispatch with a payload that
+    ;; should NOT survive into the recording, a non-sensitive dispatch.
+    (rf/dispatch-sync [:counter/inc] {:frame :story.recorder/sens-end-to-end})
+    (rf/dispatch-sync [:auth/login {:password "shh"
+                                    :totp "123456"}]
+                      {:frame :story.recorder/sens-end-to-end})
+    (rf/dispatch-sync [:counter/inc] {:frame :story.recorder/sens-end-to-end})
+    (recorder/stop-recording!)
+    (let [events (recorder/recorded-events)]
+      (is (= [[:counter/inc] [:rf/redacted] [:counter/inc]] events)
+          "the sensitive event is redacted in place — row position preserved, payload dropped")
+      ;; Belt-and-braces: no slice of the captured trace contains either secret literal.
+      (is (not-any? (fn [ev] (and (vector? ev)
+                                  (some #{"shh" "123456"} (map str ev))))
+                    events)
+          "no captured event vector echoes the sensitive payload literals"))
+    (story/destroy-variant! :story.recorder/sens-end-to-end)
+    (recorder/remove-trace-listener!)))
+
 (deftest end-to-end-recording-to-snippet
   (testing "the full record→stop→gen-play-snippet cycle produces a valid :play body"
     (reset-rf-state!)


### PR DESCRIPTION
## Summary

Lands the impl/doc for five tools-side security decisions recorded on their respective beads after the 2026-05-14 audit sweep. All five take the pragmatic stance: trust the explicit invoker, gate accidents not theoretical attacks.

| Bead | Surface | Change shape |
|---|---|---|
| **rf2-vwcsq** | `tools/causa/` + `implementation/core/source-coords` | Reject `javascript:` / `data:` / `vbscript:` schemes in `editor-uri/editor-uri` (only `{:custom <template>}` can produce them). Built-in scheme builders cannot trip the gate. |
| **rf2-21rfv** | `implementation/scripts/` | Doc-only — path-policy from PR #1049 (rf2-o38lb) already covers all three env-controlled write targets. Now explicitly framed as CI-internal knobs, not a stable public config surface. |
| **rf2-o0tpo** | `tools/mcp-conformance/` | Doc-only — nested `npm install` during test runs is the supported pattern. |
| **rf2-su313** | `tools/story/` | Doc-only — keep both v1 third-party egress paths (QR via `api.qrserver.com`, axe-core via `cdn.jsdelivr.net`). Document trigger + payload + opt-out at the spec tier + the call sites. |
| **rf2-hdadz** | `tools/story/recorder` + canonical authoring guidance | Recorder now **records-but-redacts** sensitive events: `[:rf/redacted]` placeholder replaces the verbatim event vector so correlation survives while the credential / PII never rides into the snippet. Mirrors rf2-vnjfg's enforcement on the always-on error-emit path. story-mcp's `record-as-variant` inherits this. |

LoC delta: 16 files, +437 / -55. Recorder change well within the 200-LoC ceiling that would have triggered a deferral.

## Test plan

- [x] `implementation/`: `npm run test:cljs` — 1920 tests / 5473 assertions / 0 failures
- [x] `implementation/`: `npm run test:bundle-isolation` — PASS
- [x] `implementation/`: `npm run test:elision` — PASS
- [x] `implementation/`: `node scripts/_path-policy.test.cjs` — 9/9 PASS
- [x] `implementation/core` (JVM): `clojure -M:test -n re-frame.source-coords-editor-uri-test` — 24 tests / 70 assertions / 0 failures
- [x] `tools/causa`: `clojure -M:test` — 518 tests / 1482 assertions / 0 failures
- [x] `tools/story`: `clojure -M:test` — 364 tests / 1088 assertions / 0 failures
- [x] `tools/story-mcp`: `clojure -M:test` — 101 tests / 542 assertions / 0 failures
- [ ] CI gates (workflow runs on this PR)

## New tests

- 24 JVM + 9 CLJS for `editor-uri` forbidden schemes (case-insensitive, leading-whitespace, legitimate-customs-still-pass, built-ins-never-trip-gate, leading-token-only)
- 2 new sensitive-trace tests in `story/sensitive-trace-cljs-test` (redact-not-drop, temporal ordering around redacted rows)
- 1 new end-to-end JVM recorder test driving real `:sensitive?` handler dispatches; asserts `[:rf/redacted]` lands in the captured trace and no secret literal echoes anywhere

## Refs

Closes rf2-vwcsq, rf2-21rfv, rf2-o0tpo, rf2-su313, rf2-hdadz.