### PR TITLE
refactor(story): inline group-cascades re-export — direct consumers from canonical home (rf2-r9zah)

### DIFF
--- a/tools/story/src/re_frame/story/ui/trace.cljs
+++ b/tools/story/src/re_frame/story/ui/trace.cljs
@@ -172,10 +172,8 @@
 ;; copy here with two latent bugs (an invented `:event/run` operation
 ;; and op-type/operation confusion on the fx, sub, view emits); the
 ;; framework version tracks Spec 009's actual op-type vocabulary and
-;; surfaces non-six-domino events under `:other`.
-
-;; Re-export for backwards-compat for any in-tree consumer.
-(def group-cascades projection/group-cascades)
+;; surfaces non-six-domino events under `:other`. Consumers require
+;; `re-frame.trace.projection` directly.
 
 ;; ---- cross-reference with the scrubber (rf2-sxwvf) -----------------------
 ;;
@@ -305,7 +303,7 @@
             selected-cascade   (when selected-epoch
                                  (scrubber/cascade-id-for-epoch
                                    variant-id selected-epoch))
-            all-cascades       (group-cascades events)
+            all-cascades       (projection/group-cascades events)
             visible-cascades   (filter-cascades-up-to all-cascades cap)
             hidden-by-scrub    (- (count all-cascades)
                                   (count visible-cascades))

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -31,7 +31,8 @@
             [re-frame.story.ui.scrubber :as scrubber]
             [re-frame.story.ui.scrubber-xref :as xref]
             [re-frame.story.ui.trace :as trace]
-            [re-frame.story.ui.workspace :as workspace]))
+            [re-frame.story.ui.workspace :as workspace]
+            [re-frame.trace.projection :as projection]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
@@ -263,12 +264,11 @@
 
 (deftest trace-group-cascades-classifies
   (testing "group-cascades splits trace events into six-domino slots.
-            Per rf2-wvzgd the projection now lives in
-            `re-frame.trace.projection`; Story exposes the same fn
-            under `re-frame.story.ui.trace/group-cascades` for callers
-            wired to that namespace. Event shapes here track the
-            framework's actual emit pattern per Spec 009 §`:op-type`
-            vocabulary."
+            Per rf2-wvzgd the projection lives in
+            `re-frame.trace.projection` — consumers (Story's trace
+            panel, Causa, pair2) require that namespace directly.
+            Event shapes here track the framework's actual emit
+            pattern per Spec 009 §`:op-type` vocabulary."
     (let [evs       [{:op-type :event :operation :event/dispatched
                       :id 1 :tags {:dispatch-id 100 :event [:foo]}}
                      {:op-type :event :operation :event
@@ -281,7 +281,7 @@
                       :id 5 :tags {:dispatch-id 100 :sub-id :sub/foo}}
                      {:op-type :view :operation :view/render
                       :id 6 :tags {:dispatch-id 100 :render-key [:app/root nil]}}]
-          cascades  (trace/group-cascades evs)]
+          cascades  (projection/group-cascades evs)]
       (is (= 1 (count cascades)))
       (let [c (first cascades)]
         (is (= [:foo] (:event c)))


### PR DESCRIPTION
## Summary

`tools/story/ui/trace.cljs` carried a one-liner re-export tagged "for backwards-compat for any in-tree consumer":

\`\`\`clojure
;; Re-export for backwards-compat for any in-tree consumer.
(def group-cascades projection/group-cascades)
\`\`\`

Pre-alpha: no back-compat. Cut the indirection so consumers call the canonical home (`re-frame.trace.projection`) directly.

- Delete the re-export from `tools/story/ui/trace.cljs`.
- Update the one in-file call site (`panel` render path) to `projection/group-cascades` — `projection` is already required at the top of the ns.
- Update the one test consumer (`tools/story/test/re_frame/story_ui_cljs_test.cljs`) to require `re-frame.trace.projection` and call `projection/group-cascades` directly. Refresh the surrounding docstring to drop the "Story exposes the same fn under …" wording.

LoC delta: +11 / -13.

## Quality gates

- `tools/story/` JVM tests — 406 tests, 1236 assertions, 0 failures.
- `npm run test:cljs` — 2014 tests, 5695 assertions, 0 failures.
- `npm run test:bundle-isolation` — PASS.
- `npx shadow-cljs release examples/counter-with-stories` — Build completed clean (3 files compiled, no new warnings).

## Test plan

- [x] Confirm only one `trace/group-cascades` consumer existed before the change (the test).
- [x] Confirm only one in-file caller of `group-cascades` (the `panel` render path).
- [x] Story JVM tests pass.
- [x] `npm run test:cljs` passes.
- [x] `npm run test:bundle-isolation` passes.
- [x] `examples/counter-with-stories` release build clean.

Closes rf2-r9zah.