### PR TITLE
fix(story): trace styling + duplicate createRoot on counter-with-stories (rf2-fq1yg)

### DIFF
--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -545,7 +545,7 @@
   (when (and config/enabled? dom-node)
     (when-let [prev @shell-singleton]
       (try
-        (rdc/unmount (:node prev))
+        (rdc/unmount (:root prev))
         (catch :default _ nil)))
     (let [root (rdc/create-root dom-node)]
       (rdc/render root [shell])
@@ -559,8 +559,16 @@
   ([] (unmount-shell! @shell-singleton))
   ([handle]
    (when handle
+     ;; rf2-fq1yg: `rdc/unmount` requires the React Root, NOT the DOM
+     ;; node — `(.unmount root)` is the React 18 contract. Passing the
+     ;; DOM node here silently no-op'd (DOM nodes have no `.unmount`
+     ;; method), so the shell's root stayed alive on `#app` and a
+     ;; subsequent `mount-app!` → `create-root` on the same node fired
+     ;; React's "container has already been passed to createRoot before"
+     ;; warning. Pass the handle's `:root` slot so React tears down
+     ;; cleanly and releases the container.
      (try
-       (rdc/unmount (:node handle))
+       (rdc/unmount (:root handle))
        (catch :default _ nil))
      (state/reset-shell-state!)
      (teardown-all-listeners!)

--- a/tools/story/src/re_frame/story/ui/trace.cljs
+++ b/tools/story/src/re_frame/story/ui/trace.cljs
@@ -216,10 +216,20 @@
                   :color "#d16969"
                   :font-style "italic"
                   :margin-bottom "4px"}
+   ;; rf2-fq1yg: longhand padding sides on every row. The `:row-selected`
+   ;; variant below adds a `:padding-left`; mixing shorthand `:padding`
+   ;; with longhand `:padding-left` on the same React element across
+   ;; renders triggers React's reconcile warning ("Updating a style
+   ;; property during rerender (paddingLeft) when a conflicting property
+   ;; is set (padding) can lead to styling bugs"). Keep every side
+   ;; longhand so React reconciles a stable set of keys.
    :row          {:display "grid"
                   :grid-template-columns "auto 1fr 1fr 1fr 1fr 1fr"
                   :gap "4px"
-                  :padding "2px 0"
+                  :padding-top "2px"
+                  :padding-right "0"
+                  :padding-bottom "2px"
+                  :padding-left "0"
                   :border-bottom "1px dotted #333"}
    ;; rf2-sxwvf: the highlight ring marks the cascade whose post-effects
    ;; produced the currently-scrubbed epoch. A solid amber outline plus


### PR DESCRIPTION
## Summary

Two browser-console warnings emitted by `examples/reagent/counter_with_stories` that the focused Playwright smoke surfaced but didn't fail on. Both were masking real, fixable contract violations.

- **React style-reconcile: `Updating paddingLeft padding`** — `trace.cljs`'s `:row` mixed shorthand `:padding "2px 0"` with the `:row-selected` overlay's longhand `:padding-left`. Convert `:row` to all-longhand padding sides so React reconciles a stable set of keys.
- **React: `createRoot() on a container that has already been passed to createRoot() before`** — shell.cljs's `mount-shell!` (prev-shell branch) and `unmount-shell!` called `(rdc/unmount (:node …))`, passing the DOM node. `rdc/unmount` requires the React Root (`.unmount root` is the React 18 contract; the adapter render test explicitly enforces this same shape). DOM nodes have no `.unmount`, so the call silently no-op'd, the shell's root stayed alive on `#app`, and the live app's subsequent `create-root` on the same node fired the duplicate-root warning. Pass the handle's `:root` slot.

LoC delta: +21/-3 across two files.

## Test plan

- [x] `tools/story && clojure -M:test` — 366 tests, 1093 assertions, 0 failures
- [x] `implementation && npm run test:cljs` — 1936 tests, 5513 assertions, 0 failures
- [x] Manual Playwright re-run of `counter_with_stories.spec.cjs` end-to-end against a real Chromium: spec **PASSES** and browser console is **clean of both bead-named warnings** (zero `padding/paddingLeft` hits, zero duplicate `createRoot` hits).

## Out of scope

A third pre-existing React style-reconcile warning surfaces while exercising the spec (`Removing borderBottom border` from the mode-tabs strip's `:tab` vs `:tab-active` shorthand/longhand mix). Tracked separately as **rf2-c4m8x** — not in this bead's scope (rf2-fq1yg names exactly the two above).