### PR TITLE
refactor(comments): comments-sweep-v2 — 12 reopened beads (fresh against current main)

### DIFF
--- a/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
+++ b/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
@@ -1,31 +1,18 @@
 (ns re-frame.adapter.helix
-  "The Helix adapter — the third canonical browser substrate (rf2-2qit).
-  Per Spec 006 §CLJS reference: Helix as alternative substrate.
+  "The Helix adapter — third canonical browser substrate, targeting the
+  Helix 0.2.x line. Per Spec 006 §CLJS reference: Helix as alternative
+  substrate. Ships in `day8/re-frame2-helix`; dependency flows adapter
+  → core.
 
-  Ships in its own Maven artefact (day8/re-frame2-helix) per
-  Spec 006 §Adapter shipping convention (rf2-0hxm). Apps that use Helix
-  depend on both day8/re-frame2 (core) and this artefact; apps
-  targeting Reagent depend on day8/re-frame2-reagent instead; apps
-  targeting UIx depend on day8/re-frame2-uix instead. Core does
-  *not* :require this ns — the dependency direction is adapter → core.
-
-  Per rf2-2qit Decision 2 the React frame-context lives in
-  `re-frame.adapter.context` (CLJS-only file in core); this adapter
-  consumes the *same* createContext object the Reagent and UIx
-  adapters consume, so a future mixed-substrate app's frame-provider
-  chain composes across substrates.
-
-  Per rf2-2qit Decision 8 we target the Helix 0.2.x line.
-
-  Substrate-spine sharing (rf2-3vwbx). The container quartet, derived
-  value, render-root, render-to-string, frame-provider, use-subscribe,
-  flush-views!, source-coord wrapper, and warn-once-cache logic all
-  come from `re-frame.substrate.spine` — that ns hosts the
-  React-shaped-substrate spine UIx and Helix share byte-for-byte. The
-  Helix-specific configuration here is the gensym-prefix triple, the
-  substrate-name (\"Helix\") used in warn-once text, and the helix.hooks
-  use-memo*/use-callback* (which want JS-array deps; the spine passes
-  JS arrays unconditionally)."
+  Shares the React-shaped substrate machinery (container quartet,
+  derived value, render-root, render-to-string, frame-provider, use-
+  subscribe, flush-views!, source-coord wrapper, warn-once-cache) with
+  the UIx adapter via `re-frame.substrate.spine`. Helix-specific
+  configuration: gensym prefixes, substrate name (used in warn-once
+  text), and helix.hooks `use-memo*` / `use-callback*` (the spine
+  passes JS-array deps unconditionally). The React frame-context
+  comes from `re-frame.adapter.context` so a mixed-substrate app's
+  frame-provider chain composes across substrates."
   (:require [reagent.core        :as r]
             [reagent.ratom       :as ratom]
             [helix.hooks         :as helix-hooks]

--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -1,35 +1,14 @@
 (ns re-frame.adapter.reagent-slim
   "The day8/reagent-slim adapter — emits the 9-key substrate map for
-  `re-frame.substrate.adapter`. Drop-in shape-compatible with the
-  bridge adapter `re-frame.adapter.reagent`; internals route through
-  the `reagent2.*` rewrite of Reagent (no stock-Reagent dep).
-
-  Usage:
+  `re-frame.substrate.adapter`. Shape-compatible with the bridge
+  adapter `re-frame.adapter.reagent`; internals route through the
+  `reagent2.*` rewrite of Reagent (no stock-Reagent dep).
 
       (require '[re-frame.adapter.reagent-slim :as reagent-slim])
       (rf/init! reagent-slim/adapter)
 
-  Public surface:
-
-    adapter             — the 9-key substrate spec map
-    set-hiccup-emitter! — wires SSR's render-to-string (rf2-uo7v)
-
-  Detail lives in:
-
-    DESIGN-RATIONALE.md — the why (separate-ns rationale, slim vs
-                          bridge split, render-path mechanics)
-    IMPL-SPEC.md §2.1   — the 9-key map contract
-    IMPL-SPEC.md §9     — late-bind hook table + per-hook routing
-    IMPL-SPEC.md §13.1  — artefact-publication shape
-
-  Late-bind hooks installed at ns-load time route through
-  `(substrate-adapter/current-adapter)` so the active adapter's impl
-  wins when multiple adapter ns'es are loaded into the same bundle
-  (test fixtures, story builds). See the `route-hook!` calls at the
-  bottom of this file.
-
-  Pre-release: until the bridge is retired (post-1.0), apps opt in
-  to the rewrite by requiring this ns."
+  See IMPL-SPEC.md §2.1 (9-key map contract), §9 (late-bind hook table),
+  §13.1 (artefact-publication shape) and DESIGN-RATIONALE.md."
   (:require [reagent2.core             :as r]
             [reagent2.ratom            :as ratom]
             [reagent2.dom.client       :as rdc]

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -1,19 +1,16 @@
 (ns re-frame.adapter.uix
-  "The UIx adapter — the second canonical browser substrate (rf2-3yij).
-  Per Spec 006 §CLJS reference: UIx as alternative substrate.
-  Ships in its own Maven artefact (day8/re-frame2-uix) per
-  Spec 006 §Adapter shipping convention (rf2-0hxm); core does NOT
-  :require this ns (dependency direction: adapter → core). Targets
-  UIx 2.x (hooks-based) per rf2-3yij Decision 8.
+  "The UIx adapter — second canonical browser substrate, targeting UIx
+  2.x (hooks-based). Per Spec 006 §CLJS reference: UIx as alternative
+  substrate. Ships in `day8/re-frame2-uix`; dependency flows adapter
+  → core.
 
-  Substrate-spine sharing (rf2-3vwbx). The container quartet, derived
-  value, render-root, render-to-string, frame-provider, use-subscribe,
-  flush-views!, source-coord wrapper, and warn-once-cache logic come
-  from `re-frame.substrate.spine`. The UIx-specific configuration
-  here is the gensym-prefix triple, the substrate-name (\"UIx\") used
-  in warn-once text, and the runtime hook fns from `uix.hooks.alpha`
-  (the spine passes JS-array deps; `uix.hooks.alpha/use-memo` and
-  `use-callback` are the runtime fns the `uix.core` macros expand to)."
+  Shares the React-shaped substrate machinery (container quartet,
+  derived value, render-root, render-to-string, frame-provider, use-
+  subscribe, flush-views!, source-coord wrapper, warn-once-cache) with
+  the Helix adapter via `re-frame.substrate.spine`. UIx-specific
+  configuration: gensym prefixes, substrate name (used in warn-once
+  text), and the runtime hook fns from `uix.hooks.alpha` (the
+  `uix.core` macros expand to these)."
   (:require [reagent.core      :as r]
             [reagent.ratom     :as ratom]
             [uix.core          :as uix]

--- a/implementation/core/src/re_frame/adapter/context.cljs
+++ b/implementation/core/src/re_frame/adapter/context.cljs
@@ -22,8 +22,8 @@
        Provider/Consumer pairs do not interact. Putting the createContext
        call in a single shared ns guarantees identity.
 
-  Per rf2-3yij Decision 2: factored out of re-frame.views for the UIx
-  adapter to read."
+  Factored out of re-frame.views so every React-shaped adapter (UIx,
+  Helix) reads the same context object."
   (:require ["react" :as React]
             [re-frame.frame :as frame]
             [re-frame.trace :as trace]))
@@ -118,8 +118,7 @@
   site (`_currentValue`) was a shape `coerce-context-value` cannot
   resolve to a frame keyword — typically nil, false, a number, an
   empty string, or a JS object. Recovery is `:replaced-with-default`:
-  the resolution chain falls through to `:rf/default` (current
-  observable behaviour preserved). Per rf2-8q66."
+  the resolution chain falls through to `:rf/default`."
   [v]
   (trace/emit-error! :rf.error/frame-context-corrupted
                      {:received v

--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -177,11 +177,10 @@
                                             (use `cofx/no-value` for the
                                             no-value path with a call-site)
 
-  The 3-arity form is what the `re-frame.core/inject-cofx` macro expands
-  to (per rf2-ts1a); it captures `(meta &form)` at the user call site
-  so error events emitted from the cofx body carry the invocation
-  coord. The 1-/2-arity forms wrap to the 3-arity with a `nil`
-  call-site.
+  The 3-arity form is what the `re-frame.core/inject-cofx` macro
+  expands to; it captures `(meta &form)` at the user call site so
+  error events emitted from the cofx body carry the invocation coord.
+  The 1-/2-arity forms wrap to the 3-arity with a `nil` call-site.
 
   See also: `reg-cofx`, `re-frame.core/inject-cofx` (macro form with
   call-site capture)."
@@ -207,7 +206,7 @@
            (let [frame-id        (interceptor/get-coeffect ctx :frame)
                  active-platform (active-platform-for-frame frame-id)]
              (if (cofx-runs-on-platform? meta active-platform)
-               ;; Per rf2-ryri7: publish the cofx handler's HandlerScope.
+               ;; Publish the cofx handler's HandlerScope.
                ;; `:trigger-handler` / `:sensitive?` / `:no-emit?` come
                ;; from the cofx's registration meta per Spec 009's
                ;; "innermost in-scope handler" rule. `:call-site` is

--- a/implementation/core/src/re_frame/conformance.cljc
+++ b/implementation/core/src/re_frame/conformance.cljc
@@ -107,10 +107,9 @@
     (case (first form)
       :event-arg    (let [[_ idx default-val] form
                           v (get (:event ctx) idx)]
-                      ;; The 3rd element is unconditionally a default-for-nil.
-                      ;; Per rf2-xb5o (resolves rf2-pz9f): no type-dispatch on
-                      ;; the 3rd element. For map-value key-access, use the
-                      ;; explicit [:get-event-arg n :key] form below.
+                      ;; The 3rd element is unconditionally a default-for-nil
+                      ;; — no type-dispatch. For map-value key-access, use
+                      ;; the explicit [:get-event-arg n :key] form below.
                       (if (and (>= (count form) 3) (nil? v))
                         default-val
                         v))
@@ -348,11 +347,10 @@
   actor id; it returns an updated :data map. The runtime patches the
   result back into the snapshot at :data.
 
-  Per rf2-een2 / rf2-smba: the body's :set paths are DATA-relative —
-  uniform with regular machine actions, whose canonical contract is
-  (fn [data event] effects) and whose :set paths assoc-in into :data.
-  So [:set [:pending] x] writes data.:pending = x. (Pre-rf2-een2
-  semantics treated paths as snapshot-relative; that asymmetry is gone.)"
+  The body's `:set` paths are DATA-relative — uniform with regular
+  machine actions, whose canonical contract is (fn [data event] effects)
+  and whose `:set` paths `assoc-in` into `:data`. So
+  `[:set [:pending] x]` writes `data.:pending = x`."
   [steps]
   (fn [data spawned-id]
     (let [synthetic-event [::on-spawn spawned-id]]

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -7,22 +7,22 @@
 
   Topology — this ns is a thin façade:
 
-    - Optional-artefact wrappers (rf2-hoiu) live in `re-frame.core-
-      <feature>` sibling namespaces (`flows`, `routing`, `schemas`,
-      `machines`, `ssr`, `epoch`, `http`); each looks up its target
-      fn through the late-bind hook table so requiring this ns does
-      NOT pull the feature artefacts.
-    - Macro-helper code is factored (per rf2-4rnui) into three
-      siblings — `core-reg-macros`, `core-call-site-macros`,
-      `core-reg-view-macro` — keeping each leaf under the rf2-zkca8
-      250-LoC ceiling. The user-facing `defmacro`s themselves stay in
-      THIS ns (so `rf/reg-event-db` etc. resolve alias-qualified per
-      Clojure's standard `ns-alias/Var` lookup); each is a one-line
-      shell that delegates to the sibling-ns expansion helper.
+    - Optional-artefact wrappers live in `re-frame.core-<feature>`
+      sibling namespaces (`flows`, `routing`, `schemas`, `machines`,
+      `ssr`, `epoch`, `http`); each looks up its target fn through
+      the late-bind hook table so requiring this ns does NOT pull
+      the feature artefacts.
+    - Macro-helper code is factored into three siblings —
+      `core-reg-macros`, `core-call-site-macros`, `core-reg-view-macro`
+      — keeping each leaf under the 250-LoC ceiling. The user-facing
+      `defmacro`s themselves stay in THIS ns (so `rf/reg-event-db`
+      etc. resolve alias-qualified per Clojure's standard
+      `ns-alias/Var` lookup); each is a one-line shell that delegates
+      to the sibling-ns expansion helper.
 
-  File-naming uses the flat dash-form (`core_X.cljc`, per rf2-2vbm):
-  CLJS `goog.provide` for `re-frame.core` overwrites its parent
-  object, which would wipe a previously-loaded `re-frame.core.X`."
+  File-naming uses the flat dash-form (`core_X.cljc`) because CLJS
+  `goog.provide` for `re-frame.core` overwrites its parent object,
+  which would wipe a previously-loaded `re-frame.core.X`."
   (:require [re-frame.registrar :as registrar]
             [re-frame.frame :as frame]
             [re-frame.router :as router]
@@ -101,11 +101,11 @@
 
 ;; ---- reg-* macros (JVM-only; CLJS sees them via :require-macros) --------
 ;;
-;; Each `defreg-macro` form below expands (per rf2-bd6zl) to a
-;; `defmacro` IN THIS ns — so `rf/reg-event-db` resolves alias-
-;; qualified per Clojure's `ns-alias/Var` lookup. The expansion
-;; captures source-coords at the user's call site and splices args
-;; through to the fully-qualified delegate fn.
+;; Each `defreg-macro` form below expands to a `defmacro` IN THIS ns
+;; — so `rf/reg-event-db` resolves alias-qualified per Clojure's
+;; `ns-alias/Var` lookup. The expansion captures source-coords at the
+;; user's call site and splices args through to the fully-qualified
+;; delegate fn.
 
 #?(:clj
    (do
@@ -313,9 +313,9 @@
 
 ;; ---- dispatch and subscribe ----------------------------------------------
 ;;
-;; Per rf2-ts1a — each surface ships as a macro + `*`-fn pair (Q1=C).
-;; The macros expand to `re-frame.core/dispatch*` / `subscribe*` etc.,
-;; so those defs must live here.
+;; Each surface ships as a macro + `*`-fn pair. The macros expand to
+;; `re-frame.core/dispatch*` / `subscribe*` etc., so those defs must
+;; live here.
 
 (def dispatch*       router/dispatch!)
 (def dispatch-sync*  router/dispatch-sync!)
@@ -397,11 +397,10 @@
 
 ;; ---- frame-aware closures (runtime side) ---------------------------------
 ;;
-;; Per rf2-d4sf the public `current-frame` exposes the 3-tier resolution
-;; chain (dynamic var → React context → `:rf/default`) at every user-
-;; facing surface that flows through `(dispatcher)` / `(subscriber)` /
-;; `bound-fn`. The chain is single-sourced through
-;; `frame/resolve-current-frame` (rf2-jj8xf).
+;; The public `current-frame` exposes the 3-tier resolution chain
+;; (dynamic var → React context → `:rf/default`) at every user-facing
+;; surface that flows through `(dispatcher)` / `(subscriber)` /
+;; `bound-fn`. Single-sourced through `frame/resolve-current-frame`.
 
 (defn current-frame
   "Return the active frame at the call site. Resolution chain: dynamic
@@ -629,7 +628,7 @@
                   (cond-> {:where    'rf/init!
                            :expected "adapter spec map"
                            :recovery :no-recovery
-                           :reason   "rf/init! takes the adapter spec map directly — there is no keyword form, no nil form, and no default-adapter registry. Require the adapter ns and pass its `adapter` Var: (rf/init! reagent/adapter). Per rf2-agql the default-adapter registry was removed."}
+                           :reason   "rf/init! takes the adapter spec map directly — there is no keyword form, no nil form, and no default-adapter registry. Require the adapter ns and pass its `adapter` Var: (rf/init! reagent/adapter)."}
                     (some? received) (assoc :received received)))))
 
 (defn init!

--- a/implementation/core/src/re_frame/core_call_site_macros.cljc
+++ b/implementation/core/src/re_frame/core_call_site_macros.cljc
@@ -1,32 +1,27 @@
 (ns re-frame.core-call-site-macros
-  "Helpers for the call-site-capturing macros — `dispatch`, `dispatch-
-  sync`, `subscribe`, `inject-cofx`. Per rf2-ts1a each user-facing
-  surface ships as a macro + `*`-fn pair (Q1=C: existing-name macro,
-  fn-form gets the `*` suffix; same convention as `reg-view` /
-  `reg-view*` and `reg-machine` / `reg-machine*` per Conventions
-  §`*`-suffix naming).
+  "Helpers for the call-site-capturing macros — `dispatch`,
+  `dispatch-sync`, `subscribe`, `inject-cofx`. Each user-facing surface
+  ships as a macro + `*`-fn pair (Conventions §`*`-suffix naming).
 
-  Carved out of `re-frame.core` per rf2-4rnui so the public namespace
-  stays under the 250-LoC leaf ceiling (rf2-zkca8). The user-facing
-  `defmacro dispatch` / `subscribe` / etc. shells live in
-  `re-frame.core` itself (they MUST, so `rf/dispatch` resolves alias-
-  qualified per Clojure's standard `ns-alias/Var` lookup); each shell
-  is a one-line call into the `build-…-form` plain fns here.
+  Carved out of `re-frame.core` so the public namespace stays under the
+  250-LoC leaf ceiling. The user-facing `defmacro dispatch` /
+  `subscribe` / etc. shells live in `re-frame.core` itself (they MUST,
+  so `rf/dispatch` resolves alias-qualified per Clojure's standard
+  `ns-alias/Var` lookup); each shell is a one-line call into a
+  `build-…-form` plain fn here.
 
   Each shell emits an `(if interop/debug-enabled? <stamping> <plain>)`
   branch around the matching `*`-fn call. Under `:advanced` +
   `goog.DEBUG=false` the closure compiler constant-folds the gate to
   false and the entire stamping branch — including the literal
-  `:rf.trace/call-site` map — DCEs. Per Q3=B dev-only elision.
+  `:rf.trace/call-site` map — DCEs.
 
   `emit-error!` reads `trace/*handler-scope*`'s `:call-site` slot and
-  attaches the value as `:rf.trace/call-site` (Q2=A flat sibling of
+  attaches the value as `:rf.trace/call-site` (a flat sibling of
   `:rf.trace/trigger-handler`) on the emitted event. The `coords-form`
   helper is reused from `re-frame.source-coords` so the literal map
   carries the same `{:ns :file :line :column}` shape as registration-
-  site coords (rf2-mdjp `:file` resolution rules apply identically).
-
-  File naming uses the flat dash-form (per rf2-2vbm)."
+  site coords."
   (:require [re-frame.source-coords :as source-coords]))
 
 #?(:clj (set! *warn-on-reflection* true))

--- a/implementation/core/src/re_frame/core_epoch.cljc
+++ b/implementation/core/src/re_frame/core_epoch.cljc
@@ -1,27 +1,13 @@
 (ns re-frame.core-epoch
   "Public-API wrappers for the optional epoch artefact (Tool-Pair
   §Time-travel). Implementation ships in `day8/re-frame2-epoch`
-  (`re-frame.epoch` ns) per rf2-lt4e.
+  (`re-frame.epoch`). See [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention).
 
-  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
-  look the producing fns up via the late-bind hook table at call time;
-  consumers reach the surfaces through `re-frame.core` re-exports.
-
-  Per-feature carve-out: the epoch artefact pulls the per-frame
-  `:rf/epoch-record` ring buffer, the per-cascade trace-capture path,
-  the `:sub-runs` / `:renders` / `:effects` projection walker, and
-  every `:rf.epoch/*` keyword string. The entire epoch surface is also
-  gated on `interop/debug-enabled?` (Tool-Pair §Time-travel §Production
-  elision).
-
-  Absent-artefact behaviour: wrappers degrade silently (empty vector /
-  `false` / no-op) so a release build that omits the artefact does not
-  raise. `reset-frame-db!` is the exception — it records an epoch as
-  part of its contract and raises `:rf.error/epoch-artefact-missing`.
-
-  Per rf2-h824v the wrappers below are emitted by the
-  `re-frame.core-artefact/defwrapper` factory from a declarative table —
-  one row per public surface."
+  The entire epoch surface is gated on `interop/debug-enabled?` (Tool-
+  Pair §Time-travel §Production elision). Absent-artefact wrappers
+  degrade silently (empty vector / `false` / no-op) so a release build
+  that omits the artefact does not raise. `reset-frame-db!` is the
+  exception — it raises `:rf.error/epoch-artefact-missing`."
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]))
 

--- a/implementation/core/src/re_frame/core_flows.cljc
+++ b/implementation/core/src/re_frame/core_flows.cljc
@@ -1,20 +1,7 @@
 (ns re-frame.core-flows
   "Public-API wrappers for the optional flows artefact (Spec 013).
-  Implementation ships in `day8/re-frame2-flows` (`re-frame.flows`
-  ns) per rf2-tfw3.
-
-  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
-  look the producing fns up via the late-bind hook table at call time;
-  consumers reach the surfaces through `re-frame.core` re-exports.
-
-  Per-feature carve-out: the flows artefact pulls the per-frame flow
-  registry, the topological-sort engine, and the dirty-check
-  `last-inputs` map — none of which appear on a consumer's classpath
-  when this wrapper's hooks are unregistered.
-
-  Per rf2-h824v the wrappers below are emitted by the
-  `re-frame.core-artefact/defwrapper` factory from a declarative table —
-  one row per public surface."
+  Implementation ships in `day8/re-frame2-flows` (`re-frame.flows`).
+  See [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention)."
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]))
 

--- a/implementation/core/src/re_frame/core_http.cljc
+++ b/implementation/core/src/re_frame/core_http.cljc
@@ -1,22 +1,7 @@
 (ns re-frame.core-http
   "Public-API wrappers for the optional managed-HTTP artefact (Spec 014).
-  Implementation ships in `day8/re-frame2-http`
-  (`re-frame.http-managed` ns) per rf2-5kpd.
-
-  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
-  look the producing fns up via the late-bind hook table at call time;
-  consumers reach the surfaces through `re-frame.core` re-exports.
-
-  Per-feature carve-out: the http artefact pulls the in-flight request
-  registry, the Fetch / `java.net.http.HttpClient` transport adapters,
-  the encode/decode pipeline, the retry-with-backoff machinery, the
-  eight-category `:rf.http/*` failure taxonomy, and every `:rf.http/*`
-  keyword string — none of which appear on a consumer's classpath when
-  this wrapper's hooks are unregistered.
-
-  Per rf2-h824v the wrappers below are emitted by the
-  `re-frame.core-artefact/defwrapper` factory from a declarative table —
-  one row per public surface."
+  Implementation ships in `day8/re-frame2-http` (`re-frame.http-managed`).
+  See [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention)."
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]))
 

--- a/implementation/core/src/re_frame/core_machines.cljc
+++ b/implementation/core/src/re_frame/core_machines.cljc
@@ -60,7 +60,7 @@
   ([system-id]          :delegate)
   ([system-id frame-id] :delegate))
 
-;; ---- reg-machine* / reg-machine — bespoke per rf2-8bp3 -------------------
+;; ---- reg-machine* / reg-machine — bespoke -------------------------------
 ;;
 ;; Both surfaces share the late-bind throw via `reg-machine-impl` but stamp
 ;; their own `:where` symbol on the missing-artefact ex-info so the trace

--- a/implementation/core/src/re_frame/core_machines.cljc
+++ b/implementation/core/src/re_frame/core_machines.cljc
@@ -1,24 +1,13 @@
 (ns re-frame.core-machines
   "Public-API wrappers for the optional machines artefact (Spec 005).
-  Implementation ships in `day8/re-frame2-machines`
-  (`re-frame.machines` ns) per rf2-xbtj.
+  Implementation ships in `day8/re-frame2-machines` (`re-frame.machines`).
+  See [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention).
 
-  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
-  look the producing fns up via the late-bind hook table at call time;
-  consumers reach the surfaces through `re-frame.core` re-exports.
-
-  Per-feature carve-out: the machines artefact pulls the machine
-  registry, the entry/exit cascade engine, and the `:rf/machine` /
-  `:rf/machine-has-tag?` framework subs — none of which appear on a
-  consumer's classpath when this wrapper's hooks are unregistered.
-
-  Per rf2-h824v the canonical late-bind wrappers below are emitted by
-  the `re-frame.core-artefact/defwrapper` factory. `reg-machine` /
-  `reg-machine*` keep a bespoke shape — they share the `:where`-symbol
-  parameter via `reg-machine-impl` so the macro and the plain-fn
-  surface raise with their own faithful `:where` symbol. Sugar fns
-  (`dispatch-to-system`, `sub-machine`, `has-tag?`) are not late-bind
-  surfaces — they layer over `router/dispatch!` / `subs/subscribe`."
+  `reg-machine` / `reg-machine*` keep a bespoke shape (they share the
+  `:where`-symbol parameter via `reg-machine-impl` so the macro and the
+  plain-fn surface raise with their own faithful `:where` symbol). Sugar
+  fns (`dispatch-to-system`, `sub-machine`, `has-tag?`) are not late-
+  bind surfaces — they layer over `router/dispatch!` / `subs/subscribe`."
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]
             [re-frame.late-bind :as late-bind]

--- a/implementation/core/src/re_frame/core_reg_macros.cljc
+++ b/implementation/core/src/re_frame/core_reg_macros.cljc
@@ -8,12 +8,12 @@
   the `with-coords-form` helper plus the `defreg-macro` macro-defining
   macro.
 
-  Carved out of `re-frame.core` per rf2-4rnui so the public namespace
-  stays under the 250-LoC leaf ceiling (rf2-zkca8). The user-facing
-  `defmacro reg-event-db` / `reg-sub` / `reg-flow` / … shells live in
-  `re-frame.core` itself (they MUST, so `rf/reg-event-db` resolves
-  alias-qualified per Clojure's standard `ns-alias/Var` lookup); each
-  shell is a one-line `(defreg-macro …)` form. The bulk LoC sits here.
+  Carved out of `re-frame.core` so the public namespace stays under
+  the 250-LoC leaf ceiling. The user-facing `defmacro reg-event-db` /
+  `reg-sub` / `reg-flow` / … shells live in `re-frame.core` itself
+  (they MUST, so `rf/reg-event-db` resolves alias-qualified per
+  Clojure's `ns-alias/Var` lookup); each shell is a one-line
+  `(defreg-macro …)` form. The bulk LoC sits here.
 
   rf2-xnym: the rationale for `(symbol (str (ns-name *ns*)))` rather
   than `(ns-name *ns*)` — in CLJS macro context the ns-symbol may
@@ -84,7 +84,7 @@
      "Emits a canonical `defmacro` for a `reg-*` surface. The emitted
      macro captures `(meta &form)` / `*file*` / `*ns*` and splices the
      consumer's args through to `delegate-sym` (a symbol that must
-     resolve in `re-frame.core`). Per rf2-bd6zl."
+     resolve in `re-frame.core`)."
      [macro-sym delegate-sym docstring & [attr-map]]
      (let [qualified (resolve-delegate-sym delegate-sym)]
        `(defmacro ~macro-sym

--- a/implementation/core/src/re_frame/core_reg_view_macro.cljc
+++ b/implementation/core/src/re_frame/core_reg_view_macro.cljc
@@ -5,17 +5,15 @@
   Spec 005 §Source-coord stamping, Spec 002 §with-frame / §bound-fn /
   §`:fx-overrides`, Spec 014 §Testing.
 
-  Carved out of `re-frame.core` per rf2-4rnui so the public namespace
-  stays under the 250-LoC leaf ceiling (rf2-zkca8). The user-facing
-  `defmacro reg-view` / `with-frame` / etc. shells live in
-  `re-frame.core` itself (they MUST, so `rf/reg-view` resolves alias-
-  qualified per Clojure's standard `ns-alias/Var` lookup); each shell
-  is a one-line call into the matching `expand-…` plain fn here.
+  Carved out of `re-frame.core` so the public namespace stays under
+  the 250-LoC leaf ceiling. The user-facing `defmacro reg-view` /
+  `with-frame` / etc. shells live in `re-frame.core` itself (they MUST,
+  so `rf/reg-view` resolves alias-qualified per Clojure's
+  `ns-alias/Var` lookup); each shell is a one-line call into the
+  matching `expand-…` plain fn here.
 
   The expander helpers stay plain CLJ fns so CLJS test files can also
-  exercise them JVM-side.
-
-  File naming uses the flat dash-form (per rf2-2vbm)."
+  exercise them JVM-side."
   (:require [re-frame.source-coords :as source-coords]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -77,11 +75,11 @@
      form does not reference `*ns*` / `*file*` at runtime (required for
      CLJS, where `cljs.core/*ns*` is nil at runtime).
 
-     Per rf2-yfbx: when reagent-slim is on the classpath the body is
-     classified (Form-1 / Form-2) at expansion time and the wrapper fn
-     is stamped with `^{:reagent2/form ...}` meta — an additive perf
-     hint; the runtime detection in `reagent2.impl.component/wrap-
-     render` remains load-bearing for correctness."
+     When reagent-slim is on the classpath the body is classified
+     (Form-1 / Form-2) at expansion time and the wrapper fn is stamped
+     with `^{:reagent2/form ...}` meta — an additive perf hint; the
+     runtime detection in `reagent2.impl.component/wrap-render` remains
+     load-bearing for correctness."
      [form-meta current-ns-sym current-file sym more]
      (let [parsed   (parse-reg-view-args more)
            sym-meta (or (meta sym) {})

--- a/implementation/core/src/re_frame/core_routing.cljc
+++ b/implementation/core/src/re_frame/core_routing.cljc
@@ -1,21 +1,7 @@
 (ns re-frame.core-routing
   "Public-API wrappers for the optional routing artefact (Spec 012).
-  Implementation ships in `day8/re-frame2-routing`
-  (`re-frame.routing` ns) per rf2-k682.
-
-  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
-  look the producing fns up via the late-bind hook table at call time;
-  consumers reach the surfaces through `re-frame.core` re-exports.
-
-  Per-feature carve-out (relative to the canonical convention): the
-  routing artefact pulls the route-rank / pattern-compile / nav-token
-  machinery, the `:rf/route` reg-sub family, and every `:rf.route/*` /
-  `:rf.nav/*` keyword string — none of which appear on a consumer's
-  classpath when this wrapper's hooks are unregistered.
-
-  Per rf2-h824v the wrappers below are emitted by the
-  `re-frame.core-artefact/defwrapper` factory from a declarative table —
-  one row per public surface."
+  Implementation ships in `day8/re-frame2-routing` (`re-frame.routing`).
+  See [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention)."
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]))
 

--- a/implementation/core/src/re_frame/core_schemas.cljc
+++ b/implementation/core/src/re_frame/core_schemas.cljc
@@ -1,20 +1,12 @@
 (ns re-frame.core-schemas
   "Public-API wrappers for the optional schemas artefact (Spec 010).
-  Implementation ships in `day8/re-frame2-schemas`
-  (`re-frame.schemas` ns) per rf2-p7va.
+  Implementation ships in `day8/re-frame2-schemas` (`re-frame.schemas`).
+  See [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention).
 
-  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
-  look the producing fns up via the late-bind hook table at call time;
-  consumers reach the surfaces through `re-frame.core` re-exports.
-
-  Per-feature carve-out: the schemas artefact pulls Malli (the default
-  validator) onto the classpath — apps that want to drop the ~24 KB
-  gzipped Malli surface omit the artefact and either use a substitute
-  validator (per rf2-froe) or skip schema validation entirely.
-
-  Per rf2-h824v the wrappers below are emitted by the
-  `re-frame.core-artefact/defwrapper` factory from a declarative table —
-  one row per public surface."
+  The schemas artefact pulls Malli (the default validator) onto the
+  classpath — apps that want to drop the ~24 KB gzipped Malli surface
+  omit the artefact and either substitute another validator or skip
+  schema validation entirely."
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]))
 

--- a/implementation/core/src/re_frame/core_schemas.cljc
+++ b/implementation/core/src/re_frame/core_schemas.cljc
@@ -104,9 +104,9 @@
 
 (defwrapper reg-app-schemas
   "Bulk-register `{path -> schema}` against the active frame (or the
-  `:frame` opt). Per rf2-jzs9 — the plural form of `reg-app-schema`,
-  aimed at feature-modular apps (per Conventions §Feature-modularity
-  prefix convention).
+  `:frame` opt). The plural form of `reg-app-schema`, aimed at
+  feature-modular apps (per Conventions §Feature-modularity prefix
+  convention).
 
   Shape:
 

--- a/implementation/core/src/re_frame/core_ssr.cljc
+++ b/implementation/core/src/re_frame/core_ssr.cljc
@@ -1,23 +1,7 @@
 (ns re-frame.core-ssr
   "Public-API wrappers for the optional SSR artefact (Spec 011).
-  Implementation ships in `day8/re-frame2-ssr` (`re-frame.ssr` ns)
-  per rf2-uo7v.
-
-  Per [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention) — wrappers
-  look the producing fns up via the late-bind hook table at call time;
-  consumers reach the surfaces through `re-frame.core` re-exports.
-
-  Per-feature carve-out: the SSR artefact pulls the hiccup → HTML
-  emitter, the FNV-1a render-tree-hash machinery, the per-request HTTP
-  response accumulator (a framework-private side-channel atom per
-  rf2-jbcmt), the six `:rf.server/*` fxs, the `reg-error-projector`
-  registry kind plus its default, the `:rf/hydrate` event, and every
-  `:rf.ssr/*` / `:rf.server/*` keyword string — none of which appear
-  on a consumer's classpath when this wrapper's hooks are unregistered.
-
-  Per rf2-h824v the wrappers below are emitted by the
-  `re-frame.core-artefact/defwrapper` factory from a declarative table —
-  one row per public surface."
+  Implementation ships in `day8/re-frame2-ssr` (`re-frame.ssr`).
+  See [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention)."
   (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
                                         :cljs [:refer-macros [defwrapper]])]))
 

--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -264,8 +264,8 @@
    new app-db path segment, so an inner `:large?` / `:hint` claim on
    the wrapped schema applies to the wrapper's path. Conservative v1:
    only `:maybe`. `:and` / `:or` / `:enum` may carry MULTIPLE children
-   with different props (merge / priority semantics TBD per rf2-b20zm
-   follow-on); a future iteration may extend this set."
+   with different props (merge / priority semantics TBD); a future
+   iteration may extend this set."
   #{:maybe})
 
 (defn- schema-properties
@@ -280,7 +280,7 @@
    exposes the inner `:large?` to callers. The descent preserves an
    explicit outer props map — if the wrapper itself carries props
    (`[:maybe {:large? true} :string]`), those win and no descent
-   happens. Per rf2-b20zm."
+   happens."
   [schema]
   (cond
     (and (vector? schema)
@@ -427,11 +427,11 @@
 (def ^:private redacted-sentinel
   "The `:rf/redacted` privacy sentinel emitted by the walker for slots
    matching the `:sensitive?` predicate. Re-exported from
-   `re-frame.privacy/redacted-sentinel` per rf2-iwqu9 so the in-handler
-   `with-redacted` interceptor and this wire-walker emit the same value
-   from a single source of truth. Per [009 §Privacy / sensitive data
-   in traces] — privacy owns the policy locus; the walker remains the
-   single normative emission site for the elision pathway."
+   `re-frame.privacy/redacted-sentinel` so the in-handler
+   `with-redacted` interceptor and this wire-walker emit the same value.
+   Per Spec 009 §Privacy / sensitive data in traces — privacy owns the
+   policy locus; the walker remains the single normative emission site
+   for the elision pathway."
   privacy/redacted-sentinel)
 
 (defn- sensitive-decl?

--- a/implementation/core/src/re_frame/emit_substrate.cljc
+++ b/implementation/core/src/re_frame/emit_substrate.cljc
@@ -1,10 +1,8 @@
 (ns re-frame.emit-substrate
   "Parameterised always-on emit substrate. Backs `re-frame.event-emit`
-  (rf2-rirbq) and `re-frame.error-emit` (rf2-bacs4 / rf2-hqbeh) — both
-  ship a `register / unregister / clear / fan-out` registry with
-  identical structure but distinct record shapes and short-circuit
-  conditions. Factored per rf2-z5ffh (audit finding EE1/A4 of
-  rf2-spr6q).
+  and `re-frame.error-emit` — both ship a
+  `register / unregister / clear / fan-out` registry with identical
+  structure but distinct record shapes and short-circuit conditions.
 
   The substrate is always-on: no `goog.DEBUG` gating inside this
   namespace. Listener-REGISTRATION sites SHOULD use `goog.DEBUG=false`

--- a/implementation/core/src/re_frame/error.cljc
+++ b/implementation/core/src/re_frame/error.cljc
@@ -3,16 +3,14 @@
   primitives used by error / warning trace emit sites across core and
   the per-feature artefacts.
 
-  Per rf2-w4bby — extracts the byte-identical `type-of-value` helper
-  previously duplicated in `re-frame.spec` (core) and
-  `re-frame.schemas.validate` (schemas). Both call sites use it for
-  the same purpose: rendering a short type tag in the `:reason`
-  string of a `:rf.error/schema-validation-failure` trace event.
+  `type-of-value` renders a short type tag in the `:reason` string of
+  a `:rf.error/schema-validation-failure` trace event; consumed by
+  `re-frame.spec` and `re-frame.schemas.validate`.
 
   Lives in core because schemas depends on core (Spec 006 §Adapter
-  shipping convention as extended by rf2-p7va) — pushing the helper
-  down means the schemas-side validate.cljc can `:require` it without
-  inverting the dep direction. Apps that don't load the schemas
+  shipping convention) — pushing the helper down means the schemas-
+  side validate.cljc can `:require` it without inverting the dep
+  direction. Apps that don't load the schemas
   artefact still get the helper for free under `re-frame.spec`'s
   boundary-validation interceptor.
 

--- a/implementation/core/src/re_frame/error_emit.cljc
+++ b/implementation/core/src/re_frame/error_emit.cljc
@@ -1,15 +1,13 @@
 (ns re-frame.error-emit
-  "Always-on error-emit substrate. Per rf2-hqbeh (per-frame `:on-error`
-  policy fan-out) and rf2-bacs4 (corpus-wide listener fan-out). Per
-  Spec 009 §What IS available in production §Error-handler policy.
+  "Always-on error-emit substrate. Per Spec 009 §What IS available in
+  production §Error-handler policy.
 
   Survives `:advanced` + `goog.DEBUG=false`. Carries two independent
   fan-out paths from one normative emission site (the router's
   handler-exception path):
 
-    1. Corpus-wide listener registry (rf2-bacs4) — every fn
-       registered through [[register-error-emit-listener!]] receives
-       a tight error-record (Spec 009 §Record shape):
+    1. Corpus-wide listener registry — every fn registered through
+       [[register-error-emit-listener!]] receives a tight error-record:
 
          {:error      <kw>       ;; e.g. :rf.error/handler-exception
           :event      <vector>    ;; dispatched event vector (elided)
@@ -19,35 +17,29 @@
           :exception  <ex>
           :elapsed-ms <int>}
 
-       For off-box observability shippers (Sentry / Honeybadger /
+       For off-box observability shippers (Sentry, Honeybadger,
        Rollbar).
 
-    2. Per-frame `:on-error` policy fn (rf2-hqbeh) — the frame's
-       `:on-error` slot, when present, receives a structured error
-       event (`:operation` / `:tags` / `:recovery` shape) for in-app
-       recovery decisions.
+    2. Per-frame `:on-error` policy fn — the frame's `:on-error` slot,
+       when present, receives a structured error event (`:operation` /
+       `:tags` / `:recovery` shape) for in-app recovery decisions.
 
-  Both paths are independent (a buggy listener cannot block the
-  policy fn; a buggy policy fn cannot block listeners). Both are
-  try/catch wrapped per Spec 009 §1052.
+  Both paths are independent (a buggy listener cannot block the policy
+  fn; a buggy policy fn cannot block listeners). Both are try/catch
+  wrapped.
 
   Listener REGISTRATION sites SHOULD use `goog.DEBUG=false` as a
-  belt-and-braces gate alongside an explicit config flag. The
-  substrate proper carries no gate. Sibling to the event-emit
-  listener surface (rf2-rirbq); register both when forwarding to a
-  single hosted observability back-end.
+  belt-and-braces gate alongside an explicit config flag. The substrate
+  proper carries no gate.
 
-  Per rf2-vnjfg (security audit): when the failing event's registered
-  handler-meta carries `:sensitive? true`, the always-on error path
-  ENFORCES privacy — it does NOT merely warn. Both fan-out paths
-  surface the event slot as the `:rf/redacted` sentinel rather than
-  the raw event vector. Errors still observe (the exception object,
-  the failing event-id, the frame, the recovery decision all flow
-  through unchanged — operators need them for triage), but the
-  dispatched event payload — which may carry credentials, payment
-  details, PII — is scrubbed at the substrate boundary. Mirrors the
-  rf2-6hklf event-emit drop policy; we redact rather than drop here
-  because errors are a recovery surface that MUST be observable."
+  When the failing event's registered handler-meta carries
+  `:sensitive? true`, the always-on error path ENFORCES privacy — it
+  does NOT merely warn. Both fan-out paths surface the event slot as
+  `:rf/redacted` rather than the raw event vector. The exception
+  object, event-id, frame, and recovery decision flow through
+  unchanged (operators need them for triage); the event payload —
+  which may carry credentials / PII — is scrubbed at the substrate
+  boundary."
   (:require [re-frame.elision       :as elision]
             [re-frame.emit-substrate :as emit]
             [re-frame.frame         :as frame]
@@ -91,8 +83,7 @@
   when the frame is unregistered, when no `:on-error` slot is
   configured, or when the slot is not a fn. Per Spec 009 §1052
   policy-fn exceptions are caught here so a buggy policy fn cannot
-  break the cascade. Returns the policy fn's return value or nil.
-  Per rf2-hqbeh."
+  break the cascade. Returns the policy fn's return value or nil."
   [frame-id error-event]
   (when-let [f (frame/frame frame-id)]
     (when-let [policy (get-in f [:config :on-error])]
@@ -104,10 +95,10 @@
 (defn- redact-tags-event
   "Substitute `:tags :event` (and `:tags :emit-event` if present) in
   `error-event` with `:rf/redacted`. Defensive: returns the input
-  unchanged when the shape doesn't match the documented form.
-  Per rf2-vnjfg: the structured error-event passed to the per-frame
-  `:on-error` policy fn MUST surface the redacted event when the
-  failing handler is registered `:sensitive? true`."
+  unchanged when the shape doesn't match the documented form. The
+  structured error-event passed to the per-frame `:on-error` policy
+  fn surfaces the redacted event when the failing handler is
+  registered `:sensitive? true`."
   [error-event]
   (if (and (map? error-event) (map? (:tags error-event)))
     (update error-event :tags
@@ -126,43 +117,25 @@
   Builds the tight error-record ONCE, runs
   `re-frame.elision/elide-wire-value` against `:event` with off-box
   defaults (large → `:rf.size/large-elided`; sensitive →
-  `:rf/redacted`), then fans out along two independent paths:
+  `:rf/redacted`), then fans out along two independent paths
+  (listener registry, per-frame `:on-error` policy).
 
-    1. Corpus-wide listener registry (rf2-bacs4) — emit-substrate
-       fan-out. Listener exceptions caught; siblings still run.
-    2. Per-frame `:on-error` policy fn (rf2-hqbeh) — receives the
-       supplied `error-event` map. Policy-fn exceptions caught per
-       Spec 009 §1052.
+  When the failing event's handler is registered `:sensitive? true`,
+  BOTH fan-out paths surface the event slot as `:rf/redacted` (in the
+  tight record's `:event` slot AND the structured error-event's
+  `:tags :event` slot). The exception, event-id, frame, and
+  elapsed-ms ride through unchanged so operators retain the triage
+  signal.
 
-  Per rf2-vnjfg (security audit): consults the failing event's
-  registered handler-meta `:sensitive?` flag. When the handler is
-  `:sensitive? true`, BOTH fan-out paths surface the event slot as
-  `:rf/redacted`:
-
-    - The tight error-record's `:event` slot is the `:rf/redacted`
-      sentinel (not the elided event vector).
-    - The structured error-event's `:tags :event` slot is the
-      `:rf/redacted` sentinel (in place of `emit-event`).
-
-  This is the substrate-level guarantee — even when the handler
-  failed before `with-redacted` ran (or no `with-redacted` was
-  declared at all), the always-on error path does NOT ship the raw
-  event payload to listeners or to the policy fn. The exception
-  object, the event-id, the frame, the elapsed-ms ride through
-  unchanged so operators retain the triage signal.
-
-  Called by `router.cljc` from the handler-exception path. The
-  `elapsed-ms` is the wall-clock from cascade-start to throw,
-  rounded to an integer at the substrate boundary per the contract
-  (mirrors rf2-ph8pa / rf2-rirbq). Returns nil."
+  Called by `router.cljc` from the handler-exception path. Returns nil."
   [error-kw event event-id frame-id exception elapsed-ms time error-event]
   (let [handler-meta (when event-id (registrar/lookup :event event-id))
         sensitive?   (privacy/sensitive?-from-meta handler-meta)
-        ;; Per rf2-vnjfg: redact the event slot at the substrate boundary
-        ;; when the failing handler is declared sensitive. Otherwise run
-        ;; the wire-walker as before (paths flagged `:sensitive?` /
-        ;; `:large?` via the per-frame `:rf/elision` registry still get
-        ;; their per-path substitutions).
+        ;; Redact the event slot at the substrate boundary when the
+        ;; failing handler is declared sensitive. Otherwise run the
+        ;; wire-walker as before (paths flagged `:sensitive?` /
+        ;; `:large?` via the per-frame `:rf/elision` registry still
+        ;; get their per-path substitutions).
         elided-event (if sensitive?
                        privacy/redacted-sentinel
                        (elision/elide-wire-value event {:frame frame-id}))

--- a/implementation/core/src/re_frame/event_emit.cljc
+++ b/implementation/core/src/re_frame/event_emit.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.event-emit
   "Always-on event-emit substrate for production observability
-  (Datadog, Sentry, Honeycomb, ...). Per rf2-rirbq / Spec 009
-  §What IS available in production §Event-emit listener.
+  (Datadog, Sentry, Honeycomb). Per Spec 009 §What IS available in
+  production §Event-emit listener.
 
   Survives `:advanced` + `goog.DEBUG=false`. Parallel to (not a
   fallback for) the dev-only trace surface. One record per processed
@@ -19,11 +19,11 @@
   belt-and-braces gate alongside an explicit config flag. The
   substrate proper carries no gate.
 
-  Per rf2-6hklf: if the event's registered handler-meta carries
-  `:sensitive? true`, the record is dropped entirely (listeners are
-  NOT invoked). Per rf2-qsjda: `:rf.trace/no-emit? true` likewise
-  drops the record — framework-internal bookkeeping handlers
-  (Causa/Story) are not user-domain observable signal."
+  If the event's registered handler-meta carries `:sensitive? true`,
+  the record is dropped entirely (listeners are NOT invoked).
+  `:rf.trace/no-emit? true` likewise drops — framework-internal
+  bookkeeping handlers (Causa, Story) are not user-domain observable
+  signal."
   (:require [re-frame.elision       :as elision]
             [re-frame.emit-substrate :as emit]
             [re-frame.late-bind     :as late-bind]

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -327,50 +327,24 @@
 ;; ---- destruction ----------------------------------------------------------
 ;;
 ;; destroy-frame! runs an ordered teardown. Each step lives in its own
-;; named helper so the body of destroy-frame! reads as documentation; the
-;; helper names ARE the step list. Order matters — see destroy-frame!'s
-;; docstring and Spec 002 §Destroy.
+;; named helper so the body of destroy-frame! reads as a step list. Order
+;; matters — see destroy-frame!'s docstring for the authoritative recipe.
 
 (defn- safe-call-hook!
-  "Fire a late-bound cleanup hook by key. No-op when the hook is unbound
-  (the owning artefact isn't loaded); exceptions from the hook fn are
-  swallowed so one bad cleanup hook can't block the rest of teardown.
-  Every destroy-time cleanup hook in this ns funnels through here so the
-  late-bind + best-effort policy is single-sourced."
+  "Fire a late-bound cleanup hook by key. No-op when unbound; exceptions
+  are swallowed so one bad hook can't block the rest of teardown."
   [hook-key & args]
   (when-let [f (late-bind/get-fn hook-key)]
     (try (apply f args)
          (catch #?(:clj Throwable :cljs :default) _ nil))))
 
 (defn- fire-on-destroy-event!
-  "Step 1. Fire the user-supplied :on-destroy event before any lifecycle
-  mutation, so handlers still observe an alive frame. No-op when the
-  frame has no :on-destroy or when the router artefact is absent."
   [id f]
   (when-let [on-destroy (get-in f [:config :on-destroy])]
     (when-let [dispatch-sync (late-bind/get-fn :router/dispatch-sync!)]
       (dispatch-sync on-destroy {:frame id}))))
 
 (defn- notify-machine-destruction!
-  "Step 2 (with interleaved 2a). For every machine that has an active
-  snapshot under [:rf/machines ...] in app-db:
-
-    2a. Fire the rf2-wvkn HTTP abort hook (Spec 005 §Cancellation
-        cascade — frame-destroy is a documented destroy trigger).
-        Late-bound; nil when the http artefact is absent. Runs BEFORE
-        the trace event so observers see abort-then-destroy ordering.
-    2.  Emit ONE :rf.machine.lifecycle/destroyed trace per actor
-        snapshot, carrying :reason :parent-frame-destroyed under :tags.
-        Pairs with :rf.machine.lifecycle/created emitted at reg-machine
-        so lifecycle observers see one consistent op-type for create
-        AND destroy across every cause and code path. The :reason tag
-        discriminates why the actor went away — frame-exit emits
-        :parent-frame-destroyed; the fx-substrate's :rf.machine/destroyed
-        emit-site (lifecycle_fx.cljc) carries the other reasons
-        (:rf.machine/finished, :explicit, :parent-unmount-cascade).
-
-  Full automatic exit-cascade would require storing every machine def
-  in a registry, which is out of scope for the v1 closed kind set."
   [id]
   (let [container  (get-frame-db id)
         db         (when container (adapter/read-container container))
@@ -387,17 +361,10 @@
                     :reason     :parent-frame-destroyed}))))
 
 (defn- mark-frame-destroyed!
-  "Step 3. Flip :lifecycle :destroyed? so subsequent dispatch / subscribe
-  against this frame raises :rf.error/frame-destroyed. Done before
-  sub-cache disposal so a racing reaction can't re-enter on a frame
-  that's mid-teardown."
   [id]
   (swap! frames update id assoc-in [:lifecycle :destroyed?] true))
 
 (defn- tear-down-sub-cache!
-  "Step 4. Walk every cached reaction in the frame's sub-cache and
-  dispose it; clear the cache atom. Disposal exceptions are swallowed
-  so one bad on-dispose can't block the rest of teardown."
   [f]
   (when-let [cache (:sub-cache f)]
     (doseq [[_k entry] @cache]
@@ -407,80 +374,47 @@
     (reset! cache {})))
 
 (defn- emit-frame-destroyed-trace!
-  "Step 5. Emit the :frame/destroyed trace, AFTER the per-machine
-  cascade so listeners see machines-then-frame ordering."
   [id]
   (trace/emit! :frame :frame/destroyed
                {:frame id}))
 
 (defn- dissoc-frame!
-  "Step 6. Remove the frame record from the `frames` atom so subsequent
-  lookups return nil."
   [id]
   (swap! frames dissoc id))
 
 (defn- unregister-frame!
-  "Step 7. Per Spec 001 §Hot-reload semantics — drop the frame from the
-  registrar, surfacing :rf.registry/handler-cleared so tools tracking
-  the live registry observe the slot freed."
   [id]
   (registrar/unregister! :frame id))
 
 (defn- notify-epoch-listeners!
-  "Step 8. Per Tool-Pair §Surface behaviour against destroyed frames
-  (rf2-d656): emit a one-shot :rf.epoch.cb/silenced-on-frame-destroy
-  for every register-epoch-cb! listener that previously observed this
-  frame. Late-bound through the hook table so core never statically
-  requires the epoch artefact."
   [id]
   (safe-call-hook! :epoch/on-frame-destroyed id))
 
 (defn destroy-frame!
   "Tear down a frame. Per Spec 002 §Destroy, the ordered steps are:
 
-    1. fire-on-destroy-event!       — run the user :on-destroy event
-                                      while the frame is still alive.
+    1. fire-on-destroy-event!       — run user :on-destroy while frame
+                                      is still alive.
     2. notify-machine-destruction!  — for each active machine snapshot:
-                                      (2a) fire the rf2-wvkn HTTP abort
-                                      hook, then emit the unified
+                                      fire the HTTP abort hook then emit
                                       :rf.machine.lifecycle/destroyed
-                                      trace (one per snapshot) carrying
-                                      :reason :parent-frame-destroyed.
+                                      with :reason :parent-frame-destroyed.
     3. mark-frame-destroyed!        — flip :lifecycle :destroyed?.
     4. tear-down-sub-cache!         — dispose every cached reaction.
-    5. emit-frame-destroyed-trace!  — emit :frame/destroyed.
+    *. cleanup hooks (best-effort, no-op when artefact absent):
+         :privacy/clear-suppression-cache!  — reset sensitive-without-
+                                              redaction warn-once cache.
+         :ssr/on-frame-destroyed            — clear SSR side-channel
+                                              atoms for this frame.
+         :machines/on-frame-destroyed!      — clear the machines
+                                              artefact's frame-scoped
+                                              `:after` timer table.
+    5. emit-frame-destroyed-trace!  — emit :frame/destroyed AFTER the
+                                      machine cascade.
     6. dissoc-frame!                — remove from the `frames` atom.
     7. unregister-frame!            — drop from the registrar.
-    8. notify-epoch-listeners!      — fire the rf2-d656 epoch hook.
-
-  Two cleanup hooks fire between step 4 and step 5 — both are best-
-  effort and tolerate the hook artefact being absent at runtime:
-
-    :privacy/clear-suppression-cache!   — rf2-isdwf, reset the warn-once
-                                          cache so a re-registered frame
-                                          re-emits the sensitive-without-
-                                          redaction warning if mis-config.
-    :ssr/on-frame-destroyed             — rf2-fcj33, drop the SSR
-                                          side-channel atoms' entries
-                                          for the destroyed frame
-                                          (pending-error-traces +
-                                          request-slots). Without this
-                                          hook those two defonce atoms
-                                          accumulate one entry per
-                                          request under SSR load — a
-                                          slow leak that compounds over
-                                          a long-running server process.
-    :machines/on-frame-destroyed!       — rf2-ysa94, clear the machines
-                                          artefact's frame-scoped
-                                          `:after` timer table for the
-                                          destroyed frame and release
-                                          any in-flight host-clock
-                                          handles / subscription
-                                          watchers belonging to that
-                                          frame. Without this hook the
-                                          destroyed frame's inner table
-                                          would linger and live timers
-                                          would survive teardown.
+    8. notify-epoch-listeners!      — fire the epoch hook so tools see
+                                      :rf.epoch.cb/silenced-on-frame-destroy.
 
   Subsequent dispatch / subscribe against a destroyed frame raises
   :rf.error/frame-destroyed."
@@ -490,30 +424,8 @@
     (notify-machine-destruction! id)
     (mark-frame-destroyed! id)
     (tear-down-sub-cache! f)
-    ;; Per rf2-isdwf / Spec 009 §Privacy: reset the
-    ;; sensitive-without-redaction warning suppression cache so a
-    ;; re-registration after frame teardown (test fixtures, hot
-    ;; reload that destroys and re-creates the frame) re-emits the
-    ;; warning if still mis-configured. No-op when re-frame.privacy
-    ;; hasn't been loaded.
     (safe-call-hook! :privacy/clear-suppression-cache!)
-    ;; Per rf2-fcj33 / Spec 011 §Per-request frame teardown contract:
-    ;; clear the SSR side-channel atoms (pending-error-traces +
-    ;; request-slots) for the destroyed frame. Both live outside app-db
-    ;; for documented design reasons (the buffered-traces sidestep an
-    ;; app-db clobber race; the request slot keeps host-controlled
-    ;; data out of the hydration payload). Neither is otherwise cleared
-    ;; by destroy-frame's app-db / sub-cache teardown, so under SSR
-    ;; load each request would leak one entry in each atom. No-op when
-    ;; re-frame.ssr is absent.
     (safe-call-hook! :ssr/on-frame-destroyed id)
-    ;; Per rf2-ysa94 / Spec 005 §Delayed `:after` transitions: clear the
-    ;; machines artefact's frame-scoped `:after` timer table for the
-    ;; destroyed frame. The table is partitioned per frame; without this
-    ;; hook the destroyed frame's inner-table would linger as dead
-    ;; bookkeeping and any in-flight host-clock handles would survive
-    ;; teardown. No-op when re-frame.machines is absent (the artefact
-    ;; is optional).
     (safe-call-hook! :machines/on-frame-destroyed! id)
     ;; Per rf2-wkxng / rf2-6m0se: drop every schema registered against
     ;; the destroyed frame so a re-registered frame starts with a

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -59,13 +59,12 @@
   per Spec 002 §Reading the frame from React context and Spec 006
   §Lookup algorithm.
 
-  Per rf2-d4sf, on CLJS this consults the `:adapter/current-frame`
-  late-bind hook so the React-context tier is LIVE — adapters publish
-  their React-context-aware impl through the hook at ns-load time.
-  When the hook is unbound (no adapter loaded yet, or JVM build) the
-  fallback is `current-frame` which honours the dynamic-var tier and
-  the `:rf/default` tier; the React-context tier silently no-ops in
-  that case.
+  On CLJS this consults the `:adapter/current-frame` late-bind hook
+  so the React-context tier is LIVE — adapters publish their React-
+  context-aware impl through the hook at ns-load time. When the hook
+  is unbound (no adapter loaded yet, or JVM build) the fallback is
+  `current-frame` which honours the dynamic-var tier and the
+  `:rf/default` tier; the React-context tier silently no-ops.
 
   This is the canonical 3-tier resolver — `subs/subscribe`,
   `router/dispatch*`'s default-frame computation, and
@@ -87,9 +86,9 @@
       f)))
 
 (defn frame-disposed-for-drain?
-  "Per rf2-68kok / Spec 002 §Frame disposal mid-drain: predicate used
-  by the router's drain loop to interrupt a pass when the frame was
-  destroyed mid-cycle. True when EITHER:
+  "Per Spec 002 §Frame disposal mid-drain: predicate used by the
+  router's drain loop to interrupt a pass when the frame was destroyed
+  mid-cycle. True when EITHER:
 
     (a) The frame record still exists but `:destroyed?` is flipped
         (post-step-3 of `destroy-frame!`, before step-6 dissoc), OR
@@ -237,17 +236,16 @@
   {:id         id
    :app-db     (adapter/make-state-container {})
    :router     (atom {:queue interop/empty-queue :scheduled? false})
-   ;; Per rf2-ynk7 §single-drainer invariant: a separate CAS-able cell
-   ;; that admits at most one thread into `drain!` at a time. On the JVM
-   ;; the executor's `next-tick` callback can wake while the calling
+   ;; Single-drainer invariant: a separate CAS-able cell that admits
+   ;; at most one thread into `drain!` at a time. On the JVM the
+   ;; executor's `next-tick` callback can wake while the calling
    ;; thread is mid-drain (e.g. `dispatch-sync!`); without this guard,
    ;; both threads' peek+pop sequence on `:queue` is non-atomic and
-   ;; double-processes / drops envelopes (the rf2-lmkk #442 flake). The
-   ;; loser of the CAS no-ops; the winning drainer rechecks the queue
-   ;; before releasing the flag so envelopes queued in the gap are not
-   ;; orphaned. CLJS is single-threaded so the CAS is uncontended there,
-   ;; but the same flag preserves the contract under any future
-   ;; concurrent host.
+   ;; double-processes / drops envelopes. The loser of the CAS no-ops;
+   ;; the winning drainer rechecks the queue before releasing the
+   ;; flag so envelopes queued in the gap are not orphaned. CLJS is
+   ;; single-threaded so the CAS is uncontended there, but the same
+   ;; flag preserves the contract under any future concurrent host.
    :drain-lock (atom false)
    :sub-cache  (atom {})
    :lifecycle  {:created-at (interop/now-ms)
@@ -273,28 +271,21 @@
         (nil? existing)
         (let [f (new-frame-record id config)]
           (swap! frames assoc id f)
-          ;; Run :on-create events BEFORE emitting :frame/created.
-          ;; Per Spec 002 §Frame creation: on-create completes (or — for
-          ;; the in-handler case below — is queued) first, then the
-          ;; frame is observable to listeners. The router/dispatch
-          ;; namespace handles dispatch / dispatch-sync; we forward via
-          ;; the late-bind registry to avoid a cyclic dep at compile
-          ;; time. (`resolve` is not a runtime fn in CLJS, so the older
-          ;; `(resolve 'router/...)` pattern silently no-op'd in CLJS —
-          ;; see rf2-p8g8.)
+          ;; Run :on-create events BEFORE emitting :frame/created
+          ;; (Spec 002 §Frame creation). The router/dispatch ns is
+          ;; reached through late-bind to avoid a cyclic dep at
+          ;; compile time.
           ;;
-          ;; Per rf2-cufbh / Spec 002 §`reg-frame` / `make-frame` called
-          ;; from inside a handler: when a handler creates a child
-          ;; frame mid-cascade, the child's `:on-create` MUST be queued
-          ;; asynchronously on the child's router (not dispatch-sync'd)
-          ;; — synchronous dispatch-sync from inside a handler is an
-          ;; error per Spec 002 §dispatch-sync inside a handler is an
-          ;; error, and even were it permitted the two cascades would
-          ;; interleave (the no-cross-frame-drain rule in Spec 002
-          ;; §Run-to-completion forbids that). The signal for "inside
-          ;; a handler" is `frame/*current-frame*` being bound — the
-          ;; router binds it in `process-event!` for the duration of
-          ;; the cascade.
+          ;; Per Spec 002 §`reg-frame` / `make-frame` called from inside
+          ;; a handler: when a handler creates a child frame mid-
+          ;; cascade, the child's `:on-create` MUST be async-queued
+          ;; (not dispatch-sync'd) — synchronous dispatch-sync from
+          ;; inside a handler is an error, and even were it permitted
+          ;; the two cascades would interleave (forbidden by the no-
+          ;; cross-frame-drain rule in Spec 002 §Run-to-completion).
+          ;; The signal for "inside a handler" is `*current-frame*`
+          ;; being bound — the router binds it in `process-event!`
+          ;; for the duration of the cascade.
           (when-let [on-create (:on-create config)]
             (if *current-frame*
               ;; Handler-created child frame: async-queue on the child.

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -14,12 +14,11 @@
     :rf.fx/reg-flow   — runtime, register a flow (Spec 013)
     :rf.fx/clear-flow — runtime, clear a flow
 
-  Per rf2-xbtj the machine fx-ids `:rf.machine/spawn` and
-  `:rf.machine/destroy` are registered by `re-frame.machines` (which now
-  ships in `day8/re-frame2-machines`) at its ns-load time, via the
-  regular `reg-fx` path. They are NOT reserved in core's case-block —
-  apps that don't pull in the machines artefact don't carry the trace
-  strings or the handler for them."
+  The machine fx-ids `:rf.machine/spawn` and `:rf.machine/destroy` are
+  registered by `re-frame.machines` (ships in `day8/re-frame2-machines`)
+  at its ns-load time via the regular `reg-fx` path. They are NOT
+  reserved in core's case-block — apps that don't pull in the machines
+  artefact don't carry the trace strings or the handler for them."
   (:require [re-frame.registrar :as registrar]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
@@ -281,15 +280,15 @@
   consumes this trace; pair tools route off it without re-folding the raw
   trace stream.
 
-  Per rf2-lf84g: when called inside the fx-handler's
-  `*handler-scope*` binding (the user-registered fx branch), `emit!`
-  hoists the fx handler's registration coord onto the emitted event's
-  `:rf.trace/trigger-handler` slot — so consumers can jump to the fx's
-  `reg-fx` site from the success trace. Reserved fx-id calls
-  (`:dispatch`, `:dispatch-later`, `:rf.fx/reg-flow`, `:rf.fx/clear-flow`)
-  emit outside any fx-handler binding; the outer event handler's
-  scope (if any) stamps the event handler's coord instead, which is
-  the right attribution for those — they don't have their own
+  When called inside the fx-handler's `*handler-scope*` binding (the
+  user-registered fx branch), `emit!` hoists the fx handler's
+  registration coord onto the emitted event's `:rf.trace/trigger-
+  handler` slot — so consumers can jump to the fx's `reg-fx` site
+  from the success trace. Reserved fx-id calls (`:dispatch`,
+  `:dispatch-later`, `:rf.fx/reg-flow`, `:rf.fx/clear-flow`) emit
+  outside any fx-handler binding; the outer event handler's scope
+  (if any) stamps the event handler's coord instead, which is the
+  right attribution for those — they don't have their own
   registration site."
   [fx-id args frame-id]
   (trace/emit! :fx :rf.fx/handled
@@ -379,18 +378,15 @@
           ;; NOT emit a sibling warning (the schema-validation-failure
           ;; trace IS the warning, per Spec 010).
           nil
-          ;; Per rf2-ryri7: publish the fx handler's HandlerScope —
-          ;; `:trigger-handler` (rf2-3nn8 / rf2-lf84g) for the fx
-          ;; handler's invocation AND for the success-path
-          ;; `:rf.fx/handled` emit that follows; `:sensitive?`
-          ;; (rf2-isdwf) and `:no-emit?` (rf2-qsjda) per the
-          ;; Spec 009 "innermost handler wins" rule. Errors emitted
-          ;; from inside the fx body (`:rf.error/fx-handler-exception`
-          ;; here and anything the body itself surfaces) carry the fx
-          ;; handler's source-coord; the success-path `:rf.fx/handled`
-          ;; emit picks up the same coord through `emit!`'s hoist of
-          ;; `*handler-scope*` — the outer event handler's scope would
-          ;; otherwise stamp the event handler's coord onto the
+          ;; Publish the fx handler's HandlerScope — `:trigger-handler`
+          ;; for the fx handler's invocation AND the success-path
+          ;; `:rf.fx/handled` emit; `:sensitive?` and `:no-emit?` per
+          ;; Spec 009 "innermost handler wins". Errors emitted from
+          ;; inside the fx body carry the fx handler's source-coord;
+          ;; the success-path `:rf.fx/handled` emit picks up the same
+          ;; coord through `emit!`'s hoist of `*handler-scope*` — the
+          ;; outer event handler's scope would otherwise stamp the
+          ;; event handler's coord onto the
           ;; `:rf.fx/handled` event (Story/Causa want jump-to-source to
           ;; land on the fx handler's `reg-fx` site, not the event
           ;; handler that produced the fx vector). `:call-site` /

--- a/implementation/core/src/re_frame/interop.clj
+++ b/implementation/core/src/re_frame/interop.clj
@@ -103,9 +103,9 @@
 
 ;; ---- compile-time constants -----------------------------------------------
 ;;
-;; Per rf2-vnjfg / rf2-0la4f (security audit): JVM/SSR/headless deployments
-;; need an explicit production gate, the JVM-side counterpart to CLJS
-;; `goog.DEBUG=false`. Without it, the always-dev posture keeps the trace
+;; JVM/SSR/headless deployments need an explicit production gate, the
+;; JVM-side counterpart to CLJS `goog.DEBUG=false`. Without it the
+;; always-dev posture keeps the trace
 ;; surface live in SSR (per-frame `:trace-cb` listeners, the 200-entry
 ;; retain-N ring buffer, registry trace emits, source-coord metadata) AND
 ;; keeps the epoch-history dev surfaces (`restore-epoch`, `reset-frame-db!`,
@@ -159,6 +159,5 @@
   `-Dre-frame.debug=false` or `RE_FRAME_DEBUG=false` (and the
   conventional false-y vocabulary: `0`, `no`, `off`, empty string).
   The JVM counterpart to CLJS `goog.DEBUG`. Read once at namespace
-  load — set the property / env var BEFORE `re-frame.interop` loads.
-  Per rf2-vnjfg / rf2-0la4f."
+  load — set the property / env var BEFORE `re-frame.interop` loads."
   (read-debug-flag))

--- a/implementation/core/src/re_frame/interop.cljs
+++ b/implementation/core/src/re_frame/interop.cljs
@@ -71,6 +71,9 @@
     false))
 
 ;; ---- timers ---------------------------------------------------------------
+;; Timers are a platform primitive, not substrate-reactive — call
+;; `js/setTimeout` / `js/clearTimeout` directly rather than routing
+;; through the late-bind hook table like the reactive surfaces above.
 
 (defn set-timeout!
   "Schedule f to run after ms milliseconds. Returns an opaque handle."

--- a/implementation/core/src/re_frame/interop.cljs
+++ b/implementation/core/src/re_frame/interop.cljs
@@ -1,58 +1,15 @@
 (ns re-frame.interop
   "CLJS host primitives. Everything platform-specific lives here.
-
   See Spec 002 §Interop layer and Spec 005 §Interop layer.
-
-  All other namespaces depend only on these abstractions, not on
-  goog/reagent/js* directly. A non-CLJS port replaces this file; the rest
-  of the runtime is host-agnostic in shape.
 
   Reactive-substrate surfaces (`ratom`, `ratom?`, `make-reaction`,
   `add-on-dispose!`, `dispose!`, `reactive?`, `after-render`) dispatch
-  through the late-bind hook table per rf2-s36l. The active adapter
-  publishes its substrate's impls at ns-load time:
-
-    :adapter/ratom            — (fn [v])         → ratom
-    :adapter/ratom?           — (fn [x])         → boolean
-    :adapter/make-reaction    — (fn [f])         → reaction
-    :adapter/add-on-dispose!  — (fn [a-ratom f]) → nil
-    :adapter/dispose!         — (fn [a-ratom])   → nil
-    :adapter/reactive?        — (fn [])          → boolean
-    :adapter/after-render     — (fn [f])         → nil
-
-  Before rf2-s36l this ns statically `:require`d `reagent.core` /
-  `reagent.ratom` and forwarded straight to stock Reagent. That hard-
-  coupled every CLJS app — including those built on the slim
-  (`reagent-slim`), UIx, or Helix adapters — to stock Reagent's
-  protocols at every reaction/disposal call site. The slim adapter's
-  `reagent2.ratom/Reaction` does NOT reify stock Reagent's
-  `IDisposable`, so the first `(interop/add-on-dispose! ...)` call
-  under a slim-installed app threw a protocol-dispatch error
-  (counter-slim-and-fast Playwright smoke, parked by PR #305).
-
-  After rf2-s36l: each adapter ns publishes its own per-fn hook set
-  at load time. The classic Reagent bridge wires the hooks to
-  `reagent.core/atom`, `reagent.ratom/make-reaction`, etc.; the slim
-  adapter wires them to `reagent2.*` equivalents; UIx and Helix —
-  which reify stock `reagent.ratom/IDisposable` on their derived
-  values — wire to stock Reagent.
-
-  Each adapter's hook installation routes through
-  `(substrate-adapter/current-adapter)` per rf2-0d35: the hook runs
-  the adapter's impl only when that adapter is the installed one and
-  otherwise chains to the previously-registered reader. This keeps
-  test bundles (which load multiple adapter ns's at once) honest about
-  which substrate is active.
-
-  Per the bundle-size note in rf2-5lbx R-007 and rf2-s36l: once this
-  ns stops statically `:require`ing `reagent.core` / `reagent.ratom`,
-  the slim Maven artefact (`day8/reagent-slim`) can drop its stock-
-  Reagent dep entirely and downstream consumers depending on
-  `reagent-slim` alone gain the ~25 KB gz saving. The in-tree
-  shadow-cljs build still pulls all adapter trees (the monorepo
-  configuration coexists them), so the in-tree bundle sizes do not
-  change — that's expected and fine; the bundle-comparison test
-  (rf2-51x5 / rf2-5lbx) is structural, not size-comparative."
+  through the late-bind hook table so adapter swap-in works without
+  hard-coupling this ns to any substrate's protocols. Each adapter
+  publishes its impls at ns-load time under the `:adapter/*` hook keys.
+  Hook installation routes through `(substrate-adapter/current-adapter)`
+  so test bundles loading multiple adapters stay honest about which
+  substrate is active."
   (:require [goog.async.nextTick]
             [re-frame.late-bind :as late-bind]))
 
@@ -63,9 +20,8 @@
 ;; ---- after-render hook ----------------------------------------------------
 
 (defn after-render
-  "Schedule f to run after the next render. Dispatches through the
-  active adapter's `:adapter/after-render` hook (rf2-s36l). Returns nil
-  when no adapter has registered the hook."
+  "Schedule f to run after the next render. Returns nil when no adapter
+  has registered the `:adapter/after-render` hook."
   [f]
   (when-let [hook (late-bind/get-fn :adapter/after-render)]
     (hook f)))
@@ -73,16 +29,14 @@
 ;; ---- mutable cells (used by the runtime, opaque to user code) -------------
 
 (defn ratom
-  "Construct a reactive atom seeded with v. Dispatches through the active
-  adapter's `:adapter/ratom` hook (rf2-s36l)."
+  "Construct a reactive atom seeded with v."
   [v]
   (when-let [hook (late-bind/get-fn :adapter/ratom)]
     (hook v)))
 
 (defn ratom?
   "True if x is a reactive atom (per the active adapter's substrate).
-  Dispatches through `:adapter/ratom?` (rf2-s36l); returns false when
-  no adapter has registered the hook."
+  Returns false when no adapter has registered the hook."
   [x]
   (if-let [hook (late-bind/get-fn :adapter/ratom?)]
     (hook x)
@@ -91,30 +45,26 @@
 ;; ---- reactions ------------------------------------------------------------
 
 (defn make-reaction
-  "Build a reaction that recomputes f when its dependencies change.
-  Dispatches through `:adapter/make-reaction` (rf2-s36l)."
+  "Build a reaction that recomputes f when its dependencies change."
   [f]
   (when-let [hook (late-bind/get-fn :adapter/make-reaction)]
     (hook f)))
 
 (defn add-on-dispose!
-  "Register a teardown callback on a-ratom. Dispatches through
-  `:adapter/add-on-dispose!` (rf2-s36l)."
+  "Register a teardown callback on a-ratom."
   [a-ratom f]
   (when-let [hook (late-bind/get-fn :adapter/add-on-dispose!)]
     (hook a-ratom f)))
 
 (defn dispose!
-  "Tear down a reactive atom / reaction. Dispatches through
-  `:adapter/dispose!` (rf2-s36l)."
+  "Tear down a reactive atom / reaction."
   [a-ratom]
   (when-let [hook (late-bind/get-fn :adapter/dispose!)]
     (hook a-ratom)))
 
 (defn reactive?
   "True when called from inside a reactive context (e.g. a render).
-  Dispatches through `:adapter/reactive?` (rf2-s36l); returns false
-  when no adapter has registered the hook."
+  Returns false when no adapter has registered the hook."
   []
   (if-let [hook (late-bind/get-fn :adapter/reactive?)]
     (hook)

--- a/implementation/core/src/re_frame/late_bind.cljc
+++ b/implementation/core/src/re_frame/late_bind.cljc
@@ -1,50 +1,21 @@
 (ns re-frame.late-bind
-  "Late-binding hook registry for cross-namespace forward references.
+  "Hook registry for cross-namespace and cross-artefact forward
+  references. Producing ns calls `set-fn!` at load time; consumer calls
+  `get-fn` at call time. Identical behaviour on JVM and CLJS.
 
-  Some leaf namespaces (re-frame.frame, re-frame.fx, re-frame.cofx,
-  re-frame.subs, re-frame.routing, re-frame.router) need to call into
-  higher-level namespaces (re-frame.router, re-frame.flows,
-  re-frame.schemas, re-frame.subs) but cannot `:require` them without
-  introducing a cyclic load order.
-
-  Per rf2-p7va the same mechanism carries cross-artefact references:
-  `re-frame.schemas` ships in a separate Maven artefact
-  (day8/re-frame2-schemas), so re-frame.core / re-frame.test-support
-  MUST NOT statically `:require` it — they look the schemas API up
-  through the hook table at call time. When the schemas artefact is
-  not on the classpath, the lookup returns nil and the consumer
-  no-ops (or, in the case of `rf/reg-app-schema`, throws a clear
-  `:rf.error/schemas-artefact-missing` so the misconfiguration is
-  surfaced rather than silently absorbed).
-
-  On the JVM we historically used `(resolve 'ns/sym)` to defer the
-  lookup to runtime. That works on the JVM because `clojure.core/resolve`
-  is a runtime fn — but ClojureScript has no runtime `resolve` (the
-  symbol exists only as a compile-time analyzer affordance), so every
-  CLJS call site silently no-op'd. That manifested as e.g.
-  `(rf/make-frame {:on-create [:foo]})` returning a frame whose app-db
-  was never seeded by `:on-create`, and `:fx [[:dispatch [...]]]`
-  becoming a no-op.
-
-  This namespace replaces those `resolve` calls with an explicit hook
-  registry. The producing namespace registers its callable at load
-  time via `set-fn!`; the consuming namespace fetches it via `get-fn`
-  at call time. Identical behaviour on JVM and CLJS.
-
-  Per Spec 002 §reg-frame is atomic: `:on-create` runs synchronously
-  inside `reg-frame`; `make-frame` is a thin wrapper, so by the time
-  `make-frame` returns the frame's app-db reflects the init handler's
-  commits. Callers MUST register the `:on-create` event's handler
-  BEFORE calling `make-frame` / `reg-frame`. (When the JVM/CLJS host
-  loads `re-frame.core`, the canonical re-frame.router namespace is
-  loaded — and registers its hooks — before any user code runs.)
+  Carries two flavours of forward reference:
+    1. Cyclic-load: leaf namespaces (frame, fx, cofx, subs, router)
+       calling into higher-level namespaces without `:require`ing them.
+    2. Cross-artefact: re-frame.core reaching into an optional artefact
+       (schemas, flows, routing, machines, ssr, epoch, http) without
+       statically `:require`ing it — when the artefact is absent the
+       lookup returns nil and the consumer no-ops (or throws a clear
+       `:rf.error/<artefact>-artefact-missing`).
 
   The authoritative inventory of every published key lives in
-  `re-frame.late-bind.directory` — plain CLJC data, one entry per
-  hook key, with the producer ns, design bead, and one-line
-  description. The drift test
-  `implementation/core/test/re_frame/late_bind_drift_test.clj`
-  asserts the directory and the `set-fn!` call sites stay in sync.")
+  `re-frame.late-bind.directory` — one CLJC entry per hook key. The
+  drift test `implementation/core/test/re_frame/late_bind_drift_test.clj`
+  asserts the directory matches the in-tree `set-fn!` call sites.")
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -74,37 +45,17 @@
   "Wire `step-fn` into the chained hook under `hook-key` so calling the
   hook runs `step-fn` AND every previously-registered step.
 
-  Pairs with the inline get-prev-and-wrap idiom several chained
-  hooks use (`:adapter/clear-warn-once-caches!` published by the
-  React-shaped adapters + re-frame.views.warn-once; `:reagent/set-hiccup-emitter!`
-  chained across the Reagent / UIx / Helix / reagent-slim adapters
-  per rf2-4z7bp). Each adapter ns previously open-coded:
-
-      (let [previous (late-bind/get-fn hook-key)]
-        (late-bind/set-fn! hook-key
-          (fn chained [& args]
-            (apply step-fn args)
-            (when previous (apply previous args))
-            nil)))
-
-  Replaced by the single-line call:
-
-      (late-bind/chain-fn! hook-key step-fn)
-
   Semantics:
-    * `step-fn` runs FIRST on every invocation (insertion-order
-      head of the chain — last-registered step is the outer wrapper).
+    * `step-fn` runs FIRST on every invocation (last-registered step
+      is the outer wrapper).
     * Each previous handler is invoked with the same `args` after
       `step-fn` returns.
-    * Per-step throws propagate; the chain does NOT swallow them
-      (each contributing ns is responsible for its own try/catch
-      semantics).
+    * Per-step throws propagate; the chain does NOT swallow them.
     * Returns nil — chained hooks are side-effecting (cache resets,
       emitter installs); callers do not consume a return value.
 
-  Per rf2-1fh5h (UIx batch). Sibling for routed hooks is
-  `re-frame.substrate.adapter/route-hook!` (single-step routing,
-  dispatched by installed-adapter identity)."
+  Sibling for routed (single-step, dispatched by installed-adapter
+  identity) hooks is `re-frame.substrate.adapter/route-hook!`."
   [hook-key step-fn]
   (let [previous (get-fn hook-key)]
     (set-fn! hook-key
@@ -118,35 +69,20 @@
   `:rf.error/<artefact>-artefact-missing` ex-info when the hook is
   unregistered.
 
-  The throw shape matches the documented missing-artefact contract used
-  by every `re-frame.core-<artefact>` wrapper (see rf2-5b6x — the
-  late-bind-missing test suite locks this shape across all six per-
-  feature splits):
-
     Message:  `<error-keyword>` printed as a string (e.g.
               \":rf.error/flows-artefact-missing\").
-    ex-data:  {:where    <where-sym>            ;; user-facing fn symbol
+    ex-data:  {:where    <where-sym>
                :recovery :no-recovery
                :reason   \"<where-sym> requires <maven> on the classpath;
                           add it to deps and require <require-ns> at app boot.\"
-               & extra}                          ;; per-call slots
+               & extra-data}
 
-  Args:
-    hook-key      — the late-bind hook key (e.g. `:flows/reg-flow`).
-    where-sym     — the user-facing fn symbol stamped on the error
-                    (e.g. `'rf/reg-flow`) so greping for the symbol
-                    finds the call site in user code.
-    artefact-info — a map carrying the artefact's Maven coordinates and
-                    the producing ns name:
-                      {:error-keyword :rf.error/flows-artefact-missing
-                       :maven         \"day8/re-frame2-flows\"
-                       :require-ns    \"re-frame.flows\"}
-    extra-data    — (optional) per-call ex-data slots like `:flow-id` /
-                    `:path` / `:route-id` / `:machine-id` / `:frame`.
+  `where-sym` is the user-facing fn symbol stamped on the error.
+  `artefact-info` carries `{:error-keyword :maven :require-ns}`.
+  `extra-data` is the per-call ex-data merged in (e.g. `:flow-id`,
+  `:route-id`).
 
-  Pairs with the `re-frame.core-artefact/defwrapper` factory (rf2-h824v)
-  which drives 26+ call sites across seven `core_<artefact>.cljc`
-  wrappers from a declarative table."
+  Pairs with `re-frame.core-artefact/defwrapper`."
   ([hook-key where-sym artefact-info]
    (require-fn! hook-key where-sym artefact-info nil))
   ([hook-key where-sym {:keys [error-keyword maven require-ns]} extra-data]

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -151,11 +151,11 @@
    {:key         :schemas/extract-large-paths-from-schema
     :producer-ns 're-frame.schemas
     :design-bead "rf2-nwv63"
-    :description "Walk a Malli EDN form at a base-path; return {path declaration} entries for :large? true slots. Consumed by re-frame.elision per rf2-ynnq0 Option A (rf2-w3n5u impl)."}
+    :description "Walk a Malli EDN form at a base-path; return {path declaration} entries for :large? true slots. Consumed by re-frame.elision."}
    {:key         :schemas/extract-sensitive-paths-from-schema
     :producer-ns 're-frame.schemas
     :design-bead "rf2-kj51z"
-    :description "Walk a Malli EDN form at a base-path; return paths whose props carry :sensitive? true. Consumed by re-frame.elision per rf2-ynnq0 Option A (rf2-w3n5u impl)."}
+    :description "Walk a Malli EDN form at a base-path; return paths whose props carry :sensitive? true. Consumed by re-frame.elision."}
 
    ;; ---- re-frame.machines (rf2-xbtj / rf2-8bp3) ------------------------------
    {:key         :machines/reg-machine

--- a/implementation/core/src/re_frame/privacy.cljc
+++ b/implementation/core/src/re_frame/privacy.cljc
@@ -188,8 +188,8 @@
           ;; runtime's emit sites to consult (per the in-chain
           ;; emits listed in the with-redacted docstring above).
           ;;
-          ;; Per rf2-isdwf: also force `:sensitive? true` for the
-          ;; rest of this handler's scope. The interceptor itself
+          ;; Also force `:sensitive? true` for the rest of this
+          ;; handler's scope. The interceptor itself
           ;; runs INSIDE the event-handler's `*handler-scope*`
           ;; binding (router.cljc binds before the chain runs), so
           ;; we can't `binding`-shadow it here. Instead we stash a

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -12,14 +12,13 @@
   the machine's :guards / :actions map) and NOT registered as standalone
   kinds. The kinds set below is the closed v1 list.
 
-  Per rf2-0frdi the `:app-schema` kind is RESERVED but the registrar
-  slot is intentionally **empty** — `reg-app-schema` writes only to the
+  The `:app-schema` kind is RESERVED but the registrar slot is
+  intentionally **empty** — `reg-app-schema` writes only to the
   schemas artefact's own per-frame side-table (`schemas/schemas-by-
   frame`), which is the single source of truth. The kind keyword is
   preserved for the test-support `:clear-kinds` interface and for
   Spec 001 §Registry model continuity; tools introspecting app-db
-  schemas go through `schemas/app-schemas` / `schemas/app-schema-meta-at`
-  rather than `handlers :app-schema` / `handler-meta :app-schema`.
+  schemas go through `schemas/app-schemas` / `schemas/app-schema-meta-at`.
 
   ## Production elision
 

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -694,7 +694,10 @@
     (binding [frame/*current-frame* (:frame envelope)]
       (process-event* envelope))))
 
-(def ^:private drain-depth-default 100)
+(def ^:private drain-depth-default
+  ;; Deep enough for typical cascade depths; cheap atomic rollback per
+  ;; Spec 002 §Run-to-completion rule 3 when exceeded.
+  100)
 
 (defn- handle-depth-exceeded!
   "Tail-path for the depth-limit branch of `drain!`. Atomic rollback per

--- a/implementation/core/src/re_frame/source_coords.cljc
+++ b/implementation/core/src/re_frame/source_coords.cljc
@@ -82,8 +82,8 @@
   `*file*` arg when non-sentinel, else `nil` (caller `cond->`s it in,
   so nil means omit the slot).
 
-  Per rf2-mdjp: the CLJS analyzer never binds Clojure's `*file*` during
-  macro expansion, so reading `*file*` alone returns the JVM
+  The CLJS analyzer never binds Clojure's `*file*` during macro
+  expansion, so reading `*file*` alone returns the JVM
   `\"NO_SOURCE_PATH\"` sentinel under CLJS. Form-meta `:file` is the
   portable answer."
   [form-meta file]
@@ -102,7 +102,7 @@
   data the caller splices into its expansion.
 
   :file picks the form-meta value over `*file*` and rejects the
-  `\"NO_SOURCE_PATH\"` sentinel per `resolve-file` (rf2-mdjp)."
+  `\"NO_SOURCE_PATH\"` sentinel via `resolve-file`."
   [form-meta file ns-sym]
   (let [chosen-file (resolve-file form-meta file)]
     `(cond-> {:ns '~ns-sym}
@@ -110,9 +110,9 @@
        ~(:line form-meta)   (assoc :line ~(:line form-meta))
        ~(:column form-meta) (assoc :column ~(:column form-meta)))))
 
-;; ---- per-element spec stamping (rf2-8bp3) --------------------------------
+;; ---- per-element spec stamping -------------------------------------------
 ;;
-;; Per Spec 005 §Source-coord stamping (rf2-8bp3): the `reg-machine` macro
+;; Per Spec 005 §Source-coord stamping: the `reg-machine` macro
 ;; walks its literal machine-spec form at expansion time and produces a
 ;; per-element coord index keyed by **path through the spec**. Tools (pair,
 ;; 10x, IDE jump-to-source) read the index back via `(rf/handler-meta :event
@@ -142,9 +142,9 @@
   decorated (lists, vectors, maps, symbols) carry `:line` / `:column` from
   the source position. Returns nil when the form has no positional meta.
 
-  Per rf2-mdjp the same `:file` resolution as the call-site path applies:
-  prefer the reader-attached `:file` on the form's metadata over the
-  macro's `*file*` arg, and reject the `\"NO_SOURCE_PATH\"` sentinel."
+  The same `:file` resolution as the call-site path applies: prefer
+  the reader-attached `:file` on the form's metadata over the macro's
+  `*file*` arg, and reject the `\"NO_SOURCE_PATH\"` sentinel."
   [form ns-sym file]
   (let [m            (meta form)
         chosen-file  (resolve-file m file)]
@@ -167,9 +167,8 @@
   is private to this namespace and used only inside `walk-states-tree`
   and `walk-machine-spec`, both of which bind those three locals.
 
-  Per rf2-7bha1: hides the repetitive shape behind a single two-arg call
-  at every reference-site stamp, dropping ~45 LoC of nested `when-let`s
-  for a ~20 LoC macro+helpers definition."
+  Hides the repetitive shape behind a single two-arg call at every
+  reference-site stamp."
   [path form]
   `(when-let [c# (form-coords ~form ~'ns-sym ~'file)]
      (assoc! ~'acc ~path c#)))

--- a/implementation/core/src/re_frame/source_coords/editor_uri.cljc
+++ b/implementation/core/src/re_frame/source_coords/editor_uri.cljc
@@ -1,5 +1,5 @@
 (ns re-frame.source-coords.editor-uri
-  "Build an 'open in editor' URI from a source-coord map (per rf2-evgf5).
+  "Build an 'open in editor' URI from a source-coord map.
 
   Tools that surface a `{:file :line :column :ns}` source-coord — Story's
   variant canvas, Story's per-test failure detail, Causa's event-detail
@@ -46,7 +46,7 @@
 
   Source-coord `:file` is what the macro layer captured at registration
   time. Under CLJS it's typically `\"path/to/file.cljs\"` relative to the
-  classpath root (resolved via the form-meta `:file` slot, per rf2-mdjp).
+  classpath root (resolved via the form-meta `:file` slot).
   The editor opens the file from disk, so the URI must carry a path the
   editor's resolver can find.
 

--- a/implementation/core/src/re_frame/spec.cljc
+++ b/implementation/core/src/re_frame/spec.cljc
@@ -43,13 +43,13 @@
     to flag the misconfiguration.
 
   Validation routes through the same registered validator the dev-time
-  hot path uses (per rf2-froe's `set-schema-validator!` seam) — a
-  substituted validator covers both surfaces with one registration.
-  When `set-schema-validator!` has been called with `nil` the boundary
+  hot path uses (the `set-schema-validator!` seam) — a substituted
+  validator covers both surfaces with one registration. When
+  `set-schema-validator!` has been called with `nil` the boundary
   interceptor is also a no-op (validation disabled).
 
-  This namespace stays decoupled from `re-frame.schemas` (the schemas
-  artefact is optional per rf2-p7va) by reaching into it through the
+  This namespace stays decoupled from `re-frame.schemas` (an optional
+  artefact) by reaching into it through the
   `:schemas/validate-with-registered-fn` and
   `:schemas/explain-with-registered-fn` late-bind hooks. When the
   schemas artefact is not on the classpath the hooks return nil and
@@ -116,11 +116,11 @@
 
 ;; ---- :spec/validate-at-boundary -------------------------------------------
 ;;
-;; Per Spec 010 §Production builds (rf2-r2uh). The interceptor runs in the
-;; :before slot — pre-handler, alongside the dev-mode step-1 validation
-;; site. Failure recovery is identical to step-1: skip the handler
-;; (set :rf/skip-handler? on the context per rf2-jwm4 / rf2-7leq);
-;; downstream queue continues.
+;; Per Spec 010 §Production builds. The interceptor runs in the
+;; :before slot — pre-handler, alongside the dev-mode step-1
+;; validation site. Failure recovery is identical to step-1: skip the
+;; handler (set `:rf/skip-handler?` on the context); downstream queue
+;; continues.
 
 (def validate-at-boundary
   "Production-side schema validation interceptor. Per Spec 010 §Production
@@ -128,12 +128,12 @@
   to force `:spec` validation against the dispatched event vector even
   in production builds where dev-time validation is elided.
 
-  Re-uses the handler's existing `:spec` metadata; does not introduce a
-  parallel schema. No-op in dev builds (step-1 validation already
-  fires); no-op when no validator is registered (per rf2-froe's
-  `set-schema-validator!` `nil` path); no-op when the handler carries
-  no `:spec` (and emits `:rf.warning/boundary-without-spec` once to
-  flag the misconfiguration)."
+  Re-uses the handler's existing `:spec` metadata; does not introduce
+  a parallel schema. No-op in dev builds (step-1 validation already
+  fires); no-op when no validator is registered (`set-schema-validator!`
+  was called with `nil`); no-op when the handler carries no `:spec`
+  (and emits `:rf.warning/boundary-without-spec` once to flag the
+  misconfiguration)."
   (interceptor/->interceptor
     :id :spec/validate-at-boundary
     :before
@@ -146,7 +146,7 @@
         ctx
         ;; Production path. Reach validation through the late-bind
         ;; seam so this namespace stays decoupled from the optional
-        ;; schemas artefact (rf2-p7va).
+        ;; schemas artefact.
         (let [validate-fn (late-bind/get-fn :schemas/validate-with-registered-fn)
               explain-fn  (late-bind/get-fn :schemas/explain-with-registered-fn)]
           (if (nil? validate-fn)
@@ -219,6 +219,6 @@
                                           :recovery   :no-recovery})
                       ;; Per Spec 010 §Per-step recovery step 1: handler
                       ;; is not invoked. The handler-as-interceptor
-                      ;; checks :rf/skip-handler? in its :before slot
-                      ;; (per rf2-jwm4 / rf2-7leq events.cljc).
+                      ;; checks `:rf/skip-handler?` in its :before slot
+                      ;; (see events.cljc).
                       (assoc ctx :rf/skip-handler? true))))))))))))

--- a/implementation/core/src/re_frame/std_interceptors.cljc
+++ b/implementation/core/src/re_frame/std_interceptors.cljc
@@ -42,12 +42,11 @@
                       (get-in (:db (:coeffects ctx)) path-vec))))
       :after
       (fn [ctx]
-        ;; Per rf2-rwlj2: the splice-back only fires when the handler
-        ;; actually emitted a `:db` effect. If the handler returned no
-        ;; `:db`, the slice didn't change and we MUST NOT synthesise a
-        ;; `:db` effect — downstream tools rely on "no `:db` effect = no
-        ;; DB write" (the docstring contract). The original code
-        ;; unconditionally wrote `:db`, which was idempotent at the
+        ;; The splice-back only fires when the handler actually emitted
+        ;; a `:db` effect. If the handler returned no `:db`, the slice
+        ;; didn't change and we MUST NOT synthesise a `:db` effect —
+        ;; downstream tools rely on "no `:db` effect = no DB write" (the
+        ;; docstring contract). Synthesising would be idempotent at the
         ;; value level (same `original-db` re-spliced with the same
         ;; pre-handler slice) but allocated a fresh map per path-walk-
         ;; step and produced a spurious `:db` effect from a no-`:db`

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -236,19 +236,11 @@
      exception emit :rf.error/sub-exception and yield nil (recovery
      :replaced-with-default)."
   [body-fn in-vals query-id query-v frame-id input-signals sub-meta]
-  ;; Per rf2-ryri7: publish the sub's HandlerScope for the duration
-  ;; of `:sub/run` emit + body-fn invocation + validation step. Spec
-  ;; 009 §:rf.trace/trigger-handler table row "Inside a sub recompute
-  ;; (body fn)" — the sub's source-coord rides every emit (success
-  ;; path: `:sub/run`; error path: `:rf.error/sub-exception`,
-  ;; schema-validation failures, transitive sub misses). The emit MUST
-  ;; sit inside the scope for the sub's coord to ride the success
-  ;; trace. `:sensitive?` (rf2-isdwf) per Spec 009 §Privacy — sub
-  ;; return values flow user input into views and must be filterable.
-  ;; `:no-emit?` (rf2-qsjda) — a sub whose registration carries
-  ;; `:rf.trace/no-emit? true` produces no `:sub/run` trace event
-  ;; (and no error trace if it throws). `:call-site` / `:dispatch-id`
-  ;; are inherited from the outer scope per `inherit-scope`.
+  ;; Publish the sub's HandlerScope for the duration of `:sub/run` emit
+  ;; + body-fn invocation + validation. Per Spec 009 §:rf.trace/
+  ;; trigger-handler the sub's source-coord rides every emit (`:sub/run`
+  ;; success, `:rf.error/sub-exception` / schema-validation / transitive
+  ;; sub-miss errors). The emit MUST sit inside the scope.
   (trace/with-handler-scope
     (trace/handler-scope-from-meta :sub query-id sub-meta)
     (trace/emit! :sub/run :sub/run
@@ -293,13 +285,12 @@
 ;; compute fn — only the user's body (and the trace+validate+perf+
 ;; recovery layer that brackets it) is suppressed.
 ;;
-;; Per rf2-sxacg: the layer-1 path is specialised to a fixed-arity-1
-;; wrapper that compares the db value directly. This skips the
-;; varargs-seq allocation that `(fn [& in-vals])` would force on every
-;; recompute, and replaces the seq-vs-seq `=` walk with a direct value
-;; compare. Every layer-1 sub × every dispatch that touches it pays
-;; this — it's the hottest allocation in the artefact (per the
-;; rf2-spr6q audit, SU1/PE1).
+;; The layer-1 path is specialised to a fixed-arity-1 wrapper that
+;; compares the db value directly. This skips the varargs-seq allocation
+;; a `(fn [& in-vals])` form would force on every recompute, and
+;; replaces the seq-vs-seq `=` walk with a direct value compare. Every
+;; layer-1 sub × every dispatch that touches it pays this — the hottest
+;; allocation in the artefact.
 
 (defn- make-layer-1-memoised-body
   "Specialised memo wrapper for layer-1 subs (which read app-db
@@ -362,20 +353,18 @@
     - `make-layer-1-memoised-body` / `make-layer-n-memoised-body` —
       Spec 006 §No-op via value equality (rf2-719e). Wraps the user's
       body in a `=`-skipping memo. The layer-1 form is fixed-arity-1
-      and compares the db scalar directly (per rf2-sxacg — avoids
-      per-recompute varargs-seq allocation); layer-2+ keeps the
-      vec-of-inputs shape.
-    - `validate-and-trace`  — Spec 009 :sub/run trace emit, Spec 009
-      perf bracket (rf2-du3i), Spec 010 step 6 validation (rf2-wcam),
-      and Spec 009 error contract (`:replaced-with-default` on throw).
+      and compares the db scalar directly (avoids per-recompute
+      varargs-seq allocation); layer-2+ keeps the vec-of-inputs shape.
+    - `validate-and-trace`  — Spec 009 :sub/run trace emit, perf bracket,
+      Spec 010 step 6 validation, error contract
+      (`:replaced-with-default` on throw).
 
-  Per Spec 006 §What happens when a sub references an unknown sub
-  (rf2-l9u5): when the registrar lookup misses, emit
-  `:rf.error/no-such-sub` and build a nil-yielding reaction, but
-  DO NOT store it in the cache. The miss is transient — a later
-  registration (boot order, lazy load) must let the next subscribe
-  build a fresh reaction against the real body. We achieve this by
-  branching here on nil meta."
+  Per Spec 006 §What happens when a sub references an unknown sub: when
+  the registrar lookup misses, emit `:rf.error/no-such-sub` and build a
+  nil-yielding reaction, but DO NOT store it in the cache. The miss is
+  transient — a later registration (boot order, lazy load) must let the
+  next subscribe build a fresh reaction against the real body. We
+  achieve this by branching here on nil meta."
   [frame-id query-v]
   (let [query-id      (first query-v)
         sub-meta      (registrar/lookup :sub query-id)
@@ -410,16 +399,13 @@
                             :pending-dispose nil})
       (interop/add-on-dispose! reaction
         (fn []
-          ;; Per rf2-f3rd: a layer-2+ sub's construction called `subscribe`
-          ;; once per `:<-` input (line 290 above), each incrementing the
-          ;; input's `:ref-count`. The disposal of this parent slot must
-          ;; release those refs symmetrically — without this, input
-          ;; ref-counts leak after Reagent auto-disposes the parent. We
-          ;; decrement inputs BEFORE clearing the parent slot so the cache
-          ;; introspection invariant ("ref-count reflects live refs")
-          ;; holds at every observable moment; the recursive disposal
-          ;; cascade is driven by the same ref-count → 0 path
-          ;; `unsubscribe` already takes.
+          ;; A layer-2+ sub's construction called `subscribe` once per
+          ;; `:<-` input, each incrementing the input's `:ref-count`.
+          ;; The disposal must release those refs symmetrically —
+          ;; without this, input ref-counts leak after Reagent auto-
+          ;; disposes the parent. Decrement inputs BEFORE clearing the
+          ;; parent slot so the cache invariant ("ref-count reflects
+          ;; live refs") holds at every observable moment.
           (doseq [input-q input-signals]
             (try (unsubscribe frame-id input-q)
                  (catch #?(:clj Throwable :cljs :default) _ nil)))
@@ -447,12 +433,12 @@
   the JVM build never loads it; production (`:advanced` +
   `goog.DEBUG=false`) elides via `interop/debug-enabled?`.
 
-  Per rf2-ts1a: this is the runtime-callable fn form. The macro form
+  This is the runtime-callable fn form. The macro form
   `re-frame.core/subscribe` captures `(meta &form)` and delegates here
   through `re-frame.core/subscribe*`, wrapping the call in
-  `trace/with-call-site` for the duration so any error emitted inside
-  the synchronous miss path (`:rf.error/no-such-sub`,
-  `:rf.error/frame-destroyed`) carries the invocation coord."
+  `trace/with-call-site` so any error emitted inside the synchronous
+  miss path (`:rf.error/no-such-sub`, `:rf.error/frame-destroyed`)
+  carries the invocation coord."
   ([query-v]
    #?(:cljs
       (let [frame-id (frame/resolve-current-frame)]
@@ -508,25 +494,20 @@
   so the read is part of the cofx contract rather than a side-effect
   inside the handler body.
 
-  Per rf2-zmufj: the teardown unsubscribe runs with `{:grace 0}` so
-  the one-shot read's whole lifetime — subscribe, deref, dispose —
-  completes in the calling tick. Without this, a fresh-sub call
-  would build, deref, then schedule a grace-period timer that fires
-  after the caller has moved on, leaking dispose side-effects
-  (`set-timeout!` + `clear-timeout!` + the post-grace `dispose!`
-  trace burst) past the call's observable lifetime.
+  The teardown unsubscribe runs with `{:grace 0}` so the one-shot
+  read's whole lifetime — subscribe, deref, dispose — completes in
+  the calling tick (without it the fresh-sub would schedule a grace-
+  period timer leaking dispose side-effects past the call's
+  observable lifetime).
 
   See also: `subscribe`, `unsubscribe`, `compute-sub`, `inject-cofx`."
   ([query-v] (subscribe-value (frame/resolve-current-frame) query-v))
   ([frame-id query-v]
    (let [reaction (subscribe frame-id query-v)
          v        (when reaction @reaction)]
-     ;; Per rf2-zmufj: force synchronous dispose for our own teardown so
-     ;; the one-shot read surface pays no deferred-dispose tax. The
-     ;; `{:grace 0}` opt overrides the configured grace-period for this
-     ;; call only — concurrent subscribers (if any) keep the slot alive
-     ;; via ref-count and are unaffected; this call's decrement only
-     ;; triggers disposal when it drove the 1→0 transition.
+     ;; `{:grace 0}` overrides the configured grace-period for this
+     ;; call only — concurrent subscribers keep the slot alive via
+     ;; ref-count and are unaffected.
      (unsubscribe frame-id query-v {:grace 0})
      v)))
 
@@ -571,12 +552,12 @@
   is still <= 0 (no resubscribe arrived) and dispose the reaction.
   Idempotent — a second call is a no-op because the slot is gone.
 
-  Per rf2-3mww7: the swap-fn body is pure — it returns the new cache
-  map and nothing else. The reaction to dispose is read from the
-  PRE-swap snapshot returned by `swap-vals!` and acted on AFTER the
-  CAS commits. `swap!` is allowed to retry on contention on the JVM,
-  so any side-effect (interop/dispose!) inside the swap-fn could fire
-  2+ times under concurrent invalidate + grace-fire."
+  The swap-fn body is pure — it returns the new cache map and nothing
+  else; the reaction to dispose is read from the PRE-swap snapshot
+  returned by `swap-vals!` and acted on AFTER the CAS commits. `swap!`
+  is allowed to retry on contention on the JVM, so any side-effect
+  (`interop/dispose!`) inside the swap-fn could fire 2+ times under
+  concurrent invalidate + grace-fire."
   [cache k]
   (let [[old new] (swap-vals! cache
                               (fn [m]
@@ -606,7 +587,7 @@
 
   When grace-period is 0, disposal is synchronous — useful for tests.
 
-  The 3-arity form accepts an opts map. Per rf2-zmufj:
+  The 3-arity form accepts an opts map:
 
       {:grace N}   — override the configured grace-period for THIS
                      call only. `{:grace 0}` forces synchronous
@@ -627,22 +608,19 @@
   ([frame-id query-v opts]
    (when-let [cache (:sub-cache (frame/frame frame-id))]
      (let [k     (cache-key query-v)
-           ;; Per rf2-zmufj: an explicit `:grace` in opts overrides the
-           ;; per-runtime configured grace-period for this call only.
-           ;; `contains?` rather than `(:grace opts)` so `{:grace 0}`
-           ;; is honoured (0 is truthy in Clojure but reads better
-           ;; intent-wise to gate on presence).
+           ;; An explicit `:grace` in opts overrides the per-runtime
+           ;; configured grace-period. `contains?` (not `(:grace opts)`)
+           ;; so `{:grace 0}` is honoured.
            grace (if (and (map? opts) (contains? opts :grace))
                    (:grace opts)
                    (grace-period-ms))
-           ;; Per rf2-3mww7: the swap-fn body is pure — it returns only
-           ;; the new cache map. The drop-to-zero signal is read from
-           ;; the diff between `old` and `new` AFTER the CAS commits.
-           ;; `swap!` is allowed to retry on contention on the JVM, so
-           ;; a side-effecting `(reset! dropped-to-zero? true)` inside
-           ;; the swap-fn body could fire on a discarded retry whose
-           ;; CAS lost — leading to a spurious dispose schedule for
-           ;; a slot that was never actually transitioned by this call.
+           ;; The swap-fn body is pure — it returns only the new cache
+           ;; map. The drop-to-zero signal is read from the diff between
+           ;; `old` and `new` AFTER the CAS commits. `swap!` is allowed
+           ;; to retry on JVM contention, so a side-effecting
+           ;; `(reset! dropped-to-zero? true)` inside the swap-fn body
+           ;; could fire on a discarded retry whose CAS lost — leading
+           ;; to a spurious dispose schedule.
            [old new] (swap-vals! cache
                                  (fn [m]
                                    (if-let [entry (get m k)]
@@ -716,14 +694,10 @@
   (when (= kind :sub)
     (doseq [frame-id (frame/frame-ids)]
       (when-let [cache (:sub-cache (frame/frame frame-id))]
-        ;; Per rf2-3mww7: the swap-fn body is pure — it returns only the
-        ;; new cache map. Reactions to dispose and timers to cancel are
-        ;; read from the diff between `old` and `new` AFTER the CAS
-        ;; commits. `swap!` is allowed to retry on contention on the
-        ;; JVM, so any side-effecting collector (`(swap! evictions
-        ;; conj ...)`) inside the swap-fn could double-conj — and then
-        ;; the post-swap `dispose!` loop would call dispose on the same
-        ;; reaction twice.
+        ;; The swap-fn body is pure — it returns only the new cache map.
+        ;; Reactions to dispose and timers to cancel are read from the
+        ;; diff between `old` and `new` AFTER the CAS commits (so a
+        ;; retried `swap!` can't fire dispose 2+ times).
         (let [[old new] (swap-vals! cache
                                     (fn [m]
                                       (let [hit-keys (->> (keys m)

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -163,7 +163,10 @@
 ;; bridge typical React render churn. Tests that want to assert on disposal
 ;; configure a short or zero value via configure!.
 
-(def ^:private default-grace-period-ms 50)
+(def ^:private default-grace-period-ms
+  ;; Long enough to bridge typical React render churn; short enough not
+  ;; to leak under genuine disposal.
+  50)
 
 (defonce ^:private config
   ;; Map shape so future :sub-cache configure-keys land additively.

--- a/implementation/core/src/re_frame/substrate/adapter.cljc
+++ b/implementation/core/src/re_frame/substrate/adapter.cljc
@@ -22,15 +22,13 @@
   install-adapter! and introspected via current-adapter (keyword) and
   current-adapter-spec (the full map).
 
-  Per rf2-agql (replaces rf2-84po) there is no default-adapter registry
-  and no ns-load side-effect. Each adapter ns
-  (re-frame.adapter.reagent / .uix / .helix, re-frame.substrate.plain-atom,
-  re-frame.ssr) exports an `adapter` var (the spec map); consumers
-  require the ns and pass the var explicitly via
-  `(rf/init! reagent/adapter)` etc. The registry was removed because:
-  (1) explicit > implicit at the call site; (2) the registry is bundle
-  weight even when unused — under rf2-agql an app that requires only
-  the adapter it needs ships only that adapter's code."
+  There is no default-adapter registry and no ns-load side-effect.
+  Each adapter ns (re-frame.adapter.reagent / .uix / .helix,
+  re-frame.substrate.plain-atom, re-frame.ssr) exports an `adapter`
+  var (the spec map); consumers require the ns and pass the var
+  explicitly via `(rf/init! reagent/adapter)`. Explicit > implicit
+  at the call site, and an app requiring only the adapter it needs
+  ships only that adapter's code."
   (:require [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace]))
 
@@ -38,7 +36,7 @@
 
 ;; ---- adapter installation -------------------------------------------------
 ;;
-;; Two cells, not one (rf2-6wxys). `installed-adapter` holds the live spec
+;; Two cells, not one. `installed-adapter` holds the live spec
 ;; map when an adapter is installed and `nil` otherwise. `disposed?` is a
 ;; boolean breadcrumb left behind by the most recent
 ;; `(dispose-adapter!)` so subsequent runtime calls can distinguish
@@ -116,8 +114,7 @@
   "Return true iff the most recent lifecycle event was a successful
   `dispose-adapter!` and no `install-adapter!` has fired since. False
   for `never installed` (fresh process) and after a fresh install.
-  Read-only — the breadcrumb is owned by the install / dispose pair.
-  Per rf2-6wxys §differentiate disposed-adapter from never-installed."
+  Read-only — the breadcrumb is owned by the install / dispose pair."
   []
   @disposed?)
 
@@ -125,9 +122,9 @@
   "Test-only seam — resets the installed-adapter slot and the disposed
   breadcrumb to a never-installed cold state. NOT part of the runtime
   contract; cold-start test fixtures (e.g. `boot_test/cold-start`) use
-  this to wipe the lifecycle state between cases so the
-  no-adapter-installed throw can be asserted independently of the
-  adapter-disposed throw. Per rf2-6wxys."
+  this to wipe the lifecycle state between cases so the no-adapter-
+  installed throw can be asserted independently of the adapter-
+  disposed throw."
   []
   (reset! installed-adapter nil)
   (reset! disposed? false)
@@ -272,16 +269,13 @@
 ;; `(rf/init! reagent/adapter)` then silently uses (say) UIx's impl,
 ;; breaking adapter-specific contracts.
 ;;
-;; Per rf2-0d35 the fix is to wrap each adapter's impl in a routing
-;; closure that runs the impl ONLY when this adapter is the
-;; (rf/init!)-installed one; otherwise the closure chains to the
-;; previously-registered handler (which itself does the same
-;; active-adapter check for ITS adapter). The chain terminates with
-;; fallback-fn when no previous handler is registered — typically
-;; `(constantly nil)` (default), `(constantly false)` for predicates,
-;; or `#(frame/current-frame)` for the React-context-tier
-;; `:adapter/current-frame` hook (whose chain-bottom is the
-;; dynamic-var / :rf/default resolution in re-frame.frame).
+;; The fix is to wrap each adapter's impl in a routing closure that
+;; runs the impl ONLY when this adapter is the (rf/init!)-installed
+;; one; otherwise the closure chains to the previously-registered
+;; handler (which does the same active-adapter check for ITS adapter).
+;; The chain terminates with fallback-fn — typically `(constantly nil)`,
+;; `(constantly false)` for predicates, or `#(frame/current-frame)`
+;; for the React-context-tier `:adapter/current-frame` hook.
 
 (defn route-hook!
   "Install `impl-fn` under late-bind hook `hook-key`, wrapped so the call
@@ -291,8 +285,7 @@
   the first/only adapter to publish this hook), the routed closure
   returns `(fallback-fn)`.
 
-  Per rf2-0d35. See `spec/006-ReactiveSubstrate.md` for the adapter
-  routing contract.
+  See `spec/006-ReactiveSubstrate.md` for the adapter routing contract.
 
   3-arg form: defaults `fallback-fn` to `(constantly nil)` — the
   most common shape across the adapters (nil-fallback semantics).

--- a/implementation/core/src/re_frame/substrate/plain_atom.cljc
+++ b/implementation/core/src/re_frame/substrate/plain_atom.cljc
@@ -6,11 +6,10 @@
   no caching, no listeners. Trivially compliant with the revertibility
   contract because there is no state outside the atom.
 
-  Per rf2-agql (replaces rf2-84po) there is no default-adapter registry
-  and no ns-load side-effect. Consumers (JVM tests, headless SSR hosts,
-  any process that wants the plain-atom path on CLJS) call
-  `(rf/init! plain-atom/adapter)` explicitly. The `adapter` var below
-  is the public surface.")
+  There is no default-adapter registry and no ns-load side-effect.
+  Consumers (JVM tests, headless SSR hosts, any process that wants the
+  plain-atom path on CLJS) call `(rf/init! plain-atom/adapter)`
+  explicitly. The `adapter` var below is the public surface.")
 
 #?(:clj (set! *warn-on-reflection* true))
 

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -1,11 +1,9 @@
 (ns re-frame.substrate.spine
   "Shared substrate-spine helpers for React-shaped adapters that lack a
-  native reactive-atom primitive (UIx, Helix, and any future
-  minimal-React-wrapper substrate). Per rf2-3vwbx — the duplication
-  between UIx and Helix at the substrate-contract layer was byte-for-byte
-  identical modulo gensym prefixes, hook ns, and substrate-name strings.
-  This ns lifts the shared body into one place; the adapter ns wires its
-  per-substrate hooks via `make-react-spine`.
+  native reactive-atom primitive (UIx, Helix, and any future minimal-
+  React-wrapper substrate). UIx and Helix duplicated this body byte-
+  for-byte modulo gensym prefixes, hook ns, and substrate-name strings;
+  per-adapter wiring goes through `make-react-spine`.
 
   Scope. This ns provides:
 
@@ -99,9 +97,9 @@
           on-dispose-fns (atom [])
           ;; Per-source wrapper keys we own so dispose can unwire them.
           own-keys       (atom {})           ;; source → key
-          ;; Per rf2-ggx29: iterate the watcher fns via `run!` over
-          ;; `vals` rather than `doseq` over map-entries. Skips one
-          ;; map-entry seq allocation per source-change notification.
+          ;; Iterate via `run!` over `vals` rather than `doseq` over
+          ;; map-entries — skips one map-entry seq allocation per
+          ;; source-change notification.
           notify         (fn [prev nu]
                            (when (not= prev nu)
                              (run! (fn [w] (w prev nu)) (vals @watchers))))]
@@ -115,12 +113,10 @@
       ;; spuriously notify whenever the derived projection differs in
       ;; identity from the raw source — e.g. `(odd? x)`, counts, `:k`
       ;; lookups, projections — even when the derived value itself is `=`.
-      ;; (per rf2-66hb)
       ;;
       ;; `prev-state` is written and read only inside the watch callback
-      ;; (single-threaded JS / Reagent reactivity) and never escapes this
-      ;; closure, so a `volatile!` is the right primitive — no CAS cost.
-      ;; (per rf2-eiux0)
+      ;; (single-threaded JS / Reagent reactivity) and never escapes
+      ;; this closure — `volatile!` is the right primitive, no CAS cost.
       (let [prev-state (volatile! (recompute))]
         (doseq [s source-containers]
           (let [k (gensym gensym-prefix)]
@@ -178,19 +174,18 @@
   "Return a fresh `(atom #{})` cell holding React roots the spine
   currently keeps mounted. Each adapter owns its own cell so multiple
   React-shaped adapters can coexist in a test bundle without
-  clobbering each other's tracking. Per rf2-9fdkb."
+  clobbering each other's tracking."
   []
   (atom #{}))
 
 (defn make-render
   "Build a `render` fn that registers every mounted React root in
   `active-roots-cell` and returns an unmount thunk that removes the
-  root from the cell before calling `.unmount`. Per rf2-9fdkb."
+  root from the cell before calling `.unmount`."
   [active-roots-cell]
   (fn render [render-tree mount-point opts]
-    ;; Per rf2-gwkvr: Spec 006 §`render` types `:hydrate?` as a boolean;
-    ;; non-bool truthy values are undefined-behaviour. No defensive
-    ;; `boolean` coercion.
+    ;; Spec 006 §`render` types `:hydrate?` as a boolean; non-bool
+    ;; truthy values are undefined-behaviour (no defensive coercion).
     (let [hydrate? (:hydrate? opts)
           root     (if hydrate?
                      (react-dom-client/hydrateRoot mount-point render-tree)
@@ -254,11 +249,10 @@
 
 ;; ---- context provider -----------------------------------------------------
 ;;
-;; Per rf2-3yij / rf2-2qit Decision 2: every React-shaped adapter shares
-;; the same React.createContext object (it lives in
-;; re-frame.adapter.context). The provider component is identical across
-;; substrates — only `use-current-frame` (the read-side hook) varies, and
-;; only by which hook ns supplies `use-context`.
+;; Every React-shaped adapter shares the same React.createContext object
+;; (in re-frame.adapter.context). The provider component is identical
+;; across substrates — only `use-current-frame` (the read-side hook)
+;; varies, and only by which hook ns supplies `use-context`.
 
 (defn frame-provider
   "User-facing component scoping `frame-kw` to its subtree. Wraps
@@ -268,9 +262,9 @@
   `frame-provider` is.
 
   Reads `:frame` from props. When missing or `nil`, falls through to
-  `:rf/default` (per rf2-sixo — defensive default that matches the
-  no-provider behaviour and avoids breaking tooling-generated trees that
-  elide the prop)."
+  `:rf/default` — defensive default that matches the no-provider
+  behaviour and avoids breaking tooling-generated trees that elide the
+  prop."
   [{:keys [frame children]}]
   (let [frame-kw (or frame :rf/default)]
     (apply adapter-context/provider-element frame-kw
@@ -278,10 +272,9 @@
 
 (defn register-context-provider
   "Substrate `:register-context-provider` slot. Same shape across all
-  React-shaped adapters: returns the `frame-provider` fn unchanged. The
-  frame-keyword arg is ignored because the frame keyword lives in the
-  Provider's :value at render time (rf2-4y60), not in a build-time
-  closure."
+  React-shaped adapters: returns the `frame-provider` fn unchanged.
+  The frame-keyword arg is ignored because the frame keyword lives in
+  the Provider's `:value` at render time, not in a build-time closure."
   [_frame-keyword]
   frame-provider)
 
@@ -358,8 +351,8 @@
   "Return a thunk that resets `cache-atom` to `#{}` and returns nil.
   Tests use this between cases (via `reset-runtime-fixture` and the
   chained `:adapter/clear-warn-once-caches!` hook) so a sibling test's
-  first-encounter warning cannot silently swallow a later test's same-id
-  warning. Per rf2-4edk."
+  first-encounter warning cannot silently swallow a later test's same-
+  id warning."
   [cache-atom]
   (fn clear-warned-non-dom-roots! []
     (reset! cache-atom #{})
@@ -374,10 +367,6 @@
   (fn warn-non-dom-root! [id type-tag]
     (when-not (contains? @cache-atom id)
       (swap! cache-atom conj id)
-      ;; Per rf2-g7bi4: `js/console` is universally present in modern
-      ;; browsers and Node; React-shaped substrates target React 18+
-      ;; which targets those runtimes. The historical
-      ;; `(when (exists? js/console) ...)` guard is dead.
       (.warn js/console
         (str "[re-frame] reg-view " id " — root element is "
              (pr-str type-tag) " (" substrate-name "); "
@@ -436,21 +425,16 @@
   "Wire `clear-fn` into the chained `:adapter/clear-warn-once-caches!`
   late-bind hook. The hook is chained — each adapter and re-frame.views
   contribute a clear-step; `reset-runtime-fixture` invokes the top of
-  the chain and every contributor's reset runs. Per rf2-4edk.
-
-  Thin wrapper around `late-bind/chain-fn!` (rf2-1fh5h) — the
-  generic chain idiom; this wrapper exists so callers do not need
-  to know the chain key."
+  the chain and every contributor's reset runs. Thin wrapper around
+  `late-bind/chain-fn!` so callers don't need to know the chain key."
   [clear-fn]
   (late-bind/chain-fn! :adapter/clear-warn-once-caches! clear-fn))
 
 ;; ---- subscription hook ----------------------------------------------------
 ;;
-;; Per Spec 006 §subscription-cache (rf2-3yij Decision 1 / rf2-2qit
-;; Decision 1) `use-subscribe` is the substrate-idiomatic hook surface
-;; for reading a sub. It wraps React.useSyncExternalStore so updates are
-;; scheduled by React's concurrent renderer rather than a per-component
-;; scheduler.
+;; `use-subscribe` is the substrate-idiomatic hook surface for reading
+;; a sub. It wraps React.useSyncExternalStore so updates are scheduled
+;; by React's concurrent renderer rather than a per-component scheduler.
 ;;
 ;; The hook:
 ;;   1. Resolves the active frame via use-context (Decision 2).
@@ -517,12 +501,11 @@
         active-roots-cell  (make-active-roots-cell)
         subscribe-cont     (make-subscribe-container gensym-prefix-sub)
         make-derived       (make-derived-value-fn gensym-prefix-derived)
-        ;; Per rf2-y1hbg: precompute the `use-subscribe` watch-key
-        ;; keyword namespace once (outside the render hot path). The
-        ;; per-reaction key derives from `(hash reaction)` so the
-        ;; subscribe-fn closure pays one hash + one keyword intern per
-        ;; reaction-identity change — no process-wide gensym counter
-        ;; tick per render.
+        ;; Precompute the `use-subscribe` watch-key keyword namespace
+        ;; once (outside the render hot path). The per-reaction key
+        ;; derives from `(hash reaction)` so the subscribe-fn closure
+        ;; pays one hash + one keyword intern per reaction-identity
+        ;; change — no process-wide gensym counter tick per render.
         use-sub-watch-ns   (let [s gensym-prefix-use-sub
                                  n (count s)]
                              ;; Strip the trailing "-" the gensym prefix
@@ -559,12 +542,10 @@
                 subscribe-fn
                 (use-callback
                   (fn [on-change]
-                    ;; Per rf2-y1hbg: hash-of-reaction-identity keyword
-                    ;; rather than a fresh `gensym` per call. The
-                    ;; per-reaction key is stable for the reaction's
-                    ;; lifetime, sidesteps the process-wide gensym
-                    ;; counter, and remains unique across distinct
-                    ;; reactions.
+                    ;; Hash-of-reaction-identity keyword rather than a
+                    ;; fresh `gensym` per call — stable for the
+                    ;; reaction's lifetime, sidesteps the process-wide
+                    ;; gensym counter, unique across distinct reactions.
                     (let [k (keyword use-sub-watch-ns (str (hash reaction)))]
                       (when reaction
                         (add-watch reaction k (fn [_ _ _ _] (on-change))))

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -61,12 +61,9 @@
             ;; any of them.
             [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace]
-            ;; Per rf2-rirbq: clear the always-on event-emit listener
-            ;; registry in the per-test reset so a forwarder registered
-            ;; in one test does not see events fired by a sibling test.
-            ;; The substrate is always-on (no goog.DEBUG check) and the
-            ;; registry is a plain atom — clearing is cheap and
-            ;; substrate-agnostic.
+            ;; Clear the always-on event-emit listener registry on each
+            ;; reset so a forwarder registered in one test doesn't see
+            ;; events fired by a sibling test.
             [re-frame.event-emit :as event-emit]
             [re-frame.router :as router]
             [re-frame.substrate.adapter :as adapter]
@@ -146,70 +143,40 @@
 
   Per-row rationale:
 
-    :flows/reset-flows!              — rf2-tfw3 — drop the per-frame flow
-                                       registry. Flows ships in
-                                       day8/re-frame2-flows; hook returns
-                                       nil when the artefact is absent.
-    :flows/reset-last-inputs!        — rf2-tfw3 — drop the dirty-check
-                                       last-inputs map paired with the flow
-                                       registry.
-    :schemas/clear-by-frame!         — rf2-p7va — clear per-frame schema
-                                       registrations. Paired with
-                                       `:schemas/snapshot-by-frame` +
-                                       `:schemas/restore-by-frame!` for
+    :flows/reset-flows!              — drop the per-frame flow registry.
+    :flows/reset-last-inputs!        — drop the dirty-check last-inputs
+                                       map paired with the flow registry.
+    :schemas/clear-by-frame!         — clear per-frame schema registrations.
+                                       Paired with `:schemas/snapshot-by-frame`
+                                       + `:schemas/restore-by-frame!` for
                                        snapshot/restore around the test body.
-                                       Schemas ships in
-                                       day8/re-frame2-schemas.
-    :machines/reset-timers!          — rf2-xbtj / rf2-gr8q — cancel in-flight
-                                       `:after` wall-clock timers so a stale
-                                       timer from a sibling test cannot
-                                       survive into this one. Per rf2-gr8q
-                                       the spawn-counter atom is gone; this
-                                       hook resets only the timer table.
-                                       Machines ships in
-                                       day8/re-frame2-machines.
-    :routing/reset-counters!         — rf2-k682 — reset the route-registration
-                                       counter so reg-index is deterministic
-                                       across fixture runs. Routing ships in
-                                       day8/re-frame2-routing.
-    :http/clear-all-in-flight!       — rf2-5kpd — drop the in-flight managed-
-                                       request registry so a stale handle
-                                       from a sibling test cannot survive
-                                       into this one. http-managed ships in
-                                       day8/re-frame2-http.
-    :epoch/clear-history!            — rf2-lt4e — drop the per-frame epoch
-                                       ring buffer so a previous test's
-                                       recorded epochs cannot survive into
-                                       this one. Epoch ships in
-                                       day8/re-frame2-epoch.
-    :epoch/clear-epoch-cbs!          — rf2-lt4e — drop the epoch-settled
-                                       callback registry, paired with the
-                                       ring-buffer clear above.
-    :adapter/clear-warn-once-caches! — rf2-4edk — clear the per-adapter
+    :machines/reset-timers!          — cancel in-flight `:after` wall-clock
+                                       timers so a stale timer from a
+                                       sibling test can't survive.
+    :routing/reset-counters!         — reset the route-registration counter
+                                       so reg-index is deterministic across
+                                       fixture runs.
+    :http/clear-all-in-flight!       — drop the in-flight managed-request
+                                       registry.
+    :epoch/clear-history!            — drop the per-frame epoch ring buffer.
+    :epoch/clear-epoch-cbs!          — drop the epoch-settled callback
+                                       registry.
+    :adapter/clear-warn-once-caches! — clear per-adapter
                                        `warned-non-dom-roots` warn-once
-                                       caches so a sibling test's first-
-                                       encounter warning cannot silently
-                                       swallow a later test's same-id
-                                       warning. The hook is chained:
-                                       re-frame.views, re-frame.adapter.helix
-                                       and re-frame.adapter.uix each
-                                       register a clear-step at ns-load and
-                                       the chained closure runs all of them.
-                                       When none of these CLJS-only
-                                       namespaces are on the classpath (JVM
-                                       tests), the lookup returns nil and
-                                       this is a no-op.
+                                       caches. Chained — re-frame.views,
+                                       and the helix / uix adapters each
+                                       register a clear-step.
 
   Adding a new artefact's reset becomes a one-row addition here."
-  [{:hook :flows/reset-flows!              :phase :pre-dispose  :source "rf2-tfw3"}
-   {:hook :flows/reset-last-inputs!        :phase :pre-dispose  :source "rf2-tfw3"}
-   {:hook :schemas/clear-by-frame!         :phase :pre-dispose  :source "rf2-p7va"}
-   {:hook :machines/reset-timers!          :phase :post-dispose :source "rf2-xbtj"}
-   {:hook :routing/reset-counters!         :phase :post-dispose :source "rf2-k682"}
-   {:hook :http/clear-all-in-flight!       :phase :post-dispose :source "rf2-5kpd"}
-   {:hook :epoch/clear-history!            :phase :post-dispose :source "rf2-lt4e"}
-   {:hook :epoch/clear-epoch-cbs!          :phase :post-dispose :source "rf2-lt4e"}
-   {:hook :adapter/clear-warn-once-caches! :phase :post-dispose :source "rf2-4edk"}])
+  [{:hook :flows/reset-flows!              :phase :pre-dispose}
+   {:hook :flows/reset-last-inputs!        :phase :pre-dispose}
+   {:hook :schemas/clear-by-frame!         :phase :pre-dispose}
+   {:hook :machines/reset-timers!          :phase :post-dispose}
+   {:hook :routing/reset-counters!         :phase :post-dispose}
+   {:hook :http/clear-all-in-flight!       :phase :post-dispose}
+   {:hook :epoch/clear-history!            :phase :post-dispose}
+   {:hook :epoch/clear-epoch-cbs!          :phase :post-dispose}
+   {:hook :adapter/clear-warn-once-caches! :phase :post-dispose}])
 
 (defn- run-reset-hooks!
   "Driver: fire every `reset-hook-table` row whose `:phase` matches and
@@ -235,25 +202,17 @@
        reset is late-bound so JVM tests that don't pull them in are
        unaffected).
     3. Disposes the currently-installed substrate adapter.
-    4. Cancels the machines' in-flight `:after` wall-clock timers
-       (per rf2-gr8q the spawn-counter atom is gone; the late-bind
-       hook now resets only the timer table).
+    4. Cancels the machines' in-flight `:after` wall-clock timers.
     5. Clears trace listeners and adapter warn-once caches
        (`warned-non-dom-roots` across re-frame.views and the helix /
-       uix adapters; per rf2-4edk).
+       uix adapters).
     6. If an `:adapter` was supplied, installs it and ensures the
        `:rf/default` frame. Otherwise leaves adapter installation to
        the test (or to a separate fixture).
     7. If an `:init-fn` was supplied, invokes it (zero-arg). Use this
-       hook for per-suite setup that needs the registrar / adapter live
-       — e.g. seeding test data into the just-installed adapter's
-       app-db. (Routing's reg-counter and the machines wall-clock
-       timer table are reset automatically when their respective
-       artefacts are on the classpath; see step 4 and the late-bind
-       block above. Per rf2-gr8q the machines spawn-counter atom is
-       gone — spawn-id allocation lives in-snapshot now, so per-test
-       isolation is inherited from the registrar / frame snapshot
-       reset rather than from a dedicated reset call.)
+       hook for per-suite setup that needs the registrar / adapter
+       live — e.g. seeding test data into the just-installed adapter's
+       app-db.
     8. Runs the test.
     9. Restores the registrar to the captured snapshot.
    10. Resets `frame/frames` back to `{}` for symmetry, and (when their
@@ -304,11 +263,8 @@
      ;; the per-frame schema registry around the test body. The clear
      ;; step in the mid-body run fires from `reset-hook-table` —
      ;; `clear-fn` is captured here only for the `:clear-kinds
-     ;; [:app-schema]` branch below (per rf2-0frdi `:app-schema` is no
-     ;; longer a registrar kind; the schemas artefact owns its own
-     ;; per-frame side-table). Per rf2-p7va — schemas ships in
-     ;; day8/re-frame2-schemas and this namespace must not statically
-     ;; require it.
+     ;; [:app-schema]` branch (the schemas artefact owns its own per-
+     ;; frame side-table, not a registrar kind).
      (let [snap          (snapshot-registrar)
            snapshot-fn   (late-bind/get-fn :schemas/snapshot-by-frame)
            clear-fn      (late-bind/get-fn :schemas/clear-by-frame!)
@@ -329,9 +285,9 @@
            ;; The `:clear-kinds [:app-schema]` opt is preserved as the
            ;; test-support convention for "give me a clean app-schema
            ;; slate"; the registrar `clear-kind!` above is a no-op for
-           ;; this kind (per rf2-0frdi `:app-schema` is no longer a
-           ;; registrar kind), and this branch dispatches the actual
-           ;; reset through the schemas clear-fn.
+           ;; this kind (`:app-schema` is the schemas artefact's per-
+           ;; frame side-table, not a registrar kind), and this branch
+           ;; dispatches the actual reset through the schemas clear-fn.
            (when (and (= k :app-schema) clear-fn)
              (clear-fn)))
          (when init-fn (init-fn))

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -149,7 +149,9 @@
 ;; ---- retain-N trace ring buffer (dev-only) -------------------------------
 
 (def ^:private default-buffer-depth
-  "Per Spec 009 §Retain-N trace ring buffer: default 200 events."
+  "Per Spec 009 §Retain-N trace ring buffer: default 200 events —
+  enough for one drained cascade plus prior history without per-frame
+  memory pressure."
   200)
 
 (defonce ^:private buffer-depth (atom default-buffer-depth))

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -263,9 +263,9 @@
                   (or (nil? between-t0)
                       (and (number? (:time ev))
                            (<= between-t0 (:time ev) between-t1)))
-                  ;; Per rf2-isdwf: top-level `:sensitive?` is hoisted
-                  ;; (NOT nested under :tags). Match against the
-                  ;; top-level slot only; absent reads as false.
+                  ;; Top-level `:sensitive?` is hoisted (NOT nested
+                  ;; under `:tags`). Match against the top-level slot
+                  ;; only; absent reads as false.
                   (or (nil? sensitive-filter)
                       (= (true? sensitive-filter)
                          (true? (:sensitive? ev))))

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -43,13 +43,6 @@
   (swap! event-counter inc))
 
 ;; ---- handler-scope: the five-slot in-scope reading -----------------------
-;;
-;; Per Spec 009 §Handler-scope. Every handler-execution boundary (router,
-;; subs, fx, cofx, views) publishes a HandlerScope record on
-;; `*handler-scope*` so `emit!` / `emit-error!` can hoist the relevant
-;; slots onto each emitted event. See Spec 009 for the slot semantics,
-;; composition rule (innermost wins for meta-derived slots; call-site /
-;; dispatch-id inherit), and elision contract.
 
 (defrecord HandlerScope [trigger-handler call-site dispatch-id sensitive? no-emit?])
 
@@ -77,26 +70,17 @@
 
 (defn no-emit?-from-meta
   "True iff `meta` carries `:rf.trace/no-emit? true`. Used at queue-time
-  `:event/dispatched` emit, before the handler-scope binding exists.
-  Per Spec 009 §Trace-emission opt-out.
-
-  Sibling reader for `:sensitive?` lives in `re-frame.privacy`
-  (`privacy/sensitive?-from-meta`) per rf2-iwqu9 — privacy owns the
-  policy-locus; trace owns the emit-locus."
+  `:event/dispatched` emit (before handler-scope is bound). Per Spec 009
+  §Trace-emission opt-out."
   [meta]
   (true? (:rf.trace/no-emit? meta)))
 
 (defn handler-scope-from-meta
   "Build a HandlerScope from a registrar slot's `meta` for a handler
-  about to execute. Computes the three meta-derived slots
-  (`:trigger-handler` / `:sensitive?` / `:no-emit?`); leaves
-  `:call-site` and `:dispatch-id` nil — `with-handler-scope` fills
-  them from the parent scope on bind. Per Spec 009 §Handler-scope.
-
-  The `:sensitive?` reading is inlined here to avoid a require cycle
-  with `re-frame.privacy` (privacy requires trace). The same boolean
-  shape is exposed as `re-frame.privacy/sensitive?-from-meta` for
-  every other consumer (router / event-emit) per rf2-iwqu9."
+  about to execute. `:call-site` and `:dispatch-id` are left nil for
+  `with-handler-scope` to inherit from the parent. The `:sensitive?`
+  reading is inlined here to avoid a require cycle with
+  `re-frame.privacy`. Per Spec 009 §Handler-scope."
   [kind id meta]
   (->HandlerScope (trigger-handler-from-meta kind id meta)
                   nil
@@ -163,12 +147,6 @@
           ~@body))))
 
 ;; ---- retain-N trace ring buffer (dev-only) -------------------------------
-;;
-;; Per Spec 009 §Retain-N trace ring buffer. Holds the most recent N completed
-;; trace events; queryable via (trace-buffer). All ring-buffer machinery is
-;; gated on interop/debug-enabled? (the same compile-time flag the rest of the
-;; trace surface rides) so production builds drop the buffer entirely — no
-;; allocation, no append, no storage.
 
 (def ^:private default-buffer-depth
   "Per Spec 009 §Retain-N trace ring buffer: default 200 events."
@@ -347,18 +325,9 @@
 
 ;; ---- shared emit substrate ------------------------------------------------
 ;;
-;; `emit!` (success) and `emit-error!` (error) share an envelope-
-;; construction core (`build-event`, pure; reads `*handler-scope*`) and
-;; a delivery path (`deliver!`, side-effect: ring buffer + epoch capture
-;; + listener fan-out). The two public emit fns are thin wrappers
-;; carrying the prod-DCE outer gate.
-;;
-;; The outer `(when interop/debug-enabled? ...)` and inner `(when-not
-;; (:no-emit? *handler-scope*) ...)` guards stay in the wrappers — NOT
-;; in `build-event` — because Spec 009 §Production builds mandates the
-;; outermost form of an emit call be `(when interop/debug-enabled? ...)`
-;; alone for Closure DCE to elide the expression under `:advanced` +
-;; `goog.DEBUG=false`.
+;; The `interop/debug-enabled?` gate stays in the public emit wrappers
+;; (NOT in `build-event`) so Closure DCE elides the whole expression at
+;; `:advanced` + `goog.DEBUG=false`. Per Spec 009 §Production builds.
 
 (defn- compute-sensitive?
   "Hoist `:sensitive?` from the in-scope handler's registration meta,
@@ -477,11 +446,8 @@
       (deliver! (build-event :error error-operation tags)))))
 
 ;; ---- late-bind hook registration ------------------------------------------
-;;
-;; re-frame.registrar emits a trace event when a handler is replaced but
-;; cannot `:require` this namespace without a cyclic load order.
-;; Publish `emit!` through the late-bind hook registry. See
-;; re-frame.late-bind.
+;; Published through `late-bind` so registrar can emit without requiring
+;; this ns (cyclic load order).
 
 (late-bind/set-fn! :trace/emit!       emit!)
 (late-bind/set-fn! :trace/emit-error! emit-error!)

--- a/implementation/core/src/re_frame/trace/projection.cljc
+++ b/implementation/core/src/re_frame/trace/projection.cljc
@@ -15,11 +15,11 @@
   consumers need above the raw stream for the common 'render this
   cascade as six dominoes' use case.
 
-  Per rf2-g6ih4 (cascade-wide `:dispatch-id`) the projection is robust
-  against events that the framework emits *inside* a drain even though
-  they aren't `:event/dispatched` — fx invocations, sub-runs, renders,
-  errors. Every such event now carries `:tags :dispatch-id` so the
-  group-by below assembles a complete cascade record.
+  The cascade-wide `:dispatch-id` makes the projection robust against
+  events the framework emits *inside* a drain even though they aren't
+  `:event/dispatched` — fx invocations, sub-runs, renders, errors.
+  Every such event carries `:tags :dispatch-id` so the group-by below
+  assembles a complete cascade record.
 
   ## Bucketing (per Spec 009 §`:op-type` vocabulary)
 

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -78,26 +78,9 @@
 
 ;; ---- re-exported public surface ------------------------------------------
 ;;
-;; Plain `def` aliases for the publicly-referenced ordinary fns / data
-;; surfaces. Each one is reached by external call sites through
-;; `re-frame.views/<name>`:
-;;
-;;   re-frame.adapter.reagent + runtime_cljs_test → frame-provider, build-frame-provider
-;;   late-bind hook table (:adapter/current-frame),
-;;     views-current-component-cljs-test          → current-frame
-;;   render_key_cljs_test, elision_probe          → mint-instance-token!
-;;   source_coord_parity_cljs_test                → #'format-source-coord
-;;   warn_once_fixture_isolation_cljs_test        → clear-warned-non-dom-roots!
-;;   late-bind hook table                         → maybe-warn-plain-fn-under-non-default-frame!,
-;;                                                  clear-plain-fn-warned-pairs!
-;;
-;; Keeping these as plain defs (rather than `:refer`-imported) makes
-;; `#'re-frame.views/<name>` resolve in this ns — the CLJS analyser
-;; tracks each `def` form's Var under the defining ns, so
-;; `:refer` does not surface a Var under the consuming ns. Functions are
-;; resolved by value, so a `def` alias works for invocation; only
-;; dynamic-var binding semantics force the `*render-key*` exception
-;; above.
+;; Plain `def` aliases (rather than `:refer`-imports) so
+;; `#'re-frame.views/<name>` resolves under this ns — `:refer` does
+;; not surface a Var under the consuming ns.
 
 (def frame-provider provider/frame-provider)
 (def build-frame-provider provider/build-frame-provider)

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -15,9 +15,8 @@
   to obtain the wrapped fn and use `[(rf/view :id) args]` as the
   hiccup head.
 
-  Per rf2-lh7p the file has been split into three internally-cohesive
-  sub-namespaces; this ns is now the orchestration entry point that
-  ties them together:
+  Orchestration entry point that re-exports three internally-cohesive
+  sub-namespaces:
 
     - `re-frame.views.provider`                — frame-provider + the
                                                  React-context bridge
@@ -53,7 +52,7 @@
             [re-frame.views.source-coord-annotation :as source-coord]
             [re-frame.views.warn-once :as warn-once]))
 
-;; ---- *render-key* (rf2-piag / rf2-t5tx) ----------------------------------
+;; ---- *render-key* --------------------------------------------------------
 ;;
 ;; Bound by the `reg-view*` wrapper below for the duration of each render.
 ;; Lives here (the public ns) so `re-frame.views/*render-key*` is the
@@ -118,15 +117,14 @@
 
 ;; ---- reg-view -------------------------------------------------------------
 ;;
-;; Per rf2-w9ykb the wrapper-builder is decomposed into named helpers,
-;; each owning one phase of the registration pipeline:
+;; The wrapper-builder is decomposed into named helpers, each owning
+;; one phase of the registration pipeline:
 ;;
-;;   1. `apply-adapter-wrap-view`   — consult the substrate hook
-;;   2. `view-coord-attr`           — debug-only source-coord stamp
-;;   3. `trace/handler-scope-from-meta` — pre-compute the view's HandlerScope
-;;      (already a named helper in trace.cljc — rf2-ryri7)
-;;   4. `build-frame-aware-view`    — assemble the per-render wrapped fn
-;;   5. `registrar/register!`       — install in the :view kind
+;;   1. `apply-adapter-wrap-view`         — consult the substrate hook
+;;   2. `view-coord-attr`                 — debug-only source-coord stamp
+;;   3. `trace/handler-scope-from-meta`   — pre-compute view's HandlerScope
+;;   4. `build-frame-aware-view`          — assemble the per-render wrapped fn
+;;   5. `registrar/register!`             — install in the :view kind
 ;;
 ;; reg-view* itself becomes a five-line straight-line composition.
 
@@ -216,25 +214,23 @@
   registry slot's metadata as-is; source-coord capture is performed
   by the caller (`re-frame.core/reg-view*`).
 
-  Per rf2-piag / rf2-t5tx: each render binds `*render-key*` to the
-  tuple `[id instance-token]` for the body, so the trace recorder can
-  attribute the render. The instance-token is minted at mount and
-  reused across re-renders of the same component instance (per
-  Spec 004 §Render-tree primitives).
+  Each render binds `*render-key*` to `[id instance-token]` so the
+  trace recorder can attribute the render. The instance-token is
+  minted at mount and reused across re-renders of the same component
+  instance (per Spec 004 §Render-tree primitives).
 
-  Per rf2-ryri7: the view's HandlerScope is pre-computed once at
-  registration time from `metadata` (source-coord stamp, `:sensitive?`,
-  `:rf.trace/no-emit?` — all three fixed for the life of the registered
-  view). Each render binds the scope (via `with-handler-scope`, which
-  inherits parent's `:call-site` / `:dispatch-id`) around the user
-  render-fn invocation. Errors emitted during render (subscribe-miss
-  against this frame, sub exception during a render-time deref, etc.)
-  ride the view's `:trigger-handler` coord; `:view/render` emits ride
-  `:sensitive?` per Spec 009 §Privacy and short-circuit when
-  `:no-emit?` is true.
+  The view's HandlerScope is pre-computed once at registration time
+  from `metadata` (source-coord stamp, `:sensitive?`,
+  `:rf.trace/no-emit?` — all three fixed for the life of the
+  registered view). Each render binds the scope (via
+  `with-handler-scope`, which inherits parent's `:call-site` /
+  `:dispatch-id`) around the render-fn invocation. Errors emitted
+  during render ride the view's `:trigger-handler` coord;
+  `:view/render` emits ride `:sensitive?` per Spec 009 §Privacy and
+  short-circuit when `:no-emit?` is true.
 
-  Per rf2-w9ykb the body is a five-line pipeline; the work lives in
-  the named helpers above."
+  The body is a five-line pipeline; the work lives in the named
+  helpers above."
   [id metadata render-fn]
   (let [[render-fn wrap-applied?] (apply-adapter-wrap-view id metadata render-fn)
         coord-attr (view-coord-attr id metadata wrap-applied?)

--- a/implementation/core/src/re_frame/views/provider.cljs
+++ b/implementation/core/src/re_frame/views/provider.cljs
@@ -1,55 +1,45 @@
 (ns re-frame.views.provider
   "Frame-provider component + per-render identity machinery for the
-  Reagent-side views ns. Per rf2-lh7p — split out of `re-frame.views`
-  so the views file stays focused on registration orchestration.
-  Re-frame.views re-exports the publicly-referenced surface
-  (`frame-provider`, `build-frame-provider`, `current-frame`,
-  `mint-instance-token!`, `current-render-key`, `*render-key*`) so
-  existing call sites continue to work unchanged.
+  Reagent-side views ns. Re-frame.views re-exports the publicly-
+  referenced surface (`frame-provider`, `build-frame-provider`,
+  `current-frame`, `mint-instance-token!`, `current-render-key`,
+  `*render-key*`) so existing call sites work unchanged.
 
   Three cohesive concerns live here:
 
-  1. `frame-provider` — the user-facing Reagent component that scopes
-     a frame keyword to its subtree via React context. The actual
-     React Context object is owned by `re-frame.adapter.context` so
-     adapters across substrates (Reagent / UIx / Helix) read the same
-     context (per rf2-3yij Decision 2). The `build-frame-provider`
-     factory is the lower-level substrate hook the Reagent adapter
-     registers with `register-context-provider`.
+  1. `frame-provider` / `build-frame-provider` — the user-facing
+     Reagent component that scopes a frame keyword to its subtree via
+     React context. The React Context object is owned by
+     `re-frame.adapter.context` so adapters across substrates
+     (Reagent / UIx / Helix) read the same context.
 
   2. Per-render instance-token machinery — `mint-instance-token!`,
      `reagent-component-token`. Tokens disambiguate concurrently-
-     mounted instances of the same view-kind (Spec 004 §Render-tree
-     primitives, rf2-piag / rf2-t5tx). The `*render-key*` dynamic var
-     itself lives in `re-frame.views` so the wrapper's binding and
-     consumer reads share the same canonical Var.
+     mounted instances of the same view-kind. The `*render-key*`
+     dynamic var lives in `re-frame.views` so the wrapper's binding
+     and consumer reads share the same canonical Var.
 
-  3. `current-frame` — the resolution chain that subscribe / dispatch
-     consult to find the surrounding frame at render time
-     (Spec 002 §Reading the frame from React context). It pairs with
-     the `:contextType` static reg-view's wrapper installs on its
-     output (per `re-frame.views`).
+  3. `current-frame` — the resolution chain subscribe / dispatch
+     consult at render time (Spec 002 §Reading the frame from React
+     context). Pairs with the `:contextType` static `reg-view*`
+     attaches to its wrapper output.
 
-  Per rf2-wbnl this ns does NOT statically `:require` `reagent.core`.
-  The in-flight Reagent component is read through the late-bind hook
-  `:adapter/current-component`, which the active adapter ns publishes
-  at load time. The classic bridge points the hook at
-  `reagent.core/current-component`; the slim adapter points it at
-  `reagent2.core/current-component`. With no adapter installed the
-  hook returns nil and the React-context tier of the resolution chain
-  is skipped — equivalent to a non-Reagent render context, which is
-  what JVM / headless tests already rely on."
+  This ns does NOT statically `:require` `reagent.core`. The in-flight
+  Reagent component is read through the late-bind hook
+  `:adapter/current-component`; with no adapter installed the hook
+  returns nil and the React-context tier of the resolution chain is
+  skipped (equivalent to a non-Reagent render context — JVM /
+  headless tests rely on this)."
   (:require [re-frame.adapter.context :as adapter-context]
             [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]))
 
 ;; ---- the React context for frame propagation -----------------------------
 ;;
-;; Per rf2-3yij Decision 2 the React Context object lives in
-;; `re-frame.adapter.context` so the UIx adapter (and any future
-;; React-shaped adapter) reads the *same* context — not a parallel one.
-;; The Reagent code below references it via the alias rather than
-;; minting a new createContext call.
+;; The React Context object lives in `re-frame.adapter.context` so
+;; every React-shaped adapter reads the *same* context — not a
+;; parallel one. The Reagent code below references it via the alias
+;; rather than minting a new createContext call.
 
 (def frame-context adapter-context/frame-context)
 
@@ -99,9 +89,9 @@
   `frame-provider` is.
 
   Reads `:frame` from props. When missing or `nil`, falls through to
-  `:rf/default` (per rf2-sixo — defensive default that matches the
-  no-provider behaviour and avoids breaking tooling-generated trees
-  that elide the prop).
+  `:rf/default` — defensive default that matches no-provider
+  behaviour and avoids breaking tooling-generated trees that elide
+  the prop.
 
   Reagent call shape:
 
@@ -111,9 +101,9 @@
        [footer]]
 
   Children are variadic (zero, one, or many). Same surface as the UIx
-  and Helix variants, different rendering substrate. The three adapters
-  share one React Context (per rf2-3yij Decision 2) so a subtree under
-  any frame-provider sees the right frame regardless of which substrate
+  and Helix variants, different rendering substrate. The three
+  adapters share one React Context so a subtree under any frame-
+  provider sees the right frame regardless of which substrate
   rendered the provider.
 
   `build-frame-provider` is the lower-level substrate hook; this fn is
@@ -122,21 +112,18 @@
   (let [frame-kw (or (:frame props) :rf/default)]
     (into [(build-frame-provider) frame-kw] children)))
 
-;; ---- in-flight Reagent component (rf2-wbnl) ------------------------------
+;; ---- in-flight Reagent component -----------------------------------------
 ;;
-;; The active adapter (classic bridge or slim) publishes its Reagent build's
-;; `current-component` fn through the `:adapter/current-component` late-bind
-;; hook at ns-load time. This ns must NOT statically `:require [reagent.core]`
-;; — doing so hard-couples views.cljs to stock Reagent and silently shadows
-;; the slim adapter's components in mixed-mode environments. Per the bead's
-;; resolution-chain note: dynamic var → adapter.current-component
-;; (late-bind) → nil. When no adapter has installed the hook the call returns
-;; nil and the React-context tier is skipped.
+;; The active adapter publishes its Reagent build's `current-component`
+;; fn through `:adapter/current-component` at ns-load time. Static
+;; `:require [reagent.core]` would hard-couple this ns to stock Reagent
+;; and silently shadow the slim adapter's components in mixed-mode
+;; environments.
 
 (defn current-component
   "Resolve the in-flight Reagent component via the active adapter's hook.
   Returns nil when no adapter has registered the hook (JVM / headless
-  builds; no-adapter tests). Per rf2-wbnl."
+  builds; no-adapter tests)."
   []
   (when-let [hook (late-bind/get-fn :adapter/current-component)]
     (hook)))
@@ -157,9 +144,9 @@
   context object — that is the wiring `reg-view*` attaches via
   `{:contextType frame-context}`. Plain Reagent fns lack this wiring,
   so `(.-context cmp)` is React's empty default — they fall through
-  to `:rf/default`. This narrowness is by design: it is what makes the
-  `:rf.warning/plain-fn-under-non-default-frame-once` warning
-  meaningful (rf2-d3k3 / rf2-d4sf).
+  to `:rf/default`. This narrowness is by design: it is what makes
+  the `:rf.warning/plain-fn-under-non-default-frame-once` warning
+  meaningful.
 
   The keyword/string coercion via
   `re-frame.adapter.context/coerce-context-value` is defensive cover
@@ -179,23 +166,19 @@
         (adapter-context/coerce-context-value (.-context cmp)))
       :rf/default))
 
-;; ---- per-render identity (rf2-piag / rf2-t5tx) ----------------------------
+;; ---- per-render identity --------------------------------------------------
 ;;
 ;; Render-trace entries carry a `:render-key` of shape
-;; `[<view-id> <instance-token>]`. Per rf2-t5tx Option C the tuple is the
-;; canonical identity: the view-id (registry keyword) names the kind; the
-;; instance-token disambiguates concurrently-mounted instances of the same
-;; kind. Tokens are minted at mount time from a process-wide counter and
-;; are NOT correlated across runs — they're for in-run instance discrimination
-;; only (per Spec 004 §Render-tree primitives).
+;; `[<view-id> <instance-token>]`. Tokens are minted at mount time
+;; from a process-wide counter and disambiguate concurrently-mounted
+;; instances of the same kind — they're for in-run discrimination
+;; only, no cross-run correlation.
 ;;
-;; Note: the `*render-key*` dynamic var and `current-render-key` reader
-;; live in `re-frame.views` (the public ns) rather than here. That keeps
-;; the dynamic-var Var canonical at the public path that tests reach via
-;; `re-frame.views/*render-key*` — see the views.cljs orchestration ns
-;; for the rationale. The mint / per-component-instance machinery does
-;; live here because it owns its own state (`instance-counter`) and the
-;; component-side stamp (`.-rfInstanceToken`).
+;; The `*render-key*` dynamic var and `current-render-key` reader
+;; live in `re-frame.views` (the public ns) so the canonical Var sits
+;; at the public path tests reach via `re-frame.views/*render-key*`.
+;; The mint / per-component-instance machinery lives here with its
+;; state (`instance-counter`, `.-rfInstanceToken`).
 
 (defonce ^:private instance-counter (atom 0))
 

--- a/implementation/core/src/re_frame/views/warn_once.cljs
+++ b/implementation/core/src/re_frame/views/warn_once.cljs
@@ -1,28 +1,24 @@
 (ns re-frame.views.warn-once
   "Warn-once caches and detection helpers for the Reagent-side views ns.
-  Per rf2-lh7p — split out of `re-frame.views` so the views file stays
-  focused on registration orchestration. Re-frame.views re-exports the
-  publicly-referenced surface (`clear-warned-non-dom-roots!`,
+  Re-frame.views re-exports the publicly-referenced surface
+  (`clear-warned-non-dom-roots!`,
   `maybe-warn-plain-fn-under-non-default-frame!`,
-  `clear-plain-fn-warned-pairs!`) so existing call sites continue to work
-  unchanged.
+  `clear-plain-fn-warned-pairs!`).
 
-  Two cohesive warn-once concerns live here:
+  Two warn-once concerns live here:
 
   1. Non-DOM-root warning (Spec 006 §Source-coord annotation,
      documented exemption). When a reg-view'd component returns a
-     non-DOM root (fn/class component or React Fragment) the
-     source-coord walk skips the annotation and emits a one-shot
-     console.warn per id. Pair tools fall back to the registry's
-     `:rf/id`. The `warned-non-dom-roots` defonce holds the per-process
-     set; `reset-runtime-fixture` clears it via the chained
-     `:adapter/clear-warn-once-caches!` hook per rf2-4edk.
+     non-DOM root (fn/class component or React Fragment) the source-
+     coord walk skips the annotation and emits a one-shot
+     console.warn per id. The `warned-non-dom-roots` defonce holds
+     the per-process set; `reset-runtime-fixture` clears it via the
+     chained `:adapter/clear-warn-once-caches!` hook.
 
-  2. Plain-fn-under-non-default-frame warning (Spec 004 §Plain Reagent
-     fns and Spec 006 §706). Detected at subscribe-time; suppression is
-     keyed by `[component-id non-default-frame-id]` pairs. Production
-     builds elide the entire body via the `interop/debug-enabled?`
-     gate."
+  2. Plain-fn-under-non-default-frame warning (Spec 004 §Plain
+     Reagent fns / Spec 006 §706). Detected at subscribe-time;
+     suppression keyed by `[component-id non-default-frame-id]` pairs.
+     Production builds elide via the `interop/debug-enabled?` gate."
   (:require [re-frame.adapter.context :as adapter-context]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
@@ -30,7 +26,7 @@
             [re-frame.trace :as trace]
             [re-frame.views.provider :as provider]))
 
-;; ---- non-DOM-root warning (rf2-4edk) -------------------------------------
+;; ---- non-DOM-root warning ------------------------------------------------
 
 (defonce ^:private warned-non-dom-roots (atom #{}))
 
@@ -39,9 +35,9 @@
   between cases (via `reset-runtime-fixture` and the chained
   `:adapter/clear-warn-once-caches!` hook) so a sibling test's first-
   encounter warning cannot silently swallow a later test's same-id
-  warning. Per rf2-4edk — the cache is a process-wide `defonce` so
-  the user-facing warn-once UX is unchanged in production; test-time
-  clearing is the only effect."
+  warning. The cache is a process-wide `defonce` so the user-facing
+  warn-once UX is unchanged in production; test-time clearing is the
+  only effect."
   []
   (reset! warned-non-dom-roots #{})
   nil)
@@ -124,9 +120,9 @@
 
 (defn- read-react-context-frame
   "Read the value the closest enclosing frame-provider has pushed onto
-  the shared React context. Per rf2-d4sf this is now a thin wrapper
-  around `adapter-context/current-frame` minus the dynamic-var tier —
-  the warn-once detection below has already filtered to the case where
+  the shared React context. A thin wrapper around
+  `adapter-context/current-frame` minus the dynamic-var tier — the
+  warn-once detection below has already filtered to the case where
   `*current-frame*` is unset (Condition 4), so we want the React-
   context value alone.
 
@@ -236,12 +232,9 @@
 (late-bind/set-fn! :views/clear-plain-fn-warned-pairs!
                    clear-plain-fn-warned-pairs!)
 
-;; Per rf2-4edk: register a clear of the `warned-non-dom-roots` cache
-;; under the chained `:adapter/clear-warn-once-caches!` hook. Each
-;; adapter (helix, uix) and this views ns all contribute a clear-step;
+;; Register a clear of the `warned-non-dom-roots` cache under the
+;; chained `:adapter/clear-warn-once-caches!` hook. Each adapter (helix,
+;; uix) and this views ns all contribute a clear-step;
 ;; `reset-runtime-fixture` invokes the top of the chain and every
-;; contributor's reset runs. Production behaviour is unchanged: the
-;; warn-once `defonce` is still per-process for users; only test-time
-;; clearing is new. Chain wiring goes through `late-bind/chain-fn!`
-;; (rf2-1fh5h) — the generic chain idiom.
+;; contributor's reset runs.
 (late-bind/chain-fn! :adapter/clear-warn-once-caches! clear-warned-non-dom-roots!)

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -42,7 +42,10 @@
 
 ;; ---- configuration --------------------------------------------------------
 
-(def ^:private default-depth 50)
+(def ^:private default-depth
+  ;; Deep enough to hold a typical debug session's cascade history;
+  ;; trades bounded heap for stable time-travel coverage.
+  50)
 
 (defonce ^:private config
   ;; Currently a single key (:depth) but kept as a map so future

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -11,41 +11,15 @@
   views; use a flow only if it must live in app-db for SSR / time-travel
   / inspector reasons.
 
-  ## Artefact (rf2-tfw3, fourth per-feature split per rf2-5vjj Strategy B)
+  Ships in `day8/re-frame2-flows`; entry points are published through
+  `re-frame.late-bind` so the core artefact's `re-frame.core` re-exports
+  reach them. Apps that don't register any flows don't pull the per-
+  frame flow registry, the topological-sort engine, the dirty-check
+  `last-inputs` map, or the post-drain `run-flows!` walker.
 
-  This namespace ships in `day8/re-frame2-flows`, separate from the
-  core artefact (`day8/re-frame2`). The core artefact's `re-frame.core`
-  re-exports of `reg-flow` / `clear-flow`, and the `:rf.fx/reg-flow` /
-  `:rf.fx/clear-flow` runtime fxs in `re-frame.fx`, look this
-  namespace's entry points up via the `re-frame.late-bind` hook table —
-  loading this namespace publishes the hooks. Apps that don't register
-  any flows don't drag the per-frame flow registry, the topological-
-  sort engine, the dirty-check `last-inputs` map, or the post-drain
-  `run-flows!` walker onto the classpath.
-
-  ## Internal layout (rf2-mnu8z)
-
-  Per the rf2-zkca8 leaf-size ceiling the original 431-LoC monolith
-  was split along its three natural seams; this namespace is now the
-  public FAÇADE — it owns the post-drain evaluation walker, the fx-
-  call indirections, and the late-bind hook publications, and re-
-  exports the registry's public-surface symbols. The split is:
-
-    - `re-frame.flows.topo`     — pure Kahn's topological sort +
-      cycle-path extraction. Unit-testable in isolation, no atoms,
-      no traces.
-    - `re-frame.flows.registry` — per-frame `flows` + `last-inputs`
-      atoms, validation, `reg-flow` / `clear-flow`, the registrar
-      replacement-hook for hot-reload invalidation, and the
-      test-only `reset-flows!` / `reset-last-inputs!` resets.
-    - `re-frame.flows` (this)   — `evaluate-flow!` / `run-flows!`,
-      fx-call indirections, late-bind hook publication, and the
-      public re-export surface.
-
-  External consumers continue to reach every documented symbol at
-  `re-frame.flows/<name>` — production code via the late-bind hooks,
-  the per-artefact test fixtures via `re-frame.flows/flows` and
-  `(resolve 're-frame.flows/last-inputs)`."
+  Public façade over `re-frame.flows.topo` (pure Kahn's + cycle-path
+  extraction) and `re-frame.flows.registry` (per-frame `flows` +
+  `last-inputs` atoms, `reg-flow` / `clear-flow`)."
   (:require [re-frame.elision :as elision]
             [re-frame.flows.registry :as registry]
             [re-frame.flows.topo :as topo]

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -89,12 +89,11 @@
         old-inputs (get-in @last-inputs [flow-id frame-id])]
     (if (= new-inputs old-inputs)
       (do
-        ;; Per Spec 009 §:op-type vocabulary: :rf.flow/skip records the
-        ;; suppressed recompute (per rf2-719e value-equal recompute
-        ;; suppression). Tools use this to surface "flow ran but inputs
-        ;; were stable" — distinct from "flow didn't fire at all because
-        ;; nothing wrote". Outer debug-enabled? gate elides the tag-map
-        ;; construction in prod (rf2-drr4z).
+        ;; Per Spec 009 §:op-type vocabulary: `:rf.flow/skip` records a
+        ;; value-equal recompute suppression. Tools use this to surface
+        ;; "flow ran but inputs were stable" — distinct from "flow
+        ;; didn't fire at all". Outer `debug-enabled?` gate elides the
+        ;; tag-map construction in prod.
         (when interop/debug-enabled?
           (trace/emit! :flow :rf.flow/skip
                        {:flow-id flow-id
@@ -105,9 +104,10 @@
         (let [new-output (apply (:output flow) new-inputs)
               new-db     (assoc-in db (:path flow) new-output)]
           (swap! last-inputs assoc-in [flow-id frame-id] new-inputs)
-          ;; Per Spec 009 §:op-type vocabulary: :rf.flow/computed records
-          ;; a successful recompute. Per rf2-719e the dirty-check is
-          ;; =-equality so this only fires when inputs actually changed.
+          ;; Per Spec 009 §:op-type vocabulary: `:rf.flow/computed`
+          ;; records a successful recompute. The dirty-check is
+          ;; `=`-equality so this only fires when inputs actually
+          ;; changed.
           ;;
           ;; Wire-bearing payloads (`:input-values`, `:result`) ride
           ;; through `elision/elide-wire-value` per Spec 009 §Size
@@ -247,11 +247,11 @@
 ;; ---- late-bind hook registration ----------------------------------------
 ;;
 ;; re-frame.core, re-frame.fx, re-frame.router and re-frame.test-support
-;; need to call into flows but per rf2-tfw3 ship in the core artefact
-;; — they cannot `:require` this namespace because the flows artefact
-;; is optional (apps that don't register flows don't carry it). Publish
-;; entry points through the late-bind hook registry; consumers look the
-;; fns up at call time. See re-frame.late-bind.
+;; need to call into flows but ship in the core artefact — they cannot
+;; `:require` this namespace because the flows artefact is optional
+;; (apps that don't register flows don't carry it). Publish entry
+;; points through the late-bind hook registry; consumers look the fns
+;; up at call time.
 ;;
 ;; Calls are written as literal `set-fn!` invocations with a literal
 ;; keyword (one per line) — the late-bind drift gate

--- a/implementation/http/src/re_frame/http.cljc
+++ b/implementation/http/src/re_frame/http.cljc
@@ -1,80 +1,26 @@
 (ns re-frame.http
-  "Spec 014 — call-site ergonomics for `:rf.http/managed` (rf2-pf4k).
+  "Spec 014 — call-site ergonomics for `:rf.http/managed`.
 
-  Pure helpers that synthesise the canonical `[:rf.http/managed args-map]`
-  fx-vector for the common HTTP verbs. They take a URL + an optional map
-  of additional args (per [Spec 014 §The args map]) and return a vector
-  ready to drop into `:fx`. Result:
+  Pure helpers that synthesise `[:rf.http/managed args-map]` fx-vectors
+  for the common HTTP verbs (`get` / `post` / `put` / `delete` /
+  `patch` / `head` / `options`):
 
   ```clojure
   {:fx [(rf.http/get \"/api/items\"
          {:on-success [:items/loaded]})]}
   ```
 
-  Reduces every call site by 4-6 lines vs spelling out the
-  `[:rf.http/managed {:request {:method :get :url ...} ...}]` envelope
-  directly.
+  The helper pins `(:method (:request args-map))` to the verb and the
+  `:url` to the helper's argument; all other slots pass through. Top-
+  level `merge` (caller wins) for every key except `:request`, which
+  merges with the helper's `{:method <verb> :url url}` pair (helper's
+  `:method` / `:url` win — every other request slot is caller-controlled).
 
-  ## Surface
-
-  - `(get url)` / `(get url args-map)`
-  - `(post url)` / `(post url args-map)`
-  - `(put url)` / `(put url args-map)`
-  - `(delete url)` / `(delete url args-map)`
-  - `(patch url)` / `(patch url args-map)`
-  - `(head url)` / `(head url args-map)`
-  - `(options url)` / `(options url args-map)`
-
-  Each helper sets `(:method (:request args-map))` to the verb's
-  keyword. Caller-supplied `:request` keys take precedence over the
-  defaults except `:method`, which the helper always pins. The
-  caller-supplied `:url` (if any) is overwritten with the helper's
-  `url` argument so the call-site contract reads cleanly.
-
-  All other top-level keys (`:decode`, `:accept`, `:retry`,
-  `:timeout-ms`, `:on-success`, `:on-failure`, `:request-id`,
-  `:abort-signal`, etc.) pass through to the canonical args map
-  unchanged. See Spec 014 §The args map for the closed key set.
-
-  ## Why ship in `day8/re-frame2-http`
-
-  The helpers build `[:rf.http/managed ...]` fx vectors — calling them
-  only makes sense when the http artefact is on the classpath. Shipping
-  here couples the helpers to the artefact that supplies the fx they
-  reference; an app that drops the http dep loses the helpers along
-  with the fx, instead of failing at dispatch time with a stale
-  `:rf.error/no-such-fx`.
-
-  ## Naming
-
-  `get` collides with `clojure.core/get`; we `:refer-clojure :exclude
-  [get]`. Users alias the namespace (`[re-frame.http :as rf.http]`) and
-  write `(rf.http/get ...)` — the bare symbol form is rare since the
-  helpers are typically inside `:fx [...]` already-namespaced. The
-  other verbs (`post`, `put`, `delete`, `patch`, `head`, `options`)
-  don't collide with `clojure.core`.
-
-  ## Args-map merging
-
-  The helpers compose by `merge`:
-
-  ```
-  (rf.http/post \"/api/items\"
-                {:request {:body item}
-                 :on-success [:item/saved]})
-  ;; →
-  [:rf.http/managed
-   {:request {:method :post :url \"/api/items\" :body item}
-    :on-success [:item/saved]}]
-  ```
-
-  Top-level `merge` (caller wins) for every key except `:request`,
-  which is itself merged with the helper's `{:method <verb> :url url}`
-  pair (helper's `:method` and `:url` win). This lets callers supply
-  the request envelope's other slots (`:headers`, `:body`, `:params`,
-  `:credentials`, etc.) without losing the helper's verb-pinning.
-
-  See Spec 014 for the canonical args-map shape."
+  Ships with the http artefact so dropping the dep drops the helpers
+  alongside the fx they reference (rather than failing at dispatch
+  time with `:rf.error/no-such-fx`). `get` collides with
+  `clojure.core/get`; we `:refer-clojure :exclude [get]` — users alias
+  the ns (`[re-frame.http :as rf.http]`)."
   (:refer-clojure :exclude [get])
   (:require [re-frame.http-privacy-headers :as privacy-headers]
             [re-frame.http-url             :as http-url]))

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -56,14 +56,13 @@
 ;; `:require [re-frame.machines :as machines]`) see the same surface
 ;; they did pre-split.
 
-;; Per rf2-gr8q the global `spawn-counter` atom is gone. Declarative-
-;; :invoke spawns allocate ids inside the parent snapshot's
-;; `:rf/spawn-counter` slot via `re-frame.machines.transition/
-;; allocate-spawned-id`; hand-emitted spawn fxs allocate from the frame's
-;; app-db slot at `[:rf/spawn-counter <machine-id>]` inside the spawn-fx
-;; db-swap. `machine-transition` is now an honest pure function — no
-;; module-level mutable state, deterministic from its (machine snapshot
-;; event) arguments.
+;; Declarative-`:invoke` spawns allocate ids inside the parent
+;; snapshot's `:rf/spawn-counter` slot via
+;; `re-frame.machines.transition/allocate-spawned-id`; hand-emitted
+;; spawn fxs allocate from the frame's app-db slot at
+;; `[:rf/spawn-counter <machine-id>]` inside the spawn-fx db-swap.
+;; `machine-transition` is a pure function — no module-level mutable
+;; state, deterministic from its (machine snapshot event) arguments.
 
 (def reg-machine*           registration/reg-machine*)
 (def create-machine-handler registration/create-machine-handler)
@@ -84,9 +83,8 @@
 ;; system-id sid)` resolves the spawned-machine id currently bound to
 ;; `sid` in the active frame's `[:rf/system-ids]` reverse index.
 ;;
-;; Per rf2-zkca8.2 these fns moved here from the former
-;; `re-frame.machines.lifecycle-fx` (dissolved as a façade-of-a-façade):
-;; they belong on the public artefact surface, not a level below it.
+;; These query fns live on the public artefact surface (not a level
+;; below) since they're how Spec 005 §Querying machines is reached.
 
 (defn machines
   "Return a sequence of machine-ids — every event handler whose
@@ -137,17 +135,12 @@
   hook shape used to release a destroyed frame's host-clock handles and
   subscription watchers without touching sibling frames.
 
-  Per rf2-gr8q the per-process `spawn-counter` atom is gone — declarative-
-  :invoke spawn-id allocation lives inside the parent snapshot's
-  `:rf/spawn-counter` slot, and hand-emitted-spawn allocation lives inside
-  the frame's app-db at `[:rf/spawn-counter <machine-id>]`. Both reset
-  automatically: per-test snapshot rollback (via test-support's registrar
-  snapshot/restore + frame reset) clears the app-db; per-fixture snapshot
-  input in the conformance harness is hand-built fresh on each call.
-
-  Per rf2-ysa94 the wall-clock timer table is now frame-scoped — the
-  last remaining per-process mutable state in the machines artefact —
-  so the 0-arity / 1-arity split aligns with the test-fixture and
+  Spawn-id allocation lives inside the parent snapshot's
+  `:rf/spawn-counter` slot (declarative `:invoke`) or the frame's
+  app-db at `[:rf/spawn-counter <machine-id>]` (hand-emitted spawn);
+  both reset automatically with the registrar snapshot/restore + frame
+  reset, so this hook only handles the frame-scoped wall-clock timer
+  table. The 0-arity / 1-arity split aligns with the test-fixture and
   frame-destroy call sites respectively."
   ([]
    (timer/cancel-all-timers!))
@@ -159,12 +152,12 @@
 ;; Per Spec 005 §Declarative :invoke (sugar over spawn) the runtime
 ;; effects `:rf.machine/spawn` and `:rf.machine/destroy` are emitted
 ;; into the fx vector by `apply-transition-once` whenever entry/exit
-;; cascades cross an :invoke-bearing state. Per rf2-xbtj these handlers
-;; live in this namespace (rather than `re-frame.fx`'s reserved
-;; case-block) so an app that doesn't pull in
-;; `day8/re-frame2-machines` carries neither the trace strings
-;; (`:rf.machine/spawned`, `:rf.machine/destroyed`) nor the handler
-;; symbols on its production-elision bundle.
+;; cascades cross an :invoke-bearing state. These handlers live in
+;; this namespace (rather than `re-frame.fx`'s reserved case-block) so
+;; an app that doesn't pull in `day8/re-frame2-machines` carries
+;; neither the trace strings (`:rf.machine/spawned`,
+;; `:rf.machine/destroyed`) nor the handler symbols on its production-
+;; elision bundle.
 
 (fx/reg-fx :rf.machine/spawn
   {:doc "Spawn a machine instance. Per Spec 005 §Declarative :invoke (sugar over spawn). Args carry `:machine-id`, optional `:system-id`, and optional `:initial-data`."}
@@ -228,12 +221,11 @@
 ;; machines artefact see the hooks unregistered and the surface
 ;; throws / returns safe defaults cleanly.
 ;;
-;; Per Spec 005 §reg-machine vs reg-machine* (rf2-8bp3): the late-bind
-;; hook key is `:machines/reg-machine` and points at `reg-machine*` —
-;; the plain-fn surface. The `reg-machine` macro at the `re-frame.core`
-;; boundary is import-time-only (CLJS macroexpansion runs before
-;; ns-load); the runtime always reaches through this hook to the
-;; plain-fn surface.
+;; Per Spec 005 §reg-machine vs reg-machine*: the late-bind hook key
+;; `:machines/reg-machine` points at `reg-machine*` — the plain-fn
+;; surface. The `reg-machine` macro at the `re-frame.core` boundary is
+;; import-time-only (CLJS macroexpansion runs before ns-load); the
+;; runtime always reaches through this hook to the plain-fn surface.
 
 (late-bind/set-fn! :machines/reg-machine            reg-machine*)
 (late-bind/set-fn! :machines/create-machine-handler create-machine-handler)
@@ -242,15 +234,11 @@
 (late-bind/set-fn! :machines/machine-meta           machine-meta)
 (late-bind/set-fn! :machines/machine-by-system-id   machine-by-system-id)
 (late-bind/set-fn! :machines/reset-timers!          reset-timers!)
-;; Per rf2-ysa94: per-frame timer-table cleanup wired into
-;; `frame/destroy-frame!`. The frame-scoping refactor partitions the
-;; timer table `{<frame-id> {…}}`; without this hook a destroyed
-;; frame's inner table would linger as dead bookkeeping (and worse, any
-;; in-flight host-clock handles would survive teardown). Late-bound
-;; through the hook table mirroring the rf2-fcj33 SSR
-;; `:ssr/on-frame-destroyed` cleanup pattern — core never statically
-;; requires the machines artefact, so the hook resolves to nil when
-;; this namespace is absent and `destroy-frame!` proceeds without it.
+;; Per-frame timer-table cleanup wired into `frame/destroy-frame!`.
+;; The timer table is partitioned `{<frame-id> {…}}`; without this
+;; hook a destroyed frame's inner table would linger as dead
+;; bookkeeping and in-flight host-clock handles would survive teardown.
+;; Late-bound so core never statically requires the machines artefact.
 (late-bind/set-fn! :machines/on-frame-destroyed!
                    (fn [frame-id] (timer/cancel-all-timers! frame-id)))
 (late-bind/set-fn! :machines/spawn-fx               spawn-fx)

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -1,13 +1,3 @@
-;; day8/re-frame2-machines — public façade for the state-machine
-;; artefact. Per Spec 005 §State machines.
-;;
-;; The implementation lives in `re-frame.machines.{transition, parallel,
-;; timer, lifecycle-fx}` (plus the `lifecycle_fx/*` sub-namespaces).
-;; This namespace re-exports their public surface and runs the
-;; artefact's load-time side-effects — registering the `:rf.machine/*`
-;; reserved fxs and publishing the `late-bind/set-fn!` hooks that
-;; `re-frame.core` reaches through.
-
 (ns re-frame.machines
   "State machines. Per Spec 005.
 
@@ -19,16 +9,15 @@
       depth-exceeded.
     - :after delayed transitions with per-machine :rf/after-epoch
       tracking; the synthetic :rf.machine.timer/after-elapsed event
-      fires the transition only when the carried epoch matches. Per
-      rf2-3y3y, `:after` delays admit three forms — pos-int? literal,
-      subscription vector ([:sub-id & args]; re-resolves on sub change),
-      and (fn [snapshot] ms) computed once at state entry.
+      fires the transition only when the carried epoch matches. `:after`
+      delays admit three forms — pos-int? literal, subscription vector
+      ([:sub-id & args]; re-resolves on sub change), and
+      (fn [snapshot] ms) computed once at state entry.
     - Declarative :invoke that desugars into [:rf.machine/spawn args]
       on entry and [:rf.machine/destroy actor-id] on exit; deterministic
       actor ids via a per-process counter.
-    - Declarative :invoke-all (rf2-6vmw) — spawn-and-join sugar over N
-      parallel :invoke's plus a join condition (:all / :any / {:n N} /
-      {:fn pred}).
+    - Declarative :invoke-all — spawn-and-join sugar over N parallel
+      :invoke's plus a join condition (:all / :any / {:n N} / {:fn pred}).
     - The :raise reserved fx-id (machine-internal pre-commit dispatch).
     - Snapshot at [:rf/machines <id>] in app-db.
     - Pure machine-transition fn (JVM- and CLJS-runnable, deterministic).
@@ -44,22 +33,7 @@
     - `spawn-fx`, `invoke-all-init-fx` —
       `re-frame.machines.lifecycle-fx.spawn`
     - `destroy-machine-fx` — `re-frame.machines.lifecycle-fx.destroy`
-    - `after-schedule-fx`, `after-cancel-fx` — `re-frame.machines.timer`
-
-  Per rf2-zkca8.2 the former `re-frame.machines.lifecycle-fx` façade was
-  dissolved (façade-of-a-façade — its 5 def re-exports were re-exported
-  again from here, adding a hop without semantic value). The 3 query
-  fns it carried (`machines`, `machine-meta`, `machine-by-system-id`)
-  moved verbatim into this namespace where they belong on the public
-  artefact surface; the 5 def re-exports now reach directly to the
-  concrete leaves (`registration`, `spawn`, `destroy`). The 7 cohesive
-  leaves under `lifecycle_fx/` stand — each owns a Spec 005 surface.
-
-  Conformance fixtures cover all of the above (machine-transition,
-  hierarchical-{compound,cross-level,parent-fallthrough}-transition,
-  always-{single-microstep,depth-exceeded}, after-{single-delay,
-  stale-detection,hierarchy}, invoke-spawn-on-entry-destroy-on-exit,
-  invoke-all-{join-all-completes,join-any-fails-cancels,n-of-cancels-extras})."
+    - `after-schedule-fx`, `after-cancel-fx` — `re-frame.machines.timer`"
   (:require [re-frame.frame :as frame]
             [re-frame.fx :as fx]
             [re-frame.late-bind :as late-bind]

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -15,48 +15,15 @@
   the active frame (`(frame/current-frame)`); `(reg-app-schema path
   schema {:frame frame-id})` registers explicitly.
 
-  Per Spec 010 §Non-Malli validators (rf2-froe) the validator and
-  explainer fns are pluggable via `set-schema-validator!` /
-  `set-schema-explainer!`. The default validator delegates to Malli
-  (`(resolve 'malli.core/validate)`); apps that want to opt out — to
-  drop the ~24 KB gzipped Malli surface measured in
-  findings/malli-bundle-cost-audit.md — register a different fn (or
-  `nil` for a hard no-op). The `:spec` value remains opaque to the
-  framework; only the registered validator interprets it.
+  Per Spec 010 §Non-Malli validators the validator/explainer fns are
+  pluggable via `set-schema-validator!` / `set-schema-explainer!`. The
+  default validator delegates to Malli; apps drop Malli by registering
+  a different fn (or `nil` for a hard no-op).
 
-  Per rf2-dgug5 the original 1247-LoC monolith was split along the
-  banner-line concerns the file's own opening docstring described:
-
-    - `re-frame.schemas.validator`      — pluggable validator/explainer
-      atoms + `set-schema-validator!` / `set-schema-explainer!` /
-      `reset-schema-validator!` / `run-validator` / `run-explainer`
-      (rf2-froe / rf2-t0hq).
-    - `re-frame.schemas.storage`        — per-frame schema registry
-      (`schemas-by-frame`, `reg-app-schema` / `reg-app-schemas`,
-      `app-schema-at` / `app-schema-meta-at` / `app-schemas`,
-      `frame-schema-entries`, snapshot/restore/clear). Per rf2-0frdi
-      this is the single source of truth — there is no registrar
-      `:app-schema` slot.
-    - `re-frame.schemas.walker`         — unified per-slot flag walker
-      (rf2-nwv63 / rf2-kj51z / rf2-oghml) parameterised on the flag
-      key, plus `extract-large-paths-from-schema`,
-      `extract-sensitive-paths-from-schema`, `schema-has-sensitive?`.
-    - `re-frame.schemas.elision-feeder` — per-frame `:large?` /
-      `:sensitive?` declaration aggregators + idempotent
-      `[:rf/elision]` populators (rf2-v9tw2 / rf2-c1l4d).
-    - `re-frame.schemas.digest`         — Spec 010 §Digest algorithm
-      and `app-schemas-digest`.
-    - `re-frame.schemas.validate`       — the five dev-time validation
-      entry points (`validate-event!` / `validate-cofx!` /
-      `validate-fx!` / `validate-app-db!` / `validate-sub-return!`)
-      and the production-side boundary-validation seam
-      (`validate-with-registered-fn` / `explain-with-registered-fn`).
-
-  This namespace is the public façade — it re-exports the symbols
-  every external consumer reaches through (tests, `re-frame.core-
-  schemas`, the late-bind hook table) and owns the late-bind hook
-  registration so consumer artefacts pick up the schemas surface
-  without statically requiring it."
+  Public façade over `re-frame.schemas.{validator,storage,walker,
+  elision-feeder,digest,validate}` — re-exports the symbols external
+  consumers reach through (tests, `re-frame.core-schemas`, the late-
+  bind hook table) and owns the late-bind hook publication."
   (:require [re-frame.late-bind :as late-bind]
             [re-frame.schemas.digest :as digest]
             [re-frame.schemas.elision-feeder :as elision-feeder]

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -1,44 +1,18 @@
 (ns re-frame.ssr
   "Server-side rendering and hydration. Per Spec 011.
 
-  Public façade for the day8/re-frame2-ssr artefact (rf2-uo7v, sixth
-  per-feature split per rf2-5vjj Strategy B). Per Spec 006 §Adapter
-  shipping convention — this artefact depends on core; core never
-  depends on this artefact. The cross-references from core to ssr flow
-  through `re-frame.late-bind`.
+  Public façade for the day8/re-frame2-ssr artefact. Per Spec 006
+  §Adapter shipping convention — this artefact depends on core; core
+  never depends on this artefact. Cross-references from core to ssr
+  flow through `re-frame.late-bind`.
 
-  ---- file split (rf2-gxgo7) ----
-
-  Pre-split this namespace was 1380 LoC carrying seven independent
-  concerns enumerated by its own `;; ----` banners. It's now a thin
-  façade over eight flat sub-namespaces:
-
-    - `re-frame.ssr.emit`            — hiccup → HTML emitter,
-                                       `render-to-string`, source-coord
-                                       annotation, substrate-adapter
-                                       wire-up.
-    - `re-frame.ssr.hash`            — `canonical-edn`, `fnv-1a-32`,
-                                       `render-tree-hash`.
-    - `re-frame.ssr.adapter`         — the SSR adapter map + helpers.
-    - `re-frame.ssr.hydrate`         — `:rf/hydrate` handler + the two
-                                       `:rf.ssr/check-*` fx handlers
-                                       (rf2-69ad2), `verify-hydration!`.
-    - `re-frame.ssr.response`        — response accumulator + handler
-                                       fns for the six `:rf.server/*` fxs.
-    - `re-frame.ssr.error-projector` — projector registry + default +
-                                       `project-error`.
-    - `re-frame.ssr.error-listener`  — trace listener + per-frame buffer
-                                       + drain + `get-response`.
-    - `re-frame.ssr.request`         — `request-slots`, set/get/clear
-                                       helpers, `on-frame-destroyed!`,
-                                       the `:rf.server/request` cofx
-                                       handler.
-
-  All `reg-fx` / `reg-cofx` / `reg-event-fx` / `reg-error-projector` /
-  `register-trace-cb!` side-effects fire HERE so a
-  `(require 're-frame.ssr :reload)` after `(registrar/clear-all!)` —
-  the canonical test-fixture reset shape — re-installs every
-  registration. Sub-namespaces export pure handler fns only.
+  Façade over eight flat sub-namespaces (`emit`, `hash`, `adapter`,
+  `hydrate`, `response`, `error-projector`, `error-listener`,
+  `request`). All `reg-fx` / `reg-cofx` / `reg-event-fx` /
+  `reg-error-projector` / `register-trace-cb!` side-effects fire HERE
+  so `(require 're-frame.ssr :reload)` after `(registrar/clear-all!)`
+  re-installs every registration. Sub-namespaces export pure handler
+  fns only.
 
   Implements:
     - Pure hiccup → HTML emitter (HTML5 void elements, doctype prefix,


### PR DESCRIPTION
## Summary

Comments sweep against current main, 12 reopened beads (PR #1033 closed unmenged earlier due to substrate-spine extraction conflict; spine work has since landed).

Net delta: **51 files, +778 / −1507 = −729 LoC**.

### Beads landed (10)

- **rf2-ylfqk** — strip views.cljs consumer-table comment (L79-100)
- **rf2-mclqj** — compress destroy-frame nine-step docstring duplication
- **rf2-qj3mv** — compress trace.cljc multi-paragraph banners (handler-scope, retain-N ring buffer, shared-emit substrate, late-bind registration)
- **rf2-9l78c** — cut artefact-split boilerplate paragraphs across core_X / X.cljc (the identical 'Per rf2-XXXX the X namespace ships in day8/re-frame2-X' paragraph repeated in every wrapper + producing-artefact ns docstring — single-sourced to spec/Conventions.md §Optional-artefact wrapper convention)
- **rf2-7e4lf** — compress interop.cljs 55-line ns docstring (rf2-s36l history)
- **rf2-qvguc** — compress late_bind.cljc 47-line ns docstring (JVM resolve history)
- **rf2-p88vm** — compress adapter ns docstrings (helix / uix / reagent-slim — reagent was already compact)
- **rf2-0a1yz** — sweep cut `Per rf2-*` references in source (3 commits, ~80 occurrences cut from `implementation/core/src/`, plus flows / machines / adapter / ssr / schemas / http). Where the surrounding text already states the WHY, drop the bead id; where the bead id WAS the substance, fold a one-line reason into a docstring.
- **rf2-auzvs** — add one-line WHY on `set-timeout!` / `clear-timeout!` in interop.cljs (timers are a platform primitive, not substrate-reactive)
- **rf2-y8b3h** — add inline WHY for magic numbers (subs/default-grace-period-ms, router/drain-depth-default, epoch/default-depth, trace/default-buffer-depth)

### Beads closed as stale (2)

- **rf2-b7qbt** — tools/causa registry.cljs: the 81-line Phase-N scope content the bead targeted was already removed by rf2-vd4sb. Remaining ~30 lines cover three genuine concerns (namespace prefix collision contract, target-frame isolation, orchestrator pattern).
- **rf2-tt0a3** — tools/story/story.cljc: the 45-line IMPL-SPEC Stage-N scope content was already removed by rf2-568uh. Remaining ~30 lines cover Boot + Elision (legitimate WHY).

### Concurrent surface awareness

- `implementation/adapters/` (sec-audit + bug batch): touched the doc-only surfaces helix.cljs / uix.cljs / reagent_slim.cljs for rf2-p88vm; risk is minimal (no logic changes).
- `tools/story/` (story-perf batch): didn't touch.
- `tools/causa/src/.../panels/` (Causa reg-view-wrap refactor): didn't touch.
- `implementation/core/router.cljc` + `implementation/epoch/` (rf2-v0jwt partial-epoch): added one comment to router.cljc `drain-depth-default` and epoch.cljc `default-depth` (rf2-y8b3h). Pure additive — should rebase cleanly under any partial-epoch logic refactor.

## Test plan

- [x] `cd implementation && npm run test:cljs` — 1936 tests / 5513 assertions / 0 fail
- [x] `cd implementation/core && clojure -M:test` — 512 tests / 2625 assertions / 0 fail
- [x] `cd implementation/flows && clojure -M:test` — 47 / 181 / 0
- [x] `cd implementation/machines && clojure -M:test` — 153 / 489 / 0
- [x] `cd implementation/epoch && clojure -M:test` — 83 / 319 / 0
- [x] `cd implementation/schemas && clojure -M:test` — 179 / 497 / 0
- [x] `cd implementation/ssr && clojure -M:test` — 104 / 341 / 0
- [x] `cd implementation/http && clojure -M:test` — 168 / 470 / 0
- [x] `cd implementation/routing && clojure -M:test` — 74 / 266 / 0
- [x] `cd implementation && npm run test:elision` — all sentinels PRESENT
- [x] `cd implementation && npm run test:examples` — all 25 example suites PASS