### PR TITLE
perf(routing): match-against single-realisation (rf2-wji4w)

### DIFF
--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -311,7 +311,10 @@
         m (re-matches regex url)]
     (when m
       (let [groups  (if (sequential? m) (rest m) [])
-            decoded (map (fn [g] (when g (safe-url-decode g))) groups)]
+            ;; Realise into a vector once — `decoded` is consumed twice
+            ;; below (validity scan + zipmap), and a lazy-seq would be
+            ;; walked (and `safe-url-decode` re-invoked) on each pass.
+            decoded (mapv (fn [g] (when g (safe-url-decode g))) groups)]
         ;; A nil entry for a non-nil group means malformed %-encoding —
         ;; treat as no-match (route-miss, never throw).
         (when (every? (fn [[g d]] (or (nil? g) (some? d)))


### PR DESCRIPTION
## Summary

`match-against` realised the `decoded` lazy-seq twice on every successful pattern match — once for the malformed-percent-encoding scan, then again to build the params map. Each pass re-walked the seq and re-invoked `safe-url-decode` on every captured group.

Switch `map` → `mapv` so the decoded values are realised into a vector once and reused for both consumers.

### Before
```clojure
decoded (map (fn [g] (when g (safe-url-decode g))) groups)
;; decoded walked + safe-url-decode invoked once per group in:
;;   (every? ... (map vector groups decoded))   ; pass 1
;; ...and again in:
;;   (zipmap (map keyword names) decoded)       ; pass 2
```

### After
```clojure
decoded (mapv (fn [g] (when g (safe-url-decode g))) groups)
;; realised once; both consumers walk the materialised vector
```

Behaviour unchanged. Source: rf2-fzrav perf sweep.

## Test plan

- [x] `clojure -M:test` from `implementation/routing/` — 85 tests / 371 assertions, 0 failures, 0 errors