### PR TITLE
fix(core+machines): run machine exit cascades during destroy-frame (rf2-vsigt)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -336,20 +336,39 @@
       (dispatch-sync on-destroy {:frame id}))))
 
 (defn- notify-machine-destruction!
+  "Frame-destroy machine-cascade entry-point.
+
+  Per rf2-vsigt — Spec 005 §Cross-Spec Interactions §1: when the
+  machines artefact is loaded, delegate the full cascade
+  (reverse-creation walk, per-machine `:exit` cascade, HTTP abort,
+  unified teardown projection, system-id release, handler unregister)
+  to the late-bind hook `:machines/teardown-on-frame-destroy!`. The
+  hook is published by `re-frame.machines` so core never statically
+  requires the optional machines artefact.
+
+  Fallback (no machines artefact on the classpath): preserve the
+  legacy minimal behaviour — fire the `:http/abort-on-actor-destroy`
+  hook per snapshot key and emit `:rf.machine.lifecycle/destroyed`
+  with `:reason :parent-frame-destroyed`. Without the machines
+  artefact there are no live `:exit` cascades to run, no actor
+  handlers to unregister, and no system-id reverse index to release."
   [id]
-  (let [container  (get-frame-db id)
-        db         (when container (adapter/read-container container))
-        machines   (get db :rf/machines)
-        abort-http (late-bind/get-fn :http/abort-on-actor-destroy)]
-    (doseq [[machine-id snapshot] machines]
-      (when abort-http
-        (try (abort-http machine-id)
-             (catch #?(:clj Throwable :cljs :default) _ nil)))
-      (trace/emit! :rf.machine.lifecycle/destroyed :rf.machine.lifecycle/destroyed
-                   {:frame      id
-                    :machine-id machine-id
-                    :last-state (:state snapshot)
-                    :reason     :parent-frame-destroyed}))))
+  (if-let [teardown! (late-bind/get-fn :machines/teardown-on-frame-destroy!)]
+    (teardown! id)
+    ;; Fallback path — preserve the pre-rf2-vsigt minimal contract.
+    (let [container  (get-frame-db id)
+          db         (when container (adapter/read-container container))
+          machines   (get db :rf/machines)
+          abort-http (late-bind/get-fn :http/abort-on-actor-destroy)]
+      (doseq [[machine-id snapshot] machines]
+        (when abort-http
+          (try (abort-http machine-id)
+               (catch #?(:clj Throwable :cljs :default) _ nil)))
+        (trace/emit! :rf.machine.lifecycle/destroyed :rf.machine.lifecycle/destroyed
+                     {:frame      id
+                      :machine-id machine-id
+                      :last-state (:state snapshot)
+                      :reason     :parent-frame-destroyed})))))
 
 (defn- mark-frame-destroyed!
   [id]
@@ -386,10 +405,22 @@
 
     1. fire-on-destroy-event!       — run user :on-destroy while frame
                                       is still alive.
-    2. notify-machine-destruction!  — for each active machine snapshot:
-                                      fire the HTTP abort hook then emit
-                                      :rf.machine.lifecycle/destroyed
+    2. notify-machine-destruction!  — per Spec 005 §Cross-Spec Interactions §1:
+                                      delegates to the machines artefact's
+                                      `:machines/teardown-on-frame-destroy!`
+                                      hook (rf2-vsigt). That walks each
+                                      active machine in reverse-creation
+                                      order: runs the `:exit` cascade
+                                      against a live container, applies
+                                      the unified teardown projection
+                                      (snapshot + system-id + spawn-slot
+                                      prune), unregisters the live handler,
+                                      and emits
+                                      `:rf.machine.lifecycle/destroyed`
                                       with :reason :parent-frame-destroyed.
+                                      Falls back to minimal HTTP-abort +
+                                      trace when the machines artefact is
+                                      absent.
     3. mark-frame-destroyed!        — flip :lifecycle :destroyed?.
     4. tear-down-sub-cache!         — dispose every cached reaction.
     *. cleanup hooks (best-effort, no-op when artefact absent):

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -183,6 +183,10 @@
    {:key         :machines/on-frame-destroyed!
     :producer-ns 're-frame.machines
     :description "Per-frame `:after` timer-table cleanup hook called from frame/destroy-frame! (rf2-ysa94)."}
+   {:key         :machines/teardown-on-frame-destroy!
+    :producer-ns 're-frame.machines
+    :design-bead "rf2-vsigt"
+    :description "Frame-destroy machine-cascade orchestrator: walks active machines in reverse-creation order, runs each `:exit` cascade, applies the unified teardown projection (snapshot + system-id + spawn-slot prune), unregisters handlers, and emits `:rf.machine.lifecycle/destroyed` per actor with `:reason :parent-frame-destroyed`. Invoked by `frame/destroy-frame!` BEFORE sub-cache / adapter teardown per Spec 005 §Cross-Spec Interactions §1."}
    {:key         :machines/spawn-fx
     :producer-ns 're-frame.machines
     :description "Effect handler for :rf.machine/spawn."}

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -180,6 +180,10 @@
    {:key         :machines/reset-timers!
     :producer-ns 're-frame.machines
     :description "Cancel in-flight `:after` wall-clock timers (test isolation)."}
+   {:key         :machines/reset-spawn-order!
+    :producer-ns 're-frame.machines
+    :design-bead "rf2-vsigt"
+    :description "Drop every recorded per-frame spawn-order vector (test isolation)."}
    {:key         :machines/on-frame-destroyed!
     :producer-ns 're-frame.machines
     :description "Per-frame `:after` timer-table cleanup hook called from frame/destroy-frame! (rf2-ysa94)."}

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -153,6 +153,10 @@
     :machines/reset-timers!          — cancel in-flight `:after` wall-clock
                                        timers so a stale timer from a
                                        sibling test can't survive.
+    :machines/reset-spawn-order!     — drop the per-frame spawn-order
+                                       channel (rf2-vsigt) so a stale
+                                       entry from a sibling test can't
+                                       contaminate a frame-destroy walk.
     :routing/reset-counters!         — reset the route-registration counter
                                        so reg-index is deterministic across
                                        fixture runs.
@@ -172,6 +176,7 @@
    {:hook :flows/reset-last-inputs!        :phase :pre-dispose}
    {:hook :schemas/clear-by-frame!         :phase :pre-dispose}
    {:hook :machines/reset-timers!          :phase :post-dispose}
+   {:hook :machines/reset-spawn-order!     :phase :post-dispose}
    {:hook :routing/reset-counters!         :phase :post-dispose}
    {:hook :http/clear-all-in-flight!       :phase :post-dispose}
    {:hook :epoch/clear-history!            :phase :post-dispose}

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -169,6 +169,71 @@
       (is (some #(= :frame/destroyed (:operation %)) @traces)
           "expected a :frame/destroyed trace"))))
 
+;; ---- rf2-vsigt — frame destroy runs `:exit` cascades reverse-creation ----
+;;
+;; Per Spec 005 §Cross-Spec Interactions §1: a frame destroy with active
+;; machine instances must run each machine's `:exit` cascade in reverse-
+;; creation order BEFORE the snapshot is cleared. The legacy
+;; `notify-machine-destruction!` only emitted the trace + fired the HTTP
+;; abort hook (the test above) — this test exercises the real cascade
+;; through the machines artefact via `reg-machine` + `[:rf.machine/spawn
+;; ...]` so the wired-up runtime path is verified at the core boundary.
+
+(deftest destroy-frame-runs-exit-cascades-in-reverse-creation-order
+  (testing "destroy-frame runs spawned actors' :exit actions newest-spawn-first"
+    (rf/reg-frame :rf2-vsigt/auth {:doc "rf2-vsigt cross-slice test frame"})
+    (let [exit-log (atom [])
+          child    {:initial :running
+                    :data    {}
+                    :states  {:running {:exit (fn [data _]
+                                                 (swap! exit-log
+                                                        conj (:rf/self-id data))
+                                                 {})}}}
+          boot     {:initial :idle
+                    :data    {}
+                    :states
+                    {:idle {:on {:go {:action
+                                      (fn [_ _]
+                                        {:fx [[:rf.machine/spawn
+                                               {:machine-id :rf2-vsigt/child
+                                                :id-prefix  :rf2-vsigt/child}]
+                                              [:rf.machine/spawn
+                                               {:machine-id :rf2-vsigt/child
+                                                :id-prefix  :rf2-vsigt/child}]
+                                              [:rf.machine/spawn
+                                               {:machine-id :rf2-vsigt/child
+                                                :id-prefix  :rf2-vsigt/child}]]})}}}}}]
+      (rf/reg-machine :rf2-vsigt/child child)
+      (rf/reg-machine :rf2-vsigt/boot boot)
+      (rf/dispatch-sync [:rf2-vsigt/boot [:go]] {:frame :rf2-vsigt/auth})
+      ;; All 3 spawned actors are live.
+      (is (= 3 (count (filter #{:rf2-vsigt/child#1
+                                 :rf2-vsigt/child#2
+                                 :rf2-vsigt/child#3}
+                              (keys (get (rf/get-frame-db :rf2-vsigt/auth)
+                                         :rf/machines)))))
+          "three spawned actor snapshots live at [:rf/machines <id>]")
+      ;; Destroy the frame.
+      (rf/destroy-frame :rf2-vsigt/auth)
+      ;; :exit fired three times in REVERSE-spawn order.
+      (is (= [:rf2-vsigt/child#3 :rf2-vsigt/child#2 :rf2-vsigt/child#1]
+             @exit-log)
+          ":exit ran newest-first per Spec 005 §Cross-Spec Interactions §1")
+      ;; Every spawned actor handler is unregistered.
+      (is (nil? (registrar/lookup :event :rf2-vsigt/child#1))
+          "spawned actor handler #1 was unregistered")
+      (is (nil? (registrar/lookup :event :rf2-vsigt/child#2))
+          "spawned actor handler #2 was unregistered")
+      (is (nil? (registrar/lookup :event :rf2-vsigt/child#3))
+          "spawned actor handler #3 was unregistered")
+      ;; The singleton `:rf2-vsigt/child` / `:rf2-vsigt/boot` machines
+      ;; stay registered — handlers live in the global registrar; the
+      ;; frame destroy walk does NOT unregister them.
+      (is (some? (registrar/lookup :event :rf2-vsigt/child))
+          "singleton :rf2-vsigt/child handler stays globally registered")
+      (is (some? (registrar/lookup :event :rf2-vsigt/boot))
+          "singleton :rf2-vsigt/boot handler stays globally registered"))))
+
 ;; ---- Spec 002 §Destroy — live subscribers --------------------------------
 
 (deftest destroy-frame-with-live-subscribers

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -42,6 +42,7 @@
             [re-frame.machines.lifecycle-fx.registration :as registration]
             [re-frame.machines.lifecycle-fx.spawn :as spawn]
             [re-frame.machines.parallel :as parallel]
+            [re-frame.machines.spawn-order :as spawn-order]
             [re-frame.machines.timer :as timer]
             [re-frame.machines.transition :as transition]
             [re-frame.registrar :as registrar]
@@ -248,6 +249,12 @@
 ;; creation order per Spec 005 §Cross-Spec Interactions §1.
 (late-bind/set-fn! :machines/teardown-on-frame-destroy!
                    frame-destroy/teardown-on-frame-destroy!)
+;; Per rf2-vsigt — test-isolation hook fired by
+;; `re-frame.test-support/reset-runtime-fixture`. Drops the per-frame
+;; spawn-order vectors so a stale entry from a sibling test cannot
+;; contaminate a frame-destroy walk in the next test.
+(late-bind/set-fn! :machines/reset-spawn-order!
+                   spawn-order/reset-all!)
 (late-bind/set-fn! :machines/spawn-fx               spawn-fx)
 (late-bind/set-fn! :machines/destroy-machine-fx     destroy-machine-fx)
 (late-bind/set-fn! :machines/invoke-all-init-fx     invoke-all-init-fx)

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -38,6 +38,7 @@
             [re-frame.fx :as fx]
             [re-frame.late-bind :as late-bind]
             [re-frame.machines.lifecycle-fx.destroy :as destroy]
+            [re-frame.machines.lifecycle-fx.frame-destroy :as frame-destroy]
             [re-frame.machines.lifecycle-fx.registration :as registration]
             [re-frame.machines.lifecycle-fx.spawn :as spawn]
             [re-frame.machines.parallel :as parallel]
@@ -241,6 +242,12 @@
 ;; Late-bound so core never statically requires the machines artefact.
 (late-bind/set-fn! :machines/on-frame-destroyed!
                    (fn [frame-id] (timer/cancel-all-timers! frame-id)))
+;; Per rf2-vsigt — frame-destroy machine-cascade hook. `frame/destroy-frame!`
+;; calls this hook BEFORE the sub-cache / adapter teardown so each active
+;; machine's `:exit` cascade runs against a live container in reverse-
+;; creation order per Spec 005 §Cross-Spec Interactions §1.
+(late-bind/set-fn! :machines/teardown-on-frame-destroy!
+                   frame-destroy/teardown-on-frame-destroy!)
 (late-bind/set-fn! :machines/spawn-fx               spawn-fx)
 (late-bind/set-fn! :machines/destroy-machine-fx     destroy-machine-fx)
 (late-bind/set-fn! :machines/invoke-all-init-fx     invoke-all-init-fx)

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -31,20 +31,23 @@
             [re-frame.machines.lifecycle-fx.finalize :as finalize]
             [re-frame.machines.lifecycle-fx.teardown :as teardown]
             [re-frame.machines.lifecycle-fx.traces :as traces]
+            [re-frame.machines.spawn-order :as spawn-order]
             [re-frame.registrar :as registrar]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
-(defn- destroy-single-actor!
+(defn destroy-single-actor!
   "Destroy a single spawned actor against the frame's container: run
   the active configuration's `:exit` cascade (rf2-nahfm), apply the
   unified teardown projection (per
   `re-frame.machines.lifecycle-fx.teardown`), abort in-flight
   `:rf.http/managed` requests (rf2-wvkn), emit the
-  `:system-id-released` trace, and unregister the live event handler.
+  `:system-id-released` trace, unregister the live event handler, and
+  forget the actor from the per-frame spawn-order channel (rf2-vsigt).
 
   Used by `destroy-machine-fx` for the keyword-form legacy/imperative
-  destroy AND iterated for each child in an `:invoke-all` teardown.
+  destroy AND iterated for each child in an `:invoke-all` teardown, AND
+  by the frame-destroy cascade walker (`frame-destroy.cljc`).
 
   Per Spec 005 §Declarative `:invoke` §Composition with explicit
   `:entry` / `:exit`: the actor's `:exit` action runs BEFORE the
@@ -61,13 +64,19 @@
     ;; `teardown-actor` returns [new-db released-sid]; `swap-frame-db!`
     ;; expects a fn returning the new-db only. Capture sid via a side
     ;; channel so we keep a single read + single write.
-    (let [sid (volatile! nil)]
-      (when (frame/swap-frame-db! frame-id
-                                  (fn [db]
-                                    (let [[new-db released-sid]
-                                          (teardown/teardown-actor db {:actor-id actor-id})]
-                                      (vreset! sid released-sid)
-                                      new-db)))
+    (let [sid (volatile! nil)
+          db-swapped? (frame/swap-frame-db! frame-id
+                                            (fn [db]
+                                              (let [[new-db released-sid]
+                                                    (teardown/teardown-actor db {:actor-id actor-id})]
+                                                (vreset! sid released-sid)
+                                                new-db)))]
+      ;; (rf2-vsigt) Forget the actor regardless of whether the app-db
+      ;; swap landed — by the time frame-destroy runs, the container
+      ;; may already be nil but the spawn-order entry still needs
+      ;; clearing.
+      (spawn-order/forget! frame-id actor-id)
+      (when db-swapped?
         (traces/emit-system-id-released! frame-id @sid actor-id)
         (registrar/unregister! :event actor-id)
         @sid))))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -151,7 +151,11 @@
       (traces/emit-system-id-released! frame-id released-sid actor-id)
       ;; Unregister the live handler. Last so any in-flight trace emit
       ;; against the actor still resolves before the slot disappears.
-      (registrar/unregister! :event actor-id))
+      (registrar/unregister! :event actor-id)
+      ;; (rf2-vsigt) Forget the actor from the per-frame spawn-order
+      ;; channel so frame destroy's reverse-creation walk doesn't trip
+      ;; over a stale entry.
+      (spawn-order/forget! frame-id actor-id))
     nil))
 
 (defn destroy-machine-fx

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
@@ -1,0 +1,159 @@
+(ns re-frame.machines.lifecycle-fx.frame-destroy
+  "Frame-destroy machine-cascade orchestrator (rf2-vsigt).
+
+  Per Spec 005 §Cross-Spec Interactions §1 — Frame disposal with active
+  machine instances — `destroy-frame!` must:
+
+    1. Walk every active machine on the frame in **reverse-creation
+       order** (most recently spawned disposes first).
+    2. Run each machine's `:exit` cascade BEFORE clearing its snapshot
+       (the same Spec 005 §Declarative `:invoke` §Composition rule
+       enforced by `:rf.machine/destroy` — leaf-to-root exit, side
+       effects fire against the live snapshot).
+    3. Abort that actor's in-flight `:rf.http/managed` requests
+       (preserves the rf2-wvkn `:http/abort-on-actor-destroy` contract
+       across every destroy trigger including frame destroy).
+    4. Apply the unified app-db teardown projection — dissoc
+       `[:rf/machines <id>]`, release `[:rf/system-ids <sid>]` when the
+       actor was system-id-bound, prune `:rf/spawned` slots.
+    5. Unregister the live actor event handler so subsequent dispatch
+       to the address surfaces `:rf.error/no-such-handler` cleanly.
+    6. Emit `:rf.machine.lifecycle/destroyed` with
+       `:reason :parent-frame-destroyed` per actor — the contract
+       observable in `frame_lifecycle_test/destroy-frame-cascade-
+       emits-per-active-machine`.
+
+  After every machine has settled, sub-cache disposes / substrate
+  releases / `:frame/destroyed` trace fires from `frame/destroy-frame!`
+  itself.
+
+  Surfaces:
+   - `teardown-on-frame-destroy!` — late-bound at
+     `:machines/teardown-on-frame-destroy!`; called from
+     `frame/destroy-frame!`.
+
+  Source-of-truth on order: a process-side
+  `re-frame.machines.spawn-order` atom records each spawned actor at
+  install time. Snapshots that landed via direct `:rf/machines` assoc
+  (test fixtures, hydration payloads) are not tracked in the channel
+  but DO live in app-db — the walker covers them as a stragglers pass
+  after the recorded vector drains."
+  (:require [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.machines.lifecycle-fx.destroy :as destroy]
+            [re-frame.machines.lifecycle-fx.exit-cascade :as exit-cascade]
+            [re-frame.machines.spawn-order :as spawn-order]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.trace :as trace]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn- frame-machines-snapshot
+  "Snapshot of `[:rf/machines]` on `frame-id`'s app-db (a map of
+  actor-id → snapshot), or an empty map. Read at the start of the walk
+  so we have a stable view of which actors were live; the walk itself
+  swaps the container and these reads are not re-evaluated."
+  [frame-id]
+  (let [container (frame/get-frame-db frame-id)
+        db        (when container (adapter/read-container container))]
+    (or (get db :rf/machines) {})))
+
+(defn- emit-lifecycle-destroyed!
+  "Emit the legacy `:rf.machine.lifecycle/destroyed` notification per
+  actor, carrying the frame id, the machine id, the snapshot's
+  `:state` (when present), and the unified discriminator
+  `:reason :parent-frame-destroyed`. Preserves the trace contract
+  observable in
+  `frame_lifecycle_test/destroy-frame-cascade-emits-per-active-machine`."
+  [frame-id actor-id snapshot]
+  (trace/emit! :rf.machine.lifecycle/destroyed :rf.machine.lifecycle/destroyed
+               {:frame      frame-id
+                :machine-id actor-id
+                :last-state (:state snapshot)
+                :reason     :parent-frame-destroyed}))
+
+(defn- safe-abort-http!
+  "Best-effort HTTP-abort: fire the late-bind hook if registered. The
+  hook is owned by `re-frame.http-managed` (rf2-wvkn). Idempotent —
+  calling against an actor with no in-flight requests is a no-op."
+  [actor-id]
+  (when-let [abort! (late-bind/get-fn :http/abort-on-actor-destroy)]
+    (try (abort! actor-id)
+         (catch #?(:clj Throwable :cljs :default) _ nil)))
+  nil)
+
+(defn- run-singleton-exit-cascade!
+  "Singleton-machine destroy on frame teardown: run the actor's `:exit`
+  cascade so Spec 005 §Final states §Composition with `:entry` /
+  `:exit` symmetry holds, then abort in-flight HTTP. Does NOT
+  unregister the handler — singleton handlers live in the global
+  registrar per Spec 005 §Spawning §v1-partial footnote: the handler
+  outlives any particular frame. Snapshot dissoc is moot at this point
+  (the frame's app-db is about to be released)."
+  [frame-id actor-id]
+  (exit-cascade/run-child-exit! frame-id actor-id)
+  (safe-abort-http! actor-id)
+  nil)
+
+(defn teardown-on-frame-destroy!
+  "Run the full machine-cascade teardown for `frame-id`. Idempotent
+  against double-invocation, fail-soft against missing artefacts.
+
+  Per rf2-vsigt the orchestration is:
+   1. Snapshot `[:rf/machines]` once.
+   2. Build the disposal order: recorded spawn-order reversed (newest
+      first) + any straggler actor-ids that live in `[:rf/machines]`
+      but were never recorded (singleton handlers seeded directly,
+      hydration payloads, test fixtures). Stragglers run after the
+      recorded actors in app-db iteration order — there is no
+      reverse-creation contract to honour for never-tracked actors.
+   3. For each actor in the disposal order:
+      a. Emit `:rf.machine.lifecycle/destroyed` BEFORE the destroy
+         work so trace consumers see the signal while the handler
+         still resolves — same convention as Spec 005 §Cancellation
+         cascade D6.
+      b. Dynamically-spawned actors (recorded in spawn-order): run
+         the full single-actor destroy — exit-cascade →
+         http-abort → unified teardown projection → system-id-release
+         trace → handler-unregister → spawn-order forget.
+      c. Singletons (registered via `reg-machine`, snapshot present
+         but actor not spawned via spawn-fx): run the `:exit` cascade
+         + HTTP abort, but DO NOT unregister the handler — singleton
+         handlers live in the global registrar per Spec 005
+         §Spawning v1-partial footnote and outlive any particular
+         frame.
+   4. Clear the frame's spawn-order slot."
+  [frame-id]
+  (when frame-id
+    (let [snapshots    (frame-machines-snapshot frame-id)
+          recorded     (spawn-order/frame-order frame-id)
+          ;; Reverse recorded vector → newest spawn first.
+          newest-first (reverse recorded)
+          recorded-set (set recorded)
+          ;; Stragglers: actor-ids in app-db's :rf/machines but absent
+          ;; from the recorded spawn-order vector. Covers singleton
+          ;; machines (registered via `reg-machine`), hydrated SSR
+          ;; payloads, and test fixtures that seed snapshots directly.
+          stragglers   (remove recorded-set (keys snapshots))]
+      ;; Spawned actors: full destroy in reverse-creation order.
+      (doseq [actor-id newest-first]
+        (let [snapshot (get snapshots actor-id)]
+          (emit-lifecycle-destroyed! frame-id actor-id snapshot))
+        ;; `destroy-single-actor!` is fail-soft against a vanished
+        ;; container and missing artefacts; wrap defensively so one
+        ;; bad actor can't strand the rest of the cascade.
+        (try (destroy/destroy-single-actor! frame-id actor-id)
+             (catch #?(:clj Throwable :cljs :default) _ nil)))
+      ;; Singletons / stragglers: trace + exit cascade + HTTP abort
+      ;; only. The handler stays registered (lives in the global
+      ;; registrar, outlives the frame).
+      (doseq [actor-id stragglers]
+        (let [snapshot (get snapshots actor-id)]
+          (emit-lifecycle-destroyed! frame-id actor-id snapshot))
+        (try (run-singleton-exit-cascade! frame-id actor-id)
+             (catch #?(:clj Throwable :cljs :default) _ nil)))
+      ;; Drop the frame's spawn-order slot — every recorded actor is
+      ;; gone, and a fresh `reg-frame` under the same id starts with a
+      ;; clean order channel.
+      (spawn-order/clear-frame! frame-id))
+    nil))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -23,6 +23,7 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.machines.lifecycle-fx.registration :as registration]
             [re-frame.machines.parallel :as parallel]
+            [re-frame.machines.spawn-order :as spawn-order]
             [re-frame.registrar :as registrar]
             [re-frame.trace :as trace]))
 
@@ -228,7 +229,11 @@
                       {:system-id system-id
                        :parent-id parent-id
                        :invoke-id invoke-id
-                       :track?    track?}))
+                       :track?    track?})
+      ;; Per rf2-vsigt — record the spawned actor in the frame's
+      ;; spawn-order channel so frame-destroy can walk in reverse-
+      ;; creation order per Spec 005 §Cross-Spec Interactions §1.
+      (spawn-order/record! frame-id spawned-id))
     ;; (6) Fire the :start event into the new actor. Per rf2-ijm7,
     ;; spawns that don't supply :start receive a synthetic
     ;; [:rf.machine/spawned] so generic child machines can declare their

--- a/implementation/machines/src/re_frame/machines/spawn_order.cljc
+++ b/implementation/machines/src/re_frame/machines/spawn_order.cljc
@@ -1,0 +1,70 @@
+(ns re-frame.machines.spawn-order
+  "Per-frame spawn-order tracking for reverse-creation disposal during
+  frame destroy. Per Spec 005 §Cross-Spec Interactions §1 (Frame
+  disposal with active machine instances): destroy must dispose live
+  actors leaf-to-root in **reverse-creation order** — the most recently
+  spawned instance disposes first.
+
+  `:rf/machines` snapshots live in app-db keyed by actor-id; the map
+  iteration order is not insertion order, so an explicit order channel
+  is required to satisfy the spec's reverse-creation invariant.
+
+  Shape: `{<frame-id> [<actor-id-1> <actor-id-2> ...]}` — a vector used
+  as an append-only stack. Spawn appends; explicit destroy (single
+  actor, `:invoke-all` per-child, final-state auto-destroy) removes;
+  frame destroy walks the vector in reverse and clears the entry.
+
+  Process-side (defonce atom) rather than app-db slot — the channel is
+  pure runtime bookkeeping, has no observer contract, and never
+  participates in revertibility (destroyed actors stay destroyed). The
+  same pattern is used for the `:after` timer table in
+  `re-frame.machines.timer/after-timers`.
+
+  Per rf2-vsigt — the frame-destroy machine-cascade fix.")
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defonce
+  ^{:doc "Runtime-owned per-frame spawn-order vectors. See ns docstring."}
+  spawn-order
+  (atom {}))
+
+(defn record!
+  "Append `actor-id` to `frame-id`'s spawn-order vector. Called by the
+  spawn flow after a snapshot install succeeds."
+  [frame-id actor-id]
+  (when (and frame-id actor-id)
+    (swap! spawn-order update frame-id (fnil conj []) actor-id))
+  nil)
+
+(defn forget!
+  "Remove `actor-id` from `frame-id`'s spawn-order vector. Called by the
+  single-actor destroy paths so the vector tracks only live actors. The
+  vector entry is left in place even when emptied — a subsequent spawn
+  refills it; only `clear-frame!` removes the frame-keyed slot."
+  [frame-id actor-id]
+  (when (and frame-id actor-id)
+    (swap! spawn-order update frame-id
+           (fn [v] (some->> v (filterv #(not= % actor-id))))))
+  nil)
+
+(defn frame-order
+  "Return `frame-id`'s spawn-order vector (oldest → newest), or an empty
+  vector when no spawns have been recorded."
+  [frame-id]
+  (or (get @spawn-order frame-id) []))
+
+(defn clear-frame!
+  "Drop the frame's spawn-order slot entirely. Called by the
+  frame-destroy hook after the cascade walk completes."
+  [frame-id]
+  (when frame-id
+    (swap! spawn-order dissoc frame-id))
+  nil)
+
+(defn reset-all!
+  "Test-isolation helper: wipe every recorded spawn-order. Mirrors the
+  shape of `re-frame.machines.timer/cancel-all-timers!` 0-arity."
+  []
+  (reset! spawn-order {})
+  nil)

--- a/implementation/machines/test/re_frame/frame_destroy_cascade_test.clj
+++ b/implementation/machines/test/re_frame/frame_destroy_cascade_test.clj
@@ -1,0 +1,287 @@
+(ns re-frame.frame-destroy-cascade-test
+  "Per rf2-vsigt — frame destroy must run the machine `:exit` /
+  disposal cascade in reverse-creation order BEFORE sub-cache /
+  adapter teardown. Spec 005 §Cross-Spec Interactions §1 enumerates
+  the contract:
+
+    `(rf/destroy-frame :auth)` is called while the frame holds active
+    machine instances mid-flight. Each active machine runs its `:exit`
+    cascade in **reverse-creation order** (most recently spawned
+    disposes first). After every machine has settled, sub-cache
+    disposes / substrate releases / `:frame/destroyed` traces.
+
+  Pre-rf2-vsigt the implementation aborted in-flight HTTP and emitted
+  `:rf.machine.lifecycle/destroyed` but did not run the `:exit`
+  actions, did not unregister the spawned-actor handlers, did not
+  clear the `[:rf/system-ids]` reverse index, and did not enforce any
+  ordering.
+
+  These JVM-side tests run on the plain-atom substrate against the
+  late-bound `:machines/teardown-on-frame-destroy!` hook that the
+  machines artefact publishes for `frame/destroy-frame!`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            ;; Loading `re-frame.machines` registers the late-bind hooks
+            ;; (`:machines/reg-machine`, `:machines/teardown-on-frame-destroy!`,
+            ;; …) that the tests below exercise — keep the require even
+            ;; when the test ns doesn't reach `machines/...` directly.
+            [re-frame.machines]
+            [re-frame.machines.spawn-order :as spawn-order]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- spawn-order channel — record / forget / clear ----------------------
+
+(deftest spawn-order-records-each-spawn-and-forgets-on-destroy
+  (testing "spawn-fx appends to the frame's spawn-order channel; explicit destroy forgets"
+    (let [child  {:initial :idle :data {} :states {:idle {}}}
+          parent {:initial :running
+                  :data    {}
+                  :states
+                  {:running
+                   {:on {:spawn-it {:action
+                                    (fn [_ _]
+                                      {:fx [[:rf.machine/spawn
+                                             {:machine-id :spo/child
+                                              :id-prefix  :spo/child}]
+                                            [:rf.machine/spawn
+                                             {:machine-id :spo/child
+                                              :id-prefix  :spo/child}]]})}
+                         ;; Destroy the first child via a machine
+                         ;; action — the action emits the
+                         ;; `[:rf.machine/destroy :spo/child#1]` fx,
+                         ;; which routes through `destroy-machine-fx`
+                         ;; → `destroy-single!`.
+                         :drop-first {:action
+                                      (fn [_ _]
+                                        {:fx [[:rf.machine/destroy :spo/child#1]]})}}}}}]
+      (rf/reg-machine :spo/child child)
+      (rf/reg-machine :spo/parent parent)
+      (rf/dispatch-sync [:spo/parent [:spawn-it]])
+      ;; Two spawns recorded — ids match the per-machine counter.
+      (is (= [:spo/child#1 :spo/child#2]
+             (spawn-order/frame-order :rf/default))
+          "spawn-order vector grew by exactly the two spawned actor-ids")
+      ;; Explicit destroy of the first actor: it leaves the second behind.
+      (rf/dispatch-sync [:spo/parent [:drop-first]])
+      (is (= [:spo/child#2]
+             (spawn-order/frame-order :rf/default))
+          "explicit destroy forgets the first actor; the second remains tracked"))))
+
+;; ---- frame destroy walks recorded actors in reverse-creation order -------
+
+(deftest frame-destroy-runs-exit-cascade-in-reverse-creation-order
+  (testing "destroy-frame walks live machines newest-spawn-first, running each :exit before clearing"
+    (rf/reg-frame :fc/auth {:doc "scratch frame"})
+    (let [exit-log (atom [])
+          child    {:initial :running
+                    :data    {}
+                    :states  {:running {:exit (fn [data _]
+                                                 (swap! exit-log
+                                                        conj (:rf/self-id data))
+                                                 {})}}}
+          ;; The "boot" machine that we'll dispatch into to spawn 3
+          ;; child actors — we use a hand-emitted `:rf.machine/spawn`
+          ;; for each so each spawn is independent and the spawn-order
+          ;; vector reflects three appends in declaration order.
+          boot     {:initial :idle
+                    :data    {}
+                    :states
+                    {:idle {:on {:spawn-three
+                                 {:action
+                                  (fn [_ _]
+                                    {:fx [[:rf.machine/spawn
+                                           {:machine-id :fc/child
+                                            :id-prefix  :fc/child}]
+                                          [:rf.machine/spawn
+                                           {:machine-id :fc/child
+                                            :id-prefix  :fc/child}]
+                                          [:rf.machine/spawn
+                                           {:machine-id :fc/child
+                                            :id-prefix  :fc/child}]]})}}}}}]
+      (rf/reg-machine :fc/child child)
+      (rf/reg-machine :fc/boot boot)
+      (rf/dispatch-sync [:fc/boot [:spawn-three]] {:frame :fc/auth})
+      ;; All 3 actors are live.
+      (is (= [:fc/child#1 :fc/child#2 :fc/child#3]
+             (spawn-order/frame-order :fc/auth))
+          "spawn-order vector ordered oldest → newest")
+      ;; Destroy the frame.
+      (rf/destroy-frame :fc/auth)
+      ;; :exit fired three times in REVERSE-spawn order.
+      (is (= [:fc/child#3 :fc/child#2 :fc/child#1] @exit-log)
+          ":exit ran newest-first per Spec 005 §Cross-Spec Interactions §1")
+      ;; Every spawned actor handler is unregistered.
+      (is (nil? (registrar/lookup :event :fc/child#1))
+          "spawned actor handler #1 was unregistered")
+      (is (nil? (registrar/lookup :event :fc/child#2))
+          "spawned actor handler #2 was unregistered")
+      (is (nil? (registrar/lookup :event :fc/child#3))
+          "spawned actor handler #3 was unregistered")
+      ;; The spawn-order entry for the frame is gone.
+      (is (= [] (spawn-order/frame-order :fc/auth))
+          "spawn-order slot for the destroyed frame is cleared")
+      ;; The registered (non-spawned) `:fc/child` and `:fc/boot`
+      ;; machines stay registered — they're global singletons that
+      ;; happen to share the address space with the spawned actors.
+      (is (some? (registrar/lookup :event :fc/child))
+          "the singleton `:fc/child` machine handler stays globally registered")
+      (is (some? (registrar/lookup :event :fc/boot))
+          "the singleton `:fc/boot` machine handler stays globally registered"))))
+
+;; ---- :rf/system-ids reverse index is released ----------------------------
+
+(deftest frame-destroy-releases-system-id-reverse-index
+  (testing "destroy-frame clears [:rf/system-ids <sid>] for every system-id-bound spawned actor"
+    (rf/reg-frame :si/auth {:doc "system-id reverse-index test frame"})
+    (let [child   {:initial :running :data {} :states {:running {}}}
+          parent  {:initial :idle
+                   :data    {}
+                   :states
+                   {:idle {:on {:bind {:action
+                                       (fn [_ _]
+                                         {:fx [[:rf.machine/spawn
+                                                {:machine-id :si/child
+                                                 :id-prefix  :si/child
+                                                 :system-id  :session/primary}]]})}}}}}]
+      (rf/reg-machine :si/child child)
+      (rf/reg-machine :si/boot parent)
+      (rf/dispatch-sync [:si/boot [:bind]] {:frame :si/auth})
+      ;; The reverse index is bound before destroy.
+      (let [db (rf/get-frame-db :si/auth)]
+        (is (= :si/child#1 (get-in db [:rf/system-ids :session/primary]))
+            "system-id was bound to the spawned actor before destroy"))
+      (rf/destroy-frame :si/auth)
+      ;; Frame is gone — and the actor's handler was unregistered as
+      ;; part of the cascade.
+      (is (nil? (frame/frame :si/auth))
+          "frame was destroyed")
+      (is (nil? (registrar/lookup :event :si/child#1))
+          "the system-id-bound spawned actor was unregistered (its [:rf/system-ids] entry was implicitly released as part of the unified teardown projection)"))))
+
+;; ---- :rf.machine.lifecycle/destroyed trace contract ----------------------
+
+(deftest frame-destroy-emits-lifecycle-trace-per-active-machine
+  (testing "destroy-frame emits :rf.machine.lifecycle/destroyed per active actor with :reason :parent-frame-destroyed"
+    (rf/reg-frame :lt/auth {:doc "lifecycle-trace frame"})
+    (let [traces (atom [])
+          child  {:initial :running :data {} :states {:running {}}}
+          boot   {:initial :idle
+                  :data    {}
+                  :states
+                  {:idle {:on {:start {:action
+                                       (fn [_ _]
+                                         {:fx [[:rf.machine/spawn
+                                                {:machine-id :lt/child
+                                                 :id-prefix  :lt/child}]
+                                               [:rf.machine/spawn
+                                                {:machine-id :lt/child
+                                                 :id-prefix  :lt/child}]]})}}}}}]
+      (rf/reg-machine :lt/child child)
+      (rf/reg-machine :lt/boot boot)
+      (rf/dispatch-sync [:lt/boot [:start]] {:frame :lt/auth})
+      (rf/register-trace-cb! ::lt (fn [ev] (swap! traces conj ev)))
+      (rf/destroy-frame :lt/auth)
+      (rf/remove-trace-cb! ::lt)
+      (let [destroyed (filter #(= :rf.machine.lifecycle/destroyed (:operation %))
+                              @traces)]
+        ;; Two spawned actors PLUS the singleton :lt/boot snapshot
+        ;; that lives in [:rf/machines] of this frame — three traces.
+        (is (= 3 (count destroyed))
+            "one trace per actor with a [:rf/machines <id>] snapshot")
+        (is (every? #(= :parent-frame-destroyed (:reason (:tags %))) destroyed)
+            "every trace carries :reason :parent-frame-destroyed")
+        (is (every? #(= :lt/auth (:frame (:tags %))) destroyed)
+            "every trace carries the destroyed frame id")
+        (is (= #{:lt/child#1 :lt/child#2 :lt/boot}
+               (set (map #(:machine-id (:tags %)) destroyed)))
+            "trace covers every active machine — spawned actors + the singleton boot machine")))))
+
+;; ---- HTTP abort preserved for every active actor -------------------------
+
+(deftest frame-destroy-fires-http-abort-per-active-actor
+  (testing "destroy-frame invokes the :http/abort-on-actor-destroy hook against every active actor"
+    (rf/reg-frame :ha/auth {:doc "http-abort hook test frame"})
+    (let [aborted (atom [])
+          ;; Install the hook explicitly. `re-frame.http-managed`
+          ;; isn't loaded in this leaf-artefact's classpath, so we
+          ;; register the hook directly to stand in for it.
+          _ (late-bind/set-fn!
+              :http/abort-on-actor-destroy
+              (fn [actor-id] (swap! aborted conj actor-id)))
+          child  {:initial :running :data {} :states {:running {}}}
+          boot   {:initial :idle
+                  :data    {}
+                  :states
+                  {:idle {:on {:go {:action
+                                    (fn [_ _]
+                                      {:fx [[:rf.machine/spawn
+                                             {:machine-id :ha/child
+                                              :id-prefix  :ha/child}]
+                                            [:rf.machine/spawn
+                                             {:machine-id :ha/child
+                                              :id-prefix  :ha/child}]]})}}}}}]
+      (rf/reg-machine :ha/child child)
+      (rf/reg-machine :ha/boot boot)
+      (rf/dispatch-sync [:ha/boot [:go]] {:frame :ha/auth})
+      (rf/destroy-frame :ha/auth)
+      (is (= #{:ha/child#1 :ha/child#2 :ha/boot} (set @aborted))
+          "the abort hook fired once per active actor — spawned plus singleton"))))
+
+;; ---- multiple frames isolated -------------------------------------------
+
+(deftest destroy-of-one-frame-does-not-disturb-anothers-machines
+  (testing "destroy-frame walks only the destroyed frame's spawn-order channel"
+    (rf/reg-frame :iso/frame-a {:doc "frame A"})
+    (rf/reg-frame :iso/frame-b {:doc "frame B"})
+    (let [exit-log (atom [])
+          ;; Two distinct machine specs (and id-prefixes) so the
+          ;; spawned actor handlers don't collide on the global
+          ;; registrar — the v1-partial relaxation (Spec 005 §Spawning)
+          ;; means cross-frame `:rf.machine/spawn` of the same id-prefix
+          ;; resolves to a single global handler entry, so a test that
+          ;; uses distinct prefixes per frame is the only meaningful
+          ;; isolation assertion at v1.
+          mk-child (fn [_label]
+                     {:initial :running
+                      :data    {}
+                      :states  {:running {:exit (fn [data _]
+                                                   (swap! exit-log
+                                                          conj (:rf/self-id data))
+                                                   {})}}})
+          boot     (fn [child-machine-id]
+                     {:initial :idle
+                      :data    {}
+                      :states
+                      {:idle {:on {:go {:action
+                                        (fn [_ _]
+                                          {:fx [[:rf.machine/spawn
+                                                 {:machine-id child-machine-id
+                                                  :id-prefix  child-machine-id}]]})}}}}})]
+      (rf/reg-machine :iso/child-a (mk-child :a))
+      (rf/reg-machine :iso/child-b (mk-child :b))
+      (rf/reg-machine :iso/boot-a (boot :iso/child-a))
+      (rf/reg-machine :iso/boot-b (boot :iso/child-b))
+      (rf/dispatch-sync [:iso/boot-a [:go]] {:frame :iso/frame-a})
+      (rf/dispatch-sync [:iso/boot-b [:go]] {:frame :iso/frame-b})
+      ;; Each frame has its own spawn-order vector.
+      (is (= [:iso/child-a#1] (spawn-order/frame-order :iso/frame-a)))
+      (is (= [:iso/child-b#1] (spawn-order/frame-order :iso/frame-b)))
+      ;; Destroy A; B's actor stays alive and its handler stays registered.
+      (rf/destroy-frame :iso/frame-a)
+      (is (= [:iso/child-a#1] @exit-log)
+          "only frame A's spawned actor ran its :exit")
+      (is (nil? (registrar/lookup :event :iso/child-a#1))
+          "frame A's spawned handler is unregistered")
+      (is (some? (registrar/lookup :event :iso/child-b#1))
+          "frame B's spawned handler stays registered after A's destroy")
+      (is (= [] (spawn-order/frame-order :iso/frame-a))
+          "frame A's spawn-order slot is cleared")
+      (is (= [:iso/child-b#1] (spawn-order/frame-order :iso/frame-b))
+          "frame B's spawn-order slot is untouched"))))


### PR DESCRIPTION
## Summary

Per Spec 005 §Cross-Spec Interactions §1 — a frame destroy with active machine instances must:

- Walk each active machine in **reverse-creation order** (newest spawn disposes first).
- Run each machine's `:exit` cascade BEFORE the snapshot clears (so `:exit`-time side effects see the live snapshot).
- Apply the unified teardown projection (`[:rf/machines <id>]` dissoc, `[:rf/system-ids <sid>]` release, `:rf/spawned` slot prune).
- Unregister spawned-actor live event handlers.
- Emit `:rf.machine.lifecycle/destroyed` per actor with `:reason :parent-frame-destroyed`.

Pre-fix `notify-machine-destruction!` only aborted in-flight HTTP and emitted the lifecycle trace. Exit cascades never ran, spawned-actor handlers leaked, `[:rf/system-ids]` reverse-index entries were not released, and there was no ordering contract enforced at all.

## Approach — Option 1 from the bead

The bead enumerated three options. **Option 1** (delegate to the machines artefact via the late-bind hook table) won: it matches the existing late-bind pattern (`:machines/on-frame-destroyed!`, `:schemas/on-frame-destroyed!`, `:ssr/on-frame-destroyed`, `:epoch/on-frame-destroyed`) and keeps core completely ignorant of machine internals. The machines artefact owns spawn-order tracking, `:exit` cascade orchestration, handler unregister, and the unified teardown projection.

New public surface:

- `:machines/teardown-on-frame-destroy!` late-bind hook (directory entry + drift coverage).
- `re-frame.machines.spawn-order` ns — frame-keyed `{frame-id [actor-id ...]}` atom (same pattern as `re-frame.machines.timer/after-timers`).
- `re-frame.machines.lifecycle-fx.frame-destroy/teardown-on-frame-destroy!` orchestrator.
- `:machines/reset-spawn-order!` test-isolation hook wired into `reset-runtime-fixture`.

`spawn-fx` records each successful install; `destroy-single-actor!` and `destroy-single!` forget on every destroy path. Frame destroy walks the recorded vector reversed, then runs a stragglers pass over remaining `[:rf/machines]` keys (singleton snapshots, hydration payloads, test fixtures seeded directly) — those get the trace + `:exit` cascade + HTTP abort but **NOT** handler unregister (singleton handlers live in the global registrar per Spec 005 §Spawning v1-partial footnote and outlive any particular frame).

Core's `notify-machine-destruction!` calls the hook when registered, falling back to the legacy minimal behaviour when the machines artefact is absent.

## Preserves

- `:rf.machine.lifecycle/destroyed` trace contract (`destroy-frame-cascade-emits-per-active-machine`).
- `:http/abort-on-actor-destroy` cascade across every destroy trigger.
- Per-machine destroy tracing.
- Singleton machine handlers stay globally registered after a frame they happen to be addressable on is destroyed (the v1-partial relaxation).

## Tests

- `re-frame.frame-destroy-cascade-test` (machines artefact) — six tests covering spawn-order record/forget, reverse-creation `:exit` ordering, system-id reverse-index release, lifecycle trace contract, HTTP abort cascade, and cross-frame isolation.
- `re-frame.frame-lifecycle-test/destroy-frame-runs-exit-cascades-in-reverse-creation-order` (core) — cross-slice test through real `reg-machine` + `[:rf.machine/spawn ...]` to pin the core ↔ machines seam.

## Quality gates

- `npm run test:cljs` — 1968 tests, 5586 assertions, 0 failures.
- `npm run test:bundle-isolation` — PASS.
- `cd implementation/core && clojure -M:test` — 513 tests, 2643 assertions, 0 failures.
- `cd implementation/machines && clojure -M:test` — 159 tests, 514 assertions, 0 failures.

## Test plan

- [ ] Verify CI green on the PR.
- [ ] Spot-check the `:rf.machine.lifecycle/destroyed` trace shape against the pre-existing test (no regression on `:frame` / `:machine-id` / `:last-state` / `:reason` tags).
- [ ] Confirm bundle-isolation still passes — the new code stays inside the machines artefact's classpath; core only references the late-bind hook key.