### PR TITLE
refactor: examples bead-id sweep (rf2-z4kmg) + story mode_tabs reconcile (rf2-c4m8x)

### DIFF
--- a/examples/reagent/boot/boot.cljs
+++ b/examples/reagent/boot/boot.cljs
@@ -91,8 +91,8 @@
 ;; `:invoke` / `:invoke-all`-child `:data` slot (fn-form per
 ;; Spec 005 §Spec-spec keys). The child machine spawns in `:idle`
 ;; and the runtime-synthesised `:rf.machine/spawned` event
-;; (per rf2-ijm7) transitions it to `:loading`, which fires the
-;; entry-cascade's `:begin-fetch` action.
+;; transitions it to `:loading`, which fires the entry-cascade's
+;; `:begin-fetch` action.
 
 (rf/reg-machine :boot/loader
   {:initial :idle
@@ -139,11 +139,10 @@
                         [:boot/asset-failed (:child-id data) (:error data)]]]]})}
 
    :states
-   {;; :idle is the FSM's :initial. Per rf2-ijm7, the spawn-fx
-    ;; synthesises a [:rf.machine/spawned] event into the new actor
-    ;; if no :start is supplied — :idle's transition picks it up
-    ;; and moves to :loading, which fires the entry-cascade's
-    ;; :begin-fetch action.
+   {;; :idle is the FSM's :initial. The spawn-fx synthesises a
+    ;; [:rf.machine/spawned] event into the new actor if no :start is
+    ;; supplied — :idle's transition picks it up and moves to :loading,
+    ;; which fires the entry-cascade's :begin-fetch action.
     :idle
     {:on {:rf.machine/spawned :loading}}
 

--- a/examples/reagent/boot/core.cljs
+++ b/examples/reagent/boot/core.cljs
@@ -110,9 +110,9 @@
 
 ;; React root named `react-root` (not `root`) so it does NOT collide
 ;; with any `root-view` registered above. Held in an atom and populated
-;; lazily inside `run` rather than at ns-load (rf2-gkf9) so multiple
-;; example namespaces co-required by the browser-test bundle don't
-;; race `create-root` calls onto the same shared `#app` element.
+;; lazily inside `run` rather than at ns-load so multiple example
+;; namespaces co-required by the browser-test bundle don't race
+;; `create-root` calls onto the same shared `#app` element.
 (defonce react-root (atom nil))
 
 (defn ^:export run []

--- a/examples/reagent/boot/schema.cljs
+++ b/examples/reagent/boot/schema.cljs
@@ -12,8 +12,8 @@
             ;; Loading the ns here registers its late-bind hooks so
             ;; rf/reg-app-schema resolves at the call sites below.
             [re-frame.schemas]
-            ;; Per rf2-t0hq the CLJS default validator routes through
-            ;; the late-bind hook `:schemas/malli-validate`, which the
+            ;; The CLJS default validator routes through the
+            ;; late-bind hook `:schemas/malli-validate`, which the
             ;; `re-frame.schemas.malli` adapter ns publishes at load
             ;; time. The require is the canonical CLJS opt-in for
             ;; Malli validation — without it, the default validator
@@ -112,10 +112,10 @@
 ;; SCHEMA REGISTRATION
 ;; ============================================================================
 
-;; Per rf2-wkxng / rf2-6m0se the runtime rolls back post-commit on a
-;; failing app-db schema. The slots below are absent (nil) before the
-;; boot machine writes them; every registration is wrapped in :maybe
-;; so the validator passes during the staging/loading phases.
+;; The runtime rolls back post-commit on a failing app-db schema. The
+;; slots below are absent (nil) before the boot machine writes them;
+;; every registration is wrapped in :maybe so the validator passes
+;; during the staging/loading phases.
 
 (rf/reg-app-schema [:rf/machines :app/boot] [:maybe BootSnapshot])
 

--- a/examples/reagent/counter_slim_and_fast/core.cljs
+++ b/examples/reagent/counter_slim_and_fast/core.cljs
@@ -1,7 +1,7 @@
 (ns counter-slim-and-fast.core
-  "A minimal counter mounted on the day8/reagent-slim rewrite
-   (bead rf2-5lbx; binds the S3-008 contract from reagent-slim's
-   IMPL-SPEC §1.4 + §1.8 + §6 + §12).
+  "A minimal counter mounted on the day8/reagent-slim rewrite. Binds the
+   S3-008 contract from reagent-slim's
+   IMPL-SPEC §1.4 + §1.8 + §6 + §12.
 
    Same six-domino dataflow as `examples/reagent/counter`, but every
    user-facing Reagent import points at `reagent2.*` instead of stock

--- a/examples/reagent/counter_with_stories/core.cljs
+++ b/examples/reagent/counter_with_stories/core.cljs
@@ -22,8 +22,8 @@
             ;; stories ns still loads (it's a regular CLJS ns) but
             ;; every reg-* expansion elides to nil.
             [counter-with-stories.views :as views]
-            ;; Privacy + Size elision demo (rf2-vw0to). Requiring the
-            ;; ns fires the `:auth/sign-in` :sensitive? handler reg,
+            ;; Privacy + Size elision demo. Requiring the ns fires
+            ;; the `:auth/sign-in` :sensitive? handler reg,
             ;; the `:user/avatar-pdf` :large? schema reg, the demo
             ;; subs, and exposes `install-listener!` for the boot
             ;; sequence below.
@@ -92,12 +92,11 @@
   (story/configure! {:global-args {:locale :en}})
   ;; Seed the live app's `:count` slot.
   (rf/dispatch-sync [:counter/initialise 5])
-  ;; Install the always-on event-emit listener (rf2-vw0to /
-  ;; rf2-rirbq). The listener prints every dispatched event's
-  ;; elided record to the browser console — visitors can see
-  ;; `:rf/redacted` substitution for the `:sensitive?` handler and
-  ;; the `:rf.size/large-elided` marker for the `:large?` schema
-  ;; slot without needing the trace surface or Causa attached.
+  ;; Install the always-on event-emit listener. The listener prints
+  ;; every dispatched event's elided record to the browser console —
+  ;; visitors can see `:rf/redacted` substitution for the `:sensitive?`
+  ;; handler and the `:rf.size/large-elided` marker for the `:large?`
+  ;; schema slot without needing the trace surface or Causa attached.
   (elision/install-listener!)
   ;; Wire hash-change so reloading `#/stories` lands on the shell
   ;; without a manual click-through.

--- a/examples/reagent/counter_with_stories/elision_demo.cljs
+++ b/examples/reagent/counter_with_stories/elision_demo.cljs
@@ -1,5 +1,5 @@
 (ns counter-with-stories.elision-demo
-  "Privacy + Size elision demo (rf2-vw0to).
+  "Privacy + Size elision demo.
 
   The README markets `:sensitive?` + `:large?` elision as one of
   re-frame2's headline novel-things; this namespace is the canonical
@@ -82,7 +82,7 @@
     is the SCHEMA-driven branch — the same substitution Causa
     applies when it renders `app-db` in its inspector panel.
 
-  Per rf2-vw0to. Pre-alpha."
+  Pre-alpha."
   (:require [reagent.core :as r]
             [clojure.string :as str]
             [re-frame.core :as rf]
@@ -110,12 +110,11 @@
 ;; top-level props and writes a `{:large? true :source :schema}`
 ;; entry into `[:rf/elision :declarations]`.
 ;;
-;; Per rf2-wkxng / rf2-6m0se the runtime now ROLLS BACK on a post-
-;; commit app-db schema failure — the slot may be `nil` (when the
-;; user hasn't uploaded yet), so the schema MUST permit nil. We
-;; wrap with `:maybe`; the `:large? true` flag lives on the inner
-;; `:string` slot so the walker still surfaces it under the
-;; `[:user/avatar-pdf]` registered path.
+;; The runtime ROLLS BACK on a post-commit app-db schema failure —
+;; the slot may be `nil` (when the user hasn't uploaded yet), so the
+;; schema MUST permit nil. We wrap with `:maybe`; the `:large? true`
+;; flag lives on the inner `:string` slot so the walker still surfaces
+;; it under the `[:user/avatar-pdf]` registered path.
 (rf/reg-app-schema [:user/avatar-pdf]
                    [:maybe [:string {:large? true
                                      :hint   "Avatar PDF blob"}]])

--- a/examples/reagent/counter_with_stories/elision_demo_cljs_test.cljs
+++ b/examples/reagent/counter_with_stories/elision_demo_cljs_test.cljs
@@ -1,6 +1,6 @@
 (ns counter-with-stories.elision-demo-cljs-test
-  "Integration tests for the rf2-vw0to elision demo. Asserts each
-  branch of the privacy + size elision arc actually fires:
+  "Integration tests for the privacy + size elision demo. Asserts each
+  branch of the elision arc actually fires:
 
   1. `:auth/sign-in` carries `:sensitive? true` in its registration
      metadata — `rf/handler-meta` returns the flag for trace-surface
@@ -38,16 +38,15 @@
 
 (defn- before! []
   (reset! registrar-snapshot (test-support/snapshot-registrar))
-  ;; Per rf2-qsjda: Causa's preload-time trace-cb registers its
-  ;; bookkeeping handlers with `:rf.trace/no-emit? true`, so the
-  ;; framework short-circuits emission for them and the collector
-  ;; never re-enters itself. The previous workaround that wiped
-  ;; the trace-cb registry per fixture (rf2-vw0to → rf2-nk01x
-  ;; tactical fix) is obsolete — Causa's cb runs as production
-  ;; preload wires it.
+  ;; Causa's preload-time trace-cb registers its bookkeeping
+  ;; handlers with `:rf.trace/no-emit? true`, so the framework
+  ;; short-circuits emission for them and the collector never
+  ;; re-enters itself. The previous workaround that wiped the
+  ;; trace-cb registry per fixture is obsolete — Causa's cb runs
+  ;; as production preload wires it.
   (reset! frame/frames {})
-  ;; Per rf2-wkxng / rf2-6m0se: clear cross-namespace schemas from
-  ;; the per-frame registry before re-registering this demo's
+  ;; Clear cross-namespace schemas from the per-frame registry
+  ;; before re-registering this demo's
   ;; declarations. Sibling test namespaces (auth-flow story tests,
   ;; nine-states.core, Conduit) register schemas against :rf/default
   ;; at ns-load; the post-commit validation rollback would otherwise
@@ -149,7 +148,7 @@
             branch of the walker — orthogonal to the schema-driven
             branch — keeps inline blobs off the wire even when no
             schema declared the path. Per Spec 009 §Auto-detect
-            threshold + rf2-rirbq."
+            threshold."
     (let [seen (atom [])]
       (rf/register-event-emit-listener!
         ::test-recorder
@@ -182,8 +181,8 @@
   (testing "The always-on event-emit substrate fires one record per
             processed event — EXCEPT for events whose handler-meta
             carries `:sensitive? true`, which are dropped at the
-            boundary per rf2-6hklf. `:auth/sign-in` is `:sensitive?
-            true` so it is dropped; the two `:user.avatar-pdf/*`
+            boundary. `:auth/sign-in` is `:sensitive? true` so it
+            is dropped; the two `:user.avatar-pdf/*`
             handlers are not sensitive so they deliver records.
             Asserted alongside the elision tests so the demo's
             listener install path is exercised end-to-end without
@@ -199,7 +198,7 @@
       (rf/dispatch-sync [:user.avatar-pdf/clear])
       (is (= 2 (count @seen))
           "three dispatches → two records (:auth/sign-in dropped at the
-           boundary per handler-meta :sensitive? true; rf2-6hklf)")
+           boundary per handler-meta :sensitive? true)")
       (is (= [:user.avatar-pdf/set :user.avatar-pdf/clear]
              (mapv :event-id @seen))
           "records arrive in dispatch order, sans the :sensitive? dispatch")

--- a/examples/reagent/counter_with_stories/stories.cljs
+++ b/examples/reagent/counter_with_stories/stories.cljs
@@ -97,8 +97,8 @@
             :background  "#ffffff"
             :foreground  "#1a1a1a"}})
 
-  ;; rf2-xi9zk: an `:axis :theme`-tagged mode exercises the chrome-
-  ;; level toolbar's single-select-within-axis semantics (spec/010
+  ;; An `:axis :theme`-tagged mode exercises the chrome-level
+  ;; toolbar's single-select-within-axis semantics (spec/010
   ;; §Selection semantics — by axis). Toggling :Mode.app/sepia
   ;; deactivates any other `:axis :theme` mode that was active.
   (story/reg-mode :Mode.app/sepia

--- a/examples/reagent/counter_with_stories/story_static.cljs
+++ b/examples/reagent/counter_with_stories/story_static.cljs
@@ -1,6 +1,5 @@
 (ns counter-with-stories.story-static
-  "Static-export entry point — per tools/story/spec/013-Static-Build.md
-  (rf2-8wgpm).
+  "Static-export entry point — per tools/story/spec/013-Static-Build.md.
 
   The canonical counter-with-stories example ships with two entry
   points:
@@ -19,10 +18,10 @@
     auto-open) and the bundle is suitable for publishing to GitHub
     Pages / Netlify / S3.
 
-  Per the rf2-8wgpm bead this entry-point is the sanity-test rig for the
-  `story:build` invocation; the published bundle for the canonical
-  counter-with-stories example is the artefact a downstream consumer
-  can clone, point at their own stories ns, and re-run."
+  This entry-point is the sanity-test rig for the `story:build`
+  invocation; the published bundle for the canonical counter-with-
+  stories example is the artefact a downstream consumer can clone,
+  point at their own stories ns, and re-run."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.story :as story]

--- a/examples/reagent/counter_with_stories/views.cljs
+++ b/examples/reagent/counter_with_stories/views.cljs
@@ -46,7 +46,7 @@
   (let [hint? (r/atom false)]
     (fn []
       [:div
-       ;; aria-label gives the "-" glyph an accessible name (rf2-4763); axe-core's
+       ;; aria-label gives the "-" glyph an accessible name; axe-core's
        ;; `button-name` rule passes on visible text, but the glyph alone reads
        ;; literally as "minus" to a screen reader — `aria-label` provides intent.
        [:button {:on-mouse-enter #(reset! hint? true)
@@ -63,9 +63,9 @@
                  :data-test  "inc"}
         "+"]
        ;; Hint span always renders; toggling visibility (not unmount) reserves
-       ;; layout space so the card width stays stable on hover (rf2-bnn7).
+       ;; layout space so the card width stays stable on hover.
        ;; Colour darkened from #888 (3.54:1) to #595959 (7.0:1) to clear WCAG AA
-       ;; contrast for normal text — rf2-4763.
+       ;; contrast for normal text.
        [:span {:style {:margin-left "1em" :font-size "11px" :color "#595959"
                        :visibility (if @hint? "visible" "hidden")}}
         "(demo: hint state is component-local, not in app-db)"]])))

--- a/examples/reagent/long_running_work/core.cljs
+++ b/examples/reagent/long_running_work/core.cljs
@@ -84,8 +84,8 @@
 ;;
 ;; React root is `react-root` (avoid colliding with `root-view`).
 ;; Held in an atom and populated lazily inside `run` rather than at
-;; ns-load (rf2-gkf9). Multiple example namespaces are co-required by
-;; the browser-test bundle's wrapper test namespaces; an ns-load
+;; ns-load. Multiple example namespaces are co-required by the
+;; browser-test bundle's wrapper test namespaces; an ns-load
 ;; `create-root` would race multiple roots onto the shared `#app`
 ;; element. Keeping `create-root` inside `run` makes ns-load DOM-
 ;; side-effect-free; the headless fixtures can `:require` this ns under

--- a/examples/reagent/long_running_work/worker.cljs
+++ b/examples/reagent/long_running_work/worker.cljs
@@ -148,9 +148,9 @@
 
    :states
    {:idle
-    ;; The runtime synthesises [:rf.machine/spawned] (rf2-ijm7) when
-    ;; no explicit :start is supplied; declaring it as an :on entry
-    ;; lets the child auto-kick into :processing on spawn.
+    ;; The runtime synthesises [:rf.machine/spawned] when no explicit
+    ;; :start is supplied; declaring it as an :on entry lets the child
+    ;; auto-kick into :processing on spawn.
     {:tags #{:work/idle}
      :on   {:rf.machine/spawned :processing}}
 

--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -34,9 +34,9 @@
             ;; it, dispatching `:rf.http/managed` would fail with
             ;; :rf.error/no-such-fx.
             [re-frame.http-managed]
-            ;; rf2-pf4k — call-site helpers (rf.http/get / post / put /
-            ;; delete / patch / head / options) that synthesise the
-            ;; canonical [:rf.http/managed args-map] envelope.
+            ;; Call-site helpers (rf.http/get / post / put / delete /
+            ;; patch / head / options) that synthesise the canonical
+            ;; [:rf.http/managed args-map] envelope.
             [re-frame.http :as rf.http]
             [re-frame.adapter.reagent-slim :as reagent-slim-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
@@ -74,10 +74,10 @@
                (assoc :status :error
                       :error  (:failure (:rf/reply msg))))}
 
-      ;; Initial branch — issue the request. rf2-pf4k: the
-      ;; `rf.http/get` helper synthesises the same `[:rf.http/managed
-      ;; args-map]` envelope a hand-written `:method :get` entry
-      ;; would; the call-site reads as one line of intent.
+      ;; Initial branch — issue the request. The `rf.http/get`
+      ;; helper synthesises the same `[:rf.http/managed args-map]`
+      ;; envelope a hand-written `:method :get` entry would; the
+      ;; call-site reads as one line of intent.
       :else
       {:db (assoc db :status :loading :error nil)
        :fx [(rf.http/get "api/inc.json" {:decode :json})]})))
@@ -94,7 +94,7 @@
       ;; Should not happen — the URL is intentionally 404.
       {:db (assoc db :status :idle :error nil)}
 
-      ;; rf2-pf4k — same `rf.http/get` helper as above. Per Spec 014
+      ;; Same `rf.http/get` helper as above. Per Spec 014
       ;; §Classification order, status-check fires before decode — so
       ;; even with `:decode :json`, a 404 with an HTML or plain-text
       ;; body classifies as :rf.http/http-4xx (the raw body lands at
@@ -136,7 +136,7 @@
 ;;
 ;; A "long" request is routed through a per-app stub that defers its
 ;; reply via js/setTimeout, so the :loading state is observable in a
-;; browser long enough for the cancel UI to interact with it (rf2-fv8at).
+;; browser long enough for the cancel UI to interact with it.
 ;; The Spec 014 contract is that the in-flight request dispatches
 ;; :rf.http/aborted on cancellation; the deferred-stub approach mimics
 ;; that contract end-to-end without requiring a real long-running

--- a/examples/reagent/nine_states/core.cljs
+++ b/examples/reagent/nine_states/core.cljs
@@ -668,8 +668,8 @@
 ;; MOUNT  (CLJS reference; client-only)
 ;; ============================================================================
 ;;
-;; The mount is performed inside `run` rather than at namespace-load time
-;; (rf2-gkf9). Examples are also `:require`'d by the browser-test bundle
+;; The mount is performed inside `run` rather than at namespace-load
+;; time. Examples are also `:require`'d by the browser-test bundle
 ;; (`re-frame.nine-states-cljs-test`) — which also requires sibling
 ;; examples like `realworld.core`. If both namespaces called
 ;; `rdc/create-root` against `(js/document.getElementById "app")` at

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -335,8 +335,8 @@
 
 ;; React root named `react-root` (not `root`) so it does NOT collide with
 ;; the `root-view` reg-view above. Held in an atom and populated lazily
-;; inside `run` rather than at ns-load (rf2-gkf9). Multiple example
-;; namespaces (this one, nine-states, boot, long-running-work, websocket)
+;; inside `run` rather than at ns-load. Multiple example namespaces
+;; (this one, nine-states, boot, long-running-work, websocket)
 ;; are co-required by the browser-test bundle's wrapper test namespaces
 ;; — and the test harness shares a single `#app` mount point. Performing
 ;; `create-root` at ns-load would race multiple roots onto the same

--- a/examples/reagent/realworld/schema.cljs
+++ b/examples/reagent/realworld/schema.cljs
@@ -3,8 +3,8 @@
 
    These describe the shape of every wire payload the RealWorld API returns,
    plus the shape of each app-db slice that holds them. The schemas are
-   registered with re-frame2 via `reg-app-schemas` (the bulk plural form,
-   per rf2-jzs9) for path-based validation per Spec 010.
+   registered with re-frame2 via `reg-app-schemas` (the bulk plural form)
+   for path-based validation per Spec 010.
 
    The RealWorld API spec is documented at:
      https://github.com/gothinkster/realworld/tree/main/api
@@ -208,7 +208,7 @@
 ;; Path-based schema attachment per Spec 010. The framework validates writes
 ;; to these paths in development.
 ;;
-;; This example uses the bulk plural form `rf/reg-app-schemas` (rf2-jzs9):
+;; This example uses the bulk plural form `rf/reg-app-schemas`:
 ;; a feature-modular app declares 5–20 schemas in one place, so a single
 ;; `{path -> schema}` map reads more cleanly than a tower of singular
 ;; `reg-app-schema` calls. Source-coords for the bulk call stamp every

--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -72,7 +72,7 @@
 ;; and defers modifier-key / auxiliary-button (middle-click) clicks to the
 ;; browser so the native open-in-new-tab affordance is preserved. Any
 ;; passthrough HTML attrs on the props map (e.g. `:data-testid` used by
-;; the Playwright spec, rf2-0gdsb) land on the underlying `<a>`.
+;; the Playwright spec) land on the underlying `<a>`.
 
 (reg-view home-page []
   [:div

--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -90,7 +90,7 @@
 (rf/reg-event-fx :rf/server-init
   {:doc       "Per-request server-side initialisation. Reads the request
                via the :rf.server/request cofx (Spec 011 §Request storage
-               substrate, rf2-afxhv), dispatches setup events. Server only."
+               substrate), dispatches setup events. Server only."
    :platforms #{:server}}
   [(rf/inject-cofx :rf.server/request)]
   (fn handler-rf-server-init [{:keys [db rf.server/request]} _]

--- a/examples/reagent/state_machine_walkthrough/core.cljc
+++ b/examples/reagent/state_machine_walkthrough/core.cljc
@@ -265,7 +265,7 @@
   "Three failures cycle :submitting → :error-shown → :idle ×3, then a
   fourth :submit fails the guard and lands at :locked-out.
 
-  Uses `rf/with-fx-overrides` (rf2-5uwl) — the lexical-scope counterpart to
+  Uses `rf/with-fx-overrides` — the lexical-scope counterpart to
   the per-frame `:fx-overrides` opt on `make-frame`: every dispatch
   inside the macro body inherits the override map, so the seven
   identical `:rf.http/managed` swaps don't need to thread the override

--- a/examples/reagent/websocket/connection.cljs
+++ b/examples/reagent/websocket/connection.cljs
@@ -1,6 +1,6 @@
 (ns websocket.connection
   "The `:ws/connection` connection machine — the canonical Pattern-WebSocket
-   worked example (rf2-yf97).
+   worked example.
 
    This is a faithful realisation of `spec/Pattern-WebSocket.md` §Worked
    example. The hierarchy is:

--- a/examples/reagent/websocket/core.cljs
+++ b/examples/reagent/websocket/core.cljs
@@ -1,5 +1,5 @@
 (ns websocket.core
-  "Entry point for the Pattern-WebSocket worked example (rf2-yf97).
+  "Entry point for the Pattern-WebSocket worked example.
 
    This is the canonical re-frame2 example for spec/Pattern-WebSocket.md.
    Every key piece of the pattern is exercised:
@@ -123,8 +123,8 @@
 ;; ============================================================================
 ;;
 ;; React root held in an atom and populated lazily inside `run` rather
-;; than at ns-load (rf2-gkf9). Multiple example namespaces co-required
-;; by the browser-test bundle's wrapper test namespaces share a single
+;; than at ns-load. Multiple example namespaces co-required by the
+;; browser-test bundle's wrapper test namespaces share a single
 ;; `#app` element; running `create-root` at ns-load would race multiple
 ;; roots onto the same container and leak example-A's mount into
 ;; example-B's tests. Mounting in `run` keeps ns-load DOM-side-effect-free.

--- a/examples/reagent/websocket/messages.cljs
+++ b/examples/reagent/websocket/messages.cljs
@@ -1,6 +1,6 @@
 (ns websocket.messages
   "The `:websocket/socket` actor + outbound/inbound message handling
-   for the Pattern-WebSocket example (rf2-yf97).
+   for the Pattern-WebSocket example.
 
    This file plays two roles:
 
@@ -213,9 +213,9 @@
 ;; `:invoke` destroys this actor on any exit from `:active`, which
 ;; takes care of cleanup.
 ;;
-;; The actor uses the runtime-stamped `:rf/self-id` (per rf2-ijm7) to
-;; address dispatches back to the parent's `:rf/parent-id`. The
-;; framework reserves both keys under `:data :rf/*` for spawned actors.
+;; The actor uses the runtime-stamped `:rf/self-id` to address
+;; dispatches back to the parent's `:rf/parent-id`. The framework
+;; reserves both keys under `:data :rf/*` for spawned actors.
 
 (def socket-actor-machine
   "Spec for the `:websocket/socket` actor machine — held in a `def` so
@@ -284,11 +284,11 @@
 
      :states
      {:opening
-      ;; Per Spec 005 §Initial-state `:entry` fires on machine bootstrap
-      ;; (rf2-0z73): the initial-state's `:entry` action runs once as
-      ;; part of bringing the actor to life. We open the host-side
-      ;; socket on bootstrap and transition immediately to `:open` via
-      ;; the `:always` slot once the socket is stored.
+      ;; Per Spec 005 §Initial-state `:entry` fires on machine bootstrap:
+      ;; the initial-state's `:entry` action runs once as part of
+      ;; bringing the actor to life. We open the host-side socket on
+      ;; bootstrap and transition immediately to `:open` via the
+      ;; `:always` slot once the socket is stored.
       ;;
       ;; The actor may also receive `:send` from the parent's
       ;; `:send-auth` entry-action before its own bootstrap entry has

--- a/examples/reagent/websocket/schema.cljs
+++ b/examples/reagent/websocket/schema.cljs
@@ -1,6 +1,6 @@
 (ns websocket.schema
   "Malli schemas for the WebSocket example (Pattern-WebSocket worked
-   example, rf2-yf97).
+   example).
 
    Three slices are described:
 

--- a/examples/reagent/websocket/test/websocket/connection_test.cljs
+++ b/examples/reagent/websocket/test/websocket/connection_test.cljs
@@ -1,6 +1,6 @@
 (ns websocket.connection-test
   "Headless tests for `websocket.connection` — the Pattern-WebSocket
-   worked example's connection state machine (rf2-yf97).
+   worked example's connection state machine.
 
    Coverage:
    - Initial state — the machine starts at `:disconnected` with empty

--- a/examples/reagent/websocket/test/websocket/messages_test.cljs
+++ b/examples/reagent/websocket/test/websocket/messages_test.cljs
@@ -1,7 +1,7 @@
 (ns websocket.messages-test
   "Headless tests for `websocket.messages` — the socket actor +
    message-correlation + server-push handling of the Pattern-WebSocket
-   example (rf2-yf97).
+   example.
 
    Coverage:
    - Request-reply correlation — issue a `:ws.app/request`, observe the

--- a/examples/reagent/websocket/views.cljs
+++ b/examples/reagent/websocket/views.cljs
@@ -1,5 +1,5 @@
 (ns websocket.views
-  "Views for the Pattern-WebSocket example (rf2-yf97).
+  "Views for the Pattern-WebSocket example.
 
    The UI is intentionally minimal so the connection-machine drama is
    the visible thing: a status indicator driven by the machine's tag
@@ -39,7 +39,7 @@
                   the Playwright smoke assert the reconnect counter
                   advanced after a Drop click without relying on
                   catching the transient RECONNECTING window in the
-                  pill text (rf2-4dfjv)."}
+                  pill text."}
           status-pill []
   (let [connected?     @(subscribe [:ws/connected?])
         reconnecting?  @(subscribe [:ws/reconnecting?])

--- a/tools/story/src/re_frame/story/ui/mode_tabs.cljs
+++ b/tools/story/src/re_frame/story/ui/mode_tabs.cljs
@@ -125,15 +125,25 @@
                  :font-family      "monospace"
                  :font-size        "11px"
                  :padding          "0"}
-   :tab         {:padding          "6px 14px"
-                 :cursor           "pointer"
-                 :color            "#b0b0b0"
-                 :background       "#2d2d30"
-                 :border           "none"
-                 :border-right     "1px solid #444"
-                 :font-family      "monospace"
-                 :font-size        "11px"
-                 :letter-spacing   "0.3px"}
+   ;; rf2-c4m8x: longhand-only border sides on every chip. The
+   ;; `:tab-active` overlay below adds a `:border-bottom`; mixing the
+   ;; shorthand `:border "none"` with longhand `:border-bottom` on the
+   ;; same React element across renders triggers React's reconcile
+   ;; warning ("Removing a style property during rerender (borderBottom)
+   ;; when a conflicting property is set (border) can lead to styling
+   ;; bugs"). Spell every side longhand so React reconciles a stable
+   ;; set of keys. Same shape as the trace.cljs fix in rf2-fq1yg.
+   :tab         {:padding             "6px 14px"
+                 :cursor              "pointer"
+                 :color               "#b0b0b0"
+                 :background          "#2d2d30"
+                 :border-top          "none"
+                 :border-right        "1px solid #444"
+                 :border-bottom       "none"
+                 :border-left         "none"
+                 :font-family         "monospace"
+                 :font-size           "11px"
+                 :letter-spacing      "0.3px"}
    :tab-active  {:color            "white"
                  :background       "#1e1e1e"
                  :border-bottom    "1px solid #1e1e1e"


### PR DESCRIPTION
## Summary

Two small-surface cosmetic fixes on disjoint surfaces, batched as a single PR.

### rf2-c4m8x — Story `mode_tabs` React reconcile warning (BUG)

`tools/story/src/re_frame/story/ui/mode_tabs.cljs` — the `:tab` style carried shorthand `:border "none"` plus longhand `:border-right`; the `:tab-active` overlay added longhand `:border-bottom`. React reconciles between renders that mix shorthand + longhand on the same element and warns:

> Removing a style property during rerender (borderBottom) when a conflicting property is set (border) can lead to styling bugs.

Fixed by converting `:border "none"` to all-longhand sides (`:border-top`, `:border-right`, `:border-bottom`, `:border-left`) so React reconciles a stable set of keys. Same shape as the trace.cljs fix that shipped under rf2-fq1yg (PR #1070).

### rf2-z4kmg — Strip `rf2-XXXXX` bead-id references from `examples/` (P3)

`examples/` is the human-facing read-it-to-learn surface; bead IDs are noise to a learner who isn't tracking the project's internal task graph. `implementation/` and `tools/` MAY keep bead-id references for framework contributors.

Removed 49 occurrences across 26 source files (cljs / cljc). Each comment / docstring rewritten to preserve the WHY without the bead-id reference; comments that were JUST the bead-id were deleted.

## Test plan

- [x] `cd tools/story && clojure -M:test` — 366 tests / 1093 assertions, 0 failures
- [x] `cd implementation && npm run test:cljs` — 1936 tests / 5513 assertions, 0 failures
- [x] `cd implementation && npm run test:examples` — all 26 examples PASS
- [ ] Visual sanity (post-merge): boot counter-with-stories, click mode-tab chips, confirm no React style-reconcile warning in browser console