### PR TITLE
refactor: registration-metadata fallout cluster (rf2-4h8ny+t9166+xnutu+gsl5v+44zpf+87wee+sjob2)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -69,6 +69,7 @@
                                     reg-sub reg-fx reg-cofx reg-frame
                                     reg-flow reg-route reg-app-schema reg-app-schemas
                                     reg-error-projector reg-head
+                                    reg-http-interceptor
                                     reg-view reg-machine
                                     dispatch dispatch-sync subscribe inject-cofx
                                     with-frame bound-fn with-fx-overrides
@@ -196,7 +197,16 @@
        model)`. `id` is a namespaced keyword (e.g. `:my.app/article`);
        routes name a head via `:head` route metadata. Captures source-
        coords (Spec 001) at this call site. Per Spec 011 §Head/meta
-       contract.")))
+       contract.")
+
+     (rm/defreg-macro reg-http-interceptor rf-http/reg-http-interceptor
+       "Register a request-side HTTP interceptor on a frame's
+       `:rf.http/managed` middleware chain. Captures source-coords
+       (Spec 001) at this call site. Implementation ships in
+       `day8/re-frame2-http` (Spec 014 §Middleware). See
+       `re-frame.core-http/reg-http-interceptor` for the full
+       signature."
+       {:arglists '([interceptor])})))
 
 ;; ---- reg-machine (bespoke — per-element coord stamping) -----------------
 
@@ -605,8 +615,12 @@
 (def install-managed-request-stubs!   rf-http/install-managed-request-stubs!)
 (def uninstall-managed-request-stubs! rf-http/uninstall-managed-request-stubs!)
 (def with-managed-request-stubs*      rf-http/with-managed-request-stubs*)
-(def reg-http-interceptor             rf-http/reg-http-interceptor)
 (def clear-http-interceptor           rf-http/clear-http-interceptor)
+
+;; reg-http-interceptor is a macro (per the defreg-macro form above) so
+;; source-coords are captured at the call site like every other reg-*.
+;; CLJS apps reach the fn-form via `re-frame.core-http/reg-http-interceptor`
+;; for programmatic registration that bypasses the macro path.
 
 ;; ---- configure / substrate adapter / boot --------------------------------
 

--- a/implementation/http/src/re_frame/http_middleware.cljc
+++ b/implementation/http/src/re_frame/http_middleware.cljc
@@ -27,13 +27,16 @@
   dispatched from frame B."
   (:require [re-frame.http-privacy :as privacy]
             [re-frame.interop      :as interop]
+            [re-frame.source-coords :as source-coords]
             [re-frame.trace        :as trace]))
 
 (defonce
-  ^{:doc "frame-id → vector of {:id :before} interceptor maps. Per-frame
-  so each frame's HTTP middleware chain is isolated. Order is
-  registration-order; clearing an id and re-registering re-appends to
-  the end."}
+  ^{:doc "frame-id → vector of `:rf/http-interceptor-meta` slots — each a map
+  carrying `:id`, `:before`, and the captured registration-metadata
+  (`:doc`, `:spec`, `:tags`, `:sensitive?`, flat source-coord keys
+  `:ns`/`:line`/`:column`/`:file`). Per-frame so each frame's HTTP
+  middleware chain is isolated. Order is registration-order; clearing an
+  id and re-registering re-appends to the end."}
   interceptors
   (atom {}))
 
@@ -49,13 +52,24 @@
 
   The interceptor map shape is:
 
-    {:frame  <frame-id>            ;; default :rf/default
-     :id     <keyword>              ;; required, addressable for clear
-     :before (fn [ctx] ctx')}       ;; required, request-side transform
+    {:frame      <frame-id>            ;; default :rf/default
+     :id         <keyword>             ;; required, addressable for clear
+     :before     (fn [ctx] ctx')       ;; required, request-side transform
+     :doc        <string>              ;; optional, per :rf/registration-metadata
+     :tags       <set-of-keywords>     ;; optional
+     :spec       <schema>              ;; optional
+     :sensitive? <boolean>}            ;; optional, per Spec 009 §Privacy
 
   `ctx` carries `:request` (the request map), `:args` (the full
   `:rf.http/managed` args), `:frame` (the frame-id), and `:event` (the
   originating event vector). The fn returns a (possibly-modified) ctx.
+
+  Source-coords (`:ns` / `:line` / `:column` / `:file`) are auto-captured
+  at the `rf/reg-http-interceptor` call site by the JVM-emitted macro in
+  `re-frame.core` (per Spec 001 §Source-coordinate capture). The stored
+  slot conforms to `:rf/http-interceptor-meta` (Spec-Schemas) — base
+  `:rf/registration-metadata` plus the interceptor-specific `:id`,
+  `:before`, and `:frame` keys.
 
   Re-registering an id replaces the slot in place (keeping registration
   order). Order is preserved across replace; first registration wins
@@ -74,9 +88,12 @@
                      :recovery :no-recovery
                      :received interceptor
                      :reason   "interceptor must be a map with :id (keyword) and :before (fn)"})))
-  (let [frame-id (or frame :rf/default)
-        slot     (cond-> {:id id}
-                   before (assoc :before before))]
+  (let [frame-id  (or frame :rf/default)
+        user-meta (dissoc interceptor :frame :id :before)
+        slot      (assoc (source-coords/merge-coords user-meta)
+                         :id     id
+                         :before before
+                         :frame  frame-id)]
     (swap! interceptors update frame-id
            (fn [chain]
              (let [chain (or chain [])

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -539,12 +539,13 @@ Per [rf2-6y3q](#) — apps repeatedly want to apply a transform to every outgoin
 
 ### Shape
 
-The interceptor shape matches re-frame2's event-handler interceptor idiom — each interceptor is a map `{:id <kw> :before (fn [ctx] ctx')}` — so authors reuse what they already know.
+The interceptor shape matches re-frame2's event-handler interceptor idiom — each interceptor is a map `{:id <kw> :before (fn [ctx] ctx')}` — so authors reuse what they already know. The map composes with `:rf/registration-metadata` (per [Spec-Schemas §`:rf/http-interceptor-meta`](Spec-Schemas.md#rfhttp-interceptor-meta)): `:doc` / `:tags` / `:spec` / `:sensitive?` ride alongside the interceptor-specific keys, and source-coords (`:ns` / `:line` / `:column` / `:file`) are auto-captured at the call site per [Spec 001 §Source-coordinate capture](001-Registration.md#source-coordinate-capture-cljs-reference).
 
 ```clojure
 (rf/reg-http-interceptor
   {:frame  :rf/default
    :id     :auth-header
+   :doc    "Stamp Bearer <token> on every outgoing request."
    :before (fn [ctx]
              (let [token (-> (rf/get-frame-db (:frame ctx)) :auth :token)]
                (cond-> ctx

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -335,6 +335,25 @@ The metadata map accepted by `reg-error-projector` (per [011 §Server error proj
     ]])
 ```
 
+#### `:rf/http-interceptor-meta`
+
+> **Layer:** Public
+
+The metadata map accepted by `reg-http-interceptor` (per [014 §Middleware](014-HTTPRequests.md#middleware)). Unlike the other per-kind shapes, HTTP interceptors are stored in a **per-frame side-table** (keyed by `:frame`) rather than in the global registrar — the registrar slot for `:http-interceptor` is intentionally absent. The schema describes the shape of each slot in that side-table.
+
+```clojure
+(def HttpInterceptorMeta
+  [:merge
+   RegistrationMetadata
+   [:map
+    [:id      :keyword]                                                    ;; required, addressable for clear
+    [:before  fn?]                                                         ;; required, request-side transform: (fn [ctx] ctx')
+    [:frame   :keyword]                                                    ;; runtime-stamped from user-supplied :frame or :rf/default
+    ]])
+```
+
+`:id`, `:before`, and `:frame` are the interceptor-specific slots; the base `RegistrationMetadata` keys (`:doc`, `:spec`, `:tags`, `:sensitive?`, `:ns` / `:line` / `:column` / `:file`) flow through additively — source-coords are auto-captured at the `rf/reg-http-interceptor` call site per [Spec 001 §Source-coordinate capture](001-Registration.md#source-coordinate-capture-cljs-reference). The slot is read by the runtime's `run-interceptor-chain!` (which pulls `:id` / `:before` only) and is also the canonical surface tools introspect for "where is this interceptor declared?" lookups.
+
 The route-shape — `:rf/route-metadata` — is defined separately further below in this catalogue (it predates this per-kind grouping). It composes with `:rf/registration-metadata` the same way the kinds above do; per [§`:rf/route-metadata`](#rfroute-metadata).
 
 ### `:rf/source-coord-meta`

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -226,6 +226,8 @@ The metadata map accepted by `reg-view` / `reg-view*`. The `^{:rf/id ...}` symbo
 
 `:rf/args` / `:rf/form` are stamped by the `reg-view` macro at expansion time; `reg-view*` (the plain-fn surface) carries neither — programmatic registrations have no args-vector to capture (per [004 §`reg-view*` — the plain-fn escape hatch](004-Views.md#reg-view--the-plain-fn-escape-hatch)). `:rf/props` is an optional user-supplied props schema; in dynamic hosts the framework can validate props against it at render-time-boundary in dev builds (per [010](010-Schemas.md)).
 
+**Note — Story's `:schema` legacy alias.** The Story tool (`tools/story/`) currently reads `:spec` and falls back to `:schema` (legacy alias) on view registrations — see [`tools/story/src/re_frame/story/ui/schema_validation.cljc`](../tools/story/src/re_frame/story/ui/schema_validation.cljc). The canonical key per `:rf/view-meta` is `:spec`; the `:schema` alias is a Story-internal accommodation acknowledged here only for discoverability. The framework itself recognises only `:spec`; tools authoring per Story conformance should use `:spec`. Pre-alpha: no back-compat shim — a follow-on bead will either remove the Story-side alias or formalise it as a per-tool extension key.
+
 #### `:rf/machine-meta`
 
 > **Layer:** Public

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -115,17 +115,19 @@ Common shape for the metadata map every `reg-*` accepts in its middle slot.
 ```clojure
 (def RegistrationMetadata
   [:map
-   [:doc       {:optional true} :string]                                   ;; SHOULD per [001 §:doc is dev-warned when absent]; structurally optional so re-registrations and programmatic paths still validate
-   [:spec      {:optional true} :any]                                      ;; Malli schema (or implementation equivalent)
-   [:ns        {:optional true} :symbol]                                   ;; auto-supplied by macros
-   [:line      {:optional true} :int]
-   [:file      {:optional true} :string]
-   [:tags      {:optional true} [:set :keyword]]                           ;; user-defined tags
-   [:platforms {:optional true} [:set [:enum :server :client]]]            ;; for reg-fx / reg-cofx; per [011](011-SSR.md)
+   [:doc        {:optional true} :string]                                  ;; SHOULD per [001 §:doc is dev-warned when absent]; structurally optional so re-registrations and programmatic paths still validate
+   [:spec       {:optional true} :any]                                     ;; Malli schema (or implementation equivalent)
+   [:ns         {:optional true} :symbol]                                  ;; auto-supplied by macros — flat per [§`:rf/source-coord-meta`](#rfsource-coord-meta)
+   [:line       {:optional true} :int]
+   [:column     {:optional true} :int]
+   [:file       {:optional true} :string]
+   [:tags       {:optional true} [:set :keyword]]                          ;; user-defined tags
+   [:platforms  {:optional true} [:set [:enum :server :client]]]           ;; for reg-fx / reg-cofx; per [011](011-SSR.md)
+   [:sensitive? {:optional true} :boolean]                                 ;; privacy flag — every reg-* accepts it; per [009 §Privacy / sensitive data in traces](009-Instrumentation.md#privacy--sensitive-data-in-traces) and the `:sensitive?` registration-metadata key contract therein. When `true`, the runtime stamps `:sensitive? true` on every trace event whose in-scope handler carries the flag and listeners default-drop those events (per Spec 009).
    ])
 ```
 
-Per-kind extensions (sub-specific, fx-specific, view-specific) are additive maps that conform to RegistrationMetadata's open shape. Each kind has its own narrowed schema enumerated below — `:rf/event-handler-meta`, `:rf/sub-meta`, `:rf/fx-meta`, `:rf/cofx-meta`, `:rf/view-meta`, `:rf/machine-meta`, `:rf/flow-meta`, `:rf/app-schema-meta`, `:rf/head-meta`, `:rf/error-projector-meta`, and the route-shaped `:rf/route-metadata` further below — and tools that need the per-kind shape look up the schema by registered id (e.g. via `(app-schema-at [:rf/event-handler-meta])`).
+Per-kind extensions (sub-specific, fx-specific, view-specific) are additive maps that conform to RegistrationMetadata's open shape. Each kind has its own narrowed schema enumerated below — `:rf/event-handler-meta`, `:rf/sub-meta`, `:rf/fx-meta`, `:rf/cofx-meta`, `:rf/view-meta`, `:rf/machine-meta`, `:rf/flow-meta`, `:rf/app-schema-meta`, `:rf/head-meta`, `:rf/error-projector-meta`, `:rf/http-interceptor-meta`, and the route-shaped `:rf/route-metadata` further below — and tools that need the per-kind shape look up the schema by registered id (e.g. via `(app-schema-at [:rf/event-handler-meta])`).
 
 `:doc` is `{:optional true}` in the schema but normatively SHOULD appear on every registration. The dev runtime surfaces missing-`:doc` registrations through `:rf.warning/missing-doc` (emitted at most once per `(kind, id)` pair; production-elided) — see [001 §`:doc` is dev-warned when absent](001-Registration.md#doc-is-dev-warned-when-absent) and [009 §Where trace emission lives](009-Instrumentation.md#where-trace-emission-lives) for the emission contract. The schema stays `{:optional true}` so programmatic re-registration paths and tooling that compose metadata maps without `:doc` still validate; the warning is the nudge, not a structural gate.
 

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -339,7 +339,7 @@ The route-shape — `:rf/route-metadata` — is defined separately further below
 
 > **Layer:** Public
 
-The registration-metadata source-coord sub-shape captured at `reg-*` macro-expansion time. Returned (as a sub-map of `:rf/registration-metadata`) from `(rf/handler-meta kind id)` and `(rf/frame-meta id)`; pair-shaped tools and IDE jump-to-source consumers read it for click-back-to-code resolution per [Tool-Pair §Source-mapping UI clicks back to code](Tool-Pair.md#source-mapping-ui-clicks-back-to-code).
+The registration-metadata source-coord shape captured at `reg-*` macro-expansion time. The four keys (`:ns` / `:line` / `:column` / `:file`) are merged **flat** onto `:rf/registration-metadata` — the same level as `:doc` / `:spec` / `:tags` — so `(rf/handler-meta kind id)` and `(rf/frame-meta id)` returns expose them as top-level keys: `(:line meta)` / `(:file meta)` / `(:ns meta)` / `(:column meta)`. Pair-shaped tools and IDE jump-to-source consumers read them for click-back-to-code resolution per [Tool-Pair §Source-mapping UI clicks back to code](Tool-Pair.md#source-mapping-ui-clicks-back-to-code). Trace events are the one shape that nests these keys under a `:source-coord` sub-map — see `:rf.trace/trigger-handler` on `:rf/trace-event` below — because traces carry coords for *another* handler (the in-scope trigger), so a sub-map keeps the trigger-handler shape self-contained alongside the trace's own keys.
 
 ```clojure
 (def SourceCoordMeta
@@ -372,7 +372,7 @@ The DOM-attribute string contract emitted by Reagent / SSR adapters as the value
   [:re #"^[^:]+:[^:]+:(?:\d+|\?):(?:\d+|\?)$"])                             ;; pragmatic regex; consumers parse 4 segments
 ```
 
-Consumers parse the four segments pragmatically (split on `:` from the right twice to recover `<line>` and `<col>`, then on `:` once more for `<ns>`/`<sym>`). To recover the full `:rf/source-coord-meta` shape — including `:file` — look up the handler-id via `(rf/handler-meta :view <handler-id>)` and read its source-coord sub-map; `:file` is **not** recoverable by parsing the attribute alone (it is not encoded in the 4-segment string).
+Consumers parse the four segments pragmatically (split on `:` from the right twice to recover `<line>` and `<col>`, then on `:` once more for `<ns>`/`<sym>`). To recover the full `:rf/source-coord-meta` shape — including `:file` — look up the handler-id via `(rf/handler-meta :view <handler-id>)` and read the flat top-level `:ns` / `:line` / `:column` / `:file` keys off the returned registration-metadata map; `:file` is **not** recoverable by parsing the attribute alone (it is not encoded in the 4-segment string).
 
 The string format is committed as a public contract (rf2-q7r0): pair-shaped tools, conformance harnesses, and CDP-driven test runners all parse it directly. Future extensions are additive — additional trailing segments may appear; consumers MUST handle the 4-segment shape and tolerate (ignore) trailing segments they do not recognise.
 

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -2111,25 +2111,26 @@ Per-fx args validation runs as part of the standard fx-arg validation (per [010 
 
 > **Layer:** Public
 
-Returned by `(frame-meta frame-id)`. The `:preset` field, when present, records which preset was applied (per [002 §Frame presets](002-Frames.md#frame-presets--capability-bundles-for-common-configurations)); the *expanded* keys are the effective metadata map.
+Returned by `(frame-meta frame-id)`. The `:preset` field, when present, records which preset was applied (per [002 §Frame presets](002-Frames.md#frame-presets--capability-bundles-for-common-configurations)); the *expanded* keys are the effective metadata map. Composes with `:rf/registration-metadata` the same way every other per-kind shape does — base `:doc` / `:tags` / `:spec` / `:ns` / `:line` / `:column` / `:file` / `:platforms` / `:sensitive?` come from the merge; the keys below are the frame-specific additions.
 
 ```clojure
 (def FrameMeta
-  [:map
-   [:id           :keyword]
-   [:created-at   :any]                                                    ;; timestamp
-   [:preset       {:optional true} [:enum :default :test :story :ssr-server]] ;; per 002 §Frame presets
-   [:on-create    {:optional true} [:vector :any]]                         ;; the init event vector
-   [:on-destroy   {:optional true} [:vector :any]]
-   [:fx-overrides {:optional true} [:map-of :keyword :any]]
-   [:interceptor-overrides {:optional true} [:map-of :keyword :any]]
-   [:interceptors {:optional true} [:vector :any]]
-   [:drain-depth  {:optional true} :int]
-   [:doc          {:optional true} :string]
-   [:tags         {:optional true} [:set :keyword]]
-   [:url-bound?   {:optional true} :boolean]                                ;; per [012-Routing.md](012-Routing.md)
-   [:platform     {:optional true} :keyword]                                ;; the frame's active platform; per [011-SSR.md](011-SSR.md). Single keyword (one platform per frame); compared against `reg-fx`'s `:platforms` set.
-   [:on-error     {:optional true} :keyword]])                              ;; error-projection target; per [011-SSR.md](011-SSR.md). The `:ssr-server` preset wires `:rf.error/server-projection`.
+  [:merge
+   RegistrationMetadata
+   [:map
+    [:id           :keyword]
+    [:created-at   :any]                                                   ;; timestamp
+    [:preset       {:optional true} [:enum :default :test :story :ssr-server]] ;; per 002 §Frame presets
+    [:on-create    {:optional true} [:vector :any]]                        ;; the init event vector
+    [:on-destroy   {:optional true} [:vector :any]]
+    [:fx-overrides {:optional true} [:map-of :keyword :any]]
+    [:interceptor-overrides {:optional true} [:map-of :keyword :any]]
+    [:interceptors {:optional true} [:vector :any]]
+    [:drain-depth  {:optional true} :int]
+    [:url-bound?   {:optional true} :boolean]                              ;; per [012-Routing.md](012-Routing.md)
+    [:platform     {:optional true} :keyword]                              ;; the frame's active platform; per [011-SSR.md](011-SSR.md). Single keyword (one platform per frame); compared against `reg-fx`'s `:platforms` set.
+    [:on-error     {:optional true} :keyword]                              ;; error-projection target; per [011-SSR.md](011-SSR.md). The `:ssr-server` preset wires `:rf.error/server-projection`.
+    ]])
 ```
 
 ### `:rf/preset-expansion`

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors_data.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors_data.cljs
@@ -364,17 +364,21 @@
                      "— `where is :user/login registered?`, `what does sub "
                      ":current-user look like?`, `which file owns the :navigate "
                      "fx?`. Supported kinds: event, sub, fx, cofx, view, frame, "
-                     "machine. The `machine` kind routes through "
-                     "(rf/machine-meta id) (Spec 005 §Querying machines); the "
-                     "other six route through (rf/handler-meta kind id). "
-                     "Returns `{:ok? true :kind k :id i ...meta...}` on a hit "
-                     "or `{:ok? false :reason :not-registered :kind k :id i}` "
-                     "when no slot matches.")
+                     "route, flow, head, error-projector, machine — the closed "
+                     "v1 registrar set (per Spec 001 §Registry model) minus "
+                     "`:app-schema` (intentionally empty registrar slot — its "
+                     "metadata lives in the schemas artefact's per-frame side-"
+                     "table, queried via `rf/app-schemas` instead). The "
+                     "`machine` kind routes through (rf/machine-meta id) (Spec "
+                     "005 §Querying machines); the other kinds route through "
+                     "(rf/handler-meta kind id). Returns `{:ok? true :kind k "
+                     ":id i ...meta...}` on a hit or `{:ok? false :reason "
+                     ":not-registered :kind k :id i}` when no slot matches.")
    :typicalTokens 400
    :inputSchema {:type "object"
                  :properties {:kind {:type "string"
-                                     :description "Registrar kind. One of event, sub, fx, cofx, view, frame, machine."
-                                     :enum ["event" "sub" "fx" "cofx" "view" "frame" "machine"]}
+                                     :description "Registrar kind. One of event, sub, fx, cofx, view, frame, route, flow, head, error-projector, machine."
+                                     :enum ["event" "sub" "fx" "cofx" "view" "frame" "route" "flow" "head" "error-projector" "machine"]}
                               :id   {:type "string"
                                      :description (str "EDN-encoded id, e.g. \":user/login\". For "
                                                        "composite-key subs, pass the vector form "
@@ -389,17 +393,21 @@
                      "surface — agents call this first to find out what's "
                      "registered, then `handler-meta` to drill into a specific "
                      "id. Supported kinds: event, sub, fx, cofx, view, frame, "
-                     "machine. The `machine` kind lists every event handler "
-                     "flagged `:rf/machine? true` via (rf/machines); the other "
-                     "six lift the id vector off the registrar's per-kind map. "
-                     "Returns `{:ok? true :kind k :ids [...] :count n}`. The "
-                     "id vector is sorted (string / keyword / symbol ordering) "
+                     "route, flow, head, error-projector, machine — the closed "
+                     "v1 registrar set (per Spec 001 §Registry model) minus "
+                     "`:app-schema` (intentionally empty registrar slot — use "
+                     "`rf/app-schemas` for schema enumeration). The `machine` "
+                     "kind lists every event handler flagged `:rf/machine? "
+                     "true` via (rf/machines); the other kinds lift the id "
+                     "vector off the registrar's per-kind map. Returns "
+                     "`{:ok? true :kind k :ids [...] :count n}`. The id "
+                     "vector is sorted (string / keyword / symbol ordering) "
                      "so the list shape is stable across calls.")
    :typicalTokens 800
    :inputSchema {:type "object"
                  :properties {:kind {:type "string"
-                                     :description "Registrar kind. One of event, sub, fx, cofx, view, frame, machine."
-                                     :enum ["event" "sub" "fx" "cofx" "view" "frame" "machine"]}
+                                     :description "Registrar kind. One of event, sub, fx, cofx, view, frame, route, flow, head, error-projector, machine."
+                                     :enum ["event" "sub" "fx" "cofx" "view" "frame" "route" "flow" "head" "error-projector" "machine"]}
                               :build {:type "string"}}
                  :required ["kind"]
                  :additionalProperties false}})

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/handler_meta.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/handler_meta.cljs
@@ -7,13 +7,15 @@
   ## handler-meta
 
   Returns `(rf/handler-meta kind id)` for the requested
-  `(kind, id)` pair — the registration-metadata map carrying
-  `:source-coord` (file/line/column/ns), `:doc`, `:tags`, the registrar
+  `(kind, id)` pair — the registration-metadata map carrying the flat
+  top-level source-coord keys `:ns` / `:line` / `:column` / `:file`
+  (per Spec-Schemas `:rf/source-coord-meta` — merged flat onto
+  `:rf/registration-metadata`), plus `:doc`, `:tags`, the registrar
   kind, and (per Spec 001 §The public registrar query API) whatever
   custom slots the `reg-*` macro emitted. The wire-pipeline (post-
-  rf2-cibp8) decorates every `:source-coord` map with an
-  `:rf.source/uri` string — so the AI host renders an immediate
-  jump-to-editor link off the handler-meta response.
+  rf2-cibp8) decorates every map that carries a usable source-coord
+  shape with an `:rf.source/uri` string — so the AI host renders an
+  immediate jump-to-editor link off the handler-meta response.
 
   Supported kinds: `event`, `sub`, `fx`, `cofx`, `view`, `frame`,
   `machine`. The first six map directly to `rf/handler-meta`'s

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/handler_meta.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/handler_meta.cljs
@@ -18,8 +18,12 @@
   immediate jump-to-editor link off the handler-meta response.
 
   Supported kinds: `event`, `sub`, `fx`, `cofx`, `view`, `frame`,
-  `machine`. The first six map directly to `rf/handler-meta`'s
-  registrar kinds; `machine` routes through the dedicated
+  `route`, `flow`, `head`, `error-projector`, `machine` — the closed
+  v1 registrar set (per Spec 001 §Registry model) minus `:app-schema`
+  (intentionally empty registrar slot — its metadata lives in the
+  schemas artefact's per-frame side-table, surfaced via
+  `rf/app-schemas`). The ten registrar kinds map directly to
+  `rf/handler-meta`; `machine` routes through the dedicated
   `rf/machine-meta` surface (Spec 005 §Querying machines — machines
   are registered as `:event` handlers carrying `:rf/machine? true`
   with their spec in the `:rf/machine` slot, and `machine-meta`
@@ -35,7 +39,8 @@
   surface. Agents call `registry-list {kind \"event\"}` first to find
   out what's registered, then `handler-meta` to drill in.
 
-  For `event` / `sub` / `fx` / `cofx` / `view` / `frame` the list
+  For every registrar kind (`event` / `sub` / `fx` / `cofx` / `view`
+  / `frame` / `route` / `flow` / `head` / `error-projector`) the list
   comes from `re-frame-pair2.runtime/registrar-list`. For `machine`
   the list comes from `re-frame.core/machines` — every event handler
   flagged `:rf/machine? true`.
@@ -65,14 +70,17 @@
 
 (def ^:private registrar-kinds
   "Kinds that map directly to the registrar's `kind->id->metadata`
-  table. `machine` is intentionally absent — it routes through
+  table — the closed v1 registrar set (per Spec 001 §Registry model)
+  minus `:app-schema` (intentionally empty registrar slot — schema
+  metadata lives in the schemas artefact's per-frame side-table).
+  `machine` is intentionally absent here too — it routes through
   `rf/machine-meta` (which inspects `:event`-kind metadata for the
-  `:rf/machine?` flag)."
-  #{:event :sub :fx :cofx :view :frame})
+  `:rf/machine?` flag) — but is in `supported-kinds` below."
+  #{:event :sub :fx :cofx :view :frame :route :flow :head :error-projector})
 
 (def ^:private supported-kinds
-  "The full set of kinds the tool accepts. Mirrors the bead's contract:
-  `event | sub | fx | cofx | view | machine | frame`."
+  "The full set of kinds the tool accepts. The ten registrar kinds
+  above plus the virtual `:machine` kind."
   (conj registrar-kinds :machine))
 
 (defn- parse-kind

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/source_uri.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/source_uri.cljs
@@ -1,11 +1,29 @@
 (ns re-frame-pair2-mcp.tools.source-uri
   "Source-URI decoration pass (rf2-cibp8).
 
-  Every pair2-mcp tool whose response carries `:source-coord
-  {:ns :file :line :column}` maps walks the post-shrink payload
-  through this transform. For every `:source-coord` map encountered,
-  a sibling `:rf.source/uri \"vscode://...\"` string is added (built
-  via `re-frame.source-coords.editor-uri/editor-uri`).
+  Every pair2-mcp tool whose response carries source-coord data walks
+  the post-shrink payload through this transform. The decorator
+  recognises two source-coord carriers — both shapes spec'd by
+  `:rf/source-coord-meta` in Spec-Schemas:
+
+  1. **Sub-map carrier** — trace events carry coords nested under a
+     `:source-coord` key (per `:rf/trace-event` and `:rf.trace/
+     trigger-handler`). When the walker descends into a map and that
+     map has a `:source-coord` slot whose value carries a usable
+     `:file` string, the URI is spliced on the OUTER map at
+     `:rf.source/uri`.
+  2. **Flat-key carrier** — `(rf/handler-meta kind id)` / `(rf/frame-
+     meta id)` returns merge source-coords flat onto the registration-
+     metadata map (`:ns` / `:line` / `:column` / `:file` at the top
+     level — per Spec-Schemas `:rf/source-coord-meta` and rf2-4h8ny).
+     When the walker descends into a map that itself carries a usable
+     `:file` string alongside other source-coord keys (`:ns`/`:line`/
+     `:column`), the URI is spliced on THAT map at `:rf.source/uri`.
+
+  The two carrier shapes are deliberately disjoint at the schema
+  level — trace events nest because the trigger-handler is a separate
+  handler from the trace's own coords; handler-meta is flat because
+  the call site IS the handler being introspected.
 
   ## Why a sibling URI string, not just the coord map
 
@@ -22,13 +40,20 @@
   ## Walk policy
 
   - Recurses into maps, vectors, lists, seqs, sets.
-  - When the walker descends into a map and that map has a
-    `:source-coord` slot whose value is itself a map, the URI is
-    spliced onto the map at the `:rf.source/uri` key.
-  - When `:source-coord`'s `:file` slot is missing / blank, the
-    underlying `editor-uri` returns nil; the decorator omits the
-    `:rf.source/uri` key entirely (keeps the response shape tight
-    — no `:rf.source/uri nil` slots).
+  - For the sub-map carrier: when the walker descends into a map M
+    whose `:source-coord` value is itself a map carrying `:file`,
+    the URI for that sub-map's `:file` is spliced onto M at
+    `:rf.source/uri`.
+  - For the flat-key carrier: when the walker descends into a map M
+    that itself carries a non-blank `:file` string AND at least one
+    other source-coord key (`:ns`/`:line`/`:column`) — guarding
+    against accidental decoration of unrelated maps that happen to
+    have a `:file` key — the URI for M's `:file` is spliced onto M
+    at `:rf.source/uri`.
+  - When `:file` is missing / blank, the underlying `editor-uri`
+    returns nil; the decorator omits the `:rf.source/uri` key
+    entirely (keeps the response shape tight — no `:rf.source/uri
+    nil` slots).
   - The walk is idempotent. A map that already carries
     `:rf.source/uri` is overwritten with the current editor's URI
     (so a stale URI from a server-side decorator can be replaced if
@@ -65,18 +90,52 @@
        (string? (:file v))
        (seq (:file v))))
 
+(defn- flat-coord-carrier?
+  "Is `m` itself a flat-key source-coord carrier? Match on `:file`
+  being a non-blank string AND at least one of `:ns` / `:line` /
+  `:column` being present — the multi-key guard rules out unrelated
+  maps that happen to carry a `:file` key for some other reason
+  (e.g. an MCP tool's `{:file \"/path/to/x.edn\"}` arg map).
+
+  Per `:rf/source-coord-meta`: handler-meta / frame-meta returns merge
+  these four keys flat onto the registration-metadata, so the carrier
+  shape is `{:doc ... :file ... :ns ... :line ...}` etc."
+  [m]
+  (and (map? m)
+       (string? (:file m))
+       (seq (:file m))
+       (or (contains? m :ns)
+           (contains? m :line)
+           (contains? m :column))))
+
 (defn- decorate-map
-  "Decorate `m` with `:rf.source/uri` when its `:source-coord` slot
-  carries a usable file string. Otherwise return `m` unchanged.
+  "Decorate `m` with `:rf.source/uri` when either:
+
+  - `m` carries a `:source-coord` sub-map with a usable file string
+    (trace-event carrier — per `:rf/trace-event`); the URI is built
+    from the sub-map and spliced onto `m`. OR
+  - `m` is itself a flat-key source-coord carrier (handler-meta /
+    frame-meta return shape — per `:rf/source-coord-meta`); the URI
+    is built from `m`'s own flat keys and spliced onto `m`.
+
+  Returns `m` unchanged when neither shape matches.
 
   Pure data → data; no atoms read here — the editor is threaded in
   by the caller so this fn is testable without the config atom."
   [m editor]
   (let [coord (:source-coord m)]
-    (if (coord-map? coord)
+    (cond
+      (coord-map? coord)
       (if-let [uri (editor-uri/editor-uri editor coord)]
         (assoc m :rf.source/uri uri)
         m)
+
+      (flat-coord-carrier? m)
+      (if-let [uri (editor-uri/editor-uri editor m)]
+        (assoc m :rf.source/uri uri)
+        m)
+
+      :else
       m)))
 
 (defn decorate

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/source_uri.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/source_uri.cljs
@@ -140,8 +140,8 @@
 
 (defn decorate
   "Walk `tree`, splicing `:rf.source/uri` onto every map that carries
-  a `:source-coord` slot with a usable `:file`. Returns the decorated
-  tree.
+  a `:source-coord` sub-map or is itself a flat-key source-coord
+  carrier. Returns the decorated tree.
 
   `editor` follows the `editor-uri/editor-uri` vocabulary — `:vscode`
   / `:cursor` / `:windsurf` / `:zed` / `:idea` / `{:custom <template>}`.
@@ -151,8 +151,15 @@
   [tree editor]
   (cond
     (map? tree)
+    ;; `:source-coord` values are terminal coord-data carriers — preserve
+    ;; them verbatim instead of recursing in (which would otherwise hit
+    ;; `decorate-map`'s flat-carrier branch and splice a URI onto the
+    ;; coord sub-map itself, double-decorating).
     (let [stepped (reduce-kv
-                    (fn [acc k v] (assoc acc k (decorate v editor)))
+                    (fn [acc k v]
+                      (assoc acc k (if (= k :source-coord)
+                                     v
+                                     (decorate v editor))))
                     {}
                     tree)]
       (decorate-map stepped editor))

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/handler_meta_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/handler_meta_test.cljs
@@ -64,7 +64,8 @@
             "kind + id are both required")
         (is (contains? properties :kind))
         (is (contains? properties :id))
-        (is (= #{"event" "sub" "fx" "cofx" "view" "frame" "machine"}
+        (is (= #{"event" "sub" "fx" "cofx" "view" "frame"
+                 "route" "flow" "head" "error-projector" "machine"}
                (set (:enum (:kind properties))))
             "kind enum lists every supported kind")))))
 
@@ -89,7 +90,8 @@
         (is (= #{"kind"} (set required))
             "kind is the only required arg")
         (is (contains? properties :kind))
-        (is (= #{"event" "sub" "fx" "cofx" "view" "frame" "machine"}
+        (is (= #{"event" "sub" "fx" "cofx" "view" "frame"
+                 "route" "flow" "head" "error-projector" "machine"}
                (set (:enum (:kind properties)))))))))
 
 (deftest registry-list-descriptor-surfaces-on-tools-list

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/source_uri_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/source_uri_test.cljs
@@ -161,6 +161,47 @@
     (let [v {:event-id :x :payload {:y 1}}]
       (is (= v (source-uri/decorate v :vscode))))))
 
+;; ---------------------------------------------------------------------------
+;; decorate — flat-key carrier (handler-meta / frame-meta shape; rf2-87wee).
+;;
+;; `(rf/handler-meta kind id)` and `(rf/frame-meta id)` return registration-
+;; metadata maps with flat `:ns` / `:line` / `:column` / `:file` keys (per
+;; Spec-Schemas `:rf/source-coord-meta` and rf2-4h8ny). The decorator must
+;; recognise this carrier shape and splice :rf.source/uri onto the map
+;; itself — distinct from the trace-event :source-coord sub-map carrier.
+;; ---------------------------------------------------------------------------
+
+(deftest decorate-splices-uri-on-flat-coord-carrier-map
+  (testing "a map with flat :ns/:line/:file keys (handler-meta shape) gets a :rf.source/uri"
+    (let [v   {:ok? true :kind :event :id :user/login
+               :doc "Sign the user in."
+               :ns 'app.events :file "src/app/events.cljs" :line 42 :column 7}
+          out (source-uri/decorate v :vscode)]
+      (is (= "vscode://file/src/app/events.cljs:42:7" (:rf.source/uri out)))
+      (is (= "Sign the user in." (:doc out)) ":doc passes through unchanged"))))
+
+(deftest decorate-flat-coord-carrier-requires-multi-key-guard
+  (testing "a map with only :file (no :ns/:line/:column) is NOT decorated"
+    ;; Guards against accidental decoration of unrelated maps that carry
+    ;; a :file key for some other reason (e.g. a tool arg map).
+    (let [v {:file "src/app/events.cljs"}]
+      (is (not (contains? (source-uri/decorate v :vscode) :rf.source/uri))))))
+
+(deftest decorate-flat-coord-carrier-skips-blank-file
+  (testing "a flat carrier with blank :file produces no :rf.source/uri"
+    (let [v {:ns 'app.events :file "" :line 42 :column 7}]
+      (is (not (contains? (source-uri/decorate v :vscode) :rf.source/uri))))))
+
+(deftest decorate-nested-handler-meta-shape
+  (testing "an :epochs walk through nested vectors decorates each handler-meta map"
+    (let [v   {:epochs [{:event-id :a
+                         :handler-meta {:ok? true :kind :event :id :a
+                                        :ns 'app.events :file "src/app/events.cljs"
+                                        :line 42 :column 7}}]}
+          out (source-uri/decorate v :vscode)
+          hm  (-> out :epochs first :handler-meta)]
+      (is (= "vscode://file/src/app/events.cljs:42:7" (:rf.source/uri hm))))))
+
 (deftest decorate-idempotent
   (testing "running the decorator twice yields the same result"
     (let [v       {:source-coord sample-coord}


### PR DESCRIPTION
## Summary

Cluster PR landing 7 beads surfaced by the rf2-bc0k6 registration-metadata audit (audit findings: `ai/findings/registration-metadata-audit-2026-05-15.md`). Tight surface: `spec/Spec-Schemas.md` + `tools/pair2-mcp/src/` + `spec/Tool-Pair.md` + `spec/API.md` + `spec/014-HTTPRequests.md` + `implementation/http/`.

Pre-alpha posture: no back-compat shims, no deprecation aliases. The sub-map → flat-keys standardisation is a one-way change.

## Commits

1. **rf2-4h8ny** (P3) — `docs(spec): standardise :rf/source-coord-meta as flat keys on registration-metadata`. Spec-Schemas L342 + L375 called source-coord a "sub-map"; impl/Tool-Pair/API.md all describe flat-keys. Standardise on flat (impl truth). Also fixes pair2-mcp handler-meta doc-string.
2. **rf2-t9166** (P2) — `docs(spec): add :sensitive? to :rf/registration-metadata schema`. Spec 009 says every `reg-*` accepts `:sensitive?`; schema didn't declare it. Adds `:sensitive?` slot + completes the four flat source-coord keys (`:column` was missing).
3. **rf2-xnutu** (P4) — `docs(spec): :rf/frame-meta now :merges :rf/registration-metadata`. Frame-meta was the outlier — standalone `[:map ...]` instead of `[:merge RegistrationMetadata ...]`. Now uniform with every other per-kind shape.
4. **rf2-gsl5v** (P3) — `feat(http): reg-http-interceptor captures :rf/registration-metadata`. Was bypassing the contract — slot stored only `{:id :before}`. Promote `re-frame.core/reg-http-interceptor` to a `defreg-macro` form, capture source-coords + user meta into the per-frame side-table. New schema `:rf/http-interceptor-meta` in Spec-Schemas. Spec 014 §Shape updated.
5. **rf2-44zpf** (P2) — `feat(pair2-mcp): extend handler-meta kind enum to closed v1 registrar set`. Was 7 of 11 kinds (event/sub/fx/cofx/view/frame/machine). Extends to all 10 registrar kinds + virtual `:machine` (= 11 total). `:app-schema` intentionally absent (empty registrar slot).
6. **rf2-87wee** (P3, 2 commits) — `fix(pair2-mcp): source-uri walker handles flat-key carrier shape` + recursion fix. Walker now decorates BOTH carriers — trace-event sub-map carrier and handler-meta flat-key carrier — without double-decorating. Three new tests pin the flat-carrier behaviour plus the multi-key guard.
7. **rf2-sjob2** (P4) — `docs(spec): acknowledge Story :schema legacy alias on :rf/view-meta`. Doc note; no behavioural change. Pre-alpha: no shim; follow-on bead will resolve Story's side.

## Hot-zone files touched (surgical)

- `spec/Spec-Schemas.md` — multiple commits (base schema, frame-meta, http-interceptor-meta, view-meta doc note, source-coord-meta wording)
- `spec/Tool-Pair.md` — verified L452 already says flat-keys; no edit needed
- `spec/API.md` — verified L336 already says flat-keys; no edit needed
- `spec/014-HTTPRequests.md` — §Shape interceptor map expanded with registration-metadata keys

## Test plan

- [x] `cd implementation && npm run test:cljs` — 2014 tests, 5695 assertions, 0 failures, 0 errors
- [x] `cd tools/pair2-mcp && npm test` — 442 tests, 1078 assertions, 0 failures, 0 errors
- [x] `cd implementation/http && clojure -M:test` — 168 tests, 470 assertions, 0 failures, 0 errors
- [x] No stale "source-coord sub-map" references remain in spec touching the handler-meta surface (verified by grep)
- [ ] CI gates (mkdocs strict + workflow checks) — pending CI

## Constraints honoured

- No back-compat shims; sub-map → flat-keys is one-way.
- No AI attribution in commits/PR.
- Disjoint from concurrent rf2-jicu2 agent surface (`implementation/core/src/re_frame/substrate/spine.cljs` + `implementation/adapters/*`) — zero overlap.