### PR TITLE
test(causa): extend feature matrix browser followups

### DIFF
--- a/implementation/scripts/serve-and-run-causa-feature-gate.cjs
+++ b/implementation/scripts/serve-and-run-causa-feature-gate.cjs
@@ -144,6 +144,20 @@ function trimLines(lines, max = 80) {
   return lines.slice(Math.max(0, lines.length - max));
 }
 
+function scenarioDiagnostics(state) {
+  const keys = [
+    'sourceClicks',
+    'launchModes',
+    'schemaRecovery',
+    'multiFrame',
+  ];
+  const out = {};
+  for (const key of keys) {
+    if (state[key] != null) out[key] = state[key];
+  }
+  return Object.keys(out).length === 0 ? null : out;
+}
+
 async function readCausaState(page) {
   return page.evaluate(() => {
     function text(testId) {
@@ -239,6 +253,7 @@ async function collectFailureDiagnostics(page, scenario, state, browserState) {
     },
     causa: causaState,
     loadStats: state.loadStats || null,
+    scenarioState: scenarioDiagnostics(state),
   };
 }
 
@@ -279,6 +294,14 @@ function formatDiagnostics(diag) {
     for (const [k, v] of Object.entries(diag.loadStats)) {
       lines.push(`  ${k}=${v}`);
     }
+  }
+  if (diag.scenarioState) {
+    lines.push('');
+    lines.push('scenario-specific state:');
+    lines.push(JSON.stringify(diag.scenarioState, null, 2)
+      .split('\n')
+      .map((line) => `  ${line}`)
+      .join('\n'));
   }
   lines.push('');
   lines.push('last 20 trace events:');
@@ -332,7 +355,7 @@ async function runScenarios() {
       try {
         await page.goto(fullUrl, { waitUntil: 'load', timeout: TIMEOUT_MS });
         await Promise.race([
-          scenario.run(page, state),
+          scenario.run(page, state, { browserState, scenario }),
           new Promise((_, reject) => {
             setTimeout(() => reject(new Error(`Scenario timed out after ${TIMEOUT_MS}ms`)), TIMEOUT_MS);
           }),

--- a/testbeds/multi_frame/core.cljs
+++ b/testbeds/multi_frame/core.cljs
@@ -19,7 +19,9 @@
     Button A · Inc A          → frame :counter/a only
     Button B · Inc B          → frame :counter/b only
     Button X · Cross-bump     → handler in :counter/a fans out a
-                                `:fx [[:dispatch ... {:frame ...}]]`
+                                testbed bridge fx that dispatches with
+                                public `rf/dispatch` frame opts. Reserved
+                                `:dispatch` is intra-frame by contract.
                                 that bumps :counter/b AND appends to
                                 :log/entries. The three frames'
                                 app-dbs diverge in lockstep.
@@ -90,31 +92,35 @@
 ;;
 ;; The handler RUNS against :counter/a (Button X dispatches against
 ;; :counter/a). It returns three fx — one local `:db` write and two
-;; cross-frame `:dispatch` entries targeted at :counter/b and :log.
+;; testbed bridge entries targeted at :counter/b and :log.
 ;;
-;; Per [spec/002 §Dispatches issued from inside a handler body] the
-;; reserved `:dispatch` fx carries an explicit `{:frame ...}` opt; the
-;; fx walker (`do-fx`) calls `dispatch!` with the requested frame, so
-;; the queued event lands on :counter/b's router queue (not
-;; :counter/a's). Same for :log.
+;; Reserved `:dispatch` inherits the parent envelope frame, so this
+;; testbed uses a deliberately tiny custom fx that calls public
+;; `rf/dispatch` with explicit frame opts. That keeps the surface inside
+;; the testbed while giving consumers real browser-visible fan-out.
 ;;
 ;; A consumer that watches the trace stream sees three
 ;; `:event/dispatched` traces for one click — one per frame — and
 ;; three separate epoch ring buffer entries.
+
+(rf/reg-fx ::dispatch-to-frame
+  (fn [_ctx {:keys [event frame]}]
+    (rf/dispatch event {:frame frame})))
 
 (rf/reg-event-fx ::cross-bump
   (fn [{:keys [db]} _ev]
     {;; Local write against :counter/a.
      :db (update db :n (fnil inc 0))
      :fx [;; HOT PATH — cross-frame dispatch to :counter/b.
-          [:dispatch [::inc] {:frame frame-b}]
+          [::dispatch-to-frame {:event [::inc]
+                                :frame frame-b}]
           ;; HOT PATH — cross-frame dispatch to :log; carries the
           ;; bridge's source-frame id verbatim as evidence the
           ;; framework didn't quietly rewrite it.
-          [:dispatch [::log-append {:from frame-a
-                                    :to   #{frame-b frame-log}
-                                    :kind :cross-bump}]
-           {:frame frame-log}]]}))
+          [::dispatch-to-frame {:event [::log-append {:from frame-a
+                                                      :to   #{frame-b frame-log}
+                                                      :kind :cross-bump}]
+                                :frame frame-log}]]}))
 
 ;; ----------------------------------------------------------------------------
 ;; Views
@@ -163,6 +169,11 @@
         a fan-out from " [:code ":counter/a"]
     " that bumps " [:code ":counter/b"] " and appends to "
     [:code ":log"] " in one drain."]
+   [:p {:data-testid "multi-frame-fanout-browser-semantics"
+        :style       {:color "#666"}}
+    "The browser gate asserts direct A/B isolation, cross-frame fan-out
+     into B and log, and Causa panel selection across the resulting
+     frame-tagged traces."]
 
    [:div {:style {:display :flex :flex-wrap :wrap :align-items :flex-start}}
     [rf/frame-provider {:frame frame-a}
@@ -179,7 +190,7 @@
     ;; reads the React-context default (`:rf/default`) and supplies
     ;; the target frame explicitly via the two-arg dispatch form.
     ;; The handler then fans out to :counter/b and :log via cross-
-    ;; frame `:dispatch` fx (see ::cross-bump above).
+    ;; frame bridge fx (see ::cross-bump above).
     [:button {:data-testid "cross-bump"
               :on-click    #(rf/dispatch [::cross-bump] {:frame frame-a})}
      "Cross-bump (A → B + log)"]]])

--- a/testbeds/schema_violation/core.cljs
+++ b/testbeds/schema_violation/core.cljs
@@ -20,6 +20,10 @@
             ;; Required before any reg-app-schema / :spec metadata is
             ;; consumed by validation.
             [re-frame.schemas]
+            ;; Publish Malli into the schemas artefact. Without this adapter
+            ;; CLJS schema checks soft-pass by design, so the browser testbed
+            ;; would expose counters but no recovery traces.
+            [re-frame.schemas.malli]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
@@ -139,6 +143,11 @@
    [:h1 "schema-violation testbed"]
    [:p "Each button triggers exactly one :where surface of "
     [:code ":rf.error/schema-validation-failure"] "."]
+   [:p {:data-testid "schema-recovery-browser-semantics"
+        :style       {:color "#666"}}
+    "Malli validation is loaded for this browser build; the feature gate
+     asserts rollback, skipped handlers, skipped fx, and the matching
+     Causa timeline traces."]
    [:div {:style {:display :flex :gap "0.5em" :flex-wrap :wrap}}
     [:button {:data-testid "violate-app-db"
               :on-click #(dispatch [::violate-app-db])}

--- a/tools/causa/testbeds/feature_matrix/README.md
+++ b/tools/causa/testbeds/feature_matrix/README.md
@@ -26,14 +26,21 @@ state, the last trace rows, load stats when applicable, and a screenshot path.
 
 ## Current slice
 
-This first gate pass covers 19 matrix rows with deterministic browser
-substrates and includes the 20-event/load re-check. It intentionally leaves
-these rows or sub-rows for follow-up work:
+This gate covers the deterministic browser substrates plus the 20-event/load
+re-check. It now exercises the follow-up surfaces directly:
 
-- Open in Editor / Source Coordinates: unit coverage exists, but this browser
-  gate does not yet click source chips across every panel.
-- Pop-out, Docking, and Inline Embedding: not yet exercised by this browser
-  gate.
-- Schema recovery and multi-frame fan-out: the shared testbeds are staged, but
-  the gate currently asserts stable substrate and panel handoff only where the
-  browser build does not yet expose the full recovery/fan-out semantics.
+- Open in Editor / Source Coordinates: trace and issues source chips are
+  clicked in the browser. Failures include the panel, source coordinate,
+  expected editor URI, observed bridge traces, network outcome, and screenshot.
+- Pop-out, Docking, and Inline Embedding: the current shell exposes the overlay
+  surface only. The gate asserts that the right-side overlay leaves the left
+  host app clickable, and records explicit current-build observations for
+  pop-out, docking, and inline public-mount availability.
+- Schema recovery: the schema testbed loads the Malli adapter so browser runs
+  assert rollback, skipped handlers, skipped fx, and the Causa schema panel's
+  current row/empty-state projection.
+- Multi-frame fan-out: the multi-frame testbed uses a testbed-only bridge fx to
+  dispatch into explicit frames. The gate asserts direct A/B isolation, fan-out
+  into `:counter/b` and `:log`, per-frame epoch history, trace selection,
+  event-detail projection/orphan-state behavior, causality graph visibility,
+  and the time-travel panel's current `:counter/b` target-frame projection.

--- a/tools/causa/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/causa/testbeds/feature_matrix/scenarios.cjs
@@ -196,6 +196,371 @@ async function waitForTraceMatch(page, pattern, label, timeoutMs = 10000) {
   );
 }
 
+function failWithDetails(message, details) {
+  throw new Error(`${message}: ${JSON.stringify(details, null, 2)}`);
+}
+
+function ensureStateList(state, key) {
+  if (!Array.isArray(state[key])) state[key] = [];
+  return state[key];
+}
+
+async function clickSourceCoordChip(page, { panel, sourceIncludes = [] }) {
+  const needles = Array.isArray(sourceIncludes) ? sourceIncludes : [sourceIncludes];
+  return page.evaluate(({ panel: targetPanel, needles: targetNeedles }) => {
+    const root = document.getElementById('rf-causa-root');
+    const selectors = {
+      trace: '[data-testid^="rf-causa-trace-row-"] button[data-testid$="-source-coord"]',
+      issues: '[data-testid^="rf-causa-issues-row-"] button[data-testid$="-source"]',
+      hydration: '[data-testid="rf-causa-hydration-source-coord"] button',
+    };
+    if (!root) return { clicked: false, reason: 'Causa root missing', candidates: [] };
+    const selector = selectors[targetPanel] || 'button[data-testid*="source"]';
+    const buttons = Array.from(root.querySelectorAll(selector));
+    const candidates = buttons.map((button) => {
+      const rect = button.getBoundingClientRect();
+      return {
+        testId: button.getAttribute('data-testid'),
+        text: (button.textContent || '').trim(),
+        visible: rect.width > 0 && rect.height > 0,
+      };
+    });
+    const target = buttons.find((button) => {
+      const text = (button.textContent || '').trim();
+      const visible = button.getBoundingClientRect().width > 0 &&
+        button.getBoundingClientRect().height > 0;
+      return visible && targetNeedles.every((needle) => !needle || text.includes(needle));
+    });
+    if (!target) {
+      return {
+        clicked: false,
+        reason: `No ${targetPanel} source-coordinate chip matched ${JSON.stringify(targetNeedles)}`,
+        candidates: candidates.slice(0, 20),
+      };
+    }
+    const sourceCoord = (target.textContent || '').trim();
+    const testId = target.getAttribute('data-testid');
+    target.click();
+    return { clicked: true, panel: targetPanel, sourceCoord, testId, candidates: candidates.slice(0, 20) };
+  }, { panel, needles });
+}
+
+async function assertSourceCoordBridge(page, state, ctx, opts) {
+  const beforeUrl = page.url();
+  const requestStart = ctx && ctx.browserState ? ctx.browserState.requestFailures.length : 0;
+  const click = await clickSourceCoordChip(page, opts);
+  if (!click.clicked) {
+    failWithDetails('Could not click source-coordinate chip', {
+      panel: opts.panel,
+      sourceIncludes: opts.sourceIncludes,
+      url: beforeUrl,
+      observed: click,
+    });
+  }
+
+  const expectedUri = click.sourceCoord
+    ? `vscode://file/${click.sourceCoord}:1`
+    : null;
+  const events = await waitForValue(
+    async () => readTrace(page),
+    (traceEvents) => {
+      const hasOpenEvent = traceEvents.some((event) =>
+        event.includes(':rf.causa/open-in-editor') &&
+        event.includes(click.sourceCoord));
+      const hasBridgeFx = traceEvents.some((event) =>
+        event.includes(':rf.editor/open') &&
+        (!expectedUri || event.includes(expectedUri) || event.includes('vscode://file/')));
+      return hasOpenEvent && hasBridgeFx;
+    },
+    {
+      timeoutMs: 10000,
+      description: `open-in-editor bridge for ${opts.panel} ${click.sourceCoord}`,
+    },
+  );
+  await sleep(150);
+  const requestFailures = ctx && ctx.browserState
+    ? ctx.browserState.requestFailures.slice(requestStart)
+    : [];
+  const afterUrl = page.url();
+  const record = {
+    panel: opts.panel,
+    sourceCoord: click.sourceCoord,
+    testId: click.testId,
+    expectedUri,
+    beforeUrl,
+    afterUrl,
+    requestFailures,
+    observedOpenDispatch: events.some((event) =>
+      event.includes(':rf.causa/open-in-editor') && event.includes(click.sourceCoord)),
+    observedBridgeFx: events.some((event) =>
+      event.includes(':rf.editor/open') &&
+      (!expectedUri || event.includes(expectedUri) || event.includes('vscode://file/'))),
+  };
+  ensureStateList(state, 'sourceClicks').push(record);
+  if (afterUrl !== beforeUrl) {
+    failWithDetails('Source-coordinate click changed the page URL', record);
+  }
+  return record;
+}
+
+async function assertOverlayLaunchModes(page, state) {
+  await expectTextEquals(page.locator('span').first(), '5', 10000);
+  const rootBeforeOpen = await page.locator('#rf-causa-root').count();
+  await openCausa(page);
+  const overlay = await page.evaluate(() => {
+    const shell = document.querySelector('[data-testid="rf-causa-shell"]');
+    const plus = Array.from(document.querySelectorAll('button'))
+      .filter((button) => !button.closest('#rf-causa-root'))
+      .find((button) => (button.textContent || '').trim() === '+');
+    function rect(el) {
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return {
+        left: r.left,
+        top: r.top,
+        right: r.right,
+        bottom: r.bottom,
+        width: r.width,
+        height: r.height,
+        centerX: r.left + r.width / 2,
+        centerY: r.top + r.height / 2,
+      };
+    }
+    const shellRect = rect(shell);
+    const plusRect = rect(plus);
+    const top = plusRect
+      ? document.elementFromPoint(plusRect.centerX, plusRect.centerY)
+      : null;
+    return {
+      shell: shellRect,
+      hostPlus: plusRect,
+      hostPlusText: plus ? (plus.textContent || '').trim() : null,
+      topAtHostPlus: top ? {
+        tag: top.tagName,
+        text: (top.textContent || '').trim(),
+        testId: top.getAttribute('data-testid'),
+        inCausa: Boolean(top.closest('#rf-causa-root')),
+      } : null,
+    };
+  });
+  if (!overlay.shell || overlay.shell.width < 200) {
+    failWithDetails('Causa overlay geometry was not measurable', { mode: 'overlay', observed: overlay });
+  }
+  if (!overlay.hostPlus) {
+    failWithDetails('Host app + button missing while Causa overlay is open', { mode: 'overlay', observed: overlay });
+  }
+  if (overlay.hostPlus.centerX >= overlay.shell.left) {
+    failWithDetails('Causa overlay obscures the left host-app control area', { mode: 'overlay-left-host', observed: overlay });
+  }
+  if (overlay.topAtHostPlus && overlay.topAtHostPlus.inCausa) {
+    failWithDetails('Causa chrome is topmost over the left host-app + button', { mode: 'overlay-left-host', observed: overlay });
+  }
+  await page.mouse.click(overlay.hostPlus.centerX, overlay.hostPlus.centerY);
+  await expectTextEquals(page.locator('span').first(), '6', 5000);
+
+  const popout = await page.evaluate(() => {
+    const core = window.day8 &&
+      window.day8.re_frame2_causa &&
+      window.day8.re_frame2_causa.core;
+    const keys = core ? Object.keys(core).sort() : [];
+    const fn = core && core.popout_BANG_;
+    if (typeof fn !== 'function') {
+      return { available: false, implemented: false, reason: 'day8.re_frame2_causa.core.popout_BANG_ not exported in this browser bundle', keys };
+    }
+    try {
+      const beforeUrl = location.href;
+      const value = fn();
+      return {
+        available: true,
+        implemented: false,
+        beforeUrl,
+        afterUrl: location.href,
+        returnType: typeof value,
+        keys,
+      };
+    } catch (err) {
+      return { available: true, implemented: false, threw: String(err && (err.stack || err.message || err)), keys };
+    }
+  });
+
+  const inline = await page.evaluate(() => {
+    const panels = window.day8 &&
+      window.day8.re_frame2_causa &&
+      window.day8.re_frame2_causa.panels;
+    const keys = panels ? Object.keys(panels).sort() : [];
+    return {
+      available: false,
+      implemented: false,
+      reason: 'No public inline panel mount/export is present in this browser bundle',
+      panelNamespaces: keys,
+    };
+  });
+
+  state.launchModes = {
+    overlay: {
+      rootBeforeOpen,
+      shellRect: overlay.shell,
+      hostPlusRect: overlay.hostPlus,
+      hostClickObserved: true,
+      leftHostAreaUnobscured: true,
+    },
+    popout,
+    docking: {
+      available: false,
+      implemented: false,
+      reason: 'No browser docking control is exposed by the current Causa shell.',
+    },
+    inline,
+  };
+}
+
+async function readSchemaHostState(page) {
+  return page.evaluate(() => {
+    function text(id) {
+      const el = document.querySelector(`[data-testid="${id}"]`);
+      return el ? (el.textContent || '').trim() : null;
+    }
+    return {
+      token: text('auth-token'),
+      appDbCount: Number(text('app-db-count')),
+      eventCount: Number(text('event-count')),
+      cofxCount: Number(text('cofx-count')),
+      fxCount: Number(text('fx-count')),
+      semantics: text('schema-recovery-browser-semantics'),
+    };
+  });
+}
+
+async function readMultiFrameHostState(page) {
+  return page.evaluate(() => {
+    function text(id) {
+      const el = document.querySelector(`[data-testid="${id}"]`);
+      return el ? (el.textContent || '').trim() : null;
+    }
+    return {
+      nA: Number(text('n-A')),
+      nB: Number(text('n-B')),
+      logCount: Number(text('log-count')),
+      logEntries: text('log-entries'),
+      semantics: text('multi-frame-fanout-browser-semantics'),
+    };
+  });
+}
+
+async function readFrameEpochSummary(page) {
+  return page.evaluate(() => {
+    const cljs = window.cljs && window.cljs.core;
+    const rf = window.re_frame && window.re_frame.core;
+    if (!cljs || !rf || typeof rf.epoch_history !== 'function') {
+      return { ok: false, reason: 'epoch_history unavailable', frames: {} };
+    }
+    function keyword(s) {
+      const trimmed = String(s).replace(/^:/, '');
+      const parts = trimmed.split('/');
+      if (parts.length === 2) {
+        return cljs.keyword.call
+          ? cljs.keyword.call(null, parts[0], parts[1])
+          : cljs.keyword(parts[0], parts[1]);
+      }
+      return cljs.keyword.call
+        ? cljs.keyword.call(null, trimmed)
+        : cljs.keyword(trimmed);
+    }
+    function history(frame) {
+      const records = [];
+      let s = cljs.seq(rf.epoch_history(keyword(frame)));
+      while (s) {
+        records.push(cljs.pr_str(cljs.first(s)));
+        s = cljs.next(s);
+      }
+      return { count: records.length, last: records.slice(-5) };
+    }
+    return {
+      ok: true,
+      frames: {
+        ':counter/a': history(':counter/a'),
+        ':counter/b': history(':counter/b'),
+        ':log': history(':log'),
+      },
+    };
+  });
+}
+
+async function setCausaTargetFrame(page, frame) {
+  const result = await page.evaluate((targetFrame) => {
+    const cljs = window.cljs && window.cljs.core;
+    const rf = window.re_frame && window.re_frame.core;
+    const dispatch = rf && (rf.dispatch_STAR_ ||
+      (window.re_frame.router && window.re_frame.router.dispatch_BANG_));
+    if (!cljs || typeof dispatch !== 'function') {
+      return {
+        ok: false,
+        reason: 'cljs.core or re_frame.core.dispatch_STAR_ unavailable',
+        reFrameCoreKeys: rf ? Object.keys(rf).sort().slice(0, 40) : [],
+      };
+    }
+    function keyword(s) {
+      const trimmed = String(s).replace(/^:/, '');
+      const parts = trimmed.split('/');
+      if (parts.length === 2) {
+        return cljs.keyword.call
+          ? cljs.keyword.call(null, parts[0], parts[1])
+          : cljs.keyword(parts[0], parts[1]);
+      }
+      return cljs.keyword.call
+        ? cljs.keyword.call(null, trimmed)
+        : cljs.keyword(trimmed);
+    }
+    const event = cljs.PersistentVector.fromArray([
+      keyword(':rf.causa/set-target-frame'),
+      keyword(targetFrame),
+    ], true);
+    const opts = cljs.hash_map(keyword(':frame'), keyword(':rf/causa'));
+    if (dispatch.cljs$core$IFn$_invoke$arity$2) {
+      dispatch.cljs$core$IFn$_invoke$arity$2(event, opts);
+    } else {
+      dispatch(event, opts);
+    }
+    return { ok: true, targetFrame };
+  }, frame);
+  if (!result.ok) {
+    failWithDetails('Could not set Causa target frame', { frame, observed: result });
+  }
+}
+
+async function clickTraceRowByFrame(page, { frame, event }) {
+  const result = await page.evaluate(({ targetFrame, targetEvent }) => {
+    const root = document.getElementById('rf-causa-root');
+    if (!root) return { clicked: false, reason: 'Causa root missing', candidates: [] };
+    const rows = Array.from(root.querySelectorAll('[data-testid^="rf-causa-trace-row-"]'));
+    const candidates = rows.map((row) => ({
+      testId: row.getAttribute('data-testid'),
+      text: (row.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 240),
+    }));
+    const target = rows.find((row) => {
+      const text = (row.textContent || '').trim();
+      return text.includes(targetFrame) && text.includes(targetEvent);
+    });
+    if (!target) {
+      return {
+        clicked: false,
+        reason: `No trace row matched frame=${targetFrame} event=${targetEvent}`,
+        candidates: candidates.slice(0, 20),
+      };
+    }
+    target.click();
+    return {
+      clicked: true,
+      testId: target.getAttribute('data-testid'),
+      text: (target.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 240),
+    };
+  }, { targetFrame: frame, targetEvent: event });
+  if (!result.clicked) {
+    failWithDetails('Could not select trace row by frame', { frame, event, observed: result });
+  }
+  return result;
+}
+
 async function readTraceCounts(page) {
   const text = ((await page.locator('[data-testid="rf-causa-trace-counts"]').textContent()) || '').trim();
   const match = /(\d+)\s*\/\s*(\d+)\s+in view/.exec(text);
@@ -268,7 +633,24 @@ async function runShellFeatureSweep(page) {
   await expectVisible(page.locator('[data-testid="rf-causa-mcp-empty-no-activity"]'), 5000);
 }
 
-async function runExceptionSchemaHttp(page) {
+async function runSourceCoordinatesAndLaunchModes(page, state, ctx) {
+  await assertOverlayLaunchModes(page, state);
+  await clickSidebar(page, 'trace', 'rf-causa-trace');
+  await clearTrace(page);
+  await clickHostButtonByLabel(page, '+');
+  await waitForTraceMatch(page, /counter\/core\.cljs/, 'counter source-coordinate trace');
+  await waitForValue(
+    () => page.locator('[data-testid^="rf-causa-trace-row-"] button[data-testid$="-source-coord"]').count(),
+    (count) => count > 0,
+    { timeoutMs: 5000, description: 'trace source-coordinate chips' },
+  );
+  await assertSourceCoordBridge(page, state, ctx, {
+    panel: 'trace',
+    sourceIncludes: 'counter/core.cljs',
+  });
+}
+
+async function runExceptionSchemaHttp(page, state, ctx) {
   await openCausa(page);
   await clearTrace(page);
 
@@ -285,21 +667,91 @@ async function runExceptionSchemaHttp(page) {
 
   await clickSidebar(page, 'issues', 'rf-causa-issues-ribbon');
   await expectVisible(page.locator('[data-testid="rf-causa-issues-feed"]'), 5000);
+  await assertSourceCoordBridge(page, state, ctx, { panel: 'issues' });
   await clickSidebar(page, 'trace', 'rf-causa-trace');
   await expectVisible(page.locator('[data-testid="rf-causa-trace-feed"]'), 5000);
 }
 
-async function runSchemaViolation(page) {
+async function runSchemaViolation(page, state) {
+  await openCausa(page);
+  await clearTrace(page);
   for (const id of ['violate-app-db', 'violate-event', 'violate-cofx', 'violate-fx-args']) {
     await clickTestId(page, id);
   }
-  await expectTextEquals(page.locator('[data-testid="auth-token"]'), '42', 5000);
-  await expectNumericTextAtLeast(page.locator('[data-testid="event-count"]'), 1, 5000);
-  await expectNumericTextAtLeast(page.locator('[data-testid="cofx-count"]'), 1, 5000);
-  await expectNumericTextAtLeast(page.locator('[data-testid="fx-count"]'), 1, 5000);
-  await openCausa(page);
+  const host = await waitForValue(
+    () => readSchemaHostState(page),
+    (snapshot) =>
+      snapshot.token === 'seed-token' &&
+      snapshot.appDbCount === 0 &&
+      snapshot.eventCount === 0 &&
+      snapshot.cofxCount === 0 &&
+      snapshot.fxCount === 1,
+    { timeoutMs: 10000, description: 'schema recovery host state' },
+  );
+  const expectedWheres = [':app-db', ':event', ':cofx', ':fx-args'];
+  const events = await waitForValue(
+    async () => readTrace(page),
+    (traceEvents) => expectedWheres.every((where) =>
+      traceEvents.some((event) =>
+        event.includes(':rf.error/schema-validation-failure') &&
+        event.includes(`:where ${where}`))),
+    { timeoutMs: 10000, description: 'schema validation failure traces for all recovery surfaces' },
+  );
+  const schemaEvents = events.filter((event) => event.includes(':rf.error/schema-validation-failure'));
+  const missingWheres = expectedWheres.filter((where) =>
+    !schemaEvents.some((event) => event.includes(`:where ${where}`)));
+  const fxWasHandled = events.some((event) =>
+    event.includes(':rf.fx/handled') &&
+    event.includes(':schema-violation.core/violate-fx'));
+  if (missingWheres.length > 0 || fxWasHandled) {
+    failWithDetails('Schema recovery traces did not match expected recovery surface', {
+      expectedWheres,
+      missingWheres,
+      expectedFxArgsRecovery: 'fx args failure skips the offending fx handler',
+      observedFxHandled: fxWasHandled,
+      host,
+      schemaEvents,
+    });
+  }
+  state.schemaRecovery = {
+    host,
+    observedWheres: expectedWheres,
+    validationTraceCount: schemaEvents.length,
+    appDbRollbackObserved: host.token === 'seed-token',
+    eventHandlerSkipped: host.eventCount === 0,
+    cofxHandlerSkipped: host.cofxCount === 0,
+    fxArgsSkipped: !fxWasHandled && host.fxCount === 1,
+  };
   await clickSidebar(page, 'schemas', 'rf-causa-schema-violation-timeline');
   await expectVisible(page.locator('[data-testid="rf-causa-schema-violation-timeline"]'), 5000);
+  const timelineProjection = await page.evaluate(() => {
+    function text(testId) {
+      const el = document.querySelector(`[data-testid="${testId}"]`);
+      return el ? (el.textContent || '').trim() : null;
+    }
+    return {
+      rowCount: document.querySelectorAll('[data-testid^="rf-causa-schema-timeline-row-"]').length,
+      dotCount: document.querySelectorAll('circle[data-testid^="rf-causa-schema-timeline-row-"][data-testid*="-dot-"]').length,
+      noSchemas: text('rf-causa-schema-timeline-empty-no-schemas'),
+      noViolations: text('rf-causa-schema-timeline-empty-no-violations'),
+    };
+  });
+  state.schemaRecovery.timelineProjection = timelineProjection;
+  if (timelineProjection.rowCount > 0 && timelineProjection.dotCount < 4) {
+    failWithDetails('Schema timeline rendered rows without the expected recovery dots', {
+      expectedDotCount: 4,
+      observed: timelineProjection,
+      schemaEvents,
+    });
+  }
+  if (timelineProjection.rowCount === 0 &&
+      !timelineProjection.noSchemas &&
+      !timelineProjection.noViolations) {
+    failWithDetails('Schema timeline rendered neither rows nor an explicit empty state', {
+      observed: timelineProjection,
+      schemaEvents,
+    });
+  }
 }
 
 async function runHttpToggle(page) {
@@ -329,16 +781,115 @@ async function runHttpToggle(page) {
   await expectVisible(page.locator('[data-testid="rf-causa-issues-feed"]'), 5000);
 }
 
-async function runMultiFrame(page) {
+async function runMultiFrame(page, state) {
+  await openCausa(page);
+  await clearTrace(page);
   await clickTestId(page, 'inc-A');
   await clickTestId(page, 'inc-B');
-  await expectTextEquals(page.locator('[data-testid="n-A"]'), '1', 5000);
-  await expectTextEquals(page.locator('[data-testid="n-B"]'), '1', 5000);
+  const isolated = await waitForValue(
+    () => readMultiFrameHostState(page),
+    (snapshot) => snapshot.nA === 1 && snapshot.nB === 1 && snapshot.logCount === 0,
+    { timeoutMs: 5000, description: 'direct A/B frame isolation' },
+  );
   await clickTestId(page, 'cross-bump');
-  await expectNumericTextAtLeast(page.locator('[data-testid="n-A"]'), 2, 5000);
-  await openCausa(page);
+  const fanout = await waitForValue(
+    () => readMultiFrameHostState(page),
+    (snapshot) => snapshot.nA === 2 && snapshot.nB === 2 && snapshot.logCount === 1,
+    { timeoutMs: 10000, description: 'cross-frame fan-out into B and log' },
+  );
+  const traceChecks = [
+    ['parent A cross-bump dispatch', [':event/dispatched', ':frame :counter/a', ':multi-frame.core/cross-bump']],
+    ['child B inc dispatch', [':event/dispatched', ':frame :counter/b', ':multi-frame.core/inc']],
+    ['child log append dispatch', [':event/dispatched', ':frame :log', ':multi-frame.core/log-append']],
+  ];
+  const events = await waitForValue(
+    async () => readTrace(page),
+    (traceEvents) => traceChecks.every(([, parts]) =>
+      traceEvents.some((event) => parts.every((part) => event.includes(part)))),
+    { timeoutMs: 10000, description: 'multi-frame trace fan-out across A, B, and log' },
+  );
+  const epochSummary = await readFrameEpochSummary(page);
+  if (!epochSummary.ok ||
+      epochSummary.frames[':counter/a'].count < 3 ||
+      epochSummary.frames[':counter/b'].count < 3 ||
+      epochSummary.frames[':log'].count < 2) {
+    failWithDetails('Multi-frame epoch histories did not isolate fan-out across frames', {
+      isolated,
+      fanout,
+      epochSummary,
+      expectedMinimums: {
+        ':counter/a': 3,
+        ':counter/b': 3,
+        ':log': 2,
+      },
+    });
+  }
+  state.multiFrame = {
+    isolated,
+    fanout,
+    epochSummary,
+    matchedTraceEvents: traceChecks.map(([label, parts]) => ({
+      label,
+      count: events.filter((event) => parts.every((part) => event.includes(part))).length,
+    })),
+  };
+  await clickSidebar(page, 'trace', 'rf-causa-trace');
+  await waitForValue(
+    () => page.locator('[data-testid^="rf-causa-trace-row-"]').count(),
+    (count) => count > 0,
+    { timeoutMs: 5000, description: 'multi-frame trace rows' },
+  );
+  const selected = await clickTraceRowByFrame(page, {
+    frame: ':counter/b',
+    event: ':multi-frame.core/inc',
+  });
+  state.multiFrame.selectedTraceRow = selected;
+  await clickSidebar(page, 'event-detail', 'rf-causa-event-detail');
+  const eventDetailProjection = await waitForValue(
+    () => page.evaluate(() => {
+      const orphaned = document.querySelector('[data-testid="rf-causa-event-detail-orphaned"]');
+      return {
+        cascadeRows: document.querySelectorAll('[data-testid^="rf-causa-cascade-row-"]').length,
+        orphanedText: orphaned ? (orphaned.textContent || '').trim() : null,
+      };
+    }),
+    (projection) => projection.cascadeRows > 0 || Boolean(projection.orphanedText),
+    { timeoutMs: 5000, description: 'event-detail projection after selecting B trace row' },
+  );
+  state.multiFrame.eventDetailProjection = eventDetailProjection;
+  await clickSidebar(page, 'causality', 'rf-causa-causality-graph');
+  await expectVisible(page.locator('[data-testid="rf-causa-causality-graph"]'), 5000);
+  await setCausaTargetFrame(page, ':counter/b');
   await clickSidebar(page, 'time-travel', 'rf-causa-time-travel');
   await expectVisible(page.locator('[data-testid="rf-causa-time-travel"]'), 5000);
+  const timeTravelProjection = await waitForValue(
+    () => page.evaluate(() => {
+      const panel = document.querySelector('[data-testid="rf-causa-time-travel"]');
+      const slider = document.querySelector('[data-testid="rf-causa-time-travel-slider"]');
+      const empty = document.querySelector('[data-testid="rf-causa-time-travel-empty"]');
+      const frameCodes = panel
+        ? Array.from(panel.querySelectorAll('header code')).map((el) => (el.textContent || '').trim())
+        : [];
+      return {
+        targetFrame: frameCodes.length > 0 ? frameCodes[frameCodes.length - 1] : null,
+        sliderVisible: Boolean(slider && slider.getBoundingClientRect().width > 0),
+        sliderMax: slider ? Number(slider.getAttribute('max')) : null,
+        emptyText: empty ? (empty.textContent || '').trim() : null,
+      };
+    }),
+    (projection) => projection.targetFrame === ':counter/b' &&
+      (projection.sliderVisible || Boolean(projection.emptyText)),
+    { timeoutMs: 5000, description: 'time-travel target frame projection for :counter/b' },
+  );
+  state.multiFrame.timeTravelProjection = timeTravelProjection;
+  if (timeTravelProjection.sliderVisible &&
+      (!Number.isFinite(timeTravelProjection.sliderMax) || timeTravelProjection.sliderMax < 2)) {
+    failWithDetails('Expected multi-frame time-travel slider to expose at least two epochs', {
+      selected,
+      timeTravelProjection,
+      epochSummary,
+    });
+  }
 }
 
 async function runDeepMachine(page) {
@@ -497,10 +1048,22 @@ const SCENARIOS = [
     run: runShellFeatureSweep,
   },
   {
+    name: 'source coordinates and launch-mode availability',
+    url: '/counter/',
+    panels: ['trace'],
+    coveredRows: [
+      'Open in Editor / Source Coordinates',
+      'Pop-out, Docking, and Inline Embedding',
+      'Trace',
+      'Shell, Keybinding, Config, Preload, Settings, and Production Elision',
+    ],
+    run: runSourceCoordinatesAndLaunchModes,
+  },
+  {
     name: 'deterministic exceptions and issue/trace surfacing',
     url: '/testbeds/deliberate-throw/',
     panels: ['issues', 'trace'],
-    coveredRows: ['Event Detail', 'Trace', 'Issues Ribbon', 'Effects', 'Flows', 'Machines'],
+    coveredRows: ['Event Detail', 'Trace', 'Issues Ribbon', 'Effects', 'Flows', 'Machines', 'Open in Editor / Source Coordinates'],
     run: runExceptionSchemaHttp,
   },
   {


### PR DESCRIPTION
## Summary
- Adds browser-level Causa source-coordinate chip click coverage for Trace and Issues with bridge/network diagnostics.
- Extends the feature matrix gate for overlay/launch-mode availability, schema recovery, and multi-frame fan-out/isolation.
- Strengthens schema and multi-frame testbeds so browser assertions exercise real recovery/fan-out surfaces where available, while recording current panel projection gaps explicitly.

## Verification
- npm run test:causa-feature-gate
- npm run test:cljs
- git diff --check HEAD~1..HEAD

Beads: rf2-ny4u1, rf2-f5aig, rf2-ffinc, rf2-lj40k