### PR TITLE
feat(causa): core.cljs facade per spec/API.md (rf2-13bx9)

### DIFF
--- a/tools/causa/README.md
+++ b/tools/causa/README.md
@@ -143,7 +143,7 @@ tools/causa/
 ├── spec/                                      ; normative contract (see above)
 ├── src/day8/re_frame2_causa/
 │   ├── preload.cljs                           ; registers listeners, mounts DOM
-│   ├── core.cljs                              ; init!, panel mount, settings
+│   ├── core.cljs                              ; user-facing facade (init!, open!, active-frame, ...)
 │   ├── panels/                                ; one ns per panel
 │   ├── causality/                             ; graph layout + rendering
 │   ├── ai/                                    ; co-pilot panel, provider abstraction

--- a/tools/causa/src/day8/re_frame2_causa/core.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/core.cljs
@@ -1,0 +1,240 @@
+(ns day8.re-frame2-causa.core
+  "The canonical user-facing facade for Causa.
+
+  Per `spec/API.md` §Public CLJS API + the README's `core.cljs` reference,
+  this namespace is the *one* import users reach for. It re-exports the
+  small handful of programmatic entry points enumerated by the spec —
+  `init!` / `open!` / `close!` / `toggle!` / `popout!` /
+  `active-frame` + `set-active-frame!` / `active-panel` +
+  `set-active-panel!` / `load-theme` — plus the boot-time config knob
+  surface exposed by `config.cljc` (`configure!` / `set-editor!` /
+  `set-show-sensitive!`).
+
+  ## Why a thin facade
+
+  Mirrors the `re-frame.core` pattern: one canonical require for
+  consumers, with the per-concern namespaces (`mount`, `config`,
+  `registry`, ...) remaining as the *internal* seams Causa's own code
+  reads. Hosts never need to know which file holds which fn.
+
+  ## Pre-alpha posture
+
+  Two surfaces in `spec/API.md` ship as TBD-impl stubs that emit a
+  `:rf.warning/*` trace and otherwise no-op:
+
+    - `popout!` — same-browser pop-out window (the `Ctrl+Shift+P`
+      shortcut and the window-management plumbing are scheduled
+      under a follow-on bead).
+    - `load-theme` — programmatic theme swap. The theme module
+      exists (`day8.re-frame2-causa.theme/*`) but the runtime CSS-
+      swap surface is not yet wired.
+
+  When called, each stub emits a structured trace event tagged with
+  `:origin :causa` so the gap is visible in the trace stream
+  (consistent with `spec/API.md` §Trace-event tags Causa emits).
+
+  ## What this namespace deliberately does NOT expose
+
+  Per `spec/API.md` §What this doesn't expose, the facade carries no
+  plugin-registration API, no middleware injection, no global state
+  mutators beyond the seven listed above. Internal seams
+  (`day8.re-frame2-causa.internal/*`, `day8.re-frame2-causa.shell`,
+  `day8.re-frame2-causa.registry`) are not re-exported — callers must
+  not reach for them."
+  (:require [re-frame.core :as rf]
+            [re-frame.trace :as trace]
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.keybinding :as keybinding]
+            [day8.re-frame2-causa.mount :as mount]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]))
+
+;; ---- mount entry points (re-exports from mount.cljs) --------------------
+;;
+;; `def`-aliases (not wrapper fns) so:
+;;   (a) `(= mount/open! core/open!)` holds — the facade contract is
+;;       identity, not just behavioural equivalence.
+;;   (b) Closure DCE inlines the call site against the same Var the
+;;       internal mount path uses — no second-stack-frame in
+;;       production.
+
+(def open!
+  "Mount + show the Causa shell. On first call, creates the root
+  `<div>`, renders the shell into it via the installed substrate
+  adapter, marks the shell visible. On subsequent calls (when already
+  mounted), flips the container to `display: block`.
+
+  Returns the mount-state map (for tests / introspection). No-op
+  (returns nil) when no substrate adapter is installed — production
+  builds, hosts that never called `rf/init!`, etc."
+  mount/open!)
+
+(def close!
+  "Hide the Causa shell — flip the container to `display: none`. The
+  DOM tree and substrate render tree stay in place so re-opening is a
+  CSS-only toggle (<80ms first paint per `spec/007-UX-IA.md`)."
+  mount/close!)
+
+(def toggle!
+  "Toggle the Causa shell's visibility. First call mounts + shows;
+  subsequent calls flip visibility."
+  mount/toggle!)
+
+;; ---- init! (manual install, alternative to :preloads) ------------------
+
+(defn init!
+  "Mount Causa manually — the alternative to wiring the
+  `day8.re-frame2-causa.preload` namespace into shadow-cljs's
+  `:devtools/preloads`. Idempotent: a second call is a no-op (each
+  underlying side-effect is `defonce`-guarded).
+
+  Per `spec/API.md` §Public CLJS API, `opts` accepts:
+
+      {:default-frame :app/main          ;; target-frame for the scrubber
+       :theme         :dark              ;; / :light / :high-contrast
+       :density       :compact           ;; / :cosy / :comfy
+       :ai-provider   {:provider :claude ;; ...}
+       :buffer-depths {:trace 200 :epoch 50}}
+
+  The current pre-alpha posture wires the four foundation side-effects
+  (registry, trace-cb, epoch-cb, keybinding listener) and threads
+  `:default-frame` through to the `:rf.causa/set-target-frame` event.
+  The remaining keys (`:theme`, `:density`, `:ai-provider`,
+  `:buffer-depths`) are accepted today but ignored at runtime — the
+  per-area machinery lands under follow-on beads. Passing them now
+  keeps host code forward-compatible.
+
+  Returns nothing."
+  ([]
+   (init! nil))
+  ([{:keys [default-frame] :as _opts}]
+   (registry/register-causa-handlers!)
+   (preload/register-trace-collector!)
+   (preload/register-epoch-collector!)
+   (keybinding/attach!)
+   (when default-frame
+     (rf/with-frame :rf/causa
+       (rf/dispatch [:rf.causa/set-target-frame default-frame])))
+   nil))
+
+;; ---- frame picker -------------------------------------------------------
+
+(defn active-frame
+  "Return the frame currently selected in the Causa frame picker — the
+  host frame the scrubber / app-db / machine-inspector panels are
+  observing. Defaults to `:rf/default` (per
+  `day8.re-frame2-causa.defaults/default-target-frame`) until
+  `set-active-frame!` flips it.
+
+  One-shot read; does NOT register the caller for reactive re-render.
+  Reactive consumers subscribe to `:rf.causa/target-frame` directly."
+  []
+  (rf/with-frame :rf/causa
+    (rf/subscribe-value [:rf.causa/target-frame])))
+
+(defn set-active-frame!
+  "Set the active target frame for the Causa picker. Dispatches
+  `:rf.causa/set-target-frame` into the `:rf/causa` frame so the
+  `:rf.causa/target-frame` sub and every dependent panel re-fire on
+  the standard reactive path. `nil` resets to the default
+  (`:rf/default`).
+
+  Returns nothing."
+  [frame-id]
+  (rf/with-frame :rf/causa
+    (rf/dispatch [:rf.causa/set-target-frame frame-id]))
+  nil)
+
+;; ---- panel picker -------------------------------------------------------
+
+(defn active-panel
+  "Return the panel id currently selected in Causa's sidebar — one of
+  `:event-detail` / `:causality-graph` / `:time-travel` / `:app-db-diff`
+  / etc. Defaults to `:event-detail` (the hero panel per
+  `spec/007-UX-IA.md` §The default landing view + §10 Lock 7).
+
+  One-shot read; does NOT register the caller for reactive re-render.
+  Reactive consumers subscribe to `:rf.causa/selected-panel` directly."
+  []
+  (rf/with-frame :rf/causa
+    (rf/subscribe-value [:rf.causa/selected-panel])))
+
+(defn set-active-panel!
+  "Select a panel programmatically. Dispatches `:rf.causa/select-panel`
+  into the `:rf/causa` frame; the `:rf.causa/selected-panel` sub
+  re-fires and the shell's canvas switches.
+
+  Returns nothing."
+  [panel-id]
+  (rf/with-frame :rf/causa
+    (rf/dispatch [:rf.causa/select-panel panel-id]))
+  nil)
+
+;; ---- TBD-impl stubs -----------------------------------------------------
+;;
+;; `popout!` and `load-theme` are promised by `spec/API.md` §Public CLJS
+;; API but the runtime plumbing has not landed. Calling either emits a
+;; `:rf.warning/*` trace event so the gap is visible in the trace stream
+;; (and surfaces in Causa's own Issues ribbon). Each stub returns nil
+;; rather than throwing so host code that wires the call ahead of the
+;; impl does not crash.
+
+(defn popout!
+  "Open Causa's same-browser pop-out window. **TBD-impl.** The
+  `Ctrl+Shift+P` shortcut and the window-management plumbing land
+  under a follow-on bead; this stub emits
+  `:rf.warning/causa-popout-not-yet-implemented` and returns nil.
+
+  Hosts wiring the call today are forward-compatible; the trace event
+  documents the gap in the trace stream."
+  []
+  (trace/emit! :rf.warning
+               :rf.warning/causa-popout-not-yet-implemented
+               {:origin :causa
+                :where  'day8.re-frame2-causa.core/popout!})
+  nil)
+
+(defn load-theme
+  "Programmatically swap the Causa shell's CSS theme. **TBD-impl.**
+  The theme module exists (`day8.re-frame2-causa.theme/*`) but the
+  runtime CSS-swap surface is not yet wired. This stub emits
+  `:rf.warning/causa-load-theme-not-yet-implemented` and returns nil.
+
+  Forward-compatible — host code may call with a CSS string today and
+  expect the impl to land under a follow-on bead."
+  [_css-string]
+  (trace/emit! :rf.warning
+               :rf.warning/causa-load-theme-not-yet-implemented
+               {:origin :causa
+                :where  'day8.re-frame2-causa.core/load-theme})
+  nil)
+
+;; ---- config knob re-exports --------------------------------------------
+;;
+;; `configure!` is the canonical entry point (it accepts the union of
+;; supported keys today and tomorrow); the per-knob setters are exposed
+;; for hosts that prefer the granular surface or for tests / REPL
+;; sessions that want to flip one knob without writing the full map.
+
+(def configure!
+  "Top-level Causa configuration. Accepts:
+
+    `{:editor <kw>}`                 — 'Open in editor' preference.
+    `{:trace/show-sensitive? <bool>}` — `:sensitive?` trace-event gate.
+
+  Future phases extend with theme / buffer / placement keys. Hosts
+  typically call once at boot. Returns nothing."
+  config/configure!)
+
+(def set-editor!
+  "Set the 'Open in editor' preference. Accepts `:vscode` /
+  `:cursor` / `:windsurf` / `:zed` / `:idea` /
+  `{:custom <uri-template>}`. `nil` resets to `:vscode`."
+  config/set-editor!)
+
+(def set-show-sensitive!
+  "Replace the `:trace/show-sensitive?` flag. When `false` (default),
+  Causa's trace collector drops `:sensitive? true` events; when `true`,
+  every event reaches the buffer. `nil` resets to the default
+  (`false`)."
+  config/set-show-sensitive!)

--- a/tools/causa/src/day8/re_frame2_causa/panels/time_travel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/time_travel.cljs
@@ -361,6 +361,16 @@
     (fn [db _query]
       (get db :target-frame defaults/default-target-frame)))
 
+  ;; Set the active target frame. The `core.cljs` facade's
+  ;; `set-active-frame!` dispatches this; once a UI frame picker
+  ;; lands it will dispatch the same event. `nil` resets to the
+  ;; default target frame (`:rf/default`).
+  (rf/reg-event-db :rf.causa/set-target-frame
+    (fn [db [_ frame-id]]
+      (if (nil? frame-id)
+        (dissoc db :target-frame)
+        (assoc db :target-frame frame-id))))
+
   ;; Cached snapshot of the target frame's epoch history, pumped
   ;; by `:rf.causa/epoch-recorded` (dispatched from the epoch-cb in
   ;; preload). The cache is necessary because rf/epoch-history is a

--- a/tools/causa/test/day8/re_frame2_causa/core_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/core_cljs_test.cljs
@@ -1,0 +1,209 @@
+(ns day8.re-frame2-causa.core-cljs-test
+  "Tests for `day8.re-frame2-causa.core` — the canonical user-facing
+  facade promised by `spec/API.md` (rf2-13bx9).
+
+  ## Three contract surfaces under test
+
+  1. **Re-export identity.** The mount + config re-exports MUST be
+     `def`-aliases (not wrapper fns) so `(= mount/open! core/open!)`
+     holds. Identity is the contract: a host that wires
+     `core/toggle!` into its keybinding catalogue must land on the
+     same Var the preload's listener calls.
+
+  2. **Frame / panel wiring.** `set-active-frame!` and
+     `set-active-panel!` dispatch into the `:rf/causa` frame; the
+     dispatch updates `:rf.causa/target-frame` /
+     `:rf.causa/selected-panel` slots in Causa's app-db, so the
+     companion subs re-fire and `active-frame` / `active-panel`
+     read back the new value.
+
+  3. **TBD stubs do not crash.** `popout!` and `load-theme` emit a
+     `:rf.warning/*` trace event and return nil — host code that
+     wires the call ahead of the impl must not throw."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.core :as core]
+            [day8.re-frame2-causa.mount :as mount]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- setup-causa-frame!
+  "Per-test boot: register handlers, allocate the :rf/causa frame."
+  []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; ---- (1) re-export identity --------------------------------------------
+
+(deftest mount-fns-are-aliases
+  (testing "mount entry points are def-aliases, not wrapper fns"
+    ;; Identity check — the facade Var resolves to the same fn-value
+    ;; as the underlying mount Var.
+    (is (identical? mount/open!   core/open!))
+    (is (identical? mount/close!  core/close!))
+    (is (identical? mount/toggle! core/toggle!))))
+
+(deftest config-fns-are-aliases
+  (testing "config knob setters are def-aliases"
+    (is (identical? config/configure!          core/configure!))
+    (is (identical? config/set-editor!         core/set-editor!))
+    (is (identical? config/set-show-sensitive! core/set-show-sensitive!))))
+
+;; ---- (2) frame wiring --------------------------------------------------
+;;
+;; The facade's `set-active-frame!` calls `rf/dispatch` (async — the
+;; user-facing contract; the runtime dispatch queues into the
+;; `:rf/causa` frame's router so it lands inside the next drain). The
+;; tests assert the same wiring contract via `dispatch-sync` so the
+;; drain runs to completion inside the assertion — mirrors the pattern
+;; the registry / shell tests use for `:rf.causa/select-panel` etc.
+
+(deftest active-frame-default-is-rf-default
+  (testing "active-frame defaults to :rf/default (per defaults/default-target-frame)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (is (= :rf/default (core/active-frame))))))
+
+(deftest set-target-frame-wires-active-frame
+  (testing ":rf.causa/set-target-frame updates the slot active-frame reads"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-target-frame :app/main])
+      (is (= :app/main (core/active-frame))
+          "after dispatch the facade's read returns the new value")
+      (rf/dispatch-sync [:rf.causa/set-target-frame :worker/db])
+      (is (= :worker/db (core/active-frame))
+          "subsequent flips also land")
+      (rf/dispatch-sync [:rf.causa/set-target-frame nil])
+      (is (= :rf/default (core/active-frame))
+          "nil resets to the default target frame"))))
+
+(deftest set-active-frame!-dispatches-set-target-frame
+  (testing "set-active-frame! dispatches :rf.causa/set-target-frame into :rf/causa"
+    ;; The `rf/dispatch` macro expands to `re-frame.core/dispatch*`, so
+    ;; with-redefs the underlying fn — redef'ing the macro Var would have
+    ;; no effect on already-compiled call sites.
+    (let [seen (atom [])]
+      (with-redefs [rf/dispatch* (fn [ev & _opts] (swap! seen conj ev))]
+        (core/set-active-frame! :app/main))
+      (is (= [[:rf.causa/set-target-frame :app/main]] @seen)
+          "facade dispatches the right event with the right arg"))))
+
+;; ---- (2) panel wiring --------------------------------------------------
+
+(deftest active-panel-default-is-event-detail
+  (testing "active-panel defaults to :event-detail (per defaults/default-panel-id)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (is (= :event-detail (core/active-panel))))))
+
+(deftest select-panel-wires-active-panel
+  (testing ":rf.causa/select-panel updates the slot active-panel reads"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-panel :causality-graph])
+      (is (= :causality-graph (core/active-panel)))
+      (rf/dispatch-sync [:rf.causa/select-panel :time-travel])
+      (is (= :time-travel (core/active-panel))))))
+
+(deftest set-active-panel!-dispatches-select-panel
+  (testing "set-active-panel! dispatches :rf.causa/select-panel into :rf/causa"
+    (let [seen (atom [])]
+      (with-redefs [rf/dispatch* (fn [ev & _opts] (swap! seen conj ev))]
+        (core/set-active-panel! :causality-graph))
+      (is (= [[:rf.causa/select-panel :causality-graph]] @seen)
+          "facade dispatches the right event with the right arg"))))
+
+;; ---- (3) TBD stubs — emit warning trace, return nil --------------------
+
+(deftest popout!-emits-warning-trace
+  (testing "popout! emits :rf.warning/causa-popout-not-yet-implemented and returns nil"
+    (preload/register-trace-collector!)
+    (let [result (core/popout!)
+          events (trace-bus/buffer)
+          popout-event (first (filter #(= :rf.warning/causa-popout-not-yet-implemented
+                                          (:operation %))
+                                      events))]
+      (is (nil? result) "stub returns nil")
+      (is (some? popout-event)
+          "trace bus carries the warning emit")
+      (is (= :causa (get-in popout-event [:tags :origin]))
+          "warning is tagged :origin :causa"))))
+
+(deftest load-theme-emits-warning-trace
+  (testing "load-theme emits :rf.warning/causa-load-theme-not-yet-implemented and returns nil"
+    (preload/register-trace-collector!)
+    (let [result (core/load-theme ".foo { color: red; }")
+          events (trace-bus/buffer)
+          theme-event (first (filter #(= :rf.warning/causa-load-theme-not-yet-implemented
+                                         (:operation %))
+                                     events))]
+      (is (nil? result) "stub returns nil")
+      (is (some? theme-event)
+          "trace bus carries the warning emit")
+      (is (= :causa (get-in theme-event [:tags :origin]))
+          "warning is tagged :origin :causa"))))
+
+;; ---- init! contract ----------------------------------------------------
+
+(deftest init!-no-opts-is-idempotent
+  (testing "init! wires the four foundation side-effects; second call is no-op"
+    ;; First call wires registry + trace-cb + epoch-cb + keybinding.
+    ;; The keybinding listener requires js/window which the node-test
+    ;; host does not expose; the attach call no-ops on that host (the
+    ;; (when (exists? js/window) ...) guard inside keybinding/attach!).
+    ;; The contract here is that init! runs to completion without
+    ;; throwing and the registry's idempotency sentinel reports
+    ;; installed.
+    (core/init!)
+    (is (some? (registrar/handler :sub :rf.causa/selected-panel))
+        "registry/register-causa-handlers! ran")
+    ;; Second call: each sub-side-effect is defonce-guarded so the
+    ;; combined effect is a no-op. We just assert no throw.
+    (core/init!)
+    (is true "second init! did not throw")))
+
+(deftest init!-with-default-frame-dispatches-set-target-frame
+  (testing "init! threads :default-frame through to :rf.causa/set-target-frame"
+    ;; The dispatch is async (queues into :rf/causa's router); we capture
+    ;; the call to verify the facade routes through the registered event.
+    ;; The dispatch-sync-driven landing is covered by
+    ;; `set-target-frame-wires-active-frame` above.
+    (setup-causa-frame!)
+    (let [seen (atom [])]
+      (with-redefs [rf/dispatch* (fn [ev & _opts] (swap! seen conj ev))]
+        (core/init! {:default-frame :app/main}))
+      (is (some #(= [:rf.causa/set-target-frame :app/main] %) @seen)
+          "init! dispatched :rf.causa/set-target-frame with :default-frame"))))
+
+(deftest init!-accepts-future-opts-without-throwing
+  (testing "init! tolerates spec/API.md keys not yet wired (forward-compat)"
+    ;; Per the docstring: :theme / :density / :ai-provider /
+    ;; :buffer-depths are accepted today and ignored at runtime. The
+    ;; contract is that passing them does not throw — host code wired
+    ;; against the spec stays runnable as the impl fills in.
+    (setup-causa-frame!)
+    (core/init! {:default-frame :app/main
+                 :theme         :dark
+                 :density       :compact
+                 :ai-provider   {:provider :claude}
+                 :buffer-depths {:trace 200 :epoch 50}})
+    (is true "init! did not throw on the full spec/API.md opts map")))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -203,6 +203,7 @@
    :rf.causa/set-schema-filter
    :rf.causa/set-schema-timeline-window
    :rf.causa/set-sub-cache-override-for-test
+   :rf.causa/set-target-frame
    :rf.causa/set-trace-filter
    :rf.causa/show-invalidation-chain
    :rf.causa/toggle-issues-prefix
@@ -242,9 +243,12 @@
           (str "expected :fx handler for " fx-id)))))
 
 (deftest registry-counts-match-bead
-  (testing "registry holds exactly 65 subs + 60 events + 3 fxs"
+  (testing "registry holds exactly 65 subs + 61 events + 3 fxs"
     (is (= 65 (count all-sub-names)))
-    (is (= 60 (count all-event-names)))
+    ;; 61 events after rf2-13bx9 added :rf.causa/set-target-frame (the
+    ;; companion to time-travel's :rf.causa/target-frame sub; consumed
+    ;; by the `core.cljs` facade's `set-active-frame!`).
+    (is (= 61 (count all-event-names)))
     (is (= 3  (count all-fx-names)))))
 
 (deftest registry-is-idempotent


### PR DESCRIPTION
## Summary

Creates `tools/causa/src/day8/re_frame2_causa/core.cljs` — the canonical user-facing facade promised by `tools/causa/spec/API.md` §Public CLJS API and the README's `core.cljs` reference. Mirrors the `re-frame.core` pattern: one require, all the entry points host code reaches for. Decision-resolved follow-on of rf2-it8lz (Option (a) facade, picked Mike 2026-05-14).

- **Re-exports as `def`-aliases** (identity contract, not just behavioural equivalence): `open!` / `close!` / `toggle!` from `mount.cljs`; `configure!` / `set-editor!` / `set-show-sensitive!` from `config.cljc`.
- **New entry points**: `init!` / `init! opts` (manual install, alternative to `:preloads`); `active-frame` / `set-active-frame!` (reads `:rf.causa/target-frame`, dispatches new `:rf.causa/set-target-frame` event); `active-panel` / `set-active-panel!` (reads `:rf.causa/selected-panel`, dispatches existing `:rf.causa/select-panel`).
- **TBD-impl stubs** for `popout!` and `load-theme` (both promised by spec/API.md without runtime plumbing): emit a `:rf.warning/*` trace tagged `:origin :causa` and return nil so host code wired ahead of the impl does not crash.

`init!`'s `opts` accepts the full `spec/API.md` map (`:theme` / `:density` / `:ai-provider` / `:buffer-depths`) — only `:default-frame` is wired today, the rest are accepted and ignored so host code stays forward-compatible. README's L146 file-layout reference now reads "user-facing facade (init!, open!, active-frame, ...)" to match the implementation.

## Tests

12 new deftests in `core_cljs_test.cljs` covering: re-export identity (`(identical? mount/open! core/open!)` etc.); frame / panel wiring (defaults read back from the sub, `dispatch-sync` lands, `with-redefs` of `rf/dispatch*` — the macro-expansion target — verifies the facade dispatches the right event with the right arg); TBD stubs return nil + the warning trace lands on Causa's bus; `init!` idempotency + `:default-frame` threading + forward-compat opts tolerance. Registry-test count bumped 60 → 61 events for the new `:rf.causa/set-target-frame`.

## Test plan

- [x] `cd implementation && npm run test:cljs` — 1949 tests, 5539 assertions, 0 failures / 0 errors
- [x] `cd tools/causa && clojure -M:test` — 518 tests, 1482 assertions, 0 failures / 0 errors
- [x] `cd implementation && npm run test:bundle-isolation` — PASS
- [x] `cd implementation && npm run test:elision` — PASS
- [x] `cd implementation && npm run test:perf-bundle` — PASS
- [ ] Manual REPL smoke: `(require '[day8.re-frame2-causa.core :as causa])` then `(causa/init! {...})` (covered by `init!-with-default-frame-dispatches-set-target-frame` + `init!-accepts-future-opts-without-throwing`)

Closes rf2-13bx9.