### PR TITLE
test(story): cover browser CI follow-ups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1038,15 +1038,17 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       # PR-time targeted gates for Story/Causa browser regressions. The
-      # classifier keeps this off for unrelated PRs; nightly/manual CI
-      # still owns the full rigorous Story feature-load stress gate until
-      # tools/story/spec/015-Test-Coverage.md graduates it from
-      # occasional/pre-checkin status.
+      # classifier keeps this off for unrelated PRs. Story feature-load
+      # runner/testbed/matrix changes must exercise the same live browser
+      # gate here, not only in a worker's local loop.
       - name: Run Causa feature browser gate
         run: npm run test:causa-feature-gate
 
       - name: Run Story static-export browser smoke
         run: npm run test:story-static
+
+      - name: Run Story feature-load browser gate
+        run: npm run test:story-feature-load
 
   cljs-reagent-slim-bundle-isolation:
     name: CLJS Reagent Slim bundle isolation (adapter-owned, rf2-2ppcv)

--- a/examples/scripts/serve-and-run-story-feature-load-tests.cjs
+++ b/examples/scripts/serve-and-run-story-feature-load-tests.cjs
@@ -11,8 +11,8 @@ const { spawn, spawnSync } = require('child_process');
 const fs = require('fs');
 const http = require('http');
 const path = require('path');
+const { resolveStoryFeatureLoadPort } = require('./story-feature-load-port.cjs');
 
-const PORT = parseInt(process.env.STORY_FEATURE_LOAD_PORT || '8031', 10);
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const IMPL_ROOT = path.join(REPO_ROOT, 'implementation');
 const OUT_ROOT = path.join(IMPL_ROOT, 'out', 'examples');
@@ -22,6 +22,7 @@ const HTTP_SERVER_BIN = require.resolve('http-server/bin/http-server', {
 });
 const READY_TIMEOUT_MS = 30000;
 const POLL_MS = 200;
+const VERBOSE = process.env.RF2_VERBOSE_TESTS === '1';
 
 const TESTBEDS = [
   {
@@ -96,15 +97,24 @@ async function waitForReady(port, deadline) {
 }
 
 (async () => {
+  const PORT = await resolveStoryFeatureLoadPort({ env: process.env, repoRoot: REPO_ROOT });
   compileAll();
   stageHtml();
 
   const server = spawn(process.execPath, [HTTP_SERVER_BIN, OUT_ROOT, '-p', String(PORT), '-s', '-c-1'], {
     cwd: IMPL_ROOT,
-    stdio: ['ignore', 'inherit', 'inherit'],
+    stdio: ['ignore', 'pipe', 'pipe'],
   });
 
   let serverDown = false;
+  const serverOutput = [];
+  const captureServerOutput = (chunk, stream) => {
+    const text = chunk.toString();
+    serverOutput.push(...text.split(/\r?\n/).filter(Boolean).map((line) => `[http-server:${stream}] ${line}`));
+    if (VERBOSE) process[stream].write(text);
+  };
+  server.stdout.on('data', (chunk) => captureServerOutput(chunk, 'stdout'));
+  server.stderr.on('data', (chunk) => captureServerOutput(chunk, 'stderr'));
   server.on('exit', (code, signal) => {
     serverDown = true;
     if (code !== 0 && code !== null) {
@@ -115,6 +125,7 @@ async function waitForReady(port, deadline) {
   const ready = await waitForReady(PORT, Date.now() + READY_TIMEOUT_MS);
   if (!ready || serverDown) {
     console.error(`http-server did not become reachable on :${PORT} within ${READY_TIMEOUT_MS}ms.`);
+    for (const line of serverOutput.slice(-40)) console.error(line);
     if (!serverDown) server.kill();
     process.exit(1);
   }

--- a/examples/scripts/story-feature-load-port.cjs
+++ b/examples/scripts/story-feature-load-port.cjs
@@ -1,0 +1,82 @@
+'use strict';
+
+const net = require('net');
+
+const DEFAULT_BASE_PORT = 8031;
+const DERIVED_PORT_SPAN = 2000;
+const MAX_PORT_ATTEMPTS = 200;
+
+function hashString(s) {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i += 1) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function parseExplicitPort(raw) {
+  if (raw == null || String(raw).trim() === '') return null;
+  const n = Number(String(raw).trim());
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    throw new Error(
+      `STORY_FEATURE_LOAD_PORT must be an integer in 1..65535; got ${JSON.stringify(raw)}`,
+    );
+  }
+  return n;
+}
+
+function preferredPort(repoRoot) {
+  const offset = hashString(repoRoot || process.cwd()) % DERIVED_PORT_SPAN;
+  return DEFAULT_BASE_PORT + offset;
+}
+
+function canListen(port, host = '127.0.0.1') {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once('error', () => resolve(false));
+    server.listen(port, host, () => {
+      server.close(() => resolve(true));
+    });
+  });
+}
+
+async function findAvailablePort(startPort, opts = {}) {
+  const host = opts.host || '127.0.0.1';
+  const attempts = opts.attempts || MAX_PORT_ATTEMPTS;
+  for (let i = 0; i < attempts; i += 1) {
+    const port = startPort + i;
+    if (port > 65535) break;
+    if (await canListen(port, host)) return port;
+  }
+  throw new Error(
+    `No free Story feature-load port found from ${startPort} after ${attempts} attempts. ` +
+      `Set STORY_FEATURE_LOAD_PORT to an unused port for this worktree.`,
+  );
+}
+
+async function resolveStoryFeatureLoadPort({ env = process.env, repoRoot = process.cwd() } = {}) {
+  const explicit = parseExplicitPort(env.STORY_FEATURE_LOAD_PORT);
+  if (explicit != null) {
+    if (!(await canListen(explicit))) {
+      throw new Error(
+        `STORY_FEATURE_LOAD_PORT=${explicit} is already in use. ` +
+          `Choose a unique port for this worktree.`,
+      );
+    }
+    return explicit;
+  }
+  return findAvailablePort(preferredPort(repoRoot));
+}
+
+module.exports = {
+  DEFAULT_BASE_PORT,
+  DERIVED_PORT_SPAN,
+  MAX_PORT_ATTEMPTS,
+  canListen,
+  findAvailablePort,
+  hashString,
+  parseExplicitPort,
+  preferredPort,
+  resolveStoryFeatureLoadPort,
+};

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -28,7 +28,7 @@
     "test:story-feature-load": "node ../examples/scripts/serve-and-run-story-feature-load-tests.cjs",
     "test:causa-feature-gate": "node scripts/serve-and-run-causa-feature-gate.cjs",
     "test:story-static": "node scripts/check-story-static.cjs",
-    "test:script-policy": "node scripts/_path-policy.test.cjs",
+    "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_story-feature-load-port.test.cjs",
     "test:script-helpers": "node scripts/_browser-test-report.test.cjs && node scripts/_gate-report.test.cjs"
   }
 }

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('assert/strict');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const IMPL_ROOT = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(IMPL_ROOT, '..');
+const WORKFLOW = path.join(REPO_ROOT, '.github', 'workflows', 'test.yml');
+
+const tests = [];
+
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+function classify(...files) {
+  const quote = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`;
+  const command = ['./.github/scripts/report-changed-surfaces.sh', ...files.map(quote)].join(' ');
+  const env = { ...process.env };
+  delete env.GITHUB_OUTPUT;
+  const out = execFileSync('bash', ['-lc', command], {
+    cwd: REPO_ROOT,
+    env,
+    encoding: 'utf8',
+  });
+  return Object.fromEntries(
+    out
+      .trim()
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => line.split('=')),
+  );
+}
+
+test('Story feature-load runner changes trigger targeted Story/Causa browser CI', () => {
+  const result = classify('tools/story/test/story_feature_load.cjs');
+  assert.equal(result.story_causa_browser, 'true');
+});
+
+test('Story browser scenario changes trigger targeted Story/Causa browser CI', () => {
+  const result = classify('tools/story/test/story_browser_scenarios.cjs');
+  assert.equal(result.story_causa_browser, 'true');
+});
+
+test('Story feature-load testbed changes trigger targeted Story/Causa browser CI', () => {
+  const result = classify('tools/story/testbeds/counter_with_stories/stories.cljs');
+  assert.equal(result.story_causa_browser, 'true');
+});
+
+test('targeted Story/Causa workflow runs the Story feature-load gate', () => {
+  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
+  assert.match(workflow, /story-causa-browser:[\s\S]*npm run test:story-feature-load/);
+});
+
+let failed = 0;
+for (const { name, fn } of tests) {
+  try {
+    fn();
+  } catch (err) {
+    failed += 1;
+    console.error(`FAIL ${name}`);
+    console.error(err && err.stack ? err.stack : err);
+  }
+}
+
+if (failed > 0) {
+  console.error(`changed-surfaces tests: ${failed} failed.`);
+  process.exit(1);
+}
+
+console.log(`changed-surfaces tests: ${tests.length} passed.`);

--- a/implementation/scripts/_story-feature-load-port.test.cjs
+++ b/implementation/scripts/_story-feature-load-port.test.cjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('assert/strict');
+const net = require('net');
+const path = require('path');
+
+const {
+  DEFAULT_BASE_PORT,
+  DERIVED_PORT_SPAN,
+  findAvailablePort,
+  parseExplicitPort,
+  preferredPort,
+  resolveStoryFeatureLoadPort,
+} = require('../../examples/scripts/story-feature-load-port.cjs');
+
+const tests = [];
+
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+function occupy(port) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => resolve(server));
+  });
+}
+
+function close(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+test('explicit STORY_FEATURE_LOAD_PORT parses strictly', async () => {
+  assert.equal(parseExplicitPort('8123'), 8123);
+  assert.equal(parseExplicitPort(undefined), null);
+  assert.throws(() => parseExplicitPort('0'), /1\.\.65535/);
+  assert.throws(() => parseExplicitPort('8031.5'), /1\.\.65535/);
+});
+
+test('preferred port is deterministic per worktree root', async () => {
+  const a = preferredPort(path.join('repo', 'worktree-a'));
+  const b = preferredPort(path.join('repo', 'worktree-a'));
+  assert.equal(a, b);
+  assert.ok(a >= DEFAULT_BASE_PORT);
+  assert.ok(a < DEFAULT_BASE_PORT + DERIVED_PORT_SPAN);
+});
+
+test('automatic resolution skips an occupied preferred port', async () => {
+  const preferred = 19031;
+  const server = await occupy(preferred);
+  try {
+    const port = await findAvailablePort(preferred, { attempts: 5 });
+    assert.notEqual(port, preferred);
+    assert.ok(port > preferred);
+  } finally {
+    await close(server);
+  }
+});
+
+test('explicit occupied port fails with actionable message', async () => {
+  const port = 19041;
+  const server = await occupy(port);
+  try {
+    await assert.rejects(
+      () => resolveStoryFeatureLoadPort({ env: { STORY_FEATURE_LOAD_PORT: String(port) } }),
+      /already in use.*unique port/,
+    );
+  } finally {
+    await close(server);
+  }
+});
+
+(async () => {
+  let failed = 0;
+  for (const { name, fn } of tests) {
+    try {
+      await fn();
+    } catch (err) {
+      failed += 1;
+      console.error(`FAIL ${name}`);
+      console.error(err && err.stack ? err.stack : err);
+    }
+  }
+
+  if (failed > 0) {
+    console.error(`story-feature-load-port tests: ${failed} failed.`);
+    process.exit(1);
+  }
+
+  console.log(`story-feature-load-port tests: ${tests.length} passed.`);
+})();

--- a/tools/story/test/re_frame/story_panels_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_panels_cljs_test.cljs
@@ -69,6 +69,45 @@
       (is (vector? out-visible))
       (is (vector? out-hidden)))))
 
+(defn- rendered-panel-text [tree]
+  (pr-str tree))
+
+(deftest render-panels-respects-for-parent-story-scope
+  (testing "a panel :for parent story appears for child variants only"
+    (story/reg-story-panel :Panel.scope/notes
+      {:title "Scoped"
+       :placement :right
+       :render :Panel.scope/missing-view
+       :for #{:story.scope}})
+    (let [scoped (rendered-panel-text
+                   (panels/render-panels-at-placement
+                     :right :story.scope/child {}))
+          other  (rendered-panel-text
+                   (panels/render-panels-at-placement
+                     :right :story.other/child {}))]
+      (is (re-find #":Panel\.scope/notes" scoped)
+          "parent-story :for scope must include child variants")
+      (is (not (re-find #":Panel\.scope/notes" other))
+          "parent-story :for scope must not leak into unrelated frames"))))
+
+(deftest render-panels-respects-for-exact-variant-scope
+  (testing "a panel :for exact variant appears only for that variant frame"
+    (story/reg-story-panel :Panel.scope/exact
+      {:title "Exact"
+       :placement :right
+       :render :Panel.scope/missing-view
+       :for #{:story.scope/exact}})
+    (let [exact (rendered-panel-text
+                  (panels/render-panels-at-placement
+                    :right :story.scope/exact {}))
+          sibling (rendered-panel-text
+                    (panels/render-panels-at-placement
+                      :right :story.scope/sibling {}))]
+      (is (re-find #":Panel\.scope/exact" exact)
+          "exact variant :for scope must include that frame")
+      (is (not (re-find #":Panel\.scope/exact" sibling))
+          "exact variant :for scope must not leak to siblings"))))
+
 ;; ---- layout-debug toggle state ----------------------------------------
 
 (deftest layout-debug-toggle-roundtrip

--- a/tools/story/test/story_browser_scenarios.cjs
+++ b/tools/story/test/story_browser_scenarios.cjs
@@ -12,6 +12,7 @@ const {
   expectVisible,
   waitForValue,
 } = require('../../../examples/scripts/spec-helpers.cjs');
+const assert = require('assert/strict');
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -124,6 +125,16 @@ async function snapshotHash(page, variantId) {
   return canvas(page, variantId).getAttribute('data-snapshot-hash');
 }
 
+function assertBrowserVisibleUnsignedHex(hash, description) {
+  if (!/^[0-9a-f]{8}$/.test(hash || '')) {
+    throw new Error(`${description}: expected browser-visible unsigned 8-char hex, got ${hash}`);
+  }
+  const n = Number.parseInt(hash, 16);
+  if (!Number.isInteger(n) || n < 0 || n > 0xffffffff) {
+    throw new Error(`${description}: hex was not an unsigned 32-bit value: ${hash}`);
+  }
+}
+
 function assertUrlParam(url, key, expected) {
   const parsed = new URL(url);
   const actual = parsed.searchParams.get(key);
@@ -147,6 +158,76 @@ function assertNoThirdPartyRequests(page) {
   if (unexpected.length > 0) {
     throw new Error(`unexpected third-party requests: ${JSON.stringify(unexpected)}`);
   }
+}
+
+async function installDeterministicAxe(page) {
+  await page.evaluate(() => {
+    localStorage.setItem('rf.story.a11y/cdn-opt-in', 'true');
+    window.axe = {
+      run(context) {
+        const bad = context && context.querySelector
+          ? context.querySelector('[data-test="a11y-known-bad-image"]')
+          : null;
+        if (!bad) {
+          return Promise.resolve({ violations: [] });
+        }
+        return Promise.resolve({
+          violations: [
+            {
+              id: 'image-alt',
+              impact: 'critical',
+              help: 'Images must have alternate text',
+              description: 'Fixture image intentionally omits alt text.',
+              nodes: [
+                {
+                  target: ['[data-test="a11y-known-bad-image"]'],
+                },
+              ],
+            },
+          ],
+        });
+      },
+    };
+  });
+}
+
+async function runA11yScan(page, variantId) {
+  await waitForCanvas(page, variantId);
+  await page.locator(`[data-rf-story-variant-root="${variantId}"]`).waitFor({
+    state: 'visible',
+    timeout: 5000,
+  });
+  const runButton = page
+    .getByRole('complementary')
+    .getByRole('button', { name: /^(run|re-run|retry)$/i })
+    .first();
+  await runButton.waitFor({ state: 'visible', timeout: 5000 });
+  await runButton.click();
+}
+
+async function a11yPanelSnapshot(page) {
+  return waitForValue(
+    () =>
+      page.evaluate(() => {
+        const panel = document.querySelector('aside');
+        const rows = Array.from(document.querySelectorAll('[data-test="story-a11y-violation"]'))
+          .map((el) => ({
+            id: el.getAttribute('data-a11y-id') || '',
+            impact: el.getAttribute('data-a11y-impact') || '',
+            help: el.getAttribute('data-a11y-help') || '',
+            target: el.getAttribute('data-a11y-target') || '',
+            inVariantRoot: Boolean(el.closest('[data-rf-story-variant-root]')),
+          }));
+        return {
+          text: panel ? panel.innerText : '',
+          rows,
+        };
+      }),
+    (snapshot) =>
+      /\d+\s+violation\(s\) found in variant/i.test(snapshot.text) ||
+      /axe-core failed to load|no variant mounted|needs your approval/i.test(snapshot.text),
+    { timeoutMs: 10000, description: 'a11y panel reaches terminal state' },
+  );
 }
 
 module.exports = {
@@ -185,6 +266,7 @@ module.exports = {
         (value) => /^[0-9a-f]{8}$/.test(value || ''),
         { timeoutMs: 5000, description: 'initial snapshot hash' },
       );
+      assertBrowserVisibleUnsignedHex(firstHash, 'initial snapshot hash');
 
       await page.reload({ waitUntil: 'load' });
       await primeHelpDismissed(page);
@@ -194,6 +276,7 @@ module.exports = {
         (value) => /^[0-9a-f]{8}$/.test(value || ''),
         { timeoutMs: 5000, description: 'snapshot hash after reload' },
       );
+      assertBrowserVisibleUnsignedHex(secondHash, 'snapshot hash after reload');
       if (secondHash !== firstHash) {
         throw new Error(`snapshot hash was not reproducible: ${firstHash} -> ${secondHash}`);
       }
@@ -215,6 +298,7 @@ module.exports = {
         (value) => /^[0-9a-f]{8}$/.test(value || '') && value !== firstHash,
         { timeoutMs: 5000, description: 'snapshot hash changes after arg override' },
       );
+      assertBrowserVisibleUnsignedHex(changedHash, 'changed snapshot hash');
       if (changedHash === firstHash) {
         throw new Error('snapshot hash did not change after label override');
       }
@@ -351,6 +435,49 @@ module.exports = {
       }
       await page.locator('[data-test="story-recorder-close"]').click();
       await sleep(0);
+    });
+
+    await scenario(page, 'a11y-known-good-and-known-bad-fixtures', async () => {
+      await setMode(page, 'dev');
+      await installDeterministicAxe(page);
+
+      await clickVariant(page, '/a11y-known-good');
+      await runA11yScan(page, ':story.counter-matrix/a11y-known-good');
+      let snapshot = await a11yPanelSnapshot(page);
+      if (!/0\s+violation\(s\) found in variant/i.test(snapshot.text)) {
+        throw new Error(
+          `expected known-good a11y fixture to report zero violations; ` +
+            `panel=${JSON.stringify(snapshot)}`,
+        );
+      }
+
+      await clickVariant(page, '/a11y-known-bad');
+      await runA11yScan(page, ':story.counter-matrix/a11y-known-bad');
+      snapshot = await a11yPanelSnapshot(page);
+      const row = snapshot.rows[0];
+      if (snapshot.rows.length !== 1) {
+        throw new Error(
+          `expected one known-bad a11y violation row; panel=${JSON.stringify(snapshot)}`,
+        );
+      }
+      assert.deepEqual(row, {
+        id: 'image-alt',
+        impact: 'critical',
+        help: 'Images must have alternate text',
+        target: '[data-test="a11y-known-bad-image"]',
+        inVariantRoot: false,
+      });
+      const decoratedTarget = await page
+        .locator(
+          '[data-rf-story-variant-root=":story.counter-matrix/a11y-known-bad"] [data-test="a11y-known-bad-image"][data-rf-a11y-violation="critical"]',
+        )
+        .count();
+      if (decoratedTarget !== 1) {
+        throw new Error(
+          `expected exactly one bad fixture target decorated inside its variant root; ` +
+            `count=${decoratedTarget}`,
+        );
+      }
     });
   },
 };

--- a/tools/story/testbeds/counter_with_stories/stories.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories.cljs
@@ -456,6 +456,30 @@
      :tags      #{:dev :test :internal}
      :substrates #{:reagent}})
 
+  (story/reg-variant :story.counter-matrix/a11y-known-good
+    {:doc       "Deterministic a11y known-good browser fixture. The
+                browser scenario injects a stable axe-compatible
+                scanner and asserts this fixture reports zero rows."
+     :component :counter-with-stories.views/a11y-known-good-card
+     :args      {:label "A11y known good"
+                 :settings {:title "A11y good" :enabled? true}}
+     :events    [[:counter/initialise 21]]
+     :play      [[:rf.assert/path-equals [:count] 21]]
+     :tags      #{:dev :test :internal}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.counter-matrix/a11y-known-bad
+    {:doc       "Deterministic a11y known-bad browser fixture. The
+                violation is tied to a fixture-owned image selector so
+                output stays stable and never depends on Story chrome."
+     :component :counter-with-stories.views/a11y-known-bad-card
+     :args      {:label "A11y known bad"
+                 :settings {:title "A11y bad" :enabled? true}}
+     :events    [[:counter/initialise 22]]
+     :play      [[:rf.assert/path-equals [:count] 22]]
+     :tags      #{:dev :test :internal}
+     :substrates #{:reagent}})
+
   ;; -------------------------------------------------------------------------
   ;; reg-workspace — two workspaces, one per layout the v1 ships
   ;;

--- a/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
@@ -117,9 +117,11 @@
                    :story.counter-matrix/multi-substrate
                    :story.counter-matrix/isolation-a
                    :story.counter-matrix/isolation-b
-                   :story.counter-matrix/recorder-redaction]]
+                   :story.counter-matrix/recorder-redaction
+                   :story.counter-matrix/a11y-known-good
+                   :story.counter-matrix/a11y-known-bad]]
         (is (contains? vs vid) (str vid " registered")))
-      (is (= 11 (count vs))))))
+      (is (= 13 (count vs))))))
 
 (deftest example-workspaces-registered
   (testing "both workspaces registered"

--- a/tools/story/testbeds/counter_with_stories/views.cljs
+++ b/tools/story/testbeds/counter_with_stories/views.cljs
@@ -127,6 +127,29 @@
              :data-test  "story-recorder-sensitive-action"}
     "Sensitive sign in"]])
 
+(reg-view a11y-known-good-card [_args]
+  [:div {:style {:display "inline-flex"
+                 :flex-direction "column"
+                 :gap "0.5em"}
+         :data-test "a11y-known-good-fixture"}
+   [:h2 {:style {:margin 0 :font-size "18px"}} "Accessible fixture"]
+   [:button {:type "button"
+             :aria-label "Accessible fixture action"
+             :data-test "a11y-known-good-action"}
+    "Run accessible action"]])
+
+(reg-view a11y-known-bad-card [_args]
+  [:div {:style {:display "inline-flex"
+                 :flex-direction "column"
+                 :gap "0.5em"}
+         :data-test "a11y-known-bad-fixture"}
+   [:h2 {:style {:margin 0 :font-size "18px"}} "Inaccessible fixture"]
+   [:img {:src "data:image/gif;base64,R0lGODlhAQABAAAAACw="
+          :data-test "a11y-known-bad-image"}]
+   [:button {:type "button"
+             :data-test "a11y-known-bad-action"}
+    "Unlabelled image above"]])
+
 (reg-view throwing-card [_args]
   [:div {:style {:background "#5a1d1d"
                  :color "#fff"


### PR DESCRIPTION
## Beads

- rf2-isrh7
- rf2-uevkm
- rf2-1net7

## Summary

- Run `npm run test:story-feature-load` in the targeted Story/Causa browser CI job, with a JS regression test that Story feature-load runner/testbed changes classify into that job and that the workflow includes the gate.
- Add Story feature-load port hygiene: automatic per-worktree preferred port selection, occupied-port fallback, explicit `STORY_FEATURE_LOAD_PORT` validation, and quiet http-server output unless verbose/failing.
- Add durable Story invariants near owning tests: panel `:for` parent/variant scoping, browser-visible unsigned snapshot hash assertions, and deterministic a11y known-good/known-bad Story fixtures with browser coverage and stable violation output.

## Verification

- `npm ci`
- `npm run test:script-policy && npm run test:script-helpers`
- `git diff --check HEAD^ HEAD`
- `node --check ../examples/scripts/serve-and-run-story-feature-load-tests.cjs; node --check ../examples/scripts/story-feature-load-port.cjs; node --check scripts/_changed-surfaces.test.cjs; node --check scripts/_story-feature-load-port.test.cjs; node --check ../tools/story/test/story_browser_scenarios.cjs`
- `npm run test:story-feature-load`
- `npm run test:cljs`

Note: `bd dolt pull` failed in this worktree with `Error 1105: no remote`; no bead statuses were changed or closed per dispatch instructions.