### PR TITLE
spec(machines-viz-sec): tighten share schema — drop :data + :source-coords (rf2-li3o4)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -61,7 +61,7 @@ unrecognised keys at registration time).
 | `:width` | no | `nil` (flex) | Fixed width in pixels. |
 | `:initial-zoom` | no | `1.0` | Starting zoom factor. The user can zoom/pan after mount; the prop only sets the initial value. |
 | `:auto-pan?` | no | `false` | Whether the chart auto-pans on every transition to keep the active state visible. Causa's panel sets this from its localStorage toggle; the viewer page leaves it off. |
-| `:current-state-override` | no | `nil` | A `{:state ... :data ...}` map that overrides the live snapshot. Used by the read-only viewer page to render the shared snapshot. Out-of-scope for live charts. |
+| `:current-state-override` | no | `nil` | A `{:state ... :data ...}` map that overrides the live snapshot. Used by the read-only viewer page to render the shared snapshot — when sourced from a share URL, `:data` is always absent (the share schema carries `:state` only; per [§Share-URL payload schema](#share-url-payload-schema)). Out-of-scope for live charts. |
 
 The four `:on-*` callback shapes are mirrored from
 [Causa 003 §Source-coord integration](../../causa/spec/003-Machine-Inspector.md#source-coord-integration);
@@ -174,6 +174,15 @@ https://acme.example.com/path/to/viewer.html#machine=<base64-edn>
   read client-side via `location.hash`; nothing sends it.
 - It never loads transit events, app-db slices, or any data
   outside the validated payload schema.
+- It never receives runtime `:data` — the share payload's
+  `:snapshot` carries `:state` only (per
+  [§Share-URL payload schema](#share-url-payload-schema)). The
+  viewer cannot display data values because there are none to
+  display.
+- It never receives local-filesystem `:source-coords` — they are
+  not part of the share schema. The viewer has no editor handler
+  wired, so source coords would be inert anyway; excluding them
+  prevents accidental disclosure of workstation paths.
 - It never enables `:on-*` callbacks. Hosts requesting a "click in
   the viewer goes to my docs site" would have to fork the page;
   the canonical viewer is read-only end-to-end.
@@ -200,13 +209,17 @@ Source: lifted from
 encoder:
 
 1. Validates `chart-state` against the schema. Anything outside the
-   allowlist is silently dropped (per [Principles §No session data
-   in shares](./Principles.md)).
-2. Canonicalises map / set ordering (per
+   allowlist is silently dropped — including runtime `:data` on
+   `:snapshot` and any `:source-coords` the caller passes (per
+   [Principles §No session data in shares](./Principles.md)).
+2. Strips metadata off `:definition` (registered definitions carry
+   source-coord meta per Spec 001; that meta must not propagate
+   into the share payload).
+3. Canonicalises map / set ordering (per
    [Principles §Reproducible from the registry alone](./Principles.md)).
-3. Wraps in the versioned envelope.
-4. EDN-prints → transit-writes → base64url-encodes.
-5. Wraps the fragment into the `:host` URL.
+4. Wraps in the versioned envelope.
+5. EDN-prints → transit-writes → base64url-encodes.
+6. Wraps the fragment into the `:host` URL.
 
 ### Decoder
 
@@ -239,6 +252,26 @@ Per [DESIGN-RATIONALE Lock #3](./DESIGN-RATIONALE.md).
 
 ### Share-URL payload schema
 
+Share URLs are **viewer-side artefacts** — they exist solely to let
+a remote recipient render the chart. The schema is deliberately
+narrow: it carries the machine topology and the active-state
+**name** for visual continuity, and nothing else. Two classes of
+data are structurally excluded:
+
+- **Runtime `:data`** — the machine's per-snapshot data value is
+  not part of the share payload. A well-intentioned operator
+  clicking "Copy as Share URL" must not be able to exfiltrate
+  tokens, form contents, request payloads, or any other sensitive
+  value the running machine has accumulated. Per
+  [Principles §No session data in shares](./Principles.md).
+- **Local-filesystem `:source-coords`** — source coordinates carry
+  absolute file paths (per [`spec/Spec-Schemas.md` §`:rf/source-coord-meta`](../../../spec/Spec-Schemas.md#rfsource-coord-meta))
+  which reveal usernames, workstation layout, and internal repo
+  structure. Source-coord chips are an editor-side affordance for
+  the operator running Causa; the viewer page has **no editor
+  handler wired** and cannot use them. They are dropped at encode
+  time.
+
 ```clojure
 (def ShareEnvelope
   [:map
@@ -251,27 +284,42 @@ Per [DESIGN-RATIONALE Lock #3](./DESIGN-RATIONALE.md).
    [:machine-id  keyword?]              ;; the registered machine's id
    [:frame-id    keyword?]              ;; the registered machine's frame
    [:definition  MachineDefinition]     ;; the topology (states, transitions, guards, actions, :invoke, :invoke-all, :after)
-   [:snapshot   {:optional true}        ;; the current-state snapshot at share time
-    [:map
-     [:state    keyword?]
-     [:data     :any]
-     [:meta?   {:optional true} :any]]]
-   [:source-coords {:optional true}     ;; topology source-coords (per Spec 001) — only included if present in definition meta
-    [:map-of :any :any]]])
+   [:snapshot   {:optional true}        ;; the current-state name at share time — name ONLY, no :data
+    [:map {:closed true}
+     [:state    keyword?]]]])           ;; the registered state-id; nothing else permitted in :snapshot
 ```
+
+The `:snapshot` map is `{:closed true}` and carries `:state` only.
+Runtime `:data` is structurally absent from the share payload; the
+encoder neither reads nor serialises it. The decoder rejects any
+`:snapshot` carrying additional keys with `:invalid-chart-state`.
+The viewer page mounts `MachineChart` with `:current-state-override`
+set to `{:state <state-name>}` (and `:data` therefore `nil`); the
+chart pulses the state node without any data-driven affordance.
+
+`:source-coords` is **not a top-level key** of `ChartState`. Source
+coords live only in the operator-side `(rf/machine-meta machine-id)`
+return value and never traverse the share pipeline. The viewer page
+renders with `:on-state-click` / `:on-transition-click` etc.
+no-op'd (per [§Read-only viewer](#read-only-viewer)), so the
+absence of source coords is observationally invisible.
 
 The `MachineDefinition` shape matches the `reg-machine` registered
 definition (per Spec 005 §Snapshot shape + §Transition table grammar)
 with **only** the topology slots included — `:guards` and `:actions`
 maps are encoded as **names only** (their fn bodies are not
 serialised; consumers re-resolve against their own registry if they
-want to run the machine). The viewer page never resolves them; it
-only renders.
+want to run the machine). The encoder **strips metadata** off the
+definition before serialisation (registered definitions carry
+source-coord meta per Spec 001; that meta does not propagate). The
+viewer page never resolves guards or actions; it only renders.
 
 Anything not in the schema is silently dropped by the encoder. New
-top-level keys require an explicit `:rf.machines-viz.share/allow?`
-opt-in (per [Principles §No session data in shares](./Principles.md));
-CI enforces.
+top-level keys (and any future expansion of `:snapshot`) require
+an explicit `:rf.machines-viz.share/allow?` opt-in plus an
+operator-controlled redaction hook (per
+[Principles §No session data in shares](./Principles.md)); CI
+enforces.
 
 ### URL length
 

--- a/tools/machines-viz/spec/DESIGN-RATIONALE.md
+++ b/tools/machines-viz/spec/DESIGN-RATIONALE.md
@@ -261,12 +261,13 @@ covered by complementary surfaces.
 
 ---
 
-## Lock #5 — Current-state in share-URL: snapshot, not history
+## Lock #5 — Current-state in share-URL: state name only, no `:data`
 
-**Locked 2026-05-13 (Mike, lifted from Causa 003).** **The
-share-URL payload carries the topology + a single current-state
-snapshot. No transition history; no event vector; no app-db
-slices.**
+**Locked 2026-05-13 (Mike, lifted from Causa 003; tightened
+2026-05-14 per rf2-li3o4).** **The share-URL payload carries the
+topology + the current state's name (`:state` keyword only). No
+runtime `:data`; no transition history; no event vector; no
+app-db slices; no source-coords.**
 
 ### Question
 
@@ -282,35 +283,53 @@ What state-information does the share-URL carry?
   last N transitions on load. Rejected — encodes session data,
   violates the no-session-export principle (Causa Lock #4 lifted),
   inflates the URL beyond practical limits.
-- **Topology + a single current-state snapshot.** The chart
-  renders with the snapshot's state highlighted. The recipient
-  has a "show idle" toggle to clear it.
+- **Topology + full snapshot (state + `:data`).** The original
+  lift from Causa 003. Rejected (rf2-li3o4) — `:data` is operator-
+  side runtime accumulation; a well-intentioned "Copy as Share
+  URL" click would exfiltrate tokens, form contents, and request
+  payloads. The accident-class beats the visual-continuity
+  marginal benefit.
+- **Topology + the state name only.** The chart highlights the
+  active state node; `:data` is unavailable to the viewer (which
+  has no per-data affordance anyway — the chart's data display
+  is operator-side, in Causa's inspector chrome). The recipient
+  has a "show idle" toggle to clear the highlight.
 
 ### Pick
 
-**Topology + a single current-state snapshot.**
+**Topology + the state name only (`:snapshot` is `{:closed true}`
+with `:state` only).**
 
 ### Why
 
-- **Visual continuity** — the recipient sees what the sharer was
-  looking at, the canonical case for sharing a chart.
+- **Visual continuity holds** — the recipient sees which state the
+  sharer was in; the pulse / highlight needs the state name only.
+  The chart's data display is operator-side chrome (Causa's
+  inspector panel), not a `MachineChart` affordance.
+- **Privacy is structural, not prose** — the encoder cannot emit
+  `:data` because the schema is `{:closed true}` on `:snapshot`.
+  Operators cannot accidentally share runtime values; an
+  operator who wants to share a data value pastes it explicitly
+  via a different channel.
 - **Reproducible-from-registry-alone** holds for the topology;
-  the snapshot is the only non-reproducible bit and is purely a
-  visual hint.
-- **Privacy holds** — no event vectors, no app-db slices, no user
-  inputs. A snapshot is the machine's `:state` keyword plus its
-  `:data` value (which the machine author controls); if the
-  machine author put sensitive data in `:data`, they should treat
-  the registered machine as code, which is the same rule that
-  applies to source. The share-URL does not leak run-time data.
+  the state name is the only non-reproducible bit and is purely
+  a visual hint.
 - **"Show idle" toggle** — the viewer page offers a one-click
   "clear active state" if the recipient wants to discuss the
   machine in the abstract. Causa 003 §Share-URL §Read-only viewer
   specifies this affordance.
+- **No source-coords either** — source coords carry absolute file
+  paths; the viewer has no editor handler wired; they are
+  structurally absent from the share schema. Definition metadata
+  is stripped before serialisation so macro-captured coords cannot
+  leak through `:definition` either.
 
 Source: lifted from Causa
 [`003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md)
-§Share-URL §NOT a session export + §Privacy posture.
+§Share-URL §NOT a session export + §Privacy posture, then
+tightened per the rf2-li3o4 security audit (the lift carried a
+broader `:data :any` than this jar's Principles permitted; the
+schema now matches the Principles).
 
 ---
 

--- a/tools/machines-viz/spec/Principles.md
+++ b/tools/machines-viz/spec/Principles.md
@@ -102,11 +102,31 @@ upgrading."
 
 ## No session data in shares
 
-The share-URL serialises **only** machine topology + a single
-current-state snapshot.
+A share URL is a **viewer-side artefact**: its only job is to let
+a remote recipient render the chart. Anything that exists for the
+operator's local convenience (runtime data values, editor jumps,
+filesystem paths) must not propagate. The share-URL serialises
+**only** machine topology + the current state's **name** for
+visual continuity.
 
 Forbidden in a share payload:
 
+- **Runtime `:data` from the machine snapshot.** A machine's `:data`
+  value may carry tokens, form contents, request payloads, or any
+  other runtime accumulation. The share schema's `:snapshot` map
+  is `{:closed true}` and carries `:state` only; `:data` is
+  structurally absent. This is the highest-priority class of
+  exclusion — the accident the schema protects against is a well-
+  intentioned operator clicking "Copy as Share URL" without
+  realising the snapshot is included.
+- **Local-filesystem `:source-coords`.** Source coords carry
+  absolute file paths (per
+  [`spec/Spec-Schemas.md` §`:rf/source-coord-meta`](../../../spec/Spec-Schemas.md#rfsource-coord-meta))
+  revealing usernames, workstation layout, and internal repo
+  structure. They have no use to the remote viewer (the viewer
+  page has no editor handler wired) and are dropped at encode
+  time. Definition metadata is stripped before serialisation so
+  that macro-captured coords on the topology cannot leak either.
 - Trace events (no event vectors; no dispatch ids; no causal walk).
 - Epoch history (no app-db slices outside `[:rf/machines <id>]`).
 - User-input data (no form values, no inputs the user typed).
@@ -118,14 +138,19 @@ Forbidden in a share payload:
 The principle exists because the framework's runtime carries
 sensitive data by default (per
 [Spec 009 §Privacy](../../../spec/009-Instrumentation.md)). A share-
-URL that exfiltrates trace events is a privacy hole; we close it
-structurally. Per Causa Lock #4 — Session export, lifted here.
+URL that exfiltrates trace events is a privacy hole; one that
+exfiltrates `:data` is the same hole through a different door; one
+that leaks `:file` paths is a smaller hole but the same accident-
+class. We close all three structurally. Per Causa Lock #4 — Session
+export, lifted here.
 
 The encoder is the gatekeeper: it accepts a `chart-state` value and
-silently drops anything outside the allowlist before serialising.
-The allowlist lives in [`API.md`](./API.md) §Share-URL payload
-schema; CI tests enforce that any new top-level key requires an
-explicit `:rf.machines-viz.share/allow?` opt-in.
+silently drops anything outside the allowlist before serialising —
+including runtime `:data` on `:snapshot` and any `:source-coords`
+the caller passes. The allowlist lives in [`API.md`](./API.md)
+§Share-URL payload schema; CI tests enforce that any new top-level
+key requires an explicit `:rf.machines-viz.share/allow?` opt-in
+plus an operator-controlled redaction hook.
 
 ## Reproducible from the registry alone
 


### PR DESCRIPTION
## Summary

Address the three findings from the **rf2-li3o4** P2 security audit of `tools/machines-viz`. The share-URL schema (lifted from Causa 003) contradicted the surrounding privacy prose: it allowed arbitrary `:data` on `:snapshot`, included `:source-coords` as a top-level key, and typed the source-coords allowlist as `[:map-of :any :any]`. All three are accident-class data-exfiltration vectors via "Copy as Share URL".

Spec-only — `tools/machines-viz` has no impl code yet. Edits confined to `tools/machines-viz/spec/**`. No core spec docs touched.

## Findings addressed

1. **High — arbitrary `:data` on snapshot.** `:snapshot` is now `{:closed true}` with `:state` only; runtime `:data` is structurally absent from the share payload. Encoder cannot emit it; decoder rejects it.
2. **Medium — `:source-coords` exposes local filesystem paths.** Removed entirely from `ChartState`. Encoder also strips metadata off `:definition` before serialisation so macro-captured coords cannot leak through the topology.
3. **Medium — `[:map-of :any :any]` nested allowlist.** Moot: the key is gone.

Cross-tool privacy claim in `tools/causa/spec/003-Machine-Inspector.md` lines 230-234 ("no run-time data" / "no user data") is now matched **structurally** by the schema, not merely by prose.

## Changes

- `tools/machines-viz/spec/API.md` — schema tightened; encoder pipeline gains an explicit metadata-strip step; viewer "what it never does" list extended; `:current-state-override` prop description clarified.
- `tools/machines-viz/spec/Principles.md` — §No session data in shares rewritten with `:data` and `:source-coords` as highest-priority exclusion classes; framed as accident-gating per Mike's pragmatic stance.
- `tools/machines-viz/spec/DESIGN-RATIONALE.md` — Lock #5 retitled and tightened to "state name only, no `:data`"; lift-then-tighten trail back to Causa 003 documented.

LoC delta: `+139 / −47` across 3 files.

## Test plan

- [x] `mkdocs build --strict` from repo root — 20 warnings, identical to baseline `origin/main` (all pre-existing; none introduced).
- [x] `tools/machines-viz/spec/**` not in mkdocs nav (per-tool spec convention).
- [x] No impl code touched (none exists).
- [x] No core `spec/*.md` touched; `spec/Spec-Schemas.md` read-only.

Closes rf2-li3o4.