### PR TITLE
refactor(http): audit follow-ons cluster (8 beads incl. rf2-on7sj P1 double-reply fix)

### DIFF
--- a/implementation/http/src/re_frame/http_managed.cljc
+++ b/implementation/http/src/re_frame/http_managed.cljc
@@ -178,8 +178,14 @@
 
 (fx/reg-fx :rf.fx/clear-http-interceptor
            {:doc "Spec 014 §Middleware (rf2-6y3q) — clear a request-side
-                  interceptor by id as an fx. Args is `{:frame :id}`; `:frame`
-                  defaults to `:rf/default`."}
+                  interceptor by id as an fx. Args is the map
+                  `{:frame <id> :id <kw>}` (NOT positional, matching the
+                  fx-convention shape — sibling to `:rf.fx/reg-http-interceptor`
+                  which also takes a map). `:frame` defaults to `:rf/default`
+                  when absent or nil. The fn-form `clear-http-interceptor` is
+                  the positional surface; this fx is the data-shaped surface
+                  for EDN-driven callers (conformance fixtures, event
+                  handlers at boot — rf2-k7tlm)."}
            (fn [_ctx {:keys [frame id]}]
              (middleware/clear-http-interceptor (or frame :rf/default) id)))
 

--- a/implementation/http/src/re_frame/http_middleware.cljc
+++ b/implementation/http/src/re_frame/http_middleware.cljc
@@ -157,8 +157,13 @@
             (let [out (before acc)]
               (if (map? out)
                 out
-                (throw (ex-info "interceptor :before did not return a ctx map"
-                                {:returned out}))))
+                ;; rf2-m32t9 — include the interceptor id in the cause
+                ;; string so a chain failure printed via the outer
+                ;; ex-info's :cause is locatable without reaching for
+                ;; ex-data. The :id key in ex-data is kept for
+                ;; programmatic consumers.
+                (throw (ex-info (str "interceptor " id " :before did not return a ctx map")
+                                {:id id :returned out}))))
             (catch #?(:clj Throwable :cljs :default) t
               (let [data (ex-info ":rf.error/http-interceptor-failed"
                                   {:where    'run-http-interceptor-chain!

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -99,7 +99,6 @@
                                      (catch :default _ nil)))
                               #js {:once true}))))
            timeout-handle (atom nil)
-           timeout-fired? (atom false)
            promise
            (-> (js/Promise.race
                  #js [(js/fetch url init)
@@ -108,7 +107,6 @@
                                        (reset! timeout-handle
                                                (js/setTimeout
                                                  (fn []
-                                                   (reset! timeout-fired? true)
                                                    (try (.abort internal-controller "timeout")
                                                         (catch :default _ nil))
                                                    (reject (ex-info "timeout"

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -307,17 +307,27 @@
                           :body-text (.body r)})))))))
 
 #?(:clj
-   (defn- classify-jvm-error [^Throwable t]
+   (defn- classify-jvm-error
+     "Map a JVM-side throwable to a `:rf.http/*` failure shape.
+
+     Per rf2-q3ts4: the JDK reliably surfaces `HttpTimeoutException` for
+     per-attempt timeouts and `CancellationException` for explicit
+     cancellations, so we narrow to instance-checks only. The earlier
+     `str/includes? msg \"timed out\"` / `\"abort\"` fallbacks could
+     misclassify a downstream service's error body (whose message
+     happened to contain those words) as `:rf.http/timeout` /
+     `:rf.http/aborted`, polluting the failure taxonomy. Anything not
+     matching an instance check stays at `:rf.http/transport` — the
+     correct catch-all for unknown JDK failures."
+     [^Throwable t]
      (let [cause (or (.getCause t) t)
            msg   (.getMessage cause)
            cls   (.getName (class cause))]
        (cond
-         (or (instance? java.net.http.HttpTimeoutException cause)
-             (and msg (str/includes? (str/lower-case msg) "timed out")))
+         (instance? java.net.http.HttpTimeoutException cause)
          {:kind :rf.http/timeout :elapsed-ms nil :limit-ms nil :message msg}
 
-         (or (instance? java.util.concurrent.CancellationException cause)
-             (and msg (str/includes? (str/lower-case msg) "abort")))
+         (instance? java.util.concurrent.CancellationException cause)
          {:kind :rf.http/aborted :reason :user :message msg}
 
          :else

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -380,23 +380,41 @@
        :kind          kind}
       frame)))
 
-(defn- finalise-success! [ctx accepted]
-  (registry/clear-in-flight! (:request-id ctx) (:handle ctx))
-  (cond
-    (contains? accepted :ok)
-    (dispatch-reply! (assoc ctx
-                            :kind :success
-                            :reply-payload {:kind  :success
-                                            :value (:ok accepted)}))
+(defn- already-replied?
+  "rf2-on7sj — the once-only reply guard. The handle carries a
+  `:finalised?` atom stamped at `record-in-flight!` time; the abort
+  path AND the natural-completion paths both reach `finalise-*` and
+  must NOT both dispatch a reply for the same request. CAS the flag
+  from false→true on first arrival; subsequent calls see `true` and
+  bail. Returns truthy when the caller MUST NOT proceed (already
+  replied OR no handle present at all — defensive, see below).
 
-    (contains? accepted :failure)
-    (dispatch-reply! (assoc ctx
-                            :kind :failure
-                            :reply-payload {:kind    :failure
-                                            :failure {:kind       :rf.http/accept-failure
-                                                      :detail     (:failure accepted)
-                                                      :decoded    (:decoded ctx)
-                                                      :request-id (:request-id ctx)}}))))
+  Synthetic / test-path callers may pass a ctx with no `:handle`
+  (e.g. some failure-shape unit tests build ctx maps directly). In
+  that case the guard is a no-op — the flag's nil and the call
+  proceeds. The real run-attempt! path always stamps a handle."
+  [ctx]
+  (when-let [flag (:finalised? (:handle ctx))]
+    (not (compare-and-set! flag false true))))
+
+(defn- finalise-success! [ctx accepted]
+  (when-not (already-replied? ctx)
+    (registry/clear-in-flight! (:request-id ctx) (:handle ctx))
+    (cond
+      (contains? accepted :ok)
+      (dispatch-reply! (assoc ctx
+                              :kind :success
+                              :reply-payload {:kind  :success
+                                              :value (:ok accepted)}))
+
+      (contains? accepted :failure)
+      (dispatch-reply! (assoc ctx
+                              :kind :failure
+                              :reply-payload {:kind    :failure
+                                              :failure {:kind       :rf.http/accept-failure
+                                                        :detail     (:failure accepted)
+                                                        :decoded    (:decoded ctx)
+                                                        :request-id (:request-id ctx)}})))))
 
 (defn- finalise-failure!
   "Final-failure dispatch (after retries exhausted or non-retriable).
@@ -408,29 +426,36 @@
   outcome and corrupt debounce-search patterns). The supersede event
   still emits to the trace bus (`:rf.http/aborted` with
   `:reason :request-id-superseded`); consumers wanting abort telemetry
-  subscribe via `register-trace-cb!`."
+  subscribe via `register-trace-cb!`.
+
+  Per rf2-on7sj: guarded by the once-only `:finalised?` CAS so the
+  abort path and a later natural-completion path can't both dispatch
+  a reply for the same request. The trace emit + registry clear ALSO
+  live inside the guard — a doubled trace would be just as observable
+  as a doubled reply on the dev surface."
   [ctx failure]
-  (registry/clear-in-flight! (:request-id ctx) (:handle ctx))
-  (when interop/debug-enabled?
-    ;; rf2-bma05 — redact response-side payload slots (body, body-text,
-    ;; decoded, detail) and the headers denylist before the trace
-    ;; surface sees them; stamp :sensitive? when applicable. The CLJS
-    ;; and JVM transports share the same contract.
-    (let [sensitive? (true? (:sensitive? ctx))
-          redacted   (privacy/prepare-emit-failure
-                       (assoc failure
-                              :request-id (:request-id ctx)
-                              :url        (:url ctx)
-                              :recovery   :no-recovery)
-                       sensitive?)]
-      (trace/emit-error! (:kind failure) redacted)))
-  (let [superseded? (and (= :rf.http/aborted (:kind failure))
-                         (= :request-id-superseded (:reason failure)))]
-    (when-not superseded?
-      (dispatch-reply! (assoc ctx
-                              :kind          :failure
-                              :reply-payload {:kind    :failure
-                                              :failure failure})))))
+  (when-not (already-replied? ctx)
+    (registry/clear-in-flight! (:request-id ctx) (:handle ctx))
+    (when interop/debug-enabled?
+      ;; rf2-bma05 — redact response-side payload slots (body, body-text,
+      ;; decoded, detail) and the headers denylist before the trace
+      ;; surface sees them; stamp :sensitive? when applicable. The CLJS
+      ;; and JVM transports share the same contract.
+      (let [sensitive? (true? (:sensitive? ctx))
+            redacted   (privacy/prepare-emit-failure
+                         (assoc failure
+                                :request-id (:request-id ctx)
+                                :url        (:url ctx)
+                                :recovery   :no-recovery)
+                         sensitive?)]
+        (trace/emit-error! (:kind failure) redacted)))
+    (let [superseded? (and (= :rf.http/aborted (:kind failure))
+                           (= :request-id-superseded (:reason failure)))]
+      (when-not superseded?
+        (dispatch-reply! (assoc ctx
+                                :kind          :failure
+                                :reply-payload {:kind    :failure
+                                                :failure failure}))))))
 
 (defn- maybe-retry!
   "Decide between retry, immediate-final-failure, and successful-completion.
@@ -580,6 +605,56 @@
         ;; attempt controller — abort signalling is host-specific and
         ;; lives outside the sendAsync future.
         #?@(:cljs [internal-controller (js/AbortController.)])
+        ;; rf2-on7sj — once-only reply guard. The abort path AND the
+        ;; subsequent natural-completion path (Fetch .catch on CLJS,
+        ;; CompletableFuture .whenComplete on JVM) both fan into
+        ;; finalise-*; without this CAS each slow-server abort would
+        ;; dispatch TWO replies for the same request — first the
+        ;; synthesised :rf.http/aborted (immediate), then the natural-
+        ;; completion reply (much later, after the underlying transport
+        ;; drains). The flag is stamped on the handle map; finalise-*
+        ;; reads it via `(:finalised? (:handle ctx))` and the abort-fn
+        ;; closure CASes the same atom lexically before dispatching the
+        ;; abort reply itself. JVM additionally cancels the underlying
+        ;; CompletableFuture so the work actually stops (not just the
+        ;; reply path).
+        finalised? (atom false)
+        ;; rf2-on7sj (JVM) — the abort-fn closure must `.cancel cf true`
+        ;; on the underlying CompletableFuture, but cf only exists AFTER
+        ;; this binding (built inside the try-body below). Forward via a
+        ;; one-cell atom that the JVM body fills after construction; the
+        ;; abort-fn reads it lazily through `@cf-holder`.
+        #?@(:clj  [cf-holder (atom nil)])
+        ;; rf2-on7sj — the abort-fn dispatches a synthesised reply
+        ;; directly (no finalise-failure! re-entry). Reuses the same
+        ;; trace-emit + reply-payload shape `finalise-failure!` uses
+        ;; for the natural path so abort + natural failures look
+        ;; identical to consumers. Bypassing finalise-failure! keeps
+        ;; the cancel + CAS + dispatch sequence atomic in the abort
+        ;; path and means the once-only guard has a single owner.
+        dispatch-aborted! (fn [reason]
+                            (let [failure {:kind       :rf.http/aborted
+                                           :request-id request-id
+                                           :reason     reason
+                                           :actor-id   actor-id}]
+                              (when interop/debug-enabled?
+                                (let [sensitive? (true? (:sensitive? ctx-no-handle))
+                                      redacted   (privacy/prepare-emit-failure
+                                                   (assoc failure
+                                                          :url      (:url ctx-no-handle)
+                                                          :recovery :no-recovery)
+                                                   sensitive?)]
+                                  (trace/emit-error! :rf.http/aborted redacted)))
+                              ;; Per rf2-lxd3 — supersede semantics
+                              ;; suppress the reply. Other abort reasons
+                              ;; (`:user`, `:actor-destroyed`, `:timeout`)
+                              ;; all dispatch the failure reply normally.
+                              (when-not (= :request-id-superseded reason)
+                                (dispatch-reply!
+                                  (assoc ctx-no-handle
+                                         :kind          :failure
+                                         :reply-payload {:kind    :failure
+                                                         :failure failure})))))
         ;; Register the abort handle. The handle ref is stamped into ctx
         ;; so finalise-* can clear it from both indexes without needing
         ;; the request-id (handles anonymous-from-actor requests too —
@@ -587,25 +662,46 @@
         handle   (registry/record-in-flight!
                    request-id actor-id
                    {:abort-fn (fn [reason]
-                                #?(:cljs
-                                   (try
-                                     (when internal-controller
-                                       (.abort internal-controller (clj->js reason)))
-                                     (finalise-failure!
-                                       ctx-no-handle
-                                       {:kind       :rf.http/aborted
-                                        :request-id request-id
-                                        :reason     reason
-                                        :actor-id   actor-id})
-                                     (catch :default _ nil))
-                                   :clj
-                                   (finalise-failure!
-                                     ctx-no-handle
-                                     {:kind       :rf.http/aborted
-                                      :request-id request-id
-                                      :reason     reason
-                                      :actor-id   actor-id})))
+                                ;; rf2-on7sj — single-shot CAS guard.
+                                ;; A re-entrant abort (e.g. supersede +
+                                ;; actor-destroy firing in rapid
+                                ;; succession against the same handle)
+                                ;; is a no-op past the first call.
+                                (when (compare-and-set! finalised? false true)
+                                  #?(:cljs
+                                     (try
+                                       (when internal-controller
+                                         (.abort internal-controller (clj->js reason)))
+                                       (catch :default _ nil))
+                                     :clj
+                                     ;; rf2-on7sj — cancel the underlying
+                                     ;; future so it stops running. The
+                                     ;; CompletableFuture's whenComplete
+                                     ;; will still fire (with a
+                                     ;; CancellationException), but
+                                     ;; finalise-failure! is guarded by
+                                     ;; the same :finalised? flag and
+                                     ;; bails before re-emitting.
+                                     ;; `true` = may-interrupt-if-running.
+                                     (when-let [^CompletableFuture cf @cf-holder]
+                                       (try (.cancel cf true)
+                                            (catch Throwable _ nil))))
+                                  ;; Registry cleanup happens here once;
+                                  ;; finalise-failure! is bypassed. The
+                                  ;; 1-arg form resolves the handle by
+                                  ;; request-id and walks both indexes.
+                                  ;; For anonymous (request-id-less)
+                                  ;; requests aborted via actor-destroy,
+                                  ;; the actor-side slot has already
+                                  ;; been cleared atomically by
+                                  ;; `abort-on-actor-destroy` before
+                                  ;; this abort-fn was invoked, so the
+                                  ;; no-op here is correct.
+                                  (registry/clear-in-flight! request-id)
+                                  (dispatch-aborted! reason)))
                     :url url
+                    ;; rf2-on7sj — once-only reply guard, see comment above.
+                    :finalised? finalised?
                     ;; rf2-bma05 — propagate the :sensitive? flag onto
                     ;; the in-flight handle so the actor-destroy abort
                     ;; emit (lives in the registry ns) can stamp the
@@ -631,6 +727,15 @@
            ;; rf2-r40km — pass `url` so `classify-cljs-error` can
            ;; distinguish `:rf.http/cors` from `:rf.http/transport`
            ;; via the cross-origin heuristic.
+           ;; rf2-on7sj — when the abort-fn fired and dispatch-aborted!
+           ;; already replied, the Fetch promise still rejects (because
+           ;; `.abort internal-controller` rejects the underlying
+           ;; fetch); this .catch would call `maybe-retry!` →
+           ;; `finalise-failure!` for a second pass. The once-only
+           ;; `:finalised?` CAS on the handle short-circuits the second
+           ;; dispatch inside finalise-*, so this path stays as the
+           ;; natural-completion sink without a bespoke "did we abort?"
+           ;; check here.
            (.catch (fn [err]
                      (maybe-retry! ctx' (classify-cljs-error err url)))))
        :clj
@@ -642,6 +747,20 @@
                            :body       enc-body
                            :timeout-ms timeout-ms
                            :sensitive? (true? (:sensitive? ctx))})]
+           ;; rf2-on7sj — publish cf to the abort-fn closure's holder
+           ;; BEFORE wiring whenComplete. A racing abort that arrives
+           ;; between `jvm-fetch` returning and `.whenComplete`
+           ;; registering still finds cf in the holder and can cancel
+           ;; it.
+           (reset! cf-holder cf)
+           ;; rf2-on7sj — the whenComplete callback fires even after
+           ;; `.cancel cf true`: the cancel completes-exceptionally
+           ;; with a CancellationException, which routes through this
+           ;; BiConsumer as `throwable`. `maybe-retry!` →
+           ;; `finalise-failure!` is then guarded by the once-only
+           ;; `:finalised?` CAS (the abort-fn already finalised), so
+           ;; the abort's reply is the only one that ever reaches the
+           ;; user.
            (.whenComplete cf
                           (reify java.util.function.BiConsumer
                             (accept [_ result throwable]

--- a/implementation/http/src/re_frame/http_url.cljc
+++ b/implementation/http/src/re_frame/http_url.cljc
@@ -184,12 +184,23 @@
           [query fragment]          (split-query-on-fragment query-and-fragment)]
       (if (str/blank? query)
         [url-str false]
-        (let [pairs    (str/split query #"&")
-              redacted (mapv (fn [p] (redact-query-param p (true? sensitive?)))
-                             pairs)
-              changed? (boolean (some true? (map not= pairs redacted)))
-              rebuilt  (str base "?" (str/join "&" redacted) (or fragment ""))]
-          [rebuilt changed?])))))
+        ;; rf2-dqchf — single pass: thread a volatile changed? flag
+        ;; through the mapv so the redactor and the change-detection
+        ;; share one walk over the pairs. Previously the change
+        ;; detection ran a second `(map not= pairs redacted)` walk and
+        ;; allocated a lazy seq of N booleans for the `some true?` test
+        ;; despite the rf2-02vzz claim of fusion.
+        (let [force-all? (true? sensitive?)
+              changed?   (volatile! false)
+              pairs      (str/split query #"&")
+              redacted   (mapv (fn [p]
+                                 (let [out (redact-query-param p force-all?)]
+                                   (when-not (identical? out p)
+                                     (vreset! changed? true))
+                                   out))
+                               pairs)
+              rebuilt    (str base "?" (str/join "&" redacted) (or fragment ""))]
+          [rebuilt @changed?])))))
 
 (defn redact-url
   "Convenience wrapper around `redact-url-query-string` that returns only

--- a/implementation/http/test/re_frame/http_interceptors_test.clj
+++ b/implementation/http/test/re_frame/http_interceptors_test.clj
@@ -586,3 +586,159 @@
         "second call on the already-empty registry is also nil")
     (is (= {} @http-managed/interceptors)
         "atom stays empty")))
+
+;; ---- rf2-oyd1b — direct unit tests for the fx wrappers --------------------
+;;
+;; The :rf.fx/reg-http-interceptor + :rf.fx/clear-http-interceptor fxs
+;; (rf2-yhfgf) are exercised through conformance fixtures
+;; (spec/conformance/fixtures/http-interceptor-*). These tests pin the
+;; wrapper contract directly so a conformance-harness DSL change
+;; doesn't ripple — and so a regression in either fx surfaces here
+;; with a precise failure rather than as a conformance-fixture flake.
+
+(deftest reg-http-interceptor-fx-mutates-the-atom-rf2-oyd1b
+  (testing "rf2-oyd1b — [:rf.fx/reg-http-interceptor {...}] adds an
+            interceptor to @http-managed/interceptors on :rf/default."
+    (rf/reg-event-fx :oyd1b/register
+      (fn [_ _]
+        {:fx [[:rf.fx/reg-http-interceptor
+               {:id     :oyd1b/auth
+                :before identity
+                :doc    "fixture interceptor"
+                :tags   #{:auth}}]]}))
+
+    (is (empty? (get @http-managed/interceptors :rf/default))
+        "pre-dispatch: no interceptors on :rf/default")
+
+    (rf/dispatch-sync [:oyd1b/register])
+
+    (let [chain (get @http-managed/interceptors :rf/default)
+          slot  (first (filter #(= :oyd1b/auth (:id %)) chain))]
+      (is (= 1 (count chain))
+          "the fx wrapper actually mutates the atom (not just a return-value smoke)")
+      (is (= :oyd1b/auth (:id slot)))
+      (is (fn? (:before slot)))
+      (is (= "fixture interceptor" (:doc slot)))
+      (is (= #{:auth} (:tags slot))))))
+
+(deftest reg-http-interceptor-fx-honours-explicit-frame-rf2-oyd1b
+  (testing "rf2-oyd1b — explicit :frame routes to the named slot, not :rf/default"
+    (rf/reg-event-fx :oyd1b/register-on-named
+      (fn [_ _]
+        {:fx [[:rf.fx/reg-http-interceptor
+               {:frame  :rf/api
+                :id     :oyd1b/named
+                :before identity}]]}))
+
+    (rf/dispatch-sync [:oyd1b/register-on-named])
+
+    (is (empty? (get @http-managed/interceptors :rf/default))
+        ":rf/default is not touched by an :rf/api registration")
+    (let [chain (get @http-managed/interceptors :rf/api)]
+      (is (= 1 (count chain)))
+      (is (= :oyd1b/named (:id (first chain)))))))
+
+(deftest clear-http-interceptor-fx-mutates-the-atom-rf2-oyd1b
+  (testing "rf2-oyd1b — [:rf.fx/clear-http-interceptor {:id ...}] removes
+            the slot from :rf/default (the implicit frame)."
+    (http-managed/reg-http-interceptor
+      {:id :oyd1b/to-clear :before identity})
+    (is (= 1 (count (get @http-managed/interceptors :rf/default)))
+        "pre-clear: the slot is present")
+
+    (rf/reg-event-fx :oyd1b/clear
+      (fn [_ _]
+        {:fx [[:rf.fx/clear-http-interceptor {:id :oyd1b/to-clear}]]}))
+    (rf/dispatch-sync [:oyd1b/clear])
+
+    (is (empty? (get @http-managed/interceptors :rf/default))
+        "the slot is gone after the fx")))
+
+(deftest clear-http-interceptor-fx-honours-explicit-frame-rf2-oyd1b
+  (testing "rf2-oyd1b — explicit :frame on the clear fx scopes the removal"
+    (http-managed/reg-http-interceptor
+      {:frame :rf/api :id :oyd1b/scoped :before identity})
+    (http-managed/reg-http-interceptor
+      {:id :oyd1b/default-survivor :before identity})
+
+    (rf/reg-event-fx :oyd1b/clear-on-named
+      (fn [_ _]
+        {:fx [[:rf.fx/clear-http-interceptor
+               {:frame :rf/api :id :oyd1b/scoped}]]}))
+    (rf/dispatch-sync [:oyd1b/clear-on-named])
+
+    (is (empty? (get @http-managed/interceptors :rf/api))
+        ":rf/api lost its slot")
+    (is (= 1 (count (get @http-managed/interceptors :rf/default)))
+        ":rf/default is unaffected — the clear was scoped to :rf/api")))
+
+(deftest clear-http-interceptor-fx-defaults-frame-to-rf-default-rf2-oyd1b
+  (testing "rf2-oyd1b — when :frame is nil/absent the fx routes to :rf/default
+            (matching the fn-form behaviour)."
+    (http-managed/reg-http-interceptor
+      {:id :oyd1b/dflt :before identity})
+    (rf/reg-event-fx :oyd1b/clear-no-frame
+      (fn [_ _]
+        ;; No :frame key — must default to :rf/default.
+        {:fx [[:rf.fx/clear-http-interceptor {:id :oyd1b/dflt}]]}))
+    (rf/dispatch-sync [:oyd1b/clear-no-frame])
+    (is (empty? (get @http-managed/interceptors :rf/default)))))
+
+(deftest reg-http-interceptor-fx-rejects-invalid-args-rf2-oyd1b
+  (testing "rf2-oyd1b — invalid args (missing :id, missing :before, non-keyword
+            id) trigger the same :rf.error/http-bad-interceptor throw the
+            fn-form raises. The error fires inside the runtime's fx
+            dispatch loop, so we trap via a trace-error listener and
+            assert NO interceptor was registered."
+    (let [errors (atom [])
+          cb-id  ::oyd1b-bad-args]
+      (try
+        (trace/register-trace-cb!
+          cb-id
+          (fn [ev]
+            (when (= :error (:op-type ev))
+              (swap! errors conj ev))))
+
+        ;; missing :id
+        (rf/reg-event-fx :oyd1b/bad-no-id
+          (fn [_ _]
+            {:fx [[:rf.fx/reg-http-interceptor {:before identity}]]}))
+        (try (rf/dispatch-sync [:oyd1b/bad-no-id])
+             (catch Throwable _ nil))
+        (is (empty? (get @http-managed/interceptors :rf/default))
+            "missing :id → no interceptor registered")
+
+        ;; missing :before
+        (rf/reg-event-fx :oyd1b/bad-no-before
+          (fn [_ _]
+            {:fx [[:rf.fx/reg-http-interceptor {:id :x}]]}))
+        (try (rf/dispatch-sync [:oyd1b/bad-no-before])
+             (catch Throwable _ nil))
+        (is (empty? (get @http-managed/interceptors :rf/default))
+            "missing :before → no interceptor registered")
+
+        ;; non-keyword :id
+        (rf/reg-event-fx :oyd1b/bad-string-id
+          (fn [_ _]
+            {:fx [[:rf.fx/reg-http-interceptor
+                   {:id "not-a-keyword" :before identity}]]}))
+        (try (rf/dispatch-sync [:oyd1b/bad-string-id])
+             (catch Throwable _ nil))
+        (is (empty? (get @http-managed/interceptors :rf/default))
+            "non-keyword :id → no interceptor registered")
+
+        (finally
+          (trace/remove-trace-cb! cb-id))))))
+
+(deftest reg-and-clear-http-interceptor-fxs-roundtrip-rf2-oyd1b
+  (testing "rf2-oyd1b — register-then-clear via fxs round-trips cleanly,
+            mirroring the fn-form's idempotency."
+    (rf/reg-event-fx :oyd1b/round-trip
+      (fn [_ _]
+        {:fx [[:rf.fx/reg-http-interceptor
+               {:id :oyd1b/rt :before identity}]
+              [:rf.fx/clear-http-interceptor
+               {:id :oyd1b/rt}]]}))
+    (rf/dispatch-sync [:oyd1b/round-trip])
+    (is (empty? (get @http-managed/interceptors :rf/default))
+        "register followed by clear in the same event leaves the chain empty")))

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -482,6 +482,98 @@
         (.countDown latch)
         (finally (stop-server! srv))))))
 
+;; ---- 9a. rf2-on7sj — abort + slow server must dispatch EXACTLY ONE reply ----
+;;
+;; Pre-fix: the JVM abort-fn closure called finalise-failure! with the
+;; synthesised :rf.http/aborted reply, but DID NOT `.cancel cf true` on
+;; the underlying CompletableFuture. When the server eventually
+;; responded (or the cf naturally completed), `.whenComplete` fired
+;; handle-response! → finalise-success! (or maybe-retry!), dispatching
+;; a SECOND reply for the same request — observable on the consuming
+;; event handler as a double-reply on slow-server aborts.
+;;
+;; The existing `jvm-abort-by-request-id` test (above) doesn't notice:
+;; it asserts the abort reply lands, then ends without waiting for the
+;; latch release that would fire the second reply.
+;;
+;; This regression test:
+;;   1. Spins up a latched server that blocks until released.
+;;   2. Dispatches the managed request.
+;;   3. Aborts (synthesised reply fires immediately).
+;;   4. RELEASES the latch (lets the underlying transport finish).
+;;   5. Waits long enough for the natural-completion path to fire.
+;;   6. Asserts the reply-counter is EXACTLY 1.
+
+(deftest jvm-abort-then-server-release-emits-exactly-one-reply-rf2-on7sj
+  (testing "rf2-on7sj — slow-server abort must produce exactly ONE reply
+            even after the underlying server eventually responds. The
+            abort-fn cancels the CompletableFuture and CAS-guards the
+            reply path so the latent whenComplete callback's natural
+            second emit is suppressed."
+    (let [latch (CountDownLatch. 1)
+          reply-count (atom 0)
+          all-replies (atom [])
+          {:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              ;; Block until the test releases the latch — simulating
+              ;; a slow server that responds AFTER abort.
+              (.await latch 10 TimeUnit/SECONDS)
+              (write-response! ex 200 "application/json"
+                               "{\"server\":\"responded-after-abort\"}")))]
+      (try
+        (rf/reg-event-fx :on7sj/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              (do
+                (swap! reply-count inc)
+                (swap! all-replies conj reply)
+                {:db (assoc db :reply reply)})
+              {:fx [[:rf.http/managed
+                     {:request    {:url (str "http://127.0.0.1:" port "/slow")}
+                      :request-id :on7sj/req
+                      :decode     :json}]]})))
+        (rf/reg-event-fx :on7sj/abort
+          (fn [_ _] {:fx [[:rf.http/managed-abort :on7sj/req]]}))
+
+        ;; Issue the request. Server blocks on the latch.
+        (rf/dispatch-sync [:on7sj/load])
+        (Thread/sleep 50)
+        ;; Abort while server is still blocked. The synthesised
+        ;; :rf.http/aborted reply should fire immediately.
+        (rf/dispatch-sync [:on7sj/abort])
+        ;; Wait for the abort reply.
+        (let [db (await-reply! #(some? (:reply %)) 5000)]
+          (is (= :failure (get-in db [:reply :kind])))
+          (is (= :rf.http/aborted (get-in db [:reply :failure :kind])))
+          (is (= 1 @reply-count)
+              "exactly one reply must have fired immediately after abort"))
+
+        ;; Release the server. Pre-fix: the underlying CompletableFuture
+        ;; was never cancelled and would now drain → whenComplete fires
+        ;; → second reply dispatched (the load-bearing bug). Post-fix:
+        ;; the cf.cancel + :finalised? CAS guard ensures the second
+        ;; reply path no-ops.
+        (.countDown latch)
+        ;; Wait long enough for any latent reply to fire. The server
+        ;; blocked above, but once the latch releases it writes the
+        ;; response immediately. The whenComplete callback would fire
+        ;; on the JDK HttpClient's executor; allow >500ms for the
+        ;; second reply to surface if the guard fails.
+        (Thread/sleep 800)
+
+        (is (= 1 @reply-count)
+            (str "rf2-on7sj — exactly ONE reply must fire across abort + server-release. "
+                 "Pre-fix this would dispatch TWO. Saw "
+                 @reply-count " replies: "
+                 (pr-str (mapv :kind @all-replies))))
+        (is (= 1 (count @all-replies))
+            "the all-replies log carries a single entry, matching the counter")
+        (is (= :rf.http/aborted (get-in (first @all-replies) [:failure :kind]))
+            "the single reply is the abort reply, not the late natural-completion one")
+
+        (finally (stop-server! srv))))))
+
 ;; ---- 10. thunk body -------------------------------------------------------
 
 (deftest jvm-thunk-body

--- a/implementation/http/test/re_frame/http_source_coords_test.clj
+++ b/implementation/http/test/re_frame/http_source_coords_test.clj
@@ -1,0 +1,133 @@
+(ns re-frame.http-source-coords-test
+  "Pin test for rf2-may3f: `:rf/http-interceptor-meta` source-coords
+  must actually flow into the stored interceptor slot.
+
+  rf2-gsl5v (PR #1165) promoted `rf/reg-http-interceptor` to a
+  `defreg-macro` form so source-coords (`:ns` / `:line` / `:column` /
+  `:file`) auto-capture at the call site per Spec 001 §Source-coordinate
+  capture, and `Spec-Schemas.md` documents `:rf/http-interceptor-meta`
+  as `[:merge RegistrationMetadata ...]`. Other reg-* surfaces have
+  analogous coverage in `core/test/re_frame/source_coords_test.clj`;
+  this file is the http-artefact sibling.
+
+  Asserted invariants:
+
+  1. A user-facing `rf/reg-http-interceptor` call site stamps :ns,
+     :line, :column, :file on the stored slot.
+  2. User-supplied `:doc` / `:tags` / `:sensitive?` flow through
+     into the slot alongside the auto-captured coords.
+  3. User-supplied `:ns` / `:line` overrides the auto-captured
+     values (the source-coords contract per Spec 001 — explicit user
+     keys win over framework auto-capture)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.flows :as flows]
+            [re-frame.http-managed :as http-managed]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(defn- reset-runtime [t]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr     :reload)
+  (require 're-frame.http-managed :reload)
+  (http-managed/clear-all-in-flight!)
+  (http-managed/clear-all-http-interceptors!)
+  (t))
+
+(use-fixtures :each reset-runtime)
+
+(defn- slot-for
+  "Locate the stored slot for `id` on `frame-id` in @http-managed/interceptors."
+  [frame-id id]
+  (->> (get @http-managed/interceptors frame-id)
+       (filter #(= id (:id %)))
+       first))
+
+(deftest reg-http-interceptor-stamps-auto-captured-source-coords-rf2-may3f
+  (testing "rf2-may3f — `rf/reg-http-interceptor` stamps :ns / :line /
+            :column / :file from the call site into the stored slot per
+            Spec 001 §Source-coordinate capture + the
+            :rf/http-interceptor-meta schema."
+    (rf/reg-http-interceptor
+      {:id     :rf2-may3f/auth
+       :before (fn [c] c)})
+    (let [slot (slot-for :rf/default :rf2-may3f/auth)]
+      (is (some? slot)
+          "the interceptor must actually land in the chain")
+      (is (= 're-frame.http-source-coords-test (:ns slot))
+          ":ns is captured as a symbol matching the call-site ns")
+      (is (pos-int? (:line slot))
+          ":line is a positive integer")
+      (is (pos-int? (:column slot))
+          ":column is a positive integer")
+      (is (string? (:file slot))
+          ":file is a string (the source filename)"))))
+
+(deftest reg-http-interceptor-preserves-user-metadata-rf2-may3f
+  (testing "rf2-may3f — user-supplied :doc / :tags / :sensitive? flow
+            into the stored slot alongside the auto-captured source
+            coords. None of the registration-metadata keys are dropped
+            by the merge."
+    (rf/reg-http-interceptor
+      {:id         :rf2-may3f/with-meta
+       :doc        "auth header attacher"
+       :tags       #{:auth :security}
+       :sensitive? true
+       :before     identity})
+    (let [slot (slot-for :rf/default :rf2-may3f/with-meta)]
+      (is (some? slot))
+      (is (= "auth header attacher" (:doc slot)))
+      (is (= #{:auth :security} (:tags slot)))
+      (is (true? (:sensitive? slot)))
+      ;; Auto-captured coords still present.
+      (is (some? (:ns slot)))
+      (is (pos-int? (:line slot))))))
+
+(deftest reg-http-interceptor-user-coord-keys-override-rf2-may3f
+  (testing "rf2-may3f — explicit user-supplied :ns / :line / :column /
+            :file override the auto-captured values per the source-
+            coords contract (Spec 001). The merge order is
+            auto-capture-then-user-keys, so user keys win."
+    (rf/reg-http-interceptor
+      {:id     :rf2-may3f/forwarded
+       :ns     'app.wrappers.http-interceptor-builder
+       :line   42
+       :column 7
+       :file   "src/app/wrappers/http.clj"
+       :before identity})
+    (let [slot (slot-for :rf/default :rf2-may3f/forwarded)]
+      (is (some? slot))
+      (is (= 'app.wrappers.http-interceptor-builder (:ns slot))
+          "explicit :ns wins over auto-captured")
+      (is (= 42 (:line slot))
+          "explicit :line wins")
+      (is (= 7 (:column slot))
+          "explicit :column wins")
+      (is (= "src/app/wrappers/http.clj" (:file slot))
+          "explicit :file wins"))))
+
+(deftest reg-http-interceptor-frame-key-not-leaked-into-slot-rf2-may3f
+  (testing "rf2-may3f — the :frame argument is consumed (set on the slot
+            for in-chain lookup) but the user-meta merge dissocs :frame
+            / :id / :before before merging coord keys, so no doubled
+            entries appear."
+    (rf/reg-http-interceptor
+      {:frame  :rf/api
+       :id     :rf2-may3f/api-scoped
+       :doc    "scoped to :rf/api"
+       :before identity})
+    (let [slot (slot-for :rf/api :rf2-may3f/api-scoped)]
+      (is (some? slot)
+          "the slot lands on :rf/api, not :rf/default")
+      (is (= :rf/api (:frame slot))
+          ":frame is stamped on the slot for in-chain lookup")
+      (is (= "scoped to :rf/api" (:doc slot)))
+      (is (= :rf2-may3f/api-scoped (:id slot)))
+      (is (fn? (:before slot))))))

--- a/implementation/http/test/re_frame/http_transport_security_test.clj
+++ b/implementation/http/test/re_frame/http_transport_security_test.clj
@@ -253,3 +253,47 @@
             (is (= "https://example.invalid/v1?q=:rf/redacted&page=:rf/redacted"
                    (:url tags)))
             (is (true? (:sensitive? w)))))))))
+
+;; ---- rf2-q3ts4 — classify-jvm-error no longer string-matches "abort"/"timed out" ----
+
+;; Reach the private fn via #' so the public surface stays unchanged.
+(def ^:private classify-jvm-error
+  @#'re-frame.http-transport/classify-jvm-error)
+
+(deftest classify-jvm-error-uses-instance-checks-only
+  (testing "rf2-q3ts4 — HttpTimeoutException → :rf.http/timeout (instance match)"
+    (let [t (java.net.http.HttpTimeoutException. "request timed out after 30s")
+          out (classify-jvm-error t)]
+      (is (= :rf.http/timeout (:kind out)))
+      (is (string? (:message out)))))
+
+  (testing "rf2-q3ts4 — CancellationException → :rf.http/aborted (instance match)"
+    (let [t (java.util.concurrent.CancellationException. "cancelled")
+          out (classify-jvm-error t)]
+      (is (= :rf.http/aborted (:kind out)))
+      (is (= :user (:reason out)))))
+
+  (testing "rf2-q3ts4 — a downstream service's error whose message contains
+            \"timed out\" or \"abort\" must NOT misclassify. Pre-fix the
+            substring fallback would route these to :rf.http/timeout /
+            :rf.http/aborted; post-fix they correctly stay at
+            :rf.http/transport (the catch-all for unknown JDK failures)."
+    (let [timed-out-substring-trap
+          (java.io.IOException. "upstream service reported: gateway timed out at edge")
+          abort-substring-trap
+          (java.lang.RuntimeException. "user clicked abort on 3rd-party retry-wrapper")
+          out-1 (classify-jvm-error timed-out-substring-trap)
+          out-2 (classify-jvm-error abort-substring-trap)]
+      (is (= :rf.http/transport (:kind out-1))
+          "an IOException whose message says \"timed out\" is NOT a JDK timeout — stays at :rf.http/transport")
+      (is (= :rf.http/transport (:kind out-2))
+          "a RuntimeException whose message says \"abort\" is NOT a JDK cancellation — stays at :rf.http/transport")
+      (is (= "java.io.IOException" (:cause out-1)))
+      (is (= "java.lang.RuntimeException" (:cause out-2)))))
+
+  (testing "rf2-q3ts4 — wrapped causes still resolve through (.getCause t)"
+    (let [inner (java.net.http.HttpTimeoutException. "inner timeout")
+          outer (java.util.concurrent.CompletionException. inner)
+          out (classify-jvm-error outer)]
+      (is (= :rf.http/timeout (:kind out))
+          "the JDK HttpClient wraps in CompletionException; classify- still resolves the underlying HttpTimeoutException via (.getCause t)"))))


### PR DESCRIPTION
## Summary

Eight-bead cluster implementing follow-ons from the http-slice audit (rf2-wui5v, findings at `ai/findings/http-slice-audit-2026-05-15.md`). One P1 correctness fix, two P3 bug-fixes, one P3 perf fix, two P3 test pins, one P4 polish, one P4 docs.

**rf2-on7sj is the load-bearing fix** — the JVM abort-fn didn't `.cancel cf true` on the underlying CompletableFuture, so slow-server aborts dispatched TWO replies (the synthesised :rf.http/aborted, then the natural-completion result much later). Symmetric CLJS concern addressed via the same once-only `:finalised?` CAS guard.

## Per-bead one-line summary

- **rf2-k7tlm** (P4 docs) — clarify `:rf.fx/clear-http-interceptor` map-shape vs fn-form positional asymmetry in the fx docstring.
- **rf2-m32t9** (P4 polish) — interceptor `:before`-non-map cause string now includes the interceptor id for stack-trace locatability.
- **rf2-05df7** (P3 cleanup) — drop dead `timeout-fired?` atom in cljs-fetch.
- **rf2-q3ts4** (P3 bug) — narrow `classify-jvm-error` to instance checks only; the `str/includes? "timed out"` / `"abort"` fallbacks misclassified downstream service errors. Regression tests pin the misclassification cases.
- **rf2-dqchf** (P3 perf) — fuse `redact-url-query-string` into a single walk; rf2-02vzz had claimed fusion but the change-detection ran a second `map not=` pass.
- **rf2-oyd1b** (P3 test) — seven direct unit tests for `:rf.fx/reg-http-interceptor` + `:rf.fx/clear-http-interceptor` (previously covered only via conformance fixtures).
- **rf2-may3f** (P3 test) — new file pinning `:rf/http-interceptor-meta` source-coords (auto-capture, user-meta preservation, user-coord-key override, frame-key handling).
- **rf2-on7sj** (P1 bug) — JVM abort-fn now `.cancel cf true`s the CompletableFuture; once-only `:finalised?` CAS atom on the handle prevents abort + natural-completion both dispatching replies. CLJS symmetric concern (rejection from `.abort internal-controller` riding through `.catch`) handled by the same CAS in finalise-*.

## rf2-on7sj before/after evidence

The new regression test (`jvm-abort-then-server-release-emits-exactly-one-reply-rf2-on7sj`) latches a server, dispatches the request, aborts, releases the latch, waits 800ms, and counts replies.

**Pre-fix** (transport.cljc reverted, test ran):
```
FAIL: rf2-on7sj — exactly ONE reply must fire across abort + server-release.
      Pre-fix this would dispatch TWO. Saw 2 replies: [:failure :success]
expected: (= 1 (clojure.core/deref reply-count))
  actual: (not (= 1 2))
```

**Post-fix**: 1 reply, sequence `[:failure]` (just the abort). All 170 prior tests + the new regression pass.

## Test summary

- JVM (`implementation/http`, `clojure -M:test`): 181 tests / 524 assertions, 0 failures (was 168 / 470 pre-cluster). Added 13 tests + 54 assertions.
- CLJS (`npm run test:cljs`): 2015 tests / 5683 assertions, 0 failures.

## Test plan

- [x] JVM http tests: 181 tests, all pass
- [x] CLJS test:cljs: 2015 tests, all pass
- [x] rf2-on7sj regression test demonstrated to fail on pre-fix transport.cljc (captured 2-reply sequence)
- [x] No spec/*.md edits (hot-zone avoided)
- [x] No changes outside `implementation/http/`