### PR TITLE
fix(reagent-slim): chain hiccup emitter late-bind

### DIFF
--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -113,13 +113,13 @@
    :dispose-adapter!          dispose-adapter!})
 
 ;; Per rf2-uo7v + IMPL-SPEC §9.2: publish the hiccup-emitter installer
-;; through the late-bind hook table so re-frame.ssr (in
+;; through the chained late-bind hook table so re-frame.ssr (in
 ;; day8/re-frame2-ssr) resolves it at its ns-load. Without this, an
 ;; app pulling in the SSR seam would have to manually call
 ;; `(reagent-slim/set-hiccup-emitter! ssr/render-to-string)` —
 ;; the late-bind table makes that wiring automatic when both
 ;; artefacts are on the classpath.
-(late-bind/set-fn! :reagent/set-hiccup-emitter! set-hiccup-emitter!)
+(late-bind/chain-fn! :reagent/set-hiccup-emitter! set-hiccup-emitter!)
 
 ;; Each late-bind hook below is routed through `(substrate-adapter/
 ;; current-adapter)` per rf2-0d35 via `substrate-adapter/route-hook!`

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_cljs_test.cljs
@@ -20,11 +20,32 @@
   loads multiple adapter ns's no longer sees the last-loaded one
   silently win at the hook regardless of which adapter was
   `(rf/init!)`-installed. The `:reagent/set-hiccup-emitter!` hook is
-  still rebound at ns-load time per the SSR shipping convention.
+  chained at ns-load time per the SSR shipping convention.
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [re-frame.adapter.reagent-slim :as reagent-slim]))
+            [clojure.string :as str]
+            [re-frame.adapter.reagent-slim :as reagent-slim]
+            [re-frame.late-bind :as late-bind]))
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn- a-mock-emitter
+  "A toy hiccup -> HTML emitter so install-path tests assert wiring, not
+  real rendering."
+  [render-tree _opts]
+  (str "<mock>" (pr-str render-tree) "</mock>"))
+
+(defn- with-cleared-emitter
+  "Run `f` with the adapter's hiccup-emitter forced to nil."
+  [f]
+  (reagent-slim/set-hiccup-emitter! nil)
+  (try
+    (f)
+    (finally
+      (reagent-slim/set-hiccup-emitter! nil))))
 
 ;; ---------------------------------------------------------------------------
 ;; Adapter map shape (per IMPL-SPEC §2.1 + Spec 006 §CLJS reference)
@@ -103,28 +124,45 @@
 
 (deftest render-to-string-throws-without-emitter
   (testing "render-to-string raises when no hiccup-emitter installed"
-    ;; We don't call set-hiccup-emitter! here so the slot is nil.
-    ;; Note: if a previous test ran set-hiccup-emitter!, this assertion
-    ;; would fail. The slim adapter's emitter atom is module-private;
-    ;; we can't reset it from here. We either:
-    ;;   1. Trust test ordering (this test runs first under cljs.test
-    ;;      alpha-sort) — fragile.
-    ;;   2. Just confirm the fn shape exists.
-    ;; Settle for #2:
-    (is (fn? (:render-to-string reagent-slim/adapter)))))
+    (with-cleared-emitter
+      (fn []
+        (let [render-to-string (:render-to-string reagent-slim/adapter)]
+          (is (thrown? :default (render-to-string [:div] {}))))))))
 
 (deftest set-hiccup-emitter-installs-fn
   (testing "set-hiccup-emitter! lets render-to-string emit"
-    (reagent-slim/set-hiccup-emitter! (fn [tree _opts]
-                                        (str "hiccup:" (pr-str tree))))
-    (let [render-to-string (:render-to-string reagent-slim/adapter)]
-      (is (= "hiccup:[:div]"
-             (render-to-string [:div] {})))
-      ;; Reset for downstream determinism — the atom is module-private,
-      ;; so the cleanest way to get it back to nil is to install a
-      ;; throwing fn. Tests downstream don't actually use this; we
-      ;; leave the fn installed.
-      )))
+    (with-cleared-emitter
+      (fn []
+        (reagent-slim/set-hiccup-emitter! a-mock-emitter)
+        (let [render-to-string (:render-to-string reagent-slim/adapter)
+              tree             [:div "ok"]
+              html             (render-to-string tree {})]
+          (is (str/starts-with? html "<mock>")
+              "the installed emitter is what render-to-string invokes")
+          (is (str/includes? html (pr-str tree))
+              "the installed emitter received the render-tree the caller passed in"))))))
+
+(deftest set-hiccup-emitter-published-through-late-bind-chain
+  (testing "rf2-swoks: the Reagent Slim adapter chains its set-hiccup-emitter!
+            into `:reagent/set-hiccup-emitter!` at ns-load. Calling the
+            hook installs the emitter into the Reagent Slim adapter's
+            slot, so SSR's `re-frame.ssr.emit` ns-load can auto-wire
+            render-to-string without a direct `set-hiccup-emitter!`
+            call from user code."
+    (let [hook-fn (late-bind/get-fn :reagent/set-hiccup-emitter!)]
+      (is (some? hook-fn)
+          "the chained hook is registered after the Reagent Slim adapter ns has loaded")
+      (with-cleared-emitter
+        (fn []
+          (let [render-to-string (:render-to-string reagent-slim/adapter)]
+            (is (thrown? :default (render-to-string [:div] {}))
+                "precondition: emitter cleared"))
+          (hook-fn a-mock-emitter)
+          (let [render-to-string (:render-to-string reagent-slim/adapter)
+                html             (render-to-string [:div "via-chain"] {})]
+            (is (str/starts-with? html "<mock>")
+                "the chained hook wired the Reagent Slim adapter's emitter slot"))
+          (hook-fn nil))))))
 
 ;; ---------------------------------------------------------------------------
 ;; dispose-adapter! is a no-op

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_late_bind_publication_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_late_bind_publication_cljs_test.cljs
@@ -1,0 +1,88 @@
+(ns re-frame.adapter.reagent-slim-late-bind-publication-cljs-test
+  "Per rf2-swoks - pin the late-bind hook list the Reagent Slim adapter
+  publishes at ns-load time. A future refactor that adds, removes, or
+  renames a hook trips this test.
+
+  The Reagent Slim adapter publishes via two mechanisms:
+
+    (1) `substrate-adapter/route-hook!` - routed `:adapter/*` hooks
+        that run THIS adapter's impl iff this adapter is the
+        currently-installed one; otherwise chain to the previous
+        handler. Used for Reagent-shaped adapter hooks:
+        `:adapter/current-frame`, `:adapter/current-component`,
+        `:adapter/ratom`, `:adapter/ratom?`,
+        `:adapter/make-reaction`, `:adapter/add-on-dispose!`,
+        `:adapter/dispose!`, `:adapter/reactive?`, and
+        `:adapter/after-render`.
+
+    (2) `late-bind/chain-fn!` - chained hooks where every contributor
+        runs (independent of installed-adapter identity). Used for
+        `:reagent/set-hiccup-emitter!` so one SSR ns-load installs the
+        emitter into every loaded React-shaped adapter.
+
+  This file pins the SET of hook keys published and cross-checks it
+  against the authoritative late-bind directory.
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            ;; Loading the Reagent Slim adapter triggers its ns-load
+            ;; publication side effects - that's the point of this test.
+            [re-frame.adapter.reagent-slim]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.late-bind.directory :as directory]))
+
+(def ^:private expected-hook-keys
+  "Every late-bind hook the Reagent Slim adapter publishes at ns-load."
+  #{:adapter/current-frame
+    :adapter/current-component
+    :adapter/ratom
+    :adapter/ratom?
+    :adapter/make-reaction
+    :adapter/add-on-dispose!
+    :adapter/dispose!
+    :adapter/reactive?
+    :adapter/after-render
+    :reagent/set-hiccup-emitter!})
+
+(defn- producers
+  [entry]
+  (let [p (:producer-ns entry)]
+    (if (sequential? p) p [p])))
+
+(defn- directory-entry
+  [k]
+  (some (fn [entry] (when (= k (:key entry)) entry))
+        directory/hooks))
+
+(defn- directory-hook-keys-for
+  [producer-ns]
+  (->> directory/hooks
+       (filter #(some #{producer-ns} (producers %)))
+       (map :key)
+       set))
+
+(deftest reagent-slim-adapter-publishes-expected-hook-set
+  (testing "rf2-swoks: every hook key the Reagent Slim adapter publishes
+            at ns-load is registered in the late-bind table after the
+            adapter ns has loaded. A future refactor that drops or
+            renames a hook trips this test."
+    (doseq [k expected-hook-keys]
+      (is (some? (late-bind/get-fn k))
+          (str "expected the Reagent Slim adapter to publish " k
+               " through the late-bind hook table at ns-load")))))
+
+(deftest reagent-slim-adapter-hooks-cross-checked-against-directory
+  (testing "rf2-swoks: the Reagent Slim adapter's expected hook set is
+            exactly the set listed in the authoritative late-bind
+            directory (`re-frame.late-bind.directory/hooks`)."
+    (is (= expected-hook-keys
+           (directory-hook-keys-for 're-frame.adapter.reagent-slim))
+        "directory producer entries for re-frame.adapter.reagent-slim must match the pinned hook set")
+    (doseq [k expected-hook-keys
+            :let [entry (directory-entry k)]]
+      (is (some? entry)
+          (str "no directory entry for " k))
+      (is (some #{'re-frame.adapter.reagent-slim} (producers entry))
+          (str "directory entry for " k
+               " does not list re-frame.adapter.reagent-slim as a producer; "
+               "producers: " (pr-str (producers entry)))))))


### PR DESCRIPTION
## Summary
- Publish Reagent Slim's `:reagent/set-hiccup-emitter!` installer through `late-bind/chain-fn!`.
- Add Reagent Slim late-bind publication coverage cross-checked against the directory.
- Pin the chained emitter install path in the Reagent Slim render-to-string tests.

## Verification
- `npm run test:cljs`
- `npm run test:browser`
- `clojure -M:test -n re-frame.late-bind-drift-test` from `implementation/core`
- `clojure -M:test` from `implementation/adapters/reagent-slim`
- `git diff --check HEAD~1..HEAD`