### PR TITLE
refactor(mcp-base): audit follow-ups cluster (8 beads)

### DIFF
--- a/tools/mcp-base/spec/README.md
+++ b/tools/mcp-base/spec/README.md
@@ -41,7 +41,7 @@ per-namespace contract doc; the table below indexes them:
 | `vocab` | 228 | `:rf.mcp/*` + `:rf.size/*` marker keys + envelope slots + JSON-RPC error codes. | [`vocab.md`](vocab.md) |
 | `sensitive` | 117 | spec/009 §Privacy default-suppress filter (`sensitive-event?`, `strip-sensitive`, `scrub-snapshot`). | [`sensitive.md`](sensitive.md) |
 | `elision` | 60 | Wire-boundary `:rf.size/large-elided` walker (`count-elided-markers`, rf2-9fz64). | [`elision.md`](elision.md) |
-| `args` | 127 | Argument coercion helpers (`parse-boolean`, `parse-positive-int`, `parse-keyword`, `parse-mode`, …). | [`args.md`](args.md) |
+| `args` | 127 | Argument coercion helpers (`parse-boolean`, `parse-positive-int`, `fresh-keyword`, `safe-keyword`, `parse-mode`, …). | [`args.md`](args.md) |
 | `diff-encode` | 286 | Path-keyed structural diff for epoch `:db-after` slots (rf2-1wdzp). | [`diff-encode.md`](diff-encode.md) |
 | `overflow` | 60 | Overflow-marker payload SHAPE builder + per-tool hint table (rf2-rvyzy). | [`overflow.md`](overflow.md) |
 | `cap` | 192 | Wire-boundary token-budget cap pipeline + `ResultIO` protocol (rf2-eyelu). | [`cap.md`](cap.md) |

--- a/tools/mcp-base/spec/args.md
+++ b/tools/mcp-base/spec/args.md
@@ -9,9 +9,9 @@ This doc is one of seven per-namespace contracts indexed from [`README.md`](READ
 
 `args` owns:
 
-- The cross-MCP parser catalogue (`parse-boolean`, `parse-positive-int`, `parse-non-negative-int`, `parse-keyword`, `safe-keyword`, `parse-mode`).
+- The cross-MCP parser catalogue (`parse-boolean`, `parse-positive-int`, `parse-non-negative-int`, `fresh-keyword`, `safe-keyword`, `parse-mode`).
 - The default-handling posture for each parser (call-sites supply the default; the parser is policy-free).
-- The keyword-interning safety rule (per rf2-ih7g4): unbounded inputs MUST route through `safe-keyword` rather than `parse-keyword`.
+- The keyword-interning safety rule (per rf2-ih7g4): unbounded inputs MUST route through `safe-keyword`; only operator-gated write paths may use `fresh-keyword`.
 
 `args` does NOT own:
 
@@ -32,18 +32,18 @@ The rejection posture (default-suppress vs default-allow) is named at the call-s
 | `parse-boolean` | bools, strings (`"true"`/`"false"`/`"1"`/`"0"`/`"yes"`/`"no"`/`"y"`/`"n"`/`"on"`/`"off"`, case-insensitive), keywords (`:true`/`:false`), nil | boolean | Unrecognised → `default`. Call-sites wrap to bake the default. |
 | `parse-positive-int` | ints, parsable strings | positive int or `default` | Strictly positive; zero falls to `default`. |
 | `parse-non-negative-int` | ints, parsable strings | non-negative int or `default` | Zero allowed. |
-| `parse-keyword` | keywords, strings (leading `:` optional), nil | keyword or `nil` | The `:` prefix is stripped on string input. **Caveat (rf2-ih7g4)**: this fn INTERNS — use only for registry-backed ids whose value is checked against a bounded set at the lookup site. For finite option sets, prefer `safe-keyword`. |
+| `fresh-keyword` | keywords, strings (leading `:` optional), nil | keyword or `nil` | The `:` prefix is stripped on string input. **Positive-named intern (rf2-xxtrz)**: the name signals the call-site is ALLOCATING a new id, not resolving an existing one. INTERNS by design — reserved for operator-gated write paths whose registrar grammar bounds the per-id allocation cost (e.g. story-mcp's `register-variant`). For finite option sets, use `safe-keyword`. |
 | `safe-keyword` | keywords, strings, nil | keyword from `allowed` set, or `nil` | Bounded-allowlist gate — NEVER interns a fresh keyword on rejection. The right primitive for finite option sets and any input that doesn't go straight to a registry lookup with a bounded known set. Per rf2-ih7g4. |
 | `parse-mode` | enum-shaped strings / keywords | one of an allowed set, otherwise `default` | Bakes an `allowed-modes` set; rejected values fall to `default`. Routes through `safe-keyword` so unrecognised input never interns (rf2-ih7g4). |
 
 ## Keyword-interning safety (rf2-ih7g4)
 
-The same threat model that drives `:rf.http/max-decoded-keys` ([`../../../spec/014-HTTPRequests.md` §Keyword-interning cap](../../../spec/014-HTTPRequests.md)) applies to MCP argument parsing. An MCP server is a long-running process; every `parse-keyword` call against unbounded user input grows the host's interned-symbol table for the life of the process. A compromised agent submitting N-unique-string arguments-per-call would permanently burn N slots in the keyword table.
+The same threat model that drives `:rf.http/max-decoded-keys` ([`../../../spec/014-HTTPRequests.md` §Keyword-interning cap](../../../spec/014-HTTPRequests.md)) applies to MCP argument parsing. An MCP server is a long-running process; every `(keyword raw-agent-string)` call against unbounded user input grows the host's interned-symbol table for the life of the process. A compromised agent submitting N-unique-string arguments-per-call would permanently burn N slots in the keyword table.
 
 The cross-MCP rule:
 
 1. **`safe-keyword` is the default primitive.** Every cross-MCP arg whose set of valid values is *bounded* — modes, enum-like opts, registered tool ids — uses `safe-keyword` with the allowlist passed in.
-2. **`parse-keyword` is reserved for registry-backed ids.** When the arg's value goes straight into a registry lookup whose key set is *itself* bounded by the registrar (e.g. `(registrations :event)` filtered by id), `parse-keyword` is acceptable — the interning is bounded by the registry's existing size.
+2. **`fresh-keyword` is reserved for operator-gated write paths.** When the arg's value is by design a NEW identifier (story-mcp's `register-variant` / `record-as-variant`), `fresh-keyword` is the positive-named primitive. The intern is bounded by an operator gate (`--allow-writes`) AND a registrar grammar (`:story.<path>/<name>` per `assert-id!`). The name carries the "I am allocating, not resolving" posture; no warning-laden docstring needed at the call site.
 3. **`parse-mode` routes through `safe-keyword`.** The convention's enum-shaped parser is internally safe; consumers should use it rather than rolling their own.
 
 The keyword-interning cap (`:rf.http/max-decoded-keys`) defends against the body-decode threat; this convention defends against the argument-parse threat. Both close the same DoS / keyword-table-poisoning vector.

--- a/tools/mcp-base/spec/sensitive.md
+++ b/tools/mcp-base/spec/sensitive.md
@@ -12,6 +12,7 @@ This doc is one of seven per-namespace contracts indexed from [`README.md`](READ
 - The cross-MCP `sensitive-event?` predicate over a trace-event map.
 - The `strip-sensitive` walker (returns `[kept dropped-count]`).
 - The `scrub-snapshot` walker that recurses through a snapshot payload and removes `:sensitive?`-stamped subtrees.
+- The fail-closed malformed-stamp counter (`malformed-count` / `reset-malformed-count!`) — operator-surface observability for the rf2-ih7g4 fail-closed posture; bumped silently every time a non-boolean truthy `:sensitive?` stamp arrives and is dropped + logged.
 - The fixed cross-server arg-vocabulary name (`:include-sensitive?`) every MCP tool surfacing trace-like data MUST accept.
 
 `sensitive` does NOT own:

--- a/tools/mcp-base/src/re_frame/mcp_base/args.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/args.cljc
@@ -100,13 +100,17 @@
 ;;                       keyword. The right primitive for finite option
 ;;                       sets and registry-backed lookups.
 ;;
-;;   - `parse-keyword` — the legacy permissive parser. Still INTERNS;
-;;                       documented as a registry-backed-id helper.
-;;                       Callers MUST gate by membership against a
-;;                       bounded set at the lookup site (e.g. probe
-;;                       the registry; absent ⇒ reject). Eventually a
-;;                       follow-on bead retires this in favour of
-;;                       `safe-keyword` everywhere.
+;;   - `fresh-keyword` — the policy-gated intern. INTERNS by design (the
+;;                       call site is allocating a new identifier, not
+;;                       resolving an existing one). Only callable when
+;;                       the surrounding context has already bounded the
+;;                       allocation cost — typically an operator-gated
+;;                       write path (`--allow-writes`) whose registrar
+;;                       enforces a grammar over the input. The
+;;                       positive-named successor to the retired
+;;                       `parse-keyword` (rf2-xxtrz); the fresh-id
+;;                       posture is on the name rather than in a
+;;                       warning-laden docstring.
 ;;
 ;; `parse-mode` is fixed here — every existing caller passes a finite
 ;; `recognised` set, so the gate lifts cleanly with no surface change.
@@ -186,25 +190,33 @@
 
     :else nil))
 
-(defn parse-keyword
-  "Read a keyword from an agent-supplied argument. MCP arguments
-  arrive as JSON, so keyword-typed ids come in as strings. Strips a
-  leading `:` if present (some agents may serialise EDN-ish). Returns
-  nil for nil / blank input.
+(defn fresh-keyword
+  "Coerce an agent-supplied id into a keyword, INTERNING it. The
+  positive-named primitive for write paths that allocate a new
+  identifier rather than resolve an existing one (e.g.
+  `register-variant`'s `:variant-id` arg, `record-as-variant`'s
+  `:new-variant-id` arg). Strips a leading `:` if present (some agents
+  may serialise EDN-ish). Returns nil for nil / blank input.
 
   Namespaced keywords are supported (`\"ns/name\"` ⇒ `:ns/name`).
 
-  ## Interning caveat (rf2-ih7g4)
+  ## When to call (rf2-ih7g4 / rf2-xxtrz)
 
-  This fn INTERNS — `(keyword raw-string)` on the JVM permanently
-  enlarges the global keyword table. Use ONLY where the value is
-  destined for a registry lookup with a bounded known set (variant-id,
-  substrate id, etc.) and the caller probes the registry immediately
-  after parsing. For finite option sets (e.g. `:diff`/`:full` modes),
-  prefer `safe-keyword` — which never interns outside the allowlist.
+  JVM keywords are interned in a never-shrinking global table. Every
+  `fresh-keyword` call permanently grows that table by one slot for a
+  hitherto-unseen input. Reserve this primitive for sites that have
+  ALREADY bounded the allocation by some other gate:
 
-  Callers SHOULD treat the result as a candidate that MUST be checked
-  against a bounded set before being used as a long-lived identifier."
+    - An operator-gated write path (story-mcp's `--allow-writes` flag,
+      pair2-mcp's read-side frame-id coercion against a runtime-bounded
+      frame registry).
+    - A registrar that enforces a grammar over the id (e.g.
+      `:story.<path>/<name>` in `assert-id!`) — this constrains the
+      per-id allocation cost.
+
+  For finite option sets (mode keywords, slice keywords), use
+  `safe-keyword` against a finite allowlist; `fresh-keyword` is the
+  wrong primitive there — it would intern every typo the agent sent."
   [v]
   (cond
     (keyword? v) v
@@ -228,11 +240,11 @@
   ## Bounded-allowlist gate (rf2-ih7g4)
 
   Routes through `safe-keyword` so an unrecognised agent-supplied
-  string never interns a fresh JVM keyword. The previous implementation
-  called `parse-keyword` on every input (interning), then membership-
-  checked. With this fix the membership check happens BEFORE the
-  intern, eliminating the unbounded-growth DoS path for mode-shaped
-  args (which are the vast majority of finite-set MCP args)."
+  string never interns a fresh JVM keyword. An earlier implementation
+  interned every input first and membership-checked after; the fix
+  flipped the order so the bounded check happens BEFORE the intern,
+  eliminating the unbounded-growth DoS path for mode-shaped args
+  (which are the vast majority of finite-set MCP args)."
   [raw default recognised]
   (cond
     (nil? raw)                       default

--- a/tools/mcp-base/src/re_frame/mcp_base/args.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/args.cljc
@@ -39,15 +39,13 @@
 (defn- parse-int*
   "Shared helper for `parse-positive-int` / `parse-non-negative-int`.
   `floor` is the lower clamp (1 for positive, 0 for non-negative); the
-  three input arms (int / number / string + try/catch) are identical
-  across both call sites."
+  two input arms (number / string + try/catch) cover every shape the
+  agent surface produces. `integer?` is a subset of `number?`, so the
+  single `number?` arm catches both."
   [raw default floor]
   (cond
     (nil? raw)
     default
-
-    (integer? raw)
-    (max floor (long raw))
 
     (number? raw)
     (max floor (long raw))

--- a/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
@@ -205,15 +205,32 @@
     ;; 2. Secondary char-byte cap — `cap * byte-cap-multiplier`.
     ;;    Defence-in-depth against payloads where the (count s)/4
     ;;    heuristic undercounts: CJK, emoji, base64, dense code. Trips
-    ;;    independently of the token sum; reports the char count as the
-    ;;    `:token-count` so the agent's overflow handler sees an
+    ;;    independently of the token sum; reports the char count as
+    ;;    the `:token-count` so the agent's overflow handler sees an
     ;;    actionable number (not zero, not nil).
     ;;
     ;; Either gate trips the same truncate-with-marker fallback.
-    (let [tokens    (sum-text-tokens io result)
-          chars     (sum-text-chars io result)
-          byte-cap  (* cap byte-cap-multiplier)
-          over?     (or (> tokens cap) (> chars byte-cap))]
+    ;;
+    ;; ## Single-pass token+char sum (rf2-hyp0z / F9-F10)
+    ;;
+    ;; The previous implementation called `sum-text-tokens` and
+    ;; `sum-text-chars` separately, each invoking `content-texts` on
+    ;; `io` once. For story-mcp's reify that materialised the result
+    ;; twice (including a `(pr-str (:structuredContent result))` on
+    ;; each call — the dominant cost for structured-content responses
+    ;; up to 30K chars). The single-pass transduce below folds both
+    ;; sums in one walk of the content-texts seq, materialising the
+    ;; expensive accessor exactly once per response.
+    (let [{:keys [tokens chars]}
+          (transduce (filter string?)
+                     (completing
+                       (fn [{:keys [tokens chars]} s]
+                         {:tokens (+ tokens (overflow/token-estimate s))
+                          :chars  (+ chars (count s))}))
+                     {:tokens 0 :chars 0}
+                     (content-texts io result))
+          byte-cap (* cap byte-cap-multiplier)
+          over?    (or (> tokens cap) (> chars byte-cap))]
       (if-not over?
         result
         (let [reported (if (> chars byte-cap) chars tokens)

--- a/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
@@ -45,15 +45,14 @@
   per-tool next-step prose is domain-specific. The cap value, token
   rule, and marker shape are cross-MCP conventions and stay here.
 
-  ## Pluggable strategy
+  ## Single strategy today: truncate-with-marker
 
-  Today only `:truncate-with-marker` is wired — drop the payload, emit
-  the overflow marker. Future strategies (path-slicing rf2-tygdv, lazy
-  summary rf2-u2029, diff encoding rf2-rl7y) compose here without
-  rebuilding the per-consumer wrapper. Unknown strategies degrade
-  safely to `:truncate-with-marker` rather than throwing — the
-  wire-egress posture is to ALWAYS bound the response, never to ship
-  the over-budget payload.
+  The only strategy wired is drop-the-payload-and-emit-the-overflow-
+  marker. When future strategies land (path-slicing rf2-tygdv, lazy
+  summary rf2-u2029, diff encoding rf2-rl7y) the pluggable hook gets
+  reintroduced here. Until then `apply-cap` calls
+  `build-overflow-result` directly — no `case` dispatcher pretending
+  there's more than one branch (pre-alpha YAGNI).
 
   ## Cross-platform
 
@@ -184,24 +183,15 @@
 
   `opts` keys:
 
-    :tool     — string tool name carried in the marker for the agent's
-                pattern match.
-    :cap      — integer cap in tokens, or `nil` to disable. Usually the
-                output of `max-tokens` against the consumer's
-                `:max-tokens` arg.
-    :hint     — string next-step hint embedded in the marker. The
-                consumer's per-tool hint table resolves this from
-                `tool`; absent ⇒ `overflow/overflow-hint-fallback`.
-    :strategy — `:truncate-with-marker` (default; today the only
-                wired option). Unknown values degrade safely to the
-                default — never throw, never ship the over-budget
-                payload.
-
-  Future strategies (path-slicing, lazy summary, diff encoding) slot
-  in here without touching the per-consumer wrapper or per-tool
-  handler."
-  [io result {:keys [tool cap hint strategy]
-              :or   {strategy :truncate-with-marker}}]
+    :tool — string tool name carried in the marker for the agent's
+            pattern match.
+    :cap  — integer cap in tokens, or `nil` to disable. Usually the
+            output of `max-tokens` against the consumer's
+            `:max-tokens` arg.
+    :hint — string next-step hint embedded in the marker. The
+            consumer's per-tool hint table resolves this from `tool`;
+            absent ⇒ `overflow/overflow-hint-fallback`."
+  [io result {:keys [tool cap hint]}]
   (cond
     (nil? cap)    result
     (nil? result) result
@@ -219,7 +209,7 @@
     ;;    `:token-count` so the agent's overflow handler sees an
     ;;    actionable number (not zero, not nil).
     ;;
-    ;; Either gate trips the same `:truncate-with-marker` strategy.
+    ;; Either gate trips the same truncate-with-marker fallback.
     (let [tokens    (sum-text-tokens io result)
           chars     (sum-text-chars io result)
           byte-cap  (* cap byte-cap-multiplier)
@@ -232,9 +222,4 @@
                           :token-count reported
                           :cap         cap
                           :hint        hint})]
-          ;; Unknown strategy: degrade safely to truncate-with-marker.
-          ;; The pluggable shape is preserved so a future strategy can
-          ;; branch here without touching consumers.
-          (case strategy
-            :truncate-with-marker (build-overflow-result io marker result)
-            (build-overflow-result io marker result)))))))
+          (build-overflow-result io marker result))))))

--- a/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
@@ -213,8 +213,29 @@
   "Apply a vector of patches to `base`, returning the reconstructed
   value. Patches are `[path :assoc v]` or `[path :dissoc]`. Root-path
   patches (path `[]`) replace `base` outright (for `:assoc`) or are a
-  no-op (for `:dissoc`, by convention)."
+  no-op (for `:dissoc`, by convention).
+
+  ## Decoder-boundary validation (rf2-8e61v)
+
+  `apply-patches` is the wire-decoder entry point: a malformed patch
+  reaching this fn is a contract violation by an upstream encoder (a
+  drifted re-frame2 mcp-base, a third-party decoder rolling its own
+  shape, a transport corruption). Mirror `diff-encode-db-after`'s
+  encoder-boundary gate: validate `patches` against `patches-schema`
+  and throw `:rf.error/bad-diff-patches` ex-info on mismatch.
+
+  The encoder side already pinned the grammar; this is the symmetric
+  decode-side gate so the cross-MCP wire convention surfaces the
+  drift rather than silently no-op'ing on the malformed tuple (the
+  previous behaviour fell through the `cond` to `:else acc` and
+  dropped corrupted patches without a peep).
+
+  Soft-pass behaviour mirrors the encoder: when Malli is not
+  resolvable on the runtime classpath, validation is skipped. The
+  CLJS `validate-patches?` `goog-define` toggle elides both gates
+  together in `:advanced` builds."
   [base patches]
+  (validate-patches! patches)
   (reduce
     (fn [acc patch]
       (let [[path op v] patch]

--- a/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
@@ -155,21 +155,23 @@
                          :patches        patches})))))
   nil)
 
-(declare collect-patches)
+(declare collect-patches-into)
 
-(defn- collect-map-patches
-  "Generate patches that transform map `a` into map `b` at `path`.
-  Recurses into sub-maps; vectors and scalars are treated as leaves
-  (replaced wholesale via `:assoc` rather than re-diffed element-wise
-  — element-wise vector diff doesn't shrink the wire for the typical
-  app-db where vector values are short).
+(defn- collect-map-patches-into
+  "Like `collect-map-patches`, but threads an explicit accumulator
+  `acc` rather than building a fresh vector and `into`-ing it back at
+  every recursion site. Two-pass: walks `b` once to emit `:assoc`
+  patches for added / changed keys (recursing on map/map pairs), then
+  walks `a` once to emit `:dissoc` patches for keys absent from `b`.
 
-  Two-pass: walks `b` once to emit `:assoc` patches for added /
-  changed keys (recursing on map/map pairs), then walks `a` once to
-  emit `:dissoc` patches for keys absent from `b`. Avoids the
-  intermediate key-union set the naive single-pass form would
-  allocate per call — non-trivial on the hot app-db diff path."
-  [a b path]
+  Threading the accumulator (rf2-c2k9k / F12) avoids the intermediate
+  patches vector each recursion site previously allocated for `into
+  acc` — on deep app-db diffs (5-10 nesting levels typical) every
+  recursion now `conj`s directly into the parent accumulator rather
+  than allocating a fresh vector and copying it back. Big-O is
+  unchanged; the saving is allocation pressure, mostly visible on the
+  hot `watch-epochs` / `trace-window` slice."
+  [acc a b path]
   (let [after-assocs
         (reduce-kv
           (fn [acc k bv]
@@ -182,13 +184,13 @@
                 ;; Unchanged — skip.
                 (= av bv)
                 acc
-                ;; Both maps: recurse.
+                ;; Both maps: recurse, threading acc.
                 (and (map? av) (map? bv))
-                (into acc (collect-patches av bv p))
+                (collect-patches-into acc av bv p)
                 ;; Otherwise: leaf replacement.
                 :else
                 (conj acc [p :assoc bv]))))
-          []
+          acc
           b)]
     (reduce-kv
       (fn [acc k _av]
@@ -198,16 +200,25 @@
       after-assocs
       a)))
 
+(defn- collect-patches-into
+  "Internal accumulator-threading entry point for the recursion. The
+  public `collect-patches` calls this with an empty seed vector; the
+  internal `collect-map-patches-into` calls this for each
+  map-into-map descent, sharing the parent's accumulator rather than
+  allocating a fresh sub-vector."
+  [acc a b path]
+  (cond
+    (= a b) acc
+    (and (map? a) (map? b)) (collect-map-patches-into acc a b path)
+    :else (conj acc [path :assoc b])))
+
 (defn collect-patches
-  "Patch-list factory. Two maps recurse via `collect-map-patches`; any
-  other shape change is a single root-level `:assoc` replacement.
+  "Patch-list factory. Two maps recurse via `collect-map-patches-into`;
+  any other shape change is a single root-level `:assoc` replacement.
   Exposed for tests and for advanced consumers that want to diff
   arbitrary structures (not just `:db-after` vs `:db-before`)."
   [a b path]
-  (cond
-    (= a b) []
-    (and (map? a) (map? b)) (collect-map-patches a b path)
-    :else [[path :assoc b]]))
+  (collect-patches-into [] a b path))
 
 (defn apply-patches
   "Apply a vector of patches to `base`, returning the reconstructed

--- a/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
@@ -54,13 +54,28 @@
            (java.util.concurrent.atomic.AtomicLong. 0))
    :cljs (defonce ^:private malformed-counter (atom 0)))
 
-(defn- malformed-count
+(defn malformed-count
   "Read the count of malformed `:sensitive?` stamps observed since
-  process start. Exposed for tests and operator surfaces; not part of
-  the wire vocabulary."
+  process start (or since the last `reset-malformed-count!`). The
+  fail-closed posture (rf2-ih7g4) is silent on the wire — the counter
+  is the operator-surface observability hook. Public so operator
+  dashboards and tests can read the gate's activity.
+
+  Returns a non-negative integer."
   []
   #?(:clj  (.get ^java.util.concurrent.atomic.AtomicLong malformed-counter)
      :cljs @malformed-counter))
+
+(defn reset-malformed-count!
+  "Reset the malformed-stamp counter to zero. The counter is a
+  process-wide singleton; tests that exercise the fail-closed path
+  call this to isolate their increments from other tests' increments.
+  Returns the new value (always zero)."
+  []
+  #?(:clj  (do (.set ^java.util.concurrent.atomic.AtomicLong malformed-counter 0)
+               0)
+     :cljs (do (reset! malformed-counter 0)
+               0)))
 
 (defn- bump-malformed!
   "Increment the malformed-stamp counter. Internal."

--- a/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
@@ -72,27 +72,49 @@
   (is (zero? (args/parse-non-negative-int -5 5000))))
 
 ;; ---------------------------------------------------------------------------
-;; parse-keyword
+;; fresh-keyword — positive-named intern for operator-gated write paths
+;; (rf2-xxtrz, the successor to the retired `parse-keyword`).
 ;; ---------------------------------------------------------------------------
 
-(deftest parse-keyword-passes-through-keywords
-  (is (= :foo (args/parse-keyword :foo)))
-  (is (= :ns/foo (args/parse-keyword :ns/foo))))
+(deftest fresh-keyword-passes-through-keywords
+  (is (= :foo (args/fresh-keyword :foo)))
+  (is (= :ns/foo (args/fresh-keyword :ns/foo))))
 
-(deftest parse-keyword-nil-returns-nil
-  (is (nil? (args/parse-keyword nil))))
+(deftest fresh-keyword-nil-returns-nil
+  (is (nil? (args/fresh-keyword nil))))
 
-(deftest parse-keyword-strips-leading-colon
-  (is (= :foo (args/parse-keyword ":foo")))
-  (is (= :ns/foo (args/parse-keyword ":ns/foo"))))
+(deftest fresh-keyword-strips-leading-colon
+  (is (= :foo (args/fresh-keyword ":foo")))
+  (is (= :ns/foo (args/fresh-keyword ":ns/foo"))))
 
-(deftest parse-keyword-parses-namespaced
-  (is (= :rf.assert/path-equals (args/parse-keyword "rf.assert/path-equals")))
-  (is (= :rf.assert/path-equals (args/parse-keyword ":rf.assert/path-equals"))))
+(deftest fresh-keyword-parses-namespaced
+  (is (= :rf.assert/path-equals (args/fresh-keyword "rf.assert/path-equals")))
+  (is (= :rf.assert/path-equals (args/fresh-keyword ":rf.assert/path-equals"))))
 
-(deftest parse-keyword-blank-returns-nil
-  (is (nil? (args/parse-keyword "")))
-  (is (nil? (args/parse-keyword ":"))))
+(deftest fresh-keyword-blank-returns-nil
+  (is (nil? (args/fresh-keyword "")))
+  (is (nil? (args/fresh-keyword ":"))))
+
+(deftest fresh-keyword-rejects-non-string-non-keyword-input
+  ;; The contract is "agent-supplied id" — anything other than the two
+  ;; admitted shapes (string, keyword) returns nil rather than coercing.
+  (is (nil? (args/fresh-keyword 42)))
+  (is (nil? (args/fresh-keyword [:foo])))
+  (is (nil? (args/fresh-keyword {:k :v}))))
+
+(deftest fresh-keyword-interns-on-fresh-input
+  ;; The defining contract: `fresh-keyword` INTERNS by design (the call
+  ;; site is allocating a new identifier rather than resolving an
+  ;; existing one). Pin the intern so a future refactor that swaps the
+  ;; body for a `safe-keyword`-only path trips this gate before
+  ;; reaching the operator-gated write callers (story-mcp's
+  ;; register-variant, record-as-variant).
+  (let [novel-name "rf2-xxtrz-fresh-keyword-intern-pin"]
+    (is (nil? (find-keyword novel-name))
+        "precondition: the novel name is not in the keyword table")
+    (is (= (keyword novel-name) (args/fresh-keyword novel-name)))
+    (is (some? (find-keyword novel-name))
+        "fresh-keyword MUST intern — that's the entire point of the primitive")))
 
 ;; ---------------------------------------------------------------------------
 ;; parse-mode
@@ -108,7 +130,7 @@
 
 (deftest parse-mode-strips-leading-colon
   ;; Regression pin (rf2-wnyy9 / round-2 F2): `parse-mode` must accept
-  ;; agent-supplied `":diff"` the same way `parse-keyword` accepts
+  ;; agent-supplied `":diff"` the same way the read path accepts
   ;; `":foo"`. Before the fix this silently default-fell-back — the
   ;; agent saw `:diff` returned but the value was the function's
   ;; default, not a recognised match.
@@ -172,10 +194,10 @@
 
 (deftest parse-mode-unknown-string-does-not-intern
   ;; Regression pin (rf2-ih7g4): `parse-mode` previously routed every
-  ;; string input through `parse-keyword` (which interns) and then
-  ;; membership-checked the result. With the fix, the membership check
-  ;; happens BEFORE intern. A rejected string MUST leave the keyword
-  ;; table untouched.
+  ;; string input through an interning helper and then membership-
+  ;; checked the result. With the fix, the membership check happens
+  ;; BEFORE intern. A rejected string MUST leave the keyword table
+  ;; untouched.
   (let [novel-name "rf2-ih7g4-parse-mode-novel-name-do-not-intern"]
     (is (nil? (find-keyword novel-name))
         "precondition: the novel name is not in the keyword table")

--- a/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.mcp-base.args-test
   "Tests for the shared MCP argument-coercion helpers (rf2-vw4sq)."
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is]]
             [re-frame.mcp-base.args :as args]))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
@@ -183,28 +183,20 @@
     (is (= :reached (:limit body)))
     (is (pos? (:token-count body)))))
 
-(deftest apply-cap-byte-cap-trips-when-only-secondary-fires
-  ;; Direct exercise of the secondary char cap (rf2-ih7g4). Use a
-  ;; custom IO that under-reports tokens (returns nothing to the
-  ;; token-summer) while exposing the full char count via
-  ;; `content-texts` for the byte gate. This simulates a future
-  ;; refined `token-estimate` (e.g. one that recognises base64 and
-  ;; returns a much lower per-char token cost) — the secondary char
-  ;; cap is the defence-in-depth that bounds the actual wire bytes.
+(deftest byte-cap-multiplier-and-char-sum-are-pinned
+  ;; Defence-in-depth shape pin (rf2-ih7g4 / rf2-8cpsg / F18). The
+  ;; secondary byte cap is `cap * byte-cap-multiplier` and reads from
+  ;; the same `content-texts` seq the token sum does. Under the
+  ;; current `(quot c 4)` token rule the secondary gate is
+  ;; mathematically un-trippable in isolation (token sum ≈ chars/4,
+  ;; so chars > cap*8 ⇒ tokens > cap*2 > cap); the gate is kept
+  ;; wired so a future token-rule refinement (e.g. one that
+  ;; recognises base64 with a much lower per-char cost) cannot
+  ;; silently widen the wire envelope.
   ;;
-  ;; The mock returns the full text from `content-texts` but the
-  ;; algorithm computes BOTH tokens (via `overflow/token-estimate`)
-  ;; and chars (via `count`) from the same seq. To trip ONLY the
-  ;; secondary, we need a state where token sum ≤ cap but char count
-  ;; > cap * 8. Under the current `(quot c 4)` rule this is
-  ;; mathematically impossible (token sum ≈ chars/4, so chars > cap*8
-  ;; ⇒ tokens > cap*2 > cap). The byte cap is therefore a future-
-  ;; proof gate, kept wired so a future token-rule refinement does
-  ;; not silently widen the wire envelope.
-  ;;
-  ;; Pin the algorithmic contract: the byte cap is part of `apply-cap`
-  ;; and `sum-text-chars` reads the same content-texts the token sum
-  ;; does.
+  ;; Pin the two shape invariants — `byte-cap-multiplier = 8` and
+  ;; `sum-text-chars` and `sum-text-tokens` read the same content-
+  ;; texts seq.
   (is (= 8 cap/byte-cap-multiplier))
   (let [r {:content [{:type "text" :text (big-string 100)}]}]
     (is (= 100 (cap/sum-text-chars map-io r)))

--- a/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
@@ -125,18 +125,6 @@
         body (get-in out [:structuredContent vocab/overflow-key])]
     (is (= overflow/overflow-hint-fallback (:hint body)))))
 
-(deftest apply-cap-unknown-strategy-degrades-safely
-  ;; Unknown strategy must NOT throw and must NOT ship the over-budget
-  ;; payload. It falls back to truncate-with-marker.
-  (let [big (big-string 8000)
-        r   (ok-text-result {:huge big})
-        out (cap/apply-cap map-io r {:tool "snapshot"
-                                     :cap 500
-                                     :strategy :unknown-strategy})
-        marker (:structuredContent out)]
-    (is (contains? marker vocab/overflow-key))
-    (is (= :reached (get-in marker [vocab/overflow-key :limit])))))
-
 (deftest apply-cap-at-cap-exact-boundary-passes
   ;; <= cap passes; only > cap trips. Boundary check pins inclusive-low.
   (let [s    (big-string 400)

--- a/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
@@ -6,7 +6,7 @@
   reify, story-mcp's CLJ-map reify) are exercised against the real
   pipeline in their respective test suites; the unit tests here pin
   the algorithm itself."
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is]]
             [re-frame.mcp-base.cap :as cap]
             [re-frame.mcp-base.overflow :as overflow]
             [re-frame.mcp-base.vocab :as vocab]))

--- a/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
@@ -276,3 +276,55 @@
           (is (= :rf.error/bad-diff-patches
                  (:rf.error/code (ex-data e)))
               "ex-info carries the reserved :rf.error/* code"))))))
+
+;; ---------------------------------------------------------------------------
+;; Decoder-boundary validation (rf2-8e61v / F17).
+;;
+;; `apply-patches` is the wire-decoder entry point. A malformed patch
+;; reaching this fn is a contract violation — the previous behaviour
+;; silently no-op'd on the offending tuple (fell through the `cond` to
+;; `:else acc` and dropped the corrupted patch without a peep). Mirror
+;; the encoder boundary's gate: validate against `patches-schema` and
+;; throw `:rf.error/bad-diff-patches`.
+;; ---------------------------------------------------------------------------
+
+(deftest apply-patches-rejects-malformed-tuples
+  (testing "missing op (2-element tuple with no op) throws"
+    ;; Pre-fix: silently no-op'd because the destructure put `nil` in
+    ;; `op` and the cond fell through to `:else acc`. Post-fix: the
+    ;; validate-patches! gate trips on the malformed tuple BEFORE the
+    ;; reduce starts.
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #"diff-encode patch grammar violated"
+          (de/apply-patches {} [[[:a]]]))))
+  (testing "unknown op throws"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #"diff-encode patch grammar violated"
+          (de/apply-patches {} [[[:a] :replace 1]]))))
+  (testing "non-vector path throws"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #"diff-encode patch grammar violated"
+          (de/apply-patches {} [[:a :assoc 1]]))))
+  (testing "ex-info carries reserved :rf.error/bad-diff-patches code"
+    (try
+      (de/apply-patches {} [[[:a] :replace 1]])
+      (is false "expected throw")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/bad-diff-patches
+               (:rf.error/code (ex-data e))))))))
+
+(deftest apply-patches-well-formed-input-passes-validation
+  ;; Soft contract: well-formed patches pass the gate silently and
+  ;; produce the same output the pre-validation implementation did.
+  (is (= {:a 1 :b 2}
+         (de/apply-patches {:a 1} [[[:b] :assoc 2]])))
+  (is (= {:a 1}
+         (de/apply-patches {:a 1 :b 2} [[[:b] :dissoc]])))
+  (is (= []
+         (let [out (de/apply-patches {:a 1} [])]
+           ;; empty patches: identity passthrough
+           (is (= {:a 1} out))
+           []))))

--- a/tools/mcp-base/test/re_frame/mcp_base/elision_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/elision_test.clj
@@ -53,3 +53,26 @@
                                         {:bytes 1}}}}]
       (is (= 1 (elision/count-elided-markers body-with-collision))
           "Marker body is opaque; nested marker-shape isn't double-counted."))))
+
+(deftest count-elided-markers-handles-lazy-seq-input
+  ;; Mirror sensitive_test.clj's lazy-seq pin (rf2-cwqc8 / round-2 F17).
+  ;; The walker accepts `seq?` per `elision.cljc` so a slice composed via
+  ;; `concat` / `map` / `filter` (lazy seqs) must count the same as the
+  ;; equivalent vector. Regression pin for rf2-jj46n / F20.
+  (let [marker {:rf.size/large-elided
+                {:path   [:user :pdf]
+                 :bytes  102400
+                 :type   :string
+                 :reason :declared
+                 :handle [:rf.elision/at [:user :pdf]]}}
+        contents [{:slice 1} marker {:slice 2 :nested marker}]
+        as-lazy  (map identity contents)]
+    (is (seq? as-lazy)
+        "precondition: `map` yields a lazy seq, not a vector")
+    (is (= 2 (elision/count-elided-markers as-lazy))
+        "lazy seqs count markers identically to the vector path")
+    (is (= 2 (elision/count-elided-markers contents))
+        "vector path baseline matches the lazy path")
+    (is (= 2 (elision/count-elided-markers
+              (filter (constantly true) contents)))
+        "filter-derived lazy seq counts identically")))

--- a/tools/mcp-base/test/re_frame/mcp_base/overflow_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/overflow_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.mcp-base.overflow-test
   "Tests for the overflow-marker shape (rf2-rvyzy / rf2-vw4sq)."
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is]]
             [re-frame.mcp-base.overflow :as overflow]
             [re-frame.mcp-base.vocab :as vocab]))
 

--- a/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
@@ -207,3 +207,25 @@
         [out dropped] (sensitive/scrub-snapshot snap false strip-by-id-2)]
     (is (= 2 dropped))
     (is (= [{:id 1} {:id 3}] (get-in out [:rf/default :traces])))))
+
+(deftest scrub-snapshot-2-arity-delegates-to-strip-sensitive
+  ;; The 2-arity form is the default-suppress shape used by story-mcp /
+  ;; causa-mcp; its contract that it delegates to `strip-sensitive` is
+  ;; the load-bearing spec/009 §Privacy MUST. A regression that flipped
+  ;; the default to a no-op (or any other predicate) wouldn't trip the
+  ;; existing tests — those only exercise the 2-arity form's outputs
+  ;; against trace-event-stamp inputs, never the parity-with-3-arity
+  ;; contract directly. Pin it: the 2-arity output MUST equal the
+  ;; 3-arity call with `strip-sensitive` explicit (rf2-jj46n / F21).
+  (let [snap {:rf/default
+              {:traces [{:id 1 :sensitive? false}
+                        {:id 2 :sensitive? true}
+                        {:id 3}
+                        {:id 4 :sensitive? true}]
+               :epochs [{:event-id :foo}
+                        {:event-id :auth/sign-in :sensitive? true}]
+               :machines {}}}
+        two-arity   (sensitive/scrub-snapshot snap false)
+        three-arity (sensitive/scrub-snapshot snap false sensitive/strip-sensitive)]
+    (is (= two-arity three-arity)
+        "2-arity MUST delegate to strip-sensitive — spec/009 §Privacy default")))

--- a/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
@@ -208,6 +208,46 @@
     (is (= 2 dropped))
     (is (= [{:id 1} {:id 3}] (get-in out [:rf/default :traces])))))
 
+;; ---------------------------------------------------------------------------
+;; Malformed counter — operator-surface observability for the fail-
+;; closed gate (rf2-8cpsg / F19).
+;; ---------------------------------------------------------------------------
+
+(deftest malformed-count-increments-on-fail-closed-drop
+  ;; The fail-closed posture (rf2-ih7g4) drops a non-boolean truthy
+  ;; `:sensitive?` stamp AND increments a process-wide counter so
+  ;; operator surfaces can see the contract drift. Pre-fix, the
+  ;; counter was private and untestable; now `malformed-count` /
+  ;; `reset-malformed-count!` are public so this regression pin
+  ;; exists.
+  (sensitive/reset-malformed-count!)
+  (is (zero? (sensitive/malformed-count))
+      "precondition: counter starts at zero after reset")
+  (binding [*err* (java.io.StringWriter.)] ; absorb the warning
+    (sensitive/sensitive-event? {:sensitive? "true"})
+    (sensitive/sensitive-event? {:sensitive? :yes})
+    (sensitive/sensitive-event? {:sensitive? 1}))
+  (is (= 3 (sensitive/malformed-count))
+      "every fail-closed drop bumps the counter once")
+  ;; Well-formed stamps don't bump the counter.
+  (sensitive/sensitive-event? {:sensitive? true})
+  (sensitive/sensitive-event? {:sensitive? false})
+  (sensitive/sensitive-event? {:sensitive? nil})
+  (sensitive/sensitive-event? {})
+  (is (= 3 (sensitive/malformed-count))
+      "true / false / nil / absent stamps do NOT bump the counter")
+  (sensitive/reset-malformed-count!))
+
+(deftest reset-malformed-count!-zeroes-the-counter
+  (binding [*err* (java.io.StringWriter.)]
+    (sensitive/sensitive-event? {:sensitive? "true"}))
+  (is (pos? (sensitive/malformed-count))
+      "precondition: a fail-closed drop has bumped the counter")
+  (is (zero? (sensitive/reset-malformed-count!))
+      "reset returns the new value (zero)")
+  (is (zero? (sensitive/malformed-count))
+      "reset zeroes the counter for the next test"))
+
 (deftest scrub-snapshot-2-arity-delegates-to-strip-sensitive
   ;; The 2-arity form is the default-suppress shape used by story-mcp /
   ;; causa-mcp; its contract that it delegates to `strip-sensitive` is

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/args.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/args.cljs
@@ -81,13 +81,16 @@
    (`\"rf/default\"`) and EDN-shaped strings (`\":rf/default\"`) — strips
    a leading colon when present so callers can pass either form.
 
-   Delegates to `re-frame.mcp-base.args/parse-keyword` (rf2-vw4sq) so
+   Delegates to `re-frame.mcp-base.args/fresh-keyword` (rf2-xxtrz) so
    the slice-key / frame-key coercion is single-sourced across the
    pair2-mcp wire surface — same helper underpins both
    `parse-frames-arg` and the per-slice-mode key coercion in
-   `parse-modes-arg`."
+   `parse-modes-arg`. On CLJS keywords are not interned in the JVM
+   never-shrinking-table sense, so the intern-DoS concern that gates
+   `fresh-keyword` on the JVM side doesn't apply here; the call is
+   straight string-to-keyword coercion."
   [x]
-  (base-args/parse-keyword x))
+  (base-args/fresh-keyword x))
 
 (defn coerce-path-segment
   "Coerce one segment of a JS-array path argument.
@@ -200,7 +203,7 @@
   or keywords.
 
   Slice-key coercion delegates to `->frame-keyword` (which routes
-  through `re-frame.mcp-base.args/parse-keyword`); per-slice mode
+  through `re-frame.mcp-base.args/fresh-keyword`); per-slice mode
   coercion delegates to `re-frame.mcp-base.args/parse-mode` with a
   sentinel default so unrecognised values can be detected and
   dropped rather than coerced to the global default (rf2-vw4sq)."

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
@@ -128,11 +128,11 @@
 ;; Bounded-allowlist keyword resolution (rf2-lqjbk)
 ;; ---------------------------------------------------------------------------
 ;;
-;; The legacy `args/parse-keyword` INTERNS on the JVM — a caller streaming
-;; unique random strings as `:variant-id`s would slowly grow the JVM's
-;; never-shrinking keyword table. The mitigation is to resolve every
-;; agent-supplied keyword id against a bounded set BEFORE coercing it to
-;; a keyword, using `args/safe-keyword` (which routes through
+;; A naive `(keyword raw-agent-string)` INTERNS on the JVM — a caller
+;; streaming unique random strings as `:variant-id`s would slowly grow
+;; the JVM's never-shrinking keyword table. The mitigation is to resolve
+;; every agent-supplied keyword id against a bounded set BEFORE coercing
+;; it to a keyword, using `args/safe-keyword` (which routes through
 ;; `find-keyword` on the JVM — no intern outside the allowlist).
 ;;
 ;; For READ-side handlers (every tool in dev / docs / testing) the
@@ -144,7 +144,7 @@
 ;;
 ;; The WRITE-side handlers (`register-variant`) are the documented
 ;; exception: by design they extend the registry with a fresh keyword.
-;; Those callers intern via `args/parse-keyword` directly, bounded by
+;; Those callers intern via `args/fresh-keyword` directly, bounded by
 ;; the operator-gated `--allow-writes` flag (the registry itself is the
 ;; bounded set; the operator chose to open it).
 

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
@@ -188,9 +188,9 @@
                    :extends  (:extends arguments)})
                 (let [target-vid  (cond
                                     ;; write-back path: operator-gated
-                                    ;; intern via parse-keyword.
+                                    ;; intern via fresh-keyword.
                                     (and write-back? (:new-variant-id arguments))
-                                    (args/parse-keyword (:new-variant-id arguments))
+                                    (args/fresh-keyword (:new-variant-id arguments))
 
                                     ;; non-write-back: snippet-only,
                                     ;; safe-keyword against the live

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
@@ -196,12 +196,14 @@
                 ;; rf2-lqjbk write-side exception: `register-variant`
                 ;; by definition extends the registry with a fresh
                 ;; keyword id, so `safe-keyword` against an existing
-                ;; bounded set would always reject. The intern here is
-                ;; gate-bounded by `--allow-writes` (operator-only
-                ;; opt-in); the registrar's `assert-id!` enforces the
+                ;; bounded set would always reject. `fresh-keyword`
+                ;; (rf2-xxtrz) is the positive-named primitive for this
+                ;; case — the intern here is gate-bounded by
+                ;; `--allow-writes` (operator-only opt-in); the
+                ;; registrar's `assert-id!` enforces the
                 ;; `:story.<path>/<name>` grammar, which constrains the
                 ;; per-id allocation cost.
-                (register-or-error (args/parse-keyword vid) body-v)))))))
+                (register-or-error (args/fresh-keyword vid) body-v)))))))
 
 (defn tool-unregister-variant
   "Write: programmatically unregister a variant. Gated behind


### PR DESCRIPTION
## Summary

Cluster of 8 audit follow-up beads from `rf2-u64jt` (audit at
`ai/findings/mcp-base-slice-audit-2026-05-15.md`). All changes scoped
to `tools/mcp-base/` plus 3 callsite migrations in `tools/story-mcp/`
and `tools/pair2-mcp/` for the `parse-keyword` retirement.

Pre-alpha — no back-compat shims. Tight surface; sequenced commits in
audit-finding order (smallest cleanups first, highest-impact perf
last).

### Per-commit map (audit finding → commit → bead)

| # | Bead | Audit | Commit type | What |
|---|---|---|---|---|
| 1 | rf2-pu58u | F1/F3 | cleanup | drop unused `testing` refer + collapse `parse-int*` arms |
| 2 | rf2-xxtrz | F5 | refactor | rename `parse-keyword` → `fresh-keyword` (positive-named intern; migrate 4 callsites) |
| 3 | rf2-i2n56 | F2/F16 | cleanup | drop unused `:strategy` `case` in `apply-cap` |
| 4 | rf2-jj46n | F20/F21 | test | lazy-seq input pin for elision; 2-arity delegation pin for scrub-snapshot |
| 5 | rf2-8e61v | F17 | test | pin `apply-patches` contract on malformed input (decode-side Malli gate) |
| 6 | rf2-8cpsg | F18/F19 | test | tighten byte-cap deftest name; expose `malformed-count` / `reset-malformed-count!` |
| 7 | rf2-c2k9k | F12 | perf | thread accumulator through `collect-patches` recursion |
| 8 | rf2-hyp0z | F9/F10 | perf | single-pass token+char sum in `apply-cap` |

### Highlights

**rf2-xxtrz** — masterpiece-bar option (a) per the bead: `parse-keyword`
was warning-laden in its docstring. Replaced with positive-named
`fresh-keyword` that puts the "allocating-not-resolving" posture on the
function name. Migrated `story-mcp/tools/write.cljc`,
`story-mcp/tools/recorder.cljc`, `pair2-mcp/tools/args.cljs ->frame-keyword`.

**rf2-8e61v** — `apply-patches` silently no-op'd on malformed patches.
Added decode-boundary Malli gate symmetric with the encoder's; throws
`:rf.error/bad-diff-patches`. Soft-pass when Malli unresolvable.

**rf2-hyp0z** — `apply-cap` previously walked `content-texts` twice
(once for tokens, once for chars). For story-mcp's reify that meant
`(pr-str (:structuredContent result))` twice per response. Folded into
a single transduce.

## Perf impact

Microbench on a story-mcp-shaped `ResultIO` reify with a 30K-char
`:structuredContent` payload, n=1000 iterations:
- Old double-walk: **~2.95ms / call**
- New single-pass: **~1.50ms / call**
- **~49% reduction** on the hot common-path call (`over?` check runs on
  every response, including under-budget ones)

## Test count delta

- `tools/mcp-base`: 105 tests / 260 assertions → **112 tests / 283 assertions**
  - +6 tests (lazy-seq pin, 2-arity delegation, `apply-patches` validation × 3, malformed-count × 2, fresh-keyword × 2, fresh-keyword-reject-non-string)
  - −1 test (the obsolete `apply-cap-unknown-strategy-degrades-safely`)
- `tools/story-mcp`: 124 tests / 596 assertions (unchanged; callsite migrations passed)
- `tools/pair2-mcp`: 442 tests / 1078 assertions (unchanged)
- `implementation` cljs: 2014 tests / 5680 assertions (unchanged regression gate)

## Test plan

- [x] `cd tools/mcp-base && clojure -M:test` — 112 / 283, all green
- [x] `cd tools/story-mcp && clojure -M:test` — 124 / 596 (`fresh-keyword` migration regression check)
- [x] `cd tools/pair2-mcp && npm test` — 442 / 1078 (`->frame-keyword` route through `fresh-keyword`)
- [x] `cd implementation && npm run test:cljs` — 2014 / 5680 (full cljs regression)
- [x] Microbench captured perf delta on the rf2-hyp0z hot path

## Beads closed

rf2-pu58u, rf2-xxtrz, rf2-i2n56, rf2-jj46n, rf2-8e61v, rf2-8cpsg, rf2-c2k9k, rf2-hyp0z