### PR TITLE
perf(schemas): walker/prefix? single-pass (rf2-ikxb5)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/walker.cljc
+++ b/implementation/schemas/src/re_frame/schemas/walker.cljc
@@ -232,10 +232,17 @@
 
 (defn- prefix?
   "True when `prefix` is a prefix of `path` (or equal). Both are
-  sequential collections compared element-wise."
+  indexed vectors compared element-wise. Single-pass: counts each
+  input once, no lazy-seq allocation (rf2-ikxb5 — call-site is the
+  hot `schema-sensitive-at?` `some` over `(keys decls)`)."
   [prefix path]
-  (and (<= (count prefix) (count path))
-       (= (seq prefix) (seq (take (count prefix) path)))))
+  (let [pn (count prefix)]
+    (and (<= pn (count path))
+         (loop [i 0]
+           (cond
+             (== i pn)                    true
+             (= (nth prefix i) (nth path i)) (recur (inc i))
+             :else                         false)))))
 
 (defn schema-sensitive-at?
   "Path-targeted sensitivity check (rf2-oh4se). Returns true when the


### PR DESCRIPTION
## Summary
- `walker/prefix?` previously allocated a `(take ...)` lazy-seq and called `count` twice. Replaced with a single-pass `loop` over indexed positions: counts each input once and skips lazy-seq allocation entirely.
- Both call-site inputs (`decl-path` from `(keys decls)` and `in-v` from `(vec in-path)`) are vectors, so `nth` is O(1).
- Hot via `schema-sensitive-at?`'s `some` over `(keys decls)` at every Spec 010 sensitive-redaction emit-site.

## Before
```clojure
(and (<= (count prefix) (count path))
     (= (seq prefix) (seq (take (count prefix) path))))
```

## After
```clojure
(let [pn (count prefix)]
  (and (<= pn (count path))
       (loop [i 0]
         (cond
           (== i pn)                       true
           (= (nth prefix i) (nth path i)) (recur (inc i))
           :else                           false))))
```

## Test plan
- [x] `cd implementation/schemas && clojure -M:test` — 185 tests / 522 assertions, 0 failures.

Refs: rf2-ikxb5 (sourced from rf2-fzrav perf sweep).