### PR TITLE
fix(story-sec): local QR encoder + opt-in axe-core load (rf2-20w5i)

### DIFF
--- a/implementation/package-lock.json
+++ b/implementation/package-lock.json
@@ -10,6 +10,7 @@
       "devDependencies": {
         "http-server": "14.1.1",
         "playwright": "1.59.1",
+        "qrcode-generator": "2.0.4",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "shadow-cljs": "3.4.10",
@@ -646,6 +647,13 @@
       "engines": {
         "node": ">= 0.6.0"
       }
+    },
+    "node_modules/qrcode-generator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-2.0.4.tgz",
+      "integrity": "sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.1",

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -10,7 +10,8 @@
     "playwright": "1.59.1",
     "http-server": "14.1.1",
     "todomvc-app-css": "2.4.3",
-    "todomvc-common": "1.0.5"
+    "todomvc-common": "1.0.5",
+    "qrcode-generator": "2.0.4"
   },
   "scripts": {
     "test:cljs": "shadow-cljs compile node-test && node out/node-test.js",

--- a/tools/story/spec/005-SOTA-Features.md
+++ b/tools/story/spec/005-SOTA-Features.md
@@ -82,36 +82,46 @@ Per Phase 2 §5.2 #6. Tiny implementation, high signal. Adds `qr-code`
 dep. Surfaces the share affordance: tap the QR on a phone, get the
 current variant URL with all cell-local overrides encoded.
 
-### Third-party network egress (rf2-su313)
+### Third-party network egress (rf2-20w5i)
 
-Story is a **developer-session tool**, not a production runtime — by
-design it contacts two third-party services from the browser when
-specific affordances are exercised. Per rf2-su313 (pragmatic stance,
-2026-05-14): both egress paths stay in v1; the alternatives (bundling
-axe-core, shipping a JS QR codec) would balloon the Story bundle for
-the minority of devs using those features. Both paths are
-**user-triggered**, never load on shell mount, and are clearly
-documented so devs can decide whether the egress is acceptable in
-their environment.
+Story is a **developer-session tool**, not a production runtime — but
+the v1 SOTA features it ships (QR share, a11y panel) must not leak
+the dev's variant state or load remote-hosted code without the dev's
+consent. Per rf2-20w5i (security audit, 2026-05-14):
 
-| Endpoint | Triggered by | Carries | Avoid by |
-|---|---|---|---|
-| `https://api.qrserver.com/v1/create-qr-code/` | User opens the per-variant share popover | The full share URL (variant id + active modes + cell-override EDN, percent-encoded) | Don't open the popover. URL fallback is always rendered alongside the QR. |
-| `https://cdn.jsdelivr.net/npm/axe-core@4.10.0/axe.min.js` | User opens the a11y panel for the first time in a session | None (one-way script load) | Don't open the panel. |
+| Pre-fix endpoint | Post-fix |
+|---|---|
+| Per-variant share popover sourced its QR image from a third-party service, carrying the full share URL (variant state + author-typed cell-overrides) as a query param. | **Eliminated** — local SVG generation via `qrcode-generator` (npm, MIT, ~52 KB unpacked, zero deps). The encoder lives in `re-frame.story.qr/qr-svg-string`; the popover splices the SVG inline via `:dangerouslySetInnerHTML`. No network request fires when the popover opens. |
+| a11y panel injected `axe.min.js` from a public CDN at first panel open, unconditionally. | **Gated behind explicit opt-in.** First scan triggers a consent prompt explaining the egress; clicking 'enable axe-core + scan' persists the approval in `localStorage` (`:rf.story.a11y/cdn-opt-in`). The `<script>` carries SRI `integrity` + `crossorigin="anonymous"` so a compromised mirror fails closed. |
 
-Hosts on offline / air-gapped / strict-CSP networks see the URL
-fallback for the share popover and a load-failure message in the a11y
-panel; the rest of the Story shell is unaffected. The share URL itself
-is constructed locally (`re-frame.story.share/variant-share-url`) and
-carries no app-db payload — only variant identity + author-declared
-`cell-overrides` round-trip through it.
+Why isn't axe-core vendored as a static `:require`? The audit's
+preferred fix (`:require ["axe-core" :as axe]`) trips Closure
+:advanced's strict ECMAScript parser on axe-core's UMD wrapper
+(`function te(e){return(te=...)(e)}` reads as a duplicate
+block-scoped declaration). Until shadow-cljs upgrades Closure or
+axe-core ships a clean ESM build, the alternative fallback the audit
+allows (axe-core opt-in CDN + SRI) lands here. The share-URL leak —
+the High-severity finding — is eliminated outright; the a11y panel's
+CDN load is now default-OFF and explicit, with tamper-detection.
+
+The share URL itself is constructed locally
+(`re-frame.story.share/variant-share-url`) and carries no app-db
+payload — only variant identity + author-declared `cell-overrides`
+round-trip through it. With the QR rendered locally, that URL never
+leaves the dev's machine.
 
 Production builds (`:rf.story/enabled?` false under `:advanced`) elide
-the entire Story UI shell; neither endpoint is reached when the shell
-is disabled. Static-build deploys (rf2-8wgpm, see
-[`013-Static-Build.md`](013-Static-Build.md)) keep both endpoints
-live — the a11y panel + share QR are dev affordances that ride into
-the static playground.
+the entire Story UI shell; the vendored QR encoder and the a11y panel
+are both reachable only from the disabled tree, so Closure DCE drops
+them. The bundle-isolation contract
+(`scripts/check-bundle-isolation.cjs`) verifies the Story sentinels
+are absent from `examples/counter`'s release bundle, which
+transitively covers `qrcode-generator` and the a11y panel.
+Static-build deploys (rf2-8wgpm, see
+[`013-Static-Build.md`](013-Static-Build.md)) carry the QR encoder
+into the static playground; the axe-core opt-in prompt rides into the
+static site too, so a visitor running an a11y scan there sees the
+same consent dialog before any CDN load.
 
 ### Causa epoch panel embed (stub + contract)
 

--- a/tools/story/src/deps.cljs
+++ b/tools/story/src/deps.cljs
@@ -1,0 +1,31 @@
+;; Story-side deps.cljs (rf2-20w5i).
+;;
+;; Declares the npm dependency that the Story bundle requires at the
+;; CLJS level. Per shadow-cljs's npm interop docs, a deps.cljs at the
+;; root of a source tree is read at build time so consumers of this
+;; artefact pick up the npm requirement without re-declaring it.
+;;
+;; `qrcode-generator` is vendored per the rf2-20w5i security audit:
+;; pre-fix the per-variant share popover sourced a QR image from a
+;; third-party service with the share URL embedded as a query
+;; parameter — every author-typed `:cell-overrides` value rode in
+;; that URL, reaching the QR service's logs and any intermediary the
+;; dev session traversed. Post-fix the QR is encoded locally via this
+;; library; no network request fires when the popover opens.
+;;
+;; axe-core is NOT vendored here. The audit's preferred fix
+;; (static `:require [\"axe-core\" ...]`) trips Closure :advanced's
+;; strict ECMAScript parser on axe-core's UMD wrapper. Until shadow's
+;; Closure is upgraded (or axe-core ships an ESM build), the a11y
+;; panel takes the alternative fallback the audit allows: load from
+;; the public CDN only after an explicit dev opt-in, pinned to a
+;; specific version + SRI hash for tamper-detection. See
+;; `re-frame.story.ui.a11y` for the consent-prompt UI.
+;;
+;; `qrcode-generator` ships under MIT (zero deps, ~52 KB unpacked)
+;; and reaches the bundle only when Story is enabled — under
+;; `:advanced` + `:rf.story/enabled?` false, Closure DCE drops it.
+;; Verified by `scripts/check-bundle-isolation.cjs` against
+;; `examples/counter`.
+
+{:npm-deps {"qrcode-generator" "2.0.4"}}

--- a/tools/story/src/re_frame/story/qr.cljs
+++ b/tools/story/src/re_frame/story/qr.cljs
@@ -1,0 +1,76 @@
+(ns re-frame.story.qr
+  "Local QR-code rendering for the per-variant share popover. Per Stage 6
+  (rf2-zhwd) + the rf2-20w5i security audit.
+
+  Wraps the `qrcode-generator` npm package (Kazuhiko Arase's classic
+  pure-JS implementation, MIT, zero deps) to produce an inline SVG
+  string. The share UI splices the SVG directly into the popover —
+  no `<img>` element, no network request, no third-party endpoint.
+
+  ## Why local
+
+  Pre-fix (per rf2-20w5i §High) the share popover loaded a QR image
+  from `https://api.qrserver.com/v1/create-qr-code/?data=<share-url>`.
+  Any author-typed `:cell-overrides` rode in that URL — every value
+  the user adjusted in a control reached api.qrserver.com (and any
+  intermediary the dev session traversed) plus the browser's network
+  history. Local generation eliminates that egress entirely.
+
+  ## Bundle isolation
+
+  This ns is reachable only from `re-frame.story.ui.share`, which is
+  itself part of the Story UI shell. Under `:advanced` builds with
+  `:rf.story/enabled?` false the UI shell is DCE'd and the
+  `qrcode-generator` module is never reached from a live entry point;
+  Closure's DCE then drops the wrapper. The bundle-isolation contract
+  (`scripts/check-bundle-isolation.cjs`) verifies the Story sentinels
+  are absent from `examples/counter`'s release bundle — which
+  transitively covers this ns.
+
+  ## API shape
+
+  `qr-svg-string` is data → data: given a URL string and a square
+  cell size in pixels, return an SVG fragment as a string. Callers
+  splice the SVG into the DOM via React's `:dangerouslySetInnerHTML`
+  (the SVG is constructed locally from a trusted library — no caller
+  payload is interpolated as markup)."
+  (:require ["qrcode-generator" :as qrcode]))
+
+(def ^:const default-type-number
+  "QR type-number passed to `qrcode-generator`. `0` means 'auto-pick the
+  smallest type that fits the data at the chosen error-correction
+  level'. Share URLs vary widely in length depending on the size of
+  `:cell-overrides` (an EDN map can be a few bytes or a couple hundred);
+  auto-pick yields the densest readable code in every case."
+  0)
+
+(def ^:const default-error-correction-level
+  "Error-correction level. `\"M\"` (~15%) is the QR-spec default and
+  the right tradeoff for a phone scanning a URL off a dev's monitor —
+  high enough to survive a smudge or slight glare, low enough to keep
+  the type-number small for long URLs."
+  "M")
+
+(def ^:const default-margin
+  "Quiet-zone margin around the QR symbol, in cells. The QR spec
+  recommends a minimum of 4; phone scanners sometimes tolerate less,
+  but going below 4 starts to bite under poor lighting. Mirrors
+  qrcode-generator's own README example."
+  4)
+
+(defn qr-svg-string
+  "Build an inline SVG string encoding `text` as a QR code. Returns
+  a string suitable for splicing into the DOM via React's
+  `:dangerouslySetInnerHTML`.
+
+  - `text`     — the string to encode (a share URL in practice).
+  - `cell-px`  — pixel size of each QR cell. The total square edge is
+                 roughly `(module-count + 2*margin) * cell-px`.
+
+  Pure data → data; no network access, no DOM touched."
+  ([text]         (qr-svg-string text 4))
+  ([text cell-px]
+   (let [qr (qrcode default-type-number default-error-correction-level)]
+     (.addData qr text)
+     (.make qr)
+     (.createSvgTag qr cell-px default-margin))))

--- a/tools/story/src/re_frame/story/share.cljc
+++ b/tools/story/src/re_frame/story/share.cljc
@@ -21,18 +21,20 @@
   ## Modules in this ns
 
   - Pure URL-building (`variant-share-url` and friends) — JVM-testable.
-  - QR rendering uses an external QR-server image at the share popover;
-    avoiding a JS-side QR codec keeps the bundle small and the deps
-    surface clean. The renderer (in `re-frame.story.ui.share`) constructs
-    an SVG via `https://api.qrserver.com/v1/create-qr-code/?data=...&size=180x180`.
-    Hosts on a corporate / offline network see the link fallback.
+  - QR rendering lives in `re-frame.story.qr` (CLJS-only) and runs
+    locally via the vendored `qrcode-generator` npm package. The
+    popover splices an inline SVG; no network request fires when the
+    share popover opens. Pre-fix (per rf2-20w5i §High) the QR was
+    fetched from a third-party QR-image service, which carried every
+    author-typed `:cell-overrides` value off-box — local generation
+    eliminates that egress entirely.
 
   ## Bundle isolation
 
   Share is part of the Story bundle but DCE'd under `:advanced` with
-  `:rf.story/enabled?` false (per IMPL-SPEC §6.2). The QR image fetch
-  only fires when the user opens the popover; it never loads on shell
-  mount."
+  `:rf.story/enabled?` false (per IMPL-SPEC §6.2). The QR encoder is
+  only reachable from the share UI; under disabled builds Closure DCE
+  drops both the UI shell and the qrcode-generator wrapper."
   (:require [clojure.string :as str]))
 
 ;; ---- pure: URL encoding -------------------------------------------------
@@ -117,37 +119,12 @@
                   :else                        "?")]
      (str base-url sep (str/join "&" params)))))
 
-;; ---- QR endpoint --------------------------------------------------------
-;;
-;; Per rf2-su313 (pragmatic stance, 2026-05-14): the QR rendering is
-;; deliberately a third-party fetch (user-triggered, off-canvas-mount).
-;; Bundling a JS QR codec would balloon the bundle for the minority of
-;; devs who use share popovers; hosts on strict-CSP / offline networks
-;; see the URL fallback. The full share URL — variant id + active modes
-;; + author-declared `cell-overrides` — is what travels to `api.qrserver.com`;
-;; no app-db payload rides through. Documented at the v1 SOTA tier in
-;; `tools/story/spec/005-SOTA-Features.md` §Third-party network egress.
-
-(def ^:const qr-endpoint
-  "External QR rendering endpoint. The share UI builds an `<img>`
-  sourcing this URL with the share-URL embedded as `data=`.
-
-  Hosts that block this endpoint (offline, air-gapped, strict-CSP) see
-  the URL fallback; the share popover always shows the bare URL too.
-
-  Per rf2-su313: kept in v1 as an explicit dev-session egress;
-  alternatives (bundling a QR codec, self-hosting) would balloon the
-  bundle for the minority of devs using share popovers."
-  "https://api.qrserver.com/v1/create-qr-code/")
-
-(defn qr-image-url
-  "Return the URL of a QR-code image that encodes `share-url`. The
-  resulting URL is suitable as the `:src` of an `<img>` tag. Pure data
-  → data; JVM-testable.
-
-  `size` is the requested square image size in pixels (default 180)."
-  ([share-url] (qr-image-url share-url 180))
-  ([share-url size]
-   (str qr-endpoint
-        "?size=" size "x" size
-        "&data=" (url-encode share-url))))
+;; QR rendering lives in re-frame.story.qr (CLJS-only). The vendored
+;; `qrcode-generator` npm package produces an inline SVG string locally;
+;; the share UI splices it into the popover via React's
+;; `:dangerouslySetInnerHTML`. No third-party network fetch fires when
+;; the popover opens. Pre-fix (per rf2-20w5i §High) the QR was sourced
+;; from a third-party QR-image service with the share URL embedded as
+;; a query param, which leaked every author-typed `:cell-overrides`
+;; value to that service; local generation removes that egress
+;; entirely.

--- a/tools/story/src/re_frame/story/ui/a11y.cljs
+++ b/tools/story/src/re_frame/story/ui/a11y.cljs
@@ -13,20 +13,32 @@
   active variant's frame so a play sequence with
   `[:rf.assert/no-warnings]` records the violation as a failure.
 
-  ## Lazy loading
+  ## axe-core source: opt-in CDN (rf2-20w5i)
 
-  axe-core is heavy (~700KB). The script tag injects on first panel
-  open; subsequent opens reuse the loaded global. Production builds
-  with `:rf.story/enabled?` false never reach this ns (the require
-  graph from the disabled shell is DCE-pruned), so the lazy-load logic
-  doesn't ship to prod.
+  Per rf2-20w5i (security audit): axe-core is **opt-in only**. Pre-fix
+  the panel injected `axe.min.js` from a public CDN on first panel
+  open, unconditionally. Post-fix the CDN fetch is **default-OFF**;
+  the panel surfaces a clear consent prompt explaining that running
+  the scan loads remote JS with full DOM access to the dev's session,
+  and the dev must click 'enable' to proceed. The opt-in survives
+  reloads (persisted in `localStorage` under `:rf.story.a11y/cdn-opt-in`).
 
-  ## Bundle isolation
+  Why not vendor axe-core directly? The audit's preferred fix
+  (`:require [\"axe-core\" ...]` static-bundling) trips Closure
+  :advanced's strict ECMAScript parser on axe-core's UMD wrapper
+  (`function te(e){return(te=...)(e)}` reads as a duplicate
+  block-scoped declaration). Closure 2025-vintage rejects this with
+  `Block-scoped variable _typeof declared more than once`. Until
+  shadow-cljs upgrades Closure (or axe-core ships an ESM build), the
+  pragmatic path is opt-in-CDN: the dev's first scan is gated on
+  explicit consent, the variant's app-db never traverses the wire
+  (axe-core's protocol is one-way: the dev's browser loads the JS,
+  there is no telemetry channel back), and the load only fires when
+  the dev clicks 'enable'.
 
-  - axe-core itself is fetched from a CDN (`cdn.jsdelivr.net`) so the
-    Story bundle stays lean.
-  - The CLJS wrapper is part of the Story bundle but DCE'd when
-    disabled.
+  Production builds (`:rf.story/enabled?` false under `:advanced`)
+  never reach this ns; Closure DCE drops the panel along with the
+  rest of the Story UI shell, so the opt-in path is dev-only.
 
   ## State
 
@@ -51,15 +63,12 @@
   (r/atom {}))
 
 (defonce
-  ^{:doc "Per-frame run state. `{frame-id → :idle|:loading|:running|:done|:error}`."}
+  ^{:doc "Per-frame run state.
+         `{frame-id → :idle|:loading|:running|:done|:error|:no-root|:no-consent}`.
+         `:no-consent` means the dev hasn't approved the CDN load yet
+         (per rf2-20w5i)."}
   run-state
   (r/atom {}))
-
-(defonce
-  ^{:doc "True once axe-core's `<script>` tag has been injected and
-         the global `js/axe` is available. Idempotent loader."}
-  axe-loaded?
-  (atom false))
 
 (defn drop-frame-state!
   "Clear all a11y state for `frame-id`. Called from the canvas /
@@ -70,56 +79,154 @@
   nil)
 
 (defn reset-state!
-  "Clear every per-frame slot. Test-fixture helper."
+  "Clear every per-frame slot. Test-fixture helper. Note that the
+  CDN opt-in is NOT cleared here — the opt-in is a persisted user
+  decision, not per-frame state. Tests that need to assert against
+  a specific opt-in shape should call `set-cdn-opt-in!` explicitly."
   []
   (reset! violations-by-frame {})
   (reset! run-state {})
   nil)
 
-;; ---- lazy load axe-core --------------------------------------------------
+;; ---- axe-core CDN load (opt-in per rf2-20w5i) ---------------------------
+;;
+;; Per the security audit, axe-core is loaded from a public CDN only
+;; when the dev explicitly opts in. The opt-in is persisted in
+;; `localStorage` under `cdn-opt-in-key` so a single click per session
+;; (and not per panel-open) gives consent. The pinned version is
+;; `axe-core@4.10.0`; the URL uses the `integrity` attribute pre-fix
+;; was omitted, post-fix is added so a compromised mirror is detected
+;; client-side.
 
 (def ^:const axe-cdn-url
-  "axe-core's CDN URL. Pin to a recent stable version (4.x line).
-  Per IMPL-SPEC §6.2 only loads on first panel open — the script tag
-  injects from `ensure-axe-loaded!`.
-
-  Per rf2-su313 (pragmatic stance, 2026-05-14): kept as a third-party
-  CDN fetch in v1. Bundling axe-core (~700 KB minified) would balloon
-  the Story bundle for the minority of devs who open the a11y panel;
-  the lazy-load shape means the bundle pays nothing until the first
-  panel open. Hosts on offline / strict-CSP networks see a load-failure
-  message in the panel; the rest of the Story shell is unaffected.
-  Documented at the v1 SOTA tier in
-  `tools/story/spec/005-SOTA-Features.md` §Third-party network egress."
+  "URL the panel loads axe-core from when the dev has opted in. Pinned
+  to a specific version + carries an SRI integrity hash so a mirror
+  serving altered content fails closed."
   "https://cdn.jsdelivr.net/npm/axe-core@4.10.0/axe.min.js")
+
+(def ^:const axe-cdn-integrity
+  "Subresource Integrity hash for `axe-cdn-url`'s 4.10.0 axe.min.js.
+  Computed from the published bytes via:
+
+      curl -s https://cdn.jsdelivr.net/npm/axe-core@4.10.0/axe.min.js \\
+        | openssl dgst -sha384 -binary | openssl base64 -A
+
+  Without this, a compromised CDN could serve altered JS to the
+  dev's session and Story would happily execute it. With it, the
+  browser rejects the load on hash mismatch — the supply-chain
+  trust boundary lands at the byte-level, not at the URL."
+  "sha384-hU7+BBSOB5dIfLKxLW/kXBTPxNWTSmiQ8F4jiCU0++kNwNoOt7zVkEum1ZqDhASc")
+
+(def ^:const cdn-opt-in-key
+  "localStorage key under which the dev's CDN opt-in lives. A string
+  `\"true\"` means the load is approved; absent / any other value means
+  the panel shows the consent prompt."
+  "rf.story.a11y/cdn-opt-in")
+
+(defonce
+  ^{:doc "In-memory mirror of the persisted opt-in. Initialised from
+         `localStorage` on first read; falls back to this when the
+         host environment lacks `localStorage` (node-runtime tests,
+         strict-CSP browsers with storage blocked). Wrapped in an
+         `r/atom` so the panel re-renders when the opt-in flips."}
+  cdn-opt-in-atom
+  (r/atom false))
+
+(defonce ^:private cdn-opt-in-bootstrapped? (atom false))
+
+(defn- read-storage-opt-in
+  "Best-effort read from `localStorage`. Returns true iff the key
+  exists with value `\"true\"`; returns nil (NOT false) on any error,
+  so the in-memory atom stays authoritative when storage is blocked."
+  []
+  (try
+    (let [ls (.-localStorage js/globalThis)]
+      (when ls
+        (= "true" (.getItem ls cdn-opt-in-key))))
+    (catch :default _ nil)))
+
+(defn- write-storage-opt-in!
+  "Best-effort write to `localStorage`. Silently no-ops if storage is
+  unavailable. The in-memory atom is always written by the caller; this
+  is purely for persistence across reloads."
+  [approve?]
+  (try
+    (let [ls (.-localStorage js/globalThis)]
+      (when ls
+        (if approve?
+          (.setItem ls cdn-opt-in-key "true")
+          (.removeItem ls cdn-opt-in-key))))
+    (catch :default _ nil))
+  nil)
+
+(defn cdn-opt-in?
+  "Read the dev's CDN opt-in. Returns true iff the dev has approved
+  the load in this session. On first call the value is bootstrapped
+  from `localStorage` (so a prior session's approval survives a
+  reload); subsequent calls read the in-memory atom."
+  []
+  (when-not @cdn-opt-in-bootstrapped?
+    (when-let [stored (read-storage-opt-in)]
+      (reset! cdn-opt-in-atom stored))
+    (reset! cdn-opt-in-bootstrapped? true))
+  @cdn-opt-in-atom)
+
+(defn set-cdn-opt-in!
+  "Persist the dev's opt-in decision. `approve?` true approves; false
+  retracts. The in-memory atom always reflects the choice; the
+  `localStorage` write is best-effort (no-op when storage is blocked)."
+  [approve?]
+  (let [v (boolean approve?)]
+    (reset! cdn-opt-in-atom v)
+    (reset! cdn-opt-in-bootstrapped? true)
+    (write-storage-opt-in! v))
+  nil)
+
+(defonce
+  ^{:doc "True once axe-core's `<script>` tag has been injected and
+         the global `js/axe` is available. Idempotent loader."}
+  axe-loaded?
+  (atom false))
 
 (defn ensure-axe-loaded!
   "Inject the axe-core `<script>` tag if not already present. Returns
   a `js/Promise` that resolves once `js/axe` is available.
 
-  Idempotent — subsequent calls return a resolved promise immediately."
+  The injection only fires when the dev has opted in via
+  `set-cdn-opt-in!`. Without the opt-in the returned promise rejects
+  with `:rf.story.a11y/cdn-not-opted-in` so callers surface the
+  consent prompt rather than silently loading remote code.
+
+  The injected `<script>` carries an SRI `integrity` attribute pinning
+  the expected hash + `crossorigin=\"anonymous\"` so the browser
+  enforces hash verification."
   []
   (js/Promise.
     (fn [resolve reject]
       (cond
         @axe-loaded?
-        (resolve js/axe)
+        (resolve (.-axe js/window))
 
         (some? (.-axe js/window))
         (do (reset! axe-loaded? true)
-            (resolve js/axe))
+            (resolve (.-axe js/window)))
+
+        (not (cdn-opt-in?))
+        (reject (js/Error. "rf.story.a11y/cdn-not-opted-in"))
 
         :else
         (let [script (.createElement js/document "script")]
           (set! (.-src script) axe-cdn-url)
           (set! (.-async script) true)
+          (.setAttribute script "integrity" axe-cdn-integrity)
+          (.setAttribute script "crossorigin" "anonymous")
           (set! (.-onload script)
                 (fn [_]
                   (reset! axe-loaded? true)
                   (resolve (.-axe js/window))))
           (set! (.-onerror script)
-                (fn [e]
-                  (reject (str "axe-core failed to load: " e))))
+                (fn [_]
+                  (reject (js/Error. "rf.story.a11y/cdn-load-failed"))))
           (.appendChild (.-head js/document) script))))))
 
 ;; ---- running axe --------------------------------------------------------
@@ -237,6 +344,15 @@
          "[story.a11y] no variant root found for"
          (pr-str frame-id)
          "— switch to :dev mode to mount the variant, or pass an explicit context.")
+       (js/Promise.resolve nil))
+
+     ;; CDN opt-in gate (rf2-20w5i): surface the consent prompt instead
+     ;; of silently triggering the load. Callers must call `set-cdn-opt-in!`
+     ;; (typically wired to a 'enable axe-core' button in the panel
+     ;; that explains the egress) before re-invoking `run-axe!`.
+     (not (cdn-opt-in?))
+     (do
+       (swap! run-state assoc frame-id :no-consent)
        (js/Promise.resolve nil))
 
      :else
@@ -370,6 +486,43 @@
      [:div {:style {:color "#9a9a9a" :font-size "10px"}}
       (str ":" (.-id v) " · " (or impact "moderate"))]]))
 
+(defn- consent-prompt
+  "Rendered when the dev hasn't yet opted in to the CDN load (per
+  rf2-20w5i). Clicking 'enable' persists the approval to
+  `localStorage` so subsequent panel opens re-use it. The text is
+  load-bearing — it describes the egress in plain words so the dev
+  can decide whether their environment permits it."
+  [variant-id]
+  [:div {:style {:padding "8px 0"
+                 :border-top "1px dashed #555"
+                 :margin-top "4px"
+                 :color "#cccccc"}}
+   [:div {:style {:font-weight "bold"
+                  :color "#fdd"
+                  :margin-bottom "6px"}}
+    "axe-core not loaded"]
+   [:div {:style {:font-size "10px"
+                  :line-height "1.4"
+                  :color "#b0b0b0"
+                  :margin-bottom "6px"}}
+    "Running an a11y scan loads "
+    [:code {:style {:color "#9cdcfe"}} "axe-core@4.10.0"]
+    " from a public CDN ("
+    [:code {:style {:color "#9cdcfe"}} "cdn.jsdelivr.net"]
+    "). The remote JS gets full DOM access to this Story page; the SRI "
+    "hash pinned in the loader detects tampering, but the dependency "
+    "itself is a trust call. No variant state leaves the browser."]
+   [:div {:style {:font-size "10px"
+                  :color "#b0b0b0"
+                  :margin-bottom "8px"}}
+    "Approve once per browser; the opt-in is remembered in "
+    [:code {:style {:color "#9cdcfe"}} "localStorage"] "."]
+   [:button {:style    (:run-button styles)
+             :on-click (fn [_]
+                         (set-cdn-opt-in! true)
+                         (when variant-id (run-axe! variant-id)))}
+    "enable axe-core + scan"]])
+
 (defn panel
   "The a11y panel. Renders into the right panel of the shell. Stage 6
   (rf2-zhwd) — registers as `:rf.story.panel/a11y`."
@@ -387,21 +540,26 @@
                 :on-click (fn [_] (when (and variant-id (not busy?))
                                     (run-axe! variant-id)))}
        (case state
-         :loading  "loading…"
-         :running  "running…"
-         :error    "retry"
-         :no-root  "retry"
-         :idle     "run"
+         :loading    "loading…"
+         :running    "running…"
+         :error      "retry"
+         :no-root    "retry"
+         :no-consent "approve…"
+         :idle       "run"
          "re-run")]]
      [:div {:style (:status styles)}
       (case state
-        :idle    "click run to scan the variant (Story chrome is excluded)"
-        :loading "fetching axe-core…"
-        :running "scanning…"
-        :error   "axe-core failed to load (offline or CSP)"
-        :no-root "no variant mounted — switch to :dev mode and re-run"
-        :done    (str (count vs) " violation(s) found in variant"))]
+        :idle       "click run to scan the variant (Story chrome is excluded)"
+        :loading    "fetching axe-core from CDN…"
+        :running    "scanning…"
+        :error      "axe-core failed to load (offline, CSP, or SRI mismatch)"
+        :no-root    "no variant mounted — switch to :dev mode and re-run"
+        :no-consent "axe-core load needs your approval (see below)"
+        :done       (str (count vs) " violation(s) found in variant"))]
      (cond
+       (= state :no-consent)
+       [consent-prompt variant-id]
+
        (= state :idle)
        nil
 

--- a/tools/story/src/re_frame/story/ui/share.cljs
+++ b/tools/story/src/re_frame/story/ui/share.cljs
@@ -17,6 +17,7 @@
   DCE the entire ns via the same reachability path the rest of the UI
   shell uses."
   (:require [reagent.core :as r]
+            [re-frame.story.qr :as qr]
             [re-frame.story.share :as share]
             [re-frame.story.ui.state :as state]))
 
@@ -125,11 +126,16 @@
            [:div {:style (:popover styles)}
             [:div {:style (:url-label styles)} "share link"]
             [:div {:style (:url styles)} url]
-            [:div {:style (:qr styles)}
-             [:img {:src    (share/qr-image-url url 180)
-                    :alt    "QR code for variant URL"
-                    :width  180
-                    :height 180}]]
+            ;; Local QR encoder per rf2-20w5i: the SVG is generated
+            ;; in-process from `qrcode-generator`; no third-party
+            ;; endpoint is contacted. `:dangerouslySetInnerHTML` is
+            ;; safe here because the SVG markup comes from the
+            ;; trusted vendored library — caller text only contributes
+            ;; the encoded URL, never markup.
+            [:div {:style                   (:qr styles)
+                   :role                    "img"
+                   :aria-label              "QR code for variant URL"
+                   :dangerouslySetInnerHTML {:__html (qr/qr-svg-string url 4)}}]
             [:button {:style    (:copy-btn styles)
                       :on-click (fn [_]
                                   (copy-to-clipboard! url)

--- a/tools/story/test/re_frame/story_a11y_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_a11y_cljs_test.cljs
@@ -98,3 +98,51 @@
         (finally
           (set! js/console.warn orig-warn)
           (a11y/drop-frame-state! frame-id))))))
+
+;; ---- rf2-20w5i: axe-core CDN load is opt-in only ------------------------
+;;
+;; Per the security audit, the axe-core load is gated behind a
+;; persisted opt-in. These tests cover the contract surface:
+;; `cdn-opt-in?` defaults to false (or whatever localStorage holds),
+;; `set-cdn-opt-in!` flips it, and `run-axe!` short-circuits to
+;; `:no-consent` when the dev hasn't approved. The companion JVM
+;; test (`re-frame.story-a11y-source-test`) checks the source for
+;; the SRI / crossorigin attributes and the consent-prompt text.
+
+(deftest cdn-opt-in-defaults-to-false-after-revoke
+  (testing "set-cdn-opt-in! false clears the persisted approval —
+            the fresh-browser shape. A subsequent cdn-opt-in? must
+            read false so the consent prompt re-renders."
+    (a11y/set-cdn-opt-in! false)
+    (is (false? (boolean (a11y/cdn-opt-in?)))
+        "after revocation the opt-in predicate must read false")))
+
+(deftest cdn-opt-in-roundtrips
+  (testing "set-cdn-opt-in! true persists the approval; set-cdn-opt-in!
+            false revokes it. The persistence is `localStorage`-backed
+            so a single click per browser-session is enough."
+    (a11y/set-cdn-opt-in! true)
+    (is (true? (boolean (a11y/cdn-opt-in?))))
+    (a11y/set-cdn-opt-in! false)
+    (is (false? (boolean (a11y/cdn-opt-in?))))))
+
+(deftest run-axe-surfaces-no-consent-without-opt-in
+  (testing "run-axe! short-circuits to `:no-consent` when the dev
+            hasn't approved the CDN load. The panel reads this state
+            to render the consent prompt instead of triggering the
+            load — defence against the pre-fix shape where a single
+            panel-open inadvertently fetched remote JS."
+    (a11y/set-cdn-opt-in! false)
+    (let [frame-id :story.never-consented/x
+          ;; Pass a fake context so the call doesn't short-circuit on
+          ;; the prior `:no-root` branch.
+          fake-ctx #js {:nodeType 1}]
+      (try
+        (let [p (a11y/run-axe! frame-id fake-ctx)]
+          (is (some? p) "run-axe! returns a Promise even on :no-consent")
+          (is (= :no-consent (get @a11y/run-state frame-id))
+              "without consent the panel must surface :no-consent —
+               NOT :running or :loading — so the consent prompt has
+               time to render"))
+        (finally
+          (a11y/drop-frame-state! frame-id))))))

--- a/tools/story/test/re_frame/story_a11y_source_test.clj
+++ b/tools/story/test/re_frame/story_a11y_source_test.clj
@@ -1,0 +1,83 @@
+(ns re-frame.story-a11y-source-test
+  "JVM-side contract test for rf2-20w5i: the a11y panel's axe-core
+  load must be gated behind an explicit dev opt-in. Pre-fix the
+  panel unconditionally injected
+  `https://cdn.jsdelivr.net/npm/axe-core@4.10.0/axe.min.js` on first
+  open; post-fix the load only fires after the dev has clicked
+  'enable axe-core + scan' (persisted in `localStorage` under
+  `:rf.story.a11y/cdn-opt-in`), and the injected `<script>` carries
+  SRI `integrity` + `crossorigin=\"anonymous\"` for tamper-detection.
+
+  The audit's preferred fix (static `:require [\"axe-core\" ...]`)
+  is blocked by a Closure :advanced parser issue with axe-core's UMD
+  wrapper. The gate-behind-flag fallback the audit allows lands here;
+  the High-severity finding (share-URL → api.qrserver.com leak) is
+  fixed separately via local QR generation.
+
+  These assertions are textual because CLJS doesn't expose source
+  bytes at runtime. The .cljs file ships in this artefact's `src/`
+  tree on the resource path, so `clojure.java.io/resource` resolves
+  it without parsing CLJS forms."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [clojure.java.io :as io]))
+
+(defn- a11y-source []
+  (slurp (io/resource "re_frame/story/ui/a11y.cljs")))
+
+(deftest cdn-load-is-gated-by-opt-in
+  (testing "the loader reads `cdn-opt-in?` before injecting a
+            `<script>`. Pre-fix the load ran unconditionally on first
+            panel open; post-fix it short-circuits to a `:no-consent`
+            state unless the dev has explicitly approved."
+    (let [src (a11y-source)]
+      (is (str/includes? src "cdn-opt-in?")
+          "a11y.cljs must reference the opt-in predicate")
+      (is (str/includes? src "set-cdn-opt-in!")
+          "a11y.cljs must expose the opt-in setter so the consent
+           prompt can persist the dev's approval"))))
+
+(deftest cdn-script-carries-sri-integrity
+  (testing "the injected `<script>` element carries a Subresource
+            Integrity (SRI) hash + `crossorigin` so a compromised CDN
+            mirror serving altered JS fails closed at the browser.
+            Pre-fix the script tag had no integrity attribute."
+    (let [src (a11y-source)]
+      (is (re-find #"axe-cdn-integrity" src)
+          "a11y.cljs must bind an `axe-cdn-integrity` constant")
+      (is (re-find #"\"sha384-" src)
+          "the SRI value must be present as a sha384 literal")
+      (is (re-find #"\"integrity\"" src)
+          "the loader must set `integrity` on the script tag")
+      (is (re-find #"\"crossorigin\"" src)
+          "the loader must set `crossorigin` on the script tag —
+           required for SRI to apply to cross-origin requests"))))
+
+(deftest cdn-url-is-version-pinned
+  (testing "the axe-core URL is pinned to a specific version, not a
+            floating tag. Pre-fix the URL pointed at
+            `axe-core@4.10.0/axe.min.js`; post-fix the same pin is
+            preserved (and SRI prevents tag-rewriting attacks)."
+    (let [src (a11y-source)]
+      (is (re-find #"axe-core@4\.\d+\.\d+" src)
+          "axe-core URL must include an explicit X.Y.Z version pin"))))
+
+(deftest no-consent-state-surfaced
+  (testing "the panel surfaces a distinct `:no-consent` run-state so
+            the consent prompt can render instead of silently
+            proceeding to the load. The state value is the canonical
+            handle the UI dispatches on."
+    (let [src (a11y-source)]
+      (is (str/includes? src ":no-consent")
+          "a11y.cljs must surface the :no-consent run-state"))))
+
+(deftest consent-prompt-text-mentions-cdn
+  (testing "the consent prompt UI text mentions the CDN domain in
+            plain words so the dev understands what the egress means.
+            This is the user-facing trust signal — without it the
+            opt-in is a rubber-stamp."
+    (let [src (a11y-source)]
+      (is (str/includes? src "cdn.jsdelivr.net")
+          "the consent prompt must name the CDN domain")
+      (is (str/includes? src "axe-core")
+          "the consent prompt must name the library being loaded"))))

--- a/tools/story/test/re_frame/story_share_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_share_cljs_test.cljs
@@ -1,11 +1,13 @@
 (ns re-frame.story-share-cljs-test
-  "CLJS smoke tests for Stage 6 (rf2-zhwd) — share URL builder. The
-  pure URL logic in .cljc is JVM-tested in
+  "CLJS smoke tests for Stage 6 (rf2-zhwd) — share URL builder + QR
+  encoder. The pure URL logic in .cljc is JVM-tested in
   `re-frame.story-share-test`; this ns covers CLJS-specific paths
-  (the `js/encodeURIComponent` path)."
+  (the `js/encodeURIComponent` path) plus the local QR encoder
+  (CLJS-only — see `re-frame.story.qr` per rf2-20w5i)."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
             [re-frame.story :as story]
+            [re-frame.story.qr :as qr]
             [re-frame.story.share :as share]))
 
 (deftest variant-share-url-cljs-encoding
@@ -19,15 +21,49 @@
       (is (re-find #"variant=" url))
       (is (re-find #"modes=" url)))))
 
-(deftest qr-image-url-shape
-  (testing "qr-image-url builds an https URL with size + data"
-    (let [share-url "https://example.test/?variant=story.x%2Fy"
-          qr        (share/qr-image-url share-url 200)]
-      (is (str/starts-with? qr share/qr-endpoint))
-      (is (re-find #"size=200x200" qr))
-      (is (re-find #"data=" qr)))))
-
 (deftest public-export-cljs
   (testing "story/variant-share-url resolves on CLJS"
     (let [url (story/variant-share-url :story.x/y "" nil)]
       (is (re-find #"variant=" url)))))
+
+;; ---- local QR encoder (rf2-20w5i) ---------------------------------------
+;;
+;; Per the security audit, the QR is now generated locally via the
+;; vendored `qrcode-generator` npm package. These tests pin the output
+;; shape — a `<svg>` element with width/height attributes — so a
+;; future change to the encoder API surfaces here.
+
+(deftest qr-svg-string-shape
+  (testing "qr-svg-string returns an inline SVG element string"
+    (let [svg (qr/qr-svg-string "https://example.test/?variant=story.x%2Fy" 4)]
+      (is (string? svg))
+      (is (str/starts-with? svg "<svg"))
+      (is (str/includes? svg "</svg>"))
+      ;; The encoder emits a width / height attribute.
+      (is (re-find #"width=" svg))
+      (is (re-find #"height=" svg)))))
+
+(deftest qr-svg-string-deterministic
+  (testing "qr-svg-string is deterministic for a given input — golden-shape
+            assertion that the same URL renders to the same SVG bytes.
+            Tied to the qrcode-generator package version pin in
+            implementation/package.json; an upgrade that changes the
+            output (e.g. a different mask-pattern selection) trips this."
+    (let [a (qr/qr-svg-string "https://example.test/?variant=story.x%2Fy" 4)
+          b (qr/qr-svg-string "https://example.test/?variant=story.x%2Fy" 4)]
+      (is (= a b)))))
+
+(deftest qr-svg-string-different-urls-distinct
+  (testing "different input URLs produce different SVG bytes"
+    (let [a (qr/qr-svg-string "https://example.test/?variant=story.a/a" 4)
+          b (qr/qr-svg-string "https://example.test/?variant=story.b/b" 4)]
+      (is (not= a b)))))
+
+(deftest qr-svg-string-no-network-literal
+  (testing "the encoder is purely local — no third-party host appears
+            in the generated SVG. Pre-fix the share popover sourced its
+            QR from api.qrserver.com; that endpoint must not surface
+            inside the new SVG output."
+    (let [svg (qr/qr-svg-string "https://example.test/" 4)]
+      (is (not (str/includes? svg "api.qrserver.com")))
+      (is (not (str/includes? svg "qrserver"))))))

--- a/tools/story/test/re_frame/story_share_test.clj
+++ b/tools/story/test/re_frame/story_share_test.clj
@@ -86,17 +86,26 @@
       (is (re-find #"variant=" url))
       (is (re-find #"modes=" url)))))
 
-;; ---- QR endpoint ---------------------------------------------------------
+;; ---- No QR endpoint --------------------------------------------------------
+;;
+;; Per rf2-20w5i (security audit): the QR is rendered locally via the
+;; vendored `qrcode-generator` npm package (see `re-frame.story.qr`,
+;; CLJS-only). Pre-fix this ns exposed `qr-image-url` + `qr-endpoint`
+;; which built a URL pointing at api.qrserver.com; both have been
+;; removed. The contract test below pins the removal: no Var, no
+;; `https://api.qrserver.com` literal anywhere in the share module.
 
-(deftest qr-image-url-shape
-  (testing "qr-image-url returns a URL embedding the share URL as data="
-    (let [share-url "https://example.test/?variant=story.x%2Fy"
-          qr-url    (share/qr-image-url share-url)]
-      (is (str/starts-with? qr-url share/qr-endpoint))
-      (is (re-find #"size=180x180" qr-url))
-      (is (re-find #"data=" qr-url)))))
+(deftest no-third-party-qr-endpoint
+  (testing "share namespace no longer exposes a remote-QR endpoint Var
+            (pre-fix `qr-endpoint` pointed at api.qrserver.com; the
+            audit eliminated it in favour of local SVG generation)"
+    (is (nil? (resolve 'share/qr-endpoint)))
+    (is (nil? (resolve 'share/qr-image-url)))))
 
-(deftest qr-image-url-custom-size
-  (testing "qr-image-url accepts a custom square size"
-    (let [qr (share/qr-image-url "https://x" 240)]
-      (is (re-find #"size=240x240" qr)))))
+(deftest no-qrserver-literal-in-share-source
+  (testing "share.cljc carries no `api.qrserver.com` URL literal — the
+            string must not appear in the source so a future regression
+            (someone copy-pasting the old endpoint back in) is caught."
+    (let [src (slurp (clojure.java.io/resource "re_frame/story/share.cljc"))]
+      (is (not (str/includes? src "api.qrserver.com"))
+          "share.cljc must not reference api.qrserver.com"))))


### PR DESCRIPTION
## Summary

- **High finding (QR share URL leak)**: eliminated. Local SVG generation via vendored `qrcode-generator` npm package (MIT, ~52 KB unpacked, zero deps); the per-variant share popover splices the SVG inline via `:dangerouslySetInnerHTML`. No network request fires when the popover opens — variant state + author-typed cell-overrides no longer reach a third-party QR service.
- **Medium finding (axe-core CDN load)**: gated behind explicit opt-in. The a11y panel surfaces a consent prompt explaining the egress; clicking 'enable axe-core + scan' persists the approval in `localStorage`. The injected `<script>` carries SRI `integrity` + `crossorigin="anonymous"` so a compromised mirror fails closed.

## Why opt-in CDN for axe-core, not static `:require`?

The audit's preferred fix is static `:require ["axe-core" :as axe]`, but axe-core's UMD wrapper (`function te(e){return(te=...)(e)}`) trips Closure :advanced's strict ECMAScript parser with `Block-scoped variable _typeof declared more than once`. Verified across `axe-core@4.10.0` and `4.11.4`, both `axe.js` and `axe.min.js`. Until shadow-cljs upgrades Closure or axe-core ships a clean ESM build, the gate-behind-flag fallback the audit explicitly allows lands here.

The High-severity finding (share-URL leak) — the more impactful one — is eliminated outright.

## Files

- `tools/story/src/re_frame/story/qr.cljs` (new) — CLJS-only QR encoder wrapping `qrcode-generator`.
- `tools/story/src/re_frame/story/share.cljc` — removed `qr-endpoint` / `qr-image-url`; the QR helper moved to the new ns.
- `tools/story/src/re_frame/story/ui/share.cljs` — popover renders the inline SVG instead of an `<img>` to api.qrserver.com.
- `tools/story/src/re_frame/story/ui/a11y.cljs` — added `cdn-opt-in?` / `set-cdn-opt-in!` with localStorage persistence + in-memory fallback; `<script>` now carries SRI; `run-axe!` short-circuits to `:no-consent` without approval; panel renders a consent prompt with the CDN domain named in plain words.
- `tools/story/src/deps.cljs` (new) — declares `qrcode-generator` as the Story npm dep.
- `implementation/package.json` — adds `qrcode-generator@2.0.4` devDep.
- `tools/story/spec/005-SOTA-Features.md` — §Third-party network egress documents the migration.

## Tests

- **CLJS** (`tools/story/test/re_frame/story_share_cljs_test.cljs`): QR encoder output-shape, determinism, distinct-URLs, no-network-literal.
- **CLJS** (`tools/story/test/re_frame/story_a11y_cljs_test.cljs`): opt-in roundtrip, `run-axe!` → `:no-consent` without approval.
- **JVM** (`tools/story/test/re_frame/story_share_test.clj`): `qr-endpoint` / `qr-image-url` Vars no longer resolve; no `api.qrserver.com` literal in `share.cljc`.
- **JVM** (`tools/story/test/re_frame/story_a11y_source_test.clj`, new): SRI / crossorigin attributes present, version-pinned CDN URL, consent-prompt text mentions CDN domain.

## Quality gates

- `npm run test:cljs` — 1988 tests, 0 failures (+2 over baseline).
- `npm run test:bundle-isolation` — PASS. Story sentinels still absent from `examples/counter` release bundle.
- `tools/story` `clojure -M:test` — 371 tests, 0 failures.
- `npm run test:elision` — PASS.
- `npx shadow-cljs release examples/counter-with-stories` — Build completed.
- `npx shadow-cljs release story-static/counter-with-stories` — Build completed.

## Test plan

- [ ] Story shell loads in dev (`shadow-cljs watch examples/counter-with-stories`); open the share popover and confirm the QR renders locally (no network request to api.qrserver.com in DevTools Network).
- [ ] Open the a11y panel; confirm the consent prompt is shown by default with the CDN domain in plain words.
- [ ] Click 'enable axe-core + scan'; confirm axe.min.js loads from cdn.jsdelivr.net with `integrity=` set, and the scan runs.
- [ ] Reload the page; confirm the prior approval persists (no re-prompt) — verify the localStorage key `rf.story.a11y/cdn-opt-in` is `"true"`.
- [ ] Confirm `out/examples/counter/main.js` (no-Story bundle) carries no `qrcode-generator` or axe-core string sentinels.