### PR TITLE
perf(story): batched cluster — 3 follow-on beads

### DIFF
--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -114,22 +114,55 @@
   kind->id->body
   (atom (fresh-table)))
 
+;; ---- mutation tick (rf2-zrswb) -------------------------------------------
+;;
+;; Every write through the side-table bumps `mutation-tick`. Consumers that
+;; do expensive registry-derived work (e.g. the shell's watch-mode hot-loop
+;; in `re-frame.story.ui.shell/compute-testable-content-hashes`) can record
+;; the tick they last hashed against and short-circuit when nothing has
+;; changed. The tick is monotonic, per-process, atomic; cheap to read.
+;;
+;; Optionally we'd publish a richer mutation trace (per-kind / per-id);
+;; the simple counter is sufficient for v1 — the watch-mode poll only
+;; needs a `(tick-advanced? ?)` answer to decide whether to re-walk.
+
+(defonce
+  ^{:doc "Monotonic per-process mutation counter. Bumped by every write
+         on `kind->id->body` (reg-*!, unregister!, clear-kind!, clear-all!).
+         Public so downstream consumers can build registrar-driven caches."}
+  mutation-tick
+  (atom 0))
+
+(defn current-mutation-tick
+  "Return the current mutation tick. Use as a cheap dirty-bit alongside
+  a memoised registry-derived value: cache the value AND the tick;
+  recompute only when the tick has advanced."
+  []
+  @mutation-tick)
+
+(defn- bump-tick! []
+  (swap! mutation-tick inc)
+  nil)
+
 (defn clear-all!
   "Reset the side-table. Used by test fixtures."
   []
   (reset! kind->id->body (fresh-table))
+  (bump-tick!)
   nil)
 
 (defn clear-kind!
   "Remove every id under kind. Used by test fixtures and hot-reload."
   [kind]
   (swap! kind->id->body assoc kind {})
+  (bump-tick!)
   nil)
 
 (defn unregister!
   "Remove a single id under kind."
   [kind id]
   (swap! kind->id->body update kind dissoc id)
+  (bump-tick!)
   nil)
 
 ;; ---- query API (mirrors spec/001 public registrar query API) -------------
@@ -246,6 +279,7 @@
                  (->> (validate-shape! :story id)))
         _    (validate-tag-membership! id (:tags body))]
     (swap! kind->id->body assoc-in [:story id] body)
+    (bump-tick!)
     id))
 
 (defn reg-variant*
@@ -265,6 +299,7 @@
                      (->> (validate-shape! :variant id)))
         _        (validate-tag-membership! id (:tags body))]
     (swap! kind->id->body assoc-in [:variant id] body)
+    (bump-tick!)
     id))
 
 (defn reg-workspace*
@@ -275,6 +310,7 @@
                  merge-coords
                  (->> (validate-shape! :workspace id)))]
     (swap! kind->id->body assoc-in [:workspace id] body)
+    (bump-tick!)
     id))
 
 (defn reg-mode*
@@ -286,6 +322,7 @@
                  merge-coords
                  (->> (validate-shape! :mode id)))]
     (swap! kind->id->body assoc-in [:mode id] body)
+    (bump-tick!)
     id))
 
 (defn reg-story-panel*
@@ -297,6 +334,7 @@
                  merge-coords
                  (->> (validate-shape! :story-panel id)))]
     (swap! kind->id->body assoc-in [:story-panel id] body)
+    (bump-tick!)
     id))
 
 (defn reg-decorator*
@@ -310,6 +348,7 @@
                  merge-coords
                  (->> (validate-shape! :decorator id)))]
     (swap! kind->id->body assoc-in [:decorator id] body)
+    (bump-tick!)
     id))
 
 (defn reg-tag*
@@ -320,6 +359,7 @@
                  merge-coords
                  (->> (validate-shape! :tag id)))]
     (swap! kind->id->body assoc-in [:tag id] body)
+    (bump-tick!)
     id))
 
 ;; ---- canonical tag bootstrap ---------------------------------------------

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -216,41 +216,50 @@
 
   Per rf2-agshe the inference recurses into nested `:map` / `:vector` /
   `:set` / `:tuple` shapes, producing widget descriptors the renderer
-  expands into nested rows."
-  [variant-id]
-  (let [vb      (registrar/handler-meta :variant variant-id)
-        story   (args/parent-story-id variant-id)
-        sb      (when story (registrar/handler-meta :story story))
-        types   (merge (normalize-argtypes (:argtypes sb))
-                       (normalize-argtypes (:argtypes vb)))
-        ;; Prefer an explicit `:schema` slot on the variant/story body
-        ;; (forward-compatible — Spec 010 will land an `:rf/schema` slot
-        ;; on variants for the auto-derivation path). Fall back to the
-        ;; registered :view's `:schema` slot (when reg-view starts
-        ;; carrying one). Per spec/001 §Schema-derivation pipeline.
-        component-id (or (:component vb) (:component sb))
-        component-body (when component-id
-                         (registrar/handler-meta :view component-id))
-        derive-schema (or (:schema vb)
-                          (:schema sb)
-                          (:schema component-body))
-        schema-entries (when (and (vector? derive-schema)
-                                  (= :map (schema-op derive-schema)))
-                         (into {}
-                               (map (fn [entry]
-                                      [(map-entry-key entry)
-                                       (map-entry-schema entry)]))
-                               (schema-children derive-schema)))
-        eff     (args/resolve-args variant-id)]
-    (reduce-kv
-      (fn [acc k v]
-        (if (contains? acc k)
-          acc
-          (let [from-schema (when-let [s (get schema-entries k)]
-                              (infer-widget s))]
-            (assoc acc k (or from-schema (infer-value-shape v))))))
-      (or types {})
-      eff)))
+  expands into nested rows.
+
+  HOT PATH (rf2-wb4y3): `args-editor` is keystroke-sensitive — every
+  controls-panel edit re-renders, which re-runs this fn. The optional
+  `eff-args` arg threads the caller's already-resolved args through so
+  we don't re-run `args/resolve-args` (which itself deep-merges five
+  precedence layers and re-reads the registrar). The single-arity
+  overload preserves the canonical surface for tests + non-render
+  callers; the render path threads its own resolution."
+  ([variant-id]
+   (resolve-argtypes variant-id (args/resolve-args variant-id)))
+  ([variant-id eff-args]
+   (let [vb      (registrar/handler-meta :variant variant-id)
+         story   (args/parent-story-id variant-id)
+         sb      (when story (registrar/handler-meta :story story))
+         types   (merge (normalize-argtypes (:argtypes sb))
+                        (normalize-argtypes (:argtypes vb)))
+         ;; Prefer an explicit `:schema` slot on the variant/story body
+         ;; (forward-compatible — Spec 010 will land an `:rf/schema`
+         ;; slot on variants for the auto-derivation path). Fall back
+         ;; to the registered :view's `:schema` slot (when reg-view
+         ;; starts carrying one). Per spec/001 §Schema-derivation pipeline.
+         component-id (or (:component vb) (:component sb))
+         component-body (when component-id
+                          (registrar/handler-meta :view component-id))
+         derive-schema (or (:schema vb)
+                           (:schema sb)
+                           (:schema component-body))
+         schema-entries (when (and (vector? derive-schema)
+                                   (= :map (schema-op derive-schema)))
+                          (into {}
+                                (map (fn [entry]
+                                       [(map-entry-key entry)
+                                        (map-entry-schema entry)]))
+                                (schema-children derive-schema)))]
+     (reduce-kv
+       (fn [acc k v]
+         (if (contains? acc k)
+           acc
+           (let [from-schema (when-let [s (get schema-entries k)]
+                               (infer-widget s))]
+             (assoc acc k (or from-schema (infer-value-shape v))))))
+       (or types {})
+       eff-args))))
 
 ;; ---- widget renderers ----------------------------------------------------
 
@@ -507,7 +516,14 @@
   `args/resolve-args` and walks every key, rendering a widget per the
   inferred argtype. Top-level keys render as flat rows; collection
   argtypes (`:map` / `:vector` / `:set` / `:tuple`) recurse into nested
-  rows (rf2-agshe)."
+  rows (rf2-agshe).
+
+  HOT PATH (rf2-wb4y3): every keystroke in a control row writes through
+  `:cell-overrides`, the shell-state ratom re-renders this component,
+  which re-runs the whole derivation. We resolve args ONCE here and
+  thread the result into `resolve-argtypes` — without the thread the
+  resolution ran twice (once here, once inside `resolve-argtypes`'s
+  fallback-inference branch). Same precedence chain, no duplicated work."
   [variant-id]
   (let [shell      @state/shell-state-atom
         eff-args   (args/resolve-args
@@ -515,7 +531,7 @@
                      {:active-modes (:active-modes shell)
                       :cell-overrides
                       (get-in shell [:cell-overrides variant-id])})
-        argtypes   (resolve-argtypes variant-id)]
+        argtypes   (resolve-argtypes variant-id eff-args)]
     [:div {:style (:section styles)}
      [:div {:style (:section-h styles)} "Args"]
      (if (empty? eff-args)

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -42,6 +42,7 @@
             [re-frame.story.decorators :as decorators]
             [re-frame.story.frames :as frames]
             [re-frame.story.identity :as identity]
+            [re-frame.story.registrar :as registrar]
             [re-frame.story.runtime :as runtime]
             [re-frame.trace :as rf-trace]
             [re-frame.story.ui.actions :as actions]
@@ -104,8 +105,30 @@
 ;; `sidebar/watch-rerun!` for the variants whose hash drifted.
 ;;
 ;; Detection runs on the same 500ms cadence as the existing hot-reload
-;; poll — both polls share `setInterval` for v1; v2 will wire to the
-;; registrar's mutation trace for an event-driven re-resolve.
+;; poll — both polls share `setInterval` for v1.
+;;
+;; HOT PATH (rf2-zrswb): `compute-testable-content-hashes` runs every
+;; 500ms while watch mode is on. The naïve walk hashed every testable
+;; variant on every tick — pr-str of the canonical tuple per variant,
+;; cost O(V × variant-body-size). For a corpus of N testable variants
+;; the steady-state cost is dominated by serialisation that produces
+;; the same hash 99.9% of the time.
+;;
+;; The cache below keys on `[registrar-mutation-tick, active-modes,
+;; substrate]` — the three inputs that can perturb a snapshot-identity
+;; hash across two polls (registrar writes invalidate every variant
+;; entry; shell-state mode/substrate changes too). When the key matches
+;; the previous tick's key, we return the cached map — zero hashing
+;; work. When it drifts, we recompute the lot once and re-seed the
+;; cache.
+;;
+;; The `:cell-overrides` slot of shell-state is intentionally NOT in
+;; the cache key: `snapshot-identity`'s public surface drops it (only
+;; `:active-modes` and `:substrate` are threaded into the tuple), so
+;; per-cell control edits do not perturb the watch-mode signal.
+
+(defonce ^:private testable-hash-cache
+  (atom {:key nil :hashes nil}))
 
 (defn- compute-testable-content-hashes
   "Walk the registered testable variants and return a `{variant-id →
@@ -115,16 +138,30 @@
   schema-digest (per `re-frame.story.identity` §What's in the hash —
   spec/007 §Variant snapshot identity), so a change to any of those —
   including a decorator-only edit or a view schema change — produces a
-  fresh hash."
+  fresh hash.
+
+  HOT PATH (rf2-zrswb): registrar-driven cache short-circuits when
+  neither the side-table nor the relevant shell-state slots have
+  drifted since the last tick."
   []
-  (let [testable (state/testable-variant-ids (:variants (state/registry-snapshot)))
-        shell    (state/get-state)
-        opts     {:active-modes (:active-modes shell)
-                  :substrate    (:substrate shell)}]
-    (into {}
-          (map (fn [vid]
-                 [vid (:content-hash (identity/snapshot-identity vid opts))]))
-          testable)))
+  (let [shell  (state/get-state)
+        modes  (:active-modes shell)
+        subs   (:substrate shell)
+        tick   (registrar/current-mutation-tick)
+        key    [tick modes subs]
+        cached @testable-hash-cache]
+    (if (= key (:key cached))
+      (:hashes cached)
+      (let [testable (state/testable-variant-ids
+                       (:variants (state/registry-snapshot)))
+            opts     {:active-modes modes :substrate subs}
+            hashes   (into {}
+                           (map (fn [vid]
+                                  [vid (:content-hash
+                                         (identity/snapshot-identity vid opts))]))
+                           testable)]
+        (reset! testable-hash-cache {:key key :hashes hashes})
+        hashes))))
 
 (defn detect-watch-drift!
   "When watch mode is on, compute the current testable-variant content

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -305,17 +305,25 @@
   Per rf2-z1h0f the widget also carries an eye-icon watch-mode toggle
   beneath the count chips. When on, the shell auto-re-runs testable
   variants whose snapshot-identity drifted since the last observation
-  (the detection signal is wired in `re-frame.story.ui.shell`)."
-  [shell registry]
-  (let [variant-ids (state/testable-variant-ids (:variants registry))
-        summary     (state/test-summary shell variant-ids)
-        {:keys [total passed failed running pending all-green?]} summary
-        any-run?    (pos? running)
-        watch-on?   (state/test-watch-mode? shell)
-        headline    (cond
-                      (zero? total)  "Tests"
-                      all-green?     (str "Tests · ✓ " passed)
-                      :else          (str "Tests · " passed "/" total))]
+  (the detection signal is wired in `re-frame.story.ui.shell`).
+
+  HOT PATH (rf2-dtj61): `testable-variant-ids` is the seq the parent
+  sidebar already derives for its per-variant status dots. Callers
+  may thread the precomputed seq through as `variant-ids` to avoid a
+  second registry walk; the no-arg form keeps the canonical surface
+  for tests and standalone consumers."
+  ([shell registry]
+   (test-widget shell registry (state/testable-variant-ids
+                                 (:variants registry))))
+  ([shell _registry variant-ids]
+   (let [summary     (state/test-summary shell variant-ids)
+         {:keys [total passed failed running pending all-green?]} summary
+         any-run?    (pos? running)
+         watch-on?   (state/test-watch-mode? shell)
+         headline    (cond
+                       (zero? total)  "Tests"
+                       all-green?     (str "Tests · ✓ " passed)
+                       :else          (str "Tests · " passed "/" total))]
     [:div {:style     (:widget styles)
            :data-test "story-test-widget"}
      [:div {:style (:widget-h styles)
@@ -367,7 +375,7 @@
            :on-click      (fn [_]
                             (state/swap-state! state/set-test-watch-mode
                                                (not watch-on?)))}
-          (if watch-on? "● watching" "○ watch")]]])]))
+          (if watch-on? "● watching" "○ watch")]]])])))
 
 (defn sidebar
   "Top-level sidebar component. Reads the registry snapshot + shell
@@ -381,18 +389,26 @@
   variant status dots (rendered inside each variant row when the
   variant is `:test`-tagged + `:play`-bearing) and the chrome-level
   test widget at the foot. Both read from `[:tests :runs]`; the widget
-  drives `run-variant` over the testable set on click."
+  drives `run-variant` over the testable set on click.
+
+  HOT PATH (rf2-dtj61): every shell-state ratom change re-renders this
+  component, which re-walks the registry to build the view model. We
+  compute `testable-variant-ids` ONCE here — both the per-row
+  `testable?` check (set membership) and the chrome-level `test-widget`
+  share the same derivation. Deeper memoisation keyed on
+  `(registrar-tick, tag-filter)` can wait until corpus size justifies."
   []
-  (let [shell         @state/shell-state-atom
-        registry      (state/registry-snapshot)
-        tag-filter    (:tag-filter shell)
-        sel-variant   (:selected-variant shell)
-        sel-ws        (:selected-workspace shell)
-        visible       (state/filter-variants (:variants registry) tag-filter)
-        grouped       (state/group-variants-by-story visible)
-        workspaces    (:workspaces registry)
-        test-runs     (get-in shell [:tests :runs])
-        testable-set  (set (state/testable-variant-ids (:variants registry)))]
+  (let [shell           @state/shell-state-atom
+        registry        (state/registry-snapshot)
+        tag-filter      (:tag-filter shell)
+        sel-variant     (:selected-variant shell)
+        sel-ws          (:selected-workspace shell)
+        visible         (state/filter-variants (:variants registry) tag-filter)
+        grouped         (state/group-variants-by-story visible)
+        workspaces      (:workspaces registry)
+        test-runs       (get-in shell [:tests :runs])
+        testable-vec    (state/testable-variant-ids (:variants registry))
+        testable-set    (set testable-vec)]
     [:nav {:style      (:wrap styles)
            :aria-label "Stories and workspaces"
            :tab-index  "0"}
@@ -413,4 +429,4 @@
          (for [[wid _body] (sort-by key workspaces)]
            ^{:key wid}
            [workspace-row wid (= wid sel-ws)])])]
-     [test-widget shell registry]]))
+     [test-widget shell registry testable-vec]]))

--- a/tools/story/test/re_frame/story/ui/controls_nested_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/controls_nested_cljs_test.cljc
@@ -176,6 +176,40 @@
          ;; :items vector value → :repeater
          (is (= :repeater (-> t :items :widget)))))))
 
+;; ---- rf2-wb4y3: 2-arity threads precomputed eff-args ---------------------
+
+#?(:cljs
+   (deftest resolve-argtypes-2-arity-threads-eff-args
+     (testing "the 2-arity overload uses the supplied eff-args instead of
+               re-resolving — passes a fabricated args map and asserts the
+               fallback-inference reflects that shape (not the registered
+               variant args)"
+       (story/reg-variant :story.nest/v4
+         {:args   {:registered "x"}
+          :events []})
+       ;; Supply a different eff-args map. The variant has no schema and
+       ;; no argtypes, so the fallback inference walks the supplied map's
+       ;; value shapes — :supplied should appear in the result, :registered
+       ;; should NOT (proving the supplied map was used, not the variant's
+       ;; own).
+       (let [t (controls/resolve-argtypes :story.nest/v4
+                                          {:supplied "y" :n 42})]
+         (is (contains? t :supplied))
+         (is (contains? t :n))
+         (is (not (contains? t :registered)))
+         (is (= :text   (-> t :supplied :widget)))
+         (is (= :number (-> t :n :widget)))))))
+
+#?(:cljs
+   (deftest resolve-argtypes-1-arity-still-resolves-internally
+     (testing "the 1-arity overload still works for non-render callers
+               (tests, docs, etc.) — it calls args/resolve-args itself"
+       (story/reg-variant :story.nest/v5
+         {:args   {:title "hi"}
+          :events []})
+       (let [t (controls/resolve-argtypes :story.nest/v5)]
+         (is (= :text (-> t :title :widget)))))))
+
 ;; ---- JVM + CLJS: path-aware set-cell-override ---------------------------
 
 (deftest set-cell-override-scalar-wrapper

--- a/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
@@ -270,6 +270,35 @@
          (is (some? btn))
          (is (true? (get (second btn) :disabled)))))))
 
+;; ---- rf2-dtj61: 3-arity threads precomputed variant-ids ----------------
+
+#?(:cljs
+   (deftest widget-3-arity-uses-supplied-variant-ids
+     (testing "the 3-arity overload uses the caller's supplied variant-ids
+               instead of re-deriving from the registry — passes a
+               restricted subset and asserts the headline counts reflect
+               only that subset"
+       (story/reg-variant :story.x/a {:tags #{:test} :events []
+                                      :play [[:rf.assert/path-equals [:c] 0]]})
+       (story/reg-variant :story.x/b {:tags #{:test} :events []
+                                      :play [[:rf.assert/path-equals [:c] 0]]})
+       (story/reg-variant :story.x/c {:tags #{:test} :events []
+                                      :play [[:rf.assert/path-equals [:c] 0]]})
+       ;; Supply a 1-variant subset. The registry has three; the widget
+       ;; should report total=1 because we threaded a 1-element seq, not
+       ;; the full registry-derived set.
+       (let [tree     (sidebar/test-widget (state/get-state)
+                                           (state/registry-snapshot)
+                                           [:story.x/a])
+             headline (first (find-by-data-test tree
+                                                "story-test-widget-headline"))]
+         (is (some? headline))
+         ;; "Tests" headline reads "Tests" with a 1/1 or pending split;
+         ;; the load-bearing assertion is that 3 variants did NOT land —
+         ;; we did NOT see "0/3" or "0/2".
+         (is (not (re-find #"/3" (nth headline 2))))
+         (is (not (re-find #"/2" (nth headline 2))))))))
+
 ;; ---- regression: per-variant cell-overrides threading (rf2-zq6sn) -------
 
 #?(:cljs

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -506,6 +506,32 @@
   (testing "the public probe (re-frame.story/static-mode?) reflects the flag"
     (is (false? (re-frame.story/static-mode?)))))
 
+;; ---- registrar mutation tick (rf2-zrswb) ----------------------------
+
+(deftest mutation-tick-bumps-on-every-write
+  (testing "every reg-* / unregister! / clear-* call bumps the tick;
+            consumers caching registry-derived work key off this counter"
+    (let [t0 (registrar/current-mutation-tick)]
+      (story/reg-story :story.ui.tick {:doc "tick test"})
+      (is (> (registrar/current-mutation-tick) t0))
+      (let [t1 (registrar/current-mutation-tick)]
+        (story/reg-variant :story.ui.tick/v {:events [[:init]]})
+        (is (> (registrar/current-mutation-tick) t1))
+        (let [t2 (registrar/current-mutation-tick)]
+          (registrar/unregister! :variant :story.ui.tick/v)
+          (is (> (registrar/current-mutation-tick) t2))
+          (let [t3 (registrar/current-mutation-tick)]
+            (registrar/clear-kind! :variant)
+            (is (> (registrar/current-mutation-tick) t3))))))))
+
+(deftest mutation-tick-is-monotonic
+  (testing "the tick only ever advances — never resets to a smaller value"
+    (let [t0 (registrar/current-mutation-tick)]
+      (dotimes [i 5]
+        (story/reg-variant (keyword (str "story.tick.mono/v" i))
+                           {:events [[:init]]}))
+      (is (>= (registrar/current-mutation-tick) (+ t0 5))))))
+
 ;; ---- Stage 6 contract check -----------------------------------------
 
 (deftest stage-marker


### PR DESCRIPTION
## Summary

Three perf follow-on beads from `ai/findings/perf-audit-story-2026-05-14.md`, batched as one PR by surface (`tools/story/`). All target hot loops; none change behaviour. Total +198 net LoC across 4 source files + 3 test files.

**rf2-zrswb — registrar-driven watch-mode hash cache** (P3)
- Adds a monotonic `mutation-tick` to `re-frame.story.registrar` (bumped by every reg/unregister/clear write).
- `shell/compute-testable-content-hashes` (the 500ms watch-mode poll) now caches the `{vid → hex-hash}` map keyed on `[tick, active-modes, substrate]`. Cache hit = zero hashing. Steady-state cost drops from O(V × tuple-serialisation) to O(1).
- The v1 comment in `shell.cljs` (lines 107-108) already anticipated this exact refactor (\"v2 will wire to the registrar's mutation trace for an event-driven re-resolve\"). Done.

**rf2-wb4y3 — single-pass args-editor / resolve-argtypes** (P3)
- `controls/args-editor` resolved eff-args, then `resolve-argtypes` resolved them AGAIN for its fallback-inference branch — two registrar walks and two five-layer deep-merges per keystroke.
- Adds 2-arity `(resolve-argtypes variant-id eff-args)`. Render path threads the precomputed args; tests/docs keep the canonical 1-arity surface.

**rf2-dtj61 — sidebar view-model computed once per render** (P3)
- `sidebar` and the embedded `test-widget` each walked `testable-variant-ids` independently per render. Compute once in `sidebar`, thread both vec (for the widget) and set (for per-row testable? membership) to consumers.
- Adds 3-arity `(test-widget shell registry variant-ids)`; existing 2-arity surface preserved.

Each bead = one commit. HOT PATH comments mark all three call sites.

## Test plan

- [x] `cd tools/story && clojure -M:test` — 366 tests / 1093 assertions / 0 failures
- [x] `cd implementation && npm run test:cljs` — 1920 tests / 5471 assertions / 0 failures
- [x] `cd implementation && npm run test:examples` — 26/26 examples PASS (including `counter-with-stories`, the only story-touching example)

## Coverage added

- 2 JVM tests for the mutation tick (monotonicity + bumps-on-every-write)
- 2 CLJS tests for `resolve-argtypes` 2-arity (precomputed eff-args path + 1-arity preservation)
- 1 CLJS test for `test-widget` 3-arity (precomputed variant-ids path)