### PR TITLE
test(story): add feature load gate

### DIFF
--- a/examples/scripts/run-story-feature-load-tests.cjs
+++ b/examples/scripts/run-story-feature-load-tests.cjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/*
+ * Quiet Playwright runner for the occasional Story feature/load gate.
+ *
+ * Green output is one summary line. On failure the runner flushes the
+ * buffered browser diagnostics plus Story-specific context: feature,
+ * phase, URL, active variant, active mode, and browser console/page
+ * errors. See docs/quiet-tests.md.
+ */
+
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const IMPL_ROOT = path.join(REPO_ROOT, 'implementation');
+const { chromium } = require(require.resolve('playwright', { paths: [IMPL_ROOT] }));
+
+const BASE_URL = process.env.STORY_FEATURE_LOAD_BASE_URL || 'http://127.0.0.1:8031';
+const TIMEOUT_MS = parseInt(process.env.STORY_FEATURE_LOAD_TIMEOUT_MS || '90000', 10);
+const VERBOSE = process.env.RF2_VERBOSE_TESTS === '1';
+
+const SPEC_FILES = [
+  path.join(REPO_ROOT, 'tools', 'story', 'test', 'story_feature_load.cjs'),
+];
+
+function withTimeout(promise, ms, label) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`Spec '${label}' timed out after ${ms}ms`)),
+      ms,
+    );
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+function formatStoryContext(ctx) {
+  if (!ctx) return 'Story context unavailable';
+  return [
+    `url=${ctx.url || ''}`,
+    `hash=${ctx.hash || ''}`,
+    `activeVariant=${ctx.activeVariant || ''}`,
+    `activeMode=${ctx.activeMode || ''}`,
+    `activeToolbarModes=${JSON.stringify(ctx.activeToolbarModes || [])}`,
+  ].join('\n');
+}
+
+(async () => {
+  const specs = SPEC_FILES.map((file) => {
+    const mod = require(file);
+    if (!mod || typeof mod.run !== 'function' || typeof mod.url !== 'string') {
+      throw new Error(`Bad Story feature-load spec at ${file}: must export {name, url, run}`);
+    }
+    return { ...mod, file };
+  });
+
+  const browser = await chromium.launch({ headless: true });
+  const results = [];
+  let anyFailed = false;
+
+  for (const spec of specs) {
+    const label = spec.name || path.basename(spec.file);
+    const lines = [];
+    const consoleErrors = [];
+    const pageErrors = [];
+    const log = (s) => lines.push(s);
+    const flush = () => {
+      for (const line of lines) console.log(line);
+    };
+
+    log(`\n=== ${label} ===`);
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    page.on('console', (msg) => {
+      const text = `[browser:${msg.type()}] ${msg.text()}`;
+      if (msg.type() === 'error') {
+        consoleErrors.push(text);
+      }
+      log(text);
+    });
+    page.on('pageerror', (err) => {
+      const text = `[browser:pageerror] ${err.message}`;
+      pageErrors.push(text);
+      log(text);
+      if (err.stack) log(err.stack);
+    });
+
+    const fullUrl = spec.url.startsWith('http') ? spec.url : BASE_URL + spec.url;
+    log(`Navigating to ${fullUrl}`);
+
+    let passed = false;
+    let failure = null;
+    try {
+      await page.goto(fullUrl, { waitUntil: 'load', timeout: TIMEOUT_MS });
+      await withTimeout(spec.run(page), TIMEOUT_MS, label);
+
+      if (consoleErrors.length > 0 || pageErrors.length > 0) {
+        throw new Error(
+          `Browser emitted ${consoleErrors.length} console error(s) and ` +
+            `${pageErrors.length} page error(s)`,
+        );
+      }
+
+      passed = true;
+    } catch (err) {
+      failure = err;
+      anyFailed = true;
+      log(`FAIL ${label}: ${err.message}`);
+      if (err.feature || err.phase) {
+        log(`feature=${err.feature || ''}`);
+        log(`phase=${err.phase || ''}`);
+      }
+      const ctx =
+        err.storyContext ||
+        (typeof spec.context === 'function'
+          ? await spec.context(page).catch(() => null)
+          : null);
+      log(formatStoryContext(ctx));
+      if (consoleErrors.length > 0) {
+        log('console errors:');
+        for (const line of consoleErrors) log(line);
+      }
+      if (pageErrors.length > 0) {
+        log('page errors:');
+        for (const line of pageErrors) log(line);
+      }
+      if (err.stack) log(err.stack);
+    } finally {
+      await context.close();
+    }
+
+    if (!passed || VERBOSE) flush();
+    results.push({ label, passed, failure });
+  }
+
+  await browser.close();
+
+  const failedCount = results.filter((r) => !r.passed).length;
+  if (anyFailed) {
+    console.log('\n=== summary ===');
+    for (const r of results) {
+      console.log(`${r.passed ? 'PASS' : 'FAIL'}  ${r.label}`);
+    }
+  }
+  console.log(`Ran ${results.length} Story feature-load specs. ${failedCount} failures.`);
+  process.exit(anyFailed ? 1 : 0);
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/scripts/serve-and-run-story-feature-load-tests.cjs
+++ b/examples/scripts/serve-and-run-story-feature-load-tests.cjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/*
+ * Narrow orchestrator for the occasional Story feature/load gate.
+ *
+ * Compiles only the Story testbeds needed by
+ * tools/story/test/story_feature_load.cjs, stages their HTML files,
+ * serves implementation/out/examples, and invokes the quiet runner.
+ */
+
+const { spawn, spawnSync } = require('child_process');
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+
+const PORT = parseInt(process.env.STORY_FEATURE_LOAD_PORT || '8031', 10);
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const IMPL_ROOT = path.join(REPO_ROOT, 'implementation');
+const OUT_ROOT = path.join(IMPL_ROOT, 'out', 'examples');
+const RUNNER = path.resolve(__dirname, 'run-story-feature-load-tests.cjs');
+const HTTP_SERVER_BIN = require.resolve('http-server/bin/http-server', {
+  paths: [IMPL_ROOT],
+});
+const READY_TIMEOUT_MS = 30000;
+const POLL_MS = 200;
+
+const TESTBEDS = [
+  {
+    build: 'examples/counter-with-stories',
+    htmlSrc: path.join(REPO_ROOT, 'tools', 'story', 'testbeds', 'counter_with_stories', 'index.html'),
+    outDir: path.join(OUT_ROOT, 'counter-with-stories'),
+  },
+  {
+    build: 'examples/login-form',
+    htmlSrc: path.join(REPO_ROOT, 'tools', 'story', 'testbeds', 'login_form', 'index.html'),
+    outDir: path.join(OUT_ROOT, 'login-form'),
+  },
+];
+
+function compileAll() {
+  const isWin = process.platform === 'win32';
+  const npx = isWin ? 'npx.cmd' : 'npx';
+  const shadowArgs = ['shadow-cljs', 'compile', ...TESTBEDS.map((t) => t.build)];
+  const command = isWin ? 'cmd.exe' : npx;
+  const args = isWin
+    ? ['/d', '/s', '/c', [npx, ...shadowArgs].join(' ')]
+    : shadowArgs;
+  const result = spawnSync(command, args, {
+    cwd: IMPL_ROOT,
+    encoding: 'utf8',
+  });
+  const output = `${result.stdout || ''}${result.stderr || ''}`;
+  if (process.env.RF2_VERBOSE_TESTS === '1' || result.status !== 0) {
+    process.stdout.write(output);
+  }
+  if (result.status !== 0) {
+    console.error(`> ${npx} ${shadowArgs.join(' ')}`);
+    throw new Error(`shadow-cljs compile failed (exit ${result.status})`);
+  }
+}
+
+function stageHtml() {
+  for (const testbed of TESTBEDS) {
+    if (!fs.existsSync(testbed.outDir)) {
+      throw new Error(`Build output dir missing: ${testbed.outDir}`);
+    }
+    if (!fs.existsSync(testbed.htmlSrc)) {
+      throw new Error(`HTML source missing: ${testbed.htmlSrc}`);
+    }
+    fs.copyFileSync(testbed.htmlSrc, path.join(testbed.outDir, 'index.html'));
+  }
+}
+
+function probe(port) {
+  return new Promise((resolve) => {
+    const req = http.get(
+      { host: '127.0.0.1', port, path: '/', timeout: 1000 },
+      (res) => {
+        res.resume();
+        resolve(res.statusCode != null);
+      },
+    );
+    req.on('error', () => resolve(false));
+    req.on('timeout', () => {
+      req.destroy();
+      resolve(false);
+    });
+  });
+}
+
+async function waitForReady(port, deadline) {
+  while (Date.now() < deadline) {
+    if (await probe(port)) return true;
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS));
+  }
+  return false;
+}
+
+(async () => {
+  compileAll();
+  stageHtml();
+
+  const server = spawn(process.execPath, [HTTP_SERVER_BIN, OUT_ROOT, '-p', String(PORT), '-s', '-c-1'], {
+    cwd: IMPL_ROOT,
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+
+  let serverDown = false;
+  server.on('exit', (code, signal) => {
+    serverDown = true;
+    if (code !== 0 && code !== null) {
+      console.error(`http-server exited unexpectedly (code=${code}, signal=${signal}).`);
+    }
+  });
+
+  const ready = await waitForReady(PORT, Date.now() + READY_TIMEOUT_MS);
+  if (!ready || serverDown) {
+    console.error(`http-server did not become reachable on :${PORT} within ${READY_TIMEOUT_MS}ms.`);
+    if (!serverDown) server.kill();
+    process.exit(1);
+  }
+
+  const runner = spawn(process.execPath, [RUNNER], {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      STORY_FEATURE_LOAD_BASE_URL: `http://127.0.0.1:${PORT}`,
+    },
+  });
+
+  const code = await new Promise((resolve) => runner.on('exit', resolve));
+
+  if (!serverDown) {
+    server.kill();
+  }
+  process.exit(code == null ? 1 : code);
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -25,6 +25,7 @@
     "test:bundle-comparison": "shadow-cljs release examples/counter examples/counter-slim-and-fast && node scripts/check-counter-slim-and-fast.cjs",
     "test:examples": "node ../examples/scripts/serve-and-run-examples-tests.cjs",
     "story:build": "node scripts/story-build.cjs",
+    "test:story-feature-load": "node ../examples/scripts/serve-and-run-story-feature-load-tests.cjs",
     "test:story-static": "node scripts/check-story-static.cjs",
     "test:script-policy": "node scripts/_path-policy.test.cjs",
     "test:script-helpers": "node scripts/_browser-test-report.test.cjs && node scripts/_gate-report.test.cjs"

--- a/tools/story/test/story_feature_load.cjs
+++ b/tools/story/test/story_feature_load.cjs
@@ -1,0 +1,491 @@
+/*
+ * Occasional Story feature/load gate (rf2-nd9kq).
+ *
+ * This file is intentionally NOT named *.spec.cjs: the normal examples
+ * runner must not pick it up on every default cycle. The dedicated
+ * runner at examples/scripts/run-story-feature-load-tests.cjs loads it
+ * explicitly via npm run test:story-feature-load.
+ */
+
+const {
+  expectTextEquals,
+  expectTextContains,
+  expectVisible,
+  waitForValue,
+} = require('../../../examples/scripts/spec-helpers.cjs');
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function urlFor(page, path) {
+  return new URL(path, page.url()).href;
+}
+
+async function storyContext(page) {
+  return page.evaluate(() => {
+    const activeVariant = document
+      .querySelector('[data-test-variant]')
+      ?.getAttribute('data-test-variant') || null;
+    const activeMode = document
+      .querySelector('[data-test="story-mode-tabs"] [aria-selected="true"]')
+      ?.getAttribute('data-mode-tab') || null;
+    const activeToolbarModes = Array.from(
+      document.querySelectorAll('[data-test="story-toolbar"] [aria-pressed="true"]'),
+    ).map((el) => el.getAttribute('data-toolbar-mode') || el.textContent.trim());
+    return {
+      url: window.location.href,
+      hash: window.location.hash,
+      activeVariant,
+      activeMode,
+      activeToolbarModes,
+    };
+  });
+}
+
+function withStepContext(err, feature, phase, ctx) {
+  err.message = `[feature=${feature}] [phase=${phase}] ${err.message}`;
+  err.feature = feature;
+  err.phase = phase;
+  err.storyContext = ctx;
+  return err;
+}
+
+async function step(page, phase, feature, fn) {
+  try {
+    return await fn();
+  } catch (err) {
+    throw withStepContext(err, feature, phase, await storyContext(page).catch(() => null));
+  }
+}
+
+async function primeHelpDismissed(page) {
+  await page.evaluate(() => {
+    try {
+      localStorage.setItem('re-frame.story/seen-help-v1', '1');
+    } catch (_) {
+      /* ignore */
+    }
+  });
+}
+
+async function dismissHelpIfOpen(page) {
+  const help = page.getByRole('dialog', { name: /Story playground help/i });
+  if (await help.isVisible().catch(() => false)) {
+    await help.getByRole('button', { name: /Got it/i }).click();
+  }
+}
+
+async function gotoStoryShell(page, path) {
+  const target = urlFor(page, path);
+  if (page.url() === target) {
+    await page.reload({ waitUntil: 'load' });
+  } else {
+    await page.goto(target, { waitUntil: 'load' });
+  }
+  await primeHelpDismissed(page);
+  await page.evaluate(() => {
+    if (window.location.hash !== '#/stories') {
+      window.location.hash = '#/stories';
+    }
+  });
+  await expectVisible(page.getByRole('navigation'), 10000);
+  await expectVisible(page.getByRole('main'), 10000);
+  await expectVisible(page.getByRole('complementary'), 10000);
+  await dismissHelpIfOpen(page);
+}
+
+async function clickVariant(page, slashName) {
+  const row = page
+    .getByRole('navigation')
+    .getByText(slashName, { exact: false })
+    .first();
+  await row.waitFor({ state: 'visible', timeout: 10000 });
+  await row.click();
+}
+
+async function clickWorkspace(page, keyword) {
+  const row = page
+    .getByRole('navigation')
+    .getByText(keyword, { exact: false })
+    .first();
+  await row.waitFor({ state: 'visible', timeout: 10000 });
+  await row.click();
+}
+
+async function waitForCanvasVariant(page, variantKeyword) {
+  await page
+    .locator(`[data-test-variant="${variantKeyword}"]`)
+    .waitFor({ state: 'visible', timeout: 10000 });
+}
+
+async function setMode(page, mode) {
+  const chip = page.locator(`[data-test="story-mode-tabs"] [data-mode-tab="${mode}"]`);
+  await chip.waitFor({ state: 'visible', timeout: 5000 });
+  await chip.click();
+  await waitForValue(
+    () => chip.getAttribute('aria-selected'),
+    (value) => value === 'true',
+    { timeoutMs: 5000, description: `${mode} mode selected` },
+  );
+}
+
+async function assertCounterCore(page, phase) {
+  await step(page, phase, 'shell/sidebar/story-selection', async () => {
+    await gotoStoryShell(page, '/counter-with-stories/#/stories');
+    await expectVisible(page.locator('[data-test="story-toolbar"]'), 5000);
+    await clickVariant(page, '/loaded');
+    await waitForCanvasVariant(page, ':story.counter/loaded');
+    await expectTextEquals(
+      page
+        .locator('[data-test-variant=":story.counter/loaded"]')
+        .locator('[data-test="count"]')
+        .first(),
+      '7',
+      10000,
+    );
+  });
+
+  await step(page, phase, 'mode-tabs/docs/test/canvas', async () => {
+    await setMode(page, 'docs');
+    await expectVisible(page.locator('[data-test="story-docs-view"]'), 5000);
+    await expectVisible(page.locator('[data-test="story-docs-args-table"]'), 5000);
+    await expectVisible(
+      page.locator('[data-test="story-docs-tag-link"][data-docs-tag="test"]'),
+      5000,
+    );
+
+    await setMode(page, 'test');
+    await expectVisible(page.locator('[data-test="story-test-view"]'), 5000);
+    await waitForValue(
+      () => page.locator('[data-test="story-test-status-pill"]').innerText().catch(() => ''),
+      (text) => /3\s+passed/i.test(text),
+      { timeoutMs: 10000, description: 'loaded variant passing test status' },
+    );
+
+    await setMode(page, 'dev');
+    await waitForCanvasVariant(page, ':story.counter/loaded');
+  });
+
+  await step(page, phase, 'controls/args/save/share/help/open-in-editor', async () => {
+    const canvas = page.locator('[data-test-variant=":story.counter/loaded"]');
+    const aside = page.getByRole('complementary');
+
+    const labelInput = aside.locator('[data-controls-arg=":label"] input[type="text"]').first();
+    await labelInput.waitFor({ state: 'visible', timeout: 5000 });
+    await labelInput.fill(`Edited ${phase}`);
+    await expectVisible(
+      canvas.getByText(`Edited ${phase}`, { exact: false }).first(),
+      5000,
+    );
+
+    await aside.getByRole('button', { name: /reset overrides/i }).first().click();
+    await expectVisible(canvas.getByText('Total', { exact: false }).first(), 5000);
+
+    const saveButton = aside.locator('[data-test="story-save-variant-button"]');
+    await saveButton.waitFor({ state: 'visible', timeout: 5000 });
+    await saveButton.click();
+    await expectVisible(page.locator('[data-test="story-save-variant-dialog"]'), 5000);
+    await expectTextContains(
+      page.locator('[data-test="story-save-variant-snippet"]'),
+      'reg-variant',
+      5000,
+    );
+    await page.locator('[data-test="story-save-variant-close"]').click();
+
+    const shareButton = page.getByRole('button', { name: /^share$/i }).first();
+    await shareButton.waitFor({ state: 'visible', timeout: 5000 });
+    await shareButton.click();
+    await expectVisible(page.getByRole('img', { name: /QR code for variant URL/i }), 5000);
+    await page.getByRole('button', { name: /^close$/i }).first().click();
+
+    await expectVisible(page.locator('[data-test="story-open-in-editor"]').first(), 5000);
+    await page.getByRole('button', { name: /Show playground help/i }).click();
+    await expectVisible(page.getByRole('dialog', { name: /Story playground help/i }), 5000);
+    await page.getByRole('button', { name: /Got it/i }).click();
+  });
+}
+
+async function assertTraceActionsScrubberA11y(page, phase) {
+  await step(page, phase, 'trace/actions/scrubber/cross-ref/a11y', async () => {
+    await clickVariant(page, '/loaded');
+    await waitForCanvasVariant(page, ':story.counter/loaded');
+    await setMode(page, 'dev');
+
+    const canvas = page.locator('[data-test-variant=":story.counter/loaded"]');
+    await canvas.locator('[data-test="inc"]').first().click();
+
+    await waitForValue(
+      () => page.locator('[data-test="story-trace-cascade-row"]').count(),
+      (count) => count >= 1,
+      { timeoutMs: 10000, description: 'at least one trace cascade row' },
+    );
+    await waitForValue(
+      () => page.locator('[data-test="story-actions-row"]').count(),
+      (count) => count >= 1,
+      { timeoutMs: 10000, description: 'at least one action row' },
+    );
+
+    const slider = page.locator('[data-test="story-scrubber-slider"]').first();
+    await slider.waitFor({ state: 'visible', timeout: 5000 });
+    const max = await waitForValue(
+      () => slider.getAttribute('max').then((value) => parseInt(value || '0', 10)),
+      (value) => value >= 1,
+      { timeoutMs: 10000, description: 'scrubber slider max >= 1' },
+    );
+    await slider.evaluate((el, value) => {
+      el.value = String(value);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+      el.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    }, max);
+    await waitForValue(
+      () => page.locator('[data-test="story-trace-panel"]').getAttribute('data-scrubbed-epoch'),
+      (value) => value != null && value !== '',
+      { timeoutMs: 10000, description: 'trace panel scrubbed epoch attribute' },
+    );
+    await page.locator('[data-test="story-scrubber-release"]').click();
+
+    await expectVisible(
+      page.locator('[data-rf-story-variant-root=":story.counter/loaded"]').first(),
+      5000,
+    );
+    const runButton = page
+      .getByRole('complementary')
+      .getByRole('button', { name: /^(run|re-run|retry)$/i })
+      .first();
+    await runButton.waitFor({ state: 'visible', timeout: 5000 });
+    await runButton.click();
+    await waitForValue(
+      () => page.getByRole('complementary').innerText(),
+      (text) => !/click run to scan the variant/i.test(text),
+      { timeoutMs: 15000, description: 'a11y panel leaves idle state' },
+    );
+  });
+}
+
+async function assertToolbarRecorder(page, phase) {
+  await step(page, phase, 'toolbar/recorder/review-dialog', async () => {
+    await clickVariant(page, '/loaded');
+    await waitForCanvasVariant(page, ':story.counter/loaded');
+
+    const toolbar = page.locator('[data-test="story-toolbar"]');
+    await toolbar.waitFor({ state: 'visible', timeout: 5000 });
+    const dark = toolbar.locator('[data-toolbar-mode=":Mode.app/dark"]');
+    await dark.click();
+    await waitForValue(
+      () => dark.getAttribute('aria-pressed'),
+      (value) => value === 'true',
+      { timeoutMs: 5000, description: 'dark toolbar mode active' },
+    );
+    await toolbar.locator('[data-test="story-toolbar-reset"]').click();
+    await waitForValue(
+      () => dark.getAttribute('aria-pressed'),
+      (value) => value === 'false',
+      { timeoutMs: 5000, description: 'dark toolbar mode reset' },
+    );
+
+    const rec = toolbar.locator('[data-test="story-toolbar-rec"]');
+    await rec.waitFor({ state: 'visible', timeout: 5000 });
+    await rec.click();
+    await expectVisible(page.locator('[data-test="story-recorder-overlay"]'), 5000);
+    await page
+      .locator('[data-test-variant=":story.counter/loaded"]')
+      .locator('[data-test="inc"]')
+      .first()
+      .click();
+    await waitForValue(
+      () => page.locator('[data-test="story-recorder-overlay"]').innerText(),
+      (text) => /1 event/.test(text),
+      { timeoutMs: 5000, description: 'recorder captured one event' },
+    );
+    await page.locator('[data-test="story-recorder-stop"]').click();
+    await expectVisible(page.locator('[data-test="story-recorder-dialog"]'), 5000);
+    await expectTextContains(
+      page.locator('[data-test="story-recorder-snippet"]'),
+      ':counter/inc',
+      5000,
+    );
+    await page.locator('[data-test="story-recorder-close"]').click();
+  });
+}
+
+async function assertDiagnostics(page, phase) {
+  await step(page, phase, 'diagnostics/failing-play', async () => {
+    await clickVariant(page, '/failing-play');
+    await setMode(page, 'test');
+    await expectTextContains(
+      page.locator('[data-test="story-test-view"]'),
+      ':story.counter-diagnostics/failing-play',
+      5000,
+    );
+    await waitForValue(
+      () => page.locator('[data-test="story-test-status-pill"]').innerText().catch(() => ''),
+      (text) => /failed/i.test(text),
+      { timeoutMs: 10000, description: 'failing assertion status' },
+    );
+    await waitForValue(
+      () => page.locator('[data-test="story-test-row"][data-status="fail"]').count(),
+      (count) => count >= 1,
+      { timeoutMs: 5000, description: 'failing assertion row' },
+    );
+  });
+
+  await step(page, phase, 'diagnostics/event-handler-exception', async () => {
+    await clickVariant(page, '/event-throws');
+    await setMode(page, 'test');
+    await expectTextContains(
+      page.locator('[data-test="story-test-view"]'),
+      ':story.counter-diagnostics/event-throws',
+      5000,
+    );
+    await waitForValue(
+      () => page.locator('[data-test="story-test-status-pill"]').innerText().catch(() => ''),
+      (text) => /failed/i.test(text),
+      { timeoutMs: 10000, description: 'event exception failure status' },
+    );
+    await page
+      .locator('[data-test="story-test-row"][data-status="fail"]')
+      .first()
+      .getByRole('button', { name: /show detail/i })
+      .click();
+    await waitForValue(
+      () => page.locator('[data-test="story-test-row-detail"]').count(),
+      (count) => count >= 1,
+      { timeoutMs: 5000, description: 'event exception detail expands' },
+    );
+    await waitForValue(
+      () =>
+        page
+          .locator('[data-test="story-test-row"][data-status="fail"]')
+          .first()
+          .getAttribute('data-assertion'),
+      (value) => value === ':rf.error/exception',
+      { timeoutMs: 5000, description: 'event exception assertion row type' },
+    );
+  });
+
+  await step(page, phase, 'diagnostics/loader-exception', async () => {
+    await clickVariant(page, '/loader-throws');
+    await setMode(page, 'test');
+    await expectTextContains(
+      page.locator('[data-test="story-test-view"]'),
+      ':story.counter-diagnostics/loader-throws',
+      5000,
+    );
+    await waitForValue(
+      () => page.locator('[data-test="story-test-status-pill"]').innerText().catch(() => ''),
+      (text) => /failed/i.test(text),
+      { timeoutMs: 10000, description: 'loader exception failure status' },
+    );
+    await page
+      .locator('[data-test="story-test-row"][data-status="fail"]')
+      .first()
+      .getByRole('button', { name: /show detail/i })
+      .click();
+    await waitForValue(
+      () => page.locator('[data-test="story-test-row-detail"]').count(),
+      (count) => count >= 1,
+      { timeoutMs: 5000, description: 'loader exception detail expands' },
+    );
+    await waitForValue(
+      () =>
+        page
+          .locator('[data-test="story-test-row"][data-status="fail"]')
+          .first()
+          .getAttribute('data-assertion'),
+      (value) => value === ':rf.error/exception',
+      { timeoutMs: 5000, description: 'loader exception assertion row type' },
+    );
+  });
+}
+
+async function assertLoginStory(page, phase) {
+  await step(page, phase, 'login-form/failure-and-authenticated-states', async () => {
+    await gotoStoryShell(page, '/login-form/#/stories');
+    await clickVariant(page, '/error');
+    await expectVisible(page.locator('[data-test="login-error"]'), 10000);
+    await expectTextEquals(
+      page.locator('[data-test="login-state-pill"]'),
+      'state: :error',
+      10000,
+    );
+    await clickVariant(page, '/authenticated');
+    await expectVisible(page.locator('[data-test="login-welcome"]'), 10000);
+    await clickWorkspace(page, ':Workspace.login/all-states');
+    await waitForValue(
+      () => page.locator('[data-test="login-state-pill"]').count(),
+      (count) => count >= 5,
+      { timeoutMs: 10000, description: 'login all-states workspace cells' },
+    );
+  });
+}
+
+async function runTwentyEventBurst(page) {
+  await gotoStoryShell(page, '/counter-with-stories/#/stories');
+  await clickVariant(page, '/loaded'); // 1
+  await setMode(page, 'dev'); // 2
+
+  const canvas = page.locator('[data-test-variant=":story.counter/loaded"]');
+  await canvas.locator('[data-test="inc"]').first().click(); // 3
+  await canvas.locator('[data-test="dec"]').first().click(); // 4
+  await setMode(page, 'docs'); // 5
+  await setMode(page, 'test'); // 6
+  await setMode(page, 'dev'); // 7
+
+  const aside = page.getByRole('complementary');
+  const labelInput = aside.locator('[data-controls-arg=":label"] input[type="text"]').first();
+  await labelInput.fill('Burst Label'); // 8
+  await aside.getByRole('button', { name: /reset overrides/i }).first().click(); // 9
+
+  const toolbar = page.locator('[data-test="story-toolbar"]');
+  await toolbar.locator('[data-toolbar-mode=":Mode.app/dark"]').click(); // 10
+  await toolbar.locator('[data-toolbar-mode=":Mode.app/light"]').click(); // 11
+  await toolbar.locator('[data-test="story-toolbar-reset"]').click(); // 12
+
+  await page.getByRole('button', { name: /^share$/i }).first().click(); // 13
+  await page.getByRole('button', { name: /^close$/i }).first().click(); // 14
+
+  await toolbar.locator('[data-test="story-toolbar-rec"]').click(); // 15
+  await expectVisible(page.locator('[data-test="story-recorder-overlay"]'), 5000);
+  await canvas.locator('[data-test="inc"]').first().click(); // 16
+  await page.locator('[data-test="story-recorder-stop"]').click(); // 17
+  await expectVisible(page.locator('[data-test="story-recorder-dialog"]'), 5000);
+  await page.locator('[data-test="story-recorder-close"]').click(); // 18
+
+  await clickWorkspace(page, ':Workspace.counter/all-states'); // 19
+  await waitForValue(
+    () => page.locator('[data-test="count"]').count(),
+    (count) => count >= 4,
+    { timeoutMs: 10000, description: 'counter workspace mounted during burst' },
+  );
+  await clickVariant(page, '/loaded'); // 20
+  await waitForCanvasVariant(page, ':story.counter/loaded');
+  return 20;
+}
+
+async function assertFeatureSet(page, phase) {
+  await assertCounterCore(page, phase);
+  await assertTraceActionsScrubberA11y(page, phase);
+  await assertToolbarRecorder(page, phase);
+  await assertDiagnostics(page, phase);
+  await assertLoginStory(page, phase);
+}
+
+module.exports = {
+  name: 'Story feature exercise + 20-event load gate',
+  url: '/counter-with-stories/#/stories',
+  context: storyContext,
+  run: async (page) => {
+    await primeHelpDismissed(page);
+    await assertFeatureSet(page, 'before-load');
+    const events = await step(page, 'load-burst', '20-meaningful-events', () =>
+      runTwentyEventBurst(page),
+    );
+    if (events < 20) {
+      throw new Error(`load burst executed ${events} events; expected at least 20`);
+    }
+    await sleep(0);
+    await assertFeatureSet(page, 'after-20-events');
+  },
+};

--- a/tools/story/testbeds/counter_with_stories/events.cljs
+++ b/tools/story/testbeds/counter_with_stories/events.cljs
@@ -39,6 +39,12 @@
   (fn [db [_ n]]
     (assoc db :count n)))
 
+(rf/reg-event-db :counter/throw-deterministic
+  (fn [_db _event]
+    (throw (ex-info "story-load deterministic event handler failure"
+                    {:surface :story-load
+                     :kind    :event-handler-exception}))))
+
 ;; A user-fx so the `force-fx-stub` decorator story has something
 ;; concrete to stub. In the live app this would talk to a server;
 ;; for the example we keep it tiny — the point is the stub, not the

--- a/tools/story/testbeds/counter_with_stories/stories.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories.cljs
@@ -186,6 +186,16 @@
      :tags       #{:dev :docs}
      :substrates #{:reagent}})
 
+  (story/reg-story :story.counter-diagnostics
+    {:doc        "Small deterministic failure surfaces for Story's
+                 diagnostics and test-mode UI. Kept separate from
+                 :story.counter so the canonical four counter variants
+                 stay stable."
+     :component  :counter-with-stories.views/counter-card
+     :args       {:label "Diagnostics"}
+     :tags       #{:dev :test :internal}
+     :substrates #{:reagent}})
+
   ;; -------------------------------------------------------------------------
   ;; reg-variant — four variants, each pulling on a different authoring shape
   ;; -------------------------------------------------------------------------
@@ -252,6 +262,38 @@
               [:rf.assert/path-equals     [:saving?] true]
               [:rf.assert/effect-emitted  :counter/sync-to-server]]
      :tags   #{:dev :test}
+     :substrates #{:reagent}})
+
+  ;; Diagnostic variant 1 — failing assertion without an exception.
+  ;; Test mode must show the failure as data, not as an uncaught browser
+  ;; error. This gives the feature-load gate a stable red test-mode
+  ;; surface that does not depend on timing or external services.
+  (story/reg-variant :story.counter-diagnostics/failing-play
+    {:doc    "Deterministic failing play assertion. The counter is
+             initialised to 1 but the play assertion expects 999."
+     :events [[:counter/initialise 1]]
+     :play   [[:rf.assert/path-equals [:count] 999]]
+     :tags   #{:dev :test :internal}
+     :substrates #{:reagent}})
+
+  ;; Diagnostic variant 2 — phase-4 handler exception. The Story
+  ;; play-runner projects handler exceptions into the assertion list so
+  ;; the test pane can explain the failure without blanking the shell.
+  (story/reg-variant :story.counter-diagnostics/event-throws
+    {:doc    "Deterministic event-handler exception during :play."
+     :events [[:counter/initialise 0]]
+     :play   [[:counter/throw-deterministic]]
+     :tags   #{:dev :test :internal}
+     :substrates #{:reagent}})
+
+  ;; Diagnostic variant 3 — loader-phase exception. This exercises the
+  ;; phase-1 error capture path separately from ordinary play failures.
+  (story/reg-variant :story.counter-diagnostics/loader-throws
+    {:doc     "Deterministic loader exception before events/render."
+     :loaders [[:counter/throw-deterministic]]
+     :events  [[:counter/initialise 0]]
+     :play    [[:rf.assert/path-equals [:count] 0]]
+     :tags    #{:dev :test :internal}
      :substrates #{:reagent}})
 
   ;; -------------------------------------------------------------------------

--- a/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
@@ -87,13 +87,21 @@
     (is (story/registered? :story :story.counter))))
 
 (deftest example-four-variants-registered
-  (testing "all four variants registered, parent is :story.counter"
+  (testing "all four canonical variants registered, parent is :story.counter"
     (let [vs (story/variants-of :story.counter)]
       (is (contains? vs :story.counter/empty))
       (is (contains? vs :story.counter/loaded))
       (is (contains? vs :story.counter/clicked-three-times))
       (is (contains? vs :story.counter/save-stubbed))
       (is (= 4 (count vs))))))
+
+(deftest diagnostic-variants-registered
+  (testing "the diagnostics story exposes deterministic failure surfaces"
+    (let [vs (story/variants-of :story.counter-diagnostics)]
+      (is (contains? vs :story.counter-diagnostics/failing-play))
+      (is (contains? vs :story.counter-diagnostics/event-throws))
+      (is (contains? vs :story.counter-diagnostics/loader-throws))
+      (is (= 3 (count vs))))))
 
 (deftest example-workspaces-registered
   (testing "both workspaces registered"
@@ -165,6 +173,50 @@
               (is (story/assertions-passing? result)
                   (str "play assertions: " (pr-str (:assertions result))))
               (story/destroy-variant! :story.counter/save-stubbed)
+              (done)))))))
+
+(deftest diagnostic-failing-play-records-failure
+  (testing ":story.counter-diagnostics/failing-play records a failed assertion without throwing"
+    (async done
+      (-> (story/run-variant :story.counter-diagnostics/failing-play)
+          (async-lib/then
+            (fn [result]
+              (is (= 1 (-> result :app-db :count)))
+              (is (not (story/assertions-passing? result)))
+              (is (some #(and (= :rf.assert/path-equals (:assertion %))
+                              (false? (:passed? %)))
+                        (:assertions result)))
+              (story/destroy-variant! :story.counter-diagnostics/failing-play)
+              (done)))))))
+
+(deftest diagnostic-event-exception-records-failure
+  (testing ":story.counter-diagnostics/event-throws projects handler exceptions into assertions"
+    (async done
+      (-> (story/run-variant :story.counter-diagnostics/event-throws)
+          (async-lib/then
+            (fn [result]
+              (is (not (story/assertions-passing? result)))
+              (is (some #(and (= :rf.error/exception (:assertion %))
+                              (= :phase-4-play (:phase %))
+                              (re-find #"story-load deterministic event handler failure"
+                                       (get-in % [:error :message] "")))
+                        (:assertions result)))
+              (story/destroy-variant! :story.counter-diagnostics/event-throws)
+              (done)))))))
+
+(deftest diagnostic-loader-exception-records-failure
+  (testing ":story.counter-diagnostics/loader-throws projects loader exceptions into assertions"
+    (async done
+      (-> (story/run-variant :story.counter-diagnostics/loader-throws)
+          (async-lib/then
+            (fn [result]
+              (is (not (story/assertions-passing? result)))
+              (is (some #(and (= :rf.error/exception (:assertion %))
+                              (= :phase-1-loaders (:phase %))
+                              (re-find #"story-load deterministic event handler failure"
+                                       (get-in % [:error :message] "")))
+                        (:assertions result)))
+              (story/destroy-variant! :story.counter-diagnostics/loader-throws)
               (done)))))))
 
 ;; ---- mount-shell / unmount-shell / active-shell --------------------------


### PR DESCRIPTION
## Summary
- add an occasional Story feature/load browser gate with quiet green output and detailed failure context
- exercise Story shell, selection, mode tabs, controls/args, docs/test/dev, toolbar, actions/trace/scrubber/a11y, recorder/share/save/help/open-in-editor, diagnostics, and login-form states before and after a deterministic 20-event burst
- add deterministic counter diagnostics variants for failing assertions plus event-handler and loader exceptions

## Verification
- node --check examples/scripts/run-story-feature-load-tests.cjs
- node --check examples/scripts/serve-and-run-story-feature-load-tests.cjs
- node --check tools/story/test/story_feature_load.cjs
- npm run test:story-feature-load
- npm run test:cljs

## Known unrelated blocker
- npm run test:examples currently fails during compile in tools/causa/src/day8/re_frame2_causa/panels/time_travel.cljs:306: reagent2.impl.component/classify-form-body is unbound while macroexpanding reg-view.