### PR TITLE
docs(p4-polish): boot.cljs + counter + cofx docstring sweep (rf2-l1wqb + jvixo + qspzh)

### DIFF
--- a/examples/reagent/boot/boot.cljs
+++ b/examples/reagent/boot/boot.cljs
@@ -44,7 +44,7 @@
    that needs to thread loaded data into the parent is: each child
    writes its result into a known app-db slice, the parent reads
    that slice on the join-resolved transition. This keeps the
-   loaded data in app-db throughout — inspectable in re-frame-10x
+   loaded data in app-db throughout — inspectable in pair-tools
    and snapshottable for SSR hydration.
 
    Trigger boot once at app start via `[:app/boot [:rf/start]]`. The
@@ -313,7 +313,7 @@
                (assoc :routes (:routes staging))
                ;; Mirror the loaded values into the boot machine's
                ;; :data slice so the snapshot is self-describing
-               ;; for SSR / tools / re-frame-10x inspection.
+               ;; for SSR / tools / pair-tools inspection.
                (update-in [:rf/machines :app/boot :data] assoc
                           :config (:config staging)
                           :flags  (:flags staging)

--- a/examples/reagent/counter/core.cljs
+++ b/examples/reagent/counter/core.cljs
@@ -2,14 +2,7 @@
   "A minimal counter against the re-frame2 API.
 
    Demonstrates: `reg-event-db`, `reg-sub`, `reg-view` with frame-bound
-   `dispatch`/`subscribe` injection.
-
-   NOTE on frame-provider: an earlier shape of this example wrapped
-   `:counter-buttons` in `[rf/frame-provider {:frame :counter} ...]`
-   so the subtree resolved its current frame to `:counter` rather
-   than `:rf/default`. The example still uses the default frame to
-   keep the smoke test focused; the frame-provider variant is
-   exercised by examples/reagent/login and the cross-spec test suite."
+   `dispatch`/`subscribe` injection."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core    :as rf]
             [re-frame.views]
@@ -35,8 +28,7 @@
 ;; The `:counter-buttons` view holds the UI. Per Spec 004 §reg-view, the
 ;; defn-shape macro auto-injects `dispatch` and `subscribe` as lexical
 ;; bindings; both resolve at render time to the frame in scope (the
-;; default frame here, see the namespace docstring for the
-;; frame-provider variant).
+;; default frame here).
 ;;
 ;; reg-view auto-defs a Var named after the supplied symbol and
 ;; registers the view under (keyword *ns* sym).

--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -21,11 +21,27 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-(def ^{:doc "Sentinel for `inject-cofx`'s 3-arity 'no-value' branch.
-  Used by `re-frame.core/inject-cofx`'s macro form (rf2-ts1a) to thread
-  a call-site through the no-value path without inventing a private
-  sentinel at the macro layer. Equality-tested via `identical?` so
-  user values never collide."} no-value
+(def ^{:doc "Sentinel that distinguishes \"no value supplied\" from
+  \"`nil` supplied\" in `inject-cofx`'s 3-arity form.
+
+  Why a sentinel: `inject-cofx`'s 2-arity `(inject-cofx :id value)`
+  passes `value` to the cofx handler's 2-arity body — and `nil` is a
+  valid `value` (e.g. `(inject-cofx :stub nil)` means \"stub me with a
+  nil reply\"). So the 3-arity can't use `nil` itself to mean \"caller
+  didn't supply a value\". `cofx/no-value` is a singleton keyword the
+  3-arity tests via `identical?`; user values never collide.
+
+  Why the 3-arity exists at all: it lets `re-frame.core/inject-cofx`'s
+  macro form (rf2-ts1a) thread the call-site through to the
+  interceptor even on the no-value path — without it, the macro would
+  need to expand to two different fn-form call shapes (with-value vs
+  without-value) and the macro-layer would need its own private
+  sentinel. Routing every macro expansion through the 3-arity keeps
+  the macro-side uniform.
+
+  Callers (humans + HoF use of `inject-cofx*`) reach for the 1- or
+  2-arity. The 3-arity is reserved for the macro expansion and tests
+  that want to assert call-site capture behaviour."} no-value
   ::no-value)
 
 ;; ---- the platform predicate -----------------------------------------------
@@ -174,16 +190,25 @@
       (inject-cofx :id)                   — no value, no call-site
       (inject-cofx :id value)             — per-call value, no call-site
       (inject-cofx :id value call-site)   — value + macro-stamped call-site
-                                            (use `cofx/no-value` for the
-                                            no-value path with a call-site)
+                                            (pass `cofx/no-value` as `value`
+                                            for the no-value path with a
+                                            call-site)
 
   The 3-arity form is what the `re-frame.core/inject-cofx` macro
   expands to; it captures `(meta &form)` at the user call site so
   error events emitted from the cofx body carry the invocation coord.
-  The 1-/2-arity forms wrap to the 3-arity with a `nil` call-site.
+  The 1-/2-arity forms wrap to the 3-arity with a `nil` call-site —
+  the 1-arity threads `cofx/no-value` as `value` so the 3-arity body's
+  `valued?` test (`identical?` against the sentinel) reports `false`
+  and the cofx handler is invoked via its 1-arity (no-value) shape.
+
+  Why a sentinel and not `nil`: the 2-arity admits `nil` as a real
+  per-call value (e.g. `(inject-cofx :stub nil)`), so the 3-arity
+  can't overload `nil` to mean \"caller supplied nothing\". See the
+  `no-value` def's docstring above for the full why.
 
   See also: `reg-cofx`, `re-frame.core/inject-cofx` (macro form with
-  call-site capture)."
+  call-site capture), `no-value` (the sentinel def)."
   ([cofx-id]
    (inject-cofx cofx-id no-value nil))
   ([cofx-id value]


### PR DESCRIPTION
## Summary

Three small P4 prose/docstring polish beads bundled into a single PR. One commit per bead.

- **rf2-jvixo** — `examples/reagent/counter/core.cljs`: drop stale `frame-provider` cross-ref from the ns docstring (and the trailing parenthetical in the views comment that pointed back at it). Pre-alpha posture: clean up, no replacement note.
- **rf2-l1wqb** — `examples/reagent/boot/boot.cljs`: two prose-comment swaps `re-frame-10x` → `pair-tools` (the re-frame2-era devtool stack: Story + Causa + pair2-mcp).
- **rf2-qspzh** — `implementation/core/src/re_frame/cofx.cljc`: document the `no-value` sentinel pattern in the def's docstring (why a sentinel — 2-arity admits real `nil`; why the 3-arity — uniform macro expansion + call-site capture on the no-value path; who reaches for which arity). Tightens `inject-cofx`'s Notes section to match. Impl unchanged.

## Test plan

- [x] `cd implementation && npm run test:cljs` — 2014 tests, 5695 assertions, 0 failures / 0 errors. Warnings present are pre-existing and unrelated.
- [x] Examples files are comment-only changes (no impl touched), so no further gates needed.