### PR TITLE
test(playwright): quiet green browser output

### DIFF
--- a/docs/quiet-tests.md
+++ b/docs/quiet-tests.md
@@ -73,3 +73,16 @@ This prevents future `println` creep from re-polluting the output.
 ## Like JVM flags
 
 Treat verbose output the way JVM flags treat verbose GC: it's something you opt into when you're debugging, not the default for every run.
+
+## Opting Into Verbose Browser Diagnostics
+
+Browser / Playwright harnesses follow the same rule. A green run prints
+only a compact summary by default; browser console lines, navigation
+details, and page errors are buffered and emitted on failure.
+
+For local debugging, opt into the buffered green-path diagnostics:
+
+```bash
+RF2_VERBOSE_TESTS=1 npm run test:browser
+RF2_VERBOSE_TESTS=1 npm run test:examples
+```

--- a/implementation/scripts/_browser-test-report.test.cjs
+++ b/implementation/scripts/_browser-test-report.test.cjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+const assert = require('assert/strict');
+const {
+  createDiagnosticBuffer,
+  formatCompactSummary,
+  isVerboseTests,
+  parseFailureCounts,
+  summaryPartsFromText,
+} = require('./lib/browser-test-report.cjs');
+
+const tests = [];
+
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+test('summary parser extracts cljs.test counts from noisy text', () => {
+  const parts = summaryPartsFromText([
+    '[browser:log] booted',
+    'Ran 12 tests containing 34 assertions.',
+    '0 failures, 0 errors.',
+  ].join('\n'));
+
+  assert.deepEqual(parts, {
+    ran: 'Ran 12 tests containing 34 assertions.',
+    failErr: '0 failures, 0 errors.',
+  });
+});
+
+test('failure count parser returns numeric counts', () => {
+  assert.deepEqual(parseFailureCounts('2 failures, 1 errors.'), {
+    failures: 2,
+    errors: 1,
+  });
+});
+
+test('green browser summary is one line', () => {
+  const line = formatCompactSummary({
+    ran: 'Ran 12 tests containing 34 assertions.',
+    failErr: '0 failures, 0 errors.',
+    source: 'browser console',
+  });
+
+  assert.equal(line.split(/\r?\n/).length, 1);
+  assert.equal(
+    line,
+    'Browser tests: Ran 12 tests containing 34 assertions. 0 failures, 0 errors. (source: browser console)'
+  );
+});
+
+test('diagnostic buffer preserves output streams until flush', () => {
+  const buffer = createDiagnosticBuffer();
+  buffer.add('[browser:log] hello');
+  buffer.add('page exploded\nstack line', 'stderr');
+
+  const stdout = [];
+  const stderr = [];
+  buffer.flush({
+    stdout: (line) => stdout.push(line),
+    stderr: (line) => stderr.push(line),
+  });
+
+  assert.deepEqual(stdout, ['[browser:log] hello']);
+  assert.deepEqual(stderr, ['page exploded', 'stack line']);
+});
+
+test('RF2_VERBOSE_TESTS=1 enables verbose mode', () => {
+  assert.equal(isVerboseTests({ RF2_VERBOSE_TESTS: '1' }), true);
+  assert.equal(isVerboseTests({ RF2_VERBOSE_TESTS: 'true' }), false);
+  assert.equal(isVerboseTests({}), false);
+});
+
+let failed = 0;
+for (const { name, fn } of tests) {
+  try {
+    fn();
+  } catch (err) {
+    failed += 1;
+    console.error(`FAIL ${name}`);
+    console.error(err && err.stack ? err.stack : err);
+  }
+}
+
+if (failed > 0) {
+  console.error(`browser-test-report tests: ${failed} failed.`);
+  process.exit(1);
+}
+
+console.log(`browser-test-report tests: ${tests.length} passed.`);

--- a/implementation/scripts/lib/browser-test-report.cjs
+++ b/implementation/scripts/lib/browser-test-report.cjs
@@ -1,0 +1,64 @@
+const RAN_RE = /Ran\s+(\d+)\s+tests?\s+containing\s+(\d+)\s+assertions?\./;
+const FAIL_RE = /(\d+)\s+failures?,\s*(\d+)\s+errors?\.?/;
+
+function isVerboseTests(env = process.env) {
+  return env.RF2_VERBOSE_TESTS === '1';
+}
+
+function summaryPartsFromText(text) {
+  const value = text == null ? '' : String(text);
+  const ran = value.match(RAN_RE);
+  const failErr = value.match(FAIL_RE);
+  return {
+    ran: ran ? ran[0] : null,
+    failErr: failErr ? failErr[0] : null,
+  };
+}
+
+function parseFailureCounts(failErr) {
+  const match = failErr && String(failErr).match(FAIL_RE);
+  if (!match) return null;
+  return {
+    failures: parseInt(match[1], 10),
+    errors: parseInt(match[2], 10),
+  };
+}
+
+function formatCompactSummary({ label = 'Browser tests', ran, failErr, source }) {
+  const sourceSuffix = source ? ` (source: ${source})` : '';
+  return `${label}: ${ran} ${failErr}${sourceSuffix}`;
+}
+
+function createDiagnosticBuffer() {
+  const entries = [];
+
+  const add = (line, stream = 'stdout') => {
+    if (line == null) return;
+    const normalized = String(line).replace(/\r\n/g, '\n');
+    for (const part of normalized.split('\n')) {
+      entries.push({ stream, text: part });
+    }
+  };
+
+  return {
+    add,
+    entries: () => entries.slice(),
+    isEmpty: () => entries.length === 0,
+    flush: ({ stdout = console.log, stderr = console.error } = {}) => {
+      for (const entry of entries) {
+        if (entry.stream === 'stderr') stderr(entry.text);
+        else stdout(entry.text);
+      }
+    },
+  };
+}
+
+module.exports = {
+  RAN_RE,
+  FAIL_RE,
+  isVerboseTests,
+  summaryPartsFromText,
+  parseFailureCounts,
+  formatCompactSummary,
+  createDiagnosticBuffer,
+};

--- a/implementation/scripts/run-browser-tests.cjs
+++ b/implementation/scripts/run-browser-tests.cjs
@@ -22,97 +22,170 @@
  */
 
 const { chromium } = require('playwright');
+const {
+  createDiagnosticBuffer,
+  formatCompactSummary,
+  isVerboseTests,
+  parseFailureCounts,
+  summaryPartsFromText,
+} = require('./lib/browser-test-report.cjs');
 
 const URL = process.env.BROWSER_TEST_URL || 'http://localhost:8021';
 const TIMEOUT_MS = parseInt(process.env.BROWSER_TEST_TIMEOUT_MS || '120000', 10);
 const POLL_MS = 200;
+const VERBOSE_TESTS = isVerboseTests();
 
-const RAN_RE = /Ran\s+(\d+)\s+tests?\s+containing\s+(\d+)\s+assertions?\./;
-const FAIL_RE = /(\d+)\s+failures?,\s*(\d+)\s+errors?\.?/;
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
-(async () => {
-  const browser = await chromium.launch({ headless: true });
-  const context = await browser.newContext();
-  const page = await context.newPage();
+function rememberSummary(summary, hit, sourceName) {
+  if (hit.ran && !summary.ran) {
+    summary.ran = hit.ran;
+    summary.ranSource = sourceName;
+  }
+  if (hit.failErr && !summary.failErr) {
+    summary.failErr = hit.failErr;
+    summary.failErrSource = sourceName;
+  }
+  if (summary.ran && summary.failErr) {
+    summary.source = summary.ranSource === summary.failErrSource
+      ? summary.ranSource
+      : `${summary.ranSource}; ${summary.failErrSource}`;
+    return true;
+  }
+  return false;
+}
 
-  // Capture every console line so we can scan for the cljs.test summary.
-  const consoleLines = [];
-  page.on('console', (msg) => {
-    const text = msg.text();
-    consoleLines.push(text);
-    console.log(`[browser:${msg.type()}] ${text}`);
+function printSummaryDetails(summary) {
+  console.error('--- cljs.test summary ---');
+  console.error(`(source: ${summary.source || 'not found'})`);
+  console.error(summary.ran || '(missing "Ran ... assertions." line)');
+  console.error(summary.failErr || '(missing "failures, errors" line)');
+  console.error('-------------------------');
+}
+
+function flushDiagnostics(diagnostics) {
+  if (diagnostics.isEmpty()) return;
+  console.error('--- browser test diagnostics ---');
+  diagnostics.flush({
+    stdout: (line) => console.error(line),
+    stderr: (line) => console.error(line),
   });
-  page.on('pageerror', (err) => {
-    console.error(`[browser:pageerror] ${err.message}`);
-  });
+  console.error('--------------------------------');
+}
 
-  console.log(`Navigating to ${URL} ...`);
-  await page.goto(URL, { waitUntil: 'load' });
+async function main() {
+  const diagnostics = createDiagnosticBuffer();
+  let browser = null;
 
-  // Look for the cljs.test summary in one of three places, in order of preference:
-  //   1. window.shadow$cljs_test_done   (custom hook a future runner may set)
-  //   2. console output                 (the default place shadow.test.browser logs)
-  //   3. document.body.innerText        (custom DOM reporter, if any)
-  const start = Date.now();
-  let ran = null;
-  let failErr = null;
-  let source = null;
+  try {
+    browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext();
+    const page = await context.newPage();
 
-  const findInText = (text) => {
-    const r = text && text.match(RAN_RE);
-    const f = text && text.match(FAIL_RE);
-    return r && f ? { ran: r[0], failErr: f[0] } : null;
-  };
-
-  while (Date.now() - start < TIMEOUT_MS) {
-    // 1. window flag
-    const winPayload = await page.evaluate(() => {
-      return (typeof window !== 'undefined' && window.shadow$cljs_test_done) || null;
+    // Capture every console line so we can scan for the cljs.test summary.
+    // Flush the buffer only on failure or RF2_VERBOSE_TESTS=1.
+    const consoleLines = [];
+    diagnostics.add(`URL: ${URL}`);
+    page.on('console', (msg) => {
+      const text = msg.text();
+      consoleLines.push(text);
+      diagnostics.add(`[browser:${msg.type()}] ${text}`);
     });
-    if (winPayload) {
-      const hit = findInText(typeof winPayload === 'string' ? winPayload : JSON.stringify(winPayload));
-      if (hit) { ran = hit.ran; failErr = hit.failErr; source = 'window.shadow$cljs_test_done'; break; }
+    page.on('pageerror', (err) => {
+      diagnostics.add(`[browser:pageerror] ${err.message}`, 'stderr');
+      if (err.stack) diagnostics.add(err.stack, 'stderr');
+    });
+    page.on('framenavigated', (frame) => {
+      if (frame === page.mainFrame()) {
+        diagnostics.add(`[browser:navigation] ${frame.url()}`);
+      }
+    });
+
+    diagnostics.add(`Navigating to ${URL} ...`);
+    await page.goto(URL, { waitUntil: 'load' });
+
+    // Look for the cljs.test summary in one of three places, in order of preference:
+    //   1. window.shadow$cljs_test_done   (custom hook a future runner may set)
+    //   2. console output                 (the default place shadow.test.browser logs)
+    //   3. document.body.innerText        (custom DOM reporter, if any)
+    const start = Date.now();
+    const summary = {
+      ran: null,
+      failErr: null,
+      source: null,
+      ranSource: null,
+      failErrSource: null,
+    };
+
+    while (Date.now() - start < TIMEOUT_MS) {
+      // 1. window flag
+      const winPayload = await page.evaluate(() => {
+        return (typeof window !== 'undefined' && window.shadow$cljs_test_done) || null;
+      });
+      if (winPayload) {
+        const text = typeof winPayload === 'string' ? winPayload : JSON.stringify(winPayload);
+        if (rememberSummary(summary, summaryPartsFromText(text), 'window.shadow$cljs_test_done')) {
+          break;
+        }
+      }
+
+      // 2. console buffer
+      const consoleBlob = consoleLines.join('\n');
+      if (rememberSummary(summary, summaryPartsFromText(consoleBlob), 'browser console')) {
+        break;
+      }
+
+      // 3. DOM body
+      const bodyText = await page.evaluate(() => (document.body ? document.body.innerText : ''));
+      if (rememberSummary(summary, summaryPartsFromText(bodyText), 'document.body')) {
+        break;
+      }
+
+      await sleep(POLL_MS);
     }
 
-    // 2. console buffer
-    const consoleBlob = consoleLines.join('\n');
-    const hit = findInText(consoleBlob);
-    if (hit) { ran = hit.ran; failErr = hit.failErr; source = 'browser console'; break; }
+    if (!summary.ran || !summary.failErr) {
+      console.error(`Timed out after ${TIMEOUT_MS}ms waiting for cljs.test summary.`);
+      printSummaryDetails(summary);
+      flushDiagnostics(diagnostics);
+      return 1;
+    }
 
-    // 3. DOM body
-    const bodyText = await page.evaluate(() => (document.body ? document.body.innerText : ''));
-    const hit3 = findInText(bodyText);
-    if (hit3) { ran = hit3.ran; failErr = hit3.failErr; source = 'document.body'; break; }
+    const counts = parseFailureCounts(summary.failErr);
+    if (!counts) {
+      console.error('Could not parse failures/errors counts; failing the run.');
+      printSummaryDetails(summary);
+      flushDiagnostics(diagnostics);
+      return 1;
+    }
 
-    await new Promise((r) => setTimeout(r, POLL_MS));
+    if (counts.failures > 0 || counts.errors > 0) {
+      printSummaryDetails(summary);
+      flushDiagnostics(diagnostics);
+      return 1;
+    }
+
+    console.log(formatCompactSummary({
+      ran: summary.ran,
+      failErr: summary.failErr,
+      source: summary.source,
+    }));
+    if (VERBOSE_TESTS) flushDiagnostics(diagnostics);
+    return 0;
+  } catch (err) {
+    console.error(err && err.stack ? err.stack : err);
+    flushDiagnostics(diagnostics);
+    return 1;
+  } finally {
+    if (browser) await browser.close();
   }
+}
 
-  if (!ran || !failErr) {
-    console.error(`Timed out after ${TIMEOUT_MS}ms waiting for cljs.test summary.`);
-    await browser.close();
+main()
+  .then((exitCode) => process.exit(exitCode))
+  .catch((err) => {
+    console.error(err && err.stack ? err.stack : err);
     process.exit(1);
-  }
-
-  console.log('--- cljs.test summary ---');
-  console.log(`(source: ${source})`);
-  console.log(ran);
-  console.log(failErr);
-  console.log('-------------------------');
-
-  const fm = failErr.match(FAIL_RE);
-  let exitCode = 0;
-  if (fm) {
-    const failures = parseInt(fm[1], 10);
-    const errors = parseInt(fm[2], 10);
-    if (failures > 0 || errors > 0) exitCode = 1;
-  } else {
-    console.error('Could not parse failures/errors counts; failing the run.');
-    exitCode = 1;
-  }
-
-  await browser.close();
-  process.exit(exitCode);
-})().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+  });

--- a/tools/causa/testbeds/perf_counter/spec.cjs
+++ b/tools/causa/testbeds/perf_counter/spec.cjs
@@ -20,6 +20,26 @@
  */
 
 const { expectTextEquals } = require('../../../../examples/scripts/spec-helpers.cjs');
+const VERBOSE_TESTS = process.env.RF2_VERBOSE_TESTS === '1';
+
+function userTimingDiagnostics(buckets) {
+  return [
+    '  perf-on counter - User Timing entries:',
+    `    rf:event   count=${buckets.counts.event}   sample=${buckets.samples.event}`,
+    `    rf:sub     count=${buckets.counts.sub}     sample=${buckets.samples.sub}`,
+    `    rf:fx      count=${buckets.counts.fx}      sample=${buckets.samples.fx}`,
+    `    rf:render  count=${buckets.counts.render}  sample=${buckets.samples.render}`,
+  ].join('\n');
+}
+
+function expectTimingBucket(buckets, bucket) {
+  if (buckets.counts[bucket] === 0) {
+    throw new Error(
+      `Expected at least one rf:${bucket}:* measure entry; got 0.\n` +
+        userTimingDiagnostics(buckets)
+    );
+  }
+}
 
 module.exports = {
   name: 'counter-perf',
@@ -71,23 +91,13 @@ module.exports = {
       };
     });
 
-    console.log('  perf-on counter — User Timing entries:');
-    console.log(`    rf:event   count=${buckets.counts.event}   sample=${buckets.samples.event}`);
-    console.log(`    rf:sub     count=${buckets.counts.sub}     sample=${buckets.samples.sub}`);
-    console.log(`    rf:fx      count=${buckets.counts.fx}      sample=${buckets.samples.fx}`);
-    console.log(`    rf:render  count=${buckets.counts.render}  sample=${buckets.samples.render}`);
+    if (VERBOSE_TESTS) {
+      console.log(userTimingDiagnostics(buckets));
+    }
 
-    if (buckets.counts.event === 0) {
-      throw new Error('Expected at least one rf:event:* measure entry; got 0.');
-    }
-    if (buckets.counts.sub === 0) {
-      throw new Error('Expected at least one rf:sub:* measure entry; got 0.');
-    }
-    if (buckets.counts.fx === 0) {
-      throw new Error('Expected at least one rf:fx:* measure entry; got 0.');
-    }
-    if (buckets.counts.render === 0) {
-      throw new Error('Expected at least one rf:render:* measure entry; got 0.');
-    }
+    expectTimingBucket(buckets, 'event');
+    expectTimingBucket(buckets, 'sub');
+    expectTimingBucket(buckets, 'fx');
+    expectTimingBucket(buckets, 'render');
   },
 };


### PR DESCRIPTION
## Summary

- Buffer `run-browser-tests.cjs` browser console, navigation, and pageerror diagnostics instead of streaming them on green runs.
- Print a compact green summary by default, with `RF2_VERBOSE_TESTS=1` to opt into buffered diagnostics during local debugging.
- Preserve actionable failure output: failures flush the summary source/counts plus the buffered URL, navigation, browser console, and pageerror diagnostics.
- Quiet the perf counter Playwright spec's success-only timing table while including the same bucket details in assertion failures.
- Document the verbose browser diagnostics knob in `docs/quiet-tests.md`.

## Failure-output invariant

This PR only silences success output. Red runs remain diagnostic-first: the runner flushes the buffered browser context on timeout, parse failure, non-zero cljs.test failures/errors, page errors, or thrown exceptions.

## Test plan

- [x] `node implementation/scripts/_browser-test-report.test.cjs`
- [x] `node --check implementation/scripts/run-browser-tests.cjs`
- [x] `node --check implementation/scripts/lib/browser-test-report.cjs`
- [x] `node --check implementation/scripts/_browser-test-report.test.cjs`
- [x] `node --check tools/causa/testbeds/perf_counter/spec.cjs`
- [x] Synthetic green browser run with `BROWSER_TEST_URL=data:...` verifies one-line output and suppressed browser console noise.
- [x] Synthetic failing browser run with `BROWSER_TEST_URL=data:...` verifies non-zero failure path flushes buffered diagnostics.

Full shadow-cljs/browser Playwright suites are intentionally left to CI because local runs are expensive.