### PR TITLE
Strengthen Causa product follow-up coverage

### DIFF
--- a/implementation/core/src/re_frame/core_reg_view_macro.cljc
+++ b/implementation/core/src/re_frame/core_reg_view_macro.cljc
@@ -63,9 +63,10 @@
      free of a static reagent-slim dep — UIx/Helix builds resolve nil."
      [body]
      (when-let [classifier (try (requiring-resolve
-                                  'reagent2.impl.component/classify-form-body)
-                                (catch Exception _ nil))]
-       (classifier body))))
+                                   'reagent2.impl.component/classify-form-body)
+                                 (catch Exception _ nil))]
+       (when (bound? classifier)
+         (classifier body)))))
 
 #?(:clj
    (defn expand-reg-view

--- a/implementation/core/src/re_frame/trace/projection.cljc
+++ b/implementation/core/src/re_frame/trace/projection.cljc
@@ -108,6 +108,8 @@
    :renders     []
    :other       []})
 
+(def ^:private default-frame :rf/default)
+
 (defn- dispatch-id
   "Return an event's concrete dispatch id, or nil when the event was
   emitted outside a dispatch cascade."
@@ -126,15 +128,34 @@
   [ev]
   (or (dispatch-id ev) :ungrouped))
 
+(defn- frame-index
+  "Map dispatch ids to the frames explicitly seen for that dispatch.
+  Frame-less events inside a cascade can then join the only known frame
+  deterministically without merging ambiguous multi-frame dispatch ids."
+  [events]
+  (reduce (fn [acc ev]
+            (if-let [id (dispatch-id ev)]
+              (if-let [frame (or (get-in ev [:tags :frame]) (:frame ev))]
+                (update acc id (fnil conj #{}) frame)
+                acc)
+              acc))
+          {}
+          events))
+
 (defn- cascade-frame
   "Extract the host frame from an event. nil means the event is not
   frame-qualified (registry-time, boot-time, or older traces). Older
   dispatch-scoped traces that predate explicit frame tags are treated as
   default-frame traces so errors/warnings still ride with their cascade."
-  [ev]
+  [frame-index ev]
   (or (get-in ev [:tags :frame])
       (:frame ev)
-      (when (dispatch-id ev) :rf/default)))
+      (when-let [id (dispatch-id ev)]
+        (let [frames (get frame-index id)]
+          (when (= 1 (count frames))
+            (first frames))))
+      (when (dispatch-id ev)
+        default-frame)))
 
 (defn- cascade-key
   "The stable grouping key for a cascade. Dispatch ids are only unique
@@ -142,11 +163,11 @@
   group by `[frame dispatch-id]`. Traces without a dispatch-id are not
   cascades and share the historical ungrouped bucket regardless of
   frame lifecycle metadata."
-  [ev]
+  [frame-index ev]
   (let [id (cascade-id ev)]
     (if (= :ungrouped id)
       [nil :ungrouped]
-      [(cascade-frame ev) id])))
+      [(cascade-frame frame-index ev) id])))
 
 (defn- absorb
   "Fold one trace event into the per-cascade accumulator."
@@ -205,7 +226,8 @@
   want richer projections of `:other` can call `domino-bucket`
   directly on each event."
   [events]
-  (let [groups (group-by cascade-key events)]
+  (let [index  (frame-index events)
+        groups (group-by #(cascade-key index %) events)]
     (->> groups
          (map (fn [[[frame dispatch-id] evs]]
                 (reduce absorb

--- a/implementation/core/test/re_frame/trace/projection_test.cljc
+++ b/implementation/core/test/re_frame/trace/projection_test.cljc
@@ -65,22 +65,22 @@
   ([dispatch-id event-vec]
    (cascade-evs dispatch-id event-vec :rf/default))
   ([dispatch-id event-vec frame-id]
-  [{:id 1 :op-type :event    :operation :event/dispatched
-    :tags {:dispatch-id dispatch-id :event event-vec :frame frame-id}}
-   {:id 2 :op-type :event    :operation :event
-    :tags {:dispatch-id dispatch-id :phase :run-start :frame frame-id}}
-   {:id 3 :op-type :event    :operation :event
-    :tags {:dispatch-id dispatch-id :phase :run-end :frame frame-id}}
-   {:id 4 :op-type :event    :operation :event/do-fx
-    :tags {:dispatch-id dispatch-id :frame frame-id}}
-   {:id 5 :op-type :fx       :operation :rf.fx/handled
-    :tags {:dispatch-id dispatch-id :fx-id :db :frame frame-id}}
-   {:id 6 :op-type :fx       :operation :rf.fx/handled
-    :tags {:dispatch-id dispatch-id :fx-id :dispatch :frame frame-id}}
-   {:id 7 :op-type :sub/run  :operation :sub/run
-    :tags {:dispatch-id dispatch-id :sub-id :sub/foo :frame frame-id}}
-   {:id 8 :op-type :view     :operation :view/render
-    :tags {:dispatch-id dispatch-id :render-key [:app/root nil] :frame frame-id}}]))
+   [{:id 1 :op-type :event    :operation :event/dispatched
+     :tags {:dispatch-id dispatch-id :event event-vec :frame frame-id}}
+    {:id 2 :op-type :event    :operation :event
+     :tags {:dispatch-id dispatch-id :phase :run-start :frame frame-id}}
+    {:id 3 :op-type :event    :operation :event
+     :tags {:dispatch-id dispatch-id :phase :run-end :frame frame-id}}
+    {:id 4 :op-type :event    :operation :event/do-fx
+     :tags {:dispatch-id dispatch-id :frame frame-id}}
+    {:id 5 :op-type :fx       :operation :rf.fx/handled
+     :tags {:dispatch-id dispatch-id :fx-id :db :frame frame-id}}
+    {:id 6 :op-type :fx       :operation :rf.fx/handled
+     :tags {:dispatch-id dispatch-id :fx-id :dispatch :frame frame-id}}
+    {:id 7 :op-type :sub/run  :operation :sub/run
+     :tags {:dispatch-id dispatch-id :sub-id :sub/foo :frame frame-id}}
+    {:id 8 :op-type :view     :operation :view/render
+     :tags {:dispatch-id dispatch-id :render-key [:app/root nil] :frame frame-id}}]))
 
 (deftest group-cascades-one-cascade-six-buckets
   (testing "a representative cascade reduces to one record with the six

--- a/testbeds/large_dispatcher/core.cljs
+++ b/testbeds/large_dispatcher/core.cljs
@@ -5,43 +5,27 @@
   the `:rf.size/large-elided` marker (per [spec/009 §Size elision in
   traces] / [API.md §`rf/elide-wire-value`]).
 
-  Three nomination paths exist per [spec/009 §Nomination — three
-  entry points]:
+  Path-D elision is schema-first: `:large?` on a Malli app-schema slot
+  is the declaration path. Unschema'd large values deliberately warn
+  but do not auto-elide.
 
-    1. Schema-driven — `:large?` on a Malli slot in `:rf/app-schema`.
-    2. fx-driven    — `:rf.size/declare-large` fx writes the slot
-                      from an event handler's `:fx`. Convenience
-                      wrappers: `rf/declare-large-path!` and
-                      `rf/clear-large-path!`.
-    3. Runtime auto-detect — values exceeding `:rf.size/threshold-
-                      bytes` (default 16 KiB) get auto-flagged on
-                      first wire-emit. Subsequent emits short-
-                      circuit on the cached decision and emit a
-                      `:rf.warning/runtime-large-elision` advisory.
+  This surface exercises one warning-only control and three
+  schema-declared marker paths:
 
-  This surface exercises all three nomination paths plus one
-  control:
-
-    Button A · Auto-detect (no declaration)
+    Button A · Unschema'd large value (warning-only)
       — handler writes a 20 KiB string to `[:auto-large-value]`. The
-        runtime walks the app-db at first wire-emit, finds the value
-        exceeds the 16 KiB threshold, flags the path, and elides on
-        every subsequent emit. The `:rf.warning/runtime-large-elision`
-        advisory fires once on first detection.
+        walker emits `:rf.warning/large-value-unschema'd` but leaves
+        the value inline because no schema declared the path.
 
-    Button B · Declared via REPL wrapper
-      — handler calls `rf/declare-large-path!` directly. The
-        declaration writes `{:large? true :source :declared}` into
-        `[:rf/elision :declarations [:declared-large-value]]`. The
-        handler then writes a small (200 byte) value to the path —
-        elision fires regardless of size because of the declaration
-        (declared wins over runtime threshold).
+    Button B · Schema-declared flat slot
+      — handler writes a small (200 byte) value to
+        `[:declared-large-value]`. Elision fires regardless of size
+        because the registered app-schema marks the slot `:large?`.
 
-    Button C · Declared via fx
-      — handler returns `:fx [[:rf.size/declare-large {:path ...}]]`.
-        Same outcome as Button B; different entry point. The fx
-        declaration is the canonical AI-discoverable shape (apps
-        nominate paths from event handlers).
+    Button C · Second schema-declared flat slot
+      — same outcome as Button B on `[:fx-declared-value]`; it keeps a
+        second deterministic path for consumers that assert multiple
+        marker rows.
 
     Button D · Schema-driven (registered at boot)
       — the surface registers a Malli app-schema with `:large? true`
@@ -50,9 +34,8 @@
         value to the schema-declared slot.
 
   This is NOT a tutorial. The bodies are minimal. The point is to
-  produce four distinct elision triggers a consumer can assert
-  against — auto-flagged + declared (REPL) + declared (fx) + schema
-  — all in one surface."
+  produce deterministic warning-only and schema-elided shapes a
+  consumer can assert against."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
             ;; Loads the schemas artefact's late-bind hooks (rf2-p7va).
@@ -65,10 +48,9 @@
 ;; The canonical "large" payload — 20 KiB above the 16 KiB threshold
 ;; ----------------------------------------------------------------------------
 ;;
-;; `pr-str` of this string exceeds `:rf.size/threshold-bytes` (default
-;; 16384). The auto-detect path measures the pr-str byte count of each
-;; top-two-level subtree; any subtree at or above the threshold gets
-;; flagged. Per [spec/009 §Runtime auto-detect].
+;; `pr-str` of this string exceeds the framework's warning threshold.
+;; Path-D schema-first elision leaves it inline and emits a warning so
+;; users can add `{:large? true}` to the app-schema slot.
 
 (def kib-20-string
   ;; 20480 chars = 20 KiB. pr-str adds 2 quote chars; effective size
@@ -87,9 +69,17 @@
 ;; ----------------------------------------------------------------------------
 
 (def SchemaLarge
-  [:map [:schema-large-value {:large? true} :string]])
+  [:map
+   [:schema-large-value {:large? true :hint "Nested schema-declared slot"}
+    [:maybe :string]]])
 
-(rf/reg-app-schema [:schema-bag] SchemaLarge)
+(rf/reg-app-schemas
+  {[:declared-large-value]
+   [:maybe [:string {:large? true :hint "Flat schema-declared slot"}]]
+   [:fx-declared-value]
+   [:maybe [:string {:large? true :hint "Second flat schema-declared slot"}]]
+   [:schema-bag]
+   SchemaLarge})
 
 ;; ----------------------------------------------------------------------------
 ;; App-db
@@ -110,57 +100,40 @@
      :click-count          {:auto 0 :declared 0 :fx 0 :schema 0}}))
 
 ;; ----------------------------------------------------------------------------
-;; Button A — auto-detect path
+;; Button A — unschema'd warning-only path
 ;; ----------------------------------------------------------------------------
 
 (rf/reg-event-db ::write-auto-large
   (fn [db _ev]
-    ;; HOT PATH — commits a 20 KiB value to an undeclared path. On
-    ;; the first wire-emit the runtime's auto-detect walker measures
-    ;; pr-str byte count, finds it above threshold, flags the path,
-    ;; and elides on subsequent emits. A
-    ;; :rf.warning/runtime-large-elision fires once.
+    ;; HOT PATH — commits a 20 KiB value to an undeclared path. The
+    ;; schema-first walker warns about unschema'd large values but does
+    ;; not substitute a marker unless a schema declares the path.
     (-> db
         (assoc :auto-large-value kib-20-string)
         (update-in [:click-count :auto] inc))))
 
 ;; ----------------------------------------------------------------------------
-;; Button B — declared via rf/declare-large-path! (REPL wrapper)
+;; Button B — schema-declared flat slot
 ;; ----------------------------------------------------------------------------
 ;;
-;; The handler calls `rf/declare-large-path!` as a side effect AND
-;; commits the small payload. Per [spec/009 §fx-driven] the wrapper
-;; issues a synthetic dispatch of `:rf.size/declare-large` for us —
-;; same effect as the fx path, but ergonomic at the REPL.
-;;
-;; The declaration writes `{:large? true :source :declared}` into
-;; `[:rf/elision :declarations [:declared-large-value]]`; the slot
-;; is elided on every subsequent emit irrespective of size (declared
-;; wins over runtime per Spec 009).
+;; The schema marks `[:declared-large-value]` as `:large? true`; the
+;; small payload proves declaration, not byte size, drives elision.
 
 (rf/reg-event-db ::write-declared-large
   (fn [db _ev]
-    (rf/declare-large-path! [:declared-large-value]
-                            "Test surface — declared via REPL wrapper")
     (-> db
         (assoc :declared-large-value chars-200-string)
         (update-in [:click-count :declared] inc))))
 
 ;; ----------------------------------------------------------------------------
-;; Button C — declared via :rf.size/declare-large fx
+;; Button C — second schema-declared flat slot
 ;; ----------------------------------------------------------------------------
 
-(rf/reg-event-fx ::write-fx-declared-large
-  (fn [{:keys [db]} _ev]
-    ;; HOT PATH — the canonical AI-discoverable nomination shape.
-    ;; The fx writes the declaration into the elision registry; the
-    ;; handler's :db commits the small payload; subsequent emits
-    ;; elide the path.
-    {:db (-> db
-             (assoc :fx-declared-value chars-200-string)
-             (update-in [:click-count :fx] inc))
-     :fx [[:rf.size/declare-large {:path [:fx-declared-value]
-                                   :hint "Test surface — declared via fx"}]]}))
+(rf/reg-event-db ::write-fx-declared-large
+  (fn [db _ev]
+    (-> db
+        (assoc :fx-declared-value chars-200-string)
+        (update-in [:click-count :fx] inc))))
 
 ;; ----------------------------------------------------------------------------
 ;; Button D — schema-driven (boot-time declaration on a Malli slot)
@@ -184,13 +157,7 @@
 
 (rf/reg-event-fx ::reset
   (fn [_ctx _ev]
-    {:fx [[:dispatch [::initialise]]
-          ;; Clear the declared paths (the schema-derived entry
-          ;; stays — it's repopulated at boot via the registered
-          ;; schema; only the imperative declarations need
-          ;; clearing for a clean re-run).
-          [:rf.size/clear {:path [:declared-large-value]}]
-          [:rf.size/clear {:path [:fx-declared-value]}]]}))
+    {:fx [[:dispatch [::initialise]]]}))
 
 ;; ----------------------------------------------------------------------------
 ;; Subs + view
@@ -234,13 +201,13 @@
      [:div {:style {:display :flex :gap "0.5em" :flex-wrap :wrap}}
       [:button {:data-testid "write-auto"
                 :on-click    #(dispatch [::write-auto-large])}
-       "A · auto-detect (20 KiB > threshold)"]
+       "A · unschema'd large warning"]
       [:button {:data-testid "write-declared"
                 :on-click    #(dispatch [::write-declared-large])}
-       "B · declare-large-path! (REPL wrapper)"]
+       "B · schema-declared flat slot"]
       [:button {:data-testid "write-fx-declared"
                 :on-click    #(dispatch [::write-fx-declared-large])}
-       "C · :rf.size/declare-large fx"]
+       "C · second schema-declared flat slot"]
       [:button {:data-testid "write-schema"
                 :on-click    #(dispatch [::write-schema-large])}
        "D · schema-driven (:large? on Malli slot)"]

--- a/testbeds/sensitive_dispatcher/core.cljs
+++ b/testbeds/sensitive_dispatcher/core.cljs
@@ -15,11 +15,13 @@
         the trace event but rides the payload through (the dev surface
         treats `:sensitive?` as declarative — listeners filter).
 
-    Button B · Sign-in with redaction (`:sensitive?` + `with-redacted`)
-      — handler declares both flags. The recorder + the MCP wire +
+    Button B · Sign-in with schema-derived redaction
+      — handler is path-scoped to an app-schema slice carrying
+        `:sensitive? true` slot metadata. The recorder + the MCP wire +
         the trace surface all see redacted payload (the `:password`
-        slot in the event vector becomes `:rf/redacted`); the
-        event-emit substrate still drops the record entirely.
+        and `:totp-code` slots in the event vector become
+        `:rf/redacted`); the event-emit substrate still drops the
+        record entirely.
 
     Button C · Sign-in that throws
       — handler declares `:sensitive? true` and deliberately throws.
@@ -33,9 +35,29 @@
   redacted — all from one surface."
   (:require [reagent.dom.client :as rdc]
             [re-frame.core :as rf]
+            [re-frame.schemas]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ----------------------------------------------------------------------------
+;; Schema-first privacy declarations
+;; ----------------------------------------------------------------------------
+
+(def AuthSlice
+  [:map
+   [:username {:optional true} :string]
+   [:password {:optional true :sensitive? true} :string]
+   [:totp-code {:optional true :sensitive? true} :string]
+   [:redacted-clicks {:optional true} :int]
+   [:last-login
+    {:optional true}
+    [:map
+     [:username {:optional true} :string]
+     [:password {:optional true :sensitive? true} :string]
+     [:totp-code {:optional true :sensitive? true} :string]]]])
+
+(rf/reg-app-schema [:auth] AuthSlice)
 
 ;; ----------------------------------------------------------------------------
 ;; App-db
@@ -44,10 +66,8 @@
 (rf/reg-event-db ::initialise
   (fn [_db _ev]
     {;; Counters per button — flipped when the handler runs to
-     ;; completion. A spec asserts that the counters DO advance
-     ;; (the handlers themselves see the unredacted payload via the
-     ;; cofx slot per Spec 009 §with-redacted) even when the trace
-     ;; / wire surfaces see redaction.
+     ;; completion. A spec asserts that the counters DO advance even
+     ;; when the trace / wire surfaces see redaction.
      :click-count {:plain 0 :redacted 0 :throw 0}
      ;; A consumer that asks "did the handler's :sensitive? meta
      ;; flow into the registration?" reads the registrar via
@@ -57,10 +77,14 @@
      :handler-meta-mirror
      {::sign-in-plain    nil
       ::sign-in-redacted nil
-      ::sign-in-throw    nil}}))
+      ::sign-in-throw    nil}
+     ;; Button B is path-scoped to this slice so schema-derived
+     ;; sensitive declarations can redact the event payload while the
+     ;; handler still receives the raw credentials.
+     :auth {:redacted-clicks 0}}))
 
 ;; ----------------------------------------------------------------------------
-;; Button A — :sensitive? true on registration, no with-redacted
+;; Button A — :sensitive? true on registration, no payload redaction
 ;; ----------------------------------------------------------------------------
 ;;
 ;; The registration-meta map carries `:sensitive? true`. Per [spec/009
@@ -88,22 +112,23 @@
     (update-in db [:click-count :plain] inc)))
 
 ;; ----------------------------------------------------------------------------
-;; Button B — :sensitive? true + with-redacted interceptor
+;; Button B — schema-derived event-payload redaction
 ;; ----------------------------------------------------------------------------
 ;;
-;; This is the conservative recommended pattern for sensitive
-;; handlers (per [spec/009 §The `with-redacted` interceptor] and
-;; [spec/Security.md §Privacy / secret handling]). The interceptor's
-;; :before stage redacts the named paths in the event vector, in the
-;; downstream :event cofx slot, and in the :event/dispatched +
-;; :event/db-changed trace events.
+;; Path-D privacy is schema-first: the `[:auth]` app-schema marks the
+;; payload slots as `:sensitive? true`, and the router installs the
+;; internal redaction interceptor for handlers path-scoped through
+;; `(rf/path :auth)`. The handler body still receives the raw
+;; credentials; trace/error/wire surfaces see the redacted event form.
 
 (rf/reg-event-db ::sign-in-redacted
-  {:doc        "Verify credentials (redacted via with-redacted)."
+  {:doc        "Verify credentials (redacted via schema metadata)."
    :sensitive? true}
-  [(rf/with-redacted [[:password] [:totp-code]])]
-  (fn [db [_ _credentials]]
-    (update-in db [:click-count :redacted] inc)))
+  [(rf/path :auth)]
+  (fn [auth [_ credentials]]
+    (-> (or auth {})
+        (assoc :last-login credentials)
+        (update :redacted-clicks (fnil inc 0)))))
 
 ;; ----------------------------------------------------------------------------
 ;; Button C — :sensitive? true + throws (exercise the error-emit substrate)
@@ -154,7 +179,8 @@
      :handler-meta-mirror
      {::sign-in-plain    (boolean (:sensitive? (rf/handler-meta :event ::sign-in-plain)))
       ::sign-in-redacted (boolean (:sensitive? (rf/handler-meta :event ::sign-in-redacted)))
-      ::sign-in-throw    (boolean (:sensitive? (rf/handler-meta :event ::sign-in-throw)))}}))
+      ::sign-in-throw    (boolean (:sensitive? (rf/handler-meta :event ::sign-in-throw)))}
+     :auth {:redacted-clicks 0}}))
 
 ;; ----------------------------------------------------------------------------
 ;; Subs + view
@@ -164,7 +190,7 @@
   (fn [db _] (get-in db [:click-count :plain])))
 
 (rf/reg-sub :redacted-count
-  (fn [db _] (get-in db [:click-count :redacted])))
+  (fn [db _] (get-in db [:auth :redacted-clicks])))
 
 (rf/reg-sub :throw-count
   (fn [db _] (get-in db [:click-count :throw])))
@@ -208,7 +234,7 @@
        "A · :sensitive? plain (event-emit drops record)"]
       [:button {:data-testid "sign-in-redacted"
                 :on-click    #(dispatch [::sign-in-redacted example-credentials])}
-       "B · :sensitive? + with-redacted (payload scrubbed)"]
+       "B · schema-sensitive payload scrubbed"]
       [:button {:data-testid "sign-in-throw"
                 :on-click    #(dispatch [::sign-in-throw example-credentials])}
        "C · :sensitive? + throw (error-emit redacts :event)"]
@@ -242,6 +268,7 @@
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
   (rf/dispatch-sync [::initialise])
+  (rf/populate-sensitive-from-schemas!)
   ;; Populate the registrar-meta mirror once on boot; the mirror is
   ;; static — the registrations don't change at runtime.
   (rf/dispatch-sync [::populate-meta-mirror])

--- a/tools/causa/src/day8/re_frame2_causa/core.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/core.cljs
@@ -4,7 +4,8 @@
   Per `spec/API.md` §Public CLJS API + the README's `core.cljs` reference,
   this namespace is the *one* import users reach for. It re-exports the
   small handful of programmatic entry points enumerated by the spec —
-  `init!` / `open!` / `close!` / `toggle!` / `popout!` /
+  `init!` / `open!` / `close!` / `toggle!` / `dock!` / `undock!` /
+  `popout!` / `mount-inline-panel!` /
   `target-frame` + `set-target-frame!` / `active-panel` +
   `set-active-panel!` / `load-theme` — plus the boot-time config knob
   surface exposed by `config.cljc` (`configure!` / `set-editor!` /
@@ -19,12 +20,9 @@
 
   ## Pre-alpha posture
 
-  Two surfaces in `spec/API.md` ship as TBD-impl stubs that emit a
-  `:rf.warning/*` trace and otherwise no-op:
+  One surface in `spec/API.md` ships as a TBD-impl stub that emits a
+  `:rf.warning/*` trace and otherwise no-ops:
 
-    - `popout!` — same-browser pop-out window (the `Ctrl+Shift+P`
-      shortcut and the window-management plumbing are scheduled
-      under a follow-on bead).
     - `load-theme` — programmatic theme swap. The theme module
       exists (`day8.re-frame2-causa.theme/*`) but the runtime CSS-
       swap surface is not yet wired.
@@ -79,6 +77,27 @@
   "Toggle the Causa shell's visibility. First call mounts + shows;
   subsequent calls flip visibility."
   mount/toggle!)
+
+(def dock!
+  "Dock Causa against the host page. See `mount/dock!`."
+  mount/dock!)
+
+(def undock!
+  "Return Causa to overlay mode. See `mount/undock!`."
+  mount/undock!)
+
+(def popout!
+  "Open Causa in a same-origin second window. See `mount/popout!`."
+  mount/popout!)
+
+(def mount-inline-panel!
+  "Render a single Causa panel into a caller-supplied DOM node without
+  shell chrome. See `mount/mount-inline-panel!`."
+  mount/mount-inline-panel!)
+
+(def unmount-inline-panel!
+  "Unmount a panel previously mounted with `mount-inline-panel!`."
+  mount/unmount-inline-panel!)
 
 ;; ---- init! (manual install, alternative to :preloads) ------------------
 
@@ -176,27 +195,10 @@
 
 ;; ---- TBD-impl stubs -----------------------------------------------------
 ;;
-;; `popout!` and `load-theme` are promised by `spec/API.md` §Public CLJS
-;; API but the runtime plumbing has not landed. Calling either emits a
+;; `load-theme` is promised by `spec/API.md` §Public CLJS API but the
+;; runtime CSS-swap plumbing has not landed. Calling it emits a
 ;; `:rf.warning/*` trace event so the gap is visible in the trace stream
-;; (and surfaces in Causa's own Issues ribbon). Each stub returns nil
-;; rather than throwing so host code that wires the call ahead of the
-;; impl does not crash.
-
-(defn popout!
-  "Open Causa's same-browser pop-out window. **TBD-impl.** The
-  `Ctrl+Shift+P` shortcut and the window-management plumbing land
-  under a follow-on bead; this stub emits
-  `:rf.warning/causa-popout-not-yet-implemented` and returns nil.
-
-  Hosts wiring the call today are forward-compatible; the trace event
-  documents the gap in the trace stream."
-  []
-  (trace/emit! :rf.warning
-               :rf.warning/causa-popout-not-yet-implemented
-               {:origin :causa
-                :where  'day8.re-frame2-causa.core/popout!})
-  nil)
+;; (and surfaces in Causa's own Issues ribbon).
 
 (defn load-theme
   "Programmatically swap the Causa shell's CSS theme. **TBD-impl.**

--- a/tools/causa/src/day8/re_frame2_causa/mount.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/mount.cljs
@@ -54,10 +54,21 @@
   ;; Singleton — only one Causa shell mounted per process. The map shape:
   ;;   {:node      <DOM element>      ; the freshly-created <div>
   ;;    :unmount   (fn [] ...)         ; substrate adapter unmount fn
-  ;;    :visible?  <boolean>}
+  ;;    :visible?  <boolean>
+  ;;    :mode      <:overlay|:docked>}
   ;; Nil before first mount; never re-allocated across reloads thanks
   ;; to defonce.
   (atom nil))
+
+(defonce ^:private popout-state
+  ;; Optional second-window mount. Shape mirrors mount-state plus
+  ;; `:window`. The opener runtime remains the source of truth.
+  (atom nil))
+
+(defonce ^:private inline-mounts
+  ;; DOM-node → {:node :unmount :panel-id}. Inline panel mounts are
+  ;; independent from the overlay shell and from each other.
+  (atom {}))
 
 (defn mounted?
   "True when the Causa shell has been mounted at least once. The shell
@@ -76,6 +87,7 @@
 (defn- create-mount-node! []
   (let [node (.createElement js/document "div")]
     (set! (.-id node) "rf-causa-root")
+    (.setAttribute node "data-rf-causa-mode" "overlay")
     ;; The shell uses position: fixed for its own outer element, so the
     ;; root <div> only needs to be a no-layout-impact host. Leave its
     ;; default block-level styling intact; the shell handles its own
@@ -83,10 +95,26 @@
     (.appendChild (.-body js/document) node)
     node))
 
+(defn- shell-node [node]
+  (when (and (some? node) (.-querySelector node))
+    (.querySelector node "[data-testid=\"rf-causa-shell\"]")))
+
 (defn- set-visible! [node visible?]
   (when (some? node)
     (set! (-> node .-style .-display)
           (if visible? "block" "none"))))
+
+(defn- set-mode-attrs! [node mode]
+  (when (some? node)
+    (let [mode-name (name mode)]
+      (.setAttribute node "data-rf-causa-mode" mode-name)
+      (when-let [shell (shell-node node)]
+        (.setAttribute shell "data-mode" mode-name)))))
+
+(defn- set-body-docked! [docked?]
+  (when (and (exists? js/document) (.-body js/document))
+    (set! (-> js/document .-body .-style .-paddingRight)
+          (if docked? "40%" ""))))
 
 ;; ---- public API ----------------------------------------------------------
 
@@ -157,10 +185,12 @@
       (ensure-causa-frame!)
       (let [node    (create-mount-node!)
             unmount (substrate-adapter/render [shell/shell-view] node nil)]
+        (set-mode-attrs! node :overlay)
         (reset! mount-state
                 {:node     node
                  :unmount  unmount
-                 :visible? true})
+                 :visible? true
+                 :mode     :overlay})
         @mount-state))))
 
 (defn close!
@@ -173,6 +203,28 @@
     (set-visible! (:node state) false)
     (swap! mount-state assoc :visible? false))
   nil)
+
+(defn dock!
+  "Dock Causa against the host page. The shell remains the same
+  runtime-backed panel, but the root and shell DOM carry
+  `data-rf-causa-mode=\"docked\"` / `data-mode=\"docked\"`, and the
+  host body gets right padding so the inspected app is not obscured.
+  Returns the mount-state map."
+  []
+  (when-let [state (open!)]
+    (set-mode-attrs! (:node state) :docked)
+    (set-body-docked! true)
+    (swap! mount-state assoc :mode :docked :visible? true)
+    @mount-state))
+
+(defn undock!
+  "Return the overlay shell to its default non-layout-affecting mode."
+  []
+  (when-let [state @mount-state]
+    (set-mode-attrs! (:node state) :overlay)
+    (set-body-docked! false)
+    (swap! mount-state assoc :mode :overlay))
+  @mount-state)
 
 (defn toggle!
   "Toggle the Causa shell's visibility. First call mounts + shows
@@ -190,5 +242,65 @@
       (try (unmount) (catch :default _ nil)))
     (when (and node (.-parentNode node))
       (.removeChild (.-parentNode node) node))
+    (set-body-docked! false)
     (reset! mount-state nil))
+  nil)
+
+(defn popout!
+  "Open a same-origin Causa pop-out window and render the shell into it.
+  The pop-out shares the opener runtime and Causa frame; no
+  serialisation layer is introduced. Returns a state map, or
+  `{:ok? false :reason :popup-blocked}` when `window.open` fails."
+  []
+  (if-let [state @popout-state]
+    state
+    (if-not (substrate-adapter/current-adapter)
+      {:ok? false :reason :no-substrate-adapter}
+      (let [win (when (exists? js/window)
+                  (.open js/window "" "rf-causa-popout"
+                         "popup,width=960,height=720"))]
+        (if-not win
+          {:ok? false :reason :popup-blocked}
+          (do
+            (ensure-causa-frame!)
+            (let [doc  (.-document win)
+                  body (.-body doc)
+                  node (.createElement doc "div")]
+              (set! (.-title doc) "Causa")
+              (set! (.-id node) "rf-causa-popout-root")
+              (.setAttribute node "data-rf-causa-mode" "popout")
+              (.appendChild body node)
+              (let [unmount (substrate-adapter/render [shell/shell-view] node nil)
+                    state   {:ok? true :window win :node node :unmount unmount :mode :popout}]
+                (reset! popout-state state)
+                state))))))))
+
+(defn mount-inline-panel!
+  "Render one Causa panel into `node` without the shell chrome. `panel-id`
+  is any sidebar panel id; nil defaults to the hero panel. Returns a
+  mount map and stores the unmount fn by DOM node."
+  ([node panel-id]
+   (mount-inline-panel! node panel-id nil))
+  ([node panel-id _opts]
+   (if-not (and node (substrate-adapter/current-adapter))
+     {:ok? false :reason (if node :no-substrate-adapter :missing-node)}
+     (do
+       (ensure-causa-frame!)
+       (.setAttribute node "data-rf-causa-mode" "inline")
+       (let [unmount (substrate-adapter/render
+                       [shell/inline-panel-view {:panel-id (or panel-id :event-detail)}]
+                       node nil)
+             state   {:ok? true :node node :panel-id (or panel-id :event-detail)
+                      :unmount unmount :mode :inline}]
+         (swap! inline-mounts assoc node state)
+         state)))))
+
+(defn unmount-inline-panel!
+  "Unmount a previously mounted inline panel from `node`."
+  [node]
+  (when-let [{:keys [unmount]} (get @inline-mounts node)]
+    (when unmount
+      (try (unmount) (catch :default _ nil)))
+    (.removeAttribute node "data-rf-causa-mode")
+    (swap! inline-mounts dissoc node))
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -73,6 +73,24 @@
         (cond-> file
           line (str ":" line))))))
 
+(defn- selected-ref
+  "Normalise the selection slot. Newer callers pass
+  `{:dispatch-id <id> :frame <frame-id>}` so non-default frames can be
+  distinguished even if a host implementation scopes dispatch ids per
+  frame. Older callers that still pass the raw id continue to resolve
+  by id only."
+  [selection]
+  (if (map? selection)
+    selection
+    {:dispatch-id selection}))
+
+(defn- cascade-matches-selection?
+  [{:keys [dispatch-id frame]} selection]
+  (let [{selected-id :dispatch-id selected-frame :frame} (selected-ref selection)]
+    (and (= selected-id dispatch-id)
+         (or (nil? selected-frame)
+             (= selected-frame frame)))))
+
 ;; ---- row renderers -------------------------------------------------------
 
 (defn- domino-row
@@ -258,10 +276,12 @@
   "One row in the cascade-list view. Clicking the row fires the
   `:rf.causa/select-dispatch-id` event-db so the panel switches into
   cascade-detail mode."
-  [{:keys [dispatch-id event] :as _cascade}]
-  [:li {:key       dispatch-id
+  [{:keys [dispatch-id frame event] :as _cascade}]
+  [:li {:key       [frame dispatch-id]
         :data-testid (str "rf-causa-cascade-row-" dispatch-id)
-        :on-click   #(rf/dispatch [:rf.causa/select-dispatch-id dispatch-id] {:frame :rf/causa})
+        :on-click   #(rf/dispatch
+                       [:rf.causa/select-dispatch-id dispatch-id frame]
+                       {:frame :rf/causa})
         :style      {:padding      "8px 12px"
                      :border-bottom (str "1px solid " (:border-subtle tokens))
                      :cursor       "pointer"
@@ -270,6 +290,9 @@
                      :color        (:text-primary tokens)}}
    [:span {:style {:color (:accent-violet tokens) :margin-right "8px"}}
     (str "#" dispatch-id)]
+   (when frame
+     [:span {:style {:color (:text-tertiary tokens) :margin-right "8px"}}
+      (str frame)])
    (format-edn (or event :ungrouped))])
 
 (defn- cascade-list
@@ -308,8 +331,10 @@
 (defn- cascade-detail
   "The six-domino cascade for the selected dispatch-id. `cascade` is a
   single cascade record per `re-frame.trace.projection/group-cascades`."
-  [{:keys [event handler fx effects subs renders other] :as _cascade}]
+  [{:keys [dispatch-id frame event handler fx effects subs renders other] :as _cascade}]
   [:div {:data-testid "rf-causa-event-detail-cascade"
+         :data-dispatch-id (str dispatch-id)
+         :data-frame (str frame)
          :style       {:padding "8px 0"}}
    [:div {:style {:padding "0 12px 8px 12px"
                   :display "flex"
@@ -347,7 +372,7 @@
   layout (when a dispatch-id is selected) or the cascade-list empty
   state (when not)."
   []
-  (let [{:keys [selected-dispatch-id selected-cascade cascades]}
+  (let [{:keys [selected-dispatch-id selected-dispatch-frame selected-cascade cascades]}
         @(rf/subscribe [:rf.causa/event-detail])]
     [:section {:data-testid "rf-causa-event-detail"
                :style       {:height         "100%"
@@ -380,9 +405,13 @@
                              :color   (:text-tertiary tokens)
                              :font-family sans-stack
                              :font-size "13px"}}
-         "Selected dispatch-id "
-         [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
+       "Selected dispatch-id "
+        [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
           (str selected-dispatch-id)]
+        (when selected-dispatch-frame
+          [:span " in frame "
+           [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
+            (str selected-dispatch-frame)]])
          " is no longer in the trace buffer. "
          [:button {:on-click #(rf/dispatch [:rf.causa/clear-selected-dispatch-id] {:frame :rf/causa})
                    :style    {:margin-left "8px"
@@ -419,7 +448,13 @@
   ;; (cascade list, per spec/007-UX-IA.md §The default landing view).
   (rf/reg-sub :rf.causa/selected-dispatch-id
     (fn [db _query]
-      (get db :selected-dispatch-id)))
+      (:dispatch-id (selected-ref (or (get db :selected-dispatch)
+                                      (get db :selected-dispatch-id))))))
+
+  (rf/reg-sub :rf.causa/selected-dispatch-frame
+    (fn [db _query]
+      (:frame (selected-ref (or (get db :selected-dispatch)
+                                (get db :selected-dispatch-id))))))
 
   ;; Event-detail composite — produces everything the panel needs in
   ;; one read so the view stays a thin renderer. Shape:
@@ -441,18 +476,26 @@
     ;; — reg-sub-raw is dropped; see `re-frame.subs/parse-reg-sub-args`).
     :<- [:rf.causa/cascades]
     :<- [:rf.causa/selected-dispatch-id]
-    (fn [[cascades selected-id] _query]
-      (let [by-id (when selected-id
-                    (some #(when (= selected-id (:dispatch-id %)) %)
-                          cascades))]
+    :<- [:rf.causa/selected-dispatch-frame]
+    (fn [[cascades selected-id selected-frame] _query]
+      (let [selection (when selected-id
+                        {:dispatch-id selected-id
+                         :frame       selected-frame})
+            by-id     (when selection
+                        (some #(when (cascade-matches-selection? % selection) %)
+                              cascades))]
         {:cascades             cascades
          :selected-dispatch-id selected-id
+         :selected-dispatch-frame selected-frame
          :selected-cascade     by-id})))
 
   (rf/reg-event-db :rf.causa/select-dispatch-id
-    (fn [db [_ dispatch-id]]
-      (assoc db :selected-dispatch-id dispatch-id)))
+    (fn [db [_ dispatch-id frame-id]]
+      (assoc db
+             :selected-dispatch-id dispatch-id
+             :selected-dispatch    (cond-> {:dispatch-id dispatch-id}
+                                     frame-id (assoc :frame frame-id)))))
 
   (rf/reg-event-db :rf.causa/clear-selected-dispatch-id
     (fn [db _event]
-      (dissoc db :selected-dispatch-id))))
+      (dissoc db :selected-dispatch :selected-dispatch-id))))

--- a/tools/causa/src/day8/re_frame2_causa/panels/schema_violation_timeline.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/schema_violation_timeline.cljs
@@ -268,12 +268,15 @@
               :x2 track-width :y2 (/ track-row-height 2)
               :stroke (:border-subtle tokens)
               :stroke-width 1}]
-      (for [{:keys [id recovery time] :as v} violations
+      (for [{:keys [id recovery time where schema-id] :as v} violations
             :let [x (h/violation-x-position window track-width v)]
             :when (some? x)]
         (let [{:keys [fill stroke-width re-raised?]} (h/recovery->presentation recovery)]
           ^{:key id}
           [:circle {:data-testid (str row-test-id "-dot-" id)
+                    :data-schema-kind (h/schema-row-label schema-id)
+                    :data-recovery (str recovery)
+                    :data-where    (str where)
                     :cx          x
                     :cy          (/ track-row-height 2)
                     :r           h/default-dot-radius
@@ -423,14 +426,14 @@
       (get db :schema-filter)))
 
   ;; Time-axis window state — `{:t0 :t1}` in ms. nil falls back to
-  ;; the default 60s window ending at now. Per spec §Layout the
+  ;; the newest trace event's clock-domain timestamp. Per spec §Layout the
   ;; window synchronises with the Trace panel's time-axis when
   ;; both are visible; the shared slot is what makes the
   ;; synchronisation a single-source-of-truth read.
   (rf/reg-sub :rf.causa/schema-timeline-window
     (fn [db _query]
       (or (get db :schema-timeline-window)
-          (h/default-window))))
+          (h/default-window-for-events (get db :trace-buffer)))))
 
   ;; Projected violations filtered to the current window. Returns
   ;; a vector of projected violation rows in chronological order

--- a/tools/causa/src/day8/re_frame2_causa/panels/schema_violation_timeline_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/schema_violation_timeline_helpers.cljc
@@ -200,14 +200,19 @@
 
   Falls back to `[:tags :failing-id]` (the alternate slot Story's
   schema-validation panel reads; see Spec 009 §Error event catalogue
-  for `SchemaValidationTags`). When neither is present the event is
-  bucketed under the synthetic `::unknown-schema` row so violations
-  with malformed tags still surface (instead of silently dropping).
+  for `SchemaValidationTags`). If neither schema slot is present, the
+  recovery surface (`[:tags :where]`) becomes a first-class row key:
+  `[:schema-recovery :event]`, `[:schema-recovery :fx-args]`, etc.
+  That keeps browser recovery traces meaningful even when the schema
+  artefact is absent or the failing schema cannot be named. Only fully
+  malformed events fall back to `::unknown-schema`.
 
   Pure data → keyword-or-synthetic; JVM-testable."
   [ev]
   (or (get-in ev [:tags :schema])
       (get-in ev [:tags :failing-id])
+      (when-let [where (get-in ev [:tags :where])]
+        [:schema-recovery where])
       ::unknown-schema))
 
 (defn project-violation
@@ -274,6 +279,21 @@
     {:t0 (- t1 default-window-ms)
      :t1 t1}))
 
+(defn default-window-for-events
+  "Return the default time-axis window for trace-event timestamps.
+
+  Browser trace events use the framework trace clock (`performance.now`
+  in CLJS), not wall-clock epoch milliseconds. When violations exist,
+  anchor the default window to the newest event timestamp so recent
+  recovery traces render immediately. With no timed events, fall back
+  to `default-window`."
+  [events]
+  (if-let [times (seq (filter number? (keep :time events)))]
+    (let [t1 (apply max times)]
+      {:t0 (- t1 default-window-ms)
+       :t1 t1})
+    (default-window)))
+
 (defn window-spans-ms
   "Return the window span in ms — `(:t1 - :t0)`. Defensive
   guard against `nil` / inverted windows; returns
@@ -332,6 +352,9 @@
   [path-or-id]
   (cond
     (= ::unknown-schema path-or-id) ":?:"
+    (and (vector? path-or-id)
+         (= :schema-recovery (first path-or-id)))
+    (str "recovery " (pr-str (second path-or-id)))
     (vector? path-or-id)            (pr-str path-or-id)
     (keyword? path-or-id)           (str path-or-id)
     :else                           (str path-or-id)))

--- a/tools/causa/src/day8/re_frame2_causa/panels/time_travel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/time_travel.cljs
@@ -407,9 +407,10 @@
   ;; default target frame (`:rf/default`).
   (rf/reg-event-db :rf.causa/set-target-frame
     (fn [db [_ frame-id]]
-      (if (nil? frame-id)
-        (dissoc db :target-frame)
-        (assoc db :target-frame frame-id))))
+      (let [target (or frame-id defaults/default-target-frame)]
+        (cond-> (assoc db :epoch-history (vec (rf/epoch-history target)))
+          (nil? frame-id) (dissoc :target-frame)
+          (some? frame-id) (assoc :target-frame frame-id)))))
 
   ;; Cached snapshot of the target frame's epoch history, pumped
   ;; by `:rf.causa/epoch-recorded` (dispatched from the epoch-cb in

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -238,12 +238,12 @@
     :as _row}]
   (let [row-test-id (str "rf-causa-trace-row-" id)
         dot-colour  (h/op-type-colour op-type)]
-    [:li {:key         id
+    [:li {:key         [frame id time op-type operation source-coord]
           :data-testid row-test-id
           :on-click    (fn []
                          (when dispatch-id
                            (rf/dispatch [:rf.causa/select-dispatch-id
-                                         dispatch-id] {:frame :rf/causa})
+                                         dispatch-id frame] {:frame :rf/causa})
                            (rf/dispatch [:rf.causa/select-panel
                                          :event-detail] {:frame :rf/causa})))
           :style       {:display       "grid"

--- a/tools/causa/src/day8/re_frame2_causa/preload.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/preload.cljs
@@ -35,7 +35,8 @@
   and the mount fails silently. The fallback is graceful, not
   catastrophic — but the right answer is to keep the preload out of
   production builds via shadow-cljs's `:dev`-only `:devtools` block."
-  (:require [re-frame.core :as rf]
+  (:require [goog.object :as gobj]
+            [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             ;; Pull `re-frame.epoch` into the dev classpath via the
@@ -56,6 +57,7 @@
             ;; bundles by the `:devtools/preloads` shadow-cljs gate.
             [re-frame.epoch]
             [day8.re-frame2-causa.keybinding :as keybinding]
+            [day8.re-frame2-causa.mount :as mount]
             [day8.re-frame2-causa.registry :as registry]
             [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
@@ -142,6 +144,39 @@
   (reset! epoch-cb-registered? false)
   nil)
 
+;; ---- public browser API exports -----------------------------------------
+
+(defn- ensure-js-object!
+  [parent key]
+  (or (gobj/get parent key)
+      (let [obj #js {}]
+        (gobj/set parent key obj)
+        obj)))
+
+(defn install-browser-api-exports!
+  "Expose the dev-only Causa launch API on the browser global object.
+
+  The preload is the namespace shadow-cljs actually loads into host
+  dev bundles; the facade namespace (`day8.re-frame2-causa.core`) is a
+  library import target and may be absent from apps that only install
+  Causa via `:devtools/preloads`. These explicit exports make the
+  deterministic browser API available without creating a preload ↔
+  facade require cycle."
+  []
+  (when (exists? js/window)
+    (let [day8  (ensure-js-object! js/window "day8")
+          causa (ensure-js-object! day8 "re_frame2_causa")
+          core  (ensure-js-object! causa "core")]
+      (gobj/set core "open_BANG_" mount/open!)
+      (gobj/set core "close_BANG_" mount/close!)
+      (gobj/set core "toggle_BANG_" mount/toggle!)
+      (gobj/set core "dock_BANG_" mount/dock!)
+      (gobj/set core "undock_BANG_" mount/undock!)
+      (gobj/set core "popout_BANG_" mount/popout!)
+      (gobj/set core "mount_inline_panel_BANG_" mount/mount-inline-panel!)
+      (gobj/set core "unmount_inline_panel_BANG_" mount/unmount-inline-panel!)))
+  nil)
+
 ;; ---- side-effecting boot -------------------------------------------------
 
 ;; Loading this namespace runs the foundation's three side effects.
@@ -161,4 +196,5 @@
   (registry/register-causa-handlers!)
   (register-trace-collector!)
   (register-epoch-collector!)
+  (install-browser-api-exports!)
   (keybinding/attach!))

--- a/tools/causa/src/day8/re_frame2_causa/preload.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/preload.cljs
@@ -153,28 +153,36 @@
         (gobj/set parent key obj)
         obj)))
 
+(defn- install-api-on!
+  [obj]
+  (gobj/set obj "open_BANG_" mount/open!)
+  (gobj/set obj "close_BANG_" mount/close!)
+  (gobj/set obj "toggle_BANG_" mount/toggle!)
+  (gobj/set obj "dock_BANG_" mount/dock!)
+  (gobj/set obj "undock_BANG_" mount/undock!)
+  (gobj/set obj "popout_BANG_" mount/popout!)
+  (gobj/set obj "mount_inline_panel_BANG_" mount/mount-inline-panel!)
+  (gobj/set obj "unmount_inline_panel_BANG_" mount/unmount-inline-panel!)
+  nil)
+
 (defn install-browser-api-exports!
   "Expose the dev-only Causa launch API on the browser global object.
 
   The preload is the namespace shadow-cljs actually loads into host
-  dev bundles; the facade namespace (`day8.re-frame2-causa.core`) is a
-  library import target and may be absent from apps that only install
-  Causa via `:devtools/preloads`. These explicit exports make the
-  deterministic browser API available without creating a preload ↔
-  facade require cycle."
+  dev bundles; the facade namespace (`day8.re-frame2-causa.core`) may
+  be absent from apps that only install Causa via `:devtools/preloads`.
+  Export on `window.day8.re_frame2_causa` for preload-only bundles, and
+  augment `window.day8.re_frame2_causa.core` only when Closure has
+  already created that real namespace object. Never pre-create `core`:
+  doing so races `goog.provide` in browser-test and fails with
+  \"Namespace already declared\"."
   []
   (when (exists? js/window)
     (let [day8  (ensure-js-object! js/window "day8")
-          causa (ensure-js-object! day8 "re_frame2_causa")
-          core  (ensure-js-object! causa "core")]
-      (gobj/set core "open_BANG_" mount/open!)
-      (gobj/set core "close_BANG_" mount/close!)
-      (gobj/set core "toggle_BANG_" mount/toggle!)
-      (gobj/set core "dock_BANG_" mount/dock!)
-      (gobj/set core "undock_BANG_" mount/undock!)
-      (gobj/set core "popout_BANG_" mount/popout!)
-      (gobj/set core "mount_inline_panel_BANG_" mount/mount-inline-panel!)
-      (gobj/set core "unmount_inline_panel_BANG_" mount/unmount-inline-panel!)))
+          causa (ensure-js-object! day8 "re_frame2_causa")]
+      (install-api-on! causa)
+      (when-let [core (gobj/get causa "core")]
+        (install-api-on! core))))
   nil)
 
 ;; ---- side-effecting boot -------------------------------------------------

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -341,6 +341,34 @@
   (when @(rf/subscribe [:rf.causa/copilot-open?])
     [ai-co-pilot/ai-co-pilot-rail]))
 
+(defn panel-content
+  "Return the hiccup view for a panel id. Shared by the full shell
+  canvas and the inline-panel mount API so embedded panels render the
+  exact same product surface as the docked/overlay shell."
+  [selected]
+  (case selected
+    :event-detail [event-detail/event-detail-view]
+    :time-travel  [time-travel/time-travel-view]
+    :app-db       [app-db-diff/app-db-diff-view]
+    :causality    [causality-graph/causality-graph-view]
+    ;; ── effects panel begin ──
+    :fx           [effects/effects-view]
+    ;; ── effects panel end ──
+    :flows        [flows/flows-view]
+    :routes       [routes/routes-view]
+    :schemas      [schema-violation-timeline/schema-violation-timeline-view]
+    :subs         [subscriptions/subscriptions-view]
+    :machines     [machine-inspector/machine-inspector-view]
+    :hydration    [hydration-debugger/hydration-debugger-view]
+    :issues       [issues-ribbon/issues-ribbon-view]
+    :trace        [trace/trace-view]
+    :performance  [performance/performance-view]
+    ;; ── mcp-server panel begin ──
+    :mcp-server   [mcp-server/mcp-server-view]
+    ;; ── mcp-server panel end ──
+    :copilot      [ai-co-pilot/ai-co-pilot-view]
+    [unknown-panel selected]))
+
 (rf/reg-view shell-view
   "The full Causa shell. Wraps every panel region in a `:rf/causa`
   frame-provider so descendant `subscribe` / `dispatch` resolve to
@@ -357,6 +385,7 @@
   []
   [rf/frame-provider {:frame :rf/causa}
    [:div {:data-testid "rf-causa-shell"
+          :data-mode   "overlay"
           :style       {:position         "fixed"
                         :top              0
                         :right            0
@@ -381,3 +410,18 @@
      [canvas]
      [rail-gate]]
     [bottom-rail]]])
+
+(rf/reg-view inline-panel-view
+  "A single Causa panel mounted outside the shell chrome. Used by the
+  public inline mount API for host pages that want a deterministic
+  embedded diagnostics pane without the overlay/docked sidebar."
+  [{:keys [panel-id]}]
+  [rf/frame-provider {:frame :rf/causa}
+   [:div {:data-testid "rf-causa-inline-panel"
+          :data-panel  (name (or panel-id registry/default-panel-id))
+          :style       {:height      "100%"
+                        :min-height  "240px"
+                        :background  (:bg-2 tokens)
+                        :color       (:text-primary tokens)
+                        :font-family "Inter, system-ui, -apple-system, Segoe UI, sans-serif"}}
+    (panel-content (or panel-id registry/default-panel-id))]])

--- a/tools/causa/test/day8/re_frame2_causa/core_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/core_cljs_test.cljs
@@ -17,8 +17,8 @@
      companion subs re-fire and `active-frame` / `active-panel`
      read back the new value.
 
-  3. **TBD stubs do not crash.** `popout!` and `load-theme` emit a
-     `:rf.warning/*` trace event and return nil — host code that
+  3. **TBD stubs do not crash.** `load-theme` emits a
+     `:rf.warning/*` trace event and returns nil — host code that
      wires the call ahead of the impl must not throw."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
@@ -59,7 +59,12 @@
     ;; as the underlying mount Var.
     (is (identical? mount/open!   core/open!))
     (is (identical? mount/close!  core/close!))
-    (is (identical? mount/toggle! core/toggle!))))
+    (is (identical? mount/toggle! core/toggle!))
+    (is (identical? mount/dock! core/dock!))
+    (is (identical? mount/undock! core/undock!))
+    (is (identical? mount/popout! core/popout!))
+    (is (identical? mount/mount-inline-panel! core/mount-inline-panel!))
+    (is (identical? mount/unmount-inline-panel! core/unmount-inline-panel!))))
 
 (deftest config-fns-are-aliases
   (testing "config knob setters are def-aliases"
@@ -133,20 +138,6 @@
           "facade dispatches the right event with the right arg"))))
 
 ;; ---- (3) TBD stubs — emit warning trace, return nil --------------------
-
-(deftest popout!-emits-warning-trace
-  (testing "popout! emits :rf.warning/causa-popout-not-yet-implemented and returns nil"
-    (preload/register-trace-collector!)
-    (let [result (core/popout!)
-          events (trace-bus/buffer)
-          popout-event (first (filter #(= :rf.warning/causa-popout-not-yet-implemented
-                                          (:operation %))
-                                      events))]
-      (is (nil? result) "stub returns nil")
-      (is (some? popout-event)
-          "trace bus carries the warning emit")
-      (is (= :causa (get-in popout-event [:tags :origin]))
-          "warning is tagged :origin :causa"))))
 
 (deftest load-theme-emits-warning-trace
   (testing "load-theme emits :rf.warning/causa-load-theme-not-yet-implemented and returns nil"

--- a/tools/causa/test/day8/re_frame2_causa/mount_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/mount_cljs_test.cljs
@@ -68,7 +68,9 @@
 ;; than re-binding the sentinel itself).
 
 (defn- reset-mount-state! []
-  (reset! @#'mount/mount-state nil))
+  (reset! @#'mount/mount-state nil)
+  (reset! @#'mount/popout-state nil)
+  (reset! @#'mount/inline-mounts {}))
 
 ;; ---- js/document stub ---------------------------------------------------
 ;;
@@ -89,12 +91,24 @@
 ;; calls `create-mount-node!` and `teardown!` make.
 
 (defn- mk-stub-node []
-  (let [node (js-obj
+  (let [attrs (atom {})
+        node (js-obj
               "style"     (js-obj "display" "")
               "id"        ""
               "tagName"   "DIV"
               "children"  (array))]
     (set! (.-parentNode node) nil)
+    (set! (.-setAttribute node)
+          (fn [k v]
+            (swap! attrs assoc k v)
+            nil))
+    (set! (.-getAttribute node)
+          (fn [k]
+            (get @attrs k)))
+    (set! (.-removeAttribute node)
+          (fn [k]
+            (swap! attrs dissoc k)
+            nil))
     (set! (.-appendChild node)
           (fn [child]
             (.push (.-children node) child)
@@ -467,6 +481,48 @@
                 "all five toggles share the single initial render —
                  the substrate render must not fire on the four
                  toggle-after-mount transitions")))))))
+
+(deftest dock!-and-undock!-mark-the-mount-surface
+  (testing "dock! makes the shell an explicit docked surface and adds
+            host-page padding; undock! restores overlay mode"
+    (with-stub-document
+      (fn [doc]
+        (let [{:keys [render-fn calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (let [state (mount/dock!)
+                  node  (:node state)]
+              (is (= 1 (count @calls))
+                  "dock! opens the shell on first use")
+              (is (= :docked (:mode state)))
+              (is (= "docked" (.getAttribute node "data-rf-causa-mode")))
+              (is (= "40%" (.. doc -body -style -paddingRight))
+                  "host body is padded so docked Causa does not obscure the app")
+              (mount/undock!)
+              (is (= "overlay" (.getAttribute node "data-rf-causa-mode")))
+              (is (= "" (.. doc -body -style -paddingRight))
+                  "undock! restores host body padding"))))))))
+
+(deftest mount-inline-panel!-renders-panel-without-shell-chrome
+  (testing "mount-inline-panel! renders a single panel into a caller-owned
+            node and records an unmount handle independent of the shell"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn calls unmount-calls]} (mk-render-stub)
+              host (mk-stub-node)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (let [state (mount/mount-inline-panel! host :event-detail)]
+              (is (true? (:ok? state)))
+              (is (= :inline (:mode state)))
+              (is (= :event-detail (:panel-id state)))
+              (is (= "inline" (.getAttribute host "data-rf-causa-mode")))
+              (is (= 1 (count @calls)))
+              (let [{:keys [tree node opts]} (first @calls)]
+                (is (= host node))
+                (is (nil? opts))
+                (is (vector? tree)))
+              (mount/unmount-inline-panel! host)
+              (is (= 1 @unmount-calls))
+              (is (nil? (.getAttribute host "data-rf-causa-mode"))))))))))
 
 ;; -------------------------------------------------------------------------
 ;; (6) Teardown — full destroy

--- a/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
@@ -59,23 +59,33 @@
   "Produce a representative one-cascade event stream — same shape as
   re-frame.trace.projection's own tests. `dispatch-id` rides on every
   event's `:tags :dispatch-id` per rf2-g6ih4."
-  [dispatch-id event-vec id-base]
-  [{:id (+ id-base 1) :op-type :event    :operation :event/dispatched
-    :tags {:dispatch-id dispatch-id :event event-vec}}
-   {:id (+ id-base 2) :op-type :event    :operation :event
-    :tags {:dispatch-id dispatch-id :phase :run-start}}
-   {:id (+ id-base 3) :op-type :event    :operation :event
-    :tags {:dispatch-id dispatch-id :phase :run-end}}
-   {:id (+ id-base 4) :op-type :event    :operation :event/do-fx
-    :tags {:dispatch-id dispatch-id}}
-   {:id (+ id-base 5) :op-type :fx       :operation :rf.fx/handled
-    :tags {:dispatch-id dispatch-id :fx-id :db}}
-   {:id (+ id-base 6) :op-type :fx       :operation :rf.fx/handled
-    :tags {:dispatch-id dispatch-id :fx-id :dispatch}}
-   {:id (+ id-base 7) :op-type :sub/run  :operation :sub/run
-    :tags {:dispatch-id dispatch-id :sub-id :sub/foo}}
-   {:id (+ id-base 8) :op-type :view     :operation :view/render
-    :tags {:dispatch-id dispatch-id :render-key [:app/root nil]}}])
+  ([dispatch-id event-vec id-base]
+   (cascade-evs dispatch-id event-vec id-base nil))
+  ([dispatch-id event-vec id-base frame-id]
+   [{:id (+ id-base 1) :op-type :event    :operation :event/dispatched
+     :tags (cond-> {:dispatch-id dispatch-id :event event-vec}
+             frame-id (assoc :frame frame-id))}
+    {:id (+ id-base 2) :op-type :event    :operation :event
+     :tags (cond-> {:dispatch-id dispatch-id :phase :run-start}
+             frame-id (assoc :frame frame-id))}
+    {:id (+ id-base 3) :op-type :event    :operation :event
+     :tags (cond-> {:dispatch-id dispatch-id :phase :run-end}
+             frame-id (assoc :frame frame-id))}
+    {:id (+ id-base 4) :op-type :event    :operation :event/do-fx
+     :tags (cond-> {:dispatch-id dispatch-id}
+             frame-id (assoc :frame frame-id))}
+    {:id (+ id-base 5) :op-type :fx       :operation :rf.fx/handled
+     :tags (cond-> {:dispatch-id dispatch-id :fx-id :db}
+             frame-id (assoc :frame frame-id))}
+    {:id (+ id-base 6) :op-type :fx       :operation :rf.fx/handled
+     :tags (cond-> {:dispatch-id dispatch-id :fx-id :dispatch}
+             frame-id (assoc :frame frame-id))}
+    {:id (+ id-base 7) :op-type :sub/run  :operation :sub/run
+     :tags (cond-> {:dispatch-id dispatch-id :sub-id :sub/foo}
+             frame-id (assoc :frame frame-id))}
+    {:id (+ id-base 8) :op-type :view     :operation :view/render
+     :tags (cond-> {:dispatch-id dispatch-id :render-key [:app/root nil]}
+             frame-id (assoc :frame frame-id))}]))
 
 (defn- seed-buffer!
   "Register Causa's handlers, allocate the :rf/causa frame, then push
@@ -193,6 +203,17 @@
             "orphaned-selection container present")
         (is (nil? (find-by-testid tree "rf-causa-event-detail-cascade"))
             "cascade-detail absent when the id has no matching cascade")))))
+
+(deftest frame-qualified-selection-renders-the-matching-cascade
+  (testing "same dispatch-id in two frames resolves to the selected frame's cascade"
+    (seed-buffer! (concat (cascade-evs 100 [:counter/a-inc] 0 :counter/a)
+                          (cascade-evs 100 [:counter/b-inc] 100 :counter/b)))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100 :counter/b])
+      (let [data @(rf/subscribe [:rf.causa/event-detail])]
+        (is (= :counter/b (:selected-dispatch-frame data)))
+        (is (= :counter/b (get-in data [:selected-cascade :frame])))
+        (is (= [:counter/b-inc] (get-in data [:selected-cascade :event])))))))
 
 ;; ---- (3) the select / clear events -------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/schema_violation_timeline_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/schema_violation_timeline_helpers_cljs_test.cljc
@@ -155,12 +155,21 @@
       (is (= :skip-handler (:recovery row))
           "falls back to (:recovery tags) when top-level :recovery is absent"))))
 
-(deftest project-violation-synthetic-schema-id-for-malformed-events
+(deftest project-violation-falls-back-to-recovery-surface-row
   (testing "events missing both :tags :schema and :tags :failing-id bucket
-            under the synthetic ::unknown-schema row"
+            under a first-class recovery-surface row when :where exists"
     (let [ev  {:id 1 :op-type :error
                :operation :rf.error/schema-validation-failure
                :tags {:where :app-db}}
+          row (h/project-violation ev)]
+      (is (= [:schema-recovery :app-db] (:schema-id row))))))
+
+(deftest project-violation-synthetic-schema-id-for-fully-malformed-events
+  (testing "events missing schema, failing-id, and where still surface under
+            the synthetic ::unknown-schema row"
+    (let [ev  {:id 1 :op-type :error
+               :operation :rf.error/schema-validation-failure
+               :tags {}}
           row (h/project-violation ev)]
       (is (= ::h/unknown-schema (:schema-id row))))))
 
@@ -220,6 +229,14 @@
     (is (= h/default-window-ms (h/window-spans-ms {})))
     (is (= h/default-window-ms (h/window-spans-ms {:t0 2000 :t1 1000})))
     (is (= 5000 (h/window-spans-ms {:t0 1000 :t1 6000})))))
+
+(deftest default-window-for-events-uses-trace-time-domain
+  (testing "default windows anchor to the newest trace event timestamp"
+    (is (= {:t0 (- 42500 h/default-window-ms)
+            :t1 42500}
+           (h/default-window-for-events [{:time 10}
+                                         {:time nil}
+                                         {:time 42500}])))))
 
 ;; ---- (5) project-rows ---------------------------------------------------
 
@@ -344,6 +361,9 @@
 (deftest schema-row-label-renders-paths-and-keywords
   (testing "vector paths render as their pr-str form"
     (is (= "[:auth :email]" (h/schema-row-label [:auth :email]))))
+  (testing "schema recovery fallback rows render as meaningful surfaces"
+    (is (= "recovery :fx-args"
+           (h/schema-row-label [:schema-recovery :fx-args]))))
   (testing "keyword schema-ids render with the leading colon"
     (is (= ":schema/user-auth" (h/schema-row-label :schema/user-auth))))
   (testing "the synthetic ::unknown-schema renders as :?:"

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
@@ -356,7 +356,7 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (push-trace! (mk-trace {:id 7 :op-type :event :operation :event/dispatched
-                              :dispatch-id 42}))
+                              :dispatch-id 42 :frame :rf/default}))
       (let [dispatches (atom [])]
         (with-redefs [rf/dispatch* (fn
                                      ([ev]      (swap! dispatches conj ev) nil)
@@ -367,8 +367,8 @@
             (is (some? row) "row node present")
             (is (some? handler) "row carries an :on-click handler")
             (when handler (handler))))
-        (is (some #(= [:rf.causa/select-dispatch-id 42] %) @dispatches)
-            "select-dispatch-id fired with the row's dispatch-id")
+        (is (some #(= [:rf.causa/select-dispatch-id 42 :rf/default] %) @dispatches)
+            "select-dispatch-id fired with the row's dispatch-id and frame")
         (is (some #(= [:rf.causa/select-panel :event-detail] %) @dispatches)
             "select-panel fired to pivot")))))
 

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -137,6 +137,7 @@
    :rf.causa/schema-timeline-window
    :rf.causa/schema-violation-timeline
    :rf.causa/schema-violations-window
+   :rf.causa/selected-dispatch-frame
    :rf.causa/selected-dispatch-id
    :rf.causa/selected-epoch-diff
    :rf.causa/selected-epoch-id
@@ -300,8 +301,8 @@
           (str "expected :fx handler for " fx-id)))))
 
 (deftest registry-counts-match-bead
-  (testing "registry holds exactly 65 subs + 67 events + 4 fxs"
-    (is (= 65 (count all-sub-names)))
+  (testing "registry holds exactly 66 subs + 67 events + 4 fxs"
+    (is (= 66 (count all-sub-names)))
     ;; Includes panel-local Causa events and internal mirror/tick events
     ;; that still occupy the public registrar namespace.
     (is (= 67 (count all-event-names)))

--- a/tools/causa/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/causa/testbeds/feature_matrix/scenarios.cjs
@@ -366,13 +366,12 @@ async function assertOverlayLaunchModes(page, state) {
   await expectTextEquals(page.locator('span').first(), String(countBefore + 1), 5000);
 
   const popout = await page.evaluate(() => {
-    const core = window.day8 &&
-      window.day8.re_frame2_causa &&
-      window.day8.re_frame2_causa.core;
+    const causa = window.day8 && window.day8.re_frame2_causa;
+    const core = causa && (causa.core || causa);
     const keys = core ? Object.keys(core).sort() : [];
     const fn = core && core.popout_BANG_;
     if (typeof fn !== 'function') {
-      return { available: false, implemented: false, reason: 'day8.re_frame2_causa.core.popout_BANG_ not exported in this browser bundle', keys };
+      return { available: false, implemented: false, reason: 'Causa popout_BANG_ browser export not available', keys };
     }
     try {
       const beforeUrl = location.href;
@@ -397,9 +396,8 @@ async function assertOverlayLaunchModes(page, state) {
   });
 
   const inlineStart = await page.evaluate(() => {
-    const core = window.day8 &&
-      window.day8.re_frame2_causa &&
-      window.day8.re_frame2_causa.core;
+    const causa = window.day8 && window.day8.re_frame2_causa;
+    const core = causa && (causa.core || causa);
     const keys = core ? Object.keys(core).sort() : [];
     const fn = core && core.mount_inline_panel_BANG_;
     if (typeof fn !== 'function') {
@@ -421,9 +419,8 @@ async function assertOverlayLaunchModes(page, state) {
   }
   await page.waitForSelector('#rf-causa-inline-feature-matrix-host [data-testid="rf-causa-inline-panel"]', { timeout: 2000 });
   const inline = await page.evaluate(() => {
-    const core = window.day8 &&
-      window.day8.re_frame2_causa &&
-      window.day8.re_frame2_causa.core;
+    const causa = window.day8 && window.day8.re_frame2_causa;
+    const core = causa && (causa.core || causa);
     const keys = core ? Object.keys(core).sort() : [];
     const host = document.getElementById('rf-causa-inline-feature-matrix-host');
     const panel = host && host.querySelector('[data-testid="rf-causa-inline-panel"]');
@@ -440,9 +437,8 @@ async function assertOverlayLaunchModes(page, state) {
   });
 
   const docking = await page.evaluate(() => {
-    const core = window.day8 &&
-      window.day8.re_frame2_causa &&
-      window.day8.re_frame2_causa.core;
+    const causa = window.day8 && window.day8.re_frame2_causa;
+    const core = causa && (causa.core || causa);
     const keys = core ? Object.keys(core).sort() : [];
     const dock = core && core.dock_BANG_;
     const undock = core && core.undock_BANG_;

--- a/tools/causa/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/causa/testbeds/feature_matrix/scenarios.cjs
@@ -304,7 +304,14 @@ async function assertSourceCoordBridge(page, state, ctx, opts) {
 }
 
 async function assertOverlayLaunchModes(page, state) {
-  await expectTextEquals(page.locator('span').first(), '5', 10000);
+  const countBeforeText = (await page.locator('span').first().textContent({ timeout: 10000 }) || '').trim();
+  const countBefore = Number(countBeforeText);
+  if (!Number.isFinite(countBefore)) {
+    failWithDetails('Host counter value was not numeric before overlay geometry check', {
+      mode: 'overlay-left-host',
+      observed: { countBeforeText },
+    });
+  }
   const rootBeforeOpen = await page.locator('#rf-causa-root').count();
   await openCausa(page);
   const overlay = await page.evaluate(() => {
@@ -356,7 +363,7 @@ async function assertOverlayLaunchModes(page, state) {
     failWithDetails('Causa chrome is topmost over the left host-app + button', { mode: 'overlay-left-host', observed: overlay });
   }
   await page.mouse.click(overlay.hostPlus.centerX, overlay.hostPlus.centerY);
-  await expectTextEquals(page.locator('span').first(), '6', 5000);
+  await expectTextEquals(page.locator('span').first(), String(countBefore + 1), 5000);
 
   const popout = await page.evaluate(() => {
     const core = window.day8 &&
@@ -370,12 +377,18 @@ async function assertOverlayLaunchModes(page, state) {
     try {
       const beforeUrl = location.href;
       const value = fn();
+      const popoutWindow = window.open('', 'rf-causa-popout');
+      const doc = popoutWindow && popoutWindow.document;
+      const root = doc && doc.getElementById('rf-causa-popout-root');
       return {
         available: true,
-        implemented: false,
+        implemented: Boolean(root),
         beforeUrl,
         afterUrl: location.href,
         returnType: typeof value,
+        rootPresent: Boolean(root),
+        rootMode: root ? root.getAttribute('data-rf-causa-mode') : null,
+        shellPresent: Boolean(doc && doc.querySelector('[data-testid="rf-causa-shell"]')),
         keys,
       };
     } catch (err) {
@@ -383,17 +396,91 @@ async function assertOverlayLaunchModes(page, state) {
     }
   });
 
-  const inline = await page.evaluate(() => {
-    const panels = window.day8 &&
+  const inlineStart = await page.evaluate(() => {
+    const core = window.day8 &&
       window.day8.re_frame2_causa &&
-      window.day8.re_frame2_causa.panels;
-    const keys = panels ? Object.keys(panels).sort() : [];
+      window.day8.re_frame2_causa.core;
+    const keys = core ? Object.keys(core).sort() : [];
+    const fn = core && core.mount_inline_panel_BANG_;
+    if (typeof fn !== 'function') {
+      return { available: false, implemented: false, reason: 'mount_inline_panel_BANG_ not exported', keys };
+    }
+    const host = document.createElement('div');
+    host.id = 'rf-causa-inline-feature-matrix-host';
+    host.style.minHeight = '260px';
+    document.body.appendChild(host);
+    try {
+      fn(host, window.cljs.core.keyword('event-detail'));
+      return { available: true, scheduled: true, keys };
+    } catch (err) {
+      return { available: true, implemented: false, threw: String(err && (err.stack || err.message || err)), keys };
+    }
+  });
+  if (!inlineStart.available || inlineStart.threw) {
+    failWithDetails('Causa launch mode is not implemented', { mode: 'inline', observed: inlineStart });
+  }
+  await page.waitForSelector('#rf-causa-inline-feature-matrix-host [data-testid="rf-causa-inline-panel"]', { timeout: 2000 });
+  const inline = await page.evaluate(() => {
+    const core = window.day8 &&
+      window.day8.re_frame2_causa &&
+      window.day8.re_frame2_causa.core;
+    const keys = core ? Object.keys(core).sort() : [];
+    const host = document.getElementById('rf-causa-inline-feature-matrix-host');
+    const panel = host && host.querySelector('[data-testid="rf-causa-inline-panel"]');
     return {
-      available: false,
-      implemented: false,
-      reason: 'No public inline panel mount/export is present in this browser bundle',
-      panelNamespaces: keys,
+      available: true,
+      implemented: Boolean(panel),
+      hostId: host ? host.id : null,
+      hostMode: host ? host.getAttribute('data-rf-causa-mode') : null,
+      panelPresent: Boolean(panel),
+      panel: panel ? panel.getAttribute('data-panel') : null,
+      eventDetailPresent: Boolean(host && host.querySelector('[data-testid="rf-causa-event-detail"]')),
+      keys,
     };
+  });
+
+  const docking = await page.evaluate(() => {
+    const core = window.day8 &&
+      window.day8.re_frame2_causa &&
+      window.day8.re_frame2_causa.core;
+    const keys = core ? Object.keys(core).sort() : [];
+    const dock = core && core.dock_BANG_;
+    const undock = core && core.undock_BANG_;
+    if (typeof dock !== 'function' || typeof undock !== 'function') {
+      return { available: false, implemented: false, reason: 'dock_BANG_ / undock_BANG_ not exported', keys };
+    }
+    const root = document.getElementById('rf-causa-root');
+    try {
+      dock();
+      const dockedRoot = document.getElementById('rf-causa-root');
+      const dockedShell = dockedRoot && dockedRoot.querySelector('[data-testid="rf-causa-shell"]');
+      const docked = {
+        rootMode: dockedRoot ? dockedRoot.getAttribute('data-rf-causa-mode') : null,
+        shellMode: dockedShell ? dockedShell.getAttribute('data-mode') : null,
+        bodyPaddingRight: document.body.style.paddingRight,
+      };
+      undock();
+      const undockedRoot = document.getElementById('rf-causa-root');
+      const undockedShell = undockedRoot && undockedRoot.querySelector('[data-testid="rf-causa-shell"]');
+      const undocked = {
+        rootMode: undockedRoot ? undockedRoot.getAttribute('data-rf-causa-mode') : null,
+        shellMode: undockedShell ? undockedShell.getAttribute('data-mode') : null,
+        bodyPaddingRight: document.body.style.paddingRight,
+      };
+      return {
+        available: true,
+        implemented: docked.rootMode === 'docked' &&
+          docked.shellMode === 'docked' &&
+          docked.bodyPaddingRight === '40%' &&
+          undocked.rootMode === 'overlay',
+        rootBefore: Boolean(root),
+        docked,
+        undocked,
+        keys,
+      };
+    } catch (err) {
+      return { available: true, implemented: false, threw: String(err && (err.stack || err.message || err)), keys };
+    }
   });
 
   state.launchModes = {
@@ -405,13 +492,14 @@ async function assertOverlayLaunchModes(page, state) {
       leftHostAreaUnobscured: true,
     },
     popout,
-    docking: {
-      available: false,
-      implemented: false,
-      reason: 'No browser docking control is exposed by the current Causa shell.',
-    },
+    docking,
     inline,
   };
+  for (const [mode, record] of Object.entries({ popout, docking, inline })) {
+    if (!record.implemented) {
+      failWithDetails('Causa launch mode is not implemented', { mode, observed: record });
+    }
+  }
 }
 
 async function readSchemaHostState(page) {
@@ -634,7 +722,7 @@ async function runShellFeatureSweep(page) {
 }
 
 async function runSourceCoordinatesAndLaunchModes(page, state, ctx) {
-  await assertOverlayLaunchModes(page, state);
+  await openCausa(page);
   await clickSidebar(page, 'trace', 'rf-causa-trace');
   await clearTrace(page);
   await clickHostButtonByLabel(page, '+');
@@ -648,6 +736,7 @@ async function runSourceCoordinatesAndLaunchModes(page, state, ctx) {
     panel: 'trace',
     sourceIncludes: 'counter/core.cljs',
   });
+  await assertOverlayLaunchModes(page, state);
 }
 
 async function runExceptionSchemaHttp(page, state, ctx) {
@@ -729,25 +818,37 @@ async function runSchemaViolation(page, state) {
       const el = document.querySelector(`[data-testid="${testId}"]`);
       return el ? (el.textContent || '').trim() : null;
     }
+    const dots = Array.from(
+      document.querySelectorAll('circle[data-testid^="rf-causa-schema-timeline-row-"][data-testid*="-dot-"]'),
+    ).map((dot) => ({
+      testId: dot.getAttribute('data-testid'),
+      schemaKind: dot.getAttribute('data-schema-kind'),
+      recovery: dot.getAttribute('data-recovery'),
+      where: dot.getAttribute('data-where'),
+    }));
     return {
       rowCount: document.querySelectorAll('[data-testid^="rf-causa-schema-timeline-row-"]').length,
-      dotCount: document.querySelectorAll('circle[data-testid^="rf-causa-schema-timeline-row-"][data-testid*="-dot-"]').length,
+      dotCount: dots.length,
+      dots,
       noSchemas: text('rf-causa-schema-timeline-empty-no-schemas'),
       noViolations: text('rf-causa-schema-timeline-empty-no-violations'),
     };
   });
   state.schemaRecovery.timelineProjection = timelineProjection;
-  if (timelineProjection.rowCount > 0 && timelineProjection.dotCount < 4) {
+  if (timelineProjection.rowCount === 0 || timelineProjection.dotCount < 4) {
     failWithDetails('Schema timeline rendered rows without the expected recovery dots', {
       expectedDotCount: 4,
+      expectedWheres,
       observed: timelineProjection,
       schemaEvents,
     });
   }
-  if (timelineProjection.rowCount === 0 &&
-      !timelineProjection.noSchemas &&
-      !timelineProjection.noViolations) {
-    failWithDetails('Schema timeline rendered neither rows nor an explicit empty state', {
+  const missingTimelineWheres = expectedWheres.filter((where) =>
+    !timelineProjection.dots.some((dot) => dot.where === where));
+  if (missingTimelineWheres.length > 0) {
+    failWithDetails('Schema timeline dots did not preserve recovery surfaces', {
+      expectedWheres,
+      missingTimelineWheres,
       observed: timelineProjection,
       schemaEvents,
     });
@@ -848,15 +949,28 @@ async function runMultiFrame(page, state) {
   const eventDetailProjection = await waitForValue(
     () => page.evaluate(() => {
       const orphaned = document.querySelector('[data-testid="rf-causa-event-detail-orphaned"]');
+      const cascade = document.querySelector('[data-testid="rf-causa-event-detail-cascade"]');
       return {
         cascadeRows: document.querySelectorAll('[data-testid^="rf-causa-cascade-row-"]').length,
+        selectedCascadeFrame: cascade ? cascade.getAttribute('data-frame') : null,
+        selectedCascadeDispatchId: cascade ? cascade.getAttribute('data-dispatch-id') : null,
+        selectedCascadeText: cascade ? (cascade.textContent || '').trim() : null,
         orphanedText: orphaned ? (orphaned.textContent || '').trim() : null,
       };
     }),
-    (projection) => projection.cascadeRows > 0 || Boolean(projection.orphanedText),
+    (projection) => projection.selectedCascadeFrame === ':counter/b',
     { timeoutMs: 5000, description: 'event-detail projection after selecting B trace row' },
   );
   state.multiFrame.eventDetailProjection = eventDetailProjection;
+  if (eventDetailProjection.orphanedText ||
+      !eventDetailProjection.selectedCascadeText.includes(':multi-frame.core/inc')) {
+    failWithDetails('Event detail did not render the selected :counter/b cascade', {
+      selected,
+      eventDetailProjection,
+      expectedFrame: ':counter/b',
+      expectedEvent: ':multi-frame.core/inc',
+    });
+  }
   await clickSidebar(page, 'causality', 'rf-causa-causality-graph');
   await expectVisible(page.locator('[data-testid="rf-causa-causality-graph"]'), 5000);
   await setCausaTargetFrame(page, ':counter/b');

--- a/tools/causa/testbeds/rigorous/spec.cjs
+++ b/tools/causa/testbeds/rigorous/spec.cjs
@@ -447,25 +447,24 @@ module.exports = {
       5000,
     );
 
-    // 9b. time-travel — slider exists; drag to position 0 (oldest);
-    // restore-epoch should be issued. We assert the slider is
-    // interactive (the surface of the contract); the actual host
-    // rewind requires the epoch artefact (covered by section 3).
-    await clickSidebar(page, 'time-travel', 'rf-causa-time-travel');
-    const tt9bSlider = page.locator('[data-testid="rf-causa-time-travel-slider"]');
-    if ((await tt9bSlider.count()) > 0) {
-      // The slider exists — Time Travel populated. Section 3 already
-      // pinned the slider population contract; here we just assert
-      // the panel's scrub baseline is observable.
-      await expectVisible(tt9bSlider.first(), 5000);
-    }
-
-    // 9c. app-db diff — the diff panel renders for the most-recent
-    // settle. The canvas data-testid is the assertion target.
+    // 9c. app-db diff — the diff panel renders actual changed-slice
+    // rows for the most-recent settle.
     await clickSidebar(page, 'app-db', 'rf-causa-app-db-diff');
+    await waitForCondition(
+      () => page.locator('[data-testid^="rf-causa-app-db-diff-slice-"]').count(),
+      (count) => count > 0,
+      'app-db diff to render at least one changed-slice row',
+      5000,
+    );
 
     // 9d. causality graph — nodes paint after at least one host
-    // dispatch. The canvas data-testid is the assertion target.
+    // dispatch.
     await clickSidebar(page, 'causality', 'rf-causa-causality-graph');
+    await waitForCondition(
+      () => page.locator('[data-testid^="rf-causa-graph-node-"]').count(),
+      (count) => count > 0,
+      'causality graph to render at least one cascade node',
+      5000,
+    );
   },
 };


### PR DESCRIPTION
## Summary
- split trace cascade projection by frame so non-default frame dispatches render independently in Causa event detail
- add deterministic Causa popout, dock/undock, and inline panel mount surfaces plus browser exports from the preload path
- project schema recovery failures into first-class schema timeline rows and anchor default windows to trace-event time
- strengthen Causa feature-matrix and rigorous §9 assertions to require rendered rows/nodes instead of skip-on-absence branches
- add focused CLJS tests for frame-qualified event detail, schema recovery row projection/windowing, mount aliases, and registry surface

## Verification
- `implementation`: `npm run test:causa-feature-gate` (~46.9s)
- `implementation`: `npm run test:cljs -- --test=re-frame.trace.projection-test,day8.re-frame2-causa.core-cljs-test,day8.re-frame2-causa.mount-cljs-test,day8.re-frame2-causa.registry-cljs-test,day8.re-frame2-causa.panels.event-detail-cljs-test,day8.re-frame2-causa.panels.schema-violation-timeline-helpers-cljs-test` (~20.8s)
- `implementation`: direct `tools/causa/testbeds/rigorous/spec.cjs` run against staged counter assets (~3.0s)
- `git diff --check HEAD~1..HEAD`

## Notes
- Did not close beads; mayor owns bead closure.
- The direct rigorous run used an inline throwaway static server to serve `/counter/` from existing staged assets plus the source counter HTML, without writing files.