### PR TITLE
fix(core/router): route flow-eval-exception through error substrate (rf2-hrt5c)

### DIFF
--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -481,14 +481,68 @@
 (defn- run-flows!
   "Per Spec 013 §Drain integration: run flows after :db commits and
   before :fx walks. Flow evaluation exceptions surface as
-  :rf.error/flow-eval-exception traces; the drain continues."
-  [frame event]
+  :rf.error/flow-eval-exception through BOTH the dev-only trace
+  surface AND the always-on error-emit substrate (per rf2-hrt5c — the
+  security-audit fix). The drain continues regardless.
+
+  Per rf2-hrt5c: pre-fix, `:rf.error/flow-eval-exception` rode the
+  trace path only. `trace/emit-error!` is gated by
+  `interop/debug-enabled?` and DCEs to a no-op under `:advanced` +
+  `goog.DEBUG=false` — so a CLJS production build silently swallowed
+  flow-eval throws (no `:on-error` policy fire, no corpus-wide
+  listener record for off-box monitors). This routing now mirrors the
+  handler-exception path (`emit-handler-exception!`) — both fan-out
+  paths fire from one normative emission site, the trace path
+  enriches dev consumers, and the substrate path survives prod
+  elision. There is no `:handler-id` (no handler ran — the throw
+  came from the post-commit flow walk); the `:where :flow-eval`
+  discriminator distinguishes this path from the handler-exception
+  one for policy fns that key on it."
+  [frame event event-id start-ms]
   (when-let [flows-fn (late-bind/get-fn :flows/run-flows!)]
     (try
       (flows-fn frame)
       (catch #?(:clj Throwable :cljs :default) e
-        (trace/emit-error! :rf.error/flow-eval-exception
-                           {:frame frame :event event :exception e})))))
+        (let [end-ms     (interop/now-ms)
+              ;; Per rf2-bacs4 §Record shape: `:elapsed-ms` is an
+              ;; integer. Round once at the substrate boundary so the
+              ;; contract holds across the JVM long / CLJS float split
+              ;; from `interop/now-ms` (mirrors `emit-handler-exception!`).
+              elapsed-ms (long (max 0 (- end-ms start-ms)))
+              msg        #?(:clj (.getMessage ^Throwable e) :cljs (.-message e))
+              tags       {:event-id          event-id
+                          :event             event
+                          :frame             frame
+                          :where             :flow-eval
+                          :handler-id        nil
+                          :exception         e
+                          :exception-message msg
+                          :reason            "Flow evaluation threw."
+                          :recovery          :no-recovery}]
+          ;; Always-on per rf2-bacs4 / rf2-hqbeh — fires in CLJS
+          ;; production builds where `trace/emit-error!` below is
+          ;; compile-time elided. The two fan-out paths (corpus-wide
+          ;; listener registry + per-frame `:on-error` policy) are
+          ;; independent and isolated; both see the
+          ;; `:rf.error/flow-eval-exception` record.
+          (error-emit/dispatch-on-error!
+            :rf.error/flow-eval-exception
+            event
+            event-id
+            frame
+            e
+            elapsed-ms
+            end-ms
+            {:operation :rf.error/flow-eval-exception
+             :op-type   :error
+             :tags      tags
+             :recovery  :no-recovery})
+          ;; Dev-side trace emission. Gated by `interop/debug-enabled?`
+          ;; inside `trace/emit-error!`; DCEs to a no-op in CLJS prod
+          ;; builds. Same payload shape as before the rf2-hrt5c fix —
+          ;; existing trace consumers are unaffected.
+          (trace/emit-error! :rf.error/flow-eval-exception
+                             {:frame frame :event event :exception e}))))))
 
 (defn- run-fx-effects!
   "Walk :fx in source order, threading fx-overrides through so per-frame
@@ -634,7 +688,7 @@
     (when error
       (emit-handler-exception! error event-id event frame final-ctx start-ms))
     (when (commit-db-effect! effects event-id event frame final-ctx db-before)
-      (run-flows! frame event)
+      (run-flows! frame event event-id start-ms)
       (run-fx-effects! effects frame frame-record fx-overrides envelope))
     error))
 

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -14,6 +14,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
+            [re-frame.error-emit :as error-emit]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
@@ -32,6 +33,10 @@
   (reset! schemas/schemas-by-frame {})
   (when-let [li-var (resolve 're-frame.flows/last-inputs)]
     (reset! (deref li-var) {}))
+  ;; Per rf2-bacs4: the error-emit listener registry is a `defonce`
+  ;; atom that survives test re-runs. Clear before each test so a
+  ;; listener registered by one test doesn't leak into the next.
+  (error-emit/clear-error-emit-listeners!)
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
@@ -213,6 +218,126 @@
     (rf/dispatch-sync [:bump])
     (is (= 1 (count (by-op :rf.flow/failed)))
         "subsequent input change re-attempts and :rf.flow/failed fires again")))
+
+;; ---------------------------------------------------------------------------
+;; 5b. :rf.error/flow-eval-exception routes through the always-on
+;;     error-emit substrate (rf2-hrt5c — security audit follow-up).
+;;
+;; Pre-fix, `run-flows!` caught flow throws and called
+;; `trace/emit-error!` ONLY. In CLJS production builds, that path is
+;; DCE'd by `goog.DEBUG=false` — flow failures became silent to
+;; corpus-wide error listeners (Sentry / Honeybadger / Rollbar
+;; shippers registered via `register-error-emit-listener!`) and to
+;; the per-frame `:on-error` policy fn. The handler-exception path
+;; (`emit-handler-exception!`) had ALREADY been routed through the
+;; always-on substrate; flow-eval was asymmetric. This test pins the
+;; symmetric routing: a flow-eval throw must surface on the listener
+;; registry record in JVM dev AND survive prod elision in CLJS.
+;; ---------------------------------------------------------------------------
+
+(deftest flow-eval-exception-routes-through-error-emit-substrate
+  (testing "Per rf2-hrt5c: a flow whose :output throws fires a corpus-
+            wide error-emit listener record with `:error
+            :rf.error/flow-eval-exception` — fan-out runs through
+            `error-emit/dispatch-on-error!`, mirroring the handler-
+            exception path."
+    (let [seen (atom [])]
+      (rf/register-error-emit-listener!
+        :test/flow-eval-recorder
+        (fn [record] (swap! seen conj record)))
+      (rf/reg-event-db :init (fn [_ _] {:n 1}))
+      (rf/reg-flow {:id     :boom
+                    :inputs [[:n]]
+                    :output (fn [_] (throw (ex-info "flow boom" {:why :test})))
+                    :path   [:doomed]})
+      (rf/dispatch-sync [:init])
+      (is (= 1 (count @seen))
+          "exactly one substrate record fired for one flow-eval throw")
+      (let [r (first @seen)]
+        (is (= :rf.error/flow-eval-exception (:error r))
+            ":error names the flow-eval path")
+        (is (= [:init]        (:event r))
+            ":event is the in-flight dispatch envelope")
+        (is (= :init          (:event-id r))
+            ":event-id is the dispatched event id")
+        (is (= :rf/default    (:frame r))
+            ":frame is the draining frame")
+        (is (some? (:exception r))
+            ":exception is the thrown Throwable / ex-info")
+        (is (number? (:time r))
+            ":time is wall-clock millis")
+        (is (integer? (:elapsed-ms r))
+            ":elapsed-ms is integer (rf2-ph8pa contract — no float
+             leak from CLJS performance.now())")
+        (is (not (neg? (:elapsed-ms r)))
+            ":elapsed-ms is non-negative")
+        (is (= #{:error :event :event-id :frame :time :exception :elapsed-ms}
+               (set (keys r)))
+            "record carries ONLY the tight rf2-bacs4 keys")))))
+
+(deftest flow-eval-exception-fires-per-frame-on-error-policy
+  (testing "Per rf2-hrt5c: a flow whose :output throws ALSO fires the
+            per-frame `:on-error` policy fn through the substrate.
+            The structured error-event carries `:operation
+            :rf.error/flow-eval-exception` and `:where :flow-eval`
+            so policy fns can discriminate the flow-eval path from
+            the handler-exception path."
+    (let [policy-saw (atom nil)]
+      (rf/reg-frame :rf/default
+                    {:on-error (fn [ev] (reset! policy-saw ev) nil)})
+      (rf/reg-event-db :init (fn [_ _] {:n 1}))
+      (rf/reg-flow {:id     :boom
+                    :inputs [[:n]]
+                    :output (fn [_] (throw (ex-info "flow boom" {})))
+                    :path   [:doomed]})
+      (rf/dispatch-sync [:init])
+      (let [ev @policy-saw]
+        (is (some? ev) ":on-error policy fired for the flow-eval throw")
+        (is (= :rf.error/flow-eval-exception (:operation ev))
+            ":operation names the flow-eval-exception path")
+        (is (= :error (:op-type ev)))
+        (is (= :no-recovery (:recovery ev)))
+        (let [tags (:tags ev)]
+          (is (= :flow-eval (:where tags))
+              ":where :flow-eval distinguishes from :handler-exception")
+          (is (nil? (:handler-id tags))
+              ":handler-id nil — no handler ran; the throw came from
+               the post-commit flow walk")
+          (is (= :init       (:event-id tags)))
+          (is (= [:init]     (:event tags)))
+          (is (= :rf/default (:frame tags)))
+          (is (some? (:exception tags))))))))
+
+(deftest flow-eval-exception-trace-and-substrate-fire-together
+  (testing "Per rf2-hrt5c: the trace path is NOT replaced by the
+            substrate routing — both fire from one normative
+            emission site so dev-time `:rf.error/flow-eval-exception`
+            trace consumers (re-frame-10x, conformance recorders)
+            are unaffected by the substrate addition."
+    (let [trace-saw    (atom nil)
+          listener-saw (atom nil)]
+      (rf/register-error-emit-listener!
+        :test/recorder
+        (fn [record] (reset! listener-saw record)))
+      (trace/register-trace-cb!
+        ::flow-eval-trace-recorder
+        (fn [ev]
+          (when (= :rf.error/flow-eval-exception (:operation ev))
+            (reset! trace-saw ev))))
+      (try
+        (rf/reg-event-db :init (fn [_ _] {:n 1}))
+        (rf/reg-flow {:id     :boom
+                      :inputs [[:n]]
+                      :output (fn [_] (throw (ex-info "boom" {})))
+                      :path   [:doomed]})
+        (rf/dispatch-sync [:init])
+        (is (some? @trace-saw)
+            "trace bus saw `:rf.error/flow-eval-exception` — dev path intact")
+        (is (some? @listener-saw)
+            "corpus-wide listener saw the record — always-on substrate path fired")
+        (is (= :rf.error/flow-eval-exception (:error @listener-saw)))
+        (finally
+          (trace/remove-trace-cb! ::flow-eval-trace-recorder))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 6. End-to-end sample: all five events fire across a typical lifecycle


### PR DESCRIPTION
## Summary

Security-audit follow-up (rf2-itcy9 F2 / rf2-hrt5c). `run-flows!` caught flow throws and called `trace/emit-error!` only — that path is DCE'd under `:advanced` + `goog.DEBUG=false`, so CLJS production builds silently swallowed flow-eval failures. Per-frame `:on-error` policies and corpus-wide error listeners (Sentry / Honeybadger shippers registered via `register-error-emit-listener!`) never saw the record. Asymmetric with the handler-exception path which has routed through the always-on error-emit substrate since rf2-hqbeh / rf2-bacs4.

- `run-flows!` now fans out through `error-emit/dispatch-on-error!` in parallel with the existing trace emit. Trace path preserved verbatim — dev-time consumers (re-frame-10x, conformance recorders) unaffected.
- Substrate record carries `:where :flow-eval` (vs. `:handler-exception`) and `:handler-id nil` so policy fns can discriminate the two origins. `:elapsed-ms` is computed from the cascade `start-ms` already threaded into `commit-and-flow!`, rounded to long at the substrate boundary per rf2-bacs4 / rf2-ph8pa.
- Mirrors `emit-handler-exception!`'s pairing of always-on substrate fan-out with dev-only trace emission.

## Test plan

- [x] `npm run test:cljs` — 2014 tests / 5695 assertions / 0 failures
- [x] `clojure -M:test` from `implementation/flows/` — 58 tests / 223 assertions / 0 failures
- [x] `clojure -M:test` from `implementation/core/` — 543 tests / 2748 assertions / 0 failures
- [x] Three new regression tests in `flows_trace_test.clj` pin: (1) listener registry sees tight record with `:error :rf.error/flow-eval-exception`; (2) per-frame `:on-error` fires with `:where :flow-eval` / `:handler-id nil`; (3) trace and substrate paths fire together (no replacement).