### PR TITLE
fix(causa-sec): chip-clicked allowlist + open-in-editor scheme guard (rf2-cm93v)

### DIFF
--- a/tools/causa/spec/014-Registry-Catalogue.md
+++ b/tools/causa/spec/014-Registry-Catalogue.md
@@ -463,7 +463,7 @@ process and reload-safely.
 | `:rf.causa/copilot-stream-token` | `[_ token]` | Appends one streamed token to the in-flight answer. |
 | `:rf.causa/copilot-stream-end` | `[_]` | Marks the in-flight turn as no-longer streaming. |
 | `:rf.causa/copilot-clear-conversation` | `[_]` | Clears the buffer. Per spec §Ephemeral conversation, in-memory only. |
-| `:rf.causa/copilot-chip-clicked` | `[_ {:target :value}]` | `event-fx` — dispatches the resolved target with the chip's value. Unknown chips no-op. |
+| `:rf.causa/copilot-chip-clicked` | `[_ {:chip-key :value}]` | `event-fx` — resolves the target server-side from the fixed `chip-targets` allowlist in `ai-co-pilot-helpers` and dispatches it with the chip's value as arg. Unknown chip-keys no-op. Per rf2-cm93v the handler accepts only `:chip-key` + `:value`; any caller-supplied `:target` slot is ignored. |
 
 ### Effects
 

--- a/tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs
@@ -9,8 +9,23 @@
   machine inspector state/edge/guard/action, hydration debugger, etc.)
   wrap the coord in a clickable chip that launches the user's editor
   at file:line. Phase 1 ships the helper + the shell-stub demo
-  surface; the live panels consume this in subsequent phases."
-  (:require [day8.re-frame2-causa.config :as config]
+  surface; the live panels consume this in subsequent phases.
+
+  ## Defense-in-depth scheme allowlist (rf2-cm93v)
+
+  `editor-uri/editor-uri` already rejects `javascript:` / `data:` /
+  `vbscript:` for `{:custom ...}` templates (per rf2-vwcsq). This ns
+  adds a second, positive-allowlist gate at the launch boundary —
+  before assigning to `window.location` we verify the final URI's
+  scheme is in `allowed-editor-uri-schemes`. Anything outside the set
+  (in particular `http:` / `https:` / new bad schemes we did not
+  anticipate) is rejected at the click-time seam. Per spec/Security.md
+  §Pragmatic stance the rationale is 'gate accidents, not theoretical
+  attacks' — a custom template that resolves to `https://...` would
+  navigate the page rather than launch an editor; the allowlist makes
+  that an obvious no-op rather than a silent surprise."
+  (:require [clojure.string :as str]
+            [day8.re-frame2-causa.config :as config]
             [re-frame.source-coords.editor-uri :as editor-uri]))
 
 ;; ---- styling -------------------------------------------------------------
@@ -33,6 +48,69 @@
           :display         "inline-block"
           :line-height     "16px"}})
 
+;; ---- scheme allowlist (rf2-cm93v) ----------------------------------------
+
+(def ^:const allowed-editor-uri-schemes
+  "Positive allowlist of URI schemes the launcher will hand off to the
+  OS. Anything outside the set is refused at the `open!` boundary.
+
+  Members:
+   - `vscode:`            VS Code
+   - `vscode-insiders:`   VS Code Insiders
+   - `cursor:`            Cursor (VS Code fork)
+   - `windsurf:`          Windsurf (VS Code fork)
+   - `zed:`               Zed
+   - `idea:`              JetBrains (IDEA, WebStorm, PyCharm, …)
+   - `jetbrains:`         JetBrains alt scheme
+   - `fleet:`             JetBrains Fleet
+   - `subl:`              Sublime Text
+   - `emacs:` / `emacsclient:` / `org-protocol:`  Emacs family
+   - `vim:` / `nvim:` / `mvim:`                    Vim family
+   - `txmt:`              TextMate
+   - `atom:`              Atom (legacy but still launchable)
+   - `file:`              host-resolved file URL
+
+  Per rf2-cm93v this is intentionally a positive list, not a reject
+  list — pre-cm93v the editor-template surface relied on `editor-uri`'s
+  three-scheme reject (`javascript:` / `data:` / `vbscript:`) which
+  failed open against `http:` / `https:` and any scheme that hadn't
+  been catalogued as bad yet."
+  #{"vscode" "vscode-insiders"
+    "cursor" "windsurf"
+    "zed"
+    "idea" "jetbrains" "fleet"
+    "subl"
+    "emacs" "emacsclient" "org-protocol"
+    "vim" "nvim" "mvim"
+    "txmt"
+    "atom"
+    "file"})
+
+(defn- uri-scheme
+  "Return the URI's leading scheme as a lower-case string, sans the
+  trailing `:`. Returns nil when `uri` is not a string, has no scheme,
+  or the scheme is empty.
+
+  Tolerates leading whitespace so an attacker template like
+  `\" javascript:...\"` (which would `triml` away before the browser
+  parsed it) still produces the right scheme for the allowlist check."
+  [uri]
+  (when (string? uri)
+    (let [trimmed (str/triml uri)
+          colon-ix (str/index-of trimmed ":")]
+      (when (and colon-ix (pos? colon-ix))
+        (str/lower-case (subs trimmed 0 colon-ix))))))
+
+(defn allowed-uri?
+  "Predicate — true iff `uri`'s scheme is in `allowed-editor-uri-schemes`.
+  Pure data → boolean; safe to call from tests and from the click-time
+  guard in `open!`. Per rf2-cm93v: positive allowlist, defense-in-depth
+  alongside `editor-uri`'s three-scheme reject."
+  [uri]
+  (boolean
+    (when-let [scheme (uri-scheme uri)]
+      (contains? allowed-editor-uri-schemes scheme))))
+
 ;; ---- side-effect: open the editor ----------------------------------------
 
 (defn- open!
@@ -41,11 +119,15 @@
 
   Per rf2-vwcsq: `uri` is the return of `editor-uri/editor-uri`, which
   already rejects `javascript:` / `data:` / `vbscript:` schemes by
-  returning `nil`. The `(when uri ...)` guard below is the single
-  enforcement seam at the call sites that consume `editor-uri` (this fn
-  + Story's mirror `re-frame.story.ui.open-in-editor/open!`)."
+  returning `nil`. Per rf2-cm93v this fn applies a second, positive
+  allowlist gate (`allowed-uri?`) before handing the URI off — closing
+  the `http:` / `https:` / unknown-scheme path that a `{:custom ...}`
+  template could otherwise resolve to. A rejected URI is a click-time
+  no-op (no navigation, no console noise — the chip's `(when uri ...)`
+  earlier guard handles the absent case; the allowlist handles the
+  shaped-but-disallowed case)."
   [uri]
-  (when (and uri js/window)
+  (when (and uri (allowed-uri? uri) js/window)
     (set! (.-location js/window) uri)
     nil))
 
@@ -56,8 +138,12 @@
   editor preference from `config/get-editor`; builds the URI via
   `editor-uri/editor-uri`; click fires `window.location.href`.
 
-  Returns nil when the source-coord lacks a usable `:file` slot — the
-  UI hides the chip rather than rendering a no-op.
+  Returns nil when the source-coord lacks a usable `:file` slot, when
+  `editor-uri/editor-uri` returns nil (a scheme rejected by the
+  `editor-uri`-side gate per rf2-vwcsq), or when the resolved URI's
+  scheme is not in `allowed-editor-uri-schemes` (the Causa-side
+  positive allowlist per rf2-cm93v). The UI hides the chip rather than
+  rendering an unclickable affordance.
 
   Source-coord shape: `{:file :line :column :ns}` per
   `re-frame.source-coords`. Causa receives source-coords on the trace
@@ -67,7 +153,7 @@
   (when (editor-uri/has-source? source-coord)
     (let [editor (config/get-editor)
           uri    (editor-uri/editor-uri editor source-coord)]
-      (when uri
+      (when (and uri (allowed-uri? uri))
         [:a {:style       (:chip chip-styles)
              :href        uri
              :title       (editor-uri/open-button-title source-coord)

--- a/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot.cljs
@@ -107,19 +107,20 @@
   as source-coord chips (`bg-3`, `radius-sm`, 12px caption type) so
   the eye reads them as first-class data, not decoration.
 
-  Glyph encodes type; click dispatches the chip's target with the
-  chip's value conj'd as the final positional arg. Per spec §Failure
+  Glyph encodes type; click dispatches `:rf.causa/copilot-chip-clicked`
+  with only `:chip-key` + `:value`. The handler resolves the target
+  from the fixed `chip-targets` allowlist server-side — the caller
+  cannot supply an arbitrary target (per rf2-cm93v). Per spec §Failure
   modes the renderer never invents chips from free text — only
   fragments the model emitted in the structured form get this
   treatment. Resolution failure is visible (the click target may
   resolve to a no-longer-present runtime id) but not predicted: the
   runtime is the truth."
-  [{:keys [chip-key value glyph target] :as _resolved}]
+  [{:keys [chip-key value glyph] :as _resolved}]
   [:button {:data-testid (str "rf-causa-copilot-chip-" (name chip-key))
             :on-click    #(rf/dispatch [:rf.causa/copilot-chip-clicked
                                         {:chip-key chip-key
-                                         :value    value
-                                         :target   target}] {:frame :rf/causa})
+                                         :value    value}] {:frame :rf/causa})
             :title       (str chip-key " " (pr-str value))
             :style       {:display       "inline-flex"
                           :align-items   "center"
@@ -623,13 +624,20 @@
             (assoc :copilot-streaming-token-count 0))))
 
     ;; Handle a chip click. Per spec §Chip types each chip's click
-    ;; target is the panel-jump event for that chip kind. The handler
-    ;; dispatches the resolved target with the chip's value as the
-    ;; argument. Unknown chips are no-ops (defensive — the renderer
-    ;; should not produce chips with unknown targets).
+    ;; target is the panel-jump event for that chip kind. Per rf2-cm93v
+    ;; the handler resolves `target` server-side from the fixed
+    ;; `chip-targets` allowlist — the caller may NOT supply a target
+    ;; slot (any caller-supplied target is ignored). Unknown chip-keys
+    ;; are no-ops.
+    ;;
+    ;; Frame containment: this handler runs on the `:rf/causa` frame
+    ;; (it's registered through `register-causa-handlers!` and the
+    ;; chip-view dispatches with `{:frame :rf/causa}`), so the follow-
+    ;; on `:dispatch` fx routes through the same frame's router. The
+    ;; resolved target cannot escape into the host frame.
     (register-evfx! :rf.causa/copilot-chip-clicked
-      (fn [_cofx [_ {:keys [target value]}]]
-        (when target
+      (fn [_cofx [_ {:keys [chip-key value]}]]
+        (when-let [target (get h/chip-targets chip-key)]
           {:fx [[:dispatch [target value]]]})))
 
     ;; ---- effects -----------------------------------------------------

--- a/tools/causa/test/day8/re_frame2_causa/open_in_editor_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/open_in_editor_cljs_test.cljs
@@ -60,3 +60,105 @@
     (is (nil? (open-in-editor/open-chip nil)))
     (is (nil? (open-in-editor/open-chip {:line 1})))
     (is (nil? (open-in-editor/open-chip {:file ""})))))
+
+;; ---- rf2-cm93v — scheme allowlist (defense-in-depth) -------------------
+
+(deftest allowed-uri-accepts-builtin-editor-schemes
+  (testing "the built-in editor schemes pass the allowlist"
+    (is (open-in-editor/allowed-uri? "vscode://file/src/x.cljs:1:1"))
+    (is (open-in-editor/allowed-uri? "cursor://file/src/x.cljs:1:1"))
+    (is (open-in-editor/allowed-uri? "windsurf://file/src/x.cljs:1:1"))
+    (is (open-in-editor/allowed-uri? "zed://file/src/x.cljs:1:1"))
+    (is (open-in-editor/allowed-uri?
+          "idea://open?file=src/x.cljs&line=1&column=1"))))
+
+(deftest allowed-uri-accepts-other-editor-schemes
+  (testing "other catalogued editor schemes pass — emacs / vim / sublime
+            family, jetbrains alt, file:"
+    (is (open-in-editor/allowed-uri? "subl://open?path=src/x.cljs"))
+    (is (open-in-editor/allowed-uri? "emacs:src/x.cljs"))
+    (is (open-in-editor/allowed-uri? "emacsclient://src/x.cljs"))
+    (is (open-in-editor/allowed-uri? "vim://src/x.cljs"))
+    (is (open-in-editor/allowed-uri? "nvim://src/x.cljs"))
+    (is (open-in-editor/allowed-uri? "txmt://open?url=file://src/x.cljs"))
+    (is (open-in-editor/allowed-uri? "jetbrains://idea/src/x.cljs"))
+    (is (open-in-editor/allowed-uri? "file:///abs/path/src/x.cljs"))))
+
+(deftest allowed-uri-rejects-javascript-scheme
+  (testing "javascript: is rejected — in-tab script execution vector"
+    (is (not (open-in-editor/allowed-uri? "javascript:alert(1)")))
+    (is (not (open-in-editor/allowed-uri? "JavaScript:alert(1)")))
+    (is (not (open-in-editor/allowed-uri? "JAVASCRIPT:alert(1)")))))
+
+(deftest allowed-uri-rejects-data-scheme
+  (testing "data: is rejected — inline-rendered HTML / script vector"
+    (is (not (open-in-editor/allowed-uri?
+               "data:text/html,<script>alert(1)</script>")))
+    (is (not (open-in-editor/allowed-uri?
+               "data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==")))))
+
+(deftest allowed-uri-rejects-http-scheme
+  (testing "http: is rejected — a custom editor template that resolves
+            to `http://...` would navigate the page rather than launch
+            an editor (rf2-cm93v)"
+    (is (not (open-in-editor/allowed-uri? "http://evil.example/x")))
+    (is (not (open-in-editor/allowed-uri? "HTTP://evil.example/x")))))
+
+(deftest allowed-uri-rejects-https-scheme
+  (testing "https: is rejected — same navigation vector as http:"
+    (is (not (open-in-editor/allowed-uri? "https://evil.example/x")))
+    (is (not (open-in-editor/allowed-uri? "HTTPS://evil.example/x")))))
+
+(deftest allowed-uri-rejects-vbscript-scheme
+  (testing "vbscript: is rejected — legacy IE / WebView2 script vector"
+    (is (not (open-in-editor/allowed-uri? "vbscript:msgbox(1)")))))
+
+(deftest allowed-uri-handles-non-string-and-empty
+  (testing "non-string / empty / scheme-less URIs are rejected"
+    (is (not (open-in-editor/allowed-uri? nil)))
+    (is (not (open-in-editor/allowed-uri? "")))
+    (is (not (open-in-editor/allowed-uri? "no-scheme-here")))
+    (is (not (open-in-editor/allowed-uri? ":leading-colon")))))
+
+(deftest allowed-uri-tolerates-leading-whitespace
+  (testing "leading whitespace doesn't disguise a forbidden scheme"
+    (is (not (open-in-editor/allowed-uri? " javascript:alert(1)")))
+    (is (not (open-in-editor/allowed-uri? "\thttp://evil.example/x")))
+    (is (open-in-editor/allowed-uri? " vscode://file/src/x.cljs:1:1"))))
+
+(deftest open-chip-hides-when-custom-template-resolves-to-unsafe-scheme
+  (testing "open-chip returns nil when the resolved URI's scheme is not
+            in `allowed-editor-uri-schemes` (rf2-cm93v). Defense-in-depth
+            alongside the editor-uri-side javascript:/data:/vbscript:
+            reject from rf2-vwcsq — closes the http:/https:/etc. surface
+            an upstream {:custom ...} template could otherwise resolve
+            to."
+    ;; editor-uri/editor-uri already gates javascript:/data:/vbscript:
+    ;; — for these the chip is nil regardless of the Causa-side
+    ;; allowlist. Verify those cases still hide.
+    (config/configure! {:editor {:custom "javascript:alert(1)"}})
+    (is (nil? (open-in-editor/open-chip {:file "src/x.cljs"})))
+
+    (config/configure! {:editor {:custom "data:text/html,xxx"}})
+    (is (nil? (open-in-editor/open-chip {:file "src/x.cljs"})))
+
+    ;; http: is NOT in editor-uri's reject list — the Causa-side
+    ;; allowlist is the seam that catches it.
+    (config/configure! {:editor {:custom "http://evil.example/{path}"}})
+    (is (nil? (open-in-editor/open-chip {:file "src/x.cljs"})))
+
+    ;; Same for https:
+    (config/configure! {:editor {:custom "https://evil.example/{path}"}})
+    (is (nil? (open-in-editor/open-chip {:file "src/x.cljs"})))))
+
+(deftest open-chip-renders-when-custom-template-resolves-to-safe-scheme
+  (testing "open-chip renders normally when the resolved URI's scheme
+            is in `allowed-editor-uri-schemes` (rf2-cm93v positive
+            half)"
+    (config/configure! {:editor {:custom "subl://open?path={path}&line={line}"}})
+    (let [hiccup (open-in-editor/open-chip {:file "src/x.cljs" :line 5})]
+      (is (vector? hiccup))
+      (is (= "subl://open?path=src/x.cljs&line=5" (:href (second hiccup)))))
+
+    (config/configure! {:editor {:custom "emacsclient://{path}"}})
+    (is (some? (open-in-editor/open-chip {:file "src/x.cljs"})))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_cljs_test.cljs
@@ -415,7 +415,8 @@
 ;; ---- (8) chip click routes panel-jump ----------------------------------
 
 (deftest chip-click-routes-dispatch-id-target
-  (testing ":rf.causa/copilot-chip-clicked dispatches the chip's target
+  (testing ":rf.causa/copilot-chip-clicked resolves the target from the
+            fixed `chip-targets` allowlist (rf2-cm93v) and dispatches it
             with the chip's value as arg"
     (registry/register-causa-handlers!)
     (install-llm-capture-fx!)
@@ -424,8 +425,7 @@
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/copilot-chip-clicked
                          {:chip-key :dispatch-id
-                          :value    100
-                          :target   :rf.causa/select-dispatch-id}]))
+                          :value    100}]))
     (is (= [[:rf.causa/select-dispatch-id 100]]
            (chip-dispatches)))))
 
@@ -437,9 +437,85 @@
   (rf/with-frame :rf/causa
     (rf/dispatch-sync [:rf.causa/copilot-chip-clicked
                        {:chip-key :epoch-number
-                        :value    47
-                        :target   :rf.causa/select-epoch}]))
+                        :value    47}]))
   (is (= [[:rf.causa/select-epoch 47]] (chip-dispatches))))
+
+;; ---- (8a) rf2-cm93v — chip-click target allowlist ---------------------
+
+(deftest chip-click-rejects-unknown-chip-key
+  (testing "per rf2-cm93v — unknown `:chip-key` is a no-op; no dispatch
+            fires. Pre-cm93v the handler trusted a caller-supplied
+            `:target`, turning `:rf.causa/copilot-chip-clicked` into an
+            arbitrary-dispatch gadget. The handler now resolves the
+            target from the fixed `chip-targets` map and ignores
+            anything outside it."
+    (registry/register-causa-handlers!)
+    (install-llm-capture-fx!)
+    (install-chip-capture!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/copilot-chip-clicked
+                         {:chip-key :totally-unknown
+                          :value    42}])
+      (rf/dispatch-sync [:rf.causa/copilot-chip-clicked
+                         {:chip-key nil
+                          :value    "anything"}]))
+    (is (= [] (chip-dispatches))
+        "unknown chip-keys produce no follow-on dispatch")))
+
+(deftest chip-click-ignores-caller-supplied-target
+  (testing "per rf2-cm93v — a caller-supplied `:target` slot is IGNORED.
+            The handler always resolves the target from the fixed
+            `chip-targets` allowlist. A caller cannot smuggle an
+            arbitrary event id through the `:target` slot to trigger
+            host-app events."
+    (registry/register-causa-handlers!)
+    (install-llm-capture-fx!)
+    (install-chip-capture!)
+    ;; Register a sentinel handler the attacker would aim at. If the
+    ;; old behaviour leaked through, this would record the dispatch.
+    (let [evil-fired (atom 0)]
+      (rf/reg-event-fx :evil/host-event
+        (fn [_cofx _ev] (swap! evil-fired inc) nil))
+      (frame/reg-frame :rf/causa {})
+      (rf/with-frame :rf/causa
+        (rf/dispatch-sync [:rf.causa/copilot-chip-clicked
+                           {:chip-key :dispatch-id
+                            :value    100
+                            ;; Attacker-supplied target — must be
+                            ;; ignored. The allowlist-resolved target
+                            ;; for `:dispatch-id` is
+                            ;; `:rf.causa/select-dispatch-id`.
+                            :target   :evil/host-event}]))
+      (is (= 0 @evil-fired)
+          "caller-supplied :target did not fire :evil/host-event")
+      (is (= [[:rf.causa/select-dispatch-id 100]] (chip-dispatches))
+          "the allowlist-resolved target fired instead"))))
+
+(deftest chip-click-allowlist-covers-all-chip-keys
+  (testing "every chip-key in `chip-key-set` resolves to its target via
+            the allowlist. The four supported kinds round-trip; this is
+            the positive half of the rf2-cm93v gate (the negative half
+            is the unknown-chip-key rejection above)."
+    (registry/register-causa-handlers!)
+    (install-llm-capture-fx!)
+    (install-chip-capture!)
+    (frame/reg-frame :rf/causa {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/copilot-chip-clicked
+                         {:chip-key :dispatch-id  :value 1}])
+      (rf/dispatch-sync [:rf.causa/copilot-chip-clicked
+                         {:chip-key :path         :value [:a :b]}])
+      (rf/dispatch-sync [:rf.causa/copilot-chip-clicked
+                         {:chip-key :epoch-number :value 47}])
+      (rf/dispatch-sync [:rf.causa/copilot-chip-clicked
+                         {:chip-key :handler-id   :value :foo/bar}]))
+    (is (= [[:rf.causa/select-dispatch-id   1]
+            [:rf.causa.copilot/open-path    [:a :b]]
+            [:rf.causa/select-epoch         47]
+            [:rf.causa.copilot/open-handler :foo/bar]]
+           (chip-dispatches))
+        "every chip-key resolved through `chip-targets`")))
 
 ;; ---- (9) rendered tree contracts ---------------------------------------
 


### PR DESCRIPTION
## Summary

Two HIGH security fixes from the rf2-cm93v audit, both mechanical "gate the accident" tightenings that match Mike's pragmatic stance (spec/Security.md):

- **Chip-clicked allowlist** (`tools/causa/.../panels/ai_co_pilot.cljs`) — `:rf.causa/copilot-chip-clicked` used to trust a caller-supplied `:target`, turning it into an arbitrary-dispatch gadget that broke the co-pilot's read-only contract. The handler now accepts only `:chip-key` + `:value` and resolves the target server-side from the fixed `chip-targets` allowlist in `ai-co-pilot-helpers`. Unknown chip-keys no-op; caller-supplied `:target` slots are ignored. Frame containment is unchanged — the handler runs on `:rf/causa`, so the follow-on dispatch routes through Causa's router.

- **Open-in-editor positive scheme allowlist** (`tools/causa/.../open_in_editor.cljs`) — defense-in-depth alongside `editor-uri`'s existing `javascript:` / `data:` / `vbscript:` reject from rf2-vwcsq. Adds `allowed-editor-uri-schemes` (vscode, cursor, windsurf, zed, idea, jetbrains, fleet, subl, emacs/emacsclient/org-protocol, vim/nvim/mvim, txmt, atom, file, etc.) checked at two seams: `open-chip` hides the chip when the resolved URI's scheme is not in the allowlist; `open!` rejects at the `window.location` boundary. Closes the `http:` / `https:` / unknown-scheme path that a `{:custom ...}` template could otherwise resolve to.

Spec catalogue (tools/causa/spec/014-Registry-Catalogue.md) updated to reflect the tightened `:rf.causa/copilot-chip-clicked` arg shape.

## Test plan

- [x] `npm run test:cljs` — 1982 tests / 5627 assertions, 0 failures, 0 errors
- [x] `npm run test:bundle-isolation` — PASS
- [x] New tests cover:
  - chip-clicked rejects unknown chip-keys (no-op, no follow-on dispatch)
  - chip-clicked ignores caller-supplied `:target` (sentinel `:evil/host-event` never fires)
  - chip-clicked allowlist round-trips for all four chip-keys
  - allowed-uri? accepts vscode://, cursor://, windsurf://, zed://, idea://, subl://, emacs:, vim://, file://, etc.
  - allowed-uri? rejects `javascript:`, `data:`, `vbscript:`, `http:`, `https:` (each with case-insensitivity and leading-whitespace tolerance)
  - open-chip hides for `:custom` templates resolving to unsafe schemes; renders for safe schemes

## Boundaries

- Strictly `tools/causa/` — no changes to `implementation/core/` or other tools.
- No AI attribution in commit messages or this PR.
- Tests stay quiet (no `println` / `prn` noise).

Closes rf2-cm93v.