### PR TITLE
refactor(core): replace reagent.ratom/IDisposable in spine with re-frame-owned protocol (rf2-jicu2)

### DIFF
--- a/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
+++ b/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
@@ -13,9 +13,8 @@
   passes JS-array deps unconditionally). The React frame-context
   comes from `re-frame.adapter.context` so a mixed-substrate app's
   frame-provider chain composes across substrates."
-  (:require [reagent.core        :as r]
-            [reagent.ratom       :as ratom]
-            [helix.hooks         :as helix-hooks]
+  (:require [helix.hooks         :as helix-hooks]
+            [re-frame.disposable :as rf-disposable]
             [re-frame.frame      :as frame]
             [re-frame.late-bind  :as late-bind]
             [re-frame.substrate.adapter :as substrate-adapter]
@@ -144,11 +143,21 @@
 ;;     is sugar over the same read, so subscribe / dispatch and
 ;;     `use-context` agree on the active frame. Chain-bottom fallback
 ;;     is `frame/current-frame`.
-;;   :adapter/ratom etc. — rf2-s36l. Helix's derived values reify
-;;     stock reagent.ratom/IDisposable directly, so these hooks
-;;     delegate to stock Reagent's r/atom, ratom/make-reaction, etc.
-;;     Helix itself ships no reactive-atom primitive (it is the
-;;     minimal-React-wrapper niche per rf2-2qit).
+;;   :adapter/add-on-dispose! / :adapter/dispose! — rf2-jicu2. Spine-
+;;     produced derived values reify the re-frame-owned
+;;     `re-frame.disposable/IDisposable` (no Reagent coupling). The
+;;     adapter wires straight to the protocol fns. Pre-rf2-jicu2 these
+;;     routed to `reagent.ratom/add-on-dispose!` / `ratom/dispose!`
+;;     which dragged ~9KB of reagent.ratom + reagent.impl.batching into
+;;     every Helix-only release bundle for a single defprotocol slot.
+;;     The other reactive-substrate hooks (`:adapter/ratom`,
+;;     `:adapter/ratom?`, `:adapter/make-reaction`, `:adapter/reactive?`,
+;;     `:adapter/after-render`) are intentionally NOT published by the
+;;     Helix adapter — Helix ships no reactive-atom primitive (per
+;;     rf2-2qit) and `re-frame.interop`'s reactive surfaces have zero
+;;     production call sites under Helix; publishing those hooks would
+;;     force the Helix bundle to carry reagent.core (transitively
+;;     reagent.ratom) for code it never executes.
 ;;   :adapter/wrap-view — rf2-00li. Substrate-side source-coord
 ;;     injection via React.cloneElement (the inline hiccup-walk in
 ;;     views.cljs would mis-classify React-element output as a non-DOM
@@ -158,22 +167,10 @@
 (substrate-adapter/route-hook! adapter :adapter/current-frame
   adapter-context/function-component-current-frame
   #(frame/current-frame))
-(substrate-adapter/route-hook! adapter :adapter/ratom
-  r/atom)
-(substrate-adapter/route-hook! adapter :adapter/ratom?
-  (fn ratom?-impl [x] (satisfies? ratom/IReactiveAtom x))
-  (constantly false))
-(substrate-adapter/route-hook! adapter :adapter/make-reaction
-  ratom/make-reaction)
 (substrate-adapter/route-hook! adapter :adapter/add-on-dispose!
-  ratom/add-on-dispose!)
+  rf-disposable/-add-on-dispose)
 (substrate-adapter/route-hook! adapter :adapter/dispose!
-  ratom/dispose!)
-(substrate-adapter/route-hook! adapter :adapter/reactive?
-  ratom/reactive?
-  (constantly false))
-(substrate-adapter/route-hook! adapter :adapter/after-render
-  r/after-render)
+  rf-disposable/-dispose)
 (substrate-adapter/route-hook! adapter :adapter/wrap-view
   wrap-view)
 

--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -12,6 +12,7 @@
   (:require [reagent2.core             :as r]
             [reagent2.ratom            :as ratom]
             [reagent2.dom.client       :as rdc]
+            [re-frame.disposable       :as rf-disposable]
             [re-frame.frame            :as frame]
             [re-frame.late-bind        :as late-bind]
             [re-frame.substrate.adapter :as substrate-adapter]
@@ -153,10 +154,25 @@
   (constantly false))
 (substrate-adapter/route-hook! adapter :adapter/make-reaction
   ratom/make-reaction)
+;; rf2-jicu2: spine-produced derived values (from UIx/Helix substrates
+;; in a cross-substrate test bundle) reify the re-frame-owned
+;; `re-frame.disposable/IDisposable`; reagent-slim's own Reactions
+;; reify `reagent2.ratom/IDisposable`. The dispatcher protocol-checks
+;; both shapes — the re-frame-owned one first because it is the new
+;; path; falls through to reagent2's protocol for slim-native
+;; reactions.
 (substrate-adapter/route-hook! adapter :adapter/add-on-dispose!
-  ratom/add-on-dispose!)
+  (fn add-on-dispose!-dispatch [a f]
+    (cond
+      (satisfies? rf-disposable/IDisposable a) (rf-disposable/-add-on-dispose a f)
+      (satisfies? ratom/IDisposable a)         (ratom/add-on-dispose! a f)
+      :else                                    nil)))
 (substrate-adapter/route-hook! adapter :adapter/dispose!
-  ratom/dispose!)
+  (fn dispose!-dispatch [a]
+    (cond
+      (satisfies? rf-disposable/IDisposable a) (rf-disposable/-dispose a)
+      (satisfies? ratom/IDisposable a)         (ratom/dispose! a)
+      :else                                    nil)))
 (substrate-adapter/route-hook! adapter :adapter/reactive?
   ratom/reactive?
   (constantly false))

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -6,6 +6,7 @@
   (:require [reagent.core :as r]
             [reagent.ratom :as ratom]
             [reagent.dom.client :as rdc]
+            [re-frame.disposable :as rf-disposable]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
@@ -199,10 +200,26 @@
   (constantly false))
 (substrate-adapter/route-hook! adapter :adapter/make-reaction
   ratom/make-reaction)
+;; rf2-jicu2: a Reagent-installed app may still hold a spine-produced
+;; derived value (e.g. inherited through a cross-substrate test bundle
+;; that pre-loaded UIx/Helix machinery). Dispatch handles BOTH shapes —
+;; the re-frame-owned `re-frame.disposable/IDisposable` (spine derived
+;; values) and Reagent's own `reagent.ratom/IDisposable` (Reagent
+;; reactions). Protocol-checks the re-frame-owned one first because it
+;; is the new path; falls through to Reagent's protocol for
+;; Reagent-native reactions.
 (substrate-adapter/route-hook! adapter :adapter/add-on-dispose!
-  ratom/add-on-dispose!)
+  (fn add-on-dispose!-dispatch [a f]
+    (cond
+      (satisfies? rf-disposable/IDisposable a) (rf-disposable/-add-on-dispose a f)
+      (satisfies? ratom/IDisposable a)         (ratom/add-on-dispose! a f)
+      :else                                    nil)))
 (substrate-adapter/route-hook! adapter :adapter/dispose!
-  ratom/dispose!)
+  (fn dispose!-dispatch [a]
+    (cond
+      (satisfies? rf-disposable/IDisposable a) (rf-disposable/-dispose a)
+      (satisfies? ratom/IDisposable a)         (ratom/dispose! a)
+      :else                                    nil)))
 (substrate-adapter/route-hook! adapter :adapter/reactive?
   ratom/reactive?
   (constantly false))

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -11,10 +11,9 @@
   configuration: gensym prefixes, substrate name (used in warn-once
   text), and the runtime hook fns from `uix.hooks.alpha` (the
   `uix.core` macros expand to these)."
-  (:require [reagent.core      :as r]
-            [reagent.ratom     :as ratom]
-            [uix.core          :as uix]
+  (:require [uix.core          :as uix]
             [uix.hooks.alpha   :as uix-hooks]
+            [re-frame.disposable :as rf-disposable]
             [re-frame.frame    :as frame]
             [re-frame.late-bind :as late-bind]
             [re-frame.substrate.adapter :as substrate-adapter]
@@ -145,10 +144,21 @@
 ;;     dynamic-var-fallback chain via this hook; the per-adapter
 ;;     `use-current-frame` hook above is the NARROWER React-context-
 ;;     tier-only read (per rf2-84myk).
-;;   :adapter/ratom etc. — rf2-s36l. UIx ships no reactive-atom
-;;     primitive (per rf2-3yij); derived values reify stock
-;;     reagent.ratom/IDisposable, so these hooks delegate to
-;;     `r/atom`, `ratom/make-reaction`, etc.
+;;   :adapter/add-on-dispose! / :adapter/dispose! — rf2-jicu2. Spine-
+;;     produced derived values reify the re-frame-owned
+;;     `re-frame.disposable/IDisposable` (no Reagent coupling). The
+;;     adapter wires straight to the protocol fns. Pre-rf2-jicu2 these
+;;     routed to `reagent.ratom/add-on-dispose!` / `ratom/dispose!`
+;;     which dragged ~9KB of reagent.ratom + reagent.impl.batching into
+;;     every UIx-only release bundle for a single defprotocol slot.
+;;     The other reactive-substrate hooks (`:adapter/ratom`,
+;;     `:adapter/ratom?`, `:adapter/make-reaction`, `:adapter/reactive?`,
+;;     `:adapter/after-render`) are intentionally NOT published by the
+;;     UIx adapter — UIx ships no reactive-atom primitive (per
+;;     rf2-3yij) and `re-frame.interop`'s reactive surfaces have zero
+;;     production call sites under UIx; publishing those hooks would
+;;     force the UIx bundle to carry reagent.core (transitively
+;;     reagent.ratom) for code it never executes.
 ;;   :adapter/wrap-view — rf2-00li. Substrate-side source-coord
 ;;     injection via React.cloneElement (the views.cljs inline
 ;;     hiccup-walk would mis-classify React-element output as a
@@ -157,22 +167,10 @@
 (substrate-adapter/route-hook! adapter :adapter/current-frame
   adapter-context/function-component-current-frame
   #(frame/current-frame))
-(substrate-adapter/route-hook! adapter :adapter/ratom
-  r/atom)
-(substrate-adapter/route-hook! adapter :adapter/ratom?
-  (fn ratom?-impl [x] (satisfies? ratom/IReactiveAtom x))
-  (constantly false))
-(substrate-adapter/route-hook! adapter :adapter/make-reaction
-  ratom/make-reaction)
 (substrate-adapter/route-hook! adapter :adapter/add-on-dispose!
-  ratom/add-on-dispose!)
+  rf-disposable/-add-on-dispose)
 (substrate-adapter/route-hook! adapter :adapter/dispose!
-  ratom/dispose!)
-(substrate-adapter/route-hook! adapter :adapter/reactive?
-  ratom/reactive?
-  (constantly false))
-(substrate-adapter/route-hook! adapter :adapter/after-render
-  r/after-render)
+  rf-disposable/-dispose)
 (substrate-adapter/route-hook! adapter :adapter/wrap-view
   wrap-view)
 

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_late_bind_publication_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_late_bind_publication_cljs_test.cljs
@@ -8,10 +8,18 @@
     (1) `substrate-adapter/route-hook!` — routed `:adapter/*` hooks
         that run THIS adapter's impl iff this adapter is the
         currently-installed one; otherwise chain to the previous
-        handler. Used for `:adapter/current-frame`, `:adapter/ratom`,
-        `:adapter/make-reaction`, `:adapter/add-on-dispose!`,
-        `:adapter/dispose!`, `:adapter/ratom?`, `:adapter/reactive?`,
-        `:adapter/after-render`, `:adapter/wrap-view`.
+        handler. Used for `:adapter/current-frame`,
+        `:adapter/add-on-dispose!`, `:adapter/dispose!`,
+        `:adapter/wrap-view`.
+
+        Per rf2-jicu2 the UIx adapter no longer publishes
+        `:adapter/ratom`, `:adapter/ratom?`, `:adapter/make-reaction`,
+        `:adapter/reactive?`, or `:adapter/after-render` — UIx ships no
+        reactive-atom primitive (per rf2-3yij) and the reactive
+        surfaces have zero production call sites under UIx. Publishing
+        them previously forced reagent.core (transitively reagent.ratom
+        + reagent.impl.batching) into every UIx-only release bundle for
+        code the substrate never executed.
 
     (2) `late-bind/chain-fn!` — chained hooks where every contributor
         runs (independent of installed-adapter identity). Used for
@@ -45,14 +53,14 @@
   chained hooks (alphabetical). The set membership is what the test
   pins; ordering here is for human-readable diff."
   ;; Routed via substrate-adapter/route-hook!
+  ;;
+  ;; Per rf2-jicu2 the publication set was trimmed: the UIx adapter
+  ;; no longer publishes :adapter/ratom, :adapter/ratom?,
+  ;; :adapter/make-reaction, :adapter/reactive?, or
+  ;; :adapter/after-render. See this ns's docstring for rationale.
   #{:adapter/add-on-dispose!
-    :adapter/after-render
     :adapter/current-frame
     :adapter/dispose!
-    :adapter/make-reaction
-    :adapter/ratom
-    :adapter/ratom?
-    :adapter/reactive?
     :adapter/wrap-view
     ;; Chained via late-bind/chain-fn! (through spine/install-clear-warn-once-step!)
     :adapter/clear-warn-once-caches!

--- a/implementation/core/src/re_frame/disposable.cljs
+++ b/implementation/core/src/re_frame/disposable.cljs
@@ -1,0 +1,52 @@
+(ns re-frame.disposable
+  "Re-frame-owned disposable protocol for substrate-side derived values
+  that have no native reactive-atom primitive (UIx, Helix, and any
+  future minimal-React-wrapper substrate).
+
+  Background. Before rf2-jicu2 the substrate spine's `make-derived-value`
+  reified `reagent.ratom/IDisposable` to satisfy the sub-cache's
+  cross-substrate teardown contract (`re-frame.interop/add-on-dispose!`
+  on the cached reaction at slot construction; `re-frame.interop/
+  dispose!` at slot evict). That single require dragged ~9KB of
+  `reagent.ratom` + `reagent.impl.batching` into every UIx-only and
+  Helix-only bundle — code paths neither substrate ever executes —
+  because the protocol's defining ns sat inside Reagent. The protocol
+  shape itself is one defprotocol with two method slots; there is no
+  Reagent-implementation surface a non-Reagent substrate needs.
+
+  Resolution (rf2-ykqee Verdict B). Move the protocol home to core,
+  re-frame-owned. The spine reifies this protocol on its derived value
+  containers; UIx and Helix adapters wire `:adapter/add-on-dispose!`
+  and `:adapter/dispose!` straight to the protocol fns; the
+  `reagent.ratom` require is dropped from UIx and Helix entirely. The
+  Reagent and reagent-slim adapters keep their substrate's IDisposable
+  protocol on Reagent reactions but their adapter dispatchers route
+  via a fall-through that checks BOTH this protocol AND Reagent's —
+  so a spine-produced derived value that finds its way into a Reagent
+  bundle's `interop/add-on-dispose!` call site disposes cleanly.
+
+  Method naming. Single-leading-dash (`-add-on-dispose`, `-dispose`)
+  follows CLJS convention for internal protocol methods: the protocol
+  is a structural extension point, callers reach it through
+  `re-frame.interop`'s thin wrappers (which in turn route through the
+  late-bind `:adapter/*` hook table). Users do not call these directly."
+  (:refer-clojure :exclude []))
+
+(defprotocol IDisposable
+  "Cross-substrate disposal protocol owned by re-frame. The
+  cache-wiring contract per Spec 006 §subscription-cache: re-frame's
+  per-slot evict logic calls `re-frame.interop/add-on-dispose!` which
+  dispatches via the adapter's hook; substrates without a reactive-atom
+  primitive (UIx, Helix) satisfy this protocol on their derived-value
+  reifies. Substrates with their own IDisposable (Reagent,
+  reagent-slim) leave their reaction objects alone and route through
+  their existing protocol — see each adapter's `:adapter/add-on-dispose!`
+  routing."
+  (-add-on-dispose [this on-dispose-fn]
+    "Register a 0-arg `on-dispose-fn` to fire when `this` is disposed.
+     Multiple callbacks accumulate; they run in registration order at
+     `-dispose` time.")
+  (-dispose [this]
+    "Tear down `this` synchronously: unwire any source watches and fire
+     every registered on-dispose callback. Idempotent — a second
+     `-dispose` is a no-op."))

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -355,28 +355,22 @@
     :description "Resolve the in-flight Reagent component (routed via current-adapter)."}
    {:key         :adapter/ratom
     :producer-ns '[re-frame.adapter.reagent
-                   re-frame.adapter.reagent-slim
-                   re-frame.adapter.uix
-                   re-frame.adapter.helix]
+                   re-frame.adapter.reagent-slim]
     :chained?    true
     :design-bead "rf2-s36l"
-    :description "Substrate-specific ratom constructor (re-frame.interop/ratom)."}
+    :description "Substrate-specific ratom constructor (re-frame.interop/ratom). Per rf2-jicu2 not published by UIx/Helix — those substrates ship no reactive-atom primitive and re-frame.interop's reactive surfaces have zero production call sites under them."}
    {:key         :adapter/ratom?
     :producer-ns '[re-frame.adapter.reagent
-                   re-frame.adapter.reagent-slim
-                   re-frame.adapter.uix
-                   re-frame.adapter.helix]
+                   re-frame.adapter.reagent-slim]
     :chained?    true
     :design-bead "rf2-s36l"
-    :description "Substrate-specific ratom predicate (re-frame.interop/ratom?)."}
+    :description "Substrate-specific ratom predicate (re-frame.interop/ratom?). Per rf2-jicu2 not published by UIx/Helix; absent-hook fallback returns false."}
    {:key         :adapter/make-reaction
     :producer-ns '[re-frame.adapter.reagent
-                   re-frame.adapter.reagent-slim
-                   re-frame.adapter.uix
-                   re-frame.adapter.helix]
+                   re-frame.adapter.reagent-slim]
     :chained?    true
     :design-bead "rf2-s36l"
-    :description "Substrate-specific make-reaction (re-frame.interop/make-reaction)."}
+    :description "Substrate-specific make-reaction (re-frame.interop/make-reaction). Per rf2-jicu2 not published by UIx/Helix; absent-hook returns nil."}
    {:key         :adapter/add-on-dispose!
     :producer-ns '[re-frame.adapter.reagent
                    re-frame.adapter.reagent-slim
@@ -384,7 +378,7 @@
                    re-frame.adapter.helix]
     :chained?    true
     :design-bead "rf2-s36l"
-    :description "Substrate-specific add-on-dispose! (re-frame.interop/add-on-dispose!)."}
+    :description "Substrate-specific add-on-dispose! (re-frame.interop/add-on-dispose!). Per rf2-jicu2 UIx/Helix route to the re-frame-owned re-frame.disposable/IDisposable protocol; Reagent/reagent-slim dispatch both that protocol and their substrate's own IDisposable."}
    {:key         :adapter/dispose!
     :producer-ns '[re-frame.adapter.reagent
                    re-frame.adapter.reagent-slim
@@ -392,23 +386,19 @@
                    re-frame.adapter.helix]
     :chained?    true
     :design-bead "rf2-s36l"
-    :description "Substrate-specific dispose! (re-frame.interop/dispose!)."}
+    :description "Substrate-specific dispose! (re-frame.interop/dispose!). Per rf2-jicu2 UIx/Helix route to the re-frame-owned re-frame.disposable/IDisposable protocol; Reagent/reagent-slim dispatch both that protocol and their substrate's own IDisposable."}
    {:key         :adapter/reactive?
     :producer-ns '[re-frame.adapter.reagent
-                   re-frame.adapter.reagent-slim
-                   re-frame.adapter.uix
-                   re-frame.adapter.helix]
+                   re-frame.adapter.reagent-slim]
     :chained?    true
     :design-bead "rf2-s36l"
-    :description "Substrate-specific reactive? predicate (re-frame.interop/reactive?)."}
+    :description "Substrate-specific reactive? predicate (re-frame.interop/reactive?). Per rf2-jicu2 not published by UIx/Helix; absent-hook fallback returns false."}
    {:key         :adapter/after-render
     :producer-ns '[re-frame.adapter.reagent
-                   re-frame.adapter.reagent-slim
-                   re-frame.adapter.uix
-                   re-frame.adapter.helix]
+                   re-frame.adapter.reagent-slim]
     :chained?    true
     :design-bead "rf2-s36l"
-    :description "Substrate-specific after-render hook (re-frame.interop/after-render)."}
+    :description "Substrate-specific after-render hook (re-frame.interop/after-render). Per rf2-jicu2 not published by UIx/Helix; absent-hook returns nil."}
    {:key         :adapter/wrap-view
     :producer-ns '[re-frame.adapter.uix
                    re-frame.adapter.helix]

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -8,8 +8,8 @@
   Scope. This ns provides:
 
     * The plain-`atom` container quartet (make / read / replace / subscribe).
-    * `make-derived-value` (one watch per source; reifies Reagent's
-      `IDisposable`).
+    * `make-derived-value` (one watch per source; reifies the
+      re-frame-owned `re-frame.disposable/IDisposable`).
     * React 18+ root renderer (createRoot + render, hydrateRoot for
       hydrate).
     * Late-bind hiccup-emitter atom + `render-to-string` thrower.
@@ -33,7 +33,7 @@
   shape-compliant with the 9-fn substrate contract."
   (:require ["react"             :as React]
             ["react-dom/client"  :as react-dom-client]
-            [reagent.ratom       :as ratom]
+            [re-frame.disposable :as rf-disposable]
             [re-frame.interop    :as interop]
             [re-frame.late-bind  :as late-bind]
             [re-frame.subs       :as subs]
@@ -141,19 +141,23 @@
         (-remove-watch [_this k]
           (swap! watchers dissoc k)
           nil)
-        ;; Reagent's IDisposable — `interop/add-on-dispose!` calls into
-        ;; this protocol when wiring the sub-cache's slot teardown
-        ;; (per Spec 006 §subscription-cache). Adopting the Reagent
-        ;; protocol keeps the cache wiring substrate-agnostic at the
-        ;; call site — core does not branch on adapter type.
-        ratom/IDisposable
-        (dispose! [_]
+        ;; Re-frame-owned IDisposable — `interop/add-on-dispose!` /
+        ;; `interop/dispose!` route into this protocol via the
+        ;; adapter's `:adapter/add-on-dispose!` / `:adapter/dispose!`
+        ;; hooks (per Spec 006 §subscription-cache). Pre-rf2-jicu2 the
+        ;; spine reified `reagent.ratom/IDisposable` here, which forced
+        ;; every UIx/Helix bundle to pay ~9KB optimised / 2-3KB gzipped
+        ;; of `reagent.ratom` + `reagent.impl.batching` for one
+        ;; protocol — the new `re-frame.disposable/IDisposable` is
+        ;; re-frame-owned and carries no Reagent dependency.
+        rf-disposable/IDisposable
+        (-dispose [_]
           (doseq [[s k] @own-keys] (remove-watch s k))
           (reset! own-keys {})
           (reset! watchers {})
           (doseq [f @on-dispose-fns] (f))
           (reset! on-dispose-fns []))
-        (add-on-dispose! [_ f]
+        (-add-on-dispose [_ f]
           (swap! on-dispose-fns conj f))))))
 
 ;; ---- render ---------------------------------------------------------------

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -21,7 +21,7 @@
     "test:elision": "shadow-cljs release elision-probe elision-probe-control && node scripts/check-elision.cjs",
     "test:perf-bundle": "shadow-cljs release examples/counter examples/counter-perf && node scripts/check-perf-bundle.cjs",
     "test:schemas-bundle": "shadow-cljs release schemas-bundle-probe schemas-bundle-probe-malli && node scripts/check-schemas-bundle.cjs",
-    "test:bundle-isolation": "shadow-cljs release examples/counter && node scripts/check-bundle-isolation.cjs",
+    "test:bundle-isolation": "shadow-cljs release examples/counter examples/counter-uix examples/counter-helix && node scripts/check-bundle-isolation.cjs && node scripts/check-uix-helix-reagent-free.cjs",
     "test:bundle-comparison": "shadow-cljs release examples/counter examples/counter-slim-and-fast && node scripts/check-counter-slim-and-fast.cjs",
     "test:examples": "node ../examples/scripts/serve-and-run-examples-tests.cjs",
     "story:build": "node scripts/story-build.cjs",

--- a/implementation/scripts/check-uix-helix-reagent-free.cjs
+++ b/implementation/scripts/check-uix-helix-reagent-free.cjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/*
+ * UIx-only and Helix-only bundles must NOT pull in `reagent.ratom`
+ * or `reagent.impl.batching` (rf2-jicu2; resolves the rf2-ykqee
+ * audit's Verdict B).
+ *
+ * Pre-rf2-jicu2 the substrate spine (`re-frame.substrate.spine`)
+ * reified `reagent.ratom/IDisposable` on its derived-value container
+ * — a single require dragged ~9KB optimised / 2-3KB gzipped of
+ * `reagent.ratom` + `reagent.impl.batching` into every UIx-only and
+ * Helix-only release bundle. The spine now reifies a re-frame-owned
+ * protocol (`re-frame.disposable/IDisposable`); the UIx and Helix
+ * adapters drop their `reagent.core` / `reagent.ratom` requires
+ * entirely.
+ *
+ * This script grep-asserts those bundles for the Reagent sentinel
+ * strings. The closure compiler may rename symbols under :advanced
+ * but it does NOT rewrite the string literals Reagent declares via
+ * `set!` on JS-interop slots (`cljsRatom`, `cljsRatomGeneration`,
+ * Reagent's batching method names). If any appear in the UIx-only
+ * or Helix-only counter bundles, the spine is dragging Reagent
+ * back in — bundle isolation is broken.
+ *
+ * Methodology sanity check. To avoid a vacuous negative grep, the
+ * same sentinels MUST appear in a Reagent-using bundle (the
+ * `:examples/counter` build uses the Reagent adapter); the
+ * present-check on the Reagent bundle proves the grep has signal.
+ * If a future refactor displaces the sentinel strings, both the
+ * Reagent present-check and the UIx/Helix absent-check go silent —
+ * this script then fails fast on the present-check.
+ *
+ * Exit 0 on PASS, 1 on FAIL.
+ */
+
+'use strict';
+
+const path = require('path');
+const { readReleaseBlob } = require('./lib/read-release-bundle.cjs');
+
+const ROOT = path.resolve(__dirname, '..');
+
+// ----- sentinels -------------------------------------------------------------
+//
+// Each sentinel is a string fragment unique to `reagent.ratom` or
+// `reagent.impl.batching`. The bead's measurement (rf2-ykqee) names
+// those two namespaces as the dominant payload — every Reagent
+// sibling that came along for the ride was transitively imported by
+// one or the other.
+//
+//   `cljsRatom`     — set as a JS property on React components by
+//                     reagent.ratom.cljs; survives :advanced because
+//                     it is an interop string (`set! (.-cljsRatom
+//                     component) …`), not a CLJS field.
+//   `cljsIsDirty`   — interop property `reagent.impl.batching`'s
+//                     `RenderQueue.run-queue` reads on each per-frame
+//                     drain (`(.-cljsIsDirty c)`). Survives :advanced
+//                     for the same interop-string reason. Direct
+//                     evidence the batching module body is in the bundle.
+const REAGENT_SENTINELS = [
+  { source: 'reagent.ratom cljsRatom field (set on React component)',
+    sentinel: 'cljsRatom' },
+  { source: 'reagent.impl.batching cljsIsDirty (RenderQueue.run-queue interop)',
+    sentinel: 'cljsIsDirty' },
+];
+
+// ----- helpers ---------------------------------------------------------------
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function countSubstring(blob, needle) {
+  const re = new RegExp(escapeRe(needle), 'g');
+  const m  = blob.match(re);
+  return m ? m.length : 0;
+}
+
+function checkBundle(label, bundlePath, mustContain) {
+  const blob = readReleaseBlob(bundlePath);
+  if (blob == null) {
+    console.error(`[uix-helix-reagent-free] ${label}: bundle path missing — ${bundlePath}`);
+    console.error('                          Did you run the matching shadow-cljs release?');
+    return false;
+  }
+  console.log(`  ${label}: ${bundlePath}`);
+  console.log(`    bundle size: ${blob.length} chars`);
+
+  let ok = true;
+  for (const { source, sentinel } of REAGENT_SENTINELS) {
+    const hits     = countSubstring(blob, sentinel);
+    const present  = hits > 0;
+    const expected = mustContain ? 'PRESENT (>=1)' : 'ABSENT (0)';
+    const actual   = present     ? `PRESENT (${hits})` : 'ABSENT (0)';
+    const passed   = present === mustContain;
+    const tag      = passed ? 'OK' : 'FAIL';
+    console.log(`    [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} expected ${expected}, was ${actual}`);
+    if (!passed) ok = false;
+  }
+  return ok;
+}
+
+// ----- main ------------------------------------------------------------------
+
+function main() {
+  console.log('=== UIx-only / Helix-only Reagent isolation (rf2-jicu2) ===');
+  console.log('');
+
+  const uixDir     = path.join(ROOT, 'out', 'examples', 'counter-uix');
+  const helixDir   = path.join(ROOT, 'out', 'examples', 'counter-helix');
+  const reagentDir = path.join(ROOT, 'out', 'examples', 'counter');
+
+  // Negative assertions: the new spine produces a UIx-only / Helix-only
+  // bundle with no Reagent dependency.
+  const uixOk   = checkBundle('UIx-only counter   (must NOT contain reagent.ratom / reagent.impl.batching)',
+                              uixDir, false);
+  console.log('');
+  const helixOk = checkBundle('Helix-only counter (must NOT contain reagent.ratom / reagent.impl.batching)',
+                              helixDir, false);
+  console.log('');
+  // Positive assertion: the Reagent-using counter bundle DOES carry the
+  // sentinels. Without this present-check, a sentinel-name regression
+  // would silently turn the negative greps above into vacuous passes.
+  const reagentOk = checkBundle('Reagent counter    (methodology sanity — sentinels MUST be present)',
+                                reagentDir, true);
+
+  if (uixOk && helixOk && reagentOk) {
+    console.log('');
+    console.log('=== PASS ===');
+    process.exit(0);
+  } else {
+    console.error('');
+    console.error('=== FAIL ===');
+    console.error('');
+    if (!uixOk || !helixOk) {
+      console.error('A UIx-only or Helix-only release bundle pulled in reagent.ratom');
+      console.error('or reagent.impl.batching. Per rf2-jicu2 the substrate spine reifies');
+      console.error('the re-frame-owned `re-frame.disposable/IDisposable` protocol —');
+      console.error('the UIx and Helix adapter ns\'s ship no `reagent.core` /');
+      console.error('`reagent.ratom` require. A regression here usually means:');
+      console.error('  (a) the spine reified `reagent.ratom/IDisposable` again, or');
+      console.error('  (b) a UIx/Helix-side ns picked up a transitive Reagent dep');
+      console.error('      (e.g. via a new `:require [reagent.* ...]` in adapter wiring).');
+    }
+    if (!reagentOk) {
+      console.error('The Reagent-bundle present-check failed — the sentinel grep would');
+      console.error('be vacuous. Either the sentinel strings have moved (refactor in');
+      console.error('reagent.ratom / reagent.impl.batching upstream) or the counter');
+      console.error('example stopped depending on the Reagent adapter. Investigate and');
+      console.error('refresh REAGENT_SENTINELS in this script.');
+    }
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Resolves the rf2-ykqee audit's Verdict B. The substrate spine (`re-frame.substrate.spine`) previously reified `reagent.ratom/IDisposable` on its derived-value container — a single require dragged ~9KB optimised / 3KB gzipped of `reagent.ratom` + `reagent.impl.batching` into every UIx-only and Helix-only release bundle for one defprotocol slot.

* New `re-frame.disposable/IDisposable` protocol (core-owned). Spine reifies it on its derived-value container.
* UIx and Helix adapters drop `reagent.core` and `reagent.ratom` requires entirely. They route `:adapter/add-on-dispose!` and `:adapter/dispose!` to the new protocol; they stop publishing `:adapter/ratom`, `:adapter/ratom?`, `:adapter/make-reaction`, `:adapter/reactive?`, `:adapter/after-render` (zero production call sites under UIx/Helix; publishing forced Reagent into the bundle).
* Reagent and reagent-slim adapters dispatch `:adapter/add-on-dispose!` and `:adapter/dispose!` through a `satisfies?`-cond that handles BOTH `re-frame.disposable/IDisposable` (spine-produced derived values) AND the substrate's own IDisposable (Reagent-native reactions).
* Late-bind directory updated to trim UIx/Helix from the producer-ns lists of the dropped hooks.
* New `scripts/check-uix-helix-reagent-free.cjs` wired into `npm run test:bundle-isolation`. Grep-asserts UIx-only / Helix-only release bundles do not contain `cljsRatom` or `cljsIsDirty` (the Reagent interop sentinel strings). Same sentinels are present-checked in the Reagent bundle to prevent the negative grep going vacuous.

## Protocol shape

```clojure
(defprotocol IDisposable
  (-add-on-dispose [this on-dispose-fn]
    \"Register a 0-arg `on-dispose-fn` to fire when `this` is disposed.\")
  (-dispose [this]
    \"Tear down `this` synchronously: unwire any source watches and fire
     every registered on-dispose callback.\"))
```

## Bundle measurements

Optimised `main.js`:

| Bundle               | Before (bytes) | After (bytes) | Delta             |
| -------------------- | -------------- | ------------- | ----------------- |
| `counter-uix`        | 358,878        | 348,803       | **-10,075 (-9.8 KB)** |
| `counter-helix`      | 389,866        | 376,641       | **-13,225 (-12.9 KB)** |
| `counter` (Reagent)  | 373,301        | 374,045       | +744 (+0.7 KB; new dispatcher) |

Gzipped:

| Bundle               | Before (bytes) | After (bytes) | Delta             |
| -------------------- | -------------- | ------------- | ----------------- |
| `counter-uix`        | 101,798        | 98,533        | **-3,265 (-3.2 KB)** |
| `counter-helix`      | 107,513        | 103,666       | **-3,847 (-3.8 KB)** |
| `counter` (Reagent)  | 105,222        | 105,325       | +103 (+0.1 KB)    |

Verification that UIx-only and Helix-only bundles no longer carry reagent.ratom or reagent.impl.batching:

```
UIx-only counter   bundle size: 348795 chars
    [OK] sentinel \"cljsRatom\"   expected ABSENT (0), was ABSENT (0)
    [OK] sentinel \"cljsIsDirty\" expected ABSENT (0), was ABSENT (0)
Helix-only counter bundle size: 376633 chars
    [OK] sentinel \"cljsRatom\"   expected ABSENT (0), was ABSENT (0)
    [OK] sentinel \"cljsIsDirty\" expected ABSENT (0), was ABSENT (0)
Reagent counter    bundle size: 374037 chars (methodology sanity)
    [OK] sentinel \"cljsRatom\"   expected PRESENT (>=1), was PRESENT (4)
    [OK] sentinel \"cljsIsDirty\" expected PRESENT (>=1), was PRESENT (6)
```

## Test plan

- [x] `npm run test:cljs` — 2014 tests, 5680 assertions, 0 failures
- [x] `npm run test:bundle-isolation` — counter isolation PASS + new Reagent-free PASS
- [x] `npm run test:perf-bundle` — PASS
- [x] `npm run test:elision` — PASS
- [x] core JVM tests (`clojure -M:test`) — 534 tests, 0 failures
- [x] Bundle-size measurement confirms -9.8 KB optimised / -3.2 KB gzipped on UIx-only counter; -12.9 KB / -3.8 KB on Helix-only