### PR TITLE
refactor+perf(mcp-infra): batched cluster — 7 follow-on beads

### DIFF
--- a/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
@@ -50,11 +50,23 @@
 
   This is the load-bearing default-suppress filter per spec/009
   §Privacy. Apply it to any vector of trace-event-shaped maps before
-  the result crosses the MCP boundary into the agent surface."
+  the result crosses the MCP boundary into the agent surface.
+
+  ## Fast-path (rf2-0q30r)
+
+  The docstring promises identical-vector return when no events drop;
+  the implementation honours that by scanning first with `some` and
+  only allocating a `filterv` vector when at least one match exists.
+  Common-path cost: one linear `some` scan, zero allocation, identity
+  preserved on `events`. Drop-path cost: the same linear scan plus
+  the historical `filterv`/`count`/`count` pass — one extra walk on
+  the rare branch in exchange for zero extra cost on every common
+  call."
   [events include?]
   (cond
-    include?         [events 0]
-    (empty? events)  [events 0]
+    include?                       [events 0]
+    (empty? events)                [events 0]
+    (not (some sensitive-event? events)) [events 0]
     :else
     (let [kept (filterv (complement sensitive-event?) events)
           n    (- (count events) (count kept))]

--- a/tools/mcp-conformance/test/_runner.js
+++ b/tools/mcp-conformance/test/_runner.js
@@ -1,0 +1,102 @@
+// Shared Node-side test runner for MCP-conformance harnesses.
+//
+// Every `tools/mcp-conformance/test/end-to-end-*.js` (and the
+// sibling `live-pair2-overflow.js`) repeats the same ceremony:
+//
+//   - construct a `StdioClientTransport` with `stderr: 'pipe'`
+//   - pipe the child's stderr to ours with a `[server]` prefix
+//   - construct an SDK `Client` with a `mcp-conformance-*` identity
+//   - install a watchdog `setTimeout` so a hung child can't wedge CI
+//   - on success: tear down the transport, clear the watchdog,
+//     `process.exit(0)`
+//   - on error: best-effort `client.close()`, clear the watchdog,
+//     print the failure, `process.exit(1)`
+//   - on watchdog: print the timeout, `process.exit(2)`
+//
+// Source: rf2-sems4. The split was originally three near-identical
+// ~40-LoC blocks of pure framing code; centralising the framing here
+// shrinks each test body to the workflow steps that actually differ.
+// Adding a fourth Node-side conformance test (causa-mcp impl, a third
+// pair2 variant) becomes ~30 LoC instead of ~110.
+//
+// ## Contract
+//
+// `runWithWatchdog({ watchdogMs, transportSpec, clientName, clientVersion }, body)`
+//
+//   - `watchdogMs`     — ms before the hard-cap `process.exit(2)` fires.
+//   - `transportSpec`  — `{ command, args, cwd, env }` forwarded to
+//                        `StdioClientTransport` (with `stderr: 'pipe'`
+//                        spliced in automatically).
+//   - `clientName`     — the SDK `Client` `name` slot.
+//   - `clientVersion`  — the SDK `Client` `version` slot (default
+//                        `'0.1.0'` — matches the historical value the
+//                        three concrete tests used).
+//   - `body`           — `async (client, transport) => void`. Throws on
+//                        any assertion failure; the runner reports the
+//                        message + stack and exits 1.
+//
+// `runWithWatchdog` performs the SDK connect handshake itself (every
+// historical caller did it as the first line of the body) and passes
+// the connected `client` + `transport` to `body`. Tests that want to
+// skip (no-op exit 0) call `process.exit(0)` directly BEFORE invoking
+// this function — see `live-pair2-overflow.js`'s `isSkip()` branch.
+//
+// The runner returns nothing; it always terminates the process via
+// `process.exit`. Callers that pre-flight skip MUST exit themselves.
+
+const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
+const { StdioClientTransport } = require('@modelcontextprotocol/sdk/client/stdio.js');
+
+async function runWithWatchdog(
+  { watchdogMs, transportSpec, clientName, clientVersion = '0.1.0' },
+  body,
+) {
+  // Install the watchdog FIRST so even a hang inside transport
+  // construction (rare but possible: bad cwd, env corruption) gets
+  // killed. The active timer is cleared on every exit path below.
+  const watchdog = setTimeout(() => {
+    console.error('FAIL: watchdog timeout (' + watchdogMs + 'ms)');
+    process.exit(2);
+  }, watchdogMs);
+
+  // `stderr: 'pipe'` is non-negotiable — every conformance test pipes
+  // the server's stderr so CI logs surface the server-side debug
+  // output when a step fails. Splice it in here rather than asking
+  // the caller to remember it.
+  const transport = new StdioClientTransport({ ...transportSpec, stderr: 'pipe' });
+
+  const client = new Client({ name: clientName, version: clientVersion }, { capabilities: {} });
+
+  // Pipe the child's stderr to ours with a `[server]` prefix. Same
+  // shape every historical caller used; the closure captures the
+  // transport reference cleanly.
+  transport.stderr?.on('data', (d) => process.stderr.write('[server] ' + d.toString()));
+
+  try {
+    // Initialize handshake. SDK validates the result against
+    // InitializeResultSchema; a malformed envelope throws here.
+    await client.connect(transport);
+    await body(client, transport);
+    // Success — tear down the transport explicitly. The SDK's
+    // `client.close()` kills the child process; without it CI would
+    // wait for the watchdog.
+    await client.close();
+    clearTimeout(watchdog);
+    process.exit(0);
+  } catch (err) {
+    // Best-effort teardown. If `client.close()` itself throws (e.g.
+    // because the transport already died), swallow that — the
+    // original error is the load-bearing signal.
+    try {
+      await client.close();
+    } catch (_e) {
+      // best-effort
+    }
+    clearTimeout(watchdog);
+    console.error('FAIL:', err.message);
+    if (err.stack) console.error(err.stack);
+    process.exit(1);
+  }
+}
+
+module.exports = { runWithWatchdog };

--- a/tools/mcp-conformance/test/end-to-end-pair2.js
+++ b/tools/mcp-conformance/test/end-to-end-pair2.js
@@ -28,8 +28,7 @@
 
 const path = require('node:path');
 const os = require('node:os');
-const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
-const { StdioClientTransport } = require('@modelcontextprotocol/sdk/client/stdio.js');
+const { runWithWatchdog } = require('./_runner.js');
 
 const SERVER = path.resolve(__dirname, '..', '..', 'pair2-mcp', 'out', 'server.js');
 
@@ -53,41 +52,28 @@ const EXPECTED_TOOLS = [
   'watch-epochs',
 ];
 
-async function main() {
-  // Force degraded mode: empty out $SHADOW_CLJS_NREPL_PORT and boot
-  // from a tmpdir so the port-file probe misses. Same setup as the
-  // pair2-mcp upstream stdio-roundtrip.
-  const env = { ...process.env };
-  delete env.SHADOW_CLJS_NREPL_PORT;
+// Force degraded mode: empty out $SHADOW_CLJS_NREPL_PORT and boot from
+// a tmpdir so the port-file probe misses. Same setup as the pair2-mcp
+// upstream stdio-roundtrip.
+const env = { ...process.env };
+delete env.SHADOW_CLJS_NREPL_PORT;
 
-  const transport = new StdioClientTransport({
-    command: process.execPath,
-    args: [SERVER],
-    cwd: os.tmpdir(),
-    env,
-    stderr: 'pipe',
-  });
+runWithWatchdog(
+  {
+    watchdogMs: 60000,
+    clientName: 'mcp-conformance-pair2',
+    transportSpec: {
+      command: process.execPath,
+      args: [SERVER],
+      cwd: os.tmpdir(),
+      env,
+    },
+  },
+  async (client) => {
+    const serverInfo = client.getServerVersion();
+    if (!serverInfo) throw new Error('connect succeeded but getServerVersion() is empty');
+    console.log('OK   connect ->', serverInfo);
 
-  const client = new Client(
-    { name: 'mcp-conformance-pair2', version: '0.1.0' },
-    { capabilities: {} },
-  );
-
-  // Pipe server stderr to ours so CI logs surface server-side debug
-  // output if a step fails.
-  transport.stderr?.on('data', (d) => process.stderr.write('[server] ' + d.toString()));
-
-  // 1. Connect — the SDK Client.connect() does the full initialize
-  // handshake (initialize request, response, notifications/initialized)
-  // and validates the result envelope against InitializeResultSchema.
-  // If the server's initialize response drifts from the spec, this
-  // throws.
-  await client.connect(transport);
-  const serverInfo = client.getServerVersion();
-  if (!serverInfo) throw new Error('connect succeeded but getServerVersion() is empty');
-  console.log('OK   connect ->', serverInfo);
-
-  try {
     // 2. tools/list via SDK. The SDK validates the response against
     // ListToolsResultSchema, so any descriptor-shape drift surfaces
     // here.
@@ -228,36 +214,10 @@ async function main() {
       'OK   tools/call subscription-info (degraded) -> isError + nrepl-port-not-found',
     );
 
-    // 4. Clean disconnect. The SDK closes the transport which kills
-    // the child process. If the server hangs on shutdown the harness
-    // will be killed by the watchdog timeout.
-    await client.close();
-    console.log('OK   client.close() -> transport torn down cleanly');
+    // 4. The runner tears down the transport via client.close() on
+    // exit; the SDK closes the transport which kills the child
+    // process. If the server hangs on shutdown the runner's watchdog
+    // catches it.
     console.log('\nPAIR2-MCP MCP-CLIENT CONFORMANCE GREEN');
-  } catch (err) {
-    try {
-      await client.close();
-    } catch (_e) {
-      // best-effort
-    }
-    throw err;
-  }
-}
-
-// Hard cap so a hung server doesn't wedge CI.
-const watchdog = setTimeout(() => {
-  console.error('FAIL: watchdog timeout (60s)');
-  process.exit(2);
-}, 60000);
-
-main()
-  .then(() => {
-    clearTimeout(watchdog);
-    process.exit(0);
-  })
-  .catch((e) => {
-    clearTimeout(watchdog);
-    console.error('FAIL:', e.message);
-    if (e.stack) console.error(e.stack);
-    process.exit(1);
-  });
+  },
+);

--- a/tools/mcp-conformance/test/end-to-end-story.js
+++ b/tools/mcp-conformance/test/end-to-end-story.js
@@ -27,8 +27,7 @@
 // 0 on success. Source: rf2-cum40.
 
 const path = require('node:path');
-const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
-const { StdioClientTransport } = require('@modelcontextprotocol/sdk/client/stdio.js');
+const { runWithWatchdog } = require('./_runner.js');
 
 const STORY_MCP_CWD = path.resolve(__dirname, '..', '..', 'story-mcp');
 const CLOJURE = process.env.STORY_MCP_CMD || 'clojure';
@@ -63,31 +62,26 @@ const EXPECTED_TOOLS = [
 // test scripts could in principle run against the same JVM.
 const FIXTURE_VARIANT = 'story.mcp-conformance/probe.primary';
 
-async function main() {
-  const env = { ...process.env };
+// JVM boot is slow on a cold CI worker (~10-30s); the whole register →
+// run → read → unregister loop adds a few more seconds. 90s is
+// comfortably above that without leaving a hung process if something
+// stalls.
+runWithWatchdog(
+  {
+    watchdogMs: 90000,
+    clientName: 'mcp-conformance-story',
+    transportSpec: {
+      command: CLOJURE,
+      args: ['-M', '-m', 're-frame.story-mcp.server', '--allow-writes'],
+      cwd: STORY_MCP_CWD,
+      env: { ...process.env },
+    },
+  },
+  async (client) => {
+    const serverInfo = client.getServerVersion();
+    if (!serverInfo) throw new Error('connect succeeded but getServerVersion() is empty');
+    console.log('OK   connect ->', serverInfo);
 
-  const transport = new StdioClientTransport({
-    command: CLOJURE,
-    args: ['-M', '-m', 're-frame.story-mcp.server', '--allow-writes'],
-    cwd: STORY_MCP_CWD,
-    env,
-    stderr: 'pipe',
-  });
-
-  const client = new Client(
-    { name: 'mcp-conformance-story', version: '0.1.0' },
-    { capabilities: {} },
-  );
-
-  transport.stderr?.on('data', (d) => process.stderr.write('[server] ' + d.toString()));
-
-  // 1. Connect. Initialize handshake runs through SDK.
-  await client.connect(transport);
-  const serverInfo = client.getServerVersion();
-  if (!serverInfo) throw new Error('connect succeeded but getServerVersion() is empty');
-  console.log('OK   connect ->', serverInfo);
-
-  try {
     // 2. tools/list — confirm catalogue.
     const listed = await client.listTools();
     const names = listed.tools.map((t) => t.name).sort();
@@ -200,37 +194,7 @@ async function main() {
     }
     console.log('OK   unregister-variant -> teardown verified by subsequent get-variant -> not-found');
 
-    // 7. Clean disconnect.
-    await client.close();
-    console.log('OK   client.close() -> transport torn down cleanly');
+    // 7. Clean disconnect — runner handles client.close() on success.
     console.log('\nSTORY-MCP MCP-CLIENT CONFORMANCE GREEN');
-  } catch (err) {
-    try {
-      await client.close();
-    } catch (_e) {
-      // best-effort
-    }
-    throw err;
-  }
-}
-
-// JVM boot is slow on a cold CI worker (~10-30s); the whole register →
-// run → read → unregister loop adds a few more seconds. 90s is
-// comfortably above that without leaving a hung process if something
-// stalls.
-const watchdog = setTimeout(() => {
-  console.error('FAIL: watchdog timeout (90s)');
-  process.exit(2);
-}, 90000);
-
-main()
-  .then(() => {
-    clearTimeout(watchdog);
-    process.exit(0);
-  })
-  .catch((e) => {
-    clearTimeout(watchdog);
-    console.error('FAIL:', e.message);
-    if (e.stack) console.error(e.stack);
-    process.exit(1);
-  });
+  },
+);

--- a/tools/mcp-conformance/test/live-pair2-overflow.js
+++ b/tools/mcp-conformance/test/live-pair2-overflow.js
@@ -74,8 +74,7 @@
 
 const path = require('node:path');
 const os = require('node:os');
-const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
-const { StdioClientTransport } = require('@modelcontextprotocol/sdk/client/stdio.js');
+const { runWithWatchdog } = require('./_runner.js');
 
 const SERVER = path.resolve(__dirname, '..', '..', 'pair2-mcp', 'out', 'server.js');
 
@@ -293,44 +292,41 @@ function isSkip() {
   return !process.env.SHADOW_CLJS_NREPL_PORT;
 }
 
-async function main() {
-  if (isSkip()) {
-    console.log(
-      'SKIP live-pair2-overflow: $SHADOW_CLJS_NREPL_PORT not set.\n' +
-        '      This variant requires a live shadow-cljs nREPL — without\n' +
-        '      one the server runs degraded and the wire-cap cannot be\n' +
-        '      tripped naturally. The sibling end-to-end-pair2.js covers\n' +
-        '      degraded-mode protocol conformance; this variant adds\n' +
-        '      cap-marker conformance under real over-budget conditions.',
-    );
-    return;
-  }
-
-  const env = { ...process.env };
-
-  const transport = new StdioClientTransport({
-    command: process.execPath,
-    args: [SERVER],
-    cwd: os.tmpdir(),
-    env,
-    stderr: 'pipe',
-  });
-
-  const client = new Client(
-    { name: 'mcp-conformance-pair2-live-overflow', version: '0.1.0' },
-    { capabilities: {} },
+// Pre-flight SKIP: process.exit(0) BEFORE invoking the runner so we
+// don't spawn a child or install a watchdog. Same posture as the sibling
+// end-to-end-causa.js placeholder.
+if (isSkip()) {
+  console.log(
+    'SKIP live-pair2-overflow: $SHADOW_CLJS_NREPL_PORT not set.\n' +
+      '      This variant requires a live shadow-cljs nREPL — without\n' +
+      '      one the server runs degraded and the wire-cap cannot be\n' +
+      '      tripped naturally. The sibling end-to-end-pair2.js covers\n' +
+      '      degraded-mode protocol conformance; this variant adds\n' +
+      '      cap-marker conformance under real over-budget conditions.',
   );
+  process.exit(0);
+}
 
-  transport.stderr?.on('data', (d) => process.stderr.write('[server] ' + d.toString()));
+// Hard cap so a hung server doesn't wedge CI. nREPL connect + one
+// eval round-trip + tear-down should comfortably fit in 60s.
+runWithWatchdog(
+  {
+    watchdogMs: 60000,
+    clientName: 'mcp-conformance-pair2-live-overflow',
+    transportSpec: {
+      command: process.execPath,
+      args: [SERVER],
+      cwd: os.tmpdir(),
+      env: { ...process.env },
+    },
+  },
+  async (client) => {
+    // 1. The runner already ran the SDK initialize handshake. If that
+    // had thrown it means the server's initialize envelope itself
+    // drifted; not the bug this test is hunting, but a load-bearing
+    // pre-condition.
+    console.log('OK   connect -> server attached on nREPL', process.env.SHADOW_CLJS_NREPL_PORT);
 
-  // 1. Connect via the SDK — the same full initialize handshake the
-  // degraded variant exercises. If this throws here it means the
-  // server's initialize envelope itself drifted; not the bug this
-  // test is hunting, but a load-bearing pre-condition.
-  await client.connect(transport);
-  console.log('OK   connect -> server attached on nREPL', process.env.SHADOW_CLJS_NREPL_PORT);
-
-  try {
     // 2. Fire the over-budget eval. The form returns a 25,000-char
     // string (~6,250 token-estimate) which exceeds the 5,000-token
     // default cap. The server's wire-boundary `apply-cap` MUST
@@ -461,35 +457,7 @@ async function main() {
         ')',
     );
 
-    // 8. Clean disconnect.
-    await client.close();
-    console.log('OK   client.close() -> transport torn down cleanly');
+    // 8. Clean disconnect — runner handles client.close() on success.
     console.log('\nPAIR2-MCP LIVE OVERFLOW CONFORMANCE GREEN');
-  } catch (err) {
-    try {
-      await client.close();
-    } catch (_e) {
-      // best-effort
-    }
-    throw err;
-  }
-}
-
-// Hard cap so a hung server doesn't wedge CI. nREPL connect + one
-// eval round-trip + tear-down should comfortably fit in 60s.
-const watchdog = setTimeout(() => {
-  console.error('FAIL: watchdog timeout (60s)');
-  process.exit(2);
-}, 60000);
-
-main()
-  .then(() => {
-    clearTimeout(watchdog);
-    process.exit(0);
-  })
-  .catch((e) => {
-    clearTimeout(watchdog);
-    console.error('FAIL:', e.message);
-    if (e.stack) console.error(e.stack);
-    process.exit(1);
-  });
+  },
+);

--- a/tools/mcp-conformance/wire-vocab/README.md
+++ b/tools/mcp-conformance/wire-vocab/README.md
@@ -9,13 +9,21 @@ The three MCP servers under `tools/` — `pair2-mcp`, `story-mcp`, and
 vocabulary**: namespaced map keys that an agent recognises identically
 across every server it talks to.
 
+There are **five top-level wire markers** plus one embedded fetch-handle
+tag (`:rf.elision/at`, pinned inside the `:rf.size/large-elided` body's
+`:handle` slot — not a standalone marker an agent encounters at the top
+level of a payload):
+
 ```
 :rf.mcp/overflow       — token-budget overflow marker
 :rf.mcp/summary        — tree-summary lazy-mode marker
 :rf.mcp/dedup-table    — structural-dedup wrapper
 :rf.mcp/diff-from      — diff-encoded :db-after marker
 :rf.size/large-elided  — size-elision wire marker
-:rf.elision/at         — size-elision fetch-handle tag
+:rf.elision/at         — embedded fetch-handle tag inside the
+                         :rf.size/large-elided body's :handle slot
+                         (pinned via ElisionMarkerBody, not a
+                         standalone top-level marker)
 ```
 
 Without conformance enforcement, two servers could each ship the

--- a/tools/mcp-conformance/wire-vocab/deps.edn
+++ b/tools/mcp-conformance/wire-vocab/deps.edn
@@ -34,7 +34,13 @@
          metosin/malli       {:mvn/version "0.16.4"}}
 
  :aliases
- {:test {:extra-paths ["test" "fixtures"]
+ ;; All fixtures are inlined in `wire_vocab_test.clj` (as the `:fixtures`
+ ;; slot on `canonical-markers`) and in the sibling test files —
+ ;; no `fixtures/` directory exists. A standalone fixture-tree would
+ ;; be more work than the inline form is currently worth: the fixtures
+ ;; live next to their schemas and the test files are small enough
+ ;; (rf2-ikjrr).
+ {:test {:extra-paths ["test"]
          :extra-deps  {io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts   ["-m" "cognitect.test-runner"]}}}

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj
@@ -67,14 +67,29 @@
         .getParentFile                                      ; <repo-root>
         .getAbsolutePath)))
 
-(defn read-source
+(def read-source
   "Slurp a source file inside the repo. `rel-path` is a string path
   segment relative to the repo root, using `/` as the separator. The
   test fails loudly (via `slurp`'s default IOException) if the path
   doesn't resolve — that's the right signal: a source file under
-  conformance was moved or removed."
-  [rel-path]
-  (slurp (io/file repo-root rel-path)))
+  conformance was moved or removed.
+
+  ## Memoisation (rf2-re2tv)
+
+  Callers iterate `doseq` over the same files dozens of times across
+  the three conformance test namespaces (`wire-vocab-test`,
+  `slot-name-test`, `indicator-field-test`); the wire-vocab suite was
+  ~4356ms wall-clock and almost entirely I/O-bound on a cold disk
+  cache. Wrapping in `memoize` keyed on the rel-path drops the
+  re-slurp cost to zero for every repeated access. Source files do
+  not change mid-test-run, so cache invalidation is a non-concern.
+
+  The bound name stays `read-source` (no underscore prefix or
+  `read-source*` indirection) so the call sites read identically to
+  the un-memoised form."
+  (memoize
+    (fn read-source* [rel-path]
+      (slurp (io/file repo-root rel-path)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Cross-server registry. The three MCP servers under the triplet's
@@ -129,23 +144,19 @@
   (re-pattern (str (java.util.regex.Pattern/quote variant-str)
                    "(?![\\w\\-?/!*+'<>=])")))
 
-(defn strip-comments-and-strings
-  "Return `src` with Clojure line comments (`;` to EOL) and string
-  literals (`\"...\"`, including docstrings) replaced by single
-  spaces. Preserves line structure for accurate error reporting up
-  the stack.
-
-  Implementation: simple state machine over the raw text. Tracks two
-  states (in-string vs in-comment) with `\\` escape handling inside
-  strings. Not a full Clojure reader — character literals (`\\;`),
-  regex literals (`#\"...\"`), and `#_` reader-discards are not
-  modelled. Those edge cases don't matter for the conformance pins:
-  we strip conservatively (false-positive whitelisting would be the
-  bug; a missed string is OK because the marker still wouldn't appear
-  in a bare character literal or a regex pattern targeting it)."
-  [src]
-  (let [n  (count src)
-        sb (StringBuilder. n)]
+(def ^:private strip-comments-and-strings*
+  "Uncached implementation — exposed only so the public memoised
+  `strip-comments-and-strings` can delegate. State machine over raw
+  text; tracks in-string and in-comment with `\\` escape handling.
+  Not a full Clojure reader — character literals (`\\;`), regex
+  literals (`#\"...\"`), and `#_` reader-discards are not modelled.
+  Conservative-strip semantics make those edge cases harmless: a
+  missed string would only matter if a canonical marker appeared
+  inside it, and those cases don't occur in the repo source under
+  conformance."
+  (fn [src]
+    (let [n  (count src)
+          sb (StringBuilder. n)]
     (loop [i 0, in-string? false, in-comment? false]
       (if (>= i n)
         (.toString sb)
@@ -183,4 +194,13 @@
 
             :else
             (do (.append sb c)
-                (recur (inc i) false false))))))))
+                (recur (inc i) false false)))))))))
+
+(def strip-comments-and-strings
+  "Memoised wrapper over `strip-comments-and-strings*` (rf2-re2tv).
+  Every conformance test reaches for this on top of `read-source`
+  output; both caches together collapse the wire-vocab suite's
+  ~4356ms wall-clock by avoiding repeated state-machine walks of
+  the same source text. Keyed on the input string itself — pure
+  function of `src`, so identity-keyed equality is fine."
+  (memoize strip-comments-and-strings*))

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj
@@ -103,6 +103,32 @@
 ;; anti-pin all need the same documentation-vs-emission distinction.
 ;; ---------------------------------------------------------------------------
 
+;; ---------------------------------------------------------------------------
+;; Keyword-extender-aware variant regex (rf2-qnmne).
+;;
+;; Conformance tests grep server source for canonical literal keywords and
+;; near-miss variants. Raw `str/includes?` false-positives when a variant
+;; is a prefix of a longer legitimate keyword — e.g. `":dropped-sensitive"`
+;; is a substring of a future `":dropped-sensitive-warning"` extension.
+;; The regex pins the variant as a complete keyword token: matched only
+;; when not immediately followed by a keyword-extender character.
+;;
+;; Originally `defn-` in `slot_name_test.clj` (rf2-zvv65); promoted here
+;; so `indicator_field_test.clj`'s inline-emit anti-pin can use the same
+;; elegant pattern.
+;; ---------------------------------------------------------------------------
+
+(defn variant-regex
+  "Build a Java regex that matches `variant-str` only when it is NOT
+  immediately followed by a character that would extend it into a
+  longer keyword. `[\\w\\-?/!*+'<>=]` is the conservative set of
+  characters Clojure allows mid-keyword; matching one of those after
+  the variant means we're actually looking at a longer keyword that
+  happens to share a prefix with the variant — not the variant itself."
+  [variant-str]
+  (re-pattern (str (java.util.regex.Pattern/quote variant-str)
+                   "(?![\\w\\-?/!*+'<>=])")))
+
 (defn strip-comments-and-strings
   "Return `src` with Clojure line comments (`;` to EOL) and string
   literals (`\"...\"`, including docstrings) replaced by single

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
@@ -363,6 +363,12 @@
   ;; (`(assoc envelope :dropped-sensitive N)`) while letting prose
   ;; through. Same posture as the wire-vocab gate's source-text pin
   ;; (rf2-vj8y3).
+  ;;
+  ;; The substring grep uses `fx/variant-regex` (rf2-qnmne) rather than
+  ;; raw `str/includes?` so a future legitimate extension like
+  ;; `:dropped-sensitive-warning` or `:elided-large-summary` wouldn't
+  ;; false-positive-trip the gate on the prefix match. Same pattern
+  ;; as `slot_name_test.clj`'s near-miss-variant grep.
   (let [slot-literals [":dropped-sensitive" ":elided-large"]
         srcs          (pair2-mcp-source-files)]
     (is (seq srcs)
@@ -372,8 +378,9 @@
             :when (not (contains? inline-emit-whitelist rel))]
       (testing (str rel " — must not inline " slot)
         (let [src      (fx/read-source rel)
-              stripped (fx/strip-comments-and-strings src)]
-          (is (not (str/includes? stripped slot))
+              stripped (fx/strip-comments-and-strings src)
+              pat      (fx/variant-regex slot)]
+          (is (not (re-find pat stripped))
               (str "Inline `" slot "` literal found in " rel
                    " (in code, AFTER stripping comments/docstrings/strings).\n"
                    "Every emit MUST go through `wire/with-indicators` "

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
@@ -262,16 +262,10 @@
 ;; etc — anything that isn't a keyword-extender.
 ;; ---------------------------------------------------------------------------
 
-(defn- variant-regex
-  "Build a Java regex that matches `variant-str` only when it is NOT
-  immediately followed by a character that would extend it into a
-  longer keyword. `[\\w\\-?/!*+'<>=]` is the conservative set of
-  characters Clojure allows mid-keyword; matching one of those after
-  the variant means we're actually looking at a longer keyword that
-  happens to share a prefix with the variant — not the variant itself."
-  [variant-str]
-  (re-pattern (str (java.util.regex.Pattern/quote variant-str)
-                   "(?![\\w\\-?/!*+'<>=])")))
+;; `variant-regex` lives in `re-frame.mcp-conformance.fixtures`
+;; (rf2-qnmne) — promoted from a private defn here so
+;; `indicator_field_test.clj`'s inline-emit anti-pin can share the same
+;; keyword-extender-aware pattern.
 
 (defn- near-miss-variants
   "Generate near-miss spellings of a slot keyword. Conservative — we
@@ -378,7 +372,7 @@
             :when              (seq files)]
       (testing (str server " — " rel " — near-miss " variant " for " slot)
         (let [src    (fx/read-source rel)
-              pat    (variant-regex variant)]
+              pat    (fx/variant-regex variant)]
           (is (not (re-find pat src))
               (str "Found near-miss variant " variant " for slot " slot
                    " in " server "/" rel

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -4,7 +4,11 @@
   Three MCP servers ship under `tools/`: pair2-mcp, story-mcp, and
   causa-mcp (spec-only today). The first and the third share a
   reserved cross-server **wire vocabulary** — namespaced map keys an
-  agent recognises identically across every server:
+  agent recognises identically across every server.
+
+  Five top-level markers, plus the `:rf.elision/at` fetch-handle tag
+  (embedded inside the `:rf.size/large-elided` body's `:handle` slot —
+  not a standalone marker; pinned via the elision-marker body schema):
 
   - `:rf.mcp/overflow`      — token-budget overflow marker
                               (causa-mcp Principles mechanism 1,
@@ -23,8 +27,10 @@
   - `:rf.size/large-elided` — size-elision wire marker
                               (spec/Spec-Schemas §`:rf/elision-marker`,
                                pair2-mcp Principles §\"Size-elision\")
-  - `:rf.elision/at`        — size-elision fetch-handle tag
-                              (same)
+  - `:rf.elision/at`        — size-elision fetch-handle tag, embedded
+                              inside the `:rf.size/large-elided` body's
+                              `:handle` slot per `ElisionMarkerBody`
+                              (NOT a standalone top-level marker)
 
   story-mcp does NOT currently emit any of these markers — it operates
   on small, structured story/variant metadata and stays under the

--- a/tools/pair2-mcp/shadow-cljs.edn
+++ b/tools/pair2-mcp/shadow-cljs.edn
@@ -22,7 +22,22 @@
  :builds {:server      {:target :node-script
                         :output-to "out/server.js"
                         :main re-frame-pair2-mcp.server/main
-                        :compiler-options {:optimizations :simple}}
+                        ;; `:closure-defines` (rf2-nhp8w): the
+                        ;; production bundle elides
+                        ;; `re-frame.mcp-base.diff-encode/validate-patches?`.
+                        ;; The flag gates a Malli tree-walk validating
+                        ;; every diff-encoded epoch patch tuple at the
+                        ;; wire boundary — a dev/test safety net, not
+                        ;; the contract. Under `:simple` Closure folds
+                        ;; the literal-`false` `when` branch out, so
+                        ;; the shipped server pays the diff walk only,
+                        ;; not the validation walk on top.
+                        ;; `:server-test` below leaves the flag at its
+                        ;; default `true` so the dev gate still runs.
+                        :compiler-options
+                        {:optimizations  :simple
+                         :closure-defines
+                         {re-frame.mcp-base.diff-encode/validate-patches? false}}}
           :server-test {:target :node-test
                         :output-to "out/server-test.js"
                         :ns-regexp "-test$"


### PR DESCRIPTION
## Summary

Batched-by-surface PR landing seven follow-on beads against the shared MCP infrastructure: `tools/mcp-base/` (two beads) and `tools/mcp-conformance/` (five beads). All beads are isolated from in-flight agent work; each is one commit.

### Beads landed

**mcp-base (perf):**
- **rf2-0q30r** — fast-path `strip-sensitive` when no events drop. The docstring promised identical-vector return + zero-drop on the common path; the implementation now delivers it via a `some`-then-`filterv` split. Zero extra cost on the common branch, one extra linear walk on the rare drop branch.
- **rf2-nhp8w** — elide `validate-patches?` in pair2-mcp's release bundle. Pair2-mcp builds `:simple`, so the `goog-define`-elidable validation flag stayed `true` in the shipped server and every epoch diff paid a full Malli tree-walk. Added `:closure-defines {re-frame.mcp-base.diff-encode/validate-patches? false}` on the `:server` build; `:server-test` keeps the dev gate active.

**mcp-conformance (refactor + perf + doc):**
- **rf2-sems4** — extracted `runWithWatchdog` to `test/_runner.js`. Three test/*.js files repeated ~40 LoC each of watchdog + SDK-client teardown framing. Each shrinks to its workflow steps; a fourth Node-side test (causa-mcp impl) becomes ~30 LoC instead of ~110.
- **rf2-ikjrr** — dropped dead `"fixtures"` from `wire-vocab/deps.edn :test :extra-paths`. No `fixtures/` directory exists; all fixtures are inlined alongside their schemas.
- **rf2-qnmne** — promoted `variant-regex` (keyword-extender-aware negative-lookahead) from `slot_name_test.clj` into `fixtures.clj`. The inline-emit anti-pin in `indicator_field_test.clj` now uses it, so a future legitimate extension like `:dropped-sensitive-warning` won't false-positive on the substring grep.
- **rf2-7auf6** — clarified the README + ns docstring: five top-level wire markers plus `:rf.elision/at` as an embedded fetch-handle tag (pinned inside the `:rf.size/large-elided` body's `:handle` slot, not a sixth equal sibling).
- **rf2-re2tv** — memoised `read-source` + `strip-comments-and-strings`. Three test namespaces iterate `doseq` over the same source files dozens of times. The wire-vocab suite drops from ~3.3s to ~2.9s wall-clock (~10%; JVM boot dominates the remainder).

### LoC delta

+327 / -239 = +88 net. Net additions are mostly bead-cited explanatory comments inside the refactored helpers.

## Test plan

All gates GREEN locally:

- [x] `cd tools/mcp-base && clojure -M:test` — 89 tests / 223 assertions
- [x] `cd tools/mcp-conformance/wire-vocab && clojure -M:test` — 28 tests / 437 assertions (3.3s → 2.9s post-memoise)
- [x] `cd tools/pair2-mcp && npm test` — 347 tests / 834 assertions (validates rf2-nhp8w bundle-elision didn't break pair2-mcp)
- [x] `cd tools/mcp-conformance && node test/end-to-end-pair2.js` — PAIR2-MCP MCP-CLIENT CONFORMANCE GREEN (validates rf2-sems4 runner)
- [x] `cd tools/mcp-conformance && node test/end-to-end-story.js` — STORY-MCP MCP-CLIENT CONFORMANCE GREEN (validates rf2-sems4 runner)
- [x] `cd implementation && npm run test:bundle-isolation` — PASS (validates pair2-mcp release-bundle stays clean post rf2-nhp8w)
- [x] `cd implementation && npm run test:cljs` — 1917 tests / 5462 assertions