### PR TITLE
fix(testbeds): stabilise long_flow_w_failure flow logic + un-skip cross-cutting #5 (rf2-sabm5)

### DIFF
--- a/testbeds/long_flow_w_failure/README.md
+++ b/testbeds/long_flow_w_failure/README.md
@@ -18,9 +18,18 @@ recomputes all three flows in topo order. Total cascade time =
 
 ```
 :flow-a  :inputs [[:input]]                  :output (* 2 input)        :path [:a-result]
-:flow-b  :inputs [[:input]]                  :output (* 3 input)        :path [:b-result]   ← throws when input ≥ :fail-at
+:flow-b  :inputs [[:input] [:a-result]]      :output (* 3 input)        :path [:b-result]   ← throws when input ≥ :fail-at
 :flow-c  :inputs [[:a-result] [:b-result]]   :output (+ a b)            :path [:c-result]
 ```
+
+`:flow-b` lists `[:a-result]` as a topology-pin input only — Spec 013
+§Topological sort uses path-prefix overlap to fix evaluation order,
+so the declaration forces `:flow-a → :flow-b`. Without it the two
+flows are independent (both read `[:input]`, write disjoint paths)
+and Kahn's algorithm picks an unspecified order between them —
+which would void Rule 1's "prior-flow writes preserved" guarantee
+when `:flow-b` happens to run first. `:flow-b`'s `:output` ignores
+the `a-result` value; its math is still `(* 3 input)`.
 
 ## The four-rule contract this surface exercises
 

--- a/testbeds/long_flow_w_failure/core.cljs
+++ b/testbeds/long_flow_w_failure/core.cljs
@@ -121,6 +121,26 @@
 ;; Flows — three in topo order
 ;; ----------------------------------------------------------------------------
 ;;
+;; Topology pin (rf2-sabm5). Spec 013 §Topological sort orders a flow
+;; map by path-prefix overlap between one flow's `:path` and another's
+;; `:inputs` — two flows that don't share such an overlap are
+;; topologically *parallel*, and Kahn's algorithm picks an unspecified
+;; order between them. The four-rule failure contract talks about
+;; PRIOR flows (those scheduled earlier in topo order); to assert
+;; Rule 1 ("prior-flow writes preserved") against :flow-a when
+;; :flow-b throws, the testbed must pin :flow-a → :flow-b in topo
+;; order. We do that by listing `[:a-result]` in :flow-b's :inputs
+;; — the path-prefix overlap with :flow-a's :path forces the edge.
+;; The same `[:a-result] [:b-result]` pair already pins :flow-c after
+;; both upstreams.
+;;
+;; The :input itself stays in :flow-b's :inputs so the read-from-app-
+;; db dirty-check still fires when the tick handler bumps :input —
+;; without that input edge, :flow-b would still re-evaluate on every
+;; tick (because :a-result advanced), but the input value used inside
+;; :output would not be the trigger. Listing both keeps the value
+;; flow honest and the ordering pinned.
+;;
 ;; Rule-1 / Rule-3 evidence: when :flow-b throws on tick N, :flow-a's
 ;; output for tick N IS flushed to :a-result (prior writes preserved);
 ;; :flow-c's output for tick N is NOT computed (cascade halts).
@@ -134,12 +154,18 @@
              ;; positive evidence of rule 1.
              (* 2 input))
    :path   [:a-result]
-   :doc    "Doubles :input. Watched by :flow-c."})
+   :doc    "Doubles :input. Watched by :flow-b (topo-order pin) and
+            :flow-c (math)."})
 
 (rf/reg-flow
   {:id     ::flow-b
-   :inputs [[:input]]
-   :output (fn flow-b [input]
+   ;; Two inputs — :input drives the math; :a-result is the topo-
+   ;; order pin (see flows-block comment above). The :output fn
+   ;; ignores the a-result value; its only job is to declare the
+   ;; dependency edge so :flow-a's write is observably PRIOR when
+   ;; this flow throws.
+   :inputs [[:input] [:a-result]]
+   :output (fn flow-b [input _a-result]
              ;; HOT PATH — the failure-injection site for the
              ;; cascade. The throw fires whenever this fn is called
              ;; with input == :fail-at. The flow's last-inputs is
@@ -156,17 +182,12 @@
                    ;; The :input value the :tick handler bumps to
                    ;; coincides with the tick index — tick 5
                    ;; bumps :input to 5. So we throw iff input >=
-                   ;; :fail-at (the runtime reads :fail-at out of
-                   ;; app-db at flow-eval time via a closure capture
-                   ;; below — flows take their inputs by path, but
-                   ;; the throwing fn can read any closure-captured
-                   ;; state).
-                   ;;
-                   ;; We close over `(fn ...)` rather than reading
-                   ;; another path so :flow-b stays single-input
-                   ;; (matches the realworld failure shape where
-                   ;; ONE of N flow inputs is the failure trigger,
-                   ;; not the failure config itself).
+                   ;; :fail-at. We close over `(fn ...)` via the
+                   ;; module-level atom rather than reading another
+                   ;; app-db path so the failure threshold isn't
+                   ;; tangled with the dirty-check graph (matches
+                   ;; the realworld shape where the failure config
+                   ;; rides out-of-band, not in app-db).
                    @fail-at-atom]
                (if (and (some? fail-at-input)
                         (>= input fail-at-input))
@@ -177,7 +198,8 @@
                  (* 3 input))))
    :path   [:b-result]
    :doc    "Triples :input — UNLESS input ≥ fail-at, in which case
-            throws every recompute past that threshold."})
+            throws every recompute past that threshold. Reads
+            :a-result for topo-order only (math uses :input)."})
 
 (rf/reg-flow
   {:id     ::flow-c

--- a/testbeds/long_flow_w_failure/spec.cjs
+++ b/testbeds/long_flow_w_failure/spec.cjs
@@ -56,11 +56,6 @@ const { readTraceEventsAsEdn, clearTraceBus, pollUntil } = require(
 );
 
 module.exports = {
-  // The testbed's `::start` schedules ticks via
-  //   `[:dispatch-later {:ms ... :dispatch [::tick]}]`
-  // — but Spec 002 / `re-frame.fx`'s `:dispatch-later` reads `:event`
-  // not `:dispatch`. With the wrong key the deferred timer fires
-  skip: 'long_flow_w_failure testbed flow logic + 4-rule assertions need stabilisation — un-skip exposed :a-result expected >= 10 got 8 at first :flow-b failure. Re-filed for follow-up under rf2-flowfix.',
   name: 'cross-cutting #5 — flow :rf.flow/failed four-rule semantics',
   url: '/testbeds/long-flow-w-failure/',
   run: async (page) => {


### PR DESCRIPTION
## Summary

- **Root cause (#1 — testbed logic).** Spec 013 §Topological sort orders flows by path-prefix overlap between one flow's `:path` and another's `:inputs`. The testbed's original declarations had `:flow-a` and `:flow-b` both reading `[:input]` and writing disjoint paths — Kahn's algorithm therefore picked an unspecified order between them. In practice `:flow-b` ran *first* on every drain. When `:flow-b` threw on tick 5, no prior `:flow-a` write had accumulated in the loop, so Rule 1 ("prior-flow writes preserved") had no evidence to assert against — `:a-result` stayed at 8 (tick 4's last successful value).
- **Fix.** Add `[:a-result]` to `:flow-b`'s `:inputs` as a topology-pin only — the path-prefix overlap with `:flow-a`'s `:path` forces the `:flow-a → :flow-b` edge. `:flow-b`'s `:output` ignores the `a-result` value; math is still `(* 3 input)`.
- **Un-skip.** `testbeds/long_flow_w_failure/spec.cjs` cross-cutting #5 now passes; `skip:` directive removed.

## Test plan

- [x] `npm run test:cljs` — 2014 tests / 5695 assertions, 0 failures
- [x] `npm run test:bundle-isolation` — PASS (no production-bundle leakage)
- [x] `npm run test:examples` — all 36 specs pass, including cross-cutting #5 un-skipped

## Cross-refs

- rf2-sabm5 (this PR)
- rf2-9vcul / PR #1125 — initial `:dispatch-later` key fix
- rf2-hrqvg — hybrid flow-failure contract decision
- rf2-fe84r cross-cutting #5 — un-skip closes the last skip in the cross-cutting six