### PR TITLE
fix(story-mcp): boot-time sensitive-read gate + structured EDN body + DoS bounds + safe-keyword cleanup (rf2-g9fje+lqjbk)

### DIFF
--- a/tools/story-mcp/spec/001-Wire-Protocol.md
+++ b/tools/story-mcp/spec/001-Wire-Protocol.md
@@ -12,6 +12,12 @@
   (failure traces; never used for protocol traffic).
 - The server's main loop terminates on stdin EOF; the `shutdown`
   method is also honoured.
+- **Frame-length cap** (rf2-g9fje): each inbound frame is bounded at
+  `re-frame.story-mcp.protocol/max-frame-bytes` (4 MB — well above
+  the largest legitimate MCP payload). A frame exceeding the cap is
+  drained to its next newline boundary and yields a parse-error
+  response; the loop continues. The cap exists so a hostile or
+  runaway producer can't OOM the server with an unterminated frame.
 
 ## Protocol version pin
 

--- a/tools/story-mcp/spec/002-Tool-Registry.md
+++ b/tools/story-mcp/spec/002-Tool-Registry.md
@@ -234,6 +234,11 @@ Inputs: `{:variant-id ... :substrate? ... :active-modes? ... :cell-overrides? ..
 The `:passing?` boolean is the headline "did this pass?" answer —
 truthy when every assertion in the play sequence passed.
 
+`:timeout-ms` is clamped DOWN to 30 s (rf2-g9fje); the MCP server's
+stdio loop is single-threaded so an unbounded `:timeout-ms` would
+park unrelated calls. 30 s matches the `:rf.http/timeout-ms`
+baseline (rf2-it1cd) — one ceiling, one number an agent learns.
+
 ### `snapshot-identity`
 
 Content hash of `(variant × args × decorators × loaders × substrate ×

--- a/tools/story-mcp/spec/002-Tool-Registry.md
+++ b/tools/story-mcp/spec/002-Tool-Registry.md
@@ -41,7 +41,17 @@ resource read at boot) so the jar is self-contained.
 
 Given `:variant-id` (plus optional `:substrate`, `:active-modes`,
 `:cell-overrides`, `:base-url`), runs the canvas pipeline and
-returns the post-pipeline state plus a sharable URL:
+returns the post-pipeline state plus a sharable URL.
+
+Wire-egress posture: `:app-db` is routed through
+`re-frame.core/elide-wire-value` against the variant frame's
+`[:rf/elision]` registry; declared-sensitive paths land
+`:rf/redacted` by default. Pass `:include-sensitive? true` to opt
+out — BUT the opt-in is honoured only when the server was started
+with `--allow-sensitive-reads` (rf2-g9fje); when that gate is
+closed (the default), the `:include-sensitive?` slot is omitted
+from the `tools/list` schema entirely and any caller-supplied
+value is silently ignored at egress.
 
 ```clojure
 {:lifecycle      :ok | :failed-loaders | :failed-events | ...
@@ -242,6 +252,43 @@ hint that axe-core requires the in-browser panel.
 Diagnostic for the variant's accumulated `:rf.story/assertions`
 accumulator (no re-run). Useful for agents that want to inspect the
 last-run state without paying the cost of a fresh `run-variant`.
+
+Assertion records carrying `:sensitive? true` are dropped at egress
+by default; `:include-sensitive? true` opts back in subject to the
+same `--allow-sensitive-reads` boot gate as `preview-variant` /
+`run-variant`.
+
+## Sensitive-read boot gate (`--allow-sensitive-reads`, rf2-g9fje)
+
+The three tools that surface live frame state (`preview-variant`,
+`run-variant`, `read-failures`) all accept a per-call
+`:include-sensitive?` boolean to opt out of the default redaction
+posture (see [`tools/Tool-Pair.md`](../../../spec/Tool-Pair.md)
+§Direct-read privacy posture). Per the rf2-uaymx (b) decision that
+opt-in is itself gated by a server-side boot flag, mirroring the
+`--allow-eval` posture pair2-mcp uses for `eval-cljs` (rf2-zyoj2):
+
+| Path | Mechanism |
+|---|---|
+| CLI flag | `--allow-sensitive-reads` |
+| JVM sysprop | `-Drf.story-mcp.allow-sensitive-reads=true` |
+| Env var | `RF_STORY_MCP_ALLOW_SENSITIVE_READS=true` |
+
+Closed by default. When closed:
+
+- `tools/list` omits the `:include-sensitive?` slot from the input
+  schemas of the three affected tools — agents never see an opt-in
+  they couldn't exercise.
+- The wire-egress scrubbers silently ignore any caller-supplied
+  `:include-sensitive? true` — declared-sensitive `:app-db` paths
+  remain `:rf/redacted`; assertion records stamped `:sensitive?
+  true` remain dropped.
+- The server logs one line at boot:
+  `Sensitive reads: gated (default; pass --allow-sensitive-reads to opt in)`.
+
+When open, the per-call `:include-sensitive? true` is honoured as
+documented — raw values cross the wire, the operator has signed
+off on the egress posture by passing the flag.
 
 ## Write — v1.1, dev-only, gated
 

--- a/tools/story-mcp/spec/API.md
+++ b/tools/story-mcp/spec/API.md
@@ -24,12 +24,18 @@ agent-onboarding text.
 **Input.**
 
 ```clojure
-{:variant-id      keyword (required)
- :substrate       keyword (optional)
- :active-modes    [keyword] (optional)
- :cell-overrides  {keyword any} (optional)
- :base-url        string (optional)}
+{:variant-id         keyword (required)
+ :substrate          keyword (optional)
+ :active-modes       [keyword] (optional)
+ :cell-overrides     {keyword any} (optional)
+ :base-url           string (optional)
+ :include-sensitive? boolean (optional, gated — see below)}
 ```
+
+`:include-sensitive?` is honoured ONLY when the server was started
+with `--allow-sensitive-reads` (rf2-g9fje); when that boot gate is
+closed (the default) the slot is omitted from `tools/list` and any
+caller-supplied value is silently ignored at egress.
 
 **Output.**
 
@@ -133,12 +139,17 @@ projection — byte stability matters for round-tripping).
 **Input.**
 
 ```clojure
-{:variant-id     keyword (required)
- :substrate      keyword (optional)
- :active-modes   [keyword] (optional)
- :cell-overrides {keyword any} (optional)
- :timeout-ms     number (optional)}
+{:variant-id         keyword (required)
+ :substrate          keyword (optional)
+ :active-modes       [keyword] (optional)
+ :cell-overrides     {keyword any} (optional)
+ :timeout-ms         number  (optional, capped at 30000)
+ :include-sensitive? boolean (optional, gated — see `preview-variant`)}
 ```
+
+`:timeout-ms` is clamped to 30 s (matches `:rf.http/timeout-ms`
+baseline per rf2-it1cd; rf2-g9fje). `:include-sensitive?` follows
+the same `--allow-sensitive-reads` gate as `preview-variant`.
 
 **Output.**
 
@@ -186,9 +197,18 @@ hosts return `{:violations [] :hint "axe-core requires the in-browser panel."}`.
 
 ### `read-failures`
 
-**Input.** `{:variant-id keyword (required)}`.
+**Input.**
+
+```clojure
+{:variant-id         keyword (required)
+ :include-sensitive? boolean (optional, gated — see `preview-variant`)}
+```
 
 **Output.** `{:assertions [map] :passing? boolean}`. No re-run.
+
+`:include-sensitive?` follows the same `--allow-sensitive-reads`
+boot gate as `preview-variant` / `run-variant`. Assertion records
+stamped `:sensitive? true` are dropped at egress by default.
 
 ## Write tools (gated)
 

--- a/tools/story-mcp/spec/API.md
+++ b/tools/story-mcp/spec/API.md
@@ -224,11 +224,31 @@ Both tools require `:rf.story-mcp/allow-writes?` to be true; see
  :body       map | string (required — map preferred; string is EDN)}
 ```
 
+When `:body` is a string, it's parsed as EDN under a hardened policy
+(rf2-g9fje):
+
+- **No custom tagged literals.** `:readers {}` is empty and the `:default`
+  handler throws — `#inst` / `#uuid` (EDN built-ins) parse normally;
+  any other `#<tag> ...` form is rejected. The `#=(...)` read-eval form
+  is rejected by `clojure.edn` at the dispatch-macro level (never
+  evaluated).
+- **64 KB payload ceiling.** A legitimate variant body is well under 1 KB;
+  abusive payloads return an `isError: true` `"must be a map or a valid
+  EDN string"` result before `edn/read-string` walks the input.
+- **64-level depth ceiling.** Variant bodies top out at 3-4 levels;
+  deeper inputs short-circuit cleanly.
+
+The JSON-object form is preferred when keywords aren't structurally
+required in the body — the EDN-string form exists for callers whose
+body shape (e.g. `:tags #{:dev}`) can't round-trip through JSON.
+
 **Output.** `{:registered? true :variant-id ...}` on success.
 
 **Errors.**
 - `isError: true` when gate is closed (`{:gated true :reason "..."}`).
 - `isError: true` when `:body` fails `:rf/variant` schema validation.
+- `isError: true` when `:body` is a string that fails the EDN reader
+  hardening above (`"must be a map or a valid EDN string"`).
 - `isError: true` when the parent story is not registered.
 
 ### `unregister-variant`

--- a/tools/story-mcp/src/re_frame/story_mcp/config.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/config.cljc
@@ -17,6 +17,16 @@
   - `set-allow-writes!` — write helper. Called from `-main` (`--allow-writes`
     CLI flag), from the JVM property `-Drf.story-mcp.allow-writes=true`,
     or programmatically (tests).
+  - `allow-sensitive-reads?` — atom holding the sensitive-read gate. Read
+    by the wire-egress scrubbers (`helpers/include-sensitive?`); a `false`
+    value forces redaction regardless of any per-call `:include-sensitive?`
+    arg. Symmetric with `--allow-eval` in pair2-mcp (rf2-zyoj2): arbitrary
+    code execution + raw sensitive-state reads are operator-only opt-ins,
+    not caller-controlled toggles.
+  - `set-allow-sensitive-reads!` — write helper. Same three input paths
+    as `allow-writes?`: `--allow-sensitive-reads` CLI flag, JVM property
+    `-Drf.story-mcp.allow-sensitive-reads=true`, or env var
+    `RF_STORY_MCP_ALLOW_SENSITIVE_READS=true`.
   - `protocol-version` — the MCP protocol version this server advertises.
 
   ## Why a separate ns
@@ -109,6 +119,41 @@
   []
   (boolean @allow-writes?))
 
+;; ---- sensitive-read gate (rf2-g9fje) --------------------------------------
+;;
+;; Per the rf2-uaymx (b) decision and rf2-zyoj2's `--allow-eval` precedent,
+;; raw sensitive-state reads are an operator-only opt-in. The wire-egress
+;; helpers (`helpers/include-sensitive?`) defer to this atom — when it is
+;; `false` the per-call `:include-sensitive?` arg is silently treated as
+;; `false`, so a hostile or careless caller cannot exfiltrate declared-
+;; sensitive `:app-db` slots / assertion records by flipping a JSON
+;; boolean. Closed-by-default; opened by `--allow-sensitive-reads` CLI
+;; flag, JVM sysprop `rf.story-mcp.allow-sensitive-reads=true`, or env
+;; var `RF_STORY_MCP_ALLOW_SENSITIVE_READS=true`.
+
+(defonce
+  ^{:doc "Atom holding the sensitive-read gate. Defaults to `false`. Per
+         the rf2-uaymx (b) decision the per-call `:include-sensitive?`
+         arg is honoured ONLY when this atom is also `true`. Symmetric
+         with `allow-eval?` in pair2-mcp."}
+  allow-sensitive-reads?
+  (atom false))
+
+(defn set-allow-sensitive-reads!
+  "Set the sensitive-read gate. Idempotent. Returns the new value.
+  Accepts the same string-form booleans as `set-allow-writes!`."
+  [v]
+  (let [coerced (args/parse-boolean v false)]
+    (reset! allow-sensitive-reads? coerced)
+    coerced))
+
+(defn sensitive-reads-allowed?
+  "True iff raw sensitive-read egress is currently enabled. The wire-
+  egress helpers AND each per-call `:include-sensitive?` arg must both
+  be `true` for raw values to cross the wire."
+  []
+  (boolean @allow-sensitive-reads?))
+
 ;; ---- boot config from env / sysprop ---------------------------------------
 
 (defn read-boot-config
@@ -118,25 +163,34 @@
 
   - JVM sysprop `rf.story-mcp.allow-writes` — `\"true\"` / `\"1\"` enables.
   - Env var `RF_STORY_MCP_ALLOW_WRITES` — same.
+  - JVM sysprop `rf.story-mcp.allow-sensitive-reads` — same shape.
+  - Env var `RF_STORY_MCP_ALLOW_SENSITIVE_READS` — same shape.
 
-  Both sources are parsed via the cross-MCP `args/parse-boolean`
+  All sources are parsed via the cross-MCP `args/parse-boolean`
   primitive (rf2-vw4sq) so the truthy-string vocabulary
   (`true`/`1`/`yes`/`y`/`on`, case-insensitive) is the same one an
   agent learns once.
 
-  Returns a map `{:allow-writes? boolean}`. The caller (`-main`) merges
-  in CLI overrides before calling `apply-config!`."
+  Returns a map `{:allow-writes? boolean :allow-sensitive-reads? boolean}`.
+  The caller (`-main`) merges in CLI overrides before calling
+  `apply-config!`."
   []
-  (let [sysprop (System/getProperty "rf.story-mcp.allow-writes")
-        envv    (System/getenv "RF_STORY_MCP_ALLOW_WRITES")]
-    {:allow-writes? (or (args/parse-boolean sysprop false)
-                        (args/parse-boolean envv false))}))
+  (let [wsysprop (System/getProperty "rf.story-mcp.allow-writes")
+        wenv     (System/getenv "RF_STORY_MCP_ALLOW_WRITES")
+        ssysprop (System/getProperty "rf.story-mcp.allow-sensitive-reads")
+        senv     (System/getenv "RF_STORY_MCP_ALLOW_SENSITIVE_READS")]
+    {:allow-writes?          (or (args/parse-boolean wsysprop false)
+                                 (args/parse-boolean wenv false))
+     :allow-sensitive-reads? (or (args/parse-boolean ssysprop false)
+                                 (args/parse-boolean senv false))}))
 
 (defn apply-config!
   "Apply a boot-config map to the runtime atoms. Returns the applied map."
-  [{:keys [allow-writes?] :as cfg}]
+  [{:keys [allow-writes? allow-sensitive-reads?] :as cfg}]
   (when (some? allow-writes?)
     (set-allow-writes! allow-writes?))
+  (when (some? allow-sensitive-reads?)
+    (set-allow-sensitive-reads! allow-sensitive-reads?))
   cfg)
 
 ;; ---- stage marker --------------------------------------------------------

--- a/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
@@ -49,6 +49,21 @@
   auto-namespaced `::eof` form across namespace boundaries."
   ::eof)
 
+;; ---- frame-length cap (rf2-g9fje, fix 3/3) -------------------------------
+
+(def ^:const max-frame-bytes
+  "Hard ceiling on a single newline-delimited JSON-RPC frame from the
+  stdio transport. 4 MB — well above any legitimate MCP message a
+  cooperating client would send (the largest reasonable payload is a
+  `tools/list` response, which Stage 7's nineteen-tool registry
+  prints in ~15 KB), but small enough that a hostile or runaway
+  producer can't OOM the JVM by sending a one-frame `readLine` that
+  never terminates. When a frame exceeds the cap, `read-frame` throws
+  an `ex-info` with `:rf.error/frame-too-large`; the run-loop catches
+  and writes a parse-error response, then continues to the next
+  frame."
+  (* 4 1024 1024))
+
 ;; ---- envelope construction -----------------------------------------------
 
 (defn response
@@ -132,18 +147,69 @@
 
 ;; ---- frame I/O (stdio line-delimited) ------------------------------------
 
+(defn- read-bounded-line
+  "Read characters from `^java.io.BufferedReader reader` until newline,
+  EOF, or `max-bytes` is reached. Returns:
+
+    - `nil`               — EOF before any character was read.
+    - bounded string      — happy path: the read line, without its
+                            trailing newline.
+    - `::frame-too-large` — the cap was reached before a newline.
+                            The remaining bytes of the over-cap frame
+                            are drained to the next newline (or EOF)
+                            so the next `read-bounded-line` call
+                            starts on a fresh frame boundary.
+
+  Unlike `BufferedReader.readLine`, which will happily allocate
+  unbounded memory for a `readLine` that never sees a newline, this
+  helper enforces a hard ceiling — the rf2-g9fje DoS bound for the
+  stdio transport."
+  [^java.io.BufferedReader reader max-bytes]
+  (let [sb (StringBuilder.)]
+    (loop [n 0]
+      (let [c (.read reader)]
+        (cond
+          (neg? c)
+          (if (zero? n) nil (.toString sb))
+
+          (= c (int \newline))
+          (.toString sb)
+
+          (>= n max-bytes)
+          ;; Drain the rest of this frame so the next call lands on a
+          ;; fresh boundary. We don't bound this drain (the bytes have
+          ;; already been allocated on the wire); we just don't keep
+          ;; them in the StringBuilder.
+          (do (loop []
+                (let [d (.read reader)]
+                  (when (and (not (neg? d))
+                             (not= d (int \newline)))
+                    (recur))))
+              ::frame-too-large)
+
+          :else
+          (do (.append sb (char c))
+              (recur (inc n))))))))
+
 (defn read-frame
   "Read one newline-delimited JSON frame from `^java.io.BufferedReader reader`.
   Returns the parsed map, or `::eof` when the reader has closed, or
-  throws `:rf.error/parse-error` on malformed JSON.
+  throws an `ex-info` on malformed JSON / oversize frame.
 
   Empty / whitespace lines are silently consumed (some agent hosts emit
-  trailing newlines)."
+  trailing newlines). Frames exceeding `max-frame-bytes` (rf2-g9fje)
+  throw with `:rf.error/frame-too-large`; the run-loop catches that
+  and writes a parse-error response before continuing — one oversize
+  frame can't park the loop."
   [^java.io.BufferedReader reader]
   (loop []
-    (let [line (.readLine reader)]
+    (let [line (read-bounded-line reader max-frame-bytes)]
       (cond
         (nil? line)                   eof-sentinel
+        (= ::frame-too-large line)    (throw (ex-info
+                                               "re-frame2-story-mcp: frame exceeds cap"
+                                               {:rf.error :rf.error/frame-too-large
+                                                :max-bytes max-frame-bytes}))
         (str/blank? line)             (recur)
         :else                         (parse-json line)))))
 

--- a/tools/story-mcp/src/re_frame/story_mcp/server.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/server.cljc
@@ -215,6 +215,12 @@
     accepted-and-recorded `false` which then propagated through
     `apply-config!` only when the absent default was already
     `false`).
+  - `--allow-sensitive-reads` — presence opens the sensitive-read gate
+    (rf2-g9fje). Symmetric with `--allow-writes` and with pair2-mcp's
+    `--allow-eval`: operator-only opt-in, no `=value` variant. Default
+    off; when off, the wire-egress scrubbers silently ignore any
+    `:include-sensitive? true` per-call arg and `tools/list` omits the
+    slot from advertised input schemas.
 
   Unknown flags are logged and ignored — the MCP spec doesn't define
   CLI conventions, so being permissive here is correct.
@@ -225,7 +231,8 @@
          cfg  {}]
     (if-let [a (first args)]
       (case a
-        "--allow-writes" (recur (rest args) (assoc cfg :allow-writes? true))
+        "--allow-writes"          (recur (rest args) (assoc cfg :allow-writes? true))
+        "--allow-sensitive-reads" (recur (rest args) (assoc cfg :allow-sensitive-reads? true))
         (do (log! "unknown CLI flag:" a)
             (recur (rest args) cfg)))
       cfg)))
@@ -242,6 +249,13 @@
      (log! "booted; allow-writes?=" (config/writes-allowed?)
            " protocol=" config/protocol-version
            " server=" config/server-name)
+     ;; rf2-g9fje — one-line boot signal mirroring pair2-mcp's
+     ;; `eval-cljs:` line. Operators inspecting the launch stderr can
+     ;; confirm the posture at a glance.
+     (log! "Sensitive reads:"
+           (if (config/sensitive-reads-allowed?)
+             "allowed (--allow-sensitive-reads)"
+             "gated (default; pass --allow-sensitive-reads to opt in)"))
      cfg)))
 
 (defn run-stdio!

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
@@ -19,11 +19,17 @@
   HOT PATH (rf2-d3iso): agents spam this tool. The variant-id slot per
   story is read from `story/variants-by-story` — a single O(V) pass
   over the variant side-table — instead of the previous O(S × V) shape
-  of calling `variants-of` once per story."
+  of calling `variants-of` once per story.
+
+  rf2-lqjbk: caller-supplied `:tags` entries route through
+  `args/safe-keyword` against the registered-tag set — unknown tag
+  ids skip the intersection rather than interning a fresh JVM
+  keyword."
   [args]
   (let [stories  (story/handlers :story)
+        tag-set  (story/list-tags)
         tags     (when-let [ts (:tags args)]
-                   (set (map args/parse-keyword ts)))
+                   (into #{} (keep #(args/safe-keyword % tag-set)) ts))
         filtered (if (seq tags)
                    (into {}
                          (filter (fn [[_id body]]
@@ -39,16 +45,19 @@
     (h/text-result (h/pr-edn payload) payload)))
 
 (defn tool-get-story
-  "Docs: one story's full body."
+  "Docs: one story's full body.
+
+  rf2-lqjbk: `:story-id` is resolved through `args/safe-keyword`
+  against the registered-stories set — an unknown id returns the
+  documented `Story not found` error without interning."
   [args]
   (let [[sid err] (h/required-arg args :story-id)]
     (if err err
-      (let [sk   (args/parse-keyword sid)
-            body (story/handler-meta :story sk)]
-        (if (nil? body)
-          (h/error-result (str "Story not found: " (pr-str sk)))
-          (let [payload {:id sk :body body :variants (sort (story/variants-of sk))}]
-            (h/text-result (h/pr-edn payload) payload)))))))
+      (if-let [sk (args/safe-keyword sid (story/ids :story))]
+        (let [body (story/handler-meta :story sk)
+              payload {:id sk :body body :variants (sort (story/variants-of sk))}]
+          (h/text-result (h/pr-edn payload) payload))
+        (h/error-result (str "Story not found: " (pr-str sid)))))))
 
 (defn tool-get-variant
   "Docs: one variant's full body (`handler-meta :variant id`)."
@@ -97,6 +106,13 @@
       (= kind :fx-override)  (assoc :fx-id    (:fx-id body)
                                     :response (:response body)))))
 
+(def ^:private decorator-kinds
+  "Bounded enum allowlist for `tool-list-decorators` `:kind` filter
+  (rf2-lqjbk). Three legal values per spec/Stage-2 decorator kinds;
+  an unrecognised string short-circuits through `safe-keyword` without
+  interning."
+  #{:hiccup :frame-setup :fx-override})
+
 (defn tool-list-decorators
   "Docs: read-only enumeration of registered decorators (rf2-mqp1u).
   Returns each decorator's id, kind, and doc plus the kind-specific
@@ -109,9 +125,11 @@
   Optional `args`:
 
   - `:kind` (string, optional) — narrow to one decorator kind. One
-    of `\"hiccup\"`, `\"frame-setup\"`, `\"fx-override\"`."
+    of `\"hiccup\"`, `\"frame-setup\"`, `\"fx-override\"`. Resolved
+    through `args/safe-keyword` against the bounded `decorator-kinds`
+    set (rf2-lqjbk); unrecognised values are treated as no filter."
   [args]
-  (let [kind-filter (some-> (:kind args) args/parse-keyword)
+  (let [kind-filter (some-> (:kind args) (args/safe-keyword decorator-kinds))
         decorators  (story/handlers :decorator)
         entries     (cond->> (for [[did body] decorators]
                                (decorator-summary did body))
@@ -230,16 +248,15 @@
   [args]
   (let [[sid err] (h/required-arg args :story-id)]
     (if err err
-      (let [sk   (args/parse-keyword sid)
-            body (story/handler-meta :story sk)]
-        (if (nil? body)
-          (h/error-result (str "Story not found: " (pr-str sk)))
-          (let [variants (sort (story/variants-of sk))
-                md       (render-story-markdown sk body variants)
-                payload  {:story-id sk
-                          :markdown md
-                          :variants (vec variants)}]
-            (h/text-result md payload)))))))
+      (if-let [sk (args/safe-keyword sid (story/ids :story))]
+        (let [body     (story/handler-meta :story sk)
+              variants (sort (story/variants-of sk))
+              md       (render-story-markdown sk body variants)
+              payload  {:story-id sk
+                        :markdown md
+                        :variants (vec variants)}]
+          (h/text-result md payload))
+        (h/error-result (str "Story not found: " (pr-str sid)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Registry descriptors (assembled in `tools.registry/tool-registry`)

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
@@ -124,6 +124,39 @@
       [nil (error-result (str "Missing required argument: " (name k)))]
       [v nil])))
 
+;; ---------------------------------------------------------------------------
+;; Bounded-allowlist keyword resolution (rf2-lqjbk)
+;; ---------------------------------------------------------------------------
+;;
+;; The legacy `args/parse-keyword` INTERNS on the JVM — a caller streaming
+;; unique random strings as `:variant-id`s would slowly grow the JVM's
+;; never-shrinking keyword table. The mitigation is to resolve every
+;; agent-supplied keyword id against a bounded set BEFORE coercing it to
+;; a keyword, using `args/safe-keyword` (which routes through
+;; `find-keyword` on the JVM — no intern outside the allowlist).
+;;
+;; For READ-side handlers (every tool in dev / docs / testing) the
+;; bounded set IS the live registry's id set; an id outside the registry
+;; can't possibly resolve to a registered handler anyway, so the strict
+;; gate is equivalent to "reject what the lookup would have missed
+;; anyway". The fns below take the registry-key fn as data so each
+;; helper site doesn't repeat the bind.
+;;
+;; The WRITE-side handlers (`register-variant`) are the documented
+;; exception: by design they extend the registry with a fresh keyword.
+;; Those callers intern via `args/parse-keyword` directly, bounded by
+;; the operator-gated `--allow-writes` flag (the registry itself is the
+;; bounded set; the operator chose to open it).
+
+(defn- variant-id-set
+  "Snapshot of registered variant ids — the bounded allowlist used by
+  `with-variant` / `with-variant-id` / `read-run-opts`. Captured per
+  call so a registration that lands between two read tools is reflected
+  on the second read (the registry is logically a mutable atom; we
+  re-snapshot rather than cache)."
+  []
+  (story/ids :variant))
+
 (defn read-run-opts
   "Build the `re-frame.story/run-variant` opts map from the standard MCP
   arg slots (`:substrate`, `:active-modes`, `:cell-overrides`). Each
@@ -133,23 +166,46 @@
 
   Shared by `tool-preview-variant`, `tool-run-variant`, and
   `tool-snapshot-identity` (the latter omits `:cell-overrides`, but
-  the absent-slot-not-present rule keeps the helper general)."
+  the absent-slot-not-present rule keeps the helper general).
+
+  rf2-lqjbk: `:substrate` and each entry in `:active-modes` are
+  coerced through `args/safe-keyword` against the live registry's
+  bounded set — an unrecognised id surfaces as `nil` (which
+  `run-variant`'s opts contract already tolerates as 'no override')
+  rather than as a freshly-interned keyword. The substrates set is
+  CLJS-only (the JVM-standalone deploy reads `nil`); the modes set
+  is the registered-mode id set."
   [arguments]
-  (cond-> {}
-    (some? (:substrate arguments))      (assoc :substrate (args/parse-keyword (:substrate arguments)))
-    (some? (:active-modes arguments))   (assoc :active-modes
-                                               (mapv args/parse-keyword (:active-modes arguments)))
-    (some? (:cell-overrides arguments)) (assoc :cell-overrides (:cell-overrides arguments))))
+  (let [substrate-set #?(:clj  (if-let [v (resolve-cljs-var 'story/registered-substrates)]
+                                 (try (set (v)) (catch Throwable _ #{}))
+                                 #{})
+                         :cljs (try (set (story/registered-substrates))
+                                    (catch :default _ #{})))
+        mode-set      (story/list-modes)]
+    (cond-> {}
+      (some? (:substrate arguments))
+      (assoc :substrate (args/safe-keyword (:substrate arguments) substrate-set))
+
+      (some? (:active-modes arguments))
+      (assoc :active-modes
+             (into []
+                   (keep #(args/safe-keyword % mode-set))
+                   (:active-modes arguments)))
+
+      (some? (:cell-overrides arguments)) (assoc :cell-overrides (:cell-overrides arguments)))))
 
 (defn with-variant
-  "Resolve `:variant-id` from `arguments` (required), parse it as a
-  keyword, and probe `story/variant->edn` for the body. When both
+  "Resolve `:variant-id` from `arguments` (required), resolve it against
+  the registered-variants set (no JVM intern outside the allowlist —
+  rf2-lqjbk), and probe `story/variant->edn` for the body. When both
   succeed, returns `(f vk body)`. Otherwise short-circuits with an
   error result:
 
     - Missing/blank `:variant-id` ⇒ `Missing required argument: …`
       (the shape `required-arg` emits).
-    - Unregistered variant ⇒ `Variant not found: <vk>`.
+    - Unregistered variant ⇒ `Variant not found: <vid>` (the raw
+      caller-supplied string is echoed; we don't have a keyword form
+      because the safe-keyword gate refused to intern one).
 
   Crystallises the four-line prelude shared by six tool handlers
   (`preview-variant`, `get-variant`, `variant->edn`, `run-variant`,
@@ -160,25 +216,34 @@
   (let [[vid err] (required-arg arguments :variant-id)]
     (if err
       err
-      (let [vk   (args/parse-keyword vid)
-            body (story/variant->edn vk)]
-        (if (nil? body)
-          (error-result (str "Variant not found: " (pr-str vk)))
-          (f vk body))))))
+      (if-let [vk (args/safe-keyword vid (variant-id-set))]
+        (let [body (story/variant->edn vk)]
+          (if (nil? body)
+            (error-result (str "Variant not found: " (pr-str vk)))
+            (f vk body)))
+        (error-result (str "Variant not found: " (pr-str vid)))))))
 
 (defn with-variant-id
-  "Resolve `:variant-id` from `arguments` (required) and parse it as a
-  keyword. Returns `(f vk)` when the arg is present, the
-  `required-arg` error result otherwise. For tools that tolerate
-  unregistered variants — they read whatever the registry currently
-  holds and report on it (`run-a11y`, `read-failures`,
-  `unregister-variant`). Tools that demand a registered body use
-  `with-variant` instead."
+  "Resolve `:variant-id` from `arguments` (required) against the
+  registered-variants set (rf2-lqjbk — no JVM intern outside the
+  allowlist). Returns `(f vk)` when the id resolves; otherwise an
+  error result.
+
+  Used by tools whose reads tolerate an unregistered variant
+  (`run-a11y`, `read-failures`, `unregister-variant`) — but per the
+  rf2-lqjbk bound, an UNREGISTERED variant id can't intern through
+  this surface either. The behavioural change: instead of returning
+  an empty result for a never-seen id, the tool returns the same
+  `Variant not found` error result `with-variant` emits. That is the
+  more honest answer — if the id was never registered, there's
+  nothing to read."
   [arguments f]
   (let [[vid err] (required-arg arguments :variant-id)]
     (if err
       err
-      (f (args/parse-keyword vid)))))
+      (if-let [vk (args/safe-keyword vid (variant-id-set))]
+        (f vk)
+        (error-result (str "Variant not found: " (pr-str vid)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Wire-egress scrubbers (rf2-73wuj). Per spec/Tool-Pair.md §Direct-read

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
@@ -35,7 +35,8 @@
             [re-frame.core :as rf]
             [re-frame.mcp-base.args :as args]
             [re-frame.mcp-base.sensitive :as sensitive]
-            [re-frame.story :as story]))
+            [re-frame.story :as story]
+            [re-frame.story-mcp.config :as config]))
 
 ;; ---------------------------------------------------------------------------
 ;; Result builders
@@ -94,12 +95,25 @@
 
 (defn include-sensitive?
   "True iff the caller opted in to forwarding `:sensitive? true` records
-  / app-db slots for this call. Default off. Reads the
-  `:include-sensitive?` arg via the cross-MCP `args/parse-boolean`
-  parser (so string-form booleans `\"true\"` / `\"yes\"` / `\"1\"` are
-  accepted alongside the JSON `true`)."
+  / app-db slots AND the operator has opened the server-side gate.
+  Default off. Reads the `:include-sensitive?` arg via the cross-MCP
+  `args/parse-boolean` parser (so string-form booleans `\"true\"` /
+  `\"yes\"` / `\"1\"` are accepted alongside the JSON `true`).
+
+  ## Boot-time gate (rf2-g9fje)
+
+  The operator-only gate `config/sensitive-reads-allowed?` (set by
+  `--allow-sensitive-reads`, mirroring pair2-mcp's `--allow-eval`) is
+  the outer check: when it is `false`, this fn always returns `false`,
+  the per-call `:include-sensitive?` arg is silently ignored, and
+  declared-sensitive `:app-db` slots / assertion records remain
+  redacted regardless of what the caller asked for. The MCP caller
+  surface (`tools/list`) likewise omits `:include-sensitive?` from
+  the descriptor schemas when the gate is closed (see `schemas/
+  with-include-sensitive`)."
   [arguments]
-  (args/parse-boolean (get arguments :include-sensitive?) false))
+  (and (config/sensitive-reads-allowed?)
+       (args/parse-boolean (get arguments :include-sensitive?) false)))
 
 (defn required-arg
   "Read a required argument. Returns `[value nil]` on success, or

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
@@ -153,29 +153,76 @@
                  :tool          "record-as-variant"
                  :duration-ms   duration-ms
                  :max-allowed   max-duration-ms}))
-            (let [target-vid  (or (some-> (:new-variant-id arguments) args/parse-keyword) vk)
-                  extends     (or (some-> (:extends arguments) args/parse-keyword) vk)
-                  doc         (:doc arguments)
-                  alias-arg   (:alias arguments)
-                  started     (now-ms)
-                  _           (story/start-recording! vk)
-                  _           (sleep-ms duration-ms)
-                  final-state (story/stop-recording!)
-                  events      (vec (:events final-state))
-                  snippet     (story/gen-play-snippet
-                                events
-                                (cond-> {:variant-id target-vid :extends extends}
-                                  (string? doc)       (assoc :doc doc)
-                                  (string? alias-arg) (assoc :alias alias-arg)))
-                  base        {:variant-id           vk
-                               :play-snippet         snippet
-                               :recorded-event-count (count events)
-                               :duration-ms          (- (now-ms) started)
-                               :captured             events
-                               :written-back?        false}]
-              (if-not write-back?
-                (h/text-result (h/pr-edn base) base)
-                (write-back! base body events target-vid))))))))
+            ;; rf2-lqjbk: keyword resolution for the three caller-
+            ;; supplied id slots.
+            ;;
+            ;; - `:extends` is a read-side reference — it MUST point to
+            ;;   a registered variant whose `:component` / `:args` the
+            ;;   snippet inherits. `safe-keyword` against the
+            ;;   registered-variant set rejects unknowns without
+            ;;   interning. Defaults to the source `vk` when omitted.
+            ;;
+            ;; - `:new-variant-id` is the write-back target. When
+            ;;   `:write-back?` is true we DO need a fresh keyword
+            ;;   (the registrar's gate is `--allow-writes`; the
+            ;;   operator chose to grow the registry). When
+            ;;   `:write-back?` is false the slot exists only for the
+            ;;   rendered snippet's first-line `:variant-id` literal —
+            ;;   we render the caller's string as `:<string>` via
+            ;;   `read-string` ONLY when the existing variant-id grammar
+            ;;   admits it. If not, we fall back to the source `vk`.
+            ;;   This avoids interning a JVM keyword for what may be a
+            ;;   one-shot agent suggestion.
+            (let [extends     (if-let [e-arg (:extends arguments)]
+                                (or (args/safe-keyword e-arg (story/ids :variant))
+                                    ;; Reject unknown :extends so the snippet
+                                    ;; doesn't render a dangling reference.
+                                    nil)
+                                vk)]
+              (if (nil? extends)
+                (h/error-result
+                  (str ":extends references an unregistered variant: "
+                       (pr-str (:extends arguments)))
+                  {:rf.error :rf.story-mcp/extends-not-registered
+                   :tool     "record-as-variant"
+                   :extends  (:extends arguments)})
+                (let [target-vid  (cond
+                                    ;; write-back path: operator-gated
+                                    ;; intern via parse-keyword.
+                                    (and write-back? (:new-variant-id arguments))
+                                    (args/parse-keyword (:new-variant-id arguments))
+
+                                    ;; non-write-back: snippet-only,
+                                    ;; safe-keyword against the live
+                                    ;; variant set; otherwise default to
+                                    ;; source vk rather than intern.
+                                    (:new-variant-id arguments)
+                                    (or (args/safe-keyword (:new-variant-id arguments)
+                                                           (story/ids :variant))
+                                        vk)
+
+                                    :else vk)
+                      doc         (:doc arguments)
+                      alias-arg   (:alias arguments)
+                      started     (now-ms)
+                      _           (story/start-recording! vk)
+                      _           (sleep-ms duration-ms)
+                      final-state (story/stop-recording!)
+                      events      (vec (:events final-state))
+                      snippet     (story/gen-play-snippet
+                                    events
+                                    (cond-> {:variant-id target-vid :extends extends}
+                                      (string? doc)       (assoc :doc doc)
+                                      (string? alias-arg) (assoc :alias alias-arg)))
+                      base        {:variant-id           vk
+                                   :play-snippet         snippet
+                                   :recorded-event-count (count events)
+                                   :duration-ms          (- (now-ms) started)
+                                   :captured             events
+                                   :written-back?        false}]
+                  (if-not write-back?
+                    (h/text-result (h/pr-edn base) base)
+                    (write-back! base body events target-vid))))))))))
 
 (def descriptors
   "Registry descriptors for the recorder's MCP surface — the single

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc
@@ -16,7 +16,8 @@
   The schema fragments + injection helpers live in
   `re-frame.story-mcp.tools.schemas`; the wire-boundary token-cap
   dispatcher (`invoke-tool`) lives in `re-frame.story-mcp.tools.cap`."
-  (:require [re-frame.story-mcp.tools.dev :as dev]
+  (:require [re-frame.story-mcp.config :as config]
+            [re-frame.story-mcp.tools.dev :as dev]
             [re-frame.story-mcp.tools.docs :as docs]
             [re-frame.story-mcp.tools.recorder :as recorder]
             [re-frame.story-mcp.tools.testing :as testing]
@@ -45,6 +46,19 @@
                 tool-registry)
         "tool-registry: every entry must carry positive-integer :typicalTokens")
 
+(defn- strip-include-sensitive
+  "Remove the `:include-sensitive?` slot from a tool's `:inputSchema`
+  properties. The slot is baked into the descriptor at load time by
+  `schemas/with-include-sensitive`; this fn runs at `tools/list` time
+  and removes it when the operator-only gate is closed (rf2-g9fje) so
+  the descriptor never advertises an opt-in the server is configured
+  to ignore. Idempotent: tools whose schema never carried the slot are
+  returned unchanged."
+  [schema]
+  (if (contains? (:properties schema) :include-sensitive?)
+    (update schema :properties dissoc :include-sensitive?)
+    schema))
+
 (defn tool-descriptors
   "Build the `tools/list` response payload: each tool's name +
   description + inputSchema + typicalTokens, in registry order. The
@@ -59,14 +73,26 @@
   The `:typicalTokens` slot is asserted on every entry by the
   `typical-tokens-hint-on-every-tool` test plus the registry-load
   assertion below, so the projection is a plain map literal rather
-  than a defensive `cond->`."
+  than a defensive `cond->`.
+
+  ## Sensitive-read gate (rf2-g9fje)
+
+  The `:include-sensitive?` slot is stripped from every tool's input
+  schema when the operator-only gate (`config/sensitive-reads-allowed?`)
+  is closed — agents shouldn't see an opt-in they can't exercise. The
+  three affected tools (`preview-variant`, `run-variant`, `read-failures`)
+  silently ignore caller-supplied `:include-sensitive? true` at the
+  helper layer regardless, so the descriptor strip is purely a UX
+  improvement and a defence-in-depth signal."
   []
-  (mapv (fn [{:keys [name description inputSchema typicalTokens]}]
-          {:name          name
-           :description   description
-           :inputSchema   inputSchema
-           :typicalTokens typicalTokens})
-        tool-registry))
+  (let [strip? (not (config/sensitive-reads-allowed?))]
+    (mapv (fn [{:keys [name description inputSchema typicalTokens]}]
+            {:name          name
+             :description   description
+             :inputSchema   (cond-> inputSchema
+                              strip? strip-include-sensitive)
+             :typicalTokens typicalTokens})
+          tool-registry)))
 
 (def ^:private tool-by-name-index
   "Pre-computed `name → descriptor` map so `tool-by-name` is O(1)

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc
@@ -25,9 +25,20 @@
   declared-sensitive paths land `:rf/redacted` via `elide-wire-value`,
   and assertion records stamped `:sensitive? true` are dropped via
   `strip-sensitive`. Pass true to forward the raw values; per the
-  cross-MCP convention from `re-frame.mcp-base.sensitive`."
+  cross-MCP convention from `re-frame.mcp-base.sensitive`.
+
+  Honoured only when the server was started with
+  `--allow-sensitive-reads` (rf2-g9fje). When that operator-only gate
+  is closed, the slot is omitted from `tools/list` advertisements (so
+  agents don't even see it) and any caller-supplied value is silently
+  ignored at egress."
   {:type "boolean"
-   :description "Opt in to forwarding sensitive `:app-db` slots and assertion records. Default false (declared-sensitive paths return `:rf/redacted`; assertion records stamped `:sensitive? true` are dropped). Per spec/Tool-Pair.md §Direct-read privacy posture."})
+   :description (str "Opt in to forwarding sensitive `:app-db` slots and "
+                     "assertion records. Default false (declared-sensitive paths "
+                     "return `:rf/redacted`; assertion records stamped "
+                     "`:sensitive? true` are dropped). Per spec/Tool-Pair.md "
+                     "§Direct-read privacy posture. Honoured only when the "
+                     "server was started with `--allow-sensitive-reads`.")})
 
 (defn with-max-tokens
   "Inject the `:max-tokens` slot into a tool's `:properties` map. Every
@@ -38,6 +49,12 @@
 (defn with-include-sensitive
   "Inject the `:include-sensitive?` slot into a tool's `:properties`
   map. Used by tools that surface a live `:app-db` slice or assertion
-  accumulator (`preview-variant`, `run-variant`, `read-failures`)."
+  accumulator (`preview-variant`, `run-variant`, `read-failures`).
+
+  The slot is baked into the static descriptor at load time and
+  stripped at `tools/list` time by `registry/tool-descriptors` when the
+  server's `--allow-sensitive-reads` gate is closed (rf2-g9fje) — so a
+  closed gate hides the opt-in from agents entirely, and an open gate
+  surfaces it verbatim."
   [props]
   (assoc props :include-sensitive? include-sensitive-schema))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
@@ -13,6 +13,26 @@
             [re-frame.story-mcp.tools.helpers :as h]
             [re-frame.story-mcp.tools.schemas :as s]))
 
+(def ^:const max-timeout-ms
+  "Hard ceiling on `:timeout-ms` for `run-variant` (rf2-g9fje, fix 3/3).
+  The MCP server's request loop is single-threaded — a `run-variant`
+  call with an unbounded `:timeout-ms` parks the loop and starves
+  unrelated tool calls. 30 s matches the `:rf.http/timeout-ms`
+  baseline rf2-it1cd pinned for the project's outbound HTTP fx, so an
+  agent that learns one ceiling sees the same one everywhere.
+  Caller-supplied values above this clamp DOWN to the ceiling rather
+  than reject — a legitimate slow variant should still run, just
+  capped."
+  30000)
+
+(def ^:const default-timeout-ms
+  "Default `:timeout-ms` for `run-variant` when the caller omits the
+  slot. 10 s — well under the 30 s ceiling, enough for the
+  vast majority of variants. Kept as a separate const from
+  `max-timeout-ms` so the descriptor schema can advertise both
+  without re-spelling the literal."
+  10000)
+
 (defn tool-run-variant
   "Testing: execute a variant, return the run-variant result map.
 
@@ -24,14 +44,18 @@
     :substrate      optional — keyword or string
     :active-modes   optional — coll of mode ids
     :cell-overrides optional — map of arg overrides
-    :timeout-ms     optional — JVM blocking timeout; default 10000
+    :timeout-ms     optional — JVM blocking timeout; default 10000;
+                               clamped to `max-timeout-ms` (30000) per
+                               rf2-g9fje so one slow request can't park
+                               the single-threaded stdio loop.
     :include-sensitive? optional — opt out of wire-egress redaction
                                    (default false; rf2-73wuj)"
   [args]
   (h/with-variant args
     (fn [vk _body]
       (let [opts     (h/read-run-opts args)
-            timeout  (args/parse-positive-int (:timeout-ms args) 10000)
+            timeout  (min max-timeout-ms
+                          (args/parse-positive-int (:timeout-ms args) default-timeout-ms))
             result   (try
                        (async/deref-blocking (story/run-variant vk opts) timeout)
                        (catch Throwable e
@@ -144,8 +168,13 @@
                                    :substrate s/kw-or-string
                                    :active-modes {:type "array" :items s/kw-or-string}
                                    :cell-overrides {:type "object"}
-                                   :timeout-ms {:type "integer" :minimum 1
-                                                :description "JVM blocking timeout. Default 10000."}}))
+                                   :timeout-ms {:type "integer" :minimum 1 :maximum max-timeout-ms
+                                                :description (str "JVM blocking timeout. Default "
+                                                                  default-timeout-ms "ms. Hard ceiling "
+                                                                  max-timeout-ms "ms — values above clamp DOWN "
+                                                                  "rather than reject; the MCP server's request "
+                                                                  "loop is single-threaded so an unbounded "
+                                                                  "timeout would park unrelated calls (rf2-g9fje).")}}))
                   :required ["variant-id"]
                   :additionalProperties false}
     :handler     tool-run-variant}

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
@@ -38,18 +38,116 @@
            "should leave it off.")
       {:gated true :tool tool-name})))
 
+;; ---- EDN reader hardening (rf2-g9fje, fix 2/3) ----------------------------
+;;
+;; `:body` arrives as either a JSON object (preferred — round-trippable map)
+;; or an EDN string (legacy; needed because JSON has no native keyword type
+;; and the registrar's variant schema demands `:tags #{:dev :docs}` and the
+;; like). The string path is retained because the mcp-conformance probe
+;; (`tools/mcp-conformance/test/end-to-end-story.js`) registers its fixture
+;; variant via the EDN-string path — JSON's keyword-blind surface would
+;; otherwise force a coercion pass the registrar isn't shaped for.
+;;
+;; The hardening matches the rf2-uaymx audit's "if EDN strings must stay"
+;; remediation:
+;;
+;;   1. Reject any tagged literal (`#<reader-tag> ...`) by setting both
+;;      `:readers {}` (no custom tags admitted) AND `:default` to a
+;;      throwing handler — `edn/read-string`'s default behaviour is to
+;;      silently swallow unknown tags via `*default-data-reader-fn*`,
+;;      which is a footgun on agent-supplied input.
+;;
+;;   2. Cap payload size at 64KB. A 64KB EDN map is generous for a
+;;      variant body (`:doc` + `:args` + a few `:tags`); abusive payloads
+;;      get a clean reject rather than allocating a megabyte.
+;;
+;;   3. Cap nesting depth at 64 levels. The registrar's body shape is at
+;;      most 3-4 levels deep (variant → `:args` → user-supplied map →
+;;      values); 64 is unreachable from a legitimate caller and short-
+;;      circuits a deeply-nested payload before `edn/read-string` walks it.
+
+(def ^:const ^:private max-body-bytes
+  "Hard ceiling on `:body` EDN payload size (UTF-8 bytes). 64KB. A
+  legitimate variant body — `:doc`, `:args`, a handful of `:tags` — is
+  well under 1KB; this ceiling rejects abusive payloads cleanly without
+  letting `edn/read-string` walk a megabyte string."
+  (* 64 1024))
+
+(def ^:const ^:private max-edn-depth
+  "Hard ceiling on nesting depth of the parsed EDN body. The registrar's
+  variant shape tops out at 3-4 levels; 64 is far past any legitimate
+  use and short-circuits pathological inputs before they pressure
+  `edn/read-string`'s walker."
+  64)
+
+(defn- value-depth
+  "Recursive max depth of `v`. Maps and sequences count one level per
+  layer; scalars are depth 0. Used to reject pathologically nested
+  inputs before they reach the registrar."
+  [v]
+  (cond
+    (map? v)
+    (if (empty? v)
+      0
+      (inc (reduce max 0 (concat (map value-depth (keys v))
+                                 (map value-depth (vals v))))))
+
+    (or (vector? v) (list? v) (set? v) (seq? v))
+    (if (empty? v)
+      0
+      (inc (reduce max 0 (map value-depth v))))
+
+    :else 0))
+
+(defn- read-edn-body
+  "Parse an agent-supplied EDN string into a Clojure value with the
+  rf2-g9fje hardening posture. Returns the parsed value on success, or
+  one of two sentinels on failure (caller maps these to
+  `error-result`s):
+
+    `::edn-error` — `edn/read-string` threw (malformed EDN, tagged
+                    literal, oversize / over-deep payload).
+
+  The parser is `clojure.edn/read-string` with NO custom readers
+  (`:readers {}`) and a throwing `:default` handler — any
+  `#<tag> ...` form in the input lands in the `:default` handler,
+  which throws, which the outer try/catch maps to `::edn-error`.
+  Size and depth are checked OUT-OF-BAND (before / after the read)
+  so the reader sees only sanitised inputs."
+  [^String body]
+  (try
+    (let [byte-count #?(:clj  (count (.getBytes body "UTF-8"))
+                        :cljs (count body))]
+      (if (> byte-count max-body-bytes)
+        ::edn-error
+        (let [parsed (edn/read-string
+                       {:readers {}
+                        :default (fn [tag _]
+                                   (throw (ex-info "tagged literals not permitted"
+                                                   {:rf.error :rf.story-mcp/edn-tagged-literal
+                                                    :tag      tag})))}
+                       body)]
+          (if (> (value-depth parsed) max-edn-depth)
+            ::edn-error
+            parsed))))
+    (catch Throwable _ ::edn-error)))
+
 (defn- coerce-body
   "Normalise the `:body` arg to a Clojure map, or return one of two
   sentinel keywords on parse / shape failure:
 
-    `::edn-error` — `:body` was a string but `edn/read-string` threw.
-    `::not-a-map` — `:body` was not a map nor a map-string."
+    `::edn-error` — `:body` was a string but `read-edn-body` threw or
+                    the parsed value violated the size / depth /
+                    tagged-literal hardening (rf2-g9fje).
+    `::not-a-map` — `:body` parsed (or was passed) but is not a map."
   [body]
   (cond
     (map? body)    body
-    (string? body) (try (let [v (edn/read-string body)]
-                          (if (map? v) v ::not-a-map))
-                        (catch Throwable _ ::edn-error))
+    (string? body) (let [v (read-edn-body body)]
+                     (cond
+                       (= v ::edn-error) ::edn-error
+                       (map? v)          v
+                       :else             ::not-a-map))
     :else          ::not-a-map))
 
 (defn- register-or-error
@@ -130,7 +228,13 @@
                                 {:variant-id s/kw-or-string
                                  :body {:oneOf [{:type "object"}
                                                 {:type "string"
-                                                 :description "EDN-encoded variant body, parsed via clojure.edn/read-string."}]}})
+                                                 :description (str "EDN-encoded variant body. Parsed under the rf2-g9fje "
+                                                                   "hardening: tagged literals (#<tag> ...) rejected, "
+                                                                   "no custom readers, "
+                                                                   max-body-bytes "-byte payload ceiling, "
+                                                                   max-edn-depth "-level depth ceiling. "
+                                                                   "Prefer the JSON-object form when keywords are not "
+                                                                   "needed in the body shape.")}]}})
                   :required ["variant-id" "body"]
                   :additionalProperties false}
     :handler     tool-register-variant}

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
@@ -193,6 +193,14 @@
                 ::not-a-map
                 (h/error-result (str ":body must be a map; got " (some-> body class .getName)))
 
+                ;; rf2-lqjbk write-side exception: `register-variant`
+                ;; by definition extends the registry with a fresh
+                ;; keyword id, so `safe-keyword` against an existing
+                ;; bounded set would always reject. The intern here is
+                ;; gate-bounded by `--allow-writes` (operator-only
+                ;; opt-in); the registrar's `assert-id!` enforces the
+                ;; `:story.<path>/<name>` grammar, which constrains the
+                ;; per-id allocation cost.
                 (register-or-error (args/parse-keyword vid) body-v)))))))
 
 (defn tool-unregister-variant

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -1767,6 +1767,82 @@
              (proto/read-frame reader))
           "post-cap recovery: stdio loop continues on the next frame"))))
 
+;; ---------------------------------------------------------------------------
+;; rf2-lqjbk — parse-keyword → safe-keyword sweep
+;;
+;; Caller-supplied keyword ids on the read surface MUST resolve through
+;; `args/safe-keyword` against a bounded set, NOT through the legacy
+;; `args/parse-keyword` which interns into the never-shrinking JVM
+;; keyword table. The tests below assert the no-intern property by
+;; calling each read-side tool with a fresh random-shaped id and
+;; verifying that the underlying `find-keyword` returns nil after the
+;; call (the rejection path didn't intern the string).
+;; ---------------------------------------------------------------------------
+
+(defn- find-kw
+  "Find an existing interned keyword by namespace and name without
+  interning. Returns nil when no such keyword has been interned —
+  the asserting probe for the rf2-lqjbk no-intern contract."
+  [ns-str name-str]
+  (find-keyword ns-str name-str))
+
+(deftest get-story-unknown-id-does-not-intern
+  (testing "unknown :story-id rejects WITHOUT interning a fresh JVM keyword"
+    (let [ns-str   "story.rf2-lqjbk-probe"
+          name-str (str "unknown-" (System/nanoTime))
+          r        (invoke "get-story" {:story-id (str ns-str "/" name-str)})]
+      (is (error? r) "unknown story id must error")
+      (is (re-find #"(?i)story not found" (-> r :content first :text)))
+      (is (nil? (find-kw ns-str name-str))
+          "rf2-lqjbk: the unknown id MUST NOT have been interned"))))
+
+(deftest get-variant-unknown-id-does-not-intern
+  (testing "unknown :variant-id rejects WITHOUT interning a fresh JVM keyword"
+    (let [ns-str   "story.rf2-lqjbk-probe"
+          name-str (str "unknown-variant-" (System/nanoTime))
+          r        (invoke "get-variant" {:variant-id (str ns-str "/" name-str)})]
+      (is (error? r))
+      (is (re-find #"(?i)variant not found" (-> r :content first :text)))
+      (is (nil? (find-kw ns-str name-str))
+          "rf2-lqjbk: the unknown id MUST NOT have been interned"))))
+
+(deftest read-failures-unknown-id-does-not-intern
+  (testing "read-failures on an unknown :variant-id rejects WITHOUT interning"
+    (let [ns-str   "story.rf2-lqjbk-probe"
+          name-str (str "rf-" (System/nanoTime))
+          r        (invoke "read-failures" {:variant-id (str ns-str "/" name-str)})]
+      (is (error? r))
+      (is (nil? (find-kw ns-str name-str))
+          "rf2-lqjbk: the unknown id MUST NOT have been interned"))))
+
+(deftest list-stories-unknown-tag-does-not-intern
+  (testing "list-stories filter with an unknown :tags entry skips it WITHOUT interning"
+    (let [name-str (str "rf2-lqjbk-tag-" (System/nanoTime))
+          r        (invoke "list-stories" {:tags [name-str "dev"]})]
+      (is (success? r) "the known :dev tag still narrows; the unknown tag is dropped")
+      (is (nil? (find-kw nil name-str))
+          "rf2-lqjbk: unknown tag id MUST NOT intern"))))
+
+(deftest list-decorators-unknown-kind-falls-through
+  (testing ":kind filter with an unrecognised value rejects WITHOUT interning"
+    (let [name-str (str "rf2-lqjbk-kind-" (System/nanoTime))
+          r        (invoke "list-decorators" {:kind name-str})]
+      (is (success? r) "the no-filter fallback still returns the registered decorators")
+      (is (nil? (find-kw nil name-str))
+          "rf2-lqjbk: unknown kind name MUST NOT intern"))))
+
+(deftest run-variant-unknown-substrate-does-not-intern
+  (testing "run-variant :substrate with an unknown value is dropped WITHOUT interning"
+    ;; A registered variant; the unknown :substrate is dropped from the
+    ;; opts map (run-variant tolerates an absent slot), so the call still
+    ;; succeeds but the substrate name never enters the keyword table.
+    (let [name-str (str "rf2-lqjbk-sub-" (System/nanoTime))
+          r        (invoke "run-variant" {:variant-id "story.button/primary"
+                                          :substrate  name-str})]
+      (is (success? r))
+      (is (nil? (find-kw nil name-str))
+          "rf2-lqjbk: unknown substrate id MUST NOT intern"))))
+
 (deftest run-loop-survives-oversize-frame
   (testing "an oversize frame produces a parse-error response and the loop continues"
     (let [oversize (apply str (repeat (inc proto/max-frame-bytes) \x))

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -24,6 +24,7 @@
             [re-frame.story-mcp.tools.dev :as dev]
             [re-frame.story-mcp.tools.recorder :as recorder-tool]
             [re-frame.story-mcp.tools.registry :as registry]
+            [re-frame.story-mcp.tools.testing :as testing-tool]
             [re-frame.substrate.plain-atom :as plain-atom]))
 
 ;; ResultIO mirror over story-mcp's CLJ-map result shape — used by the
@@ -1687,6 +1688,101 @@
                "clients can pre-validate without round-tripping a doomed call"))
       (is (zero? (:minimum dur-schema))
           ":minimum stays at 0 — the no-block default is canonical"))))
+
+;; ---------------------------------------------------------------------------
+;; run-variant :timeout-ms cap (rf2-g9fje fix 3/3)
+;;
+;; The single-threaded stdio loop parks for the full `:timeout-ms` window
+;; — caller-supplied values clamp DOWN to `testing-tool/max-timeout-ms`
+;; (30 s, matches rf2-it1cd's `:rf.http/timeout-ms` baseline). A
+;; legitimately-slow variant runs against the cap; a hostile caller can't
+;; park the loop indefinitely.
+;; ---------------------------------------------------------------------------
+
+(deftest run-variant-timeout-ms-schema-advertises-ceiling
+  (testing "run-variant's :timeout-ms schema carries :maximum mirroring the runtime cap"
+    (let [t          (some #(when (= "run-variant" (:name %)) %) registry/tool-registry)
+          ts-schema  (-> t :inputSchema :properties :timeout-ms)]
+      (is (= testing-tool/max-timeout-ms (:maximum ts-schema))
+          "schema :maximum tracks the runtime cap so clients can pre-validate")
+      (is (= 1 (:minimum ts-schema))
+          ":minimum stays at 1 — a zero-timeout doesn't make sense on a blocking call"))))
+
+(deftest run-variant-timeout-ms-clamps-down-to-cap
+  ;; Pin the behavioural contract: the helper that computes the effective
+  ;; timeout MUST clamp values above the ceiling rather than reject. A
+  ;; legitimate slow variant still runs (against the cap), the loop never
+  ;; parks past 30 s.
+  (testing "values above the ceiling clamp down to max-timeout-ms"
+    (is (= testing-tool/max-timeout-ms
+           (min testing-tool/max-timeout-ms
+                ((requiring-resolve 're-frame.mcp-base.args/parse-positive-int)
+                 60000 testing-tool/default-timeout-ms)))
+        "60s caller-supplied → clamped to 30s")
+    (is (= 5000
+           (min testing-tool/max-timeout-ms
+                ((requiring-resolve 're-frame.mcp-base.args/parse-positive-int)
+                 5000 testing-tool/default-timeout-ms)))
+        "below-cap values ride through unchanged")
+    (is (= testing-tool/default-timeout-ms
+           (min testing-tool/max-timeout-ms
+                ((requiring-resolve 're-frame.mcp-base.args/parse-positive-int)
+                 nil testing-tool/default-timeout-ms)))
+        "absent :timeout-ms uses the default")))
+
+;; ---------------------------------------------------------------------------
+;; Protocol-side frame-length cap (rf2-g9fje fix 3/3)
+;;
+;; `BufferedReader.readLine` allocates unbounded memory for a one-line
+;; frame that never sees a newline. The MCP server's stdio transport is
+;; line-delimited per spec/2025-06-18/basic/transports; an attacker (or
+;; a runaway producer) sending an unterminated frame would OOM the JVM.
+;; `read-frame` now caps each frame at `proto/max-frame-bytes` (4 MB,
+;; well above the largest legitimate MCP message); over-cap frames
+;; throw `:rf.error/frame-too-large`, which the run-loop catches and
+;; converts to a parse-error response.
+;; ---------------------------------------------------------------------------
+
+(deftest read-frame-rejects-oversize-frame
+  (testing "a frame exceeding max-frame-bytes throws :rf.error/frame-too-large"
+    (let [oversize (str (apply str (repeat (inc proto/max-frame-bytes) \x)) "\n")
+          reader   (java.io.BufferedReader. (java.io.StringReader. oversize))]
+      (try
+        (proto/read-frame reader)
+        (is false "should have thrown")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :rf.error/frame-too-large (:rf.error (ex-data e)))
+              "ex-data carries the rf.error tag the run-loop dispatches on"))))))
+
+(deftest read-frame-survives-after-oversize-frame
+  (testing "the next frame after an oversize one is still readable"
+    (let [oversize (apply str (repeat (inc proto/max-frame-bytes) \x))
+          good     "{\"jsonrpc\":\"2.0\",\"method\":\"ping\",\"id\":7}"
+          input    (str oversize "\n" good "\n")
+          reader   (java.io.BufferedReader. (java.io.StringReader. input))]
+      ;; First read throws (frame-too-large drains the oversize frame to
+      ;; the next newline). Second read lands the good frame.
+      (try (proto/read-frame reader) (catch clojure.lang.ExceptionInfo _ nil))
+      (is (= {:jsonrpc "2.0" :method "ping" :id 7}
+             (proto/read-frame reader))
+          "post-cap recovery: stdio loop continues on the next frame"))))
+
+(deftest run-loop-survives-oversize-frame
+  (testing "an oversize frame produces a parse-error response and the loop continues"
+    (let [oversize (apply str (repeat (inc proto/max-frame-bytes) \x))
+          in-text  (str oversize "\n"
+                        "{\"jsonrpc\":\"2.0\",\"id\":11,\"method\":\"ping\"}\n")
+          reader   (java.io.BufferedReader. (java.io.StringReader. in-text))
+          sw       (java.io.StringWriter.)
+          err      (java.io.StringWriter.)]
+      (binding [*err* err]
+        (server/run-loop! reader sw))
+      (let [out-lines (filter seq (clojure.string/split-lines (.toString sw)))
+            frames    (mapv #(cheshire.core/parse-string % true) out-lines)]
+        (is (= 2 (count frames)) "one parse-error + one ping response")
+        (is (= vocab/code-parse-error (-> (nth frames 0) :error :code))
+            "oversize frame routes through the parse-error response shape")
+        (is (= 11 (:id (nth frames 1))) "the loop continued to the next frame")))))
 
 ;; ---------------------------------------------------------------------------
 ;; Cap accounting includes :structuredContent size (rf2-mzndx)

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -603,6 +603,70 @@
       (is (success? r))
       (is (= "Wire body." (:doc (story/variant->edn :story.button/wire)))))))
 
+;; ---------------------------------------------------------------------------
+;; EDN reader hardening on register-variant :body (rf2-g9fje fix 2/3)
+;;
+;; The EDN-string path through `tool-register-variant` is locked down per
+;; the rf2-uaymx audit: no tagged literals, no custom readers, 64KB size
+;; cap, 64-level depth cap. Pre-fix, `(edn/read-string body)` would happily
+;; eval `#=(...)` evaluator forms (when `*read-eval*` was true) or invoke
+;; any data reader on the `*data-readers*` table; post-fix the reader is
+;; `:readers {}` with a throwing `:default`, so any tagged-literal form
+;; lands in `::edn-error`.
+;; ---------------------------------------------------------------------------
+
+(deftest register-variant-rejects-tagged-literal
+  (testing "EDN body containing a custom tagged literal is rejected (rf2-g9fje)"
+    (config/set-allow-writes! true)
+    ;; Custom tags (non-EDN-built-in: not #inst / #uuid) route through the
+    ;; reader's :default handler, which throws under the rf2-g9fje
+    ;; hardening. The throw lands as ::edn-error → the "must be a map or
+    ;; a valid EDN string" error message.
+    (let [r (invoke "register-variant"
+                    {:variant-id "story.button/tagged"
+                     :body "{:doc #my.app/widget {:x 1}}"})]
+      (is (error? r))
+      (is (re-find #"(?i)must be a map or a valid EDN string" (-> r :content first :text))
+          "tagged literals route through the EDN-error message"))))
+
+(deftest register-variant-rejects-reader-eval-form
+  (testing "EDN body containing #=() does not evaluate (rf2-g9fje)"
+    (config/set-allow-writes! true)
+    ;; `#=(...)` is the read-time eval form. `clojure.edn/read-string`
+    ;; ignores `*read-eval*` and rejects it as a tagged literal under
+    ;; our throwing :default. The body should be refused.
+    (let [r (invoke "register-variant"
+                    {:variant-id "story.button/eval"
+                     :body "{:doc #=(println \"PWNED\") :args {}}"})]
+      (is (error? r)
+          "the #= eval form must be rejected before any side-effect can fire"))))
+
+(deftest register-variant-rejects-oversize-edn-body
+  (testing "EDN body exceeding the 64KB ceiling is rejected (rf2-g9fje)"
+    (config/set-allow-writes! true)
+    (let [big-doc (apply str (repeat (* 70 1024) \x))
+          r       (invoke "register-variant"
+                          {:variant-id "story.button/oversize"
+                           :body       (str "{:doc \"" big-doc "\"}")})]
+      (is (error? r))
+      (is (re-find #"(?i)must be a map or a valid EDN string" (-> r :content first :text))
+          "oversize payload routes through the EDN-error message"))))
+
+(deftest register-variant-rejects-over-deep-edn-body
+  (testing "EDN body exceeding the 64-level depth ceiling is rejected (rf2-g9fje)"
+    (config/set-allow-writes! true)
+    ;; Build a 100-level nested map by string concatenation; well past the
+    ;; 64 ceiling. The depth check runs AFTER `edn/read-string` parses, so
+    ;; the rejection happens before the registrar sees the value.
+    (let [deep-edn (str (apply str (repeat 100 "{:a "))
+                        "1"
+                        (apply str (repeat 100 "}")))
+          r        (invoke "register-variant"
+                           {:variant-id "story.button/deep"
+                            :body       deep-edn})]
+      (is (error? r))
+      (is (re-find #"(?i)must be a map or a valid EDN string" (-> r :content first :text))))))
+
 (deftest register-variant-rejects-bad-shape
   (testing "registration with an invalid body returns a tool-execution error"
     (config/set-allow-writes! true)

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -61,6 +61,10 @@
   (story/clear-all!)
   (story/install-canonical-vocabulary!)
   (config/set-allow-writes! false)
+  ;; rf2-g9fje — sensitive-read gate. Default off everywhere (mirrors
+  ;; the `--allow-sensitive-reads` boot-time posture). Tests that
+  ;; exercise the opt-in branch flip it explicitly.
+  (config/set-allow-sensitive-reads! false)
   ;; Recorder atom is per-process — clear between tests so a previous
   ;; test's captured events don't bleed in.
   (recorder/clear!)
@@ -1184,6 +1188,7 @@
 
 (deftest preview-variant-app-db-includes-sensitive-when-opted-in
   (testing ":include-sensitive? true forwards the raw value through the walker"
+    (config/set-allow-sensitive-reads! true)
     (with-clean-frame [vid :story.button/primary]
       (seed-app-db! vid {:public "ok" :secret "TOPSECRET"})
       (declare-sensitive! vid [:secret])
@@ -1210,6 +1215,7 @@
 
 (deftest run-variant-app-db-includes-sensitive-when-opted-in
   (testing "run-variant's :include-sensitive? true forwards the raw value"
+    (config/set-allow-sensitive-reads! true)
     (with-clean-frame [vid :story.button/primary]
       (seed-app-db! vid {:public "ok" :secret "TOPSECRET"})
       (declare-sensitive! vid [:secret])
@@ -1293,6 +1299,7 @@
 
 (deftest read-failures-includes-sensitive-when-opted-in
   (testing ":include-sensitive? true preserves sensitive records"
+    (config/set-allow-sensitive-reads! true)
     (with-clean-frame [vid :story.button/primary]
       (seed-app-db! vid
                     {:rf.story/assertions
@@ -1319,6 +1326,111 @@
             (str tname " missing :include-sensitive? slot"))
         (is (= "boolean" (-> props :include-sensitive? :type))
             (str tname " :include-sensitive? slot is not boolean-typed"))))))
+
+;; ---------------------------------------------------------------------------
+;; Sensitive-read boot gate (rf2-g9fje)
+;;
+;; Per the rf2-uaymx (b) decision: the per-call `:include-sensitive?` arg
+;; is honoured ONLY when the operator opened the server-side gate at boot
+;; (`--allow-sensitive-reads`). When the gate is closed:
+;;
+;;   1. `tools/list` omits `:include-sensitive?` from the input schemas of
+;;      preview-variant / run-variant / read-failures (caller UX — no
+;;      ghost knob).
+;;   2. `:include-sensitive? true` on a tool call is silently ignored at
+;;      the egress helpers (defence-in-depth — even a caller who learned
+;;      about the slot some other way can't exfiltrate raw values).
+;; ---------------------------------------------------------------------------
+
+(deftest sensitive-reads-gate-defaults-closed
+  (testing "fixture leaves the gate closed by default"
+    (is (false? (config/sensitive-reads-allowed?))
+        "fixture must reset the gate between tests")))
+
+(deftest sensitive-reads-gate-flag-flips-config
+  (testing "--allow-sensitive-reads flag flips the boot config"
+    (let [cfg (#'server/parse-args ["--allow-sensitive-reads"])]
+      (is (true? (:allow-sensitive-reads? cfg))))
+    (let [cfg (#'server/parse-args [])]
+      (is (nil? (:allow-sensitive-reads? cfg))
+          "absent flag leaves the slot unset so merge respects sysprop/env defaults"))))
+
+(deftest tools-list-strips-include-sensitive-when-gate-closed
+  (testing "tools/list omits :include-sensitive? from the schema when the gate is closed"
+    (is (false? (config/sensitive-reads-allowed?)))
+    (let [descriptors (registry/tool-descriptors)]
+      (doseq [tname ["preview-variant" "run-variant" "read-failures"]]
+        (let [t     (some #(when (= tname (:name %)) %) descriptors)
+              props (-> t :inputSchema :properties)]
+          (is (not (contains? props :include-sensitive?))
+              (str "gate closed: " tname " must not advertise :include-sensitive?")))))))
+
+(deftest tools-list-surfaces-include-sensitive-when-gate-open
+  (testing "tools/list advertises :include-sensitive? when the gate is open"
+    (config/set-allow-sensitive-reads! true)
+    (let [descriptors (registry/tool-descriptors)]
+      (doseq [tname ["preview-variant" "run-variant" "read-failures"]]
+        (let [t     (some #(when (= tname (:name %)) %) descriptors)
+              props (-> t :inputSchema :properties)]
+          (is (contains? props :include-sensitive?)
+              (str "gate open: " tname " must advertise :include-sensitive?"))
+          (is (= "boolean" (-> props :include-sensitive? :type))))))))
+
+(deftest preview-variant-gate-closed-ignores-per-call-flag
+  (testing "with gate closed, :include-sensitive? true is silently ignored at egress"
+    (is (false? (config/sensitive-reads-allowed?)))
+    (with-clean-frame [vid :story.button/primary]
+      (seed-app-db! vid {:public "ok" :secret "TOPSECRET"})
+      (declare-sensitive! vid [:secret])
+      (let [r (invoke "preview-variant" {:variant-id "story.button/primary"
+                                         :include-sensitive? true})
+            s (:structuredContent r)]
+        (is (success? r))
+        (is (= :rf/redacted (get-in s [:app-db :secret]))
+            "gate closed: per-call opt-in is dropped; redaction stands")))))
+
+(deftest run-variant-gate-closed-ignores-per-call-flag
+  (testing "with gate closed, :include-sensitive? true is silently ignored at egress"
+    (is (false? (config/sensitive-reads-allowed?)))
+    (with-clean-frame [vid :story.button/primary]
+      (seed-app-db! vid {:public "ok" :secret "TOPSECRET"})
+      (declare-sensitive! vid [:secret])
+      (let [r (invoke "run-variant" {:variant-id "story.button/primary"
+                                     :include-sensitive? true})
+            s (:structuredContent r)]
+        (is (success? r))
+        (is (= :rf/redacted (get-in s [:app-db :secret]))
+            "gate closed: per-call opt-in is dropped; redaction stands")))))
+
+(deftest read-failures-gate-closed-ignores-per-call-flag
+  (testing "with gate closed, :include-sensitive? true does not surface sensitive records"
+    (is (false? (config/sensitive-reads-allowed?)))
+    (with-clean-frame [vid :story.button/primary]
+      (seed-app-db! vid
+                    {:rf.story/assertions
+                     [{:assertion :rf.assert/path-equals :passed? true}
+                      {:assertion  :rf.assert/path-equals
+                       :passed?    false
+                       :sensitive? true
+                       :reason     "leak"}]})
+      (let [r (invoke "read-failures" {:variant-id "story.button/primary"
+                                       :include-sensitive? true})
+            s (:structuredContent r)]
+        (is (success? r))
+        (is (= 1 (:total s))
+            "gate closed: sensitive records remain dropped despite the opt-in")))))
+
+(deftest read-boot-config-sensitive-reads-sysprop
+  (testing "JVM sysprop seeds :allow-sensitive-reads? true"
+    (let [restore (System/getProperty "rf.story-mcp.allow-sensitive-reads")]
+      (try
+        (System/setProperty "rf.story-mcp.allow-sensitive-reads" "true")
+        (let [cfg (config/read-boot-config)]
+          (is (true? (:allow-sensitive-reads? cfg))))
+        (finally
+          (if restore
+            (System/setProperty "rf.story-mcp.allow-sensitive-reads" restore)
+            (System/clearProperty "rf.story-mcp.allow-sensitive-reads")))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Agent-onboarding text parity (rf2-36upq S5)


### PR DESCRIPTION
## Summary

2-bead micro-cluster (rf2-g9fje + rf2-lqjbk) — closes the four remaining open story-mcp security findings from rf2-uaymx and the rf2-ih7g4 caller-site sweep, in one PR with four sequenced commits.

### C1 — Boot-time sensitive-read gate (rf2-g9fje fix 1/3, HIGH)

New `--allow-sensitive-reads` CLI flag (symmetric with `--allow-writes` and pair2-mcp's `--allow-eval`). Closed by default; the per-call `:include-sensitive?` arg is now honoured ONLY when the gate is also open. When closed:

- `tools/list` strips `:include-sensitive?` from the schemas of `preview-variant` / `run-variant` / `read-failures` (clean UX).
- The wire-egress helpers silently ignore any caller-supplied `:include-sensitive? true` (defence-in-depth — declared-sensitive `:app-db` paths remain `:rf/redacted`; assertion records stamped `:sensitive? true` remain dropped).
- Server logs one boot line: `Sensitive reads: gated (default; pass --allow-sensitive-reads to opt in)`.

Three input paths: CLI flag, JVM sysprop `rf.story-mcp.allow-sensitive-reads`, env var `RF_STORY_MCP_ALLOW_SENSITIVE_READS`.

### C2 — EDN reader hardening on register-variant :body (rf2-g9fje fix 2/3)

The EDN-string `:body` path (retained because mcp-conformance and similar callers register variants whose body shape needs keyword-typed slots like `:tags #{:dev}` that JSON can't round-trip) is now locked down:

- `:readers {}` (no custom tag handlers) + throwing `:default` — custom `#<tag>` literals reject; `#=(...)` is rejected by `clojure.edn` at dispatch-macro level (never evaluates).
- 64 KB payload ceiling.
- 64-level depth ceiling.

The JSON-object body path is unchanged and remains the preferred shape.

### C3 — DoS bounds (rf2-g9fje fix 3/3)

- `run-variant` `:timeout-ms` clamps DOWN to 30 s (matches `:rf.http/timeout-ms` baseline per rf2-it1cd). Caller-controlled values above the ceiling run against the cap rather than reject.
- `record-as-variant` `:duration-ms` already capped at 30 s (rf2-4yuhi); kept aligned.
- Protocol-side `read-frame` now caps each inbound JSON-RPC frame at 4 MB. An oversize frame throws `:rf.error/frame-too-large`; the run-loop converts it to a parse-error response and drains the over-cap bytes so the next frame lands on a fresh boundary.

Cancellation is implicit via the bounded timeouts: worst-case loop park is now 30 s rather than indefinite.

### C4 — parse-keyword → safe-keyword sweep (rf2-lqjbk)

Caller-supplied keyword ids on the read surface now route through `args/safe-keyword` against a bounded registry-key set — `find-keyword`-backed, so an unknown id never interns a fresh JVM keyword. Sweeps `:variant-id` / `:substrate` / `:active-modes` / `:story-id` / `:tags` / `:extends` / `:kind` across helpers / docs / recorder. Tests pin the no-intern property via `find-keyword` probes after each reject path.

Write-side `register-variant` keeps the legacy `parse-keyword` intern (documented exception: BY DESIGN extends the registry; gated by `--allow-writes`).

## Test plan

- [x] `tools/story-mcp/` `clojure -M:test` — 124 tests, 596 assertions, 0 failures.
- [x] `implementation/` `npm run test:cljs` — 2014 tests, 5695 assertions, 0 failures.
- [x] `implementation/` `npm run test:bundle-isolation` — PASS.
- [x] `tools/mcp-conformance/` `npm run test:story` — end-to-end against live story-mcp subprocess, GREEN.

## Spec updates

- `tools/story-mcp/spec/001-Wire-Protocol.md` — documents the 4 MB frame-size cap.
- `tools/story-mcp/spec/002-Tool-Registry.md` — documents the sensitive-read boot gate (three-input-path table) and the `:timeout-ms` ceiling.
- `tools/story-mcp/spec/API.md` — documents the gate-aware `:include-sensitive?` slot, the `:timeout-ms` cap, and the hardened EDN reader policy on `register-variant :body`.

## Closes

- rf2-g9fje
- rf2-lqjbk