### PR TITLE
feat(story): facet tag taxonomy (rf2-7ncf9)

### DIFF
--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -372,6 +372,29 @@
   tags. Stable across hosts."
   schemas/canonical-tags)
 
+(def canonical-axes
+  "Re-export of the four canonical facet axes documented in spec/001
+  §reg-tag — `:status`, `:role`, `:team`, `:feature` (rf2-7ncf9 SB9
+  facet taxonomy). Stable across hosts."
+  schemas/canonical-axes)
+
+(def canonical-status-values
+  "Re-export of the recommended `:status` axis vocabulary."
+  schemas/canonical-status-values)
+
+(def canonical-role-values
+  "Re-export of the recommended `:role` axis vocabulary."
+  schemas/canonical-role-values)
+
+(defn tag->axis-index
+  "Per spec/001 §reg-tag — return a `{tag-id → axis-kw}` map across
+  every registered tag, in one O(T) pass. Tags without `:axis` map to
+  `:re-frame.story.registrar/no-axis`. The sidebar's facet-grouped
+  filter row + the `:tag-filter` AND-across-axes predicate (rf2-7ncf9)
+  consume this."
+  []
+  (registrar/tag->axis-index))
+
 ;; ---- programmatic registration surface -----------------------------------
 ;;
 ;; Per IMPL-SPEC §4.9 the `*`-suffix runtime helpers are public for

--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -461,3 +461,35 @@
   any of these at boot (e.g. `:internal` / `:experimental`)."
   []
   (query-tags-by #(= :exclude (:default-filter %))))
+
+;; ---- faceted tag-filter helpers (rf2-7ncf9) ------------------------------
+
+(def ^:private no-axis-key
+  "Sentinel axis key for tags that have no `:axis` slot. Lives in
+  this ns so the sidebar AND the filter logic name the same bucket
+  without coupling either to the other."
+  ::no-axis)
+
+(defn tag->axis
+  "Pure data → data: return the `:axis` keyword on the registered tag
+  body for `tag-id`, or `::no-axis` if the tag is registered without
+  one. Returns `::no-axis` for unregistered tags too — they're treated
+  as un-grouped from the filter UI's perspective.
+
+  This is the per-tag lookup; `tag->axis-index` builds the full map in
+  one pass over the tag side-table for callers that need it across
+  many tags."
+  [tag-id]
+  (or (:axis (handler-meta :tag tag-id))
+      no-axis-key))
+
+(defn tag->axis-index
+  "Pure data → data: build the `{tag-id → axis-kw}` index across every
+  registered tag in one O(T) pass. Tags without `:axis` map to
+  `::no-axis`. Used by the sidebar's facet-grouped filter row + the
+  `state/variant-tag-match?` AND-across-axes predicate (rf2-7ncf9)."
+  []
+  (reduce-kv (fn [acc tid body]
+               (assoc acc tid (or (:axis body) no-axis-key)))
+             {}
+             (handlers :tag)))

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -118,6 +118,51 @@
   `:rf.error/unknown-tag` at registration."
   #{:dev :docs :test :screenshot :experimental :internal :agent})
 
+;; ---- canonical facet axes (rf2-7ncf9 — SB9 facet taxonomy) ---------------
+
+(def canonical-axes
+  "Pure data → data: the four canonical facet axes Story documents for
+  the sidebar tag-filter UI. Mirrors Storybook 9's status / role /
+  team / feature axes (rf2-v05qb SB9 parity).
+
+  Two axes ship with a recommended vocabulary:
+
+  - `:status` → `#{:alpha :beta :stable :deprecated}` — release maturity.
+  - `:role`   → `#{:design :dev :product}` — audience role.
+
+  Two axes are user-extensible (no canonical enum):
+
+  - `:team`    — owning team / squad / regression-set.
+  - `:feature` — feature / product area.
+
+  The recommended vocabularies are NOT enforced by the schema —
+  `:status` may carry any keyword the project registers. They exist as
+  a discoverable convention so multiple projects converge on the same
+  shape without further coordination.
+
+  The preferred faceted-tag shape is the namespaced keyword:
+  `:status/alpha`, `:role/dev`, `:team/checkout`, `:feature/payment` —
+  the namespace mirrors the `:axis` slot, the name is the value. This
+  is lighter than wrapping tags in maps and survives EDN round-trip
+  without ceremony."
+  {:status  {:user-extensible? false
+             :values           #{:alpha :beta :stable :deprecated}}
+   :role    {:user-extensible? false
+             :values           #{:design :dev :product}}
+   :team    {:user-extensible? true}
+   :feature {:user-extensible? true}})
+
+(def canonical-status-values
+  "The recommended `:status` axis vocabulary — release-maturity values
+  Storybook 9 documents. Projects MAY use other status keywords; the
+  schema does not enforce membership."
+  (get-in canonical-axes [:status :values]))
+
+(def canonical-role-values
+  "The recommended `:role` axis vocabulary — audience roles Storybook 9
+  documents. Projects MAY use other role keywords."
+  (get-in canonical-axes [:role :values]))
+
 ;; ---- shared shapes --------------------------------------------------------
 
 (def EventVector

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -6,6 +6,15 @@
   the shell state's `:selected-variant`. Workspaces register below the
   story tree.
 
+  ## Faceted tag-filter (rf2-7ncf9 — SB9 parity)
+
+  Registered tags with an `:axis` slot (e.g. `:status/alpha` carrying
+  `:axis :status`) render in per-axis chip rows. The filter applies
+  **AND across axes** + **OR within an axis** — activating
+  `:status/stable` AND `:role/design` narrows to variants carrying
+  BOTH a `:status` match AND a `:role` match. Tags with no `:axis`
+  render in a trailing un-grouped row.
+
   ## Layout
 
       ┌──────────────────────┐
@@ -44,8 +53,10 @@
   `:docs`, `:test`, `:screenshot`, `:experimental`, `:internal`,
   `:agent`); unknown tags fall back to a neutral grey. The badges are
   inert (the filter row owns interaction) — purely a scan affordance."
-  (:require [re-frame.story.runtime           :as runtime]
+  (:require [clojure.string                   :as str]
+            [re-frame.story.runtime           :as runtime]
             [re-frame.story.async             :as async]
+            [re-frame.story.registrar         :as registrar]
             [re-frame.story.ui.sidebar-styles :refer [styles]]
             [re-frame.story.ui.state          :as state]))
 
@@ -64,6 +75,10 @@
        set
        sort
        vec))
+
+;; `group-tags-by-axis` and `ordered-axes` are pure data → data leaves
+;; — they live in `re-frame.story.ui.state` so the JVM test corpus can
+;; exercise them without booting Reagent (rf2-7ncf9).
 
 ;; ---- pure: per-variant status dot (rf2-q0irb) ---------------------------
 
@@ -118,20 +133,62 @@
 
 ;; ---- components ----------------------------------------------------------
 
+(defn- axis-label-text
+  "Pure data → data: render an axis keyword as the upper-case label
+  text shown above its chip row. The `:re-frame.story.registrar/no-axis`
+  sentinel renders as `OTHER`."
+  [axis]
+  (if (= axis :re-frame.story.registrar/no-axis)
+    "OTHER"
+    (str/upper-case (name axis))))
+
+(defn- tag-chip
+  [tag active?]
+  ^{:key tag}
+  [:span {:style       (merge (:tag styles)
+                              (when active? (:tag-active styles)))
+          :data-test   "story-sidebar-tag-chip"
+          :data-tag    (str tag)
+          :data-active (str (boolean active?))
+          :on-click    (fn [_] (state/swap-state!
+                                 state/toggle-tag-filter tag))}
+   (str tag)])
+
+(defn- axis-row
+  "Render one axis's labelled chip row. The label is rendered above
+  the chips so axes wrap onto multiple lines on narrow viewports."
+  [axis tags tag-filter]
+  ^{:key axis}
+  [:div {:style       (:axis-row styles)
+         :data-test   "story-sidebar-axis-row"
+         :data-axis   (name axis)}
+   [:span {:style     (:axis-label styles)
+           :data-test "story-sidebar-axis-label"}
+    (axis-label-text axis)]
+   [:div {:style (:axis-chips styles)}
+    (for [tag tags]
+      (tag-chip tag (contains? tag-filter tag)))]])
+
 (defn- tag-filter-row
+  "Faceted filter (rf2-7ncf9). Tags are grouped by their registered
+  `:axis` slot — one labelled chip row per axis (`:status`, `:role`,
+  `:team`, `:feature`, then any project-defined axes alphabetically,
+  with un-axis-grouped tags trailing in an `OTHER` row).
+
+  Active chips highlight; the AND-across / OR-within rule lives in
+  `state/variant-tag-match?`."
   [variants tag-filter]
   (let [all-tags (collect-tags variants)]
-    [:div {:style (:tag-row styles)}
-     (if (empty? all-tags)
-       [:span {:style (:empty styles)} "no tags"]
-       (for [tag all-tags]
-         ^{:key tag}
-         [:span {:style    (merge (:tag styles)
-                                  (when (contains? tag-filter tag)
-                                    (:tag-active styles)))
-                 :on-click (fn [_] (state/swap-state!
-                                     state/toggle-tag-filter tag))}
-          (str tag)]))]))
+    (if (empty? all-tags)
+      [:div {:style (:tag-row styles)}
+       [:span {:style (:empty styles)} "no tags"]]
+      (let [tag->axis (registrar/tag->axis-index)
+            by-axis   (state/group-tags-by-axis all-tags tag->axis)
+            axes      (state/ordered-axes by-axis)]
+        [:div {:style       (:tag-row styles)
+               :data-test   "story-sidebar-tag-filter"}
+         (for [axis axes]
+           (axis-row axis (get by-axis axis) tag-filter))]))))
 
 (defn status-dot
   "Render the per-variant status glyph. Variants not in `[:tests :runs]`
@@ -403,7 +460,13 @@
         tag-filter      (:tag-filter shell)
         sel-variant     (:selected-variant shell)
         sel-ws          (:selected-workspace shell)
-        visible         (state/filter-variants (:variants registry) tag-filter)
+        ;; rf2-7ncf9 — faceted filter: AND across axes, OR within.
+        ;; The axis-index reads from the tag registrar; passing it to
+        ;; `filter-variants` activates the 3-arity facet-aware form.
+        tag->axis       (registrar/tag->axis-index)
+        visible         (state/filter-variants (:variants registry)
+                                               tag-filter
+                                               tag->axis)
         grouped         (state/group-variants-by-story visible)
         workspaces      (:workspaces registry)
         test-runs       (get-in shell [:tests :runs])

--- a/tools/story/src/re_frame/story/ui/sidebar_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar_styles.cljs
@@ -32,10 +32,22 @@
                   :font-size "10px"
                   :letter-spacing "0.5px"}
    :tag-row      {:display "flex"
-                  :flex-wrap "wrap"
-                  :gap "4px"
+                  :flex-direction "column"
+                  :gap "6px"
                   :padding "8px 12px"
                   :border-bottom "1px solid #333"}
+   ;; rf2-7ncf9 — faceted tag-filter: one labelled chip row per axis.
+   :axis-row     {:display "flex"
+                  :flex-direction "column"
+                  :gap "3px"}
+   :axis-label   {:font-size "9px"
+                  :color "#9a9a9a"
+                  :letter-spacing "0.5px"
+                  :text-transform "uppercase"
+                  :font-weight "bold"}
+   :axis-chips   {:display "flex"
+                  :flex-wrap "wrap"
+                  :gap "4px"}
    :tag          {:padding "2px 6px"
                   :background "#37373d"
                   :color "#cccccc"

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -302,24 +302,125 @@
 
 ;; ---- pure derivations ----------------------------------------------------
 
+(defn group-tags-by-axis
+  "Pure data → data: split a seq of tags into `{axis-kw → [tag …]}`
+  using `tag->axis` (a `{tag-id → axis-kw}` map). Each per-axis
+  vector is sorted by `name` so the chip layout is stable across
+  re-renders. Tags missing from `tag->axis` land under
+  `:re-frame.story.registrar/no-axis` (the same sentinel
+  `registrar/tag->axis` returns for un-axis-grouped tags).
+
+  rf2-7ncf9 — faceted tag-filter UI. The sidebar's filter row walks
+  this result to render one labelled chip row per axis."
+  [tags tag->axis]
+  (->> tags
+       (reduce (fn [acc t]
+                 (let [axis (get tag->axis t :re-frame.story.registrar/no-axis)]
+                   (update acc axis (fnil conj []) t)))
+               {})
+       (reduce-kv (fn [acc axis ts]
+                    (assoc acc axis (vec (sort-by name ts))))
+                  {})))
+
+(def axis-display-order
+  "Pure data → data: the canonical chip-row order. Mirrors spec/001
+  §reg-tag's documented facet axes — `:status` first, then `:role`,
+  `:team`, `:feature`, then any project-defined axes (alphabetical),
+  with the no-axis bucket last."
+  [:status :role :team :feature])
+
+(defn ordered-axes
+  "Pure data → data: return the axes present in `by-axis` (a
+  `{axis-kw → [tag …]}` map) in stable display order. Canonical axes
+  appear first in `axis-display-order`; project-defined axes follow
+  alphabetically; the no-axis sentinel is always last."
+  [by-axis]
+  (let [present       (set (keys by-axis))
+        canonical     (filter present axis-display-order)
+        extras        (->> present
+                           (remove (set axis-display-order))
+                           (remove #{:re-frame.story.registrar/no-axis})
+                           (sort-by name))
+        trailing      (when (contains? present
+                                       :re-frame.story.registrar/no-axis)
+                        [:re-frame.story.registrar/no-axis])]
+    (vec (concat canonical extras trailing))))
+
+(defn partition-tag-filter-by-axis
+  "Pure data → data: split a `tag-filter` set into `{axis-kw → #{tag …}}`
+  using `tag->axis` (a `{tag-id → axis-kw}` map; see
+  `registrar/tag->axis-index`). Tags missing from `tag->axis` are
+  bucketed under `:re-frame.story.registrar/no-axis` — the same
+  sentinel `registrar/tag->axis` returns for un-axis-grouped tags. The
+  faceted-filter predicate (`variant-tag-match?`) consumes the result.
+
+  Faceted-filter semantics (rf2-7ncf9, SB9 parity): AND across axes,
+  OR within an axis. Partitioning is the first half — the predicate
+  enforces the AND-across rule by requiring every per-axis subset to
+  intersect the variant's `:tags`."
+  [tag-filter tag->axis]
+  (reduce (fn [acc tag]
+            (let [axis (get tag->axis tag :re-frame.story.registrar/no-axis)]
+              (update acc axis (fnil conj #{}) tag)))
+          {}
+          tag-filter))
+
 (defn variant-tag-match?
-  "True iff `variant-body`'s `:tags` set intersects the `tag-filter`,
-  or the filter is empty. Bare-bones inclusion-tag logic per spec/007
-  §Inclusion tags. Stage 4 ignores the `:!`-prefix removal syntax —
-  that's resolved at registration time in `re-frame.story.registrar`
-  via `validate-tag-membership!`."
-  [variant-body tag-filter]
-  (or (empty? tag-filter)
-      (let [tset (or (:tags variant-body) #{})]
-        (some #(contains? tset %) tag-filter))))
+  "True iff `variant-body`'s `:tags` set satisfies the `tag-filter`.
+
+  Faceted filter semantics (rf2-7ncf9 SB9 parity):
+
+  - **OR within an axis** — if the filter activates `:status/alpha`
+    AND `:status/beta`, a variant tagged with either passes that
+    axis.
+  - **AND across axes** — activating `:status/stable` AND `:role/design`
+    narrows to variants carrying BOTH a `:status`-axis match AND a
+    `:role`-axis match.
+  - Tags without an `:axis` slot form a synthetic
+    `:re-frame.story.registrar/no-axis` pseudo-axis with the same
+    OR-within rule.
+  - Empty filter → every variant passes (Stage-4 behaviour preserved).
+
+  The pure 2-arity (without `tag->axis`) keeps the legacy OR-only
+  semantics so existing callers that don't have an axis-index handy
+  (tests, downstream tools) keep working. The 3-arity is the
+  facet-aware form the sidebar uses.
+
+  Stage 4 ignores the `:!`-prefix removal syntax — that's resolved at
+  registration time in `re-frame.story.registrar` via
+  `validate-tag-membership!`."
+  ([variant-body tag-filter]
+   (or (empty? tag-filter)
+       (let [tset (or (:tags variant-body) #{})]
+         (some #(contains? tset %) tag-filter))))
+  ([variant-body tag-filter tag->axis]
+   (or (empty? tag-filter)
+       (let [tset       (or (:tags variant-body) #{})
+             per-axis   (partition-tag-filter-by-axis tag-filter tag->axis)]
+         ;; Every axis bucket must intersect the variant's tag set
+         ;; (AND across axes; OR within an axis).
+         (every? (fn [[_ active-on-axis]]
+                   (some #(contains? tset %) active-on-axis))
+                 per-axis)))))
 
 (defn filter-variants
   "Return the subset of `id->body` whose `:tags` match the filter.
-  Pure data → data; JVM-testable."
-  [id->body tag-filter]
-  (into {}
-        (filter (fn [[_ body]] (variant-tag-match? body tag-filter)))
-        id->body))
+  Pure data → data; JVM-testable.
+
+  The 2-arity preserves legacy OR-across-tags semantics. The 3-arity
+  takes a `tag->axis` map (see `registrar/tag->axis-index`) and
+  applies the faceted AND-across / OR-within rule (rf2-7ncf9). The
+  sidebar calls the 3-arity with a registrar-derived axis-index; the
+  legacy 2-arity stays for the bare-data callers that don't carry
+  registrar context."
+  ([id->body tag-filter]
+   (into {}
+         (filter (fn [[_ body]] (variant-tag-match? body tag-filter)))
+         id->body))
+  ([id->body tag-filter tag->axis]
+   (into {}
+         (filter (fn [[_ body]] (variant-tag-match? body tag-filter tag->axis)))
+         id->body)))
 
 (def parent-story-id
   "Cheap parent-story derivation. Canonical definition lives in

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -200,6 +200,131 @@
     (is (= :story.foo (state/parent-story-id :story.foo/bar)))
     (is (nil? (state/parent-story-id :unqualified)))))
 
+;; ---- faceted filter (rf2-7ncf9 — SB9 facet taxonomy) -------------------
+
+(deftest partition-tag-filter-by-axis-bucketed
+  (testing "partition splits the filter set into per-axis buckets"
+    (let [tag->axis {:status/alpha   :status
+                     :status/beta    :status
+                     :role/dev       :role
+                     :team/checkout  :team}]
+      (is (= {:status #{:status/alpha :status/beta}
+              :role   #{:role/dev}}
+             (state/partition-tag-filter-by-axis
+               #{:status/alpha :status/beta :role/dev}
+               tag->axis))))
+    (testing "tags missing from tag->axis bucket under ::no-axis"
+      (is (= {:re-frame.story.registrar/no-axis #{:dev}
+              :status                           #{:status/alpha}}
+             (state/partition-tag-filter-by-axis
+               #{:dev :status/alpha}
+               {:status/alpha :status}))))))
+
+(deftest variant-tag-match?-faceted-and-across-or-within
+  (testing "OR within an axis (faceted)"
+    (let [tag->axis {:status/alpha :status :status/beta :status
+                     :status/stable :status}
+          variant   {:tags #{:status/alpha :role/dev}}]
+      ;; alpha OR beta active — variant has alpha → passes
+      (is (state/variant-tag-match? variant #{:status/alpha :status/beta} tag->axis))
+      ;; stable active — variant has neither → fails
+      (is (not (state/variant-tag-match? variant #{:status/stable} tag->axis)))))
+  (testing "AND across axes (faceted)"
+    (let [tag->axis  {:status/stable :status :role/design :role :role/dev :role}
+          designer-stable {:tags #{:status/stable :role/design}}
+          dev-stable      {:tags #{:status/stable :role/dev}}]
+      ;; status+role both required; designer-stable matches
+      (is (state/variant-tag-match? designer-stable
+                                    #{:status/stable :role/design}
+                                    tag->axis))
+      ;; dev-stable has :status/stable but not :role/design → fails
+      (is (not (state/variant-tag-match? dev-stable
+                                         #{:status/stable :role/design}
+                                         tag->axis)))))
+  (testing "empty filter passes every variant"
+    (is (state/variant-tag-match? {:tags #{:status/alpha}} #{} {:status/alpha :status})))
+  (testing "no-axis tags share a synthetic bucket with OR semantics"
+    ;; Two un-axis-grouped tags share the ::no-axis bucket — OR-within
+    ;; means a variant carrying either passes.
+    (let [variant {:tags #{:dev}}]
+      (is (state/variant-tag-match? variant #{:dev :docs} {}))
+      (is (not (state/variant-tag-match? variant #{:docs :test} {}))))))
+
+(deftest filter-variants-faceted
+  (testing "filter-variants/3 applies AND-across, OR-within"
+    (story/reg-tag :status/alpha  {:axis :status})
+    (story/reg-tag :status/stable {:axis :status})
+    (story/reg-tag :role/dev      {:axis :role})
+    (story/reg-tag :role/design   {:axis :role})
+    (story/reg-variant :story.facet/a
+      {:tags #{:status/alpha :role/dev} :events []})
+    (story/reg-variant :story.facet/b
+      {:tags #{:status/stable :role/dev} :events []})
+    (story/reg-variant :story.facet/c
+      {:tags #{:status/stable :role/design} :events []})
+    (let [vs        (story-registrar/handlers :variant)
+          tag->axis (story-registrar/tag->axis-index)]
+      (testing "OR-within status — alpha OR stable returns all three"
+        (is (= 3 (count (state/filter-variants
+                          vs #{:status/alpha :status/stable} tag->axis)))))
+      (testing "AND-across — status/stable AND role/design narrows to one"
+        (let [filtered (state/filter-variants
+                         vs #{:status/stable :role/design} tag->axis)]
+          (is (= 1 (count filtered)))
+          (is (contains? filtered :story.facet/c))))
+      (testing "status/stable alone keeps both stables"
+        (let [filtered (state/filter-variants
+                         vs #{:status/stable} tag->axis)]
+          (is (= 2 (count filtered)))
+          (is (contains? filtered :story.facet/b))
+          (is (contains? filtered :story.facet/c)))))))
+
+(deftest group-tags-by-axis-buckets-and-sorts
+  (testing "group-tags-by-axis splits a tag seq into per-axis vectors"
+    (let [tag->axis {:status/alpha   :status
+                     :status/stable  :status
+                     :role/dev       :role
+                     :loose/freeform :re-frame.story.registrar/no-axis}
+          tags     [:status/alpha :role/dev :status/stable :loose/freeform :unregistered]
+          grouped  (state/group-tags-by-axis tags tag->axis)]
+      ;; Each axis bucket is a sorted vector for stable rendering
+      (is (= [:status/alpha :status/stable] (:status grouped)))
+      (is (= [:role/dev]                    (:role grouped)))
+      ;; The :re-frame.story.registrar/no-axis bucket catches both
+      ;; explicit no-axis tags and unregistered ones.
+      (is (= [:loose/freeform :unregistered]
+             (:re-frame.story.registrar/no-axis grouped))))))
+
+(deftest ordered-axes-canonical-then-extras-then-no-axis
+  (testing "canonical axes go first, project-defined alphabetical, no-axis last"
+    (let [by-axis {:status                              [:s/a]
+                   :role                                [:r/x]
+                   :zeta                                [:z/x]
+                   :alpha                               [:a/x]
+                   :re-frame.story.registrar/no-axis    [:loose]}]
+      (is (= [:status :role :alpha :zeta
+              :re-frame.story.registrar/no-axis]
+             (state/ordered-axes by-axis)))))
+  (testing "missing canonical axes are skipped, no-axis still trails"
+    (is (= [:status :re-frame.story.registrar/no-axis]
+           (state/ordered-axes
+             {:status                              [:s/a]
+              :re-frame.story.registrar/no-axis    [:loose]})))))
+
+(deftest tag->axis-index-roundtrip
+  (testing "tag->axis-index maps every registered tag to its :axis"
+    (story/reg-tag :status/stable {:axis :status})
+    (story/reg-tag :role/dev      {:axis :role})
+    (story/reg-tag :team/checkout {:axis :team})
+    (story/reg-tag :loose/freeform {:doc "no axis"})
+    (let [idx (story-registrar/tag->axis-index)]
+      (is (= :status                              (get idx :status/stable)))
+      (is (= :role                                (get idx :role/dev)))
+      (is (= :team                                (get idx :team/checkout)))
+      (is (= :re-frame.story.registrar/no-axis    (get idx :loose/freeform)))
+      ;; Canonical tags are pre-registered without :axis
+      (is (= :re-frame.story.registrar/no-axis    (get idx :dev))))))
+
 ;; ---- workspace resolver --------------------------------------------------
 
 (deftest grid-layout

--- a/tools/story/testbeds/counter_with_stories/stories.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories.cljs
@@ -75,6 +75,20 @@
     {:doc "Tag applied to the variant that ships as the example's
           canonical screenshot — the one the README points at."})
 
+  ;; rf2-7ncf9 — faceted tag taxonomy (SB9 parity). Tags carrying an
+  ;; `:axis` slot group into per-axis chip rows in the sidebar filter.
+  ;; The filter applies AND across axes + OR within an axis. The
+  ;; preferred shape is the namespaced keyword (`:status/stable`,
+  ;; `:role/dev`, `:team/checkout`, `:feature/counter`) — the
+  ;; namespace mirrors the axis, the name is the value.
+  (story/reg-tag :status/alpha    {:axis :status :doc "Pre-release."})
+  (story/reg-tag :status/stable   {:axis :status :doc "Production-ready."})
+  (story/reg-tag :role/dev        {:axis :role   :doc "For devs."})
+  (story/reg-tag :role/design     {:axis :role   :doc "For designers."})
+  (story/reg-tag :team/counter    {:axis :team   :doc "Counter squad."})
+  (story/reg-tag :feature/counter {:axis :feature
+                                   :doc  "Counter feature surface."})
+
   ;; -------------------------------------------------------------------------
   ;; reg-mode — the dark / light Chromatic-style saved tuples
   ;;
@@ -198,7 +212,10 @@
      :play   [[:rf.assert/path-equals [:count]              7]
               [:rf.assert/sub-equals  [:count-doubled]      14]
               [:rf.assert/sub-equals  [:count-parity]       :odd]]
-     :tags   #{:dev :docs :test :counter-with-stories/canonical}
+     ;; rf2-7ncf9 — faceted tags alongside the existing canonical seven.
+     ;; The sidebar groups these into per-axis chip rows.
+     :tags   #{:dev :docs :test :counter-with-stories/canonical
+               :status/stable :role/dev :team/counter :feature/counter}
      :substrates #{:reagent}})
 
   ;; Variant 3 — interaction. The increments happen INSIDE the play


### PR DESCRIPTION
## Summary

Storybook 9's faceted-tag UX, layered onto Story's existing canonical-vs-custom split. Tags carrying an `:axis` slot group into per-axis chip rows in the sidebar filter; the filter applies **AND across axes** and **OR within an axis**.

- **Preferred shape — namespaced keyword.** `:status/alpha`, `:role/dev`, `:team/checkout`, `:feature/payment`. The namespace mirrors the `:axis` slot, the name is the value. Lighter than a wrapper map; survives EDN round-trip without ceremony.
- **Four canonical axes** documented in `schemas/canonical-axes`:
  - `:status` — `#{:alpha :beta :stable :deprecated}` (release maturity)
  - `:role` — `#{:design :dev :product}` (audience role)
  - `:team` — user-extensible (owning team / squad)
  - `:feature` — user-extensible (feature area)
  The status / role vocabularies are recommended, not schema-enforced.
- **Filter semantics.** `:status/stable` AND `:role/design` narrows to variants carrying BOTH a status match AND a role match. Within an axis (`:status/alpha` OR `:status/beta`) it's OR. Empty filter still passes every variant.
- **Sidebar.** One labelled chip row per axis. Canonical axes appear first (`:status` → `:role` → `:team` → `:feature`); project-defined axes follow alphabetically; un-axis-grouped tags trail under an `OTHER` row.

### Example

```clojure
(rf/reg-tag :status/stable {:axis :status})
(rf/reg-tag :role/design   {:axis :role})
(rf/reg-tag :team/checkout {:axis :team})

(rf/reg-variant :story.checkout/happy-path
  {:tags #{:status/stable :role/design :team/checkout :test}
   :events []
   :substrates #{:reagent}})
```

The counter-with-stories testbed gains faceted tags on `:story.counter/loaded` to demonstrate the chip-row UX.

## Test plan

- [x] `tools/story/ → clojure -M:test` — 412 tests, 1261 assertions, 0 failures
- [x] `implementation/ → npm run test:cljs` — 2014 tests, 5695 assertions, 0 failures
- [x] New tests cover `variant-tag-match?` (AND-across / OR-within), `filter-variants/3` (faceted), `partition-tag-filter-by-axis`, `group-tags-by-axis`, `ordered-axes`, and `tag->axis-index`
- [x] Legacy 2-arity `variant-tag-match?` / `filter-variants` keep their OR-only semantics for callers that don't pass an axis-index