### PR TITLE
perf(core): rf2-fzrav follow-ups cluster (4 beads)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -79,7 +79,8 @@
   :rf/skip-handler? when validation fails so the handler-as-interceptor
   short-circuits."
   [ctx cofx-id cofx-meta]
-  (if-let [validate (late-bind/get-fn :schemas/validate-cofx!)]
+  ;; Sticky hook (rf2-f72pd) — fires per-cofx invocation.
+  (if-let [validate (late-bind/get-fn-cached :schemas/validate-cofx!)]
     (let [event    (interceptor/get-coeffect ctx :event)
           event-id (first event)
           ;; The cofx's injected value is whatever it just stashed under

--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -595,10 +595,20 @@
            (assoc acc k (walk vv (conj path k) ctx)))
          (empty v) v)
 
+        ;; Indexed-vector recurse — hand-rolled loop over `(nth v i)`
+        ;; rather than `(mapv (fn [idx vv] ...) (range) v)`. The
+        ;; `(range)` form allocated one lazy-seq cons cell per child to
+        ;; carry the index alongside `mapv`'s walk; for a wide vector
+        ;; slice (large `:items` collections) on every wire-emit walk
+        ;; that adds up (rf2-ioduy). Transient accumulator avoids the
+        ;; per-step persistent-conj path-vector allocation.
         (vector? v)
-        (mapv (fn [idx vv]
-                (walk vv (conj path idx) ctx))
-              (range) v)
+        (let [n (count v)]
+          (loop [i 0 acc (transient [])]
+            (if (< i n)
+              (recur (inc i)
+                     (conj! acc (walk (nth v i) (conj path i) ctx)))
+              (persistent! acc))))
 
         (set? v)
         ;; Sets don't have indices; walk children with the same path so
@@ -606,13 +616,20 @@
         ;; callers won't declare individual set members.
         (into #{} (map #(walk % path ctx)) v)
 
-        (seq? v)
         ;; Sequences (lists / lazy seqs) — walk and return a vector for
         ;; wire stability. Per Tool-Pair, wire payloads are EDN data;
-        ;; converting seq -> vector is safe.
-        (mapv (fn [idx vv]
-                (walk vv (conj path idx) ctx))
-              (range) v)
+        ;; converting seq -> vector is safe. `reduce` with a volatile
+        ;; index counter avoids the `(range)` lazy-seq cons cells the
+        ;; previous `(mapv f (range) v)` form allocated per child
+        ;; (rf2-ioduy).
+        (seq? v)
+        (let [idx (volatile! -1)]
+          (persistent!
+           (reduce (fn [acc vv]
+                     (vswap! idx inc)
+                     (conj! acc (walk vv (conj path @idx) ctx)))
+                   (transient [])
+                   v)))
 
         :else
         v))))

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -71,7 +71,11 @@
   `core/current-frame` all delegate here so the React-context tier is
   single-sourced (rf2-jj8xf)."
   []
-  #?(:cljs (if-let [f (late-bind/get-fn :adapter/current-frame)]
+  ;; Sticky hook (rf2-f72pd) — `:adapter/current-frame` is published
+  ;; once per loaded React-shaped adapter at ns-load time and routed
+  ;; via `current-adapter`; it fires on every default-frame resolution
+  ;; (every dispatch and every subscribe).
+  #?(:cljs (if-let [f (late-bind/get-fn-cached :adapter/current-frame)]
              (f)
              (current-frame))
      :clj  (current-frame)))

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -79,10 +79,15 @@
 ;; ---- lookup ---------------------------------------------------------------
 
 (defn frame
-  "Return the frame record for id, or nil if not registered or destroyed."
+  "Return the frame record for id, or nil if not registered or destroyed.
+
+  2-level lookup written as keyword-invoke (`(-> f :lifecycle :destroyed?)`)
+  rather than `(get-in f [:lifecycle :destroyed?])` — `get-in` allocates
+  a path vector per call (rf2-mqv4m), and `frame` runs on every dispatch
+  / subscribe through `current-frame` resolution."
   [id]
   (when-let [f (get @frames id)]
-    (when-not (get-in f [:lifecycle :destroyed?])
+    (when-not (-> f :lifecycle :destroyed?)
       f)))
 
 (defn frame-disposed-for-drain?
@@ -103,7 +108,7 @@
   destroyed-vs-never-registered discrimination."
   [id]
   (if-let [f (get @frames id)]
-    (true? (get-in f [:lifecycle :destroyed?]))
+    (true? (-> f :lifecycle :destroyed?))
     ;; Absent from the atom — destroy-frame!'s step 6 ran, OR the id
     ;; was never registered. The drain-loop caller only consults this
     ;; while a pass is already in flight, so the latter case cannot
@@ -146,13 +151,13 @@
   Per Spec 002 §The public registrar query API."
   ([]
    (into #{}
-         (comp (filter (fn [[_ f]] (not (get-in f [:lifecycle :destroyed?]))))
+         (comp (filter (fn [[_ f]] (not (-> f :lifecycle :destroyed?))))
                (map key))
          @frames))
   ([ns-prefix]
    (let [prefix (str ns-prefix)]
      (into #{}
-           (comp (filter (fn [[_ f]] (not (get-in f [:lifecycle :destroyed?]))))
+           (comp (filter (fn [[_ f]] (not (-> f :lifecycle :destroyed?))))
                  (map key)
                  (filter (fn [k]
                            (when-let [ns (namespace k)]
@@ -331,7 +336,7 @@
 
 (defn- fire-on-destroy-event!
   [id f]
-  (when-let [on-destroy (get-in f [:config :on-destroy])]
+  (when-let [on-destroy (-> f :config :on-destroy)]
     (when-let [dispatch-sync (late-bind/get-fn :router/dispatch-sync!)]
       (dispatch-sync on-destroy {:frame id}))))
 

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -195,7 +195,10 @@
    ;; `:fx-overrides` / `:interceptor-overrides` / `:trace-id` /
    ;; `:origin` / `:source`.
    (fn [frame-id parent-envelope args]
-     (when-let [f (late-bind/get-fn :router/dispatch!)]
+     ;; Sticky hook (rf2-f72pd) — `:router/dispatch!` is published once
+     ;; at re-frame.router load and never withdrawn; this fires per
+     ;; `:dispatch` fx invocation.
+     (when-let [f (late-bind/get-fn-cached :router/dispatch!)]
        (f args (child-dispatch-opts frame-id parent-envelope))))
 
    :dispatch-later
@@ -207,7 +210,9 @@
      (let [opts (child-dispatch-opts frame-id parent-envelope)]
        (interop/set-timeout!
          (fn []
-           (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+           ;; Sticky hook (rf2-f72pd) — same as above; the timer
+           ;; callback fires per scheduled :dispatch-later.
+           (when-let [dispatch! (late-bind/get-fn-cached :router/dispatch!)]
              (dispatch! event opts)))
          ms)))
 
@@ -416,8 +421,11 @@
               (let [msg  #?(:clj (.getMessage ^Throwable e)
                             :cljs (.-message e))
                     time (interop/now-ms)]
+                ;; Sticky hook (rf2-f72pd) — always-on per-error
+                ;; observability fan-out per rf2-bacs4; survives
+                ;; `:advanced` + `goog.DEBUG=false`.
                 (when-let [dispatch-on-error!
-                           (late-bind/get-fn :error-emit/dispatch-on-error)]
+                           (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
                   (dispatch-on-error!
                     category
                     origin-event
@@ -472,7 +480,8 @@
         ;; `validate-fx!` itself emits the `:rf.error/schema-validation-
         ;; failure :where :fx-args` trace; this caller only honours the
         ;; boolean.
-        (let [validate-fx! (late-bind/get-fn :schemas/validate-fx!)
+        ;; Sticky hook (rf2-f72pd) — fires per-fx invocation.
+        (let [validate-fx! (late-bind/get-fn-cached :schemas/validate-fx!)
               fx-ok?       (if (and validate-fx! (:spec meta))
                              (try
                                (validate-fx! fx-id origin-event-id args meta)

--- a/implementation/core/src/re_frame/interop.cljs
+++ b/implementation/core/src/re_frame/interop.cljs
@@ -17,13 +17,22 @@
 
 (def next-tick goog.async.nextTick)
 
+;; ---- adapter-published reactive hooks -------------------------------------
+;;
+;; The seven `:adapter/*` reactive hooks below are published once per
+;; loaded React-shaped adapter at ns-load time (see Spec 006 §Substrate
+;; adapter contract and rf2-jicu2). They are read on every render /
+;; subscribe / reaction tear-down — sticky-cache via
+;; `late-bind/get-fn-cached` (rf2-f72pd) so the resolution is one
+;; per-key atom slot rather than a `@hooks` map walk per call.
+
 ;; ---- after-render hook ----------------------------------------------------
 
 (defn after-render
   "Schedule f to run after the next render. Returns nil when no adapter
   has registered the `:adapter/after-render` hook."
   [f]
-  (when-let [hook (late-bind/get-fn :adapter/after-render)]
+  (when-let [hook (late-bind/get-fn-cached :adapter/after-render)]
     (hook f)))
 
 ;; ---- mutable cells (used by the runtime, opaque to user code) -------------
@@ -31,14 +40,14 @@
 (defn ratom
   "Construct a reactive atom seeded with v."
   [v]
-  (when-let [hook (late-bind/get-fn :adapter/ratom)]
+  (when-let [hook (late-bind/get-fn-cached :adapter/ratom)]
     (hook v)))
 
 (defn ratom?
   "True if x is a reactive atom (per the active adapter's substrate).
   Returns false when no adapter has registered the hook."
   [x]
-  (if-let [hook (late-bind/get-fn :adapter/ratom?)]
+  (if-let [hook (late-bind/get-fn-cached :adapter/ratom?)]
     (hook x)
     false))
 
@@ -47,26 +56,26 @@
 (defn make-reaction
   "Build a reaction that recomputes f when its dependencies change."
   [f]
-  (when-let [hook (late-bind/get-fn :adapter/make-reaction)]
+  (when-let [hook (late-bind/get-fn-cached :adapter/make-reaction)]
     (hook f)))
 
 (defn add-on-dispose!
   "Register a teardown callback on a-ratom."
   [a-ratom f]
-  (when-let [hook (late-bind/get-fn :adapter/add-on-dispose!)]
+  (when-let [hook (late-bind/get-fn-cached :adapter/add-on-dispose!)]
     (hook a-ratom f)))
 
 (defn dispose!
   "Tear down a reactive atom / reaction."
   [a-ratom]
-  (when-let [hook (late-bind/get-fn :adapter/dispose!)]
+  (when-let [hook (late-bind/get-fn-cached :adapter/dispose!)]
     (hook a-ratom)))
 
 (defn reactive?
   "True when called from inside a reactive context (e.g. a render).
   Returns false when no adapter has registered the hook."
   []
-  (if-let [hook (late-bind/get-fn :adapter/reactive?)]
+  (if-let [hook (late-bind/get-fn-cached :adapter/reactive?)]
     (hook)
     false))
 

--- a/implementation/core/src/re_frame/late_bind.cljc
+++ b/implementation/core/src/re_frame/late_bind.cljc
@@ -27,19 +27,93 @@
   hooks
   (atom {}))
 
+;; ---- sticky resolution cache (rf2-f72pd) ----------------------------------
+;;
+;; `get-fn-cached` is a sticky variant of `get-fn` for hooks that are
+;; published once at boot and never withdrawn in production
+;; (`:schemas/validate-*!`, `:flows/run-flows!`, `:epoch/settle!`,
+;; `:epoch/capture-event`, `:event-emit/dispatch-on-event`,
+;; `:router/dispatch!`, …). These run on every dispatch — the dispatch
+;; cascade reads ~6+ keys per event, so a 100-event cascade was 600+
+;; identical atom-derefs of `hooks` plus 600+ identical map lookups.
+;;
+;; The cache memoises the resolution: first hit reads `hooks`, populates
+;; `fn-cache`, and returns; subsequent hits read `fn-cache` directly. On
+;; the JVM the gain is bounded (atom-deref is JIT-friendly); on V8 the
+;; relevant pressure is megamorphic-IC busting at the `@hooks` site,
+;; which the per-key dedicated slot avoids.
+;;
+;; Invariant: `set-fn!` and `chain-fn!` invalidate the slot for the key
+;; they re-publish. Production registers each hook once at boot and
+;; never again — cache hits 100%. Dev hot-reload of an artefact
+;; re-registers — the next cached lookup re-resolves through `hooks`,
+;; identical to today's behaviour. The pattern mirrors
+;; `re-frame.registrar/emit!-cache` (which memoised `:trace/emit!`
+;; under the same logic before this generalised mechanism existed).
+
+(defonce ^:private fn-cache
+  ;; hook-key → resolved-fn. Distinct from `hooks` so the cache slot
+  ;; semantics are clean: only positive resolutions are cached, and
+  ;; `set-fn!` / `chain-fn!` clear the slot atomically. Nil resolutions
+  ;; (key not yet published) fall through to the `hooks` lookup every
+  ;; call so a deferred publication is visible the next dispatch.
+  (atom {}))
+
+(defn invalidate-cache!
+  "Drop the cached resolution for `hook-key`. Called from `set-fn!` and
+  `chain-fn!` so the next `get-fn-cached` re-resolves through `hooks`.
+  Public so test fixtures and dev-time refresh tooling can force a
+  re-resolve."
+  [hook-key]
+  (swap! fn-cache dissoc hook-key)
+  nil)
+
 (defn set-fn!
   "Register a fn under hook-key. The producing namespace calls this at
-  the bottom of its file; consumers look it up via `get-fn`."
+  the bottom of its file; consumers look it up via `get-fn` (one-shot)
+  or `get-fn-cached` (sticky / hot-path).
+
+  Invalidates the sticky resolution cache for `hook-key` so any
+  previously-cached resolution is dropped — the next `get-fn-cached`
+  call re-resolves through `hooks`. This guarantees hot-reload of an
+  artefact swaps the resolved fn on the very next dispatch."
   [hook-key f]
   (swap! hooks assoc hook-key f)
+  (invalidate-cache! hook-key)
   nil)
 
 (defn get-fn
   "Return the fn registered under hook-key, or nil if no producer has
   registered it yet. Callers MUST handle the nil case (the common
-  pattern is `(when-let [f (late-bind/get-fn ...)] (f args))`)."
+  pattern is `(when-let [f (late-bind/get-fn ...)] (f args))`).
+
+  Use `get-fn-cached` instead at hot-path call sites that read the
+  same key on every dispatch — `get-fn` re-derefs `hooks` and re-walks
+  the map every call; `get-fn-cached` memoises the resolution."
   [hook-key]
   (get @hooks hook-key))
+
+(defn get-fn-cached
+  "Sticky variant of `get-fn` (rf2-f72pd) — memoises the resolved fn
+  for `hook-key` so subsequent calls read a per-key atom slot rather
+  than re-deref'ing the global `hooks` map.
+
+  Returns the resolved fn, or nil when no producer has published the
+  key yet. Nil resolutions are NOT cached — a deferred publication is
+  visible on the next call.
+
+  The cache is invalidated on `set-fn!` / `chain-fn!` for the key, so
+  dev-time hot-reload of an artefact re-resolves on the next dispatch.
+  Use at hot-path call sites — every dispatch reads
+  `:schemas/validate-event!`, `:schemas/validate-app-db!`,
+  `:flows/run-flows!`, `:epoch/settle!`, `:epoch/capture-event`,
+  `:event-emit/dispatch-on-event`, `:router/dispatch!` — so a
+  100-event cascade resolved each ~100 times before this cache."
+  [hook-key]
+  (or (get @fn-cache hook-key)
+      (when-let [resolved (get @hooks hook-key)]
+        (swap! fn-cache assoc hook-key resolved)
+        resolved)))
 
 (defn chain-fn!
   "Wire `step-fn` into the chained hook under `hook-key` so calling the

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -91,7 +91,7 @@
 ;; `:trace/emit!` (re-frame.trace depends on re-frame.registrar, so
 ;; `:require` would cycle). `:trace/emit!` is published once at
 ;; re-frame.trace load and never withdrawn, so the resolution is sticky
-;; — the cache below memoises it.
+;; — `late-bind/get-fn-cached` memoises it (rf2-f72pd).
 ;;
 ;; Each call site keeps its OUTERMOST `(when interop/debug-enabled? ...)`
 ;; gate. That gate is the load-bearing condition Closure constant-folds
@@ -101,17 +101,16 @@
 ;; literals reachable from the unconditional helper call and defeat the
 ;; elision-probe sentinels.
 
-(defonce ^:private emit!-cache (atom nil))
-
 (defn- emit!
   "Invoke `:trace/emit!` with the `:registry` op-type, memoising the
-  late-bind resolution. Callers MUST wrap invocations in
-  `(when interop/debug-enabled? ...)` so Closure DCE elides the call
-  and its literal args under `:advanced + goog.DEBUG=false`."
+  late-bind resolution through `late-bind/get-fn-cached` (rf2-f72pd —
+  this fn previously held its own per-key `emit!-cache` atom; that
+  pattern is now generalised in `re-frame.late-bind`). Callers MUST
+  wrap invocations in `(when interop/debug-enabled? ...)` so Closure
+  DCE elides the call and its literal args under `:advanced +
+  goog.DEBUG=false`."
   [operation tags]
-  (when-let [f (or @emit!-cache
-                   (when-let [resolved (late-bind/get-fn :trace/emit!)]
-                     (reset! emit!-cache resolved)))]
+  (when-let [f (late-bind/get-fn-cached :trace/emit!)]
     (f :registry operation tags)))
 
 (defn register!

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -131,7 +131,9 @@
   (when-not (valid-kind? kind)
     (throw (ex-info (str "re-frame2: unknown registry kind: " kind)
                     {:kind kind :id id})))
-  (let [previous (get-in @kind->id->metadata [kind id])]
+  ;; 2-level lookup as paired `get`s rather than `(get-in ... [kind id])` —
+  ;; `get-in` allocates a path vector per call (rf2-mqv4m).
+  (let [previous (-> @kind->id->metadata (get kind) (get id))]
     (swap! kind->id->metadata assoc-in [kind id] metadata)
     (cond
       ;; Re-registration path — fire hooks and emit handler-replaced.
@@ -181,7 +183,7 @@
   "Remove a single id under kind. Hot-reload code paths use this; user code
   rarely does."
   [kind id]
-  (let [previous (get-in @kind->id->metadata [kind id])]
+  (let [previous (-> @kind->id->metadata (get kind) (get id))]
     (swap! kind->id->metadata update kind dissoc id)
     ;; Per Spec 009 §:op-type vocabulary: :rf.registry/handler-cleared
     ;; fires on explicit removal so hot-reload tools can update their
@@ -213,9 +215,13 @@
 ;; ---- lookup ---------------------------------------------------------------
 
 (defn lookup
-  "Return the metadata map registered for (kind, id), or nil."
+  "Return the metadata map registered for (kind, id), or nil.
+
+  Uses paired `get` calls rather than `(get-in ... [kind id])` — `get-in`
+  allocates a path vector per call (rf2-mqv4m), and `lookup` runs per
+  dispatch (event handler), per fx (handler), and per sub (handler)."
   [kind id]
-  (get-in @kind->id->metadata [kind id]))
+  (-> @kind->id->metadata (get kind) (get id)))
 
 (defn handler
   "Return just the handler fn from the metadata, or nil. The handler is

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -296,7 +296,10 @@
   skipped. Defaults to true when the schemas namespace hasn't been
   loaded."
   [event-id event handler-meta]
-  (if-let [validate! (late-bind/get-fn :schemas/validate-event!)]
+  ;; Sticky hook (rf2-f72pd) — `:schemas/validate-event!` is published
+  ;; once at re-frame.schemas load and never withdrawn in production;
+  ;; this fires per-dispatch.
+  (if-let [validate! (late-bind/get-fn-cached :schemas/validate-event!)]
     (try (validate! event-id event handler-meta)
          (catch #?(:clj Throwable :cljs :default) _ true))
     true))
@@ -416,7 +419,8 @@
   actual app-db state from the rest of the cascade. Real schema
   failures route through the in-band false return."
   [db-after event-id frame]
-  (if-let [validate (late-bind/get-fn :schemas/validate-app-db!)]
+  ;; Sticky hook (rf2-f72pd) — fires per-dispatch.
+  (if-let [validate (late-bind/get-fn-cached :schemas/validate-app-db!)]
     (try
       ;; nil-coerce: pre-rf2-6m0se the fn returned nil on success.
       ;; Treat nil as true (don't roll back) so a hosted port that
@@ -516,7 +520,8 @@
   §Failure semantics rule 3 + §rationale (line 202) state the
   cascade halts at a failing flow."
   [frame event event-id start-ms]
-  (if-let [flows-fn (late-bind/get-fn :flows/run-flows!)]
+  ;; Sticky hook (rf2-f72pd) — fires per-dispatch.
+  (if-let [flows-fn (late-bind/get-fn-cached :flows/run-flows!)]
     (try
       (flows-fn frame)
       true
@@ -760,7 +765,9 @@
                 :event    event
                 :frame    frame
                 :phase    :run-end})
-  (when-let [emit-event! (late-bind/get-fn :event-emit/dispatch-on-event)]
+  ;; Sticky hook (rf2-f72pd) — always-on per-event observability fan-out
+  ;; per rf2-rirbq; survives `:advanced` + `goog.DEBUG=false`.
+  (when-let [emit-event! (late-bind/get-fn-cached :event-emit/dispatch-on-event)]
     (let [end-ms     (interop/now-ms)
           elapsed-ms (long (max 0 (- end-ms start-ms)))]
       (emit-event! event
@@ -914,7 +921,7 @@
                         :rollback?  true
                         :recovery   :no-recovery})
     (swap! router assoc :queue interop/empty-queue :scheduled? false)
-    (when-let [settle! (late-bind/get-fn :epoch/settle!)]
+    (when-let [settle! (late-bind/get-fn-cached :epoch/settle!)]
       ;; :db-after equals :db-before — atomic rollback semantics. The
       ;; record carries the cascade's :trace-events / :sub-runs /
       ;; :renders / :effects up to the halt point so devtools can
@@ -933,7 +940,7 @@
   enqueue-after-empty-check race that motivated this bead."
   [frame-id _router db-before depth]
   (when (pos? depth)
-    (when-let [settle! (late-bind/get-fn :epoch/settle!)]
+    (when-let [settle! (late-bind/get-fn-cached :epoch/settle!)]
       (let [db-after (frame/frame-app-db-value frame-id)]
         (settle! frame-id db-before db-after)))))
 
@@ -1032,7 +1039,7 @@
     (trace/emit! :frame :rf.frame/drain-interrupted
                  {:frame         frame-id
                   :dropped-count dropped})
-    (when-let [settle! (late-bind/get-fn :epoch/settle!)]
+    (when-let [settle! (late-bind/get-fn-cached :epoch/settle!)]
       (settle! frame-id db-before db-after :halted-destroy halt-reason))))
 
 (defn- run-one-pass!

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -205,7 +205,8 @@
   surprises)."
   [value query-v sub-id sub-meta]
   (if (and sub-meta (:spec sub-meta))
-    (if-let [validate (late-bind/get-fn :schemas/validate-sub-return!)]
+    ;; Sticky hook (rf2-f72pd) — fires per-sub recompute.
+    (if-let [validate (late-bind/get-fn-cached :schemas/validate-sub-return!)]
       (if (try (validate sub-id query-v value sub-meta)
                (catch #?(:clj Throwable :cljs :default) _ true))
         value

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -535,13 +535,16 @@
                    {:sub-id  query-id
                     :query-v query-v})
       (let [body-fn (:handler-fn meta)
-            inputs  (:input-signals meta)]
+            inputs  (:input-signals meta)
+            ;; Bind n once — `(empty? inputs)` then `(= 1 (count inputs))`
+            ;; counted twice on the multi-input path (rf2-r1rma).
+            n       (count inputs)]
         (try
           (let [v (cond
-                    (empty? inputs)
+                    (zero? n)
                     (body-fn db query-v)
 
-                    (= 1 (count inputs))
+                    (= 1 n)
                     (body-fn (compute-sub (first inputs) db) query-v)
 
                     :else

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -320,7 +320,10 @@
   NOT wipe the internal capture path. Per Tool-Pair §Time-travel and
   Spec 009 §`register-epoch-cb!`."
   [event]
-  (when-let [capture (late-bind/get-fn :epoch/capture-event)]
+  ;; Sticky hook (rf2-f72pd) — `:epoch/capture-event` is published once
+  ;; at re-frame.epoch load and never withdrawn; this fires on every
+  ;; trace emit during a cascade.
+  (when-let [capture (late-bind/get-fn-cached :epoch/capture-event)]
     (try
       (capture event)
       (catch #?(:clj Throwable :cljs :default) _ nil))))

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -110,7 +110,10 @@
   itself rides."
   [render-key]
   (when interop/debug-enabled?
-    (when-let [emit! (late-bind/get-fn :trace/emit!)]
+    ;; Sticky hook (rf2-f72pd) — `:trace/emit!` is published once at
+    ;; re-frame.trace load and never withdrawn; this fires per render
+    ;; under dev builds.
+    (when-let [emit! (late-bind/get-fn-cached :trace/emit!)]
       (emit! :view :view/render
              {:render-key render-key
               :frame      (provider/current-frame)}))))

--- a/implementation/core/src/re_frame/views/provider.cljs
+++ b/implementation/core/src/re_frame/views/provider.cljs
@@ -125,7 +125,10 @@
   Returns nil when no adapter has registered the hook (JVM / headless
   builds; no-adapter tests)."
   []
-  (when-let [hook (late-bind/get-fn :adapter/current-component)]
+  ;; Sticky hook (rf2-f72pd) — published once per loaded React-shaped
+  ;; adapter; called per Reagent render path that consults its
+  ;; component identity.
+  (when-let [hook (late-bind/get-fn-cached :adapter/current-component)]
     (hook)))
 
 ;; ---- frame resolution at render time -------------------------------------


### PR DESCRIPTION
## Summary

Cluster of 4 perf follow-ups from the rf2-fzrav perf sweep (findings: `ai/findings/perf-sweep-2026-05-15.md`). All touch `implementation/core/src/re_frame/`. Sequenced commits, smallest to biggest.

- **rf2-mqv4m (P4)** — replace 2-level `get-in` with paired `get`s / keyword-invoke across `registrar.cljc` (`lookup`, `register!`, `unregister!`) and `frame.cljc` (`frame`, `frame-disposed-for-drain?`, `frame-ids` x2, `fire-on-destroy-event!`). 8 sites total. Eliminates per-call path-vector allocation in dispatch / fx / sub lookup paths.

- **rf2-r1rma (P4)** — `compute-sub` bound `(count inputs)` once via `n`; dispatch on `(zero? n)` / `(= 1 n)`. Cosmetic micro-allocation cleanup.

- **rf2-ioduy (P3)** — `elision/walk` `vector?` and `seq?` container branches dropped `(mapv (fn [idx vv] ...) (range) v)` (per-child cons cell). Replaced with hand-rolled indexed `loop`/`recur` over `(nth v i)` + transient (vector?) and `reduce` with `volatile!` index counter (seq?).

- **rf2-f72pd (P2 HIGH)** — added `late-bind/get-fn-cached` (sticky resolution memo into a per-key atom slot, invalidated on `set-fn!` / `chain-fn!`) + `invalidate-cache!`. Updated 18 hot-path call sites across `router` / `fx` / `cofx` / `subs` / `trace` / `frame` / `interop` / `views` / `views/provider` / `registrar`. Dropped the now-redundant per-key `emit!-cache` atom in `registrar.cljc` — predated this generalised mechanism, replaced with one `get-fn-cached` call (cross-bead unification, ~10 lines net deleted).

## Test plan

- [x] `npm run test:cljs` — green: 2045 tests, 5805 assertions, 0 failures, 0 errors (clean baseline + clean after each commit).
- [x] `npm run test:perf-bundle` — green: counter perf-off bundle 367163 chars, perf-on 368543 chars, sentinels match.
- [x] Late-bind drift test green (5 tests, 319 assertions) — directory still in sync.
- [ ] CI sweep across browser / elision / examples / bundle-isolation gates.

## Constraints honoured

- No AI attribution.
- Pre-alpha — no back-compat shims; `set-fn!` invalidation contract is the new normative semantics.
- Hot-zone files untouched (no `Conventions.md` / `MIGRATION.md` / `API.md` / etc).
- Disjoint from concurrent surface work (concurrency stress tests, SSR perf cluster, epoch / adapter / schemas / routing solo perf agents).