### PR TITLE
refactor(template): audit follow-ups cluster (7 beads)

### DIFF
--- a/tools/template/spec/001-Substrate-Variants.md
+++ b/tools/template/spec/001-Substrate-Variants.md
@@ -66,9 +66,10 @@ All three variants emit the same top-level project shape — see
 [002-Generated-Shape.md](002-Generated-Shape.md). The substrate
 choice swaps:
 
-- `core.cljs` — the entry point. Reagent uses `reagent.dom/render`;
-  UIx uses `uix.dom/render-root`; Helix uses `react-dom/client`'s
-  `createRoot`.
+- `core.cljs` — the entry point. Reagent uses
+  `reagent.dom.client/create-root` + `.render` (the React-18
+  hooks-era API); UIx uses `uix.dom/render-root`; Helix uses
+  `react-dom/client`'s `createRoot`.
 - `views.cljs` — the counter view. Reagent uses plain hiccup;
   UIx uses `$` with `defui`; Helix uses `defnc` and `d/...`
   elements.

--- a/tools/template/spec/001-Substrate-Variants.md
+++ b/tools/template/spec/001-Substrate-Variants.md
@@ -126,6 +126,9 @@ Adding a variant requires:
 2. A new resource sub-tree at
    `src/clj/new/re_frame2/<substrate>/` (matching the existing
    reagent/uix/helix shape).
-3. A test entry in `test/clj/new/re_frame2/core_test.clj`.
+3. A test entry in each of `test/clj/new/re_frame2_test.clj`,
+   `test/clj/new/template_emission_test.clj`, and
+   `test/clj/new/emitted_test_run_test.clj` (per-substrate runs in
+   the existing deftests).
 
 The substrate-agnostic `shared/` tree is reused as-is.

--- a/tools/template/spec/002-Generated-Shape.md
+++ b/tools/template/spec/002-Generated-Shape.md
@@ -18,6 +18,8 @@ my-app/
 ├── .editorconfig             2-space, LF, trim trailing, final newline
 ├── .clj-kondo/
 │   └── config.edn            empty default; lint rules slot in here
+├── .cljfmt.edn               cljfmt formatter config — `clojure -M:cljfmt check` / `fix`
+├── .lefthook.yml             pre-commit format + lint hook (see lefthook.dev/installation)
 ├── resources/public/
 │   ├── index.html            host page; loads /js/main.js + /css/app.css
 │   └── css/app.css           three-rule plain stylesheet
@@ -80,6 +82,8 @@ tools/template/
         │   ├── editorconfig              ; emitted as .editorconfig
         │   ├── clj-kondo/
         │   │   └── config.edn            ; emitted under .clj-kondo/
+        │   ├── cljfmt.edn                ; emitted as .cljfmt.edn
+        │   ├── lefthook.yml              ; emitted as .lefthook.yml
         │   ├── events.cljs
         │   ├── events_test.cljs
         │   ├── subs.cljs

--- a/tools/template/spec/API.md
+++ b/tools/template/spec/API.md
@@ -119,8 +119,8 @@ clojure -Sdeps '{:deps {day8/clj-template.re-frame2
 ```
 
 This is the path the template's own JVM tests
-(`test/clj/new/re_frame2/core_test.clj`) take internally — they
-invoke the entry fn directly without the clj-new harness.
+(`test/clj/new/re_frame2_test.clj` and siblings) take internally —
+they invoke the entry fn directly without the clj-new harness.
 
 ## Outputs
 

--- a/tools/template/spec/DESIGN-RATIONALE.md
+++ b/tools/template/spec/DESIGN-RATIONALE.md
@@ -121,9 +121,12 @@ the first cut.
   `subs.cljs`, host HTML) is identical across substrates. Only
   `core.cljs`, `views.cljs`, `deps.edn`, and the npm pins
   differ. The per-substrate resource sub-tree is ~5 files.
-- **CI exercises all three.** The JVM test
-  (`test/clj/new/re_frame2/core_test.clj`) runs every substrate
-  end-to-end, so adding a substrate has a low maintenance tax.
+- **CI exercises all three.** The three-file JVM test suite
+  (`test/clj/new/re_frame2_test.clj` plus the
+  `template_emission_test.clj` static-parse and
+  `emitted_test_run_test.clj` behavioural slices) runs every
+  substrate end-to-end, so adding a substrate has a low maintenance
+  tax.
 
 Reagent remains the default — it's the canonical substrate every
 re-frame example targets first. UIx and Helix are equal citizens,
@@ -242,11 +245,13 @@ per-variant top-level tree (no shared tree at all).
 
 ## §8 — JVM test (no clj-new harness in the test path)
 
-**Decision.** The JVM test
-(`test/clj/new/re_frame2/core_test.clj`) invokes the template's
-entry fn directly, bypassing clj-new's `create` harness. It does
-three things per substrate: generate to a tmp dir, walk the
-file tree, run `clojure -P` against the generated `deps.edn`.
+**Decision.** The JVM tests (`test/clj/new/re_frame2_test.clj`
+and its two siblings, `template_emission_test.clj` and
+`emitted_test_run_test.clj`) invoke the template's entry fn
+directly, bypassing clj-new's `create` harness. The layered shape:
+generate to a tmp dir, walk the file tree, parse-and-audit the
+emitted cljs against framework surface, and optionally compile +
+run the emitted tests via shadow-cljs.
 
 **Why.**
 
@@ -261,9 +266,13 @@ file tree, run `clojure -P` against the generated `deps.edn`.
 
 The `clojure -P` deps-parse is a "best-effort" check — it confirms
 the generated `deps.edn` is well-formed and that re-frame2 coords
-resolve. It requires a `clojure` CLI on PATH; if absent, the test
-logs and skips. Deps-parse is a nice-to-have signal; the harder
-contract is the file-tree shape.
+resolve. It is gated behind `RF2_TEMPLATE_DEPS_RESOLVE=1` (CI sets
+this; local fast-loop default-off so a missing alpha publish on
+Clojars doesn't fail every run). The behavioural compile+run slice
+(`emitted_test_run_test.clj`) is similarly opt-in via
+`RF2_TEMPLATE_RUN_EMITTED_TESTS=1`. Deps-parse and behavioural-run
+are nice-to-have signals; the harder contract is the file-tree
+shape + the static-parse framework-surface audit.
 
 ## §9 — Forgiving substrate coercion
 

--- a/tools/template/spec/Principles.md
+++ b/tools/template/spec/Principles.md
@@ -123,18 +123,32 @@ fuzz. The user sees the typo and fixes it.
 
 ## P7 — Tested end-to-end, per substrate
 
-The template's JVM test (`test/clj/new/re_frame2/core_test.clj`)
-exercises each substrate end-to-end:
+The template ships a three-file layered JVM test suite under
+`test/clj/new/`. Each substrate (Reagent / UIx / Helix) is exercised
+end-to-end across the three layers:
 
-1. Generate a tmp app via the template's main fn.
-2. Walk the produced file tree and assert the expected shape.
-3. Run `clojure -P` against the generated `deps.edn` to confirm a
-   successful deps-parse.
+1. **Shape.** `re_frame2_test.clj` — generates a tmp app via the
+   template's main fn, walks the produced file tree, asserts file
+   presence + `deps.edn` substrate-adapter coords. Always runs.
+2. **Static parse.** `template_emission_test.clj` — parses every
+   emitted `.cljs` file, resolves each `<alias>/<sym>` reference
+   against the framework source under `implementation/core/src/`,
+   and asserts the symbol exists. Catches rename/cut drift between
+   the template scaffold and the runtime API. Always runs.
+3. **Behavioural.** `emitted_test_run_test.clj` — compiles and runs
+   the emitted `events_test.cljs` end-to-end via shadow-cljs + Node.
+   Gated behind `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` (CI sets it; off
+   locally for fast loop).
 
-The test runs on CI. A change that breaks file-tree shape for any
-substrate fails the build. The `clojure -P` check is best-effort
-— it requires a `clojure` CLI on PATH, logs and skips if not
-available.
+A `clojure -P` deps-parse smoke also runs in `re_frame2_test.clj`,
+gated behind `RF2_TEMPLATE_DEPS_RESOLVE=1` (CI sets it). It is
+default-off locally until the alpha artefacts land on Clojars —
+until publication every `clojure -P` fails with a "couldn't find
+artifact" error that is a known skip, not a real signal.
+
+CI sets both env vars; a change that breaks file-tree shape, drifts
+the framework surface, or breaks the emitted test compile fails the
+build. Local fast-loop default is shape + static-parse only.
 
 ## Cross-references
 

--- a/tools/template/src/clj/new/re_frame2/reagent/views.cljs
+++ b/tools/template/src/clj/new/re_frame2/reagent/views.cljs
@@ -20,7 +20,7 @@
      - shape subscriptions so each row subscribes to *its* slice, not
        the whole collection — collection-level subscriptions cause every
        row to re-render on every cell change."
-  (:require [re-frame.core    :as rf]
+  (:require [re-frame.core]
             [re-frame.views])
   (:require-macros [re-frame.core :refer [reg-view]]))
 

--- a/tools/template/src/clj/new/re_frame2/shared/README.md
+++ b/tools/template/src/clj/new/re_frame2/shared/README.md
@@ -159,6 +159,12 @@ picks up every `*_test.cljs` namespace under `test/` and runs it via
 reactive substrate (no DOM needed). Add more `*_test.cljs` files
 alongside it as your app grows.
 
+**Windows note:** shadow-cljs's `node_modules` resolution can rely on
+filesystem symlinks. Symlink creation on Windows requires either
+**Developer Mode** enabled (Settings → For developers → Developer
+Mode) or an admin-elevated shell. If `npm test` fails with a symlink-
+related error, that's the fix.
+
 ## Project layout
 
 ```

--- a/tools/template/src/clj/new/re_frame2/shared/dev/scratch.cljs
+++ b/tools/template/src/clj/new/re_frame2/shared/dev/scratch.cljs
@@ -19,7 +19,13 @@
 
   ;; Run a scratch experiment against a throw-away frame — leaves
   ;; the live :rf/default frame untouched.
-  (rf/with-frame {:rf/id ::scratch}
+  ;;
+  ;; `with-frame` Shape 1 takes a keyword frame-id and binds
+  ;; `*current-frame*` to it for the duration of the body. (Shape 2
+  ;; is `[sym expr]` for an eval-bind-run-destroy pattern; map or
+  ;; non-keyword first-args are NOT supported and silently misbind
+  ;; the current frame — see Spec 002 §with-frame.)
+  (rf/with-frame :scratch
     (rf/dispatch-sync [:counter/initialise])
     (rf/dispatch-sync [:counter/increment])
     @(rf/subscribe [:counter/value]))

--- a/tools/template/src/clj/new/re_frame2/shared/events_test.cljs
+++ b/tools/template/src/clj/new/re_frame2/shared/events_test.cljs
@@ -44,3 +44,10 @@
     (rf/dispatch-sync [:counter/increment])
     (rf/dispatch-sync [:counter/increment])
     (is (= 3 (:counter/value (rf/get-frame-db :rf/default))))))
+
+(deftest counter-value-sub-reads-current-count
+  (testing ":counter/value sub returns the slice value after event flow"
+    (rf/dispatch-sync [:counter/initialise])
+    (rf/dispatch-sync [:counter/increment])
+    (rf/dispatch-sync [:counter/increment])
+    (is (= 2 @(rf/subscribe [:counter/value])))))

--- a/tools/template/test/clj/new/template_emission_test.clj
+++ b/tools/template/test/clj/new/template_emission_test.clj
@@ -351,6 +351,70 @@
               (str (.getName file) " (" substrate ") requires " target-ns
                    " but no source file found under implementation/core/src/")))))))
 
+;; --- scratch.cljs with-frame shape audit (rf2-ah0gi) -----------------------
+;;
+;; The emitted dev/scratch.cljs is the user's REPL on-ramp. Any
+;; `(rf/with-frame …)` call in the (comment …) block MUST use Shape 1
+;; (a keyword) or Shape 2 (a 2-elem `[sym expr]` vector) per Spec 002
+;; §with-frame and the macro definition at
+;; `implementation/core/src/re_frame/core_reg_view_macro.cljc`. A map
+;; first-arg (or any other literal) falls through to Shape 1 and binds
+;; `*current-frame*` to a non-frame value — runtime breaks far from
+;; the call site. The audit walks every `with-frame` form in scratch
+;; and asserts the first-arg shape.
+
+(defn- with-frame-call?
+  "True when `form` is `(rf-or-alias/with-frame …)` — covers both
+  alias-qualified (`rf/with-frame`) and bare (`with-frame`) usage."
+  [form]
+  (and (seq? form)
+       (symbol? (first form))
+       (= "with-frame" (name (first form)))))
+
+(defn- valid-with-frame-first-arg?
+  "Shape 1 = keyword; Shape 2 = 2-elem [sym expr] vector. Anything
+  else is the bug rf2-ah0gi found."
+  [arg]
+  (or (keyword? arg)
+      (and (vector? arg)
+           (= 2 (count arg))
+           (symbol? (first arg)))))
+
+(defn- collect-with-frame-calls
+  "Walk `forms` and return every `(with-frame …)` call form, including
+  those nested inside `(comment …)` blocks (which is where the emitted
+  scratch ns puts its examples)."
+  [forms]
+  (let [acc (volatile! [])]
+    (walk/postwalk
+      (fn [x]
+        (when (with-frame-call? x)
+          (vswap! acc conj x))
+        x)
+      forms)
+    @acc))
+
+(defn- assert-scratch-with-frame-shape!
+  [substrate ^java.io.File root]
+  (let [scratch (io/file root "dev/scratch.cljs")]
+    (is (.isFile scratch)
+        (str "dev/scratch.cljs emitted for " substrate))
+    (let [forms (read-cljs-forms scratch)
+          calls (collect-with-frame-calls forms)]
+      (is (seq calls)
+          (str "scratch.cljs (" substrate
+               ") contains at least one (with-frame …) example — "
+               "the REPL on-ramp should demonstrate the shape"))
+      (doseq [call calls]
+        (let [first-arg (second call)]
+          (is (valid-with-frame-first-arg? first-arg)
+              (str "scratch.cljs (" substrate ") (with-frame "
+                   (pr-str first-arg) " …) — first arg must be a "
+                   "keyword (Shape 1) or a 2-elem [sym expr] vector "
+                   "(Shape 2). Per Spec 002 §with-frame, anything "
+                   "else binds *current-frame* to a non-frame "
+                   "value and breaks downstream dispatch/subscribe.")))))))
+
 (defn- run-for-substrate!
   [substrate]
   (let [tmp  (tmp-dir (str "rf2-emission-" (name substrate) "-"))
@@ -358,10 +422,12 @@
     (try
       (let [proj (run-template! tmp "acme/my-app" substrate)]
         (assert-events-test-shape! substrate proj)
+        (assert-scratch-with-frame-shape! substrate proj)
         (doseq [rel ["test/acme/my_app/events_test.cljs"
                      "src/acme/my_app/events.cljs"
                      "src/acme/my_app/subs.cljs"
-                     "src/acme/my_app/views.cljs"]]
+                     "src/acme/my_app/views.cljs"
+                     "dev/scratch.cljs"]]
           (audit-framework-surface! substrate (io/file proj rel) root)))
       (finally
         (delete-recursively tmp)))))


### PR DESCRIPTION
## Summary

Implements 7 follow-up beads from the `tools/template` audit (rf2-5g1j7), all confined to `tools/template/`. **Excludes rf2-08kgd** (counter app-db key disagreement — held for Mike-decision).

### Beads

- **rf2-ah0gi (P1 BUG)** — Fix emitted `dev/scratch.cljs` `with-frame` shape: was `(rf/with-frame {:rf/id ::scratch} …)` which falls through to Shape 1 and misbinds `*current-frame*` to a map literal. Now uses canonical Shape 1 `(rf/with-frame :scratch …)`. Adds a static-parse audit that walks every `with-frame` call in the emitted `dev/scratch.cljs` and asserts the first-arg shape is keyword (Shape 1) or `[sym expr]` (Shape 2).
- **rf2-odz53 (P2 BUG)** — `tools/template/spec/001-Substrate-Variants.md` updated: `reagent.dom/render` → `reagent.dom.client/create-root + .render` (matches what the template actually emits — React-18 hooks-era API).
- **rf2-pi1t0 (P2)** — Sweep 5 stale `core_test.clj` references across `001-Substrate-Variants.md`, `API.md`, `DESIGN-RATIONALE.md` (×2), `Principles.md`; replace with the actual three-file layout (`re_frame2_test.clj` + `template_emission_test.clj` + `emitted_test_run_test.clj`). Rewrites Principles P7 to describe the layered shape and the `RF2_TEMPLATE_DEPS_RESOLVE` / `RF2_TEMPLATE_RUN_EMITTED_TESTS` env-var opt-in story.
- **rf2-7qp3w (P3)** — Drop unused `:as rf` alias from emitted Reagent `views.cljs` (kondo `unused-namespace`). Keeps `[re-frame.core]` as a side-effecting require so the macro-expanded fully-qualified `re-frame.core/dispatcher` / `subscriber` references load at runtime.
- **rf2-u74t5 (P3)** — Add `counter-value-sub-reads-current-count` deftest to emitted `events_test.cljs` — completes the event+sub round-trip the user copies shape from.
- **rf2-b0dkq (P3)** — Add `.cljfmt.edn` + `.lefthook.yml` to the `spec/002-Generated-Shape.md` emitted-tree diagram and the template-side resource-tree diagram (currently the two diagrams omit files the template actually emits).
- **rf2-8wlwu (P3)** — Add a one-line Windows Developer Mode note to the emitted README's "Run tests" section (covers the symlink-friction failure mode).

## Test plan

- [x] `cd tools/template && clojure -M:test` — **11 tests / 216 assertions, 0 failures, 0 errors** (baseline: 11 / 189; +27 assertions from the new sub-deftest's qualified-symbol audit and the new scratch with-frame shape audit running per-substrate).
- [x] Verified the new with-frame shape audit catches the original bug (temporarily reverted only `scratch.cljs`; all 3 substrate static-parse tests failed with the expected message; restored).
- [x] No hot-zone files touched. All edits within `tools/template/` plus `tools/template/spec/*`.