### PR TITLE
fix(editor-uri): unify Story+Causa allowlist into shared ns (rf2-p887o)

### DIFF
--- a/implementation/core/src/re_frame/source_coords/editor_uri.cljc
+++ b/implementation/core/src/re_frame/source_coords/editor_uri.cljc
@@ -130,6 +130,88 @@
           lower   (str/lower-case trimmed)]
       (boolean (some #(str/starts-with? lower %) forbidden-uri-schemes)))))
 
+;; ---- positive scheme allowlist (rf2-cm93v / rf2-p887o) -------------------
+;;
+;; `forbidden-scheme?` (rf2-vwcsq) is a blocklist of three known-bad schemes
+;; — it fails open against `http:` / `https:` and any scheme that hasn't
+;; been catalogued as bad yet. The launch-time seam in each tool (Story's
+;; and Causa's `open!`) layers a positive allowlist on top: anything
+;; outside `allowed-editor-uri-schemes` is refused before `window.location`
+;; gets assigned. Per spec/Security.md §Pragmatic stance the rationale is
+;; "gate accidents, not theoretical attacks" — a `{:custom ...}` template
+;; that resolves to `http://...` would navigate the tab rather than launch
+;; an editor; the allowlist makes that an obvious no-op rather than a
+;; silent surprise.
+;;
+;; Originally lived in `day8.re-frame2-causa.open-in-editor` (rf2-cm93v);
+;; lifted to this shared ns per rf2-p887o so Story consumes the same
+;; predicate Causa does.
+
+(def ^:const allowed-editor-uri-schemes
+  "Positive allowlist of URI schemes the launcher will hand off to the
+  OS. Anything outside the set is refused at each tool's `open!`
+  boundary.
+
+  Members:
+   - `vscode:`            VS Code
+   - `vscode-insiders:`   VS Code Insiders
+   - `cursor:`            Cursor (VS Code fork)
+   - `windsurf:`          Windsurf (VS Code fork)
+   - `zed:`               Zed
+   - `idea:`              JetBrains (IDEA, WebStorm, PyCharm, …)
+   - `jetbrains:`         JetBrains alt scheme
+   - `fleet:`             JetBrains Fleet
+   - `subl:`              Sublime Text
+   - `emacs:` / `emacsclient:` / `org-protocol:`  Emacs family
+   - `vim:` / `nvim:` / `mvim:`                    Vim family
+   - `txmt:`              TextMate
+   - `atom:`              Atom (legacy but still launchable)
+   - `file:`              host-resolved file URL
+
+  Per rf2-cm93v this is intentionally a positive list, not a reject
+  list — pre-cm93v the editor-template surface relied on `editor-uri`'s
+  three-scheme reject (`javascript:` / `data:` / `vbscript:`) which
+  failed open against `http:` / `https:` and any scheme that hadn't
+  been catalogued as bad yet."
+  #{"vscode" "vscode-insiders"
+    "cursor" "windsurf"
+    "zed"
+    "idea" "jetbrains" "fleet"
+    "subl"
+    "emacs" "emacsclient" "org-protocol"
+    "vim" "nvim" "mvim"
+    "txmt"
+    "atom"
+    "file"})
+
+(defn- uri-scheme
+  "Return the URI's leading scheme as a lower-case string, sans the
+  trailing `:`. Returns nil when `uri` is not a string, has no scheme,
+  or the scheme is empty.
+
+  Tolerates leading whitespace so an attacker template like
+  `\" javascript:...\"` (which would `triml` away before the browser
+  parsed it) still produces the right scheme for the allowlist check."
+  [uri]
+  (when (string? uri)
+    (let [trimmed  (str/triml uri)
+          colon-ix (str/index-of trimmed ":")]
+      (when (and colon-ix (pos? colon-ix))
+        (str/lower-case (subs trimmed 0 colon-ix))))))
+
+(defn allowed-uri?
+  "Predicate — true iff `uri`'s scheme is in `allowed-editor-uri-schemes`.
+  Pure data → boolean; safe to call from tests and from the click-time
+  guard in each tool's `open!`. Per rf2-cm93v: positive allowlist,
+  defense-in-depth alongside `editor-uri`'s three-scheme reject.
+
+  Per rf2-p887o lives here (not in Causa) so Story consumes the same
+  predicate — both surfaces gate `{:custom ...}` templates identically."
+  [uri]
+  (boolean
+    (when-let [scheme (uri-scheme uri)]
+      (contains? allowed-editor-uri-schemes scheme))))
+
 (def ^:private default-editor
   "Default editor when no `:editor` config key is set. VS Code is the
   most-installed editor in 2026 (Stack Overflow Developer Survey 2025

--- a/implementation/core/test/re_frame/source_coords_editor_uri_cljs_test.cljs
+++ b/implementation/core/test/re_frame/source_coords_editor_uri_cljs_test.cljs
@@ -56,3 +56,31 @@
     (is (some? (eu/editor-uri {:custom "jetbrains://idea/{path}:{line}"}      coord)))
     (is (some? (eu/editor-uri {:custom "subl://open?path={path}&line={line}"} coord)))
     (is (some? (eu/editor-uri {:custom "emacsclient://open?file={path}"}      coord)))))
+
+;; ---- positive scheme allowlist (rf2-cm93v / rf2-p887o) -------------------
+
+(deftest allowed-uri-on-cljs
+  (testing "the positive allowlist round-trips identically on CLJS"
+    ;; built-in schemes pass
+    (is (eu/allowed-uri? "vscode://file/src/x.cljs:1:1"))
+    (is (eu/allowed-uri? "cursor://file/src/x.cljs:1:1"))
+    (is (eu/allowed-uri? "windsurf://file/src/x.cljs:1:1"))
+    (is (eu/allowed-uri? "zed://file/src/x.cljs:1:1"))
+    (is (eu/allowed-uri? "idea://open?file=src/x.cljs&line=1&column=1"))
+    ;; other catalogued schemes
+    (is (eu/allowed-uri? "subl://open?path=src/x.cljs"))
+    (is (eu/allowed-uri? "emacsclient://src/x.cljs"))
+    (is (eu/allowed-uri? "file:///abs/path/src/x.cljs"))
+    ;; rejected schemes
+    (is (not (eu/allowed-uri? "javascript:alert(1)")))
+    (is (not (eu/allowed-uri? "data:text/html,xxx")))
+    (is (not (eu/allowed-uri? "vbscript:msgbox(1)")))
+    (is (not (eu/allowed-uri? "http://evil.example/x")))
+    (is (not (eu/allowed-uri? "https://evil.example/x")))
+    ;; non-strings / shape edge cases
+    (is (not (eu/allowed-uri? nil)))
+    (is (not (eu/allowed-uri? "")))
+    (is (not (eu/allowed-uri? "no-scheme-here")))
+    ;; leading whitespace is tolerated
+    (is (not (eu/allowed-uri? " javascript:alert(1)")))
+    (is (eu/allowed-uri? " vscode://file/src/x.cljs:1:1"))))

--- a/implementation/core/test/re_frame/source_coords_editor_uri_test.clj
+++ b/implementation/core/test/re_frame/source_coords_editor_uri_test.clj
@@ -195,3 +195,93 @@
     (is (some? (eu/editor-uri
                  {:custom "myeditor://open?file={path}"}
                  {:file "javascript:not-a-scheme.cljs" :line 1 :column 1})))))
+
+;; ---- positive scheme allowlist (rf2-cm93v / rf2-p887o) -------------------
+;;
+;; The allowlist was lifted from `day8.re-frame2-causa.open-in-editor` into
+;; this shared ns per rf2-p887o so Story and Causa consume the same predicate.
+
+(deftest allowed-uri-accepts-builtin-editor-schemes
+  (testing "the built-in editor schemes pass the allowlist"
+    (is (eu/allowed-uri? "vscode://file/src/x.cljs:1:1"))
+    (is (eu/allowed-uri? "cursor://file/src/x.cljs:1:1"))
+    (is (eu/allowed-uri? "windsurf://file/src/x.cljs:1:1"))
+    (is (eu/allowed-uri? "zed://file/src/x.cljs:1:1"))
+    (is (eu/allowed-uri?
+          "idea://open?file=src/x.cljs&line=1&column=1"))))
+
+(deftest allowed-uri-accepts-other-editor-schemes
+  (testing "other catalogued editor schemes pass — emacs / vim / sublime
+            family, jetbrains alt, file:"
+    (is (eu/allowed-uri? "subl://open?path=src/x.cljs"))
+    (is (eu/allowed-uri? "emacs:src/x.cljs"))
+    (is (eu/allowed-uri? "emacsclient://src/x.cljs"))
+    (is (eu/allowed-uri? "vim://src/x.cljs"))
+    (is (eu/allowed-uri? "nvim://src/x.cljs"))
+    (is (eu/allowed-uri? "txmt://open?url=file://src/x.cljs"))
+    (is (eu/allowed-uri? "jetbrains://idea/src/x.cljs"))
+    (is (eu/allowed-uri? "file:///abs/path/src/x.cljs"))))
+
+(deftest allowed-uri-rejects-javascript-scheme
+  (testing "javascript: is rejected — in-tab script execution vector"
+    (is (not (eu/allowed-uri? "javascript:alert(1)")))
+    (is (not (eu/allowed-uri? "JavaScript:alert(1)")))
+    (is (not (eu/allowed-uri? "JAVASCRIPT:alert(1)")))))
+
+(deftest allowed-uri-rejects-data-scheme
+  (testing "data: is rejected — inline-rendered HTML / script vector"
+    (is (not (eu/allowed-uri?
+               "data:text/html,<script>alert(1)</script>")))
+    (is (not (eu/allowed-uri?
+               "data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==")))))
+
+(deftest allowed-uri-rejects-http-scheme
+  (testing "http: is rejected — a custom editor template that resolves
+            to `http://...` would navigate the page rather than launch
+            an editor (rf2-cm93v)"
+    (is (not (eu/allowed-uri? "http://evil.example/x")))
+    (is (not (eu/allowed-uri? "HTTP://evil.example/x")))))
+
+(deftest allowed-uri-rejects-https-scheme
+  (testing "https: is rejected — same navigation vector as http:"
+    (is (not (eu/allowed-uri? "https://evil.example/x")))
+    (is (not (eu/allowed-uri? "HTTPS://evil.example/x")))))
+
+(deftest allowed-uri-rejects-vbscript-scheme
+  (testing "vbscript: is rejected — legacy IE / WebView2 script vector"
+    (is (not (eu/allowed-uri? "vbscript:msgbox(1)")))))
+
+(deftest allowed-uri-handles-non-string-and-empty
+  (testing "non-string / empty / scheme-less URIs are rejected"
+    (is (not (eu/allowed-uri? nil)))
+    (is (not (eu/allowed-uri? "")))
+    (is (not (eu/allowed-uri? "no-scheme-here")))
+    (is (not (eu/allowed-uri? ":leading-colon")))))
+
+(deftest allowed-uri-tolerates-leading-whitespace
+  (testing "leading whitespace doesn't disguise a forbidden scheme"
+    (is (not (eu/allowed-uri? " javascript:alert(1)")))
+    (is (not (eu/allowed-uri? "\thttp://evil.example/x")))
+    (is (eu/allowed-uri? " vscode://file/src/x.cljs:1:1"))))
+
+(deftest allowed-editor-uri-schemes-set-shape
+  (testing "the allowlist enumerates the catalogued editor schemes"
+    (is (contains? eu/allowed-editor-uri-schemes "vscode"))
+    (is (contains? eu/allowed-editor-uri-schemes "cursor"))
+    (is (contains? eu/allowed-editor-uri-schemes "windsurf"))
+    (is (contains? eu/allowed-editor-uri-schemes "zed"))
+    (is (contains? eu/allowed-editor-uri-schemes "idea"))
+    (is (contains? eu/allowed-editor-uri-schemes "subl"))
+    (is (contains? eu/allowed-editor-uri-schemes "emacs"))
+    (is (contains? eu/allowed-editor-uri-schemes "vim"))
+    (is (contains? eu/allowed-editor-uri-schemes "file"))
+    ;; http: / https: must NOT be on the list — that's the whole point.
+    (is (not (contains? eu/allowed-editor-uri-schemes "http")))
+    (is (not (contains? eu/allowed-editor-uri-schemes "https")))))
+
+(deftest builtin-schemes-all-pass-the-allowlist
+  (testing "every built-in scheme builder produces a URI the allowlist accepts"
+    (doseq [editor [nil :vscode :cursor :windsurf :zed :idea]]
+      (let [uri (eu/editor-uri editor sample-coord)]
+        (is (eu/allowed-uri? uri)
+            (str editor " produced a URI the allowlist rejects: " uri))))))

--- a/tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs
@@ -11,21 +11,24 @@
   at file:line. Phase 1 ships the helper + the shell-stub demo
   surface; the live panels consume this in subsequent phases.
 
-  ## Defense-in-depth scheme allowlist (rf2-cm93v)
+  ## Defense-in-depth scheme allowlist (rf2-cm93v / rf2-p887o)
 
   `editor-uri/editor-uri` already rejects `javascript:` / `data:` /
-  `vbscript:` for `{:custom ...}` templates (per rf2-vwcsq). This ns
-  adds a second, positive-allowlist gate at the launch boundary —
-  before assigning to `window.location` we verify the final URI's
-  scheme is in `allowed-editor-uri-schemes`. Anything outside the set
+  `vbscript:` for `{:custom ...}` templates (per rf2-vwcsq). The
+  click-time seam below layers a positive-allowlist gate on top
+  (`editor-uri/allowed-uri?`): before assigning to `window.location`
+  we verify the final URI's scheme is in
+  `editor-uri/allowed-editor-uri-schemes`. Anything outside the set
   (in particular `http:` / `https:` / new bad schemes we did not
   anticipate) is rejected at the click-time seam. Per spec/Security.md
   §Pragmatic stance the rationale is 'gate accidents, not theoretical
   attacks' — a custom template that resolves to `https://...` would
   navigate the page rather than launch an editor; the allowlist makes
-  that an obvious no-op rather than a silent surprise."
-  (:require [clojure.string :as str]
-            [day8.re-frame2-causa.config :as config]
+  that an obvious no-op rather than a silent surprise.
+
+  The allowlist itself lives in the shared `editor-uri` ns (rf2-p887o)
+  so Story consumes the same predicate Causa does."
+  (:require [day8.re-frame2-causa.config :as config]
             [re-frame.source-coords.editor-uri :as editor-uri]))
 
 ;; ---- styling -------------------------------------------------------------
@@ -48,69 +51,6 @@
           :display         "inline-block"
           :line-height     "16px"}})
 
-;; ---- scheme allowlist (rf2-cm93v) ----------------------------------------
-
-(def ^:const allowed-editor-uri-schemes
-  "Positive allowlist of URI schemes the launcher will hand off to the
-  OS. Anything outside the set is refused at the `open!` boundary.
-
-  Members:
-   - `vscode:`            VS Code
-   - `vscode-insiders:`   VS Code Insiders
-   - `cursor:`            Cursor (VS Code fork)
-   - `windsurf:`          Windsurf (VS Code fork)
-   - `zed:`               Zed
-   - `idea:`              JetBrains (IDEA, WebStorm, PyCharm, …)
-   - `jetbrains:`         JetBrains alt scheme
-   - `fleet:`             JetBrains Fleet
-   - `subl:`              Sublime Text
-   - `emacs:` / `emacsclient:` / `org-protocol:`  Emacs family
-   - `vim:` / `nvim:` / `mvim:`                    Vim family
-   - `txmt:`              TextMate
-   - `atom:`              Atom (legacy but still launchable)
-   - `file:`              host-resolved file URL
-
-  Per rf2-cm93v this is intentionally a positive list, not a reject
-  list — pre-cm93v the editor-template surface relied on `editor-uri`'s
-  three-scheme reject (`javascript:` / `data:` / `vbscript:`) which
-  failed open against `http:` / `https:` and any scheme that hadn't
-  been catalogued as bad yet."
-  #{"vscode" "vscode-insiders"
-    "cursor" "windsurf"
-    "zed"
-    "idea" "jetbrains" "fleet"
-    "subl"
-    "emacs" "emacsclient" "org-protocol"
-    "vim" "nvim" "mvim"
-    "txmt"
-    "atom"
-    "file"})
-
-(defn- uri-scheme
-  "Return the URI's leading scheme as a lower-case string, sans the
-  trailing `:`. Returns nil when `uri` is not a string, has no scheme,
-  or the scheme is empty.
-
-  Tolerates leading whitespace so an attacker template like
-  `\" javascript:...\"` (which would `triml` away before the browser
-  parsed it) still produces the right scheme for the allowlist check."
-  [uri]
-  (when (string? uri)
-    (let [trimmed (str/triml uri)
-          colon-ix (str/index-of trimmed ":")]
-      (when (and colon-ix (pos? colon-ix))
-        (str/lower-case (subs trimmed 0 colon-ix))))))
-
-(defn allowed-uri?
-  "Predicate — true iff `uri`'s scheme is in `allowed-editor-uri-schemes`.
-  Pure data → boolean; safe to call from tests and from the click-time
-  guard in `open!`. Per rf2-cm93v: positive allowlist, defense-in-depth
-  alongside `editor-uri`'s three-scheme reject."
-  [uri]
-  (boolean
-    (when-let [scheme (uri-scheme uri)]
-      (contains? allowed-editor-uri-schemes scheme))))
-
 ;; ---- side-effect: open the editor ----------------------------------------
 
 (defn- open!
@@ -120,14 +60,14 @@
   Per rf2-vwcsq: `uri` is the return of `editor-uri/editor-uri`, which
   already rejects `javascript:` / `data:` / `vbscript:` schemes by
   returning `nil`. Per rf2-cm93v this fn applies a second, positive
-  allowlist gate (`allowed-uri?`) before handing the URI off — closing
-  the `http:` / `https:` / unknown-scheme path that a `{:custom ...}`
-  template could otherwise resolve to. A rejected URI is a click-time
-  no-op (no navigation, no console noise — the chip's `(when uri ...)`
-  earlier guard handles the absent case; the allowlist handles the
-  shaped-but-disallowed case)."
+  allowlist gate (`editor-uri/allowed-uri?`) before handing the URI
+  off — closing the `http:` / `https:` / unknown-scheme path that a
+  `{:custom ...}` template could otherwise resolve to. A rejected URI
+  is a click-time no-op (no navigation, no console noise — the chip's
+  `(when uri ...)` earlier guard handles the absent case; the
+  allowlist handles the shaped-but-disallowed case)."
   [uri]
-  (when (and uri (allowed-uri? uri) js/window)
+  (when (and uri (editor-uri/allowed-uri? uri) js/window)
     (set! (.-location js/window) uri)
     nil))
 
@@ -141,9 +81,9 @@
   Returns nil when the source-coord lacks a usable `:file` slot, when
   `editor-uri/editor-uri` returns nil (a scheme rejected by the
   `editor-uri`-side gate per rf2-vwcsq), or when the resolved URI's
-  scheme is not in `allowed-editor-uri-schemes` (the Causa-side
-  positive allowlist per rf2-cm93v). The UI hides the chip rather than
-  rendering an unclickable affordance.
+  scheme is not in `editor-uri/allowed-editor-uri-schemes` (the
+  shared positive allowlist per rf2-cm93v / rf2-p887o). The UI hides
+  the chip rather than rendering an unclickable affordance.
 
   Source-coord shape: `{:file :line :column :ns}` per
   `re-frame.source-coords`. Causa receives source-coords on the trace
@@ -153,7 +93,7 @@
   (when (editor-uri/has-source? source-coord)
     (let [editor (config/get-editor)
           uri    (editor-uri/editor-uri editor source-coord)]
-      (when (and uri (allowed-uri? uri))
+      (when (and uri (editor-uri/allowed-uri? uri))
         [:a {:style       (:chip chip-styles)
              :href        uri
              :title       (editor-uri/open-button-title source-coord)

--- a/tools/causa/test/day8/re_frame2_causa/open_in_editor_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/open_in_editor_cljs_test.cljs
@@ -1,16 +1,19 @@
 (ns day8.re-frame2-causa.open-in-editor-cljs-test
   "CLJS smoke tests for Causa's 'Open in editor' chip (rf2-evgf5).
 
-  The URI math lives in `re-frame.source-coords.editor-uri` and is
-  matrix-tested at the core layer. This file covers Causa-specific
-  glue:
+  The URI math + the scheme allowlist live in
+  `re-frame.source-coords.editor-uri` and are matrix-tested at the
+  core layer (rf2-p887o lifted the allowlist out of this ns). This
+  file covers Causa-specific glue:
 
   - `config/set-editor!` round-trips on the CLJS side.
   - `open-chip` returns nil for source-coords without `:file`.
   - `open-chip` renders an `<a>` hiccup tag with the configured
     editor's URI scheme.
   - The chip carries `data-testid=\"causa-open-in-editor\"` so the
-    e2e suite can target it."
+    e2e suite can target it.
+  - `open-chip` hides when a `{:custom ...}` template resolves to a
+    scheme outside `editor-uri/allowed-editor-uri-schemes`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.open-in-editor :as open-in-editor]))
@@ -61,89 +64,31 @@
     (is (nil? (open-in-editor/open-chip {:line 1})))
     (is (nil? (open-in-editor/open-chip {:file ""})))))
 
-;; ---- rf2-cm93v — scheme allowlist (defense-in-depth) -------------------
-
-(deftest allowed-uri-accepts-builtin-editor-schemes
-  (testing "the built-in editor schemes pass the allowlist"
-    (is (open-in-editor/allowed-uri? "vscode://file/src/x.cljs:1:1"))
-    (is (open-in-editor/allowed-uri? "cursor://file/src/x.cljs:1:1"))
-    (is (open-in-editor/allowed-uri? "windsurf://file/src/x.cljs:1:1"))
-    (is (open-in-editor/allowed-uri? "zed://file/src/x.cljs:1:1"))
-    (is (open-in-editor/allowed-uri?
-          "idea://open?file=src/x.cljs&line=1&column=1"))))
-
-(deftest allowed-uri-accepts-other-editor-schemes
-  (testing "other catalogued editor schemes pass — emacs / vim / sublime
-            family, jetbrains alt, file:"
-    (is (open-in-editor/allowed-uri? "subl://open?path=src/x.cljs"))
-    (is (open-in-editor/allowed-uri? "emacs:src/x.cljs"))
-    (is (open-in-editor/allowed-uri? "emacsclient://src/x.cljs"))
-    (is (open-in-editor/allowed-uri? "vim://src/x.cljs"))
-    (is (open-in-editor/allowed-uri? "nvim://src/x.cljs"))
-    (is (open-in-editor/allowed-uri? "txmt://open?url=file://src/x.cljs"))
-    (is (open-in-editor/allowed-uri? "jetbrains://idea/src/x.cljs"))
-    (is (open-in-editor/allowed-uri? "file:///abs/path/src/x.cljs"))))
-
-(deftest allowed-uri-rejects-javascript-scheme
-  (testing "javascript: is rejected — in-tab script execution vector"
-    (is (not (open-in-editor/allowed-uri? "javascript:alert(1)")))
-    (is (not (open-in-editor/allowed-uri? "JavaScript:alert(1)")))
-    (is (not (open-in-editor/allowed-uri? "JAVASCRIPT:alert(1)")))))
-
-(deftest allowed-uri-rejects-data-scheme
-  (testing "data: is rejected — inline-rendered HTML / script vector"
-    (is (not (open-in-editor/allowed-uri?
-               "data:text/html,<script>alert(1)</script>")))
-    (is (not (open-in-editor/allowed-uri?
-               "data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==")))))
-
-(deftest allowed-uri-rejects-http-scheme
-  (testing "http: is rejected — a custom editor template that resolves
-            to `http://...` would navigate the page rather than launch
-            an editor (rf2-cm93v)"
-    (is (not (open-in-editor/allowed-uri? "http://evil.example/x")))
-    (is (not (open-in-editor/allowed-uri? "HTTP://evil.example/x")))))
-
-(deftest allowed-uri-rejects-https-scheme
-  (testing "https: is rejected — same navigation vector as http:"
-    (is (not (open-in-editor/allowed-uri? "https://evil.example/x")))
-    (is (not (open-in-editor/allowed-uri? "HTTPS://evil.example/x")))))
-
-(deftest allowed-uri-rejects-vbscript-scheme
-  (testing "vbscript: is rejected — legacy IE / WebView2 script vector"
-    (is (not (open-in-editor/allowed-uri? "vbscript:msgbox(1)")))))
-
-(deftest allowed-uri-handles-non-string-and-empty
-  (testing "non-string / empty / scheme-less URIs are rejected"
-    (is (not (open-in-editor/allowed-uri? nil)))
-    (is (not (open-in-editor/allowed-uri? "")))
-    (is (not (open-in-editor/allowed-uri? "no-scheme-here")))
-    (is (not (open-in-editor/allowed-uri? ":leading-colon")))))
-
-(deftest allowed-uri-tolerates-leading-whitespace
-  (testing "leading whitespace doesn't disguise a forbidden scheme"
-    (is (not (open-in-editor/allowed-uri? " javascript:alert(1)")))
-    (is (not (open-in-editor/allowed-uri? "\thttp://evil.example/x")))
-    (is (open-in-editor/allowed-uri? " vscode://file/src/x.cljs:1:1"))))
+;; ---- rf2-cm93v / rf2-p887o — Causa-side allowlist behaviour ------------
+;;
+;; The matrix tests for `allowed-uri?` itself live in the shared editor-uri
+;; test ns (rf2-p887o). These cases cover the Causa chip's wiring: the
+;; chip hides when a `{:custom ...}` template resolves to a disallowed
+;; scheme, and renders normally for safe ones.
 
 (deftest open-chip-hides-when-custom-template-resolves-to-unsafe-scheme
   (testing "open-chip returns nil when the resolved URI's scheme is not
-            in `allowed-editor-uri-schemes` (rf2-cm93v). Defense-in-depth
+            in `editor-uri/allowed-editor-uri-schemes`. Defense-in-depth
             alongside the editor-uri-side javascript:/data:/vbscript:
             reject from rf2-vwcsq — closes the http:/https:/etc. surface
             an upstream {:custom ...} template could otherwise resolve
             to."
     ;; editor-uri/editor-uri already gates javascript:/data:/vbscript:
-    ;; — for these the chip is nil regardless of the Causa-side
-    ;; allowlist. Verify those cases still hide.
+    ;; — for these the chip is nil regardless of the allowlist. Verify
+    ;; those cases still hide.
     (config/configure! {:editor {:custom "javascript:alert(1)"}})
     (is (nil? (open-in-editor/open-chip {:file "src/x.cljs"})))
 
     (config/configure! {:editor {:custom "data:text/html,xxx"}})
     (is (nil? (open-in-editor/open-chip {:file "src/x.cljs"})))
 
-    ;; http: is NOT in editor-uri's reject list — the Causa-side
-    ;; allowlist is the seam that catches it.
+    ;; http: is NOT in editor-uri's reject list — the allowlist is
+    ;; the seam that catches it.
     (config/configure! {:editor {:custom "http://evil.example/{path}"}})
     (is (nil? (open-in-editor/open-chip {:file "src/x.cljs"})))
 
@@ -153,8 +98,7 @@
 
 (deftest open-chip-renders-when-custom-template-resolves-to-safe-scheme
   (testing "open-chip renders normally when the resolved URI's scheme
-            is in `allowed-editor-uri-schemes` (rf2-cm93v positive
-            half)"
+            is in `editor-uri/allowed-editor-uri-schemes`"
     (config/configure! {:editor {:custom "subl://open?path={path}&line={line}"}})
     (let [hiccup (open-in-editor/open-chip {:file "src/x.cljs" :line 5})]
       (is (vector? hiccup))

--- a/tools/story/src/re_frame/story/ui/open_in_editor.cljs
+++ b/tools/story/src/re_frame/story/ui/open_in_editor.cljs
@@ -24,6 +24,21 @@
   fallback, per rf2-mdjp). The UI hides the chip entirely so the user
   doesn't click a no-op.
 
+  ## Defense-in-depth scheme allowlist (rf2-cm93v / rf2-p887o)
+
+  `editor-uri/editor-uri` already rejects `javascript:` / `data:` /
+  `vbscript:` for `{:custom ...}` templates (per rf2-vwcsq). The
+  click-time seam below layers a positive-allowlist gate on top
+  (`editor-uri/allowed-uri?`): before assigning to `window.location`
+  we verify the final URI's scheme is in
+  `editor-uri/allowed-editor-uri-schemes`. Anything outside the set
+  (in particular `http:` / `https:` / new schemes we did not
+  anticipate) is rejected at the click-time seam — a custom template
+  that resolves to `https://...` would navigate the tab rather than
+  launch an editor; the allowlist makes that an obvious no-op rather
+  than a silent surprise. The predicate lives in the shared
+  `editor-uri` ns so Causa's parallel surface consumes the same gate.
+
   ## Bundle isolation
 
   Lives in the Story CLJS bundle; production builds elide the entire
@@ -65,11 +80,15 @@
 
   Per rf2-vwcsq: `uri` is the return of `editor-uri/editor-uri`, which
   already rejects `javascript:` / `data:` / `vbscript:` schemes by
-  returning `nil`. The `(when uri ...)` guard below is the call site's
-  enforcement seam — a forbidden custom template never reaches
-  `window.location`."
+  returning `nil`. Per rf2-cm93v / rf2-p887o this fn applies a second,
+  positive allowlist gate (`editor-uri/allowed-uri?`) before handing
+  the URI off — closing the `http:` / `https:` / unknown-scheme path
+  that a `{:custom ...}` template could otherwise resolve to. A
+  rejected URI is a click-time no-op (no navigation, no console noise
+  — the chip's `(when uri ...)` earlier guard handles the absent
+  case; the allowlist handles the shaped-but-disallowed case)."
   [uri]
-  (when (and uri js/window)
+  (when (and uri (editor-uri/allowed-uri? uri) js/window)
     (set! (.-location js/window) uri)
     nil))
 
@@ -80,8 +99,12 @@
   preference from `config/editor`; constructs the URI via
   `editor-uri/editor-uri`; click fires `window.location.href := uri`.
 
-  Returns nil when the source-coord has no usable `:file` slot — the
-  UI hides the chip rather than showing a no-op affordance.
+  Returns nil when the source-coord has no usable `:file` slot, when
+  `editor-uri/editor-uri` returns nil (a scheme rejected by the
+  `editor-uri`-side gate per rf2-vwcsq), or when the resolved URI's
+  scheme is not in `editor-uri/allowed-editor-uri-schemes` (the
+  shared positive allowlist per rf2-cm93v / rf2-p887o). The UI hides
+  the chip rather than rendering an unclickable affordance.
 
   `variant-of-style` is `:title` (default — for the canvas title bar)
   or `:test-detail` (for the per-test failure detail box, slightly
@@ -101,7 +124,7 @@
            style  (case variant-of-style
                     :test-detail (:chip-test chip-styles)
                     (:chip chip-styles))]
-       (when uri
+       (when (and uri (editor-uri/allowed-uri? uri))
          [:a {:style       style
               :href        uri
               :title       (editor-uri/open-button-title source-coord)

--- a/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
@@ -84,3 +84,53 @@
           props  (second hiccup)]
       (is (= "Open in editor — src/app.cljs:99"
              (:title props))))))
+
+;; ---- rf2-cm93v / rf2-p887o — Story-side allowlist behaviour -----------
+;;
+;; The matrix tests for `allowed-uri?` itself live in the shared editor-uri
+;; test ns. These cases cover the Story chip's wiring: the chip hides when
+;; a `{:custom ...}` template resolves to a disallowed scheme, and renders
+;; normally for safe ones — parity with Causa's surface (rf2-p887o).
+
+(deftest open-chip-hides-when-custom-template-resolves-to-unsafe-scheme
+  (testing "open-chip returns nil when the resolved URI's scheme is not
+            in `editor-uri/allowed-editor-uri-schemes`. Defense-in-depth
+            alongside the editor-uri-side javascript:/data:/vbscript:
+            reject from rf2-vwcsq — closes the http:/https:/etc. surface
+            an upstream {:custom ...} template could otherwise resolve
+            to."
+    ;; editor-uri/editor-uri already gates javascript:/data:/vbscript:
+    ;; — for these the chip is nil regardless of the allowlist. Verify
+    ;; those cases still hide.
+    (config/set-editor! {:custom "javascript:alert(1)"})
+    (is (nil? (open-in-editor/open-chip {:file "src/x.cljs"})))
+
+    (config/set-editor! {:custom "data:text/html,xxx"})
+    (is (nil? (open-in-editor/open-chip {:file "src/x.cljs"})))
+
+    ;; http: is NOT in editor-uri's reject list — the allowlist is
+    ;; the seam that catches it. Without rf2-p887o this used to render
+    ;; a clickable chip that would navigate the tab.
+    (config/set-editor! {:custom "http://evil.example/{path}"})
+    (is (nil? (open-in-editor/open-chip {:file "src/x.cljs"})))
+
+    ;; Same for https:
+    (config/set-editor! {:custom "https://evil.example/{path}"})
+    (is (nil? (open-in-editor/open-chip {:file "src/x.cljs"})))))
+
+(deftest open-chip-renders-when-custom-template-resolves-to-safe-scheme
+  (testing "open-chip renders normally when the resolved URI's scheme
+            is in `editor-uri/allowed-editor-uri-schemes`"
+    (config/set-editor! {:custom "subl://open?path={path}&line={line}"})
+    (let [hiccup (open-in-editor/open-chip {:file "src/x.cljs" :line 5})]
+      (is (vector? hiccup))
+      (is (= "subl://open?path=src/x.cljs&line=5" (:href (second hiccup)))))
+
+    (config/set-editor! {:custom "emacsclient://{path}"})
+    (is (some? (open-in-editor/open-chip {:file "src/x.cljs"})))))
+
+(deftest open-chip-for-variant-hides-on-unsafe-scheme
+  (testing "open-chip-for-variant inherits the allowlist gate"
+    (config/set-editor! {:custom "http://evil.example/{path}"})
+    (is (nil? (open-in-editor/open-chip-for-variant
+                {:source {:file "src/x.cljs" :line 1}})))))


### PR DESCRIPTION
## Summary

- Lift `allowed-editor-uri-schemes` + `allowed-uri?` from `day8.re-frame2-causa.open-in-editor` into the shared `re-frame.source-coords.editor-uri` ns. Both Story and Causa now consume the same predicate.
- Apply the allowlist gate at Story's `open!` and `open-chip` seams — previously Story relied only on `editor-uri`'s three-scheme blocklist (`javascript:`/`data:`/`vbscript:`), so a `{:custom \"http://evil.example/{path}\"}` template gave a silent tab-nav instead of a no-op.
- Move the allowlist matrix tests (JVM + CLJS smoke) into the shared `editor-uri` test files; leave chip-wiring tests in each tool's test ns and add Story-side allowlist-behaviour cases mirroring Causa's.

Pre-alpha: no back-compat shim — the Causa-local defs are deleted outright. Closes rf2-p887o.

## Files

- `implementation/core/src/re_frame/source_coords/editor_uri.cljc` — new home of `allowed-editor-uri-schemes` + `allowed-uri?`.
- `tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs` — duplicate defs removed; consume from shared ns.
- `tools/story/src/re_frame/story/ui/open_in_editor.cljs` — gate `open!` + `open-chip` on `editor-uri/allowed-uri?`.
- Tests moved/added under `implementation/core/test/` + `tools/story/test/`; reduced under `tools/causa/test/`.

## Test plan

- [x] `npm run test:cljs` (1983 tests / 5634 assertions; 0 failures)
- [x] `npm run test:bundle-isolation` (PASS)
- [x] `npm run test:elision` (PASS)
- [x] `clojure -M:test --namespace re-frame.source-coords-editor-uri-test` (35 tests / 117 assertions; 0 failures)