### PR TITLE
chore: repo hygiene partial — editorconfig + clj-kondo + gitignore (rf2-mfi1s)

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,28 @@
+;; clj-kondo config for re-frame2 — repo-root.
+;;
+;; Activates project-aware analysis so editor integrations (Calva,
+;; CIDER, Cursive) and CI lints share one source of truth. Minimal
+;; but useful — enable the high-signal linters and let the per-artefact
+;; classpaths (under implementation/, tools/, examples/) inherit.
+;;
+;; The re-frame2 defining forms (`reg-event-db`, `reg-sub`, `reg-fx`,
+;; `reg-view`, …) are recognised by clj-kondo's built-in support for
+;; clojure.core-style defining forms — no hook lib required for the
+;; canonical shapes. Add :hooks here as the framework's macros grow
+;; surfaces clj-kondo's defaults can't infer.
+{:linters
+ {:unresolved-symbol {:level :warning}
+  :unused-binding    {:level :warning}
+  :unused-referred-var {:level :warning}
+  :unused-namespace  {:level :warning}
+  :redefined-var     {:level :warning}
+  :inline-def        {:level :warning}}
+
+ :lint-as
+ {;; Common re-frame2 registration macros that share clojure.core/def
+  ;; arglist shape — clj-kondo lints the body as a fn definition.
+  re-frame.core/reg-event-db    clojure.core/def
+  re-frame.core/reg-event-fx    clojure.core/def
+  re-frame.core/reg-sub         clojure.core/def
+  re-frame.core/reg-fx          clojure.core/def
+  re-frame.core/reg-cofx        clojure.core/def}}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# EditorConfig — https://editorconfig.org
+# Repo-root config for re-frame2. Spec is the artefact; consistent
+# whitespace across spec docs, CLJ(S/C) sources, and tooling matters.
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Clojure / ClojureScript / cljc — explicit for clarity even though
+# the [*] defaults already cover them.
+[*.{clj,cljs,cljc,edn}]
+indent_style = space
+indent_size = 2
+
+# Markdown trailing whitespace is sometimes meaningful (two-space line
+# break). Disable the trim for .md to avoid surprise edits.
+[*.md]
+trim_trailing_whitespace = false
+
+# Makefiles require literal tabs.
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,20 @@ skills/*/node_modules/
 skills/*/.shadow-cljs/
 skills/*/out/
 skills/*/target/
+
+# clj-kondo cache (rf2-mfi1s) — config.edn at /.clj-kondo/ is checked in;
+# the cache subdir is regenerated per-machine.
+/.clj-kondo/.cache/
+/.clj-kondo/.cache-version
+
+# Orphan npm lockfile (rf2-mfi1s) — there is no repo-root package.json;
+# this guards against stray `npm` invocations from the wrong cwd.
+/package-lock.json
+
+# CDP scratch dir from examples/ test runs (rf2-mfi1s) — local Chrome
+# user-data-dir, never committed.
+/examples/.edge-cdp/
+
+# Local worktrees created by EnterWorktree tool (rf2-mfi1s) — agent
+# scratch space, local-only.
+/.claude/worktrees/


### PR DESCRIPTION
## Summary

Implements rf2-mfi1s items 1, 2, 3 (gitignore guard), 4 (4 of 6 items in the bead's batch):

- **`.editorconfig`** — repo-root config: 2-space indent, lf, trim trailing ws, final newline. .md excluded from trim to preserve markdown two-space line breaks. Makefile carve-out for tabs.
- **`.clj-kondo/config.edn`** — high-signal linters enabled (unresolved-symbol, unused-binding/referred-var/namespace, redefined-var, inline-def at :warning). `:lint-as` shims for canonical re-frame2 reg-* macros so clj-kondo lints their bodies as fn defs.
- **`.gitignore`** — explicit rules for: `.clj-kondo/.cache/`, `.clj-kondo/.cache-version`, orphan `/package-lock.json`, `/examples/.edge-cdp/`, `/.claude/worktrees/`.

Pure repo-root scope; no source files touched.

## Deferred (filed as follow-on)

- Item 5 (CODE_OF_CONDUCT.md / CONTRIBUTING.md / SECURITY.md) — needs human policy decision + content filter snag on the dispatched agent.
- Item 6 (version pin) — would require editing hot-zone `implementation/deps.edn`; warrants its own bead.

## Test plan

- [x] `git status` clean post-commit
- [x] `.editorconfig` parses (no errors)
- [x] No source files modified