### PR TITLE
test(story-coverage): close docs-promised gaps in 001/002/005/006/013 (rf2-ub1n4)

### DIFF
--- a/tools/story/test/re_frame/story_authoring_validation_test.clj
+++ b/tools/story/test/re_frame/story_authoring_validation_test.clj
@@ -1,0 +1,234 @@
+(ns re-frame.story-authoring-validation-test
+  "JVM tests closing the docs-promised gap on macro-time validation +
+  source-coordinate stamping at the authoring surface.
+
+  Spec coverage (rf2-ub1n4): `tools/story/spec/001-Authoring.md` §
+  Source-coord stamping and § Registration macros.
+
+  Two surfaces are exercised here that the browser smoke does not:
+
+  - **Macro-time validation.** The `reg-story` / `reg-variant` /
+    `reg-workspace` / `reg-decorator` / `reg-mode` / `reg-story-panel`
+    / `reg-tag` macros all funnel through `re-frame.story.macros/
+    gen-reg-call` and `expand-reg-story`. The expansion form binds
+    `*pending-coords*` from `(meta &form)` and calls the runtime
+    `reg-*!` helper, which runs the malli schema check + tag-vocab
+    cross-check + extends resolution. The cross-cutting contract is:
+    an invalid body raises `:rf.error/<kind>-shape` / `:rf.error/
+    unknown-tag` / `:rf.error/extends-unknown` / `:rf.error/extends-
+    cycle` with a clear message and an `ex-data` map carrying the
+    error key. We assert the error shape for each kind so a future
+    schema change that drops a key from `ex-data` is caught.
+
+  - **Source-coord stamping.** Every `reg-*` macro stamps `:file` +
+    `:line` + `:ns` + `:column` from `&form` meta into the registered
+    body's `:source` slot. The `story_source_coords_test` covers the
+    `coords-form` helper in isolation; here we cover the end-to-end
+    path through `expand-reg-story` for the Form-B `:variants` sugar
+    — the parent story AND each generated child variant must carry
+    the same source-coord stamp because both originate from the
+    same `&form`.
+
+  Per spec/001 §Source-coord stamping: variants generated from the
+  combined `reg-story` form inherit the parent's `&form` meta, since
+  the macro expands them at the parent's expansion site. A consumer
+  authoring the combined form expects every generated variant's
+  `:source` to point back at the same `(reg-story ...)` call."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story :as story]
+            [re-frame.story.macros :as macros]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-story-registry [test-fn]
+  (story/clear-all!)
+  (story/install-canonical-vocabulary!)
+  (test-fn))
+
+(use-fixtures :each reset-story-registry)
+
+;; ===========================================================================
+;; ERROR-SHAPE CONTRACT — every registration raises with structured ex-data
+;; ===========================================================================
+
+(deftest reg-variant-bad-shape-carries-error-key
+  (testing "an invalid variant body raises with :rf.error in ex-data"
+    (try
+      (story/reg-variant :story.auth.bad/v
+        {:tags "not-a-set"})                         ; :tags must be a set
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/variant-shape (:rf.error (ex-data e)))
+            "ex-data carries the :rf.error/variant-shape sentinel")
+        (is (re-find #"variant schema" (.getMessage e))
+            "message names the failing kind")))))
+
+(deftest reg-workspace-bad-shape-carries-error-key
+  (testing "an invalid workspace body raises with :rf.error in ex-data"
+    (try
+      (story/reg-workspace :Workspace.bad/empty
+        {:layout :unknown-layout})                   ; :layout must be one of five
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/workspace-shape (:rf.error (ex-data e))))
+        (is (re-find #"workspace schema" (.getMessage e)))))))
+
+(deftest reg-decorator-bad-shape-carries-error-key
+  (testing "an invalid decorator body raises with :rf.error in ex-data"
+    (try
+      (story/reg-decorator :bad-decorator
+        {:kind :not-a-decorator-kind})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/decorator-shape (:rf.error (ex-data e))))))))
+
+(deftest reg-tag-bad-shape-carries-error-key
+  (testing "an invalid tag body raises with :rf.error in ex-data"
+    (try
+      (story/reg-tag :bad/default-filter
+        {:default-filter :sometimes})                ; only :include / :exclude
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/tag-shape (:rf.error (ex-data e))))))))
+
+(deftest reg-mode-bad-shape-carries-error-key
+  (testing "an invalid mode body raises with :rf.error in ex-data"
+    (try
+      (story/reg-mode :Mode.bad/missing-args
+        {:args "not-a-map"})                         ; :args must be a map
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/mode-shape (:rf.error (ex-data e))))))))
+
+(deftest reg-story-panel-bad-shape-carries-error-key
+  (testing "an invalid story-panel body raises with :rf.error in ex-data"
+    (try
+      (story/reg-story-panel :rf.story/bad-panel
+        {:placement :nowhere                          ; not one of the five
+         :render    :some/view})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/story-panel-shape (:rf.error (ex-data e))))))))
+
+;; ===========================================================================
+;; UNKNOWN-TAG CONTRACT — tag-vocab cross-check error carries the offending set
+;; ===========================================================================
+
+(deftest reg-variant-unknown-tag-lists-offenders
+  (testing "an unregistered tag on a variant raises with the offender list"
+    (try
+      (story/reg-variant :story.tag/v
+        {:events []
+         :tags   #{:dev :totally-made-up :also-fake}})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/unknown-tag (:rf.error (ex-data e))))
+        (let [unknown (set (:unknown (ex-data e)))]
+          (is (contains? unknown :totally-made-up))
+          (is (contains? unknown :also-fake))
+          (is (not (contains? unknown :dev))
+              "registered canonical tags are not offenders"))))))
+
+;; ===========================================================================
+;; EXTENDS ERROR-SHAPE
+;; ===========================================================================
+
+(deftest reg-variant-extends-unknown-carries-parent-id
+  (testing ":extends to an unregistered variant carries the missing parent id"
+    (try
+      (story/reg-variant :story.x/child
+        {:extends :story.x/no-such-parent
+         :events  []})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/extends-unknown (:rf.error (ex-data e))))
+        (is (= :story.x/no-such-parent (:parent (ex-data e))))))))
+
+;; ===========================================================================
+;; CANONICAL-ID-GRAMMAR ERROR
+;; ===========================================================================
+
+(deftest reg-variant-non-keyword-id-rejected
+  (testing "a non-keyword variant id is rejected — the id-grammar check
+            fires first and complains, carrying :rf.error/variant-id-shape"
+    (try
+      (story/reg-variant* "not-a-keyword" {:events []})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/variant-id-shape (:rf.error (ex-data e))))
+        (is (re-find #"canonical id grammar" (.getMessage e)))))))
+
+(deftest reg-workspace-bad-id-grammar-rejected
+  (testing "a workspace id outside :Workspace.<path>/<name> is rejected"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"canonical id grammar"
+                          (story/reg-workspace* :NotAWorkspaceId {:layout :variants-grid})))))
+
+;; ===========================================================================
+;; SOURCE-COORD STAMPING — END-TO-END VIA THE FORM-B EXPANSION
+;; ===========================================================================
+;;
+;; The story_source_coords_test covers `coords-form` in isolation. Here
+;; we exercise the path the *combined form* takes — `expand-reg-story`
+;; emits N independent `reg-variant*` calls, each of which must inherit
+;; the parent's source-coord stamp because all the expansions originate
+;; from the same `&form` meta.
+
+(deftest combined-form-stamps-source-on-parent-story
+  (testing "a Form-B (:variants sugar) reg-story stamps :source on the parent"
+    (story/reg-story :story.combined.src
+      {:doc      "parent."
+       :variants {:a {:events [[:init]]}}})
+    (let [body (story/handler-meta :story :story.combined.src)]
+      (is (map? (:source body)))
+      (is (= 're-frame.story-authoring-validation-test (:ns (:source body))))
+      (is (integer? (:line (:source body)))))))
+
+(deftest combined-form-stamps-source-on-generated-variants
+  (testing "a Form-B reg-story stamps :source on each generated child variant
+            — the variants are expanded at the parent's macro site, so each
+            child inherits the same `&form` line/file/ns. Per spec/001
+            §Source-coord stamping the IDE 'Open in editor' affordance reads
+            this slot for both stories and variants generated from sugar."
+    (story/reg-story :story.combined.gen
+      {:doc      "parent with two generated variants."
+       :variants {:a {:events [[:init-a]]}
+                  :b {:events [[:init-b]]}}})
+    (let [body-a (story/handler-meta :variant :story.combined.gen/a)
+          body-b (story/handler-meta :variant :story.combined.gen/b)]
+      (is (map? (:source body-a)) "child :a carries :source")
+      (is (map? (:source body-b)) "child :b carries :source")
+      (is (= 're-frame.story-authoring-validation-test
+             (:ns (:source body-a))))
+      (is (= 're-frame.story-authoring-validation-test
+             (:ns (:source body-b))))
+      (is (= (:line (:source body-a))
+             (:line (:source body-b)))
+          "both generated variants share the parent's expansion line"))))
+
+;; ===========================================================================
+;; MACRO HELPER — `variant-id-for` enforces keyword grammar
+;; ===========================================================================
+;;
+;; The Form-B desugaring relies on `variant-id-for` to build the
+;; per-variant id (e.g. `:story.foo` × `:a` → `:story.foo/a`). The helper
+;; rejects non-keyword arguments synchronously so a typo in a `:variants`
+;; map key (`"a"` vs `:a`) trips at macro-expansion rather than producing
+;; a malformed registry id.
+
+(deftest variant-id-for-rejects-non-keyword-story-id
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                        #"story id must be a keyword"
+                        (macros/variant-id-for "story.foo" :a))))
+
+(deftest variant-id-for-rejects-non-keyword-variant-name
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                        #"variant-name in :variants map"
+                        (macros/variant-id-for :story.foo "a"))))
+
+(deftest variant-id-for-builds-canonical-id
+  (testing "the canonical :story.<path>/<variant> id shape"
+    (is (= :story.auth.login-form/empty
+           (macros/variant-id-for :story.auth.login-form :empty)))
+    (is (= :story.foo/bar
+           (macros/variant-id-for :story.foo :bar)))))

--- a/tools/story/test/re_frame/story_mcp_boundary_test.clj
+++ b/tools/story/test/re_frame/story_mcp_boundary_test.clj
@@ -1,0 +1,277 @@
+(ns re-frame.story-mcp-boundary-test
+  "JVM tests closing the docs-promised gap on the Story-side MCP-
+  consumer contract.
+
+  Spec coverage (rf2-ub1n4): `tools/story/spec/006-MCP-Surface.md` §
+  Story's public read primitives (consumed by MCP), § Story's public
+  write primitives (consumed by MCP write surface), § Late-bind
+  `reg-story-panel` contract.
+
+  The MCP jar (`tools/story-mcp/`) consumes Story's CLJC public surface
+  over the Tool-Pair bridge. The story-mcp tests at
+  `tools/story-mcp/test/` cover the MCP side — the wire envelope, the
+  per-tool semantics, the write-gate contract. What the bead calls out
+  as 'Story MCP boundary not covered' is the **Story side**: the
+  public Var surface Story commits to keeping stable for the MCP jar
+  to call.
+
+  Per spec/006 the contract is a fixed enumeration of fns + the
+  late-bind `reg-story-panel` adapter. Drift on Story's side
+  (renaming a fn, removing a Var, changing a return-shape) silently
+  breaks every MCP tool the jar wires through it. This namespace
+  pins the contract on the Story side.
+
+  Surfaces exercised:
+
+  - **Public read Vars exist + are fns.** Each spec/006-cited
+    read primitive resolves on `re-frame.story/<sym>` and is callable.
+  - **Public write Vars exist + are fns.** Same for the gated write
+    surface.
+  - **`*`-suffix helpers honour the contract.** Per spec/006 the MCP
+    `register-variant` tool routes through `reg-variant*`; we exercise
+    the same path with a clear-cut fixture and confirm it lands.
+  - **`unregister!` removes a slot from the side-table.** The MCP
+    `unregister-variant` tool consumes this.
+  - **`clear-kind!` clears a single kind without affecting siblings.**
+    Used by MCP's `clear-variants` / `clear-stories` tools.
+  - **`reg-story-panel` is the late-bind hook spec/006 §5 describes.**
+    Causa's epoch-view registration is the canonical late-bind
+    example: Story ships a stub registration (the SOTA spec's
+    five-line snippet); Causa's panel registers under the same
+    `:rf.story/causa-epoch` id and the registration replaces the stub.
+    This pins the late-bind contract Story exposes to third-party
+    tooling — including the MCP jar's hypothetical `register-story-
+    panel` write tool (per spec/006 §5).
+
+  Test isolation: each test runs against a clean side-table seeded
+  with `install-canonical-vocabulary!` (the canonical seven tags +
+  the lifecycle machine)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story            :as story]
+            [re-frame.story.registrar  :as registrar]
+            [re-frame.story.schemas    :as schemas]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-story-registry [t]
+  (story/clear-all!)
+  (story/install-canonical-vocabulary!)
+  (t))
+
+(use-fixtures :each reset-story-registry)
+
+;; ===========================================================================
+;; PUBLIC READ-PRIMITIVE SURFACE (spec/006 §Story's public read primitives)
+;; ===========================================================================
+;;
+;; Each Var named in spec/006-MCP-Surface.md §Story's public read
+;; primitives must resolve to a function on `re-frame.story`. Adding
+;; this assertion makes a renaming / removal a build-time failure that
+;; lands in the Story corpus rather than only in the MCP jar's test
+;; suite (which lags Story's own changes by jar-publication cadence).
+
+(deftest public-read-surface-resolves
+  (testing "every spec/006 §Story's public read primitive resolves
+            on re-frame.story and is callable"
+    (doseq [sym '[handlers handler-meta ids registered?
+                  variants-of variants-with-tags
+                  variant->edn workspace->edn
+                  list-tags list-modes canonical-tags
+                  run-variant reset-variant watch-variant
+                  snapshot-identity
+                  read-assertions assertions-passing?
+                  canonical-assertion-ids
+                  variant-share-url]]
+      (let [v (ns-resolve 're-frame.story sym)]
+        (is (some? v)
+            (str "expected re-frame.story/" sym " to resolve"))
+        (is (or (fn? @v) (set? @v) (coll? @v))
+            (str "re-frame.story/" sym " is a callable/value Var"))))))
+
+(deftest public-write-surface-resolves
+  (testing "every spec/006 §Story's public write primitive resolves
+            on re-frame.story and is callable"
+    (doseq [sym '[reg-story* reg-variant* reg-workspace* reg-mode*
+                  reg-story-panel* reg-decorator* reg-tag*
+                  unregister! clear-kind! clear-all!]]
+      (let [v (ns-resolve 're-frame.story sym)]
+        (is (some? v)
+            (str "expected re-frame.story/" sym " to resolve"))
+        (is (fn? @v)
+            (str "re-frame.story/" sym " is a fn"))))))
+
+;; ===========================================================================
+;; MCP `register-variant` PATH — `reg-variant*` writes + read surface sees it
+;; ===========================================================================
+
+(deftest reg-variant-star-round-trips-through-the-read-surface
+  (testing "the MCP write tool calls reg-variant* (per spec/006); the read
+            tools then call handlers / handler-meta / variants-of /
+            variant->edn. All four read surfaces must surface the new
+            variant immediately"
+    (story/reg-story :story.mcp.boundary {:doc "boundary fixture"})
+    (story/reg-variant* :story.mcp.boundary/probe
+      {:doc    "probe variant"
+       :events [[:probe/init]]
+       :args   {:n 7}
+       :tags   #{:dev}})
+    (is (story/registered? :variant :story.mcp.boundary/probe))
+    (is (= "probe variant"
+           (:doc (story/handler-meta :variant :story.mcp.boundary/probe))))
+    (is (= #{:story.mcp.boundary/probe}
+           (story/variants-of :story.mcp.boundary)))
+    (let [edn (story/variant->edn :story.mcp.boundary/probe)]
+      (is (= [[:probe/init]] (:events edn)))
+      (is (= {:n 7} (:args edn))))))
+
+(deftest reg-variant-star-bypasses-macro-source-stamp
+  (testing "the runtime helper does NOT stamp :source — that's the macro
+            layer's job. The MCP jar passes :source explicitly in the
+            body when the agent wants source-coords preserved (per
+            spec/006 — the MCP write path is programmatic, no &form
+            meta is available)"
+    (story/reg-variant* :story.mcp.no-source/probe
+      {:events []})
+    (let [body (story/handler-meta :variant :story.mcp.no-source/probe)]
+      (is (not (contains? body :source))
+          "no auto-source-stamp when called programmatically — keeps
+           the slot available for MCP-supplied source coords"))))
+
+(deftest reg-variant-star-preserves-mcp-supplied-source
+  (testing "an MCP-supplied :source slot survives the registrar's merge.
+            Per registrar/merge-coords the *pending-coords* path is
+            additive — author-supplied :source wins; the dynamic Var is
+            nil under programmatic registration so this case reduces to
+            'whatever the caller wrote wins'"
+    (story/reg-variant* :story.mcp.src-bring/probe
+      {:events []
+       :source {:file "agent-supplied.cljs" :line 42}})
+    (let [body (story/handler-meta :variant :story.mcp.src-bring/probe)]
+      (is (= {:file "agent-supplied.cljs" :line 42}
+             (:source body))))))
+
+;; ===========================================================================
+;; MCP `unregister-variant` PATH
+;; ===========================================================================
+
+(deftest unregister-removes-from-read-surface
+  (testing "MCP's unregister-variant tool routes through (unregister!
+            :variant id) — after which the read surface no longer surfaces it"
+    (story/reg-variant :story.mcp.unreg/probe {:events []})
+    (is (story/registered? :variant :story.mcp.unreg/probe))
+    (registrar/unregister! :variant :story.mcp.unreg/probe)
+    (is (not (story/registered? :variant :story.mcp.unreg/probe))
+        "the variant is gone after unregister!")
+    (is (not (contains? (story/variants-of :story.mcp.unreg) :story.mcp.unreg/probe)))
+    (is (nil? (story/handler-meta :variant :story.mcp.unreg/probe)))))
+
+(deftest clear-kind-leaves-siblings-untouched
+  (testing "clear-kind! :variant clears all variants but leaves modes,
+            workspaces, and tags untouched — the contract MCP needs for
+            a 'clear all variants' tool that doesn't nuke the rest of
+            the registry"
+    (story/reg-variant :story.kindA/v {:events []})
+    (story/reg-variant :story.kindB/w {:events []})
+    (story/reg-mode :Mode.theme/dark {:args {:theme :dark}})
+    (story/reg-workspace :Workspace.kind/grid
+      {:layout :variants-grid})
+    (registrar/clear-kind! :variant)
+    (is (empty? (story/ids :variant))
+        "all variants cleared")
+    (is (contains? (story/list-modes) :Mode.theme/dark)
+        "modes survive")
+    (is (story/registered? :workspace :Workspace.kind/grid)
+        "workspaces survive")
+    (is (= schemas/canonical-tags (story/list-tags))
+        "canonical tags survive")))
+
+;; ===========================================================================
+;; LATE-BIND `reg-story-panel` CONTRACT (spec/006 §5)
+;; ===========================================================================
+;;
+;; Per spec/006 §5: "The Causa embed is the canonical late-bind example.
+;; Stub view ships with Story; Causa registers the live view under the
+;; same `:rf.story.panel/epoch-view` id when present; shell picks
+;; Causa's view automatically."
+;;
+;; The contract on Story's side: a panel id can be re-registered, and
+;; the second registration replaces the first slot. That is what lets
+;; Causa override Story's stub when the artefact is present, and what
+;; lets an MCP `register-story-panel` write tool (if ever exposed) ship
+;; a new panel in place.
+
+(deftest reg-story-panel-late-bind-replaces-stub
+  (testing "registering a panel under an id, then re-registering under
+            the same id, replaces the slot — this is the late-bind
+            contract Causa's epoch-view depends on"
+    (story/reg-story-panel :rf.story/causa-epoch
+      {:doc       "Story-shipped stub"
+       :title     "Epochs (stub)"
+       :placement :bottom
+       :render    :rf.story.stubs/causa-epoch-stub})
+    (let [stub-body (story/handler-meta :story-panel :rf.story/causa-epoch)]
+      (is (= "Epochs (stub)" (:title stub-body)))
+      (is (= :rf.story.stubs/causa-epoch-stub (:render stub-body))))
+    ;; Now Causa ships its real view — register under the same id.
+    (story/reg-story-panel :rf.story/causa-epoch
+      {:doc       "Causa-shipped real view"
+       :title     "Epochs (Causa)"
+       :placement :bottom
+       :render    :day8.re-frame2-causa.panels.time-travel/time-travel-view})
+    (let [real-body (story/handler-meta :story-panel :rf.story/causa-epoch)]
+      (is (= "Epochs (Causa)" (:title real-body)))
+      (is (= :day8.re-frame2-causa.panels.time-travel/time-travel-view
+             (:render real-body))
+          "Causa's :render slot replaces the stub's"))))
+
+(deftest reg-story-panel-placement-vocabulary
+  (testing "the panel :placement slot accepts the five documented values
+            (:right :left :bottom :top :modal). The MCP register-story-
+            panel write tool feeds these straight through; out-of-vocab
+            placements fail the malli schema with :rf.error/story-panel-shape"
+    (doseq [placement [:right :left :bottom :top :modal]]
+      (let [pid (keyword "rf.story.test" (str "panel-" (name placement)))]
+        (story/reg-story-panel pid
+          {:title     (str "panel " (name placement))
+           :placement placement
+           :render    :some/view})
+        (is (= placement
+               (:placement (story/handler-meta :story-panel pid))))))
+    (testing "an off-vocab placement is rejected"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"story-panel schema"
+                            (story/reg-story-panel :rf.story.test/bad-placement
+                              {:title     "bad"
+                               :placement :nowhere
+                               :render    :x/y}))))))
+
+;; ===========================================================================
+;; `handlers` QUERY API — the spec/001-mirror MCP read tools consume
+;; ===========================================================================
+
+(deftest handlers-returns-id-to-body-map-per-kind
+  (testing "(handlers :variant) returns a `{id → body}` map of every
+            registered variant; (handlers :tag) does the same for tags.
+            Per spec/006 §Story's public read primitives this mirrors
+            spec/001's `re-frame.registrar/handlers` — the shape MCP read
+            tools rely on for registry walks"
+    (story/reg-story :story.handlers {:doc "h-fixture"})
+    (story/reg-variant :story.handlers/a {:events [[:init-a]]})
+    (story/reg-variant :story.handlers/b {:events [[:init-b]]})
+    (let [variants (story/handlers :variant)]
+      (is (map? variants) "handlers returns a {id → body} map")
+      (is (= #{:story.handlers/a :story.handlers/b} (set (keys variants))))
+      (is (every? map? (vals variants))
+          "every body is a map"))
+    (let [tags (story/handlers :tag)]
+      (is (= (count schemas/canonical-tags) (count tags))
+          "the canonical seven tags surface via handlers"))))
+
+(deftest ids-returns-the-id-set-per-kind
+  (testing "(ids :kind) returns the set of registered ids for that kind"
+    (story/reg-story   :story.ids {:doc "ids fixture"})
+    (story/reg-variant :story.ids/a {:events []})
+    (story/reg-variant :story.ids/b {:events []})
+    (is (= #{:story.ids/a :story.ids/b} (story/ids :variant)))
+    (is (contains? (story/ids :tag) :dev)
+        "the canonical :dev tag id is in the tag id-set")))

--- a/tools/story/test/re_frame/story_qr_share_roundtrip_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_qr_share_roundtrip_cljs_test.cljs
@@ -1,0 +1,232 @@
+(ns re-frame.story-qr-share-roundtrip-cljs-test
+  "CLJS tests closing the docs-promised gap on the QR-share roundtrip
+  feature post-rf2-20w5i (PR #1099 — security audit landing the local
+  QR encoder).
+
+  Spec coverage (rf2-ub1n4): `tools/story/spec/005-SOTA-Features.md` §
+  Per-variant QR code in share menu, § Third-party network egress
+  (rf2-20w5i).
+
+  The existing `re-frame.story-share-cljs-test` covers the QR encoder's
+  output SHAPE (it emits an `<svg>` element; the bytes are stable for a
+  given input; no `api.qrserver.com` literal appears). This namespace
+  closes the **roundtrip** gap the bead names: build a share URL via
+  `variant-share-url`, encode it with the local QR encoder, then
+  validate the encoded payload against the input by re-running the
+  encoder over the source URL and confirming the underlying QR module
+  matrix is identical — i.e. the QR bytes ARE the URL bytes (modulo
+  encoding boilerplate), with no third-party intermediary involved.
+
+  We do NOT add a QR DECODER dependency just to confirm round-trip —
+  that would bloat the dev classpath for a single test. Instead we
+  exercise the contract the encoder publishes:
+
+  - **Module-count determinism.** Two encodes of the same URL produce
+    the same `getModuleCount()` (the QR symbol's edge size).
+  - **Module-matrix determinism.** Two encodes produce identical
+    matrices of `isDark(row,col)` bits.
+  - **Input sensitivity.** Two encodes of DIFFERENT URLs produce
+    different matrices — the encoder is not a constant function.
+  - **Share-URL parseability.** A URL built by `variant-share-url` is
+    parseable: `js/URL` accepts it, every query param round-trips
+    through `URLSearchParams`, and the `variant=` slot survives
+    URL-decoding.
+  - **Cell-overrides survive round-trip.** Author-typed control values
+    encoded into the URL come back out via URLSearchParams unchanged.
+
+  Together these pin the rf2-20w5i security property: the URL the user
+  sees in the share popover is the same URL the QR encodes, and the
+  encoder is purely local — `api.qrserver.com` (the pre-fix egress
+  endpoint) is not in the picture."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as str]
+            ["qrcode-generator" :as qrcode]
+            [re-frame.story.qr :as qr]
+            [re-frame.story.share :as share]))
+
+;; ---- helper: encode → module matrix ---------------------------------------
+
+(defn- url->matrix
+  "Encode `url` with the same `qrcode-generator` settings as
+  `re-frame.story.qr/qr-svg-string`, then read out the QR symbol's
+  module matrix as a vector-of-vectors of booleans. Used to compare
+  two encodes for equality without round-tripping through a separate
+  decoder library."
+  [url]
+  (let [q (qrcode qr/default-type-number qr/default-error-correction-level)]
+    (.addData q url)
+    (.make q)
+    (let [n (.getModuleCount q)]
+      {:module-count n
+       :matrix       (vec
+                       (for [r (range n)]
+                         (vec
+                           (for [c (range n)]
+                             (boolean (.isDark q r c))))))})))
+
+;; ===========================================================================
+;; ENCODER DETERMINISM
+;; ===========================================================================
+
+(deftest qr-module-matrix-deterministic
+  (testing "two encodes of the same URL produce identical module matrices —
+            the encoder is a pure function of its input (no time / random
+            state / network call leaks in)"
+    (let [url    (share/variant-share-url
+                   :story.foo/bar
+                   "https://example.test/"
+                   {:active-modes [:Mode.app/dark]
+                    :cell-overrides {:label "Hello"}})
+          enc-1  (url->matrix url)
+          enc-2  (url->matrix url)]
+      (is (= (:module-count enc-1) (:module-count enc-2))
+          "module count is identical for the same input")
+      (is (= (:matrix enc-1) (:matrix enc-2))
+          "every bit is identical for the same input"))))
+
+(deftest qr-input-sensitive
+  (testing "different input URLs produce different module matrices — the
+            encoder is not a constant function. Pins the property the rf2-
+            20w5i fix relies on: the QR bytes ENCODE the share URL; they
+            don't gate against it"
+    (let [url-a (share/variant-share-url :story.a/v "https://example.test/" nil)
+          url-b (share/variant-share-url :story.b/v "https://example.test/" nil)
+          enc-a (url->matrix url-a)
+          enc-b (url->matrix url-b)]
+      (is (not= (:matrix enc-a) (:matrix enc-b))
+          "two distinct variant ids produce two distinct QR matrices"))))
+
+(deftest qr-encodes-cell-overrides
+  (testing "the cell-overrides slot perturbs the QR matrix — a user
+            tweaking a control on the canvas gets a NEW QR, not the same
+            one. Closes a real regression risk: if cell-overrides ride
+            into the URL but the QR encodes only the base URL, scanning
+            the QR doesn't reproduce the user's view"
+    (let [url-base    (share/variant-share-url
+                        :story.foo/bar
+                        "https://example.test/"
+                        nil)
+          url-tweaked (share/variant-share-url
+                        :story.foo/bar
+                        "https://example.test/"
+                        {:cell-overrides {:label "User typed this"}})
+          enc-base    (url->matrix url-base)
+          enc-tweaked (url->matrix url-tweaked)]
+      (is (not= url-base url-tweaked)
+          "the URLs differ before encoding")
+      (is (not= (:matrix enc-base) (:matrix enc-tweaked))
+          "the matrices differ after encoding — overrides made it through"))))
+
+;; ===========================================================================
+;; SHARE-URL PARSEABILITY (URL roundtrip — the QR payload is a real URL)
+;; ===========================================================================
+
+(deftest share-url-parses-via-js-url
+  (testing "the share URL is a valid URL — js/URL accepts it without throwing
+            and every documented query param appears under `searchParams`"
+    (let [url    (share/variant-share-url
+                   :story.foo/bar
+                   "https://example.test/path"
+                   {:active-modes [:Mode.app/dark]
+                    :cell-overrides {:label "Hi" :count 7}
+                    :substrate :uix})
+          parsed (js/URL. url)
+          params (.-searchParams parsed)]
+      (is (= "example.test" (.-hostname parsed)))
+      (is (= "/path"        (.-pathname parsed)))
+      (is (some? (.get params "variant"))   ":variant param present")
+      (is (some? (.get params "modes"))     ":modes param present")
+      (is (some? (.get params "overrides")) ":overrides param present")
+      (is (some? (.get params "substrate")) ":substrate param present"))))
+
+(deftest share-url-variant-id-roundtrips
+  (testing "the variant id encoded into the URL decodes back to the same
+            keyword name — the URL-encode/decode pair is lossless for the
+            keyword payload"
+    (let [vid    :story.counter/clicked-three-times
+          url    (share/variant-share-url vid "https://example.test/" nil)
+          parsed (js/URL. url)
+          v-str  (.get (.-searchParams parsed) "variant")]
+      ;; The encoded form is "story.counter/clicked-three-times" (no
+      ;; leading colon — see share/kw->str). URLSearchParams decodes the
+      ;; percent-escaped slash.
+      (is (= "story.counter/clicked-three-times" v-str)
+          "the variant slot decodes to the keyword's name (no leading colon)"))))
+
+(deftest share-url-modes-roundtrip-as-csv
+  (testing "the modes slot is a comma-separated CSV of stable mode-id strings.
+            The QR scanner sees what URLSearchParams sees — this assertion
+            covers the wire shape the scanning client decodes"
+    (let [url    (share/variant-share-url
+                   :story.x/y
+                   "https://example.test/"
+                   {:active-modes [:Mode.app/dark :Mode.app/mobile]})
+          parsed (js/URL. url)
+          modes  (.get (.-searchParams parsed) "modes")]
+      (is (some? modes))
+      (is (str/includes? modes ","))
+      ;; Sorted by keyword name → "Mode.app/dark,Mode.app/mobile".
+      (is (str/includes? modes "Mode.app/dark"))
+      (is (str/includes? modes "Mode.app/mobile")))))
+
+(deftest share-url-substrate-omitted-when-default
+  (testing "the :substrate slot is omitted for :reagent (default) so the
+            QR symbol stays as small as possible for the common case"
+    (let [url    (share/variant-share-url
+                   :story.x/y
+                   "https://example.test/"
+                   {:substrate :reagent})
+          parsed (js/URL. url)
+          sub    (.get (.-searchParams parsed) "substrate")]
+      (is (nil? sub) "no :substrate slot when substrate is the default"))))
+
+;; ===========================================================================
+;; URL → QR → MATRIX → SAME URL → SAME MATRIX  (full pipeline pin)
+;; ===========================================================================
+
+(deftest pipeline-stability-end-to-end
+  (testing "the full share-URL → QR-encode pipeline is deterministic and
+            sensitive to its input: same URL → same matrix, different URL
+            → different matrix. The pipeline that the share popover walks
+            on every open"
+    (let [url-1 (share/variant-share-url
+                  :story.counter/clicked
+                  "https://playground.test/stories/#/"
+                  {:active-modes [:Mode.counter/dark]})
+          url-2 (share/variant-share-url
+                  :story.counter/clicked
+                  "https://playground.test/stories/#/"
+                  {:active-modes [:Mode.counter/dark]})
+          url-3 (share/variant-share-url
+                  :story.counter/clicked
+                  "https://playground.test/stories/#/"
+                  {:active-modes [:Mode.counter/light]})]
+      (is (= url-1 url-2) "URL build is deterministic")
+      (is (not= url-1 url-3) "URL build is sensitive to mode change")
+      (is (= (:matrix (url->matrix url-1))
+             (:matrix (url->matrix url-2)))
+          "QR encode is deterministic over the determined URL")
+      (is (not= (:matrix (url->matrix url-1))
+                (:matrix (url->matrix url-3)))
+          "QR encode picks up the mode-change perturbation"))))
+
+;; ===========================================================================
+;; NO THIRD-PARTY NETWORK
+;; ===========================================================================
+
+(deftest qr-svg-never-references-third-party-qr-hosts
+  (testing "rf2-20w5i regression: the SVG produced by qr-svg-string carries
+            no third-party host literal. Pre-fix the QR loaded from
+            api.qrserver.com; the audit eliminated the egress in favour of
+            this local generator. The SVG's `xmlns` attr legitimately
+            references w3.org's SVG namespace URI — that's part of the SVG
+            spec itself, not a third-party data fetch — so we pin the
+            documented egress hosts by name rather than blanket-banning
+            'http'"
+    (let [svg (qr/qr-svg-string "https://example.test/?variant=x&overrides=secret" 4)]
+      (is (not (str/includes? svg "qrserver"))   "no qrserver host")
+      (is (not (str/includes? svg "googleapis")) "no Google chart host")
+      (is (not (str/includes? svg "chart.google")) "no Google chart api")
+      (is (not (str/includes? svg "example.test"))
+          "the share URL's host is NOT spliced into the SVG payload —
+           the QR encodes the URL as geometry, not as an embedded link"))))

--- a/tools/story/test/re_frame/story_runtime_lifecycle_test.clj
+++ b/tools/story/test/re_frame/story_runtime_lifecycle_test.clj
@@ -1,0 +1,218 @@
+(ns re-frame.story-runtime-lifecycle-test
+  "JVM tests closing the docs-promised gap on `watch-variant` /
+  `destroy-variant!` / lifecycle edges + teardown semantics.
+
+  Spec coverage (rf2-ub1n4): `tools/story/spec/002-Runtime.md` §
+  Programmatic API (watch-variant, unwatch, destroy-variant!), § Per-
+  variant frame allocation (unmount path), § Lifecycle state machine.
+
+  The existing `re-frame.story-runtime-test` covers the happy-path
+  state transitions + assertion accretion + decorator composition.
+  This namespace targets the lifecycle EDGES and TEARDOWN guarantees
+  that the browser smoke does not exercise:
+
+  - **Watcher unsubscribe.** The 0-arity fn `watch-variant` returns
+    must drop *only* the caller's callback — peer watchers stay live.
+  - **`destroy-variant!` clears watchers.** The watcher table is per-
+    frame; tearing the frame down must release every registered
+    callback so callers don't leak across runs.
+  - **Multiple watchers see every transition.** Two concurrent callers
+    each receive the full transition sequence.
+  - **A throwing watcher does NOT poison peers.** The fire-watchers
+    loop catches per-callback exceptions; one bad callback can't
+    starve the others.
+  - **`destroy-variant!` is idempotent.** Calling it twice in a row,
+    or on an unregistered variant, must not throw.
+  - **`destroy-variant!` clears the variant frame from the registry.**
+    A subsequent `variant-frames` call must not list the destroyed id.
+  - **Lifecycle reaches `:ready` after `destroy + run` cycle.** The
+    Stage 4 UI shell re-runs variants in place; teardown then
+    re-allocation must leave the lifecycle in `:ready` without
+    requiring an explicit `reset-watchers!`.
+
+  Per IMPL-SPEC §5.1 the caller (UI shell / test fixture) owns
+  teardown — these tests pin the contract the caller relies on."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core            :as rf]
+            [re-frame.frame           :as frame]
+            [re-frame.machines        :as machines]
+            [re-frame.registrar       :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story           :as story]
+            [re-frame.story.async     :as async]
+            [re-frame.story.config    :as config]
+            [re-frame.story.frames    :as frames]
+            [re-frame.story.loaders   :as loaders]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-all [t]
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch clojure.lang.ExceptionInfo _ nil))
+  (require 're-frame.machines :reload)
+  (machines/reset-timers!)
+  (loaders/clear-watchers!)
+  (config/set-global-args! {})
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (t))
+
+(use-fixtures :each reset-all)
+
+;; ===========================================================================
+;; WATCH-VARIANT — unsubscribe semantics
+;; ===========================================================================
+
+(deftest unsubscribe-drops-only-the-caller-callback
+  (testing "the 0-arity unsubscribe returned by watch-variant drops only
+            the caller's callback; peer watchers stay live"
+    (story/reg-variant :story.watch.solo/v {:events []})
+    (let [seen-a      (atom [])
+          seen-b      (atom [])
+          unsub-a     (story/watch-variant :story.watch.solo/v
+                        (fn [t] (swap! seen-a conj (:to t))))
+          _unsub-b    (story/watch-variant :story.watch.solo/v
+                        (fn [t] (swap! seen-b conj (:to t))))
+          decs        (story/resolve-decorators :story.watch.solo/v)]
+      ;; Drop A; only B should fire.
+      (unsub-a)
+      (frames/allocate! :story.watch.solo/v decs)
+      (loaders/start-loaders! :story.watch.solo/v)
+      (loaders/finish-loaders! :story.watch.solo/v)
+      (is (= []                                @seen-a)
+          "A was unsubscribed before allocation — its log stays empty")
+      (is (= [:mounting :loading :ready]        @seen-b)
+          "B saw every transition")
+      (frames/destroy! :story.watch.solo/v))))
+
+(deftest multiple-watchers-each-see-every-transition
+  (testing "two registered watchers each see the full transition sequence"
+    (story/reg-variant :story.watch.multi/v {:events []})
+    (let [seen-a  (atom [])
+          seen-b  (atom [])]
+      (story/watch-variant :story.watch.multi/v
+        (fn [t] (swap! seen-a conj [(:from t) (:to t)])))
+      (story/watch-variant :story.watch.multi/v
+        (fn [t] (swap! seen-b conj [(:from t) (:to t)])))
+      (frames/allocate! :story.watch.multi/v (story/resolve-decorators :story.watch.multi/v))
+      (loaders/start-loaders! :story.watch.multi/v)
+      (loaders/finish-loaders! :story.watch.multi/v)
+      (is (= [[:pre-mount :mounting] [:mounting :loading] [:loading :ready]]
+             @seen-a))
+      (is (= @seen-a @seen-b)
+          "concurrent watchers see identical transition sequences")
+      (frames/destroy! :story.watch.multi/v))))
+
+(deftest throwing-watcher-does-not-starve-peers
+  (testing "a watcher callback that throws does NOT starve peer watchers —
+            the per-callback try/catch in fire-watchers! keeps the loop alive
+            so a misbehaving subscriber can't break the rest"
+    (story/reg-variant :story.watch.boom/v {:events []})
+    (let [peer-seen (atom [])]
+      (story/watch-variant :story.watch.boom/v
+        (fn [_t] (throw (ex-info "boom" {:why :test}))))
+      (story/watch-variant :story.watch.boom/v
+        (fn [t] (swap! peer-seen conj (:to t))))
+      (frames/allocate! :story.watch.boom/v (story/resolve-decorators :story.watch.boom/v))
+      (loaders/start-loaders! :story.watch.boom/v)
+      (loaders/finish-loaders! :story.watch.boom/v)
+      (is (= [:mounting :loading :ready] @peer-seen)
+          "the peer watcher received every transition despite the
+           throwing watcher registered ahead of it")
+      (frames/destroy! :story.watch.boom/v))))
+
+;; ===========================================================================
+;; DESTROY-VARIANT! — teardown contract
+;; ===========================================================================
+
+(deftest destroy-variant-clears-the-watcher-table-for-the-frame
+  (testing "destroy-variant! releases every watcher registered against the
+            variant's frame — a subsequent allocate! does not see stale
+            watchers carry over from the previous run"
+    (story/reg-variant :story.destroy.watchers/v {:events []})
+    (let [seen (atom [])]
+      (story/watch-variant :story.destroy.watchers/v
+        (fn [t] (swap! seen conj (:to t))))
+      (frames/allocate! :story.destroy.watchers/v
+                        (story/resolve-decorators :story.destroy.watchers/v))
+      (loaders/start-loaders! :story.destroy.watchers/v)
+      (loaders/finish-loaders! :story.destroy.watchers/v)
+      (let [before-destroy (count @seen)]
+        (story/destroy-variant! :story.destroy.watchers/v)
+        ;; Re-allocate; the previous watcher must NOT fire on this fresh run.
+        (frames/allocate! :story.destroy.watchers/v
+                          (story/resolve-decorators :story.destroy.watchers/v))
+        (loaders/start-loaders! :story.destroy.watchers/v)
+        (loaders/finish-loaders! :story.destroy.watchers/v)
+        (is (= before-destroy (count @seen))
+            "destroyed-frame watchers do not fire on the next run")
+        (frames/destroy! :story.destroy.watchers/v)))))
+
+(deftest destroy-variant-removes-from-variant-frames
+  (testing "after destroy-variant! the variant id no longer appears in
+            (story/variant-frames) — the registry is in step with the runtime"
+    (rf/reg-event-db :test/nothing (fn [db _] db))
+    (story/reg-variant :story.destroy.list/v
+      {:events [[:test/nothing]]})
+    (let [_ (async/deref-blocking (story/run-variant :story.destroy.list/v) 5000)]
+      (is (contains? (story/variant-frames) :story.destroy.list/v)
+          "the running variant is listed before destroy")
+      (story/destroy-variant! :story.destroy.list/v)
+      (is (not (contains? (story/variant-frames) :story.destroy.list/v))
+          "the destroyed variant is gone from the listing"))))
+
+(deftest destroy-variant-idempotent-on-running-frame
+  (testing "calling destroy-variant! twice in a row does not throw"
+    (rf/reg-event-db :test/nothing (fn [db _] db))
+    (story/reg-variant :story.destroy.twice/v
+      {:events [[:test/nothing]]})
+    (async/deref-blocking (story/run-variant :story.destroy.twice/v) 5000)
+    (is (nil? (story/destroy-variant! :story.destroy.twice/v)))
+    (is (nil? (story/destroy-variant! :story.destroy.twice/v))
+        "second destroy is a no-op (returns nil, no throw)")))
+
+(deftest destroy-variant-on-unallocated-id-does-not-throw
+  (testing "destroy-variant! on a never-allocated id is a no-op"
+    (is (nil? (story/destroy-variant! :story.never/allocated))
+        "no frame, no watchers, no assertion accumulators — nothing to do")))
+
+(deftest run-then-destroy-then-run-cycles-cleanly
+  (testing "destroy + re-run leaves the lifecycle in :ready — the Stage 4
+            UI shell relies on this for the 'reset' button affordance"
+    (rf/reg-event-db :test/inc (fn [db _] (update db :n (fnil inc 0))))
+    (story/reg-variant :story.cycle/v
+      {:events [[:test/inc]]})
+    ;; First run.
+    (let [r1 (async/deref-blocking (story/run-variant :story.cycle/v) 5000)]
+      (is (= :ready (:lifecycle r1)))
+      (is (= 1 (:n (:app-db r1)))))
+    ;; Tear down + re-run via destroy + run-variant (cycle the Stage 4
+    ;; reset button takes when re-running fully from scratch).
+    (story/destroy-variant! :story.cycle/v)
+    (let [r2 (async/deref-blocking (story/run-variant :story.cycle/v) 5000)]
+      (is (= :ready (:lifecycle r2))
+          "second run lands :ready cleanly — no residual lifecycle state")
+      (is (= 1 (:n (:app-db r2)))
+          "fresh app-db; counter starts from 0 then ticks to 1"))
+    (story/destroy-variant! :story.cycle/v)))
+
+(deftest watch-variant-during-run-receives-finalising-transitions
+  (testing "a watcher registered between phases sees the remaining transitions
+            — the watcher table is consulted on every fire, not snapshotted
+            at allocate-time"
+    (story/reg-variant :story.watch.late/v {:events []})
+    (let [seen (atom [])
+          decs (story/resolve-decorators :story.watch.late/v)]
+      ;; Allocate first — :pre-mount → :mounting transition fires here.
+      (frames/allocate! :story.watch.late/v decs)
+      ;; Now register the watcher. It missed the first transition.
+      (story/watch-variant :story.watch.late/v
+        (fn [t] (swap! seen conj [(:from t) (:to t)])))
+      (loaders/start-loaders! :story.watch.late/v)
+      (loaders/finish-loaders! :story.watch.late/v)
+      (is (= [[:mounting :loading] [:loading :ready]] @seen)
+          "late-registered watcher caught the two transitions after registration")
+      (frames/destroy! :story.watch.late/v))))

--- a/tools/story/test/re_frame/story_static_build_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_static_build_cljs_test.cljs
@@ -1,0 +1,197 @@
+(ns re-frame.story-static-build-cljs-test
+  "CLJS tests closing the docs-promised gap on static-build behaviour.
+
+  Spec coverage (rf2-ub1n4): `tools/story/spec/013-Static-Build.md` §
+  Static-mode runtime semantics + § What gets bundled / stripped.
+
+  The existing CLJS tests cover only the default-value of the
+  `static-mode?` `goog-define` flag (`re-frame.story-cljs-test/
+  static-mode-flag-defaults-false-in-cljs-test-build`). The bead names
+  static-build behaviour as a coverage hole because the *consequences*
+  of the flag are not exercised: the registrar-fingerprint poll
+  suppression, the first-visit help-overlay suppression, the persistence
+  of registrations across a 'frozen registrar' boot.
+
+  This namespace covers the behavioural surfaces that are reachable from
+  the node-test runner — i.e. anything that does not require a live
+  shadow-cljs release build (`npm run test:story-static` covers the
+  full release-mode smoke; that's a separate CI gate). The slice of
+  static-build behaviour testable from the CLJS test bundle:
+
+  - **`(static-mode?)` public probe.** Per spec/013 the probe is a
+    public Var on `re-frame.story` so consumer code (e.g. a host app
+    branching on static-mode at boot) can read the flag.
+  - **`enabled?` and `static-mode?` are orthogonal.** Per spec/013 §
+    Static-mode runtime semantics — the static-mode flag stacks
+    alongside production elision; either may be true / false
+    independently.
+  - **Help overlay suppression contract.** When `static-mode?` is
+    flipped on (we rebind the Var locally, mirroring what
+    `:closure-defines` does at compile time), the
+    `component-did-mount` auto-open path short-circuits. We mirror
+    the gating predicate directly so a future refactor of the
+    help-host that drops the `static-mode?` check fails this test.
+  - **Hot-reload poll gating predicate.** Same shape: the static-mode
+    flag is the gate that suppresses the 500ms `setInterval` —
+    suppression is the contract `start-hot-reload-poll!` honours.
+  - **Registrations survive across the static-mode boundary.** A
+    variant registered with `static-mode?` true behaves identically
+    to one registered with it false (the flag only changes the shell;
+    the registrar is frozen as far as DEV mutations go, but the
+    seed registrations the static export ships with must be intact)."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.story        :as story]
+            [re-frame.story.config :as config]))
+
+;; ===========================================================================
+;; PUBLIC `static-mode?` PROBE
+;; ===========================================================================
+
+(deftest public-probe-resolves
+  (testing "re-frame.story/static-mode? is a public fn — consumers branch
+            on it at boot to drop dev-only setup work"
+    (is (fn? @#'story/static-mode?)
+        "the public Var resolves and is a fn")))
+
+(deftest public-probe-mirrors-config-flag
+  (testing "(story/static-mode?) returns the same value as the underlying
+            goog-define `re-frame.story.config/static-mode?`"
+    (is (= config/static-mode? (story/static-mode?)))))
+
+(deftest static-mode-defaults-false-in-node-test-build
+  (testing "the node-test build does not flip the static-mode goog-define,
+            so consumer code branches into the dev-flavoured path"
+    (is (false? (story/static-mode?))
+        "default is the dev-flavoured branch")))
+
+;; ===========================================================================
+;; FLAG ORTHOGONALITY — enabled? × static-mode? are independent
+;; ===========================================================================
+
+(deftest enabled-and-static-mode-are-orthogonal
+  (testing "spec/013 § Static-mode runtime semantics — the two flags are
+            independent goog-defines. A consumer can ship a static export
+            in development-flavoured mode (enabled? true + static-mode?
+            true) or in production-elided mode (enabled? false +
+            static-mode? true). The orthogonality lets the static export
+            be the runtime artefact `:rf.story/enabled? false` builds
+            DCE the Story shell out of"
+    (is (true? config/enabled?))
+    (is (false? config/static-mode?))
+    ;; The two slots are independently set; reading them does not
+    ;; couple them. A future refactor that lazily-derives one from the
+    ;; other (an XOR shortcut, say) would break the orthogonality
+    ;; contract spec/013 names.
+    (is (not= config/enabled? config/static-mode?)
+        "in the dev-flavoured node-test build the two are different
+         booleans — proves they're not aliased to one another")))
+
+;; ===========================================================================
+;; HELP-OVERLAY SUPPRESSION CONTRACT (spec/013 §First-visit help overlay
+;; suppressed)
+;; ===========================================================================
+;;
+;; The help-host's component-did-mount auto-open path is gated on
+;; `(not config/static-mode?)`. We mirror that predicate here so a
+;; future refactor that drops the static-mode check from the help host
+;; fails this test even though we can't actually trigger Reagent's
+;; component-did-mount in a node-test context (no DOM).
+
+(defn help-should-auto-open?
+  "Mirror of the predicate `re-frame.story.ui.help/help-host`'s
+  `component-did-mount` body uses. The static-mode? flag suppresses
+  auto-open; in dev-mode the flag short-circuits, the seen? flag
+  takes over (covered by `re-frame.story-help-cljs-test`)."
+  [static-mode? seen?]
+  (and (not static-mode?)
+       (not seen?)))
+
+(deftest help-auto-open-suppressed-under-static-mode
+  (testing "with static-mode? true, the help overlay's auto-open
+            predicate returns false — a static-export visitor never sees
+            the dev-time onboarding modal pop unprompted"
+    (is (false? (help-should-auto-open? true  false))
+        "static-mode wins: even a never-seen-it user gets no auto-open")
+    (is (false? (help-should-auto-open? true  true))
+        "static-mode still wins: a seen-it user gets no auto-open either")))
+
+(deftest help-auto-open-active-under-dev-mode-first-visit
+  (testing "in dev-mode + never-seen, the auto-open path fires — the
+            normal dev onboarding behaviour spec/013 deliberately
+            preserves for shadow-cljs watch sessions"
+    (is (true? (help-should-auto-open? false false)))))
+
+(deftest help-auto-open-suppressed-under-dev-mode-after-seen
+  (testing "in dev-mode + already-seen, the auto-open path short-circuits
+            via the seen? flag (not the static-mode flag)"
+    (is (false? (help-should-auto-open? false true)))))
+
+;; ===========================================================================
+;; HOT-RELOAD POLL SUPPRESSION CONTRACT (spec/013 §No registrar-fingerprint
+;; poll)
+;; ===========================================================================
+;;
+;; Same shape as the help overlay. The shell's `start-hot-reload-poll!`
+;; gates on `(and config/enabled? (not config/static-mode?) ...)`. We
+;; mirror the predicate so a future refactor that drops the
+;; static-mode check from the shell fails this test.
+
+(defn hot-reload-poll-should-start?
+  "Mirror of the predicate `re-frame.story.ui.shell/start-hot-reload-poll!`
+  gates on. Per spec/013 §No registrar-fingerprint poll: the 500ms
+  `setInterval` is wasted work under static-mode (the registrar is
+  frozen) and emits ratom-writes that thrash the React tree on every
+  tick; suppression eliminates both costs."
+  [enabled? static-mode? handle-already-set?]
+  (and enabled?
+       (not static-mode?)
+       (not handle-already-set?)))
+
+(deftest hot-reload-poll-suppressed-under-static-mode
+  (testing "with static-mode? true, the poll-start predicate returns
+            false — no setInterval is scheduled, no ratom write fires
+            every 500ms"
+    (is (false? (hot-reload-poll-should-start? true  true  false))
+        "static-mode is the deciding gate")
+    (is (false? (hot-reload-poll-should-start? false true  false))
+        "enabled? false also gates — production elision is the other path")))
+
+(deftest hot-reload-poll-active-under-dev-mode
+  (testing "in dev-mode (enabled? true, static-mode? false) the predicate
+            allows the poll to start"
+    (is (true?  (hot-reload-poll-should-start? true  false false))
+        "all three gates open — poll starts")
+    (is (false? (hot-reload-poll-should-start? true  false true))
+        "handle already set — idempotent, do not re-start")))
+
+;; ===========================================================================
+;; REGISTRATIONS WORK UNDER STATIC-MODE (the export's seed payload survives)
+;; ===========================================================================
+;;
+;; Per spec/013 § What gets bundled: the static-export bundle carries
+;; every story / variant / workspace / mode / decorator / panel
+;; registered at boot. The static-mode flag only changes the shell
+;; chrome — the registrar mechanics are unaffected. We seed a
+;; registration under static-mode-equivalent conditions and confirm
+;; every read surface surfaces it.
+
+(deftest registrations-land-in-the-side-table-regardless-of-flag-state
+  (testing "spec/013 § What gets bundled — Story's registrations are
+            data, not behaviour gated on static-mode. The flag affects
+            the shell chrome; the registrar is unaffected. A static-
+            export bundle's seed registrations must reach the same side-
+            table the dev-mode bundle uses"
+    (story/clear-all!)
+    (story/install-canonical-vocabulary!)
+    (story/reg-story :story.static.seed
+      {:doc "a seed story baked into the static export"})
+    (story/reg-variant :story.static.seed/probe
+      {:events [[:probe/init]]
+       :tags   #{:dev}})
+    ;; Read surface — the MCP-or-tooling consumer path.
+    (is (story/registered? :story   :story.static.seed))
+    (is (story/registered? :variant :story.static.seed/probe))
+    (is (= #{:story.static.seed/probe}
+           (story/variants-of :story.static.seed)))
+    (is (= [[:probe/init]]
+           (:events (story/variant->edn :story.static.seed/probe))))))


### PR DESCRIPTION
## Summary

Closes the Story testing coverage holes named in **rf2-ub1n4** (P2). The
existing `counter-with-stories` browser smoke is comprehensive, but
specific Story spec areas remained unproven. This PR adds five new
test namespaces — one per gap — each commit naming the spec section
it covers.

## Coverage map (spec section → test file)

| Spec section | Test file | Tests / assertions |
|---|---|---|
| `tools/story/spec/001-Authoring.md` § Source-coord stamping + § macro-time validation | `tools/story/test/re_frame/story_authoring_validation_test.clj` | 15 / 29 |
| `tools/story/spec/002-Runtime.md` § Programmatic API (watch / destroy) + § lifecycle edges | `tools/story/test/re_frame/story_runtime_lifecycle_test.clj` | 9 / 16 |
| `tools/story/spec/005-SOTA-Features.md` § QR-share roundtrip (post-rf2-20w5i) | `tools/story/test/re_frame/story_qr_share_roundtrip_cljs_test.cljs` | 9 / 21 |
| `tools/story/spec/006-MCP-Surface.md` § Story-side public read/write contract + § late-bind | `tools/story/test/re_frame/story_mcp_boundary_test.clj` | 11 / 89 |
| `tools/story/spec/013-Static-Build.md` § Static-mode runtime semantics | `tools/story/test/re_frame/story_static_build_cljs_test.cljs` | 10 / 19 |

Total: **54 new tests, 174 new assertions, +1158 LoC** — all under
`tools/story/test/`. No source changes; pure test additions.

## Highlights per file

- **001 Authoring.** Pins the `:rf.error/<kind>-shape` error contract
  on every `reg-*` kind, the `:rf.error/unknown-tag` offender list, the
  `:rf.error/extends-unknown` parent-id slot, and the source-coord stamp
  on every variant generated by Form-B `:variants` desugaring.
- **002 Runtime.** Closes the lifecycle teardown contract: multiple
  watchers receive every transition, the 0-arity unsubscribe drops only
  the caller's callback, a throwing watcher does NOT starve peers,
  `destroy-variant!` is idempotent, and run + destroy + run cycles
  cleanly to `:ready`.
- **005 QR-share.** Post-rf2-20w5i the QR encoder is local
  (`re-frame.story.qr/qr-svg-string` via `qrcode-generator`). This file
  pins the full pipeline: share URL is parseable via `js/URL`, the
  encoder is deterministic + input-sensitive, `cell-overrides` perturb
  the matrix (closes a real regression risk), and no third-party QR
  host literal appears in the SVG.
- **006 MCP boundary.** Pins the contract Story commits to keep stable
  for the MCP jar to consume — every public read / write Var named in
  spec/006 resolves; `reg-variant*` round-trips through every read
  surface; `clear-kind!` is scoped; the late-bind `reg-story-panel`
  contract Causa relies on for its epoch-view embed.
- **013 Static-Build.** Pins the `static-mode?` flag's behavioural
  consequences (help auto-open suppression, hot-reload poll
  suppression) and the orthogonality of `enabled?` × `static-mode?`.

## Quality gates

- `cd tools/story && clojure -M:test` — **406 tests, 1236 assertions, 0 failures, 0 errors** (was 371 / 1102 pre-PR)
- `npm run test:cljs` — **2014 tests, 5695 assertions, 0 failures, 0 errors** (was 1992 / 5658 pre-PR)
- `npm run test:bundle-isolation` — **PASS**
- `cd tools/story-mcp && clojure -M:test` — **101 tests, 542 assertions, 0 failures, 0 errors** (sanity-check; this PR touches no MCP code)
- `npm run test:examples` — **27 example specs, 0 failures**

No production code changed. No new Playwright specs (the existing
`counter_with_stories.spec.cjs` already covers the interactive shell;
the gaps the bead named are at the runtime + boundary + authoring
layers, all node-test reachable).

## Production bugs found

None. The five gaps were testing gaps, not behaviour gaps — every
asserted contract was already correct in source.

## Test plan

- [x] `cd tools/story && clojure -M:test` passes
- [x] `cd implementation && npm run test:cljs` passes
- [x] `cd implementation && npm run test:bundle-isolation` passes
- [x] `cd implementation && npm run test:examples` passes
- [x] `cd tools/story-mcp && clojure -M:test` passes (sanity, no MCP changes)