### PR TITLE
spec(story): document Story-Causa coexistence convention (rf2-skp3n)

### DIFF
--- a/tools/story/spec/002-Runtime.md
+++ b/tools/story/spec/002-Runtime.md
@@ -23,6 +23,57 @@ At variant-unmount the runtime calls `(rf/destroy-frame! variant-id)`.
 Hot-reload preserves the side-table; a re-registration of the same
 variant calls `reset-frame!` and re-runs the lifecycle.
 
+## Coexistence with hosting application state
+
+Story installs runtime slots into every variant frame's `app-db` under
+the reserved `:rf.story/*` namespace (per
+[spec/Conventions.md](../../../spec/Conventions.md) reserved-namespace
+rules). The slots Stage 3 installs today:
+
+- `:rf.story/lifecycle` — discrete state of the variant's four-phase
+  lifecycle machine (mirrored by `loaders.cljc` after each transition).
+- `:rf.story/loaders-complete?` — boolean signal read by the
+  `:loaders-complete-when` predicate path.
+- `:rf.story/assertions` — vector of assertion records appended by the
+  `:rf.assert/*` handlers during phase 4.
+
+These slots are not optional. The lifecycle machine, the loader-
+completion predicate, and the play-phase assertion bus all read them
+back during the four-phase run; clearing any of them mid-lifecycle
+corrupts the variant.
+
+**Rule.** A host application's `reg-event-db` handlers — and any
+other code path that writes `app-db` — MUST preserve the `:rf.story/*`
+namespace when seeding or resetting `db`. The hazard is the
+"replace-the-whole-db" idiom:
+
+```clojure
+;; WRONG — wipes :rf.story/lifecycle, :rf.story/loaders-complete?,
+;; :rf.story/assertions, and any future :rf.story/* slot. Safe in a
+;; standalone app; corrupts every Story variant that runs this event.
+(rf/reg-event-db :app/initialise
+  (fn [_db _event]
+    {:app/items [] :app/discount nil}))
+
+;; RIGHT — preserves all reserved slots Story (or any other framework
+;; tool) installs into the frame's app-db.
+(rf/reg-event-db :app/initialise
+  (fn [db _event]
+    (assoc db :app/items [] :app/discount nil)))
+```
+
+Equivalently, `(merge db {:app/items [] :app/discount nil})` is fine;
+the rule is "thread `db` through, do not throw it away". Domain-key
+clearing is the host's business; the reserved `:rf.story/*` namespace
+is Story's.
+
+The originating evidence is commit `c2accadf` (rf2-2uwp1, cart-total
+Story slice): `:cart/initialise` was a whole-`db` replacement and wiped
+the variant frame's lifecycle slots the moment the variant ran the
+event. The fix swapped `(fn [_db _event] {...})` for
+`(fn [db _event] (assoc db ...))`. Host apps integrating Story SHOULD
+audit their init/reset events for the same anti-pattern.
+
 ## Args resolution precedence
 
 When the rendering layer asks "what args is this variant rendered


### PR DESCRIPTION
## Summary

- Adds a normative §"Coexistence with hosting application state" to `tools/story/spec/002-Runtime.md` covering the three reserved `:rf.story/*` app-db slots Story installs into every variant frame (`:rf.story/lifecycle`, `:rf.story/loaders-complete?`, `:rf.story/assertions`).
- States the **MUST** rule: host `reg-event-db` handlers (and any other writers of `app-db`) must preserve the `:rf.story/*` namespace when seeding or resetting `db` — the "replace-the-whole-db" idiom (`(fn [_db _event] {...})`) corrupts every Story variant that runs the event.
- Cross-refs commit `c2accadf` (rf2-2uwp1, cart-total Story slice) as the originating evidence — `:cart/initialise` wiped the variant frame's lifecycle slots; the fix swapped `(fn [_db _event] {...})` for `(fn [db _event] (assoc db ...))`.
- ~50 added lines; no other files touched.

## Why this file

Story is the imposing party — its frame slots are what need preserving — so the convention docs sit next to the runtime that installs them. The new section follows §"Per-variant frame allocation" (where variant frame `app-db` semantics are established) and precedes §"Args resolution precedence". Cross-refs the framework-level reserved-namespace rules at `spec/Conventions.md`.

## Test plan

- [x] `python -m mkdocs build --strict` — 67 warnings before edit, 67 after; my change introduces zero new warnings. (All pre-existing warnings come from `docs/` and `release-process.md` cross-refs into the staged-spec tree; `tools/story/spec/*` is not in the mkdocs build.)
- [x] Cross-ref path verified: `../../../spec/Conventions.md` resolves correctly from `tools/story/spec/002-Runtime.md`.
- [x] Reserved-slot list cross-checked against `tools/story/src/re_frame/story/loaders.cljc`, `runtime.cljc`, `assertions.cljc` — `:rf.story/lifecycle`, `:rf.story/loaders-complete?`, `:rf.story/assertions` are the three slots actually installed.

Bead: rf2-skp3n (P2). Worktree: `C:/Users/miket/code/re-frame2-worktrees/coexistence-spec-rf2-skp3n`. Mayor closes bead on merge per protocol.