### PR TITLE
refactor(epoch): audit follow-ups cluster (rf2-1294f+i0rl9+kl5p1+7kxxx)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -936,26 +936,30 @@
 
 (defn- frame-exists-or-fail
   "Resolve `frame-id` to its `frame-record` or yield the canonical
-  no-such-handler precondition-failure tuple. Returns `[:ok
-  frame-record]` or `[:fail :rf.error/no-such-handler {:kind :frame
-  :frame frame-id}]`. Shared by every Tool-Pair / time-travel write
-  surface so the no-such-handler tag shape stays canonical."
+  no-such-handler precondition-failure result. Returns
+  `{:outcome :ok :frame-record <record>}` or
+  `{:outcome :fail :op :rf.error/no-such-handler
+    :tags {:kind :frame :frame frame-id}}`. Shared by every Tool-Pair /
+  time-travel write surface so the no-such-handler tag shape stays
+  canonical."
   [frame-id]
   (if-let [frame-record (frame/frame frame-id)]
-    [:ok frame-record]
-    [:fail :rf.error/no-such-handler
-     {:kind  :frame
-      :frame frame-id}]))
+    {:outcome :ok :frame-record frame-record}
+    {:outcome :fail
+     :op      :rf.error/no-such-handler
+     :tags    {:kind  :frame
+               :frame frame-id}}))
 
 (defn- check-restore-preconditions!
   "Validate the seven documented preconditions for restoring `frame-id`
-  to `epoch-id`. Returns:
+  to `epoch-id`. Returns a result map:
 
-    [:ok epoch]  — all checks passed; `epoch` is the resolved history
+    {:outcome :ok :epoch <epoch>}
+                 — all checks passed; `:epoch` is the resolved history
                    record whose `:db-after` is the restore target.
-    [:fail kw tags]
-                 — first failing check; `kw` is the trace operation
-                   the caller must emit, `tags` are its tags. No
+    {:outcome :fail :op <kw> :tags <map>}
+                 — first failing check; `:op` is the trace operation
+                   the caller must emit, `:tags` are its tags. No
                    trace events are emitted from inside this helper —
                    emission is the caller's job so the
                    precondition test stays a pure data check.
@@ -967,14 +971,15 @@
   (let [frame-result (frame-exists-or-fail frame-id)]
     (cond
       ;; (1) Frame registered?
-      (= :fail (first frame-result))
+      (= :fail (:outcome frame-result))
       frame-result
 
       ;; (2) In-flight drain?
-      (drain-in-flight? (second frame-result))
-      [:fail :rf.epoch/restore-during-drain
-       {:frame    frame-id
-        :epoch-id epoch-id}]
+      (drain-in-flight? (:frame-record frame-result))
+      {:outcome :fail
+       :op      :rf.epoch/restore-during-drain
+       :tags    {:frame    frame-id
+                 :epoch-id epoch-id}}
 
       :else
       (let [history (epoch-history frame-id)
@@ -982,10 +987,11 @@
         (cond
           ;; (3) Epoch present in current history?
           (nil? epoch)
-          [:fail :rf.epoch/restore-unknown-epoch
-           {:frame        frame-id
-            :epoch-id     epoch-id
-            :history-size (count history)}]
+          {:outcome :fail
+           :op      :rf.epoch/restore-unknown-epoch
+           :tags    {:frame        frame-id
+                     :epoch-id     epoch-id
+                     :history-size (count history)}}
 
           ;; (3a) Halted-cascade target? Per rf2-v0jwt: an epoch whose
           ;; :outcome is not :ok records partial state the cascade
@@ -994,11 +1000,12 @@
           ;; the failure surfaces with the actual halt context, not
           ;; a downstream consequence of the partial db.
           (not= :ok (get epoch :outcome :ok))
-          [:fail :rf.epoch/restore-non-ok-record
-           {:frame       frame-id
-            :epoch-id    epoch-id
-            :outcome     (:outcome epoch)
-            :halt-reason (:halt-reason epoch)}]
+          {:outcome :fail
+           :op      :rf.epoch/restore-non-ok-record
+           :tags    {:frame       frame-id
+                     :epoch-id    epoch-id
+                     :outcome     (:outcome epoch)
+                     :halt-reason (:halt-reason epoch)}}
 
           :else
           (let [db-target (:db-after epoch)]
@@ -1013,30 +1020,33 @@
               ;; live digest, so pair tools can pinpoint *what
               ;; changed* about the schema set, not merely *that*
               ;; it changed.
-              [:fail :rf.epoch/restore-schema-mismatch
-               {:frame                  frame-id
-                :epoch-id               epoch-id
-                :schema-digest-recorded (:schema-digest epoch)
-                :schema-digest-current  (current-schema-digest frame-id)
-                :failing-paths          (vec failing-paths)}]
+              {:outcome :fail
+               :op      :rf.epoch/restore-schema-mismatch
+               :tags    {:frame                  frame-id
+                         :epoch-id               epoch-id
+                         :schema-digest-recorded (:schema-digest epoch)
+                         :schema-digest-current  (current-schema-digest frame-id)
+                         :failing-paths          (vec failing-paths)}}
 
               (if-let [missing (seq (missing-references db-target))]
                 ;; (5) Missing handler referenced from db?
-                [:fail :rf.epoch/restore-missing-handler
-                 {:frame    frame-id
-                  :epoch-id epoch-id
-                  :missing  (vec missing)}]
+                {:outcome :fail
+                 :op      :rf.epoch/restore-missing-handler
+                 :tags    {:frame    frame-id
+                           :epoch-id epoch-id
+                           :missing  (vec missing)}}
 
                 (if-let [{:keys [machine-id recorded current]} (machine-version-mismatch db-target)]
                   ;; (6) Machine snapshot version drift?
-                  [:fail :rf.epoch/restore-version-mismatch
-                   {:frame            frame-id
-                    :epoch-id         epoch-id
-                    :machine-id       machine-id
-                    :version-recorded recorded
-                    :version-current  current}]
+                  {:outcome :fail
+                   :op      :rf.epoch/restore-version-mismatch
+                   :tags    {:frame            frame-id
+                             :epoch-id         epoch-id
+                             :machine-id       machine-id
+                             :version-recorded recorded
+                             :version-current  current}}
 
-                  [:ok epoch])))))))))
+                  {:outcome :ok :epoch epoch})))))))))
 
 (defn- perform-restore!
   "Carry out the actual `app-db` rewind once preconditions have passed.
@@ -1073,10 +1083,10 @@
   [frame-id epoch-id]
   (if-not interop/debug-enabled?
     false
-    (let [result (check-restore-preconditions! frame-id epoch-id)]
-      (case (first result)
-        :ok   (perform-restore! frame-id (second result))
-        :fail (do (emit-precondition-failure! (second result) (nth result 2))
+    (let [{:keys [outcome epoch op tags]} (check-restore-preconditions! frame-id epoch-id)]
+      (case outcome
+        :ok   (perform-restore! frame-id epoch)
+        :fail (do (emit-precondition-failure! op tags)
                   false)))))
 
 ;; ---- reset-frame-db! (Tool-Pair §Pair-tool writes, rf2-zq55) -------------
@@ -1106,30 +1116,32 @@
 
 (defn- check-reset-frame-db-preconditions!
   "Validate the three documented preconditions for `reset-frame-db!`.
-  Returns `[:ok]` when all checks pass, otherwise `[:fail kw tags]`
-  matching the precondition-failure shape of
-  `check-restore-preconditions!`. Pure data — no trace events emitted
-  from here; emission is the caller's job."
+  Returns `{:outcome :ok}` when all checks pass, otherwise
+  `{:outcome :fail :op <kw> :tags <map>}` matching the precondition-
+  failure shape of `check-restore-preconditions!`. Pure data — no
+  trace events emitted from here; emission is the caller's job."
   [frame-id new-db]
   (let [frame-result (frame-exists-or-fail frame-id)]
     (cond
       ;; (1) Frame registered?
-      (= :fail (first frame-result))
+      (= :fail (:outcome frame-result))
       frame-result
 
       ;; (2) In-flight drain?
-      (drain-in-flight? (second frame-result))
-      [:fail :rf.epoch/reset-frame-db-during-drain
-       {:frame frame-id}]
+      (drain-in-flight? (:frame-record frame-result))
+      {:outcome :fail
+       :op      :rf.epoch/reset-frame-db-during-drain
+       :tags    {:frame frame-id}}
 
       ;; (3) Schema mismatch?
       (not (schema-validate-ok? frame-id new-db))
-      [:fail :rf.epoch/reset-frame-db-schema-mismatch
-       {:frame         frame-id
-        :failing-paths (failing-paths-for frame-id new-db)}]
+      {:outcome :fail
+       :op      :rf.epoch/reset-frame-db-schema-mismatch
+       :tags    {:frame         frame-id
+                 :failing-paths (failing-paths-for frame-id new-db)}}
 
       :else
-      [:ok])))
+      {:outcome :ok})))
 
 (defn- perform-reset-frame-db!
   "Carry out the `app-db` replacement once preconditions have passed.
@@ -1174,10 +1186,10 @@
   [frame-id new-db]
   (if-not interop/debug-enabled?
     false
-    (let [result (check-reset-frame-db-preconditions! frame-id new-db)]
-      (case (first result)
+    (let [{:keys [outcome op tags]} (check-reset-frame-db-preconditions! frame-id new-db)]
+      (case outcome
         :ok   (perform-reset-frame-db! frame-id new-db)
-        :fail (do (emit-precondition-failure! (second result) (nth result 2))
+        :fail (do (emit-precondition-failure! op tags)
                   false)))))
 
 ;; ---- late-bind hook registration ------------------------------------------

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -613,7 +613,12 @@
 
   When the cascade had no successful event handler (e.g. an unknown
   event id or a frame-destroyed dispatch), no :run-start fires; fall
-  back to the first event we can find with an `:event-id` tag.
+  back to the first event we can find with an `:event-id` tag. Per
+  rf2-7kxxx (audit r3 §F2): if that fallback event carries no `:event`
+  tag we DO NOT synthesise `[eid]` — that would misrepresent an event
+  that originally carried payload as payload-less. `build-record`'s
+  conditional `cond->` (rf2-kl5p1) omits the `:trigger-event` slot
+  when `:event` is nil, which the schema's open map admits.
 
   Per rf2-txrq9: single-walk reduction over `events` — the original
   two-pass `or`-of-`some` reordered both walks across the buffer
@@ -634,12 +639,15 @@
                 (reduced {:run-start {:event-id (:event-id tags)
                                       :event    (:event tags)}})
                 ;; Capture the first :event-id we see as the fallback.
+                ;; Per rf2-7kxxx: do NOT fabricate `:event` — when the
+                ;; tag is absent we leave the field nil, and downstream
+                ;; `build-record` (rf2-kl5p1) omits the
+                ;; `:trigger-event` slot entirely rather than emit a
+                ;; misleading synthesised vector.
                 (if (or (:fallback acc) (nil? (:event-id tags)))
                   acc
-                  (assoc acc :fallback
-                         (let [eid (:event-id tags)]
-                           {:event-id eid
-                            :event    (or (:event tags) [eid])}))))))
+                  (assoc acc :fallback {:event-id (:event-id tags)
+                                        :event    (:event tags)})))))
           {}
           events)]
     (or (:run-start result) (:fallback result))))

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -664,12 +664,23 @@
    ;; :halted-handler-exception); :halt-reason is a structured
    ;; descriptor populated on halt paths, absent on :ok. The schema
    ;; in Spec-Schemas §:rf/epoch-record is the canonical pin.
+   ;;
+   ;; Per rf2-kl5p1 (audit r3 §F1): `:event-id` and `:trigger-event`
+   ;; are emitted only when `find-trigger-event` resolves them. The
+   ;; schema declares `:event-id :keyword` (required, non-maybe) per
+   ;; Spec-Schemas §`:rf/epoch-record` — emitting `:event-id nil` on a
+   ;; halt path where no `:event/run-start` trace was buffered would
+   ;; violate the schema; the open-map admits the slot's absence but
+   ;; rejects a nil value. The live router halt paths already short-
+   ;; circuit on an empty buffer via `(when (seq events) ...)` in
+   ;; `settle!`, so the only path that can reach this branch with a
+   ;; trigger-less buffer is `on-frame-destroyed!`'s `:halted-destroy`
+   ;; commit; the conditional `cond->` slots make that record valid
+   ;; against the schema.
    (let [{:keys [event-id event]} (find-trigger-event events)]
      (cond-> {:epoch-id      (next-epoch-id)
               :frame         frame-id
               :committed-at  (interop/now-ms)
-              :event-id      event-id
-              :trigger-event event
               :db-before     db-before
               :db-after      db-after
               :outcome       outcome
@@ -683,6 +694,8 @@
               :sub-runs      (project-sub-runs events)
               :renders       (project-renders events)
               :effects       (project-effects events)}
+       event-id    (assoc :event-id event-id)
+       event       (assoc :trigger-event event)
        halt-reason (assoc :halt-reason halt-reason)))))
 
 ;; ---- drain-settle hook ----------------------------------------------------
@@ -701,12 +714,12 @@
       Drain-boundary commit with explicit outcome. `outcome` is one of
       `:ok` / `:halted-depth` / `:halted-destroy` /
       `:halted-handler-exception`; `halt-reason` is a structured
-      descriptor populated on halt paths (nil on `:ok`). For halt
-      outcomes the record is committed even when the captured buffer
-      is empty — devtools want the cascade context surfaced regardless,
-      and the absent `:event-id` / `:trigger-event` slots on an
-      empty-buffer halt are tolerated by the open-map schema (the
-      `find-trigger-event` walk returns nil → those slots are nil).
+      descriptor populated on halt paths (nil on `:ok`). On a buffer
+      with no recoverable trigger (no `:event/run-start` and no
+      `:event-id` tag — e.g. a destroy that races a registration-time
+      emit) `build-record` omits `:event-id` / `:trigger-event`
+      entirely; the schema admits absent slots, rejects nil values
+      (per rf2-kl5p1 / audit r3 §F1).
 
   `db-before` is the app-db value snapshotted before the cascade began;
   `db-after` is the value the runtime settled to — equal to `db-before`

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -795,24 +795,19 @@
     (entries frame-id)
     {}))
 
-(defn- schema-validate-ok?
-  "True when the recorded db validates against every app-schema
-  registered against frame-id. Defensive: when no schemas are
-  registered or Malli is not on the path, we consider the db valid
-  (we can't disprove it)."
-  [frame-id db]
-  (let [schemas  (registered-app-schemas frame-id)
-        validate (malli-validate-fn)]
-    (or (empty? schemas)
-        (nil? validate)
-        (every? (fn [[path meta]]
-                  (let [schema (:schema meta)
-                        v      (get-in db path)]
-                    (try (validate schema v)
-                         (catch #?(:clj Throwable :cljs :default) _ true))))
-                schemas))))
+(defn- failing-schema-paths
+  "Return a vector of failing schema-paths for `db` against `frame-id`'s
+  registered app-schemas. Empty vector means valid — either every
+  registered schema accepted the path's value, OR no schemas are
+  registered, OR no Malli validator is on the classpath. The latter
+  two are soft-pass: we can't disprove validity, so we treat the db
+  as valid.
 
-(defn- failing-paths-for [frame-id db]
+  Single walk over the schema set — callers that previously chained
+  `schema-validate-ok?` + `failing-paths-for` paid two walks where one
+  suffices. The validity question is `(empty? (failing-schema-paths
+  frame-id db))`."
+  [frame-id db]
   (let [schemas  (registered-app-schemas frame-id)
         validate (malli-validate-fn)]
     (if (or (empty? schemas) (nil? validate))
@@ -1012,7 +1007,7 @@
             ;; Each helper is called once and its result bound, so the
             ;; failure path walks the recorded db / schema set / machine
             ;; map exactly once per check (rf2-081zk).
-            (if-let [failing-paths (seq (failing-paths-for frame-id db-target))]
+            (if-let [failing-paths (seq (failing-schema-paths frame-id db-target))]
               ;; (4) Schema mismatch?
               ;; Per Spec 010 §Schema digest + Tool-Pair §Time-travel:
               ;; the trace carries both the digest pinned on the
@@ -1133,15 +1128,18 @@
        :op      :rf.epoch/reset-frame-db-during-drain
        :tags    {:frame frame-id}}
 
-      ;; (3) Schema mismatch?
-      (not (schema-validate-ok? frame-id new-db))
-      {:outcome :fail
-       :op      :rf.epoch/reset-frame-db-schema-mismatch
-       :tags    {:frame         frame-id
-                 :failing-paths (failing-paths-for frame-id new-db)}}
-
       :else
-      {:outcome :ok})))
+      ;; (3) Schema mismatch? Single walk — `failing-schema-paths`
+      ;; returns the failing paths (or [] for the valid / soft-pass
+      ;; cases), folding what was previously a two-helper / two-walk
+      ;; chain into one.
+      (let [failing (failing-schema-paths frame-id new-db)]
+        (if (seq failing)
+          {:outcome :fail
+           :op      :rf.epoch/reset-frame-db-schema-mismatch
+           :tags    {:frame         frame-id
+                     :failing-paths failing}}
+          {:outcome :ok})))))
 
 (defn- perform-reset-frame-db!
   "Carry out the `app-db` replacement once preconditions have passed.

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -2012,6 +2012,67 @@
       (is (= [:seed 1 2 3] (:trigger-event record))
           ":trigger-event is the full event vector — payload preserved"))))
 
+;; ---- rf2-7kxxx: find-trigger-event must not synthesise [eid] when
+;; ---- :event tag is absent on the fallback arm ----------------------------
+;;
+;; Per audit r3 §F2: the fallback arm of `find-trigger-event` previously
+;; synthesised `[eid]` as `:event` when the buffered event carried an
+;; `:event-id` tag but no `:event` tag. That misrepresents an event that
+;; originally carried payload (e.g. `[:foo "bar" 42]`) as a payload-less
+;; event. Post-fix: the fallback returns `:event nil` when the tag is
+;; absent, and (per rf2-kl5p1) `build-record` then omits the
+;; `:trigger-event` slot entirely. No silent fabrication; consumers
+;; rendering 'what triggered this cascade' either see the real event
+;; vector or none at all.
+
+(deftest find-trigger-event-fallback-does-not-synthesise-event-vector
+  (testing "find-trigger-event's fallback arm — :event-id tag present,
+            :event tag absent — returns :event nil rather than fabricating
+            [eid]; the calling build-record then omits :trigger-event"
+    (let [tag-less-fallback [{:op-type   :event
+                              :operation :event
+                              :tags      {:frame    :test/main
+                                          :event-id :foo}}]
+          trigger           (#'epoch/find-trigger-event tag-less-fallback)]
+      (is (= :foo (:event-id trigger))
+          ":event-id is recovered from the fallback arm")
+      (is (nil? (:event trigger))
+          ":event is NOT synthesised as [:foo] — the slot is nil so
+           build-record can decide not to emit a fabricated
+           :trigger-event"))
+
+    ;; Build-record consumes the fallback's nil :event via its conditional
+    ;; cond-> (rf2-kl5p1) and emits no :trigger-event slot.
+    (rf/reg-frame :test/main {})
+    (let [tag-less-events [{:op-type   :event
+                            :operation :event
+                            :tags      {:frame    :test/main
+                                        :event-id :foo}}]
+          record          (#'epoch/build-record
+                            :test/main nil nil tag-less-events
+                            :halted-destroy
+                            {:operation :rf.frame/destroyed-mid-drain})]
+      (is (= :foo (:event-id record))
+          ":event-id lands on the record from the fallback arm")
+      (is (not (contains? record :trigger-event))
+          ":trigger-event is absent — no synthesised vector survives
+           into the record"))))
+
+(deftest find-trigger-event-fallback-preserves-payload-when-event-tag-present
+  (testing "find-trigger-event's fallback arm preserves the full event
+            vector when the buffered event DOES carry an :event tag —
+            the rf2-7kxxx fix must not strip payload from the
+            non-degenerate fallback path"
+    (let [events  [{:op-type   :event
+                    :operation :event
+                    :tags      {:frame    :test/main
+                                :event-id :foo
+                                :event    [:foo "bar" 42]}}]
+          trigger (#'epoch/find-trigger-event events)]
+      (is (= :foo (:event-id trigger)))
+      (is (= [:foo "bar" 42] (:event trigger))
+          "the full event vector survives — payload is preserved"))))
+
 ;; ---- rf2-eo4pr: record-observation! guards its swap -----------------------
 ;;
 ;; `notify-listeners!` invokes `record-observation!` once per listener per

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -1941,6 +1941,77 @@
            pre-destroy event can leak into a same-keyed frame's next
            cascade"))))
 
+;; ---- rf2-kl5p1: build-record omits :event-id / :trigger-event when
+;; ---- find-trigger-event yields nothing -----------------------------------
+;;
+;; Per audit r3 §F1: `:rf/epoch-record` declares `[:event-id :keyword]`
+;; (required, non-maybe per Spec-Schemas §`:rf/epoch-record`). The live
+;; router halt paths short-circuit `build-record` on an empty buffer via
+;; `(when (seq events) ...)` in `settle!`, but `on-frame-destroyed!`'s
+;; `:halted-destroy` path commits a partial record from whatever buffered
+;; events are present — and a degenerate buffer that holds a `:event/
+;; run-start` but no `:event-id` / `:event` tags would otherwise produce
+;; `:event-id nil` / `:trigger-event nil`, violating the schema.
+;;
+;; Contract pin: when `find-trigger-event` returns nil for both fields,
+;; the assembled record carries NEITHER slot (the schema admits the
+;; absent slot, rejects nil values). `build-record` is exercised
+;; directly because driving a real router path with this exact degenerate
+;; buffer requires cooperation with internals the audit-time fix does
+;; not change.
+
+(deftest build-record-omits-event-id-and-trigger-event-on-tag-less-buffer
+  (testing "build-record on a buffer whose only `:event/run-start` trace
+            carries neither :event-id nor :event in :tags omits the
+            :event-id and :trigger-event slots from the record (rather
+            than emitting them as nil, which would violate the
+            :event-id :keyword schema)"
+    (rf/reg-frame :test/main {})
+    ;; Synthetic `:event/run-start` with empty tags — the `in-cascade?`
+    ;; gate at on-frame-destroyed! fires on phase :run-start, but the
+    ;; tags carry no :event-id / :event, so find-trigger-event resolves
+    ;; nothing. This mirrors the degenerate path the audit identified
+    ;; on the :halted-destroy commit.
+    (let [tag-less-events [{:op-type   :event
+                            :operation :event
+                            :tags      {:frame :test/main
+                                        :phase :run-start}}]
+          record          (#'epoch/build-record
+                            :test/main nil nil tag-less-events
+                            :halted-destroy
+                            {:operation :rf.frame/destroyed-mid-drain})]
+      (is (not (contains? record :event-id))
+          "the record does NOT carry :event-id when find-trigger-event
+           yields nil — the slot is absent rather than nil-valued
+           (schema rejects nil; absent is fine on the open map)")
+      (is (not (contains? record :trigger-event))
+          "the record does NOT carry :trigger-event when find-trigger-event
+           yields nil — symmetric to :event-id, the slot is absent
+           rather than nil-valued")
+      ;; Sanity: every required non-conditional slot still landed, and
+      ;; the halt-reason came through.
+      (is (= :test/main (:frame record)))
+      (is (= :halted-destroy (:outcome record)))
+      (is (= {:operation :rf.frame/destroyed-mid-drain}
+             (:halt-reason record))))))
+
+(deftest build-record-emits-event-id-and-trigger-event-when-trigger-resolves
+  (testing "the conditional cond-> slots are emitted when find-trigger-event
+            resolves both — the rf2-kl5p1 fix must not regress the
+            happy-path record shape"
+    (rf/reg-frame :test/main {})
+    (let [events [{:op-type   :event
+                   :operation :event
+                   :tags      {:frame    :test/main
+                               :phase    :run-start
+                               :event-id :seed
+                               :event    [:seed 1 2 3]}}]
+          record (#'epoch/build-record :test/main {} {:n 0} events)]
+      (is (= :seed (:event-id record))
+          ":event-id is the resolved event keyword")
+      (is (= [:seed 1 2 3] (:trigger-event record))
+          ":trigger-event is the full event vector — payload preserved"))))
+
 ;; ---- rf2-eo4pr: record-observation! guards its swap -----------------------
 ;;
 ;; `notify-listeners!` invokes `record-observation!` once per listener per


### PR DESCRIPTION
## Summary

Cluster of four follow-ups surfaced by the rf2-3391t epoch-audit (round 3, findings at `ai/findings/epoch-slice-audit-2026-05-15.md`). Single file: `implementation/epoch/src/re_frame/epoch.cljc` + `epoch_test.clj`. No hot-zone files touched.

## Commits

1. **rf2-1294f — `refactor(epoch): map-shape precondition results`**
   Replace positional `[:fail kw tags]` tuples in `check-restore-preconditions!`, `check-reset-frame-db-preconditions!`, and `frame-exists-or-fail` with `{:outcome … :op … :tags … :epoch … :frame-record …}` maps. Dispatch sites destructure cleanly; `(nth result 2)` is gone. Per audit r3 §F4.

2. **rf2-i0rl9 — `refactor(epoch): collapse schema-validate-ok? + failing-paths-for`**
   One helper (`failing-schema-paths`) does the schema walk; emptiness == validity. `check-reset-frame-db-preconditions!` no longer pays two walks on the schema-mismatch failure path. Per audit r3 §F3.

3. **rf2-kl5p1 — `fix(epoch): build-record omits :event-id when find-trigger-event yields nil`**
   Schema declares `:event-id :keyword` (required, non-maybe per Spec-Schemas §`:rf/epoch-record`). `cond->` now conditionally assoc's `:event-id` and `:trigger-event` so a halt-destroy record built from a trigger-less buffer omits the slots rather than emitting them as nil (the schema admits absent, rejects nil). Two regression tests pin the contract. Per audit r3 §F1.

4. **rf2-7kxxx — `refactor(epoch): find-trigger-event fallback no longer synthesises [eid]`**
   The fallback arm previously fabricated `[eid]` as `:event` when the buffered event carried `:event-id` but no `:event` tag — misrepresenting a payload-carrying event (`[:foo "bar" 42]`) as payload-less. Now returns `:event nil`; `build-record`'s conditional `cond->` (rf2-kl5p1) then omits `:trigger-event` entirely. Two regression tests pin the contract. Per audit r3 §F2.

## Cross-bead interaction

rf2-7kxxx's fix composes with rf2-kl5p1: removing the `[eid]` synthesis would have introduced a `:trigger-event nil` slot on its own, but the rf2-kl5p1 conditional `cond->` already strips nil-valued `:trigger-event`. The two commits together make the halt-path record schema-clean without fabricating data.

## Cross-ref

- `ai/findings/epoch-slice-audit-2026-05-15.md` §F1, §F2, §F3, §F4
- Spec-Schemas §`:rf/epoch-record` (Spec-Schemas.md:2206-2270)

## Test plan

- [x] `clojure -M:test` in `implementation/epoch` — 89 tests / 343 assertions / 0 failures (was 85 / 330; +4 new regression tests for rf2-kl5p1 and rf2-7kxxx).
- [x] `npm run test:cljs` from `implementation/` — 2014 tests / 5695 assertions / 0 failures.