### PR TITLE
fix(story): scope a11y scan to variant root, not Story chrome (rf2-qgms1)

### DIFF
--- a/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
+++ b/examples/reagent/counter_with_stories/counter_with_stories.spec.cjs
@@ -1124,30 +1124,62 @@ module.exports = {
     //
     // The a11y panel exposes a "run" button. Clicking it kicks off the
     // axe-core lazy-load + scan. The panel's status line transitions
-    // from "click run to scan the rendered output" to "fetching
-    // axe-core…" → "scanning…" → "N violation(s) found". We don't
-    // assert which violations land (varies by environment); we assert
-    // that the run was kicked off — the status text changes away from
-    // the idle copy.
+    // from the idle copy ("click run to scan the variant …") through
+    // "fetching axe-core…" / "scanning…" / "N violation(s) found in
+    // variant". We don't assert which violations land (varies by
+    // environment); we assert that the run was kicked off — the status
+    // text changes away from the idle copy.
+    //
+    // Per rf2-qgms1: axe-core MUST scan only the variant's tree, NOT
+    // Story's surrounding chrome (sidebar, toolbar, panels, title bar).
+    // The fix stamps `data-rf-story-variant-root` on the wrapper around
+    // the user-authored decorated view; `run-axe!` finds that node via
+    // querySelector and passes it as axe-core's `context` arg. We
+    // assert that (a) the variant root exists in the DOM, and (b) any
+    // violation overlays land INSIDE the variant root — never on Story
+    // chrome nodes.
     //
     // The panel is registered under :rf.story.panel/a11y with title
     // "a11y" rendered in the panel-head. Its run button has accessible
     // name "run" (transitions to "re-run" / "retry" after a scan).
+
+    // 12a. Variant-root marker is present before any scan kicks off —
+    // canvas.cljs / workspace.cljc stamp it whenever a variant is
+    // mounted. Without this marker the a11y panel would default to
+    // scanning the whole document body (the original rf2-qgms1 bug).
+    const variantRoots = page.locator(
+      '[data-rf-story-variant-root=":story.counter/loaded"]',
+    );
+    {
+      const start = Date.now();
+      let n = 0;
+      while (Date.now() - start < 5000) {
+        n = await variantRoots.count();
+        if (n >= 1) break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (n < 1) {
+        throw new Error(
+          'rf2-qgms1: expected [data-rf-story-variant-root=":story.counter/loaded"] to be stamped on the mounted variant wrapper',
+        );
+      }
+    }
+
     const runBtn = aside.getByRole('button', { name: /^(run|re-run|retry)$/i }).first();
     await runBtn.waitFor({ state: 'visible', timeout: 5000 });
     await runBtn.click();
 
-    // The status copy starts as "click run to scan the rendered output"
-    // and transitions through "fetching axe-core…" / "scanning…" /
-    // "N violation(s) found". We poll for the transition off the idle
-    // copy — if the status remains "click run …" the click was
-    // ineffective.
+    // The status copy starts as the idle string ("click run to scan
+    // the variant …") and transitions through "fetching axe-core…"
+    // / "scanning…" / "N violation(s) found in variant". We poll for
+    // the transition off the idle copy — if the status remains the
+    // idle copy the click was ineffective.
     {
       const start = Date.now();
       let stillIdle = true;
       while (Date.now() - start < 15000) {
         stillIdle = await aside
-          .getByText(/click run to scan the rendered output/i)
+          .getByText(/click run to scan the variant/i)
           .first()
           .isVisible()
           .catch(() => false);
@@ -1157,6 +1189,41 @@ module.exports = {
       if (stillIdle) {
         throw new Error('a11y panel run did not transition off idle status');
       }
+    }
+
+    // 12b. rf2-qgms1: any `[data-rf-a11y-violation]` overlay decoration
+    // MUST land INSIDE the variant root, never on a Story-chrome node
+    // (sidebar, toolbar, panel, shell button). The overlay is the
+    // user-visible projection of axe-core's violations — if axe-core
+    // had been called with `document.body` as context (the old bug),
+    // chrome nodes like the sidebar's tag-filter chips or the
+    // toolbar's mode chips would frequently pick up the overlay
+    // attribute. Asserting "every overlay is inside a variant root"
+    // is equivalent to asserting "the scan was correctly scoped".
+    //
+    // Wait briefly for any decoration to land (axe-core's scan is
+    // async; on offline CI it may resolve to :error with zero
+    // violations, in which case the loop's zero-decorations is still
+    // a passing assertion — no false-positive overlays = correct
+    // scoping by trivial vacuity).
+    await new Promise((r) => setTimeout(r, 250));
+    const leakedDecorations = await page.evaluate(() => {
+      const all = Array.from(document.querySelectorAll('[data-rf-a11y-violation]'));
+      // An overlay node "leaks" iff none of its ancestors carry the
+      // `data-rf-story-variant-root` attribute.
+      const leaked = all.filter((el) => !el.closest('[data-rf-story-variant-root]'));
+      return leaked.map((el) => ({
+        tag: el.tagName,
+        cls: el.className && el.className.toString ? el.className.toString() : '',
+        text: (el.textContent || '').slice(0, 80),
+      }));
+    });
+    if (leakedDecorations.length > 0) {
+      throw new Error(
+        `rf2-qgms1: ${leakedDecorations.length} a11y overlay(s) leaked onto Story chrome — ` +
+          `axe-core scan should be scoped to [data-rf-story-variant-root], not document.body. ` +
+          `Leaked nodes: ${JSON.stringify(leakedDecorations).slice(0, 400)}`,
+      );
     }
 
     // ====================================================================

--- a/tools/story/src/re_frame/story/ui/a11y.cljs
+++ b/tools/story/src/re_frame/story/ui/a11y.cljs
@@ -33,7 +33,8 @@
   Violations are stored in a local atom `frame-id → [violation ...]`
   keyed by the variant frame id. The right-panel component reads this
   atom reactively."
-  (:require [reagent.core :as r]
+  (:require [clojure.string :as string]
+            [reagent.core :as r]
             [re-frame.core :as rf]
             [re-frame.trace :as trace]
             [re-frame.story.config :as config]
@@ -140,54 +141,129 @@
      :id     (.-id violation)
      :help   (.-help violation)}))
 
+(defn variant-root-selector
+  "CSS selector for the variant root element of `frame-id`. Per
+  rf2-qgms1: canvas.cljs / workspace.cljc stamp
+  `data-rf-story-variant-root` (with the variant id pr-str'd) on the
+  immediate wrapper around the user-authored decorated view, so a11y
+  can scope axe-core's scan to ONLY the variant's tree — excluding
+  Story chrome (sidebar, toolbar, panels, title bar).
+
+  Returns a string CSS selector (`[data-rf-story-variant-root='…']`)
+  with the pr-str'd id properly escaped so namespaced keywords (e.g.
+  `:story.counter/incrementing`) survive the quoting boundary."
+  [frame-id]
+  (let [printed (pr-str frame-id)
+        ;; CSS attribute-selector values quoted in single-quotes: escape
+        ;; backslashes and embedded single-quotes. pr-str of a keyword
+        ;; produces ASCII without quotes, so in practice this is a
+        ;; no-op for normal frame-ids — but defensive against odd ids.
+        escaped (-> printed
+                    (string/replace #"\\" "\\\\\\\\")
+                    (string/replace #"'"  "\\\\'"))]
+    (str "[data-rf-story-variant-root='" escaped "']")))
+
+(defn find-variant-root
+  "Resolve the DOM element marked as `frame-id`'s variant root, or nil
+  if not mounted (e.g. the user is viewing the variant in :docs or
+  :test mode, or has selected a workspace). Per rf2-qgms1 the canvas /
+  workspace stamp `data-rf-story-variant-root` on the wrapper around
+  the user-authored tree.
+
+  Wrapped in a try/catch so the helper is safe to call in node-runtime
+  test contexts where `js/document` is undefined (raw access throws
+  ReferenceError); a node-runtime call returns nil and `run-axe!`'s
+  caller surfaces a :no-root state."
+  [frame-id]
+  (try
+    (let [doc (.-document js/globalThis)]
+      (when doc
+        (.querySelector doc (variant-root-selector frame-id))))
+    (catch :default _ nil)))
+
 (defn- record-violation-overlay!
   "Decorate the violation's DOM nodes so the inline stylesheet
   highlights them. Each axe-core node has `:target` (a CSS selector
   list); we attach `data-rf-a11y-violation` to each matching element.
 
+  Per rf2-qgms1 the query is rooted at `scope-el` (the variant root)
+  so we never decorate Story-chrome nodes — even if axe-core somehow
+  returned a selector matching outside the scope, the overlay stays
+  inside the variant.
+
   Best-effort: if the selectors don't match (e.g. the DOM mutated
   since the run) the overlay simply doesn't appear."
-  [violation]
-  (let [nodes (.-nodes violation)]
+  [scope-el violation]
+  (let [nodes (.-nodes violation)
+        root  (or scope-el js/document)]
     (doseq [node (array-seq nodes)]
       (doseq [target (array-seq (.-target node))]
         (try
-          (let [el (.querySelector js/document target)]
+          (let [el (.querySelector root target)]
             (when el
               (.setAttribute el "data-rf-a11y-violation"
                              (or (.-impact violation) "moderate"))))
           (catch :default _ nil))))))
 
 (defn run-axe!
-  "Run axe-core against `:rf-story-canvas` or the whole document and
-  store violations under `frame-id`. Returns a `js/Promise` that
-  resolves to the violations vector.
+  "Run axe-core against the variant root for `frame-id` and store
+  violations under `frame-id`. Returns a `js/Promise` that resolves to
+  the violations vector — or nil when the variant root cannot be
+  resolved (e.g. the user is in :docs/:test mode, or the variant is
+  not currently mounted).
+
+  Per rf2-qgms1 the default scope is the variant's
+  `data-rf-story-variant-root` element, NOT `document.body`. Scanning
+  the whole body flagged Story's OWN chrome (sidebar buttons, toolbar
+  tabs, side-rail items) as violations — which is wrong: Story chrome
+  a11y is Story's concern, not the variant author's.
+
+  An explicit `context` second-arg overrides the lookup (used by
+  tests). Pass an Element, a CSS-selector string, or an axe-core
+  context object.
 
   Per IMPL-SPEC §11.1 surfaces violations into `:rf.assert/no-warnings`
   via the trace-warning hook."
   ([frame-id]
-   (run-axe! frame-id (.-body js/document)))
+   (run-axe! frame-id (find-variant-root frame-id)))
   ([frame-id context]
-   (swap! run-state assoc frame-id :loading)
-   (-> (ensure-axe-loaded!)
-       (.then
-         (fn [axe]
-           (swap! run-state assoc frame-id :running)
-           (.run axe context)))
-       (.then
-         (fn [results]
-           (let [vs (.-violations results)]
-             (swap! violations-by-frame assoc frame-id (vec (array-seq vs)))
-             (doseq [v (array-seq vs)]
-               (record-violation-overlay! v)
-               (emit-warning-for-violation frame-id v))
-             (swap! run-state assoc frame-id :done)
-             vs)))
-       (.catch
-         (fn [e]
-           (swap! run-state assoc frame-id :error)
-           (js/console.error "[story.a11y]" e)
-           nil)))))
+   (cond
+     ;; No variant root and no explicit context → surface the
+     ;; degraded state instead of silently scanning the wrong tree.
+     (nil? context)
+     (do
+       (swap! run-state assoc frame-id :no-root)
+       (js/console.warn
+         "[story.a11y] no variant root found for"
+         (pr-str frame-id)
+         "— switch to :dev mode to mount the variant, or pass an explicit context.")
+       (js/Promise.resolve nil))
+
+     :else
+     (do
+       (swap! run-state assoc frame-id :loading)
+       (-> (ensure-axe-loaded!)
+           (.then
+             (fn [axe]
+               (swap! run-state assoc frame-id :running)
+               (.run axe context)))
+           (.then
+             (fn [results]
+               (let [vs        (.-violations results)
+                     scope-el  (when (and (some? context)
+                                          (some? (.-nodeType context)))
+                                 context)]
+                 (swap! violations-by-frame assoc frame-id (vec (array-seq vs)))
+                 (doseq [v (array-seq vs)]
+                   (record-violation-overlay! scope-el v)
+                   (emit-warning-for-violation frame-id v))
+                 (swap! run-state assoc frame-id :done)
+                 vs)))
+           (.catch
+             (fn [e]
+               (swap! run-state assoc frame-id :error)
+               (js/console.error "[story.a11y]" e)
+               nil)))))))
 
 ;; ---- styling ------------------------------------------------------------
 
@@ -314,15 +390,17 @@
          :loading  "loading…"
          :running  "running…"
          :error    "retry"
+         :no-root  "retry"
          :idle     "run"
          "re-run")]]
      [:div {:style (:status styles)}
       (case state
-        :idle    "click run to scan the rendered output"
+        :idle    "click run to scan the variant (Story chrome is excluded)"
         :loading "fetching axe-core…"
         :running "scanning…"
         :error   "axe-core failed to load (offline or CSP)"
-        :done    (str (count vs) " violation(s) found"))]
+        :no-root "no variant mounted — switch to :dev mode and re-run"
+        :done    (str (count vs) " violation(s) found in variant"))]
      (cond
        (= state :idle)
        nil

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -270,8 +270,19 @@
            ;; standard `rf/frame-provider` uses Reagent's `:>` interop
            ;; which calls `(name kw)` on prop values and drops the
            ;; namespace before React sees it.
+           ;;
+           ;; Per rf2-qgms1: stamp `data-rf-story-variant-root` on the
+           ;; immediate wrapper around the user-authored decorated view
+           ;; so the a11y panel (ui/a11y.cljs) can scope axe-core's
+           ;; scan to ONLY the variant's rendered tree — excluding the
+           ;; surrounding Story chrome (title bar, share button, open-
+           ;; in-editor chip, panels, sidebar, toolbar). Without this
+           ;; marker axe-core's `run()` against `document.body` flags
+           ;; Story's own UI as the source of violations, which is
+           ;; wrong: Story chrome a11y is Story's concern, not the
+           ;; variant author's.
            [frame-provider-ns-safe {:frame variant-id}
-            [:div
+            [:div {:data-rf-story-variant-root (pr-str variant-id)}
              (safe-decorated-view
                [resolved-view eff-args]
                (:hiccup decorator-pack)

--- a/tools/story/src/re_frame/story/ui/workspace.cljc
+++ b/tools/story/src/re_frame/story/ui/workspace.cljc
@@ -236,8 +236,12 @@
               ;; on prop values and drops the namespace before React
               ;; sees it; `canvas/frame-provider-ns-safe` bypasses that
               ;; via a direct `React.createElement` call.
+              ;; Per rf2-qgms1: stamp `data-rf-story-variant-root` on
+              ;; the immediate wrapper around the decorated view (same
+              ;; reason as canvas.cljs) so the a11y panel can scope
+              ;; axe-core to ONLY the variant's rendered tree.
               [canvas/frame-provider-ns-safe {:frame variant-id}
-               [:div
+               [:div {:data-rf-story-variant-root (pr-str variant-id)}
                 (canvas/safe-decorated-view
                   [resolved-view eff-args]
                   (:hiccup decorator-pack)

--- a/tools/story/test/re_frame/story_a11y_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_a11y_cljs_test.cljs
@@ -60,3 +60,41 @@
   (testing "the violations stylesheet is a non-empty CSS string"
     (is (string? a11y/violations-stylesheet))
     (is (pos? (count a11y/violations-stylesheet)))))
+
+;; ---- rf2-qgms1: variant-root scoping ------------------------------------
+
+(deftest variant-root-selector-targets-data-attribute
+  (testing "variant-root-selector returns a CSS attribute selector keyed on the variant id"
+    (let [sel (a11y/variant-root-selector :story.counter/loaded)]
+      (is (string? sel))
+      ;; Must use the data attribute the canvas / workspace stamp.
+      (is (re-find #"data-rf-story-variant-root=" sel))
+      ;; pr-str of a namespaced keyword includes the leading colon.
+      (is (re-find #":story.counter/loaded" sel))
+      ;; Closing-bracket selector form so `querySelector` accepts it.
+      (is (.startsWith sel "[data-rf-story-variant-root="))
+      (is (.endsWith   sel "]")))))
+
+(deftest variant-root-selector-distinct-per-variant
+  (testing "different variant-ids yield distinct selectors"
+    (is (not= (a11y/variant-root-selector :story.counter/loaded)
+              (a11y/variant-root-selector :story.counter/clicked-three-times)))))
+
+(deftest run-axe-handles-no-variant-root
+  (testing "run-axe! sets :no-root state when no variant root resolves
+            — the default arity uses find-variant-root which returns nil
+            outside a browser DOM (node-runtime test env), so calling
+            run-axe! with just the frame-id must short-circuit cleanly
+            and surface a :no-root status to the panel."
+    (let [frame-id :story.never-mounted/x
+          ;; Mute the warn so test output stays clean.
+          orig-warn js/console.warn]
+      (set! js/console.warn (fn [& _] nil))
+      (try
+        (let [p (a11y/run-axe! frame-id)]
+          (is (some? p) "run-axe! returns a Promise even on the no-root path")
+          (is (= :no-root (get @a11y/run-state frame-id))
+              "run-state for an unmounted variant must be :no-root, NOT :running or :done — surfacing that the scan was not run against the wrong tree"))
+        (finally
+          (set! js/console.warn orig-warn)
+          (a11y/drop-frame-state! frame-id))))))


### PR DESCRIPTION
## Summary

- Story's a11y panel was passing `document.body` to axe-core's `run()`, so the scanner flagged Story's OWN chrome (sidebar buttons, toolbar mode chips, panel headers, mode-tab chips) as violations alongside the user-authored variant. Per Mike's observation on 2026-05-14.
- Root cause: `(run-axe! frame-id (.-body js/document))` — variant content is one node deep inside the shell layout, so the scanner walked the entire Story DOM.
- Fix: `canvas.cljs` / `workspace.cljc` now stamp `data-rf-story-variant-root` (with the pr-str'd variant-id as the value) on the immediate wrapper around the user-authored decorated view. `a11y.cljs` resolves that node via `querySelector` and passes it as axe-core's `context`, so the scan is scoped to the variant only. When no variant is mounted (e.g. :docs / :test mode, or workspace selected), the panel surfaces a `:no-root` state instead of silently scanning the wrong tree.

## Test plan

- [x] `cd tools/story && clojure -M:test` — 366 tests / 1093 assertions pass (Clojure side)
- [x] `cd implementation && npm run test:cljs` — 1939 tests / 5521 assertions pass (includes three new CLJS smoke tests: selector shape, per-variant distinctness, and the no-root short-circuit proving the default arity never runs against the wrong tree)
- [x] `cd implementation && npm run test:examples` — 26 / 26 example specs pass, including `counter-with-stories` §12 which now exercises two new rf2-qgms1 regression guards:
  - The variant-root marker (`[data-rf-story-variant-root=":story.counter/loaded"]`) must be present in the DOM before the click — pre-condition for correct scoping.
  - After the scan completes, zero `[data-rf-a11y-violation]` overlay nodes may leak outside any `[data-rf-story-variant-root]` ancestor. If axe-core were called against `document.body` again, toolbar chips / sidebar buttons would pick up the overlay attr and this assertion would fail.