### PR TITLE
fix(ssr-sec): validate tag-names + header-names + cookie fields (rf2-z7gor)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -45,10 +45,60 @@
   #{:area :base :br :col :embed :hr :img :input :link :meta :param :source
     :track :wbr})
 
+;; rf2-z7gor / security audit 2026-05-14 — tag-name injection gate.
+;; `parse-tag-name` historically split the keyword on `#` / `.` and handed
+;; the leading fragment straight to `<...>` / `</...>` emission with no
+;; grammar check. A keyword like `(keyword "img src=x onerror=alert(1)")`
+;; emitted `<img src=x onerror=alert(1)></img src=x onerror=alert(1)>` —
+;; the attribute-name validator was bypassed entirely. We gate the tag
+;; component itself: HTML5 / SVG / MathML element names require an ASCII
+;; letter start, then letters / digits / hyphens. Reject anything else.
+;;
+;; Decision: fail-fast (throw) rather than escape-and-emit. A tag-name
+;; outside the grammar has no safe wire interpretation — escaping would
+;; produce `<img&#x20;src=...>` which no browser parses as a tag, just a
+;; visible glyph. Same shape as the rf2-hbty2 header-value gate.
+;;
+;; `:<>` (React fragment) and `:>` (Reagent-native) are special heads
+;; consumed by `emit-element` BEFORE this validator runs — they never
+;; reach `parse-tag-name`. The grammar below applies only to actual DOM
+;; tag emissions.
+(def ^:private tag-name-re
+  ;; HTML5 §element-name + SVG element-name + MathML element-name all
+  ;; share the same conservative ASCII grammar: leading letter, then
+  ;; letters / digits / hyphens. Custom elements (per HTML5 §custom-
+  ;; element-name) require an ASCII-lower first letter + a `-`; the
+  ;; conservative grammar admits both standard elements and well-formed
+  ;; custom-element names.
+  #"[A-Za-z][A-Za-z0-9-]*")
+
+(defn- validate-tag-name!
+  "Throw `:rf.error/invalid-tag-name` if `tag-name` does not match the
+  HTML5 / SVG / MathML element-name grammar (`[A-Za-z][A-Za-z0-9-]*`).
+  Per rf2-z7gor — DOM tag-name component of a hiccup keyword was emitted
+  without validation, allowing tag-injection through hostile keywords
+  like `(keyword \"img src=x onerror=alert(1)\")`."
+  [tag-name source-kw]
+  (when-not (and (string? tag-name)
+                 (re-matches tag-name-re tag-name))
+    (throw (ex-info ":rf.error/invalid-tag-name"
+                    {:reason   (str "tag-name " (pr-str tag-name)
+                                    " (from hiccup head " (pr-str source-kw) ")"
+                                    " does not match the HTML5/SVG/MathML"
+                                    " element-name grammar"
+                                    " ([A-Za-z][A-Za-z0-9-]*) — DOM tag-name"
+                                    " injection forbidden")
+                     :tag-name tag-name
+                     :source   source-kw
+                     :recovery :no-recovery})))
+  tag-name)
+
 ;; Tag-name parsing for the :div#id.cls syntax. Reagent / Hiccup convention.
 (defn parse-tag-name
   "Split a keyword like :div#main.col-12.bold into [:div {:id \"main\"
-  :class \"col-12 bold\"}] components."
+  :class \"col-12 bold\"}] components. Throws `:rf.error/invalid-tag-name`
+  (rf2-z7gor) if the tag component is not a well-formed HTML5/SVG/MathML
+  element name."
   [tag-kw]
   (let [s     (name tag-kw)
         ;; Match: tag-name optionally followed by #id and .class fragments.
@@ -59,6 +109,7 @@
                      (->> (clojure.string/split classes #"\.")
                           (remove empty?)
                           (clojure.string/join " ")))]
+    (validate-tag-name! tag tag-kw)
     [tag
      (cond-> {}
        id         (assoc :id id)
@@ -173,6 +224,16 @@
      (vector? el)
      (let [head (first el)]
        (cond
+         ;; Fragment `:<>` and Reagent-native `:>` are special heads — not
+         ;; DOM tag-name keywords. Per Spec 011: a fragment emits its
+         ;; rendered children with no wrapper; root-attrs (rf2-lxwse) skip
+         ;; these heads, source-coord annotation skips these heads, and
+         ;; the tag-name validator (rf2-z7gor) does not apply. Handled
+         ;; ahead of the general keyword branch so they never reach
+         ;; `parse-tag-name`.
+         (or (= :<> head) (= :> head))
+         (emit-children (rest el))
+
          (keyword? head)
          (let [;; Look up registered view first.
                maybe-view (registrar/lookup :view head)]
@@ -195,13 +256,7 @@
                      [(second el) (drop 2 el)]
                      [{} (rest el)])
                    merged-attrs (merge-class-attrs tag-attrs user-attrs)
-                   ;; Fragment `:<>` and Reagent-native `:>` heads are
-                   ;; exempt from root-attrs injection (matches the
-                   ;; `inject-coord-on-root-hiccup` skip-list per
-                   ;; rf2-lxwse acceptance criteria) — drop root-attrs
-                   ;; on these heads.
-                   skip-attrs?  (or (= :<> head) (= :> head))
-                   attrs        (if (and root-attrs (not skip-attrs?))
+                   attrs        (if root-attrs
                                   (merge-root-attrs merged-attrs root-attrs)
                                   merged-attrs)
                    void?        (contains? void-elements (keyword tag-name))]

--- a/implementation/ssr/src/re_frame/ssr/response.cljc
+++ b/implementation/ssr/src/re_frame/ssr/response.cljc
@@ -126,6 +126,94 @@
                        :recovery :no-recovery})))
     s))
 
+;; rf2-z7gor / security audit 2026-05-14 — header-name + cookie-field
+;; gates at the fx boundary. The rf2-hbty2 work validated header
+;; VALUES; header NAMES and the structured cookie map were still trusted.
+;; The ring host adapter happens to re-validate at materialisation time
+;; (rf2-rpedl in ssr-ring/cookie.clj), but the SSR layer is also the
+;; integration boundary for Pedestal / HttpKit / other custom adapters
+;; that consume the response shape directly — so the fx boundary is the
+;; right place to enforce the invariant once, with the dispatching event
+;; still in scope rather than as a deep adapter exception.
+;;
+;; RFC 7230 §3.2.6 token grammar (header names + RFC 6265 §4.1.1
+;; cookie-name): `1*tchar` where `tchar` ∈ the visible US-ASCII set
+;; MINUS the separators `( ) < > @ , ; : \ " / [ ] ? = { }` and
+;; whitespace. The regex below encodes that set explicitly so the
+;; grammar is auditable in place; empty names are rejected by the `+`
+;; quantifier.
+
+(def ^:private token-grammar-re
+  #"[!#$%&'*+\-.0-9A-Z\^_`a-z|~]+")
+
+(defn- validate-header-name!
+  "Throw `:rf.error/header-invalid-name` if the header name violates the
+  RFC 7230 §3.2.6 token grammar — empty, contains CR / LF / NUL,
+  whitespace, or separators. Same gate as the cookie-name validator.
+  Per rf2-z7gor §security-audit-2026-05-14."
+  [n]
+  (let [s (str n)]
+    (when-not (re-matches token-grammar-re s)
+      (throw (ex-info ":rf.error/header-invalid-name"
+                      {:reason   (str "header :name " (pr-str s)
+                                      " violates RFC 7230 §3.2.6 token grammar"
+                                      " (no CTLs, whitespace, or separators"
+                                      " ()<>@,;:\\\"/[]?={})")
+                       :header   n
+                       :recovery :no-recovery})))
+    s))
+
+(defn- validate-cookie-name!
+  "Throw `:rf.error/cookie-invalid-name` if the cookie name violates the
+  RFC 6265 §4.1.1 token grammar. Same shape as the rf2-rpedl validator
+  in `ssr-ring/cookie.clj` — applied here at the fx boundary so non-ring
+  host adapters get the same gate. Per rf2-z7gor."
+  [n]
+  (when (nil? n)
+    (throw (ex-info ":rf.error/cookie-invalid-name"
+                    {:reason   "cookie :name is required"
+                     :name     n
+                     :recovery :no-recovery})))
+  (let [s (#?(:clj clojure.core/name :cljs cljs.core/name) n)]
+    (when-not (re-matches token-grammar-re s)
+      (throw (ex-info ":rf.error/cookie-invalid-name"
+                      {:reason   (str "cookie :name " (pr-str s)
+                                      " violates RFC 6265 §4.1.1 token grammar"
+                                      " (no CTLs, whitespace, or separators"
+                                      " ()<>@,;:\\\"/[]?={})")
+                       :name     n
+                       :recovery :no-recovery})))
+    s))
+
+(defn- validate-cookie-attr!
+  "Throw `:rf.error/cookie-invalid-<field>` if the cookie attribute
+  string contains CR / LF / NUL. Applied to `:value`, `:path`, `:domain`
+  — the string-typed fields that are concatenated verbatim into the
+  Set-Cookie wire form by host adapters. Per rf2-z7gor."
+  [field-key v]
+  (let [s (str v)]
+    (when (re-find header-injection-chars-re s)
+      (throw (ex-info (str ":rf.error/cookie-invalid-" (name field-key))
+                      {:reason   (str "cookie " field-key " " (pr-str s)
+                                      " contains CR/LF/NUL — forbidden by"
+                                      " RFC 7230 §3.2.4 (header-splitting"
+                                      " injection)")
+                       :field    field-key
+                       :value    v
+                       :recovery :no-recovery})))
+    s))
+
+(defn- validate-cookie!
+  "Run name + field validators across the cookie map. Per rf2-z7gor —
+  gate the structured cookie at the fx boundary so misuse surfaces with
+  the dispatching event in scope rather than as a deep adapter exception."
+  [cookie]
+  (validate-cookie-name! (:name cookie))
+  (when (some? (:value  cookie)) (validate-cookie-attr! :value  (:value  cookie)))
+  (when (some? (:path   cookie)) (validate-cookie-attr! :path   (:path   cookie)))
+  (when (some? (:domain cookie)) (validate-cookie-attr! :domain (:domain cookie)))
+  cookie)
+
 (def status-writes-key   :rf.server/_status-writes)
 (def redirect-writes-key :rf.server/_redirect-writes)
 
@@ -228,9 +316,11 @@
 (defn set-header-fx
   "Handler fn for `:rf.server/set-header`. Replaces any existing header
   with the same name (case-insensitive). Throws
-  `:rf.error/header-invalid-value` on a value carrying CR/LF/NUL
-  (rf2-hbty2)."
+  `:rf.error/header-invalid-name` on a name violating the RFC 7230
+  §3.2.6 token grammar (rf2-z7gor), and `:rf.error/header-invalid-value`
+  on a value carrying CR/LF/NUL (rf2-hbty2)."
   [{:keys [frame]} {:keys [name value]}]
+  (validate-header-name!  name)
   (validate-header-value! name value)
   (swap-response!
     frame
@@ -239,9 +329,12 @@
 (defn append-header-fx
   "Handler fn for `:rf.server/append-header`. Preserves any existing
   header with the same name — required for Set-Cookie-style multi-valued
-  headers. Throws `:rf.error/header-invalid-value` on a value carrying
-  CR/LF/NUL (rf2-hbty2)."
+  headers. Throws `:rf.error/header-invalid-name` on a name violating the
+  RFC 7230 §3.2.6 token grammar (rf2-z7gor), and
+  `:rf.error/header-invalid-value` on a value carrying CR/LF/NUL
+  (rf2-hbty2)."
   [{:keys [frame]} {:keys [name value]}]
+  (validate-header-name!  name)
   (validate-header-value! name value)
   (swap-response!
     frame
@@ -250,21 +343,29 @@
 (defn set-cookie-fx
   "Handler fn for `:rf.server/set-cookie`. Cookie attributes are stored
   as a structured map (RFC 6265 wire-form serialisation is host-adapter
-  business)."
+  business). Throws `:rf.error/cookie-invalid-name` on a name violating
+  the RFC 6265 §4.1.1 token grammar, and
+  `:rf.error/cookie-invalid-{value,path,domain}` on a CRLF/NUL-bearing
+  attribute string — rf2-z7gor gates the structured cookie at the fx
+  boundary so non-ring host adapters get the same safety the ring
+  materialiser (rf2-rpedl) provides at wire-write time."
   [{:keys [frame]} cookie-map]
+  (validate-cookie! cookie-map)
   (swap-response!
     frame
     (fn [r] (update r :cookies (fnil conj []) cookie-map))))
 
 (defn delete-cookie-fx
   "Handler fn for `:rf.server/delete-cookie`. Sugar over set-cookie
-  with :max-age 0 and an empty :value."
+  with :max-age 0 and an empty :value. Same rf2-z7gor name + path +
+  domain validation as `set-cookie-fx`."
   [{:keys [frame]} {:keys [name path domain]}]
   (let [cookie (cond-> {:name    name
                         :value   ""
                         :max-age 0}
                  path   (assoc :path   path)
                  domain (assoc :domain domain))]
+    (validate-cookie! cookie)
     (swap-response!
       frame
       (fn [r] (update r :cookies (fnil conj []) cookie)))))

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -1352,3 +1352,205 @@
         traces :rf.error/redirect-invalid-location
         "safe-redirect with CRLF in :location"))))
 
+;; ===========================================================================
+;; rf2-z7gor — tag-name injection (emit) + header-name / cookie field
+;; validation (response) — security audit 2026-05-14 §P2
+;;
+;; Companion gates to the rf2-hbty2 header-value gate:
+;;   1. parse-tag-name handed the keyword's leading fragment straight to
+;;      `<...>` emission with no grammar check; a hostile keyword like
+;;      `(keyword "img src=x onerror=alert(1)")` bypassed the attribute
+;;      validator entirely. Validate the tag-name against the HTML5/SVG/
+;;      MathML element-name grammar and fail-fast on misuse.
+;;   2. set-header / append-header validated VALUES (rf2-hbty2) but
+;;      accepted any :name; set-cookie / delete-cookie stored the whole
+;;      cookie map verbatim. Validate header names against the RFC 7230
+;;      §3.2.6 token grammar and cookie fields against RFC 6265 §4.1.1
+;;      + the CR/LF/NUL ban — at the fx boundary so non-ring host
+;;      adapters get the same safety.
+;; ===========================================================================
+
+(deftest ssr-render-rejects-hostile-tag-keywords
+  (testing "rf2-z7gor — a keyword carrying attribute-like injection in the
+            tag component is rejected by :rf.error/invalid-tag-name. The
+            two documented reproductions from the bead."
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo #":rf\.error/invalid-tag-name"
+          (rf/render-to-string [(keyword "img src=x onerror=alert(1)")] {}))
+        "img-with-event-handler injection rejected")
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo #":rf\.error/invalid-tag-name"
+          (rf/render-to-string [(keyword "div> <script") "x"] {}))
+        "tag-break-into-script injection rejected"))
+
+  (testing "rf2-z7gor — whitespace, separators, CTLs, empty all rejected"
+    (doseq [hostile [(keyword " ")
+                     (keyword "a b")
+                     (keyword "tag\rname")
+                     (keyword "tag\nname")
+                     (keyword "")
+                     (keyword "1-leading-digit")
+                     (keyword "<script>")]]
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo #":rf\.error/invalid-tag-name"
+            (rf/render-to-string [hostile] {}))
+          (str "hostile tag-name " (pr-str hostile))))))
+
+(deftest ssr-render-accepts-legit-tag-keywords
+  (testing "rf2-z7gor — regression guard: HTML / SVG / MathML / custom
+            element names + the :tag#id.cls sugar all still flow"
+    (is (= "<div>x</div>"
+           (rf/render-to-string [:div "x"] {})))
+    (is (= "<my-component></my-component>"
+           (rf/render-to-string [:my-component] {})))
+    (is (= "<svg></svg>"
+           (rf/render-to-string [:svg] {})))
+    (is (= "<foreignObject>a</foreignObject>"
+           (rf/render-to-string [:foreignObject "a"] {}))
+        "SVG camelCase element names still parse")
+    (is (= "<div id=\"main\" class=\"col-12 bold\">x</div>"
+           (rf/render-to-string [:div#main.col-12.bold "x"] {}))
+        ":tag#id.cls sugar still parses (validator runs on the tag fragment)")
+    (is (= "<p>a</p><p>b</p>"
+           (rf/render-to-string [:<> [:p "a"] [:p "b"]] {}))
+        ":<> fragment renders children with no wrapper")))
+
+(deftest ssr-set-header-rejects-invalid-name
+  (testing "rf2-z7gor — :rf.server/set-header with CRLF in :name surfaces
+            :rf.error/header-invalid-name (sister gate to rf2-hbty2's
+            header-value gate)"
+    (rf/reg-event-fx :hdr/crlf-in-name
+      (fn [_ _]
+        {:fx [[:rf.server/set-header
+               {:name  "X-Test\r\nSet-Cookie: evil=1"
+                :value "ok"}]]}))
+    (let [f      (rf/make-frame {:platform :server})
+          traces (capture-fx-traces!
+                   (fn [] (rf/dispatch-sync [:hdr/crlf-in-name] {:frame f})))]
+      (expect-fx-error-keyword!
+        traces :rf.error/header-invalid-name
+        "set-header with CRLF in :name")))
+
+  (testing "rf2-z7gor — separators / whitespace / empty all rejected"
+    (doseq [hostile ["Bad: Name" "Bad Name" "" "with(parens)"
+                     (str "nul" (char 0) "bad")]]
+      (rf/reg-event-fx :hdr/probe-name
+        (fn [_ _]
+          {:fx [[:rf.server/set-header {:name hostile :value "ok"}]]}))
+      (let [f      (rf/make-frame {:platform :server})
+            traces (capture-fx-traces!
+                     (fn [] (rf/dispatch-sync [:hdr/probe-name] {:frame f})))]
+        (expect-fx-error-keyword!
+          traces :rf.error/header-invalid-name
+          (str "hostile header name " (pr-str hostile)))))))
+
+(deftest ssr-append-header-rejects-invalid-name
+  (testing "rf2-z7gor — :rf.server/append-header with CRLF in :name surfaces
+            :rf.error/header-invalid-name (same gate as set-header)"
+    (rf/reg-event-fx :hdr/append-crlf-name
+      (fn [_ _]
+        {:fx [[:rf.server/append-header
+               {:name  "X-Audit\r\nSet-Cookie: forged=1"
+                :value "ok"}]]}))
+    (let [f      (rf/make-frame {:platform :server})
+          traces (capture-fx-traces!
+                   (fn [] (rf/dispatch-sync [:hdr/append-crlf-name] {:frame f})))]
+      (expect-fx-error-keyword!
+        traces :rf.error/header-invalid-name
+        "append-header with CRLF in :name"))))
+
+(deftest ssr-set-cookie-rejects-invalid-fields
+  (testing "rf2-z7gor — :rf.server/set-cookie with CRLF in :name surfaces
+            :rf.error/cookie-invalid-name (RFC 6265 §4.1.1 token grammar)"
+    (rf/reg-event-fx :ck/crlf-in-name
+      (fn [_ _]
+        {:fx [[:rf.server/set-cookie
+               {:name  "session\r\nSet-Cookie: stolen=1"
+                :value "abc"}]]}))
+    (let [f      (rf/make-frame {:platform :server})
+          traces (capture-fx-traces!
+                   (fn [] (rf/dispatch-sync [:ck/crlf-in-name] {:frame f})))]
+      (expect-fx-error-keyword!
+        traces :rf.error/cookie-invalid-name
+        "set-cookie with CRLF in :name")))
+
+  (testing "rf2-z7gor — :rf.server/set-cookie with CRLF in :value surfaces
+            :rf.error/cookie-invalid-value"
+    (rf/reg-event-fx :ck/crlf-in-value
+      (fn [_ _]
+        {:fx [[:rf.server/set-cookie
+               {:name  "session"
+                :value "abc\r\nSet-Cookie: stolen=1"}]]}))
+    (let [f      (rf/make-frame {:platform :server})
+          traces (capture-fx-traces!
+                   (fn [] (rf/dispatch-sync [:ck/crlf-in-value] {:frame f})))]
+      (expect-fx-error-keyword!
+        traces :rf.error/cookie-invalid-value
+        "set-cookie with CRLF in :value")))
+
+  (testing "rf2-z7gor — :rf.server/set-cookie with CRLF in :path surfaces
+            :rf.error/cookie-invalid-path"
+    (rf/reg-event-fx :ck/crlf-in-path
+      (fn [_ _]
+        {:fx [[:rf.server/set-cookie
+               {:name  "session"
+                :value "abc"
+                :path  "/\r\nSet-Cookie: stolen=1"}]]}))
+    (let [f      (rf/make-frame {:platform :server})
+          traces (capture-fx-traces!
+                   (fn [] (rf/dispatch-sync [:ck/crlf-in-path] {:frame f})))]
+      (expect-fx-error-keyword!
+        traces :rf.error/cookie-invalid-path
+        "set-cookie with CRLF in :path")))
+
+  (testing "rf2-z7gor — :rf.server/set-cookie with CRLF in :domain surfaces
+            :rf.error/cookie-invalid-domain"
+    (rf/reg-event-fx :ck/crlf-in-domain
+      (fn [_ _]
+        {:fx [[:rf.server/set-cookie
+               {:name   "session"
+                :value  "abc"
+                :domain "example.com\r\nSet-Cookie: stolen=1"}]]}))
+    (let [f      (rf/make-frame {:platform :server})
+          traces (capture-fx-traces!
+                   (fn [] (rf/dispatch-sync [:ck/crlf-in-domain] {:frame f})))]
+      (expect-fx-error-keyword!
+        traces :rf.error/cookie-invalid-domain
+        "set-cookie with CRLF in :domain"))))
+
+(deftest ssr-delete-cookie-rejects-invalid-fields
+  (testing "rf2-z7gor — :rf.server/delete-cookie runs the same validators
+            as set-cookie (it's sugar over set-cookie)"
+    (rf/reg-event-fx :ck/del-crlf-path
+      (fn [_ _]
+        {:fx [[:rf.server/delete-cookie
+               {:name "session" :path "/admin\r\nbad"}]]}))
+    (let [f      (rf/make-frame {:platform :server})
+          traces (capture-fx-traces!
+                   (fn [] (rf/dispatch-sync [:ck/del-crlf-path] {:frame f})))]
+      (expect-fx-error-keyword!
+        traces :rf.error/cookie-invalid-path
+        "delete-cookie with CRLF in :path"))))
+
+(deftest ssr-clean-names-still-accepted
+  (testing "rf2-z7gor — regression guard: legitimate header names + cookie
+            field shapes still flow"
+    (rf/reg-event-fx :clean/all
+      (fn [_ _]
+        {:fx [[:rf.server/set-header  {:name "Cache-Control"
+                                       :value "no-cache"}]
+              [:rf.server/set-header  {:name "X-Forwarded-For"
+                                       :value "1.2.3.4"}]
+              [:rf.server/set-cookie  {:name    "session"
+                                       :value   "abc123"
+                                       :path    "/"
+                                       :domain  "example.com"}]
+              [:rf.server/delete-cookie {:name "stale" :path "/"}]]}))
+    (let [f (rf/make-frame {:platform :server :on-create [:clean/all]})
+          resp (get-response f)]
+      (is (some (fn [[k _]] (= "Cache-Control"   k)) (:headers resp)))
+      (is (some (fn [[k _]] (= "X-Forwarded-For" k)) (:headers resp)))
+      (is (= 2 (count (:cookies resp))))
+      (is (= "session" (-> resp :cookies first :name)))
+      (is (= "stale"   (-> resp :cookies second :name))))))
+


### PR DESCRIPTION
## Summary

Implements the recommended security fixes from the rf2-z7gor P2 audit of `implementation/ssr`. Both findings are clear "gate the accident" fixes that fit the pragmatic stance — they prevent well-meaning code from accidentally injecting via DOM tag keywords or header / cookie names.

### Fix 1 (High) — tag-name validator (`emit.cljc`)

`parse-tag-name` historically split the keyword on `#` / `.` and handed the leading fragment straight to `<...>` / `</...>` emission with no grammar check.

Reproductions (from the bead):
- `render-to-string [(keyword "img src=x onerror=alert(1)")] {}` previously emitted `<img src=x onerror=alert(1)></img src=x onerror=alert(1)>` — bypasses the attribute-name validator entirely. Now throws `:rf.error/invalid-tag-name`.
- `render-to-string [(keyword "div> <script") "x"] {}` previously emitted `<div> <script>x</div> <script>`. Now throws `:rf.error/invalid-tag-name`.

Grammar: `[A-Za-z][A-Za-z0-9-]*` (HTML5 / SVG / MathML element-name rules — covers standard tags, custom elements, and SVG camelCase like `:foreignObject`).

Side effect: `:<>` (fragment) and `:>` (Reagent-native) are now handled at the `emit-element` level ahead of `parse-tag-name`. A fragment correctly emits its children with no wrapper — previously the emitter wrote `<<>>...</<>>` (broken HTML that no test was asserting against).

### Fix 2 (Medium) — header-name + cookie field validators (`response.cljc`)

The rf2-hbty2 work validated header VALUES + redirect locations. Header NAMES and the structured cookie map were still trusted.

The ring host adapter happens to re-validate at materialisation time (rf2-rpedl in `ssr-ring/cookie.clj`), but the SSR layer is also the integration boundary for Pedestal / HttpKit / custom adapters that consume the response shape directly — so the fx boundary is the right place to enforce the invariant once, with the dispatching event still in scope.

Added at the `:rf.server/*` fx boundary:
- `validate-header-name!` — RFC 7230 §3.2.6 token grammar. Wired into `set-header-fx` + `append-header-fx`. Throws `:rf.error/header-invalid-name`.
- `validate-cookie!` — RFC 6265 §4.1.1 token grammar on `:name`, CR/LF/NUL gate on `:value` / `:path` / `:domain`. Wired into `set-cookie-fx` + `delete-cookie-fx`. Throws `:rf.error/cookie-invalid-{name,value,path,domain}`.

Same fail-fast shape as rf2-hbty2 / rf2-rpedl.

## Test plan

- [x] `clojure -M:test` from `implementation/ssr` — 123 tests / 401 assertions / 0 failures (baseline was 116 / 369; +7 new tests / +32 assertions).
- [x] `clojure -M:test` from `implementation/ssr-ring` — 36 / 168 / 0 failures (unchanged).
- [x] `npm run test:cljs` from `implementation/` — 1982 / 5627 / 0 failures.
- [x] Bead reproductions both pinned: `(keyword "img src=x onerror=alert(1)")` and `(keyword "div> <script")` both throw `:rf.error/invalid-tag-name`.
- [x] Header `:name` `"X-Test\r\nSet-Cookie: evil=1"` → `:rf.error/header-invalid-name`.
- [x] Cookie `:name` / `:value` / `:path` / `:domain` with CRLF → matching `:rf.error/cookie-invalid-<field>`.
- [x] Regression guards: clean header names (`Cache-Control`, `X-Forwarded-For`), legit tag names (`:div`, `:my-component`, `:svg`, `:foreignObject`, `:tag#id.cls`, `:<>`), and clean cookies all flow.