### PR TITLE
perf(adapters/reagent): make-derived-value drop apply + lazy map deref (rf2-v1nu0)

### DIFF
--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -33,8 +33,25 @@
 ;; ---- derived (reactions) --------------------------------------------------
 
 (defn- make-derived-value [source-containers compute-fn]
-  (ratom/make-reaction
-    (fn [] (apply compute-fn (map deref source-containers)))))
+  ;; Per recompute we want zero lazy-seq allocation and zero `apply`
+  ;; cost on the dominant arities. Subs typically chain off 1 input
+  ;; (layer-1 always; layer-n usually 1–2); specialise those, fall
+  ;; back to `mapv` (eager, vector-backed) + `apply` for ≥3.
+  ;; rf2-v1nu0; sourced from the rf2-fzrav perf sweep findings.
+  ;;
+  ;; `count` is captured once at construction (source-containers is a
+  ;; vector — see `inputs` in `re-frame.subs`) so the recompute closure
+  ;; pays no per-tick count.
+  (let [n (count source-containers)
+        recompute (case n
+                    0 (fn [] (compute-fn))
+                    1 (let [s0 (nth source-containers 0)]
+                        (fn [] (compute-fn @s0)))
+                    2 (let [s0 (nth source-containers 0)
+                            s1 (nth source-containers 1)]
+                        (fn [] (compute-fn @s0 @s1)))
+                    (fn [] (apply compute-fn (mapv deref source-containers))))]
+    (ratom/make-reaction recompute)))
 
 ;; ---- render ---------------------------------------------------------------
 ;;


### PR DESCRIPTION
## Summary

Per the rf2-fzrav perf sweep findings (`ai/findings/perf-sweep-2026-05-15.md` §M2): the Reagent adapter's `make-derived-value` ran `(apply compute-fn (map deref source-containers))` on every reaction recompute — for every sub recompute, every dispatch. That allocates a lazy seq (one cons cell per source) and pays `apply` traversal cost.

Specialise the dominant arities at construction time (most subs chain off 1 input; layer-1 always does, layer-n usually 1–2):

```
n=0  -> (compute-fn)
n=1  -> (compute-fn @s0)
n=2  -> (compute-fn @s0 @s1)
n>=3 -> (apply compute-fn (mapv deref source-containers))
```

`count` is captured once at construction (`source-containers` is a vector — see `inputs` in `re-frame.subs`), so the recompute closure pays no per-tick `count`. Arity-1/2 closures also capture sources via `nth` once, removing repeat indexing per recompute. The fallback uses `mapv` (eager, vector-backed) instead of lazy `map`.

Behaviourally identical to the prior code for ≥3 inputs.

## Test plan

- [x] `cd implementation && npm run test:cljs` — 2045 tests, 5805 assertions, 0 failures, 0 errors.

Closes rf2-v1nu0.