### PR TITLE
refactor(causa): cleanup follow-ons mini-cluster (rf2-nmc1f + rf2-tanmj)

### DIFF
--- a/tools/causa/spec/014-Registry-Catalogue.md
+++ b/tools/causa/spec/014-Registry-Catalogue.md
@@ -17,10 +17,11 @@ this doc enumerates what sits inside it.
 
 | Prefix | Used for |
 |---|---|
-| `:rf.causa/<id>` | Every subscription, every event, every cofx. |
+| `:rf.causa/<id>` | Every subscription, every cofx, and every cross-panel event (consumed from ≥2 panels) or shared-infrastructure event (trace-buffer pump, epoch-history pump, etc.). |
+| `:rf.causa.<panel>/<id>` | Every panel-internal event — owned by exactly one panel, never dispatched from another. The namespace itself encodes "panel-internal, no cross-panel callers"; renaming the panel renames the namespace. Per the rf2-nmc1f cleanup the issues-ribbon panel uses this convention (`:rf.causa.issues/clear-filters`, `:rf.causa.issues/toggle-severity`, etc.). Other panels MAY adopt the convention as their event surface stabilises. |
 | `:rf.causa.fx/<id>` | Every effect (fx). The trailing `.fx/` segment is the canonical effect-id marker — agents grepping for the fx subset MAY use `:rf.causa.fx/` as the discriminator. |
 
-Causa MUST NOT register a handler under any non-`:rf.causa/*` keyword.
+Causa MUST NOT register a handler under any non-`:rf.causa*/` keyword.
 A host registering `:user/login` and Causa registering
 `:rf.causa/select-panel` cannot stamp on each other; the prefix is the
 collision-avoidance contract enforced by code review and the registry
@@ -267,10 +268,10 @@ axis independent; empty / `nil` disables the axis.
 
 | Event | Vector shape | Behaviour |
 |---|---|---|
-| `:rf.causa/toggle-issues-severity` | `[_ severity]` | Toggles a severity chip in/out. |
-| `:rf.causa/toggle-issues-prefix` | `[_ prefix]` | Toggles a prefix chip in/out. |
-| `:rf.causa/set-issues-since-seconds` | `[_ seconds]` | Converts s → ms; `nil` / non-positive clears the axis. |
-| `:rf.causa/clear-issues-filters` | `[_]` | Clears every axis. |
+| `:rf.causa.issues/toggle-severity` | `[_ severity]` | Toggles a severity chip in/out. |
+| `:rf.causa.issues/toggle-prefix` | `[_ prefix]` | Toggles a prefix chip in/out. |
+| `:rf.causa.issues/set-since-seconds` | `[_ seconds]` | Converts s → ms; `nil` / non-positive clears the axis. |
+| `:rf.causa.issues/clear-filters` | `[_]` | Clears every axis. |
 
 ## Flows panel
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
@@ -104,7 +104,7 @@
                  :colour   colour
                  :test-id  (str "rf-causa-issues-severity-chip-"
                                 (name severity))
-                 :on-click #(rf/dispatch [:rf.causa/toggle-issues-severity
+                 :on-click #(rf/dispatch [:rf.causa.issues/toggle-severity
                                           severity] {:frame :rf/causa})}))))
 
 (defn- prefix-chips
@@ -122,7 +122,7 @@
                    :active?  active?
                    :colour   (:accent-violet tokens)
                    :test-id  (str "rf-causa-issues-prefix-chip-" prefix)
-                   :on-click #(rf/dispatch [:rf.causa/toggle-issues-prefix
+                   :on-click #(rf/dispatch [:rf.causa.issues/toggle-prefix
                                             prefix] {:frame :rf/causa})})))))
 
 (defn- since-input
@@ -149,7 +149,7 @@
                                    (let [parsed (js/parseInt v 10)]
                                      (when-not (js/isNaN parsed) parsed))
                                    (catch :default _ nil))]
-                           (rf/dispatch [:rf.causa/set-issues-since-seconds n] {:frame :rf/causa})))
+                           (rf/dispatch [:rf.causa.issues/set-since-seconds n] {:frame :rf/causa})))
             :style     {:width "60px"
                         :background (:bg-3 tokens)
                         :color (:text-primary tokens)
@@ -183,7 +183,7 @@
      (str rendered " / " total " in view")]
     (when any-filter?
       [:button {:data-testid "rf-causa-issues-clear-filters"
-                :on-click    #(rf/dispatch [:rf.causa/clear-issues-filters] {:frame :rf/causa})
+                :on-click    #(rf/dispatch [:rf.causa.issues/clear-filters] {:frame :rf/causa})
                 :style       {:margin-left "auto"
                               :background  "transparent"
                               :color       (:cyan tokens)
@@ -325,7 +325,7 @@
                 :color (:text-tertiary tokens)}}
     "Adjust the severity / prefix / since-ms chips above to widen the feed."]
    [:button {:data-testid "rf-causa-issues-empty-clear-filters"
-             :on-click    #(rf/dispatch [:rf.causa/clear-issues-filters] {:frame :rf/causa})
+             :on-click    #(rf/dispatch [:rf.causa.issues/clear-filters] {:frame :rf/causa})
              :style       {:background "transparent"
                            :color      (:cyan tokens)
                            :border     (str "1px solid " (:border-default tokens))
@@ -438,7 +438,7 @@
 
   ;; Toggle a severity chip in/out of the active filter set. Per
   ;; the bead's contract each axis is independent.
-  (rf/reg-event-db :rf.causa/toggle-issues-severity
+  (rf/reg-event-db :rf.causa.issues/toggle-severity
     (fn [db [_ severity]]
       (let [current (get db :issues-active-severities #{})]
         (assoc db :issues-active-severities
@@ -448,7 +448,7 @@
 
   ;; Toggle a category-prefix chip. Same shape as the severity
   ;; toggle — multi-select set; empty set = no restriction.
-  (rf/reg-event-db :rf.causa/toggle-issues-prefix
+  (rf/reg-event-db :rf.causa.issues/toggle-prefix
     (fn [db [_ prefix]]
       (let [current (get db :issues-active-prefixes #{})]
         (assoc db :issues-active-prefixes
@@ -459,7 +459,7 @@
   ;; Set the since-ms axis from a seconds-typed user input. The
   ;; view converts s → ms here so the helper's filter-application
   ;; stays uniform in ms. nil / non-positive values clear the axis.
-  (rf/reg-event-db :rf.causa/set-issues-since-seconds
+  (rf/reg-event-db :rf.causa.issues/set-since-seconds
     (fn [db [_ seconds]]
       (if (and (number? seconds) (pos? seconds))
         (assoc db :issues-since-ms (* (long seconds) 1000))
@@ -468,7 +468,7 @@
   ;; Clear every filter axis in one shot. The Clear filters
   ;; affordance in the header + the no-matches empty state both
   ;; fire this.
-  (rf/reg-event-db :rf.causa/clear-issues-filters
+  (rf/reg-event-db :rf.causa.issues/clear-filters
     (fn [db _event]
       (-> db
           (dissoc :issues-active-severities)

--- a/tools/causa/test/day8/re_frame2_causa/core_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/core_cljs_test.cljs
@@ -31,13 +31,13 @@
             [day8.re-frame2-causa.mount :as mount]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!))
 
 (use-fixtures :each

--- a/tools/causa/test/day8/re_frame2_causa/mount_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/mount_cljs_test.cljs
@@ -55,6 +55,7 @@
             [day8.re-frame2-causa.mount :as mount]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
 ;; ---- private-state accessors --------------------------------------------
@@ -213,8 +214,7 @@
 ;; transition test doesn't poison neighbours via stale singleton state.
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   ;; Per rf2-in6l2 the registry installs the trace-buffer mirror
   ;; events (note-trace-event / clear-trace-buffer / sync-trace-buffer).
   ;; `ensure-causa-frame!` (called inside `open!`) dispatches

--- a/tools/causa/test/day8/re_frame2_causa/open_in_editor_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/open_in_editor_cljs_test.cljs
@@ -28,6 +28,7 @@
             [day8.re-frame2-causa.open-in-editor :as open-in-editor]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
 (defn reset-editor! []
@@ -40,8 +41,7 @@
 ;; cheap snapshot/restore cost; the rf2-g5q8d tests below need the
 ;; clean runtime so registrations don't bleed between tests.
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!)
   (reset-editor!))
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_cljs_test.cljs
@@ -39,6 +39,7 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.ai-co-pilot :as copilot]
             [day8.re-frame2-causa.panels.ai-co-pilot-helpers :as h]))
@@ -46,8 +47,7 @@
 ;; ---- fixture ------------------------------------------------------------
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!))
 
 (use-fixtures :each

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
@@ -39,14 +39,14 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!)
   ;; The `:rf.causa/selected-epoch-diff` cache is a top-level
   ;; `defonce` (lifted from let-local for rf2-o94sp testability —

--- a/tools/causa/test/day8/re_frame2_causa/panels/causality_graph_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/causality_graph_view_cljs_test.cljs
@@ -32,14 +32,14 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.causality-graph :as causality-graph]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!)
   ;; Reset the topology cache (rf2-rj40a / audit 2d) so cache-hit
   ;; assertions are deterministic across the test corpus.

--- a/tools/causa/test/day8/re_frame2_causa/panels/effects_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/effects_view_cljs_test.cljs
@@ -39,14 +39,14 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.effects :as effects]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!))
 
 (use-fixtures :each

--- a/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
@@ -32,14 +32,14 @@
             [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!)
   ;; Reset the :sensitive? privacy gate to its default (suppress) so the
   ;; redaction-state tests below start from a known baseline regardless

--- a/tools/causa/test/day8/re_frame2_causa/panels/flows_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/flows_view_cljs_test.cljs
@@ -37,14 +37,14 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.flows :as flows]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!))
 
 (use-fixtures :each

--- a/tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_view_cljs_test.cljs
@@ -31,14 +31,14 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.hydration-debugger :as hydration]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!))
 
 (use-fixtures :each

--- a/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
@@ -52,14 +52,14 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!))
 
 (use-fixtures :each

--- a/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
@@ -23,14 +23,14 @@
        prefix; the prefix chip-row only renders when at least one
        prefix has issues.
 
-    6. **Severity filter** — `:rf.causa/toggle-issues-severity` adds/
+    6. **Severity filter** — `:rf.causa.issues/toggle-severity` adds/
        removes severities from the active set and the rendered rows
        narrow to match.
 
-    7. **Prefix filter** — `:rf.causa/toggle-issues-prefix` works the
+    7. **Prefix filter** — `:rf.causa.issues/toggle-prefix` works the
        same way for category prefixes.
 
-    8. **Since-ms filter** — `:rf.causa/set-issues-since-seconds`
+    8. **Since-ms filter** — `:rf.causa.issues/set-since-seconds`
        sets/clears the time window.
 
     9. **Row interactions** — clicking a row pivots to event-detail
@@ -133,14 +133,14 @@
         ":rf.causa/issues-ribbon sub registered")
     (is (some? (registrar/handler :sub :rf.causa/issues-filters))
         ":rf.causa/issues-filters sub registered")
-    (is (some? (registrar/handler :event :rf.causa/toggle-issues-severity))
-        ":rf.causa/toggle-issues-severity event registered")
-    (is (some? (registrar/handler :event :rf.causa/toggle-issues-prefix))
-        ":rf.causa/toggle-issues-prefix event registered")
-    (is (some? (registrar/handler :event :rf.causa/set-issues-since-seconds))
-        ":rf.causa/set-issues-since-seconds event registered")
-    (is (some? (registrar/handler :event :rf.causa/clear-issues-filters))
-        ":rf.causa/clear-issues-filters event registered")))
+    (is (some? (registrar/handler :event :rf.causa.issues/toggle-severity))
+        ":rf.causa.issues/toggle-severity event registered")
+    (is (some? (registrar/handler :event :rf.causa.issues/toggle-prefix))
+        ":rf.causa.issues/toggle-prefix event registered")
+    (is (some? (registrar/handler :event :rf.causa.issues/set-since-seconds))
+        ":rf.causa.issues/set-since-seconds event registered")
+    (is (some? (registrar/handler :event :rf.causa.issues/clear-filters))
+        ":rf.causa.issues/clear-filters event registered")))
 
 (deftest issues-ribbon-defaults-to-no-issues
   (testing "with no events the composite returns empty-kind :no-issues"
@@ -206,7 +206,7 @@
       (push-trace! (mk-issue {:id 1 :op-type :error
                               :operation :rf.error/handler-threw}))
       ;; Toggle in a severity the issue doesn't carry — filter excludes it.
-      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :advisory])
+      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :advisory])
       (let [tree (issues-ribbon/issues-ribbon-view)]
         (is (some? (find-by-testid tree "rf-causa-issues-empty-no-matches"))
             ":no-matches empty-state container present")
@@ -295,17 +295,17 @@
 ;; ---- (6) severity filter ------------------------------------------------
 
 (deftest toggle-severity-mutates-causa-frame
-  (testing ":rf.causa/toggle-issues-severity toggles set membership on
+  (testing ":rf.causa.issues/toggle-severity toggles set membership on
             the Causa frame"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :error])
+      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :error])
       (is (= #{:error}
              (:severities @(rf/subscribe [:rf.causa/issues-filters]))))
-      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :warning])
+      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :warning])
       (is (= #{:error :warning}
              (:severities @(rf/subscribe [:rf.causa/issues-filters]))))
-      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :error])
+      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :error])
       (is (= #{:warning}
              (:severities @(rf/subscribe [:rf.causa/issues-filters])))
           "second toggle removes the severity"))))
@@ -320,7 +320,7 @@
                               :operation :rf.warning/recoverable}))
       (push-trace! (mk-issue {:id 3 :op-type :info
                               :operation :rf.info/note}))
-      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :warning])
+      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :warning])
       (let [data @(rf/subscribe [:rf.causa/issues-ribbon])]
         (is (= 3 (:total data)))
         (is (= 1 (:rendered data)))
@@ -329,14 +329,14 @@
 ;; ---- (7) prefix filter --------------------------------------------------
 
 (deftest toggle-prefix-mutates-causa-frame
-  (testing ":rf.causa/toggle-issues-prefix toggles set membership on
+  (testing ":rf.causa.issues/toggle-prefix toggles set membership on
             the Causa frame"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/toggle-issues-prefix "rf.error"])
+      (rf/dispatch-sync [:rf.causa.issues/toggle-prefix "rf.error"])
       (is (= #{"rf.error"}
              (:prefixes @(rf/subscribe [:rf.causa/issues-filters]))))
-      (rf/dispatch-sync [:rf.causa/toggle-issues-prefix "rf.error"])
+      (rf/dispatch-sync [:rf.causa.issues/toggle-prefix "rf.error"])
       (is (= #{} (:prefixes @(rf/subscribe [:rf.causa/issues-filters])))
           "second toggle removes the prefix"))))
 
@@ -348,7 +348,7 @@
                               :operation :rf.error/handler-threw}))
       (push-trace! (mk-issue {:id 2 :op-type :error
                               :operation :rf.ssr/hydration-mismatch}))
-      (rf/dispatch-sync [:rf.causa/toggle-issues-prefix "rf.ssr"])
+      (rf/dispatch-sync [:rf.causa.issues/toggle-prefix "rf.ssr"])
       (let [data @(rf/subscribe [:rf.causa/issues-ribbon])]
         (is (= 1 (:rendered data)))
         (is (= [2] (mapv :id (:issues data))))))))
@@ -356,27 +356,27 @@
 ;; ---- (8) since-ms filter ------------------------------------------------
 
 (deftest set-since-seconds-converts-to-ms
-  (testing ":rf.causa/set-issues-since-seconds takes seconds and stores ms"
+  (testing ":rf.causa.issues/set-since-seconds takes seconds and stores ms"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/set-issues-since-seconds 30])
+      (rf/dispatch-sync [:rf.causa.issues/set-since-seconds 30])
       (is (= 30000 (:since-ms @(rf/subscribe [:rf.causa/issues-filters])))
           "30s stored as 30000ms")
-      (rf/dispatch-sync [:rf.causa/set-issues-since-seconds nil])
+      (rf/dispatch-sync [:rf.causa.issues/set-since-seconds nil])
       (is (nil? (:since-ms @(rf/subscribe [:rf.causa/issues-filters])))
           "nil clears the axis")
-      (rf/dispatch-sync [:rf.causa/set-issues-since-seconds 0])
+      (rf/dispatch-sync [:rf.causa.issues/set-since-seconds 0])
       (is (nil? (:since-ms @(rf/subscribe [:rf.causa/issues-filters])))
           "0 / non-positive clears the axis"))))
 
 (deftest clear-issues-filters-drops-every-axis
-  (testing ":rf.causa/clear-issues-filters drops all three axes in one shot"
+  (testing ":rf.causa.issues/clear-filters drops all three axes in one shot"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :error])
-      (rf/dispatch-sync [:rf.causa/toggle-issues-prefix "rf.error"])
-      (rf/dispatch-sync [:rf.causa/set-issues-since-seconds 60])
-      (rf/dispatch-sync [:rf.causa/clear-issues-filters])
+      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :error])
+      (rf/dispatch-sync [:rf.causa.issues/toggle-prefix "rf.error"])
+      (rf/dispatch-sync [:rf.causa.issues/set-since-seconds 60])
+      (rf/dispatch-sync [:rf.causa.issues/clear-filters])
       (let [filters @(rf/subscribe [:rf.causa/issues-filters])]
         (is (or (nil? (:severities filters)) (empty? (:severities filters))))
         (is (or (nil? (:prefixes filters)) (empty? (:prefixes filters))))
@@ -392,7 +392,7 @@
       (is (nil? (find-by-testid (issues-ribbon/issues-ribbon-view)
                                 "rf-causa-issues-clear-filters"))
           "no Clear filters button when no axis is active")
-      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :error])
+      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :error])
       (is (some? (find-by-testid (issues-ribbon/issues-ribbon-view)
                                  "rf-causa-issues-clear-filters"))
           "Clear filters button surfaces once a severity is active"))))
@@ -460,8 +460,8 @@
   (testing "the panel's filter state lives on :rf/causa, never :rf/default"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :error])
-      (rf/dispatch-sync [:rf.causa/set-issues-since-seconds 60]))
+      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :error])
+      (rf/dispatch-sync [:rf.causa.issues/set-since-seconds 60]))
     (let [causa-db   (frame/frame-app-db-value :rf/causa)
           default-db (frame/frame-app-db-value :rf/default)]
       (is (= #{:error} (:issues-active-severities causa-db))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
@@ -33,14 +33,14 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!))
 
 (use-fixtures :each

--- a/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_view_cljs_test.cljs
@@ -37,14 +37,14 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.mcp-server :as mcp-server]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!))
 
 (use-fixtures :each

--- a/tools/causa/test/day8/re_frame2_causa/panels/performance_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/performance_view_cljs_test.cljs
@@ -43,6 +43,7 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.performance :as performance]
             [day8.re-frame2-causa.panels.performance-helpers :as h]))
@@ -50,8 +51,7 @@
 ;; ---- fixtures -----------------------------------------------------------
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!))
 
 (use-fixtures :each

--- a/tools/causa/test/day8/re_frame2_causa/panels/routes_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/routes_view_cljs_test.cljs
@@ -42,14 +42,14 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.routes :as routes]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!))
 
 (use-fixtures :each

--- a/tools/causa/test/day8/re_frame2_causa/panels/schema_violation_timeline_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/schema_violation_timeline_cljs_test.cljs
@@ -28,6 +28,7 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.schema-violation-timeline :as panel]
             [day8.re-frame2-causa.panels.schema-violation-timeline-helpers :as h]))
@@ -35,8 +36,7 @@
 ;; ---- fixture ------------------------------------------------------------
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!))
 
 (use-fixtures :each

--- a/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_view_cljs_test.cljs
@@ -33,14 +33,14 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.subscriptions :as subscriptions]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!))
 
 (use-fixtures :each

--- a/tools/causa/test/day8/re_frame2_causa/panels/time_travel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/time_travel_cljs_test.cljs
@@ -35,6 +35,7 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.time-travel :as time-travel]
             [day8.re-frame2-causa.panels.time-travel-helpers :as h]))
@@ -42,8 +43,7 @@
 ;; ---- fixture ------------------------------------------------------------
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!))
 
 (use-fixtures :each

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
@@ -48,14 +48,14 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.trace :as trace]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!))
 
 (use-fixtures :each

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -152,9 +152,17 @@
    :rf.causa/trace-filters])
 
 (def ^:private all-event-names
-  [:rf.causa/clear-flow-selection
+  ;; Issues-ribbon panel-internal events (rf2-nmc1f) — nested under
+  ;; `:rf.causa.issues/*` so the namespace itself encodes
+  ;; "panel-internal, no cross-panel callers". Per the
+  ;; `:rf.causa.<panel>/*` convention codified in
+  ;; `tools/causa/spec/014-Registry-Catalogue.md` §Naming convention.
+  [:rf.causa.issues/clear-filters
+   :rf.causa.issues/set-since-seconds
+   :rf.causa.issues/toggle-prefix
+   :rf.causa.issues/toggle-severity
+   :rf.causa/clear-flow-selection
    :rf.causa/clear-fx-selection
-   :rf.causa/clear-issues-filters
    :rf.causa/clear-machine-selection
    :rf.causa/clear-mcp-filters
    :rf.causa/clear-mismatch-selection
@@ -194,7 +202,6 @@
    :rf.causa/select-sub
    :rf.causa/select-violation
    :rf.causa/set-active-route-slice-override-for-test
-   :rf.causa/set-issues-since-seconds
    :rf.causa/set-machine-snapshots-override-for-test
    :rf.causa/set-mcp-since-seconds
    :rf.causa/set-performance-budget-ms
@@ -209,8 +216,6 @@
    :rf.causa/set-trace-filter
    :rf.causa/show-invalidation-chain
    :rf.causa/sync-trace-buffer
-   :rf.causa/toggle-issues-prefix
-   :rf.causa/toggle-issues-severity
    :rf.causa/toggle-mcp-op-type
    :rf.causa/toggle-mcp-origin-filter
    :rf.causa/toggle-sub-filter
@@ -720,42 +725,42 @@
       (is (nil? @(rf/subscribe [:rf.causa/selected-epoch-id]))))))
 
 (deftest event-toggle-issues-severity-roundtrip
-  (testing ":rf.causa/toggle-issues-severity adds + removes a chip"
+  (testing ":rf.causa.issues/toggle-severity adds + removes a chip"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :error])
+      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :error])
       (is (= #{:error} (:severities @(rf/subscribe [:rf.causa/issues-filters]))))
-      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :warning])
+      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :warning])
       (is (= #{:error :warning}
              (:severities @(rf/subscribe [:rf.causa/issues-filters]))))
-      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :error])
+      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :error])
       (is (= #{:warning}
              (:severities @(rf/subscribe [:rf.causa/issues-filters])))))))
 
 (deftest event-clear-issues-filters
-  (testing ":rf.causa/clear-issues-filters drops all three axes"
+  (testing ":rf.causa.issues/clear-filters drops all three axes"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/toggle-issues-severity :error])
-      (rf/dispatch-sync [:rf.causa/toggle-issues-prefix "rf.error"])
-      (rf/dispatch-sync [:rf.causa/set-issues-since-seconds 60])
-      (rf/dispatch-sync [:rf.causa/clear-issues-filters])
+      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :error])
+      (rf/dispatch-sync [:rf.causa.issues/toggle-prefix "rf.error"])
+      (rf/dispatch-sync [:rf.causa.issues/set-since-seconds 60])
+      (rf/dispatch-sync [:rf.causa.issues/clear-filters])
       (let [f @(rf/subscribe [:rf.causa/issues-filters])]
         (is (= #{} (:severities f)))
         (is (= #{} (:prefixes f)))
         (is (nil? (:since-ms f)))))))
 
 (deftest event-set-issues-since-seconds-normalises
-  (testing ":rf.causa/set-issues-since-seconds — positive sets ms; nil clears"
+  (testing ":rf.causa.issues/set-since-seconds — positive sets ms; nil clears"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/set-issues-since-seconds 30])
+      (rf/dispatch-sync [:rf.causa.issues/set-since-seconds 30])
       (is (= 30000 (:since-ms @(rf/subscribe [:rf.causa/issues-filters]))))
       ;; non-positive clears
-      (rf/dispatch-sync [:rf.causa/set-issues-since-seconds 0])
+      (rf/dispatch-sync [:rf.causa.issues/set-since-seconds 0])
       (is (nil? (:since-ms @(rf/subscribe [:rf.causa/issues-filters]))))
-      (rf/dispatch-sync [:rf.causa/set-issues-since-seconds 15])
-      (rf/dispatch-sync [:rf.causa/set-issues-since-seconds nil])
+      (rf/dispatch-sync [:rf.causa.issues/set-since-seconds 15])
+      (rf/dispatch-sync [:rf.causa.issues/set-since-seconds nil])
       (is (nil? (:since-ms @(rf/subscribe [:rf.causa/issues-filters])))))))
 
 (deftest event-set-trace-filter-axis-and-clear

--- a/tools/causa/test/day8/re_frame2_causa/sensitive_trace_loop_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/sensitive_trace_loop_cljs_test.cljs
@@ -65,6 +65,7 @@
             [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
 ;; ---- fixtures -----------------------------------------------------------
@@ -77,8 +78,7 @@
 ;; flag so each test starts from the baseline.
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (registry/register-causa-handlers!)
   ;; Allocate the :rf/causa frame so `note-suppressed!`'s dispatch
   ;; guard passes. Without the frame, `note-suppressed!` skips the

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -47,6 +47,7 @@
             [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.shell :as shell]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.ai-co-pilot :as ai-co-pilot]
@@ -69,8 +70,7 @@
 ;; ---- fixture ------------------------------------------------------------
 
 (defn- causa-init! []
-  (preload/reset-for-test!)
-  (registry/reset-for-test!)
+  (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!)
   (config/reset-suppressed-count!))
 


### PR DESCRIPTION
## Summary

Two-bead mini-cluster — both deferred follow-ons from the rf2-kmhvg / rf2-i0veg causa-cluster work (#1184). Single PR, two sequenced commits.

### rf2-nmc1f — issues-ribbon events nested under `:rf.causa.issues/*`

Demonstrative slice of the nested-namespace convention. Renames the four panel-internal issues-ribbon events so the namespace itself encodes "panel-internal":

  - `:rf.causa/toggle-issues-severity`   -> `:rf.causa.issues/toggle-severity`
  - `:rf.causa/toggle-issues-prefix`     -> `:rf.causa.issues/toggle-prefix`
  - `:rf.causa/set-issues-since-seconds` -> `:rf.causa.issues/set-since-seconds`
  - `:rf.causa/clear-issues-filters`     -> `:rf.causa.issues/clear-filters`

Codifies the `:rf.causa.<panel>/*` convention in `tools/causa/spec/014-Registry-Catalogue.md` Naming-convention table alongside the existing `:rf.causa.fx/*` carve-out. The audit notes the broader cleanup across all 17 panels exceeds a single P3 budget; the catalogue update lets future panel work adopt the convention as its event surface stabilises.

Touches: panel reg-event sites + dispatch sites + view test + registry catalogue test (all-event-names roster) + spec table — 4 files.

### rf2-tanmj — fixture migration to `test-support/reset-all!`

Folds the per-test reset pair into the single combined call:

```clojure
;; before
(defn- causa-init! []
  (preload/reset-for-test!)
  (registry/reset-for-test!)
  (trace-bus/clear-buffer!))

;; after
(defn- causa-init! []
  (causa-test-support/reset-all!)
  (trace-bus/clear-buffer!))
```

Across 21 fixture-using test files. Skips `preload_cljs_test.cljs` and `registry_cljs_test.cljs` (those test the very ns-es). Aliased as `causa-test-support` to avoid collision with the existing `re-frame.test-support` (`test-support`) already in scope for `reset-runtime-fixture`.

Pre-alpha — no back-compat shims in either commit.

## Test plan

- [x] `clojure -M:test` in `tools/causa/`: 518 tests / 1482 assertions, 0 failures (baseline + post-cluster identical)
- [x] `npm run test:cljs` in `implementation/`: 2048 tests / 5819 assertions, 0 failures (no regression in re-frame2 core)