### PR TITLE
infra(shadow-cljs): suppress :infer-warning in :node-test target — restore quiet-on-success signal (rf2-ls3wn)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -140,7 +140,25 @@
    ;; ../test-quiet/src/re_frame/test_quiet/shadow_node.cljs and is
    ;; on the classpath via the source-paths list below.
    :main      re-frame.test-quiet.shadow-node/main
-   :compiler-options {:warnings {:redef false}}}
+   ;; rf2-ls3wn — disable externs inference (and therefore the
+   ;; :infer-warning class) in the test build. The cljs.test reporter is
+   ;; silent-on-success (rf2-try1x, PR #1079) but the test classpath
+   ;; spans every artefact + every testbed + every tool's source tree,
+   ;; so unrelated externs-inference noise (~16 lines per warning, ~32
+   ;; warnings on a green run ≈ 500 lines) drowns the green-run signal.
+   ;;
+   ;; Shadow defaults `:infer-externs :auto`, which root-binds
+   ;; `(:infer-warning ana/*cljs-warnings*)` to true for every
+   ;; non-from-jar source — overriding any `:warnings {:infer-warning
+   ;; false}` we'd set here (see shadow/build/compiler.clj). The only
+   ;; way to fully silence the class is `:infer-externs false`.
+   ;;
+   ;; Externs inference stays ON for the production :browser builds
+   ;; (where it catches real :advanced extern bugs); the :node-test
+   ;; build runs un-minified on Node so externs aren't relevant, and
+   ;; test code is allowed to be less type-disciplined.
+   :compiler-options {:warnings      {:redef false}
+                      :infer-externs false}}
 
   :browser-test
   {:target    :browser-test


### PR DESCRIPTION
## Summary

Following rf2-try1x (PR #1079), the `cljs.test` reporter is silent-on-success but `npm run test:cljs` still emitted ~32 shadow-cljs warning blocks (~16 lines each ≈ 500 lines) on a green run. Defeats the quiet-test reporter's purpose.

Root cause: shadow-cljs defaults `:infer-externs :auto`, which root-binds `(:infer-warning ana/*cljs-warnings*)` to `true` for every non-from-jar source. The override `merge warnings` happens **before** the `cond->` that flips `:infer-warning` on (see `shadow/build/compiler.clj` ~L737-742), so a `:warnings {:infer-warning false}` entry has no effect. The only way to fully silence the class is `:infer-externs false`.

Fix: add `:infer-externs false` to the `:node-test` build's `:compiler-options`. Externs inference stays ON for the production `:browser` builds (where it catches real `:advanced` extern bugs); the `:node-test` build runs un-minified on Node so externs aren't relevant, and test code is allowed to be less type-disciplined.

## Before / after

Green-run line counts (`cd implementation && npm run test:cljs 2>&1 | wc -l`):

| | Lines | Warning blocks |
|---|---|---|
| Before | 524 | 32 (23 `:infer-warning`, 9 other) |
| After  | 154 | 9 (all real analyser signal) |

The 9 surviving warnings are real CLJS analyser warnings (`undeclared-var`, `fn-arity`, `redef-in-file`, `ns-var-clash`) — genuine signal worth keeping. Fixing those is out of scope here.

## Test plan

- [x] `npm run test:cljs` — `Ran 1988 tests containing 5638 assertions. 0 failures, 0 errors.`
- [x] `npm run test:bundle-isolation` — `=== PASS ===` (production `:browser` builds still surface inference warnings; this is test-only suppression)
- [x] Single-line config change to `:node-test` only; no other builds touched

Refs rf2-ls3wn, follow-up to rf2-try1x (PR #1079).