### PR TITLE
fix(story): harden a11y chrome and resize rails

### DIFF
--- a/tools/story/src/re_frame/story/ui/a11y.cljs
+++ b/tools/story/src/re_frame/story/ui/a11y.cljs
@@ -470,7 +470,7 @@
     (:impact-moderate styles)))
 
 (defn- violation-row
-  [v]
+  [^js v]
   (let [impact (.-impact v)
         nodes  (.-nodes v)
         first-target (when (and nodes (pos? (.-length nodes)))
@@ -478,7 +478,12 @@
                              targets (.-target n0)]
                          (when (and targets (pos? (.-length targets)))
                            (aget targets 0))))]
-    [:div {:style (merge (:violation styles) (impact-style impact))}
+    [:div {:style            (merge (:violation styles) (impact-style impact))
+           :data-test        "story-a11y-violation"
+           :data-a11y-id     (.-id v)
+           :data-a11y-impact (or impact "")
+           :data-a11y-help   (.-help v)
+           :data-a11y-target (or first-target "")}
      [:div {:style (:v-help styles)} (.-help v)]
      [:div {:style (:v-desc styles)} (.-description v)]
      (when first-target

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -56,6 +56,7 @@
             [re-frame.story.ui.save-variant :as save-variant-ui]
             [re-frame.story.ui.scrubber :as scrubber]
             [re-frame.story.ui.share :as share]
+            [re-frame.story.ui.shell.rails :as rails]
             [re-frame.story.ui.shell-styles :refer [styles]]
             [re-frame.story.ui.sidebar :as sidebar]
             [re-frame.story.ui.state :as state]
@@ -388,11 +389,16 @@
   []
   (let [shell      @state/shell-state-atom
         variant-id (:selected-variant shell)
-        vis        (:panel-visibility shell)]
-    [:aside {:style    (:right styles)
-             :role     "complementary"
+        vis        (:panel-visibility shell)
+        widths     (rails/current-widths)
+        narrow?    (rails/narrow-viewport?)]
+    [:aside {:style      (merge (:right styles)
+                                {:width (str (:right widths) "px")}
+                                (when narrow? (:right-narrow styles)))
+             :data-test  "story-inspectors"
+             :role       "complementary"
              :aria-label "Inspectors"
-             :tab-index "0"}
+             :tab-index  "0"}
      (when (:controls vis)
        [controls/panel variant-id])
      (when (and (:scrubber vis) variant-id)
@@ -498,6 +504,7 @@
          ;; can drive the modal without coupling the .cljc helper to
          ;; Reagent / DOM. Idempotent.
          (save-variant-ui/install!)
+         (rails/hydrate!)
          (when-let [vid (:selected-variant @state/shell-state-atom)]
            (ensure-listeners-for-variant! vid))))
      :component-will-unmount
@@ -508,35 +515,48 @@
        (teardown-all-listeners!))
      :reagent-render
      (fn []
-       [:div {:style (:root styles)}
-        ;; rf2-xi9zk: chrome-level toolbar — horizontal strip above the
-        ;; three-pane row. Exposes every registered :mode as a toggle
-        ;; chip; selection writes the chrome-wide :active-modes slot.
-        [toolbar/toolbar-strip]
-        [:div {:style (:body styles)}
-         [sidebar/sidebar]
-         [main-pane]
-         [right-panel]]
-        ;; rf2-381i: first-time help overlay + persistent re-open chip.
-        ;; The chip lives in a fixed-position slot so it floats above the
-        ;; right inspector pane regardless of which panels are visible.
-        [:div {:style (:help-slot styles)}
-         [help/help-button]]
-        [help/help-host]
-        ;; rf2-5fc15: Test Codegen recording overlay (top-right banner
-        ;; while a recording is in flight) + save-as-variant dialog
-        ;; (opens after stop). Both are fixed-position so they float
-        ;; above the three-pane layout. rf2-39u9e adds the mid-recording
-        ;; assertion picker — a modal that opens off the overlay's
-        ;; `+ assert` button.
-        [recorder-ui/recording-overlay]
-        [recorder-ui/assertion-picker]
-        [recorder-ui/save-dialog]
-        ;; rf2-one3t: save-current-canvas-state-as-variant dialog. Lives
-        ;; alongside the recorder's save dialog — both float above the
-        ;; three-pane layout via fixed positioning; both surface the
-        ;; generated EDN snippet for review-then-commit.
-        [save-variant-ui/save-dialog]])}))
+       (let [widths  (rails/current-widths)
+             narrow? (rails/narrow-viewport?)]
+         [:div {:style (:root styles)}
+          ;; rf2-xi9zk: chrome-level toolbar — horizontal strip above the
+          ;; three-pane row. Exposes every registered :mode as a toggle
+          ;; chip; selection writes the chrome-wide :active-modes slot.
+          [toolbar/toolbar-strip]
+          [:div {:style (merge (:body styles)
+                               (when narrow? (:body-narrow styles)))}
+           [sidebar/sidebar {:style (merge {:width       (str (:left widths) "px")
+                                            :flex-basis  (str (:left widths) "px")
+                                            :flex-shrink "0"}
+                                           (when narrow?
+                                             {:width "auto"
+                                              :flex-basis "auto"
+                                              :max-height "42vh"}))}]
+           (when-not narrow?
+             [rails/splitter :left])
+           [main-pane]
+           (when-not narrow?
+             [rails/splitter :right])
+           [right-panel]]
+          ;; rf2-381i: first-time help overlay + persistent re-open chip.
+          ;; The chip lives in a fixed-position slot so it floats above the
+          ;; right inspector pane regardless of which panels are visible.
+          [:div {:style (:help-slot styles)}
+           [help/help-button]]
+          [help/help-host]
+          ;; rf2-5fc15: Test Codegen recording overlay (top-right banner
+          ;; while a recording is in flight) + save-as-variant dialog
+          ;; (opens after stop). Both are fixed-position so they float
+          ;; above the three-pane layout. rf2-39u9e adds the mid-recording
+          ;; assertion picker — a modal that opens off the overlay's
+          ;; `+ assert` button.
+          [recorder-ui/recording-overlay]
+          [recorder-ui/assertion-picker]
+          [recorder-ui/save-dialog]
+          ;; rf2-one3t: save-current-canvas-state-as-variant dialog. Lives
+          ;; alongside the recorder's save dialog — both float above the
+          ;; three-pane layout via fixed positioning; both surface the
+          ;; generated EDN snippet for review-then-commit.
+          [save-variant-ui/save-dialog]]))}))
 
 ;; ---- mount / unmount surface ---------------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/shell/rails.cljs
+++ b/tools/story/src/re_frame/story/ui/shell/rails.cljs
@@ -1,0 +1,150 @@
+(ns re-frame.story.ui.shell.rails
+  "Resizable Story shell rails. Keeps persistence, clamping, and the
+  accessible splitter widget out of the top-level shell composer."
+  (:require [reagent.core :as r]
+            [re-frame.story.ui.shell-styles :refer [styles]]
+            [re-frame.story.ui.state :as state]))
+
+(def ^:private storage-key
+  "re-frame.story/rail-widths")
+
+(def default-widths
+  {:left 260 :right 320})
+
+(def constraints
+  {:left       {:min 180 :max 420}
+   :right      {:min 240 :max 520}
+   :canvas-min 360})
+
+(defn- safe-local-storage []
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (try (.-localStorage js/window)
+         (catch :default _ nil))))
+
+(defn- viewport-width []
+  (if (and (exists? js/window) (.-innerWidth js/window))
+    (.-innerWidth js/window)
+    1200))
+
+(defn narrow-viewport? []
+  (< (viewport-width) 820))
+
+(defn- clamp-number [n lo hi]
+  (-> n (max lo) (min hi)))
+
+(defn normalise-widths [widths]
+  (let [left-in   (or (:left widths) (:left default-widths))
+        right-in  (or (:right widths) (:right default-widths))
+        left      (clamp-number left-in
+                                (get-in constraints [:left :min])
+                                (get-in constraints [:left :max]))
+        right     (clamp-number right-in
+                                (get-in constraints [:right :min])
+                                (get-in constraints [:right :max]))
+        budget    (- (viewport-width) (:canvas-min constraints) 20)
+        overflow  (max 0 (- (+ left right) budget))
+        right-cut (min overflow (- right (get-in constraints [:right :min])))
+        right'    (- right right-cut)
+        overflow' (- overflow right-cut)
+        left'     (- left (min overflow' (- left (get-in constraints [:left :min]))))]
+    {:left left' :right right'}))
+
+(defn current-widths []
+  (normalise-widths
+    (merge default-widths (:rail-widths @state/shell-state-atom))))
+
+(defn- read-widths []
+  (try
+    (when-let [ls (safe-local-storage)]
+      (when-let [raw (.getItem ls storage-key)]
+        (let [parsed (js/JSON.parse raw)
+              left   (.-left parsed)
+              right  (.-right parsed)]
+          (cond-> {}
+            (number? left)  (assoc :left left)
+            (number? right) (assoc :right right)))))
+    (catch :default _ nil)))
+
+(defn- persist! [widths]
+  (try
+    (when-let [ls (safe-local-storage)]
+      (.setItem ls storage-key (js/JSON.stringify (clj->js widths))))
+    (catch :default _ nil))
+  nil)
+
+(defn hydrate! []
+  (when-let [stored (read-widths)]
+    (let [widths (normalise-widths (merge default-widths stored))]
+      (state/swap-state! assoc :rail-widths widths)))
+  nil)
+
+(defn set-width! [side width]
+  (let [widths (normalise-widths
+                 (assoc (current-widths) side width))]
+    (state/swap-state! assoc :rail-widths widths)
+    (persist! widths)))
+
+(defn- adjust-width! [side delta]
+  (set-width! side (+ (get (current-widths) side) delta)))
+
+(defn splitter
+  "Accessible mouse + keyboard separator between shell panes."
+  [side]
+  (let [dragging? (r/atom false)]
+    (r/create-class
+      {:display-name (str "rf-story-rail-splitter-" (name side))
+       :reagent-render
+       (fn [side]
+         (let [widths  (current-widths)
+               c       (get constraints side)
+               left?   (= side :left)
+               label   (if left? "Resize stories sidebar" "Resize inspectors rail")
+               test-id (if left?
+                         "story-left-rail-splitter"
+                         "story-right-rail-splitter")
+               step    16]
+           [:div {:style            (merge (:splitter styles)
+                                           (when @dragging? (:splitter-active styles)))
+                  :data-test        test-id
+                  :role             "separator"
+                  :aria-label       label
+                  :aria-orientation "vertical"
+                  :aria-valuemin    (:min c)
+                  :aria-valuemax    (:max c)
+                  :aria-valuenow    (get widths side)
+                  :tab-index        "0"
+                  :on-key-down      (fn [e]
+                                      (let [k     (.-key e)
+                                            mult  (if (.-shiftKey e) 4 1)
+                                            delta (* step mult)]
+                                        (case k
+                                          "ArrowLeft"  (do (.preventDefault e)
+                                                           (adjust-width! side (if left? (- delta) delta)))
+                                          "ArrowRight" (do (.preventDefault e)
+                                                           (adjust-width! side (if left? delta (- delta))))
+                                          "Home"       (do (.preventDefault e)
+                                                           (set-width! side (:min c)))
+                                          "End"        (do (.preventDefault e)
+                                                           (set-width! side (:max c)))
+                                          nil)))
+                  :on-mouse-down    (fn [e]
+                                      (.preventDefault e)
+                                      (let [start-x (.-clientX e)
+                                            start-w (get (current-widths) side)
+                                            move-fn (atom nil)
+                                            up-fn   (atom nil)]
+                                        (reset! dragging? true)
+                                        (reset! move-fn
+                                                (fn [move-e]
+                                                  (let [dx (- (.-clientX move-e) start-x)]
+                                                    (set-width!
+                                                      side
+                                                      (+ start-w (if left? dx (- dx)))))))
+                                        (reset! up-fn
+                                                (fn [_]
+                                                  (reset! dragging? false)
+                                                  (.removeEventListener js/document "mousemove" @move-fn)
+                                                  (.removeEventListener js/document "mouseup" @up-fn)))
+                                        (.addEventListener js/document "mousemove" @move-fn)
+                                        (.addEventListener js/document "mouseup" @up-fn)))}
+            [:span {:style (:splitter-grip styles)}]]))})))

--- a/tools/story/src/re_frame/story/ui/shell_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/shell_styles.cljs
@@ -17,16 +17,42 @@
                :flex "1"
                :min-height "0"
                :overflow "hidden"}
+   :body-narrow {:flex-direction "column"
+                 :overflow "auto"}
    :main      {:display "flex"
                :flex-direction "column"
                :flex "1"
+               :min-width "0"
                :overflow "hidden"}
    :right     {:width "320px"
+               :flex-shrink "0"
                :display "flex"
                :flex-direction "column"
                :border-left "1px solid #444"
                :background "#252526"
                :overflow "auto"}
+   :right-narrow {:width "auto"
+                  :max-height "42vh"
+                  :border-left "none"
+                  :border-top "1px solid #444"}
+   :splitter  {:width "10px"
+               :flex "0 0 10px"
+               :background "#1e1e1e"
+               :border "0"
+               :border-left "1px solid #333"
+               :border-right "1px solid #333"
+               :cursor "col-resize"
+               :padding "0"
+               :position "relative"}
+   :splitter-grip {:position "absolute"
+                   :top "50%"
+                   :left "3px"
+                   :width "2px"
+                   :height "36px"
+                   :transform "translateY(-50%)"
+                   :background "#6a6a6a"
+                   :box-shadow "3px 0 0 #6a6a6a"}
+   :splitter-active {:background "#094771"}
    :tab-bar   {:display "flex"
                :background "#2d2d30"
                :border-bottom "1px solid #444"

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -457,7 +457,8 @@
   `testable?` check (set membership) and the chrome-level `test-widget`
   share the same derivation. Deeper memoisation keyed on
   `(registrar-tick, tag-filter)` can wait until corpus size justifies."
-  []
+  ([] (sidebar nil))
+  ([opts]
   (let [shell           @state/shell-state-atom
         registry        (state/registry-snapshot)
         tag-filter      (:tag-filter shell)
@@ -475,7 +476,8 @@
         test-runs       (get-in shell [:tests :runs])
         testable-vec    (state/testable-variant-ids (:variants registry))
         testable-set    (set testable-vec)]
-    [:nav {:style      (:wrap styles)
+    [:nav {:style      (merge (:wrap styles) (:style opts))
+           :data-test  "story-sidebar"
            :aria-label "Stories and workspaces"
            :tab-index  "0"}
      [:div {:style (:tree styles)}
@@ -495,4 +497,4 @@
          (for [[wid _body] (sort-by key workspaces)]
            ^{:key wid}
            [workspace-row wid (= wid sel-ws)])])]
-     [test-widget shell registry testable-vec]]))
+     [test-widget shell registry testable-vec]])))

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -72,6 +72,9 @@
                            Unspecified → :dev (canvas). Persisted in
                            localStorage under `re-frame.story/active-
                            mode-tab/<variant-id>`.
+  - `:rail-widths`       — {:left px :right px}. User-resized Story shell
+                           rail widths, hydrated from localStorage by the
+                           CLJS shell. The defaults keep the canvas usable.
   - `:tests` — sub-map grouping every chrome-test-widget slot under
                one root (rf2-uefbk). Holds:
 
@@ -111,6 +114,7 @@
    :pinned-snapshots    {}
    :panel-visibility    {:trace true :scrubber true :controls true :actions true}
    :active-mode-tab     {}
+   :rail-widths         {:left 260 :right 320}
    :tests               {:runs           {}
                          :watch-mode?    false
                          :content-hashes {}}})

--- a/tools/story/testbeds/counter_with_stories/counter_with_stories.spec.cjs
+++ b/tools/story/testbeds/counter_with_stories/counter_with_stories.spec.cjs
@@ -71,6 +71,27 @@ async function waitForCounterCell(page) {
   });
 }
 
+async function elementWidth(locator, label) {
+  const box = await locator.boundingBox();
+  if (!box) {
+    throw new Error(`expected ${label} to have a bounding box`);
+  }
+  return box.width;
+}
+
+async function dragHorizontal(page, locator, dx) {
+  const box = await locator.boundingBox();
+  if (!box) {
+    throw new Error('expected splitter to have a bounding box before dragging');
+  }
+  const x = box.x + box.width / 2;
+  const y = box.y + box.height / 2;
+  await page.mouse.move(x, y);
+  await page.mouse.down();
+  await page.mouse.move(x + dx, y, { steps: 8 });
+  await page.mouse.up();
+}
+
 module.exports = {
   name: 'counter-with-stories',
   url: '/counter-with-stories/',
@@ -137,6 +158,69 @@ module.exports = {
     await expectVisible(page.getByRole('navigation'), 5000);
     await expectVisible(page.getByRole('main'), 5000);
     await expectVisible(page.getByRole('complementary'), 5000);
+
+    // ====================================================================
+    // 2b. Resizable shell rails — drag, constraints, persistence (rf2-fvfji)
+    // ====================================================================
+    //
+    // The Story shell has two keyboard-focusable splitters:
+    //   - left splitter between the stories nav and canvas
+    //   - right splitter between the canvas and inspectors
+    //
+    // Drag both, assert the rails move while the canvas keeps usable
+    // width, then reload and assert the persisted rail widths hydrate.
+    const sidebarRail = page.locator('[data-test="story-sidebar"]');
+    const inspectorsRail = page.locator('[data-test="story-inspectors"]');
+    const leftSplitter = page.locator('[data-test="story-left-rail-splitter"]');
+    const rightSplitter = page.locator('[data-test="story-right-rail-splitter"]');
+
+    await leftSplitter.waitFor({ state: 'visible', timeout: 5000 });
+    await rightSplitter.waitFor({ state: 'visible', timeout: 5000 });
+    if ((await leftSplitter.getAttribute('role')) !== 'separator') {
+      throw new Error('expected left rail splitter to expose role="separator"');
+    }
+    if ((await rightSplitter.getAttribute('role')) !== 'separator') {
+      throw new Error('expected right rail splitter to expose role="separator"');
+    }
+
+    const leftBefore = await elementWidth(sidebarRail, 'sidebar rail before resize');
+    const rightBefore = await elementWidth(inspectorsRail, 'inspectors rail before resize');
+    await dragHorizontal(page, leftSplitter, 72);
+    await dragHorizontal(page, rightSplitter, -64);
+
+    const leftAfter = await elementWidth(sidebarRail, 'sidebar rail after resize');
+    const rightAfter = await elementWidth(inspectorsRail, 'inspectors rail after resize');
+    const canvasAfter = await elementWidth(page.getByRole('main'), 'canvas after rail resize');
+    if (leftAfter < leftBefore + 40) {
+      throw new Error(`expected sidebar rail to grow after drag; before=${leftBefore}, after=${leftAfter}`);
+    }
+    if (rightAfter < rightBefore + 32) {
+      throw new Error(`expected inspectors rail to grow after drag; before=${rightBefore}, after=${rightAfter}`);
+    }
+    if (canvasAfter < 360) {
+      throw new Error(`expected canvas to remain at least 360px wide after rail resize, got ${canvasAfter}`);
+    }
+
+    await page.evaluate(() => {
+      localStorage.setItem('re-frame.story/seen-help-v1', '1');
+    });
+    await page.reload();
+    await page.evaluate(() => {
+      window.location.hash = '#/stories';
+    });
+    await page
+      .getByText(/Select a variant or workspace from the sidebar/i, { exact: false })
+      .first()
+      .waitFor({ state: 'visible', timeout: 10000 });
+
+    const leftRestored = await elementWidth(sidebarRail, 'sidebar rail after reload');
+    const rightRestored = await elementWidth(inspectorsRail, 'inspectors rail after reload');
+    if (Math.abs(leftRestored - leftAfter) > 3) {
+      throw new Error(`expected sidebar rail width to persist; before reload=${leftAfter}, after reload=${leftRestored}`);
+    }
+    if (Math.abs(rightRestored - rightAfter) > 3) {
+      throw new Error(`expected inspectors rail width to persist; before reload=${rightAfter}, after reload=${rightRestored}`);
+    }
 
     // ====================================================================
     // 3. Sidebar navigation — variants (rf2-zme7 + rf2-kljn)
@@ -1119,16 +1203,14 @@ module.exports = {
     }
 
     // ====================================================================
-    // 12. A11y panel — clicking "run" produces a status update
+    // 12. A11y panel — clicking "run" reports zero loaded-variant violations
     // ====================================================================
     //
     // The a11y panel exposes a "run" button. Clicking it kicks off the
-    // axe-core lazy-load + scan. The panel's status line transitions
-    // from the idle copy ("click run to scan the variant …") through
-    // "fetching axe-core…" / "scanning…" / "N violation(s) found in
-    // variant". We don't assert which violations land (varies by
-    // environment); we assert that the run was kicked off — the status
-    // text changes away from the idle copy.
+    // axe-core lazy-load + scan. This test opts in explicitly so the
+    // run is deterministic, then requires the loaded variant to report
+    // zero violations. If violations appear, the thrown error includes
+    // the axe id/help/impact/target payload from the panel rows.
     //
     // Per rf2-qgms1: axe-core MUST scan only the variant's tree, NOT
     // Story's surrounding chrome (sidebar, toolbar, panels, title bar).
@@ -1165,29 +1247,45 @@ module.exports = {
       }
     }
 
+    await page.evaluate(() => {
+      localStorage.setItem('rf.story.a11y/cdn-opt-in', 'true');
+    });
     const runBtn = aside.getByRole('button', { name: /^(run|re-run|retry)$/i }).first();
     await runBtn.waitFor({ state: 'visible', timeout: 5000 });
     await runBtn.click();
 
-    // The status copy starts as the idle string ("click run to scan
-    // the variant …") and transitions through "fetching axe-core…"
-    // / "scanning…" / "N violation(s) found in variant". We poll for
-    // the transition off the idle copy — if the status remains the
-    // idle copy the click was ineffective.
+    // Poll until the scan reaches a terminal panel state. A terminal
+    // non-zero result fails with structured violation details so the
+    // offending chrome/variant selector is immediately actionable.
     {
       const start = Date.now();
-      let stillIdle = true;
+      let result = null;
       while (Date.now() - start < 15000) {
-        stillIdle = await aside
-          .getByText(/click run to scan the variant/i)
-          .first()
-          .isVisible()
-          .catch(() => false);
-        if (!stillIdle) break;
+        result = await page.evaluate(() => {
+          const panel = document.querySelector('aside');
+          const text = panel ? panel.innerText : '';
+          const rows = Array.from(document.querySelectorAll('[data-test="story-a11y-violation"]'))
+            .map((el) => ({
+              id: el.getAttribute('data-a11y-id') || '',
+              impact: el.getAttribute('data-a11y-impact') || '',
+              help: el.getAttribute('data-a11y-help') || '',
+              target: el.getAttribute('data-a11y-target') || '',
+            }));
+          return { text, rows };
+        });
+        if (
+          /\d+\s+violation\(s\) found in variant/i.test(result.text) ||
+          /axe-core failed to load|no variant mounted|needs your approval/i.test(result.text)
+        ) {
+          break;
+        }
         await new Promise((r) => setTimeout(r, 100));
       }
-      if (stillIdle) {
-        throw new Error('a11y panel run did not transition off idle status');
+      if (!result || !/0\s+violation\(s\) found in variant/i.test(result.text)) {
+        throw new Error(
+          `expected loaded variant a11y scan to report 0 violations; panel text=${JSON.stringify(result && result.text)}; ` +
+            `violations=${JSON.stringify(result ? result.rows : [])}`,
+        );
       }
     }
 

--- a/tools/story/testbeds/counter_with_stories/stories.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories.cljs
@@ -146,10 +146,10 @@
      :kind :hiccup
      :wrap (fn [body args]
              (let [label (first (:decorator/args args))]
-               [:div {:style {:border  "1px dashed #888"
+               [:div {:style {:border  "1px dashed #9a9a9a"
                               :padding "0.5em"
                               :margin  "0.25em"}}
-                [:div {:style {:font-size "10px" :color "#888"}}
+                [:div {:style {:font-size "10px" :color "#d0d0d0"}}
                  (str "decorator: " (or label "log"))]
                 body]))})
 


### PR DESCRIPTION
## Beads
- rf2-g58x7
- rf2-fvfji

## Summary
- Fix the counter-with-stories Story decorator label contrast so the loaded variant a11y scan reports zero violations.
- Make Story shell left/right rails resizable with clamped widths, localStorage persistence, keyboard-operable separator semantics, and narrow-viewport stacking fallback.
- Strengthen counter-with-stories Playwright coverage for rail resize persistence and deterministic axe opt-in with actionable violation details.

## Validation
- `npm run test:cljs`
- `npx shadow-cljs compile examples/counter-with-stories`
- Targeted counter-with-stories Playwright spec via local `http-server` against `implementation/out/examples`.

Note: `bd dolt push` was attempted, but this worktree has no Dolt remote configured.