### PR TITLE
fix(template-sec): default CSP + production hardening README section (rf2-sh3l8)

### DIFF
--- a/tools/template/src/clj/new/re_frame2/shared/README.md
+++ b/tools/template/src/clj/new/re_frame2/shared/README.md
@@ -62,6 +62,52 @@ npx shadow-cljs release app
 Production output lands in `resources/public/js/`. Serve `resources/public/`
 from any static host.
 
+## Production hardening
+
+The generated `resources/public/index.html` ships a `<meta http-equiv="Content-Security-Policy" ...>`
+tag so an unconfigured static host still gets a strict default-safe
+baseline. **Prefer setting the same policy as a real response header**
+on your server — meta-tag CSPs are evaluated late (some directives are
+ignored entirely, e.g. `frame-ancestors`) and can be removed by an
+upstream proxy that rewrites HTML.
+
+The scaffold loads only same-origin JS/CSS and has no inline
+script/style, so the strict default policy holds without weakening:
+
+```
+Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'
+X-Content-Type-Options: nosniff
+Referrer-Policy: strict-origin-when-cross-origin
+```
+
+If you add a CDN, embed in an iframe, inline a `<style>` block, or
+load an analytics snippet, **explicitly widen the policy** for that
+origin / hash — don't drop it to `'unsafe-inline'` wholesale.
+
+Example **nginx** server block:
+
+```nginx
+location / {
+  add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+}
+```
+
+Example **Caddy** Caddyfile snippet:
+
+```caddyfile
+header {
+  Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
+  X-Content-Type-Options "nosniff"
+  Referrer-Policy "strict-origin-when-cross-origin"
+}
+```
+
+Always deploy the `release` build (not `watch`) to production — the
+release build sets `:closure-defines {goog.DEBUG false}` (next
+section), strips the Causa preload, and ships the minified bundle.
+
 ## Production builds
 
 `shadow-cljs release` already sets `:closure-defines {goog.DEBUG false}` —

--- a/tools/template/src/clj/new/re_frame2/shared/index.html
+++ b/tools/template/src/clj/new/re_frame2/shared/index.html
@@ -3,6 +3,14 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- Default-safe Content Security Policy. The scaffold only loads
+         same-origin JS/CSS and has no inline script/style, so this
+         strict baseline holds without weakening. For production,
+         prefer serving the same policy via a Content-Security-Policy
+         response header (see README "Production hardening"); the meta
+         tag here is the fall-back when no server-side header is set. -->
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'">
     <title>{{name}} — re-frame2</title>
     <link rel="stylesheet" href="/css/app.css">
   </head>

--- a/tools/template/test/clj/new/re_frame2_test.clj
+++ b/tools/template/test/clj/new/re_frame2_test.clj
@@ -231,6 +231,33 @@
           (is (.contains readme-text "License-MIT")
               "README ships a License badge"))
 
+        ;; -- Security baseline (rf2-sh3l8) --
+        ;;
+        ;; The generated index.html must carry a strict default-safe
+        ;; Content-Security-Policy meta tag, and the README must
+        ;; document a "Production hardening" section covering
+        ;; server-side headers, nosniff, and Referrer-Policy. Together
+        ;; these guarantee that an app deployed unchanged from the
+        ;; scaffold has a browser-enforced mitigation layer, and that
+        ;; the operator knows how to graduate the meta-tag fall-back to
+        ;; real response headers in production.
+        (let [index-text  (slurp (io/file root "resources/public/index.html"))
+              readme-text (slurp (io/file root "README.md"))]
+          (is (.contains index-text "Content-Security-Policy")
+              "index.html ships a CSP meta tag")
+          (is (.contains index-text "default-src 'self'")
+              "index.html CSP uses default-src 'self'")
+          (is (.contains index-text "frame-ancestors 'none'")
+              "index.html CSP forbids framing (anti-clickjacking)")
+          (is (.contains index-text "object-src 'none'")
+              "index.html CSP forbids plugin objects")
+          (is (.contains readme-text "Production hardening")
+              "README documents Production hardening")
+          (is (.contains readme-text "X-Content-Type-Options")
+              "README covers nosniff header")
+          (is (.contains readme-text "Referrer-Policy")
+              "README covers Referrer-Policy header"))
+
         ;; -- best-effort deps-parse with `clojure -P` --
         ;;
         ;; The generated app pins re-frame2 to v0.0.1.alpha (per VERSION


### PR DESCRIPTION
## Summary

Closes the LOW finding from the **rf2-sh3l8** security audit of `tools/template`: generated apps now ship with a strict default-safe browser-security baseline instead of a bare host page.

- **`shared/index.html`** now carries a `<meta http-equiv="Content-Security-Policy" ...>` tag with the strict policy:
  ```
  default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'
  ```
  The scaffold loads only same-origin JS/CSS and has no inline script/style, so the policy holds without weakening.
- **`shared/README.md`** gets a new "Production hardening" section that explains why server-side response headers are preferred (meta-tag CSPs are evaluated late, and `frame-ancestors` is ignored entirely from meta), with copy-pasteable **nginx** and **Caddy** snippets covering CSP + `X-Content-Type-Options: nosniff` + `Referrer-Policy: strict-origin-when-cross-origin`. Also stresses always deploying the `release` build.
- **`test/clj/new/re_frame2_test.clj`** pins the contract: every per-substrate emission test now asserts the generated `index.html` ships the CSP meta tag with the expected directives, and the README documents the hardening section.

Approach: **both** the meta-tag fall-back and the README guidance, per the bead's "preferred + acceptable fallback" recommendation. Programmers expecting safe defaults get them even without configuring server headers; operators who *do* configure headers get the better, server-side path documented inline.

LoC delta: **+81 / -0** across 3 files (8 in index.html, 46 in README, 27 in tests).

## Validation

- `clojure -M:test` from `tools/template/` — 8 tests, **186 assertions**, 0 failures (the new CSP/README assertions pin the contract end-to-end via a real template emission into a tmp dir; runs for all three substrates: Reagent, UIx, Helix).
- `npm run test:cljs` from `implementation/` — **1982 tests, 5627 assertions**, 0 failures.
- `npm run test:bundle-isolation` from `implementation/` — PASS (template surface is build-time-only; no runtime classpath impact).

## Test plan

- [x] Generate Reagent app from template → verify `resources/public/index.html` carries the CSP meta tag (covered by `reagent-substrate-test`)
- [x] Same for UIx (`uix-substrate-test`)
- [x] Same for Helix (`helix-substrate-test`)
- [x] Generated README contains "Production hardening" section with nosniff + Referrer-Policy guidance (covered in all three)
- [x] Existing template tests still pass (file shape, deps coords, shadow-cljs wiring, README badges)
- [x] Implementation CLJS suite + bundle isolation gates unaffected

## Surface

`tools/template/` only — no changes to the `:substrate` allowlist (already correctly gated per the audit's spot check) or any other surface.