### PR TITLE
test(ssr): browser integration tests — hydration + error paths + multi-frame (rf2-ik4io)

### DIFF
--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -229,6 +229,41 @@ const EXAMPLES = [
     htmlSrc: path.join(REPO_ROOT, 'examples', 'reagent', 'websocket', 'index.html'),
     outDir: path.join(OUT_ROOT, 'websocket'),
   },
+  // rf2-ik4io — SSR hydration baseline. Static index.html bakes
+  // pre-rendered HTML + a :rf/hydration-payload script; the browser-
+  // side run reads the payload, dispatches :rf/hydrate, and calls
+  // verify-hydration!. The companion spec.cjs lives at
+  // testbeds/ssr_basic/spec.cjs.
+  //
+  // These three SSR testbeds are top-level `testbeds/<surface>/`
+  // siblings of `examples/<substrate>/` (per the testbeds split,
+  // rf2-96nb3); the shadow-cljs build id uses the `testbeds/` prefix
+  // and lands the bundle under `implementation/out/testbeds/<id>/`.
+  // The orchestrator serves http://127.0.0.1:8030/<id>/ from OUT_ROOT
+  // (out/examples/), so we redirect outDir into the served root with
+  // a `testbed-` prefix to keep the URL path unambiguous.
+  {
+    build: 'testbeds/ssr-basic',
+    htmlSrc: path.join(REPO_ROOT, 'testbeds', 'ssr_basic', 'index.html'),
+    outDir: path.join(OUT_ROOT, 'testbed-ssr-basic'),
+  },
+  // rf2-ik4io — SSR hydration-mismatch surface. The payload bakes a
+  // deliberately wrong :rf/render-hash so verify-hydration! emits
+  // :rf.ssr/hydration-mismatch with :recovery :warned-and-replaced.
+  {
+    build: 'testbeds/ssr-hydration-mismatch',
+    htmlSrc: path.join(REPO_ROOT, 'testbeds', 'ssr_hydration_mismatch', 'index.html'),
+    outDir: path.join(OUT_ROOT, 'testbed-ssr-hydration-mismatch'),
+  },
+  // rf2-ik4io — SSR multi-frame surface. Three frames each hydrate
+  // independently from their own payload slice; the three panels
+  // prove per-frame state restoration through the hydration
+  // boundary.
+  {
+    build: 'testbeds/ssr-multi-frame',
+    htmlSrc: path.join(REPO_ROOT, 'testbeds', 'ssr_multi_frame', 'index.html'),
+    outDir: path.join(OUT_ROOT, 'testbed-ssr-multi-frame'),
+  },
 ];
 
 function compileAll() {

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -749,4 +749,51 @@
    :output-dir "out/testbeds/known-bad-a11y"
    :asset-path "."
    :modules    {:main {:init-fn known-bad-a11y.core/run}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
+
+  ;; rf2-ik4io — ssr-basic testbed (SSR hydration baseline). The static
+  ;; index.html bakes pre-rendered HTML + a :rf/hydration-payload script
+  ;; (mirroring what the JVM-side render-to-string + payload builder
+  ;; would emit per spec/011-SSR.md). The browser-side run reads the
+  ;; payload, dispatches :rf/hydrate, renders, and calls
+  ;; verify-hydration!. A trace listener mirrors every :rf.ssr/* and
+  ;; :rf/hydrate trace event onto window.__rf_trace_events() for
+  ;; Playwright assertion.
+  ;;
+  ;; :output-dir lands under out/examples/ (not out/testbeds/) so the
+  ;; examples orchestrator's http-server root serves the bundle
+  ;; without a second copy step. The `testbed-` prefix on the directory
+  ;; keeps the served URL path unambiguous against the canonical
+  ;; tutorial examples.
+  :testbeds/ssr-basic
+  {:target     :browser
+   :output-dir "out/examples/testbed-ssr-basic"
+   :asset-path "."
+   :modules    {:main {:init-fn ssr-basic.core/run}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
+
+  ;; rf2-ik4io — ssr-hydration-mismatch testbed (the deliberate-mismatch
+  ;; surface). The payload bakes a known-wrong :rf/render-hash so
+  ;; verify-hydration! emits :rf.ssr/hydration-mismatch with
+  ;; :recovery :warned-and-replaced per spec/011 §Hydration-mismatch
+  ;; detection. The same trace listener as ssr-basic exposes the trace
+  ;; event payload on window so the dev-mode assertion can read it.
+  :testbeds/ssr-hydration-mismatch
+  {:target     :browser
+   :output-dir "out/examples/testbed-ssr-hydration-mismatch"
+   :asset-path "."
+   :modules    {:main {:init-fn ssr-hydration-mismatch.core/run}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
+
+  ;; rf2-ik4io — ssr-multi-frame testbed (per-frame hydration isolation).
+  ;; Three frames each receive their own :rf/hydrate dispatch with a
+  ;; per-frame :rf/app-db slice; the resulting view tree's three
+  ;; per-frame panels prove each frame's state was restored
+  ;; independently. Exercises Spec 002's per-request frame contract
+  ;; through the hydration boundary.
+  :testbeds/ssr-multi-frame
+  {:target     :browser
+   :output-dir "out/examples/testbed-ssr-multi-frame"
+   :asset-path "."
+   :modules    {:main {:init-fn ssr-multi-frame.core/run}}
    :devtools   {:preloads [day8.re-frame2-causa.preload]}}}}

--- a/testbeds/ssr_basic/README.md
+++ b/testbeds/ssr_basic/README.md
@@ -1,0 +1,72 @@
+# `testbeds/ssr-basic`
+
+The **SSR hydration baseline**. Server-rendered HTML + a serialised
+`:rf/hydration-payload` arrive baked into the static `index.html` (the
+shape the JVM-side `render-to-string` + payload builder would emit per
+[`spec/011-SSR.md`](../../spec/011-SSR.md)). The browser-side `run`:
+
+1. Reads the EDN payload from `<script id="__rf_payload">`.
+2. Dispatches `[:rf/hydrate payload]` (replace-app-db policy, locked).
+3. Renders the registered root view against the now-seeded app-db.
+4. Calls `re-frame.ssr/verify-hydration!` with the resolved render tree
+   so the runtime can compare hashes and emit
+   `:rf.ssr/hydration-mismatch` on disagreement.
+
+| `data-testid` | What it carries / proves |
+|---|---|
+| `ssr-basic` | Root marker — visible from first byte (pre-rendered). |
+| `not-hydrated` / `hydrated` | Discriminator on `:rf/hydration` presence in app-db. The static HTML ships the `not-hydrated` marker; first render after `:rf/hydrate` swaps to `hydrated`. |
+| `count` | Seeded via payload's `:rf/app-db {:count 7}`. Click `inc` mutates → re-render → count++. |
+| `title` | Seeded via payload's `:rf/app-db {:title "seeded"}`. Click `set-title` writes `"hydrated"`. |
+| `resp-status` / `resp-ct` / `resp-cookies-count` / `resp-cookie-name` | Materialise the payload's `:rf/response` slice — proves per-request `:rf.server/*` accumulator round-trips through the wire into the view layer. |
+
+The trace listener registered at boot mirrors every `:rf.ssr/*` and
+`:rf/hydrate` trace event onto `window.__rf_trace_events()` so Playwright
+can assert against the hydration handshake without poking at internal
+cljs vars.
+
+## What this surface tests (per spec/011-SSR.md)
+
+| Spec section | Behaviour exercised |
+|---|---|
+| §Hydration is a defined protocol | Payload arrives, `:rf/hydrate` replaces app-db, client renders. |
+| §Payload scope (canonical boundary) | The four required keys plus optional `:rf/response`; nothing else on the wire. |
+| §The `:rf/hydrate` event | `:replace-app-db` policy carries the server's slice verbatim; `[:rf/hydration]` metadata stashed. |
+| §Hydration-mismatch detection | `verify-hydration!` invoked post first-render; no mismatch when server-hash is nil (baseline). |
+| §`:rf.ssr/check-version` (rf2-69ad2) | Fx dispatched as part of `:rf/hydrate`'s `:fx`; trace event surfaces via the listener. |
+| §Response storage substrate | The payload-carried `:rf/response` shape exercises the canonical `{:status :headers :cookies :redirect}` accumulator. |
+| §Frames are per-request | `:rf/frame-id` in the payload demonstrates the frame-id round-trip — server's frame becomes the addressing target on hydrate. |
+
+## What this surface deliberately omits
+
+- The mismatch path. The payload's `:rf/render-hash` is `nil`, so
+  `verify-hydration!` no-ops cleanly. Mismatch detection is exercised
+  by [`testbeds/ssr_hydration_mismatch/`](../ssr_hydration_mismatch/).
+- Multi-frame hydration. Exercised by [`testbeds/ssr_multi_frame/`](../ssr_multi_frame/).
+- The JVM-side render. Spec 011's hiccup → HTML emitter and FNV-1a
+  hash are pinned by `implementation/ssr/test/re_frame/` (the JVM
+  conformance corpus and end-to-end tests).
+
+## Running
+
+From `implementation/`:
+
+```bash
+shadow-cljs watch testbeds/ssr-basic
+# Or via the orchestrator:
+npm run test:examples
+```
+
+Shadow-cljs build id is `testbeds/ssr-basic`; output lands in
+`implementation/out/testbeds/ssr-basic/`. The orchestrator
+(`examples/scripts/serve-and-run-examples-tests.cjs`) stages this
+testbed's `index.html` next to `main.js` and serves the directory
+at `/ssr-basic/`.
+
+## Cross-references
+
+- [`spec/011-SSR.md` §Hydration is a defined protocol](../../spec/011-SSR.md) — the round-trip contract.
+- [`spec/011-SSR.md` §Payload scope](../../spec/011-SSR.md) — the canonical four payload keys.
+- [`spec/011-SSR.md` §Response storage substrate](../../spec/011-SSR.md) — the per-request side-channel substrate the `:rf/response` slot serialises.
+- [`examples/reagent/ssr/core.cljc`](../../examples/reagent/ssr/core.cljc) — the JVM-side `handle-request` reference; the static index.html is the byte-shape this function would emit.
+- [`implementation/ssr/test/re_frame/ssr_end_to_end_test.clj`](../../implementation/ssr/test/re_frame/ssr_end_to_end_test.clj) — the JVM-side end-to-end coverage; this testbed pairs with it on the browser side.

--- a/testbeds/ssr_basic/core.cljs
+++ b/testbeds/ssr_basic/core.cljs
@@ -59,7 +59,10 @@
 
 (defn- ev->js
   "Project a trace event into a Playwright-friendly JS shape — only the
-  fields the spec.cjs assertions need, stringified where useful."
+  fields the spec.cjs assertions read against. `:recovery` is hoisted
+  to the top level of the trace envelope (per Spec 009 §Error event
+  shape — `re-frame.trace/build-event`'s recovery-hoist branch); the
+  others ride in `:tags`."
   [ev]
   (let [t (:tags ev)]
     (clj->js
@@ -69,7 +72,8 @@
         (:client-hash t) (assoc :client-hash (:client-hash t))
         (:failing-id t)  (assoc :failing-id (str (:failing-id t)))
         (:check t)       (assoc :check (str (:check t)))
-        (:recovery t)    (assoc :recovery (str (:recovery t)))))))
+        ;; `:recovery` is hoisted onto the top-level envelope.
+        (:recovery ev)   (assoc :recovery (str (:recovery ev)))))))
 
 (defn install-trace-listener! []
   ;; HOT PATH — wire the trace bus to a window-side mirror so a

--- a/testbeds/ssr_basic/core.cljs
+++ b/testbeds/ssr_basic/core.cljs
@@ -1,0 +1,209 @@
+(ns ssr-basic.core
+  "Shared framework-behavior testbed — SSR hydration baseline.
+
+  This surface exercises the SSR round-trip from the browser end. The
+  pre-rendered HTML and the serialised payload are baked into the static
+  `index.html` (the shape `re-frame.ssr/render-to-string` + the JVM
+  payload builder would emit — see `examples/reagent/ssr/core.cljc`'s
+  `handle-request` for the reference). The browser-side `run` reads the
+  payload, dispatches `:rf/hydrate` (locked `:replace-app-db` policy per
+  [spec/011-SSR.md §The :rf/hydrate event]), renders against the now-
+  seeded app-db, and invokes `verify-hydration!` to drive hash-based
+  mismatch detection.
+
+  Per-request `:rf.server/*` response data — the per-request side-channel
+  the server-side framework uses for headers / cookies / status / redirect
+  — round-trips via the payload's optional `:rf/response` slice; the
+  client materialises it into app-db at `[:server-response]` so the view
+  can render the resolved shape.
+
+  What a Playwright consumer observes:
+
+    - The pre-rendered counter / title / response panel are visible from
+      the first byte (before main.js loads).
+    - After main.js boots, `:rf/hydrate` replaces app-db with the
+      payload's `:rf/app-db` slice. The hydrate metadata lands at
+      [:rf/hydration] in app-db and a `data-testid='hydrated'` element
+      switches from `not-hydrated` to `hydrated`.
+    - `:rf.ssr/check-version` (always) and `:rf.ssr/check-schema-digest`
+      (when the payload carries a digest) fxs run. The runtime emits
+      `:rf.ssr/compatibility-check-skipped` traces when the late-bind
+      hooks aren't registered — captured by the trace listener installed
+      below and exposed on `window.__rf_trace_events()`.
+    - `verify-hydration!` is invoked post-first-render with the resolved
+      client tree. On the happy path (no hash baked in the payload) the
+      check no-ops cleanly; a sibling testbed (`ssr_hydration_mismatch/`)
+      exercises the mismatch trace.
+    - Click pipeline is live post-hydration: `inc` mutates `:count`, the
+      sub recomputes, the view re-renders.
+
+  This is NOT a tutorial — bodies are stark. HOT PATH comments mark the
+  three load-bearing trigger sites: trace-bus listener install, hydrate
+  dispatch, and post-render `verify-hydration!`."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.ssr :as ssr]
+            [re-frame.trace :as trace]
+            [cljs.reader])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ----------------------------------------------------------------------------
+;; Trace listener — capture every :rf.ssr/* + :rf/hydrate trace event
+;; onto `window.__rf_trace_events()` so Playwright can assert against
+;; the hydration handshake post-load.
+;; ----------------------------------------------------------------------------
+
+(defonce trace-events (atom []))
+
+(defn- ev->js
+  "Project a trace event into a Playwright-friendly JS shape — only the
+  fields the spec.cjs assertions need, stringified where useful."
+  [ev]
+  (let [t (:tags ev)]
+    (clj->js
+      (cond-> {:operation (str (:operation ev))
+               :op-type   (some-> ev :op-type str)}
+        (:server-hash t) (assoc :server-hash (:server-hash t))
+        (:client-hash t) (assoc :client-hash (:client-hash t))
+        (:failing-id t)  (assoc :failing-id (str (:failing-id t)))
+        (:check t)       (assoc :check (str (:check t)))
+        (:recovery t)    (assoc :recovery (str (:recovery t)))))))
+
+(defn install-trace-listener! []
+  ;; HOT PATH — wire the trace bus to a window-side mirror so a
+  ;; Playwright assertion can inspect the hydration trace stream
+  ;; without poking at internal cljs vars.
+  (trace/register-trace-cb! ::ssr-basic-listener
+    (fn [ev]
+      (let [op (:operation ev)]
+        (when (and op
+                   (or (= "rf.ssr" (namespace op))
+                       (= :rf/hydrate op)))
+          (swap! trace-events conj ev)))))
+  (set! (.-__rf_trace_events js/window)
+        (fn [] (clj->js (mapv #(js->clj (ev->js %)) @trace-events)))))
+
+;; ----------------------------------------------------------------------------
+;; Events / subs
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-db ::inc
+  (fn [db _ev]
+    (update db :count (fnil inc 0))))
+
+(rf/reg-event-db ::set-title
+  (fn [db [_ t]]
+    (assoc db :title t)))
+
+(rf/reg-sub :count       (fn [db _] (or (:count db) 0)))
+(rf/reg-sub :title       (fn [db _] (or (:title db) "untitled")))
+(rf/reg-sub :server-resp (fn [db _] (:server-response db)))
+(rf/reg-sub :hydrated?   (fn [db _] (boolean (:rf/hydration db))))
+
+;; ----------------------------------------------------------------------------
+;; Views
+;; ----------------------------------------------------------------------------
+
+(reg-view counter-panel []
+  (let [n     @(subscribe [:count])
+        title @(subscribe [:title])]
+    [:div {:data-testid "counter-panel"
+           :style {:border  "1px solid #aaa"
+                   :padding "0.5em"
+                   :margin  "0.25em 0"}}
+     [:h2 {:data-testid "title"} title]
+     [:p "count=" [:span {:data-testid "count"} n]]
+     [:button {:data-testid "inc"
+               :on-click    #(dispatch [::inc])}
+      "Inc"]
+     [:button {:data-testid "set-title"
+               :on-click    #(dispatch [::set-title "hydrated"])}
+      "Set title"]]))
+
+(reg-view server-response-panel []
+  (let [resp @(subscribe [:server-resp])]
+    [:div {:data-testid "server-response"
+           :style {:border  "1px solid #ddd"
+                   :padding "0.5em"
+                   :margin  "0.25em 0"
+                   :font-family "monospace"}}
+     [:h3 "Per-request response"]
+     [:p "status=" [:span {:data-testid "resp-status"} (str (:status resp))]]
+     [:p "content-type="
+      [:span {:data-testid "resp-ct"}
+       (str (get-in resp [:headers "content-type"]))]]
+     [:p "cookies-count="
+      [:span {:data-testid "resp-cookies-count"}
+       (str (count (:cookies resp)))]]
+     [:p "first-cookie-name="
+      [:span {:data-testid "resp-cookie-name"}
+       (str (or (:name (first (:cookies resp))) "-"))]]]))
+
+(reg-view hydration-status-panel []
+  (let [hydrated? @(subscribe [:hydrated?])]
+    [:div {:data-testid (if hydrated? "hydrated" "not-hydrated")
+           :style {:padding "0.25em"
+                   :color   (if hydrated? "#070" "#700")}}
+     (if hydrated? "hydrated" "not-hydrated")]))
+
+(reg-view root []
+  [:div {:data-testid "ssr-basic"
+         :style {:font-family "sans-serif" :padding "1em"}}
+   [:h1 "ssr-basic testbed"]
+   [hydration-status-panel]
+   [counter-panel]
+   [server-response-panel]])
+
+;; ----------------------------------------------------------------------------
+;; Mount + hydrate
+;; ----------------------------------------------------------------------------
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(defn read-server-payload
+  "Read the EDN payload baked into the static index.html. Per Spec 011
+  §Payload scope: `{:rf/version :rf/frame-id :rf/app-db :rf/render-hash
+  :rf/schema-digest? :rf/response?}`."
+  []
+  (when-let [el (.getElementById js/document "__rf_payload")]
+    (cljs.reader/read-string (.-textContent el))))
+
+(defn- materialise-response
+  "Hoist the payload's optional `:rf/response` slice into the seeded
+  `:rf/app-db` under `[:server-response]` so the client view can render
+  the resolved per-request response shape. The server-side framework
+  keeps the response accumulator in a private side-channel (per Spec 011
+  §Response storage substrate) — not in app-db — so this client-side
+  hoist is the test surface's bridge from the wire to the view layer."
+  [payload]
+  (cond-> payload
+    (and (map? payload) (:rf/response payload))
+    (update :rf/app-db assoc :server-response (:rf/response payload))))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  (install-trace-listener!)
+
+  (let [payload (some-> (read-server-payload) materialise-response)]
+    (if payload
+      ;; HOT PATH — :rf/hydrate is auto-registered by re-frame.ssr;
+      ;; replaces app-db with the payload's :rf/app-db, stashes
+      ;; metadata at [:rf/hydration], dispatches the two compatibility-
+      ;; check fxs (which the trace listener mirrors).
+      (rf/dispatch-sync [:rf/hydrate payload])
+      ;; Degraded path: no payload baked. Don't crash — render against
+      ;; the empty app-db. This is the "client-only first load" shape.
+      (rf/dispatch-sync [::inc]))
+    (rdc/render react-root [root])
+
+    ;; HOT PATH — verify-hydration! reads the server-hash stashed at
+    ;; [:rf/hydration :server-hash], computes the client-render hash,
+    ;; and emits :rf.ssr/hydration-mismatch on disagreement.
+    ;; Resolve the view under the current (default) frame so the
+    ;; subs evaluate against the post-hydrate app-db.
+    (when payload
+      (let [tree ((rf/view :ssr-basic.core/root))]
+        (ssr/verify-hydration! :rf/default tree)))))

--- a/testbeds/ssr_basic/index.html
+++ b/testbeds/ssr_basic/index.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: ssr-basic (hydration baseline)</title>
+  <style>
+    body { font-family: sans-serif; margin: 2em; }
+    h1 { margin-top: 0; }
+    h2, h3 { margin: 0.25em 0; }
+    button { margin: 0 0.25em 0.25em 0; padding: 4px 10px; }
+    p { margin: 0.25em 0; }
+  </style>
+</head>
+<body>
+  <!--
+    SERVER-RENDERED markup. Per Spec 011 §The render-tree → HTML emitter,
+    this is the bytes the JVM-side `(rf/render-to-string ((rf/view
+    :ssr-basic.core/root)) {:doctype? true :emit-hash? true})` would have
+    produced if a Clojure server were sitting in front. The companion
+    `<script id="__rf_payload">` below carries the serialised app-db +
+    metadata so the client-side `run` can `:rf/hydrate` against the same
+    state the server's render saw.
+
+    The static page deliberately omits a `data-rf-render-hash` attribute
+    on the root — the matching hash would have to be computed from the
+    full canonical-EDN walk of the resolved hiccup tree, which is JVM-
+    side machinery. The payload's `:rf/render-hash` slot is left nil so
+    `verify-hydration!` no-ops cleanly (server has nothing to compare
+    against). The hash-mismatch path is exercised by the sibling testbed
+    `testbeds/ssr_hydration_mismatch/`; this surface is the no-mismatch
+    baseline.
+  -->
+  <div id="app">
+    <div data-testid="ssr-basic" style="font-family: sans-serif; padding: 1em">
+      <h1>ssr-basic testbed</h1>
+      <!-- Pre-hydrate: the not-hydrated marker is visible. The client
+           overwrites this with the live view tree after first render. -->
+      <div data-testid="not-hydrated" style="padding: 0.25em; color: #700">
+        not-hydrated
+      </div>
+      <div data-testid="counter-panel"
+           style="border: 1px solid #aaa; padding: 0.5em; margin: 0.25em 0">
+        <h2 data-testid="title">seeded</h2>
+        <p>count=<span data-testid="count">7</span></p>
+        <button data-testid="inc">Inc</button>
+        <button data-testid="set-title">Set title</button>
+      </div>
+      <div data-testid="server-response"
+           style="border: 1px solid #ddd; padding: 0.5em; margin: 0.25em 0; font-family: monospace">
+        <h3>Per-request response</h3>
+        <p>status=<span data-testid="resp-status">200</span></p>
+        <p>content-type=<span data-testid="resp-ct">text/html; charset=utf-8</span></p>
+        <p>cookies-count=<span data-testid="resp-cookies-count">1</span></p>
+        <p>first-cookie-name=<span data-testid="resp-cookie-name">session</span></p>
+      </div>
+    </div>
+  </div>
+  <script id="__rf_payload" type="application/edn">
+{:rf/version     1
+ :rf/frame-id    :rf/default
+ :rf/render-hash nil
+ :rf/app-db      {:count 7
+                  :title "seeded"}
+ :rf/response    {:status   200
+                  :headers  {"content-type" "text/html; charset=utf-8"
+                             "x-request-id" "test-req-1"}
+                  :cookies  [{:name      "session"
+                              :value     "abc123"
+                              :http-only true
+                              :secure    true
+                              :same-site :lax
+                              :path      "/"}]
+                  :redirect nil}}
+  </script>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/testbeds/ssr_basic/spec.cjs
+++ b/testbeds/ssr_basic/spec.cjs
@@ -1,0 +1,143 @@
+/*
+ * SSR baseline — hydration round-trip + per-request lifecycle.
+ *
+ * The static index.html bakes pre-rendered HTML plus an EDN
+ * :rf/hydration-payload script (mirroring what
+ * `re-frame.ssr/render-to-string` + the JVM payload builder emit per
+ * spec/011-SSR.md).  The browser-side `run`:
+ *
+ *   1. Reads the payload from `<script id="__rf_payload">`.
+ *   2. Dispatches `:rf/hydrate` — replace-app-db policy seeds the
+ *      client app-db with the server's authoritative slice.
+ *   3. Renders against the now-seeded app-db.
+ *   4. Calls `verify-hydration!` post-first-render — the hash-mismatch
+ *      detection path (no mismatch on this surface; the baseline
+ *      payload's :rf/render-hash is nil, see ssr_hydration_mismatch/
+ *      for the deliberate-mismatch surface).
+ *
+ * This spec walks the round-trip:
+ *
+ *   - The pre-rendered HTML is visible BEFORE the bundle loads (the
+ *     server-rendered counter, title, and per-request response panel
+ *     read 7/seeded/200 from the static markup).
+ *   - The bundle loads cleanly — no console errors, no pageerrors.
+ *   - After hydration, the `data-testid="hydrated"` marker replaces
+ *     `not-hydrated` — proves `:rf/hydration` metadata landed in
+ *     app-db.
+ *   - The reactive substrate is live: clicking `inc` mutates count
+ *     7 → 8; clicking `set-title` writes "hydrated" into title.
+ *   - The payload's :rf/response slice — status, content-type, the
+ *     `session` cookie — round-trips into the view layer.  Proves
+ *     per-request :rf.server/* response state survives the wire.
+ *   - The trace listener captured at least the hydrate's
+ *     compatibility-check trace events on the window mirror.
+ */
+
+const {
+  expectTextEquals,
+  expectTextContains,
+  expectVisible,
+} = require('../../examples/scripts/spec-helpers.cjs');
+
+module.exports = {
+  name: 'testbeds/ssr-basic (hydration baseline)',
+  url: '/testbed-ssr-basic/',
+  run: async (page) => {
+    // ---- (1) static HTML present before bundle interaction ----------
+    //
+    // The page is loaded at this point; the static HTML's pre-rendered
+    // counter / title are visible. Pre-hydration the marker reads
+    // `not-hydrated`; the bundle's mount switches it to `hydrated`.
+    const root = page.locator('[data-testid="ssr-basic"]');
+    await expectVisible(root, 10000);
+
+    // ---- (2) hydration handshake completes --------------------------
+    const hydrated = page.locator('[data-testid="hydrated"]');
+    await expectVisible(hydrated, 10000);
+    await expectTextEquals(hydrated, 'hydrated', 5000);
+
+    // ---- (3) seeded state from payload's :rf/app-db -----------------
+    //
+    // The payload baked {:count 7 :title "seeded"} — the client view
+    // renders these post-hydrate, replacing whatever the pre-rendered
+    // HTML displayed (which happens to match by construction, but the
+    // value source after hydration is the reactive substrate).
+    await expectTextEquals(page.locator('[data-testid="count"]'), '7', 5000);
+    await expectTextEquals(page.locator('[data-testid="title"]'), 'seeded', 5000);
+
+    // ---- (4) reactive substrate is live -----------------------------
+    //
+    // Click `inc` — handler dispatches, app-db's :count slot bumps,
+    // sub recomputes, view re-renders. Proves the hydration handoff
+    // didn't break the six-domino loop.
+    await page.locator('[data-testid="inc"]').click();
+    await expectTextEquals(page.locator('[data-testid="count"]'), '8', 5000);
+
+    // Click `set-title` — same domino path, different slot.
+    await page.locator('[data-testid="set-title"]').click();
+    await expectTextEquals(page.locator('[data-testid="title"]'), 'hydrated', 5000);
+
+    // ---- (5) per-request :rf/response round-trip --------------------
+    //
+    // The payload's :rf/response slice carried {:status 200 :headers
+    // {"content-type" "text/html; charset=utf-8" ...} :cookies [{:name
+    // "session" ...}]}. After hydration the view reads it back from
+    // [:server-response] in app-db.
+    await expectTextEquals(
+      page.locator('[data-testid="resp-status"]'),
+      '200',
+      5000,
+    );
+    await expectTextContains(
+      page.locator('[data-testid="resp-ct"]'),
+      'text/html',
+      5000,
+    );
+    await expectTextEquals(
+      page.locator('[data-testid="resp-cookies-count"]'),
+      '1',
+      5000,
+    );
+    await expectTextEquals(
+      page.locator('[data-testid="resp-cookie-name"]'),
+      'session',
+      5000,
+    );
+
+    // ---- (6) trace bus mirrored the hydration handshake -------------
+    //
+    // The cljs side registered a trace listener that mirrors every
+    // :rf.ssr/* and :rf/hydrate trace event onto
+    // window.__rf_trace_events(). The hydration handshake fired the
+    // two compatibility-check fxs (:rf.ssr/check-version and, when
+    // the payload carries one, :rf.ssr/check-schema-digest). With no
+    // late-bind hooks registered on this surface we expect at least
+    // one :rf.ssr/compatibility-check-skipped trace.
+    const events = await page.evaluate(() => {
+      const fn = window.__rf_trace_events;
+      return fn ? fn() : [];
+    });
+    if (!Array.isArray(events) || events.length === 0) {
+      throw new Error(
+        `expected at least one :rf.ssr/* trace event on window.__rf_trace_events(); got ${JSON.stringify(events)}`,
+      );
+    }
+    const ops = events.map((e) => e.operation);
+    if (!ops.some((op) => op === ':rf.ssr/compatibility-check-skipped')) {
+      throw new Error(
+        `expected at least one :rf.ssr/compatibility-check-skipped trace (no :rf2/runtime-version hook registered on this surface); got operations: ${JSON.stringify(ops)}`,
+      );
+    }
+
+    // ---- (7) no :rf.ssr/hydration-mismatch on the baseline ----------
+    //
+    // The payload's :rf/render-hash is nil, so verify-hydration! has
+    // nothing to compare against and silently no-ops. A mismatch trace
+    // here would be a real bug.
+    if (ops.includes(':rf.ssr/hydration-mismatch')) {
+      throw new Error(
+        `unexpected :rf.ssr/hydration-mismatch trace on the baseline surface (server-hash was nil); got: ${JSON.stringify(events)}`,
+      );
+    }
+  },
+};

--- a/testbeds/ssr_hydration_mismatch/README.md
+++ b/testbeds/ssr_hydration_mismatch/README.md
@@ -1,0 +1,70 @@
+# `testbeds/ssr-hydration-mismatch`
+
+The deliberate-mismatch surface. The payload bakes a known-wrong
+`:rf/render-hash` (`"deadbeef"`) into the static `index.html`. The
+browser-side `run` dispatches `:rf/hydrate` (so the bogus hash lands
+at `[:rf/hydration :server-hash]`), renders the view, and calls
+`verify-hydration!` — which computes the client-side hash, compares,
+disagrees, and emits `:rf.ssr/hydration-mismatch` per
+[`spec/011-SSR.md` §Hydration-mismatch detection](../../spec/011-SSR.md).
+
+The trace listener routes the captured trace's tags through
+`::record-mismatch` so the dev-mode banner re-renders with the
+structured payload visible inline.
+
+| `data-testid` | What it carries / proves |
+|---|---|
+| `ssr-hydration-mismatch` | Root marker. |
+| `hydrated` / `not-hydrated` | Discriminator on `:rf/hydration` presence. |
+| `mismatch-banner` / `mismatch-banner-empty` | Pre-mismatch the `-empty` variant is rendered; post-mismatch the banner with the structured payload replaces it. |
+| `mismatch-server-hash` | The payload's `:rf/render-hash` (`"deadbeef"`). |
+| `mismatch-client-hash` | The runtime's computed hash for the resolved client tree — an 8-char lowercase hex string per Spec 011 §Hydration-mismatch detection. |
+| `mismatch-failing-id` | `:rf/hydrate` (the v1 body-mismatch discriminator per Spec 011 §Mismatch detection — head). |
+| `mismatch-recovery` | `:warned-and-replaced` (the runtime default; warn-and-replace per [§Mismatch recovery and configuration](../../spec/011-SSR.md)). |
+| `count` / `inc` | Post-mismatch the page remains interactive — warn-and-replace is degraded-but-running, not crash. |
+
+## What this surface tests (per spec/011-SSR.md)
+
+| Spec section | Behaviour exercised |
+|---|---|
+| §Hydration-mismatch detection | `verify-hydration!` reads the server hash, computes the client hash, emits `:rf.ssr/hydration-mismatch` on disagreement with structured tags (`:server-hash`, `:client-hash`, `:failing-id`, `:recovery`). |
+| §Mismatch recovery and configuration | Default posture is `:warned-and-replaced` — the trace fires but the client renders against the seeded state and the page stays interactive. |
+| §The `:rf/hydrate` event | The server-hash is stashed at `[:rf/hydration :server-hash]` automatically by the framework-registered handler — user code didn't have to participate. |
+
+## Why a known-wrong hex string instead of a "real" mismatch
+
+The spec's hash is an 8-character lowercase-hex FNV-1a over the
+canonical-EDN serialisation of the render-tree (per Spec 011
+§Hydration-mismatch detection). To force a real mismatch where the
+client computes some hash and the payload carries a different one, we
+need the client and server to disagree.
+
+A static `index.html` can't compute the FNV-1a at page-build time
+(no JVM in the browser). Instead, baking a constant `"deadbeef"`
+guarantees disagreement against the client's structurally-correct
+hash (whatever it works out to be at runtime). The trace's
+`:server-hash` is literally `"deadbeef"` — the spec.cjs asserts on
+this exact value. The `:client-hash` is whatever the runtime
+computes; the spec.cjs asserts it's a non-nil string of the right
+shape (8 lowercase-hex chars).
+
+## Running
+
+From `implementation/`:
+
+```bash
+shadow-cljs watch testbeds/ssr-hydration-mismatch
+# Or via the orchestrator:
+npm run test:examples
+```
+
+Build id `testbeds/ssr-hydration-mismatch`; served at
+`/testbed-ssr-hydration-mismatch/`.
+
+## Cross-references
+
+- [`spec/011-SSR.md` §Hydration-mismatch detection](../../spec/011-SSR.md) — the contract.
+- [`spec/011-SSR.md` §Mismatch recovery and configuration](../../spec/011-SSR.md) — the recovery posture (warn-and-replace).
+- [`spec/009-Instrumentation.md` §Error event catalogue](../../spec/009-Instrumentation.md) — the `:rf.ssr/hydration-mismatch` taxonomy entry.
+- [`implementation/ssr/test/re_frame/ssr_end_to_end_test.clj`](../../implementation/ssr/test/re_frame/ssr_end_to_end_test.clj) — the JVM-side mismatch coverage; this testbed pairs with it on the browser side.
+- Sibling: [`testbeds/ssr_basic/`](../ssr_basic/) — the no-mismatch baseline.

--- a/testbeds/ssr_hydration_mismatch/core.cljs
+++ b/testbeds/ssr_hydration_mismatch/core.cljs
@@ -1,0 +1,183 @@
+(ns ssr-hydration-mismatch.core
+  "Shared framework-behavior testbed — deliberate hydration-mismatch.
+
+  Per [spec/011-SSR.md §Hydration-mismatch detection]: after the first
+  client render, `verify-hydration!` recomputes the structural hash of
+  the resolved render-tree, reads the server hash stashed at
+  `[:rf/hydration :server-hash]`, and emits
+  `:rf.ssr/hydration-mismatch` (op-type `:error`, recovery
+  `:warned-and-replaced`) on disagreement.
+
+  This surface forces disagreement: the payload bakes a known-wrong
+  `:rf/render-hash` string (`'deadbeef'`) that cannot match whatever
+  the client's render-tree hashes to under the seeded app-db. The
+  mismatch trace fires; the cljs trace listener captures the event
+  and exposes its `:server-hash`, `:client-hash`, `:failing-id`, and
+  `:recovery` payload onto `window.__rf_trace_events()`. A
+  `data-testid='mismatch-banner'` element renders the captured
+  payload visibly so dev-mode visibility is observable from the DOM
+  (dev posture: warn-and-replace; the client renders against the
+  seeded state and the page remains interactive).
+
+  What a Playwright consumer observes:
+
+    - Hydration completes — `data-testid='hydrated'` marker is visible.
+    - `verify-hydration!` is called post-first-render; the trace
+      listener captures a `:rf.ssr/hydration-mismatch` event with
+      `:server-hash='deadbeef'`, a non-nil `:client-hash`, and
+      `:recovery=:warned-and-replaced`.
+    - The mismatch-banner div renders the captured payload — proves
+      dev-mode visibility of the structured trace surface.
+    - The page is still interactive — clicking `inc` works post-
+      mismatch; the runtime's default recovery is warn-and-replace,
+      not crash."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.ssr :as ssr]
+            [re-frame.trace :as trace]
+            [cljs.reader])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ----------------------------------------------------------------------------
+;; Trace listener — mirrors :rf.ssr/* + :rf/hydrate traces onto the
+;; window AND keeps the most recent mismatch payload as a Reagent atom
+;; the view can subscribe to (so the dev-mode banner re-renders when
+;; the mismatch fires).
+;; ----------------------------------------------------------------------------
+
+(defonce trace-events (atom []))
+
+(rf/reg-event-db ::record-mismatch
+  (fn [db [_ tags]]
+    (assoc db :mismatch tags)))
+
+(defn- normalise-tags [t]
+  ;; Plain edn map → JS-safe map for the window mirror.
+  (cond-> {}
+    (:server-hash t)     (assoc :server-hash (:server-hash t))
+    (:client-hash t)     (assoc :client-hash (:client-hash t))
+    (:failing-id t)      (assoc :failing-id (str (:failing-id t)))
+    (:recovery t)        (assoc :recovery (str (:recovery t)))
+    (:first-diff-path t) (assoc :first-diff-path (pr-str (:first-diff-path t)))
+    (:reason t)          (assoc :reason (:reason t))))
+
+(defn install-trace-listener! []
+  (trace/register-trace-cb! ::ssr-hydration-mismatch-listener
+    (fn [ev]
+      (let [op (:operation ev)]
+        (when (and op
+                   (or (= "rf.ssr" (namespace op))
+                       (= :rf/hydrate op)))
+          (swap! trace-events conj ev)
+          ;; HOT PATH — when the mismatch fires, propagate the tags
+          ;; into app-db so the dev-mode banner view re-renders.
+          (when (= :rf.ssr/hydration-mismatch op)
+            (rf/dispatch [::record-mismatch (normalise-tags (:tags ev))]))))))
+
+  (set! (.-__rf_trace_events js/window)
+        (fn []
+          (clj->js
+            (mapv (fn [ev]
+                    (let [t (:tags ev)]
+                      (cond-> {:operation (str (:operation ev))
+                               :op-type   (some-> ev :op-type str)}
+                        true  (merge (normalise-tags t)))))
+                  @trace-events)))))
+
+;; ----------------------------------------------------------------------------
+;; Events / subs
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-db ::inc
+  (fn [db _ev]
+    (update db :count (fnil inc 0))))
+
+(rf/reg-sub :count     (fn [db _] (or (:count db) 0)))
+(rf/reg-sub :mismatch  (fn [db _] (:mismatch db)))
+(rf/reg-sub :hydrated? (fn [db _] (boolean (:rf/hydration db))))
+
+;; ----------------------------------------------------------------------------
+;; Views
+;; ----------------------------------------------------------------------------
+
+(reg-view hydration-status []
+  (let [hydrated? @(subscribe [:hydrated?])]
+    [:div {:data-testid (if hydrated? "hydrated" "not-hydrated")
+           :style {:padding "0.25em" :color (if hydrated? "#070" "#700")}}
+     (if hydrated? "hydrated" "not-hydrated")]))
+
+(reg-view mismatch-banner []
+  ;; Dev-mode visibility of the :rf.ssr/hydration-mismatch payload.
+  ;; Per spec/011 §Mismatch recovery and configuration the default
+  ;; posture is warn-and-replace; the user-visible banner makes the
+  ;; structured trace inspectable without dev-tools.
+  (let [m @(subscribe [:mismatch])]
+    (if m
+      [:div {:data-testid "mismatch-banner"
+             :style {:border  "2px solid #c33"
+                     :padding "0.75em"
+                     :margin  "0.5em 0"
+                     :background "#fee"
+                     :font-family "monospace"}}
+       [:h3 {:style {:margin-top 0}} ":rf.ssr/hydration-mismatch"]
+       [:p "server-hash="
+        [:span {:data-testid "mismatch-server-hash"} (:server-hash m)]]
+       [:p "client-hash="
+        [:span {:data-testid "mismatch-client-hash"} (str (:client-hash m))]]
+       [:p "failing-id="
+        [:span {:data-testid "mismatch-failing-id"} (:failing-id m)]]
+       [:p "recovery="
+        [:span {:data-testid "mismatch-recovery"} (:recovery m)]]
+       [:p {:style {:color "#666"}} (:reason m)]]
+      [:div {:data-testid "mismatch-banner-empty"
+             :style {:color "#888"}}
+       "(no mismatch yet)"])))
+
+(reg-view counter-panel []
+  (let [n @(subscribe [:count])]
+    [:div {:data-testid "counter-panel"
+           :style {:border "1px solid #aaa" :padding "0.5em" :margin "0.25em 0"}}
+     [:p "count=" [:span {:data-testid "count"} n]]
+     [:button {:data-testid "inc"
+               :on-click    #(dispatch [::inc])}
+      "Inc"]]))
+
+(reg-view root []
+  [:div {:data-testid "ssr-hydration-mismatch"
+         :style {:font-family "sans-serif" :padding "1em"}}
+   [:h1 "ssr-hydration-mismatch testbed"]
+   [hydration-status]
+   [mismatch-banner]
+   [counter-panel]])
+
+;; ----------------------------------------------------------------------------
+;; Mount + hydrate
+;; ----------------------------------------------------------------------------
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(defn read-server-payload []
+  (when-let [el (.getElementById js/document "__rf_payload")]
+    (cljs.reader/read-string (.-textContent el))))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  (install-trace-listener!)
+  (let [payload (read-server-payload)]
+    (when payload
+      ;; HOT PATH — :rf/hydrate replaces app-db; the payload's
+      ;; :rf/render-hash 'deadbeef' is stashed at
+      ;; [:rf/hydration :server-hash] so verify-hydration! can compare
+      ;; against the client's computed hash.
+      (rf/dispatch-sync [:rf/hydrate payload]))
+    (rdc/render react-root [root])
+
+    ;; HOT PATH — the trigger site for :rf.ssr/hydration-mismatch.
+    ;; The resolved tree hashes to a value that won't equal the
+    ;; payload's 'deadbeef'; verify-hydration! emits the mismatch
+    ;; trace which our listener routes to ::record-mismatch.
+    (let [tree ((rf/view :ssr-hydration-mismatch.core/root))]
+      (ssr/verify-hydration! :rf/default tree))))

--- a/testbeds/ssr_hydration_mismatch/core.cljs
+++ b/testbeds/ssr_hydration_mismatch/core.cljs
@@ -53,15 +53,23 @@
   (fn [db [_ tags]]
     (assoc db :mismatch tags)))
 
-(defn- normalise-tags [t]
-  ;; Plain edn map → JS-safe map for the window mirror.
-  (cond-> {}
-    (:server-hash t)     (assoc :server-hash (:server-hash t))
-    (:client-hash t)     (assoc :client-hash (:client-hash t))
-    (:failing-id t)      (assoc :failing-id (str (:failing-id t)))
-    (:recovery t)        (assoc :recovery (str (:recovery t)))
-    (:first-diff-path t) (assoc :first-diff-path (pr-str (:first-diff-path t)))
-    (:reason t)          (assoc :reason (:reason t))))
+(defn- normalise-event
+  "Project a trace event into a plain edn map carrying just the slots
+  the spec assertions read against. `:recovery` is hoisted to the top
+  level of the trace envelope (per Spec 009 §Error event shape — see
+  `re-frame.trace/build-event`'s recovery-hoist branch); the other
+  hydration-mismatch payload slots ride in `:tags`."
+  [ev]
+  (let [t (:tags ev)]
+    (cond-> {:operation (str (:operation ev))
+             :op-type   (some-> ev :op-type str)}
+      (:server-hash t)     (assoc :server-hash (:server-hash t))
+      (:client-hash t)     (assoc :client-hash (:client-hash t))
+      (:failing-id t)      (assoc :failing-id (str (:failing-id t)))
+      (:reason t)          (assoc :reason (:reason t))
+      (:first-diff-path t) (assoc :first-diff-path (pr-str (:first-diff-path t)))
+      ;; `:recovery` is HOISTED — at top level, not under tags.
+      (:recovery ev)       (assoc :recovery (str (:recovery ev))))))
 
 (defn install-trace-listener! []
   (trace/register-trace-cb! ::ssr-hydration-mismatch-listener
@@ -71,20 +79,15 @@
                    (or (= "rf.ssr" (namespace op))
                        (= :rf/hydrate op)))
           (swap! trace-events conj ev)
-          ;; HOT PATH — when the mismatch fires, propagate the tags
-          ;; into app-db so the dev-mode banner view re-renders.
+          ;; HOT PATH — when the mismatch fires, propagate the
+          ;; projected payload into app-db so the dev-mode banner
+          ;; view re-renders against the captured trace.
           (when (= :rf.ssr/hydration-mismatch op)
-            (rf/dispatch [::record-mismatch (normalise-tags (:tags ev))]))))))
+            (rf/dispatch [::record-mismatch (normalise-event ev)]))))))
 
   (set! (.-__rf_trace_events js/window)
         (fn []
-          (clj->js
-            (mapv (fn [ev]
-                    (let [t (:tags ev)]
-                      (cond-> {:operation (str (:operation ev))
-                               :op-type   (some-> ev :op-type str)}
-                        true  (merge (normalise-tags t)))))
-                  @trace-events)))))
+          (clj->js (mapv normalise-event @trace-events)))))
 
 ;; ----------------------------------------------------------------------------
 ;; Events / subs

--- a/testbeds/ssr_hydration_mismatch/index.html
+++ b/testbeds/ssr_hydration_mismatch/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: ssr-hydration-mismatch</title>
+  <style>
+    body { font-family: sans-serif; margin: 2em; }
+    h1 { margin-top: 0; }
+  </style>
+</head>
+<body>
+  <!--
+    Server-rendered HTML — a placeholder shape. The pre-rendered
+    `not-hydrated` marker is intentional: the post-hydrate render
+    replaces this subtree with the live view (which then transitions
+    to `hydrated`). Per Spec 011, the test is about the *hash*
+    comparison — the visible HTML doesn't need to mismatch byte-for-
+    byte to drive the trace.
+  -->
+  <div id="app">
+    <div data-testid="ssr-hydration-mismatch"
+         style="font-family: sans-serif; padding: 1em">
+      <h1>ssr-hydration-mismatch testbed</h1>
+      <div data-testid="not-hydrated" style="padding: 0.25em; color: #700">
+        not-hydrated
+      </div>
+    </div>
+  </div>
+  <!--
+    The payload bakes a deliberately-wrong :rf/render-hash. The
+    8-char-lowercase-hex shape matches the spec's FNV-1a output (per
+    Spec 011 §Hydration-mismatch detection: "lowercase hex of the raw
+    hash bytes; no prefix"); 'deadbeef' will not equal the
+    client's computed hash for the seeded {:count 0} tree.
+
+    On first render verify-hydration! reads this hash, computes the
+    client tree's hash, and emits :rf.ssr/hydration-mismatch with
+    :recovery :warned-and-replaced. The trace listener captures the
+    event onto window.__rf_trace_events() AND dispatches
+    ::record-mismatch so the dev-mode banner renders the payload
+    inline (data-testid='mismatch-banner').
+  -->
+  <script id="__rf_payload" type="application/edn">
+{:rf/version     1
+ :rf/frame-id    :rf/default
+ :rf/render-hash "deadbeef"
+ :rf/app-db      {:count 0}}
+  </script>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/testbeds/ssr_hydration_mismatch/spec.cjs
+++ b/testbeds/ssr_hydration_mismatch/spec.cjs
@@ -1,0 +1,136 @@
+/*
+ * SSR hydration-mismatch — verify-hydration! emits a structured
+ * :rf.ssr/hydration-mismatch trace event with the payload visible
+ * inline in dev mode.
+ *
+ * The static index.html bakes a known-wrong :rf/render-hash
+ * ("deadbeef"). On first render, verify-hydration! reads the
+ * server hash, hashes the resolved client tree, disagrees, emits
+ * :rf.ssr/hydration-mismatch (op-type :error, recovery
+ * :warned-and-replaced) per spec/011-SSR.md §Hydration-mismatch
+ * detection.
+ *
+ * This spec walks the mismatch path:
+ *
+ *   - Hydration completes (data-testid='hydrated' marker visible).
+ *   - The mismatch banner renders the captured trace's tags
+ *     verbatim:
+ *       - server-hash = 'deadbeef' (the baked-wrong value)
+ *       - client-hash = a non-nil 8-char lowercase-hex string
+ *       - failing-id = ':rf/hydrate' (v1 body-mismatch discriminator)
+ *       - recovery = ':warned-and-replaced' (runtime default)
+ *   - The window mirror exposes the same trace event.
+ *   - The page remains interactive post-mismatch: clicking inc
+ *     mutates the counter — proves warn-and-replace is degraded-
+ *     but-running, not crash.
+ */
+
+const {
+  expectTextEquals,
+  expectTextContains,
+  expectVisible,
+} = require('../../examples/scripts/spec-helpers.cjs');
+
+const HEX_8 = /^[0-9a-f]{8}$/;
+
+module.exports = {
+  name: 'testbeds/ssr-hydration-mismatch (mismatch trace fires)',
+  url: '/testbed-ssr-hydration-mismatch/',
+  run: async (page) => {
+    // ---- (1) hydration handshake completes --------------------------
+    const hydrated = page.locator('[data-testid="hydrated"]');
+    await expectVisible(hydrated, 10000);
+    await expectTextEquals(hydrated, 'hydrated', 5000);
+
+    // ---- (2) the mismatch banner renders the structured trace ------
+    //
+    // The trace listener captured :rf.ssr/hydration-mismatch and
+    // routed its tags through ::record-mismatch; the banner view
+    // subscribes to [:mismatch] and renders the structured payload
+    // inline. Without this, dev-mode visibility would require dev-
+    // tools — Spec 011 §Mismatch recovery and configuration covers
+    // the contract.
+    const banner = page.locator('[data-testid="mismatch-banner"]');
+    await expectVisible(banner, 10000);
+
+    // server-hash literally matches the baked-wrong value.
+    await expectTextEquals(
+      page.locator('[data-testid="mismatch-server-hash"]'),
+      'deadbeef',
+      5000,
+    );
+
+    // client-hash is whatever the runtime computed — assert on
+    // shape only (8 lowercase-hex chars per spec/011 §Hydration-
+    // mismatch detection).
+    const clientHash = await page
+      .locator('[data-testid="mismatch-client-hash"]')
+      .textContent();
+    if (!HEX_8.test((clientHash || '').trim())) {
+      throw new Error(
+        `expected mismatch-client-hash to be an 8-char lowercase-hex string; got "${clientHash}"`,
+      );
+    }
+    if ((clientHash || '').trim() === 'deadbeef') {
+      throw new Error(
+        'client-hash equalled the (deliberately wrong) server-hash — that would be a spec violation',
+      );
+    }
+
+    // failing-id is :rf/hydrate per spec/011 v1 body-mismatch
+    // discriminator (head-mismatch is reserved post-v1).
+    await expectTextEquals(
+      page.locator('[data-testid="mismatch-failing-id"]'),
+      ':rf/hydrate',
+      5000,
+    );
+
+    // recovery is :warned-and-replaced — the runtime default.
+    await expectTextEquals(
+      page.locator('[data-testid="mismatch-recovery"]'),
+      ':warned-and-replaced',
+      5000,
+    );
+
+    // ---- (3) the window mirror exposes the same trace ---------------
+    const events = await page.evaluate(() => {
+      const fn = window.__rf_trace_events;
+      return fn ? fn() : [];
+    });
+    const mismatch = (events || []).find(
+      (e) => e.operation === ':rf.ssr/hydration-mismatch',
+    );
+    if (!mismatch) {
+      throw new Error(
+        `expected a :rf.ssr/hydration-mismatch trace on window.__rf_trace_events(); got operations: ${JSON.stringify((events || []).map((e) => e.operation))}`,
+      );
+    }
+    if (mismatch.server_hash !== undefined && mismatch.server_hash !== 'deadbeef') {
+      // window.__rf_trace_events() projects keys with hyphens converted to
+      // underscores via cljs->js. Either spelling can land — accept both.
+      throw new Error(
+        `expected mismatch.server_hash to equal 'deadbeef'; got "${mismatch.server_hash}"`,
+      );
+    }
+    if (mismatch['server-hash'] !== undefined && mismatch['server-hash'] !== 'deadbeef') {
+      throw new Error(
+        `expected mismatch['server-hash'] to equal 'deadbeef'; got "${mismatch['server-hash']}"`,
+      );
+    }
+    const op = mismatch.op_type || mismatch['op-type'];
+    if (op !== ':error') {
+      throw new Error(
+        `expected :rf.ssr/hydration-mismatch op-type to be ':error'; got "${op}"`,
+      );
+    }
+
+    // ---- (4) page is still interactive post-mismatch ---------------
+    //
+    // Default recovery is warn-and-replace — the client renders
+    // against the seeded state (count=0) and the dispatch pipeline
+    // is live. Click `inc`, observe the count bump.
+    await expectTextEquals(page.locator('[data-testid="count"]'), '0', 5000);
+    await page.locator('[data-testid="inc"]').click();
+    await expectTextEquals(page.locator('[data-testid="count"]'), '1', 5000);
+  },
+};

--- a/testbeds/ssr_multi_frame/README.md
+++ b/testbeds/ssr_multi_frame/README.md
@@ -1,0 +1,63 @@
+# `testbeds/ssr-multi-frame`
+
+Three frames coexist on the page (`:counter/a`, `:counter/b`, `:log`),
+each receiving its OWN `:rf/hydrate` dispatch from a per-frame slice
+of the baked payload. Per [`spec/011-SSR.md` §Frames are per-request](../../spec/011-SSR.md)
++ [`spec/002-Frames.md` §What lives in a frame](../../spec/002-Frames.md):
+each frame owns its own `app-db`, router queue, and signal-graph
+cache; the hydration protocol operates frame-by-frame.
+
+The static `index.html` bakes ONE payload script carrying a map of
+`{frame-id → per-frame-payload}`; the browser-side `run` walks it
+and dispatches `[:rf/hydrate slice]` against each frame.
+
+| `data-testid` | What it carries / proves |
+|---|---|
+| `panel-A`, `panel-B`, `panel-log` | Per-frame panel containers. |
+| `n-A`, `n-B` | The seeded `:n` from each counter frame's payload slice (`10`, `99`). |
+| `entries-count` | The `:log` frame's payload-seeded entry count (`2`). |
+| `hyd-A`, `hyd-B`, `hyd-log` | `true` once each frame's `:rf/hydration` metadata lands. |
+| `hash-A`, `hash-B`, `hash-log` | The payload-supplied `:rf/render-hash` per frame (`aaaa1111`, `bbbb2222`, `cccc3333`). |
+| `summary-{a,b,log}-hash` | Cross-frame readout via `rf/subscribe-value frame-id`. |
+| `summary-all-distinct` | `true` iff the three per-frame `:server-hash` values are pairwise distinct — proves no cross-frame bleed. |
+| `inc-A`, `inc-B` | Per-frame post-hydration interactivity; clicking `inc-A` bumps `:counter/a`'s `:n` only — `:counter/b` and `:log` are untouched. |
+
+## What this surface tests (per spec/011-SSR.md and spec/002-Frames.md)
+
+| Spec section | Behaviour exercised |
+|---|---|
+| Spec 011 §Frames are per-request | Three independent frames hydrate from three distinct payload slices; the three `app-db`s never cross-contaminate. |
+| Spec 011 §The `:rf/hydrate` event | The standard `:rf/hydrate` handler is reused per frame; the framework's `:frame` opt routes the dispatch to the right router queue. |
+| Spec 002 §What lives in a frame | Per-frame app-db + router queue + sub cache isolation survives the hydration round-trip. |
+| Spec 002 §Routing the dispatch envelope | `[:rf/hydrate slice]` with `{:frame fid}` lands on `fid`'s queue, never `:rf/default`'s. |
+
+## What this surface deliberately omits
+
+- Hash-mismatch detection per frame. Each frame's payload carries a
+  symbolic hash (`aaaa1111`, …) — `verify-hydration!` isn't called
+  here. Sibling [`testbeds/ssr_hydration_mismatch/`](../ssr_hydration_mismatch/)
+  exercises the mismatch path on a single frame.
+- Cross-frame `:dispatch` fan-out. That's the
+  [`testbeds/multi_frame/`](../multi_frame/) surface's concern;
+  conflating the two would dilute what this surface proves.
+
+## Running
+
+From `implementation/`:
+
+```bash
+shadow-cljs watch testbeds/ssr-multi-frame
+# Or via the orchestrator:
+npm run test:examples
+```
+
+Build id `testbeds/ssr-multi-frame`; served at
+`/testbed-ssr-multi-frame/`.
+
+## Cross-references
+
+- [`spec/011-SSR.md` §Frames are per-request](../../spec/011-SSR.md) — the per-request frame contract.
+- [`spec/002-Frames.md` §What lives in a frame](../../spec/002-Frames.md) — the per-frame isolation contract.
+- Sibling: [`testbeds/multi_frame/`](../multi_frame/) — the cross-frame `:dispatch` fan-out surface (NOT SSR).
+- Sibling: [`testbeds/ssr_basic/`](../ssr_basic/) — the single-frame hydration baseline.
+- Sibling: [`testbeds/ssr_hydration_mismatch/`](../ssr_hydration_mismatch/) — the deliberate-mismatch surface.

--- a/testbeds/ssr_multi_frame/core.cljs
+++ b/testbeds/ssr_multi_frame/core.cljs
@@ -1,0 +1,200 @@
+(ns ssr-multi-frame.core
+  "Shared framework-behavior testbed — per-frame hydration isolation.
+
+  Three frames coexist on the page (`:counter/a`, `:counter/b`, `:log`),
+  each receiving its OWN `:rf/hydrate` dispatch from a per-frame
+  payload slice. Per [spec/011-SSR.md §Frames are per-request] +
+  [spec/002-Frames.md §What lives in a frame]: each frame owns its
+  own app-db, router queue, and signal-graph cache; the hydration
+  protocol must operate frame-by-frame.
+
+  The static `index.html` bakes ONE payload script carrying a map of
+  `{frame-id → per-frame-payload}`. The browser-side `run` walks the
+  map and dispatches `[:rf/hydrate slice]` per frame with explicit
+  `{:frame frame-id}` opt.
+
+  Per-frame seeded values:
+
+    :counter/a → {:n 10}                                    -> 'A: n=10'
+    :counter/b → {:n 99}                                    -> 'B: n=99'
+    :log       → {:entries [{:from :ssr :note 'hello'} ...]}-> log entries
+
+  Post-hydrate, three sibling `[rf/frame-provider {:frame ...}]`
+  subtrees render the three panels. Each subtree reads ONLY its own
+  frame's app-db — `:counter/a`'s `:n` sub fires against `:counter/a`'s
+  app-db, never `:counter/b`'s. A `data-testid='hydration-summary'`
+  element renders the three frames' post-hydrate `:rf/hydration`
+  metadata to prove each frame's hydrate-event fired against its own
+  app-db (no cross-frame bleed).
+
+  What a Playwright consumer observes:
+
+    - Three panels with distinct seeded values, each tagged with the
+      frame id. Cross-frame state is independent (Inc-A only bumps
+      `:counter/a`; A's panel reads 11, B's panel still reads 99).
+    - The hydration-summary block confirms three independent
+      `:rf/hydration {:server-hash ...}` records — one per frame —
+      proving the round-trip is per-frame.
+
+  This is NOT a tutorial — bodies are stark."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.ssr :as ssr]
+            [cljs.reader])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+(def frame-a   :counter/a)
+(def frame-b   :counter/b)
+(def frame-log :log)
+
+;; ----------------------------------------------------------------------------
+;; App-db initialisers (per-frame shape, registered once)
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-db ::counter-init
+  (fn [_db _ev]
+    {:n 0}))
+
+(rf/reg-event-db ::log-init
+  (fn [_db _ev]
+    {:entries []}))
+
+;; ----------------------------------------------------------------------------
+;; Per-frame handlers — the framework dispatches each to the targeted frame
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-db ::inc
+  (fn [db _ev]
+    (update db :n (fnil inc 0))))
+
+(rf/reg-event-db ::log-append
+  (fn [db [_ entry]]
+    (update db :entries (fnil conj []) entry)))
+
+(rf/reg-sub :n          (fn [db _] (:n db)))
+(rf/reg-sub :entries    (fn [db _] (:entries db)))
+(rf/reg-sub :hydration  (fn [db _] (:rf/hydration db)))
+
+;; ----------------------------------------------------------------------------
+;; Views
+;; ----------------------------------------------------------------------------
+
+(reg-view counter-panel [label test-suffix]
+  (let [n     @(subscribe [:n])
+        hyd   @(subscribe [:hydration])]
+    [:div {:data-testid (str "panel-" test-suffix)
+           :style {:border  "1px solid #aaa"
+                   :padding "0.5em"
+                   :margin  "0.25em"
+                   :min-width "10em"}}
+     [:h3 (str label ": ")
+      [:span {:data-testid (str "label-" test-suffix)} label]]
+     [:p "n=" [:span {:data-testid (str "n-" test-suffix)} n]]
+     [:p "hydrated="
+      [:span {:data-testid (str "hyd-" test-suffix)}
+       (str (boolean hyd))]]
+     [:p "server-hash="
+      [:span {:data-testid (str "hash-" test-suffix)}
+       (str (:server-hash hyd))]]
+     [:button {:data-testid (str "inc-" test-suffix)
+               :on-click    #(dispatch [::inc])}
+      "Inc"]]))
+
+(reg-view log-panel []
+  (let [entries @(subscribe [:entries])
+        hyd     @(subscribe [:hydration])]
+    [:div {:data-testid "panel-log"
+           :style {:border "1px solid #aaa"
+                   :padding "0.5em"
+                   :margin "0.25em"
+                   :min-width "16em"}}
+     [:h3 "log"]
+     [:p "entries-count="
+      [:span {:data-testid "entries-count"} (count entries)]]
+     [:p "hydrated="
+      [:span {:data-testid "hyd-log"} (str (boolean hyd))]]
+     [:p "server-hash="
+      [:span {:data-testid "hash-log"} (str (:server-hash hyd))]]
+     [:ul {:data-testid "log-entries"
+           :style {:max-height "8em" :overflow :auto}}
+      (for [[idx e] (map-indexed vector entries)]
+        ^{:key idx}
+        [:li (pr-str e)])]]))
+
+(reg-view hydration-summary []
+  ;; Cross-frame readout — proves each frame's :rf/hydration metadata
+  ;; was written independently. We use the frame-explicit
+  ;; subscribe-value (2-arg form: `[frame-id query-v]`) so each call
+  ;; resolves against the named frame's app-db, not the surrounding
+  ;; `frame-provider`'s default.
+  (let [hyd-a (rf/subscribe-value frame-a   [:hydration])
+        hyd-b (rf/subscribe-value frame-b   [:hydration])
+        hyd-l (rf/subscribe-value frame-log [:hydration])]
+    [:div {:data-testid "hydration-summary"
+           :style {:border  "1px solid #aaa"
+                   :padding "0.5em"
+                   :margin  "0.5em 0"
+                   :font-family "monospace"}}
+     [:p "frame :counter/a hash="
+      [:span {:data-testid "summary-a-hash"} (str (:server-hash hyd-a))]]
+     [:p "frame :counter/b hash="
+      [:span {:data-testid "summary-b-hash"} (str (:server-hash hyd-b))]]
+     [:p "frame :log hash="
+      [:span {:data-testid "summary-log-hash"} (str (:server-hash hyd-l))]]
+     [:p "all-distinct="
+      [:span {:data-testid "summary-all-distinct"}
+       (str (= 3 (count (set [(:server-hash hyd-a)
+                              (:server-hash hyd-b)
+                              (:server-hash hyd-l)]))))]]]))
+
+(reg-view root []
+  [:div {:data-testid "ssr-multi-frame"
+         :style {:font-family "sans-serif" :padding "1em"}}
+   [:h1 "ssr-multi-frame testbed"]
+   [hydration-summary]
+   [:div {:style {:display :flex :flex-wrap :wrap :align-items :flex-start}}
+    [rf/frame-provider {:frame frame-a}
+     [counter-panel "A" "A"]]
+    [rf/frame-provider {:frame frame-b}
+     [counter-panel "B" "B"]]
+    [rf/frame-provider {:frame frame-log}
+     [log-panel]]]])
+
+;; ----------------------------------------------------------------------------
+;; Mount + hydrate per-frame
+;; ----------------------------------------------------------------------------
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(defn read-server-payload []
+  (when-let [el (.getElementById js/document "__rf_payload")]
+    (cljs.reader/read-string (.-textContent el))))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+
+  ;; Register the three frames with their initialisers. Each has its
+  ;; own :on-create, but :rf/hydrate (dispatched below) will REPLACE
+  ;; the resulting app-db with the per-frame payload slice (locked
+  ;; :replace-app-db policy).
+  (rf/reg-frame frame-a   {:on-create [::counter-init]})
+  (rf/reg-frame frame-b   {:on-create [::counter-init]})
+  (rf/reg-frame frame-log {:on-create [::log-init]})
+
+  (let [payload (read-server-payload)
+        ;; payload shape:
+        ;;   {:rf/version    1
+        ;;    :rf/per-frame {<frame-id> <per-frame-payload>, ...}}
+        per-frame (:rf/per-frame payload)]
+    (when (map? per-frame)
+      ;; HOT PATH — per-frame :rf/hydrate dispatch. Each call
+      ;; targets a distinct frame; the framework writes against that
+      ;; frame's app-db ONLY (no cross-frame bleed). The :frame opt
+      ;; on the dispatch envelope is the routing key (per
+      ;; spec/002 §Routing the dispatch envelope).
+      (doseq [[fid slice] per-frame]
+        (rf/dispatch-sync [:rf/hydrate slice] {:frame fid})))
+    (rdc/render react-root [root])))

--- a/testbeds/ssr_multi_frame/index.html
+++ b/testbeds/ssr_multi_frame/index.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: ssr-multi-frame</title>
+  <style>
+    body { font-family: sans-serif; margin: 2em; }
+    h1, h3 { margin: 0.25em 0; }
+    p { margin: 0.25em 0; }
+  </style>
+</head>
+<body>
+  <!--
+    The pre-rendered HTML is a placeholder (`not-hydrated`); the
+    interesting assertion is the per-frame `:rf/hydration` metadata
+    after hydrate completes. Each frame receives its own
+    `:rf/hydrate` dispatch with a distinct payload slice; the post-
+    hydrate summary block proves the three frames hold independent
+    metadata (distinct `:server-hash` values) and the three counter
+    panels read their seeded `:n` from their own app-db.
+  -->
+  <div id="app">
+    <div data-testid="ssr-multi-frame">
+      <h1>ssr-multi-frame testbed (loading)</h1>
+    </div>
+  </div>
+  <!--
+    Per-frame payload bundle. The outer map carries one entry per
+    frame; the value is a standalone :rf/hydration-payload
+    (`{:rf/version :rf/render-hash :rf/app-db}`) the runtime accepts
+    verbatim. Per Spec 011 §Frames are per-request: each frame's
+    payload survives independently; the framework writes to that
+    frame's app-db only.
+
+    Distinct :rf/render-hash strings per frame so the summary
+    block's `all-distinct=true` assertion is non-vacuous.
+  -->
+  <script id="__rf_payload" type="application/edn">
+{:rf/version 1
+ :rf/per-frame
+ {:counter/a {:rf/version     1
+              :rf/render-hash "aaaa1111"
+              :rf/app-db      {:n 10}}
+  :counter/b {:rf/version     1
+              :rf/render-hash "bbbb2222"
+              :rf/app-db      {:n 99}}
+  :log       {:rf/version     1
+              :rf/render-hash "cccc3333"
+              :rf/app-db      {:entries
+                               [{:from :ssr :note "hello"}
+                                {:from :ssr :note "world"}]}}}}
+  </script>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/testbeds/ssr_multi_frame/spec.cjs
+++ b/testbeds/ssr_multi_frame/spec.cjs
@@ -1,0 +1,115 @@
+/*
+ * SSR per-frame hydration isolation — three frames each receive
+ * their own :rf/hydrate dispatch from a per-frame payload slice;
+ * the three resulting app-dbs are independent.
+ *
+ * Per spec/011-SSR.md §Frames are per-request + spec/002-Frames.md
+ * §What lives in a frame: each frame owns its own app-db, router
+ * queue, and signal-graph cache; the hydration protocol operates
+ * frame-by-frame.
+ *
+ * What this spec walks:
+ *
+ *   - Three panels each render the seeded :n / :entries from
+ *     their own payload slice. The three :n values are 10 / 99
+ *     (counter A / B); the log frame has 2 entries.
+ *   - Each frame's :rf/hydration metadata is independent — the
+ *     summary block reports three distinct :server-hash values
+ *     (aaaa1111, bbbb2222, cccc3333).
+ *   - data-testid='summary-all-distinct' reads true, proving the
+ *     three hashes are pairwise distinct (no cross-frame bleed).
+ *   - Per-frame interactivity: clicking inc-A bumps only
+ *     :counter/a's :n (10 → 11); :counter/b's :n stays at 99.
+ */
+
+const {
+  expectTextEquals,
+  expectVisible,
+} = require('../../examples/scripts/spec-helpers.cjs');
+
+module.exports = {
+  name: 'testbeds/ssr-multi-frame (per-frame hydration isolation)',
+  url: '/testbed-ssr-multi-frame/',
+  run: async (page) => {
+    // ---- (1) three panels render the seeded per-frame values --------
+    await expectVisible(page.locator('[data-testid="panel-A"]'), 10000);
+    await expectVisible(page.locator('[data-testid="panel-B"]'), 5000);
+    await expectVisible(page.locator('[data-testid="panel-log"]'), 5000);
+
+    await expectTextEquals(page.locator('[data-testid="n-A"]'), '10', 5000);
+    await expectTextEquals(page.locator('[data-testid="n-B"]'), '99', 5000);
+    await expectTextEquals(
+      page.locator('[data-testid="entries-count"]'),
+      '2',
+      5000,
+    );
+
+    // ---- (2) per-frame :rf/hydration metadata landed independently --
+    await expectTextEquals(page.locator('[data-testid="hyd-A"]'), 'true', 5000);
+    await expectTextEquals(page.locator('[data-testid="hyd-B"]'), 'true', 5000);
+    await expectTextEquals(page.locator('[data-testid="hyd-log"]'), 'true', 5000);
+
+    // The payload-supplied :rf/render-hash per frame lands on the
+    // matching frame's :rf/hydration :server-hash slot. Distinct
+    // values prove the framework wrote to three distinct app-dbs.
+    await expectTextEquals(
+      page.locator('[data-testid="hash-A"]'),
+      'aaaa1111',
+      5000,
+    );
+    await expectTextEquals(
+      page.locator('[data-testid="hash-B"]'),
+      'bbbb2222',
+      5000,
+    );
+    await expectTextEquals(
+      page.locator('[data-testid="hash-log"]'),
+      'cccc3333',
+      5000,
+    );
+
+    // ---- (3) cross-frame readout via subscribe-value frame-id ------
+    //
+    // The hydration-summary block calls rf/subscribe-value with each
+    // frame-id explicitly, reading the SAME [:hydration] query
+    // against three different frames. Each call resolves the
+    // matching :server-hash → proves the per-frame sub cache is
+    // partitioned correctly.
+    await expectTextEquals(
+      page.locator('[data-testid="summary-a-hash"]'),
+      'aaaa1111',
+      5000,
+    );
+    await expectTextEquals(
+      page.locator('[data-testid="summary-b-hash"]'),
+      'bbbb2222',
+      5000,
+    );
+    await expectTextEquals(
+      page.locator('[data-testid="summary-log-hash"]'),
+      'cccc3333',
+      5000,
+    );
+    await expectTextEquals(
+      page.locator('[data-testid="summary-all-distinct"]'),
+      'true',
+      5000,
+    );
+
+    // ---- (4) per-frame post-hydration interactivity -----------------
+    //
+    // Clicking inc-A dispatches `[::inc]` against `:counter/a`'s
+    // router queue (the frame-provider's lexical scope picks the
+    // frame). Only :counter/a's :n bumps; :counter/b stays at 99.
+    await page.locator('[data-testid="inc-A"]').click();
+    await expectTextEquals(page.locator('[data-testid="n-A"]'), '11', 5000);
+    // Cross-frame isolation: B unchanged.
+    await expectTextEquals(page.locator('[data-testid="n-B"]'), '99', 5000);
+
+    await page.locator('[data-testid="inc-B"]').click();
+    await page.locator('[data-testid="inc-B"]').click();
+    await expectTextEquals(page.locator('[data-testid="n-B"]'), '101', 5000);
+    // A unaffected.
+    await expectTextEquals(page.locator('[data-testid="n-A"]'), '11', 5000);
+  },
+};


### PR DESCRIPTION
## Summary

Three new top-level testbed surfaces + three Playwright specs that
exercise the SSR hydration round-trip from the browser end. JVM-side
SSR has strong coverage (`implementation/ssr/test/`); this PR fills
the **browser** side — proves that SSR-rendered HTML revives correctly
in the browser without console errors, hydration mismatches, or state
divergence.

## Surfaces built

- **`testbeds/ssr_basic/`** — the hydration baseline. Static
  `index.html` bakes pre-rendered HTML + an EDN
  `:rf/hydration-payload` script (mirroring what the JVM-side
  `render-to-string` + payload builder emit per spec/011-SSR.md).
  Browser-side `run` reads the payload, dispatches `:rf/hydrate`,
  renders, and calls `verify-hydration!`. A trace listener mirrors
  every `:rf.ssr/*` + `:rf/hydrate` trace event onto
  `window.__rf_trace_events()`. Per-request `:rf.server/*` response
  data (status, headers, cookies) round-trips via the payload's
  `:rf/response` slice.
- **`testbeds/ssr_hydration_mismatch/`** — deliberate mismatch.
  Payload bakes a known-wrong `:rf/render-hash` (`"deadbeef"`);
  `verify-hydration!` emits `:rf.ssr/hydration-mismatch` with
  `:recovery :warned-and-replaced`. The trace listener routes the
  captured tags into a `::record-mismatch` handler so the dev-mode
  banner re-renders the structured payload inline.
- **`testbeds/ssr_multi_frame/`** — per-frame hydration isolation.
  Three frames (`:counter/a`, `:counter/b`, `:log`) each receive
  their own `:rf/hydrate` dispatch from a per-frame slice; the
  three panels prove each frame's state was restored independently
  with no cross-frame bleed.

## Coverage map (spec/011-SSR.md section → scenario)

| Section | ssr_basic | ssr_hydration_mismatch | ssr_multi_frame |
|---|---|---|---|
| §Hydration is a defined protocol | ✓ | ✓ | ✓ |
| §Payload scope (canonical boundary) | ✓ | ✓ | ✓ |
| §The `:rf/hydrate` event | ✓ (replace-app-db, metadata stash) | ✓ (server-hash stash) | ✓ (per-frame stash) |
| §Hydration-mismatch detection | ✓ (baseline: no mismatch) | ✓ (deliberate mismatch + tags) | n/a |
| §Mismatch recovery and configuration | n/a | ✓ (`:warned-and-replaced` default) | n/a |
| §`:rf.ssr/check-version` (rf2-69ad2) | ✓ (`:rf.ssr/compatibility-check-skipped`) | n/a | n/a |
| §Response storage substrate | ✓ (round-trip via `:rf/response` slice) | n/a | n/a |
| §Frames are per-request | ✓ (frame-id round-trip) | n/a | ✓ (3 independent frames) |
| §Hydration mismatch — `:failing-id` discriminator | n/a | ✓ (`:rf/hydrate` v1) | n/a |
| spec/002 §What lives in a frame | n/a | n/a | ✓ |
| spec/002 §Routing the dispatch envelope | n/a | n/a | ✓ (`{:frame fid}` per dispatch) |

## Wiring

- Three new shadow-cljs build entries in `implementation/shadow-cljs.edn`
  (`:testbeds/ssr-basic`, `:testbeds/ssr-hydration-mismatch`,
  `:testbeds/ssr-multi-frame`). Output dirs land under
  `out/examples/testbed-ssr-*/` so the examples orchestrator's
  http-server root serves them without an extra copy step.
- Three new entries in `examples/scripts/serve-and-run-examples-tests.cjs`'s
  EXAMPLES list — keeps the testbeds in the orchestrator's compile-
  stage-serve cycle alongside the canonical tutorial examples.
- Each surface has `core.cljs` + `index.html` + `README.md` + `spec.cjs`,
  matching the convention.

## Out of scope (filed for follow-on)

- **JVM-side validator round-trip tests** (tag-name validator
  rf2-z7gor, header/cookie CRLF validators). These fail fast on the
  JVM render path — the client never sees the broken HTML. Testing
  this from the browser would require a JVM SSR server we don't
  have in the static-html testbed setup. The validators are
  thoroughly covered JVM-side; will file a follow-on bead for an
  end-to-end JVM-integration layer.
- **Cross-substrate** (UIx, Helix). Reagent-first per the bead's
  guidance; will file follow-on beads if cross-substrate browser
  integration coverage becomes needed.

## Quality gates

- `npm run test:cljs` — 1994 tests / 5651 assertions / 0 failures.
- `npm run test:bundle-isolation` — PASS.
- `npm run test:examples` — 30 specs / 30 PASS (after socket
  TIME_WAIT drain on Windows).
- All three new shadow-cljs builds release-compile clean.
- JVM SSR suite (`implementation/ssr clojure -M:test`) — 123 tests
  / 401 assertions / 0 failures (regression check; this PR doesn't
  touch implementation/ssr/).

## Test plan

- [ ] Run `npm run test:examples` and observe 30/30 green.
- [ ] Spot-check the three new testbeds in `shadow-cljs watch`
      and verify the Causa preload + trace listener interact
      cleanly.