### PR TITLE
fix(core): cascade-propagate inheritable envelope keys + wire :interceptor-overrides + fx-ctx :envelope + privacy docstring (rf2-4jci1.{1,2,4,5})

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -155,6 +155,27 @@
   (when-let [f (late-bind/get-fn hook-key)]
     (f args {:frame frame-id})))
 
+;; Inheritable envelope fields — copied from parent to child when
+;; `:dispatch` / `:dispatch-later` queue a new envelope. Per Spec 002
+;; §Cascade propagation (line 1162) and §Drain-loop pseudocode
+;; `inheritable-envelope-keys` (lines 947-952). `:event` and
+;; `:dispatched-at` are NOT inherited — the child gets its own.
+(def ^:private inheritable-envelope-keys
+  [:frame :fx-overrides :interceptor-overrides :trace-id :origin :source])
+
+(defn- child-dispatch-opts
+  "Project the parent envelope's inheritable keys onto the opts map for a
+  child dispatch. Per Spec 002 §Cascade propagation: the dispatched
+  child inherits `:frame`, `:fx-overrides`, `:interceptor-overrides`,
+  `:trace-id`, `:origin`, `:source`. When `parent-envelope` is nil
+  (caller did not thread one through — legacy routing-artefact callers
+  or test fixtures), falls back to `{:frame frame-id}` so single-key
+  propagation still holds."
+  [frame-id parent-envelope]
+  (if parent-envelope
+    (select-keys parent-envelope inheritable-envelope-keys)
+    {:frame frame-id}))
+
 (def ^:private reserved-fx-handlers
   "Reserved fx-id → body-fn `(fn [frame-id parent-envelope args])`.
   Driven by `handle-one-fx`; emit of `:rf.fx/handled` lives in the
@@ -163,24 +184,32 @@
 
   `parent-envelope` is the dispatch envelope of the event that produced
   this fx vector. Per Spec 002 §The binary fx-handler signature (line
-  603) and §Drain-loop pseudocode (lines 916, 961-963), the slot is
-  available to reserved-fx defmethods for `:dispatch` / `:dispatch-later`
-  so they can copy parent-envelope fields onto the child dispatch — see
-  the cascade-propagation work that consumes this seam in a follow-up
-  commit. Flows fxs ignore it."
+  603) and §Drain-loop pseudocode (lines 916, 961-963), the reserved-fx
+  defmethods for `:dispatch` / `:dispatch-later` read the parent envelope
+  to propagate inheritable keys (`:fx-overrides`, `:interceptor-overrides`,
+  `:trace-id`, `:origin`, `:source`) onto the child dispatch — per
+  Spec 002 §Cascade propagation."
   {:dispatch
-   ;; Append to back of the frame's router queue.
-   (fn [frame-id _parent-envelope args]
-     (call-frame-scoped-hook! :router/dispatch! frame-id args))
+   ;; Append to back of the frame's router queue. Per Spec 002
+   ;; §Cascade propagation, the child envelope inherits the parent's
+   ;; `:fx-overrides` / `:interceptor-overrides` / `:trace-id` /
+   ;; `:origin` / `:source`.
+   (fn [frame-id parent-envelope args]
+     (when-let [f (late-bind/get-fn :router/dispatch!)]
+       (f args (child-dispatch-opts frame-id parent-envelope))))
 
    :dispatch-later
    ;; Delayed dispatch — wraps the same router hook in `set-timeout!`.
-   (fn [frame-id _parent-envelope {:keys [ms event]}]
-     (interop/set-timeout!
-       (fn []
-         (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
-           (dispatch! event {:frame frame-id})))
-       ms))
+   ;; Inheritable keys are projected at fx-firing time and captured in
+   ;; the closure so the deferred dispatch carries the parent envelope's
+   ;; overrides into the eventual child cascade.
+   (fn [frame-id parent-envelope {:keys [ms event]}]
+     (let [opts (child-dispatch-opts frame-id parent-envelope)]
+       (interop/set-timeout!
+         (fn []
+           (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+             (dispatch! event opts)))
+         ms)))
 
    ;; Per Spec 013 — flows are frame-scoped. The flow registers against
    ;; the dispatching frame.

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -156,17 +156,26 @@
     (f args {:frame frame-id})))
 
 (def ^:private reserved-fx-handlers
-  "Reserved fx-id → body-fn `(fn [frame-id args])`. Driven by
-  `handle-one-fx`; emit of `:rf.fx/handled` lives in the caller so each
-  reserved fx surfaces exactly one success trace, uniformly."
+  "Reserved fx-id → body-fn `(fn [frame-id parent-envelope args])`.
+  Driven by `handle-one-fx`; emit of `:rf.fx/handled` lives in the
+  caller so each reserved fx surfaces exactly one success trace,
+  uniformly.
+
+  `parent-envelope` is the dispatch envelope of the event that produced
+  this fx vector. Per Spec 002 §The binary fx-handler signature (line
+  603) and §Drain-loop pseudocode (lines 916, 961-963), the slot is
+  available to reserved-fx defmethods for `:dispatch` / `:dispatch-later`
+  so they can copy parent-envelope fields onto the child dispatch — see
+  the cascade-propagation work that consumes this seam in a follow-up
+  commit. Flows fxs ignore it."
   {:dispatch
    ;; Append to back of the frame's router queue.
-   (fn [frame-id args]
+   (fn [frame-id _parent-envelope args]
      (call-frame-scoped-hook! :router/dispatch! frame-id args))
 
    :dispatch-later
    ;; Delayed dispatch — wraps the same router hook in `set-timeout!`.
-   (fn [frame-id {:keys [ms event]}]
+   (fn [frame-id _parent-envelope {:keys [ms event]}]
      (interop/set-timeout!
        (fn []
          (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
@@ -184,11 +193,11 @@
    ;; `{:frame frame-id}` as the second arg. The fx-shape hooks were
    ;; one-line pass-throughs; consolidated to two hooks.
    :rf.fx/reg-flow
-   (fn [frame-id args]
+   (fn [frame-id _parent-envelope args]
      (call-frame-scoped-hook! :flows/reg-flow frame-id args))
 
    :rf.fx/clear-flow
-   (fn [frame-id args]
+   (fn [frame-id _parent-envelope args]
      (call-frame-scoped-hook! :flows/clear-flow frame-id args))})
 
 (defn- resolve-fx-with-overrides
@@ -314,13 +323,23 @@
   `:rf.http/managed` (Spec 014 §Reply addressing) can address replies back
   to the originator without a separate cofx-injection step.
 
+  `parent-envelope` (when supplied) is the dispatch envelope of the
+  originating event. Per Spec 002 §The binary fx-handler signature
+  (line 603) and §Drain-loop pseudocode (lines 916, 961-963) it is
+  exposed on the fx-handler ctx at `(:envelope m)` — reserved-fx
+  defmethods (`:dispatch`, `:dispatch-later`) read it to propagate
+  inheritable envelope keys onto child dispatches per
+  §Cascade propagation. User fxs typically only read `(:frame m)`.
+
   Public so that fx wrappers (per Spec 012 §Navigation tokens
   `:rf.route/with-nav-token`, and any future single-fx re-entry helper)
   can route a single inner fx entry through the same machinery as the
   outer walk — without re-emitting the `:event/do-fx` boundary marker
   that `do-fx` terminates each walk with. `do-fx` remains the entry
   point for the whole `:fx` vector."
-  [frame-id [original-fx-id args] active-platform overrides origin-event]
+  ([frame-id pair active-platform overrides origin-event]
+   (handle-one-fx frame-id pair active-platform overrides origin-event nil))
+  ([frame-id [original-fx-id args] active-platform overrides origin-event parent-envelope]
   (let [fx-id (resolve-fx-with-overrides original-fx-id overrides)
         resolved-meta (resolved-fx-meta original-fx-id fx-id overrides)
         origin-event-id (when (vector? origin-event) (first origin-event))]
@@ -341,9 +360,12 @@
       ;; `:rf.machine/destroy` machine fx-ids are NOT in this table —
       ;; they are registered by re-frame.machines (day8/re-frame2-machines)
       ;; via the regular reg-fx path and arrive here through the
-      ;; registrar default below.
+      ;; registrar default below. The reserved-fx body signature is
+      ;; `(fn [frame-id parent-envelope args])` — `:dispatch` /
+      ;; `:dispatch-later` read parent-envelope to propagate
+      ;; inheritable envelope keys per Spec 002 §Cascade propagation.
       (do
-        (reserved-body frame-id args)
+        (reserved-body frame-id parent-envelope args)
         (emit-handled! fx-id args frame-id))
       ;; Default: user-registered fx — OR a synthesised meta carrying a
       ;; function-value override (per `resolved-fx-meta` above; the
@@ -394,8 +416,17 @@
           (trace/with-handler-scope
             (trace/handler-scope-from-meta :fx fx-id meta)
             (let [ok? (try
+                        ;; Per Spec 002 §The binary fx-handler signature
+                        ;; (line 603): the fx-handler ctx carries `:frame`
+                        ;; (active frame id), `:event` (origin event
+                        ;; vector — Spec 014 §Reply addressing), and
+                        ;; `:envelope` (parent dispatch envelope — read
+                        ;; by reserved fxs only; surfaced here too so
+                        ;; user fxs can observe `:trace-id` / `:origin`
+                        ;; / `:source` without a separate cofx hop).
                         ((:handler-fn meta) (cond-> {:frame frame-id}
-                                              origin-event (assoc :event origin-event))
+                                              origin-event   (assoc :event origin-event)
+                                              parent-envelope (assoc :envelope parent-envelope))
                                             args)
                         true
                         (catch #?(:clj Throwable :cljs :default) e
@@ -423,7 +454,7 @@
                          {:fx-id    fx-id
                           :fx-args  args
                           :frame    frame-id
-                          :recovery :no-recovery}))))))
+                          :recovery :no-recovery})))))))
 
 (defn do-fx
   "Walk the :fx vector in source order. Per Spec 002 §`:fx` ordering rule 3:
@@ -435,16 +466,26 @@
   may be provided. Each [fx-id args] is rewritten through that map
   before lookup.
 
-  The optional 5-arity passes the originating event vector through to
-  user-registered fx handlers as `:event` on their ctx — needed by Spec
-  014 §Reply addressing (the fx captures the originating event-id from
-  the dispatch envelope's cofx)."
+  The 5-arity passes the originating event vector through to user-
+  registered fx handlers as `:event` on their ctx — needed by Spec 014
+  §Reply addressing (the fx captures the originating event-id from the
+  dispatch envelope's cofx).
+
+  The 6-arity additionally threads the originating dispatch envelope
+  through to reserved-fx defmethods (and exposes it at `(:envelope m)`
+  on user-fx ctx) per Spec 002 §The binary fx-handler signature (line
+  603) and §Drain-loop pseudocode (lines 916, 961-963). Reserved-fx
+  bodies for `:dispatch` and `:dispatch-later` read the envelope to
+  propagate inheritable keys onto the child dispatch per §Cascade
+  propagation."
   ([frame-id fx-vec active-platform]
-   (do-fx frame-id fx-vec active-platform {} nil))
+   (do-fx frame-id fx-vec active-platform {} nil nil))
   ([frame-id fx-vec active-platform overrides]
-   (do-fx frame-id fx-vec active-platform overrides nil))
+   (do-fx frame-id fx-vec active-platform overrides nil nil))
   ([frame-id fx-vec active-platform overrides origin-event]
+   (do-fx frame-id fx-vec active-platform overrides origin-event nil))
+  ([frame-id fx-vec active-platform overrides origin-event parent-envelope]
    (doseq [pair fx-vec]
      (when (and (vector? pair) (seq pair))
-       (handle-one-fx frame-id pair active-platform overrides origin-event)))
+       (handle-one-fx frame-id pair active-platform overrides origin-event parent-envelope)))
    (trace/emit! :event :event/do-fx {:frame frame-id})))

--- a/implementation/core/src/re_frame/privacy.cljc
+++ b/implementation/core/src/re_frame/privacy.cljc
@@ -28,9 +28,8 @@
     UNREDACTED payload via the regular `:event` coeffect slot; the
     redaction is for the trace surface — every downstream emit that
     copies the event vector (the handler's `:rf.trace/trigger-handler`
-    cofx view of the event, the `:event/db-changed` `:tags :app-db-before`
-    / `:app-db-after` slots when the corresponding paths exist in
-    app-db, and any `:rf.error/handler-exception` `:tags :event` slot
+    cofx view of the event, the `:event/db-changed` `:tags :event`
+    slot, and any `:rf.error/handler-exception` `:tags :event` slot
     the runtime emits for a throw from this handler) picks up the
     redacted form.
 
@@ -153,10 +152,9 @@
       ;;    - The `:rf.trace/trigger-handler` cofx-slot view of the event
       ;;      (so any emit inside the chain copying the event sees the
       ;;      redacted form).
-      ;;    - The `:event/db-changed` `:tags :app-db-before` /
-      ;;      `:app-db-after` slots (when the corresponding paths exist
-      ;;      in app-db) — handled by the runtime's db-changed emit
-      ;;      consulting the interceptor's stashed paths.
+      ;;    - The `:event/db-changed` `:tags :event` slot — handled by
+      ;;      the runtime's db-changed emit consulting `:rf/redacted-event`
+      ;;      on the interceptor context.
       ;;    - Any `:rf.error/handler-exception` `:tags :event` slot.
       ;;
       ;; The handler body itself sees the UNREDACTED payload via the

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -227,29 +227,63 @@
   "Shared sentinel for the no-extra-interceptors hot path."
   [])
 
+(def ^:private empty-icpt-overrides
+  "Shared sentinel for the no-interceptor-overrides hot path."
+  {})
+
 (defn- apply-overrides
   "Per Spec 002 §Per-frame and per-call overrides: per-frame and per-call
   override maps merge with per-call winning. Returns
-  `{:fx-overrides :extra-interceptors}` for this dispatch.
+  `{:fx-overrides :icpt-overrides :extra-interceptors}` for this dispatch.
 
   HOT PATH: fires on every dispatch. The dominant production path is
   override-free — most apps neither set per-frame `:fx-overrides` /
-  `:interceptors` in their `reg-frame` config nor pass per-call
-  `:fx-overrides` in the dispatch envelope. On that path we
-  short-circuit to shared empty sentinels rather than `merge`-ing
-  empty maps and `vec`-ing an empty `concat`."
+  `:interceptor-overrides` / `:interceptors` in their `reg-frame`
+  config nor pass per-call overrides in the dispatch envelope. On that
+  path we short-circuit to shared empty sentinels rather than `merge`-
+  ing empty maps and `vec`-ing an empty `concat`.
+
+  Per Spec 002 §`:interceptor-overrides` (lines 1108-1139): per-frame
+  and per-call interceptor-override maps merge with per-call winning,
+  same as `:fx-overrides`. The merged map is consumed by
+  `apply-icpt-overrides` in `prepare-handler-ctx` to substitute
+  interceptors in the chain by `:id`."
   [envelope frame-record]
   (let [frame-cfg            (:config frame-record)
         per-call-fx          (:fx-overrides envelope)
         per-frame-fx         (:fx-overrides frame-cfg)
+        per-call-icpt        (:interceptor-overrides envelope)
+        per-frame-icpt       (:interceptor-overrides frame-cfg)
         frame-interceptors   (:interceptors frame-cfg)]
     (if (and (nil? per-call-fx)
              (nil? per-frame-fx)
+             (nil? per-call-icpt)
+             (nil? per-frame-icpt)
              (nil? frame-interceptors))
       {:fx-overrides       empty-fx-overrides
+       :icpt-overrides     empty-icpt-overrides
        :extra-interceptors empty-extra-interceptors}
       {:fx-overrides       (merge per-frame-fx per-call-fx)
+       :icpt-overrides     (merge per-frame-icpt per-call-icpt)
        :extra-interceptors (vec frame-interceptors)})))
+
+(defn- apply-icpt-overrides
+  "Per Spec 002 §`:interceptor-overrides` (lines 1124-1130): walk
+  `chain` and substitute interceptors by `:id` against `overrides`.
+  Entries whose `:id` is a key in `overrides` are replaced by the
+  override's value; `nil`-valued overrides remove the interceptor from
+  the chain.
+
+  HOT PATH no-op: when `overrides` is empty the chain is returned
+  unchanged."
+  [chain overrides]
+  (if (empty? overrides)
+    chain
+    (->> chain
+         (mapv #(if (and (map? %) (contains? overrides (:id %)))
+                  (get overrides (:id %))
+                  %))
+         (filterv some?))))
 
 (defn- validate-event!
   "Per Spec 010 §Validation order step 1 (rf2-jwm4): validate the
@@ -532,18 +566,28 @@
   §Per-frame and per-call overrides) and threads them through the
   initial cofx map. Returns `{:full-chain :initial-ctx :fx-overrides}`.
 
+  Chain assembly order, per Spec 002:
+  1. Prepend per-frame `:interceptors` to the handler's own chain
+     (additive — §`:interceptors` — *add* interceptors).
+  2. Walk the assembled chain and apply `:interceptor-overrides`
+     (replace-by-`:id` per §`:interceptor-overrides` lines 1108-1139);
+     `nil`-valued overrides remove an interceptor from the chain.
+
   HOT PATH: fires on every dispatch. On the override-free path (no
-  per-frame / per-call `:fx-overrides`, no per-frame `:interceptors`),
+  per-frame / per-call `:fx-overrides`, no per-frame / per-call
+  `:interceptor-overrides`, no per-frame `:interceptors`),
   `apply-overrides` returns shared empty sentinels and we reuse the
-  handler's own `:interceptors` vector directly rather than
-  `concat`-ing an empty extra-interceptors prefix and re-`vec`-ing
-  the result."
+  handler's own `:interceptors` vector directly without `concat`-ing
+  an empty extra-interceptors prefix or walking the chain for
+  interceptor-overrides."
   [envelope frame frame-record handler-meta]
-  (let [{:keys [extra-interceptors fx-overrides]} (apply-overrides envelope frame-record)
-        full-chain  (if (seq extra-interceptors)
-                      (vec (concat extra-interceptors (:interceptors handler-meta)))
-                      (:interceptors handler-meta))
-        initial-ctx (assemble-initial-ctx envelope frame frame-record fx-overrides)]
+  (let [{:keys [extra-interceptors fx-overrides icpt-overrides]}
+        (apply-overrides envelope frame-record)
+        prepended-chain (if (seq extra-interceptors)
+                          (vec (concat extra-interceptors (:interceptors handler-meta)))
+                          (:interceptors handler-meta))
+        full-chain      (apply-icpt-overrides prepended-chain icpt-overrides)
+        initial-ctx     (assemble-initial-ctx envelope frame frame-record fx-overrides)]
     {:full-chain   full-chain
      :initial-ctx  initial-ctx
      :fx-overrides fx-overrides}))

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -459,12 +459,20 @@
 (defn- run-fx-effects!
   "Walk :fx in source order, threading fx-overrides through so per-frame
   / per-call overrides take effect. Per-frame :platform overrides
-  interop/platform when set."
-  [effects frame frame-record fx-overrides event]
+  interop/platform when set.
+
+  Per Spec 002 §The binary fx-handler signature (line 603) and §Cascade
+  propagation (line 1162): the originating dispatch envelope is
+  threaded into `do-fx` so reserved-fx defmethods (`:dispatch`,
+  `:dispatch-later`) can copy inheritable keys (`:fx-overrides`,
+  `:interceptor-overrides`, `:trace-id`, `:origin`, `:source`) onto
+  child dispatches. User fxs see it at `(:envelope m)`."
+  [effects frame frame-record fx-overrides envelope]
   (when-let [fx-vec (:fx effects)]
     (let [active-platform (or (get-in frame-record [:config :platform])
-                              interop/platform)]
-      (fx/do-fx frame fx-vec active-platform fx-overrides event))))
+                              interop/platform)
+          event           (:event envelope)]
+      (fx/do-fx frame fx-vec active-platform fx-overrides event envelope))))
 
 ;; ---- process-event* phases ------------------------------------------------
 ;;
@@ -570,8 +578,12 @@
   flows do NOT evaluate and `:fx` does NOT walk. The pre-handler db
   is read from `(get-in final-ctx [:coeffects :db])` (assemble-
   initial-ctx stamps it there). Downstream queued events still drain
-  per run-to-completion (handled by `drain-loop!`'s outer pass)."
-  [final-ctx event-id event frame frame-record fx-overrides start-ms]
+  per run-to-completion (handled by `drain-loop!`'s outer pass).
+
+  Per Spec 002 §Cascade propagation: `envelope` is threaded into
+  `run-fx-effects!` so reserved-fx defmethods can propagate
+  inheritable keys onto child dispatches."
+  [final-ctx event-id event frame frame-record fx-overrides envelope start-ms]
   (let [effects   (:effects final-ctx)
         error     (:rf/interceptor-error final-ctx)
         db-before (get-in final-ctx [:coeffects :db])]
@@ -579,7 +591,7 @@
       (emit-handler-exception! error event-id event frame final-ctx start-ms))
     (when (commit-db-effect! effects event-id event frame final-ctx db-before)
       (run-flows! frame event)
-      (run-fx-effects! effects frame frame-record fx-overrides event))
+      (run-fx-effects! effects frame frame-record fx-overrides envelope))
     error))
 
 (defn- emit-cascade-trailers!
@@ -651,7 +663,7 @@
           (prepare-handler-ctx envelope frame frame-record handler-meta)
           final-ctx (run-chain event-id full-chain initial-ctx event-ok?)
           error     (commit-and-flow! final-ctx event-id event frame
-                                      frame-record fx-overrides start-ms)]
+                                      frame-record fx-overrides envelope start-ms)]
       (emit-cascade-trailers! event-id event frame error start-ms))))
 
 (defn- process-event*

--- a/implementation/core/test/re_frame/cascade_envelope_propagation_test.clj
+++ b/implementation/core/test/re_frame/cascade_envelope_propagation_test.clj
@@ -1,0 +1,178 @@
+(ns re-frame.cascade-envelope-propagation-test
+  "Per rf2-4jci1.1 — Spec/002 §Cascade propagation (line 1162) +
+  §Drain-loop pseudocode `inheritable-envelope-keys` (lines 947-952).
+
+  The dispatch envelope's `:fx-overrides`, `:interceptor-overrides`,
+  `:trace-id`, `:origin`, `:source`, `:frame` MUST propagate through
+  `:fx [[:dispatch ...]]` cascades: when a handler returns an effect-map
+  containing `:dispatch`, the dispatched child inherits the parent
+  envelope's overrides. Same mechanism for `:dispatch-later`.
+
+  JVM-only — the cascade propagation is platform-agnostic; the runtime
+  paths under test do not depend on a CLJS host."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (trace/clear-trace-cbs!)
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- :fx-overrides cascade propagation ------------------------------------
+
+(deftest fx-overrides-propagate-through-dispatch-cascade
+  (testing "per-call :fx-overrides ride the :fx [[:dispatch ...]] cascade"
+    (let [http-fired (atom [])
+          http-stub  (atom [])]
+      (rf/reg-fx :test/http
+        (fn [_ args] (swap! http-fired conj args)))
+      (rf/reg-fx :test/http.stub
+        (fn [_ args] (swap! http-stub conj args)))
+      (rf/reg-event-fx :test/parent
+        (fn [_ _]
+          {:fx [[:test/http {:tag :from-parent}]
+                [:dispatch [:test/child]]]}))
+      (rf/reg-event-fx :test/child
+        (fn [_ _]
+          {:fx [[:test/http {:tag :from-child}]]}))
+
+      (rf/dispatch-sync
+        [:test/parent]
+        {:fx-overrides {:test/http :test/http.stub}})
+
+      (is (empty? @http-fired)
+          "no real :test/http fired — every call should hit the stub")
+      (is (= [{:tag :from-parent} {:tag :from-child}] @http-stub)
+          "the stub captured BOTH the parent's and the child's :test/http calls")))
+
+  (testing "per-call :fx-overrides propagate through nested :dispatch cascades"
+    (let [http-stub (atom [])]
+      (rf/reg-fx :test/http  (fn [_ _]))
+      (rf/reg-fx :test/http.stub
+        (fn [_ args] (swap! http-stub conj args)))
+      (rf/reg-event-fx :test/lvl-0
+        (fn [_ _]
+          {:fx [[:test/http {:lvl 0}]
+                [:dispatch [:test/lvl-1]]]}))
+      (rf/reg-event-fx :test/lvl-1
+        (fn [_ _]
+          {:fx [[:test/http {:lvl 1}]
+                [:dispatch [:test/lvl-2]]]}))
+      (rf/reg-event-fx :test/lvl-2
+        (fn [_ _]
+          {:fx [[:test/http {:lvl 2}]]}))
+
+      (rf/dispatch-sync
+        [:test/lvl-0]
+        {:fx-overrides {:test/http :test/http.stub}})
+
+      (is (= [{:lvl 0} {:lvl 1} {:lvl 2}] @http-stub)
+          "override propagated through three levels of :dispatch cascade"))))
+
+;; ---- :trace-id / :origin / :source propagation ----------------------------
+
+(deftest trace-id-origin-source-propagate-through-cascade
+  (testing ":trace-id, :origin, :source all ride the child envelope"
+    ;; Capture parent and child envelopes via the trace stream — every
+    ;; :event/dispatched event surfaces :origin / :source on :tags.
+    (let [seen (atom [])]
+      (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+      (try
+        (rf/reg-event-fx :test/parent
+          (fn [_ _]
+            {:fx [[:dispatch [:test/child]]]}))
+        (rf/reg-event-db :test/child (fn [db _] db))
+
+        (rf/dispatch-sync [:test/parent]
+                          {:trace-id ::scoped-trace
+                           :origin   :test
+                           :source   :unit-test})
+
+        (let [dispatched   (->> @seen
+                                 (filter #(= :event/dispatched (:operation %))))
+              parent-ev    (first (filter #(= [:test/parent] (get-in % [:tags :event])) dispatched))
+              child-ev     (first (filter #(= [:test/child]  (get-in % [:tags :event])) dispatched))]
+          (is (some? parent-ev) "parent's :event/dispatched is captured")
+          (is (some? child-ev)  "child's :event/dispatched is captured")
+          ;; :origin rides :tags; :source is hoisted to top-level by
+          ;; trace/emit! per Spec 009 §Core fields (line 367/388).
+          (is (= :test      (get-in parent-ev [:tags :origin])) "parent carries :origin :test")
+          (is (= :unit-test (:source parent-ev))             "parent carries :source :unit-test")
+          (is (= :test      (get-in child-ev  [:tags :origin]))
+              ":origin :test propagated through the cascade")
+          (is (= :unit-test (:source child-ev))
+              ":source :unit-test propagated through the cascade"))
+        (finally (rf/remove-trace-cb! ::rec))))))
+
+;; ---- :envelope exposed on fx-handler ctx (rf2-4jci1.4) -------------------
+
+(deftest fx-handler-ctx-carries-envelope-slot
+  (testing "user fx-handler receives (:envelope m) — the parent dispatch envelope"
+    (let [captured-envelopes (atom [])]
+      (rf/reg-fx :test/capture-envelope
+        (fn [m _args] (swap! captured-envelopes conj (:envelope m))))
+      (rf/reg-event-fx :test/run
+        (fn [_ _]
+          {:fx [[:test/capture-envelope]]}))
+
+      (rf/dispatch-sync [:test/run]
+                        {:trace-id  ::abc
+                         :origin    :test
+                         :source    :unit-test})
+
+      (let [env (first @captured-envelopes)]
+        (is (some? env) "the fx-handler ctx carried :envelope")
+        (is (= ::abc      (:trace-id env)))
+        (is (= :test      (:origin env)))
+        (is (= :unit-test (:source env)))
+        (is (= [:test/run] (:event env)))))))
+
+;; ---- :dispatch-later propagates inheritable keys --------------------------
+;;
+;; :dispatch-later wraps in set-timeout!; we can verify the opts the
+;; eventual :router/dispatch! call would receive by stubbing set-timeout!
+;; semantics. Easier path: register a fixture timer that runs the inner
+;; fn synchronously via a custom :dispatch-later shape — but the existing
+;; reserved-fx body is platform-coupled (interop/set-timeout!). For JVM
+;; the timer fires on a future; we use a CountDownLatch coordinated stub
+;; to keep the test deterministic.
+
+(deftest dispatch-later-propagates-inheritable-keys
+  (testing ":dispatch-later carries parent overrides into the deferred dispatch"
+    (let [stub-fired (atom [])
+          done       (promise)]
+      (rf/reg-fx :test/http (fn [_ _]))
+      (rf/reg-fx :test/http.stub
+        (fn [_ args]
+          (swap! stub-fired conj args)
+          (deliver done :fired)))
+      (rf/reg-event-fx :test/parent
+        (fn [_ _]
+          {:fx [[:dispatch-later {:ms 1 :event [:test/child]}]]}))
+      (rf/reg-event-fx :test/child
+        (fn [_ _]
+          {:fx [[:test/http {:tag :deferred}]]}))
+
+      (rf/dispatch-sync
+        [:test/parent]
+        {:fx-overrides {:test/http :test/http.stub}})
+
+      (is (= :fired (deref done 2000 :timeout))
+          ":dispatch-later fired the :test/child cascade")
+      (is (= [{:tag :deferred}] @stub-fired)
+          ":fx-overrides propagated into :dispatch-later's deferred dispatch"))))

--- a/implementation/core/test/re_frame/interceptor_overrides_test.clj
+++ b/implementation/core/test/re_frame/interceptor_overrides_test.clj
@@ -1,0 +1,147 @@
+(ns re-frame.interceptor-overrides-test
+  "Per rf2-4jci1.2 — Spec/002 §`:interceptor-overrides` (lines 1108-1139)
+  + §Per-frame and per-call overrides §merge.
+
+  Per-call `{:interceptor-overrides {:my-app/logging nil}}` AND
+  per-frame `(reg-frame :f {:interceptor-overrides {...}})` MUST walk
+  the assembled interceptor chain and substitute entries by their `:id`:
+
+    * `id -> nil`            removes the interceptor.
+    * `id -> <interceptor>`  replaces the entry.
+    * id not present in map  leaves entry untouched.
+
+  Per-call wins over per-frame on key conflict (matches `:fx-overrides`
+  precedence per Spec 002 §Per-frame and per-call overrides §merge).
+
+  Pre-fix the `:interceptor-overrides` key was accepted by
+  `build-envelope` and stored on the envelope but no code path read
+  it back. This test pins the consume-side wiring."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.interceptor :as interceptor]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (trace/clear-trace-cbs!)
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- logger-interceptor [log id]
+  (interceptor/->interceptor
+    :id     id
+    :before (fn [ctx] (swap! log conj [id :before]) ctx)
+    :after  (fn [ctx] (swap! log conj [id :after]) ctx)))
+
+;; ---- per-call :interceptor-overrides ---------------------------------------
+
+(deftest per-call-interceptor-override-removes-by-id
+  (testing "per-call {:icpt nil} drops the interceptor from the chain"
+    (let [log (atom [])]
+      (rf/reg-event-db :test/run
+        [(logger-interceptor log ::log-a)
+         (logger-interceptor log ::log-b)]
+        (fn [db _] (assoc db :ran? true)))
+
+      (rf/dispatch-sync [:test/run]
+                        {:interceptor-overrides {::log-a nil}})
+
+      (is (= [[::log-b :before]
+              [::log-b :after]]
+             @log)
+          "::log-a was removed; ::log-b's before/after still fired"))))
+
+(deftest per-call-interceptor-override-replaces-by-id
+  (testing "per-call {:icpt <new>} replaces the interceptor"
+    (let [log (atom [])
+          original-icpt (logger-interceptor log ::log-x)
+          stub-icpt     (interceptor/->interceptor
+                          :id     ::log-x
+                          :before (fn [ctx] (swap! log conj [::stub :fired]) ctx))]
+      (rf/reg-event-db :test/run
+        [original-icpt]
+        (fn [db _] db))
+
+      (rf/dispatch-sync [:test/run]
+                        {:interceptor-overrides {::log-x stub-icpt}})
+
+      (is (= [[::stub :fired]] @log)
+          "the stub fired in place of the original ::log-x interceptor"))))
+
+;; ---- per-frame :interceptor-overrides --------------------------------------
+
+(deftest per-frame-interceptor-override-applies-to-every-dispatch
+  (testing "per-frame :interceptor-overrides walks the chain on every dispatch"
+    (let [log (atom [])]
+      (rf/reg-frame :test/silent
+        {:interceptor-overrides {::log-a nil}})
+      (rf/reg-event-db :test/run
+        [(logger-interceptor log ::log-a)
+         (logger-interceptor log ::log-b)]
+        (fn [db _] db))
+
+      (rf/dispatch-sync [:test/run] {:frame :test/silent})
+
+      (is (= [[::log-b :before]
+              [::log-b :after]]
+             @log)
+          "::log-a was removed by the frame-config override"))))
+
+;; ---- merge order: per-call wins over per-frame -----------------------------
+
+(deftest per-call-overrides-per-frame-on-key-conflict
+  (testing "when the same :id appears in per-call AND per-frame overrides, per-call wins"
+    (let [log (atom [])
+          frame-stub (interceptor/->interceptor
+                       :id     ::log
+                       :before (fn [ctx] (swap! log conj :frame-stub) ctx))
+          call-stub  (interceptor/->interceptor
+                       :id     ::log
+                       :before (fn [ctx] (swap! log conj :call-stub) ctx))]
+      (rf/reg-frame :test/scoped
+        {:interceptor-overrides {::log frame-stub}})
+      (rf/reg-event-db :test/run
+        [(logger-interceptor log ::log)]
+        (fn [db _] db))
+
+      (rf/dispatch-sync [:test/run]
+                        {:frame :test/scoped
+                         :interceptor-overrides {::log call-stub}})
+
+      (is (= [:call-stub] @log)
+          "per-call override won over per-frame override on key conflict"))))
+
+;; ---- ids absent from override map pass through unchanged -------------------
+
+(deftest unmatched-ids-pass-through-unchanged
+  (testing "interceptors whose :id is not a key in the override map fire normally"
+    (let [log (atom [])]
+      (rf/reg-event-db :test/run
+        [(logger-interceptor log ::log-a)
+         (logger-interceptor log ::log-b)]
+        (fn [db _] db))
+
+      (rf/dispatch-sync [:test/run]
+                        {:interceptor-overrides {::log-c nil}})    ;; ::log-c not in chain
+
+      (is (= [[::log-a :before]
+              [::log-b :before]
+              [::log-b :after]
+              [::log-a :after]]
+             @log)
+          "both interceptors fired in standard before/after sandwich"))))


### PR DESCRIPTION
## Summary

Four-commit cluster off rf2-4jci1 (core+epoch slice audit). Closes two
P1 correctness gaps against Spec/002, lands the structural prerequisite,
and clears one P3 doc drift.

**Pre-alpha**: no back-compat for the dead-code `:interceptor-overrides`
path; commits are sequenced for review clarity.

### Per-commit summary

1. **rf2-4jci1.4** — `fix(core): expose parent envelope at (:envelope m)
   on fx-handler ctx`. Plumbing-only seam: reserved-fx body signature
   widens to `(fn [frame-id parent-envelope args])`; `handle-one-fx` /
   `do-fx` gain new arities threading `parent-envelope`; user-fx ctx
   grows an `:envelope` slot. Per Spec/002 §The binary fx-handler
   signature (line 603) + §Drain-loop pseudocode (lines 916, 961-963).
   Structural prereq for Commit 2.

2. **rf2-4jci1.1** — `fix(core): cascade-propagate inheritable envelope
   keys through :dispatch / :dispatch-later`. **P1 correctness.** Per
   Spec/002 §Cascade propagation (line 1162) + §Drain-loop pseudocode
   `inheritable-envelope-keys` (lines 947-952): consumes the seam to
   propagate `:frame :fx-overrides :interceptor-overrides :trace-id
   :origin :source` from parent envelope to child dispatches.
   Pre-fix only `:frame` flowed; the other five were silently dropped.

3. **rf2-4jci1.2** — `fix(core): consume :interceptor-overrides —
   replace-by-id walk per Spec/002`. **P1 correctness.** Adds
   `apply-icpt-overrides` (Spec/002 §1124-1130) and wires per-frame +
   per-call merge (per-call wins) through `prepare-handler-ctx`.
   Pre-fix the key was accepted by `build-envelope` and stored on the
   envelope but no code path consumed it.

4. **rf2-4jci1.5** — `docs(core): drop stale :app-db-before /
   :app-db-after refs from privacy docstrings`. P3 doc cleanup.
   `with-redacted` does NOT scrub `:app-db-*` tags (the runtime never
   emits them); it DOES scrub `:event/db-changed` `:tags :event`.
   Drop-claim direction (runtime contract is unchanged).

### LoC

`+311 / -68` across `fx.cljc` (+59/-23), `router.cljc` (+47/-12),
`privacy.cljc` (+5/-7), and two new test files (+200 lines).

### Tests

**JVM (`clojure -M:test`):** 543 tests / 2745 assertions PASS on
`implementation/core/` (+5 from baseline 538); 85 tests / 330
assertions PASS on `implementation/epoch/`.

**CLJS (`npm run test:cljs`):** 2014 tests / 5695 assertions PASS.

**Bundle isolation (`npm run test:bundle-isolation`):** PASS.

#### New cascade-propagation tests
(`implementation/core/test/re_frame/cascade_envelope_propagation_test.clj`)

- `fx-overrides-propagate-through-dispatch-cascade` — per-call
  `:fx-overrides` ride a 1-level cascade AND a 3-level nested cascade.
- `trace-id-origin-source-propagate-through-cascade` — `:origin` and
  `:source` ride parent + child `:event/dispatched`.
- `fx-handler-ctx-carries-envelope-slot` — exercises Commit 1's seam:
  user fx-handler reads `(:envelope m)`.
- `dispatch-later-propagates-inheritable-keys` — deferred-dispatch path
  carries the parent's `:fx-overrides`.

#### New interceptor-overrides tests
(`implementation/core/test/re_frame/interceptor_overrides_test.clj`)

- `per-call-interceptor-override-removes-by-id` — `{:id nil}` drops the
  interceptor.
- `per-call-interceptor-override-replaces-by-id` — `{:id <new>}`
  substitutes; the stub fires in its place.
- `per-frame-interceptor-override-applies-to-every-dispatch`.
- `per-call-overrides-per-frame-on-key-conflict` — per-call wins.
- `unmatched-ids-pass-through-unchanged`.

### Cross-refs

- Parent audit: rf2-4jci1 (OPEN; closes when .1 + .2 land).
- Spec/002 — inheritable-envelope-keys + cascade propagation contract.
- rf2-4jci1.3 (`make-restore-fn` decision) — separate Mike decision,
  NOT in this PR.

## Test plan

- [x] `npm run test:cljs` PASS (zero regressions)
- [x] `npm run test:bundle-isolation` PASS
- [x] `clojure -M:test` PASS on `implementation/core/`
- [x] `clojure -M:test` PASS on `implementation/epoch/`
- [x] New cascade-propagation tests exercise per-call `:fx-overrides`,
      `:trace-id`, `:origin`, `:source`, and `:dispatch-later` paths.
- [x] New interceptor-overrides tests exercise per-call AND per-frame
      override-by-id, removal, replacement, and merge precedence.