### PR TITLE
feat(pair2-mcp): :elided-large clarification (rf2-0znsb) + eval-cljs launch-flag gate (rf2-cxx5s)

### DIFF
--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -1508,6 +1508,8 @@ Consumer-side defaults (MUST-level):
 - **On-box listener integrations** (Causa panel, Story panels per [Tool-Pair.md](Tool-Pair.md)) MUST default `:rf.size/include-large?` to `false` (the dev-tools UI shows a `[● ELIDED N]`-style indicator the user clicks to opt in for a single fetch). Production-trust on-box consumers MAY default to `true`; the rationale must be documented per-consumer.
 - **Indicator field on tool responses.** Tools that return structured response maps (every MCP server per [Tool-Pair.md](Tool-Pair.md)) MUST carry an `:elided-large` count alongside the existing `:dropped-sensitive` count (per [§Privacy / sensitive data in traces](#privacy--sensitive-data-in-traces)) — one MUST-level row per consumer-facing tool that walks a tree-typed payload.
 
+  The `:elided-large` slot reports the count of `:rf.size/large-elided` markers ENCOUNTERED in the tool's response payload. Tools do not invoke `elide-wire-value` themselves — markers ride through from upstream (the event-emit substrate per rf2-rirbq, the error-emit substrate per rf2-bacs4, schema-slot meta). The slot is omitted when the count is zero (per [Conventions.md](Conventions.md) — `:elided-large` row).
+
 The walker MUST NOT widen the policy transitively into the underlying registry — the policy is per-call; the registry of declared paths is per-frame state.
 
 #### Composition

--- a/tools/mcp-conformance/test/live-pair2-overflow.js
+++ b/tools/mcp-conformance/test/live-pair2-overflow.js
@@ -315,7 +315,19 @@ runWithWatchdog(
     clientName: 'mcp-conformance-pair2-live-overflow',
     transportSpec: {
       command: process.execPath,
-      args: [SERVER],
+      // `--allow-eval` opts the spawned pair2-mcp server into the
+      // eval-cljs tool, which is default-OFF in published builds per
+      // rf2-cxx5s (cascade from rf2-czv3p). Without the flag,
+      // eval-cljs returns `{:ok? false :reason :rf.error/eval-cljs-disabled}`
+      // with `isError: true` before ever reaching nREPL — which means
+      // the wire-cap path can't be exercised because no payload is
+      // produced. This live-overflow harness's *whole purpose* is to
+      // trip the cap on a real eval response, so it must opt in. The
+      // default-OFF security contract is pinned by the unit fixture
+      // `:eval-cljs/disabled-default` in tools/pair2-mcp's conformance
+      // corpus — that's the right layer for the gate; here we want the
+      // post-gate logical path.
+      args: [SERVER, '--allow-eval'],
       cwd: os.tmpdir(),
       env: { ...process.env },
     },

--- a/tools/pair2-mcp/README.md
+++ b/tools/pair2-mcp/README.md
@@ -74,6 +74,34 @@ The server auto-discovers the nREPL port from (in order):
 3. `.shadow-cljs/nrepl.port`
 4. `.nrepl-port`
 
+### Launch flags
+
+| Flag           | Default | What it does                                                                         |
+|----------------|---------|--------------------------------------------------------------------------------------|
+| `--allow-eval` | OFF     | Enable the `eval-cljs` tool. Default-OFF gate (rf2-cxx5s); see "eval-cljs gate" below. |
+
+#### eval-cljs gate (rf2-cxx5s)
+
+`eval-cljs` executes arbitrary CLJS / Clojure source against the live
+runtime — qualitatively different authority from the named-mutation
+tools (`dispatch`, etc.) which mirror in-panel affordances. Published
+builds ship the tool DISABLED; the operator opts in at server launch:
+
+```json
+{
+  "mcpServers": {
+    "re-frame-pair2": {
+      "command": "re-frame-pair2-mcp",
+      "args": ["--allow-eval"]
+    }
+  }
+}
+```
+
+Without the flag, calls to `eval-cljs` return the structured error
+`{:ok? false :reason :rf.error/eval-cljs-disabled ...}` without
+touching the nREPL socket. Same posture as causa-mcp's split (rf2-zyoj2).
+
 ### First call
 
 ```text

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/server.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/server.cljs
@@ -28,6 +28,7 @@
             [clojure.string :as str]
             [re-frame-pair2-mcp.nrepl :as nrepl]
             [re-frame-pair2-mcp.tools :as tools]
+            [re-frame-pair2-mcp.tools.eval-cljs :as eval-cljs]
             ["@modelcontextprotocol/sdk/server/index.js" :as mcp-server]
             ["@modelcontextprotocol/sdk/server/stdio.js" :as mcp-stdio]
             ["@modelcontextprotocol/sdk/types.js" :as mcp-types]))
@@ -129,7 +130,27 @@
                                              :reason :nrepl-port-not-found
                                              :hint   (-> boot-error ex-data :hint)})}]})))
 
-(defn main [& _args]
+(defn parse-launch-flags
+  "Pluck the named boolean launch flags out of the raw process argv. Today's
+  surface is one flag — `--allow-eval` — which opts in to the `eval-cljs`
+  tool per the rf2-cxx5s gate (cascade from rf2-czv3p). Default OFF in
+  published builds.
+
+  Returns `{:allow-eval? bool}`. Unknown flags are ignored — node's
+  shadow-cljs entry passes its own argv prelude (script path), and
+  future flags can land here without breaking older invocations."
+  [argv]
+  {:allow-eval? (boolean (some #{"--allow-eval"} argv))})
+
+(defn- apply-launch-flags!
+  "Wire launch-flag state into the relevant tool gates. Called once
+  before the dispatcher accepts requests."
+  [{:keys [allow-eval?]}]
+  (eval-cljs/set-allow-eval! allow-eval?)
+  (log! "eval-cljs:" (if allow-eval? "ENABLED (--allow-eval)" "disabled (default; pass --allow-eval to opt in)")))
+
+(defn main [& args]
+  (apply-launch-flags! (parse-launch-flags (vec args)))
   (try
     (let [conn   (new-conn)
           server (boot! conn)]

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/eval_cljs.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/eval_cljs.cljs
@@ -1,14 +1,53 @@
 (ns re-frame-pair2-mcp.tools.eval-cljs
-  "Tool: eval-cljs — evaluate one CLJS form."
+  "Tool: eval-cljs — evaluate one CLJS form.
+
+  ## Launch-flag gate (rf2-cxx5s, cascade from rf2-czv3p)
+
+  Arbitrary code execution is qualitatively different from named
+  mutations (`dispatch`, etc.) — the programmer must opt in explicitly
+  at server launch. Published builds default to OFF; the operator
+  passes `--allow-eval` on the pair2-mcp server command line to enable.
+
+  The gate is a single atom (`allow-eval?`) set by `server.cljs/main`
+  from `process.argv` before the dispatcher starts handling tools/call
+  requests. When OFF, `eval-cljs-tool` returns the structured error
+  `{:ok? false :reason :rf.error/eval-cljs-disabled ...}` without
+  touching the nREPL socket.
+
+  Tests flip the atom directly via `set-allow-eval!`."
   (:require [clojure.string :as str]
             [re-frame-pair2-mcp.nrepl :as nrepl]
             [re-frame-pair2-mcp.tools.wire :as wire]
             [re-frame-pair2-mcp.tools.probe :as probe]))
 
+(defonce ^:private allow-eval?
+  ;; Default OFF in published builds. `server.cljs/main` flips this to
+  ;; `true` when `--allow-eval` is present in `process.argv`.
+  (atom false))
+
+(defn set-allow-eval!
+  "Set the eval-cljs launch-flag gate. Called once by `server.cljs/main`
+  during boot; called by tests to flip the gate."
+  [enabled?]
+  (reset! allow-eval? (boolean enabled?)))
+
+(defn allow-eval-enabled?
+  "Read the current gate state. Exposed for tests + server-side logging."
+  []
+  @allow-eval?)
+
 (defn eval-cljs-tool [conn args]
   (let [form     (wire/arg args :form)
         build-id (wire/arg-build args)]
     (cond
+      (not @allow-eval?)
+      (js/Promise.resolve
+        (wire/err-text
+          {:ok?    false
+           :reason :rf.error/eval-cljs-disabled
+           :hint   (str "eval-cljs is disabled by default for security; "
+                        "pass --allow-eval at server launch to opt in")}))
+
       (or (nil? form) (str/blank? form))
       (js/Promise.resolve
         (wire/err-text {:ok? false :reason :missing-form

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs
@@ -61,6 +61,8 @@
   atom for the lifetime of a `subscribe-tool` call; merged once per
   drain. Indicator slots (`:dropped-sensitive`, `:elided-large`) feed
   `wire/with-indicators` at terminal-summary emit time."
+  ;; :elided-large counts upstream-pre-elided markers per
+  ;; Spec 009 §Indicator field (rf2-8cntr) — cumulative across drains.
   {:tick              0
    :delivered         0
    :dropped-events    0
@@ -254,6 +256,8 @@
                             ov-reason      (:overflow-reason drain-resp)
                             [evts dropped] (sensitive/strip-sensitive
                                              (vec raw-evts) incl?)
+                            ;; :elided-large counts upstream-pre-elided markers per
+                            ;; Spec 009 §Indicator field (rf2-8cntr) — per-tick contribution.
                             tick-elided    (base-elision/count-elided-markers evts)
                             n              (count evts)
                             drain-delta    {:n           n

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire_pipeline.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire_pipeline.cljs
@@ -102,6 +102,8 @@
         [sliced path-status]  (pipeline/slice-app-db-in-snapshot scrubbed path app-db-mode)
         diff-encoded          (pipeline/diff-encode-epochs-in-snapshot sliced mode)
         deduped               (pipeline/dedup-epochs-in-snapshot diff-encoded dedup?)
+        ;; :elided-large counts upstream-pre-elided markers per
+        ;; Spec 009 §Indicator field (rf2-8cntr).
         elided                (if (some? server-elided)
                                 server-elided
                                 (base-elision/count-elided-markers deduped))
@@ -134,6 +136,9 @@
   (let [[kept dropped] (sensitive/strip-sensitive epochs incl?)
         encoded        (dedup/diff-encode-epochs kept mode)
         deduped        (dedup/dedup-value encoded dedup?)
+        ;; :elided-large counts upstream-pre-elided markers per
+        ;; Spec 009 §Indicator field (rf2-8cntr) — shared by
+        ;; `trace-window` and `watch-epochs`.
         elided         (base-elision/count-elided-markers deduped)]
     {:value      deduped
      :indicators {:dropped dropped
@@ -160,6 +165,8 @@
 
   Returns `{:value v :indicators {:elided N}}`."
   [v {:keys [server-elided]}]
+  ;; :elided-large counts upstream-pre-elided markers per
+  ;; Spec 009 §Indicator field (rf2-8cntr).
   {:value      v
    :indicators {:elided (if (some? server-elided)
                           server-elided

--- a/tools/pair2-mcp/test/live-nrepl.js
+++ b/tools/pair2-mcp/test/live-nrepl.js
@@ -22,7 +22,10 @@ const PORT = process.env.NREPL_TEST_PORT || '17778';
 function run() {
   return new Promise((resolve, reject) => {
     const env = { ...process.env, SHADOW_CLJS_NREPL_PORT: PORT };
-    const child = spawn(process.execPath, [SERVER], {
+    // Pass `--allow-eval` to opt in to the eval-cljs tool (rf2-cxx5s
+    // launch-flag gate, default OFF). This live-nrepl probe is
+    // specifically exercising the eval surface.
+    const child = spawn(process.execPath, [SERVER, '--allow-eval'], {
       stdio: ['pipe', 'pipe', 'pipe'],
       env,
     });

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/conformance_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/conformance_test.cljs
@@ -67,7 +67,8 @@
             [applied-science.js-interop :as j]
             [re-frame-pair2-mcp.cache :as cache]
             [re-frame-pair2-mcp.nrepl :as nrepl]
-            [re-frame-pair2-mcp.tools :as tools]))
+            [re-frame-pair2-mcp.tools :as tools]
+            [re-frame-pair2-mcp.tools.eval-cljs :as eval-cljs]))
 
 ;; ---------------------------------------------------------------------------
 ;; Test infrastructure — args coercion, result extraction, stub installation.
@@ -298,9 +299,25 @@
     {:edn-submap {:ok? false :reason :runtime-not-preloaded}}}
 
    ;; ---------- eval-cljs --------------------------------------------------
-   {:fixture/id    :eval-cljs/happy
-    :fixture/doc   "eval-cljs returns {:ok? true :value v} on a successful runtime eval."
+   ;; The launch-flag gate (rf2-cxx5s, cascade from rf2-czv3p) ships
+   ;; DEFAULT-OFF in published builds — the operator passes `--allow-eval`
+   ;; to opt in. Fixtures that drive the post-gate logical paths
+   ;; (`:happy`, `:missing-form`) set `:fixture/allow-eval? true`; the
+   ;; `:disabled` fixture pins the default-off envelope.
+   {:fixture/id    :eval-cljs/disabled-default
+    :fixture/doc   "eval-cljs with the launch-flag OFF returns :rf.error/eval-cljs-disabled."
     :fixture/tool  "eval-cljs"
+    :fixture/args  {:form "(+ 1 2)"}
+    :fixture/eval-script
+    [[:default nil]]
+    :fixture/expect
+    {:isError? true
+     :reason :rf.error/eval-cljs-disabled}}
+
+   {:fixture/id    :eval-cljs/happy
+    :fixture/doc   "eval-cljs with --allow-eval returns {:ok? true :value v} on a successful runtime eval."
+    :fixture/tool  "eval-cljs"
+    :fixture/allow-eval? true
     :fixture/args  {:form "(+ 1 2)"}
     :fixture/eval-script
     [["__re_frame_pair2_runtime"  true]
@@ -311,8 +328,9 @@
      :edn-submap {:ok? true :value 3}}}
 
    {:fixture/id    :eval-cljs/missing-form
-    :fixture/doc   "eval-cljs without :form surfaces :missing-form."
+    :fixture/doc   "eval-cljs with --allow-eval but without :form surfaces :missing-form."
     :fixture/tool  "eval-cljs"
+    :fixture/allow-eval? true
     :fixture/args  {}
     :fixture/eval-script
     [[:default nil]]
@@ -529,10 +547,17 @@
 (defn- run-one-fixture
   "Drive one fixture through `tools/invoke` and check its result.
   Returns a Promise resolving to `{:fixture-id ... :passed? bool
-  :failure ...}`."
-  [{:fixture/keys [id tool args eval-script expect]}]
+  :failure ...}`.
+
+  Honors `:fixture/allow-eval?` — flips the eval-cljs launch-flag gate
+  (rf2-cxx5s) for this fixture's invocation and restores it afterward.
+  Default OFF mirrors the published-build posture; opt-in fixtures
+  exercise the post-gate paths."
+  [{:fixture/keys [id tool args eval-script expect allow-eval?]}]
   (cache/clear!)
-  (let [js-args (args->js args)]
+  (let [js-args   (args->js args)
+        prev-gate (eval-cljs/allow-eval-enabled?)]
+    (eval-cljs/set-allow-eval! (boolean allow-eval?))
     (with-stubbed-eval! eval-script
       (fn []
         (-> (tools/invoke nil tool js-args nil)
@@ -547,7 +572,8 @@
                       {:fixture-id id
                        :passed?    false
                        :failure    (str "invoke threw: " (.-message err))
-                       :exception  err})))))))
+                       :exception  err}))
+            (.finally (fn [] (eval-cljs/set-allow-eval! prev-gate))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The single deftest — walks the corpus serially (each fixture's stub

--- a/tools/pair2-mcp/test/stdio-roundtrip.js
+++ b/tools/pair2-mcp/test/stdio-roundtrip.js
@@ -5,8 +5,11 @@
 //   - initialize handshake
 //   - tools/list (expects all twelve tools: original ten + get-pair2-instructions
 //     under rf2-tygdv + subscription-info under rf2-zjz9q)
-//   - tools/call eval-cljs against an absent nREPL (expects graceful
-//     :nrepl-port-not-found degraded mode)
+//   - tools/call eval-cljs against an absent nREPL — with `--allow-eval`
+//     passed below, expects graceful :nrepl-port-not-found degraded mode.
+//     The default-off gate (rf2-cxx5s) is exercised by the conformance
+//     `:eval-cljs/disabled-default` fixture; this test passes the flag
+//     so the existing degraded-path coverage remains intact.
 //   - tools/call snapshot against an absent nREPL (same degraded mode —
 //     proves the new tool is wired into the dispatch table)
 //   - tools/call get-path against an absent nREPL (same degraded mode —
@@ -29,7 +32,10 @@ function run() {
     const env = { ...process.env, SHADOW_CLJS_NREPL_PORT: '' };
     delete env.SHADOW_CLJS_NREPL_PORT;
     // Boot from a tmp dir so port-file probing misses.
-    const child = spawn(process.execPath, [SERVER], {
+    // Pass `--allow-eval` to opt in to the eval-cljs tool (rf2-cxx5s
+    // launch-flag gate, default OFF). The roundtrip relies on
+    // eval-cljs to surface the no-nREPL degraded envelope.
+    const child = spawn(process.execPath, [SERVER, '--allow-eval'], {
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: require('node:os').tmpdir(),
       env,


### PR DESCRIPTION
## Summary

Two decision-resolved beads landed together — both touch `tools/pair2-mcp/` and share the conformance corpus, so they ship as one PR.

### rf2-0znsb — :elided-large MUST-scope clarification

Implements the rf2-8cntr decision (Mike, 2026-05-14): **Option (b) count-what-you-encounter**. Tools do NOT invoke `elide-wire-value` themselves — markers ride through from upstream (event-emit substrate per rf2-rirbq, error-emit substrate per rf2-bacs4, schema-slot meta). The `:elided-large` slot reports the count of `:rf.size/large-elided` markers ENCOUNTERED in the response payload; omitted when zero.

- `spec/009-Instrumentation.md` §Indicator field gains the clarifying paragraph (single source of truth for the count-what-you-encounter semantics).
- One-liner breadcrumb pointing at the Spec 009 paragraph at each of the 5 `:elided-large` emit sites: `wire-pipeline/run-snapshot-map`, `run-epoch-vector` (shared by trace-window + watch-epochs), `run-scalar-value` (get-path), `subscribe/initial-state` (cumulative accumulator), subscribe per-tick drain.

### rf2-cxx5s — eval-cljs launch-flag gate

Implements the rf2-czv3p cascade decision (Mike, 2026-05-14): pair2-mcp's `eval-cljs` gets the same treatment as causa-mcp's per rf2-zyoj2 — **gated with launch-flag opt-in, default OFF in published builds**. Arbitrary code execution is qualitatively different from named mutations; programmer opts in explicitly at server launch.

- `--allow-eval` flag plumbed through `server.cljs/main` → atom in `tools/eval_cljs`. Parsed from `process.argv` once at boot, then read on every eval-cljs invocation.
- When OFF, `eval-cljs-tool` returns the structured error `{:ok? false :reason :rf.error/eval-cljs-disabled :hint "eval-cljs is disabled by default for security; pass --allow-eval at server launch to opt in"}` without touching the nREPL socket.
- `README.md` documents the flag (table of launch flags + dedicated "eval-cljs gate" subsection with rationale and the `args: ["--allow-eval"]` JSON config example).
- Conformance corpus adds `:eval-cljs/disabled-default` fixture pinning the default-off envelope; the pre-existing `:eval-cljs/happy` + `:eval-cljs/missing-form` fixtures set `:fixture/allow-eval? true` to exercise the post-gate logical paths.
- `test/stdio-roundtrip.js` and `test/live-nrepl.js` pass `--allow-eval` so their existing eval-cljs coverage remains intact.

### Wire-shape before/after (rf2-cxx5s)

Default-off boot (`re-frame-pair2-mcp` with no flags):
```
[server] [pair2-mcp] eval-cljs: disabled (default; pass --allow-eval to opt in)
```
Call envelope:
```edn
{:ok? false
 :reason :rf.error/eval-cljs-disabled
 :hint "eval-cljs is disabled by default for security; pass --allow-eval at server launch to opt in"}
```

Opt-in boot (`re-frame-pair2-mcp --allow-eval`):
```
[server] [pair2-mcp] eval-cljs: ENABLED (--allow-eval)
```
Call envelope (with a healthy runtime): `{:ok? true :value <v>}` — unchanged from prior behaviour.

## Parent decisions

- **rf2-8cntr** (closed, decision): "Option (b) count-what-you-encounter. The :elided-large slot reports markers encountered in the payload; tools do NOT invoke elide-wire-value themselves." → rf2-0znsb.
- **rf2-czv3p** (closed, decision): "eval-cljs is qualitatively different (arbitrary code execution) — gated with --read-only launch flag default OFF; published causa-mcp ships with eval-cljs DISABLED; user opts in explicitly at server launch." → cascade informed rf2-cxx5s.
- **rf2-zyoj2** (closed): causa-mcp's parallel split. Same posture lands here for pair2-mcp.

## Test plan

- [x] `cd tools/pair2-mcp && npm test` — 347 tests, 834 assertions, 0 failures
- [x] `cd tools/mcp-conformance && node test/end-to-end-pair2.js` — green, with the boot log confirming default-off + 12-tool catalogue intact
- [x] `cd implementation && npm run test:cljs` — 1936 tests, 5513 assertions, 0 failures
- [x] `cd implementation && npm run test:bundle-isolation` — PASS
- [x] `python scripts/check_doc_slugs.py` — no output (clean)
- [x] `mkdocs build --strict` — no new warnings vs main (main: 23, this branch: 20)