### PR TITLE
fix(skill-retro2-sec): narrow tool grant + temp-file filing + opt-in discover-app (rf2-cy498)

### DIFF
--- a/skills/re-frame-pair-retro2/SKILL.md
+++ b/skills/re-frame-pair-retro2/SKILL.md
@@ -29,14 +29,12 @@ description: >
   a real `re-frame-pair2` session must have occurred in this
   conversation or be summarised by the user as a recap.
 allowed-tools:
-  - Bash(gh issue *)
-  - Bash(gh pr *)
   - Read
-  - Edit
-  - Write
   - Grep
   - Glob
-  - mcp__re-frame-pair2__discover-app
+  - Bash(gh issue list *)
+  - Bash(gh issue view *)
+  - Bash(gh issue create *)
 ---
 
 # re-frame-pair-retro2
@@ -56,8 +54,9 @@ Deliver:
 
 - **Always start with session analysis.** Do not jump to fixes.
 - **Friction points before root causes.** Let the user pick which ones to dig into.
-- **Default to diagnosis, not contribution.** Do not assume the user wants to file a GitHub issue or propose a patch.
-- **Never file a GitHub issue or edit another repo without explicit user approval.**
+- **Default to diagnosis, not contribution.** Do not assume the user wants to file a GitHub issue or propose a patch. The default tool grant is read-only — `Read`, `Grep`, `Glob`, plus `gh issue list` / `gh issue view` for searching existing issues. Mutation (`gh issue create`) is granted but gated by the approval rule below.
+- **Never file a GitHub issue without explicit user approval.** Drafting issue text is fine; running `gh issue create` is not, until the user has seen the draft and said go. The skill does NOT carry `Edit` or `Write` in its tool grant — proposing source rewrites in another repo is out of scope; route those as issue suggestions, not edits.
+- **Live-runtime probes are opt-in.** The skill operates on a session transcript or a user-supplied recap — it does not probe the live re-frame2 runtime by default. `mcp__re-frame-pair2__discover-app` and other pair2 MCP tools are NOT in the default tool grant; reach for them only when the retro is explicitly tied to an in-conversation live pair2 session whose runtime is already attached and the user has confirmed a runtime probe is wanted. Recap-only and offline retros never probe.
 - **Stay focused on improving `re-frame-pair2`.** If the right fix is upstream in `re-frame2` (Tool-Pair surfaces, trace stream, epoch-history, schema reflection, source-coord annotation), say so and route the proposal to a GitHub issue against the `re-frame2` repo, not `re-frame-pair2`.
 - **Tracker boundary — file GitHub issues, never `bd` beads.** `bd` is the re-frame2 monorepo's internal tracker; skills consumed downstream file against the target repo's GitHub issues via `gh issue create`. See the shell-safety pattern below.
 - **Do not propose fixes via `re-frame-10x`.** v2's pair tooling does not depend on it. Time-travel and trace-stream consumption ride directly on `re-frame2`'s Tool-Pair surfaces (`register-trace-cb!`, `register-epoch-cb!`, `epoch-history`, `restore-epoch`, `app-schemas`, source-coord annotation).
@@ -107,7 +106,12 @@ If the session is too thin, say so plainly and ask for a recap or permission to 
 
 ## Filing improvements
 
-Never file a GitHub issue without explicit user approval. After presenting the retrospective, offer filing work only if useful: draft issue text, file via `gh issue create` against the appropriate repo, or split into multiple focused issues.
+Filing is a **two-step, approval-gated** mode — distinct from the default diagnose-only mode:
+
+1. **Default mode (no approval needed).** Read the transcript, surface findings, draft issue text inline in the conversation. Use `gh issue list` / `gh issue view` to check whether an existing issue already covers the friction (the default tool grant permits these read paths).
+2. **Filing mode (explicit approval required).** Only after the user has seen a draft and explicitly says "file it" (or equivalent), invoke `gh issue create` against the appropriate repo. The skill MUST NOT run `gh issue create` on its own initiative — `Bash(gh issue create *)` is granted in the frontmatter solely to enable this user-approved transition.
+
+After presenting the retrospective, offer filing work only if useful: draft issue text, file via `gh issue create` against the appropriate repo, or split into multiple focused issues.
 
 **Routing.** `re-frame-pair2` — friction in the pair tool (SKILL.md, scripts, recipes, structured results, attach/discovery, cross-platform). `re-frame2` — friction caused by the framework's Tool-Pair contract (missing trace events, gaps in `epoch-history` / `restore-epoch` failure modes, missing registrar query surfaces, source-coord annotation gaps, schema-reflection shortcomings).
 

--- a/skills/re-frame-pair-retro2/references/known-frictions.md
+++ b/skills/re-frame-pair-retro2/references/known-frictions.md
@@ -139,9 +139,9 @@ Signals:
 - a "why didn't they use tool X?" thread surfaces with no way to confirm X was actually callable in that session
 
 Typical improvements:
-- run `mcp__re-frame-pair2__discover-app` once at the start of a retrospective to capture the live build's id, health, and session sentinel — confirms the runtime the user was operating against and (combined with the server's `tools/list`) sanity-checks "tool X was actually available"
-- when proposing a fix that adds or renames a tool, cross-reference the live catalogue rather than the skill's docs alone
-- if `discover-app` itself fails or returns `:reason :runtime-not-preloaded`, that becomes evidence the user's environment never had the pair2 surface — a finding in its own right, not a retro blocker
+- when the retro is explicitly tied to an in-conversation live pair2 session whose runtime is already attached AND the user has confirmed a runtime probe is wanted, `mcp__re-frame-pair2__discover-app` MAY be invoked to capture the live build's id, health, and session sentinel — confirms the runtime the user was operating against and (combined with the server's `tools/list`) sanity-checks "tool X was actually available". This is **opt-in only** — recap-only or offline retros never probe (the skill's primary contract per `spec/inputs.md` is transcript-only; `mcp__re-frame-pair2__discover-app` is not in the default tool grant). If the user has not confirmed a probe, reason from the transcript alone — the skill's domain is the session shape, not the live runtime.
+- when proposing a fix that adds or renames a tool, cross-reference the live catalogue rather than the skill's docs alone (same opt-in gate applies — only when runtime access is already part of the conversation)
+- if `discover-app` was invoked and itself fails or returns `:reason :runtime-not-preloaded`, that becomes evidence the user's environment never had the pair2 surface — a finding in its own right, not a retro blocker
 
 ### Source-coordinate availability
 


### PR DESCRIPTION
## Summary

Address the three findings from the P2 security audit on `skills/re-frame-pair-retro2` (rf2-cy498). Pragmatic least-privilege — trust the explicit invoker, gate accidents rather than theoretical attacks.

### Finding 1 (High) — over-broad mutation permissions

The diagnose-only retro skill granted `Edit`, `Write`, `Bash(gh pr *)`, and `mcp__re-frame-pair2__discover-app` at the same time the body said "default to diagnosis, not contribution" and "never file without approval". Prompt injection or model error could mutate user code during what's supposed to be a retrospective.

Frontmatter now reads:

```yaml
allowed-tools:
  - Read
  - Grep
  - Glob
  - Bash(gh issue list *)
  - Bash(gh issue view *)
  - Bash(gh issue create *)
```

`Edit`, `Write`, `Bash(gh pr *)`, and `mcp__re-frame-pair2__discover-app` are gone. `Bash(gh issue *)` narrowed to three explicit verbs — `list` + `view` (read-only diagnose-mode defaults) and `create` (granted only to enable the user-approved filing transition).

SKILL.md §Guard rails and §Filing improvements now describe the two-step, approval-gated filing mode: default mode reads / drafts / lists existing issues; filing mode runs `gh issue create` only after the user has seen the draft and said go.

### Finding 2 (High) — shell interpolation of transcript-derived text

Already resolved by rf2-80grk / rf2-hpkkx. SKILL.md §Shell safety and `references/issue-template.md` §Filing with `gh issue create` both demonstrate the canonical here-doc + `gh issue create --body "$(cat /tmp/issue-body.md)"` pattern with a single-quoted `<<'EOF'` delimiter — so `$`, backticks, and `\` stay literal. No changes needed; the bead-recommended pattern is already in place.

### Finding 3 (Medium) — transcript-only contract vs live-runtime probe

`spec/inputs.md` and `spec/design.md` say the skill works on the transcript / recap; `references/known-frictions.md` previously told the agent to invoke `mcp__re-frame-pair2__discover-app` at the start of every retrospective. Resolved by:

- Removing the MCP tool from the default frontmatter grant (above).
- Rewriting the known-friction recommendation so `discover-app` is **opt-in only** — invoked solely when the retro is explicitly tied to an in-conversation live pair2 session whose runtime is already attached AND the user has confirmed a runtime probe. Recap-only and offline retros never probe.

This restores consistency with the transcript-only primary contract.

### Maintainer-specific paths

None found in the skill leaves. The `/tmp/issue-body.md` placeholder in the shell-safety pattern is the standard Unix temp convention from the skills-baseline (`skills/README.md` §Published-skill `allowed-tools` baseline), not a maintainer artefact.

## LoC delta

2 files changed, 15 insertions(+), 11 deletions(-).

## Test plan

- [x] `mkdocs build --strict` produces the same 20 pre-existing warnings as `origin/main` — no new warnings introduced by these edits (the skill tree is not in the mkdocs nav).
- [x] SKILL.md reads coherently end-to-end after the edits — guard rails and filing protocol stay self-consistent with the narrowed tool grant.
- [x] Tracker-boundary L10 preserved: no new `rf2-XXXX` ids introduced into user-facing skill content.

Closes rf2-cy498.