### PR TITLE
fix(causa-testbeds): stabilise rigorous spec — remove skip after timing/selector audit (rf2-grpgc)

### DIFF
--- a/tools/causa/testbeds/rigorous/spec.cjs
+++ b/tools/causa/testbeds/rigorous/spec.cjs
@@ -167,17 +167,6 @@ async function clearTraceBuffer(page) {
 module.exports = {
   name: 'causa-rigorous',
   url: '/counter/',
-  // rf2-p8f2s — the rigorous proposal spec was carried into PR #1072 as
-  // a developer-driven manual file (`causa_rigorous.cjs` — no `.spec.`
-  // suffix, so the runner walker skipped it). The mechanical migration
-  // step renamed it to `spec.cjs` and broadened the walker; the spec
-  // now gets discovered. It exercises 7+ interactive panels of the
-  // Causa UI end-to-end and times out at step 6 (click trace row → wait
-  // event-detail panel) on the current build. Skip in CI for now; the
-  // follow-up bead (rf2-grpgc) will stabilise the interactions and
-  // flip this off. The shorter `counter-driven` spec (sibling) still
-  // covers the mount + panel-handoff invariants.
-  skip: 'rigorous proposal not yet stable in CI (rf2-grpgc follow-up)',
   run: async (page) => {
     const counterValue = page.locator('span').first();
 


### PR DESCRIPTION
## Summary

Removes the `skip` directive on `tools/causa/testbeds/rigorous/spec.cjs` (bead **rf2-grpgc**, P3 follow-up to rf2-p8f2s).

### Root cause

The skip was set when the rigorous proposal spec began timing out at the trace-row → event-detail panel handoff (5s window). That problematic assertion was **already removed** in a prior commit — see lines 387-393 of the spec, which document the omission: the row-click pivot is dispatch-id-gated (warning/error trace rows have no dispatch-id so don't pivot) and the high-rate background trace cascade makes targeting a specific dispatch-id row non-deterministic. The shorter `counter-driven` sibling spec already covers the sidebar → event-detail pivot invariant.

The fix was therefore not a code change — it was flipping off the now-stale `skip` directive and dropping its lead-in comment block.

### Verification

Ran the rigorous spec 10× consecutively against a locally-compiled `examples/counter` build (Windows + Chromium headless), using the same Playwright + http-server pipeline that `npm run test:examples` drives in CI:

```
PASS run 1 in 1612ms
PASS run 2 in 1691ms
...
PASS run 10 in 1633ms
```

10/10 PASS, sub-2s per run — well below the runner's 30s per-spec timeout.

### Boundaries

- Surface: `tools/causa/testbeds/rigorous/spec.cjs` only.
- LoC delta: **-11, +0** (skip directive + lead-in comment removed).
- No production code touched; no other testbed touched.

## Test plan

- [x] Local 10× sequential runs of the rigorous spec — all PASS, ~1.6–2.0s each
- [ ] CI `cljs-examples` job passes including `causa-rigorous` (no longer SKIP)