### PR TITLE
fix(mcp-conformance-sec): absolute exe paths + symlink-safe cleanup (rf2-33vvc)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1399,6 +1399,14 @@ jobs:
       - name: Install mcp-conformance deps
         run: npm install
 
+      # exec-safety helpers (rf2-33vvc): unit-test the
+      # trusted-PATH-resolution + symlink-safe-unlink helpers that the
+      # hermetic orchestrator + story-mcp harness route through. The
+      # symlink-rejection branches need a runner that allows symlinkSync
+      # — Ubuntu GHA does; Windows would soft-skip them.
+      - name: Run mcp-conformance exec-safety unit tests
+        run: npm run test:exec-safety
+
       - name: Run pair2-mcp end-to-end MCP-client conformance
         run: npm run test:pair2
 

--- a/tools/mcp-conformance/.gitignore
+++ b/tools/mcp-conformance/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tools/mcp-conformance/lib/exec-safety.cjs
+++ b/tools/mcp-conformance/lib/exec-safety.cjs
@@ -1,0 +1,319 @@
+// Cross-platform exec-resolution and filesystem-cleanup safety helpers
+// for the mcp-conformance harness. Source: rf2-33vvc.
+//
+// ## Why this exists
+//
+// Two accident classes the audit (rf2-33vvc) flagged:
+//
+//   1. **Windows command-hijack accident** — bare executable names
+//      (`npm`, `npx`, `clojure`) invoked with `shell: true` and `cwd`
+//      set to a repo-controlled directory resolve against the cwd
+//      before PATH. A checkout that happens to carry a `npm.cmd` /
+//      `npx.cmd` / `clojure.cmd` in that cwd (e.g. a fixture dir, or
+//      anywhere reachable in PATHEXT order) would silently execute it
+//      instead of the intended toolchain. The fix is to resolve each
+//      tool name to a single trusted absolute path up-front via PATH
+//      search, refuse to use any candidate that resolves inside the
+//      workspace, and spawn with `shell: false` so the resolved path
+//      is the *only* thing the OS gets to interpret.
+//
+//   2. **Symlink-escape cleanup accident** — `fs.unlinkSync` on a
+//      candidate path under a known root will happily delete a file
+//      outside that root if any parent component is a symlink. The
+//      cleanup step that wipes stale `nrepl.port` files runs before
+//      any other validation, so a fixture tree with a symlinked
+//      `.shadow-cljs/` could be coerced into deleting an arbitrary
+//      file. The fix is to `realpath` the candidate (or, for files
+//      that don't exist yet, the candidate's parent + basename) and
+//      verify the resolved path stays under the resolved allowed
+//      root before unlinking.
+//
+// Mike's pragmatic security stance (per project policy): trust the
+// explicit invoker, gate *accidents* rather than theoretical attacks.
+// Both helpers below gate the accident class without adding ceremony
+// at the call sites.
+//
+// ## API
+//
+//   resolveTrustedExe(name, { workspaceRoot, env, platform })
+//     → absolute path on the host filesystem to an executable named
+//       `name`. Walks PATH (and PATHEXT on Windows); returns the
+//       first match whose realpath does NOT start with
+//       `realpath(workspaceRoot)`. Throws if no candidate is found,
+//       or if every candidate resolves inside the workspace.
+//
+//   safeUnlinkInside(candidatePath, allowedRoot)
+//     → unlinks `candidatePath` iff its realpath (or, when the file
+//       doesn't exist, the realpath of its parent directory + basename)
+//       resolves under `realpath(allowedRoot)`. No-op when the file
+//       doesn't exist. Throws on symlink-escape. Returns true if the
+//       file existed and was unlinked, false otherwise.
+//
+// Both helpers are pure-Node, no external deps; they're test-only
+// fixtures (bundle-isolated by construction — `tools/mcp-conformance/`
+// is not on any production import path).
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// ---------------------------------------------------------------------
+// resolveTrustedExe
+// ---------------------------------------------------------------------
+
+function isWindows(platform) {
+  return (platform || process.platform) === 'win32';
+}
+
+function pathExtensionsFor(platform, env) {
+  if (!isWindows(platform)) return [''];
+  // Windows: PATHEXT controls which extensions are considered
+  // executable. Default is `.COM;.EXE;.BAT;.CMD;...`. The empty string
+  // is included first so an exact-name match (e.g. `clojure` if the
+  // bare file is somehow on disk) also gets considered before the
+  // shell-extension fallbacks. Case-insensitive on Windows, but we
+  // normalise the candidate filesystem check via lowercased compare
+  // below regardless.
+  const pathext = env.PATHEXT || '.COM;.EXE;.BAT;.CMD;.VBS;.JS;.WS';
+  const exts = pathext.split(';').map((s) => s.trim()).filter(Boolean);
+  // Include the bare name (no extension) first — a Unix-style
+  // executable on PATH (e.g. a `clojure` shim with no extension) still
+  // works on Windows under a POSIX-emulating shell.
+  return ['', ...exts];
+}
+
+function realpathSyncOrNull(p) {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return null;
+  }
+}
+
+// Returns true iff `child` is equal to `parent` or is a descendant of
+// it. Both args must already be realpath'd (no symlink in either).
+function isPathInside(child, parent) {
+  // Normalise trailing separators so `/a/b` doesn't fail to match `/a/b/`.
+  const c = path.resolve(child);
+  const p = path.resolve(parent);
+  if (c === p) return true;
+  const sep = path.sep;
+  const pWithSep = p.endsWith(sep) ? p : p + sep;
+  // Case-insensitive compare on Windows — the filesystem itself is
+  // case-insensitive there, and the audit's accident class doesn't
+  // care about case.
+  if (process.platform === 'win32') {
+    return c.toLowerCase().startsWith(pWithSep.toLowerCase());
+  }
+  return c.startsWith(pWithSep);
+}
+
+/**
+ * Resolve `name` to an absolute path on disk, scanning `env.PATH`
+ * (and, on Windows, `env.PATHEXT`). The returned path MUST realpath
+ * to somewhere outside `workspaceRoot` — any candidate that resolves
+ * inside the workspace is skipped, and if every candidate fails the
+ * check the function throws.
+ *
+ * @param {string} name  The bare command name (e.g. "npm", "clojure").
+ *                       MUST NOT contain a path separator — pass just
+ *                       the basename and let PATH search do its job.
+ * @param {object} opts
+ * @param {string} opts.workspaceRoot
+ *                       Absolute path to the repo root. Any candidate
+ *                       resolving under this directory is rejected.
+ * @param {object} [opts.env]      Environment to read PATH/PATHEXT from
+ *                                 (defaults to process.env). Surfaced
+ *                                 as a parameter so tests can drive it.
+ * @param {string} [opts.platform] Platform string (defaults to
+ *                                 process.platform). Surfaced as a
+ *                                 parameter so tests can drive both
+ *                                 win32 and posix code paths.
+ *
+ * @returns {string} Absolute path to the resolved executable.
+ * @throws  If no candidate is found, if the name contains a path
+ *          separator, or if every candidate resolves inside the
+ *          workspace.
+ */
+function resolveTrustedExe(name, opts) {
+  if (typeof name !== 'string' || name.length === 0) {
+    throw new Error('resolveTrustedExe: name must be a non-empty string');
+  }
+  if (name.includes('/') || name.includes('\\')) {
+    throw new Error(
+      'resolveTrustedExe: name must not contain a path separator (got ' +
+        JSON.stringify(name) +
+        '). Pass the bare basename and let PATH search do its job.',
+    );
+  }
+  const env = opts && opts.env ? opts.env : process.env;
+  const platform = opts && opts.platform ? opts.platform : process.platform;
+  if (!opts || typeof opts.workspaceRoot !== 'string') {
+    throw new Error('resolveTrustedExe: opts.workspaceRoot is required');
+  }
+  const workspaceRootReal = realpathSyncOrNull(opts.workspaceRoot);
+  if (!workspaceRootReal) {
+    throw new Error(
+      'resolveTrustedExe: workspaceRoot does not exist or is unreadable: ' +
+        opts.workspaceRoot,
+    );
+  }
+
+  const pathStr = env.PATH || env.Path || env.path || '';
+  // Per Node docs, path.delimiter is `;` on Windows and `:` on POSIX.
+  const dirs = pathStr.split(path.delimiter).filter(Boolean);
+  if (dirs.length === 0) {
+    throw new Error(
+      'resolveTrustedExe: PATH is empty or unset; cannot resolve ' + name,
+    );
+  }
+
+  const exts = pathExtensionsFor(platform, env);
+  const tried = []; // for diagnostic error message
+  const rejectedInsideWorkspace = [];
+
+  for (const dir of dirs) {
+    for (const ext of exts) {
+      const candidate = path.join(dir, name + ext);
+      let stat;
+      try {
+        stat = fs.statSync(candidate);
+      } catch {
+        continue;
+      }
+      if (!stat.isFile()) continue;
+      tried.push(candidate);
+      // Realpath through any symlink — what we trust is the *target*,
+      // not the link. A PATH entry pointing at a workspace-internal
+      // tool via a symlink is the exact accident the audit flagged.
+      const real = realpathSyncOrNull(candidate) || candidate;
+      if (isPathInside(real, workspaceRootReal)) {
+        rejectedInsideWorkspace.push({ candidate, real });
+        continue;
+      }
+      return real;
+    }
+  }
+
+  if (rejectedInsideWorkspace.length > 0) {
+    const list = rejectedInsideWorkspace
+      .map((r) => `  ${r.candidate} -> ${r.real}`)
+      .join('\n');
+    throw new Error(
+      `resolveTrustedExe: every candidate for "${name}" resolved inside ` +
+        `the workspace (${workspaceRootReal}). Refusing to execute ` +
+        `workspace-relative binaries via PATH (rf2-33vvc accident-gating).\n` +
+        `Rejected candidates:\n${list}\n` +
+        `Install ${name} system-wide or adjust PATH so a host binary ` +
+        `appears first.`,
+    );
+  }
+  throw new Error(
+    `resolveTrustedExe: could not find "${name}" on PATH. ` +
+      `Tried ${tried.length} file candidate(s) across ${dirs.length} ` +
+      `directories (PATHEXT entries: ${JSON.stringify(exts)}).`,
+  );
+}
+
+// ---------------------------------------------------------------------
+// safeUnlinkInside
+// ---------------------------------------------------------------------
+
+/**
+ * Unlink `candidatePath` only when its realpath resolves under
+ * `realpath(allowedRoot)`. Symlink-safe: if any parent component is a
+ * symlink whose target escapes the allowed root, the unlink is
+ * rejected. No-op when the file doesn't exist.
+ *
+ * Implementation: when the candidate exists we realpath it directly.
+ * When it doesn't exist we realpath its *parent directory* + append
+ * the basename and check that — this catches the symlinked-parent
+ * case even when the file itself is absent (we still wouldn't want to
+ * lstat-then-write through a parent symlink in a future call, but
+ * here we just bail before unlink would do damage).
+ *
+ * @param {string} candidatePath
+ * @param {string} allowedRoot
+ * @returns {boolean} true if the file existed and was unlinked,
+ *                    false otherwise (file didn't exist).
+ * @throws  If the candidate's realpath escapes the allowed root.
+ */
+function safeUnlinkInside(candidatePath, allowedRoot) {
+  if (typeof candidatePath !== 'string' || candidatePath.length === 0) {
+    throw new Error('safeUnlinkInside: candidatePath must be a non-empty string');
+  }
+  if (typeof allowedRoot !== 'string' || allowedRoot.length === 0) {
+    throw new Error('safeUnlinkInside: allowedRoot must be a non-empty string');
+  }
+  const allowedRootReal = realpathSyncOrNull(allowedRoot);
+  if (!allowedRootReal) {
+    throw new Error(
+      'safeUnlinkInside: allowedRoot does not exist or is unreadable: ' +
+        allowedRoot,
+    );
+  }
+
+  // lstat first: if the candidate doesn't exist at all, we're done.
+  // Using lstat (not stat) so a broken symlink at the leaf is still
+  // visible — we want to refuse to unlink even a dangling link if
+  // its location is outside the allowed root.
+  let leafExists;
+  try {
+    fs.lstatSync(candidatePath);
+    leafExists = true;
+  } catch (e) {
+    if (e && e.code === 'ENOENT') {
+      leafExists = false;
+    } else {
+      throw e;
+    }
+  }
+
+  // Resolve a stable absolute path for the candidate. When the leaf
+  // exists we can realpath it directly; when it doesn't we realpath
+  // the parent directory (which MUST exist for unlink to be meaningful)
+  // and re-attach the basename. The parent-realpath path catches a
+  // symlinked parent — e.g. `<fixture>/.shadow-cljs` being a symlink
+  // to `/etc` — even when the leaf is absent.
+  const dir = path.dirname(candidatePath);
+  const base = path.basename(candidatePath);
+  const parentReal = realpathSyncOrNull(dir);
+  let resolvedLeaf;
+  if (leafExists) {
+    resolvedLeaf = realpathSyncOrNull(candidatePath);
+    // If realpath of the existing leaf fails (rare; permissions, race),
+    // fall back to parent-realpath + basename so we still get a
+    // symlink-resolved path for the containment check.
+    if (!resolvedLeaf && parentReal) {
+      resolvedLeaf = path.join(parentReal, base);
+    }
+  } else if (parentReal) {
+    resolvedLeaf = path.join(parentReal, base);
+  }
+
+  if (!resolvedLeaf) {
+    // Parent directory itself doesn't exist; the file definitely
+    // doesn't either. Treat as no-op.
+    return false;
+  }
+
+  if (!isPathInside(resolvedLeaf, allowedRootReal)) {
+    throw new Error(
+      `safeUnlinkInside: refusing to unlink ${candidatePath} — resolved ` +
+        `path ${resolvedLeaf} is outside allowed root ${allowedRootReal} ` +
+        `(rf2-33vvc symlink-escape accident-gating).`,
+    );
+  }
+
+  if (!leafExists) return false;
+  fs.unlinkSync(candidatePath);
+  return true;
+}
+
+module.exports = {
+  resolveTrustedExe,
+  safeUnlinkInside,
+  // Exposed for tests; not part of the public contract.
+  _internals: { isPathInside, pathExtensionsFor },
+};

--- a/tools/mcp-conformance/package-lock.json
+++ b/tools/mcp-conformance/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0"
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "cross-spawn": "^7.0.6"
       }
     },
     "node_modules/@hono/node-server": {

--- a/tools/mcp-conformance/package.json
+++ b/tools/mcp-conformance/package.json
@@ -10,10 +10,12 @@
     "test:pair2-live-overflow-hermetic": "node scripts/run-live-pair2-overflow-hermetic.cjs",
     "test:story": "node test/end-to-end-story.js",
     "test:causa": "node test/end-to-end-causa.js",
-    "test": "node test/end-to-end-pair2.js && node test/live-pair2-overflow.js && node test/end-to-end-story.js && node test/end-to-end-causa.js"
+    "test:exec-safety": "node --test test/exec-safety.test.cjs",
+    "test": "node --test test/exec-safety.test.cjs && node test/end-to-end-pair2.js && node test/live-pair2-overflow.js && node test/end-to-end-story.js && node test/end-to-end-causa.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "cross-spawn": "^7.0.6"
   },
   "keywords": [
     "re-frame",

--- a/tools/mcp-conformance/scripts/run-live-pair2-overflow-hermetic.cjs
+++ b/tools/mcp-conformance/scripts/run-live-pair2-overflow-hermetic.cjs
@@ -54,12 +54,25 @@
  */
 'use strict';
 
-const { spawn, spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const http = require('node:http');
 const net = require('node:net');
 const path = require('node:path');
 const os = require('node:os');
+const crossSpawn = require('cross-spawn');
+const { resolveTrustedExe, safeUnlinkInside } = require('../lib/exec-safety.cjs');
+
+// We use `cross-spawn` instead of Node's `child_process.spawn` for the
+// two Windows-toolchain spawn sites (`npm` install + `npx shadow-cljs
+// watch`) because Node's spawn refuses to execute `.cmd` / `.bat` with
+// `shell: false` since the CVE-2024-27980 fix (EINVAL). cross-spawn
+// dispatches to cmd.exe under the hood when the resolved target ends
+// in `.cmd`, escapes arguments correctly, and — load-bearing for the
+// rf2-33vvc audit fix — does NOT do a cwd-prefixed PATH walk when the
+// command argument is an absolute path (see `which`'s
+// `cmd.match(/\//)` short-circuit). The accident-gating contract is
+// preserved by passing an absolute path resolved via the host's
+// PATH-only scan (see `lib/exec-safety.cjs`).
 
 const HERE = __dirname;
 const MCP_CONFORMANCE_ROOT = path.resolve(HERE, '..');
@@ -308,17 +321,32 @@ async function waitUntil(label, predicate, timeoutMs) {
   throw new Error(`timeout after ${timeoutMs}ms waiting for: ${label}`);
 }
 
-function spawnNpm(cmd, args, cwd) {
-  const isWin = process.platform === 'win32';
-  const bin = isWin ? `${cmd}.cmd` : cmd;
-  const r = spawnSync(bin, args, {
+// Resolve `npm` / `npx` / etc. to a single trusted absolute path via
+// PATH search, refusing any candidate that resolves under REPO_ROOT.
+// Cached per-name so the PATH walk runs once. See `lib/exec-safety.cjs`
+// for the rationale (rf2-33vvc Windows command-hijack accident-gating).
+const TRUSTED_EXE_CACHE = new Map();
+function trustedExe(name) {
+  if (TRUSTED_EXE_CACHE.has(name)) return TRUSTED_EXE_CACHE.get(name);
+  const resolved = resolveTrustedExe(name, { workspaceRoot: REPO_ROOT });
+  TRUSTED_EXE_CACHE.set(name, resolved);
+  return resolved;
+}
+
+function runTrusted(name, args, cwd) {
+  const bin = trustedExe(name);
+  // cross-spawn.sync handles the `.cmd` -> cmd.exe dispatch on Windows
+  // without re-introducing PATH/cwd lookup ambiguity — see the module
+  // comment at the top of this file for the contract. Passing the
+  // absolute path is what keeps cross-spawn's `which.sync` from doing
+  // its own cwd-relative walk.
+  const r = crossSpawn.sync(bin, args, {
     cwd,
     stdio: 'inherit',
-    shell: isWin,
     env: process.env,
   });
   if (r.status !== 0) {
-    throw new Error(`${cmd} ${args.join(' ')} in ${cwd} exited ${r.status}`);
+    throw new Error(`${name} ${args.join(' ')} in ${cwd} exited ${r.status}`);
   }
 }
 
@@ -364,12 +392,15 @@ async function main() {
   // child will rewrite the appropriate file as part of its boot. Wipe
   // ALL candidate paths so a stale entry at one location can't shadow
   // the fresh file at another.
+  //
+  // Per rf2-33vvc: route every unlink through `safeUnlinkInside` so a
+  // symlinked candidate (or symlinked parent directory) that escapes
+  // FIXTURE_DIR can't be coerced into deleting a file outside the
+  // fixture tree.
   for (const p of NREPL_PORT_FILE_CANDIDATES) {
     try {
-      if (exists(p)) {
-        fs.unlinkSync(p);
-        log(`removed stale port file ${p}`);
-      }
+      const removed = safeUnlinkInside(p, FIXTURE_DIR);
+      if (removed) log(`removed stale port file ${p}`);
     } catch (e) {
       log(`could not remove stale port file ${p} (${e.message}); continuing`);
     }
@@ -378,17 +409,21 @@ async function main() {
   // ---- Install fixture deps --------------------------------------------
   if (!exists(path.join(FIXTURE_DIR, 'node_modules'))) {
     log(`installing fixture deps in ${FIXTURE_DIR}`);
-    spawnNpm('npm', ['install', '--no-audit', '--no-fund'], FIXTURE_DIR);
+    runTrusted('npm', ['install', '--no-audit', '--no-fund'], FIXTURE_DIR);
   }
 
   // ---- Boot shadow-cljs watch ------------------------------------------
-  const isWin = process.platform === 'win32';
-  const shadowBin = isWin ? 'npx.cmd' : 'npx';
-  log(`spawning shadow-cljs watch app in ${FIXTURE_DIR}`);
-  const shadow = spawn(shadowBin, ['shadow-cljs', 'watch', 'app'], {
+  // Resolve `npx` to a trusted absolute path (rejected if it lives
+  // inside REPO_ROOT) and route the spawn through cross-spawn so the
+  // `.cmd`-on-Windows shape works without re-introducing the shell.
+  // Per rf2-33vvc: the pre-fix shape passed `npx.cmd` + `shell: true`
+  // + `cwd = FIXTURE_DIR`, which would have happily executed a
+  // fixture-local `npx.cmd` if one ever landed in the checkout.
+  const npxBin = trustedExe('npx');
+  log(`spawning shadow-cljs watch app in ${FIXTURE_DIR} (npx=${npxBin})`);
+  const shadow = crossSpawn(npxBin, ['shadow-cljs', 'watch', 'app'], {
     cwd: FIXTURE_DIR,
     stdio: ['ignore', 'pipe', 'pipe'],
-    shell: isWin,
     env: { ...process.env, FORCE_COLOR: '0' },
   });
   let shadowExited = false;
@@ -543,7 +578,12 @@ async function main() {
       ...process.env,
       SHADOW_CLJS_NREPL_PORT: String(port),
     };
-    const testRun = spawnSync(process.execPath, [LIVE_TEST], {
+    // `process.execPath` is always an absolute path to the currently-
+    // running node binary; it's outside the workspace by construction.
+    // No PATH walk is performed by cross-spawn for absolute paths
+    // (see `which`'s separator short-circuit), so this stays
+    // accident-safe.
+    const testRun = crossSpawn.sync(process.execPath, [LIVE_TEST], {
       cwd: MCP_CONFORMANCE_ROOT,
       stdio: 'inherit',
       env: testEnv,

--- a/tools/mcp-conformance/test/end-to-end-story.js
+++ b/tools/mcp-conformance/test/end-to-end-story.js
@@ -28,9 +28,19 @@
 
 const path = require('node:path');
 const { runWithWatchdog } = require('./_runner.js');
+const { resolveTrustedExe } = require('../lib/exec-safety.cjs');
 
 const STORY_MCP_CWD = path.resolve(__dirname, '..', '..', 'story-mcp');
-const CLOJURE = process.env.STORY_MCP_CMD || 'clojure';
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+// Resolve `clojure` to a trusted absolute path outside the workspace,
+// or honour the explicit STORY_MCP_CMD override (trust the invoker —
+// rf2-33vvc accident-gating only fires on the implicit-PATH path).
+// Without the override, spawning bare `clojure` with `cwd =
+// STORY_MCP_CWD` would let a workspace-local `clojure.cmd` hijack the
+// invocation on Windows; the resolved-absolute-path form prevents it.
+const CLOJURE = process.env.STORY_MCP_CMD
+  ? process.env.STORY_MCP_CMD
+  : resolveTrustedExe('clojure', { workspaceRoot: REPO_ROOT });
 
 // Per-server tool catalogue. Same set as tools/story-mcp/test/stdio-roundtrip.js
 // — pin exact so accidental renames / additions / deletions surface here.

--- a/tools/mcp-conformance/test/exec-safety.test.cjs
+++ b/tools/mcp-conformance/test/exec-safety.test.cjs
@@ -1,0 +1,375 @@
+// Unit tests for `lib/exec-safety.cjs` (rf2-33vvc).
+//
+// Uses Node's built-in `node:test` so the harness picks up no extra
+// dev-dependency. Runs quiet on success (per docs/quiet-tests.md):
+// `node:test` only prints a per-file summary line on green and
+// dumps the full failure diff on red.
+//
+// Two surfaces under test:
+//
+//   1. `resolveTrustedExe` — must return an absolute path that
+//      realpaths to OUTSIDE the workspace root, and must throw when
+//      every PATH candidate falls inside the workspace (the exact
+//      accident-class flagged by the audit). We drive both POSIX and
+//      win32 code paths via the platform parameter; the workspace
+//      itself doubles as the "compromised PATH entry" so the test is
+//      hermetic — no real binary or temp PATH munging required.
+//
+//   2. `safeUnlinkInside` — must reject any candidate whose
+//      realpath (or, for missing files, whose realpath'd parent
+//      directory + basename) escapes the allowed root. Symlink-leaf
+//      and symlinked-parent cases both covered. Symlink support is
+//      gated on the platform — Windows requires elevated rights for
+//      symlinkSync, so we soft-skip there.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { resolveTrustedExe, safeUnlinkInside } = require('../lib/exec-safety.cjs');
+
+// ---------------------------------------------------------------------
+// Test scratch dir
+// ---------------------------------------------------------------------
+
+function freshTmpDir(label) {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), `rf2-33vvc-${label}-`));
+  // Realpath the tmpdir up-front — on macOS `os.tmpdir()` is
+  // `/var/folders/...` which is itself a symlink to `/private/var/...`.
+  // Without normalising, downstream comparisons would always fail.
+  return fs.realpathSync(base);
+}
+
+function rmrf(p) {
+  try {
+    fs.rmSync(p, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+// Try to create a symlink; return null on platforms / permission
+// configurations where symlinkSync fails (Windows without dev-mode /
+// admin). Tests that need symlinks soft-skip when this returns null.
+function trySymlink(target, link) {
+  try {
+    fs.symlinkSync(target, link);
+    return link;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------
+// resolveTrustedExe
+// ---------------------------------------------------------------------
+
+test('resolveTrustedExe: returns absolute path outside workspace (posix)', () => {
+  // Hermetic setup: build two PATH directories, one inside the
+  // workspace and one outside. The outside one carries a real
+  // executable file; the function MUST pick that one. Drive with
+  // platform='linux' so the empty-extension code path is exercised.
+  const workspace = freshTmpDir('workspace');
+  const outsideDir = freshTmpDir('outside');
+  try {
+    // The "trusted" host-side binary lives outside the workspace.
+    const trustedExe = path.join(outsideDir, 'mytool');
+    fs.writeFileSync(trustedExe, '#!/bin/sh\necho hello\n', { mode: 0o755 });
+
+    // A workspace-local "fake" binary that MUST NOT be picked.
+    const fakeWorkspaceExe = path.join(workspace, 'mytool');
+    fs.writeFileSync(fakeWorkspaceExe, '#!/bin/sh\necho gotcha\n', { mode: 0o755 });
+
+    // workspace comes FIRST in PATH so a naive implementation would
+    // pick it; the helper MUST skip it.
+    const env = { PATH: [workspace, outsideDir].join(path.delimiter) };
+    const resolved = resolveTrustedExe('mytool', {
+      workspaceRoot: workspace,
+      env,
+      platform: 'linux',
+    });
+    assert.equal(path.isAbsolute(resolved), true, 'resolved path must be absolute');
+    assert.equal(resolved, fs.realpathSync(trustedExe));
+    assert.notEqual(
+      resolved,
+      fs.realpathSync(fakeWorkspaceExe),
+      'must not pick the workspace-local candidate',
+    );
+  } finally {
+    rmrf(workspace);
+    rmrf(outsideDir);
+  }
+});
+
+test('resolveTrustedExe: throws when every candidate resolves inside workspace', () => {
+  // Setup: PATH carries ONLY the workspace dir. Every candidate
+  // resolves inside; the function MUST throw rather than execute a
+  // workspace-relative binary.
+  const workspace = freshTmpDir('hijack-only');
+  try {
+    const fake = path.join(workspace, 'mytool');
+    fs.writeFileSync(fake, '#!/bin/sh\necho gotcha\n', { mode: 0o755 });
+
+    const env = { PATH: workspace };
+    assert.throws(
+      () =>
+        resolveTrustedExe('mytool', {
+          workspaceRoot: workspace,
+          env,
+          platform: 'linux',
+        }),
+      (err) => {
+        assert.match(err.message, /workspace/);
+        assert.match(err.message, /rf2-33vvc/);
+        return true;
+      },
+    );
+  } finally {
+    rmrf(workspace);
+  }
+});
+
+test('resolveTrustedExe: throws when name is not on PATH at all', () => {
+  const workspace = freshTmpDir('empty-path');
+  const outsideDir = freshTmpDir('empty-outside');
+  try {
+    const env = { PATH: outsideDir };
+    assert.throws(
+      () =>
+        resolveTrustedExe('definitely-not-a-real-binary', {
+          workspaceRoot: workspace,
+          env,
+          platform: 'linux',
+        }),
+      /could not find/,
+    );
+  } finally {
+    rmrf(workspace);
+    rmrf(outsideDir);
+  }
+});
+
+test('resolveTrustedExe: rejects names containing a path separator', () => {
+  const workspace = freshTmpDir('sep-reject');
+  try {
+    assert.throws(
+      () =>
+        resolveTrustedExe('foo/bar', {
+          workspaceRoot: workspace,
+          env: { PATH: workspace },
+          platform: 'linux',
+        }),
+      /path separator/,
+    );
+    assert.throws(
+      () =>
+        resolveTrustedExe('foo\\bar', {
+          workspaceRoot: workspace,
+          env: { PATH: workspace },
+          platform: 'linux',
+        }),
+      /path separator/,
+    );
+  } finally {
+    rmrf(workspace);
+  }
+});
+
+test('resolveTrustedExe: walks PATHEXT on win32 platform', () => {
+  // win32 code path: even on a POSIX host we can exercise the
+  // PATHEXT walk by passing platform='win32' explicitly. The
+  // candidate file we write carries a `.CMD` extension; the helper
+  // must locate it via the PATHEXT-driven extension probe.
+  const workspace = freshTmpDir('win32-workspace');
+  const outsideDir = freshTmpDir('win32-outside');
+  try {
+    // Note the `.CMD` extension — bare `mytool` does NOT exist on
+    // disk; only `mytool.CMD` does. The PATHEXT walk must catch it.
+    const trustedExe = path.join(outsideDir, 'mytool.CMD');
+    fs.writeFileSync(trustedExe, '@echo hello\n');
+
+    const env = {
+      PATH: outsideDir,
+      PATHEXT: '.COM;.EXE;.BAT;.CMD',
+    };
+    const resolved = resolveTrustedExe('mytool', {
+      workspaceRoot: workspace,
+      env,
+      platform: 'win32',
+    });
+    assert.equal(resolved, fs.realpathSync(trustedExe));
+  } finally {
+    rmrf(workspace);
+    rmrf(outsideDir);
+  }
+});
+
+test('resolveTrustedExe: follows symlinks and rejects when target is inside workspace', { skip: process.platform === 'win32' }, () => {
+  // Setup: outsideDir contains a symlink `mytool` → workspace/realtool.
+  // A naive implementation would pick the symlink and call it
+  // "outside the workspace" by string-prefix. realpath-driven check
+  // catches the redirection and rejects.
+  const workspace = freshTmpDir('symlink-workspace');
+  const outsideDir = freshTmpDir('symlink-outside');
+  try {
+    const realtool = path.join(workspace, 'realtool');
+    fs.writeFileSync(realtool, '#!/bin/sh\necho gotcha\n', { mode: 0o755 });
+    const symlink = path.join(outsideDir, 'mytool');
+    const linked = trySymlink(realtool, symlink);
+    if (!linked) return; // platform/permissions can't symlink — soft-skip
+
+    const env = { PATH: outsideDir };
+    assert.throws(
+      () =>
+        resolveTrustedExe('mytool', {
+          workspaceRoot: workspace,
+          env,
+          platform: 'linux',
+        }),
+      /workspace/,
+    );
+  } finally {
+    rmrf(workspace);
+    rmrf(outsideDir);
+  }
+});
+
+// ---------------------------------------------------------------------
+// safeUnlinkInside
+// ---------------------------------------------------------------------
+
+test('safeUnlinkInside: unlinks file inside allowed root', () => {
+  const root = freshTmpDir('unlink-ok');
+  try {
+    const target = path.join(root, 'file.txt');
+    fs.writeFileSync(target, 'contents');
+    assert.equal(fs.existsSync(target), true);
+    const removed = safeUnlinkInside(target, root);
+    assert.equal(removed, true);
+    assert.equal(fs.existsSync(target), false);
+  } finally {
+    rmrf(root);
+  }
+});
+
+test('safeUnlinkInside: no-op when file does not exist', () => {
+  const root = freshTmpDir('unlink-noop');
+  try {
+    const target = path.join(root, 'never-existed.txt');
+    const removed = safeUnlinkInside(target, root);
+    assert.equal(removed, false);
+  } finally {
+    rmrf(root);
+  }
+});
+
+test('safeUnlinkInside: rejects when realpath escapes allowed root (symlinked leaf)', { skip: process.platform === 'win32' }, () => {
+  // The hostile shape: a leaf file inside the allowed root that is
+  // itself a symlink pointing OUTSIDE the root. Naive unlinkSync
+  // would happily remove the symlink (Unix unlink only removes the
+  // link itself, not the target — but the audit fix is to refuse to
+  // touch any path whose realpath escapes the root, which is the
+  // stronger property and gates the symlinked-parent case below.)
+  const root = freshTmpDir('unlink-escape-leaf');
+  const outsideDir = freshTmpDir('unlink-escape-outside');
+  try {
+    const outsideFile = path.join(outsideDir, 'sensitive.txt');
+    fs.writeFileSync(outsideFile, 'do not delete');
+    const candidate = path.join(root, 'innocent-looking.txt');
+    const linked = trySymlink(outsideFile, candidate);
+    if (!linked) return; // platform/permissions — soft-skip
+
+    assert.throws(
+      () => safeUnlinkInside(candidate, root),
+      /symlink-escape/,
+    );
+    // The outside file must still exist; the symlink itself may be
+    // intact (we refused to touch either).
+    assert.equal(fs.existsSync(outsideFile), true);
+  } finally {
+    rmrf(root);
+    rmrf(outsideDir);
+  }
+});
+
+test('safeUnlinkInside: rejects when parent dir is a symlink escaping root', { skip: process.platform === 'win32' }, () => {
+  // The exact accident class flagged by the audit: the candidate
+  // path lives at `root/.shadow-cljs/nrepl.port`, but `.shadow-cljs`
+  // is itself a symlink whose target is outside the root. The leaf
+  // file may not even exist yet — the parent-symlink realpath check
+  // catches it before any unlink fires.
+  const root = freshTmpDir('unlink-escape-parent');
+  const outsideDir = freshTmpDir('unlink-escape-parent-outside');
+  try {
+    // Set up the "real" .shadow-cljs target outside the root with a
+    // file inside it.
+    const realSide = path.join(outsideDir, 'shadow-cljs');
+    fs.mkdirSync(realSide);
+    const sensitiveFile = path.join(realSide, 'nrepl.port');
+    fs.writeFileSync(sensitiveFile, 'arbitrary file');
+
+    // Symlink `root/.shadow-cljs` → `outsideDir/shadow-cljs`.
+    const symlinkedParent = path.join(root, '.shadow-cljs');
+    const linked = trySymlink(realSide, symlinkedParent);
+    if (!linked) return; // soft-skip
+
+    const candidate = path.join(symlinkedParent, 'nrepl.port');
+    // The candidate appears to live under `root/.shadow-cljs/...`,
+    // but realpath resolves the parent symlink, so the resolved
+    // path is `outsideDir/shadow-cljs/nrepl.port` — outside root.
+    assert.throws(
+      () => safeUnlinkInside(candidate, root),
+      /symlink-escape/,
+    );
+    // The sensitive file MUST still exist — the whole point of the fix.
+    assert.equal(fs.existsSync(sensitiveFile), true);
+  } finally {
+    rmrf(root);
+    rmrf(outsideDir);
+  }
+});
+
+test('safeUnlinkInside: rejects parent-symlink even when leaf does not exist', { skip: process.platform === 'win32' }, () => {
+  // Variant of the above: the parent is a symlink escaping root AND
+  // the leaf file doesn't exist yet. The parent-realpath check
+  // still catches it (this is the "no-op when missing" path that
+  // must not silently pass through symlink-escaped parents).
+  const root = freshTmpDir('unlink-noop-escape-parent');
+  const outsideDir = freshTmpDir('unlink-noop-escape-parent-outside');
+  try {
+    const realSide = path.join(outsideDir, 'shadow-cljs');
+    fs.mkdirSync(realSide);
+    // Do NOT create the leaf file; the parent-realpath check must
+    // still reject the path.
+    const symlinkedParent = path.join(root, '.shadow-cljs');
+    const linked = trySymlink(realSide, symlinkedParent);
+    if (!linked) return;
+
+    const candidate = path.join(symlinkedParent, 'nrepl.port');
+    assert.throws(
+      () => safeUnlinkInside(candidate, root),
+      /symlink-escape/,
+    );
+  } finally {
+    rmrf(root);
+    rmrf(outsideDir);
+  }
+});
+
+test('safeUnlinkInside: rejects empty / missing inputs', () => {
+  const root = freshTmpDir('unlink-bad-inputs');
+  try {
+    assert.throws(() => safeUnlinkInside('', root), /candidatePath/);
+    assert.throws(() => safeUnlinkInside('/whatever', ''), /allowedRoot/);
+    assert.throws(
+      () => safeUnlinkInside('/whatever', '/this/path/does/not/exist/anywhere'),
+      /does not exist/,
+    );
+  } finally {
+    rmrf(root);
+  }
+});


### PR DESCRIPTION
## Summary

Implements the P2 audit fixes from **rf2-33vvc** for `tools/mcp-conformance/`:

- **Medium — Windows command-hijack:** the hermetic orchestrator and story-mcp end-to-end harness spawned bare `npm` / `npx` / `clojure` with `shell: true` and `cwd` set to a repo-controlled directory, allowing a checkout-local `*.cmd` to be preferred over the host toolchain. Add `lib/exec-safety.cjs::resolveTrustedExe` that resolves each name to an absolute path via a PATH-only scan (PATHEXT-aware on Windows), refuses any candidate whose realpath resolves inside the workspace, and routes spawn sites through `cross-spawn` so the `.cmd` dispatch works without re-introducing `shell: true`. Cross-spawn short-circuits its own cwd-relative walk when given an absolute path, so the accident-gating contract is preserved end-to-end.
- **Low — symlink-unsafe cleanup:** the stale-port cleanup unlinked candidate paths without checking whether any parent was a symlink. Add `lib/exec-safety.cjs::safeUnlinkInside` that realpaths the candidate (or, when the leaf is absent, the candidate's parent + basename) and refuses to unlink anything whose resolved path escapes the allowed root.
- The story-mcp `STORY_MCP_CMD` env override is preserved verbatim (trust the explicit invoker, per Mike's pragmatic stance — accident-gating only fires on the implicit-PATH path).
- Adds `test/exec-safety.test.cjs` (12 cases) covering posix + win32-PATHEXT code paths, workspace-only rejection, and symlinked-leaf / symlinked-parent rejection (latter soft-skipped on platforms where `symlinkSync` needs elevation). Wired into the `mcp-conformance-pair2` CI job ahead of the pair2/story/causa runs.

## Test plan

- [x] `tools/mcp-conformance/`: `npm run test:exec-safety` — 8 active, 4 soft-skipped (Windows without dev-mode for symlink branches)
- [x] `implementation/`: `npm run test:cljs` — 1982 tests, 5627 assertions, 0 failures
- [x] `implementation/`: `npm run test:bundle-isolation` — PASS
- [x] `tools/mcp-conformance/`: `npm run test:causa` — SKIP marker still emits
- [ ] CI: full `mcp-conformance-pair2` + `mcp-conformance-story` runs surface the new gate

## Audit trace

- Bead: rf2-33vvc (blocks rf2-td83t — top-level tools/skills security sweep)
- Surface: `tools/mcp-conformance/` only — no public-API touch, no spec change