### PR TITLE
test(story): add browser scenario slice

### DIFF
--- a/examples/scripts/run-story-feature-load-tests.cjs
+++ b/examples/scripts/run-story-feature-load-tests.cjs
@@ -18,9 +18,19 @@ const BASE_URL = process.env.STORY_FEATURE_LOAD_BASE_URL || 'http://127.0.0.1:80
 const TIMEOUT_MS = parseInt(process.env.STORY_FEATURE_LOAD_TIMEOUT_MS || '300000', 10);
 const VERBOSE = process.env.RF2_VERBOSE_TESTS === '1';
 
-const SPEC_FILES = [
+const ALL_SPEC_FILES = [
   path.join(REPO_ROOT, 'tools', 'story', 'test', 'story_feature_load.cjs'),
+  path.join(REPO_ROOT, 'tools', 'story', 'test', 'story_browser_scenarios.cjs'),
 ];
+
+const SPEC_FILTER = process.env.STORY_FEATURE_LOAD_SPEC || '';
+const SPEC_FILES = SPEC_FILTER
+  ? ALL_SPEC_FILES.filter((file) => path.basename(file).includes(SPEC_FILTER))
+  : ALL_SPEC_FILES;
+
+if (SPEC_FILTER && SPEC_FILES.length === 0) {
+  throw new Error(`STORY_FEATURE_LOAD_SPEC=${SPEC_FILTER} matched no Story specs`);
+}
 
 function withTimeout(promise, ms, label) {
   let timer;

--- a/tools/story/src/re_frame/story/identity.cljc
+++ b/tools/story/src/re_frame/story/identity.cljc
@@ -137,7 +137,8 @@
   [x]
   (let [canon (canonical-form [:rf/snapshot-canonical-v1 x])
         s     (pr-str canon)
-        h     (bit-and 0xffffffff (hash s))
+        h     #?(:clj  (bit-and 0xffffffff (hash s))
+                 :cljs (unsigned-bit-shift-right (hash s) 0))
         hex   #?(:clj  (format "%08x" h)
                  :cljs (let [s (.toString h 16)
                              pad (- 8 (.-length s))]

--- a/tools/story/src/re_frame/story/share.cljc
+++ b/tools/story/src/re_frame/story/share.cljc
@@ -35,7 +35,9 @@
   `:rf.story/enabled?` false (per IMPL-SPEC §6.2). The QR encoder is
   only reachable from the share UI; under disabled builds Closure DCE
   drops both the UI shell and the qrcode-generator wrapper."
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            #?(:clj  [clojure.edn :as edn]
+               :cljs [cljs.reader :as edn])))
 
 ;; ---- pure: URL encoding -------------------------------------------------
 
@@ -55,6 +57,73 @@
   (if (keyword? k)
     (str (when-let [n (namespace k)] (str n "/")) (name k))
     (str k)))
+
+(defn parse-keyword-token
+  "Parse the keyword token emitted by `kw->str`.
+
+  Accepts both the wire form (`\"story.counter/loaded\"`) and the
+  printed keyword form (`\":story.counter/loaded\"`) so old manually-
+  copied URLs remain usable. Returns nil for blank / malformed input."
+  [s]
+  (when (string? s)
+    (let [trimmed (str/trim s)
+          token   (if (str/starts-with? trimmed ":")
+                    (subs trimmed 1)
+                    trimmed)]
+      (when (seq token)
+        (if-let [slash (str/index-of token "/")]
+          (let [ns-part (subs token 0 slash)
+                name-part (subs token (inc slash))]
+            (when (and (seq ns-part) (seq name-part))
+              (keyword ns-part name-part)))
+          (keyword token))))))
+
+(defn parse-modes-param
+  "Parse a `modes=` URLSearchParams value into a vector of mode ids.
+  The wire shape is the same comma-separated token list `build-params`
+  emits."
+  [s]
+  (when (and (string? s) (seq (str/trim s)))
+    (->> (str/split s #",")
+         (map parse-keyword-token)
+         (remove nil?)
+         vec)))
+
+(defn parse-substrate-param
+  "Parse the optional `substrate=` URLSearchParams value. Returns a
+  keyword or nil."
+  [s]
+  (parse-keyword-token s))
+
+(defn- ^:no-doc read-edn
+  [s]
+  (try
+    [true (edn/read-string s)]
+    (catch #?(:clj Exception :cljs :default) _
+      [false nil])))
+
+(defn- ^:no-doc parse-override-entry
+  [entry]
+  (when-let [idx (and (string? entry) (str/index-of entry ":"))]
+    (let [k-token (subs entry 0 idx)
+          v-token (subs entry (inc idx))
+          k       (parse-keyword-token k-token)
+          [ok? v] (read-edn v-token)]
+      (when (and k ok?)
+        [k v]))))
+
+(defn parse-overrides-param
+  "Parse an `overrides=` URLSearchParams value into a cell-overrides
+  map. The v1 wire shape is a comma-separated list of
+  `<arg-token>:<edn-value>` pairs; malformed entries are ignored so a
+  stale share URL degrades to the valid subset instead of poisoning the
+  shell state."
+  [s]
+  (when (and (string? s) (seq (str/trim s)))
+    (not-empty
+      (into {}
+            (keep parse-override-entry)
+            (str/split s #",")))))
 
 (defn- ^:no-doc kv-pair
   "Build a `k=v` URL parameter fragment. `k` is a keyword;
@@ -113,11 +182,17 @@
   ([variant-id opts]           (variant-share-url variant-id "" opts))
   ([variant-id base-url opts]
    (let [params (build-params (assoc opts :variant-id variant-id))
-         sep    (cond
-                  (str/blank? base-url)        ""
-                  (str/includes? base-url "?") "&"
-                  :else                        "?")]
-     (str base-url sep (str/join "&" params)))))
+         joined (str/join "&" params)]
+     (if (str/blank? base-url)
+       joined
+       (let [hash-idx (str/index-of base-url "#")
+             before   (if hash-idx (subs base-url 0 hash-idx) base-url)
+             fragment (when hash-idx (subs base-url hash-idx))
+             sep      (cond
+                        (str/blank? before)      ""
+                        (str/includes? before "?") "&"
+                        :else                    "?")]
+         (str before sep joined fragment))))))
 
 ;; QR rendering lives in re-frame.story.qr (CLJS-only). The vendored
 ;; `qrcode-generator` npm package produces an inline SVG string locally;

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -24,6 +24,7 @@
             [re-frame.story.registrar :as registrar]
             [re-frame.story.args :as args]
             [re-frame.story.decorators :as decorators]
+            [re-frame.story.identity :as identity]
             [re-frame.story.runtime :as runtime]
             [re-frame.story.ui.multi-substrate :as multi-substrate]
             [re-frame.story.ui.open-in-editor :as open-in-editor]
@@ -257,8 +258,13 @@
 
        multi?
        ;; Stage 6: multi-substrate side-by-side grid. Per IMPL-SPEC §2.2
-       ;; failures render inline rather than aborting.
-       [multi-substrate/multi-substrate-grid variant-id]
+       ;; failures render inline rather than aborting. The grid still
+       ;; renders user views, so it needs the same frame context as the
+       ;; single-substrate path; otherwise Reagent subscriptions fall
+       ;; back to the live app/default frame.
+       ^{:key (str "multi-" variant-id)}
+       [frame-provider-ns-safe {:frame variant-id}
+        [multi-substrate/multi-substrate-grid variant-id]]
 
        :else
        (let [resolved-view (rf/view view-id)]
@@ -281,6 +287,7 @@
            ;; Story's own UI as the source of violations, which is
            ;; wrong: Story chrome a11y is Story's concern, not the
            ;; variant author's.
+           ^{:key (str "single-" variant-id)}
            [frame-provider-ns-safe {:frame variant-id}
             [:div {:data-rf-story-variant-root (pr-str variant-id)}
              (safe-decorated-view
@@ -310,11 +317,18 @@
        (when config/enabled?
          (when-let [variant-id (:selected-variant @state/shell-state-atom)]
            (run-with-shell-opts! variant-id))))
-     :reagent-render
-     (fn []
-       (let [shell      @state/shell-state-atom
-             variant-id (:selected-variant shell)
-             _tick      (:hot-reload-tick shell)]   ;; deref to subscribe
+    :reagent-render
+    (fn []
+      (let [shell      @state/shell-state-atom
+            variant-id (:selected-variant shell)
+            snapshot   (when variant-id
+                         (identity/snapshot-identity
+                           variant-id
+                           {:active-modes   (:active-modes shell)
+                            :cell-overrides (get-in shell [:cell-overrides
+                                                           variant-id])
+                            :substrate      (:substrate shell)}))
+            _tick      (:hot-reload-tick shell)]   ;; deref to subscribe
          ;; Per rf2-xc65: the canvas wrap is the scrollable container
          ;; for variant content; `tab-index "0"` makes it keyboard-
          ;; focusable so axe-core's `scrollable-region-focusable` rule
@@ -332,7 +346,9 @@
          [:section (cond-> {:style      (:wrap styles)
                             :aria-label "Variant canvas"
                             :tab-index  "0"}
-                     variant-id (assoc :data-test-variant (pr-str variant-id)))
+                     variant-id (assoc :data-test-variant (pr-str variant-id))
+                     (:content-hash snapshot)
+                     (assoc :data-snapshot-hash (:content-hash snapshot)))
           (if variant-id
             [canvas-inner variant-id]
             [:div {:style (:empty styles)}

--- a/tools/story/src/re_frame/story/ui/share.cljs
+++ b/tools/story/src/re_frame/story/ui/share.cljs
@@ -17,6 +17,7 @@
   DCE the entire ns via the same reachability path the rest of the UI
   shell uses."
   (:require [reagent.core :as r]
+            [re-frame.story.registrar :as registrar]
             [re-frame.story.qr :as qr]
             [re-frame.story.share :as share]
             [re-frame.story.ui.state :as state]))
@@ -89,13 +90,47 @@
   (let [shell @state/shell-state-atom
         base  (when js/window
                 (let [loc (.-location js/window)]
-                  (str (.-origin loc) (.-pathname loc))))]
+                  (str (.-origin loc) (.-pathname loc) "#/stories")))]
     (share/variant-share-url
       variant-id
       (or base "")
       {:active-modes   (:active-modes shell)
        :cell-overrides (get-in shell [:cell-overrides variant-id])
        :substrate      (:substrate shell)})))
+
+(defn- current-url-params
+  []
+  (when (exists? js/window)
+    (let [search (some-> js/window .-location .-search)]
+      (when (and (string? search) (seq search))
+        (try
+          (js/URLSearchParams. search)
+          (catch :default _ nil))))))
+
+(defn hydrate-from-url!
+  "Hydrate the share-URL-owned shell state from `window.location.search`.
+
+  Toolbar modes hydrate in `re-frame.story.ui.toolbar`; this function
+  owns the rest of the share URL contract: focused variant, per-variant
+  cell overrides, and substrate. Invalid/stale variant ids are ignored
+  so old QR links degrade to the shell empty state instead of crashing."
+  []
+  (when-let [params (current-url-params)]
+    (let [variant-id (share/parse-keyword-token (.get params "variant"))
+          overrides  (share/parse-overrides-param (.get params "overrides"))
+          substrate  (share/parse-substrate-param (.get params "substrate"))
+          valid?     (and variant-id (registrar/registered? :variant variant-id))]
+      (state/swap-state!
+        (fn [s]
+          (let [s' (if valid?
+                     (cond-> (-> s
+                                 (state/select-variant variant-id)
+                                 (state/select-workspace nil))
+                       (seq overrides)
+                       (assoc-in [:cell-overrides variant-id] overrides))
+                     s)]
+            (cond-> s'
+              substrate (assoc :substrate substrate))))))))
 
 (defn- copy-to-clipboard!
   "Best-effort clipboard write. Uses the async clipboard API where
@@ -119,13 +154,16 @@
       [:div {:style {:position "relative" :display "inline-block"}}
        [:button {:style    (:button styles)
                  :title    "Share this variant (URL + QR)"
+                 :data-test "story-share-button"
                  :on-click (fn [_] (swap! open? not))}
         "share"]
        (when @open?
          (let [url (current-share-url variant-id)]
-           [:div {:style (:popover styles)}
+           [:div {:style (:popover styles)
+                  :data-test "story-share-popover"}
             [:div {:style (:url-label styles)} "share link"]
-            [:div {:style (:url styles)} url]
+            [:div {:style (:url styles)
+                   :data-test "story-share-url"} url]
             ;; Local QR encoder per rf2-20w5i: the SVG is generated
             ;; in-process from `qrcode-generator`; no third-party
             ;; endpoint is contacted. `:dangerouslySetInnerHTML` is
@@ -135,6 +173,8 @@
             [:div {:style                   (:qr styles)
                    :role                    "img"
                    :aria-label              "QR code for variant URL"
+                   :data-test               "story-share-qr"
+                   :data-share-url          url
                    :dangerouslySetInnerHTML {:__html (qr/qr-svg-string url 4)}}]
             [:button {:style    (:copy-btn styles)
                       :on-click (fn [_]

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -55,6 +55,7 @@
             [re-frame.story.ui.recorder :as recorder-ui]
             [re-frame.story.ui.save-variant :as save-variant-ui]
             [re-frame.story.ui.scrubber :as scrubber]
+            [re-frame.story.ui.share :as share]
             [re-frame.story.ui.shell-styles :refer [styles]]
             [re-frame.story.ui.sidebar :as sidebar]
             [re-frame.story.ui.state :as state]
@@ -481,6 +482,11 @@
          (toolbar/hydrate!)
          (start-hot-reload-poll!)
          (selection-watcher)
+         ;; Hydrate the share URL's focused variant / overrides /
+         ;; substrate slots after the selection watcher is installed:
+         ;; deep-link selection must take the same preallocate-frame path
+         ;; as a user clicking a sidebar row.
+         (share/hydrate-from-url!)
          ;; rf2-5fc15: install the Test Codegen recorder's trace-bus
          ;; listener once at shell mount. The listener short-circuits
          ;; on every emit when no recording is in flight, so leaving

--- a/tools/story/test/re_frame/story_runtime_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_runtime_cljs_test.cljs
@@ -96,7 +96,8 @@
                                      {:substrate :reagent})]
       (is (= :story.cljs.id/v (:variant-id s)))
       (is (string?            (:content-hash s)))
-      (is (= 8 (count (:content-hash s)))))))
+      (is (re-matches #"[0-9a-f]{8}" (:content-hash s))
+          "content-hash is unsigned fixed-width lowercase hex"))))
 
 ;; ---- args precedence ----------------------------------------------------
 

--- a/tools/story/test/re_frame/story_share_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_share_cljs_test.cljs
@@ -26,6 +26,26 @@
     (let [url (story/variant-share-url :story.x/y "" nil)]
       (is (re-find #"variant=" url)))))
 
+(deftest hash-routed-share-url-keeps-query-before-fragment
+  (testing "CLJS builder emits ?variant= before #/stories so the shell can hydrate"
+    (let [url (share/variant-share-url
+                :story.counter/loaded
+                "https://example.test/counter-with-stories/#/stories"
+                {:cell-overrides {:label "Shared"}})]
+      (is (str/starts-with? url "https://example.test/counter-with-stories/?"))
+      (is (str/includes? url "#/stories"))
+      (is (str/includes? url "variant="))
+      (is (str/includes? url "overrides=")))))
+
+(deftest parse-share-url-params-cljs
+  (testing "CLJS parser reconstructs the share URL tokens used by the shell hydrator"
+    (is (= :story.counter/loaded
+           (share/parse-keyword-token "story.counter/loaded")))
+    (is (= [:Mode.app/dark :Mode.app/mobile]
+           (share/parse-modes-param "Mode.app/dark,Mode.app/mobile")))
+    (is (= {:label "Shared" :count 7}
+           (share/parse-overrides-param "label:\"Shared\",count:7")))))
+
 ;; ---- local QR encoder (rf2-20w5i) ---------------------------------------
 ;;
 ;; Per the security audit, the QR is now generated locally via the

--- a/tools/story/test/re_frame/story_share_test.clj
+++ b/tools/story/test/re_frame/story_share_test.clj
@@ -76,6 +76,29 @@
                 nil)]
       (is (re-find #"\?from=index&variant=" url)))))
 
+(deftest variant-share-url-inserts-query-before-hash-route
+  (testing "hash-routed Story links keep query params in location.search"
+    (let [url (share/variant-share-url
+                :story.foo/bar
+                "https://example.test/counter-with-stories/#/stories"
+                {:active-modes [:Mode.app/dark]})]
+      (is (str/starts-with?
+            url
+            "https://example.test/counter-with-stories/?"))
+      (is (str/includes? url "#/stories"))
+      (is (re-find #"variant=" url))
+      (is (re-find #"modes=" url)))))
+
+(deftest parse-share-url-params
+  (testing "share URL parser reconstructs variant, modes, substrate, and overrides"
+    (is (= :story.counter/loaded
+           (share/parse-keyword-token "story.counter/loaded")))
+    (is (= [:Mode.app/dark :Mode.app/mobile]
+           (share/parse-modes-param "Mode.app/dark,Mode.app/mobile")))
+    (is (= :uix (share/parse-substrate-param "uix")))
+    (is (= {:label "Shared Label" :count 9}
+           (share/parse-overrides-param "label:\"Shared Label\",count:9")))))
+
 (deftest variant-share-url-public-export
   (testing "story/variant-share-url is exported"
     (let [url (story/variant-share-url

--- a/tools/story/test/story_browser_scenarios.cjs
+++ b/tools/story/test/story_browser_scenarios.cjs
@@ -1,0 +1,356 @@
+/*
+ * Focused Story browser scenarios (rf2-dczqg).
+ *
+ * This spec is intentionally narrower than story_feature_load.cjs. It
+ * exercises real Story features that need a live browser DOM and keeps
+ * every failure anchored to a feature name plus the active Story route.
+ */
+
+const {
+  expectTextEquals,
+  expectTextContains,
+  expectVisible,
+  waitForValue,
+} = require('../../../examples/scripts/spec-helpers.cjs');
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function urlFor(page, path) {
+  return new URL(path, page.url()).href;
+}
+
+async function storyContext(page) {
+  return page.evaluate(() => {
+    const activeVariant =
+      document.querySelector('[data-test-variant]')?.getAttribute('data-test-variant') ||
+      null;
+    const canvas = activeVariant
+      ? document.querySelector(`[data-test-variant="${activeVariant}"]`)
+      : null;
+    const activeMode =
+      document
+        .querySelector('[data-test="story-mode-tabs"] [aria-selected="true"]')
+        ?.getAttribute('data-mode-tab') || null;
+    const activeToolbarModes = Array.from(
+      document.querySelectorAll('[data-test="story-toolbar"] [aria-pressed="true"]'),
+    ).map((el) => el.getAttribute('data-toolbar-mode') || el.textContent.trim());
+    return {
+      url: window.location.href,
+      search: window.location.search,
+      hash: window.location.hash,
+      activeVariant,
+      activeMode,
+      activeToolbarModes,
+      snapshotHash: canvas?.getAttribute('data-snapshot-hash') || null,
+    };
+  });
+}
+
+function withContext(err, feature, ctx) {
+  err.message = `[story-browser-scenario=${feature}] ${err.message}`;
+  err.feature = feature;
+  err.phase = 'story-browser-scenarios';
+  err.storyContext = ctx;
+  return err;
+}
+
+async function scenario(page, feature, fn) {
+  try {
+    return await fn();
+  } catch (err) {
+    throw withContext(err, feature, await storyContext(page).catch(() => null));
+  }
+}
+
+async function primeHelpDismissed(page) {
+  await page.evaluate(() => {
+    try {
+      localStorage.setItem('re-frame.story/seen-help-v1', '1');
+    } catch (_) {
+      /* ignore */
+    }
+  });
+}
+
+async function dismissHelpIfOpen(page) {
+  const help = page.getByRole('dialog', { name: /Story playground help/i });
+  if (await help.isVisible().catch(() => false)) {
+    await help.getByRole('button', { name: /Got it/i }).click();
+  }
+}
+
+async function gotoStory(page, path) {
+  await page.goto(urlFor(page, path), { waitUntil: 'load' });
+  await primeHelpDismissed(page);
+  await expectVisible(page.getByRole('navigation'), 10000);
+  await expectVisible(page.getByRole('main'), 10000);
+  await expectVisible(page.getByRole('complementary'), 10000);
+  await dismissHelpIfOpen(page);
+}
+
+async function clickVariant(page, slashName) {
+  const row = page
+    .getByRole('navigation')
+    .getByText(slashName, { exact: false })
+    .first();
+  await row.waitFor({ state: 'visible', timeout: 10000 });
+  await row.click();
+}
+
+function canvas(page, variantId) {
+  return page.locator(
+    `main section[aria-label="Variant canvas"][data-test-variant="${variantId}"]`,
+  );
+}
+
+async function waitForCanvas(page, variantId) {
+  await canvas(page, variantId).waitFor({ state: 'visible', timeout: 10000 });
+}
+
+async function setMode(page, mode) {
+  const chip = page.locator(`[data-test="story-mode-tabs"] [data-mode-tab="${mode}"]`);
+  await chip.waitFor({ state: 'visible', timeout: 5000 });
+  await chip.click();
+  await waitForValue(
+    () => chip.getAttribute('aria-selected'),
+    (value) => value === 'true',
+    { timeoutMs: 5000, description: `${mode} mode selected` },
+  );
+}
+
+async function snapshotHash(page, variantId) {
+  return canvas(page, variantId).getAttribute('data-snapshot-hash');
+}
+
+function assertUrlParam(url, key, expected) {
+  const parsed = new URL(url);
+  const actual = parsed.searchParams.get(key);
+  if (actual !== expected) {
+    throw new Error(`expected share URL ${key}=${expected}, got ${actual} in ${url}`);
+  }
+  return parsed;
+}
+
+function assertNoThirdPartyRequests(page) {
+  const requests = page.__storyBrowserScenarioRequests || [];
+  const base = new URL(page.url());
+  const unexpected = requests.filter((requestUrl) => {
+    try {
+      const u = new URL(requestUrl, base.href);
+      return u.origin !== base.origin;
+    } catch (_) {
+      return false;
+    }
+  });
+  if (unexpected.length > 0) {
+    throw new Error(`unexpected third-party requests: ${JSON.stringify(unexpected)}`);
+  }
+}
+
+module.exports = {
+  name: 'Story browser scenarios (rf2-dczqg)',
+  url: '/counter-with-stories/#/stories',
+  context: storyContext,
+  run: async (page) => {
+    page.__storyBrowserScenarioRequests = [];
+    page.on('request', (request) => {
+      page.__storyBrowserScenarioRequests.push(request.url());
+    });
+
+    await scenario(page, 'share-url-hydrates-variant-modes-and-props', async () => {
+      await primeHelpDismissed(page);
+      await gotoStory(
+        page,
+        '/counter-with-stories/?variant=story.counter%2Floaded&modes=Mode.app%2Fdark&overrides=label%3A%22Shared%20Label%22#/stories',
+      );
+
+      await waitForCanvas(page, ':story.counter/loaded');
+      const loaded = canvas(page, ':story.counter/loaded');
+      await expectTextContains(loaded, 'Shared Label', 10000);
+      await expectTextEquals(loaded.locator('[data-test="count"]').first(), '7', 10000);
+
+      const dark = page.locator('[data-toolbar-mode=":Mode.app/dark"]');
+      await waitForValue(
+        () => dark.getAttribute('aria-pressed'),
+        (value) => value === 'true',
+        { timeoutMs: 5000, description: 'dark mode hydrated from URL' },
+      );
+    });
+
+    await scenario(page, 'snapshot-identity-reproducible-and-input-sensitive', async () => {
+      const firstHash = await waitForValue(
+        () => snapshotHash(page, ':story.counter/loaded'),
+        (value) => /^[0-9a-f]{8}$/.test(value || ''),
+        { timeoutMs: 5000, description: 'initial snapshot hash' },
+      );
+
+      await page.reload({ waitUntil: 'load' });
+      await primeHelpDismissed(page);
+      await waitForCanvas(page, ':story.counter/loaded');
+      const secondHash = await waitForValue(
+        () => snapshotHash(page, ':story.counter/loaded'),
+        (value) => /^[0-9a-f]{8}$/.test(value || ''),
+        { timeoutMs: 5000, description: 'snapshot hash after reload' },
+      );
+      if (secondHash !== firstHash) {
+        throw new Error(`snapshot hash was not reproducible: ${firstHash} -> ${secondHash}`);
+      }
+
+      const labelInput = page
+        .getByRole('complementary')
+        .locator('[data-controls-arg=":label"] input[type="text"]')
+        .first();
+      await labelInput.waitFor({ state: 'visible', timeout: 5000 });
+      await labelInput.fill('Changed by browser scenario');
+      await expectTextContains(
+        canvas(page, ':story.counter/loaded'),
+        'Changed by browser scenario',
+        5000,
+      );
+
+      const changedHash = await waitForValue(
+        () => snapshotHash(page, ':story.counter/loaded'),
+        (value) => /^[0-9a-f]{8}$/.test(value || '') && value !== firstHash,
+        { timeoutMs: 5000, description: 'snapshot hash changes after arg override' },
+      );
+      if (changedHash === firstHash) {
+        throw new Error('snapshot hash did not change after label override');
+      }
+    });
+
+    await scenario(page, 'share-popover-and-qr-preserve-variant-id', async () => {
+      await page.getByRole('button', { name: /^share$/i }).first().click();
+      const shareUrl = await page.locator('[data-test="story-share-url"]').innerText();
+      const parsed = assertUrlParam(shareUrl.trim(), 'variant', 'story.counter/loaded');
+      if (parsed.hash !== '#/stories') {
+        throw new Error(`expected share URL to route back to #/stories, got ${parsed.hash}`);
+      }
+      const modes = parsed.searchParams.get('modes') || '';
+      if (!modes.includes('Mode.app/dark')) {
+        throw new Error(`expected share URL modes to include Mode.app/dark, got ${modes}`);
+      }
+      const overrides = parsed.searchParams.get('overrides') || '';
+      if (!overrides.includes('label:"Changed by browser scenario"')) {
+        throw new Error(`expected share URL overrides to include edited label, got ${overrides}`);
+      }
+
+      const qr = page.locator('[data-test="story-share-qr"]');
+      await expectVisible(qr, 5000);
+      const qrUrl = await qr.getAttribute('data-share-url');
+      if (qrUrl !== shareUrl.trim()) {
+        throw new Error(`QR data-share-url differed from visible share URL: ${qrUrl}`);
+      }
+      assertNoThirdPartyRequests(page);
+      await page.getByRole('button', { name: /^close$/i }).first().click();
+    });
+
+    await scenario(page, 'assertions-pass-fail-structured-output', async () => {
+      await setMode(page, 'test');
+      await waitForValue(
+        () => page.locator('[data-test="story-test-status-pill"]').innerText().catch(() => ''),
+        (text) => /3\s+passed/i.test(text),
+        { timeoutMs: 10000, description: 'loaded variant passing assertions' },
+      );
+      await waitForValue(
+        () => page.locator('[data-test="story-test-row"][data-status="pass"]').count(),
+        (count) => count >= 3,
+        { timeoutMs: 5000, description: 'three passing assertion rows' },
+      );
+
+      await clickVariant(page, '/failing-play');
+      await waitForCanvas(page, ':story.counter-diagnostics/failing-play');
+      await setMode(page, 'test');
+      await waitForValue(
+        () => page.locator('[data-test="story-test-status-pill"]').innerText().catch(() => ''),
+        (text) => /failed/i.test(text),
+        { timeoutMs: 10000, description: 'failing variant status' },
+      );
+      const failRow = page.locator('[data-test="story-test-row"][data-status="fail"]').first();
+      await failRow.waitFor({ state: 'visible', timeout: 5000 });
+      const assertionId = await failRow.getAttribute('data-assertion');
+      if (!assertionId || !assertionId.startsWith(':rf.assert/')) {
+        throw new Error(`expected structured failing assertion id, got ${assertionId}`);
+      }
+    });
+
+    await scenario(page, 'substrate-decorator-and-frame-isolation', async () => {
+      await setMode(page, 'dev');
+      await clickVariant(page, '/clicked-three-times');
+      await waitForCanvas(page, ':story.counter/clicked-three-times');
+      await expectTextContains(page.getByRole('main'), 'decorator: story-level', 5000);
+      await expectTextContains(page.getByRole('main'), 'decorator: variant-level', 5000);
+
+      await clickVariant(page, '/decorator-throws');
+      await waitForCanvas(page, ':story.counter-matrix/decorator-throws');
+      await expectTextContains(page.getByRole('main'), 'Decorator wrap threw', 10000);
+      await expectTextContains(
+        page.getByRole('main'),
+        'story-load deterministic decorator failure',
+        10000,
+      );
+      await expectTextEquals(
+        canvas(page, ':story.counter-matrix/decorator-throws')
+          .locator('[data-test="count"]')
+          .first(),
+        '8',
+        10000,
+      );
+
+      await clickVariant(page, '/multi-substrate');
+      await waitForCanvas(page, ':story.counter-matrix/multi-substrate');
+      await expectTextContains(page.getByRole('main'), 'uix', 10000);
+      await expectTextContains(page.getByRole('main'), 'is not registered', 10000);
+      await expectTextEquals(
+        canvas(page, ':story.counter-matrix/multi-substrate')
+          .locator('[data-test="count"]')
+          .first(),
+        '10',
+        10000,
+      );
+
+      await clickVariant(page, '/isolation-a');
+      await waitForCanvas(page, ':story.counter-matrix/isolation-a');
+      const a = canvas(page, ':story.counter-matrix/isolation-a');
+      await a.locator('[data-test="inc"]').first().click();
+      await expectTextEquals(a.locator('[data-test="count"]').first(), '2', 10000);
+
+      await clickVariant(page, '/isolation-b');
+      await waitForCanvas(page, ':story.counter-matrix/isolation-b');
+      const b = canvas(page, ':story.counter-matrix/isolation-b');
+      await expectTextEquals(b.locator('[data-test="count"]').first(), '100', 10000);
+    });
+
+    await scenario(page, 'recorder-redacts-sensitive-events', async () => {
+      await clickVariant(page, '/recorder-redaction');
+      await waitForCanvas(page, ':story.counter-matrix/recorder-redaction');
+
+      const rec = page.locator('[data-test="story-toolbar-rec"]');
+      await rec.waitFor({ state: 'visible', timeout: 5000 });
+      await rec.click();
+      await expectVisible(page.locator('[data-test="story-recorder-overlay"]'), 5000);
+
+      await canvas(page, ':story.counter-matrix/recorder-redaction')
+        .locator('[data-test="story-recorder-sensitive-action"]')
+        .click();
+      await waitForValue(
+        () => page.locator('[data-test="story-recorder-overlay"]').innerText(),
+        (text) => /\d+\s+events?/.test(text) && !/0\s+events/.test(text),
+        { timeoutMs: 5000, description: 'recorder captured redacted sensitive event' },
+      );
+
+      await page.locator('[data-test="story-recorder-stop"]').click();
+      await expectVisible(page.locator('[data-test="story-recorder-dialog"]'), 5000);
+      const snippet = await page.locator('[data-test="story-recorder-snippet"]').innerText();
+      if (!snippet.includes('[:rf/redacted]')) {
+        throw new Error(`expected recorder snippet to contain [:rf/redacted], got ${snippet}`);
+      }
+      if (snippet.includes('browser-secret')) {
+        throw new Error(`recorder snippet leaked the sensitive password: ${snippet}`);
+      }
+      await page.locator('[data-test="story-recorder-close"]').click();
+      await sleep(0);
+    });
+  },
+};

--- a/tools/story/testbeds/counter_with_stories/stories.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories.cljs
@@ -407,6 +407,19 @@
      :tags   #{:dev :test :internal}
      :substrates #{:reagent}})
 
+  (story/reg-variant :story.counter-matrix/recorder-redaction
+    {:doc       "Recorder browser fixture: the visible button dispatches
+                a :sensitive? event with a password payload. The Story
+                recorder must preserve the row position while emitting
+                [:rf/redacted] in the generated :play snippet."
+     :component :counter-with-stories.views/recorder-redaction-card
+     :args      {:label "Recorder redaction"
+                 :settings {:title "Recorder" :enabled? true}}
+     :events    [[:counter/initialise 11]]
+     :play      [[:rf.assert/path-equals [:count] 11]]
+     :tags      #{:dev :test :internal}
+     :substrates #{:reagent}})
+
   ;; -------------------------------------------------------------------------
   ;; reg-workspace — two workspaces, one per layout the v1 ships
   ;;

--- a/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
@@ -113,9 +113,10 @@
                    :story.counter-matrix/decorator-throws
                    :story.counter-matrix/multi-substrate
                    :story.counter-matrix/isolation-a
-                   :story.counter-matrix/isolation-b]]
+                   :story.counter-matrix/isolation-b
+                   :story.counter-matrix/recorder-redaction]]
         (is (contains? vs vid) (str vid " registered")))
-      (is (= 8 (count vs))))))
+      (is (= 9 (count vs))))))
 
 (deftest example-workspaces-registered
   (testing "both workspaces registered"

--- a/tools/story/testbeds/counter_with_stories/views.cljs
+++ b/tools/story/testbeds/counter_with_stories/views.cljs
@@ -108,3 +108,15 @@
    [:div {:style {:display "flex" :align-items "center"}}
     [counter-buttons]
     [parity-badge]]])
+
+(reg-view recorder-redaction-card [{:keys [label]}]
+  [:div {:style {:display "inline-flex"
+                 :flex-direction "column"
+                 :gap "0.75em"}}
+   [counter-card {:label label}]
+   [:button {:on-click   #(dispatch [:auth/sign-in
+                                      {:email "redaction@example.com"
+                                       :password "browser-secret"}])
+             :aria-label "Dispatch sensitive sign-in event"
+             :data-test  "story-recorder-sensitive-action"}
+    "Sensitive sign in"]])


### PR DESCRIPTION
## Summary
- add a focused Story browser scenario spec covering share URL hydration/QR, snapshot identity, structured assertion output, substrate/decorator/frame isolation, and recorder redaction
- make Story share URLs hash-route safe and hydrate variant, overrides, and substrate from URL search params
- expose canvas snapshot hashes and fix CLJS snapshot hash unsigned formatting
- add a recorder-redaction Story testbed variant and make the Story feature-load runner filterable via STORY_FEATURE_LOAD_SPEC

## Testing
- `STORY_FEATURE_LOAD_SPEC=story_browser_scenarios STORY_FEATURE_LOAD_PORT=8141 npm run test:story-feature-load` (17.7s final pre-rebase, 20.0s post-rebase)
- `STORY_FEATURE_LOAD_PORT=8141 npm run test:story-feature-load` (58.6s, full Story feature-load gate, 2 specs)
- `cd tools/story && clojure -M:test` (8.7s pre-rebase, 7.2s post-rebase)
- `cd implementation && npm run test:cljs` (18.6s; existing hot-reload redef warning, 0 failures)
- fast PR spine equivalents: lockstep via `scripts/test-fast-pr.sh` first step passed; `python scripts/check_skill_mcp_drift.py --verbose --ci` (0.3s); `cd implementation/core && clojure -M:test` (89.5s); `npm run test:script-policy && npm run test:script-helpers` (0.6s); CLJS node integration listed above

## Test Tier Notes
- The focused Story browser scenario is the local commit-tier check for this slice because it isolates the new browser coverage and stays quiet on success.
- `tools/story` JVM and `npm run test:cljs` are PR-relevant for the changed CLJC/CLJS Story surfaces.
- The full `npm run test:story-feature-load` gate belongs in the nightly/manual expensive tier today; it was still run locally because the Story runner changed and this PR adds a second spec.
- Broader Causa/browser/bundle/release matrix checks are intentionally skipped here because this slice only touches Story browser/testbed surfaces and the expensive workflow owns those cross-surface gates.

Report: `ai/findings/story-browser-scenarios-rf2-dczqg.md` in the assigned worktree.