### PR TITLE
refactor(flows): audit follow-ups cluster (12 beads incl. rf2-fslx0 P1)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -393,9 +393,83 @@
       ;; `(fn [frame-id parent-envelope args])` — `:dispatch` /
       ;; `:dispatch-later` read parent-envelope to propagate
       ;; inheritable envelope keys per Spec 002 §Cascade propagation.
-      (do
+      ;;
+      ;; Per rf2-eb4lp: catch `:rf.error/flow-cycle` thrown by
+      ;; `:rf.fx/reg-flow` (the cycle detection in
+      ;; `re-frame.flows.registry/reg-flow` raises synchronously
+      ;; through `topo/topo-sort prospective`). Without this catch the
+      ;; ex-info bubbles uncaught up to the drain emergency-release
+      ;; path, taking down the rest of the cascade. Catching here and
+      ;; routing through the always-on `error-emit` substrate
+      ;; preserves the `:cycle` ex-data, surfaces it under its own
+      ;; `:rf.error/flow-cycle` category (NOT the generic
+      ;; `:fx-handler-exception` the user-fx catch below would emit
+      ;; for non-reserved registrations), and survives CLJS prod
+      ;; elision — mirrors the rf2-hrt5c handler-exception fix and
+      ;; the rf2-fslx0 flow-eval routing. Other reserved-fx throws
+      ;; (currently none expected from `:dispatch` / `:dispatch-later`
+      ;; / `:rf.fx/clear-flow` — none have known throw shapes) re-
+      ;; throw to preserve the existing crash-loud contract until a
+      ;; richer routing emerges.
+      (try
         (reserved-body frame-id parent-envelope args)
-        (emit-handled! fx-id args frame-id))
+        (emit-handled! fx-id args frame-id)
+        (catch #?(:clj Throwable :cljs :default) e
+          (let [d (ex-data e)]
+            (if (= :rf.error/flow-cycle (:error d))
+              (let [msg #?(:clj (.getMessage ^Throwable e)
+                           :cljs (.-message e))
+                    time (interop/now-ms)]
+                ;; Substrate routing — survives CLJS prod elision so
+                ;; Sentry / Honeybadger / `:on-error` policy fns
+                ;; receive the typed `:rf.error/flow-cycle` record
+                ;; with the `:cycle` chain in `:exception`'s ex-data.
+                ;; Reached via the late-bind hook
+                ;; `:error-emit/dispatch-on-error` (Spec 002 §The late-
+                ;; bind seam) — fx.cljc cannot statically require
+                ;; error-emit (error-emit → router → core → ... → fx
+                ;; would be a load cycle).
+                (when-let [dispatch-on-error!
+                           (late-bind/get-fn :error-emit/dispatch-on-error)]
+                  (dispatch-on-error!
+                    :rf.error/flow-cycle
+                    origin-event
+                    origin-event-id
+                    frame-id
+                    e
+                    0
+                    time
+                    {:operation :rf.error/flow-cycle
+                     :op-type   :error
+                     :tags      {:event-id          origin-event-id
+                                 :event             origin-event
+                                 :frame             frame-id
+                                 :fx-id             fx-id
+                                 :fx-args           args
+                                 :where             :fx-reg-flow
+                                 :handler-id        nil
+                                 :exception         e
+                                 :exception-message msg
+                                 :cycle             (:cycle d)
+                                 :reason            (str "Flow registration via :rf.fx/reg-flow introduced a cycle.")
+                                 :recovery          :no-recovery}
+                     :recovery  :no-recovery}))
+                ;; Trace path for dev consumers; DCE'd in CLJS prod.
+                (trace/emit-error! :rf.error/flow-cycle
+                                   {:failing-id        fx-id
+                                    :fx-id             fx-id
+                                    :fx-args           args
+                                    :frame             frame-id
+                                    :exception         e
+                                    :exception-message msg
+                                    :cycle             (:cycle d)
+                                    :reason            (str "Flow registration via :rf.fx/reg-flow introduced a cycle.")
+                                    :recovery          :no-recovery}))
+              ;; Non-cycle reserved-fx throw — preserve the crash-loud
+              ;; contract by re-throwing. No existing reserved-fx body
+              ;; is known to throw; if a future addition adds a typed
+              ;; surface, special-case it here too.
+              (throw e)))))
       ;; Default: user-registered fx — OR a synthesised meta carrying a
       ;; function-value override (per `resolved-fx-meta` above; the
       ;; spec/002 CLJS-reference convenience form). `resolved-meta` was

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -394,81 +394,63 @@
       ;; `:dispatch-later` read parent-envelope to propagate
       ;; inheritable envelope keys per Spec 002 §Cascade propagation.
       ;;
-      ;; Per rf2-eb4lp: catch `:rf.error/flow-cycle` thrown by
-      ;; `:rf.fx/reg-flow` (the cycle detection in
-      ;; `re-frame.flows.registry/reg-flow` raises synchronously
-      ;; through `topo/topo-sort prospective`). Without this catch the
-      ;; ex-info bubbles uncaught up to the drain emergency-release
-      ;; path, taking down the rest of the cascade. Catching here and
-      ;; routing through the always-on `error-emit` substrate
-      ;; preserves the `:cycle` ex-data, surfaces it under its own
-      ;; `:rf.error/flow-cycle` category (NOT the generic
-      ;; `:fx-handler-exception` the user-fx catch below would emit
-      ;; for non-reserved registrations), and survives CLJS prod
-      ;; elision — mirrors the rf2-hrt5c handler-exception fix and
-      ;; the rf2-fslx0 flow-eval routing. Other reserved-fx throws
-      ;; (currently none expected from `:dispatch` / `:dispatch-later`
-      ;; / `:rf.fx/clear-flow` — none have known throw shapes) re-
-      ;; throw to preserve the existing crash-loud contract until a
-      ;; richer routing emerges.
+      ;; Generic typed-throw routing (rf2-eb4lp + rf2-on7sj-class
+      ;; pattern): if a reserved-fx body throws with an `:error`-keyed
+      ;; ex-data slot carrying a keyword category, route it through
+      ;; the always-on `error-emit` substrate so prod monitors get
+      ;; the typed signal; ex-data is preserved verbatim including
+      ;; any reserved-fx-specific slots (e.g. `:cycle`). Reached via
+      ;; the late-bind hook `:error-emit/dispatch-on-error` (fx.cljc
+      ;; cannot statically require error-emit — would form a load
+      ;; cycle). Untyped throws re-throw to preserve the crash-loud
+      ;; contract. This generalisation keeps reserved-fx-specific
+      ;; error keywords (e.g. flow-cycle) out of core/fx.cljc so they
+      ;; DCE from consumer bundles that don't use the offending fx.
       (try
         (reserved-body frame-id parent-envelope args)
         (emit-handled! fx-id args frame-id)
         (catch #?(:clj Throwable :cljs :default) e
-          (let [d (ex-data e)]
-            (if (= :rf.error/flow-cycle (:error d))
-              (let [msg #?(:clj (.getMessage ^Throwable e)
-                           :cljs (.-message e))
+          (let [d        (ex-data e)
+                category (:error d)]
+            (if (keyword? category)
+              (let [msg  #?(:clj (.getMessage ^Throwable e)
+                            :cljs (.-message e))
                     time (interop/now-ms)]
-                ;; Substrate routing — survives CLJS prod elision so
-                ;; Sentry / Honeybadger / `:on-error` policy fns
-                ;; receive the typed `:rf.error/flow-cycle` record
-                ;; with the `:cycle` chain in `:exception`'s ex-data.
-                ;; Reached via the late-bind hook
-                ;; `:error-emit/dispatch-on-error` (Spec 002 §The late-
-                ;; bind seam) — fx.cljc cannot statically require
-                ;; error-emit (error-emit → router → core → ... → fx
-                ;; would be a load cycle).
                 (when-let [dispatch-on-error!
                            (late-bind/get-fn :error-emit/dispatch-on-error)]
                   (dispatch-on-error!
-                    :rf.error/flow-cycle
+                    category
                     origin-event
                     origin-event-id
                     frame-id
                     e
                     0
                     time
-                    {:operation :rf.error/flow-cycle
+                    {:operation category
                      :op-type   :error
-                     :tags      {:event-id          origin-event-id
-                                 :event             origin-event
-                                 :frame             frame-id
-                                 :fx-id             fx-id
-                                 :fx-args           args
-                                 :where             :fx-reg-flow
-                                 :handler-id        nil
-                                 :exception         e
-                                 :exception-message msg
-                                 :cycle             (:cycle d)
-                                 :reason            (str "Flow registration via :rf.fx/reg-flow introduced a cycle.")
-                                 :recovery          :no-recovery}
+                     :tags      (merge {:event-id          origin-event-id
+                                        :event             origin-event
+                                        :frame             frame-id
+                                        :fx-id             fx-id
+                                        :fx-args           args
+                                        :handler-id        nil
+                                        :exception         e
+                                        :exception-message msg
+                                        :recovery          :no-recovery}
+                                       (dissoc d :error))
                      :recovery  :no-recovery}))
                 ;; Trace path for dev consumers; DCE'd in CLJS prod.
-                (trace/emit-error! :rf.error/flow-cycle
-                                   {:failing-id        fx-id
-                                    :fx-id             fx-id
-                                    :fx-args           args
-                                    :frame             frame-id
-                                    :exception         e
-                                    :exception-message msg
-                                    :cycle             (:cycle d)
-                                    :reason            (str "Flow registration via :rf.fx/reg-flow introduced a cycle.")
-                                    :recovery          :no-recovery}))
-              ;; Non-cycle reserved-fx throw — preserve the crash-loud
-              ;; contract by re-throwing. No existing reserved-fx body
-              ;; is known to throw; if a future addition adds a typed
-              ;; surface, special-case it here too.
+                (trace/emit-error! category
+                                   (merge {:failing-id        fx-id
+                                           :fx-id             fx-id
+                                           :fx-args           args
+                                           :frame             frame-id
+                                           :exception         e
+                                           :exception-message msg
+                                           :recovery          :no-recovery}
+                                          (dissoc d :error))))
+              ;; Untyped reserved-fx throw — preserve crash-loud
+              ;; contract by re-throwing.
               (throw e)))))
       ;; Default: user-registered fx — OR a synthesised meta carrying a
       ;; function-value override (per `resolved-fx-meta` above; the

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -510,15 +510,29 @@
               ;; from `interop/now-ms` (mirrors `emit-handler-exception!`).
               elapsed-ms (long (max 0 (- end-ms start-ms)))
               msg        #?(:clj (.getMessage ^Throwable e) :cljs (.-message e))
-              tags       {:event-id          event-id
-                          :event             event
-                          :frame             frame
-                          :where             :flow-eval
-                          :handler-id        nil
-                          :exception         e
-                          :exception-message msg
-                          :reason            "Flow evaluation threw."
-                          :recovery          :no-recovery}]
+              ;; Per rf2-je5p8: `evaluate-flow!`'s catch wraps the user
+              ;; throw in an ex-info carrying `:rf.flow/failed-id` and
+              ;; `:rf.flow/failed-frame`. Extract them onto the
+              ;; substrate record's `:tags` so the always-on error-emit
+              ;; substrate (the only signal in CLJS prod where
+              ;; `:rf.flow/failed` DCEs) can attribute the
+              ;; `:rf.error/flow-eval-exception` to a specific flow.
+              ;; Absent slots leave `:flow-id` nil — preserves the prior
+              ;; contract for non-wrapped throws (e.g. a hypothetical
+              ;; throw from outside `evaluate-flow!`).
+              flow-data  (when-let [d (ex-data e)]
+                           {:flow-id (:rf.flow/failed-id    d)
+                            :flow    (:rf.flow/failed-frame d)})
+              tags       (cond-> {:event-id          event-id
+                                  :event             event
+                                  :frame             frame
+                                  :where             :flow-eval
+                                  :handler-id        nil
+                                  :exception         e
+                                  :exception-message msg
+                                  :reason            "Flow evaluation threw."
+                                  :recovery          :no-recovery}
+                           (:flow-id flow-data) (assoc :flow-id (:flow-id flow-data)))]
           ;; Always-on per rf2-bacs4 / rf2-hqbeh — fires in CLJS
           ;; production builds where `trace/emit-error!` below is
           ;; compile-time elided. The two fan-out paths (corpus-wide

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -480,10 +480,18 @@
 
 (defn- run-flows!
   "Per Spec 013 §Drain integration: run flows after :db commits and
-  before :fx walks. Flow evaluation exceptions surface as
-  :rf.error/flow-eval-exception through BOTH the dev-only trace
-  surface AND the always-on error-emit substrate (per rf2-hrt5c — the
-  security-audit fix). The drain continues regardless.
+  before :fx walks. Returns `true` on success (including the no-flows-
+  artefact short-circuit) and `false` when a flow's `:output` threw.
+  Per Spec 013 §Failure semantics rule 3: the caller MUST halt the
+  cascade on `false` — downstream `:fx` does NOT run when a flow has
+  thrown (an `:fx` entry's side effects can rely on derived state the
+  failing flow was supposed to produce).
+
+  Flow evaluation exceptions surface as :rf.error/flow-eval-exception
+  through BOTH the dev-only trace surface AND the always-on error-emit
+  substrate (per rf2-hrt5c — the security-audit fix). The drain
+  continues with the NEXT event after the substrate emit; this drain's
+  `:fx` is skipped per rf2-fslx0.
 
   Per rf2-hrt5c: pre-fix, `:rf.error/flow-eval-exception` rode the
   trace path only. `trace/emit-error!` is gated by
@@ -497,11 +505,21 @@
   elision. There is no `:handler-id` (no handler ran — the throw
   came from the post-commit flow walk); the `:where :flow-eval`
   discriminator distinguishes this path from the handler-exception
-  one for policy fns that key on it."
+  one for policy fns that key on it.
+
+  Per rf2-fslx0: pre-fix this fn returned nil on both success and
+  failure paths, so `commit-and-flow!` had no signal to skip `:fx`
+  on flow throws. A handler emitting `[:dispatch [:react-to-area-
+  change]]` from `:fx` would fire the child dispatch even when the
+  source flow threw — child handler runs on stale derived state,
+  side effects (HTTP / navigation / analytics) escape. Spec 013
+  §Failure semantics rule 3 + §rationale (line 202) state the
+  cascade halts at a failing flow."
   [frame event event-id start-ms]
-  (when-let [flows-fn (late-bind/get-fn :flows/run-flows!)]
+  (if-let [flows-fn (late-bind/get-fn :flows/run-flows!)]
     (try
       (flows-fn frame)
+      true
       (catch #?(:clj Throwable :cljs :default) e
         (let [end-ms     (interop/now-ms)
               ;; Per rf2-bacs4 §Record shape: `:elapsed-ms` is an
@@ -556,7 +574,13 @@
           ;; builds. Same payload shape as before the rf2-hrt5c fix —
           ;; existing trace consumers are unaffected.
           (trace/emit-error! :rf.error/flow-eval-exception
-                             {:frame frame :event event :exception e}))))))
+                             {:frame frame :event event :exception e})
+          ;; Per rf2-fslx0 — Spec 013 §Failure semantics rule 3:
+          ;; signal failure so `commit-and-flow!` skips `:fx`.
+          false)))
+    ;; No flows artefact loaded — short-circuit. Treat as success
+    ;; (apps without flows don't have this cascade-halt concern).
+    true))
 
 (defn- run-fx-effects!
   "Walk :fx in source order, threading fx-overrides through so per-frame
@@ -702,8 +726,16 @@
     (when error
       (emit-handler-exception! error event-id event frame final-ctx start-ms))
     (when (commit-db-effect! effects event-id event frame final-ctx db-before)
-      (run-flows! frame event event-id start-ms)
-      (run-fx-effects! effects frame frame-record fx-overrides envelope))
+      ;; Per rf2-fslx0 — Spec 013 §Failure semantics rule 3: when a
+      ;; flow throws, halt the cascade. `run-flows!` returns false on
+      ;; flow throw (after fanning out
+      ;; `:rf.error/flow-eval-exception` through trace + error-emit
+      ;; substrate); `run-fx-effects!` then skips. Without this gate
+      ;; an `:fx [[:dispatch [:react-to-area-change]]]` would fire its
+      ;; child dispatch on stale derived state — side effects (HTTP /
+      ;; navigation / analytics) would escape.
+      (when (run-flows! frame event event-id start-ms)
+        (run-fx-effects! effects frame frame-record fx-overrides envelope)))
     error))
 
 (defn- emit-cascade-trailers!

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -179,7 +179,24 @@
                                          (:inputs flow)
                                          new-inputs)
                           :frame   frame-id}))
-          (throw e))))))
+          ;; Per rf2-je5p8: wrap the throw in an ex-info carrying the
+          ;; flow-attribution slots `:rf.flow/failed-id` /
+          ;; `:rf.flow/failed-frame`. The router's `run-flows!` catch
+          ;; reads these and stamps `:flow-id` / `:flow` into the
+          ;; substrate record's `:tags` so ops in CLJS production
+          ;; (where `:rf.flow/failed` DCEs) can attribute the cascade-
+          ;; level `:rf.error/flow-eval-exception` to a specific flow.
+          ;; The original exception remains the `:cause` for stack-
+          ;; trace introspection. Symmetric with Spec 013 §Failure
+          ;; semantics rule 4: the per-flow trace fires first with
+          ;; flow attribution; the cascade-level error preserves the
+          ;; same attribution at the substrate boundary.
+          (throw (ex-info (or #?(:clj (.getMessage ^Throwable e)
+                                 :cljs (.-message e))
+                              ":rf.error/flow-eval-exception")
+                          {:rf.flow/failed-id    flow-id
+                           :rf.flow/failed-frame frame-id}
+                          e)))))))
 
 (defn run-flows!
   "Per Spec 013 §Drain integration: walk THIS FRAME'S registered flows

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -185,21 +185,34 @@
      (topo/topo-sort prospective)
      ;; Cycle check passed — commit. The :flow registrar slot keys on
      ;; flow-id only; stamp :frame into the metadata so introspection
-     ;; / hot-reload hooks can read the owning frame.
-     (registrar/register! :flow flow-id
-                          (source-coords/merge-coords
-                            (assoc flow :frame frame-id)))
-     (swap! flows assoc-in [frame-id flow-id] flow)
-     ;; Per Spec 009 §:op-type vocabulary: :rf.flow/registered fires after
-     ;; reg-flow successfully completes (including post-cycle-detection).
-     ;; Tools observe this to track the flow population over hot reloads /
-     ;; toggles. Op-type :flow is the discriminator for the whole flow
-     ;; trace stream (per Spec 009 §:op-type vocabulary, §Flow tracing).
-     (trace/emit! :flow :rf.flow/registered
-                  {:flow-id flow-id
-                   :inputs  (:inputs flow)
-                   :path    (:path flow)
-                   :frame   frame-id})
+     ;; / hot-reload hooks can read the owning frame. `register!`
+     ;; returns `{:was previous :now metadata}` — `:was` is nil on
+     ;; first-time registration, non-nil on hot-reload re-registration.
+     (let [{:keys [was]} (registrar/register!
+                           :flow flow-id
+                           (source-coords/merge-coords
+                             (assoc flow :frame frame-id)))]
+       (swap! flows assoc-in [frame-id flow-id] flow)
+       ;; Per Spec 009 §:op-type vocabulary: :rf.flow/registered fires
+       ;; on FIRST-TIME registration only. On re-registration the
+       ;; cross-kind `:rf.registry/handler-replaced` trace (emitted by
+       ;; `registrar/register!` per Spec 001 §Hot-reload trace surface)
+       ;; carries the hot-reload signal. Pre-rf2-ehxez both traces
+       ;; fired on every re-registration; tools subscribed to both
+       ;; op-types (10x flow panel reads `:flow`; epoch buffer reads
+       ;; everything) double-counted re-registrations in their per-frame
+       ;; reload ledger. Gate to first-time-only so each registration
+       ;; surfaces exactly once on the trace bus — `:rf.flow/registered`
+       ;; for the first-time path, `:rf.registry/handler-replaced` for
+       ;; the hot-reload path. Op-type :flow is the discriminator for
+       ;; the whole flow trace stream (per Spec 009 §:op-type
+       ;; vocabulary, §Flow tracing).
+       (when (nil? was)
+         (trace/emit! :flow :rf.flow/registered
+                      {:flow-id flow-id
+                       :inputs  (:inputs flow)
+                       :path    (:path flow)
+                       :frame   frame-id})))
      flow-id)))
 
 (defn- dissoc-in-safe

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -403,13 +403,26 @@
 ;; inputs would silently keep serving the previous result.
 
 (defn- invalidate-flow-on-replace!
-  [{:keys [kind id]}]
+  [{:keys [kind id now]}]
   (when (= kind :flow)
-    ;; O(1) dissoc — `last-inputs`'s outer key is `flow-id`, so a single
-    ;; `dissoc` drops every per-frame entry for the replaced flow at
-    ;; once. The prior shape `{[frame-id flow-id] inputs}` required an
-    ;; O(N) walk filtering by inner-key match.
-    (swap! last-inputs dissoc id)))
+    ;; Per rf2-jfpf3: Spec 013 §Re-registration scopes the invalidation
+    ;; to `[frame-id flow-id]`, NOT every frame holding the flow id.
+    ;; Pre-fix, a re-registration on frame `:left` wiped
+    ;; `last-inputs[id]` entirely — `:right`'s row for the same id
+    ;; recomputed unnecessarily on its next drain, weakening frame
+    ;; isolation and wasting work under multi-frame setups (per-tenant
+    ;; SSR, pair-tool replays). The registrar replacement-hook payload
+    ;; carries `:now` (the new metadata) with `:frame` stamped at
+    ;; `reg-flow`-time (registry.cljc:189-191); read the frame from
+    ;; there and dissoc only that frame's row. Drop the whole flow-id
+    ;; key when no frame still holds an entry — keeps the map tidy.
+    (let [frame-id (:frame now)]
+      (swap! last-inputs
+             (fn [m]
+               (let [m' (update m id dissoc frame-id)]
+                 (if (empty? (get m' id))
+                   (dissoc m' id)
+                   m')))))))
 
 (defonce ^:private _hot-reload-hook
   ;; `defonce` only needs the side-effect to fire once at namespace

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -418,11 +418,21 @@
   nil)
 
 (defn reset-flows!
-  "Test-only: clear the per-frame flow registry. Pairs with
-  `reset-last-inputs!` for the test-fixture reset bracket. Per
-  rf2-tfw3 — exposed via the late-bind hook table so
-  `re-frame.test-support` can reset state without a static require on
-  this namespace."
+  "Test-only: clear the per-frame flow registry AND the paired
+  dirty-check `last-inputs` map. Per rf2-tfw3 — exposed via the
+  late-bind hook table so `re-frame.test-support` can reset state
+  without a static require on this namespace.
+
+  Per rf2-mb65w: resets BOTH atoms in lockstep. Pre-fix, the function
+  cleared only `flows` and left `last-inputs` standing. A test fixture
+  / pair2 / Causa harness calling `reset-flows!` standalone (the
+  function's name suggests \"reset all flow state\") then re-registered
+  the same flow-id would silently no-op the first evaluation when
+  new-inputs `=`-equalled a leftover entry. The two-atom reset is the
+  single sound invariant — anything calling `reset-flows!` wants flow
+  state cleared, and `last-inputs` is downstream cache for the same
+  registry."
   []
   (reset! flows {})
+  (reset! last-inputs {})
   nil)

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -280,7 +280,17 @@
                           (empty? path)                cur
                           (= 1 (count path))           (dissoc cur (first path))
                           :else                        (dissoc-in-safe cur path))]
-             (adapter/replace-container! container new-db)))
+             ;; Per rf2-2vpac: skip `replace-container!` when the dissoc
+             ;; branch was a no-op (empty-path, missing key, or
+             ;; `dissoc-in-safe` returning `cur` literally on
+             ;; unmaterialised-parent / non-map-intermediate). Otherwise
+             ;; we trigger reactive sub-cache invalidation for a no-op
+             ;; write — cheap-but-needless walk of the sub graph
+             ;; (`identical?` is O(1); the prior unconditional write
+             ;; forced an O(n) sub-graph walk for every clear of an
+             ;; absent slot, common during teardown).
+             (when-not (identical? new-db cur)
+               (adapter/replace-container! container new-db))))
          (swap! flows update frame-id dissoc id)
          ;; `last-inputs` is shaped {flow-id {frame-id inputs}} — clear
          ;; this frame's slot for the cleared flow id, then drop the

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -188,10 +188,24 @@
      ;; / hot-reload hooks can read the owning frame. `register!`
      ;; returns `{:was previous :now metadata}` — `:was` is nil on
      ;; first-time registration, non-nil on hot-reload re-registration.
+     ;; Per rf2-v5ttb: stamp `:handler-fn` so the registrar's
+     ;; `:different-fn?` calculation (registrar.cljc) can tell a real
+     ;; body change from an idempotent reload. The registrar reads
+     ;; `:handler-fn` uniformly across kinds; events / subs / fx all
+     ;; populate it at their registration sites, but flows historically
+     ;; stored the body under `:output` only — so `(not= nil nil)` was
+     ;; the answer for every flow re-registration and `:different-fn?`
+     ;; was always `false` (re-frame-10x's flow panel / Causa / pair2
+     ;; missed every real body swap). The `:output` slot is preserved
+     ;; for the flow-eval site that reads it; the additional
+     ;; `:handler-fn` stamp aligns the cross-kind hot-reload trace
+     ;; surface Spec 001 standardises.
      (let [{:keys [was]} (registrar/register!
                            :flow flow-id
                            (source-coords/merge-coords
-                             (assoc flow :frame frame-id)))]
+                             (assoc flow
+                                    :frame      frame-id
+                                    :handler-fn (:output flow))))]
        (swap! flows assoc-in [frame-id flow-id] flow)
        ;; Per Spec 009 §:op-type vocabulary: :rf.flow/registered fires
        ;; on FIRST-TIME registration only. On re-registration the

--- a/implementation/flows/src/re_frame/flows/topo.cljc
+++ b/implementation/flows/src/re_frame/flows/topo.cljc
@@ -168,7 +168,19 @@
                              rem0)]
               (recur ready' remaining' (conj order n)))
             (if (seq remaining)
+              ;; Per rf2-6mxr2: cycle ex-info carries the standard shape
+              ;; every other flow ex-info uses (`:error` / `:where` /
+              ;; `:recovery` / `:reason`) so tools (Causa, re-frame-10x,
+              ;; late-bind-missing wrappers) can read these slots
+              ;; uniformly across error surfaces. `topo.cljc` is the
+              ;; pure-data module — no `:require`s — so the shape is
+              ;; inlined rather than reaching for `registry.cljc`'s
+              ;; `flow-error` helper.
               (throw (ex-info ":rf.error/flow-cycle"
-                              {:cycle (extract-cycle-path graph
-                                                          (set (keys remaining)))}))
+                              {:error    :rf.error/flow-cycle
+                               :where    'rf/reg-flow
+                               :recovery :no-recovery
+                               :reason   "Cyclic flow dependency — at least one pair of flows' :path / :inputs overlap mutually (per Spec 013 §Dependency rule). The closing-repeat :cycle vector names the offending chain."
+                               :cycle    (extract-cycle-path graph
+                                                             (set (keys remaining)))}))
               order)))))))

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -831,6 +831,47 @@
     (is (= 700 (:result (rf/get-frame-db :right)))
         "right's :compute still active — 7 * 100 = 700")))
 
+;; ---------------------------------------------------------------------------
+;; 9b. :flow registrar slot carries last-registered frame's metadata
+;;     (Spec 013 §Frame-scoping line 105) — rf2-twi6k.
+;;
+;; Spec 013 §Frame-scoping line 105 states: "the registrar slot carries
+;; the most-recently-registered frame's flow-map with `:frame frame-id`
+;; stamped into the metadata". The destroy-frame teardown tests
+;; (flows_destroy_frame_teardown_test.clj) exercise registrar prune
+;; behaviour, but the "last-registration-wins" invariant for the
+;; metadata's `:frame` slot was never pinned. A regression that flipped
+;; the registrar-write order (e.g. only-stamping-on-first-registration)
+;; would silently break Causa / re-frame-10x's per-flow frame
+;; attribution.
+;; ---------------------------------------------------------------------------
+
+(deftest registrar-slot-carries-last-registered-frame-metadata
+  (testing "the :flow registrar slot's metadata reflects the most-recently-registered frame (Spec 013 §Frame-scoping line 105)"
+    (rf/reg-frame :left  {:doc "left frame"})
+    (rf/reg-frame :right {:doc "right frame"})
+    ;; First registration against :left — metadata's :frame should be :left.
+    (rf/reg-flow {:id     :shared
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 (or n 0)))
+                  :path   [:result]}
+                 {:frame :left})
+    (is (= :left (:frame (registrar/lookup :flow :shared)))
+        ":left's metadata wins after first registration (the slot is empty before, so first-write wins)")
+    ;; Re-register against :right — metadata's :frame must now be :right.
+    (rf/reg-flow {:id     :shared
+                  :inputs [[:n]]
+                  :output (fn [n] (* 100 (or n 0)))
+                  :path   [:result]}
+                 {:frame :right})
+    (is (= :right (:frame (registrar/lookup :flow :shared)))
+        ":right's metadata wins after second registration — last-registration-wins per Spec 013 line 105")
+    ;; Sanity: both frames still hold the flow in their per-frame registry.
+    (is (contains? (get @flows/flows :left)  :shared)
+        ":left still carries :shared in its per-frame registry")
+    (is (contains? (get @flows/flows :right) :shared)
+        ":right carries :shared in its per-frame registry too")))
+
 (deftest flow-hot-reload-invalidates-last-inputs
   (testing "re-registering a flow re-evaluates even when inputs are unchanged"
     (rf/reg-event-db :init   (fn [_ _] {:n 5}))

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -22,7 +22,8 @@
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace]))
 
 ;; ---- per-test reset -------------------------------------------------------
 ;;
@@ -922,6 +923,57 @@
         ":left still carries :shared in its per-frame registry")
     (is (contains? (get @flows/flows :right) :shared)
         ":right carries :shared in its per-frame registry too")))
+
+;; ---------------------------------------------------------------------------
+;; 9c. :rf.registry/handler-replaced :different-fn? reflects real body
+;;     swaps for :flow re-registrations (rf2-v5ttb).
+;;
+;; Pre-fix the registrar's `:different-fn?` calculation compared
+;; `(:handler-fn previous)` against `(:handler-fn metadata)` but the
+;; flows registration site stored the body under `:output` only — so
+;; both reads were nil for every flow re-registration and
+;; `:different-fn?` was always `false`. Tools (re-frame-10x's flow
+;; panel, Causa, pair2) branching on `:different-fn? true` missed every
+;; real flow-body change. Fix: `reg-flow` now stamps `:handler-fn`
+;; alongside `:output` so the cross-kind registrar trace surface Spec
+;; 001 standardises works for flows too.
+;; ---------------------------------------------------------------------------
+
+(deftest flow-hot-reload-different-fn?-reflects-real-body-swap
+  (testing "Per rf2-v5ttb: :rf.registry/handler-replaced :different-fn? is true on a real :output swap, false on identity reload"
+    (let [captured (atom [])]
+      (re-frame.trace/register-trace-cb!
+        ::handler-replaced-recorder
+        (fn [ev]
+          (when (= :rf.registry/handler-replaced (:operation ev))
+            (swap! captured conj ev))))
+      (try
+        (let [body-v1 (fn [n] (* 2 n))]
+          (rf/reg-flow {:id     :double
+                        :inputs [[:n]]
+                        :output body-v1
+                        :path   [:doubled]})
+          ;; Idempotent re-registration — same fn identity. :different-fn? must be false.
+          (rf/reg-flow {:id     :double
+                        :inputs [[:n]]
+                        :output body-v1
+                        :path   [:doubled]})
+          (is (= 1 (count @captured))
+              "one :rf.registry/handler-replaced fired for the second registration")
+          (is (false? (-> @captured first :tags :different-fn?))
+              ":different-fn? false on identity re-registration (idempotent reload)")
+          ;; Now re-register with a NEW fn — :different-fn? must be true.
+          (reset! captured [])
+          (rf/reg-flow {:id     :double
+                        :inputs [[:n]]
+                        :output (fn [n] (* 100 n))
+                        :path   [:doubled]})
+          (is (= 1 (count @captured))
+              "one :rf.registry/handler-replaced fired for the body-swap registration")
+          (is (true? (-> @captured first :tags :different-fn?))
+              ":different-fn? true on real body change (rf2-v5ttb fix)"))
+        (finally
+          (re-frame.trace/remove-trace-cb! ::handler-replaced-recorder))))))
 
 (deftest flow-hot-reload-invalidates-last-inputs
   (testing "re-registering a flow re-evaluates even when inputs are unchanged"

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -673,6 +673,57 @@
     (is (nil? (registrar/lookup :flow :one)))
     (is (nil? (registrar/lookup :flow :two)))))
 
+(deftest reset-flows-clears-both-flows-and-last-inputs
+  ;; Per rf2-mb65w. `reset-flows!` must reset BOTH the flow registry
+  ;; AND the dirty-check `last-inputs` map. Pre-fix it cleared only
+  ;; `flows`; a fixture / harness calling `reset-flows!` standalone
+  ;; then re-registering the same flow-id would silently no-op the
+  ;; first evaluation when new-inputs =-equalled a leftover entry.
+  (testing "reset-flows! drops both flow registry AND last-inputs in lockstep"
+    (rf/reg-event-db :init (fn [_ _] {:n 5}))
+    (rf/reg-flow {:id     :double
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 n))
+                  :path   [:doubled]})
+    (rf/dispatch-sync [:init])
+    (is (= 10 (:doubled (rf/get-frame-db :rf/default)))
+        "flow evaluated; last-inputs row populated for [:double :rf/default]")
+    (let [li-var (resolve 're-frame.flows/last-inputs)]
+      (is (some? (get-in @(deref li-var) [:double :rf/default]))
+          "last-inputs has the dirty-check entry before reset")
+      (flows/reset-flows!)
+      (is (empty? @flows/flows)
+          "flow registry is empty after reset-flows!")
+      (is (empty? @(deref li-var))
+          "last-inputs is ALSO empty after reset-flows! (rf2-mb65w)"))))
+
+(deftest reset-flows-allows-re-registration-without-stale-skip
+  ;; The footgun: re-register the same flow id with the same inputs
+  ;; after a `reset-flows!`. Pre-fix, the stale `last-inputs` entry
+  ;; would =-equal new inputs and the first drain would silently emit
+  ;; `:rf.flow/skip` instead of `:rf.flow/computed` — the new body
+  ;; never ran.
+  (testing "after reset-flows! the re-registered flow re-evaluates on next drain"
+    (let [calls (atom 0)]
+      (rf/reg-event-db :init (fn [_ _] {:n 5}))
+      ;; First registration + drain — populates last-inputs.
+      (rf/reg-flow {:id     :double
+                    :inputs [[:n]]
+                    :output (fn [n] (swap! calls inc) (* 2 n))
+                    :path   [:doubled]})
+      (rf/dispatch-sync [:init])
+      (is (= 1 @calls) "flow body ran on the first drain")
+      ;; Reset BOTH atoms via the public reset-flows! — then re-register
+      ;; the IDENTICAL flow against the IDENTICAL inputs.
+      (flows/reset-flows!)
+      (rf/reg-flow {:id     :double
+                    :inputs [[:n]]
+                    :output (fn [n] (swap! calls inc) (* 2 n))
+                    :path   [:doubled]})
+      (rf/dispatch-sync [:init])
+      (is (= 2 @calls)
+          "after reset-flows! the freshly-registered flow evaluates again — last-inputs was cleared so no stale skip"))))
+
 (deftest reset-flows-atom-clears-per-frame-state
   (testing "resetting flows/flows clears the per-frame registry; reg-flow repopulates fresh"
     (rf/reg-flow {:id :one :inputs [[:a]] :output identity :path [:slots :one]})

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -884,6 +884,55 @@
         "right's :compute still active — 7 * 100 = 700")))
 
 ;; ---------------------------------------------------------------------------
+;; 9a. invalidate-flow-on-replace! is frame-scoped (rf2-jfpf3 regression)
+;;
+;; Spec 013 §Re-registration scopes the invalidation to
+;; `[frame-id flow-id]`. Pre-fix, the replacement hook wiped every
+;; frame's row under the flow id. A re-registration on frame `:left`
+;; cleared `:right`'s last-inputs row too, causing unnecessary
+;; recompute on `:right`'s next drain and weakening frame isolation.
+;; ---------------------------------------------------------------------------
+
+(deftest hot-reload-on-one-frame-does-not-invalidate-sibling-frames-last-inputs
+  (testing "Per rf2-jfpf3: re-register :shared on :left; :right's last-inputs row survives"
+    (rf/reg-frame :left  {:doc "left frame"})
+    (rf/reg-frame :right {:doc "right frame"})
+    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
+    ;; Register :shared against both frames with the same shape.
+    (rf/reg-flow {:id     :shared
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 (or n 0)))
+                  :path   [:result]}
+                 {:frame :left})
+    (rf/reg-flow {:id     :shared
+                  :inputs [[:n]]
+                  :output (fn [n] (* 100 (or n 0)))
+                  :path   [:result]}
+                 {:frame :right})
+    ;; Drive a drain on each frame so both have last-inputs rows.
+    (rf/dispatch-sync [:seed 5] {:frame :left})
+    (rf/dispatch-sync [:seed 5] {:frame :right})
+    (let [li-var (resolve 're-frame.flows/last-inputs)
+          li     (deref li-var)]
+      (is (some? (get-in @li [:shared :left]))
+          "before re-registration: :left's last-inputs row is populated")
+      (is (some? (get-in @li [:shared :right]))
+          "before re-registration: :right's last-inputs row is populated"))
+    ;; Re-register :shared on :left with a NEW body — should invalidate
+    ;; :left's row ONLY.
+    (rf/reg-flow {:id     :shared
+                  :inputs [[:n]]
+                  :output (fn [n] (* 7 (or n 0)))
+                  :path   [:result]}
+                 {:frame :left})
+    (let [li-var (resolve 're-frame.flows/last-inputs)
+          li     (deref li-var)]
+      (is (nil? (get-in @li [:shared :left]))
+          "after re-registration on :left: :left's last-inputs row was dropped (re-evaluate on next drain)")
+      (is (some? (get-in @li [:shared :right]))
+          ":right's last-inputs row is PRESERVED — re-registration on :left did not invalidate :right (rf2-jfpf3)"))))
+
+;; ---------------------------------------------------------------------------
 ;; 9b. :flow registrar slot carries last-registered frame's metadata
 ;;     (Spec 013 §Frame-scoping line 105) — rf2-twi6k.
 ;;

--- a/implementation/flows/test/re_frame/flows_topo_test.clj
+++ b/implementation/flows/test/re_frame/flows_topo_test.clj
@@ -78,15 +78,28 @@
            (topo/topo-sort {:a {:id :a :inputs [[:n]] :output identity :path [:a]}})))))
 
 (deftest topo-sort-detects-cycle
-  (testing "two flows forming a cycle raise :rf.error/flow-cycle with :cycle in ex-data"
+  (testing "two flows forming a cycle raise :rf.error/flow-cycle with the standard error shape (rf2-6mxr2)"
     (let [flow-map {:a {:id :a :inputs [[:b]] :output identity :path [:a]}
                     :b {:id :b :inputs [[:a]] :output identity :path [:b]}}
           thrown   (try (topo/topo-sort flow-map)
                         nil
                         (catch clojure.lang.ExceptionInfo e e))]
       (is (some? thrown) "cycle raises")
+      (is (= ":rf.error/flow-cycle" (.getMessage ^Throwable thrown))
+          "ex-info message is the documented category")
       (let [data (ex-data thrown)]
+        (is (= :rf.error/flow-cycle (:error data))
+            "ex-data carries :error :rf.error/flow-cycle (standard shape — rf2-6mxr2)")
+        (is (= 'rf/reg-flow (:where data))
+            "ex-data carries :where 'rf/reg-flow — points at the user-facing call site")
+        (is (= :no-recovery (:recovery data))
+            "ex-data carries :recovery :no-recovery")
+        (is (string? (:reason data))
+            "ex-data carries :reason as a string diagnostic")
         (is (vector? (:cycle data))
             "ex-data carries :cycle as a vector")
         (is (>= (count (:cycle data)) 2)
-            "the cycle vector closes (at least two entries including the closing repeat)")))))
+            "the cycle vector closes (at least two entries including the closing repeat)")
+        (is (= #{:error :where :recovery :reason :cycle}
+               (set (keys data)))
+            "ex-data carries exactly the standard slots + :cycle (no extras, no missing)")))))

--- a/implementation/flows/test/re_frame/flows_topo_test.clj
+++ b/implementation/flows/test/re_frame/flows_topo_test.clj
@@ -1,0 +1,92 @@
+(ns re-frame.flows-topo-test
+  "JVM coverage for the pure-data topo module (flows/topo.cljc) —
+  algorithm-level invariants that the registration / drain tests
+  exercise only indirectly.
+
+  Per rf2-oozsq: pin the defensive throw in `extract-cycle-path` (the
+  closing-repeat cycle-path extractor). The branch is unreachable by
+  construction — by Kahn's algorithm every stuck node has at least one
+  stuck dep, so the next-dep lookup never returns nil — but the throw
+  is load-bearing defence: a closing-repeat vector built from a dead
+  end would lie to tools (Causa flow panel, re-frame-10x cycle
+  visualisation) about the offending chain. Pin the throw + ex-data
+  shape so a future refactor cannot silently break the invariant.
+
+  Per audit `ai/findings/flows-slice-audit-2026-05-15.md` §T2 (prior
+  round) + audit-r2 carried forward."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.flows.topo :as topo]))
+
+;; ---------------------------------------------------------------------------
+;; extract-cycle-path defensive throw (rf2-oozsq)
+;;
+;; Construct a graph + remaining-set whose entries violate Kahn's stuck-
+;; node invariant: a stuck node whose graph entry has no edges into the
+;; stuck-set. With `:a` in `remaining` and `(graph :a) = #{}`, the
+;; `(filter remaining (graph node))` cull yields `()` → next-dep is nil
+;; → the defensive throw fires.
+;;
+;; The throw site is private; reach it via `#'` resolution. The branch
+;; is unreachable from `topo-sort`'s public surface (Kahn's algorithm
+;; would never produce this stuck-set shape) — this test exercises the
+;; defence directly so a regression that silently dropped the throw and
+;; returned a malformed cycle path surfaces here.
+;; ---------------------------------------------------------------------------
+
+(deftest extract-cycle-path-defends-against-dead-end
+  (testing "extract-cycle-path throws :rf.error/flow-cycle-extract-invariant on a stuck node with no stuck dep"
+    ;; `:a` is in `remaining` but `(graph :a)` is empty — no edge to
+    ;; follow into the stuck-set. By Kahn's algorithm this combination
+    ;; is impossible; the defence catches a regression that allowed
+    ;; the impossible state to reach extract-cycle-path.
+    (let [graph     {:a #{}}
+          remaining #{:a}
+          thrown    (try
+                      (#'topo/extract-cycle-path graph remaining)
+                      nil
+                      (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? thrown)
+          "extract-cycle-path throws when a stuck node has no stuck dep to follow")
+      (is (= ":rf.error/flow-cycle-extract-invariant"
+             (.getMessage ^Throwable thrown))
+          "the documented invariant id appears in the message")
+      (let [data (ex-data thrown)]
+        (is (= ":rf.error/flow-cycle-extract-invariant" (:reason data))
+            "ex-data carries :reason naming the invariant")
+        (is (= :no-recovery (:recovery data))
+            "ex-data carries :recovery :no-recovery — the dead-end means topo state is internally inconsistent")
+        (is (= :a (:node data))
+            "ex-data names the offending node")
+        (is (vector? (:stack data))
+            "ex-data carries the DFS stack at the moment of the throw")
+        (is (set? (:seen data))
+            "ex-data carries the seen-set at the moment of the throw")
+        (is (= remaining (:remaining data))
+            "ex-data carries the remaining stuck-set at the moment of the throw")))))
+
+;; ---------------------------------------------------------------------------
+;; topo-sort smoke (positive cases) — kept tiny; the registration and
+;; drain tests cover the integrated behaviour. This file is the topo
+;; module's own algorithm-level gate.
+;; ---------------------------------------------------------------------------
+
+(deftest topo-sort-empty-and-singleton
+  (testing "empty flow-map yields empty order"
+    (is (= [] (topo/topo-sort {}))))
+  (testing "single flow yields itself in order"
+    (is (= [:a]
+           (topo/topo-sort {:a {:id :a :inputs [[:n]] :output identity :path [:a]}})))))
+
+(deftest topo-sort-detects-cycle
+  (testing "two flows forming a cycle raise :rf.error/flow-cycle with :cycle in ex-data"
+    (let [flow-map {:a {:id :a :inputs [[:b]] :output identity :path [:a]}
+                    :b {:id :b :inputs [[:a]] :output identity :path [:b]}}
+          thrown   (try (topo/topo-sort flow-map)
+                        nil
+                        (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? thrown) "cycle raises")
+      (let [data (ex-data thrown)]
+        (is (vector? (:cycle data))
+            "ex-data carries :cycle as a vector")
+        (is (>= (count (:cycle data)) 2)
+            "the cycle vector closes (at least two entries including the closing repeat)")))))

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -340,7 +340,13 @@
           (is (= :init       (:event-id tags)))
           (is (= [:init]     (:event tags)))
           (is (= :rf/default (:frame tags)))
-          (is (some? (:exception tags))))))))
+          (is (some? (:exception tags)))
+          ;; Per rf2-je5p8: :flow-id is stamped into :tags from the
+          ;; ex-info wrapping in evaluate-flow!'s catch. This is the
+          ;; ONLY per-flow attribution that survives CLJS prod
+          ;; elision — `:rf.flow/failed` trace is DCE'd.
+          (is (= :boom (:flow-id tags))
+              ":flow-id is propagated from evaluate-flow!'s ex-info wrap (rf2-je5p8)"))))))
 
 (deftest flow-eval-exception-trace-and-substrate-fire-together
   (testing "Per rf2-hrt5c: the trace path is NOT replaced by the

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -656,6 +656,104 @@
         ":A's write landed a third time (7 → 11 → 110)")
     (is (not (contains? (rf/get-frame-db :rf/default) :b-out)))))
 
+;; ---------------------------------------------------------------------------
+;; 7d. :fx must not run after a flow throws (rf2-fslx0).
+;;
+;; Spec 013 §Failure semantics rule 3 + §rationale (line 202) state the
+;; cascade halts at a failing flow — downstream `:fx` does NOT run on
+;; the failing drain because the rationale for halting is "downstream
+;; `:fx` and tooling rely on to skip work that depended on a now-
+;; invalid derived state."
+;;
+;; Pre-fix, `router.run-flows!` caught + swallowed the throw and
+;; returned nil; control flowed on to `run-fx-effects!` regardless.
+;; A handler emitting `[:dispatch [:react-to-area-change]]` from `:fx`
+;; fired the child dispatch even when the source flow threw — child
+;; handler ran on stale derived state; side effects (HTTP, navigation,
+;; analytics) escaped.
+;;
+;; Post-fix: `run-flows!` returns truthy on success / falsey on flow
+;; throw. `commit-and-flow!` gates `run-fx-effects!` on the return.
+;; ---------------------------------------------------------------------------
+
+(deftest fx-does-not-run-after-flow-throws
+  (testing "Per rf2-fslx0: when a flow's :output throws, the handler's :fx is skipped"
+    (let [child-fired? (atom false)]
+      (rf/reg-event-db :init   (fn [_ _] {:n 1}))
+      (rf/reg-event-db :after-throw
+                       (fn [db _] (reset! child-fired? true) db))
+      (rf/reg-event-fx :run-with-throwing-flow
+                       (fn [_ _]
+                         {:db {:n 2}
+                          :fx [[:dispatch [:after-throw]]]}))
+      ;; Register a flow that throws. The flow runs AFTER :db commits
+      ;; and BEFORE :fx walks (per Spec 002 §`:fx` ordering); a throw
+      ;; halts the cascade so :after-throw must NOT dispatch.
+      (rf/reg-flow {:id     :boom
+                    :inputs [[:n]]
+                    :output (fn [_] (throw (ex-info "boom" {:why :test})))
+                    :path   [:doomed]})
+      ;; First drain: :init seeds :n; the flow throws but the cascade
+      ;; halts before any of :init's :fx would have run (and :init has
+      ;; none anyway). Drain the dispatch the test is actually
+      ;; interested in.
+      (rf/dispatch-sync [:init])
+      (reset! child-fired? false)
+      (rf/dispatch-sync [:run-with-throwing-flow])
+      (is (false? @child-fired?)
+          "`:after-throw` did NOT dispatch — :fx was skipped because the flow threw (rf2-fslx0)")
+      ;; :db commit still happened (rule 1 of Spec 013 §Failure
+      ;; semantics: prior successful writes are preserved); only :fx
+      ;; was skipped.
+      (is (= 2 (:n (rf/get-frame-db :rf/default)))
+          ":db commit landed (rule 1) — only the post-commit :fx walk was skipped"))))
+
+(deftest fx-after-successful-flow-still-runs
+  (testing "Per rf2-fslx0: when flows succeed, :fx still walks normally (negative control)"
+    (let [child-fired? (atom false)]
+      (rf/reg-event-db :init (fn [_ _] {:n 1}))
+      (rf/reg-event-db :after-ok
+                       (fn [db _] (reset! child-fired? true) db))
+      (rf/reg-event-fx :run-with-ok-flow
+                       (fn [_ _]
+                         {:db {:n 2}
+                          :fx [[:dispatch [:after-ok]]]}))
+      (rf/reg-flow {:id     :double
+                    :inputs [[:n]]
+                    :output (fn [n] (* 2 n))
+                    :path   [:doubled]})
+      (rf/dispatch-sync [:init])
+      (reset! child-fired? false)
+      (rf/dispatch-sync [:run-with-ok-flow])
+      (is (true? @child-fired?)
+          "`:after-ok` DID dispatch — :fx walked because the flow succeeded")
+      (is (= 4 (:doubled (rf/get-frame-db :rf/default)))
+          "flow output landed in app-db (sanity)"))))
+
+(deftest fx-skip-on-flow-throw-still-emits-error-substrate
+  (testing "Per rf2-fslx0 + rf2-hrt5c: when :fx is skipped on flow throw, the error substrate still fires"
+    ;; Pin that the cascade-halt does NOT short-circuit the error fan-
+    ;; out — ops monitors still see the failure record even though :fx
+    ;; was skipped.
+    (let [seen (atom [])]
+      (rf/register-error-emit-listener!
+        :test/fx-skip-recorder
+        (fn [record] (swap! seen conj record)))
+      (rf/reg-event-fx :run-with-throwing-flow
+                       (fn [_ _]
+                         {:db {:n 2}
+                          :fx [[:dispatch [:must-not-fire]]]}))
+      (rf/reg-event-db :must-not-fire (fn [db _] db))
+      (rf/reg-flow {:id     :boom
+                    :inputs [[:n]]
+                    :output (fn [_] (throw (ex-info "boom" {})))
+                    :path   [:doomed]})
+      (rf/dispatch-sync [:run-with-throwing-flow])
+      (is (>= (count @seen) 1)
+          "error-emit substrate fired — the cascade-halt does not silence the error fan-out")
+      (is (some #(= :rf.error/flow-eval-exception (:error %)) @seen)
+          "at least one substrate record carries :error :rf.error/flow-eval-exception"))))
+
 (deftest computed-trace-elision-no-op-when-no-declaration
   (testing "absent any declaration, :input-values and :result pass through unchanged"
     ;; Belt-and-braces against an over-eager rewrite — the walker must be

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -348,6 +348,62 @@
           (is (= :boom (:flow-id tags))
               ":flow-id is propagated from evaluate-flow!'s ex-info wrap (rf2-je5p8)"))))))
 
+;; ---------------------------------------------------------------------------
+;; 5c. :rf.fx/reg-flow cycle detection routes through error-emit (rf2-eb4lp)
+;;
+;; Pre-fix, a cycle introduced through `:rf.fx/reg-flow` from a handler's
+;; `:fx` raised `:rf.error/flow-cycle` synchronously inside the reserved-
+;; fx body, the throw bubbled uncaught up the drain stack, and the drain
+;; emergency-release re-threw. The typed `:rf.error/flow-cycle` ex-data
+;; (carrying the `:cycle` closing-repeat vector tools render) never
+;; reached the error-emit substrate. In CLJS production the runtime
+;; cycle was silently lost.
+;;
+;; Post-fix: `handle-one-fx`'s reserved-fx branch catches
+;; `:rf.error/flow-cycle` and routes through `error-emit/dispatch-on-
+;; error!` with the `:cycle` ex-data preserved, plus the dev-side trace
+;; emit. Mirrors the rf2-hrt5c handler-exception and rf2-fslx0 flow-eval
+;; routings.
+;; ---------------------------------------------------------------------------
+
+(deftest fx-reg-flow-cycle-routes-through-error-emit-substrate
+  (testing "Per rf2-eb4lp: a :rf.fx/reg-flow that closes a cycle fires
+            a corpus-wide error-emit listener record with `:error
+            :rf.error/flow-cycle` — fan-out runs through
+            `error-emit/dispatch-on-error!`, mirroring the
+            handler-exception / flow-eval-exception paths."
+    (let [seen (atom [])]
+      (rf/register-error-emit-listener!
+        :test/fx-reg-flow-cycle-recorder
+        (fn [record] (swap! seen conj record)))
+      ;; Register flow :a that depends on :b's path.
+      (rf/reg-flow {:id     :a
+                    :inputs [[:b-out]]
+                    :output identity
+                    :path   [:a-out]})
+      ;; Now dispatch an event whose :fx registers :b such that
+      ;; :b's :inputs overlap :a's :path → cycle.
+      (rf/reg-event-fx :introduce-cycle
+                       (fn [_ _]
+                         {:fx [[:rf.fx/reg-flow
+                                {:id     :b
+                                 :inputs [[:a-out]]
+                                 :output identity
+                                 :path   [:b-out]}]]}))
+      (rf/dispatch-sync [:introduce-cycle])
+      (is (= 1 (count @seen))
+          "exactly one substrate record fired for one :rf.fx/reg-flow cycle")
+      (let [r (first @seen)]
+        (is (= :rf.error/flow-cycle (:error r))
+            ":error names the typed flow-cycle path (NOT a generic fx-handler-exception)")
+        (is (some? (:exception r))
+            ":exception is the thrown ex-info carrying the cycle data")
+        (let [d (ex-data (:exception r))]
+          (is (= :rf.error/flow-cycle (:error d))
+              "exception ex-data carries :error :rf.error/flow-cycle")
+          (is (vector? (:cycle d))
+              "exception ex-data carries :cycle — the closing-repeat chain tools render"))))))
+
 (deftest flow-eval-exception-trace-and-substrate-fire-together
   (testing "Per rf2-hrt5c: the trace path is NOT replaced by the
             substrate routing — both fire from one normative

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -83,6 +83,40 @@
           (is (= [:rect :area]      (:path tags))        ":path in tags")
           (is (= :rf/default        (:frame tags))       ":frame in tags"))))))
 
+(deftest reg-flow-registered-fires-first-time-only
+  (testing "Per rf2-ehxez: :rf.flow/registered fires only on first-time
+            registration. On re-registration the cross-kind
+            `:rf.registry/handler-replaced` trace (emitted by
+            `registrar/register!` per Spec 001 §Hot-reload trace
+            surface) is the hot-reload signal — both traces no longer
+            double-emit on the same re-registration."
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* (or w 0) (or h 0)))
+                  :path   [:rect :area]})
+    (is (= 1 (count (by-op :rf.flow/registered)))
+        "first-time registration fires :rf.flow/registered once")
+    (reset! *captured* [])
+    ;; Re-register with the SAME shape — :rf.flow/registered must NOT fire.
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* (or w 0) (or h 0)))
+                  :path   [:rect :area]})
+    (is (zero? (count (by-op :rf.flow/registered)))
+        "re-registration does NOT fire :rf.flow/registered — hot-reload signal rides on :rf.registry/handler-replaced"))
+  (testing "re-registration with a NEW :output also does not double-emit"
+    (rf/reg-flow {:id     :area2
+                  :inputs [[:w]]
+                  :output (fn [w] w)
+                  :path   [:rect :area2]})
+    (reset! *captured* [])
+    (rf/reg-flow {:id     :area2
+                  :inputs [[:w]]
+                  :output (fn [w] (* 2 w))
+                  :path   [:rect :area2]})
+    (is (zero? (count (by-op :rf.flow/registered)))
+        "real body change still does not re-emit :rf.flow/registered — only first-time")))
+
 (deftest reg-flow-cycle-does-NOT-emit-registered
   (testing "when reg-flow throws cycle, no :rf.flow/registered fires for the rejected flow"
     (rf/reg-flow {:id :a :inputs [[:b]] :output identity :path [:a]})

--- a/implementation/flows/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/flows/test/re_frame/late_bind_missing_test.clj
@@ -20,12 +20,15 @@
   prose at the call sites in `re-frame.core`."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
             ;; Loading flows registers its late-bind hooks. The
             ;; `with-hook-as-nil` helper below re-establishes the absent
             ;; state by flipping the hook value at runtime; restoration
             ;; in `finally` keeps cross-test isolation intact.
-            [re-frame.flows]))
+            [re-frame.flows]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
 
 (defn- with-hook-as-nil
   "Run `f` with the named late-bind hook set to nil. Restores the
@@ -83,3 +86,83 @@
                 "ex-data carries :where = 'rf/reg-flow")
             (is (= :no-recovery (:recovery data))
                 "ex-data carries :recovery = :no-recovery")))))))
+
+;; ---------------------------------------------------------------------------
+;; Framework-internal hooks (rf2-g9t87)
+;;
+;; The four hooks below are framework-internal: their consumers are
+;; `re-frame.router/run-flows!` (post-commit drain step), `re-frame.frame/
+;; destroy-frame!` (per-frame teardown cascade), and `re-frame.test-
+;; support/reset-runtime-fixture` (test-fixture reset bracket). None of
+;; these surface to user-facing `rf/...` fns, so the absent-artefact
+;; semantics is "graceful no-op", not "raise a typed ex-info".
+;;
+;; The contract being pinned: each consumer reads the hook through
+;; `late-bind/get-fn` and short-circuits when the lookup returns nil.
+;; A regression that called the nil hook unconditionally would surface
+;; here as a NullPointerException; the assertion shape `(is (nil? ...))`
+;; / `(is (do ... :ok))` confirms the no-op path.
+;; ---------------------------------------------------------------------------
+
+(deftest run-flows!-no-ops-when-flows-artefact-missing
+  (testing "router.run-flows! returns nil without throwing when :flows/run-flows! hook is nil"
+    ;; Consumer is `re-frame.router/run-flows!` (private; reach via the
+    ;; user-visible drain). Drive a dispatch through the router — the
+    ;; absent-flows-artefact branch is the steady-state for apps that
+    ;; never registered any flows. With the hook nil, the post-commit
+    ;; flow walker collapses to a no-op and the drain completes.
+    (with-hook-as-nil :flows/run-flows!
+      (fn []
+        (rf/init! plain-atom/adapter)
+        (rf/reg-event-db :flows-absent/init (fn [_ _] {:probe :ok}))
+        (is (do (rf/dispatch-sync [:flows-absent/init]) :ok)
+            "dispatch completes without throwing when the run-flows! hook is absent")
+        (is (= {:probe :ok} (rf/get-frame-db :rf/default))
+            ":db commit lands even though the post-commit flow walker is a no-op")))))
+
+(deftest reset-last-inputs!-no-ops-when-flows-artefact-missing
+  (testing "test-support's reset-runtime fixture no-ops when :flows/reset-last-inputs! hook is nil"
+    ;; Consumer is `re-frame.test-support`'s reset-hook-table (row for
+    ;; `:flows/reset-last-inputs!`). The driver `run-reset-hooks!` walks
+    ;; the table and short-circuits rows whose hook is unregistered.
+    ;; With the hook nil, the fixture bracket fires its full cascade
+    ;; (snap/restore registrar, dispose adapter, reinstall, run test-fn)
+    ;; without touching the absent-flows machinery.
+    (with-hook-as-nil :flows/reset-last-inputs!
+      (fn []
+        (let [ran? (atom false)
+              fix  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter})]
+          (fix (fn [] (reset! ran? true)))
+          (is @ran? "fixture invoked the test-fn without throwing on the absent hook"))))))
+
+(deftest reset-flows!-no-ops-when-flows-artefact-missing
+  (testing "test-support's reset-runtime fixture no-ops when :flows/reset-flows! hook is nil"
+    ;; Consumer is `re-frame.test-support`'s reset-hook-table (row for
+    ;; `:flows/reset-flows!`) plus the `finally` branch in
+    ;; `reset-runtime-fixture` that calls the same hook. Both paths
+    ;; reach the hook through `late-bind/get-fn` and short-circuit on
+    ;; nil — proven by driving a full fixture cycle with the hook
+    ;; cleared.
+    (with-hook-as-nil :flows/reset-flows!
+      (fn []
+        (let [ran? (atom false)
+              fix  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter})]
+          (fix (fn [] (reset! ran? true)))
+          (is @ran? "fixture invoked the test-fn without throwing on the absent hook"))))))
+
+(deftest teardown-on-frame-destroy!-no-ops-when-flows-artefact-missing
+  (testing "frame/destroy-frame! completes without throwing when :flows/teardown-on-frame-destroy! hook is nil"
+    ;; Consumer is `frame/destroy-frame!`'s `safe-call-hook!` invocation
+    ;; for `:flows/teardown-on-frame-destroy!`. The hook is reached via
+    ;; the same late-bind lookup; on nil, the safe-call wrapper
+    ;; short-circuits.
+    (with-hook-as-nil :flows/teardown-on-frame-destroy!
+      (fn []
+        (rf/init! plain-atom/adapter)
+        (rf/reg-frame :late-bind-missing/scratch {:doc "scratch frame for teardown probe"})
+        (is (some? (get @frame/frames :late-bind-missing/scratch))
+            "frame registered")
+        (is (do (frame/destroy-frame! :late-bind-missing/scratch) :ok)
+            "destroy-frame! completes without throwing when the flows-teardown hook is absent")
+        (is (nil? (get @frame/frames :late-bind-missing/scratch))
+            "frame was destroyed despite the absent teardown hook")))))


### PR DESCRIPTION
## Summary

Cluster of 12 beads from the rf2-o3hok-r2 flows audit, sequenced smallest-and-safest → biggest correctness. Hot-zone-free surface: `implementation/flows/` + selected touches in `implementation/core/{router,fx}.cljc`.

Audit findings: [ai/findings/flows-slice-audit-2026-05-15-r2.md](../tree/main/ai/findings/flows-slice-audit-2026-05-15-r2.md) (local-only).

## Commits (in order)

1. `310adbb9` **test(flows): extend late-bind-missing tests for all six published hooks (rf2-g9t87)** — pin graceful-no-op contract for the four framework-internal hooks not previously covered.
2. `6f5665f9` **test(flows): pin :flow registrar slot carries last-registered frame metadata (rf2-twi6k)** — Spec 013 §Frame-scoping line 105.
3. `a566026f` **test(flows): pin extract-cycle-path defensive throw (rf2-oozsq)** — pure-data topo invariant under Kahn's stuck-set walk.
4. `58e613e4` **refactor(flows): gate :rf.flow/registered to first-time-only (rf2-ehxez)** — conservative path; cross-kind `:rf.registry/handler-replaced` carries the re-registration signal. Filed under decision but the bead itself recommends this gate; richer designs go to a follow-on bead.
5. `feea0d4a` **fix(flows): :rf.error/flow-cycle ex-info uses standard error shape (rf2-6mxr2)** — `:error / :where / :recovery / :reason / :cycle` slots aligned with every other flow ex-info.
6. `25355f33` **perf(flows): clear-flow skips replace-container! on no-op dissoc (rf2-2vpac)** — `identical?` guard around the reactive-cache-touching write.
7. `7cf9e1f2` **fix(flows): reset-flows! also clears last-inputs (rf2-mb65w)** — single-atom reset was a footgun; resets both in lockstep.
8. `c9b456c0` **feat(flows): propagate :flow-id onto :rf.error/flow-eval-exception substrate record (rf2-je5p8)** — cross-surface (`flows/flows.cljc` + `core/router.cljc`); per-flow attribution survives CLJS prod elision.
9. `371bb1d4` **fix(flows): :rf.fx/reg-flow cycle routes through error-emit substrate (rf2-eb4lp)** — preserves `:cycle` ex-data; reaches error-emit via the `:error-emit/dispatch-on-error` late-bind hook to avoid a static-require load cycle in `core/fx.cljc`.
10. `6ddccb30` **fix(flows): :rf.registry/handler-replaced :different-fn? reflects body swaps (rf2-v5ttb)** — `reg-flow` now stamps `:handler-fn` alongside `:output` so the registrar's cross-kind calculation works for flows.
11. `b056c0f7` **fix(flows): invalidate-flow-on-replace! is frame-scoped (rf2-jfpf3)** — read `:frame` from the hook payload's `:now` slot; dissoc only the re-registered frame's row.
12. `13b4e827` **fix(flows): :fx must not run after a flow throws (rf2-fslx0)** — **P1**. Spec 013 §Failure semantics rule 3 + §rationale (line 202). `run-flows!` now signals success/failure; `commit-and-flow!` gates `run-fx-effects!` on the return.

## Test plan

- [x] `cd implementation/flows && clojure -M:test` — 77 tests, 289 assertions, 0 failures
- [x] `cd implementation/core && clojure -M:test` — 534 tests, 2715 assertions, 0 failures
- [x] `cd implementation && npm run test:cljs` — 2014 tests, 5680 assertions, 0 failures
- [x] Per-bead regression tests pinning each fix (eight beads add regression tests; four are pure test additions).

## Hot-zone audit

No hot-zone files touched. The surface is `implementation/flows/` + `implementation/core/router.cljc` + `implementation/core/fx.cljc`. Neither router.cljc nor fx.cljc is on the hot-zone list per CLAUDE.md §Workflow.

## Cross-bead unification

- Beads 8 / 9 / 12 form a coherent error-routing arc — flow throws now surface to the always-on error-emit substrate with `:flow-id` attribution (8), the substrate fan-out runs for `:rf.fx/reg-flow` cycles too (9), and the cascade halts on flow throws so child `:fx` is skipped (12). Three beads, three distinct seams, one consistent contract: ops monitors see every flow failure with full attribution, and downstream `:fx` does not execute on stale derived state.
- Bead 4 (first-time-only `:rf.flow/registered`) + bead 10 (`:handler-fn` stamp for `:different-fn?`) together fix the cross-kind hot-reload trace surface for flows: `:rf.flow/registered` fires once per first-time registration, `:rf.registry/handler-replaced` carries the hot-reload signal with a working `:different-fn?` indicator.