### PR TITLE
fix(pair2-mcp-sec): dispatch EDN-only + snapshot sub-cache wire-walker (rf2-vflrg)

### DIFF
--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors_data.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors_data.cljs
@@ -45,10 +45,16 @@
 
 (def dispatch
   {:name "dispatch"
-   :description "Fire a re-frame2 event tagged with :origin :pair. Default mode is queued dispatch. Set `sync` for dispatch-sync, `trace` for synchronous dispatch returning the assembled :rf/epoch-record."
+   :description (str "Fire a re-frame2 event tagged with :origin :pair. Default mode is queued dispatch. "
+                     "Set `sync` for dispatch-sync, `trace` for synchronous dispatch returning the "
+                     "assembled :rf/epoch-record. The `event` arg is parsed as EDN server-side (rf2-vflrg) — "
+                     "MUST be a vector (e.g. `[:cart/checkout {:reason :user}]`). Non-vector EDN returns "
+                     "`:reason :not-an-event-vector`; unreadable input returns `:reason :invalid-event-edn`. "
+                     "Host-form source (e.g. `(println :x)`) is rejected — use `eval-cljs` for arbitrary "
+                     "evaluation.")
    :typicalTokens 300
    :inputSchema {:type "object"
-                 :properties {:event {:type "string" :description "The event vector, e.g. [:cart/checkout]"}
+                 :properties {:event {:type "string" :description "The event vector as EDN, e.g. \"[:cart/checkout]\" or \"[:cart/add {:sku \\\"abc\\\"}]\". MUST be a vector — non-vector EDN and host-form source are rejected."}
                               :sync  {:type "boolean"}
                               :trace {:type "boolean"}
                               :frame {:type "string" :description "Operating frame (e.g. :stories)"}
@@ -157,9 +163,13 @@
                      "`epochs-mode \"full\"` for full-pair shape (the time-travel-restore mode, which needs verbatim state). "
                      "Diff-encode runs before the lazy-summary so `bytes` hints reflect post-shrink cost. "
                      "Per spec/009 §Privacy the `:traces` and `:epochs` slices default-drop items carrying "
-                     "`:sensitive? true`; opt back in with `include-sensitive? true`. App-db / sub-cache / "
-                     "machines slices pass through unchanged — payload redaction is the `with-redacted` "
-                     "interceptor's job, not the forwarder's. "
+                     "`:sensitive? true`; opt back in with `include-sensitive? true`. "
+                     "Per Tool-Pair §Direct-read privacy posture (rf2-vflrg) the `:app-db` and `:sub-cache` "
+                     "slices are routed through `re-frame.core/elide-wire-value` with off-box defaults — "
+                     "declared-sensitive paths return the `:rf/redacted` sentinel and large slots return "
+                     "the `:rf.size/large-elided` marker; the same `include-sensitive? true` flag opts back "
+                     "in to seeing the raw value at sensitive paths. The `:machines` slice passes through "
+                     "unchanged — payload redaction there is the `with-redacted` interceptor's job. "
                      "Each frame's `:epochs` slice is structurally deduped (rf2-obpa9) after diff-encoding — "
                      "repeated subtrees (notably the per-record `:db-before` reference) collapse to a "
                      "`{:rf.mcp/dedup-table ...}` wrapper; agent host reconstructs via `de-dupe.core/expand`. "
@@ -214,7 +224,11 @@
                               :dedup    knobs/dedup-property
                               :elision  knobs/elision-property
                               :include-sensitive? {:type "boolean"
-                                                   :description "Opt back in to forwarding `:sensitive? true` items in the :traces / :epochs slices. Default false."}
+                                                   :description (str "Opt back in to BOTH (a) forwarding `:sensitive? true` "
+                                                                     "items in the :traces / :epochs slices AND (b) seeing "
+                                                                     "the raw value at declared-sensitive paths in the "
+                                                                     ":app-db / :sub-cache slices (the walker's "
+                                                                     "`:rf.size/include-sensitive?` opt). Default false.")}
                               :build   {:type "string" :description "shadow-cljs build id (default: app)"}}
                  :additionalProperties false}})
 
@@ -233,7 +247,10 @@
                      "slot or an over-threshold leaf returns a `{:rf.size/large-elided ...}` marker "
                      "with a `:handle [:rf.elision/at <path>]` fetch handle, not the raw bytes. Drill "
                      "into a non-elided child by re-calling with a deeper `path`. Pass `elision false` "
-                     "to bypass the walk and receive the raw value.")
+                     "to bypass the walk and receive the raw value. "
+                     "Privacy (rf2-vflrg, per Tool-Pair §Direct-read privacy posture): declared-sensitive "
+                     "paths return the `:rf/redacted` sentinel by default — opt in to seeing the raw "
+                     "value at sensitive paths via `include-sensitive? true`.")
    :typicalTokens 500
    :inputSchema {:type "object"
                  :properties {:path  {:description (str "Path into app-db. EDN-encoded vector of keys "
@@ -245,6 +262,11 @@
                               :frame   {:type "string"
                                         :description "Frame-id (e.g. \":rf/default\"). Defaults to the operating frame."}
                               :elision knobs/elision-property
+                              :include-sensitive? {:type "boolean"
+                                                   :description (str "Opt in to seeing the raw value at declared-sensitive "
+                                                                     "paths (the walker's `:rf.size/include-sensitive?` opt). "
+                                                                     "Default false ⇒ sensitive paths return the `:rf/redacted` "
+                                                                     "sentinel.")}
                               :build   {:type "string"}}
                  :required ["path"]
                  :additionalProperties false}})

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/dispatch.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/dispatch.cljs
@@ -1,10 +1,75 @@
 (ns re-frame-pair2-mcp.tools.dispatch
-  "Tool: dispatch — fire an event."
-  (:require [clojure.string :as str]
+  "Tool: dispatch — fire an event.
+
+  ## Why parse the `event` arg as EDN (rf2-vflrg)
+
+  The MCP `dispatch` surface is intentionally narrower than `eval-cljs`:
+  the contract is `dispatch {event '[:ev/id ...]'}` — an EDN event
+  vector, nothing else. An earlier shape inlined the caller's string
+  verbatim into the generated eval form via `rt-raw`, which made the
+  string a host-form expression rather than data. Any caller (or a
+  prompt-injected agent) could supply arbitrary CLJS — `(println :pwn)`
+  would have run — defeating the boundary that gates `eval-cljs`
+  separately. Pre-alpha posture: this is gating the accident
+  (\"I meant to dispatch an event, not execute code\") and the trivial
+  malicious-string injection.
+
+  Parsing the arg as EDN and requiring a `vector?` shape forces the
+  payload to be data; it is then emitted into the runtime call through
+  the normal `pr-str` path (`rt-call` arg). Unreadable strings and
+  non-vector shapes return a structured `:reason :invalid-event-edn` /
+  `:reason :not-an-event-vector` error rather than reaching the
+  runtime."
+  (:require [cljs.reader]
+            [clojure.string :as str]
             [re-frame-pair2-mcp.nrepl :as nrepl]
             [re-frame-pair2-mcp.tools.eval-form :as ef]
             [re-frame-pair2-mcp.tools.wire :as wire]
             [re-frame-pair2-mcp.tools.probe :as probe]))
+
+(defn- parse-event-edn
+  "Parse the `event` MCP arg as EDN. Returns
+  `[:ok parsed-vector]` on success or `[:err err-map]` on any failure.
+  Two failure modes carry distinct reasons:
+
+  - `:invalid-event-edn`     — `read-string` threw / returned nil.
+  - `:not-an-event-vector`   — parsed cleanly but the shape is wrong
+                                (e.g. a map, a symbol, a bare keyword).
+
+  The hint repeats the documented usage shape so an agent that
+  fat-fingers the call gets a corrective example without an extra
+  round-trip."
+  [event-str]
+  (let [trimmed (some-> event-str str/trim)]
+    (cond
+      (or (nil? trimmed) (str/blank? trimmed))
+      [:err {:ok? false :reason :missing-event
+             :hint "usage: dispatch {event '[:ev/id ...]' [sync true] [trace true] [frame :foo] [fx-overrides {...}]}"}]
+
+      :else
+      (let [parsed (try
+                     (cljs.reader/read-string trimmed)
+                     (catch :default e
+                       ::reader-fail))]
+        (cond
+          (= ::reader-fail parsed)
+          [:err {:ok? false :reason :invalid-event-edn
+                 :event event-str
+                 :hint "event must be an EDN-readable vector, e.g. \"[:cart/checkout]\""}]
+
+          (not (vector? parsed))
+          [:err {:ok? false :reason :not-an-event-vector
+                 :event event-str
+                 :parsed-type (cond
+                                (map? parsed)      :map
+                                (keyword? parsed)  :keyword
+                                (symbol? parsed)   :symbol
+                                (sequential? parsed) :list
+                                :else              :scalar)
+                 :hint "event must be a vector, e.g. \"[:cart/checkout {:reason :user}]\""}]
+
+          :else
+          [:ok parsed])))))
 
 (defn dispatch-tool [conn args]
   (let [event-str    (wire/arg args :event)
@@ -12,25 +77,25 @@
         sync?        (boolean (wire/arg args :sync))
         trace?       (boolean (wire/arg args :trace))
         frame        (wire/arg-keyword args :frame)
-        fx-overrides (when-let [o (wire/arg args :fx-overrides)] (js->clj o :keywordize-keys true))]
-    (cond
-      (or (nil? event-str) (str/blank? event-str))
-      (js/Promise.resolve
-        (wire/err-text {:ok? false :reason :missing-event
-                        :hint "usage: dispatch {event '[:ev/id ...]' [sync true] [trace true] [frame :foo] [fx-overrides {...}]}"}))
+        fx-overrides (when-let [o (wire/arg args :fx-overrides)] (js->clj o :keywordize-keys true))
+        [tag payload] (parse-event-edn event-str)]
+    (case tag
+      :err
+      (js/Promise.resolve (wire/err-text payload))
 
-      :else
-      (let [opts-form (cond-> {}
+      :ok
+      (let [event-vec payload
+            opts-form (cond-> {}
                         frame        (assoc :frame frame)
                         fx-overrides (assoc :fx-overrides fx-overrides))
-            ;; The agent passes `event-str` as raw CLJS source (e.g.
-            ;; "[:my/event arg]"); wrap with `rt-raw` so `emit` inlines
-            ;; it verbatim instead of `pr-str`'ing the outer string.
-            event-form (ef/rt-raw event-str)
+            ;; rf2-vflrg: the event is now a parsed CLJS vector. Pass it
+            ;; through `rt-call`'s normal arg-emit path so it is `pr-str`'d
+            ;; as an EDN literal — the runtime fn receives data, not host
+            ;; source. NO `rt-raw` splice on this surface.
             fn-sym     (cond trace? 'dispatch-and-collect
                              sync?  'pair-dispatch-sync!
                              :else  'pair-dispatch!)
-            form (ef/emit (ef/rt-call fn-sym event-form opts-form))
+            form (ef/emit (ef/rt-call fn-sym event-vec opts-form))
             mode (cond trace? :trace sync? :sync :else :queued)]
         (-> (probe/ensure-runtime! conn build-id)
             (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/elision.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/elision.cljs
@@ -24,24 +24,55 @@
 
   ## Where it fires
 
-  - `snapshot` tool: each frame's `:app-db` slice is run through the
-    walker before slice-app-db-in-snapshot sees it.
+  - `snapshot` tool: each frame's `:app-db` AND `:sub-cache` slices are
+    run through the walker before slice-app-db-in-snapshot sees them.
+    The `:sub-cache` arm pins the Tool-Pair contract that direct reads
+    of `(rf/sub-cache frame-id)` MUST route through `elide-wire-value`
+    (rf2-vflrg).
   - `get-path` tool: the value at the requested path is run through
     the walker before pr-str.
 
   ## `:elision` MCP arg
 
   Boolean opt-out. Default `true`. The arg is parsed by the shared
-  `re-frame-pair2-mcp.tools.args/parse-bool-arg` table (rf2-c4fmh)."
+  `re-frame-pair2-mcp.tools.args/parse-bool-arg` table (rf2-c4fmh).
+
+  ## `:include-sensitive?` MCP arg (rf2-vflrg)
+
+  The same `:include-sensitive?` flag that gates trace / epoch
+  forwarding (spec/009 §Privacy) also gates whether the walker treats
+  declared-sensitive slots as pass-through (`:rf.size/include-sensitive?
+  true`) or substitutes them with the `:rf/redacted` sentinel
+  (`:rf.size/include-sensitive? false`, the default). Off-box default
+  per Tool-Pair §`Direct-read privacy posture for sub-cache and
+  get-path`: sensitive slots are dropped unless the caller opts in
+  explicitly."
   (:require [re-frame.mcp-base.vocab :as base-vocab]))
 
 (defn elision-opts-edn
   "Render the elision opts map as an EDN string for inlining into a
-  CLJS eval form sent over nREPL. Today the only knob is the
-  on/off boolean (`base-vocab/include-large-opt`): when elision is
-  enabled we pass `{:rf.size/include-large? false}` so the walker
-  emits markers; when disabled we set `:rf.size/include-large? true`
-  so values pass through unmodified. `:frame` and `:path` are
-  caller-supplied at the call-site inside the form."
-  [enabled?]
-  (pr-str {base-vocab/include-large-opt (not enabled?)}))
+  CLJS eval form sent over nREPL.
+
+  Knobs:
+
+  - `enabled?`            — when true, `:rf.size/include-large?` is
+                            `false` so the walker emits markers; when
+                            false, `true` so values pass through
+                            unmodified.
+  - `include-sensitive?`  — when true, `:rf.size/include-sensitive?` is
+                            `true` so the walker passes declared-
+                            sensitive slots through unmodified; when
+                            false (the default), `false` so the walker
+                            substitutes the `:rf/redacted` sentinel.
+
+  Both knobs default off-box-safe per the Tool-Pair §Direct-read
+  privacy posture contract — large slots elide, sensitive slots
+  redact, unless the caller opts in explicitly.
+
+  Single-arity form retains the legacy default (`include-sensitive?`
+  false) so legacy call-sites don't need to spell it out."
+  ([enabled?]
+   (elision-opts-edn enabled? false))
+  ([enabled? include-sensitive?]
+   (pr-str {base-vocab/include-large-opt     (not enabled?)
+            base-vocab/include-sensitive-opt (boolean include-sensitive?)})))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/get_path.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/get_path.cljs
@@ -28,7 +28,14 @@
   (let [build-id  (wire/arg-build raw-args)
         frame     (some-> (wire/arg raw-args :frame) args/->frame-keyword)
         path      (args/parse-path-arg (wire/arg raw-args :path))
-        elision?  (args/parse-bool-arg raw-args :elision)]
+        elision?  (args/parse-bool-arg raw-args :elision)
+        ;; rf2-vflrg — `:include-sensitive?` threads into the walker's
+        ;; `:rf.size/include-sensitive?` opt. Off-box default per
+        ;; Tool-Pair §`Direct-read privacy posture for sub-cache and
+        ;; get-path`: declared-sensitive slots redact unless the caller
+        ;; opts in explicitly. The shared `parse-bool-arg` table
+        ;; (rf2-c4fmh) gates the default at `false`.
+        incl?     (args/parse-bool-arg raw-args :include-sensitive?)]
     (cond
       (nil? path)
       (js/Promise.resolve
@@ -64,7 +71,7 @@
             frame-edn     (if frame
                             (pr-str frame)
                             (ef/emit (ef/rt-call 'current-frame)))
-            elision-opts  (elision/elision-opts-edn elision?)
+            elision-opts  (elision/elision-opts-edn elision? incl?)
             elide-call    (if elision?
                             (str "(re-frame.core/elide-wire-value v"
                                  "  (merge {:path path :frame " frame-edn "}"

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/snapshot.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/snapshot.cljs
@@ -34,16 +34,26 @@
         dedup?      (args/parse-bool-arg raw-args :dedup)
         elision?    (args/parse-bool-arg raw-args :elision)
         opts        {:frames frames :include include}
-        ;; Eval form composition (rf2-urjnc + rf2-e35a5). The snapshot
-        ;; composer returns a per-frame map; we wrap each frame's
-        ;; `:app-db` slice with `re-frame.core/elide-wire-value` so
-        ;; large / sensitive slots get the `:rf.size/large-elided`
-        ;; marker server-side, before the EDN crosses the wire. The
-        ;; walker reads the `[:rf/elision]` registry from the live
+        ;; Eval form composition (rf2-urjnc + rf2-e35a5 + rf2-vflrg).
+        ;; The snapshot composer returns a per-frame map; we wrap each
+        ;; frame's `:app-db` AND `:sub-cache` slices with
+        ;; `re-frame.core/elide-wire-value` so large / sensitive slots
+        ;; get the `:rf.size/large-elided` / `:rf/redacted` marker
+        ;; server-side, before the EDN crosses the wire.
+        ;;
+        ;; The walker reads the `[:rf/elision]` registry from the live
         ;; app-db — it has to run app-side, where the registry is
-        ;; reachable. When elision is disabled the eval form skips
-        ;; the walk entirely (a value pass-through is cheaper than
-        ;; walking with `:rf.size/include-large? true`).
+        ;; reachable. When elision is disabled the eval form skips the
+        ;; walk entirely (a value pass-through is cheaper than walking
+        ;; with `:rf.size/include-large? true`).
+        ;;
+        ;; rf2-vflrg pins the Tool-Pair §`Direct-read privacy posture
+        ;; for sub-cache and get-path` contract: BOTH the `:app-db` and
+        ;; `:sub-cache` direct-read surfaces MUST honour
+        ;; `:rf.size/include-sensitive?` (default false ⇒ sensitive
+        ;; slots redact). The `include-sensitive?` MCP arg threads into
+        ;; the walker's opt of the same shape via
+        ;; `elision-opts-edn`'s two-arity form. Off-box defaults apply.
         ;;
         ;; Per rf2-e35a5: the eval form now ALSO counts elision
         ;; markers server-side and returns `{:value <snap>
@@ -51,11 +61,11 @@
         ;; count from opts instead of re-walking the post-pipeline
         ;; payload — the walker is the only thing that inserts
         ;; markers, so it can hand the count back as a piggyback on
-        ;; the same round-trip. Dedup never touches the `:app-db`
-        ;; slice (where elision fired) — it only re-shapes `:epochs`
-        ;; — so the pre-dedup server count equals the post-dedup
-        ;; client count.
-        elision-opts-form (elision/elision-opts-edn elision?)
+        ;; the same round-trip. Dedup never touches the `:app-db` /
+        ;; `:sub-cache` slices (where elision fired) — it only
+        ;; re-shapes `:epochs` — so the pre-dedup server count equals
+        ;; the post-dedup client count.
+        elision-opts-form (elision/elision-opts-edn elision? incl?)
         form     (if elision?
                    (ef/emit
                      (ef/rt-let
@@ -63,14 +73,15 @@
                         'walked (ef/rt-raw
                                   (str "(reduce-kv"
                                        " (fn [m fid fmap]"
-                                       "   (assoc m fid"
-                                       "          (if (and (map? fmap) (contains? fmap :app-db))"
-                                       "            (update fmap :app-db"
-                                       "                    (fn [db] (re-frame.core/elide-wire-value db"
-                                       "                               (merge {:frame fid} "
-                                       elision-opts-form
-                                       "))))"
-                                       "            fmap)))"
+                                       "   (if (map? fmap)"
+                                       "     (let [opts (merge {:frame fid} " elision-opts-form ")"
+                                       "           f    (fn [v] (re-frame.core/elide-wire-value v opts))"
+                                       "           fmap (if (contains? fmap :app-db)"
+                                       "                  (update fmap :app-db f) fmap)"
+                                       "           fmap (if (contains? fmap :sub-cache)"
+                                       "                  (update fmap :sub-cache f) fmap)]"
+                                       "       (assoc m fid fmap))"
+                                       "     (assoc m fid fmap)))"
                                        " {} snap)"))]
                        (ef/rt-raw
                          (str "{:value walked"

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/dispatch_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/dispatch_test.cljs
@@ -1,0 +1,206 @@
+(ns re-frame-pair2-mcp.dispatch-test
+  "Unit tests for the dispatch tool's event-arg parsing (rf2-vflrg).
+
+  The dispatch surface is intentionally narrower than `eval-cljs`:
+  the contract is an EDN event vector, nothing else. These tests pin
+  that boundary at the arg-parse step — an unreadable string, a
+  non-vector EDN value, or a host-form CLJS source string must NOT
+  reach the runtime; they MUST return a structured error envelope.
+
+  The eval-form composition (`rt-call fn-sym event-vec opts-form`) is
+  exercised indirectly via the `rt-call` arg-emit path (covered in
+  `re-frame-pair2-mcp.eval-form-test`). The data flow we pin here:
+
+      MCP arg (string) → read-string → vector check → rt-call data arg
+                              ↑
+                              the security gate (rf2-vflrg)"
+  (:require [cljs.test :refer-macros [deftest is async]]
+            [cljs.reader]
+            [applied-science.js-interop :as j]
+            [re-frame-pair2-mcp.nrepl :as nrepl]
+            [re-frame-pair2-mcp.tools.dispatch :as dispatch]))
+
+;; ---------------------------------------------------------------------------
+;; Stub harness — capture the form string the dispatch tool would have
+;; sent over nREPL, without opening a socket.
+;; ---------------------------------------------------------------------------
+
+(defn- fresh-conn []
+  (let [conn (nrepl/make-conn 0 "127.0.0.1")]
+    ;; Pretend the runtime preload is already confirmed so probe
+    ;; resolves synchronously and we exercise the form-building path.
+    (swap! conn assoc :probed-builds #{:app})
+    conn))
+
+(defn- with-captured-eval!
+  "Install a stub `cljs-eval-value` that records the form string into
+  `captured*` and resolves to `canned-value`. Restore in `.finally`."
+  [captured* canned-value body-fn]
+  (let [orig nrepl/cljs-eval-value
+        stub (fn
+               ([_conn _build-id form-str]
+                (reset! captured* form-str)
+                (js/Promise.resolve canned-value))
+               ([_conn _build-id form-str _opts]
+                (reset! captured* form-str)
+                (js/Promise.resolve canned-value)))]
+    (set! nrepl/cljs-eval-value stub)
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_] (body-fn)))
+        (.finally (fn [] (set! nrepl/cljs-eval-value orig))))))
+
+(defn- read-result-text
+  "Extract the EDN text from a `wire/ok-text` / `wire/err-text` JS
+  envelope and read it back as CLJS data."
+  [result-js]
+  (let [content (j/get result-js :content)
+        item    (when (array? content) (aget content 0))
+        text    (when item (j/get item :text))]
+    (cljs.reader/read-string text)))
+
+(defn- err? [result-js]
+  (true? (j/get result-js :isError)))
+
+;; ---------------------------------------------------------------------------
+;; Rejection arms — the security gate.
+;; ---------------------------------------------------------------------------
+
+(deftest rejects-arbitrary-cljs-source
+  ;; The headline rf2-vflrg case: an attacker / a prompt-injected
+  ;; agent supplies host-form source instead of an event vector. The
+  ;; pre-fix shape inlined this via `rt-raw`, so `(println :pwned)`
+  ;; would have run inside the runtime eval. Post-fix: the parser
+  ;; reads it as a list, the vector-check fails, the runtime is
+  ;; never contacted.
+  (async done
+    (-> (dispatch/dispatch-tool (fresh-conn) #js {:event "(println :pwned)"})
+        (.then (fn [r]
+                 (is (err? r))
+                 (let [edn (read-result-text r)]
+                   (is (= :not-an-event-vector (:reason edn)))
+                   (is (= :list (:parsed-type edn))))
+                 (done))))))
+
+(deftest rejects-bare-keyword
+  ;; `:cart/checkout` is valid EDN but not a vector — agents that
+  ;; forget the brackets get a corrective error.
+  (async done
+    (-> (dispatch/dispatch-tool (fresh-conn) #js {:event ":cart/checkout"})
+        (.then (fn [r]
+                 (is (err? r))
+                 (let [edn (read-result-text r)]
+                   (is (= :not-an-event-vector (:reason edn)))
+                   (is (= :keyword (:parsed-type edn))))
+                 (done))))))
+
+(deftest rejects-map
+  ;; A map is valid EDN but the wrong shape.
+  (async done
+    (-> (dispatch/dispatch-tool (fresh-conn) #js {:event "{:id :foo}"})
+        (.then (fn [r]
+                 (is (err? r))
+                 (let [edn (read-result-text r)]
+                   (is (= :not-an-event-vector (:reason edn)))
+                   (is (= :map (:parsed-type edn))))
+                 (done))))))
+
+(deftest rejects-unreadable-edn
+  ;; Mismatched brackets / a lone `#` / any reader failure surfaces as
+  ;; `:invalid-event-edn` so the caller can distinguish "didn't parse"
+  ;; from "wrong shape".
+  (async done
+    (-> (dispatch/dispatch-tool (fresh-conn) #js {:event "[:foo"})
+        (.then (fn [r]
+                 (is (err? r))
+                 (let [edn (read-result-text r)]
+                   (is (= :invalid-event-edn (:reason edn))))
+                 (done))))))
+
+(deftest rejects-blank-event
+  (async done
+    (-> (dispatch/dispatch-tool (fresh-conn) #js {:event "   "})
+        (.then (fn [r]
+                 (is (err? r))
+                 (let [edn (read-result-text r)]
+                   (is (= :missing-event (:reason edn))))
+                 (done))))))
+
+(deftest rejects-missing-event
+  (async done
+    (-> (dispatch/dispatch-tool (fresh-conn) #js {})
+        (.then (fn [r]
+                 (is (err? r))
+                 (let [edn (read-result-text r)]
+                   (is (= :missing-event (:reason edn))))
+                 (done))))))
+
+;; ---------------------------------------------------------------------------
+;; Acceptance arm — the EDN vector reaches the runtime as data.
+;; ---------------------------------------------------------------------------
+
+(deftest accepts-edn-vector-and-emits-data-arg
+  ;; Happy path: `[:cart/checkout]` reads as a vector, flows into
+  ;; `rt-call` as a normal data arg, and emits as a pr-str'd literal
+  ;; inside the runtime call.
+  (async done
+    (let [captured (atom nil)]
+      (-> (with-captured-eval! captured {:dispatched? true}
+            (fn []
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:cart/checkout]"})))
+          (.then (fn [r]
+                   (is (not (err? r)))
+                   (let [form @captured]
+                     (is (string? form))
+                     ;; The runtime call is `(rt/pair-dispatch! [:cart/checkout] {})`
+                     ;; (or `pair-dispatch-sync!` / `dispatch-and-collect` for
+                     ;; sync / trace modes). The event vector rides as an EDN
+                     ;; literal — pinned via the `pr-str` shape.
+                     (is (re-find #"pair-dispatch!" form))
+                     (is (re-find #"\[:cart/checkout\]" form))
+                     ;; And critically — NO host-form splice. The form is
+                     ;; standalone CLJS that the runtime can read back as
+                     ;; data. We can round-trip the outer call as EDN.
+                     (let [parsed (cljs.reader/read-string form)]
+                       (is (= 're-frame-pair2.runtime/pair-dispatch! (first parsed))
+                           "first arg is the qualified fn symbol")
+                       (is (= [:cart/checkout] (second parsed))
+                           "second arg is the event vector — DATA, not source")))
+                   (done)))))))
+
+(deftest accepts-event-with-args
+  ;; A two-element event: `[:cart/add {:sku "abc"}]`. The map rides
+  ;; as a literal inside the vector.
+  (async done
+    (let [captured (atom nil)]
+      (-> (with-captured-eval! captured {:dispatched? true}
+            (fn []
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:cart/add {:sku \"abc\"}]"})))
+          (.then (fn [r]
+                   (is (not (err? r)))
+                   (let [parsed (cljs.reader/read-string @captured)]
+                     (is (= [:cart/add {:sku "abc"}] (second parsed))))
+                   (done)))))))
+
+(deftest sync-mode-routes-to-pair-dispatch-sync
+  (async done
+    (let [captured (atom nil)]
+      (-> (with-captured-eval! captured {:dispatched? true}
+            (fn []
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:cart/checkout]" :sync true})))
+          (.then (fn [_]
+                   (is (re-find #"pair-dispatch-sync!" @captured))
+                   (done)))))))
+
+(deftest trace-mode-routes-to-dispatch-and-collect
+  (async done
+    (let [captured (atom nil)]
+      (-> (with-captured-eval! captured {:dispatched? true}
+            (fn []
+              (dispatch/dispatch-tool (fresh-conn)
+                                      #js {:event "[:cart/checkout]" :trace true})))
+          (.then (fn [_]
+                   (is (re-find #"dispatch-and-collect" @captured))
+                   (done)))))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/elision_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/elision_test.cljs
@@ -83,28 +83,34 @@
   elision on/off. Keep in lockstep with `snapshot-tool` in
   `tools/snapshot.cljs`. Post-rf2-e35a5 both arms wrap the snapshot
   in `{:value <snap> :elided-count N}` so the count piggybacks on
-  the same nREPL round-trip — no separate client-side walk."
-  [opts elision?]
-  (let [elision-opts-form (elision/elision-opts-edn elision?)]
-    (if elision?
-      (str "(let [snap (re-frame-pair2.runtime/snapshot-state "
-           (pr-str opts) ")"
-           "      walked (reduce-kv"
-           "               (fn [m fid fmap]"
-           "                 (assoc m fid"
-           "                        (if (and (map? fmap) (contains? fmap :app-db))"
-           "                          (update fmap :app-db"
-           "                                  (fn [db] (re-frame.core/elide-wire-value db"
-           "                                             (merge {:frame fid} "
-           elision-opts-form
-           "))))"
-           "                          fmap)))"
-           "               {} snap)]"
-           "  {:value walked"
-           "   :elided-count (count (filter #(and (map? %) (contains? % :rf.size/large-elided))"
-           "                                (tree-seq coll? seq walked)))})")
-      (str "{:value (re-frame-pair2.runtime/snapshot-state "
-           (pr-str opts) ") :elided-count 0}"))))
+  the same nREPL round-trip — no separate client-side walk.
+
+  Post-rf2-vflrg the walker fires on BOTH `:app-db` and `:sub-cache`
+  slices and threads `include-sensitive?` into the walker's
+  `:rf.size/include-sensitive?` opt."
+  ([opts elision?] (build-snapshot-form opts elision? false))
+  ([opts elision? include-sensitive?]
+   (let [elision-opts-form (elision/elision-opts-edn elision? include-sensitive?)]
+     (if elision?
+       (str "(let [snap (re-frame-pair2.runtime/snapshot-state "
+            (pr-str opts) ")"
+            "      walked (reduce-kv"
+            "               (fn [m fid fmap]"
+            "                 (if (map? fmap)"
+            "                   (let [opts (merge {:frame fid} " elision-opts-form ")"
+            "                         f    (fn [v] (re-frame.core/elide-wire-value v opts))"
+            "                         fmap (if (contains? fmap :app-db)"
+            "                                (update fmap :app-db f) fmap)"
+            "                         fmap (if (contains? fmap :sub-cache)"
+            "                                (update fmap :sub-cache f) fmap)]"
+            "                     (assoc m fid fmap))"
+            "                   (assoc m fid fmap)))"
+            "               {} snap)]"
+            "  {:value walked"
+            "   :elided-count (count (filter #(and (map? %) (contains? % :rf.size/large-elided))"
+            "                                (tree-seq coll? seq walked)))})")
+       (str "{:value (re-frame-pair2.runtime/snapshot-state "
+            (pr-str opts) ") :elided-count 0}")))))
 
 (deftest snapshot-form-elision-off-wraps-bare-snap-with-zero-count
   ;; Post-rf2-e35a5: even with elision off, the form returns the
@@ -130,24 +136,46 @@
     (is (re-find #"re-frame-pair2\.runtime/snapshot-state" form))
     (is (re-find #"re-frame\.core/elide-wire-value" form))
     ;; Per-frame walking, not whole-snapshot walking — the walker is
-    ;; applied to each :app-db slice with that frame's id, so the
+    ;; applied to each slice with that frame's id, so the
     ;; `[:rf/elision]` registry lookup hits the right frame.
     (is (re-find #":frame fid" form))
     ;; The walker is invoked with `:rf.size/include-large? false` so
     ;; markers actually fire.
     (is (re-find #":rf\.size/include-large\? false" form))))
 
-(deftest snapshot-form-only-walks-app-db-slice
-  ;; The other slices (:sub-cache :machines :epochs :traces) have their
-  ;; own wire-protocol mechanisms (dedup, diff-encode). Elision is
-  ;; scoped to :app-db — the slice whose payload can blow the cap on a
-  ;; single large slot.
+(deftest snapshot-form-walks-both-app-db-and-sub-cache
+  ;; rf2-vflrg — the snapshot eval form now walks BOTH `:app-db` AND
+  ;; `:sub-cache` slices through `elide-wire-value`. Per Tool-Pair
+  ;; §Direct-read privacy posture, the `sub-cache` direct-read surface
+  ;; MUST route through the wire walker with off-box defaults.
+  ;;
+  ;; The other slices (:machines :epochs :traces) have their own
+  ;; wire-protocol mechanisms (dedup, diff-encode, sensitive-strip);
+  ;; the walker fires only on the two direct-read slices that need it.
   (let [form (build-snapshot-form {:frames :all
-                                   :include [:app-db :epochs]}
+                                   :include [:app-db :sub-cache :machines :epochs]}
                                   true)]
-    ;; The walker is invoked once, with the :app-db slot.
-    (is (= 1 (count (re-seq #"elide-wire-value" form))))
-    (is (re-find #"contains\? fmap :app-db" form))))
+    ;; The form's `f` binding is the walker call; we check both
+    ;; `update` arms cite the two direct-read slices by key.
+    (is (re-find #"contains\? fmap :app-db" form))
+    (is (re-find #"contains\? fmap :sub-cache" form))
+    ;; Machines / epochs / traces are not walked here — they have
+    ;; their own wire mechanisms.
+    (is (not (re-find #"contains\? fmap :machines" form)))
+    (is (not (re-find #"contains\? fmap :epochs" form)))))
+
+(deftest snapshot-form-threads-include-sensitive
+  ;; rf2-vflrg — `:include-sensitive?` flows through to the walker's
+  ;; `:rf.size/include-sensitive?` opt so the same MCP arg that opts
+  ;; in to forwarding sensitive traces / epochs also opts in to seeing
+  ;; the raw value at sensitive paths in the :app-db / :sub-cache
+  ;; slices.
+  (let [form-default   (build-snapshot-form {:frames :all :include [:app-db]} true false)
+        form-opted-in  (build-snapshot-form {:frames :all :include [:app-db]} true true)]
+    (is (re-find #":rf\.size/include-sensitive\? false" form-default)
+        "default ⇒ sensitive slots redact")
+    (is (re-find #":rf\.size/include-sensitive\? true" form-opted-in)
+        "include-sensitive? true ⇒ sensitive slots pass through")))
 
 (deftest snapshot-form-counts-elision-markers-server-side
   ;; rf2-e35a5: the eval form returns `{:value <snap> :elided-count N}`
@@ -177,43 +205,47 @@
   "Mirror of the get-path-tool's eval-form composition. Keep in
   lockstep with `get-path-tool` in tools.cljs. Post-rf2-e35a5: the
   happy-path envelope carries `:elided-count` so the wire-pipeline
-  reads the count from opts instead of re-walking the scalar."
-  [path frame elision?]
-  (let [path-edn      (pr-str path)
-        snapshot-call (if frame
-                        (str "(re-frame-pair2.runtime/snapshot " (pr-str frame) ")")
-                        "(re-frame-pair2.runtime/snapshot)")
-        frame-edn     (if frame (pr-str frame) "(re-frame-pair2.runtime/current-frame)")
-        elision-opts  (elision/elision-opts-edn elision?)
-        elide-call    (if elision?
-                        (str "(re-frame.core/elide-wire-value v"
-                             "  (merge {:path path :frame " frame-edn "}"
-                             "         " elision-opts "))")
-                        "v")
-        count-expr    (if elision?
-                        (str "(count (filter #(and (map? %) (contains? % :rf.size/large-elided))"
-                             "               (tree-seq coll? seq elided-v)))")
-                        "0")]
-    (str "(let [db " snapshot-call
-         "      path " path-edn
-         "      missing #js {}"
-         "      v (get-in db path missing)"
-         "      elided-v " elide-call
-         "      n " count-expr "]"
-         "  (if (identical? v missing)"
-         "    {:ok? false :reason :path-not-found"
-         "     :path path"
-         "     :deepest-valid-prefix"
-         "     (loop [acc [] cur db rem path]"
-         "       (cond"
-         "         (empty? rem) acc"
-         "         (and (map? cur) (contains? cur (first rem)))"
-         "         (recur (conj acc (first rem)) (get cur (first rem)) (rest rem))"
-         "         (and (sequential? cur) (integer? (first rem))"
-         "              (<= 0 (first rem) (dec (count cur))))"
-         "         (recur (conj acc (first rem)) (nth (vec cur) (first rem)) (rest rem))"
-         "         :else acc))}"
-         "    {:ok? true :exists? true :path path :value elided-v :elided-count n}))")))
+  reads the count from opts instead of re-walking the scalar.
+
+  Post-rf2-vflrg the four-arity form takes `include-sensitive?` and
+  threads it into the walker's `:rf.size/include-sensitive?` opt."
+  ([path frame elision?] (build-get-path-form path frame elision? false))
+  ([path frame elision? include-sensitive?]
+   (let [path-edn      (pr-str path)
+         snapshot-call (if frame
+                         (str "(re-frame-pair2.runtime/snapshot " (pr-str frame) ")")
+                         "(re-frame-pair2.runtime/snapshot)")
+         frame-edn     (if frame (pr-str frame) "(re-frame-pair2.runtime/current-frame)")
+         elision-opts  (elision/elision-opts-edn elision? include-sensitive?)
+         elide-call    (if elision?
+                         (str "(re-frame.core/elide-wire-value v"
+                              "  (merge {:path path :frame " frame-edn "}"
+                              "         " elision-opts "))")
+                         "v")
+         count-expr    (if elision?
+                         (str "(count (filter #(and (map? %) (contains? % :rf.size/large-elided))"
+                              "               (tree-seq coll? seq elided-v)))")
+                         "0")]
+     (str "(let [db " snapshot-call
+          "      path " path-edn
+          "      missing #js {}"
+          "      v (get-in db path missing)"
+          "      elided-v " elide-call
+          "      n " count-expr "]"
+          "  (if (identical? v missing)"
+          "    {:ok? false :reason :path-not-found"
+          "     :path path"
+          "     :deepest-valid-prefix"
+          "     (loop [acc [] cur db rem path]"
+          "       (cond"
+          "         (empty? rem) acc"
+          "         (and (map? cur) (contains? cur (first rem)))"
+          "         (recur (conj acc (first rem)) (get cur (first rem)) (rest rem))"
+          "         (and (sequential? cur) (integer? (first rem))"
+          "              (<= 0 (first rem) (dec (count cur))))"
+          "         (recur (conj acc (first rem)) (nth (vec cur) (first rem)) (rest rem))"
+          "         :else acc))}"
+          "    {:ok? true :exists? true :path path :value elided-v :elided-count n}))"))))
 
 (deftest get-path-form-elision-off-bypasses-walker
   ;; Elision off = the raw value rides the wire. Backwards-compatible
@@ -257,6 +289,17 @@
         form  (build-get-path-form path nil true)
         edn   (pr-str path)]
     (is (not= -1 (.indexOf form edn)))))
+
+(deftest get-path-form-threads-include-sensitive
+  ;; rf2-vflrg — `include-sensitive?` threads through to the walker's
+  ;; `:rf.size/include-sensitive?` opt. Default is off (sensitive paths
+  ;; redact); opt in with `true`.
+  (let [form-default  (build-get-path-form [:user :token] :rf/default true false)
+        form-opted-in (build-get-path-form [:user :token] :rf/default true true)]
+    (is (re-find #":rf\.size/include-sensitive\? false" form-default)
+        "default ⇒ sensitive paths redact")
+    (is (re-find #":rf\.size/include-sensitive\? true" form-opted-in)
+        "include-sensitive? true ⇒ raw value at sensitive paths")))
 
 ;; ---------------------------------------------------------------------------
 ;; Composition × wire-cap (rf2-rvyzy fallback).
@@ -386,7 +429,53 @@
   ;; render this verbatim into the EDN sent over nREPL. The kw shape
   ;; is normative per the walker's docstring; a rename in the framework
   ;; surface needs a co-ordinated update here.
-  (is (= "{:rf.size/include-large? false}"
-         (elision/elision-opts-edn true)))
-  (is (= "{:rf.size/include-large? true}"
-         (elision/elision-opts-edn false))))
+  ;; Post-rf2-vflrg both opts ride the same map; assert against the
+  ;; parsed form so map-key-order doesn't matter.
+  (let [parsed-on  (cljs.reader/read-string (elision/elision-opts-edn true))
+        parsed-off (cljs.reader/read-string (elision/elision-opts-edn false))]
+    (is (false? (:rf.size/include-large? parsed-on)))
+    (is (true?  (:rf.size/include-large? parsed-off)))
+    (is (false? (:rf.size/include-sensitive? parsed-on)))
+    (is (false? (:rf.size/include-sensitive? parsed-off)))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-vflrg — `:include-sensitive?` threads through `elision-opts-edn`.
+;;
+;; Per Tool-Pair §Direct-read privacy posture, the `snapshot` and
+;; `get-path` direct-read surfaces MUST honour
+;; `:rf.size/include-sensitive?`. The two-arity form lifts the MCP arg
+;; `:include-sensitive?` into the walker's namespace-prefixed opt.
+;; ---------------------------------------------------------------------------
+
+(deftest elision-opts-edn-include-sensitive-defaults-false
+  ;; The single-arity legacy form preserves the off-box-safe default:
+  ;; sensitive slots redact unless the caller opts in explicitly.
+  (let [parsed (cljs.reader/read-string (elision/elision-opts-edn true))]
+    (is (false? (:rf.size/include-sensitive? parsed))
+        "single-arity ⇒ include-sensitive? false (the default per Tool-Pair §Direct-read privacy posture)")))
+
+(deftest elision-opts-edn-include-sensitive-true-opts-in
+  ;; The documented opt-in flow: `:include-sensitive? true` flows into
+  ;; the walker opt of the same shape. Sensitive slots then pass through
+  ;; unmodified.
+  (let [parsed (cljs.reader/read-string (elision/elision-opts-edn true true))]
+    (is (true? (:rf.size/include-sensitive? parsed))
+        "two-arity true ⇒ walker passes sensitive values through")))
+
+(deftest elision-opts-edn-include-sensitive-false-explicit
+  ;; Explicit `false` matches the single-arity default.
+  (let [parsed-explicit (cljs.reader/read-string (elision/elision-opts-edn true false))
+        parsed-default  (cljs.reader/read-string (elision/elision-opts-edn true))]
+    (is (= parsed-explicit parsed-default))))
+
+(deftest elision-opts-edn-include-sensitive-orthogonal-to-elision-switch
+  ;; The two knobs are orthogonal: elision-off + sensitive-on is a
+  ;; valid (if unusual) combo — the agent has explicitly opted into both
+  ;; raw values (`elision false`) and raw sensitive values
+  ;; (`include-sensitive? true`).
+  (doseq [enabled?           [true false]
+          include-sensitive? [true false]]
+    (let [parsed (cljs.reader/read-string
+                   (elision/elision-opts-edn enabled? include-sensitive?))]
+      (is (= (not enabled?) (:rf.size/include-large? parsed)))
+      (is (= include-sensitive? (:rf.size/include-sensitive? parsed))))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/snapshot_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/snapshot_test.cljs
@@ -10,7 +10,11 @@
   contract.
 
   Tests require the public parsers directly from
-  `re-frame-pair2-mcp.tools.args` — the source ns is the contract."
+  `re-frame-pair2-mcp.tools.args` — the source ns is the contract.
+
+  Production-form integration coverage for rf2-vflrg lives in
+  `re-frame-pair2-mcp.elision-test` (via the `build-snapshot-form`
+  mirror); see the note at the bottom of this file."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [cljs.reader]
             [re-frame-pair2-mcp.tools.args :as args]
@@ -58,3 +62,17 @@
     (is (= :all (-> edn second :frames)))
     (is (= [:app-db :sub-cache :machines :epochs :traces]
            (-> edn second :include)))))
+
+;; ---------------------------------------------------------------------------
+;; Note on rf2-vflrg integration coverage:
+;;
+;; Eval-form composition for the snapshot tool (now walking BOTH `:app-db`
+;; and `:sub-cache` through `re-frame.core/elide-wire-value`, threading
+;; `:include-sensitive?` into the walker's opt) is pinned in
+;; `re-frame-pair2-mcp.elision-test` via the production `build-snapshot-form`
+;; mirror — see `snapshot-form-walks-both-app-db-and-sub-cache` and
+;; `snapshot-form-threads-include-sensitive`. Driving `snapshot-tool`
+;; directly here would race against `invoke-test`'s var-swap stubs of
+;; `snapshot/snapshot-tool` itself (their `.finally` restores can outrun
+;; the next async test's start), so we keep the mirror approach.
+;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the two HIGH-severity fixes from the rf2-vflrg P2 security audit of `tools/pair2-mcp`.

**Fix 1 — dispatch parses EDN, rejects host-form source.** `dispatch-tool` previously inlined the user-supplied `event` string verbatim into the generated eval form via `rt-raw`; a caller (or prompt-injected agent) could supply arbitrary CLJS (e.g. `(println :pwned)`) instead of an EDN event vector, defeating the documented boundary between `dispatch` and `eval-cljs`. The event arg is now parsed as EDN and required to be a `vector?`; non-vector EDN returns `:reason :not-an-event-vector`, unreadable input returns `:reason :invalid-event-edn`. The parsed vector reaches the runtime through `rt-call`'s normal data-arg path (`pr-str`'d as an EDN literal), not via `rt-raw` splice.

**Fix 2 — snapshot routes `:sub-cache` through the wire walker, threads `:include-sensitive?`.** Per Tool-Pair §`Direct-read privacy posture for sub-cache and get-path` (lines 561-575), both `sub-cache` and `get-path` direct-read surfaces MUST route through `re-frame.core/elide-wire-value` with off-box defaults (sensitive ⇒ redact, large ⇒ marker). Pre-fix, `snapshot` only walked `:app-db`; `:sub-cache` rode the wire verbatim, and the walker's `:rf.size/include-sensitive?` opt was never threaded from MCP args. The snapshot eval form now walks BOTH `:app-db` AND `:sub-cache`; `get-path` parses `:include-sensitive?` and threads it; `elision-opts-edn` gains a two-arity form emitting both `:rf.size/include-large?` and `:rf.size/include-sensitive?`. Tool descriptors updated to advertise the new posture.

## Test plan

- [x] `npm run test:cljs` (implementation): 1968 tests / 5586 assertions, 0 failures
- [x] `npm test` (pair2-mcp): 363 tests / 878 assertions, 0 failures
- [x] `npm run test:bundle-isolation`: PASS
- [x] New dispatch tests (`dispatch_test.cljs`): host-form source rejected, bare keyword / map / unreadable EDN rejected with structured reasons; EDN vector flows through as data
- [x] New elision tests: snapshot eval form walks both `:app-db` and `:sub-cache`; `include-sensitive?` threads into walker opt for both snapshot and get-path

## Scope

Strictly `tools/pair2-mcp/src/` + corresponding tests. No core / other tool / spec edits (spec/Tool-Pair.md is hot-zone, read-only).