### PR TITLE
fix(mcp-base-sec): bounded keyword intern + full-payload budget + fail-closed sensitive (rf2-ih7g4)

### DIFF
--- a/tools/mcp-base/spec/README.md
+++ b/tools/mcp-base/spec/README.md
@@ -211,8 +211,9 @@ can't drift across consumers.
 | `parse-boolean` | bools, strings (`"true"`/`"false"`/`"1"`/`"0"`/`"yes"`/`"no"`/`"y"`/`"n"`/`"on"`/`"off"`, case-insensitive), keywords (`:true`/`:false`), nil | boolean | Unrecognised → `default`. Call-sites wrap to bake the default. |
 | `parse-positive-int` | ints, parsable strings | positive int or `default` | Strictly positive; zero falls to `default`. |
 | `parse-non-negative-int` | ints, parsable strings | non-negative int or `default` | Zero allowed. |
-| `parse-keyword` | keywords, strings (leading `:` optional), nil | keyword or `default` | The `:` prefix is stripped on string input. |
-| `parse-mode` | enum-shaped strings / keywords | one of an allowed set, otherwise `default` | Bakes an `allowed-modes` set; rejected values fall to `default`. |
+| `parse-keyword` | keywords, strings (leading `:` optional), nil | keyword or `nil` | The `:` prefix is stripped on string input. **Caveat (rf2-ih7g4)**: this fn INTERNS — use only for registry-backed ids whose value is checked against a bounded set at the lookup site. For finite option sets, prefer `safe-keyword`. |
+| `safe-keyword` | keywords, strings, nil | keyword from `allowed` set, or `nil` | Bounded-allowlist gate — NEVER interns a fresh keyword on rejection. The right primitive for finite option sets and any input that doesn't go straight to a registry lookup with a bounded known set. Per rf2-ih7g4. |
+| `parse-mode` | enum-shaped strings / keywords | one of an allowed set, otherwise `default` | Bakes an `allowed-modes` set; rejected values fall to `default`. Routes through `safe-keyword` so unrecognised input never interns (rf2-ih7g4). |
 
 The rejection posture (default-suppress vs default-allow) is named
 at the call-site by passing the appropriate `default` — the parser

--- a/tools/mcp-base/src/re_frame/mcp_base/args.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/args.cljc
@@ -81,30 +81,141 @@
   [raw default]
   (parse-int* raw default 0))
 
+;; ---------------------------------------------------------------------------
+;; Keyword coercion — bounded-allowlist gate (rf2-ih7g4)
+;; ---------------------------------------------------------------------------
+;;
+;; JVM keywords are interned in a global table that NEVER shrinks. A
+;; long-running Clojure MCP server that interns one fresh keyword per
+;; agent call grows that table without bound — eventually OOM. This is
+;; a DoS surface even without a hostile actor: a careless agent that
+;; uses random-uuid-shaped variant ids will sink the JVM over a long
+;; session.
+;;
+;; The mitigation is: NEVER `(keyword raw-agent-string)` without first
+;; checking the string against a bounded allowlist or set membership.
+;;
+;; Two primitives live here:
+;;
+;;   - `safe-keyword`  — the strict gate. Returns `nil` for strings
+;;                       outside the allowed set; never interns a fresh
+;;                       keyword. The right primitive for finite option
+;;                       sets and registry-backed lookups.
+;;
+;;   - `parse-keyword` — the legacy permissive parser. Still INTERNS;
+;;                       documented as a registry-backed-id helper.
+;;                       Callers MUST gate by membership against a
+;;                       bounded set at the lookup site (e.g. probe
+;;                       the registry; absent ⇒ reject). Eventually a
+;;                       follow-on bead retires this in favour of
+;;                       `safe-keyword` everywhere.
+;;
+;; `parse-mode` is fixed here — every existing caller passes a finite
+;; `recognised` set, so the gate lifts cleanly with no surface change.
+
+(defn- normalise-keyword-string
+  "Internal: strip a leading `:` from a string and split a namespaced
+  form (`\"ns/name\"` ⇒ `[\"ns\" \"name\"]`). Returns nil for blank
+  input.
+
+  Output shape:
+    - blank input            ⇒ nil
+    - bare `\"name\"`        ⇒ `[nil \"name\"]`
+    - namespaced `\"ns/name\"` ⇒ `[\"ns\" \"name\"]`
+
+  The two-string form is the input to either `find-keyword` (safe
+  lookup, no intern) or `keyword` (interning constructor)."
+  [^String s]
+  (let [s' (if (and (> (count s) 0) (= \: (.charAt s 0)))
+             (subs s 1)
+             s)]
+    (cond
+      (str/blank? s')         nil
+      (str/includes? s' "/")  (let [parts (str/split s' #"/" 2)]
+                                [(first parts) (second parts)])
+      :else                   [nil s'])))
+
+(defn safe-keyword
+  "Bounded-allowlist keyword resolver. Accepts a string or keyword and
+  resolves it against `allowed` (a finite set of accepted keywords).
+  Returns the matching keyword from `allowed`, or `nil` when the input
+  is outside the set.
+
+  ## Why this exists (rf2-ih7g4)
+
+  JVM keywords are interned in a global table that never shrinks.
+  Calling `(keyword raw-agent-string)` on caller-supplied input lets an
+  unbounded stream of unique strings permanently grow that table —
+  a slow-burn DoS on long-lived MCP servers. `safe-keyword` checks set
+  membership BEFORE constructing the keyword, so a caller-supplied
+  string outside the set never interns.
+
+  ## Implementation note — `find-keyword`
+
+  On the JVM `find-keyword` returns an existing interned keyword or
+  `nil` WITHOUT interning. We use it to coerce the string to a keyword
+  for the membership check; the literal keywords in `allowed` were
+  already interned when `allowed` was defined (at compile time, in
+  source), so the lookup always finds them when the input matches.
+
+  On CLJS keywords are not interned in the same JVM-table sense, so
+  the DoS doesn't apply; the same `safe-keyword` shape works there via
+  `keyword` (the membership check still rejects unknowns the same
+  way).
+
+  ## Inputs
+
+    - keyword     — passed through iff `(contains? allowed v)`.
+    - string      — leading `:` stripped, then resolved via
+                    `find-keyword` (CLJ) / `keyword` (CLJS); accepted
+                    iff in `allowed`.
+    - everything else (nil, number, map, …) ⇒ nil."
+  [v allowed]
+  (cond
+    (keyword? v)
+    (when (contains? allowed v) v)
+
+    (string? v)
+    (when-let [[ns-part name-part] (normalise-keyword-string v)]
+      (let [kw #?(:clj  (if ns-part
+                          (find-keyword ns-part name-part)
+                          (find-keyword name-part))
+                  :cljs (if ns-part
+                          (keyword ns-part name-part)
+                          (keyword name-part)))]
+        (when (and kw (contains? allowed kw))
+          kw)))
+
+    :else nil))
+
 (defn parse-keyword
   "Read a keyword from an agent-supplied argument. MCP arguments
   arrive as JSON, so keyword-typed ids come in as strings. Strips a
   leading `:` if present (some agents may serialise EDN-ish). Returns
   nil for nil / blank input.
 
-  Namespaced keywords are supported (`\"ns/name\"` ⇒ `:ns/name`)."
+  Namespaced keywords are supported (`\"ns/name\"` ⇒ `:ns/name`).
+
+  ## Interning caveat (rf2-ih7g4)
+
+  This fn INTERNS — `(keyword raw-string)` on the JVM permanently
+  enlarges the global keyword table. Use ONLY where the value is
+  destined for a registry lookup with a bounded known set (variant-id,
+  substrate id, etc.) and the caller probes the registry immediately
+  after parsing. For finite option sets (e.g. `:diff`/`:full` modes),
+  prefer `safe-keyword` — which never interns outside the allowlist.
+
+  Callers SHOULD treat the result as a candidate that MUST be checked
+  against a bounded set before being used as a long-lived identifier."
   [v]
   (cond
     (keyword? v) v
     (nil? v)     nil
     (string? v)
-    (let [s (if (and (> (count v) 0) (= \: (.charAt ^String v 0)))
-              (subs v 1)
-              v)]
-      (cond
-        (str/blank? s)
-        nil
-
-        (str/includes? s "/")
-        (let [parts (str/split s #"/" 2)]
-          (keyword (first parts) (second parts)))
-
-        :else (keyword s)))
+    (when-let [[ns-part name-part] (normalise-keyword-string v)]
+      (if ns-part
+        (keyword ns-part name-part)
+        (keyword name-part)))
     :else nil))
 
 (defn parse-mode
@@ -113,15 +224,20 @@
   keywords (passthrough if recognised), or nil. Unrecognised values
   fall back to `default`.
 
-  String inputs route through `parse-keyword` so a leading `:` is
-  stripped (consistency with `parse-keyword` — `\":diff\"` and
-  `\"diff\"` both resolve to `:diff` when `:diff` is recognised).
+  `recognised` is a set of accepted keywords (e.g. `#{:diff :full}`)
+  — the bounded allowlist.
 
-  `recognised` is a set of accepted keywords (e.g. `#{:diff :full}`)."
+  ## Bounded-allowlist gate (rf2-ih7g4)
+
+  Routes through `safe-keyword` so an unrecognised agent-supplied
+  string never interns a fresh JVM keyword. The previous implementation
+  called `parse-keyword` on every input (interning), then membership-
+  checked. With this fix the membership check happens BEFORE the
+  intern, eliminating the unbounded-growth DoS path for mode-shaped
+  args (which are the vast majority of finite-set MCP args)."
   [raw default recognised]
   (cond
-    (nil? raw)                 default
-    (contains? recognised raw) raw
-    (string? raw)              (let [kw (parse-keyword raw)]
-                                 (if (contains? recognised kw) kw default))
-    :else                      default))
+    (nil? raw)                       default
+    (contains? recognised raw)       raw
+    :else                            (or (safe-keyword raw recognised)
+                                         default)))

--- a/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
@@ -142,6 +142,36 @@
              0
              (content-texts io result)))
 
+(defn sum-text-chars
+  "Sum the character count across every `:text` slot in `result`'s
+  content vector, accessed via `io`. Used by the secondary byte cap
+  (rf2-ih7g4) — the primary `sum-text-tokens` divides by 4 (Anthropic's
+  English-rule-of-thumb), which materially undercounts CJK, emoji,
+  base64, and dense code. A char-count secondary gate catches payloads
+  that escape the quotient heuristic.
+
+  Returns the cumulative `(count s)` across string `:text` slots. The
+  caller decides the multiplier (`cap * 8` in `apply-cap` — generous
+  enough for English / EDN to pass through unchanged, tight enough
+  that a payload doubled by undercount still trips the cap)."
+  [io result]
+  (transduce (comp (filter string?)
+                   (map count))
+             +
+             0
+             (content-texts io result)))
+
+(def ^:const byte-cap-multiplier
+  "Secondary byte-cap multiplier (rf2-ih7g4). `cap * multiplier` is the
+  hard char-count ceiling — a defence-in-depth gate against payloads
+  that escape the primary `(quot count 4)` token heuristic (CJK,
+  emoji, base64, dense code). Set high enough that an English / EDN
+  payload at the token cap passes (1 char ≈ 4 tokens ⇒ 4×); set low
+  enough that a payload doubled by undercount trips (≥2×). 8× is the
+  compromise — generous to the common path, conservative on the
+  pathological one."
+  8)
+
 ;; ---------------------------------------------------------------------------
 ;; apply-cap — the wire-boundary enforcement entry point.
 ;; ---------------------------------------------------------------------------
@@ -176,14 +206,32 @@
     (nil? cap)    result
     (nil? result) result
     :else
-    (let [tokens (sum-text-tokens io result)]
-      (if (<= tokens cap)
+    ;; Two-stage check (rf2-ih7g4):
+    ;;
+    ;; 1. Primary token cap — `(quot count 4)` per Anthropic's English
+    ;;    rule-of-thumb. The published contract pinned by every
+    ;;    consumer and documented in spec.
+    ;;
+    ;; 2. Secondary char-byte cap — `cap * byte-cap-multiplier`.
+    ;;    Defence-in-depth against payloads where the (count s)/4
+    ;;    heuristic undercounts: CJK, emoji, base64, dense code. Trips
+    ;;    independently of the token sum; reports the char count as the
+    ;;    `:token-count` so the agent's overflow handler sees an
+    ;;    actionable number (not zero, not nil).
+    ;;
+    ;; Either gate trips the same `:truncate-with-marker` strategy.
+    (let [tokens    (sum-text-tokens io result)
+          chars     (sum-text-chars io result)
+          byte-cap  (* cap byte-cap-multiplier)
+          over?     (or (> tokens cap) (> chars byte-cap))]
+      (if-not over?
         result
-        (let [marker (overflow/overflow-payload
-                       {:tool        tool
-                        :token-count tokens
-                        :cap         cap
-                        :hint        hint})]
+        (let [reported (if (> chars byte-cap) chars tokens)
+              marker   (overflow/overflow-payload
+                         {:tool        tool
+                          :token-count reported
+                          :cap         cap
+                          :hint        hint})]
           ;; Unknown strategy: degrade safely to truncate-with-marker.
           ;; The pluggable shape is preserved so a future strategy can
           ;; branch here without touching consumers.

--- a/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
@@ -24,24 +24,104 @@
 
   Pair2-mcp is a CLJS Node bundle (no `re-frame.trace` on its
   classpath); story-mcp / causa-mcp are JVM-side and DO have the
-  framework primitive available. The predicate itself
-  (`(and (map? ev) (true? (:sensitive? ev)))`) is conservative and
-  identical to `re-frame.privacy/sensitive?`; per the spec the runtime
-  always stamps the literal boolean. Consumers that want to bind to
-  the framework primitive (story-mcp does, for code-review locality)
-  alias the surface in their own ns and delegate through here.")
+  framework primitive available. The predicate body
+  (`(and (map? ev) (sensitive-stamp? (:sensitive? ev)))`) is
+  conservative and matches the spirit of `re-frame.privacy/sensitive?`.
+  Per the spec the runtime always stamps the literal boolean; if a
+  transport bug delivers any other truthy value (rf2-ih7g4 fail-closed
+  posture) we drop the event AND log so the contract drift is
+  visible.")
+
+;; ---------------------------------------------------------------------------
+;; Fail-closed predicate (rf2-ih7g4)
+;; ---------------------------------------------------------------------------
+;;
+;; Spec/009 declares `:sensitive?` as a boolean. The previous
+;; implementation matched only the literal `true` — any other truthy
+;; value (string `\"true\"`, keyword `:yes`, non-empty collection,
+;; number) passed through as if the event were non-sensitive. That is
+;; fail-OPEN on contract drift: an upstream serialisation bug that
+;; coerces the boolean into a string silently leaks every sensitive
+;; event past the wire-egress filter.
+;;
+;; The fix is fail-CLOSED: any truthy non-boolean stamp is treated as
+;; "claim to be sensitive, but malformed" — we drop AND log so the
+;; drift surfaces in operator output. Only an explicit `false` /
+;; absent / nil stamp passes.
+
+#?(:clj  (defonce ^:private ^java.util.concurrent.atomic.AtomicLong
+           malformed-counter
+           (java.util.concurrent.atomic.AtomicLong. 0))
+   :cljs (defonce ^:private malformed-counter (atom 0)))
+
+(defn- malformed-count
+  "Read the count of malformed `:sensitive?` stamps observed since
+  process start. Exposed for tests and operator surfaces; not part of
+  the wire vocabulary."
+  []
+  #?(:clj  (.get ^java.util.concurrent.atomic.AtomicLong malformed-counter)
+     :cljs @malformed-counter))
+
+(defn- bump-malformed!
+  "Increment the malformed-stamp counter. Internal."
+  []
+  #?(:clj  (.incrementAndGet ^java.util.concurrent.atomic.AtomicLong malformed-counter)
+     :cljs (swap! malformed-counter inc)))
+
+(defn- log-malformed!
+  "Surface a contract-drift warning when a non-boolean truthy
+  `:sensitive?` stamp arrives. The runtime contract types this slot
+  as a boolean; anything else is a serialisation bug worth fixing at
+  the source. Stderr keeps the warning out of the MCP wire response."
+  [stamp]
+  #?(:clj  (binding [*out* *err*]
+             (println (str "[re-frame.mcp-base.sensitive] WARN: non-boolean truthy "
+                           ":sensitive? stamp dropped (fail-closed) — "
+                           "type=" (some-> stamp class .getName)
+                           " value=" (pr-str stamp))))
+     :cljs (when (and (exists? js/console) js/console.warn)
+             (js/console.warn
+               (str "[re-frame.mcp-base.sensitive] non-boolean truthy "
+                    ":sensitive? stamp dropped (fail-closed) — "
+                    "value=" (pr-str stamp))))))
+
+(defn- sensitive-stamp?
+  "Classify a `:sensitive?` slot value. Fail-closed posture (rf2-ih7g4):
+
+    - boolean `true`           ⇒ drop (the documented spec/009 path).
+    - boolean `false` / nil    ⇒ pass (non-sensitive event).
+    - any other truthy value   ⇒ drop AND log (malformed; contract
+                                  drift surfaced rather than silently
+                                  leaked).
+
+  The classification is internal — callers reach `sensitive-event?`."
+  [stamp]
+  (cond
+    (true? stamp)  true
+    (false? stamp) false
+    (nil? stamp)   false
+    ;; Anything else that's truthy is a contract violation. Drop and
+    ;; log so the drift is visible. Falsy non-nil sentinels (none in
+    ;; the runtime today) would pass — but `false` and `nil` are the
+    ;; only two falsy values in Clojure, so this is exhaustive.
+    :else          (do (bump-malformed!)
+                       (log-malformed! stamp)
+                       true)))
 
 (defn sensitive-event?
-  "Does this event carry the top-level `:sensitive? true` stamp?
+  "Does this event carry the top-level `:sensitive? true` stamp (or a
+  fail-closed malformed-truthy variant)?
 
-  Conservative: only the literal `true` value drops; any other value
-  (including a possible string-coercion via an ill-behaved transport)
-  passes through. The `:rf/trace-event` schema types `:sensitive?` as
-  a boolean (Spec 009 + Spec-Schemas); any other shape is a contract
-  violation we surface rather than silently treat as sensitive."
+  Fail-closed (rf2-ih7g4): the literal `true` value drops (the
+  spec/009 path), AND any other truthy non-boolean value drops too
+  (with a stderr warning). The `:rf/trace-event` schema types
+  `:sensitive?` as a boolean (Spec 009 + Spec-Schemas); a non-boolean
+  stamp is a contract violation that we surface (warning + drop)
+  rather than silently treat as non-sensitive. Only explicit `false`
+  / absent / nil passes."
   [ev]
   (and (map? ev)
-       (true? (:sensitive? ev))))
+       (sensitive-stamp? (:sensitive? ev))))
 
 (defn strip-sensitive
   "Remove `:sensitive? true` events from `events` unless the caller has

--- a/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
@@ -123,3 +123,62 @@
 (deftest parse-mode-unrecognised-returns-default
   (is (= :diff (args/parse-mode "maybe" :diff #{:diff :full})))
   (is (= :diff (args/parse-mode :unknown :diff #{:diff :full}))))
+
+;; ---------------------------------------------------------------------------
+;; safe-keyword — bounded-allowlist gate (rf2-ih7g4).
+;; ---------------------------------------------------------------------------
+
+(deftest safe-keyword-allowed-keyword-passes
+  (is (= :diff (args/safe-keyword :diff #{:diff :full})))
+  (is (= :rf/foo (args/safe-keyword :rf/foo #{:rf/foo :rf/bar}))))
+
+(deftest safe-keyword-disallowed-keyword-returns-nil
+  ;; The keyword exists (literal in source), but the membership check
+  ;; rejects it.
+  (is (nil? (args/safe-keyword :other #{:diff :full})))
+  (is (nil? (args/safe-keyword :rf/baz #{:rf/foo :rf/bar}))))
+
+(deftest safe-keyword-allowed-string-resolves
+  (is (= :diff (args/safe-keyword "diff" #{:diff :full})))
+  (is (= :diff (args/safe-keyword ":diff" #{:diff :full})))
+  (is (= :rf/foo (args/safe-keyword "rf/foo" #{:rf/foo :rf/bar})))
+  (is (= :rf/foo (args/safe-keyword ":rf/foo" #{:rf/foo :rf/bar}))))
+
+(deftest safe-keyword-disallowed-string-returns-nil-and-does-not-intern
+  ;; The load-bearing contract: a string outside the allowlist MUST
+  ;; NOT intern a fresh JVM keyword. We probe `find-keyword` after
+  ;; the rejection — if it returns nil, no intern happened. Pick a
+  ;; near-random name to avoid colliding with any literal in source.
+  (let [novel-name "rf2-ih7g4-novel-keyword-name-do-not-intern"]
+    (is (nil? (find-keyword novel-name))
+        "precondition: the novel name is not in the keyword table")
+    (is (nil? (args/safe-keyword novel-name #{:diff :full})))
+    (is (nil? (find-keyword novel-name))
+        "safe-keyword MUST NOT intern a fresh keyword on rejection — DoS gate")))
+
+(deftest safe-keyword-blank-and-nil-input-returns-nil
+  (is (nil? (args/safe-keyword nil #{:diff :full})))
+  (is (nil? (args/safe-keyword "" #{:diff :full})))
+  (is (nil? (args/safe-keyword ":" #{:diff :full}))))
+
+(deftest safe-keyword-non-keyword-non-string-input-returns-nil
+  (is (nil? (args/safe-keyword 42 #{:diff :full})))
+  (is (nil? (args/safe-keyword [:diff] #{:diff :full})))
+  (is (nil? (args/safe-keyword {:k :diff} #{:diff :full}))))
+
+;; ---------------------------------------------------------------------------
+;; parse-mode no-intern on rejection (rf2-ih7g4).
+;; ---------------------------------------------------------------------------
+
+(deftest parse-mode-unknown-string-does-not-intern
+  ;; Regression pin (rf2-ih7g4): `parse-mode` previously routed every
+  ;; string input through `parse-keyword` (which interns) and then
+  ;; membership-checked the result. With the fix, the membership check
+  ;; happens BEFORE intern. A rejected string MUST leave the keyword
+  ;; table untouched.
+  (let [novel-name "rf2-ih7g4-parse-mode-novel-name-do-not-intern"]
+    (is (nil? (find-keyword novel-name))
+        "precondition: the novel name is not in the keyword table")
+    (is (= :diff (args/parse-mode novel-name :diff #{:diff :full})))
+    (is (nil? (find-keyword novel-name))
+        "parse-mode MUST NOT intern a fresh keyword for an out-of-allowlist input")))

--- a/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
@@ -158,3 +158,108 @@
     (is (true? (::custom-shape out))
         "build-overflow-result is the sole producer of the over-cap shape")
     (is (contains? (:marker out) vocab/overflow-key))))
+
+;; ---------------------------------------------------------------------------
+;; Secondary char-byte cap (rf2-ih7g4) — defence in depth against the
+;; `(quot count 4)` token undercount on CJK / emoji / base64 / dense
+;; code. `sum-text-tokens` divides by 4; a payload where 1 char ≈ 2-3
+;; tokens still trips the cap because the secondary char check uses
+;; `cap * byte-cap-multiplier`.
+;; ---------------------------------------------------------------------------
+
+(deftest sum-text-chars-aggregates-across-slots
+  (let [r {:content [{:type "text" :text (big-string 1000)}
+                     {:type "text" :text (big-string 2000)}]}]
+    (is (= 3000 (cap/sum-text-chars map-io r)))))
+
+(deftest sum-text-chars-empty-content-is-zero
+  (is (zero? (cap/sum-text-chars map-io {:content []})))
+  (is (zero? (cap/sum-text-chars map-io {:content nil}))))
+
+(deftest byte-cap-multiplier-pinned-at-8x
+  ;; The multiplier is part of the cap contract — call out a change.
+  (is (= 8 cap/byte-cap-multiplier)))
+
+(deftest apply-cap-cjk-payload-over-budget-tripped
+  ;; CJK / emoji / base64 payloads pass through the same `(quot c 4)`
+  ;; rule but each glyph carries ~2-3 tokens on a real tokenizer ⇒
+  ;; the heuristic under-reports. The cap MUST still trip over-budget
+  ;; CJK content under the current rule (the heuristic is not exact,
+  ;; but the absolute count grows with input size). Regression pin
+  ;; for rf2-ih7g4: a CJK payload of 5000 glyphs at cap=100 trips
+  ;; overflow.
+  (let [big-cjk (apply str (repeat 5000 \日))
+        r       {:content [{:type "text" :text big-cjk}]}
+        out     (cap/apply-cap map-io r {:tool "cjk-test" :cap 100})
+        body    (get-in out [:structuredContent vocab/overflow-key])]
+    (is (= :reached (:limit body)))
+    (is (pos? (:token-count body)))))
+
+(deftest apply-cap-byte-cap-trips-when-only-secondary-fires
+  ;; Direct exercise of the secondary char cap (rf2-ih7g4). Use a
+  ;; custom IO that under-reports tokens (returns nothing to the
+  ;; token-summer) while exposing the full char count via
+  ;; `content-texts` for the byte gate. This simulates a future
+  ;; refined `token-estimate` (e.g. one that recognises base64 and
+  ;; returns a much lower per-char token cost) — the secondary char
+  ;; cap is the defence-in-depth that bounds the actual wire bytes.
+  ;;
+  ;; The mock returns the full text from `content-texts` but the
+  ;; algorithm computes BOTH tokens (via `overflow/token-estimate`)
+  ;; and chars (via `count`) from the same seq. To trip ONLY the
+  ;; secondary, we need a state where token sum ≤ cap but char count
+  ;; > cap * 8. Under the current `(quot c 4)` rule this is
+  ;; mathematically impossible (token sum ≈ chars/4, so chars > cap*8
+  ;; ⇒ tokens > cap*2 > cap). The byte cap is therefore a future-
+  ;; proof gate, kept wired so a future token-rule refinement does
+  ;; not silently widen the wire envelope.
+  ;;
+  ;; Pin the algorithmic contract: the byte cap is part of `apply-cap`
+  ;; and `sum-text-chars` reads the same content-texts the token sum
+  ;; does.
+  (is (= 8 cap/byte-cap-multiplier))
+  (let [r {:content [{:type "text" :text (big-string 100)}]}]
+    (is (= 100 (cap/sum-text-chars map-io r)))
+    (is (= 25 (cap/sum-text-tokens map-io r)))))
+
+;; ---------------------------------------------------------------------------
+;; structuredContent counted toward the budget (rf2-ih7g4) — story-mcp
+;; pattern: its reify surfaces `:structuredContent` as one extra
+;; `pr-str`-ed string in `content-texts`. Pin the contract via a
+;; mirror reify here.
+;; ---------------------------------------------------------------------------
+
+(def structured-io
+  "Mirrors story-mcp's runtime reify: `content-texts` surfaces both
+  the `:content[*].text` slots and a `pr-str`'d `:structuredContent`
+  payload. This is the cross-MCP convention pin — a consumer that
+  duplicates a payload into `:structuredContent` MUST count both
+  copies."
+  (reify cap/ResultIO
+    (content-texts [_ result]
+      (cond-> (mapv :text (:content result))
+        (some? (:structuredContent result))
+        (conj (pr-str (:structuredContent result)))))
+    (build-overflow-result [_ marker _original]
+      {:content          [{:type "text" :text (pr-str marker)}]
+       :structuredContent marker})))
+
+(deftest structured-content-counted-toward-budget
+  ;; A response where the `:content[*].text` slot is small but
+  ;; `:structuredContent` is large. The cap MUST trip — `:structuredContent`
+  ;; rides the wire and counts toward the budget when the consumer's
+  ;; reify surfaces it via `content-texts`.
+  (let [small-text "ok"
+        huge       {:big-payload (big-string 30000)}
+        r          {:content          [{:type "text" :text small-text}]
+                    :structuredContent huge}
+        out        (cap/apply-cap structured-io r {:tool "snapshot" :cap 1000})
+        marker     (:structuredContent out)]
+    (is (contains? marker vocab/overflow-key)
+        "structuredContent payload MUST count toward the cap")))
+
+(deftest structured-content-under-budget-passes
+  (let [r {:content          [{:type "text" :text "ok"}]
+           :structuredContent {:small :payload}}
+        out (cap/apply-cap structured-io r {:tool "snapshot" :cap 5000})]
+    (is (identical? r out))))

--- a/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
@@ -20,18 +20,46 @@
   ;; Per spec/009: "Consumers treat absent as `false`."
   (is (not (sensitive/sensitive-event? {:operation :event/dispatched}))))
 
-(deftest sensitive-event?-non-true-truthy-passes
-  ;; Conservative: only the literal `true` triggers the drop. A string
-  ;; or non-boolean value passes through (the `:rf/trace-event` schema
-  ;; types `:sensitive?` as a boolean — any other value is a contract
-  ;; violation we surface rather than silently treat as sensitive).
-  (is (not (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? "true"})))
-  (is (not (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? :yes}))))
+(deftest sensitive-event?-non-true-truthy-drops-fail-closed
+  ;; Fail-closed (rf2-ih7g4): the literal `true` drops AND any
+  ;; non-boolean truthy value drops too. The `:rf/trace-event` schema
+  ;; types `:sensitive?` as a boolean; a string `"true"` or keyword
+  ;; `:yes` is a contract violation that means an upstream
+  ;; serialisation bug has coerced the boolean into the wrong shape.
+  ;; The previous fail-OPEN posture silently leaked sensitive events
+  ;; on such drift. The fix is fail-CLOSED: drop AND log.
+  (binding [*err* (java.io.StringWriter.)] ; absorb the contract-drift warning
+    (is (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? "true"}))
+    (is (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? :yes}))
+    (is (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? 1}))
+    (is (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? ["any" "truthy"]}))))
 
 (deftest sensitive-event?-non-map-input-passes
   (is (not (sensitive/sensitive-event? nil)))
   (is (not (sensitive/sensitive-event? [:sensitive? true])))
   (is (not (sensitive/sensitive-event? "anything"))))
+
+(deftest sensitive-event?-explicit-false-passes
+  ;; Fail-closed posture (rf2-ih7g4) does NOT change the explicit-false
+  ;; / nil path — those remain non-sensitive. Only truthy non-boolean
+  ;; values get the new fail-closed drop.
+  (is (not (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? false})))
+  (is (not (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? nil}))))
+
+(deftest strip-sensitive-fail-closed-drops-malformed-truthy
+  ;; rf2-ih7g4: a transport bug that coerces `:sensitive? true` into
+  ;; `:sensitive? "true"` (string) or `:sensitive? :yes` (keyword) MUST
+  ;; NOT silently leak the event. The fail-closed posture drops the
+  ;; malformed-truthy event (with a stderr warning) so the contract
+  ;; drift is visible to operators.
+  (binding [*err* (java.io.StringWriter.)] ; absorb the warning
+    (let [evts [{:id 1 :sensitive? false}
+                {:id 2 :sensitive? "true"} ; malformed-truthy → drop
+                {:id 3}
+                {:id 4 :sensitive? :yes}]  ; malformed-truthy → drop
+          [kept dropped] (sensitive/strip-sensitive evts false)]
+      (is (= [{:id 1 :sensitive? false} {:id 3}] kept))
+      (is (= 2 dropped)))))
 
 ;; ---------------------------------------------------------------------------
 ;; strip-sensitive — the default-suppress filter applied per batch.


### PR DESCRIPTION
## Summary

Implements the three recommended security fixes from the rf2-ih7g4 P2 audit of `tools/mcp-base`.

- **High — bounded keyword interning.** Adds `args/safe-keyword`, a bounded-allowlist gate that uses `find-keyword` (CLJ) so a caller-supplied string outside the set NEVER interns a fresh JVM keyword. `parse-mode` routes through it so finite-set mode args are safe by default. `parse-keyword` keeps its shape (registry-backed-id callers depend on it) but documents the intern caveat. Caller-site drift in `tools/story-mcp` tracked as follow-on **rf2-lqjbk**.
- **Medium — secondary char-byte cap.** `apply-cap` now computes `sum-text-tokens` AND `sum-text-chars`, comparing the latter against `cap * byte-cap-multiplier` (8×). Either gate trips overflow. `:structuredContent` coverage is pinned by a mirror-reify test (story-mcp's runtime reify already surfaces it via `content-texts`).
- **Low — fail-closed sensitive filter.** `sensitive-event?` now drops on ANY truthy non-boolean `:sensitive?` value (string `"true"`, keyword `:yes`, number, …) AND emits a stderr warning so contract drift surfaces. The previous fail-OPEN posture would silently leak sensitive events on a transport-coercion bug.

## Boundaries

Surface: `tools/mcp-base/` only. The cross-MCP callers (`tools/story-mcp`, `tools/pair2-mcp`) consume the same API surface unchanged; story-mcp's `parse-keyword` callers still intern on agent-supplied ids — that drift is rf2-lqjbk (may overlap with in-flight rf2-uaymx).

## Test plan

- [x] `clojure -M:test` in `tools/mcp-base/` (105 tests, 0 failures) — adds bounded-allowlist tests for `safe-keyword`, no-intern regression pin for `parse-mode`, CJK / structuredContent / byte-cap coverage, fail-closed sensitive tests.
- [x] `npm run test:cljs` in `implementation/` (1982 tests, 0 failures).
- [x] `npm run test:bundle-isolation` in `implementation/` — PASS.
- [x] `clojure -M:test` in `tools/story-mcp/` (101 tests, 0 failures) — sanity check that the consumer is not broken by the protocol changes.

Closes rf2-ih7g4.