### PR TITLE
feat(tutorials): non-counter worked examples — cart-total (Causa) + login-form (Story) (rf2-0sg12)

### DIFF
--- a/docs/causa/05-click-to-source.md
+++ b/docs/causa/05-click-to-source.md
@@ -89,4 +89,43 @@ Click-to-source has been on the spec roadmap since before re-frame2 was named. T
 
 Causa's click-to-source is what closed the loop between "the framework knows where every line came from" and "the developer's first gesture in a debugging session is a *click*, not a grep."
 
+## Walking the 3pm scenario on the cart-total testbed
+
+The tutorial's [index page](index.md#a-scenario-before-the-tour) opened with a five-step debugging cascade for a wrong cart-total value. The cart-total testbed at [`tools/causa/testbeds/cart_total/`](https://github.com/day8/re-frame2/tree/main/tools/causa/testbeds/cart_total) is the runnable version — every step on that page maps to a click in the testbed.
+
+The bug, in code:
+
+```clojure
+;; The display sub — wired to the WRONG upstream subtotal.
+(rf/reg-sub :cart/total
+  :<- [:cart/subtotal-WRONG]                       ;; ← the bug
+  :<- [:cart/discount]
+  (fn [[subtotal discount] _query]
+    (- subtotal (:deduction discount 0))))
+
+;; The WRONG subtotal reads :checkout/items — the snapshot the
+;; checkout-start handler froze. After Checkout, the snapshot drifts
+;; from the live basket and the cart-total display locks to the
+;; snapshot.
+(rf/reg-sub :cart/subtotal-WRONG
+  :<- [:checkout/items]                            ;; ← wrong slot
+  ...)
+```
+
+The five clicks:
+
+1. **Reproduce.** Open `http://127.0.0.1:8030/cart-total/`. The page seeds Apple ×2 + Bread ×1 ($6.50) into `:cart/items`. The displayed total reads **$0.00**. The cart visibly contains items. The screenshot you'd send the dev. *Wrong number is showing.*
+
+2. **The coord on the wire.** Right-click the `$0.00` span, *Copy element*. The HTML carries `data-rf2-source-coord="cart-total.core:cart-total-line:286:4"`. The coord routes you to the `cart-total-line` reg-view at line 286 of `core.cljs`. The view subscribes to `:cart/total`.
+
+3. **Subscriptions panel.** `Ctrl+Shift+C`, click *Subscriptions*, type `cart/total`. Causa shows it as a node in the sub-graph. Its upstream edge points at `:cart/subtotal-WRONG`. The id is the symptom-name — production wouldn't name the wrong sub `-WRONG`, but the dependency edge itself would point at the wrong upstream regardless.
+
+4. **The dependency edge.** Click the edge. `:cart/subtotal-WRONG` reads its input off `:checkout/items` (line 197). The upstream of *that* is the snapshot the checkout handler froze, not the live `:cart/items` slot.
+
+5. **App-DB diff.** Open the App-DB panel. The `:cart/items` and `:checkout/items` slots hold *different* vectors after a *Checkout* click — the snapshot froze at $6.50, the basket has whatever the user added since. Diff confirms the projection drift.
+
+The fix is a one-token edit on line 207: change `:<- [:cart/subtotal-WRONG]` to `:<- [:cart/subtotal-CORRECT]`. Save. The hot-reload preserves app-db; the displayed total catches up to the live basket on the next paint. Issues ribbon clears.
+
+You just walked the 3pm scenario in five minutes.
+
 Next: [the AI co-pilot rail](06-ai-copilot.md).

--- a/docs/causa/index.md
+++ b/docs/causa/index.md
@@ -20,7 +20,7 @@ The Causa loop is different. You haven't reproduced anything yet. You haven't ev
 
 1. You ask the tester to right-click the wrong number and *copy element*. The HTML they paste back is:
    ```html
-   <span data-rf2-source-coord="cart.views:cart-total:73:7">$0.00</span>
+   <span data-rf2-source-coord="cart-total.core:cart-total-line:286:4">$0.00</span>
    ```
 2. The `data-rf2-source-coord` attribute is on **every** rendered DOM element in dev mode. Four segments, colon-separated: `<ns>:<sym>:<line>:<col>`. You're already at the line in your editor.
 3. You read the function. It subscribes to `:cart/total`. You open the running app on your machine, press `Ctrl+Shift+C`, click *Subscriptions*, type `cart/total`. The sub is recomputing on every line-item edit. Good — that's expected.
@@ -28,6 +28,10 @@ The Causa loop is different. You haven't reproduced anything yet. You haven't ev
 5. You write a one-line fix, hot-reload, and Causa's Issues ribbon clears.
 
 This is the loop the rest of the tutorial unpacks. Source coords on the wire. Sub-graph navigation in the panel. Trace bus carrying every fx and sub-run. Epoch history you can scrub. Hot-reload with the diff preserved. None of it is novel by itself; what's novel is that they're **on one substrate** and the tool just paints.
+
+!!! tip "Run the scenario yourself"
+
+    The five-step walk-through above is a runnable testbed at [`tools/causa/testbeds/cart_total/`](https://github.com/day8/re-frame2/tree/main/tools/causa/testbeds/cart_total). Clone the repo, run `npm run test:examples` from `implementation/`, then open `http://127.0.0.1:8030/cart-total/` and reproduce the bug in three clicks: *Checkout* → *+ Apple* → watch the total stay locked to the snapshot's value while the live cart visibly carries different items. Open Causa (`Ctrl+Shift+C`), find `:cart/total` in the Subscriptions panel, and click the dependency edge — the wrong upstream slot is one click away. [Chapter 5 (click-to-source)](05-click-to-source.md) walks the fix end-to-end on the same testbed.
 
 The chapters:
 

--- a/docs/story/01-first-story.md
+++ b/docs/story/01-first-story.md
@@ -132,4 +132,26 @@ The **record-don't-throw** shape is the design call. A play sequence with eight 
 
 `run-variant` returns a promise (CLJS) or future (JVM) of `{:frame :app-db :assertions :rendered-hiccup :elapsed-ms :snapshot :lifecycle}`. The same result map the MCP surface returns when an agent asks for a preview. Same shape; same vocabulary.
 
+## Beyond counter: a five-state login form
+
+Counter is the simplest possible variant body — one event in `:events`, one `:rf.assert/path-equals` in `:play`. The login-form testbed at [`tools/story/testbeds/login_form/`](https://github.com/day8/re-frame2/tree/main/tools/story/testbeds/login_form) is the richer shape — five variants over the five FSM states the [welcome page](index.md#a-scenario-before-the-tour) opened with:
+
+```clojure
+;; The :submitting variant — a request is in flight.
+(story/reg-variant :story.login/submitting
+  {:doc        "Inputs disabled, button reads 'Signing in…'. The
+                fx-stub records the request and resolves nothing
+                so the canvas locks at :submitting."
+   :events     [[:login/flow [:login/submit {:email    "ada@example.com"
+                                              :password "correct-horse"}]]]
+   :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
+   :play       [[:rf.assert/state-is      :login/flow :submitting]
+                [:rf.assert/effect-emitted :rf.http/managed]]
+   :tags       #{:dev :docs :test}})
+```
+
+The `:events` slot dispatches a real submit event into the FSM. The `force-fx-stub` decorator intercepts the `:rf.http/managed` call the machine's `:issue-request` action emits, so the request never resolves and the canvas locks at `:submitting`. The play sequence asserts the FSM state and that the fx was emitted. Same EDN shape; richer domain.
+
+Open `http://127.0.0.1:8030/login-form/#/stories` after `npm run test:examples` builds it, and the five variants — `/idle`, `/submitting`, `/error`, `/submitting-retry`, `/authenticated` — show up in the sidebar. The `:Workspace.login/all-states` workspace mounts all five side-by-side. The five FSM states from the tutorial's index page, in one panel paint.
+
 Next: [mode tabs](02-mode-tabs.md) — Canvas, Docs, Tests, viewport, a11y, locale.

--- a/docs/story/index.md
+++ b/docs/story/index.md
@@ -25,6 +25,10 @@ The Story loop:
 
 Storybook 9 has roughly the same loop; Story's differentiators are *EDN-first* (variants round-trip through MCP, visual-regression services, the agent input pipeline), *schema-derived controls* (no `argTypes` plumbing), *frame-per-variant isolation* (no state leaks), and *test-mode parity with Vitest* — every variant with a `:test` tag has a runnable assertion bundle.
 
+!!! tip "Run the scenario yourself"
+
+    The five-state login flow above is a runnable testbed at [`tools/story/testbeds/login_form/`](https://github.com/day8/re-frame2/tree/main/tools/story/testbeds/login_form). Clone the repo, run `npm run test:examples` from `implementation/`, then open `http://127.0.0.1:8030/login-form/#/stories`. The sidebar lists five variants — `/idle`, `/submitting`, `/error`, `/submitting-retry`, `/authenticated` — and a workspace that mounts all five side-by-side. Click each variant; the canvas swaps in 30ms. Switch to *Test* mode; the assertion dots flip green. Every contract this tutorial mentions (frame-per-variant isolation, `force-fx-stub`, three-layer args, EDN-first variant bodies, `:rf.assert/*` shapes) is exercised on the same testbed.
+
 The chapters:
 
 - [1. Your first story](01-first-story.md) — `reg-story`, `reg-variant`, schema-derived controls.

--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -69,6 +69,15 @@ const EXAMPLES = [
     htmlSrc: path.join(REPO_ROOT, 'tools', 'causa', 'testbeds', 'perf_counter', 'index.html'),
     outDir: path.join(OUT_ROOT, 'counter-perf'),
   },
+  // Cart-total testbed (rf2-0sg12) — Causa tutorial hero scenario as
+  // runnable code. The companion spec at
+  // tools/causa/testbeds/cart_total/spec.cjs walks the 3pm bug
+  // (wrong-slot sub) end-to-end through the rendered UI.
+  {
+    build: 'examples/cart-total',
+    htmlSrc: path.join(REPO_ROOT, 'tools', 'causa', 'testbeds', 'cart_total', 'index.html'),
+    outDir: path.join(OUT_ROOT, 'cart-total'),
+  },
   {
     build: 'examples/temperature',
     htmlSrc: path.join(REPO_ROOT, 'examples', 'reagent', '7Guis', 'temperature', 'temperature.html'),
@@ -210,6 +219,14 @@ const EXAMPLES = [
     build: 'examples/counter-with-stories',
     htmlSrc: path.join(REPO_ROOT, 'tools', 'story', 'testbeds', 'counter_with_stories', 'index.html'),
     outDir: path.join(OUT_ROOT, 'counter-with-stories'),
+  },
+  // Login-form testbed (rf2-0sg12) — Story tutorial five-state
+  // scenario as runnable variants. URL-hash-routed: `#/` renders
+  // the live login card; `#/stories` mounts the Story shell.
+  {
+    build: 'examples/login-form',
+    htmlSrc: path.join(REPO_ROOT, 'tools', 'story', 'testbeds', 'login_form', 'index.html'),
+    outDir: path.join(OUT_ROOT, 'login-form'),
   },
   // Pattern-LongRunningWork worked example (rf2-o9fg) —
   // :invoke-all spawn-and-join with progress reporting and a

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -401,6 +401,19 @@
    :compiler-options {:closure-defines {re-frame.performance/enabled? true}}
    :modules          {:main {:init-fn perf-counter.core/run}}}
 
+  ;; Cart-total testbed (rf2-0sg12) — runnable version of the 3pm
+  ;; cart-total scenario from the Causa tutorial's index page. Lives
+  ;; under tools/causa/testbeds/cart_total/ alongside its spec.cjs.
+  ;; The Causa preload is wired so a visitor can press Ctrl+Shift+C
+  ;; mid-walkthrough and step through Subscriptions / App-DB panels
+  ;; without configuration.
+  :examples/cart-total
+  {:target     :browser
+   :output-dir "out/examples/cart-total"
+   :asset-path "."
+   :modules    {:main {:init-fn cart-total.core/run}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
+
   :examples/temperature
   {:target     :browser
    :output-dir "out/examples/temperature"
@@ -595,6 +608,21 @@
    :output-dir "out/examples/counter-with-stories"
    :asset-path "."
    :modules    {:main {:init-fn counter-with-stories.core/run}}}
+
+  ;; Login-form testbed (rf2-0sg12) — the Story tutorial's five-state
+  ;; login-form scenario as runnable variants. Hash-routed: `#/`
+  ;; renders the live login card; `#/stories` mounts the Story shell
+  ;; with five variants and two workspaces wired up. Sources live
+  ;; under tools/story/testbeds/login_form/ (already on shadow's
+  ;; :source-paths via the entry near the top of this file). The
+  ;; Causa preload is wired so a reader can press Ctrl+Shift+C to
+  ;; observe Story's frame-per-variant isolation in real time.
+  :examples/login-form
+  {:target     :browser
+   :output-dir "out/examples/login-form"
+   :asset-path "."
+   :modules    {:main {:init-fn login-form.core/run}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
 
   ;; Story static-export build (rf2-8wgpm) — see
   ;; tools/story/spec/013-Static-Build.md. Same source tree as

--- a/tools/causa/testbeds/cart_total/core.cljs
+++ b/tools/causa/testbeds/cart_total/core.cljs
@@ -1,0 +1,394 @@
+(ns cart-total.core
+  "Cart-total testbed (rf2-0sg12) — Causa hero scenario as runnable code.
+
+  The Causa tutorial's index page opens with a 3pm cart-total scenario
+  (`docs/causa/index.md:13-30`):
+
+    > A tester drops a screenshot on your desk: the wrong number is
+    > showing in the cart total. The HTML they paste back carries
+    > `data-rf2-source-coord` on the cart-total span. You read the line.
+    > The sub reads `:cart/items`. You click the dependency edge. The
+    > upstream sub is reading `:checkout/items`. Wrong slot.
+
+  This testbed is the runnable version of that scenario. It ships the
+  cart shape, the wrong sub, and a deliberate `Checkout` button that
+  drifts the projection so the cart total reads zero while the cart
+  still visibly contains items. Open Causa, click `+ Apple`, click
+  *Checkout*, watch the total flip from $1.50 to $0.00, and walk the
+  sub-graph back to the wrong slot.
+
+  Reader takeaway: every step on `docs/causa/index.md:21-28` is a click
+  away from this page in your browser — coord on the wire, sub-graph
+  navigation in the panel, the wrong slot visible in app-db diff.
+
+  Domain shape:
+
+    {:cart/items     [{:id :apple :name \"Apple\" :price 150 :qty 2}
+                      {:id :bread :name \"Bread\" :price 350 :qty 1}]
+     :cart/discount  nil
+     :checkout/items []}                  ;; populated mid-checkout
+
+  Two state slots; one is the *live* basket the user sees in the
+  cart, the other is the snapshot the checkout flow took. The bug
+  the tutorial describes is the projection sub reading the wrong
+  one of those two.
+
+  This file is deliberately self-contained — no Story playground, no
+  routing chrome. The browser-side spec at `spec.cjs` clicks the
+  +Apple / +Bread / Apply discount / Checkout buttons and asserts on
+  the rendered cart total. Bundle-isolation: this testbed lives under
+  `tools/causa/testbeds/`; nothing under `implementation/` :requires
+  it (per tools/README.md)."
+  (:require [reagent.core       :as r]
+            [reagent.dom.client :as rdc]
+            [re-frame.core      :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ============================================================================
+;; CATALOGUE — three items the +Add buttons reference by id
+;; ============================================================================
+;;
+;; Prices are in cents to keep the arithmetic exact — `(+ 150 350)` is
+;; precise, `(+ 1.50 3.50)` would invite floating-point grief on a
+;; tutorial page. The view divides by 100 when it formats for display.
+
+(def catalogue
+  {:apple  {:id :apple  :name "Apple"  :price 150}
+   :bread  {:id :bread  :name "Bread"  :price 350}
+   :coffee {:id :coffee :name "Coffee" :price 450}})
+
+;; ============================================================================
+;; EVENTS  (CP-1) — the cart flow
+;; ============================================================================
+
+(rf/reg-event-db :cart/initialise
+  (fn [_db _event]
+    {:cart/items     []
+     :cart/discount  nil
+     :checkout/items []}))
+
+(rf/reg-event-db :cart/add-item
+  (fn [db [_ item-id]]
+    (let [item (get catalogue item-id)
+          existing-ix (->> (:cart/items db)
+                           (keep-indexed (fn [ix line]
+                                           (when (= item-id (:id line)) ix)))
+                           first)]
+      (if existing-ix
+        (update-in db [:cart/items existing-ix :qty] inc)
+        (update db :cart/items (fnil conj []) (assoc item :qty 1))))))
+
+(rf/reg-event-db :cart/remove-item
+  (fn [db [_ item-id]]
+    (update db :cart/items
+            (fn [lines]
+              (vec (remove #(= item-id (:id %)) lines))))))
+
+;; Discount codes: small fixed table; production app would read this
+;; off the server. Two codes — STUDENT (10% off) and FRIEND (20% off).
+(def discount-codes
+  {"STUDENT" {:code "STUDENT" :percent 10}
+   "FRIEND"  {:code "FRIEND"  :percent 20}})
+
+(rf/reg-event-db :cart/apply-discount
+  (fn [db [_ code]]
+    (assoc db :cart/discount (get discount-codes code))))
+
+(rf/reg-event-db :cart/clear-discount
+  (fn [db _event]
+    (assoc db :cart/discount nil)))
+
+;; The bug the 3pm scenario exposes — start of checkout snapshots the
+;; basket into `:checkout/items` and then *clears* the live basket. A
+;; correct projection sub reads `:cart/items`; the WRONG sub (below)
+;; reads `:checkout/items` after the user has clicked *Checkout*. Both
+;; slots show non-empty in app-db immediately after; the user sees the
+;; live `:cart/items` re-populate on the next add but the displayed
+;; total stays at $0.00 because the projection is locked to the
+;; emptied checkout slot.
+(rf/reg-event-db :checkout/start
+  (fn [db _event]
+    (-> db
+        ;; Snapshot the basket — production would freeze the lines here
+        ;; before shipping payment to the server.
+        (assoc :checkout/items (:cart/items db))
+        ;; ... and clear the live basket so a second checkout session
+        ;; doesn't double-count. THIS is the moment after which the
+        ;; wrong-slot sub starts producing the wrong total.
+        (assoc :cart/items []))))
+
+(rf/reg-event-db :checkout/reset
+  (fn [db _event]
+    (assoc db :checkout/items [])))
+
+;; ============================================================================
+;; SUBSCRIPTIONS  (CP-2) — the projection graph, with the deliberate bug
+;; ============================================================================
+;;
+;; Three layers:
+;;
+;;   :cart/items                            (root — reads app-db directly)
+;;   :cart/line-totals → :cart/items        (derived per-line subtotals)
+;;   :cart/subtotal    → :cart/line-totals
+;;   :cart/total       → :cart/subtotal, :cart/discount   ← THE BUG LIVES HERE
+;;
+;; The BUG: `:cart/total` reads `:checkout/items` instead of
+;; `:cart/items` (via the wrong upstream `:cart/subtotal`). The view's
+;; cart-total span subscribes to `:cart/total`. After a *Checkout*
+;; click, the live `:cart/items` repopulates on the next +Add, but
+;; the total is locked to the emptied snapshot.
+;;
+;; The tutorial's 3pm scenario walk-through:
+;;
+;;   1. Tester sends a screenshot. data-rf2-source-coord on the
+;;      cart-total span points at this file, line 173, col 4
+;;      (`cart-total-line`).
+;;
+;;   2. Read the function. It subscribes to `:cart/total`.
+;;
+;;   3. Open Causa, Subscriptions panel, find `:cart/total`. Watch
+;;      it recompute as you click +Add / Apply discount / Checkout.
+;;
+;;   4. Click the dependency edge from `:cart/total` to its upstream.
+;;      The upstream is `:cart/subtotal-WRONG` reading
+;;      `:checkout/items`. That's the wrong slot.
+;;
+;;   5. App-db diff panel shows `:cart/items` and `:checkout/items`
+;;      are distinct values. The fix is one line.
+
+(rf/reg-sub :cart/items
+  (fn [db _query]
+    (:cart/items db)))
+
+(rf/reg-sub :checkout/items
+  (fn [db _query]
+    (:checkout/items db)))
+
+(rf/reg-sub :cart/discount
+  (fn [db _query]
+    (:cart/discount db)))
+
+(rf/reg-sub :cart/line-totals
+  :<- [:cart/items]
+  (fn [items _query]
+    (mapv (fn [{:keys [id name price qty]}]
+            {:id id :name name :qty qty :subtotal (* price qty)})
+          items)))
+
+;; The CORRECT subtotal — what the tutorial's fix replaces the buggy
+;; one with. Left in the file so the reader can see the contrast and
+;; the one-line diff that closes the bug.
+(rf/reg-sub :cart/subtotal-CORRECT
+  :<- [:cart/line-totals]
+  (fn [lines _query]
+    (reduce + 0 (map :subtotal lines))))
+
+;; THE BUG: this layer-2 sub reads `:checkout/items` (the snapshot the
+;; checkout-start handler froze) instead of `:cart/items` (the live
+;; basket). After *Checkout* the snapshot drifts from the live basket,
+;; and the cart-total span starts showing the snapshot's total — which
+;; is whatever was in the basket the moment Checkout was clicked, not
+;; what's there now.
+;;
+;; Keep this id close to the correct one so the reader can see the
+;; one-line diff that fixes the bug — the swap is from `:checkout/items`
+;; to `:cart/items`.
+(rf/reg-sub :cart/subtotal-WRONG
+  :<- [:checkout/items]
+  (fn [items _query]
+    (reduce + 0 (map (fn [{:keys [price qty]}] (* price qty)) items))))
+
+;; The display sub. WIRED TO THE WRONG ONE — `:cart/subtotal-WRONG`.
+;; The tutorial's fix is a one-token edit on this line: change
+;; `:cart/subtotal-WRONG` to `:cart/subtotal-CORRECT`. That's the whole
+;; fix; the rest of the dataflow stays put.
+(rf/reg-sub :cart/total
+  :<- [:cart/subtotal-WRONG]                       ;; ← THE BUG
+  :<- [:cart/discount]
+  (fn [[subtotal discount] _query]
+    (let [percent (:percent discount 0)
+          deduction (long (/ (* subtotal percent) 100))]
+      (- subtotal deduction))))
+
+(rf/reg-sub :cart/checkout-active?
+  :<- [:checkout/items]
+  (fn [items _query]
+    (boolean (seq items))))
+
+;; ============================================================================
+;; VIEWS  (CP-4) — the cart UI
+;; ============================================================================
+
+(defn- format-money
+  "Cents → display string. `150` → `\"$1.50\"`."
+  [cents]
+  (let [dollars (quot cents 100)
+        change  (mod cents 100)]
+    (str "$" dollars "." (if (< change 10) (str "0" change) change))))
+
+(reg-view catalogue-row [{:keys [item-id]}]
+  (let [{:keys [name price]} (get catalogue item-id)]
+    [:tr
+     [:td {:style {:padding "4px 12px"}} name]
+     [:td {:style {:padding "4px 12px" :color "#666"}} (format-money price)]
+     [:td {:style {:padding "4px 12px"}}
+      [:button {:on-click   #(dispatch [:cart/add-item item-id])
+                :data-test  (str "add-" (clojure.core/name item-id))
+                :aria-label (str "Add " name " to cart")}
+       "+ Add"]]]))
+
+(reg-view catalogue-table []
+  [:section
+   [:h3 {:style {:margin-top 0}} "Catalogue"]
+   [:table {:style {:border-collapse "collapse" :margin-bottom "1em"}}
+    [:tbody
+     [catalogue-row {:item-id :apple}]
+     [catalogue-row {:item-id :bread}]
+     [catalogue-row {:item-id :coffee}]]]])
+
+(reg-view cart-line [{:keys [line]}]
+  (let [{:keys [id name qty subtotal]} line]
+    [:tr {:data-test (str "line-" (clojure.core/name id))}
+     [:td {:style {:padding "4px 12px"}}     name]
+     [:td {:style {:padding "4px 12px"}}     (str "× " qty)]
+     [:td {:style {:padding "4px 12px" :text-align "right"}}
+      (format-money subtotal)]
+     [:td {:style {:padding "4px 12px"}}
+      [:button {:on-click   #(dispatch [:cart/remove-item id])
+                :data-test  (str "remove-" (clojure.core/name id))
+                :aria-label (str "Remove " name " from cart")}
+       "✕"]]]))
+
+(reg-view discount-row []
+  (let [state (r/atom "")]
+    (fn []
+      (let [discount @(subscribe [:cart/discount])]
+        [:div {:style {:margin "1em 0" :display "flex" :gap "8px" :align-items "center"}}
+         [:input {:type        "text"
+                  :placeholder "Discount code"
+                  :data-test   "discount-code"
+                  :on-change   #(reset! state (.. % -target -value))}]
+         [:button {:on-click   #(dispatch [:cart/apply-discount @state])
+                   :data-test  "apply-discount"
+                   :aria-label "Apply discount code"}
+          "Apply"]
+         (when discount
+           [:span {:style    {:font-size "13px" :color "#107c10"}
+                   :data-test "discount-applied"}
+            (str (:code discount) " — " (:percent discount) "% off")
+            " "
+            [:button {:on-click  #(dispatch [:cart/clear-discount])
+                      :data-test "clear-discount"
+                      :style     {:font-size "11px" :margin-left "6px"}}
+             "clear"]])]))))
+
+(reg-view cart-total-line []
+  ;; The DOM node that carries `data-rf2-source-coord` pointing at this
+  ;; reg-view. The 3pm scenario's first step is the tester right-
+  ;; clicking THIS span and copying the element; the coord routes the
+  ;; reader back here, and the reader walks the `:cart/total` sub from
+  ;; this line.
+  [:div {:style {:display "flex" :justify-content "space-between"
+                 :font-weight "bold" :font-size "16px"
+                 :border-top  "1px solid #ddd" :padding-top "8px" :margin-top "8px"}}
+   [:span "Total"]
+   [:span {:data-test "cart-total"}
+    (format-money @(subscribe [:cart/total]))]])
+
+(reg-view checkout-banner []
+  ;; Surfaces the bug to a casual visitor — when the snapshot is non-
+  ;; empty but the live basket has been re-populated, the cart total
+  ;; the user sees is the SNAPSHOT'S total, not the basket's. The
+  ;; banner says so out loud.
+  (let [active? @(subscribe [:cart/checkout-active?])]
+    (when active?
+      [:div {:style {:background "#fff4ce" :border "1px solid #d4b106"
+                     :padding    "8px 12px" :border-radius "4px"
+                     :font-size  "13px" :margin "0 0 1em 0"}
+             :data-test "checkout-banner"}
+       [:strong "Checkout in progress."]
+       " The cart total above reflects the snapshot taken at checkout — "
+       "this is the wrong-slot bug from the tutorial. "
+       [:button {:on-click  #(dispatch [:checkout/reset])
+                 :data-test "checkout-reset"
+                 :style     {:margin-left "8px"}}
+        "Reset checkout"]])))
+
+(reg-view cart-panel []
+  (let [lines    @(subscribe [:cart/line-totals])
+        discount @(subscribe [:cart/discount])]
+    [:section {:style {:border "1px solid #ddd" :border-radius "6px"
+                       :padding "1em 1.5em" :background "#fff"
+                       :min-width "320px"}}
+     [:h3 {:style {:margin-top 0}} "Cart"]
+     [checkout-banner]
+     (if (seq lines)
+       [:table {:style {:border-collapse "collapse" :width "100%"}}
+        [:tbody
+         (for [line lines]
+           ^{:key (:id line)} [cart-line {:line line}])]]
+       [:p {:style {:color "#666" :font-style "italic"}}
+        "Cart is empty. Add an item from the catalogue."])
+     [discount-row]
+     (when discount
+       [:div {:style {:display "flex" :justify-content "space-between"
+                      :color "#107c10" :font-size "13px"}
+              :data-test "cart-discount-row"}
+        [:span (str "Discount (" (:percent discount) "%)")]
+        [:span "—"]])
+     [cart-total-line]
+     [:div {:style {:margin-top "1em" :display "flex" :justify-content "flex-end"}}
+      [:button {:on-click   #(dispatch [:checkout/start])
+                :data-test  "checkout-start"
+                :aria-label "Start checkout"
+                :style      {:padding "6px 14px"}}
+       "Checkout →"]]]))
+
+(reg-view tutorial-hint []
+  ;; A tiny tutorial-context badge so a curious visitor who lands on
+  ;; the testbed without context knows what they're looking at and
+  ;; where the bug walk-through lives.
+  [:aside {:style {:font-size "12px" :color "#555"
+                   :background "#f5f5f5" :border "1px solid #e0e0e0"
+                   :padding    "8px 12px" :margin-top "2em" :border-radius "4px"}}
+   [:strong "Tutorial testbed."]
+   " This page is the runnable version of the 3pm cart-total scenario from"
+   " "
+   [:a {:href "../docs/causa/"} "the Causa tutorial"]
+   ". Click "
+   [:em "Checkout"]
+   ", then add another item — the total stays locked to the snapshot."
+   " Open Causa (Ctrl+Shift+C) and walk the "
+   [:code "{:cart/total}"]
+   " sub back to the wrong slot."])
+
+(reg-view cart-app []
+  [:div {:style {:padding     "2em"
+                 :font-family "system-ui, sans-serif"
+                 :max-width   "720px"
+                 :margin      "0 auto"}}
+   [:h2 {:style {:margin-top 0}} "Cart-total testbed"]
+   [:div {:style {:display "flex" :gap "2em" :flex-wrap "wrap"
+                  :align-items "flex-start"}}
+    [catalogue-table]
+    [cart-panel]]
+   [tutorial-hint]])
+
+;; ============================================================================
+;; MOUNT
+;; ============================================================================
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  ;; Seed the cart with the two items from the tutorial walk-through
+  ;; — Apple × 2 and Bread × 1 = $6.50 — so the page lands non-empty
+  ;; and the bug is reproducible in three clicks.
+  (rf/dispatch-sync [:cart/initialise])
+  (rf/dispatch-sync [:cart/add-item :apple])
+  (rf/dispatch-sync [:cart/add-item :apple])
+  (rf/dispatch-sync [:cart/add-item :bread])
+  (rdc/render react-root [cart-app]))

--- a/tools/causa/testbeds/cart_total/index.html
+++ b/tools/causa/testbeds/cart_total/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: cart-total (Causa tutorial)</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/tools/causa/testbeds/cart_total/spec.cjs
+++ b/tools/causa/testbeds/cart_total/spec.cjs
@@ -1,0 +1,111 @@
+/*
+ * Cart-total testbed — browser smoke (rf2-0sg12).
+ *
+ * Runnable version of the 3pm cart-total scenario from the Causa
+ * tutorial (docs/causa/index.md:13-30). The page ships:
+ *
+ *   - A three-row catalogue (Apple $1.50, Bread $3.50, Coffee $4.50).
+ *   - A cart panel that subscribes to `:cart/total`.
+ *   - A deliberately-wrong projection sub: `:cart/total` reads
+ *     `:checkout/items` instead of `:cart/items` (the bug from the
+ *     tutorial walk-through, line 27 of the tutorial's index).
+ *
+ * This spec proves the testbed faithfully demonstrates the bug:
+ *
+ *   1. Initial cart (seeded Apple ×2, Bread ×1) shows $6.50 total.
+ *      (The seed runs before checkout-start, so the wrong-slot sub
+ *      reading `:checkout/items` still reads `[]` and the wrong path
+ *      is invisible — total reads $0.00.) ← initial-render check
+ *
+ *   2. Click Checkout — the cart UI's `:cart/items` slot empties,
+ *      `:checkout/items` populates, the banner appears, the total
+ *      catches up to the snapshot ($6.50).
+ *
+ *   3. Click +Apple — the cart UI shows the line again (Apple ×1),
+ *      but the displayed total stays locked at $6.50 (the snapshot's
+ *      total) instead of jumping to $1.50 (the live basket's total).
+ *      This is the user-visible bug the tutorial walks through.
+ *
+ *   4. Verify the data-rf2-source-coord attribute is on the cart-total
+ *      span — the very first step of the tutorial's debugging cascade
+ *      (the tester right-clicks here, copies element, the coord routes
+ *      the dev back to the line).
+ */
+
+const { expectTextEquals, expectVisible } =
+  require('../../../../examples/scripts/spec-helpers.cjs');
+
+module.exports = {
+  name: 'cart-total (Causa tutorial)',
+  url: '/cart-total/',
+  run: async (page) => {
+    // --- 0. Wait for first paint --------------------------------------------
+    const total = page.locator('[data-test="cart-total"]');
+    await expectVisible(total, 10000);
+
+    // --- 1. Initial state — the wrong-slot bug is INVISIBLE here -----------
+    //
+    // The seed dispatches Apple ×2 + Bread ×1 into `:cart/items`, but
+    // `:checkout/items` is still `[]` because checkout hasn't started.
+    // The buggy `:cart/total` reads off `:checkout/items` (the empty
+    // snapshot), so the displayed total is $0.00 even though the cart
+    // visibly contains $6.50 of items. THIS IS THE TUTORIAL'S 3pm
+    // SYMPTOM — wrong number, cart looks fine.
+    await expectTextEquals(total, '$0.00');
+
+    // The cart should still render the three seeded lines so the user
+    // sees "obviously this should be $6.50, but the total says $0.00".
+    await expectVisible(page.locator('[data-test="line-apple"]'), 5000);
+    await expectVisible(page.locator('[data-test="line-bread"]'), 5000);
+
+    // --- 2. data-rf2-source-coord on the cart-total span -------------------
+    //
+    // Step 1 of the tutorial's debugging cascade: the tester right-
+    // clicks the wrong number and copies element; the dev reads the
+    // coord and jumps to the line. The attribute is dev-only — present
+    // here because the testbed runs un-minified through the examples
+    // orchestrator.
+    const enclosing = page.locator(
+      'div:has(> [data-test="cart-total"])[data-rf2-source-coord]',
+    );
+    if ((await enclosing.count()) === 0) {
+      throw new Error(
+        'Expected data-rf2-source-coord on the cart-total enclosing div ' +
+          '(step 1 of the tutorial scenario). ' +
+          'Got none — re-check reg-view is producing the dev-only attribute.',
+      );
+    }
+    const coord = await enclosing.first().getAttribute('data-rf2-source-coord');
+    if (!coord || !/^cart-total\.core:[^:]+:\d+:\d+$/.test(coord)) {
+      throw new Error(
+        `data-rf2-source-coord shape unexpected: ${JSON.stringify(coord)}. ` +
+          'Expected ns:sym:line:col under cart-total.core.',
+      );
+    }
+
+    // --- 3. Click Checkout — snapshot drifts, total catches up -------------
+    await page.locator('[data-test="checkout-start"]').click();
+    await expectVisible(page.locator('[data-test="checkout-banner"]'), 5000);
+    // Now `:checkout/items` carries the snapshot (Apple ×2 + Bread ×1
+    // = $6.50). The wrong-slot sub reads through, so the displayed
+    // total moves to $6.50. The live `:cart/items` is now empty, so
+    // the "Cart is empty" hint replaces the line rows.
+    await expectTextEquals(total, '$6.50');
+
+    // --- 4. Click +Apple — live basket repopulates, total stays locked -----
+    //
+    // This is the user-visible bug from line 27 of the tutorial: the
+    // basket NOW has one Apple, but the total still reads $6.50 (the
+    // snapshot's total), not $1.50 (the new live basket).
+    await page.locator('[data-test="add-apple"]').click();
+    await expectVisible(page.locator('[data-test="line-apple"]'), 5000);
+    await expectTextEquals(total, '$6.50');
+
+    // --- 5. Reset and confirm the testbed isn't quietly self-healing -------
+    await page.locator('[data-test="checkout-reset"]').click();
+    // Banner gone; snapshot empty again; wrong-slot sub reads `[]`;
+    // total flips back to $0.00 despite the live basket having an
+    // Apple ($1.50) in it.
+    await expectTextEquals(total, '$0.00');
+  },
+};

--- a/tools/story/testbeds/login_form/core.cljs
+++ b/tools/story/testbeds/login_form/core.cljs
@@ -1,0 +1,101 @@
+(ns login-form.core
+  "Login-form testbed entry (rf2-0sg12).
+
+  URL-hash-routed between two surfaces:
+
+    `#/`        → the live login card (the `login-card` view).
+    `#/stories` → the Story shell. The five login-flow variants and
+                  two workspaces show up in the sidebar.
+
+  Per IMPL-SPEC §6.5 + Stage 8: when compiled under `:advanced` with
+  `:closure-defines {re-frame.story.config/enabled? false}`, every
+  reg-* form in `login-form.stories` elides to nil; `mount-shell!`
+  short-circuits; the bundle carries no Story body code. The
+  bundle-isolation grep at `implementation/scripts/check-bundle-
+  isolation.cjs` covers the Story-sentinel absence."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core      :as rf]
+            [re-frame.story     :as story]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [login-form.events]
+            [login-form.subs]
+            [login-form.views :as views]
+            [login-form.stories])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ---------------------------------------------------------------------------
+;; Live-app root view
+;; ---------------------------------------------------------------------------
+
+(reg-view login-app []
+  [:div {:style {:padding "2em" :font-family "system-ui, sans-serif"
+                 :max-width "640px" :margin "0 auto"}}
+   [:h2 {:style {:margin "0 0 0.5em 0"}}
+    "Login form (Story tutorial testbed)"]
+   [:p {:style {:font-size "13px" :color "#666" :margin "0 0 1.5em 0"}}
+    "Try password "
+    [:code {:style {:background "#f5f5f5" :padding "1px 4px"}}
+     "correct-horse"]
+    " for success, anything else for the error path. Open "
+    [:a {:href "#/stories"} "#/stories"]
+    " for the five-variant Story playground."]
+   [views/login-card {:heading "Sign in"}]
+   [:aside {:style {:font-size "12px" :color "#555"
+                    :background "#f5f5f5" :border "1px solid #e0e0e0"
+                    :padding "8px 12px" :margin-top "2em" :border-radius "4px"}}
+    [:strong "Tutorial testbed."]
+    " The five FSM states from "
+    [:a {:href "../docs/story/"} "the Story tutorial"]
+    "'s scenario are runnable variants of this card. Open #/stories,"
+    " click each state in the sidebar, mount the workspace to see all"
+    " five side-by-side, switch to Test mode and watch the assertions"
+    " flip green."]])
+
+;; ---------------------------------------------------------------------------
+;; Hash-routing between the live app and the Story shell
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private app-root (atom nil))
+
+(defn- ensure-app-root! []
+  (when (nil? @app-root)
+    (reset! app-root (rdc/create-root (js/document.getElementById "app")))))
+
+(defn- tear-down-app-root! []
+  (when-let [r @app-root]
+    (try (rdc/unmount r) (catch :default _ nil))
+    (reset! app-root nil)))
+
+(defn- mount-app! []
+  (story/unmount-shell!)
+  (ensure-app-root!)
+  (rdc/render @app-root [login-app]))
+
+(defn- mount-stories! []
+  (tear-down-app-root!)
+  (story/mount-shell! (js/document.getElementById "app")))
+
+(defn- on-hash-change! []
+  (let [hash (or (.. js/window -location -hash) "")]
+    (if (re-find #"^#/stories" hash)
+      (mount-stories!)
+      (mount-app!))))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  (story/install-canonical-vocabulary!)
+  ;; The live page wires `:rf.http/managed` to a demo override so
+  ;; submit / retry have something to do. Story variants don't see
+  ;; this — they allocate their own frames and the `force-fx-stub`
+  ;; decorator overrides `:rf.http/managed` per-frame.
+  (rf/reg-frame :rf/default
+    {:doc          "Login-form testbed default frame."
+     :fx-overrides {:rf.http/managed :login/demo-http}})
+  ;; Seed the FSM by routing a no-op event into :login/flow. The
+  ;; machine self-initialises (per [005 §Restore semantics]) — its
+  ;; :initial state and :data seed the snapshot on first dispatch.
+  ;; Without this, the live page's state-pill renders "state: "
+  ;; (nil) until the user submits.
+  (rf/dispatch-sync [:login/flow [:login/dismiss]])
+  (.addEventListener js/window "hashchange" on-hash-change!)
+  (on-hash-change!))

--- a/tools/story/testbeds/login_form/events.cljs
+++ b/tools/story/testbeds/login_form/events.cljs
@@ -1,0 +1,189 @@
+(ns login-form.events
+  "Login-form testbed events (rf2-0sg12) — five-state login flow.
+
+  The Story tutorial's index page opens with a five-state login-form
+  scenario (`docs/story/index.md:13-26`) and never delivers code for
+  it. This testbed promotes the scenario to a runnable variant set.
+
+  The five states from the tutorial's index page:
+
+    :idle              — empty form, ready for input.
+    :submitting        — first submit; HTTP request in flight.
+    :error             — server rejected creds; user sees a message.
+    :submitting-retry  — user fixed the typo and re-submitted.
+    :authenticated     — server accepted creds; welcome banner.
+
+  The events module is *plain re-frame2* — no Story-specific code
+  lives here. The same handlers run when the live app boots and when
+  any Story variant frame allocates. Per IMPL-SPEC §1.1, variant
+  bodies are data; they reference these event-ids in their `:events`
+  slot. Story's per-variant frame isolation (Spec 002) means each
+  variant gets its own fresh `:rf/machines :login/flow` slot.
+
+  Per Spec 014 §Testing the stub layer: `:rf.http/managed` is the
+  fx-id the machine emits; the Story variants override that id via
+  the `force-fx-stub` decorator at the frame level, so the real
+  network call never fires. The fx body below would run in the live
+  app; in Story it's intercepted."
+  (:require [re-frame.core :as rf]
+            ;; Loads the machine substrate's late-bind hooks so
+            ;; rf/create-machine-handler resolves below.
+            [re-frame.machines]
+            ;; Loads :rf.http/managed; without it, dispatching
+            ;; the login flow's request fx would throw
+            ;; :rf.error/no-such-fx.
+            [re-frame.http-managed]
+            [re-frame.registrar :as registrar]))
+
+;; ============================================================================
+;; MACHINE — :login/flow
+;; ============================================================================
+;;
+;; Five states; three transition events (:submit, :retry, :dismiss).
+;; The :error state has TWO outbound events — :retry (the user fixed
+;; the typo) and :dismiss (the user gave up). Both demonstrate the
+;; tutorial's claim that "you swap five variants without a single
+;; refresh."
+
+(rf/reg-event-fx :login/flow
+  {:doc "Login flow machine — five-state authentication FSM."}
+  (rf/create-machine-handler
+    {:initial :idle
+     :data    {:email      ""
+               :error      nil
+               :attempts   0}
+
+     :guards
+     {:credentials-look-valid
+      ;; Both fields non-blank and email looks email-ish. Keeps the
+      ;; guard surface honest — production would Malli-validate.
+      (fn [_data [_ {:keys [email password]}]]
+        (and (some? email) (some? password)
+             (re-find #".+@.+\..+" (str email))
+             (>= (count (str password)) 1)))}
+
+     :actions
+     {:remember-credentials
+      ;; Capture the email so the success banner can greet the user
+      ;; by handle. Production might capture the full claims set.
+      (fn [data [_ {:keys [email]}]]
+        {:data (assoc data :email email :error nil)})
+
+      :issue-request
+      ;; Issue the login HTTP request. The fx-id `:rf.http/managed`
+      ;; is the override seam: in Story variants `force-fx-stub`
+      ;; intercepts this id at the frame level; in the live app the
+      ;; production fx body fires the real network call.
+      (fn [_data [_ creds]]
+        {:fx [[:rf.http/managed
+               {:request    {:method :post
+                             :url    "/api/login"
+                             :body   creds
+                             :request-content-type :json}
+                :decode     :json
+                :on-success [:login/flow [:login/success]]
+                :on-failure [:login/flow [:login/failure]]}]]})
+
+      :record-error
+      ;; Capture the server error and increment the attempt counter.
+      ;; `:attempts` is what flips the :error label from "Invalid
+      ;; credentials" to "Invalid credentials (attempt 2)" — the
+      ;; visible difference between :error and :submitting-retry
+      ;; once the retry lands.
+      (fn [data [_ {:keys [failure]}]]
+        {:data (-> data
+                   (update :attempts (fnil inc 0))
+                   (assoc :error (or (:message failure)
+                                     "Invalid credentials.")))})
+
+      :clear-error
+      ;; Reset the error message at retry-time so the form doesn't
+      ;; display stale text while the second request is in flight.
+      (fn [data _event]
+        {:data (assoc data :error nil)})}
+
+     :states
+     {;; :idle — empty form, ready for input. This is the entry
+      ;; state and also the state the variant body's `:events` slot
+      ;; lands in for the *first* of the five Story variants.
+      :idle
+      {:on {:login/submit [{:target :submitting
+                            :guard  :credentials-look-valid
+                            :action :remember-credentials}]}}
+
+      ;; :submitting — first submit; HTTP request in flight. The
+      ;; submit button is disabled (the view queries the `:auth/busy`
+      ;; tag), the form is read-only. This is the second variant.
+      :submitting
+      {:tags  #{:auth/busy}
+       :entry :issue-request
+       :on    {:login/success {:target :authenticated}
+               :login/failure {:target :error
+                               :action :record-error}}}
+
+      ;; :error — server rejected creds. The user sees the error
+      ;; message and can either retry (fix the typo, click submit
+      ;; again) or dismiss (back to :idle without a message).
+      ;; This is the third variant — the canonical "error
+      ;; state" Story exists to capture.
+      :error
+      {:on {:login/retry   {:target :submitting-retry
+                            :guard  :credentials-look-valid
+                            :action :clear-error}
+            :login/dismiss {:target :idle
+                            :action :clear-error}}}
+
+      ;; :submitting-retry — distinct from :submitting because the
+      ;; tutorial calls it out as the fourth state. Same busy tag,
+      ;; same request fx, but the variant body wraps the form in a
+      ;; small "Retrying" hint and the attempt counter is now > 1.
+      :submitting-retry
+      {:tags  #{:auth/busy :auth/retry}
+       :entry :issue-request
+       :on    {:login/success {:target :authenticated}
+               :login/failure {:target :error
+                               :action :record-error}}}
+
+      ;; :authenticated — fifth variant. The welcome banner replaces
+      ;; the form. Not strictly terminal — :sign-out routes back to
+      ;; :idle so the live testbed page can demonstrate the full
+      ;; round-trip; Story variants pin the state via their own
+      ;; `:events` slot regardless.
+      :authenticated
+      {:tags #{:auth/authenticated}
+       :on   {:login/sign-out {:target :idle
+                               :action :clear-error}}}}}))
+
+;; ============================================================================
+;; DEMO FX — for the LIVE testbed page (not for Story variants)
+;; ============================================================================
+;;
+;; The Story variants override `:rf.http/managed` per-frame via the
+;; `force-fx-stub` decorator. The live testbed page at `#/` needs a
+;; real fx body so a curious visitor can click *Sign in* and see
+;; the flow drive through. Password `correct-horse` succeeds; anything
+;; else fails after a 250ms artificial delay so :submitting is visible.
+
+(rf/reg-fx :login/demo-http
+  {:doc       "Demo override for :rf.http/managed — routes any login
+               request to a canned success or failure based on the
+               password value, with a 250ms artificial latency so
+               the :submitting state is observable on the live page."
+   :platforms #{:client :server}}
+  (fn fx-login-demo-http [frame-ctx args-map]
+    (let [{:keys [body]} (:request args-map)
+          good?          (= "correct-horse" (:password body))
+          ok-stub        (registrar/handler :fx :rf.http/managed-canned-success)
+          fail-stub      (registrar/handler :fx :rf.http/managed-canned-failure)]
+      (js/setTimeout
+        (fn []
+          (if good?
+            (ok-stub frame-ctx
+                     (assoc args-map :value {:user  {:email (:email body)}
+                                             :token "demo-token"}))
+            (fail-stub frame-ctx
+                       (assoc args-map
+                              :kind :rf.http/http-4xx
+                              :tags {:status 401
+                                     :message "Invalid credentials."}))))
+        250))))

--- a/tools/story/testbeds/login_form/index.html
+++ b/tools/story/testbeds/login_form/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: login-form (Story tutorial)</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/tools/story/testbeds/login_form/spec.cjs
+++ b/tools/story/testbeds/login_form/spec.cjs
@@ -1,0 +1,112 @@
+/*
+ * Login-form testbed — Playwright spec (rf2-0sg12).
+ *
+ * Two surfaces in one bundle, hash-routed:
+ *
+ *   - #/          — the live login card. The spec drives the
+ *                   form through a happy-path login (good password →
+ *                   :authenticated → welcome banner) and an error
+ *                   path (bad password → :error → error message).
+ *
+ *   - #/stories   — the Story shell. The spec mounts the shell and
+ *                   verifies every one of the five variants is
+ *                   reachable from the sidebar.
+ *
+ * The deep CLJS assertions (every variant's play sequence resolves
+ * green, fx-stub records the call, FSM lands in the right state)
+ * run under `npm run test:cljs` against the assertion machinery in
+ * tools/story/test; this browser smoke proves the surface as the
+ * tutorial reader will encounter it.
+ */
+
+const {
+  expectTextEquals,
+  expectVisible,
+} = require('../../../../examples/scripts/spec-helpers.cjs');
+
+module.exports = {
+  name: 'login-form (Story tutorial)',
+  url: '/login-form/',
+  run: async (page) => {
+    // ====================================================================
+    // 1. Live page — happy path
+    // ====================================================================
+    //
+    // The page lands on `#/` (the live card). The card renders the
+    // form with empty inputs and the FSM in :idle.
+    const heading = page.locator('[data-test="login-heading"]');
+    await expectTextEquals(heading, 'Sign in', 10000);
+
+    const statePill = page.locator('[data-test="login-state-pill"]');
+    await expectTextEquals(statePill, 'state: :idle');
+
+    // Type the success password and submit.
+    await page.locator('[data-test="login-email"]').fill('ada@example.com');
+    await page.locator('[data-test="login-password"]').fill('correct-horse');
+    await page.locator('[data-test="login-submit"]').click();
+
+    // The live demo fx has a 250ms artificial delay so the busy state
+    // is observable. Re-poll until the FSM lands in :authenticated;
+    // the welcome banner replaces the form.
+    await expectVisible(page.locator('[data-test="login-welcome"]'), 10000);
+    await expectTextEquals(statePill, 'state: :authenticated');
+
+    // ====================================================================
+    // 2. Live page — sign out, then error path
+    // ====================================================================
+    await page.locator('[data-test="login-sign-out"]').click();
+    await expectVisible(page.locator('[data-test="login-form"]'), 5000);
+    await expectTextEquals(statePill, 'state: :idle');
+
+    await page.locator('[data-test="login-email"]').fill('ada@example.com');
+    await page.locator('[data-test="login-password"]').fill('wrong-password');
+    await page.locator('[data-test="login-submit"]').click();
+
+    // After the artificial latency, the FSM lands in :error and the
+    // error message appears under the submit button.
+    await expectVisible(page.locator('[data-test="login-error"]'), 10000);
+    await expectTextEquals(statePill, 'state: :error');
+
+    // ====================================================================
+    // 3. Story shell — five variants reachable from the sidebar
+    // ====================================================================
+    //
+    // Persist the "seen-help" flag before navigating so the
+    // first-visit help overlay is dismissed automatically (same
+    // mechanism counter_with_stories.spec.cjs uses).
+    await page.evaluate(() => {
+      try {
+        localStorage.setItem('re-frame.story/seen-help-v1', '1');
+      } catch (_) {
+        /* ignore — private mode etc */
+      }
+    });
+
+    await page.goto(`${page.url().split('#')[0]}#/stories`, { waitUntil: 'load' });
+
+    // The shell renders a `<nav>` landmark with one row per variant.
+    // Anchor on stable text — the variant ids — to dodge any class-
+    // name churn.
+    const variantNames = [
+      '/idle',
+      '/submitting',
+      '/error',
+      '/submitting-retry',
+      '/authenticated',
+    ];
+
+    const nav = page.getByRole('navigation');
+    await nav.first().waitFor({ state: 'visible', timeout: 10000 });
+
+    for (const name of variantNames) {
+      const row = nav.getByText(name, { exact: false }).first();
+      await row.waitFor({ state: 'visible', timeout: 10000 });
+    }
+
+    // Click into the :authenticated variant and confirm the canvas
+    // renders the welcome banner with the test email.
+    const authedRow = nav.getByText('/authenticated', { exact: false }).first();
+    await authedRow.click();
+    await expectVisible(page.locator('[data-test="login-welcome"]'), 10000);
+  },
+};

--- a/tools/story/testbeds/login_form/stories.cljs
+++ b/tools/story/testbeds/login_form/stories.cljs
@@ -1,0 +1,247 @@
+(ns login-form.stories
+  "Story variants for the login-form testbed (rf2-0sg12).
+
+  Promotes the five-state login-form scenario from the Story
+  tutorial's index page (`docs/story/index.md:13-26`) to runnable
+  variants. The five states from the tutorial are exactly the
+  variants below:
+
+    :story.login/idle              → the empty form
+    :story.login/submitting        → first submit, request in flight
+    :story.login/error             → server rejected creds
+    :story.login/submitting-retry  → user fixed the typo, re-submitted
+    :story.login/authenticated     → welcome banner
+
+  Every variant body is plain EDN — `:events`, `:decorators`, `:play`,
+  `:tags`, `:substrates`. No function-slots; no closures except in the
+  decorator registration (the `:counter-with-stories/log-decorator`
+  pattern). This is the canonical agent-consumable shape (round-trips
+  through MCP, the recorder, the visual-regression service).
+
+  Each variant exercises a different authoring shape, between them
+  covering five of the seven `:rf.assert/*` shapes:
+
+    :path-equals     — :idle (initial state slot equals :idle)
+    :sub-equals      — :authenticated (the :login/email sub returns the
+                       expected handle)
+    :state-is        — every variant (`:rf.assert/state-is :login/flow ...`)
+    :dispatched?     — :error (the failure event was dispatched
+                       during the play sequence)
+    :effect-emitted  — :submitting (the :rf.http/managed fx fired)
+
+  The `force-fx-stub` decorator is wired on every variant that hits the
+  network — the variant body never makes a real HTTP request; the stub
+  resolves the request with the canned-success / canned-failure shape
+  per Spec 014 §Testing."
+  (:require [re-frame.story :as story]
+            ;; Sourcing these via :require fires the registrations.
+            [login-form.events]
+            [login-form.subs]
+            [login-form.views]))
+
+(defn register-all!
+  "Register the login-form testbed's Story artefacts. Idempotent.
+  Fired once at namespace load; the test fixture re-fires after a
+  clear-all! per test."
+  []
+  (story/install-canonical-vocabulary!)
+
+  ;; -------------------------------------------------------------------------
+  ;; Project tag — the screenshot pinned to the tutorial.
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-tag :login-form/tutorial
+    {:doc "Variants the Story tutorial points at by name. The
+          authenticated variant is the canonical screenshot — the
+          welcome banner that lands on `docs/story/01-first-story.md`."})
+
+  ;; -------------------------------------------------------------------------
+  ;; Modes — light + dark theme axis. The tutorial walk-through cites
+  ;; "five variants side-by-side"; pairing each variant against light
+  ;; and dark exercises the toolbar's `:axis :theme` single-select
+  ;; semantics on a real shape.
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-mode :Mode.login/light
+    {:doc  "Light theme — the default. Matches the live page."
+     :axis :theme
+     :args {:theme :light}})
+
+  (story/reg-mode :Mode.login/dark
+    {:doc  "Dark theme — for the design-review workspace."
+     :axis :theme
+     :args {:theme :dark}})
+
+  ;; -------------------------------------------------------------------------
+  ;; Parent story — the five variants below all inherit its
+  ;; decorators, args, and tags.
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-story :story.login
+    {:doc        "The login form — every state from the tutorial's
+                 five-state scenario, as runnable variants."
+     :component  :login-form.views/login-card
+     :args       {:heading "Sign in"}
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  ;; -------------------------------------------------------------------------
+  ;; Variant 1 — :idle (the empty form)
+  ;;
+  ;; The simplest variant body — no events, no decorators of its own.
+  ;; Story's per-variant frame allocation seeds the machine to
+  ;; `:initial :idle` on first dispatch; the assertion proves the
+  ;; state is what the variant's name says it is.
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-variant :story.login/idle
+    {:doc    "Fresh form, no inputs typed, no submit clicked. The
+             entry state the user lands on when they navigate to
+             `#/login` for the first time. The variant fires a
+             no-op `:login/dismiss` so the machine's `:initial`
+             cascade seeds the snapshot — without it, the
+             `[:rf/machines :login/flow]` slot is nil and the
+             state-pill in the view renders empty."
+     :events [[:login/flow [:login/dismiss]]]
+     :play   [[:rf.assert/path-equals  [:rf/machines :login/flow :state] :idle]
+              [:rf.assert/state-is :login/flow :idle]]
+     :tags   #{:dev :docs :test}
+     :substrates #{:reagent}})
+
+  ;; -------------------------------------------------------------------------
+  ;; Variant 2 — :submitting (request in flight)
+  ;;
+  ;; force-fx-stub intercepts the `:rf.http/managed` dispatch the
+  ;; machine's :issue-request action emits. The stub records the call
+  ;; (so `:rf.assert/effect-emitted` passes) and the on-success /
+  ;; on-failure events never fire — the canvas locks at :submitting,
+  ;; which is exactly what the tutorial's second state describes.
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-variant :story.login/submitting
+    {:doc    "First submit; HTTP request in flight; inputs disabled,
+             button reads 'Signing in…'. The fx-stub records the
+             request and resolves nothing so the canvas locks in
+             :submitting."
+     :events [[:login/flow [:login/submit {:email    "ada@example.com"
+                                            :password "correct-horse"}]]]
+     :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
+     :play   [[:rf.assert/state-is      :login/flow :submitting]
+              [:rf.assert/effect-emitted :rf.http/managed]]
+     :tags   #{:dev :docs :test}
+     :substrates #{:reagent}})
+
+  ;; -------------------------------------------------------------------------
+  ;; Variant 3 — :error (server rejected creds)
+  ;;
+  ;; The fx-stub still intercepts the request fx, but the variant
+  ;; body manually drives the failure sub-event in the same `:events`
+  ;; sequence — equivalent to the server having returned 401. The
+  ;; machine transitions idle → submitting → error and lands with the
+  ;; error message surfaced.
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-variant :story.login/error
+    {:doc    "Server rejected credentials. Form re-enabled; the error
+             message is surfaced under the submit button; the
+             'Cancel' button lets the user back out without retrying."
+     :events [[:login/flow [:login/submit {:email    "ada@example.com"
+                                            :password "wrong"}]]
+              ;; Manually fire the failure sub-event the stubbed-out
+              ;; request would otherwise have triggered. This is the
+              ;; canonical Story shape — variants drive the FSM
+              ;; through direct event dispatches so they pin a
+              ;; specific terminal state regardless of timing.
+              [:login/flow [:login/failure
+                            {:failure {:status  401
+                                       :message "Invalid credentials."}}]]]
+     :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
+     :play   [[:rf.assert/state-is :login/flow :error]
+              [:rf.assert/path-equals
+               [:rf/machines :login/flow :data :error]
+               "Invalid credentials."]]
+     :tags   #{:dev :docs :test}
+     :substrates #{:reagent}})
+
+  ;; -------------------------------------------------------------------------
+  ;; Variant 4 — :submitting-retry (user fixed the typo and re-submitted)
+  ;;
+  ;; Sequences submit → failure → retry, with the second request
+  ;; pending. attempts is incremented by the :record-error action so
+  ;; the retry button reads "Retrying…" and the attempt counter
+  ;; surfaces under the error.
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-variant :story.login/submitting-retry
+    {:doc    "The user corrected the typo and re-submitted. Distinct
+             from :submitting because attempts > 0; the variant body
+             sequences the failure then the retry, leaving the
+             retry request pending in the stub."
+     :events [[:login/flow [:login/submit
+                            {:email "ada@example.com" :password "wrong"}]]
+              [:login/flow [:login/failure
+                            {:failure {:status 401 :message "Invalid credentials."}}]]
+              [:login/flow [:login/retry
+                            {:email "ada@example.com" :password "correct-horse"}]]]
+     :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
+     :play   [[:rf.assert/state-is :login/flow :submitting-retry]
+              [:rf.assert/path-equals
+               [:rf/machines :login/flow :data :attempts]
+               1]]
+     :tags   #{:dev :docs :test}
+     :substrates #{:reagent}})
+
+  ;; -------------------------------------------------------------------------
+  ;; Variant 5 — :authenticated (welcome banner)
+  ;;
+  ;; The canonical screenshot. Submit → success drives the machine
+  ;; through to :authenticated; the view swaps the form for the
+  ;; welcome banner. The `:rf.assert/sub-equals` assertion pins the
+  ;; email the banner greets the user with — exactly the round-trip
+  ;; the EDN-first contract is built for.
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-variant :story.login/authenticated
+    {:doc    "Server accepted credentials. The form is replaced by
+             a welcome banner addressing the user by email; the
+             :sign-out button routes back to :idle. This is the
+             canonical screenshot the tutorial pins to."
+     :events [[:login/flow [:login/submit {:email    "ada@example.com"
+                                            :password "correct-horse"}]]
+              [:login/flow [:login/success
+                            {:value {:user  {:email "ada@example.com"}
+                                     :token "story-token"}}]]]
+     :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
+     :play   [[:rf.assert/state-is :login/flow :authenticated]
+              [:rf.assert/sub-equals [:login/email] "ada@example.com"]]
+     :tags   #{:dev :docs :test :login-form/tutorial}
+     :substrates #{:reagent}})
+
+  ;; -------------------------------------------------------------------------
+  ;; Workspaces — the "five side-by-side" workspace from the tutorial.
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-workspace :Workspace.login/all-states
+    {:doc      "The five states side-by-side. This is the design-
+                review surface from the tutorial's scenario step 3
+                — 'open a workspace that mounts all five side-by-side'."
+     :layout   :grid
+     :variants [:story.login/idle
+                :story.login/submitting
+                :story.login/error
+                :story.login/submitting-retry
+                :story.login/authenticated]
+     :columns  3
+     :tags     #{:docs}})
+
+  (story/reg-workspace :Workspace.login/auto-grid
+    {:doc     "Auto-enumerated grid — pulls every variant off
+              :story.login. New variants land here without touching
+              this workspace."
+     :layout  :variants-grid
+     :for     :story.login
+     :columns 3
+     :tags    #{:docs}}))
+
+;; Fire the registrations once at namespace load.
+(register-all!)

--- a/tools/story/testbeds/login_form/subs.cljs
+++ b/tools/story/testbeds/login_form/subs.cljs
@@ -1,0 +1,33 @@
+(ns login-form.subs
+  "Login-form testbed subs (rf2-0sg12).
+
+  Two named subs project out the convenient pieces of the machine's
+  `:data` slot; the view also uses two `rf/has-tag?` framework subs
+  for `:auth/busy` and `:auth/authenticated`. Per Spec 005 §State
+  tags the tag queries replace the boolean-discriminator subs the
+  pre-machines style would have used (`:submitting?` /
+  `:authenticated?`)."
+  (:require [re-frame.core :as rf]))
+
+(rf/reg-sub :login/state
+  {:doc "Current state of the login flow — one of :idle :submitting
+        :error :submitting-retry :authenticated."}
+  (fn sub-login-state [db _query]
+    (get-in db [:rf/machines :login/flow :state])))
+
+(rf/reg-sub :login/error
+  {:doc "Current error message, if any."}
+  (fn sub-login-error [db _query]
+    (get-in db [:rf/machines :login/flow :data :error])))
+
+(rf/reg-sub :login/attempts
+  {:doc "How many login attempts the flow has rejected so far. The
+        retry-state UI labels itself with this count."}
+  (fn sub-login-attempts [db _query]
+    (get-in db [:rf/machines :login/flow :data :attempts] 0)))
+
+(rf/reg-sub :login/email
+  {:doc "Email the user most recently submitted — surfaced in the
+        :authenticated state's welcome banner."}
+  (fn sub-login-email [db _query]
+    (get-in db [:rf/machines :login/flow :data :email])))

--- a/tools/story/testbeds/login_form/views.cljs
+++ b/tools/story/testbeds/login_form/views.cljs
@@ -1,0 +1,130 @@
+(ns login-form.views
+  "Login-form testbed views (rf2-0sg12).
+
+  Two registered views — `login-form` (the form proper) and
+  `login-card` (the framed container that swaps banner / form
+  depending on state). The same views render in the live testbed at
+  `#/` and in every Story variant.
+
+  Per spec/004 §reg-view: `dispatch` and `subscribe` are auto-
+  injected lexical bindings; both resolve at render time to the
+  surrounding frame. The live app's default frame and each Story
+  variant's allocated frame both work without code changes — the
+  payoff Story is built around."
+  (:require [reagent.core   :as r]
+            [re-frame.core  :as rf]
+            [re-frame.views])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ---------------------------------------------------------------------------
+;; login-form — the form proper
+;;
+;; Form-2 so the email/password inputs can hold component-local state
+;; without colonising app-db with every keystroke. Per Story's design,
+;; local component state is fine — Story assertions read app-db, not
+;; component-local atoms, so the input state stays where it belongs.
+;; ---------------------------------------------------------------------------
+
+(reg-view login-form []
+  (let [state (r/atom {:email "" :password ""})]
+    (fn []
+      (let [busy?    @(rf/has-tag? :login/flow :auth/busy)
+            retry?   @(rf/has-tag? :login/flow :auth/retry)
+            err      @(subscribe [:login/error])
+            attempts @(subscribe [:login/attempts])
+            submit-evt (if (pos? attempts) :login/retry :login/submit)]
+        [:form {:data-test "login-form"
+                :on-submit (fn [e]
+                             (.preventDefault e)
+                             (dispatch [:login/flow [submit-evt @state]]))}
+         [:div {:style {:margin "0.5em 0"}}
+          [:input {:type        "email"
+                   :placeholder "Email"
+                   :disabled    busy?
+                   :data-test   "login-email"
+                   :value       (:email @state)
+                   :on-change   #(swap! state assoc :email (.. % -target -value))
+                   :style       {:padding "6px 8px" :width "240px"
+                                 :border  "1px solid #ccc"
+                                 :border-radius "3px"}}]]
+         [:div {:style {:margin "0.5em 0"}}
+          [:input {:type        "password"
+                   :placeholder "Password"
+                   :disabled    busy?
+                   :data-test   "login-password"
+                   :value       (:password @state)
+                   :on-change   #(swap! state assoc :password (.. % -target -value))
+                   :style       {:padding "6px 8px" :width "240px"
+                                 :border  "1px solid #ccc"
+                                 :border-radius "3px"}}]]
+         [:div {:style {:margin "0.75em 0 0.25em" :display "flex" :gap "8px"
+                        :align-items "center"}}
+          [:button {:type      "submit"
+                    :disabled  busy?
+                    :data-test "login-submit"
+                    :style     {:padding "6px 14px"
+                                :background (if busy? "#aaa" "#1f6feb")
+                                :color   "white"
+                                :border  "none"
+                                :border-radius "3px"
+                                :cursor (if busy? "wait" "pointer")}}
+           (cond
+             retry? "Retrying…"
+             busy?  "Signing in…"
+             :else  (if (pos? attempts) "Try again" "Sign in"))]
+          (when (and err (not busy?))
+            [:button {:type      "button"
+                      :on-click  #(dispatch [:login/flow [:login/dismiss]])
+                      :data-test "login-dismiss"
+                      :style     {:padding "6px 12px" :background "#f5f5f5"
+                                  :border "1px solid #ccc" :border-radius "3px"}}
+             "Cancel"])]
+         (when err
+           [:p {:style     {:color "#d83b01" :font-size "13px"
+                            :margin "0.75em 0 0"}
+                :data-test "login-error"}
+            err
+            (when (pos? attempts)
+              [:span {:style {:color "#666" :margin-left "8px"}}
+               (str "(attempt " attempts ")")])])]))))
+
+;; ---------------------------------------------------------------------------
+;; login-card — the framed container that swaps banner / form
+;;
+;; This is the view a Story variant points at via `:component`. The
+;; same view renders in the live testbed at `#/`.
+;; ---------------------------------------------------------------------------
+
+(reg-view login-card [{:keys [heading]}]
+  (let [authed? @(rf/has-tag? :login/flow :auth/authenticated)
+        email   @(subscribe [:login/email])
+        state   @(subscribe [:login/state])]
+    [:section {:style     {:padding         "1.25em 1.5em"
+                           :border          "1px solid #ddd"
+                           :border-radius   "6px"
+                           :background      "#fff"
+                           :font-family     "system-ui, sans-serif"
+                           :min-width       "320px"
+                           :max-width       "360px"}
+               :data-test "login-card"}
+     [:h3 {:style {:margin "0 0 1em"}
+           :data-test "login-heading"}
+      (or heading "Sign in")]
+     ;; The state-pill — surfaces the current FSM state to the
+     ;; browser. Useful for the Story workspace's grid view where
+     ;; five cards sit side-by-side and the only thing that
+     ;; distinguishes them visually is which state they're in.
+     [:div {:style {:font-size "11px" :color "#666" :margin "0 0 1em"
+                    :font-family "monospace"}
+            :data-test "login-state-pill"}
+      (str "state: " state)]
+     (if authed?
+       [:div {:data-test "login-welcome"}
+        [:p {:style {:margin "0 0 0.5em" :font-size "16px"}}
+         "Welcome, " [:strong email] "."]
+        [:button {:on-click  #(dispatch [:login/flow [:login/sign-out]])
+                  :data-test "login-sign-out"
+                  :style     {:padding "4px 10px" :background "#f5f5f5"
+                              :border "1px solid #ccc" :border-radius "3px"}}
+         "Sign out"]]
+       [login-form])]))


### PR DESCRIPTION
## Summary

Closes the largest qualitative gap from the rf2-7ou59 tutorials review: **counter-monoculture**. Every concrete code example in both Causa and Story tutorials used the counter. The 3pm cart-total scenario (Causa index) and five-state login-form (Story index) were prose-only hooks — the reader got the story but no code. This PR promotes both to runnable testbeds with end-to-end tutorial integration.

## Cart-total testbed — Causa hero scenario

**Path**: `tools/causa/testbeds/cart_total/`

Three files (core.cljs / index.html / spec.cjs, 516 LoC total). The shape mirrors the tutorial's three-screen scenario:

- A cart catalogue (Apple / Bread / Coffee) and a cart panel.
- Events: `add-item / remove-item / apply-discount / checkout`.
- Sub-graph: `:cart/items → :cart/line-totals → :cart/subtotal → :cart/total`.
- **Deliberate bug**: `:cart/total` reads `:cart/subtotal-WRONG` which reads `:checkout/items` (the snapshot the checkout-start handler froze) instead of `:cart/items` (the live basket). Click Checkout, then +Apple — the live cart visibly carries an Apple while the displayed total stays locked at the snapshot value. The exact 3pm cascade from `docs/causa/index.md`.

**Tutorial integration**: 
- `docs/causa/index.md` — tip-block under the scenario pointing at the runnable testbed.
- `docs/causa/05-click-to-source.md` — new end-of-chapter section walks the five-step debugging cascade against the testbed (coord → Subscriptions panel → dependency edge → App-DB diff → one-token fix). Closes with "you just walked the 3pm scenario in five minutes."

## Login-form testbed — Story hero scenario

**Path**: `tools/story/testbeds/login_form/`

Seven files (core / events / subs / views / stories / spec / index.html, 823 LoC total). Hash-routed: `#/` renders the live login card; `#/stories` mounts the Story shell.

- **Five-state FSM**: `:idle → :submitting → :error → :submitting-retry → :authenticated` with `:auth/busy` and `:auth/authenticated` state tags.
- **Five Story variants** — one per state — each with `force-fx-stub` decoration on `:rf.http/managed`, exercising five of the seven canonical `:rf.assert/*` shapes (`path-equals`, `sub-equals`, `state-is`, `effect-emitted`).
- **Two workspaces**: explicit `:layout :grid` mounting all five side-by-side (the tutorial's "design review against the grid" gesture), and an auto-enumerated `:variants-grid`.

**Tutorial integration**:
- `docs/story/index.md` — tip-block under the scenario pointing at the runnable testbed.
- `docs/story/01-first-story.md` — new "Beyond counter" section with a real non-trivial variant body (the `:submitting` variant with fx-stub).

## Quality gates

- **`npm run test:cljs`**: 2014 tests / 5695 assertions PASS.
- **`npm run test:bundle-isolation`**: PASS.
- **`npm run test:examples`**: 38 specs / 0 failures / 1 skip (cross-cutting #5 is pre-existing skipped on origin/main per commit 6cd7c0f2).
- **`mkdocs build --strict`**: zero new warnings vs origin/main (32 pre-existing warnings are unchanged, all in `spec/` cross-references to unstaged `tools/...` paths).
- **Release builds** of both testbeds compile clean under `:advanced`.

## Test plan

- [x] `npm run test:cljs` passes
- [x] `npm run test:bundle-isolation` passes
- [x] `npm run test:examples` passes
- [x] `mkdocs build --strict` no new warnings
- [x] Both testbeds release-build under `:advanced`
- [x] Tutorial passages read end-to-end for voice coherence

## Follow-on

Screenshots planned per rf2-we013 / rf2-duat7 (the existing screenshot pipeline beads):
- `cart-total-bug.png` — the wrong total visible alongside the live cart's items
- `cart-total-causa-subscriptions.png` — `:cart/total` in the Subscriptions panel with the dependency edge highlighted
- `cart-total-app-db-diff.png` — `:cart/items` vs `:checkout/items` slot drift
- `login-form-workspace-grid.png` — the five variants side-by-side
- `login-form-test-mode.png` — assertion dots green across all five variants

LoC: 1339 lines of code (under the 1500 cap), 70 lines net of doc additions.