### PR TITLE
fix(testbeds): http_toggle canned-failure trace + drain_depth_trigger halt-listener cleanup (rf2-3g16l+86k63)

### DIFF
--- a/testbeds/drain_depth_trigger/README.md
+++ b/testbeds/drain_depth_trigger/README.md
@@ -22,13 +22,9 @@ click Start
 halts via the runtime's ceiling. After the halt:
 
 - `:depth-reached` reads back to `0` — rule 3 rollback evidence.
-- The error-emit substrate (per [spec/009 §What IS available in
-  production]) fires `:rf.error/drain-depth-exceeded`; the surface's
-  in-app listener flips `:halted?` to `true` via a second dispatch
-  (which runs on a fresh drain post-rollback).
 - The frame's epoch record for the failed cascade carries outcome
   `:halted-depth` (per [Spec-Schemas §`:rf/epoch-record` Outcomes],
-  rf2-v0jwt).
+  rf2-v0jwt). Consumers read this record off `rf/epoch-history`.
 
 ## Controls
 
@@ -36,15 +32,18 @@ halts via the runtime's ceiling. After the halt:
 |---|---|---|
 | `Drain depth ceiling` | `drain-depth` | The frame's `:drain-depth`. Re-registers the default frame with the new value (a surgical update per [spec/002 §Surgical update] — only the ceiling changes; in-flight events and app-db are not reset). Default 25. |
 | `Start (recurse — halts at depth)` | `start` | Dispatches `[::recurse]`. The handler recurses; the drain halts. |
-| `Reset` | `reset` | Restores `:depth-reached` and `:halted?` to their initial values for re-runs. |
+| `Reset` | `reset` | Restores `:depth-reached` to `0` for re-runs. |
 
 ## DOM mirrors
 
 | Element | What it tells a spec |
 |---|---|
 | `depth-reached` | `0` after a halt — the atomic rollback restored the pre-drain snapshot. |
-| `halted` | `true` after the error-emit substrate fires the `:rf.error/drain-depth-exceeded` category. Allows a Playwright spec to assert on the halt without scraping the ring buffer. |
 | `drain-depth-mirror` | The current ceiling — useful for confirming the input edit propagated to the frame's meta. |
+
+The halt itself is observable on the framework side via `rf/epoch-history`
+(the `:halted-depth` epoch record, see [Spec-Schemas §`:rf/epoch-record`
+Outcomes]) — no DOM mirror is required for the halt observable.
 
 ## Why a configurable ceiling
 

--- a/testbeds/drain_depth_trigger/core.cljs
+++ b/testbeds/drain_depth_trigger/core.cljs
@@ -3,18 +3,16 @@
   dispatches itself in its `:fx`, with a configurable depth ceiling
   registered on the frame via `:drain-depth`. A consumer (Causa, Story,
   pair2-mcp) observes the runtime's run-to-completion drain hitting
-  the depth limit and emitting `:rf.error/drain-depth-exceeded` per
-  [spec/002 §Run-to-completion rule 3] / [spec/009 §Error catalogue]:
+  the depth limit and the atomic rollback (per [spec/002
+  §Run-to-completion rule 3] / [spec/009 §Error catalogue]):
 
     - Rule 3 — when the drain depth limit is reached, the runtime
                rolls the frame's `app-db` back atomically to the
                value snapshotted at the start of the drain.
-    - The emitted error event carries `:depth`, `:queue-size`, and
-      `:last-event`. The event-handler that produced the runaway
-      cascade is named via `:rf.trace/trigger-handler`.
     - The frame's epoch record for the failed cascade lands with
       outcome `:halted-depth` per [Spec-Schemas §`:rf/epoch-record`
-      Outcomes] (rf2-v0jwt).
+      Outcomes] (rf2-v0jwt). Consumers read this record off
+      `rf/epoch-history`.
 
   Two buttons drive the surface:
 
@@ -24,8 +22,7 @@
                       processes the queue in a tight loop until the
                       frame's `:drain-depth` ceiling fires.
 
-    Reset           → resets `:depth-reached` and `:halted?`. Lets
-                      the surface be re-armed for repeat observation.
+    Reset           → resets `:depth-reached` for re-runs.
 
   An input bound to `:drain-depth` lets the user lower the ceiling
   for fast specs (the default 100 is fine, but a Playwright spec that
@@ -63,10 +60,6 @@
     {;; Counter the recursive handler bumps. After a halt this reads
      ;; back to 0 — positive evidence of the atomic rollback (rule 3).
      :depth-reached 0
-     ;; The DOM mirror flips to true when the error-emit listener (see
-     ;; below) sees the drain-depth-exceeded category fire. Lets a
-     ;; spec assert the halt without scraping the trace stream.
-     :halted?       false
      ;; Frame's :drain-depth, mirrored for the view. Re-registers
      ;; the frame on change via `:rf/reg-frame` so the runtime sees
      ;; the updated ceiling on the next drain.
@@ -99,35 +92,23 @@
      :fx [[:dispatch [::recurse]]]}))
 
 ;; ----------------------------------------------------------------------------
-;; Halt observer — error-emit listener
+;; Reset
 ;; ----------------------------------------------------------------------------
 ;;
-;; The always-on error-emit substrate (per [spec/009 §Error-emit listener])
-;; fires on `:rf.error/drain-depth-exceeded`. The surface registers a
-;; tiny listener whose only job is to flip `:halted?` in app-db so the
-;; DOM mirror reflects the runtime's view without forcing a Playwright
-;; spec to inspect the ring buffer. Per [spec/009 §What IS available in
-;; production] the listener survives `:advanced` + `goog.DEBUG=false`
-;; — a consumer running this testbed in any build mode sees the halt.
-
-(defn install-halt-listener! []
-  (rf/register-error-emit-listener!
-    ::halt-observer
-    (fn [error-record]
-      (when (= :rf.error/drain-depth-exceeded
-               (:error error-record))
-        ;; A second dispatch into the same frame after the halt; the
-        ;; first drain has already rolled back, the second drain runs
-        ;; cleanly and flips the mirror.
-        (rf/dispatch [::halt-observed])))))
-
-(rf/reg-event-db ::halt-observed
-  (fn [db _ev]
-    (assoc db :halted? true)))
+;; Note — this testbed historically registered an error-emit listener
+;; (`register-error-emit-listener!`) intending to flip a `:halted?`
+;; mirror when `:rf.error/drain-depth-exceeded` fired. That listener
+;; never fired: the runtime's depth-exceeded path emits ONLY via
+;; `trace/emit-error!`, not `error-emit/dispatch-on-error!` (the
+;; substrate `register-error-emit-listener!` subscribes to). Per
+;; rf2-86k63 the mirror has been removed — the framework-side
+;; observables (`:depth-reached` rolling back to 0, the `:halted-depth`
+;; epoch record on `rf/epoch-history`) already cover the contract
+;; under test and are what the cross-cutting scenario asserts on.
 
 (rf/reg-event-db ::reset
   (fn [db _ev]
-    (assoc db :depth-reached 0 :halted? false)))
+    (assoc db :depth-reached 0)))
 
 ;; ----------------------------------------------------------------------------
 ;; Drain-depth control
@@ -148,12 +129,10 @@
 ;; ----------------------------------------------------------------------------
 
 (rf/reg-sub :depth-reached (fn [db _] (:depth-reached db)))
-(rf/reg-sub :halted?       (fn [db _] (:halted? db)))
 (rf/reg-sub :drain-depth   (fn [db _] (:drain-depth db)))
 
 (reg-view buttons []
   (let [depth-reached @(subscribe [:depth-reached])
-        halted?       @(subscribe [:halted?])
         drain-depth   @(subscribe [:drain-depth])]
     [:div {:data-testid "drain-depth-trigger"
            :style       {:font-family "sans-serif" :padding "1em"}}
@@ -185,8 +164,6 @@
      [:p {:style {:color "#666" :white-space :pre-wrap}}
       "depth-reached=" [:span {:data-testid "depth-reached"} depth-reached]
       "  (= 0 after halt — rule 3 rollback evidence)"  "\n"
-      "halted?="       [:span {:data-testid "halted"}        (str halted?)]
-      "  (flipped by the error-emit listener)"        "\n"
       "drain-depth="   [:span {:data-testid "drain-depth-mirror"} drain-depth]]]))
 
 (reg-view root []
@@ -206,6 +183,5 @@
   ;; per [spec/002 §Surgical update] re-registering only changes the
   ;; supplied keys (here :drain-depth), the other defaults survive.
   (rf/reg-frame :rf/default {:drain-depth default-drain-depth})
-  (install-halt-listener!)
   (rf/dispatch-sync [::initialise])
   (rdc/render react-root [root]))

--- a/testbeds/drain_depth_trigger/spec.cjs
+++ b/testbeds/drain_depth_trigger/spec.cjs
@@ -32,11 +32,9 @@
  *      them).
  *
  * Trigger choice — keep the testbed's default drain-depth of 25 (low
- * enough for sub-second halt). Click Start. After the halt, the
- * surface's `install-halt-listener!` dispatches `::halt-observed`
- * which flips `:halted? true` — that drain runs cleanly AFTER the
- * rollback, so we can also assert the listener-fired mirror to
- * confirm the post-halt state machinery survived.
+ * enough for sub-second halt). Click Start. The framework-side
+ * observables (depth-reached rolling back to 0 + the :halted-depth
+ * epoch record on `rf/epoch-history`) cover the contract end-to-end.
  */
 
 const path = require('path');
@@ -54,10 +52,8 @@ module.exports = {
     await expectVisible(page.locator('[data-testid="drain-depth-trigger"]'), 10000);
 
     // Pre-conditions: the depth-reached mirror starts at 0, the
-    // halted? mirror reads "false", the ceiling is 25 (the testbed's
-    // default — we don't override).
+    // ceiling is 25 (the testbed's default — we don't override).
     await expectTextEquals(page.locator('[data-testid="depth-reached"]'), '0', 5000);
-    await expectTextEquals(page.locator('[data-testid="halted"]'), 'false', 5000);
     await expectTextEquals(page.locator('[data-testid="drain-depth-mirror"]'), '25', 5000);
 
     // Drive Start — `::recurse` dispatches itself in its `:fx`. The
@@ -89,11 +85,6 @@ module.exports = {
     // Per rf2-v0jwt the failing drain commits a partial epoch record
     // with `:outcome :halted-depth`. Read `rf/epoch-history :rf/default`
     // (the testbed runs on the default frame) and walk for the record.
-    //
-    // The post-halt drain (from `::halt-observed`) commits a SECOND
-    // epoch record with `:outcome :ok`; we pin our assertion to the
-    // record whose outcome is `:halted-depth` to isolate from the
-    // post-halt success.
     const records = await pollUntil(async () => {
       const probe = await readEpochHistoryAsEdn(page);
       if (!probe.ok) throw new Error(`could not read epoch history: ${probe.reason}`);

--- a/testbeds/http_toggle/README.md
+++ b/testbeds/http_toggle/README.md
@@ -36,21 +36,32 @@ origin. No CI environment refuses it.
 
 ## Trace shape per click (per [spec/009 §:op-type vocabulary](../../spec/009-Instrumentation.md))
 
-The `:rf.http/managed` envelope emits a sequence of `:rf.http/*` trace
-events through the request lifecycle. Per Spec 014 §Trace events, the
-consumer sees at least:
+Every failure click emits one category-attributed error-trace event
+whose `:operation` is the failure `:kind`, matching the live failure
+path's emit from `re-frame.http-transport/finalise-failure!`:
 
 ```
-:rf.http/dispatched            ;; request issued
-:rf.http/<success | failure>   ;; reply received
-:rf.http/<:kind from above>    ;; the category tag, e.g. :rf.http/http-4xx
+:operation :rf.http/<:kind>    ;; :op-type :error, e.g. :rf.http/http-4xx
+                               ;; :tags {:kind :rf.http/<kind>
+                               ;;        :request-id ...
+                               ;;        :url ...
+                               ;;        :recovery :no-recovery
+                               ;;        + category-specific tags}
 ```
+
+For the seven canned-failure outcomes, the per-testbed
+`:http-toggle/canned-failure-with-trace` fx replays this emit before
+delegating to the framework's `:rf.http/managed-canned-failure` stub
+(see [rf2-3g16l](../../../.beads) — the framework stub bypasses
+`trace/emit-error!`, so the testbed wraps it to preserve the live
+path's contract). The successful `:success` outcome rides the live
+transport path and emits no error trace.
 
 The category-attribution scenario in rf2-fe84r reads: *"HTTP failure
 cascade visible as ordered `:rf.http/*` with category attribution"* —
 this testbed walks one outcome per dropdown entry, so the consumer's
 spec can iterate the dropdown values and assert each emits its expected
-`:kind` tag.
+`:kind` tag directly on the trace bus.
 
 ## What's deliberately *missing*
 

--- a/testbeds/http_toggle/core.cljs
+++ b/testbeds/http_toggle/core.cljs
@@ -28,6 +28,7 @@
             [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
+            [re-frame.trace :as trace]
             ;; Managed-HTTP ships in day8/re-frame2-http. Requiring at
             ;; app boot triggers its load-time fx registrations
             ;; (`:rf.http/managed`, the canned-* stubs); without it,
@@ -72,6 +73,46 @@
 
 (def request-id ::in-flight)
 
+;; ----------------------------------------------------------------------------
+;; Canned-failure-with-trace — fix for rf2-3g16l
+;; ----------------------------------------------------------------------------
+;;
+;; The framework-shipped `:rf.http/managed-canned-failure` synthesises a
+;; failure reply via the same late-bind dispatch path the live transport
+;; uses, but it does NOT call `trace/emit-error!`. The live failure path
+;; (`re-frame.http-transport/finalise-failure!`) emits a single
+;; `:rf.http/<kind>` error-trace event before dispatching the reply; the
+;; canned stub skips it. The testbed README documents an ordered
+;; `:rf.http/<kind>` stream per click — so this per-testbed wrapper fx
+;; replays the live path's `trace/emit-error!` before delegating to the
+;; canned stub. Consumers (Causa, Story, cross-cutting specs) can now
+;; assert on the `:operation :rf.http/<kind>` trace directly rather than
+;; falling back to the `:rf.fx/handled` proxy.
+
+(rf/reg-fx :http-toggle/canned-failure-with-trace
+  {:doc       "Testbed-only wrapper around :rf.http/managed-canned-failure.
+               Emits the category-attributed :rf.http/<kind> error trace
+               (matching the live failure path's finalise-failure! emit)
+               and then delegates to the framework canned stub for the
+               actual reply synthesis. See rf2-3g16l."
+   :platforms #{:client}}
+  (fn fx-canned-failure-with-trace [frame-ctx args-map]
+    (let [kind (or (:kind args-map) :rf.http/transport)
+          tags (or (:tags args-map) {})
+          url  (get-in args-map [:request :url])]
+      ;; Match finalise-failure!'s emit shape: operation is the failure
+      ;; :kind, tags carry the category-specific slots plus :request-id,
+      ;; :url, and :recovery (canned failures are :no-recovery — they
+      ;; classify identically to a terminal live failure).
+      (trace/emit-error! kind
+                         (assoc tags
+                                :kind       kind
+                                :request-id (:request-id args-map)
+                                :url        url
+                                :recovery   :no-recovery))
+      ((registrar/handler :fx :rf.http/managed-canned-failure)
+       frame-ctx args-map))))
+
 (rf/reg-event-fx ::go
   (fn [{:keys [db]} [_ msg]]
     (cond
@@ -103,7 +144,7 @@
                 ;; canned-failure stub. Same reply envelope as a live
                 ;; 4xx; the consumer's trace watcher cannot distinguish.
                 :rf.http/http-4xx
-                [:rf.http/managed-canned-failure
+                [:http-toggle/canned-failure-with-trace
                  {:request    {:method :get :url "api/4xx"}
                   :request-id request-id
                   :kind       :rf.http/http-4xx
@@ -112,7 +153,7 @@
                                :headers {}}}]
 
                 :rf.http/http-5xx
-                [:rf.http/managed-canned-failure
+                [:http-toggle/canned-failure-with-trace
                  {:request    {:method :get :url "api/5xx"}
                   :request-id request-id
                   :kind       :rf.http/http-5xx
@@ -121,7 +162,7 @@
                                :headers {}}}]
 
                 :rf.http/timeout
-                [:rf.http/managed-canned-failure
+                [:http-toggle/canned-failure-with-trace
                  {:request    {:method :get :url "api/timeout"}
                   :request-id request-id
                   :kind       :rf.http/timeout
@@ -137,7 +178,7 @@
                  {:request-id request-id}]
 
                 :rf.http/transport
-                [:rf.http/managed-canned-failure
+                [:http-toggle/canned-failure-with-trace
                  {:request    {:method :get :url "api/transport"}
                   :request-id request-id
                   :kind       :rf.http/transport
@@ -145,7 +186,7 @@
                                :cause   "ECONNREFUSED"}}]
 
                 :rf.http/decode-failure
-                [:rf.http/managed-canned-failure
+                [:http-toggle/canned-failure-with-trace
                  {:request    {:method :get :url "api/decode"}
                   :request-id request-id
                   :kind       :rf.http/decode-failure
@@ -154,7 +195,7 @@
                                :schema-validation-failure? false}}]
 
                 :rf.http/cors
-                [:rf.http/managed-canned-failure
+                [:http-toggle/canned-failure-with-trace
                  {:request    {:method :get :url "https://other.example/api/cors"}
                   :request-id request-id
                   :kind       :rf.http/cors
@@ -180,12 +221,14 @@
                §Testing for the canonical stub seam."
    :platforms #{:client}}
   (fn fx-deferred-abortable [frame-ctx args-map]
-    (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+    (let [stub (registrar/handler :fx :http-toggle/canned-failure-with-trace)]
       ;; Demo-only artificial latency. The :request-id in args-map
       ;; would normally bind the abort handle in the in-flight
       ;; registry; for the testbed stub, the Cancel button fires the
       ;; abort via the live :rf.http/managed-abort fx which short-
-      ;; circuits the timer.
+      ;; circuits the timer. Delegating to the trace-emitting wrapper
+      ;; (rf2-3g16l) keeps the abort path's trace stream uniform with
+      ;; every other failure category.
       (js/setTimeout
         (fn []
           (stub frame-ctx (assoc args-map

--- a/testbeds/http_toggle/spec.cjs
+++ b/testbeds/http_toggle/spec.cjs
@@ -12,23 +12,17 @@
  * slot carrying the canonical `:failure :kind` category keyword.
  *
  * Observation surface — the testbed routes seven of eight failure
- * categories through `:rf.http/managed-canned-failure` (Spec 014
- * §Testing). The framework emits `:rf.fx/handled` on the trace bus
- * for every fx call (per `re-frame.fx`'s `trace/emit!` line 294), so
- * a canned-failure click produces ONE `:rf.fx/handled` trace event
- * whose `:tags :fx-id` is `:rf.http/managed-canned-failure`. The
- * configured `:kind` rides through the reply payload to the
- * dispatched handler, which writes it onto app-db; the substrate
- * re-renders the `[data-testid="failure-kind"]` mirror.
- *
- * Trace surface vs. README claim — the testbed README aspirationally
- * lists `:rf.http/dispatched` / `:rf.http/<kind>` as the emitted
- * trace events. In the current implementation, only the LIVE
- * failure path (`re-frame.http-transport/finalise-failure!`) emits
- * `:operation (:kind failure)` via `trace/emit-error!` — the
- * canned-failure stub bypasses that path. The cross-cutting
- * observable that survives both code paths is the
- * (fx → reply → mirror) round-trip, which is what we assert.
+ * categories through `:http-toggle/canned-failure-with-trace` (a
+ * per-testbed wrapper around `:rf.http/managed-canned-failure` that
+ * replays the live failure path's `trace/emit-error!` emit; see
+ * rf2-3g16l). Every failure click produces a category-attributed
+ * `:operation :rf.http/<kind>` error-trace event whose `:tags :kind`
+ * matches the dropdown selection — the same shape the live path's
+ * `re-frame.http-transport/finalise-failure!` emits before
+ * dispatching the reply. The reply payload also rides through to the
+ * dispatched handler, which writes the category keyword onto app-db;
+ * the substrate re-renders the `[data-testid="failure-kind"]`
+ * mirror.
  *
  * Categories exercised — drive THREE categories that span the
  * classification surface: `:rf.http/http-4xx` (status-before-decode,
@@ -80,22 +74,27 @@ module.exports = {
       await outcomeSelect.selectOption({ value: optionValue });
       await goButton.click();
 
-      // ---- Trace-bus contract — fx-handled with canned-failure fx ---
-      // Every fx fires `:rf.fx/handled` per `re-frame.fx`. The testbed
-      // routes failures through `:rf.http/managed-canned-failure`, so
-      // a trace event with `:operation :rf.fx/handled` and
-      // `:fx-id :rf.http/managed-canned-failure` MUST land in the
-      // buffer for THIS click. That single event carries the request's
-      // `:kind` in its `:fx-args` slot — category attribution survives
-      // the fx-walk boundary.
+      // ---- Trace-bus contract — category-attributed error trace ----
+      // The per-testbed wrapper fx
+      // (`:http-toggle/canned-failure-with-trace`) emits a single
+      // `:operation :rf.http/<kind>` error-trace event before
+      // delegating to the framework canned stub — same shape the live
+      // failure path's `finalise-failure!` emits. Asserting on this
+      // event directly proves end-to-end category attribution on the
+      // trace bus (the canonical Spec 009 observable), not via the
+      // generic `:rf.fx/handled` proxy.
+      const expectedOperation = new RegExp(
+        `:operation\\s+${failureKind.replace(/\./g, '\\.')}`,
+      );
       await pollUntil(async () => {
         const probe = await readTraceEventsAsEdn(page);
         if (!probe.ok) throw new Error(`could not read trace bus: ${probe.reason}`);
         return probe.events.find((s) =>
-          /:operation\s+:rf\.fx\/handled/.test(s) &&
-          /:fx-id\s+:rf\.http\/managed-canned-failure/.test(s),
+          /:op-type\s+:error/.test(s) &&
+          expectedOperation.test(s) &&
+          new RegExp(`:kind\\s+${failureKind.replace(/\./g, '\\.')}`).test(s),
         );
-      }, `:rf.fx/handled trace event for :rf.http/managed-canned-failure after ${optionValue} Go click`, 10000);
+      }, `:operation ${failureKind} error trace after ${optionValue} Go click`, 10000);
 
       // ---- Reply contract — DOM mirror lands at the same category ---
       // The handler's `(:rf/reply msg)` branch reads


### PR DESCRIPTION
## Summary

Micro-cluster fixing two small testbeds bugs surfaced during the rf2-fe84r cross-cutting scenario landing. Two sequenced commits in one PR; per-surface boundaries respected (no cross-cutting framework edits).

### Commit 1 — `testbeds/http_toggle/` (rf2-3g16l)

The framework-shipped `:rf.http/managed-canned-failure` synthesises a failure reply but skips `trace/emit-error!` — only the LIVE failure path's `re-frame.http-transport/finalise-failure!` emits the category-attributed `:rf.http/<kind>` operation. The testbed README documented an ordered `:rf.http/<kind>` stream per click that never landed for the seven canned-failure outcomes; the cross-cutting scenario fell back to asserting on `:rf.fx/handled` with `:fx-id :rf.http/managed-canned-failure`.

Per-testbed fix: register `:http-toggle/canned-failure-with-trace`, a thin wrapper that replays the live path's `trace/emit-error!` emit (kind, request-id, url, recovery + category tags) before delegating to the framework canned stub. The deferred-abortable stub routes through the wrapper too so the `:rf.http/aborted` trace stream is uniform with every other failure category. Spec.cjs now asserts directly on `:operation :rf.http/<kind>` / `:op-type :error` on the trace bus — the canonical Spec 009 observable.

### Commit 2 — `testbeds/drain_depth_trigger/` (rf2-86k63)

The testbed registered an `install-halt-listener!` via `register-error-emit-listener!` intending to flip a `:halted?` mirror on `:rf.error/drain-depth-exceeded`. The listener never fired: re-frame's runtime emits the depth-exceeded event ONLY via `trace/emit-error!` (the ring-buffer/trace surface), not via the always-on `error-emit/dispatch-on-error!` substrate the listener subscribes to.

Per the bead's fix decision (option b): drop the unused listener + the `:halted?` mirror outright. The cross-cutting scenario already asserts on framework-side observables (`:depth-reached` rolling back to 0, the `:halted-depth` epoch record on `rf/epoch-history`) which both fire correctly and remain unchanged. The remaining question — whether `:rf.error/drain-depth-exceeded` SHOULD ride the always-on error-emit substrate matching the handler-exception pattern (option a) — is a framework-side design decision outside the testbeds scope; the unused listener was masking it.

## Test plan

- [x] `npm run test:cljs` — 2014 tests / 5695 assertions / 0 failures / 0 errors
- [x] `npm run test:bundle-isolation` — PASS
- [x] `npm run test:examples` — both cross-cutting scenarios I edit (#2 HTTP failure cascade, #6 drain-depth rollback) PASS; pre-existing #5 flow failure on origin/main is unrelated to this PR