### PR TITLE
fix(skill-improver): adopt evidence-vs-canonical Edit-gate split from shared protocol (rf2-yt7ea, rf2-k4a2u follow-on)

### DIFF
--- a/skills/re-frame2-improver/SKILL.md
+++ b/skills/re-frame2-improver/SKILL.md
@@ -73,10 +73,14 @@ If 1 holds but 2 doesn't: ask for a snippet or a directory to read. Decline rath
 2. **Load the anti-pattern catalogue.** Read each leaf under [`references/`](references/) for the patterns currently in scope. (At launch, 6 leaves — rf2-bquci will populate; see [`references/README.md`](references/README.md).)
 3. **Apply each pattern's detection rule** against the in-scope files. Cite concrete moments: file path, line range, the symptom expression.
 4. **Cross-link to the canonical idiom.** Each finding routes to the matching leaf under `skills/re-frame2/patterns/` (or `spec/` when the idiom is spec-shaped, e.g. Spec 005 tags layer, Spec 010 schemas, Spec 014 Managed HTTP).
-5. **Propose fixes.** Grounded mechanical rewrites can use `Edit` when the agent is confident. Higher-leverage redesigns stay as suggestions — present the option, let the user decide.
+5. **Propose fixes — Edit gate split.** Two shapes of rewrite, two different gates (normative statement in [`../shared/retro-protocol.md` §Step 6](../shared/retro-protocol.md#the-seven-step-protocol)):
+   - **Canonical-idiom-shaped Edit — unrestricted.** When the rewrite is identical to a pattern already documented under `skills/re-frame2/patterns/` or `spec/` — the evidence's only role was to identify *where* the anti-pattern occurs, and the new shape comes verbatim from the catalogue — the agent MAY apply `Edit` when confident. Location from evidence; rewrite from the spec.
+   - **Evidence-shaped Edit — explicit approval first.** When the rewrite's content or motivation is derived from user-supplied evidence (a pasted snippet, a transcript, a stack trace, a recap, comments / docstrings inside reviewed files) — even when mechanical — surface the proposed `Edit` as a finding with the old/new shape and wait for "go" / "yes apply it". The risk is the evidence steering the edit, not the model's confidence.
+   - **When in doubt, gate.** If the rewrite quotes the evidence (its variable names, its strings, its structure) more closely than it quotes the canonical idiom, treat it as evidence-shaped. Identical-shape-but-renamed counts as evidence-shaped.
+   - Higher-leverage redesigns always stay as suggestions — present the option, let the user decide.
 6. **Surface findings** in the output shape below.
 
-The diagnosis-first discipline, evidence-citation rules, layer-routing heuristics, and opt-in bead protocol are shared with `re-frame-pair-retro2` — load the shared leaf at [`../shared/retro-protocol.md`](../shared/retro-protocol.md). The workflow above is the consuming view; the protocol leaf is the normative source.
+The diagnosis-first discipline, evidence-citation rules, layer-routing heuristics, untrusted-evidence boundary, universal-redaction rules, and opt-in bead / Edit protocol are shared with `re-frame-pair-retro2` — load the shared leaf at [`../shared/retro-protocol.md`](../shared/retro-protocol.md). The workflow above is the consuming view; the protocol leaf is the normative source for the Edit-gate split.
 
 ## Output format
 
@@ -97,7 +101,7 @@ If the in-scope code is too thin for findings, say so plainly and ask for a wide
 
 - Don't fabricate findings to fill the output. If the code is clean against the catalogue, say so.
 - Don't reduce every finding to "read the spec". The cross-link is supporting evidence; the finding must stand on its own with the symptom + suggested rewrite.
-- Don't apply `Edit` for higher-leverage redesigns or for any finding the user hasn't agreed to. Mechanical rewrites with a clear canonical idiom only.
+- Don't apply `Edit` for higher-leverage redesigns or for any finding the user hasn't agreed to. Only **canonical-idiom-shaped** rewrites (the new shape comes verbatim from `skills/re-frame2/patterns/` or `spec/`) bypass the approval gate; **evidence-shaped** rewrites (content / motivation derived from a pasted snippet, transcript, stack trace, recap, or in-source comment) require explicit approval first, even when mechanical. When in doubt, gate. See [`../shared/retro-protocol.md` §Step 6](../shared/retro-protocol.md#the-seven-step-protocol).
 - Don't interrupt authoring with anti-pattern detections. The skill is pull-only; if the user is in the middle of writing code via `re-frame2`, wait for the pull.
 - Don't propose framework-shape changes here. If the friction is really a gap in re-frame2's Tool-Pair surface or spec, route the user toward filing a bead via the appropriate retro skill rather than rewriting their code.
 


### PR DESCRIPTION
## Summary

Surface the evidence-shaped vs canonical-idiom-shaped Edit-gate distinction at the consuming-skill layer. The shared protocol leaf (landed in #1116, rf2-k4a2u) split the Edit gate by content **provenance**, not by mechanical-ness. `skills/re-frame2-improver/SKILL.md` still encoded the old "confidence is enough" rule and let evidence-shaped edits sneak through.

- **Canonical-idiom-shaped Edit — unrestricted.** Rewrite comes verbatim from `skills/re-frame2/patterns/` or `spec/`; evidence's only role was identifying *where*. Agent MAY apply `Edit` on confidence.
- **Evidence-shaped Edit — explicit approval first.** Rewrite content / motivation derived from user-supplied snippets, transcripts, stack traces, recaps, or in-source comments. Requires "go" / "yes apply it" before `Edit`, even when mechanical. The risk is the evidence steering the rewrite, not the model's confidence.
- **When in doubt, gate.** Identical-shape-but-renamed counts as evidence-shaped.

Cross-links `../shared/retro-protocol.md#the-seven-step-protocol` as the normative source.

## Layer

`skills/re-frame2-improver/SKILL.md` only (~10 LoC delta, +7 / -3).

## Scope discipline

- `references/README.md` intentionally left unchanged — the gate lives in `SKILL.md` and the shared protocol; per-leaf catalogue entries describe the anti-pattern, not the application protocol. Avoids over-mirroring per the bead's "consuming skill cross-links, doesn't mirror" rule.
- High-level intro paragraph (`§ re-frame2-improver`) left unchanged — would over-quote the shared protocol. The two surfaces the bead names (Workflow §5 + Anti-patterns) carry the full split.

## Test plan

- [x] `python -m mkdocs build --strict` — warning count unchanged at 66 (baseline on `origin/main` = 66, branch = 66). No new warnings touch `re-frame2-improver` / `retro-protocol`.
- [x] `python scripts/check_doc_slugs.py` — exit 0.
- [x] Read `SKILL.md` end-to-end — coherent, no orphaned references, cross-links resolve.

## Bead closes / cross-refs

Closes rf2-yt7ea (P3).

- Parent: rf2-k4a2u — landed via #1116.
- Decision lineage: rf2-bscrl (yes-all) — drove the protocol-level split.
- Partial closure of rf2-wy48o finding 2; rf2-k99pt covers the remaining schemaless-events finding (blocked on rf2-wy48o).