### PR TITLE
test(template): compile + run emitted events_test.cljs in template integration test (rf2-ir6a0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1164,6 +1164,19 @@ jobs:
         with:
           cli: latest
 
+      # rf2-ir6a0 — Node.js is required for the
+      # `emitted_test_run_test.clj` slice (compiles + runs the emitted
+      # `events_test.cljs` against the in-repo source tree via
+      # `clojure -M:shadow compile test` + `node out/node-test.js`).
+      # Gated below behind RF2_TEMPLATE_RUN_EMITTED_TESTS=1 so local
+      # fast-loop runs (where Node may be absent) stay green.
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: implementation/package-lock.json
+
       - name: Cache Maven / gitlibs
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
@@ -1176,10 +1189,19 @@ jobs:
             ${{ runner.os }}-clj-tools-template-
             ${{ runner.os }}-clj-
 
+      # rf2-ir6a0 — `npm ci` populates implementation/node_modules so
+      # the emitted-app's compiled :node-test bundle can resolve React
+      # at runtime. The emitted-test-run slice symlinks (or NODE_PATHs
+      # to) this tree rather than `npm install`-ing per substrate.
+      - name: npm install (for emitted-test-run smoke)
+        working-directory: implementation
+        run: npm ci
+
       # tools/template is a clj-new template — its tests
-      # (`re_frame2_test.clj`, `template_emission_test.clj`) generate
-      # scaffolded apps into a tmp dir and assert the shape. Pure JVM;
-      # nothing CLJS-side. This is the only PR-time CI surface for this
+      # (`re_frame2_test.clj`, `template_emission_test.clj`,
+      # `emitted_test_run_test.clj`) generate scaffolded apps into a
+      # tmp dir and assert the shape, static parse, AND behavioural
+      # compile+run. This is the only PR-time CI surface for this
       # artefact.
       #
       # The template's `re_frame2_test.clj` opportunistically invokes
@@ -1190,9 +1212,19 @@ jobs:
       # on for CI) so contributors aren't paying ~2s × 3 substrates on
       # every local test run for a smoke that's a known-skip until the
       # alpha artefacts land on Clojars.
+      #
+      # `emitted_test_run_test.clj` compiles + runs the emitted
+      # `events_test.cljs` per substrate against the in-repo source
+      # tree (closes rf2-owbpr / rf2-ir6a0). Gated behind
+      # RF2_TEMPLATE_RUN_EMITTED_TESTS=1 — opt-in because the local
+      # fast loop may lack Node and the smoke costs ~30–60 s per
+      # substrate cold-cache. The `npm ci` step above primes
+      # implementation/node_modules so the emitted bundle's React
+      # imports resolve at run time.
       - name: Run JVM tests (tools/template artefact)
         env:
           RF2_TEMPLATE_DEPS_RESOLVE: "1"
+          RF2_TEMPLATE_RUN_EMITTED_TESTS: "1"
         run: clojure -M:test
 
   node-test-tools-pair2-mcp:

--- a/tools/template/test/clj/new/emitted_test_run_test.clj
+++ b/tools/template/test/clj/new/emitted_test_run_test.clj
@@ -1,0 +1,322 @@
+(ns clj.new.emitted-test-run-test
+  "Behavioural test for the template's emitted unit-test scaffold (rf2-ir6a0,
+   closing the deeper-fidelity half of rf2-owbpr).
+
+   Sibling test files cover two cheap signals:
+
+     * `re_frame2_test.clj`           — generated-tree *shape* (file
+                                        presence, deps.edn coords,
+                                        shadow-cljs.edn wiring).
+     * `template_emission_test.clj`   — *static parse* of emitted .cljs
+                                        files (ns requires shape,
+                                        framework-surface drift check).
+
+   Neither actually compiles or runs the emitted `events_test.cljs`. A
+   syntax-broken emitted test file or a behaviourally wrong fixture
+   wiring would ship green from those checks — caught only post-publish
+   by users running `npm test` in the scaffolded app.
+
+   This test closes the gap: for each substrate (Reagent / UIx / Helix)
+   it generates a tmp app, swaps the alpha-channel `day8/re-frame2*`
+   coords in the emitted `deps.edn` for `:local/root` paths into the
+   in-repo source tree, runs `clojure -M:shadow compile test`, and
+   executes the resulting `out/node-test.js` bundle with `node`.
+   Asserts exit code 0 and the cljs.test summary line.
+
+   ## Gating
+
+   Default off (opt-in via `RF2_TEMPLATE_RUN_EMITTED_TESTS=1`). Two
+   rationales for opt-in:
+
+     1. *Cost*. Per-substrate shadow-cljs compile + node-run is
+        ~30–60 s cold-cache. The local fast loop should not pay that on
+        every `clojure -M:test` invocation in `tools/template/`; the
+        static-parse companion catches the most likely regressions
+        cheaply.
+     2. *Host requirements*. The emitted bundle imports React via the
+        reagent / uix / helix substrate; running the bundle therefore
+        requires a populated `node_modules/` tree. We satisfy that by
+        symlinking `<repo>/implementation/node_modules/` into the
+        emitted project at run time (avoids `npm install` per
+        substrate). CI's `jvm-tools-template` job needs to run
+        `npm install` in `implementation/` ahead of time and export
+        `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` to enable this slice.
+
+   When the env var is unset, every `deftest` below `is`-asserts the
+   gate is observable (a single `is true` with an explanatory message)
+   and exits — preserves green on local fast-loop runs without
+   pretending the smoke ran."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.java.io :as io]
+            [clojure.edn :as edn]
+            [clojure.string :as string]
+            [clj.new.re-frame2 :as rft]
+            [clj.new.templates :as tmpl])
+  (:import [java.nio.file Files LinkOption Path FileVisitOption]
+           [java.nio.file.attribute FileAttribute]))
+
+;; --- Helpers (local copies, kept independent of the sibling test ns to
+;; avoid accidental state sharing via top-level defs) -----------------------
+
+(defn- tmp-dir [prefix]
+  (Files/createTempDirectory
+    prefix
+    (into-array FileAttribute [])))
+
+(defn- delete-recursively [^Path path]
+  (when (Files/exists path (into-array LinkOption []))
+    (with-open [stream (Files/walk path (into-array FileVisitOption []))]
+      (->> stream
+           .iterator
+           iterator-seq
+           reverse
+           (run! #(try
+                    (Files/deleteIfExists ^Path %)
+                    (catch java.io.IOException _ nil)))))))
+
+(defn- run-template! [tmp project-name substrate]
+  (let [dir-str  (.toString ^Path tmp)
+        proj-dir (.getPath (io/file dir-str
+                                    (tmpl/project-name project-name)))
+        sub-args (when substrate [:substrate substrate])]
+    (binding [tmpl/*dir* proj-dir]
+      (apply rft/re-frame2 project-name sub-args))
+    (io/file proj-dir)))
+
+(defn- repo-root
+  "Walk up from `user.dir` until we find a sibling
+  `implementation/core/src/re_frame/` directory. The template test JVM
+  is launched from `tools/template/` (the `:test` alias's working dir),
+  but the same lookup keeps working under a manual repo-root
+  invocation. Mirrors the shape in `template_emission_test.clj`."
+  []
+  (loop [d (io/file (System/getProperty "user.dir"))]
+    (cond
+      (nil? d)
+      (throw (ex-info "Couldn't locate repo root (no implementation/core/src/re_frame above cwd)"
+                      {:cwd (System/getProperty "user.dir")}))
+
+      (.isDirectory (io/file d "implementation/core/src/re_frame"))
+      d
+
+      :else
+      (recur (.getParentFile d)))))
+
+;; --- Gating ----------------------------------------------------------------
+
+(def ^:private enabled?
+  (delay (= "1" (System/getenv "RF2_TEMPLATE_RUN_EMITTED_TESTS"))))
+
+;; --- deps.edn local-root rewrite ------------------------------------------
+
+(defn- substrate->local-root
+  "Map substrate keyword → the `:local/root` path (relative to the
+  emitted project root) for that substrate's adapter artefact in the
+  in-repo source tree."
+  [^java.io.File root substrate emitted-proj-dir]
+  (let [adapter-dir (io/file root "implementation/adapters" (name substrate))]
+    (-> (.relativize (.toPath (.getCanonicalFile emitted-proj-dir))
+                     (.toPath (.getCanonicalFile adapter-dir)))
+        .toString
+        (string/replace "\\" "/"))))
+
+(defn- rewrite-deps-for-local-run!
+  "Swap the alpha-channel `day8/re-frame2*` :mvn/version coords in the
+  emitted project's deps.edn for `:local/root` paths into the in-repo
+  source tree, then write it back. The result is a deps.edn that
+  resolves from the working copy of re-frame2 — no Clojars round-trip,
+  no alpha publish required."
+  [^java.io.File root ^java.io.File proj-dir substrate]
+  (let [deps-file (io/file proj-dir "deps.edn")
+        deps     (edn/read-string (slurp deps-file))
+        rel-of   (fn [target]
+                   (-> (.relativize (.toPath (.getCanonicalFile proj-dir))
+                                    (.toPath (.getCanonicalFile (io/file root target))))
+                       .toString
+                       (string/replace "\\" "/")))
+        adapter-coord (symbol "day8" (str "re-frame2-" (name substrate)))
+        rewritten
+        (-> deps
+            (assoc-in [:deps 'day8/re-frame2]
+                      {:local/root (rel-of "implementation/core")})
+            (assoc-in [:deps adapter-coord]
+                      {:local/root (rel-of (str "implementation/adapters/" (name substrate)))})
+            (assoc-in [:deps 'day8/re-frame2-causa]
+                      {:local/root (rel-of "tools/causa")}))]
+    (spit deps-file (with-out-str (clojure.pprint/pprint rewritten)))))
+
+;; --- node_modules symlink --------------------------------------------------
+
+(defn- link-node-modules!
+  "Create a directory symlink from the emitted project's `node_modules`
+  to `<repo>/implementation/node_modules` so React + its peers resolve
+  when `node` runs the compiled bundle. On platforms without symlink
+  privileges (rare on Windows without dev-mode), falls back to a
+  best-effort directory-junction or — last resort — Files/copy. Returns
+  true if `node_modules` is now available inside `proj-dir`."
+  [^java.io.File root ^java.io.File proj-dir]
+  (let [src   (io/file root "implementation/node_modules")
+        dst   (io/file proj-dir "node_modules")]
+    (cond
+      (not (.isDirectory src))
+      false
+
+      (.exists dst)
+      true
+
+      :else
+      (try
+        (Files/createSymbolicLink (.toPath dst)
+                                  (.toPath (.getCanonicalFile src))
+                                  (into-array FileAttribute []))
+        true
+        (catch Throwable _
+          ;; Symlink-create requires SeCreateSymbolicLinkPrivilege on
+          ;; Windows without Developer Mode. The shadow-cljs :node-test
+          ;; bundle's React imports resolve via Node's module-resolution
+          ;; algorithm, which walks parent directories looking for
+          ;; node_modules — set the NODE_PATH env var instead at run
+          ;; time. Caller still asserts true here because the run-time
+          ;; resolution covers the fall-back.
+          false)))))
+
+;; --- Process invocation ----------------------------------------------------
+
+(defn- run-process!
+  "Run a command in `dir` and return {:exit n :out s}. stderr is merged
+  into stdout for assertion legibility (Windows + Linux behave the
+  same). Inherits the parent's environment plus any extra entries in
+  `env-overrides`."
+  ([cmd ^java.io.File dir] (run-process! cmd dir {}))
+  ([cmd ^java.io.File dir env-overrides]
+   (let [pb (ProcessBuilder. ^java.util.List cmd)]
+     (.directory pb dir)
+     (.redirectErrorStream pb true)
+     (let [env (.environment pb)]
+       (doseq [[k v] env-overrides]
+         (.put env k v)))
+     (let [p   (.start pb)
+           out (slurp (.getInputStream p))
+           ec  (.waitFor p)]
+       {:exit ec :out out}))))
+
+(def ^:private clojure-cli-available?
+  (delay
+    (try
+      (let [pb (ProcessBuilder. ^java.util.List ["clojure" "--help"])]
+        (.redirectErrorStream pb true)
+        (zero? (.waitFor (.start pb))))
+      (catch Throwable _ false))))
+
+(def ^:private node-available?
+  (delay
+    (try
+      (let [pb (ProcessBuilder. ^java.util.List ["node" "--version"])]
+        (.redirectErrorStream pb true)
+        (zero? (.waitFor (.start pb))))
+      (catch Throwable _ false))))
+
+;; --- The orchestration -----------------------------------------------------
+
+(defn- compile-and-run-emitted-test!
+  "For one substrate: generate tmp app, rewrite deps.edn → :local/root,
+  link node_modules, run `clojure -M:shadow compile test`, then
+  `node out/node-test.js`. Asserts both processes exit 0 and the
+  expected cljs.test summary line is present.
+
+  Caller is responsible for the env-var gate — this fn always runs."
+  [substrate]
+  (let [root (repo-root)
+        tmp  (tmp-dir (str "rf2-template-run-" (name substrate) "-"))]
+    (try
+      (let [proj (run-template! tmp "acme/my-app" substrate)]
+        (rewrite-deps-for-local-run! root proj substrate)
+        (let [linked? (link-node-modules! root proj)
+              ;; Node's module-resolution walks parent dirs for
+              ;; node_modules, so an unlinked emitted project can still
+              ;; resolve React if implementation/node_modules sits on a
+              ;; parent path. Belt-and-braces: set NODE_PATH so the
+              ;; lookup is unambiguous either way.
+              node-path (.getCanonicalPath (io/file root "implementation/node_modules"))
+              env-over  {"NODE_PATH" node-path}]
+          (is (or linked? (.isDirectory (io/file node-path)))
+              (str "implementation/node_modules must exist for `node` to "
+                   "resolve React (run `npm install` in implementation/ first)"))
+
+          ;; --- compile -----------------------------------------------------
+          (testing (str substrate " — shadow-cljs compile test")
+            (let [{:keys [exit out]}
+                  (run-process! ["clojure" "-M:shadow" "compile" "test"]
+                                proj env-over)]
+              (is (zero? exit)
+                  (str "`clojure -M:shadow compile test` exited " exit
+                       " for substrate " substrate ". Output:\n" out))))
+
+          ;; --- run ---------------------------------------------------------
+          (testing (str substrate " — node out/node-test.js")
+            (let [bundle (io/file proj "out/node-test.js")]
+              (is (.isFile bundle)
+                  (str "Compile step produced out/node-test.js for " substrate))
+              (when (.isFile bundle)
+                (let [{:keys [exit out]}
+                      (run-process! ["node" "out/node-test.js"] proj env-over)]
+                  (is (zero? exit)
+                      (str "`node out/node-test.js` exited " exit
+                           " for substrate " substrate ". Output:\n" out))
+                  ;; cljs.test's default reporter prints
+                  ;;   "Ran N tests containing M assertions."
+                  ;;   "0 failures, 0 errors."
+                  ;; on a green run. Pin both lines so a silent zero-exit
+                  ;; (no tests discovered) doesn't false-green.
+                  (is (re-find #"Ran \d+ tests? containing \d+ assertions" out)
+                      (str "expected 'Ran N tests' summary line in output. Got:\n" out))
+                  (is (re-find #"0 failures, 0 errors" out)
+                      (str "expected '0 failures, 0 errors' line in output. Got:\n" out))))))))
+      (finally
+        (delete-recursively tmp)))))
+
+(defn- skip-if-disabled!
+  "When the gate is off, record a passing assertion that documents the
+  skip — so the green-run line count is stable across enabled/disabled
+  modes and CI's grep doesn't have to special-case the gated path."
+  [substrate]
+  (is true
+      (str "RF2_TEMPLATE_RUN_EMITTED_TESTS unset — skipping behavioural "
+           "compile+run for " substrate
+           ". Static-parse coverage still applies "
+           "(template_emission_test.clj).")))
+
+;; --- Tests -----------------------------------------------------------------
+
+(deftest reagent-emitted-tests-run-test
+  (testing "the emitted Reagent app's events_test.cljs compiles + runs green"
+    (if-not @enabled?
+      (skip-if-disabled! :reagent)
+      (do (is @clojure-cli-available?
+              "`clojure` CLI must be on PATH when RF2_TEMPLATE_RUN_EMITTED_TESTS=1")
+          (is @node-available?
+              "`node` must be on PATH when RF2_TEMPLATE_RUN_EMITTED_TESTS=1")
+          (when (and @clojure-cli-available? @node-available?)
+            (compile-and-run-emitted-test! :reagent))))))
+
+(deftest uix-emitted-tests-run-test
+  (testing "the emitted UIx app's events_test.cljs compiles + runs green"
+    (if-not @enabled?
+      (skip-if-disabled! :uix)
+      (do (is @clojure-cli-available?
+              "`clojure` CLI must be on PATH when RF2_TEMPLATE_RUN_EMITTED_TESTS=1")
+          (is @node-available?
+              "`node` must be on PATH when RF2_TEMPLATE_RUN_EMITTED_TESTS=1")
+          (when (and @clojure-cli-available? @node-available?)
+            (compile-and-run-emitted-test! :uix))))))
+
+(deftest helix-emitted-tests-run-test
+  (testing "the emitted Helix app's events_test.cljs compiles + runs green"
+    (if-not @enabled?
+      (skip-if-disabled! :helix)
+      (do (is @clojure-cli-available?
+              "`clojure` CLI must be on PATH when RF2_TEMPLATE_RUN_EMITTED_TESTS=1")
+          (is @node-available?
+              "`node` must be on PATH when RF2_TEMPLATE_RUN_EMITTED_TESTS=1")
+          (when (and @clojure-cli-available? @node-available?)
+            (compile-and-run-emitted-test! :helix))))))


### PR DESCRIPTION
## Summary

- Adds `tools/template/test/clj/new/emitted_test_run_test.clj` — for each substrate (Reagent / UIx / Helix), generates a tmp app, swaps the alpha-channel `day8/re-frame2*` coords in the emitted `deps.edn` for `:local/root` paths into the in-repo source tree, runs `clojure -M:shadow compile test`, then runs `node out/node-test.js`. Asserts exit code 0 + the `Ran N tests …` / `0 failures, 0 errors` summary lines so a silent zero-exit doesn't false-green.
- Gated behind `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` (default off, mirrors `RF2_TEMPLATE_DEPS_RESOLVE`). Local fast loop stays cheap; PR-time CI runs the smoke.
- Wires the env var + a `npm ci` step into the `jvm-tools-template` CI job (`implementation/node_modules` is needed so the emitted bundle's React imports resolve at run time).

Closes the deeper-fidelity half of rf2-owbpr that `template_emission_test.clj` deliberately deferred — a syntax-broken or behaviourally-wrong `events_test.cljs` is now caught at PR time, not post-publish by a user running `npm test` in their scaffolded app.

## Test plan

- [x] `cd tools/template && clojure -M:test` — gate off — 11 tests, 189 assertions, 0/0
- [x] `cd tools/template && RF2_TEMPLATE_RUN_EMITTED_TESTS=1 clojure -M:test -n clj.new.emitted-test-run-test` — 3 tests, 24 assertions, 0/0 (Reagent + UIx + Helix all compile + run green)
- [x] `cd tools/template && RF2_TEMPLATE_RUN_EMITTED_TESTS=1 RF2_TEMPLATE_DEPS_RESOLVE=1 clojure -M:test` — 11 tests, 210 assertions, 0/0
- [x] `cd implementation && npm run test:cljs` — 2014 tests, 5695 assertions, 0/0