### PR TITLE
feat(testbeds): Tier 1 shared framework-behavior surfaces (deliberate-throw + schema-violation + http-toggle)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -597,4 +597,13 @@
    :output-dir "out/testbeds/schema-violation"
    :asset-path "."
    :modules    {:main {:init-fn schema-violation.core/run}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
+
+  ;; rf2-kzcim — http-toggle testbed (single button + outcome dropdown
+  ;; enumerating the eight :rf.http/* categories per Spec 014).
+  :testbeds/http-toggle
+  {:target     :browser
+   :output-dir "out/testbeds/http-toggle"
+   :asset-path "."
+   :modules    {:main {:init-fn http-toggle.core/run}}
    :devtools   {:preloads [day8.re-frame2-causa.preload]}}}}

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -91,7 +91,18 @@
                 "../examples/reagent/long_running_work/test"
                 "../examples/reagent/websocket/test"
                 "../examples/uix"
-                "../examples/helix"]
+                "../examples/helix"
+                ;; rf2-kzcim Tier 1 — shared framework-behavior
+                ;; testbeds. Top-level testbeds/<surface>/ siblings of
+                ;; examples/; the per-testbed CLJS namespace
+                ;; (e.g. deliberate-throw.core) resolves under this
+                ;; source path. Per the testbeds split (rf2-96nb3),
+                ;; these are framework-behavior fixtures consumed by
+                ;; multiple tools (Causa, Story, pair2-mcp); the
+                ;; sources are bundle-isolated from the examples
+                ;; surface (no example :requires anything under
+                ;; testbeds/, and vice versa).
+                "../testbeds"]
  :dependencies [[reagent           "2.0.1"]
                 [metosin/malli     "0.20.1"]
                 [com.pitch/uix.core "1.4.4"]
@@ -550,4 +561,31 @@
   {:target     :browser
    :output-dir "out/examples/websocket"
    :asset-path "."
-   :modules    {:main {:init-fn websocket.core/run}}}}}
+   :modules    {:main {:init-fn websocket.core/run}}}
+
+  ;; ============================================================================
+  ;; Testbeds (rf2-kzcim — shared framework-behavior surfaces).
+  ;;
+  ;; Each testbed surface compiles into out/testbeds/<name>/ and is
+  ;; paired with the testbed's hand-written index.html. The Causa
+  ;; preload (rf2-n6x4q) is wired on every testbed dev build mirroring
+  ;; the examples convention — dev-only, DCEs from release builds.
+  ;;
+  ;; Bundle-isolation contract: testbeds/ source is on shadow's
+  ;; :source-paths but nothing under examples/ or implementation/
+  ;; :requires anything under testbeds/. The same contract that
+  ;; firewalls tools/ from production builds (tools/README.md) applies
+  ;; here in reverse: testbed namespaces are visible to the
+  ;; bundle-isolation grep as a denylist token so a future regression
+  ;; that accidentally :requires a testbed from production code surfaces
+  ;; on CI.
+  ;; ============================================================================
+
+  ;; rf2-kzcim — deliberate-throw testbed (the throw-from-each-layer
+  ;; surface; four buttons, four :rf.error/* categories).
+  :testbeds/deliberate-throw
+  {:target     :browser
+   :output-dir "out/testbeds/deliberate-throw"
+   :asset-path "."
+   :modules    {:main {:init-fn deliberate-throw.core/run}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}}}

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -588,4 +588,13 @@
    :output-dir "out/testbeds/deliberate-throw"
    :asset-path "."
    :modules    {:main {:init-fn deliberate-throw.core/run}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
+
+  ;; rf2-kzcim — schema-violation testbed (the four :where surfaces of
+  ;; :rf.error/schema-validation-failure; one button per :where).
+  :testbeds/schema-violation
+  {:target     :browser
+   :output-dir "out/testbeds/schema-violation"
+   :asset-path "."
+   :modules    {:main {:init-fn schema-violation.core/run}}
    :devtools   {:preloads [day8.re-frame2-causa.preload]}}}}

--- a/testbeds/README.md
+++ b/testbeds/README.md
@@ -1,0 +1,68 @@
+# Testbeds — shared framework-behavior surfaces
+
+> **Type:** Test fixture (framework-behavior).
+> Not a tutorial. The apps here deliberately error, deliberately leak, deliberately blow budgets — every line exists to give a tool (Causa, Story, pair2-mcp, causa-mcp) something concrete to observe. Read [`examples/`](../examples/) for tutorial-shaped apps; read here when you need to know what a panel/recorder/MCP wire is *supposed* to do when a `:rf.error/*`, `:rf.http/*`, or `:rf.flow/*` event flies past.
+
+The split lives in [`spec/Ownership.md` §examples-split](../spec/Ownership.md) and the umbrella decision sits in **rf2-96nb3**. Top-level structure:
+
+- **`examples/`** — tutorial apps. Each demonstrates one or two specs and reads as exemplary application code.
+- **`tools/<tool>/testbeds/`** — tool-specific fixtures. Colocated with the tool that owns them; for example, `tools/causa/testbeds/counter-driven/` exercises Causa's trace panel against a known counter dataflow.
+- **`testbeds/`** *(this directory)* — **shared** framework-behavior fixtures. Consumed by multiple tools at once; the surfaces don't know about consumers, and consumers test against them externally.
+
+## Layout
+
+```
+testbeds/
+  deliberate_throw/       <-- four exception trigger sites (handler / fx / flow / machine)
+  schema_violation/        <-- four schema-validation trigger sites (app-db / event / cofx / fx)
+  http_toggle/             <-- single button + outcome dropdown for the eight :rf.http/* categories
+```
+
+Per-surface conventions (every testbed in this directory follows them):
+
+1. **One subdirectory per surface.** Sources, `index.html`, and a per-surface `README.md` are colocated; the namespace is kebab-cased to match the snake_cased directory name (`deliberate_throw/` → `deliberate-throw.core`).
+2. **Stark code.** No tutorial commentary in the bodies; HOT PATH comments only at the trigger sites — the one or two lines that produce the framework event the consumer is watching for.
+3. **Minimal app-db.** A testbed is *not* the place to show off a realistic app shape; the `non-trivial-app-db/` testbed (Tier 3) is where that lives.
+4. **Reagent canonical.** A surface ships under a single substrate unless cross-substrate behaviour is the point.
+5. **Central build wiring.** Shadow-cljs build entries live in [`implementation/shadow-cljs.edn`](../implementation/shadow-cljs.edn) under the `:testbeds/*` build-id prefix; the examples orchestrator at [`examples/scripts/serve-and-run-examples-tests.cjs`](../examples/scripts/serve-and-run-examples-tests.cjs) picks them up via the same source-path + index.html + outDir triple every example uses.
+
+## Running a testbed in dev
+
+From `implementation/`:
+
+```bash
+shadow-cljs watch testbeds/deliberate-throw
+shadow-cljs watch testbeds/schema-violation
+shadow-cljs watch testbeds/http-toggle
+```
+
+Then open `http://localhost:9630/build/<build-id>/dashboard` (or the per-testbed index.html served from `implementation/out/testbeds/<name>/`). The Causa preload is wired on every testbed build (mirroring the examples convention) so the trace panel and dev-tools are live on each surface.
+
+## Which tools consume what
+
+| Surface | Causa scenarios | Story scenarios | pair2-mcp scenarios |
+|---|---|---|---|
+| `deliberate_throw/` | Handler exception surfaces as `:effects` outcome `:error` on epoch record; `:rf.error/handler-exception` highlighted in trace stream; partial epoch on flow throw; structured trace in Story `:play` replay | Recorder captures the click, plays it back, repro is identical; `:rf.assert/*` envelope around the trigger | Trace event arrives over the wire with `:rf.error/*` :op-type intact; `:dispatch` MCP call surfaces the error in the response envelope |
+| `schema_violation/` | Schema-validation-failure trace + `:rollback?` flag visible in trace panel; `:where` tag is one of `:event / :app-db / :cofx / :fx-args`; recovery (`:rollback?`, `:skipped`, `:replaced-with-default`) matches the per-step table | Recorder redacts post-`:sensitive?` events; the variant under `app-db` validation triggers the rollback path observable in subscribed views | Schema-validation-failure event arrives with `:path`, `:value`, `:explain` carried verbatim; `:rollback?` flag visible |
+| `http_toggle/` | Ordered `:rf.http/*` events visible in trace panel; `:kind` tag matches the picked outcome; category attribution preserved across abort + retry | Recorder captures the outcome-toggle as ordinary event vector; replay reproduces the same `:rf.http/*` category deterministically (stubs are pure) | `:rf.http/managed` envelope visible in the dispatch response; the eight categories enumerate against a fixed outcome dropdown |
+
+## Tier roadmap (rf2-kzcim)
+
+Tier 1 — load-bearing trio (this commit set):
+
+- ✅ `deliberate_throw/`
+- ✅ `schema_violation/`
+- ✅ `http_toggle/`
+
+Tier 2 (state-machine + frame surfaces): `multi_frame/`, `deep_machine/`, `long_flow_w_failure/`.
+
+Tier 3 (devtools edge cases): `drain_depth_trigger/`, `non_trivial_app_db/`, `sensitive_dispatcher/`, `large_dispatcher/`.
+
+Tier 4 (a11y): `known_bad_a11y/` — a Story variant with a deliberate a11y violation; the variant root carries the violation, not the Story chrome (cross-ref rf2-qgms1).
+
+## Cross-references
+
+- [`spec/009-Instrumentation.md` §Error contract](../spec/009-Instrumentation.md) — the `:rf.error/*` taxonomy the `deliberate_throw/` surface fires every member of.
+- [`spec/010-Schemas.md` §Per-step recovery](../spec/010-Schemas.md) — the five validation points the `schema_violation/` surface walks one button per.
+- [`spec/014-HTTPRequests.md` §Failure categories](../spec/014-HTTPRequests.md) — the eight `:rf.http/*` categories the `http_toggle/` outcome dropdown enumerates.
+- [`spec/Ownership.md`](../spec/Ownership.md) — where every contract surface this directory exercises is owned.

--- a/testbeds/deliberate_throw/README.md
+++ b/testbeds/deliberate_throw/README.md
@@ -1,0 +1,73 @@
+# `testbeds/deliberate-throw`
+
+A four-button Reagent app that throws on every click. Each button is
+wired to a different layer of the six-domino cascade so a consumer
+observes exactly one `:rf.error/*` category per click.
+
+| Button | `data-testid` | Trigger | Category emitted | Recovery (per [spec/009](../../spec/009-Instrumentation.md), [spec/010](../../spec/010-Schemas.md)) |
+|---|---|---|---|---|
+| A · handler-exception | `throw-handler` | `(throw ...)` inside the event handler body. | `:rf.error/handler-exception` | `:no-recovery` — the failing handler's `:db` / `:fx` are suppressed; downstream queue continues. No epoch record is committed under the `:halted-handler-exception` shape — the error surfaces as a trace under `:trace-events` on the drain's `:ok` epoch record (per [Spec-Schemas §`:rf/epoch-record`](../../spec/Spec-Schemas.md)). |
+| B · fx-handler-exception | `throw-fx` | `(throw ...)` inside a registered fx body. The handler returned cleanly; the throw lands during the fx walk. | `:rf.error/fx-handler-exception` | `:no-recovery` — the offending fx is skipped; sibling fx in the same `:fx` vector continue. The handler's `:db` already committed. |
+| C · flow-eval-exception | `throw-flow` | `(throw ...)` inside a registered flow's `:output` fn. The handler bumps `:flow-input`; the runtime's post-handler flows pass walks the flow and re-throws after `:rf.flow/failed` fires. | `:rf.flow/failed` first, then `:rf.error/flow-eval-exception` | Prior writes preserved (the handler's `:db` committed before the flows pass); failing flow's `last-inputs` NOT advanced; cascade halts at the router's outer catch. |
+| D · machine-action-exception | `throw-machine` | `(throw ...)` inside a machine action body. The transition is `{:target :idle :action :throw}`; the action body is the throw site. | `:rf.error/machine-action-exception` | `:no-recovery` — snapshot does not commit (pre-action `[:rf/machines <id>]` slice preserved), accumulated `:fx` from earlier slots dropped, `:always` does not fire on the failed cascade. Distinct from `:rf.error/handler-exception` — the machine layer catches and emits the machine-scoped category. |
+
+## Why the four sites are distinct
+
+Each layer's throw produces a different trace shape with different
+recovery semantics. A trace panel that conflated them — or a recorder
+that captured a flow throw but missed the per-flow `:rf.flow/failed`
+attribution preceding it — would fail to surface the load-bearing fact
+about where the cascade halted. The four buttons are the minimum that
+lets a consumer verify it discriminates.
+
+## What's deliberately *missing*
+
+- No `try` / `catch` around any trigger site. The throw must propagate
+  to the framework boundary; that's where the structured error event is
+  emitted.
+- No `:on-error` policy fn on the frame. The default per-category
+  `:recovery` is what consumers test against; an `:on-error` override
+  would mask it.
+- No epoch recorder wired into the app. The recorder is the consumer's
+  concern — `tools/causa/testbeds/deliberate-throw-recorder/spec.cjs`
+  (when filed) will register the listener itself.
+
+## Test scenarios from rf2-fe84r this surface enables
+
+**Causa (26)**:
+- `:rf.error/*` events highlighted in trace stream
+- Handler exception surfaces as `:effects` outcome `:error` per epoch record
+- Partial epoch record (drain-halt) shows up with non-`:ok` outcome (rf2-v0jwt) — via Button D (machine action; the snapshot non-commit is the cleanest drain-halt observable)
+- Click-to-source from trace event lands on source-coord line — Buttons A/B/C/D each register their handler/fx/flow/machine via the four canonical `reg-*` shapes, so every flavour of source-coord capture exercises here.
+
+**Cross-cutting (6)**:
+- Deliberately-throwing handler surfaces structured trace in BOTH Causa + Story `:play`
+- Flow `:rf.flow/failed` shows four-rule failure semantics (rf2-hrqvg) — Button C
+- State-machine transition cascade shows `:rf.machine/*` events — Button D's pre-throw transition fires the `:rf.machine/transition` trace before the action throws
+
+**Story (18)**:
+- Recorder captures click → records `:play` → replays identically — Buttons A/B/C/D should all replay deterministically (the throws are pure)
+- `:rf.assert/*` pass/fail with structured output — assertions wrapped around each button's expected `:rf.error/*` shape live in `tools/story/testbeds/<scenario>/spec.cjs` (filed after this surface lands)
+
+## Running
+
+From `implementation/`:
+
+```bash
+shadow-cljs watch testbeds/deliberate-throw
+# Then open http://localhost:9630 to find the build's dev URL,
+# or run the full examples orchestrator:
+npm run test:examples
+```
+
+The shadow-cljs build id is `testbeds/deliberate-throw`; output lands
+in `implementation/out/testbeds/deliberate-throw/`. The example
+orchestrator stages `index.html` next to `main.js` and serves it under
+`/testbeds/deliberate-throw/` on port 8030.
+
+## Cross-references
+
+- [`spec/009-Instrumentation.md` §Error contract](../../spec/009-Instrumentation.md) — the `:rf.error/*` catalogue this surface fires four entries from.
+- [`spec/005-StateMachines.md` §Errors](../../spec/005-StateMachines.md) — the machine-action-exception contract.
+- [`spec/013-Flows.md` §Failure semantics](../../spec/013-Flows.md) — the four-rule flow-failure contract (rf2-hrqvg).
+- [`spec/Spec-Schemas.md` §`:rf/epoch-record`](../../spec/Spec-Schemas.md) — the epoch-record outcome taxonomy a consumer's recorder reads.

--- a/testbeds/deliberate_throw/core.cljs
+++ b/testbeds/deliberate_throw/core.cljs
@@ -1,0 +1,172 @@
+(ns deliberate-throw.core
+  "Shared framework-behavior testbed — four trigger sites that throw on
+  `:on-click` dispatch. Each button is wired to a different layer of the
+  six-domino cascade so a consumer (Causa, Story, pair2-mcp) observes
+  the corresponding :rf.error/* category emerge once per click.
+
+  This is NOT a tutorial. The bodies are deliberately stark — no error
+  handling, no recovery, no diagnostic prose. The whole point is to
+  produce a single, predictable failure per button so external test
+  harnesses can assert against it.
+
+  Triggered categories (per [spec/009 §Error contract]):
+
+    Button A → :rf.error/handler-exception        (synchronous handler throw)
+    Button B → :rf.error/fx-handler-exception     (fx body throw)
+    Button C → :rf.error/flow-eval-exception      (flow :output throw)
+    Button D → :rf.error/machine-action-exception (machine :actions throw)"
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.flows]                            ;; load-time hook for reg-flow
+            [re-frame.machines]                          ;; load-time hook for create-machine-handler
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ----------------------------------------------------------------------------
+;; App-db
+;; ----------------------------------------------------------------------------
+;;
+;; Minimal by design — three counters that the throwing handlers *would*
+;; bump if their cascades completed. A consumer that sees the value at
+;; [:click-count :handler] stay at 0 after a Button-A click has positive
+;; evidence the handler threw (the `:db` effect did not commit).
+
+(rf/reg-event-db ::initialise
+  (fn [_db _ev]
+    {:click-count {:handler 0 :fx 0 :flow 0 :machine 0}
+     ;; Flow input — bumping this triggers Button C's flow recompute.
+     :flow-input  0}))
+
+;; ----------------------------------------------------------------------------
+;; Button A — synchronous throw in event handler
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-db ::throw-in-handler
+  (fn [_db _ev]
+    ;; HOT PATH — the throw site for :rf.error/handler-exception.
+    ;; The runtime's outer interceptor catches; emits the structured
+    ;; error event with this fn's :handler-id and the original message.
+    (throw (ex-info "deliberate-throw / handler" {:where :handler}))))
+
+;; ----------------------------------------------------------------------------
+;; Button B — throw inside fx body
+;; ----------------------------------------------------------------------------
+;;
+;; The handler returns `{:fx [[::boom ...]]}` cleanly; the throw happens
+;; later, during the fx walk. Per [spec/010 §Per-step recovery] the
+;; offending fx is skipped; other fx in the same vector continue. The
+;; runtime emits :rf.error/fx-handler-exception with this fx-id.
+
+(rf/reg-fx ::boom
+  (fn [_frame-ctx _args]
+    ;; HOT PATH — the throw site for :rf.error/fx-handler-exception.
+    (throw (ex-info "deliberate-throw / fx" {:where :fx}))))
+
+(rf/reg-event-fx ::throw-in-fx
+  (fn [{:keys [db]} _ev]
+    {:db (update-in db [:click-count :fx] inc)
+     :fx [[::boom {}]]}))
+
+;; ----------------------------------------------------------------------------
+;; Button C — throw inside flow :output
+;; ----------------------------------------------------------------------------
+;;
+;; The flow is registered once at ns-load (registration order doesn't
+;; matter — the runtime topsorts before the first drain). Button C's
+;; handler bumps :flow-input; on the post-handler flows pass, the
+;; runtime walks this flow, calls :output with the new input, and the
+;; throw fires there.
+;;
+;; Per [spec/013 §Failure semantics]: two trace events fire in order —
+;; :rf.flow/failed (per-flow attribution) followed by the cascade-level
+;; :rf.error/flow-eval-exception (router outer catch). The handler's
+;; `:db` is preserved (prior writes survive); the failing flow's
+;; `last-inputs` is NOT advanced.
+
+(rf/reg-flow
+  {:id     ::throws
+   :inputs [[:flow-input]]
+   :output (fn [_input]
+             ;; HOT PATH — the throw site for :rf.error/flow-eval-exception.
+             (throw (ex-info "deliberate-throw / flow" {:where :flow})))
+   :path   [:flow-output]
+   :doc    "Flow :output that throws every recompute."})
+
+(rf/reg-event-db ::throw-in-flow
+  (fn [db _ev]
+    (-> db
+        (update-in [:click-count :flow] inc)
+        ;; Bumping :flow-input is what causes the flow to recompute.
+        ;; The flow's :output throws — see ::throws above.
+        (update :flow-input inc))))
+
+;; ----------------------------------------------------------------------------
+;; Button D — throw inside machine action
+;; ----------------------------------------------------------------------------
+;;
+;; The machine has one transition; the transition references the
+;; :throw action by keyword; the action body throws.
+;;
+;; Per [spec/005 §Errors] and [spec/009 :rf.error/machine-action-exception]:
+;; the machine layer catches and emits the machine-scoped category, NOT
+;; :rf.error/handler-exception. The snapshot does not commit; accumulated
+;; :fx from earlier slots in the cascade is dropped; :always does not
+;; fire on the failed cascade.
+
+(rf/reg-event-fx ::throw-in-machine
+  (rf/create-machine-handler
+    {:initial :idle
+     :actions {:throw
+               (fn [_data _event]
+                 ;; HOT PATH — the throw site for :rf.error/machine-action-exception.
+                 (throw (ex-info "deliberate-throw / machine action"
+                                 {:where :machine})))}
+     :states  {:idle {:on {::tick {:target :idle :action :throw}}}}}))
+
+;; ----------------------------------------------------------------------------
+;; Subs + view
+;; ----------------------------------------------------------------------------
+
+(rf/reg-sub :handler-count (fn [db _] (get-in db [:click-count :handler])))
+(rf/reg-sub :fx-count      (fn [db _] (get-in db [:click-count :fx])))
+(rf/reg-sub :flow-count    (fn [db _] (get-in db [:click-count :flow])))
+(rf/reg-sub :machine-count (fn [db _] (get-in db [:click-count :machine])))
+
+(reg-view buttons []
+  [:div {:data-testid "deliberate-throw" :style {:font-family "sans-serif" :padding "1em"}}
+   [:h1 "deliberate-throw testbed"]
+   [:p "Each button triggers exactly one :rf.error/* category. Click and observe."]
+   [:div {:style {:display :flex :gap "0.5em" :flex-wrap :wrap}}
+    [:button {:data-testid "throw-handler"
+              :on-click #(dispatch [::throw-in-handler])}
+     "A · handler-exception"]
+    [:button {:data-testid "throw-fx"
+              :on-click #(dispatch [::throw-in-fx])}
+     "B · fx-handler-exception"]
+    [:button {:data-testid "throw-flow"
+              :on-click #(dispatch [::throw-in-flow])}
+     "C · flow-eval-exception"]
+    [:button {:data-testid "throw-machine"
+              :on-click #(dispatch [::throw-in-machine [::tick]])}
+     "D · machine-action-exception"]]
+   [:p {:style {:margin-top "1em" :color "#666"}}
+    "handler=" [:span {:data-testid "handler-count"} @(subscribe [:handler-count])]
+    " · fx=" [:span {:data-testid "fx-count"} @(subscribe [:fx-count])]
+    " · flow=" [:span {:data-testid "flow-count"} @(subscribe [:flow-count])]
+    " · machine=" [:span {:data-testid "machine-count"} @(subscribe [:machine-count])]]])
+
+(reg-view root []
+  [buttons])
+
+;; ----------------------------------------------------------------------------
+;; Mount
+;; ----------------------------------------------------------------------------
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  (rf/dispatch-sync [::initialise])
+  (rdc/render react-root [root]))

--- a/testbeds/deliberate_throw/index.html
+++ b/testbeds/deliberate_throw/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: deliberate-throw</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/testbeds/http_toggle/README.md
+++ b/testbeds/http_toggle/README.md
@@ -1,0 +1,99 @@
+# `testbeds/http-toggle`
+
+A single Reagent button + outcome dropdown that drives a
+`:rf.http/managed` request through one of the eight failure categories
+in Spec 014 (plus the success path). One click + one selection emits
+the corresponding `:rf.http/*` event(s) on the trace stream so a
+consumer (Causa, Story, pair2-mcp) verifies category attribution
+end-to-end.
+
+| Outcome | `data-testid` (option) | Strategy | Reply `:kind` / `:failure :kind` |
+|---|---|---|---|
+| 200 success | `:success` | Live Fetch against `api/success.json` (static asset shipped under the testbed dir). | `:kind :success`, `:value {:ok true :value "http-toggle success"}` |
+| 4xx | `:rf.http/http-4xx` | Canned-failure stub with `:status 404`, raw HTML body. | `:kind :failure`, `:failure :kind :rf.http/http-4xx`, `:status 404`, `:body "<html>not found</html>"` |
+| 5xx | `:rf.http/http-5xx` | Canned-failure stub with `:status 500`, raw HTML body. | `:kind :failure`, `:failure :kind :rf.http/http-5xx`, `:status 500`, `:body "<html>server error</html>"` |
+| timeout | `:rf.http/timeout` | Canned-failure stub. | `:kind :failure`, `:failure :kind :rf.http/timeout`, `:elapsed-ms 5000`, `:limit-ms 5000` |
+| aborted | `:rf.http/aborted` | Per-testbed `:http-toggle/deferred-abortable` stub defers a canned reply by 500ms so the spec can observe `:status :loading` and click Cancel. The Cancel button fires the live `:rf.http/managed-abort` fx. | `:kind :failure`, `:failure :kind :rf.http/aborted`, `:request-id ::in-flight`, `:reason :user` |
+| transport | `:rf.http/transport` | Canned-failure stub. | `:kind :failure`, `:failure :kind :rf.http/transport`, `:message "Network unreachable"`, `:cause "ECONNREFUSED"` |
+| decode-failure | `:rf.http/decode-failure` | Canned-failure stub (live decode-failure requires a JSON endpoint that 2xxs with invalid JSON; the stub preserves the reply envelope). | `:kind :failure`, `:failure :kind :rf.http/decode-failure`, `:body-text "<<not-json>>"`, `:cause "SyntaxError: ..."` |
+| CORS | `:rf.http/cors` | Canned-failure stub. CLJS-only; the JVM never emits this category. | `:kind :failure`, `:failure :kind :rf.http/cors`, `:url "https://other.example/api/cors"` |
+
+## Why canned-failure for seven of eight
+
+The framework-shipped `:rf.http/managed-canned-failure` fx synthesises
+the same `:rf/reply` envelope a live request would on each category
+(per [spec/014 §Testing](../../spec/014-HTTPRequests.md) and the
+JVM smokes in `re-frame.http-managed-test`). For a testbed whose job
+is to drive each category deterministically — across CI environments
+that may not allow outbound CORS or 503-flaky-endpoint requests —
+the canned-stub seam is the canonical move. The reply shape consumers
+read (`:kind :failure`, `:failure :kind :rf.http/<category>`, the
+category-specific tags) is identical.
+
+The live success path is exercised because it's the simplest possible
+real round-trip: an HTTP GET against a static asset under the same
+origin. No CI environment refuses it.
+
+## Trace shape per click (per [spec/009 §:op-type vocabulary](../../spec/009-Instrumentation.md))
+
+The `:rf.http/managed` envelope emits a sequence of `:rf.http/*` trace
+events through the request lifecycle. Per Spec 014 §Trace events, the
+consumer sees at least:
+
+```
+:rf.http/dispatched            ;; request issued
+:rf.http/<success | failure>   ;; reply received
+:rf.http/<:kind from above>    ;; the category tag, e.g. :rf.http/http-4xx
+```
+
+The category-attribution scenario in rf2-fe84r reads: *"HTTP failure
+cascade visible as ordered `:rf.http/*` with category attribution"* —
+this testbed walks one outcome per dropdown entry, so the consumer's
+spec can iterate the dropdown values and assert each emits its expected
+`:kind` tag.
+
+## What's deliberately *missing*
+
+- No retry policy. The testbed pins each click to one attempt; the
+  `:retry` slot is exercised by tools-side fixtures that need to assert
+  on the multi-attempt cascade.
+- No `:accept` projection. The reply lands at `:value` (success path)
+  or `:failure` (failure paths) verbatim; consumers reading the
+  envelope shape don't need `:accept` to mutate it.
+- No URL parameterisation. Every outcome uses a hard-coded URL so the
+  trace's `:request :url` slot is deterministic across runs.
+
+## Test scenarios from rf2-fe84r this surface enables
+
+**Causa (26)**:
+- HTTP failure cascade visible as ordered `:rf.http/*` with category attribution — the bread-and-butter scenario this surface exists to drive.
+- Time-travel scrub forward/back mutates visible UI — every outcome produces a `:status` and `:reply` mutation observable on `data-testid="status"` and `data-testid="reply-kind"`.
+
+**Cross-cutting (6)**:
+- HTTP failure cascade visible as ordered `:rf.http/*` with category attribution (the canonical cross-cutting scenario).
+
+**Story (18)**:
+- Recorder captures click → records `:play` → replays identically. The canned-stub seam is deterministic; the live `:success` outcome may be skipped from a recorder replay (or stub-overridden) depending on the recording mode.
+- A11y panel surfaces violations on known-bad variant — out of scope here; covered by Tier-4's `known-bad-a11y/`.
+
+## Running
+
+From `implementation/`:
+
+```bash
+shadow-cljs watch testbeds/http-toggle
+# Or full orchestrator:
+npm run test:examples
+```
+
+The shadow-cljs build id is `testbeds/http-toggle`; output lands in
+`implementation/out/testbeds/http-toggle/`. The `api/success.json`
+asset is staged next to `main.js` by the orchestrator (one
+`extraFiles` entry in `serve-and-run-examples-tests.cjs`).
+
+## Cross-references
+
+- [`spec/014-HTTPRequests.md` §Failure categories](../../spec/014-HTTPRequests.md) — the closed-for-v1 vocabulary the dropdown enumerates.
+- [`spec/014-HTTPRequests.md` §Classification order](../../spec/014-HTTPRequests.md) — status-before-decode is why `:rf.http/http-4xx` carries the raw `:body` and decode is skipped.
+- [`spec/014-HTTPRequests.md` §Testing](../../spec/014-HTTPRequests.md) — the canned-failure stub seam this testbed leans on for the seven failure outcomes.
+- [`examples/reagent/managed_http_counter/`](../../examples/reagent/managed_http_counter/) — the tutorial-shaped companion to this testbed; demonstrates the canonical reply-addressing pattern in tutorial-grade prose.

--- a/testbeds/http_toggle/api/success.json
+++ b/testbeds/http_toggle/api/success.json
@@ -1,0 +1,1 @@
+{"ok":true,"value":"http-toggle success"}

--- a/testbeds/http_toggle/core.cljs
+++ b/testbeds/http_toggle/core.cljs
@@ -1,0 +1,266 @@
+(ns http-toggle.core
+  "Shared framework-behavior testbed — a single HTTP-request button and
+  a toggleable outcome dropdown that enumerates the eight failure
+  categories of `:rf.http/managed` (plus the success path). One click +
+  one dropdown selection drives the request through the configured
+  outcome, and the runtime emits the corresponding :rf.http/* event(s)
+  the consumer is watching for.
+
+  Outcomes (per [spec/014 §Failure categories]):
+
+    :success            → 2xx with decoded JSON; reply :kind :success
+    :rf.http/http-4xx   → 4xx response; decode skipped; :body raw
+    :rf.http/http-5xx   → 5xx response; decode skipped; :body raw
+    :rf.http/timeout    → per-attempt timeout fired
+    :rf.http/aborted    → abort via :request-id (the testbed's Cancel)
+    :rf.http/transport  → network / DNS / connection-refused
+    :rf.http/decode-failure → 2xx response whose body failed decode
+    :rf.http/cors       → CORS preflight rejected or response blocked
+
+  Routing strategy: the success path issues a REAL Fetch against
+  `/api/<outcome>.json` (static asset shipped under the testbed dir).
+  Every failure outcome is synthesised via the framework-shipped
+  canned-failure stub (`:rf.http/managed-canned-failure`, per Spec 014
+  §Testing) — same reply shape as the live failure path, no network
+  required. This keeps the testbed deterministic across CI environments
+  while preserving the canonical reply envelope every consumer reads."
+  (:require [cljs.reader :as edn]
+            [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
+            ;; Managed-HTTP ships in day8/re-frame2-http. Requiring at
+            ;; app boot triggers its load-time fx registrations
+            ;; (`:rf.http/managed`, the canned-* stubs); without it,
+            ;; dispatching `:rf.http/managed` would fail with
+            ;; :rf.error/no-such-fx.
+            [re-frame.http-managed]
+            [re-frame.http :as rf.http]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ----------------------------------------------------------------------------
+;; App-db
+;; ----------------------------------------------------------------------------
+;;
+;; Minimal — :outcome carries the dropdown selection; :status is
+;; :idle | :loading | :done | :error; :reply carries the last reply for
+;; consumers to inspect via the DOM. A consumer's spec asserts on the
+;; :rf.http/* trace stream first; the DOM mirror is a fall-back.
+
+(rf/reg-event-db ::initialise
+  (fn [_db _ev]
+    {:outcome :success
+     :status  :idle
+     :reply   nil}))
+
+(rf/reg-event-db ::set-outcome
+  (fn [db [_ outcome]]
+    (assoc db :outcome outcome)))
+
+;; ----------------------------------------------------------------------------
+;; The Go button — one event handler that branches on (:outcome db).
+;; ----------------------------------------------------------------------------
+;;
+;; Reply addressing: the same handler-id receives the reply via the
+;; default reply-addressing path (per Spec 014). On (:rf/reply msg), the
+;; handler files the reply into :reply; on initial dispatch (no
+;; :rf/reply), it issues the configured request.
+;;
+;; The Cancel button is wired to abort whatever request was issued under
+;; this request-id.
+
+(def request-id ::in-flight)
+
+(rf/reg-event-fx ::go
+  (fn [{:keys [db]} [_ msg]]
+    (cond
+      ;; Reply branch — categorise and stash.
+      (some-> msg :rf/reply :kind some?)
+      {:db (-> db
+               (assoc :status (if (= :success (:kind (:rf/reply msg))) :done :error))
+               (assoc :reply  (:rf/reply msg)))}
+
+      ;; Initial branch — fan out by selected outcome. Each branch
+      ;; produces ONE `:fx` entry whose canonical envelope the framework
+      ;; classifies; for the failure paths, that envelope is a direct
+      ;; call into the canned-failure stub with the desired :kind / :tags
+      ;; pre-baked.
+      :else
+      (let [outcome (:outcome db)]
+        {:db (-> db (assoc :status :loading :reply nil))
+         :fx [(case outcome
+                ;; HOT PATH — the live-Fetch site. This is the only
+                ;; outcome that actually crosses the wire; the response
+                ;; is the static asset `/api/success.json` shipped
+                ;; alongside the testbed.
+                :success
+                (rf.http/get "api/success.json"
+                             {:decode     :json
+                              :request-id request-id})
+
+                ;; HOT PATH — synthesised :rf.http/http-4xx via the
+                ;; canned-failure stub. Same reply envelope as a live
+                ;; 4xx; the consumer's trace watcher cannot distinguish.
+                :rf.http/http-4xx
+                [:rf.http/managed-canned-failure
+                 {:request    {:method :get :url "api/4xx"}
+                  :request-id request-id
+                  :kind       :rf.http/http-4xx
+                  :tags       {:status 404 :status-text "Not Found"
+                               :body   "<html>not found</html>"
+                               :headers {}}}]
+
+                :rf.http/http-5xx
+                [:rf.http/managed-canned-failure
+                 {:request    {:method :get :url "api/5xx"}
+                  :request-id request-id
+                  :kind       :rf.http/http-5xx
+                  :tags       {:status 500 :status-text "Internal Server Error"
+                               :body   "<html>server error</html>"
+                               :headers {}}}]
+
+                :rf.http/timeout
+                [:rf.http/managed-canned-failure
+                 {:request    {:method :get :url "api/timeout"}
+                  :request-id request-id
+                  :kind       :rf.http/timeout
+                  :tags       {:elapsed-ms 5000 :limit-ms 5000}}]
+
+                :rf.http/aborted
+                ;; Issue a deferred request so the Cancel button has
+                ;; time to fire. See ::go-and-await-cancel below — for
+                ;; the testbed flow, the user selects :rf.http/aborted
+                ;; then clicks Go, then clicks Cancel; the abort path
+                ;; emits :rf.http/aborted via the live abort handler.
+                [:http-toggle/deferred-abortable
+                 {:request-id request-id}]
+
+                :rf.http/transport
+                [:rf.http/managed-canned-failure
+                 {:request    {:method :get :url "api/transport"}
+                  :request-id request-id
+                  :kind       :rf.http/transport
+                  :tags       {:message "Network unreachable"
+                               :cause   "ECONNREFUSED"}}]
+
+                :rf.http/decode-failure
+                [:rf.http/managed-canned-failure
+                 {:request    {:method :get :url "api/decode"}
+                  :request-id request-id
+                  :kind       :rf.http/decode-failure
+                  :tags       {:body-text "<<not-json>>"
+                               :cause     "SyntaxError: Unexpected token < at 0"
+                               :schema-validation-failure? false}}]
+
+                :rf.http/cors
+                [:rf.http/managed-canned-failure
+                 {:request    {:method :get :url "https://other.example/api/cors"}
+                  :request-id request-id
+                  :kind       :rf.http/cors
+                  :tags       {:message "CORS preflight rejected"
+                               :url     "https://other.example/api/cors"}}])]}))))
+
+;; ----------------------------------------------------------------------------
+;; Deferred-abortable stub — synthesises the :rf.http/aborted path
+;; ----------------------------------------------------------------------------
+;;
+;; The live :rf.http/managed-abort fx fires the abort handle on the
+;; in-flight registry; the in-flight request resolves with
+;; :rf.http/aborted via the default reply-addressing path. To exercise
+;; that contract without a real long-poll endpoint, this per-app stub
+;; defers a canned-failure synthesis by 500ms — long enough for a
+;; spec to observe the :loading state and click Cancel.
+
+(rf/reg-fx :http-toggle/deferred-abortable
+  {:doc       "Testbed-only fx that defers a canned :rf.http/aborted
+               reply by 500ms so the spec can observe :status :loading
+               and click Cancel before the timer fires. Production
+               apps should never use raw js/setTimeout — see Spec 014
+               §Testing for the canonical stub seam."
+   :platforms #{:client}}
+  (fn fx-deferred-abortable [frame-ctx args-map]
+    (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+      ;; Demo-only artificial latency. The :request-id in args-map
+      ;; would normally bind the abort handle in the in-flight
+      ;; registry; for the testbed stub, the Cancel button fires the
+      ;; abort via the live :rf.http/managed-abort fx which short-
+      ;; circuits the timer.
+      (js/setTimeout
+        (fn []
+          (stub frame-ctx (assoc args-map
+                                 :kind :rf.http/aborted
+                                 :tags {:request-id (:request-id args-map)
+                                        :reason     :user})))
+        500))))
+
+(rf/reg-event-fx ::cancel
+  (fn [_ctx _ev]
+    {:fx [;; The live abort fx. On the testbed's deferred-abortable
+          ;; path, the in-flight registry isn't populated, so this is
+          ;; a no-op against the registry but emits the abort trace
+          ;; the consumer's trace watcher is looking for.
+          [:rf.http/managed-abort request-id]]}))
+
+;; ----------------------------------------------------------------------------
+;; Subs + view
+;; ----------------------------------------------------------------------------
+
+(rf/reg-sub :outcome (fn [db _] (:outcome db)))
+(rf/reg-sub :status  (fn [db _] (:status db)))
+(rf/reg-sub :reply   (fn [db _] (:reply db)))
+
+(def outcomes
+  [[:success                "200 success (live Fetch /api/success.json)"]
+   [:rf.http/http-4xx       ":rf.http/http-4xx (404, raw body)"]
+   [:rf.http/http-5xx       ":rf.http/http-5xx (500, raw body)"]
+   [:rf.http/timeout        ":rf.http/timeout"]
+   [:rf.http/aborted        ":rf.http/aborted (deferred — click Cancel)"]
+   [:rf.http/transport      ":rf.http/transport (network)"]
+   [:rf.http/decode-failure ":rf.http/decode-failure (bad JSON)"]
+   [:rf.http/cors           ":rf.http/cors"]])
+
+(reg-view buttons []
+  (let [outcome @(subscribe [:outcome])
+        status  @(subscribe [:status])
+        reply   @(subscribe [:reply])]
+    [:div {:data-testid "http-toggle" :style {:font-family "sans-serif" :padding "1em"}}
+     [:h1 "http-toggle testbed"]
+     [:p "Pick an outcome, click Go. The runtime emits the corresponding "
+      [:code ":rf.http/*"] " event(s)."]
+     [:div {:style {:display :flex :gap "0.5em" :flex-wrap :wrap :align-items :center}}
+      [:select {:data-testid "outcome-select"
+                :value       (pr-str outcome)
+                :on-change   (fn [e]
+                               (let [picked (edn/read-string (.. e -target -value))]
+                                 (dispatch [::set-outcome picked])))}
+       (for [[v label] outcomes]
+         ^{:key v}
+         [:option {:value (pr-str v)} label])]
+      [:button {:data-testid "go"
+                :on-click #(dispatch [::go])}
+       "Go"]
+      [:button {:data-testid "cancel"
+                :on-click #(dispatch [::cancel])}
+       "Cancel"]]
+     [:p {:style {:margin-top "1em" :color "#666"}}
+      "status=" [:span {:data-testid "status"} (name status)]
+      (when reply
+        [:span " · reply.kind=" [:span {:data-testid "reply-kind"} (pr-str (:kind reply))]
+         (when-let [k (get-in reply [:failure :kind])]
+           [:span " · failure.kind=" [:span {:data-testid "failure-kind"} (pr-str k)]])])]]))
+
+(reg-view root []
+  [buttons])
+
+;; ----------------------------------------------------------------------------
+;; Mount
+;; ----------------------------------------------------------------------------
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  (rf/dispatch-sync [::initialise])
+  (rdc/render react-root [root]))

--- a/testbeds/http_toggle/index.html
+++ b/testbeds/http_toggle/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: http-toggle</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/testbeds/schema_violation/README.md
+++ b/testbeds/schema_violation/README.md
@@ -1,0 +1,84 @@
+# `testbeds/schema-violation`
+
+A four-button Reagent app where every click triggers a
+`:rf.error/schema-validation-failure` trace at a distinct check-point in
+the per-event validation order. The `:where` discriminator names which
+of the five check-points fired; each `:where` carries a different
+`:recovery` keyword.
+
+| Button | `data-testid` | `:where` | Recovery (per [spec/010 §Per-step recovery](../../spec/010-Schemas.md)) | Observable diff in app-db |
+|---|---|---|---|---|
+| A · :where :app-db | `violate-app-db` | `:app-db` | `:rollback? true`, `:recovery :no-recovery`. The `:db` effect is rolled back to its pre-handler value; flows do NOT evaluate and `:fx` does NOT walk for this dispatch. Downstream queued events still drain. | `[:auth :token]` stays at `"seed-token"`. The handler tried to commit `42` (an int) at a slot whose registered schema demands `:string`. |
+| B · :where :event | `violate-event` | `:event` | `:no-recovery` — handler not invoked; downstream queue continues. | `[:click-count :event]` stays at `0`. The handler's `:spec` is `[:cat [:= ::violate-event] pos-int?]`; the button dispatches it with the string `"not-a-number"`. |
+| C · :where :cofx | `violate-cofx` | `:cofx` | `:no-recovery` — handler not invoked; downstream queue continues. | `[:click-count :cofx]` stays at `0`. The cofx's `:spec` is `pos-int?`; the cofx body deliberately injects `-1`. |
+| D · :where :fx-args | `violate-fx-args` | `:fx-args` | `:recovery :skipped` — the offending fx is skipped; sibling fx continue. The handler's `:db` already committed. | `[:click-count :fx]` increments per click (the handler's `:db` ran). The fx body never ran — its `:spec` (`[:map [:url :string]]`) rejected the vector args. |
+
+## Trace shape per click (per [spec/009 §Error contract](../../spec/009-Instrumentation.md))
+
+Every Button's click emits one (and only one) trace of the form:
+
+```clojure
+{:operation :rf.error/schema-validation-failure
+ :op-type   :error
+ :tags      {:where      <:event | :cofx | :app-db | :fx-args>
+             :path       [...]      ;; structural — the failing slot's path
+             :value      <bad>      ;; the rejected value (redacted if :sensitive?)
+             :explain    <Malli explanation>
+             :failing-id <reg-* id> ;; the handler/cofx/fx that owns the failure
+             :rollback?  <true only for :app-db>
+             :recovery   <:no-recovery | :skipped>}}
+```
+
+For `:where :app-db`, the trace additionally carries `:registered-path`
+(the `reg-app-schema` root) and the `:path` is the **failing leaf**
+(the registered root concat'd with the Malli explainer's value-navigation
+suffix). Consumers that want the registration anchor reach
+`(:registered-path tags)`; consumers that want the failing slot reach
+`(:path tags)`.
+
+## What's deliberately *missing*
+
+- No `:on-error` policy fn — the default per-`:where` recovery is what
+  consumers verify against.
+- No `:rf/validate-at-boundary` interceptor — that interceptor is for
+  production-mode schema enforcement on untrusted-input handlers, not
+  for the dev-mode validation surfaces this testbed exercises.
+- No `:sensitive?` slots in the schemas. The privacy/redaction surface
+  is exercised by the (Tier 3) `sensitive_dispatcher/` testbed; this
+  testbed keeps the values visible so consumers can assert the `:value`
+  tag carries the verbatim offending value.
+
+## Test scenarios from rf2-fe84r this surface enables
+
+**Causa (26)**:
+- Schema-validation-failure trace + `:rollback?` flag visible — Button A surfaces the rollback path; Buttons B/C/D verify the trace shape without `:rollback?`.
+- `:rf.error/*` events highlighted in trace stream — `:rf.error/schema-validation-failure` is one of the most common ops in the dev-mode trace surface.
+- Click-to-source from trace event lands on source-coord line — each `reg-*` registration captures source coords; the failing-id in the trace links back to its declaration.
+
+**Cross-cutting (6)**:
+- Schema-validation-failure produces app-db rollback + `:rollback?` flag (rf2-hrqvg covers the flow analogue; this surface is the app-db analogue).
+- Subscribe → re-render → trace ordering preserved — Button A's `[:auth :token]` sub stays at the pre-handler value across the failed dispatch, which is the load-bearing rollback observability claim.
+
+**Story (18)**:
+- Recorder captures click → records `:play` → replays identically. Schema violation should replay deterministically (the inputs are pure).
+- `:rf.assert/*` pass/fail with structured output — assertions over the four `:where` discriminators live in tool-side testbeds.
+
+## Running
+
+From `implementation/`:
+
+```bash
+shadow-cljs watch testbeds/schema-violation
+# Or full orchestrator:
+npm run test:examples
+```
+
+The shadow-cljs build id is `testbeds/schema-violation`; output lands
+in `implementation/out/testbeds/schema-violation/`.
+
+## Cross-references
+
+- [`spec/010-Schemas.md` §Per-step recovery](../../spec/010-Schemas.md) — the table this testbed walks one button per row from.
+- [`spec/010-Schemas.md` §Validation order](../../spec/010-Schemas.md) — the six-step order; this testbed exercises steps 1, 2, 4, 5.
+- [`spec/009-Instrumentation.md` §Error contract](../../spec/009-Instrumentation.md) — the `:rf.error/schema-validation-failure` row in the catalogue.
+- [`spec/Spec-Schemas.md` §Per-category `:tags` schemas](../../spec/Spec-Schemas.md) — the per-`:where` `:tags` map shape consumers parse.

--- a/testbeds/schema_violation/core.cljs
+++ b/testbeds/schema_violation/core.cljs
@@ -1,0 +1,175 @@
+(ns schema-violation.core
+  "Shared framework-behavior testbed — four trigger sites that each fail
+  schema validation at a distinct check-point in the per-event order
+  (per [spec/010 §Per-step recovery]). One button per :where surface so
+  a consumer (Causa, Story, pair2-mcp) observes the corresponding
+  :rf.error/schema-validation-failure shape emerge once per click.
+
+  Triggered :where surfaces:
+
+    Button A → :where :app-db     (post-handler :db fails its registered :rf/app-schema)
+    Button B → :where :event      (dispatched vector fails the handler's :spec)
+    Button C → :where :cofx       (cofx :spec rejects the injected value)
+    Button D → :where :fx-args    (fx :spec rejects the offending fx's args)
+
+  Each recovery differs (rollback, skip-handler, skip-fx, ...) — see
+  README.md for the per-button matrix."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            ;; Loads the schemas artefact's late-bind hooks (rf2-p7va).
+            ;; Required before any reg-app-schema / :spec metadata is
+            ;; consumed by validation.
+            [re-frame.schemas]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ----------------------------------------------------------------------------
+;; App-db + schemas
+;; ----------------------------------------------------------------------------
+;;
+;; Minimal — three counters plus an :auth slice with a schema. The
+;; schema's only constraint is :token must be a string; Button A
+;; deliberately writes an int there.
+
+(def AuthSlice
+  [:map [:token :string]])
+
+(rf/reg-app-schema [:auth] AuthSlice)
+
+(rf/reg-event-db ::initialise
+  (fn [_db _ev]
+    {:auth        {:token "seed-token"}
+     :click-count {:app-db 0 :event 0 :cofx 0 :fx 0}}))
+
+;; ----------------------------------------------------------------------------
+;; Button A — :where :app-db (handler commits a value that fails the
+;;            registered :rf/app-schema at the registered path)
+;; ----------------------------------------------------------------------------
+;;
+;; The handler returns a `:db` whose [:auth :token] slot holds an int.
+;; The post-handler app-db validation step (per [spec/010 §Validation
+;; order] step 4) catches it and emits the failure trace with
+;; :rollback? true. The :db effect is rolled back — :auth :token stays
+;; at "seed-token" — and the dispatch is treated as failed (flows do
+;; not evaluate, :fx does not walk).
+
+(rf/reg-event-db ::violate-app-db
+  (fn [db _ev]
+    ;; HOT PATH — the commit site for :where :app-db.
+    ;; The runtime's post-handler validation re-reads [:auth :token]
+    ;; against AuthSlice and rejects the int 42.
+    (assoc-in db [:auth :token] 42)))
+
+;; ----------------------------------------------------------------------------
+;; Button B — :where :event (dispatched vector fails the handler's :spec)
+;; ----------------------------------------------------------------------------
+;;
+;; The handler declares :spec requiring a positive int as arg-1. Button
+;; B dispatches it with the string "not-a-number". Per [spec/010
+;; §Per-step recovery] step 1, the handler is NOT invoked; the failure
+;; trace fires with :where :event; the downstream queue continues to
+;; drain (the cascade stops only at this event).
+
+(rf/reg-event-db ::violate-event
+  {:spec [:cat [:= ::violate-event] pos-int?]}
+  (fn [db _ev]
+    (update-in db [:click-count :event] inc)))
+
+;; ----------------------------------------------------------------------------
+;; Button C — :where :cofx (cofx :spec rejects the injected value)
+;; ----------------------------------------------------------------------------
+;;
+;; The cofx :spec demands the injected value is a positive int; the
+;; cofx body deliberately injects -1. The handler is NOT invoked; the
+;; failure trace fires with :where :cofx and :failing-id naming the
+;; cofx. The downstream queue continues to drain.
+
+(rf/reg-cofx ::bad-counter
+  {:spec pos-int?}
+  (fn [coeffects _]
+    ;; HOT PATH — the injection site for :where :cofx.
+    ;; Returns a value that the registered :spec will reject.
+    (assoc coeffects ::bad-counter -1)))
+
+(rf/reg-event-fx ::violate-cofx
+  [(rf/inject-cofx ::bad-counter)]
+  (fn [{:keys [db]} _ev]
+    {:db (update-in db [:click-count :cofx] inc)}))
+
+;; ----------------------------------------------------------------------------
+;; Button D — :where :fx-args (fx :spec rejects the offending fx's args)
+;; ----------------------------------------------------------------------------
+;;
+;; The fx's :spec demands a map with :url string. Button D's handler
+;; dispatches it with a vector. Per [spec/010 §Per-step recovery] step
+;; 5, the offending fx is skipped (the failure trace fires with :where
+;; :fx-args); other fx in the same :fx vector continue. The handler's
+;; :db already committed.
+
+(rf/reg-fx ::violate-fx
+  {:spec [:map [:url :string]]}
+  (fn [_frame-ctx _args]
+    ;; This body never runs in the canonical Button-D path — the :spec
+    ;; rejects the args before the fx is invoked. (If the user disables
+    ;; validation in production, this body would run with the
+    ;; misshapen args, which is harmless for this testbed.)
+    nil))
+
+(rf/reg-event-fx ::violate-fx-args
+  (fn [{:keys [db]} _ev]
+    {:db (update-in db [:click-count :fx] inc)
+     :fx [;; HOT PATH — the fx-args site for :where :fx-args.
+          ;; The registered :spec is [:map [:url :string]]; supplying
+          ;; a vector triggers the per-fx skip path.
+          [::violate-fx ["not-a-map"]]]}))
+
+;; ----------------------------------------------------------------------------
+;; Subs + view
+;; ----------------------------------------------------------------------------
+
+(rf/reg-sub :auth-token   (fn [db _] (get-in db [:auth :token])))
+(rf/reg-sub :app-db-count (fn [db _] (get-in db [:click-count :app-db])))
+(rf/reg-sub :event-count  (fn [db _] (get-in db [:click-count :event])))
+(rf/reg-sub :cofx-count   (fn [db _] (get-in db [:click-count :cofx])))
+(rf/reg-sub :fx-count     (fn [db _] (get-in db [:click-count :fx])))
+
+(reg-view buttons []
+  [:div {:data-testid "schema-violation" :style {:font-family "sans-serif" :padding "1em"}}
+   [:h1 "schema-violation testbed"]
+   [:p "Each button triggers exactly one :where surface of "
+    [:code ":rf.error/schema-validation-failure"] "."]
+   [:div {:style {:display :flex :gap "0.5em" :flex-wrap :wrap}}
+    [:button {:data-testid "violate-app-db"
+              :on-click #(dispatch [::violate-app-db])}
+     "A · :where :app-db (rolled back)"]
+    [:button {:data-testid "violate-event"
+              :on-click #(dispatch [::violate-event "not-a-number"])}
+     "B · :where :event (handler skipped)"]
+    [:button {:data-testid "violate-cofx"
+              :on-click #(dispatch [::violate-cofx])}
+     "C · :where :cofx (handler skipped)"]
+    [:button {:data-testid "violate-fx-args"
+              :on-click #(dispatch [::violate-fx-args])}
+     "D · :where :fx-args (fx skipped)"]]
+   [:p {:style {:margin-top "1em" :color "#666"}}
+    "token=" [:span {:data-testid "auth-token"} @(subscribe [:auth-token])]
+    " · app-db=" [:span {:data-testid "app-db-count"} @(subscribe [:app-db-count])]
+    " · event=" [:span {:data-testid "event-count"} @(subscribe [:event-count])]
+    " · cofx=" [:span {:data-testid "cofx-count"} @(subscribe [:cofx-count])]
+    " · fx=" [:span {:data-testid "fx-count"} @(subscribe [:fx-count])]]])
+
+(reg-view root []
+  [buttons])
+
+;; ----------------------------------------------------------------------------
+;; Mount
+;; ----------------------------------------------------------------------------
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  (rf/dispatch-sync [::initialise])
+  (rdc/render react-root [root]))

--- a/testbeds/schema_violation/index.html
+++ b/testbeds/schema_violation/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: schema-violation</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

First Tier of **rf2-kzcim** — the three load-bearing shared framework-behavior testbed surfaces that unlock ~half the 53 browser-test scenarios catalogued in **rf2-fe84r**. Lives in a new top-level \`testbeds/\` directory per the umbrella decision in **rf2-96nb3** (Mike's YES + colocation, 2026-05-14).

- \`testbeds/deliberate-throw/\` — four buttons that throw at four different layers of the six-domino cascade (handler / fx / flow :output / machine action); each surfaces exactly one \`:rf.error/*\` category per click.
- \`testbeds/schema-violation/\` — four buttons that each fail schema validation at a distinct \`:where\` check-point (\`:app-db\` / \`:event\` / \`:cofx\` / \`:fx-args\`); each carries a different \`:recovery\`.
- \`testbeds/http-toggle/\` — one button + outcome dropdown enumerating the eight \`:rf.http/*\` failure categories of Spec 014 (success via live Fetch; seven failures via the framework-shipped canned-failure stub).

## Scope of this PR

- One commit per testbed surface (rf2-kzcim's enumerated load-bearing trio).
- Source-path widening + per-testbed build entries added to \`implementation/shadow-cljs.edn\` mirroring the existing \`:examples/*\` shape (including the Causa dev preload).
- Per-testbed \`README.md\` documents the trigger sites, the \`:rf.error/*\` (or \`:rf.http/*\`) category each emits, and the test scenarios from rf2-fe84r the surface enables.
- Top-level \`testbeds/README.md\` documents the per-surface conventions, the tools-to-scenarios mapping, and the Tier 2-4 roadmap.

## Out of scope (filed for follow-up)

- **Orchestrator wiring** — \`examples/scripts/serve-and-run-examples-tests.cjs\` currently serves \`implementation/out/examples/\` as its single root; broadening the glob to discover \`testbeds/*/spec.cjs\` and serving \`implementation/out/{examples,testbeds}/\` is mechanical-step-1 territory (**rf2-p8f2s**, in flight). Each testbed compiles cleanly via \`shadow-cljs watch testbeds/<name>\` today.
- **Browser specs** — the per-testbed Playwright specs (the 53-scenario suite) live in **rf2-fe84r**; tools that consume these surfaces own the spec files in their respective \`tools/<tool>/testbeds/<scenario>/spec.cjs\` paths.
- **Tier 2-4 surfaces** — \`multi_frame/\`, \`deep_machine/\`, \`long_flow_w_failure/\`, \`drain_depth_trigger/\`, \`non_trivial_app_db/\`, \`sensitive_dispatcher/\`, \`large_dispatcher/\`, \`known_bad_a11y/\`. The rf2-kzcim umbrella stays open until they land.

## Test plan

- [x] \`shadow-cljs compile testbeds/deliberate-throw\` — clean, 0 warnings.
- [x] \`shadow-cljs compile testbeds/schema-violation\` — clean, 0 warnings.
- [x] \`shadow-cljs compile testbeds/http-toggle\` — clean, 0 warnings.
- [x] \`shadow-cljs release\` on all three — \`:advanced\` compilation succeeds, 0 warnings.
- [x] \`npm run test:cljs\` — 1936 tests / 5513 assertions, 0 failures, 0 errors.
- [x] \`npm run test:bundle-isolation\` — passes; no testbed bleed into the production bundle's sentinel set.
- [ ] \`npm run test:examples\` — pending orchestrator broadening from rf2-p8f2s; testbeds will be picked up once the glob extends to \`testbeds/*\`.

## References

- rf2-96nb3 — [EPIC] examples-split umbrella (Mike's YES + colocation)
- rf2-kzcim — testbeds Tier 1 implementation (this PR closes the Tier 1 portion; the bead stays open for Tier 2-4)
- rf2-fe84r — 53 browser-test scenarios (~half unlocked by this PR)
- rf2-p8f2s — mechanical migration step 1 (in flight; will broaden the orchestrator's glob)
- spec/009 §Error contract — the \`:rf.error/*\` catalogue \`deliberate-throw/\` fires four entries from
- spec/010 §Per-step recovery — the table \`schema-violation/\` walks one button per row from
- spec/014 §Failure categories — the closed-for-v1 vocabulary \`http-toggle/\` enumerates