### PR TITLE
refactor(story): r2 audit follow-ups cluster (11 beads)

### DIFF
--- a/tools/story/spec/000-Vision.md
+++ b/tools/story/spec/000-Vision.md
@@ -57,7 +57,7 @@ required by the
 
 - **Visual development.** Iterate on a component in isolation; see
   every state side-by-side; flip between substrates (Reagent, UIx,
-  Helix, reagent-slim) when the view is substrate-portable.
+  Helix) when the view is substrate-portable.
 - **Test fixtures.** A `:test`-tagged variant *is* a complete component
   test; `(run-variant id)` returns
   `{:frame :app-db :assertions :rendered-hiccup :elapsed-ms}` —

--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -431,7 +431,7 @@ cells independently.
 
 ```clojure
 (story/reg-variant :story.ui.button/all-substrates
-  {:substrates #{:reagent :uix :helix :reagent-slim}})
+  {:substrates #{:reagent :uix :helix}})
 ```
 
 The multi-substrate pane (render shell) renders each substrate

--- a/tools/story/spec/002-Runtime.md
+++ b/tools/story/spec/002-Runtime.md
@@ -217,7 +217,7 @@ bridge if needed). Stage 3 picks one and locks it.
 
 ```clojure
 (rf/variant-substrates variant-id)
-;; => #{:reagent :uix :helix :reagent-slim}  (or a subset, per :substrates on variant/story)
+;; => #{:reagent :uix :helix}  (or a subset, per :substrates on variant/story)
 ```
 
 The story tool's multi-substrate pane iterates this set, rendering

--- a/tools/story/spec/003-Render-Shell.md
+++ b/tools/story/spec/003-Render-Shell.md
@@ -73,9 +73,9 @@ the registry level; stale variants re-mount.
 
 ## Multi-substrate side-by-side rendering
 
-For a variant declaring `:substrates #{:reagent :uix :helix
-:reagent-slim}` (or any subset; default = the host frame's adapter),
-the render shell renders each substrate **inline** in its own pane.
+For a variant declaring `:substrates #{:reagent :uix :helix}` (or any
+subset; default = the host frame's adapter), the render shell renders
+each substrate **inline** in its own pane.
 
 - Each per-substrate render runs in a try/catch boundary.
 - A substrate-specific failure renders inline alongside the other

--- a/tools/story/spec/005-SOTA-Features.md
+++ b/tools/story/spec/005-SOTA-Features.md
@@ -48,11 +48,10 @@ together are best-in-class. See
 
 ### Multi-substrate side-by-side rendering
 
-A variant declares `:substrates #{:reagent :uix :helix :reagent-slim}`
-(subset, default = the host frame's adapter); the multi-substrate
-pane renders each substrate side-by-side. Substrate-specific failures
-render inline (per [`003-Render-Shell.md`](003-Render-Shell.md)
-§Multi-substrate).
+A variant declares `:substrates #{:reagent :uix :helix}` (subset,
+default = the host frame's adapter); the multi-substrate pane renders
+each substrate side-by-side. Substrate-specific failures render inline
+(per [`003-Render-Shell.md`](003-Render-Shell.md) §Multi-substrate).
 
 This is unique to re-frame2 — the multi-substrate goal in the EPs
 makes the side-by-side rendering a natural fit; no JS tool can ship

--- a/tools/story/spec/DESIGN-RATIONALE.md
+++ b/tools/story/spec/DESIGN-RATIONALE.md
@@ -33,10 +33,11 @@ tools per the Storybook MCP Dev / Docs / Testing toolset split. See
 ### §inline-substrate-failures — render inline
 
 **Decision.** A variant may declare `:substrates #{:reagent :uix
-:helix :reagent-slim}` (subset, default = the host frame's adapter);
-when Story renders the variant against multiple substrates the
-failure for each is rendered **inline** with the variant pane — not
-auto-skipped.
+:helix}` (subset, default = the host frame's adapter); when Story
+renders the variant against multiple substrates the failure for each
+is rendered **inline** with the variant pane — not auto-skipped.
+`:reagent-slim` is reserved for future addition once the renderer
+ships; until then it is not on the canonical substrate enum.
 
 **Rationale.** Substrate-portability gaps are the entire point of
 multi-substrate rendering. Hiding failures hides the bugs Story

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -100,7 +100,7 @@
       :argtypes   {<arg-key> {...}}
       :tags       #{...}
       :modes      #{...}
-      :substrates #{:reagent :uix :helix :reagent-slim}
+      :substrates #{:reagent :uix :helix}
       :platforms  #{:server :client}
       :variants   {<variant-name> <variant-body>}}   ;; Form-B sugar
      ```

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -34,15 +34,15 @@
   - `allocate!` — create the frame (and register fx-override stubs);
     install the lifecycle machine's `:pre-mount` snapshot.
   - `destroy!` — tear down the frame; clear watchers.
-  - `reset!*` — destroy + re-allocate; the caller then re-runs the
+  - `reset-frame!` — destroy + re-allocate; the caller then re-runs the
     lifecycle.
 
   ## Hot-reload
 
   Stage 4's UI shell observes the registrar's `:rf.registry/handler-*`
-  trace events and re-runs `reset!*` for any variant whose registered
-  body changed. Stage 3 surfaces the entry point; the trigger lives in
-  Stage 4."
+  trace events and re-runs `reset-frame!` for any variant whose
+  registered body changed. Stage 3 surfaces the entry point; the
+  trigger lives in Stage 4."
   (:require [re-frame.core             :as rf]
             [re-frame.story.config     :as config]
             [re-frame.story.decorators :as decorators]
@@ -238,10 +238,12 @@
 
 ;; ---- destroy + re-allocate -----------------------------------------------
 
-(defn reset!*
-  "Destroy the variant frame and re-allocate it. Used by
-  `runtime/reset-variant`. The caller is responsible for re-running
-  the four-phase lifecycle (loaders → events → render → play) after."
+(defn reset-frame!
+  "Destroy the variant frame and re-allocate it. Mirrors the framework's
+  `re-frame.core/reset-frame!` naming (rf2-noizc — aligning Story's
+  frame helpers with the framework `*-frame!` convention). The caller
+  is responsible for re-running the four-phase lifecycle (loaders →
+  events → render → play) after."
   [variant-id decorator-stack]
   (destroy! variant-id)
   (allocate! variant-id decorator-stack))

--- a/tools/story/src/re_frame/story/predicates.cljc
+++ b/tools/story/src/re_frame/story/predicates.cljc
@@ -43,3 +43,29 @@
   (boolean (and (sequential? event)
                 (seq event)
                 (assertion-id? (first event)))))
+
+;; ---- EDN-format helpers --------------------------------------------------
+
+(defn indent-after
+  "Continuation indent that lines successive items up directly under
+  the character immediately following `prefix` on the previous line.
+  Returns `\"\\n<count(prefix) spaces>\"`. Pure data → string.
+
+  Used by `recorder/gen-play-snippet`, `save-variant/gen-variant-
+  snippet`, and `review-dialog`'s snippet renderer to join multi-line
+  EDN bodies. The argument is the literal first-line text preceding
+  the items (e.g. `\"   :play [\"` or `\"   :args {\"`) — passing the
+  rendered prefix verbatim keeps the geometry obvious and
+  breakage-resistant.
+
+  Example:
+
+      (str \"   :play [item1\" (indent-after \"   :play [\") \"item2]\")
+      ;; => \"   :play [item1\\n          item2]\"
+      ;;                  ^---------- item2 aligns under item1
+
+  Lives in the predicates leaf (rf2-ar0t9) so producers
+  (recorder / save-variant) don't have to `:require` the consumer
+  (review-dialog) just for this 4-line helper."
+  [prefix]
+  (str "\n" (apply str (repeat (count prefix) \space))))

--- a/tools/story/src/re_frame/story/recorder.cljc
+++ b/tools/story/src/re_frame/story/recorder.cljc
@@ -110,7 +110,6 @@
   (:require [clojure.string :as str]
             [re-frame.story.config :as config]
             [re-frame.story.predicates :as pred]
-            [re-frame.story.review-dialog :as review-dialog]
             [re-frame.trace :as trace]))
 
 ;; ---------------------------------------------------------------------------
@@ -184,10 +183,10 @@
   round-trips through re-frame's registrar machinery."
   [events {:keys [variant-id doc extends alias]
            :or   {alias "story"}}]
-  (let [;; The shared `indent-after` helper aligns events on continuation
-        ;; lines directly under the `[` of `:play [` — derived from the
-        ;; literal first-line prefix so the geometry is self-documenting.
-        ;; See `review-dialog/indent-after` for the unification rationale.
+  (let [;; The shared `indent-after` helper (predicates leaf) aligns events
+        ;; on continuation lines directly under the `[` of `:play [` —
+        ;; derived from the literal first-line prefix so the geometry is
+        ;; self-documenting. See `predicates/indent-after`.
         play-prefix "   :play ["
         body-keys   (cond-> []
                       doc     (conj [:doc (pr-str doc)])
@@ -195,7 +194,7 @@
                       true    (conj [:play
                                      (if (seq events)
                                        (str "["
-                                            (str/join (review-dialog/indent-after play-prefix)
+                                            (str/join (pred/indent-after play-prefix)
                                                       (map pr-str events))
                                             "]")
                                        "[]")]))

--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -417,17 +417,56 @@
             seed
             (ids :variant))))
 
+;; ---- variants-with-tags (memoised on mutation-tick, rf2-c5nwl) ----------
+;;
+;; The hot path is the sidebar compose loop + the SOTA assertions/play
+;; flows: every render computes
+;; `(variants-with-tags qs)` to surface the testable / docs-tagged subset.
+;; Each call is O(V × |query|) over the variant side-table. Once the
+;; registrar's mutation-tick is bumped, every cached answer becomes stale;
+;; until then, repeated calls with the same query collide on the same
+;; underlying set.
+;;
+;; The cache key is `[tick, sorted-qs]` so callers that pass the same
+;; query (in any order) hit the same slot. The cache is per-process and
+;; invalidates on every registrar mutation; a single-slot variant
+;; (last-call only) would also work, but the {tick → {qs → result}}
+;; shape keeps the assertions + sidebar + docs queries from evicting
+;; each other when they fire from the same render.
+
+(defonce ^:private variants-with-tags-cache
+  (atom {:tick -1 :by-query {}}))
+
+(defn- compute-variants-with-tags [qs]
+  (->> (registrations :variant)
+       (filter (fn [[_ body]]
+                 (let [tset (:tags body #{})]
+                   (some #(contains? tset %) qs))))
+       (map first)
+       set))
+
 (defn variants-with-tags
   "Return the variant ids whose `:tags` set intersects `query-tags`. Per
-  IMPL-SPEC §3.2 — the public `variants-with-tags` wraps this."
+  IMPL-SPEC §3.2 — the public `variants-with-tags` wraps this.
+
+  Memoised on the registrar mutation-tick (rf2-c5nwl): repeated calls
+  with the same query between two registrar writes return the same
+  cached set in O(1)."
   [query-tags]
-  (let [qs (set query-tags)]
-    (->> (registrations :variant)
-         (filter (fn [[_ body]]
-                   (let [tset (:tags body #{})]
-                     (some #(contains? tset %) qs))))
-         (map first)
-         set)))
+  (let [qs        (set query-tags)
+        cache-key (sort qs)
+        tick      @mutation-tick
+        cache     @variants-with-tags-cache]
+    (if (and (= tick (:tick cache))
+             (contains? (:by-query cache) cache-key))
+      (get (:by-query cache) cache-key)
+      (let [result (compute-variants-with-tags qs)]
+        (swap! variants-with-tags-cache
+               (fn [{prev-tick :tick prev-by :by-query}]
+                 (if (= prev-tick tick)
+                   {:tick tick :by-query (assoc prev-by cache-key result)}
+                   {:tick tick :by-query {cache-key result}})))
+        result))))
 
 (defn- query-tags-by
   "Pure data → data: return the set of registered tag ids whose body

--- a/tools/story/src/re_frame/story/review_dialog.cljc
+++ b/tools/story/src/re_frame/story/review_dialog.cljc
@@ -200,7 +200,7 @@
   (set-draft-id state (or (parse-variant-id-string s) s)))
 
 ;; ---------------------------------------------------------------------------
-;; Pure: snippet-format helpers
+;; Snippet-format helper — `indent-after` moved to predicates leaf
 ;;
 ;; The two save-as flows render multi-line EDN where successive items
 ;; (event vectors / map kv pairs) align directly under the opening
@@ -210,35 +210,10 @@
 ;;       {:play [[:counter/inc]
 ;;               [:counter/dec]]})
 ;;
-;; The continuation indent on the second line is geometric — N spaces
-;; that line `[:counter/dec]` up under `[:counter/inc]`. Pre-unification
-;; the recorder and save-variant carried separate hard-coded strings
-;; for that indent (`"\n           "` 11 spaces / `"\n            "` 12
-;; spaces), both off-by-one in opposite directions from the correct 10.
-;; The shared helper derives the indent from the rendered first-line
-;; prefix so the alignment is self-documenting and any future tweak to
-;; the wrapping shape stays consistent across flows.
-;; ---------------------------------------------------------------------------
-
-(defn indent-after
-  "Continuation indent that lines successive items up directly under
-  the character immediately following `prefix` on the previous line.
-  Returns `\"\\n<count(prefix) spaces>\"`. Pure data → string.
-
-  Used by `recorder/gen-play-snippet` and `save-variant/gen-variant-
-  snippet` to join multi-line EDN bodies. The argument is the literal
-  first-line text preceding the items (e.g. `\"   :play [\"` or
-  `\"   :args {\"`) — passing the rendered prefix verbatim keeps the
-  geometry obvious and breakage-resistant.
-
-  Example:
-
-      (str \"   :play [item1\" (indent-after \"   :play [\") \"item2]\")
-      ;; => \"   :play [item1\\n          item2]\"
-      ;;                  ^---------- item2 aligns under item1"
-  [prefix]
-  (str "\n" (apply str (repeat (count prefix) \space))))
-
+;; Per rf2-ar0t9: `indent-after` lives in `re-frame.story.predicates`
+;; so producers (recorder, save-variant) don't have to `:require`
+;; review-dialog (the consumer) for a 4-line helper. The dep direction
+;; recorder → review-dialog was upside-down.
 ;; ---------------------------------------------------------------------------
 ;; CLJS-only: Reagent ratom factory + adapter glue
 ;;

--- a/tools/story/src/re_frame/story/save_variant.cljc
+++ b/tools/story/src/re_frame/story/save_variant.cljc
@@ -41,6 +41,7 @@
             [re-frame.core                  :as rf]
             [re-frame.story.args            :as args]
             [re-frame.story.config          :as config]
+            [re-frame.story.predicates      :as pred]
             [re-frame.story.review-dialog   :as review-dialog]
             [re-frame.story.ui.state        :as state]))
 
@@ -83,7 +84,7 @@
   "Pretty-print an args map as a multi-line EDN form. Each top-level
   key/value pair renders on its own line, aligned directly under the
   opening `{` of `:args {`. Empty maps render as `{}`. Uses the shared
-  `review-dialog/indent-after` helper so the continuation indent stays
+  `predicates/indent-after` helper so the continuation indent stays
   in lockstep with the recorder's `gen-play-snippet`."
   [m]
   (if (empty? m)
@@ -91,7 +92,7 @@
     (str "{"
          (->> (sort-by (fn [[k _]] (str k)) m)
               (map (fn [[k v]] (str (pr-str k) " " (pr-str v))))
-              (str/join (review-dialog/indent-after "   :args {")))
+              (str/join (pred/indent-after "   :args {")))
          "}")))
 
 (defn gen-variant-snippet

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -209,8 +209,11 @@
 
 (def SubstrateSet
   "Subset of the recognised substrate ids. The framework supplies the
-  closed set; Story validates membership."
-  [:set [:enum :reagent :uix :helix :reagent-slim]])
+  closed set; Story validates membership. `:reagent-slim` is reserved
+  for future use — it is not yet on the canonical substrate enum (the
+  renderer hasn't shipped). See spec/000-Vision + the rf2-tb0ga
+  cleanup."
+  [:set [:enum :reagent :uix :helix]])
 
 (def PlatformSet
   "Subset of `#{:server :client}` per spec/007 `:platforms`."

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -30,9 +30,9 @@
   Lists the variant's resolved decorators; each can be skipped at
   runtime by name (the toggle writes a `:disabled-decorators` shell-
   state slot the canvas reads). Stage 4 ships the toggle UI; the
-  disable-by-name routing through `resolve-decorators` is a Stage 6
-  refinement when the decorator stack grows more complex. For Stage 4
-  the toggle is informational + a 'save layout' hook."
+  disable-by-name routing through `resolve-decorators` is a future
+  refinement when the decorator stack grows more complex; today the
+  toggle is informational."
   (:require [re-frame.story.registrar          :as registrar]
             [re-frame.story.args               :as args]
             [re-frame.story.decorators         :as decorators]
@@ -580,27 +580,11 @@
           [:span {:style (:label styles)} (str id)]
           [:span (str ":kind " (or (:kind body) "?"))]]))]))
 
-(defn save-layout-button
-  "Emit a stub 'save layout as :Workspace' action. Per IMPL-SPEC §2.5
-  the workspace persistence has two modes: local-storage (default) and
-  the explicit save-as which writes a transit-shareable registration.
-  Stage 4 stubs the save-as button; the transit emission lands in
-  Stage 6 alongside the QR code share affordance."
-  []
-  [:button {:style    (:button styles)
-            :on-click (fn [_]
-                        ;; Stage 4: no-op visual affordance — the
-                        ;; transit-emission lives behind the §2.5
-                        ;; surface that lands in Stage 6.
-                        (when js/window
-                          (js/console.log "[story] save-layout: Stage 6 ships transit emission")))}
-   "save layout as :Workspace.x/y"])
-
 (defn panel
-  "The full controls panel — args editor + decorator list + save-layout
-  + save-as-variant actions. Per rf2-xi9zk the per-variant mode-picker
-  moved to the chrome-level toolbar (`re-frame.story.ui.toolbar`); the
-  controls panel keeps args / decorator sections only.
+  "The full controls panel — args editor + decorator list + save-as-variant
+  action. Per rf2-xi9zk the per-variant mode-picker moved to the
+  chrome-level toolbar (`re-frame.story.ui.toolbar`); the controls panel
+  keeps args / decorator sections only.
 
   rf2-one3t: the 'save as new variant' button captures the live canvas
   state (effective args after the five-layer precedence chain) and
@@ -613,5 +597,4 @@
      [args-editor variant-id])
    (when variant-id
      [decorator-list variant-id])
-   [save-variant-ui/save-variant-button variant-id]
-   [save-layout-button]])
+   [save-variant-ui/save-variant-button variant-id]])

--- a/tools/story/src/re_frame/story/ui/multi_substrate.cljs
+++ b/tools/story/src/re_frame/story/ui/multi_substrate.cljs
@@ -32,7 +32,6 @@
   (:require [reagent.core :as r]
             [re-frame.core :as rf]
             [re-frame.story.args :as args]
-            [re-frame.story.decorators :as decorators]
             [re-frame.story.registrar :as registrar]
             [re-frame.story.ui.state :as state]))
 
@@ -214,7 +213,12 @@
   here when a variant's substrate set has more than one entry.
 
   Each cell renders inside a Reagent error boundary so a throw in one
-  substrate's render doesn't take down its neighbours (IMPL-SPEC §2.2)."
+  substrate's render doesn't take down its neighbours (IMPL-SPEC §2.2).
+
+  Note (rf2-77nuq): per-substrate decorator stacks (IMPL-SPEC §5.3)
+  are not yet threaded through here — `safe-render-cell` renders the
+  raw view-id under each substrate. When that work lands, resolve the
+  decorator pack here and thread it into each cell's render."
   [variant-id]
   (let [shell        @state/shell-state-atom
         variant-body (registrar/handler-meta :variant variant-id)
@@ -223,7 +227,6 @@
         substrates   (resolve-substrate-set variant-body story-body
                                             (or (:substrate shell) :reagent))
         view-id      (or (:component variant-body) (:component story-body))
-        decor-pack   (decorators/resolve-decorators variant-id)
         eff-args     (args/resolve-args
                        variant-id
                        {:active-modes   (:active-modes shell)

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -115,17 +115,20 @@
 ;; the same hash 99.9% of the time.
 ;;
 ;; The cache below keys on `[registrar-mutation-tick, active-modes,
-;; substrate]` — the three inputs that can perturb a snapshot-identity
-;; hash across two polls (registrar writes invalidate every variant
-;; entry; shell-state mode/substrate changes too). When the key matches
-;; the previous tick's key, we return the cached map — zero hashing
-;; work. When it drifts, we recompute the lot once and re-seed the
-;; cache.
+;; substrate, cell-overrides]` — the four inputs that can perturb a
+;; snapshot-identity hash across two polls. Registrar writes invalidate
+;; every variant entry; shell-state mode/substrate changes do too; and
+;; per-cell control edits land in `:cell-overrides` and ARE threaded
+;; through `args/resolve-args` into `snapshot-tuple`'s `:effective-args`
+;; slot (identity.cljc:213 + args.cljc:125-134) — they DO perturb the
+;; hash. When the key matches the previous tick's key, we return the
+;; cached map — zero hashing work. When it drifts, we recompute the lot
+;; once and re-seed the cache.
 ;;
-;; The `:cell-overrides` slot of shell-state is intentionally NOT in
-;; the cache key: `snapshot-identity`'s public surface drops it (only
-;; `:active-modes` and `:substrate` are threaded into the tuple), so
-;; per-cell control edits do not perturb the watch-mode signal.
+;; Pre-rf2-mclvi the cache key dropped `:cell-overrides` citing
+;; `snapshot-identity` as the source of truth, but `snapshot-tuple`
+;; DOES read them via `resolve-args` — the cache was stale after every
+;; control edit, watch-mode missed re-runs.
 
 (defonce ^:private testable-hash-cache
   (atom {:key nil :hashes nil}))
@@ -134,31 +137,34 @@
   "Walk the registered testable variants and return a `{variant-id →
   hex-hash}` map of snapshot-identity content hashes. The hash captures
   the variant's `:play` / `:events` / `:loaders` / `:decorators` /
-  `:tags` slots plus the parent story's slice and the view's registered
-  schema-digest (per `re-frame.story.identity` §What's in the hash —
-  spec/007 §Variant snapshot identity), so a change to any of those —
-  including a decorator-only edit or a view schema change — produces a
-  fresh hash.
+  `:tags` slots plus the parent story's slice, the view's registered
+  schema-digest, AND the variant's resolved effective args (which fold
+  in the user's live `:cell-overrides`). See `re-frame.story.identity`
+  §What's in the hash + spec/007 §Variant snapshot identity.
 
   HOT PATH (rf2-zrswb): registrar-driven cache short-circuits when
-  neither the side-table nor the relevant shell-state slots have
-  drifted since the last tick."
+  neither the side-table nor the relevant shell-state slots
+  (`:active-modes` / `:substrate` / `:cell-overrides`) have drifted
+  since the last tick."
   []
-  (let [shell  (state/get-state)
-        modes  (:active-modes shell)
-        subs   (:substrate shell)
-        tick   (registrar/current-mutation-tick)
-        key    [tick modes subs]
-        cached @testable-hash-cache]
+  (let [shell      (state/get-state)
+        modes      (:active-modes shell)
+        subs       (:substrate shell)
+        overrides  (:cell-overrides shell)
+        tick       (registrar/current-mutation-tick)
+        key        [tick modes subs overrides]
+        cached     @testable-hash-cache]
     (if (= key (:key cached))
       (:hashes cached)
       (let [testable (state/testable-variant-ids
                        (:variants (state/registry-snapshot)))
-            opts     {:active-modes modes :substrate subs}
             hashes   (into {}
                            (map (fn [vid]
-                                  [vid (:content-hash
-                                         (identity/snapshot-identity vid opts))]))
+                                  (let [opts {:active-modes   modes
+                                              :substrate      subs
+                                              :cell-overrides (get overrides vid)}]
+                                    [vid (:content-hash
+                                           (identity/snapshot-identity vid opts))])))
                            testable)]
         (reset! testable-hash-cache {:key key :hashes hashes})
         hashes))))

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -176,15 +176,18 @@
   with un-axis-grouped tags trailing in an `OTHER` row).
 
   Active chips highlight; the AND-across / OR-within rule lives in
-  `state/variant-tag-match?`."
-  [variants tag-filter]
+  `state/variant-tag-match?`.
+
+  `tag->axis` is computed once at the sidebar top and threaded in;
+  per rf2-0z8e2 we previously walked the tag registrar twice per
+  render (once here, once at the top for the variant filter)."
+  [variants tag-filter tag->axis]
   (let [all-tags (collect-tags variants)]
     (if (empty? all-tags)
       [:div {:style (:tag-row styles)}
        [:span {:style (:empty styles)} "no tags"]]
-      (let [tag->axis (registrar/tag->axis-index)
-            by-axis   (state/group-tags-by-axis all-tags tag->axis)
-            axes      (state/ordered-axes by-axis)]
+      (let [by-axis (state/group-tags-by-axis all-tags tag->axis)
+            axes    (state/ordered-axes by-axis)]
         [:div {:style       (:tag-row styles)
                :data-test   "story-sidebar-tag-filter"}
          (for [axis axes]
@@ -477,7 +480,7 @@
            :tab-index  "0"}
      [:div {:style (:tree styles)}
       [:div {:style (:header styles)} "Stories"]
-      [tag-filter-row (:variants registry) tag-filter]
+      [tag-filter-row (:variants registry) tag-filter tag->axis]
       (if (empty? grouped)
         [:div {:style (:empty styles)}
          (if (empty? (:variants registry))

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -34,9 +34,12 @@
   — production builds with the flag false see an empty state map and
   the shell entry point short-circuits before any subscription / mount
   call. Per IMPL-SPEC §6.3."
-  (:require [re-frame.story.config     :as config]
-            [re-frame.story.predicates :as pred]
-            [re-frame.story.registrar  :as registrar]
+  (:require [re-frame.story.config                :as config]
+            [re-frame.story.predicates            :as pred]
+            [re-frame.story.ui.state.filters      :as state.filters]
+            [re-frame.story.ui.state.snapshot     :as state.snapshot]
+            [re-frame.story.ui.state.tests        :as state.tests]
+            [re-frame.story.ui.state.transitions  :as state.transitions]
             #?(:cljs [reagent.core :as r])))
 
 ;; ---- pure data: the default shape ----------------------------------------
@@ -112,315 +115,41 @@
                          :watch-mode?    false
                          :content-hashes {}}})
 
-;; ---- pure transition fns (JVM-testable) ----------------------------------
+;; ---- pure transitions (extracted to state.transitions, rf2-gcpon) -------
 
-(defn select-variant
-  "Set the focused variant id (or nil to deselect)."
-  [state variant-id]
-  (assoc state :selected-variant variant-id))
+(def select-variant            state.transitions/select-variant)
+(def select-workspace          state.transitions/select-workspace)
+(def toggle-tag-filter         state.transitions/toggle-tag-filter)
+(def set-active-modes          state.transitions/set-active-modes)
+(def toggle-mode               state.transitions/toggle-mode)
+(def clear-active-modes        state.transitions/clear-active-modes)
+(def group-modes-by-axis       state.transitions/group-modes-by-axis)
+(def set-cell-override         state.transitions/set-cell-override)
+(def set-cell-override-scalar  state.transitions/set-cell-override-scalar)
+(def clear-cell-overrides      state.transitions/clear-cell-overrides)
+(def bump-hot-reload-tick      state.transitions/bump-hot-reload-tick)
+(def record-fingerprints       state.transitions/record-fingerprints)
+(def pin-snapshot              state.transitions/pin-snapshot)
+(def toggle-panel              state.transitions/toggle-panel)
 
-(defn select-workspace
-  "Set the focused workspace id (or nil to deselect)."
-  [state workspace-id]
-  (assoc state :selected-workspace workspace-id))
+;; ---- mode-tab (rf2-9hc8) re-exports --------------------------------------
 
-(defn toggle-tag-filter
-  "Flip `tag` in the `:tag-filter` set."
-  [state tag]
-  (update state :tag-filter
-          (fn [s] (if (contains? s tag) (disj s tag) (conj (or s #{}) tag)))))
+(def mode-tabs                 state.transitions/mode-tabs)
+(def mode-tab-labels           state.transitions/mode-tab-labels)
+(def default-mode-tab          state.transitions/default-mode-tab)
+(def valid-mode-tab?           state.transitions/valid-mode-tab?)
+(def active-mode-tab           state.transitions/active-mode-tab)
+(def set-active-mode-tab       state.transitions/set-active-mode-tab)
 
-(defn set-active-modes
-  "Replace the active modes vector."
-  [state modes]
-  (assoc state :active-modes (vec modes)))
+;; ---- pure derivations (extracted to state.filters, rf2-gcpon) -----------
 
-(defn- mode-axis
-  "Resolve `mode-id`'s `:axis` (if any) via the registrar. Pure data →
-  data; isolated as a helper so `toggle-mode` is trivially JVM-
-  testable (the helper consults the registrar; pass an explicit
-  `axis-fn` to bypass it in pure tests)."
-  [mode-id]
-  (:axis (registrar/handler-meta :mode mode-id)))
-
-(defn toggle-mode
-  "Toggle `mode-id` against the current `active-modes` vector. Honors
-  `:axis` semantics per spec/010 §Selection semantics — by axis:
-
-  - Currently active → deactivate (regardless of axis).
-  - Axis-grouped     → drop siblings sharing the axis, then add.
-  - Un-grouped       → multi-select, append.
-
-  Pure data → data; JVM-testable. The `axis-fn` arity injects the
-  axis-lookup for tests that don't want a live registrar.
-
-  Returns the new active-modes vector — caller is responsible for
-  writing it back via `set-active-modes`."
-  ([active-modes mode-id]
-   (toggle-mode active-modes mode-id mode-axis))
-  ([active-modes mode-id axis-fn]
-   (let [active (vec (or active-modes []))]
-     (cond
-       (some #(= % mode-id) active)
-       (vec (remove #(= % mode-id) active))
-
-       (some? (axis-fn mode-id))
-       (let [axis     (axis-fn mode-id)
-             siblings (set (filter
-                             (fn [mid] (= axis (axis-fn mid)))
-                             active))]
-         (conj (vec (remove siblings active)) mode-id))
-
-       :else
-       (conj active mode-id)))))
-
-(defn clear-active-modes
-  "Drop every active mode — implements the toolbar's `[reset]` action."
-  [state]
-  (assoc state :active-modes []))
-
-(defn group-modes-by-axis
-  "Build the toolbar's chip layout. Pure data → data; JVM-testable.
-
-  `id->body` is the `{mode-id → mode-body}` map from
-  `(registrar/registrations :mode)`. Returns
-
-      {:axes   [[axis [mode-id ...]] ...]  ; sorted alphabetically by axis-name
-       :unaxed [mode-id ...]}              ; un-grouped modes, sorted alphabetically
-
-  — an explicit two-slot map (no sentinels). The caller renders the
-  axis-tagged groups left-to-right and the un-grouped chips at the
-  trailing edge. Within each bucket the ids are sorted alphabetically."
-  [id->body]
-  (let [axed   (->> id->body
-                    (filter (fn [[_ b]] (some? (:axis b))))
-                    (group-by (fn [[_ b]] (:axis b)))
-                    (map (fn [[axis pairs]]
-                           [axis (vec (sort (map first pairs)))]))
-                    (sort-by (fn [[axis _]] (str axis)))
-                    vec)
-        unaxed (->> id->body
-                    (filter (fn [[_ b]] (nil? (:axis b))))
-                    (map first)
-                    sort
-                    vec)]
-    {:axes axed :unaxed unaxed}))
-
-(defn set-cell-override
-  "Set a single arg override for `variant-id`. `path` is a vector
-  `[arg-key & sub-path]` — the first element is the top-level arg-key,
-  the remaining elements address into the nested value via `assoc-in`
-  semantics. Used by the nested Malli walker per rf2-agshe.
-
-  An empty path is a no-op (caller error; the state is returned
-  unchanged). For top-level scalar overrides use `set-cell-override-
-  scalar`, a thin wrapper that wraps the arg-key in a singleton vector."
-  [state variant-id path value]
-  (if (seq path)
-    (assoc-in state (into [:cell-overrides variant-id] path) value)
-    state))
-
-(defn set-cell-override-scalar
-  "Set a top-level arg override for `variant-id`. Thin wrapper around
-  `set-cell-override` for the scalar case (no nested walk). Equivalent
-  to `(set-cell-override state variant-id [arg-key] value)`."
-  [state variant-id arg-key value]
-  (set-cell-override state variant-id [arg-key] value))
-
-(defn clear-cell-overrides
-  "Drop every override for `variant-id`."
-  [state variant-id]
-  (update state :cell-overrides dissoc variant-id))
-
-(defn bump-hot-reload-tick
-  "Increment the hot-reload tick — variant components observe this slot
-  and re-mount on change. Returns the new state map."
-  [state]
-  (update state :hot-reload-tick (fnil inc 0)))
-
-(defn record-fingerprints
-  "Stamp the current decorator fingerprints for `variant-id`. Stage 4's
-  hot-reload trigger reads the previous map and compares against the
-  current registry; a mismatch bumps `:hot-reload-tick`."
-  [state variant-id fingerprints]
-  (assoc-in state [:fingerprints variant-id] fingerprints))
-
-(defn pin-snapshot
-  "Record a pinned snapshot label/epoch pair for `variant-id`."
-  [state variant-id label epoch-id]
-  (update-in state [:pinned-snapshots variant-id]
-             (fnil conj [])
-             {:label label :epoch-id epoch-id}))
-
-(defn toggle-panel
-  "Flip a panel's visibility."
-  [state panel-id]
-  (update-in state [:panel-visibility panel-id] not))
-
-;; ---- mode-tab (rf2-9hc8) -------------------------------------------------
-
-(def mode-tabs
-  "Ordered vector of canonical render-shell mode tabs. Stable id order
-  drives the chip strip's left-to-right layout. `:dev` is the canvas
-  view (rendered by `re-frame.story.ui.canvas`), `:docs` is the
-  read-only AutoDocs-equivalent (rf2-rodx), `:test` is the
-  in-canvas aggregated pass/fail view (rf2-qmjo)."
-  [:dev :docs :test])
-
-(def mode-tab-labels
-  "Human-readable label per mode-tab id. Used by the chip strip."
-  {:dev  "Canvas"
-   :docs "Docs"
-   :test "Tests"})
-
-(def default-mode-tab
-  "Default mode-tab when no per-variant selection is recorded. `:dev`
-  preserves Story v1's existing behaviour — the variant renders in the
-  canvas as soon as it's selected."
-  :dev)
-
-(defn valid-mode-tab?
-  "Is `tab` one of the canonical mode-tabs?"
-  [tab]
-  (boolean (some #{tab} mode-tabs)))
-
-(defn active-mode-tab
-  "Look up the currently-active mode-tab for `variant-id`. Falls back
-  to `default-mode-tab` when no selection is recorded."
-  [state variant-id]
-  (or (get-in state [:active-mode-tab variant-id])
-      default-mode-tab))
-
-(defn set-active-mode-tab
-  "Record the active mode-tab for `variant-id`. `tab` MUST be one of
-  `mode-tabs`; an unrecognised value is silently ignored so callers
-  can't poison the state."
-  [state variant-id tab]
-  (if (valid-mode-tab? tab)
-    (assoc-in state [:active-mode-tab variant-id] tab)
-    state))
-
-;; ---- pure derivations ----------------------------------------------------
-
-(defn group-tags-by-axis
-  "Pure data → data: split a seq of tags into `{axis-kw → [tag …]}`
-  using `tag->axis` (a `{tag-id → axis-kw}` map). Each per-axis
-  vector is sorted by `name` so the chip layout is stable across
-  re-renders. Tags missing from `tag->axis` land under
-  `:re-frame.story.registrar/no-axis` (the same sentinel
-  `registrar/tag->axis` returns for un-axis-grouped tags).
-
-  rf2-7ncf9 — faceted tag-filter UI. The sidebar's filter row walks
-  this result to render one labelled chip row per axis."
-  [tags tag->axis]
-  (->> tags
-       (reduce (fn [acc t]
-                 (let [axis (get tag->axis t :re-frame.story.registrar/no-axis)]
-                   (update acc axis (fnil conj []) t)))
-               {})
-       (reduce-kv (fn [acc axis ts]
-                    (assoc acc axis (vec (sort-by name ts))))
-                  {})))
-
-(def axis-display-order
-  "Pure data → data: the canonical chip-row order. Mirrors spec/001
-  §reg-tag's documented facet axes — `:status` first, then `:role`,
-  `:team`, `:feature`, then any project-defined axes (alphabetical),
-  with the no-axis bucket last."
-  [:status :role :team :feature])
-
-(defn ordered-axes
-  "Pure data → data: return the axes present in `by-axis` (a
-  `{axis-kw → [tag …]}` map) in stable display order. Canonical axes
-  appear first in `axis-display-order`; project-defined axes follow
-  alphabetically; the no-axis sentinel is always last."
-  [by-axis]
-  (let [present       (set (keys by-axis))
-        canonical     (filter present axis-display-order)
-        extras        (->> present
-                           (remove (set axis-display-order))
-                           (remove #{:re-frame.story.registrar/no-axis})
-                           (sort-by name))
-        trailing      (when (contains? present
-                                       :re-frame.story.registrar/no-axis)
-                        [:re-frame.story.registrar/no-axis])]
-    (vec (concat canonical extras trailing))))
-
-(defn partition-tag-filter-by-axis
-  "Pure data → data: split a `tag-filter` set into `{axis-kw → #{tag …}}`
-  using `tag->axis` (a `{tag-id → axis-kw}` map; see
-  `registrar/tag->axis-index`). Tags missing from `tag->axis` are
-  bucketed under `:re-frame.story.registrar/no-axis` — the same
-  sentinel `registrar/tag->axis` returns for un-axis-grouped tags. The
-  faceted-filter predicate (`variant-tag-match?`) consumes the result.
-
-  Faceted-filter semantics (rf2-7ncf9, SB9 parity): AND across axes,
-  OR within an axis. Partitioning is the first half — the predicate
-  enforces the AND-across rule by requiring every per-axis subset to
-  intersect the variant's `:tags`."
-  [tag-filter tag->axis]
-  (reduce (fn [acc tag]
-            (let [axis (get tag->axis tag :re-frame.story.registrar/no-axis)]
-              (update acc axis (fnil conj #{}) tag)))
-          {}
-          tag-filter))
-
-(defn variant-tag-match?
-  "True iff `variant-body`'s `:tags` set satisfies the `tag-filter`.
-
-  Faceted filter semantics (rf2-7ncf9 SB9 parity):
-
-  - **OR within an axis** — if the filter activates `:status/alpha`
-    AND `:status/beta`, a variant tagged with either passes that
-    axis.
-  - **AND across axes** — activating `:status/stable` AND `:role/design`
-    narrows to variants carrying BOTH a `:status`-axis match AND a
-    `:role`-axis match.
-  - Tags without an `:axis` slot form a synthetic
-    `:re-frame.story.registrar/no-axis` pseudo-axis with the same
-    OR-within rule.
-  - Empty filter → every variant passes (Stage-4 behaviour preserved).
-
-  The pure 2-arity (without `tag->axis`) keeps the legacy OR-only
-  semantics so existing callers that don't have an axis-index handy
-  (tests, downstream tools) keep working. The 3-arity is the
-  facet-aware form the sidebar uses.
-
-  Stage 4 ignores the `:!`-prefix removal syntax — that's resolved at
-  registration time in `re-frame.story.registrar` via
-  `validate-tag-membership!`."
-  ([variant-body tag-filter]
-   (or (empty? tag-filter)
-       (let [tset (or (:tags variant-body) #{})]
-         (some #(contains? tset %) tag-filter))))
-  ([variant-body tag-filter tag->axis]
-   (or (empty? tag-filter)
-       (let [tset       (or (:tags variant-body) #{})
-             per-axis   (partition-tag-filter-by-axis tag-filter tag->axis)]
-         ;; Every axis bucket must intersect the variant's tag set
-         ;; (AND across axes; OR within an axis).
-         (every? (fn [[_ active-on-axis]]
-                   (some #(contains? tset %) active-on-axis))
-                 per-axis)))))
-
-(defn filter-variants
-  "Return the subset of `id->body` whose `:tags` match the filter.
-  Pure data → data; JVM-testable.
-
-  The 2-arity preserves legacy OR-across-tags semantics. The 3-arity
-  takes a `tag->axis` map (see `registrar/tag->axis-index`) and
-  applies the faceted AND-across / OR-within rule (rf2-7ncf9). The
-  sidebar calls the 3-arity with a registrar-derived axis-index; the
-  legacy 2-arity stays for the bare-data callers that don't carry
-  registrar context."
-  ([id->body tag-filter]
-   (into {}
-         (filter (fn [[_ body]] (variant-tag-match? body tag-filter)))
-         id->body))
-  ([id->body tag-filter tag->axis]
-   (into {}
-         (filter (fn [[_ body]] (variant-tag-match? body tag-filter tag->axis)))
-         id->body)))
+(def group-tags-by-axis           state.filters/group-tags-by-axis)
+(def axis-display-order           state.filters/axis-display-order)
+(def ordered-axes                 state.filters/ordered-axes)
+(def partition-tag-filter-by-axis state.filters/partition-tag-filter-by-axis)
+(def variant-tag-match?           state.filters/variant-tag-match?)
+(def filter-variants              state.filters/filter-variants)
+(def group-variants-by-story      state.filters/group-variants-by-story)
 
 (def parent-story-id
   "Cheap parent-story derivation. Canonical definition lives in
@@ -428,43 +157,11 @@
   sites keep their `state/parent-story-id` shape."
   pred/parent-story-id)
 
-(defn group-variants-by-story
-  "Build a sorted vector of `{:story-id ... :variants [...]}` entries
-  from the variants map. Variants whose parent story is unregistered
-  still appear under their derived parent id — the sidebar surfaces them
-  with a 'no story' indicator.
+;; ---- registry snapshot (extracted to state.snapshot, rf2-gcpon) ---------
 
-  Sorted by story id (alphabetic on the keyword name) so the sidebar is
-  stable across re-renders."
-  [id->body]
-  (let [by-story (group-by (comp parent-story-id key) id->body)]
-    (->> by-story
-         (map (fn [[story-id variants]]
-                {:story-id story-id
-                 :variants (vec (sort-by key variants))}))
-         (sort-by (fn [{:keys [story-id]}]
-                    (if story-id (str story-id) "")))
-         vec)))
-
-;; ---- registry snapshot ---------------------------------------------------
-;;
-;; The shell takes a fresh snapshot of the Story registrar on every
-;; render — variants/stories/workspaces/modes/decorators/panels/tags are
-;; what's currently registered, and the sidebar / control panel /
-;; workspace panes consume the snapshot.
-
-(defn registry-snapshot
-  "Return a single map containing every Story-side artefact kind. Used
-  by the shell's render fns to walk the registry without N atom-deref
-  calls (and to support future memoisation if perf becomes an issue)."
-  []
-  {:stories      (registrar/registrations :story)
-   :variants     (registrar/registrations :variant)
-   :workspaces   (registrar/registrations :workspace)
-   :modes        (registrar/registrations :mode)
-   :decorators   (registrar/registrations :decorator)
-   :story-panels (registrar/registrations :story-panel)
-   :tags         (registrar/registrations :tag)})
+(def registry-snapshot
+  "Re-export of `re-frame.story.ui.state.snapshot/registry-snapshot`."
+  state.snapshot/registry-snapshot)
 
 ;; ---- the reactive bag (CLJS-only) ----------------------------------------
 
@@ -501,218 +198,23 @@
   (when config/enabled?
     (apply swap! shell-state-atom f args)))
 
-;; ---- test-runs (rf2-q0irb) ----------------------------------------------
+;; ---- test-runs + watch-mode (extracted to state.tests, rf2-gcpon) -------
 ;;
-;; Cross-variant aggregation surface: each variant's last `run-variant`
-;; outcome is folded into `[:tests :runs]`. The chrome-level test
-;; widget reads it as a summary; the sidebar's per-variant rows read
-;; individual entries as a status dot. Both surfaces are pure
-;; derivations of this one slot.
-;;
-;; The test-mode pane's local `results-atom` (in
-;; `re-frame.story.ui.test-mode.state`) keeps the full result-map
-;; (assertion records + expanded-row UI state); this shell-state slot
-;; carries only the aggregate counts the chrome widget + sidebar dots
-;; need. Two stores, two read paths, no contention — the pane's local
-;; atom drives the detail view, the shell-state slot drives the global
-;; surfaces.
+;; The cross-variant test-run aggregation surface (rf2-q0irb) and the
+;; watch-mode helpers (rf2-z1h0f) live in `re-frame.story.ui.state.tests`
+;; — split out per rf2-gcpon to honor the rf2-zkca8 leaf-size ceiling.
+;; Re-exported here so consumer requires of `re-frame.story.ui.state`
+;; keep working unchanged.
 
-(def test-run-statuses
-  "Canonical run-state ids, in render order.
-
-  - `:pass`     last run: every assertion passed (and at least one assertion).
-  - `:fail`     last run: ≥1 assertion failed.
-  - `:running`  run currently in flight.
-  - `:pending`  no run recorded yet (or run produced zero assertions)."
-  [:pass :fail :running :pending])
-
-(defn mark-test-running
-  "Stamp `variant-id` as :running. Idempotent."
-  [state variant-id]
-  (assoc-in state [:tests :runs variant-id] {:status :running}))
-
-(defn aggregate-summary
-  "Walk `assertions` (the vector pulled off a `run-variant` result map)
-  and produce the aggregated pass/fail/skip counts:
-
-      {:total       <n>
-       :passed      <n>
-       :failed      <n>
-       :skipped     <n>
-       :all-passed? <bool>}
-
-  `:skipped` counts records carrying `:assertion :rf.assert/skipped` —
-  re-frame2's v1 runtime doesn't emit this id, but the slot stays open
-  so spec/004 additions flow through without a pane refactor.
-  `:all-passed?` is true iff `:total > 0 AND :failed = 0 AND :skipped = 0`.
-
-  Lives in `state.cljc` (not `test-mode.pure`) so both the test-mode
-  pane AND the sidebar / chrome-level test widget can call one
-  canonical fold without a require cycle (sidebar can't require
-  test-mode, which would loop back through shell-state). Pure data →
-  data; JVM-testable."
-  [assertions]
-  (let [items     (or assertions [])
-        skipped?  (fn [r] (= :rf.assert/skipped (:assertion r)))
-        skipped   (count (filter skipped? items))
-        active    (remove skipped? items)
-        passed    (count (filter :passed? active))
-        failed    (- (count active) passed)
-        total     (count items)]
-    {:total       total
-     :passed      passed
-     :failed      failed
-     :skipped     skipped
-     :all-passed? (and (pos? total) (zero? failed) (zero? skipped))}))
-
-(defn record-test-run
-  "Write the aggregate of a `run-variant` result into `[:tests :runs]`.
-
-  `summary` is the map returned by `aggregate-summary` —
-  `{:total :passed :failed :skipped :all-passed?}` — extended with
-  optional `:ran-at-ms` and `:elapsed-ms`. A run that recorded zero
-  assertions lands as `:pending` (rather than `:pass`/`:fail`) so the
-  sidebar dot reads grey — the variant ran but produced no signal."
-  [state variant-id summary]
-  (let [{:keys [total passed failed skipped all-passed?
-                ran-at-ms elapsed-ms]} (or summary {})
-        status (cond
-                 (zero? (or total 0)) :pending
-                 all-passed?          :pass
-                 :else                :fail)]
-    (assoc-in state [:tests :runs variant-id]
-              {:status     status
-               :total      (or total 0)
-               :passed     (or passed 0)
-               :failed     (or failed 0)
-               :skipped    (or skipped 0)
-               :ran-at-ms  ran-at-ms
-               :elapsed-ms elapsed-ms})))
-
-(defn clear-test-run
-  "Drop the run record for `variant-id`."
-  [state variant-id]
-  (update-in state [:tests :runs] dissoc variant-id))
-
-(defn variant-test-status
-  "Return the canonical status keyword for `variant-id` (one of
-  `test-run-statuses`). Variants with no recorded run read `:pending`.
-  Pure data → data; JVM-testable."
-  [state variant-id]
-  (or (get-in state [:tests :runs variant-id :status])
-      :pending))
-
-(defn test-summary
-  "Aggregate the chrome-level test widget's headline counts across the
-  given seq of variant-ids — the variants tagged `:test` registered at
-  the time of call. Returns:
-
-      {:total      <count of variant-ids>
-       :passed     <count whose last run was :pass>
-       :failed     <count whose last run was :fail>
-       :running    <count currently in flight>
-       :pending    <count with no recorded run>
-       :all-green? <bool — total > 0 AND failed = 0 AND running = 0
-                          AND pending = 0>}
-
-  Pure data → data; the JVM corpus exercises it against a fixture map
-  without booting Reagent. `all-green?` mirrors `aggregate-summary`'s
-  `:all-passed?` — true only when every variant has a recorded green
-  run; a sea of `:pending` reads as 'not green yet', not 'all green'."
-  [state variant-ids]
-  (let [runs    (get-in state [:tests :runs])
-        ;; Single O(N) frequencies pass — read each variant's status
-        ;; once and bucket by keyword. Missing entries default to :pending.
-        buckets (frequencies
-                  (map (fn [vid] (or (get-in runs [vid :status]) :pending))
-                       variant-ids))
-        total   (count variant-ids)
-        passed  (get buckets :pass    0)
-        failed  (get buckets :fail    0)
-        running (get buckets :running 0)
-        pending (get buckets :pending 0)]
-    {:total      total
-     :passed     passed
-     :failed     failed
-     :running    running
-     :pending    pending
-     :all-green? (and (pos? total)
-                      (zero? failed)
-                      (zero? running)
-                      (zero? pending))}))
-
-(defn testable-variant-ids
-  "Return the seq of variant-ids tagged `:test`, in stable (alphabetical)
-  order. The chrome widget + sidebar dots key off this seq.
-
-  Variants are testable iff (a) their `:tags` contains `:test`, AND
-  (b) they declare a non-empty `:play` slot. The second filter prunes
-  variants tagged `:test` but without any assertions to run — those
-  contribute neither to the headline counts nor to the 'Run all'
-  iteration. Pure data → data; JVM-testable. `id->body` is the
-  `{variant-id → body}` map from `(registrar/registrations :variant)`."
-  [id->body]
-  (->> id->body
-       (filter (fn [[_ body]]
-                 (and (contains? (or (:tags body) #{}) :test)
-                      (seq (or (:play body) [])))))
-       (map first)
-       sort
-       vec))
-
-;; ---- watch mode (rf2-z1h0f) ---------------------------------------------
-;;
-;; Storybook 9 ships a Vitest-addon watch-mode toggle (eye icon) that
-;; re-runs the changed stories on file save. Story's parity surface is
-;; this: an opt-in toggle on the chrome-level test widget that
-;; subscribes to per-variant snapshot-identity drift and re-fires
-;; `run-variant` for the variants whose identity changed. The detection
-;; signal is the variant's snapshot-identity content-hash
-;; (re-frame.story.identity/snapshot-identity); a delta against the
-;; recorded [:tests :content-hashes] slot triggers the re-run.
-
-(defn set-test-watch-mode
-  "Toggle/set the chrome-level watch-mode flag. When `on?` is true the
-  shell auto-re-runs testable variants whose snapshot identity drifts;
-  when false the toggle is off and the recorded hashes are cleared (the
-  next toggle-on seeds them fresh from the current registry). Pure data
-  → data; JVM-testable."
-  [state on?]
-  (if on?
-    (assoc-in state [:tests :watch-mode?] true)
-    (update state :tests assoc
-            :watch-mode?    false
-            :content-hashes {})))
-
-(defn test-watch-mode?
-  "Return `true` iff watch mode is currently on. Pure."
-  [state]
-  (boolean (get-in state [:tests :watch-mode?])))
-
-(defn record-test-content-hashes
-  "Stamp the current snapshot-identity content hashes for every testable
-  variant. `id->hash` is `{variant-id → hex-string}`. The detector
-  reads this slot on the next tick to decide which variants drifted."
-  [state id->hash]
-  (assoc-in state [:tests :content-hashes] (or id->hash {})))
-
-(defn watch-mode-drift
-  "Pure data → data: given the previous `[:tests :content-hashes]` map and a
-  freshly-computed `current` `{variant-id → hex}` map, return the
-  ordered vector of variant-ids whose hash differs from `prev` (i.e.
-  the variants the watch-mode detector should re-run on this tick).
-
-  Variants present in `current` but absent from `prev` are treated as
-  drifted — the seed call to `record-test-content-hashes` happens on
-  toggle-on so a missing prev entry signals a fresh registration that
-  the user wants exercised. Variants present in `prev` but absent from
-  `current` (deregistered) are silently dropped — there's nothing to
-  re-run. JVM-testable."
-  [prev current]
-  (let [prev    (or prev {})
-        current (or current {})]
-    (->> current
-         (filter (fn [[vid hex]] (not= hex (get prev vid))))
-         (map first)
-         sort
-         vec)))
+(def test-run-statuses           state.tests/test-run-statuses)
+(def mark-test-running           state.tests/mark-test-running)
+(def aggregate-summary           state.tests/aggregate-summary)
+(def record-test-run             state.tests/record-test-run)
+(def clear-test-run              state.tests/clear-test-run)
+(def variant-test-status         state.tests/variant-test-status)
+(def test-summary                state.tests/test-summary)
+(def testable-variant-ids        state.tests/testable-variant-ids)
+(def set-test-watch-mode         state.tests/set-test-watch-mode)
+(def test-watch-mode?            state.tests/test-watch-mode?)
+(def record-test-content-hashes  state.tests/record-test-content-hashes)
+(def watch-mode-drift            state.tests/watch-mode-drift)

--- a/tools/story/src/re_frame/story/ui/state/filters.cljc
+++ b/tools/story/src/re_frame/story/ui/state/filters.cljc
@@ -1,0 +1,156 @@
+(ns re-frame.story.ui.state.filters
+  "Pure data → data helpers for the sidebar's faceted tag-filter UI and
+  story-grouped variant listing. Split from
+  `re-frame.story.ui.state` per rf2-gcpon (leaf-size ceiling rf2-zkca8).
+
+  ## What lives here
+
+  - `group-tags-by-axis`        — bucket tags into per-axis vectors.
+  - `axis-display-order`        — canonical chip-row order.
+  - `ordered-axes`              — render-order for an axis-bucket map.
+  - `partition-tag-filter-by-axis` — split the active filter set by axis.
+  - `variant-tag-match?`        — faceted predicate (AND-across / OR-within).
+  - `filter-variants`           — apply the predicate over a variant map.
+  - `group-variants-by-story`   — build the sidebar tree.
+
+  The faceted-filter contract (rf2-7ncf9 SB9 parity): AND across axes,
+  OR within an axis. Documented per-fn below."
+  (:require [re-frame.story.predicates :as pred]))
+
+(defn group-tags-by-axis
+  "Pure data → data: split a seq of tags into `{axis-kw → [tag …]}`
+  using `tag->axis` (a `{tag-id → axis-kw}` map). Each per-axis
+  vector is sorted by `name` so the chip layout is stable across
+  re-renders. Tags missing from `tag->axis` land under
+  `:re-frame.story.registrar/no-axis` (the same sentinel
+  `registrar/tag->axis` returns for un-axis-grouped tags).
+
+  rf2-7ncf9 — faceted tag-filter UI. The sidebar's filter row walks
+  this result to render one labelled chip row per axis."
+  [tags tag->axis]
+  (->> tags
+       (reduce (fn [acc t]
+                 (let [axis (get tag->axis t :re-frame.story.registrar/no-axis)]
+                   (update acc axis (fnil conj []) t)))
+               {})
+       (reduce-kv (fn [acc axis ts]
+                    (assoc acc axis (vec (sort-by name ts))))
+                  {})))
+
+(def axis-display-order
+  "Pure data → data: the canonical chip-row order. Mirrors spec/001
+  §reg-tag's documented facet axes — `:status` first, then `:role`,
+  `:team`, `:feature`, then any project-defined axes (alphabetical),
+  with the no-axis bucket last."
+  [:status :role :team :feature])
+
+(defn ordered-axes
+  "Pure data → data: return the axes present in `by-axis` (a
+  `{axis-kw → [tag …]}` map) in stable display order. Canonical axes
+  appear first in `axis-display-order`; project-defined axes follow
+  alphabetically; the no-axis sentinel is always last."
+  [by-axis]
+  (let [present       (set (keys by-axis))
+        canonical     (filter present axis-display-order)
+        extras        (->> present
+                           (remove (set axis-display-order))
+                           (remove #{:re-frame.story.registrar/no-axis})
+                           (sort-by name))
+        trailing      (when (contains? present
+                                       :re-frame.story.registrar/no-axis)
+                        [:re-frame.story.registrar/no-axis])]
+    (vec (concat canonical extras trailing))))
+
+(defn partition-tag-filter-by-axis
+  "Pure data → data: split a `tag-filter` set into `{axis-kw → #{tag …}}`
+  using `tag->axis` (a `{tag-id → axis-kw}` map; see
+  `registrar/tag->axis-index`). Tags missing from `tag->axis` are
+  bucketed under `:re-frame.story.registrar/no-axis` — the same
+  sentinel `registrar/tag->axis` returns for un-axis-grouped tags. The
+  faceted-filter predicate (`variant-tag-match?`) consumes the result.
+
+  Faceted-filter semantics (rf2-7ncf9, SB9 parity): AND across axes,
+  OR within an axis. Partitioning is the first half — the predicate
+  enforces the AND-across rule by requiring every per-axis subset to
+  intersect the variant's `:tags`."
+  [tag-filter tag->axis]
+  (reduce (fn [acc tag]
+            (let [axis (get tag->axis tag :re-frame.story.registrar/no-axis)]
+              (update acc axis (fnil conj #{}) tag)))
+          {}
+          tag-filter))
+
+(defn variant-tag-match?
+  "True iff `variant-body`'s `:tags` set satisfies the `tag-filter`.
+
+  Faceted filter semantics (rf2-7ncf9 SB9 parity):
+
+  - **OR within an axis** — if the filter activates `:status/alpha`
+    AND `:status/beta`, a variant tagged with either passes that
+    axis.
+  - **AND across axes** — activating `:status/stable` AND `:role/design`
+    narrows to variants carrying BOTH a `:status`-axis match AND a
+    `:role`-axis match.
+  - Tags without an `:axis` slot form a synthetic
+    `:re-frame.story.registrar/no-axis` pseudo-axis with the same
+    OR-within rule.
+  - Empty filter → every variant passes (Stage-4 behaviour preserved).
+
+  The pure 2-arity (without `tag->axis`) keeps the legacy OR-only
+  semantics so existing callers that don't have an axis-index handy
+  (tests, downstream tools) keep working. The 3-arity is the
+  facet-aware form the sidebar uses.
+
+  Stage 4 ignores the `:!`-prefix removal syntax — that's resolved at
+  registration time in `re-frame.story.registrar` via
+  `validate-tag-membership!`."
+  ([variant-body tag-filter]
+   (or (empty? tag-filter)
+       (let [tset (or (:tags variant-body) #{})]
+         (some #(contains? tset %) tag-filter))))
+  ([variant-body tag-filter tag->axis]
+   (or (empty? tag-filter)
+       (let [tset       (or (:tags variant-body) #{})
+             per-axis   (partition-tag-filter-by-axis tag-filter tag->axis)]
+         ;; Every axis bucket must intersect the variant's tag set
+         ;; (AND across axes; OR within an axis).
+         (every? (fn [[_ active-on-axis]]
+                   (some #(contains? tset %) active-on-axis))
+                 per-axis)))))
+
+(defn filter-variants
+  "Return the subset of `id->body` whose `:tags` match the filter.
+  Pure data → data; JVM-testable.
+
+  The 2-arity preserves legacy OR-across-tags semantics. The 3-arity
+  takes a `tag->axis` map (see `registrar/tag->axis-index`) and
+  applies the faceted AND-across / OR-within rule (rf2-7ncf9). The
+  sidebar calls the 3-arity with a registrar-derived axis-index; the
+  legacy 2-arity stays for the bare-data callers that don't carry
+  registrar context."
+  ([id->body tag-filter]
+   (into {}
+         (filter (fn [[_ body]] (variant-tag-match? body tag-filter)))
+         id->body))
+  ([id->body tag-filter tag->axis]
+   (into {}
+         (filter (fn [[_ body]] (variant-tag-match? body tag-filter tag->axis)))
+         id->body)))
+
+(defn group-variants-by-story
+  "Build a sorted vector of `{:story-id ... :variants [...]}` entries
+  from the variants map. Variants whose parent story is unregistered
+  still appear under their derived parent id — the sidebar surfaces them
+  with a 'no story' indicator.
+
+  Sorted by story id (alphabetic on the keyword name) so the sidebar is
+  stable across re-renders."
+  [id->body]
+  (let [by-story (group-by (comp pred/parent-story-id key) id->body)]
+    (->> by-story
+         (map (fn [[story-id variants]]
+                {:story-id story-id
+                 :variants (vec (sort-by key variants))}))
+         (sort-by (fn [{:keys [story-id]}]
+                    (if story-id (str story-id) "")))
+         vec)))

--- a/tools/story/src/re_frame/story/ui/state/snapshot.cljc
+++ b/tools/story/src/re_frame/story/ui/state/snapshot.cljc
@@ -1,0 +1,25 @@
+(ns re-frame.story.ui.state.snapshot
+  "Registry-snapshot leaf — single-call helper that builds a map of
+  every Story-side artefact kind in one walk. Split from
+  `re-frame.story.ui.state` per rf2-gcpon.
+
+  The shell takes a fresh snapshot of the Story registrar on every
+  render: variants / stories / workspaces / modes / decorators /
+  panels / tags are what's currently registered, and the sidebar /
+  control panel / workspace panes consume the snapshot. Lives in its
+  own leaf so future memoisation (e.g. cache keyed on the registrar
+  mutation-tick rf2-zrswb / rf2-c5nwl) is local."
+  (:require [re-frame.story.registrar :as registrar]))
+
+(defn registry-snapshot
+  "Return a single map containing every Story-side artefact kind. Used
+  by the shell's render fns to walk the registry without N atom-deref
+  calls (and to support future memoisation if perf becomes an issue)."
+  []
+  {:stories      (registrar/registrations :story)
+   :variants     (registrar/registrations :variant)
+   :workspaces   (registrar/registrations :workspace)
+   :modes        (registrar/registrations :mode)
+   :decorators   (registrar/registrations :decorator)
+   :story-panels (registrar/registrations :story-panel)
+   :tags         (registrar/registrations :tag)})

--- a/tools/story/src/re_frame/story/ui/state/tests.cljc
+++ b/tools/story/src/re_frame/story/ui/state/tests.cljc
@@ -1,0 +1,247 @@
+(ns re-frame.story.ui.state.tests
+  "Pure test-run aggregation + watch-mode helpers for the shell state
+  map. Split from `re-frame.story.ui.state` per rf2-gcpon (leaf-size
+  ceiling rf2-zkca8 — the parent ns was 718L).
+
+  ## What lives here
+
+  - `test-run-statuses`         — canonical run-state ids.
+  - `mark-test-running`         — pure transition.
+  - `aggregate-summary`         — fold a per-variant assertion vector
+                                  into pass/fail/skipped counts.
+  - `record-test-run`           — write the aggregate into
+                                  `[:tests :runs <variant-id>]`.
+  - `clear-test-run`            — drop a run record.
+  - `variant-test-status`       — read the per-variant status keyword.
+  - `test-summary`              — aggregate across an id-seq.
+  - `testable-variant-ids`      — derive the seq of `:test`-tagged
+                                  variants with a non-empty `:play`.
+  - `set-test-watch-mode`       — toggle the chrome watch-mode flag.
+  - `test-watch-mode?`          — read the flag.
+  - `record-test-content-hashes` — stamp per-variant snapshot hashes.
+  - `watch-mode-drift`          — pure differ over prev/current hash maps.
+
+  ## Why a separate leaf
+
+  Both surfaces (test-runs + watch-mode) read/write under the same
+  `:tests` root in the shell-state map. They share no code with the
+  selection / filter / cell-override surfaces in
+  `re-frame.story.ui.state` proper — splitting honors the leaf-size
+  ceiling without losing locality. The parent ns re-exports the
+  public defs so existing consumer requires (`re-frame.story.ui.state`)
+  keep working.")
+
+;; ---- test-runs (rf2-q0irb) -----------------------------------------------
+;;
+;; Cross-variant aggregation surface: each variant's last `run-variant`
+;; outcome is folded into `[:tests :runs]`. The chrome-level test
+;; widget reads it as a summary; the sidebar's per-variant rows read
+;; individual entries as a status dot. Both surfaces are pure
+;; derivations of this one slot.
+;;
+;; The test-mode pane's local `results-atom` (in
+;; `re-frame.story.ui.test-mode.state`) keeps the full result-map
+;; (assertion records + expanded-row UI state); this shell-state slot
+;; carries only the aggregate counts the chrome widget + sidebar dots
+;; need. Two stores, two read paths, no contention — the pane's local
+;; atom drives the detail view, the shell-state slot drives the global
+;; surfaces.
+
+(def test-run-statuses
+  "Canonical run-state ids, in render order.
+
+  - `:pass`     last run: every assertion passed (and at least one assertion).
+  - `:fail`     last run: ≥1 assertion failed.
+  - `:running`  run currently in flight.
+  - `:pending`  no run recorded yet (or run produced zero assertions)."
+  [:pass :fail :running :pending])
+
+(defn mark-test-running
+  "Stamp `variant-id` as :running. Idempotent."
+  [state variant-id]
+  (assoc-in state [:tests :runs variant-id] {:status :running}))
+
+(defn aggregate-summary
+  "Walk `assertions` (the vector pulled off a `run-variant` result map)
+  and produce the aggregated pass/fail/skip counts:
+
+      {:total       <n>
+       :passed      <n>
+       :failed      <n>
+       :skipped     <n>
+       :all-passed? <bool>}
+
+  `:skipped` counts records carrying `:assertion :rf.assert/skipped` —
+  re-frame2's v1 runtime doesn't emit this id, but the slot stays open
+  so spec/004 additions flow through without a pane refactor.
+  `:all-passed?` is true iff `:total > 0 AND :failed = 0 AND :skipped = 0`.
+
+  Lives here (not `test-mode.pure`) so both the test-mode pane AND the
+  sidebar / chrome-level test widget can call one canonical fold
+  without a require cycle (sidebar can't require test-mode, which
+  would loop back through shell-state). Pure data → data; JVM-testable."
+  [assertions]
+  (let [items     (or assertions [])
+        skipped?  (fn [r] (= :rf.assert/skipped (:assertion r)))
+        skipped   (count (filter skipped? items))
+        active    (remove skipped? items)
+        passed    (count (filter :passed? active))
+        failed    (- (count active) passed)
+        total     (count items)]
+    {:total       total
+     :passed      passed
+     :failed      failed
+     :skipped     skipped
+     :all-passed? (and (pos? total) (zero? failed) (zero? skipped))}))
+
+(defn record-test-run
+  "Write the aggregate of a `run-variant` result into `[:tests :runs]`.
+
+  `summary` is the map returned by `aggregate-summary` —
+  `{:total :passed :failed :skipped :all-passed?}` — extended with
+  optional `:ran-at-ms` and `:elapsed-ms`. A run that recorded zero
+  assertions lands as `:pending` (rather than `:pass`/`:fail`) so the
+  sidebar dot reads grey — the variant ran but produced no signal."
+  [state variant-id summary]
+  (let [{:keys [total passed failed skipped all-passed?
+                ran-at-ms elapsed-ms]} (or summary {})
+        status (cond
+                 (zero? (or total 0)) :pending
+                 all-passed?          :pass
+                 :else                :fail)]
+    (assoc-in state [:tests :runs variant-id]
+              {:status     status
+               :total      (or total 0)
+               :passed     (or passed 0)
+               :failed     (or failed 0)
+               :skipped    (or skipped 0)
+               :ran-at-ms  ran-at-ms
+               :elapsed-ms elapsed-ms})))
+
+(defn clear-test-run
+  "Drop the run record for `variant-id`."
+  [state variant-id]
+  (update-in state [:tests :runs] dissoc variant-id))
+
+(defn variant-test-status
+  "Return the canonical status keyword for `variant-id` (one of
+  `test-run-statuses`). Variants with no recorded run read `:pending`.
+  Pure data → data; JVM-testable."
+  [state variant-id]
+  (or (get-in state [:tests :runs variant-id :status])
+      :pending))
+
+(defn test-summary
+  "Aggregate the chrome-level test widget's headline counts across the
+  given seq of variant-ids — the variants tagged `:test` registered at
+  the time of call. Returns:
+
+      {:total      <count of variant-ids>
+       :passed     <count whose last run was :pass>
+       :failed     <count whose last run was :fail>
+       :running    <count currently in flight>
+       :pending    <count with no recorded run>
+       :all-green? <bool — total > 0 AND failed = 0 AND running = 0
+                          AND pending = 0>}
+
+  Pure data → data; the JVM corpus exercises it against a fixture map
+  without booting Reagent. `all-green?` mirrors `aggregate-summary`'s
+  `:all-passed?` — true only when every variant has a recorded green
+  run; a sea of `:pending` reads as 'not green yet', not 'all green'."
+  [state variant-ids]
+  (let [runs    (get-in state [:tests :runs])
+        ;; Single O(N) frequencies pass — read each variant's status
+        ;; once and bucket by keyword. Missing entries default to :pending.
+        buckets (frequencies
+                  (map (fn [vid] (or (get-in runs [vid :status]) :pending))
+                       variant-ids))
+        total   (count variant-ids)
+        passed  (get buckets :pass    0)
+        failed  (get buckets :fail    0)
+        running (get buckets :running 0)
+        pending (get buckets :pending 0)]
+    {:total      total
+     :passed     passed
+     :failed     failed
+     :running    running
+     :pending    pending
+     :all-green? (and (pos? total)
+                      (zero? failed)
+                      (zero? running)
+                      (zero? pending))}))
+
+(defn testable-variant-ids
+  "Return the seq of variant-ids tagged `:test`, in stable (alphabetical)
+  order. The chrome widget + sidebar dots key off this seq.
+
+  Variants are testable iff (a) their `:tags` contains `:test`, AND
+  (b) they declare a non-empty `:play` slot. The second filter prunes
+  variants tagged `:test` but without any assertions to run — those
+  contribute neither to the headline counts nor to the 'Run all'
+  iteration. Pure data → data; JVM-testable. `id->body` is the
+  `{variant-id → body}` map from `(registrar/registrations :variant)`."
+  [id->body]
+  (->> id->body
+       (filter (fn [[_ body]]
+                 (and (contains? (or (:tags body) #{}) :test)
+                      (seq (or (:play body) [])))))
+       (map first)
+       sort
+       vec))
+
+;; ---- watch mode (rf2-z1h0f) ---------------------------------------------
+;;
+;; Storybook 9 ships a Vitest-addon watch-mode toggle (eye icon) that
+;; re-runs the changed stories on file save. Story's parity surface is
+;; this: an opt-in toggle on the chrome-level test widget that
+;; subscribes to per-variant snapshot-identity drift and re-fires
+;; `run-variant` for the variants whose identity changed. The detection
+;; signal is the variant's snapshot-identity content-hash
+;; (re-frame.story.identity/snapshot-identity); a delta against the
+;; recorded [:tests :content-hashes] slot triggers the re-run.
+
+(defn set-test-watch-mode
+  "Toggle/set the chrome-level watch-mode flag. When `on?` is true the
+  shell auto-re-runs testable variants whose snapshot identity drifts;
+  when false the toggle is off and the recorded hashes are cleared (the
+  next toggle-on seeds them fresh from the current registry). Pure data
+  → data; JVM-testable."
+  [state on?]
+  (if on?
+    (assoc-in state [:tests :watch-mode?] true)
+    (update state :tests assoc
+            :watch-mode?    false
+            :content-hashes {})))
+
+(defn test-watch-mode?
+  "Return `true` iff watch mode is currently on. Pure."
+  [state]
+  (boolean (get-in state [:tests :watch-mode?])))
+
+(defn record-test-content-hashes
+  "Stamp the current snapshot-identity content hashes for every testable
+  variant. `id->hash` is `{variant-id → hex-string}`. The detector
+  reads this slot on the next tick to decide which variants drifted."
+  [state id->hash]
+  (assoc-in state [:tests :content-hashes] (or id->hash {})))
+
+(defn watch-mode-drift
+  "Pure data → data: given the previous `[:tests :content-hashes]` map and a
+  freshly-computed `current` `{variant-id → hex}` map, return the
+  ordered vector of variant-ids whose hash differs from `prev` (i.e.
+  the variants the watch-mode detector should re-run on this tick).
+
+  Variants present in `current` but absent from `prev` are treated as
+  drifted — the seed call to `record-test-content-hashes` happens on
+  toggle-on so a missing prev entry signals a fresh registration that
+  the user wants exercised. Variants present in `prev` but absent from
+  `current` (deregistered) are silently dropped — there's nothing to
+  re-run. JVM-testable."
+  [prev current]
+  (let [prev    (or prev {})
+        current (or current {})]
+    (->> current
+         (filter (fn [[vid hex]] (not= hex (get prev vid))))
+         (map first)
+         sort
+         vec)))

--- a/tools/story/src/re_frame/story/ui/state/transitions.cljc
+++ b/tools/story/src/re_frame/story/ui/state/transitions.cljc
@@ -1,0 +1,208 @@
+(ns re-frame.story.ui.state.transitions
+  "Pure shell-state transition fns (data → data). Split from
+  `re-frame.story.ui.state` per rf2-gcpon (leaf-size ceiling rf2-zkca8).
+
+  ## What lives here
+
+  Every selection / filter / mode / cell-override / fingerprint /
+  panel-visibility transition the shell uses. Every fn is pure
+  (state → state, or pure data → data) so the JVM test corpus can
+  exercise them without booting Reagent.
+
+  The parent ns `re-frame.story.ui.state` re-exports every Var here,
+  so consumer requires keep working unchanged."
+  (:require [re-frame.story.registrar :as registrar]))
+
+;; ---- selection / filters -------------------------------------------------
+
+(defn select-variant
+  "Set the focused variant id (or nil to deselect)."
+  [state variant-id]
+  (assoc state :selected-variant variant-id))
+
+(defn select-workspace
+  "Set the focused workspace id (or nil to deselect)."
+  [state workspace-id]
+  (assoc state :selected-workspace workspace-id))
+
+(defn toggle-tag-filter
+  "Flip `tag` in the `:tag-filter` set."
+  [state tag]
+  (update state :tag-filter
+          (fn [s] (if (contains? s tag) (disj s tag) (conj (or s #{}) tag)))))
+
+;; ---- mode bookkeeping ----------------------------------------------------
+
+(defn set-active-modes
+  "Replace the active modes vector."
+  [state modes]
+  (assoc state :active-modes (vec modes)))
+
+(defn- mode-axis
+  "Resolve `mode-id`'s `:axis` (if any) via the registrar. Pure data →
+  data; isolated as a helper so `toggle-mode` is trivially JVM-
+  testable (the helper consults the registrar; pass an explicit
+  `axis-fn` to bypass it in pure tests)."
+  [mode-id]
+  (:axis (registrar/handler-meta :mode mode-id)))
+
+(defn toggle-mode
+  "Toggle `mode-id` against the current `active-modes` vector. Honors
+  `:axis` semantics per spec/010 §Selection semantics — by axis:
+
+  - Currently active → deactivate (regardless of axis).
+  - Axis-grouped     → drop siblings sharing the axis, then add.
+  - Un-grouped       → multi-select, append.
+
+  Pure data → data; JVM-testable. The `axis-fn` arity injects the
+  axis-lookup for tests that don't want a live registrar.
+
+  Returns the new active-modes vector — caller is responsible for
+  writing it back via `set-active-modes`."
+  ([active-modes mode-id]
+   (toggle-mode active-modes mode-id mode-axis))
+  ([active-modes mode-id axis-fn]
+   (let [active (vec (or active-modes []))]
+     (cond
+       (some #(= % mode-id) active)
+       (vec (remove #(= % mode-id) active))
+
+       (some? (axis-fn mode-id))
+       (let [axis     (axis-fn mode-id)
+             siblings (set (filter
+                             (fn [mid] (= axis (axis-fn mid)))
+                             active))]
+         (conj (vec (remove siblings active)) mode-id))
+
+       :else
+       (conj active mode-id)))))
+
+(defn clear-active-modes
+  "Drop every active mode — implements the toolbar's `[reset]` action."
+  [state]
+  (assoc state :active-modes []))
+
+(defn group-modes-by-axis
+  "Build the toolbar's chip layout. Pure data → data; JVM-testable.
+
+  `id->body` is the `{mode-id → mode-body}` map from
+  `(registrar/registrations :mode)`. Returns
+
+      {:axes   [[axis [mode-id ...]] ...]  ; sorted alphabetically by axis-name
+       :unaxed [mode-id ...]}              ; un-grouped modes, sorted alphabetically
+
+  — an explicit two-slot map (no sentinels). The caller renders the
+  axis-tagged groups left-to-right and the un-grouped chips at the
+  trailing edge. Within each bucket the ids are sorted alphabetically."
+  [id->body]
+  (let [axed   (->> id->body
+                    (filter (fn [[_ b]] (some? (:axis b))))
+                    (group-by (fn [[_ b]] (:axis b)))
+                    (map (fn [[axis pairs]]
+                           [axis (vec (sort (map first pairs)))]))
+                    (sort-by (fn [[axis _]] (str axis)))
+                    vec)
+        unaxed (->> id->body
+                    (filter (fn [[_ b]] (nil? (:axis b))))
+                    (map first)
+                    sort
+                    vec)]
+    {:axes axed :unaxed unaxed}))
+
+;; ---- cell overrides ------------------------------------------------------
+
+(defn set-cell-override
+  "Set a single arg override for `variant-id`. `path` is a vector
+  `[arg-key & sub-path]` — the first element is the top-level arg-key,
+  the remaining elements address into the nested value via `assoc-in`
+  semantics. Used by the nested Malli walker per rf2-agshe.
+
+  An empty path is a no-op (caller error; the state is returned
+  unchanged). For top-level scalar overrides use `set-cell-override-
+  scalar`, a thin wrapper that wraps the arg-key in a singleton vector."
+  [state variant-id path value]
+  (if (seq path)
+    (assoc-in state (into [:cell-overrides variant-id] path) value)
+    state))
+
+(defn set-cell-override-scalar
+  "Set a top-level arg override for `variant-id`. Thin wrapper around
+  `set-cell-override` for the scalar case (no nested walk). Equivalent
+  to `(set-cell-override state variant-id [arg-key] value)`."
+  [state variant-id arg-key value]
+  (set-cell-override state variant-id [arg-key] value))
+
+(defn clear-cell-overrides
+  "Drop every override for `variant-id`."
+  [state variant-id]
+  (update state :cell-overrides dissoc variant-id))
+
+;; ---- hot-reload + fingerprints + snapshots + panels ---------------------
+
+(defn bump-hot-reload-tick
+  "Increment the hot-reload tick — variant components observe this slot
+  and re-mount on change. Returns the new state map."
+  [state]
+  (update state :hot-reload-tick (fnil inc 0)))
+
+(defn record-fingerprints
+  "Stamp the current decorator fingerprints for `variant-id`. Stage 4's
+  hot-reload trigger reads the previous map and compares against the
+  current registry; a mismatch bumps `:hot-reload-tick`."
+  [state variant-id fingerprints]
+  (assoc-in state [:fingerprints variant-id] fingerprints))
+
+(defn pin-snapshot
+  "Record a pinned snapshot label/epoch pair for `variant-id`."
+  [state variant-id label epoch-id]
+  (update-in state [:pinned-snapshots variant-id]
+             (fnil conj [])
+             {:label label :epoch-id epoch-id}))
+
+(defn toggle-panel
+  "Flip a panel's visibility."
+  [state panel-id]
+  (update-in state [:panel-visibility panel-id] not))
+
+;; ---- mode-tab (rf2-9hc8) -------------------------------------------------
+
+(def mode-tabs
+  "Ordered vector of canonical render-shell mode tabs. Stable id order
+  drives the chip strip's left-to-right layout. `:dev` is the canvas
+  view (rendered by `re-frame.story.ui.canvas`), `:docs` is the
+  read-only AutoDocs-equivalent (rf2-rodx), `:test` is the
+  in-canvas aggregated pass/fail view (rf2-qmjo)."
+  [:dev :docs :test])
+
+(def mode-tab-labels
+  "Human-readable label per mode-tab id. Used by the chip strip."
+  {:dev  "Canvas"
+   :docs "Docs"
+   :test "Tests"})
+
+(def default-mode-tab
+  "Default mode-tab when no per-variant selection is recorded. `:dev`
+  preserves Story v1's existing behaviour — the variant renders in the
+  canvas as soon as it's selected."
+  :dev)
+
+(defn valid-mode-tab?
+  "Is `tab` one of the canonical mode-tabs?"
+  [tab]
+  (boolean (some #{tab} mode-tabs)))
+
+(defn active-mode-tab
+  "Look up the currently-active mode-tab for `variant-id`. Falls back
+  to `default-mode-tab` when no selection is recorded."
+  [state variant-id]
+  (or (get-in state [:active-mode-tab variant-id])
+      default-mode-tab))
+
+(defn set-active-mode-tab
+  "Record the active mode-tab for `variant-id`. `tab` MUST be one of
+  `mode-tabs`; an unrecognised value is silently ignored so callers
+  can't poison the state."
+  [state variant-id tab]
+  (if (valid-mode-tab? tab)
+    (assoc-in state [:active-mode-tab variant-id] tab)
+    state))

--- a/tools/story/test/re_frame/story/ui/test_watch_mode_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_watch_mode_cljs_test.cljc
@@ -18,7 +18,8 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.story :as story]
             [re-frame.story.ui.state :as state]
-            #?@(:cljs [[re-frame.story.ui.sidebar :as sidebar]])))
+            #?@(:cljs [[re-frame.story.ui.shell   :as shell]
+                       [re-frame.story.ui.sidebar :as sidebar]])))
 
 ;; ---- fixtures ------------------------------------------------------------
 
@@ -209,3 +210,60 @@
        (sidebar/watch-rerun! [])
        (let [s (state/get-state)]
          (is (nil? (get-in s [:tests :runs :story.x/a])))))))
+
+;; ---- rf2-mclvi regression: cell-override edit triggers a re-run -------
+;;
+;; Before rf2-mclvi the watch-mode hash cache key explicitly omitted
+;; `:cell-overrides` while `snapshot-tuple` (via `resolve-args`) DID
+;; thread overrides into the hash input. The cache served stale answers
+;; on every control edit; the detector saw no drift and missed the
+;; re-run. The cache now includes `:cell-overrides` in the key + threads
+;; per-variant overrides into the snapshot-identity opts.
+
+#?(:cljs
+   (deftest cell-override-edit-perturbs-watch-mode-hash
+     (testing "editing :cell-overrides on a :test-tagged variant
+               produces a fresh content-hash via detect-watch-drift!
+               and stamps the variant :running (rf2-mclvi)"
+       (story/reg-variant :story.x/a
+         {:component :app.ui/echo
+          :args      {:n 0}
+          :tags      #{:test}
+          :events    []
+          :play      [[:rf.assert/path-equals [:c] 0]]})
+       ;; Flip watch-mode on and seed the initial hashes with no overrides.
+       (state/swap-state! state/set-test-watch-mode true)
+       (state/swap-state!
+         (fn [s]
+           (state/record-test-content-hashes
+             s
+             ;; Seed from the current registry — these are the baseline
+             ;; hashes the detector diffs against.
+             {})))
+       ;; First detection pass — should seed hashes + (because prev is
+       ;; empty) treat every testable variant as drifted, re-running it.
+       (shell/detect-watch-drift!)
+       (let [seeded-hashes (get-in (state/get-state) [:tests :content-hashes])]
+         (is (contains? seeded-hashes :story.x/a)
+             "after the first pass the slot is seeded from the registry"))
+       ;; Re-seed against the post-baseline so the next pass starts from
+       ;; the registry's current truth; cell-edit happens after.
+       (let [post-seed (get-in (state/get-state) [:tests :content-hashes])
+             baseline  (get post-seed :story.x/a)]
+         ;; Drop the per-variant :running stamp so we can detect a fresh one.
+         (state/swap-state! state/clear-test-run :story.x/a)
+         ;; Now simulate a control-panel edit — write into :cell-overrides.
+         (state/swap-state! state/set-cell-override :story.x/a [:n] 42)
+         (shell/detect-watch-drift!)
+         (let [after-hashes (get-in (state/get-state) [:tests :content-hashes])
+               after-hash   (get after-hashes :story.x/a)
+               run-state    (get-in (state/get-state) [:tests :runs :story.x/a])]
+           (testing "the recomputed hash differs from the baseline (cell-overrides
+                     ARE threaded through snapshot-tuple)"
+             (is (not= baseline after-hash)
+                 (str "expected fresh hash after cell-override edit; got "
+                      (pr-str baseline) " → " (pr-str after-hash))))
+           (testing "the detector dispatched watch-rerun! → :running stamp lands"
+             (is (= :running (:status run-state))
+                 (str "expected the variant marked :running after the cell-
+                       override edit; run-state was " (pr-str run-state)))))))))

--- a/tools/story/test/re_frame/story_review_dialog_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_review_dialog_cljs_test.cljs
@@ -9,6 +9,7 @@
   flows both depend on."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
+            [re-frame.story.predicates :as pred]
             [re-frame.story.review-dialog :as review-dialog]))
 
 ;; ---- parse-variant-id-string ---------------------------------------------
@@ -192,9 +193,9 @@
 
 (deftest indent-after-matches-prefix-width
   (testing "indent-after returns \\n + N spaces equal to the prefix length"
-    (is (= "\n" (review-dialog/indent-after "")))
-    (is (= "\n          " (review-dialog/indent-after "   :play [")))
-    (is (= "\n          " (review-dialog/indent-after "   :args {")))
-    (is (= (review-dialog/indent-after "   :play [")
-           (review-dialog/indent-after "   :args {"))
+    (is (= "\n" (pred/indent-after "")))
+    (is (= "\n          " (pred/indent-after "   :play [")))
+    (is (= "\n          " (pred/indent-after "   :args {")))
+    (is (= (pred/indent-after "   :play [")
+           (pred/indent-after "   :args {"))
         "both flows' prefixes collapse to the same indent")))

--- a/tools/story/test/re_frame/story_review_dialog_test.clj
+++ b/tools/story/test/re_frame/story_review_dialog_test.clj
@@ -21,6 +21,7 @@
     `parse-and-set-draft-id`) — JVM-testable in isolation; the CLJS
     adapter swaps a Reagent ratom around them."
   (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.predicates :as pred]
             [re-frame.story.review-dialog :as review-dialog]))
 
 ;; ---- parse-variant-id-string ---------------------------------------------
@@ -188,15 +189,15 @@
 
 (deftest indent-after-shape
   (testing "indent-after returns a newline followed by N spaces matching prefix width"
-    (is (= "\n" (review-dialog/indent-after "")))
-    (is (= "\n " (review-dialog/indent-after "x")))
-    (is (= "\n     " (review-dialog/indent-after "12345")))))
+    (is (= "\n" (pred/indent-after "")))
+    (is (= "\n " (pred/indent-after "x")))
+    (is (= "\n     " (pred/indent-after "12345")))))
 
 (deftest indent-after-aligns-recorder-play-body
   (testing "the indent lines events up under the first item of `:play [` on the previous line"
     (let [prefix      "   :play ["
           first-line  (str prefix "[:counter/inc]")
-          cont-indent (review-dialog/indent-after prefix)
+          cont-indent (pred/indent-after prefix)
           full        (str first-line cont-indent "[:counter/dec]")
           lines       (clojure.string/split full #"\n")
           ;; column of the first event char on line 1 = (count prefix)
@@ -214,7 +215,7 @@
   (testing "the indent lines kv pairs up under the first kv of `:args {` on the previous line"
     (let [prefix      "   :args {"
           first-line  (str prefix ":a 1")
-          cont-indent (review-dialog/indent-after prefix)
+          cont-indent (pred/indent-after prefix)
           full        (str first-line cont-indent ":b 2")
           lines       (clojure.string/split full #"\n")
           line1-first-kv-col (count prefix)
@@ -225,9 +226,9 @@
 
 (deftest indent-after-pure-and-deterministic
   (testing "the helper is pure — same input → same output"
-    (is (= (review-dialog/indent-after "   :play [")
-           (review-dialog/indent-after "   :play [")))
+    (is (= (pred/indent-after "   :play [")
+           (pred/indent-after "   :play [")))
     ;; And the recorder + save-variant prefixes collapse to the same width
     ;; (both keys are 4 chars; both bodies indent 3 + key + space + bracket = 10)
-    (is (= (review-dialog/indent-after "   :play [")
-           (review-dialog/indent-after "   :args {")))))
+    (is (= (pred/indent-after "   :play [")
+           (pred/indent-after "   :args {")))))

--- a/tools/story/test/re_frame/story_substrate_isolation_test.clj
+++ b/tools/story/test/re_frame/story_substrate_isolation_test.clj
@@ -1,0 +1,96 @@
+(ns re-frame.story-substrate-isolation-test
+  "JVM test pinning Story's substrate-isolation contract (rf2-k7zdq).
+
+  Story's UI-shell substrate is Reagent (IMPL-SPEC §8); per-variant
+  multi-substrate rendering (UIx / Helix) is OPT-IN via
+  `register-substrate!` from the consuming app at boot — Story core
+  does NOT `:require` any UIx or Helix namespace. That contract means
+  a host app can embed Story without dragging UIx / Helix into its
+  classpath unless it elects to render variants under those
+  substrates.
+
+  This test walks every source file under `tools/story/src/` and
+  asserts the contract — no source ns may `:require` a
+  `uix.core` / `uix.dom` / `helix.core` / `helix.dom` ns. References
+  to the *keywords* `:uix` / `:helix` (substrate-ids in the enum,
+  docstring callouts, sentinel comments) are permitted; what is
+  forbidden is a fully-qualified namespace require that would pull
+  the adapter onto Story's classpath.
+
+  Companion to `implementation/scripts/check-bundle-isolation.cjs`
+  which guards the OUTPUT side (counter bundle must not contain
+  Story sentinel strings); this test guards the INPUT side (Story
+  source must not require UIx/Helix nses)."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]))
+
+;; ----- helpers ------------------------------------------------------------
+
+(defn- src-files
+  "Walk tools/story/src/ and return every .cljc / .cljs / .clj file as
+  a `java.io.File`. The classpath element `src` resolves to the same
+  directory whether tests run via `clojure -M:test` from `tools/story`
+  or via the top-level shadow build."
+  []
+  (let [root (io/file "src")]
+    (when (.isDirectory root)
+      (->> (file-seq root)
+           (filter #(.isFile ^java.io.File %))
+           (filter (fn [^java.io.File f]
+                     (let [n (.getName f)]
+                       (or (str/ends-with? n ".cljc")
+                           (str/ends-with? n ".cljs")
+                           (str/ends-with? n ".clj")))))))))
+
+(def ^:private forbidden-require-patterns
+  "Namespace prefixes that, if `:require`-d from Story source, would
+  drag the corresponding adapter onto Story's classpath. Reagent is
+  intentionally NOT in this list — Story's UI shell IS Reagent per
+  IMPL-SPEC §8."
+  [#"\[\s*uix\.core"
+   #"\[\s*uix\.dom"
+   #"\[\s*helix\.core"
+   #"\[\s*helix\.dom"
+   #"\[\s*helix\.hooks"])
+
+(defn- offending-requires
+  "Return a seq of `{:file path :match line}` for every forbidden
+  require pattern found in `body`. Reads the file body as a single
+  string; matches against require-form bracket prefixes that survive
+  whitespace / newlines."
+  [^java.io.File f]
+  (let [body (slurp f)
+        path (.getPath f)]
+    (for [pat   forbidden-require-patterns
+          :let  [m (re-find pat body)]
+          :when m]
+      {:file path :match m :pattern (str pat)})))
+
+;; ----- the contract test --------------------------------------------------
+
+(deftest story-source-must-not-require-uix-or-helix
+  (testing "no namespace under tools/story/src/ may :require uix.* / helix.*
+(rf2-k7zdq — multi-substrate is opt-in via register-substrate!)"
+    (let [files     (src-files)
+          offences  (mapcat offending-requires files)]
+      (is (seq files) "expected to find source files under tools/story/src/")
+      (is (empty? offences)
+          (str "Story source files require forbidden UIx / Helix namespaces:\n"
+               (str/join "\n" (map (fn [{:keys [file pattern match]}]
+                                     (str "  " file
+                                          "  (pattern " pattern
+                                          " matched " (pr-str match) ")"))
+                                   offences))
+               "\n\nPer IMPL-SPEC §2.2 + §8 Story's UI shell is Reagent; UIx and "
+               "Helix substrates plug in at boot via "
+               "`re-frame.story.ui.multi-substrate/register-substrate!`. "
+               "Story core MUST NOT drag those adapters onto its classpath."))))
+
+  (testing "the substrate enum still advertises :reagent + :uix + :helix
+(consumer-app registration surface — keyword refs only, not requires)"
+    (let [enum-file (io/file "src/re_frame/story/schemas.cljc")
+          body      (slurp enum-file)]
+      (is (str/includes? body ":reagent"))
+      (is (str/includes? body ":uix"))
+      (is (str/includes? body ":helix")))))

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -532,6 +532,26 @@
                            {:events [[:init]]}))
       (is (>= (registrar/current-mutation-tick) (+ t0 5))))))
 
+(deftest variants-with-tags-memoised-on-mutation-tick
+  (testing "variants-with-tags returns cached results between two registrar writes (rf2-c5nwl)"
+    (story/reg-tag :status/stable {:axis :status})
+    (story/reg-tag :role/dev      {:axis :role})
+    (story/reg-variant :story.memo/a {:tags #{:status/stable} :events []})
+    (story/reg-variant :story.memo/b {:tags #{:role/dev}     :events []})
+    (story/reg-variant :story.memo/c {:tags #{:status/stable :role/dev} :events []})
+    (let [r1 (registrar/variants-with-tags #{:status/stable})
+          r2 (registrar/variants-with-tags #{:status/stable})]
+      (testing "same query between writes returns identical (cache-hit) set"
+        (is (identical? r1 r2))
+        (is (= #{:story.memo/a :story.memo/c} r1))))
+    (testing "different query in same tick is also cached + correct"
+      (let [r-role (registrar/variants-with-tags #{:role/dev})]
+        (is (= #{:story.memo/b :story.memo/c} r-role))))
+    (testing "registrar mutation invalidates the cache"
+      (story/reg-variant :story.memo/d {:tags #{:status/stable} :events []})
+      (let [r3 (registrar/variants-with-tags #{:status/stable})]
+        (is (= #{:story.memo/a :story.memo/c :story.memo/d} r3))))))
+
 ;; ---- Public tag->axis-index API -------------------------------------
 
 (deftest public-tag-axis-index-no-axis-sentinel

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -532,6 +532,26 @@
                            {:events [[:init]]}))
       (is (>= (registrar/current-mutation-tick) (+ t0 5))))))
 
+;; ---- Public tag->axis-index API -------------------------------------
+
+(deftest public-tag-axis-index-no-axis-sentinel
+  (testing "story/tag->axis-index returns the ::no-axis sentinel for tags
+without :axis (rf2-jlsvj — lock the public-API contract)"
+    (story/reg-tag :status/stable  {:axis :status})
+    (story/reg-tag :role/dev       {:axis :role})
+    (story/reg-tag :loose/freeform {:doc "no axis on this tag"})
+    (let [idx (story/tag->axis-index)]
+      (is (map? idx))
+      (testing "axis-bearing tags map to their axis"
+        (is (= :status (get idx :status/stable)))
+        (is (= :role   (get idx :role/dev))))
+      (testing "tags registered without :axis map to the registrar/no-axis sentinel"
+        (is (= :re-frame.story.registrar/no-axis
+               (get idx :loose/freeform))))
+      (testing "canonical tags are pre-registered without :axis and bucket to no-axis"
+        (is (= :re-frame.story.registrar/no-axis
+               (get idx :dev)))))))
+
 ;; ---- Stage 6 contract check -----------------------------------------
 
 (deftest stage-marker

--- a/tools/story/testbeds/counter_with_stories/counter_with_stories.spec.cjs
+++ b/tools/story/testbeds/counter_with_stories/counter_with_stories.spec.cjs
@@ -13,7 +13,7 @@
  *                 playground — sidebar navigation, mode-tag filtering,
  *                 workspace cell mounting, time-travel scrubber, trace
  *                 panel, a11y panel, layout-debug toggles, args editor,
- *                 mode picker, decorator list, save-layout button —
+ *                 mode picker, decorator list —
  *                 one assertion per surface so each one is exercised
  *                 by the smoke (rf2-kljn).
  *

--- a/tools/story/testbeds/counter_with_stories/counter_with_stories.spec.cjs
+++ b/tools/story/testbeds/counter_with_stories/counter_with_stories.spec.cjs
@@ -1301,22 +1301,10 @@ module.exports = {
     // Shell still alive — variant title still visible.
     await waitForVariantTitle(page, ':story.counter/loaded');
 
-    // ====================================================================
-    // 14. Save-layout button — clicks without crashing
-    // ====================================================================
-    //
-    // The save-layout button is a Stage-4 stub: clicking emits a
-    // console.log only. We confirm the button exists, click it, and
-    // afterwards the shell is still mounted (the canvas variant title
-    // and the run-button both stay visible).
-    const saveBtn = aside.getByRole('button', { name: /save layout as :Workspace/i }).first();
-    await saveBtn.waitFor({ state: 'visible', timeout: 5000 });
-    await saveBtn.click();
-    // Shell still alive — variant title still on the page.
-    await waitForVariantTitle(page, ':story.counter/loaded');
+    // (section 14 removed: save-layout button stub dropped in rf2-gqzs8 / PR #1170 — pre-alpha dead-surface deletion)
 
     // ====================================================================
-    // 15. Project-custom :Panel.counter-with-stories/notes panel
+    // 14. Project-custom :Panel.counter-with-stories/notes panel
     // ====================================================================
     //
     // Stage 6's panel-host renders every registered :story-panel whose
@@ -1342,7 +1330,7 @@ module.exports = {
     }
 
     // ====================================================================
-    // 16. Switch back to the live app — counter reappears + inc still wired
+    // 15. Switch back to the live app — counter reappears + inc still wired
     // ====================================================================
     //
     // Hash-change back to the live app; counter should reappear. The


### PR DESCRIPTION
## Summary

Implements all 11 follow-on beads from the rf2-cgqam round-2 audit of `tools/story/` (findings doc: `ai/findings/story-r2-audit-2026-05-15.md`). Tight surface — every change lives under `tools/story/`. Pre-alpha; no back-compat aliases.

## Beads (cleanup/refactor → correctness)

| # | Bead | Pri | Change |
|---|---|---|---|
| 1 | rf2-gqzs8 | P3 | Drop `save-layout-button` (Stage-4 stub) + its controls-panel callsite |
| 2 | rf2-jlsvj | P3 | Add JVM test for public `story/tag->axis-index` no-axis sentinel |
| 3 | rf2-tb0ga | P3 | Drop `:reagent-slim` from canonical substrate enum (renderer hasn't shipped); spec/schema/story.cljc aligned |
| 4 | rf2-noizc | P2 | Rename `frames/reset!*` → `frames/reset-frame!` (align with framework `*-frame!` convention) |
| 5 | rf2-77nuq | P2 | Drop dead `decor-pack` binding in `multi_substrate.cljs`; breadcrumb for IMPL-SPEC §5.3 per-substrate stacks |
| 6 | rf2-ar0t9 | P2 | Move `indent-after` from `review-dialog` → `predicates` leaf (fix upside-down dep direction recorder → review-dialog) |
| 7 | rf2-k7zdq | P2 | JVM bundle-isolation test: Story source must not `:require` `uix.*` / `helix.*` |
| 8 | rf2-0z8e2 | P2 | Hoist `tag->axis-index` to single per-render call in sidebar (was 2x) |
| 9 | rf2-c5nwl | P2 | Memoise `variants-with-tags` on the registrar mutation-tick (rf2-zrswb dirty bit) |
| 10 | rf2-gcpon | P2 | Split `state.cljc` (718L) into 4 leaves under 250L: `state.cljc` (220L) facade + `state/transitions.cljc` (208L) + `state/filters.cljc` (156L) + `state/tests.cljc` (247L) + `state/snapshot.cljc` (25L) |
| 11 | rf2-mclvi | **P1** | **fix watch-mode cache key + per-variant opts to include `:cell-overrides`** — the cache was stale on every control edit, watch-mode missed re-runs; regression test added |

## Cross-bead interactions

- rf2-gcpon (state split) lays the surface for rf2-c5nwl (variants-with-tags memoisation) which keys on the registrar mutation-tick — both honour the rf2-zrswb dirty-bit pattern.
- rf2-ar0t9 (indent-after → predicates) leaves recorder.cljc without a `review-dialog` require, tightening the producer/consumer split the modal-extract rf2-7jpky aimed at.
- rf2-mclvi (the P1 fix) is independent; the regression test exercises shell.cljs's `detect-watch-drift!` via the CLJS arm in `test_watch_mode_cljs_test`.

## Test plan

- [x] `cd tools/story && clojure -M:test` — 415 tests, 1275 assertions, all green (was 413/1266; +2 tests +9 assertions: 1 from rf2-jlsvj, 1 from rf2-k7zdq isolation gate + rf2-c5nwl memoisation regression).
- [x] `cd implementation && npm run test:cljs` — 2015 tests, 5683 assertions, all green (includes the rf2-mclvi CLJS regression for the watch-mode cell-override drift).
- [ ] Visual smoke: render Story shell; toggle watch-mode on; edit a control on a `:test`-tagged variant; verify the test-widget re-runs (rf2-mclvi end-to-end).