### PR TITLE
Story: add global command palette

### DIFF
--- a/tools/story/src/re_frame/story/ui/command_palette.cljc
+++ b/tools/story/src/re_frame/story/ui/command_palette.cljc
@@ -1,0 +1,146 @@
+(ns re-frame.story.ui.command-palette
+  "Pure helpers for Story's global command palette."
+  (:require [clojure.string :as str]
+            [re-frame.story.predicates :as pred]))
+
+(def searchable-kinds
+  [:story :variant :workspace :mode :decorator])
+
+(def kind-labels
+  {:story     "Story"
+   :variant   "Variant"
+   :workspace "Workspace"
+   :mode      "Mode"
+   :decorator "Decorator"})
+
+(defn- doc-text [body]
+  (let [doc (:doc body)]
+    (cond
+      (string? doc) doc
+      (some? doc)   (pr-str doc)
+      :else         "")))
+
+(defn- id-text [id]
+  (if (keyword? id)
+    (str id)
+    (pr-str id)))
+
+(defn- entry-search-text [{:keys [kind id body]}]
+  (str/lower-case
+    (str (name kind) " " (id-text id) " " (doc-text body))))
+
+(defn- variants-for-story [variants story-id]
+  (->> variants
+       keys
+       (filter #(= story-id (pred/parent-story-id %)))
+       sort
+       vec))
+
+(defn entries
+  "Build palette entries from a `state/registry-snapshot` map.
+
+  Stories include their child variants so the impure selector can jump
+  to the first concrete variant when a story row is chosen."
+  [snapshot]
+  (let [variants (:variants snapshot)]
+    (->> searchable-kinds
+         (mapcat
+           (fn [kind]
+             (let [slot (case kind
+                          :story     :stories
+                          :variant   :variants
+                          :workspace :workspaces
+                          :mode      :modes
+                          :decorator :decorators)]
+               (map (fn [[id body]]
+                      (cond-> {:kind        kind
+                               :kind-label  (get kind-labels kind (name kind))
+                               :id          id
+                               :id-label    (id-text id)
+                               :doc         (doc-text body)
+                               :body        body}
+                        (= kind :story)
+                        (assoc :variant-ids (variants-for-story variants id))))
+                    (sort-by (comp str first) (get snapshot slot {}))))))
+         vec)))
+
+(defn normalize-query [query]
+  (-> (or query "")
+      str/lower-case
+      str/trim))
+
+(defn- subsequence?
+  "True when every char in `needle` appears in order in `haystack`."
+  [needle haystack]
+  (loop [remaining (seq needle)
+         chars     (seq haystack)]
+    (cond
+      (nil? remaining) true
+      (nil? chars)     false
+      (= (first remaining) (first chars))
+      (recur (next remaining) (next chars))
+      :else
+      (recur remaining (next chars)))))
+
+(defn- token-score [entry token]
+  (let [id    (str/lower-case (:id-label entry))
+        kind  (name (:kind entry))
+        doc   (str/lower-case (:doc entry))
+        text  (entry-search-text entry)]
+    (cond
+      (str/blank? token) 0
+      (= token id)      240
+      (= token kind)    180
+      (str/starts-with? id token) 140
+      (str/includes? id token) 110
+      (str/includes? doc token) 80
+      (str/includes? text token) 60
+      (subsequence? token id) 32
+      (subsequence? token text) 18
+      :else nil)))
+
+(defn match-score
+  "Return a positive score when `entry` matches `query`, otherwise nil.
+  Matching is token-AND; each token may be a substring or fuzzy
+  subsequence across kind/id/doc text."
+  [entry query]
+  (let [q      (normalize-query query)
+        tokens (remove str/blank? (str/split q #"\s+"))]
+    (if (empty? tokens)
+      1
+      (let [scores (map #(token-score entry %) tokens)]
+        (when (every? some? scores)
+          (+ (reduce + scores)
+             (case (:kind entry)
+               :variant   8
+               :workspace 7
+               :story     6
+               :mode      5
+               :decorator 4
+               0)))))))
+
+(defn search
+  "Return matching entries sorted by descending score, then stable kind/id."
+  ([entries query]
+   (search entries query 20))
+  ([entries query limit]
+   (->> entries
+        (keep (fn [entry]
+                (when-let [score (match-score entry query)]
+                  (assoc entry :score score))))
+        (sort-by (fn [entry]
+                   [(- (:score entry))
+                    (.indexOf searchable-kinds (:kind entry))
+                    (:id-label entry)]))
+        (take limit)
+        vec)))
+
+(defn clamp-active-index [index result-count]
+  (cond
+    (not (pos? result-count)) 0
+    (< index 0)               (dec result-count)
+    (>= index result-count)   0
+    :else                     index))
+
+(defn move-active-index [index delta result-count]
+  (clamp-active-index (+ (or index 0) delta) result-count))

--- a/tools/story/src/re_frame/story/ui/command_palette/view.cljs
+++ b/tools/story/src/re_frame/story/ui/command_palette/view.cljs
@@ -1,0 +1,243 @@
+(ns re-frame.story.ui.command-palette.view
+  "Global Cmd-K / Ctrl-K command palette for the Story shell."
+  (:require [clojure.string :as str]
+            [reagent.core :as r]
+            [re-frame.story.config :as config]
+            [re-frame.story.ui.command-palette :as palette]
+            [re-frame.story.ui.state :as state]
+            [re-frame.story.ui.toolbar :as toolbar]))
+
+(defn shortcut-event?
+  "True when `event` is Story's global command-palette shortcut."
+  [event]
+  (and (= "keydown" (.-type event))
+       (= "k" (str/lower-case (or (.-key event) "")))
+       (or (.-metaKey event) (.-ctrlKey event))
+       (not (.-altKey event))
+       (not (.-shiftKey event))))
+
+(defn- focus-input! [input]
+  (when-let [node @input]
+    (.setTimeout js/window #(.focus node) 0)))
+
+(defn select-entry!
+  "Apply a palette entry to shell state, then return true when handled.
+
+  Variants and workspaces are navigable. Stories jump to their first
+  registered child variant when one exists. Modes reuse the toolbar
+  toggle so persistence stays in one place. Decorators are registry
+  data only in the MVP, so selecting them simply closes the palette."
+  [entry]
+  (case (:kind entry)
+    :variant
+    (do
+      (state/swap-state!
+        (fn [s]
+          (-> s
+              (state/select-variant (:id entry))
+              (state/select-workspace nil))))
+      true)
+
+    :workspace
+    (do
+      (state/swap-state!
+        (fn [s]
+          (-> s
+              (state/select-workspace (:id entry))
+              (state/select-variant nil))))
+      true)
+
+    :story
+    (when-let [variant-id (first (:variant-ids entry))]
+      (state/swap-state!
+        (fn [s]
+          (-> s
+              (state/select-variant variant-id)
+              (state/select-workspace nil))))
+      true)
+
+    :mode
+    (do
+      (toolbar/toggle-mode! (:id entry))
+      true)
+
+    :decorator
+    true
+
+    true))
+
+(def ^:private styles
+  {:scrim       {:position "fixed"
+                 :inset "0"
+                 :z-index 100000
+                 :background "rgba(0, 0, 0, 0.42)"
+                 :display "flex"
+                 :justify-content "center"
+                 :align-items "flex-start"
+                 :padding-top "12vh"}
+   :panel       {:width "min(680px, calc(100vw - 32px))"
+                 :max-height "68vh"
+                 :background "#1f1f23"
+                 :border "1px solid #4a4a52"
+                 :border-radius "12px"
+                 :box-shadow "0 24px 80px rgba(0, 0, 0, 0.5)"
+                 :overflow "hidden"
+                 :font-family "ui-monospace, SFMono-Regular, Consolas, monospace"
+                 :color "#f2f2f2"}
+   :input-wrap  {:border-bottom "1px solid #3b3b42"
+                 :padding "12px"}
+   :input       {:width "100%"
+                 :box-sizing "border-box"
+                 :background "#2b2b31"
+                 :border "1px solid #55555f"
+                 :border-radius "8px"
+                 :color "#ffffff"
+                 :font-size "15px"
+                 :outline "none"
+                 :padding "10px 12px"}
+   :list        {:max-height "calc(68vh - 64px)"
+                 :overflow-y "auto"
+                 :padding "6px"}
+   :row         {:display "grid"
+                 :grid-template-columns "92px 1fr"
+                 :gap "12px"
+                 :padding "9px 10px"
+                 :border-radius "8px"
+                 :cursor "pointer"}
+   :row-active  {:background "#3a3a43"}
+   :kind        {:font-size "11px"
+                 :text-transform "uppercase"
+                 :letter-spacing "0.08em"
+                 :color "#aeb4c0"
+                 :padding-top "2px"}
+   :id          {:font-size "13px"
+                 :color "#ffffff"}
+   :doc         {:font-size "12px"
+                 :color "#b8b8c0"
+                 :line-height "1.35"
+                 :margin-top "2px"
+                 :white-space "nowrap"
+                 :overflow "hidden"
+                 :text-overflow "ellipsis"}
+   :empty       {:padding "24px"
+                 :text-align "center"
+                 :color "#9a9aa3"
+                 :font-size "13px"}})
+
+(defn- result-row [entry active? on-hover on-select]
+  ^{:key [(:kind entry) (:id entry)]}
+  [:div {:style         (merge (:row styles) (when active? (:row-active styles)))
+         :role          "option"
+         :aria-selected (str (boolean active?))
+         :data-test     "story-command-palette-result"
+         :data-kind     (name (:kind entry))
+         :data-id       (:id-label entry)
+         :on-mouse-enter on-hover
+         :on-click      on-select}
+   [:div {:style (:kind styles)} (:kind-label entry)]
+   [:div
+    [:div {:style (:id styles)} (:id-label entry)]
+    (when (seq (:doc entry))
+      [:div {:style (:doc styles)} (:doc entry)])]])
+
+(defn command-palette-host
+  "Install the global shortcut and render the floating palette overlay."
+  []
+      (let [open?        (r/atom false)
+        query        (r/atom "")
+        active-index (r/atom 0)
+        input        (atom nil)
+        listener     (atom nil)
+        close!       (fn []
+                       (reset! open? false)
+                       (reset! query "")
+                       (reset! active-index 0))
+        open!        (fn []
+                       (reset! open? true)
+                       (reset! active-index 0)
+                       (focus-input! input))]
+    (r/create-class
+      {:display-name "rf-story-command-palette"
+       :component-did-mount
+       (fn [_]
+         (when config/enabled?
+           (let [f (fn [event]
+                     (cond
+                       (shortcut-event? event)
+                       (do
+                         (.preventDefault event)
+                         (if @open? (close!) (open!)))
+
+                       (and @open? (= "Escape" (.-key event)))
+                       (do
+                         (.preventDefault event)
+                         (close!))))]
+             (reset! listener f)
+             (.addEventListener js/window "keydown" f true))))
+       :component-will-unmount
+       (fn [_]
+         (when-let [f @listener]
+           (.removeEventListener js/window "keydown" f true)
+           (reset! listener nil)))
+       :reagent-render
+       (fn []
+         (when @open?
+           (let [results (palette/search
+                           (palette/entries (state/registry-snapshot))
+                           @query
+                           30)
+                 count   (count results)
+                 active  (palette/clamp-active-index @active-index count)]
+             (when (not= active @active-index)
+               (reset! active-index active))
+             [:div {:style     (:scrim styles)
+                    :data-test "story-command-palette"
+                    :on-click  (fn [_] (close!))}
+              [:div {:style    (:panel styles)
+                     :role     "dialog"
+                     :aria-modal "true"
+                     :aria-label "Story command palette"
+                     :on-click (fn [event] (.stopPropagation event))}
+               [:div {:style (:input-wrap styles)}
+                [:input {:ref          #(reset! input %)
+                         :style        (:input styles)
+                         :value        @query
+                         :placeholder  "Search stories, variants, workspaces, modes, decorators..."
+                         :data-test    "story-command-palette-input"
+                         :on-change    (fn [event]
+                                         (reset! query (.. event -target -value))
+                                         (reset! active-index 0))
+                         :on-key-down  (fn [event]
+                                         (case (.-key event)
+                                           "ArrowDown"
+                                           (do (.preventDefault event)
+                                               (swap! active-index
+                                                      palette/move-active-index 1 count))
+                                           "ArrowUp"
+                                           (do (.preventDefault event)
+                                               (swap! active-index
+                                                      palette/move-active-index -1 count))
+                                           "Enter"
+                                           (do (.preventDefault event)
+                                               (when-let [entry (get results active)]
+                                                 (select-entry! entry)
+                                                 (close!)))
+                                           "Escape"
+                                           (do (.preventDefault event)
+                                               (close!))
+                                           nil))}]]
+               [:div {:style (:list styles)
+                      :role  "listbox"}
+                (if (seq results)
+                  (doall
+                    (map-indexed
+                      (fn [idx entry]
+                        (result-row entry
+                                    (= idx active)
+                                    #(reset! active-index idx)
+                                    #(do (select-entry! entry)
+                                         (close!))))
+                      results))
+                  [:div {:style (:empty styles)
+                         :data-test "story-command-palette-empty"}
+                   "No matching registry entries."])]]])))})))

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -47,6 +47,7 @@
             [re-frame.trace :as rf-trace]
             [re-frame.story.ui.actions :as actions]
             [re-frame.story.ui.canvas :as canvas]
+            [re-frame.story.ui.command-palette.view :as command-palette]
             [re-frame.story.ui.controls :as controls]
             [re-frame.story.ui.docs :as docs]
             [re-frame.story.ui.help :as help]
@@ -573,7 +574,8 @@
           ;; alongside the recorder's save dialog — both float above the
           ;; three-pane layout via fixed positioning; both surface the
           ;; generated EDN snippet for review-then-commit.
-          [save-variant-ui/save-dialog]]))}))
+          [save-variant-ui/save-dialog]
+          [command-palette/command-palette-host]]))}))
 
 ;; ---- mount / unmount surface ---------------------------------------------
 

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -22,6 +22,8 @@
             [re-frame.story :as story]
             [re-frame.story.registrar :as story-registrar]
             [re-frame.story.ui.canvas :as canvas]
+            [re-frame.story.ui.command-palette :as command-palette]
+            [re-frame.story.ui.command-palette.view :as command-palette-view]
             [re-frame.story.ui.docs :as docs]
             [re-frame.story.ui.state :as state]
             [re-frame.story.ui.controls :as controls]
@@ -87,6 +89,51 @@
     (state/swap-state! state/clear-cell-overrides :story.x/y)
     (is (nil? (get-in (state/get-state)
                       [:cell-overrides :story.x/y])))))
+
+;; ---- command palette -----------------------------------------------------
+
+(deftest command-palette-shortcut-detection
+  (testing "Cmd-K and Ctrl-K open the global palette"
+    (is (command-palette-view/shortcut-event?
+          #js {:type "keydown" :key "k" :metaKey true}))
+    (is (command-palette-view/shortcut-event?
+          #js {:type "keydown" :key "K" :ctrlKey true})))
+  (testing "modified or unrelated keydowns do not open it"
+    (is (not (command-palette-view/shortcut-event?
+               #js {:type "keydown" :key "k" :ctrlKey true :shiftKey true})))
+    (is (not (command-palette-view/shortcut-event?
+               #js {:type "keyup" :key "k" :ctrlKey true})))))
+
+(deftest command-palette-selection-side-effects
+  (testing "variant selection focuses a variant and clears workspace"
+    (state/swap-state! state/select-workspace :Workspace.cp/all)
+    (command-palette-view/select-entry! {:kind :variant :id :story.cp/empty})
+    (is (= :story.cp/empty (:selected-variant (state/get-state))))
+    (is (nil? (:selected-workspace (state/get-state)))))
+  (testing "workspace selection focuses a workspace and clears variant"
+    (state/swap-state! state/select-variant :story.cp/empty)
+    (command-palette-view/select-entry! {:kind :workspace :id :Workspace.cp/all})
+    (is (= :Workspace.cp/all (:selected-workspace (state/get-state))))
+    (is (nil? (:selected-variant (state/get-state)))))
+  (testing "story selection jumps to the first registered child variant"
+    (command-palette-view/select-entry!
+      {:kind :story :id :story.cp :variant-ids [:story.cp/a :story.cp/b]})
+    (is (= :story.cp/a (:selected-variant (state/get-state)))))
+  (testing "mode selection toggles the active mode"
+    (command-palette-view/select-entry! {:kind :mode :id :Mode.cp/dark})
+    (is (= [:Mode.cp/dark] (:active-modes (state/get-state))))))
+
+(deftest command-palette-search-roundtrip
+  (testing "CLJS search path mirrors the JVM helper"
+    (let [results (command-palette/search
+                    (command-palette/entries
+                      {:stories    {:story.cljs.cp {:doc "Shell docs"}}
+                       :variants   {:story.cljs.cp/happy {:doc "Happy path"}}
+                       :workspaces {}
+                       :modes      {}
+                       :decorators {}})
+                    "happy")]
+      (is (= :story.cljs.cp/happy (:id (first results)))))))
 
 ;; ---- pure filter + grouping ---------------------------------------------
 

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -22,6 +22,7 @@
             [re-frame.story.config    :as config]
             [re-frame.story.loaders   :as loaders]
             [re-frame.story.registrar :as story-registrar]
+            [re-frame.story.ui.command-palette :as command-palette]
             [re-frame.story.ui.docs   :as docs]
             [re-frame.story.ui.state  :as state]
             [re-frame.story.ui.test-mode.pure :as test-mode]
@@ -122,6 +123,57 @@
     (let [s  state/default-shell-state
           s1 (state/toggle-panel s :trace)]
       (is (= false (get-in s1 [:panel-visibility :trace]))))))
+
+;; ---- command palette -----------------------------------------------------
+
+(deftest command-palette-builds-search-corpus
+  (testing "entries enumerate stories, variants, workspaces, modes, and decorators"
+    (let [snapshot {:stories    {:story.cp {:doc "Counter parent"}}
+                    :variants   {:story.cp/empty {:doc "Fresh counter"}
+                                 :story.cp/full  {:doc "Loaded counter"}}
+                    :workspaces {:Workspace.cp/all {:doc "All states"}}
+                    :modes      {:Mode.cp/dark {:doc "Dark theme"}}
+                    :decorators {:cp/outline {:doc "Outline wrapper"}}}
+          entries  (command-palette/entries snapshot)
+          by-kind  (frequencies (map :kind entries))
+          story    (first (filter #(= [:story :story.cp]
+                                      [(:kind %) (:id %)])
+                                  entries))]
+      (is (= 1 (:story by-kind)))
+      (is (= 2 (:variant by-kind)))
+      (is (= 1 (:workspace by-kind)))
+      (is (= 1 (:mode by-kind)))
+      (is (= 1 (:decorator by-kind)))
+      (is (= [:story.cp/empty :story.cp/full] (:variant-ids story))))))
+
+(deftest command-palette-search-matches-id-doc-and-kind
+  (let [entries (command-palette/entries
+                  {:stories    {:story.checkout {:doc "Payment flow"}}
+                   :variants   {:story.checkout/error {:doc "Declined card state"}}
+                   :workspaces {:Workspace.checkout/grid {:doc "All payment states"}}
+                   :modes      {:Mode.theme/dark {:doc "Night palette"}}
+                   :decorators {:checkout/auth {:doc "Authenticated shell"}}})]
+    (testing "id substring matches rank exact surface hits"
+      (is (= :story.checkout/error
+             (:id (first (command-palette/search entries "checkout error"))))))
+    (testing "doc text is searchable"
+      (is (= :story.checkout/error
+             (:id (first (command-palette/search entries "declined"))))))
+    (testing "kind participates in search"
+      (is (= :Workspace.checkout/grid
+             (:id (first (command-palette/search entries "workspace payment"))))))
+    (testing "fuzzy subsequence catches compact user input"
+      (is (= :Mode.theme/dark
+             (:id (first (command-palette/search entries "mthdrk"))))))
+    (testing "unmatched query returns no rows"
+      (is (empty? (command-palette/search entries "no such thing"))))))
+
+(deftest command-palette-active-index-wraps
+  (testing "arrow navigation wraps both directions"
+    (is (= 1 (command-palette/move-active-index 0 1 3)))
+    (is (= 0 (command-palette/move-active-index 2 1 3)))
+    (is (= 2 (command-palette/move-active-index 0 -1 3)))
+    (is (= 0 (command-palette/move-active-index 0 1 0)))))
 
 ;; ---- mode-tabs (rf2-9hc8) ------------------------------------------------
 

--- a/tools/story/test/story_feature_load.cjs
+++ b/tools/story/test/story_feature_load.cjs
@@ -40,6 +40,7 @@ const MATRIX_FEATURES = [
   'Async/fx failure',
   'Render shell mount/unmount',
   'Sidebar navigation',
+  'Command palette',
   'Mode tabs',
   'Docs mode',
   'Test mode pane',
@@ -728,6 +729,31 @@ async function assertHealthyLoaded(page) {
   );
 }
 
+async function assertCommandPalette(page) {
+  await ensureCounterLoaded(page);
+
+  await page.keyboard.press('Control+K');
+  await expectVisible(page.locator('[data-test="story-command-palette"]'), 5000);
+  await page.locator('[data-test="story-command-palette-input"]').fill('clicked three');
+  await page.keyboard.press('Enter');
+  await waitForCanvasVariant(page, ':story.counter/clicked-three-times');
+
+  await page.keyboard.press('Control+K');
+  await page.locator('[data-test="story-command-palette-input"]').fill('auto grid');
+  await page.locator('[data-test="story-command-palette-result"][data-id=":Workspace.counter/auto-grid"]').click();
+  await assertMainContains(page, 'variants-grid', 10000);
+
+  await page.keyboard.press('Control+K');
+  await page.locator('[data-test="story-command-palette-input"]').fill('sepia');
+  await page.locator('[data-test="story-command-palette-result"][data-id=":Mode.app/sepia"]').click();
+  await waitForValue(
+    () => page.locator('[data-toolbar-mode=":Mode.app/sepia"]').getAttribute('aria-pressed'),
+    (value) => value === 'true',
+    { timeoutMs: 5000, description: 'sepia mode selected through command palette' },
+  );
+  await resetToolbarModes(page);
+}
+
 async function assertWorkspaceLayouts(page) {
   await gotoStoryShell(page, '/counter-with-stories/#/stories');
   for (const [workspace, marker] of [
@@ -1078,6 +1104,7 @@ const FEATURE_CHECKS = {
     await gotoStoryShell(page, '/counter-with-stories/#/stories');
   },
   'Sidebar navigation': assertHealthyLoaded,
+  'Command palette': assertCommandPalette,
   'Mode tabs': async (page) => {
     await ensureCounterLoaded(page);
     await setMode(page, 'docs');


### PR DESCRIPTION
## Summary

Implements bead `rf2-n8dtz`: a global Cmd-K / Ctrl-K command palette for Story.

- Adds pure command-palette helpers for registry corpus construction, fuzzy-ish matching, scoring, and active-index wrapping.
- Adds a floating Story shell overlay with global shortcut, query input, arrow-key navigation, Enter selection, Escape/backdrop close, and selection wiring for variants, workspaces, stories, modes, and decorators.
- Adds JVM, CLJS, and Story feature-load coverage for matching, shortcut/selection behavior, and browser interaction.

## Validation

- `cd tools/story; clojure -M:test` — 425 tests, 1325 assertions, 0 failures, 0 errors. Existing failure-path tests print expected exception traces.
- `cd implementation; npm install` — installed existing dev dependencies locally for validation.
- `cd implementation; npm run test:cljs` — 2074 tests, 5946 assertions, 0 failures, 0 errors. One existing `:redef-in-file` warning in `hot_reload_cljs_test.cljs`.
- `cd implementation; npm run test:story-feature-load` — 2 Story feature-load specs, 0 failures. Harness prints existing post-run `http-server exited unexpectedly (code=1, signal=null)` while returning success.