### PR TITLE
docs(tutorials): voice rescue Causa chs 7-10 + deepen Story ch 5 snapshot-identity (rf2-tadee+rf2-2yvwh)

### DIFF
--- a/docs/causa/07-schema-timeline.md
+++ b/docs/causa/07-schema-timeline.md
@@ -1,6 +1,8 @@
 # 7. Schema-violation timeline
 
-When you register a Malli schema at any of re-frame2's documented boundaries — `app-db` slot, event payload, sub return, cofx — the runtime validates against it on every crossing. Failures emit `:rf.error/schema-validation-failure` trace events with the full `:explain` payload. Causa's Schemas panel turns those events into a timeline.
+You shipped a refactor on Monday — a small change to the `:cart/items` shape, added a `:line-id` slot, nothing your tests caught. By Wednesday afternoon Sentry has three rows that look like the same problem on three different users' machines: a red error toast on the checkout page. You can't reproduce locally. The stack trace is in a sub two hops downstream of the slot you touched.
+
+This is what schemas are for, and the Schemas panel is what you open. You'd registered a Malli schema on `:cart/items` weeks ago. The runtime has been validating against it on every crossing the whole time — and the moment the refactor landed, that boundary started failing on the shapes the old discount code emits. The Issues ribbon is showing the count. The Schemas panel is where you see *when* the contract drift started and *which* slot broke first.
 
 The panel lights up only when you've registered at least one schema. The companion narrative is [Guide 04a — Schemas](../guide/04a-schemas.md).
 

--- a/docs/causa/08-hydration.md
+++ b/docs/causa/08-hydration.md
@@ -1,10 +1,10 @@
 # 8. Hydration debugger
 
-If your app is SSR-rendered — re-frame2's server side ships at [Guide 11](../guide/11-server-side.md) — the first cascade in the browser is *hydration*: the client takes the server-rendered HTML, re-runs the same views against the same `app-db`, and asserts the two trees match.
+Your tester refreshes the page and the count flips from 12 to 0. Server-rendered HTML said one number; the client booted up and said another. They send you a screenshot of the half-second of flicker — the SSR'd value visible until the React reconciler stamps over it with the wrong one.
 
-When they don't, you get a hydration mismatch. The Hydration panel is what you open to find out why.
+That's a hydration mismatch, and the Hydration panel is the focused view. The Issues ribbon will already have a `:rf.error/hydration-mismatch` row; click into it and the panel paints both render trees side-by-side with the offending node highlighted. The diagnosis isn't "the trees don't agree" — it's "the view at `cart.views:cart-total:73` rendered `$12.00` on the server and `$0.00` on the client, because the cofx that seeds `:cart/items` read `(js/Date.)` in a way the JVM-side renderer couldn't."
 
-The panel **only appears in the sidebar when hydration actually runs in the page**. A SPA-only build won't see it at all.
+The panel **only appears in the sidebar when hydration actually runs in the page**. A SPA-only build won't see it at all. SSR ships at [Guide 11](../guide/11-server-side.md).
 
 ![Hydration debugger — server and client trees side-by-side, mismatch highlighted](../images/causa/08-hydration.png)
 
@@ -35,7 +35,7 @@ When they don't, it's almost always one of:
 - A view that called `js/window` from inside the body (no SSR-shape guard).
 - A cofx that returned different data on the server (the request-id wasn't seeded the same way).
 
-The panel surfaces *which view* mismatched, *which attribute*, *with what values* — so the diagnosis isn't "the trees don't match"; it's "the view at `cart.views:cart-total:73` rendered `$0.00` on the server and `$14.00` on the client".
+The panel surfaces *which view* mismatched, *which attribute*, *with what values* — at the resolution of a single line of source. That's why the opener's diagnosis sentence reads as one specific call-out rather than the generic "the trees don't agree."
 
 ## The fix loop
 

--- a/docs/causa/09-machine-inspector.md
+++ b/docs/causa/09-machine-inspector.md
@@ -1,8 +1,10 @@
 # 9. Machine inspector
 
-re-frame2's state machines are first-class — registered, queryable, snapshot-as-value, with transitions that ride the standard six-step pipeline. (The narrative is at [Guide 08 — State machines](../guide/08-state-machines.md).)
+You have a login flow with six states — `:idle`, `:submitting`, `:error`, `:submitting-retry`, `:authenticated`, `:locked-out` — and the user reports they can't get back from `:error` to `:submitting-retry`. The retry button is wired; the click fires; nothing transitions. You squint at the machine spec; the guard looks fine.
 
-The Machines panel renders each registered machine as a Stately-quality state-chart. Live.
+You open Causa, click *Machines*, and there it is: the diagram paints the attempted edge in grey, with the `false` return from `:enough-attempts?` rendered inline. The guard you wrote last week checks `(< attempts 3)`, but the variant your test is running through has `:attempts 4` — and you can read it right there in the snapshot column without recompiling, because the machine's first-class on the same six-step pipeline as every other event ([Guide 08 — State machines](../guide/08-state-machines.md) is the narrative).
+
+The panel renders each registered machine as a Stately-quality state-chart. Live.
 
 ![Machine inspector with state-chart](../images/causa/09-machines.png)
 

--- a/docs/causa/10-app-db-diff.md
+++ b/docs/causa/10-app-db-diff.md
@@ -1,8 +1,10 @@
 # 10. App-DB diff
 
-`app-db` is a value. Two epochs are two values. The diff is the difference between them.
+You just dispatched `:checkout/start` on the cart-total testbed and half the tree moved. The Event-detail panel's mini-diff is the right size for "one leaf changed" — what you want now is the *whole* delta, slice by slice, with the un-touched 90% of the tree out of the way. App-DB panel is what you escalate to.
 
-The App-DB panel renders the diff of the **current epoch** (the one selected in Event detail or the time-travel scrubber) — `:db-before` and `:db-after`, slice-aware.
+`app-db` is a value. Two epochs are two values. The diff is the difference between them — and on the cart-total epoch where `:checkout/items` got populated and `:cart/items` got emptied, the diff is two paths and four values. Not a 200-line tree dump.
+
+The panel renders the diff of the **current epoch** (the one selected in Event detail or the time-travel scrubber) — `:db-before` and `:db-after`, slice-aware.
 
 ![App-DB diff for a cascade](../images/causa/10-app-db-diff.png)
 
@@ -51,7 +53,7 @@ Three patterns the diff handles distinctively:
 
 ## When you'd open it
 
-- "I just dispatched something — did `app-db` change?" — Event detail's mini-diff is enough for one-leaf updates; the App-DB panel is what you escalate to for "this cascade rewrote half the tree, and I want to see exactly which half."
+- "This cascade rewrote half the tree, and I want to see exactly which half." — the framing case from the opener; the App-DB panel is what Event detail's mini-diff escalates into.
 - "I think a sub is stale, but `app-db` says the value's right." — pin both the slot and the sub's recompute marker; watch them tick together.
 - "I want a session-long watch on `:auth/state`." — pin it; the panel paints it on every epoch.
 

--- a/docs/story/05-snapshot-identity.md
+++ b/docs/story/05-snapshot-identity.md
@@ -1,26 +1,79 @@
 # 5. Snapshot identity + QR sharing
 
-Every variant cell — the `(variant × mode × per-cell args)` tuple — has a **snapshot identity**: a content hash of everything that determines what the canvas will render. The hash is the join key visual-regression services use to bucket screenshots; it's how Story tells Chromatic, Argos, Percy, Lost Pixel, or your in-house diff tool "this screenshot is the same scenario as last week's, even though `:label` is different — diff them."
+You're three weeks into building the login form. Five variants are pinned to Chromatic: `:story.login/idle`, `/submitting`, `/error`, `/submitting-retry`, `/authenticated`. Two weeks of baselines. The design team has signed off on each one. The visual-regression service is happy.
 
-## Why content-hash rather than slug
+Then a teammate looks at the names and pushes back. *Submitting-retry* is awkward; what's wrong with calling it `:story.login/retrying`? You agree; it's a five-second edit; you push. CI runs Chromatic against the new build. Forty-eight new buckets land in the dashboard, forty-eight old buckets get archived. The diff service shows every "new" screenshot as a 100%-novel image because the bucket key is the variant slug and the slug just changed. Two weeks of baselines, gone — not because the pixels changed, but because the *name* did.
 
-A naive identity would be `:story.counter/loaded@dark`. That works until you tweak `:label "Total"` → `"Count"` and the visual-regression service flags the change as a delta of an entirely new variant. Content-hashing the resolved-args fingerprint makes the identity track the *picked state*, not the *name path*.
+This is the trade-off Storybook 9 ships and most playground tools after it: identity-by-slug. Rename anything and the diff service forgets. It's also the trade-off Story is built to avoid. Story's snapshot identity is **content-based** — a hash of what's rendered, not what it's called. Renames are free. The bucket key tracks the *picked state*, not the *name path*. Same screenshot, same hash, same bucket.
 
-So:
+## What identity tracks
 
-- Renaming `:story.counter/loaded` → `:story.counter/with-load` doesn't change the identity.
-- Renaming a top-level `:Mode.app/dark` → `:Mode.dark` doesn't change the identity.
-- Changing `:label "Count"` → `"Total"` *does* change the identity (because the rendered content does).
+Every variant cell — the `(variant × mode × per-cell args)` tuple — has a **snapshot identity**: a content hash of everything that determines what the canvas will render. The hash is the join key visual-regression services use to bucket screenshots; it's how Story tells Chromatic, Argos, Percy, Lost Pixel, or your in-house diff tool "this screenshot is the same scenario as last week's — diff them."
+
+So, concretely, on the five-state login form:
+
+- Renaming `:story.login/submitting-retry` → `:story.login/retrying` doesn't change the identity. **Same bucket; baselines preserved.**
+- Renaming a top-level `:Mode.login/dark` → `:Mode.login/midnight` doesn't change the identity either. **Same bucket; baselines preserved.**
+- Changing the `:heading` arg from `"Sign in"` to `"Welcome back"` *does* change the identity. **New bucket; new baseline required.**
 
 The contract: **identity tracks content; name tracks lineage**. Both are stable, separately.
 
-The hash is a SHA-256 of a transit-printed `{:variant-id :resolved-args :mode-args :decorators-fingerprint}` tuple. The hash is deterministic across machines, build tags, and load orders — the contract on `resolved-args` is sorted-keys, canonical types.
+The hash is a SHA-256 of a transit-printed tuple — `:resolved-args`, `:mode-args`, an `:events-fingerprint`, and a `:decorators-fingerprint`. Crucially, the *variant slug itself is not part of the input*. The fingerprint hashes what the variant produces, not what it's called. The hash is deterministic across machines, build tags, and load orders — the contract on `resolved-args` is sorted-keys, canonical types.
+
+## A worked rename — `:submitting-retry` → `:retrying`
+
+Walk through the rename on the login-form testbed.
+
+**Before** (the variant body in `tools/story/testbeds/login_form/stories.cljs:175`):
+
+```clojure
+(story/reg-variant :story.login/submitting-retry
+  {:doc    "The user corrected the typo and re-submitted."
+   :events [[:login/flow [:login/submit {:email "ada@example.com" :password "wrong"}]]
+            [:login/flow [:login/failure {:failure {:status 401}}]]
+            [:login/flow [:login/retry  {:email "ada@example.com" :password "correct-horse"}]]]
+   :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
+   :play   [[:rf.assert/state-is :login/flow :submitting-retry]]
+   :tags   #{:dev :docs :test}
+   :substrates #{:reagent}})
+```
+
+The fingerprint Story computes for this variant under `:Mode.login/dark` (canonical, sorted, transit-printed) is roughly:
+
+```clojure
+{:resolved-args          {:heading "Sign in", :theme :dark}
+ :mode-args              {:theme :dark}
+ :events-fingerprint     "sha256:f3a1…"
+ :decorators-fingerprint "sha256:9c40…"}
+```
+
+Notice the slug `:story.login/submitting-retry` is nowhere in that tuple. The SHA-256 of the whole thing is, say, `e2b7f4…a1`. That's the bucket key. Chromatic has two weeks of baselines pinned to `e2b7f4…a1`.
+
+**After** the rename, the variant body is identical except for the slug:
+
+```clojure
+(story/reg-variant :story.login/retrying
+  {:doc    "The user corrected the typo and re-submitted."
+   :events [...]   ; unchanged
+   :decorators [...]   ; unchanged
+   :play   [[:rf.assert/state-is :login/flow :submitting-retry]]   ; <-- arguably should rename too
+   :tags   #{:dev :docs :test}
+   :substrates #{:reagent}})
+```
+
+Re-run the fingerprint computation on the new variant. The `:resolved-args` are the same `{:heading "Sign in", :theme :dark}`. The `:events-fingerprint` is the same `sha256:f3a1…` because the events sequence is identical. The `:decorators-fingerprint` is the same. The SHA-256 is *still* `e2b7f4…a1`.
+
+Chromatic, Argos, Percy, Lost Pixel — every one of them keys on the hash. The bucket continuity holds. Your two weeks of baselines are intact.
+
+(One nit: if your assertions still pin the *machine* state name `:submitting-retry`, you'd want to rename the machine state separately. The variant identity is decoupled from internal naming — but your tests aren't.)
 
 ## QR sharing — local-vendored encoder
 
-Story's *share via QR* button renders the snapshot-identity (plus the picked workspace + mode + cell-overrides) into a QR code, displayed inline. Scan with a phone; the phone opens a URL into your locally-served Story instance at that exact picked state.
+Story's *share via QR* button renders the snapshot identity (plus the picked workspace + mode + cell-overrides) into a QR code, displayed inline. Scan with a phone; the phone opens a URL into your locally-served Story instance at that exact picked state.
 
 ![QR sharing — scan to open the picked variant state on another device](../images/story/05-qr-share.png)
+
+The use case: design review against a real device. You've built the login form's `:error` variant; the design lead wants to see it on the actual phone they were thinking about, not the Chrome device emulator. Click the QR, scan with the phone, the phone opens the variant on your dev server — same picked state, same args, same mode, same workspace overrides. Two seconds vs the usual "let me get my laptop on the same WiFi as your phone."
 
 The QR encoder is **vendored locally** (per [rf2-20w5i](https://github.com/day8/re-frame2)). No CDN hit, no external dependency at render time. The vendored encoder is ~3kB after `:advanced` (DCE handles dead modes); production builds short-circuit before the encoder code is reachable.
 
@@ -45,6 +98,8 @@ Storybook's identity is path-based — slugs, story titles, mode names. Visual-r
 
 Story's identity is *content-based*. Stable identity follows the content. Renames are free. The trade is that an args-tweak is a new identity — which is the point: you want the diff service to flag that the picked state changed.
 
-A second trade: the agent self-healing loop relies on this. When an agent registers a new variant body via MCP, the bucket continuity for an existing snapshot is determined by the content hash, not the agent's chosen name. So an agent can generate-then-name without worrying about colliding bucket keys.
+A second trade: the agent self-healing loop relies on this. When an agent generates a new variant via the MCP write surface — say, prompted with "give me an `:error` variant where the server returns 503 instead of 401" — the bucket continuity for the *existing* `:story.login/error` snapshot is determined by the content hash, not the agent's chosen name. The agent can generate-then-name without worrying about colliding bucket keys, and a human can rename what the agent produced without breaking the diff service's history.
+
+The pattern composes: humans rename freely, agents generate freely, the diff service stays anchored to what's actually rendered. That's the whole point.
 
 Next: [time-travel in Story](06-time-travel.md).


### PR DESCRIPTION
## Summary

Tutorial polish micro-cluster filed off the rf2-7ou59 review (findings at `ai/findings/tutorials-review-causa-story-2026-05-15.md`). Two beads, two sequenced commits, zero file overlap.

**Commit 1 — rf2-tadee** — Causa chs 7-10 voice rescue. The middle chapters (schemas, hydration, machines, app-db) had drifted into reference mode; each gets a scenario-shaped opener in the on-dynamics voice — "you've just been bitten by X / here's what you do" — naming a person and a moment. Bodies preserved; a few duplicate sentences tightened where the new opener now lands the point the body restated. The cart-total testbed (just landed via rf2-0sg12 / #1139) grounds the app-db opener's concrete debugging shape.

**Commit 2 — rf2-2yvwh** — Story ch 5 (snapshot identity) deepened from 50 to ~105 lines:
- Scenario opener: the three-week-old login-form where renaming `:submitting-retry` → `:retrying` archives 48 Chromatic buckets the moment the slug changes (under slug-based identity) — the reader feels the cost before the contract is explained.
- New worked-rename section: before/after variant bodies from `tools/story/testbeds/login_form/stories.cljs`, fingerprint tuple printed both times, the SHA-256 collision shown rather than told.
- QR-share screenshot (`docs/images/story/05-qr-share.png`) finally referenced with a design-review-against-a-phone use case.
- Agent-self-healing now reads as a concrete composition rule.

Pre-alpha posture: no back-compat concerns. The login-form and cart-total testbeds (rf2-0sg12) are the running examples; both are referenced rather than re-explained.

## Test plan

- [x] `mkdocs build --strict` — 65 warnings, exactly the baseline on `origin/main` (zero new warnings from this change).
- [x] `python scripts/check_doc_slugs.py` — clean.
- [x] Voice-coherence read-through: all four Causa chapters and Story ch 5 read top-to-bottom; the scenario-then-contract-then-payoff shape lands.
- [ ] Reviewer spot-check the worked rename example for accuracy against the actual fingerprint contract.

Refs: rf2-tadee, rf2-2yvwh; follow-on from rf2-7ou59 review; cites the rf2-0sg12 testbeds shipped in #1139.