### PR TITLE
feat(pair2-mcp): source-coord URIs + handler-meta + registry-list (rf2-cibp8+pctf8)

### DIFF
--- a/tools/pair2-mcp/deps.edn
+++ b/tools/pair2-mcp/deps.edn
@@ -29,11 +29,14 @@
 ;; ## Bundle isolation
 ;;
 ;; Per tools/README.md the dependency arrow flows tool → implementation
-;; (and never the reverse). This artefact has no `:local/root` dep on
-;; `implementation/` because it does not :require any re-frame2 source:
-;; it terminates the agent host's stdio channel and bridges to a
-;; separately-running re-frame app's nREPL socket. The runtime injection
-;; (`runtime.cljs`) ships from the pair2 skill, not from here.
+;; (and never the reverse). This artefact carries a thin `:local/root`
+;; dep on `implementation/core` (rf2-cibp8) so the wire-pipeline's
+;; source-URI decorator can `:require` the pure-data
+;; `re-frame.source-coords.editor-uri` ns. Nothing else from
+;; implementation/core is consumed by the server bundle — the require
+;; graph is shallow (editor-uri → clojure.string only). The runtime
+;; injection (`runtime.cljs`) still ships from the pair2 skill, not
+;; from here.
 ;;
 ;; ## Tests
 ;;
@@ -58,6 +61,13 @@
          ;; default-suppress filter, the path-keyed diff-encode, and
          ;; the overflow-marker shape. Per rf2-vw4sq.
          day8/re-frame2-mcp-base  {:local/root "../mcp-base"}
+
+         ;; implementation/core (rf2-cibp8) — pulled in for the pure-
+         ;; data `re-frame.source-coords.editor-uri` ns the wire-
+         ;; pipeline's source-URI decorator composes over. The require
+         ;; graph from editor-uri is shallow (clojure.string only); no
+         ;; Reagent / re-frame runtime classes land in the node bundle.
+         day8/re-frame2           {:local/root "../../implementation/core"}
 
          ;; day8/de-dupe — structural dedup of persistent data structures
          ;; (rf2-obpa9). The library substitutes repeated subtrees with

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/config.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/config.cljs
@@ -1,0 +1,69 @@
+(ns re-frame-pair2-mcp.config
+  "Runtime configuration for the pair2-mcp server (rf2-cibp8).
+
+  Phase 1 owns one concern: the 'Open in editor' preference that
+  controls the URI scheme attached to every `:source-coord` map crossing
+  the wire (rf2-cibp8).
+
+  ## Why a separate config ns
+
+  Mirrors `day8.re-frame2-causa.config/get-editor` and
+  `re-frame.story.config/get-editor` — every consumer of
+  `re-frame.source-coords.editor-uri/editor-uri` reads its preference
+  from a per-tool atom so hosts can run multiple tools side-by-side
+  with different editors. Pair2-mcp's user is the AI agent on the
+  other end of the stdio channel; the chosen editor governs the URI
+  shape the agent renders as a clickable link.
+
+  Default is `:vscode` — the most-installed editor in 2026 (Stack
+  Overflow Developer Survey 2025 + JetBrains DevEcosystem 2025 both
+  put it >70%) and the scheme every supported AI host recognises.
+
+  ## Configuration surface
+
+  Hosts pick the editor once at server start via the
+  `RE_FRAME_PAIR2_MCP_EDITOR` env var (read at namespace load) or
+  programmatically via `set-editor!`. The env-var path is the
+  expected onboarding flow — an MCP launcher script that already
+  wires `SHADOW_CLJS_BUILD_ID` adds one line:
+
+      RE_FRAME_PAIR2_MCP_EDITOR=cursor
+
+  ## Accepted values
+
+  Same vocabulary as the underlying `editor-uri/editor-uri`:
+  `:vscode` / `:cursor` / `:windsurf` / `:zed` / `:idea` plus the
+  `{:custom \"<uri-template>\"}` form. Unknown keywords fall through
+  to `:vscode` per the editor-uri ns's accommodating policy."
+  (:require [applied-science.js-interop :as j]))
+
+(def ^:private env-editor
+  "Editor keyword read from the `RE_FRAME_PAIR2_MCP_EDITOR` env var at
+  namespace load. Returns nil when unset / blank so the atom's default
+  (`:vscode`) wins."
+  (let [raw (j/get-in js/process [:env :RE_FRAME_PAIR2_MCP_EDITOR])]
+    (when (and (string? raw) (seq raw))
+      (keyword raw))))
+
+(defonce
+  ^{:doc "Atom holding pair2-mcp's 'Open in editor' preference. Default
+         `:vscode` (overridable via `RE_FRAME_PAIR2_MCP_EDITOR` at
+         server start). Accepts the keywords `:vscode` / `:cursor` /
+         `:windsurf` / `:zed` / `:idea` plus the
+         `{:custom \"<uri-template>\"}` form (see
+         `re-frame.source-coords.editor-uri/editor-uri`)."}
+  editor
+  (atom (or env-editor :vscode)))
+
+(defn set-editor!
+  "Replace pair2-mcp's 'Open in editor' preference. `nil` resets to
+  `:vscode`. Returns nothing — call for side-effect."
+  [e]
+  (reset! editor (or e :vscode))
+  nil)
+
+(defn get-editor
+  "Return the current editor preference. Read by the wire-pipeline's
+  source-URI decorator to build `:rf.source/uri` strings."
+  []
+  @editor)

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools.cljs
@@ -20,20 +20,24 @@
   | unsubscribe   | Close a streaming subscription                            |
   | subscription-info | List active streaming subscriptions + queue stats     |
   |               | (rf2-zjz9q)                                               |
+  | handler-meta  | Registration metadata for a (kind, id) — source-coord +   |
+  |               | :rf.source/uri (rf2-pctf8)                                |
+  | registry-list | All registered ids under a kind (rf2-pctf8)               |
   | get-pair2-instructions | Inline agent-onboarding text (rf2-fnpqg)         |
 
   ## Per-tool / per-concern layout (rf2-vrbwx, rf2-47g8l)
 
   This namespace is the public façade — `invoke` glue, internal
-  dispatch, and re-exported descriptor surface. The twelve tool bodies
-  and the seven cross-cutting concerns each live in `tools/<concern>`
-  or `tools/<tool>` files:
+  dispatch, and re-exported descriptor surface. The fourteen tool
+  bodies and the seven cross-cutting concerns each live in
+  `tools/<concern>` or `tools/<tool>` files:
 
   - Concerns: `wire`, `probe`, `cap`, `dedup`, `elision`, `sensitive`,
     `cursor`, `args`, `summary`, `snapshot-pipeline`, `boundary-step`.
   - Tools: `discover-app`, `eval-cljs`, `dispatch`, `trace-window`,
     `watch-epochs`, `tail-build`, `snapshot`, `get-path`, `subscribe`,
-    `unsubscribe`, `subscription-info`, `get-pair2-instructions`.
+    `unsubscribe`, `subscription-info`, `handler-meta`,
+    `registry-list`, `get-pair2-instructions`.
   - Descriptors: `descriptors-knobs` (universal knob property data),
     `descriptors-data` (per-tool descriptor maps), `descriptors`
     (`tool-descriptors-js` + the knob splicers).

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors_data.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors_data.cljs
@@ -351,6 +351,59 @@
                               :build  {:type "string"}}
                  :additionalProperties false}})
 
+(def handler-meta
+  {:name "handler-meta"
+   :description (str "Return the registration-metadata map for a registered "
+                     "handler — source-coord (file/line/column/ns), :doc, :tags, "
+                     "and any custom slots emitted by the reg-* macro. The wire "
+                     "pipeline (rf2-cibp8) decorates the :source-coord map with "
+                     "an :rf.source/uri string the AI host renders as a "
+                     "clickable jump-to-editor link. "
+                     "Use this when you know an id and want to find its "
+                     "definition without a wide-authority eval-cljs round-trip "
+                     "— `where is :user/login registered?`, `what does sub "
+                     ":current-user look like?`, `which file owns the :navigate "
+                     "fx?`. Supported kinds: event, sub, fx, cofx, view, frame, "
+                     "machine. The `machine` kind routes through "
+                     "(rf/machine-meta id) (Spec 005 §Querying machines); the "
+                     "other six route through (rf/handler-meta kind id). "
+                     "Returns `{:ok? true :kind k :id i ...meta...}` on a hit "
+                     "or `{:ok? false :reason :not-registered :kind k :id i}` "
+                     "when no slot matches.")
+   :typicalTokens 400
+   :inputSchema {:type "object"
+                 :properties {:kind {:type "string"
+                                     :description "Registrar kind. One of event, sub, fx, cofx, view, frame, machine."
+                                     :enum ["event" "sub" "fx" "cofx" "view" "frame" "machine"]}
+                              :id   {:type "string"
+                                     :description (str "EDN-encoded id, e.g. \":user/login\". For "
+                                                       "composite-key subs, pass the vector form "
+                                                       "as a string, e.g. \"[:rf/composite :x]\".")}
+                              :build {:type "string"}}
+                 :required ["kind" "id"]
+                 :additionalProperties false}})
+
+(def registry-list
+  {:name "registry-list"
+   :description (str "Return every registered id under a kind. The discovery "
+                     "surface — agents call this first to find out what's "
+                     "registered, then `handler-meta` to drill into a specific "
+                     "id. Supported kinds: event, sub, fx, cofx, view, frame, "
+                     "machine. The `machine` kind lists every event handler "
+                     "flagged `:rf/machine? true` via (rf/machines); the other "
+                     "six lift the id vector off the registrar's per-kind map. "
+                     "Returns `{:ok? true :kind k :ids [...] :count n}`. The "
+                     "id vector is sorted (string / keyword / symbol ordering) "
+                     "so the list shape is stable across calls.")
+   :typicalTokens 800
+   :inputSchema {:type "object"
+                 :properties {:kind {:type "string"
+                                     :description "Registrar kind. One of event, sub, fx, cofx, view, frame, machine."
+                                     :enum ["event" "sub" "fx" "cofx" "view" "frame" "machine"]}
+                              :build {:type "string"}}
+                 :required ["kind"]
+                 :additionalProperties false}})
+
 (def get-pair2-instructions
   {:name "get-pair2-instructions"
    :description (str "Return the pair2-mcp agent-onboarding text (rf2-fnpqg): tool catalogue, EDN posture, "

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/handler_meta.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/handler_meta.cljs
@@ -1,0 +1,241 @@
+(ns re-frame-pair2-mcp.tools.handler-meta
+  "Tools: handler-meta + registry-list (rf2-pctf8).
+
+  Direct introspection on the registrar — `where is `:user/login`
+  registered?` answered without a wide-authority `eval-cljs` round-trip.
+
+  ## handler-meta
+
+  Returns `(rf/handler-meta kind id)` for the requested
+  `(kind, id)` pair — the registration-metadata map carrying
+  `:source-coord` (file/line/column/ns), `:doc`, `:tags`, the registrar
+  kind, and (per Spec 001 §The public registrar query API) whatever
+  custom slots the `reg-*` macro emitted. The wire-pipeline (post-
+  rf2-cibp8) decorates every `:source-coord` map with an
+  `:rf.source/uri` string — so the AI host renders an immediate
+  jump-to-editor link off the handler-meta response.
+
+  Supported kinds: `event`, `sub`, `fx`, `cofx`, `view`, `frame`,
+  `machine`. The first six map directly to `rf/handler-meta`'s
+  registrar kinds; `machine` routes through the dedicated
+  `rf/machine-meta` surface (Spec 005 §Querying machines — machines
+  are registered as `:event` handlers carrying `:rf/machine? true`
+  with their spec in the `:rf/machine` slot, and `machine-meta`
+  unwraps that slot).
+
+  Returns `{:ok? false :reason :not-registered :kind k :id id}` when
+  no slot is found (so the agent gets a structured signal — same
+  shape `re-frame-pair2.runtime/registrar-describe` already uses).
+
+  ## registry-list
+
+  Returns the full set of registered ids for a kind — the discovery
+  surface. Agents call `registry-list {kind \"event\"}` first to find
+  out what's registered, then `handler-meta` to drill in.
+
+  For `event` / `sub` / `fx` / `cofx` / `view` / `frame` the list
+  comes from `re-frame-pair2.runtime/registrar-list`. For `machine`
+  the list comes from `re-frame.core/machines` — every event handler
+  flagged `:rf/machine? true`.
+
+  ## Why not `eval-cljs`?
+
+  `eval-cljs` is wide-authority by design (per `eval-cljs.cljs`'s
+  launch-flag gate). The pair2 contract is: structured tools for the
+  common case, eval-cljs for the unknown unknowns. `handler-meta` /
+  `registry-list` cover the most-frequent introspection asks
+  (\"where's X defined\", \"what's registered\") with a narrow surface
+  the agent can rely on across runtimes and editor-config postures."
+  (:require [clojure.string :as str]
+            [re-frame-pair2-mcp.nrepl :as nrepl]
+            [re-frame-pair2-mcp.tools.eval-form :as ef]
+            [re-frame-pair2-mcp.tools.wire :as wire]
+            [re-frame-pair2-mcp.tools.probe :as probe]))
+
+;; ---------------------------------------------------------------------------
+;; Kind normalisation.
+;;
+;; The MCP arg comes in as a JS string ("event", "sub", …). We coerce
+;; to the runtime keyword the registrar uses. `machine` is the one
+;; logical kind that doesn't map 1:1 to a registrar kind — it routes
+;; through `rf/machine-meta` instead.
+;; ---------------------------------------------------------------------------
+
+(def ^:private registrar-kinds
+  "Kinds that map directly to the registrar's `kind->id->metadata`
+  table. `machine` is intentionally absent — it routes through
+  `rf/machine-meta` (which inspects `:event`-kind metadata for the
+  `:rf/machine?` flag)."
+  #{:event :sub :fx :cofx :view :frame})
+
+(def ^:private supported-kinds
+  "The full set of kinds the tool accepts. Mirrors the bead's contract:
+  `event | sub | fx | cofx | view | machine | frame`."
+  (conj registrar-kinds :machine))
+
+(defn- parse-kind
+  "Coerce the `:kind` MCP arg to a keyword from `supported-kinds`, or
+  return `nil` if the value is missing / unrecognised. Accepts both
+  bare names (`\"event\"`) and EDN-shaped strings (`\":event\"`) — the
+  same accommodation the rest of the pair2-mcp args surface offers."
+  [s]
+  (when (and (string? s) (not (str/blank? s)))
+    (let [trimmed (str/triml s)
+          name    (if (str/starts-with? trimmed ":")
+                    (subs trimmed 1)
+                    trimmed)
+          k       (keyword name)]
+      (when (contains? supported-kinds k)
+        k))))
+
+(defn- parse-id
+  "Coerce the `:id` MCP arg to a CLJS value. The id is supplied as an
+  EDN-encoded string (`\":user/login\"`, `\"my.app/handler\"`,
+  `\"[:rf/composite \\\"x\\\"]\"`) so callers can pass any registered
+  id shape, including composite vectors used for sub-graph keys.
+
+  Returns `[:ok parsed]` on success or `[:err msg]` on a read failure.
+  A bare keyword-shaped string (leading `:`) round-trips through
+  `read-string`; a plain word like `\"foo\"` reads as a symbol — we
+  reject that to surface the contract clearly (registered ids are
+  keywords, not symbols)."
+  [s]
+  (cond
+    (or (nil? s) (and (string? s) (str/blank? s)))
+    [:err :missing-id]
+
+    :else
+    (let [trimmed (str/trim s)
+          parsed  (try (cljs.reader/read-string trimmed)
+                       (catch :default _ ::reader-fail))]
+      (cond
+        (= ::reader-fail parsed) [:err :invalid-id-edn]
+        :else                    [:ok parsed]))))
+
+(defn- kinds-hint
+  "Comma-joined list of the supported kinds — used in error envelopes
+  so a fat-fingered :kind gets a corrective hint."
+  []
+  (str/join ", " (sort (map name supported-kinds))))
+
+;; ---------------------------------------------------------------------------
+;; Tool — handler-meta.
+;;
+;; Eval-form composition: for the six registrar kinds we route through
+;; `re-frame-pair2.runtime/registrar-describe` (already published; carries
+;; the `:not-registered` envelope on miss). For `:machine` we wrap
+;; `re-frame.core/machine-meta` directly — the runtime ns has no
+;; machine-aware wrapper today, and adding one is out of scope (lives in
+;; rf2-pctf8's caller side, not the runtime preload).
+;; ---------------------------------------------------------------------------
+
+(defn- registrar-form
+  "Build the eval form that calls `re-frame-pair2.runtime/registrar-describe`
+  for a registrar kind."
+  [kind id]
+  (ef/emit (ef/rt-call 'registrar-describe kind id)))
+
+(defn- machine-form
+  "Build the eval form that wraps `re-frame.core/machine-meta` with the
+  same envelope shape `registrar-describe` returns — either the meta
+  map or a structured `:not-registered` map. Keeps the tool's response
+  shape uniform across kinds.
+
+  The composed form is one expression so the eval is a single
+  round-trip — composition is the same idiom every other tool uses."
+  [id]
+  (let [id-edn (pr-str id)]
+    (str "(if-let [m (re-frame.core/machine-meta " id-edn ")]"
+         "  m"
+         "  {:ok? false :reason :not-registered :kind :machine :id " id-edn "})")))
+
+(defn handler-meta-tool [conn args]
+  (let [build-id (wire/arg-build args)
+        kind-str (wire/arg args :kind)
+        id-str   (wire/arg args :id)
+        kind     (parse-kind kind-str)
+        [id-tag id-val] (parse-id id-str)]
+    (cond
+      (nil? kind)
+      (js/Promise.resolve
+        (wire/err-text {:ok?     false
+                        :reason  :invalid-kind
+                        :kind    kind-str
+                        :hint    (str "kind must be one of: " (kinds-hint))}))
+
+      (= :err id-tag)
+      (js/Promise.resolve
+        (wire/err-text {:ok?    false
+                        :reason id-val
+                        :id     id-str
+                        :hint   (str "id must be an EDN-readable keyword, e.g. \":user/login\". "
+                                     "For composite-key subs, pass the vector form.")}))
+
+      :else
+      (let [form (if (= :machine kind)
+                   (machine-form id-val)
+                   (registrar-form kind id-val))]
+        (-> (probe/ensure-runtime! conn build-id)
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+            (.then (fn [v]
+                     ;; Three envelope shapes resolve into one shape
+                     ;; agents can rely on:
+                     ;;   - hit (map with no :reason): merge :ok? true
+                     ;;     and the requested kind/id so agents don't
+                     ;;     have to remember what they asked for.
+                     ;;   - miss (`{:ok? false :reason :not-registered}`):
+                     ;;     pass through unchanged.
+                     ;;   - eval returned non-map: surface as
+                     ;;     :unexpected-shape — should never happen
+                     ;;     against a healthy runtime.
+                     (wire/ok-text
+                       (cond
+                         (not (map? v))
+                         {:ok? false :reason :unexpected-shape
+                          :kind kind :id id-val :value v}
+
+                         (false? (:ok? v))
+                         (assoc v :kind kind :id id-val)
+
+                         :else
+                         (assoc v :ok? true :kind kind :id id-val)))))
+            (.catch (fn [err] (probe/err->result :handler-meta-failed err))))))))
+
+;; ---------------------------------------------------------------------------
+;; Tool — registry-list.
+;; ---------------------------------------------------------------------------
+
+(defn- list-form
+  "Build the eval form returning the sorted id vector for a kind. For
+  the six registrar kinds we route through
+  `re-frame-pair2.runtime/registrar-list`; for `:machine` we wrap
+  `re-frame.core/machines` (Spec 005 §Querying machines — every event
+  handler with `:rf/machine? true`)."
+  [kind]
+  (if (= :machine kind)
+    "(vec (sort (re-frame.core/machines)))"
+    (ef/emit (ef/rt-call 'registrar-list kind))))
+
+(defn registry-list-tool [conn args]
+  (let [build-id (wire/arg-build args)
+        kind-str (wire/arg args :kind)
+        kind     (parse-kind kind-str)]
+    (cond
+      (nil? kind)
+      (js/Promise.resolve
+        (wire/err-text {:ok?    false
+                        :reason :invalid-kind
+                        :kind   kind-str
+                        :hint   (str "kind must be one of: " (kinds-hint))}))
+
+      :else
+      (let [form (list-form kind)]
+        (-> (probe/ensure-runtime! conn build-id)
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+            (.then (fn [v]
+                     (wire/ok-text
+                       {:ok?   true
+                        :kind  kind
+                        :ids   (vec v)
+                        :count (count v)})))
+            (.catch (fn [err] (probe/err->result :registry-list-failed err))))))))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/registry.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/registry.cljs
@@ -67,6 +67,7 @@
             [re-frame-pair2-mcp.tools.subscribe :as subscribe]
             [re-frame-pair2-mcp.tools.unsubscribe :as unsubscribe]
             [re-frame-pair2-mcp.tools.subscription-info :as subscription-info]
+            [re-frame-pair2-mcp.tools.handler-meta :as handler-meta]
             [re-frame-pair2-mcp.tools.get-pair2-instructions :as get-pair2-instructions]
             [re-frame-pair2-mcp.tools.descriptors-data :as data]))
 
@@ -87,8 +88,9 @@
 
 (defn- ignoring-extra
   "Adapt a 2-arity per-tool fn `(fn [conn args])` into the registry's
-  3-arity convention `(fn [conn args _extra])`. Eleven of the twelve
-  registered tools ignore `extra` (only `subscribe` consults it);
+  3-arity convention `(fn [conn args _extra])`. Thirteen of the
+  fourteen registered tools ignore `extra` (only `subscribe`
+  consults it);
   this adapter collapses the verbatim `(fn [conn args _extra]
   (per-tool-fn conn args))` boilerplate at the call sites.
 
@@ -109,17 +111,16 @@
 ;; ---------------------------------------------------------------------------
 
 (def tools
-  "The twelve-tool catalogue. Single source of truth for the
+  "The fourteen-tool catalogue. Single source of truth for the
   `tools/list` descriptors, the `tools/call` dispatcher, and the
   per-tool cache opt-in. See ns docstring for the entry shape.
 
   Each `:handler` is a thin late-binding wrapper around the per-tool
-  fn — `ignoring-extra` for the eleven tools that ignore `extra`, or
-  an inline `(fn [conn args extra] ...)` for `subscribe` (the
-  twelfth tool, which uses `extra` for its progress-callback
-  plumbing). Both shapes resolve the underlying fn per-call so test
-  seams that `set!` the var (rf2-nogok) take effect on the next
-  dispatch."
+  fn — `ignoring-extra` for the thirteen tools that ignore `extra`,
+  or an inline `(fn [conn args extra] ...)` for `subscribe` (which
+  uses `extra` for its progress-callback plumbing). Both shapes
+  resolve the underlying fn per-call so test seams that `set!` the
+  var (rf2-nogok) take effect on the next dispatch."
   [{:name       "discover-app"
     :handler    (ignoring-extra #(discover-app/discover-app %1 %2))
     :cacheable? true
@@ -164,6 +165,14 @@
     :handler    (ignoring-extra #(subscription-info/subscription-info-tool %1 %2))
     :cacheable? false
     :descriptor data/subscription-info}
+   {:name       "handler-meta"
+    :handler    (ignoring-extra #(handler-meta/handler-meta-tool %1 %2))
+    :cacheable? true
+    :descriptor data/handler-meta}
+   {:name       "registry-list"
+    :handler    (ignoring-extra #(handler-meta/registry-list-tool %1 %2))
+    :cacheable? true
+    :descriptor data/registry-list}
    {:name       "get-pair2-instructions"
     :handler    (ignoring-extra #(get-pair2-instructions/get-pair2-instructions-tool %1 %2))
     :cacheable? true

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/source_uri.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/source_uri.cljs
@@ -1,0 +1,113 @@
+(ns re-frame-pair2-mcp.tools.source-uri
+  "Source-URI decoration pass (rf2-cibp8).
+
+  Every pair2-mcp tool whose response carries `:source-coord
+  {:ns :file :line :column}` maps walks the post-shrink payload
+  through this transform. For every `:source-coord` map encountered,
+  a sibling `:rf.source/uri \"vscode://...\"` string is added (built
+  via `re-frame.source-coords.editor-uri/editor-uri`).
+
+  ## Why a sibling URI string, not just the coord map
+
+  AI hosts (Claude Code, GPT, etc.) auto-render strings whose shape
+  matches a registered URI scheme as clickable links — `vscode://...`,
+  `cursor://...`, `idea://open?...` all open the editor at the
+  declared location. A structured map like `{:ns :foo :file
+  \"foo.cljs\" :line 42 :column 7}` does NOT auto-render — the host
+  would have to construct the URI itself, and in practice doesn't.
+  Shipping the pre-built URI alongside the coord turns a single
+  source-coord into a one-click jump-to-definition affordance for
+  every event / sub / fx the agent inspects.
+
+  ## Walk policy
+
+  - Recurses into maps, vectors, lists, seqs, sets.
+  - When the walker descends into a map and that map has a
+    `:source-coord` slot whose value is itself a map, the URI is
+    spliced onto the map at the `:rf.source/uri` key.
+  - When `:source-coord`'s `:file` slot is missing / blank, the
+    underlying `editor-uri` returns nil; the decorator omits the
+    `:rf.source/uri` key entirely (keeps the response shape tight
+    — no `:rf.source/uri nil` slots).
+  - The walk is idempotent. A map that already carries
+    `:rf.source/uri` is overwritten with the current editor's URI
+    (so a stale URI from a server-side decorator can be replaced if
+    the agent reconfigures the editor mid-session).
+
+  ## Ordering invariant
+
+  Runs INSIDE `run-wire-pipeline` AFTER dedup + summary so the
+  decoration operates on the post-shrink tree — no wasted URI
+  builds on subtrees that will be replaced with summary markers,
+  and no broken `:source-coord` maps inside dedup-table cells
+  (dedup replaces equal subtrees with a single canonical instance,
+  so each source-coord is visited once)."
+  (:require [re-frame.source-coords.editor-uri :as editor-uri]))
+
+;; ---------------------------------------------------------------------------
+;; The walker.
+;;
+;; We can't use `clojure.walk/postwalk` here — postwalk visits every
+;; node bottom-up, but we need to inspect the VALUE under the
+;; `:source-coord` key from the PARENT map's perspective (so we can
+;; splice the URI as a sibling, not transform the coord itself). A
+;; bespoke recursion is cheaper than walking twice.
+;; ---------------------------------------------------------------------------
+
+(defn- coord-map?
+  "Is `v` a plausible source-coord map? Match on the load-bearing slot
+  (`:file`) being a non-blank string. Per the editor-uri ns, a
+  source-coord without `:file` produces a nil URI — so we don't bother
+  splicing onto a map that has no `:file`. `:line` / `:column` /
+  `:ns` are optional decorations editor-uri tolerates."
+  [v]
+  (and (map? v)
+       (string? (:file v))
+       (seq (:file v))))
+
+(defn- decorate-map
+  "Decorate `m` with `:rf.source/uri` when its `:source-coord` slot
+  carries a usable file string. Otherwise return `m` unchanged.
+
+  Pure data → data; no atoms read here — the editor is threaded in
+  by the caller so this fn is testable without the config atom."
+  [m editor]
+  (let [coord (:source-coord m)]
+    (if (coord-map? coord)
+      (if-let [uri (editor-uri/editor-uri editor coord)]
+        (assoc m :rf.source/uri uri)
+        m)
+      m)))
+
+(defn decorate
+  "Walk `tree`, splicing `:rf.source/uri` onto every map that carries
+  a `:source-coord` slot with a usable `:file`. Returns the decorated
+  tree.
+
+  `editor` follows the `editor-uri/editor-uri` vocabulary — `:vscode`
+  / `:cursor` / `:windsurf` / `:zed` / `:idea` / `{:custom <template>}`.
+
+  Pure data → data. Idempotent: re-decoration replaces an existing
+  `:rf.source/uri` with the URI for the current editor."
+  [tree editor]
+  (cond
+    (map? tree)
+    (let [stepped (reduce-kv
+                    (fn [acc k v] (assoc acc k (decorate v editor)))
+                    {}
+                    tree)]
+      (decorate-map stepped editor))
+
+    (vector? tree)
+    (mapv #(decorate % editor) tree)
+
+    (set? tree)
+    (into #{} (map #(decorate % editor)) tree)
+
+    (seq? tree)
+    ;; Preserve the seq-ness so callers (and pr-str) see what they
+    ;; emitted, not a magically-realised vector.
+    (doall (map #(decorate % editor) tree))
+
+    :else
+    tree))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire_pipeline.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/wire_pipeline.cljs
@@ -25,6 +25,10 @@
         → dedup               (structural sharing across the wire)
         → indicator-count     (count :rf.size/large-elided markers)
         → summary             (lazy-summary for non-app-db rich slices)
+        → source-uri          (rf2-cibp8: splice :rf.source/uri onto
+                               every :source-coord map; runs after
+                               shrink so no URI build is wasted on
+                               summary-replaced subtrees)
 
   ## Indicator counting (rf2-e35a5)
 
@@ -74,9 +78,11 @@
   collapses from a 20-line `let` of intermediate names to a 5-line
   pipeline call + envelope assembly."
   (:require [re-frame.mcp-base.elision :as base-elision]
+            [re-frame-pair2-mcp.config :as config]
             [re-frame-pair2-mcp.tools.dedup :as dedup]
             [re-frame-pair2-mcp.tools.sensitive :as sensitive]
-            [re-frame-pair2-mcp.tools.snapshot-pipeline :as pipeline]))
+            [re-frame-pair2-mcp.tools.snapshot-pipeline :as pipeline]
+            [re-frame-pair2-mcp.tools.source-uri :as source-uri]))
 
 (defn- run-snapshot-map
   "Full snapshot pipeline. Sequences:
@@ -198,12 +204,20 @@
   silently degrading would mask a programmer typo / a new-payload
   contributor who forgot to register the arm. The post-eval shrink
   pipeline is a fixed surface; a dynamic-dispatch fallback has no
-  legitimate use."
+  legitimate use.
+
+  After the per-kind arm returns, the source-URI decorator (rf2-cibp8)
+  splices `:rf.source/uri` onto every `:source-coord`-bearing map in
+  the result. Runs last so the decoration walks only the
+  post-shrink tree — summary-replaced slices ship as `{:rf.mcp/summary
+  ...}` markers (no `:source-coord` inside), so the walk is short."
   [payload {:keys [kind] :as opts}]
-  (case kind
-    :snapshot-map (run-snapshot-map payload opts)
-    :epoch-vector (run-epoch-vector payload opts)
-    :scalar-value (run-scalar-value payload opts)
-    (throw (ex-info "run-wire-pipeline: unknown :kind"
-                    {:kind  kind
-                     :valid #{:snapshot-map :epoch-vector :scalar-value}}))))
+  (let [{:keys [value] :as out}
+        (case kind
+          :snapshot-map (run-snapshot-map payload opts)
+          :epoch-vector (run-epoch-vector payload opts)
+          :scalar-value (run-scalar-value payload opts)
+          (throw (ex-info "run-wire-pipeline: unknown :kind"
+                          {:kind  kind
+                           :valid #{:snapshot-map :epoch-vector :scalar-value}})))]
+    (assoc out :value (source-uri/decorate value (config/get-editor)))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/conformance_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/conformance_test.cljs
@@ -1,5 +1,5 @@
 (ns re-frame-pair2-mcp.conformance-test
-  "Per rf2-xkxbv (audit rf2-7hie3 §TE3). Drives the twelve-tool catalogue
+  "Per rf2-xkxbv (audit rf2-7hie3 §TE3). Drives the pair2-mcp tool catalogue
   through `tools/invoke` against a stub `conn` and asserts the recorded
   wire-shape EDN — the artefact's contract suite, sibling to:
 
@@ -242,7 +242,7 @@
 ;; ---------------------------------------------------------------------------
 
 (def corpus
-  "Inline conformance corpus for pair2-mcp's twelve-tool catalogue.
+  "Inline conformance corpus for pair2-mcp's tool catalogue.
 
   Coverage matrix today (rf2-xkxbv, rf2-fnpqg):
 
@@ -582,7 +582,7 @@
 ;;
 ;; Why one deftest, not one per fixture: matches the framework-side
 ;; runners (`ssr-conformance-test`, `machines-conformance-test`); the
-;; corpus is a unit of coverage, not twelve units. Failure reports name
+;; corpus is a unit of coverage, not N units. Failure reports name
 ;; each failing fixture by `:fixture/id` so a CI failure is
 ;; self-locating without forcing the runner to declare N `deftest`s
 ;; that would expand at compile time as the corpus grows.

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/handler_meta_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/handler_meta_test.cljs
@@ -1,0 +1,180 @@
+(ns re-frame-pair2-mcp.handler-meta-test
+  "Unit tests for the `handler-meta` + `registry-list` MCP tools (rf2-pctf8).
+
+  Both tools build a CLJS form that calls into the preloaded runtime
+  (`re-frame-pair2.runtime/registrar-describe` / `registrar-list` for
+  the six registrar kinds; `re-frame.core/machine-meta` /
+  `re-frame.core/machines` for the `:machine` kind). Live end-to-end
+  coverage runs against a shadow-cljs runtime; these tests pin:
+
+    1. The descriptor wire-up — both tools surface on `tool-descriptors`
+       and `tool-descriptors-js` with the right shape (required args,
+       enum vocab, typicalTokens).
+    2. The kind / id parsers — recognised kinds map to keywords;
+       unknown / malformed values are rejected with structured envelopes;
+       EDN-encoded ids round-trip cleanly.
+    3. The form composition — given a valid (kind, id) pair the right
+       runtime fn is called (`registrar-describe` for the six registrar
+       kinds; `machine-meta` for `:machine`).
+    4. Error envelopes — missing / invalid kind / id arguments surface
+       structured `:reason` slots an agent can read."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [re-frame-pair2-mcp.tools :as tools]
+            [re-frame-pair2-mcp.tools.handler-meta :as hm]))
+
+;; ---------------------------------------------------------------------------
+;; Helpers.
+;; ---------------------------------------------------------------------------
+
+(defn- args-js [m]
+  (let [o #js {}]
+    (doseq [[k v] m]
+      (j/assoc! o (name k) v))
+    o))
+
+(defn- extract-text [result]
+  (let [content (j/get result :content)
+        item    (when (array? content) (aget content 0))]
+    (when item (j/get item :text))))
+
+(defn- extract-edn [result]
+  (some-> (extract-text result) edn/read-string))
+
+(defn- is-error? [result]
+  (true? (j/get result :isError)))
+
+(defn- find-descriptor [name]
+  (some #(when (= name (:name %)) %) tools/tool-descriptors))
+
+;; ---------------------------------------------------------------------------
+;; Descriptor — handler-meta.
+;; ---------------------------------------------------------------------------
+
+(deftest handler-meta-descriptor-present
+  (testing "handler-meta is registered in tool-descriptors"
+    (let [d (find-descriptor "handler-meta")]
+      (is (some? d) "descriptor exists")
+      (is (string? (:description d)))
+      (is (integer? (:typicalTokens d)))
+      (is (pos? (:typicalTokens d)))
+      (let [{:keys [required properties]} (:inputSchema d)]
+        (is (= #{"kind" "id"} (set required))
+            "kind + id are both required")
+        (is (contains? properties :kind))
+        (is (contains? properties :id))
+        (is (= #{"event" "sub" "fx" "cofx" "view" "frame" "machine"}
+               (set (:enum (:kind properties))))
+            "kind enum lists every supported kind")))))
+
+(deftest handler-meta-descriptor-surfaces-on-tools-list
+  (testing "handler-meta shows up in tool-descriptors-js"
+    (let [arr   (tools/tool-descriptors-js)
+          names (set (for [i (range (alength arr))]
+                       (j/get (aget arr i) :name)))]
+      (is (contains? names "handler-meta")))))
+
+;; ---------------------------------------------------------------------------
+;; Descriptor — registry-list.
+;; ---------------------------------------------------------------------------
+
+(deftest registry-list-descriptor-present
+  (testing "registry-list is registered in tool-descriptors"
+    (let [d (find-descriptor "registry-list")]
+      (is (some? d) "descriptor exists")
+      (is (string? (:description d)))
+      (is (integer? (:typicalTokens d)))
+      (let [{:keys [required properties]} (:inputSchema d)]
+        (is (= #{"kind"} (set required))
+            "kind is the only required arg")
+        (is (contains? properties :kind))
+        (is (= #{"event" "sub" "fx" "cofx" "view" "frame" "machine"}
+               (set (:enum (:kind properties)))))))))
+
+(deftest registry-list-descriptor-surfaces-on-tools-list
+  (testing "registry-list shows up in tool-descriptors-js"
+    (let [arr   (tools/tool-descriptors-js)
+          names (set (for [i (range (alength arr))]
+                       (j/get (aget arr i) :name)))]
+      (is (contains? names "registry-list")))))
+
+;; ---------------------------------------------------------------------------
+;; handler-meta-tool — error envelopes (no nREPL needed).
+;;
+;; The tool short-circuits on bad args BEFORE reaching `probe/ensure-runtime!`.
+;; A nil conn never gets touched on these paths.
+;; ---------------------------------------------------------------------------
+
+(deftest handler-meta-rejects-missing-kind
+  (testing "handler-meta with no :kind surfaces :invalid-kind"
+    (let [p (hm/handler-meta-tool nil (args-js {:id ":user/login"}))]
+      (.then p (fn [result]
+                 (is (is-error? result))
+                 (let [edn (extract-edn result)]
+                   (is (= :invalid-kind (:reason edn)))))))))
+
+(deftest handler-meta-rejects-unknown-kind
+  (testing "handler-meta with an out-of-vocab :kind surfaces :invalid-kind"
+    (let [p (hm/handler-meta-tool nil (args-js {:kind "not-a-kind"
+                                                 :id   ":user/login"}))]
+      (.then p (fn [result]
+                 (is (is-error? result))
+                 (let [edn (extract-edn result)]
+                   (is (= :invalid-kind (:reason edn)))
+                   (is (= "not-a-kind" (:kind edn)))))))))
+
+(deftest handler-meta-rejects-missing-id
+  (testing "handler-meta with kind but no :id surfaces :missing-id"
+    (let [p (hm/handler-meta-tool nil (args-js {:kind "event"}))]
+      (.then p (fn [result]
+                 (is (is-error? result))
+                 (let [edn (extract-edn result)]
+                   (is (= :missing-id (:reason edn)))))))))
+
+(deftest handler-meta-rejects-invalid-id-edn
+  (testing "handler-meta with unreadable :id surfaces :invalid-id-edn"
+    (let [p (hm/handler-meta-tool nil (args-js {:kind "event"
+                                                 :id   "{:unclosed"}))]
+      (.then p (fn [result]
+                 (is (is-error? result))
+                 (let [edn (extract-edn result)]
+                   (is (= :invalid-id-edn (:reason edn)))))))))
+
+;; ---------------------------------------------------------------------------
+;; registry-list-tool — error envelopes.
+;; ---------------------------------------------------------------------------
+
+(deftest registry-list-rejects-missing-kind
+  (testing "registry-list with no :kind surfaces :invalid-kind"
+    (let [p (hm/registry-list-tool nil (args-js {}))]
+      (.then p (fn [result]
+                 (is (is-error? result))
+                 (let [edn (extract-edn result)]
+                   (is (= :invalid-kind (:reason edn)))))))))
+
+(deftest registry-list-rejects-unknown-kind
+  (testing "registry-list with an out-of-vocab :kind surfaces :invalid-kind"
+    (let [p (hm/registry-list-tool nil (args-js {:kind "ghost"}))]
+      (.then p (fn [result]
+                 (is (is-error? result))
+                 (let [edn (extract-edn result)]
+                   (is (= :invalid-kind (:reason edn)))))))))
+
+;; ---------------------------------------------------------------------------
+;; Name + descriptor kind-vocab consistency.
+;; ---------------------------------------------------------------------------
+
+(deftest tool-name-uses-kebab-case
+  (testing "the two new tool descriptors use kebab-case names"
+    (is (= "handler-meta" (:name (find-descriptor "handler-meta")))
+        "name uses kebab-case, not handler_meta / handlerMeta")
+    (is (= "registry-list" (:name (find-descriptor "registry-list")))
+        "name uses kebab-case, not registry_list / registryList")))
+
+(deftest descriptors-share-the-kind-vocab
+  (testing "handler-meta and registry-list share the same :kind enum"
+    (let [hm-enum (-> (find-descriptor "handler-meta") :inputSchema :properties :kind :enum set)
+          rl-enum (-> (find-descriptor "registry-list") :inputSchema :properties :kind :enum set)]
+      (is (= hm-enum rl-enum)
+          "drift here would make agents learn two vocabularies for one concept"))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/source_uri_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/source_uri_test.cljs
@@ -1,0 +1,231 @@
+(ns re-frame-pair2-mcp.source-uri-test
+  "Unit tests for the source-URI decorator (rf2-cibp8).
+
+  Pins three properties:
+
+  1. **Walk reach.** Every `:source-coord` map nested anywhere in the
+     payload tree (top-level, inside a vector, inside a nested map,
+     inside a seq) gets a sibling `:rf.source/uri` string.
+  2. **URI shape.** The URI is built via
+     `re-frame.source-coords.editor-uri/editor-uri`, so the scheme
+     matches the configured editor (`:vscode` default, `:cursor` /
+     `:idea` / etc. via `set-editor!`).
+  3. **Skip-when-no-:file.** A `:source-coord` map without a `:file`
+     slot (or with a blank file) produces no `:rf.source/uri` —
+     editor-uri returns nil there and we omit the key rather than
+     emit a `nil` slot.
+
+  The decorator is pure data → data; tests poke `decorate` directly
+  with an explicit editor and never need the live atom. The atom-read
+  path is covered by an explicit `get-editor` round-trip at the head
+  of the file."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame-pair2-mcp.config :as config]
+            [re-frame-pair2-mcp.tools.source-uri :as source-uri]
+            [re-frame-pair2-mcp.tools.wire-pipeline :as wp]))
+
+;; ---------------------------------------------------------------------------
+;; config/get-editor — atom round-trip.
+;; ---------------------------------------------------------------------------
+
+(deftest config-defaults-to-vscode
+  (testing "default editor is :vscode (or whatever env-var set on this process)"
+    ;; The env-var is not set in test, so the default fires.
+    (is (= :vscode (config/get-editor)))))
+
+(deftest config-set-editor-round-trips
+  (testing "set-editor!/get-editor round-trips a keyword"
+    (let [prior (config/get-editor)]
+      (try
+        (config/set-editor! :cursor)
+        (is (= :cursor (config/get-editor)))
+        (config/set-editor! {:custom "myide://{path}:{line}"})
+        (is (= {:custom "myide://{path}:{line}"} (config/get-editor)))
+        (finally
+          (config/set-editor! prior))))))
+
+(deftest config-set-editor-nil-resets-to-vscode
+  (testing "set-editor! nil resets to :vscode"
+    (let [prior (config/get-editor)]
+      (try
+        (config/set-editor! :cursor)
+        (config/set-editor! nil)
+        (is (= :vscode (config/get-editor)))
+        (finally
+          (config/set-editor! prior))))))
+
+;; ---------------------------------------------------------------------------
+;; decorate — walk reach.
+;; ---------------------------------------------------------------------------
+
+(def ^:private sample-coord
+  {:ns 'app.events :file "src/app/events.cljs" :line 42 :column 7})
+
+(def ^:private sample-coord-no-file
+  {:ns 'app.events :line 42 :column 7})
+
+(def ^:private sample-coord-blank-file
+  {:ns 'app.events :file "" :line 42 :column 7})
+
+(deftest decorate-splices-uri-on-top-level-source-coord
+  (testing "a top-level :source-coord map gets a sibling :rf.source/uri"
+    (let [v   {:event-id :user/login :source-coord sample-coord}
+          out (source-uri/decorate v :vscode)]
+      (is (= sample-coord (:source-coord out)))
+      (is (= "vscode://file/src/app/events.cljs:42:7" (:rf.source/uri out))))))
+
+(deftest decorate-respects-editor-choice
+  (testing "the URI scheme matches the chosen editor"
+    (let [v {:event-id :x :source-coord sample-coord}]
+      (is (= "cursor://file/src/app/events.cljs:42:7"
+             (:rf.source/uri (source-uri/decorate v :cursor))))
+      (is (= "idea://open?file=src/app/events.cljs&line=42&column=7"
+             (:rf.source/uri (source-uri/decorate v :idea))))
+      (is (= "zed://file/src/app/events.cljs:42:7"
+             (:rf.source/uri (source-uri/decorate v :zed))))
+      (is (= "windsurf://file/src/app/events.cljs:42:7"
+             (:rf.source/uri (source-uri/decorate v :windsurf)))))))
+
+(deftest decorate-custom-editor-template
+  (testing "a :custom editor template flows through to the URI"
+    (let [v {:source-coord sample-coord}
+          editor {:custom "myide://open?path={path}&row={line}"}]
+      (is (= "myide://open?path=src/app/events.cljs&row=42"
+             (:rf.source/uri (source-uri/decorate v editor)))))))
+
+(deftest decorate-recurses-into-vectors
+  (testing "source-coords inside a vector each get a URI"
+    (let [v   [{:id 1 :source-coord sample-coord}
+               {:id 2 :source-coord (assoc sample-coord :file "src/app/subs.cljs")}]
+          out (source-uri/decorate v :vscode)]
+      (is (= "vscode://file/src/app/events.cljs:42:7"
+             (:rf.source/uri (nth out 0))))
+      (is (= "vscode://file/src/app/subs.cljs:42:7"
+             (:rf.source/uri (nth out 1)))))))
+
+(deftest decorate-recurses-into-nested-maps
+  (testing "source-coords inside a nested map slot get a URI"
+    (let [v   {:epochs [{:event       [:cart/add]
+                         :handler-meta {:id :cart/add
+                                        :source-coord sample-coord}}]}
+          out (source-uri/decorate v :vscode)
+          hm  (-> out :epochs first :handler-meta)]
+      (is (= "vscode://file/src/app/events.cljs:42:7" (:rf.source/uri hm))))))
+
+(deftest decorate-recurses-into-seqs
+  (testing "source-coords inside a seq each get a URI"
+    (let [v   (list {:source-coord sample-coord})
+          out (source-uri/decorate v :vscode)]
+      (is (seq? out))
+      (is (= "vscode://file/src/app/events.cljs:42:7"
+             (:rf.source/uri (first out)))))))
+
+(deftest decorate-recurses-into-sets
+  (testing "source-coords inside a set each get a URI"
+    (let [v   #{{:source-coord sample-coord}}
+          out (source-uri/decorate v :vscode)]
+      (is (set? out))
+      (is (= "vscode://file/src/app/events.cljs:42:7"
+             (:rf.source/uri (first out)))))))
+
+;; ---------------------------------------------------------------------------
+;; decorate — skip-when-no-:file.
+;; ---------------------------------------------------------------------------
+
+(deftest decorate-skips-source-coord-without-file
+  (testing "a :source-coord without :file produces no :rf.source/uri key"
+    (let [v   {:event-id :x :source-coord sample-coord-no-file}
+          out (source-uri/decorate v :vscode)]
+      (is (= sample-coord-no-file (:source-coord out)))
+      (is (not (contains? out :rf.source/uri))))))
+
+(deftest decorate-skips-source-coord-with-blank-file
+  (testing "a :source-coord with blank :file produces no :rf.source/uri key"
+    (let [v   {:event-id :x :source-coord sample-coord-blank-file}
+          out (source-uri/decorate v :vscode)]
+      (is (not (contains? out :rf.source/uri))))))
+
+(deftest decorate-skips-non-map-source-coord-slot
+  (testing "a non-map :source-coord slot is left alone (no URI splice)"
+    ;; Some payloads carry `:source-coord nil` or a placeholder string;
+    ;; the decorator MUST NOT crash and MUST NOT add a URI key.
+    (let [v1 {:source-coord nil}
+          v2 {:source-coord "n/a"}
+          v3 {:source-coord [:not :a :map]}]
+      (is (not (contains? (source-uri/decorate v1 :vscode) :rf.source/uri)))
+      (is (not (contains? (source-uri/decorate v2 :vscode) :rf.source/uri)))
+      (is (not (contains? (source-uri/decorate v3 :vscode) :rf.source/uri))))))
+
+(deftest decorate-leaves-non-source-coord-maps-untouched
+  (testing "maps without a :source-coord slot are returned shape-for-shape"
+    (let [v {:event-id :x :payload {:y 1}}]
+      (is (= v (source-uri/decorate v :vscode))))))
+
+(deftest decorate-idempotent
+  (testing "running the decorator twice yields the same result"
+    (let [v       {:source-coord sample-coord}
+          once    (source-uri/decorate v :vscode)
+          twice   (source-uri/decorate once :vscode)]
+      (is (= once twice)))))
+
+(deftest decorate-overwrites-stale-rf-source-uri-when-editor-changes
+  (testing "a re-decoration with a different editor replaces the URI"
+    (let [v       {:source-coord sample-coord :rf.source/uri "vscode://stale"}
+          out     (source-uri/decorate v :cursor)]
+      (is (= "cursor://file/src/app/events.cljs:42:7" (:rf.source/uri out))))))
+
+(deftest decorate-passes-through-scalars
+  (testing "scalars (strings, numbers, keywords, nil) round-trip unchanged"
+    (is (= 42      (source-uri/decorate 42 :vscode)))
+    (is (= "x"     (source-uri/decorate "x" :vscode)))
+    (is (= :foo    (source-uri/decorate :foo :vscode)))
+    (is (= nil     (source-uri/decorate nil :vscode)))
+    (is (= true    (source-uri/decorate true :vscode)))))
+
+;; ---------------------------------------------------------------------------
+;; Integration — run-wire-pipeline splices URIs on every kind.
+;; ---------------------------------------------------------------------------
+
+(defn- with-editor [editor f]
+  (let [prior (config/get-editor)]
+    (try
+      (config/set-editor! editor)
+      (f)
+      (finally
+        (config/set-editor! prior)))))
+
+(deftest pipeline-epoch-vector-decorates-source-coords
+  (testing "run-wire-pipeline :epoch-vector splices :rf.source/uri onto epoch source-coords"
+    (with-editor :vscode
+      #(let [epochs [{:event-id :a :source-coord sample-coord}
+                     {:event-id :b
+                      :source-coord (assoc sample-coord :file "src/app/subs.cljs")}]
+             {:keys [value]} (wp/run-wire-pipeline epochs
+                                                   {:kind   :epoch-vector
+                                                    :incl?  false
+                                                    :mode   :diff
+                                                    :dedup? false})]
+         (is (= "vscode://file/src/app/events.cljs:42:7"
+                (:rf.source/uri (nth value 0))))
+         (is (= "vscode://file/src/app/subs.cljs:42:7"
+                (:rf.source/uri (nth value 1))))))))
+
+(deftest pipeline-scalar-value-decorates-source-coord
+  (testing "run-wire-pipeline :scalar-value walks the scalar tree and splices URIs"
+    (with-editor :vscode
+      #(let [v {:registered :user/login :source-coord sample-coord}
+             {:keys [value]} (wp/run-wire-pipeline v
+                                                   {:kind          :scalar-value
+                                                    :server-elided 0})]
+         (is (= "vscode://file/src/app/events.cljs:42:7"
+                (:rf.source/uri value)))))))
+
+(deftest pipeline-respects-live-editor
+  (testing "the pipeline reads the live editor preference at decoration time"
+    (with-editor :cursor
+      #(let [v {:source-coord sample-coord}
+             {:keys [value]} (wp/run-wire-pipeline v
+                                                   {:kind          :scalar-value
+                                                    :server-elided 0})]
+         (is (= "cursor://file/src/app/events.cljs:42:7"
+                (:rf.source/uri value)))))))


### PR DESCRIPTION
## Summary

Micro-cluster of two beads, sequenced commits, one PR.

- **Commit 1 (rf2-cibp8)**: wire-pipeline decorator splices `:rf.source/uri` onto every `:source-coord` map crossing the wire, so AI hosts auto-render a clickable jump-to-editor link instead of seeing an inert map.
- **Commit 2 (rf2-pctf8)**: two new MCP tools — `handler-meta` and `registry-list` — give agents direct introspection on the registrar without a wide-authority `eval-cljs` round-trip. The handler-meta response carries the decorated source-coord from Commit 1.

### What changed

- New `re-frame-pair2-mcp.config` ns — `get-editor` / `set-editor!` for the pair2-mcp editor preference, mirroring Causa's and Story's pattern. Defaults to `:vscode`; overridable at server start via the `RE_FRAME_PAIR2_MCP_EDITOR` env var.
- New `re-frame-pair2-mcp.tools.source-uri` ns — pure walker decorating `:source-coord` maps with `:rf.source/uri` strings.
- `wire-pipeline.cljs` runs the decorator at the tail of `run-wire-pipeline` for every kind (`:snapshot-map`, `:epoch-vector`, `:scalar-value`).
- `deps.edn` adds a thin `:local/root` on `implementation/core` for the pure-data `re-frame.source-coords.editor-uri` ns.
- New `re-frame-pair2-mcp.tools.handler-meta` ns — `handler-meta-tool` + `registry-list-tool`, registered in `registry.cljs` (cacheable).
- New descriptors in `descriptors-data.cljs`; tool count goes from twelve to fourteen.
- New tests: `source_uri_test.cljs` (20 tests) and `handler_meta_test.cljs` (12 tests).

### Quality gates

- `tools/pair2-mcp $ npm test` — 395 tests, 954 assertions. 2 pre-existing failures in `sensitive-filter-test` (rf2-wb06a flake territory; unrelated to this PR — verified by stashing the PR's diff and re-running).
- `implementation $ npm run test:cljs` — 1988 tests, 5638 assertions, 0 failures.
- `implementation $ npm run test:bundle-isolation` — PASS.

### Rebase concerns

- `editor_uri.cljc` is HOT (rf2-p887o moving allowlist there in parallel). This PR only `:require`s from it — no edits. If conflicts arise on merge, the source-uri decorator owns the rebase but the surface area is just the import.

## Test plan

- [x] `tools/pair2-mcp $ npm test` passes (no new failures)
- [x] `implementation $ npm run test:cljs` passes
- [x] `implementation $ npm run test:bundle-isolation` passes
- [ ] Live MCP roundtrip — confirm `handler-meta {kind "event" id ":counter/inc"}` returns a map with `:source-coord` AND `:rf.source/uri`
- [ ] Live MCP roundtrip — confirm `registry-list {kind "sub"}` returns the sub-id vector