### PR TITLE
ci: filter docs pushes and add Story/Causa browser gate

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Conservative changed-surface classifier for PR CI tiering.
 # Usage:
-#   .github/scripts/changed-surfaces.sh [--all] [path ...]
+#   .github/scripts/report-changed-surfaces.sh [--all] [path ...]
 #
 # With explicit paths, classify those paths. Without paths, derive the changed
 # file list from the GitHub Actions event, or from HEAD^ locally.
@@ -64,7 +64,7 @@ else
   while IFS= read -r file; do
     [ -z "$file" ] && continue
     case "$file" in
-      .github/workflows/test.yml|.github/workflows/expensive-tests.yml|.github/scripts/changed-surfaces.sh|TESTING.md)
+      .github/workflows/test.yml|.github/workflows/expensive-tests.yml|.github/scripts/report-changed-surfaces.sh|TESTING.md)
         mark_all
         ;;
       implementation/core/*)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,17 +3,31 @@ name: tests
 on:
   push:
     branches: [main]
+    # Push-only filter: docs/site-only pushes are covered by docs.yml and
+    # bead-only pushes should run no CI. Pull requests deliberately stay
+    # unfiltered so required checks cannot remain permanently pending.
     paths-ignore:
       - '.beads/**'
+      - 'docs/**'
+      - 'spec/**'
+      - 'skills/**/*.md'
+      - 'tools/**/*.md'
+      - 'mkdocs.yml'
+      - 'mkdocs_hooks.py'
+      - 'TESTING.md'
+      - 'requirements.txt'
+      - 'scripts/check_doc_slugs.py'
+      - 'scripts/_test_fixtures/check_doc_slugs/**'
+      - '.github/workflows/docs.yml'
   pull_request:
     branches: [main]
 
 # Fast PR spine jobs stay always-on: lockstep drift, skill/MCP drift,
 # core JVM, CLJS node integration, and JS harness self-tests. Expensive
-# browser, bundle, examples, tool, template, MCP-live, and skill
-# structural jobs are guarded by the conservative changed-surface
-# classifier below. Skipped diagnostic jobs are not required coverage;
-# the nightly/manual workflow carries the rigorous full sweep.
+# browser, bundle, examples, Story/Causa, tool, template, MCP-live, and
+# skill structural jobs are guarded by the conservative changed-surface
+# classifier below. Skipped diagnostic jobs are not required coverage; the
+# nightly/manual workflow carries the rigorous full sweep.
 
 jobs:
   detect_changed_surfaces:
@@ -40,7 +54,7 @@ jobs:
 
       - name: Classify changed surfaces
         id: detect
-        run: ./.github/scripts/changed-surfaces.sh
+        run: ./.github/scripts/report-changed-surfaces.sh
 
   # PR-time drift detection for the lockstep-version contract
   # (rf2-ace2 / rf2-w05l). Fast — the script is shared with
@@ -976,6 +990,64 @@ jobs:
       # once the suite has been stable for a couple of cycles.
       - name: Compile examples, serve, and run Playwright specs
         run: npm run test:examples
+
+  story-causa-browser:
+    name: Story/Causa browser gates (targeted)
+    needs: detect_changed_surfaces
+    if: needs.detect_changed_surfaces.outputs.story_causa_browser == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: implementation
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: implementation/package-lock.json
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08  # 13.4
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs (Story/Causa shadow-cljs deps)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: ${{ runner.os }}-story-causa-browser-${{ hashFiles('implementation/shadow-cljs.edn', 'implementation/package-lock.json', 'tools/story/deps.edn', 'tools/causa/deps.edn', 'implementation/core/deps.edn', 'implementation/adapters/reagent/deps.edn', 'implementation/machines/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-story-causa-browser-
+            ${{ runner.os }}-cljs-
+
+      - name: npm install
+        run: npm ci
+
+      - name: Install Playwright (Chromium + system deps)
+        run: npx playwright install --with-deps chromium
+
+      # PR-time targeted gate for Story/Causa browser regressions. The
+      # classifier keeps this off for unrelated PRs; nightly/manual CI
+      # still owns the full rigorous browser/bundle sweep.
+      - name: Run Story feature-load browser gate
+        run: npm run test:story-feature-load
+
+      - name: Run Causa feature browser gate
+        run: npm run test:causa-feature-gate
+
+      - name: Run Story static-export browser smoke
+        run: npm run test:story-static
 
   cljs-reagent-slim-bundle-isolation:
     name: CLJS Reagent Slim bundle isolation (adapter-owned, rf2-2ppcv)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1037,12 +1037,11 @@ jobs:
       - name: Install Playwright (Chromium + system deps)
         run: npx playwright install --with-deps chromium
 
-      # PR-time targeted gate for Story/Causa browser regressions. The
+      # PR-time targeted gates for Story/Causa browser regressions. The
       # classifier keeps this off for unrelated PRs; nightly/manual CI
-      # still owns the full rigorous browser/bundle sweep.
-      - name: Run Story feature-load browser gate
-        run: npm run test:story-feature-load
-
+      # still owns the full rigorous Story feature-load stress gate until
+      # tools/story/spec/015-Test-Coverage.md graduates it from
+      # occasional/pre-checkin status.
       - name: Run Causa feature browser gate
         run: npm run test:causa-feature-gate
 

--- a/tools/story/testbeds/counter_with_stories/views.cljs
+++ b/tools/story/testbeds/counter_with_stories/views.cljs
@@ -79,15 +79,21 @@
 
 (reg-view parity-badge []
   (r/with-let [_ nil]
-    (let [p @(subscribe [:count-parity])]
+    (let [p @(subscribe [:count-parity])
+          badge (case p
+                  :even {:bg "#dff6dd" :fg "#107c10" :text "even"}
+                  :odd  {:bg "#fff4ce" :fg "#7e5b00" :text "odd"}
+                  ;; Story chrome can render this panel before the
+                  ;; selected variant frame has replayed its seed events.
+                  {:bg "#f3f2f1" :fg "#605e5c" :text "pending"})]
       [:span {:style {:padding         "2px 8px"
                       :border-radius   "10px"
                       :font-size       "11px"
-                      :background      (case p :even "#dff6dd" :odd "#fff4ce")
-                      :color           (case p :even "#107c10" :odd "#7e5b00")
+                      :background      (:bg badge)
+                      :color           (:fg badge)
                       :margin-left     "1em"}
               :data-test "parity"}
-       (case p :even "even" :odd "odd")])))
+       (:text badge)])))
 
 ;; ---- Composed counter card ----------------------------------------------
 ;;


### PR DESCRIPTION
## Summary

- Rename `.github/scripts/changed-surfaces.sh` to `.github/scripts/report-changed-surfaces.sh` and update workflow/script references.
- Add push-only `paths-ignore` entries to `test.yml` for bead-only and docs/spec/site-only changes.
- Wire the existing `story_causa_browser` classifier output to a targeted PR-time Story/Causa browser job.

## CI path-filter reasoning

GitHub `paths-ignore` on `push` skips a workflow only when every changed path matches an ignored pattern. `test.yml` now ignores `.beads/**` plus the same docs/site inputs that `docs.yml` watches. That means:

- Docs/spec/site-only pushes still trigger `docs.yml`, but skip `test.yml`.
- Bead-only pushes match `.beads/**` for `test.yml` and do not match `docs.yml`, so neither docs nor tests run.
- Mixed docs + code pushes still run `test.yml` because not every changed path is ignored.
- `pull_request` remains unfiltered, so required PR checks cannot be left permanently pending by path filters.

## Story/Causa gate shape

The new `story-causa-browser` job runs only when `detect_changed_surfaces.outputs.story_causa_browser == 'true'`. It runs the Causa feature browser gate plus the stable Story static-export browser smoke. The full Story feature-load stress gate remains in nightly/manual CI and local pre-checkin because `tools/story/spec/015-Test-Coverage.md` still classifies `test:story-feature-load` as occasional/pre-checkin until its flake rate is proven acceptable.

## Validation

- `git diff --check`
- `git diff --check origin/main...HEAD`
- YAML parse for `test.yml`, `docs.yml`, `expensive-tests.yml`
- `npm run test:script-policy`
- `npm run test:script-helpers`
- `bash .github/scripts/report-changed-surfaces.sh docs/guide/foo.md spec/API.md .beads/issues.jsonl`
- `bash .github/scripts/report-changed-surfaces.sh .beads/issues.jsonl`
- `bash .github/scripts/report-changed-surfaces.sh tools/story/src/foo.cljs`
- `bash .github/scripts/report-changed-surfaces.sh tools/causa/src/foo.cljs`
- `bash .github/scripts/report-changed-surfaces.sh .github/scripts/report-changed-surfaces.sh`
- `bash .github/scripts/report-changed-surfaces.sh --all`
- `npm ci`
- `npx playwright install chromium`
- `STORY_FEATURE_LOAD_PORT=18331 npm run test:story-feature-load` (local pre-checkin stress probe; default `8031` was occupied by another worker worktree)
- `npm run test:causa-feature-gate` (passed after rebase; one subsequent local run exposed the known source-coordinate scenario intermittency, immediate rerun passed)
- `npm run test:story-static`

`actionlint` is not installed in this worktree environment, so workflow validation is parser-level plus local classifier/script checks.