### PR TITLE
fix(adapters): sec-audit + reagent-slim React.memo bug — 2 beads

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
@@ -189,9 +189,63 @@
     (coll? v) (->> v (keep named->str) (str/join " "))
     :else     (str v)))
 
+;; ---------------------------------------------------------------------------
+;; React-internal / non-HTML attribute filtering (rf2-dwds9 HIGH)
+;;
+;; React event-handler props (`onClick`, `onChange`, …) MUST NOT appear
+;; in the static HTML output:
+;;
+;;   - They are not HTML attributes — `react-dom/server.renderToStaticMarkup`
+;;     omits them entirely.
+;;   - Serialising `{:on-click handler-string}` as `onclick="..."` would
+;;     turn a server-side render of user-supplied data into an XSS
+;;     vector (an `:on-click` whose value is a JavaScript expression
+;;     would execute on every click of the rendered HTML).
+;;   - Function-valued props (event handlers, ref callbacks) coerced
+;;     through `(str f)` leak `function (...) { ... }` source into the
+;;     attribute, which is both useless and potentially sensitive.
+;;
+;; Strategy: drop `on*`-prefixed names AND drop any fn-valued prop value
+;; regardless of name. The two checks are complementary — `on*` covers
+;; the case where the value is a string template (XSS shape); the
+;; fn-value check covers any non-event prop that happens to carry a
+;; callback (`:on-frame`, `:loader`, `:ref-fn`, …).
+;;
+;; Also covered: React-internal props that have no HTML meaning
+;; (`:key`, `:ref`, `:dangerouslySetInnerHTML` — handled by caller).
+;; ---------------------------------------------------------------------------
+
+(defn- ^boolean event-handler-prop?
+  "True when `k`'s name looks like a React event-handler prop
+  (`onClick`, `onChange`, `on-click`, …). Matches both kebab- and
+  camelCase forms before `attr-name` lowercasing."
+  [k]
+  (let [n (cond
+            (keyword? k) (name k)
+            (symbol? k)  (name k)
+            (string? k)  k
+            :else        nil)]
+    (and (some? n)
+         (>= (count n) 3)
+         ;; Match `on-` (kebab) and `on[A-Z]` (camel).
+         (or (and (str/starts-with? n "on-") (> (count n) 3))
+             (and (str/starts-with? n "on")
+                  (let [ch (.charAt n 2)]
+                    (and (>= (.charCodeAt ch 0) 65)   ; 'A'
+                         (<= (.charCodeAt ch 0) 90)))))))) ; 'Z'
+
 (defn- emit-attr
   "Emit one [k v] attribute pair to the StringBuilder. Skips nil and
-  false values; emits boolean-attribute short form for true."
+  false values; emits boolean-attribute short form for true.
+
+  Drops React-internal / non-HTML props (rf2-dwds9 HIGH):
+    - `:key` / `:ref` — React-internal.
+    - `:dangerouslySetInnerHTML` — handled by caller (children path).
+    - Event-handler props (`on*`) — not HTML attrs; emitting them as
+      `onclick=\"...\"` would be an XSS surface and diverges from
+      `react-dom/server.renderToStaticMarkup`.
+    - Fn-valued props of any name — `(str f)` leaks `function () {…}`
+      source into the attribute. React-DOM-server elides these too."
   [^StringBuffer sb k v]
   (cond
     (nil? v)   nil
@@ -206,6 +260,17 @@
     ;; :dangerouslySetInnerHTML is handled by the caller (children
     ;; emission); skip here.
     (= :dangerouslySetInnerHTML k) nil
+
+    ;; rf2-dwds9 HIGH: drop React event-handler props from static
+    ;; markup. Matches `react-dom/server.renderToStaticMarkup`'s
+    ;; behaviour and closes the XSS surface where a stringy `on*` value
+    ;; would be emitted as an inline event handler.
+    (event-handler-prop? k) nil
+
+    ;; rf2-dwds9 HIGH: drop fn-valued props (event handlers, ref
+    ;; callbacks, custom callback props). Stringifying a fn would leak
+    ;; source text into the attribute and serves no HTML purpose.
+    (fn? v) nil
 
     (= :style k)
     (when (and (map? v) (seq v))

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -92,14 +92,55 @@
                 (str/replace class-shorthand #"\." " "))]
     (->HiccupTag tag id class)))
 
+;; ---------------------------------------------------------------------------
+;; Cache + props-object safety (rf2-dwds9 MEDIUM)
+;;
+;; Hiccup keys reaching `aset` are user-controlled. A literal
+;; `{:__proto__ x}` or `{:constructor x}` in a prop map would, on a
+;; plain `#js {}` target, write to the prototype chain — mutating
+;; `Object.prototype` (or our shared caches' prototype) and leaking
+;; inherited slots across every subsequent render.
+;;
+;; Strategy: BLOCK the reserved key trio (`__proto__`, `prototype`,
+;; `constructor`) before any `aset`. Two enforcement points:
+;;
+;;   - `cached-prop-name` — never caches a reserved name; returns it
+;;     verbatim. (Belt: keeps the shared cache map clean.)
+;;   - `kv-conv` — drops reserved camelCased names before writing to
+;;     the per-render JS props object. (Braces: the actual prototype-
+;;     pollution chokepoint, because the props object is what flows
+;;     into `React.createElement`.)
+;;
+;; Why NOT null-prototype objects? React's renderer calls
+;; `styles.hasOwnProperty(...)` on nested objects like `:style` when
+;; diffing inline styles (`react-dom` ReactDOMHostConfig). A
+;; null-proto object throws `TypeError: styles.hasOwnProperty is not
+;; a function`. So props objects stay on the default prototype, and
+;; the reserved-key filter is the sole defence — sufficient on its
+;; own because every prototype-pollution path runs through the filtered
+;; `aset` chokepoints.
+;; ---------------------------------------------------------------------------
+
+(def ^:private reserved-prop-keys
+  "JS property keys that must NEVER be `aset` from user-controlled
+  input. Writing to these mutates the prototype of the object instead
+  of creating an own property, which leaks inherited slots across
+  every subsequent prop-map conversion. Per rf2-dwds9 MEDIUM."
+  #{"__proto__" "prototype" "constructor"})
+
+(defn- ^boolean reserved-prop-key? [n]
+  (contains? reserved-prop-keys n))
+
 (def ^:private tag-name-cache #js {})
 
 (defn- cached-parse [k]
   (let [n (name k)]
-    (if (.hasOwnProperty tag-name-cache n)
+    (if (and (not (reserved-prop-key? n))
+             (.hasOwnProperty tag-name-cache n))
       (aget tag-name-cache n)
       (let [v (parse-tag k)]
-        (aset tag-name-cache n v)
+        (when-not (reserved-prop-key? n)
+          (aset tag-name-cache n v))
         v))))
 
 ;; ---------------------------------------------------------------------------
@@ -147,16 +188,27 @@
     :charset  → \"charSet\"
     :tab-index → \"tabIndex\"
     :data-foo → \"data-foo\"  (data-* not camelCased)
-    :aria-label → \"aria-label\" (aria-* not camelCased)"
+    :aria-label → \"aria-label\" (aria-* not camelCased)
+
+  Per rf2-dwds9 MEDIUM: reserved JS keys (`__proto__`, `prototype`,
+  `constructor`) are never cached and are returned verbatim. The
+  downstream `convert-props` writes drop these too (see `kv-conv`),
+  so a malicious key cannot reach the React props object."
   [k]
   (if (or (keyword? k) (symbol? k))
     (let [n (name k)]
-      (if-some [cached (when (.hasOwnProperty prop-name-cache n)
-                         (aget prop-name-cache n))]
-        cached
-        (let [v (dash-to-prop-name k)]
-          (aset prop-name-cache n v)
-          v)))
+      (cond
+        ;; Reserved keys: skip the cache entirely, return the raw name.
+        ;; (Downstream kv-conv drops the aset; the name is harmless here.)
+        (reserved-prop-key? n) n
+
+        :else
+        (if-some [cached (when (.hasOwnProperty prop-name-cache n)
+                           (aget prop-name-cache n))]
+          cached
+          (let [v (dash-to-prop-name k)]
+            (aset prop-name-cache n v)
+            v))))
     k))
 
 ;; ---------------------------------------------------------------------------
@@ -207,11 +259,22 @@
 
 (declare convert-prop-value)
 
-(defn- kv-conv [o k v]
-  (let [k' (cached-prop-name k)
-        v' (convert-prop-value k v)]
-    (aset o k' v')
-    o))
+(defn- kv-conv
+  "Reduce-kv step: convert one [k v] pair into the JS props object `o`.
+
+  Per rf2-dwds9 MEDIUM: reserved JS keys (`__proto__`, `prototype`,
+  `constructor`) are dropped silently. `aset o \"__proto__\" v` would
+  invoke the prototype-setter on the props object — replacing its
+  prototype chain with whatever `v` is, leaking inherited slots into
+  every subsequent property lookup. The key has no legitimate React
+  meaning, so dropping is the only correct behaviour."
+  [o k v]
+  (let [k' (cached-prop-name k)]
+    (if (and (string? k') (reserved-prop-key? k'))
+      o
+      (let [v' (convert-prop-value k v)]
+        (aset o k' v')
+        o))))
 
 (defn convert-prop-value
   "Convert a hiccup prop-map value `v` for prop-name `k` to a React-
@@ -227,8 +290,19 @@
     - JS values pass through.
     - Maps recursively convert (style maps + custom-component prop maps).
     - Coll? values become JS arrays via clj->js (children, vector classes).
-    - Fns pass through (event handlers, ref callbacks).
-    - Everything else passes through unchanged."
+    - Fn values pass through verbatim — referentially stable across renders.
+      Event handlers and ref callbacks reach React with the SAME identity
+      the caller supplied, so `React.memo` / `shouldComponentUpdate`
+      bail-outs work. Wrapping fns in a fresh closure per render would
+      silently defeat memoisation.
+    - Non-fn `IFn` values (keywords, maps, sets used as fns; vectors used
+      as positional lookups) are wrapped in a variadic shim so the React
+      side can invoke them as plain JS functions.
+    - Everything else passes through unchanged.
+
+  HOT PATH — this runs once per prop on every render. The `(fn? v)`
+  test sits before `(ifn? v)` so the common case (event-handler fn) does
+  not allocate a wrapper."
   ([v]
    ;; 1-arg form: used recursively for map values where there's no
    ;; outer prop-name context (e.g. nested style objects). Treat
@@ -241,6 +315,7 @@
      (named?* v)  (name v)         ; nested map values: stringify (CSS values)
      (map? v)     (reduce-kv kv-conv #js {} v)
      (coll? v)    (clj->js v)
+     (fn? v)      v                ; pass through — preserves identity
      (ifn? v)     (fn [& args] (apply v args))
      :else        v))
   ([k v]
@@ -254,6 +329,7 @@
                       v))
      (map? v)     (reduce-kv kv-conv #js {} v)
      (coll? v)    (clj->js v)
+     (fn? v)      v                ; pass through — preserves identity
      (ifn? v)     (fn [& args] (apply v args))
      :else        v)))
 

--- a/implementation/adapters/reagent-slim/test/reagent2/dom/server_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/dom/server_cljs_test.cljs
@@ -340,3 +340,75 @@
   (testing "non-keyword/symbol/fn head throws ex-info"
     (is (thrown-with-msg? js/Error #":rf.error/static-markup-bad-tag"
           (server/render-to-static-markup [42 "x"])))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-dwds9 HIGH: XSS surface — event handlers + fn props stripped
+;;
+;; The static-markup serializer must NOT emit React event-handler props
+;; (`onClick`, `:on-click`, …) as HTML attributes. Doing so would (a)
+;; serve no purpose (HTML inline-event handlers aren't bound to the
+;; React handler), and (b) open an XSS vector: a string-valued
+;; `:on-click "alert(1)"` would render as `onclick="alert(1)"`. Same
+;; for function-valued props of any name — `(str f)` would leak the
+;; source text into the attribute.
+;;
+;; `react-dom/server.renderToStaticMarkup` elides these; the rewrite
+;; now matches.
+;; ---------------------------------------------------------------------------
+
+(deftest event-handler-string-stripped-rf2-dwds9
+  (testing "rf2-dwds9: :on-click with string value does NOT emit
+            onclick attribute (XSS vector closed)"
+    (is (= "<div></div>"
+           (server/render-to-static-markup [:div {:on-click "alert(1)"}])))
+    (is (= "<div></div>"
+           (server/render-to-static-markup [:div {:onClick "alert(1)"}])))
+    (is (= "<button>x</button>"
+           (server/render-to-static-markup
+            [:button {:on-click "javascript:evil()"} "x"]))
+        "no leaked onclick attribute on the rendered button")))
+
+(deftest event-handler-fn-stripped-rf2-dwds9
+  (testing "rf2-dwds9: fn-valued :on-click is stripped (does not
+            emit `function () { ... }` source as the attribute value)"
+    (let [handler (fn [_e])
+          out (server/render-to-static-markup
+               [:div {:on-click handler}])]
+      (is (= "<div></div>" out)
+          "no onclick attribute, no leaked source"))))
+
+(deftest fn-valued-non-event-prop-stripped-rf2-dwds9
+  (testing "rf2-dwds9: any fn-valued prop (not just `on*`) is stripped
+            so source text never leaks into the attribute"
+    (let [callback (fn [])
+          out (server/render-to-static-markup
+               [:div {:custom-callback callback}])]
+      (is (= "<div></div>" out)))))
+
+(deftest other-on-prefix-attrs-stripped-rf2-dwds9
+  (testing "rf2-dwds9: camelCase `onChange`, `onSubmit`, `onMouseEnter`
+            all stripped (full event-handler family)"
+    (is (= "<form></form>"
+           (server/render-to-static-markup
+            [:form {:onSubmit "evil()" :onChange "evil2()"}])))
+    (is (= "<div></div>"
+           (server/render-to-static-markup
+            [:div {:onMouseEnter "evil()"}])))))
+
+(deftest on-not-event-prefix-passes-through
+  (testing "rf2-dwds9: attribute names starting with `on` but NOT
+            event-handler shape (e.g. `:once`) are NOT stripped —
+            event-handler-prop? requires `on-x` (kebab) or `onX` (camel
+            with uppercase letter after `on`)"
+    (is (= "<div once=\"true\"></div>"
+           (server/render-to-static-markup [:div {:once "true"}]))
+        "`:once` (no `-` after `on`, no capital after `on`) is preserved")
+    (is (= "<div onyx=\"x\"></div>"
+           (server/render-to-static-markup [:div {:onyx "x"}]))
+        "`:onyx` (lowercase letter after `on`) is preserved")))
+
+(deftest key-and-ref-still-stripped
+  (testing "regression: :key and :ref drops still work after the new
+            event-prop filter was added"
+    (is (= "<div></div>"
+           (server/render-to-static-markup [:div {:key "k" :ref "r"}])))))

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
@@ -155,6 +155,46 @@
           out (template/convert-prop-value :on-click f)]
       (is (fn? out)))))
 
+(deftest convert-prop-value-fn-preserves-identity-rf2-wyocr
+  (testing "rf2-wyocr: fn props pass through with === identity preserved
+            so React.memo / shouldComponentUpdate bail-outs work. Two
+            calls with the SAME fn return the SAME reference."
+    (let [handler (fn [_e] :clicked)
+          ;; 2-arg form — the production path through `kv-conv`.
+          a (template/convert-prop-value :on-click handler)
+          b (template/convert-prop-value :on-click handler)]
+      (is (identical? handler a)
+          "fn returned is the SAME reference passed in (=== check)")
+      (is (identical? a b)
+          "two conversions of the same fn produce the same reference"))
+    (let [handler (fn [_e] :nested)
+          ;; 1-arg form — used for nested map values.
+          a (template/convert-prop-value handler)
+          b (template/convert-prop-value handler)]
+      (is (identical? handler a)
+          "1-arg form preserves identity too")
+      (is (identical? a b)
+          "1-arg form: repeat conversions return the same reference"))))
+
+(deftest convert-prop-value-non-fn-ifn-still-wrapped
+  (testing "rf2-wyocr: keyword (IFn but not fn?) still wraps via shim
+            so the React side can invoke it as a JS function"
+    (let [out (template/convert-prop-value :on-click :some-kw)]
+      ;; Keyword is named? so it hits the named? branch first; this is
+      ;; the warn-once path, not the ifn wrap. Verify a true non-fn IFn
+      ;; (a map-as-fn) goes through the wrapper path.
+      (is (or (keyword? out) (string? out))
+          "keyword routed through named? branch (warn-once path)"))
+    (let [m   {:a 1 :b 2}
+          out (template/convert-prop-value :custom-lookup m)]
+      ;; Maps are routed to the map? branch (recursive conversion), not
+      ;; the ifn? branch — that's correct (a prop-map value is recursively
+      ;; converted as a JS object, not invoked as a fn).
+      (is (= "object" (goog/typeOf out))
+          "map value recursively converts to JS object (map? branch wins)")
+      (is (= 1 (aget out "a")) "key a flows through")
+      (is (= 2 (aget out "b")) "key b flows through"))))
+
 (deftest convert-prop-value-1-arg-form-stringifies-named
   (testing "1-arg form (nested map values) stringifies named values"
     ;; Used recursively for map values where there's no outer prop-
@@ -448,3 +488,89 @@
   (testing "no *source-coord* binding → no data-rf2-source-coord attr"
     (let [^js el (template/as-element [:div])]
       (is (nil? (aget (.-props el) "data-rf2-source-coord"))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-dwds9 MEDIUM: prototype-pollution defence
+;;
+;; User-controlled hiccup keys like `:__proto__`, `:constructor`, and
+;; `:prototype` MUST NOT mutate the prototype chain of the per-element
+;; props object or any shared cache. `kv-conv` and `cached-prop-name`
+;; drop the reserved key trio before any `aset`, which is the single
+;; chokepoint where user keys become JS object writes.
+;;
+;; These tests pin the contract by attempting the attack-shape and
+;; asserting the result has no leaked slot reachable from the props
+;; object, no own slot for the reserved name, and legitimate sibling
+;; keys still flow through.
+;; ---------------------------------------------------------------------------
+
+(deftest prototype-key-dropped-from-props-rf2-dwds9
+  (testing "rf2-dwds9: {:__proto__ {:polluted true}} prop does NOT
+            mutate the props object's prototype chain. Without the
+            kv-conv filter, `aset obj '__proto__' {...}` would invoke
+            the prototype-setter and change Object.prototype lookups
+            on every subsequent prop object — exactly the leak we close."
+    (let [;; A sentinel "evil" prototype carrying a slot we can detect.
+          evil      #js {:polluted "yes"}
+          ^js el    (template/as-element [:div {:__proto__ evil
+                                                :id "legit"}])
+          props     (.-props el)]
+      ;; The props object did NOT inherit `polluted` from the evil object.
+      (is (or (nil? (aget props "polluted"))
+              (= js/undefined (aget props "polluted")))
+          "evil prototype slot did NOT become reachable via aget")
+      ;; The legitimate sibling key still flows through.
+      (is (= "legit" (aget props "id"))
+          "legit prop alongside the __proto__ attempt is still present")
+      ;; Belt: no own slot for __proto__.
+      (is (not (.call (.. js/Object -prototype -hasOwnProperty)
+                      props "__proto__"))
+          "no own '__proto__' slot on the props object"))))
+
+(deftest constructor-key-dropped-from-props-rf2-dwds9
+  (testing "rf2-dwds9: {:constructor \"x\"} prop is dropped (does not
+            override the prototype's constructor or leak as own property)"
+    (let [^js el (template/as-element [:div {:constructor "leaked"}])
+          props  (.-props el)]
+      (is (not (.call (.. js/Object -prototype -hasOwnProperty)
+                      props "constructor"))
+          "no own 'constructor' slot on the props object"))))
+
+(deftest prototype-string-key-dropped-rf2-dwds9
+  (testing "rf2-dwds9: {:prototype \"x\"} prop is dropped"
+    (let [^js el (template/as-element [:div {:prototype "leaked"}])
+          props  (.-props el)]
+      (is (not (.call (.. js/Object -prototype -hasOwnProperty)
+                      props "prototype"))
+          "no own 'prototype' slot on the props object"))))
+
+(deftest nested-prototype-key-dropped-rf2-dwds9
+  (testing "rf2-dwds9: nested {:style {:__proto__ {...} :color \"red\"}}
+            does NOT leak the evil prototype's slots into the style object"
+    (let [evil   #js {:polluted "yes"}
+          ^js el (template/as-element [:div {:style {:__proto__ evil
+                                                     :color "red"}}])
+          style  (.. el -props -style)]
+      (is (or (nil? (aget style "polluted"))
+              (= js/undefined (aget style "polluted")))
+          "evil prototype slot did NOT pollute the style object")
+      (is (= "red" (.-color style))
+          "legitimate sibling props in the same map survive"))))
+
+(deftest convert-prop-value-reserved-keys-dropped-rf2-dwds9
+  (testing "rf2-dwds9: convert-prop-value at the map? branch drops
+            reserved keys before `aset` — no prototype mutation, no
+            own-property pollution; legitimate sibling keys survive"
+    (let [evil #js {:polluted "yes"}
+          out (template/convert-prop-value
+                {:__proto__ evil :constructor "y" :prototype "z"
+                 :legit "ok"})]
+      (is (= "object" (goog/typeOf out)))
+      (is (= "ok" (aget out "legit"))
+          "legitimate keys flow through")
+      (is (or (nil? (aget out "polluted"))
+              (= js/undefined (aget out "polluted")))
+          "evil prototype slot did NOT become reachable via aget")
+      (doseq [k ["__proto__" "constructor" "prototype"]]
+        (is (not (.call (.. js/Object -prototype -hasOwnProperty) out k))
+            (str "reserved key '" k "' is not an own property"))))))


### PR DESCRIPTION
## Summary

Two `implementation/adapters/reagent-slim` fixes landed together.

### rf2-wyocr (BUG, P2) — `convert-prop-value` fn-prop pass-through

`convert-prop-value` wrapped every fn-typed prop in a fresh variadic closure on each render. The docstring claimed "Fns pass through (event handlers, ref callbacks)" but the code did the opposite, silently defeating `React.memo` / `shouldComponentUpdate` referential-stability for any downstream consumer.

Fix: route `(fn? v)` through verbatim BEFORE the `(ifn? v)` wrapper shim (which still exists for legitimate non-fn `IFn` values — maps/sets/keywords used as functions). The wrapper allocation no longer happens on the hot path; identity is preserved across calls so React's memoisation works.

Found by perf-audit-2.

### rf2-dwds9 (sec-audit, P2) — two findings closed

**HIGH (`reagent2.dom.server`, XSS surface)** — `render-to-static-markup` previously emitted React event-handler props and function-valued props as literal HTML attributes. A string-valued `:on-click "alert(1)"` would have rendered as `onclick="alert(1)"` (an XSS vector); function-valued props would have leaked source via `(str f)`. Both classes are now stripped at `emit-attr`, matching `react-dom/server.renderToStaticMarkup`'s behaviour. The `on*` prefix check handles both kebab- and camelCase shapes; the `fn?`-value check catches non-event props that happen to carry a callback.

**MEDIUM (`reagent2.impl.template`, prototype pollution)** — caches and per-render props objects used `aset` on user-controlled keys with no filtering. A `:__proto__`/`:constructor`/`:prototype` key in a prop map could have mutated the prototype chain of the props object (or shared cache), leaking inherited slots into every subsequent render and potentially injecting reserved React props such as `dangerouslySetInnerHTML` or event handlers.

Defence: drop the reserved key trio (`__proto__`, `prototype`, `constructor`) at the two `aset` chokepoints — `cached-prop-name` returns reserved names verbatim without caching, and `kv-conv` skips the write before it flows into `React.createElement`. (Null-prototype props objects were considered but ruled out: React's host config calls `styles.hasOwnProperty(...)` on nested style objects, which would throw.)

## Diffs

- `implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs` — both fixes
- `implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs` — sec-audit HIGH
- `implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs` — regression tests for both
- `implementation/adapters/reagent-slim/test/reagent2/dom/server_cljs_test.cljs` — XSS attack tests

## Test plan

- [x] `npm run test:cljs` — 1933 tests, 5504 assertions, 0 failures
- [x] `clojure -M:test` in `adapters/reagent-slim/` — 11 tests, 12 assertions, 0 failures
- [x] `npm run test:examples` — all 26 example smoke tests PASS (timer, circle-drawer, counter-slim-and-fast, managed-http-counter all green; these all consume reagent-slim)
- [x] `npm run test:bundle-isolation` — PASS (clean build)
- [x] Identity-pinning regression for fn-prop pass-through (`identical?` check on the same fn passed twice through `convert-prop-value` — both arity forms)
- [x] XSS-shape attack tests for `render-to-static-markup` (string + fn `on-click` values, kebab- and camelCase `on*` shapes, non-event fn props)
- [x] Prototype-pollution attack tests with an "evil" sentinel prototype that would leak `polluted: "yes"` into the props object if the filter were missing

## Beads

- Closes rf2-dwds9
- Closes rf2-wyocr