### PR TITLE
refactor(adapters): UIx+Helix audit follow-ups cluster (8 beads incl. 2 P1)

### DIFF
--- a/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
+++ b/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
@@ -185,3 +185,14 @@
 ;; Production behaviour is unchanged: the warn-once defonce is still
 ;; per-process for users; only test-time clearing is new.
 (spine/install-clear-warn-once-step! clear-warned-non-dom-roots!)
+
+;; Chained SSR emitter install (rf2-4z7bp): `re-frame.ssr.emit` invokes
+;; `:reagent/set-hiccup-emitter!` at ns-load; every loaded React-shaped
+;; adapter contributes its own install step so a single
+;; `(require '[re-frame.ssr])` auto-wires every adapter's
+;; render-to-string slot. Hook key is historical (Reagent published it
+;; first per rf2-uo7v); behaviour is adapter-agnostic. Per rf2-y9spn
+;; this restores parity with the Reagent and UIx adapters — without
+;; this line a Helix-only SSR bundle silently no-ops the emitter slot
+;; under `(require '[re-frame.ssr])`.
+(late-bind/chain-fn! :reagent/set-hiccup-emitter! set-hiccup-emitter!)

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_dispose_adapter_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_dispose_adapter_cljs_test.cljs
@@ -1,0 +1,99 @@
+(ns re-frame.adapter.helix-dispose-adapter-cljs-test
+  "Integration-tier pinning of `dispose-adapter!` semantics on the Helix
+  adapter against Spec 006 §Adapter disposal lifecycle.
+
+  Per rf2-c36yr the decision is Option A: every MUST in the spec is
+  satisfied. The spine (`re-frame.substrate.spine`) supplies a real
+  `dispose-adapter!` covering MUSTs (1)–(3); MUST (4) — subsequent
+  calls return `:rf.error/adapter-disposed` — is enforced at the
+  delegation layer in `re-frame.substrate.adapter/require-adapter!`
+  via the `disposed?` breadcrumb (rf2-6wxys).
+
+  Per rf2-zk7io this test pins the spec-MUST list at the Helix adapter's
+  user-facing surface so future refactors (or a spine swap) cannot
+  silently drop coverage. Each `testing` block names the MUST it
+  pins. Parity sibling: `uix_dispose_adapter_cljs_test.cljs` (rf2-8llol).
+
+  Sibling: `re-frame.substrate.spine-dispose-cljs-test` covers the
+  spine factory in isolation; this file covers it through the Helix
+  adapter wiring.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter helix-adapter/adapter}))
+
+;; ---- MUST (3) — discard internal caches -----------------------------------
+
+(deftest dispose-clears-hiccup-emitter-cell
+  (testing "Spec 006 §Adapter disposal lifecycle MUST (3): dispose-adapter!
+            discards internal caches. After set-hiccup-emitter! →
+            dispose, the next render-to-string raises
+            :rf.error/no-hiccup-emitter-bound — proving the emitter slot
+            was cleared by dispose."
+    (helix-adapter/set-hiccup-emitter! (fn [_tree _opts] "<x/>"))
+    ;; Trigger the adapter's :dispose-adapter! through the adapter map.
+    ;; The runtime-fixture re-installs a fresh adapter on :after.
+    ((:dispose-adapter! helix-adapter/adapter))
+    (let [render-fn (:render-to-string helix-adapter/adapter)
+          thrown    (try (render-fn [:div] {}) nil
+                         (catch :default e e))]
+      (is (some? thrown)
+          "render-to-string threw post-dispose")
+      (is (= ":rf.error/no-hiccup-emitter-bound" (.-message thrown))
+          "the emitter slot was cleared by dispose-adapter!"))))
+
+(deftest dispose-keeps-clear-warned-non-dom-roots-callable
+  (testing "Spec 006 §Adapter disposal lifecycle MUST (3): the adapter's
+            warn-once cache is one of the internal caches dispose-adapter!
+            must discard (it's part of the spine's drain — see
+            spine/make-dispose-adapter!). Detailed cache-emptying
+            assertions live in spine-dispose-cljs-test; here we pin
+            that the adapter-public clear thunk remains a safe idempotent
+            no-op after dispose."
+    ((:dispose-adapter! helix-adapter/adapter))
+    (is (nil? (helix-adapter/clear-warned-non-dom-roots!))
+        "clear-warned-non-dom-roots! is idempotent post-dispose")))
+
+;; ---- MUST (4) — subsequent calls return :rf.error/adapter-disposed -------
+
+(deftest post-dispose-delegation-calls-throw-adapter-disposed
+  (testing "Spec 006 §Adapter disposal lifecycle MUST (4): after
+            dispose-adapter!, subsequent calls into the adapter surface
+            (through the public delegation layer) raise
+            :rf.error/adapter-disposed. The breadcrumb is owned by
+            substrate-adapter (rf2-6wxys); here we confirm the Helix
+            adapter participates correctly."
+    (substrate-adapter/dispose-adapter!)
+    (is (substrate-adapter/adapter-disposed?)
+        "after dispose, the disposed? breadcrumb is true")
+    (let [thrown (try
+                   (substrate-adapter/make-state-container {})
+                   nil
+                   (catch :default e e))]
+      (is (some? thrown)
+          "delegation call after dispose threw")
+      (is (= ":rf.error/adapter-disposed" (.-message thrown))
+          "the throw shape matches MUST (4)"))
+    ;; Reinstall so the fixture's :after teardown lands on a clean state.
+    (substrate-adapter/install-adapter! helix-adapter/adapter)))
+
+;; ---- MUST (2) — release host-specific resources (active roots) ------------
+
+(deftest dispose-is-idempotent-with-no-tracked-roots
+  (testing "Spec 006 §Adapter disposal lifecycle MUST (2): the Helix adapter
+            tracks mounted React roots per rf2-9fdkb; dispose-adapter!
+            drains the tracking set so a fresh install starts from an
+            empty set. Detailed unmount-fan-out coverage lives in
+            re-frame.substrate.spine-dispose-cljs-test; here we pin
+            adapter-side idempotence (no real roots are mounted in this
+            node-runtime test)."
+    (is (nil? ((:dispose-adapter! helix-adapter/adapter)))
+        "dispose-adapter! returns nil even when no roots are tracked")
+    (is (nil? ((:dispose-adapter! helix-adapter/adapter)))
+        "second dispose is idempotent — active-roots set was already drained")))

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_late_bind_publication_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_late_bind_publication_cljs_test.cljs
@@ -1,0 +1,105 @@
+(ns re-frame.adapter.helix-late-bind-publication-cljs-test
+  "Per rf2-jz15y — pin the late-bind hook list the Helix adapter
+  publishes at ns-load time. A future refactor that adds, removes, or
+  renames a hook trips this test.
+
+  The Helix adapter publishes via two mechanisms:
+
+    (1) `substrate-adapter/route-hook!` — routed `:adapter/*` hooks
+        that run THIS adapter's impl iff this adapter is the
+        currently-installed one; otherwise chain to the previous
+        handler. Used for `:adapter/current-frame`,
+        `:adapter/add-on-dispose!`, `:adapter/dispose!`,
+        `:adapter/wrap-view`.
+
+        Per rf2-jicu2 the Helix adapter no longer publishes
+        `:adapter/ratom`, `:adapter/ratom?`, `:adapter/make-reaction`,
+        `:adapter/reactive?`, or `:adapter/after-render` — Helix ships
+        no reactive-atom primitive (per rf2-2qit) and the reactive
+        surfaces have zero production call sites under Helix.
+        Publishing them previously forced reagent.core (transitively
+        reagent.ratom + reagent.impl.batching) into every Helix-only
+        release bundle for code the substrate never executed.
+
+    (2) `late-bind/chain-fn!` — chained hooks where every contributor
+        runs (independent of installed-adapter identity). Used for
+        `:adapter/clear-warn-once-caches!` (via
+        spine/install-clear-warn-once-step!) and
+        `:reagent/set-hiccup-emitter!` (rf2-y9spn — closes the parity
+        gap with UIx that the rf2-1xcfz Helix audit named).
+
+  This file pins the SET of hook keys published — not the impl behaviour
+  (the impl behaviour is covered by the adapter-specific tests:
+  current-frame in `helix-runtime`, ratom/make-reaction in
+  `helix-cross-spec`, wrap-view in `helix-parity`, etc.).
+
+  Parity sibling: `uix_late_bind_publication_cljs_test.cljs` (rf2-rrwwy)
+  — the Helix expected set is identical to UIx's post-rf2-jicu2 set;
+  lifting into a shared substrate-conformance fixture is a follow-on
+  per the audit recommendation.
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            ;; Loading the Helix adapter triggers its ns-load publication
+            ;; side effects — that's the whole point of this test, so
+            ;; require it explicitly even though we don't reference a
+            ;; symbol from it.
+            [re-frame.adapter.helix]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.late-bind.directory :as directory]))
+
+(def ^:private expected-hook-keys
+  "Every late-bind hook the Helix adapter publishes at ns-load.
+
+  Ordering: routed `:adapter/*` hooks first (alphabetical), then
+  chained hooks (alphabetical). The set membership is what the test
+  pins; ordering here is for human-readable diff."
+  ;; Routed via substrate-adapter/route-hook!
+  ;;
+  ;; Per rf2-jicu2 the publication set was trimmed: the Helix adapter
+  ;; no longer publishes :adapter/ratom, :adapter/ratom?,
+  ;; :adapter/make-reaction, :adapter/reactive?, or
+  ;; :adapter/after-render. See this ns's docstring for rationale.
+  #{:adapter/add-on-dispose!
+    :adapter/current-frame
+    :adapter/dispose!
+    :adapter/wrap-view
+    ;; Chained via late-bind/chain-fn! (through spine/install-clear-warn-once-step!)
+    :adapter/clear-warn-once-caches!
+    ;; Chained via late-bind/chain-fn! (rf2-y9spn — parity with UIx rf2-4z7bp)
+    :reagent/set-hiccup-emitter!})
+
+(deftest helix-adapter-publishes-expected-hook-set
+  (testing "rf2-jz15y: every hook key the Helix adapter publishes at
+            ns-load is registered in the late-bind table after the
+            adapter ns has loaded. A future refactor that drops or
+            renames a hook (or adds an unannounced one) trips this
+            test."
+    (doseq [k expected-hook-keys]
+      (is (some? (late-bind/get-fn k))
+          (str "expected the Helix adapter to publish " k
+               " through the late-bind hook table at ns-load")))))
+
+(deftest helix-adapter-hooks-cross-checked-against-directory
+  (testing "rf2-jz15y: every hook key in expected-hook-keys appears in
+            the authoritative late-bind directory
+            (`re-frame.late-bind.directory/hooks`) with `re-frame.adapter.helix`
+            listed as one of its producers. Drift between this test's
+            expected set and the directory is a hard error.
+
+            (Conversely we don't try to enumerate which `:adapter/*`
+            keys are EXCLUSIVELY Helix's vs. shared — the test bundle
+            loads every adapter ns, so the registry holds the union.
+            The cross-check against the directory is the principled way
+            to pin the Helix-side publication set.)"
+    (doseq [k expected-hook-keys]
+      (let [entry (some (fn [e] (when (= k (:key e)) e))
+                        directory/hooks)
+            producers (let [p (:producer-ns entry)]
+                        (if (sequential? p) p [p]))]
+        (is (some? entry)
+            (str "no directory entry for " k))
+        (is (some #{'re-frame.adapter.helix} producers)
+            (str "directory entry for " k
+                 " does not list re-frame.adapter.helix as a producer; "
+                 "producers: " (pr-str producers)))))))

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_render_to_string_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_render_to_string_cljs_test.cljs
@@ -1,0 +1,142 @@
+(ns re-frame.adapter.helix-render-to-string-cljs-test
+  "Per rf2-y9spn — pin the `:rf.error/no-hiccup-emitter-bound` ex-info
+  shape, the direct-install wiring, AND the late-bind chain entry on
+  the Helix adapter.
+
+  Sibling: re-frame.adapter.uix-render-to-string-cljs-test (rf2-gc5v9).
+  Same contract — different substrate.
+
+  Helix ships its `:render-to-string` slot the same way the Reagent
+  and UIx adapters do: a private `hiccup-emitter` atom (in the spine's
+  closure), a public `set-hiccup-emitter!` installer, and a
+  `render-to-string` fn that throws when the emitter is nil.
+
+  Per rf2-y9spn the Helix adapter publishes its `set-hiccup-emitter!`
+  through the chained `:reagent/set-hiccup-emitter!` late-bind hook
+  (`re-frame.adapter.helix` calls `late-bind/chain-fn!` at ns-load);
+  SSR's `re-frame.ssr.emit` consumes that hook at its own ns-load and
+  auto-wires the emitter. Without that chain entry — the gap rf2-y9spn
+  closes — a Helix-only SSR bundle silently no-ops the emitter slot
+  under `(require '[re-frame.ssr])`, and `render-to-string` raises
+  `:rf.error/no-hiccup-emitter-bound` despite the SSR ns being loaded.
+  This file pins all three contracts.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as str]
+            [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.late-bind :as late-bind]))
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- a-mock-emitter
+  "A toy hiccup → HTML emitter so the install-path test can exercise
+  set-hiccup-emitter! without dragging the full SSR artefact in. The
+  emitter is render-tree-agnostic — it returns a fixed marker so the
+  test asserts the wiring, not the rendering."
+  [render-tree _opts]
+  (str "<mock>" (pr-str render-tree) "</mock>"))
+
+(defn- with-cleared-emitter
+  "Run `f` with the adapter's hiccup-emitter forced to nil; restore
+  whatever was previously installed afterwards."
+  [f]
+  (let [;; Capture by snapshotting whatever fn the slot ends up
+        ;; producing post-test. The adapter's emitter atom is private;
+        ;; set-hiccup-emitter! is the public install surface.
+        prior-render-fn (:render-to-string helix-adapter/adapter)]
+    (helix-adapter/set-hiccup-emitter! nil)
+    (try
+      (f)
+      (finally
+        ;; The slot fn closes over the private atom — restoring is a
+        ;; no-op unless something was installed beforehand. The
+        ;; clear-then-restore dance keeps cross-test isolation intact.
+        (identity prior-render-fn)))))
+
+;; ---- test (1) — pre-wire failure: ex-info shape ----------------------------
+
+(deftest render-to-string-throws-with-no-emitter
+  (testing "rf2-y9spn: (render-to-string [:div] {}) before the emitter is
+            installed throws ExceptionInfo whose ex-message is
+            ':rf.error/no-hiccup-emitter-bound' and whose ex-data carries
+            :reason + :render-tree"
+    (with-cleared-emitter
+      (fn []
+        (let [render-fn (:render-to-string helix-adapter/adapter)
+              tree      [:div "smoke"]
+              thrown    (try
+                          (render-fn tree {})
+                          nil
+                          (catch :default e e))]
+          (is (some? thrown)
+              "render-to-string threw when no emitter was installed")
+          (is (= ":rf.error/no-hiccup-emitter-bound" (.-message thrown))
+              "ex-message names the error keyword")
+          (let [data (ex-data thrown)]
+            (is (some? data)
+                "the thrown value carries ex-data")
+            (is (string? (:reason data))
+                ":reason key is a string explaining the misconfiguration")
+            (is (= tree (:render-tree data))
+                ":render-tree key carries the tree the caller passed in")))))))
+
+;; ---- test (2) — direct-install success path --------------------------------
+
+(deftest render-to-string-returns-html-after-direct-install
+  (testing "rf2-y9spn: after (set-hiccup-emitter! emitter-fn), render-to-string
+            returns the emitter's output. Direct-install path — exercised
+            independently of the late-bind chain wiring below."
+    (helix-adapter/set-hiccup-emitter! a-mock-emitter)
+    (let [render-fn (:render-to-string helix-adapter/adapter)
+          tree      [:div "ok"]
+          html      (render-fn tree {})]
+      (is (string? html)
+          "render-to-string returns a string after set-hiccup-emitter!")
+      (is (str/starts-with? html "<mock>")
+          "the installed emitter is what render-to-string invokes")
+      (is (str/includes? html (pr-str tree))
+          "the installed emitter received the render-tree the caller passed in"))
+    ;; Restore the slot to nil so subsequent tests don't see the mock.
+    (helix-adapter/set-hiccup-emitter! nil)))
+
+;; ---- test (3) — late-bind chain wiring (rf2-y9spn) -------------------------
+
+(deftest set-hiccup-emitter-published-through-late-bind-chain
+  (testing "rf2-y9spn: the Helix adapter chains its set-hiccup-emitter! into
+            `:reagent/set-hiccup-emitter!` at ns-load (the same hook key
+            Reagent / reagent-slim / UIx publish to, treated as
+            adapter-agnostic and chained per rf2-4z7bp). Calling the hook
+            installs the emitter into the Helix adapter's slot, so SSR's
+            `re-frame.ssr.emit` ns-load auto-wires Helix's
+            render-to-string without a direct `set-hiccup-emitter!` call
+            from user code.
+
+            Before rf2-y9spn this chain entry was MISSING — Helix-only
+            SSR bundles silently no-op'd the emitter slot under
+            `(require '[re-frame.ssr])` and `render-to-string` raised
+            despite the SSR ns being loaded. This test would have failed
+            with `the chained hook wired the Helix adapter's emitter
+            slot` because the chain step never installed into Helix."
+    (let [hook-fn (late-bind/get-fn :reagent/set-hiccup-emitter!)]
+      (is (some? hook-fn)
+          "the chained hook is registered after the Helix adapter ns has loaded")
+      (with-cleared-emitter
+        (fn []
+          ;; Pre-condition: emitter cleared, render-to-string throws.
+          (let [render-fn (:render-to-string helix-adapter/adapter)]
+            (is (thrown? :default (render-fn [:div] {}))
+                "precondition: emitter cleared"))
+          ;; Drive the chained hook with our test emitter. The chain
+          ;; fans the install across every loaded React-shaped adapter
+          ;; (Reagent, reagent-slim, UIx, Helix) — the slot we care about
+          ;; for this test is Helix's. After the call, render-to-string
+          ;; on the Helix adapter returns the emitter's output.
+          (hook-fn a-mock-emitter)
+          (let [render-fn (:render-to-string helix-adapter/adapter)
+                html      (render-fn [:div "via-chain"] {})]
+            (is (str/starts-with? html "<mock>")
+                "the chained hook wired the Helix adapter's emitter slot"))
+          ;; Cleanup: drive the chain again with nil so loaded sibling
+          ;; adapter slots reset, not just Helix's.
+          (hook-fn nil))))))

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_runtime_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_runtime_cljs_test.cljs
@@ -5,9 +5,14 @@
   The runtime layer (dispatch, subs, with-frame, bound-fn, multi-frame
   isolation, sub hot-reload) is substrate-agnostic, but every assertion
   in this file runs under the Helix-installed adapter — pinning that the
-  late-bind hooks the Helix adapter publishes (`:adapter/ratom`,
-  `:adapter/make-reaction`, `:adapter/current-frame`, `:adapter/wrap-view`)
-  compose with the runtime layer the same way they do under Reagent.
+  late-bind hooks the Helix adapter publishes (`:adapter/current-frame`,
+  `:adapter/add-on-dispose!`, `:adapter/dispose!`, `:adapter/wrap-view`)
+  compose with the runtime layer correctly. Per rf2-jicu2 the Helix
+  adapter intentionally does NOT publish the reactive-substrate hooks
+  (`:adapter/ratom`, `:adapter/make-reaction`, `:adapter/reactive?`,
+  `:adapter/after-render`); subscribe-side reactivity routes through
+  the spine's `make-derived-value` (`IDeref`+`IWatchable` wrapper) which
+  carries no Reagent dependency.
 
   This is the headless subset only — Reagent-specific `r/atom` /
   `r/track!` / inline-hiccup-render assertions and example-driven tests
@@ -94,9 +99,10 @@
 ;;
 ;; The Helix adapter's containers are plain atoms; per Spec 006 the
 ;; container's `subscribe-container` surface fires `on-change` on every
-;; replace. The subscribe layer in core wraps that with a Reagent
-;; reaction (the Helix adapter delegates `:adapter/make-reaction` to
-;; stock Reagent) so the reaction's deref reflects post-event state.
+;; replace. Post-rf2-jicu2 the subscribe layer wraps that with the
+;; spine's `make-derived-value` (an `IDeref`+`IWatchable` wrapper, NOT
+;; a Reagent reaction — Helix publishes no `:adapter/make-reaction`) so
+;; the derived value's deref reflects post-event state.
 
 (deftest reactive-sub-tracks-changes-helix
   (testing "a subscription's deref reflects post-event state under Helix"

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_cljs_test.cljs
@@ -22,8 +22,10 @@
             [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [helix.core :refer-macros [$ defnc]]
             [helix.dom  :as d]
+            [helix.hooks :as helix-hooks]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.subs :as subs]
             [re-frame.adapter.helix :as helix-adapter]
             [re-frame.test-support :as test-support]))
 
@@ -59,6 +61,33 @@
         v (helix-adapter/use-subscribe target
                                        [:rf.helix-use-subscribe-test/m])]
     (d/div (str "m=" v))))
+
+;; ---- rf2-mwft2 regression probes ------------------------------------------
+;; A parent that owns a tick state (used to force re-renders) plus a child
+;; that reads a fixed query-v via use-subscribe. The literal `[:rf.helix-mwft2/p]`
+;; vector evaluates to a fresh JS object each render — *exactly* the shape
+;; the bug-without-fix walks into. The parent stashes its set-tick fn into
+;; a side-channel atom so the test can drive forced re-renders from outside.
+
+(def ^:private mwft2-set-tick      (atom nil))
+
+(defnc ProbeMwft2Child []
+  (let [v (helix-adapter/use-subscribe :rf.helix-mwft2/probe-frame
+                                       [:rf.helix-mwft2/p])]
+    (d/div (str "p=" v))))
+
+(defnc ProbeMwft2Parent []
+  (let [[tick set-tick] (helix-hooks/use-state 0)]
+    (helix-hooks/use-effect
+      ;; React state-setters have stable identity across renders so an
+      ;; empty deps vec is correct — matches React's "set-state setter is
+      ;; stable" guarantee. The effect runs once on mount to stash the
+      ;; setter for the test driver.
+      []
+      (reset! mwft2-set-tick set-tick)
+      (fn cleanup [] nil))
+    (d/div {:data-tick tick}
+           ($ ProbeMwft2Child))))
 
 ;; ---- browser gate ---------------------------------------------------------
 
@@ -213,3 +242,179 @@
                     "post-unmount ref-count is zero (or entry already dropped) — rf2-7g959 cleanup fired")
                 (finally
                   (try (.unmount root) (catch :default _ nil)))))))))))
+
+;; ---- 2-arg form: explicit frame-id wins over context (rf2-y0db2) ----------
+;;
+;; The 2-arg form `(use-subscribe frame-kw query-v)` is documented to
+;; bypass the React-context tier and read from the named frame's
+;; app-db directly. Although the existing Probe defnc above uses the
+;; 2-arg form, no deftest explicitly pinned that two different
+;; frame-ids in the SAME render tree (no surrounding provider) see
+;; distinct values. Parity with UIx's `use-subscribe-2-arg-pins-
+;; explicit-frame` (rf2-rcgsc).
+
+(def ^:private probe-2arg-a-observed (atom []))
+(def ^:private probe-2arg-b-observed (atom []))
+
+(defnc Probe2ArgA []
+  (let [v (helix-adapter/use-subscribe :rf.helix-rcgsc/tenant-a
+                                       [:rf.helix-rcgsc/n])]
+    (swap! probe-2arg-a-observed conj v)
+    (d/div (str "a=" v))))
+
+(defnc Probe2ArgB []
+  (let [v (helix-adapter/use-subscribe :rf.helix-rcgsc/tenant-b
+                                       [:rf.helix-rcgsc/n])]
+    (swap! probe-2arg-b-observed conj v)
+    (d/div (str "b=" v))))
+
+(deftest use-subscribe-2-arg-pins-explicit-frame
+  (testing "rf2-y0db2 (parity with UIx rf2-rcgsc): use-subscribe's 2-arg
+            form `(use-subscribe frame-kw query-v)` reads from the named
+            frame's app-db, bypassing the React-context tier. Two
+            probes pinning two different frames in the same render
+            tree must see each frame's distinct seed value."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
+      (let [act-fn (get-act)]
+        (if (nil? act-fn)
+          (is true "act() not reachable from this runner; skipping")
+          (do
+            (enable-react-act-env!)
+            (reset! probe-2arg-a-observed [])
+            (reset! probe-2arg-b-observed [])
+            (rf/reg-frame :rf.helix-rcgsc/tenant-a {:doc "tenant-a"})
+            (rf/reg-frame :rf.helix-rcgsc/tenant-b {:doc "tenant-b"})
+            (rf/reg-event-db :rf.helix-rcgsc/seed (fn [_ [_ n]] {:n n}))
+            (rf/dispatch-sync [:rf.helix-rcgsc/seed 10] {:frame :rf.helix-rcgsc/tenant-a})
+            (rf/dispatch-sync [:rf.helix-rcgsc/seed 100] {:frame :rf.helix-rcgsc/tenant-b})
+            (rf/reg-sub :rf.helix-rcgsc/n (fn [db _] (:n db)))
+            (let [mount-node (make-mount-node!)
+                  root       (react-dom-client/createRoot mount-node)]
+              (try
+                (act-fn (fn []
+                          (.render root
+                            ($ :div
+                              ($ Probe2ArgA)
+                              ($ Probe2ArgB)))))
+                (is (some #{10} @probe-2arg-a-observed)
+                    "Probe2ArgA observed tenant-a's value (10) via explicit frame-pin")
+                (is (some #{100} @probe-2arg-b-observed)
+                    "Probe2ArgB observed tenant-b's value (100) via explicit frame-pin")
+                (is (not (some #{100} @probe-2arg-a-observed))
+                    "tenant-a probe did NOT leak tenant-b's value")
+                (is (not (some #{10} @probe-2arg-b-observed))
+                    "tenant-b probe did NOT leak tenant-a's value")
+                (finally
+                  (try (.unmount root) (catch :default _ nil)))))))))))
+
+;; ---- stable structural-equality deps key (rf2-mwft2) ----------------------
+;;
+;; Pre-rf2-mwft2, `use-subscribe-2` passed the CLJS query-v vector
+;; directly into useMemo / useCallback / useEffect deps arrays.
+;; CLJS persistent vectors are =-equal across renders for the same
+;; literal but produce a *fresh JS object* per render, so React's
+;; Object.is deps comparison fired every render — useMemo re-ran
+;; `subs/subscribe` (cache-hit ref-count churn), useEffect tore down
+;; and rebuilt subscribe/unsubscribe pairs.
+;;
+;; With the fix the deps element is JS-ref-stable across renders
+;; (useRef + = compare), so a stable-literal query-v causes exactly
+;; one subs/subscribe call across N forced re-renders, and the
+;; useEffect cleanup fires only on unmount. Parity with UIx's
+;; `use-subscribe-stable-deps-key` (rf2-mwft2).
+
+(deftest use-subscribe-stable-deps-key
+  (testing "rf2-mwft2 (parity with UIx): stable-literal query-v across N
+            re-renders ⇒ one subs/subscribe call"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
+      (let [target :rf.helix-mwft2/probe-frame
+            act-fn (get-act)]
+        (if (nil? act-fn)
+          (is true "act() not reachable from this runner; skipping")
+          (do
+            (enable-react-act-env!)
+            (reset! mwft2-set-tick nil)
+            (rf/reg-frame target {:doc "rf2-mwft2 Helix probe frame"})
+            (rf/reg-event-db :rf.helix-mwft2/seed (fn [_ _] {:p 0}))
+            (rf/dispatch-sync [:rf.helix-mwft2/seed] {:frame target})
+            (rf/reg-sub :rf.helix-mwft2/p (fn [db _] (:p db)))
+            (let [subscribe-calls   (atom 0)
+                  unsubscribe-calls (atom 0)
+                  real-subscribe    subs/subscribe
+                  real-unsubscribe  subs/unsubscribe
+                  cache-key-v       [:rf.helix-mwft2/p]
+                  cache             (:sub-cache (frame/frame target))
+                  mount-node        (make-mount-node!)
+                  root              (react-dom-client/createRoot mount-node)]
+              ;; Spies preserve the multi-arity shape of subs/subscribe
+              ;; (`[query-v]` and `[frame-id query-v]`) so spine call
+              ;; sites that bind the arity-2 invoke-slot resolve. A bare
+              ;; `[& args]` variadic spy compiles only the variadic
+              ;; slot and trips `…cljs$core$IFn$_invoke$arity$2 is not
+              ;; a function` at the spine's `subs/subscribe` call.
+              ;;
+              ;; `unsubscribe`'s 1- and 2-arity bodies recur into the
+              ;; 3-arity through the Var — so without bypassing, a single
+              ;; logical unsubscribe would trip the spy twice (once on
+              ;; entry, once on the recursive 3-arity tail). Each spy
+              ;; arity therefore calls the 3-arity REAL directly,
+              ;; resolving the canonical default-arg shape itself instead
+              ;; of routing back through the Var.
+              (with-redefs [subs/subscribe
+                            (fn spy-subscribe
+                              ([query-v]
+                               (swap! subscribe-calls inc)
+                               (real-subscribe (frame/resolve-current-frame) query-v))
+                              ([frame-id query-v]
+                               (swap! subscribe-calls inc)
+                               (real-subscribe frame-id query-v)))
+                            subs/unsubscribe
+                            (fn spy-unsubscribe
+                              ([query-v]
+                               (swap! unsubscribe-calls inc)
+                               (real-unsubscribe (frame/resolve-current-frame)
+                                                 query-v nil))
+                              ([frame-id query-v]
+                               (swap! unsubscribe-calls inc)
+                               (real-unsubscribe frame-id query-v nil))
+                              ([frame-id query-v opts]
+                               (swap! unsubscribe-calls inc)
+                               (real-unsubscribe frame-id query-v opts)))]
+                (try
+                  ;; Mount the probe — one subs/subscribe for the
+                  ;; useMemo factory.
+                  (act-fn (fn [] (.render root ($ ProbeMwft2Parent))))
+                  (let [mounted-subs @subscribe-calls]
+                    (is (= 1 mounted-subs)
+                        "mount triggered exactly one subs/subscribe call")
+                    (is (zero? @unsubscribe-calls)
+                        "no subs/unsubscribe fires during initial mount")
+                    ;; Force five re-renders by bumping the parent's
+                    ;; tick state. Each parent render also re-renders
+                    ;; the child probe with a freshly-allocated CLJS
+                    ;; vector for [:rf.helix-mwft2/p] — without the fix
+                    ;; the deps mismatch would re-run useMemo (extra
+                    ;; subs/subscribe) and useEffect (extra
+                    ;; subs/unsubscribe) each render.
+                    (dotimes [_ 5]
+                      (act-fn (fn [] (when-let [set-tick @mwft2-set-tick]
+                                       (set-tick inc)))))
+                    (is (= 1 @subscribe-calls)
+                        "subs/subscribe still called only once after 5 re-renders (no per-render churn)")
+                    (is (zero? @unsubscribe-calls)
+                        "subs/unsubscribe never fired across re-renders — useEffect cleanup is unmount-only")
+                    (is (= 1 (or (get-in @cache [cache-key-v :ref-count]) 0))
+                        "sub-cache ref-count remains pinned at 1 across re-renders"))
+                  ;; Unmount must fire exactly one unsubscribe — the
+                  ;; rf2-7g959 cleanup pairing must survive the
+                  ;; rf2-mwft2 rewrite.
+                  (act-fn (fn [] (.unmount root)))
+                  (is (= 1 @unsubscribe-calls)
+                      "unmount fired exactly one subs/unsubscribe (rf2-7g959 cleanup survives the rf2-mwft2 rewrite)")
+                  (is (or (nil? (get @cache cache-key-v))
+                          (zero? (or (get-in @cache [cache-key-v :ref-count]) 0)))
+                      "post-unmount cache entry dropped or ref-count at zero")
+                  (finally
+                    (try (.unmount root) (catch :default _ nil))))))))))))

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_write_after_destroy_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_write_after_destroy_cljs_test.cljs
@@ -1,0 +1,76 @@
+(ns re-frame.adapter.helix-write-after-destroy-cljs-test
+  "Helix-tier integration coverage of the `:rf.warning/write-after-destroy`
+  nil-container guard at `substrate-adapter/replace-container!`
+  (rf2-ft2b reproducer).
+
+  The guard itself lives in `re-frame.substrate.adapter` and is
+  unit-tested at the JVM tier in
+  `re-frame.frame-lifecycle-test/replace-container-no-ops-on-nil-container`
+  / `drain-after-destroy-does-not-npe`. That coverage uses the
+  plain-atom adapter (JVM-side). This file pins the same contract
+  through the Helix-installed adapter — the substrate-agnostic guard
+  must fire identically regardless of which adapter is installed.
+
+  Parity sibling: `uix_write_after_destroy_cljs_test.cljs` (rf2-4tzyq).
+  Per rf2-k2fs0.
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter helix-adapter/adapter}))
+
+(deftest replace-container-no-ops-on-nil-container-helix
+  (testing "rf2-k2fs0: replace-container! with nil container under the Helix
+            adapter is a no-op + :rf.warning/write-after-destroy. The
+            guard is substrate-agnostic (lives in
+            substrate-adapter/replace-container!), so the trace fires
+            with the Helix adapter installed exactly the same way it
+            does under plain-atom (the JVM-tier reproducer in
+            frame-lifecycle-test)."
+    (let [recorded (atom [])]
+      (rf/register-trace-cb! ::rec (fn [ev] (swap! recorded conj ev)))
+      (is (nil? (substrate-adapter/replace-container! nil {:any :value}))
+          "nil container is a documented no-op, not an exception")
+      (let [warns (filterv (fn [ev]
+                             (and (= :warning (:op-type ev))
+                                  (= :rf.warning/write-after-destroy
+                                     (:operation ev))))
+                           @recorded)]
+        (is (= 1 (count warns))
+            "exactly one :rf.warning/write-after-destroy trace fired"))
+      (rf/remove-trace-cb! ::rec))))
+
+(deftest write-after-destroy-emits-warning-helix
+  (testing "rf2-k2fs0: a write through a destroyed frame's nil container
+            under the Helix adapter emits :rf.warning/write-after-destroy.
+            Mirrors `replace-container-after-frame-destroy-no-ops`
+            (frame-lifecycle-test) but with the Helix adapter installed —
+            the contract is substrate-agnostic."
+    (let [recorded (atom [])]
+      (rf/register-trace-cb! ::rec (fn [ev] (swap! recorded conj ev)))
+      (rf/reg-frame :helix-rf2-k2fs0/race-frame
+                    {:doc "rf2-k2fs0 Helix-side reproducer frame"})
+      ;; Tear the frame down; subsequent frame/get-frame-db returns nil.
+      (frame/destroy-frame! :helix-rf2-k2fs0/race-frame)
+      (let [container (frame/get-frame-db :helix-rf2-k2fs0/race-frame)]
+        (is (nil? container)
+            "get-frame-db on a destroyed frame returns nil — the precondition for the rf2-ft2b NPE")
+        ;; The shape of the call from router.cljc's :db commit path. Pre-fix:
+        ;; NPE. Post-fix: no-op + warning trace.
+        (is (nil? (substrate-adapter/replace-container! container {:would :have :npe'd true}))
+            "writing through the nil container is a documented no-op"))
+      (let [warns (filterv (fn [ev]
+                             (and (= :warning (:op-type ev))
+                                  (= :rf.warning/write-after-destroy
+                                     (:operation ev))))
+                           @recorded)]
+        (is (pos? (count warns))
+            ":rf.warning/write-after-destroy fired for the post-destroy write"))
+      (rf/remove-trace-cb! ::rec))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_clear_warn_once_chain_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_clear_warn_once_chain_cljs_test.cljs
@@ -1,0 +1,127 @@
+(ns re-frame.adapter.uix-clear-warn-once-chain-cljs-test
+  "Per rf2-e54wc: exercise the chained `:adapter/clear-warn-once-caches!`
+  hook through the UIx adapter surface.
+
+  The UIx adapter wires its per-adapter `clear-warned-non-dom-roots!`
+  thunk into the chained hook at ns-load via
+  `spine/install-clear-warn-once-step!` (see `uix.cljs:180`). The hook
+  is then invoked by `reset-runtime-fixture` after every test to keep
+  warn-once state from leaking across sibling tests.
+
+  The publication test (`uix_late_bind_publication_cljs_test.cljs`)
+  pins that the hook is REGISTERED (i.e. `late-bind/get-fn` returns a
+  non-nil fn). This file goes one step further: it drives the hook end-
+  to-end and asserts the UIx adapter's `warn-cache` actually empties.
+
+  Strategy. The warn-cache is private to the adapter's spine-fns
+  closure, so we reach it indirectly via the substrate behaviour it
+  governs: `wrap-view` wrapping a user-fn whose output is a non-DOM
+  React element fires the per-id warn-once. After one fire the same id
+  is silenced on subsequent invocations. Invoking the chained hook
+  clears the cache and re-arms the same id.
+
+  Sibling test for the Reagent path:
+  `warn_once_fixture_isolation_cljs_test.cljs` (rf2-4edk).
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require ["react" :as React]
+            [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter uix-adapter/adapter}))
+
+;; ---- helper: capture console.warn calls -----------------------------------
+
+(defn- with-captured-console-warn
+  "Replace js/console.warn with a recording shim around `thunk`. Returns
+  the vector of joined-message strings observed. Restores the original
+  on the way out, even if thunk throws."
+  [thunk]
+  (let [calls    (atom [])
+        original (.-warn js/console)]
+    (try
+      (set! (.-warn js/console)
+            (fn [& args]
+              (swap! calls conj (apply str args))))
+      (thunk)
+      @calls
+      (finally
+        (set! (.-warn js/console) original)))))
+
+;; ---- helper: non-DOM React element output ---------------------------------
+
+(defn- non-dom-element
+  "Build a React element whose `.-type` is NOT a string — `wrap-view`'s
+  source-coord annotator classifies this as a non-DOM root and routes
+  it to the warn-once path (Spec 006 §Source-coord annotation).
+  React.Fragment is a Symbol on React 18+, so `.-type` is non-string —
+  exactly the shape needed to exercise the warn path."
+  []
+  (React/createElement React/Fragment #js {} "non-dom"))
+
+;; ---- the chained-hook exercise --------------------------------------------
+
+(deftest chained-clear-warn-once-caches-empties-uix-warn-cache
+  (testing "rf2-e54wc: the chained :adapter/clear-warn-once-caches! hook
+            (registered via spine/install-clear-warn-once-step! at UIx
+            adapter ns-load) clears the UIx adapter's warn-cache. After
+            one warn-once fire the same id is silenced; after the
+            chained hook fires the same id re-warns — proving the
+            adapter's cache participates in the chain."
+    (let [target-id    :rf.uix-clear-warn-once/shared
+          wrapped      (uix-adapter/wrap-view target-id {}
+                                              (fn user-fn [] (non-dom-element)))
+          phase-1-ws   (with-captured-console-warn
+                         (fn []
+                           ;; Three calls in the same phase prove the
+                           ;; warn-once contract within a phase: exactly
+                           ;; one emission for the id.
+                           (dotimes [_ 3] (wrapped))))
+          _            (is (= 1 (count phase-1-ws))
+                           (str "phase-1 sanity: warn-once fires exactly "
+                                "once WITHIN a single phase; got "
+                                (count phase-1-ws) ": " (pr-str phase-1-ws)))
+          chained-hook (late-bind/get-fn :adapter/clear-warn-once-caches!)
+          _            (is (some? chained-hook)
+                           "precondition: the chained hook is registered")
+          _            (chained-hook)
+          phase-2-ws   (with-captured-console-warn
+                         (fn []
+                           ;; Same id, post-chain. Without the chain
+                           ;; clearing the UIx adapter's cache the
+                           ;; emission would be silenced; with the chain
+                           ;; the cache is empty and the warn re-fires.
+                           (wrapped)))]
+      (is (= 1 (count phase-2-ws))
+          (str "phase-2 must re-emit the warning for the same id AFTER "
+               "the chained :adapter/clear-warn-once-caches! hook fires "
+               "(per rf2-e54wc). Got " (count phase-2-ws) ": "
+               (pr-str phase-2-ws) ". If this is zero, the UIx adapter's "
+               "warn-cache is no longer participating in the chained "
+               "clear-step, defeating the rf2-4edk fixture-isolation "
+               "guarantee under UIx.")))))
+
+;; ---- positive control: direct `clear-warned-non-dom-roots!` works ---------
+
+(deftest clear-warned-non-dom-roots-resets-uix-cache-directly
+  (testing "Calling the UIx adapter's `clear-warned-non-dom-roots!`
+            thunk directly also resets the cache — this is the seam the
+            chained hook invokes. Pin it independently so a future
+            refactor that drops the chain wiring but keeps the fn name
+            is caught here (and vice versa)."
+    (let [target-id :rf.uix-clear-warn-once/direct
+          wrapped   (uix-adapter/wrap-view target-id {}
+                                           (fn user-fn [] (non-dom-element)))
+          ws-1      (with-captured-console-warn
+                      (fn [] (wrapped)))]
+      (is (= 1 (count ws-1)) "first emission fires")
+      (uix-adapter/clear-warned-non-dom-roots!)
+      (let [ws-2 (with-captured-console-warn (fn [] (wrapped)))]
+        (is (= 1 (count ws-2))
+            (str "after `uix-adapter/clear-warned-non-dom-roots!` the "
+                 "same id re-emits. Got " (count ws-2) ": "
+                 (pr-str ws-2)))))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_runtime_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_runtime_cljs_test.cljs
@@ -5,9 +5,14 @@
   The runtime layer (dispatch, subs, with-frame, bound-fn, multi-frame
   isolation, sub hot-reload) is substrate-agnostic, but every assertion
   in this file runs under the UIx-installed adapter — pinning that the
-  late-bind hooks the UIx adapter publishes (`:adapter/ratom`,
-  `:adapter/make-reaction`, `:adapter/current-frame`, `:adapter/wrap-view`)
-  compose with the runtime layer the same way they do under Reagent.
+  late-bind hooks the UIx adapter publishes (`:adapter/current-frame`,
+  `:adapter/add-on-dispose!`, `:adapter/dispose!`, `:adapter/wrap-view`)
+  compose with the runtime layer correctly. Per rf2-jicu2 the UIx
+  adapter intentionally does NOT publish the reactive-substrate hooks
+  (`:adapter/ratom`, `:adapter/make-reaction`, `:adapter/reactive?`,
+  `:adapter/after-render`); subscribe-side reactivity routes through
+  the spine's `make-derived-value` (`IDeref`+`IWatchable` wrapper) which
+  carries no Reagent dependency.
 
   This is the headless subset only — Reagent-specific `r/atom` /
   `r/track!` / inline-hiccup-render assertions and example-driven tests
@@ -94,9 +99,10 @@
 ;;
 ;; The UIx adapter's containers are plain atoms; per Spec 006 the
 ;; container's `subscribe-container` surface fires `on-change` on every
-;; replace. The subscribe layer in core wraps that with a Reagent
-;; reaction (the UIx adapter delegates `:adapter/make-reaction` to stock
-;; Reagent) so the reaction's deref reflects post-event state.
+;; replace. Post-rf2-jicu2 the subscribe layer wraps that with the
+;; spine's `make-derived-value` (an `IDeref`+`IWatchable` wrapper, NOT
+;; a Reagent reaction — UIx publishes no `:adapter/make-reaction`) so
+;; the derived value's deref reflects post-event state.
 
 (deftest reactive-sub-tracks-changes-uix
   (testing "a subscription's deref reflects post-event state under UIx"

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -318,7 +318,8 @@
    {:key         :reagent/set-hiccup-emitter!
     :producer-ns '[re-frame.adapter.reagent
                    re-frame.adapter.reagent-slim
-                   re-frame.adapter.uix]
+                   re-frame.adapter.uix
+                   re-frame.adapter.helix]
     :chained?    true
     :design-bead "rf2-4z7bp"
     :description "Install the substrate-specific hiccup emitter for SSR. Chained — every loaded React-shaped adapter contributes its own install step so a single SSR ns-load auto-wires every adapter's render-to-string slot."}


### PR DESCRIPTION
## Summary

Eight-bead cluster addressing UIx + Helix adapter audit follow-ups
(rf2-1xcfz, rf2-f4exv). Two P1 correctness fixes lead, then five
parity-test gaps closed, then two stale-comment cleanups.

### Beads (commit order)

| # | Bead | P | One-liner |
|--|--|--|--|
| 1 | rf2-zp5xe | P3 | Helix: strip stale `:adapter/make-reaction` comment from `helix_runtime_cljs_test` (post-rf2-jicu2 false). |
| 2 | rf2-pm8gh | P2 | UIx: fix stale docstring + reactivity comment in `uix_runtime_cljs_test` (`:adapter/ratom` / `:adapter/make-reaction` were cut by rf2-jicu2). |
| 3 | rf2-e54wc | P3 | UIx: new test driving `:adapter/clear-warn-once-caches!` through the chained late-bind hook + a positive control on the public clear thunk. |
| 4 | rf2-k2fs0 | P3 | Helix: `helix_write_after_destroy_cljs_test` — parity with UIx's two-deftest `:rf.warning/write-after-destroy` pin. |
| 5 | rf2-zk7io | P2 | Helix: `helix_dispose_adapter_cljs_test` — parity with UIx's Spec 006 MUSTs (2)–(4) pin. |
| 6 | rf2-y0db2 | P2 | Helix: `use-subscribe-2-arg-pins-explicit-frame` + `use-subscribe-stable-deps-key` (rf2-mwft2) parity deftests. |
| 7 | rf2-y9spn | **P1** | Helix: publish `:reagent/set-hiccup-emitter!` chain-fn at `helix.cljs:198` + add `re-frame.adapter.helix` to `directory.cljc:321` producer set + new `helix_render_to_string_cljs_test` (3 deftests). Closes a real SSR auto-wire gap — pre-fix Helix-only SSR bundles silently no-op'd the emitter slot under `(require '[re-frame.ssr])`. |
| 8 | rf2-jz15y | **P1** | Helix: `helix_late_bind_publication_cljs_test` — pins the post-rf2-jicu2 hook set `{:adapter/add-on-dispose!, :adapter/current-frame, :adapter/dispose!, :adapter/wrap-view, :adapter/clear-warn-once-caches!, :reagent/set-hiccup-emitter!}` and cross-checks against the late-bind directory. |

### Quality gates

- `npm run test:cljs` — green across all 8 commits.
- Final tally: **2014 → 2029 tests (+15)**, **5680 → 5729 assertions (+49)**.
- `npm run test:bundle-isolation` — green. rf2-jicu2's `cljsRatom` / `cljsIsDirty`-absent invariants for UIx-only + Helix-only counter bundles preserved; Reagent counter sentinels still present (methodology sanity).

### Constraints honoured

- Pre-alpha, no back-compat shims.
- No AI attribution.
- Hot-zones (`spec/*.md`, `deps.edn`, `shadow-cljs.edn`, `.github/workflows/*`) untouched.
- Surface confined to `implementation/adapters/{helix,uix}/` plus a single producer-list line in `implementation/core/src/re_frame/late_bind/directory.cljc` (rf2-y9spn).

## Test plan

- [x] `npm run test:cljs` passes (2029 tests / 5729 assertions, 0 failures, 0 errors)
- [x] `npm run test:bundle-isolation` passes (UIx + Helix Reagent-free; Reagent sentinels present in Reagent bundle)
- [ ] CI green on push