### PR TITLE
docs(guide): new chapter — Configuration and Safety Primitives (rf2-50uta)

### DIFF
--- a/docs/guide/24-configuration-and-safety/01-framework-config.md
+++ b/docs/guide/24-configuration-and-safety/01-framework-config.md
@@ -8,7 +8,7 @@
 
 ## The `configure` keys
 
-There are four. Each is a plain-data setting that applies to the framework runtime as a whole. The full normative table — vocabulary, opts shape, defaults, status — lives at [API.md §Configure keys](../../spec/API.md#configure-keys); this page is the guide-side narrative.
+There are four. Each is a plain-data setting that applies to the framework runtime as a whole. The full normative table — vocabulary, opts shape, defaults, status — lives at [API.md §Configure keys](../../../spec/API.md#configure-keys); this page is the guide-side narrative.
 
 ### `:epoch-history` — how far back can you rewind?
 
@@ -62,7 +62,7 @@ Unlike the two above, `:sub-cache` is **not** dev-only — the sub-cache exists 
 (rf/configure :elision {:rf.size/threshold-bytes 0})       ;; disable runtime size-based detection
 ```
 
-The wire-elision walker (per [chapter 23b](../23b-large-blobs.md) and [API.md §`rf/elide-wire-value`](../../spec/API.md#elide-wire-value-the-wire-boundary-walker)) replaces large values with `:rf.size/large-elided` markers before they egress to off-box consumers. The threshold-bytes value is the **runtime auto-detection threshold** — a value larger than this gets a marker even if the schema didn't pre-declare it as `:large?`.
+The wire-elision walker (per [chapter 23b](../23b-large-blobs.md) and [API.md §`rf/elide-wire-value`](../../../spec/API.md#elide-wire-value-the-wire-boundary-walker)) replaces large values with `:rf.size/large-elided` markers before they egress to off-box consumers. The threshold-bytes value is the **runtime auto-detection threshold** — a value larger than this gets a marker even if the schema didn't pre-declare it as `:large?`.
 
 16KB is the default because it's about the size where pretty-printing the value into a Datadog event starts being a bad idea. Tune up if you've got endpoints that legitimately return larger blobs that fit your back-end; tune down if you're shipping to a back-end with a smaller event limit.
 
@@ -96,7 +96,7 @@ If you're using the default substrate ([chapter 19](../19-adapters.md)) and Mall
 
 These are **not** folded under `configure` because keyword-keyed addressing loses the type information a consumer needs to pass an actual fn/component reference. `configure` is for *data*; `set-!` is for *impls*. That asymmetry is the explicit signal: "the framework is going to hold this reference and call it back from places you don't control."
 
-For the full enumeration of the `set-!` / `install-!` surface, see [API.md §Adapter lifecycle](../../spec/API.md) and [API.md §Schemas](../../spec/API.md). Both surfaces are small (five-ish fns each) and follow the same pattern: install / swap / inspect / dispose.
+For the full enumeration of the `set-!` / `install-!` surface, see [API.md §Adapter lifecycle](../../../spec/API.md) and [API.md §Schemas](../../../spec/API.md). Both surfaces are small (five-ish fns each) and follow the same pattern: install / swap / inspect / dispose.
 
 ## The per-frame neighbour
 
@@ -114,8 +114,8 @@ The third bucket is per-frame metadata. Anything whose lifetime is "as long as t
 
 ## Cross-references
 
-- [API.md §Configure keys](../../spec/API.md#configure-keys) — the normative key table.
-- [Conventions §Configuration surfaces](../../spec/Conventions.md#configuration-surfaces-configure-vs-set--vs-per-frame-metadata) — the three-bucket model.
+- [API.md §Configure keys](../../../spec/API.md#configure-keys) — the normative key table.
+- [Conventions §Configuration surfaces](../../../spec/Conventions.md#configuration-surfaces-configure-vs-set--vs-per-frame-metadata) — the three-bucket model.
 - [Chapter 06a — Frames](../06a-frames.md) — the per-frame metadata grammar.
 - [Chapter 15 — Tooling](../15-devtools-and-pair-tools.md) — the consumers of `:epoch-history` and `:trace-buffer`.
 - [Chapter 19 — Adapters](../19-adapters.md) — `install-adapter!`, `dispose-adapter!`, and friends.

--- a/docs/guide/24-configuration-and-safety/01-framework-config.md
+++ b/docs/guide/24-configuration-and-safety/01-framework-config.md
@@ -1,0 +1,122 @@
+# 24.01 — Framework configuration
+
+## TL;DR
+
+`(rf/configure key opts)` is the one entry point for process-level framework knobs. The vocabulary is closed-and-additive: four keys today, never renamed, never removed; new keys arrive by Spec change. This page enumerates them, lists their defaults, and gives you the question each one answers.
+
+`set-!` / `install-!` are the *other* entry point — for hooks that need a fn-reference rather than a data value. Per-frame metadata is the third. The chapter index sketched the three-bucket model; this page is the inside of bucket 1, with a glance at bucket 2.
+
+## The `configure` keys
+
+There are four. Each is a plain-data setting that applies to the framework runtime as a whole. The full normative table — vocabulary, opts shape, defaults, status — lives at [API.md §Configure keys](../../spec/API.md#configure-keys); this page is the guide-side narrative.
+
+### `:epoch-history` — how far back can you rewind?
+
+```clojure
+(rf/configure :epoch-history {:depth 50})        ;; the default
+(rf/configure :epoch-history {:depth 200})       ;; deeper history; more memory
+(rf/configure :epoch-history {:depth 0})         ;; disable
+```
+
+Every dispatched event's full cascade is recorded as an *epoch record* — `:db-before`, `:db-after`, `:sub-runs`, `:renders`, `:effects`, `:trace-events` — and stored in a ring buffer. That buffer is what powers [chapter 15](../15-devtools-and-pair-tools.md)'s time-travel debugging, `restore-epoch`, `reset-frame-db!`, and the Tool-Pair surface.
+
+50 epochs is enough for a typical debug session (you almost never want to rewind further than 50 user actions). 200 is reasonable for long-running stress tests. 0 disables history entirely — useful in SSR production where you have no replayer attached and the per-cascade allocation is wasted work.
+
+The setting is **dev-only** by status. Under `:advanced` + `goog.DEBUG=false`, the recording site DCEs and the buffer never allocates, regardless of what you configured.
+
+### `:trace-buffer` — how many trace events sit in memory?
+
+```clojure
+(rf/configure :trace-buffer {:depth 200})        ;; the default
+(rf/configure :trace-buffer {:depth 1000})       ;; longer trace history
+(rf/configure :trace-buffer {:depth 0})          ;; disable the buffer
+```
+
+The trace buffer is the ring of `:rf.*/*` trace events that backs your dev tooling — the same stream that [chapter 22](../22-trace-to-datadog.md) ships to observability back-ends, the same stream that pair2-mcp inspects when an agent asks "what happened in the last cascade." Bigger buffer means longer history; smaller buffer means less memory.
+
+The default of 200 is sized to comfortably hold a single complex cascade (one user action that fans out into 30+ machine transitions, an HTTP response, a few sub-runs, the lot). If you're investigating a multi-event saga, bump it. If you're in production and you've registered listeners that ship events as they arrive (rather than reading the buffer), set it to 0 — the listeners get every event live; the buffer is wasted memory.
+
+Like `:epoch-history`, the buffer is dev-only. Production builds elide the allocation regardless.
+
+### `:sub-cache` — how long do unused subscriptions live before disposal?
+
+```clojure
+(rf/configure :sub-cache {:grace-period-ms 50})   ;; the default
+(rf/configure :sub-cache {:grace-period-ms 200})  ;; tolerate longer route transitions
+(rf/configure :sub-cache {:grace-period-ms 0})    ;; synchronous disposal
+```
+
+Subscription caching is ref-counted: when the last consumer of a subscription disappears, the cache schedules disposal. The **grace period** is how long the disposal waits — if a new consumer shows up inside the window, the subscription is rescued and the disposal is cancelled.
+
+The reason this matters: route transitions, modal close-and-reopen flows, and "scrub the timeline forward then back" interactions briefly unmount and remount the same subscription tree. With a 50ms grace period, those flows reuse the cached subscription without re-running the computation; the cache is doing its job. Tune up if your app has slow-mounting routes; tune down (or to 0) if you're memory-constrained and want subs to drop the second nobody's reading them.
+
+Setting it to 0 selects synchronous disposal: the subscription tears down on the same tick as the last consumer leaves. Useful for tests that assert on cache cardinality; rarely useful in production.
+
+Unlike the two above, `:sub-cache` is **not** dev-only — the sub-cache exists in production builds, and the grace-period configuration applies there too.
+
+### `:elision` — how big is "big enough to elide?"
+
+```clojure
+(rf/configure :elision {:rf.size/threshold-bytes 16384})   ;; the default — 16KB
+(rf/configure :elision {:rf.size/threshold-bytes 65536})   ;; tolerate bigger inline values
+(rf/configure :elision {:rf.size/threshold-bytes 0})       ;; disable runtime size-based detection
+```
+
+The wire-elision walker (per [chapter 23b](../23b-large-blobs.md) and [API.md §`rf/elide-wire-value`](../../spec/API.md#elide-wire-value-the-wire-boundary-walker)) replaces large values with `:rf.size/large-elided` markers before they egress to off-box consumers. The threshold-bytes value is the **runtime auto-detection threshold** — a value larger than this gets a marker even if the schema didn't pre-declare it as `:large?`.
+
+16KB is the default because it's about the size where pretty-printing the value into a Datadog event starts being a bad idea. Tune up if you've got endpoints that legitimately return larger blobs that fit your back-end; tune down if you're shipping to a back-end with a smaller event limit.
+
+Setting it to 0 disables the runtime walker for size-based detection; only **schema-declared** `:large?` slots elide. That's the right setting for environments where you've fully audited every slot via schemas and want the runtime to honour those declarations and nothing else — no accidental elision of an unexpectedly-large response payload, no false negatives from "small slot containing a large value."
+
+Note that `:sensitive?` elision is **never** size-gated. Sensitive values redact regardless of size; the threshold only governs `:large?`-flavoured size elision.
+
+## When to tune
+
+The defaults are the right answer for almost every app. The cases where you tune are narrow:
+
+- **Bumping `:epoch-history`** for a debug session where you want to scrub a longer cascade.
+- **Bumping `:trace-buffer`** when you're hunting a bug that spans multiple user actions and the existing buffer is rotating events out before you can read them.
+- **Bumping `:sub-cache` grace period** when route transitions feel laggy because the sub recomputed instead of resurrecting from cache. (This is rare; the default catches most cases.)
+- **Bumping `:elision` threshold** when your back-end can handle larger events than 16KB and you want fewer round-trips to refetch elided values.
+- **Setting any of the dev-only keys to 0** in long-running JVM SSR processes where dev recording is wasted allocation.
+
+If you find yourself wanting to tune something that isn't on the list, the option doesn't exist — and that's deliberate. The framework's stance is that the per-process knobs are a small fixed set; new knobs land by Spec change, not by adding a "configurable" flag to wallpaper over a design issue.
+
+## The `set-!` / `install-!` neighbours
+
+A few things look like they should be `configure` keys but aren't, because the value the framework needs is a fn or component reference rather than data. These live under separate `set-!` / `install-!` fns; the bang on the end is the framework's way of telling you the surface mutates a process-level slot the framework calls into from arbitrary sites.
+
+```clojure
+(rf/install-adapter! reagent/adapter)                ;; install the reactive substrate
+(rf/set-schema-validator! malli.core/validate)       ;; swap the schema validator
+(rf/set-schema-explainer! malli.core/explain)        ;; swap the schema explainer
+```
+
+If you're using the default substrate ([chapter 19](../19-adapters.md)) and Malli for schemas ([chapter 04a](../04a-schemas.md)), you call none of these and the boot wiring is automatic. If you want to drop the Malli dependency and bring your own validator (Plumatic, Specs, hand-rolled), `set-schema-validator!` is the entry point.
+
+These are **not** folded under `configure` because keyword-keyed addressing loses the type information a consumer needs to pass an actual fn/component reference. `configure` is for *data*; `set-!` is for *impls*. That asymmetry is the explicit signal: "the framework is going to hold this reference and call it back from places you don't control."
+
+For the full enumeration of the `set-!` / `install-!` surface, see [API.md §Adapter lifecycle](../../spec/API.md) and [API.md §Schemas](../../spec/API.md). Both surfaces are small (five-ish fns each) and follow the same pattern: install / swap / inspect / dispose.
+
+## The per-frame neighbour
+
+The third bucket is per-frame metadata. Anything whose lifetime is "as long as this frame exists" — `:fx-overrides` for one test fixture, `:drain-depth` tightened for one story, `:on-error` for one production frame versus one SSR frame — lives on the frame's metadata, not in `configure`:
+
+```clojure
+(rf/reg-frame :auth
+  {:on-create  [:auth/initialise]
+   :drain-depth 100
+   :on-error   {:default :log
+                :rf.error/drain-depth-exceeded :halt}})
+```
+
+[Chapter 06a](../06a-frames.md) walks the whole frame-metadata grammar. The next page in this chapter, [§04 Drain depth](04-drain-depth-and-error-recovery.md), digs into `:drain-depth` and `:on-error` specifically — both are bucket-3 knobs that the safety story leans on.
+
+## Cross-references
+
+- [API.md §Configure keys](../../spec/API.md#configure-keys) — the normative key table.
+- [Conventions §Configuration surfaces](../../spec/Conventions.md#configuration-surfaces-configure-vs-set--vs-per-frame-metadata) — the three-bucket model.
+- [Chapter 06a — Frames](../06a-frames.md) — the per-frame metadata grammar.
+- [Chapter 15 — Tooling](../15-devtools-and-pair-tools.md) — the consumers of `:epoch-history` and `:trace-buffer`.
+- [Chapter 19 — Adapters](../19-adapters.md) — `install-adapter!`, `dispose-adapter!`, and friends.
+- [Chapter 23b — Large blobs](../23b-large-blobs.md) — the consumer of `:elision`.

--- a/docs/guide/24-configuration-and-safety/02-http-safety.md
+++ b/docs/guide/24-configuration-and-safety/02-http-safety.md
@@ -35,7 +35,7 @@ When the cap trips, the request fails as a normal `:rf.http/decode-failure` repl
 
 Your `:on-failure` handler sees the structured shape; the request didn't complete; no keyword slots were committed. The first line of defense — if you can — is to use `:decode :text` for endpoints whose response you don't need as a keyword-keyed map; the cap is the second line, for the JSON cases where you do.
 
-The full normative description sits at [014-HTTPRequests.md §Keyword-interning cap](../../spec/014-HTTPRequests.md) and [Security.md §DoS by input](../../spec/Security.md#dos-by-input).
+The full normative description sits at [014-HTTPRequests.md §Keyword-interning cap](../../../spec/014-HTTPRequests.md) and [Security.md §DoS by input](../../../spec/Security.md#dos-by-input).
 
 ## Slow-loris defense — `:timeout-ms` default 30000
 
@@ -59,7 +59,7 @@ The opt-outs are explicit. You either pass `:timeout-ms nil` or `:timeout-ms 0`:
 
 Two values mean opt-out, both deliberate-looking, because "the caller meant to" should be visible to a reviewer. If you don't write `:timeout-ms`, you get 30000. If you write it as a small positive integer (`5000` for "I expect this to be quick"), you get that. The only way to remove the timeout entirely is to type `nil` or `0` — and a reviewer who sees that line knows the call-site author signed off on unbounded wall-clock.
 
-See [014-HTTPRequests.md §`:timeout-ms` security defaults](../../spec/014-HTTPRequests.md) and [Security.md §DoS by input](../../spec/Security.md#dos-by-input).
+See [014-HTTPRequests.md §`:timeout-ms` security defaults](../../../spec/014-HTTPRequests.md) and [Security.md §DoS by input](../../../spec/Security.md#dos-by-input).
 
 ## CRLF fail-fast on response-shape fx
 
@@ -93,7 +93,7 @@ A few decisions are worth pointing at, because they're deliberate:
 
 - **Structural URL check on redirects, in addition to CRLF.** `:rf.server/redirect` also rejects malformed-URL inputs at the same site, so a `:rf.error/redirect-invalid-location` surfaces both the CRLF case and the "this isn't a URL" case under one error category.
 
-The full normative description lives at [Security.md §CRLF injection at HTTP-response boundaries](../../spec/Security.md#crlf-injection-at-http-response-boundaries) and [011-SSR.md §Standard fx](../../spec/011-SSR.md).
+The full normative description lives at [Security.md §CRLF injection at HTTP-response boundaries](../../../spec/Security.md#crlf-injection-at-http-response-boundaries) and [011-SSR.md §Standard fx](../../../spec/011-SSR.md).
 
 ## What you don't have to do
 
@@ -106,6 +106,6 @@ The same posture extends to the JSON cap and the timeout: you don't write `(try 
 - [Chapter 10 — Doing HTTP requests](../10-doing-http-requests.md) — the managed-HTTP narrative; this page is the defensive layer underneath.
 - [Chapter 11 — The server side](../11-server-side.md) — the response-shape fx; this page covers their CRLF check.
 - [Chapter 14 — Errors](../14-errors.md) — `:on-error` policies and per-category recovery.
-- [Security.md](../../spec/Security.md) — the threat model + defense catalogue. The eventual pattern/impl split (rf2-1g6cj) may rename this doc; the content moves with it.
-- [014-HTTPRequests.md](../../spec/014-HTTPRequests.md) — normative spec for managed-HTTP, including the keyword cap and the timeout default.
-- [011-SSR.md](../../spec/011-SSR.md) — normative spec for SSR response-shape fx, including the CRLF check site.
+- [Security.md](../../../spec/Security.md) — the threat model + defense catalogue. The eventual pattern/impl split (rf2-1g6cj) may rename this doc; the content moves with it.
+- [014-HTTPRequests.md](../../../spec/014-HTTPRequests.md) — normative spec for managed-HTTP, including the keyword cap and the timeout default.
+- [011-SSR.md](../../../spec/011-SSR.md) — normative spec for SSR response-shape fx, including the CRLF check site.

--- a/docs/guide/24-configuration-and-safety/02-http-safety.md
+++ b/docs/guide/24-configuration-and-safety/02-http-safety.md
@@ -1,0 +1,111 @@
+# 24.02 — HTTP safety primitives
+
+## TL;DR
+
+Three defenses, one chapter. The framework caps JSON keyword interning so a hostile upstream can't burn unbounded keyword slots. It applies a 30-second timeout to managed requests so a slow-loris partner can't pin your connection pool open forever. It refuses to ship a header (or set a cookie, or issue a redirect) whose value contains `\r\n`, because that's how header injection works. All three are on by default; all three surface as structured errors when they fire.
+
+[Chapter 10](../10-doing-http-requests.md) is the place to learn what managed-HTTP looks like to a normal app. [Chapter 11](../11-server-side.md) is the place to learn what SSR response-shape fx do. This page is the safety layer between you and a few specific classes of failure that those chapters don't dwell on. It's deliberately short because each defense is small.
+
+## JSON keyword cap — `:rf.http/max-decoded-keys`
+
+When `:rf.http/managed` decodes a JSON response and keywordizes its keys (the default), every unique key turns into a Clojure keyword. Clojure keywords are interned; once a JVM has seen `:foo` it remembers it for the lifetime of the process. That's normally invisible — most apps see a few hundred distinct keys across their entire wire vocabulary.
+
+But: an upstream that's been compromised (or just hostile) can return a JSON object whose keys are `"a000000"`, `"a000001"`, `"a000002"`, … and a long-running JVM SSR worker that hits that endpoint a million times eventually fills its keyword storage and tips over. The same threat applies to a webhook receiver, an MCP server's response decode, or any other always-on JVM that decodes attacker-influenceable JSON.
+
+The framework caps the number of unique keys it'll keywordize per request. The default is **10000** — comfortably more than any legitimate response, comfortably less than a denial-of-service. The cap is enforced at the decode site in both the JVM (Cheshire) and CLJS (the reader) paths.
+
+You can opt up per-request:
+
+```clojure
+(rf/dispatch
+ [:catalog/refresh
+  {:rf.http/managed
+   {:request {:method :get :url "/catalog/full-dump"}
+    :rf.http/max-decoded-keys 50000           ;; one specific endpoint legitimately wants more
+    :on-success [:catalog/loaded]}}])
+```
+
+When the cap trips, the request fails as a normal `:rf.http/decode-failure` reply on the request's `:on-failure` path:
+
+```clojure
+{:kind   :rf.http/decode-failure
+ :reason :too-many-keys
+ :limit  10000}
+```
+
+Your `:on-failure` handler sees the structured shape; the request didn't complete; no keyword slots were committed. The first line of defense — if you can — is to use `:decode :text` for endpoints whose response you don't need as a keyword-keyed map; the cap is the second line, for the JSON cases where you do.
+
+The full normative description sits at [014-HTTPRequests.md §Keyword-interning cap](../../spec/014-HTTPRequests.md) and [Security.md §DoS by input](../../spec/Security.md#dos-by-input).
+
+## Slow-loris defense — `:timeout-ms` default 30000
+
+A "slow-loris" upstream is one that never quite finishes the response — it sends a header, dribbles a byte, waits, dribbles another byte, waits. On the CLJS side that's a fetch promise that never resolves. On the JVM side that's a `CompletableFuture` that never completes and a connection-pool slot that never returns. Run a long-lived JVM against a compromised partner and you can have your pool exhausted in minutes.
+
+`:rf.http/managed` applies a **30-second per-attempt wall-clock timeout** to every request that doesn't explicitly opt out. The timeout fires regardless of what state the request is in — TCP open, TLS handshake, headers in, body in, body trickling — and surfaces as:
+
+```clojure
+{:kind :rf.http/timeout :elapsed-ms 30000}
+```
+
+on the `:on-failure` path. The `:retry` policy (if you've declared one) sees `:rf.http/timeout` like any other classifier and decides whether to retry.
+
+The opt-outs are explicit. You either pass `:timeout-ms nil` or `:timeout-ms 0`:
+
+```clojure
+;; explicit opt-out — caller is taking responsibility for the lifetime
+{:request    {:method :get :url "/very/long/streaming/endpoint"}
+ :timeout-ms nil}
+```
+
+Two values mean opt-out, both deliberate-looking, because "the caller meant to" should be visible to a reviewer. If you don't write `:timeout-ms`, you get 30000. If you write it as a small positive integer (`5000` for "I expect this to be quick"), you get that. The only way to remove the timeout entirely is to type `nil` or `0` — and a reviewer who sees that line knows the call-site author signed off on unbounded wall-clock.
+
+See [014-HTTPRequests.md §`:timeout-ms` security defaults](../../spec/014-HTTPRequests.md) and [Security.md §DoS by input](../../spec/Security.md#dos-by-input).
+
+## CRLF fail-fast on response-shape fx
+
+This one's for the server side. SSR's response-shape fx (per [chapter 11](../11-server-side.md)) write headers, set cookies, and issue redirects:
+
+```clojure
+{:fx [[:rf.server/set-header  "X-Trace-Id" trace-id]
+      [:rf.server/set-cookie  {:name "session" :value sid :domain "example.com" :path "/"}]
+      [:rf.server/redirect    302 "/dashboard"]]}
+```
+
+Each of those values eventually becomes a line in the HTTP response: `X-Trace-Id: abc123\r\n`, `Set-Cookie: session=...; Domain=example.com; Path=/\r\n`, `Location: /dashboard\r\n`. The `\r\n` at the end of each line is the framework's job, not the caller's — and it's also a problem.
+
+If a value the caller passed *itself* contains `\r\n`, the response splits. A `trace-id` of `"abc\r\nSet-Cookie: admin=true"` becomes two response lines: the legitimate `X-Trace-Id`, then a brand-new `Set-Cookie: admin=true` the attacker injected. This is **header injection**, and the right defense is "refuse the input."
+
+The framework refuses. Each response-shape fx checks its value (or its per-attribute fields, for cookies) for `\r` or `\n` at handler time, and on detection emits:
+
+| Fx | Error |
+|---|---|
+| `:rf.server/set-header` / `:rf.server/append-header` | `:rf.error/header-invalid-value` |
+| `:rf.server/redirect` (Location-header) | `:rf.error/redirect-invalid-location` |
+| `:rf.server/set-cookie` (any attribute field) | `:rf.error/header-invalid-value` |
+
+The error fires on the failing fx, the response is **not** written, the caller's `:on-error` policy (or the SSR error projector, per [ch.11](../11-server-side.md)) takes over.
+
+A few decisions are worth pointing at, because they're deliberate:
+
+- **No strip-and-warn.** The framework does not silently delete the CRLF and continue. Silent normalisation lets attacker-encoded variants (`%0D%0A`, double-encodings, etc.) through if the downstream decoder treats them differently — and worse, it masks the bug from the dev writing the call site. Fail-fast is the only honest answer.
+
+- **Per-attribute on cookies.** A cookie isn't one string; it's a map of `:name`, `:value`, `:domain`, `:path`, `:max-age`, `:same-site`. Each one rides as its own attribute in the `Set-Cookie:` line, and each one is checked independently. The threat model isn't "attacker controls the whole value" — it's "attacker controls the user-id flowing into `:name`, or the partner-supplied `:domain`, and only that piece can carry CRLF."
+
+- **Structural URL check on redirects, in addition to CRLF.** `:rf.server/redirect` also rejects malformed-URL inputs at the same site, so a `:rf.error/redirect-invalid-location` surfaces both the CRLF case and the "this isn't a URL" case under one error category.
+
+The full normative description lives at [Security.md §CRLF injection at HTTP-response boundaries](../../spec/Security.md#crlf-injection-at-http-response-boundaries) and [011-SSR.md §Standard fx](../../spec/011-SSR.md).
+
+## What you don't have to do
+
+A common pattern in older Ring-style code is "sanitise every value before you pass it to the response builder." You don't have to do that with `:rf.server/*`. The framework's stance: the **fx-handler** is the sanitisation site, not your code, and the contract is "give me your data; I'll fail-fast if you handed me something dangerous." If your code passes the framework a value with `\r\n` in it, the framework's response is "your caller has a bug, here's the error category, surface it the way you'd surface any other bug." You spend exactly zero lines of defensive code at the call site.
+
+The same posture extends to the JSON cap and the timeout: you don't write `(try ... (catch SocketTimeoutException ...))` at every call site. You declare the `:retry` policy you want, and the framework's failure classification (`:rf.http/timeout`, `:rf.http/decode-failure`, the eight-category taxonomy from [ch.10](../10-doing-http-requests.md)) tells your reply handler what kind of failure it's seeing.
+
+## Cross-references
+
+- [Chapter 10 — Doing HTTP requests](../10-doing-http-requests.md) — the managed-HTTP narrative; this page is the defensive layer underneath.
+- [Chapter 11 — The server side](../11-server-side.md) — the response-shape fx; this page covers their CRLF check.
+- [Chapter 14 — Errors](../14-errors.md) — `:on-error` policies and per-category recovery.
+- [Security.md](../../spec/Security.md) — the threat model + defense catalogue. The eventual pattern/impl split (rf2-1g6cj) may rename this doc; the content moves with it.
+- [014-HTTPRequests.md](../../spec/014-HTTPRequests.md) — normative spec for managed-HTTP, including the keyword cap and the timeout default.
+- [011-SSR.md](../../spec/011-SSR.md) — normative spec for SSR response-shape fx, including the CRLF check site.

--- a/docs/guide/24-configuration-and-safety/03-redirect-and-editor-uris.md
+++ b/docs/guide/24-configuration-and-safety/03-redirect-and-editor-uris.md
@@ -1,0 +1,117 @@
+# 24.03 — Redirects and editor URIs
+
+## TL;DR
+
+Two URI-shaped surfaces, two scheme policies. The framework's editor-launch links — the click-to-source affordance that opens your IDE at a specific line — reject three known-bad schemes (`javascript:`, `data:`, `vbscript:`) and, at the tool's click-time boundary, only honour a positive allowlist of editor schemes. `:rf.server/redirect` rejects CRLF in the `Location:` value and surfaces a structural URL check. Both defenses are small, and both are about closing the gap between "a string the framework will hand to the browser" and "a string the user controls."
+
+The previous page covered the headers-and-cookies CRLF check on the server. This page covers the two scheme-checked surfaces — `:rf.server/redirect` (where the Location header is itself a URI) and the editor-URI templates that pair-tools use to open IDE links from in-page click affordances.
+
+## `:rf.server/redirect` and `:rf.error/redirect-invalid-location`
+
+A redirect from your SSR handler is a `Location:` header plus an HTTP 3xx status:
+
+```clojure
+;; common case — internal redirect after sign-in
+{:fx [[:rf.server/redirect 302 "/dashboard"]]}
+
+;; with a query string
+{:fx [[:rf.server/redirect 302 (str "/login?return=" return-url)]]}
+
+;; conditional — redirect to a partner domain
+{:fx [[:rf.server/redirect 302 (str "https://" partner-domain "/oauth/return")]]}
+```
+
+The framework's `:rf.server/redirect` fx-handler runs two checks on the Location value:
+
+1. **CRLF fail-fast** — same check as every other `:rf.server/*` value (see [§02 HTTP safety](02-http-safety.md)). A value containing `\r` or `\n` surfaces `:rf.error/redirect-invalid-location` and the redirect is not written.
+
+2. **Structural URL shape** — the value must parse as a URL or as a relative path. A value that doesn't parse fails under the same `:rf.error/redirect-invalid-location` category. This catches malformed inputs (`"https//missing-colon"`, `"foo bar"` with embedded spaces, etc.) before the response goes out.
+
+The error category is unified by design: the caller doesn't need to discriminate "CRLF in my URL" from "this isn't a URL" — both are "the redirect target you handed me isn't acceptable," and the fix is the same in both cases. The error event's `:tags` carry the failing value (subject to the `:sensitive?` redaction from [chapter 23a](../23a-privacy-secrets.md) if the value rides under a sensitive slot), so your trace stream surfaces the bug at its source.
+
+`:rf.server/redirect` is also where the **safe-redirect-fx** pattern lives. The recommended shape for "redirect to a URL the user supplied" — say, the OAuth-return URL passed through a query string — is:
+
+```clojure
+;; In your event handler:
+(rf/reg-event-fx :auth/post-login-redirect
+  (fn [{:keys [db]} _]
+    (let [requested-return (-> db :request :query-params :return)
+          ;; Validate against your allowlist BEFORE building the fx.
+          target           (if (allowed-return-url? requested-return)
+                             requested-return
+                             "/dashboard")]
+      {:fx [[:rf.server/redirect 302 target]]})))
+```
+
+The framework's CRLF + URL-shape check catches the *malformed* and the *injecting* cases. Validating against an **allowlist** of legitimate return URLs is your responsibility — the framework doesn't and can't know which return URLs are yours. The pattern is: validate at the event handler, hand the fx a value that's *already* known-good, let the framework's fail-fast catch any contract violation if you've made a mistake. Defense in depth.
+
+See [Security.md §CRLF injection at HTTP-response boundaries](../../spec/Security.md#crlf-injection-at-http-response-boundaries) for the normative description.
+
+## Editor URI templates — the scheme allowlist
+
+This one's about the dev-tools surface, not user-facing HTTP. When [chapter 15](../15-devtools-and-pair-tools.md)'s click-to-source affordance opens your editor at a file:line, it builds a URI string and hands it to the browser:
+
+```
+vscode://file/path/to/foo.cljs:42:7
+cursor://file/path/to/foo.cljs:42:7
+idea://open?file=path/to/foo.cljs&line=42&column=7
+```
+
+Each tool that surfaces source-coords (Story, Causa, pair2-mcp) lets you pick your editor at boot:
+
+```clojure
+{:rf.story/editor :vscode}     ;; one of :vscode / :cursor / :windsurf / :zed / :idea
+{:rf.story/editor {:custom "vim://open?path={path}&line={line}"}}
+```
+
+The five named editors (`:vscode`, `:cursor`, `:windsurf`, `:zed`, `:idea`) are built-ins; the framework's builders for those schemes can only emit a known-good URI. The interesting surface is the `{:custom "..."}` form — the open-ended template that lets you point at any editor (Sublime's `subl:`, Emacs's `org-protocol:`, JetBrains Fleet's `fleet:`, your bespoke `my-editor://`, …) without waiting for an upstream PR.
+
+That template, though, is a string the user wrote. If it's `{:custom "javascript:alert(1)"}`, clicking the source-coord link would run script in your dev tab. That's the threat; the defense is two-layered.
+
+### Layer 1 — the three-scheme reject
+
+The framework's URI builder refuses to emit a URI whose leading scheme is one of three known-bad schemes:
+
+| Scheme | Why it's rejected |
+|---|---|
+| `javascript:` | Runs arbitrary JavaScript in the current origin |
+| `data:` | Can carry inline HTML/script the browser renders |
+| `vbscript:` | Legacy IE script scheme; still honoured in some embedded WebView surfaces |
+
+If a `{:custom ...}` template's leading scheme matches any of these (case-insensitive, leading-whitespace-tolerant), the builder returns `nil`. The UI layer's `(when uri ...)` wrapper hides the link rather than rendering a no-op chip — visible failure, no silent rendering of a dangerous string.
+
+The reject is **case-insensitive** and **whitespace-tolerant** — `" JavaScript:..."` and `"DATA:..."` still trip the gate. The attacker template that prepends whitespace hoping `triml` will strip it before the browser parses doesn't get through.
+
+### Layer 2 — the click-time positive allowlist
+
+At the **click-time** boundary, each tool layers a positive allowlist on top of the three-scheme reject. The allowlist is `editor-uri/allowed-editor-uri-schemes` and covers the canonical editor schemes:
+
+```
+vscode, vscode-insiders, cursor, windsurf, zed,
+idea, jetbrains, fleet,
+subl, emacs, emacsclient, org-protocol,
+vim, nvim, mvim,
+txmt, atom, file
+```
+
+A `{:custom ...}` template that resolves to `http://...` or `gopher://...` would otherwise navigate the tab rather than launch an editor — surprising to the dev who's expecting "this opens my IDE." The allowlist makes that an obvious no-op rather than a silent surprise.
+
+The two layers are deliberately redundant. The three-scheme reject closes the script-execution attack surface — that's the must-have. The positive allowlist closes the "navigate-where-you-didn't-mean-to" footgun — that's the would-be-nice. A tool that accidentally drops one layer still has the other.
+
+Both predicates live in `re-frame.source-coords.editor-uri` and are exported for tooling reuse: `editor-uri` (the builder) and `allowed-uri?` (the click-time gate). If you write your own dev tool that surfaces source-coords, use both.
+
+See [Security.md §Editor URI scheme allowlist](../../spec/Security.md) for the full rationale (rf2-vwcsq + rf2-cm93v / rf2-p887o for the positive allowlist).
+
+## What you don't have to validate
+
+The framework's stance — same as the previous page — is that the *fx-handler* (for redirects) and the *URI builder* (for editor templates) are the right sites for input validation, not your code at every call site. If you pass `:rf.server/redirect` a value that contains CRLF, the fx-handler surfaces the bug. If you write a `{:custom "javascript:..."}` template into your editor config, the builder returns `nil` and the UI hides the link.
+
+What you *do* have to handle is the allowlist of return URLs — the framework can't know which targets are yours. Everything else, the framework's check sites have you covered.
+
+## Cross-references
+
+- [§02 — HTTP safety primitives](02-http-safety.md) — the broader CRLF fail-fast story; `:rf.server/redirect` inherits its CRLF check from there.
+- [Chapter 11 — The server side](../11-server-side.md) — `:rf.server/*` fx narrative.
+- [Chapter 15 — Tooling](../15-devtools-and-pair-tools.md) — where click-to-source surfaces live (Story, Causa, pair2-mcp).
+- [Security.md §Editor URI scheme allowlist](../../spec/Security.md) — the normative description (and the rf2-vwcsq + rf2-cm93v decisions).
+- [Security.md §CRLF injection at HTTP-response boundaries](../../spec/Security.md#crlf-injection-at-http-response-boundaries) — the redirect's CRLF check site.

--- a/docs/guide/24-configuration-and-safety/03-redirect-and-editor-uris.md
+++ b/docs/guide/24-configuration-and-safety/03-redirect-and-editor-uris.md
@@ -45,7 +45,7 @@ The error category is unified by design: the caller doesn't need to discriminate
 
 The framework's CRLF + URL-shape check catches the *malformed* and the *injecting* cases. Validating against an **allowlist** of legitimate return URLs is your responsibility — the framework doesn't and can't know which return URLs are yours. The pattern is: validate at the event handler, hand the fx a value that's *already* known-good, let the framework's fail-fast catch any contract violation if you've made a mistake. Defense in depth.
 
-See [Security.md §CRLF injection at HTTP-response boundaries](../../spec/Security.md#crlf-injection-at-http-response-boundaries) for the normative description.
+See [Security.md §CRLF injection at HTTP-response boundaries](../../../spec/Security.md#crlf-injection-at-http-response-boundaries) for the normative description.
 
 ## Editor URI templates — the scheme allowlist
 
@@ -100,7 +100,7 @@ The two layers are deliberately redundant. The three-scheme reject closes the sc
 
 Both predicates live in `re-frame.source-coords.editor-uri` and are exported for tooling reuse: `editor-uri` (the builder) and `allowed-uri?` (the click-time gate). If you write your own dev tool that surfaces source-coords, use both.
 
-See [Security.md §Editor URI scheme allowlist](../../spec/Security.md) for the full rationale (rf2-vwcsq + rf2-cm93v / rf2-p887o for the positive allowlist).
+See [Security.md §Editor URI scheme allowlist](../../../spec/Security.md) for the full rationale (rf2-vwcsq + rf2-cm93v / rf2-p887o for the positive allowlist).
 
 ## What you don't have to validate
 
@@ -113,5 +113,5 @@ What you *do* have to handle is the allowlist of return URLs — the framework c
 - [§02 — HTTP safety primitives](02-http-safety.md) — the broader CRLF fail-fast story; `:rf.server/redirect` inherits its CRLF check from there.
 - [Chapter 11 — The server side](../11-server-side.md) — `:rf.server/*` fx narrative.
 - [Chapter 15 — Tooling](../15-devtools-and-pair-tools.md) — where click-to-source surfaces live (Story, Causa, pair2-mcp).
-- [Security.md §Editor URI scheme allowlist](../../spec/Security.md) — the normative description (and the rf2-vwcsq + rf2-cm93v decisions).
-- [Security.md §CRLF injection at HTTP-response boundaries](../../spec/Security.md#crlf-injection-at-http-response-boundaries) — the redirect's CRLF check site.
+- [Security.md §Editor URI scheme allowlist](../../../spec/Security.md) — the normative description (and the rf2-vwcsq + rf2-cm93v decisions).
+- [Security.md §CRLF injection at HTTP-response boundaries](../../../spec/Security.md#crlf-injection-at-http-response-boundaries) — the redirect's CRLF check site.

--- a/docs/guide/24-configuration-and-safety/04-drain-depth-and-error-recovery.md
+++ b/docs/guide/24-configuration-and-safety/04-drain-depth-and-error-recovery.md
@@ -80,7 +80,7 @@ The three policies that make sense for this specific category:
 
 The default (no `:on-error` registered for the category) is `:log`. The frame stays alive; the next event will drain normally.
 
-See [014's `:rf.error/drain-depth-exceeded` row](../../spec/009-Instrumentation.md) and [Chapter 14 §Frame-scoped error policy](../14-errors.md) for the broader `:on-error` story.
+See [014's `:rf.error/drain-depth-exceeded` row](../../../spec/009-Instrumentation.md) and [Chapter 14 §Frame-scoped error policy](../14-errors.md) for the broader `:on-error` story.
 
 ## Tuning checklist
 
@@ -103,6 +103,6 @@ Inside a state machine, `:always` (eventless transitions) and `:raise` (action-s
 - [Chapter 06a — Frames](../06a-frames.md) — `:drain-depth` as a frame-metadata key.
 - [Chapter 14 — Errors](../14-errors.md) — the full `:on-error` story.
 - [Chapter 15 — Tooling](../15-devtools-and-pair-tools.md) — the trace surface that lets you observe drain depth in legitimate cascades.
-- [Spec 002 — Frames §Drain loop](../../spec/002-Frames.md) — the normative description of the depth-limited drain and the atomic rollback.
-- [Security.md §DoS by input](../../spec/Security.md#dos-by-input) — drain-depth as one of the bounded-resource defenses.
+- [Spec 002 — Frames §Drain loop](../../../spec/002-Frames.md) — the normative description of the depth-limited drain and the atomic rollback.
+- [Security.md §DoS by input](../../../spec/Security.md#dos-by-input) — drain-depth as one of the bounded-resource defenses.
 - [§06 — Machine substrate features](06-state-machine-substrate-features.md) — `:always`-depth and `:raise`-depth.

--- a/docs/guide/24-configuration-and-safety/04-drain-depth-and-error-recovery.md
+++ b/docs/guide/24-configuration-and-safety/04-drain-depth-and-error-recovery.md
@@ -1,0 +1,108 @@
+# 24.04 — Drain depth and error recovery
+
+## TL;DR
+
+re-frame2's run-to-completion drain has a ceiling. A handler that dispatches itself, or a cascade that bounces back and forth between two machines without ever settling, will eventually trip the ceiling. When it does, the drain aborts **atomically** — `app-db` is rolled back to its pre-cascade snapshot — and the failure surfaces as `:rf.error/drain-depth-exceeded` on your frame's `:on-error` policy. No partial writes, no half-applied cascades, no "the third event in the chain got through but the fourth didn't." This page covers the ceiling, the rollback, the tuning knob, and how it composes with the per-frame `:on-error` story.
+
+[Chapter 06a](../06a-frames.md) names `:drain-depth` as a frame-metadata key in passing. [Chapter 14](../14-errors.md) names `:rf.error/drain-depth-exceeded` as a row in the error taxonomy. This page is the *why* — the threat the ceiling defends against, the semantics of the rollback, and the integration with `:on-error`.
+
+## The threat — recursive-cascade DoS
+
+re-frame's run-to-completion drain is the property that makes event handlers easy to reason about: a dispatched event runs end-to-end before any other event is observed, including events that dispatch other events. A handler returning `{:fx [[:dispatch [:next-step]]]}` queues the dispatched event in the drain's FIFO; the drain processes it as part of the same cascade.
+
+The problem is that nothing structural prevents that cascade from going on forever. A handler that dispatches itself (`{:fx [[:dispatch [:current-event]]]}`) loops. Two handlers that dispatch each other ping-pong. A state machine with an `:always` transition whose guard is somehow always true microstep-loops. Without a ceiling, any of these would consume the drain loop indefinitely — the JavaScript event loop blocks, the JVM thread spins, the UI freezes, the SSR request hangs.
+
+The ceiling makes that into a bounded failure rather than an unbounded freeze. **Recursive cascades fail; they don't hang.** That's the load-bearing property.
+
+## The ceiling — `:drain-depth`
+
+Every frame carries a `:drain-depth` setting. The default is **100** — comfortably more than any legitimate cascade (a single user action typically dispatches between 1 and 10 events; the worst legitimate case is a complex boot sequence that fans out to maybe 30). 100 is two orders of magnitude above legitimate; well below "the dev's editor froze."
+
+You tune per frame:
+
+```clojure
+(rf/reg-frame :auth
+  {:on-create  [:auth/initialise]
+   :drain-depth 100})            ;; the framework default — written explicitly
+
+(rf/reg-frame :test-fixture
+  {:drain-depth 1000             ;; tests that deliberately fire long sagas
+   :on-create  [:test/setup]})
+
+(rf/reg-frame :story-variant
+  {:preset      :story
+   :drain-depth 16})             ;; story preset's default — fail fast in interactive demos
+```
+
+The `:test` and `:story` presets ship with their own defaults (1000 and 16 respectively). Tests legitimately deliberately exercise long sagas; story variants are interactive demos where a runaway cascade should fail fast under a story rather than spinning up to the production limit and confusing the demo.
+
+You can also tune at dispatch-time if you've got a specific cascade that legitimately wants more headroom for one call:
+
+```clojure
+(rf/dispatch [:bulk-import-large-csv] {:drain-depth 500})
+```
+
+Per-call overrides merge over per-frame metadata; the call-site value wins.
+
+## The rollback — atomic, complete
+
+When the cascade hits the ceiling, the runtime does **three** things, in order:
+
+1. **Restore the pre-drain `app-db` snapshot.** Whatever state the frame was in before the cascade began is the state it's in after the abort. The drain's partial writes — every event that did successfully run before the ceiling tripped — are discarded.
+2. **Restore frame-local registrations** that the cascade made. A handler that ran `(rf/dispatch [:rf.machine/spawn ...])` inside the cascade — which registered a frame-local handler at the spawned actor's `[:rf/machines <id>]` slot — has that registration reverted along with the `app-db` rollback. Otherwise an aborted drain would leave orphaned handlers attached to a frame at a value that never references them.
+3. **Surface the failure.** `:rf.error/drain-depth-exceeded` is emitted with `:tags {:depth :queue-size :last-event :rollback? true}` and routed through your frame's `:on-error` policy.
+
+The remaining queued events — the ones the cascade hadn't yet reached when the ceiling tripped — are discarded. The epoch buffer ([chapter 15](../15-devtools-and-pair-tools.md)) records nothing for the failed drain. The frame is at the last settled state, which is always reachable by replay.
+
+This is the "events are atomic" principle scaled up to the cascade boundary. A handler is atomic with respect to its own side effects ([ch.04](../04-events-state-cycle.md)); a *cascade* is atomic with respect to depth-exceeded aborts. If you've thought about events as "either all the effects happen or none of them do," the same model now applies to cascades: either the whole cascade settles or it's rolled back.
+
+The rollback boundary is **value-shape**, not "rewind real-world side effects." Out-of-band side effects that already committed to external substrates — an HTTP request that flew, a `dispatch-later` timer that scheduled — are not undone. The framework can't unsend a request; what it *can* do is keep its own state consistent so your replay path has somewhere honest to start from.
+
+## The integration — `:on-error`
+
+`:rf.error/drain-depth-exceeded` arrives at your frame's `:on-error` policy like any other error category ([chapter 14](../14-errors.md)). Three things you can do with it:
+
+```clojure
+(rf/reg-frame :auth
+  {:on-create [:auth/initialise]
+   :on-error
+   {:default                       :log
+    :rf.error/drain-depth-exceeded :halt}})        ;; opinionated — stop, don't try to recover
+```
+
+The three policies that make sense for this specific category:
+
+- **`:log`** — emit the error to your observability surface and move on. The frame is at the pre-cascade state; the next dispatched event will run. This is the right policy for *unexpected* cascades — a bug you want to surface and fix, not a system you want to halt over.
+
+- **`:halt`** — emit and stop processing further events on this frame. Useful for fixtures where any drain overflow is a test failure and there's no point letting subsequent events run on a frame whose dynamic story has gone sideways. Story variants (`:preset :story`) lean toward this; production frames lean toward `:log`.
+
+- **A custom handler** — `(fn [error] ...)` that does whatever your app needs. Reset a known-good state, log to a specific channel, fire a side-effect that pages an on-call human. The handler runs after the rollback, so your code is starting from the pre-cascade state — not from the half-applied middle.
+
+The default (no `:on-error` registered for the category) is `:log`. The frame stays alive; the next event will drain normally.
+
+See [014's `:rf.error/drain-depth-exceeded` row](../../spec/009-Instrumentation.md) and [Chapter 14 §Frame-scoped error policy](../14-errors.md) for the broader `:on-error` story.
+
+## Tuning checklist
+
+Default `:drain-depth 100` is right for almost every frame. Cases for tuning:
+
+- **Bump up** if you've got a frame that legitimately fans out deep cascades — bulk-import flows, multi-step migrations, test fixtures that exercise long sagas. 500 or 1000 are typical bumped values.
+
+- **Bump down** if you've got an interactive surface (a story variant, a dev sandbox) where any runaway cascade should fail fast rather than waste a user's clock on a runaway loop. `:preset :story` defaults to 16 for exactly this reason.
+
+- **Don't bump in production unless you've audited why your cascade is long.** A production frame routinely hitting 50+ depth is a code smell — usually a state machine ping-ponging, or an unintended self-dispatch. Bumping the ceiling masks the design issue; fixing the dispatch loop is the right move.
+
+If you're not sure what depth your cascades typically reach, the trace surface tells you: every successful drain records its depth as part of the per-cascade trace ([ch.15](../15-devtools-and-pair-tools.md)). Check the trace for your typical user actions; pick a ceiling at 5x the observed maximum.
+
+## A note on `:always`-depth and `:raise`-depth
+
+Inside a state machine, `:always` (eventless transitions) and `:raise` (action-scoped re-dispatch) each have their own depth ceilings — independent of the outer drain. Their defaults are both **16**, and they emit their own error categories (`:rf.error/machine-always-depth-exceeded`, `:rf.error/machine-raise-depth-exceeded`). The next page covers `:always` and friends in detail; the depth ceilings on them are part of the same defense-in-depth shape as the outer drain. Three independent depth counters, three independent ceilings, three independent abort paths — each catching the runaway-loop case at its own layer.
+
+## Cross-references
+
+- [Chapter 06a — Frames](../06a-frames.md) — `:drain-depth` as a frame-metadata key.
+- [Chapter 14 — Errors](../14-errors.md) — the full `:on-error` story.
+- [Chapter 15 — Tooling](../15-devtools-and-pair-tools.md) — the trace surface that lets you observe drain depth in legitimate cascades.
+- [Spec 002 — Frames §Drain loop](../../spec/002-Frames.md) — the normative description of the depth-limited drain and the atomic rollback.
+- [Security.md §DoS by input](../../spec/Security.md#dos-by-input) — drain-depth as one of the bounded-resource defenses.
+- [§06 — Machine substrate features](06-state-machine-substrate-features.md) — `:always`-depth and `:raise`-depth.

--- a/docs/guide/24-configuration-and-safety/05-reserved-namespaces.md
+++ b/docs/guide/24-configuration-and-safety/05-reserved-namespaces.md
@@ -1,0 +1,128 @@
+# 24.05 — Reserved namespaces
+
+## TL;DR
+
+re-frame2 reserves a single root keyword namespace for framework-owned ids: `:rf/*`. Every framework runtime id — events, fx, cofx, subs, app-db keys, trace operations, error categories, warnings, machine lifecycle events, route events, navigation fx, SSR advisories, MCP wire markers, **everything** — lives under `:rf/*` or one of its sub-namespaces. This page is the human-readable catalogue. The linter checks this list; the migration agent checks this list; new Spec areas extend it by additive change. User code MUST NOT register handlers, fx, subs, or frames under `:rf/*`.
+
+The normative catalogue lives at [Conventions.md §Reserved namespaces](../../spec/Conventions.md#reserved-namespaces-framework-owned). This page is the guide-side narrative — the same names, in the same order, with one-line "what each one is for" so you can scan rather than read.
+
+## Why one root
+
+Old re-frame used 14 separate top-level prefixes: `:registry/*`, `:machine/*`, `:route/*`, `:nav/*`, `:re-frame/*`, and so on. Each Spec area picked its own prefix. The result was that "is this framework-owned?" became a memorisation question — every reserved name lived in a different mental bucket, and a user registering `:route/checkout` could find it colliding with a route name they wrote half a year ago.
+
+re-frame2 collapses to **one root prefix** and hierarchical sub-namespaces under it. Every framework-owned name starts `:rf` and a slash or a dot — the answer to "is this framework-owned?" is one character: does it start with `:rf`?
+
+That's it. `:rf.frame/...`, `:rf.error/...`, `:rf.http/...`, `:rf.machine/...`, `:rf.size/...`, `:rf.route/...`, `:rf.epoch/...`, `:rf.causa/...` — they're all framework-owned by virtue of the prefix. Pick anything outside the prefix and the framework's stance is "your name, your problem."
+
+## The catalogue
+
+Every reserved framework-owned sub-namespace. **21 entries** in the current set; the set is fixed-and-additive (entries never repurposed; new ones added by Spec change).
+
+| Sub-namespace | What for | Owning spec |
+|---|---|---|
+| `:rf/*` | Pattern-level events / fx / app-db keys / subs; the universal default frame id `:rf/default` | 002 / 011 / 012 |
+| `:rf.frame/<gensym>` | Anonymous frame ids minted by `make-frame` | 002 |
+| `:rf.frame/<operation>` | Frame-lifecycle trace operations (`drain-interrupted`, `destroyed`, …) | 002 / 009 |
+| `:rf.registry/*` | Registrar-mutation trace operations (`handler-registered`, `handler-cleared`, `handler-replaced`) | 001 / 009 |
+| `:rf.fx/*` | Effect-resolution advisories (`:rf.fx/skipped-on-platform`, `:rf.fx/override-applied`) and reserved fx args (`:rf.fx/spawn-args`) | 002 / 009 |
+| `:rf.cofx/*` | Cofx-resolution advisories (e.g. `:rf.cofx/skipped-on-platform`) | 009 / 011 |
+| `:rf.error/*` | Error trace operations — the closed `:rf.error/<category>` taxonomy ([ch.14](../14-errors.md)) | 009 |
+| `:rf.warning/*` | Warning trace operations — same shape as errors, severity `:warning` | 009 |
+| `:rf.machine/*` | Machine lifecycle + transition trace operations; framework machine subs (`[:rf/machine <id>]`) | 005 |
+| `:rf.machine.lifecycle/*`, `:rf.machine.timer/*`, `:rf.machine.event/*`, `:rf.machine.microstep/*` | Sub-areas of machine traces (further hierarchy under `:rf.machine`) | 005 |
+| `:rf.route/*` | Framework routing events + subs + trace operations ([ch.17a](../17a-routing-reference.md)) | 012 |
+| `:rf.nav/*` | Navigation fx ids (`:rf.nav/push-url`, `:rf.nav/replace-url`, `:rf.nav/scroll`, `:rf.nav/external`) | 012 |
+| `:rf.ssr/*` | SSR-specific advisories (hydration mismatch, head mismatch, …) | 011 |
+| `:rf.server/*` | Server-side response-shape fx (`:rf.server/set-status`, `-set-cookie`, `-redirect`, `-error-projection`, `-set-header`, `-append-header`) | 011 |
+| `:rf.epoch/*` | Tool-Pair epoch operations (`restore-epoch`, version-mismatch, schema-mismatch, …) | Tool-Pair |
+| `:rf.causa/*` | Canonical-devtools namespace for Causa — events, subs, fxs, app-db keys, traces | Tool-Pair |
+| `:rf.assert/*` | Assertion-event vocabulary used by the post-v1 stories library's play functions and test runner | 007 |
+| `:rf.test/*` | Test-runner-internal events and fx-stub ids | 008 |
+| `:rf.http/*` | Managed-HTTP fx ids and failure taxonomy keys (`:rf.http/managed`, `-managed-abort`, `:rf.http/timeout`, `:rf.http/decode-failure`, …); security args slot `:rf.http/max-decoded-keys` | 014 |
+| `:rf.http.interceptor/*` | Per-frame request-side interceptor chain lifecycle operations | 014 |
+| `:rf.size/*` | Size-elision wire markers + policy keys (`:rf.size/large-elided`, `-threshold-bytes`, `-include-sensitive?`, `-include-large?`, …) | 009 |
+| `:rf.elision/*` | Sentinel-handle namespace for the `:rf.elision/at` shape used by `get-path` to re-fetch an elided value | 009 |
+| `:rf.mcp/*` | Cross-MCP wire-vocabulary markers (`:rf.mcp/overflow`, `:rf.mcp/summary`, `:rf.mcp/diff-from`, `:rf.mcp/dedup-table`, `:rf.mcp/ref`, `:rf.mcp/cache-hit`, `:rf.mcp/cursor-stale`) | Tool-Pair |
+| `:rf.trace/*` | Trace-channel control slots — closed set of three: `:rf.trace/no-emit?`, `:rf.trace/trigger-handler`, `:rf.trace/call-site` | 009 |
+| `:rf.route.nav-token/*` | Navigation-token lifecycle trace operations (`allocated`, `stale-suppressed`) | 012 / 009 |
+| `:rf.adapter/*` | Substrate-adapter `:kind` discriminator values (`:rf.adapter/reagent`, `:rf.adapter/uix`, `:rf.adapter/helix`) | 006 |
+
+Add it up: 25 rows above; the audit listed 21 framework-owned prefixes because `:rf.frame/<gensym>` and `:rf.frame/<operation>` count together, `:rf.machine.*/*` sub-areas count under `:rf.machine`, and the canonical-namespace `:rf/*` itself is the root. Either way, the answer to "what's reserved?" is "anything that starts with `:rf.` and a slash."
+
+## How the rules apply
+
+Three rules. They cover every collision case.
+
+### 1. User-registered ids must not collide
+
+```clojure
+;; FORBIDDEN — :rf/hydrate is a framework-pattern-level event
+(rf/reg-event-fx :rf/hydrate ...)
+
+;; FORBIDDEN — :rf.http/my-thing sits under a framework-reserved prefix
+(rf/reg-fx :rf.http/my-thing ...)
+
+;; FORBIDDEN — any segment under :rf.frame/* is reserved
+(rf/reg-event-fx :rf.frame/my-custom-init ...)
+```
+
+The linter flags the registration. The migration agent flags the registration. The runtime registrar's `handler-replaced` trace fires loudly. If you must override a framework event for legitimate reasons (test fixtures replacing `:rf/hydrate` in-test, for example), use the documented extension points — `:on-create` on a test frame, `:fx-overrides` on a per-dispatch basis — not raw registration over a reserved id.
+
+### 2. Library authors choose their own prefixes
+
+Third-party libraries pick a top-level segment of their own. The convention is "library name, no slash":
+
+```clojure
+:reagent/*           ;; the Reagent integration
+:re-pressed/*        ;; the re-pressed library
+:re-frisk/*          ;; the re-frisk library
+:my-app/*            ;; your app's feature prefix
+```
+
+Avoid `:rf*` for library names — both `:rf` (the framework root) and `:rf.<x>` (any sub-prefix) are off-limits. The framework can grow new sub-namespaces (`:rf.queue/*`, `:rf.someday/*`) and a third-party library claiming one would silently collide.
+
+The two **library-owned** prefixes that live *adjacent to* the framework's `:rf.*` root are:
+
+| Library-owned prefix | Library | Used for |
+|---|---|---|
+| `:story.<...>` | post-v1 stories library | Story ids (`:story.auth.login-form`) and variant ids |
+| `:Workspace.<...>` | post-v1 stories library | Workspace ids |
+
+These prefixes are **library-owned, not framework-reserved** — they're canonical when the library is loaded; they don't violate the single-root invariant. Their normative catalogue lives at [Conventions.md §Library-owned prefixes](../../spec/Conventions.md#library-owned-prefixes).
+
+### 3. Trace-event `:operation` vocabulary is open
+
+A library can register its own trace operations under its own prefix — `:my-lib.error/something-broke`, `:my-lib.fx/store-write`, whatever. The framework's reserved set is closed (additive only by Spec change); your library's set is open.
+
+This matters because a tooling consumer (a Datadog shipper, an MCP server) should be able to filter by your library's prefix without worrying about colliding with the framework's set. Pick your prefix once, stamp every trace event with it, and downstream filtering is mechanical.
+
+## How to check yourself
+
+Three quick paths to verify a name is free:
+
+1. **The linter.** Run your normal CLJ/CLJS lint pass; the framework ships a rule that flags any registration under `:rf*`. If your lint pass is clean, your names are clean.
+
+2. **The migration agent.** If you're coming from re-frame v1, the migration agent's first pass renames every `:re-frame/*` to `:rf/*` and flags every user-defined name colliding with the new reserved set. The output points at every collision.
+
+3. **`(rf/handler-ids)`.** At the REPL, ask the framework what's registered:
+
+   ```clojure
+   (filter #(re-find #"^:rf" (str %)) (rf/handler-ids))
+   ```
+
+   Anything that comes back is framework-owned (or a stamped trace operation, which uses the same prefix space). If your name shows up here when you didn't intend it to, you've collided.
+
+## When the framework wants to add a name
+
+The framework adds names by **additive change to the Conventions.md table**. New sub-namespaces ship under `:rf.<spec-area>/*` rather than inventing a top-level prefix. The fixed-and-additive contract means existing entries can't be repurposed and can't be removed — your code under, say, `:my-app.http/*` keeps working; a brand-new `:rf.deferred/*` namespace appears (because Spec 015 introduced it) without disturbing anything.
+
+If you've registered a handler under a name that looks like a future framework reservation but isn't yet, the migration agent will flag it when the framework eventually claims that name. The fix is mechanical: rename your handler. The framework's commitment is that this case is rare; the catalogue above is the practical upper bound on what you should consider off-limits forever.
+
+## Cross-references
+
+- [Conventions.md §Reserved namespaces](../../spec/Conventions.md#reserved-namespaces-framework-owned) — the normative catalogue.
+- [Conventions.md §Reserved fx-ids](../../spec/Conventions.md#reserved-fx-ids) — the unqualified reserved fx-id set (`:dispatch`, `:dispatch-later`, `:raise`, `:rf.machine/spawn`, `:rf.machine/destroy`, `:rf.fx/reg-flow`, `:rf.fx/clear-flow`, `:rf.size/declare-large`, `:rf.size/clear`).
+- [Conventions.md §Reserved app-db keys](../../spec/Conventions.md#reserved-app-db-keys) — `:rf/machines`, `:rf/system-ids`, `:rf/spawned`, `:rf/route`, `:rf/pending-navigation`, `:rf/elision`.
+- [Conventions.md §Reserved state-node keys](../../spec/Conventions.md#reserved-state-node-keys-machine-transition-tables) — the machine transition-table state-node keys (`:on`, `:entry`, `:exit`, `:meta`, `:states`, `:always`, `:after`, `:invoke`, `:invoke-all`).
+- [Chapter 14 — Errors](../14-errors.md) — the `:rf.error/*` taxonomy in narrative form.
+- [Spec 009 §Error event catalogue](../../spec/009-Instrumentation.md) — the complete `:rf.error/*` + `:rf.warning/*` enumeration.

--- a/docs/guide/24-configuration-and-safety/05-reserved-namespaces.md
+++ b/docs/guide/24-configuration-and-safety/05-reserved-namespaces.md
@@ -4,7 +4,7 @@
 
 re-frame2 reserves a single root keyword namespace for framework-owned ids: `:rf/*`. Every framework runtime id — events, fx, cofx, subs, app-db keys, trace operations, error categories, warnings, machine lifecycle events, route events, navigation fx, SSR advisories, MCP wire markers, **everything** — lives under `:rf/*` or one of its sub-namespaces. This page is the human-readable catalogue. The linter checks this list; the migration agent checks this list; new Spec areas extend it by additive change. User code MUST NOT register handlers, fx, subs, or frames under `:rf/*`.
 
-The normative catalogue lives at [Conventions.md §Reserved namespaces](../../spec/Conventions.md#reserved-namespaces-framework-owned). This page is the guide-side narrative — the same names, in the same order, with one-line "what each one is for" so you can scan rather than read.
+The normative catalogue lives at [Conventions.md §Reserved namespaces](../../../spec/Conventions.md#reserved-namespaces-framework-owned). This page is the guide-side narrative — the same names, in the same order, with one-line "what each one is for" so you can scan rather than read.
 
 ## Why one root
 
@@ -88,7 +88,7 @@ The two **library-owned** prefixes that live *adjacent to* the framework's `:rf.
 | `:story.<...>` | post-v1 stories library | Story ids (`:story.auth.login-form`) and variant ids |
 | `:Workspace.<...>` | post-v1 stories library | Workspace ids |
 
-These prefixes are **library-owned, not framework-reserved** — they're canonical when the library is loaded; they don't violate the single-root invariant. Their normative catalogue lives at [Conventions.md §Library-owned prefixes](../../spec/Conventions.md#library-owned-prefixes).
+These prefixes are **library-owned, not framework-reserved** — they're canonical when the library is loaded; they don't violate the single-root invariant. Their normative catalogue lives at [Conventions.md §Library-owned prefixes](../../../spec/Conventions.md#library-owned-prefixes).
 
 ### 3. Trace-event `:operation` vocabulary is open
 
@@ -120,9 +120,9 @@ If you've registered a handler under a name that looks like a future framework r
 
 ## Cross-references
 
-- [Conventions.md §Reserved namespaces](../../spec/Conventions.md#reserved-namespaces-framework-owned) — the normative catalogue.
-- [Conventions.md §Reserved fx-ids](../../spec/Conventions.md#reserved-fx-ids) — the unqualified reserved fx-id set (`:dispatch`, `:dispatch-later`, `:raise`, `:rf.machine/spawn`, `:rf.machine/destroy`, `:rf.fx/reg-flow`, `:rf.fx/clear-flow`, `:rf.size/declare-large`, `:rf.size/clear`).
-- [Conventions.md §Reserved app-db keys](../../spec/Conventions.md#reserved-app-db-keys) — `:rf/machines`, `:rf/system-ids`, `:rf/spawned`, `:rf/route`, `:rf/pending-navigation`, `:rf/elision`.
-- [Conventions.md §Reserved state-node keys](../../spec/Conventions.md#reserved-state-node-keys-machine-transition-tables) — the machine transition-table state-node keys (`:on`, `:entry`, `:exit`, `:meta`, `:states`, `:always`, `:after`, `:invoke`, `:invoke-all`).
+- [Conventions.md §Reserved namespaces](../../../spec/Conventions.md#reserved-namespaces-framework-owned) — the normative catalogue.
+- [Conventions.md §Reserved fx-ids](../../../spec/Conventions.md#reserved-fx-ids) — the unqualified reserved fx-id set (`:dispatch`, `:dispatch-later`, `:raise`, `:rf.machine/spawn`, `:rf.machine/destroy`, `:rf.fx/reg-flow`, `:rf.fx/clear-flow`, `:rf.size/declare-large`, `:rf.size/clear`).
+- [Conventions.md §Reserved app-db keys](../../../spec/Conventions.md#reserved-app-db-keys) — `:rf/machines`, `:rf/system-ids`, `:rf/spawned`, `:rf/route`, `:rf/pending-navigation`, `:rf/elision`.
+- [Conventions.md §Reserved state-node keys](../../../spec/Conventions.md#reserved-state-node-keys-machine-transition-tables) — the machine transition-table state-node keys (`:on`, `:entry`, `:exit`, `:meta`, `:states`, `:always`, `:after`, `:invoke`, `:invoke-all`).
 - [Chapter 14 — Errors](../14-errors.md) — the `:rf.error/*` taxonomy in narrative form.
-- [Spec 009 §Error event catalogue](../../spec/009-Instrumentation.md) — the complete `:rf.error/*` + `:rf.warning/*` enumeration.
+- [Spec 009 §Error event catalogue](../../../spec/009-Instrumentation.md) — the complete `:rf.error/*` + `:rf.warning/*` enumeration.

--- a/docs/guide/24-configuration-and-safety/06-state-machine-substrate-features.md
+++ b/docs/guide/24-configuration-and-safety/06-state-machine-substrate-features.md
@@ -75,7 +75,7 @@ Rationale: the loop either fires repeatedly to depth-exceeded (if the guard stay
 
 A self-targeting `:always` with a *different* guard — used as a re-entry on a changed condition — is permitted. Only the same-guard same-target case is rejected.
 
-For the full normative grammar see [005 §Eventless `:always` transitions](../../spec/005-StateMachines.md).
+For the full normative grammar see [005 §Eventless `:always` transitions](../../../spec/005-StateMachines.md).
 
 ## `:after` — delayed transitions
 
@@ -119,13 +119,13 @@ If `:loaded` arrives before 30 s, the machine transitions to `:ready` and the ti
 
 You don't need to write cancellation logic. The framework uses an **epoch counter** stamped into the machine's `:data` to detect stale timers — every state exit increments the counter, every scheduled timer carries the epoch at scheduling time, and the receiving handler validates the carried epoch against the current one. A mismatch silently drops the timer and emits `:rf.machine.timer/stale-after` for observability.
 
-The pattern is general: any async-shaped feature that re-enters a state can use epoch-based stale detection rather than imperative cancel APIs. See [Pattern-StaleDetection.md](../../spec/Pattern-StaleDetection.md) for the cross-cutting form; routing's navigation tokens ([ch.17a](../17a-routing-reference.md)) use the same shape.
+The pattern is general: any async-shaped feature that re-enters a state can use epoch-based stale detection rather than imperative cancel APIs. See [Pattern-StaleDetection.md](../../../spec/Pattern-StaleDetection.md) for the cross-cutting form; routing's navigation tokens ([ch.17a](../17a-routing-reference.md)) use the same shape.
 
 ### SSR no-op
 
 `:after` no-ops in SSR mode. Entry actions don't schedule timers; the synthetic timer-elapsed event is never emitted. The server renders the current `:state` statically; the client hydrates that state and timers begin from hydration. This is the same kind of substrate-aware behaviour as `:rf.http/managed` — the framework picks the right thing per platform.
 
-For the full grammar see [005 §Delayed `:after` transitions](../../spec/005-StateMachines.md).
+For the full grammar see [005 §Delayed `:after` transitions](../../../spec/005-StateMachines.md).
 
 ## `:invoke` — declarative child actors
 
@@ -185,9 +185,9 @@ The runtime sees the second form; you wrote the first. Same machine.
   :on     {:auth/succeeded :authenticated}}}
 ```
 
-When the 30 s `:after` fires, the parent's exit cascade destroys the `:auth-flow` child (which itself cascades any in-flight `:rf.http/managed` aborts — see [Cancellation cascade](../../spec/005-StateMachines.md#cancellation-cascade--in-flight-rfhttpmanaged-aborts)). The timer is anchored to the parent state's entry, not to any HTTP attempt; the child's internal retries can't outlive the parent's deadline.
+When the 30 s `:after` fires, the parent's exit cascade destroys the `:auth-flow` child (which itself cascades any in-flight `:rf.http/managed` aborts — see [Cancellation cascade](../../../spec/005-StateMachines.md#cancellation-cascade--in-flight-rfhttpmanaged-aborts)). The timer is anchored to the parent state's entry, not to any HTTP attempt; the child's internal retries can't outlive the parent's deadline.
 
-For the full description of `:invoke`'s desugaring, composition with `:entry` / `:exit`, hierarchical composition, error categories, see [005 §Declarative `:invoke`](../../spec/005-StateMachines.md).
+For the full description of `:invoke`'s desugaring, composition with `:entry` / `:exit`, hierarchical composition, error categories, see [005 §Declarative `:invoke`](../../../spec/005-StateMachines.md).
 
 ## `:invoke-all` — spawn-and-join
 
@@ -234,7 +234,7 @@ Apps that want non-cancelling joins (analytics fan-out where each child is indep
 
 It isn't an "everything happens at once" primitive — children spawn in source order, but each child runs as its own actor with its own drain. The "parallelism" is logical-actor-parallelism, not OS-thread-parallelism. (CLJS is single-threaded; JVM SSR may execute multiple actors on multiple threads, but the contract is "the runtime coordinates the join.")
 
-For the full description see [005 §Spawn-and-join via `:invoke-all`](../../spec/005-StateMachines.md).
+For the full description see [005 §Spawn-and-join via `:invoke-all`](../../../spec/005-StateMachines.md).
 
 ## `:final?` / `:on-done` / `:output-key` — terminal states
 
@@ -284,7 +284,7 @@ A *singleton* machine (registered top-level, no parent `:invoke`) reaching `:fin
 
 A leaf inside one region of a parallel-region machine may declare `:final? true`; the meaning is "**this region** has reached its final state." That region halts; sibling regions continue. The parent machine as a whole is `:final?` only when EVERY region's active state is `:final?` — at which point the auto-destroy and `:on-done` cascade fires as usual.
 
-For the full normative description see [005 §Final states](../../spec/005-StateMachines.md).
+For the full normative description see [005 §Final states](../../../spec/005-StateMachines.md).
 
 ## Parallel regions — orthogonal axes of one feature
 
@@ -315,7 +315,7 @@ Three regions run **simultaneously** from one machine. Each region has its own s
 
 ### When to reach for parallel regions
 
-Use them when the **regions are orthogonal axes of one feature** — different axes of "what is this page doing right now?" that should compose freely. The motivating case is the Nine States pattern ([Pattern-NineStates](../../spec/Pattern-NineStates.md)): a page-level convention whose render decisions slice across (data cardinality × form validity × mode).
+Use them when the **regions are orthogonal axes of one feature** — different axes of "what is this page doing right now?" that should compose freely. The motivating case is the Nine States pattern ([Pattern-NineStates](../../../spec/Pattern-NineStates.md)): a page-level convention whose render decisions slice across (data cardinality × form validity × mode).
 
 If your regions are conceptually **independent features that don't share data**, the right answer is *N separate machines* — separate `[:rf/machines <id>]` entries coordinated via cross-actor dispatch. Both patterns ship; choose by domain shape.
 
@@ -325,7 +325,7 @@ If your regions are conceptually **independent features that don't share data**,
 
 `:always` cascades similarly fire per region; tags compose by union across active states.
 
-For the full normative description see [005 §Parallel regions](../../spec/005-StateMachines.md).
+For the full normative description see [005 §Parallel regions](../../../spec/005-StateMachines.md).
 
 ## What lives in `:data`, what the runtime owns
 
@@ -340,13 +340,13 @@ A few `:rf/*` keys appear inside a machine's `:data` slot. These are runtime-own
 | `:rf/invoke-id` | The `:invoke`-bearing state's prefix-path (used to address the spawn-registry slot) |
 | `:rf/invoke-all-id` / `:rf/invoke-all-child-id` | `:invoke-all` analogues |
 
-These slots are documented at [Conventions.md §Reserved snapshot-internal keys](../../spec/Conventions.md#reserved-snapshot-internal-keys-machine-runtime). Their persistence behaviour is also documented there (some survive `pr-str` / SSR hydration; some are transient).
+These slots are documented at [Conventions.md §Reserved snapshot-internal keys](../../../spec/Conventions.md#reserved-snapshot-internal-keys-machine-runtime). Their persistence behaviour is also documented there (some survive `pr-str` / SSR hydration; some are transient).
 
 ## Cross-references
 
 - [Chapter 08 — State machines](../08-state-machines.md) — the basic state-machine narrative; this page is its substrate-feature deep-dive.
-- [Spec 005 — State Machines](../../spec/005-StateMachines.md) — the normative description for every key on this page.
-- [Pattern-NineStates.md](../../spec/Pattern-NineStates.md) — the page-level pattern that motivated parallel regions.
-- [Pattern-StaleDetection.md](../../spec/Pattern-StaleDetection.md) — the cross-cutting epoch-counter pattern that `:after` shares with routing's nav tokens.
+- [Spec 005 — State Machines](../../../spec/005-StateMachines.md) — the normative description for every key on this page.
+- [Pattern-NineStates.md](../../../spec/Pattern-NineStates.md) — the page-level pattern that motivated parallel regions.
+- [Pattern-StaleDetection.md](../../../spec/Pattern-StaleDetection.md) — the cross-cutting epoch-counter pattern that `:after` shares with routing's nav tokens.
 - [§04 — Drain depth and error recovery](04-drain-depth-and-error-recovery.md) — the outer drain's depth ceiling. `:always`-depth and `:raise`-depth ceilings live inside machines; they compose with the outer ceiling.
-- [Cancellation cascade](../../spec/005-StateMachines.md#cancellation-cascade--in-flight-rfhttpmanaged-aborts) — what happens to in-flight HTTP requests when a spawned actor is destroyed.
+- [Cancellation cascade](../../../spec/005-StateMachines.md#cancellation-cascade--in-flight-rfhttpmanaged-aborts) — what happens to in-flight HTTP requests when a spawned actor is destroyed.

--- a/docs/guide/24-configuration-and-safety/06-state-machine-substrate-features.md
+++ b/docs/guide/24-configuration-and-safety/06-state-machine-substrate-features.md
@@ -1,0 +1,352 @@
+# 24.06 — State-machine substrate features
+
+## TL;DR
+
+[Chapter 08](../08-state-machines.md) names four state-node keys in passing: `:always`, `:after`, `:invoke`, `:invoke-all`. Plus `:final?` / `:on-done` / `:output-key` for terminal states. Plus parallel regions. This page is the worked-example tour. Each section answers one question: "what does this key let me write, and what does the framework do for me?"
+
+Read this when you've outgrown a flat-FSM machine and your dynamic model wants to express something xstate-shaped. The substrate has the capability; the guide should have the worked example. None of these keys is exotic — they're all sugar for things you could express by hand. The sugar earns its keep because the desugared shape is verbose, the patterns are mechanical, and stamping them by name lets tooling reason about your machine the way a flat FSM is reasoned about.
+
+## The four substrate keys at a glance
+
+| Key | What it does | Sugar for |
+|---|---|---|
+| `:always` | Eventless transition — fires when its guard becomes true | A `:raise` of a synthetic event from every action that could enable the condition |
+| `:after` | Delayed transition — fires after a wall-clock delay | `:dispatch-later` + epoch-stamped synthetic event + stale check |
+| `:invoke` | Declarative actor — spawn-on-entry, destroy-on-exit | `:rf.machine/spawn` in `:entry`, `:rf.machine/destroy` in `:exit` |
+| `:invoke-all` | Spawn N actors in parallel, join on a condition | N `:invoke`s + join-state bookkeeping + per-condition resolution |
+
+Each key is *declarative* — the runtime walks the spec at registration time and rewrites it into the underlying primitive. The runtime sees the desugared form; tooling sees the original spec; you write whichever is more readable.
+
+## `:always` — eventless transitions
+
+> "After this snapshot just changed, if condition X is true, immediately go to state Y."
+
+```clojure
+{:checking-form
+ {:always [{:guard :form-valid?   :target :submitting}
+           {:guard :form-invalid? :target :show-errors}]
+  :on     {:edit {:action :merge-edits}}}}
+```
+
+When the machine lands in `:checking-form` (by any path), the runtime checks each `:always` entry in order, first-match-wins. If `:form-valid?` returns true, the machine transitions to `:submitting` immediately. If `:form-invalid?` returns true, it goes to `:show-errors`. If neither matches, the machine stays in `:checking-form` and waits for `:edit` to do something interesting.
+
+The key property: **the externally-observable transition is the fixed point of the `:always` loop.** External observers (subs, other machines, tools) see only the post-cascade settled state. The intermediate "we entered `:checking-form` for one tick" is invisible. That's xstate / SCXML *macrostep* semantics.
+
+### The shape
+
+`:always` is a vector of guarded transition specs. Each entry has `:guard` (a keyword resolving against the machine's `:guards` map) and `:target` (the destination state). Optional `:action` runs as part of the transition.
+
+```clojure
+(rf/reg-machine :form-flow
+  {:initial :editing
+   :guards  {:form-valid?   (fn [data _] (every? string? (vals (:fields data))))
+             :form-invalid? (fn [data _] (some empty? (vals (:fields data))))}
+   :states
+   {:editing       {:on {:check :checking-form}}
+    :checking-form {:always [{:guard :form-valid?   :target :submitting}
+                              {:guard :form-invalid? :target :show-errors}]}
+    :show-errors   {:on {:edit :editing}}
+    :submitting    {:on {:done :complete}}
+    :complete      {}}})
+```
+
+### Microstep depth limit
+
+The `:always` loop has a depth ceiling — default **16**, configurable per-machine via `:always-depth-limit`. A guard that's always true would loop forever; the ceiling makes that into a structured failure rather than a freeze:
+
+```clojure
+:rf.error/machine-always-depth-exceeded
+;; with :tags {:machine-id <id> :depth 16 :path [<state> <state> <state> ...]}
+```
+
+The cascade halts with the snapshot **uncommitted**; observers don't see the partial path. Same atomic-rollback shape as the outer drain ([§04](04-drain-depth-and-error-recovery.md)).
+
+### Self-loops rejected at registration
+
+A `:always` targeting its own state with the same `:guard` is a registration-time error:
+
+```clojure
+;; REJECTED — :rf.error/machine-always-self-loop
+{:checking-form
+ {:always [{:guard :form-valid? :target :checking-form}]}}
+```
+
+Rationale: the loop either fires repeatedly to depth-exceeded (if the guard stays true) or is a no-op (if the guard flips on first hit). In both cases the author intended something else. Catch the typo at registration.
+
+A self-targeting `:always` with a *different* guard — used as a re-entry on a changed condition — is permitted. Only the same-guard same-target case is rejected.
+
+For the full normative grammar see [005 §Eventless `:always` transitions](../../spec/005-StateMachines.md).
+
+## `:after` — delayed transitions
+
+> "If the machine is still in this state N milliseconds from now, move to state Y."
+
+```clojure
+{:splash
+ {:after {3000 :main                              ;; show splash for 3 seconds
+          5000 {:guard :network-slow? :target :slow-warning}
+          30000 :hard-timeout}
+  :on    {:user-clicked-skip :main}}}
+```
+
+Three timers run concurrently from the moment the machine enters `:splash`. Whichever timer fires first **and** matches its guard (if any) triggers its transition. The state's exit cancels any sibling timers — they go stale and silently drop on their eventual firing.
+
+This is the canonical primitive for splash screens, polling, slow-connection nudges, soft and hard timeouts, animation gates — anything where "time elapsed in this state" is itself the signal.
+
+### The shape
+
+`:after` is a map from delay (milliseconds) to either:
+
+- a target state keyword (`3000 :main` — fire unconditionally after 3 s),
+- a transition spec map (`5000 {:guard :network-slow? :target :slow-warning}` — fire after 5 s if guard passes, else suppress and let other timers continue).
+
+```clojure
+(rf/reg-machine :load-flow
+  {:initial :loading
+   :guards  {:still-loading? (fn [data _] (not (:result data)))}
+   :states
+   {:loading {:after {30000 {:guard :still-loading? :target :hard-error}}
+              :on    {:loaded :ready
+                      :failed :error}}
+    :ready   {}
+    :error   {}
+    :hard-error {}}})
+```
+
+If `:loaded` arrives before 30 s, the machine transitions to `:ready` and the timer cancels. If 30 s elapse, the timer fires; the guard checks whether we're still loading; if so the machine transitions to `:hard-error`.
+
+### Stale timers + epoch-based cancellation
+
+You don't need to write cancellation logic. The framework uses an **epoch counter** stamped into the machine's `:data` to detect stale timers — every state exit increments the counter, every scheduled timer carries the epoch at scheduling time, and the receiving handler validates the carried epoch against the current one. A mismatch silently drops the timer and emits `:rf.machine.timer/stale-after` for observability.
+
+The pattern is general: any async-shaped feature that re-enters a state can use epoch-based stale detection rather than imperative cancel APIs. See [Pattern-StaleDetection.md](../../spec/Pattern-StaleDetection.md) for the cross-cutting form; routing's navigation tokens ([ch.17a](../17a-routing-reference.md)) use the same shape.
+
+### SSR no-op
+
+`:after` no-ops in SSR mode. Entry actions don't schedule timers; the synthetic timer-elapsed event is never emitted. The server renders the current `:state` statically; the client hydrates that state and timers begin from hydration. This is the same kind of substrate-aware behaviour as `:rf.http/managed` — the framework picks the right thing per platform.
+
+For the full grammar see [005 §Delayed `:after` transitions](../../spec/005-StateMachines.md).
+
+## `:invoke` — declarative child actors
+
+> "While in this state, run a child machine. When we leave the state, destroy it."
+
+```clojure
+{:fetching
+ {:invoke {:machine-id :http/protocol
+           :data       {:url "/api/profile"}
+           :on-spawn   (fn [data id] (assoc data :pending id))
+           :start      [:begin]}
+  :on     {:succeeded :loaded
+           :failed    :error}}}
+```
+
+Entering `:fetching` spawns a `:http/protocol` actor; leaving `:fetching` destroys it. The child's lifetime is bound to the parent state's occupancy. If you write the spawn-and-destroy by hand, it looks like:
+
+```clojure
+;; what create-machine-handler desugars the :invoke into:
+{:fetching
+ {:entry (fn [data _]
+           {:fx [[:rf.machine/spawn {:machine-id :http/protocol
+                                     :data       {:url "/api/profile"}
+                                     :on-spawn   (fn [d id] (assoc d :pending id))
+                                     :start      [:begin]
+                                     :rf/parent-id <this-machine>
+                                     :rf/invoke-id [:fetching]}]]})
+  :exit  (fn [_ _]
+           {:fx [[:rf.machine/destroy {:rf/parent-id <this-machine>
+                                       :rf/invoke-id [:fetching]}]]})
+  :on    {:succeeded :loaded
+          :failed    :error}}}
+```
+
+The runtime sees the second form; you wrote the first. Same machine.
+
+### Key slots
+
+| Key | Purpose |
+|---|---|
+| `:machine-id` *or* `:definition` | Which machine to spawn (registered id, or inline transition table) |
+| `:data` | Initial data — literal map or `(fn [snapshot event] data)` |
+| `:on-spawn` | `(fn [data spawned-id] new-data)` — how the parent records the child id |
+| `:on-done` | `(fn [data result] new-data)` — fires when child enters `:final?` (see below) |
+| `:start` | Event vector dispatched to the newborn after spawn |
+| `:invoke-id` | Explicit id instead of gensym — useful for tests / per-state singletons |
+| `:id-prefix` | Base for the gensym'd id (defaults to `:machine-id`) |
+
+### What about timeouts?
+
+`:invoke` doesn't take a `:timeout-ms` slot. Wall-clock timeouts on the spawned actor live on the *parent state's* `:after` map. One primitive, not two:
+
+```clojure
+{:authenticating
+ {:invoke {:machine-id :auth-flow}
+  :after  {30000 :auth-failed}                ;; 30 s wall-clock guard
+  :on     {:auth/succeeded :authenticated}}}
+```
+
+When the 30 s `:after` fires, the parent's exit cascade destroys the `:auth-flow` child (which itself cascades any in-flight `:rf.http/managed` aborts — see [Cancellation cascade](../../spec/005-StateMachines.md#cancellation-cascade--in-flight-rfhttpmanaged-aborts)). The timer is anchored to the parent state's entry, not to any HTTP attempt; the child's internal retries can't outlive the parent's deadline.
+
+For the full description of `:invoke`'s desugaring, composition with `:entry` / `:exit`, hierarchical composition, error categories, see [005 §Declarative `:invoke`](../../spec/005-StateMachines.md).
+
+## `:invoke-all` — spawn-and-join
+
+> "Spawn N children in parallel. When the join condition resolves, fire a parent event."
+
+```clojure
+{:hydrating
+ {:invoke-all
+  {:children         [{:id :cfg  :machine-id :load-config}
+                      {:id :flag :machine-id :load-feature-flags}
+                      {:id :user :machine-id :load-user-profile}
+                      {:id :dash :machine-id :load-dashboards}]
+   :join             :all                      ;; or :any / {:n 2} / {:fn pred}
+   :on-child-done    :child/done               ;; child → parent event keyword
+   :on-child-error   :child/error
+   :on-all-complete  [:hydrate/done]
+   :on-any-failed    [:hydrate/failed]}
+  :after {60000 :hydrate/timed-out}            ;; whole-join wall-clock guard
+  :on    {:hydrate/done       :ready
+          :hydrate/failed     :error
+          :hydrate/timed-out  :degraded}}}
+```
+
+Four children spawn in parallel. The runtime tracks completions; the join condition (`:all` here — every child must signal done) resolves when all four `:child/done` events arrive; the parent's `:hydrate/done` event fires; the machine transitions to `:ready`.
+
+### Join condition discriminators
+
+| `:join` | Resolves when |
+|---|---|
+| `:all` (default) | Every `:children` entry has signalled `:on-child-done` |
+| `:any` | The first `:on-child-done` arrives |
+| `{:n N}` | The Nth `:on-child-done` arrives |
+| `{:fn (fn [{:keys [done failed]}] truthy)}` | Your predicate returns truthy |
+
+Each option fires `:on-some-complete` (for `:any` / `{:n N}` / `{:fn}`) or `:on-all-complete` (for `:all`). Any child failure short-circuits via `:on-any-failed` if you've declared it.
+
+### Cancel-on-decision (default `true`)
+
+When the join resolves, siblings still in flight are cancelled. Each cancelled sibling has its `:rf.machine/destroy` fired (with the in-flight `:rf.http/managed` aborts cascading), and the runtime emits `:rf.machine.invoke/cancelled-on-join-resolution` for each.
+
+Apps that want non-cancelling joins (analytics fan-out where each child is independently valuable) declare `:cancel-on-decision? false` — siblings run to completion; their results land in the join-state but trigger no further parent event because `:resolved?` already flipped.
+
+### What `:invoke-all` *isn't*
+
+It isn't an "everything happens at once" primitive — children spawn in source order, but each child runs as its own actor with its own drain. The "parallelism" is logical-actor-parallelism, not OS-thread-parallelism. (CLJS is single-threaded; JVM SSR may execute multiple actors on multiple threads, but the contract is "the runtime coordinates the join.")
+
+For the full description see [005 §Spawn-and-join via `:invoke-all`](../../spec/005-StateMachines.md).
+
+## `:final?` / `:on-done` / `:output-key` — terminal states
+
+> "When the machine enters this leaf, finish — and optionally tell the parent what came of it."
+
+```clojure
+;; Child machine — declares its terminal state with :final? + :output-key.
+(rf/reg-machine :auth-flow
+  {:initial :running
+   :data    {}
+   :states
+   {:running {:on {:server-ok {:target :done
+                               :action (fn [data ev]
+                                         {:data (assoc data :token (second ev))})}}}
+    :done    {:final?     true
+              :output-key :token}}})
+
+;; Parent — :on-done reads the child's reported result.
+(rf/reg-machine :login
+  {:initial :idle
+   :states
+   {:idle {:on {:submit :authenticating}}
+    :authenticating
+    {:invoke {:machine-id :auth-flow
+              :on-done    (fn [data result] (assoc data :token result))}
+     :on    {:auth/cancelled :idle}}}})
+```
+
+When `:auth-flow` enters `:done`, the runtime:
+
+1. Reads the child's `:data` at `:output-key :token` — call it `result`.
+2. Looks up the parent's `:invoke` and runs `:on-done` against the parent's `:data` with that `result` — the returned map replaces the parent's `:data`.
+3. Emits a `:rf.machine/done` trace event with `:machine-id`, `:output`, `:parent-id`.
+4. Tears down the child via the standard destroy path (with `:reason :rf.machine/finished`).
+
+### Singletons too
+
+A *singleton* machine (registered top-level, no parent `:invoke`) reaching `:final?` **also auto-destroys**. "Final means final." If you want a persistent terminal state, **omit `:final?`** and use an ordinary leaf state. This is the most common gotcha for users meeting `:final?` for the first time, so it's worth saying out loud.
+
+### Constraints
+
+- **Leaf-only.** A compound state can't itself be `:final?`. Express finality with a leaf inside the compound.
+- **No `:on`, `:always`, `:after`, `:invoke`, `:invoke-all` on a `:final?` state.** Final means final — no further transitions.
+- **`:output-key` requires `:final?`.** A non-final state declaring `:output-key` is a registration error.
+
+### Parallel regions
+
+A leaf inside one region of a parallel-region machine may declare `:final? true`; the meaning is "**this region** has reached its final state." That region halts; sibling regions continue. The parent machine as a whole is `:final?` only when EVERY region's active state is `:final?` — at which point the auto-destroy and `:on-done` cascade fires as usual.
+
+For the full normative description see [005 §Final states](../../spec/005-StateMachines.md).
+
+## Parallel regions — orthogonal axes of one feature
+
+```clojure
+(rf/reg-machine :nine-states
+  {:type    :parallel
+   :regions
+   {:data {:initial :loading
+           :states {:loading {:on {:loaded :ready :failed :failed}}
+                    :ready   {}
+                    :failed  {}}}
+    :form {:initial :neutral
+           :states {:neutral  {:on {:edit :invalid}}
+                    :invalid  {:on {:fix  :valid}}
+                    :valid    {}}}
+    :mode {:initial :active
+           :states {:active {:on {:done :done}}
+                    :done   {}}}}})
+```
+
+Three regions run **simultaneously** from one machine. Each region has its own state-tree and reacts to events independently — `:loaded` advances the `:data` region, `:edit` advances the `:form` region, `:done` advances the `:mode` region. The whole machine's snapshot at any moment is a map:
+
+```clojure
+{:state {:data :ready :form :valid :mode :active}
+ :data  <shared :data slot for all three regions>
+ :tags  #{<union of all three regions' active-state tags>}}
+```
+
+### When to reach for parallel regions
+
+Use them when the **regions are orthogonal axes of one feature** — different axes of "what is this page doing right now?" that should compose freely. The motivating case is the Nine States pattern ([Pattern-NineStates](../../spec/Pattern-NineStates.md)): a page-level convention whose render decisions slice across (data cardinality × form validity × mode).
+
+If your regions are conceptually **independent features that don't share data**, the right answer is *N separate machines* — separate `[:rf/machines <id>]` entries coordinated via cross-actor dispatch. Both patterns ship; choose by domain shape.
+
+### Per-region scoping
+
+`:after` timers and `:invoke` lifetimes are per-region. A `:after` on the `:data` region doesn't get cancelled when the `:form` region transitions. The runtime maintains a per-region epoch counter (`:rf/after-epoch-by-region` inside `:data`) so a sibling region's transition doesn't invalidate this region's in-flight timers.
+
+`:always` cascades similarly fire per region; tags compose by union across active states.
+
+For the full normative description see [005 §Parallel regions](../../spec/005-StateMachines.md).
+
+## What lives in `:data`, what the runtime owns
+
+A few `:rf/*` keys appear inside a machine's `:data` slot. These are runtime-owned — your machine bodies should read them, never write under them:
+
+| Key | Meaning |
+|---|---|
+| `:rf/after-epoch` | Per-machine epoch counter for `:after`-timer stale detection (flat / compound) |
+| `:rf/after-epoch-by-region` | Per-region counter for `:after`-timer stale detection (parallel regions) |
+| `:rf/self-id` | The machine's own gensym'd id (set by spawn-fx for spawned actors) |
+| `:rf/parent-id` | The parent machine's id (set on `:invoke` / `:invoke-all` children) |
+| `:rf/invoke-id` | The `:invoke`-bearing state's prefix-path (used to address the spawn-registry slot) |
+| `:rf/invoke-all-id` / `:rf/invoke-all-child-id` | `:invoke-all` analogues |
+
+These slots are documented at [Conventions.md §Reserved snapshot-internal keys](../../spec/Conventions.md#reserved-snapshot-internal-keys-machine-runtime). Their persistence behaviour is also documented there (some survive `pr-str` / SSR hydration; some are transient).
+
+## Cross-references
+
+- [Chapter 08 — State machines](../08-state-machines.md) — the basic state-machine narrative; this page is its substrate-feature deep-dive.
+- [Spec 005 — State Machines](../../spec/005-StateMachines.md) — the normative description for every key on this page.
+- [Pattern-NineStates.md](../../spec/Pattern-NineStates.md) — the page-level pattern that motivated parallel regions.
+- [Pattern-StaleDetection.md](../../spec/Pattern-StaleDetection.md) — the cross-cutting epoch-counter pattern that `:after` shares with routing's nav tokens.
+- [§04 — Drain depth and error recovery](04-drain-depth-and-error-recovery.md) — the outer drain's depth ceiling. `:always`-depth and `:raise`-depth ceilings live inside machines; they compose with the outer ceiling.
+- [Cancellation cascade](../../spec/005-StateMachines.md#cancellation-cascade--in-flight-rfhttpmanaged-aborts) — what happens to in-flight HTTP requests when a spawned actor is destroyed.

--- a/docs/guide/24-configuration-and-safety/index.md
+++ b/docs/guide/24-configuration-and-safety/index.md
@@ -18,7 +18,7 @@ The framework has three orthogonal places configuration can live, and each one e
 
 The first two are global. The third is local. If you ever feel like you want to configure the same thing in two places, the option is doing two things and should be split. The framework's stance is one option, one bucket; that constraint is what makes the configuration story small enough to hold in your head.
 
-For the canonical normative description of the three buckets see [Conventions §Configuration surfaces](../../spec/Conventions.md#configuration-surfaces-configure-vs-set--vs-per-frame-metadata).
+For the canonical normative description of the three buckets see [Conventions §Configuration surfaces](../../../spec/Conventions.md#configuration-surfaces-configure-vs-set--vs-per-frame-metadata).
 
 ## The shape of the safety story
 
@@ -30,7 +30,7 @@ Safety primitives in re-frame2 work the same way the rest of the framework does:
 
 The framework does not strip-and-warn. It does not silently normalise. It does not "do its best with what you gave it." It rejects, raises, and tells you exactly what was wrong. The bet — same bet [chapter 12](../12-the-dynamic-model.md) makes about the dynamic model — is that surfacing the bug at its source is cheaper than letting it bake itself into the system's observable behaviour.
 
-> **Where the contracts live.** This chapter is the *guide-side* tour. The normative descriptions of every safety primitive live in [`spec/Security.md`](../../spec/Security.md) (threat model + defense-in-depth catalogue). That doc is, as of pre-alpha, slated to split into *pattern* and *implementation* halves (per rf2-1g6cj) — when that lands, the cross-refs in this chapter may need rewriting. The information is what matters; the path will move.
+> **Where the contracts live.** This chapter is the *guide-side* tour. The normative descriptions of every safety primitive live in [`spec/Security.md`](../../../spec/Security.md) (threat model + defense-in-depth catalogue). That doc is, as of pre-alpha, slated to split into *pattern* and *implementation* halves (per rf2-1g6cj) — when that lands, the cross-refs in this chapter may need rewriting. The information is what matters; the path will move.
 
 ## What this chapter covers
 

--- a/docs/guide/24-configuration-and-safety/index.md
+++ b/docs/guide/24-configuration-and-safety/index.md
@@ -1,0 +1,46 @@
+# 24 — Configuration and safety primitives
+
+## TL;DR
+
+re-frame2 ships with a small set of knobs you can turn — and a smaller set of guardrails you can't. This chapter is about both. The knobs live behind `configure`, `set-!` / `install-!`, and per-frame metadata. The guardrails — CRLF rejection, scheme allowlists, JSON keyword caps, slow-loris timeouts, drain-depth ceilings — sit between your code and a class of failure mode you don't want to be the person who discovered.
+
+You don't have to read this chapter to write a re-frame2 app. The defaults are sensible. But the day you wonder *why* your handler stopped at a header value containing `\r\n`, or *what number* the trace ring buffer actually holds, or *which prefix* the framework is going to flinch at when you try to register a handler under it — this is the chapter.
+
+## The shape of the thing
+
+The framework has three orthogonal places configuration can live, and each one exists because the **lifetime** of the thing being configured is different. Once you see the three buckets, the API stops feeling scattered:
+
+| Lifetime | Surface | Examples |
+|---|---|---|
+| Process — apply to the runtime as a whole | `(rf/configure :key opts)` | trace-buffer depth, sub-cache grace period, elision threshold |
+| Process — but the value is a fn or component the framework has to call | `(rf/set-x!)` / `(rf/install-x!)` | schema validator, schema explainer, substrate adapter |
+| Per-frame — apply only to one frame's existence | `reg-frame` / `make-frame` metadata, or `dispatch` opts | `:drain-depth`, `:on-error`, `:fx-overrides`, `:interceptors`, `:on-create` |
+
+The first two are global. The third is local. If you ever feel like you want to configure the same thing in two places, the option is doing two things and should be split. The framework's stance is one option, one bucket; that constraint is what makes the configuration story small enough to hold in your head.
+
+For the canonical normative description of the three buckets see [Conventions §Configuration surfaces](../../spec/Conventions.md#configuration-surfaces-configure-vs-set--vs-per-frame-metadata).
+
+## The shape of the safety story
+
+Safety primitives in re-frame2 work the same way the rest of the framework does: **the architecture forbids the thing**, rather than the docs asking you politely. Each safety primitive in this chapter has the same shape:
+
+1. A specific input or condition that, if it reached the system, would cause a class of failure (header injection, DoS-by-keyword, runaway recursion, XSS via clickable IDE link).
+2. A check site, deep in the framework, that detects the condition.
+3. A structured failure that surfaces to your `:on-error` policy (or your trace listener, or your error projector) so you see the bug the way you'd see any other.
+
+The framework does not strip-and-warn. It does not silently normalise. It does not "do its best with what you gave it." It rejects, raises, and tells you exactly what was wrong. The bet — same bet [chapter 12](../12-the-dynamic-model.md) makes about the dynamic model — is that surfacing the bug at its source is cheaper than letting it bake itself into the system's observable behaviour.
+
+> **Where the contracts live.** This chapter is the *guide-side* tour. The normative descriptions of every safety primitive live in [`spec/Security.md`](../../spec/Security.md) (threat model + defense-in-depth catalogue). That doc is, as of pre-alpha, slated to split into *pattern* and *implementation* halves (per rf2-1g6cj) — when that lands, the cross-refs in this chapter may need rewriting. The information is what matters; the path will move.
+
+## What this chapter covers
+
+Six pages. Each page answers one concrete question:
+
+- [01 — Framework configuration](01-framework-config.md). What `configure` lets you tune (and when to bother). The four keys, what they default to, and how to know your value is doing anything.
+- [02 — HTTP safety primitives](02-http-safety.md). The CRLF fail-fast on server-side responses, the JSON keyword-interning cap, and the slow-loris timeout that makes the network give up on unresponsive partners before they exhaust your pool.
+- [03 — Redirect and editor URIs](03-redirect-and-editor-uris.md). What schemes the framework rejects on click-to-source IDE templates, and the related sanity gates on `:rf.server/redirect`.
+- [04 — Drain depth and error recovery](04-drain-depth-and-error-recovery.md). What the run-to-completion drain's depth ceiling protects you from, why the rollback is atomic, and how to tune it per frame.
+- [05 — Reserved namespaces](05-reserved-namespaces.md). The single catalogue of every `:rf.*/*` prefix the framework owns. Tools check; the linter checks; this is the human-readable copy.
+- [06 — Machine substrate features](06-state-machine-substrate-features.md). The four advanced state-node keys ([chapter 08](../08-state-machines.md) names them in passing) — `:always`, `:after`, `:invoke`, `:invoke-all` — with worked examples and the rules they enforce. Plus `:final?` / `:on-done` / `:output-key` and how parallel regions compose.
+
+Read in order if you're new. Skim individual pages when something specific bites.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,14 @@ nav:
       - "22 — Production observability": guide/22-trace-to-datadog.md
       - "23a — Privacy: keeping secrets out of traces": guide/23a-privacy-secrets.md
       - "23b — Large blobs: keeping the wire small": guide/23b-large-blobs.md
+    - "24 — Configuration and safety primitives":
+      - Overview: guide/24-configuration-and-safety/index.md
+      - "24.01 — Framework configuration": guide/24-configuration-and-safety/01-framework-config.md
+      - "24.02 — HTTP safety primitives": guide/24-configuration-and-safety/02-http-safety.md
+      - "24.03 — Redirects and editor URIs": guide/24-configuration-and-safety/03-redirect-and-editor-uris.md
+      - "24.04 — Drain depth and error recovery": guide/24-configuration-and-safety/04-drain-depth-and-error-recovery.md
+      - "24.05 — Reserved namespaces": guide/24-configuration-and-safety/05-reserved-namespaces.md
+      - "24.06 — State-machine substrate features": guide/24-configuration-and-safety/06-state-machine-substrate-features.md
 
   - Skills:
     - Overview: skills/index.md

--- a/mkdocs_hooks.py
+++ b/mkdocs_hooks.py
@@ -42,6 +42,12 @@ GH_BLOB_BASE = "https://github.com/day8/re-frame2/blob/main"
 # the same depth.
 _GUIDE_TO_SPEC = re.compile(r'\]\(\.\./\.\./spec/')
 
+# Case 1a-deep: chapter sub-pages live at docs/guide/<chapter-dir>/X.md (depth
+# 3 below repo root). From the source tree the correct ref to spec/ is
+# ../../../spec/; in the staged docs_dir (docs/spec/) the correct ref is
+# ../../spec/. The rewrite collapses one level, same as the depth-2 case.
+_GUIDE_DEEP_TO_SPEC = re.compile(r'\]\(\.\./\.\./\.\./spec/')
+
 # Case 1b: docs-root pages (e.g. docs/release-process.md) link to spec via
 # ../spec/ — correct for the GitHub source tree (where spec/ lives at the
 # repo root, one level up from docs/). In the staged tree spec/ is copied
@@ -118,7 +124,18 @@ def on_page_markdown(markdown, page, config, files):
     src = page.file.src_path.replace('\\', '/')
 
     if src.startswith('guide/') or src.startswith('skills/'):
-        markdown = _GUIDE_TO_SPEC.sub('](../spec/', markdown)
+        # Choose by source depth. A guide sub-chapter at
+        # docs/guide/<chapter-dir>/X.md is depth 3; its source spec ref is
+        # ../../../spec/ and the staged path is ../../spec/. Plain
+        # docs/guide/X.md is depth 2; ../../spec/ -> ../spec/.
+        # Applying both rules unconditionally would let the depth-2 rule
+        # re-rewrite the depth-3 rule's output ../../spec/ down to ../spec/,
+        # so we dispatch on src depth.
+        if src.count('/') >= 2:
+            # depth-3 (or deeper) — sub-chapter pages
+            markdown = _GUIDE_DEEP_TO_SPEC.sub('](../../spec/', markdown)
+        else:
+            markdown = _GUIDE_TO_SPEC.sub('](../spec/', markdown)
     elif src.startswith('spec/'):
         # Spec pages link to docs-root pages via ../docs/ — collapse the
         # docs/ segment so the staged-tree path is ../release-process.md


### PR DESCRIPTION
## Summary

Implements **rf2-50uta** (P2): a new guide chapter that closes the framework-configuration + safety-primitives discoverability gap surfaced by the rf2-tmr1s audit. Multi-page chapter under `docs/guide/24-configuration-and-safety/`.

The audit (`ai/findings/guide-impl-coverage-audit-2026-05-14.md`) identified 21 ❌ missing + 14 ⚠️ underdocumented items clustered in three places: safety primitives invisible from the guide, no chapter on the `configure` surface, and state-machine substrate features named only as four-sentence teasers. This chapter closes the highest-stakes items in those clusters.

## Per-page summary

Seven pages, ~985 lines of prose total. One commit per page for clean review:

| Page | Topic | Audit items closed |
|---|---|---|
| `index.md` | Chapter intro + the three-bucket configuration model + the shape of the safety story | Lead-in to all items below |
| `01-framework-config.md` | The `configure` surface — all four keys (`:epoch-history`, `:trace-buffer`, `:sub-cache`, `:elision`), defaults, when to tune; `set-!` / `install-!` neighbours; per-frame metadata bucket | ⚠️1 (configure surface) |
| `02-http-safety.md` | `:rf.http/max-decoded-keys` (JSON DoS cap), `:timeout-ms` 30s default (slow-loris), CRLF fail-fast on `:rf.server/set-header` / `-set-cookie` | ❌1 (CRLF), ❌3 (JSON cap), ❌4 (:timeout-ms) |
| `03-redirect-and-editor-uris.md` | `:rf.server/redirect` + safe-redirect-fx pattern; editor-URI two-layer defense (three-scheme reject + click-time allowlist) | ❌2 (editor URI rejection); reinforces ❌1 |
| `04-drain-depth-and-error-recovery.md` | The threat (recursive-cascade DoS); the ceiling + per-frame / per-call tuning; the atomic rollback (app-db + frame-local registrations); integration with `:on-error` | ⚠️2 (drain-depth narrative) |
| `05-reserved-namespaces.md` | The full ~25-row catalogue of framework-owned `:rf.*/*` sub-namespaces; the single-root invariant; library-owned prefix neighbours; how to check yourself | ⚠️3 (reserved namespaces) |
| `06-state-machine-substrate-features.md` | Worked examples for `:always` / `:after` / `:invoke` / `:invoke-all`; final states (`:final?` / `:on-done` / `:output-key`); parallel regions; runtime-owned `:rf/*` keys inside `:data` | ❌14 (`:always`/`:after`/`:invoke`/`:invoke-all`), ⚠️11 (`:final?`/`:on-done`/`:output-key`) |

Net audit closures: **5 ❌ misses + 4 ⚠️ wins**.

## Voice + tone

Inherits the voice of `docs/guide/12-the-dynamic-model.md` — opinionated, conversational, slightly bemused; "here's how this protects you from yourself" framing throughout the safety pages; never reference-manual-shaped. Each section answers one concrete question.

## Mechanical changes

- Added the chapter to `mkdocs.yml` under "Useful patterns".
- Extended `mkdocs_hooks.py` with a depth-3 `_GUIDE_DEEP_TO_SPEC` rewrite (sub-chapter pages live at `docs/guide/<chapter-dir>/X.md`, depth 3, so source spec refs need `../../../spec/`; the hook collapses to `../../spec/` in the staged tree). Dispatches by src-path depth so the existing depth-2 rule doesn't re-rewrite the depth-3 output.

## Test plan

- [x] `mkdocs build --strict` clean — 24 warnings, all pre-existing in spec/* files linking to `tools/` (identical baseline on `main`). Zero new warnings on the new chapter.
- [x] Each page read top-to-bottom for voice consistency + cross-ref resolution.
- [x] No edits outside `docs/guide/24-configuration-and-safety/`, `mkdocs.yml`, `mkdocs_hooks.py`.
- [x] All `../../../spec/` paths resolve correctly on GitHub source-tree browse AND after the staged-docs rewrite.

## Boundaries respected

- Did not edit existing chapters (cross-ref instead).
- Did not edit spec files (consumed them, not modified).
- No AI attribution.
- Total prose ~985 lines, well under the 2500 LoC budget.

## Notes for future work

- `spec/Security.md` is slated to split into pattern + impl halves (rf2-1g6cj). Several cross-refs in this chapter point at `Security.md` — when the split lands, those refs will need follow-up rewriting. Flagged in the chapter's index page as a movable cross-ref.
- The audit identified more items in P3+ buckets that this chapter doesn't cover (flows narrative, `compute-sub`, `dispatch-sequence` worked examples, etc.). Those remain open for follow-up beads.