### PR TITLE
fix(pair2-mcp-drift): enumerate handler-meta + registry-list in conformance + skill (rf2-kmeds)

### DIFF
--- a/skills/re-frame-pair2/SKILL.md
+++ b/skills/re-frame-pair2/SKILL.md
@@ -26,6 +26,8 @@ allowed-tools:
   - mcp__re-frame-pair2__subscribe
   - mcp__re-frame-pair2__unsubscribe
   - mcp__re-frame-pair2__subscription-info
+  - mcp__re-frame-pair2__handler-meta
+  - mcp__re-frame-pair2__registry-list
   - mcp__re-frame-pair2__get-pair2-instructions
   # story-mcp — live-session tools only (rf2-1v7tu HYBRID). The
   # authoring-side surface (register-variant, get-variant,

--- a/tools/mcp-conformance/test/end-to-end-pair2.js
+++ b/tools/mcp-conformance/test/end-to-end-pair2.js
@@ -34,15 +34,20 @@ const SERVER = path.resolve(__dirname, '..', '..', 'pair2-mcp', 'out', 'server.j
 
 // Expected tools advertised by pair2-mcp's tools/list. Pinned exact so
 // accidental renames / additions / deletions surface here. Mirrors the
-// upstream stdio-roundtrip baseline (twelve tools post-rf2-fnpqg, which
-// added `get-pair2-instructions` as an agent-paste preamble tool on top
-// of the eleven-tool post-rf2-zjz9q baseline).
+// upstream stdio-roundtrip baseline (fourteen tools post-rf2-cibp8 +
+// rf2-pctf8, which added `handler-meta` and `registry-list` as the
+// registry-introspection pair on top of the twelve-tool post-rf2-fnpqg
+// baseline; that earlier expansion added `get-pair2-instructions` as an
+// agent-paste preamble tool on top of the eleven-tool post-rf2-zjz9q
+// baseline).
 const EXPECTED_TOOLS = [
   'discover-app',
   'dispatch',
   'eval-cljs',
   'get-pair2-instructions',
   'get-path',
+  'handler-meta',
+  'registry-list',
   'snapshot',
   'subscribe',
   'subscription-info',

--- a/tools/pair2-mcp/test/stdio-roundtrip.js
+++ b/tools/pair2-mcp/test/stdio-roundtrip.js
@@ -89,11 +89,13 @@ function run() {
 
       notify('notifications/initialized', {});
 
-      // 2. tools/list — expect all twelve tools (six original + snapshot
+      // 2. tools/list — expect all fourteen tools (six original + snapshot
       // mega-op from rf2-x70e + subscribe/unsubscribe streaming pair
       // from rf2-hq49 + get-path read-by-path primitive from rf2-tygdv
       // + subscription-info read-side wrapper from rf2-zjz9q +
-      // get-pair2-instructions agent-onboarding text from rf2-fnpqg).
+      // get-pair2-instructions agent-onboarding text from rf2-fnpqg +
+      // handler-meta registry-introspection from rf2-cibp8 +
+      // registry-list registry-enumeration from rf2-pctf8).
       // rf2-7dvg cut inject-runtime in favour of a shadow-cljs
       // :preloads entry; see SKILL.md §Setup.
       const list = await call('tools/list', {});
@@ -104,6 +106,8 @@ function run() {
         'eval-cljs',
         'get-pair2-instructions',
         'get-path',
+        'handler-meta',
+        'registry-list',
         'snapshot',
         'subscribe',
         'subscription-info',


### PR DESCRIPTION
## Summary

PR #1107 (rf2-cibp8 + rf2-pctf8) added two new pair2-mcp tools — `handler-meta` (registry-introspection) and `registry-list` (registry-enumeration) — but didn't update the three surfaces that pin the tool catalogue. Result: two CI checks (`MCP conformance tools/pair2-mcp` rf2-cum40 + `Verify skill <-> MCP allowed-tools drift` rf2-flzdp) have been failing on every unrelated PR, forcing `--admin` overrides on merges (e.g. rf2-mwft2 #1108, rf2-5br2q #1109).

This PR closes the drift. Expectation-only — no production source touched.

## Changes

- `tools/mcp-conformance/test/end-to-end-pair2.js` — bumps `EXPECTED_TOOLS` from 12 to 14, with rf2-cibp8 / rf2-pctf8 cross-refs in the comment.
- `tools/pair2-mcp/test/stdio-roundtrip.js` — same bump on the upstream hand-rolled JSON-RPC baseline that the conformance test mirrors.
- `skills/re-frame-pair2/SKILL.md` — adds `mcp__re-frame-pair2__handler-meta` + `mcp__re-frame-pair2__registry-list` to the `allowed-tools` frontmatter so the skill-drift gate finds the host-prefixed entries against `descriptors_data.cljs`.

## Test plan

- [x] `python scripts/check_skill_mcp_drift.py --verbose` -> `pair2-mcp <-> re-frame-pair2: server=14 tools, skill=14 allow-listed`, no drift.
- [x] `node tools/mcp-conformance/test/end-to-end-pair2.js` -> `PAIR2-MCP MCP-CLIENT CONFORMANCE GREEN`, 14 tools advertised.
- [x] `node tools/pair2-mcp/test/stdio-roundtrip.js` -> `SERVER STDIO ROUND-TRIP GREEN`.
- [x] `npm run test:cljs` -> 1995 tests, 5652 assertions, 0 failures.
- [x] `npm run test:bundle-isolation` -> `=== PASS ===`.

Closes rf2-kmeds. Unblocks clean CI for all subsequent PRs (no more `--admin` merges for unrelated work).