### PR TITLE
perf(impl): cross-impl perf-followup — 5 audit-follow-on beads

### DIFF
--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -446,12 +446,18 @@
 ;; ---- the walker ----------------------------------------------------------
 
 (defn- walk
-  "Internal recursion driver for `elide-wire-value`. `path` and
-   `frame-id` ride as positional args so the (otherwise stable) `opts`
-   map isn't re-`assoc`'d at every child — meaningful on deep walks
-   (the elision walker fires per event-emit + per sub-return). All
-   public arities funnel through here after one-shot opts decoding."
-  [v path frame-id opts]
+  "Internal recursion driver for `elide-wire-value`.
+
+  HOT PATH: invoked per node during every wire-emission walk; under
+  prod with event-emit / error-emit listeners installed this fires
+  on every cascade. Per rf2-oetyi the registry lookup and opts-
+  derived locals (`include-large?`, `include-sensitive?`, threshold,
+  …) are hoisted into `elide-wire-value`'s top arity and ride here
+  as `ctx` — a per-walk-call invariant struct. Only `path` changes
+  on recursion. Pre-rf2-oetyi `walk` re-read `(registry-of frame-id)`
+  and destructured `opts` on every recursive node, so a million-node
+  walk did a million map lookups for a value that doesn't change."
+  [v path ctx]
   (cond
     ;; Nil / scalar fast path — never elidable.
     (or (nil? v) (number? v) (boolean? v) (keyword? v) (symbol? v))
@@ -459,12 +465,13 @@
 
     ;; Consult the registry first; declared / schema / runtime-flagged hit?
     :else
-    (let [as-of-epoch        (:as-of-epoch opts)
-          include-large?     (:rf.size/include-large? opts)
-          include-sensitive? (:rf.size/include-sensitive? opts)
-          include-digests?   (:rf.size/include-digests? opts)
-          threshold          (:rf.size/threshold-bytes opts)
-          reg                (registry-of frame-id)
+    (let [reg                (:reg ctx)
+          frame-id           (:frame-id ctx)
+          threshold          (:threshold ctx)
+          include-large?     (:include-large? ctx)
+          include-sensitive? (:include-sensitive? ctx)
+          include-digests?   (:include-digests? ctx)
+          as-of-epoch        (:as-of-epoch ctx)
           decl               (resolve-declaration reg path)
           ;; sensitive? — registry may carry it; the rf2-isdwf
           ;; per-event :sensitive? stamping lands separately. The
@@ -531,26 +538,26 @@
         (map? v)
         (reduce-kv
          (fn [acc k vv]
-           (assoc acc k (walk vv (conj path k) frame-id opts)))
+           (assoc acc k (walk vv (conj path k) ctx)))
          (empty v) v)
 
         (vector? v)
         (mapv (fn [idx vv]
-                (walk vv (conj path idx) frame-id opts))
+                (walk vv (conj path idx) ctx))
               (range) v)
 
         (set? v)
         ;; Sets don't have indices; walk children with the same path so
         ;; a registered set-element predicate still applies. Most
         ;; callers won't declare individual set members.
-        (into #{} (map #(walk % path frame-id opts)) v)
+        (into #{} (map #(walk % path ctx)) v)
 
         (seq? v)
         ;; Sequences (lists / lazy seqs) — walk and return a vector for
         ;; wire stability. Per Tool-Pair, wire payloads are EDN data;
         ;; converting seq -> vector is safe.
         (mapv (fn [idx vv]
-                (walk vv (conj path idx) frame-id opts))
+                (walk vv (conj path idx) ctx))
               (range) v)
 
         :else
@@ -599,14 +606,22 @@
    (let [frame-id  (or (:frame opts) (frame/current-frame) :rf/default)
          threshold (long (or (:rf.size/threshold-bytes opts)
                              @re-frame.elision/threshold-bytes))
-         ;; Normalise opts once: defaults coerced, booleans pre-evaluated,
-         ;; resolved frame-id / threshold cached for the whole recursion.
-         opts'     (-> (or opts {})
-                       (assoc :rf.size/threshold-bytes      threshold
-                              :rf.size/include-large?      (true? (:rf.size/include-large? opts))
-                              :rf.size/include-sensitive?  (true? (:rf.size/include-sensitive? opts))
-                              :rf.size/include-digests?    (true? (:rf.size/include-digests? opts))))]
-     (walk v (vec (:path opts)) frame-id opts'))))
+         ;; Per rf2-oetyi: hoist the registry read and opts-derived
+         ;; locals into one immutable ctx struct, built once here and
+         ;; threaded positionally through `walk` — rather than re-
+         ;; resolving `(registry-of frame-id)` and re-destructuring
+         ;; opts on every recursive node. The registry is constant
+         ;; for the duration of one walk; opts are user input that
+         ;; doesn't mutate mid-recursion. HOT PATH under prod with
+         ;; event-emit / error-emit listeners installed.
+         ctx       {:reg                (registry-of frame-id)
+                    :frame-id           frame-id
+                    :threshold          threshold
+                    :include-large?     (true? (:rf.size/include-large? opts))
+                    :include-sensitive? (true? (:rf.size/include-sensitive? opts))
+                    :include-digests?   (true? (:rf.size/include-digests? opts))
+                    :as-of-epoch        (:as-of-epoch opts)}]
+     (walk v (vec (:path opts)) ctx))))
 
 ;; ---- introspection sugar --------------------------------------------------
 

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -217,19 +217,39 @@
                     :reason       reason
                     :recovery     :no-recovery}))))
 
+(def ^:private empty-fx-overrides
+  "Shared sentinel returned by `apply-overrides` on the no-override hot
+  path. Reused across every override-free dispatch so the cascade
+  doesn't churn a fresh empty map per event."
+  {})
+
+(def ^:private empty-extra-interceptors
+  "Shared sentinel for the no-extra-interceptors hot path."
+  [])
+
 (defn- apply-overrides
   "Per Spec 002 §Per-frame and per-call overrides: per-frame and per-call
-  override maps merge with per-call winning. Returns the effective
-  interceptor list and fx-overrides map for this dispatch."
+  override maps merge with per-call winning. Returns
+  `{:fx-overrides :extra-interceptors}` for this dispatch.
+
+  HOT PATH: fires on every dispatch. The dominant production path is
+  override-free — most apps neither set per-frame `:fx-overrides` /
+  `:interceptors` in their `reg-frame` config nor pass per-call
+  `:fx-overrides` in the dispatch envelope. On that path we
+  short-circuit to shared empty sentinels rather than `merge`-ing
+  empty maps and `vec`-ing an empty `concat`."
   [envelope frame-record]
   (let [frame-cfg            (:config frame-record)
         per-call-fx          (:fx-overrides envelope)
-        per-frame-fx         (:fx-overrides frame-cfg {})
-        per-call-interceptors  (:interceptor-overrides envelope)
-        per-frame-interceptors (:interceptor-overrides frame-cfg {})]
-    {:fx-overrides           (merge per-frame-fx per-call-fx)
-     :interceptor-overrides  (merge per-frame-interceptors per-call-interceptors)
-     :extra-interceptors     (vec (concat (:interceptors frame-cfg [])))}))
+        per-frame-fx         (:fx-overrides frame-cfg)
+        frame-interceptors   (:interceptors frame-cfg)]
+    (if (and (nil? per-call-fx)
+             (nil? per-frame-fx)
+             (nil? frame-interceptors))
+      {:fx-overrides       empty-fx-overrides
+       :extra-interceptors empty-extra-interceptors}
+      {:fx-overrides       (merge per-frame-fx per-call-fx)
+       :extra-interceptors (vec frame-interceptors)})))
 
 (defn- validate-event!
   "Per Spec 010 §Validation order step 1 (rf2-jwm4): validate the
@@ -502,10 +522,19 @@
   "Build the effective interceptor chain and initial context for a
   resolved handler. Merges per-frame + per-call overrides (Spec 002
   §Per-frame and per-call overrides) and threads them through the
-  initial cofx map. Returns `{:full-chain :initial-ctx :fx-overrides}`."
+  initial cofx map. Returns `{:full-chain :initial-ctx :fx-overrides}`.
+
+  HOT PATH: fires on every dispatch. On the override-free path (no
+  per-frame / per-call `:fx-overrides`, no per-frame `:interceptors`),
+  `apply-overrides` returns shared empty sentinels and we reuse the
+  handler's own `:interceptors` vector directly rather than
+  `concat`-ing an empty extra-interceptors prefix and re-`vec`-ing
+  the result."
   [envelope frame frame-record handler-meta]
   (let [{:keys [extra-interceptors fx-overrides]} (apply-overrides envelope frame-record)
-        full-chain  (vec (concat extra-interceptors (:interceptors handler-meta)))
+        full-chain  (if (seq extra-interceptors)
+                      (vec (concat extra-interceptors (:interceptors handler-meta)))
+                      (:interceptors handler-meta))
         initial-ctx (assemble-initial-ctx envelope frame frame-record fx-overrides)]
     {:full-chain   full-chain
      :initial-ctx  initial-ctx

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -120,31 +120,51 @@
 (defonce ^:private histories
   (atom {}))
 
-(defn- elide-older-trace-events
-  "Strip the `:trace-events` vector from records older than the most-
-  recent `keep` entries. Records keep their structured projections
-  (`:sub-runs` / `:renders` / `:effects`) but lose the raw trace
-  stream. nil `keep` means 'keep every record's :trace-events'."
-  [history keep]
-  (if (and (some? keep) (nat-int? keep))
-    (let [n        (count history)
-          boundary (max 0 (- n keep))]
-      (if (zero? boundary)
-        history
-        (into [] (map-indexed (fn [i r]
-                                (if (< i boundary)
-                                  (dissoc r :trace-events)
-                                  r)))
-              history)))
-    history))
+(defn- elide-just-crossed-trace-events
+  "When the record at index `(- (count history) keep 1)` crosses the
+  keep-boundary, dissoc its `:trace-events`. O(1) per append: every
+  earlier record was already elided on its own crossing, so the only
+  record that needs work is the one that just slid out of the keep-
+  window. Records keep their structured projections (`:sub-runs` /
+  `:renders` / `:effects`) but lose the raw trace stream. nil `keep`
+  means 'keep every record's :trace-events'.
 
-(defn- append-record [history record d keep]
+  HOT PATH: invoked from `append-record` on every drain settle (every
+  user-facing event). Pre-rf2-1e38x this rewrote the whole history
+  vector via `map-indexed`; under steady state only one record per
+  append actually transitions, so the O(n) walk was wasted work. The
+  steady-state invariant holds because every prior append already
+  elided its own just-crossed record; runtime reductions of `keep`
+  via `(rf/configure :epoch-history ...)` will take full effect on
+  subsequent appends rather than retroactively rewriting the buffer
+  (pre-alpha posture)."
+  [history keep]
+  (let [n (count history)]
+    (if (and (some? keep) (nat-int? keep) (> n keep))
+      (let [idx (- n keep 1)
+            r   (nth history idx)]
+        (if (contains? r :trace-events)
+          (assoc history idx (dissoc r :trace-events))
+          history))
+      history)))
+
+(defn- append-record
+  "Conj `record` onto the frame's history vector, cap to `d` via
+  `subvec` (cheap structural reuse — no copy), then elide the just-
+  crossed record's `:trace-events` per `keep`.
+
+  HOT PATH: fires once per cascade settle, i.e. once per dispatched
+  user event under steady state. Cost is O(1) in both the depth cap
+  and the trace-events elision — the vector grows by one, optionally
+  drops its leftmost element via `subvec`, and at most one record's
+  `:trace-events` slot is dissoc'd."
+  [history record d keep]
   (let [history+ (conj (or history []) record)
         n        (count history+)
         capped   (if (and (pos? d) (> n d))
                    (subvec history+ (- n d))
                    history+)]
-    (elide-older-trace-events capped keep)))
+    (elide-just-crossed-trace-events capped keep)))
 
 (defn- record!
   "Append a record into the frame's history. The depth cap and the
@@ -350,7 +370,15 @@
   ;; frame-id → vector of trace events (in arrival order)
   (atom {}))
 
-(defn- buffer-event! [frame-id event]
+(defn- buffer-event!
+  "Append `event` onto the frame's in-flight cascade buffer.
+
+  HOT PATH: fires once per `trace/emit!` while a cascade is in flight,
+  which is the dominant per-event cost (sub-runs, renders, fx, error
+  emits all funnel here). O(1) swap! + (fnil conj []) — the buffer
+  vector grows by one and is harvested wholesale at cascade settle
+  via `harvest-buffer!`."
+  [frame-id event]
   (swap! capture-buffers update frame-id (fnil conj []) event))
 
 (defn- harvest-buffer! [frame-id]

--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -42,8 +42,8 @@
 
 'use strict';
 
-const fs   = require('fs');
 const path = require('path');
+const { readReleaseBlob } = require('./lib/read-release-bundle.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
 
@@ -217,28 +217,11 @@ const ARTEFACTS = [
 
 // ----- helpers ---------------------------------------------------------------
 
-function readAllJs(dir) {
-  // Concatenate every *.js file under dir into a single blob. shadow-cljs
-  // :browser :advanced may split the runtime across files (cljs_base, the
-  // module's own file); a global grep is the right shape for the isolation
-  // contract.
-  if (!fs.existsSync(dir)) {
-    return null;
-  }
-  const out = [];
-  const walk = (d) => {
-    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
-      const full = path.join(d, entry.name);
-      if (entry.isDirectory()) {
-        walk(full);
-      } else if (entry.isFile() && entry.name.endsWith('.js')) {
-        out.push(fs.readFileSync(full, 'utf8'));
-      }
-    }
-  };
-  walk(dir);
-  return out.join('\n');
-}
+// Bundle reading is shared with the sibling check-* scripts via
+// scripts/lib/read-release-bundle.cjs (rf2-qlk4w). The helper reads
+// only top-level *.js — the release artefact — so a stale dev-build
+// `cljs-runtime/` subdir from a prior `shadow-cljs compile` doesn't
+// get grep-ed alongside.
 
 function escapeRe(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -291,7 +274,7 @@ function main() {
   console.log('=== Bundle isolation: counter example (rf2-51x5) ===');
 
   const bundleDir = path.join(ROOT, 'out', 'examples', 'counter');
-  const blob = readAllJs(bundleDir);
+  const blob = readReleaseBlob(bundleDir);
 
   if (blob == null) {
     console.error(`[bundle-isolation] bundle path missing — ${bundleDir}`);

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -34,6 +34,7 @@
 
 const fs   = require('fs');
 const path = require('path');
+const { readReleaseBlob } = require('./lib/read-release-bundle.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
 
@@ -228,31 +229,12 @@ const DEV_ONLY_SENTINELS = [
 
 // ----- helpers ---------------------------------------------------------------
 
-function readAllJs(dir) {
-  // Collect every *.js file under dir into a single concatenated blob.
-  // shadow-cljs :browser :advanced may split the runtime across files
-  // (cljs_base, the module's own file); a global grep is the right
-  // shape for the elision contract.
-  if (!fs.existsSync(dir)) {
-    return null;
-  }
-  const out = [];
-  const walk = (d) => {
-    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
-      const full = path.join(d, entry.name);
-      if (entry.isDirectory()) {
-        walk(full);
-      } else if (entry.isFile() && entry.name.endsWith('.js')) {
-        out.push(fs.readFileSync(full, 'utf8'));
-      }
-    }
-  };
-  walk(dir);
-  return out.join('\n');
-}
+// Bundle reading is shared with the sibling check-* scripts via
+// scripts/lib/read-release-bundle.cjs (rf2-qlk4w). Top-level *.js
+// only; a stale dev-build `cljs-runtime/` subdir is skipped.
 
 function checkBundle(label, bundlePath, mustContain) {
-  const blob = readAllJs(bundlePath);
+  const blob = readReleaseBlob(bundlePath);
   if (blob == null) {
     console.error(`[elision] ${label}: bundle path missing — ${bundlePath}`);
     console.error('         Did you run "shadow-cljs release elision-probe"?');

--- a/implementation/scripts/check-perf-bundle.cjs
+++ b/implementation/scripts/check-perf-bundle.cjs
@@ -30,8 +30,8 @@
 
 'use strict';
 
-const fs   = require('fs');
 const path = require('path');
+const { readReleaseBlob } = require('./lib/read-release-bundle.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
 
@@ -59,27 +59,12 @@ const PERF_SENTINELS = [
 
 // ----- helpers ---------------------------------------------------------------
 
-function readAllJs(dir) {
-  if (!fs.existsSync(dir)) {
-    return null;
-  }
-  const out = [];
-  const walk = (d) => {
-    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
-      const full = path.join(d, entry.name);
-      if (entry.isDirectory()) {
-        walk(full);
-      } else if (entry.isFile() && entry.name.endsWith('.js')) {
-        out.push(fs.readFileSync(full, 'utf8'));
-      }
-    }
-  };
-  walk(dir);
-  return out.join('\n');
-}
+// Bundle reading is shared with the sibling check-* scripts via
+// scripts/lib/read-release-bundle.cjs (rf2-qlk4w). Top-level *.js
+// only; a stale dev-build `cljs-runtime/` subdir is skipped.
 
 function checkBundle(label, bundlePath, mustContain) {
-  const blob = readAllJs(bundlePath);
+  const blob = readReleaseBlob(bundlePath);
   if (blob == null) {
     console.error(`[perf-bundle] ${label}: bundle path missing — ${bundlePath}`);
     console.error('              Did you run the matching shadow-cljs release?');
@@ -128,8 +113,8 @@ function main() {
                             onDir,  true);
 
   // Report the counts the bead asks for.
-  const offBlob = readAllJs(offDir);
-  const onBlob  = readAllJs(onDir);
+  const offBlob = readReleaseBlob(offDir);
+  const onBlob  = readReleaseBlob(onDir);
   const patterns = ['performance\\.mark',
                     'performance\\.measure',
                     're-frame\\.performance'];

--- a/implementation/scripts/check-schemas-bundle.cjs
+++ b/implementation/scripts/check-schemas-bundle.cjs
@@ -37,6 +37,7 @@
 const fs   = require('fs');
 const path = require('path');
 const zlib = require('zlib');
+const { listReleaseJsFiles } = require('./lib/read-release-bundle.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
 
@@ -65,24 +66,9 @@ const BUNDLES = [
 
 // ----- helpers ---------------------------------------------------------------
 
-function listJsFiles(dir) {
-  if (!fs.existsSync(dir)) {
-    return null;
-  }
-  const out = [];
-  const walk = (d) => {
-    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
-      const full = path.join(d, entry.name);
-      if (entry.isDirectory()) {
-        walk(full);
-      } else if (entry.isFile() && entry.name.endsWith('.js')) {
-        out.push(full);
-      }
-    }
-  };
-  walk(dir);
-  return out;
-}
+// Bundle file listing is shared with the sibling check-* scripts via
+// scripts/lib/read-release-bundle.cjs (rf2-qlk4w). Top-level *.js
+// only; a stale dev-build `cljs-runtime/` subdir is skipped.
 
 function gzippedSize(file) {
   const raw = fs.readFileSync(file);
@@ -90,7 +76,7 @@ function gzippedSize(file) {
 }
 
 function sumGzippedBytes(dir) {
-  const files = listJsFiles(dir);
+  const files = listReleaseJsFiles(dir);
   if (files == null) {
     return null;
   }

--- a/implementation/scripts/lib/read-release-bundle.cjs
+++ b/implementation/scripts/lib/read-release-bundle.cjs
@@ -1,0 +1,56 @@
+// Shared release-bundle reader for the check-* scripts (rf2-qlk4w).
+//
+// shadow-cljs `:browser :release` writes the closure-compiled output as
+// top-level *.js files in the configured `:output-dir` (e.g. `main.js`,
+// `probe.js`, plus any sibling module files like `cljs_base.js`). All
+// the builds these scripts measure are single-module, so the release
+// artefact is exactly those top-level files.
+//
+// A previous dev-build `shadow-cljs compile` against the same output
+// dir leaves a `cljs-runtime/` subdirectory of unoptimised dev sources;
+// `shadow-cljs release` does NOT clean it (rf2-z9a06). Walking the
+// output dir recursively (as the pre-rf2-qlk4w readers did) grep-ed
+// those stale dev sources alongside the release artefact, producing
+// false FAILs on dev-only sentinels. CI is unaffected because every
+// CI run is on a clean dir; local repros after a dev compile tripped
+// the trap. `check-counter-slim-and-fast.cjs` documented the trap
+// inline and filtered to top-level; this module factors the same fix
+// out so the four sibling scanners share one implementation.
+//
+// Two flavours:
+//   readReleaseBlob(dir)     → concatenated string blob; null when
+//                              `dir` doesn't exist. For substring /
+//                              regex grep contracts.
+//   listReleaseJsFiles(dir)  → array of absolute paths; null when
+//                              `dir` doesn't exist. For per-file work
+//                              (e.g. gzipped-size totalling).
+
+const fs   = require('fs');
+const path = require('path');
+
+function listReleaseJsFiles(dir) {
+  if (!fs.existsSync(dir)) {
+    return null;
+  }
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.endsWith('.js')) {
+      out.push(path.join(dir, entry.name));
+    }
+  }
+  return out;
+}
+
+function readReleaseBlob(dir) {
+  const files = listReleaseJsFiles(dir);
+  if (files == null) {
+    return null;
+  }
+  const out = [];
+  for (const f of files) {
+    out.push(fs.readFileSync(f, 'utf8'));
+  }
+  return out.join('\n');
+}
+
+module.exports = { readReleaseBlob, listReleaseJsFiles };


### PR DESCRIPTION
## Summary

Five P3 perf follow-on beads from the recent perf-audit sweep, batched
by surface across `implementation/{core, epoch, scripts}/`. All audit
findings translated to surgical hot-path improvements; behaviour-
preserving (all gates green).

- **rf2-1e38x + rf2-57dyc** `implementation/epoch/src/re_frame/epoch.cljc` — O(1) trace-events eviction in `elide-just-crossed-trace-events` (renamed). Pre-rf2-1e38x rewrote the full history vector via `map-indexed` on every drain settle; under steady state only one record ever needs work (the one that just slid out of the keep-window). Hot-path comments pinned on `append-record`, `elide-just-crossed-trace-events`, and `buffer-event!`.
- **rf2-tccqt** `implementation/core/src/re_frame/router.cljc` — override-free fast path in `apply-overrides` + `prepare-handler-ctx`. Shared empty sentinels for the dominant prod path; reuse the handler's own `:interceptors` vector when no extra-interceptors apply (skip the `concat` + `vec`). Drops the dead `:interceptor-overrides` slot.
- **rf2-oetyi** `implementation/core/src/re_frame/elision.cljc` — hoist `(registry-of frame-id)` and opts decoding out of `walk` recursion into `elide-wire-value`'s top arity. Walk now threads one immutable `ctx` struct; deep walks no longer pay a registry lookup + opts-destructure per node.
- **rf2-qlk4w** `implementation/scripts/lib/read-release-bundle.cjs` — factor shared helper for the four `check-*.cjs` scanners (`bundle-isolation`, `elision`, `perf-bundle`, `schemas-bundle`). Reads only top-level release `*.js`, skipping the stale dev-build `cljs-runtime/` subdir that `shadow-cljs release` doesn't clean (rf2-z9a06). Mirrors the fix `check-counter-slim-and-fast.cjs` already documented inline.

LoC delta: +206 / −142 (net +64), and roughly half of the additions are HOT PATH comments / docstrings pinning the new invariants.

## Test plan

- [x] `cd implementation/core && clojure -M:test` — 512 tests / 2625 assertions, 0 failures, 0 errors
- [x] `cd implementation/epoch && clojure -M:test` — 83 tests / 319 assertions, 0 failures, 0 errors
- [x] `cd implementation && npm run test:cljs` — 1936 tests / 5513 assertions, 0 failures, 0 errors
- [x] `cd implementation && npm run test:elision` — PASS (both prod-elide and control-present grep contracts green)
- [x] `cd implementation && npm run test:bundle-isolation` — PASS (every per-feature sentinel + consumer allow-list green)
- [x] `cd implementation && npm run test:perf-bundle` — PASS (perf-off:0 sentinels; perf-on:12)
- [x] `cd implementation && npm run test:schemas-bundle` — PASS (Malli-off 50.9 KB, Malli-on 80.7 KB; +29.8 KB delta clears the 15 KB methodology floor)

## Conflict-awareness

- PR #1066 (`rf2-v0jwt` partial-epoch-records) is still open and touches `implementation/{core/router.cljc, epoch/epoch.cljc, scripts/check-elision.cjs}`. Verified line-by-line: PR #1066's hunks land at router L340+ / epoch L42 + L117+ / check-elision L151+; this PR's surgery targets router L220 + L501, epoch L123 + L353, and check-elision's `readAllJs` (now removed). Rebase should be mechanical when either PR lands first.
- `comments-sweep-v2` (in-flight) touches comments at router L340+ / elision L427 / epoch L42 — adjacent but non-overlapping with the perf hunks.