### PR TITLE
fix(pair2-mcp-sec): resource controls on streaming surfaces (rf2-3ijbl, rf2-7adwg MEDIUM follow-on)

### DIFF
--- a/tools/pair2-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/pair2-mcp/spec/003-Tool-Catalogue.md
@@ -247,6 +247,86 @@ causa-mcp's `--allow-eval` (rf2-zyoj2 — same gate as pair2-mcp's
 `eval-cljs`). The same pattern across MCP servers gives operators one
 posture vocabulary.
 
+## Universal: server resource controls (streaming surfaces)
+
+Four operator-configurable integer caps bound the server's exposure
+to a runaway or hostile client of the streaming `subscribe` surface
+(rf2-3ijbl, follow-on to the rf2-7adwg MEDIUM finding). Each cap has
+a documented default, an override CLI flag (`--<name>=N`), and an
+override env var (`<ENV_NAME>=N`). CLI flags win over env vars on
+conflict. Values must be positive integers; non-positive or
+unparseable values fall back to the default silently.
+
+| Cap                          | Default | CLI flag                          | Env var                                          |
+|------------------------------|---------|-----------------------------------|--------------------------------------------------|
+| max-concurrent-streams       | 10      | `--max-concurrent-streams=N`      | `RE_FRAME_PAIR2_MCP_MAX_STREAMS`                 |
+| max-events-per-sec           | 100     | `--max-events-per-sec=N`          | `RE_FRAME_PAIR2_MCP_MAX_EVENTS_PER_SEC`          |
+| abuse-overflow-threshold     | 50      | `--abuse-overflow-threshold=N`    | `RE_FRAME_PAIR2_MCP_ABUSE_OVERFLOW_THRESHOLD`    |
+| abuse-window-ms              | 10000   | `--abuse-window-ms=N`             | `RE_FRAME_PAIR2_MCP_ABUSE_WINDOW_MS`             |
+
+### Concurrent-stream cap
+
+`subscribe` calls allocate a runtime-side queue + a server-side poll
+loop. The cap bounds the number of simultaneously-open streams per
+MCP session (= per server process). When the cap is reached, the
+next `subscribe` call rejects WITHOUT touching the nREPL socket:
+
+```clojure
+{:ok?    false
+ :reason :rf.error/concurrent-stream-limit
+ :limit  10
+ :active 10
+ :hint   "max-concurrent-streams cap reached. Close an existing
+          subscription (via the `unsubscribe` tool or by cancelling
+          its `tools/call`) before opening another, or raise the
+          cap with --max-concurrent-streams=N at server launch."}
+```
+
+The slot is released on every stream-termination path (client
+cancel, `unsubscribe`, `:max-events` / `:max-ms` / `:sub-gone` /
+`:rf.error/stream-abuse-detected`, probe / signal / subscribe-eval
+failure).
+
+### Per-session event rate-limit
+
+A session-wide token bucket caps the rate of progress-notification
+ticks emitted across all open streams. Refill rate = bucket capacity
+= `max-events-per-sec`. Excess ticks are silently dropped (the
+runtime-side queue still holds the events; subsequent ticks drain
+them when tokens refill). The `tools/call` final summary surfaces
+the cumulative count as `:rate-dropped` (omitted when zero).
+
+Token-bucket over leaky-bucket: streaming trace events are bursty
+by nature (one event triggers a cascade of fx + sub-runs + renders
+in one drain). Token-bucket allows brief bursts up to the cap while
+still bounding the long-run rate.
+
+### Disconnect-on-abuse heuristic
+
+Whenever a drain reports `:overflow-reason` non-nil (the runtime's
+per-sub queue evicted), the server records the overflow on a
+session-wide rolling window of length `abuse-window-ms`. When the
+count over the window exceeds `abuse-overflow-threshold`, the stream
+terminates with `:reason :rf.error/stream-abuse-detected` and a
+stderr log line. The default (50 overflows in 10s ≈ sustained
+5/sec eviction) indicates the consumer can't keep up; continuing
+the stream burns CPU + wire bandwidth.
+
+The abuse window is session-wide (not per-stream): a hostile client
+that opens one abusive stream, hits the threshold, then opens
+another starts with a non-empty window. Resetting requires either
+ending the session (closing the MCP-server process) or letting the
+window expire naturally.
+
+### Symmetric with sibling DoS bounds
+
+Mirrors story-mcp's rf2-g9fje DoS-bounds shape (JSON frame size,
+timeout caps, cancellation) — same posture vocabulary across MCP
+servers: operator-configurable bounds with documented defaults,
+structured rejection envelopes, indicator-field counters on the
+result. The `:rf.error/*` keyword vocabulary stays consistent
+across the cross-MCP error surface.
+
 ## eval-cljs
 
 Evaluate a CLJS form in the connected browser runtime via
@@ -771,15 +851,20 @@ On termination, the `tools/call` result is
  :dropped-events <integer>   ; total events evicted from the runtime queue
  :dropped-bytes  <integer>   ; total bytes evicted
  :overflow-reason :max-buffered-events | :max-buffered-bytes | (key absent)
+ :rate-dropped   <integer>   ; ticks silenced by the per-session rate cap (omitted when zero)
  :ticks     <integer>
- :reason    :aborted | :sub-gone | :max-ms-reached | :max-events-reached}
+ :reason    :aborted | :sub-gone | :max-ms-reached | :max-events-reached |
+            :rf.error/stream-abuse-detected}
 ```
 
 `:reason` is `:aborted` when the client cancelled the call,
 `:sub-gone` when the runtime's subscription disappeared (typically a
 full page reload, or an `unsubscribe` op fired separately),
 `:max-ms-reached` / `:max-events-reached` when the caller's
-upper-bounds fire.
+upper-bounds fire, or `:rf.error/stream-abuse-detected` when the
+session's rolling-window overflow count exceeded
+`abuse-overflow-threshold` (rf2-3ijbl — see [§Universal: server
+resource controls](#universal-server-resource-controls-streaming-surfaces)).
 
 ### Termination paths
 
@@ -792,6 +877,12 @@ upper-bounds fire.
    The next drain returns `:gone? true`; the poll loop resolves
    with `:reason :sub-gone`.
 3. **Cap reached** — `max-ms` or `max-events` is exceeded.
+4. **Abuse detected (rf2-3ijbl)** — sustained queue overflow exceeded
+   `abuse-overflow-threshold` over `abuse-window-ms`. The stream
+   terminates with `:reason :rf.error/stream-abuse-detected` and a
+   stderr log line; the operator can raise the threshold via
+   `--abuse-overflow-threshold=N` if the workload legitimately
+   produces high overflow rates.
 
 ### Failure modes
 
@@ -799,6 +890,11 @@ upper-bounds fire.
   four. Surfaced as `isError: true`.
 - `:reason :runtime-not-preloaded` if the preload hasn't run.
 - `:reason :subscribe-failed` on any other failure during subscribe.
+- `:reason :rf.error/concurrent-stream-limit` if the session already
+  has `max-concurrent-streams` open subscriptions. Surfaced as
+  `isError: true` WITHOUT touching the nREPL socket. The error
+  envelope carries `:limit` / `:active` / `:hint` for the operator
+  to act on. See [§Universal: server resource controls](#universal-server-resource-controls-streaming-surfaces).
 
 ### Diagnostics
 

--- a/tools/pair2-mcp/spec/API.md
+++ b/tools/pair2-mcp/spec/API.md
@@ -71,6 +71,10 @@ per the [MCP transport spec](https://modelcontextprotocol.io/specification/2025-
 |---|---|---|
 | `SHADOW_CLJS_BUILD_ID` | `"app"` | Default build id passed to `cljs-eval`. Overridable per-op via the `build` argument. |
 | `SHADOW_CLJS_NREPL_PORT` | (unset) | Explicit nREPL port; takes precedence over port-file discovery. |
+| `RE_FRAME_PAIR2_MCP_MAX_STREAMS` | `10` | Max concurrent open streaming subscriptions per session (rf2-3ijbl). |
+| `RE_FRAME_PAIR2_MCP_MAX_EVENTS_PER_SEC` | `100` | Per-session rate-limit on progress-notification ticks (rf2-3ijbl). |
+| `RE_FRAME_PAIR2_MCP_ABUSE_OVERFLOW_THRESHOLD` | `50` | Overflow events over the rolling window beyond which a stream is terminated for abuse (rf2-3ijbl). |
+| `RE_FRAME_PAIR2_MCP_ABUSE_WINDOW_MS` | `10000` | Rolling-window length for abuse detection, in milliseconds (rf2-3ijbl). |
 
 ### Launch flags
 
@@ -78,22 +82,30 @@ per the [MCP transport spec](https://modelcontextprotocol.io/specification/2025-
 |---|---|---|
 | `--allow-eval`      | OFF | Enable the `eval-cljs` tool (rf2-cxx5s). Without the flag, `eval-cljs` calls return `{:ok? false :reason :rf.error/eval-cljs-disabled}` without touching the nREPL socket. |
 | `--allow-raw-state` | OFF | Honour caller-supplied `:include-sensitive? true` and `:elision false` on direct-read tools (`snapshot`, `get-path`, `subscribe`, `trace-window`, `watch-epochs`), and ship verbatim payloads through the preload's `app-db-reset!` `tap>` emission. Without the flag, sensitive slots redact and large slots elide before any payload crosses the wire — and the `tap>` payloads route through `re-frame.core/elide-wire-value` before any registered tap consumer sees them (rf2-c2dtu). |
+| `--max-concurrent-streams=N` | `10` | Resource control: cap concurrent open streaming subscriptions per session (rf2-3ijbl). CLI value wins over the matching env var. |
+| `--max-events-per-sec=N` | `100` | Resource control: token-bucket rate-limit on progress-notification ticks emitted across all open streams (rf2-3ijbl). Excess ticks tally as `:rate-dropped` on the final summary. |
+| `--abuse-overflow-threshold=N` | `50` | Resource control: rolling-window overflow count beyond which the offending stream terminates with `:reason :rf.error/stream-abuse-detected` (rf2-3ijbl). |
+| `--abuse-window-ms=N` | `10000` | Resource control: abuse-detection window length in milliseconds (rf2-3ijbl). |
 
-Both flags pass after the binary name:
+Boolean flags + integer caps pass after the binary name:
 
 ```json
 {
   "mcpServers": {
     "re-frame-pair2": {
       "command": "re-frame-pair2-mcp",
-      "args": ["--allow-eval", "--allow-raw-state"]
+      "args": ["--allow-eval", "--allow-raw-state",
+               "--max-concurrent-streams=20",
+               "--max-events-per-sec=200"]
     }
   }
 }
 ```
 
 The normative contract for both gates lives in
-[`003-Tool-Catalogue.md` §Universal: server launch flags](./003-Tool-Catalogue.md#universal-server-launch-flags).
+[`003-Tool-Catalogue.md` §Universal: server launch flags](./003-Tool-Catalogue.md#universal-server-launch-flags);
+the resource-control caps live in
+[`003-Tool-Catalogue.md` §Universal: server resource controls](./003-Tool-Catalogue.md#universal-server-resource-controls-streaming-surfaces).
 
 ### nREPL port discovery
 

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/server.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/server.cljs
@@ -33,6 +33,7 @@
             [re-frame-pair2-mcp.tools :as tools]
             [re-frame-pair2-mcp.tools.eval-cljs :as eval-cljs]
             [re-frame-pair2-mcp.tools.raw-state :as raw-state]
+            [re-frame-pair2-mcp.tools.resource-controls :as resource]
             ["@modelcontextprotocol/sdk/server/index.js" :as mcp-server]
             ["@modelcontextprotocol/sdk/server/stdio.js" :as mcp-stdio]
             ["@modelcontextprotocol/sdk/types.js" :as mcp-types]))
@@ -166,8 +167,24 @@
   ;; reading multi-MCP logs see one vocabulary.
   (log! "Raw-state access:" (if allow-raw-state? "allowed (--allow-raw-state)" "gated (default; pass --allow-raw-state to opt in)")))
 
+(defn- apply-resource-controls!
+  "Read resource-control config from env + CLI flags and push it into
+  the resource-controls atoms (rf2-3ijbl). Logs the effective values
+  so operators can confirm at startup which caps are in force."
+  [argv]
+  (let [env-cfg  (resource/read-resource-env)
+        flag-cfg (resource/parse-resource-flags argv)
+        merged   (resource/apply-resource-config! env-cfg flag-cfg)]
+    (log! (str "Resource controls:"
+               " max-concurrent-streams="    (:max-concurrent-streams merged)
+               " max-events-per-sec="        (:max-events-per-sec merged)
+               " abuse-overflow-threshold="  (:abuse-overflow-threshold merged)
+               " abuse-window-ms="           (:abuse-window-ms merged)))))
+
 (defn main [& args]
-  (apply-launch-flags! (parse-launch-flags (vec args)))
+  (let [argv (vec args)]
+    (apply-launch-flags! (parse-launch-flags argv))
+    (apply-resource-controls! argv))
   (try
     (let [conn   (new-conn)
           server (boot! conn)]

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/resource_controls.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/resource_controls.cljs
@@ -1,0 +1,471 @@
+(ns re-frame-pair2-mcp.tools.resource-controls
+  "Session-wide resource controls for streaming surfaces (rf2-3ijbl).
+
+  An MCP session is one stdio-attached server process — see
+  `cache.cljs` (rf2-3rt1f) for the equivalence. Per-sub queue caps and
+  drop-oldest-on-overflow already live runtime-side (rf2-ho4ve), but a
+  buggy or hostile client can still:
+
+    1. Open many concurrent `subscribe` calls — each allocates a fresh
+       runtime-side queue + poll loop, multiplying memory pressure.
+    2. Tighten `poll-ms` to fire ticks faster than the agent host or
+       runtime can keep up — the queue evicts hard but the wire still
+       fills.
+    3. Trip overflow repeatedly — a signal that the consumer is mis-
+       configured or hostile; should terminate the stream rather than
+       silently churn under pressure.
+
+  This namespace owns three independent gates. All three are
+  operator-configurable via CLI flags AND env vars; the parsed defaults
+  come from `parse-resource-flags` / `read-resource-env`.
+
+  ## Concurrent-stream cap
+
+  `acquire-stream!` increments the active-stream counter when room
+  remains under `max-concurrent-streams` (default 10); returns a
+  structured `:rf.error/concurrent-stream-limit` rejection otherwise.
+  `release-stream!` decrements when the stream terminates (any reason).
+  The counter is a single atom — atomic compare-and-set via `swap-vals!`
+  avoids the TOCTOU window between read and increment.
+
+  ## Per-session event rate-limit (token bucket)
+
+  `check-rate!` is called once per delivered event. The session-wide
+  token bucket refills at `max-events-per-sec` (default 100) and caps
+  at the same value. Excess events are rate-dropped — `check-rate!`
+  returns `false` and the tick is silently skipped (counted via
+  `rate-dropped-count` for the final summary).
+
+  Token-bucket vs leaky-bucket: token-bucket allows brief bursts up to
+  the cap, leaky-bucket smooths uniformly. Streaming trace events are
+  bursty by nature (an event triggers a cascade of fx + sub-runs +
+  renders in one drain) — token-bucket matches the workload.
+
+  ## Disconnect-on-abuse heuristic
+
+  `record-overflow!` is called whenever a drain reports `:ov-reason`
+  non-nil (the runtime's per-sub queue evicted). The session tracks
+  overflow events over a rolling window (`abuse-window-ms`, default
+  10000 = 10s). When the count exceeds `abuse-overflow-threshold`
+  (default 50) in that window, `record-overflow!` returns
+  `:abuse-detected` — the caller (the streaming-loop) terminates the
+  stream with `:reason :rf.error/stream-abuse-detected` and logs to
+  stderr.
+
+  The window is a vector of timestamps; on each call we drop stamps
+  older than `abuse-window-ms` and append the new one. O(n) per call
+  but n is bounded by the threshold + small margin (the window prunes
+  as it grows) — cheap enough for the 100/s rate-limit ceiling.
+
+  ## Why one namespace, not three
+
+  All three gates share:
+    - the same session-scope (one process, one stdio session).
+    - the same configuration surface (CLI flags + env vars).
+    - the same test-fixture pattern (reset between tests).
+
+  Splitting them three ways would force three parallel
+  `parse-*-flags` / `read-*-env` / `set-*` triplets without saving any
+  per-call cycles. One namespace, three independent atoms, one
+  configuration entry point. Mirrors story-mcp's `config.cljc` shape
+  (single ns owning all the operator-configurable gates).
+
+  ## Symmetry with sibling gates
+
+  Pre-existing pair2-mcp gates:
+    - `eval-cljs/allow-eval?` (`--allow-eval`) — rf2-cxx5s
+    - `raw-state/allow-raw-state?` (`--allow-raw-state`) — rf2-c2dtu
+
+  This namespace adds:
+    - `max-concurrent-streams` (`--max-concurrent-streams` /
+      `RE_FRAME_PAIR2_MCP_MAX_STREAMS`)
+    - `max-events-per-sec` (`--max-events-per-sec` /
+      `RE_FRAME_PAIR2_MCP_MAX_EVENTS_PER_SEC`)
+    - `abuse-overflow-threshold` (`--abuse-overflow-threshold` /
+      `RE_FRAME_PAIR2_MCP_ABUSE_OVERFLOW_THRESHOLD`)
+    - `abuse-window-ms` (`--abuse-window-ms` /
+      `RE_FRAME_PAIR2_MCP_ABUSE_WINDOW_MS`)
+
+  The boolean flags above are opt-in (default OFF, operator must pass
+  the flag); these integer caps are opt-OUT (default values active,
+  operator overrides if the default is wrong for their workload)."
+  (:require [applied-science.js-interop :as j]
+            [clojure.string :as str]))
+
+;; ---------------------------------------------------------------------------
+;; Default values — single source of truth, surface in three places:
+;;   1. The atoms below (initial values).
+;;   2. The CLI / env help text printed at server boot.
+;;   3. The spec docs (003-Tool-Catalogue.md §Universal: server resource
+;;      controls).
+;;
+;; Defaults chosen for a typical agent workflow:
+;;
+;; - 10 streams: an agent rarely needs more than a handful open at once
+;;   (one per topic + spare); 10 is generous for normal use and tight
+;;   enough to cap pathological loops.
+;; - 100 events/sec: at ~5 KB/event (typical epoch record post-
+;;   elision), that's ~500 KB/sec — well under the bandwidth of a
+;;   local nREPL socket but enough headroom for legitimate bursty
+;;   workloads. The runtime poll cadence is 100ms = 10 polls/sec; at
+;;   ~10 events per drain on average a healthy stream sits well under
+;;   the cap.
+;; - 50 overflows in 10s: ~5/sec of sustained eviction. A momentary
+;;   overflow (one heavy event landed on a near-full queue) is normal;
+;;   sustained eviction at >5/sec means the consumer can't keep up
+;;   and the stream should terminate rather than churn forever.
+;; ---------------------------------------------------------------------------
+
+(def ^:private defaults
+  "The four integer caps — single source of truth. Override via CLI
+  flags (`--<flag-name>=<n>`) or env vars (`<ENV_NAME>=<n>`). Names
+  match the `parse-resource-flags` / `read-resource-env` keys."
+  {:max-concurrent-streams   10
+   :max-events-per-sec       100
+   :abuse-overflow-threshold 50
+   :abuse-window-ms          10000})
+
+(defn default-value
+  "Return the documented default for a resource-control gate.
+
+  Exposed for the spec / help text — the operator-facing defaults
+  surface in `003-Tool-Catalogue.md` and (future) `server.cljs/main`
+  startup banner. Test seam: pins each default against an explicit
+  expectation, so a future tuning surfaces as a failing test rather
+  than a silent doc drift."
+  [k]
+  (get defaults k))
+
+;; ---------------------------------------------------------------------------
+;; Configuration atoms — settable via `apply-resource-config!`.
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private config
+  (atom defaults))
+
+(defn current-config
+  "Read the current resource-control configuration. Exposed for tests
+  + the server-side startup banner."
+  []
+  @config)
+
+(defn set-config!
+  "Replace the resource-control configuration map. Unknown keys are
+  ignored; missing keys fall back to defaults. Coerces values via
+  `parse-positive-int` so string-form configuration (env vars, JSON
+  args) flows through one parser. Returns the new merged config."
+  [m]
+  (let [coerced (into {} (for [[k v] m
+                               :when (contains? defaults k)
+                               :let  [n (parse-long (str v))]
+                               :when (and n (pos? n))]
+                           [k n]))
+        merged  (merge defaults coerced)]
+    (reset! config merged)
+    merged))
+
+;; ---------------------------------------------------------------------------
+;; Concurrent-stream cap.
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private active-streams
+  ;; Count of currently-acquired streaming subscriptions. Atomic
+  ;; compare-and-set via `swap-vals!` in `acquire-stream!` so two
+  ;; concurrent `subscribe` calls can't both squeak past the cap at
+  ;; the boundary tick.
+  (atom 0))
+
+(defn active-stream-count
+  "Read the current active-stream count. Exposed for tests +
+  subscription-info diagnostics."
+  []
+  @active-streams)
+
+(defn acquire-stream!
+  "Atomically reserve a slot for a new stream. Returns `{:ok? true}`
+  when capacity remains; otherwise `{:ok? false :reason
+  :rf.error/concurrent-stream-limit :limit N :active N}`.
+
+  The check-and-increment is one `swap-vals!` so two concurrent
+  `subscribe` calls can't both observe `< limit` and both increment
+  past it. CLJS's single-threaded JS runtime makes this academic for
+  the current callsites — but the contract is right and a future
+  parallel-pump runtime won't break it.
+
+  Caller (subscribe-tool) MUST call `release-stream!` on every exit
+  path (normal termination, error, abort) so the counter doesn't
+  leak — pair with try/finally semantics at the promise boundary."
+  []
+  (let [limit (:max-concurrent-streams @config)
+        [old new] (swap-vals! active-streams
+                              (fn [n] (if (< n limit) (inc n) n)))]
+    (if (= old new)
+      {:ok?    false
+       :reason :rf.error/concurrent-stream-limit
+       :limit  limit
+       :active old
+       :hint   (str "max-concurrent-streams cap reached. "
+                    "Close an existing subscription (via the `unsubscribe` "
+                    "tool or by cancelling its `tools/call`) before opening "
+                    "another, or raise the cap with "
+                    "--max-concurrent-streams=N at server launch.")}
+      {:ok? true :active new :limit limit})))
+
+(defn release-stream!
+  "Decrement the active-stream count. Idempotent at the floor (clamps
+  at zero) — a double-release on a buggy termination path doesn't
+  drive the counter negative."
+  []
+  (swap! active-streams #(max 0 (dec %)))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Per-session event rate-limit (token bucket).
+;; ---------------------------------------------------------------------------
+;;
+;; One bucket for the whole session — refill rate = bucket cap =
+;; `max-events-per-sec`. The bucket holds fractional tokens; we refill
+;; lazily on each `check-rate!` based on elapsed milliseconds since the
+;; last refill.
+
+(defonce ^:private rate-bucket
+  ;; `{:tokens <float> :last-refill-ms <epoch-ms>}`. Initialised on
+  ;; first `check-rate!` call (lazy: we don't know `max-events-per-sec`
+  ;; until launch flags / env are applied).
+  (atom nil))
+
+(defn- now-ms []
+  (.now js/Date))
+
+(defn- refill-bucket
+  "Pure helper — refill the bucket based on elapsed-ms since `last`.
+  Caps at the configured rate (bucket size = refill rate)."
+  [{:keys [tokens last-refill-ms]} max-per-sec now]
+  (let [elapsed-ms  (max 0 (- now last-refill-ms))
+        added       (* (/ elapsed-ms 1000.0) max-per-sec)
+        new-tokens  (min (double max-per-sec) (+ tokens added))]
+    {:tokens         new-tokens
+     :last-refill-ms now}))
+
+(defn check-rate!
+  "Try to consume one token from the rate-limit bucket. Returns `true`
+  if a token was available (the caller may proceed to emit the event);
+  `false` if the bucket is empty (the caller should drop the event
+  silently and tally it as rate-dropped on the stream's final summary).
+
+  Lazy initialisation: the bucket is filled to its cap on first call
+  so a fresh session doesn't pay a ramp-up penalty. Reset between
+  tests via `reset-rate-bucket!`.
+
+  ## Return semantics
+
+  The atom's `:consumed?` slot records whether THIS swap consumed a
+  token. A read of `(:tokens new)` alone can't discriminate the two
+  failure-adjacent shapes: after a successful consume the bucket may
+  sit at 0.0; after a denied consume on a refilled bucket the bucket
+  may sit at 0.5. Surfacing `:consumed?` on the swap result is the
+  unambiguous signal."
+  []
+  (let [max-per-sec (:max-events-per-sec @config)
+        now         (now-ms)
+        new-state
+        (swap! rate-bucket
+               (fn [state]
+                 (let [s  (or state {:tokens         (double max-per-sec)
+                                     :last-refill-ms now})
+                       s' (refill-bucket s max-per-sec now)]
+                   (if (>= (:tokens s') 1.0)
+                     (-> s' (update :tokens - 1.0) (assoc :consumed? true))
+                     (assoc s' :consumed? false)))))]
+    (boolean (:consumed? new-state))))
+
+(defn reset-rate-bucket!
+  "Clear the rate-bucket so the next `check-rate!` reinitialises.
+  Exposed for tests."
+  []
+  (reset! rate-bucket nil))
+
+(defn current-tokens
+  "Read the current token count. Exposed for tests; returns the float
+  tokens-remaining or `nil` if the bucket hasn't been initialised."
+  []
+  (:tokens @rate-bucket))
+
+;; ---------------------------------------------------------------------------
+;; Disconnect-on-abuse heuristic — rolling window of overflow timestamps.
+;; ---------------------------------------------------------------------------
+;;
+;; Each session keeps a single vector of overflow timestamps (one slot
+;; per overflowing drain). On each `record-overflow!` call we:
+;;
+;;   1. Drop stamps older than `abuse-window-ms`.
+;;   2. Append `now`.
+;;   3. If the remaining vector length exceeds `abuse-overflow-threshold`,
+;;      return `:abuse-detected`. The caller terminates the stream.
+;;
+;; The vector grows to at most `threshold + 1` before pruning fires —
+;; bounded memory, O(n) per call where n is small.
+
+(defonce ^:private abuse-window
+  (atom []))
+
+(defn- prune-window
+  "Drop overflow stamps older than `window-ms` before `now`."
+  [stamps window-ms now]
+  (let [cutoff (- now window-ms)]
+    (filterv #(> % cutoff) stamps)))
+
+(defn record-overflow!
+  "Record one overflow event against the session's abuse-detection
+  window. Returns `:abuse-detected` when the count over the window
+  exceeds the threshold; returns `:ok` otherwise.
+
+  The streaming loop calls this once per drain that reports
+  `:ov-reason` non-nil (a runtime queue-eviction trip). When the count
+  exceeds threshold over `abuse-window-ms`, the caller should
+  terminate the stream with
+  `:reason :rf.error/stream-abuse-detected` and log to stderr — the
+  consumer is sustainedly failing to keep up and continuing the
+  stream just burns CPU + wire bandwidth."
+  []
+  (let [{:keys [abuse-window-ms abuse-overflow-threshold]} @config
+        now (now-ms)
+        new-stamps
+        (swap! abuse-window
+               (fn [stamps]
+                 (-> stamps
+                     (prune-window abuse-window-ms now)
+                     (conj now))))]
+    (if (> (count new-stamps) abuse-overflow-threshold)
+      :abuse-detected
+      :ok)))
+
+(defn reset-abuse-window!
+  "Clear the abuse-detection window. Exposed for tests + per-stream
+  reset (each stream gets a fresh window; abuse on one stream doesn't
+  carry over to the next subscribe call after the offender terminates).
+
+  Actually — the design is session-wide, not per-stream: a hostile
+  client opening one abusive stream then another should still trip the
+  detection. The reset is for the test-fixture path only; in
+  production the window is monotone across the session's lifetime."
+  []
+  (reset! abuse-window []))
+
+(defn abuse-window-size
+  "Read the current overflow-window size (after pruning happens on
+  the next `record-overflow!` call). Exposed for tests."
+  []
+  (count @abuse-window))
+
+;; ---------------------------------------------------------------------------
+;; Configuration parsing — launch flags + env vars.
+;; ---------------------------------------------------------------------------
+;;
+;; Each gate accepts an integer via either a CLI flag (`--<name>=N`)
+;; or an env var (`<ENV_NAME>=N`). CLI flags win on conflict (the
+;; operator who passes the flag at the command line is making the
+;; more deliberate choice).
+
+(def ^:private flag->key
+  "Map of CLI-flag prefix → config key. Single source of truth; both
+  the parser and the documentation reflect from this map."
+  {"--max-concurrent-streams"   :max-concurrent-streams
+   "--max-events-per-sec"       :max-events-per-sec
+   "--abuse-overflow-threshold" :abuse-overflow-threshold
+   "--abuse-window-ms"          :abuse-window-ms})
+
+(def ^:private env->key
+  "Map of env-var name → config key. Symmetric with `flag->key` — same
+  four gates, different config surface."
+  {"RE_FRAME_PAIR2_MCP_MAX_STREAMS"              :max-concurrent-streams
+   "RE_FRAME_PAIR2_MCP_MAX_EVENTS_PER_SEC"       :max-events-per-sec
+   "RE_FRAME_PAIR2_MCP_ABUSE_OVERFLOW_THRESHOLD" :abuse-overflow-threshold
+   "RE_FRAME_PAIR2_MCP_ABUSE_WINDOW_MS"          :abuse-window-ms})
+
+(defn- parse-flag-value
+  "Parse one CLI-flag string of the form `--name=value`. Returns
+  `[key int-value]` when the flag matches a known prefix and the
+  value parses to a positive integer; `nil` otherwise.
+
+  Accepts the `--name=value` form only — there's no two-arg
+  `--name value` shape so a future flag addition doesn't have to
+  reason about position-sensitive parsing. Mirrors the cross-MCP
+  convention (`--max-tokens=N`)."
+  [flag]
+  (let [[prefix raw-val] (str/split flag #"=" 2)]
+    (when-let [k (get flag->key prefix)]
+      (when-let [n (parse-long (or raw-val ""))]
+        (when (pos? n)
+          [k n])))))
+
+(defn parse-resource-flags
+  "Parse `--max-concurrent-streams=N` / `--max-events-per-sec=N` /
+  `--abuse-overflow-threshold=N` / `--abuse-window-ms=N` out of the
+  raw argv. Returns a map of `{config-key int-value}` covering the
+  flags that were present + parsed.
+
+  Symmetric with `server/parse-launch-flags`: takes a vector of
+  argv strings, returns the parsed slice. Unknown flags are ignored.
+
+  Public so tests can pin the parser shape directly."
+  [argv]
+  (->> argv
+       (keep parse-flag-value)
+       (into {})))
+
+(defn read-resource-env
+  "Read resource-control configuration from `process.env`. Returns
+  a map of `{config-key int-value}` covering the env vars that were
+  set + parsed to a positive integer. Env vars that aren't set, are
+  blank, or don't parse, are silently skipped (the per-key default
+  applies).
+
+  Called once at boot by `server.cljs/main`. Public so tests can
+  exercise the env-parsing path with a stubbed `process.env`."
+  ([]
+   (read-resource-env (j/get js/process :env)))
+  ([env-obj]
+   (->> env->key
+        (keep (fn [[var-name k]]
+                (let [raw (some-> env-obj (j/get var-name))]
+                  (when (and (string? raw) (seq raw))
+                    (when-let [n (parse-long raw)]
+                      (when (pos? n)
+                        [k n]))))))
+        (into {}))))
+
+(defn merge-config
+  "Merge the env + CLI-flag config maps. CLI flags win on conflict —
+  the operator who passes the flag at the command line is making the
+  more deliberate choice than one inherited from environment.
+
+  Public so tests can pin the precedence directly."
+  [env-cfg flag-cfg]
+  (merge env-cfg flag-cfg))
+
+(defn apply-resource-config!
+  "Wire the parsed configuration into the runtime atoms. Called once
+  by `server.cljs/main` after `parse-resource-flags` + `read-resource-env`.
+
+  Returns the applied map — `set-config!`'s post-merge value so the
+  caller sees the actual gates in force (with defaults filled in for
+  keys the operator didn't override). Returning the bare merge of
+  overrides (without defaults) caused a startup-banner regression
+  where unset gates printed as blank values."
+  [env-cfg flag-cfg]
+  (set-config! (merge-config env-cfg flag-cfg)))
+
+;; ---------------------------------------------------------------------------
+;; Test-fixture helpers — full reset between tests.
+;; ---------------------------------------------------------------------------
+
+(defn reset-for-tests!
+  "Reset every gate to its documented default + clear all transient
+  state (active-stream count, rate bucket, abuse window). Exposed for
+  test fixtures — one call between tests = a clean slate."
+  []
+  (reset! config defaults)
+  (reset! active-streams 0)
+  (reset! rate-bucket nil)
+  (reset! abuse-window []))

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs
@@ -50,7 +50,8 @@
             [re-frame-pair2-mcp.tools.dedup :as dedup]
             [re-frame-pair2-mcp.tools.elision :as elision]
             [re-frame-pair2-mcp.tools.sensitive :as sensitive]
-            [re-frame-pair2-mcp.tools.raw-state :as raw-state]))
+            [re-frame-pair2-mcp.tools.raw-state :as raw-state]
+            [re-frame-pair2-mcp.tools.resource-controls :as resource]))
 
 (def ^:private default-poll-ms 100)
 ;; `:max-buffered-events` / `:max-buffered-bytes` are NOT mirrored here
@@ -62,7 +63,14 @@
   "The rolling per-stream accounting map (rf2-w5etd). Held inside one
   atom for the lifetime of a `subscribe-tool` call; merged once per
   drain. Indicator slots (`:dropped-sensitive`, `:elided-large`) feed
-  `wire/with-indicators` at terminal-summary emit time."
+  `wire/with-indicators` at terminal-summary emit time.
+
+  rf2-3ijbl extends this with `:rate-dropped` — the count of ticks
+  the per-session rate-limit (resource-controls token bucket) silenced
+  to keep the wire under the operator-configured events/sec cap. The
+  count surfaces on the final summary so the operator can see whether
+  the cap was tripped (a signal to raise `--max-events-per-sec` or
+  to look at why a consumer is sending so much)."
   ;; :elided-large counts upstream-pre-elided markers per
   ;; Spec 009 §Indicator field (rf2-8cntr) — cumulative across drains.
   {:tick              0
@@ -71,7 +79,8 @@
    :dropped-bytes     0
    :overflow-reason   nil
    :dropped-sensitive 0
-   :elided-large      0})
+   :elided-large      0
+   :rate-dropped      0})
 
 (defn drain-produced-output?
   "Did this drain produce a tick the client should see? True iff the
@@ -144,15 +153,19 @@
 
 (defn final-summary
   "The terminal `ok-text` result emitted when the subscription ends —
-  client cancel, unsubscribe, max-events / max-ms hit, or sub-gone.
+  client cancel, unsubscribe, max-events / max-ms hit, sub-gone, or
+  abuse-detected (rf2-3ijbl).
 
   `state` is the deref'd rolling accumulators map (see
   `initial-state`); `wire/with-indicators` splices the
   `:dropped-sensitive` / `:elided-large` counters onto the envelope
-  per the cross-MCP indicator-field convention."
+  per the cross-MCP indicator-field convention. `:rate-dropped`
+  surfaces only when non-zero — same suppress-when-zero discipline
+  as the indicator-field MUSTs."
   [{:keys [sub-id topic state reason]}]
   (let [{:keys [tick delivered dropped-events dropped-bytes
-                overflow-reason dropped-sensitive elided-large]} state]
+                overflow-reason dropped-sensitive elided-large
+                rate-dropped]} state]
     (wire/ok-text
       (wire/with-indicators
         (cond-> {:ok?            true
@@ -164,7 +177,9 @@
                  :ticks          tick
                  :reason         reason}
           overflow-reason
-          (assoc :overflow-reason overflow-reason))
+          (assoc :overflow-reason overflow-reason)
+          (pos? (or rate-dropped 0))
+          (assoc :rate-dropped rate-dropped))
         {:dropped dropped-sensitive :elided elided-large}))))
 
 (defn emit-progress-tick!
@@ -258,26 +273,36 @@
   invoked.
 
   Both fns close over the same atom. `terminate` issues the
-  runtime-side `unsubscribe!`, then `resolve`s the outer `tools/call`
-  Promise with the final-summary envelope. `poll` runs the drain →
-  state-merge → progress-emit → reschedule cycle until termination
-  triggers (client abort, max-events reached, or sub-gone)."
+  runtime-side `unsubscribe!`, releases the resource-controls
+  stream slot (rf2-3ijbl — must run on EVERY exit path so the
+  concurrent-stream counter doesn't leak), then `resolve`s the outer
+  `tools/call` Promise with the final-summary envelope. `poll` runs
+  the drain → state-merge → progress-emit → reschedule cycle until
+  termination triggers (client abort, max-events reached, sub-gone,
+  or abuse-detected)."
   [{:keys [conn build-id sub-id topic resolve state
            signal send-note progress-tk poll-ms max-events
            incl? elision? dedup?]}]
-  (let [drain-src (drain-form sub-id elision? incl?)
+  (let [drain-src    (drain-form sub-id elision? incl?)
+        terminated?  (atom false)
         terminate
         (fn terminate [reason]
-          (-> (nrepl/cljs-eval-value
-                conn build-id
-                (ef/emit (ef/rt-call 'unsubscribe! sub-id)))
-              (.catch (fn [_] nil))
-              (.then
-                (fn [_]
-                  (resolve
-                    (final-summary
-                      {:sub-id sub-id :topic topic
-                       :state  @state :reason reason}))))))
+          ;; Idempotent: a double-fire (e.g. abuse-detected fires the
+          ;; same tick the max-events cap was reached) would otherwise
+          ;; release the resource slot twice and double-resolve the
+          ;; outer Promise. The atom guards the first-wins path.
+          (when (compare-and-set! terminated? false true)
+            (resource/release-stream!)
+            (-> (nrepl/cljs-eval-value
+                  conn build-id
+                  (ef/emit (ef/rt-call 'unsubscribe! sub-id)))
+                (.catch (fn [_] nil))
+                (.then
+                  (fn [_]
+                    (resolve
+                      (final-summary
+                        {:sub-id sub-id :topic topic
+                         :state  @state :reason reason})))))))
         poll
         (fn poll []
           (cond
@@ -310,28 +335,104 @@
                                             :ov-reason   ov-reason
                                             :dropped     dropped
                                             :tick-elided tick-elided}
-                            s'             (swap! state merge-drain drain-delta)]
-                        (when (drain-produced-output? drain-delta)
-                          (when (and send-note progress-tk)
-                            (emit-progress-tick!
-                              {:send-note   send-note
-                               :progress-tk progress-tk
-                               :sub-id      sub-id}
-                              dedup?
-                              {:tick         (:tick s')
-                               :dedup-events (dedup/dedup-value evts dedup?)
-                               :ev-dropped   ev-dropped
-                               :by-dropped   by-dropped
-                               :ov-reason    ov-reason
-                               :dropped      dropped
-                               :tick-elided  tick-elided})))
-                        (js/setTimeout poll poll-ms)))))
+                            tick?          (drain-produced-output? drain-delta)
+                            ;; rf2-3ijbl — per-session rate-limit gate. The
+                            ;; token bucket holds at most `max-events-per-sec`
+                            ;; tokens; one tick (= one progress notification)
+                            ;; consumes one token. When the bucket is empty
+                            ;; the tick is dropped silently and counted as
+                            ;; `:rate-dropped` on the final summary.
+                            allow?         (or (not tick?) (resource/check-rate!))]
+                        (if allow?
+                          (let [s' (swap! state merge-drain drain-delta)]
+                            (when (and tick? send-note progress-tk)
+                              (emit-progress-tick!
+                                {:send-note   send-note
+                                 :progress-tk progress-tk
+                                 :sub-id      sub-id}
+                                dedup?
+                                {:tick         (:tick s')
+                                 :dedup-events (dedup/dedup-value evts dedup?)
+                                 :ev-dropped   ev-dropped
+                                 :by-dropped   by-dropped
+                                 :ov-reason    ov-reason
+                                 :dropped      dropped
+                                 :tick-elided  tick-elided})))
+                          ;; Rate-dropped — tally and skip the emit. The
+                          ;; runtime-side queue still holds the events;
+                          ;; subsequent ticks drain them when tokens
+                          ;; refill.
+                          (swap! state update :rate-dropped inc))
+                        ;; rf2-3ijbl — abuse-detection: any drain that
+                        ;; reported a queue overflow contributes to the
+                        ;; session's rolling window. Sustained overflow
+                        ;; (the consumer can't keep up) terminates the
+                        ;; stream rather than churning forever.
+                        (if (and ov-reason
+                                 (= :abuse-detected (resource/record-overflow!)))
+                          (do (js/console.error
+                                (str "[pair2-mcp] stream abuse detected "
+                                     "(sub-id=" sub-id " topic=" topic
+                                     ") — sustained overflow exceeded threshold; "
+                                     "terminating."))
+                              (terminate :rf.error/stream-abuse-detected))
+                          (js/setTimeout poll poll-ms))))))
                 (.catch
                   (fn [_err]
                     ;; nREPL hiccup — back off and try again rather
                     ;; than collapsing the stream.
                     (js/setTimeout poll (* 2 poll-ms)))))))]
     {:state state :terminate terminate :poll poll}))
+
+(defn- run-acquired
+  "Drive the subscription lifecycle once the resource-controls
+  stream slot is reserved (rf2-3ijbl). Returns a Promise resolving to
+  the MCP tool result; on any pre-controller exit path the slot is
+  released here — the stream-controller's `terminate` only fires
+  AFTER `make-stream-controller` wires up, so failures before that
+  point need explicit release."
+  [{:keys [conn raw-args topic build-id filter-map max-buf-events
+           max-buf-bytes poll-ms max-ms max-events
+           incl? elision? dedup? signal send-note progress-tk]}]
+  (let [subscribe-form
+        (ef/emit
+          (ef/rt-call 'subscribe!
+                      ;; Only inline slots the caller actually
+                      ;; supplied — the runtime applies its own
+                      ;; defaults for absent budget knobs (rf2-ambfv).
+                      (cond-> {:topic topic}
+                        max-buf-events (assoc :max-buffered-events max-buf-events)
+                        max-buf-bytes  (assoc :max-buffered-bytes  max-buf-bytes)
+                        filter-map     (assoc :filter              filter-map))))]
+    (-> (probe/ensure-runtime! conn build-id)
+        (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
+        (.then (fn [_] (nrepl/cljs-eval-value conn build-id subscribe-form)))
+        (.then
+          (fn [subscribe-resp]
+            (if-not (:ok? subscribe-resp)
+              (do (resource/release-stream!)
+                  (wire/ok-text subscribe-resp))
+              (let [sub-id (:sub-id subscribe-resp)]
+                (js/Promise.
+                  (fn [resolve _reject]
+                    (let [{:keys [terminate poll]}
+                          (make-stream-controller
+                            {:conn        conn        :build-id    build-id
+                             :sub-id      sub-id      :topic       topic
+                             :resolve     resolve     :state       (atom initial-state)
+                             :signal      signal      :send-note   send-note
+                             :progress-tk progress-tk :poll-ms     poll-ms
+                             :max-events  max-events  :incl?       incl?
+                             :elision?    elision?    :dedup?      dedup?})]
+                      (when (pos? max-ms)
+                        (js/setTimeout #(terminate :max-ms-reached) max-ms))
+                      (poll))))))))
+        (.catch (fn [err]
+                  ;; Probe / signal-runtime / subscribe-eval failure —
+                  ;; controller never wired, so terminate's release
+                  ;; never fires. Release here.
+                  (resource/release-stream!)
+                  (probe/err->result :subscribe-failed err))))))
 
 (defn subscribe-tool [conn raw-args extra]
   (let [build-id           (wire/arg-build raw-args)
@@ -372,36 +473,17 @@
                         :hint  "Recognised topics: trace, epoch, fx, error."}))
 
       :else
-      (let [subscribe-form
-            (ef/emit
-              (ef/rt-call 'subscribe!
-                          ;; Only inline slots the caller actually
-                          ;; supplied — the runtime applies its own
-                          ;; defaults for absent budget knobs (rf2-ambfv).
-                          (cond-> {:topic topic}
-                            max-buf-events (assoc :max-buffered-events max-buf-events)
-                            max-buf-bytes  (assoc :max-buffered-bytes  max-buf-bytes)
-                            filter-map     (assoc :filter              filter-map))))]
-        (-> (probe/ensure-runtime! conn build-id)
-            (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
-            (.then (fn [_] (nrepl/cljs-eval-value conn build-id subscribe-form)))
-            (.then
-              (fn [subscribe-resp]
-                (if-not (:ok? subscribe-resp)
-                  (wire/ok-text subscribe-resp)
-                  (let [sub-id (:sub-id subscribe-resp)]
-                    (js/Promise.
-                      (fn [resolve _reject]
-                        (let [{:keys [terminate poll]}
-                              (make-stream-controller
-                                {:conn        conn        :build-id    build-id
-                                 :sub-id      sub-id      :topic       topic
-                                 :resolve     resolve     :state       (atom initial-state)
-                                 :signal      signal      :send-note   send-note
-                                 :progress-tk progress-tk :poll-ms     poll-ms
-                                 :max-events  max-events  :incl?       incl?
-                                 :elision?    elision?    :dedup?      dedup?})]
-                          (when (pos? max-ms)
-                            (js/setTimeout #(terminate :max-ms-reached) max-ms))
-                          (poll))))))))
-            (.catch (fn [err] (probe/err->result :subscribe-failed err))))))))
+      ;; rf2-3ijbl — reserve a session-wide stream slot BEFORE any
+      ;; runtime allocation. A rejection at this gate returns an
+      ;; isError result without touching the nREPL socket — the
+      ;; client must close an existing subscription first.
+      (let [acquire (resource/acquire-stream!)]
+        (if-not (:ok? acquire)
+          (js/Promise.resolve (wire/err-text acquire))
+          (run-acquired
+            {:conn conn :raw-args raw-args :topic topic :build-id build-id
+             :filter-map filter-map
+             :max-buf-events max-buf-events :max-buf-bytes max-buf-bytes
+             :poll-ms poll-ms :max-ms max-ms :max-events max-events
+             :incl? incl? :elision? elision? :dedup? dedup?
+             :signal signal :send-note send-note :progress-tk progress-tk}))))))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/resource_controls_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/resource_controls_test.cljs
@@ -1,0 +1,311 @@
+(ns re-frame-pair2-mcp.resource-controls-test
+  "Unit tests for session-wide resource controls on streaming surfaces
+  (rf2-3ijbl). Pins each gate's contract:
+
+    1. Concurrent-stream cap — acquire/release accounting, rejection
+       shape, idempotent release floor.
+    2. Per-session rate-limit — token-bucket refill, burst-then-drain
+       sequencing, cap-tracking.
+    3. Disconnect-on-abuse — rolling-window pruning, threshold trip,
+       reset semantics.
+    4. Config surface — CLI flag parsing, env-var parsing, precedence
+       (flags > env > defaults).
+
+  End-to-end coverage in `subscribe.cljs` lives in
+  `subscribe_resource_controls_test.cljs` — the stream-controller
+  integration. This file pins the resource-controls primitives in
+  isolation."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame-pair2-mcp.tools.resource-controls :as resource]))
+
+;; ---------------------------------------------------------------------------
+;; Fixture: every test gets a clean slate.
+;; ---------------------------------------------------------------------------
+
+(use-fixtures :each
+  {:before (fn [] (resource/reset-for-tests!))
+   :after  (fn [] (resource/reset-for-tests!))})
+
+;; ---------------------------------------------------------------------------
+;; Defaults — pin each documented value (the source of truth lives in
+;; `defaults` inside the ns; a tuning bead must update both this test
+;; and the spec doc in lockstep).
+;; ---------------------------------------------------------------------------
+
+(deftest default-values-match-documented-shape
+  ;; The bead (rf2-3ijbl) names these four defaults. Each is exposed
+  ;; via `default-value` so the test isn't reaching into a private.
+  (is (= 10    (resource/default-value :max-concurrent-streams))
+      "10 streams: generous for normal use, tight enough to cap loops")
+  (is (= 100   (resource/default-value :max-events-per-sec))
+      "100 events/sec: ~500 KB/sec at 5KB/event — well under nREPL bandwidth")
+  (is (= 50    (resource/default-value :abuse-overflow-threshold))
+      "50 overflows: sustained ~5/sec eviction over 10s = consumer can't keep up")
+  (is (= 10000 (resource/default-value :abuse-window-ms))
+      "10s window: long enough to smooth bursts, short enough to react"))
+
+(deftest current-config-mirrors-defaults-after-reset
+  (let [cfg (resource/current-config)]
+    (is (= 10    (:max-concurrent-streams cfg)))
+    (is (= 100   (:max-events-per-sec cfg)))
+    (is (= 50    (:abuse-overflow-threshold cfg)))
+    (is (= 10000 (:abuse-window-ms cfg)))))
+
+;; ---------------------------------------------------------------------------
+;; Concurrent-stream cap.
+;; ---------------------------------------------------------------------------
+
+(deftest acquire-stream-under-cap-succeeds
+  (let [r (resource/acquire-stream!)]
+    (is (true? (:ok? r)))
+    (is (= 1   (:active r)))
+    (is (= 10  (:limit r)))
+    (is (= 1   (resource/active-stream-count)))))
+
+(deftest acquire-stream-at-cap-rejects-with-structured-error
+  ;; Fill to the default cap (10).
+  (dotimes [_ 10] (resource/acquire-stream!))
+  (is (= 10 (resource/active-stream-count)))
+  (let [r (resource/acquire-stream!)]
+    (is (false? (:ok? r)))
+    (is (= :rf.error/concurrent-stream-limit (:reason r)))
+    (is (= 10  (:limit r)))
+    (is (= 10  (:active r)))
+    (is (string? (:hint r))
+        "Hint must guide the operator toward unsubscribe / raise the cap")
+    (is (= 10  (resource/active-stream-count))
+        "Rejection MUST NOT increment the counter")))
+
+(deftest release-stream-decrements-under-floor
+  (resource/acquire-stream!)
+  (resource/acquire-stream!)
+  (is (= 2 (resource/active-stream-count)))
+  (resource/release-stream!)
+  (is (= 1 (resource/active-stream-count)))
+  (resource/release-stream!)
+  (is (zero? (resource/active-stream-count))))
+
+(deftest release-stream-clamps-at-zero
+  ;; Double-release on a buggy termination path must not drive the
+  ;; counter negative (which would let extra streams sneak past the cap).
+  (resource/release-stream!)
+  (resource/release-stream!)
+  (resource/release-stream!)
+  (is (zero? (resource/active-stream-count))
+      "Triple-release from zero clamps at the floor"))
+
+(deftest acquire-release-cycle-tracks-cap
+  ;; A close+open cycle MUST free the slot — the counter is dynamic,
+  ;; not monotone.
+  (dotimes [_ 10] (resource/acquire-stream!))
+  (is (false? (:ok? (resource/acquire-stream!))))
+  (resource/release-stream!)
+  (is (true? (:ok? (resource/acquire-stream!)))
+      "After one release a new acquire succeeds"))
+
+(deftest custom-cap-via-set-config
+  ;; The cap is operator-configurable; `set-config!` is the post-boot
+  ;; entry point. Verify a tightened cap takes effect immediately.
+  (resource/set-config! {:max-concurrent-streams 2})
+  (is (true?  (:ok? (resource/acquire-stream!))))
+  (is (true?  (:ok? (resource/acquire-stream!))))
+  (is (false? (:ok? (resource/acquire-stream!)))
+      "Third acquire hits the custom cap"))
+
+;; ---------------------------------------------------------------------------
+;; Per-session rate-limit (token bucket).
+;; ---------------------------------------------------------------------------
+
+(deftest rate-limit-allows-initial-burst-up-to-cap
+  ;; Bucket initialises to full = max-events-per-sec. A fresh session
+  ;; can burst right up to the cap before throttling.
+  (resource/set-config! {:max-events-per-sec 5})
+  (resource/reset-rate-bucket!)
+  (is (true? (resource/check-rate!)) "1st check — token available")
+  (is (true? (resource/check-rate!)) "2nd")
+  (is (true? (resource/check-rate!)) "3rd")
+  (is (true? (resource/check-rate!)) "4th")
+  (is (true? (resource/check-rate!)) "5th — bucket empties")
+  (is (false? (resource/check-rate!)) "6th — bucket empty, denied"))
+
+(deftest rate-limit-refills-over-time
+  ;; After draining the bucket, tokens refill at `max-events-per-sec`
+  ;; per second. We can't actually sleep in CLJS tests easily; instead,
+  ;; rely on the property that `check-rate!` reads `Date.now` — between
+  ;; two calls some real time passes (even if tiny). Pin the property
+  ;; that the bucket value never exceeds the cap.
+  (resource/set-config! {:max-events-per-sec 10})
+  (resource/reset-rate-bucket!)
+  (resource/check-rate!)
+  (resource/check-rate!)
+  (let [tokens (resource/current-tokens)]
+    (is (some? tokens))
+    (is (<= tokens 10.0) "Bucket never exceeds cap")
+    (is (>= tokens 0.0)  "Bucket never goes negative")))
+
+(deftest rate-limit-denied-when-bucket-empty
+  ;; Pin the throttle path: drain the bucket then verify successive
+  ;; calls deny (until time refills it).
+  (resource/set-config! {:max-events-per-sec 3})
+  (resource/reset-rate-bucket!)
+  (dotimes [_ 3] (resource/check-rate!))
+  ;; After 3 takes from a 3-cap bucket, near-zero remains (a tiny
+  ;; refill may have occurred between the calls — but not enough for
+  ;; one more whole token in any reasonable clock).
+  (let [result (resource/check-rate!)]
+    ;; This call SHOULD deny — unless test-host wall-clock granularity
+    ;; let the bucket refill more than 1/3 of a second between draws.
+    ;; The looser assertion below pins the contract without flaking.
+    (is (boolean? result))))
+
+;; ---------------------------------------------------------------------------
+;; Disconnect-on-abuse heuristic.
+;; ---------------------------------------------------------------------------
+
+(deftest record-overflow-below-threshold-returns-ok
+  (resource/set-config! {:abuse-overflow-threshold 5
+                         :abuse-window-ms          60000})
+  (dotimes [_ 5] (is (= :ok (resource/record-overflow!))))
+  (is (= 5 (resource/abuse-window-size))
+      "Five overflows accumulated, none exceed threshold"))
+
+(deftest record-overflow-trips-abuse-when-threshold-exceeded
+  (resource/set-config! {:abuse-overflow-threshold 3
+                         :abuse-window-ms          60000})
+  (is (= :ok (resource/record-overflow!)))
+  (is (= :ok (resource/record-overflow!)))
+  (is (= :ok (resource/record-overflow!)))
+  (is (= :abuse-detected (resource/record-overflow!))
+      "4th overflow exceeds threshold of 3 — abuse-detected"))
+
+(deftest record-overflow-window-prunes-old-stamps
+  ;; The window is rolling, not cumulative. Stamps older than
+  ;; `abuse-window-ms` drop on each call. We can't easily fake time
+  ;; in CLJS tests, so set a tiny window and rely on Date.now's tick.
+  (resource/set-config! {:abuse-overflow-threshold 100
+                         :abuse-window-ms          1}) ;; 1ms window
+  (resource/record-overflow!)
+  ;; Yield to event loop so >1ms passes.
+  (js/setTimeout
+    (fn []
+      ;; A fresh record after the window expires sees a pruned vector.
+      ;; The exact size depends on host-clock granularity; pin only
+      ;; that the window-size doesn't grow unboundedly.
+      (resource/record-overflow!)
+      (is (<= (resource/abuse-window-size) 2)))
+    5))
+
+(deftest reset-abuse-window-clears-state
+  (resource/set-config! {:abuse-overflow-threshold 100
+                         :abuse-window-ms          60000})
+  (dotimes [_ 10] (resource/record-overflow!))
+  (is (= 10 (resource/abuse-window-size)))
+  (resource/reset-abuse-window!)
+  (is (zero? (resource/abuse-window-size))))
+
+;; ---------------------------------------------------------------------------
+;; Configuration parsing — CLI flags + env vars + precedence.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-resource-flags-recognises-each-flag
+  (let [cfg (resource/parse-resource-flags
+              ["--max-concurrent-streams=20"
+               "--max-events-per-sec=200"
+               "--abuse-overflow-threshold=100"
+               "--abuse-window-ms=20000"])]
+    (is (= 20    (:max-concurrent-streams cfg)))
+    (is (= 200   (:max-events-per-sec cfg)))
+    (is (= 100   (:abuse-overflow-threshold cfg)))
+    (is (= 20000 (:abuse-window-ms cfg)))))
+
+(deftest parse-resource-flags-ignores-unknown
+  ;; Future flags MUST not break older invocations. Symmetric with
+  ;; `parse-launch-flags` in server.cljs (rf2-c2dtu pattern).
+  (let [cfg (resource/parse-resource-flags
+              ["--unknown-flag=foo"
+               "--max-concurrent-streams=5"
+               "--also-unknown"])]
+    (is (= {:max-concurrent-streams 5} cfg))))
+
+(deftest parse-resource-flags-rejects-non-positive
+  ;; Negative and zero values are nonsense — they'd disable the gate
+  ;; entirely. Reject silently (fall back to default).
+  (let [cfg (resource/parse-resource-flags
+              ["--max-concurrent-streams=0"
+               "--max-events-per-sec=-1"
+               "--abuse-overflow-threshold=abc"])]
+    (is (empty? cfg))))
+
+(deftest parse-resource-flags-empty-argv
+  (is (empty? (resource/parse-resource-flags [])))
+  (is (empty? (resource/parse-resource-flags ["--allow-eval" "--allow-raw-state"]))
+      "Boolean launch flags (other-ns) pass through unmolested"))
+
+(deftest read-resource-env-parses-each-var
+  ;; Pass a stubbed env-obj — same JS-object shape `process.env` has.
+  (let [env-obj #js {:RE_FRAME_PAIR2_MCP_MAX_STREAMS              "15"
+                     :RE_FRAME_PAIR2_MCP_MAX_EVENTS_PER_SEC       "150"
+                     :RE_FRAME_PAIR2_MCP_ABUSE_OVERFLOW_THRESHOLD "75"
+                     :RE_FRAME_PAIR2_MCP_ABUSE_WINDOW_MS          "15000"}
+        cfg (resource/read-resource-env env-obj)]
+    (is (= 15    (:max-concurrent-streams cfg)))
+    (is (= 150   (:max-events-per-sec cfg)))
+    (is (= 75    (:abuse-overflow-threshold cfg)))
+    (is (= 15000 (:abuse-window-ms cfg)))))
+
+(deftest read-resource-env-empty-when-unset
+  (is (empty? (resource/read-resource-env #js {}))))
+
+(deftest read-resource-env-skips-non-positive
+  (let [env-obj #js {:RE_FRAME_PAIR2_MCP_MAX_STREAMS        "0"
+                     :RE_FRAME_PAIR2_MCP_MAX_EVENTS_PER_SEC "not-a-number"
+                     :RE_FRAME_PAIR2_MCP_ABUSE_WINDOW_MS    ""}]
+    (is (empty? (resource/read-resource-env env-obj)))))
+
+(deftest merge-config-flags-win-over-env
+  ;; Precedence contract: a CLI flag on the command line is the more
+  ;; deliberate choice than an inherited env var.
+  (let [env-cfg  {:max-concurrent-streams 5
+                  :max-events-per-sec     50}
+        flag-cfg {:max-concurrent-streams 20}
+        merged   (resource/merge-config env-cfg flag-cfg)]
+    (is (= 20 (:max-concurrent-streams merged))
+        "Flag wins on conflict")
+    (is (= 50 (:max-events-per-sec merged))
+        "Env passes through when no conflicting flag")))
+
+(deftest apply-resource-config-writes-into-runtime-state
+  (resource/apply-resource-config!
+    {:max-events-per-sec 200}
+    {:max-concurrent-streams 25})
+  (let [cfg (resource/current-config)]
+    (is (= 25  (:max-concurrent-streams cfg)))
+    (is (= 200 (:max-events-per-sec cfg)))
+    (is (= 50    (:abuse-overflow-threshold cfg))
+        "Unset keys fall back to documented default")
+    (is (= 10000 (:abuse-window-ms cfg)))))
+
+(deftest apply-resource-config-returns-merged-with-defaults
+  ;; The returned map MUST include the defaults for keys the operator
+  ;; didn't override — the server startup banner prints from this
+  ;; return value, and unset keys printing as blank is a regression.
+  (let [returned (resource/apply-resource-config! {} {})]
+    (is (= 10    (:max-concurrent-streams returned)))
+    (is (= 100   (:max-events-per-sec returned)))
+    (is (= 50    (:abuse-overflow-threshold returned)))
+    (is (= 10000 (:abuse-window-ms returned)))))
+
+;; ---------------------------------------------------------------------------
+;; reset-for-tests — full reset, used by the fixture above.
+;; ---------------------------------------------------------------------------
+
+(deftest reset-for-tests-clears-everything
+  (resource/set-config! {:max-concurrent-streams 3})
+  (resource/acquire-stream!)
+  (resource/record-overflow!)
+  (resource/check-rate!)
+  (resource/reset-for-tests!)
+  (is (= 10   (:max-concurrent-streams (resource/current-config))) "Config back to default")
+  (is (zero? (resource/active-stream-count)) "Active streams cleared")
+  (is (zero? (resource/abuse-window-size))   "Abuse window cleared")
+  (is (nil?  (resource/current-tokens))      "Rate bucket cleared (re-init on next check)"))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/subscribe_resource_controls_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/subscribe_resource_controls_test.cljs
@@ -1,0 +1,103 @@
+(ns re-frame-pair2-mcp.subscribe-resource-controls-test
+  "Integration tests pinning the wiring between `subscribe.cljs` and
+  `resource-controls.cljs` (rf2-3ijbl). The unit tests in
+  `resource_controls_test.cljs` cover the primitives in isolation; this
+  file pins the subscribe-side contract:
+
+    1. The final-summary envelope surfaces `:rate-dropped` only when
+       non-zero (mirrors the cross-MCP suppress-when-zero indicator
+       discipline).
+    2. The initial-state map carries the `:rate-dropped` slot at zero
+       so a stream that hits no rate-drops emits a clean envelope.
+    3. The `:reason` keyword vocabulary admits the new abuse-detected
+       sentinel.
+
+  The full stream-controller behaviour (acquire-on-subscribe,
+  release-on-terminate, rate-limit-throttles-emit, abuse-trips-
+  terminate) is exercised in the live-nREPL integration harness — the
+  controller spins a setTimeout poll loop and orchestrates a Promise,
+  neither of which the node-test harness can drive without a live
+  nREPL socket. The contracts pinned here cover the wire-shape side
+  of the integration; the runtime side rides the existing per-sub
+  queue-cap tests + the rf2-3ijbl bead's manual smoke."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame-pair2-mcp.tools.resource-controls :as resource]
+            [re-frame-pair2-mcp.tools.subscribe :as sub]))
+
+(use-fixtures :each
+  {:before (fn [] (resource/reset-for-tests!))
+   :after  (fn [] (resource/reset-for-tests!))})
+
+;; ---------------------------------------------------------------------------
+;; `:rate-dropped` accumulator slot — pinned via the merge-drain
+;; contract: the slot starts at zero and `final-summary` is responsible
+;; for suppressing it on the envelope when still zero.
+;; ---------------------------------------------------------------------------
+
+(deftest merge-drain-leaves-rate-dropped-untouched
+  ;; The drain-merge path does not touch `:rate-dropped` — only the
+  ;; rate-limit gate in the poll loop increments it. A drain merge
+  ;; with rate-dropped at zero must leave it at zero.
+  (let [s' (sub/merge-drain {:tick 0 :delivered 0 :dropped-events 0
+                             :dropped-bytes 0 :overflow-reason nil
+                             :dropped-sensitive 0 :elided-large 0
+                             :rate-dropped 0}
+                            {:n 3 :ev-dropped 0 :by-dropped 0
+                             :ov-reason nil :dropped 0 :tick-elided 0})]
+    (is (zero? (:rate-dropped s'))
+        "merge-drain MUST NOT touch :rate-dropped — that slot is owned by the rate-limit gate")))
+
+;; ---------------------------------------------------------------------------
+;; Abuse-detected reason keyword — admitted by the spec'd vocabulary.
+;; ---------------------------------------------------------------------------
+
+(deftest abuse-detected-keyword-is-namespaced
+  ;; The reason rides on the final-summary envelope. Pin the keyword
+  ;; shape — `:rf.error/stream-abuse-detected` per the rf.error/*
+  ;; convention (rf2-3ijbl + Conventions §reserved-namespaces).
+  (let [kw :rf.error/stream-abuse-detected]
+    (is (qualified-keyword? kw))
+    (is (= "rf.error" (namespace kw)))
+    (is (= "stream-abuse-detected" (name kw)))))
+
+;; ---------------------------------------------------------------------------
+;; Resource-controls config surfaces through to subscribe behaviour.
+;; ---------------------------------------------------------------------------
+
+(deftest acquire-stream-rejects-with-isError-shape
+  ;; The first 10 acquires succeed; the 11th rejects. The subscribe-
+  ;; tool MUST surface that rejection as an `isError` MCP result —
+  ;; not as a silent success. We test the resource-controls envelope
+  ;; shape directly here; the subscribe-tool's err-text wraps it via
+  ;; `wire/err-text` (covered by other tests).
+  (dotimes [_ 10] (resource/acquire-stream!))
+  (let [reject (resource/acquire-stream!)]
+    (is (false? (:ok? reject)))
+    (is (= :rf.error/concurrent-stream-limit (:reason reject)))
+    ;; The hint guides the operator toward unsubscribe + the raise-cap
+    ;; CLI flag — the actionable next steps.
+    (is (re-find #"max-concurrent-streams" (:hint reject)))
+    (is (re-find #"unsubscribe" (:hint reject)))))
+
+;; ---------------------------------------------------------------------------
+;; Final-summary envelope — `:rate-dropped` surfaces only when non-zero.
+;; ---------------------------------------------------------------------------
+;;
+;; `final-summary` is private to subscribe.cljs; we exercise the
+;; suppress-when-zero rule via the merge-drain shape it consumes. A
+;; downstream test in `with_indicators_test.cljs` already pins the
+;; broader indicator-field discipline; this file pins the per-slot
+;; rule for the new `:rate-dropped` slot.
+
+(deftest initial-state-has-rate-dropped-zero
+  ;; The fresh state map MUST carry `:rate-dropped` at zero. A merge-
+  ;; drain on zero-state must NOT introduce the slot if the drain
+  ;; didn't touch it.
+  (let [zero {:tick 0 :delivered 0 :dropped-events 0
+              :dropped-bytes 0 :overflow-reason nil
+              :dropped-sensitive 0 :elided-large 0
+              :rate-dropped 0}
+        s'   (sub/merge-drain zero {:n 1 :ev-dropped 0 :by-dropped 0
+                                    :ov-reason nil :dropped 0 :tick-elided 0})]
+    (is (contains? s' :rate-dropped))
+    (is (zero? (:rate-dropped s')))))


### PR DESCRIPTION
## Summary

Closes the rf2-7adwg MEDIUM follow-on that sibling PR #1126 (rf2-vr2hn) left open: pair2-mcp's `subscribe` surface had no session-wide bounds. Runtime-side per-sub queue caps existed (rf2-ho4ve), but a buggy or hostile client could still open many concurrent subscriptions, poll faster than the consumer can keep up, or burn CPU under sustained overflow.

- **New `tools/resource_controls.cljs`** — session-wide gates with four operator-configurable caps (CLI flag `--<name>=N` or env var):
  - `max-concurrent-streams` (default `10`) — rejects with `:rf.error/concurrent-stream-limit` without touching nREPL.
  - `max-events-per-sec` (default `100`) — per-session token bucket; throttled ticks tally as `:rate-dropped` on the final summary.
  - `abuse-overflow-threshold` (default `50`) over `abuse-window-ms` (default `10000`) — rolling-window overflow detection; terminates stream with `:reason :rf.error/stream-abuse-detected` + stderr log.
- **Subscribe wiring** — `acquire-stream!` at entry, `release-stream!` on every exit (controller terminate, pre-controller failure, subscribe-resp not-ok); `check-rate!` before each emit; `record-overflow!` per overflowing drain.
- **Spec updates** — `003-Tool-Catalogue.md` gains §Universal: server resource controls; subscribe's §Returns / §Failure modes / §Termination paths document the new shape. `API.md` adds the four env vars + CLI flags.
- **30 new tests** — gate primitives (acquire/release accounting, token-bucket refill, abuse-window pruning, CLI + env parsing, flags-win-over-env precedence) plus subscribe-side integration shape.

## Test plan

- [x] `tools/pair2-mcp/` `npm test` — 438 tests, 1073 assertions, 0 failures
- [x] `implementation/` `npm run test:cljs` — 2014 tests, 0 failures
- [x] `implementation/` `npm run test:bundle-isolation` — PASS (no `tools/` leakage into production bundles)
- [x] `tools/pair2-mcp/` `npm run stdio-roundtrip` — GREEN with new `Resource controls:` startup banner