### PR TITLE
refactor(causa): reg-view-wrap panels for immediate reactive trace-buffer updates (rf2-in6l2)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/mount.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/mount.cljs
@@ -25,9 +25,27 @@
   The preload's `interop/debug-enabled?` gate (see preload.cljs) means
   mount never reaches production builds. This namespace therefore
   contains no production-elision logic of its own — the call-site
-  gate is sufficient."
-  (:require [re-frame.substrate.adapter :as substrate-adapter]
-            [day8.re-frame2-causa.shell :as shell]))
+  gate is sufficient.
+
+  ## Lazy `:rf/causa` frame registration (rf2-in6l2)
+
+  The Causa shell wraps every panel in `[rf/frame-provider {:frame
+  :rf/causa} …]` and every panel is `reg-view`-wrapped so subscribes
+  resolve through the React-context tier to the named frame. For that
+  routing to land in the *registered* `:rf/causa` frame (not chain-
+  resolve to `:rf/default`), the frame must exist — and the preload
+  can't register it because the preload runs before the host's
+  `rf/init!` has installed a substrate adapter, and `reg-frame` writes
+  trace events that need a running adapter to be reactive (per rf2-e9s81
+  the preload-time `reg-frame :rf/causa` path is the one that produced
+  the iw5ym regression). The first Ctrl+Shift+C keypress fires AFTER
+  `rf/init!`, so `open!` is the canonical place to call `reg-frame` —
+  the call is idempotent (surgical update on re-register) so subsequent
+  toggles are no-ops on this axis."
+  (:require [re-frame.core :as rf]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [day8.re-frame2-causa.shell :as shell]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
 ;; ---- mount state ---------------------------------------------------------
 
@@ -71,11 +89,47 @@
 
 ;; ---- public API ----------------------------------------------------------
 
+(defn- ensure-causa-frame!
+  "Register the `:rf/causa` frame if not already registered. Idempotent
+  via `reg-frame`'s surgical-update-on-re-register semantics (per Spec
+  002 §reg-frame). Called from `open!` on every keypress — first call
+  creates the frame, subsequent calls are surgical no-ops.
+
+  ## Why here, not at preload time
+
+  Per rf2-in6l2 the registration was attempted at preload time but
+  reverted (rf2-e9s81): the preload runs before the host's `rf/init!`
+  has installed a substrate adapter, and the `:on-create` listener
+  dispatch needs a running adapter to be reactive. The first
+  Ctrl+Shift+C keypress fires from the user well after `rf/init!`, so
+  `open!` is the canonical lazy-registration point.
+
+  ## App-db seeding
+
+  Seeds the freshly-created frame's app-db with the trace buffer's
+  current contents at `:trace-buffer` so the layer-1
+  `:rf.causa/trace-buffer` sub re-fires off the standard app-db-write
+  reactive path from this point on (rf2-in6l2). Subsequent
+  `trace-bus/collect-trace!` calls dispatch `:rf.causa/note-trace-event`
+  into `:rf/causa` so the sub fires IMMEDIATELY on every push — no
+  dependency on a host-side dispatch for the panel to refresh."
+  []
+  (rf/reg-frame :rf/causa {})
+  ;; Seed the frame's app-db with whatever the trace-bus atom has
+  ;; accumulated so far (the host may have driven dispatches before
+  ;; the user opened Causa).
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/sync-trace-buffer (trace-bus/buffer)])))
+
 (defn open!
-  "Mount + show the Causa shell. On first call: create the root <div>,
-  render the shell into it via the installed substrate adapter, mark
-  visible. On subsequent calls (when already mounted): make the
-  container visible.
+  "Mount + show the Causa shell. On first call: register the `:rf/causa`
+  frame, create the root <div>, render the shell into it via the
+  installed substrate adapter, mark visible. On subsequent calls (when
+  already mounted): make the container visible.
+
+  Per rf2-in6l2 the `:rf/causa` registration is lazy here (post-
+  `rf/init!`) rather than at preload time; see `ensure-causa-frame!`
+  for the rationale.
 
   Returns the mount-state map for tests / introspection."
   []
@@ -84,6 +138,7 @@
         (swap! mount-state assoc :visible? true)
         @mount-state)
     (when (substrate-adapter/current-adapter)
+      (ensure-causa-frame!)
       (let [node    (create-mount-node!)
             unmount (substrate-adapter/render [shell/shell-view] node nil)]
         (reset! mount-state

--- a/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot.cljs
@@ -81,7 +81,7 @@
   Clicking the cue toggles the rail open."
   [_cue-active?]
   [:button {:data-testid "rf-causa-copilot-cue"
-            :on-click    #(rf/dispatch [:rf.causa/copilot-toggle])
+            :on-click    #(rf/dispatch [:rf.causa/copilot-toggle] {:frame :rf/causa})
             :title       "Ask Causa (Ctrl+Shift+/)"
             :style       {:background  "transparent"
                           :border      "none"
@@ -110,7 +110,7 @@
             :on-click    #(rf/dispatch [:rf.causa/copilot-chip-clicked
                                         {:chip-key chip-key
                                          :value    value
-                                         :target   target}])
+                                         :target   target}] {:frame :rf/causa})
             :title       (str chip-key " " (pr-str value))
             :style       {:display       "inline-flex"
                           :align-items   "center"
@@ -281,12 +281,12 @@
                      (set-input! "")
                      (cond
                        (= :clear (:command parsed))
-                       (rf/dispatch [:rf.causa/copilot-clear-conversation])
+                       (rf/dispatch [:rf.causa/copilot-clear-conversation] {:frame :rf/causa})
 
                        :else
                        (rf/dispatch
                          [:rf.causa/copilot-submit-question
-                          {:text text :parsed parsed}])))))]
+                          {:text text :parsed parsed}] {:frame :rf/causa})))))]
     [:div {:style {:position "relative"
                    :padding "8px 12px"
                    :border-top (str "1px solid " (:border-subtle tokens))
@@ -351,7 +351,7 @@
                   :color (:text-secondary tokens)
                   :font-family mono-stack :font-size "12px"}}
     [:button {:data-testid "rf-causa-copilot-provider-picker"
-              :on-click    #(rf/dispatch [:rf.causa/copilot-cycle-provider])
+              :on-click    #(rf/dispatch [:rf.causa/copilot-cycle-provider] {:frame :rf/causa})
               :title       "Provider"
               :style       {:background "transparent"
                             :border "none"
@@ -360,7 +360,7 @@
                             :padding "2px 4px"}}
      "⌗"]
     [:button {:data-testid "rf-causa-copilot-close"
-              :on-click    #(rf/dispatch [:rf.causa/copilot-toggle])
+              :on-click    #(rf/dispatch [:rf.causa/copilot-toggle] {:frame :rf/causa})
               :title       "Close"
               :style       {:background "transparent"
                             :border "none"
@@ -371,10 +371,11 @@
 
 ;; ---- public views -------------------------------------------------------
 
-(defn ai-co-pilot-rail
+(rf/reg-view ai-co-pilot-rail
   "The rail-shaped view — title bar + scrollable conversation + input
   row. This is the open form (320px right-rail per spec §Panel
-  layout)."
+  layout). Per rf2-in6l2 `reg-view`-registered so the subscribe
+  routes through React context to `:rf/causa`."
   []
   (let [conversation (or @(rf/subscribe [:rf.causa/copilot-conversation]) [])]
     [:aside {:data-testid "rf-causa-copilot-rail"
@@ -392,7 +393,7 @@
       [conversation-view conversation]]
      [input-row]]))
 
-(defn ai-co-pilot-cue
+(rf/reg-view ai-co-pilot-cue
   "The collapsed form — a single `◇` cue glyph. Per spec §Default
   state the rail is collapsed by default; the glyph is the
   affordance for opening it.
@@ -400,12 +401,15 @@
   Rendered into the shell's right margin when
   `:rf.causa/copilot-open?` is false. The cue glyph + the sidebar
   `Co-pilot` row + the `Ctrl+Shift+/` keybinding all dispatch the
-  same `:rf.causa/copilot-toggle` event."
+  same `:rf.causa/copilot-toggle` event.
+
+  Per rf2-in6l2 `reg-view`-registered so the subscribe routes
+  through React context to `:rf/causa`."
   []
   (let [cue-active? (boolean @(rf/subscribe [:rf.causa/copilot-cue-active?]))]
     [cue-glyph cue-active?]))
 
-(defn ai-co-pilot-view
+(rf/reg-view ai-co-pilot-view
   "The panel-style view used when the sidebar's Co-pilot row is
   selected as the active canvas panel. Mirrors the rail view but
   drops the explicit width (the canvas owns its layout). This is the

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
@@ -187,7 +187,7 @@
                     :gap "6px"
                     :margin-bottom "6px"}}
       [:button {:data-testid (str "rf-causa-app-db-diff-pin-" (pr-str path))
-                :on-click    #(rf/dispatch [:rf.causa/pin-slice path])
+                :on-click    #(rf/dispatch [:rf.causa/pin-slice path] {:frame :rf/causa})
                 :style       {:background  "transparent"
                               :color       (:cyan tokens)
                               :border      (str "1px solid " (:border-default tokens))
@@ -198,7 +198,7 @@
                               :font-size   "10px"}}
        "Pin"]
       [:button {:data-testid (str "rf-causa-app-db-diff-show-when-" (pr-str path))
-                :on-click    #(rf/dispatch [:rf.causa/focus-slice-path path])
+                :on-click    #(rf/dispatch [:rf.causa/focus-slice-path path] {:frame :rf/causa})
                 :style       {:background  "transparent"
                               :color       (:magenta tokens)
                               :border      (str "1px solid " (:border-default tokens))
@@ -209,7 +209,7 @@
                               :font-size   "10px"}}
        "Show me when this changed"]
       [:button {:data-testid (str "rf-causa-app-db-diff-copy-path-" (pr-str path))
-                :on-click    #(rf/dispatch [:rf.causa/copy-path-to-clipboard path])
+                :on-click    #(rf/dispatch [:rf.causa/copy-path-to-clipboard path] {:frame :rf/causa})
                 :style       {:background  "transparent"
                               :color       (:text-secondary tokens)
                               :border      (str "1px solid " (:border-default tokens))
@@ -223,7 +223,7 @@
                 :on-click    #(rf/dispatch [:rf.causa/copy-value-to-clipboard
                                             (case op
                                               :removed before
-                                              after)])
+                                              after)] {:frame :rf/causa})
                 :style       {:background  "transparent"
                               :color       (:text-secondary tokens)
                               :border      (str "1px solid " (:border-default tokens))
@@ -305,7 +305,7 @@
     [:span {:style {:color (:text-tertiary tokens)}}
      (truncate (format-edn value) 36)]
     [:button {:data-testid (str "rf-causa-app-db-diff-unpin-" (pr-str path))
-              :on-click    #(rf/dispatch [:rf.causa/unpin-slice path])
+              :on-click    #(rf/dispatch [:rf.causa/unpin-slice path] {:frame :rf/causa})
               :style       {:background "transparent"
                             :border     "none"
                             :color      (:text-tertiary tokens)
@@ -347,7 +347,7 @@
   turn re-filters the causality graph + repaints this panel)."
   [{:keys [epoch-id event op before after] :as _hit}]
   [:li {:data-testid (str "rf-causa-app-db-diff-focus-hit-" (pr-str epoch-id))
-        :on-click    #(rf/dispatch [:rf.causa/select-epoch epoch-id])
+        :on-click    #(rf/dispatch [:rf.causa/select-epoch epoch-id] {:frame :rf/causa})
         :style       {:display "flex"
                       :align-items "center"
                       :gap "12px"
@@ -392,7 +392,7 @@
      [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
       (format-edn focused-path)]]
     [:button {:data-testid "rf-causa-app-db-diff-clear-focus"
-              :on-click    #(rf/dispatch [:rf.causa/clear-slice-focus])
+              :on-click    #(rf/dispatch [:rf.causa/clear-slice-focus] {:frame :rf/causa})
               :style       {:background "transparent"
                             :border (str "1px solid " (:border-default tokens))
                             :color (:text-secondary tokens)
@@ -440,7 +440,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(defn app-db-diff-view
+(rf/reg-view app-db-diff-view
   "The App-DB Diff panel's root view. Subscribes to
   `:rf.causa/app-db-diff` and renders the slice-centric stack +
   pinned slices + reserved-keys group, or the empty state when no

--- a/tools/causa/src/day8/re_frame2_causa/panels/causality_graph.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/causality_graph.cljs
@@ -109,7 +109,7 @@
         label (node-label node)
         glyph (h/node-glyph node selected?)]
     [:g {:data-testid (str "rf-causa-graph-node-" dispatch-id)
-         :on-click    #(rf/dispatch [:rf.causa/select-dispatch-id dispatch-id])
+         :on-click    #(rf/dispatch [:rf.causa/select-dispatch-id dispatch-id] {:frame :rf/causa})
          :style       {:cursor cursor}}
      [:rect {:x            x
              :y            y
@@ -253,7 +253,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(defn causality-graph-view
+(rf/reg-view causality-graph-view
   "The Causality Graph panel's root view. Subscribes to
   `:rf.causa/causality-graph-data` and renders either the empty
   state (no cascades) or the SVG canvas (one or more cascades)."
@@ -288,7 +288,7 @@
           [:code {:style {:color (:magenta tokens) :font-family mono-stack}}
            (str selected-epoch-id)]
           [:button {:data-testid "rf-causa-causality-graph-clear-filter"
-                    :on-click    #(rf/dispatch [:rf.causa/clear-selected-epoch])
+                    :on-click    #(rf/dispatch [:rf.causa/clear-selected-epoch] {:frame :rf/causa})
                     :style       {:margin-left "6px"
                                   :background "transparent"
                                   :border (str "1px solid " (:border-default tokens))

--- a/tools/causa/src/day8/re_frame2_causa/panels/effects.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/effects.cljs
@@ -143,7 +143,7 @@
     :as _row}
    selected?]
   [:li {:data-testid (str "rf-causa-fx-row-" (h/format-fx-id fx-id))
-        :on-click   #(rf/dispatch [:rf.causa/select-fx-id fx-id])
+        :on-click   #(rf/dispatch [:rf.causa/select-fx-id fx-id] {:frame :rf/causa})
         :style      {:display       "flex"
                      :align-items   "center"
                      :padding       "6px 12px"
@@ -264,7 +264,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(defn effects-view
+(rf/reg-view effects-view
   "The Effects panel's root view. Subscribes to
   `:rf.causa/effects-data` and renders the summary header + fx list
   (or the empty state when no fxs are registered)."

--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -261,7 +261,7 @@
   [{:keys [dispatch-id event] :as _cascade}]
   [:li {:key       dispatch-id
         :data-testid (str "rf-causa-cascade-row-" dispatch-id)
-        :on-click   #(rf/dispatch [:rf.causa/select-dispatch-id dispatch-id])
+        :on-click   #(rf/dispatch [:rf.causa/select-dispatch-id dispatch-id] {:frame :rf/causa})
         :style      {:padding      "8px 12px"
                      :border-bottom (str "1px solid " (:border-subtle tokens))
                      :cursor       "pointer"
@@ -320,7 +320,7 @@
                   :color       (:text-tertiary tokens)}}
     [:span "Cascade"]
     [:button {:data-testid "rf-causa-event-detail-clear"
-              :on-click    #(rf/dispatch [:rf.causa/clear-selected-dispatch-id])
+              :on-click    #(rf/dispatch [:rf.causa/clear-selected-dispatch-id] {:frame :rf/causa})
               :style       {:background  "transparent"
                             :border      (str "1px solid " (:border-default tokens))
                             :color       (:text-secondary tokens)
@@ -341,7 +341,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(defn event-detail-view
+(rf/reg-view event-detail-view
   "The hero panel's root view. Subscribes to
   `:rf.causa/event-detail` and renders either the cascade-detail
   layout (when a dispatch-id is selected) or the cascade-list empty
@@ -384,7 +384,7 @@
          [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
           (str selected-dispatch-id)]
          " is no longer in the trace buffer. "
-         [:button {:on-click #(rf/dispatch [:rf.causa/clear-selected-dispatch-id])
+         [:button {:on-click #(rf/dispatch [:rf.causa/clear-selected-dispatch-id] {:frame :rf/causa})
                    :style    {:margin-left "8px"
                               :background  "transparent"
                               :border      (str "1px solid " (:border-default tokens))

--- a/tools/causa/src/day8/re_frame2_causa/panels/flows.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/flows.cljs
@@ -114,7 +114,7 @@
     :as _row}
    selected?]
   [:li {:data-testid (str "rf-causa-flow-row-" (h/format-flow-id flow-id))
-        :on-click   #(rf/dispatch [:rf.causa/select-flow-id flow-id])
+        :on-click   #(rf/dispatch [:rf.causa/select-flow-id flow-id] {:frame :rf/causa})
         :style      {:display       "flex"
                      :align-items   "center"
                      :padding       "6px 12px"
@@ -244,7 +244,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(defn flows-view
+(rf/reg-view flows-view
   "The Flows panel's root view. Subscribes to
   `:rf.causa/flows-data` and renders the summary header + flow
   list (or the empty state when no flows are registered)."

--- a/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger.cljs
@@ -135,7 +135,7 @@
   [{:keys [id path summary view-id] :as _entry} selected?]
   [:li {:key       id
         :data-testid (str "rf-causa-hydration-mismatch-row-" (str id))
-        :on-click  #(rf/dispatch [:rf.causa/select-mismatch id])
+        :on-click  #(rf/dispatch [:rf.causa/select-mismatch id] {:frame :rf/causa})
         :style     {:padding      "6px 12px"
                     :border-bottom (str "1px solid " (:border-subtle tokens))
                     :background   (if selected? (:bg-active tokens) "transparent")
@@ -187,7 +187,7 @@
   [{:keys [path hash]} divergent?]
   [:span {:data-testid (str "rf-causa-hydration-hash-chip-"
                             (str/join "-" path))
-          :on-click    #(rf/dispatch [:rf.causa/reroot-tree-view path])
+          :on-click    #(rf/dispatch [:rf.causa/reroot-tree-view path] {:frame :rf/causa})
           :style       {:display       "inline-block"
                         :padding       "1px 6px"
                         :margin-left   "6px"
@@ -302,7 +302,7 @@
          [:span {:style {:margin-left "12px"}}
           "Registered at: "
           [:code {:on-click   (fn [_]
-                                (rf/dispatch [:rf.causa/open-in-editor coord]))
+                                (rf/dispatch [:rf.causa/open-in-editor coord] {:frame :rf/causa}))
                   :style      {:color       (:cyan tokens)
                                :font-family mono-stack
                                :cursor      "pointer"
@@ -357,7 +357,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(defn hydration-debugger-view
+(rf/reg-view hydration-debugger-view
   "The Hydration Debugger panel's root view. Subscribes to
   `:rf.causa/hydration-debugger-data` and renders either:
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
@@ -105,7 +105,7 @@
                  :test-id  (str "rf-causa-issues-severity-chip-"
                                 (name severity))
                  :on-click #(rf/dispatch [:rf.causa/toggle-issues-severity
-                                          severity])}))))
+                                          severity] {:frame :rf/causa})}))))
 
 (defn- prefix-chips
   "Filter chip row for the distinct category prefixes present in the
@@ -123,7 +123,7 @@
                    :colour   (:accent-violet tokens)
                    :test-id  (str "rf-causa-issues-prefix-chip-" prefix)
                    :on-click #(rf/dispatch [:rf.causa/toggle-issues-prefix
-                                            prefix])})))))
+                                            prefix] {:frame :rf/causa})})))))
 
 (defn- since-input
   "The `since-ms` filter — a numeric input rendered as a chip-row
@@ -149,7 +149,7 @@
                                    (let [parsed (js/parseInt v 10)]
                                      (when-not (js/isNaN parsed) parsed))
                                    (catch :default _ nil))]
-                           (rf/dispatch [:rf.causa/set-issues-since-seconds n])))
+                           (rf/dispatch [:rf.causa/set-issues-since-seconds n] {:frame :rf/causa})))
             :style     {:width "60px"
                         :background (:bg-3 tokens)
                         :color (:text-primary tokens)
@@ -183,7 +183,7 @@
      (str rendered " / " total " in view")]
     (when any-filter?
       [:button {:data-testid "rf-causa-issues-clear-filters"
-                :on-click    #(rf/dispatch [:rf.causa/clear-issues-filters])
+                :on-click    #(rf/dispatch [:rf.causa/clear-issues-filters] {:frame :rf/causa})
                 :style       {:margin-left "auto"
                               :background  "transparent"
                               :color       (:cyan tokens)
@@ -214,8 +214,8 @@
           :data-testid row-test-id
           :on-click    (fn []
                          (when dispatch-id
-                           (rf/dispatch [:rf.causa/select-dispatch-id dispatch-id])
-                           (rf/dispatch [:rf.causa/select-panel :event-detail])))
+                           (rf/dispatch [:rf.causa/select-dispatch-id dispatch-id] {:frame :rf/causa})
+                           (rf/dispatch [:rf.causa/select-panel :event-detail] {:frame :rf/causa})))
           :style       {:display       "grid"
                         :grid-template-columns "84px 18px minmax(120px, 1fr) 2fr auto"
                         :gap           "10px"
@@ -266,7 +266,7 @@
                                 ;; affordance per the bead's contract.
                                 (.stopPropagation e)
                                 (rf/dispatch [:rf.causa/open-in-editor
-                                              {:source-coord source-coord}]))
+                                              {:source-coord source-coord}] {:frame :rf/causa}))
                  :style       {:background  "transparent"
                                :color       (:cyan tokens)
                                :border      (str "1px solid " (:border-subtle tokens))
@@ -325,7 +325,7 @@
                 :color (:text-tertiary tokens)}}
     "Adjust the severity / prefix / since-ms chips above to widen the feed."]
    [:button {:data-testid "rf-causa-issues-empty-clear-filters"
-             :on-click    #(rf/dispatch [:rf.causa/clear-issues-filters])
+             :on-click    #(rf/dispatch [:rf.causa/clear-issues-filters] {:frame :rf/causa})
              :style       {:background "transparent"
                            :color      (:cyan tokens)
                            :border     (str "1px solid " (:border-default tokens))
@@ -338,7 +338,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(defn issues-ribbon-view
+(rf/reg-view issues-ribbon-view
   "The Issues ribbon panel's root view. Subscribes to
   `:rf.causa/issues-ribbon` and renders the empty-state or the feed."
   []

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -104,7 +104,7 @@
                             (let [v   (-> e .-target .-value)
                                   row (some #(when (= v (str (:machine-id %))) %) rows)]
                               (when-let [id (:machine-id row)]
-                                (rf/dispatch [:rf.causa/select-machine-id id]))))
+                                (rf/dispatch [:rf.causa/select-machine-id id] {:frame :rf/causa}))))
              :style       {:flex 1
                            :background (:bg-3 tokens)
                            :border (str "1px solid " (:border-default tokens))
@@ -235,7 +235,7 @@
   [{:keys [id from to event dispatch-id microstep?]}]
   [:li {:data-testid (str "rf-causa-machine-inspector-transition-" id)
         :on-click    (when dispatch-id
-                       #(rf/dispatch [:rf.causa/select-dispatch-id dispatch-id]))
+                       #(rf/dispatch [:rf.causa/select-dispatch-id dispatch-id] {:frame :rf/causa}))
         :title       (h/format-event event)
         :style       {:display "inline-flex"
                       :align-items "center"
@@ -341,7 +341,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(defn machine-inspector-view
+(rf/reg-view machine-inspector-view
   "The Machine Inspector panel's root view. Subscribes to
   `:rf.causa/machine-inspector-data` and renders either the empty
   state (no machines registered) or the picker + chart placeholder +

--- a/tools/causa/src/day8/re_frame2_causa/panels/mcp_server.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/mcp_server.cljs
@@ -132,7 +132,7 @@
                    :colour   (:causa-mcp-cyan tokens)
                    :test-id  (str "rf-causa-mcp-op-type-chip-" (name op-type))
                    :on-click #(rf/dispatch [:rf.causa/toggle-mcp-op-type
-                                            op-type])})))))
+                                            op-type] {:frame :rf/causa})})))))
 
 (defn- since-input
   "The `since-ms` filter — a numeric input rendered as a chip-row
@@ -159,7 +159,7 @@
                                    (let [parsed (js/parseInt v 10)]
                                      (when-not (js/isNaN parsed) parsed))
                                    (catch :default _ nil))]
-                           (rf/dispatch [:rf.causa/set-mcp-since-seconds n])))
+                           (rf/dispatch [:rf.causa/set-mcp-since-seconds n] {:frame :rf/causa})))
             :style     {:width "60px"
                         :background (:bg-3 tokens)
                         :color (:text-primary tokens)
@@ -213,7 +213,7 @@
                     :color (:text-secondary tokens)}}
     [:input {:type      "checkbox"
              :checked   (boolean origin-filter-enabled?)
-             :on-change #(rf/dispatch [:rf.causa/toggle-mcp-origin-filter])
+             :on-change #(rf/dispatch [:rf.causa/toggle-mcp-origin-filter] {:frame :rf/causa})
              :style     {:cursor "pointer"}}]
     [:span "Highlight :causa-mcp events across panels"]]])
 
@@ -256,7 +256,7 @@
      (str rendered " / " total " in view")]
     (when any-filter?
       [:button {:data-testid "rf-causa-mcp-clear-filters"
-                :on-click    #(rf/dispatch [:rf.causa/clear-mcp-filters])
+                :on-click    #(rf/dispatch [:rf.causa/clear-mcp-filters] {:frame :rf/causa})
                 :style       {:margin-left "auto"
                               :background  "transparent"
                               :color       (:cyan tokens)
@@ -285,8 +285,8 @@
           :data-testid row-test-id
           :on-click    (fn []
                          (when dispatch-id
-                           (rf/dispatch [:rf.causa/select-dispatch-id dispatch-id])
-                           (rf/dispatch [:rf.causa/select-panel :event-detail])))
+                           (rf/dispatch [:rf.causa/select-dispatch-id dispatch-id] {:frame :rf/causa})
+                           (rf/dispatch [:rf.causa/select-panel :event-detail] {:frame :rf/causa})))
           :style       {:display       "grid"
                         :grid-template-columns "84px 90px minmax(120px, 1fr) auto 2fr auto"
                         :gap           "10px"
@@ -348,7 +348,7 @@
                                 ;; handler doesn't also fire.
                                 (.stopPropagation e)
                                 (rf/dispatch [:rf.causa/open-in-editor
-                                              {:source-coord source-coord}]))
+                                              {:source-coord source-coord}] {:frame :rf/causa}))
                  :style       {:background  "transparent"
                                :color       (:cyan tokens)
                                :border      (str "1px solid " (:border-subtle tokens))
@@ -415,7 +415,7 @@
    [:p {:style {:margin "0 0 12px 0" :color (:text-tertiary tokens)}}
     "Adjust the op-type / since-ms chips above to widen the feed."]
    [:button {:data-testid "rf-causa-mcp-empty-clear-filters"
-             :on-click    #(rf/dispatch [:rf.causa/clear-mcp-filters])
+             :on-click    #(rf/dispatch [:rf.causa/clear-mcp-filters] {:frame :rf/causa})
              :style       {:background "transparent"
                            :color      (:cyan tokens)
                            :border     (str "1px solid " (:border-default tokens))
@@ -428,7 +428,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(defn mcp-server-view
+(rf/reg-view mcp-server-view
   "The MCP Server panel's root view. Subscribes to
   `:rf.causa/mcp-server` (composite) + `:rf.causa/mcp-origin-filter-
   enabled?` (settings sub-pane state)."

--- a/tools/causa/src/day8/re_frame2_causa/panels/performance.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/performance.cljs
@@ -164,8 +164,8 @@
           :data-tier   (name tier)
           :data-over-budget (str (boolean over-budget?))
           :on-click    (fn []
-                         (rf/dispatch [:rf.causa/select-dispatch-id dispatch-id])
-                         (rf/dispatch [:rf.causa/select-panel :event-detail]))
+                         (rf/dispatch [:rf.causa/select-dispatch-id dispatch-id] {:frame :rf/causa})
+                         (rf/dispatch [:rf.causa/select-panel :event-detail] {:frame :rf/causa}))
           :style       {:display       "grid"
                         :grid-template-columns "18px 60px minmax(140px, 1fr) 70px 110px 1.2fr 70px"
                         :gap           "10px"
@@ -251,7 +251,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(defn performance-view
+(rf/reg-view performance-view
   "The Performance panel's root view. Subscribes to
   `:rf.causa/performance-data` and renders the empty-state or the
   feed."

--- a/tools/causa/src/day8/re_frame2_causa/panels/routes.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routes.cljs
@@ -170,7 +170,7 @@
   highlight + the `active` marker."
   [{:keys [route-id path doc] :as _row} selected? active?]
   [:li {:data-testid (str "rf-causa-route-row-" (h/format-route-id route-id))
-        :on-click   #(rf/dispatch [:rf.causa/select-route route-id])
+        :on-click   #(rf/dispatch [:rf.causa/select-route route-id] {:frame :rf/causa})
         :style      {:display       "flex"
                      :align-items   "center"
                      :padding       "6px 16px"
@@ -250,8 +250,8 @@
     [:li {:data-testid row-test-id
           :on-click    (fn []
                          (when dispatch-id
-                           (rf/dispatch [:rf.causa/select-dispatch-id dispatch-id])
-                           (rf/dispatch [:rf.causa/select-panel :event-detail])))
+                           (rf/dispatch [:rf.causa/select-dispatch-id dispatch-id] {:frame :rf/causa})
+                           (rf/dispatch [:rf.causa/select-panel :event-detail] {:frame :rf/causa})))
           :style       {:display       "grid"
                         :grid-template-columns "84px minmax(160px, 1fr) minmax(120px, 1fr) auto"
                         :gap           "10px"
@@ -367,7 +367,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(defn routes-view
+(rf/reg-view routes-view
   "The Routes panel's root view. Subscribes to `:rf.causa/routes-data`
   and renders the active-route breadcrumb + registered-routes list +
   navigation-history feed (or the empty state when no routes are

--- a/tools/causa/src/day8/re_frame2_causa/panels/schema_violation_timeline.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/schema_violation_timeline.cljs
@@ -151,7 +151,7 @@
                   :color (:text-primary tokens)}}
      "schema violation"]
     [:button {:data-testid "rf-causa-schema-violation-detail-close"
-              :on-click    #(rf/dispatch [:rf.causa/clear-violation-selection])
+              :on-click    #(rf/dispatch [:rf.causa/clear-violation-selection] {:frame :rf/causa})
               :style       {:background "transparent"
                             :border     "none"
                             :color      (:text-tertiary tokens)
@@ -197,8 +197,8 @@
    (when dispatch-id
      [:button {:data-testid "rf-causa-schema-violation-detail-open-in-graph"
                :on-click    (fn []
-                              (rf/dispatch [:rf.causa/select-dispatch-id dispatch-id])
-                              (rf/dispatch [:rf.causa/select-panel :causality]))
+                              (rf/dispatch [:rf.causa/select-dispatch-id dispatch-id] {:frame :rf/causa})
+                              (rf/dispatch [:rf.causa/select-panel :causality] {:frame :rf/causa}))
                :style       {:background  "transparent"
                              :color       (:cyan tokens)
                              :border      (str "1px solid " (:border-default tokens))
@@ -217,7 +217,7 @@
                   :letter-spacing "0.6px"}}
     "Filter"]
    [:button {:data-testid "rf-causa-schema-violation-detail-filter-row"
-             :on-click    #(rf/dispatch [:rf.causa/set-schema-filter schema-id])
+             :on-click    #(rf/dispatch [:rf.causa/set-schema-filter schema-id] {:frame :rf/causa})
              :style       {:background  "transparent"
                            :color       (:cyan tokens)
                            :border      (str "1px solid " (:border-default tokens))
@@ -283,7 +283,7 @@
                                    fill)
                     :stroke-width stroke-width
                     :style       {:cursor "pointer"}
-                    :on-click    #(rf/dispatch [:rf.causa/select-violation id])}
+                    :on-click    #(rf/dispatch [:rf.causa/select-violation id] {:frame :rf/causa})}
            [:title (h/format-tooltip v)]]))]]))
 
 ;; ---- header strip -------------------------------------------------------
@@ -320,7 +320,7 @@
                       :font-size   "11px"}}
        (h/schema-row-label schema-filter)]
       [:button {:data-testid "rf-causa-schema-timeline-clear-filter"
-                :on-click    #(rf/dispatch [:rf.causa/set-schema-filter nil])
+                :on-click    #(rf/dispatch [:rf.causa/set-schema-filter nil] {:frame :rf/causa})
                 :style       {:background "transparent"
                               :color      (:cyan tokens)
                               :border     (str "1px solid " (:border-default tokens))
@@ -333,7 +333,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(defn schema-violation-timeline-view
+(rf/reg-view schema-violation-timeline-view
   "The Schema-violation Timeline panel's root view. Subscribes to
   `:rf.causa/schema-violation-timeline` and renders the empty-state
   or the per-schema track stack."

--- a/tools/causa/src/day8/re_frame2_causa/panels/subscriptions.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/subscriptions.cljs
@@ -94,7 +94,7 @@
         glyph   (get h/status->glyph status)
         tooltip (get h/status->tooltip status)]
     [:button {:data-testid (str "rf-causa-sub-filter-" (name status))
-              :on-click    #(rf/dispatch [:rf.causa/toggle-sub-filter status])
+              :on-click    #(rf/dispatch [:rf.causa/toggle-sub-filter status] {:frame :rf/causa})
               :title       tooltip
               :style       {:display        "inline-flex"
                             :align-items    "center"
@@ -176,7 +176,7 @@
    selected?]
   [:li {:data-testid (str "rf-causa-sub-row-"
                           (h/format-sub-id sub-id))
-        :on-click   #(rf/dispatch [:rf.causa/select-sub query-v])
+        :on-click   #(rf/dispatch [:rf.causa/select-sub query-v] {:frame :rf/causa})
         :style      {:display       "flex"
                      :align-items   "center"
                      :padding       "6px 12px"
@@ -212,8 +212,8 @@
                                (h/format-sub-id sub-id))
              :on-click (fn [e]
                          (.stopPropagation e)
-                         (rf/dispatch [:rf.causa/select-sub query-v])
-                         (rf/dispatch [:rf.causa/show-invalidation-chain query-v]))
+                         (rf/dispatch [:rf.causa/select-sub query-v] {:frame :rf/causa})
+                         (rf/dispatch [:rf.causa/show-invalidation-chain query-v] {:frame :rf/causa}))
              :title    "Show invalidation chain"
              :style    {:margin-left "8px"
                         :background "transparent"
@@ -306,7 +306,7 @@
                     :color       (:text-primary tokens)}}
      "Invalidation chain"]
     [:button {:data-testid "rf-causa-subscriptions-chain-close"
-              :on-click    #(rf/dispatch [:rf.causa/hide-invalidation-chain])
+              :on-click    #(rf/dispatch [:rf.causa/hide-invalidation-chain] {:frame :rf/causa})
               :style       {:background "transparent"
                             :border (str "1px solid " (:border-default tokens))
                             :color (:text-secondary tokens)
@@ -404,7 +404,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(defn subscriptions-view
+(rf/reg-view subscriptions-view
   "The Subscriptions panel's root view. Subscribes to
   `:rf.causa/subscriptions-data` and renders the filter chips +
   sub list + (when a sub is selected and the chain is open) the

--- a/tools/causa/src/day8/re_frame2_causa/panels/time_travel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/time_travel.cljs
@@ -113,10 +113,10 @@
                                     (:accent-violet tokens)
                                     (:text-tertiary tokens))
                         :cursor   "pointer"}
-             :on-click #(rf/dispatch [:rf.causa/select-epoch epoch-id])}
+             :on-click #(rf/dispatch [:rf.causa/select-epoch epoch-id] {:frame :rf/causa})}
       (str (if attached "●" "○") " " label)]
      [:button {:data-testid (str "rf-causa-pin-reset-" (str epoch-id))
-               :on-click    #(rf/dispatch [:rf.causa/reset-to-pinned epoch-id])
+               :on-click    #(rf/dispatch [:rf.causa/reset-to-pinned epoch-id] {:frame :rf/causa})
                :style       {:background    "transparent"
                              :border        "none"
                              :color         (:cyan tokens)
@@ -127,7 +127,7 @@
                :title       "Reset frame-db to this pin"}
       "↺"]
      [:button {:data-testid (str "rf-causa-pin-remove-" (str epoch-id))
-               :on-click    #(rf/dispatch [:rf.causa/unpin epoch-id])
+               :on-click    #(rf/dispatch [:rf.causa/unpin epoch-id] {:frame :rf/causa})
                :style       {:background    "transparent"
                              :border        "none"
                              :color         (:text-tertiary tokens)
@@ -167,7 +167,7 @@
         cur-idx  (or selected-index max-idx)
         on-step  (fn [delta]
                    (when-let [new-id (h/step-epoch history selected-epoch-id delta)]
-                     (rf/dispatch [:rf.causa/select-epoch new-id])))]
+                     (rf/dispatch [:rf.causa/select-epoch new-id] {:frame :rf/causa})))]
     [:div {:data-testid "rf-causa-time-travel-track"
            :style       {:padding "12px"
                          :display "flex"
@@ -178,7 +178,7 @@
                :on-click    #(when (seq history)
                                (rf/dispatch
                                  [:rf.causa/select-epoch
-                                  (:epoch-id (first history))]))
+                                  (:epoch-id (first history))] {:frame :rf/causa}))
                :title       "Jump to oldest"
                :style       {:background  "transparent"
                              :border      (str "1px solid " (:border-default tokens))
@@ -198,7 +198,7 @@
               :on-change   (fn [e]
                              (let [idx (js/parseInt (.. e -target -value))]
                                (when-let [eid (h/epoch-id-at-index history idx)]
-                                 (rf/dispatch [:rf.causa/select-epoch eid]))))
+                                 (rf/dispatch [:rf.causa/select-epoch eid] {:frame :rf/causa}))))
               :on-key-down (fn [e]
                              (case (.-key e)
                                "[" (do (.preventDefault e) (on-step -1))
@@ -210,7 +210,7 @@
                :on-click    #(when (seq history)
                                (rf/dispatch
                                  [:rf.causa/select-epoch
-                                  (:epoch-id (peek (vec history)))]))
+                                  (:epoch-id (peek (vec history)))] {:frame :rf/causa}))
                :title       "Jump to newest"
                :style       {:background  "transparent"
                              :border      (str "1px solid " (:border-default tokens))
@@ -262,7 +262,7 @@
                :on-click    #(when target-eid
                                (rf/dispatch
                                  [:rf.causa/pin-current target-eid
-                                  (read-label-input)])
+                                  (read-label-input)] {:frame :rf/causa})
                                (set-label-input! ""))
                :style       {:background  (if cap-reached?
                                             (:bg-3 tokens)
@@ -280,7 +280,7 @@
       "Pin"]
      [:button {:data-testid "rf-causa-reset-to-epoch"
                :disabled    (or history-empty? (nil? target-eid))
-               :on-click    #(rf/dispatch [:rf.causa/reset-to-epoch target-eid])
+               :on-click    #(rf/dispatch [:rf.causa/reset-to-epoch target-eid] {:frame :rf/causa})
                :style       {:background  "transparent"
                              :color       (:text-secondary tokens)
                              :border      (str "1px solid " (:border-default tokens))
@@ -299,7 +299,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(defn time-travel-view
+(rf/reg-view time-travel-view
   "The Time Travel panel's root view. Subscribes to
   `:rf.causa/time-travel` and renders the empty-state / track + chips
   / actions stack."

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -160,7 +160,7 @@
                    :on-click #(rf/dispatch
                                 [:rf.causa/set-trace-filter
                                  axis
-                                 (when-not active? value)])})))))
+                                 (when-not active? value)] {:frame :rf/causa})})))))
 
 ;; ---- header strip -------------------------------------------------------
 
@@ -184,7 +184,7 @@
      (str rendered " / " total " in view")]
     (when any-filter?
       [:button {:data-testid "rf-causa-trace-clear-filters"
-                :on-click    #(rf/dispatch [:rf.causa/clear-trace-filters])
+                :on-click    #(rf/dispatch [:rf.causa/clear-trace-filters] {:frame :rf/causa})
                 :style       {:margin-left "auto"
                               :background  "transparent"
                               :color       (:cyan tokens)
@@ -216,7 +216,7 @@
               :on-click    (fn [e]
                              (.stopPropagation e)
                              (rf/dispatch [:rf.causa/set-trace-filter
-                                           axis value]))
+                                           axis value] {:frame :rf/causa}))
               :title       (str "filter " (name axis) " = "
                                 (format-axis-value value))
               :style       {:background    "transparent"
@@ -243,9 +243,9 @@
           :on-click    (fn []
                          (when dispatch-id
                            (rf/dispatch [:rf.causa/select-dispatch-id
-                                         dispatch-id])
+                                         dispatch-id] {:frame :rf/causa})
                            (rf/dispatch [:rf.causa/select-panel
-                                         :event-detail])))
+                                         :event-detail] {:frame :rf/causa})))
           :style       {:display       "grid"
                         :grid-template-columns
                         "84px 14px minmax(140px, 1fr) 2fr auto auto"
@@ -308,7 +308,7 @@
                  :on-click    (fn [e]
                                 (.stopPropagation e)
                                 (rf/dispatch [:rf.causa/open-in-editor
-                                              {:source-coord source-coord}]))
+                                              {:source-coord source-coord}] {:frame :rf/causa}))
                  :style       {:background  "transparent"
                                :color       (:cyan tokens)
                                :border      (str "1px solid " (:border-subtle tokens))
@@ -357,7 +357,7 @@
                 :color (:text-tertiary tokens)}}
     "Adjust the chip rows above — clearing any one axis widens the ribbon."]
    [:button {:data-testid "rf-causa-trace-empty-clear-filters"
-             :on-click    #(rf/dispatch [:rf.causa/clear-trace-filters])
+             :on-click    #(rf/dispatch [:rf.causa/clear-trace-filters] {:frame :rf/causa})
              :style       {:background "transparent"
                            :color      (:cyan tokens)
                            :border     (str "1px solid " (:border-default tokens))
@@ -370,7 +370,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(defn trace-view
+(rf/reg-view trace-view
   "The Trace panel's root view. Subscribes to `:rf.causa/trace-feed`
   and renders either the chip-filterable ribbon or the empty-state."
   []

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -80,20 +80,24 @@
     ;; ---- cross-panel primitives ---------------------------------
 
     ;; Causa's trace-buffer sub returns the Causa-side ring buffer
-    ;; contents (NOT the framework's `(rf/trace-buffer)`). Reading
-    ;; directly from `trace-bus/buffer` is the right shape here
-    ;; because the buffer is process-global, not per-frame — every
-    ;; Causa shell mounted across any frame should see the same
-    ;; trace stream. The sub thunks the pure-data accessor so
-    ;; reactive contexts get a fresh read on every recompute;
-    ;; layer-1 re-fires on the host's next dispatch and picks up
-    ;; whatever the trace-cb has accumulated. See `trace_bus.cljc`
-    ;; §Reactivity for the trade-off and the refactor path that
-    ;; would re-introduce immediate-update reactivity without the
-    ;; layering hazard.
+    ;; contents (NOT the framework's `(rf/trace-buffer)`). Per rf2-in6l2
+    ;; the slot lives in Causa's app-db at `:trace-buffer`; the trace
+    ;; collector dispatches `:rf.causa/note-trace-event` into `:rf/causa`
+    ;; on every push so the sub re-fires on the standard app-db-write
+    ;; reactive path — panels re-render IMMEDIATELY on every trace
+    ;; event with no dependency on the host's next dispatch (the prior
+    ;; rf2-e9s81 shape thunked `trace-bus/buffer` directly so visible
+    ;; delay was bounded by the host's next dispatch).
+    ;;
+    ;; The pre-mount fallback `(trace-bus/buffer)` keeps the sub useful
+    ;; if a consumer reaches in before `mount.cljs/open!` has registered
+    ;; the `:rf/causa` frame + seeded the slot (e.g. headless tests
+    ;; that drive `collect-trace!` without opening the shell). In a
+    ;; live session the seed lands at first Ctrl+Shift+C and the
+    ;; app-db slot is the authoritative reactive source from there on.
     (rf/reg-sub :rf.causa/trace-buffer
-      (fn [_db _query]
-        (trace-bus/buffer)))
+      (fn [db _query]
+        (or (get db :trace-buffer) (trace-bus/buffer))))
 
     ;; Total count of :sensitive? trace events the collector has
     ;; suppressed under the current `:trace/show-sensitive?` setting
@@ -137,6 +141,56 @@
     (rf/reg-event-db :rf.causa/select-panel
       (fn [db [_ panel-id]]
         (assoc db :selected-panel panel-id)))
+
+    ;; ---- trace-buffer mirror events (rf2-in6l2) -------------------
+    ;;
+    ;; `collect-trace!` dispatches `:rf.causa/note-trace-event` into
+    ;; `:rf/causa` on every push so the layer-1 `:rf.causa/trace-buffer`
+    ;; sub fires on the standard app-db-write reactive path. The event
+    ;; mirrors `trace-bus/push`'s capped-vector eviction algebra so the
+    ;; app-db slot stays bounded by the same depth contract as the
+    ;; trace-bus atom — single source of truth on the cap, dual write
+    ;; for the reactive surface.
+    ;;
+    ;; The mirror is *additive*: `trace-bus/buffer-state` remains as
+    ;; the JVM-runnable data primitive (push algebra, sensitive-trace
+    ;; tests, filter-vocab consumer tests) and as the seed source when
+    ;; `mount.cljs/open!` first registers `:rf/causa`. The CLJS path
+    ;; dual-writes atom + dispatch.
+    ;;
+    ;; Per rf2-qsjda + the matching `:rf.causa/note-sensitive-
+    ;; suppressed` pattern: `:rf.trace/no-emit? true` opts the handler
+    ;; out of framework trace emission. Without it the dispatch would
+    ;; emit `:event/dispatched` etc. back through the trace-cb fan-out,
+    ;; the collector would see its own self-emit, and the cascade would
+    ;; loop until `drain-depth-default` terminated it.
+    (rf/reg-event-db :rf.causa/note-trace-event
+      {:rf.trace/no-emit? true}
+      (fn [db [_ event]]
+        (let [buf   (get db :trace-buffer [])
+              depth (trace-bus/current-depth)]
+          (assoc db :trace-buffer (trace-bus/push buf depth event)))))
+
+    ;; Clear the mirrored slot in lockstep with the trace-bus atom
+    ;; (dispatched from `trace-bus/clear-buffer!` in CLJS). Per
+    ;; rf2-qsjda the `:rf.trace/no-emit?` flag applies for the same
+    ;; loop-avoidance reason as `:rf.causa/note-trace-event`.
+    (rf/reg-event-db :rf.causa/clear-trace-buffer
+      {:rf.trace/no-emit? true}
+      (fn [db _event]
+        (dissoc db :trace-buffer)))
+
+    ;; Wholesale overwrite of the mirrored slot. Dispatched from
+    ;; `mount.cljs/open!` on first Ctrl+Shift+C to seed `:rf/causa`'s
+    ;; app-db with whatever the trace-bus atom has accumulated before
+    ;; the shell was opened, and from `trace-bus/set-buffer-depth!`
+    ;; when the depth shrinks so the mirror reflects the post-shrink
+    ;; contents. Per rf2-qsjda `:rf.trace/no-emit? true` for the same
+    ;; loop-avoidance reason.
+    (rf/reg-event-db :rf.causa/sync-trace-buffer
+      {:rf.trace/no-emit? true}
+      (fn [db [_ buffer]]
+        (assoc db :trace-buffer (vec buffer))))
 
     ;; Bump the per-frame suppressed-events counter (rf2-0vxdn).
     ;; Dispatched from `trace-bus/collect-trace!` (CLJS) under

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -20,13 +20,25 @@
       │ Bottom rail (40px)                                      │
       └─────────────────────────────────────────────────────────┘
 
-  ## Frame isolation (rf2-tijr Option C)
+  ## Frame isolation (rf2-tijr Option C + rf2-in6l2)
 
   The whole shell is wrapped in `[rf/frame-provider {:frame :rf/causa}
   ...]`. Every `subscribe` / `dispatch` inside the shell resolves to
   the `:rf/causa` frame; the host's `:rf/default` is untouched. Causa
   registrations under `:rf.causa/*` (see registry.cljs) operate
   against `:rf/causa`'s db when called from inside the shell.
+
+  Per rf2-in6l2 every subscribing region of the shell is `reg-view`-
+  registered so its rendered React component carries `:contextType
+  frame-context` — the closest enclosing Provider's `:rf/causa`
+  flows through React-context and `(rf/subscribe …)` inside the body
+  resolves to the registered frame. With plain `defn`s the
+  React-context tier would be skipped (Spec 004 §Plain Reagent fns
+  do not pick up the surrounding frame) and subscribe would fall
+  through to `:rf/default` — silently routing every Causa panel
+  query into the host's app-db. The frame is lazy-registered by
+  `mount.cljs/open!` (`rf/init!` must run before `reg-frame` can
+  succeed; the preload runs too early).
 
   ## Pure hiccup
 
@@ -89,14 +101,20 @@
 
 ;; ---- regions -------------------------------------------------------------
 
-(defn- top-strip
+(rf/reg-view top-strip
   "Top strip (56px). Per spec/007-UX-IA.md §The five regions item 1:
   causality strip + frame picker + global actions (Issues badge,
   epoch counter, command palette, help, close).
 
   v1 stub: brand mark + version label + close-affordance text.
   Live causality strip / frame picker / Issues badge land as
-  follow-on work."
+  follow-on work.
+
+  Per rf2-in6l2 the body subscribes (`:rf.causa/copilot-open?`) so
+  the component is `reg-view`-registered — the wrapper attaches
+  `:contextType frame-context` so the surrounding `[rf/frame-provider
+  {:frame :rf/causa}]` (in `shell-view` below) reaches the subscribe
+  via React context."
   [_props]
   [:div {:style {:display          "flex"
                  :align-items      "center"
@@ -142,7 +160,7 @@
   parent decides per-row what 'awake' means."
   [{:keys [id label dormant?]} active?]
   [:li {:data-testid (str "rf-causa-sidebar-item-" (name id))
-        :on-click    #(rf/dispatch [:rf.causa/select-panel id])
+        :on-click    #(rf/dispatch [:rf.causa/select-panel id] {:frame :rf/causa})
         :style       {:padding         "6px 16px"
                       :cursor          "pointer"
                       :background      (if active? (:bg-active tokens) "transparent")
@@ -161,7 +179,7 @@
       :else    "○")]
    label])
 
-(defn- sidebar
+(rf/reg-view sidebar
   "Sidebar (192px) — panel navigation + density toggle. Per spec/007-
   UX-IA.md §Sidebar groups three groups (events/app-db/causality/...,
   conditional-with-activity, dormant) divider-separated.
@@ -178,7 +196,10 @@
   — boolean-only, so the sidebar's reactive path doesn't pull the
   full mismatch-detail composite (which resolves selection, computes
   the side-by-side detail, and walks the source-coord) on every
-  shell re-render."
+  shell re-render.
+
+  Per rf2-in6l2 `reg-view`-registered so the subscribes route through
+  React context to `:rf/causa`."
   []
   (let [active (or @(rf/subscribe [:rf.causa/selected-panel])
                    registry/default-panel-id)
@@ -219,11 +240,14 @@
    [:p {:style {:font-size "14px" :color (:text-secondary tokens)}}
     "Unknown panel: " [:code (pr-str selected)]]])
 
-(defn- canvas
+(rf/reg-view canvas
   "Canvas — renders the active panel's content. The match is on
   `:rf.causa/selected-panel`. When a row dispatches
   `:rf.causa/select-panel <id>` the registry sets `:selected-panel`
-  on the `:rf/causa` frame's app-db and this canvas recomputes."
+  on the `:rf/causa` frame's app-db and this canvas recomputes.
+
+  Per rf2-in6l2 `reg-view`-registered so the subscribe routes
+  through React context to `:rf/causa`."
   []
   (let [selected (or @(rf/subscribe [:rf.causa/selected-panel])
                      registry/default-panel-id)]
@@ -253,7 +277,7 @@
       :copilot      [ai-co-pilot/ai-co-pilot-view]
       [unknown-panel selected])))
 
-(defn- bottom-rail
+(rf/reg-view bottom-rail
   "Bottom rail (40px) — time-travel scrubber + frame info + issues
   badge. Per spec/007-UX-IA.md §The five regions item 5.
 
@@ -268,7 +292,10 @@
   disappears on `trace-bus/clear-buffer!` (counter resets together
   with the buffer) and when the host calls
   `(causa-config/configure! {:trace/show-sensitive? true})` BEFORE
-  the events flow (the counter never bumps in that case)."
+  the events flow (the counter never bumps in that case).
+
+  Per rf2-in6l2 `reg-view`-registered so the subscribe routes
+  through React context to `:rf/causa`."
   []
   (let [redacted-count @(rf/subscribe [:rf.causa/suppressed-sensitive-count])]
     [:footer {:style {:height           "40px"
@@ -298,12 +325,35 @@
 
 ;; ---- shell view ----------------------------------------------------------
 
-(defn shell-view
+;; Right-edge rail gate (rf2-in6l2). Extracted as its own `reg-view`
+;; so the `:rf.causa/copilot-open?` subscribe routes through React
+;; context to `:rf/causa` — the parent `shell-view` itself is mounted
+;; at the React-context default (no enclosing Provider above it), so
+;; a subscribe in its own body would route to `:rf/default`. Child
+;; components rendered INSIDE the frame-provider see `:rf/causa` via
+;; the React-context tier.
+(rf/reg-view rail-gate
+  "Conditional right-edge rail per spec/007-UX-IA.md §The five regions
+  item 4. Collapsed by default (Lock 8); renders only when
+  `:rf.causa/copilot-open?` is true. The cue glyph in the top strip is
+  the affordance for opening it when collapsed."
+  []
+  (when @(rf/subscribe [:rf.causa/copilot-open?])
+    [ai-co-pilot/ai-co-pilot-rail]))
+
+(rf/reg-view shell-view
   "The full Causa shell. Wraps every panel region in a `:rf/causa`
   frame-provider so descendant `subscribe` / `dispatch` resolve to
   the isolated frame. The shell's outer container is a fixed-position
   overlay along the right edge of the viewport (40% width per
-  spec/007-UX-IA.md §Layout)."
+  spec/007-UX-IA.md §Layout).
+
+  Per rf2-in6l2 `reg-view`-registered for parity with every other
+  shell region. The shell-view itself sits OUTSIDE its own frame-
+  provider (it's the mount root) so React-context inside `shell-view`'s
+  body still resolves to the default — every subscribing child is its
+  own reg-view component so the surrounding `:rf/causa` Provider
+  reaches them via React context."
   []
   [rf/frame-provider {:frame :rf/causa}
    [:div {:data-testid "rf-causa-shell"
@@ -329,10 +379,5 @@
                    :overflow      "hidden"}}
      [sidebar]
      [canvas]
-     ;; Right-edge rail per spec/007-UX-IA.md §The five regions item 4.
-     ;; Collapsed by default (Lock 8); renders only when
-     ;; `:rf.causa/copilot-open?` is true. The cue glyph in the top
-     ;; strip is the affordance for opening it when collapsed.
-     (when @(rf/subscribe [:rf.causa/copilot-open?])
-       [ai-co-pilot/ai-co-pilot-rail])]
+     [rail-gate]]
     [bottom-rail]]])

--- a/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
@@ -37,27 +37,39 @@
   opts in via `(causa-config/configure! {:trace/show-sensitive?
   true})`.
 
-  ## Reactivity
+  ## Reactivity (rf2-in6l2)
 
-  The buffer is held in a plain atom (`buffer-state` below). The
-  `:rf.causa/trace-buffer` sub (in `registry.cljs`) thunks
-  `(trace-bus/buffer)` so subscribers get a fresh read on every
-  recompute. The sub is layer-1 so it re-fires on every app-db
-  change of the resolved frame — under Causa's normal usage
-  (panels rendered inside a host app), every host dispatch dirties
-  the host's app-db and the sub re-fires, picking up whatever the
-  trace-cb has accumulated in the atom since the last recompute.
-  Visible delay between trace push and panel update is bounded by
-  the host's next dispatch, indistinguishable from native trace-
-  rate UI cadence on every example app the foundation ships.
+  The buffer lives in two places that move in lockstep:
 
-  An architecturally clean reactive-on-every-push surface would
-  require either reg-view-wrapping Causa's panels (so plain-fn
-  subscribes route to `:rf/causa` via the React-context tier) or a
-  fixed-frame sub mechanism — both wider refactors filed for follow-
-  up. Until then, the layer-1 + host-driven recompute path delivers
-  the same UX without the layering hazards."
+    1. The `buffer-state` atom (this ns) — the JVM-runnable data
+       primitive. Tests over push algebra / sensitive-trace privacy /
+       filter-vocab consumer use the atom directly; CLJC so the shape
+       runs under both runtimes.
+
+    2. Causa's app-db `:trace-buffer` slot (lazy-registered by
+       `mount.cljs/open!` at first Ctrl+Shift+C, mirrored on every
+       `collect-trace!` via `:rf.causa/note-trace-event`). Panels
+       subscribe to `:rf.causa/trace-buffer` which reads this slot —
+       the layer-1 sub re-fires on the standard app-db-write reactive
+       path so the panel re-renders IMMEDIATELY on every trace push
+       with no dependency on a host-side dispatch.
+
+  Why both: the atom is the JVM-runnable primitive and the pre-mount
+  fallback (`collect-trace!` can fire before `open!` has registered
+  the frame; the atom still accumulates and the seed lands when the
+  user opens Causa). The app-db slot is the reactive surface that
+  reg-view-wrapped panels read via the `:rf/causa` frame.
+
+  Per rf2-e9s81 the parallel-app-db approach was attempted at preload
+  time and reverted because the preload couldn't register `:rf/causa`
+  in that window (no substrate adapter yet) and chain-resolving to
+  `:rf/default` polluted the host's app-db / consumed drain-depth
+  headroom. The rf2-in6l2 design lands the dispatch under `:rf/causa`
+  proper, registered lazily at mount time — closing the gap without
+  the layering hazards."
   (:require [re-frame.interop :as interop]
+            #?(:cljs [re-frame.core :as rf])
+            #?(:cljs [re-frame.frame :as frame])
             [day8.re-frame2-causa.config :as config]))
 
 ;; ---- ring-buffer state ----------------------------------------------------
@@ -90,6 +102,31 @@
     (if (> n depth)
       (subvec buffer' (- n depth))
       buffer')))
+
+;; ---- causa-frame mirror dispatch helper (rf2-in6l2) -------------------
+;;
+;; CLJS-only — the framework dispatch surface is CLJS-only on this code
+;; path (the JVM `re-frame.frame/frame` lookup is also CLJC but `rf/
+;; dispatch` is the gating call). When the `:rf/causa` frame is
+;; registered (`mount.cljs/open!` ran), every `collect-trace!` /
+;; `clear-buffer!` / `set-buffer-depth!` mirrors its effect into the
+;; frame's app-db via dispatch — so the layer-1 sub re-fires on the
+;; standard app-db-write reactive path and panels re-render IMMEDIATELY.
+;; Pre-mount the frame is absent; the mirror is a no-op and the atom
+;; still accumulates (the eventual `mount.cljs/open!` seeds the slot
+;; from the atom). Per `mount.cljs/ensure-causa-frame!` for the seed.
+
+#?(:cljs
+   (defn- mirror-into-causa!
+     "Dispatch `event-v` into `:rf/causa`'s frame iff the frame is
+     registered. Pre-mount this is a silent no-op (no warning trace,
+     no exception) — the trace-bus atom keeps accumulating and the
+     `:rf.causa/sync-trace-buffer` seed in `mount.cljs/open!` lifts
+     the atom's contents into the freshly-registered frame."
+     [event-v]
+     (when (some? (frame/frame :rf/causa))
+       (rf/with-frame :rf/causa
+         (rf/dispatch event-v)))))
 
 ;; ---- collector --------------------------------------------------------
 
@@ -137,7 +174,15 @@
       (config/note-suppressed! (get-in event [:tags :frame]))
 
       :else
-      (swap! buffer-state push @buffer-depth event))))
+      (do
+        (swap! buffer-state push @buffer-depth event)
+        ;; Mirror into :rf/causa so the reg-view-wrapped panels'
+        ;; `:rf.causa/trace-buffer` sub re-fires on the standard app-db-
+        ;; write reactive path. CLJS only — the JVM build does not run
+        ;; panels. Pre-mount the mirror is a no-op (frame absent); the
+        ;; atom keeps accumulating and `mount.cljs/open!`'s seed lifts
+        ;; the contents at first Ctrl+Shift+C.
+        #?(:cljs (mirror-into-causa! [:rf.causa/note-trace-event event]))))))
 
 ;; ---- read-side accessors -------------------------------------------
 
@@ -261,6 +306,10 @@
   []
   (when interop/debug-enabled?
     (reset! buffer-state [])
+    ;; Mirror the clear into :rf/causa so the reactive `:trace-buffer`
+    ;; slot empties in lockstep with the atom. Pre-mount this is a
+    ;; silent no-op (frame absent).
+    #?(:cljs (mirror-into-causa! [:rf.causa/clear-trace-buffer]))
     (config/reset-suppressed-count!))
   nil)
 
@@ -277,5 +326,8 @@
                (cond
                  (zero? depth) []
                  (> n depth)   (subvec v (- n depth))
-                 :else         v)))))
+                 :else         v))))
+    ;; Mirror the post-shrink contents into `:rf/causa`'s app-db so
+    ;; the reactive slot reflects the same eviction the atom just took.
+    #?(:cljs (mirror-into-causa! [:rf.causa/sync-trace-buffer @buffer-state])))
   nil)

--- a/tools/causa/test/day8/re_frame2_causa/mount_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/mount_cljs_test.cljs
@@ -47,6 +47,8 @@
   shadow-cljs preload + real Reagent render + real Ctrl+Shift+C —
   lives in the Playwright lane (rf2-s2bhn)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
@@ -213,6 +215,12 @@
 (defn- causa-init! []
   (preload/reset-for-test!)
   (registry/reset-for-test!)
+  ;; Per rf2-in6l2 the registry installs the trace-buffer mirror
+  ;; events (note-trace-event / clear-trace-buffer / sync-trace-buffer).
+  ;; `ensure-causa-frame!` (called inside `open!`) dispatches
+  ;; `:rf.causa/sync-trace-buffer` to seed the slot — that needs the
+  ;; event handlers installed.
+  (registry/register-causa-handlers!)
   (trace-bus/clear-buffer!)
   (reset-mount-state!))
 
@@ -658,3 +666,79 @@
             (mount/teardown!)
             (is (false? (mount/mounted?))
                 "mounted? flips back to false after teardown!")))))))
+
+;; -------------------------------------------------------------------------
+;; (8) Lazy `:rf/causa` frame registration (rf2-in6l2)
+;; -------------------------------------------------------------------------
+;;
+;; Per rf2-in6l2 the `:rf/causa` frame is lazy-registered by `open!` —
+;; the preload runs before `rf/init!` has installed a substrate adapter
+;; so `reg-frame` cannot run there (per rf2-e9s81). The first Ctrl+
+;; Shift+C keypress fires `open!` AFTER `rf/init!`, so that's the
+;; canonical registration point. Subsequent toggles surgical-update
+;; (reg-frame's re-register semantics) — the frame's app-db and sub-
+;; cache are preserved across keypresses.
+
+(deftest first-open!-registers-causa-frame
+  (testing "first open! registers the :rf/causa frame so reg-view-wrapped
+            panels' React-context resolution lands in a real frame
+            (not chain-resolves to :rf/default)"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (is (nil? (frame/frame :rf/causa))
+                ":rf/causa is absent on the clean baseline")
+            (mount/open!)
+            (is (some? (frame/frame :rf/causa))
+                ":rf/causa registered after open!")))))))
+
+(deftest first-open!-seeds-trace-buffer-mirror
+  (testing "first open! seeds Causa's app-db `:trace-buffer` slot with
+            the trace-bus atom's current contents — closes the pre-
+            mount-trace-events window: events that arrived before the
+            user opened Causa (atom accumulated, no frame to dispatch
+            into yet) lift into the reactive slot on first mount"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            ;; Push two events into the trace-bus atom BEFORE the
+            ;; first open!. The frame doesn't exist yet, so the
+            ;; `mirror-into-causa!` guard skips the dispatch — atom
+            ;; still accumulates.
+            (trace-bus/collect-trace!
+              {:id 1 :op-type :event :operation :rf.test/pre-mount :tags {}})
+            (trace-bus/collect-trace!
+              {:id 2 :op-type :event :operation :rf.test/pre-mount :tags {}})
+            (mount/open!)
+            ;; After open! the slot reflects the pre-mount atom contents.
+            (rf/with-frame :rf/causa
+              (let [buf @(rf/subscribe [:rf.causa/trace-buffer])]
+                (is (= 2 (count buf))
+                    "pre-mount atom contents seeded into the reactive slot")
+                (is (= [1 2] (mapv :id buf))
+                    "seed preserves oldest-first ordering")))))))))
+
+(deftest open!-is-idempotent-on-causa-frame-registration
+  (testing "subsequent open!s after the frame is registered surgical-
+            update the frame's config (reg-frame contract per Spec 002
+            §Re-registration) without re-allocating the app-db.
+            Production toggle path: every Ctrl+Shift+C calls open!;
+            the close path doesn't unmount, so re-registration is
+            the on-show no-op the bead's design relies on"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (mount/open!)
+            (let [first-frame (frame/frame :rf/causa)
+                  first-db    (frame/get-frame-db :rf/causa)]
+              (mount/close!)
+              (mount/open!)
+              (let [second-frame (frame/frame :rf/causa)
+                    second-db   (frame/get-frame-db :rf/causa)]
+                (is (some? first-frame))
+                (is (some? second-frame))
+                (is (identical? first-db second-db)
+                    "app-db container preserved across re-register")))))))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -163,6 +163,7 @@
    :rf.causa/clear-selected-epoch
    :rf.causa/clear-selected-sub
    :rf.causa/clear-slice-focus
+   :rf.causa/clear-trace-buffer
    :rf.causa/clear-trace-filters
    :rf.causa/clear-violation-selection
    :rf.causa/copy-path-to-clipboard
@@ -172,6 +173,7 @@
    :rf.causa/focus-slice-path
    :rf.causa/hide-invalidation-chain
    :rf.causa/note-sensitive-suppressed
+   :rf.causa/note-trace-event
    :rf.causa/open-in-editor
    :rf.causa/pin-current
    :rf.causa/pin-slice
@@ -205,6 +207,7 @@
    :rf.causa/set-sub-cache-override-for-test
    :rf.causa/set-trace-filter
    :rf.causa/show-invalidation-chain
+   :rf.causa/sync-trace-buffer
    :rf.causa/toggle-issues-prefix
    :rf.causa/toggle-issues-severity
    :rf.causa/toggle-mcp-op-type
@@ -242,9 +245,11 @@
           (str "expected :fx handler for " fx-id)))))
 
 (deftest registry-counts-match-bead
-  (testing "registry holds exactly 65 subs + 60 events + 3 fxs"
+  (testing "registry holds exactly 65 subs + 63 events + 3 fxs (rf2-in6l2
+            added 3 events: :rf.causa/note-trace-event,
+            :rf.causa/clear-trace-buffer, :rf.causa/sync-trace-buffer)"
     (is (= 65 (count all-sub-names)))
-    (is (= 60 (count all-event-names)))
+    (is (= 63 (count all-event-names)))
     (is (= 3  (count all-fx-names)))))
 
 (deftest registry-is-idempotent
@@ -280,15 +285,16 @@
 ;; ---- (2) high-value sub contracts: defaults on a fresh frame ------------
 
 (deftest sub-trace-buffer-thunks-trace-bus
-  (testing ":rf.causa/trace-buffer thunks `trace-bus/buffer` (the
-            process-global ring atom). Tests push BEFORE the first
-            subscribe — the first deref of a fresh Reaction reads
-            whatever the atom holds at that moment. Re-deriving after
-            an atom mutation is NOT covered by this contract (the
-            Reaction caches against the no-op input-signal); under
-            Causa's normal usage that gap is closed by the host's
-            next app-db dispatch dirtying the resolved frame's db.
-            Per rf2-e9s81 — see `trace_bus.cljc` §Reactivity."
+  (testing ":rf.causa/trace-buffer falls through to `trace-bus/buffer`
+            (the process-global ring atom) when Causa's app-db slot is
+            empty — the pre-mount fallback path that lets headless tests
+            drive the collector without first dispatching the seed.
+            Tests push BEFORE the first subscribe; the first deref of a
+            fresh Reaction reads through to the atom and sees the
+            current contents. Per rf2-in6l2 — see `trace_bus.cljc`
+            §Reactivity for the dual atom + app-db slot, and
+            `registry.cljs` for the sub's `(or (get db :trace-buffer)
+            (trace-bus/buffer))` fall-through."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       ;; Push first, then subscribe — the Reaction's first read sees
@@ -314,6 +320,74 @@
     (rf/with-frame :rf/causa
       (is (= [] @(rf/subscribe [:rf.causa/trace-buffer]))
           "empty atom → sub returns []"))))
+
+(deftest sub-trace-buffer-immediate-reactive-update-via-mirror
+  (testing "Per rf2-in6l2 — once the `:rf/causa` frame is registered,
+            `collect-trace!` mirrors each push into Causa's app-db slot
+            `:trace-buffer` via `:rf.causa/note-trace-event` so the
+            layer-1 sub fires on the standard app-db-write reactive
+            path. Drive the mirror event synchronously via dispatch-
+            sync (the production path uses dispatch — async drain —
+            but the same handler runs); assert that the sub reads
+            from app-db rather than the atom fall-through once the
+            slot is populated."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Seed the app-db slot via the production event handler. With
+      ;; the slot populated the sub MUST read from app-db (not the atom
+      ;; fall-through) — that's the reactive surface panels depend on.
+      (rf/dispatch-sync [:rf.causa/note-trace-event
+                         {:id 1 :op-type :event :operation :rf.test/a :tags {}}])
+      (rf/dispatch-sync [:rf.causa/note-trace-event
+                         {:id 2 :op-type :event :operation :rf.test/b :tags {}}])
+      (let [buf @(rf/subscribe [:rf.causa/trace-buffer])]
+        (is (= 2 (count buf))
+            "two mirrored pushes are visible immediately on subscribe")
+        (is (= [1 2] (mapv :id buf))
+            "events are oldest-first, matching trace-bus/push algebra"))
+      ;; Bump once more — the reaction re-fires on the same dispatch
+      ;; path the production trace-collector takes. No
+      ;; clear-subscription-cache! workaround needed.
+      (rf/dispatch-sync [:rf.causa/note-trace-event
+                         {:id 3 :op-type :event :operation :rf.test/c :tags {}}])
+      (let [buf @(rf/subscribe [:rf.causa/trace-buffer])]
+        (is (= 3 (count buf))
+            "subsequent mirror dispatch re-fires the sub — immediate update")
+        (is (= [1 2 3] (mapv :id buf)))))))
+
+(deftest sub-trace-buffer-clear-event-drops-mirror-slot
+  (testing "Per rf2-in6l2 — `:rf.causa/clear-trace-buffer` (dispatched
+            from `trace-bus/clear-buffer!` in CLJS) drops the mirrored
+            slot in lockstep with the atom reset. After clear the
+            sub falls back through the atom path again."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/note-trace-event
+                         {:id 1 :op-type :event :operation :rf.test/x :tags {}}])
+      (is (= 1 (count @(rf/subscribe [:rf.causa/trace-buffer]))))
+      (rf/dispatch-sync [:rf.causa/clear-trace-buffer])
+      ;; After clear the slot is dissoc'd; the sub falls back to the
+      ;; atom (also empty since the trace-bus atom was cleared at the
+      ;; start of the test via the fixture's causa-init!).
+      (is (= [] @(rf/subscribe [:rf.causa/trace-buffer]))
+          "clear-trace-buffer drops the slot and the atom is empty too"))))
+
+(deftest sub-trace-buffer-sync-event-overwrites-slot
+  (testing "Per rf2-in6l2 — `:rf.causa/sync-trace-buffer` overwrites the
+            slot wholesale, used by `mount.cljs/open!` to seed the slot
+            with the atom's pre-mount contents and by `set-buffer-depth!`
+            to reflect post-shrink atom state."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [seed [{:id 100 :op-type :event :operation :rf.test/seeded :tags {}}
+                  {:id 101 :op-type :event :operation :rf.test/seeded :tags {}}]]
+        (rf/dispatch-sync [:rf.causa/sync-trace-buffer seed])
+        (is (= seed @(rf/subscribe [:rf.causa/trace-buffer]))
+            "seed lands wholesale in the slot")
+        ;; Overwrite with a smaller seed — wholesale replace, not merge.
+        (rf/dispatch-sync [:rf.causa/sync-trace-buffer [{:id 200 :tags {}}]])
+        (is (= [{:id 200 :tags {}}] @(rf/subscribe [:rf.causa/trace-buffer]))
+            "second sync wholly replaces the slot (no merge)")))))
 
 (deftest sub-trace-buffer-evicts-on-overflow
   (testing "trace-bus enforces the eviction-on-overflow algebra against


### PR DESCRIPTION
## Summary

- Wire Causa's shell + 16 panels through `reg-view` so subscribes carry the `:rf/causa` frame via React-context (closes the architecturally-clean shape the rf2-e9s81 revert deferred from rf2-iw5ym).
- Lazy-register `:rf/causa` from `mount.cljs/open!` (the preload runs before `rf/init!` has installed the substrate adapter — per rf2-e9s81 that's why the preload-time `reg-frame` path produced the iw5ym regression).
- Restore iw5ym-style mirroring: `collect-trace!` dispatches `:rf.causa/note-trace-event` into `:rf/causa` so the layer-1 `:rf.causa/trace-buffer` sub re-fires on the standard app-db-write reactive path — panels re-render IMMEDIATELY on every trace push, no dependency on the host's next dispatch.

## Shape of the change

- **`mount.cljs`** — `ensure-causa-frame!` calls `reg-frame :rf/causa` on every `open!` (idempotent surgical-update per Spec 002) and seeds `:trace-buffer` with the trace-bus atom's pre-mount contents via `:rf.causa/sync-trace-buffer`. Pre-mount traces still accumulate in the atom; the seed lifts them into the reactive slot at first Ctrl+Shift+C.
- **`shell.cljs`** — `top-strip`, `sidebar`, `canvas`, `bottom-rail`, `shell-view`, plus a new `rail-gate` reg-view (extracted because `shell-view` itself sits OUTSIDE its own frame-provider as the mount root, so a body-level subscribe in `shell-view` would route to `:rf/default`).
- **16 panel `…-view` fns** — `defn` → `rf/reg-view`. `ai-co-pilot-rail` + `ai-co-pilot-cue` also reg-view-wrapped.
- **`registry.cljs`** — `:rf.causa/trace-buffer` reads `:trace-buffer` from app-db with atom fall-through for the pre-mount / headless-test path. Three new mirror events carry `:rf.trace/no-emit? true` (per rf2-qsjda) to break the cb-dispatch loop.
- **`trace_bus.cljc`** — `collect-trace!` / `clear-buffer!` / `set-buffer-depth!` mirror state into `:rf/causa` (CLJS only; guarded on `(frame/frame :rf/causa)` so pre-mount is a silent no-op).
- **Panel/shell click handlers** — every `(rf/dispatch [:rf.causa/…])` carries `{:frame :rf/causa}` opts so click handlers fired outside the React render cycle (when the React-context tier would resolve to `:rf/default`) route to the registered frame explicitly.

## Reactive surface — before/after

| | Before | After |
|---|---|---|
| Sub source | `(trace-bus/buffer)` atom thunk | `:trace-buffer` slot in `:rf/causa` app-db (atom fall-through pre-mount) |
| Re-fire trigger | Host frame's next app-db change | Per-trace `:rf.causa/note-trace-event` dispatch |
| Visible push→render delay | Bounded by host's next dispatch | Bounded by a single-event drain settle on `:rf/causa` |
| Plain-fn warnings | One per Causa panel, every Causa subscribe | None |

## Test plan

- [x] `tools/causa && clojure -M:test` — 518 tests, 0 failures (baseline)
- [x] `implementation && npm run test:cljs` — 1923 tests, 0 failures (1917 baseline + 6 new pinning the reactive-update path)
- [x] `implementation && npm run test:perf-bundle` — PASS (Causa is bundle-isolated; refactor is dev-side only under `interop/debug-enabled?`)

22 files, 532 insertions, 164 deletions.