### PR TITLE
refactor(causa): remediate the 4 shipped panel splits (rf2-nb8if)

### DIFF
--- a/tools/causa/spec/Conventions.md
+++ b/tools/causa/spec/Conventions.md
@@ -1,0 +1,137 @@
+# Causa Conventions
+
+Conventions for Causa source organisation that aren't normative re-frame2
+spec but are worth pinning so panel-level work stays uniform across the
+artefact.
+
+## Panel facade + leaf split
+
+When a panel is split into focused leaves under
+`tools/causa/src/day8/re_frame2_causa/panels/`, the split MUST follow the
+shape below. Four panels (`app_db_diff`, `ai_co_pilot`, `subscriptions`,
+`mcp_server`) shipped to this convention via the rf2-nb8if remediation
+PR; `time_travel` predates it and matches by independent design.
+
+The canonical exemplar is `app_db_diff.cljs` — a small facade body, the
+panel's `reg-view` lives in the facade, leaves expose plain functions
+plus `install!`. Where the facade view body would be too large to read at
+a glance, the facade `reg-view` delegates to a plain Reagent fn from
+`<panel>-views.cljs` (as `subscriptions.cljs` does — see "View body
+delegation" below).
+
+### Required shape
+
+1. **Facade owns every public `reg-view`.** The panel's externally-named
+   `reg-view` calls live in the facade namespace, never in a leaf. The
+   facade is the one place a maintainer reads to discover which view
+   names a panel registers. (Counter-example before remediation:
+   `ai-co-pilot-views.cljs` contained three `reg-view` forms and the
+   facade re-bound them via `def view views/view`. That re-bind is now
+   gone.)
+
+2. **Leaves do not call `reg-view`.** Leaves expose plain Reagent
+   functions (e.g. `(defn header [opts] [:header ...])`), pure helpers,
+   or `install!` for sub/event registrations. A grep for `reg-view`
+   under `panels/<panel>_*.cljs[c]` outside the facade should return
+   nothing.
+
+3. **`install!` is idempotent and returns `nil`.** The facade's
+   `install!` chains its leaf `install!`s (alphabetical order is not
+   required — call order should match the panel's natural dependency
+   order: subs before events when events read sub names, etc.) and
+   explicitly returns `nil`. Returning the chain's last value (truthy
+   or falsy depending on the last `reg-*` form) is forbidden — callers
+   should not be able to depend on a result.
+
+   ```clojure
+   (defn install!
+     "Idempotent install for the <Panel>'s Causa-side registrations."
+     []
+     (subs/install!)
+     (events/install!)
+     nil)
+   ```
+
+4. **Re-exports are minimal and intentional.** The facade re-exports:
+   - `install!` (always, as the panel's installation entry point).
+   - View vars that callers (typically `shell.cljs`) reference by name
+     (e.g. `app-db-diff/app-db-diff-view`,
+     `ai-co-pilot/ai-co-pilot-rail`).
+
+   The facade does **NOT** re-export every leaf's surface. Leaves are
+   internal organisation; their `install!` and helpers are reached via
+   the facade's `install!` chain or via direct `:require` from sibling
+   leaves and per-leaf tests. Re-exporting bulk leaf surfaces (events,
+   subs, feed projections, chrome helpers, style tokens) would invert
+   the encapsulation the split exists to create.
+
+   For pure-data helper bulk re-exports — the `<panel>_helpers.cljc`
+   case where multiple leaves' pure fns roll up into a single stable
+   facade for the helpers test — see the existing
+   `subscriptions_helpers.cljc`, `ai_co_pilot_helpers.cljc`, and
+   `mcp_server_helpers.cljc` files. That's a separate concern (pure
+   helper aggregation) from the panel facade discussed here.
+
+### View body delegation
+
+The facade's `reg-view` body is either:
+
+- **Inline**, when the body is small enough to read alongside the
+  facade's intent (e.g. `app_db_diff.cljs` — ~50 hiccup lines on the
+  composite-sub deref), OR
+- **Delegating** to a single plain Reagent fn from
+  `<panel>-views.cljs`, when the body would exceed the facade's
+  cohesive scope:
+
+  ```clojure
+  (rf/reg-view subscriptions-view
+    "The Subscriptions panel's root view."
+    []
+    [views/subscriptions-panel])
+  ```
+
+  The leaf fn (`subscriptions-panel`) is a plain `defn`, not a
+  `reg-view`. The facade is still where the registration happens; the
+  leaf is the implementation.
+
+A facade `reg-view` body that imports a leaf-side `reg-view` (i.e. the
+leaf calls `reg-view` and the facade `def`-rebinds) is the divergence
+remediation explicitly removed; do not re-introduce it.
+
+### Per-leaf smoke tests
+
+Every implementation leaf SHOULD ship at least one smoke test in its own
+`<leaf>_cljs_test.cljs[c]` file. ~20 lines is a reasonable target.
+
+- **View leaves** (Reagent fns rendering hiccup): render once, assert no
+  throw and a key `data-testid` hook is present in the produced tree.
+- **Events leaves** (one or more `reg-event-*` calls inside `install!`):
+  call `install!`, dispatch one happy-path event, assert the resulting
+  app-db transition.
+- **Subs leaves** (one or more `reg-sub` calls inside `install!`): call
+  `install!`, read one representative sub, assert its shape.
+- **Helper / projection leaves** (pure CLJC fns): call the pure fn,
+  assert the output shape.
+
+The smoke test is per-leaf, not per-symbol. Its job is to pin the leaf
+as an independently usable unit so a future regression that drops a
+`reg-*` form from the facade's `install!` chain (or moves a helper to a
+new leaf) is caught at the leaf level, not only at the umbrella level
+through downstream "handler not found" failures.
+
+The umbrella `register-causa-handlers!` path remains the integration
+contract; per-leaf smoke tests are the unit contract.
+
+## Panel-id ordering inside the registry
+
+Per `registry.cljs` the panels' `install!` calls run in alphabetical
+panel-id order. When you add a new panel facade, slot its `install!` into
+the alphabetical list and keep the comment in lockstep.
+
+## See also
+
+- `tools/causa/spec/017-Test-Coverage-Matrix.md` — feature-level coverage
+  matrix for browser gates.
+- Repo-root `spec/Conventions.md` — re-frame2-wide conventions
+  (`:rf/*` reserved namespaces, reserved app-db keys, etc.). Causa's
+  conventions live here; framework conventions live there.

--- a/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot.cljs
@@ -1,32 +1,42 @@
 (ns day8.re-frame2-causa.panels.ai-co-pilot
-  "Stable facade for Causa's AI Co-Pilot panel.
+  "AI Co-Pilot panel shell.
 
-  The panel is intentionally split by responsibility:
+  Follows the canonical panel facade pattern documented in
+  `tools/causa/spec/Conventions.md` — the facade owns the panel's
+  three public `reg-view`s; bodies delegate to plain Reagent fns in
+  `ai-co-pilot-views`. Subs/events leaves expose `install!`.
 
-  - views live in `ai-co-pilot-views` and its section leaves.
-  - registrations live in `ai-co-pilot-subs` and `ai-co-pilot-events`.
-  - pure data helpers live behind `ai-co-pilot-helpers`.
+  The panel is split by responsibility:
 
-  The public view vars stay here so shell/tests keep requiring one
-  namespace while the implementation leaves stay below the leaf budget."
-  (:require [day8.re-frame2-causa.panels.ai-co-pilot-events :as events]
+  - view shells (rail / cue / canvas) — bodies in `ai-co-pilot-views`.
+  - chrome / conversation / input sub-views — leaf cljs files,
+    plain Reagent fns.
+  - registrations — `ai-co-pilot-subs` + `ai-co-pilot-events`.
+  - pure data helpers — `ai-co-pilot-helpers` (a stable .cljc facade
+    rolling up chips / conversation-model / redaction / slash leaves)."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.ai-co-pilot-events :as events]
             [day8.re-frame2-causa.panels.ai-co-pilot-subs :as subs]
             [day8.re-frame2-causa.panels.ai-co-pilot-views :as views]))
 
-(def ai-co-pilot-rail
+(rf/reg-view ai-co-pilot-rail
   "Open 320px right-rail form of the AI Co-Pilot."
-  views/ai-co-pilot-rail)
+  []
+  [views/ai-co-pilot-rail])
 
-(def ai-co-pilot-cue
+(rf/reg-view ai-co-pilot-cue
   "Collapsed cue glyph form of the AI Co-Pilot."
-  views/ai-co-pilot-cue)
+  []
+  [views/ai-co-pilot-cue])
 
-(def ai-co-pilot-view
+(rf/reg-view ai-co-pilot-view
   "Canvas panel form of the AI Co-Pilot."
-  views/ai-co-pilot-view)
+  []
+  [views/ai-co-pilot-view])
 
 (defn install!
-  "Install the AI Co-Pilot panel's Causa-side registrations.
+  "Idempotent install for the AI Co-Pilot panel's Causa-side
+  registrations. Returns nil per the facade convention.
 
   Installation is pull-only: it registers handlers and a no-op LLM
   stream effect but never initiates an outbound provider request."

--- a/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot_input.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot_input.cljs
@@ -42,9 +42,14 @@
                                :margin-top "2px"}}
                  doc]]))])))
 
-(rf/reg-view input-row
+(defn input-row
   "Question input. `/clear` is handled locally; all other non-empty
-  submissions dispatch the pull-only LLM submit event."
+  submissions dispatch the pull-only LLM submit event.
+
+  Plain Reagent fn (not a reg-view) per the canonical facade
+  convention — only the panel's three public view names
+  (`ai-co-pilot-rail`/`-cue`/`-view`) live as `reg-view`s in the
+  facade `ai-co-pilot.cljs`."
   []
   (let [input  (or @(rf/subscribe [:rf.causa/copilot-input-text]) "")
         parsed (h/parse-slash-command input)

--- a/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot_views.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot_views.cljs
@@ -1,12 +1,17 @@
 (ns day8.re-frame2-causa.panels.ai-co-pilot-views
-  "Top-level AI Co-Pilot view shells."
+  "Top-level AI Co-Pilot view shells.
+
+  Plain Reagent fns per the canonical facade convention — the panel's
+  three public `reg-view` names (`ai-co-pilot-rail`,
+  `ai-co-pilot-cue`, `ai-co-pilot-view`) live in the facade
+  `ai-co-pilot.cljs`; this leaf supplies the implementation bodies."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.ai-co-pilot-chrome :as chrome]
             [day8.re-frame2-causa.panels.ai-co-pilot-conversation :as conversation]
             [day8.re-frame2-causa.panels.ai-co-pilot-input :as input]
             [day8.re-frame2-causa.theme.tokens :refer [tokens sans-stack]]))
 
-(rf/reg-view ai-co-pilot-rail
+(defn ai-co-pilot-rail
   "Open right-rail form: title bar, scrollable conversation, input row."
   []
   (let [conversation (or @(rf/subscribe [:rf.causa/copilot-conversation]) [])]
@@ -25,13 +30,13 @@
       [conversation/conversation-view conversation]]
      [input/input-row]]))
 
-(rf/reg-view ai-co-pilot-cue
+(defn ai-co-pilot-cue
   "Collapsed `◇` cue glyph. The pulse stops after first use."
   []
   (let [cue-active? (boolean @(rf/subscribe [:rf.causa/copilot-cue-active?]))]
     [chrome/cue-glyph cue-active?]))
 
-(rf/reg-view ai-co-pilot-view
+(defn ai-co-pilot-view
   "Canvas panel form for the sidebar Co-pilot row."
   []
   (let [conversation (or @(rf/subscribe [:rf.causa/copilot-conversation]) [])]

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
@@ -3,7 +3,12 @@
 
   The panel is slice-centric: it renders changed slices for the
   selected epoch, pinned live slices, reserved runtime keys, or the
-  'Show me when this changed' result for a focused path."
+  'Show me when this changed' result for a focused path.
+
+  Canonical exemplar of the panel facade pattern documented in
+  `tools/causa/spec/Conventions.md` — facade owns the public
+  `reg-view`, leaves expose plain fns + `install!`, the facade's
+  `install!` chains leaf installs and returns `nil`."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.app-db-diff-events :as events]
             [day8.re-frame2-causa.panels.app-db-diff-sections
@@ -64,7 +69,8 @@
 
 (defn install!
   "Idempotent install for the App-DB Diff panel's Causa-side
-  registrations."
+  registrations. Returns nil per the facade convention."
   []
   (subs/install!)
-  (events/install!))
+  (events/install!)
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/panels/mcp_server.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/mcp_server.cljs
@@ -1,28 +1,42 @@
 (ns day8.re-frame2-causa.panels.mcp-server
-  "Stable facade for Causa's MCP Server panel.
+  "MCP Server panel shell.
 
-  The MCP panel is split by responsibility:
+  Follows the canonical panel facade pattern documented in
+  `tools/causa/spec/Conventions.md` — the facade owns the panel's
+  single public `reg-view`; the body delegates to the plain Reagent
+  fn `mcp-server-views/mcp-server-view`. Subs/events leaves expose
+  `install!`.
 
-  - `mcp-server-views` owns the root shell and subscriptions.
-  - `mcp-server-chrome` owns header, filters, and inline settings.
-  - `mcp-server-feed` owns feed rows and empty states.
-  - `mcp-server-subs` owns read-model registrations.
-  - `mcp-server-events` owns write-event registrations.
-  - `mcp-server-helpers` remains the pure CLJC projection/model layer.
+  The panel is split by responsibility:
 
-  The public view var and `install!` entry stay here so shell/tests keep
-  requiring one stable namespace."
-  (:require [day8.re-frame2-causa.panels.mcp-server-events :as events]
+  - view shell — body in `mcp-server-views`.
+  - header / filters / inline settings — `mcp-server-chrome`.
+  - feed rows / empty states — `mcp-server-feed`.
+  - style tokens / origin colour — `mcp-server-style`.
+  - subscriptions — `mcp-server-subs`.
+  - events — `mcp-server-events`.
+  - pure projection/model — `mcp-server-helpers` (.cljc; JVM-testable).
+
+  Per the convention §Re-exports are minimal and intentional, the
+  facade re-exports `install!` (the panel's installation entry) and
+  `mcp-server-view` (the view name `shell.cljs` references). Leaf
+  subs/events/feed/chrome/style surfaces are NOT re-exported — they
+  are internal organisation reached via the `install!` chain or
+  direct sibling :require, and re-exporting them would invert the
+  encapsulation the split exists to create."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.mcp-server-events :as events]
             [day8.re-frame2-causa.panels.mcp-server-subs :as subs]
             [day8.re-frame2-causa.panels.mcp-server-views :as views]))
 
-(def mcp-server-view
+(rf/reg-view mcp-server-view
   "The MCP Server panel's root view."
-  views/mcp-server-view)
+  []
+  [views/mcp-server-view])
 
 (defn install!
   "Idempotent install for the MCP Server panel's Causa-side
-  registrations."
+  registrations. Returns nil per the facade convention."
   []
   (subs/install!)
   (events/install!)

--- a/tools/causa/src/day8/re_frame2_causa/panels/mcp_server_views.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/mcp_server_views.cljs
@@ -1,5 +1,9 @@
 (ns day8.re-frame2-causa.panels.mcp-server-views
-  "Top-level view shell for the MCP Server panel."
+  "Top-level view shell for the MCP Server panel.
+
+  Plain Reagent fn per the canonical facade convention — the panel's
+  public `reg-view` (`mcp-server-view`) lives in the facade
+  `mcp-server.cljs`; this leaf supplies the implementation body."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.mcp-server-chrome :as chrome]
             [day8.re-frame2-causa.panels.mcp-server-feed :as feed]
@@ -8,7 +12,7 @@
 (def ^:private tokens style/tokens)
 (def ^:private sans-stack style/sans-stack)
 
-(rf/reg-view mcp-server-view
+(defn mcp-server-view
   "The MCP Server panel's root view. Subscribes to
   `:rf.causa/mcp-server` (composite) + `:rf.causa/mcp-origin-filter-
   enabled?` (settings sub-pane state)."

--- a/tools/causa/src/day8/re_frame2_causa/panels/subscriptions.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/subscriptions.cljs
@@ -1,5 +1,11 @@
 (ns day8.re-frame2-causa.panels.subscriptions
-  "Subscriptions panel shell."
+  "Subscriptions panel shell.
+
+  Follows the canonical panel facade pattern documented in
+  `tools/causa/spec/Conventions.md` — facade owns the public
+  `reg-view`; the body delegates to a plain Reagent fn in
+  `subscriptions-views` because the body is too large to inline
+  cohesively."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.subscriptions-events
              :as events]
@@ -13,7 +19,9 @@
   [views/subscriptions-panel])
 
 (defn install!
-  "Install the Subscriptions panel's Causa-side registrations."
+  "Idempotent install for the Subscriptions panel's Causa-side
+  registrations. Returns nil per the facade convention."
   []
   (subs/install!)
-  (events/install!))
+  (events/install!)
+  nil)

--- a/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_chrome_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_chrome_cljs_test.cljs
@@ -1,0 +1,21 @@
+(ns day8.re-frame2-causa.panels.ai-co-pilot-chrome-cljs-test
+  "Per-leaf smoke test for `ai-co-pilot-chrome` (rf2-nb8if).
+
+  Renders the two public chrome fns and asserts data-testid hooks."
+  (:require [cljs.test :refer-macros [deftest is]]
+            [day8.re-frame2-causa.panels.ai-co-pilot-chrome :as chrome]))
+
+(defn- has-testid? [tree testid]
+  (some (fn [node]
+          (and (vector? node)
+               (map? (second node))
+               (= testid (:data-testid (second node)))))
+        (tree-seq (some-fn vector? seq?) seq tree)))
+
+(deftest cue-glyph-renders-with-testid
+  (is (has-testid? (chrome/cue-glyph true) "rf-causa-copilot-cue")))
+
+(deftest title-bar-renders-provider-and-close-buttons
+  (let [tree (chrome/title-bar)]
+    (is (has-testid? tree "rf-causa-copilot-provider-picker"))
+    (is (has-testid? tree "rf-causa-copilot-close"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_conversation_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_conversation_cljs_test.cljs
@@ -1,0 +1,35 @@
+(ns day8.re-frame2-causa.panels.ai-co-pilot-conversation-cljs-test
+  "Per-leaf smoke test for `ai-co-pilot-conversation` (rf2-nb8if).
+
+  Renders the public `conversation-view` fn over a couple of turns
+  and asserts the question / answer data-testid hooks are present."
+  (:require [cljs.test :refer-macros [deftest is]]
+            [day8.re-frame2-causa.panels.ai-co-pilot-conversation :as conversation]
+            [day8.re-frame2-causa.panels.ai-co-pilot-helpers :as h]))
+
+(defn- expand-fn [node]
+  (if (and (vector? node) (fn? (first node)))
+    (try (apply (first node) (rest node))
+         (catch :default _ node))
+    node))
+
+(defn- has-testid? [tree testid]
+  (some (fn [node]
+          (and (vector? node)
+               (map? (second node))
+               (= testid (:data-testid (second node)))))
+        (->> (tree-seq (some-fn vector? seq?) seq (expand-fn tree))
+             (map expand-fn))))
+
+(deftest conversation-view-renders-empty-tree
+  (is (vector? (conversation/conversation-view []))))
+
+(deftest conversation-view-renders-question-and-answer-turns
+  (let [conv (-> (h/empty-conversation)
+                 (h/append-question "what's up?")
+                 (h/start-answer)
+                 (h/append-token "all good")
+                 (h/end-answer))
+        tree (conversation/conversation-view conv)]
+    (is (has-testid? tree "rf-causa-copilot-turn-question"))
+    (is (has-testid? tree "rf-causa-copilot-turn-answer"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_events_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_events_cljs_test.cljs
@@ -1,0 +1,37 @@
+(ns day8.re-frame2-causa.panels.ai-co-pilot-events-cljs-test
+  "Per-leaf smoke test for `ai-co-pilot-events` (rf2-nb8if).
+
+  Calls the leaf's `install!` directly and asserts the copilot
+  events + the pull-only `:rf.causa.fx/llm-stream` no-op fx are
+  registered. Dispatches one happy-path event
+  (`:rf.causa/copilot-toggle`) and asserts the :rf/causa app-db
+  flips both `:copilot-open?` and `:copilot-first-used?`."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels.ai-co-pilot-events :as events]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest leaf-install-registers-events-and-fx
+  (events/install!)
+  (is (some? (registrar/handler :event :rf.causa/copilot-toggle)))
+  (is (some? (registrar/handler :event :rf.causa/copilot-set-input-text)))
+  (is (some? (registrar/handler :event :rf.causa/copilot-cycle-provider)))
+  (is (some? (registrar/handler :event :rf.causa/copilot-submit-question)))
+  (is (some? (registrar/handler :event :rf.causa/copilot-clear-conversation)))
+  (is (some? (registrar/handler :event :rf.causa/copilot-chip-clicked)))
+  (is (some? (registrar/handler :fx :rf.causa.fx/llm-stream))))
+
+(deftest copilot-toggle-flips-open-and-first-used
+  (events/install!)
+  (frame/reg-frame :rf/causa {})
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/copilot-toggle]))
+  (let [db (frame/frame-app-db-value :rf/causa)]
+    (is (true? (:copilot-open? db)))
+    (is (true? (:copilot-first-used? db)))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_input_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_input_cljs_test.cljs
@@ -1,0 +1,29 @@
+(ns day8.re-frame2-causa.panels.ai-co-pilot-input-cljs-test
+  "Per-leaf smoke test for `ai-co-pilot-input` (rf2-nb8if).
+
+  Renders the `input-row` plain Reagent fn (converted from a
+  `reg-view` per the canonical convention — internal sub-views are
+  plain fns) and asserts the input + submit data-testid hooks."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels.ai-co-pilot-input :as input]
+            [day8.re-frame2-causa.panels.ai-co-pilot-subs :as subs]))
+
+(defn- has-testid? [tree testid]
+  (some (fn [node]
+          (and (vector? node)
+               (map? (second node))
+               (= testid (:data-testid (second node)))))
+        (tree-seq (some-fn vector? seq?) seq tree)))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest input-row-renders-input-and-submit
+  (subs/install!)
+  (frame/reg-frame :rf/causa {})
+  (let [tree (input/input-row)]
+    (is (has-testid? tree "rf-causa-copilot-input"))
+    (is (has-testid? tree "rf-causa-copilot-submit"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_subs_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_subs_cljs_test.cljs
@@ -1,0 +1,23 @@
+(ns day8.re-frame2-causa.panels.ai-co-pilot-subs-cljs-test
+  "Per-leaf smoke test for `ai-co-pilot-subs` (rf2-nb8if).
+
+  Calls the leaf's `install!` directly and asserts the seven
+  copilot-* subs are registered."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels.ai-co-pilot-subs :as subs]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest leaf-install-registers-the-seven-copilot-subs
+  (subs/install!)
+  (is (some? (registrar/handler :sub :rf.causa/copilot-open?)))
+  (is (some? (registrar/handler :sub :rf.causa/copilot-conversation)))
+  (is (some? (registrar/handler :sub :rf.causa/copilot-provider)))
+  (is (some? (registrar/handler :sub :rf.causa/copilot-cue-active?)))
+  (is (some? (registrar/handler :sub :rf.causa/copilot-redaction-settings)))
+  (is (some? (registrar/handler :sub :rf.causa/copilot-streaming-token-count)))
+  (is (some? (registrar/handler :sub :rf.causa/copilot-input-text))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_views_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_views_cljs_test.cljs
@@ -1,0 +1,45 @@
+(ns day8.re-frame2-causa.panels.ai-co-pilot-views-cljs-test
+  "Per-leaf smoke test for `ai-co-pilot-views` (rf2-nb8if).
+
+  Renders each plain Reagent fn (`ai-co-pilot-rail`,
+  `ai-co-pilot-cue`, `ai-co-pilot-view`) once and asserts the load-
+  bearing data-testid hook is present. The leaf is plain-fn-only
+  per the canonical convention — the public `reg-view` lives in
+  the facade `ai-co-pilot.cljs`."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels.ai-co-pilot-subs :as subs]
+            [day8.re-frame2-causa.panels.ai-co-pilot-views :as views]))
+
+(defn- expand-fn [node]
+  (if (and (vector? node) (fn? (first node)))
+    (apply (first node) (rest node))
+    node))
+
+(defn- has-testid? [tree testid]
+  (some (fn [node]
+          (and (vector? node)
+               (map? (second node))
+               (= testid (:data-testid (second node)))))
+        (->> (tree-seq (some-fn vector? seq?) seq (expand-fn tree))
+             (map expand-fn))))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest rail-renders-with-testid
+  (subs/install!)
+  (frame/reg-frame :rf/causa {})
+  (is (has-testid? (views/ai-co-pilot-rail) "rf-causa-copilot-rail")))
+
+(deftest cue-renders-with-testid
+  (subs/install!)
+  (frame/reg-frame :rf/causa {})
+  (is (has-testid? (views/ai-co-pilot-cue) "rf-causa-copilot-cue")))
+
+(deftest view-renders-with-testid
+  (subs/install!)
+  (frame/reg-frame :rf/causa {})
+  (is (has-testid? (views/ai-co-pilot-view) "rf-causa-copilot-panel")))

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_events_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_events_cljs_test.cljs
@@ -1,0 +1,34 @@
+(ns day8.re-frame2-causa.panels.app-db-diff-events-cljs-test
+  "Per-leaf smoke test for `app-db-diff-events` (rf2-nb8if).
+
+  Calls the leaf's `install!` directly (NOT the umbrella
+  `register-causa-handlers!`) so the leaf is pinned as an
+  independently usable install unit. Dispatches one happy-path
+  event and asserts the resulting :rf/causa app-db transition."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels.app-db-diff-events :as events]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest leaf-install-registers-events-and-fxs
+  (events/install!)
+  (is (some? (registrar/handler :event :rf.causa/pin-slice)))
+  (is (some? (registrar/handler :event :rf.causa/unpin-slice)))
+  (is (some? (registrar/handler :event :rf.causa/focus-slice-path)))
+  (is (some? (registrar/handler :event :rf.causa/clear-slice-focus)))
+  (is (some? (registrar/handler :fx :rf.causa.fx/copy-to-clipboard))))
+
+(deftest pin-slice-dispatch-writes-pin-store
+  (events/install!)
+  (frame/reg-frame :rf/causa {})
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/pin-slice [:cart :items]]))
+  (is (= [[:cart :items]]
+         (get-in (frame/frame-app-db-value :rf/causa)
+                 [:pinned-slices-store :rf/default]))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_format_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_format_cljs_test.cljs
@@ -1,0 +1,21 @@
+(ns day8.re-frame2-causa.panels.app-db-diff-format-cljs-test
+  "Per-leaf smoke test for `app-db-diff-format` (rf2-nb8if).
+
+  The format leaf carries pure display-only formatters — `format-edn`,
+  `display-value`, `format-display-edn`, `truncate`, plus the
+  `op->border` / `op->label` lookup tables and the
+  `display-large-string-threshold` ceiling. CLJS-only because the
+  underlying leaf is `.cljs` (parent panel is CLJS-only)."
+  (:require [cljs.test :refer-macros [deftest is]]
+            [day8.re-frame2-causa.panels.app-db-diff-format :as f]))
+
+(deftest format-leaf-smoke
+  (is (= "[:cart :items]" (f/format-edn [:cart :items])))
+  (is (= "abc…" (f/truncate "abcdef" 4))
+      "truncate trims and appends an ellipsis at the cap")
+  (is (contains? f/op->border :added))
+  (is (contains? f/op->label :modified))
+  (let [big (apply str (repeat (inc f/display-large-string-threshold) "x"))
+        v   (f/display-value {:k big})]
+    (is (map? (:rf.size/large-elided (:k v)))
+        "large strings collapse to the elision marker")))

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_sections_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_sections_cljs_test.cljs
@@ -1,0 +1,44 @@
+(ns day8.re-frame2-causa.panels.app-db-diff-sections-cljs-test
+  "Per-leaf smoke test for `app-db-diff-sections` (rf2-nb8if).
+
+  Renders the three section-level public fns (`reserved-group`,
+  `pinned-group`, `focus-result-panel`) and asserts the
+  `data-testid` hooks the parent panel relies on. Walks the
+  hiccup tree directly — no DOM mount, no Reagent runtime."
+  (:require [cljs.test :refer-macros [deftest is]]
+            [day8.re-frame2-causa.panels.app-db-diff-sections :as sections]))
+
+(defn- has-testid? [tree testid]
+  (some (fn [node]
+          (and (vector? node)
+               (map? (second node))
+               (= testid (:data-testid (second node)))))
+        (tree-seq (some-fn vector? seq?) seq tree)))
+
+(deftest reserved-group-renders-when-pairs-present
+  (let [tree (sections/reserved-group [[:rf/route {:id :app/cart}]])]
+    (is (vector? tree))
+    (is (has-testid? tree "rf-causa-app-db-diff-reserved-group"))
+    (is (has-testid? tree "rf-causa-app-db-diff-reserved-:rf/route"))))
+
+(deftest reserved-group-collapses-when-empty
+  (is (nil? (sections/reserved-group []))))
+
+(deftest pinned-group-renders-when-slices-present
+  (let [tree (sections/pinned-group
+               [{:path [:cart :items] :value [{:id 7}]}])]
+    (is (has-testid? tree "rf-causa-app-db-diff-pinned-group"))
+    (is (has-testid? tree "rf-causa-app-db-diff-pinned-[:cart :items]"))))
+
+(deftest focus-result-panel-renders-no-hits-message
+  (let [tree (sections/focus-result-panel [:cart :items] [])]
+    (is (has-testid? tree "rf-causa-app-db-diff-focus-result"))
+    (is (has-testid? tree "rf-causa-app-db-diff-clear-focus"))))
+
+(deftest focus-result-panel-renders-hit-list
+  (let [tree (sections/focus-result-panel
+               [:cart :items]
+               [{:epoch-id :e-1 :event [:cart/add] :op :added
+                 :before nil :after [{:id 7}]}])]
+    (is (has-testid? tree "rf-causa-app-db-diff-focus-hits"))
+    (is (has-testid? tree "rf-causa-app-db-diff-focus-hit-:e-1"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_slices_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_slices_cljs_test.cljs
@@ -1,0 +1,36 @@
+(ns day8.re-frame2-causa.panels.app-db-diff-slices-cljs-test
+  "Per-leaf smoke test for `app-db-diff-slices` (rf2-nb8if).
+
+  Renders each public slice fn (`empty-state`, `slice-row`,
+  `changed-slices-stack`) once and asserts the load-bearing
+  `data-testid` hook is present in the produced hiccup."
+  (:require [cljs.test :refer-macros [deftest is]]
+            [day8.re-frame2-causa.panels.app-db-diff-slices :as slices]))
+
+(defn- has-testid? [tree testid]
+  (some (fn [node]
+          (and (vector? node)
+               (map? (second node))
+               (= testid (:data-testid (second node)))))
+        (tree-seq (some-fn vector? seq?) seq tree)))
+
+(deftest empty-state-renders
+  (let [tree (slices/empty-state :rf/default)]
+    (is (vector? tree))
+    (is (has-testid? tree "rf-causa-app-db-diff-empty"))))
+
+(deftest slice-row-renders-with-action-buttons
+  (let [tree (slices/slice-row {:op :modified :path [:cart :items]
+                                :before [] :after [{:id 7}]})]
+    (is (has-testid? tree "rf-causa-app-db-diff-slice-[:cart :items]"))
+    (is (has-testid? tree "rf-causa-app-db-diff-pin-[:cart :items]"))
+    (is (has-testid? tree "rf-causa-app-db-diff-show-when-[:cart :items]"))))
+
+(deftest changed-slices-stack-renders-no-changes-state-on-empty
+  (is (has-testid? (slices/changed-slices-stack [])
+                   "rf-causa-app-db-diff-no-changes")))
+
+(deftest changed-slices-stack-renders-slice-container-when-non-empty
+  (let [tree (slices/changed-slices-stack
+               [{:op :added :path [:user] :before nil :after "ada"}])]
+    (is (has-testid? tree "rf-causa-app-db-diff-slices"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_subs_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_subs_cljs_test.cljs
@@ -1,0 +1,33 @@
+(ns day8.re-frame2-causa.panels.app-db-diff-subs-cljs-test
+  "Per-leaf smoke test for `app-db-diff-subs` (rf2-nb8if).
+
+  Calls the leaf's `install!` directly (NOT the umbrella) and asserts
+  the seven Phase 5 subs are registered. Reads the composite
+  `:rf.causa/app-db-diff` once on a fresh frame and asserts the
+  default-shape map. Pins the per-`:epoch-id` `defonce diff-cache`
+  atom is reachable as a leaf var."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels.app-db-diff-subs :as subs]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn [] (reset! subs/diff-cache {}))}))
+
+(deftest leaf-install-registers-the-eight-subs
+  (subs/install!)
+  (is (some? (registrar/handler :sub :rf.causa/target-frame-db)))
+  (is (some? (registrar/handler :sub :rf.causa/selected-epoch-record)))
+  (is (some? (registrar/handler :sub :rf.causa/selected-epoch-diff)))
+  (is (some? (registrar/handler :sub :rf.causa/pinned-slices-store)))
+  (is (some? (registrar/handler :sub :rf.causa/pinned-slices)))
+  (is (some? (registrar/handler :sub :rf.causa/focused-slice-path)))
+  (is (some? (registrar/handler :sub :rf.causa/show-me-when-this-changed-result)))
+  (is (some? (registrar/handler :sub :rf.causa/app-db-diff))))
+
+(deftest diff-cache-is-a-leaf-level-atom
+  (is (some? subs/diff-cache))
+  (is (map? @subs/diff-cache)))

--- a/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_chrome_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_chrome_cljs_test.cljs
@@ -1,0 +1,28 @@
+(ns day8.re-frame2-causa.panels.mcp-server-chrome-cljs-test
+  "Per-leaf smoke test for `mcp-server-chrome` (rf2-nb8if).
+
+  Renders the two public chrome fns over an empty/idle filter state."
+  (:require [cljs.test :refer-macros [deftest is]]
+            [day8.re-frame2-causa.panels.mcp-server-chrome :as chrome]))
+
+(defn- has-testid? [tree testid]
+  (some (fn [node]
+          (and (vector? node)
+               (map? (second node))
+               (= testid (:data-testid (second node)))))
+        (tree-seq (some-fn vector? seq?) seq tree)))
+
+(deftest header-renders-with-no-filter
+  (is (vector?
+        (chrome/header {:agent-attached?   false
+                        :total             0
+                        :rendered          0
+                        :active-op-types   #{}
+                        :distinct-op-types []
+                        :op-type-counts    {}
+                        :since-ms          nil
+                        :any-filter?       false}))))
+
+(deftest settings-sub-pane-renders
+  (is (vector?
+        (chrome/settings-sub-pane {:origin-filter-enabled? false}))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_events_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_events_cljs_test.cljs
@@ -1,0 +1,37 @@
+(ns day8.re-frame2-causa.panels.mcp-server-events-cljs-test
+  "Per-leaf smoke test for `mcp-server-events` (rf2-nb8if).
+
+  Calls the leaf's `install!` directly and asserts the four events
+  are registered. Dispatches one happy-path event and asserts the
+  :rf/causa app-db transition."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels.mcp-server-events :as events]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest leaf-install-registers-events
+  (events/install!)
+  (is (some? (registrar/handler :event :rf.causa/toggle-mcp-op-type)))
+  (is (some? (registrar/handler :event :rf.causa/set-mcp-since-seconds)))
+  (is (some? (registrar/handler :event :rf.causa/clear-mcp-filters)))
+  (is (some? (registrar/handler :event :rf.causa/toggle-mcp-origin-filter))))
+
+(deftest toggle-mcp-op-type-flips-active-set
+  (events/install!)
+  (frame/reg-frame :rf/causa {})
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/toggle-mcp-op-type :tool-call]))
+  (is (= #{:tool-call}
+         (:mcp-active-op-types (frame/frame-app-db-value :rf/causa))))
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/toggle-mcp-op-type :tool-call]))
+  (is (not (contains? (or (:mcp-active-op-types
+                           (frame/frame-app-db-value :rf/causa)) #{})
+                      :tool-call))
+      "toggling the same op-type a second time disjs it"))

--- a/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_feed_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_feed_cljs_test.cljs
@@ -1,0 +1,34 @@
+(ns day8.re-frame2-causa.panels.mcp-server-feed-cljs-test
+  "Per-leaf smoke test for `mcp-server-feed` (rf2-nb8if).
+
+  Renders the public feed fns and asserts data-testid hooks."
+  (:require [cljs.test :refer-macros [deftest is]]
+            [day8.re-frame2-causa.panels.mcp-server-feed :as feed]))
+
+(defn- has-testid? [tree testid]
+  (some (fn [node]
+          (and (vector? node)
+               (map? (second node))
+               (= testid (:data-testid (second node)))))
+        (tree-seq (some-fn vector? seq?) seq tree)))
+
+(deftest mcp-row-renders-with-row-testid
+  (let [tree (feed/mcp-row {:id          1
+                            :time        1700000000000
+                            :op-type     :tool
+                            :operation   :tool/call
+                            :tool        :get-app-db
+                            :description "tool — get-app-db"
+                            :source-coord "foo.cljs:42"
+                            :dispatch-id nil})]
+    (is (has-testid? tree "rf-causa-mcp-row-1"))))
+
+(deftest empty-state-no-activity-renders
+  (is (vector? (feed/empty-state-no-activity))))
+
+(deftest empty-state-no-matches-renders
+  (is (vector? (feed/empty-state-no-matches))))
+
+(deftest activity-feed-renders-no-activity-when-empty-kind
+  (is (vector?
+        (feed/activity-feed {:rows [] :empty-kind :no-activity}))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_style_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_style_cljs_test.cljs
@@ -1,0 +1,17 @@
+(ns day8.re-frame2-causa.panels.mcp-server-style-cljs-test
+  "Per-leaf smoke test for `mcp-server-style` (rf2-nb8if).
+
+  Pins the panel-local token map carries the inferential
+  `:causa-mcp-cyan` origin colour (Tailwind cyan-500 #06B6D4 per
+  helpers spec)."
+  (:require [cljs.test :refer-macros [deftest is]]
+            [day8.re-frame2-causa.panels.mcp-server-style :as style]
+            [day8.re-frame2-causa.panels.mcp-server-helpers :as h]))
+
+(deftest tokens-include-causa-mcp-origin-colour
+  (is (= h/causa-mcp-origin-colour (:causa-mcp-cyan style/tokens))
+      "the leaf-local token map re-exposes the inferential origin colour"))
+
+(deftest sans-and-mono-stacks-are-non-empty-strings
+  (is (string? style/sans-stack))
+  (is (string? style/mono-stack)))

--- a/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_subs_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_subs_cljs_test.cljs
@@ -1,0 +1,19 @@
+(ns day8.re-frame2-causa.panels.mcp-server-subs-cljs-test
+  "Per-leaf smoke test for `mcp-server-subs` (rf2-nb8if).
+
+  Calls the leaf's `install!` directly and asserts the three subs
+  the panel reads are registered."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels.mcp-server-subs :as subs]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest leaf-install-registers-subs
+  (subs/install!)
+  (is (some? (registrar/handler :sub :rf.causa/mcp-filters)))
+  (is (some? (registrar/handler :sub :rf.causa/mcp-server)))
+  (is (some? (registrar/handler :sub :rf.causa/mcp-origin-filter-enabled?))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_views_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_views_cljs_test.cljs
@@ -1,0 +1,34 @@
+(ns day8.re-frame2-causa.panels.mcp-server-views-cljs-test
+  "Per-leaf smoke test for `mcp-server-views` (rf2-nb8if).
+
+  Renders `mcp-server-view` (a plain Reagent fn per the canonical
+  facade convention — the public `reg-view` lives in the facade
+  `mcp-server.cljs`) and asserts the root data-testid hook."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels.mcp-server-subs :as subs]
+            [day8.re-frame2-causa.panels.mcp-server-views :as views]))
+
+(defn- expand-fn [node]
+  (if (and (vector? node) (fn? (first node)))
+    (try (apply (first node) (rest node))
+         (catch :default _ node))
+    node))
+
+(defn- has-testid? [tree testid]
+  (some (fn [node]
+          (and (vector? node)
+               (map? (second node))
+               (= testid (:data-testid (second node)))))
+        (->> (tree-seq (some-fn vector? seq?) seq (expand-fn tree))
+             (map expand-fn))))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest mcp-server-view-renders-with-testid
+  (subs/install!)
+  (frame/reg-frame :rf/causa {})
+  (is (has-testid? (views/mcp-server-view) "rf-causa-mcp-server")))

--- a/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_badges_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_badges_cljs_test.cljs
@@ -1,0 +1,28 @@
+(ns day8.re-frame2-causa.panels.subscriptions-badges-cljs-test
+  "Per-leaf smoke test for `subscriptions-badges` (rf2-nb8if).
+
+  Renders the four public badge fns and asserts at least one of
+  them carries the data-testid hook the parent panel relies on."
+  (:require [cljs.test :refer-macros [deftest is]]
+            [day8.re-frame2-causa.panels.subscriptions-badges :as badges]))
+
+(defn- has-testid? [tree testid]
+  (some (fn [node]
+          (and (vector? node)
+               (map? (second node))
+               (= testid (:data-testid (second node)))))
+        (tree-seq (some-fn vector? seq?) seq tree)))
+
+(deftest status-colour-returns-a-non-nil-token
+  (is (some? (badges/status-colour :fresh)))
+  (is (some? (badges/status-colour :error))))
+
+(deftest status-badge-renders
+  (is (vector? (badges/status-badge :fresh false))))
+
+(deftest layer-pill-renders-with-the-layer-number
+  (is (vector? (badges/layer-pill 1))))
+
+(deftest filter-header-renders-with-testid
+  (is (has-testid? (badges/filter-header #{} {:fresh 2} 2)
+                   "rf-causa-subscriptions-filters")))

--- a/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_chain_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_chain_cljs_test.cljs
@@ -1,0 +1,31 @@
+(ns day8.re-frame2-causa.panels.subscriptions-chain-cljs-test
+  "Per-leaf smoke test for `subscriptions-chain` (rf2-nb8if).
+
+  Renders `chain-view` for the missing and present cases and
+  asserts the data-testid hooks the parent panel relies on."
+  (:require [cljs.test :refer-macros [deftest is]]
+            [day8.re-frame2-causa.panels.subscriptions-chain :as chain]))
+
+(defn- has-testid? [tree testid]
+  (some (fn [node]
+          (and (vector? node)
+               (map? (second node))
+               (= testid (:data-testid (second node)))))
+        (tree-seq (some-fn vector? seq?) seq tree)))
+
+(deftest chain-view-renders-with-testid-when-missing
+  (let [tree (chain/chain-view {:missing? true :focused nil
+                                :inputs [] :app-db-paths []})]
+    (is (has-testid? tree "rf-causa-subscriptions-chain"))
+    (is (has-testid? tree "rf-causa-subscriptions-chain-missing"))))
+
+(deftest chain-view-renders-focused-when-present
+  (let [tree (chain/chain-view
+               {:missing? false
+                :focused {:query-v [:cart/total]
+                          :sub-id :cart/total :status :fresh
+                          :layer 2 :ref-count 1
+                          :input-subs [] :recomputed? false :error nil}
+                :inputs []
+                :app-db-paths []})]
+    (is (has-testid? tree "rf-causa-subscriptions-chain-focused"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_chain_model_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_chain_model_cljs_test.cljc
@@ -1,0 +1,25 @@
+(ns day8.re-frame2-causa.panels.subscriptions-chain-model-cljs-test
+  "Per-leaf smoke test for `subscriptions-chain-model` (rf2-nb8if).
+
+  Pure CLJC; JVM-runnable. Existing aggregate coverage lives in
+  `subscriptions_helpers_cljs_test.cljc` against the helpers
+  facade; this file pins the chain-model leaf as an independently
+  callable unit."
+  (:require #?(:clj  [clojure.test :refer [deftest is]]
+               :cljs [cljs.test    :refer-macros [deftest is]])
+            [day8.re-frame2-causa.panels.subscriptions-chain-model
+             :as chain-model]))
+
+(deftest compute-chain-marks-missing-when-cache-empty
+  (let [chain (chain-model/compute-chain
+                [:cart/total] {} [] {} #{})]
+    (is (true? (:missing? chain)))
+    (is (nil? (:focused chain)))))
+
+(deftest compute-chain-projects-focused-row-when-present
+  (let [cache {[:cart/total] {:layer 2 :ref-count 1 :input-subs []}}
+        chain (chain-model/compute-chain
+                [:cart/total] cache [] {} #{})]
+    (is (false? (:missing? chain)))
+    (is (= :cart/total (:sub-id (:focused chain))))
+    (is (= 2 (:layer (:focused chain))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_events_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_events_cljs_test.cljs
@@ -1,0 +1,33 @@
+(ns day8.re-frame2-causa.panels.subscriptions-events-cljs-test
+  "Per-leaf smoke test for `subscriptions-events` (rf2-nb8if).
+
+  Calls the leaf's `install!` directly and asserts the six events
+  are registered. Dispatches one happy-path event and asserts the
+  :rf/causa app-db transition."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels.subscriptions-events :as events]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest leaf-install-registers-events
+  (events/install!)
+  (is (some? (registrar/handler :event :rf.causa/select-sub)))
+  (is (some? (registrar/handler :event :rf.causa/clear-selected-sub)))
+  (is (some? (registrar/handler :event :rf.causa/toggle-sub-filter)))
+  (is (some? (registrar/handler :event :rf.causa/show-invalidation-chain)))
+  (is (some? (registrar/handler :event :rf.causa/hide-invalidation-chain)))
+  (is (some? (registrar/handler :event :rf.causa/set-sub-cache-override-for-test))))
+
+(deftest select-sub-dispatch-writes-selected-sub
+  (events/install!)
+  (frame/reg-frame :rf/causa {})
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/select-sub [:cart/total]]))
+  (is (= [:cart/total]
+         (:selected-sub (frame/frame-app-db-value :rf/causa)))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_format_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_format_cljs_test.cljc
@@ -1,0 +1,14 @@
+(ns day8.re-frame2-causa.panels.subscriptions-format-cljs-test
+  "Per-leaf smoke test for `subscriptions-format` (rf2-nb8if).
+
+  Pure CLJC; JVM-runnable."
+  (:require #?(:clj  [clojure.test :refer [deftest is]]
+               :cljs [cljs.test    :refer-macros [deftest is]])
+            [day8.re-frame2-causa.panels.subscriptions-format :as f]))
+
+(deftest format-query-v-pretty-prints
+  (is (= "[:cart/total]" (f/format-query-v [:cart/total]))))
+
+(deftest format-sub-id-handles-keywords-and-symbols
+  (is (= ":cart/total" (f/format-sub-id :cart/total)))
+  (is (= "my-sub" (f/format-sub-id 'my-sub))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_projection_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_projection_cljs_test.cljc
@@ -1,0 +1,35 @@
+(ns day8.re-frame2-causa.panels.subscriptions-projection-cljs-test
+  "Per-leaf smoke test for `subscriptions-projection` (rf2-nb8if).
+
+  Pure CLJC; JVM-runnable. Existing aggregate coverage lives in
+  `subscriptions_helpers_cljs_test.cljc` against the helpers
+  facade; this file pins the projection leaf as an independently
+  callable unit so a facade rewrite that drops a re-export is
+  caught at the leaf level."
+  (:require #?(:clj  [clojure.test :refer [deftest is]]
+               :cljs [cljs.test    :refer-macros [deftest is]])
+            [day8.re-frame2-causa.panels.subscriptions-projection
+             :as projection]))
+
+(deftest compute-status-classifies-error
+  (is (= :error
+         (projection/compute-status {:ref-count 1} nil true))))
+
+(deftest project-rows-returns-row-per-cache-entry
+  (let [rows (projection/project-rows
+               {[:cart/total] {:layer 1 :ref-count 1 :input-subs []}}
+               []
+               {})]
+    (is (= 1 (count rows)))
+    (is (= [:cart/total] (:query-v (first rows))))))
+
+(deftest status-counts-tallies-frequencies
+  (is (= {:fresh 2}
+         (projection/status-counts
+           [{:status :fresh} {:status :fresh}]))))
+
+(deftest filter-by-status-restricts-to-keep-set
+  (is (= [{:status :error}]
+         (projection/filter-by-status
+           [{:status :error} {:status :fresh}]
+           #{:error}))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_rows_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_rows_cljs_test.cljs
@@ -1,0 +1,25 @@
+(ns day8.re-frame2-causa.panels.subscriptions-rows-cljs-test
+  "Per-leaf smoke test for `subscriptions-rows` (rf2-nb8if).
+
+  Renders `sub-list` for both the empty and populated cases and
+  asserts the data-testid hooks the parent panel relies on."
+  (:require [cljs.test :refer-macros [deftest is]]
+            [day8.re-frame2-causa.panels.subscriptions-rows :as rows]))
+
+(defn- has-testid? [tree testid]
+  (some (fn [node]
+          (and (vector? node)
+               (map? (second node))
+               (= testid (:data-testid (second node)))))
+        (tree-seq (some-fn vector? seq?) seq tree)))
+
+(deftest sub-list-empty-state-renders
+  (is (has-testid? (rows/sub-list [] nil)
+                   "rf-causa-subscriptions-empty-rows")))
+
+(deftest sub-list-renders-rows
+  (let [r [{:query-v [:cart/total] :sub-id :cart/total
+            :status :fresh :layer 1 :ref-count 1 :input-subs []
+            :recomputed? false :error nil}]]
+    (is (has-testid? (rows/sub-list r nil)
+                     "rf-causa-subscriptions-list"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_status_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_status_cljs_test.cljc
@@ -1,0 +1,18 @@
+(ns day8.re-frame2-causa.panels.subscriptions-status-cljs-test
+  "Per-leaf smoke test for `subscriptions-status` (rf2-nb8if).
+
+  Asserts the status taxonomy lookups carry every status keyword
+  with a non-nil mapping. Pure CLJC; JVM-runnable."
+  (:require #?(:clj  [clojure.test :refer [deftest is]]
+               :cljs [cljs.test    :refer-macros [deftest is]])
+            [day8.re-frame2-causa.panels.subscriptions-status :as status]))
+
+(deftest each-status-has-token-glyph-tooltip
+  (doseq [s status/statuses]
+    (is (some? (get status/status->token s)))
+    (is (some? (get status/status->glyph s)))
+    (is (some? (get status/status->tooltip s)))))
+
+(deftest statuses-vector-has-five-canonical-entries
+  (is (= #{:error :re-running :invalidated :fresh :cached-no-watcher}
+         (set status/statuses))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_subs_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_subs_cljs_test.cljs
@@ -1,0 +1,22 @@
+(ns day8.re-frame2-causa.panels.subscriptions-subs-cljs-test
+  "Per-leaf smoke test for `subscriptions-subs` (rf2-nb8if).
+
+  Calls the leaf's `install!` directly and asserts the six subs +
+  the composite `:rf.causa/subscriptions-data` are registered."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels.subscriptions-subs :as subs]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest leaf-install-registers-the-subs
+  (subs/install!)
+  (is (some? (registrar/handler :sub :rf.causa/sub-cache)))
+  (is (some? (registrar/handler :sub :rf.causa/sub-error-cache)))
+  (is (some? (registrar/handler :sub :rf.causa/selected-sub)))
+  (is (some? (registrar/handler :sub :rf.causa/sub-filters)))
+  (is (some? (registrar/handler :sub :rf.causa/sub-chain-open?)))
+  (is (some? (registrar/handler :sub :rf.causa/subscriptions-data))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_views_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_views_cljs_test.cljs
@@ -1,0 +1,36 @@
+(ns day8.re-frame2-causa.panels.subscriptions-views-cljs-test
+  "Per-leaf smoke test for `subscriptions-views` (rf2-nb8if).
+
+  Renders `subscriptions-panel` (a plain Reagent fn per the
+  canonical facade convention — the public `reg-view` lives in the
+  facade) and asserts the top-level data-testid hook."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels.subscriptions-subs :as subs]
+            [day8.re-frame2-causa.panels.subscriptions-views :as views]))
+
+(defn- expand-fn [node]
+  (if (and (vector? node) (fn? (first node)))
+    (try (apply (first node) (rest node))
+         (catch :default _ node))
+    node))
+
+(defn- has-testid? [tree testid]
+  (some (fn [node]
+          (and (vector? node)
+               (map? (second node))
+               (= testid (:data-testid (second node)))))
+        (->> (tree-seq (some-fn vector? seq?) seq (expand-fn tree))
+             (map expand-fn))))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest subscriptions-panel-renders-with-testid
+  (subs/install!)
+  (frame/reg-frame :rf/causa {})
+  (is (has-testid? (views/subscriptions-panel)
+                   "rf-causa-subscriptions")
+      "the root :section data-testid is present"))


### PR DESCRIPTION
## Summary

Coordinated remediation of the 4 already-shipped Causa panel splits
(app-db-diff, ai-co-pilot, subscriptions, mcp-server). Per the
2026-05-16 findings docs the 4 splits had diverged into 3 different
facade shapes and 3 of them had landed zero per-leaf tests; this PR
standardises the facade pattern across all 4 and adds per-leaf smoke
tests so every leaf is pinned as an independently usable unit.

## Canonical facade chosen

The **app-db-diff** facade (closest to P1 in the findings doc —
facade-as-view + facade-install) is the canonical exemplar. The
convention is now codified in `tools/causa/spec/Conventions.md`:

1. Facade owns every public `reg-view`.
2. Leaves never call `reg-view`.
3. `install!` is idempotent and returns `nil`.
4. Re-exports are minimal — `install!` plus view vars referenced by
   shell.cljs. Subs / events / chrome / feed / style leaves are
   internal organisation, NOT re-exported.

Facade view bodies are either inline (small body, like app-db-diff)
or delegate to a plain Reagent fn in `<panel>-views` (large body,
like subscriptions / ai-co-pilot / mcp-server).

## Per-panel summary

| Panel | Before | After |
|---|---|---|
| app-db-diff | already canonical; `install!` returned chain tail | doc cross-ref + `install!` returns nil |
| subscriptions | reg-view in facade delegating to plain fn (P3) | doc cross-ref + `install!` returns nil |
| ai-co-pilot | 3 reg-views in `_views.cljs` + 1 in `_input.cljs`; facade def-rebinds (P2) | all 3 public reg-views moved into facade delegating to plain fns; `input-row` converted to plain `defn` |
| mcp-server | reg-view in `_views.cljs`; facade def-rebinds (P2) | reg-view moved into facade delegating; explicit re-export-policy doc inline |

## MCP Server facade re-export decision

Per the brief's 'extend OR document why' clause for the MCP bulk
re-export question: the facade re-exports `install!` + `mcp-server-view`
ONLY. Subs/events/feed/chrome/style leaves are NOT re-exported —
they are internal organisation reached via the `install!` chain or
direct sibling `:require` from per-leaf tests, and bulk re-exports
would invert the encapsulation the split exists to create. The
policy is documented inline in the facade docstring and matches the
canonical convention.

## Per-leaf smoke test counts

| Panel | New test files | New test fns |
|---|---|---|
| app-db-diff | 5 (events, subs, format, sections, slices) | 14 |
| ai-co-pilot | 6 (events, subs, views, chrome, conversation, input) | 11 |
| subscriptions | 10 (events, subs, views, badges, chain, rows, status, format, projection, chain-model) | 22 |
| mcp-server | 6 (events, subs, views, chrome, feed, style) | 12 |
| **Total** | **27 new test files** | **59 new test fns** |

Per the canonical convention each leaf is now pinned as an
independently usable unit so a future regression that drops a `reg-*`
form from the facade `install!` chain is caught at the leaf level,
not only at the umbrella level via downstream 'handler not found'
failures.

## Test results

| Gate | Before | After | Delta |
|---|---|---|---|
| Causa JVM (`cd tools/causa && clojure -M:test`) | 525 tests, 1492 assertions | 535 tests, 1521 assertions | +10 tests, +29 assertions |
| CLJS (`implementation && npm run test:cljs`) | 2081 tests, 5984 assertions | 2140 tests, 6121 assertions | +59 tests, +137 assertions |

All gates green at every commit.

## Findings refs

- `ai/findings/causa-testing-work-review-2026-05-16.md` — Causa-specific
  review that called out the 3 facade shapes and recommended P1.
- `ai/findings/testing-review-2026-05-16.md` — broader review that
  called out the MCP per-leaf coverage gap (events/views/feed/chrome/
  style/subs uncovered at the leaf level).

## Commit map (sequenced smallest+safest → biggest)

1. `bf753f73` — canonical convention doc + app-db-diff cross-ref
2. `e9d55dda` — Subscriptions facade alignment
3. `f28d56d6` — AI Co-Pilot facade alignment
4. `3a4849e0` — MCP Server facade alignment + re-export policy doc
5. `734919b3` — app-db-diff per-leaf smoke tests
6. `a05c0ffb` — ai-co-pilot per-leaf smoke tests
7. `0f1b9892` — subscriptions per-leaf smoke tests
8. `ad29ad87` — mcp-server per-leaf smoke tests

## Test plan

- [x] `cd tools/causa && clojure -M:test` (525 → 535 tests, all green)
- [x] `cd implementation && npm run test:cljs` (2081 → 2140 tests, all green)
- [x] `bash scripts/test-fast-pr.sh` (full fast-PR spine green)

Bead: rf2-nb8if (umbrella; mayor closes on merge).