### PR TITLE
feat(testbeds): rf2-kzcim Tier 3+4 — 5 surfaces (drain_depth + non_trivial_app_db + sensitive_dispatcher + large_dispatcher + known_bad_a11y)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -695,4 +695,15 @@
    :output-dir "out/testbeds/non-trivial-app-db"
    :asset-path "."
    :modules    {:main {:init-fn non-trivial-app-db.core/run}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
+
+  ;; rf2-kzcim Tier 3 — sensitive-dispatcher testbed (three handlers
+  ;; marked :sensitive? true in registration meta; each exercises a
+  ;; distinct boundary — event-emit drop, with-redacted scrub, error-
+  ;; emit redact — per Spec 009 §Substrate-level enforcement).
+  :testbeds/sensitive-dispatcher
+  {:target     :browser
+   :output-dir "out/testbeds/sensitive-dispatcher"
+   :asset-path "."
+   :modules    {:main {:init-fn sensitive-dispatcher.core/run}}
    :devtools   {:preloads [day8.re-frame2-causa.preload]}}}}

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -706,4 +706,16 @@
    :output-dir "out/testbeds/sensitive-dispatcher"
    :asset-path "."
    :modules    {:main {:init-fn sensitive-dispatcher.core/run}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
+
+  ;; rf2-kzcim Tier 3 — large-dispatcher testbed (four handlers each
+  ;; commit a value to a path whose wire elision is governed by a
+  ;; different nomination path — runtime auto-detect, REPL wrapper,
+  ;; :rf.size/declare-large fx, schema-driven :large? on a Malli slot
+  ;; — per Spec 009 §Size elision in traces).
+  :testbeds/large-dispatcher
+  {:target     :browser
+   :output-dir "out/testbeds/large-dispatcher"
+   :asset-path "."
+   :modules    {:main {:init-fn large-dispatcher.core/run}}
    :devtools   {:preloads [day8.re-frame2-causa.preload]}}}}

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -673,4 +673,15 @@
    :output-dir "out/testbeds/long-flow-w-failure"
    :asset-path "."
    :modules    {:main {:init-fn long-flow-w-failure.core/run}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
+
+  ;; rf2-kzcim Tier 3 — drain-depth-trigger testbed (one handler that
+  ;; recursively dispatches itself; the runtime's run-to-completion
+  ;; drain halts at the frame's :drain-depth ceiling and rolls back
+  ;; per Spec 002 rule 3 + Spec 009 :rf.error/drain-depth-exceeded).
+  :testbeds/drain-depth-trigger
+  {:target     :browser
+   :output-dir "out/testbeds/drain-depth-trigger"
+   :asset-path "."
+   :modules    {:main {:init-fn drain-depth-trigger.core/run}}
    :devtools   {:preloads [day8.re-frame2-causa.preload]}}}}

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -684,4 +684,15 @@
    :output-dir "out/testbeds/drain-depth-trigger"
    :asset-path "."
    :modules    {:main {:init-fn drain-depth-trigger.core/run}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
+
+  ;; rf2-kzcim Tier 3 — non-trivial-app-db testbed (a 55-leaf app-db
+  ;; nested up to 5 levels deep; six buttons each trigger a
+  ;; structurally distinct diff shape at a known path — exercises the
+  ;; consumer's diff visualisation under realistic depth).
+  :testbeds/non-trivial-app-db
+  {:target     :browser
+   :output-dir "out/testbeds/non-trivial-app-db"
+   :asset-path "."
+   :modules    {:main {:init-fn non-trivial-app-db.core/run}}
    :devtools   {:preloads [day8.re-frame2-causa.preload]}}}}

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -718,4 +718,17 @@
    :output-dir "out/testbeds/large-dispatcher"
    :asset-path "."
    :modules    {:main {:init-fn large-dispatcher.core/run}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
+
+  ;; rf2-kzcim Tier 4 — known-bad-a11y testbed (Story-mode surface
+  ;; with one parent story + two variants — known-bad packs five
+  ;; deliberate axe-core violations; known-good has zero. Verifies
+  ;; the a11y panel scopes axe-core to data-rf-story-variant-root
+  ;; per rf2-qgms1 PR #1080 — flags variant body only, never Story
+  ;; chrome).
+  :testbeds/known-bad-a11y
+  {:target     :browser
+   :output-dir "out/testbeds/known-bad-a11y"
+   :asset-path "."
+   :modules    {:main {:init-fn known-bad-a11y.core/run}}
    :devtools   {:preloads [day8.re-frame2-causa.preload]}}}}

--- a/testbeds/README.md
+++ b/testbeds/README.md
@@ -19,6 +19,11 @@ testbeds/
   multi_frame/             <-- three frames coexisting; cross-frame :dispatch fan-out from one click
   deep_machine/            <-- one machine: parallel regions + 5-deep compound + :always/:after/:invoke/:invoke-all
   long_flow_w_failure/     <-- 5-second cascade driving 3 flows in topo order with configurable mid-flow throw
+  drain_depth_trigger/     <-- handler that recursively dispatches itself; configurable depth ceiling
+  non_trivial_app_db/      <-- 55-leaf app-db nested 5 deep; six diff shapes one per button
+  sensitive_dispatcher/    <-- :sensitive? handlers — event-emit drop / with-redacted / error-emit redact
+  large_dispatcher/        <-- four nomination paths for :rf.size/large-elided (auto / declared / fx / schema)
+  known_bad_a11y/          <-- Story-mode surface; bad+good variants verify the a11y panel scope (rf2-qgms1)
 ```
 
 Per-surface conventions (every testbed in this directory follows them):
@@ -37,6 +42,14 @@ From `implementation/`:
 shadow-cljs watch testbeds/deliberate-throw
 shadow-cljs watch testbeds/schema-violation
 shadow-cljs watch testbeds/http-toggle
+shadow-cljs watch testbeds/multi-frame
+shadow-cljs watch testbeds/deep-machine
+shadow-cljs watch testbeds/long-flow-w-failure
+shadow-cljs watch testbeds/drain-depth-trigger
+shadow-cljs watch testbeds/non-trivial-app-db
+shadow-cljs watch testbeds/sensitive-dispatcher
+shadow-cljs watch testbeds/large-dispatcher
+shadow-cljs watch testbeds/known-bad-a11y
 ```
 
 Then open `http://localhost:9630/build/<build-id>/dashboard` (or the per-testbed index.html served from `implementation/out/testbeds/<name>/`). The Causa preload is wired on every testbed build (mirroring the examples convention) so the trace panel and dev-tools are live on each surface.
@@ -51,6 +64,11 @@ Then open `http://localhost:9630/build/<build-id>/dashboard` (or the per-testbed
 | `multi_frame/` | Separate epoch ring buffers per frame; the Cross-bump click produces three distinct epoch records (one per frame) with `:frame` tag intact; time-travel scrubs each frame independently | Time-travel scrub within a Story variant mounting this surface preserves per-frame isolation; the recorder captures the cross-frame fan-out as one envelope-rooted sequence | `:dispatch` MCP call with `{:frame ...}` opt arrives at the addressed frame; the response envelope carries the resolved `:frame` verbatim; cross-frame fan-out visible in the cascade's epoch record |
 | `deep_machine/` | `:rf.machine/*` events for every transition / spawn / destroy / invoke-all-init / invoke-all-join visible in the trace stream; the `:state` snapshot reads correctly at every compound rung; click-to-source resolves every named action / guard | Recorder captures the deep cascade deterministically; replay reproduces the same `:rf.machine/*` shape | Snapshot-restore round-trip preserves the full `:state` map for parallel regions and the deep compound path; `:rf/after-epoch-by-region` survives `pr-str` |
 | `long_flow_w_failure/` | Trace panel grows on subsequent dispatch over 60+ trace events from one Start click; `:rf.flow/failed → :rf.error/flow-eval-exception` pairs highlighted; ring-buffer budget enforced under cascade saturation when `total-ticks` dialled up | Recorder captures the timed cascade deterministically (timers are data, flows are pure) | The four-rule contract observable over the MCP wire as ordered trace events — `:rf.flow/computed` for `:flow-a` survives every drain; `:rf.flow/failed` for `:flow-b` appears at the threshold |
+| `drain_depth_trigger/` | Partial epoch record (drain-halt) shows up with non-`:ok` outcome (`:halted-depth`, rf2-v0jwt); the failed cascade's N `:event/dispatched` traces leading up to the halt are visible; the post-halt second drain (the in-app listener's flip) reads cleanly on the next epoch | Recorder captures the Start click + halt deterministically; replay reproduces the same N-deep cascade + rollback shape | `:rf.error/drain-depth-exceeded` event arrives over the wire with `:depth`, `:queue-size`, `:last-event` carried verbatim; the post-rollback `app-db` snapshot reads back to the pre-drain shape via `get-path` |
+| `non_trivial_app_db/` | Six distinct `:event/db-changed` shapes per click against a 55-leaf app-db nested 5 deep; diff renderer drills into vector indices and 5-level subtrees; time-travel scrubs preserve every depth | Snapshot identity reproducible across runs — the deterministic 6-click sequence produces a bit-identical snapshot on replay; variants mounting this surface verify the chrome doesn't choke on realistic app-db | Snapshot-restore round-trip preserves all 55 leaves; `get-path` resolves at every depth without elision (no slot is `:large?`) |
+| `sensitive_dispatcher/` | `:sensitive?` event arrives with `:event` redacted to `:rf/redacted` (Button B); error-emit substrate's redacted `:event` slot on Button C's throw; event-emit substrate drops the per-event record entirely on Button A | Recorder redacts secret-bearing events (rf2-hdadz) — Button B's click is captured with `:rf/redacted` in place of the password/totp slots | The MCP wire applies the same redaction posture; `:dropped-sensitive` indicator surfaces when the wire walker dropped a leaf |
+| `large_dispatcher/` | `:large?` value arrives as `:rf.size/large-elided` marker — four `:source` values discriminate the nomination path (`:runtime-flagged` on Button A, `:declared` on B+C, `:schema` on D); `:rf.warning/runtime-large-elision` fires once on Button A's first emit | Recorder captures the click deterministically; replay reproduces the same elision marker on each emit | The marker's `:handle` shape is `get-path`-callable; the wire-cap budget stays under 5K-token cap regardless of payload size |
+| `known_bad_a11y/` | n/a (Causa doesn't consume a11y output) | A11y panel surfaces violations on `:story.a11y/known-bad` (≥5) and reports 0 on `:story.a11y/known-good` — the pairwise contract that proves axe-core's scan is scoped to the variant root per rf2-qgms1 / PR #1080 | n/a (the a11y contract is Story-local) |
 
 ## Tier roadmap (rf2-kzcim)
 
@@ -60,15 +78,22 @@ Tier 1 — load-bearing trio:
 - ✅ `schema_violation/`
 - ✅ `http_toggle/`
 
-Tier 2 — state-machine + frame surfaces (this commit set):
+Tier 2 — state-machine + frame surfaces:
 
 - ✅ `multi_frame/`
 - ✅ `deep_machine/`
 - ✅ `long_flow_w_failure/`
 
-Tier 3 (devtools edge cases): `drain_depth_trigger/`, `non_trivial_app_db/`, `sensitive_dispatcher/`, `large_dispatcher/`.
+Tier 3 — devtools edge cases:
 
-Tier 4 (a11y): `known_bad_a11y/` — a Story variant with a deliberate a11y violation; the variant root carries the violation, not the Story chrome (cross-ref rf2-qgms1).
+- ✅ `drain_depth_trigger/`
+- ✅ `non_trivial_app_db/`
+- ✅ `sensitive_dispatcher/`
+- ✅ `large_dispatcher/`
+
+Tier 4 — a11y:
+
+- ✅ `known_bad_a11y/`
 
 ## Cross-references
 
@@ -78,4 +103,9 @@ Tier 4 (a11y): `known_bad_a11y/` — a Story variant with a deliberate a11y viol
 - [`spec/010-Schemas.md` §Per-step recovery](../spec/010-Schemas.md) — the five validation points the `schema_violation/` surface walks one button per.
 - [`spec/013-Flows.md` §Failure semantics](../spec/013-Flows.md) — the four-rule flow-failure contract the `long_flow_w_failure/` surface exercises over a multi-second cascade.
 - [`spec/014-HTTPRequests.md` §Failure categories](../spec/014-HTTPRequests.md) — the eight `:rf.http/*` categories the `http_toggle/` outcome dropdown enumerates.
+- [`spec/002-Frames.md` §Run-to-completion](../spec/002-Frames.md) — the depth-bounded drain rule 3 the `drain_depth_trigger/` surface forces the runtime to hit.
+- [`spec/009-Instrumentation.md` §Privacy / sensitive data in traces](../spec/009-Instrumentation.md) — the `:sensitive?` registration meta + `with-redacted` interceptor + always-on substrate enforcement the `sensitive_dispatcher/` surface exercises three buttons against.
+- [`spec/009-Instrumentation.md` §Size elision in traces](../spec/009-Instrumentation.md) — the three nomination paths + `:rf.size/large-elided` marker shape the `large_dispatcher/` surface exercises four buttons against.
+- [`spec/Spec-Schemas.md` §`:rf/epoch-record` Outcomes](../spec/Spec-Schemas.md) — the `:halted-depth` outcome key the `drain_depth_trigger/` surface produces (rf2-v0jwt).
+- **rf2-qgms1 / PR #1080** — the a11y-panel scope fix the `known_bad_a11y/` surface regression-tests against (axe-core's `context` parameter scopes the scan to `data-rf-story-variant-root`).
 - [`spec/Ownership.md`](../spec/Ownership.md) — where every contract surface this directory exercises is owned.

--- a/testbeds/drain_depth_trigger/README.md
+++ b/testbeds/drain_depth_trigger/README.md
@@ -1,0 +1,114 @@
+# `testbeds/drain-depth-trigger`
+
+A single Reagent-mounted handler whose `:fx` recursively dispatches
+itself. The runtime's run-to-completion drain halts the cascade when
+the frame's `:drain-depth` ceiling is reached and rolls the frame's
+`app-db` back atomically (per [spec/002 §Run-to-completion rule 3]).
+A consumer (Causa, Story, pair2-mcp) observes the
+`:rf.error/drain-depth-exceeded` shape, the rollback, and the
+`:halted-depth` epoch outcome (rf2-v0jwt).
+
+## The cascade
+
+```
+click Start
+  → dispatch [::recurse]
+       :db  (update db :depth-reached inc)
+       :fx  [[:dispatch [::recurse]]]   ← always
+            ...
+```
+
+`::recurse` has no termination branch on purpose. The cascade only
+halts via the runtime's ceiling. After the halt:
+
+- `:depth-reached` reads back to `0` — rule 3 rollback evidence.
+- The error-emit substrate (per [spec/009 §What IS available in
+  production]) fires `:rf.error/drain-depth-exceeded`; the surface's
+  in-app listener flips `:halted?` to `true` via a second dispatch
+  (which runs on a fresh drain post-rollback).
+- The frame's epoch record for the failed cascade carries outcome
+  `:halted-depth` (per [Spec-Schemas §`:rf/epoch-record` Outcomes],
+  rf2-v0jwt).
+
+## Controls
+
+| Control | `data-testid` | What it does |
+|---|---|---|
+| `Drain depth ceiling` | `drain-depth` | The frame's `:drain-depth`. Re-registers the default frame with the new value (a surgical update per [spec/002 §Surgical update] — only the ceiling changes; in-flight events and app-db are not reset). Default 25. |
+| `Start (recurse — halts at depth)` | `start` | Dispatches `[::recurse]`. The handler recurses; the drain halts. |
+| `Reset` | `reset` | Restores `:depth-reached` and `:halted?` to their initial values for re-runs. |
+
+## DOM mirrors
+
+| Element | What it tells a spec |
+|---|---|
+| `depth-reached` | `0` after a halt — the atomic rollback restored the pre-drain snapshot. |
+| `halted` | `true` after the error-emit substrate fires the `:rf.error/drain-depth-exceeded` category. Allows a Playwright spec to assert on the halt without scraping the ring buffer. |
+| `drain-depth-mirror` | The current ceiling — useful for confirming the input edit propagated to the frame's meta. |
+
+## Why a configurable ceiling
+
+The framework default is 100. A spec asserting on the halt observability
+shape (single error event, rollback, second drain runs cleanly) only
+needs enough depth to prove the runtime ran the cascade more than once
+before halting. Default 25 keeps the trace stream legible while still
+producing 25 `:event/dispatched` traces before the halt fires; dialling
+to 5 keeps specs sub-second.
+
+## What's deliberately *missing*
+
+- **No `:on-error` policy.** The default `:no-recovery` recovery is the
+  contract under test; an `:on-error` override would mask the halt.
+- **No partial-cascade error injection.** The cascade goes from clean
+  start to depth-exceeded halt with no other errors — keeps the trace
+  stream's halt event identifiable in one slot.
+- **No `dispatch-later` on the recursion site.** A `:dispatch-later`
+  recursion would put each child on a fresh drain (timer fires after
+  the parent settles); only synchronous `[:dispatch ...]` inside `:fx`
+  exercises the depth ceiling within a single drain.
+
+## Test scenarios from rf2-fe84r this surface enables
+
+**Causa (26)**:
+- **Partial epoch record (drain-halt) shows up with non-`:ok` outcome
+  (rf2-v0jwt)** — the load-bearing scenario this surface unblocks. The
+  halt produces an epoch record with `:outcome :halted-depth`; Causa's
+  trace panel surfaces the partial cascade with the halt category
+  highlighted.
+- `:rf.error/*` events highlighted in trace stream — the
+  `:rf.error/drain-depth-exceeded` row fires once per Start click.
+- Trace panel grows on subsequent dispatch — the cascade produces N
+  `:event/dispatched` traces (N = ceiling) before halting.
+
+**Cross-cutting (6)**:
+- **Drain-depth-exceeded produces app-db rollback + `:halted-depth`
+  epoch record (rf2-v0jwt)** — the load-bearing scenario. The DOM
+  mirror at `depth-reached=0` after Start is positive rollback
+  evidence; the `:halted-depth` epoch outcome is the contract on the
+  ring-buffer side.
+
+**Story (18)**:
+- Recorder captures click → records `:play` → replays identically —
+  the Start click is deterministic (the handler is pure; the ceiling
+  is data). Replay reproduces the same halt shape.
+
+## Running
+
+From `implementation/`:
+
+```bash
+shadow-cljs watch testbeds/drain-depth-trigger
+# Or via the orchestrator:
+npm run test:examples
+```
+
+The shadow-cljs build id is `testbeds/drain-depth-trigger`; output
+lands in `implementation/out/testbeds/drain-depth-trigger/`.
+
+## Cross-references
+
+- [`spec/002-Frames.md` §Run-to-completion rule 3](../../spec/002-Frames.md) — the depth-bounded drain contract this surface exercises.
+- [`spec/002-Frames.md` §`:drain-depth`](../../spec/002-Frames.md) — the per-frame ceiling knob this surface re-registers on change.
+- [`spec/009-Instrumentation.md` §Error event catalogue](../../spec/009-Instrumentation.md) — the `:rf.error/drain-depth-exceeded` row this surface fires.
+- [`spec/009-Instrumentation.md` §What IS available in production](../../spec/009-Instrumentation.md) — the always-on error-emit substrate the in-app listener attaches to.
+- [`spec/Spec-Schemas.md` §`:rf/epoch-record` Outcomes](../../spec/Spec-Schemas.md) — the `:halted-depth` outcome key consumers assert against.

--- a/testbeds/drain_depth_trigger/core.cljs
+++ b/testbeds/drain_depth_trigger/core.cljs
@@ -1,0 +1,211 @@
+(ns drain-depth-trigger.core
+  "Shared framework-behavior testbed — a single handler that recursively
+  dispatches itself in its `:fx`, with a configurable depth ceiling
+  registered on the frame via `:drain-depth`. A consumer (Causa, Story,
+  pair2-mcp) observes the runtime's run-to-completion drain hitting
+  the depth limit and emitting `:rf.error/drain-depth-exceeded` per
+  [spec/002 §Run-to-completion rule 3] / [spec/009 §Error catalogue]:
+
+    - Rule 3 — when the drain depth limit is reached, the runtime
+               rolls the frame's `app-db` back atomically to the
+               value snapshotted at the start of the drain.
+    - The emitted error event carries `:depth`, `:queue-size`, and
+      `:last-event`. The event-handler that produced the runaway
+      cascade is named via `:rf.trace/trigger-handler`.
+    - The frame's epoch record for the failed cascade lands with
+      outcome `:halted-depth` per [Spec-Schemas §`:rf/epoch-record`
+      Outcomes] (rf2-v0jwt).
+
+  Two buttons drive the surface:
+
+    Start (recurse) → dispatches `::recurse`. The handler increments
+                      `:depth-reached` and queues another `::recurse`
+                      via `:fx [[:dispatch [::recurse]]]`. The drain
+                      processes the queue in a tight loop until the
+                      frame's `:drain-depth` ceiling fires.
+
+    Reset           → resets `:depth-reached` and `:halted?`. Lets
+                      the surface be re-armed for repeat observation.
+
+  An input bound to `:drain-depth` lets the user lower the ceiling
+  for fast specs (the default 100 is fine, but a Playwright spec that
+  asserts on halt observability can dial down to 5 for a sub-second
+  run; the surface re-registers the frame on change).
+
+  This is NOT a tutorial — the bodies are stark. The whole point is
+  to give a consumer ONE click that produces a drain-depth-exceeded
+  failure shape at a deterministic depth a spec can assert against."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ----------------------------------------------------------------------------
+;; Constants
+;; ----------------------------------------------------------------------------
+
+(def default-drain-depth
+  "Default depth ceiling registered on the surface's frame. Low enough
+  that the runaway cascade halts in well under a second of wall-clock
+  time, high enough to demonstrate the runtime ran multiple iterations
+  before the rollback fired. The default framework `:drain-depth` is
+  100 (per Spec 002 §`:drain-depth`); this surface ships with 25 so a
+  visual demo halts visibly faster."
+  25)
+
+;; ----------------------------------------------------------------------------
+;; App-db
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-db ::initialise
+  (fn [_db _ev]
+    {;; Counter the recursive handler bumps. After a halt this reads
+     ;; back to 0 — positive evidence of the atomic rollback (rule 3).
+     :depth-reached 0
+     ;; The DOM mirror flips to true when the error-emit listener (see
+     ;; below) sees the drain-depth-exceeded category fire. Lets a
+     ;; spec assert the halt without scraping the trace stream.
+     :halted?       false
+     ;; Frame's :drain-depth, mirrored for the view. Re-registers
+     ;; the frame on change via `:rf/reg-frame` so the runtime sees
+     ;; the updated ceiling on the next drain.
+     :drain-depth   default-drain-depth}))
+
+;; ----------------------------------------------------------------------------
+;; The runaway handler
+;; ----------------------------------------------------------------------------
+;;
+;; ::recurse is `reg-event-fx`. Its body returns a `:db` that increments
+;; the depth counter AND an `:fx` that queues another ::recurse against
+;; the same frame. The runtime processes the queue in source order in
+;; one run-to-completion drain; each ::recurse appends one ::recurse,
+;; the queue never empties, and depth grows linearly with iteration
+;; count.
+;;
+;; Per [spec/002 §Run-to-completion]:
+;;   - The whole cascade runs to fixed point within one drain.
+;;   - The drain is depth-bounded; rule 3 fires the rollback when the
+;;     depth limit is reached.
+;;   - The frame's `app-db` is restored to the snapshot taken at the
+;;     start of the drain. `:depth-reached` reads back to 0.
+
+(rf/reg-event-fx ::recurse
+  (fn [{:keys [db]} _ev]
+    ;; HOT PATH — the recursion site. The handler ALWAYS dispatches
+    ;; another ::recurse; there is no termination branch on purpose —
+    ;; only the runtime's depth ceiling can halt this cascade.
+    {:db (update db :depth-reached (fnil inc 0))
+     :fx [[:dispatch [::recurse]]]}))
+
+;; ----------------------------------------------------------------------------
+;; Halt observer — error-emit listener
+;; ----------------------------------------------------------------------------
+;;
+;; The always-on error-emit substrate (per [spec/009 §Error-emit listener])
+;; fires on `:rf.error/drain-depth-exceeded`. The surface registers a
+;; tiny listener whose only job is to flip `:halted?` in app-db so the
+;; DOM mirror reflects the runtime's view without forcing a Playwright
+;; spec to inspect the ring buffer. Per [spec/009 §What IS available in
+;; production] the listener survives `:advanced` + `goog.DEBUG=false`
+;; — a consumer running this testbed in any build mode sees the halt.
+
+(defn install-halt-listener! []
+  (rf/register-error-emit-listener!
+    ::halt-observer
+    (fn [error-record]
+      (when (= :rf.error/drain-depth-exceeded
+               (:error error-record))
+        ;; A second dispatch into the same frame after the halt; the
+        ;; first drain has already rolled back, the second drain runs
+        ;; cleanly and flips the mirror.
+        (rf/dispatch [::halt-observed])))))
+
+(rf/reg-event-db ::halt-observed
+  (fn [db _ev]
+    (assoc db :halted? true)))
+
+(rf/reg-event-db ::reset
+  (fn [db _ev]
+    (assoc db :depth-reached 0 :halted? false)))
+
+;; ----------------------------------------------------------------------------
+;; Drain-depth control
+;; ----------------------------------------------------------------------------
+;;
+;; Re-registering the default frame with a new `:drain-depth` updates the
+;; ceiling on subsequent drains (per [spec/002 §Surgical update]). The
+;; `:on-create` event is NOT re-fired on a surgical update — only the
+;; depth ceiling changes — so `:depth-reached` survives across edits.
+
+(rf/reg-event-db ::set-drain-depth
+  (fn [db [_ new-depth]]
+    (rf/reg-frame :rf/default {:drain-depth new-depth})
+    (assoc db :drain-depth new-depth)))
+
+;; ----------------------------------------------------------------------------
+;; Subs + view
+;; ----------------------------------------------------------------------------
+
+(rf/reg-sub :depth-reached (fn [db _] (:depth-reached db)))
+(rf/reg-sub :halted?       (fn [db _] (:halted? db)))
+(rf/reg-sub :drain-depth   (fn [db _] (:drain-depth db)))
+
+(reg-view buttons []
+  (let [depth-reached @(subscribe [:depth-reached])
+        halted?       @(subscribe [:halted?])
+        drain-depth   @(subscribe [:drain-depth])]
+    [:div {:data-testid "drain-depth-trigger"
+           :style       {:font-family "sans-serif" :padding "1em"}}
+     [:h1 "drain-depth-trigger testbed"]
+     [:p "One handler that dispatches itself in :fx. The runtime's
+          run-to-completion drain ceiling halts the cascade and rolls
+          :depth-reached back to 0 — positive evidence of the atomic
+          rollback (rule 3)."]
+
+     [:div {:style {:display :flex :gap "0.5em" :flex-wrap :wrap
+                    :align-items :center :margin-bottom "0.5em"}}
+      [:label
+       "Drain depth ceiling:"
+       [:input {:data-testid "drain-depth"
+                :type        "number"
+                :min         1
+                :value       drain-depth
+                :style       {:width "5em" :margin-left "0.25em"}
+                :on-change   (fn [e]
+                               (let [v (js/parseInt (.. e -target -value) 10)]
+                                 (dispatch [::set-drain-depth v])))}]]
+      [:button {:data-testid "start"
+                :on-click    #(dispatch [::recurse])}
+       "Start (recurse — halts at depth)"]
+      [:button {:data-testid "reset"
+                :on-click    #(dispatch [::reset])}
+       "Reset"]]
+
+     [:p {:style {:color "#666" :white-space :pre-wrap}}
+      "depth-reached=" [:span {:data-testid "depth-reached"} depth-reached]
+      "  (= 0 after halt — rule 3 rollback evidence)"  "\n"
+      "halted?="       [:span {:data-testid "halted"}        (str halted?)]
+      "  (flipped by the error-emit listener)"        "\n"
+      "drain-depth="   [:span {:data-testid "drain-depth-mirror"} drain-depth]]]))
+
+(reg-view root []
+  [buttons])
+
+;; ----------------------------------------------------------------------------
+;; Mount
+;; ----------------------------------------------------------------------------
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  ;; Register the default frame with the low ceiling BEFORE init —
+  ;; the Start click only needs the runtime's drain to fire the halt;
+  ;; per [spec/002 §Surgical update] re-registering only changes the
+  ;; supplied keys (here :drain-depth), the other defaults survive.
+  (rf/reg-frame :rf/default {:drain-depth default-drain-depth})
+  (install-halt-listener!)
+  (rf/dispatch-sync [::initialise])
+  (rdc/render react-root [root]))

--- a/testbeds/drain_depth_trigger/index.html
+++ b/testbeds/drain_depth_trigger/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: drain-depth-trigger</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/testbeds/known_bad_a11y/README.md
+++ b/testbeds/known_bad_a11y/README.md
@@ -1,0 +1,127 @@
+# `testbeds/known-bad-a11y`
+
+A Story-mode testbed with TWO variants registered against one parent
+Story:
+
+- `:story.a11y/known-bad` — a variant body packing five deliberate
+  axe-core violations into the smallest DOM that triggers each rule.
+- `:story.a11y/known-good` — the same shape but with proper a11y
+  attributes. Zero violations expected.
+
+A consumer (Story's a11y panel) reads the surface to verify the
+load-bearing rf2-qgms1 fix (PR #1080): axe-core's scan is scoped to
+the `data-rf-story-variant-root` wrapper, so violations report
+**only** the user-authored variant tree, never Story's own chrome
+(sidebar, toolbar, panels, title bar).
+
+## The five violations on the bad variant
+
+| Violation | Element | Missing | axe-core rule | Impact |
+|---|---|---|---|---|
+| 1 | `<img data-testid="bad-img">` | `alt` attribute | `image-alt` | critical |
+| 2 | `<button data-testid="bad-button">` | text content / `aria-label` | `button-name` | critical |
+| 3 | `<input data-testid="bad-input">` | associated `<label>` | `label` | critical |
+| 4 | `<a data-testid="bad-link">` | text content / `aria-label` | `link-name` | serious |
+| 5 | `<p data-testid="bad-contrast">` | sufficient contrast (`#eaeaea` on `#ffffff`) | `color-contrast` | serious |
+
+Each violation is one DOM element with one missing attribute or value
+— the minimum that triggers its rule. No other behaviour, no other
+content. A consumer asserting on the panel's violation count expects
+**at least five** entries on the bad variant (axe-core may surface
+additional related violations like `region` or `landmark-one-main`;
+these are bonuses, not the contract).
+
+## The good variant — the control
+
+Same five elements with corrected a11y:
+
+- `<img alt="...">` — accessible name.
+- `<button>Click me</button>` — text content as accessible name.
+- `<label htmlFor="…"><input id="…"></label>` — label association.
+- `<a>Home</a>` — text content as accessible name.
+- `<p style="color: #000; background: #fff">` — WCAG AA contrast.
+
+A consumer asserts **zero** violations on the good variant. This is
+the rf2-qgms1 regression test: if the scan over-scopes into Story's
+chrome (sidebar, toolbar, panels, title bar) it would surface the
+chrome's own a11y posture and the good variant would report N≥1
+violations.
+
+## Why this surface tests rf2-qgms1
+
+Per rf2-qgms1's fix (PR #1080): `axe-core`'s scan is scoped via the
+`context` parameter to the variant-root selector
+`[data-rf-story-variant-root='<variant-id>']`. The selector is
+stamped by Story's canvas / workspace components on the immediate
+wrapper around the user-authored decorated view.
+
+This testbed proves the contract:
+
+1. **Bad variant produces ≥5 violations** — proves axe-core ran
+   against the variant body.
+2. **Good variant produces 0 violations** — proves axe-core did NOT
+   reach into Story's chrome (where there are inevitable cosmetic
+   a11y items the framework owns and apps should not flag).
+3. **Switching between the two leaves no stale state** — proves
+   `drop-frame-state!` is wired correctly on variant teardown.
+
+The contract is **pairwise**: each individual assertion is necessary
+but not sufficient. If the good variant reports 5 violations and the
+bad variant reports 10, the scan is mis-scoped (it includes the
+chrome AND the variant). The regression is the cross-product.
+
+## What's deliberately *missing*
+
+- **No interaction state in the variants.** The five violations are
+  pure DOM; no events, no subs. A consumer's panel result depends
+  only on the rendered HTML, not on dispatch state.
+- **No play sequence.** The `:rf.assert/no-warnings` assertion could
+  be wired here but would conflate two contracts (axe-core scan
+  scope + warning channel routing). The play wiring lives in the
+  Story integration tests; this surface is the visual contract.
+- **No mode axis interaction.** Modes (dark/light/sepia) could
+  produce contrast-axis violations on the good variant; the surface
+  stays mode-agnostic to keep the pairwise contract clean.
+- **No additional axe-core rules.** Five rules across two impact
+  levels is the smallest cover that exercises Story's surface
+  formatting (the panel groups by impact, then by rule).
+- **No global-args layered config.** Per `counter_with_stories/`
+  Story configures `:global-args {:locale :en}`; this surface
+  mirrors the convention so the variant doesn't accidentally
+  inherit a different locale that affects axe-core's lang-attr
+  rules.
+
+## Test scenarios from rf2-fe84r this surface enables
+
+**Story (18)**:
+- **A11y panel surfaces violations on known-bad variant (cross-ref
+  rf2-qgms1 — scope to variant)** — the load-bearing scenario this
+  surface unblocks. The panel must report ≥5 violations on
+  `:story.a11y/known-bad` and 0 on `:story.a11y/known-good`. Story
+  chrome's own a11y posture (sidebar icons, panel tabs, etc.) must
+  not appear in either report.
+- Variants render under each substrate — both variants register
+  with `:substrates #{:reagent}`; the surface re-renders cleanly on
+  variant switch.
+
+## Running
+
+From `implementation/`:
+
+```bash
+shadow-cljs watch testbeds/known-bad-a11y
+# Or via the orchestrator:
+npm run test:examples
+```
+
+The shadow-cljs build id is `testbeds/known-bad-a11y`; output lands
+in `implementation/out/testbeds/known-bad-a11y/`. Open the page,
+select either variant in the sidebar, open the a11y panel, click
+Run.
+
+## Cross-references
+
+- [`tools/story/spec/007-Mode-Tabs.md`](../../tools/story/spec/007-Mode-Tabs.md) — the a11y mode tab + panel placement.
+- [`tools/story/src/re_frame/story/ui/a11y.cljs`](../../tools/story/src/re_frame/story/ui/a11y.cljs) — the panel that consumes this surface (`variant-root-selector` scopes axe-core to `[data-rf-story-variant-root='<id>']`).
+- **rf2-qgms1 / PR #1080** — the bug fix this surface regression-tests against.
+- **rf2-su313** — the upstream decision to keep the axe-core CDN dependency despite the third-party-egress concern (the surface depends on this call standing).

--- a/testbeds/known_bad_a11y/core.cljs
+++ b/testbeds/known_bad_a11y/core.cljs
@@ -1,0 +1,159 @@
+(ns known-bad-a11y.core
+  "Shared framework-behavior testbed — a Story variant whose body
+  carries deliberate axe-core a11y violations. A consumer (Story's
+  a11y panel) verifies that:
+
+    1. axe-core reports the violations against the user-authored
+       variant's DOM, scoped to the `data-rf-story-variant-root`
+       wrapper (per rf2-qgms1's fix — PR #1080).
+    2. Story's OWN chrome (sidebar, toolbar, panels, title bar) is
+       NOT flagged by the same scan — even if the chrome contains
+       elements that would otherwise trip axe-core (e.g. an icon
+       button without an aria-label, a colour-contrast warning on
+       a faint label).
+
+  This is NOT a tutorial. The variant body is deliberately minimal
+  — five well-known a11y violations packed into the smallest DOM
+  that triggers each axe-core rule. The bodies have no other
+  business logic.
+
+  Five violations on the bad variant's root:
+
+    1. `img-alt` — `<img>` without `alt` attribute. Axe rule:
+       `image-alt`, impact: critical.
+    2. `button-name` — `<button>` with no accessible name (no text,
+       no `aria-label`). Axe rule: `button-name`, impact: critical.
+    3. `label` — `<input>` with no associated `<label>`. Axe rule:
+       `label`, impact: critical.
+    4. `link-name` — `<a>` with no accessible name. Axe rule:
+       `link-name`, impact: serious.
+    5. `color-contrast` — text with insufficient contrast against
+       background. Axe rule: `color-contrast`, impact: serious.
+
+  The good variant body has the same elements WITH proper a11y
+  attributes — axe-core's scan must produce zero violations on it.
+  The two variants share the same Story so a consumer asserts
+  pairwise: bad has N≥5 violations, good has 0, both run against
+  the same variant-root scope, neither flags Story chrome."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.story :as story]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ----------------------------------------------------------------------------
+;; The bad-variant view — five deliberate a11y violations
+;; ----------------------------------------------------------------------------
+;;
+;; HOT PATH — every violation site is one line; the elements have no
+;; other purpose than to trigger their axe-core rule.
+
+(reg-view bad-variant []
+  [:section {:data-testid "known-bad-a11y-bad"}
+   [:h2 "Known-bad a11y variant"]
+
+   ;; Violation 1 — image without alt.
+   [:img {:data-testid "bad-img"
+          :src         "data:image/gif;base64,R0lGODlhAQABAAAAACw="
+          :style       {:width 16 :height 16}}]
+
+   ;; Violation 2 — button without accessible name.
+   [:button {:data-testid "bad-button"
+             :style       {:width 16 :height 16 :background "#888"}}]
+
+   ;; Violation 3 — unlabeled input.
+   [:input {:data-testid "bad-input"
+            :type        "text"}]
+
+   ;; Violation 4 — anchor without accessible name.
+   [:a {:data-testid "bad-link" :href "#"} ""]
+
+   ;; Violation 5 — insufficient colour contrast (light grey on white).
+   [:p {:data-testid "bad-contrast"
+        :style       {:color "#eaeaea" :background "#ffffff"}}
+    "Very faint text that fails the WCAG AA contrast threshold."]])
+
+;; ----------------------------------------------------------------------------
+;; The good-variant view — same elements, WITH proper a11y attributes
+;; ----------------------------------------------------------------------------
+
+(reg-view good-variant []
+  [:section {:data-testid "known-bad-a11y-good"}
+   [:h2 "A11y-clean variant"]
+
+   ;; Same image, WITH alt.
+   [:img {:data-testid "good-img"
+          :src         "data:image/gif;base64,R0lGODlhAQABAAAAACw="
+          :alt         "A small placeholder pixel"
+          :style       {:width 16 :height 16}}]
+
+   ;; Same button, WITH text content (accessible name).
+   [:button {:data-testid "good-button"
+             :style       {:width 80 :height 24}}
+    "Click me"]
+
+   ;; Same input, WITH associated label.
+   [:label {:html-for "good-input-id"} "Name: "
+    [:input {:id          "good-input-id"
+             :data-testid "good-input"
+             :type        "text"}]]
+
+   ;; Same anchor, WITH text content.
+   [:a {:data-testid "good-link" :href "#"} "Home"]
+
+   ;; Same paragraph, WITH high-contrast colours.
+   [:p {:data-testid "good-contrast"
+        :style       {:color "#000000" :background "#ffffff"}}
+    "High-contrast text that meets the WCAG AA threshold."]])
+
+;; ----------------------------------------------------------------------------
+;; Story registrations — one parent story, two variants
+;; ----------------------------------------------------------------------------
+
+(defn register-all!
+  []
+  (story/install-canonical-vocabulary!)
+
+  (story/reg-story :story.a11y
+    {:doc        "Known-bad / known-good a11y variants — used to verify
+                 the a11y panel scopes axe-core to the variant root
+                 (rf2-qgms1, PR #1080) and reports violations only
+                 from the user-authored variant, not Story chrome."
+     :tags       #{:dev :test}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.a11y/known-bad
+    {:doc        "Five deliberate axe-core violations packed into the
+                 smallest DOM that triggers each rule. The a11y panel
+                 should surface every one of them."
+     :component  :known-bad-a11y.core/bad-variant
+     :tags       #{:dev :test}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.a11y/known-good
+    {:doc        "Same shape as :story.a11y/known-bad but with proper
+                 a11y attributes. The a11y panel should surface zero
+                 violations on this variant — proves the scan is
+                 scoped to the variant root, not Story chrome."
+     :component  :known-bad-a11y.core/good-variant
+     :tags       #{:dev :test}
+     :substrates #{:reagent}}))
+
+;; Fire the registrations once at namespace load.
+(register-all!)
+
+;; ----------------------------------------------------------------------------
+;; Mount — Story shell directly, no hash routing
+;; ----------------------------------------------------------------------------
+;;
+;; This testbed boots straight into the Story shell. A consumer
+;; (Story's a11y panel + a Playwright spec) drives variant selection
+;; via the sidebar; the URL ergonomics live in the consuming Story
+;; example (counter_with_stories), not here.
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  (story/install-canonical-vocabulary!)
+  (story/configure! {:global-args {:locale :en}})
+  (story/mount-shell! (js/document.getElementById "app")))

--- a/testbeds/known_bad_a11y/index.html
+++ b/testbeds/known_bad_a11y/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: known-bad-a11y</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/testbeds/large_dispatcher/README.md
+++ b/testbeds/large_dispatcher/README.md
@@ -1,0 +1,133 @@
+# `testbeds/large-dispatcher`
+
+Four handlers each commit a value to a path whose wire-elision is
+governed by a different one of the three nomination paths defined in
+[spec/009 §Nomination — three entry points](../../spec/009-Instrumentation.md).
+A consumer (Causa, Story, pair2-mcp) reads the surface to verify
+the wire-boundary walker substitutes the `:rf.size/large-elided`
+marker on the appropriate slot under each path.
+
+## The four nomination paths
+
+| Button | `data-testid` | Path written | Mechanism | Payload size | Why it elides |
+|---|---|---|---|---|---|
+| A | `write-auto` | `[:auto-large-value]` | Runtime auto-detect (no declaration) | **20 KiB** | The walker's `pr-str` byte count exceeds `:rf.size/threshold-bytes` (16 KiB default); the path gets auto-flagged on first emit and elides on every subsequent emit. The `:rf.warning/runtime-large-elision` advisory fires once on first detection. |
+| B | `write-declared` | `[:declared-large-value]` | `rf/declare-large-path!` (REPL wrapper) | 200 bytes | Handler calls the wrapper directly; declaration writes `{:large? true :source :declared}` into the elision registry. Elision fires regardless of size (declared wins over runtime threshold). |
+| C | `write-fx-declared` | `[:fx-declared-value]` | `:rf.size/declare-large` fx | 200 bytes | Canonical AI-discoverable nomination shape — handler returns `:fx [[:rf.size/declare-large {:path ...}]]`. Same outcome as button B, different entry point. |
+| D | `write-schema` | `[:schema-bag :schema-large-value]` | Malli app-schema `:large? true` slot | 200 bytes | The slot is declared `:large?` on a registered `:rf/app-schema`. The runtime walks every registered app-schema at boot (per `populate-elision-from-schemas!`) and writes a `{:large? true :source :schema}` entry into the registry. |
+
+## DOM mirrors
+
+| Element | What it asserts |
+|---|---|
+| `auto-len` | `20480` after click A — the handler sees the full 20 KiB value via the regular cofx slot. The handler body is NOT affected by elision; only the wire-emit shape is. |
+| `declared-len` / `fx-len` / `schema-len` | `200` after the corresponding click — small payloads but declared/fx/schema-derived elision still fires on the wire. |
+| `auto-count` / `declared-count` / `fx-count` / `schema-count` | Advances on each click — proves the handler ran. |
+| `elision-decls` | The contents of `[:rf/elision :declarations]` — a Playwright spec can assert that buttons B + C + D populate the slot with the expected `:source` (`:declared` / `:declared` / `:schema`). |
+
+## The wire marker
+
+Per [spec/009 §Wire marker — `:rf.size/large-elided`], the walker
+substitutes the elided value with a normative shape:
+
+```clojure
+{:rf.size/large-elided
+  {:path    [:auto-large-value]               ;; absolute path
+   :bytes   20482                              ;; pr-str byte count
+   :type    :string                            ;; one of :map :vector :set :scalar :string
+   :reason  :runtime-flagged                   ;; or :declared / :schema
+   :handle  [:rf.elision/at [:auto-large-value]]}}
+```
+
+A consumer asserting on the wire emit looks for the
+`:rf.size/large-elided` keyword in the trace event's `:tags :app-db-*`
+slots (or `:db-before` / `:db-after` in the epoch record); the
+specific `:reason` distinguishes the nomination path.
+
+## Why four buttons
+
+Three nomination paths plus one composition control (auto-detect on
+a 20 KiB write vs. declared on a 200-byte write) is the smallest
+shape that exercises all the discrimination axes a consumer needs:
+
+- **Three independent `:source` values** (`:declared`, `:schema`,
+  `:runtime-flagged`) — a consumer that conflates them fails on
+  button A (auto-detect should show `:source :runtime-flagged`,
+  not `:declared`).
+- **Imperative entry point vs declarative** (button B vs button C)
+  — the REPL wrapper and the fx end at the same registry slot;
+  a consumer that surfaces `:source :declared` for both is correct.
+- **Schema-derived vs handler-declared** (button D vs B/C) — the
+  `:source :schema` entry exists in the registry from boot, before
+  any click. A consumer that only walks declarations on dispatch
+  misses this category.
+- **Threshold-triggered vs declaration-triggered** (button A vs
+  B/C/D) — the auto-detect path produces a one-shot
+  `:rf.warning/runtime-large-elision` advisory; the declaration
+  paths do not. The presence/absence of the warning is the
+  discriminator.
+
+## What's deliberately *missing*
+
+- **No `:sensitive?` on any path.** Privacy markers are the
+  `sensitive_dispatcher/` testbed's job; composition (sensitive
+  wins over size — per Spec 009) requires both, but each surface
+  exercises one axis cleanly.
+- **No `:digest` slot computation.** The `:digest` field of the
+  marker is gated on the `:include-digests?` config flag; this
+  surface stays on the default `false` so the marker shape is
+  minimal and stable across runs.
+- **No off-box wire egress in the surface itself.** The MCP wire
+  is exercised by the consuming tool (pair2-mcp); this surface
+  produces the in-process elision shape that the wire reads.
+- **No state-machine snapshots.** Machine snapshots elide via the
+  same walker (per [spec/005 §Wire-boundary elision]); conflating
+  the machine surface with the app-db surface would dilute
+  the four nomination paths.
+
+## Test scenarios from rf2-fe84r this surface enables
+
+**Causa (26)**:
+- **`:large?` value arrives as `:rf.size/large-elided` marker** —
+  the load-bearing scenario this surface unblocks. Causa's trace
+  panel must show the `[:auto-large-value]` slot replaced with the
+  marker shape under `:tags :app-db-after` on the first emit after
+  button A.
+- `:rf.warning/runtime-large-elision` highlighted in trace stream —
+  button A's first emit fires the advisory; subsequent button-A
+  clicks do not (the path is cached as flagged).
+- Click-to-source from trace event lands on source-coord line —
+  every handler in this surface carries reader meta; the four
+  buttons each resolve to their handler's coord.
+
+**Story (18)**:
+- Recorder captures click → records `:play` → replays identically
+  — the four clicks are deterministic; replay reproduces the same
+  elision shape on each emit.
+
+**Cross-cutting (6)**:
+- Subscribe → re-render → trace ordering preserved — the four subs
+  on the per-slot length re-run only when their slice changes;
+  the elision marker doesn't reach the subscription layer (subs
+  see the unredacted app-db value).
+
+## Running
+
+From `implementation/`:
+
+```bash
+shadow-cljs watch testbeds/large-dispatcher
+# Or via the orchestrator:
+npm run test:examples
+```
+
+The shadow-cljs build id is `testbeds/large-dispatcher`; output
+lands in `implementation/out/testbeds/large-dispatcher/`.
+
+## Cross-references
+
+- [`spec/009-Instrumentation.md` §Size elision in traces](../../spec/009-Instrumentation.md) — the three-nomination-path contract this surface exercises.
+- [`spec/009-Instrumentation.md` §Wire marker — `:rf.size/large-elided`](../../spec/009-Instrumentation.md) — the marker shape consumers assert against.
+- [`spec/API.md` §`rf/elide-wire-value`](../../spec/API.md) — the wire-boundary walker (single normative emission site).
+- [`spec/Spec-Schemas.md` §`:rf/elision-marker`](../../spec/Spec-Schemas.md) — the per-field MUST-level requirements on the marker shape.
+- [`spec/Conventions.md` §Reserved fx-ids](../../spec/Conventions.md) — the `:rf.size/declare-large` / `:rf.size/clear` framework fxs.

--- a/testbeds/large_dispatcher/core.cljs
+++ b/testbeds/large_dispatcher/core.cljs
@@ -1,0 +1,292 @@
+(ns large-dispatcher.core
+  "Shared framework-behavior testbed — events whose payloads exceed the
+  wire-elision threshold. A consumer (Causa, Story, pair2-mcp)
+  observes the runtime's wire-boundary walker substitute a value with
+  the `:rf.size/large-elided` marker (per [spec/009 §Size elision in
+  traces] / [API.md §`rf/elide-wire-value`]).
+
+  Three nomination paths exist per [spec/009 §Nomination — three
+  entry points]:
+
+    1. Schema-driven — `:large?` on a Malli slot in `:rf/app-schema`.
+    2. fx-driven    — `:rf.size/declare-large` fx writes the slot
+                      from an event handler's `:fx`. Convenience
+                      wrappers: `rf/declare-large-path!` and
+                      `rf/clear-large-path!`.
+    3. Runtime auto-detect — values exceeding `:rf.size/threshold-
+                      bytes` (default 16 KiB) get auto-flagged on
+                      first wire-emit. Subsequent emits short-
+                      circuit on the cached decision and emit a
+                      `:rf.warning/runtime-large-elision` advisory.
+
+  This surface exercises all three nomination paths plus one
+  control:
+
+    Button A · Auto-detect (no declaration)
+      — handler writes a 20 KiB string to `[:auto-large-value]`. The
+        runtime walks the app-db at first wire-emit, finds the value
+        exceeds the 16 KiB threshold, flags the path, and elides on
+        every subsequent emit. The `:rf.warning/runtime-large-elision`
+        advisory fires once on first detection.
+
+    Button B · Declared via REPL wrapper
+      — handler calls `rf/declare-large-path!` directly. The
+        declaration writes `{:large? true :source :declared}` into
+        `[:rf/elision :declarations [:declared-large-value]]`. The
+        handler then writes a small (200 byte) value to the path —
+        elision fires regardless of size because of the declaration
+        (declared wins over runtime threshold).
+
+    Button C · Declared via fx
+      — handler returns `:fx [[:rf.size/declare-large {:path ...}]]`.
+        Same outcome as Button B; different entry point. The fx
+        declaration is the canonical AI-discoverable shape (apps
+        nominate paths from event handlers).
+
+    Button D · Schema-driven (registered at boot)
+      — the surface registers a Malli app-schema with `:large? true`
+        on the `:schema-large-value` slot at boot. Any write to that
+        path triggers elision on emit. Button D writes a 200-byte
+        value to the schema-declared slot.
+
+  This is NOT a tutorial. The bodies are minimal. The point is to
+  produce four distinct elision triggers a consumer can assert
+  against — auto-flagged + declared (REPL) + declared (fx) + schema
+  — all in one surface."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            ;; Loads the schemas artefact's late-bind hooks (rf2-p7va).
+            [re-frame.schemas]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ----------------------------------------------------------------------------
+;; The canonical "large" payload — 20 KiB above the 16 KiB threshold
+;; ----------------------------------------------------------------------------
+;;
+;; `pr-str` of this string exceeds `:rf.size/threshold-bytes` (default
+;; 16384). The auto-detect path measures the pr-str byte count of each
+;; top-two-level subtree; any subtree at or above the threshold gets
+;; flagged. Per [spec/009 §Runtime auto-detect].
+
+(def kib-20-string
+  ;; 20480 chars = 20 KiB. pr-str adds 2 quote chars; effective size
+  ;; in the wire shape is 20482 bytes — comfortably above 16 KiB.
+  (apply str (repeat 20480 \X)))
+
+;; A small "control" payload — 200 chars. Used by the declared and
+;; schema paths to prove elision fires REGARDLESS of size when the
+;; path is nominated.
+(def chars-200-string
+  (apply str (repeat 200 \Y)))
+
+;; ----------------------------------------------------------------------------
+;; Malli app-schema with :large? on one slot — exercises the
+;; schema-driven nomination path
+;; ----------------------------------------------------------------------------
+
+(def SchemaLarge
+  [:map [:schema-large-value {:large? true} :string]])
+
+(rf/reg-app-schema [:schema-bag] SchemaLarge)
+
+;; ----------------------------------------------------------------------------
+;; App-db
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-db ::initialise
+  (fn [_db _ev]
+    {;; The four slots one button per. All start as nil; clicks
+     ;; commit the appropriate large or small value.
+     :auto-large-value     nil
+     :declared-large-value nil
+     :fx-declared-value    nil
+     :schema-bag           {:schema-large-value nil}
+     ;; A counter per button — tracks how many times each was
+     ;; clicked. Allows a Playwright spec to confirm the handler
+     ;; body actually ran (the elision is wire-boundary; the
+     ;; handler always sees the unredacted value).
+     :click-count          {:auto 0 :declared 0 :fx 0 :schema 0}}))
+
+;; ----------------------------------------------------------------------------
+;; Button A — auto-detect path
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-db ::write-auto-large
+  (fn [db _ev]
+    ;; HOT PATH — commits a 20 KiB value to an undeclared path. On
+    ;; the first wire-emit the runtime's auto-detect walker measures
+    ;; pr-str byte count, finds it above threshold, flags the path,
+    ;; and elides on subsequent emits. A
+    ;; :rf.warning/runtime-large-elision fires once.
+    (-> db
+        (assoc :auto-large-value kib-20-string)
+        (update-in [:click-count :auto] inc))))
+
+;; ----------------------------------------------------------------------------
+;; Button B — declared via rf/declare-large-path! (REPL wrapper)
+;; ----------------------------------------------------------------------------
+;;
+;; The handler calls `rf/declare-large-path!` as a side effect AND
+;; commits the small payload. Per [spec/009 §fx-driven] the wrapper
+;; issues a synthetic dispatch of `:rf.size/declare-large` for us —
+;; same effect as the fx path, but ergonomic at the REPL.
+;;
+;; The declaration writes `{:large? true :source :declared}` into
+;; `[:rf/elision :declarations [:declared-large-value]]`; the slot
+;; is elided on every subsequent emit irrespective of size (declared
+;; wins over runtime per Spec 009).
+
+(rf/reg-event-db ::write-declared-large
+  (fn [db _ev]
+    (rf/declare-large-path! [:declared-large-value]
+                            "Test surface — declared via REPL wrapper")
+    (-> db
+        (assoc :declared-large-value chars-200-string)
+        (update-in [:click-count :declared] inc))))
+
+;; ----------------------------------------------------------------------------
+;; Button C — declared via :rf.size/declare-large fx
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-fx ::write-fx-declared-large
+  (fn [{:keys [db]} _ev]
+    ;; HOT PATH — the canonical AI-discoverable nomination shape.
+    ;; The fx writes the declaration into the elision registry; the
+    ;; handler's :db commits the small payload; subsequent emits
+    ;; elide the path.
+    {:db (-> db
+             (assoc :fx-declared-value chars-200-string)
+             (update-in [:click-count :fx] inc))
+     :fx [[:rf.size/declare-large {:path [:fx-declared-value]
+                                   :hint "Test surface — declared via fx"}]]}))
+
+;; ----------------------------------------------------------------------------
+;; Button D — schema-driven (boot-time declaration on a Malli slot)
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-db ::write-schema-large
+  (fn [db _ev]
+    ;; HOT PATH — writes a small payload to a path the schema
+    ;; declares :large? true. The runtime read the schema at boot
+    ;; (per `populate-elision-from-schemas!`) and seeded
+    ;; [:rf/elision :declarations [:schema-bag :schema-large-value]]
+    ;; with :source :schema. Elision fires on this path regardless
+    ;; of value size.
+    (-> db
+        (assoc-in [:schema-bag :schema-large-value] chars-200-string)
+        (update-in [:click-count :schema] inc))))
+
+;; ----------------------------------------------------------------------------
+;; Reset
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-fx ::reset
+  (fn [_ctx _ev]
+    {:fx [[:dispatch [::initialise]]
+          ;; Clear the declared paths (the schema-derived entry
+          ;; stays — it's repopulated at boot via the registered
+          ;; schema; only the imperative declarations need
+          ;; clearing for a clean re-run).
+          [:rf.size/clear {:path [:declared-large-value]}]
+          [:rf.size/clear {:path [:fx-declared-value]}]]}))
+
+;; ----------------------------------------------------------------------------
+;; Subs + view
+;; ----------------------------------------------------------------------------
+
+(rf/reg-sub :auto-len      (fn [db _] (count (str (:auto-large-value db)))))
+(rf/reg-sub :declared-len  (fn [db _] (count (str (:declared-large-value db)))))
+(rf/reg-sub :fx-len        (fn [db _] (count (str (:fx-declared-value db)))))
+(rf/reg-sub :schema-len    (fn [db _] (count (str (get-in db [:schema-bag :schema-large-value])))))
+(rf/reg-sub :auto-count    (fn [db _] (get-in db [:click-count :auto])))
+(rf/reg-sub :declared-count (fn [db _] (get-in db [:click-count :declared])))
+(rf/reg-sub :fx-count      (fn [db _] (get-in db [:click-count :fx])))
+(rf/reg-sub :schema-count  (fn [db _] (get-in db [:click-count :schema])))
+
+;; Read the elision-declarations slot directly so the view shows the
+;; registrar's view of what's been nominated. A spec asserts this
+;; reads the same shape as `(rf/elision-declarations frame-id)`.
+(rf/reg-sub :elision-decls
+  (fn [db _] (get-in db [:rf/elision :declarations])))
+
+(reg-view buttons []
+  (let [auto-len       @(subscribe [:auto-len])
+        declared-len   @(subscribe [:declared-len])
+        fx-len         @(subscribe [:fx-len])
+        schema-len     @(subscribe [:schema-len])
+        auto-count     @(subscribe [:auto-count])
+        declared-count @(subscribe [:declared-count])
+        fx-count       @(subscribe [:fx-count])
+        schema-count   @(subscribe [:schema-count])
+        decls          @(subscribe [:elision-decls])]
+    [:div {:data-testid "large-dispatcher"
+           :style       {:font-family "sans-serif" :padding "1em"}}
+     [:h1 "large-dispatcher testbed"]
+     [:p "Four nomination paths for the wire-boundary elision walker.
+          Each click commits a value to a path whose elision is
+          governed by a different mechanism — the trace surface and
+          the MCP wire should substitute "
+         [:code ":rf.size/large-elided"]
+         " on the appropriate slot."]
+
+     [:div {:style {:display :flex :gap "0.5em" :flex-wrap :wrap}}
+      [:button {:data-testid "write-auto"
+                :on-click    #(dispatch [::write-auto-large])}
+       "A · auto-detect (20 KiB > threshold)"]
+      [:button {:data-testid "write-declared"
+                :on-click    #(dispatch [::write-declared-large])}
+       "B · declare-large-path! (REPL wrapper)"]
+      [:button {:data-testid "write-fx-declared"
+                :on-click    #(dispatch [::write-fx-declared-large])}
+       "C · :rf.size/declare-large fx"]
+      [:button {:data-testid "write-schema"
+                :on-click    #(dispatch [::write-schema-large])}
+       "D · schema-driven (:large? on Malli slot)"]
+      [:button {:data-testid "reset"
+                :on-click    #(dispatch [::reset])}
+       "Reset"]]
+
+     [:p {:style {:margin-top "1em" :color "#666" :white-space :pre-wrap}}
+      "auto-len="     [:span {:data-testid "auto-len"}     auto-len]
+      "  (= 20480 after click — handler sees full value)"           "\n"
+      "declared-len=" [:span {:data-testid "declared-len"} declared-len]
+      "  (= 200 — small payload, declared elides anyway)"           "\n"
+      "fx-len="       [:span {:data-testid "fx-len"}       fx-len]
+      "  (= 200 — small payload, fx-declared elides anyway)"        "\n"
+      "schema-len="   [:span {:data-testid "schema-len"}   schema-len]
+      "  (= 200 — small payload, schema-declared elides anyway)"    "\n\n"
+      "click-count="
+      [:span "auto="   [:span {:data-testid "auto-count"}   auto-count]
+             " declared=" [:span {:data-testid "declared-count"} declared-count]
+             " fx=" [:span {:data-testid "fx-count"} fx-count]
+             " schema=" [:span {:data-testid "schema-count"} schema-count]]]
+
+     [:h3 {:style {:margin-top "1em"}} "elision declarations"]
+     [:pre {:data-testid "elision-decls"
+            :style       {:white-space :pre-wrap :font-size "0.9em"
+                          :background  "#f5f5f5" :padding "0.5em"}}
+      (pr-str decls)]]))
+
+(reg-view root []
+  [buttons])
+
+;; ----------------------------------------------------------------------------
+;; Mount
+;; ----------------------------------------------------------------------------
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  (rf/dispatch-sync [::initialise])
+  ;; Populate the elision registry from any registered schemas
+  ;; carrying :large? marks. Per [API.md §`populate-elision-from-
+  ;; schemas!`] this walks the app-schema registry and writes
+  ;; `{:large? true :source :schema}` slots into the elision
+  ;; declarations map. The schema-driven path's declaration enters
+  ;; the registry without an explicit handler dispatch.
+  (rf/populate-elision-from-schemas!)
+  (rdc/render react-root [root]))

--- a/testbeds/large_dispatcher/index.html
+++ b/testbeds/large_dispatcher/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: large-dispatcher</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/testbeds/non_trivial_app_db/README.md
+++ b/testbeds/non_trivial_app_db/README.md
@@ -1,0 +1,126 @@
+# `testbeds/non-trivial-app-db`
+
+A Reagent-mounted surface whose `app-db` carries 55 leaves across 6
+top-level keys at depths 1 through 5. Six buttons drive six
+structurally distinct diff shapes. A consumer (Causa, Story,
+pair2-mcp) uses this surface to verify its diff visualisation
+renders realistic state without collapsing detail or re-rendering
+unchanged subtrees.
+
+## The app-db shape
+
+```
+:user      ← 4 leaves @ depth 2
+:settings  ← 8 leaves @ depth 3
+:cart      ← 12 leaves @ depth 4 (vector-of-maps)
+:catalog   ← 18 leaves @ depth 5
+:session   ← 8 leaves @ depth 2
+:metrics   ← 5 scalar leaves @ depth 1
+```
+
+Total: 55 leaves, max depth 5. Values are picked to render legibly:
+short strings, small numbers, no multi-line text. The shape is
+realistic-looking — a SaaS-style app with a user profile, config
+tree, multi-item cart, nested catalogue, session state, and a flat
+metrics dashboard. (`core.cljs` carries the literal `initial-db`.)
+
+## The six diff shapes
+
+| Button | `data-testid` | Path | Depth | Shape |
+|---|---|---|---|---|
+| 1 | `toggle-theme` | `[:settings :theme]` | 2 | Scalar swap (`:dark`↔`:light`). |
+| 2 | `toggle-notifications` | `[:settings :notifications]` | 3 | Map merge — TWO sibling keys flip simultaneously. |
+| 3 | `add-cart-item` | `[:cart :items]` | 2→item | Vector append — new index appears, existing indices unchanged. |
+| 4 | `bump-first-item-qty` | `[:cart :items 0 :qty]` + `[:cart :items 0 :price :amount]` | 4 | Vector swap-by-index — drill into a vector element, change a leaf AND a descendant subtree's leaf. |
+| 5 | `register-new-sku` | `[:catalog :categories :books :groups :tech :skus]` | 5 | Set add at the deepest path on the surface. |
+| 6 | `revoke-write-and-collapse-sidebar` | `[:session :auth :scopes]` + `[:session :ui :sidebar-open?]` | 3 | Two sibling subtrees of one top-level slice change in one drain. |
+
+Each click produces ONE structural diff shape with a known path. A
+diff renderer that conflates `[:settings :theme]` with the whole
+`:settings` map (button 1 vs 2) fails immediately. A renderer that
+doesn't drill into vector indices conflates buttons 3 and 4. A
+renderer that collapses past depth 3 fails button 5.
+
+## DOM mirrors
+
+The whole snapshot is rendered as a pretty-printed pre-formatted
+block under `data-testid="app-db-pr-str"`. A Playwright spec can
+assert the exact before/after pair around any click without needing
+to walk the trace stream.
+
+## Why this many leaves
+
+A canonical demo counter has ~3 leaves; a realistic app has hundreds.
+Diff renderers that work on the counter shape often fail above ~20
+leaves because their visual hierarchy assumes a flat structure. 55
+leaves is the smallest count that exercises:
+
+- **Vertical compression at depth 5** (the `:catalog` slice forces
+  the renderer to collapse 3+ levels above the changed leaf without
+  losing the breadcrumb).
+- **Sibling-key diffs at all three of "scalar, collection, set"**
+  (button 6 covers two of three; button 1 + button 5 cover the third).
+- **Vector-as-collection vs vector-as-index** (buttons 3 + 4).
+- **Multiple top-level slices touched in one drain** (button 6).
+- **Top-level slices that DON'T change** (`:metrics` and `:user`
+  never change on any click — the renderer must visibly leave them
+  alone).
+
+## What's deliberately *missing*
+
+- **No primitives larger than ~50 chars per leaf.** Large values are
+  the `large_dispatcher/` testbed's job. This surface keeps every
+  leaf small so the renderer's elision contract doesn't kick in.
+- **No `:sensitive?` on any slice.** Privacy markers are the
+  `sensitive_dispatcher/` testbed's job; including one here would
+  conflate diff rendering with redaction rendering.
+- **No state-machine snapshots in app-db.** Per [spec/005] the
+  machine snapshot lives in a separate registry (`[:rf/machines …]`);
+  surface deliberately uses only the plain-app-db diffing path.
+- **No `:rf/elision` declarations.** The elision walker is exercised
+  by the `large_dispatcher/` testbed; this surface keeps the diff
+  renderer's job pure (every value rides the wire verbatim).
+
+## Test scenarios from rf2-fe84r this surface enables
+
+**Causa (26)**:
+- Trace panel populates on first dispatch — each button produces a
+  visible `:event/db-changed` trace with `:tags :app-db-before` and
+  `:tags :app-db-after` carrying the 55-leaf shape.
+- Time-travel scrub forward/back mutates visible UI — scrubbing 6
+  clicks back-and-forth exercises the diff renderer at every depth.
+- `:event/db-changed` trace event for app-db changes — the surface
+  produces one per click with a structurally distinct shape.
+
+**Story (18)**:
+- Variants render under each substrate — Story mounts of this
+  surface verify the variant renderer doesn't choke on the 55-leaf
+  app-db (a common bug in early Story chrome before rf2-qgms1).
+- Snapshot identity reproducible across runs — the deterministic
+  6-click sequence produces a bit-identical snapshot on replay; the
+  surface's `:metrics` slice carries pure counters with no clock
+  state, no random values, no input dependencies.
+
+**Cross-cutting (6)**:
+- Subscribe → re-render → trace ordering preserved — each of the
+  6 top-level slice subs re-runs only when its slice changes (the
+  diff structure is sub-aligned).
+
+## Running
+
+From `implementation/`:
+
+```bash
+shadow-cljs watch testbeds/non-trivial-app-db
+# Or via the orchestrator:
+npm run test:examples
+```
+
+The shadow-cljs build id is `testbeds/non-trivial-app-db`; output
+lands in `implementation/out/testbeds/non-trivial-app-db/`.
+
+## Cross-references
+
+- [`spec/009-Instrumentation.md` §Trace event for app-db changes](../../spec/009-Instrumentation.md) — the `:event/db-changed` shape this surface's clicks emit, with `:tags :app-db-before` / `:tags :app-db-after` consumers diff against.
+- [`spec/Spec-Schemas.md` §`:rf/epoch-record`](../../spec/Spec-Schemas.md) — the epoch record's `:db-before` / `:db-after` slots carrying the 55-leaf shape per cascade.
+- [`spec/Tool-Pair.md` §Time-travel](../../spec/Tool-Pair.md) — the pair2-mcp time-travel contract a diff visualisation rides.

--- a/testbeds/non_trivial_app_db/core.cljs
+++ b/testbeds/non_trivial_app_db/core.cljs
@@ -1,0 +1,285 @@
+(ns non-trivial-app-db.core
+  "Shared framework-behavior testbed — an app-db with ~5 levels of nesting
+  and ~50 leaf paths, deliberately shaped to exercise a consumer
+  (Causa, Story, pair2-mcp) diffing visualisation under realistic
+  depth. Each button mutates a different slot at a different depth so
+  the consumer's diff renderer must:
+
+    - Highlight the changed leaf without re-rendering the whole tree.
+    - Collapse-by-default the unchanged subtrees while keeping the
+      changed path expanded.
+    - Show the before/after value pair on the changed leaf with the
+      full key path leading down to it.
+    - Diff structurally distinct value shapes (scalar swap, map merge,
+      vector append, vector swap-by-index, set add, set remove).
+
+  This is NOT a tutorial. The app-db shape is the *only* point — a
+  realistic shape against which a diffing UI's visual hierarchy is
+  exercised. The handlers below are minimal — one shot per button, one
+  diff slot per click.
+
+  App-db shape (5 deep, 50+ leaves):
+
+    {:user        {...4 leaves at 2 levels...}            ← 2-deep
+     :settings    {...8 leaves at 3 levels...}            ← 3-deep
+     :cart        {...12 leaves at 4 levels...}           ← 4-deep
+     :catalog     {...18 leaves at 5 levels...}           ← 5-deep
+     :session     {...8 leaves at 2 levels...}            ← 2-deep
+     :metrics     {...5 scalar leaves at 1 level...}}     ← 1-deep
+
+  Total: 55 leaf paths across 6 top-level keys, max depth 5."
+  (:require [cljs.pprint :as pprint]
+            [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ----------------------------------------------------------------------------
+;; The canonical app-db shape
+;; ----------------------------------------------------------------------------
+;;
+;; Shape is the surface's load-bearing artefact. The values are picked
+;; to render legibly in a diff view (short strings, small numbers, no
+;; multi-line text). The structure is realistic-looking: a SaaS-style
+;; app with a user profile, configuration tree, a multi-item cart, a
+;; nested catalogue, session state, and a flat metrics dashboard.
+
+(def initial-db
+  {;; :user — 2 levels deep, 4 leaves.
+   :user      {:id       "user-42"
+               :profile  {:name  "Ada Lovelace"
+                          :email "ada@example.com"
+                          :role  :admin}}
+
+   ;; :settings — 3 levels deep, 8 leaves.
+   :settings  {:theme         :dark
+               :locale        "en-AU"
+               :notifications {:email     true
+                               :push      false
+                               :marketing false}
+               :feature-flags {:beta?      true
+                               :new-cart?  false
+                               :ai-search? true}}
+
+   ;; :cart — 4 levels deep, 12 leaves. Two items, each with nested
+   ;; metadata. Demonstrates vector-of-maps diffing.
+   :cart      {:items    [{:sku      "BK-001"
+                           :title    "Refactoring"
+                           :qty      2
+                           :price    {:currency :AUD
+                                      :amount   42.50}}
+                          {:sku      "BK-002"
+                           :title    "Domain Modelling"
+                           :qty      1
+                           :price    {:currency :AUD
+                                      :amount   35.00}}]
+               :total    120.00
+               :coupon   nil}
+
+   ;; :catalog — 5 levels deep, 18 leaves. Two categories, each with
+   ;; nested product groups carrying SKUs and feature sets.
+   :catalog   {:categories
+               {:books    {:name     "Books"
+                           :groups   {:tech    {:name "Technical"
+                                                :skus #{"BK-001" "BK-002" "BK-003"}}
+                                      :fiction {:name "Fiction"
+                                                :skus #{"BK-101" "BK-102"}}}}
+                :gadgets  {:name     "Gadgets"
+                           :groups   {:audio   {:name "Audio"
+                                                :skus #{"AU-201" "AU-202"}}
+                                      :video   {:name "Video"
+                                                :skus #{"VI-301"}}}}}}
+
+   ;; :session — 2 levels deep, 8 leaves.
+   :session   {:auth          {:token-valid? true
+                               :expires-at   1700000000
+                               :scopes       #{:read :write}}
+               :ui            {:sidebar-open?    true
+                               :selected-route   :home
+                               :pending-modal    nil
+                               :last-interaction 1700000000}}
+
+   ;; :metrics — 1 level deep, 5 scalar leaves. Demonstrates that the
+   ;; surface's overall depth doesn't preclude a flat slice for the
+   ;; uninteresting-but-numerous parts of an app-db.
+   :metrics   {:requests     0
+               :errors       0
+               :renders      0
+               :sub-runs     0
+               :flow-evals   0}})
+
+(rf/reg-event-db ::initialise
+  (fn [_db _ev]
+    initial-db))
+
+;; ----------------------------------------------------------------------------
+;; Six handlers — one for each structural diff shape a consumer must
+;; render distinctively.
+;; ----------------------------------------------------------------------------
+
+;; --- 1 · Scalar swap deep in the tree ---
+;; Toggles :settings :theme between :dark and :light. The diff renderer
+;; should highlight the single leaf and leave the surrounding 7 leaves
+;; of :settings collapsed.
+
+(rf/reg-event-db ::toggle-theme
+  (fn [db _ev]
+    ;; HOT PATH — single-leaf scalar swap at depth 2.
+    (update-in db [:settings :theme]
+               {:dark :light :light :dark})))
+
+;; --- 2 · Map merge at depth 3 ---
+;; Flips two leaves of :settings :notifications in one write. Verifies
+;; the diff renderer can show two simultaneously-changed siblings
+;; without collapsing them under a single "this map changed" line.
+
+(rf/reg-event-db ::toggle-notifications
+  (fn [db _ev]
+    (update-in db [:settings :notifications]
+               (fn [m]
+                 (-> m
+                     (update :email     not)
+                     (update :marketing not))))))
+
+;; --- 3 · Vector append (cart line item) ---
+;; Adds a new cart line item. Tests vector-as-collection diffing —
+;; the renderer should show the new index without re-marking the
+;; existing items as changed.
+
+(rf/reg-event-db ::add-cart-item
+  (fn [db _ev]
+    (let [new-item {:sku   "BK-099"
+                    :title "Patterns of Distributed Systems"
+                    :qty   1
+                    :price {:currency :AUD :amount 55.00}}]
+      (-> db
+          (update-in [:cart :items] (fnil conj []) new-item)
+          (update-in [:cart :total] (fnil + 0) 55.00)))))
+
+;; --- 4 · Vector swap-by-index ---
+;; Mutates an existing cart line's :qty AND its nested :price :amount.
+;; Tests that the diff renderer correctly drills *into* a vector
+;; element without flagging siblings, AND that the descendant change
+;; on the price subtree is rendered as part of the same item's diff.
+
+(rf/reg-event-db ::bump-first-item-qty
+  (fn [db _ev]
+    (-> db
+        (update-in [:cart :items 0 :qty] inc)
+        (update-in [:cart :items 0 :price :amount] + 42.50)
+        (update-in [:cart :total] + 42.50))))
+
+;; --- 5 · Set add (deepest, level 5) ---
+;; Adds a SKU to :catalog :categories :books :groups :tech :skus.
+;; This is the deepest mutation in the surface — exercises the
+;; diff renderer's vertical compression at five levels of nesting.
+
+(rf/reg-event-db ::register-new-sku
+  (fn [db _ev]
+    ;; HOT PATH — five-level-deep set mutation.
+    (update-in db [:catalog :categories :books :groups :tech :skus]
+               (fnil conj #{})
+               "BK-099")))
+
+;; --- 6 · Set remove + flag flip in one drain ---
+;; Removes a scope from :session :auth :scopes AND flips
+;; :session :ui :sidebar-open?. Tests sibling-key diffs at two
+;; distinct sub-paths of :session.
+
+(rf/reg-event-db ::revoke-write-and-collapse-sidebar
+  (fn [db _ev]
+    (-> db
+        (update-in [:session :auth :scopes]
+                   (fnil disj #{}) :write)
+        (update-in [:session :ui :sidebar-open?] not))))
+
+;; --- Reset ---
+(rf/reg-event-db ::reset
+  (fn [_db _ev]
+    initial-db))
+
+;; ----------------------------------------------------------------------------
+;; Subs — one per top-level slice so a consumer can re-render only the
+;; changed slice. Selecting from sub level 1 prevents an unnecessary
+;; re-render cascade across the whole tree.
+;; ----------------------------------------------------------------------------
+
+(rf/reg-sub :user     (fn [db _] (:user     db)))
+(rf/reg-sub :settings (fn [db _] (:settings db)))
+(rf/reg-sub :cart     (fn [db _] (:cart     db)))
+(rf/reg-sub :catalog  (fn [db _] (:catalog  db)))
+(rf/reg-sub :session  (fn [db _] (:session  db)))
+(rf/reg-sub :metrics  (fn [db _] (:metrics  db)))
+
+;; Aggregate sub — full db pr-str for the rare consumer that wants
+;; the whole snapshot in one slot (e.g. snapshot identity verification).
+
+(rf/reg-sub :app-db-snapshot
+  :<- [:user] :<- [:settings] :<- [:cart] :<- [:catalog]
+  :<- [:session] :<- [:metrics]
+  (fn [[user settings cart catalog session metrics] _]
+    {:user user :settings settings :cart cart
+     :catalog catalog :session session :metrics metrics}))
+
+;; ----------------------------------------------------------------------------
+;; View
+;; ----------------------------------------------------------------------------
+
+(reg-view db-pre []
+  (let [snapshot @(subscribe [:app-db-snapshot])]
+    [:pre {:data-testid "app-db-pr-str"
+           :style       {:white-space :pre-wrap :font-size "0.9em"
+                         :background  "#f5f5f5" :padding "0.5em"
+                         :margin      "0.5em 0"
+                         :max-height  "20em" :overflow :auto}}
+     (with-out-str (pprint/pprint snapshot))]))
+
+(reg-view buttons []
+  [:div {:data-testid "non-trivial-app-db"
+         :style       {:font-family "sans-serif" :padding "1em"}}
+   [:h1 "non-trivial-app-db testbed"]
+   [:p "55 leaves across 6 top-level keys, max depth 5. Each button
+        triggers one structural diff shape at a known path. Diff
+        visualisation should highlight only the changed slot."]
+
+   [:div {:style {:display :flex :gap "0.5em" :flex-wrap :wrap}}
+    [:button {:data-testid "toggle-theme"
+              :on-click    #(dispatch [::toggle-theme])}
+     "1 · scalar swap @ [:settings :theme] (d=2)"]
+    [:button {:data-testid "toggle-notifications"
+              :on-click    #(dispatch [::toggle-notifications])}
+     "2 · map merge @ [:settings :notifications] (d=3)"]
+    [:button {:data-testid "add-cart-item"
+              :on-click    #(dispatch [::add-cart-item])}
+     "3 · vector append @ [:cart :items] (d=2→item)"]
+    [:button {:data-testid "bump-first-item-qty"
+              :on-click    #(dispatch [::bump-first-item-qty])}
+     "4 · vector swap-by-index @ [:cart :items 0 …] (d=4)"]
+    [:button {:data-testid "register-new-sku"
+              :on-click    #(dispatch [::register-new-sku])}
+     "5 · set add @ [:catalog …books…tech :skus] (d=5)"]
+    [:button {:data-testid "revoke-write-and-collapse"
+              :on-click    #(dispatch [::revoke-write-and-collapse-sidebar])}
+     "6 · set remove + flag flip @ :session siblings (d=3)"]
+    [:button {:data-testid "reset"
+              :on-click    #(dispatch [::reset])}
+     "Reset"]]
+
+   [:h3 {:style {:margin-top "1em"}} "app-db snapshot"]
+   [db-pre]])
+
+(reg-view root []
+  [buttons])
+
+;; ----------------------------------------------------------------------------
+;; Mount
+;; ----------------------------------------------------------------------------
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  (rf/dispatch-sync [::initialise])
+  (rdc/render react-root [root]))

--- a/testbeds/non_trivial_app_db/index.html
+++ b/testbeds/non_trivial_app_db/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: non-trivial-app-db</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/testbeds/sensitive_dispatcher/README.md
+++ b/testbeds/sensitive_dispatcher/README.md
@@ -1,0 +1,115 @@
+# `testbeds/sensitive-dispatcher`
+
+Three handlers marked `:sensitive? true` in their registration
+metadata, each driving a distinct privacy contract on a different
+boundary. A consumer (Causa, Story, pair2-mcp) reads the surface to
+verify the always-on event-emit substrate, the always-on error-emit
+substrate, the dev trace surface, the recorder, and the MCP wire
+each enforce their slice of the contract.
+
+## The three privacy boundaries
+
+| Button | `data-testid` | Registration | Expected wire shape |
+|---|---|---|---|
+| A | `sign-in-plain` | `:sensitive? true` (plain) | **Event-emit substrate DROPS the record entirely** (per rf2-6hklf). Dev trace surface stamps `:sensitive? true` at the top level of every trace event; payload rides through verbatim — downstream consumers filter via the stamp. |
+| B | `sign-in-redacted` | `:sensitive? true` + `[(rf/with-redacted [[:password] [:totp-code]])]` | The `:password` and `:totp-code` slots of the event vector become `:rf/redacted` before the trace emits. Recorder, MCP wire, and trace stream all see the scrubbed shape. Event-emit substrate still DROPS the record. The handler body sees the unredacted payload (its work depends on the real values). |
+| C | `sign-in-throw` | `:sensitive? true` + throws on dispatch | **Error-emit substrate REDACTS `:event` to `:rf/redacted`** before fan-out (per rf2-vnjfg). Operators see exception class + frame + failing event-id + `:elapsed-ms`; secret payload does not leak. |
+
+The canonical credentials payload (`example-credentials` in
+`core.cljs`) literal-carries the strings `"shhh-this-is-secret"` and
+`"123456"` so a Playwright spec can assert these strings DO NOT
+appear on the wire shape under any of the three buttons.
+
+## DOM mirrors
+
+| Element | What it asserts |
+|---|---|
+| `plain-count` | Advances on Button A — proves substrate-drop ≠ skip-handler. The handler body runs even though the event-emit listener never sees the record. |
+| `redacted-count` | Advances on Button B — proves the `with-redacted` interceptor scrubs only the trace surface, NOT the handler body. The cofx slot the handler reads is the unredacted payload (per [spec/009 §The `with-redacted` interceptor]). |
+| `throw-count` | Always 0 — the throw fires before any `:db` commit. The error-emit listener fires with the redacted `:event`. |
+| `meta-plain` / `meta-redacted` / `meta-throw` | `"true"` after boot — the registrar's stored handler-meta carries `:sensitive? true` for all three handlers. A spec calling `(rf/handler-meta :event id)` directly reads the same. |
+
+## Why three buttons
+
+Three is the smallest count that exercises all four privacy
+boundaries the spec separates:
+
+- **Event-emit substrate drop** (buttons A + B + C; A and B don't
+  throw, C does — both paths drop on the event-emit substrate).
+- **Trace-surface payload visibility under `:sensitive?` declarative
+  stamp** (button A — `:sensitive? true` at top level on every
+  trace event, payload rides through; consumer filters).
+- **Trace-surface payload redaction under `with-redacted`** (button
+  B — `:rf/redacted` sentinel replaces the named keys at trace
+  emission).
+- **Error-emit substrate redaction** (button C — `:event` slot of
+  the error record substituted with `:rf/redacted` at the wire
+  boundary).
+
+A consumer that conflates any pair (e.g. event-emit drop with
+error-emit drop, or `with-redacted` scope with `:sensitive?` top-
+level stamp) fails on the missing distinction.
+
+## What's deliberately *missing*
+
+- **No `:large?` declaration.** The privacy markers compose with
+  size markers per Spec 009 (sensitive drop wins on conflict); that
+  composition is the `large_dispatcher/` testbed's job.
+- **No multi-frame routing.** Sensitive cascades that cross frames
+  retain the stamp per-handler scope; this surface stays on the
+  default frame so each button's outcome is observable in isolation.
+- **No HTTP fx.** The `:rf.http/managed` fx carries its own
+  `:sensitive?` posture (per [spec/014 §Sensitive HTTP] / Security
+  decision log); conflating it with handler-level `:sensitive?`
+  would dilute the contract under test.
+- **No `:rf.warning/sensitive-without-redaction` warning trigger.**
+  Per [spec/009 §Production-elision behaviour] that warning fires
+  when `:sensitive?` is declared WITHOUT `with-redacted`; Button A
+  triggers it on dev builds. The surface deliberately does not
+  capture or display the warning — it's a dev-only advisory and
+  the consumer's panel surfaces it via the warning channel.
+
+## Test scenarios from rf2-fe84r this surface enables
+
+**Causa (26)**:
+- **`:sensitive?` event arrives with `:event` redacted to
+  `:rf/redacted`** — the load-bearing scenario this surface
+  unblocks. Button B fires; Causa's trace panel must show the
+  `:event` payload's `:password` and `:totp-code` slots replaced
+  with the sentinel, not the original strings.
+- Handler exception surfaces as `:effects` outcome `:error` per
+  epoch record — Button C fires; the epoch record carries
+  `:outcome :error` with the redacted event-payload slot.
+
+**Story (18)**:
+- **Recorder redacts secret-bearing events (rf2-hdadz)** — the
+  load-bearing scenario. Button B's click should be captured by
+  the recorder with the redacted event vector, not the raw one.
+  A recorder that captures the raw vector ships secrets out of
+  the box.
+
+**Cross-cutting (6)**:
+- `:rf.warning/sensitive-without-redaction` dev advisory — Button A
+  emits the warning at registration time (since `:sensitive?` is
+  declared without `with-redacted`); consumer panels surface this
+  as a registration-time advisory.
+
+## Running
+
+From `implementation/`:
+
+```bash
+shadow-cljs watch testbeds/sensitive-dispatcher
+# Or via the orchestrator:
+npm run test:examples
+```
+
+The shadow-cljs build id is `testbeds/sensitive-dispatcher`; output
+lands in `implementation/out/testbeds/sensitive-dispatcher/`.
+
+## Cross-references
+
+- [`spec/009-Instrumentation.md` §Privacy / sensitive data in traces](../../spec/009-Instrumentation.md) — the contract for the `:sensitive?` registration meta key, the `with-redacted` interceptor, and the top-level trace-event stamp.
+- [`spec/009-Instrumentation.md` §Substrate-level enforcement on the always-on surfaces](../../spec/009-Instrumentation.md) — the event-emit drop (rf2-6hklf) and error-emit redact (rf2-vnjfg) contracts buttons A/B and C exercise.
+- [`spec/Security.md` §Privacy / secret handling](../../spec/Security.md) — the privacy decisions log keying every behaviour above to a bead.
+- [`spec/Conventions.md` §Reserved namespaces](../../spec/Conventions.md) — the `:rf/redacted` sentinel keyword owned by the framework.

--- a/testbeds/sensitive_dispatcher/core.cljs
+++ b/testbeds/sensitive_dispatcher/core.cljs
@@ -1,0 +1,248 @@
+(ns sensitive-dispatcher.core
+  "Shared framework-behavior testbed — handlers carrying `:sensitive? true`
+  in their registration metadata. A consumer (Causa, Story, pair2-mcp)
+  verifies that the always-on event-emit substrate, the dev-time trace
+  surface, the recorder, and the MCP wire each honour the privacy
+  contract (per [spec/009 §Privacy / sensitive data in traces] and
+  [spec/Security.md §Privacy / secret handling]).
+
+  Three buttons drive three distinct privacy shapes:
+
+    Button A · Sign-in (`:sensitive? true` on registration)
+      — handler declares `:sensitive? true` on registration meta. The
+        event-emit listener substrate DROPS the record entirely (per
+        rf2-6hklf); the dev trace surface stamps `:sensitive? true` on
+        the trace event but rides the payload through (the dev surface
+        treats `:sensitive?` as declarative — listeners filter).
+
+    Button B · Sign-in with redaction (`:sensitive?` + `with-redacted`)
+      — handler declares both flags. The recorder + the MCP wire +
+        the trace surface all see redacted payload (the `:password`
+        slot in the event vector becomes `:rf/redacted`); the
+        event-emit substrate still drops the record entirely.
+
+    Button C · Sign-in that throws
+      — handler declares `:sensitive? true` and deliberately throws.
+        The always-on error-emit substrate REDACTS the event payload
+        to `:rf/redacted` (per rf2-vnjfg) so error monitors see the
+        exception class + frame + elapsed but NOT the secret payload.
+
+  This is NOT a tutorial. The bodies are minimal. The point is to
+  produce three deterministic privacy outcomes a consumer can assert
+  against — payload dropped vs payload redacted vs error-payload
+  redacted — all from one surface."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ----------------------------------------------------------------------------
+;; App-db
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-db ::initialise
+  (fn [_db _ev]
+    {;; Counters per button — flipped when the handler runs to
+     ;; completion. A spec asserts that the counters DO advance
+     ;; (the handlers themselves see the unredacted payload via the
+     ;; cofx slot per Spec 009 §with-redacted) even when the trace
+     ;; / wire surfaces see redaction.
+     :click-count {:plain 0 :redacted 0 :throw 0}
+     ;; A consumer that asks "did the handler's :sensitive? meta
+     ;; flow into the registration?" reads the registrar via
+     ;; (rf/handler-meta :event ::sign-in) and sees :sensitive? true.
+     ;; The mirror below echoes that into the DOM so a Playwright
+     ;; spec can read it directly.
+     :handler-meta-mirror
+     {::sign-in-plain    nil
+      ::sign-in-redacted nil
+      ::sign-in-throw    nil}}))
+
+;; ----------------------------------------------------------------------------
+;; Button A — :sensitive? true on registration, no with-redacted
+;; ----------------------------------------------------------------------------
+;;
+;; The registration-meta map carries `:sensitive? true`. Per [spec/009
+;; §Substrate-level enforcement on the always-on surfaces]:
+;;
+;;   - The event-emit substrate (per `register-event-emit-listener!`)
+;;     drops the record for this dispatch entirely. Listeners are
+;;     NOT invoked. Sensitive cascades produce no per-event
+;;     observability record at all (rf2-6hklf).
+;;
+;;   - The dev-time trace surface stamps `:sensitive? true` at the
+;;     top level of every trace event emitted within this handler's
+;;     scope; the payload itself rides through unchanged. Tools
+;;     downstream of the trace surface (recorders, off-box pair2
+;;     server, Causa-MCP) filter / redact per their own policy.
+
+(rf/reg-event-db ::sign-in-plain
+  {:doc        "Verify credentials (plain :sensitive? — no redaction)."
+   :sensitive? true}
+  (fn [db [_ _credentials]]
+    ;; HOT PATH — handler sees unredacted credentials map via the
+    ;; regular :event cofx slot. The :sensitive? declarative axis
+    ;; is independent of what the handler body sees; only the trace
+    ;; and the always-on substrates' wire shapes change.
+    (update-in db [:click-count :plain] inc)))
+
+;; ----------------------------------------------------------------------------
+;; Button B — :sensitive? true + with-redacted interceptor
+;; ----------------------------------------------------------------------------
+;;
+;; This is the conservative recommended pattern for sensitive
+;; handlers (per [spec/009 §The `with-redacted` interceptor] and
+;; [spec/Security.md §Privacy / secret handling]). The interceptor's
+;; :before stage redacts the named paths in the event vector, in the
+;; downstream :event cofx slot, and in the :event/dispatched +
+;; :event/db-changed trace events.
+
+(rf/reg-event-db ::sign-in-redacted
+  {:doc        "Verify credentials (redacted via with-redacted)."
+   :sensitive? true}
+  [(rf/with-redacted [[:password] [:totp-code]])]
+  (fn [db [_ _credentials]]
+    (update-in db [:click-count :redacted] inc)))
+
+;; ----------------------------------------------------------------------------
+;; Button C — :sensitive? true + throws (exercise the error-emit substrate)
+;; ----------------------------------------------------------------------------
+;;
+;; The handler's throw drives the always-on error-emit substrate
+;; (per [spec/009 §Substrate-level enforcement] §error-emit). When
+;; the failing handler's meta carries `:sensitive? true` the
+;; substrate REDACTS the :event slot of the error-record to
+;; `:rf/redacted` before fan-out. Operators see the exception class,
+;; the frame id, the failing event-id, and `:elapsed-ms` but NOT
+;; the secret payload (per rf2-vnjfg).
+
+(rf/reg-event-db ::sign-in-throw
+  {:doc        "Sign-in that throws — exercises the error-emit redaction."
+   :sensitive? true}
+  (fn [_db [_ _credentials]]
+    ;; HOT PATH — the throw site. The runtime's outer catch fires
+    ;; the always-on error-emit listener with :event redacted to
+    ;; :rf/redacted because of the :sensitive? meta.
+    (throw (ex-info "sensitive-dispatcher / sign-in-throw"
+                    {:where :handler}))))
+
+;; ----------------------------------------------------------------------------
+;; Handler-meta mirror — populate at mount so the DOM can show the
+;; registrar's view of the `:sensitive?` flag
+;; ----------------------------------------------------------------------------
+;;
+;; The registrar copies `:sensitive?` from registration metadata into
+;; the registry slot's stored meta. `(rf/handler-meta :event id)`
+;; reads it back. The mirror below puts the value into app-db so
+;; a Playwright spec can assert on the registrar's view directly.
+
+(rf/reg-event-db ::populate-meta-mirror
+  (fn [db _ev]
+    (assoc db :handler-meta-mirror
+              {::sign-in-plain    (boolean (:sensitive? (rf/handler-meta :event ::sign-in-plain)))
+               ::sign-in-redacted (boolean (:sensitive? (rf/handler-meta :event ::sign-in-redacted)))
+               ::sign-in-throw    (boolean (:sensitive? (rf/handler-meta :event ::sign-in-throw)))})))
+
+;; ----------------------------------------------------------------------------
+;; Reset
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-db ::reset
+  (fn [_db _ev]
+    {:click-count {:plain 0 :redacted 0 :throw 0}
+     :handler-meta-mirror
+     {::sign-in-plain    (boolean (:sensitive? (rf/handler-meta :event ::sign-in-plain)))
+      ::sign-in-redacted (boolean (:sensitive? (rf/handler-meta :event ::sign-in-redacted)))
+      ::sign-in-throw    (boolean (:sensitive? (rf/handler-meta :event ::sign-in-throw)))}}))
+
+;; ----------------------------------------------------------------------------
+;; Subs + view
+;; ----------------------------------------------------------------------------
+
+(rf/reg-sub :plain-count
+  (fn [db _] (get-in db [:click-count :plain])))
+
+(rf/reg-sub :redacted-count
+  (fn [db _] (get-in db [:click-count :redacted])))
+
+(rf/reg-sub :throw-count
+  (fn [db _] (get-in db [:click-count :throw])))
+
+(rf/reg-sub :meta-plain
+  (fn [db _] (get-in db [:handler-meta-mirror ::sign-in-plain])))
+
+(rf/reg-sub :meta-redacted
+  (fn [db _] (get-in db [:handler-meta-mirror ::sign-in-redacted])))
+
+(rf/reg-sub :meta-throw
+  (fn [db _] (get-in db [:handler-meta-mirror ::sign-in-throw])))
+
+;; A canonical secret payload reused by every button. The literal
+;; secret strings ride the event-vector emit; consumers verify the
+;; on-wire form replaces these with `:rf/redacted` according to
+;; their policy.
+(def example-credentials
+  {:username  "ada"
+   :password  "shhh-this-is-secret"
+   :totp-code "123456"})
+
+(reg-view buttons []
+  (let [plain-count    @(subscribe [:plain-count])
+        redacted-count @(subscribe [:redacted-count])
+        throw-count    @(subscribe [:throw-count])
+        meta-plain     @(subscribe [:meta-plain])
+        meta-redacted  @(subscribe [:meta-redacted])
+        meta-throw     @(subscribe [:meta-throw])]
+    [:div {:data-testid "sensitive-dispatcher"
+           :style       {:font-family "sans-serif" :padding "1em"}}
+     [:h1 "sensitive-dispatcher testbed"]
+     [:p "Three handlers all carrying " [:code ":sensitive? true"]
+         ". Each click produces a distinct redaction shape on the
+          trace stream, the event-emit substrate, the error-emit
+          substrate, and the MCP wire."]
+
+     [:div {:style {:display :flex :gap "0.5em" :flex-wrap :wrap}}
+      [:button {:data-testid "sign-in-plain"
+                :on-click    #(dispatch [::sign-in-plain example-credentials])}
+       "A · :sensitive? plain (event-emit drops record)"]
+      [:button {:data-testid "sign-in-redacted"
+                :on-click    #(dispatch [::sign-in-redacted example-credentials])}
+       "B · :sensitive? + with-redacted (payload scrubbed)"]
+      [:button {:data-testid "sign-in-throw"
+                :on-click    #(dispatch [::sign-in-throw example-credentials])}
+       "C · :sensitive? + throw (error-emit redacts :event)"]
+      [:button {:data-testid "reset"
+                :on-click    #(dispatch [::reset])}
+       "Reset"]]
+
+     [:p {:style {:margin-top "1em" :color "#666" :white-space :pre-wrap}}
+      "plain-count="    [:span {:data-testid "plain-count"}    plain-count]
+      "  (advances iff handler ran — proves substrate-drop ≠ skip-handler)"  "\n"
+      "redacted-count=" [:span {:data-testid "redacted-count"} redacted-count]   "\n"
+      "throw-count="    [:span {:data-testid "throw-count"}    throw-count]
+      "  (always 0 — handler throws before commit)"                          "\n\n"
+      "(handler-meta :event ::sign-in-plain    :sensitive?)="
+      [:span {:data-testid "meta-plain"}    (str meta-plain)]    "\n"
+      "(handler-meta :event ::sign-in-redacted :sensitive?)="
+      [:span {:data-testid "meta-redacted"} (str meta-redacted)] "\n"
+      "(handler-meta :event ::sign-in-throw    :sensitive?)="
+      [:span {:data-testid "meta-throw"}    (str meta-throw)]]]))
+
+(reg-view root []
+  [buttons])
+
+;; ----------------------------------------------------------------------------
+;; Mount
+;; ----------------------------------------------------------------------------
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  (rf/dispatch-sync [::initialise])
+  ;; Populate the registrar-meta mirror once on boot; the mirror is
+  ;; static — the registrations don't change at runtime.
+  (rf/dispatch-sync [::populate-meta-mirror])
+  (rdc/render react-root [root]))

--- a/testbeds/sensitive_dispatcher/index.html
+++ b/testbeds/sensitive_dispatcher/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: sensitive-dispatcher</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Tier 3 + Tier 4 of the shared framework-behavior testbed surfaces under bead **rf2-kzcim**. Tier 1 (PR #1082) + Tier 2 (PR #1088) shipped already; this PR closes the umbrella.

Five new surfaces under top-level \`testbeds/\`, each one commit, plus a small docs commit refreshing the testbed index:

### Tier 3 (devtools edge cases)

1. **\`testbeds/drain_depth_trigger/\`** — one handler whose \`:fx\` recursively dispatches itself; the runtime's run-to-completion drain halts at the frame's \`:drain-depth\` ceiling and rolls the frame's \`app-db\` back atomically (Spec 002 rule 3). The in-app \`:rf.error/drain-depth-exceeded\` listener flips a DOM mirror via a second drain so the halt is observable without scraping the ring buffer. Configurable ceiling input lets specs dial down to 5 for sub-second runs.

2. **\`testbeds/non_trivial_app_db/\`** — 55-leaf app-db across 6 top-level keys at depths 1 through 5. Six buttons each trigger a structurally distinct diff shape (scalar swap / map merge / vector append / vector swap-by-index / set add at depth 5 / sibling-subtree change) at a known path. Pretty-printed \`pr-str\` DOM mirror so a Playwright spec can assert the before/after pair around any click.

3. **\`testbeds/sensitive_dispatcher/\`** — three handlers all marked \`:sensitive? true\` in registration meta, each driving a distinct privacy contract: (A) plain \`:sensitive?\` → event-emit substrate drops the record entirely (rf2-6hklf); (B) \`:sensitive?\` + \`with-redacted\` → \`:password\` and \`:totp-code\` slots become \`:rf/redacted\` before trace emits; (C) \`:sensitive?\` + throws → error-emit substrate redacts \`:event\` to \`:rf/redacted\` (rf2-vnjfg). Handler-meta mirror reads \`:sensitive?\` from the registrar.

4. **\`testbeds/large_dispatcher/\`** — four nomination paths for the wire-elision walker: (A) runtime auto-detect on a 20 KiB write (above the 16 KiB threshold; \`:rf.warning/runtime-large-elision\` fires once); (B) \`rf/declare-large-path!\` REPL wrapper; (C) \`:rf.size/declare-large\` fx (canonical AI-discoverable shape); (D) schema-driven \`:large? true\` on a Malli slot, seeded at boot via \`populate-elision-from-schemas!\`. DOM mirror shows the elision-declarations registry.

### Tier 4 (a11y)

5. **\`testbeds/known_bad_a11y/\`** — Story-mode surface with one parent story (\`:story.a11y\`) + two variants. \`:story.a11y/known-bad\` packs five deliberate axe-core violations (image-alt, button-name, label, link-name, color-contrast) into the minimum DOM that triggers each rule. \`:story.a11y/known-good\` has the same elements with proper a11y attributes — zero violations expected. The contract is pairwise: \`known-bad\` must report ≥5 (proves the scan reached the variant), \`known-good\` must report 0 (proves the scan did NOT reach Story chrome). Verifies the load-bearing rf2-qgms1 fix (PR #1080).

Each surface carries \`core.cljs\` + \`index.html\` + \`README.md\` and a per-build entry in \`implementation/shadow-cljs.edn\` under \`:testbeds/<kebab-case>\` (Causa dev preload included, mirroring Tier 1+2). \`testbeds/README.md\` index refreshed with the new surfaces, the consumer table, and the tier-roadmap checkmarks.

### Pre-alpha posture

Backward compatibility is not a concern. Optimised for clarity / correctness (masterpiece bar). The five surfaces deliberately exercise edge behaviour to give consumer tools concrete observable shapes; no tutorial value, no content leakage into examples.

### Quality gates

- \`npm run test:cljs\` — **PASS** (1982 tests, 5627 assertions, 0 failures / 0 errors)
- \`npm run test:bundle-isolation\` — **PASS**
- Each surface release-builds clean under \`:advanced\` via \`shadow-cljs release testbeds/<name>\` (verified locally per surface)

### Bead

Closes **rf2-kzcim** — Tier 1-4 of the shared framework-behavior testbed surfaces all delivered.

## Test plan

- [x] \`npm run test:cljs\` green
- [x] \`npm run test:bundle-isolation\` green
- [x] Each surface release-build green (5/5: drain-depth-trigger, non-trivial-app-db, sensitive-dispatcher, large-dispatcher, known-bad-a11y)
- [ ] Each surface boots in dev: \`shadow-cljs watch testbeds/<name>\` opens cleanly; the documented DOM mirrors / buttons behave per the per-surface README
- [ ] Tier 1+2 surfaces still build / boot unchanged (regression check)