### PR TITLE
test(examples): sweep specs — data-testid selectors + polled waits (rf2-i0j1x)

### DIFF
--- a/examples/helix/counter_helix/core.cljs
+++ b/examples/helix/counter_helix/core.cljs
@@ -57,7 +57,7 @@
         dispatch (rf/dispatcher)]
     (d/div
        (d/button {:on-click #(dispatch [:counter/dec])} "-")
-       (d/span {:style {:margin "0 1em"}} count)
+       (d/span {:style {:margin "0 1em"} :data-testid "counter-value"} count)
        (d/button {:on-click #(dispatch [:counter/inc])} "+"))))
 
 (defnc counter-app []

--- a/examples/helix/counter_helix/counter_helix.spec.cjs
+++ b/examples/helix/counter_helix/counter_helix.spec.cjs
@@ -18,7 +18,8 @@ module.exports = {
   name: 'counter-helix',
   url: '/counter-helix/',
   run: async (page) => {
-    const span = page.locator('span').first();
+    // Anchor on data-testid (rf2-i0j1x).
+    const span = page.getByTestId('counter-value');
     await expectTextEquals(span, '5', 10000);
 
     await page.getByRole('button', { name: '+' }).click();

--- a/examples/reagent/7Guis/circle_drawer/circle_drawer.cljs
+++ b/examples/reagent/7Guis/circle_drawer/circle_drawer.cljs
@@ -189,9 +189,12 @@
         can-redo?  @(subscribe [:drawer/can-redo?])]
     [:div.drawer
      [:div.row
-      [:button {:on-click #(dispatch [:drawer/undo]) :disabled (not can-undo?)} "Undo"]
-      [:button {:on-click #(dispatch [:drawer/redo]) :disabled (not can-redo?)} "Redo"]]
-     [:svg {:width 600 :height 400 :style {:border "1px solid #999"}
+      [:button {:data-testid "drawer-undo"
+                :on-click #(dispatch [:drawer/undo]) :disabled (not can-undo?)} "Undo"]
+      [:button {:data-testid "drawer-redo"
+                :on-click #(dispatch [:drawer/redo]) :disabled (not can-redo?)} "Redo"]]
+     [:svg {:data-testid "drawer-canvas"
+            :width 600 :height 400 :style {:border "1px solid #999"}
             :on-click (fn [e]
                         (let [rect (.. e -currentTarget getBoundingClientRect)
                               x    (- (.. e -clientX) (.-left rect))
@@ -205,14 +208,17 @@
                                      (dispatch [:drawer/open-dialog id]))}])]
 
      (when dialog
-       [:div.dialog {:style {:border "1px solid #999" :padding "10px" :margin-top "5px"}}
+       [:div.dialog {:data-testid "drawer-dialog"
+                     :style {:border "1px solid #999" :padding "10px" :margin-top "5px"}}
         [:p (str "Adjust diameter of circle " (:circle-id dialog))]
         [:input {:type      "range"
+                 :data-testid "drawer-slider"
                  :min       5 :max 100 :step 1
                  :value     (:draft-radius dialog)
                  :on-change #(dispatch [:drawer/dialog-drag
                                         (js/parseInt (.. % -target -value))])}]
-        [:button {:on-click #(dispatch [:drawer/close-dialog])} "Close"]])]))
+        [:button {:data-testid "drawer-close"
+                  :on-click #(dispatch [:drawer/close-dialog])} "Close"]])]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS

--- a/examples/reagent/7Guis/circle_drawer/circle_drawer.spec.cjs
+++ b/examples/reagent/7Guis/circle_drawer/circle_drawer.spec.cjs
@@ -16,15 +16,24 @@
  * menu intervening.
  */
 
-const { expectVisible, expectAttribute } = require('../../../scripts/spec-helpers.cjs');
+const {
+  expectAttribute,
+  expectCount,
+  expectVisible,
+  waitForValue,
+} = require('../../../scripts/spec-helpers.cjs');
 
 module.exports = {
   name: 'circle-drawer (7guis #6)',
   url: '/circle-drawer/',
   run: async (page) => {
-    const svg = page.locator('svg');
-    const undoBtn = page.getByRole('button', { name: /undo/i });
-    const redoBtn = page.getByRole('button', { name: /redo/i });
+    // Anchor controls on data-testid (rf2-i0j1x). The drawn circles
+    // themselves are the data model — they have no per-id testid by
+    // design — so position lookups remain via the `svg circle` family.
+    const svg = page.getByTestId('drawer-canvas');
+    const undoBtn = page.getByTestId('drawer-undo');
+    const redoBtn = page.getByTestId('drawer-redo');
+    const circles = page.locator('[data-testid="drawer-canvas"] circle');
 
     await expectVisible(svg, 10000);
 
@@ -34,60 +43,43 @@ module.exports = {
 
     // Click canvas: 1 circle.
     await svg.click({ position: { x: 120, y: 120 } });
-    await page.waitForFunction(
-      () => document.querySelectorAll('svg circle').length === 1,
-      null,
-      { timeout: 5000 },
-    );
+    await expectCount(circles, 1, 5000);
     await expectAttribute(undoBtn, 'disabled', null);
 
     // Click again: 2 circles.
     await svg.click({ position: { x: 300, y: 200 } });
-    await page.waitForFunction(
-      () => document.querySelectorAll('svg circle').length === 2,
-      null,
-      { timeout: 5000 },
-    );
+    await expectCount(circles, 2, 5000);
 
     // Right-click the first circle to open the dialog.
-    const firstCircle = page.locator('svg circle').nth(0);
+    const firstCircle = circles.first();
     const initialRadius = await firstCircle.getAttribute('r');
     await firstCircle.click({ button: 'right' });
-    const slider = page.locator('input[type="range"]');
+    const slider = page.getByTestId('drawer-slider');
     await expectVisible(slider, 5000);
 
     // Drag slider to a different value, close dialog.
     await slider.fill('70');
-    await page.getByRole('button', { name: /close/i }).click();
-    await page.waitForFunction(
-      () => {
-        const c = document.querySelectorAll('svg circle')[0];
-        return c && c.getAttribute('r') === '70';
-      },
-      null,
-      { timeout: 5000 },
+    await page.getByTestId('drawer-close').click();
+    await waitForValue(
+      () => firstCircle.getAttribute('r'),
+      (r) => r === '70',
+      { timeoutMs: 5000, description: 'first circle r="70"' },
     );
 
     // Undo: radius change reverts.
     await undoBtn.click();
-    await page.waitForFunction(
-      (initial) => {
-        const c = document.querySelectorAll('svg circle')[0];
-        return c && c.getAttribute('r') === initial;
-      },
-      initialRadius,
-      { timeout: 5000 },
+    await waitForValue(
+      () => firstCircle.getAttribute('r'),
+      (r) => r === initialRadius,
+      { timeoutMs: 5000, description: `first circle r="${initialRadius}"` },
     );
 
     // Redo: radius change reapplies.
     await redoBtn.click();
-    await page.waitForFunction(
-      () => {
-        const c = document.querySelectorAll('svg circle')[0];
-        return c && c.getAttribute('r') === '70';
-      },
-      null,
-      { timeout: 5000 },
+    await waitForValue(
+      () => firstCircle.getAttribute('r'),
+      (r) => r === '70',
+      { timeoutMs: 5000, description: 'first circle r="70" (redo)' },
     );
   },
 };

--- a/examples/reagent/7Guis/crud/crud.spec.cjs
+++ b/examples/reagent/7Guis/crud/crud.spec.cjs
@@ -16,7 +16,11 @@
  * size-6 multi-row <select> that backs the list.
  */
 
-const { expectVisible } = require('../../../scripts/spec-helpers.cjs');
+const {
+  expectCount,
+  expectVisible,
+  waitForValue,
+} = require('../../../scripts/spec-helpers.cjs');
 
 module.exports = {
   name: 'crud (7guis #5)',
@@ -26,6 +30,7 @@ module.exports = {
     // selectors were brittle against any sibling text-input landing
     // in the view.
     const selectList = page.getByTestId('crud-list');
+    const options = selectList.locator('option');
     const filterInput = page.getByTestId('crud-filter');
     const nameInput = page.getByTestId('crud-name');
     const surnameInput = page.getByTestId('crud-surname');
@@ -36,64 +41,40 @@ module.exports = {
     await expectVisible(selectList, 10000);
 
     // Initial: 3 seeded people.
-    await page.waitForFunction(
-      () => document.querySelectorAll('select.list option').length === 3,
-      null,
-      { timeout: 10000 },
-    );
+    await expectCount(options, 3, 10000);
 
     // Filter: prefix "M" -> 1 entry (Mustermann).
     await filterInput.fill('M');
-    await page.waitForFunction(
-      () => document.querySelectorAll('select.list option').length === 1,
-      null,
-      { timeout: 5000 },
-    );
+    await expectCount(options, 1, 5000);
 
     // Clear filter, list back to 3.
     await filterInput.fill('');
-    await page.waitForFunction(
-      () => document.querySelectorAll('select.list option').length === 3,
-      null,
-      { timeout: 5000 },
-    );
+    await expectCount(options, 3, 5000);
 
     // Create: type Anna Sonnen, click Create -> list grows to 4.
     await nameInput.fill('Anna');
     await surnameInput.fill('Sonnen');
     await createBtn.click();
-    await page.waitForFunction(
-      () => document.querySelectorAll('select.list option').length === 4,
-      null,
-      { timeout: 5000 },
-    );
+    await expectCount(options, 4, 5000);
 
     // Update: select the Anna Sonnen entry by its visible label, change
     // surname, click Update; the list option's text reflects the new value.
     await selectList.selectOption({ label: 'Sonnen, Anna' });
-    await page.waitForFunction(
-      () => {
-        const sel = document.querySelector('select.list');
-        return sel && sel.value !== '';
-      },
-      null,
-      { timeout: 5000 },
+    await waitForValue(
+      () => selectList.inputValue(),
+      (v) => v !== '',
+      { timeoutMs: 5000, description: 'crud-list selection committed' },
     );
     await surnameInput.fill('Sunnybaum');
     await updateBtn.click();
-    await page.waitForFunction(
-      () => Array.from(document.querySelectorAll('select.list option'))
-        .some((o) => o.textContent === 'Sunnybaum, Anna'),
-      null,
-      { timeout: 5000 },
+    await waitForValue(
+      () => options.allTextContents(),
+      (texts) => texts.some((t) => t === 'Sunnybaum, Anna'),
+      { timeoutMs: 5000, description: 'option text "Sunnybaum, Anna" present' },
     );
 
     // Delete: list shrinks back to 3.
     await deleteBtn.click();
-    await page.waitForFunction(
-      () => document.querySelectorAll('select.list option').length === 3,
-      null,
-      { timeout: 5000 },
-    );
+    await expectCount(options, 3, 5000);
   },
 };

--- a/examples/reagent/7Guis/timer/timer.cljs
+++ b/examples/reagent/7Guis/timer/timer.cljs
@@ -140,7 +140,7 @@
        [:div.fill {:style {:width  (str progress "%")
                            :height "20px"
                            :background "#4a9"}}]]]
-     [:div.row [:label seconds " s"]]
+     [:div.row [:label {:data-testid "timer-elapsed"} seconds " s"]]
      [:div.row
       [:label "Duration: "]
       [:input {:type      "range"
@@ -156,7 +156,8 @@
       ;; before the next scheduled :timer/tick can fire. With async dispatch
       ;; the post-Reset DOM commit could lag the next tick (and the test's
       ;; 50ms poll), causing the brief 0.0 window to be missed.
-      [:button {:on-click #(rf/dispatch-sync [:timer/reset])} "Reset"]]]))
+      [:button {:data-testid "timer-reset"
+                :on-click #(rf/dispatch-sync [:timer/reset])} "Reset"]]]))
 
 ;; ============================================================================
 ;; HEADLESS TESTS  (scheduling-light; we don't drive real time, just verify

--- a/examples/reagent/7Guis/timer/timer.spec.cjs
+++ b/examples/reagent/7Guis/timer/timer.spec.cjs
@@ -10,17 +10,18 @@
  * - Reset: elapsed back to "0.0 s".
  */
 
-const { expectVisible } = require('../../../scripts/spec-helpers.cjs');
+const {
+  expectVisible,
+  waitForValue,
+} = require('../../../scripts/spec-helpers.cjs');
 
 async function readElapsed(page) {
-  // The view renders elapsed seconds inside a <label>, e.g. "1.5 s".
-  // We read the .row containing the elapsed-only label (no preceding label).
-  const labels = await page.locator('label').allTextContents();
-  for (const t of labels) {
-    const m = (t || '').match(/^\s*(\d+\.\d+)\s*s\s*$/);
-    if (m) return parseFloat(m[1]);
-  }
-  return null;
+  // The view renders elapsed seconds inside [data-testid="timer-elapsed"],
+  // e.g. "1.5 s". Parse the leading float; on the (extremely brief)
+  // first-render the label may not be present yet — return null.
+  const t = (await page.getByTestId('timer-elapsed').textContent()) || '';
+  const m = t.match(/(\d+\.\d+)\s*s/);
+  return m ? parseFloat(m[1]) : null;
 }
 
 module.exports = {
@@ -32,30 +33,18 @@ module.exports = {
 
     // Wait for the timer to actually advance past zero — poll the
     // elapsed label rather than sleeping a fixed budget (rf2-u3amn).
-    const start = Date.now();
-    let elapsed1 = 0;
-    while (Date.now() - start < 5000) {
-      const v = await readElapsed(page);
-      if (v != null && v > 0) {
-        elapsed1 = v;
-        break;
-      }
-      await new Promise((r) => setTimeout(r, 50));
-    }
-    if (elapsed1 <= 0) {
-      throw new Error(`expected elapsed > 0 within 5s, got ${elapsed1}`);
-    }
+    await waitForValue(() => readElapsed(page), (v) => v != null && v > 0, {
+      timeoutMs: 5000,
+      description: 'timer elapsed > 0',
+    });
 
     // Click Reset; elapsed should return to 0.0.
-    await page.getByRole('button', { name: /reset/i }).click();
+    await page.getByTestId('timer-reset').click();
     // Use a small grace window — the very first reading may be a tiny
     // fraction of a tick if the next tick fired immediately.
-    const resetStart = Date.now();
-    while (Date.now() - resetStart < 2000) {
-      const e = await readElapsed(page);
-      if (e === 0 || e === 0.0) return;
-      await new Promise((r) => setTimeout(r, 50));
-    }
-    throw new Error('Reset did not return elapsed to 0.0 within 2s');
+    await waitForValue(() => readElapsed(page), (v) => v === 0, {
+      timeoutMs: 2000,
+      description: 'timer elapsed reset to 0.0',
+    });
   },
 };

--- a/examples/reagent/counter/core.cljs
+++ b/examples/reagent/counter/core.cljs
@@ -44,7 +44,7 @@
 (reg-view counter-buttons []
   [:div
    [:button {:on-click #(dispatch [:counter/dec])} "-"]
-   [:span {:style {:margin "0 1em"}} @(subscribe [:count])]
+   [:span {:style {:margin "0 1em"} :data-testid "counter-value"} @(subscribe [:count])]
    [:button {:on-click #(dispatch [:counter/inc])} "+"]])
 
 ;; The root `counter-app` view renders `counter-buttons` against the

--- a/examples/reagent/counter/counter.spec.cjs
+++ b/examples/reagent/counter/counter.spec.cjs
@@ -18,8 +18,9 @@ module.exports = {
   name: 'counter',
   url: '/counter/',
   run: async (page) => {
-    // The counter renders one <span> between the - and + buttons holding the count.
-    const span = page.locator('span').first();
+    // Anchor on data-testid (rf2-i0j1x) — survives sibling DOM
+    // changes that would otherwise break `span.first()`.
+    const span = page.getByTestId('counter-value');
     await expectTextEquals(span, '5', 10000);
 
     await page.getByRole('button', { name: '+' }).click();

--- a/examples/reagent/counter_slim_and_fast/core.cljs
+++ b/examples/reagent/counter_slim_and_fast/core.cljs
@@ -72,7 +72,7 @@
 (reg-view counter-buttons []
   [:div
    [:button {:on-click #(dispatch [:counter/dec])} "-"]
-   [:span {:style {:margin "0 1em"}} @(subscribe [:count])]
+   [:span {:style {:margin "0 1em"} :data-testid "counter-value"} @(subscribe [:count])]
    [:button {:on-click #(dispatch [:counter/inc])} "+"]])
 
 (reg-view counter-app []

--- a/examples/reagent/counter_slim_and_fast/counter_slim_and_fast.spec.cjs
+++ b/examples/reagent/counter_slim_and_fast/counter_slim_and_fast.spec.cjs
@@ -28,7 +28,8 @@ module.exports = {
   name: 'counter-slim-and-fast',
   url: '/counter-slim-and-fast/',
   run: async (page) => {
-    const span = page.locator('span').first();
+    // Anchor on data-testid (rf2-i0j1x).
+    const span = page.getByTestId('counter-value');
     await expectTextEquals(span, '5', 10000);
 
     await page.getByRole('button', { name: '+' }).click();

--- a/examples/reagent/long_running_work/long_running_work.spec.cjs
+++ b/examples/reagent/long_running_work/long_running_work.spec.cjs
@@ -27,8 +27,13 @@
  * machine ↔ React ↔ browser-clock wiring.
  */
 
-const { expectTextEquals, expectTextContains, expectVisible, waitForStableValue } =
-  require('../../scripts/spec-helpers.cjs');
+const {
+  expectTextEquals,
+  expectTextContains,
+  expectVisible,
+  waitForStableValue,
+  waitForValue,
+} = require('../../scripts/spec-helpers.cjs');
 
 async function readProgressDone(page) {
   const label = page.locator('[data-testid="progress-label"]');
@@ -61,18 +66,11 @@ module.exports = {
     // Wait for visible progress — at 50ms / item, the bar should
     // tick past 1 within a couple of hundred ms. We poll until the
     // counter goes above zero or time out.
-    const start = Date.now();
-    let progress;
-    while (Date.now() - start < 5000) {
-      progress = await readProgressDone(page);
-      if (progress.done > 0) break;
-      await new Promise((r) => setTimeout(r, 50));
-    }
-    if (!progress || progress.done <= 0) {
-      throw new Error(
-        `expected progress to advance past 0 within 5s; got ${progress && progress.done}/${progress && progress.total}`,
-      );
-    }
+    await waitForValue(
+      () => readProgressDone(page),
+      (p) => p.done > 0,
+      { timeoutMs: 5000, description: 'progress.done > 0' },
+    );
 
     // --- Cancel mid-flight: workers stop, state → :cancelled ------------------
     await page.getByTestId('cancel').click();
@@ -126,14 +124,11 @@ module.exports = {
     await page.getByTestId('start').click();
     await expectTextEquals(stateValue, 'working');
     // Wait for visible progress.
-    {
-      const t0 = Date.now();
-      while (Date.now() - t0 < 5000) {
-        const p = await readProgressDone(page);
-        if (p.done > 0) break;
-        await new Promise((r) => setTimeout(r, 50));
-      }
-    }
+    await waitForValue(
+      () => readProgressDone(page),
+      (p) => p.done > 0,
+      { timeoutMs: 5000, description: 'progress.done > 0 (post-restart)' },
+    );
     await page.getByTestId('toggle-bench').click();
     // The bench is unmounted; its DOM is gone. Click Show to
     // re-mount, and assert the machine is in :cancelled — i.e. the

--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -165,14 +165,15 @@
     [:div.page
      [:h1 "Recent articles"]
      [:button.toggle-bodies
-      {:on-click #(dispatch [:articles/toggle-bodies])}
+      {:data-testid "toggle-bodies"
+       :on-click #(dispatch [:articles/toggle-bodies])}
       (if show-bodies? "Hide bodies" "Show bodies")]
      (if (seq arts)
-       (into [:ul]
+       (into [:ul {:data-testid "articles-list"}]
              (for [{:keys [id title body]} arts]
                ^{:key id}
                [:li [:h3 title]
-                (when show-bodies? [:p.body body])]))
+                (when show-bodies? [:p.body {:data-testid "article-body"} body])]))
        [:p "No articles."])]))
 
 (rf/reg-view ^{:rf/id :app/root} root-view []

--- a/examples/reagent/ssr/index.html
+++ b/examples/reagent/ssr/index.html
@@ -33,10 +33,10 @@
   <div id="app">
     <div class="page">
       <h1>Recent articles</h1>
-      <button class="toggle-bodies">Hide bodies</button>
-      <ul>
-        <li><h3>Article A</h3><p class="body">Body A</p></li>
-        <li><h3>Article B</h3><p class="body">Body B</p></li>
+      <button class="toggle-bodies" data-testid="toggle-bodies">Hide bodies</button>
+      <ul data-testid="articles-list">
+        <li><h3>Article A</h3><p class="body" data-testid="article-body">Body A</p></li>
+        <li><h3>Article B</h3><p class="body" data-testid="article-body">Body B</p></li>
       </ul>
     </div>
   </div>

--- a/examples/reagent/ssr/ssr.spec.cjs
+++ b/examples/reagent/ssr/ssr.spec.cjs
@@ -21,6 +21,7 @@
  */
 
 const {
+  expectCount,
   expectTextContains,
   expectVisible,
 } = require('../../scripts/spec-helpers.cjs');
@@ -33,33 +34,29 @@ module.exports = {
     await expectVisible(heading, 10000);
     await expectTextContains(heading, 'Recent articles', 5000);
 
+    // Anchor on data-testid (rf2-i0j1x).
+    const articlesList = page.getByTestId('articles-list');
+    const bodies = page.getByTestId('article-body');
+    const toggle = page.getByTestId('toggle-bodies');
+
     // The pre-rendered article titles are present from the static HTML.
-    await expectTextContains(page.locator('ul'), 'Article A', 5000);
-    await expectTextContains(page.locator('ul'), 'Article B', 5000);
+    await expectTextContains(articlesList, 'Article A', 5000);
+    await expectTextContains(articlesList, 'Article B', 5000);
 
     // Bodies are visible by default.
-    await expectVisible(page.locator('p.body').first(), 5000);
+    await expectVisible(bodies.first(), 5000);
 
     // Clicking the toggle goes through the real dispatch / re-render
     // path on the now-hydrated client. After click, the bodies are
     // gone but the titles remain — proves the client took over.
-    const toggle = page.locator('button.toggle-bodies');
     await expectVisible(toggle, 5000);
     await toggle.click();
     // Poll until the body paragraphs are detached — Reagent unmounts
     // them when (when show-bodies? ...) goes false.
-    const start = Date.now();
-    while (Date.now() - start < 5000) {
-      const count = await page.locator('p.body').count();
-      if (count === 0) break;
-      await new Promise((r) => setTimeout(r, 50));
-    }
-    if ((await page.locator('p.body').count()) !== 0) {
-      throw new Error('clicking "Hide bodies" did not remove p.body elements');
-    }
+    await expectCount(bodies, 0, 5000);
 
     // Titles remain — hydrated app-db still holds the articles.
-    await expectTextContains(page.locator('ul'), 'Article A', 2000);
-    await expectTextContains(page.locator('ul'), 'Article B', 2000);
+    await expectTextContains(articlesList, 'Article A', 2000);
+    await expectTextContains(articlesList, 'Article B', 2000);
   },
 };

--- a/examples/reagent/state_machine_walkthrough/state_machine_walkthrough.spec.cjs
+++ b/examples/reagent/state_machine_walkthrough/state_machine_walkthrough.spec.cjs
@@ -29,10 +29,14 @@ module.exports = {
   name: 'state-machines walkthrough (lockout)',
   url: '/state-machine-walkthrough/',
   run: async (page) => {
-    const banner = page.locator('strong.state');
-    const emailInput = page.locator('input[type="email"]');
-    const passwordInput = page.locator('input[type="password"]');
-    const submitBtn = page.locator('form.login-form button[type="submit"]');
+    // Anchor on data-testid attrs (rf2-i0j1x) — the previous role +
+    // CSS-class selectors (`strong.state`, `form.login-form
+    // button[type="submit"]`, `.error-row button`, `.locked`) tracked
+    // styling decisions in the views.
+    const banner = page.getByTestId('state-banner');
+    const emailInput = page.getByTestId('login-email');
+    const passwordInput = page.getByTestId('login-password');
+    const submitBtn = page.getByTestId('login-submit');
 
     // Initial state: machine is idle (the snapshot is created on first
     // dispatch, so a freshly-mounted page reads (uninitialised) for
@@ -49,7 +53,7 @@ module.exports = {
     };
 
     const dismissOnce = async () => {
-      await page.locator('.error-row button').click();
+      await page.getByTestId('login-dismiss').click();
       await expectTextEquals(banner, 'idle', 5000);
     };
 
@@ -67,7 +71,7 @@ module.exports = {
 
     // The form is replaced by the locked-out panel.
     await expectTextContains(
-      page.locator('.locked'),
+      page.getByTestId('locked-panel'),
       'Account locked',
       5000,
     );

--- a/examples/reagent/state_machine_walkthrough/views.cljs
+++ b/examples/reagent/state_machine_walkthrough/views.cljs
@@ -36,25 +36,31 @@
             locked? @(rf/has-tag? :auth.login/flow :auth/locked)
             err     @(subscribe [:auth.login/error])]
         [:form.login-form
-         {:on-submit (fn [e]
+         {:data-testid "login-form"
+          :on-submit (fn [e]
                        (.preventDefault e)
                        (when-not (or busy? locked?)
                          (dispatch [:auth.login/flow
                                     [:auth.login/submit @state]])))}
          [:input  {:type        "email"
                    :placeholder "Email"
+                   :data-testid "login-email"
                    :disabled    (or busy? locked?)
                    :on-change   #(swap! state assoc :email (.. % -target -value))}]
          [:input  {:type        "password"
                    :placeholder "Password"
+                   :data-testid "login-password"
                    :disabled    (or busy? locked?)
                    :on-change   #(swap! state assoc :password (.. % -target -value))}]
-         [:button {:type "submit" :disabled (or busy? locked?)}
+         [:button {:type "submit"
+                   :data-testid "login-submit"
+                   :disabled (or busy? locked?)}
           (if busy? "Signing in…" "Sign in")]
          (when (and err (not locked?))
            [:div.error-row
             [:p.error err]
             [:button {:type "button"
+                      :data-testid "login-dismiss"
                       :on-click #(dispatch [:auth.login/flow
                                              [:auth.login/dismiss]])}
              "Dismiss"]])]))))
@@ -66,12 +72,13 @@
   (let [state @(subscribe [:auth.login/state])]
     [:div.banner
      [:span "State: "]
-     [:strong.state {:data-state (when state (name state))}
+     [:strong.state {:data-testid "state-banner"
+                     :data-state (when state (name state))}
       (if state (name state) "(uninitialised)")]]))
 
 (reg-view ^{:doc "Locked-out terminal panel."}
           locked-panel []
-  [:div.locked
+  [:div.locked {:data-testid "locked-panel"}
    [:h2 "Account locked"]
    [:p "Three failed attempts. Contact support to unlock."]])
 

--- a/examples/reagent/todomvc/todomvc.spec.cjs
+++ b/examples/reagent/todomvc/todomvc.spec.cjs
@@ -14,33 +14,24 @@
 
 const {
   expectAttribute,
+  expectCount,
   expectInputValue,
   expectTextContains,
   expectTextEquals,
+  waitForValue,
 } = require('../../scripts/spec-helpers.cjs');
 
-async function expectCount(locator, expected, timeoutMs = 5000) {
-  const start = Date.now();
-  let last = null;
-  while (Date.now() - start < timeoutMs) {
-    last = await locator.count();
-    if (last === expected) return;
-    await new Promise((r) => setTimeout(r, 50));
-  }
-  throw new Error(`expected count ${expected} but got ${last} within ${timeoutMs}ms`);
-}
-
 async function expectFocusedNewTodo(page, timeoutMs = 5000) {
-  const start = Date.now();
-  let focused = false;
-  while (Date.now() - start < timeoutMs) {
-    focused = await page.evaluate(
-      () => document.activeElement && document.activeElement.classList.contains('new-todo'),
-    );
-    if (focused) return;
-    await new Promise((r) => setTimeout(r, 50));
-  }
-  throw new Error('expected the .new-todo input to be focused');
+  await waitForValue(
+    () =>
+      page.evaluate(
+        () =>
+          document.activeElement &&
+          document.activeElement.classList.contains('new-todo'),
+      ),
+    (focused) => !!focused,
+    { timeoutMs, description: '.new-todo input to be focused' },
+  );
 }
 
 async function readTodos(page) {

--- a/examples/reagent/websocket/websocket.spec.cjs
+++ b/examples/reagent/websocket/websocket.spec.cjs
@@ -20,7 +20,11 @@
  *     backoff fires.
  */
 
-const { expectVisible, expectTextContains } = require('../../scripts/spec-helpers.cjs');
+const {
+  expectVisible,
+  expectTextContains,
+  waitForValue,
+} = require('../../scripts/spec-helpers.cjs');
 
 module.exports = {
   name: 'pattern-websocket — connection machine demo',
@@ -95,22 +99,14 @@ module.exports = {
     // Polled because the cascade re-enters :active synchronously but
     // :bump-retry runs as the :ws/closed action — its commit goes
     // through the dispatch queue.
-    {
-      const start = Date.now();
-      let attemptsAfter = attemptsBefore;
-      while (Date.now() - start < 5000) {
-        attemptsAfter = parseInt(
-          (await attemptsCounter.textContent()) || '0',
-          10,
-        );
-        if (attemptsAfter > attemptsBefore) break;
-        await new Promise((r) => setTimeout(r, 50));
-      }
-      if (!(attemptsAfter > attemptsBefore)) {
-        throw new Error(
-          `expected reconnect-attempts to advance past ${attemptsBefore}, got ${attemptsAfter}`,
-        );
-      }
-    }
+    await waitForValue(
+      async () =>
+        parseInt((await attemptsCounter.textContent()) || '0', 10),
+      (n) => n > attemptsBefore,
+      {
+        timeoutMs: 5000,
+        description: `reconnect-attempts to advance past ${attemptsBefore}`,
+      },
+    );
   },
 };

--- a/examples/scripts/spec-helpers.cjs
+++ b/examples/scripts/spec-helpers.cjs
@@ -58,6 +58,50 @@ async function expectAttribute(locator, attr, expected, timeoutMs = 5000) {
   );
 }
 
+async function expectCount(locator, expected, timeoutMs = 5000) {
+  const start = Date.now();
+  let last = null;
+  while (Date.now() - start < timeoutMs) {
+    last = await locator.count();
+    if (last === expected) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(
+    `expected count ${expected} but got ${last} within ${timeoutMs}ms`,
+  );
+}
+
+/*
+ * Poll `readFn` until it returns a value satisfying `predicate`, then
+ * return that value. Use this in preference to hand-rolled
+ * `while (Date.now() - start < N) { await new Promise(r => setTimeout(r, 50)); }`
+ * loops in specs — same poll-until-condition shape, single source of truth
+ * for the interval / timeout / error message.
+ *
+ * Options:
+ *   intervalMs (default 50)   — gap between reads.
+ *   timeoutMs  (default 5000) — bail with throw if predicate never holds.
+ *   description (default "value satisfying predicate") — context for the
+ *     error message ("expected <description> within <timeout>ms, last=<value>").
+ */
+async function waitForValue(readFn, predicate, options = {}) {
+  const {
+    intervalMs = 50,
+    timeoutMs = 5000,
+    description = 'value satisfying predicate',
+  } = options;
+  const start = Date.now();
+  let last;
+  while (Date.now() - start < timeoutMs) {
+    last = await readFn();
+    if (predicate(last)) return last;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(
+    `waitForValue: expected ${description} within ${timeoutMs}ms (last=${JSON.stringify(last)})`,
+  );
+}
+
 /*
  * Poll `readFn` until `samples` consecutive reads agree, then return the
  * stable value. This replaces fixed-duration sleeps in specs that need to
@@ -105,5 +149,7 @@ module.exports = {
   expectInputValue,
   expectVisible,
   expectAttribute,
+  expectCount,
   waitForStableValue,
+  waitForValue,
 };

--- a/examples/uix/counter_uix/core.cljs
+++ b/examples/uix/counter_uix/core.cljs
@@ -55,7 +55,7 @@
         dispatch (rf/dispatcher)]
     ($ :div
        ($ :button {:on-click #(dispatch [:counter/dec])} "-")
-       ($ :span {:style #js {:margin "0 1em"}} count)
+       ($ :span {:style #js {:margin "0 1em"} :data-testid "counter-value"} count)
        ($ :button {:on-click #(dispatch [:counter/inc])} "+"))))
 
 (defui counter-app []

--- a/examples/uix/counter_uix/counter_uix.spec.cjs
+++ b/examples/uix/counter_uix/counter_uix.spec.cjs
@@ -17,7 +17,8 @@ module.exports = {
   name: 'counter-uix',
   url: '/counter-uix/',
   run: async (page) => {
-    const span = page.locator('span').first();
+    // Anchor on data-testid (rf2-i0j1x).
+    const span = page.getByTestId('counter-value');
     await expectTextEquals(span, '5', 10000);
 
     await page.getByRole('button', { name: '+' }).click();


### PR DESCRIPTION
## Summary

Finishes the examples Playwright sweep started in PR #529 (rf2-i0j1x).
Two threads of work, applied across every spec that still had fragile
selectors or hand-rolled timing loops.

### data-testid sweep

Replaced positional / role / text-anchored selectors with stable
`data-testid` attrs on the surfaces that needed them, adding
`:data-testid` to the corresponding views/cores in lockstep:

- counter (reagent / slim-and-fast / uix / helix) — `counter-value`
  (was `page.locator('span').first()`)
- state_machine_walkthrough — login form / inputs / submit / dismiss
  / state-banner / locked-panel (was `strong.state`,
  `form.login-form button[type=\"submit\"]`, `.error-row button`,
  `.locked`)
- ssr — toggle-bodies / articles-list / article-body (was `p.body`,
  `button.toggle-bodies`, `ul`); index.html updated so the
  pre-rendered server payload still matches the view
- 7Guis/timer — `timer-elapsed` / `timer-reset` (was reading all
  `<label>` text and regex-scraping)
- 7Guis/circle_drawer — drawer-canvas / drawer-undo / drawer-redo
  / drawer-slider / drawer-close / drawer-dialog (the drawn
  `<circle>` nodes remain anonymous — they are the data model)

Per-circle / per-todo / per-RealWorld-article selectors stay on
their CSS-class anchors where those classes are stable conventions
(TodoMVC, RealWorld Conduit).

### Polled-waits cleanup

New shared helpers in `examples/scripts/spec-helpers.cjs`:

- `expectCount(locator, n, timeoutMs)` — polled `locator.count()`,
  absorbing the inline copy from todomvc.spec.cjs.
- `waitForValue(readFn, predicate, opts)` — polled predicate;
  replaces the hand-rolled `while (Date.now() - start < N) { ... }`
  sleep-loops scattered across timer, long_running_work, websocket,
  todomvc (focus check), circle_drawer, crud, and ssr.

Every former bare `setTimeout(50)` inside a spec poll loop now
routes through these helpers (or the existing `waitForStableValue`),
centralising the polling interval and the timeout-error message.

## Test plan

- [x] `npm run test:cljs` — 2014 tests, 5695 assertions, 0 failures
- [x] `npm run test:examples` — 36 example specs, 0 failures (1 skipped, pre-existing)