### PR TITLE
fix(machines): :invoke-all child-id verification — gate forged returns (rf2-ns8ut, P1)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -10,16 +10,20 @@
       snapshot's `:state` path leaf→root looking for a state node whose
       `:invoke-all` declares the matching event keyword.
    2. Reads the join state at `[:rf/spawned <parent> <invoke-id>]`.
-   3. Adds `<child-id>` (event[1]) to `:done` or `:failed`.
-   4. If `:resolved?` is already true, the event is silently dropped
+   3. Verifies `<child-id>` (event[1]) is one of the parent's spawned
+      children. Forged / unknown ids are rejected with the
+      `:rf.error/machine-invoke-all-bad-child-id` error trace and a
+      no-op fx (the join state is NOT mutated). See rf2-ns8ut.
+   4. Adds `<child-id>` to `:done` or `:failed`.
+   5. If `:resolved?` is already true, the event is silently dropped
       (post-resolution late-completion).
-   5. Else evaluates the join condition. On resolution:
+   6. Else evaluates the join condition. On resolution:
         - latches `:resolved?` true,
         - if `:cancel-on-decision?` (default true), emits per-sibling
           `:rf.machine/destroy` fx and `:rf.machine.invoke/cancelled-on-
           join-resolution` traces,
         - dispatches the parent join event via `:fx [[:dispatch ...]]`.
-   6. Writes the new join state back into app-db.
+   7. Writes the new join state back into app-db.
 
   The interceptor's public entry point is `intercept-invoke-all-event`;
   the handler-factory in `re-frame.machines.lifecycle-fx.registration`
@@ -250,6 +254,25 @@
                             :invoke-id  invoke-id
                             :child-id   child-id
                             :kind       kind})
+              {:db db :fx []})
+
+          ;; Forged / unknown child-id: the inbound `child-id` is NOT in
+          ;; the seeded `:children` map. The accident class is a
+          ;; hand-crafted dispatch (copy-paste from a sibling :invoke-all,
+          ;; typo, cascaded event from a sibling parent) that the runtime
+          ;; would otherwise silently fold into `:done` / `:failed`,
+          ;; collapsing the join early. Gate it: emit a structured error
+          ;; trace and short-circuit with a no-op fx (do NOT mutate the
+          ;; join state). Per Spec 005 §Spawn-and-join and the machines
+          ;; security-audit finding F1 (rf2-ns8ut / rf2-s9tf8).
+          (not (contains? (:children join-state) child-id))
+          (do (trace/emit-error! :rf.error/machine-invoke-all-bad-child-id
+                                 {:machine-id parent-id
+                                  :invoke-id  invoke-id
+                                  :child-id   child-id
+                                  :children   (set (keys (:children join-state)))
+                                  :kind       kind
+                                  :recovery   :event-dropped})
               {:db db :fx []})
 
           :else

--- a/implementation/machines/test/re_frame/invoke_all_test.clj
+++ b/implementation/machines/test/re_frame/invoke_all_test.clj
@@ -435,6 +435,224 @@
         (finally
           (rf/remove-trace-cb! ::late-cb))))))
 
+;; ---- forged child-id rejection (rf2-ns8ut) ------------------------------
+;;
+;; intercept-invoke-all-event must verify the inbound `child-id` is one
+;; of the parent's spawned children before mutating the join state.
+;; Otherwise a hand-crafted dispatch (typo, copy-paste from a sibling
+;; :invoke-all, cascaded event from another parent) silently folds an
+;; unknown id into `:done` / `:failed` and can collapse the join early
+;; (silent state-machine corruption). The runtime gates this with
+;; `:rf.error/machine-invoke-all-bad-child-id` and a no-op fx — the
+;; join state is NOT mutated and the join does not resolve on the
+;; forged event.
+;;
+;; Pragmatic security stance: trust the explicit invoker but gate
+;; accidents. See ai/findings/machines-security-audit-2026-05-15.md F1.
+
+(defn- mk-inert-child
+  "A child that records its parent-id but never auto-dispatches back —
+  letting us hand-craft forged `[parent [:on-child-done <bogus>]]`
+  events into the parent without race with real child completion."
+  []
+  {:initial :running
+   :data    {:id nil}
+   :actions {:record-id
+             (fn [data ev]
+               {:data (assoc data :id (second ev))})}
+   :states
+   {:running {:on {:set-id {:action :record-id}}}}})
+
+(defn- collect-traces
+  "Run `body-fn` with a trace listener attached; return the collected
+  vector of trace envelopes."
+  [body-fn]
+  (let [traces (atom [])
+        cb-key (gensym ::forged-cb)]
+    (rf/register-trace-cb! cb-key (fn [ev] (swap! traces conj ev)))
+    (try
+      (body-fn)
+      (finally
+        (rf/remove-trace-cb! cb-key)))
+    @traces))
+
+(defn- bad-child-id-error-traces
+  [traces]
+  (->> traces
+       (filter #(= :rf.error/machine-invoke-all-bad-child-id
+                   (:operation %)))))
+
+(deftest forged-child-id-with-no-live-children-is-rejected
+  (testing "an :on-child-done dispatch carrying a child-id NOT in the
+  parent's spawned set emits :rf.error/machine-invoke-all-bad-child-id
+  and is a no-op (join state untouched, no resolution)"
+    (let [parent {:initial :idle
+                  :states
+                  {:idle      {:on {:start :hydrating}}
+                   :hydrating
+                   {:invoke-all
+                    {:children        [{:id :a :machine-id :child/forge-a :start [:set-id :a]}
+                                       {:id :b :machine-id :child/forge-b :start [:set-id :b]}]
+                     :join            :all
+                     :on-child-done   :asset/loaded
+                     :on-child-error  :asset/failed
+                     :on-all-complete [:hydrate/done]
+                     :on-any-failed   [:hydrate/failed]}
+                    :on    {:hydrate/done   :ready
+                            :hydrate/failed :error}}
+                   :ready  {}
+                   :error  {}}}]
+      (rf/reg-machine :child/forge-a (mk-inert-child))
+      (rf/reg-machine :child/forge-b (mk-inert-child))
+      (rf/reg-machine :sup/forge-none parent)
+      (rf/dispatch-sync [:sup/forge-none [:start]])
+      (let [pre-jstate (get-in (frame-db) [:rf/spawned :sup/forge-none [:hydrating]])
+            children   (:children pre-jstate)
+            _          (is (= #{:a :b} (set (keys children))))
+            traces (collect-traces
+                    (fn []
+                      (rf/dispatch-sync
+                        [:sup/forge-none [:asset/loaded :totally-fake-id]])))
+            post-jstate (get-in (frame-db) [:rf/spawned :sup/forge-none [:hydrating]])
+            errs (bad-child-id-error-traces traces)]
+        (is (= 1 (count errs))
+            "exactly one :rf.error/machine-invoke-all-bad-child-id trace fired")
+        (let [err  (first errs)
+              tags (:tags err)]
+          (is (= :sup/forge-none (:machine-id tags)))
+          (is (= [:hydrating] (:invoke-id tags)))
+          (is (= :totally-fake-id (:child-id tags)))
+          (is (= #{:a :b} (:children tags))
+              ":children carries the legitimate seed set")
+          (is (= :done (:kind tags))
+              ":kind carries the resolution-side the forged event aimed at")
+          (is (= :event-dropped (:recovery err))
+              ":recovery is hoisted to top-level on error envelopes"))
+        (is (= pre-jstate post-jstate)
+            "join state unchanged: forged id NOT added to :done or :failed")
+        (is (= :hydrating (:state (snapshot :sup/forge-none)))
+            "parent did NOT resolve on the forged event")))))
+
+(deftest repeated-forged-completions-each-emit-error-and-do-not-resolve
+  (testing "repeated forged :on-child-done dispatches each emit error
+  traces; the join still does not resolve"
+    (let [parent {:initial :idle
+                  :states
+                  {:idle      {:on {:start :hydrating}}
+                   :hydrating
+                   {:invoke-all
+                    {:children        [{:id :a :machine-id :child/forge-r :start [:set-id :a]}]
+                     :join            :all
+                     :on-child-done   :asset/loaded
+                     :on-child-error  :asset/failed
+                     :on-all-complete [:hydrate/done]
+                     :on-any-failed   [:hydrate/failed]}
+                    :on    {:hydrate/done   :ready
+                            :hydrate/failed :error}}
+                   :ready  {}
+                   :error  {}}}]
+      (rf/reg-machine :child/forge-r (mk-inert-child))
+      (rf/reg-machine :sup/forge-repeated parent)
+      (rf/dispatch-sync [:sup/forge-repeated [:start]])
+      (let [traces (collect-traces
+                    (fn []
+                      (rf/dispatch-sync [:sup/forge-repeated [:asset/loaded :fake-1]])
+                      (rf/dispatch-sync [:sup/forge-repeated [:asset/loaded :fake-2]])
+                      (rf/dispatch-sync [:sup/forge-repeated [:asset/failed :fake-3]])))
+            errs (bad-child-id-error-traces traces)
+            jstate (get-in (frame-db) [:rf/spawned :sup/forge-repeated [:hydrating]])]
+        (is (= 3 (count errs))
+            "one error trace per forged dispatch")
+        (is (= [:fake-1 :fake-2 :fake-3]
+               (mapv (comp :child-id :tags) errs))
+            "each error trace carries its specific forged child-id")
+        (is (= [:done :done :failed]
+               (mapv (comp :kind :tags) errs))
+            "each error trace carries the resolution-side it aimed at")
+        (is (= #{} (:done jstate)))
+        (is (= #{} (:failed jstate)))
+        (is (false? (:resolved? jstate)))
+        (is (= :hydrating (:state (snapshot :sup/forge-repeated))))))))
+
+(deftest sibling-invoke-all-child-id-is-not-counted-into-other-join
+  (testing "a child-id legitimate to one parent's :invoke-all is forged
+  for ANOTHER parent's :invoke-all and is rejected by the other"
+    (let [parent-1 {:initial :idle
+                    :states
+                    {:idle      {:on {:start :working}}
+                     :working
+                     {:invoke-all
+                      {:children        [{:id :p1-a :machine-id :child/p1a :start [:set-id :p1-a]}]
+                       :join            :all
+                       :on-child-done   :asset/loaded
+                       :on-child-error  :asset/failed
+                       :on-all-complete [:done]}}}}
+          parent-2 {:initial :idle
+                    :states
+                    {:idle      {:on {:start :working}}
+                     :working
+                     {:invoke-all
+                      {:children        [{:id :p2-x :machine-id :child/p2x :start [:set-id :p2-x]}]
+                       :join            :all
+                       :on-child-done   :asset/loaded
+                       :on-child-error  :asset/failed
+                       :on-all-complete [:done]}}}}]
+      (rf/reg-machine :child/p1a (mk-inert-child))
+      (rf/reg-machine :child/p2x (mk-inert-child))
+      (rf/reg-machine :sup/p1 parent-1)
+      (rf/reg-machine :sup/p2 parent-2)
+      (rf/dispatch-sync [:sup/p1 [:start]])
+      (rf/dispatch-sync [:sup/p2 [:start]])
+      ;; Dispatch p2's child-id (:p2-x) into p1's join — it is foreign
+      ;; to p1's seeded :children {:p1-a ...} and must be rejected.
+      (let [traces (collect-traces
+                    (fn []
+                      (rf/dispatch-sync [:sup/p1 [:asset/loaded :p2-x]])))
+            errs (bad-child-id-error-traces traces)
+            p1-j (get-in (frame-db) [:rf/spawned :sup/p1 [:working]])]
+        (is (= 1 (count errs))
+            "sibling parent's child-id is forged-for-this-parent and rejected")
+        (is (= :p2-x (:child-id (:tags (first errs)))))
+        (is (= #{:p1-a} (:children (:tags (first errs))))
+            ":children reflects p1's seed, NOT p2's")
+        (is (= #{} (:done p1-j))
+            "p1's join state untouched by the foreign id")
+        (is (false? (:resolved? p1-j)))))))
+
+(deftest legitimate-child-id-flow-not-regressed-by-the-gate
+  (testing "the legitimate child-id path still resolves and the gate
+  does not emit a bad-child-id error for real children"
+    (let [child  (mk-child :sup/gate-ok :asset/loaded :asset/failed)
+          parent {:initial :idle
+                  :states
+                  {:idle      {:on {:start :hydrating}}
+                   :hydrating
+                   {:invoke-all
+                    {:children        [{:id :a :machine-id :child/gate-a :start [:set-id :a]}
+                                       {:id :b :machine-id :child/gate-b :start [:set-id :b]}]
+                     :join            :all
+                     :on-child-done   :asset/loaded
+                     :on-child-error  :asset/failed
+                     :on-all-complete [:hydrate/done]}
+                    :on    {:hydrate/done :ready}}
+                   :ready {}}}]
+      (rf/reg-machine :child/gate-a child)
+      (rf/reg-machine :child/gate-b child)
+      (rf/reg-machine :sup/gate-ok parent)
+      (let [traces (collect-traces
+                    (fn []
+                      (rf/dispatch-sync [:sup/gate-ok [:start]])
+                      (let [ids (:children (get-in (frame-db)
+                                                   [:rf/spawned :sup/gate-ok
+                                                    [:hydrating]]))]
+                        (rf/dispatch-sync [(:a ids) [:go]])
+                        (rf/dispatch-sync [(:b ids) [:go]]))))
+            errs (bad-child-id-error-traces traces)]
+        (is (= [] (vec errs))
+            "no :rf.error/machine-invoke-all-bad-child-id for legitimate flow")
+        (is (= :ready (:state (snapshot :sup/gate-ok)))
+            "legitimate :invoke-all resolution still fires :on-all-complete")))))
+
 (deftest any-failed-trace-carries-reason-payload
   (testing ":rf.machine.invoke-all/any-failed trace carries :reason from decisive failure"
     (let [traces (atom [])


### PR DESCRIPTION
## Summary

- **Bug class**: silent state-machine corruption. `intercept-invoke-all-event` trusted the inbound `child-id` from the event vector and folded it directly into `:done` / `:failed` via `(fnil conj #{})`. `join-condition-met?` resolves purely from set-count vs `n-total` — so a hand-crafted dispatch (typo, copy-paste from a sibling `:invoke-all`, cascaded event from a destroyed sibling) could **collapse the join condition early** with no signal.
- **Fix**: before the `case kind` bump, verify `(contains? (:children join-state) child-id)` against the seeded children map. Unknown ids emit `:rf.error/machine-invoke-all-bad-child-id` (carrying the bogus id, the legitimate seed set, the resolution-kind, and `:recovery :event-dropped`) and return a no-op fx — the join state is NOT mutated.
- **Pragmatic security stance**: trust the explicit invoker, but gate accidents. This is the silent-misbehaviour-on-malformed-input class Mike's filter prioritises.

Per `ai/findings/machines-security-audit-2026-05-15.md` F1 (audit bead rf2-s9tf8).

## Test plan

- [x] New regression tests pin the rejection contract:
  - forged id with no live completions emits exactly one error, leaves `:done` / `:failed` empty, `:resolved? false`, parent stays in source state
  - repeated forged completions each emit their own error trace; each tag carries its specific forged child-id + the resolution-side
  - a sibling parent's legitimate child-id is foreign to this parent's seed and rejected (no cross-pollination)
  - legitimate child-id flow still resolves normally with no `:rf.error/machine-invoke-all-bad-child-id` traces
- [x] `clojure -M:test` from `implementation/machines/`: **163 tests, 538 assertions, 0 failures, 0 errors**
- [x] `npm run test:cljs`: **2014 tests, 5695 assertions, 0 failures, 0 errors**
- [x] `npm run test:bundle-isolation`: **PASS** (all sentinel checks green)

## Surface

- `implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc` — gate at `intercept-invoke-all-event`'s `cond`, between the `:resolved?` branch and the bump
- `implementation/machines/test/re_frame/invoke_all_test.clj` — four new regression tests + helpers

LoC: +245 / -4 (gate is 14 LoC; rest is tests + docstring update).

Closes rf2-ns8ut.