### PR TITLE
test(causa): expand feature matrix load coverage

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
@@ -87,6 +87,42 @@
     (catch :default _
       (str v))))
 
+(def ^:private display-large-string-threshold
+  "Display-only ceiling for string values in App-DB Diff. The panel is
+  a diagnostic surface, not a payload dump; large values are represented
+  structurally so the DOM and failure diagnostics stay bounded."
+  1024)
+
+(defn- display-value
+  "Return `v` with large string leaves replaced by a stable marker for
+  panel rendering. This does not mutate app-db or clipboard behaviour;
+  it only protects the visible Causa surface from rendering huge values."
+  [v]
+  (cond
+    (and (string? v) (> (count v) display-large-string-threshold))
+    {:rf.size/large-elided {:chars (count v)}}
+
+    (map? v)
+    (into (empty v) (map (fn [[k value]] [k (display-value value)])) v)
+
+    (vector? v)
+    (mapv display-value v)
+
+    (set? v)
+    (into (empty v) (map display-value) v)
+
+    (sequential? v)
+    (doall (map display-value v))
+
+    :else
+    v))
+
+(defn- format-display-edn
+  "Best-effort EDN-like format for visible values. Large leaves are
+  rendered as `:rf.size/large-elided` markers before printing."
+  [v]
+  (format-edn (display-value v)))
+
 (defn- truncate
   "Truncate `s` to `n` chars (adding an ellipsis)."
   [s n]
@@ -141,7 +177,7 @@
                   :color         (:text-primary tokens)
                   :word-break    "break-word"
                   :white-space   "pre-wrap"}}
-    (format-edn value)]])
+    (format-display-edn value)]])
 
 (defn- slice-row
   "One slice mini-panel for a `[op path before after]` triple.

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -234,11 +234,11 @@
 (defn- trace-row
   "One row in the trace ribbon."
   [{:keys [id time op-type operation source origin frame description
-           source-coord dispatch-id]
+           source-coord dispatch-id row-index]
     :as _row}]
   (let [row-test-id (str "rf-causa-trace-row-" id)
         dot-colour  (h/op-type-colour op-type)]
-    [:li {:key         [frame id time op-type operation source-coord]
+    [:li {:key         [row-index frame id time op-type operation source-coord]
           :data-testid row-test-id
           :on-click    (fn []
                          (when dispatch-id

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
@@ -326,7 +326,10 @@
                   (update :rendered inc))
               state'')))
         result         (reduce accumulate init-state events)
-        sorted-display (vec (:rev-filtered result))
+        sorted-display (mapv (fn [idx row]
+                                (assoc row :row-index idx))
+                              (range)
+                              (:rev-filtered result))
         empty-kind  (cond
                       (zero? (:total result))    :no-events
                       (zero? (:rendered result)) :no-matches

--- a/tools/causa/testbeds/feature_matrix/README.md
+++ b/tools/causa/testbeds/feature_matrix/README.md
@@ -44,3 +44,11 @@ re-check. It now exercises the follow-up surfaces directly:
   into `:counter/b` and `:log`, per-frame epoch history, trace selection,
   event-detail projection/orphan-state behavior, causality graph visibility,
   and the time-travel panel's current `:counter/b` target-frame projection.
+- Sensitive and large payload load: the sensitive and large dispatcher
+  scenarios now drive 20 meaningful host dispatches each, asserting redaction
+  indicators, absence of raw secret payloads, large-elision markers, and
+  app-db/trace panel stability under repeated privacy/size events.
+- Trace row budget: the load gate saturates Causa's 1000-event trace ring,
+  asserts the Trace panel keeps the DOM to the 200-row rendering budget with an
+  overflow indicator, then drives 20 more host dispatches without growing the
+  rendered row count.

--- a/tools/causa/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/causa/testbeds/feature_matrix/scenarios.cjs
@@ -697,6 +697,80 @@ async function readTraceCounts(page) {
   return { rendered: Number(match[1]), total: Number(match[2]), text };
 }
 
+async function readTraceDomBudget(page) {
+  return page.evaluate(() => {
+    const root = document.getElementById('rf-causa-root');
+    const feed = root && root.querySelector('[data-testid="rf-causa-trace-feed"]');
+    const overflow = root && root.querySelector('[data-testid="rf-causa-trace-overflow-indicator"]');
+    return {
+      rootPresent: Boolean(root),
+      feedPresent: Boolean(feed),
+      rowCount: root ? root.querySelectorAll('li[data-testid^="rf-causa-trace-row-"]').length : 0,
+      overflowPresent: Boolean(overflow),
+      overflowText: overflow ? (overflow.textContent || '').trim() : null,
+    };
+  });
+}
+
+async function pushSyntheticTraceEvents(page, count) {
+  const result = await page.evaluate((eventCount) => {
+    const cljs = window.cljs && window.cljs.core;
+    const bus = window.day8 &&
+      window.day8.re_frame2_causa &&
+      window.day8.re_frame2_causa.trace_bus;
+    if (!cljs || !bus || typeof bus.collect_trace_BANG_ !== 'function') {
+      return {
+        ok: false,
+        reason: 'cljs.core or day8.re_frame2_causa.trace_bus.collect_trace_BANG_ unavailable',
+        busKeys: bus ? Object.keys(bus).sort().slice(0, 60) : [],
+      };
+    }
+    function keyword(s) {
+      const trimmed = String(s).replace(/^:/, '');
+      const parts = trimmed.split('/');
+      if (parts.length === 2) {
+        return cljs.keyword.call
+          ? cljs.keyword.call(null, parts[0], parts[1])
+          : cljs.keyword(parts[0], parts[1]);
+      }
+      return cljs.keyword.call
+        ? cljs.keyword.call(null, trimmed)
+        : cljs.keyword(trimmed);
+    }
+    const now = Date.now();
+    for (let i = 0; i < eventCount; i += 1) {
+      const dispatchId = 500000 + i;
+      const tags = cljs.hash_map(
+        keyword(':frame'), keyword(':rf/default'),
+        keyword(':event-id'), keyword(':causa.synthetic/load'),
+        keyword(':event'), cljs.PersistentVector.fromArray([keyword(':causa.synthetic/load'), i], true),
+        keyword(':dispatch-id'), dispatchId,
+        keyword(':origin'), keyword(':app'),
+        keyword(':source'), keyword(':synthetic'),
+      );
+      const ev = cljs.hash_map(
+        keyword(':id'), dispatchId,
+        keyword(':time'), now + i,
+        keyword(':operation'), keyword(':event/dispatched'),
+        keyword(':op-type'), keyword(':info'),
+        keyword(':source'), keyword(':synthetic'),
+        keyword(':tags'), tags,
+      );
+      bus.collect_trace_BANG_(ev);
+    }
+    return {
+      ok: true,
+      pushed: eventCount,
+      depth: typeof bus.current_depth === 'function' ? bus.current_depth() : null,
+      buffered: typeof bus.buffer === 'function' ? cljs.count(bus.buffer()) : null,
+    };
+  }, count);
+  if (!result.ok) {
+    failWithDetails('Could not push synthetic Causa trace events', result);
+  }
+  return result;
+}
+
 async function readLaunchModeProjection(page) {
   return page.evaluate(() => {
     const cljs = window.cljs && window.cljs.core;
@@ -1211,31 +1285,100 @@ async function runAppDbPrivacyLarge(page) {
   await expectVisible(page.locator('[data-testid="rf-causa-app-db-diff"]'), 5000);
 }
 
-async function runSensitiveDispatcher(page) {
+async function runSensitiveDispatcher(page, state) {
   await openCausa(page);
   await clearTrace(page);
-  await clickTestId(page, 'sign-in-plain');
-  await clickTestId(page, 'sign-in-redacted');
-  await expectTextEquals(page.locator('[data-testid="plain-count"]'), '1', 5000);
-  await expectTextEquals(page.locator('[data-testid="redacted-count"]'), '1', 5000);
+  const start = Date.now();
+  for (let i = 0; i < 20; i += 1) {
+    if (i % 5 === 4) {
+      await clickTestId(page, 'sign-in-throw');
+    } else {
+      await clickTestId(page, i % 2 === 0 ? 'sign-in-plain' : 'sign-in-redacted');
+    }
+  }
+  await expectTextEquals(page.locator('[data-testid="plain-count"]'), '8', 5000);
+  await expectTextEquals(page.locator('[data-testid="redacted-count"]'), '8', 5000);
+  await expectTextEquals(page.locator('[data-testid="throw-count"]'), '0', 5000);
   await expectVisible(page.locator('[data-testid="rf-causa-redacted-indicator"]'), 5000);
+  const indicatorText = ((await page.locator('[data-testid="rf-causa-redacted-indicator"]').textContent()) || '').trim();
+  const indicatorCount = Number((/REDACTED\s+(\d+)/.exec(indicatorText) || [])[1]);
+  if (!Number.isFinite(indicatorCount) || indicatorCount < 20) {
+    failWithDetails('Sensitive 20-dispatch load did not increment the redaction indicator enough', {
+      indicatorText,
+      indicatorCount,
+      expectedAtLeast: 20,
+    });
+  }
   const bodyText = await page.locator('body').textContent();
   if ((bodyText || '').includes('shhh-this-is-secret')) {
     throw new Error('Raw sensitive password leaked into DOM.');
   }
+  const traceEvents = await readTrace(page);
+  const sensitiveErrors = traceEvents.filter((event) =>
+    event.includes('sensitive-dispatcher / sign-in-throw'));
+  if (sensitiveErrors.length > 0 &&
+      !sensitiveErrors.every((event) => event.includes(':rf/redacted') && !event.includes('shhh-this-is-secret'))) {
+    failWithDetails('Sensitive error traces were not redacted', {
+      sensitiveErrors,
+    });
+  }
+  await clickSidebar(page, 'trace', 'rf-causa-trace');
+  await expectVisible(page.locator('[data-testid="rf-causa-trace-feed"]'), 5000);
+  state.loadStats = {
+    eventCountBefore: 0,
+    eventCountAfter: traceEvents.length,
+    traceBufferDepth: traceEvents.length,
+    visibleRowCount: await page.locator('[data-testid^="rf-causa-trace-row-"]').count(),
+    renderDurationMs: Date.now() - start,
+    sensitiveDispatchCount: 20,
+    redactionIndicatorCount: indicatorCount,
+  };
 }
 
-async function runLargeDispatcher(page) {
+async function runLargeDispatcher(page, state) {
   await openCausa(page);
   await clearTrace(page);
-  for (const id of ['write-auto', 'write-declared', 'write-fx-declared', 'write-schema']) {
-    await clickTestId(page, id);
+  const ids = ['write-declared', 'write-fx-declared', 'write-schema'];
+  const start = Date.now();
+  for (let i = 0; i < 19; i += 1) {
+    await clickTestId(page, ids[i % ids.length]);
   }
-  await expectTextEquals(page.locator('[data-testid="auto-count"]'), '1', 5000);
-  await expectTextEquals(page.locator('[data-testid="declared-count"]'), '1', 5000);
-  await expectTextEquals(page.locator('[data-testid="fx-count"]'), '1', 5000);
-  await expectTextEquals(page.locator('[data-testid="schema-count"]'), '1', 5000);
+  await clickTestId(page, 'write-auto');
+  for (const [testId, expected] of [
+    ['auto-count', '1'],
+    ['declared-count', '7'],
+    ['fx-count', '6'],
+    ['schema-count', '6'],
+  ]) {
+    await expectTextEquals(page.locator(`[data-testid="${testId}"]`), expected, 5000);
+  }
   await expectVisible(page.locator('[data-testid="elision-decls"]'), 5000);
+  const traceEvents = await readTrace(page);
+  await clickSidebar(page, 'app-db', 'rf-causa-app-db-diff');
+  await expectVisible(page.locator('[data-testid="rf-causa-app-db-diff"]'), 5000);
+  const appDbText = ((await page.locator('[data-testid="rf-causa-app-db-diff"]').textContent()) || '').trim();
+  if (!appDbText.includes(':rf.size/large-elided')) {
+    failWithDetails('Large-value 20-dispatch load did not surface elision markers in App-DB Diff', {
+      traceCount: traceEvents.length,
+      tail: traceEvents.slice(-20),
+      appDbText: appDbText.slice(0, 1200),
+    });
+  }
+  if (appDbText.includes('XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')) {
+    failWithDetails('Large raw payload leaked into App-DB Diff text', {
+      traceCount: traceEvents.length,
+      appDbText: appDbText.slice(0, 1200),
+    });
+  }
+  state.loadStats = {
+    eventCountBefore: 0,
+    eventCountAfter: traceEvents.length,
+    traceBufferDepth: traceEvents.length,
+    visibleRowCount: await page.locator('[data-testid^="rf-causa-app-db-diff-slice-"]').count(),
+    renderDurationMs: Date.now() - start,
+    largeDispatchCount: 20,
+    elisionMarkerVisible: true,
+  };
 }
 
 async function runHydration(page) {
@@ -1275,6 +1418,59 @@ async function runTwentyEventLoad(page, state) {
     visibleRows: after.rendered,
     traceBufferDepth: after.total,
     elapsedMs,
+  };
+}
+
+async function runTraceBudgetSaturation(page, state) {
+  await expectTextEquals(page.locator('span').first(), '5', 10000);
+  await openCausa(page);
+  await clickSidebar(page, 'trace', 'rf-causa-trace');
+  await clearTrace(page);
+  const start = Date.now();
+  const pushed = await pushSyntheticTraceEvents(page, 1000);
+  const saturated = await waitForValue(
+    () => readTraceCounts(page),
+    (counts) => counts.total === 1000,
+    { timeoutMs: 10000, description: 'trace buffer saturation at 1000 rows' },
+  );
+  const saturatedDom = await waitForValue(
+    () => readTraceDomBudget(page),
+    (budget) => budget.rowCount === 200 && budget.overflowPresent,
+    { timeoutMs: 10000, description: 'trace DOM row budget at 200 with overflow indicator' },
+  );
+  if (saturatedDom.rowCount > 200) {
+    failWithDetails('Trace panel exceeded its 200-row DOM budget under saturation', {
+      pushed,
+      counts: saturated,
+      dom: saturatedDom,
+    });
+  }
+
+  for (let i = 0; i < 20; i += 1) {
+    await clickHostButtonByLabel(page, i % 2 === 0 ? '+' : '-');
+  }
+  const after = await waitForValue(
+    async () => ({
+      counts: await readTraceCounts(page),
+      dom: await readTraceDomBudget(page),
+      events: await readTrace(page),
+    }),
+    (snapshot) =>
+      snapshot.counts.total === 1000 &&
+      snapshot.dom.rowCount <= 200 &&
+      snapshot.events.some((event) => event.includes(':counter/inc')) &&
+      snapshot.events.some((event) => event.includes(':counter/dec')),
+    { timeoutMs: 10000, description: 'trace budget still capped after 20 host dispatches' },
+  );
+  state.loadStats = {
+    eventCountBefore: saturated.total,
+    eventCountAfter: after.counts.total,
+    traceBufferDepth: after.counts.total,
+    visibleRowCount: after.dom.rowCount,
+    renderDurationMs: Date.now() - start,
+    bufferEvictionCount: Math.max(0, saturated.total + 20 - after.counts.total),
+    overflowText: after.dom.overflowText,
+    syntheticEventsPushed: pushed.pushed,
   };
 }
 
@@ -1531,16 +1727,18 @@ const SCENARIOS = [
     run: runAppDbPrivacyLarge,
   },
   {
-    name: 'sensitive redaction substrate',
+    name: '20-event sensitive redaction load',
     url: '/testbeds/sensitive-dispatcher/',
     panels: ['trace'],
+    load: true,
     coveredRows: ['Redaction, Sensitive, and Large Values', 'Trace'],
     run: runSensitiveDispatcher,
   },
   {
-    name: 'large value elision substrate',
+    name: '20-event large value elision load',
     url: '/testbeds/large-dispatcher/',
-    panels: ['trace'],
+    panels: ['trace', 'app-db'],
+    load: true,
     coveredRows: ['Redaction, Sensitive, and Large Values', 'App-DB Diff'],
     run: runLargeDispatcher,
   },
@@ -1566,6 +1764,18 @@ const SCENARIOS = [
       'Shell, Keybinding, Config, Preload, Settings, and Production Elision',
     ],
     run: runTwentyEventLoad,
+  },
+  {
+    name: '1000-event trace row-budget plus 20-dispatch re-check',
+    url: '/counter/',
+    panels: ['trace'],
+    load: true,
+    coveredRows: [
+      'Trace',
+      'Performance',
+      'Shell, Keybinding, Config, Preload, Settings, and Production Elision',
+    ],
+    run: runTraceBudgetSaturation,
   },
   {
     name: '20-event launch-mode shared runtime re-check',


### PR DESCRIPTION
## Summary
- Expand the Causa feature matrix gate with 20-dispatch sensitive redaction and large-value elision load scenarios.
- Add a 1000-event Trace saturation scenario that verifies the 200-row DOM budget and then drives 20 more host dispatches.
- Fix Causa-local issues exposed by the new load coverage: App-DB Diff now renders large string leaves as `:rf.size/large-elided` markers, and Trace rows include a projected display index in their React key to avoid duplicate-key row leakage under saturation.

## Verification
- `node --check tools/causa/testbeds/feature_matrix/scenarios.cjs`
- `npm run test:causa-feature-gate` in `implementation` — passed: 16 Causa feature scenarios, 0 failures, 21 matrix rows.
- `npm run test:cljs` in `implementation` — passed: 2071 tests, 5935 assertions, 0 failures, 0 errors. Existing warning: `:redef-in-file` in `hot_reload_cljs_test.cljs`.
- `git diff --check` — passed; Windows line-ending conversion warnings only.

## Notes
- No shared browser harness files were changed; this should not conflict with PR #1223's harness cleanup.
- PR #1222 (`rf2-eehov`) is still open; this PR does not reimplement true-inline launch behavior and should remain rebaseable after #1222 lands.
- `bd dolt push` was attempted per protocol, but this worktree has no Dolt remote configured.