### PR TITLE
fix(flows): teardown-on-destroy-frame memory leak (rf2-wbtjn — symmetric with rf2-vsigt)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -431,6 +431,13 @@
          :machines/on-frame-destroyed!      — clear the machines
                                               artefact's frame-scoped
                                               `:after` timer table.
+         :schemas/on-frame-destroyed!       — drop schemas registered
+                                              against this frame
+                                              (rf2-wkxng / rf2-6m0se).
+         :flows/teardown-on-frame-destroy!  — drop flows + last-inputs
+                                              rows + dead `:flow`
+                                              registrar slots
+                                              (rf2-wbtjn).
     5. emit-frame-destroyed-trace!  — emit :frame/destroyed AFTER the
                                       machine cascade.
     6. dissoc-frame!                — remove from the `frames` atom.
@@ -458,6 +465,15 @@
     ;; re-frame.schemas is absent (the artefact is optional per
     ;; rf2-p7va).
     (safe-call-hook! :schemas/on-frame-destroyed! id)
+    ;; Per rf2-wbtjn: drop every flow registered against the destroyed
+    ;; frame plus its cached `last-inputs` rows, and prune the
+    ;; `:flow` registrar slot when the destroyed frame was the last
+    ;; owner. Symmetric with the machines teardown hook above
+    ;; (rf2-vsigt). Without this hook a long-running SSR JVM with
+    ;; per-request frame churn grows the flow registry unboundedly.
+    ;; No-op when re-frame.flows is absent (the artefact is optional
+    ;; per rf2-tfw3).
+    (safe-call-hook! :flows/teardown-on-frame-destroy! id)
     (emit-frame-destroyed-trace! id)
     (dissoc-frame! id)
     (unregister-frame! id)

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -71,6 +71,10 @@
    {:key         :flows/reset-flows!
     :producer-ns 're-frame.flows
     :description "Clear the per-frame flow registry (test isolation)."}
+   {:key         :flows/teardown-on-frame-destroy!
+    :producer-ns 're-frame.flows
+    :design-bead "rf2-wbtjn"
+    :description "Drop the destroyed frame's per-frame flow registry slot, its `last-inputs` rows, and any `:flow` registrar entries whose last owning frame was destroyed. Invoked by `frame/destroy-frame!` symmetric with the machines teardown hook (rf2-vsigt) — without this hook a long-running SSR JVM with per-request frame churn grows the flow registry unboundedly."}
 
    ;; ---- re-frame.schemas (rf2-p7va boundary; rf2-r2uh / rf2-froe / rf2-t0hq) -
    {:key         :schemas/validate-event!

--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -423,15 +423,10 @@
               meta    (get fx-registry id {})
               handler (conformance/realise-fx-handler id body adapter-helpers)]
           (rf/reg-fx id (assoc meta :handler-fn handler) handler))))
-    ;; flow registrations
-    (let [flow-registry (get-in fixture [:fixture/registry :flow] {})
-          flow-bodies   (or (:fixture/flow-bodies fixture) {})]
-      (doseq [[flow-id flow-meta] flow-registry]
-        (when-let [body (get flow-bodies flow-id)]
-          (let [output-fn (conformance/realise-flow-output-fn body)]
-            (rf/reg-flow (-> flow-meta
-                             (assoc :id flow-id)
-                             (assoc :output output-fn)))))))
+    ;; Flow registration is intentionally NOT done here — flows are
+    ;; FRAME-SCOPED (per Spec 013), so the destroy-frame call later in
+    ;; `run-fixture` would wipe them via the rf2-wbtjn teardown hook.
+    ;; `realise-flows!` (called after `reg-frame`) handles them.
     ;; route registrations
     (doseq [[id meta] (get handlers-map :route)]
       (rf/reg-route id meta))
@@ -470,6 +465,25 @@
   [fixture]
   (doseq [[path schema] (get-in fixture [:fixture/registry :app-schema])]
     (rf/reg-app-schema path schema)))
+
+(defn- realise-flows!
+  "Register the fixture's static flows. Called AFTER `reg-frame` — per
+  Spec 013 flows are FRAME-SCOPED, so the destroy-frame teardown hook
+  (rf2-wbtjn) clears any flows registered before the destroy step.
+
+  The static flow shape lives under `:fixture/registry :flow` (with
+  `:inputs` / `:path` / `:doc`) and the body DSL under
+  `:fixture/flow-bodies`. Dynamic flow registration via
+  `:rf.fx/reg-flow` is handled in the conformance DSL interpreter."
+  [fixture]
+  (let [flow-registry (get-in fixture [:fixture/registry :flow] {})
+        flow-bodies   (or (:fixture/flow-bodies fixture) {})]
+    (doseq [[flow-id flow-meta] flow-registry]
+      (when-let [body (get flow-bodies flow-id)]
+        (let [output-fn (conformance/realise-flow-output-fn body)]
+          (rf/reg-flow (-> flow-meta
+                           (assoc :id flow-id)
+                           (assoc :output output-fn))))))))
 
 (defn- collect-traces [fixture-id]
   (let [traces (atom [])]
@@ -803,6 +817,10 @@
                            (rf/reg-frame (:id f) (dissoc f :id)))
                          :else
                          (rf/reg-frame :rf/default frame-config))
+          ;; Flow registration runs AFTER reg-frame: per Spec 013 flows
+          ;; are frame-scoped, and the rf2-wbtjn destroy-frame teardown
+          ;; hook would wipe any flows registered before the destroy.
+          _            (realise-flows! fixture)
           dispatches   (or (:fixture/dispatches fixture) [])]
       (doseq [ev dispatches]
         (cond

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -436,23 +436,10 @@
               meta  (get fx-registry id {})
               handler (conformance/realise-fx-handler id body adapter-helpers)]
           (rf/reg-fx id (assoc meta :handler-fn handler) handler))))
-    ;; flow registrations — per Spec 013, flows are registered on the
-    ;; current frame with positional :output fns. The fixture corpus
-    ;; declares flow shape under :fixture/registry :flow (with :inputs /
-    ;; :path / :doc) and the body DSL under :fixture/flow-bodies
-    ;; (a parallel {flow-id [steps]} map). The harness realises each
-    ;; body into a positional output fn and calls reg-flow.
-    ;;
-    ;; Dynamic flow registration via :rf.fx/reg-flow is handled in the
-    ;; conformance DSL interpreter (see resolve-fx-args in conformance.cljc).
-    (let [flow-registry (get-in fixture [:fixture/registry :flow] {})
-          flow-bodies   (or (:fixture/flow-bodies fixture) {})]
-      (doseq [[flow-id flow-meta] flow-registry]
-        (when-let [body (get flow-bodies flow-id)]
-          (let [output-fn (conformance/realise-flow-output-fn body)]
-            (rf/reg-flow (-> flow-meta
-                             (assoc :id flow-id)
-                             (assoc :output output-fn)))))))
+    ;; Flow registration is intentionally NOT done here — flows are
+    ;; FRAME-SCOPED (per Spec 013), so the destroy-frame call later in
+    ;; `run-fixture` would wipe them via the rf2-wbtjn teardown hook.
+    ;; `realise-flows!` (called after `reg-frame`) handles them.
     ;; route registrations
     (doseq [[id meta] (get handlers-map :route)]
       (rf/reg-route id meta))
@@ -487,6 +474,28 @@
                              (update :guards           #(merge guards %))
                              (update :on-spawn-actions #(merge on-spawn-actions %)))]
               (reg-machine machine-id merged))))))))
+
+(defn- realise-flows!
+  "Per Spec 013 flows are FRAME-SCOPED: their lifecycle, evaluation, and
+  undo / time-travel semantics all belong to one frame. So flow
+  registration must happen AFTER `reg-frame` — otherwise the
+  destroy-frame teardown hook (rf2-wbtjn) clears the flows we just
+  registered when the runner destroys :rf/default to fire the
+  fixture's `:on-create` cascade under its declared config.
+
+  The static flow shape lives under `:fixture/registry :flow` (with
+  `:inputs` / `:path` / `:doc`) and the body DSL under
+  `:fixture/flow-bodies`. Dynamic flow registration via
+  `:rf.fx/reg-flow` is handled in the conformance DSL interpreter."
+  [fixture]
+  (let [flow-registry (get-in fixture [:fixture/registry :flow] {})
+        flow-bodies   (or (:fixture/flow-bodies fixture) {})]
+    (doseq [[flow-id flow-meta] flow-registry]
+      (when-let [body (get flow-bodies flow-id)]
+        (let [output-fn (conformance/realise-flow-output-fn body)]
+          (rf/reg-flow (-> flow-meta
+                           (assoc :id flow-id)
+                           (assoc :output output-fn))))))))
 
 (defn- collect-traces [fixture-id]
   (let [traces (atom [])]
@@ -904,6 +913,10 @@
                            (rf/reg-frame (:id f) (dissoc f :id)))
                          :else
                          (rf/reg-frame :rf/default frame-config))
+          ;; Flow registration runs AFTER reg-frame: per Spec 013 flows
+          ;; are frame-scoped, and the rf2-wbtjn destroy-frame teardown
+          ;; hook would wipe any flows registered before the destroy.
+          _            (realise-flows! fixture)
           dispatches   (or (:fixture/dispatches fixture) [])]
       (doseq [ev dispatches]
         (cond

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -264,3 +264,12 @@
 (late-bind/set-fn! :flows/run-flows!         run-flows!)
 (late-bind/set-fn! :flows/reset-last-inputs! reset-last-inputs!)
 (late-bind/set-fn! :flows/reset-flows!       reset-flows!)
+;; Per rf2-wbtjn — frame-destroy teardown hook (symmetric with the
+;; machines `:machines/teardown-on-frame-destroy!` hook landed by
+;; rf2-vsigt). `frame/destroy-frame!` invokes this hook so per-frame
+;; flow-registry entries, the matching `last-inputs` rows, and any
+;; `:flow` registrar slots whose last owning frame was destroyed all
+;; clear in one step. Without the hook a long-running SSR JVM (per-
+;; request frame churn) leaks flow state indefinitely.
+(late-bind/set-fn! :flows/teardown-on-frame-destroy!
+                   registry/teardown-on-frame-destroy!)

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -304,6 +304,59 @@
                        :frame   frame-id})))
      nil)))
 
+;; ---- frame-destroy teardown ---------------------------------------------
+;;
+;; Per rf2-wbtjn — symmetric with the machines `:teardown-on-frame-destroy!`
+;; hook (rf2-vsigt). On `destroy-frame!`, the flows registered against the
+;; destroyed frame, the per-frame `last-inputs` rows, AND any `:flow`
+;; registrar entries whose last owning frame was the destroyed one MUST
+;; clear — otherwise SSR-style per-request frame churn / pair-tool
+;; time-travel / `make-frame` ephemeral usage leak flow definitions and
+;; cached input vectors indefinitely (audit
+;; `ai/findings/flows-security-audit-2026-05-15.md` F1).
+
+(defn teardown-on-frame-destroy!
+  "Drop every per-frame entry the flows artefact holds against `frame-id`:
+
+   1. Snapshot the flow-ids the destroyed frame owned (needed for the
+      registrar prune in step 4).
+   2. Dissoc `frame-id` from the per-frame flow registry.
+   3. For each flow-id present in `last-inputs`, dissoc the destroyed
+      frame's row. Drop the whole flow-id key when no other frame still
+      holds an entry for it.
+   4. For each flow-id the destroyed frame owned, drop the `:flow`
+      registrar slot when no other frame still registers that id — the
+      `:frame` stamped onto the registrar entry was the destroyed frame.
+
+   Idempotent against a frame the registry never recorded (a frame
+   destroy before any `reg-flow`). Published via the
+   `:flows/teardown-on-frame-destroy!` late-bind hook so
+   `frame/destroy-frame!` reaches it without statically requiring the
+   flows artefact."
+  [frame-id]
+  (when frame-id
+    (let [owned-flow-ids (keys (get @flows frame-id))]
+      (swap! flows dissoc frame-id)
+      (swap! last-inputs
+             (fn [m]
+               (reduce-kv
+                 (fn [acc flow-id by-frame]
+                   (let [by-frame' (dissoc by-frame frame-id)]
+                     (if (empty? by-frame')
+                       acc
+                       (assoc acc flow-id by-frame'))))
+                 {}
+                 m)))
+      ;; Registrar prune: drop the `:flow` slot for any flow-id the
+      ;; destroyed frame owned that no other frame still holds. The
+      ;; surviving-frame check mirrors `clear-flow`'s shape — O(F) over
+      ;; remaining frame count, short-circuits on first hit.
+      (let [remaining @flows]
+        (doseq [flow-id owned-flow-ids]
+          (when (not-any? #(contains? % flow-id) (vals remaining))
+            (registrar/unregister! :flow flow-id))))))
+  nil)
+
 ;; ---- hot-reload invalidation --------------------------------------------
 ;;
 ;; Per Spec 001 §Hot-reload semantics: when a flow re-registers, the

--- a/implementation/flows/test/re_frame/flows_conformance_test.clj
+++ b/implementation/flows/test/re_frame/flows_conformance_test.clj
@@ -226,11 +226,16 @@
                   (substrate-adapter/replace-container! container new-db)))
    :dispatch! (fn [event frame-id] (rf/dispatch event {:frame frame-id}))})
 
-(defn- realise-handlers
-  "Register every handler the fixture declares (events / subs / fxs /
-  flows). The fx slot reuses any `:rf.fx/reg-flow` / `:rf.fx/clear-flow`
-  default handlers wired by `re-frame.flows` at ns-load; the fixture
-  body may supply additional fx ids that the events emit."
+(defn- realise-event-sub-fx-handlers
+  "Register every event / sub / fx handler the fixture declares. Excludes
+  flow registration — flows are FRAME-SCOPED (per Spec 013), so a
+  destroy-frame call between handler-registration and dispatch would
+  clear them (rf2-wbtjn). Caller registers flows AFTER the frame is
+  re-registered via `realise-flows!`.
+
+  The fx slot reuses any `:rf.fx/reg-flow` / `:rf.fx/clear-flow` default
+  handlers wired by `re-frame.flows` at ns-load; the fixture body may
+  supply additional fx ids that the events emit."
   [fixture]
   (let [hmap          (or (:fixture/handlers fixture) {})
         event-meta    (get-in fixture [:fixture/registry :event] {})
@@ -275,21 +280,26 @@
         (let [body    (get fx-bodies id [[:noop]])
               meta    (get fx-registry id {})
               handler (conformance/realise-fx-handler id body helpers)]
-          (rf/reg-fx id (assoc meta :handler-fn handler) handler))))
-    ;; ---- flows ---------------------------------------------------------
-    ;; Per Spec 013 the static flow shapes live under :fixture/registry :flow
-    ;; (with :inputs / :path) and the body DSL under :fixture/flow-bodies.
-    ;; Dynamic flow registration via :rf.fx/reg-flow is handled by the
-    ;; conformance DSL interpreter (resolve-fx-args in conformance.cljc
-    ;; lifts the :body field into an :output fn before the fx fires).
-    (let [flow-registry (get-in fixture [:fixture/registry :flow] {})
-          flow-bodies   (or (:fixture/flow-bodies fixture) {})]
-      (doseq [[flow-id flow-meta] flow-registry]
-        (when-let [body (get flow-bodies flow-id)]
-          (let [output-fn (conformance/realise-flow-output-fn body)]
-            (rf/reg-flow (-> flow-meta
-                             (assoc :id flow-id)
-                             (assoc :output output-fn)))))))))
+          (rf/reg-fx id (assoc meta :handler-fn handler) handler))))))
+
+(defn- realise-flows!
+  "Per Spec 013 the static flow shapes live under :fixture/registry :flow
+  (with :inputs / :path) and the body DSL under :fixture/flow-bodies.
+  Dynamic flow registration via :rf.fx/reg-flow is handled by the
+  conformance DSL interpreter (resolve-fx-args in conformance.cljc
+  lifts the :body field into an :output fn before the fx fires).
+
+  Called AFTER the frame is (re-)registered — see the
+  ordering note in `run-fixture` (rf2-wbtjn)."
+  [fixture]
+  (let [flow-registry (get-in fixture [:fixture/registry :flow] {})
+        flow-bodies   (or (:fixture/flow-bodies fixture) {})]
+    (doseq [[flow-id flow-meta] flow-registry]
+      (when-let [body (get flow-bodies flow-id)]
+        (let [output-fn (conformance/realise-flow-output-fn body)]
+          (rf/reg-flow (-> flow-meta
+                           (assoc :id flow-id)
+                           (assoc :output output-fn))))))))
 
 ;; ---- trace capture -------------------------------------------------------
 
@@ -414,7 +424,6 @@
   (try
     (let [fid          (:fixture/id fixture)
           traces       (collect-traces fid)
-          _            (realise-handlers fixture)
           frame-config (or (:fixture/frame-config fixture) {})
           frames-spec  (:fixture/frames fixture)
           ;; `reset-runtime` already created :rf/default WITHOUT an
@@ -427,11 +436,22 @@
           ;; `:fixture/frames [{:id ...} ...]` and the single `:rf/default`
           ;; seam is bypassed. Single-frame fixtures keep the original
           ;; shape (`:fixture/frame-config` configures `:rf/default`).
+          ;;
+          ;; Order (rf2-wbtjn): event / sub / fx handlers must be
+          ;; registered BEFORE `reg-frame` fires the `:on-create`
+          ;; cascade — `:on-create` dispatches the fixture's seed event,
+          ;; which needs its handler resolved. Flow registration MUST
+          ;; come AFTER `reg-frame`: the destroy-frame teardown hook
+          ;; (the symmetric leak fix this bead lands) clears any flows
+          ;; registered against the frame being destroyed, so
+          ;; registering them before the destroy would wipe them.
           _            (rf/destroy-frame :rf/default)
+          _            (realise-event-sub-fx-handlers fixture)
           _            (if (seq frames-spec)
                          (doseq [f frames-spec]
                            (rf/reg-frame (:id f) (dissoc f :id)))
                          (rf/reg-frame :rf/default frame-config))
+          _            (realise-flows! fixture)
           dispatches   (or (:fixture/dispatches fixture) [])]
       ;; Dispatches may be a bare event vector (single-frame default) or
       ;; an envelope map `{:event [...] :frame <id> ...}` (multi-frame,

--- a/implementation/flows/test/re_frame/flows_destroy_frame_teardown_test.clj
+++ b/implementation/flows/test/re_frame/flows_destroy_frame_teardown_test.clj
@@ -1,0 +1,198 @@
+(ns re-frame.flows-destroy-frame-teardown-test
+  "Per rf2-wbtjn — `destroy-frame!` must clean up the per-frame flow
+  state (registry slot, `last-inputs` rows, owning-frame registrar
+  entries). Symmetric with the machines `:machines/teardown-on-frame-destroy!`
+  hook (rf2-vsigt).
+
+  Pre-rf2-wbtjn the implementation tore down sub-cache, machine
+  cascade, SSR side-channels, schemas and epoch state on
+  `destroy-frame!` but left flows untouched — `flows[frame-id]`,
+  `last-inputs[flow-id][frame-id]` and any `:flow` registrar slots
+  whose last owning frame was destroyed all retained references.
+  Memory leak class: long-running SSR JVM (per-request frame churn),
+  pair-tool time-travel, `make-frame` ephemeral usage.
+
+  These JVM-side tests run on the plain-atom substrate against the
+  late-bound `:flows/teardown-on-frame-destroy!` hook the flows
+  artefact publishes for `frame/destroy-frame!`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.flows :as flows]
+            ;; Loading `re-frame.flows` registers the late-bind hook
+            ;; (`:flows/teardown-on-frame-destroy!`) the tests exercise —
+            ;; keep the require even when the test ns doesn't reach
+            ;; `flows/...` directly through a public fn.
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+;; ---- per-test reset ------------------------------------------------------
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! flows/last-inputs {})
+  (reset! schemas/schemas-by-frame {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- hook publication ----------------------------------------------------
+
+(deftest flows-publishes-teardown-hook
+  (testing ":flows/teardown-on-frame-destroy! is published when re-frame.flows is loaded"
+    (is (fn? (late-bind/get-fn :flows/teardown-on-frame-destroy!))
+        "the hook is callable after the flows artefact ns-loads")))
+
+;; ---- per-frame registry slot cleared on destroy --------------------------
+
+(deftest destroy-frame-clears-per-frame-flow-registry-slot
+  (testing "destroying a frame drops its slot from re-frame.flows.registry/flows"
+    (rf/reg-frame :fc/scratch {:doc "scratch frame for destroy teardown test"})
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* (or w 0) (or h 0)))
+                  :path   [:rect :area]}
+                 {:frame :fc/scratch})
+    (is (contains? @flows/flows :fc/scratch)
+        "precondition: the flow registered under the scratch frame's slot")
+    (frame/destroy-frame! :fc/scratch)
+    (is (not (contains? @flows/flows :fc/scratch))
+        "post-destroy: the destroyed frame's slot is gone")))
+
+;; ---- last-inputs rows cleared on destroy --------------------------------
+
+(deftest destroy-frame-clears-last-inputs-rows-for-destroyed-frame
+  (testing "destroying a frame removes the destroyed-frame entry from each flow's last-inputs row"
+    (rf/reg-frame :fc/scratch {:doc "scratch frame for last-inputs teardown test"})
+    (rf/reg-event-db :fc/seed (fn [_ _] {:w 3 :h 4}))
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* w h))
+                  :path   [:rect :area]}
+                 {:frame :fc/scratch})
+    ;; Drive a drain on the scratch frame so the dirty-check populates
+    ;; `last-inputs[:area][:fc/scratch]`.
+    (rf/dispatch-sync [:fc/seed] {:frame :fc/scratch})
+    (is (= [3 4]
+           (get-in @flows/last-inputs [:area :fc/scratch]))
+        "precondition: last-inputs recorded the scratch frame's inputs")
+    (frame/destroy-frame! :fc/scratch)
+    (is (not (contains? (get @flows/last-inputs :area) :fc/scratch))
+        "post-destroy: the destroyed frame's last-inputs entry is gone")
+    (is (not (contains? @flows/last-inputs :area))
+        "and the whole flow-id row is dropped (no other frame still held an entry)")))
+
+;; ---- last-inputs rows from sibling frames are preserved -----------------
+
+(deftest destroy-frame-preserves-sibling-frames-last-inputs
+  (testing "destroying frame A leaves frame B's last-inputs row for the same flow id intact"
+    (rf/reg-frame :fc/a {:doc "frame A"})
+    (rf/reg-frame :fc/b {:doc "frame B"})
+    (rf/reg-event-db :fc/seed-a (fn [_ _] {:w 2 :h 5}))
+    (rf/reg-event-db :fc/seed-b (fn [_ _] {:w 7 :h 9}))
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* w h))
+                  :path   [:rect :area]}
+                 {:frame :fc/a})
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* w h))
+                  :path   [:rect :area]}
+                 {:frame :fc/b})
+    (rf/dispatch-sync [:fc/seed-a] {:frame :fc/a})
+    (rf/dispatch-sync [:fc/seed-b] {:frame :fc/b})
+    (is (= [2 5] (get-in @flows/last-inputs [:area :fc/a])))
+    (is (= [7 9] (get-in @flows/last-inputs [:area :fc/b])))
+    (frame/destroy-frame! :fc/a)
+    (is (not (contains? (get @flows/last-inputs :area) :fc/a))
+        "destroyed-frame A's last-inputs row is gone")
+    (is (= [7 9] (get-in @flows/last-inputs [:area :fc/b]))
+        "sibling frame B's last-inputs row is preserved")))
+
+;; ---- registrar :flow slot pruned when destroyed frame was last owner ----
+
+(deftest destroy-frame-prunes-registrar-slot-when-last-owner
+  (testing "destroying the only frame that owned a flow id drops the :flow registrar slot"
+    (rf/reg-frame :fc/scratch {:doc "scratch frame"})
+    (rf/reg-flow {:id     :sole-area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* (or w 0) (or h 0)))
+                  :path   [:rect :area]}
+                 {:frame :fc/scratch})
+    (is (some? (registrar/lookup :flow :sole-area))
+        "precondition: registrar carries the flow slot")
+    (frame/destroy-frame! :fc/scratch)
+    (is (nil? (registrar/lookup :flow :sole-area))
+        "post-destroy: registrar slot is gone — no leaked entry")))
+
+;; ---- registrar :flow slot preserved when sibling frame still owns it ----
+
+(deftest destroy-frame-preserves-registrar-slot-when-sibling-still-owns
+  (testing "destroying frame A leaves :flow registrar slot intact if frame B still registers the id"
+    (rf/reg-frame :fc/a {:doc "frame A"})
+    (rf/reg-frame :fc/b {:doc "frame B"})
+    (rf/reg-flow {:id     :shared
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* (or w 0) (or h 0)))
+                  :path   [:rect :area]}
+                 {:frame :fc/a})
+    (rf/reg-flow {:id     :shared
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* (or w 0) (or h 0)))
+                  :path   [:rect :area]}
+                 {:frame :fc/b})
+    (frame/destroy-frame! :fc/a)
+    (is (some? (registrar/lookup :flow :shared))
+        "registrar slot survives because frame B still registers :shared")))
+
+;; ---- SSR-style per-request frame churn stays bounded --------------------
+
+(deftest ssr-style-frame-churn-stays-bounded
+  (testing "creating + destroying N ephemeral frames each with a flow leaves the registry empty"
+    (let [N 20]
+      (dotimes [i N]
+        (let [frame-id (keyword "fc" (str "ephemeral-" i))]
+          (rf/reg-frame frame-id {:doc (str "ephemeral frame " i)})
+          (rf/reg-flow {:id     :churn
+                        :inputs [[:n]]
+                        :output (fn [n] (or n 0))
+                        :path   [:result]}
+                       {:frame frame-id})
+          (rf/reg-event-db :fc/seed-churn (fn [_ [_ v]] {:n v}))
+          (rf/dispatch-sync [:fc/seed-churn i] {:frame frame-id})
+          (frame/destroy-frame! frame-id)))
+      (is (empty? @flows/flows)
+          "per-frame flow registry is empty after N destroy cycles")
+      (is (empty? @flows/last-inputs)
+          "last-inputs is empty after N destroy cycles")
+      (is (nil? (registrar/lookup :flow :churn))
+          "registrar :flow slot is gone after the last owning frame was destroyed"))))
+
+;; ---- frame-id reuse: new reg-frame starts clean -------------------------
+
+(deftest reg-frame-after-destroy-starts-clean
+  (testing "registering a frame under a reused id after destroy starts with no leftover flow state"
+    (rf/reg-frame :fc/scratch {:doc "first incarnation"})
+    (rf/reg-event-db :fc/seed (fn [_ _] {:w 3 :h 4}))
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* (or w 0) (or h 0)))
+                  :path   [:rect :area]}
+                 {:frame :fc/scratch})
+    (rf/dispatch-sync [:fc/seed] {:frame :fc/scratch})
+    (frame/destroy-frame! :fc/scratch)
+    (rf/reg-frame :fc/scratch {:doc "second incarnation"})
+    (is (not (contains? @flows/flows :fc/scratch))
+        "the new frame has no inherited flow-registry slot")
+    (is (not (contains? (get @flows/last-inputs :area) :fc/scratch))
+        "the new frame has no inherited last-inputs row")
+    (is (nil? (registrar/lookup :flow :area))
+        "the new frame has no inherited :flow registrar slot")))


### PR DESCRIPTION
## Summary

- `destroy-frame!` was missing a flows teardown hook — `flows[frame-id]`, `last-inputs[flow-id][frame-id]` and dead `:flow` registrar slots all leaked indefinitely. Long-running SSR JVMs (per-request frame churn), pair-tool time-travel, and `make-frame` ephemeral usage all retained references. Found by the rf2-itcy9 flows-slice security audit ([`ai/findings/flows-security-audit-2026-05-15.md`](../blob/main/ai/findings/flows-security-audit-2026-05-15.md) F1).
- Mirrors the rf2-vsigt machines destroy-cascade pattern (PR #1089): new `:flows/teardown-on-frame-destroy!` late-bind hook published by the flows artefact, called by core's `destroy-frame!` alongside the schemas / machines / SSR / epoch teardown hooks. No-op when the flows artefact is absent.
- Pre-alpha posture: optimised for elegance — clean late-bind hook shape; surface limited to `implementation/core/` (call site) + `implementation/flows/` (impl) + conformance-runner ordering tweaks.

## Implementation

- `implementation/flows/src/re_frame/flows/registry.cljc` — `teardown-on-frame-destroy!`: drops the per-frame registry slot, prunes destroyed-frame entries from `last-inputs` (dropping fully-empty rows), unregisters the `:flow` registrar slot when the destroyed frame was the last owner.
- `implementation/flows/src/re_frame/flows.cljc` — publishes via `(late-bind/set-fn! :flows/teardown-on-frame-destroy! ...)`.
- `implementation/core/src/re_frame/frame.cljc` — calls the hook from `destroy-frame!` alongside the other artefact teardown hooks; docstring step list extended.
- `implementation/core/src/re_frame/late_bind/directory.cljc` — directory entry for the drift gate.

## Conformance runner fix (latent ordering bug)

The conformance runners (`core/test/.../conformance_test.clj`, `core/test/.../conformance_corpus_cljs_test.cljs`, `flows/test/.../flows_conformance_test.clj`) registered flows BEFORE the runner's `(rf/destroy-frame :rf/default)` call. This pattern previously survived because flows leaked past destroy. The fix splits flow registration out (`realise-flows!`) and calls it AFTER `reg-frame` — so the fixture's `:on-create` cascade still resolves seeded event handlers, and flows survive into the dispatches.

## Test plan

- [x] New `flows_destroy_frame_teardown_test.clj` — 8 deftests / 19 assertions covering hook publication, per-frame registry slot cleared, last-inputs row dropped, sibling-frame state preserved, registrar slot pruned vs preserved, SSR-style 20-cycle frame churn stays bounded, frame-id reuse starts clean.
- [x] `npm run test:cljs` — 2014 tests / 5695 assertions, 0 failures.
- [x] `npm run test:bundle-isolation` — `=== PASS ===`.
- [x] JVM core (`clojure -M:test` from `implementation/core/`) — 534 tests / 2727 assertions, 0 failures.
- [x] JVM flows (`clojure -M:test` from `implementation/flows/`) — 55 tests / 200 assertions, 0 failures.

Closes rf2-wbtjn.