### PR TITLE
perf(template): batched cluster — 3 follow-on beads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1185,8 +1185,14 @@ jobs:
       # The template's `re_frame2_test.clj` opportunistically invokes
       # `clojure -P` against generated deps.edn if `clojure` is on PATH
       # to confirm the deps parse — the setup-clojure step above ensures
-      # that probe runs.
+      # that probe runs. The probe is gated behind
+      # RF2_TEMPLATE_DEPS_RESOLVE=1 (default off for local fast loop,
+      # on for CI) so contributors aren't paying ~2s × 3 substrates on
+      # every local test run for a smoke that's a known-skip until the
+      # alpha artefacts land on Clojars.
       - name: Run JVM tests (tools/template artefact)
+        env:
+          RF2_TEMPLATE_DEPS_RESOLVE: "1"
         run: clojure -M:test
 
   node-test-tools-pair2-mcp:

--- a/tools/template/src/clj/new/re_frame2/helix/views.cljs
+++ b/tools/template/src/clj/new/re_frame2/helix/views.cljs
@@ -3,7 +3,21 @@
    function-style views; the dataflow is identical. Subscriptions deliver
    values via the `use-subscribe` hook, dispatches send events via
    `rf/dispatcher`. There is no auto-injection on the Helix adapter —
-   components call these explicitly."
+   components call these explicitly.
+
+   Note: this file is starter-template render-path code, kept
+   intentionally minimal so the dataflow reads at a glance. The inline
+   `#(dispatch ...)` handler and the per-render `(rf/dispatcher)` call
+   are fine for a single counter button. When you scale up to list/grid
+   views (rendering N rows × M cells), revisit:
+     - wrap event handlers in `helix.hooks/use-callback` so children
+       memoised with `:helix/memo` don't re-render on parent identity
+       churn;
+     - hoist `(rf/dispatcher)` to a single `let` per component, not one
+       per element call;
+     - shape subscriptions so each row subscribes to *its* slice, not
+       the whole collection — collection-level subscriptions cause every
+       row to re-render on every cell change."
   (:require [helix.core             :refer [$ defnc]]
             [helix.dom              :as d]
             [re-frame.core          :as rf]

--- a/tools/template/src/clj/new/re_frame2/reagent/views.cljs
+++ b/tools/template/src/clj/new/re_frame2/reagent/views.cljs
@@ -7,7 +7,19 @@
    `reg-view` (the Reagent macro) defines the view symbol *and* registers
    it under (keyword *ns* sym), and auto-injects `dispatch` /
    `subscribe` as lexical bindings resolved to the frame in scope at
-   render time."
+   render time.
+
+   Note: this file is starter-template render-path code, kept
+   intentionally minimal so the dataflow reads at a glance. The inline
+   `#(dispatch ...)` handler and the per-render `subscribe` call are
+   fine for a single counter button — they cost one closure allocation
+   per render and one subscription cache hit. When you scale up to
+   list/grid views (rendering N rows × M cells), revisit:
+     - hoist event handlers (or use the substrate's `useCallback`
+       equivalent) so children don't re-render on parent identity churn;
+     - shape subscriptions so each row subscribes to *its* slice, not
+       the whole collection — collection-level subscriptions cause every
+       row to re-render on every cell change."
   (:require [re-frame.core    :as rf]
             [re-frame.views])
   (:require-macros [re-frame.core :refer [reg-view]]))

--- a/tools/template/src/clj/new/re_frame2/uix/views.cljs
+++ b/tools/template/src/clj/new/re_frame2/uix/views.cljs
@@ -3,7 +3,20 @@
    function-style views; the dataflow is identical — subscriptions
    deliver values via the `use-subscribe` hook, dispatches send events
    via `rf/dispatcher`. There is no auto-injection on the UIx adapter
-   — components call these explicitly."
+   — components call these explicitly.
+
+   Note: this file is starter-template render-path code, kept
+   intentionally minimal so the dataflow reads at a glance. The inline
+   `#(dispatch ...)` handler and the per-render `(rf/dispatcher)` call
+   are fine for a single counter button. When you scale up to list/grid
+   views (rendering N rows × M cells), revisit:
+     - wrap event handlers in `uix.core/use-callback` so children
+       memoised with `defui` don't re-render on parent identity churn;
+     - hoist `(rf/dispatcher)` to a single `let` per component, not one
+       per JSX node;
+     - shape subscriptions so each row subscribes to *its* slice, not
+       the whole collection — collection-level subscriptions cause every
+       row to re-render on every cell change."
   (:require [uix.core             :refer [$ defui]]
             [re-frame.core        :as rf]
             [re-frame.adapter.uix :as uix-adapter]))

--- a/tools/template/test/clj/new/re_frame2_test.clj
+++ b/tools/template/test/clj/new/re_frame2_test.clj
@@ -62,21 +62,47 @@
 (defn- read-edn [^java.io.File f]
   (edn/read-string (slurp f)))
 
-(defn- clojure-cli-available? []
-  (try
-    (let [pb (ProcessBuilder. ^java.util.List
-                              ["clojure" "--help"])]
-      (.redirectErrorStream pb true)
-      (let [p (.start pb)
-            ok? (.waitFor p)]
-        (zero? ok?)))
-    (catch Throwable _ false)))
+(def ^:private clojure-cli-available?
+  ;; Probe `clojure --help` once per JVM. The probe spawns a process
+  ;; and blocks on its exit code (~hundreds of ms on Windows where
+  ;; the `clojure` PowerShell shim re-launches a JVM); doing it per
+  ;; substrate inflated suite time noticeably.
+  (delay
+    (try
+      (let [pb (ProcessBuilder. ^java.util.List ["clojure" "--help"])]
+        (.redirectErrorStream pb true)
+        (let [p (.start pb)
+              ok? (.waitFor p)]
+          (zero? ok?)))
+      (catch Throwable _ false))))
+
+(def ^:private deps-resolve-enabled?
+  ;; The per-substrate `clojure -P` smoke is gated behind an opt-in
+  ;; env var. Rationale: the generated app pins re-frame2 to
+  ;; v0.0.1.alpha (see VERSION at the repo root). Until the alpha
+  ;; artefacts are actually published to Clojars, every `clojure -P`
+  ;; invocation fails with "Could not find artifact day8/re-frame2"
+  ;; and is treated as a known-skip — buying us nothing while costing
+  ;; the dominant share of suite wall-time (~2s × 3 substrates on a
+  ;; cold cache).
+  ;;
+  ;; Local fast loop:   default off — static shape checks above still
+  ;;                    cover the template contract.
+  ;; CI / release lane: set RF2_TEMPLATE_DEPS_RESOLVE=1 to re-enable.
+  ;;                    Once an alpha publish lands, the smoke flips
+  ;;                    from known-skip to a real signal automatically.
+  (delay
+    (= "1" (System/getenv "RF2_TEMPLATE_DEPS_RESOLVE"))))
 
 (defn- run-clojure-P
-  "Run `clojure -P` in the given directory. Returns {:exit n :out s} or
-   nil if the clojure CLI is unavailable."
+  "Run `clojure -P` in the given directory. Returns {:exit n :out s},
+   `:skipped` if the smoke is gated off, or nil if the clojure CLI is
+   unavailable."
   [^java.io.File dir]
-  (when (clojure-cli-available?)
+  (cond
+    (not @deps-resolve-enabled?) :skipped
+    (not @clojure-cli-available?) nil
+    :else
     (let [pb (ProcessBuilder. ^java.util.List ["clojure" "-P"])
           _  (.directory pb dir)
           _  (.redirectErrorStream pb true)
@@ -216,21 +242,34 @@
         ;; treat the "artefact not on Clojars" outcome as a known-skip
         ;; rather than a test failure; once an alpha publish lands,
         ;; the assertion below becomes a real signal automatically.
-        (when-let [{:keys [exit out]} (run-clojure-P root)]
+        ;;
+        ;; Gating: the smoke is opt-in via RF2_TEMPLATE_DEPS_RESOLVE=1
+        ;; (default off for the local fast loop). See `run-clojure-P`
+        ;; above for rationale.
+        (let [result (run-clojure-P root)]
           (cond
-            (zero? exit)
-            (is true "`clojure -P` succeeded — alpha artefacts are publicly resolvable")
+            (= :skipped result)
+            nil  ;; gated off — fast-loop path, static shape checks above cover the contract
 
-            (re-find #"Could not find artifact day8(:|/)re-frame2" out)
-            (println (str "  [skip] `clojure -P` cannot find day8/re-frame2 " substrate
-                          " coords on Clojars — this is expected until an alpha "
-                          "publish lands. Static shape checks above still cover "
-                          "the template contract."))
+            (nil? result)
+            nil  ;; clojure CLI unavailable on PATH — nothing to assert
 
             :else
-            (is (zero? exit)
-                (str "`clojure -P` exited " exit " for " substrate
-                     " generated app. Output:\n" out)))))
+            (let [{:keys [exit out]} result]
+              (cond
+                (zero? exit)
+                (is true "`clojure -P` succeeded — alpha artefacts are publicly resolvable")
+
+                (re-find #"Could not find artifact day8(:|/)re-frame2" out)
+                (println (str "  [skip] `clojure -P` cannot find day8/re-frame2 " substrate
+                              " coords on Clojars — this is expected until an alpha "
+                              "publish lands. Static shape checks above still cover "
+                              "the template contract."))
+
+                :else
+                (is (zero? exit)
+                    (str "`clojure -P` exited " exit " for " substrate
+                         " generated app. Output:\n" out)))))))
       (finally
         (delete-recursively tmp)))))
 

--- a/tools/template/test/clj/new/template_emission_test.clj
+++ b/tools/template/test/clj/new/template_emission_test.clj
@@ -201,30 +201,58 @@
 
       :else nil)))
 
-(defn- defined-symbols
-  "Read a framework .cljc/.cljs source and return the set of symbols it
-  introduces with a top-level `def` / `defn` / `defn-` / `defmacro` /
-  `defmulti` / `defonce`. Reader conditionals (cljc) are not stripped —
-  we scan raw source text, so a symbol defined in *either* the :clj or
-  :cljs branch is treated as defined. That's exactly what we want for a
-  surface-existence check: cljs consumers of a cljc namespace see the
-  :cljs branch's defs.
+(def ^:private ^java.util.regex.Pattern def-pattern
+  ;; Reader conditionals (cljc) are not stripped — we scan raw source
+  ;; text, so a symbol defined in *either* the :clj or :cljs branch is
+  ;; treated as defined. That's exactly what we want for a
+  ;; surface-existence check: cljs consumers of a cljc namespace see
+  ;; the :cljs branch's defs.
+  ;;
+  ;; The regex tolerates one or more leading metadata clauses
+  ;; (`^:private`, `^:no-doc`, `^{...}`, `^TypeHint`) between the
+  ;; defining form and the symbol name.
+  ;;
+  ;; Compiled once at ns-load — the previous shape rebuilt the
+  ;; java.util.regex.Pattern per call (×N framework files × N
+  ;; references × 3 substrates = thousands of compiles per suite run).
+  (let [meta-clause "(?:\\^(?:\\w[\\w/.:?<>=*+!\\-]*|\\{[^}]*\\})\\s+)*"
+        sym-char    "[a-zA-Z*+!?<>=$%_\\-][\\w*+!?<>=$%\\-]*"]
+    (re-pattern
+      (str "\\(def(?:n-?|macro|multi|once|protocol|record|type)?\\s+"
+           meta-clause
+           "(" sym-char ")"))))
 
-  The regex tolerates one or more leading metadata clauses
-  (`^:private`, `^:no-doc`, `^{...}`, `^TypeHint`) between the
-  defining form and the symbol name."
+(defn- scan-defined-symbols
+  "Slurp+regex a single framework .cljc/.cljs source and return the
+  set of symbols it introduces with a top-level `def` / `defn` /
+  `defn-` / `defmacro` / `defmulti` / `defonce` / `defprotocol` /
+  `defrecord` / `deftype`. Memoised entry point is `defined-symbols`
+  below — direct callers should prefer that."
   [^java.io.File f]
-  (let [src         (slurp f)
-        ;; Build the pattern in pieces for readability.
-        meta-clause "(?:\\^(?:\\w[\\w/.:?<>=*+!\\-]*|\\{[^}]*\\})\\s+)*"
-        sym-char    "[a-zA-Z*+!?<>=$%_\\-][\\w*+!?<>=$%\\-]*"
-        def-pattern (re-pattern
-                      (str "\\(def(?:n-?|macro|multi|once|protocol|record|type)?\\s+"
-                           meta-clause
-                           "(" sym-char ")"))]
-    (into #{}
-          (map (fn [[_ sym]] (symbol sym)))
-          (re-seq def-pattern src))))
+  (into #{}
+        (map (fn [[_ sym]] (symbol sym)))
+        (re-seq def-pattern (slurp f))))
+
+(def ^:private defined-symbols-cache
+  ;; Keyed by canonical absolute path. The framework source tree is
+  ;; immutable for the lifetime of a test JVM (no hot-reload mid-suite
+  ;; under `clojure -M:test`), so path is a sufficient key — mtime is
+  ;; not required. Cleared automatically when the JVM exits.
+  (atom {}))
+
+(defn- defined-symbols
+  "Memoised wrapper over `scan-defined-symbols`. The audit loop calls
+  this with the same framework source file once per (substrate ×
+  referenced-symbol) pair — without memoisation each emitted-file's
+  audit re-slurps and re-regexes every framework `.cljc`/`.cljs` it
+  references. With memoisation the cost collapses to one slurp+regex
+  per framework source file per JVM."
+  [^java.io.File f]
+  (let [k (.getAbsolutePath f)]
+    (or (get @defined-symbols-cache k)
+        (let [v (scan-defined-symbols f)]
+          (swap! defined-symbols-cache assoc k v)
+          v))))
 
 ;; --- The events_test.cljs assertions ------------------------------------
 


### PR DESCRIPTION
## Summary

Batched-by-surface PR for three P3 perf follow-on beads filed by the `tools/template/` perf audit (rf2-z7bzu). All three beads touch the template artefact; sequenced smallest-blast-radius first so each commit stands alone.

### Beads landed

- **rf2-qy708** — `perf(template): comment emitted views.cljs as starter render-path pattern`
  The emitted `views.cljs` for each substrate (Reagent / UIx / Helix) is the live render path of scaffolded apps *and* the pattern users copy into list/grid views. Added a preventative footgun-guard comment to each substrate's `views.cljs` ns docstring calling out the two scale-up hazards: inline handlers (wrap in `use-callback`) and collection-level subscriptions (shape per-row slices). Pure comment additions — no template logic / build / test surface change.

- **rf2-7bpmp** — `perf(template): memoize defined-symbols in emission audit`
  `template_emission_test.clj`'s `defined-symbols` re-slurped each framework `.cljc`/`.cljs` source AND recompiled the `def(n|macro|...)` regex on every call. Three changes:
  - hoisted `def-pattern` to a top-level `def` so the `java.util.regex.Pattern` compiles once at ns-load;
  - split into a pure `scan-defined-symbols` and a memoised `defined-symbols` wrapper;
  - cache by absolute path (framework source tree is immutable for the JVM's lifetime under `clojure -M:test`).

- **rf2-n1ezd** — `perf(template): gate per-substrate clojure -P behind RF2_TEMPLATE_DEPS_RESOLVE`
  The `clojure -P` deps-resolve smoke dominated local wall-time (~6s of a ~9s suite) for zero current signal — the alpha artefacts aren't on Clojars yet, so every run is a known-skip. Gated behind `RF2_TEMPLATE_DEPS_RESOLVE=1` (default off for local fast loop); the `.github/workflows/test.yml jvm-tools-template` job now sets the env var so CI coverage is preserved. Also probed `clojure --help` availability once per JVM (delay) instead of once per substrate.

### Wall-time delta (`tools/template clojure -M:test`)

| Mode | Wall time | Note |
|---|---|---|
| Before (master) | ~9.3 s | 3-substrate suite |
| After, default (gate off) | ~2.8 s | local fast loop — ~70% reduction |
| After, `RF2_TEMPLATE_DEPS_RESOLVE=1` | ~7.1 s | CI lane — known-skips remain until alpha publish lands |

The memoisation in rf2-7bpmp also reduces redundant slurp+regex work proportional to `#emitted-files × #substrates × #re-frame.* references` — it's smaller in absolute terms (most of the savings is from the deps-resolve gate) but pays off whenever the framework surface grows.

## Test plan

- [x] `cd tools/template && clojure -M:test` — 8 tests / 165 assertions / 0 failures
- [x] `cd tools/template && RF2_TEMPLATE_DEPS_RESOLVE=1 clojure -M:test` — same, CI lane verified
- [x] `cd implementation && npm run test:cljs` — 1917 tests / 5462 assertions / 0 failures
- [ ] CI: `jvm-tools-template` job (with `RF2_TEMPLATE_DEPS_RESOLVE=1`) goes green