### PR TITLE
test(story): cover recorder snapshot browser slice

### DIFF
--- a/ai/findings/story-recorder-snapshot-rf2-zwu95.md
+++ b/ai/findings/story-recorder-snapshot-rf2-zwu95.md
@@ -52,8 +52,9 @@ browser gate both pass locally.
 
 ## Missing or intentionally not forced
 
-- Share URL hydration from a pasted link was not implemented. This slice
-  verifies generation integrity only.
+- Deep-link hydration from a pasted share URL was not added or asserted by
+  this slice. The rebased base already has parser/hydration support; this
+  slice verifies generated URL integrity only.
 - The expensive static-build, production-elision, bundle-size, and release-tier
   checks were not run locally; the changed surface is covered by the
   Story feature-load PR gate and the narrow JVM URL test.

--- a/ai/findings/story-recorder-snapshot-rf2-zwu95.md
+++ b/ai/findings/story-recorder-snapshot-rf2-zwu95.md
@@ -1,0 +1,87 @@
+# Story recorder/snapshot browser slice - rf2-zwu95
+
+## Current status
+
+Story now has a passing browser-test slice for the recorder/playback,
+redaction, assertion diagnostics, snapshot identity, share/QR URL
+integrity, decorator isolation, and frame-isolation scenarios covered
+by rf2-zwu95. The narrow JVM share-url test and the Story feature-load
+browser gate both pass locally.
+
+## Scenarios landed
+
+- Recorder captures three canvas user actions against `:story.counter/empty`;
+  the generated snippet contains exactly three `[:counter/inc]` events and the
+  replay-authored `:story.counter/clicked-three-times` variant produces the
+  same visible count of 3.
+- Recorder redacts a real sensitive sign-in dispatch from
+  `:story.counter-matrix/recorder-redaction`, producing `[:rf/redacted]`
+  and not leaking `browser-secret`, `redaction@example.com`, or
+  `:auth/sign-in`.
+- Test mode assertion failures expose actionable structured detail: expected,
+  actual, and reason are visible after expanding the failing row.
+- Snapshot identity is surfaced on the canvas and remains stable across a
+  reload for the same variant, args, modes, and substrate.
+- Share/QR URL generation preserves the variant id, active toolbar mode,
+  selected args, and `#/stories` route by inserting query params before the
+  hash fragment.
+- Decorator wrapping is isolated across variants: the variant-level decorator
+  appears on `:story.counter/clicked-three-times` and does not leak onto
+  `:story.counter/loaded`.
+- Frame isolation is exercised by mutating isolation A, mutating isolation B,
+  and returning to A; A returns to its own initial frame state rather than
+  inheriting B's mutation.
+
+## Support fixes landed
+
+- Canvas runtime runs are keyed by variant, mode, overrides, substrate, and
+  hot-reload tick. Ordinary app-db rerenders no longer replay static
+  `:events` and reset user interactions.
+- The hot-reload poll now updates its fingerprint baseline for newly allocated
+  or removed frames without bumping `:hot-reload-tick`. Only existing-frame
+  fingerprint drift forces a rerun.
+- The canvas frame provider subtree is keyed by variant id so React does not
+  reuse the previous variant's frame provider during a fast variant switch.
+- Story panels honor their optional `:for` targets against the focused variant
+  or its parent story, preventing project-specific panels from reading
+  unrelated frame state.
+- CLJS snapshot hashes are formatted as unsigned 32-bit hex strings, matching
+  the JVM expectation used by tests.
+- Share UI gained stable data-test hooks so the browser harness can assert the
+  URL and QR surface without role ambiguity.
+
+## Missing or intentionally not forced
+
+- Share URL hydration from a pasted link was not implemented. This slice
+  verifies generation integrity only.
+- The expensive static-build, production-elision, bundle-size, and release-tier
+  checks were not run locally; the changed surface is covered by the
+  Story feature-load PR gate and the narrow JVM URL test.
+- Recorder persistence/save-to-source remains outside this slice. The browser
+  test stops at generated snippet review because no write surface is required
+  for rf2-zwu95.
+
+## Overlap avoided
+
+Noether is working under rf2-dczqg. During rebase, upstream already had a
+recorder redaction fixture under `:story.counter-matrix/recorder-redaction`;
+this slice adopted that fixture instead of adding a second redaction story.
+The remaining work stayed on the narrower recorder/assertion/snapshot/share/
+decorator/frame-isolation path. I did not touch broad Story authoring flows,
+catalog design, general docs generation, or non-recorder Story UX beyond the
+minimal test hooks and substrate fixes needed to make these scenarios
+deterministic.
+
+## Actionable insights
+
+- The default Story feature-load port 8031 is easy to collide with across
+  parallel worktrees. Agents should use a unique `STORY_FEATURE_LOAD_PORT`
+  during local pre-checkin, and CI should allocate ports per job.
+- New-frame fingerprint baseline updates should not be treated as hot-reload
+  drift. Re-running a just-selected variant can replay fixture events during a
+  user recording and produce false recorder output.
+- Story panel `:for` scoping is load-bearing for testbed isolation. A panel
+  written for one story can crash another story if it assumes a frame shape and
+  is rendered globally.
+- Snapshot identity tests should assert browser-visible unsigned hex, not just
+  JVM hashes, because CLJS signed integer formatting can silently diverge.

--- a/tools/story/src/re_frame/story/share.cljc
+++ b/tools/story/src/re_frame/story/share.cljc
@@ -131,6 +131,31 @@
   [k v-encoded]
   (str (url-encode (name k)) "=" v-encoded))
 
+(defn- ^:no-doc split-fragment
+  "Split `url` into `[base fragment]`, preserving the fragment without
+  its leading `#`. Share links must append query params before the hash
+  route so browsers send `variant=` through `location.search` instead
+  of burying it inside `location.hash`."
+  [url]
+  (if-let [idx (str/index-of (or url "") "#")]
+    [(subs url 0 idx) (subs url (inc idx))]
+    [(or url "") nil]))
+
+(defn- ^:no-doc append-query-params
+  "Append already-encoded query `params` to `base-url`, inserting them
+  before any hash fragment."
+  [base-url params]
+  (let [[path fragment] (split-fragment base-url)
+        query           (str/join "&" params)
+        sep             (cond
+                          (str/blank? path)        ""
+                          (str/includes? path "?") "&"
+                          :else                    "?")
+        with-query      (str path sep query)]
+    (if (some? fragment)
+      (str with-query "#" fragment)
+      with-query)))
+
 ;; ---- pure: param building -----------------------------------------------
 
 (defn build-params
@@ -177,22 +202,15 @@
   Returns a string of the form
   `<base-url>?variant=<id>&modes=<list>&overrides=<list>&substrate=<s>`.
   Empty / nil parts are omitted (e.g. no modes → no `modes=` param).
+  If `base-url` contains a hash route, params are inserted before `#`
+  so the query remains available via `window.location.search`.
   Pure data → data; JVM + CLJS-portable."
   ([variant-id]                (variant-share-url variant-id "" nil))
   ([variant-id opts]           (variant-share-url variant-id "" opts))
   ([variant-id base-url opts]
-   (let [params (build-params (assoc opts :variant-id variant-id))
-         joined (str/join "&" params)]
-     (if (str/blank? base-url)
-       joined
-       (let [hash-idx (str/index-of base-url "#")
-             before   (if hash-idx (subs base-url 0 hash-idx) base-url)
-             fragment (when hash-idx (subs base-url hash-idx))
-             sep      (cond
-                        (str/blank? before)      ""
-                        (str/includes? before "?") "&"
-                        :else                    "?")]
-         (str before sep joined fragment))))))
+   (append-query-params
+     (or base-url "")
+     (build-params (assoc opts :variant-id variant-id)))))
 
 ;; QR rendering lives in re-frame.story.qr (CLJS-only). The vendored
 ;; `qrcode-generator` npm package produces an inline SVG string locally;

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -24,7 +24,6 @@
             [re-frame.story.registrar :as registrar]
             [re-frame.story.args :as args]
             [re-frame.story.decorators :as decorators]
-            [re-frame.story.identity :as identity]
             [re-frame.story.runtime :as runtime]
             [re-frame.story.ui.multi-substrate :as multi-substrate]
             [re-frame.story.ui.open-in-editor :as open-in-editor]
@@ -191,6 +190,34 @@
     (runtime/run-variant variant-id opts)
     nil))
 
+(defn- run-key
+  "The shell-state slice that should trigger a fresh runtime run for
+  the focused variant. Ordinary app-db updates inside the variant frame
+  must not re-dispatch the variant's static `:events`; otherwise user
+  interactions reset the canvas and the recorder captures fixture
+  initialisation events as if they were user actions."
+  [shell variant-id]
+  {:variant-id       variant-id
+   :hot-reload-tick  (:hot-reload-tick shell)
+   :active-modes     (:active-modes shell)
+   :cell-overrides   (get-in shell [:cell-overrides variant-id])
+   :substrate        (:substrate shell)})
+
+(defonce ^:private canvas-last-run-key
+  (atom nil))
+
+(defn- run-if-needed!
+  []
+  (when config/enabled?
+    (let [shell      @state/shell-state-atom
+          variant-id (:selected-variant shell)]
+      (if-not variant-id
+        (reset! canvas-last-run-key nil)
+        (let [key (run-key shell variant-id)]
+          (when (not= key @canvas-last-run-key)
+            (reset! canvas-last-run-key key)
+            (run-with-shell-opts! variant-id)))))))
+
 (defn- variant-substrate-set
   "Resolve the variant's effective substrate set. Per IMPL-SPEC §3.1
   the variant body's `:substrates` wins, otherwise the parent story's
@@ -289,7 +316,8 @@
            ;; variant author's.
            ^{:key (str "single-" variant-id)}
            [frame-provider-ns-safe {:frame variant-id}
-            [:div {:data-rf-story-variant-root (pr-str variant-id)}
+            [:div {:key (str "variant-root:" (pr-str variant-id))
+                   :data-rf-story-variant-root (pr-str variant-id)}
              (safe-decorated-view
                [resolved-view eff-args]
                (:hiccup decorator-pack)
@@ -299,36 +327,35 @@
      (render-errors (:errors decorator-pack))
      (render-assertions assertions)]))
 
-(defn canvas
+(def canvas
   "Render the focused variant. Triggers a `run-variant` on mount and on
   each `:hot-reload-tick` bump. Renders the variant's `:component` view
   with the resolved `:hiccup` decorator stack applied."
-  []
   (r/create-class
-    {:display-name "rf-story-canvas"
-     :component-did-mount
-     (fn [_this]
-       (when config/enabled?
-         (when-let [variant-id (:selected-variant @state/shell-state-atom)]
-           (run-with-shell-opts! variant-id))))
-     :component-did-update
-     (fn [this _old-argv]
-       ;; Re-run when the selected variant changes or hot-reload ticks.
-       (when config/enabled?
-         (when-let [variant-id (:selected-variant @state/shell-state-atom)]
-           (run-with-shell-opts! variant-id))))
-    :reagent-render
-    (fn []
-      (let [shell      @state/shell-state-atom
-            variant-id (:selected-variant shell)
-            snapshot   (when variant-id
-                         (identity/snapshot-identity
-                           variant-id
-                           {:active-modes   (:active-modes shell)
-                            :cell-overrides (get-in shell [:cell-overrides
-                                                           variant-id])
-                            :substrate      (:substrate shell)}))
-            _tick      (:hot-reload-tick shell)]   ;; deref to subscribe
+     {:display-name "rf-story-canvas"
+      :component-did-mount
+      (fn [_this]
+        (run-if-needed!))
+      :component-did-update
+      (fn [_this _old-argv]
+        ;; Re-run only when the variant runtime inputs change. The old
+        ;; unconditional update path re-fired `:events` on every app-db
+        ;; render, resetting interactive state and polluting recorder
+        ;; output with fixture setup events.
+        (run-if-needed!))
+      :component-will-unmount
+      (fn [_this]
+        (reset! canvas-last-run-key nil))
+     :reagent-render
+     (fn []
+       (let [shell      @state/shell-state-atom
+             variant-id (:selected-variant shell)
+             opts       {:active-modes   (:active-modes shell)
+                         :cell-overrides (get-in shell [:cell-overrides variant-id])
+                         :substrate      (:substrate shell)}
+             snapshot   (when variant-id
+                          (runtime/snapshot-identity variant-id opts))
+             _tick      (:hot-reload-tick shell)]   ;; deref to subscribe
          ;; Per rf2-xc65: the canvas wrap is the scrollable container
          ;; for variant content; `tab-index "0"` makes it keyboard-
          ;; focusable so axe-core's `scrollable-region-focusable` rule
@@ -343,12 +370,12 @@
          ;; have torn down (sidebar `:selected-variant` and
          ;; `:selected-workspace` are independent slots; clicking a
          ;; variant doesn't clear a previously-selected workspace).
-         [:section (cond-> {:style      (:wrap styles)
-                            :aria-label "Variant canvas"
-                            :tab-index  "0"}
+        [:section (cond-> {:style      (:wrap styles)
+                           :aria-label "Variant canvas"
+                           :tab-index  "0"}
                      variant-id (assoc :data-test-variant (pr-str variant-id))
-                     (:content-hash snapshot)
-                     (assoc :data-snapshot-hash (:content-hash snapshot)))
+                     (:content-hash snapshot) (assoc :data-snapshot-hash
+                                                     (:content-hash snapshot)))
           (if variant-id
             [canvas-inner variant-id]
             [:div {:style (:empty styles)}

--- a/tools/story/src/re_frame/story/ui/panels.cljs
+++ b/tools/story/src/re_frame/story/ui/panels.cljs
@@ -49,6 +49,7 @@
   (:require [reagent.core :as r]
             [re-frame.core :as rf]
             [re-frame.story.config :as config]
+            [re-frame.story.args :as args]
             [re-frame.story.layout-debug :as layout-debug]
             [re-frame.story.registrar :as story-registrar]
             [re-frame.story.ui.a11y :as a11y]
@@ -274,6 +275,17 @@
                  :text-transform "uppercase"
                  :letter-spacing "0.5px"}})
 
+(defn- panel-applies-to-variant?
+  "True when a panel's optional `:for` set matches the focused variant
+  or its parent story. Panels with no `:for` are global. Without this
+  filter, project-specific panels leak into unrelated stories and their
+  frame-scoped subscriptions can crash against missing app-db shape."
+  [body variant-id]
+  (let [targets (:for body)]
+    (or (empty? targets)
+        (contains? targets variant-id)
+        (contains? targets (args/parent-story-id variant-id)))))
+
 (defn render-panels-at-placement
   "Render every registered `:story-panel` whose `:placement` matches
   `placement` and whose visibility flag in the shell state is truthy.
@@ -293,6 +305,7 @@
         slots  (->> panels
                     (filter (fn [[pid body]]
                               (and (= placement (:placement body))
+                                   (panel-applies-to-variant? body variant-id)
                                    ;; default visible unless explicit false
                                    (let [vis (get panel-visibility pid)]
                                      (or (nil? vis) (true? vis))))))

--- a/tools/story/src/re_frame/story/ui/share.cljs
+++ b/tools/story/src/re_frame/story/ui/share.cljs
@@ -159,11 +159,13 @@
         "share"]
        (when @open?
          (let [url (current-share-url variant-id)]
-           [:div {:style (:popover styles)
-                  :data-test "story-share-popover"}
+           [:div {:style              (:popover styles)
+                  :data-test          "story-share-popover"
+                  :data-share-variant (pr-str variant-id)}
             [:div {:style (:url-label styles)} "share link"]
-            [:div {:style (:url styles)
-                   :data-test "story-share-url"} url]
+            [:div {:style     (:url styles)
+                   :data-test "story-share-url"}
+             url]
             ;; Local QR encoder per rf2-20w5i: the SVG is generated
             ;; in-process from `qrcode-generator`; no third-party
             ;; endpoint is contacted. `:dangerouslySetInnerHTML` is

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -78,6 +78,23 @@
         (map (fn [vid] [vid (decorators/resolution-fingerprints vid)]))
         (frames/variant-frames)))
 
+(defn- existing-frame-fingerprint-drift?
+  "True when a frame that was present on the previous poll now reports
+  different decorator fingerprints.
+
+  New frames are not hot-reload drift: they were just allocated by
+  selection/canvas and already ran with the current registry. Treating
+  their first snapshot as drift forces an immediate second run, which
+  replays static `:events` and can pollute recorder output. Removed
+  frames likewise only need the baseline updated."
+  [prev current]
+  (boolean
+    (some (fn [[variant-id fingerprints]]
+            (let [previous (get prev variant-id ::missing)]
+              (and (not= previous ::missing)
+                   (not= previous fingerprints))))
+          current)))
+
 (defn detect-and-tick!
   "Compare the current fingerprint snapshot against the shell state's
   recorded fingerprints; if anything drifted, bump the hot-reload tick
@@ -88,14 +105,14 @@
   (when config/enabled?
     (let [current (compute-fingerprint-snapshot)
           shell   (state/get-state)
-          prev    (:fingerprints shell)]
+          prev    (:fingerprints shell)
+          drift?  (existing-frame-fingerprint-drift? prev current)]
       (when (not= current prev)
         (state/swap-state!
           (fn [s]
-            (-> s
-                (state/bump-hot-reload-tick)
-                (assoc :fingerprints current))))
-        true))))
+            (cond-> (assoc s :fingerprints current)
+              drift? state/bump-hot-reload-tick)))
+        drift?))))
 
 ;; ---- watch-mode detector (rf2-z1h0f) -------------------------------------
 ;;

--- a/tools/story/test/re_frame/story_share_test.clj
+++ b/tools/story/test/re_frame/story_share_test.clj
@@ -99,6 +99,21 @@
     (is (= {:label "Shared Label" :count 9}
            (share/parse-overrides-param "label:\"Shared Label\",count:9")))))
 
+(deftest variant-share-url-preserves-hash-route
+  (testing "variant-share-url inserts params before # so the Story route survives"
+    (let [url (share/variant-share-url
+                :story.counter/loaded
+                "https://example.test/counter-with-stories/#/stories"
+                {:active-modes   [:Mode.app/dark]
+                 :cell-overrides {:label "Share Slice"}
+                 :substrate      :reagent})]
+      (is (str/starts-with?
+            url
+            "https://example.test/counter-with-stories/?variant=story.counter%2Floaded"))
+      (is (str/includes? url "&modes=Mode.app%2Fdark"))
+      (is (str/includes? url "overrides=label%3A%22Share+Slice%22"))
+      (is (str/ends-with? url "#/stories")))))
+
 (deftest variant-share-url-public-export
   (testing "story/variant-share-url is exported"
     (let [url (story/variant-share-url

--- a/tools/story/test/story_feature_load.cjs
+++ b/tools/story/test/story_feature_load.cjs
@@ -181,6 +181,58 @@ async function assertAsideContains(page, text, timeoutMs = 5000) {
   );
 }
 
+function canvasFor(page, variantKeyword) {
+  return page.locator(
+    `main section[aria-label="Variant canvas"][data-test-variant="${variantKeyword}"]`,
+  );
+}
+
+async function assertMainNotContains(page, text, timeoutMs = 3000) {
+  await waitForValue(
+    () => page.getByRole('main').getByText(text, { exact: false }).count(),
+    (count) => count === 0,
+    { timeoutMs, description: `main does not contain ${text}` },
+  );
+}
+
+async function setToolbarMode(page, mode) {
+  const toolbar = page.locator('[data-test="story-toolbar"]');
+  await toolbar.waitFor({ state: 'visible', timeout: 5000 });
+  const chip = toolbar.locator(`[data-toolbar-mode="${mode}"]`);
+  await chip.waitFor({ state: 'visible', timeout: 5000 });
+  if ((await chip.getAttribute('aria-pressed')) !== 'true') {
+    await chip.click();
+  }
+  await waitForValue(
+    () => chip.getAttribute('aria-pressed'),
+    (value) => value === 'true',
+    { timeoutMs: 5000, description: `${mode} toolbar mode active` },
+  );
+}
+
+async function resetToolbarModes(page) {
+  const toolbar = page.locator('[data-test="story-toolbar"]');
+  await toolbar.waitFor({ state: 'visible', timeout: 5000 });
+  const reset = toolbar.locator('[data-test="story-toolbar-reset"]');
+  if (await reset.isVisible().catch(() => false)) {
+    await reset.click();
+  }
+  await waitForValue(
+    () => toolbar.locator('[aria-pressed="true"]').count(),
+    (count) => count === 0,
+    { timeoutMs: 5000, description: 'all toolbar modes reset' },
+  );
+}
+
+async function recorderSnippetText(page) {
+  await expectVisible(page.locator('[data-test="story-recorder-dialog"]'), 5000);
+  return waitForValue(
+    () => page.locator('[data-test="story-recorder-snippet"]').textContent().catch(() => ''),
+    (text) => text.trim().length > 0,
+    { timeoutMs: 5000, description: 'recorder snippet text' },
+  );
+}
+
 async function assertNoUnexpectedThirdPartyEgress(page) {
   const requests = page.__storyFeatureRequests || [];
   const baseUrl = page.url();
@@ -287,17 +339,63 @@ async function assertCounterCore(page, phase) {
     );
     await page.locator('[data-test="story-save-variant-close"]').click();
 
-    const shareButton = page.getByRole('button', { name: /^share$/i }).first();
+    const shareButton = canvas.locator('[data-test="story-share-button"]').first();
     await shareButton.waitFor({ state: 'visible', timeout: 5000 });
     await shareButton.click();
-    await expectVisible(page.getByRole('img', { name: /QR code for variant URL/i }), 5000);
-    await page.getByRole('button', { name: /^close$/i }).first().click();
+    await expectVisible(canvas.locator('[data-test="story-share-popover"]'), 5000);
+    await expectVisible(canvas.getByRole('img', { name: /QR code for variant URL/i }), 5000);
+    await canvas.getByRole('button', { name: /^close$/i }).first().click();
 
     await expectVisible(page.locator('[data-test="story-open-in-editor"]').first(), 5000);
     await page.getByRole('button', { name: /Show playground help/i }).click();
     await expectVisible(page.getByRole('dialog', { name: /Story playground help/i }), 5000);
     await page.getByRole('button', { name: /Got it/i }).click();
   });
+}
+
+async function assertShareUrlIntegrity(page, phase) {
+  await ensureCounterLoaded(page);
+  await resetToolbarModes(page);
+  await setToolbarMode(page, ':Mode.app/dark');
+
+  const canvas = canvasFor(page, ':story.counter/loaded');
+  const aside = page.getByRole('complementary');
+  const label = `Share Slice ${phase}`;
+  const labelInput = aside.locator('[data-controls-arg=":label"] input[type="text"]').first();
+  await labelInput.waitFor({ state: 'visible', timeout: 5000 });
+  await labelInput.fill(label);
+  await expectVisible(canvas.getByText(label, { exact: false }).first(), 5000);
+
+  await canvas.locator('[data-test="story-share-button"]').first().click();
+  const popover = canvas.locator('[data-test="story-share-popover"]');
+  await expectVisible(popover, 5000);
+  await expectVisible(popover.getByRole('img', { name: /QR code for variant URL/i }), 5000);
+
+  const shareUrl = await waitForValue(
+    () => popover.locator('[data-test="story-share-url"]').textContent().catch(() => ''),
+    (text) => /variant=/.test(text) && /modes=/.test(text) && /overrides=/.test(text),
+    { timeoutMs: 5000, description: 'share URL includes variant, modes, and overrides' },
+  );
+  const parsed = new URL(shareUrl);
+  const variant = parsed.searchParams.get('variant');
+  const modes = (parsed.searchParams.get('modes') || '').split(',');
+  const overrides = parsed.searchParams.get('overrides') || '';
+  if (variant !== 'story.counter/loaded') {
+    throw new Error(`share URL variant mismatch: expected story.counter/loaded, got ${variant}`);
+  }
+  if (!modes.includes('Mode.app/dark')) {
+    throw new Error(`share URL modes missing Mode.app/dark: ${parsed.searchParams.get('modes')}`);
+  }
+  if (!overrides.includes(`label:"${label}"`)) {
+    throw new Error(`share URL overrides missing label ${JSON.stringify(label)}: ${overrides}`);
+  }
+  if (parsed.hash !== '#/stories') {
+    throw new Error(`share URL hash mismatch: expected #/stories, got ${parsed.hash}`);
+  }
+
+  await popover.getByRole('button', { name: /^close$/i }).click();
+  await aside.getByRole('button', { name: /reset overrides/i }).first().click();
+  await resetToolbarModes(page);
 }
 
 async function assertTraceActionsScrubberA11y(page, phase) {
@@ -361,46 +459,74 @@ async function assertTraceActionsScrubberA11y(page, phase) {
 
 async function assertToolbarRecorder(page, phase) {
   await step(page, phase, 'toolbar/recorder/review-dialog', async () => {
-    await clickVariant(page, '/loaded');
-    await waitForCanvasVariant(page, ':story.counter/loaded');
+    await clickVariant(page, '/empty');
+    await waitForCanvasVariant(page, ':story.counter/empty');
+    await setMode(page, 'dev');
 
     const toolbar = page.locator('[data-test="story-toolbar"]');
     await toolbar.waitFor({ state: 'visible', timeout: 5000 });
-    const dark = toolbar.locator('[data-toolbar-mode=":Mode.app/dark"]');
-    await dark.click();
-    await waitForValue(
-      () => dark.getAttribute('aria-pressed'),
-      (value) => value === 'true',
-      { timeoutMs: 5000, description: 'dark toolbar mode active' },
-    );
-    await toolbar.locator('[data-test="story-toolbar-reset"]').click();
-    await waitForValue(
-      () => dark.getAttribute('aria-pressed'),
-      (value) => value === 'false',
-      { timeoutMs: 5000, description: 'dark toolbar mode reset' },
-    );
+    await setToolbarMode(page, ':Mode.app/dark');
+    await resetToolbarModes(page);
 
     const rec = toolbar.locator('[data-test="story-toolbar-rec"]');
     await rec.waitFor({ state: 'visible', timeout: 5000 });
     await rec.click();
     await expectVisible(page.locator('[data-test="story-recorder-overlay"]'), 5000);
-    await page
-      .locator('[data-test-variant=":story.counter/loaded"]')
-      .locator('[data-test="inc"]')
-      .first()
+    const recordedCanvas = canvasFor(page, ':story.counter/empty');
+    for (let i = 0; i < 3; i += 1) {
+      await recordedCanvas.locator('[data-test="inc"]').first().click();
+    }
+    await waitForValue(
+      () => page.locator('[data-test="story-recorder-overlay"]').innerText(),
+      (text) => /3\s+events/.test(text),
+      { timeoutMs: 5000, description: 'recorder captured three user events' },
+    );
+    await expectTextEquals(recordedCanvas.locator('[data-test="count"]').first(), '3', 10000);
+    await page.locator('[data-test="story-recorder-stop"]').click();
+    const snippet = await recorderSnippetText(page);
+    const incEvents = snippet.match(/\[:counter\/inc\]/g) || [];
+    if (incEvents.length !== 3) {
+      throw new Error(`recorder snippet expected 3 [:counter/inc] events, got ${incEvents.length}: ${snippet}`);
+    }
+    await page.locator('[data-test="story-recorder-close"]').click();
+
+    await clickVariant(page, '/clicked-three-times');
+    await waitForCanvasVariant(page, ':story.counter/clicked-three-times');
+    await expectTextEquals(
+      canvasFor(page, ':story.counter/clicked-three-times').locator('[data-test="count"]').first(),
+      '3',
+      10000,
+    );
+  });
+
+  await step(page, phase, 'toolbar/recorder/redacts-sensitive-events', async () => {
+    await clickVariant(page, '/recorder-redaction');
+    await waitForCanvasVariant(page, ':story.counter-matrix/recorder-redaction');
+    await setMode(page, 'dev');
+
+    const toolbar = page.locator('[data-test="story-toolbar"]');
+    const rec = toolbar.locator('[data-test="story-toolbar-rec"]');
+    await rec.waitFor({ state: 'visible', timeout: 5000 });
+    await rec.click();
+    await expectVisible(page.locator('[data-test="story-recorder-overlay"]'), 5000);
+    await canvasFor(page, ':story.counter-matrix/recorder-redaction')
+      .locator('[data-test="story-recorder-sensitive-action"]')
       .click();
     await waitForValue(
       () => page.locator('[data-test="story-recorder-overlay"]').innerText(),
-      (text) => /\d+\s+events?/.test(text) && !/0\s+events/.test(text),
-      { timeoutMs: 5000, description: 'recorder captured at least one event' },
+      (text) => /1\s+event/.test(text),
+      { timeoutMs: 5000, description: 'recorder captured one redacted event' },
     );
     await page.locator('[data-test="story-recorder-stop"]').click();
-    await expectVisible(page.locator('[data-test="story-recorder-dialog"]'), 5000);
-    await expectTextContains(
-      page.locator('[data-test="story-recorder-snippet"]'),
-      ':counter/inc',
-      5000,
-    );
+    const snippet = await recorderSnippetText(page);
+    if (!snippet.includes('[:rf/redacted]')) {
+      throw new Error(`recorder snippet missing [:rf/redacted]: ${snippet}`);
+    }
+    for (const leaked of ['browser-secret', 'redaction@example.com', ':auth/sign-in']) {
+      if (snippet.includes(leaked)) {
+        throw new Error(`recorder snippet leaked sensitive token ${JSON.stringify(leaked)}: ${snippet}`);
+      }
+    }
     await page.locator('[data-test="story-recorder-close"]').click();
   });
 }
@@ -423,6 +549,19 @@ async function assertDiagnostics(page, phase) {
       () => page.locator('[data-test="story-test-row"][data-status="fail"]').count(),
       (count) => count >= 1,
       { timeoutMs: 5000, description: 'failing assertion row' },
+    );
+    await page
+      .locator('[data-test="story-test-row"][data-status="fail"]')
+      .first()
+      .getByRole('button', { name: /show detail/i })
+      .click();
+    await waitForValue(
+      () => page.locator('[data-test="story-test-row-detail"]').first().innerText().catch(() => ''),
+      (text) =>
+        /expected:\s*999/.test(text) &&
+        /actual:\s*1/.test(text) &&
+        /expected 999 at \[:count\] but got 1/.test(text),
+      { timeoutMs: 5000, description: 'failing assertion detail has expected, actual, and reason' },
     );
   });
 
@@ -523,6 +662,44 @@ async function ensureCounterLoaded(page) {
   await waitForCanvasVariant(page, ':story.counter/loaded');
 }
 
+async function resetLoadedControls(page) {
+  const aside = page.getByRole('complementary');
+  const reset = aside.getByRole('button', { name: /reset overrides/i }).first();
+  if (await reset.isVisible().catch(() => false)) {
+    await reset.click();
+  }
+  await expectVisible(
+    canvasFor(page, ':story.counter/loaded').getByText('Total', { exact: false }).first(),
+    5000,
+  );
+}
+
+async function snapshotHashFor(page, variantKeyword) {
+  return waitForValue(
+    () => canvasFor(page, variantKeyword).getAttribute('data-snapshot-hash'),
+    (value) => /^[0-9a-f]{8}$/.test(value || ''),
+    { timeoutMs: 5000, description: `${variantKeyword} snapshot content hash` },
+  );
+}
+
+async function assertSnapshotIdentityStable(page) {
+  await ensureCounterLoaded(page);
+  await resetToolbarModes(page);
+  await resetLoadedControls(page);
+  const first = await snapshotHashFor(page, ':story.counter/loaded');
+
+  await gotoStoryShell(page, '/counter-with-stories/#/stories');
+  await clickVariant(page, '/loaded');
+  await setMode(page, 'dev');
+  await resetToolbarModes(page);
+  await resetLoadedControls(page);
+  const second = await snapshotHashFor(page, ':story.counter/loaded');
+
+  if (first !== second) {
+    throw new Error(`snapshot identity drifted across reload: ${first} !== ${second}`);
+  }
+}
+
 async function assertHealthyLoaded(page) {
   await ensureCounterLoaded(page);
   await expectTextEquals(
@@ -601,19 +778,24 @@ async function assertIsolationPair(page) {
   await gotoStoryShell(page, '/counter-with-stories/#/stories');
   await clickVariant(page, '/isolation-a');
   await waitForCanvasVariant(page, ':story.counter-matrix/isolation-a');
-  const a = page.locator(
-    'main section[aria-label="Variant canvas"][data-test-variant=":story.counter-matrix/isolation-a"]',
-  );
+  const a = canvasFor(page, ':story.counter-matrix/isolation-a');
   await a.locator('[data-test="inc"]').first().click();
   await expectTextEquals(a.locator('[data-test="count"]').first(), '2', 10000);
 
-  await gotoStoryShell(page, '/counter-with-stories/#/stories');
   await clickVariant(page, '/isolation-b');
   await waitForCanvasVariant(page, ':story.counter-matrix/isolation-b');
-  const b = page.locator(
-    'main section[aria-label="Variant canvas"][data-test-variant=":story.counter-matrix/isolation-b"]',
-  );
+  const b = canvasFor(page, ':story.counter-matrix/isolation-b');
   await expectTextEquals(b.locator('[data-test="count"]').first(), '100', 10000);
+  await b.locator('[data-test="inc"]').first().click();
+  await expectTextEquals(b.locator('[data-test="count"]').first(), '101', 10000);
+
+  await clickVariant(page, '/isolation-a');
+  await waitForCanvasVariant(page, ':story.counter-matrix/isolation-a');
+  await expectTextEquals(
+    canvasFor(page, ':story.counter-matrix/isolation-a').locator('[data-test="count"]').first(),
+    '1',
+    10000,
+  );
 }
 
 async function assertMultiSubstrate(page) {
@@ -712,6 +894,10 @@ const FEATURE_CHECKS = {
     await assertMatrixVariant(page, '/clicked-three-times', ':story.counter/clicked-three-times', 3);
     await assertMainContains(page, 'decorator: story-level');
     await assertMainContains(page, 'decorator: variant-level');
+    await clickVariant(page, '/loaded');
+    await waitForCanvasVariant(page, ':story.counter/loaded');
+    await assertMainContains(page, 'decorator: story-level');
+    await assertMainNotContains(page, 'decorator: variant-level');
     await assertDecoratorFailure(page);
   },
   'reg-story-panel': async (page) => {
@@ -759,8 +945,7 @@ const FEATURE_CHECKS = {
     await assertDecoratorFailure(page);
   },
   'Snapshot identity': async (page) => {
-    await ensureCounterLoaded(page);
-    await expectVisible(page.locator('[data-test="story-open-in-editor"]').first(), 5000);
+    await assertSnapshotIdentityStable(page);
   },
   'Destroy/reset/watch variant API': assertIsolationPair,
   'Assertion events': async (page) => {
@@ -821,11 +1006,8 @@ const FEATURE_CHECKS = {
     await outline.click();
     await outline.click();
   },
-  'Share and QR': async (page) => {
-    await ensureCounterLoaded(page);
-    await page.getByRole('button', { name: /^share$/i }).first().click();
-    await expectVisible(page.getByRole('img', { name: /QR code for variant URL/i }), 5000);
-    await page.getByRole('button', { name: /^close$/i }).first().click();
+  'Share and QR': async (page, phase) => {
+    await assertShareUrlIntegrity(page, phase);
   },
   'Recorder / test codegen': assertToolbarRecorder,
   'Save current canvas state': async (page) => {


### PR DESCRIPTION
## Summary

Implements the rf2-zwu95 Story browser-test slice for recorder/play replay, recorder redaction, structured assertion output, snapshot identity stability, share/QR URL integrity, decorator isolation, and frame isolation.

Support fixes included because they were required to make the scenarios deterministic:
- canvas runtime runs are keyed so ordinary frame app-db updates do not replay static `:events`
- new/removed frame fingerprint baselines no longer trigger hot-reload reruns
- canvas frame-provider roots are keyed by variant id
- Story panels honor `:for` scoping against variant or parent story
- share URLs insert query params before the hash route and expose stable test hooks

## Tests

- `clojure -M:test -n re-frame.story-share-test` from `tools/story` - 14 tests, 31 assertions, 0 failures, 0 errors, 00:00:04.5093924
- `node --check ..\tools\story\test\story_feature_load.cjs` from `implementation` - 00:00:00.0350760
- `STORY_FEATURE_LOAD_PORT=8131 npm run test:story-feature-load` from `implementation` - 2 Story feature-load specs, 0 failures, 00:01:15.1744519

Under the new testing scheme, the Story feature-load command should run in PR CI for Story browser-harness changes because it exercises the changed browser surfaces end-to-end and remains quiet on success with actionable step context on failure. The JVM share-url test is a fast agent pre-checkin/PR check for URL canonicalisation. I skipped release-tier static build, production elision, bundle-size, and broad manual/nightly checks locally because this PR changes Story dev/test surfaces and the targeted browser gate covers the affected behavior without paying those expensive tiers on every agent pre-checkin.

## Notes

- Used `STORY_FEATURE_LOAD_PORT=8131` locally to avoid the default port 8031 collision with another Story worktree.
- Rebase found an upstream recorder-redaction fixture from adjacent Story work; this PR adopted that fixture rather than adding a duplicate redaction story.
- Report: `ai/findings/story-recorder-snapshot-rf2-zwu95.md`