### PR TITLE
test(ci): quiet green JS gate scripts

### DIFF
--- a/docs/quiet-tests.md
+++ b/docs/quiet-tests.md
@@ -86,3 +86,20 @@ For local debugging, opt into the buffered green-path diagnostics:
 RF2_VERBOSE_TESTS=1 npm run test:browser
 RF2_VERBOSE_TESTS=1 npm run test:examples
 ```
+
+## Opting Into Verbose JS Gate Diagnostics
+
+Bundle / elision gate scripts follow the same contract. A green run
+prints one compact `PASS <gate>:` line by default. Sentinel tables,
+threshold details, bundle-grep counts, and remediation text are
+buffered and emitted on failure.
+
+For local investigation, opt into the green-path tables:
+
+```bash
+RF2_VERBOSE_TESTS=1 npm run test:elision
+RF2_VERBOSE_TESTS=1 npm run test:bundle-isolation
+RF2_VERBOSE_TESTS=1 npm run test:bundle-comparison
+RF2_VERBOSE_TESTS=1 npm run test:schemas-bundle
+RF2_VERBOSE_TESTS=1 npm run test:perf-bundle
+```

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -26,6 +26,7 @@
     "test:examples": "node ../examples/scripts/serve-and-run-examples-tests.cjs",
     "story:build": "node scripts/story-build.cjs",
     "test:story-static": "node scripts/check-story-static.cjs",
-    "test:script-policy": "node scripts/_path-policy.test.cjs"
+    "test:script-policy": "node scripts/_path-policy.test.cjs",
+    "test:script-helpers": "node scripts/_browser-test-report.test.cjs && node scripts/_gate-report.test.cjs"
   }
 }

--- a/implementation/scripts/_gate-report.test.cjs
+++ b/implementation/scripts/_gate-report.test.cjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('assert/strict');
+const {
+  createGateReporter,
+  isVerboseTests,
+} = require('./lib/gate-report.cjs');
+
+const tests = [];
+
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+test('green details are buffered while PASS stays one line', () => {
+  const stdout = [];
+  const stderr = [];
+  const report = createGateReporter({
+    env: {},
+    stdout: (line) => stdout.push(line),
+    stderr: (line) => stderr.push(line),
+  });
+
+  report.detail('sentinel table line 1\nsentinel table line 2');
+  report.pass('demo-gate', '2 sentinels checked; bundle=out/demo');
+
+  assert.deepEqual(stdout, [
+    'PASS demo-gate: 2 sentinels checked; bundle=out/demo',
+  ]);
+  assert.deepEqual(stderr, []);
+  assert.equal(report.bufferedLineCount(), 2);
+});
+
+test('failure flush emits buffered diagnostics to stderr', () => {
+  const stderr = [];
+  const report = createGateReporter({
+    env: {},
+    stdout: () => {},
+    stderr: (line) => stderr.push(line),
+  });
+
+  report.detail('[FAIL] sentinel expected ABSENT, was PRESENT');
+  report.flushDetails();
+
+  assert.deepEqual(stderr, ['[FAIL] sentinel expected ABSENT, was PRESENT']);
+  assert.equal(report.bufferedLineCount(), 0);
+});
+
+test('RF2_VERBOSE_TESTS=1 streams details immediately', () => {
+  const stdout = [];
+  const stderr = [];
+  const report = createGateReporter({
+    env: { RF2_VERBOSE_TESTS: '1' },
+    stdout: (line) => stdout.push(line),
+    stderr: (line) => stderr.push(line),
+  });
+
+  report.detail('verbose table line');
+  report.flushDetails();
+  report.pass('demo-gate', 'ok');
+
+  assert.deepEqual(stdout, ['verbose table line', 'PASS demo-gate: ok']);
+  assert.deepEqual(stderr, []);
+  assert.equal(report.bufferedLineCount(), 0);
+});
+
+test('verbose env parser is shared with browser tests', () => {
+  assert.equal(isVerboseTests({ RF2_VERBOSE_TESTS: '1' }), true);
+  assert.equal(isVerboseTests({ RF2_VERBOSE_TESTS: 'true' }), false);
+  assert.equal(isVerboseTests({}), false);
+});
+
+let failed = 0;
+for (const { name, fn } of tests) {
+  try {
+    fn();
+  } catch (err) {
+    failed += 1;
+    console.error(`FAIL ${name}`);
+    console.error(err && err.stack ? err.stack : err);
+  }
+}
+
+if (failed > 0) {
+  console.error(`gate-report tests: ${failed} failed.`);
+  process.exit(1);
+}
+
+console.log(`gate-report tests: ${tests.length} passed.`);

--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -43,9 +43,11 @@
 'use strict';
 
 const path = require('path');
+const { createGateReporter } = require('./lib/gate-report.cjs');
 const { readReleaseBlob } = require('./lib/read-release-bundle.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
+const report = createGateReporter();
 
 // ----- the bundle-isolation contract ----------------------------------------
 
@@ -313,64 +315,87 @@ function countPattern(blob, re) {
 }
 
 function checkArtefact(blob, art) {
-  console.log(`  ${art.name}:`);
+  report.detail(`  ${art.name}:`);
 
   let internalOk = true;
+  let internalFailures = 0;
   for (const { source, sentinel } of art.internalSentinels) {
     const hits = countSubstring(blob, sentinel);
     const ok   = hits === 0;
     const tag  = ok ? 'OK' : 'FAIL';
-    console.log(`    [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} ` +
-                `expected 0, was ${hits}`);
-    if (!ok) internalOk = false;
+    report.detail(`    [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} ` +
+                  `expected 0, was ${hits}`);
+    if (!ok) {
+      internalOk = false;
+      internalFailures += 1;
+    }
   }
 
   let allowListOk = true;
   let allowListHits = 0;
+  const allowListChecked = art.consumerAllowList ? 1 : 0;
   if (art.consumerAllowList) {
     allowListHits = countPattern(blob, art.consumerAllowList);
     allowListOk   = allowListHits <= art.expectedAllowListHits;
     const tag     = allowListOk ? 'OK' : 'FAIL';
-    console.log(`    [${tag}] consumer allow-list ${art.consumerAllowList}: ` +
-                `${allowListHits} hit(s), expected <= ${art.expectedAllowListHits}`);
+    report.detail(`    [${tag}] consumer allow-list ${art.consumerAllowList}: ` +
+                  `${allowListHits} hit(s), expected <= ${art.expectedAllowListHits}`);
   }
 
-  return { ok: internalOk && allowListOk, internalOk, allowListOk, allowListHits };
+  return {
+    ok: internalOk && allowListOk,
+    internalOk,
+    allowListOk,
+    allowListHits,
+    internalChecked: art.internalSentinels.length,
+    internalFailures,
+    allowListChecked,
+  };
 }
 
 // ----- main ------------------------------------------------------------------
 
 function main() {
-  console.log('=== Bundle isolation: counter example (rf2-51x5) ===');
+  report.detail('=== Bundle isolation: counter example (rf2-51x5) ===');
 
   const bundleDir = path.join(ROOT, 'out', 'examples', 'counter');
   const blob = readReleaseBlob(bundleDir);
 
   if (blob == null) {
+    report.flushDetails();
     console.error(`[bundle-isolation] bundle path missing — ${bundleDir}`);
     console.error('                   Did you run "shadow-cljs release examples/counter"?');
     process.exit(1);
   }
 
-  console.log(`bundle: ${bundleDir}`);
-  console.log(`bundle size: ${blob.length} chars`);
-  console.log('');
+  report.detail(`bundle: ${bundleDir}`);
+  report.detail(`bundle size: ${blob.length} chars`);
+  report.detail('');
 
   let allOk = true;
   const failures = [];
+  let internalChecked = 0;
+  let allowListChecked = 0;
   for (const art of ARTEFACTS) {
     const res = checkArtefact(blob, art);
+    internalChecked += res.internalChecked;
+    allowListChecked += res.allowListChecked;
     if (!res.ok) {
       allOk = false;
       failures.push({ name: art.name, ...res });
     }
   }
 
-  console.log('');
+  report.detail('');
   if (allOk) {
-    console.log('=== PASS ===');
+    report.pass(
+      'bundle-isolation',
+      `${ARTEFACTS.length} artefact entries; ${internalChecked} internal sentinels absent; ` +
+        `${allowListChecked} allow-list budgets ok; bundle=${bundleDir} (${blob.length} chars)`
+    );
     process.exit(0);
   } else {
+    report.flushDetails();
     console.error('=== FAIL ===');
     console.error('');
     console.error('At least one per-feature artefact (or tools/story) leaked');

--- a/implementation/scripts/check-counter-slim-and-fast.cjs
+++ b/implementation/scripts/check-counter-slim-and-fast.cjs
@@ -43,8 +43,10 @@
 
 const fs   = require('fs');
 const path = require('path');
+const { createGateReporter } = require('./lib/gate-report.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
+const report = createGateReporter();
 
 // ----- the bundle-comparison contract ---------------------------------------
 
@@ -164,15 +166,17 @@ function checkAbsent(blob, sentinels, blobLabel) {
   // Assert each sentinel's hit-count is 0. Used for the slim build's
   // "no stock-Reagent / no react-dom/server" assertion.
   let ok = true;
+  let passedCount = 0;
   for (const { source, sentinel } of sentinels) {
     const hits = countSubstring(blob, sentinel);
     const passed = hits === 0;
     const tag = passed ? 'OK' : 'FAIL';
-    console.log(`    [${tag}] ${source}: ` +
-                `${JSON.stringify(sentinel)} expected 0 in ${blobLabel}, was ${hits}`);
+    report.detail(`    [${tag}] ${source}: ` +
+                  `${JSON.stringify(sentinel)} expected 0 in ${blobLabel}, was ${hits}`);
+    if (passed) passedCount += 1;
     if (!passed) ok = false;
   }
-  return ok;
+  return { ok, checked: sentinels.length, passed: passedCount };
 }
 
 function checkPresent(blob, sentinels, blobLabel) {
@@ -182,22 +186,24 @@ function checkPresent(blob, sentinels, blobLabel) {
   // stock build too (e.g. a future Reagent rev DCEs it), we re-derive
   // the sentinel set; this script then prevents silent vacuous passes.
   let ok = true;
+  let passedCount = 0;
   for (const { source, sentinel } of sentinels) {
     const hits = countSubstring(blob, sentinel);
     const passed = hits >= 1;
     const tag = passed ? 'OK' : 'FAIL';
-    console.log(`    [${tag}] ${source}: ` +
-                `${JSON.stringify(sentinel)} expected >=1 in ${blobLabel}, was ${hits}`);
+    report.detail(`    [${tag}] ${source}: ` +
+                  `${JSON.stringify(sentinel)} expected >=1 in ${blobLabel}, was ${hits}`);
+    if (passed) passedCount += 1;
     if (!passed) ok = false;
   }
-  return ok;
+  return { ok, checked: sentinels.length, passed: passedCount };
 }
 
 // ----- main ------------------------------------------------------------------
 
 function main() {
-  console.log('=== Bundle comparison: counter-slim-and-fast (rf2-5lbx) ===');
-  console.log('');
+  report.detail('=== Bundle comparison: counter-slim-and-fast (rf2-5lbx) ===');
+  report.detail('');
 
   const slimDir  = path.join(ROOT, 'out', 'examples', 'counter-slim-and-fast');
   const stockDir = path.join(ROOT, 'out', 'examples', 'counter');
@@ -205,11 +211,13 @@ function main() {
   const stock = readAllJs(stockDir);
 
   if (slim == null) {
+    report.flushDetails();
     console.error(`[bundle-comparison] slim bundle missing — ${slimDir}`);
     console.error('                    Did you run "shadow-cljs release examples/counter-slim-and-fast"?');
     process.exit(1);
   }
   if (stock == null) {
+    report.flushDetails();
     console.error(`[bundle-comparison] stock bundle missing — ${stockDir}`);
     console.error('                    Did you run "shadow-cljs release examples/counter"?');
     console.error('                    The stock bundle is required as the methodology control:');
@@ -218,24 +226,24 @@ function main() {
     process.exit(1);
   }
 
-  console.log(`slim  bundle: ${slimDir}  (${slim.length} chars)`);
-  console.log(`stock bundle: ${stockDir} (${stock.length} chars)`);
-  console.log('');
+  report.detail(`slim  bundle: ${slimDir}  (${slim.length} chars)`);
+  report.detail(`stock bundle: ${stockDir} (${stock.length} chars)`);
+  report.detail('');
 
   // Contract 1: every stock-Reagent sentinel appears in the stock
   // bundle. Methodology sanity. If this fails the test has lost signal
   // — pick a fresh sentinel set from the new stock build.
-  console.log('Contract 1 (methodology): stock-Reagent sentinels are reachable from');
-  console.log('                          the stock-Reagent counter (must be PRESENT).');
+  report.detail('Contract 1 (methodology): stock-Reagent sentinels are reachable from');
+  report.detail('                          the stock-Reagent counter (must be PRESENT).');
   const c1 = checkPresent(stock, STOCK_REAGENT_SENTINELS, 'STOCK');
-  console.log('');
+  report.detail('');
 
   // Contract 2 (the binding S3-008 claim): NONE of the stock-Reagent
   // sentinels appears in the slim bundle.
-  console.log('Contract 2 (S3-008, stock-Reagent isolation): stock-Reagent impl is');
-  console.log('                          ABSENT from the slim bundle.');
+  report.detail('Contract 2 (S3-008, stock-Reagent isolation): stock-Reagent impl is');
+  report.detail('                          ABSENT from the slim bundle.');
   const c2 = checkAbsent(slim, STOCK_REAGENT_SENTINELS, 'SLIM');
-  console.log('');
+  report.detail('');
 
   // Contract 3 (the binding pure-CLJS-SSR claim): NONE of the
   // react-dom/server sentinels appears in the slim bundle. Note this
@@ -245,34 +253,40 @@ function main() {
   // (counter_slim_and_fast/core.cljs's `run`), so the SSR path IS in
   // the bundle. The assertion is: the SSR path is pure-CLJS, meaning
   // no react-dom/server symbols even with SSR pulled in.
-  console.log('Contract 3 (S3-005, pure-CLJS SSR): react-dom/server is ABSENT from');
-  console.log('                          the slim bundle (even with reagent2.dom.server');
-  console.log('                          exercised at boot).');
+  report.detail('Contract 3 (S3-005, pure-CLJS SSR): react-dom/server is ABSENT from');
+  report.detail('                          the slim bundle (even with reagent2.dom.server');
+  report.detail('                          exercised at boot).');
   const c3 = checkAbsent(slim, REACT_DOM_SERVER_SENTINELS, 'SLIM');
-  console.log('');
+  report.detail('');
 
-  const allOk = c1 && c2 && c3;
+  const allOk = c1.ok && c2.ok && c3.ok;
   if (allOk) {
-    console.log('=== PASS ===');
+    const checked = c1.checked + c2.checked + c3.checked;
+    report.pass(
+      'bundle-comparison',
+      `3 contracts passed; ${checked} sentinel checks; slim=${slimDir} (${slim.length} chars); ` +
+        `stock=${stockDir} (${stock.length} chars)`
+    );
     process.exit(0);
   } else {
+    report.flushDetails();
     console.error('=== FAIL ===');
     console.error('');
-    if (!c1) {
+    if (!c1.ok) {
       console.error('Contract 1 failed: the stock-Reagent sentinels did not appear in the');
       console.error('stock-Reagent counter bundle. The grep has lost signal — re-derive a');
       console.error('fresh sentinel set from the new stock-Reagent bundle (compare against');
       console.error('reagent.impl.{template,component,input} class-name strings, the');
       console.error('cljsRatom property key, etc.).');
     }
-    if (!c2) {
+    if (!c2.ok) {
       console.error('Contract 2 failed: stock-Reagent impl is leaking into the slim bundle.');
       console.error('The S3-008 framing is broken. Likely cause: a re-frame.* core ns is');
       console.error('`:require`ing stock `reagent.*` instead of routing through the slim');
       console.error('adapter\'s late-bind hooks. See implementation/adapters/reagent-slim/');
       console.error('IMPL-SPEC.md §1.4 + §1.8.');
     }
-    if (!c3) {
+    if (!c3.ok) {
       console.error('Contract 3 failed: react-dom/server is in the slim bundle. The');
       console.error('pure-CLJS SSR claim from IMPL-SPEC §8 + S3-005 is broken. Likely');
       console.error('cause: a `:require ["react-dom/server" ...]` slipped into a slim');

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -34,9 +34,11 @@
 
 const fs   = require('fs');
 const path = require('path');
+const { createGateReporter } = require('./lib/gate-report.cjs');
 const { readReleaseBlob } = require('./lib/read-release-bundle.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
+const report = createGateReporter();
 
 // ----- the elision contract --------------------------------------------------
 
@@ -244,58 +246,74 @@ function checkBundle(label, bundlePath, mustContain) {
   if (blob == null) {
     console.error(`[elision] ${label}: bundle path missing — ${bundlePath}`);
     console.error('         Did you run "shadow-cljs release elision-probe"?');
-    return false;
+    return { ok: false, checked: 0, passed: 0, bytes: null, missing: true };
   }
-  console.log(`[elision] ${label}: ${bundlePath}`);
-  console.log(`          bundle size: ${blob.length} chars`);
+  report.detail(`[elision] ${label}: ${bundlePath}`);
+  report.detail(`          bundle size: ${blob.length} chars`);
 
   let ok = true;
+  let passedCount = 0;
   for (const { source, sentinel } of DEV_ONLY_SENTINELS) {
     const present = blob.includes(sentinel);
     const expected = mustContain ? 'PRESENT' : 'ABSENT';
     const actual   = present     ? 'PRESENT' : 'ABSENT';
     const passed   = present === mustContain;
     const tag      = passed ? 'OK' : 'FAIL';
-    console.log(`          [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} expected ${expected}, was ${actual}`);
+    report.detail(`          [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} expected ${expected}, was ${actual}`);
+    if (passed) passedCount += 1;
     if (!passed) ok = false;
   }
-  return ok;
+  return {
+    ok,
+    checked: DEV_ONLY_SENTINELS.length,
+    passed: passedCount,
+    bytes: blob.length,
+    bundlePath,
+    missing: false,
+  };
 }
 
 // ----- main ------------------------------------------------------------------
 
 function main() {
-  console.log('=== Production elision probe (Spec 009 §Production builds) ===');
+  report.detail('=== Production elision probe (Spec 009 §Production builds) ===');
 
   const probeDir   = path.join(ROOT, 'out', 'elision-probe');
   const controlDir = path.join(ROOT, 'out', 'elision-probe-control');
 
   // Production bundle: sentinels MUST be absent.
-  const prodOk = checkBundle('production (goog.DEBUG=false)', probeDir, false);
+  const prod = checkBundle('production (goog.DEBUG=false)', probeDir, false);
 
   // Control bundle: sentinels MUST be present (if compiled).
-  let controlOk = true;
+  let control = { ok: true, skipped: true };
   if (fs.existsSync(controlDir)) {
-    controlOk = checkBundle('control    (goog.DEBUG=true) ', controlDir, true);
+    control = checkBundle('control    (goog.DEBUG=true) ', controlDir, true);
   } else {
-    console.log('[elision] control bundle not built — skipping methodology check.');
-    console.log('          Run "npx shadow-cljs release elision-probe-control"');
-    console.log('          to enable the methodology assertion.');
+    report.detail('[elision] control bundle not built — skipping methodology check.');
+    report.detail('          Run "npx shadow-cljs release elision-probe-control"');
+    report.detail('          to enable the methodology assertion.');
   }
 
-  if (prodOk && controlOk) {
-    console.log('=== PASS ===');
+  if (prod.ok && control.ok) {
+    const controlSummary = control.skipped
+      ? 'control skipped'
+      : `control ${control.passed}/${control.checked} present (${control.bytes} chars)`;
+    report.pass(
+      'elision',
+      `production ${prod.passed}/${prod.checked} absent (${prod.bytes} chars); ${controlSummary}; bundle=${probeDir}`
+    );
     process.exit(0);
   } else {
+    report.flushDetails();
     console.error('=== FAIL ===');
-    if (!prodOk) {
+    if (!prod.ok) {
       console.error('Production elision broke: at least one dev-only sentinel');
       console.error('survived advanced compilation with goog.DEBUG=false.');
       console.error('Per Spec 009 §Production builds, every emit / schema / ');
       console.error('registrar dev-only branch must be gated on');
       console.error('re-frame.interop/debug-enabled? so DCE removes it.');
     }
-    if (!controlOk) {
+    if (!control.ok) {
       console.error('Control bundle missing dev-only sentinels — the grep test');
       console.error('would be vacuous.  A sentinel string was likely renamed,');
       console.error('moved out of a gated branch, or removed.  Update');

--- a/implementation/scripts/check-perf-bundle.cjs
+++ b/implementation/scripts/check-perf-bundle.cjs
@@ -31,9 +31,11 @@
 'use strict';
 
 const path = require('path');
+const { createGateReporter } = require('./lib/gate-report.cjs');
 const { readReleaseBlob } = require('./lib/read-release-bundle.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
+const report = createGateReporter();
 
 // ----- the perf-flag elision contract ---------------------------------------
 
@@ -68,22 +70,31 @@ function checkBundle(label, bundlePath, mustContain) {
   if (blob == null) {
     console.error(`[perf-bundle] ${label}: bundle path missing — ${bundlePath}`);
     console.error('              Did you run the matching shadow-cljs release?');
-    return false;
+    return { ok: false, checked: 0, passed: 0, bytes: null, missing: true };
   }
-  console.log(`[perf-bundle] ${label}: ${bundlePath}`);
-  console.log(`              bundle size: ${blob.length} chars`);
+  report.detail(`[perf-bundle] ${label}: ${bundlePath}`);
+  report.detail(`              bundle size: ${blob.length} chars`);
 
   let ok = true;
+  let passedCount = 0;
   for (const { source, sentinel } of PERF_SENTINELS) {
     const present = blob.includes(sentinel);
     const expected = mustContain ? 'PRESENT' : 'ABSENT';
     const actual   = present     ? 'PRESENT' : 'ABSENT';
     const passed   = present === mustContain;
     const tag      = passed ? 'OK' : 'FAIL';
-    console.log(`              [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} expected ${expected}, was ${actual}`);
+    report.detail(`              [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} expected ${expected}, was ${actual}`);
+    if (passed) passedCount += 1;
     if (!passed) ok = false;
   }
-  return ok;
+  return {
+    ok,
+    checked: PERF_SENTINELS.length,
+    passed: passedCount,
+    bytes: blob.length,
+    bundlePath,
+    missing: false,
+  };
 }
 
 // Count `performance.mark|performance.measure|re-frame.performance` for
@@ -99,18 +110,18 @@ function countOccurrences(blob, patterns) {
 // ----- main ------------------------------------------------------------------
 
 function main() {
-  console.log('=== Performance-API bundle isolation / presence (Spec 009 §Performance instrumentation) ===');
+  report.detail('=== Performance-API bundle isolation / presence (Spec 009 §Performance instrumentation) ===');
 
   const offDir = path.join(ROOT, 'out', 'examples', 'counter');
   const onDir  = path.join(ROOT, 'out', 'examples', 'counter-perf');
 
   // OFF bundle: sentinels MUST be absent.
-  const offOk = checkBundle('perf-off (default counter, enabled?=false)',
-                            offDir, false);
+  const off = checkBundle('perf-off (default counter, enabled?=false)',
+                          offDir, false);
 
   // ON bundle: sentinels MUST be present.
-  const onOk  = checkBundle('perf-on  (counter-perf,  enabled?=true) ',
-                            onDir,  true);
+  const on  = checkBundle('perf-on  (counter-perf,  enabled?=true) ',
+                          onDir,  true);
 
   // Report the counts the bead asks for.
   const offBlob = readReleaseBlob(offDir);
@@ -120,26 +131,31 @@ function main() {
                     're-frame\\.performance'];
   const offCount = countOccurrences(offBlob, patterns);
   const onCount  = countOccurrences(onBlob,  patterns);
-  console.log('');
-  console.log('=== Bundle-grep counts ===');
-  console.log(`  perf-off counter (must be 0):     ${offCount}`);
-  console.log(`  perf-on  counter (must be > 0):   ${onCount}`);
+  report.detail('');
+  report.detail('=== Bundle-grep counts ===');
+  report.detail(`  perf-off counter (must be 0):     ${offCount}`);
+  report.detail(`  perf-on  counter (must be > 0):   ${onCount}`);
 
   const countsOk = (offCount === 0) && (onCount > 0);
 
-  if (offOk && onOk && countsOk) {
-    console.log('=== PASS ===');
+  if (off.ok && on.ok && countsOk) {
+    report.pass(
+      'perf-bundle',
+      `off-count=${offCount}; on-count=${onCount}; off=${offDir} (${off.bytes} chars); ` +
+        `on=${onDir} (${on.bytes} chars)`
+    );
     process.exit(0);
   } else {
+    report.flushDetails();
     console.error('=== FAIL ===');
-    if (!offOk || offCount !== 0) {
+    if (!off.ok || offCount !== 0) {
       console.error('Perf-off bundle isolation broke: a Performance API call');
       console.error('site or the re-frame.performance ns survived advanced');
       console.error('compilation with re-frame.performance/enabled?=false.');
       console.error('Per Spec 009 §Performance instrumentation, the bracket');
       console.error('site must collapse to (f) so DCE removes the gated body.');
     }
-    if (!onOk || !(onCount > 0)) {
+    if (!on.ok || !(onCount > 0)) {
       console.error('Perf-on bundle missing expected sentinels — the grep');
       console.error('test would be vacuous. The helper or its call sites');
       console.error('may have been refactored without updating sentinels.');

--- a/implementation/scripts/check-schemas-bundle.cjs
+++ b/implementation/scripts/check-schemas-bundle.cjs
@@ -37,9 +37,11 @@
 const fs   = require('fs');
 const path = require('path');
 const zlib = require('zlib');
+const { createGateReporter } = require('./lib/gate-report.cjs');
 const { listReleaseJsFiles } = require('./lib/read-release-bundle.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
+const report = createGateReporter();
 
 // ----- the schemas bundle-cost contract -------------------------------------
 
@@ -90,8 +92,8 @@ function fmtKb(bytes) {
 // ----- main ------------------------------------------------------------------
 
 function main() {
-  console.log('=== Schemas bundle-cost gate (Spec 010 §Bundle cost, rf2-fqbcy) ===');
-  console.log('');
+  report.detail('=== Schemas bundle-cost gate (Spec 010 §Bundle cost, rf2-fqbcy) ===');
+  report.detail('');
 
   const sizes = {};
   let bundlesOk = true;
@@ -108,13 +110,13 @@ function main() {
     sizes[b.name] = total;
     const ok = total <= b.gzippedMaxBytes;
     const tag = ok ? 'OK' : 'FAIL';
-    console.log(`  [${tag}] ${b.name}`);
-    console.log(`        spec:      ${b.specRow}`);
-    console.log(`        bundle:    ${fmtKb(total)} gzipped (${total} bytes)`);
-    console.log(`        threshold: ${fmtKb(b.gzippedMaxBytes)} (${b.gzippedMaxBytes} bytes)`);
+    report.detail(`  [${tag}] ${b.name}`);
+    report.detail(`        spec:      ${b.specRow}`);
+    report.detail(`        bundle:    ${fmtKb(total)} gzipped (${total} bytes)`);
+    report.detail(`        threshold: ${fmtKb(b.gzippedMaxBytes)} (${b.gzippedMaxBytes} bytes)`);
     if (!ok) {
       bundlesOk = false;
-      console.error(`        REGRESSION: bundle exceeds threshold by ${fmtKb(total - b.gzippedMaxBytes)}`);
+      report.detail(`        REGRESSION: bundle exceeds threshold by ${fmtKb(total - b.gzippedMaxBytes)}`);
     }
   }
 
@@ -134,22 +136,30 @@ function main() {
     const minDelta = 15 * 1024;
     const ok = delta >= minDelta;
     const tag = ok ? 'OK' : 'FAIL';
-    console.log('');
-    console.log(`  [${tag}] methodology guard — Malli-on bundle is strictly larger`);
-    console.log(`        delta: ${fmtKb(delta)} (${delta} bytes)`);
-    console.log(`        threshold: ≥ ${fmtKb(minDelta)} (Spec row 3 − row 2 = 23.6 KB)`);
+    report.detail('');
+    report.detail(`  [${tag}] methodology guard — Malli-on bundle is strictly larger`);
+    report.detail(`        delta: ${fmtKb(delta)} (${delta} bytes)`);
+    report.detail(`        threshold: ≥ ${fmtKb(minDelta)} (Spec row 3 − row 2 = 23.6 KB)`);
     if (!ok) {
       methodologyOk = false;
-      console.error('        FAIL — Malli adapter\'s body was eliminated;');
-      console.error('        the +Malli gate is now vacuous.');
+      report.detail('        FAIL — Malli adapter\'s body was eliminated;');
+      report.detail('        the +Malli gate is now vacuous.');
     }
   }
 
-  console.log('');
+  report.detail('');
   if (bundlesOk && methodologyOk) {
-    console.log('=== PASS ===');
+    const probe = sizes['schemas-bundle-probe'];
+    const probeMalli = sizes['schemas-bundle-probe-malli'];
+    report.pass(
+      'schemas-bundle',
+      `schemas-bundle-probe=${fmtKb(probe)}/${fmtKb(BUNDLES[0].gzippedMaxBytes)}; ` +
+        `schemas-bundle-probe-malli=${fmtKb(probeMalli)}/${fmtKb(BUNDLES[1].gzippedMaxBytes)}; ` +
+        `delta=${fmtKb(probeMalli - probe)}`
+    );
     process.exit(0);
   } else {
+    report.flushDetails();
     console.error('=== FAIL ===');
     console.error('');
     console.error('Per Spec 010 §Bundle cost the schemas-artefact bundle cost');

--- a/implementation/scripts/check-uix-helix-reagent-free.cjs
+++ b/implementation/scripts/check-uix-helix-reagent-free.cjs
@@ -35,9 +35,11 @@
 'use strict';
 
 const path = require('path');
+const { createGateReporter } = require('./lib/gate-report.cjs');
 const { readReleaseBlob } = require('./lib/read-release-bundle.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
+const report = createGateReporter();
 
 // ----- sentinels -------------------------------------------------------------
 //
@@ -80,12 +82,13 @@ function checkBundle(label, bundlePath, mustContain) {
   if (blob == null) {
     console.error(`[uix-helix-reagent-free] ${label}: bundle path missing — ${bundlePath}`);
     console.error('                          Did you run the matching shadow-cljs release?');
-    return false;
+    return { ok: false, checked: 0, passed: 0, bytes: null, missing: true };
   }
-  console.log(`  ${label}: ${bundlePath}`);
-  console.log(`    bundle size: ${blob.length} chars`);
+  report.detail(`  ${label}: ${bundlePath}`);
+  report.detail(`    bundle size: ${blob.length} chars`);
 
   let ok = true;
+  let passedCount = 0;
   for (const { source, sentinel } of REAGENT_SENTINELS) {
     const hits     = countSubstring(blob, sentinel);
     const present  = hits > 0;
@@ -93,17 +96,25 @@ function checkBundle(label, bundlePath, mustContain) {
     const actual   = present     ? `PRESENT (${hits})` : 'ABSENT (0)';
     const passed   = present === mustContain;
     const tag      = passed ? 'OK' : 'FAIL';
-    console.log(`    [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} expected ${expected}, was ${actual}`);
+    report.detail(`    [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} expected ${expected}, was ${actual}`);
+    if (passed) passedCount += 1;
     if (!passed) ok = false;
   }
-  return ok;
+  return {
+    ok,
+    checked: REAGENT_SENTINELS.length,
+    passed: passedCount,
+    bytes: blob.length,
+    bundlePath,
+    missing: false,
+  };
 }
 
 // ----- main ------------------------------------------------------------------
 
 function main() {
-  console.log('=== UIx-only / Helix-only Reagent isolation (rf2-jicu2) ===');
-  console.log('');
+  report.detail('=== UIx-only / Helix-only Reagent isolation (rf2-jicu2) ===');
+  report.detail('');
 
   const uixDir     = path.join(ROOT, 'out', 'examples', 'counter-uix');
   const helixDir   = path.join(ROOT, 'out', 'examples', 'counter-helix');
@@ -111,27 +122,32 @@ function main() {
 
   // Negative assertions: the new spine produces a UIx-only / Helix-only
   // bundle with no Reagent dependency.
-  const uixOk   = checkBundle('UIx-only counter   (must NOT contain reagent.ratom / reagent.impl.batching)',
-                              uixDir, false);
-  console.log('');
-  const helixOk = checkBundle('Helix-only counter (must NOT contain reagent.ratom / reagent.impl.batching)',
-                              helixDir, false);
-  console.log('');
+  const uix   = checkBundle('UIx-only counter   (must NOT contain reagent.ratom / reagent.impl.batching)',
+                            uixDir, false);
+  report.detail('');
+  const helix = checkBundle('Helix-only counter (must NOT contain reagent.ratom / reagent.impl.batching)',
+                            helixDir, false);
+  report.detail('');
   // Positive assertion: the Reagent-using counter bundle DOES carry the
   // sentinels. Without this present-check, a sentinel-name regression
   // would silently turn the negative greps above into vacuous passes.
-  const reagentOk = checkBundle('Reagent counter    (methodology sanity — sentinels MUST be present)',
-                                reagentDir, true);
+  const reagent = checkBundle('Reagent counter    (methodology sanity — sentinels MUST be present)',
+                              reagentDir, true);
 
-  if (uixOk && helixOk && reagentOk) {
-    console.log('');
-    console.log('=== PASS ===');
+  if (uix.ok && helix.ok && reagent.ok) {
+    const checked = uix.checked + helix.checked + reagent.checked;
+    report.pass(
+      'uix-helix-reagent-free',
+      `3 bundles checked; ${checked} sentinel checks; uix=${uixDir} (${uix.bytes} chars); ` +
+        `helix=${helixDir} (${helix.bytes} chars); reagent=${reagentDir} (${reagent.bytes} chars)`
+    );
     process.exit(0);
   } else {
+    report.flushDetails();
     console.error('');
     console.error('=== FAIL ===');
     console.error('');
-    if (!uixOk || !helixOk) {
+    if (!uix.ok || !helix.ok) {
       console.error('A UIx-only or Helix-only release bundle pulled in reagent.ratom');
       console.error('or reagent.impl.batching. Per rf2-jicu2 the substrate spine reifies');
       console.error('the re-frame-owned `re-frame.disposable/IDisposable` protocol —');
@@ -141,7 +157,7 @@ function main() {
       console.error('  (b) a UIx/Helix-side ns picked up a transitive Reagent dep');
       console.error('      (e.g. via a new `:require [reagent.* ...]` in adapter wiring).');
     }
-    if (!reagentOk) {
+    if (!reagent.ok) {
       console.error('The Reagent-bundle present-check failed — the sentinel grep would');
       console.error('be vacuous. Either the sentinel strings have moved (refactor in');
       console.error('reagent.ratom / reagent.impl.batching upstream) or the counter');

--- a/implementation/scripts/lib/gate-report.cjs
+++ b/implementation/scripts/lib/gate-report.cjs
@@ -1,0 +1,47 @@
+'use strict';
+
+const { isVerboseTests } = require('./browser-test-report.cjs');
+
+function splitLines(text) {
+  return String(text == null ? '' : text).replace(/\r\n/g, '\n').split('\n');
+}
+
+function createGateReporter({
+  env = process.env,
+  verbose = isVerboseTests(env),
+  stdout = (line) => console.log(line),
+  stderr = (line) => console.error(line),
+} = {}) {
+  const buffered = [];
+
+  function detail(line = '') {
+    for (const part of splitLines(line)) {
+      if (verbose) stdout(part);
+      else buffered.push(part);
+    }
+  }
+
+  function flushDetails({ stream = stderr } = {}) {
+    if (verbose) return;
+    for (const line of buffered) stream(line);
+    buffered.length = 0;
+  }
+
+  function pass(label, summary) {
+    const suffix = summary ? `: ${summary}` : '';
+    stdout(`PASS ${label}${suffix}`);
+  }
+
+  return {
+    detail,
+    flushDetails,
+    pass,
+    isVerbose: () => verbose,
+    bufferedLineCount: () => buffered.length,
+  };
+}
+
+module.exports = {
+  createGateReporter,
+  isVerboseTests,
+};


### PR DESCRIPTION
## Summary
- Add a shared JS gate reporter that buffers detailed diagnostics on normal runs, emits them on failure, and streams them when `RF2_VERBOSE_TESTS=1`.
- Convert the elision, bundle-isolation, slim bundle-comparison, UIx/Helix reagent-free, schemas bundle, and perf bundle gates to one-line green `PASS` summaries.
- Document verbose JS gate usage and add lightweight helper regression coverage.

## Checks
- `npm run test:script-helpers`
- `npm run test:script-policy`
- `npm run test:elision`
- `npm run test:perf-bundle`
- `npm run test:schemas-bundle`
- `npm run test:bundle-isolation`
- `npm run test:bundle-comparison`
- `node scripts/check-perf-bundle.cjs`
- `RF2_VERBOSE_TESTS=1 node scripts/check-perf-bundle.cjs`