### PR TITLE
feat(testbeds): rf2-kzcim Tier 2 — multi_frame + deep_machine + long_flow_w_failure (3 surfaces)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -652,4 +652,14 @@
    :output-dir "out/testbeds/multi-frame"
    :asset-path "."
    :modules    {:main {:init-fn multi-frame.core/run}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
+
+  ;; rf2-kzcim Tier 2 — deep-machine testbed (one machine exercising
+  ;; every Spec 005 grammar surface: parallel regions, hierarchical
+  ;; compound 5+ levels deep, :always, :after, :invoke, :invoke-all).
+  :testbeds/deep-machine
+  {:target     :browser
+   :output-dir "out/testbeds/deep-machine"
+   :asset-path "."
+   :modules    {:main {:init-fn deep-machine.core/run}}
    :devtools   {:preloads [day8.re-frame2-causa.preload]}}}}

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -641,4 +641,15 @@
    :output-dir "out/testbeds/http-toggle"
    :asset-path "."
    :modules    {:main {:init-fn http-toggle.core/run}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
+
+  ;; rf2-kzcim Tier 2 — multi-frame testbed (three frames coexisting:
+  ;; :counter/a, :counter/b, :log; the Cross-bump button fans out a
+  ;; handler running on :counter/a to dispatches against :counter/b
+  ;; and :log via cross-frame `:dispatch` fx per Spec 002).
+  :testbeds/multi-frame
+  {:target     :browser
+   :output-dir "out/testbeds/multi-frame"
+   :asset-path "."
+   :modules    {:main {:init-fn multi-frame.core/run}}
    :devtools   {:preloads [day8.re-frame2-causa.preload]}}}}

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -662,4 +662,15 @@
    :output-dir "out/testbeds/deep-machine"
    :asset-path "."
    :modules    {:main {:init-fn deep-machine.core/run}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
+
+  ;; rf2-kzcim Tier 2 — long-flow-w-failure testbed (a multi-second
+  ;; cascade of app-db writes driving three flows in topo order; the
+  ;; middle flow throws on a configurable input threshold to
+  ;; exercise the four-rule failure semantics per Spec 013 rf2-hrqvg).
+  :testbeds/long-flow-w-failure
+  {:target     :browser
+   :output-dir "out/testbeds/long-flow-w-failure"
+   :asset-path "."
+   :modules    {:main {:init-fn long-flow-w-failure.core/run}}
    :devtools   {:preloads [day8.re-frame2-causa.preload]}}}}

--- a/testbeds/README.md
+++ b/testbeds/README.md
@@ -13,9 +13,12 @@ The split lives in [`spec/Ownership.md` §examples-split](../spec/Ownership.md) 
 
 ```
 testbeds/
-  deliberate_throw/       <-- four exception trigger sites (handler / fx / flow / machine)
+  deliberate_throw/        <-- four exception trigger sites (handler / fx / flow / machine)
   schema_violation/        <-- four schema-validation trigger sites (app-db / event / cofx / fx)
   http_toggle/             <-- single button + outcome dropdown for the eight :rf.http/* categories
+  multi_frame/             <-- three frames coexisting; cross-frame :dispatch fan-out from one click
+  deep_machine/            <-- one machine: parallel regions + 5-deep compound + :always/:after/:invoke/:invoke-all
+  long_flow_w_failure/     <-- 5-second cascade driving 3 flows in topo order with configurable mid-flow throw
 ```
 
 Per-surface conventions (every testbed in this directory follows them):
@@ -45,16 +48,23 @@ Then open `http://localhost:9630/build/<build-id>/dashboard` (or the per-testbed
 | `deliberate_throw/` | Handler exception surfaces as `:effects` outcome `:error` on epoch record; `:rf.error/handler-exception` highlighted in trace stream; partial epoch on flow throw; structured trace in Story `:play` replay | Recorder captures the click, plays it back, repro is identical; `:rf.assert/*` envelope around the trigger | Trace event arrives over the wire with `:rf.error/*` :op-type intact; `:dispatch` MCP call surfaces the error in the response envelope |
 | `schema_violation/` | Schema-validation-failure trace + `:rollback?` flag visible in trace panel; `:where` tag is one of `:event / :app-db / :cofx / :fx-args`; recovery (`:rollback?`, `:skipped`, `:replaced-with-default`) matches the per-step table | Recorder redacts post-`:sensitive?` events; the variant under `app-db` validation triggers the rollback path observable in subscribed views | Schema-validation-failure event arrives with `:path`, `:value`, `:explain` carried verbatim; `:rollback?` flag visible |
 | `http_toggle/` | Ordered `:rf.http/*` events visible in trace panel; `:kind` tag matches the picked outcome; category attribution preserved across abort + retry | Recorder captures the outcome-toggle as ordinary event vector; replay reproduces the same `:rf.http/*` category deterministically (stubs are pure) | `:rf.http/managed` envelope visible in the dispatch response; the eight categories enumerate against a fixed outcome dropdown |
+| `multi_frame/` | Separate epoch ring buffers per frame; the Cross-bump click produces three distinct epoch records (one per frame) with `:frame` tag intact; time-travel scrubs each frame independently | Time-travel scrub within a Story variant mounting this surface preserves per-frame isolation; the recorder captures the cross-frame fan-out as one envelope-rooted sequence | `:dispatch` MCP call with `{:frame ...}` opt arrives at the addressed frame; the response envelope carries the resolved `:frame` verbatim; cross-frame fan-out visible in the cascade's epoch record |
+| `deep_machine/` | `:rf.machine/*` events for every transition / spawn / destroy / invoke-all-init / invoke-all-join visible in the trace stream; the `:state` snapshot reads correctly at every compound rung; click-to-source resolves every named action / guard | Recorder captures the deep cascade deterministically; replay reproduces the same `:rf.machine/*` shape | Snapshot-restore round-trip preserves the full `:state` map for parallel regions and the deep compound path; `:rf/after-epoch-by-region` survives `pr-str` |
+| `long_flow_w_failure/` | Trace panel grows on subsequent dispatch over 60+ trace events from one Start click; `:rf.flow/failed → :rf.error/flow-eval-exception` pairs highlighted; ring-buffer budget enforced under cascade saturation when `total-ticks` dialled up | Recorder captures the timed cascade deterministically (timers are data, flows are pure) | The four-rule contract observable over the MCP wire as ordered trace events — `:rf.flow/computed` for `:flow-a` survives every drain; `:rf.flow/failed` for `:flow-b` appears at the threshold |
 
 ## Tier roadmap (rf2-kzcim)
 
-Tier 1 — load-bearing trio (this commit set):
+Tier 1 — load-bearing trio:
 
 - ✅ `deliberate_throw/`
 - ✅ `schema_violation/`
 - ✅ `http_toggle/`
 
-Tier 2 (state-machine + frame surfaces): `multi_frame/`, `deep_machine/`, `long_flow_w_failure/`.
+Tier 2 — state-machine + frame surfaces (this commit set):
+
+- ✅ `multi_frame/`
+- ✅ `deep_machine/`
+- ✅ `long_flow_w_failure/`
 
 Tier 3 (devtools edge cases): `drain_depth_trigger/`, `non_trivial_app_db/`, `sensitive_dispatcher/`, `large_dispatcher/`.
 
@@ -62,7 +72,10 @@ Tier 4 (a11y): `known_bad_a11y/` — a Story variant with a deliberate a11y viol
 
 ## Cross-references
 
+- [`spec/002-Frames.md` §What lives in a frame](../spec/002-Frames.md) — the per-frame partitioning + cross-frame dispatch contract the `multi_frame/` surface exercises.
+- [`spec/005-StateMachines.md` §Hierarchical compound states / §Parallel regions / §Declarative `:invoke` / §Spawn-and-join via `:invoke-all` / §Delayed `:after` / §Eventless `:always`](../spec/005-StateMachines.md) — the six machine-grammar capabilities the `deep_machine/` surface exercises in one declaration.
 - [`spec/009-Instrumentation.md` §Error contract](../spec/009-Instrumentation.md) — the `:rf.error/*` taxonomy the `deliberate_throw/` surface fires every member of.
 - [`spec/010-Schemas.md` §Per-step recovery](../spec/010-Schemas.md) — the five validation points the `schema_violation/` surface walks one button per.
+- [`spec/013-Flows.md` §Failure semantics](../spec/013-Flows.md) — the four-rule flow-failure contract the `long_flow_w_failure/` surface exercises over a multi-second cascade.
 - [`spec/014-HTTPRequests.md` §Failure categories](../spec/014-HTTPRequests.md) — the eight `:rf.http/*` categories the `http_toggle/` outcome dropdown enumerates.
 - [`spec/Ownership.md`](../spec/Ownership.md) — where every contract surface this directory exercises is owned.

--- a/testbeds/deep_machine/README.md
+++ b/testbeds/deep_machine/README.md
@@ -1,0 +1,111 @@
+# `testbeds/deep-machine`
+
+One Reagent-mounted state machine that, in a single registration,
+exercises every grammar surface from [`spec/005-StateMachines.md`](../../spec/005-StateMachines.md)
+a tool (Causa, Story, pair2-mcp) needs to discriminate when
+visualising hierarchy and transition cascades. The buttons drive the
+machine through each capability one at a time.
+
+| Capability | Where it lives | What a consumer should see |
+|---|---|---|
+| **Parallel regions** | `:type :parallel` at the root; two regions `:work` + `:health` | The snapshot's `:state` is a map of region → path. One event broadcasts to both regions — `:work/go` advances `:work` while `:health` stays at `:cold`. |
+| **Hierarchical compound 5+ levels deep** | `:work` region descends `:idle → :phase-a → :sub-a → :nested-a → :deep-a → :leaf-a` | Active leaf path on click of `work-go` is `[:work :phase-a :sub-a :nested-a :deep-a :leaf-a]` — region + five compound levels. Deepest-wins resolution walks back up the path on every event. |
+| **`:always`** (eventless transitions) | `:work` region's `:resolving` node | After `work-done`, the runtime fires a microstep cascade through `:resolving` to `:done-a` without an explicit event on the trace stream. The `:phase-a-ran?` guard's truthiness picks the branch. |
+| **`:after`** (delayed transitions) | `:health` region's `:warming` node — `{:after {200 :ready}}` | `health-heat` schedules a `:dispatch-later` for the `:rf.machine.timer/after-elapsed` synthetic event; ~200ms later the region transitions to `:ready`. Per-region `:rf/after-epoch-by-region` slot at `[:data :rf/after-epoch-by-region :health]` advances on each entry/exit. |
+| **`:invoke`** (single child actor) | `:work/leaf-a` (the deepest leaf) | On entry, the desugared `:rf.machine/spawn` fx mounts `:helper/tick` at `[:rf/spawned :deep/main [:work :phase-a :sub-a :nested-a :deep-a :leaf-a]]`. On exit (via `work-done`), the desugared `:rf.machine/destroy` fires. |
+| **`:invoke-all`** (parallel children + join) | `:work/phase-b` | After `work-spawn`, the runtime emits one `:rf.machine/invoke-all-init` plus three `:rf.machine/spawn` fxs (one per child id `:j1` / `:j2` / `:j3`). After clicking finish on all three, `:helper/all-finished` fires and the parent transitions to `:done-b`. |
+
+## Button reference
+
+| Button | `data-testid` | Drives |
+|---|---|---|
+| `:work/go` | `work-go` | Descend the deep hierarchy into `[:work :phase-a … :leaf-a]`; `:invoke` spawns `:helper/tick`. |
+| `:work/done` | `work-done` | Exit the deep leaf; `:invoke`-destroy fires; `:always` cascade settles into `:done-a`. |
+| `:work/spawn` | `work-spawn` | `:invoke-all` spawns three `:helper/job` children. |
+| finish j1 / j2 / j3 | `helper-finish-j1`, `helper-finish-j2`, `helper-finish-j3` | Each transitions one child to its `:final?` leaf; the runtime advances `:invoke-all` join bookkeeping; the third fires `:helper/all-finished` and the parent transitions to `:done-b`. |
+| `:work/reset` | `work-reset` | Return `:work` region to `:idle` from any state. |
+| `:health/heat` | `health-heat` | Drive `:health` region from `:cold` → `:warming` → (after 200ms) → `:ready`. |
+| `:health/cool` | `health-cool` | Return `:health` region to `:cold`. |
+
+## Why one machine, not five
+
+The five capability axes (parallel / hierarchical / `:always` /
+`:after` / `:invoke` / `:invoke-all`) compose in the spec; a
+visualiser that handles each in isolation may still break when they
+interact — e.g. an `:invoke` declared on a deeply nested leaf inside
+a region, where the spawn/destroy fx must be emitted with the full
+prefix-path resolved at desugar time. A tool that conflates the
+spawn-registry path with the leaf-only key fails on this surface.
+
+The two child machines (`:helper/tick`, `:helper/job`) are minimal —
+they exist as well-formed `:machine-id`s the parent's `:invoke` /
+`:invoke-all` can address. Their bodies are not interesting; the
+load-bearing thing this surface shows is the parent's spawn /
+destroy / join shape, not what the children compute.
+
+## What's deliberately *missing*
+
+- **No `:final?` on the parent.** The parent never terminates;
+  `:work/reset` cycles it. A future surface can layer the final-state
+  contract.
+- **No nested parallel regions.** Per [spec/005 §Parallel regions]
+  v1 explicitly disallows nesting; `create-machine-handler` would
+  reject this at registration. The five-deep compound on `:work`
+  + the top-level parallel split between `:work` and `:health` is
+  the depth ceiling under the v1 grammar.
+- **No `:on-error` policy.** Per-frame error overrides are a
+  separate contract; this surface stays on the happy path so each
+  cascade is observable as a clean transition.
+- **No `:after` driven by a snapshot-fn or a subscription.** Per
+  [spec/005 §`:after` delay shapes] those are valid; the testbed
+  uses a literal `pos-int?` for the deterministic 200ms test
+  window. A future surface can layer the fn-delay shape.
+
+## Test scenarios from rf2-fe84r this surface enables
+
+**Causa (26)**:
+- Trace panel populates on first dispatch — each Button produces a
+  rich cascade (multiple `:rf.machine/*` traces per click) that
+  exercises the trace panel's grouping by `:cascade-id`.
+- Click-to-source from trace event lands on source-coord line —
+  every `:guards` / `:actions` entry in the deep machine carries
+  reader meta; the `:rf.machine/source-coords` index resolves
+  every transition's source line.
+
+**Cross-cutting (6)**:
+- **State-machine transition cascade shows `:rf.machine/*` events**
+  — the load-bearing scenario this surface unblocks. Each of the
+  buttons above produces a different `:rf.machine/*` trace shape
+  the consumer's panel must surface and discriminate:
+  - `work-go`: `:rf.machine/transition` (compound entry cascade) +
+    `:rf.machine/spawn` (the `:invoke` desugaring).
+  - `work-done`: `:rf.machine/destroy` (the `:invoke` desugaring on
+    leaf exit) + `:rf.machine/transition` (the `:always`
+    microstep).
+  - `work-spawn`: `:rf.machine/invoke-all-init` + three
+    `:rf.machine/spawn` in source order.
+  - `helper-finish-j3` (after j1 and j2): `:rf.machine/invoke-all-join`
+    + `:rf.machine/transition` (`:helper/all-finished` →
+    `:done-b`).
+
+## Running
+
+From `implementation/`:
+
+```bash
+shadow-cljs watch testbeds/deep-machine
+# Or via the orchestrator:
+npm run test:examples
+```
+
+The shadow-cljs build id is `testbeds/deep-machine`; output lands in
+`implementation/out/testbeds/deep-machine/`.
+
+## Cross-references
+
+- [`spec/005-StateMachines.md` §Hierarchical compound states](../../spec/005-StateMachines.md) — the deep-hierarchy contract `:work` exercises.
+- [`spec/005-StateMachines.md` §Parallel regions](../../spec/005-StateMachines.md) — the top-level `:type :parallel` shape.
+- [`spec/005-StateMachines.md` §Declarative `:invoke`](../../spec/005-StateMachines.md) — the deepest-leaf actor lifecycle.
+- [`spec/005-StateMachines.md` §Spawn-and-join via `:invoke-all`](../../spec/005-StateMachines.md) — the `:phase-b` three-child shape.
+- [`spec/005-StateMachines.md` §Delayed `:after` transitions](../../spec/005-StateMachines.md) — the `:health/warming` 200ms timer.
+- [`spec/005-StateMachines.md` §Eventless `:always` transitions](../../spec/005-StateMachines.md) — the `:work/resolving` decision node.

--- a/testbeds/deep_machine/core.cljs
+++ b/testbeds/deep_machine/core.cljs
@@ -1,0 +1,346 @@
+(ns deep-machine.core
+  "Shared framework-behavior testbed — one machine that, in a single
+  declaration, exercises every machine grammar surface a tool (Causa,
+  Story, pair2-mcp) needs to discriminate when visualising the
+  hierarchy and the transition cascade. A consumer sees:
+
+    - **Parallel regions** at the top level (`:type :parallel` with
+      two regions, `:work` and `:health`). One event broadcasts to
+      both regions per [spec/005 §Parallel regions].
+    - **Hierarchical compound states** 5+ levels deep on the `:work`
+      region — the active leaf's full path is
+      `[:work :phase-a :sub-a :nested-a :deep-a :leaf-a]` (region +
+      five compound levels + leaf). A 'jump to substate' click on
+      any rung must lift to the correct ancestor.
+    - **`:always`** (eventless transitions) on the `:work` region's
+      `:resolving` decision node — a microstep cascade that settles
+      before the snapshot commits.
+    - **`:after`** (delayed transitions) on the `:health` region —
+      `:warming` auto-transitions to `:ready` after 200ms.
+    - **`:invoke`** (single child actor) on the deep leaf
+      `:leaf-a` — spawns a `:helper/tick` child whose lifecycle is
+      bound to the leaf's; on leaf exit the desugared destroy fires.
+    - **`:invoke-all`** (parallel children + join) on `:phase-b` —
+      three `:helper/job` workers spawn in parallel; `:on-all-done`
+      transitions the parent.
+
+  This is NOT a tutorial — the bodies are minimal. The whole point is
+  to give a consumer ONE machine whose snapshot, transitions, and
+  spawn-registry slots exercise every spec/005 capability in one
+  click trace. Each Button below drives the machine into a state
+  that exposes one feature."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.machines]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ----------------------------------------------------------------------------
+;; Child machines (singletons reused for :invoke / :invoke-all)
+;; ----------------------------------------------------------------------------
+;;
+;; Two minimal child machines. They exist solely so the parent can
+;; declare `:invoke` and `:invoke-all` against well-formed
+;; `:machine-id`s. Each child's body is intentionally trivial —
+;; the load-bearing thing the testbed shows is the parent's
+;; spawn/destroy/join shape, not what the children compute.
+
+(def helper-tick-machine
+  {:initial :ticking
+   :states
+   {:ticking
+    ;; Single-actor child: ticks once on entry, then sits idle until
+    ;; the parent's leaf exits and the desugared destroy tears it
+    ;; down. The :tick action mutates :data so a consumer can see
+    ;; the child's snapshot diverge from the parent's.
+    {:tags  #{:helper/ticking}
+     :entry (fn [data _ev] {:data (assoc data :ticked? true)})}}})
+
+(rf/reg-machine :helper/tick helper-tick-machine)
+
+(def helper-job-machine
+  {:initial :running
+   :states
+   {:running
+    {:tags    #{:helper/running}
+     ;; Each child runs once and transitions to its terminal state.
+     ;; The :invoke-all join machinery in the parent reads each
+     ;; child's :final? leaf to advance the bookkeeping at
+     ;; [:rf/spawned :deep/main [:work :phase-b] :done].
+     :on      {:helper.job/finish :done}}
+    :done
+    {:meta   {:terminal? true}
+     :final? true
+     :tags   #{:helper/done}}}})
+
+(rf/reg-machine :helper/job helper-job-machine)
+
+;; ----------------------------------------------------------------------------
+;; The main machine — :deep/main
+;; ----------------------------------------------------------------------------
+;;
+;; Two parallel regions:
+;;
+;;   :work    — five-deep compound hierarchy with :always cascade,
+;;              :invoke at the deepest leaf, and :invoke-all on
+;;              :phase-b. The :always cascade settles before commit.
+;;
+;;   :health  — flat region with :after-driven transition. Provides
+;;              a separate region clock that a consumer can verify
+;;              keeps its own `:rf/after-epoch-by-region` slot per
+;;              [spec/005 §Per-region scoping].
+
+(def main-machine
+  {:type :parallel
+
+   :data {:tick-count   0
+          :phase-a-ran? false
+          :phase-b-done []}
+
+   :guards
+   {:phase-a-ran?
+    (fn guard-phase-a-ran? [data _ev]
+      (true? (:phase-a-ran? data)))}
+
+   :actions
+   {:bump-tick
+    (fn action-bump-tick [data _ev]
+      {:data (update data :tick-count (fnil inc 0))})
+
+    :mark-phase-a-ran
+    (fn action-mark-phase-a-ran [data _ev]
+      {:data (assoc data :phase-a-ran? true)})
+
+    :record-phase-b-done
+    (fn action-record-phase-b-done [data [_ child-id]]
+      {:data (update data :phase-b-done (fnil conj []) child-id)})}
+
+   :regions
+   {;; ---- :work region — 5-deep compound + :always + :invoke + :invoke-all ----
+    :work
+    {:initial :idle
+     :states
+     {:idle
+      ;; Region-root leaf. :work/go descends into :phase-a (five
+      ;; compound levels unwind in one transition); :work/spawn
+      ;; sidesteps into the :invoke-all-bearing :phase-b.
+      {:tags #{:work/idle}
+       :on   {:work/go    :phase-a
+              :work/spawn :phase-b}}
+
+      :phase-a
+      ;; Compound level 1 of 5. Drops to :sub-a on entry.
+      {:tags    #{:work/phase-a}
+       :initial :sub-a
+       :on      {:work/reset :idle}
+       :states
+       {:sub-a
+        ;; Compound level 2 of 5. Drops to :nested-a on entry.
+        {:tags    #{:work/sub-a}
+         :initial :nested-a
+         :states
+         {:nested-a
+          ;; Compound level 3 of 5. Drops to :deep-a on entry.
+          {:tags    #{:work/nested-a}
+           :initial :deep-a
+           :states
+           {:deep-a
+            ;; Compound level 4 of 5. Drops to :leaf-a on entry.
+            {:tags    #{:work/deep-a}
+             :initial :leaf-a
+             :states
+             {:leaf-a
+              ;; Compound level 5 — the deepest leaf. Full active
+              ;; path on entry:
+              ;;   [:work :phase-a :sub-a :nested-a :deep-a :leaf-a]
+              ;;
+              ;; Carries the :invoke declaration — the desugared
+              ;; entry/exit fx spawn / destroy the :helper/tick
+              ;; child. A consumer that walks `[:rf/spawned
+              ;; :deep/main [:work :phase-a :sub-a :nested-a :deep-a
+              ;; :leaf-a]]` sees the spawned child while this leaf
+              ;; is active.
+              ;;
+              ;; The :work/done transition propagates back up
+              ;; through every compound's :exit cascade and lands
+              ;; the :work region in :resolving (sibling of
+              ;; :phase-a). The desugared destroy of :helper/tick
+              ;; fires on leaf exit.
+              {:tags   #{:work/leaf-a :work/deepest}
+               :entry  :bump-tick
+               :invoke {:machine-id :helper/tick
+                        :data       (fn [_snap _ev] {:ticked? false})}
+               :on    {:work/done {:target :resolving
+                                   :action :mark-phase-a-ran}}}}}}}}}}}
+
+      :resolving
+      ;; Eventless decision: was :phase-a fully traversed (i.e. did
+      ;; :leaf-a's :work/done fire and stamp :phase-a-ran?)? The
+      ;; :always cascade is first-match-wins. A consumer sees a
+      ;; microstep cascade — entry into :resolving, :always fires,
+      ;; exit from :resolving, entry into :done-a — without an
+      ;; event appearing on the trace stream.
+      {:always [{:guard :phase-a-ran? :target :done-a}
+                {:target :idle}]}
+
+      :done-a
+      ;; Leaf — terminal-ish for the :phase-a path. :work/reset
+      ;; cycles back to :idle.
+      {:tags #{:work/done-a}
+       :on   {:work/reset :idle}}
+
+      :phase-b
+      ;; Sibling of :phase-a, NOT nested under it. Hosts the
+      ;; :invoke-all — three :helper/job children spawn in
+      ;; parallel; the :on-all-done keyword (`:helper/all-finished`)
+      ;; dispatches when the runtime's join machinery sees all
+      ;; three children's :final? state.
+      ;;
+      ;; A consumer that watches the trace stream after :work/spawn
+      ;; sees one :rf.machine/invoke-all-init plus three
+      ;; :rf.machine/spawn fxs in source order; the children's
+      ;; :final? states fire :on-child-done back to the parent;
+      ;; after the third, :helper/all-finished fires.
+      {:tags #{:work/phase-b}
+       :invoke-all
+       {:children [{:id :j1 :machine-id :helper/job :data {:id :j1}}
+                   {:id :j2 :machine-id :helper/job :data {:id :j2}}
+                   {:id :j3 :machine-id :helper/job :data {:id :j3}}]
+        :on-child-done :record-phase-b-done
+        :on-all-done   :helper/all-finished}
+       :on   {:helper/all-finished :done-b
+              :work/reset          :idle}}
+
+      :done-b
+      {:tags #{:work/done-b}
+       :on   {:work/reset :idle}}}}
+
+    ;; ---- :health region — flat with :after ----
+    :health
+    ;; Independent of :work. Cycles :cold → :warming → :ready via an
+    ;; :after delay. Per [spec/005 §Per-region scoping] the
+    ;; :rf/after-epoch slot is per-region (lives at
+    ;; `[:data :rf/after-epoch-by-region :health]`) — a :work
+    ;; transition does not invalidate this region's in-flight
+    ;; timer.
+    {:initial :cold
+     :states
+     {:cold
+      {:tags #{:health/cold}
+       :on   {:health/heat :warming}}
+
+      :warming
+      ;; HOT PATH — :after schedules a :dispatch-later for the
+      ;; synthetic `:rf.machine.timer/after-elapsed` event; on
+      ;; expiry the transition fires.
+      {:tags  #{:health/warming :health/transient}
+       :after {200 :ready}}
+
+      :ready
+      {:tags #{:health/ready}
+       :on   {:health/cool :cold}}}}}})
+
+(rf/reg-machine :deep/main main-machine)
+
+;; ----------------------------------------------------------------------------
+;; App-db init
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-fx ::initialise
+  (fn [_ _]
+    ;; Boot the parent machine to its initial state (idle + cold).
+    ;; The runtime stamps :rf/bootstrap-pending? on the snapshot;
+    ;; the first event clears it after the initial-entry cascade.
+    {:fx [[:dispatch [:deep/main [:rf.machine/bootstrap]]]]}))
+
+;; ----------------------------------------------------------------------------
+;; Subs + view
+;; ----------------------------------------------------------------------------
+
+(rf/reg-sub :work-state
+  :<- [:rf/machine :deep/main]
+  (fn [snap _]
+    (get-in snap [:state :work])))
+
+(rf/reg-sub :health-state
+  :<- [:rf/machine :deep/main]
+  (fn [snap _]
+    (get-in snap [:state :health])))
+
+(rf/reg-sub :tags
+  :<- [:rf/machine :deep/main]
+  (fn [snap _]
+    (:tags snap)))
+
+(rf/reg-sub :tick-count
+  :<- [:rf/machine :deep/main]
+  (fn [snap _]
+    (get-in snap [:data :tick-count])))
+
+(rf/reg-sub :phase-b-done
+  :<- [:rf/machine :deep/main]
+  (fn [snap _]
+    (get-in snap [:data :phase-b-done])))
+
+(reg-view buttons []
+  (let [work-state   @(subscribe [:work-state])
+        health-state @(subscribe [:health-state])
+        tags         @(subscribe [:tags])
+        tick-count   @(subscribe [:tick-count])
+        phase-b-done @(subscribe [:phase-b-done])]
+    [:div {:data-testid "deep-machine" :style {:font-family "sans-serif" :padding "1em"}}
+     [:h1 "deep-machine testbed"]
+     [:p "One machine, every grammar surface. Click through to drive
+          the parallel regions independently."]
+
+     [:div {:style {:display :flex :gap "0.5em" :flex-wrap :wrap}}
+      [:button {:data-testid "work-go"
+                :on-click #(dispatch [:deep/main [:work/go]])}
+       "1 · :work/go  (descend 5 levels — :invoke spawns)"]
+      [:button {:data-testid "work-done"
+                :on-click #(dispatch [:deep/main [:work/done]])}
+       "2 · :work/done  (:always cascade → :done-a; :invoke destroys)"]
+      [:button {:data-testid "work-spawn"
+                :on-click #(dispatch [:deep/main [:work/spawn]])}
+       "3 · :work/spawn  (:invoke-all — 3 children)"]
+      [:button {:data-testid "helper-finish-j1"
+                :on-click #(dispatch [:helper/job [:helper.job/finish] :j1])}
+       "4a · finish j1"]
+      [:button {:data-testid "helper-finish-j2"
+                :on-click #(dispatch [:helper/job [:helper.job/finish] :j2])}
+       "4b · finish j2"]
+      [:button {:data-testid "helper-finish-j3"
+                :on-click #(dispatch [:helper/job [:helper.job/finish] :j3])}
+       "4c · finish j3"]
+      [:button {:data-testid "work-reset"
+                :on-click #(dispatch [:deep/main [:work/reset]])}
+       "5 · :work/reset"]
+      [:button {:data-testid "health-heat"
+                :on-click #(dispatch [:deep/main [:health/heat]])}
+       "H · :health/heat  (:after 200ms → :ready)"]
+      [:button {:data-testid "health-cool"
+                :on-click #(dispatch [:deep/main [:health/cool]])}
+       "C · :health/cool"]]
+
+     [:p {:style {:margin-top "1em" :color "#666" :white-space :pre-wrap}}
+      "work-state="   [:span {:data-testid "work-state"}   (pr-str work-state)]   "\n"
+      "health-state=" [:span {:data-testid "health-state"} (pr-str health-state)] "\n"
+      "tags="         [:span {:data-testid "tags"}         (pr-str tags)]         "\n"
+      "tick-count="   [:span {:data-testid "tick-count"}   tick-count]            "\n"
+      "phase-b-done=" [:span {:data-testid "phase-b-done"} (pr-str phase-b-done)]]]))
+
+(reg-view root []
+  [buttons])
+
+;; ----------------------------------------------------------------------------
+;; Mount
+;; ----------------------------------------------------------------------------
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  (rf/dispatch-sync [::initialise])
+  (rdc/render react-root [root]))

--- a/testbeds/deep_machine/index.html
+++ b/testbeds/deep_machine/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: deep-machine</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/testbeds/long_flow_w_failure/README.md
+++ b/testbeds/long_flow_w_failure/README.md
@@ -1,0 +1,142 @@
+# `testbeds/long-flow-w-failure`
+
+A multi-second cascade of `app-db` writes that drive a three-flow
+topology, with a configurable mid-flow failure injection. The
+single Start click produces a visible ~5-second stream of
+`:rf.flow/computed` / `:rf.flow/failed` / `:rf.error/flow-eval-exception`
+traces that a consumer (Causa, Story, pair2-mcp) reads to verify the
+four-rule flow-failure contract from
+[`spec/013-Flows.md` §Failure semantics](../../spec/013-Flows.md)
+(rf2-hrqvg).
+
+## The cascade
+
+`Start` schedules N ticks at 250ms intervals via `:dispatch-later`.
+Each tick bumps `:input` by one; every bump fires a flows pass that
+recomputes all three flows in topo order. Total cascade time =
+`:total-ticks × 250ms` (default 5 seconds).
+
+```
+:flow-a  :inputs [[:input]]                  :output (* 2 input)        :path [:a-result]
+:flow-b  :inputs [[:input]]                  :output (* 3 input)        :path [:b-result]   ← throws when input ≥ :fail-at
+:flow-c  :inputs [[:a-result] [:b-result]]   :output (+ a b)            :path [:c-result]
+```
+
+## The four-rule contract this surface exercises
+
+Per [spec/013 §Failure semantics](../../spec/013-Flows.md), when
+`:flow-b`'s `:output` throws on a recompute, the runtime applies
+four rules atomically. The DOM mirror at the bottom of the surface
+makes each rule's effect human-readable:
+
+| Rule | What it says | Where to look |
+|---|---|---|
+| 1 — prior writes preserved | `:flow-a` computes first; its output IS flushed to `[:a-result]` BEFORE `:flow-b`'s throw propagates. | `a-result` advances on every tick, including the failing one. |
+| 2 — failing flow's output is not written | `:flow-b`'s recompute throws; `:b-result` is not updated; `:flow-b`'s `last-inputs` is NOT advanced — the flow re-attempts on the next tick. | `b-result` stops advancing at `(* 3 (dec :fail-at))`; subsequent ticks re-throw without writing. |
+| 3 — cascade halts at the failing flow | `:flow-c` does NOT run on the drain where `:flow-b` throws. | `c-result` stops advancing at the tick that lands `:input == :fail-at`. |
+| 4 — exception surfaces as `:rf.error/flow-eval-exception` | The per-flow `:rf.flow/failed` trace fires first (with `:flow-id ::flow-b` under `:tags`); the cascade-level `:rf.error/flow-eval-exception` fires when the router catches the propagated throw. | The trace stream after `:fail-at` shows pairs of `[:rf.flow/failed, :rf.error/flow-eval-exception]` on every subsequent tick. |
+
+## Controls
+
+| Control | `data-testid` | What it does |
+|---|---|---|
+| `Fail at tick` | `fail-at` | The tick index at which `:flow-b` begins throwing. Default 5; the cascade is intact for ticks 1..4, throws on ticks 5..N. |
+| `Total ticks` | `total-ticks` | How many ticks `Start` schedules. Default 20 (5 seconds at 250ms/tick). A spec testing just the rules can dial to 6 for a faster run. |
+| `Start cascade` | `start` | Pre-schedules every tick at boot via `:dispatch-later`. The cascade is data, not a recursive timer chain. |
+| `Reset` | `reset` | Restores the surface to its initial state for re-runs. |
+
+## DOM mirrors
+
+The surface mirrors `:a-result` / `:b-result` / `:c-result` in the
+DOM so a Playwright spec can assert against the rules without
+needing a recorder. After Start with defaults (fail-at=5,
+total-ticks=20):
+
+- `a-result`: keeps advancing 0, 2, 4, 6, … 40. (Rule 1.)
+- `b-result`: advances 0, 3, 6, 9, 12, then stops. (Rule 2.)
+- `c-result`: advances 0, 5, 10, 15, 20, then stops. (Rule 3.)
+
+A consumer that reads the trace stream can assert:
+- 20 `:rf.flow/computed` traces for `::flow-a` (one per tick).
+- 4 `:rf.flow/computed` traces for `::flow-b` (ticks 1..4).
+- 16 `:rf.flow/failed` traces for `::flow-b` (ticks 5..20).
+- 16 `:rf.error/flow-eval-exception` traces (one per `:rf.flow/failed`).
+- 4 `:rf.flow/computed` traces for `::flow-c` (ticks 1..4).
+- 0 `:rf.flow/computed` traces for `::flow-c` after tick 5.
+
+The exact trace order per drain: `:flow-a` computed → `:flow-b`
+failed → `:flow-error/flow-eval-exception`.
+
+## Why a multi-second window
+
+The four-rule contract is a per-drain property — observable on any
+single throw. But a consumer's UI (trace panel, recorder, MCP wire)
+under stress tests differently when 60+ flow traces stream past in
+five seconds vs. when one click produces 3 traces. The default
+total-ticks=20 keeps the trace volume realistic without blowing
+ring-buffer budgets (the Spec 009 200-row default holds 60 per-tick
+traces fine).
+
+A consumer that tests the rules at minimum cost dials total-ticks
+down to 6 and fail-at to 4 — the cascade completes in 1.5 seconds
+and produces enough trace shape to assert every rule.
+
+## What's deliberately *missing*
+
+- **No `:on-error` policy.** The four-rule contract is what the
+  default recovery does; an `:on-error` override would mask it.
+- **No `:rf.fx/clear-flow` on the failing flow.** Clearing
+  `::flow-b` mid-cascade is a separate contract; this surface
+  stays on the canonical "let it keep re-throwing" path so the
+  rule-2 evidence accumulates over multiple ticks.
+- **No retry logic on `:tick`.** Every tick fires unconditionally;
+  the failing flow's re-throw is what produces rule 2's
+  evidence — not retry orchestration in user code.
+- **No `:flow-b` recovery on `Fail at tick > total-ticks`.** Setting
+  fail-at to a value higher than total-ticks gives a clean cascade
+  with zero failures — useful as a control case for verifying the
+  trace shape when no failure injection is active.
+
+## Test scenarios from rf2-fe84r this surface enables
+
+**Causa (26)**:
+- Trace panel grows on subsequent dispatch (rf2-1barg regression
+  — gold standard) — exercised 20× in one Start click.
+- `:rf.error/*` events highlighted in trace stream — exercised
+  16× per default run (one per failing tick).
+- ≤200-row budget enforced under 1000-event ring saturation —
+  dial `total-ticks` up to 333+ to produce 1000+ flow traces in
+  one cascade; verify ring-buffer truncation against the budget.
+
+**Cross-cutting (6)**:
+- **Flow `:rf.flow/failed` shows four-rule failure semantics
+  (rf2-hrqvg)** — the load-bearing scenario this surface unblocks.
+  Each of the four rules has a DOM mirror + a deterministic trace
+  shape a spec can assert against; the 5-second cascade gives the
+  rules time to accumulate evidence beyond a single drain.
+
+**Story (18)**:
+- Recorder captures click → records `:play` → replays identically —
+  the Start click is deterministic (timer schedule is data; flow
+  recomputes are pure given the same `:input` sequence). Replay
+  reproduces the same per-tick trace stream.
+
+## Running
+
+From `implementation/`:
+
+```bash
+shadow-cljs watch testbeds/long-flow-w-failure
+# Or via the orchestrator:
+npm run test:examples
+```
+
+The shadow-cljs build id is `testbeds/long-flow-w-failure`; output
+lands in `implementation/out/testbeds/long-flow-w-failure/`.
+
+## Cross-references
+
+- [`spec/013-Flows.md` §Failure semantics](../../spec/013-Flows.md) — the four-rule contract this surface exists to exercise.
+- [`spec/013-Flows.md` §Flow tracing](../../spec/013-Flows.md) — the `:rf.flow/*` op taxonomy a consumer's trace panel filters against.
+- [`spec/009-Instrumentation.md` §Error contract](../../spec/009-Instrumentation.md) — the `:rf.error/flow-eval-exception` shape rule 4 produces.
+- [`spec/002-Frames.md` §Cascade propagation](../../spec/002-Frames.md) — the `:dispatch-later` frame-capture contract every scheduled tick relies on.

--- a/testbeds/long_flow_w_failure/core.cljs
+++ b/testbeds/long_flow_w_failure/core.cljs
@@ -1,0 +1,336 @@
+(ns long-flow-w-failure.core
+  "Shared framework-behavior testbed — a multi-second cascade of
+  app-db writes that drive a three-flow topology, with a configurable
+  mid-flow failure injection. A consumer (Causa, Story, pair2-mcp)
+  observes the four-rule flow-failure contract (per
+  [spec/013 §Failure semantics] / rf2-hrqvg) play out over a
+  human-visible time window:
+
+    Rule 1 — prior-flow writes are preserved (:flow-a's output keeps
+             advancing while :flow-b's throw is mid-cascade).
+    Rule 2 — the failing flow's output is not written; its
+             `last-inputs` is NOT advanced; the flow re-attempts on
+             the next drain.
+    Rule 3 — the cascade halts at the failing flow; :flow-c does NOT
+             run on the drain where :flow-b throws.
+    Rule 4 — the exception surfaces at the router's outer catch as
+             :rf.error/flow-eval-exception; the per-flow
+             :rf.flow/failed trace fires first.
+
+  The cascade ('long flow'):
+
+    Click Start →
+      [:dispatch [::tick]] now
+      [:dispatch-later 250ms [::tick]]
+      [:dispatch-later 500ms [::tick]] ...
+      [:dispatch-later (N-1)*250ms [::tick]]
+
+  Each :tick handler bumps :input — a numeric counter that's an
+  input to all three flows. Every bump recomputes the three flows in
+  topo order:
+
+    :flow-a — :inputs [[:input]]; :output multiplies by 2; :path
+              [:a-result].
+    :flow-b — :inputs [[:input]]; :output throws on the configured
+              tick index; otherwise multiplies by 3; :path
+              [:b-result].
+    :flow-c — :inputs [[:a-result] [:b-result]]; :output sums
+              the two; :path [:c-result]. Only runs when :flow-a and
+              :flow-b both successfully advance.
+
+  Two toggles configure the failure injection:
+
+    [Fail at tick #N] — the tick index at which :flow-b throws.
+                        Default: 5 (so the failure lands ~1.25s in,
+                        with prior ticks succeeding and subsequent
+                        ticks still re-attempting).
+    [Total ticks N]   — how many ticks the Start button schedules.
+                        Default: 20 (5 seconds total at 250ms/tick).
+
+  This is NOT a tutorial — the bodies are minimal. The whole point
+  is to give a consumer a single Start click that produces a visible
+  3-trace-per-tick stream over 5 seconds with a :rf.flow/failed
+  shape at a deterministic mid-point a spec can assert against."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.flows]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ----------------------------------------------------------------------------
+;; Constants
+;; ----------------------------------------------------------------------------
+
+(def default-tick-ms
+  "Inter-tick delay. 250ms keeps the cascade visible to a human
+  observer while being short enough for a Playwright spec to run
+  through 20 ticks in ~5 seconds."
+  250)
+
+(def default-total-ticks
+  "Total number of ticks the Start button schedules. 20 ticks at
+  250ms/tick → 5-second cascade. Each tick produces three flow
+  recomputes (or two if :flow-b throws at this tick), so the trace
+  stream is ~60 :rf.flow/* events."
+  20)
+
+(def default-fail-at
+  "Tick index at which :flow-b throws. With default-total-ticks=20
+  and default-fail-at=5, four ticks succeed (1..4), :flow-b throws
+  on tick 5, then ticks 6..20 each retry (because :flow-b's
+  last-inputs is NOT advanced per rule 2) — every subsequent tick
+  re-throws on :flow-b's recompute against the new :input."
+  5)
+
+;; ----------------------------------------------------------------------------
+;; App-db
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-db ::initialise
+  (fn [_db _ev]
+    {;; The single numeric input every flow watches.
+     :input        0
+     ;; Bookkeeping for the failure injection.
+     :tick-count   0
+     :fail-at      default-fail-at
+     :total-ticks  default-total-ticks
+     :status       :idle                 ;; :idle | :running | :done
+     ;; The runtime writes :a-result / :b-result / :c-result via
+     ;; the flows' :path slots — declared here only so the initial
+     ;; state is observable before the first drain.
+     :a-result     0
+     :b-result     0
+     :c-result     0}))
+
+;; ----------------------------------------------------------------------------
+;; Out-of-band closure capture for the failure threshold
+;; ----------------------------------------------------------------------------
+;;
+;; :flow-b's :output reads the failure threshold via this atom so the
+;; flow keeps `:inputs [[:input]]` (single-input, matches the
+;; canonical "one upstream input is the failure trigger" shape). The
+;; toggle button below `reset!`s this atom AND writes :fail-at into
+;; app-db (so the view can display it). A consumer can also flip the
+;; threshold via the atom directly for tests, but the app-db mirror
+;; is the canonical view-state.
+
+(defonce fail-at-atom (atom default-fail-at))
+
+;; ----------------------------------------------------------------------------
+;; Flows — three in topo order
+;; ----------------------------------------------------------------------------
+;;
+;; Rule-1 / Rule-3 evidence: when :flow-b throws on tick N, :flow-a's
+;; output for tick N IS flushed to :a-result (prior writes preserved);
+;; :flow-c's output for tick N is NOT computed (cascade halts).
+
+(rf/reg-flow
+  {:id     ::flow-a
+   :inputs [[:input]]
+   :output (fn flow-a [input]
+             ;; Trivial pure transform. The point is the WRITE — a
+             ;; consumer that sees :a-result advance on tick N has
+             ;; positive evidence of rule 1.
+             (* 2 input))
+   :path   [:a-result]
+   :doc    "Doubles :input. Watched by :flow-c."})
+
+(rf/reg-flow
+  {:id     ::flow-b
+   :inputs [[:input]]
+   :output (fn flow-b [input]
+             ;; HOT PATH — the failure-injection site for the
+             ;; cascade. The throw fires whenever this fn is called
+             ;; with input == :fail-at. The flow's last-inputs is
+             ;; NOT advanced (rule 2), so the next drain with a new
+             ;; :input value re-attempts; if the new :input is also
+             ;; ≥ :fail-at, the throw re-fires.
+             ;;
+             ;; A consumer reading the trace stream sees
+             ;; :rf.flow/failed (this flow's id) followed by
+             ;; :rf.error/flow-eval-exception (rule 4) on EVERY
+             ;; subsequent tick after the fail-at threshold —
+             ;; positive evidence of rule 2.
+             (let [fail-at-input
+                   ;; The :input value the :tick handler bumps to
+                   ;; coincides with the tick index — tick 5
+                   ;; bumps :input to 5. So we throw iff input >=
+                   ;; :fail-at (the runtime reads :fail-at out of
+                   ;; app-db at flow-eval time via a closure capture
+                   ;; below — flows take their inputs by path, but
+                   ;; the throwing fn can read any closure-captured
+                   ;; state).
+                   ;;
+                   ;; We close over `(fn ...)` rather than reading
+                   ;; another path so :flow-b stays single-input
+                   ;; (matches the realworld failure shape where
+                   ;; ONE of N flow inputs is the failure trigger,
+                   ;; not the failure config itself).
+                   @fail-at-atom]
+               (if (and (some? fail-at-input)
+                        (>= input fail-at-input))
+                 (throw (ex-info "long-flow-w-failure / :flow-b"
+                                 {:where :flow
+                                  :input input
+                                  :fail-at fail-at-input}))
+                 (* 3 input))))
+   :path   [:b-result]
+   :doc    "Triples :input — UNLESS input ≥ fail-at, in which case
+            throws every recompute past that threshold."})
+
+(rf/reg-flow
+  {:id     ::flow-c
+   :inputs [[:a-result] [:b-result]]
+   :output (fn flow-c [a b]
+             ;; Watches :flow-a's and :flow-b's outputs. Only runs
+             ;; when both upstreams have successfully advanced —
+             ;; per rule 3, :flow-c does NOT run on the drain
+             ;; where :flow-b throws.
+             (+ a b))
+   :path   [:c-result]
+   :doc    "Sums :a-result + :b-result. Watches :flow-a and
+            :flow-b's outputs."})
+
+;; ----------------------------------------------------------------------------
+;; Tick handler — the cascade engine
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-fx ::tick
+  (fn [{:keys [db]} _ev]
+    (let [next-tick (inc (:tick-count db))
+          total     (:total-ticks db)]
+      ;; Bump :input — this is the WRITE every flow watches.
+      ;; Per [spec/013 §Dirty-check semantics], the input-change
+      ;; triggers a flows pass; all three flows recompute (or
+      ;; attempt to) in topo order.
+      {:db (-> db
+               (assoc :input      next-tick)
+               (assoc :tick-count next-tick)
+               (cond->
+                 (>= next-tick total) (assoc :status :done)))})))
+
+(rf/reg-event-fx ::start
+  (fn [{:keys [db]} _ev]
+    (let [total   (:total-ticks db)
+          tick-ms default-tick-ms]
+      ;; Pre-schedule every tick at boot — the cascade is data,
+      ;; not a recursive timer chain. Per [spec/002 §Cascade
+      ;; propagation], `:dispatch-later` captures the current
+      ;; frame id at scheduling time so every tick lands on the
+      ;; right frame regardless of when the timer fires.
+      ;;
+      ;; The fx vector grows linearly with :total-ticks; for the
+      ;; default 20 ticks this is 20 entries. A consumer testing
+      ;; the cascade halt rules can dial :total-ticks down to a
+      ;; minimum 6-or-so to keep specs fast.
+      {:db (assoc db :status :running :tick-count 0 :input 0)
+       :fx (vec (for [i (range 1 (inc total))]
+                  [:dispatch-later
+                   {:ms (* i tick-ms) :dispatch [::tick]}]))})))
+
+(rf/reg-event-fx ::reset
+  (fn [_ctx _ev]
+    {:fx [[:dispatch [::initialise]]]}))
+
+(rf/reg-event-db ::set-fail-at
+  (fn [db [_ new-fail-at]]
+    (reset! fail-at-atom new-fail-at)
+    (assoc db :fail-at new-fail-at)))
+
+(rf/reg-event-db ::set-total-ticks
+  (fn [db [_ new-total]]
+    (assoc db :total-ticks new-total)))
+
+;; ----------------------------------------------------------------------------
+;; Subs + view
+;; ----------------------------------------------------------------------------
+
+(rf/reg-sub :input       (fn [db _] (:input db)))
+(rf/reg-sub :tick-count  (fn [db _] (:tick-count db)))
+(rf/reg-sub :fail-at     (fn [db _] (:fail-at db)))
+(rf/reg-sub :total-ticks (fn [db _] (:total-ticks db)))
+(rf/reg-sub :status      (fn [db _] (:status db)))
+(rf/reg-sub :a-result    (fn [db _] (:a-result db)))
+(rf/reg-sub :b-result    (fn [db _] (:b-result db)))
+(rf/reg-sub :c-result    (fn [db _] (:c-result db)))
+
+(reg-view buttons []
+  (let [status      @(subscribe [:status])
+        tick-count  @(subscribe [:tick-count])
+        total       @(subscribe [:total-ticks])
+        fail-at     @(subscribe [:fail-at])
+        input-val   @(subscribe [:input])
+        a-result    @(subscribe [:a-result])
+        b-result    @(subscribe [:b-result])
+        c-result    @(subscribe [:c-result])
+        running?    (= status :running)]
+    [:div {:data-testid "long-flow-w-failure"
+           :style {:font-family "sans-serif" :padding "1em"}}
+     [:h1 "long-flow-w-failure testbed"]
+     [:p "A " [:span {:data-testid "duration-label"}
+              (str (/ (* total default-tick-ms) 1000.0))]
+      "-second cascade. Each tick recomputes three flows in topo
+      order; :flow-b throws when :input ≥ fail-at, demonstrating
+      the four-rule flow-failure contract over a human-visible
+      window."]
+
+     [:div {:style {:display :flex :gap "0.5em" :flex-wrap :wrap
+                    :align-items :center :margin-bottom "0.5em"}}
+      [:label
+       "Fail at tick:"
+       [:input {:data-testid "fail-at"
+                :type        "number"
+                :min         1
+                :value       fail-at
+                :style       {:width "4em" :margin-left "0.25em"}
+                :disabled    running?
+                :on-change   (fn [e]
+                               (let [v (js/parseInt (.. e -target -value) 10)]
+                                 (dispatch [::set-fail-at v])))}]]
+      [:label
+       "Total ticks:"
+       [:input {:data-testid "total-ticks"
+                :type        "number"
+                :min         1
+                :value       total
+                :style       {:width "4em" :margin-left "0.25em"}
+                :disabled    running?
+                :on-change   (fn [e]
+                               (let [v (js/parseInt (.. e -target -value) 10)]
+                                 (dispatch [::set-total-ticks v])))}]]
+      [:button {:data-testid "start"
+                :on-click    #(dispatch [::start])
+                :disabled    running?}
+       "Start cascade"]
+      [:button {:data-testid "reset"
+                :on-click    #(dispatch [::reset])}
+       "Reset"]]
+
+     [:p {:style {:color "#666" :white-space :pre-wrap}}
+      "status="     [:span {:data-testid "status"}     (name status)]      "\n"
+      "tick="       [:span {:data-testid "tick"}       (str tick-count "/" total)] "\n"
+      "input="      [:span {:data-testid "input"}      input-val]          "\n"
+      "a-result="   [:span {:data-testid "a-result"}   a-result]
+      "  (= 2 × input — rule 1 evidence)"                                  "\n"
+      "b-result="   [:span {:data-testid "b-result"}   b-result]
+      "  (= 3 × input until tick=" fail-at
+      "; thereafter unchanged — rule 2 evidence)"                          "\n"
+      "c-result="   [:span {:data-testid "c-result"}   c-result]
+      "  (= a + b until tick=" fail-at
+      "; thereafter unchanged — rule 3 evidence)"]]))
+
+(reg-view root []
+  [buttons])
+
+;; ----------------------------------------------------------------------------
+;; Mount
+;; ----------------------------------------------------------------------------
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  (rf/dispatch-sync [::initialise])
+  (rdc/render react-root [root]))

--- a/testbeds/long_flow_w_failure/index.html
+++ b/testbeds/long_flow_w_failure/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: long-flow-w-failure</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/testbeds/multi_frame/README.md
+++ b/testbeds/multi_frame/README.md
@@ -1,0 +1,103 @@
+# `testbeds/multi-frame`
+
+A three-frame Reagent app — two counter frames (`:counter/a`,
+`:counter/b`) plus an append-only `:log` frame — with a Cross-bump
+button whose handler runs on `:counter/a` and fans out a cross-frame
+`:dispatch` to `:counter/b` and `:log` in a single drain.
+
+The point: a consumer (Causa, Story, pair2-mcp) observes that the
+framework keeps each frame's `app-db`, signal-graph cache, and epoch
+ring buffer cleanly partitioned — even when a single click produces
+events that route to three distinct frames.
+
+| Button | `data-testid` | What it does | What a consumer should see |
+|---|---|---|---|
+| Inc A | `inc-A` | Local dispatch against `:counter/a`. | One epoch in `:counter/a`'s ring buffer; the `:counter/a` `:n` sub recomputes; `:counter/b` and `:log` sub-caches untouched. |
+| Inc B | `inc-B` | Local dispatch against `:counter/b`. | Mirror image of the above on `:counter/b`. |
+| Cross-bump | `cross-bump` | Dispatches `::cross-bump` against `:counter/a`; the handler returns a `:db` update plus `:fx [[:dispatch ... {:frame :counter/b}] [:dispatch ... {:frame :log}]]`. | Three `:event/dispatched` traces in one drain (one per frame); three distinct epoch records; the log entry's payload carries `:from :counter/a` verbatim — evidence the framework didn't rewrite the source-frame identity on the hop. |
+
+## Why three frames
+
+Three is the smallest count that exhibits all the distinct partitions
+a tool needs to distinguish:
+
+- **Two of the same shape** (`:counter/a` and `:counter/b`) — proves
+  isolation of two frames that share the *same handler set* and
+  *same app-db shape*. A consumer that conflates them by handler-id
+  or by sub-key fails here.
+- **One distinct shape** (`:log`) — proves the frame plurality
+  contract is genuinely independent of handler set; the log frame's
+  app-db has no `:n` key at all. A consumer that assumes "all frames
+  have a counter" fails here.
+
+## Cross-frame dispatch — the load-bearing pattern
+
+The Cross-bump handler is `reg-event-fx`; its `:fx` carries reserved
+`:dispatch` entries with explicit `{:frame ...}` opt maps (per
+[spec/002 §Cascade propagation](../../spec/002-Frames.md)). The fx
+walker (`do-fx`) calls `dispatch!` with the requested frame, so each
+queued event lands on the right router queue without per-frame
+plumbing in the handler body.
+
+A consumer that reads the trace stream sees the three dispatches in
+**source order** (per [spec/002 §`:fx` ordering and serial
+execution](../../spec/002-Frames.md)) — the handler's `:db` commits
+first, then `[:dispatch ... :counter/b]` fires, then `[:dispatch
+... :log]` fires. The three frames' `app-db` writes interleave in
+that order against their respective `app-db`s.
+
+## What's deliberately *missing*
+
+- No `subscribe` directly references another frame's value. Cross-
+  frame subscription is supported (per [spec/002 §Cross-frame
+  subscription](../../spec/002-Frames.md)) but it's a different
+  contract from cross-frame dispatch; this surface exists to
+  exercise dispatch isolation. A future testbed can layer cross-
+  frame subs.
+- No `destroy-frame` lifecycle. The three frames are created on app
+  init and live forever; the destroy contract is exercised by tests
+  that own the lifecycle (per [spec/002 §Per-instance frames]).
+- No `:fx-overrides` per frame. Per-frame fx replacement is a
+  separate contract; conflating it with the cross-dispatch shape
+  would dilute what this surface proves.
+
+## Test scenarios from rf2-fe84r this surface enables
+
+**Causa (26)**:
+- **Multi-frame app shows separate epoch ring buffers per frame** —
+  the load-bearing scenario this surface unblocks. After one
+  Cross-bump click, Causa's trace panel must show three distinct
+  epoch records, one per frame, with the correct `:frame` tag on
+  each.
+- Trace panel populates on first dispatch — exercised three times
+  per click on this surface, once per frame.
+- Time-travel scrub forward/back mutates visible UI — needs to scrub
+  three frames independently; per-frame scrubbing exercises here.
+
+**Story (18)**:
+- Time-travel scrub within story preserves frame isolation — Story
+  variants that mount this surface verify the scrubber doesn't leak
+  state across the three frames.
+
+**Cross-cutting (6)**:
+- Subscribe → re-render → trace ordering preserved — exercised
+  per-frame on the inc-A / inc-B paths.
+
+## Running
+
+From `implementation/`:
+
+```bash
+shadow-cljs watch testbeds/multi-frame
+# Or via the orchestrator:
+npm run test:examples
+```
+
+The shadow-cljs build id is `testbeds/multi-frame`; output lands in
+`implementation/out/testbeds/multi-frame/`.
+
+## Cross-references
+
+- [`spec/002-Frames.md` §What lives in a frame](../../spec/002-Frames.md) — the per-frame partitioning contract this surface exercises.
+- [`spec/002-Frames.md` §Dispatches issued from inside a handler body](../../spec/002-Frames.md) — the cross-frame `:dispatch` fx contract the Cross-bump button exercises.
+- [`spec/009-Instrumentation.md` §Per-frame epoch buffers](../../spec/009-Instrumentation.md) — the ring-buffer-per-frame shape Causa's recorder reads against.

--- a/testbeds/multi_frame/core.cljs
+++ b/testbeds/multi_frame/core.cljs
@@ -1,0 +1,204 @@
+(ns multi-frame.core
+  "Shared framework-behavior testbed — three isolated frames living in
+  the same page, with deliberate cross-frame dispatch. A consumer
+  (Causa, Story, pair2-mcp) observes that the framework keeps each
+  frame's `app-db`, signal-graph cache, and epoch ring buffer cleanly
+  partitioned — even when an event dispatched against frame A reaches
+  in to dispatch against frame B during the same drain.
+
+  The three frames:
+
+    :counter/a  → simple counter; the canonical 'frame A' identity.
+    :counter/b  → simple counter; the canonical 'frame B' identity.
+    :log        → append-only event log; a passive sink the bridge
+                  feeds. Demonstrates that an :origin tag carrying the
+                  *source* frame survives the cross-frame hop.
+
+  Three buttons exercise the cross-frame contract:
+
+    Button A · Inc A          → frame :counter/a only
+    Button B · Inc B          → frame :counter/b only
+    Button X · Cross-bump     → handler in :counter/a fans out a
+                                `:fx [[:dispatch ... {:frame ...}]]`
+                                that bumps :counter/b AND appends to
+                                :log/entries. The three frames'
+                                app-dbs diverge in lockstep.
+
+  This is NOT a tutorial — the bodies are minimal. The whole point is
+  to produce three distinct `[:rf/frame ... :rf/app-db ...]` ring
+  buffer entries per click (per [spec/009 §Per-frame epoch buffers])
+  and three distinct sub-cache populations a consumer can diff. No
+  recovery, no error handling, no orchestration prose."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ----------------------------------------------------------------------------
+;; Frames
+;; ----------------------------------------------------------------------------
+;;
+;; Three named frames. The framework guarantees each gets its own
+;; `app-db`, router queue, and signal-graph cache (per [spec/002
+;; §What lives in a frame]). The handler registrar is global — the
+;; ::initialise, ::inc, and ::log-append handlers below are registered
+;; once and resolve against whichever frame the dispatch targets.
+
+(def frame-a   :counter/a)
+(def frame-b   :counter/b)
+(def frame-log :log)
+
+;; ----------------------------------------------------------------------------
+;; App-db initialisers (per-frame shape, registered once)
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-db ::counter-init
+  (fn [_db _ev]
+    {:n 0}))
+
+(rf/reg-event-db ::log-init
+  (fn [_db _ev]
+    {:entries []}))
+
+;; ----------------------------------------------------------------------------
+;; Per-frame counter handlers
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-db ::inc
+  (fn [db _ev]
+    ;; HOT PATH — runs against whichever frame the dispatch targeted.
+    ;; The same handler-fn is exercised once per frame; the framework
+    ;; passes the correct frame's `app-db` to each invocation.
+    (update db :n (fnil inc 0))))
+
+(rf/reg-sub :n (fn [db _] (:n db)))
+
+;; ----------------------------------------------------------------------------
+;; Log frame handler — pure sink for cross-frame writes
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-db ::log-append
+  (fn [db [_ entry]]
+    (update db :entries (fnil conj []) entry)))
+
+(rf/reg-sub :entries (fn [db _] (:entries db)))
+
+;; ----------------------------------------------------------------------------
+;; Cross-frame bridge handler
+;; ----------------------------------------------------------------------------
+;;
+;; The handler RUNS against :counter/a (Button X dispatches against
+;; :counter/a). It returns three fx — one local `:db` write and two
+;; cross-frame `:dispatch` entries targeted at :counter/b and :log.
+;;
+;; Per [spec/002 §Dispatches issued from inside a handler body] the
+;; reserved `:dispatch` fx carries an explicit `{:frame ...}` opt; the
+;; fx walker (`do-fx`) calls `dispatch!` with the requested frame, so
+;; the queued event lands on :counter/b's router queue (not
+;; :counter/a's). Same for :log.
+;;
+;; A consumer that watches the trace stream sees three
+;; `:event/dispatched` traces for one click — one per frame — and
+;; three separate epoch ring buffer entries.
+
+(rf/reg-event-fx ::cross-bump
+  (fn [{:keys [db]} _ev]
+    {;; Local write against :counter/a.
+     :db (update db :n (fnil inc 0))
+     :fx [;; HOT PATH — cross-frame dispatch to :counter/b.
+          [:dispatch [::inc] {:frame frame-b}]
+          ;; HOT PATH — cross-frame dispatch to :log; carries the
+          ;; bridge's source-frame id verbatim as evidence the
+          ;; framework didn't quietly rewrite it.
+          [:dispatch [::log-append {:from frame-a
+                                    :to   #{frame-b frame-log}
+                                    :kind :cross-bump}]
+           {:frame frame-log}]]}))
+
+;; ----------------------------------------------------------------------------
+;; Views
+;; ----------------------------------------------------------------------------
+;;
+;; Each frame gets its own `frame-provider`-rooted subtree; the
+;; `reg-view`-injected `dispatch` / `subscribe` inside each subtree
+;; closes over the providing frame's id. A consumer that diffs the
+;; rendered DOM observes three independent counters / log lines —
+;; each fed by exactly one frame's signal-graph.
+
+(reg-view counter-panel [label]
+  ;; The injected `dispatch` / `subscribe` resolve via React context
+  ;; to the surrounding `frame-provider`'s frame keyword (per [spec/002
+  ;; §View ergonomics]).
+  (let [n @(subscribe [:n])]
+    [:div {:style {:border       "1px solid #aaa"
+                   :padding      "0.5em"
+                   :margin       "0.25em"
+                   :min-width    "10em"}}
+     [:h3 label]
+     [:p "n=" [:span {:data-testid (str "n-" (name label))} n]]
+     [:button {:data-testid (str "inc-" (name label))
+               :on-click    #(dispatch [::inc])}
+      "Inc"]]))
+
+(reg-view log-panel []
+  (let [entries @(subscribe [:entries])]
+    [:div {:style {:border    "1px solid #aaa"
+                   :padding   "0.5em"
+                   :margin    "0.25em"
+                   :min-width "20em"}}
+     [:h3 "log"]
+     [:p "count=" [:span {:data-testid "log-count"} (count entries)]]
+     [:ul {:data-testid "log-entries"
+           :style {:max-height "8em" :overflow :auto}}
+      (for [[idx e] (map-indexed vector entries)]
+        ^{:key idx}
+        [:li (pr-str e)])]]))
+
+(reg-view root []
+  [:div {:data-testid "multi-frame" :style {:font-family "sans-serif" :padding "1em"}}
+   [:h1 "multi-frame testbed"]
+   [:p "Three frames coexist on this page. Each owns its own app-db,
+        router queue, and sub-cache. The Cross-bump button dispatches
+        a fan-out from " [:code ":counter/a"]
+    " that bumps " [:code ":counter/b"] " and appends to "
+    [:code ":log"] " in one drain."]
+
+   [:div {:style {:display :flex :flex-wrap :wrap :align-items :flex-start}}
+    [rf/frame-provider {:frame frame-a}
+     [counter-panel "A"]]
+
+    [rf/frame-provider {:frame frame-b}
+     [counter-panel "B"]]
+
+    [rf/frame-provider {:frame frame-log}
+     [log-panel]]]
+
+   [:div {:style {:margin-top "0.5em"}}
+    ;; The Cross-bump button is OUTSIDE every `frame-provider` — it
+    ;; reads the React-context default (`:rf/default`) and supplies
+    ;; the target frame explicitly via the two-arg dispatch form.
+    ;; The handler then fans out to :counter/b and :log via cross-
+    ;; frame `:dispatch` fx (see ::cross-bump above).
+    [:button {:data-testid "cross-bump"
+              :on-click    #(rf/dispatch [::cross-bump] {:frame frame-a})}
+     "Cross-bump (A → B + log)"]]])
+
+;; ----------------------------------------------------------------------------
+;; Mount
+;; ----------------------------------------------------------------------------
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  ;; Register the three frames before any dispatch. `:on-create`
+  ;; seeds each frame's app-db via the corresponding init handler;
+  ;; the framework runs each frame's `:on-create` against that
+  ;; frame's empty app-db, so the same init handler can be shared
+  ;; across both counter frames.
+  (rf/reg-frame frame-a   {:on-create [::counter-init]})
+  (rf/reg-frame frame-b   {:on-create [::counter-init]})
+  (rf/reg-frame frame-log {:on-create [::log-init]})
+  (rdc/render react-root [root]))

--- a/testbeds/multi_frame/index.html
+++ b/testbeds/multi_frame/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: multi-frame</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Tier 2 of rf2-kzcim — three new shared framework-behavior testbed
surfaces under top-level `testbeds/`, modelled on the Tier 1 trio
shipped in PR #1082.

- **`testbeds/multi_frame/`** — three frames coexisting on one page
  (`:counter/a`, `:counter/b`, `:log`); the Cross-bump button fans
  out a handler running on `:counter/a` to dispatches against
  `:counter/b` and `:log` via cross-frame `:dispatch` fx. Exercises
  the per-frame `app-db` / sub-cache / epoch ring buffer
  partitioning contract per [Spec 002 §What lives in a frame].
- **`testbeds/deep_machine/`** — one machine that, in a single
  registration, exercises every Spec 005 grammar surface:
  `:type :parallel` + hierarchical compound 5 levels deep on
  `:work` (active leaf path `[:work :phase-a :sub-a :nested-a
  :deep-a :leaf-a]`) + `:always` (eventless) on `:resolving` +
  `:after` (200ms) on `:health/warming` + `:invoke` on the
  deepest leaf + `:invoke-all` on `:phase-b` (three children).
- **`testbeds/long_flow_w_failure/`** — a 5-second cascade
  (configurable) of `app-db` writes driving three flows in topo
  order; `:flow-b` throws on a configurable input threshold to
  exercise the four-rule failure semantics per [Spec 013
  §Failure semantics] (rf2-hrqvg) over a human-visible window.
  DOM mirrors `:a-result` / `:b-result` / `:c-result` so a
  Playwright spec can assert each rule's effect without a
  recorder.

Each surface follows the Tier 1 shape: `core.cljs` + `index.html`
+ `README.md` + a per-surface `:testbeds/<kebab-case>` build entry
in `implementation/shadow-cljs.edn` (incl. the Causa dev preload,
mirroring the `:examples/*` convention).

## rf2-fe84r scenarios unlocked

Each surface's README cross-references the consumer scenarios it
enables. The load-bearing ones:

- `multi_frame/` → **Causa: Multi-frame app shows separate epoch
  ring buffers per frame** (plus 2 more Causa scenarios + Story
  time-travel-preserves-frame-isolation + the
  subscribe-trace-ordering cross-cutting scenario).
- `deep_machine/` → **Cross-cutting: State-machine transition
  cascade shows `:rf.machine/*` events** (plus Causa trace-panel-
  populates / click-to-source).
- `long_flow_w_failure/` → **Cross-cutting: Flow `:rf.flow/failed`
  shows four-rule failure semantics (rf2-hrqvg)** (plus Causa
  trace-panel-growth gold-standard + ring-buffer-budget + Story
  recorder-replay).

## Boundaries

- Surfaces exercise framework-behavior **clarity** — they
  deliberately error / blow budgets / produce long cascades. NOT
  tutorial value. No content from these surfaces leaks into
  `examples/`.
- Tests are NOT written here — surfaces only. The Playwright /
  consumer specs that exercise them live in `rf2-fe84r`
  (53-scenario suite).
- rf2-kzcim left OPEN — Tier 3 (devtools edge cases:
  `drain_depth_trigger`, `non_trivial_app_db`,
  `sensitive_dispatcher`, `large_dispatcher`) and Tier 4 (a11y:
  `known_bad_a11y`) still to do.

## Test plan

- [x] `shadow-cljs release testbeds/multi-frame` — clean.
- [x] `shadow-cljs release testbeds/deep-machine` — clean.
- [x] `shadow-cljs release testbeds/long-flow-w-failure` — clean.
- [x] `npm run test:cljs` — 1968 tests / 5586 assertions, 0
      failures, 0 errors.
- [x] `npm run test:bundle-isolation` — PASS (the testbed
      sources stay isolated from the counter bundle, same
      contract as Tier 1).
- [ ] Manual smoke: open each surface in `shadow-cljs watch
      testbeds/<name>` and exercise the buttons; trace stream
      shows the expected `:rf.error/*` / `:rf.machine/*` /
      `:rf.flow/*` events.