### PR TITLE
fix cljs warning cleanup batch

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -348,6 +348,15 @@
   (binding [*current-component* this]
     (f)))
 
+(defn- copy-argv-from-props!
+  "Read the argv off React's `props` and stash it on `c` as
+  `cljsArgv`. Called from the React constructor and from render entry.
+  The argv lives on the instance so wrap-render reads a single source
+  of truth."
+  [^js c ^js props]
+  (when props
+    (set! (.-cljsArgv c) (.-__rfArgv props))))
+
 (defn- install-lifecycle!
   "Attach the cap's lifecycle methods (those present in `spec`) to the
   React class's prototype. The user fn for each key is invoked with
@@ -458,15 +467,6 @@
                        ;; ._run re-captures deps AND produces fresh hiccup.
                        (._run rea false))]
           (->react-element hiccup))))))
-
-(defn- copy-argv-from-props!
-  "Read the argv off React's `props` and stash it on `c` as
-  `cljsArgv`. Called from the React constructor and from
-  componentWillReceiveProps-style points. The argv lives on the
-  instance so wrap-render reads a single source of truth."
-  [^js c ^js props]
-  (when props
-    (set! (.-cljsArgv c) (.-__rfArgv props))))
 
 (defn create-class*
   "Build a React component class from a Form-3 spec map. Validates

--- a/implementation/adapters/reagent/test/re_frame/dispose_adapter_sub_cache_walk_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/dispose_adapter_sub_cache_walk_cljs_test.cljs
@@ -115,19 +115,23 @@
       (let [reactions-before (vec (cached-reactions-across-all-frames))]
         (is (>= (count reactions-before) 2)
             "precondition: at least one Reaction per frame is cached")
-        (is (every? #(ratom/reactive? %) (filter ratom/reactive? reactions-before))
-            "precondition: snapshotted handles ARE Reagent Reactions")
+        (is (every? #(satisfies? ratom/IDisposable %) reactions-before)
+            "precondition: snapshotted handles satisfy Reagent's disposal contract")
 
-        ;; Drive the walk.
-        (adapter/dispose-adapter!)
+        (let [disposed (atom #{})]
+          (doseq [r reactions-before]
+            (ratom/add-on-dispose! r (fn [& _] (swap! disposed conj r))))
 
-        ;; Invariant 1: every previously-cached Reaction is now
-        ;; disposed. Reagent's Reactions carry a mutable `.-state` slot
-        ;; that flips to ::ratom/dispose on dispose.
-        (doseq [r reactions-before]
-          (is (= ratom/dispose (.-state r))
-              (str "post-dispose: Reaction " (pr-str r)
-                   " on a frame's sub-cache is in the disposed state"))))
+          ;; Drive the walk.
+          (adapter/dispose-adapter!)
+
+          ;; Invariant 1: every previously-cached Reaction is now
+          ;; disposed. Assert through Reagent's public disposal callback
+          ;; surface rather than its private state sentinel.
+          (doseq [r reactions-before]
+            (is (contains? @disposed r)
+                (str "post-dispose: Reaction " (pr-str r)
+                     " on a frame's sub-cache fired its dispose hook")))))
 
       ;; Invariant 2: every frame's sub-cache atom is empty.
       (doseq [[fid frame-record] @frame/frames
@@ -167,11 +171,15 @@
 
         ;; Also snapshot the real reactions so we can verify they were
         ;; reached.
-        (let [reactions-before [r-a r-b]]
+        (let [reactions-before [r-a r-b]
+              disposed         (atom #{})]
+          (doseq [r reactions-before]
+            (ratom/add-on-dispose! r (fn [& _] (swap! disposed conj r))))
+
           (adapter/dispose-adapter!)
 
           (doseq [r reactions-before]
-            (is (= ratom/dispose (.-state r))
+            (is (contains? @disposed r)
                 "the walk reached and disposed the real Reaction past the poison entry"))
 
           (is (= {} @(:sub-cache (frame/frame :walk/a)))

--- a/implementation/adapters/reagent/test/re_frame/init_resolver_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/init_resolver_cljs_test.cljs
@@ -57,9 +57,10 @@
     ;; so `(rf/init!)` raises before reaching the runtime ex-info path.
     ;; CLJS surfaces this as an ordinary Error / TypeError depending on
     ;; compilation mode; we assert only that *something* throws and no
-    ;; adapter is installed.
+    ;; adapter is installed. Use `apply` to keep the intentional bad
+    ;; arity a runtime assertion without a static compiler warning.
     (let [thrown (try
-                   (rf/init!)
+                   (apply rf/init! [])
                    nil
                    (catch :default e e))]
       (is (some? thrown)

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -6,7 +6,7 @@
   never depends on this artefact. Cross-references from core to ssr
   flow through `re-frame.late-bind`.
 
-  Façade over eight flat sub-namespaces (`emit`, `hash`, `adapter`,
+  Façade over eight flat sub-namespaces (`emit`, `hash`, `substrate`,
   `hydrate`, `response`, `error-projector`, `error-listener`,
   `request`). All `reg-fx` / `reg-cofx` / `reg-event-fx` /
   `reg-error-projector` / `register-trace-cb!` side-effects fire HERE
@@ -39,7 +39,6 @@
             [re-frame.events :as events]
             [re-frame.fx :as fx]
             [re-frame.late-bind :as late-bind]
-            [re-frame.ssr.adapter :as adapter-ns]
             [re-frame.ssr.emit :as emit]
             [re-frame.ssr.error-listener :as error-listener]
             [re-frame.ssr.error-projector :as error-projector]
@@ -54,6 +53,7 @@
             [re-frame.ssr.hydrate :as hydrate]
             [re-frame.ssr.request :as request]
             [re-frame.ssr.response :as response]
+            [re-frame.ssr.substrate :as substrate]
             ;; rf2-ojakd / rf2-olb64 (a) — streaming SSR primitive
             ;; (:rf/suspense-boundary). Loaded eagerly so the three
             ;; late-bind hooks (:ssr.streaming/render-shell!,
@@ -76,7 +76,7 @@
 ;; JVM↔CLJS canonical-EDN parity check (hash_check_cljs_test).
 (def ^:private canonical-edn         hash/canonical-edn)
 (def ^:private fnv-1a-32             hash/fnv-1a-32)
-(def adapter                         adapter-ns/adapter)
+(def adapter                         substrate/adapter)
 (def verify-hydration!               hydrate/verify-hydration!)
 (def default-response                response/default-response)
 ;; framework-private — Spec 011 §Response storage substrate (rf2-jbcmt).

--- a/implementation/ssr/src/re_frame/ssr/substrate.cljc
+++ b/implementation/ssr/src/re_frame/ssr/substrate.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.ssr.adapter
+(ns re-frame.ssr.substrate
   "The SSR substrate adapter (rf2-agql). Per Spec 006 §Plain-atom adapter
   and Spec 011 §init flow.
 
@@ -16,6 +16,11 @@
   exclusively; see Spec 006 §Plain-atom adapter and rf2-z1ke (substrate
   contract portability findings). Eight of the nine contract slots are
   implemented cleanly; render is the deliberate exception.
+
+  Internal implementation namespace. The public adapter remains
+  re-frame.ssr/adapter; this ns deliberately avoids
+  re-frame.ssr.adapter so CLJS does not see a child-namespace /
+  parent-var name clash.
 
   Per the rf2-gxgo7 split of re-frame.ssr."
   (:require [re-frame.ssr.emit :as emit]))

--- a/tools/story/src/re_frame/story/fx_stubs.cljc
+++ b/tools/story/src/re_frame/story/fx_stubs.cljc
@@ -66,6 +66,7 @@
   (:require [re-frame.core         :as rf]
             [re-frame.story.assertions :as assertions]
             [re-frame.story.config :as config]
+            [re-frame.story.frames :as frames]
             [re-frame.story.registrar :as registrar]))
 
 ;; ---------------------------------------------------------------------------
@@ -148,13 +149,9 @@
   `re-frame.story.frames/stub-call-log-for`. Each entry carries the
   original `:fx-id`; we set-ify."
   [variant-id]
-  (let [resolve-fn
-        (try
-          #?(:clj  (requiring-resolve 're-frame.story.frames/stub-call-log-for)
-             :cljs (some-> (find-ns 're-frame.story.frames)
-                           (ns-resolve 'stub-call-log-for)))
-          (catch #?(:clj Throwable :cljs :default) _ nil))
-        entries (if resolve-fn (resolve-fn variant-id) [])]
+  (let [entries (try
+                  (frames/stub-call-log-for variant-id)
+                  (catch #?(:clj Throwable :cljs :default) _ []))]
     (set (keep :fx-id entries))))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/story/src/re_frame/story/loaders.cljc
+++ b/tools/story/src/re_frame/story/loaders.cljc
@@ -54,6 +54,7 @@
   Story runtime entry points read `(rf/handler-meta :event
   :rf.story.lifecycle/machine)` and find nothing, returning early."
   (:require [re-frame.story.config    :as config]
+            [re-frame.story.assertions :as assertions]
             #?(:clj  [re-frame.machines :as machines]
                :cljs [re-frame.machines :as machines])
             [re-frame.core            :as rf]))
@@ -325,20 +326,10 @@
   (keyword? pred))
 
 (defn- dispatched-events-set
-  "Read the dispatched-events set for `frame-id`. Lazily resolved to
-  avoid a circular require with the assertions module."
+  "Read the dispatched-events set for `frame-id`."
   [frame-id]
   (try
-    (let [resolve-fn #?(:clj  (requiring-resolve
-                                're-frame.story.assertions/frame-dispatched)
-                       :cljs ((fn []
-                                ;; CLJS: the assertions ns is loaded by
-                                ;; the runtime/install-helpers! path.
-                                (some-> (find-ns 're-frame.story.assertions)
-                                        (ns-resolve 'frame-dispatched)))))]
-      (when resolve-fn
-        (let [evs (resolve-fn frame-id)]
-          (set evs))))
+    (set (assertions/frame-dispatched frame-id))
     (catch #?(:clj Throwable :cljs :default) _ #{})))
 
 (defn- vector-of-events-satisfied?


### PR DESCRIPTION
## Summary

Quiet the assigned CLJS compiler-warning cleanup batch:

- Replace Reagent disposal assertions that referenced private/invalid ratom internals with public `IDisposable`/`add-on-dispose!` checks.
- Preserve the intentional no-arg `rf/init!` arity test via `apply` so the runtime behavior remains covered without a static arity warning.
- Move reagent-slim `copy-argv-from-props!` before its first use.
- Replace Story CLJS `ns-resolve` paths with static namespace references.
- Rename the internal SSR adapter implementation namespace from `re-frame.ssr.adapter` to `re-frame.ssr.substrate` so the public `re-frame.ssr/adapter` var no longer clashes with a child namespace. Public `ssr/adapter` is preserved.

## Verification

- `npm ci`
- `npm run test:cljs` from `implementation` (passes: 2060 tests, 5888 assertions, 0 failures/errors)
- `git diff --check HEAD~1..HEAD`

## Notes

The assigned warnings are cleared. One unrelated remaining CLJS compiler warning is still present in `implementation/adapters/reagent/test/re_frame/hot_reload_cljs_test.cljs` for an intentional `reg-view` redefinition.