### PR TITLE
spec(Managed-Effects): align flow failure taxonomy with impl (rf2-kvdx9)

### DIFF
--- a/spec/Managed-Effects.md
+++ b/spec/Managed-Effects.md
@@ -42,7 +42,7 @@ Failures are classified into a closed, enumerable taxonomy under a single reserv
 | WebSocket connections | `:rf.ws/*` (`:rf.ws/transport`, `:rf.ws/auth`, `:rf.ws/stale-socket`, ...) | [Pattern-WebSocket](Pattern-WebSocket.md) |
 | State-machine actors | `:rf.machine/*` (`:rf.machine/invoke-failed`, `:rf.machine/snapshot-version-mismatch`, ...) | [005 §Error contract](005-StateMachines.md) |
 | SSR per-request | `:rf.ssr/*` (`:rf.ssr/hydration-mismatch`, `:rf.ssr/render-failed`, ...) | [011 §Error contract](011-SSR.md) |
-| Managed flows | `:rf.flow/*` (`:rf.flow/cycle-detected`, `:rf.flow/output-throw`, ...) | [013 §Errors](013-Flows.md) |
+| Managed flows | `:rf.flow/*` per-flow trace operations (`:rf.flow/failed` on `:output` throw, `:rf.flow/computed` / `:rf.flow/skip` on success); cascade-level `:rf.error/flow-eval-exception` at the router's outer catch; registration-time `:rf.error/flow-cycle` ex-info | [013 §Failure semantics](013-Flows.md#failure-semantics) |
 
 Every failure is a structured trace event with `:operation`, `:tags`, and `:recovery` per [009 §Error contract](009-Instrumentation.md#error-contract). No surface invents its own error shape.
 
@@ -88,7 +88,7 @@ Six server-side response-shape fxs (`set-status`, `set-header`, `append-header`,
 
 ### `:rf.flow/*` — managed derived computation ([Spec 013](013-Flows.md))
 
-The internal-effect cousin. The "external system" is the framework's own scheduler — flows are registered rules that compute on input change and materialise their output into `app-db`. They satisfy the eight properties applied to a derived-state surface: effect-as-data (the registration map), framework-owned execution (the scheduler runs them after each event drain in topological order), failure taxonomy (`:rf.flow/cycle-detected`, `:rf.flow/output-throw`), trace-bus observability (`:rf.flow/evaluated` per evaluation), elision composition (`:sensitive?` on flow outputs), retry/abort/teardown (runtime-toggleable via `:rf.fx/reg-flow` / `:rf.fx/clear-flow`), in-flight registry (queryable via the registrar), per-frame scoping (flows are frame-local — see [013 §Frame-scoping](013-Flows.md#frame-scoping)).
+The internal-effect cousin. The "external system" is the framework's own scheduler — flows are registered rules that compute on input change and materialise their output into `app-db`. They satisfy the eight properties applied to a derived-state surface: effect-as-data (the registration map), framework-owned execution (the scheduler runs them after each event drain in topological order), failure taxonomy (per-flow `:rf.flow/failed` on `:output` throw under the four-rule contract at [013 §Failure semantics](013-Flows.md#failure-semantics) — prior writes preserved, failing flow's `last-inputs` not advanced, cascade halts, router emits `:rf.error/flow-eval-exception`; registration-time cycles throw `:rf.error/flow-cycle`), trace-bus observability (`:rf.flow/computed` and `:rf.flow/skip` per evaluation, plus `:rf.flow/registered` / `:rf.flow/cleared` lifecycle events), elision composition (`:sensitive?` on flow outputs), retry/abort/teardown (runtime-toggleable via `:rf.fx/reg-flow` / `:rf.fx/clear-flow`), in-flight registry (queryable via the registrar), per-frame scoping (flows are frame-local — see [013 §Frame-scoping](013-Flows.md#frame-scoping)).
 
 ## How new managed-effect surfaces inherit the contract
 


### PR DESCRIPTION
## Summary

Fixes F5 of the spec/impl alignment audit (`ai/findings/spec-impl-alignment-sweep-2026-05-15.md`). `spec/Managed-Effects.md` referenced flow failure operations that exist in neither Spec 013 nor the implementation:

- **Was:** `:rf.flow/cycle-detected`, `:rf.flow/output-throw`, `:rf.flow/evaluated`
- **Is (per Spec 013 + impl):**
  - per-flow output throw → `:rf.flow/failed` (four-rule contract from rf2-hrqvg / PR #1172 fx-after-throw fix in rf2-fslx0)
  - cascade-level surface → `:rf.error/flow-eval-exception` at router's outer catch
  - registration-time cycle → `:rf.error/flow-cycle` ex-info (not a runtime trace event)
  - per-evaluation traces → `:rf.flow/computed` / `:rf.flow/skip` (plus `:rf.flow/registered` / `:rf.flow/cleared` lifecycle events)

Spec-only doc edit; touches §3 failure-taxonomy table row and the §`:rf.flow/*` instances paragraph. Two-line diff. Cross-link points to [013 §Failure semantics](../blob/spec/rf2-kvdx9-managed-effects-taxonomy/spec/013-Flows.md#failure-semantics).

## Test plan

- [x] `mkdocs build --strict` from repo root: 66 warnings (baseline preserved; none reference Managed-Effects.md). Pre-existing strict-mode noise in `docs/guide/` unrelated to this change.
- [x] Grep confirms `:rf.flow/cycle-detected` and `:rf.flow/output-throw` exist nowhere in `implementation/` or `spec/` after the change.
- [x] Cited operations (`:rf.flow/failed`, `:rf.flow/computed`, `:rf.flow/skip`, `:rf.flow/registered`, `:rf.flow/cleared`, `:rf.error/flow-eval-exception`, `:rf.error/flow-cycle`) all match Spec 013 §Failure semantics + §Flow tracing tables.

Closes rf2-kvdx9.