### PR TITLE
fix(pair2-mcp-test): align sensitive-filter tests with fail-closed contract (rf2-5br2q)

### DIFF
--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/sensitive_filter_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/sensitive_filter_test.cljs
@@ -29,13 +29,21 @@
   ;; Per spec/009: "Consumers treat absent as `false`."
   (is (not (sensitive/sensitive-event? {:operation :event/dispatched}))))
 
-(deftest sensitive-event-non-true-truthy-passes
-  ;; Conservative: only the literal `true` triggers the drop. A string
-  ;; or non-boolean value passes through (the `:rf/trace-event` schema
-  ;; types `:sensitive?` as a boolean — any other value is a contract
-  ;; violation we surface rather than silently treat as sensitive).
-  (is (not (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? "true"})))
-  (is (not (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? :yes}))))
+(deftest sensitive-event-non-true-truthy-drops-fail-closed
+  ;; Fail-closed (rf2-ih7g4): the literal `true` drops AND any
+  ;; non-boolean truthy value drops too. The `:rf/trace-event` schema
+  ;; types `:sensitive?` as a boolean; a string `"true"` or keyword
+  ;; `:yes` is a contract violation that means an upstream
+  ;; serialisation bug has coerced the boolean into the wrong shape.
+  ;; The previous fail-OPEN posture silently leaked sensitive events
+  ;; on such drift. Pair2-mcp delegates to
+  ;; `re-frame.mcp-base.sensitive/sensitive-event?` (rf2-vw4sq) so the
+  ;; contract is byte-identical across the MCP triplet.
+  (with-redefs [js/console (clj->js {:warn (fn [& _])})] ; absorb the contract-drift warning
+    (is (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? "true"}))
+    (is (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? :yes}))
+    (is (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? 1}))
+    (is (sensitive/sensitive-event? {:operation :event/dispatched :sensitive? ["any" "truthy"]}))))
 
 (deftest sensitive-event-non-map-input-passes
   (is (not (sensitive/sensitive-event? nil)))
@@ -81,6 +89,22 @@
         [kept dropped] (sensitive/strip-sensitive evts false)]
     (is (= [] kept))
     (is (= 3 dropped))))
+
+(deftest strip-sensitive-fail-closed-drops-malformed-truthy
+  ;; rf2-ih7g4: a transport bug that coerces `:sensitive? true` into
+  ;; `:sensitive? "true"` (string) or `:sensitive? :yes` (keyword) MUST
+  ;; NOT silently leak the event past the pair2-mcp wire boundary. The
+  ;; fail-closed posture (inherited from `re-frame.mcp-base.sensitive`)
+  ;; drops the malformed-truthy event so the contract drift is visible
+  ;; to operators on stderr / js/console.warn.
+  (with-redefs [js/console (clj->js {:warn (fn [& _])})] ; absorb the warning
+    (let [evts [{:id 1 :sensitive? false}
+                {:id 2 :sensitive? "true"} ; malformed-truthy → drop
+                {:id 3}
+                {:id 4 :sensitive? :yes}]  ; malformed-truthy → drop
+          [kept dropped] (sensitive/strip-sensitive evts false)]
+      (is (= [{:id 1 :sensitive? false} {:id 3}] kept))
+      (is (= 2 dropped)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Default posture — the load-bearing assertion for the spec/009 MUST.


### PR DESCRIPTION
## Summary

Closes [rf2-5br2q](https://github.com/day8/re-frame2/issues?q=rf2-5br2q). Fixes the 2 pre-existing failures in `tools/pair2-mcp/test/re_frame_pair2_mcp/sensitive_filter_test.cljs` that rf2-wb06a's flake-fix verification (PR #1104, 10x run) surfaced.

## Root cause — stale test, not production drift

PR #1095 (rf2-ih7g4) tightened `re-frame.mcp-base.sensitive/sensitive-event?` from **fail-OPEN** to **fail-CLOSED**: any non-boolean truthy `:sensitive?` stamp (string `"true"`, keyword `:yes`, number, vector) now drops AND warns on stderr / `js/console.warn` instead of silently passing through.

Two tests in pair2-mcp's `sensitive_filter_test.cljs` still asserted the old fail-OPEN behaviour:

```
FAIL in (sensitive-event-non-true-truthy-passes)
expected: (not (sensitive/sensitive-event? {... :sensitive? "true"}))
  actual: (not (not true))
```

Pair2-mcp's `tools/sensitive.cljs` delegates directly to the base predicate (rf2-vw4sq), so the production behaviour already matches the new spec/009 §Privacy fail-closed contract. **The tests pre-dated rf2-ih7g4 and asserted the old broken posture; this PR updates them to pin the tightened contract.**

## Changes (`tools/pair2-mcp/test/re_frame_pair2_mcp/sensitive_filter_test.cljs`)

- Rename `sensitive-event-non-true-truthy-passes` → `sensitive-event-non-true-truthy-drops-fail-closed`. Now asserts that string / keyword / number / vector truthy stamps DROP (the four shapes the mcp-base test pins).
- Add `strip-sensitive-fail-closed-drops-malformed-truthy` mirroring the mcp-base batch-filter coverage — a malformed-truthy event in a mixed batch must drop alongside the well-formed `true`.
- Suppress the contract-drift warning via `with-redefs js/console` so test output stays quiet (CLJS analogue of the mcp-base test's `binding [*err* (java.io.StringWriter.)]` JVM pattern).

## Test plan

- [x] `cd tools/pair2-mcp && npm test` — **0 failures, 0 errors** (396 tests / 958 assertions; was 395/954 with 2 failures)
- [x] `cd implementation && npm run test:cljs` — **0 failures** (1983 tests / 5634 assertions)
- [x] `cd implementation && npm run test:bundle-isolation` — **PASS**

## Boundaries

Pair2-mcp-only surface; `tools/mcp-base/` untouched (production code is already correct).