### PR TITLE
feat(http): :rf.fx/reg-http-interceptor + :rf.fx/clear-http-interceptor fx + conformance fixtures (rf2-yhfgf)

### DIFF
--- a/implementation/core/src/re_frame/conformance.cljc
+++ b/implementation/core/src/re_frame/conformance.cljc
@@ -31,7 +31,8 @@
     [:fn :keyword arg1 ...]         partial application of a builtin
 
   Builtins: :inc :dec :+ :- :* :/ :identity :conj :assoc :dissoc
-            :item-amount :count")
+            :item-amount :count"
+  (:require [re-frame.late-bind :as late-bind]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -200,12 +201,85 @@
         :else
         (resolve-value last-step ctx)))))
 
+;; ---- :rf.fx/reg-http-interceptor — DSL `:before` body --------------------
+;;
+;; Per rf2-yhfgf — the conformance corpus drives `:rf.fx/reg-http-interceptor`
+;; via pure-data EDN, so an interceptor's `:before` slot is a DSL body
+;; rather than a fn literal. The harness realises that DSL into a real
+;; `(fn [ctx] ctx')` at fx-resolution time so the chain runner (which
+;; lives in `re-frame.http-middleware`, unaware of the DSL) can invoke
+;; it the same way it invokes a hand-written `:before`.
+;;
+;; Body operator set is minimal — the chain's contract is "transform the
+;; request map and return the modified ctx", so the DSL covers the pieces
+;; that touch ctx.:request plus the dispatch escape hatch fixtures use to
+;; record "the interceptor fired" observably:
+;;
+;;   [:assoc-in-request path value]   — `(assoc-in ctx [:request & path] value)`
+;;   [:dispatch event-vec]            — enqueue `event-vec` on the originating
+;;                                       frame (lands in the next drain cycle)
+;;
+;; The realised fn looks up the router's dispatch entry point via the
+;; `:router/dispatch!` late-bind hook so the conformance ns stays free
+;; of a static require on `re-frame.router` (mirrors how `frame.cljc`
+;; reaches dispatch from the lifecycle path). The dispatched event is
+;; the deterministic seam fixtures use to write "interceptor fired"
+;; markers into app-db.
+
+(defn realise-interceptor-before-fn
+  "DSL `:before` body → `(fn [chain-ctx] chain-ctx')`.
+
+  Operators:
+    [:assoc-in-request path v]   — `(assoc-in ctx [:request & path] v)`
+    [:dispatch event-vec]        — enqueue `event-vec` on `(:frame ctx)`;
+                                    the dispatch lands in the next drain
+                                    cycle, after the current request
+                                    settles.
+    [:noop]                       — explicit no-op
+
+  Value forms inside `path` / `v` / `event-vec` resolve via `resolve-value`
+  against a ctx exposing `:request` (the live request slot at body time)
+  and `:event` (the originating event vector)."
+  [steps]
+  (fn [chain-ctx]
+    (let [dispatch! (late-bind/get-fn :router/dispatch!)
+          frame-id  (:frame chain-ctx)]
+      (reduce
+        (fn [acc step]
+          (let [resolver-ctx {:request (:request acc)
+                              :event   (:event acc)
+                              :db      (:request acc)}]
+            (case (first step)
+              :assoc-in-request
+              (let [[_ path v] step
+                    rv (resolve-value v resolver-ctx)]
+                (update acc :request #(assoc-in % path rv)))
+
+              :dispatch
+              (let [[_ event-form] step
+                    ev (resolve-value event-form resolver-ctx)]
+                (when dispatch!
+                  (dispatch! ev {:frame frame-id}))
+                acc)
+
+              :noop acc
+
+              (throw (ex-info "unknown :before DSL op"
+                              {:op step :allowed #{:assoc-in-request
+                                                   :dispatch :noop}})))))
+        chain-ctx
+        steps))))
+
 (defn- resolve-fx-args
   "Resolve fx args, leaving DSL fields that the conformance harness owns
   alone. `:rf.fx/reg-flow`'s `:body` is itself a DSL body — it must NOT
   be walked through resolve-value (which would treat `[:fn :k ...]` as
   a value form and partially-apply it). Pull `:body` aside, resolve the
-  rest of the map normally, then realise `:body` into `:output`."
+  rest of the map normally, then realise `:body` into `:output`.
+
+  Per rf2-yhfgf — `:rf.fx/reg-http-interceptor`'s `:before` is also a
+  DSL body. Same shape, different realisation: the body becomes a
+  `(fn [chain-ctx] chain-ctx')` for the request-side middleware chain."
   [fx-id args ctx]
   (case fx-id
     :rf.fx/reg-flow
@@ -213,6 +287,14 @@
       (let [body          (:body args)
             other-resolved (resolve-value (dissoc args :body) ctx)]
         (assoc other-resolved :output (realise-flow-output-fn body)))
+      (resolve-value args ctx))
+
+    :rf.fx/reg-http-interceptor
+    (if (and (map? args) (contains? args :before))
+      (let [before-body    (:before args)
+            other-resolved (resolve-value (dissoc args :before) ctx)]
+        (assoc other-resolved :before
+               (realise-interceptor-before-fn before-body)))
       (resolve-value args ctx))
 
     (resolve-value args ctx)))

--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -251,6 +251,12 @@
   (machines/reset-timers!)
   ;; 4. Drop the in-flight HTTP request registry between fixtures.
   (http-managed/clear-all-in-flight!)
+  ;; 4a. Spec 014 §Middleware (rf2-yhfgf) — drop the per-frame request-
+  ;;     side interceptor chain. The atom holding the chain is `defonce`
+  ;;     in `re-frame.http-middleware`; without an explicit clear, a
+  ;;     fixture that registers an interceptor leaks it into the next
+  ;;     fixture's chain walk.
+  (http-managed/clear-all-http-interceptors!)
   ;; 5. Dispose the currently-installed adapter (if any) and re-install
   ;;    plain-atom. `init!` is idempotent and creates the :rf/default
   ;;    frame; subsequent reg-frame calls for that id update in-place.
@@ -406,7 +412,12 @@
                           (concat (when (seq sub-meta) [sub-meta])
                                   (interleave (repeat :<-) inputs)
                                   [body])))))
-    ;; fx handlers (bodies + meta)
+    ;; fx handlers (bodies + meta).
+    ;;
+    ;; Per rf2-yhfgf — an id with NO body in :fixture/handlers but a meta
+    ;; in :fixture/registry is "declare the dependency, leave the framework
+    ;; registration alone": the harness DOES NOT overwrite the framework-
+    ;; shipped fx with a noop. Mirrors the JVM runner's contract.
     (let [adapter-helpers
           {:read-db!  (fn [frame-id]
                         (frame/frame-app-db-value frame-id))
@@ -419,10 +430,12 @@
           fx-registry (get-in fixture [:fixture/registry :fx] {})
           all-fx-ids  (into #{} (concat (keys fx-bodies) (keys fx-registry)))]
       (doseq [id all-fx-ids]
-        (let [body    (get fx-bodies id [[:noop]])
-              meta    (get fx-registry id {})
-              handler (conformance/realise-fx-handler id body adapter-helpers)]
-          (rf/reg-fx id (assoc meta :handler-fn handler) handler))))
+        (let [explicit-body (contains? fx-bodies id)
+              body          (get fx-bodies id [[:noop]])
+              meta          (get fx-registry id {})
+              handler       (conformance/realise-fx-handler id body adapter-helpers)]
+          (when explicit-body
+            (rf/reg-fx id (assoc meta :handler-fn handler) handler)))))
     ;; Flow registration is intentionally NOT done here — flows are
     ;; FRAME-SCOPED (per Spec 013), so the destroy-frame call later in
     ;; `run-fixture` would wipe them via the rf2-wbtjn teardown hook.

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -240,7 +240,14 @@
   ((requiring-resolve 're-frame.routing/reset-counters!))
   ((requiring-resolve 're-frame.machines/reset-timers!))
   ;; Spec 014 — drop the in-flight request registry between fixtures.
-  ((requiring-resolve 're-frame.http-managed/clear-all-in-flight!)))
+  ((requiring-resolve 're-frame.http-managed/clear-all-in-flight!))
+  ;; Spec 014 §Middleware (rf2-yhfgf) — the per-frame interceptor chain
+  ;; is held in a `defonce` atom inside `re-frame.http-middleware` and
+  ;; persists across `:reload` (defonce semantics). The interceptor
+  ;; corpus fixtures register chains scoped to their fixture; clear
+  ;; between runs so a previous fixture's interceptors don't leak into
+  ;; the next fixture's chain walk.
+  ((requiring-resolve 're-frame.http-managed/clear-all-http-interceptors!)))
 
 ;; ---- fixture execution ----------------------------------------------------
 
@@ -417,8 +424,19 @@
     ;;
     ;; Two sources combine: :fixture/handlers :fx (bodies) and
     ;; :fixture/registry :fx (metadata, including :platforms / :spec).
-    ;; A registry-only entry registers as a no-op so fx that the fixture
-    ;; merely declares but doesn't body still resolve at do-fx time.
+    ;;
+    ;; Per rf2-yhfgf: an id with NO body in :fixture/handlers but a meta
+    ;; in :fixture/registry is "declare the dependency, leave the framework
+    ;; registration alone" — the harness DOES NOT overwrite the
+    ;; framework-shipped fx with a noop. This lets fixtures rely on the
+    ;; real fx behaviour for ids like :rf.fx/reg-http-interceptor where
+    ;; the load-bearing logic lives inside the framework registration
+    ;; and a fixture-DSL body cannot replicate it. Pre-rf2-yhfgf the
+    ;; harness re-registered every registry-declared id with a noop,
+    ;; which silently masked the framework registration; the new contract
+    ;; respects the "no explicit body = leave the framework alone" rule
+    ;; while keeping the existing override mechanism (explicit body
+    ;; under :fixture/handlers :fx) unchanged.
     (let [adapter-helpers
           {:read-db!  (fn [frame-id]
                         (frame/frame-app-db-value frame-id))
@@ -432,10 +450,12 @@
           fx-registry (get-in fixture [:fixture/registry :fx] {})
           all-fx-ids  (into #{} (concat (keys fx-bodies) (keys fx-registry)))]
       (doseq [id all-fx-ids]
-        (let [body  (get fx-bodies id [[:noop]])
-              meta  (get fx-registry id {})
-              handler (conformance/realise-fx-handler id body adapter-helpers)]
-          (rf/reg-fx id (assoc meta :handler-fn handler) handler))))
+        (let [explicit-body (contains? fx-bodies id)
+              body          (get fx-bodies id [[:noop]])
+              meta          (get fx-registry id {})
+              handler       (conformance/realise-fx-handler id body adapter-helpers)]
+          (when explicit-body
+            (rf/reg-fx id (assoc meta :handler-fn handler) handler)))))
     ;; Flow registration is intentionally NOT done here — flows are
     ;; FRAME-SCOPED (per Spec 013), so the destroy-frame call later in
     ;; `run-fixture` would wipe them via the rf2-wbtjn teardown hook.

--- a/implementation/http/src/re_frame/http_machine_wrapper.cljc
+++ b/implementation/http/src/re_frame/http_machine_wrapper.cljc
@@ -42,6 +42,7 @@
   façade for source-coord capture) — per Spec 014 §Testing."
   (:require [re-frame.fx           :as fx]
             [re-frame.http-encoding :as encoding]
+            [re-frame.http-middleware :as middleware]
             [re-frame.late-bind    :as late-bind]))
 
 ;; rf2-2utlm — the canned stubs delegate to `encoding/dispatch-reply-
@@ -59,9 +60,35 @@
 ;; `encoding/resolve-origin-event` (single source of truth shared with
 ;; `http-managed/managed-handler`).
 
-(defn canned-success-handler
-  "Stub fx — synthesises a success reply per Spec 014 §Testing."
+(defn- run-request-chain
+  "Per rf2-yhfgf — the request-side middleware chain (Spec 014 §Middleware)
+  fires for every issued request, not just real-transport ones. The canned
+  stub fxs replace the TRANSPORT, not the entire managed pipeline, so they
+  walk the chain before synthesising the reply. The chain's `:before` fns
+  may carry load-bearing side effects (auth-token attachment, idempotency-
+  key stamping, observability) that the canned path would otherwise mask.
+
+  A throw inside any `:before` raises `:rf.error/http-interceptor-failed`
+  with the same classification the real handler emits (per `run-interceptor-
+  chain!`), and the canned reply is NOT dispatched."
   [frame-ctx args-map]
+  (let [frame-id     (or (:frame frame-ctx) :rf/default)
+        origin-event (encoding/resolve-origin-event frame-ctx args-map)
+        ctx0         {:request (:request args-map)
+                      :args    args-map
+                      :frame   frame-id
+                      :event   origin-event}]
+    (middleware/run-interceptor-chain! frame-id ctx0)))
+
+(defn canned-success-handler
+  "Stub fx — synthesises a success reply per Spec 014 §Testing.
+
+  Per rf2-yhfgf — walks the per-frame request-side interceptor chain
+  before synthesising the reply, so `:before` interceptors with
+  load-bearing side effects (auth headers, observability) fire on the
+  canned path the same way they fire on the real-transport path."
+  [frame-ctx args-map]
+  (run-request-chain frame-ctx args-map)
   (let [value (get args-map :value {:stubbed true})]
     (encoding/dispatch-reply-via-late-bind!
       {:origin-event  (encoding/resolve-origin-event frame-ctx args-map)
@@ -73,7 +100,14 @@
     nil))
 
 (defn canned-failure-handler
+  "Stub fx — synthesises a failure reply per Spec 014 §Testing.
+
+  Per rf2-yhfgf — walks the per-frame request-side interceptor chain
+  before synthesising the reply (symmetric with `canned-success-handler`).
+  Real-transport failures still go through the chain too; the canned path
+  honours the same pre-transport contract."
   [frame-ctx args-map]
+  (run-request-chain frame-ctx args-map)
   (let [kind    (or (:kind args-map) :rf.http/transport)
         tags    (or (:tags args-map) {})
         failure (assoc tags :kind kind)]

--- a/implementation/http/src/re_frame/http_managed.cljc
+++ b/implementation/http/src/re_frame/http_managed.cljc
@@ -148,6 +148,41 @@
            {:doc "Spec 014 — abort an in-flight :rf.http/managed by request-id."}
            handlers/managed-abort-handler)
 
+;; ---- middleware fx wrappers (rf2-yhfgf) -----------------------------------
+;;
+;; `reg-http-interceptor` / `clear-http-interceptor` are direct fn-call APIs
+;; — load-time registration of cross-cutting request transforms (Spec 014
+;; §Middleware, rf2-6y3q). Most apps register at app bootstrap and never
+;; call again. But the conformance corpus (Spec 011 §Conformance) is
+;; pure-data EDN, has no fn-call seam, and drives behaviour exclusively
+;; through `:fx` ops + `:fx-overrides`. The two fxs below let portable
+;; EDN fixtures register/clear interceptors via the same DSL channel they
+;; use for everything else — `[:fx [[:rf.fx/reg-http-interceptor {...}]]]`
+;; / `[:fx [[:rf.fx/clear-http-interceptor {...}]]]`.
+;;
+;; Args shapes mirror the fns 1:1:
+;;   :rf.fx/reg-http-interceptor   {:frame <id> :id <kw> :before <fn>}
+;;   :rf.fx/clear-http-interceptor {:frame <id> :id <kw>}
+;;
+;; Both fxs are dev+prod (`:platforms #{:client :server}`). Authors can
+;; register interceptors via an event-handler at boot, which is a clean
+;; alternative to the fn-call shape for codebases that prefer to drive
+;; bootstrap through the dispatch surface.
+
+(fx/reg-fx :rf.fx/reg-http-interceptor
+           {:doc "Spec 014 §Middleware (rf2-6y3q) — register a request-side
+                  interceptor as an fx. Args is the same `{:frame :id :before}`
+                  map `reg-http-interceptor` accepts."}
+           (fn [_ctx args]
+             (middleware/reg-http-interceptor args)))
+
+(fx/reg-fx :rf.fx/clear-http-interceptor
+           {:doc "Spec 014 §Middleware (rf2-6y3q) — clear a request-side
+                  interceptor by id as an fx. Args is `{:frame :id}`; `:frame`
+                  defaults to `:rf/default`."}
+           (fn [_ctx {:keys [frame id]}]
+             (middleware/clear-http-interceptor (or frame :rf/default) id)))
+
 ;; The two canned-stub fxs are gated on `interop/debug-enabled?` so they
 ;; elide in production. Per Spec 014 §Testing — "Don't ship the canned-
 ;; stub fxs as production-eligible". The gate applies on BOTH hosts: on

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -350,8 +350,10 @@ See `fixtures/` for the actual files. Each fixture is one EDN file; each exercis
 | `epoch-ring-multi-dispatch.edn` | `:epoch/ring-multi-dispatch` | Multiple settled drains append to the epoch-history ring in oldest-first order; each record's `:db-before` chains from the previous `:db-after` |
 | `trace-buffer-filter-categories.edn` | `:trace-buffer/filter-categories` | One cascade reaches all four trace-bus categories — `:event` (lifecycle), `:rf.fx/handled`, `:sub/run`, `:rf.error/handler-exception` — so the trace-buffer's filter axes (`:op-type` / `:operation` / `:severity`) have reachable data per category |
 | `view-registration.edn` | `:view/registration` | `reg-view` registers a view body that consumes a sub; the registrar accepts the registration and the dependent sub returns the live post-drain value (the data a render-trigger would consume). Render-time observables remain out of scope per the §Render-time observables note below |
+| `http-interceptor-before-transforms.edn` | `:rf.http.interceptor/before-transforms` | `:rf.fx/reg-http-interceptor` registers a request-side `:before` interceptor (Spec 014 §Middleware, rf2-6y3q + rf2-yhfgf); the `:rf.http.interceptor/registered` trace fires at registration, and the body executes against the live ctx on a subsequent canned-success request — observable via a marker the body dispatches into app-db |
+| `http-interceptor-clear.edn` | `:rf.http.interceptor/clear` | `:rf.fx/clear-http-interceptor` unregisters an interceptor by id; the `:rf.http.interceptor/cleared` trace fires; a subsequent request runs WITHOUT the cleared body — the dispatched-marker counter advances on the pre-clear request and STAYS at one through the post-clear request |
 
-Coverage spans the main categories: handlers, frames, envelope, subs, fx, errors, machines, routing, SSR, hydration, epoch, trace bus, and view registration.
+Coverage spans the main categories: handlers, frames, envelope, subs, fx, errors, machines, routing, SSR, hydration, epoch, trace bus, view registration, and HTTP request interceptors.
 
 ## Render-time observables (out of scope)
 

--- a/spec/conformance/fixtures/http-interceptor-before-transforms.edn
+++ b/spec/conformance/fixtures/http-interceptor-before-transforms.edn
@@ -1,0 +1,118 @@
+;; Conformance fixture: rf.http.interceptor/before-transforms
+;;
+;; Per Spec 014 §Middleware (rf2-6y3q) + rf2-yhfgf — `:rf.fx/reg-http-
+;; interceptor` registers a request-side `:before` interceptor as an fx
+;; (rather than the direct fn-call `reg-http-interceptor`, which the
+;; pure-data conformance corpus has no surface for). The runtime emits
+;; a `:rf.http.interceptor/registered` trace at the registration site.
+;;
+;; The fixture exercises the contract end-to-end:
+;;   1. `:rf.fx/reg-http-interceptor` fires from `:app/init`, registering
+;;      a `:before` whose body adds an "Authorization" header to the
+;;      outbound request AND dispatches a fixture-internal event that
+;;      writes a marker into app-db so the chain-firing is observable.
+;;   2. `:article/load` issues a `:rf.http/managed` request; the runtime
+;;      walks the chain (per Spec 014 §Middleware) — for canned-success
+;;      fxs the chain walks too (rf2-yhfgf), so the `:before`'s side-
+;;      effects fire in the canned path. The fixture asserts on the
+;;      `:fixture/interceptor-fired` marker landing in app-db AND on
+;;      the canned-success reply reaching the `:on-success` target.
+;;
+;; The fixture takes no position on the chain modifying the OUTGOING
+;; request headers — the canned-success path doesn't reach a real
+;; transport, so the modified request is not externally observable
+;; here. The dispatched marker IS observable and proves the body
+;; executed against the live ctx.
+
+{:fixture/id           :rf.http.interceptor/before-transforms
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/sub :core/fx :core/trace
+                         :rf.http/managed}
+ :fixture/doc          "reg-http-interceptor via :rf.fx/reg-http-interceptor — the registered :before's body modifies the request shape AND dispatches an observability marker; the marker lands in app-db. The :rf.http.interceptor/registered trace fires at registration; the canned-success reply reaches the :on-success target."
+
+ :fixture/registry
+ {:event {:app/init                     {:doc "Boot — register the interceptor."}
+          :article/load                 {:doc "Issue the GET."}
+          :article/loaded               {:doc "Receive the canned-success payload."}
+          :fixture/interceptor-fired    {:doc "Recorded by the :before's :dispatch op."}}
+  :sub   {:article            {:doc "The article slice."}
+          :interceptor-marker {:doc "The marker recorded by the :before."}}
+  :fx    {:rf.http/managed                {:platforms #{:client :server}}
+          :rf.http/managed-canned-success {:platforms #{:client :server}}
+          :rf.fx/reg-http-interceptor     {:platforms #{:client :server}}}}
+
+ :fixture/handlers
+ {:event
+  {:app/init
+   [[:fx [[:rf.fx/reg-http-interceptor
+           {:id     :auth
+            :before [[:assoc-in-request [:headers "Authorization"]
+                      "Bearer fixture-token"]
+                     [:dispatch [:fixture/interceptor-fired :auth-applied]]]}]]]]
+
+   ;; The :fx-overrides redirect this to :rf.http/managed-canned-success
+   ;; (framework, rf2-yhfgf) which walks the middleware chain THEN
+   ;; synthesises the reply. :value is the payload the canned reply
+   ;; carries — the framework canned-success uses it verbatim.
+   :article/load
+   [[:fx [[:rf.http/managed
+           {:request    {:method :get :url "/articles/hello"}
+            :decode     :json
+            :value      {:title "hello" :id 42}
+            :on-success [:article/loaded]}]]]]
+
+   :article/loaded
+   [[:set [:article] [:event-arg 1]]]
+
+   :fixture/interceptor-fired
+   [[:set [:interceptor-marker] [:event-arg 1]]]}
+
+  :sub
+  {:article            [[:get [:article]]]
+   :interceptor-marker [[:get [:interceptor-marker]]]}
+
+  ;; :rf.fx/reg-http-interceptor and :rf.http/managed-canned-success are
+  ;; intentionally NOT given fixture-DSL bodies — per the rf2-yhfgf harness
+  ;; rule, declaring an id in :fixture/registry :fx WITHOUT an explicit
+  ;; body in :fixture/handlers :fx leaves the framework registration in
+  ;; place. The framework's canned-success now walks the middleware
+  ;; chain before synthesising the reply (rf2-yhfgf), so the registered
+  ;; :before interceptor fires through the canned path.
+  :fx
+  {:rf.http/managed [[:noop]]}}
+
+ :fixture/frame-config
+ {:on-create    [:app/init]
+  :fx-overrides {:rf.http/managed :rf.http/managed-canned-success}}
+
+ :fixture/dispatches
+ [[:article/load]]
+
+ :fixture/expect
+ {:final-app-db
+  {:article            {:kind  :success
+                        :value {:title "hello" :id 42}}
+   :interceptor-marker :auth-applied}
+
+  :sub-values
+  {[:article]            {:kind  :success
+                          :value {:title "hello" :id 42}}
+   [:interceptor-marker] :auth-applied}
+
+  ;; Order: the registration trace fires at :app/init. The first
+  ;; :article/load fires the canned-success fx (override-applied),
+  ;; which walks the middleware chain (rf2-yhfgf) — the :before
+  ;; dispatches :fixture/interceptor-fired BEFORE returning. Once the
+  ;; chain settles, canned-success synthesises the reply event
+  ;; :article/loaded which dispatches AFTER. The two dispatched events
+  ;; drain in FIFO order: :fixture/interceptor-fired first,
+  ;; :article/loaded second.
+  :trace-emissions
+  [{:operation :rf.http.interceptor/registered
+    :tags      {:frame :rf/default :id :auth}}
+   {:operation :event :tags {:event-id :article/load}}
+   {:operation :rf.fx/override-applied
+    :tags      {:from :rf.http/managed
+                :to   :rf.http/managed-canned-success}}
+   {:operation :event :tags {:event-id :fixture/interceptor-fired}}
+   {:operation :event :tags {:event-id :article/loaded}}]}}

--- a/spec/conformance/fixtures/http-interceptor-clear.edn
+++ b/spec/conformance/fixtures/http-interceptor-clear.edn
@@ -1,0 +1,99 @@
+;; Conformance fixture: rf.http.interceptor/clear
+;;
+;; Per Spec 014 §Middleware (rf2-6y3q) + rf2-yhfgf — `:rf.fx/clear-http-
+;; interceptor` unregisters an interceptor by id; subsequent requests
+;; run WITHOUT the interceptor's side effects. The runtime emits a
+;; `:rf.http.interceptor/cleared` trace at the clear site.
+;;
+;; The fixture sequence:
+;;   1. `:app/init` registers a `:before` interceptor whose body bumps
+;;      a counter via dispatch.
+;;   2. First `:article/load` fires the canned-success path; the chain
+;;      walks (rf2-yhfgf), the `:before` runs, the counter advances
+;;      to 1.
+;;   3. `:fixture/clear-interceptor` fires `:rf.fx/clear-http-interceptor`
+;;      and the registered slot is removed.
+;;   4. Second `:article/load` fires the canned-success path again; the
+;;      chain is empty (no interceptors registered), so the counter
+;;      STAYS at 1. This is the load-bearing assertion — clear actually
+;;      detaches the body, not just the registry slot.
+
+{:fixture/id           :rf.http.interceptor/clear
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/sub :core/fx :core/trace
+                         :rf.http/managed}
+ :fixture/doc          "clear-http-interceptor via :rf.fx/clear-http-interceptor — after clearing, a subsequent canned-success request runs WITHOUT the cleared interceptor's body firing. Counter stays at 1 (one fire pre-clear, none post-clear). The :rf.http.interceptor/cleared trace fires at the clear site."
+
+ :fixture/registry
+ {:event {:app/init                  {:doc "Boot — register the interceptor."}
+          :article/load              {:doc "Issue the GET."}
+          :article/loaded            {:doc "Receive the canned-success payload."}
+          :fixture/clear-interceptor {:doc "Trigger :rf.fx/clear-http-interceptor."}
+          :fixture/interceptor-fired {:doc "Recorded by the :before's :dispatch op."}}
+  :sub   {:fire-count {:doc "How many times the :before fired."}}
+  :fx    {:rf.http/managed                {:platforms #{:client :server}}
+          :rf.http/managed-canned-success {:platforms #{:client :server}}
+          :rf.fx/reg-http-interceptor     {:platforms #{:client :server}}
+          :rf.fx/clear-http-interceptor   {:platforms #{:client :server}}}}
+
+ :fixture/handlers
+ {:event
+  {:app/init
+   [[:fx [[:rf.fx/reg-http-interceptor
+           {:id     :counter
+            :before [[:dispatch [:fixture/interceptor-fired]]]}]]]]
+
+   :article/load
+   [[:fx [[:rf.http/managed
+           {:request    {:method :get :url "/articles/hello"}
+            :decode     :json
+            :value      {:title "hello"}
+            :on-success [:article/loaded]}]]]]
+
+   :article/loaded
+   [[:set [:article] [:event-arg 1]]]
+
+   :fixture/clear-interceptor
+   [[:fx [[:rf.fx/clear-http-interceptor {:id :counter}]]]]
+
+   :fixture/interceptor-fired
+   [[:update [:fire-count] [:fn :inc]]]}
+
+  :sub
+  {:fire-count [[:get [:fire-count]]]}
+
+  ;; :rf.fx/reg-http-interceptor, :rf.fx/clear-http-interceptor, and
+  ;; :rf.http/managed-canned-success are intentionally NOT given
+  ;; fixture-DSL bodies — per the rf2-yhfgf harness rule, declaring an
+  ;; id in :fixture/registry :fx WITHOUT an explicit body in
+  ;; :fixture/handlers :fx leaves the framework registration in place.
+  :fx
+  {:rf.http/managed [[:noop]]}}
+
+ :fixture/frame-config
+ {:on-create    [:app/init]
+  :fx-overrides {:rf.http/managed :rf.http/managed-canned-success}}
+
+ :fixture/dispatches
+ [[:article/load]
+  [:fixture/clear-interceptor]
+  [:article/load]]
+
+ :fixture/expect
+ {:final-app-db
+  {:article    {:kind  :success
+                :value {:title "hello"}}
+   :fire-count 1}
+
+  :sub-values
+  {[:fire-count] 1}
+
+  :trace-emissions
+  [{:operation :rf.http.interceptor/registered
+    :tags      {:frame :rf/default :id :counter}}
+   {:operation :event :tags {:event-id :article/load}}
+   {:operation :event :tags {:event-id :fixture/interceptor-fired}}
+   {:operation :event :tags {:event-id :fixture/clear-interceptor}}
+   {:operation :rf.http.interceptor/cleared
+    :tags      {:frame :rf/default :id :counter}}
+   {:operation :event :tags {:event-id :article/load}}]}}


### PR DESCRIPTION
## Summary

- New `:rf.fx/reg-http-interceptor` and `:rf.fx/clear-http-interceptor` fxs wrap `reg-http-interceptor` / `clear-http-interceptor` (Spec 014 §Middleware, rf2-6y3q) so portable EDN conformance fixtures can register / clear interceptors through the `:fx` channel they already use.
- Canned-success / canned-failure stubs now walk the request-side interceptor chain before synthesising the reply — they replace the TRANSPORT, not the entire managed pipeline, so `:before` interceptors with load-bearing side effects (auth header injection, observability) fire on the canned path the same way they fire on the real-transport path.
- Two new conformance fixtures (`http-interceptor-before-transforms.edn`, `http-interceptor-clear.edn`) + conformance harness extensions: `realise-interceptor-before-fn` for DSL `:before` bodies, `resolve-fx-args` handling for `:rf.fx/reg-http-interceptor` (mirrors `:rf.fx/reg-flow`), and a per-fixture reset of the interceptor chain. The harness now respects "no explicit body in `:fixture/handlers :fx` = leave the framework registration alone" so fixtures can rely on the real fx behaviour.

## Test plan

- [x] `cd implementation/http && clojure -M:test` — 168 tests / 470 assertions (interceptor chain in canned stubs)
- [x] `cd implementation/core && clojure -M:test` — 534 tests / 2727 assertions (incl. conformance corpus + new fixtures)
- [x] `cd implementation && npm run test:cljs` — 2014 tests / 5695 assertions (CLJS conformance + new fixtures)
- [x] `npm run test:bundle-isolation` — all sentinels pass
- [x] `npm run test:elision` — all sentinels present