### PR TITLE
test(causa): Story-on-Causa Phase 1a — panel-gallery scaffold + event-detail (rf2-1o7mp)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -414,6 +414,20 @@
    :modules    {:main {:init-fn cart-total.core/run}}
    :devtools   {:preloads [day8.re-frame2-causa.preload]}}
 
+  ;; Causa panel-gallery testbed (rf2-1o7mp) — visual gallery of Causa
+  ;; panels under varying state magnitude. Sources live under
+  ;; tools/causa/testbeds/panel_gallery/ alongside the stories ns.
+  ;; Phase 1a (rf2-1o7mp) ships the event-detail panel; the namespace
+  ;; gates a Phase-2 fan-out where each remaining panel adds its own
+  ;; <panel>_stories.cljs to this same testbed (one URL, one workspace
+  ;; mega-grid). No Causa preload — the gallery embeds bare panels
+  ;; inside Story variants and never mounts Causa's own shell.
+  :testbeds/panel-gallery
+  {:target     :browser
+   :output-dir "out/testbeds/panel-gallery"
+   :asset-path "."
+   :modules    {:main {:init-fn panel-gallery.core/run}}}
+
   :examples/temperature
   {:target     :browser
    :output-dir "out/examples/temperature"

--- a/tools/causa/testbeds/panel_gallery/_smoke.cjs
+++ b/tools/causa/testbeds/panel_gallery/_smoke.cjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/*
+ * Local-only smoke for the panel-gallery testbed (rf2-1o7mp). Boots an
+ * http-server against the testbed bundle and drives Playwright to:
+ *   1. Open `/index.html`              — landing renders.
+ *   2. Open `/#/stories`               — Story shell mounts.
+ *   3. Wait for the workspace gallery  — twelve variant cells render.
+ *   4. Snapshot console errors         — none beyond the expected.
+ *
+ * Not wired into CI. Run manually post-compile to verify the gallery
+ * boots end-to-end:
+ *
+ *   shadow-cljs compile testbeds/panel-gallery
+ *   cp tools/causa/testbeds/panel_gallery/index.html implementation/out/testbeds/panel-gallery/
+ *   node tools/causa/testbeds/panel_gallery/_smoke.cjs
+ */
+
+const { spawn } = require('child_process');
+const path = require('path');
+const http = require('http');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
+const IMPL_ROOT = path.join(REPO_ROOT, 'implementation');
+const OUT_DIR = path.join(IMPL_ROOT, 'out', 'testbeds', 'panel-gallery');
+const PORT = Number(process.env.PANEL_GALLERY_SMOKE_PORT || 8766);
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+const HTTP_SERVER_BIN = require.resolve('http-server/bin/http-server', {
+  paths: [IMPL_ROOT],
+});
+
+function waitForReady(url, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    function probe() {
+      const req = http.get(url, (res) => {
+        res.resume();
+        if (res.statusCode === 200) resolve();
+        else if (Date.now() - start > timeoutMs) {
+          reject(new Error(`bad status ${res.statusCode} after ${timeoutMs}ms`));
+        } else setTimeout(probe, 200);
+      });
+      req.on('error', () => {
+        if (Date.now() - start > timeoutMs) reject(new Error(`server not ready in ${timeoutMs}ms`));
+        else setTimeout(probe, 200);
+      });
+    }
+    probe();
+  });
+}
+
+(async () => {
+  const server = spawn(process.execPath, [HTTP_SERVER_BIN, OUT_DIR, '-p', String(PORT), '-s'], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let exitCode = 0;
+  try {
+    await waitForReady(`${BASE_URL}/index.html`, 5000);
+    const { chromium } = require(require.resolve('playwright', { paths: [IMPL_ROOT] }));
+    const browser = await chromium.launch();
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    const consoleErrors = [];
+    page.on('pageerror', (err) => consoleErrors.push(`pageerror: ${err.message}`));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(`console.error: ${msg.text()}`);
+    });
+
+    // 1. landing
+    await page.goto(`${BASE_URL}/index.html`, { waitUntil: 'load' });
+    await page.waitForSelector('h1', { timeout: 5000 });
+    const heading = await page.locator('h1').first().textContent();
+    if (!heading.includes('Causa panel gallery')) throw new Error(`landing heading wrong: ${heading}`);
+
+    // 2. shell
+    await page.goto(`${BASE_URL}/index.html#/stories`, { waitUntil: 'load' });
+    // Story shell mounts a sidebar; the sidebar always renders; variants
+    // mount after the user picks a story or a workspace.
+    await page.waitForTimeout(1500);
+
+    // Probe the page DOM to discover what Story has rendered.
+    const sidebarText = await page.locator('body').textContent({ timeout: 5000 });
+    const hasStoryShell = sidebarText.includes('story.causa.event-detail') ||
+                          sidebarText.includes('Workspace.causa.event-detail') ||
+                          sidebarText.includes('event-detail');
+    if (!hasStoryShell) throw new Error(`Story shell text not found; first 500: ${sidebarText.slice(0, 500)}`);
+
+    // Dismiss the welcome overlay if present.
+    const gotIt = page.locator('button:has-text("Got it")').first();
+    if ((await gotIt.count()) > 0) await gotIt.click({ timeout: 2000 }).catch(() => {});
+    await page.waitForTimeout(500);
+
+    // The sidebar lists every variant + workspace by name. Click the
+    // workspace-grid entry first; fall back to the first variant.
+    let variantRoots = 0;
+    const workspaceLine = page.locator('text=/Workspace.causa.event-detail\\/all/').first();
+    if ((await workspaceLine.count()) > 0) {
+      await workspaceLine.click({ timeout: 3000 }).catch(() => {});
+      await page.waitForTimeout(2000);
+      variantRoots = await page.locator('[data-rf-story-variant-root]').count();
+    }
+    if (variantRoots < 1) {
+      const variantLine = page.locator('text=/empty-buffer/').first();
+      if ((await variantLine.count()) > 0) {
+        await variantLine.click({ timeout: 3000 }).catch(() => {});
+        await page.waitForTimeout(1500);
+        variantRoots = await page.locator('[data-rf-story-variant-root]').count();
+      }
+    }
+    const cards = await page.locator('[data-testid="panel-gallery-event-detail-card"]').count();
+
+    console.log(`landing OK • shell text contains story keys • variant-roots=${variantRoots} cards=${cards}`);
+    if (consoleErrors.length) {
+      console.log('--- console errors ---');
+      for (const err of consoleErrors) console.log(err);
+      console.log('----------------------');
+    }
+    if (variantRoots < 1) {
+      // Debug — dump the visible body content so we can see what Story rendered.
+      const bodyText = await page.locator('body').textContent({ timeout: 2000 });
+      console.log('--- body text snippet ---');
+      console.log(bodyText.slice(0, 2000));
+      console.log('-------------------------');
+      // Dump links / clickable elements
+      const links = await page.evaluate(() => {
+        const out = [];
+        document.querySelectorAll('a,button,[role="button"],[data-testid]').forEach((el) => {
+          out.push(`${el.tagName} testid=${el.getAttribute('data-testid')} text=${(el.textContent || '').slice(0, 60)}`);
+        });
+        return out.slice(0, 40);
+      });
+      console.log('--- clickable elements ---');
+      console.log(links.join('\n'));
+      console.log('--------------------------');
+      throw new Error(`expected ≥1 variant root after navigation, got ${variantRoots}`);
+    }
+    console.log('smoke OK');
+    await browser.close();
+  } catch (err) {
+    console.error('smoke FAILED:', err.message);
+    exitCode = 1;
+  } finally {
+    server.kill('SIGTERM');
+    setTimeout(() => process.exit(exitCode), 200);
+  }
+})();

--- a/tools/causa/testbeds/panel_gallery/core.cljs
+++ b/tools/causa/testbeds/panel_gallery/core.cljs
@@ -1,0 +1,131 @@
+(ns panel-gallery.core
+  "Boot for the Causa panel gallery testbed (rf2-1o7mp).
+
+  ## What this testbed is
+
+  A visual gallery of Causa panel states, framed exactly like
+  Storybook frames UI components: scroll the workspace, see what each
+  panel looks like with 0 / 3 / 30 / 300 cascades, with the redacted
+  marker present, with the large-elision marker, with errors. The
+  gallery IS the surface a developer (Mike first) reaches for when
+  asking 'what does this panel look like under load X?'. There is no
+  CI gate at this stage; the panel rendering without throwing is
+  itself the cheap regression check Story's variant lifecycle gives
+  for free.
+
+  See `ai/findings/story-on-causa-feasibility-2026-05-16.md` for the
+  full panel coverage plan (8 panels, ~80 variants total). This
+  testbed lands the first panel — event-detail, 12 variants — under
+  Phase 1a (rf2-1o7mp).
+
+  ## What this boot does
+
+  1. Initialises re-frame with the Reagent adapter.
+  2. Registers Causa's `:rf.causa/*` events / subs / fxs (without
+     mounting Causa's own shell — we want the bare panels embedded in
+     variants, not the host's overlay).
+  3. Installs Story's canonical vocabulary (the seven reg-* macros and
+     the canonical tags / modes).
+  4. Loads the per-panel stories namespaces (their `register-all!`
+     fires at namespace load).
+  5. Mounts the Story shell into `#app` on `#/stories`; otherwise
+     renders a tiny landing page with a link in.
+
+  ## Why no Causa preload
+
+  The Causa preload (`day8.re-frame2-causa.preload`) does three
+  things: register handlers, register the trace collector, and
+  auto-open the shell into the host's `[data-rf-causa-host]`. The
+  gallery wants only the first; we don't want the shell auto-mounting
+  and we don't need live trace collection (variants supply synthetic
+  trace events). Calling `register-causa-handlers!` directly skips the
+  parts we don't need.
+
+  ## Bundle isolation
+
+  This testbed is dev-only by construction: it `:requires` from
+  `tools/causa/src/` and `tools/story/src/`, both of which are
+  excluded from production builds via shadow-cljs build gates and the
+  bundle-isolation enforcement at `implementation/scripts/test-bundle-
+  isolation.sh`. Production app code never `:requires` anything under
+  `tools/causa/testbeds/`."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.story :as story]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [day8.re-frame2-causa.registry :as causa-registry]
+            [panel-gallery.gallery-views :as gallery-views]
+            ;; Side-effecting story registrations — namespaces fire
+            ;; their `register-all!` at load time.
+            [panel-gallery.event-detail-stories]))
+
+;; ============================================================================
+;; LANDING — the URL `/` view (no `#/stories` hash)
+;; ============================================================================
+
+(defn- landing-view []
+  [:div {:class "gallery-landing"}
+   [:h1 "Causa panel gallery"]
+   [:p "A visual gallery of Causa's panels under varying state magnitude."
+    " Phase 1a (rf2-1o7mp) ships the event-detail panel; Phase 2 adds the
+    remaining seven panels."]
+   [:p "Open the gallery at "
+    [:a {:href "#/stories"} [:code "#/stories"]]
+    " to scroll the workspace."]
+   [:p {:style {:margin-top "2em" :font-size "13px" :color "#7c8088"}}
+    "Each variant seeds its frame's "
+    [:code ":trace-buffer"]
+    " (and selection slots where relevant) by firing real Causa init
+    events. The panel renders bare in a card — Causa's own shell is
+    not mounted. Frame isolation: every variant has its own state."]])
+
+;; ============================================================================
+;; MOUNT
+;; ============================================================================
+
+(defonce ^:private app-root (atom nil))
+
+(defn- ensure-app-root! []
+  (when (nil? @app-root)
+    (reset! app-root (rdc/create-root (js/document.getElementById "app"))))
+  @app-root)
+
+(defn- tear-down-app-root! []
+  (when-let [root @app-root]
+    (try (rdc/unmount root) (catch :default _ nil))
+    (reset! app-root nil)))
+
+(defn- mount-landing! []
+  (story/unmount-shell!)
+  (ensure-app-root!)
+  (rdc/render @app-root [landing-view]))
+
+(defn- mount-stories! []
+  (tear-down-app-root!)
+  (story/mount-shell! (js/document.getElementById "app")))
+
+(defn- on-hash-change! []
+  (let [hash (or (.. js/window -location -hash) "")]
+    (if (re-find #"^#/stories" hash)
+      (mount-stories!)
+      (mount-landing!))))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  ;; Causa's :rf.causa/* events / subs / fxs land on the registry once.
+  ;; The handlers operate on the current frame's app-db, so each
+  ;; variant frame the Story canvas allocates becomes its own isolated
+  ;; "Causa frame" for the duration of the variant render.
+  (causa-registry/register-causa-handlers!)
+  ;; Story's canonical vocabulary (seven reg-* macros / tags / modes /
+  ;; canvas decorators) installed once at boot. Each
+  ;; `<panel>_stories.cljs` namespace also calls
+  ;; `install-canonical-vocabulary!` defensively at registration so
+  ;; ns reload after `:after-load` is safe.
+  (story/install-canonical-vocabulary!)
+  ;; Defensive — register the gallery view-id even if the stories ns
+  ;; loaded before this fn ran (CLJS reload order isn't guaranteed at
+  ;; the application level).
+  (gallery-views/register!)
+  (.addEventListener js/window "hashchange" on-hash-change!)
+  (on-hash-change!))

--- a/tools/causa/testbeds/panel_gallery/event_detail_stories.cljs
+++ b/tools/causa/testbeds/panel_gallery/event_detail_stories.cljs
@@ -1,0 +1,248 @@
+(ns panel-gallery.event-detail-stories
+  "Story coverage for the Causa event-detail panel under gallery framing
+  (rf2-1o7mp).
+
+  Twelve variants, each one render of `event-detail-view` against a
+  variant frame whose `:trace-buffer` (and where relevant
+  `:selected-dispatch-id` / `:selected-dispatch`) has been seeded by
+  REAL Causa init events fired into the variant frame.
+
+  ## Why real init events
+
+  Variant `:events` are dispatched via `(rf/dispatch-sync ev {:frame
+  variant-id})` per `tools/story/spec/002-Runtime.md`. Causa's
+  registered handlers (`:rf.causa/sync-trace-buffer`,
+  `:rf.causa/select-dispatch-id`) write via `(assoc db ...)` — so
+  Story's `:rf.story/*` runtime slots survive untouched. Direct
+  app-db assoc would wipe the lifecycle / loaders-complete / assertions
+  slots and corrupt the variant.
+
+  ## Why frame-provider {:frame variant-id} not :rf/causa
+
+  The Story canvas wraps each variant in `[frame-provider {:frame
+  variant-id}]` (per `tools/story/src/re_frame/story/ui/canvas.cljs`).
+  Subscriptions inside the rendered tree resolve to the variant frame.
+  `:rf.causa/trace-buffer` reads `(get db :trace-buffer)` from the
+  current frame's app-db — exactly the variant-frame slot the seed
+  events wrote. Each variant therefore observes its own bespoke trace
+  buffer in isolation; no two variants share state."
+  (:require [re-frame.story :as story]
+            [panel-gallery.fixtures :as fixtures]
+            [panel-gallery.gallery-views :as gallery-views]))
+
+;; ---- gallery view registration -----------------------------------------
+;;
+;; Story requires `:component` to be a registered view-id (per the
+;; canvas's `(re-frame.core/view <id>)` lookup). The gallery's
+;; component is a thin wrapper around `event-detail-view` so the panel
+;; renders inside the variant's frame-provider unchanged. Wrapper
+;; absorbs the Story-provided args map (the panel takes no args).
+
+(defn register-gallery-view! []
+  (gallery-views/register!))
+
+;; ---- variants -----------------------------------------------------------
+
+(defn register-all!
+  "Register the event-detail Story surface. Idempotent under
+  `register-canonical-vocabulary!` resets so the namespace is reloadable."
+  []
+  (story/install-canonical-vocabulary!)
+  (register-gallery-view!)
+
+  (story/reg-tag :feature/causa-event-detail
+    {:axis :feature
+     :doc  "Causa event-detail panel — hero panel, six-domino cascade view."})
+
+  (story/reg-tag :state/empty
+    {:axis :state-magnitude :doc "No traces in the buffer."})
+  (story/reg-tag :state/small
+    {:axis :state-magnitude :doc "≤ 5 cascades / fanout rows."})
+  (story/reg-tag :state/medium
+    {:axis :state-magnitude :doc "Tens of cascades or fanout rows."})
+  (story/reg-tag :state/large
+    {:axis :state-magnitude :doc "Hundreds of rows; exercises overflow."})
+  (story/reg-tag :state/special
+    {:axis :state-magnitude :doc "Edge state — orphan, redacted, large-elided, error."})
+
+  (story/reg-story :story.causa.event-detail
+    {:doc        "Visual gallery of the Causa event-detail panel under
+                 varying state magnitude. Each variant seeds its frame's
+                 :trace-buffer (and selection slots where relevant) via
+                 Causa's real init events; the rendered panel reads from
+                 the variant frame in isolation."
+     :component  :panel-gallery.event-detail/Panel
+     :tags       #{:dev :feature/causa-event-detail}
+     :substrates #{:reagent}})
+
+  ;; ----- 1. empty cascade buffer ----------------------------------------
+  (story/reg-variant :story.causa.event-detail/empty-buffer
+    {:doc        "No cascades in the buffer. Panel renders the
+                 'No cascades yet' empty-state copy alongside the
+                 cascade-list container."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/empty-buffer)]]
+     :tags       #{:dev :state/empty}
+     :substrates #{:reagent}})
+
+  ;; ----- 2. cascade list, small (3) -------------------------------------
+  (story/reg-variant :story.causa.event-detail/cascade-list-3
+    {:doc        "Three cascades, no selection. Panel renders the
+                 cascade-list rows; clicking one would set selection,
+                 but the gallery shows the unselected resting state."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/n-cascades 3)]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- 3. cascade list, medium (30) -----------------------------------
+  (story/reg-variant :story.causa.event-detail/cascade-list-30
+    {:doc        "Thirty cascades. The cascade list is comfortably
+                 scrollable; the panel's overflow indicator stays
+                 quiet under the cap."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/n-cascades 30)]]
+     :tags       #{:dev :state/medium}
+     :substrates #{:reagent}})
+
+  ;; ----- 4. cascade list, large (300) -----------------------------------
+  (story/reg-variant :story.causa.event-detail/cascade-list-300
+    {:doc        "Three hundred cascades. Exercises the overflow
+                 indicator (`overflow.capped-list`) and gives the
+                 reviewer a feel for the panel under storm load."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/n-cascades 300)]]
+     :tags       #{:dev :state/large}
+     :substrates #{:reagent}})
+
+  ;; ----- 5. detail, single fx -------------------------------------------
+  (story/reg-variant :story.causa.event-detail/detail-single-fx
+    {:doc        "One cascade selected; minimal effects (one :db fx).
+                 The narrowest detail render — every domino present
+                 but each at its smallest visual surface."
+     :events     [[:rf.causa/sync-trace-buffer
+                   (fixtures/cascade-with-counts
+                     {:dispatch-id 100
+                      :event-vec   [:counter/increment]
+                      :id-base     50
+                      :effects     1
+                      :subs        1
+                      :renders     1})]
+                  [:rf.causa/select-dispatch-id 100 nil]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- 6. detail, medium fanout (8 effects) ---------------------------
+  (story/reg-variant :story.causa.event-detail/detail-multi-fx-medium
+    {:doc        "One cascade selected; eight effects, four subs, three
+                 renders. Mid-size cascade — every domino is populated
+                 enough to read but the panel still fits one screen."
+     :events     [[:rf.causa/sync-trace-buffer
+                   (fixtures/cascade-with-counts
+                     {:dispatch-id 100
+                      :event-vec   [:checkout/submit {:order-id 42}]
+                      :id-base     50
+                      :effects     8
+                      :subs        4
+                      :renders     3})]
+                  [:rf.causa/select-dispatch-id 100 nil]]
+     :tags       #{:dev :state/medium}
+     :substrates #{:reagent}})
+
+  ;; ----- 7. detail, very large fanout (30+ effects) ---------------------
+  (story/reg-variant :story.causa.event-detail/detail-multi-fx-large
+    {:doc        "One cascade selected; thirty-five effects. The effects
+                 row scrolls vertically inside the cascade-detail layout;
+                 the gallery exercises the panel's behaviour under fanout
+                 storm."
+     :events     [[:rf.causa/sync-trace-buffer
+                   (fixtures/cascade-with-counts
+                     {:dispatch-id 100
+                      :event-vec   [:dashboard/refresh-all]
+                      :id-base     50
+                      :effects     35
+                      :subs        15
+                      :renders     12})]
+                  [:rf.causa/select-dispatch-id 100 nil]]
+     :tags       #{:dev :state/large}
+     :substrates #{:reagent}})
+
+  ;; ----- 8. detail, deep cascade nesting (5 cascades, sequential) ------
+  (story/reg-variant :story.causa.event-detail/detail-deep-cascade
+    {:doc        "Five cascades simulating a programmatic re-dispatch
+                 chain (login → load profile → fetch perms → cache →
+                 audit). The cascade list shows the full chain; the
+                 selected detail is the root login event with its own
+                 effects/subs/renders."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/deep-nested-buffer)]
+                  [:rf.causa/select-dispatch-id 100 nil]]
+     :tags       #{:dev :state/medium}
+     :substrates #{:reagent}})
+
+  ;; ----- 9. detail, redacted slot present -------------------------------
+  (story/reg-variant :story.causa.event-detail/detail-redacted
+    {:doc        "Selected cascade carries a `:sensitive?`-redacted
+                 event whose password and totp slots arrive as
+                 `:rf/redacted`. The panel's `format-edn` surfaces the
+                 marker verbatim — Spec 009 §Privacy in action."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/redacted-cascade-buffer)]
+                  [:rf.causa/select-dispatch-id 100 nil]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 10. detail, large-payload (elided marker) ----------------------
+  (story/reg-variant :story.causa.event-detail/detail-large-payload
+    {:doc        "Selected cascade's event payload is large-elided per
+                 Spec 009 §Size elision. The panel renders the
+                 `:rf.size/large-elided` marker map verbatim — handle,
+                 source, original-size, truncated-preview all visible."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/large-payload-buffer)]
+                  [:rf.causa/select-dispatch-id 100 nil]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 11. detail with :other rows (errors / warnings / machines) ----
+  ;;
+  ;; Panel-specific axis A: `event-detail` distinctly renders an
+  ;; :other-row bucket for traces that don't fit the six-domino
+  ;; vocabulary (errors, warnings, machine transitions). This variant
+  ;; is the one place in the gallery that exercises that branch.
+  (story/reg-variant :story.causa.event-detail/detail-other-rows
+    {:doc        "Selected cascade carries non-domino rows — handler
+                 exception, large-elision warning, machine transition.
+                 Surfaces the panel's `other-row` render branch
+                 (yellow-tone label, op-type + operation columns)."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/other-rows-buffer)]
+                  [:rf.causa/select-dispatch-id 100 nil]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 12. cascade list with mixed perf-tier dots --------------------
+  ;;
+  ;; Panel-specific axis B: `event-detail` is the panel that renders
+  ;; perf-tier coloured dots on `:duration-ms` (rf2-6ja23). Five
+  ;; cascades with durations spanning the 1ms / 6ms / 22ms / 87ms /
+  ;; 312ms tiers exercise every tier in one variant.
+  (story/reg-variant :story.causa.event-detail/cascade-list-perf-tiers
+    {:doc        "Five cascades whose `:run-end` :duration-ms spans
+                 every perf-tier swatch in the ladder (1 / 6 / 22 / 87
+                 / 312 ms). Selecting any cascade in the live UI would
+                 swap to the cascade-detail with the matching tier
+                 dot; the gallery shows the cascade-list resting state
+                 so all five tiers are visible side-by-side."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/long-handler-buffer)]
+                  [:rf.causa/select-dispatch-id 102 nil]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- workspace ------------------------------------------------------
+
+  (story/reg-workspace :Workspace.causa.event-detail/all
+    {:doc      "All twelve event-detail variants in one auto-grid.
+                Mike scrolls; the panel's response to varying state
+                magnitude is visible at a glance."
+     :layout   :variants-grid
+     :story    :story.causa.event-detail
+     :columns  2
+     :tags     #{:dev}}))
+
+;; Register at namespace load — the side-effecting boot pattern every
+;; testbed stories ns uses (cf. `cart-total.stories`). Idempotent:
+;; `register-all!` is safe to call repeatedly.
+(register-all!)

--- a/tools/causa/testbeds/panel_gallery/fixtures.cljs
+++ b/tools/causa/testbeds/panel_gallery/fixtures.cljs
@@ -1,0 +1,271 @@
+(ns panel-gallery.fixtures
+  "Pure fixture builders for the Causa panel gallery (rf2-1o7mp).
+
+  Story variants seed state by firing REAL Causa init events
+  (`:rf.causa/sync-trace-buffer`, `:rf.causa/select-dispatch-id`)
+  against the variant frame. Those handlers preserve `db` via `assoc`,
+  so Story's `:rf.story/*` runtime slots survive untouched per
+  `tools/story/spec/002-Runtime.md` §Coexistence with hosting
+  application state.
+
+  This namespace exposes pure builder functions that synthesize
+  trace-event vectors shaped exactly as
+  `re-frame.trace.projection/group-cascades` projects them:
+
+      {:id <int>
+       :op-type   :event | :fx | :sub/run | :view | :error | :warning | ...
+       :operation :event/dispatched | :event | :event/do-fx | :rf.fx/handled | ...
+       :tags      {:dispatch-id <int>
+                   :event       <event-vec>     ;; on :event/dispatched
+                   :phase       :run-start | :run-end
+                   :fx-id       <kw>            ;; on :fx
+                   :sub-id      <kw>            ;; on :sub/run
+                   :render-key  [<view-id> <args>] ;; on :view
+                   :frame       <frame-id>}}
+
+  The mirror of this shape lives in
+  `tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs`
+  (`cascade-evs`); the gallery uses the same template so any future
+  panel projection change shows up identically in both places.
+
+  Builders return plain vectors; the variant `:events` slot wraps each
+  in `[:rf.causa/sync-trace-buffer <buffer>]` for the seed dispatch.")
+
+;; ---- domino-row builders ------------------------------------------------
+;;
+;; Eight-event template per cascade — one of each row the event-detail
+;; panel renders. id-base lets a caller stack many cascades without id
+;; collision. Optional frame-id rides on every emit so cross-frame
+;; cascades surface the panel's `:frame` annotation in the cascade list.
+
+(defn cascade-evs
+  "Synthesize the eight trace events for a single cascade. Mirrors the
+  `cascade-evs` helper in event_detail_cljs_test so the gallery exercises
+  exactly the rows the unit tests pin.
+
+  Returns a vector of trace-event maps shaped per
+  `re-frame.trace.projection/group-cascades`."
+  ([dispatch-id event-vec id-base]
+   (cascade-evs dispatch-id event-vec id-base nil))
+  ([dispatch-id event-vec id-base frame-id]
+   (let [tag (cond-> {:dispatch-id dispatch-id}
+               frame-id (assoc :frame frame-id))]
+     [{:id (+ id-base 1) :op-type :event :operation :event/dispatched
+       :tags (assoc tag :event event-vec)}
+      {:id (+ id-base 2) :op-type :event :operation :event
+       :tags (assoc tag :phase :run-start)}
+      {:id (+ id-base 3) :op-type :event :operation :event
+       :tags (assoc tag :phase :run-end :duration-ms 4)}
+      {:id (+ id-base 4) :op-type :event :operation :event/do-fx
+       :tags tag}
+      {:id (+ id-base 5) :op-type :fx :operation :rf.fx/handled
+       :tags (assoc tag :fx-id :db)}
+      {:id (+ id-base 6) :op-type :fx :operation :rf.fx/handled
+       :tags (assoc tag :fx-id :dispatch)}
+      {:id (+ id-base 7) :op-type :sub/run :operation :sub/run
+       :tags (assoc tag :sub-id :sub/foo)}
+      {:id (+ id-base 8) :op-type :view :operation :view/render
+       :tags (assoc tag :render-key [:app/root nil])}])))
+
+(defn cascade-with-counts
+  "Build a cascade with caller-controlled fanout. `counts` is a map of
+  `{:effects N :subs N :renders N}`; each non-zero count emits that
+  many additional rows of the matching `:op-type`. Always emits the
+  three baseline event/do-fx rows so the cascade has a recognisable
+  spine; never emits the eighth `:view/render` row when `:renders 0`.
+
+  Synthetic fx-ids / sub-ids / render-keys cycle through a small pool
+  so the panel renders distinguishable values rather than 30 identical
+  rows."
+  [{:keys [dispatch-id event-vec id-base frame-id
+           effects subs renders]
+    :or {effects 1 subs 0 renders 0}}]
+  (let [tag (cond-> {:dispatch-id dispatch-id}
+              frame-id (assoc :frame frame-id))
+        spine [{:id (+ id-base 1) :op-type :event :operation :event/dispatched
+                :tags (assoc tag :event event-vec)}
+               {:id (+ id-base 2) :op-type :event :operation :event
+                :tags (assoc tag :phase :run-start)}
+               {:id (+ id-base 3) :op-type :event :operation :event
+                :tags (assoc tag :phase :run-end :duration-ms 7)}
+               {:id (+ id-base 4) :op-type :event :operation :event/do-fx
+                :tags tag}]
+        fx-pool [:db :dispatch :http :rf.machine/transition :rf.flow/computed
+                 :navigate :persist :metrics]
+        sub-pool [:auth/user :route/active :counter/value :cart/items
+                  :ui/theme :i18n/locale :session/heartbeat :feature/flags
+                  :perf/budget :error/recent]
+        render-pool [[:app/root nil] [:nav/bar nil] [:counter/badge nil]
+                     [:cart/list nil] [:auth/menu {:variant :compact}]
+                     [:perf/ribbon nil] [:settings/tab {:tab :general}]
+                     [:modal/host nil]]
+        fx-rows (mapv (fn [i]
+                        {:id (+ id-base 100 i) :op-type :fx :operation :rf.fx/handled
+                         :tags (assoc tag :fx-id (nth fx-pool (mod i (count fx-pool))))})
+                      (range effects))
+        sub-rows (mapv (fn [i]
+                         {:id (+ id-base 1000 i) :op-type :sub/run :operation :sub/run
+                          :tags (assoc tag :sub-id (nth sub-pool (mod i (count sub-pool))))})
+                       (range subs))
+        render-rows (mapv (fn [i]
+                            {:id (+ id-base 10000 i) :op-type :view :operation :view/render
+                             :tags (assoc tag :render-key
+                                          (nth render-pool (mod i (count render-pool))))})
+                          (range renders))]
+    (-> []
+        (into spine)
+        (into fx-rows)
+        (into sub-rows)
+        (into render-rows))))
+
+(defn cascade-with-other
+  "Single cascade carrying non-domino rows under `:other` — errors,
+  warnings, and machine transitions. Exercises `event-detail`'s
+  `other-row` render branch."
+  [dispatch-id id-base]
+  (let [tag {:dispatch-id dispatch-id}]
+    [{:id (+ id-base 1) :op-type :event :operation :event/dispatched
+      :tags (assoc tag :event [:user/save-profile {:id 7}])}
+     {:id (+ id-base 2) :op-type :event :operation :event
+      :tags (assoc tag :phase :run-start)}
+     {:id (+ id-base 3) :op-type :event :operation :event
+      :tags (assoc tag :phase :run-end :duration-ms 12)}
+     {:id (+ id-base 4) :op-type :event :operation :event/do-fx
+      :tags tag}
+     {:id (+ id-base 5) :op-type :fx :operation :rf.fx/handled
+      :tags (assoc tag :fx-id :db)}
+     ;; Non-domino rows — surface under :other.
+     {:id (+ id-base 6) :op-type :rf.error/handler-exception
+      :operation :rf.error/handler-exception
+      :tags (assoc tag :event [:user/save-profile {:id 7}])}
+     {:id (+ id-base 7) :op-type :rf.warning/runtime-large-elision
+      :operation :rf.warning/runtime-large-elision
+      :tags (assoc tag :sub-id :user/profile)}
+     {:id (+ id-base 8) :op-type :rf.machine/transition
+      :operation :rf.machine/transition
+      :tags (assoc tag :machine-id :user/save :from :idle :to :saving)}]))
+
+;; ---- buffer builders ----------------------------------------------------
+;;
+;; Each builder returns the trace-buffer vector ready to be passed
+;; verbatim to `:rf.causa/sync-trace-buffer`. The seed event in
+;; `core.cljs` writes the vector into the variant frame's app-db
+;; under `:trace-buffer`; the `:rf.causa/trace-buffer` sub then reads
+;; it on the standard reactive path.
+
+(defn empty-buffer [] [])
+
+(defn n-cascades
+  "Build `n` shallow cascades, each with the canonical 8-row template
+  and a unique `:dispatch-id` / event vector. Useful for cascade-list
+  variants where the panel renders one row per cascade."
+  [n]
+  (->> (range n)
+       (mapcat (fn [i]
+                 (cascade-evs (+ 100 i)
+                              [:demo/event-N i]
+                              (* (inc i) 50))))
+       vec))
+
+(defn n-cascades-cross-frame
+  "Like `n-cascades` but every other cascade rides on a non-default
+  frame-id so the panel's per-row frame annotation is exercised."
+  [n]
+  (->> (range n)
+       (mapcat (fn [i]
+                 (let [fid (case (mod i 3)
+                             0 nil
+                             1 :tenant/alpha
+                             2 :tenant/beta)]
+                   (cascade-evs (+ 200 i)
+                                [:tenant/poke i]
+                                (* (inc i) 50)
+                                fid))))
+       vec))
+
+(defn deep-nested-buffer
+  "A single root cascade plus four child cascades simulating
+  programmatic re-dispatch from each handler. Each child carries its
+  own dispatch-id so the cascade list shows five entries — the
+  cascade-detail view of the root reveals the original event."
+  []
+  (->> [[100 [:auth/login {:user :ada}]]
+        [101 [:auth/load-profile :ada]]
+        [102 [:profile/fetch-permissions :ada]]
+        [103 [:permissions/cache-load :ada]]
+        [104 [:audit/note-login :ada]]]
+       (map-indexed (fn [i [dispatch-id ev]]
+                      (cascade-evs dispatch-id ev (* (inc i) 50))))
+       (mapcat identity)
+       vec))
+
+(defn redacted-cascade-buffer
+  "One cascade whose dispatched event carries a redaction marker on a
+  password slot. The panel surfaces the marker verbatim — this is the
+  visual edge for `:sensitive?` handlers per Spec 009."
+  []
+  (let [dispatch-id 100
+        id-base 50
+        tag {:dispatch-id dispatch-id}]
+    [{:id (+ id-base 1) :op-type :event :operation :event/dispatched
+      :tags (assoc tag :event [:user/sign-in {:email "ada@example.com"
+                                              :password :rf/redacted
+                                              :totp     :rf/redacted}])}
+     {:id (+ id-base 2) :op-type :event :operation :event
+      :tags (assoc tag :phase :run-start)}
+     {:id (+ id-base 3) :op-type :event :operation :event
+      :tags (assoc tag :phase :run-end :duration-ms 9)}
+     {:id (+ id-base 4) :op-type :event :operation :event/do-fx
+      :tags tag}
+     {:id (+ id-base 5) :op-type :fx :operation :rf.fx/handled
+      :tags (assoc tag :fx-id :http)}]))
+
+(defn large-payload-buffer
+  "One cascade whose event payload is large-elided per Spec 009. The
+  panel renders the marker shape verbatim — the upstream emit sets the
+  marker; the panel's job is to surface it without trying to expand."
+  []
+  (let [dispatch-id 100
+        id-base 50
+        tag {:dispatch-id dispatch-id}]
+    [{:id (+ id-base 1) :op-type :event :operation :event/dispatched
+      :tags (assoc tag :event [:report/upload
+                               {:rf.size/large-elided
+                                {:source :runtime-flagged
+                                 :handle :report/payload-1234
+                                 :original-size 4218543
+                                 :truncated-preview "{\"rows\": [{...} ...]"}}])}
+     {:id (+ id-base 2) :op-type :event :operation :event
+      :tags (assoc tag :phase :run-start)}
+     {:id (+ id-base 3) :op-type :event :operation :event
+      :tags (assoc tag :phase :run-end :duration-ms 23)}
+     {:id (+ id-base 4) :op-type :event :operation :event/do-fx
+      :tags tag}
+     {:id (+ id-base 5) :op-type :fx :operation :rf.fx/handled
+      :tags (assoc tag :fx-id :http)}
+     {:id (+ id-base 6) :op-type :fx :operation :rf.fx/handled
+      :tags (assoc tag :fx-id :metrics)}]))
+
+(defn other-rows-buffer
+  "A buffer whose selected cascade carries non-domino rows — errors,
+  warnings, machine transitions — so the panel's `other-row` branch
+  renders."
+  []
+  (cascade-with-other 100 50))
+
+(defn long-handler-buffer
+  "A buffer of cascades whose `:run-end` rows carry a wide spread of
+  `:duration-ms` values so the panel's perf-tier dot ladder is visible
+  across the cascade list."
+  []
+  (->> [{:dispatch-id 100 :event-vec [:counter/increment] :id-base 50  :duration 1}
+        {:dispatch-id 101 :event-vec [:cart/add-item :apple] :id-base 100 :duration 6}
+        {:dispatch-id 102 :event-vec [:report/render-table] :id-base 150 :duration 22}
+        {:dispatch-id 103 :event-vec [:dashboard/refresh] :id-base 200 :duration 87}
+        {:dispatch-id 104 :event-vec [:scenario/replay] :id-base 250 :duration 312}]
+       (mapcat (fn [{:keys [dispatch-id event-vec id-base duration]}]
+                 (-> (cascade-evs dispatch-id event-vec id-base)
+                     ;; Patch the run-end emit's :duration-ms so the
+                     ;; perf-tier dot reflects the variant's intent.
+                     (update 2 update :tags assoc :duration-ms duration))))
+       vec))

--- a/tools/causa/testbeds/panel_gallery/gallery_views.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_views.cljs
@@ -1,0 +1,55 @@
+(ns panel-gallery.gallery-views
+  "Registered views referenced by Story variant `:component` slots in
+  the Causa panel gallery (rf2-1o7mp).
+
+  Story canvas resolves `:component` to a registered re-frame view via
+  `(rf/view <id>)` (per `tools/story/src/re_frame/story/ui/canvas.cljs`).
+  The variant frame-provider has already wrapped the rendered tree
+  with `[frame-provider {:frame variant-id}]`, so any subscribe inside
+  the panel resolves to the variant frame's app-db.
+
+  Each gallery component is a thin wrapper around a single Causa
+  panel's root view — it absorbs the Story-supplied args map and
+  renders the panel inside a card that sets a fixed-ish height so the
+  variants-grid layout stays visually uniform."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.event-detail :as event-detail]
+            [day8.re-frame2-causa.theme.tokens :refer [tokens]]))
+
+(def ^:private card-style
+  "Card chrome around an embedded panel — gives the variants-grid a
+  consistent visual shell with a labelled border so a reviewer can
+  spot the panel boundary."
+  {:height          "520px"
+   :width           "100%"
+   :display         "flex"
+   :flex-direction  "column"
+   :background      (:bg-1 tokens)
+   :border          (str "1px solid " (:border-default tokens))
+   :border-radius   "6px"
+   :overflow        "hidden"
+   :font-family     "system-ui, sans-serif"})
+
+(defn- event-detail-panel
+  "Embedded mount of the Causa event-detail panel for one Story
+  variant. The variant-frame provider above this tree routes
+  `:rf.causa/event-detail` and `:rf.causa/cascades` reads to the
+  variant frame's app-db, where the seed events have written the
+  `:trace-buffer` and `:selected-dispatch-id` slots."
+  [_args]
+  [:div {:style card-style
+         :data-testid "panel-gallery-event-detail-card"}
+   [event-detail/event-detail-view]])
+
+(defn register!
+  "Register every gallery view-id referenced by a variant `:component`.
+  Uses `reg-view*` (the runtime-registration surface, per Spec 004)
+  because the gallery view-ids are explicit panel-keyed keywords
+  rather than auto-derived from a defn symbol — we want
+  `:panel-gallery.event-detail/Panel` not
+  `:panel-gallery.gallery-views/event-detail-panel`. Idempotent —
+  re-registering the same id replaces the handler; subsequent calls
+  are silent at the registry."
+  []
+  (rf/reg-view* :panel-gallery.event-detail/Panel event-detail-panel)
+  nil)

--- a/tools/causa/testbeds/panel_gallery/index.html
+++ b/tools/causa/testbeds/panel_gallery/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: Causa panel gallery</title>
+  <style>
+    body { margin: 0; font-family: system-ui, sans-serif; background: #1a1d23; color: #e6e8eb; }
+    #app { min-height: 100vh; }
+    .gallery-landing { padding: 2em; max-width: 720px; margin: 0 auto; line-height: 1.5; }
+    .gallery-landing h1 { font-weight: 600; margin: 0 0 0.5em 0; }
+    .gallery-landing p { color: #a8aeb6; }
+    .gallery-landing a { color: #7c93ff; }
+    .gallery-landing code { background: #2a2e36; padding: 1px 6px; border-radius: 3px; font-size: 13px; }
+  </style>
+</head>
+<body>
+  <main id="app"></main>
+  <script src="main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Phase 1a of the Story-on-Causa visual gallery (per the v2 framing in [`ai/findings/story-on-causa-feasibility-2026-05-16.md`](https://github.com/day8/re-frame2/blob/main/ai/findings/story-on-causa-feasibility-2026-05-16.md)). Lands the shared panel-gallery testbed scaffold plus 12 event-detail variants — the first slice of an ~80-variant gallery across 8 panels.

- New testbed at `tools/causa/testbeds/panel_gallery/` (URL: `/panel-gallery/#/stories`).
- Twelve event-detail variants tagged for state-magnitude filtering — empty / cascade-list (3 / 30 / 300) / detail-{single, medium, large} / deep-cascade / redacted / large-payload / other-rows / perf-tier ladder.
- Variants seed state by firing **real Causa init events** (`:rf.causa/sync-trace-buffer`, `:rf.causa/select-dispatch-id`) into the variant frame — preserves Story's `:rf.story/*` runtime slots per [`tools/story/spec/002-Runtime.md`](https://github.com/day8/re-frame2/blob/main/tools/story/spec/002-Runtime.md) §Coexistence with hosting application state. Zero source-side changes to Causa panels.
- One workspace `:Workspace.causa.event-detail/all` enumerates all 12 variants in a `:variants-grid` two-column scroll.
- Bundle-isolation contract preserved: `tools/causa/testbeds/` is on shadow's source-paths; nothing under `implementation/` `:requires` panel-gallery; the testbed has no Causa preload (it embeds bare panels, never mounts the host's shell).

## Architecture

Each variant frame doubles as an isolated "Causa frame": the Story canvas wraps the rendered tree in `[frame-provider variant-id]`, so Causa's panel subs read from the variant frame's app-db. Variant `:events` dispatch into the same frame, seeding its `:trace-buffer` slot via the registered handler chain — no test-only override events; every variant uses production-shaped Causa init events.

## Test plan

- [x] `npm run test:cljs` — 2140 tests / 6121 assertions / 0 failures
- [x] `shadow-cljs compile testbeds/panel-gallery` — green (1 panel-gallery namespace + 4 dependency namespaces compiled)
- [x] `node tools/causa/testbeds/panel_gallery/_smoke.cjs` — Playwright-driven smoke; clicks the workspace, asserts ≥1 variant root + ≥1 panel card; observed 12/12 (full grid renders)
- [ ] Manual visual review at `/panel-gallery/#/stories` once dev server is up — `cd implementation && shadow-cljs watch testbeds/panel-gallery`, then serve `out/testbeds/panel-gallery/` and open `#/stories`. Click `Workspace.causa.event-detail/all` in the sidebar; the two-column grid renders all 12 variants.

## Bead

Closes rf2-1o7mp (mayor closes on merge per workflow). Phase 1a's scope sets the stage for Phase 1b (rf2-2uwp1 re-scope — app-db-diff + subscriptions) and Phase 2 (5 parallel-friendly beads, one per remaining panel).