### PR TITLE
test(playwright): quiet remaining green runners

### DIFF
--- a/examples/scripts/run-examples-tests.cjs
+++ b/examples/scripts/run-examples-tests.cjs
@@ -63,6 +63,13 @@ const SPEC_ROOTS = [
   path.join(REPO_ROOT, 'testbeds'),
 ];
 const TIMEOUT_MS = parseInt(process.env.EXAMPLE_SPEC_TIMEOUT_MS || '30000', 10);
+const { isVerboseTests } = require(path.join(
+  IMPL_ROOT,
+  'scripts',
+  'lib',
+  'browser-test-report.cjs',
+));
+const VERBOSE_TESTS = isVerboseTests();
 
 // Specs live alongside the example or testbed they exercise. Under
 // examples/ they sit two or three levels deep with file shape
@@ -159,10 +166,8 @@ function withTimeout(promise, ms, label) {
     const context = await browser.newContext();
     const page = await context.newPage();
 
-    const consoleLines = [];
     page.on('console', (msg) => {
       const text = msg.text();
-      consoleLines.push(text);
       log(`[browser:${msg.type()}] ${text}`);
     });
     let pageErrored = null;
@@ -193,7 +198,7 @@ function withTimeout(promise, ms, label) {
       await context.close();
     }
 
-    if (!passed) flush();
+    if (!passed || VERBOSE_TESTS) flush();
     results.push({ label, passed, failure });
   }
 

--- a/implementation/scripts/check-story-static.cjs
+++ b/implementation/scripts/check-story-static.cjs
@@ -44,6 +44,10 @@ const fs = require('fs');
 const http = require('http');
 const net = require('net');
 const path = require('path');
+const {
+  createDiagnosticBuffer,
+  isVerboseTests,
+} = require('./lib/browser-test-report.cjs');
 
 const IMPL_ROOT = path.resolve(__dirname, '..');
 const REPO_ROOT = path.resolve(IMPL_ROOT, '..');
@@ -59,25 +63,54 @@ const HTTP_SERVER_BIN = require.resolve('http-server/bin/http-server', {
 const DEFAULT_PORT = 8040;
 const READY_TIMEOUT_MS = 30000;
 const POLL_MS = 200;
+const VERBOSE_TESTS = isVerboseTests();
+const diagnostics = createDiagnosticBuffer();
 
 // Per rf2-o38lb: ownership-token sentinel, same shape as
 // serve-and-run-browser-tests.cjs.
 const TOKEN_FILE_BASENAME = '.rf-harness-token';
 const TOKEN_PATH = path.join(OUT_DIR, TOKEN_FILE_BASENAME);
 
-function runBuild() {
+function addChunk(diagnostics, prefix, chunk, stream = 'stdout') {
+  const normalized = String(chunk || '').replace(/\r\n/g, '\n');
+  for (const line of normalized.split('\n')) {
+    if (line.length === 0) continue;
+    diagnostics.add(`${prefix}${line}`, stream);
+  }
+}
+
+function flushDiagnostics(diagnostics) {
+  if (diagnostics.isEmpty()) return;
+  console.error('--- story-static diagnostics ---');
+  diagnostics.flush({
+    stdout: (line) => console.error(line),
+    stderr: (line) => console.error(line),
+  });
+  console.error('--------------------------------');
+}
+
+function runBuild(diagnostics) {
   // Use process.execPath directly without shell:true — on Windows the
   // installed node.exe path commonly contains spaces ("Program Files"),
   // which the shell wrapper splits on. Skipping `shell` keeps the
   // argv pass-through verbatim.
   const script = path.join(__dirname, 'story-build.cjs');
+  diagnostics.add(`Process: ${process.execPath} ${script}`);
   const result = spawnSync(process.execPath, [script], {
     cwd: IMPL_ROOT,
-    stdio: 'inherit',
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe'],
   });
+  if (result.stdout) addChunk(diagnostics, '[story-build:stdout] ', result.stdout);
+  if (result.stderr) addChunk(diagnostics, '[story-build:stderr] ', result.stderr, 'stderr');
+  if (result.error) {
+    throw result.error;
+  }
   if (result.status !== 0) {
     throw new Error(`story-build.cjs failed (exit ${result.status})`);
   }
+  diagnostics.add(`story-build.cjs exited ${result.status}`);
 }
 
 // True if the given TCP port is currently free on 127.0.0.1.
@@ -104,12 +137,12 @@ function findFreePort() {
   });
 }
 
-async function resolvePort() {
+async function resolvePort(diagnostics) {
   if (await isPortFree(DEFAULT_PORT)) {
     return DEFAULT_PORT;
   }
   const fallback = await findFreePort();
-  console.warn(
+  diagnostics.add(
     `Default port ${DEFAULT_PORT} is busy; falling back to free port ${fallback}.`,
   );
   return fallback;
@@ -196,7 +229,7 @@ async function waitForReady(port, expectedToken, deadline, state) {
   return { ok: false, reason: sawReachable ? 'token-never-served' : 'timeout' };
 }
 
-async function smokeTest(baseUrl) {
+async function smokeTest(baseUrl, diagnostics) {
   let playwright;
   try {
     playwright = require('playwright');
@@ -210,10 +243,19 @@ async function smokeTest(baseUrl) {
   const context = await browser.newContext();
   const page = await context.newPage();
 
-  const consoleErrors = [];
-  page.on('pageerror', (err) => consoleErrors.push(`pageerror: ${err.message}`));
+  diagnostics.add('Spec: story-static static export smoke');
+  diagnostics.add(`URL: ${baseUrl}`);
+  page.on('pageerror', (err) => {
+    diagnostics.add(`[browser:pageerror] ${err.message}`, 'stderr');
+    if (err.stack) diagnostics.add(err.stack, 'stderr');
+  });
   page.on('console', (msg) => {
-    if (msg.type() === 'error') consoleErrors.push(`console.error: ${msg.text()}`);
+    diagnostics.add(`[browser:${msg.type()}] ${msg.text()}`);
+  });
+  page.on('framenavigated', (frame) => {
+    if (frame === page.mainFrame()) {
+      diagnostics.add(`[browser:navigation] ${frame.url()}`);
+    }
   });
 
   try {
@@ -270,10 +312,6 @@ async function smokeTest(baseUrl) {
       .first()
       .waitFor({ state: 'visible', timeout: 10000 });
 
-    if (consoleErrors.length > 0) {
-      console.warn('console errors observed (non-fatal):');
-      for (const e of consoleErrors) console.warn('  ' + e);
-    }
   } finally {
     await browser.close();
   }
@@ -281,7 +319,7 @@ async function smokeTest(baseUrl) {
 
 (async () => {
   // 1. Build.
-  runBuild();
+  runBuild(diagnostics);
 
   // 2. Sanity-check the on-disk shape — the build script writes
   //    index.html + main.js + manifest.json next to a `cljs-runtime/`
@@ -290,6 +328,7 @@ async function smokeTest(baseUrl) {
     const p = path.join(OUT_DIR, required);
     if (!fs.existsSync(p)) {
       console.error(`Build output missing ${required} at ${p}`);
+      flushDiagnostics(diagnostics);
       process.exit(1);
     }
   }
@@ -298,18 +337,24 @@ async function smokeTest(baseUrl) {
   const token = writeOwnershipToken();
   if (!token) {
     console.error(`Asset root missing: ${OUT_DIR}`);
+    flushDiagnostics(diagnostics);
     process.exit(1);
   }
 
   // 4. Pick a port and serve.
-  const port = await resolvePort();
-  console.log(`Serving ${OUT_DIR} on http://127.0.0.1:${port}`);
+  const port = await resolvePort(diagnostics);
+  diagnostics.add(`Serving ${OUT_DIR} on http://127.0.0.1:${port}`);
 
   const server = spawn(
     process.execPath,
     [HTTP_SERVER_BIN, OUT_DIR, '-p', String(port), '-s', '-c-1'],
-    { cwd: IMPL_ROOT, stdio: ['ignore', 'inherit', 'inherit'] },
+    { cwd: IMPL_ROOT, stdio: ['ignore', 'pipe', 'pipe'] },
   );
+  diagnostics.add(
+    `Process: ${process.execPath} ${[HTTP_SERVER_BIN, OUT_DIR, '-p', String(port), '-s', '-c-1'].join(' ')}`,
+  );
+  server.stdout.on('data', (d) => addChunk(diagnostics, '[http-server:stdout] ', d));
+  server.stderr.on('data', (d) => addChunk(diagnostics, '[http-server:stderr] ', d, 'stderr'));
 
   // Track server lifecycle for fail-fast on early exit.
   const state = { exited: false, exitCode: null, exitSignal: null };
@@ -318,7 +363,9 @@ async function smokeTest(baseUrl) {
     state.exitCode = code;
     state.exitSignal = signal;
     if (code !== 0 && code !== null) {
-      console.error(`http-server exited unexpectedly (code=${code}, signal=${signal}).`);
+      diagnostics.add(`http-server exited unexpectedly (code=${code}, signal=${signal}).`, 'stderr');
+    } else {
+      diagnostics.add(`http-server exited (code=${code}, signal=${signal}).`);
     }
   });
 
@@ -328,6 +375,7 @@ async function smokeTest(baseUrl) {
   const teardown = () => {
     if (tornDownRef.value) return;
     tornDownRef.value = true;
+    diagnostics.add('Tearing down story-static http-server.');
     if (!state.exited) {
       try { server.kill(); } catch (_) {}
     }
@@ -363,24 +411,33 @@ async function smokeTest(baseUrl) {
       );
     }
     teardown();
+    flushDiagnostics(diagnostics);
     process.exit(1);
   }
 
   // 6. Smoke.
   let smokeError = null;
   try {
-    await smokeTest(`http://127.0.0.1:${port}/`);
-    console.log('story-static smoke passed.');
+    await smokeTest(`http://127.0.0.1:${port}/`, diagnostics);
   } catch (err) {
     smokeError = err;
     console.error('story-static smoke failed:', err.message || err);
+    if (err && err.stack) diagnostics.add(err.stack, 'stderr');
   }
 
   // 7. Tear down.
   teardown();
+  if (!smokeError) {
+    if (VERBOSE_TESTS) flushDiagnostics(diagnostics);
+    console.log('Story static smoke passed.');
+  } else {
+    flushDiagnostics(diagnostics);
+  }
   process.exit(smokeError ? 1 : 0);
 })().catch((err) => {
   console.error(err);
+  if (err && err.stack) diagnostics.add(err.stack, 'stderr');
+  flushDiagnostics(diagnostics);
   removeOwnershipToken();
   process.exit(1);
 });

--- a/skills/re-frame-pair2/tests/e2e/_helpers.cjs
+++ b/skills/re-frame-pair2/tests/e2e/_helpers.cjs
@@ -1,10 +1,12 @@
 /*
  * Shared helpers for pair2 e2e specs (rf2-cxik).
  *
- * - `runShim(skillRoot, fixtureDir, subcmd, args, env?)` — execute
+ * - `runShim(ctx, subcmd, args, env?)` — execute
  *   `bb scripts/ops.clj <subcmd> [args]` against the live fixture's
- *   nREPL. Returns { exit, stdout, stderr }. CWD is the fixture dir
- *   so ops.clj's port-file lookup finds the live shadow-cljs port.
+ *   nREPL, buffering stdout/stderr into ctx.diagnostics when present.
+ *   The older positional call shape is still accepted for focused
+ *   helper tests. Returns { exit, stdout, stderr }. CWD is the fixture
+ *   dir so ops.clj's port-file lookup finds the live shadow-cljs port.
  *
  * - `parseEdn(s)` — naive but adequate parser for the structured
  *   shapes we assert on (maps, vectors, keywords, strings, ints,
@@ -19,13 +21,106 @@
 const { spawnSync } = require('child_process');
 const path = require('path');
 
-function runShim(skillRoot, fixtureDir, subcmd, args = [], env = {}) {
+function isVerboseTests(env = process.env) {
+  return env.RF2_VERBOSE_TESTS === '1';
+}
+
+function createDiagnostics({ verbose = isVerboseTests() } = {}) {
+  const entries = [];
+
+  const writeLive = (line, stream) => {
+    if (!verbose) return;
+    const write = stream === 'stderr' ? console.error : console.log;
+    write(line);
+  };
+
+  return {
+    verbose,
+    add(line, stream = 'stdout') {
+      if (line == null) return;
+      const normalized = String(line).replace(/\r\n/g, '\n');
+      for (const part of normalized.split('\n')) {
+        entries.push({ stream, text: part });
+        writeLive(part, stream);
+      }
+    },
+    isEmpty() {
+      return entries.length === 0;
+    },
+    flush({ stdout = console.log, stderr = console.error } = {}) {
+      for (const entry of entries) {
+        if (entry.stream === 'stderr') stderr(entry.text);
+        else stdout(entry.text);
+      }
+    },
+  };
+}
+
+function flushDiagnostics(diagnostics) {
+  if (!diagnostics || diagnostics.verbose || diagnostics.isEmpty()) return;
+  console.error('--- pair2 e2e diagnostics ---');
+  diagnostics.flush({
+    stdout: (line) => console.error(line),
+    stderr: (line) => console.error(line),
+  });
+  console.error('-----------------------------');
+}
+
+function addChunk(diagnostics, prefix, chunk, stream = 'stdout') {
+  if (!diagnostics || !chunk) return;
+  const normalized = String(chunk).replace(/\r\n/g, '\n');
+  for (const line of normalized.split('\n')) {
+    if (line.length === 0) continue;
+    diagnostics.add(`${prefix}${line}`, stream);
+  }
+}
+
+function runShim(ctxOrSkillRoot, fixtureDirOrSubcmd, subcmdOrArgs, argsOrEnv = [], envOrEmpty = {}) {
+  let ctx = null;
+  let skillRoot;
+  let fixtureDir;
+  let subcmd;
+  let args;
+  let env;
+
+  if (ctxOrSkillRoot && typeof ctxOrSkillRoot === 'object') {
+    ctx = ctxOrSkillRoot;
+    skillRoot = ctx.skillRoot;
+    fixtureDir = ctx.fixtureDir;
+    subcmd = fixtureDirOrSubcmd;
+    args = Array.isArray(subcmdOrArgs) ? subcmdOrArgs : [];
+    env = Array.isArray(subcmdOrArgs) ? argsOrEnv : (subcmdOrArgs || {});
+  } else {
+    skillRoot = ctxOrSkillRoot;
+    fixtureDir = fixtureDirOrSubcmd;
+    subcmd = subcmdOrArgs;
+    args = argsOrEnv;
+    env = envOrEmpty;
+  }
+
+  args = Array.isArray(args) ? args : [];
+  env = env || {};
+
   const opsClj = path.join(skillRoot, 'scripts', 'ops.clj');
+  const diagnostics = ctx && ctx.diagnostics;
+  const label = ctx && ctx.spec ? ctx.spec : subcmd;
+  if (diagnostics) {
+    diagnostics.add(
+      `[pair2-e2e:${label}] process: bb ${opsClj} ${subcmd} ${args.join(' ')}`.trim(),
+    );
+  }
   const res = spawnSync('bb', [opsClj, subcmd, ...args], {
     cwd: fixtureDir,
     encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
     env: { ...process.env, ...env },
   });
+  if (diagnostics) {
+    diagnostics.add(`[pair2-e2e:${label}] bb exit ${res.status}`);
+    if (res.error) diagnostics.add(`[pair2-e2e:${label}] bb error ${res.error.message}`, 'stderr');
+    addChunk(diagnostics, `[pair2-e2e:${label}:stdout] `, res.stdout);
+    addChunk(diagnostics, `[pair2-e2e:${label}:stderr] `, res.stderr, 'stderr');
+  }
   return {
     exit: res.status,
     stdout: res.stdout || '',
@@ -156,8 +251,33 @@ async function openPage(ctx) {
   const browser = await playwright.chromium.launch({ headless: true });
   const context = await browser.newContext();
   const page = await context.newPage();
-  await page.goto(ctx.fixtureUrl);
+  const diagnostics = ctx && ctx.diagnostics;
+  const label = ctx && ctx.spec ? ctx.spec : 'open-page';
+  if (diagnostics) {
+    diagnostics.add(`[pair2-e2e:${label}] URL: ${ctx.fixtureUrl}`);
+  }
+  page.on('console', (msg) => {
+    if (diagnostics) diagnostics.add(`[pair2-e2e:${label}:browser:${msg.type()}] ${msg.text()}`);
+  });
+  page.on('pageerror', (err) => {
+    if (!diagnostics) return;
+    diagnostics.add(`[pair2-e2e:${label}:browser:pageerror] ${err.message}`, 'stderr');
+    if (err.stack) diagnostics.add(err.stack, 'stderr');
+  });
+  page.on('framenavigated', (frame) => {
+    if (diagnostics && frame === page.mainFrame()) {
+      diagnostics.add(`[pair2-e2e:${label}:browser:navigation] ${frame.url()}`);
+    }
+  });
+  await page.goto(ctx.fixtureUrl, { waitUntil: 'load' });
   return { browser, page };
 }
 
-module.exports = { runShim, parseEdn, openPage };
+module.exports = {
+  createDiagnostics,
+  flushDiagnostics,
+  isVerboseTests,
+  runShim,
+  parseEdn,
+  openPage,
+};

--- a/skills/re-frame-pair2/tests/e2e/_helpers.test.cjs
+++ b/skills/re-frame-pair2/tests/e2e/_helpers.test.cjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert/strict');
+const {
+  createDiagnostics,
+  flushDiagnostics,
+  isVerboseTests,
+} = require('./_helpers.cjs');
+
+const tests = [];
+
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+test('RF2_VERBOSE_TESTS=1 enables pair2 e2e verbose diagnostics', () => {
+  assert.equal(isVerboseTests({ RF2_VERBOSE_TESTS: '1' }), true);
+  assert.equal(isVerboseTests({ RF2_VERBOSE_TESTS: 'true' }), false);
+  assert.equal(isVerboseTests({}), false);
+});
+
+test('diagnostics buffer preserves stream routing until flush', () => {
+  const diagnostics = createDiagnostics({ verbose: false });
+  diagnostics.add('[pair2-e2e] fixture reachable');
+  diagnostics.add('page exploded\nstack line', 'stderr');
+
+  const stdout = [];
+  const stderr = [];
+  diagnostics.flush({
+    stdout: (line) => stdout.push(line),
+    stderr: (line) => stderr.push(line),
+  });
+
+  assert.deepEqual(stdout, ['[pair2-e2e] fixture reachable']);
+  assert.deepEqual(stderr, ['page exploded', 'stack line']);
+});
+
+test('failure flush prints quiet diagnostics to stderr only', () => {
+  const diagnostics = createDiagnostics({ verbose: false });
+  diagnostics.add('[pair2-e2e] running dispatch-trace.e2e.cjs');
+
+  const originalError = console.error;
+  const stderr = [];
+  console.error = (line) => stderr.push(line);
+  try {
+    flushDiagnostics(diagnostics);
+  } finally {
+    console.error = originalError;
+  }
+
+  assert.deepEqual(stderr, [
+    '--- pair2 e2e diagnostics ---',
+    '[pair2-e2e] running dispatch-trace.e2e.cjs',
+    '-----------------------------',
+  ]);
+});
+
+test('verbose diagnostics are live-only and not flushed again', () => {
+  const originalLog = console.log;
+  const originalError = console.error;
+  const stdout = [];
+  const stderr = [];
+  console.log = (line) => stdout.push(line);
+  console.error = (line) => stderr.push(line);
+  try {
+    const diagnostics = createDiagnostics({ verbose: true });
+    diagnostics.add('[pair2-e2e] fixture reachable');
+    diagnostics.add('page exploded', 'stderr');
+    flushDiagnostics(diagnostics);
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+
+  assert.deepEqual(stdout, ['[pair2-e2e] fixture reachable']);
+  assert.deepEqual(stderr, ['page exploded']);
+});
+
+let failed = 0;
+for (const { name, fn } of tests) {
+  try {
+    fn();
+  } catch (err) {
+    failed += 1;
+    console.error(`FAIL ${name}`);
+    console.error(err && err.stack ? err.stack : err);
+  }
+}
+
+if (failed > 0) {
+  console.error(`pair2 e2e helper tests: ${failed} failed.`);
+  process.exit(1);
+}
+
+console.log(`pair2 e2e helper tests: ${tests.length} passed.`);

--- a/skills/re-frame-pair2/tests/e2e/connect-discover.e2e.cjs
+++ b/skills/re-frame-pair2/tests/e2e/connect-discover.e2e.cjs
@@ -18,7 +18,7 @@ async function run(ctx) {
   // runtime — discover-app probes the live JS environment.
   const { browser } = await openPage(ctx);
   try {
-    const r = runShim(ctx.skillRoot, ctx.fixtureDir, 'discover');
+    const r = runShim(ctx, 'discover');
     if (r.exit !== 0) {
       throw new Error('discover exit ' + r.exit + ': ' + r.stderr);
     }

--- a/skills/re-frame-pair2/tests/e2e/dispatch-trace.e2e.cjs
+++ b/skills/re-frame-pair2/tests/e2e/dispatch-trace.e2e.cjs
@@ -22,7 +22,7 @@ async function run(ctx) {
 
     // Dispatch through pair2's sync shim. --sync gives us a deterministic
     // epoch id once drain settles.
-    const d = runShim(ctx.skillRoot, ctx.fixtureDir, 'dispatch', [
+    const d = runShim(ctx, 'dispatch', [
       '[:counter/inc]',
       '--sync',
     ]);
@@ -44,7 +44,7 @@ async function run(ctx) {
     }
 
     // Trace window should carry the epoch.
-    const t = runShim(ctx.skillRoot, ctx.fixtureDir, 'trace-recent', ['10000']);
+    const t = runShim(ctx, 'trace-recent', ['10000']);
     if (t.exit !== 0) throw new Error('trace exit ' + t.exit + ': ' + t.stderr);
     const tv = parseEdn(t.stdout);
     if (!tv || tv['ok?'] !== true) throw new Error('trace !ok?: ' + t.stdout);

--- a/skills/re-frame-pair2/tests/e2e/hot-reload-probe.e2e.cjs
+++ b/skills/re-frame-pair2/tests/e2e/hot-reload-probe.e2e.cjs
@@ -24,7 +24,7 @@ async function run(ctx) {
   const { browser } = await openPage(ctx);
   try {
     // Capture before
-    const before = runShim(ctx.skillRoot, ctx.fixtureDir, 'eval', [PROBE]);
+    const before = runShim(ctx, 'eval', [PROBE]);
     if (before.exit !== 0) {
       throw new Error('eval(before) exit ' + before.exit + ': ' + before.stderr);
     }
@@ -48,7 +48,7 @@ async function run(ctx) {
     try {
       // tail-build --probe waits for the value to flip; the default
       // --wait-ms is 5000.
-      const t = runShim(ctx.skillRoot, ctx.fixtureDir, 'tail-build', [
+      const t = runShim(ctx, 'tail-build', [
         '--probe',
         PROBE,
         '--wait-ms',
@@ -69,7 +69,7 @@ async function run(ctx) {
       }
 
       // Sanity: the probe should now read a different value.
-      const after = runShim(ctx.skillRoot, ctx.fixtureDir, 'eval', [PROBE]);
+      const after = runShim(ctx, 'eval', [PROBE]);
       if (after.exit !== 0) {
         throw new Error('eval(after) exit ' + after.exit + ': ' + after.stderr);
       }

--- a/skills/re-frame-pair2/tests/e2e/run.cjs
+++ b/skills/re-frame-pair2/tests/e2e/run.cjs
@@ -20,9 +20,15 @@
 const fs = require('fs');
 const path = require('path');
 const http = require('http');
+const {
+  createDiagnostics,
+  flushDiagnostics,
+  isVerboseTests,
+} = require('./_helpers.cjs');
 
 const HERE = __dirname;
 const SKILL_ROOT = path.resolve(HERE, '..', '..');
+const VERBOSE_TESTS = isVerboseTests();
 
 async function pingFixture(url, timeoutMs = 1500) {
   return new Promise((resolve) => {
@@ -51,6 +57,9 @@ function pickFixtureUrl() {
 async function main() {
   const fixtureDir = pickFixtureDir();
   const fixtureUrl = pickFixtureUrl();
+  const diagnostics = createDiagnostics({ verbose: VERBOSE_TESTS });
+  diagnostics.add(`[pair2-e2e] fixture URL: ${fixtureUrl}`);
+  diagnostics.add(`[pair2-e2e] fixture dir: ${fixtureDir || '(not found)'}`);
 
   const fixtureUp = await pingFixture(fixtureUrl);
   if (!fixtureUp) {
@@ -63,8 +72,9 @@ async function main() {
     );
     process.exit(0);
   }
+  diagnostics.add('[pair2-e2e] fixture reachable');
 
-  const ctx = { fixtureDir, fixtureUrl, skillRoot: SKILL_ROOT };
+  const ctx = { fixtureDir, fixtureUrl, skillRoot: SKILL_ROOT, diagnostics };
 
   const specs = fs
     .readdirSync(HERE)
@@ -73,28 +83,31 @@ async function main() {
 
   if (specs.length === 0) {
     console.error('[pair2-e2e] no spec files found in ' + HERE);
+    flushDiagnostics(diagnostics);
     process.exit(1);
   }
 
   let failures = 0;
   for (const spec of specs) {
     const specPath = path.join(HERE, spec);
-    console.log('[pair2-e2e] running ' + spec);
+    diagnostics.add('[pair2-e2e] running ' + spec);
     try {
       const mod = require(specPath);
       if (typeof mod.run !== 'function') {
         throw new Error('spec did not export `run(ctx)`');
       }
-      await mod.run(ctx);
-      console.log('[pair2-e2e]   ' + spec + ' PASS');
+      await mod.run({ ...ctx, spec });
+      diagnostics.add('[pair2-e2e]   ' + spec + ' PASS');
     } catch (err) {
       failures += 1;
-      console.error('[pair2-e2e]   ' + spec + ' FAIL: ' + (err.stack || err));
+      console.error('[pair2-e2e]   ' + spec + ' FAIL: ' + (err.message || err));
+      diagnostics.add('[pair2-e2e]   ' + spec + ' FAIL: ' + (err.stack || err), 'stderr');
     }
   }
 
   if (failures > 0) {
     console.error('[pair2-e2e] ' + failures + ' failed');
+    flushDiagnostics(diagnostics);
     process.exit(1);
   }
   console.log('[pair2-e2e] ' + specs.length + ' passed');

--- a/tools/mcp-conformance/scripts/run-live-pair2-overflow-hermetic.cjs
+++ b/tools/mcp-conformance/scripts/run-live-pair2-overflow-hermetic.cjs
@@ -85,6 +85,18 @@ const FIXTURE_DIR = path.join(
   'fixture',
 );
 const PAIR2_MCP_DIR = path.join(REPO_ROOT, 'tools', 'pair2-mcp');
+const {
+  createDiagnosticBuffer,
+  isVerboseTests,
+} = require(path.join(
+  REPO_ROOT,
+  'implementation',
+  'scripts',
+  'lib',
+  'browser-test-report.cjs',
+));
+const VERBOSE_TESTS = isVerboseTests();
+const DIAGNOSTICS = createDiagnosticBuffer();
 
 // Shadow-cljs writes its nREPL port file under whichever cache-root
 // the build is configured for. Default in 3.x is `.shadow-cljs/`; older
@@ -148,11 +160,37 @@ const INNER_TESTS = [
   },
 ];
 
+function recordLine(line, stream = 'stdout') {
+  DIAGNOSTICS.add(line, stream);
+  if (VERBOSE_TESTS) {
+    const write = stream === 'stderr' ? console.error : console.log;
+    write(line);
+  }
+}
+
+function recordChunk(prefix, chunk, stream = 'stdout') {
+  const normalized = String(chunk || '').replace(/\r\n/g, '\n');
+  for (const line of normalized.split('\n')) {
+    if (line.length === 0) continue;
+    recordLine(`${prefix}${line}`, stream);
+  }
+}
+
+function flushDiagnostics() {
+  if (VERBOSE_TESTS || DIAGNOSTICS.isEmpty()) return;
+  console.error('--- pair2 hermetic diagnostics ---');
+  DIAGNOSTICS.flush({
+    stdout: (line) => console.error(line),
+    stderr: (line) => console.error(line),
+  });
+  console.error('----------------------------------');
+}
+
 function log(msg) {
-  process.stdout.write(`[hermetic] ${msg}\n`);
+  recordLine(`[hermetic] ${msg}`);
 }
 function logErr(msg) {
-  process.stderr.write(`[hermetic] ${msg}\n`);
+  recordLine(`[hermetic] ${msg}`, 'stderr');
 }
 
 function exists(p) {
@@ -362,14 +400,23 @@ function runTrusted(name, args, cwd) {
   // comment at the top of this file for the contract. Passing the
   // absolute path is what keeps cross-spawn's `which.sync` from doing
   // its own cwd-relative walk.
+  log(`running ${name} ${args.join(' ')} in ${cwd} (bin=${bin})`);
   const r = crossSpawn.sync(bin, args, {
     cwd,
-    stdio: 'inherit',
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe'],
     env: process.env,
   });
+  if (r.stdout) recordChunk(`[${name}:stdout] `, r.stdout);
+  if (r.stderr) recordChunk(`[${name}:stderr] `, r.stderr, 'stderr');
+  if (r.error) {
+    throw r.error;
+  }
   if (r.status !== 0) {
     throw new Error(`${name} ${args.join(' ')} in ${cwd} exited ${r.status}`);
   }
+  log(`${name} exited ${r.status}`);
 }
 
 function resolvePlaywright() {
@@ -462,16 +509,17 @@ async function main() {
     log(`shadow-cljs exited code=${code} sig=${sig}`);
   });
   shadow.stdout.on('data', (d) => {
-    process.stdout.write('[shadow] ' + d.toString());
+    recordChunk('[shadow:stdout] ', d);
   });
   shadow.stderr.on('data', (d) => {
-    process.stderr.write('[shadow] ' + d.toString());
+    recordChunk('[shadow:stderr] ', d, 'stderr');
   });
 
   let browser = null;
 
   // Wire signal-driven cleanup so a CI cancel doesn't strand the JVM.
   const cleanup = () => {
+    log('cleanup requested');
     if (browser) {
       try { browser.close(); } catch {}
     }
@@ -489,6 +537,7 @@ async function main() {
     process.on(sig, () => {
       logErr(`caught ${sig} — tearing down`);
       cleanup();
+      flushDiagnostics();
       process.exit(130);
     });
   }
@@ -558,11 +607,18 @@ async function main() {
     browser = await playwright.chromium.launch({ headless: true });
     const context = await browser.newContext();
     const page = await context.newPage();
+    log(`browser URL ${FIXTURE_URL}`);
     page.on('console', (msg) => {
-      process.stdout.write(`[browser:${msg.type()}] ${msg.text()}\n`);
+      recordLine(`[browser:${msg.type()}] ${msg.text()}`);
     });
     page.on('pageerror', (err) => {
-      process.stderr.write(`[browser:error] ${err.message}\n`);
+      recordLine(`[browser:pageerror] ${err.message}`, 'stderr');
+      if (err.stack) recordLine(err.stack, 'stderr');
+    });
+    page.on('framenavigated', (frame) => {
+      if (frame === page.mainFrame()) {
+        recordLine(`[browser:navigation] ${frame.url()}`);
+      }
     });
     await page.goto(FIXTURE_URL, { waitUntil: 'load' });
     log('page loaded');
@@ -628,24 +684,29 @@ async function main() {
       SHADOW_CLJS_NREPL_PORT: String(port),
     };
     for (const test of INNER_TESTS) {
-      log(`running ${path.basename(test.path)} — ${test.name}`);
+      const testFile = path.basename(test.path);
+      log(`running ${testFile} - ${test.name}`);
       const testStatus = await new Promise((resolve, reject) => {
         const child = crossSpawn(process.execPath, [test.path], {
           cwd: MCP_CONFORMANCE_ROOT,
-          stdio: 'inherit',
+          stdio: ['ignore', 'pipe', 'pipe'],
           env: testEnv,
         });
+        child.stdout.on('data', (d) => recordChunk(`[${testFile}:stdout] `, d));
+        child.stderr.on('data', (d) => recordChunk(`[${testFile}:stderr] `, d, 'stderr'));
         child.on('error', reject);
         child.on('exit', (code, signal) => {
           // signal-terminated children report null exit codes; treat
           // the signal as a non-zero status so the conformance gate
           // fails loud rather than silently passing.
           if (code === null) {
+            log(`${testFile} killed by ${signal}`);
             reject(new Error(
               `${path.basename(test.path)} killed by ${signal}`,
             ));
             return;
           }
+          log(`${testFile} exited ${code}`);
           resolve(code);
         });
       });
@@ -673,6 +734,7 @@ async function main() {
 // timeout. Length set to cover cold Maven cache + cold chromium boot.
 const watchdog = setTimeout(() => {
   logErr(`watchdog timeout (${HERMETIC_TIMEOUT_MS}ms) — bailing`);
+  flushDiagnostics();
   process.exit(2);
 }, HERMETIC_TIMEOUT_MS);
 watchdog.unref();
@@ -680,12 +742,16 @@ watchdog.unref();
 main()
   .then(() => {
     clearTimeout(watchdog);
+    console.log(
+      `PAIR2-MCP live hermetic conformance passed (${INNER_TESTS.length} inner tests).`,
+    );
     process.exit(0);
   })
   .catch((err) => {
     clearTimeout(watchdog);
     logErr('FAIL: ' + (err && err.message ? err.message : err));
     if (err && err.stack) logErr(err.stack);
+    flushDiagnostics();
     // err.exitCode is set when the inner live-pair2-overflow.cjs itself
     // exited non-zero — surface it so CI distinguishes conformance
     // failure (1) from orchestration failure (2).


### PR DESCRIPTION
## Summary
- Quiet remaining Playwright/browser-style green paths behind RF2_VERBOSE_TESTS=1.
- Buffer story-static, pair2 hermetic, examples, and pair2 e2e diagnostics for red-path flushing.
- Add pair2 e2e helper tests for verbose detection and diagnostic buffering/flush behavior.

## Verification
- node --check examples/scripts/run-examples-tests.cjs
- node --check implementation/scripts/check-story-static.cjs
- node --check tools/mcp-conformance/scripts/run-live-pair2-overflow-hermetic.cjs
- node --check skills/re-frame-pair2/tests/e2e/_helpers.cjs; node --check skills/re-frame-pair2/tests/e2e/run.cjs; node --check skills/re-frame-pair2/tests/e2e/_helpers.test.cjs; node --check skills/re-frame-pair2/tests/e2e/connect-discover.e2e.cjs; node --check skills/re-frame-pair2/tests/e2e/dispatch-trace.e2e.cjs; node --check skills/re-frame-pair2/tests/e2e/hot-reload-probe.e2e.cjs
- node implementation/scripts/_browser-test-report.test.cjs
- node skills/re-frame-pair2/tests/e2e/_helpers.test.cjs
- node skills/re-frame-pair2/tests/e2e/run.cjs (soft-skip: fixture not available at http://localhost:8030)

## Not Run
- node implementation/scripts/check-story-static.cjs could not start because http-server/bin/http-server is not installed in implementation/node_modules.