### PR TITLE
perf(ssr): rf2-fzrav follow-ups cluster (2 beads)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -94,11 +94,26 @@
   tag-name)
 
 ;; Tag-name parsing for the :div#id.cls syntax. Reagent / Hiccup convention.
-(defn parse-tag-name
-  "Split a keyword like :div#main.col-12.bold into [:div {:id \"main\"
-  :class \"col-12 bold\"}] components. Throws `:rf.error/invalid-tag-name`
-  (rf2-z7gor) if the tag component is not a well-formed HTML5/SVG/MathML
-  element name."
+;;
+;; Per rf2-ezdwh (perf-sweep H1, ai/findings/perf-sweep-2026-05-15.md):
+;; `parse-tag-name` is called once per DOM-tag emission. Repeated heads
+;; (`:div`, `:span`, `:p`, `:div#main.col-12`, …) appear thousands of
+;; times in a single render and re-parsed every time — `(name kw)` +
+;; `re-matches` + optional `string/split` + `remove empty?` + `join` +
+;; a second `re-matches` inside `validate-tag-name!`. The result
+;; depends solely on keyword identity.
+;;
+;; The memo is per-render (bound at `render-to-string` /
+;; `streaming/render-shell` / `streaming/render-continuation` entry)
+;; rather than process-wide so cache size never outlives one render
+;; pass. A volatile! map `{kw [tag-name tag-attrs]}` is fine — emit is
+;; single-threaded per render. When the cache is unbound (caller
+;; invokes `parse-tag-name` outside an emit pass — tests, custom
+;; consumers, the streaming `walk-dom-tag`) the call falls through to
+;; the uncached parse, so the public surface is unchanged.
+
+(defn- parse-tag-name*
+  "Pure parse — the body the memo wraps."
   [tag-kw]
   (let [s     (name tag-kw)
         ;; Match: tag-name optionally followed by #id and .class fragments.
@@ -114,6 +129,30 @@
      (cond-> {}
        id         (assoc :id id)
        class-list (assoc :class class-list))]))
+
+(def ^:dynamic *tag-name-cache*
+  "Per-render volatile! holding `{tag-kw [tag-name tag-attrs]}`. Bound
+  at the public emit entry points; nil outside a render pass (cold
+  callers fall through to the uncached parse). Per rf2-ezdwh."
+  nil)
+
+(defn parse-tag-name
+  "Split a keyword like :div#main.col-12.bold into [:div {:id \"main\"
+  :class \"col-12 bold\"}] components. Throws `:rf.error/invalid-tag-name`
+  (rf2-z7gor) if the tag component is not a well-formed HTML5/SVG/MathML
+  element name.
+
+  When called inside a render pass (`*tag-name-cache*` bound), the
+  result is memoised by keyword identity and reused on subsequent
+  emissions of the same head — typical SSR shells repeat `:div`,
+  `:span`, `:p` thousands of times. Per rf2-ezdwh."
+  [tag-kw]
+  (if-let [cache *tag-name-cache*]
+    (or (get @cache tag-kw)
+        (let [parsed (parse-tag-name* tag-kw)]
+          (vswap! cache assoc tag-kw parsed)
+          parsed))
+    (parse-tag-name* tag-kw)))
 
 (defn merge-class-attrs
   "Merge the class from the tag-name into the attrs map's :class."
@@ -309,15 +348,20 @@
   stamper. Spec 011's hash/emit separation is preserved (no combined
   walker)."
   [render-tree opts]
-  (let [supplied-hash (:render-hash opts)
-        root-attrs    (cond
-                        supplied-hash {:data-rf-render-hash supplied-hash}
-                        (:emit-hash? opts)
-                        {:data-rf-render-hash (hash/render-tree-hash render-tree)})
-        body          (emit-element render-tree root-attrs)]
-    (if (:doctype? opts)
-      (str "<!DOCTYPE html>" body)
-      body)))
+  ;; Per rf2-ezdwh — bind the per-render parse-tag-name memo so
+  ;; repeated heads (`:div`, `:span`, `:p`, …) parse once instead of
+  ;; once per emission. Cache lives only for the duration of this
+  ;; render call.
+  (binding [*tag-name-cache* (volatile! {})]
+    (let [supplied-hash (:render-hash opts)
+          root-attrs    (cond
+                          supplied-hash {:data-rf-render-hash supplied-hash}
+                          (:emit-hash? opts)
+                          {:data-rf-render-hash (hash/render-tree-hash render-tree)})
+          body          (emit-element render-tree root-attrs)]
+      (if (:doctype? opts)
+        (str "<!DOCTYPE html>" body)
+        body))))
 
 ;; Wire render-to-string into the plain-atom adapter so callers using
 ;; rf/render-to-string (delegating through the substrate adapter) get

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -227,8 +227,13 @@
   "At a `:rf/suspense-boundary`, materialise the fallback inline as a
   `<template>` placeholder + register a continuation for the subtree."
   [el acc]
-  (let [attrs (second el)
-        children (drop 2 el)]
+  (let [attrs    (second el)
+        ;; Per rf2-ezdwh — `children` was a `(drop 2 el)` lazy seq the
+        ;; cond branches below counted twice (`(zero? (count children))`
+        ;; then `(= 1 (count children))`). Realise to a vector once and
+        ;; bind `n` so the cond reads as a constant-time arity dispatch.
+        children (vec (drop 2 el))
+        n        (count children)]
     (when-not (suspense-attrs? attrs)
       (throw (ex-info ":rf.error/suspense-boundary-invalid-attrs"
                       {:reason   ":rf/suspense-boundary requires {:id … :fallback …} attrs map"
@@ -240,10 +245,10 @@
           ;; attrs map. Single-child or multi-child both work — we wrap
           ;; multi-children in a `:<>` fragment so the continuation
           ;; renders one logical hiccup form.
-          subtree (cond
-                    (zero? (count children)) nil
-                    (= 1 (count children))   (first children)
-                    :else                    (into [:<>] children))
+          subtree (case n
+                    0 nil
+                    1 (nth children 0)
+                    (into [:<>] children))
           ;; Render the fallback with the standard emitter so it can
           ;; itself contain view-refs / nested hiccup. NOT a recursive
           ;; walk — fallbacks cannot nest suspense-boundaries (they
@@ -329,11 +334,16 @@
   semantics — the failure boundary stops at the continuation; a shell-
   walk throw is a structural failure that escalates."
   [root-hiccup]
-  (let [acc       (new-continuations-acc)
-        shell     (walk root-hiccup acc)
-        conts     (dedupe-continuations @acc)]
-    {:shell-html shell
-     :continuations conts}))
+  ;; Per rf2-ezdwh — bind the per-render parse-tag-name memo so the
+  ;; walker's DOM-tag emissions and any inline fallback renders share
+  ;; one cache for the whole shell pass. The cache lives only for the
+  ;; duration of `render-shell`.
+  (binding [emit/*tag-name-cache* (volatile! {})]
+    (let [acc       (new-continuations-acc)
+          shell     (walk root-hiccup acc)
+          conts     (dedupe-continuations @acc)]
+      {:shell-html shell
+       :continuations conts})))
 
 (defn render-continuation
   "Drain one continuation. `frame-id` is the per-request frame whose

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -176,15 +176,25 @@
 
 (declare walk)
 
-(defn- some-suspense-boundary?
-  "Cheap pre-scan: is there a `:rf/suspense-boundary` anywhere in the
-  hiccup vector's subtree? Lets the walker take the fast non-recursive
-  emit path on DOM-tag elements whose subtrees are boundary-free."
-  [el]
-  (cond
-    (not (vector? el)) false
-    (= :rf/suspense-boundary (first el)) true
-    :else (boolean (some some-suspense-boundary? (rest el)))))
+;; Per rf2-muasb (perf-sweep H2, ai/findings/perf-sweep-2026-05-15.md):
+;; the prior implementation called `(some-suspense-boundary? el)` —
+;; itself a recursive scan of the entire subtree — on every DOM-tag
+;; descent, then took a fast `emit/emit-element` path when the
+;; subtree was boundary-free. For a shell with N DOM nodes the
+;; ancestor-chain scans collectively walked O(N × tree-depth) nodes,
+;; quadratic on deep trees with a buried boundary, and the fast path
+;; saved only one fn-call boundary on a tree-walk that emit-element
+;; would do anyway.
+;;
+;; Replaced with the simplest correct shape: walk always recurses
+;; through DOM-tag children via `walk-dom-tag`. Single keyword check
+;; per node either way. A registered view resolved via `:view`
+;; lookup may itself contain boundaries (the conformance fixture
+;; root does); the recursion-always shape catches those without any
+;; pre-scan. The fast-path option (emit/emit-element on
+;; statically-clean subtrees) cannot see through view-refs and so
+;; cannot serve as a correct pre-filter without the per-descent
+;; cost the audit calls out.
 
 (defn- walk-children [children acc]
   (clojure.string/join (mapv #(walk % acc) children)))
@@ -192,18 +202,18 @@
 (defn- walk-dom-tag
   "Emit a DOM tag element while recursing into its children with the
   walker (so nested boundaries get caught). Mirrors the non-void branch
-  of `emit/emit-element` but threads `acc` through."
+  of `emit/emit-element` but threads `acc` through. Per rf2-muasb the
+  prior shape called `parse-tag-name` twice on `head` (once destructured
+  to `[tag-name _]`, then again to `[_ tag-attrs]`); collapsed to one
+  call here, the binding shape mirrors `emit/emit-element` exactly."
   [el acc]
-  (let [head (first el)
-        [tag-name _tag-attrs-from-head] (emit/parse-tag-name head)
+  (let [head                  (first el)
+        [tag-name tag-attrs]  (emit/parse-tag-name head)
         [user-attrs children] (if (map? (second el))
                                 [(second el) (drop 2 el)]
                                 [{} (rest el)])
-        ;; Re-derive `[tag-attrs]` and `merged` exactly as emit-element
-        ;; does — keeps tag#id.cls parity with the non-streaming path.
-        [_ tag-attrs] (emit/parse-tag-name head)
-        merged-attrs  (emit/merge-class-attrs tag-attrs user-attrs)
-        void?         (contains? emit/void-elements (keyword tag-name))]
+        merged-attrs          (emit/merge-class-attrs tag-attrs user-attrs)
+        void?                 (contains? emit/void-elements (keyword tag-name))]
     (if void?
       (str "<" tag-name (emit/attr-string merged-attrs) ">")
       (str "<" tag-name (emit/attr-string merged-attrs) ">"
@@ -281,14 +291,12 @@
                         (emit/inject-coord-on-root-hiccup coord raw)
                         raw)]
             (walk out acc))
-          ;; DOM tag — emit via the standard emitter ONLY IF the
-          ;; subtree contains no suspense-boundaries; otherwise recurse
-          ;; manually so we descend into them. A quick pre-scan keeps
-          ;; the common case (no boundary in subtree) fast — fall
-          ;; through to emit-element which is already optimised.
-          (if (some-suspense-boundary? el)
-            (walk-dom-tag el acc)
-            (emit/emit-element el)))))
+          ;; DOM tag — always recurse via `walk-dom-tag` so nested
+          ;; suspense-boundaries are reachable. Per rf2-muasb the
+          ;; prior `some-suspense-boundary?` pre-scan was a perf
+          ;; anti-pattern: O(N) per descent, dominated whatever it
+          ;; saved by short-circuiting to `emit/emit-element`.
+          (walk-dom-tag el acc))))
 
     (and (vector? el) (fn? (first el)))
     ;; fn-headed component — invoke + recurse on the body.


### PR DESCRIPTION
## Summary

Cluster of 2 P2-HIGH perf follow-ups from the rf2-fzrav implementation
sweep (`ai/findings/perf-sweep-2026-05-15.md`). Both touch
`implementation/ssr/`; commits are sequenced.

### rf2-muasb — replace per-descent boundary pre-scan with always-recurse

`streaming/walk` called `some-suspense-boundary?` — itself a recursive
subtree scan — on every DOM-tag descent. For a shell with N DOM nodes
and a buried boundary, ancestor-chain scans collectively walked
O(N x tree-depth) nodes. Replaced with the simplest correct shape:
walk always recurses through DOM-tag children via `walk-dom-tag`.
A static pre-scan at render-shell entry was tried but rejected — it
cannot see through `[:registered-view]` refs (the conformance fixture
root is one), so any short-circuit would silently break streaming for
view-rooted shells. Bonus dedupe: `walk-dom-tag` was calling
`parse-tag-name` twice on `head`; collapsed to one call.

### rf2-ezdwh — per-render `parse-tag-name` memo + `walk-suspense-boundary` count-twice

`parse-tag-name` ran the full `(name kw)` + double `re-matches` +
optional `string/split` + `remove empty?` + `join` pipeline once per
DOM-tag emission. Result depends solely on keyword identity; repeated
heads (`:div`, `:span`, `:p`, `:div#main.col-12`) appear thousands of
times in a single render. Memo is per-render — `*tag-name-cache*`
dynamic var bound to a `volatile! {}` at `render-to-string` and
`streaming/render-shell` entry; cache lives exactly one render pass.
Cold callers outside a render pass fall through to the unmemoised
path so the public surface is unchanged.

Bundled L5: `walk-suspense-boundary` was calling `(count children)`
twice on a `(drop 2 el)` lazy seq; realised once to a vector, bound
`n`, switched the cond to a `case` arity dispatch.

## Perf measurement

Bench fixture: `streaming/render-shell` on hiccup tree of ~1000 DOM
nodes (100 entries x 10-deep wrapping chains, buried boundary).
Median ms across 100 iters; warmed JVM. Numbers are cluster-cumulative
vs pre-cluster baseline.

| Fixture | Pre-cluster | Post-cluster | Reduction |
|---|---|---|---|
| `streaming/render-shell` (wide-fan) | 2.94 ms | 2.26 ms | ~23% |
| `emit/render-to-string` (pure)      | 1.25 ms | 1.11 ms | ~11% |
| `streaming/render-shell` (deep chain, quadratic worst case) | 0.34 ms | 0.12 ms | ~63% |

The deep-chain fixture explicitly stresses the rf2-muasb quadratic;
the wide-fan + emit fixtures pick up the rf2-ezdwh memo win.

## Test plan

- [x] `clojure -M:test` in `implementation/ssr/` — 139 tests / 469 assertions, 0 failures
- [x] `npm run test:cljs` in `implementation/` — 2045 tests / 5805 assertions, 0 failures (regression check)
- [x] Conformance fixture (`spec/conformance/fixtures/ssr-streaming.edn`) drives `streaming-fixture-shell-walk-matches-pin` + `streaming-fixture-resolve-continuations-match-pin` + `streaming-fixture-final-payload-shape-matches-pin` unchanged

## Constraints

- Pre-alpha; no AI attribution.
- Hot-zone: NONE touched (`implementation/ssr/src/` is per-feature artefact).
- Concurrent disjoint: rf2-ozhy9 ssr-ring concurrency stress (`implementation/ssr-ring/test/`) does not overlap.