### PR TITLE
chore(impl): annotate magic numbers (rf2-xbev)

### DIFF
--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -220,6 +220,9 @@
 
 #?(:clj
    (defonce ^:private jvm-http-client
+     ;; 10s connect timeout — distinct from `:timeout-ms` (which bounds
+     ;; the whole request). Caps the TCP/TLS handshake so a black-holed
+     ;; host fails fast instead of leaning on the per-request timeout.
      (delay (-> (HttpClient/newBuilder)
                 (.connectTimeout (Duration/ofSeconds 10))
                 (.build)))))

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -1102,8 +1102,20 @@
         (when hit
           {:transition (assoc hit :decl-path prefix) :decl-path prefix})))))
 
-(def ^:private always-depth-limit-default 16)
-(def ^:private raise-depth-limit-default  16)
+(def ^:private always-depth-limit-default
+  ;; Per Spec 005 §Drain semantics: bounds the `:always` microstep loop
+  ;; (each iteration drains every match leaf→root). 16 leaves plenty of
+  ;; headroom for legitimate cascades while still catching `:always`
+  ;; loops within a single macrostep. Overridable per machine via
+  ;; `:always-depth-limit`.
+  16)
+
+(def ^:private raise-depth-limit-default
+  ;; Per Spec 005 §Drain semantics: bounds the recursive `:raise` queue
+  ;; drain. Symmetric with `always-depth-limit-default` — 16 is generous
+  ;; for hand-authored event-chains and catches accidental cycles.
+  ;; Overridable per machine via `:raise-depth-limit`.
+  16)
 
 ;; Forward-declared so `drain-raises` can call `machine-transition-single`
 ;; directly. The recursive `:raise` step is always against an already-

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -236,6 +236,10 @@
                 ;; Redirect short-circuits the stream — no chunked body.
                 (pipeline/ssr-response->ring-response resp nil content-type)
                 ;; Streaming path: build a pipe + spawn the writer thread.
+                ;; 16 KiB pipe buffer — large enough to absorb the shell
+                ;; chunk in one write so the writer thread rarely blocks
+                ;; on a slow consumer, small enough that one stuck client
+                ;; doesn't pin a non-trivial chunk of heap per request.
                 (let [pipe-in  (PipedInputStream. (* 16 1024))
                       pipe-out (PipedOutputStream. pipe-in)]
                   (.start


### PR DESCRIPTION
## Summary

Survey + annotate magic numbers across `implementation/`. The vast majority
of domain-meaningful literals (`50`, `100`, `200`, `50` (epoch), `16384`,
`10000`, `10000` (routing keys), `1048576`, `50` (scroll-positions-cap))
were already extracted to named `def`s with docstrings or section comments;
this pass fills the small remaining gaps.

Numbers annotated this pass: **3 sites, 4 literals**.

### Per-artefact

- **machines** (`machines/transition.cljc`):
  - `always-depth-limit-default = 16` — added explanatory comment
  - `raise-depth-limit-default  = 16` — added explanatory comment
- **ssr-ring** (`ssr/ring/streaming.clj`):
  - `(* 16 1024)` PipedInputStream buffer — added trade-off note
- **http** (`http_transport.cljc`):
  - `(Duration/ofSeconds 10)` JVM-client connect timeout — disambiguated
    from per-request `:timeout-ms`

### Survey findings (no change required)

These were already named + documented before this pass:

| File | Constant | Value |
|---|---|---|
| `core/elision.cljc` | `default-threshold-bytes` | `16384` |
| `core/elision.cljc` | `max-pr-str-bytes` | `1048576` |
| `core/subs.cljc` | `default-grace-period-ms` | `50` |
| `core/trace.cljc` | `default-buffer-depth` | `200` |
| `core/router.cljc` | `drain-depth-default` | `100` |
| `core/frame.cljc` | preset `:drain-depth` (100/16) | inline |
| `epoch/epoch.cljc` | `default-depth` | `50` |
| `http/util_json.cljc` | `default-max-decoded-keys` | `10000` |
| `routing/routing.cljc` | `default-max-decoded-keys` | `10000` |
| `routing/routing.cljc` | `scroll-positions-cap` | `50` |
| `http/http_encoding.cljc` | backoff defaults | inline-spec |

HTTP status codes (`200` / `300` / `400` / `500`) and FNV-1a constants
(`2166136261` / `16777619`) are universally understood and already
have surrounding context — no annotation.

### Follow-on configurability candidates

Surfaced as potential `configure` keys but NOT refactored in-band:

- `machines/transition.cljc` `always-depth-limit-default` /
  `raise-depth-limit-default` — already overridable per-machine, but a
  process-level default-knob could mirror `:trace-buffer` / `:epoch-history`.
- `ssr-ring/streaming.clj` 16 KiB pipe buffer — currently host-baked;
  could become a `streaming-handler` opt for backpressure tuning.
- `http_transport.cljc` 10s connect timeout — currently process-baked;
  could become a `configure :rf.http/transport` key.

## Test plan

- [x] `npm run test:cljs` — 2014 tests, 5695 assertions, 0 failures, 0 errors