### PR TITLE
feat(testbeds-tests): rf2-fe84r cross-cutting 6 scenarios (partial dispatch)

### DIFF
--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -264,6 +264,58 @@ const EXAMPLES = [
     htmlSrc: path.join(REPO_ROOT, 'testbeds', 'ssr_multi_frame', 'index.html'),
     outDir: path.join(OUT_ROOT, 'testbed-ssr-multi-frame'),
   },
+  // rf2-fe84r cross-cutting six — shared framework-behavior testbed
+  // surfaces. Unlike the SSR testbeds above (whose shadow-cljs
+  // builds emit directly into `out/examples/testbed-<id>/`), the
+  // rf2-kzcim testbeds emit into `out/testbeds/<id>/` and the
+  // orchestrator copies the bundle into `OUT_ROOT/testbeds/<id>/`
+  // so http-server serves it under the same origin as the examples.
+  // The `bundleSrc` field opts a build into the bundle-copy step.
+  // The two staging conventions coexist; rf2-ik4io and rf2-kzcim
+  // each made a defensible decision at their time and the
+  // orchestrator handles both.
+  {
+    build: 'testbeds/deliberate-throw',
+    htmlSrc: path.join(REPO_ROOT, 'testbeds', 'deliberate_throw', 'index.html'),
+    bundleSrc: path.join(IMPL_ROOT, 'out', 'testbeds', 'deliberate-throw'),
+    outDir: path.join(OUT_ROOT, 'testbeds', 'deliberate-throw'),
+  },
+  {
+    build: 'testbeds/http-toggle',
+    htmlSrc: path.join(REPO_ROOT, 'testbeds', 'http_toggle', 'index.html'),
+    bundleSrc: path.join(IMPL_ROOT, 'out', 'testbeds', 'http-toggle'),
+    outDir: path.join(OUT_ROOT, 'testbeds', 'http-toggle'),
+    extraFiles: [
+      {
+        src: path.join(REPO_ROOT, 'testbeds', 'http_toggle', 'api', 'success.json'),
+        dest: path.join('api', 'success.json'),
+      },
+    ],
+  },
+  {
+    build: 'testbeds/deep-machine',
+    htmlSrc: path.join(REPO_ROOT, 'testbeds', 'deep_machine', 'index.html'),
+    bundleSrc: path.join(IMPL_ROOT, 'out', 'testbeds', 'deep-machine'),
+    outDir: path.join(OUT_ROOT, 'testbeds', 'deep-machine'),
+  },
+  {
+    build: 'testbeds/non-trivial-app-db',
+    htmlSrc: path.join(REPO_ROOT, 'testbeds', 'non_trivial_app_db', 'index.html'),
+    bundleSrc: path.join(IMPL_ROOT, 'out', 'testbeds', 'non-trivial-app-db'),
+    outDir: path.join(OUT_ROOT, 'testbeds', 'non-trivial-app-db'),
+  },
+  {
+    build: 'testbeds/long-flow-w-failure',
+    htmlSrc: path.join(REPO_ROOT, 'testbeds', 'long_flow_w_failure', 'index.html'),
+    bundleSrc: path.join(IMPL_ROOT, 'out', 'testbeds', 'long-flow-w-failure'),
+    outDir: path.join(OUT_ROOT, 'testbeds', 'long-flow-w-failure'),
+  },
+  {
+    build: 'testbeds/drain-depth-trigger',
+    htmlSrc: path.join(REPO_ROOT, 'testbeds', 'drain_depth_trigger', 'index.html'),
+    bundleSrc: path.join(IMPL_ROOT, 'out', 'testbeds', 'drain-depth-trigger'),
+    outDir: path.join(OUT_ROOT, 'testbeds', 'drain-depth-trigger'),
+  },
 ];
 
 function compileAll() {
@@ -285,10 +337,41 @@ function compileAll() {
   }
 }
 
+function copyDirRecursive(src, dest) {
+  // Minimal recursive copy. Used only for `bundleSrc` — staging a
+  // shadow-cljs build whose `:output-dir` lives outside `OUT_ROOT`
+  // (testbed surfaces, rf2-fe84r) into the served tree. Each file
+  // overwrites the destination unconditionally so repeat runs pick up
+  // re-compiled bundles.
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const s = path.join(src, entry.name);
+    const d = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDirRecursive(s, d);
+    } else if (entry.isFile()) {
+      fs.copyFileSync(s, d);
+    }
+  }
+}
+
 function stageHtml() {
   // Silent-on-success (rf2-try1x): per-file staging notices are
   // suppressed.  Errors still throw with the offending path.
   for (const ex of EXAMPLES) {
+    // rf2-fe84r — testbed surfaces ship their shadow-cljs `:output-dir`
+    // outside OUT_ROOT (per the per-surface `:testbeds/<name>` build's
+    // `out/testbeds/<name>` setting). Stage the compiled bundle into
+    // OUT_ROOT first so the static server picks it up under the
+    // expected URL path. Examples that emit straight into OUT_ROOT
+    // omit `bundleSrc` and skip this step.
+    if (ex.bundleSrc) {
+      if (!fs.existsSync(ex.bundleSrc)) {
+        throw new Error(`Bundle source missing: ${ex.bundleSrc}`);
+      }
+      copyDirRecursive(ex.bundleSrc, ex.outDir);
+    }
+
     if (!fs.existsSync(ex.outDir)) {
       throw new Error(`Build output dir missing: ${ex.outDir}`);
     }

--- a/testbeds/deep_machine/spec.cjs
+++ b/testbeds/deep_machine/spec.cjs
@@ -1,0 +1,162 @@
+/*
+ * Cross-cutting scenario #3 of 6 from rf2-fe84r §Section B.
+ *
+ *   "State-machine transition cascade shows `:rf.machine/*` events."
+ *
+ * Exercises `testbeds/deep_machine/` (rf2-kzcim). The surface ships
+ * one parent machine `:deep/main` with parallel regions (`:work` +
+ * `:health`), a 5-deep compound hierarchy under `:work`, and `:invoke`
+ * / `:invoke-all` declarations that spawn child machines.
+ *
+ * What "`:rf.machine/*` events" means here — the machines artefact
+ * emits a family of trace events through `re-frame.trace/emit!` whose
+ * `:operation` keywords are all in the `:rf.machine/*` namespace
+ * (per `implementation/machines/src/.../lifecycle_fx/`):
+ *
+ *   - `:rf.machine/transition`           on every state transition
+ *   - `:rf.machine/snapshot-updated`     after snapshot commit
+ *   - `:rf.machine/event-received`       on event arrival
+ *   - `:rf.machine/spawned`              on `:invoke` child start
+ *   - `:rf.machine/destroyed`            on `:invoke` child stop
+ *   - `:rf.machine/system-id-bound`      on spawn-id binding
+ *   - `:rf.machine/system-id-released`   on destroy
+ *
+ * Asserting the trace bus carries `:rf.machine/transition` (and at
+ * least one `:rf.machine/snapshot-updated`) after a `:work/go` click
+ * proves the cascade emitted through the machine layer's trace path —
+ * the cross-cutting observable the bead names.
+ *
+ * Trigger choice — Button 1 (`:work/go`) descends five compound levels
+ * in one transition (region root → `:phase-a` → `:sub-a` → `:nested-a`
+ * → `:deep-a` → `:leaf-a`), then `:invoke`'s the `:helper/tick` child
+ * on `:leaf-a` entry. The cascade therefore emits BOTH transition
+ * traces AND spawn traces in one click — the densest single
+ * observation of the machine layer's emit surface.
+ */
+
+const path = require('path');
+const { expectVisible, expectTextEquals } = require(
+  path.join('..', '..', 'examples', 'scripts', 'spec-helpers.cjs'),
+);
+const { readTraceEventsAsEdn, clearTraceBus, pollUntil } = require(
+  path.join('..', 'spec-helpers.cjs'),
+);
+
+module.exports = {
+  // The testbed's `:phase-b` `:invoke-all` declaration is stale per
+  // current Spec 005 §Spawn-and-join: the validator at
+  // `re-frame.machines.lifecycle_fx.validation/validate-invoke-all!`
+  // (rf2-6vmw) requires `:on-child-done`, `:on-child-error`, and
+  // `:on-all-complete` (vector) — the testbed declares `:on-all-done`
+  // (a single keyword), so `(rf/reg-machine :deep/main ...)` throws
+  // at module-load time and the page never mounts. Per the rf2-fe84r
+  // dispatch boundaries, this spec cannot touch the testbed
+  // `core.cljs`; the surface needs a fix in its own bead before the
+  // scenario can land. Skipping pins the file at the canonical
+  // location with the reason; unskipping is a one-line revert once
+  // the surface fix ships.
+  skip: 'deep_machine/core.cljs declares :on-all-done; validator requires :on-child-done/:on-child-error/:on-all-complete (stale per rf2-6vmw). Filed for follow-up.',
+  name: 'cross-cutting #3 — state-machine transition cascade',
+  url: '/testbeds/deep-machine/',
+  run: async (page) => {
+    await expectVisible(page.locator('[data-testid="deep-machine"]'), 10000);
+
+    // The testbed's `::initialise` dispatches the parent machine's
+    // `:rf.machine/bootstrap` event on boot. By the time the root
+    // testid is visible, the parent has settled into its initial
+    // parallel-region state — `:work` at `:idle`, `:health` at
+    // `:cold`. The work-state mirror reflects that.
+    //
+    // Reading the state from app-db via the rendered text proves
+    // the framework's `:rf/machine` sub-graph resolves correctly
+    // — but isn't the cross-cutting contract. The contract is the
+    // trace stream; the DOM mirror is the precondition check that
+    // says "init landed cleanly, fire the trigger".
+    await expectTextEquals(page.locator('[data-testid="work-state"]'), ':idle', 10000);
+
+    // Clear the trace bus so the find() below scopes to the events
+    // emitted by this click — the bootstrap cascade and substrate
+    // init landed dozens of unrelated `:event/*` traces beforehand.
+    const cleared = await clearTraceBus(page);
+    if (!cleared.ok) {
+      throw new Error(`could not clear trace bus: ${cleared.reason}`);
+    }
+
+    // Drive `:work/go` — the transition descends five compound levels
+    // in one cascade. Per Spec 005 §Compound state entry: the runtime
+    // walks `:phase-a` → `:sub-a` → `:nested-a` → `:deep-a` → `:leaf-a`,
+    // firing `:entry` actions at each rung. The `:leaf-a` rung also
+    // hosts the `:invoke {:machine-id :helper/tick ...}` declaration,
+    // so a `:helper/tick` child spawns on entry.
+    await page.locator('[data-testid="work-go"]').click();
+
+    // The work-state mirror flips off `:idle` once the transition
+    // cascade settles. Per `re-frame.machines.transition/denormalise-
+    // state` the 5-level descent renders as a vector path
+    // `[:phase-a :sub-a :nested-a :deep-a :leaf-a]` (a single-keyword
+    // form is reserved for length-1 paths). Asserting "no longer
+    // :idle" is the substrate-observable that says the cascade
+    // committed; the exact path form is a separate scenario.
+    {
+      const workState = page.locator('[data-testid="work-state"]');
+      const start = Date.now();
+      let last = '';
+      while (Date.now() - start < 10000) {
+        last = (await workState.textContent())?.trim() || '';
+        if (last && last !== ':idle') break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      if (!last || last === ':idle') {
+        throw new Error(
+          `:work region did not transition off :idle after :work/go click (last="${last}")`,
+        );
+      }
+    }
+
+    // Walk the trace bus for the cross-cutting contract — at least
+    // one `:rf.machine/transition` AND one `:rf.machine/snapshot-
+    // updated` from the cascade. Both fire from
+    // `re-frame.machines.lifecycle_fx.registration` (lines 331, 337
+    // per the canonical implementation). A cascade that drove
+    // FIVE transitions in one drain should produce FIVE
+    // `:rf.machine/transition` emits, but the cross-cutting contract
+    // only requires presence — counting them would test the spawn
+    // semantics, which is a separate scenario.
+    const events = await pollUntil(async () => {
+      const probe = await readTraceEventsAsEdn(page);
+      if (!probe.ok) throw new Error(`could not read trace bus: ${probe.reason}`);
+      const transitions = probe.events.filter((s) =>
+        /:operation\s+:rf\.machine\/transition/.test(s),
+      );
+      const snapshots = probe.events.filter((s) =>
+        /:operation\s+:rf\.machine\/snapshot-updated/.test(s),
+      );
+      if (transitions.length >= 1 && snapshots.length >= 1) {
+        return { transitions, snapshots, all: probe.events };
+      }
+      return null;
+    }, ':rf.machine/transition + :rf.machine/snapshot-updated trace events after :work/go click', 10000);
+
+    // Spawn observation — the `:leaf-a` `:invoke` declaration fires
+    // a `:rf.machine/spawned` emit through
+    // `lifecycle_fx/spawn.cljc:209`. The cascade is part of the same
+    // drain so a `:rf.machine/spawned` is necessarily in the buffer
+    // by the time the work-state mirror lands at `:leaf-a`.
+    const spawned = events.all.filter((s) =>
+      /:operation\s+:rf\.machine\/spawned/.test(s),
+    );
+    if (spawned.length === 0) {
+      throw new Error(
+        ':leaf-a entry should fire :rf.machine/spawned (`:invoke {:machine-id :helper/tick}`); not observed in trace bus',
+      );
+    }
+
+    // Tick-count check — the `:leaf-a` `:entry` action `:bump-tick`
+    // fires once on entry, so the parent's `:data :tick-count` lands
+    // at 1. This is the substrate's proof that the action body
+    // executed (a transition can emit `:rf.machine/transition`
+    // without the entry action firing only in a broken implementation;
+    // reading the post-action data slot confirms end-to-end).
+    await expectTextEquals(page.locator('[data-testid="tick-count"]'), '1', 5000);
+  },
+};

--- a/testbeds/deliberate_throw/spec.cjs
+++ b/testbeds/deliberate_throw/spec.cjs
@@ -1,0 +1,116 @@
+/*
+ * Cross-cutting scenario #1 of 6 from rf2-fe84r §Section B.
+ *
+ *   "Deliberately-throwing handler surfaces structured trace in both
+ *    Causa + Story `:play`."
+ *
+ * Exercises `testbeds/deliberate_throw/` (rf2-kzcim). The surface ships
+ * four trigger sites — handler / fx / flow / machine. This spec drives
+ * Button A (handler-exception), the canonical case: a synchronous throw
+ * in the event-handler body. The runtime's outer interceptor catches
+ * and emits a structured `:rf.error/handler-exception` trace event
+ * with `:op-type :error`, the failing handler's id, the original
+ * message, and a `:where :handler` tag (per Spec 009 §Error contract).
+ *
+ * What "structured trace" means here — the trace event the framework
+ * lands on the trace bus after the throw carries:
+ *
+ *   - `:operation :rf.error/handler-exception` (the category)
+ *   - `:op-type :error` (severity tier)
+ *   - `:tags { :exception ... :where :handler ... }` (the structured
+ *     detail). The Story `:play` replay path AND Causa's trace panel
+ *     both consume off this single bus, so asserting on the framework
+ *     trace event is the cross-cutting observable that proves the
+ *     contract holds independent of which tool is consuming.
+ *
+ * Observation surface — every testbed wires `day8.re-frame2-causa.preload`
+ * via shadow-cljs `:devtools/:preloads`, which registers Causa's
+ * `:rf.causa/trace-collector` callback against the framework's trace
+ * bus. Reading `day8.re_frame2_causa.trace_bus.buffer()` returns the
+ * same CLJS vector of trace-event maps the framework deposited. The
+ * preload's collector runs whether the user opened Causa or not, so
+ * the spec stays a framework-behavior observation (no shell mount, no
+ * panel render required).
+ *
+ * Recovery posture — handler-exception is `:no-recovery` per Spec 009.
+ * The router's `emit-handler-exception!` (re-frame/routing.cljc:285)
+ * captures the exception into `:rf/interceptor-error` rather than
+ * re-throwing; the drain continues, the failing handler's `:db` is
+ * dropped, no pageerror bubbles. So this spec does NOT need to
+ * intercept `page.on('pageerror', ...)` — the runner's pageerror gate
+ * stays clean.
+ */
+
+const path = require('path');
+const { expectVisible } = require(path.join('..', '..', 'examples', 'scripts', 'spec-helpers.cjs'));
+const { readTraceEventsAsEdn, pollUntil } = require(path.join('..', 'spec-helpers.cjs'));
+
+module.exports = {
+  name: 'cross-cutting #1 — deliberate-throw structured trace',
+  url: '/testbeds/deliberate-throw/',
+  run: async (page) => {
+    // The surface mounts a four-button view; wait for the root testid
+    // so we know the substrate has initialised and event registration
+    // has run. The buttons fan dispatches at the framework via
+    // reagent-adapter → router → trace bus.
+    await expectVisible(page.locator('[data-testid="deliberate-throw"]'), 10000);
+
+    // Pre-condition: the handler-counter mirror in app-db starts at 0.
+    // Button A's body throws as its first statement, so `:db` never
+    // commits and the mirror stays 0 after the click. Reading the
+    // mirror after the click is the rule-of-recovery assertion
+    // (handler-exception is `:no-recovery` per Spec 009).
+    const handlerCount = page.locator('[data-testid="handler-count"]');
+    if ((await handlerCount.textContent())?.trim() !== '0') {
+      throw new Error('handler-count did not start at 0');
+    }
+
+    // Drive Button A. The dispatched event ::throw-in-handler is a
+    // `reg-event-db` whose body's first statement is
+    // `(throw (ex-info "deliberate-throw / handler" {:where :handler}))`.
+    await page.locator('[data-testid="throw-handler"]').click();
+
+    // Poll the Causa-side trace bus mirror for the structured error
+    // event. The bus is the framework's emitted stream — Causa's
+    // preload registers a `:rf.causa/trace-collector` cb that pushes
+    // every framework emit into `trace_bus/buffer-state`. We render
+    // each event through `pr-str` to get a JS-comparable string.
+    //
+    // The cross-cutting contract — ONE event with:
+    //   :operation :rf.error/handler-exception
+    //   :op-type   :error
+    //   :tags carrying :where :handler (from the testbed's ex-data)
+    const match = await pollUntil(async () => {
+      const probe = await readTraceEventsAsEdn(page);
+      if (!probe.ok) {
+        throw new Error(`could not read trace bus: ${probe.reason}`);
+      }
+      return probe.events.find((s) =>
+        /:operation\s+:rf\.error\/handler-exception/.test(s) &&
+        /:op-type\s+:error/.test(s),
+      );
+    }, 'a :rf.error/handler-exception trace event with :op-type :error after Button A click');
+
+    // The `:where :handler` tag survives — it's the testbed's
+    // discriminator that confirms the framework hoisted the ex-data
+    // onto `:tags`. The testbed's throw site is `(throw (ex-info
+    // "..." {:where :handler}))`, and Spec 009 §Error contract requires
+    // ex-data tags to ride through onto `:tags` (the privacy walker
+    // may redact values but key presence is preserved).
+    if (!/:where\s+:handler/.test(match)) {
+      throw new Error(
+        `expected matched error event to carry :where :handler from the ex-info data; sample: ${match}`,
+      );
+    }
+
+    // Recovery posture: handler-exception is `:no-recovery` per Spec
+    // 009 — the failing handler's `:db` is suppressed. The mirror
+    // stays 0 after a click that should have bumped it (the testbed
+    // throws as its first statement so `:db` never commits).
+    if ((await handlerCount.textContent())?.trim() !== '0') {
+      throw new Error(
+        'handler-count advanced after Button A click — expected :no-recovery semantics to suppress the :db write',
+      );
+    }
+  },
+};

--- a/testbeds/drain_depth_trigger/spec.cjs
+++ b/testbeds/drain_depth_trigger/spec.cjs
@@ -1,0 +1,173 @@
+/*
+ * Cross-cutting scenario #6 of 6 from rf2-fe84r §Section B.
+ *
+ *   "Drain-depth-exceeded produces app-db rollback + `:halted-depth`
+ *    epoch record (rf2-v0jwt)."
+ *
+ * Exercises `testbeds/drain_depth_trigger/` (rf2-kzcim). The surface
+ * ships ONE handler `::recurse` that always dispatches another
+ * `::recurse` in its `:fx`. The frame's `:drain-depth` ceiling is
+ * configurable (defaults to 25 in the testbed; the framework
+ * default is 100); the runtime's run-to-completion drain hits the
+ * ceiling, atomically rolls back to the pre-drain `app-db` snapshot,
+ * and emits `:rf.error/drain-depth-exceeded`.
+ *
+ * What "`:halted-depth` epoch record" means here — per Spec
+ * Spec-Schemas §`:rf/epoch-record` Outcomes + rf2-v0jwt, the failing
+ * drain commits a single epoch record with:
+ *
+ *   :outcome     :halted-depth
+ *   :db-before   == :db-after   (atomic rollback semantics)
+ *   :halt-reason {:operation :rf.error/drain-depth-exceeded
+ *                 :depth <ceiling>}
+ *   :event-id    ::recurse              (the trigger event)
+ *   :trace-events seq of trace emits leading up to the halt
+ *
+ * The cross-cutting contract reads:
+ *   1. The halted record IS in `rf/epoch-history :rf/default`.
+ *   2. `:outcome` is `:halted-depth`.
+ *   3. `:db-before` equals `:db-after` — the rollback is atomic.
+ *   4. `:depth-reached` mirror in app-db reads back to 0 — the
+ *      handler's increments did NOT survive (the rollback wiped
+ *      them).
+ *
+ * Trigger choice — keep the testbed's default drain-depth of 25 (low
+ * enough for sub-second halt). Click Start. After the halt, the
+ * surface's `install-halt-listener!` dispatches `::halt-observed`
+ * which flips `:halted? true` — that drain runs cleanly AFTER the
+ * rollback, so we can also assert the listener-fired mirror to
+ * confirm the post-halt state machinery survived.
+ */
+
+const path = require('path');
+const { expectVisible, expectTextEquals } = require(
+  path.join('..', '..', 'examples', 'scripts', 'spec-helpers.cjs'),
+);
+const { readEpochHistoryAsEdn, pollUntil } = require(
+  path.join('..', 'spec-helpers.cjs'),
+);
+
+module.exports = {
+  name: 'cross-cutting #6 — drain-depth-exceeded rollback + :halted-depth epoch',
+  url: '/testbeds/drain-depth-trigger/',
+  run: async (page) => {
+    await expectVisible(page.locator('[data-testid="drain-depth-trigger"]'), 10000);
+
+    // Pre-conditions: the depth-reached mirror starts at 0, the
+    // halted? mirror reads "false", the ceiling is 25 (the testbed's
+    // default — we don't override).
+    await expectTextEquals(page.locator('[data-testid="depth-reached"]'), '0', 5000);
+    await expectTextEquals(page.locator('[data-testid="halted"]'), 'false', 5000);
+    await expectTextEquals(page.locator('[data-testid="drain-depth-mirror"]'), '25', 5000);
+
+    // Drive Start — `::recurse` dispatches itself in its `:fx`. The
+    // runtime processes the queue in a tight drain; each `::recurse`
+    // appends one more; the queue never empties; depth grows linearly
+    // with iteration count.
+    //
+    // Per Spec 002 §Run-to-completion rule 3: the drain is depth-
+    // bounded. When `:drain-depth` (25) is reached, the runtime
+    // atomically rolls back to the snapshot taken at the start of
+    // the drain. The handler's increments to `:depth-reached` are
+    // discarded.
+    await page.locator('[data-testid="start"]').click();
+
+    // ---- Rollback evidence — `:depth-reached` reads back to 0 ------
+    // Per Spec 002 rule 3 the rollback is atomic — the frame's
+    // app-db is restored to the snapshot taken at the START of the
+    // drain. `:depth-reached` was 0 at the start; the handler bumped
+    // it to 25 during the runaway cascade; the rollback wiped those
+    // bumps. The mirror reads 0 after the halt.
+    //
+    // Polling is required because the drain runs synchronously but
+    // the React re-render lands on the next microtask. The post-
+    // rollback mirror reading 0 — instead of 25 — is the canonical
+    // proof rule 3's atomic-rollback fired.
+    await expectTextEquals(page.locator('[data-testid="depth-reached"]'), '0', 10000);
+
+    // ---- Epoch record — `:outcome :halted-depth` --------------------
+    // Per rf2-v0jwt the failing drain commits a partial epoch record
+    // with `:outcome :halted-depth`. Read `rf/epoch-history :rf/default`
+    // (the testbed runs on the default frame) and walk for the record.
+    //
+    // The post-halt drain (from `::halt-observed`) commits a SECOND
+    // epoch record with `:outcome :ok`; we pin our assertion to the
+    // record whose outcome is `:halted-depth` to isolate from the
+    // post-halt success.
+    const records = await pollUntil(async () => {
+      const probe = await readEpochHistoryAsEdn(page);
+      if (!probe.ok) throw new Error(`could not read epoch history: ${probe.reason}`);
+      const halted = probe.records.find((s) => /:outcome\s+:halted-depth/.test(s));
+      if (halted) return { halted, all: probe.records };
+      return null;
+    }, ':outcome :halted-depth epoch record in rf/epoch-history :rf/default', 10000);
+
+    // The halted record carries the structured halt descriptor
+    // pointing at `:rf.error/drain-depth-exceeded`. Per the spec
+    // `:halt-reason` is a sub-map; we regex-match on the operation
+    // keyword inside it (pr-str renders nested maps inline so a
+    // single regex over the record's string form works).
+    if (!/:halt-reason\s+\{[^}]*:operation\s+:rf\.error\/drain-depth-exceeded/.test(records.halted)) {
+      throw new Error(
+        `:halt-reason should carry :operation :rf.error/drain-depth-exceeded; sample: ${records.halted}`,
+      );
+    }
+
+    // The record's `:depth` slot pins the drain's ceiling — 25 (the
+    // testbed's default-drain-depth). Reading `:depth` proves the
+    // record captured the frame's ceiling, not a stale framework
+    // default of 100.
+    if (!/:depth\s+25/.test(records.halted)) {
+      throw new Error(
+        `:halt-reason should carry :depth 25 (testbed's drain-depth ceiling); sample: ${records.halted}`,
+      );
+    }
+
+    // The record's `:event-id` carries the cascade's trigger event,
+    // namespaced by the testbed: `:drain-depth-trigger.core/recurse`.
+    if (!/:event-id\s+:drain-depth-trigger\.core\/recurse/.test(records.halted)) {
+      throw new Error(
+        `:event-id on the halted record should be :drain-depth-trigger.core/recurse; sample: ${records.halted}`,
+      );
+    }
+
+    // Atomic-rollback check — per Spec 002 rule 3, `:db-before` and
+    // `:db-after` are equal on the halted record. CLJS maps are
+    // unordered, so a string regex on the pr-str form would false-
+    // negative on key-order drift. Compare with `cljs.core/=` instead
+    // by reaching into the epoch-history vector inside `page.evaluate`
+    // — the same record we matched on by pr-str above.
+    const dbsEqual = await page.evaluate(() => {
+      const cljs = window.cljs && window.cljs.core;
+      const rf = window.re_frame && window.re_frame.core;
+      if (!cljs || !rf || typeof rf.epoch_history !== 'function') {
+        return { ok: false, reason: 'cljs.core / re_frame.core.epoch_history not on window' };
+      }
+      const kw = (s) => cljs.keyword.call ? cljs.keyword.call(null, s) : cljs.keyword(s);
+      const eq = (a, b) => cljs._EQ_.call ? cljs._EQ_.call(null, a, b) : cljs._EQ_(a, b);
+      const get = (m, k) => cljs.get.call ? cljs.get.call(null, m, k) : cljs.get(m, k);
+      const history = rf.epoch_history(kw('rf/default'));
+      const halted = kw('halted-depth');
+      const outcomeKw = kw('outcome');
+      const beforeKw = kw('db-before');
+      const afterKw = kw('db-after');
+      let s = cljs.seq(history);
+      while (s) {
+        const r = cljs.first(s);
+        if (eq(get(r, outcomeKw), halted)) {
+          return { ok: true, equal: eq(get(r, beforeKw), get(r, afterKw)) };
+        }
+        s = cljs.next(s);
+      }
+      return { ok: false, reason: 'no :halted-depth record found' };
+    });
+    if (!dbsEqual.ok) {
+      throw new Error(`atomic-rollback check failed: ${dbsEqual.reason}`);
+    }
+    if (!dbsEqual.equal) {
+      throw new Error(
+        ':db-before must equal :db-after on a :halted-depth record (atomic rollback per Spec 002 rule 3)',
+      );
+    }
+  },
+};

--- a/testbeds/http_toggle/spec.cjs
+++ b/testbeds/http_toggle/spec.cjs
@@ -1,0 +1,111 @@
+/*
+ * Cross-cutting scenario #2 of 6 from rf2-fe84r §Section B.
+ *
+ *   "HTTP failure cascade visible as ordered `:rf.http/*` with
+ *    category attribution."
+ *
+ * Exercises `testbeds/http_toggle/` (rf2-kzcim). The surface ships a
+ * single button + outcome dropdown enumerating the eight `:rf.http/*`
+ * failure categories from Spec 014 (plus the success path). One click
+ * + one selection drives the configured outcome through the framework
+ * and the reply envelope lands at the dispatched handler's `:rf/reply`
+ * slot carrying the canonical `:failure :kind` category keyword.
+ *
+ * Observation surface — the testbed routes seven of eight failure
+ * categories through `:rf.http/managed-canned-failure` (Spec 014
+ * §Testing). The framework emits `:rf.fx/handled` on the trace bus
+ * for every fx call (per `re-frame.fx`'s `trace/emit!` line 294), so
+ * a canned-failure click produces ONE `:rf.fx/handled` trace event
+ * whose `:tags :fx-id` is `:rf.http/managed-canned-failure`. The
+ * configured `:kind` rides through the reply payload to the
+ * dispatched handler, which writes it onto app-db; the substrate
+ * re-renders the `[data-testid="failure-kind"]` mirror.
+ *
+ * Trace surface vs. README claim — the testbed README aspirationally
+ * lists `:rf.http/dispatched` / `:rf.http/<kind>` as the emitted
+ * trace events. In the current implementation, only the LIVE
+ * failure path (`re-frame.http-transport/finalise-failure!`) emits
+ * `:operation (:kind failure)` via `trace/emit-error!` — the
+ * canned-failure stub bypasses that path. The cross-cutting
+ * observable that survives both code paths is the
+ * (fx → reply → mirror) round-trip, which is what we assert.
+ *
+ * Categories exercised — drive THREE categories that span the
+ * classification surface: `:rf.http/http-4xx` (status-before-decode,
+ * raw body retained), `:rf.http/timeout` (per-attempt timeout
+ * synthesis), `:rf.http/decode-failure` (2xx → bad JSON →
+ * decode-failure path). Walking all eight would add minutes for no
+ * additional information — the contract is "each category survives
+ * the canned-stub → reply round-trip with its `:kind` intact"; three
+ * representative categories prove the wiring is per-category, not
+ * collapsed to a single generic failure.
+ */
+
+const path = require('path');
+const { expectVisible, expectTextEquals } = require(
+  path.join('..', '..', 'examples', 'scripts', 'spec-helpers.cjs'),
+);
+const { readTraceEventsAsEdn, clearTraceBus, pollUntil } = require(
+  path.join('..', 'spec-helpers.cjs'),
+);
+
+const CATEGORIES = [
+  { optionValue: ':rf.http/http-4xx',       failureKind: ':rf.http/http-4xx' },
+  { optionValue: ':rf.http/timeout',        failureKind: ':rf.http/timeout' },
+  { optionValue: ':rf.http/decode-failure', failureKind: ':rf.http/decode-failure' },
+];
+
+module.exports = {
+  name: 'cross-cutting #2 — HTTP failure cascade category attribution',
+  url: '/testbeds/http-toggle/',
+  run: async (page) => {
+    await expectVisible(page.locator('[data-testid="http-toggle"]'), 10000);
+
+    const outcomeSelect = page.locator('[data-testid="outcome-select"]');
+    const goButton = page.locator('[data-testid="go"]');
+    const statusSpan = page.locator('[data-testid="status"]');
+    const failureKindSpan = page.locator('[data-testid="failure-kind"]');
+
+    for (const { optionValue, failureKind } of CATEGORIES) {
+      // Clear the trace bus so the find() below scopes to events
+      // emitted by THIS click.
+      const cleared = await clearTraceBus(page);
+      if (!cleared.ok) {
+        throw new Error(`could not clear trace bus: ${cleared.reason}`);
+      }
+
+      // Set the dropdown — the <select>'s `value=` attribute carries
+      // the pr-str of the keyword (`":rf.http/http-4xx"`); match it
+      // exactly so Playwright selects the right `<option>`.
+      await outcomeSelect.selectOption({ value: optionValue });
+      await goButton.click();
+
+      // ---- Trace-bus contract — fx-handled with canned-failure fx ---
+      // Every fx fires `:rf.fx/handled` per `re-frame.fx`. The testbed
+      // routes failures through `:rf.http/managed-canned-failure`, so
+      // a trace event with `:operation :rf.fx/handled` and
+      // `:fx-id :rf.http/managed-canned-failure` MUST land in the
+      // buffer for THIS click. That single event carries the request's
+      // `:kind` in its `:fx-args` slot — category attribution survives
+      // the fx-walk boundary.
+      await pollUntil(async () => {
+        const probe = await readTraceEventsAsEdn(page);
+        if (!probe.ok) throw new Error(`could not read trace bus: ${probe.reason}`);
+        return probe.events.find((s) =>
+          /:operation\s+:rf\.fx\/handled/.test(s) &&
+          /:fx-id\s+:rf\.http\/managed-canned-failure/.test(s),
+        );
+      }, `:rf.fx/handled trace event for :rf.http/managed-canned-failure after ${optionValue} Go click`, 10000);
+
+      // ---- Reply contract — DOM mirror lands at the same category ---
+      // The handler's `(:rf/reply msg)` branch reads
+      // `(:kind (:failure msg))` off the reply payload and writes the
+      // category keyword to `[:failure-kind]` in app-db. The substrate
+      // re-renders the mirror; reading its text confirms the category
+      // survived the canned-stub → reply → dispatch → sub → DOM
+      // round-trip — the end-to-end "category attribution" contract.
+      await expectTextEquals(statusSpan, 'error', 5000);
+      await expectTextEquals(failureKindSpan, failureKind, 5000);
+    }
+  },
+};

--- a/testbeds/long_flow_w_failure/spec.cjs
+++ b/testbeds/long_flow_w_failure/spec.cjs
@@ -1,0 +1,181 @@
+/*
+ * Cross-cutting scenario #5 of 6 from rf2-fe84r §Section B.
+ *
+ *   "Flow `:rf.flow/failed` shows four-rule failure semantics
+ *    (rf2-hrqvg)."
+ *
+ * Exercises `testbeds/long_flow_w_failure/` (rf2-kzcim). The surface
+ * drives a cascade of ticks; each tick bumps `:input` and triggers
+ * three flows in topo order (`::flow-a` → `::flow-b` → `::flow-c`).
+ * `::flow-b` throws when `:input ≥ :fail-at`. Per Spec 013 §Failure
+ * semantics (resolved by rf2-hrqvg) the four-rule contract is:
+ *
+ *   Rule 1 — prior-flow writes preserved: `::flow-a`'s output IS
+ *            flushed on the tick `::flow-b` throws.
+ *   Rule 2 — failing flow's output NOT written; `last-inputs` is
+ *            NOT advanced; the flow re-attempts on every subsequent
+ *            tick that bumps the input.
+ *   Rule 3 — cascade halts at the failing flow: `::flow-c` does
+ *            NOT run on the drain `::flow-b` throws.
+ *   Rule 4 — per-flow `:rf.flow/failed` trace fires first; then the
+ *            cascade-level `:rf.error/flow-eval-exception` at the
+ *            router's outer catch.
+ *
+ * Trigger choice — use the testbed's defaults (`:fail-at 5`,
+ * `:total-ticks 20`). Tick 5 first throws (`:input 5 ≥ :fail-at 5`);
+ * ticks 6..20 each re-throw per Rule 2. The full cascade is 5
+ * seconds (20 ticks × 250ms) but we don't wait for completion —
+ * scoping the assertion to "first 4-5 failures observed in trace
+ * order" is sufficient to demonstrate all four rules:
+ *
+ *   - Rule 1 observable mid-cascade: `:a-result` advances at every
+ *     tick (we sample after the first failure lands).
+ *   - Rule 2 observable mid-cascade: multiple `:rf.flow/failed`
+ *     emits accumulate while `:input` keeps advancing past
+ *     `:fail-at` — proves `:last-inputs` stayed unadvanced.
+ *   - Rule 3 observable mid-cascade: `:c-result` stays at its
+ *     pre-failure value (sum of `:a-result` + `:b-result` at the
+ *     last successful tick, = 4×2 + 4×3 = 20).
+ *   - Rule 4 observable on the trace bus: `:rf.flow/failed` emits
+ *     precede the matching `:rf.error/flow-eval-exception`.
+ *
+ * Avoiding the configure-via-input race — Playwright's `.fill()`
+ * clears the input first, firing an intermediate `parseInt("", 10)
+ * === NaN` dispatch through `::set-fail-at` / `::set-total-ticks`
+ * that pollutes the cascade's read-time state. Using the testbed's
+ * built-in defaults sidesteps that entirely; the cascade is
+ * deterministic without any pre-Start tweaking.
+ */
+
+const path = require('path');
+const { expectVisible, expectTextEquals } = require(
+  path.join('..', '..', 'examples', 'scripts', 'spec-helpers.cjs'),
+);
+const { readTraceEventsAsEdn, clearTraceBus, pollUntil } = require(
+  path.join('..', 'spec-helpers.cjs'),
+);
+
+module.exports = {
+  // The testbed's `::start` schedules ticks via
+  //   `[:dispatch-later {:ms ... :dispatch [::tick]}]`
+  // — but Spec 002 / `re-frame.fx`'s `:dispatch-later` reads `:event`
+  // not `:dispatch`. With the wrong key the deferred timer fires
+  // `(dispatch! nil ...)` (no-op) and the cascade never starts. The
+  // testbed needs `:dispatch` renamed to `:event`. Filed under the
+  // follow-up bead; this spec is skipped until the surface fix lands,
+  // at which point unskipping is a one-line revert.
+  skip: 'long_flow_w_failure/core.cljs :dispatch-later uses :dispatch key; spec requires :event. Cascade never fires. Filed for follow-up.',
+  name: 'cross-cutting #5 — flow :rf.flow/failed four-rule semantics',
+  url: '/testbeds/long-flow-w-failure/',
+  run: async (page) => {
+    await expectVisible(page.locator('[data-testid="long-flow-w-failure"]'), 10000);
+
+    // Clear the trace bus so the find() below scopes to events
+    // emitted by THIS cascade. Earlier `:rf.flow/registered` and
+    // `:event/dispatched` traces from substrate init are otherwise
+    // in the buffer.
+    const cleared = await clearTraceBus(page);
+    if (!cleared.ok) {
+      throw new Error(`could not clear trace bus: ${cleared.reason}`);
+    }
+
+    // Start the cascade. The testbed pre-schedules 20 ticks at 250ms
+    // each = 5-second total cascade. Tick 5 first throws; ticks 6..20
+    // each re-throw.
+    await page.locator('[data-testid="start"]').click();
+
+    // Sanity probe — wait for the FIRST tick to bump `:input` off 0.
+    // If the cascade scheduled correctly the input mirror reads >0
+    // within ~250ms. If this hangs the cascade itself isn't firing
+    // — surface that with a clear error before the trace assertion
+    // times out with the same root cause.
+    await pollUntil(async () => {
+      const txt = (await page.locator('[data-testid="input"]').textContent()) || '';
+      const v = parseInt(txt.trim(), 10);
+      return Number.isFinite(v) && v > 0 ? v : null;
+    }, ':input mirror to advance past 0 (cascade scheduled at least one tick)', 10000);
+
+    // ---- Rule 4 — `:rf.flow/failed` before matching `:rf.error/flow-eval-exception` ----
+    // Per `re-frame.flows/dirty-check-and-rerun-flow`:
+    //   1. The flow's `:output` throws inside the inner try/catch.
+    //   2. The catch emits `:rf.flow/failed` with `:flow-id ::flow-b`.
+    //   3. The catch re-throws.
+    //   4. `run-flows!` propagates to the router's outer catch which
+    //      emits the cascade-level `:rf.error/flow-eval-exception`.
+    //
+    // The buffer is append-order; index comparison preserves the
+    // emit order. Poll until we see the pair land (first failure
+    // arrives ~tick-5 × 250ms = 1.25s after Start).
+    const observed = await pollUntil(async () => {
+      const probe = await readTraceEventsAsEdn(page);
+      if (!probe.ok) throw new Error(`could not read trace bus: ${probe.reason}`);
+      const failedIdx = probe.events.findIndex((s) =>
+        /:operation\s+:rf\.flow\/failed/.test(s) &&
+        /:flow-id\s+:long-flow-w-failure\.core\/flow-b/.test(s),
+      );
+      const errIdx = probe.events.findIndex((s) =>
+        /:operation\s+:rf\.error\/flow-eval-exception/.test(s),
+      );
+      if (failedIdx >= 0 && errIdx >= 0 && failedIdx < errIdx) {
+        return { failedIdx, errIdx };
+      }
+      return null;
+    }, ':rf.flow/failed for ::flow-b followed by :rf.error/flow-eval-exception', 15000);
+    void observed; // load-bearing assertion above
+
+    // ---- Rule 1 — prior-flow writes preserved (`::flow-a` advanced) ---
+    // `::flow-a` doubles `:input`; the cascade started with `:input 0`
+    // and pre-schedules 20 ticks. By the time the first
+    // `:rf.flow/failed` lands at tick 5, `:a-result` has advanced
+    // through 2 (tick 1), 4 (tick 2), 6 (tick 3), 8 (tick 4), 10
+    // (tick 5). The flow ran on EVERY tick — Rule 1 is "prior-flow
+    // writes preserved".
+    //
+    // Sample `:a-result` after the failure observation above; it
+    // must be ≥ 10 (the value at tick 5, where `:flow-b` first
+    // throws). Reading the live value via DOM lets the assertion be
+    // robust to ticks landing AFTER the failure observation (the
+    // cascade keeps running for ~3.75s more by the time we read).
+    const aResultText = (await page.locator('[data-testid="a-result"]').textContent()) || '';
+    const aResult = parseInt(aResultText.trim(), 10);
+    if (!Number.isFinite(aResult) || aResult < 10) {
+      throw new Error(
+        `Rule 1 evidence — expected :a-result >= 10 after first :flow-b failure (=:2*input at tick 5); got "${aResultText}"`,
+      );
+    }
+
+    // ---- Rule 2 — failing flow's output NOT written --------------
+    // `::flow-b` triples `:input` UNTIL `:input ≥ :fail-at`. Last
+    // successful tick was 4 (input < 5), so `:b-result` reads 12.
+    // Subsequent ticks throw — Rule 2 says `:last-inputs` did NOT
+    // advance, so the path slot stays at 12 regardless of how many
+    // re-attempts the runtime fires.
+    //
+    // Poll for the value because the testbed's React commit lands
+    // a tick after the underlying app-db write.
+    await expectTextEquals(page.locator('[data-testid="b-result"]'), '12', 10000);
+
+    // ---- Rule 3 — cascade halts at failing flow ------------------
+    // `::flow-c` sums `:a-result + :b-result`. Last successful tick
+    // (where BOTH upstreams advanced) was 4: a=8, b=12, c=20. After
+    // tick 4 every drain halts at `:flow-b`'s throw — `::flow-c`
+    // does NOT run, so `:c-result` stays at 20.
+    await expectTextEquals(page.locator('[data-testid="c-result"]'), '20', 10000);
+
+    // ---- Rule 2 supplemental — re-attempt cardinality ------------
+    // Each tick past `:fail-at` re-throws because `:last-inputs`
+    // stayed unadvanced. So the trace buffer accumulates MULTIPLE
+    // `:rf.flow/failed` emits (one per post-fail tick). Asserting
+    // ≥ 3 distinct emits proves the re-attempt loop fired more than
+    // once — the "every subsequent tick re-attempts" half of Rule 2.
+    await pollUntil(async () => {
+      const probe = await readTraceEventsAsEdn(page);
+      if (!probe.ok) throw new Error(`could not read trace bus: ${probe.reason}`);
+      const failures = probe.events.filter((s) =>
+        /:operation\s+:rf\.flow\/failed/.test(s) &&
+        /:flow-id\s+:long-flow-w-failure\.core\/flow-b/.test(s),
+      );
+      return failures.length >= 3 ? failures.length : null;
+    }, '≥3 :rf.flow/failed emits (Rule 2 re-attempt cardinality)', 15000);
+  },
+};

--- a/testbeds/non_trivial_app_db/spec.cjs
+++ b/testbeds/non_trivial_app_db/spec.cjs
@@ -1,0 +1,159 @@
+/*
+ * Cross-cutting scenario #4 of 6 from rf2-fe84r §Section B.
+ *
+ *   "Subscribe → re-render → trace ordering preserved."
+ *
+ * Exercises `testbeds/non_trivial_app_db/` (rf2-kzcim). The surface
+ * ships a 55-leaf app-db nested up to 5 levels deep, with six buttons
+ * each triggering a structurally distinct diff at a known path.
+ *
+ * What "trace ordering preserved" means here — Spec 009 §:op-type
+ * vocabulary + Spec 002 §Cascade propagation guarantee a strict
+ * temporal order in the trace stream for a single dispatched event:
+ *
+ *   1. `:event/dispatched`   — at queue/enqueue time (router emits)
+ *   2. `:event/db-changed`   — after the handler's `:db` commits
+ *
+ * (Sub-runs and view-renders re-fire downstream of `:db` commit; per
+ * the bead's "subscribe → re-render" half of the contract those land
+ * in the same drain as the `:db` commit but emit `:sub/run` /
+ * `:view/render` trace events on separate `:op-type` axes — the
+ * ordering we test here is the event/* axis only. `:event/do-fx`
+ * fires when the handler returns `:fx`, but this testbed's handlers
+ * are all `reg-event-db` (`:db`-only), so `:event/do-fx` is OUT of
+ * scope for this surface.)
+ *
+ * The cross-cutting contract for this scenario: a click that triggers
+ * a structural mutation lands its `:event/dispatched` BEFORE its
+ * `:event/db-changed` trace event (the buffer is append-order; index
+ * comparison preserves the emit order). The substrate re-renders
+ * against the new app-db; the DOM updates; reading the mirror
+ * confirms the cascade settled. The trace ordering + the
+ * subscribe-fired DOM update prove the six-domino cascade fired in
+ * spec order.
+ *
+ * Trigger choice — Button 5 (`:register-new-sku`) mutates the deepest
+ * path in the surface: `[:catalog :categories :books :groups :tech
+ * :skus]` (5 levels). The depth doesn't change the trace ordering
+ * (`:event/db-changed` fires regardless of mutation depth) but it
+ * exercises the most realistic post-handler state.
+ *
+ * Anchoring on event-id `non-trivial-app-db.core/register-new-sku`
+ * lets us scope the find() to the trace events FROM THIS CLICK —
+ * subscriptions firing on init, layout-debug toggles, etc all add
+ * unrelated events to the buffer before and after the click.
+ */
+
+const path = require('path');
+const { expectVisible } = require(
+  path.join('..', '..', 'examples', 'scripts', 'spec-helpers.cjs'),
+);
+const { readTraceEventsAsEdn, clearTraceBus, pollUntil } = require(
+  path.join('..', 'spec-helpers.cjs'),
+);
+
+module.exports = {
+  name: 'cross-cutting #4 — subscribe→re-render→trace ordering preserved',
+  url: '/testbeds/non-trivial-app-db/',
+  run: async (page) => {
+    await expectVisible(page.locator('[data-testid="non-trivial-app-db"]'), 10000);
+
+    // Pre-condition: the app-db pretty-print does NOT contain "BK-099"
+    // (the SKU Button 5 adds). The mirror is a sub off `:catalog`,
+    // which subscribes to the whole `:catalog` slice — proves the
+    // initial app-db shape landed.
+    const dbPre = page.locator('[data-testid="app-db-pr-str"]');
+    if (((await dbPre.textContent()) || '').includes('BK-099')) {
+      throw new Error('app-db starts with BK-099 already present — testbed init drifted');
+    }
+
+    // Clear the trace bus so the ordering assertion below scopes to
+    // the events emitted by THIS click. The bootstrap dispatch
+    // (`::initialise`) and substrate init landed many `:event/*` /
+    // `:sub/*` traces before the test runs.
+    const cleared = await clearTraceBus(page);
+    if (!cleared.ok) {
+      throw new Error(`could not clear trace bus: ${cleared.reason}`);
+    }
+
+    // Drive Button 5 — `:register-new-sku` is a `reg-event-db` whose
+    // body adds "BK-099" to a 5-level-deep set under :catalog.
+    await page.locator('[data-testid="register-new-sku"]').click();
+
+    // Poll until the cascade's three canonical trace events are
+    // present in the buffer. Each carries `:id` (monotonic across
+    // emit order) so the buffer's append-order index can stand in
+    // for the emit ordering.
+    //
+    // The trace bus was cleared just before the click, so any
+    // `:event/dispatched` / `:event/db-changed` / `:event/do-fx` in
+    // the buffer below originate from THIS cascade or whatever
+    // initialise / reg-* emissions ran in the same tick (which all
+    // happened BEFORE the cascade we're testing — they'd be at
+    // earlier indices if present). Scoping by event-id keyword
+    // would be more rigorous but is sensitive to namespace-munge
+    // surprises; the empty-buffer-before-click design provides the
+    // same cascade isolation more robustly.
+    const observed = await pollUntil(async () => {
+      const probe = await readTraceEventsAsEdn(page);
+      if (!probe.ok) throw new Error(`could not read trace bus: ${probe.reason}`);
+      // `:event/dispatched`'s tags carry `:event [<event-vector>]`
+      // (not `:event-id ...` directly — that key only appears on
+      // `:event/db-changed`, per `re-frame.router/emit-dispatched-
+      // trace!` vs `commit-effect-:db!`). Match the event-vector's
+      // shape with "register-new-sku" inside it.
+      const dispatched = probe.events
+        .map((s, i) =>
+          /:operation\s+:event\/dispatched/.test(s) && /register-new-sku/.test(s)
+            ? i
+            : -1,
+        )
+        .filter((i) => i >= 0)
+        .pop();
+      if (dispatched == null || dispatched < 0) return null;
+      // `:event/db-changed` fires from `commit-effect-:db!` after the
+      // handler's `:db` lands. The buffer's monotonic `:id` means a
+      // later append-order index proves a later emit time. Find the
+      // first `:event/db-changed` AFTER the dispatch index.
+      const dbChanged = probe.events.findIndex(
+        (s, i) => i > dispatched && /:operation\s+:event\/db-changed/.test(s),
+      );
+      if (dbChanged >= 0) {
+        return { dispatched, dbChanged };
+      }
+      return null;
+    }, 'an :event/dispatched for register-new-sku followed by :event/db-changed', 10000);
+
+    // Ordering contract — per Spec 009 §:op-type vocabulary and Spec
+    // 002 §Cascade propagation: `:event/dispatched < :event/db-changed`.
+    // The buffer is append-order, so the index comparison preserves
+    // the emit order. A spec violation (e.g. `:event/db-changed`
+    // firing before its enqueue-time `:event/dispatched`) would
+    // surface as an out-of-order index here.
+    if (!(observed.dispatched < observed.dbChanged)) {
+      throw new Error(
+        `:event/dispatched must precede :event/db-changed for the same cascade; ` +
+          `got indices dispatched=${observed.dispatched} dbChanged=${observed.dbChanged}`,
+      );
+    }
+
+    // Sub re-fired → view re-rendered → DOM updated. Reading the
+    // mirror confirms the subscribe → render half of the cascade
+    // settled after the trace bus saw the `:event/do-fx` emit. The
+    // pretty-print sub aggregates every top-level slice; the
+    // mirror's text picks up "BK-099" once the new sku lands in the
+    // `:tech :skus` set.
+    //
+    // This is the "subscribe → re-render → trace ordering preserved"
+    // contract's second half: the view's re-render (downstream of the
+    // sub firing on the app-db write) lands AFTER the trace bus's
+    // db-changed emit but in the SAME drain — the substrate commits
+    // to the DOM as part of the same RAF tick that flushed the
+    // re-frame queue. We poll the mirror because the React commit
+    // settles a tick after the trace emit.
+    await pollUntil(async () => {
+      const txt = (await dbPre.textContent()) || '';
+      return txt.includes('BK-099');
+    }, 'app-db mirror to re-render with "BK-099" after :register-new-sku cascade', 10000);
+  },
+};

--- a/testbeds/spec-helpers.cjs
+++ b/testbeds/spec-helpers.cjs
@@ -1,0 +1,133 @@
+/*
+ * Cross-cutting testbed spec helpers (rf2-fe84r).
+ *
+ * Shared between the six framework-behavior scenarios under
+ * `testbeds/<surface>/spec.cjs`. Each scenario asserts against the
+ * framework's trace bus and/or epoch history via the Causa preload's
+ * mirror — every testbed wires `day8.re-frame2-causa.preload` through
+ * shadow-cljs `:devtools/:preloads`, which registers a trace-collector
+ * cb against `re-frame.trace/register-trace-cb!`. Reading the
+ * Causa-side mirror is therefore reading the framework's emitted
+ * stream (Causa's collector is push-on-emit, not opt-in).
+ *
+ * Helpers are CLJS-aware: each `page.evaluate(...)` invocation uses
+ * `cljs.core.pr_str` to materialise CLJS PersistentMap entries into
+ * canonical EDN strings the calling JS can regex-match. This avoids
+ * the alternative — poking at munged keyword internals from JS — and
+ * keeps the assertion vocabulary aligned with the spec docs.
+ *
+ * The framework's own `re-frame.core/trace-buffer` and
+ * `re-frame.core/epoch-history` are also accessible on `window` under
+ * their dotted-ns munge in `:browser :dev` builds; the Causa surface
+ * is preferred for the trace bus because every testbed already routes
+ * through it. For epoch history we use `re_frame.core.epoch_history`
+ * directly — epoch records are not buffered by Causa's trace bus.
+ */
+
+/**
+ * Read the Causa trace bus and return each event as a pr-str EDN
+ * string. Returns `{ ok, events?, reason? }`.
+ *
+ * `events` is oldest-first to match the buffer's append-order, so a
+ * caller asserting on ordering can `events.findIndex(...)` and
+ * compare positions directly.
+ */
+async function readTraceEventsAsEdn(page) {
+  return page.evaluate(() => {
+    const cljs = window.cljs && window.cljs.core;
+    const bus =
+      window.day8 &&
+      window.day8.re_frame2_causa &&
+      window.day8.re_frame2_causa.trace_bus;
+    if (!cljs || !bus || typeof bus.buffer !== 'function') {
+      return {
+        ok: false,
+        reason: 'cljs.core / day8.re_frame2_causa.trace_bus.buffer not on window',
+      };
+    }
+    const events = [];
+    let s = cljs.seq(bus.buffer());
+    while (s) {
+      const ev = cljs.first(s);
+      events.push(cljs.pr_str ? cljs.pr_str(ev) : String(ev));
+      s = cljs.next(s);
+    }
+    return { ok: true, events };
+  });
+}
+
+/**
+ * Clear the Causa trace bus. Useful between sub-scenarios in one
+ * spec to keep `events.find(...)` scoped to the events under test
+ * without earlier `:counter/initialise` / lifecycle emits in the way.
+ *
+ * Per `day8.re-frame2-causa.trace-bus/clear-buffer!`: this empties
+ * Causa's own buffer; the framework's `re-frame.trace/trace-buffer`
+ * is untouched (the two are independent ring buffers per Spec 009
+ * §Retain-N trace ring buffer).
+ */
+async function clearTraceBus(page) {
+  return page.evaluate(() => {
+    const bus =
+      window.day8 &&
+      window.day8.re_frame2_causa &&
+      window.day8.re_frame2_causa.trace_bus;
+    if (!bus || typeof bus.clear_buffer_BANG_ !== 'function') {
+      return { ok: false, reason: 'trace_bus.clear_buffer_BANG_ not on window' };
+    }
+    bus.clear_buffer_BANG_();
+    return { ok: true };
+  });
+}
+
+/**
+ * Read `rf/epoch-history` for the given frame keyword (default
+ * `:rf/default`). Each record is rendered to a pr-str EDN string.
+ * Returns `{ ok, records?, reason? }`.
+ */
+async function readEpochHistoryAsEdn(page, frameKeyword = ':rf/default') {
+  return page.evaluate((kwStr) => {
+    const cljs = window.cljs && window.cljs.core;
+    const rf = window.re_frame && window.re_frame.core;
+    if (!cljs || !rf || typeof rf.epoch_history !== 'function') {
+      return {
+        ok: false,
+        reason: 'cljs.core / re_frame.core.epoch_history not on window',
+      };
+    }
+    // `cljs.core.keyword` accepts a bare string OR a "ns/name" form
+    // — it splits on the slash internally (see cljs.core/keyword's
+    // arity-1 source). Strip the leading colon if present so
+    // "rf/default" and ":rf/default" both work.
+    const raw = kwStr.startsWith(':') ? kwStr.slice(1) : kwStr;
+    const kw = cljs.keyword.call ? cljs.keyword.call(null, raw) : cljs.keyword(raw);
+    const records = [];
+    let s = cljs.seq(rf.epoch_history(kw));
+    while (s) {
+      records.push(cljs.pr_str(cljs.first(s)));
+      s = cljs.next(s);
+    }
+    return { ok: true, records };
+  }, frameKeyword);
+}
+
+/**
+ * Poll `fn` until it returns truthy or the timeout elapses. Returns
+ * the truthy result, or throws with `label` on timeout.
+ */
+async function pollUntil(fn, label, timeoutMs = 10000, intervalMs = 50) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const r = await fn();
+    if (r) return r;
+    await new Promise((res) => setTimeout(res, intervalMs));
+  }
+  throw new Error(`pollUntil timed out (${timeoutMs}ms): ${label}`);
+}
+
+module.exports = {
+  readTraceEventsAsEdn,
+  clearTraceBus,
+  readEpochHistoryAsEdn,
+  pollUntil,
+};


### PR DESCRIPTION
## Summary

Lands the **cross-cutting 6 of 53** scenarios from rf2-fe84r — the framework-behavior subset that lives at `testbeds/<surface>/spec.cjs`, disjoint from the 26 Causa-side and 18 Story-side scenarios that remain open under the bead. Each spec asserts on the framework's trace bus / epoch history (via the Causa preload's mirror), NOT on Causa or Story chrome.

Per-scenario:

| # | Scenario | Surface | Status |
|---|---|---|---|
| 1 | deliberate-throw handler-exception structured trace (`:rf.error/handler-exception` with `:op-type :error` + `:where :handler`) | `testbeds/deliberate_throw/` | passing |
| 2 | HTTP failure category attribution end-to-end (canned-failure fx → reply → DOM mirror) | `testbeds/http_toggle/` | passing |
| 3 | State-machine transition cascade trace observability | `testbeds/deep_machine/` | **skipped** — pending rf2-nt6ct (surface's `:invoke-all` declaration is stale per Spec 005 validator) |
| 4 | `:event/dispatched < :event/db-changed` ordering + post-cascade DOM mirror update | `testbeds/non_trivial_app_db/` | passing |
| 5 | Flow `:rf.flow/failed` four-rule semantics (rf2-hrqvg) | `testbeds/long_flow_w_failure/` | **skipped** — pending rf2-9vcul (surface's `:dispatch-later` uses wrong key, cascade never fires) |
| 6 | Drain-depth rollback + `:halted-depth` epoch record (rf2-v0jwt) | `testbeds/drain_depth_trigger/` | passing |

Each skipped scenario uses the runner's `skip:` opt-out so the spec file sits at the canonical location and unskips with a one-line revert once the surface fix lands.

## What's also in this PR

- **Orchestrator wiring**: `examples/scripts/serve-and-run-examples-tests.cjs` gains six new EXAMPLES entries (one per rf2-kzcim testbed surface) plus a `bundleSrc` field that opts a build into a new `copyDirRecursive` staging step. The rf2-kzcim testbeds emit into `out/testbeds/<id>/`; the orchestrator now copies the bundle into `out/examples/testbeds/<id>/` so http-server serves it under the same origin as the examples. The convention coexists with rf2-ik4io's SSR testbeds (which emit directly into `out/examples/testbed-<id>/`).
- **Shared test helpers**: `testbeds/spec-helpers.cjs` — three CLJS-aware `page.evaluate` helpers (`readTraceEventsAsEdn`, `clearTraceBus`, `readEpochHistoryAsEdn`) plus `pollUntil`. Each reads CLJS data through `cljs.core.pr_str` to render canonical EDN strings the JS spec can regex-match.

## Follow-up beads filed

Three pre-existing testbed-surface bugs discovered during this dispatch:

- **rf2-nt6ct** (P2) — `testbeds/deep_machine/` `:phase-b` `:invoke-all` is stale per Spec 005 (`:on-all-done` should be `:on-child-done` + `:on-child-error` + `:on-all-complete`). Blocks scenario #3.
- **rf2-9vcul** (P2) — `testbeds/long_flow_w_failure/` `::start` uses `:dispatch` key in `:dispatch-later` args; Spec 002 / `re-frame.fx` reads `:event`. Cascade never schedules. Blocks scenario #5.
- **rf2-86k63** (P3) — `testbeds/drain_depth_trigger/`'s halt observer (registered via `register-error-emit-listener!`) is unreachable; framework only emits drain-depth-exceeded to the trace bus, not through `error-emit/dispatch-on-error!`. Cosmetic — scenario #6 passes without depending on the listener.

## What's deferred

44 of 53 scenarios remain open under rf2-fe84r:
- **26 Causa-side** scenarios (live at `tools/causa/testbeds/<scenario>/spec.cjs`)
- **18 Story-side** scenarios (live at `tools/story/testbeds/<scenario>/spec.cjs`)

The disjoint cross-cutting subset was chosen for this dispatch to avoid merge conflicts with potential parallel work on rf2-ub1n4 (Story coverage) or future Causa-side dispatch.

## Test plan

- [x] `npm run test:examples` from `implementation/` — 36 specs, 0 failures, 2 skipped (scenarios #3 + #5 with documented reasons)
- [x] Each non-skipped spec asserts on framework observables (trace bus / epoch history), not tool chrome
- [x] Each spec cites the testbed surface it exercises and the rf2-fe84r scenario # in its header
- [x] Each cross-cutting scenario lives in its own `spec.cjs` per the bead's design