### PR TITLE
spec(stories): rewrite reg-* examples to story/ ns (rf2-x5ut2)

### DIFF
--- a/spec/007-Stories.md
+++ b/spec/007-Stories.md
@@ -22,7 +22,7 @@ Stories/variants/workspaces are downstream concerns. They are *enabled by* the f
 
 - Lets 002 and 004 stay focused on the foundation.
 - Lets the story-tool design evolve independently of foundation framework decisions.
-- `reg-story`/`reg-variant`/`reg-workspace` are sugar; everything is doable by hand with `reg-frame` + `reg-view` + `frame-provider`.
+- `story/reg-story`/`story/reg-variant`/`story/reg-workspace` are sugar; everything is doable by hand with `reg-frame` + `reg-view` + `frame-provider`.
 
 ## Canonical id grammar
 
@@ -36,10 +36,10 @@ The story / variant / workspace id syntax is **locked** and used consistently th
 
 Rules:
 
-1. The `:story.<...>` and `:Workspace.<...>` prefixes are **library-owned** by the post-v1 stories library — they are not framework-reserved under `:rf/*` (see [Conventions §Library-owned prefixes](Conventions.md#library-owned-prefixes)). User code MUST NOT register stories/workspaces under conflicting prefixes when this library is loaded.
+1. The `:story.<...>` and `:Workspace.<...>` prefixes are **library-owned** by the `re-frame.story` tools artefact (`tools/story/`) — they are not framework-reserved under `:rf/*` (see [Conventions §Library-owned prefixes](Conventions.md#library-owned-prefixes)). User code MUST NOT register stories/workspaces under conflicting prefixes when this library is loaded.
 2. The dotted path segments organise the tree the story tool renders — split on `.` to build the navigator.
 3. Variant names go after `/`. A variant id always belongs to exactly one story; the story id is everything before `/`.
-4. Tools enumerate via `(rf/registrations :story)`, `(rf/registrations :variant)`, `(rf/registrations :workspace)`. The hierarchy is recoverable from the id alone — no separate `:title` field is required.
+4. Tools enumerate via `(story/registrations :story)`, `(story/registrations :variant)`, `(story/registrations :workspace)` — the Story library exposes its own registry-introspection over the tool-owned side-table at `tools.story.registry/*` (Story is a separate tools artefact and `:story`/`:variant`/`:workspace` are NOT framework registry kinds — see [Conventions §Library-owned prefixes](Conventions.md#library-owned-prefixes) and [§Public-query parity](#story-tool-extension-hook)). The hierarchy is recoverable from the id alone — no separate `:title` field is required.
 
 ## The three concepts
 
@@ -48,16 +48,16 @@ Rules:
 A story is the **topic** — typically a component, slice, or screen. It declares what's being demonstrated, the *shared* fixtures across its variants, decorators, args, play, and metadata. A story without variants is a degenerate case.
 
 ```clojure
-(rf/reg-story :story.auth.login-form
+(story/reg-story :story.auth.login-form
   {:doc        "The login form component."
-   :component  login-form               ;; the view at the centre of the story
-   :decorators [[centered-layout]
-                [theme :light]]
+   :component  :app.auth/login-form          ;; keyword id of a registered :view
+   :decorators [[:centered-layout]
+                [:theme :light]]
    :args       {:placeholder "you@example.com"
                 :submit-label "Sign in"}
    :argtypes   {:placeholder  {:control :text}
                 :submit-label {:control :text}}
-   :tags       #{:dev :docs}})          ;; inclusion tags — see below
+   :tags       #{:dev :docs}})               ;; inclusion tags — see below
 ```
 
 The story is registered under a hierarchical keyword: `:story.<path>` where path segments organise the story tree.
@@ -67,23 +67,23 @@ The story is registered under a hierarchical keyword: `:story.<path>` where path
 A variant is a **specific scenario** — one state of a story. Variants register against a parent story and inherit its decorators, args, etc.; variants override or extend.
 
 ```clojure
-(rf/reg-variant :story.auth.login-form/empty
+(story/reg-variant :story.auth.login-form/empty
   {:doc    "Fresh form, nothing entered."
    :events [[:auth/initialise]]})
 
-(rf/reg-variant :story.auth.login-form/validation-error
+(story/reg-variant :story.auth.login-form/validation-error
   {:doc    "Invalid email shown inline after submit."
    :events [[:auth/initialise]
             [:auth/email-changed "not-an-email"]
             [:auth/login-pressed]]
    :tags   #{:dev :docs :test}})        ;; this one is also used as a test fixture
 
-(rf/reg-variant :story.auth.login-form/loading
+(story/reg-variant :story.auth.login-form/loading
   {:doc       "Submit pressed, server response pending."
    :events    [[:auth/initialise]
                [:auth/email-changed "alice@example.com"]
                [:auth/login-pressed]]
-   :decorators [[force-fx-stub :my-app/http {:status :pending}]]})
+   :decorators [[:force-fx-stub :my-app/http {:status :pending}]]})
 ```
 
 (`:my-app/http` here is a placeholder for a user-supplied fx; the framework ships `:rf.http/managed` — see [014-HTTPRequests](014-HTTPRequests.md).)
@@ -98,7 +98,7 @@ Locked. A variant's body is a **serialisable artefact** — every field is plain
 - **Storable.** A frozen variant snapshot (per [§Variant snapshot identity](#variant-snapshot-identity)) is serialisable.
 - **Diffable.** Two variants compare structurally; the story tool's "what changed" panel is structural diff, not function identity.
 
-Concretely, the keys allowed in a `reg-variant` body:
+Concretely, the keys allowed in a `story/reg-variant` body:
 
 | Key | Shape | Notes |
 |---|---|---|
@@ -114,14 +114,14 @@ Concretely, the keys allowed in a `reg-variant` body:
 | `:args->events` | map | Per-arg event-id mapping `{<arg-key> <event-id>}`; the registered handler at `<event-id>` receives the new value as its payload. Data only — see [§Args mapping to state](#args-mapping-to-state). |
 | `:platforms` | set | Subset of `#{:server :client}`; controls where the variant runs. |
 
-**No fn-valued slots** in variant bodies. Where today's prior art (Storybook decorators, Histoire `setup`) takes a function, re-frame2 takes a registered id (`reg-decorator :centered-layout {...}`); the function lives at the registration site, not at the variant call site.
+**No fn-valued slots** in variant bodies. Where today's prior art (Storybook decorators, Histoire `setup`) takes a function, re-frame2 takes a registered id (`story/reg-decorator :centered-layout {...}`); the function lives at the registration site, not at the variant call site.
 
 #### Composed variants — reference parent by id, override by data
 
 A variant may reference another variant as its base, overriding selected keys:
 
 ```clojure
-(rf/reg-variant :story.auth.login-form/loading-with-prefill
+(story/reg-variant :story.auth.login-form/loading-with-prefill
   {:extends :story.auth.login-form/loading                ;; parent variant id
    :events [[:auth/initialise]
             [:auth/email-changed "alice@example.com"]
@@ -134,20 +134,20 @@ A variant may reference another variant as its base, overriding selected keys:
 
 The `:rf/variant` schema enforces both rules (data-only fields; `:extends` resolves to a registered variant id). See [Spec-Schemas §`:rf/variant`](Spec-Schemas.md#rfvariant).
 
-### Combined `reg-story` form — a sugar that desugars
+### Combined `story/reg-story` form — a sugar that desugars
 
 Two registration forms are canonical, and authors choose by ergonomics:
 
-**Form A (separate, hot-reload-friendly):** `(rf/reg-story :id metadata)` + N `(rf/reg-variant :story-id/variant-id metadata)` calls. Each variant is a top-level form — saving the file invalidates only the changed variant; hot-reload is precise.
+**Form A (separate, hot-reload-friendly):** `(story/reg-story :id metadata)` + N `(story/reg-variant :story-id/variant-id metadata)` calls. Each variant is a top-level form — saving the file invalidates only the changed variant; hot-reload is precise.
 
-**Form B (combined):** `(rf/reg-story :id metadata)` with a `:variants` map in the metadata. The story library *desugars* this at macro-expansion time into Form A — the registrar receives N independent `reg-variant` calls, so hot-reload-by-variant still works the same way. Form B is sugar for one-form-per-story authoring.
+**Form B (combined):** `(story/reg-story :id metadata)` with a `:variants` map in the metadata. The story library *desugars* this at macro-expansion time into Form A — the registrar receives N independent `story/reg-variant` calls, so hot-reload-by-variant still works the same way. Form B is sugar for one-form-per-story authoring.
 
 ```clojure
-;; Form B: combined; the macro emits N reg-variant calls at expansion.
-(rf/reg-story :story.auth.login-form
+;; Form B: combined; the macro emits N story/reg-variant calls at expansion.
+(story/reg-story :story.auth.login-form
   {:doc "The login form component."
-   :component login-form
-   :decorators [[centered-layout]]
+   :component :app.auth/login-form
+   :decorators [[:centered-layout]]
    :args     {:placeholder "you@example.com"}
    :argtypes {:placeholder {:control :text}}
    :tags     #{:dev :docs}
@@ -159,7 +159,7 @@ Two registration forms are canonical, and authors choose by ergonomics:
               :loading           {:events [[:auth/initialise]
                                            [:auth/email-changed "alice@example.com"]
                                            [:auth/login-pressed]]
-                                  :decorators [[force-fx-stub :my-app/http {:status :pending}]]}}})
+                                  :decorators [[:force-fx-stub :my-app/http {:status :pending}]]}}})
 ```
 
 Both forms are first-class.
@@ -169,7 +169,7 @@ Both forms are first-class.
 A workspace is a **layout** — multiple stories/variants arranged on screen for browsing, documentation, or side-by-side comparison.
 
 ```clojure
-(rf/reg-workspace :Workspace.Auth/all-states
+(story/reg-workspace :Workspace.Auth/all-states
   {:doc    "Every login-form state side by side, for QA review."
    :layout :grid
    :variants [:story.auth.login-form/empty
@@ -177,7 +177,7 @@ A workspace is a **layout** — multiple stories/variants arranged on screen for
               :story.auth.login-form/loading
               :story.auth.login-form/rate-limited]})
 
-(rf/reg-workspace :Workspace.Auth/docs
+(story/reg-workspace :Workspace.Auth/docs
   {:doc       "Auth flow documentation page."
    :layout    :prose                  ;; markdown-flavoured layout
    :content   [{:type :prose :body "## The login flow\n\n..."}
@@ -195,11 +195,11 @@ Storybook's headline UX is the **controls** panel — interactive props that re-
 ### Args at three levels
 
 1. **Global args** — re-frame2 doesn't have a global default beyond what frames give us. Story-tool config can supply defaults (theme, locale).
-2. **Story-level args** — declared on `reg-story`; inherited by every variant.
+2. **Story-level args** — declared on `story/reg-story`; inherited by every variant.
 3. **Variant-level args** — override or extend the story's args.
 
 ```clojure
-(rf/reg-variant :story.auth.login-form/customised
+(story/reg-variant :story.auth.login-form/customised
   {:args {:placeholder "your.email@company.com"      ;; override story default
           :submit-label "Authenticate"}
    :events [[:auth/initialise]]})
@@ -246,7 +246,7 @@ For variants that need args to map into `app-db` (e.g., a `:logged-in?` arg cont
       {:fx [[:dispatch [:auth/restore-session {:user "alice"}]]]}
       {:fx [[:dispatch [:auth/log-out]]]})))
 
-(rf/reg-variant :story.auth.login-form/logged-in-arg
+(story/reg-variant :story.auth.login-form/logged-in-arg
   {:args         {:logged-in? false}
    :args->events {:logged-in? :story.auth/set-logged-in}    ;; registered id, not a fn
    :events       [[:auth/initialise]]})
@@ -262,25 +262,27 @@ Decorators wrap stories with shared infrastructure: themes, layout containers, m
 
 1. **Hiccup wrapper.** A vector that wraps the rendered view.
 2. **Frame setup.** A function that mutates the story's frame at creation — pre-populates `app-db`, registers per-frame interceptors.
-3. **Fx override.** A declaration that swaps an fx for the lifetime of the variant — `[force-fx-stub :my-app/http canned-response]`.
+3. **Fx override.** A declaration that swaps an fx for the lifetime of the variant — `[:force-fx-stub :my-app/http canned-response]`.
+
+Each decorator vector in a variant body is `[<decorator-id> args...]` — id-valued (a keyword), not function-valued, per the variant-as-data discipline:
 
 ```clojure
 ;; Hiccup wrapper — pure visual
-[centered-layout]
-[theme :light]
-[fixed-width 480]
+[:centered-layout]
+[:theme :light]
+[:fixed-width 480]
 
 ;; Frame setup — affects state
-[mock-auth {:user {:id 42 :name "Alice"}}]
-[mock-router {:current-path "/dashboard"}]
+[:mock-auth {:user {:id 42 :name "Alice"}}]
+[:mock-router {:current-path "/dashboard"}]
 
 ;; Fx override — affects effects. The stub payload is data; any handler logic
 ;; lives in a registered event/fx handler that the decorator references by id.
-[force-fx-stub :my-app/http {:status 200 :body {...}}]
-[force-fx-stub :localstorage {:value nil}]
+[:force-fx-stub :my-app/http {:status 200 :body {...}}]
+[:force-fx-stub :localstorage {:value nil}]
 ```
 
-Decorators are themselves re-frame artefacts — usually small libraries that ship as `re-frame.decorators.theme`, `re-frame.decorators.auth`, etc. Story authors require what they need; decorators register hooks against the framework's interceptor and fx surfaces (no new framework primitives required).
+Decorators are themselves registered library artefacts — usually small libraries that ship as `re-frame.decorators.theme`, `re-frame.decorators.auth`, etc. Story authors `(:require ...)` the decorator library to register the ids, then reference each decorator by its keyword id from the variant body; decorators register hooks against the framework's interceptor and fx surfaces (no new framework primitives required).
 
 ### Decorator-as-frame-config-merger
 
@@ -291,7 +293,7 @@ A decorator's *frame setup* mode generalises into "things that should be true of
 Play is a **sequence of events fired after the variant has rendered**, distinct from `:events` (which run before render to set up state).
 
 ```clojure
-(rf/reg-variant :story.auth.login-form/login-flow
+(story/reg-variant :story.auth.login-form/login-flow
   {:doc    "Full happy-path login interaction."
    :events [[:auth/initialise]]                    ;; setup before render
    :play   [[:auth/email-changed "alice@example.com"]
@@ -335,21 +337,21 @@ A variant's tags default to `#{:dev :docs}`. Tools intersect their requested tag
 
 ### Tags are a registered, queryable vocabulary
 
-Tags are not free-form strings — every tag a project recognises must be **registered** via `reg-tag`:
+Tags are not free-form strings — every tag a project recognises must be **registered** via `story/reg-tag`:
 
 ```clojure
-(rf/reg-tag :dev
+(story/reg-tag :dev
   {:doc "Visible in the development story tool."})
 
-(rf/reg-tag :auth/regression-set
+(story/reg-tag :auth/regression-set
   {:doc "Variants used in the auth feature's regression suite."})
 ```
 
 The default tag vocabulary above (`:dev`, `:docs`, `:test`, `:screenshot`, `:experimental`, `:internal`, `:agent`) is registered by the stories library at load time. Project-specific tags must be registered before use. The tag set is **queryable**:
 
 ```clojure
-(rf/registrations :tag)               ;; → all registered tags + their docs
-(rf/registrations :tag #(contains? (:tags %) :auth))   ;; filtered
+(story/registrations :tag)               ;; → all registered tags + their docs
+(story/registrations :tag #(contains? (:tags %) :auth))   ;; filtered
 ```
 
 Tools enumerate this set before assigning tags to a variant. A variant whose tags include an unregistered keyword fails registration with `:rf.error/unknown-tag`. This is the AI-first "public query surfaces" principle ([Principles.md §Public query surfaces](Principles.md#public-query-surfaces)) applied to tag vocabulary.
@@ -365,7 +367,7 @@ Loaders run asynchronously before stories render to fetch data. **Deterministic 
     {:fx [[:my-app/http {:url     "/fixtures/heatmap.json"
                          :on-success [:charts/load-fixture]}]]}))
 
-(rf/reg-variant :story.charts.heatmap/with-real-data
+(story/reg-variant :story.charts.heatmap/with-real-data
   {:doc      "Renders against a fixture fetched from disk."
    :loaders  [[:charts.heatmap/fetch-fixture]]              ;; event vector — the handler does the async work
    :events   [[:charts/load-fixture]]
@@ -400,7 +402,7 @@ Decorators expose these hooks as composable building blocks (`force-fx-stub`, `i
 Variants are runnable outside the story UI. The library exposes a function form for each:
 
 ```clojure
-(rf/run-variant :story.auth.login-form/validation-error)
+(story/run-variant :story.auth.login-form/validation-error)
 ;; → {:frame   :story.auth.login-form/validation-error
 ;;    :app-db  {...}                        ;; final state after :events + :play
 ;;    :assertions [{:passed? true ...} ...]
@@ -417,7 +419,7 @@ Use cases:
 
 The same data drives every consumer. No artefact duplication.
 
-> **Live-watching a variant.** `(rf/watch-variant variant-id)` re-runs the variant whenever any of its dependencies (events, subs, view, schema) re-register. The framework already ships hot-reload notifications; `watch-variant` is a thin library composition over them. Cycle-prevention via registry-version diffing — only re-run when a dependency's registration metadata actually changed.
+> **Live-watching a variant.** `(story/watch-variant variant-id)` re-runs the variant whenever any of its dependencies (events, subs, view, schema) re-register. The framework already ships hot-reload notifications; `watch-variant` is a thin library composition over them. Cycle-prevention via registry-version diffing — only re-run when a dependency's registration metadata actually changed.
 
 ## Variant snapshot identity
 
@@ -428,7 +430,7 @@ Every variant has a stable **snapshot identity** comprising its `:variant-id` pl
 - the parent story's component id (`:component`) and decorators,
 - the *registered* schema digest of the view (per [011 §`:rf/schema-digest`](011-SSR.md)) — so a schema change invalidates the snapshot identity.
 
-The hash is computed over a canonicalised data form (sorted keys, deterministic vector order) so it round-trips across hosts. Visual-regression and screenshot pipelines key against `[variant-id content-hash]` — when the body changes, the hash changes; when the body doesn't change, the hash is stable across runs. The framework hook is `(rf/snapshot-identity variant-id) → {:variant-id ..., :content-hash "..."}`.
+The hash is computed over a canonicalised data form (sorted keys, deterministic vector order) so it round-trips across hosts. Visual-regression and screenshot pipelines key against `[variant-id content-hash]` — when the body changes, the hash changes; when the body doesn't change, the hash is stable across runs. The library hook is `(story/snapshot-identity variant-id) → {:variant-id ..., :content-hash "..."}`.
 
 This is the AI-first "machine-readable invariants" principle: tooling comparing before-and-after a code change asks the runtime which variants' snapshot identities changed without re-rendering them.
 
@@ -437,7 +439,7 @@ This is the AI-first "machine-readable invariants" principle: tooling comparing 
 The stories library's tool surface is **extensible by registering panels**. A panel is a registered view with a known kind:
 
 ```clojure
-(rf/reg-story-panel :a11y/inspector
+(story/reg-story-panel :a11y/inspector
   {:doc       "Accessibility issues for the active variant."
    :title     "Accessibility"
    :placement :right
@@ -463,7 +465,7 @@ These are **dev-tool conveniences with documented egress, not gated**. Both endp
 
 **Framework hooks (in 002):** `make-frame`/`destroy-frame!`/`reset-frame!`; per-frame `:fx-overrides`/`:interceptor-overrides`/`:interceptors`; run-to-completion drain; public registrar query API (`registrations`/`frame-meta`/`frame-ids`/`get-frame-db`/`snapshot-of`/`sub-topology`); hot-reload notifications.
 
-**`re-frame.stories` library:** `reg-story`/`reg-variant`/`reg-workspace`; side-table registries; `run-variant` (programmatic execution + assertions); `reset-variant`; `variants-with-tags`; the story-tool UI.
+**`re-frame.story` library (the `tools/story/` artefact):** `story/reg-story`/`story/reg-variant`/`story/reg-workspace`/`story/reg-decorator`/`story/reg-tag`/`story/reg-mode`/`story/reg-story-panel`; tool-owned side-table registries at `tools.story.registry/*`; `story/registrations` (Public-query parity over the side-table); `story/run-variant` (programmatic execution + assertions); `story/reset-variant`; `story/variants-with-tags`; `story/snapshot-identity`; `story/watch-variant`; the story-tool UI.
 
 The framework surface is sufficient for any team to roll their own equivalent if they want.
 
@@ -472,7 +474,7 @@ The framework surface is sufficient for any team to roll their own equivalent if
 A variant *is* a frame, registered under its variant keyword. But variant `:events` are NOT desugared to `reg-frame :on-create` — `reg-frame :on-create` is single-event by design ([002 §reg-frame](002-Frames.md#reg-frame--atomic-create-and-register-and-the-canonical-metadata-grammar)), while variant `:events` is an explicitly multi-step setup sequence (the whole point of stories is to express setup as a list of user-flavoured steps). The story library handles its own iteration, in the four-phase order locked above:
 
 ```clojure
-;; conceptual setup logic for reg-variant
+;; conceptual setup logic for story/reg-variant
 (defn setup-variant! [variant-id]
   (let [{:keys [loaders events]} (variant-meta variant-id)
         story-events             (story-events-for variant-id)
@@ -507,9 +509,9 @@ Multiple `:story.*` namespaces can come from different libraries. The story tool
 
 ## Resolved decisions
 
-### Should `reg-story` and `reg-variant` be separate, or unified?
+### Should `story/reg-story` and `story/reg-variant` be separate, or unified?
 
-**Both forms, with the combined form desugaring to separate registrations.** `(reg-story :id metadata)` + N `(reg-variant :story-id/variant-id metadata)` is the canonical pair. The combined `:variants {...}` map on `reg-story` is sugar that desugars at macro-expansion time to N independent `reg-variant` calls — hot-reload-by-variant still works. See [§Combined `reg-story` form](#combined-reg-story-form--a-sugar-that-desugars).
+**Both forms, with the combined form desugaring to separate registrations.** `(story/reg-story :id metadata)` + N `(story/reg-variant :story-id/variant-id metadata)` is the canonical pair. The combined `:variants {...}` map on `story/reg-story` is sugar that desugars at macro-expansion time to N independent `story/reg-variant` calls — hot-reload-by-variant still works. See [§Combined `story/reg-story` form](#combined-storyreg-story-form--a-sugar-that-desugars).
 
 ### Args mapping — view-direct or via app-db?
 
@@ -517,11 +519,11 @@ Args go to the view directly by default; explicit `:args->events` for variants t
 
 ### Test integration — built-in runner or test-framework adapter?
 
-The story library ships a `run-variant`-flavoured runner. Test-framework adapters (`re-frame-test`, etc.) consume `run-variant` and produce framework-specific test cases. The built-in runner is part of the story library, not the framework; adapters layer on top of it.
+The story library ships a `story/run-variant`-flavoured runner. Test-framework adapters (`re-frame-test`, etc.) consume `story/run-variant` and produce framework-specific test cases. The built-in runner is part of the story library, not the framework; adapters layer on top of it.
 
 ### Screenshot / visual-regression integration
 
-The framework hook is: variants have a stable snapshot identity (`:variant-id` + content hash) per [§Variant snapshot identity](#variant-snapshot-identity). Specific visual-regression service integrations consume the variant registry, `run-variant`'s rendered hiccup, and the snapshot identity.
+The library hook is: variants have a stable snapshot identity (`:variant-id` + content hash) per [§Variant snapshot identity](#variant-snapshot-identity). Specific visual-regression service integrations consume the variant registry, `story/run-variant`'s rendered hiccup, and the snapshot identity.
 
 ## See also
 

--- a/tools/causa/spec/008-Embedding-Contract.md
+++ b/tools/causa/spec/008-Embedding-Contract.md
@@ -100,9 +100,10 @@ Per `tools/story/` (when it lands):
 
 ```clojure
 (ns day8.story.variants
-  (:require [day8.re-frame2-causa.panels.event-detail :as causa-event]))
+  (:require [re-frame.story :as story]
+            [day8.re-frame2-causa.panels.event-detail :as causa-event]))
 
-(rf/reg-story-panel :story.auth/login
+(story/reg-story-panel :story.auth/login
   {:panels
    [{:title  "Login form"
      :render (fn [variant-data] [login-form variant-data])}

--- a/tools/mcp-conformance/NAMING.md
+++ b/tools/mcp-conformance/NAMING.md
@@ -103,7 +103,7 @@ extension** to pair2-mcp / story-mcp.
 | `get-variant` | `get-` | Conformant. |
 | `list-tags` | `list-` | Conformant. |
 | `list-modes` | `list-` | Conformant. |
-| `list-decorators` | `list-` | Conformant — read-only `(rf/registrations :decorator)` enumeration (rf2-mqp1u). |
+| `list-decorators` | `list-` | Conformant — read-only `(story/registrations :decorator)` enumeration (rf2-mqp1u). |
 | `list-assertions` | `list-` | Conformant. |
 | `get-docs-markdown` | `get-` | Conformant — single-record read of a story's GFM-projected documentation (rf2-i0kyy). Sibling shape to `get-story`. |
 | `variant->edn` | bare (Clojure idiom) | **Deviation** — `->edn` is a Clojure-idiomatic projection name (mirrors `into`, `seq->vec` etc.). The convention catalogues this as an accepted exception: when the operation is a **canonical-form serialiser** of a known artefact, `<thing>->edn` is preferable to `get-<thing>-edn` because the arrow signals the projection direction. Story-mcp ships exactly one of these; if a sibling appears (`variant->json`, etc.) it follows the same shape. |

--- a/tools/story-mcp/spec/002-Tool-Registry.md
+++ b/tools/story-mcp/spec/002-Tool-Registry.md
@@ -84,7 +84,7 @@ filled in during Stage 7 polish.
 
 ### `list-stories`
 
-`(rf/registrations :story)` enumeration, optionally filtered by tag-set
+`(story/registrations :story)` enumeration, optionally filtered by tag-set
 intersection (`{:tags [...]}`).
 
 ### `get-story`
@@ -104,11 +104,11 @@ Canonical + project-custom tags split.
 
 ### `list-modes`
 
-`(rf/registrations :mode)` enumeration.
+`(story/registrations :mode)` enumeration.
 
 ### `list-decorators` (rf2-mqp1u)
 
-Read-only `(rf/registrations :decorator)` enumeration. Each entry carries
+Read-only `(story/registrations :decorator)` enumeration. Each entry carries
 `:id`, `:kind`, `:doc` plus the kind-specific pure-data slots —
 `:has-wrap?` for `:hiccup` decorators (the closure itself doesn't
 transport over MCP); `:init` + `:app-db-patch` for `:frame-setup`;

--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -162,7 +162,7 @@ Body:
 ```
 
 Per [spec/007 §Story-tool extension hook](../../../spec/007-Stories.md).
-The render shell reads `(rf/registrations :story-panel)` and lays them out.
+The render shell reads `(story/registrations :story-panel)` and lays them out.
 The five-rule embed contract is defined in
 [`006-MCP-Surface.md`](006-MCP-Surface.md) and
 [`003-Render-Shell.md`](003-Render-Shell.md).
@@ -216,11 +216,11 @@ Query the default-excluded set via:
 - `(story/tags-default-excluded)` — set of tag ids with `:default-filter :exclude`.
 
 ```clojure
-(rf/reg-tag :auth/regression-set
+(story/reg-tag :auth/regression-set
   {:doc  "Auth regression-suite variants."
    :axis :team})
 
-(rf/reg-tag :alpha
+(story/reg-tag :alpha
   {:doc            "Pre-release status."
    :axis           :status
    :default-filter :exclude})
@@ -256,11 +256,11 @@ toolbar grouping hint.
 Example:
 
 ```clojure
-(rf/reg-mode :Mode.app/dark-mobile
+(story/reg-mode :Mode.app/dark-mobile
   {:doc  "Dark theme on a mobile viewport."
    :args {:theme :dark :viewport :mobile :locale :en}})
 
-(rf/reg-mode :Mode.app/light-desktop
+(story/reg-mode :Mode.app/light-desktop
   {:args {:theme :light :viewport :desktop :locale :en}})
 ```
 
@@ -278,12 +278,17 @@ Worked examples illustrating every aspect of the authoring grammar.
 
 ```clojure
 (ns app.stories.button
-  (:require [re-frame.story :as story]
-            [app.ui.button :refer [button]]))
+  (:require [re-frame.core :as rf]
+            [re-frame.story :as story]))
+
+;; The view is registered under a keyword id (per spec/004 §reg-view).
+(rf/reg-view :app.ui/button
+  (fn [args]
+    [:button.btn (:label args)]))
 
 (story/reg-story :story.ui.button
   {:doc       "Primary action button."
-   :component button
+   :component :app.ui/button             ;; keyword id of a registered :view
    :args      {:label "Click me"}})
 
 (story/reg-variant :story.ui.button/default
@@ -325,13 +330,13 @@ Author writes zero `:argtypes` unless overriding the auto-derivation.
 ### Decorators and `:args->events`
 
 ```clojure
-(rf/reg-decorator :centered-layout
+(story/reg-decorator :centered-layout
   {:doc  "Centre the rendered content."
    :kind :hiccup
    :wrap (fn [body _]
            [:div.flex.items-center.justify-center.h-screen body])})
 
-(rf/reg-decorator :mock-auth
+(story/reg-decorator :mock-auth
   {:doc  "Inject a mock authenticated user into the variant's frame."
    :kind :frame-setup
    :init [[:auth/restore-session {:user "alice"}]]})
@@ -412,10 +417,10 @@ Resolution at registration time. Cycles raise
 ### Modes (saved tuples)
 
 ```clojure
-(rf/reg-mode :Mode.app/dark-mobile
+(story/reg-mode :Mode.app/dark-mobile
   {:args {:theme :dark :viewport :mobile}})
 
-(rf/reg-mode :Mode.app/light-desktop
+(story/reg-mode :Mode.app/light-desktop
   {:args {:theme :light :viewport :desktop}})
 
 (story/reg-story :story.ui.button

--- a/tools/story/spec/002-Runtime.md
+++ b/tools/story/spec/002-Runtime.md
@@ -227,13 +227,17 @@ each; substrate-specific failures show inline (see
 ## Tag-vocabulary queries
 
 ```clojure
-(rf/registrations :tag)                               ; all registered tags
-(rf/registrations :tag #(contains? (:tags %) :auth))  ; filtered
+(story/registrations :tag)                               ; all registered tags
+(story/registrations :tag #(contains? (:tags %) :auth))  ; filtered
 ```
 
-Already framework-supplied via the
-[spec/001 registrar query API](../../../spec/001-Registration.md);
-Story registers the seven canonical tags at load.
+`story/registrations` is the Public-query parity bridge over the
+tool-owned side-table at `tools.story.registry/*` (see
+[spec/007 §Story-tool extension hook](../../../spec/007-Stories.md));
+it mirrors the framework's
+[spec/001 registrar query API](../../../spec/001-Registration.md)
+shape over Story's own kinds. Story registers the seven canonical
+tags at load.
 
 ## Open items (Stage 3 picks)
 

--- a/tools/story/spec/003-Render-Shell.md
+++ b/tools/story/spec/003-Render-Shell.md
@@ -95,9 +95,9 @@ Workspace layouts persist **both** ways:
   by `[workspace-id breakpoint]`. Persistence is per-user, per-browser.
 - **Save-as registered artefact.** A "Save layout as `:Workspace.x/y`"
   button serialises the current layout to transit (full
-  `reg-workspace` body), re-registers it under the chosen id, and
+  `story/reg-workspace` body), re-registers it under the chosen id, and
   exports the transit blob for cross-machine sharing. Other users
-  `(rf/reg-workspace ...)` the transit body to consume the layout
+  `(story/reg-workspace ...)` the transit body to consume the layout
   durably.
 
 Stage 4 (render shell) wires the local-storage save on every layout

--- a/tools/story/spec/004-Assertions.md
+++ b/tools/story/spec/004-Assertions.md
@@ -108,7 +108,7 @@ Per [`001-Authoring.md`](001-Authoring.md) §reg-decorator, the
 `:fx-override` decorator kind stubs an effect at frame creation:
 
 ```clojure
-(rf/reg-decorator :force-fx-stub
+(story/reg-decorator :force-fx-stub
   {:doc  "Stub a registered fx with a static response."
    :kind :fx-override
    :fx-id    <fx-id>

--- a/tools/story/spec/005-SOTA-Features.md
+++ b/tools/story/spec/005-SOTA-Features.md
@@ -130,7 +130,7 @@ panel (Causa is the structural successor to re-frame-10x, per
 Lock #1):
 
 ```clojure
-(rf/reg-story-panel :rf.story/causa-epoch
+(story/reg-story-panel :rf.story/causa-epoch
   {:doc       "Causa's epoch buffer for the active variant."
    :title     "Epochs (Causa)"
    :placement :bottom

--- a/tools/story/spec/010-Toolbar.md
+++ b/tools/story/spec/010-Toolbar.md
@@ -101,17 +101,17 @@ A `reg-mode` body MAY carry an optional `:axis` keyword that groups
 modes for the toolbar's chip layout:
 
 ```clojure
-(rf/reg-mode :Mode.app/dark-theme
+(story/reg-mode :Mode.app/dark-theme
   {:doc  "Dark theme."
    :axis :theme
    :args {:theme :dark}})
 
-(rf/reg-mode :Mode.app/light-theme
+(story/reg-mode :Mode.app/light-theme
   {:doc  "Light theme."
    :axis :theme
    :args {:theme :light}})
 
-(rf/reg-mode :Mode.app/mobile-viewport
+(story/reg-mode :Mode.app/mobile-viewport
   {:doc  "Mobile viewport."
    :axis :viewport
    :args {:viewport :mobile}})

--- a/tools/story/spec/DESIGN-RATIONALE.md
+++ b/tools/story/spec/DESIGN-RATIONALE.md
@@ -159,7 +159,7 @@ via (Causa is the structural successor to re-frame-10x, per
 Lock #1):
 
 ```clojure
-(rf/reg-story-panel :rf.story/causa-epoch
+(story/reg-story-panel :rf.story/causa-epoch
   {:doc       "Causa's epoch buffer for the active variant."
    :title     "Epochs (Causa)"
    :placement :bottom

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -629,14 +629,14 @@
   adapter pattern from spec/007 §Portable into tests:
 
       (deftest counter-empty-state
-        (let [result @(rf/run-variant :story.counter/empty {})]
-          (is (rf.story/assertions-passing? result))))"
+        (let [result @(story/run-variant :story.counter/empty {})]
+          (is (story/assertions-passing? result))))"
   [assertions-or-result]
   (assertions/passing? assertions-or-result))
 
 (defn read-assertions
   "Per IMPL-SPEC §3.5 — return the assertions vector accumulated against
-  `variant-id`'s frame. Identical to `(:assertions (rf/run-variant ...))`
+  `variant-id`'s frame. Identical to `(:assertions (story/run-variant ...))`
   but doesn't re-run the variant. Useful for live introspection from the
   UI shell or REPL."
   [variant-id]

--- a/tools/story/src/re_frame/story/layout_debug.cljc
+++ b/tools/story/src/re_frame/story/layout_debug.cljc
@@ -29,7 +29,7 @@
 
   Add one or more to a variant's `:decorators`:
 
-      (rf/reg-variant :story.button/pressed
+      (story/reg-variant :story.button/pressed
         {:decorators [[:rf.story/layout-debug.outline]
                       [:rf.story/layout-debug.pseudo #{:hover :focus}]]
          :events     [...]})

--- a/tools/story/src/re_frame/story/ui/panels.cljs
+++ b/tools/story/src/re_frame/story/ui/panels.cljs
@@ -7,7 +7,7 @@
   Per IMPL-SPEC §3.1 + §4.5 (Stage 6 addition) — a story panel is
   registered via:
 
-      (rf/reg-story-panel <panel-id>
+      (story/reg-story-panel <panel-id>
         {:doc          \"...\"
          :title        \"...\"             ;; sidebar / tab label
          :placement    :right|:left|:bottom|:top|:modal
@@ -15,7 +15,7 @@
          :enabled-when (optional)         ;; predicate fn from registry → boolean
          :for          #{<context-id>}})  ;; optional: contexts the panel belongs to
 
-  The shell's panel-host component reads `(rf/registrations :story-panel)`
+  The shell's panel-host component reads `(story/registrations :story-panel)`
   + the shell's `:panel-visibility` map and renders every visible
   panel into its `:placement` slot. The `:render` view receives the
   current variant-id as its single arg.
@@ -38,7 +38,7 @@
 
   When Causa is ready, the stub registration replaces with:
 
-      (rf/reg-story-panel :rf.story.panel/epoch
+      (story/reg-story-panel :rf.story.panel/epoch
         {:title \"Epochs (10x)\"
          :placement :bottom
          :render :rf.epoch-10x/panel-view})
@@ -133,7 +133,7 @@
     "view will register under the same id (" (pr-str epoch-panel-render-id)
     ") when " [:code "day8/re-frame2-10x"] " is on the classpath."]
    [:pre {:style (:stub-code styles)}
-    (str "(rf/reg-story-panel " epoch-panel-id "\n"
+    (str "(story/reg-story-panel " epoch-panel-id "\n"
          "  {:title     \"Epochs (10x)\"\n"
          "   :placement :bottom\n"
          "   :render    " epoch-panel-render-id "})")]])


### PR DESCRIPTION
## Summary

Per `ai/findings/spec-impl-alignment-sweep-2026-05-15.md` F3/F4/F9/F11: Spec 007 examples wrote `(rf/reg-story ...)` / `(rf/reg-variant ...)` and `(rf/registrations :story)` — but Story is a separate tools artefact (`re-frame.story` namespace; tool-owned side-table at `tools.story.registry/*`). The framework's `:story`/`:variant`/`:workspace`/`:tag`/`:mode`/`:decorator`/`:story-panel` registry kinds **don't exist** (Spec 001's closed kinds set), so calls in the spec examples would fail at the require.

This PR rewrites every spec-doc example to use `story/...` correctly, fixes the F4 Var-vs-keyword `:component` mismatch (impl validates as keyword), and brings the F11 stale "post-v1 stories library" framing forward.

### Per-doc edits

- **`spec/007-Stories.md`** (the F3 hot-spot): every `rf/reg-story`, `rf/reg-variant`, `rf/reg-workspace`, `rf/reg-tag`, `rf/reg-story-panel` rewritten to `story/...`. The Tools-enumerate rule on line 42 now correctly cites `(story/registrations :story|:variant|:workspace)` and notes the side-table provenance with a cross-ref to Conventions §Library-owned prefixes. `rf/run-variant`, `rf/watch-variant`, `rf/snapshot-identity` rewritten to `story/...` and the surrounding "framework hook" prose softened to "library hook". The What-the-framework-supplies-vs-library-adds section now spells out the Story public surface explicitly. **F4**: example `:component login-form` (Var) replaced with the keyword id `:app.auth/login-form` to match the impl's `:rf/variant` schema. Decorator examples shifted from Var-style `[centered-layout]` to data-style `[:centered-layout]` per the variant-as-data discipline. **F11**: stale "post-v1 stories library" framing updated — `tools/story/` ships today.
- **`tools/story/spec/{001-Authoring,002-Runtime,003-Render-Shell,004-Assertions,005-SOTA-Features,010-Toolbar,DESIGN-RATIONALE}.md`**: the same `rf/...` → `story/...` rewrites for `reg-tag`, `reg-mode`, `reg-decorator`, `reg-story-panel`, `reg-workspace`, and `(rf/registrations :tag|:story-panel)`. The 002-Runtime tag-query block now explains the Public-query bridge over Story's side-table. The Authoring-doc minimal example now includes a `reg-view` registration so the keyword `:app.ui/button` resolves.
- **`tools/causa/spec/008-Embedding-Contract.md`**: example `(rf/reg-story-panel :story.auth/login ...)` → `story/reg-story-panel`; missing `[re-frame.story :as story]` require added.
- **`tools/story-mcp/spec/002-Tool-Registry.md`** + **`tools/mcp-conformance/NAMING.md`**: the `list-stories`, `list-modes`, `list-decorators` tool-shape descriptions now cite `(story/registrations ...)`.
- **`tools/story/src/re_frame/story{,/ui/panels,/layout_debug}.cljc(s)`**: docstring examples updated for consistency (the recommended form for users is `story/...`).

### mkdocs verification

`python -m mkdocs build --strict` from repo root: **66 warnings**, identical to the `main` baseline (pre-existing `docs/guide/24-configuration-and-safety/*` and `skills/re-frame2-implementor.md` cross-refs to `spec/*` files that aren't in the mkdocs nav). **No new broken links** introduced by this change.

## Test plan

- [x] `mkdocs build --strict` from repo root — 66 warnings (matches `main`).
- [x] `grep -n '(rf/reg-story\|reg-variant\|reg-workspace\|reg-tag\|reg-mode\|reg-decorator\|reg-story-panel)' spec/ tools/*/spec/` — zero matches in normative-spec docs (research findings under `tools/story/spec/findings/` deliberately left as historical material).
- [x] `grep -n '(rf/registrations :\(story\|variant\|workspace\|tag\|mode\|decorator\|story-panel\))' spec/ tools/*/spec/` — zero matches in normative-spec docs.

Closes rf2-x5ut2.