### PR TITLE
test(story): cover unit gap matrix cases

### DIFF
--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -68,9 +68,9 @@
    :effective-args  {}
    :lifecycle       :ready})
 
-;; Forward declarations so phase fns (defined before record-error!) can
-;; project exceptions per IMPL-SPEC §5.5 without reordering the file.
-(declare record-error!)
+;; Forward declarations so phase fns (defined before record helpers) can
+;; project failures per IMPL-SPEC §5.5 without reordering the file.
+(declare record-error! record-loader-incomplete!)
 
 ;; ---- phase exception capture --------------------------------------------
 ;;
@@ -182,8 +182,13 @@
     ;; Evaluate :loaders-complete-when. In Stage 3 the predicate
     ;; resolves synchronously; Stage 6+ might add an async-retry shape.
     (let [complete? (loaders/evaluate-complete-when variant-id variant-body)]
-      (when complete?
-        (loaders/finish-loaders! variant-id)))))
+      (if complete?
+        (do
+          (loaders/finish-loaders! variant-id)
+          true)
+        (do
+          (record-loader-incomplete! variant-id variant-body)
+          false)))))
 
 ;; ---- error recording -----------------------------------------------------
 
@@ -198,6 +203,18 @@
                :data    (when (instance? #?(:clj clojure.lang.ExceptionInfo
                                             :cljs ExceptionInfo) err)
                           (ex-data err))}
+   :passed?   false})
+
+(defn- loader-incomplete-record
+  "Build the non-throwing projection used when a loader predicate is
+  false. The runtime cannot advance into events/play while the loader
+  contract says the variant is not ready; returning a failed assertion
+  keeps the result actionable without requiring a browser timeout."
+  [variant-body]
+  {:assertion :rf.error/loader-incomplete
+   :phase     :phase-1-loaders
+   :predicate (:loaders-complete-when variant-body)
+   :reason    "loaders-complete-when did not report completion; events and play were skipped"
    :passed?   false})
 
 (defn record-error!
@@ -221,6 +238,14 @@
            :event      event
            :error-msg  #?(:clj  (.getMessage ^Throwable dispatch-err)
                           :cljs (str dispatch-err))})))
+    record))
+
+(defn- record-loader-incomplete!
+  [variant-id variant-body]
+  (let [record (loader-incomplete-record variant-body)]
+    (try
+      (rf/dispatch-sync [::append-assertion record] {:frame variant-id})
+      (catch #?(:clj Throwable :cljs :default) _ nil))
     record))
 
 ;; ---- helper event registrations ------------------------------------------
@@ -303,15 +328,15 @@
   "Phase 1: drive loaders to completion. Thin wrapper that returns
   `ctx` so the orchestrator stays a clean threaded pipeline."
   [{:keys [variant-id] :as ctx}]
-  (run-loaders! variant-id)
-  ctx)
+  (assoc ctx :loaders-complete? (run-loaders! variant-id)))
 
 (defn- run-phase-2!
   "Phase 2: dispatch every `:events` entry, then mark events complete
   on the lifecycle machine."
-  [{:keys [variant-id] :as ctx}]
-  (run-events! variant-id)
-  (loaders/finish-events! variant-id)
+  [{:keys [variant-id loaders-complete?] :as ctx}]
+  (when loaders-complete?
+    (run-events! variant-id)
+    (loaders/finish-events! variant-id))
   ctx)
 
 (defn- run-phase-4!
@@ -320,8 +345,10 @@
 
   Phase 3 (render) is Stage 4's UI-shell concern and is not driven
   from this orchestrator."
-  [{:keys [variant-id play-events]}]
-  (play/execute-play! variant-id play-events))
+  [{:keys [variant-id play-events loaders-complete?]}]
+  (if loaders-complete?
+    (play/execute-play! variant-id play-events)
+    (async/resolved (read-assertions variant-id))))
 
 (defn- finalise-run!
   "Build and deliver the result map once phase 4's promise settles.

--- a/tools/story/test/re_frame/story_fx_stubs_test.clj
+++ b/tools/story/test/re_frame/story_fx_stubs_test.clj
@@ -167,3 +167,34 @@
     (is (contains? (fx-stubs/observed-fx-ids :story.fxlog/v) :http)
         "observed-fx-ids surfaces the stubbed fx after the run")
     (story/destroy-variant! :story.fxlog/v)))
+
+(deftest force-fx-stub-log-is-per-frame
+  (testing "two variants emitting the same fx id keep stub logs and effect assertions isolated by frame"
+    (rf/reg-event-fx :do/http-a
+      (fn [_ _]
+        {:fx [[:http {:url "/a"}]]}))
+    (rf/reg-event-fx :do/http-b
+      (fn [_ _]
+        {:fx [[:http {:url "/b"}]]}))
+    (story/reg-variant :story.fxisolation/a
+      {:decorators [[:rf.story/force-fx-stub :http {:status :ok}]]
+       :events     []
+       :play       [[:do/http-a]
+                    [:rf.assert/effect-emitted :http]]})
+    (story/reg-variant :story.fxisolation/b
+      {:decorators [[:rf.story/force-fx-stub :http {:status :ok}]]
+       :events     []
+       :play       [[:do/http-b]
+                    [:rf.assert/effect-emitted :http]]})
+    (let [ra (async/deref-blocking (story/run-variant :story.fxisolation/a) 5000)
+          rb (async/deref-blocking (story/run-variant :story.fxisolation/b) 5000)
+          log-a (frames/stub-call-log-for :story.fxisolation/a)
+          log-b (frames/stub-call-log-for :story.fxisolation/b)]
+      (is (every? :passed? (:assertions ra)))
+      (is (every? :passed? (:assertions rb)))
+      (is (= [{:url "/a"}] (mapv :payload log-a)))
+      (is (= [{:url "/b"}] (mapv :payload log-b)))
+      (is (= #{:http} (fx-stubs/observed-fx-ids :story.fxisolation/a)))
+      (is (= #{:http} (fx-stubs/observed-fx-ids :story.fxisolation/b))))
+    (story/destroy-variant! :story.fxisolation/a)
+    (story/destroy-variant! :story.fxisolation/b)))

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -440,6 +440,37 @@
           "events ran AFTER loaders"))
     (story/destroy-variant! :story.flow/v)))
 
+(deftest run-variant-blocks-events-when-loaders-incomplete
+  (testing "a false loaders-complete-when predicate keeps the variant in :loading and skips events/play"
+    (rf/reg-event-db :test/not-ready?
+      (fn [db _]
+        (assoc db :rf.story/loaders-complete? false)))
+    (rf/reg-event-db :test/load-but-not-ready
+      (fn [db _] (assoc db :loaded? true)))
+    (rf/reg-event-db :test/should-not-run
+      (fn [db _] (assoc db :events-ran? true)))
+    (story/reg-variant :story.flow/blocked
+      {:loaders               [[:test/load-but-not-ready]]
+       :loaders-complete-when :test/not-ready?
+       :events                [[:test/should-not-run]]
+       :play                  [[:rf.assert/path-equals [:events-ran?] true]]})
+    (let [r (async/deref-blocking (story/run-variant :story.flow/blocked) 5000)
+          incomplete (->> (:assertions r)
+                          (filter #(= :rf.error/loader-incomplete (:assertion %)))
+                          first)]
+      (is (= :loading (:lifecycle r))
+          "the lifecycle remains in the loader phase")
+      (is (true? (-> r :app-db :loaded?))
+          "loader events still run")
+      (is (not (contains? (:app-db r) :events-ran?))
+          "normal events are blocked until loaders complete")
+      (is (some? incomplete)
+          "the failure projection is explicit instead of a quiet hang")
+      (is (= :phase-1-loaders (:phase incomplete)))
+      (is (= 1 (count (:assertions r)))
+          "play assertions are skipped because the variant never became ready"))
+    (story/destroy-variant! :story.flow/blocked)))
+
 (deftest run-variant-frame-setup-decorator
   (testing ":frame-setup decorators fire :init events before loaders"
     (rf/reg-event-db :test/mock-init

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -206,6 +206,49 @@
     ;; The two variants are independent registrations
     (is (= 2 (count (story/variants-of :story.auth.login-form))))))
 
+(deftest form-b-desugars-to-separate-form-shape
+  (testing "Form-B combined authoring produces the same registry bodies as explicit separate forms"
+    (story/reg-story :story.formb.combined
+      {:doc       "Combined story."
+       :component :app.formb/view
+       :args      {:label "parent"}
+       :tags      #{:dev}
+       :variants  {:idle {:events [[:formb/init]]
+                           :args   {:state :idle}
+                           :tags   #{:dev :test}}
+                   :busy {:events [[:formb/init] [:formb/load]]
+                          :args   {:state :busy}
+                          :tags   #{:dev}}}})
+    (let [combined-story (dissoc (story/handler-meta :story :story.formb.combined)
+                                 :source)
+          combined-idle  (dissoc (story/handler-meta :variant :story.formb.combined/idle)
+                                 :source)
+          combined-busy  (dissoc (story/handler-meta :variant :story.formb.combined/busy)
+                                 :source)]
+      (story/clear-all!)
+      (story/install-canonical-vocabulary!)
+      (story/reg-story :story.formb.separate
+        {:doc       "Combined story."
+         :component :app.formb/view
+         :args      {:label "parent"}
+         :tags      #{:dev}})
+      (story/reg-variant :story.formb.separate/idle
+        {:events [[:formb/init]]
+         :args   {:state :idle}
+         :tags   #{:dev :test}})
+      (story/reg-variant :story.formb.separate/busy
+        {:events [[:formb/init] [:formb/load]]
+         :args   {:state :busy}
+         :tags   #{:dev}})
+      (is (= combined-story
+             (dissoc (story/handler-meta :story :story.formb.separate) :source)))
+      (is (= combined-idle
+             (dissoc (story/handler-meta :variant :story.formb.separate/idle) :source)))
+      (is (= combined-busy
+             (dissoc (story/handler-meta :variant :story.formb.separate/busy) :source)))
+      (is (= #{:story.formb.separate/idle :story.formb.separate/busy}
+             (story/variants-of :story.formb.separate))))))
+
 ;; ---- workspace ---------------------------------------------------------
 
 (deftest reg-workspace-grid

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -582,6 +582,26 @@
       (is (= 0 (:total s)))
       (is (false? (:all-passed? s))))))
 
+(deftest record-test-run-preserves-skipped-and-failure-counts
+  (testing "test-widget projection keeps skipped and failed counts actionable"
+    (let [summary (state/aggregate-summary
+                    [{:assertion :rf.assert/path-equals :passed? true}
+                     {:assertion :rf.assert/path-equals :passed? false}
+                     {:assertion :rf.assert/skipped     :passed? false}])
+          s       (state/record-test-run state/default-shell-state
+                                         :story.agg/failing
+                                         (assoc summary
+                                                :ran-at-ms 123
+                                                :elapsed-ms 7))
+          run     (get-in s [:tests :runs :story.agg/failing])]
+      (is (= :fail (:status run)))
+      (is (= 3 (:total run)))
+      (is (= 1 (:passed run)))
+      (is (= 1 (:failed run)))
+      (is (= 1 (:skipped run)))
+      (is (= 7 (:elapsed-ms run)))
+      (is (= 123 (:ran-at-ms run))))))
+
 (deftest test-mode-assertion-row-projection
   (testing "assertion-row maps a passing record to :status :pass"
     (let [row (test-mode/assertion-row


### PR DESCRIPTION
## Summary

- Add focused JVM coverage for Story coverage-matrix gaps: Form-B registry equivalence, loader-incomplete failure projection, per-frame fx-stub isolation, and assertion aggregation projection.
- Tighten Story runtime behavior so incomplete loader predicates stay in :loading, skip events/play, and return an actionable :rf.error/loader-incomplete assertion instead of quietly continuing.

## Verification

- cd tools/story; clojure -M:test -n re-frame.story-test -n re-frame.story-runtime-test -n re-frame.story-fx-stubs-test -n re-frame.story-ui-test
- cd tools/story; clojure -M:test
- cd implementation; npm ci
- cd implementation; npm run test:cljs

Do not merge yet; Mayor owns PR merging and bead closure.