### PR TITLE
docs(spec): codify canonical event-vector shape best-practice (rf2-zg4od, rf2-jvzxh walkthrough Mike clarification)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -342,7 +342,15 @@
      "Enqueue `event-vec` on the target frame's router; returns nil
      immediately, BEFORE the handler runs. Captures call-site coords
      (rf2-ts1a) for error-trace attribution. For HoF / programmatic use
-     call `dispatch*`. Per Spec 002 §Routing."
+     call `dispatch*`. Per Spec 002 §Routing.
+
+     Canonical `event-vec` shape (best practice — not enforced):
+       [<event-id>]                   ;; trivial
+       [<event-id> <single-scalar>]   ;; single-argument
+       [<event-id> {<k> <v>}]         ;; multi-argument — single map payload
+     Variadic `[<id> a b c]` is accepted by the runtime for v1-migration
+     and caller convenience; the linter nudges new code toward the map
+     form. See spec/Conventions.md §Canonical event-vector shape."
      ([event-vec]
       (csm/build-dispatch-form (meta &form) (symbol (str (ns-name *ns*))) *file*
                                event-vec nil))
@@ -356,7 +364,11 @@
      fixed point. For tests / REPL / bootstrap only — never call from
      inside a running event handler (raises `:rf.error/dispatch-sync-
      in-handler`). Captures call-site coords (rf2-ts1a). For HoF /
-     programmatic use call `dispatch-sync*`. Per Spec 002 §dispatch-sync."
+     programmatic use call `dispatch-sync*`. Per Spec 002 §dispatch-sync.
+
+     Canonical `event-vec` shape — see `dispatch` docstring above; same
+     best-practice convention applies (id-first, with at most one
+     trailing map; variadic tolerated, linter nudges)."
      ([event-vec]
       (csm/build-dispatch-sync-form (meta &form) (symbol (str (ns-name *ns*))) *file*
                                     event-vec nil))

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -1124,7 +1124,12 @@
   in public API terms). The macro form `re-frame.core/dispatch` stamps
   an `:rf.trace/call-site` onto `opts` at compile time; from there it
   rides the envelope and gets bound around the handler chain's
-  invocation in `process-event!`."
+  invocation in `process-event!`.
+
+  Canonical `event` shape is `[<id>]`, `[<id> <single-scalar>]`, or
+  `[<id> <map>]` — best practice, not enforced. Variadic vectors are
+  tolerated for v1-migration / caller convenience. See spec/Conventions.md
+  §Canonical event-vector shape."
   ([event] (dispatch! event {}))
   ([event opts]
    (let [envelope     (build-envelope event opts)

--- a/spec/API.md
+++ b/spec/API.md
@@ -72,6 +72,8 @@
 
 `opts` map keys: `:frame`, `:fx-overrides`, `:interceptor-overrides`, `:trace-id`, `:source`. Envelope shape and semantics: see [002 §Routing: the dispatch envelope](002-Frames.md#routing-the-dispatch-envelope).
 
+**Canonical `event` / `query-v` shape (best practice).** `[<id>]` (trivial), `[<id> <single-scalar>]` (single-arg), `[<id> {<k> <v>}]` (multi-arg → single map payload). Variadic `[<id> a b c]` is tolerated by the runtime for v1-migration and caller convenience; the linter nudges new code toward the map form. Full rationale and cross-refs: [Conventions §Canonical event-vector shape](Conventions.md#canonical-event-vector-shape-best-practice).
+
 ---
 
 ## View ergonomics

--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -240,6 +240,29 @@ A feature does not reach into another feature's slice directly — it goes throu
 
 Full rationale: [000-Vision §Pointers to per-area Specs (Features)](000-Vision.md#pointers-to-per-area-specs) and [Construction-Prompts.md §CP-6](Construction-Prompts.md).
 
+## Canonical event-vector shape (best practice)
+
+The **canonical** call-shape for an event vector — and for the parallel subscribe query vector — is **id-first, with at most one trailing map**:
+
+```clojure
+[<event-id>]                   ;; trivial — id only
+[<event-id> <single-scalar>]   ;; single-argument
+[<event-id> {<k> <v> ...}]     ;; multi-argument — single map payload
+```
+
+Same shape for `subscribe`: `[:items-filtered {:status :pending :limit 20}]`.
+
+This is **best practice, not enforced**. The framework runtime accepts variadic vectors (`[<id> a b c]`) — the v1 multi-positional shape is tolerated for migration and caller convenience, and the linter nudges new code toward the map form (per [MIGRATION §M-19](MIGRATION.md#m-19-multi-positional-dispatch--subscribe-vectors--map-payload-form-opt-in)). Boundary validators (`dispatch`, `dispatch-sync`, the pair-tool MCP dispatch surface) check `vector?` only; they do not reject variadic shape.
+
+Why the canonical form is `[<id> <map>]`:
+
+- **Name over place.** Map keys carry meaning that positional args don't; see [Principles §Name over place](Principles.md#name-over-place).
+- **Refactor stability.** Adding a field is one key, not a coordinated edit across every call site.
+- **Generator-amenable.** AI scaffolds (per [Construction-Prompts §CP-1](Construction-Prompts.md#cp-1-add-an-event-handler)) emit the map form; round-tripping through the spec preserves it.
+- **`unwrap` sugar.** The optional `unwrap` interceptor (per [API §Standard interceptors](API.md#standard-interceptors)) assumes this exact shape — handlers using it destructure the payload directly: `(fn [_ {:keys [...]}] ...)`.
+
+Cross-refs: [002 §Routing — canonical call shapes table](002-Frames.md#routing-the-dispatch-envelope), [Construction-Prompts §CP-1 — Call-shape convention](Construction-Prompts.md#cp-1-add-an-event-handler), [MIGRATION §M-19](MIGRATION.md#m-19-multi-positional-dispatch--subscribe-vectors--map-payload-form-opt-in).
+
 ## `:interceptors` is positional, not metadata (`reg-event-*`)
 
 For `reg-event-db` / `reg-event-fx` / `reg-event-ctx`, the **interceptor chain lives in the positional middle slot**, not inside the metadata-map. The metadata-map is reserved for *reflection* (`:doc`, `:spec`, `:tags`, `:platforms`, `:ns`, `:line`, `:file`) — keys tooling reads back from the registrar to describe what was registered.


### PR DESCRIPTION
## Summary

Codifies the canonical re-frame2 event-vector shape — `[event-id]`, `[event-id <single-scalar>]`, or `[event-id <map>]` — as **best practice only**. Closes rf2-zg4od.

Surfaced during the rf2-jvzxh walkthrough. Mike confirmed: best-practice, not enforced — the framework runtime MUST continue to accept variadic vectors for v1-migration + caller convenience. No validator changes.

### Where the canonical shape is codified

- **`spec/Conventions.md`** — new section "Canonical event-vector shape (best practice)" between the Feature-modularity prefix convention and the `:interceptors`-is-positional convention. Cross-refs the 002 Routing table, MIGRATION §M-19, Principles §Name over place, and Construction-Prompts CP-1.
- **`spec/API.md`** — annotated the Dispatch and subscribe table footer with the canonical shape + cross-ref into Conventions.
- **`implementation/core/src/re_frame/core.cljc`** — extended `dispatch` and `dispatch-sync` macro docstrings.
- **`implementation/core/src/re_frame/router.cljc`** — extended `dispatch!` fn docstring (the runtime form behind public `dispatch*`).

The 002-Frames Routing table (the existing "Canonical / Tolerated" grid) and Construction-Prompts CP-1 (already documents the convention for new code) remain the prose anchors; Conventions.md now hosts the named cross-link target.

### What this PR explicitly does NOT do

- No tightening of `pair2-mcp` dispatch validator (existing `vector?` check is correct).
- No rejection of variadic events anywhere in the framework.
- No behaviour change in `re-frame.core/dispatch` or `dispatch-sync`.

## Test plan

- [x] `scripts/check_doc_slugs.py --verbose` — clean (0 broken links across 304 markdown files).
- [x] `npm run test:cljs` (from `implementation/`) — 2014 tests, 5695 assertions, 0 failures, 0 errors.
- [ ] `mkdocs build --strict` flags 24 pre-existing warnings unrelated to this PR (none reference the new section or annotations). The docs CI workflow (`.github/workflows/docs.yml`) runs `mkdocs build` non-strict; the link validator is the fail-loud gate.