### PR TITLE
test(mcp-conformance): epoch + view + http-interceptors + trace-buffer fixtures (rf2-f082b)

### DIFF
--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -346,8 +346,12 @@ See `fixtures/` for the actual files. Each fixture is one EDN file; each exercis
 | `ssr-head-hydration.edn` | `:ssr/head-hydration` | Hydration payload carries the unified `:rf/render-hash` (covering head + body in v1); client recomputes; matches; no `:rf.ssr/hydration-mismatch` (`:failing-id :rf.ssr/head-mismatch`) emitted. A dedicated `:rf/head` / `:rf/head-hash` payload channel is reserved for the post-v1 `reg-head` extension. |
 | `ssr-error-sanitisation.edn` | `:ssr/error-sanitisation` | Handler throws; trace carries full detail; public response shape is locked generic-500; rendered HTML contains no internal detail |
 | `ssr-error-known-mapping.edn` | `:ssr/error-known-mapping` | Default projector maps `:rf.error/no-such-handler` (routing context) → `{:status 404 :code :not-found ...}` public-error |
+| `epoch-record-shape.edn` | `:epoch/record-shape` | Per-dispatch `:rf/epoch-record` carries `:event-id`, `:trigger-event`, `:db-before` / `:db-after` snapshot pair, and `:outcome :ok` — the Tool-Pair time-travel contract |
+| `epoch-ring-multi-dispatch.edn` | `:epoch/ring-multi-dispatch` | Multiple settled drains append to the epoch-history ring in oldest-first order; each record's `:db-before` chains from the previous `:db-after` |
+| `trace-buffer-filter-categories.edn` | `:trace-buffer/filter-categories` | One cascade reaches all four trace-bus categories — `:event` (lifecycle), `:rf.fx/handled`, `:sub/run`, `:rf.error/handler-exception` — so the trace-buffer's filter axes (`:op-type` / `:operation` / `:severity`) have reachable data per category |
+| `view-registration.edn` | `:view/registration` | `reg-view` registers a view body that consumes a sub; the registrar accepts the registration and the dependent sub returns the live post-drain value (the data a render-trigger would consume). Render-time observables remain out of scope per the §Render-time observables note below |
 
-Coverage spans the main categories: handlers, frames, envelope, subs, fx, errors, machines, routing, SSR, hydration.
+Coverage spans the main categories: handlers, frames, envelope, subs, fx, errors, machines, routing, SSR, hydration, epoch, trace bus, and view registration.
 
 ## Render-time observables (out of scope)
 

--- a/spec/conformance/fixtures/epoch-record-shape.edn
+++ b/spec/conformance/fixtures/epoch-record-shape.edn
@@ -1,0 +1,57 @@
+;; Conformance fixture: epoch/record-shape
+;; Pin the per-dispatch :rf/epoch-record contract: every settled drain
+;; commits one record carrying :event-id, :trigger-event, :db-before /
+;; :db-after, and :outcome :ok.
+;;
+;; A second-host implementation that wires events / subs / fx correctly
+;; can still fail this fixture if its epoch-history ring isn't recording
+;; settled drains (or is recording the wrong db-snapshot pair). Per
+;; Spec 009 §Epoch history and rf2-v0jwt: the record is the load-bearing
+;; observable for Tool-Pair time-travel and the conformance corpus
+;; pinning is the contract a port must satisfy.
+
+{:fixture/id           :epoch/record-shape
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/trace}
+ :fixture/doc          "A single drain commits one :rf/epoch-record with :event-id, :trigger-event, :outcome :ok, and the canonical :db-before / :db-after snapshot pair. The on-create cascade is its own settled drain (position 0); the user dispatch is position 1."
+
+ :fixture/registry
+ {:event {:counter/initialise {:doc "Seed the counter."}
+          :counter/inc        {:doc "Increment."}}}
+
+ :fixture/handlers
+ {:event {:counter/initialise [[:set [:count] 0]]
+          :counter/inc        [[:update [:count] [:fn :inc]]]}}
+
+ :fixture/frame-config
+ {:on-create [:counter/initialise]}
+
+ :fixture/dispatches
+ [[:counter/inc]]
+
+ :fixture/expect
+ {:final-app-db {:count 1}
+
+  :trace-emissions
+  [{:operation :event :tags {:event-id :counter/initialise}}
+   {:operation :event :tags {:event-id :counter/inc}}]
+
+  ;; Two settled drains: the :on-create cascade (position 0) and the
+  ;; user :counter/inc (position 1). Both commit an :ok record carrying
+  ;; the :db-before / :db-after pair. Partial-submap match — extra slots
+  ;; (`:effects`, `:sub-runs`, `:renders`, `:trace-events`, `:epoch-id`,
+  ;; `:duration-ms`) are not asserted but MUST be present per the
+  ;; :rf/epoch-record schema.
+  :epoch-records
+  [{:frame  :rf/default
+    :record {:event-id      :counter/initialise
+             :trigger-event [:counter/initialise]
+             :db-before     {}
+             :db-after      {:count 0}
+             :outcome       :ok}}
+   {:frame  :rf/default
+    :record {:event-id      :counter/inc
+             :trigger-event [:counter/inc]
+             :db-before     {:count 0}
+             :db-after      {:count 1}
+             :outcome       :ok}}]}}

--- a/spec/conformance/fixtures/epoch-ring-multi-dispatch.edn
+++ b/spec/conformance/fixtures/epoch-ring-multi-dispatch.edn
@@ -1,0 +1,63 @@
+;; Conformance fixture: epoch/ring-multi-dispatch
+;; The epoch-history ring buffer records settled drains in append order
+;; (oldest-first). Multiple dispatches in a fixture produce one record
+;; per dispatch; positions are stable across re-runs.
+;;
+;; Tool-Pair time-travel and the re-frame-10x epoch panel both walk
+;; this ring; a second-host implementation that emits one record per
+;; dispatch but in REVERSE order would break the time-travel contract
+;; even though every individual record looks right. This fixture pins
+;; the order.
+
+{:fixture/id           :epoch/ring-multi-dispatch
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/trace}
+ :fixture/doc          "Three sequential dispatches commit three :rf/epoch-record entries in append order (oldest-first). The :on-create cascade is its own record at position 0; the three user dispatches land at positions 1..3. The :db-before / :db-after pairs chain so each record's :db-before equals the previous record's :db-after."
+
+ :fixture/registry
+ {:event {:counter/initialise {:doc "Seed."}
+          :counter/inc        {:doc "Increment."}
+          :counter/double     {:doc "Multiply by two."}
+          :counter/set-to-ten {:doc "Replace count with 10."}}}
+
+ :fixture/handlers
+ {:event {:counter/initialise [[:set [:count] 0]]
+          :counter/inc        [[:update [:count] [:fn :inc]]]
+          :counter/double     [[:update [:count] [:fn :* 2]]]
+          :counter/set-to-ten [[:set [:count] 10]]}}
+
+ :fixture/frame-config
+ {:on-create [:counter/initialise]}
+
+ :fixture/dispatches
+ [[:counter/inc]
+  [:counter/double]
+  [:counter/set-to-ten]]
+
+ :fixture/expect
+ {:final-app-db {:count 10}
+
+  ;; Four records in append order. Each :db-before chains from the
+  ;; previous :db-after; the runtime MUST preserve this snapshot pair
+  ;; for Tool-Pair restore semantics.
+  :epoch-records
+  [{:frame  :rf/default
+    :record {:event-id  :counter/initialise
+             :db-before {}
+             :db-after  {:count 0}
+             :outcome   :ok}}
+   {:frame  :rf/default
+    :record {:event-id  :counter/inc
+             :db-before {:count 0}
+             :db-after  {:count 1}
+             :outcome   :ok}}
+   {:frame  :rf/default
+    :record {:event-id  :counter/double
+             :db-before {:count 1}
+             :db-after  {:count 2}
+             :outcome   :ok}}
+   {:frame  :rf/default
+    :record {:event-id  :counter/set-to-ten
+             :db-before {:count 2}
+             :db-after  {:count 10}
+             :outcome   :ok}}]}}

--- a/spec/conformance/fixtures/trace-buffer-filter-categories.edn
+++ b/spec/conformance/fixtures/trace-buffer-filter-categories.edn
@@ -1,0 +1,90 @@
+;; Conformance fixture: trace-buffer/filter-categories
+;; The trace bus emits events spanning four reserved op-type categories
+;; — :event (event lifecycle), :fx (fx routing), :sub/run (sub
+;; computation), and :error (structured failures). A second-host
+;; implementation whose trace bus only emits the :event category would
+;; pass every event-handler fixture in the corpus and still leave the
+;; trace-buffer filter API (filter by :op-type / :operation) without
+;; reachable data on the other three axes.
+;;
+;; Per Spec 009 §Trace operations / §Retain-N trace ring buffer
+;; (`(trace-buffer {:op-type :fx})`, `{:operation :rf.error/...}`,
+;; `{:severity :error}`): the filter axes presuppose the trace bus
+;; emits at least one event per category in canonical app cascades.
+;; This fixture drives one cascade that fires events in all four
+;; categories and pins the per-category operation/op-type pairings.
+
+{:fixture/id           :trace-buffer/filter-categories
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/sub :core/fx
+                         :core/error :core/trace}
+ :fixture/doc          "One cascade reaches all four trace-bus categories — :event (lifecycle), :rf.fx/handled (fx routing), :sub/run (sub computation, triggered by the runner's :sub-values check), and :rf.error/handler-exception (structured failure). The trace stream MUST carry at least one event per category so the trace-buffer's filter-by-op-type / filter-by-operation axes have reachable data on each."
+
+ :fixture/registry
+ {:event {:counter/initialise {:doc "Seed."}
+          :counter/inc        {:doc "Increment + side fx."}
+          :counter/will-throw {:doc "Always throws — exercises :rf.error/*."}}
+  :sub   {:count {:doc "Layer-1 sub used by the runner's :sub-values check, exercising :sub/run."}}
+  :fx    {:log {:doc "Pure side-fx that logs to app-db. Exercises :rf.fx/handled."}}}
+
+ :fixture/handlers
+ {:event {:counter/initialise [[:set [:count] 0]]
+          :counter/inc        [[:update [:count] [:fn :inc]]
+                                [:fx :log {:msg "incremented"}]]
+          :counter/will-throw [[:throw "boom"]]}
+  :sub   {:count [[:get [:count]]]}
+  :fx    {:log [[:update [:log] [:fn :conj [:get-event-arg 1 :msg]]]]}}
+
+ :fixture/frame-config
+ {:on-create [:counter/initialise]}
+
+ :fixture/dispatches
+ [[:counter/inc]
+  [:counter/will-throw]]
+
+ :fixture/expect
+ {:final-app-db {:count 1
+                 :log   ["incremented"]}
+
+  ;; The runner's :sub-values check triggers a fresh sub run — that
+  ;; emit lands in the trace stream and lets the partial-match below
+  ;; succeed for the :sub/run category.
+  :sub-values {[:count] 1}
+
+  :trace-emissions
+  [;; :rf.event/* category — event lifecycle. The :on-create
+   ;; :counter/initialise is the first hit; the explicit :event matcher
+   ;; covers the canonical lifecycle emit point (Spec 009 §:event
+   ;; trace-event vocabulary).
+   {:operation :event
+    :op-type   :event
+    :tags      {:event-id :counter/initialise}}
+
+   ;; :rf.fx/* category — fx routing. The :log fx the :counter/inc
+   ;; handler emitted lands on the trace bus as :rf.fx/handled with
+   ;; :op-type :fx. This is what the trace-buffer's `{:op-type :fx}`
+   ;; filter selects on (Spec 009 §Retain-N trace ring buffer).
+   {:operation :rf.fx/handled
+    :op-type   :fx
+    :tags      {:fx-id :log}}
+
+   ;; :rf.error/* category — structured failures. :will-throw throws;
+   ;; the runtime emits :rf.error/handler-exception with :op-type :error.
+   ;; The trace-buffer's `{:severity :error}` filter selects on
+   ;; :op-type :error (Spec 009 §Retain-N trace ring buffer).
+   {:operation :rf.error/handler-exception
+    :op-type   :error
+    :tags      {:category   :rf.error/handler-exception
+                :handler-id :counter/will-throw}}
+
+   ;; :rf.sub/* category — sub computation. The runner's :sub-values
+   ;; check below invokes rf/subscribe-value, which the runtime
+   ;; instruments with a :sub/run emit (Spec 009 §:sub/run trace event,
+   ;; rf2-i7eb). The :op-type is :sub/run; trace-buffer's
+   ;; `{:op-type :sub/run}` filter selects on that.
+   {:operation :sub/run
+    :op-type   :sub/run
+    :tags      {:sub-id :count}}]
+
+  :effects-routed
+  [{:fx-id :log :args {:msg "incremented"}}]}}

--- a/spec/conformance/fixtures/view-registration.edn
+++ b/spec/conformance/fixtures/view-registration.edn
@@ -1,0 +1,66 @@
+;; Conformance fixture: view/registration
+;; A view is registered via reg-view, depends on a sub, and the
+;; underlying app-db mutates. The portable-corpus contract is:
+;;
+;;  1. The registrar accepts a :view registration without error
+;;     (so the load-time wiring path doesn't crash).
+;;  2. The view's hiccup body is a fn-of-the-event-args that the
+;;     harness can realise via the conformance handler-body DSL —
+;;     i.e. reflection forms (`[:event-arg n]`, `[:db-get path]`)
+;;     resolve at call time and the body returns the expected
+;;     hiccup tree.
+;;  3. The sub the view depends on returns the live value after the
+;;     app-db mutates — the value a render-trigger would consume.
+;;
+;; Render-time observables (component lifecycle, React re-render
+;; firing) are out of scope for the host-agnostic corpus per
+;; spec/conformance/README.md §Render-time observables (out of
+;; scope). This fixture pins the data the view would receive; the
+;; substrate-level render trigger is covered by host-side unit tests
+;; (see implementation/adapters/reagent/test/.../view_render_trigger_handler_cljs_test.cljs).
+
+{:fixture/id           :view/registration
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/sub}
+ :fixture/doc          "Register a view that subscribes to :count, mutate app-db via :counter/inc, and pin the sub's post-drain value to what the view would render. The view body's hiccup tree carries the bound :count value via the conformance DSL's `[:db-get [:count]]` reflection form (the runner realises it as a render-time read)."
+
+ :fixture/registry
+ {:event {:counter/initialise {:doc "Seed."}
+          :counter/inc        {:doc "Increment."}}
+  :sub   {:count {:doc "Layer-1 sub the view consumes."}}
+  :view  {:counter-display {:doc "A read-only display of :count. Per Spec 004 reg-view; the view body's render fn is realised by the conformance DSL's `realise-view-handler`."}}}
+
+ :fixture/handlers
+ {:event {:counter/initialise [[:set [:count] 0]]
+          :counter/inc        [[:update [:count] [:fn :inc]]]}
+  :sub   {:count [[:get [:count]]]}
+
+  ;; View body — the conformance DSL realises this into a render fn
+  ;; whose `[:db-get [:count]]` reflection form resolves at call
+  ;; time. The body shape is `[:hiccup <tree>]`; the tree is the
+  ;; literal returned hiccup with reflection forms substituted.
+  :view  {:counter-display
+          [[:hiccup
+            [:div.counter
+             [:span.label "count:"]
+             [:span.value [:db-get [:count]]]]]]}}
+
+ :fixture/frame-config
+ {:on-create [:counter/initialise]}
+
+ :fixture/dispatches
+ [[:counter/inc]
+  [:counter/inc]
+  [:counter/inc]]
+
+ :fixture/expect
+ {:final-app-db {:count 3}
+
+  ;; The sub the view consumes carries the live post-drain value.
+  ;; A render-trigger that read this sub would re-render with the
+  ;; new value; the portable-corpus pin is that the sub returns it.
+  :sub-values {[:count] 3}
+
+  :trace-emissions
+  [{:operation :event :tags {:event-id :counter/initialise}}
+   {:operation :event :tags {:event-id :counter/inc}}]}}


### PR DESCRIPTION
## Summary

- Adds four EDN fixtures to `spec/conformance/fixtures/` covering surfaces that had zero cross-host portable contract pinning before this PR — epoch ring, trace bus filter vocabulary, and view registration.
- A second-host re-frame2 implementation (e.g. a future `rf-clr` on .NET) can now use the corpus to verify its epoch-history ring records the right snapshot pairs and outcomes; its trace bus emits across all four reserved categories (`:event` / `:fx` / `:sub/run` / `:error`); and its `reg-view` slot accepts the registration and the dependent sub returns the live value the view would render with.
- HTTP-interceptor fixtures intentionally scoped out — the portable exercise needs a new `:rf.fx/reg-http-interceptor` runtime fx (the current API is a direct fn-call, not addressable via the DSL). Tracked under follow-up bead **rf2-yhfgf**.

### Fixtures added

| File | Coverage |
|---|---|
| `epoch-record-shape.edn` | Per-dispatch `:rf/epoch-record` carries `:event-id`, `:trigger-event`, `:db-before` / `:db-after` snapshot pair, `:outcome :ok` — Tool-Pair time-travel contract |
| `epoch-ring-multi-dispatch.edn` | Multiple settled drains append in oldest-first order; each record's `:db-before` chains from the previous record's `:db-after` |
| `trace-buffer-filter-categories.edn` | One cascade reaches all four trace-bus categories so trace-buffer filter axes (`:op-type` / `:operation` / `:severity`) have reachable data per category |
| `view-registration.edn` | `reg-view` registers a view body that consumes a sub; the registrar accepts the registration and the dependent sub returns the live post-drain value |

### Why no http-interceptor fixture in this PR

`reg-http-interceptor` / `clear-http-interceptor` are direct fn-call APIs, not addressable via the conformance DSL's `:fx` op. The existing `http-managed-*.edn` fixtures only drive `:rf.http/managed` itself via `:fx-overrides`; there is no analogue for interceptor registration. Adding one means a new `:rf.fx/reg-http-interceptor` runtime fx (a small, self-contained change with its own behavioural contract). Filed as **rf2-yhfgf**.

## Test plan

- [x] Full JVM core suite (`clojure -M:test` from `implementation/core`) — 534 tests / 2727 assertions, all green
- [x] Full CLJS suite (`npm run test:cljs` from `implementation/`) — 2014 tests / 5695 assertions, all green
- [x] Each fixture validated directly via `re-frame.conformance-test/run-fixture` — `:passed? true` on all four

## Spec posture

`spec/conformance/README.md` table updated; `:fixture/spec-version "1.0"` on all four. No changes to hot-zone files (`Conventions.md`, `MIGRATION.md`, etc.). Fixtures author-only — no DSL, runner, or capability-set changes.