### PR TITLE
chore(tools): build coordinator deps.edn + shadow-cljs.edn (rf2-nuuk3)

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,6 @@
+# rf2-nuuk3 — coordinator-level transient artefacts. shadow-cljs and
+# clojure -X both create caches in cwd; running the tools/-level
+# coordinator from `tools/` lands them here.
+.shadow-cljs/
+.cpcache/
+out/

--- a/tools/README.md
+++ b/tools/README.md
@@ -60,9 +60,19 @@ Each `deps.edn` carries a `:local/root` dep on `../../implementation/core`
 (plus whichever per-feature artefacts the tool legitimately consumes).
 Each tool publishes to Clojars under `day8/re-frame2-<tool>`.
 
-A top-level `tools/deps.edn` and `tools/shadow-cljs.edn` may appear later
-as build coordinators (matching the pattern in `implementation/`) once
-there's more than one tool to coordinate. Not needed yet.
+A top-level `tools/deps.edn` and `tools/shadow-cljs.edn` (rf2-nuuk3) act
+as build coordinators across the tool tier, matching the pattern in
+`implementation/`. `tools/deps.edn` declares each tool as a `:local/root`
+dep and exposes a `:test` alias that aggregates every JVM-runnable
+tool's `test/` tree; running `clojure -M:test` from `tools/` exercises
+the aggregated suite. `tools/shadow-cljs.edn` mirrors the per-tool CLJS
+builds (today: `pair2-mcp/server` and `pair2-mcp/server-test`) so
+`shadow-cljs compile <build>` works from `tools/` as well as from each
+tool's directory. Per-tool invocations remain valid — the coordinators
+compose the per-tool builds, they do not replace them. CLJS-only tools
+(`causa`) and JVM-only tools whose sources contain placeholder-bearing
+template files (`template`) are excluded from the shadow-cljs surface
+for technical reasons documented in the coordinator's comment block.
 
 ## Shipped
 

--- a/tools/deps.edn
+++ b/tools/deps.edn
@@ -1,0 +1,90 @@
+;; Top-level tools coordinator (rf2-nuuk3).
+;;
+;; The published artefacts are
+;;   - causa/       (day8/re-frame2-causa)
+;;   - mcp-base/    (day8/re-frame2-mcp-base)
+;;   - pair2-mcp/   (@day8/re-frame-pair2-mcp, npm only)
+;;   - story/       (day8/re-frame2-story)
+;;   - story-mcp/   (day8/re-frame2-story-mcp)
+;;   - template/    (day8/clj-template.re-frame2)
+;; see tools/causa/deps.edn, tools/mcp-base/deps.edn,
+;; tools/pair2-mcp/deps.edn, tools/story/deps.edn,
+;; tools/story-mcp/deps.edn, and tools/template/deps.edn.
+;;
+;; Other tool directories (causa-mcp/, machines-viz/, machines-viz-mcp/,
+;; mcp-conformance/) are spec-only or Node-only today — no `deps.edn` /
+;; CLJ surface to coordinate. They will be added here when their `src/`
+;; trees land. The Node-side `tools/mcp-conformance/wire-vocab/deps.edn`
+;; is a self-contained JVM conformance test; it is run from its own
+;; directory and is not coordinated here.
+;;
+;; This top-level deps.edn is *not* itself a published artefact — it is
+;; the build coordinator that pulls every tool artefact onto a single
+;; classpath for aggregate test runs and for the shadow-cljs builds (see
+;; tools/shadow-cljs.edn) that exercise pair2-mcp end-to-end. Per-tool
+;; JVM tests run via the per-tool deps.edn directly.
+;;
+;; ## Why template is NOT in the base :deps map
+;;
+;; `tools/template/` ships clj-new templates — its `src/` tree contains
+;; placeholder-bearing `.cljs` template files (e.g. `(ns {{namespace}}...)`
+;; in src/clj/new/re_frame2/shared/events_test.cljs) that are NOT valid
+;; ClojureScript. Adding `day8/clj-template.re-frame2` to the base `:deps`
+;; map would put those files on the shadow-cljs classpath; shadow-cljs
+;; would try to compile them and fail at the read-loop. The template dep
+;; therefore lives ONLY on the `:test` alias, which runs on the JVM
+;; where the .cljs templates are treated as plain resources.
+;;
+;; ## Bundle-isolation
+;;
+;; This file does NOT change the tool→implementation dependency arrow
+;; (see tools/README.md §The bundle-isolation contract). It only widens
+;; the *coordinator's* classpath; nothing under implementation/ may
+;; :require anything under tools/.
+{:paths []
+ :deps  {day8/re-frame2-causa     {:local/root "causa"}
+         day8/re-frame2-mcp-base  {:local/root "mcp-base"}
+         day8/re-frame-pair2-mcp  {:local/root "pair2-mcp"}
+         day8/re-frame2-story     {:local/root "story"}
+         day8/re-frame2-story-mcp {:local/root "story-mcp"}}
+
+ :aliases
+ {;; Aggregate JVM-side test run across every tool whose tests are
+  ;; runnable on the JVM (mcp-base, story, story-mcp, template). Useful
+  ;; for ad-hoc REPL work and as a single-command sanity check across
+  ;; the tool tier. Production CI runs each tool's :test alias
+  ;; separately (per-tool gates).
+  ;;
+  ;; Note on coverage gaps:
+  ;;   - tools/causa/ — CLJS-side only (DOM + Reagent shell). Its tests
+  ;;     run under the implementation/shadow-cljs.edn :node-test build,
+  ;;     not on the JVM.
+  ;;   - tools/pair2-mcp/ — CLJS Node-script. Its tests run under
+  ;;     tools/pair2-mcp/shadow-cljs.edn :server-test (mirrored in
+  ;;     tools/shadow-cljs.edn).
+  :test
+  {:extra-deps  {;; template lives on the JVM-only path — see the
+                 ;; "Why template is NOT in the base :deps map" block
+                 ;; above for the shadow-cljs incompatibility.
+                 day8/clj-template.re-frame2
+                 {:local/root "template"}
+                 ;; rf2-try1x — silent-on-success reporter.
+                 day8/re-frame2-test-quiet
+                 {:local/root "../implementation/test-quiet"}
+                 io.github.cognitect-labs/test-runner
+                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+   :extra-paths ["mcp-base/test"
+                 "story/test"
+                 "story-mcp/test"
+                 "template/test"]
+   ;; The `-d` args are necessary because cognitect.test-runner's
+   ;; default `--dir` is "test" (relative to cwd) — without explicit
+   ;; dir flags the runner scans `tools/test/` and finds nothing. The
+   ;; aggregated build needs one `-d` per per-tool test path. Per-tool
+   ;; `:test` aliases keep their default invocation (a single
+   ;; `test/` path relative to the tool's own deps.edn).
+   :main-opts   ["-m" "re-frame.test-quiet.runner"
+                 "-d" "mcp-base/test"
+                 "-d" "story/test"
+                 "-d" "story-mcp/test"
+                 "-d" "template/test"]}}}

--- a/tools/shadow-cljs.edn
+++ b/tools/shadow-cljs.edn
@@ -1,0 +1,71 @@
+;; Top-level tools shadow-cljs build (rf2-nuuk3).
+;;
+;; Mirrors the role of tools/deps.edn for CLJS builds. Today the only
+;; tool with a shadow-cljs surface is tools/pair2-mcp/ (compiled to a
+;; Node script published on npm as `@day8/re-frame-pair2-mcp`); the
+;; other tools are either JVM-only (mcp-base, story, story-mcp,
+;; template) or CLJS-but-built-from-implementation/shadow-cljs.edn
+;; (causa — its tests run under the implementation's :node-test build).
+;;
+;; This coordinator aggregates pair2-mcp's `:server` and `:server-test`
+;; builds at the tools/ root so the npm-side `shadow-cljs compile
+;; <build>` invocation works from `tools/` as well as from
+;; `tools/pair2-mcp/`. Builds are namespaced under
+;; `pair2-mcp/<name>` so future tool builds (e.g. `causa/<name>` when
+;; Causa gains its own CLJS surface separate from the implementation
+;; build) can land alongside without name collisions.
+;;
+;; `:deps true` routes classpath resolution through tools/deps.edn —
+;; same mechanism pair2-mcp's per-tool shadow-cljs.edn uses (rf2-obpa9).
+;; Per-tool `:source-paths` live in each tool's deps.edn `:paths`; under
+;; `:deps true` shadow-cljs warns and ignores any `:source-paths` here,
+;; so the slot is intentionally absent. pair2-mcp/test is on the
+;; classpath via pair2-mcp/deps.edn `:paths ["src" "test"]` already.
+;;
+;; Per-tool builds remain runnable from each tool's own directory —
+;; this coordinator does not replace them; it composes them.
+;;
+;; ## Output paths
+;;
+;; `:output-to` points at `pair2-mcp/out/server.js` (relative to
+;; tools/), the same on-disk artefact the per-tool build produces. Both
+;; invocation paths (from tools/ vs from tools/pair2-mcp/) drop into
+;; the same `tools/pair2-mcp/out/` directory, and the npm `bin` entry
+;; in tools/pair2-mcp/package.json points at `./out/server.js` either
+;; way.
+;;
+;; ## Why template is invisible here
+;;
+;; `tools/template/` is JVM-only (clj-new template) — its `src/` tree
+;; contains placeholder-bearing `.cljs` template files that are NOT
+;; valid ClojureScript. The template dep is excluded from
+;; tools/deps.edn's base `:deps` map for that reason (see the comment
+;; block in tools/deps.edn). With `:deps true` active, shadow-cljs only
+;; sees what the base `:deps` map exposes, so the template's
+;; placeholder-bearing files never reach the shadow-cljs reader.
+{:deps true
+
+ :builds
+ {;; Production build (the Node MCP server). Mirrors the per-tool
+  ;; tools/pair2-mcp/shadow-cljs.edn `:server` build verbatim; see
+  ;; that file for the :closure-defines rationale.
+  :pair2-mcp/server
+  {:target    :node-script
+   :output-to "pair2-mcp/out/server.js"
+   :main      re-frame-pair2-mcp.server/main
+   :compiler-options
+   {:optimizations  :simple
+    :closure-defines
+    {re-frame.mcp-base.diff-encode/validate-patches? false}}}
+
+  ;; Node-test build (unit tests for the MCP server). Mirrors the
+  ;; per-tool `:server-test` build. The reporter ns
+  ;; (`re-frame.test-quiet.shadow-node`) is on the classpath via the
+  ;; `day8/re-frame2-test-quiet` :local/root pulled in transitively
+  ;; from pair2-mcp/deps.edn.
+  :pair2-mcp/server-test
+  {:target    :node-test
+   :output-to "pair2-mcp/out/server-test.js"
+   :ns-regexp "-test$"
+   :autorun   true
+   :main      re-frame.test-quiet.shadow-node/main}}}


### PR DESCRIPTION
## Summary

Scaffold top-level `tools/deps.edn` + `tools/shadow-cljs.edn` matching the coordinator pattern in `implementation/`. Five tool directories with `deps.edn` now exist (`causa`, `mcp-base`, `pair2-mcp`, `story`, `story-mcp`, `template`) — the threshold `tools/README.md` anticipated is crossed.

- **`tools/deps.edn`** declares each tool as a `:local/root` dep and exposes a `:test` alias aggregating every JVM-runnable tool's `test/` tree. From `tools/`, `clojure -M:test` runs **646 tests / 2281 assertions, 0 failures** across `mcp-base`, `story`, `story-mcp`, and `template`. `causa` is CLJS-only (its tests run under `implementation/shadow-cljs.edn`'s `:node-test` build) and `pair2-mcp` is a CLJS Node-script — both covered by shadow-cljs below.
- **`tools/shadow-cljs.edn`** mirrors `pair2-mcp`'s `:server` and `:server-test` builds at the coordinator level so `shadow-cljs compile <build>` works from `tools/` as well as from each tool's own directory. Builds are namespaced under `pair2-mcp/<name>` so future tool builds (e.g. `causa/<name>`) can land alongside without collisions. Verified: `shadow-cljs compile pair2-mcp/server` and `pair2-mcp/server-test` both build cleanly; the test build's autorun runs **438 tests / 1073 assertions, 0 failures**.
- **`tools/template` is JVM-only** (clj-new template with `{{namespace}}` placeholders in its `.cljs` sources). Lives on the `:test` alias's `:extra-deps` so the base `:deps` map stays shadow-cljs safe — comment block in the coordinator explains the rationale.
- **`tools/.gitignore`** covers the transient `.shadow-cljs/`, `.cpcache/`, `out/` caches the coordinators create at `tools/` root.
- **`tools/README.md` §Per-tool layout**: removed the "may appear later" caveat; documented the coordinator usage.

Per-tool invocations remain valid — the coordinators compose the per-tool builds, they do not replace them.

## Test plan

- [x] `cd tools && clojure -M:test` — 646 tests, 2281 assertions, 0 failures, 0 errors.
- [x] `cd tools && npx --prefix pair2-mcp shadow-cljs compile pair2-mcp/server` — clean build.
- [x] `cd tools && npx --prefix pair2-mcp shadow-cljs compile pair2-mcp/server-test` — 438 tests, 1073 assertions, 0 failures, 0 errors (autorun).
- [x] Per-tool invocations still work (sanity-checked `cd tools/story && clojure -M:test` — 406 tests pre-coordinator, unchanged).