### PR TITLE
fix(testbeds): correct :dispatch-later key (:dispatch -> :event) in long_flow_w_failure (rf2-9vcul)

### DIFF
--- a/testbeds/long_flow_w_failure/core.cljs
+++ b/testbeds/long_flow_w_failure/core.cljs
@@ -227,7 +227,7 @@
       {:db (assoc db :status :running :tick-count 0 :input 0)
        :fx (vec (for [i (range 1 (inc total))]
                   [:dispatch-later
-                   {:ms (* i tick-ms) :dispatch [::tick]}]))})))
+                   {:ms (* i tick-ms) :event [::tick]}]))})))
 
 (rf/reg-event-fx ::reset
   (fn [_ctx _ev]


### PR DESCRIPTION
## Summary

- Renames `:dispatch` -> `:event` in `testbeds/long_flow_w_failure/core.cljs`'s `::start` handler `:dispatch-later` args.
- Per Spec 002 §Cascade propagation and `re-frame.fx`'s `:dispatch-later` reserved handler (`fx.cljc:169` destructures `{:keys [ms event]}`), the canonical args shape is `{:ms <n> :event <event-vec>}`.
- With `:dispatch` the runtime resolved `event` to `nil`; the deferred timer fired `(dispatch! nil ...)` (silent no-op) and the 5-second cascade never started — `:status` flipped to `:running` but no tick ever bumped `:input`.

## Context

- Filed by rf2-fe84r (PR #1124) — the cross-cutting `:rf.flow/failed` four-rule scenario was filed with `skip:` pending this surface fix.
- Once this lands, rf2-fe84r's `spec.cjs` can drop its `skip:` line on rebase (one-line revert).

## Test plan

- [x] `npm run test:cljs` — 0 failures / 0 errors across 5695 assertions.
- [x] `npm run test:bundle-isolation` — PASS.
- [x] `npm run test:examples` — 30 specs, 0 failures / 0 skipped.
- [x] `npx shadow-cljs compile :testbeds/long-flow-w-failure` — clean compile, 0 warnings.

## Cross-refs

- bead rf2-9vcul
- spec/002-Frames.md §Cascade propagation (line 383: canonical `{:ms <n> :event event-vec}` shape)
- implementation/core/src/re_frame/fx.cljc:169 (the reserved handler that destructures `:event`)
- rf2-fe84r / PR #1124 (filed this bead; scenario #5 unblocked)