### PR TITLE
fix(testbeds): align deep_machine :invoke-all with Spec 005 validator (rf2-nt6ct)

### DIFF
--- a/testbeds/deep_machine/README.md
+++ b/testbeds/deep_machine/README.md
@@ -13,7 +13,7 @@ machine through each capability one at a time.
 | **`:always`** (eventless transitions) | `:work` region's `:resolving` node | After `work-done`, the runtime fires a microstep cascade through `:resolving` to `:done-a` without an explicit event on the trace stream. The `:phase-a-ran?` guard's truthiness picks the branch. |
 | **`:after`** (delayed transitions) | `:health` region's `:warming` node — `{:after {200 :ready}}` | `health-heat` schedules a `:dispatch-later` for the `:rf.machine.timer/after-elapsed` synthetic event; ~200ms later the region transitions to `:ready`. Per-region `:rf/after-epoch-by-region` slot at `[:data :rf/after-epoch-by-region :health]` advances on each entry/exit. |
 | **`:invoke`** (single child actor) | `:work/leaf-a` (the deepest leaf) | On entry, the desugared `:rf.machine/spawn` fx mounts `:helper/tick` at `[:rf/spawned :deep/main [:work :phase-a :sub-a :nested-a :deep-a :leaf-a]]`. On exit (via `work-done`), the desugared `:rf.machine/destroy` fires. |
-| **`:invoke-all`** (parallel children + join) | `:work/phase-b` | After `work-spawn`, the runtime emits one `:rf.machine/invoke-all-init` plus three `:rf.machine/spawn` fxs (one per child id `:j1` / `:j2` / `:j3`). After clicking finish on all three, `:helper/all-finished` fires and the parent transitions to `:done-b`. |
+| **`:invoke-all`** (parallel children + join) | `:work/phase-b` | After `work-spawn`, the runtime emits one `:rf.machine.invoke-all/started` plus three `:rf.machine/spawn` fxs (one per child id `:j1` / `:j2` / `:j3`). Each child dispatches `:helper/child-done` to the parent from its terminal `:done` `:entry`; after the third the runtime fires `:rf.machine.invoke-all/all-completed` and dispatches `[:helper/all-finished]` into the parent, transitioning to `:done-b`. |
 
 ## Button reference
 
@@ -22,7 +22,7 @@ machine through each capability one at a time.
 | `:work/go` | `work-go` | Descend the deep hierarchy into `[:work :phase-a … :leaf-a]`; `:invoke` spawns `:helper/tick`. |
 | `:work/done` | `work-done` | Exit the deep leaf; `:invoke`-destroy fires; `:always` cascade settles into `:done-a`. |
 | `:work/spawn` | `work-spawn` | `:invoke-all` spawns three `:helper/job` children. |
-| finish j1 / j2 / j3 | `helper-finish-j1`, `helper-finish-j2`, `helper-finish-j3` | Each transitions one child to its `:final?` leaf; the runtime advances `:invoke-all` join bookkeeping; the third fires `:helper/all-finished` and the parent transitions to `:done-b`. |
+| finish j1 / j2 / j3 | `helper-finish-j1`, `helper-finish-j2`, `helper-finish-j3` | Each transitions one child to its `:final?` leaf; the child's terminal `:entry` dispatches `:helper/child-done` to the parent; the runtime advances `:invoke-all` join bookkeeping; the third triggers `:on-all-complete` which dispatches `[:helper/all-finished]` into the parent and transitions to `:done-b`. |
 | `:work/reset` | `work-reset` | Return `:work` region to `:idle` from any state. |
 | `:health/heat` | `health-heat` | Drive `:health` region from `:cold` → `:warming` → (after 200ms) → `:ready`. |
 | `:health/cool` | `health-cool` | Return `:health` region to `:cold`. |
@@ -82,9 +82,10 @@ destroy / join shape, not what the children compute.
   - `work-done`: `:rf.machine/destroy` (the `:invoke` desugaring on
     leaf exit) + `:rf.machine/transition` (the `:always`
     microstep).
-  - `work-spawn`: `:rf.machine/invoke-all-init` + three
+  - `work-spawn`: `:rf.machine.invoke-all/started` + three
     `:rf.machine/spawn` in source order.
-  - `helper-finish-j3` (after j1 and j2): `:rf.machine/invoke-all-join`
+  - `helper-finish-j3` (after j1 and j2): three intercepted
+    `:helper/child-done` dispatches + `:rf.machine.invoke-all/all-completed`
     + `:rf.machine/transition` (`:helper/all-finished` →
     `:done-b`).
 

--- a/testbeds/deep_machine/core.cljs
+++ b/testbeds/deep_machine/core.cljs
@@ -21,8 +21,11 @@
       `:leaf-a` — spawns a `:helper/tick` child whose lifecycle is
       bound to the leaf's; on leaf exit the desugared destroy fires.
     - **`:invoke-all`** (parallel children + join) on `:phase-b` —
-      three `:helper/job` workers spawn in parallel; `:on-all-done`
-      transitions the parent.
+      three `:helper/job` workers spawn in parallel; each child
+      dispatches the parent's `:on-child-done` keyword from its
+      terminal `:done` `:entry`; on the third the runtime fires
+      `:on-all-complete` ([:helper/all-finished]) and the parent
+      transitions to `:done-b`.
 
   This is NOT a tutorial — the bodies are minimal. The whole point is
   to give a consumer ONE machine whose snapshot, transitions, and
@@ -61,18 +64,32 @@
 
 (def helper-job-machine
   {:initial :running
+
+   :actions
+   {:dispatch-child-done
+    ;; Terminal action: dispatch the parent's :on-child-done keyword.
+    ;; Per Spec 005 §Child completion protocol the event shape is
+    ;;   [<parent-id> [<on-child-done-keyword> <child-id> & extra]]
+    ;; The runtime stamps :rf/parent-id and :rf/invoke-all-child-id
+    ;; into each spawned child's :data at allocate-time, so the child
+    ;; reads them out for the dispatch-back. The parent's
+    ;; create-machine-handler intercepts the event and updates the
+    ;; join state at [:rf/spawned :deep/main [:work :phase-b]].
+    (fn action-dispatch-child-done [data _event]
+      {:fx [[:dispatch [(:rf/parent-id data)
+                        [:helper/child-done (:rf/invoke-all-child-id data)]]]]})}
+
    :states
    {:running
     {:tags    #{:helper/running}
-     ;; Each child runs once and transitions to its terminal state.
-     ;; The :invoke-all join machinery in the parent reads each
-     ;; child's :final? leaf to advance the bookkeeping at
-     ;; [:rf/spawned :deep/main [:work :phase-b] :done].
+     ;; Each child runs once and transitions to its terminal :done
+     ;; leaf. The dispatch-back fires from :done's :entry — see below.
      :on      {:helper.job/finish :done}}
     :done
     {:meta   {:terminal? true}
      :final? true
-     :tags   #{:helper/done}}}})
+     :tags   #{:helper/done}
+     :entry  :dispatch-child-done}}})
 
 (rf/reg-machine :helper/job helper-job-machine)
 
@@ -94,9 +111,9 @@
 (def main-machine
   {:type :parallel
 
-   :data {:tick-count   0
-          :phase-a-ran? false
-          :phase-b-done []}
+   :data {:tick-count            0
+          :phase-a-ran?          false
+          :phase-b-all-finished? false}
 
    :guards
    {:phase-a-ran?
@@ -112,9 +129,14 @@
     (fn action-mark-phase-a-ran [data _ev]
       {:data (assoc data :phase-a-ran? true)})
 
-    :record-phase-b-done
-    (fn action-record-phase-b-done [data [_ child-id]]
-      {:data (update data :phase-b-done (fnil conj []) child-id)})}
+    :record-all-finished
+    ;; Transition action — fires on the parent's :on-all-complete
+    ;; event after the third child's :on-child-done is intercepted
+    ;; by the runtime. The transition target settles into :done-b;
+    ;; this action stamps a :data flag so the view's mirror shows
+    ;; the join resolved.
+    (fn action-record-all-finished [data _event]
+      {:data (assoc data :phase-b-all-finished? true)})}
 
    :regions
    {;; ---- :work region — 5-deep compound + :always + :invoke + :invoke-all ----
@@ -193,23 +215,32 @@
       :phase-b
       ;; Sibling of :phase-a, NOT nested under it. Hosts the
       ;; :invoke-all — three :helper/job children spawn in
-      ;; parallel; the :on-all-done keyword (`:helper/all-finished`)
-      ;; dispatches when the runtime's join machinery sees all
-      ;; three children's :final? state.
+      ;; parallel; each child dispatches the parent's
+      ;; `:on-child-done` keyword (`:helper/child-done`) from its
+      ;; terminal `:done` `:entry`. The runtime intercepts these
+      ;; events at the parent's create-machine-handler boundary,
+      ;; updates the join state at [:rf/spawned :deep/main
+      ;; [:work :phase-b]], and — once all three have reported —
+      ;; dispatches the parent's `:on-all-complete` event vector
+      ;; (`[:helper/all-finished]`) which the parent's :on table
+      ;; routes to `:done-b`.
       ;;
       ;; A consumer that watches the trace stream after :work/spawn
-      ;; sees one :rf.machine/invoke-all-init plus three
+      ;; sees one :rf.machine.invoke-all/started plus three
       ;; :rf.machine/spawn fxs in source order; the children's
-      ;; :final? states fire :on-child-done back to the parent;
-      ;; after the third, :helper/all-finished fires.
+      ;; terminal states dispatch :helper/child-done back to the
+      ;; parent; after the third, :rf.machine.invoke-all/all-completed
+      ;; fires and `[:helper/all-finished]` lands.
       {:tags #{:work/phase-b}
        :invoke-all
-       {:children [{:id :j1 :machine-id :helper/job :data {:id :j1}}
-                   {:id :j2 :machine-id :helper/job :data {:id :j2}}
-                   {:id :j3 :machine-id :helper/job :data {:id :j3}}]
-        :on-child-done :record-phase-b-done
-        :on-all-done   :helper/all-finished}
-       :on   {:helper/all-finished :done-b
+       {:children        [{:id :j1 :machine-id :helper/job :data {:id :j1}}
+                          {:id :j2 :machine-id :helper/job :data {:id :j2}}
+                          {:id :j3 :machine-id :helper/job :data {:id :j3}}]
+        :on-child-done   :helper/child-done
+        :on-child-error  :helper/child-error
+        :on-all-complete [:helper/all-finished]}
+       :on   {:helper/all-finished {:target :done-b
+                                    :action :record-all-finished}
               :work/reset          :idle}}
 
       :done-b
@@ -278,17 +309,17 @@
   (fn [snap _]
     (get-in snap [:data :tick-count])))
 
-(rf/reg-sub :phase-b-done
+(rf/reg-sub :phase-b-all-finished?
   :<- [:rf/machine :deep/main]
   (fn [snap _]
-    (get-in snap [:data :phase-b-done])))
+    (get-in snap [:data :phase-b-all-finished?])))
 
 (reg-view buttons []
-  (let [work-state   @(subscribe [:work-state])
-        health-state @(subscribe [:health-state])
-        tags         @(subscribe [:tags])
-        tick-count   @(subscribe [:tick-count])
-        phase-b-done @(subscribe [:phase-b-done])]
+  (let [work-state            @(subscribe [:work-state])
+        health-state          @(subscribe [:health-state])
+        tags                  @(subscribe [:tags])
+        tick-count            @(subscribe [:tick-count])
+        phase-b-all-finished? @(subscribe [:phase-b-all-finished?])]
     [:div {:data-testid "deep-machine" :style {:font-family "sans-serif" :padding "1em"}}
      [:h1 "deep-machine testbed"]
      [:p "One machine, every grammar surface. Click through to drive
@@ -324,11 +355,11 @@
        "C · :health/cool"]]
 
      [:p {:style {:margin-top "1em" :color "#666" :white-space :pre-wrap}}
-      "work-state="   [:span {:data-testid "work-state"}   (pr-str work-state)]   "\n"
-      "health-state=" [:span {:data-testid "health-state"} (pr-str health-state)] "\n"
-      "tags="         [:span {:data-testid "tags"}         (pr-str tags)]         "\n"
-      "tick-count="   [:span {:data-testid "tick-count"}   tick-count]            "\n"
-      "phase-b-done=" [:span {:data-testid "phase-b-done"} (pr-str phase-b-done)]]]))
+      "work-state="            [:span {:data-testid "work-state"}            (pr-str work-state)]            "\n"
+      "health-state="          [:span {:data-testid "health-state"}          (pr-str health-state)]          "\n"
+      "tags="                  [:span {:data-testid "tags"}                  (pr-str tags)]                  "\n"
+      "tick-count="            [:span {:data-testid "tick-count"}            tick-count]                     "\n"
+      "phase-b-all-finished?=" [:span {:data-testid "phase-b-all-finished?"} (pr-str phase-b-all-finished?)]]]))
 
 (reg-view root []
   [buttons])

--- a/testbeds/deep_machine/spec.cjs
+++ b/testbeds/deep_machine/spec.cjs
@@ -43,19 +43,6 @@ const { readTraceEventsAsEdn, clearTraceBus, pollUntil } = require(
 );
 
 module.exports = {
-  // The testbed's `:phase-b` `:invoke-all` declaration is stale per
-  // current Spec 005 §Spawn-and-join: the validator at
-  // `re-frame.machines.lifecycle_fx.validation/validate-invoke-all!`
-  // (rf2-6vmw) requires `:on-child-done`, `:on-child-error`, and
-  // `:on-all-complete` (vector) — the testbed declares `:on-all-done`
-  // (a single keyword), so `(rf/reg-machine :deep/main ...)` throws
-  // at module-load time and the page never mounts. Per the rf2-fe84r
-  // dispatch boundaries, this spec cannot touch the testbed
-  // `core.cljs`; the surface needs a fix in its own bead before the
-  // scenario can land. Skipping pins the file at the canonical
-  // location with the reason; unskipping is a one-line revert once
-  // the surface fix ships.
-  skip: 'deep_machine/core.cljs declares :on-all-done; validator requires :on-child-done/:on-child-error/:on-all-complete (stale per rf2-6vmw). Filed for follow-up.',
   name: 'cross-cutting #3 — state-machine transition cascade',
   url: '/testbeds/deep-machine/',
   run: async (page) => {


### PR DESCRIPTION
## Summary

- Realigns `testbeds/deep_machine/` `:phase-b` `:invoke-all` to the current Spec 005 §Spawn-and-join canonical shape — the validator at `re-frame.machines.lifecycle_fx.validation/validate-invoke-all!` (rf2-6vmw) requires `:on-child-done`, `:on-child-error`, and `:on-all-complete` (event vector); the testbed's stale `{:on-child-done :record-phase-b-done :on-all-done :helper/all-finished}` was missing `:on-child-error` and used a single-keyword `:on-all-done` slot the validator rejects. `(rf/reg-machine :deep/main ...)` threw `:rf.error/machine-invoke-all-bad-shape` at module-load, the page never mounted, and `testbeds/deep_machine/spec.cjs` (cross-cutting #3 from rf2-fe84r, PR #1124) sat behind a `skip:` directive.
- Wires the child-side completion protocol per spec — `:helper/job`'s terminal `:done` state now carries an `:entry` action that dispatches the parent's `:on-child-done` keyword back, reading `:rf/parent-id` + `:rf/invoke-all-child-id` from each child's stamped `:data`. Parent records the join resolution via a `:record-all-finished` action on the `:helper/all-finished` transition into `:done-b`.
- Un-skips `testbeds/deep_machine/spec.cjs` (the cross-cutting #3 scenario filed by rf2-fe84r). `npm run test:examples` now runs 36 specs with 0 failures and only 1 unrelated skip (rf2-9vcul's `long_flow_w_failure`).

## Test plan

- [x] `shadow-cljs release :testbeds/deep-machine` — clean build, 0 warnings
- [x] `npm run test:cljs` — 2014 tests / 5695 assertions / 0 failures
- [x] `npm run test:bundle-isolation` — PASS (all sentinels at 0)
- [x] `npm run test:examples` — 36 example specs, 0 failures, 1 unrelated skip (rf2-9vcul); the deep_machine scenario passes

## Cross-references

- Closes rf2-nt6ct
- Unblocks rf2-fe84r §B scenario #3
- Spec 005 §Spawn-and-join via `:invoke-all` — canonical shape source
- Validator at `implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc` `validate-invoke-all!`