### PR TITLE
fix(causa-open-in-editor): wire panel clicks through open-chip allowlist (rf2-g5q8d, P0)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs
@@ -1,15 +1,36 @@
 (ns day8.re-frame2-causa.open-in-editor
-  "Causa-side 'Open in editor' chip (rf2-evgf5).
+  "Causa-side 'Open in editor' affordance (rf2-evgf5, rf2-g5q8d).
 
-  Mirrors `re-frame.story.ui.open-in-editor` — same affordance shape,
-  reads Causa's editor preference from `day8.re-frame2-causa.config`.
+  Mirrors `re-frame.story.ui.open-in-editor` — same chip shape, reads
+  Causa's editor preference from `day8.re-frame2-causa.config`.
 
-  Per the bead's scope expansion (2026-05-13): Causa panels that
-  display a source-coord (event-detail hero, six-domino cascade,
-  machine inspector state/edge/guard/action, hydration debugger, etc.)
-  wrap the coord in a clickable chip that launches the user's editor
-  at file:line. Phase 1 ships the helper + the shell-stub demo
-  surface; the live panels consume this in subsequent phases.
+  This ns owns three surfaces:
+
+    1. `open-chip` — render an `<a>` hiccup chip for a source-coord.
+       Used by demo surfaces + any panel that wants the chip's exact
+       presentation. The `:on-click` fires the OS scheme handler
+       directly via `window.location`.
+
+    2. `:rf.causa/open-in-editor` reg-event-fx — the panel-side
+       dispatch shape (`[:rf.causa/open-in-editor coord]` or
+       `[:rf.causa/open-in-editor {:source-coord coord}]`). Panels
+       render their own button/code/span affordance and dispatch this
+       event; the trace bus then captures the click as a first-class
+       observable operation under the `:rf/causa` frame. The handler
+       returns an effect map that fires `:rf.editor/open` with the
+       resolved URI.
+
+    3. `:rf.editor/open` reg-fx — the side-effectful launcher. Resolves
+       the URI from the source-coord against `config/get-editor`,
+       applies the rf2-cm93v positive allowlist, then sets
+       `window.location.href`. Standalone so non-Causa callers (e.g. a
+       future test-mode shortcut, MCP-side open-uri replay) can share
+       the gate.
+
+  Per rf2-g5q8d (P0 — the panel chip was a no-op previously). The
+  earlier wiring routed clicks to a stub `reg-event-db` that recorded
+  the coord into app-db and did nothing else; this ns now owns the
+  full data-driven path end-to-end.
 
   ## Defense-in-depth scheme allowlist (rf2-cm93v / rf2-p887o)
 
@@ -28,7 +49,9 @@
 
   The allowlist itself lives in the shared `editor-uri` ns (rf2-p887o)
   so Story consumes the same predicate Causa does."
-  (:require [day8.re-frame2-causa.config :as config]
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [day8.re-frame2-causa.config :as config]
             [re-frame.source-coords.editor-uri :as editor-uri]))
 
 ;; ---- styling -------------------------------------------------------------
@@ -51,9 +74,79 @@
           :display         "inline-block"
           :line-height     "16px"}})
 
+;; ---- pure: resolve a source-coord to a launchable URI -------------------
+
+(defn- parse-file-line
+  "Parse a `\"file:line\"` (or bare `\"file\"`) display string into the
+  structured source-coord map shape `editor-uri/editor-uri` expects.
+
+  Three panel-side projection helpers (trace_helpers, issues_ribbon_
+  helpers, mcp_server_helpers) flatten the structured coord to a
+  display string at projection time so the row's chip can render it.
+  When the user clicks the chip, the dispatch ships that display
+  string — the handler has to walk back to the structured form to
+  build the editor URI.
+
+  The fallback split is on the LAST `:` so a Windows-style
+  `\"C:/users/.../x.cljs:42\"` parses correctly (drive-letter colon
+  stays with the path). Returns `{:file ... :line <int-or-nil>}` —
+  `:column` falls through to `editor-uri`'s default of 1."
+  [s]
+  (when (and (string? s) (not (str/blank? s)))
+    (let [trimmed  (str/triml s)
+          colon-ix (str/last-index-of trimmed ":")
+          tail     (when (and colon-ix (pos? colon-ix))
+                     (subs trimmed (inc colon-ix)))]
+      (if (and tail (seq tail) (re-matches #"\d+" tail))
+        {:file (subs trimmed 0 colon-ix)
+         :line (js/parseInt tail 10)}
+        {:file trimmed}))))
+
+(defn- coerce-coord
+  "Normalise the dispatch payload to a structured source-coord map.
+
+  Accepts (in order of preference):
+
+    - A bare structured map `{:file ... :line ...}` (the hydration
+      debugger panel's dispatch shape).
+    - A wrapper map `{:source-coord <coord>}` where `<coord>` is
+      either a structured map OR a `\"file:line\"` display string
+      (the trace / issues-ribbon / mcp-server panels' dispatch
+      shape — projection helpers flatten the coord at row-projection
+      time so the chip can render `\"x.cljs:42\"`).
+    - A bare display string `\"file:line\"` (defensive — no panel
+      currently dispatches this directly, but the parser handles it).
+
+  Returns the map form; callers feed it to `editor-uri/editor-uri`
+  unchanged."
+  [payload]
+  (let [unwrapped (if (and (map? payload) (contains? payload :source-coord))
+                    (:source-coord payload)
+                    payload)]
+    (cond
+      (map? unwrapped)    unwrapped
+      (string? unwrapped) (parse-file-line unwrapped)
+      :else               nil)))
+
+(defn resolve-uri
+  "Pure-data: source-coord → launchable URI string, or nil. Returns nil
+  when the coord lacks `:file`, when `editor-uri/editor-uri` returns nil
+  (a forbidden scheme per rf2-vwcsq), or when the resolved URI's scheme
+  is outside `editor-uri/allowed-editor-uri-schemes` (the shared
+  positive allowlist per rf2-cm93v / rf2-p887o).
+
+  The chip render path and the `:rf.editor/open` reg-fx both call this
+  — one source of truth for the URI shape across the data path and the
+  side-effect path."
+  [source-coord]
+  (when (editor-uri/has-source? source-coord)
+    (let [uri (editor-uri/editor-uri (config/get-editor) source-coord)]
+      (when (and uri (editor-uri/allowed-uri? uri))
+        uri))))
+
 ;; ---- side-effect: open the editor ----------------------------------------
 
-(defn- open!
+(defn open!
   "Set `window.location.href` to `uri`. Custom URI schemes hand off to
   the OS handler chain. Returns nothing.
 
@@ -65,9 +158,12 @@
   `{:custom ...}` template could otherwise resolve to. A rejected URI
   is a click-time no-op (no navigation, no console noise — the chip's
   `(when uri ...)` earlier guard handles the absent case; the
-  allowlist handles the shaped-but-disallowed case)."
+  allowlist handles the shaped-but-disallowed case).
+
+  Public so the `:rf.editor/open` reg-fx (registered in `install!`) can
+  share the exact same gate the in-DOM chip uses."
   [uri]
-  (when (and uri (editor-uri/allowed-uri? uri) js/window)
+  (when (and uri (editor-uri/allowed-uri? uri) (exists? js/window))
     (set! (.-location js/window) uri)
     nil))
 
@@ -90,22 +186,91 @@
   events it buffers (`:source-coord` slot) and on the registry's
   `(rf/handler-meta kind id)` reads."
   [source-coord]
-  (when (editor-uri/has-source? source-coord)
-    (let [editor (config/get-editor)
-          uri    (editor-uri/editor-uri editor source-coord)]
-      (when (and uri (editor-uri/allowed-uri? uri))
-        [:a {:style       (:chip chip-styles)
-             :href        uri
-             :title       (editor-uri/open-button-title source-coord)
-             :data-testid "causa-open-in-editor"
-             :data-editor (cond
-                            (map? editor) "custom"
-                            :else         (name editor))
-             :on-click    (fn [e]
-                            ;; Stop the browser from trying to render
-                            ;; the custom URI inline; fire the handoff
-                            ;; explicitly so the OS scheme handler
-                            ;; dispatches.
-                            (.preventDefault e)
-                            (open! uri))}
-         "open"]))))
+  (when-let [uri (resolve-uri source-coord)]
+    (let [editor (config/get-editor)]
+      [:a {:style       (:chip chip-styles)
+           :href        uri
+           :title       (editor-uri/open-button-title source-coord)
+           :data-testid "causa-open-in-editor"
+           :data-editor (cond
+                          (map? editor) "custom"
+                          :else         (name editor))
+           :on-click    (fn [e]
+                          ;; Stop the browser from trying to render
+                          ;; the custom URI inline; fire the handoff
+                          ;; explicitly so the OS scheme handler
+                          ;; dispatches.
+                          (.preventDefault e)
+                          (open! uri))}
+       "open"])))
+
+;; ---- registration: the data-driven open-in-editor path ------------------
+
+(defn install!
+  "Idempotent install for the panel-side dispatch wiring (rf2-g5q8d).
+
+  Registers two framework primitives:
+
+    - `:rf.causa/open-in-editor` reg-event-fx — the dispatch shape the
+      four panels (trace, issues-ribbon, mcp-server, hydration-
+      debugger) use when their source-coord affordance is clicked.
+      The handler unwraps the payload, resolves the URI, and returns
+      `{:fx [[:rf.editor/open {:uri ...}]]}`. The dispatch lands in
+      the trace bus as a first-class observable operation under the
+      `:rf/causa` frame — agents reading the buffer see the click as
+      `{:operation :rf.causa/open-in-editor :tags {:frame :rf/causa}
+        ...}` rather than as a silent `window.location` write.
+
+    - `:rf.editor/open` reg-fx — the side-effectful launcher. Calls
+      `open!` (which applies the rf2-cm93v allowlist + writes
+      `window.location.href`). Lives under the `:rf.editor/*` prefix
+      rather than `:rf.causa.fx/*` because the gate is editor-related,
+      not Causa-specific — a future Story / pair2 caller can fire
+      `[:rf.editor/open {:uri ...}]` and share the same allowlist
+      seam.
+
+  Called from `registry.cljs/register-causa-handlers!` alongside the
+  per-panel `install!` fns."
+  []
+  ;; ---- :rf.editor/open ----
+  ;;
+  ;; The side-effect handler. Two arg shapes are accepted:
+  ;;
+  ;;   {:uri "vscode://..."}                — pre-resolved URI
+  ;;   {:source-coord {:file ... :line ...}} — resolve via
+  ;;                                            `resolve-uri` first
+  ;;
+  ;; The pre-resolved form is the canonical shape the
+  ;; `:rf.causa/open-in-editor` event-fx emits (handler does the
+  ;; resolution); the `:source-coord` form is a convenience for
+  ;; callers that want one-step dispatch and don't need the resolve
+  ;; step visible in the trace.
+  (rf/reg-fx :rf.editor/open
+    (fn [_ctx args]
+      (let [uri (or (:uri args)
+                    (when-let [coord (:source-coord args)]
+                      (resolve-uri coord)))]
+        (open! uri))))
+
+  ;; ---- :rf.causa/open-in-editor ----
+  ;;
+  ;; Pre-rf2-g5q8d this was a `reg-event-db` stub that recorded the
+  ;; coord into app-db and did nothing else; the editor never opened.
+  ;; The handler now resolves the URI through the allowlist seam and
+  ;; routes it to `:rf.editor/open`.
+  ;;
+  ;; The handler does NOT write to `db` — the click is a pure
+  ;; navigation, not a state transition. Per Spec 002 §Effect map
+  ;; shape, omitting `:db` from the return leaves Causa's app-db
+  ;; untouched. The trace bus still records the dispatch so the
+  ;; "click → open" trail is observable.
+  (rf/reg-event-fx :rf.causa/open-in-editor
+    (fn [_ctx [_event-id payload]]
+      (let [coord (coerce-coord payload)
+            uri   (resolve-uri coord)]
+        ;; Always emit the fx — even when uri is nil. `open!` is a
+        ;; no-op for nil, and routing through the fx (rather than
+        ;; short-circuiting in the handler) keeps the side-effect
+        ;; bookkeeping in one place + makes the fx the single
+        ;; instrumentable seam for replay/dev-tools.
+        {:fx [[:rf.editor/open {:uri uri}]]}))))

--- a/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger.cljs
@@ -554,11 +554,10 @@
         (dissoc db :hydration-reroot-path)
         (assoc db :hydration-reroot-path (vec path)))))
 
-  ;; Open-in-editor stub. The full handler lives in
-  ;; `open-in-editor.cljs` (rf2-evgf5); this event-db is a thin
-  ;; record-the-attempt so the panel can surface a UX cue when the
-  ;; user clicks a source-coord. The actual editor jump runs via
-  ;; the open-in-editor module's effect when wired.
-  (rf/reg-event-db :rf.causa/open-in-editor
-    (fn [db [_ coord]]
-      (assoc db :last-open-in-editor-coord coord))))
+  ;; `:rf.causa/open-in-editor` lives in
+  ;; `day8.re-frame2-causa.open-in-editor/install!` (rf2-g5q8d) — the
+  ;; cross-panel dispatch shape used by trace, issues-ribbon,
+  ;; mcp-server, and this panel routes through the shared event-fx +
+  ;; `:rf.editor/open` fx pair so every click resolves through the
+  ;; same rf2-cm93v allowlist seam.
+  )

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -33,6 +33,7 @@
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-causa.defaults :as defaults]
+            [day8.re-frame2-causa.open-in-editor :as open-in-editor]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.ai-co-pilot :as ai-co-pilot]
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
@@ -237,7 +238,15 @@
     ;; `panels/<panel>.cljs` under `(defn install! [] ...)`. Order is
     ;; alphabetised — re-frame resolves `:<-` chains lazily at
     ;; subscribe time so registration order is purely cosmetic.
+    ;;
+    ;; The open-in-editor install is cross-panel — its
+    ;; `:rf.causa/open-in-editor` event-fx + `:rf.editor/open` fx are
+    ;; dispatched from trace, issues-ribbon, mcp-server, and the
+    ;; hydration debugger (rf2-g5q8d). Installed alongside the
+    ;; per-panel installs so the registration order matches the
+    ;; per-panel pattern.
 
+    (open-in-editor/install!)
     (ai-co-pilot/install!)
     (app-db-diff/install!)
     (causality-graph/install!)

--- a/tools/causa/test/day8/re_frame2_causa/open_in_editor_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/open_in_editor_cljs_test.cljs
@@ -1,5 +1,6 @@
 (ns day8.re-frame2-causa.open-in-editor-cljs-test
-  "CLJS smoke tests for Causa's 'Open in editor' chip (rf2-evgf5).
+  "CLJS smoke tests for Causa's 'Open in editor' surface (rf2-evgf5,
+  rf2-g5q8d).
 
   The URI math + the scheme allowlist live in
   `re-frame.source-coords.editor-uri` and are matrix-tested at the
@@ -13,16 +14,41 @@
   - The chip carries `data-testid=\"causa-open-in-editor\"` so the
     e2e suite can target it.
   - `open-chip` hides when a `{:custom ...}` template resolves to a
-    scheme outside `editor-uri/allowed-editor-uri-schemes`."
+    scheme outside `editor-uri/allowed-editor-uri-schemes`.
+  - rf2-g5q8d — `:rf.causa/open-in-editor` reg-event-fx produces a
+    `:rf.editor/open` fx with a URI resolved through the rf2-cm93v
+    allowlist; runs on the `:rf/causa` frame without contaminating
+    the host."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.config :as config]
-            [day8.re-frame2-causa.open-in-editor :as open-in-editor]))
+            [day8.re-frame2-causa.open-in-editor :as open-in-editor]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
 (defn reset-editor! []
   (config/set-editor! :vscode))
 
-(use-fixtures :each {:before reset-editor!
-                     :after  reset-editor!})
+;; Combined per-test fixture: resets the re-frame runtime (so each
+;; rf2-g5q8d test below sees a clean registrar + frame table) AND the
+;; editor preference (so the chip-render tests above see :vscode). The
+;; chip-render tests don't drive the runtime, so they pay only the
+;; cheap snapshot/restore cost; the rf2-g5q8d tests below need the
+;; clean runtime so registrations don't bleed between tests.
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!)
+  (reset-editor!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
 
 (deftest open-chip-renders-anchor-with-href
   (testing "open-chip returns an <a> hiccup vector when source has :file"
@@ -106,3 +132,191 @@
 
     (config/configure! {:editor {:custom "emacsclient://{path}"}})
     (is (some? (open-in-editor/open-chip {:file "src/x.cljs"})))))
+
+;; ---- rf2-g5q8d — :rf.causa/open-in-editor + :rf.editor/open ------------
+;;
+;; Per the rf2-3vucz audit, the four Causa panels (trace, issues-ribbon,
+;; mcp-server, hydration-debugger) dispatch `[:rf.causa/open-in-editor
+;; coord]` when their source-coord affordance is clicked. Pre-rf2-g5q8d
+;; the handler was a stub reg-event-db that recorded the coord into
+;; app-db and never opened anything — load-bearing UX silently broken.
+;;
+;; The block below pins the contract of the rewired event-fx + fx pair:
+;;
+;;   1. Dispatching the event produces a `:rf.editor/open` fx whose
+;;      `:uri` resolves through `resolve-uri` (= rf2-cm93v allowlist).
+;;   2. Both dispatch shapes are accepted: the bare-coord form (the
+;;      hydration debugger's call site) and the `{:source-coord ...}`
+;;      wrapper form (the other three panels' call site).
+;;   3. A coord whose resolved URI is rejected by the allowlist (custom
+;;      `javascript:` / `data:` / `http:` template) yields a fx whose
+;;      `:uri` is nil — the side-effect fx is a no-op for nil.
+;;   4. The handler runs on Causa's `:rf/causa` frame (per the panels'
+;;      `{:frame :rf/causa}` dispatch opts); Causa's app-db is NOT
+;;      written (the click is pure navigation).
+
+(defonce ^:private captured-editor-fx (atom []))
+
+(defn- setup!
+  "Per-test bootstrap shared by every rf2-g5q8d test: register Causa's
+  handlers, allocate the `:rf/causa` frame, and replace the
+  `:rf.editor/open` reg-fx with a capture stub so assertions can
+  inspect the fx args without touching `window.location`. Mirrors the
+  fx-replacement pattern in `time_travel_cljs_test.cljs`."
+  []
+  (reset! captured-editor-fx [])
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {})
+  (rf/reg-fx :rf.editor/open
+    (fn [_ctx args] (swap! captured-editor-fx conj args))))
+
+(deftest open-in-editor-event-emits-fx-with-resolved-uri
+  (testing "rf2-g5q8d — dispatching `:rf.causa/open-in-editor` with
+            a bare coord (the hydration-debugger shape) produces a
+            `:rf.editor/open` fx whose :uri is the resolved URI"
+    (setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/open-in-editor
+                         {:ns 'app.events :file "src/app/events.cljs"
+                          :line 17 :column 3}])
+      (is (= 1 (count @captured-editor-fx))
+          "exactly one open-fx fires per dispatch")
+      (is (= "vscode://file/src/app/events.cljs:17:3"
+             (:uri (first @captured-editor-fx)))
+          "the resolved vscode:// URI rides on the fx args"))))
+
+(deftest open-in-editor-event-accepts-wrapped-shape
+  (testing "rf2-g5q8d — dispatching with `{:source-coord coord}` (the
+            trace / issues-ribbon / mcp-server panels' shape) produces
+            the same fx as the bare-coord form"
+    (setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/open-in-editor
+                         {:source-coord {:file "src/x.cljs" :line 5 :column 1}}])
+      (is (= "vscode://file/src/x.cljs:5:1"
+             (:uri (first @captured-editor-fx)))
+          "the wrapper shape unwraps + resolves the same way"))))
+
+(deftest open-in-editor-event-parses-display-string-coord
+  (testing "rf2-g5q8d — the three trace-style panels (trace, issues-
+            ribbon, mcp-server) project the structured coord to a
+            `\"file:line\"` display string at projection time; the
+            handler parses the display string back to the structured
+            form so the URI build works end-to-end. This is the
+            single-failure path that landed the load-bearing UX in
+            the rf2-3vucz audit."
+    (setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/open-in-editor
+                         {:source-coord "src/app/events.cljs:42"}])
+      (is (= "vscode://file/src/app/events.cljs:42:1"
+             (:uri (first @captured-editor-fx)))
+          "display string parses to `:file` + `:line`; `:column`
+           falls through to the editor-uri builder's default of 1"))))
+
+(deftest open-in-editor-event-parses-bare-display-string
+  (testing "rf2-g5q8d — defensive shape: bare display string with no
+            wrapper map (no panel does this today; handler accepts it
+            for future callers that don't wrap)"
+    (setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/open-in-editor "src/x.cljs:7"])
+      (is (= "vscode://file/src/x.cljs:7:1"
+             (:uri (first @captured-editor-fx)))))))
+
+(deftest open-in-editor-event-display-string-without-line
+  (testing "rf2-g5q8d — display string with no trailing line number
+            (degenerate: the projection helpers always include line,
+            but the parser falls through gracefully to `{:file <s>}`)"
+    (setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/open-in-editor
+                         {:source-coord "src/x.cljs"}])
+      (is (= "vscode://file/src/x.cljs:1:1"
+             (:uri (first @captured-editor-fx)))
+          "`:line` defaults to 1 via editor-uri"))))
+
+(deftest open-in-editor-event-honours-editor-preference
+  (testing "rf2-g5q8d — the fx's URI reflects `config/get-editor`
+            (the same source of truth the chip render uses)"
+    (setup!)
+    (config/set-editor! :cursor)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/open-in-editor
+                         {:file "src/x.cljs" :line 10}])
+      (is (= "cursor://file/src/x.cljs:10:1"
+             (:uri (first @captured-editor-fx)))))))
+
+(deftest open-in-editor-event-rejects-javascript-scheme
+  (testing "rf2-g5q8d / rf2-cm93v — a custom template that resolves to
+            `javascript:` is rejected at the handler seam. The
+            editor-uri-side gate (rf2-vwcsq) returns nil; the fx
+            receives nil and is a no-op. Defense-in-depth — the test
+            pins the contract even though the editor-uri gate fires
+            first."
+    (setup!)
+    (config/configure! {:editor {:custom "javascript:alert(1)"}})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/open-in-editor
+                         {:file "src/x.cljs" :line 1}])
+      (is (= 1 (count @captured-editor-fx))
+          "fx still fires — the handler doesn't short-circuit")
+      (is (nil? (:uri (first @captured-editor-fx)))
+          "the resolved URI is nil — `open!` will refuse to navigate"))))
+
+(deftest open-in-editor-event-rejects-http-scheme
+  (testing "rf2-g5q8d / rf2-cm93v — a custom template that resolves to
+            `http:` is rejected by the Causa-side positive allowlist
+            (http: is NOT in the editor-uri-side reject list, so this
+            is the seam that catches it)"
+    (setup!)
+    (config/configure! {:editor {:custom "http://evil.example/{path}"}})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/open-in-editor
+                         {:file "src/x.cljs" :line 1}])
+      (is (nil? (:uri (first @captured-editor-fx)))
+          "http: is outside `allowed-editor-uri-schemes`"))))
+
+(deftest open-in-editor-event-runs-on-causa-frame-without-host-contamination
+  (testing "rf2-g5q8d — the handler doesn't write to Causa's app-db
+            (no `:db` in the returned effect map). The click is pure
+            navigation; no host-frame escape, no Causa-frame state
+            pollution."
+    (setup!)
+    (rf/with-frame :rf/causa
+      (let [pre-db (frame/frame-app-db-value :rf/causa)]
+        (rf/dispatch-sync [:rf.causa/open-in-editor
+                           {:file "src/x.cljs" :line 1}])
+        (let [post-db (frame/frame-app-db-value :rf/causa)]
+          (is (= pre-db post-db)
+              "Causa's app-db is untouched by the click — no
+               `:last-open-in-editor-coord` etc. (the prior stub
+               reg-event-db's behaviour, removed by rf2-g5q8d)"))))))
+
+(deftest open-in-editor-fx-receives-uri-key-not-source-coord
+  (testing "rf2-g5q8d — `:rf.editor/open` invoked via the canonical
+            pre-resolved shape `{:uri \"...\"}`. The handler in this
+            test is the capture stub; the assertion here pins the
+            contract that the producer event-fx passes a `:uri` key
+            (vs `:source-coord`)."
+    (setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/open-in-editor
+                         {:file "src/x.cljs" :line 1}])
+      (is (contains? (first @captured-editor-fx) :uri)
+          "fx arg shape: `{:uri <string-or-nil>}`")
+      (is (not (contains? (first @captured-editor-fx) :source-coord))
+          "the resolve step happens in the event-fx, not the fx"))))
+
+(deftest open-in-editor-event-resolves-through-shared-resolve-uri-helper
+  (testing "rf2-g5q8d — the event-fx's URI matches what `open-chip`
+            renders for the same coord (one source of truth for URI
+            resolution + allowlist gating across the data path and
+            the side-effect path)"
+    (setup!)
+    (let [coord {:file "src/app/events.cljs" :line 42 :column 7}]
+      (rf/with-frame :rf/causa
+        (rf/dispatch-sync [:rf.causa/open-in-editor coord]))
+      (is (= (:href (second (open-in-editor/open-chip coord)))
+             (:uri (first @captured-editor-fx)))
+          "chip's :href ≡ fx's :uri"))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -220,7 +220,12 @@
 (def ^:private all-fx-names
   [:rf.causa.fx/copy-to-clipboard
    :rf.causa.fx/reset-frame-db!
-   :rf.causa.fx/restore-epoch])
+   :rf.causa.fx/restore-epoch
+   ;; rf2-g5q8d — cross-panel open-in-editor side-effect. Lives under
+   ;; the editor-generic `:rf.editor/*` prefix rather than `:rf.causa.fx/*`
+   ;; because the rf2-cm93v allowlist seam is editor-related, not
+   ;; Causa-specific.
+   :rf.editor/open])
 
 ;; ---- (1) smoke: every registered name resolves -------------------------
 
@@ -246,7 +251,7 @@
           (str "expected :fx handler for " fx-id)))))
 
 (deftest registry-counts-match-bead
-  (testing "registry holds exactly 65 subs + 64 events + 3 fxs"
+  (testing "registry holds exactly 65 subs + 64 events + 4 fxs"
     (is (= 65 (count all-sub-names)))
     ;; 64 events = 60 baseline + rf2-13bx9's :rf.causa/set-target-frame
     ;; (companion to time-travel's :rf.causa/target-frame sub; consumed
@@ -256,7 +261,12 @@
     ;; that keep `:trace-buffer` on `:rf/causa`'s app-db in lockstep
     ;; with the trace-bus atom.
     (is (= 64 (count all-event-names)))
-    (is (= 3  (count all-fx-names)))))
+    ;; 4 fxs = 3 baseline (`:rf.causa.fx/copy-to-clipboard`,
+    ;; `:rf.causa.fx/reset-frame-db!`, `:rf.causa.fx/restore-epoch`)
+    ;; + rf2-g5q8d's `:rf.editor/open` (cross-panel open-in-editor
+    ;; launcher; lives under the editor-generic prefix because the
+    ;; rf2-cm93v allowlist is editor-related, not Causa-specific).
+    (is (= 4  (count all-fx-names)))))
 
 (deftest registry-is-idempotent
   (testing "calling register-causa-handlers! twice is a no-op (same handler instance)"
@@ -945,13 +955,33 @@
       (rf/dispatch-sync [:rf.causa/dismiss-pin-overflow-toast])
       (is (nil? (:pin-overflow-toast (frame/frame-app-db-value :rf/causa)))))))
 
-(deftest event-open-in-editor-records-coord
-  (testing ":rf.causa/open-in-editor stores the last attempted coord"
+(deftest event-open-in-editor-routes-through-editor-fx
+  (testing "rf2-g5q8d — `:rf.causa/open-in-editor` is now a reg-event-fx
+            that resolves the coord through the rf2-cm93v allowlist and
+            fires `:rf.editor/open`. It does NOT write to app-db (the
+            click is pure navigation; the prior stub's
+            `:last-open-in-editor-coord` slot is gone). Detailed
+            contract assertions live in `open_in_editor_cljs_test.cljs`;
+            here we pin the registry-level shape only."
     (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/open-in-editor "file://foo.cljs:10:5"])
-      (is (= "file://foo.cljs:10:5"
-             (:last-open-in-editor-coord (frame/frame-app-db-value :rf/causa)))))))
+    (let [captured (atom [])]
+      ;; Replace the open fx with a capture stub (same pattern as the
+      ;; time-travel reg-fx tests above).
+      (rf/reg-fx :rf.editor/open
+        (fn [_ctx args] (swap! captured conj args)))
+      (rf/with-frame :rf/causa
+        (rf/dispatch-sync [:rf.causa/open-in-editor
+                           {:file "src/x.cljs" :line 10 :column 5}])
+        (is (= 1 (count @captured))
+            "the event-fx emits exactly one :rf.editor/open fx")
+        (is (= "vscode://file/src/x.cljs:10:5"
+               (:uri (first @captured)))
+            "the fx carries the resolved URI")
+        (is (nil? (:last-open-in-editor-coord
+                    (frame/frame-app-db-value :rf/causa)))
+            "Causa's app-db is NOT written — the stub's
+             `:last-open-in-editor-coord` slot is intentionally
+             gone (rf2-g5q8d)")))))
 
 ;; ---- (5) test-only override events --------------------------------------
 


### PR DESCRIPTION
## Summary

The four Causa panels (trace, issues-ribbon, mcp-server, hydration-debugger) rendered a source-coord affordance that dispatched `[:rf.causa/open-in-editor coord]`. The handler was a stub `reg-event-db` that recorded the coord into app-db and did NOTHING else — clicking the chip never opened the editor. Discovered in the rf2-3vucz click-to-source audit ([ai/findings/source-coord-clickability-audit-2026-05-14.md](https://github.com/day8/re-frame2/blob/main/ai/findings/source-coord-clickability-audit-2026-05-14.md)); load-bearing UX silently broken across the panel surface.

**Approach A (per bead): keep the data-driven dispatch shape, fix the handler internally.** The dispatch sites in the four panels are unchanged; the click is now a first-class observable operation in the Causa trace bus under the `:rf/causa` frame.

## Changes

- `tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs` — new `install!` registers `:rf.causa/open-in-editor` as a `reg-event-fx` + `:rf.editor/open` as a `reg-fx`. The event-fx coerces the payload to a structured coord (accepts bare map / `{:source-coord ...}` wrapper / `"file:line"` display string — the projection helpers in `trace_helpers` / `issues_ribbon_helpers` / `mcp_server_helpers` flatten the coord to a display string at row-projection time, so the handler walks back to the structured form), resolves the URI via `editor-uri/editor-uri`, applies the rf2-cm93v positive allowlist via `resolve-uri`, and routes `{:uri ...}` to `:rf.editor/open`. The fx calls `open!` (the existing helper) which re-applies the allowlist + writes `window.location.href`.

- `panels/hydration_debugger.cljs:557-564` — drop the stub `reg-event-db`. The cross-panel handler now lives in `open_in_editor.cljs`.

- `registry.cljs` — orchestrator calls `open-in-editor/install!` alongside the per-panel installs.

- `open_in_editor_cljs_test.cljs` — 11 new deftests pin the contract.

- `registry_cljs_test.cljs` — replace the stub-pinning test with the new fx-routing contract; bump fx count 3 → 4.

The fx lives under the editor-generic `:rf.editor/*` prefix (vs `:rf.causa.fx/*`) so a future Story / pair2 caller can share the same allowlist seam.

## Audit evidence

Per the rf2-3vucz audit, the four broken panel call sites are:
- `panels/trace.cljs:307-320`
- `panels/issues_ribbon.cljs:261-278`
- `panels/mcp_server.cljs:343-358`
- `panels/hydration_debugger.cljs:298-308`

All four route to the rewired handler now. The stub at `panels/hydration_debugger.cljs:562-564` is deleted.

## Test plan

- [x] Unit: dispatching `[:rf.causa/open-in-editor coord]` produces a `:rf.editor/open` fx with a valid URI per the rf2-cm93v allowlist
- [x] Unit: both dispatch shapes accepted (bare coord / `{:source-coord ...}` wrapper / display-string)
- [x] Reject: malicious coord with `javascript:` scheme → fx receives `:uri nil` (defense-in-depth — `open-chip`'s allowlist enforces, but the handler test pins the contract)
- [x] Reject: custom template resolving to `http:` → fx receives `:uri nil` (Causa-side positive allowlist is the seam that catches it; editor-uri-side reject list doesn't)
- [x] Frame containment: handler runs on `:rf/causa` frame; Causa's app-db is NOT written (no `:db` in the effect map; the prior stub's `:last-open-in-editor-coord` slot is gone)
- [x] Fx-arg shape: `{:uri "..."}` (resolve step happens in the event-fx, not the fx)
- [x] Equivalence: `open-chip`'s rendered `:href` ≡ event-fx's emitted `:uri` (single source of truth for URI resolution)
- [x] `npm run test:cljs` — 1999/0 (+11 from 1988 baseline)
- [x] `npm run test:bundle-isolation` — PASS

## End-to-end verifiability

The click-to-editor path is now end-to-end-verifiable in dev: open Causa, click any source-coord chip in any of the four panels, and the OS scheme handler launches the configured editor at file:line. The earlier behaviour was a silent `:last-open-in-editor-coord` app-db write with no editor launch.