### PR TITLE
test(browser): harden local harness cleanup

### DIFF
--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -18,10 +18,14 @@
  * local package so teardown kills the real server process on Windows too.
  */
 
-const { spawn, spawnSync } = require('child_process');
+const { spawnSync } = require('child_process');
 const fs = require('fs');
-const http = require('http');
 const path = require('path');
+const {
+  createHarnessCleanup,
+  spawnHarnessProcess,
+  waitForHttpReady,
+} = require('../../implementation/scripts/lib/local-browser-harness.cjs');
 
 const PORT = 8030;
 // __dirname is <repo>/examples/scripts. IMPL_ROOT is <repo>/implementation
@@ -36,7 +40,8 @@ const HTTP_SERVER_BIN = require.resolve('http-server/bin/http-server', {
   paths: [IMPL_ROOT],
 });
 const READY_TIMEOUT_MS = 30000;
-const POLL_MS = 200;
+const cleanup = createHarnessCleanup();
+cleanup.installSignalHandlers();
 
 // Each example: shadow-cljs build id, the html source to stage, and the
 // directory under out/examples it lands in. The url-path is what the
@@ -410,39 +415,14 @@ function stageHtml() {
   }
 }
 
-function probe(port) {
-  return new Promise((resolve) => {
-    const req = http.get(
-      { host: '127.0.0.1', port, path: '/', timeout: 1000 },
-      (res) => {
-        res.resume();
-        resolve(res.statusCode != null);
-      },
-    );
-    req.on('error', () => resolve(false));
-    req.on('timeout', () => {
-      req.destroy();
-      resolve(false);
-    });
-  });
-}
-
-async function waitForReady(port, deadline) {
-  while (Date.now() < deadline) {
-    if (await probe(port)) return true;
-    await new Promise((r) => setTimeout(r, POLL_MS));
-  }
-  return false;
-}
-
-(async () => {
+async function main() {
   compileAll();
   stageHtml();
 
-  const server = spawn(process.execPath, [HTTP_SERVER_BIN, OUT_ROOT, '-p', String(PORT), '-s', '-c-1'], {
+  const server = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [HTTP_SERVER_BIN, OUT_ROOT, '-p', String(PORT), '-s', '-c-1'], {
     cwd: IMPL_ROOT,
     stdio: ['ignore', 'inherit', 'inherit'],
-  });
+  }));
 
   let serverDown = false;
   server.on('exit', (code, signal) => {
@@ -452,25 +432,29 @@ async function waitForReady(port, deadline) {
     }
   });
 
-  const ready = await waitForReady(PORT, Date.now() + READY_TIMEOUT_MS);
+  const ready = await waitForHttpReady(PORT, Date.now() + READY_TIMEOUT_MS, {
+    isAborted: () => serverDown,
+  });
   if (!ready || serverDown) {
     console.error(`http-server did not become reachable on :${PORT} within ${READY_TIMEOUT_MS}ms.`);
-    if (!serverDown) server.kill();
-    process.exit(1);
+    return 1;
   }
 
-  const runner = spawn(process.execPath, [RUNNER], {
+  const runner = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [RUNNER], {
     stdio: 'inherit',
     env: { ...process.env, EXAMPLES_BASE_URL: `http://127.0.0.1:${PORT}` },
-  });
+  }));
 
   const code = await new Promise((resolve) => runner.on('exit', resolve));
 
-  if (!serverDown) {
-    server.kill();
-  }
-  process.exit(code == null ? 1 : code);
-})().catch((err) => {
+  return code == null ? 1 : code;
+}
+
+main().then(async (code) => {
+  await cleanup.cleanup();
+  process.exit(code);
+}).catch(async (err) => {
   console.error(err);
+  await cleanup.cleanup();
   process.exit(1);
 });

--- a/examples/scripts/serve-and-run-story-feature-load-tests.cjs
+++ b/examples/scripts/serve-and-run-story-feature-load-tests.cjs
@@ -7,11 +7,15 @@
  * serves implementation/out/examples, and invokes the quiet runner.
  */
 
-const { spawn, spawnSync } = require('child_process');
+const { spawnSync } = require('child_process');
 const fs = require('fs');
-const http = require('http');
 const path = require('path');
 const { resolveStoryFeatureLoadPort } = require('./story-feature-load-port.cjs');
+const {
+  createHarnessCleanup,
+  spawnHarnessProcess,
+  waitForHttpReady,
+} = require('../../implementation/scripts/lib/local-browser-harness.cjs');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const IMPL_ROOT = path.join(REPO_ROOT, 'implementation');
@@ -21,8 +25,9 @@ const HTTP_SERVER_BIN = require.resolve('http-server/bin/http-server', {
   paths: [IMPL_ROOT],
 });
 const READY_TIMEOUT_MS = 30000;
-const POLL_MS = 200;
 const VERBOSE = process.env.RF2_VERBOSE_TESTS === '1';
+const cleanup = createHarnessCleanup();
+cleanup.installSignalHandlers();
 
 const TESTBEDS = [
   {
@@ -71,40 +76,15 @@ function stageHtml() {
   }
 }
 
-function probe(port) {
-  return new Promise((resolve) => {
-    const req = http.get(
-      { host: '127.0.0.1', port, path: '/', timeout: 1000 },
-      (res) => {
-        res.resume();
-        resolve(res.statusCode != null);
-      },
-    );
-    req.on('error', () => resolve(false));
-    req.on('timeout', () => {
-      req.destroy();
-      resolve(false);
-    });
-  });
-}
-
-async function waitForReady(port, deadline) {
-  while (Date.now() < deadline) {
-    if (await probe(port)) return true;
-    await new Promise((resolve) => setTimeout(resolve, POLL_MS));
-  }
-  return false;
-}
-
-(async () => {
-  const PORT = await resolveStoryFeatureLoadPort({ env: process.env, repoRoot: REPO_ROOT });
+async function main() {
+  const port = await resolveStoryFeatureLoadPort({ env: process.env, repoRoot: REPO_ROOT });
   compileAll();
   stageHtml();
 
-  const server = spawn(process.execPath, [HTTP_SERVER_BIN, OUT_ROOT, '-p', String(PORT), '-s', '-c-1'], {
+  const server = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [HTTP_SERVER_BIN, OUT_ROOT, '-p', String(port), '-s', '-c-1'], {
     cwd: IMPL_ROOT,
     stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  }));
 
   let serverDown = false;
   const serverOutput = [];
@@ -122,29 +102,33 @@ async function waitForReady(port, deadline) {
     }
   });
 
-  const ready = await waitForReady(PORT, Date.now() + READY_TIMEOUT_MS);
+  const ready = await waitForHttpReady(port, Date.now() + READY_TIMEOUT_MS, {
+    isAborted: () => serverDown,
+  });
   if (!ready || serverDown) {
-    console.error(`http-server did not become reachable on :${PORT} within ${READY_TIMEOUT_MS}ms.`);
+    console.error(`http-server did not become reachable on :${port} within ${READY_TIMEOUT_MS}ms.`);
     for (const line of serverOutput.slice(-40)) console.error(line);
-    if (!serverDown) server.kill();
-    process.exit(1);
+    return 1;
   }
 
-  const runner = spawn(process.execPath, [RUNNER], {
+  const runner = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [RUNNER], {
     stdio: 'inherit',
     env: {
       ...process.env,
-      STORY_FEATURE_LOAD_BASE_URL: `http://127.0.0.1:${PORT}`,
+      STORY_FEATURE_LOAD_BASE_URL: `http://127.0.0.1:${port}`,
     },
-  });
+  }));
 
   const code = await new Promise((resolve) => runner.on('exit', resolve));
 
-  if (!serverDown) {
-    server.kill();
-  }
-  process.exit(code == null ? 1 : code);
-})().catch((err) => {
+  return code == null ? 1 : code;
+}
+
+main().then(async (code) => {
+  await cleanup.cleanup();
+  process.exit(code);
+}).catch(async (err) => {
   console.error(err);
+  await cleanup.cleanup();
   process.exit(1);
 });

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -29,6 +29,6 @@
     "test:causa-feature-gate": "node scripts/serve-and-run-causa-feature-gate.cjs",
     "test:story-static": "node scripts/check-story-static.cjs",
     "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_story-feature-load-port.test.cjs",
-    "test:script-helpers": "node scripts/_browser-test-report.test.cjs && node scripts/_gate-report.test.cjs"
+    "test:script-helpers": "node scripts/_browser-test-report.test.cjs && node scripts/_gate-report.test.cjs && node scripts/_local-browser-harness.test.cjs"
   }
 }

--- a/implementation/scripts/_local-browser-harness.test.cjs
+++ b/implementation/scripts/_local-browser-harness.test.cjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert/strict');
+const http = require('http');
+const {
+  createHarnessCleanup,
+  spawnHarnessProcess,
+  terminateProcessTree,
+  waitForHttpReady,
+} = require('./lib/local-browser-harness.cjs');
+
+const tests = [];
+
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+function listenOnLoopback(server) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve(server.address().port));
+  });
+}
+
+function waitForExit(child, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.off('exit', onExit);
+      reject(new Error(`child ${child.pid} did not exit within ${timeoutMs}ms`));
+    }, timeoutMs);
+    const onExit = (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal });
+    };
+    child.once('exit', onExit);
+  });
+}
+
+test('waitForHttpReady resolves true for a reachable local server', async () => {
+  const server = http.createServer((_, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain' });
+    res.end('ok');
+  });
+  const port = await listenOnLoopback(server);
+  try {
+    assert.equal(
+      await waitForHttpReady(port, Date.now() + 1000, { pollMs: 10 }),
+      true,
+    );
+  } finally {
+    server.close();
+  }
+});
+
+test('waitForHttpReady stops when aborted', async () => {
+  assert.equal(
+    await waitForHttpReady(1, Date.now() + 1000, {
+      isAborted: () => true,
+      pollMs: 10,
+    }),
+    false,
+  );
+});
+
+test('cleanup manager runs cleanup callbacks once', async () => {
+  let calls = 0;
+  const cleanup = createHarnessCleanup({ onError: () => {} });
+  cleanup.addCleanup(() => { calls += 1; });
+  await cleanup.cleanup();
+  await cleanup.cleanup();
+  cleanup.cleanupSync();
+  assert.equal(calls, 1);
+});
+
+test('terminateProcessTree stops a managed child process', async () => {
+  const child = spawnHarnessProcess(process.execPath, [
+    '-e',
+    'setInterval(() => {}, 1000)',
+  ], {
+    stdio: ['ignore', 'ignore', 'ignore'],
+  });
+
+  const exitPromise = waitForExit(child);
+  await terminateProcessTree(child, { timeoutMs: 2000 });
+  const exit = await exitPromise;
+  assert.notEqual(exit, null);
+});
+
+(async () => {
+  let failed = 0;
+  for (const { name, fn } of tests) {
+    try {
+      await fn();
+    } catch (err) {
+      failed += 1;
+      console.error(`FAIL ${name}`);
+      console.error(err && err.stack ? err.stack : err);
+    }
+  }
+
+  if (failed > 0) {
+    console.error(`local-browser-harness tests: ${failed} failed.`);
+    process.exit(1);
+  }
+
+  console.log(`local-browser-harness tests: ${tests.length} passed.`);
+})().catch((err) => {
+  console.error(err && err.stack ? err.stack : err);
+  process.exit(1);
+});

--- a/implementation/scripts/check-story-static.cjs
+++ b/implementation/scripts/check-story-static.cjs
@@ -38,7 +38,7 @@
 
 'use strict';
 
-const { spawn, spawnSync } = require('child_process');
+const { spawnSync } = require('child_process');
 const crypto = require('crypto');
 const fs = require('fs');
 const http = require('http');
@@ -48,6 +48,10 @@ const {
   createDiagnosticBuffer,
   isVerboseTests,
 } = require('./lib/browser-test-report.cjs');
+const {
+  createHarnessCleanup,
+  spawnHarnessProcess,
+} = require('./lib/local-browser-harness.cjs');
 
 const IMPL_ROOT = path.resolve(__dirname, '..');
 const REPO_ROOT = path.resolve(IMPL_ROOT, '..');
@@ -65,6 +69,14 @@ const READY_TIMEOUT_MS = 30000;
 const POLL_MS = 200;
 const VERBOSE_TESTS = isVerboseTests();
 const diagnostics = createDiagnosticBuffer();
+const cleanup = createHarnessCleanup({
+  onError: (err) => diagnostics.add(err && err.stack ? err.stack : String(err), 'stderr'),
+});
+cleanup.addCleanup(() => {
+  diagnostics.add('Tearing down story-static http-server.');
+  removeOwnershipToken();
+});
+cleanup.installSignalHandlers();
 
 // Per rf2-o38lb: ownership-token sentinel, same shape as
 // serve-and-run-browser-tests.cjs.
@@ -240,6 +252,11 @@ async function smokeTest(baseUrl, diagnostics) {
   }
 
   const browser = await playwright.chromium.launch();
+  cleanup.addCleanup(async () => {
+    try {
+      await browser.close();
+    } catch (_) {}
+  });
   const context = await browser.newContext();
   const page = await context.newPage();
 
@@ -345,11 +362,11 @@ async function smokeTest(baseUrl, diagnostics) {
   const port = await resolvePort(diagnostics);
   diagnostics.add(`Serving ${OUT_DIR} on http://127.0.0.1:${port}`);
 
-  const server = spawn(
+  const server = cleanup.trackProcess(spawnHarnessProcess(
     process.execPath,
     [HTTP_SERVER_BIN, OUT_DIR, '-p', String(port), '-s', '-c-1'],
     { cwd: IMPL_ROOT, stdio: ['ignore', 'pipe', 'pipe'] },
-  );
+  ));
   diagnostics.add(
     `Process: ${process.execPath} ${[HTTP_SERVER_BIN, OUT_DIR, '-p', String(port), '-s', '-c-1'].join(' ')}`,
   );
@@ -368,22 +385,6 @@ async function smokeTest(baseUrl, diagnostics) {
       diagnostics.add(`http-server exited (code=${code}, signal=${signal}).`);
     }
   });
-
-  // Shared teardown — kills the server we spawned (and only that one)
-  // and removes the ownership token. Idempotent.
-  const tornDownRef = { value: false };
-  const teardown = () => {
-    if (tornDownRef.value) return;
-    tornDownRef.value = true;
-    diagnostics.add('Tearing down story-static http-server.');
-    if (!state.exited) {
-      try { server.kill(); } catch (_) {}
-    }
-    removeOwnershipToken();
-  };
-  process.on('exit', teardown);
-  process.on('SIGINT', () => { teardown(); process.exit(130); });
-  process.on('SIGTERM', () => { teardown(); process.exit(143); });
 
   // 5. Wait for ready WITH ownership-token verification.
   const ready = await waitForReady(port, token, Date.now() + READY_TIMEOUT_MS, state);
@@ -410,7 +411,7 @@ async function smokeTest(baseUrl, diagnostics) {
         `http-server did not become reachable on :${port} within ${READY_TIMEOUT_MS}ms.`,
       );
     }
-    teardown();
+    await cleanup.cleanup();
     flushDiagnostics(diagnostics);
     process.exit(1);
   }
@@ -426,7 +427,7 @@ async function smokeTest(baseUrl, diagnostics) {
   }
 
   // 7. Tear down.
-  teardown();
+  await cleanup.cleanup();
   if (!smokeError) {
     if (VERBOSE_TESTS) flushDiagnostics(diagnostics);
     console.log('Story static smoke passed.');
@@ -437,7 +438,12 @@ async function smokeTest(baseUrl, diagnostics) {
 })().catch((err) => {
   console.error(err);
   if (err && err.stack) diagnostics.add(err.stack, 'stderr');
-  flushDiagnostics(diagnostics);
-  removeOwnershipToken();
-  process.exit(1);
+  cleanup.cleanup().then(() => {
+    flushDiagnostics(diagnostics);
+    process.exit(1);
+  }, (cleanupErr) => {
+    console.error(cleanupErr && cleanupErr.stack ? cleanupErr.stack : cleanupErr);
+    flushDiagnostics(diagnostics);
+    process.exit(1);
+  });
 });

--- a/implementation/scripts/lib/local-browser-harness.cjs
+++ b/implementation/scripts/lib/local-browser-harness.cjs
@@ -1,0 +1,203 @@
+'use strict';
+
+const { spawn, spawnSync } = require('child_process');
+const http = require('http');
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function probeHttp(port, opts = {}) {
+  const host = opts.host || '127.0.0.1';
+  const path = opts.path || '/';
+  const timeout = opts.timeout || 1000;
+
+  return new Promise((resolve) => {
+    const req = http.get({ host, port, path, timeout }, (res) => {
+      res.resume();
+      resolve(res.statusCode != null);
+    });
+    req.on('error', () => resolve(false));
+    req.on('timeout', () => {
+      req.destroy();
+      resolve(false);
+    });
+  });
+}
+
+async function waitForHttpReady(port, deadline, opts = {}) {
+  const pollMs = opts.pollMs || 200;
+  const isAborted = opts.isAborted || (() => false);
+  while (Date.now() < deadline) {
+    if (isAborted()) return false;
+    if (await probeHttp(port, opts)) return true;
+    if (isAborted()) return false;
+    await sleep(pollMs);
+  }
+  return false;
+}
+
+function spawnHarnessProcess(command, args, opts = {}) {
+  const spawnOpts = { ...opts };
+  if (spawnOpts.detached == null && process.platform !== 'win32') {
+    // Make the child a process-group leader so teardown can kill the full
+    // server/browser subtree instead of only the direct Node child.
+    spawnOpts.detached = true;
+  }
+  return spawn(command, args, spawnOpts);
+}
+
+function hasExited(child) {
+  return !child ||
+    !child.pid ||
+    child.exitCode != null ||
+    child.signalCode != null;
+}
+
+function waitForExit(child, timeoutMs) {
+  if (hasExited(child)) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      child.off('exit', onExit);
+      resolve(false);
+    }, timeoutMs);
+    const onExit = () => {
+      clearTimeout(timer);
+      resolve(true);
+    };
+    child.once('exit', onExit);
+  });
+}
+
+function terminateProcessTreeSync(child, opts = {}) {
+  if (hasExited(child)) return;
+  const signal = opts.signal || 'SIGTERM';
+  if (process.platform === 'win32') {
+    spawnSync('taskkill.exe', ['/pid', String(child.pid), '/T', '/F'], {
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    return;
+  }
+
+  try {
+    process.kill(-child.pid, signal);
+  } catch (_) {
+    try {
+      child.kill(signal);
+    } catch (__) {}
+  }
+}
+
+async function terminateProcessTree(child, opts = {}) {
+  if (hasExited(child)) return;
+
+  terminateProcessTreeSync(child, { signal: opts.signal || 'SIGTERM' });
+  if (await waitForExit(child, opts.timeoutMs || 2000)) return;
+
+  if (process.platform !== 'win32') {
+    terminateProcessTreeSync(child, { signal: 'SIGKILL' });
+  } else {
+    try {
+      child.kill('SIGKILL');
+    } catch (_) {}
+  }
+  await waitForExit(child, 500);
+}
+
+function createHarnessCleanup(opts = {}) {
+  const processes = [];
+  const cleanupFns = [];
+  const onError = opts.onError || ((err) => {
+    if (err) console.error(err && err.stack ? err.stack : err);
+  });
+  const exit = opts.exit || ((code) => process.exit(code));
+  let cleaned = false;
+  let cleaning = null;
+
+  function trackProcess(child) {
+    if (child) processes.push(child);
+    return child;
+  }
+
+  function addCleanup(fn) {
+    cleanupFns.push(fn);
+    return fn;
+  }
+
+  function cleanupSync() {
+    if (cleaned) return;
+    cleaned = true;
+    for (const child of [...processes].reverse()) {
+      try {
+        terminateProcessTreeSync(child);
+      } catch (err) {
+        onError(err);
+      }
+    }
+    for (const fn of [...cleanupFns].reverse()) {
+      try {
+        fn();
+      } catch (err) {
+        onError(err);
+      }
+    }
+  }
+
+  async function cleanup() {
+    if (cleaning) return cleaning;
+    cleaning = (async () => {
+      if (cleaned) return;
+      cleaned = true;
+      for (const child of [...processes].reverse()) {
+        try {
+          await terminateProcessTree(child);
+        } catch (err) {
+          onError(err);
+        }
+      }
+      for (const fn of [...cleanupFns].reverse()) {
+        try {
+          await fn();
+        } catch (err) {
+          onError(err);
+        }
+      }
+    })();
+    return cleaning;
+  }
+
+  function installSignalHandlers() {
+    process.once('SIGINT', () => {
+      cleanup().then(() => exit(130), (err) => {
+        onError(err);
+        exit(1);
+      });
+    });
+    process.once('SIGTERM', () => {
+      cleanup().then(() => exit(143), (err) => {
+        onError(err);
+        exit(1);
+      });
+    });
+    process.once('exit', cleanupSync);
+  }
+
+  return {
+    addCleanup,
+    cleanup,
+    cleanupSync,
+    installSignalHandlers,
+    trackProcess,
+  };
+}
+
+module.exports = {
+  createHarnessCleanup,
+  probeHttp,
+  sleep,
+  spawnHarnessProcess,
+  terminateProcessTree,
+  terminateProcessTreeSync,
+  waitForHttpReady,
+};

--- a/implementation/scripts/serve-and-run-browser-tests.cjs
+++ b/implementation/scripts/serve-and-run-browser-tests.cjs
@@ -23,13 +23,16 @@
  * instead of waiting out the full readiness timeout.
  */
 
-const { spawn } = require('child_process');
 const crypto = require('crypto');
 const fs = require('fs');
 const http = require('http');
 const net = require('net');
 const path = require('path');
 const { enforcePolicy, DEFAULT_OUT_ROOT } = require('./_path-policy.cjs');
+const {
+  createHarnessCleanup,
+  spawnHarnessProcess,
+} = require('./lib/local-browser-harness.cjs');
 
 const DEFAULT_PORT = 8021;
 // $BROWSER_TEST_ROOT lets a caller point the orchestrator at a different
@@ -55,6 +58,9 @@ const INDEX = path.join(ROOT, 'index.html');
 const RUNNER = path.resolve(__dirname, 'run-browser-tests.cjs');
 const READY_TIMEOUT_MS = 30000;
 const POLL_MS = 200;
+const cleanup = createHarnessCleanup();
+cleanup.addCleanup(removeOwnershipToken);
+cleanup.installSignalHandlers();
 
 // shadow-cljs's :browser-test target generates an index.html with an empty
 // <body>. Some example namespaces (e.g. examples/reagent/nine_states/core.cljs)
@@ -264,10 +270,10 @@ async function waitForReady(port, expectedToken, deadline, state) {
   // On Windows, npx is a .cmd shim — must go through the shell.
   const httpServerCmd = isWin ? 'npx.cmd' : 'npx';
   const args = ['http-server', ROOT, '-p', String(port), '-s', '-c-1'];
-  const server = spawn(httpServerCmd, args, {
+  const server = cleanup.trackProcess(spawnHarnessProcess(httpServerCmd, args, {
     stdio: ['ignore', 'inherit', 'inherit'],
     shell: isWin,
-  });
+  }));
 
   // Track the server's lifecycle so the readiness loop can fail fast
   // if http-server dies before becoming reachable. With pre-binding via
@@ -279,21 +285,6 @@ async function waitForReady(port, expectedToken, deadline, state) {
     state.exitCode = code;
     state.exitSignal = signal;
   });
-
-  // Shared teardown — kills the server we spawned (and only that one)
-  // and removes the ownership token. Idempotent.
-  const tornDownRef = { value: false };
-  const teardown = () => {
-    if (tornDownRef.value) return;
-    tornDownRef.value = true;
-    if (!state.exited) {
-      try { server.kill(); } catch (_) {}
-    }
-    removeOwnershipToken();
-  };
-  process.on('exit', teardown);
-  process.on('SIGINT', () => { teardown(); process.exit(130); });
-  process.on('SIGTERM', () => { teardown(); process.exit(143); });
 
   const ready = await waitForReady(port, token, Date.now() + READY_TIMEOUT_MS, state);
   if (!ready.ok) {
@@ -322,21 +313,22 @@ async function waitForReady(port, expectedToken, deadline, state) {
         `http-server did not become reachable on :${port} within ${READY_TIMEOUT_MS}ms.`
       );
     }
-    teardown();
-    process.exit(1);
+    return 1;
   }
 
-  const runner = spawn(process.execPath, [RUNNER], {
+  const runner = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [RUNNER], {
     stdio: 'inherit',
     env: { ...process.env, BROWSER_TEST_URL: `http://127.0.0.1:${port}` },
-  });
+  }));
 
   const code = await new Promise((resolve) => runner.on('exit', resolve));
 
-  teardown();
-  process.exit(code == null ? 1 : code);
-})().catch((err) => {
+  return code == null ? 1 : code;
+})().then(async (code) => {
+  await cleanup.cleanup();
+  process.exit(code);
+}).catch(async (err) => {
   console.error(err);
-  removeOwnershipToken();
+  await cleanup.cleanup();
   process.exit(1);
 });

--- a/implementation/scripts/serve-and-run-causa-feature-gate.cjs
+++ b/implementation/scripts/serve-and-run-causa-feature-gate.cjs
@@ -10,12 +10,16 @@
  * tools/causa/spec/017-Test-Coverage-Matrix.md.
  */
 
-const { spawn, spawnSync } = require('child_process');
+const { spawnSync } = require('child_process');
 const fs = require('fs');
-const http = require('http');
 const path = require('path');
 
 const { isVerboseTests } = require('./lib/browser-test-report.cjs');
+const {
+  createHarnessCleanup,
+  spawnHarnessProcess,
+  waitForHttpReady,
+} = require('./lib/local-browser-harness.cjs');
 const {
   SCENARIOS,
   STAGED_SURFACES,
@@ -36,10 +40,8 @@ const { chromium } = require(require.resolve('playwright', {
 const HTTP_SERVER_BIN = require.resolve('http-server/bin/http-server', {
   paths: [IMPL_ROOT],
 });
-
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
+const cleanup = createHarnessCleanup();
+cleanup.installSignalHandlers();
 
 function relPath(parts) {
   return path.join(REPO_ROOT, ...parts);
@@ -109,31 +111,6 @@ function stageSurfaces() {
       fs.copyFileSync(src, dest);
     }
   }
-}
-
-function probe(port) {
-  return new Promise((resolve) => {
-    const req = http.get(
-      { host: '127.0.0.1', port, path: '/', timeout: 1000 },
-      (res) => {
-        res.resume();
-        resolve(res.statusCode != null);
-      },
-    );
-    req.on('error', () => resolve(false));
-    req.on('timeout', () => {
-      req.destroy();
-      resolve(false);
-    });
-  });
-}
-
-async function waitForReady(port, deadline) {
-  while (Date.now() < deadline) {
-    if (await probe(port)) return true;
-    await sleep(200);
-  }
-  return false;
 }
 
 function safeFileStem(s) {
@@ -318,6 +295,11 @@ function formatDiagnostics(diag) {
 
 async function runScenarios() {
   const browser = await chromium.launch({ headless: true });
+  cleanup.addCleanup(async () => {
+    try {
+      await browser.close();
+    } catch (_) {}
+  });
   const results = [];
   let anyFailed = false;
 
@@ -412,10 +394,10 @@ async function main() {
   compileSurfaces();
   stageSurfaces();
 
-  const server = spawn(process.execPath, [HTTP_SERVER_BIN, OUT_ROOT, '-p', String(PORT), '-s', '-c-1'], {
+  const server = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [HTTP_SERVER_BIN, OUT_ROOT, '-p', String(PORT), '-s', '-c-1'], {
     cwd: IMPL_ROOT,
     stdio: ['ignore', 'inherit', 'inherit'],
-  });
+  }));
 
   let serverDown = false;
   server.on('exit', (code, signal) => {
@@ -425,22 +407,23 @@ async function main() {
     }
   });
 
-  const ready = await waitForReady(PORT, Date.now() + READY_TIMEOUT_MS);
+  const ready = await waitForHttpReady(PORT, Date.now() + READY_TIMEOUT_MS, {
+    isAborted: () => serverDown,
+  });
   if (!ready || serverDown) {
-    if (!serverDown) server.kill();
     throw new Error(`http-server did not become reachable on :${PORT} within ${READY_TIMEOUT_MS}ms.`);
   }
 
-  try {
-    return await runScenarios();
-  } finally {
-    if (!serverDown) server.kill();
-  }
+  return await runScenarios();
 }
 
 main()
-  .then((code) => process.exit(code))
-  .catch((err) => {
+  .then(async (code) => {
+    await cleanup.cleanup();
+    process.exit(code);
+  })
+  .catch(async (err) => {
     console.error(err && err.stack ? err.stack : err);
+    await cleanup.cleanup();
     process.exit(1);
   });


### PR DESCRIPTION
## Bead

- rf2-t7ry3: harden Windows local browser harness cleanup

## Summary

- Added a shared `local-browser-harness.cjs` helper for local browser harnesses: quiet HTTP readiness polling, signal-aware cleanup, and process-tree termination.
- Uses `taskkill /T /F` on Windows and process-group termination on non-Windows for tracked child processes.
- Wired the helper into browser-test, examples, Story feature-load/static, and Causa feature-gate orchestrators so server/browser runner cleanup happens on success, failure, timeout/early readiness failure, thrown errors, and SIGINT/SIGTERM where practical.
- Rebased over #1224 and preserved its Story feature-load dynamic port selection, quiet `http-server` buffering, and expanded CI/script-policy behavior.

## Changed files

- `implementation/scripts/lib/local-browser-harness.cjs`
- `implementation/scripts/_local-browser-harness.test.cjs`
- `implementation/scripts/serve-and-run-browser-tests.cjs`
- `implementation/scripts/check-story-static.cjs`
- `implementation/scripts/serve-and-run-causa-feature-gate.cjs`
- `examples/scripts/serve-and-run-examples-tests.cjs`
- `examples/scripts/serve-and-run-story-feature-load-tests.cjs`
- `implementation/package.json`

## Verification

- `npm run test:script-helpers`
- `npm run test:script-policy`
- `node --check examples/scripts/serve-and-run-examples-tests.cjs examples/scripts/serve-and-run-story-feature-load-tests.cjs examples/scripts/story-feature-load-port.cjs implementation/scripts/check-story-static.cjs implementation/scripts/serve-and-run-browser-tests.cjs implementation/scripts/serve-and-run-causa-feature-gate.cjs implementation/scripts/_local-browser-harness.test.cjs implementation/scripts/lib/local-browser-harness.cjs implementation/scripts/_changed-surfaces.test.cjs implementation/scripts/_story-feature-load-port.test.cjs`
- `npm run test:story-static`
- `git diff --check`
- Post-run cleanup checks: no `http-server` process from this worktree; `.rf-harness-token` removed.

## Follow-up recommendations

- If future harnesses start long-lived local servers, wire them through `local-browser-harness.cjs` rather than adding bespoke `server.kill()` teardown.
- `bd dolt push` was previously attempted but skipped because no Dolt remote is configured in this worktree; no bead was closed per dispatch instructions.