### PR TITLE
fix(pair2-mcp-sec): extend --allow-raw-state gate to subscribe tool (rf2-vr2hn, rf2-7adwg follow-on)

### DIFF
--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs
@@ -48,6 +48,7 @@
             [re-frame-pair2-mcp.tools.probe :as probe]
             [re-frame-pair2-mcp.tools.args :as args]
             [re-frame-pair2-mcp.tools.dedup :as dedup]
+            [re-frame-pair2-mcp.tools.elision :as elision]
             [re-frame-pair2-mcp.tools.sensitive :as sensitive]
             [re-frame-pair2-mcp.tools.raw-state :as raw-state]))
 
@@ -194,6 +195,49 @@
       (catch :default _ nil))))
 
 ;; ---------------------------------------------------------------------------
+;; Drain eval-form — server-side elision wrap (rf2-vr2hn).
+;; ---------------------------------------------------------------------------
+;;
+;; `drain-subscription!` returns `{:ok? :sub-id :events [...]
+;; :dropped-events :dropped-bytes :overflow-reason :gone?}`. The `:epoch`
+;; topic ships full epoch records — `:db-after` / `:db-before` / `:app-db`
+;; slices ride verbatim. When the `--allow-raw-state` boot gate is OFF
+;; (the published-build default), each event must flow through
+;; `re-frame.core/elide-wire-value` BEFORE it crosses the nREPL wire —
+;; mirroring the snapshot / get-path gate (rf2-c2dtu) so an operator who
+;; didn't pass `--allow-raw-state` can't be talked into shipping raw
+;; state through a hostile per-call arg.
+;;
+;; The walker reads the live `[:rf/elision]` registry, so it has to run
+;; app-side. We compose `drain-subscription!` server-side with a mapv
+;; over `:events`, returning the same envelope with elided values in
+;; place. When elision is OFF (operator opted in via `--allow-raw-state`
+;; AND passed `:elision false`), the bare drain form ships raw — the
+;; pre-rf2-vr2hn posture.
+
+(defn drain-form
+  "Build the nREPL drain eval form. When `elision?` is true, wraps the
+  drain envelope so `:events` flows through `re-frame.core/elide-wire-value`
+  server-side; when false, emits the bare drain call. `incl?` threads
+  into the walker's `:rf.size/include-sensitive?` opt — gate-OFF callers
+  see redacted sensitive slots regardless of any per-call opt-in.
+
+  Public (not `defn-`) so unit tests can pin the form shape directly —
+  the form-string is the contract surface between MCP server and the
+  app-side runtime."
+  [sub-id elision? incl?]
+  (if elision?
+    (ef/emit
+      (ef/rt-let
+        ['drain (ef/rt-call 'drain-subscription! sub-id)
+         'opts  (ef/rt-raw (elision/elision-opts-edn true incl?))
+         'evts  (ef/rt-raw
+                  (str "(mapv #(re-frame.core/elide-wire-value % opts)"
+                       " (:events drain))"))]
+        (ef/rt-raw "(assoc drain :events evts)")))
+    (ef/emit (ef/rt-call 'drain-subscription! sub-id))))
+
+;; ---------------------------------------------------------------------------
 ;; Streaming controller — termination + poll loop.
 ;; ---------------------------------------------------------------------------
 
@@ -220,8 +264,9 @@
   triggers (client abort, max-events reached, or sub-gone)."
   [{:keys [conn build-id sub-id topic resolve state
            signal send-note progress-tk poll-ms max-events
-           incl? dedup?]}]
-  (let [terminate
+           incl? elision? dedup?]}]
+  (let [drain-src (drain-form sub-id elision? incl?)
+        terminate
         (fn terminate [reason]
           (-> (nrepl/cljs-eval-value
                 conn build-id
@@ -244,9 +289,7 @@
             (terminate :max-events-reached)
 
             :else
-            (-> (nrepl/cljs-eval-value
-                  conn build-id
-                  (ef/emit (ef/rt-call 'drain-subscription! sub-id)))
+            (-> (nrepl/cljs-eval-value conn build-id drain-src)
                 (.then
                   (fn [drain-resp]
                     (if (:gone? drain-resp)
@@ -308,6 +351,16 @@
         incl?              (if (raw-state/force-redact?)
                              false
                              (args/parse-bool-arg raw-args :include-sensitive?))
+        ;; rf2-vr2hn — the `--allow-raw-state` boot gate forces
+        ;; `:elision true` on every streamed event when OFF, mirroring
+        ;; the snapshot / get-path gate. Server-side, the drain envelope's
+        ;; `:events` flow through `re-frame.core/elide-wire-value` before
+        ;; crossing the nREPL wire — declared-large slots elide and
+        ;; declared-sensitive slots redact. `force-elision?` is the
+        ;; single arbiter; a caller's `:elision false` arg is dropped
+        ;; when the gate is OFF.
+        elision?           (or (args/parse-bool-arg raw-args :elision)
+                               (raw-state/force-elision?))
         dedup?             (args/parse-bool-arg raw-args :dedup)
         {:keys [signal send-note progress-tk]} (parse-mcp-extra extra)]
     (cond
@@ -347,7 +400,7 @@
                                  :signal      signal      :send-note   send-note
                                  :progress-tk progress-tk :poll-ms     poll-ms
                                  :max-events  max-events  :incl?       incl?
-                                 :dedup?      dedup?})]
+                                 :elision?    elision?    :dedup?      dedup?})]
                           (when (pos? max-ms)
                             (js/setTimeout #(terminate :max-ms-reached) max-ms))
                           (poll))))))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/subscribe_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/subscribe_test.cljs
@@ -9,6 +9,7 @@
   against a real shadow-cljs build."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [cljs.reader]
+            [clojure.string :as str]
             [applied-science.js-interop :as j]
             [re-frame-pair2-mcp.tools.args :as args]
             [re-frame-pair2-mcp.tools.eval-form :as ef]
@@ -410,3 +411,68 @@
   (let [s1 (sub/merge-drain zero-state (drain {:n 1 :tick-elided 2}))
         s2 (sub/merge-drain s1         (drain {:n 1 :tick-elided 3}))]
     (is (= 5 (:elided-large s2)))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-vr2hn — `--allow-raw-state` boot gate on the drain eval form.
+;;
+;; The drain envelope's `:events` slot rides the nREPL wire verbatim. For
+;; the `:epoch` topic that means full epoch records (`:db-after` /
+;; `:db-before` / `:app-db`) — a hostile per-call arg shouldn't be able
+;; to talk an operator who didn't pass `--allow-raw-state` into shipping
+;; raw state. The gate mirrors the snapshot / get-path / trace-window
+;; pattern (rf2-c2dtu): when OFF, the drain form wraps `:events` with
+;; `re-frame.core/elide-wire-value` server-side, sensitive slots redact,
+;; large slots elide. When ON, the bare drain ships raw — the
+;; pre-rf2-vr2hn posture.
+;; ---------------------------------------------------------------------------
+
+(deftest drain-form-gated-elision-wraps-events
+  ;; Gate OFF (the default published-build posture). The drain form must:
+  ;;   - call `drain-subscription!` for the sub-id.
+  ;;   - mapv each event through `re-frame.core/elide-wire-value`.
+  ;;   - assoc the elided events back onto the drain envelope.
+  ;;   - thread `:rf.size/include-sensitive? false` into the walker opts.
+  (let [form (sub/drain-form "sub-abc" true false)]
+    (is (str/includes? form "drain-subscription!")
+        "drain-subscription! is the runtime entry point")
+    (is (str/includes? form "\"sub-abc\"")
+        "sub-id rides the form as an EDN string literal")
+    (is (str/includes? form "re-frame.core/elide-wire-value")
+        "every event flows through the size-elision walker")
+    (is (str/includes? form ":rf.size/include-large? false")
+        "walker is active (not pass-through)")
+    (is (str/includes? form ":rf.size/include-sensitive? false")
+        "sensitive slots redact when the caller did NOT opt in")))
+
+(deftest drain-form-gated-elision-honours-include-sensitive
+  ;; Gate ON path — when the operator passed `--allow-raw-state` AND the
+  ;; caller passed `:include-sensitive? true`, the walker still fires
+  ;; (elision is independent of sensitive), but sensitive slots pass
+  ;; through.
+  (let [form (sub/drain-form "sub-xyz" true true)]
+    (is (str/includes? form "re-frame.core/elide-wire-value"))
+    (is (str/includes? form ":rf.size/include-sensitive? true")
+        "include-sensitive? true threads into the walker opts")))
+
+(deftest drain-form-elision-off-bare-drain
+  ;; Gate ON + caller passes `:elision false` — the form must NOT wrap
+  ;; with the walker. Bare `drain-subscription!` call ships raw events
+  ;; (the pre-rf2-vr2hn posture).
+  (let [form (sub/drain-form "sub-raw" false false)]
+    (is (str/includes? form "drain-subscription!"))
+    (is (not (str/includes? form "re-frame.core/elide-wire-value"))
+        "elision OFF ⇒ no walker; raw events ride the wire")
+    (is (= "(re-frame-pair2.runtime/drain-subscription! \"sub-raw\")"
+           form)
+        "bare drain form is the pre-rf2-vr2hn shape")))
+
+(deftest drain-form-sub-id-pr-str-literal
+  ;; The sub-id is an EDN string literal — `pr-str` escapes quotes /
+  ;; backslashes correctly so a runtime read-string round-trips it
+  ;; verbatim. Pin against a sub-id containing characters that would
+  ;; break naive concatenation.
+  (let [form (sub/drain-form "id-with-\"quote\"" true false)]
+    ;; pr-str emits the embedded quotes as `\"` — the round-trip is
+    ;; correct, no raw-`str` concatenation hazard.
+    (is (str/includes? form "\\\"quote\\\"")
+        "embedded quotes survive as escaped EDN literals")))


### PR DESCRIPTION
## Summary

- Closes rf2-vr2hn — extends the `--allow-raw-state` boot gate (rf2-c2dtu, PR #1123) to the streaming `subscribe` tool.
- The `:epoch` topic shipped full epoch records (`:db-after` / `:db-before` / `:app-db`) verbatim over nREPL — a gate-OFF runtime would still leak raw state through any caller who opened an epoch subscription. The gate now covers it.
- Mirrors snapshot / get-path / trace-window: when the boot gate is OFF (published-build default), the drain form composes `drain-subscription!` server-side with `mapv` of `re-frame.core/elide-wire-value` over `:events`. Declared-large slots elide, declared-sensitive slots redact. Gate ON + caller passes `:elision false` ⇒ bare drain form ships raw (pre-rf2-vr2hn posture).
- `raw-state/force-elision?` is the single arbiter, in lockstep with the snapshot / get-path call sites; no new gate state.

## Threading

- `subscribe-tool` parses `:elision` and ORs with `force-elision?` → `elision?` flag.
- New public `drain-form sub-id elision? incl?` builds the nREPL eval form. `elision? true` → `rt-let` binding the drain envelope, `mapv` events through `re-frame.core/elide-wire-value` with `elision-opts-edn` opts; `elision? false` → bare `(re-frame-pair2.runtime/drain-subscription! sub-id)`.
- `make-stream-controller` threads `elision?` and computes `drain-src` once at controller-build time (drain form is invariant across poll ticks).

## Test plan

- [x] `tools/pair2-mcp/` `npm test` — 408 tests, 985 assertions, 0 failures (new tests pin gated-elision wraps events, sensitive opt-in honoured, elision-off bare-drain, sub-id pr-str escapes).
- [x] `implementation/` `npm run test:cljs` — 2014 tests, 5695 assertions, 0 failures.
- [x] `implementation/` `npm run test:bundle-isolation` — PASS.

## Cross-refs

- rf2-c2dtu (PR #1123) — boot-gate pattern this mirrors.
- rf2-7adwg — parent audit; this is its MEDIUM-finding follow-on (sub-privacy).
- Note: rf2-vr2hn's bd description originally framed the resource-controls MEDIUM; the privacy-gate finding from the parent audit is the more pressing closure surface and is fixed here. A resource-controls follow-on can be filed separately.