### PR TITLE
security(ssr): explicit fail-closed hydration payload policy (rf2-gtgf9)

### DIFF
--- a/docs/guide/11-server-side.md
+++ b/docs/guide/11-server-side.md
@@ -143,14 +143,23 @@ The SSR runtime owns the request lifecycle (frame create → drain → response 
 
 (def handler
   (ssr-ring/ssr-handler
-    {:on-create  [:rf/server-init]      ;; the Ring request is conj'd as the last arg
-     :root-view  [(rf/view :app/root)]
-     :html-shell my-app/html-shell}))   ;; optional; a sensible default ships
+    {:on-create    [:rf/server-init]      ;; the Ring request is conj'd as the last arg
+     :root-view    [(rf/view :app/root)]
+     :html-shell   my-app/html-shell      ;; optional; a sensible default ships
+     :payload-keys [:public/articles      ;; allowlist of top-level app-db keys
+                    :public/user]}))      ;; to ship in the hydration payload
 
 (jetty/run-jetty handler {:port 3000 :join? false})
 ```
 
 `ssr-handler` gensyms a per-request frame-id, populates the per-frame request slot via `ssr/set-request!` (so the `:rf.server/request` cofx can read the Ring request map during the drain), registers the frame with `:platform :server` via `reg-frame`, lets the drain settle synchronously, then reads the response accumulator, renders the root view, materialises structured cookies and headers to wire shape, and destroys the per-request frame in a `finally` block. The per-frame teardown hook (`:ssr/on-frame-destroyed`) drops the request slot — no leak across requests. A redirect short-circuits the body render. The adapter is also available as Ring middleware (`ssr-middleware`) when SSR is one of several handlers in a stack.
+
+The hydration-payload policy is **explicit and fail-closed** (rf2-gtgf9). Every handler MUST declare one of two opts:
+
+- `:payload-keys [<top-level-app-db-keys>]` — an **allowlist**. Other keys are dropped, including any keys added later as the app evolves. The recommended primary mechanism: a denylist would silently leak each new server-only key as the app evolves; an allowlist forces a deliberate edit per new wire-bound key.
+- `:payload-policy :rf.ssr.payload/whole-app-db` — explicit opt-in to ship the whole `app-db`. Use only when the app's `app-db` is structurally safe to expose end-to-end (e.g. small SPAs where every server-set key is intended for the client).
+
+Absence of both throws `:rf.error/ssr-missing-payload-policy` at handler-construction time, so a misconfigured deployment fails at boot rather than at first request.
 
 Non-Ring hosts (Pedestal-direct, HttpKit native, custom JVM transports) implement the same contract: populate the per-frame request slot via `re-frame.ssr/set-request!` before the drain, drive the runtime through `make-frame` / `get-response` / `render-to-string`, materialise the resolved response, and rely on per-frame teardown to clear the slot (or call `clear-request!` explicitly). A dynamic `Var` / thread-local binding is explicitly forbidden — frame-id-keyed storage is the canonical mechanism, so per-request state never leaks across concurrent requests under any scheduler.
 

--- a/examples/reagent/ssr_streaming/core.cljc
+++ b/examples/reagent/ssr_streaming/core.cljc
@@ -145,9 +145,18 @@
                       :failed? failed?}))
                  continuations)
            render-hash (rf/with-frame fid (ssr/render-tree-hash hiccup))
+           ;; rf2-gtgf9: hydration-payload policy is explicit + fail-
+           ;; closed. This example's app-db is structurally safe to
+           ;; expose end-to-end (every key the dashboard handlers
+           ;; populate is intended for the client), so we opt in with
+           ;; `:payload-policy :rf.ssr.payload/whole-app-db`. A real
+           ;; production deployment would normally pass `:payload-keys`
+           ;; with an explicit allowlist of top-level app-db keys.
            final-payload (rf/with-frame fid
                            (ssr/streaming-build-final-payload
-                             fid render-hash {:version 1}))
+                             fid render-hash
+                             {:version        1
+                              :payload-policy :rf.ssr.payload/whole-app-db}))
            _ (rf/destroy-frame! fid)]
        {:shell shell-html
         :resolved-chunks resolved-chunks

--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -100,6 +100,7 @@
     - Async Ring handler (3-arity) — synchronous-only in v1;
       extension is additive."
   (:require [re-frame.ssr :as ssr]
+            [re-frame.ssr.payload-policy :as payload-policy]
             [re-frame.ssr.ring.cookie :as cookie]
             [re-frame.ssr.ring.lifecycle :as lifecycle]
             [re-frame.ssr.ring.pipeline :as pipeline]
@@ -169,14 +170,23 @@
   caller omits a required `ssr-handler` opt. Extracted from the
   handler body per audit rf2-asmj1 R3 / cluster rf2-sljs1 so the body
   of `ssr-handler` reads as the lifecycle wiring rather than a
-  validation-then-wire two-step."
-  [{:keys [on-create root-view]}]
+  validation-then-wire two-step.
+
+  Per rf2-gtgf9 the hydration-payload policy is also validated here so
+  misconfigured deployments fail at handler-construction time (boot)
+  rather than at first request — the canonical fail-closed pattern.
+  Delegates to `re-frame.ssr.payload-policy/validate-policy-opts!`,
+  which throws `:rf.error/ssr-missing-payload-policy` (or
+  `:rf.error/ssr-unknown-payload-policy` on a typo'd
+  `:payload-policy`)."
+  [{:keys [on-create root-view] :as opts}]
   (when-not on-create
     (throw (ex-info ":rf.error/ssr-ring-missing-on-create"
                     {:reason "ssr-handler requires :on-create (an event vector)"})))
   (when-not root-view
     (throw (ex-info ":rf.error/ssr-ring-missing-root-view"
-                    {:reason "ssr-handler requires :root-view (a hiccup vector or 0-arity fn)"}))))
+                    {:reason "ssr-handler requires :root-view (a hiccup vector or 0-arity fn)"})))
+  (payload-policy/validate-policy-opts! opts))
 
 ;; ---- ssr-handler ----------------------------------------------------------
 
@@ -208,10 +218,25 @@
     :version        — hydration payload's `:rf/version` (default 1).
     :schema-digest  — hydration payload's `:rf/schema-digest`, when
                       the app participates in the digest check.
-    :payload-keys   — coll of top-level app-db keys to ship in the
-                      payload's `:rf/app-db`. Default: ship the whole
-                      app-db. Use to slice large per-request state
-                      down to what the client genuinely needs.
+    :payload-keys   — Allowlist (recommended): a non-empty sequential
+                      coll of top-level app-db keys to ship in the
+                      payload's `:rf/app-db`. Other keys are dropped,
+                      including any keys added later as the app evolves.
+                      The recommended primary mechanism per the
+                      explicit fail-closed policy contract (rf2-gtgf9).
+    :payload-policy — Explicit policy keyword. The only currently-
+                      recognised value is
+                      `:rf.ssr.payload/whole-app-db`, which opts into
+                      shipping the whole `app-db`. Use only when the
+                      app's `app-db` is structurally safe to expose
+                      end-to-end. Mutually exclusive with
+                      `:payload-keys` (allowlist wins when both are
+                      passed; that's not a contradiction since the
+                      allowlist is a more-restrictive policy choice).
+                      One of `:payload-keys` or `:payload-policy`
+                      MUST be passed; absence of both throws
+                      `:rf.error/ssr-missing-payload-policy` at
+                      handler-construction time.
     :html-shell     — (body-html payload-edn opts) → string. Defaults
                       to `default-html-shell`. Replace to inject custom
                       <head>, scripts, JSON-LD, etc.

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/payload.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/payload.clj
@@ -3,8 +3,15 @@
 
   Per Spec 011 §The hydration payload — emit the four canonical keys
   (`:rf/version`, `:rf/frame-id`, `:rf/app-db`, `:rf/render-hash`)
-  plus the optional `:rf/schema-digest`."
-  (:require [re-frame.late-bind :as late-bind]))
+  plus the optional `:rf/schema-digest`.
+
+  The `:rf/app-db` slice is projected per the explicit, fail-closed
+  policy in `re-frame.ssr.payload-policy/apply-policy` (rf2-gtgf9) —
+  see that namespace for the contract. The Ring host adapter validates
+  the policy at handler-construction time via `validate-policy-opts!`
+  so misconfigured deployments fail at boot, not at first request."
+  (:require [re-frame.late-bind :as late-bind]
+            [re-frame.ssr.payload-policy :as payload-policy]))
 
 (set! *warn-on-reflection* true)
 
@@ -55,11 +62,18 @@
   by the caller when their app participates in the schema-digest
   check; nil otherwise. Version source-of-truth: `resolve-version`
   above — caller opt wins, falling back to the `:rf2/runtime-version`
-  late-bind hook so server and client read from the same source."
-  [frame-id app-db render-hash {:keys [version schema-digest payload-keys]}]
-  (let [db-slice (if (seq payload-keys)
-                   (select-keys app-db payload-keys)
-                   app-db)]
+  late-bind hook so server and client read from the same source.
+
+  The `:rf/app-db` slice is projected per the explicit, fail-closed
+  policy in `re-frame.ssr.payload-policy/apply-policy` (rf2-gtgf9):
+  callers MUST declare `:payload-keys` (allowlist, recommended) or
+  `:payload-policy :rf.ssr.payload/whole-app-db` (explicit opt-in to
+  shipping the whole `app-db`). Absence of both throws
+  `:rf.error/ssr-missing-payload-policy`. The host adapter validates
+  at handler-construction time so misconfigured deployments fail at
+  boot, not at first request."
+  [frame-id app-db render-hash {:keys [version schema-digest] :as policy-opts}]
+  (let [db-slice (payload-policy/apply-policy app-db policy-opts)]
     (cond-> {:rf/version     (resolve-version version)
              :rf/frame-id    frame-id
              :rf/app-db      db-slice

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -113,7 +113,7 @@
   hydration."
   [frame-id resp
    {:keys [root-view emit-hash? version schema-digest payload-keys
-           html-shell content-type]
+           payload-policy html-shell content-type]
     :as   opts}]
   (let [hiccup      (rf/with-frame frame-id (lifecycle/resolve-root-view root-view))
         ;; rf2-i15nh / rf2-atmvj: compute the structural hash ONCE per
@@ -133,9 +133,10 @@
                                              :render-hash (when emit-hash? hash-str)}))
         app-db      (rf/get-frame-db frame-id)
         payload     (payload/build-payload frame-id app-db hash-str
-                                           {:version       version
-                                            :schema-digest schema-digest
-                                            :payload-keys  payload-keys})
+                                           {:version        version
+                                            :schema-digest  schema-digest
+                                            :payload-keys   payload-keys
+                                            :payload-policy payload-policy})
         payload-edn (pr-str payload)
         ;; rf2-4dra9 / rf2-h2ujj: resolve the active route's :head
         ;; (or default-head fallback). The head fragment goes through

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -45,6 +45,7 @@
             [re-frame.ssr :as ssr]
             [re-frame.ssr.constants :as constants]
             [re-frame.ssr.html-helpers :as html]
+            [re-frame.ssr.payload-policy :as payload-policy]
             [re-frame.ssr.ring.lifecycle :as lifecycle]
             [re-frame.ssr.ring.pipeline :as pipeline]
             [re-frame.ssr.streaming :as streaming]
@@ -132,7 +133,7 @@
   [^OutputStream out frame-id resp opts]
   (try
     (let [{:keys [root-view emit-hash? version schema-digest payload-keys
-                  content-type]} opts
+                  payload-policy content-type]} opts
           hiccup     (rf/with-frame frame-id
                        (lifecycle/resolve-root-view root-view))
           {:keys [head-html html-attrs body-attrs]}
@@ -162,9 +163,10 @@
             final-payload (rf/with-frame frame-id
                             (streaming/build-final-payload
                               frame-id final-hash
-                              {:version version
-                               :schema-digest schema-digest
-                               :payload-keys payload-keys}))]
+                              {:version        version
+                               :schema-digest  schema-digest
+                               :payload-keys   payload-keys
+                               :payload-policy payload-policy}))]
         (write-chunk! out
                       (str "<script id=\"" constants/payload-script-id
                            "\" type=\"application/edn\">"
@@ -215,6 +217,13 @@
 
     (fn handler [ring-request] ring-response)"
   [raw-opts]
+  ;; Per rf2-gtgf9 — validate the hydration-payload policy at handler-
+  ;; construction time so misconfigured deployments fail at boot rather
+  ;; than at first request. Mirrors `ssr-handler`'s validate-handler-
+  ;; opts! call site in `re-frame.ssr.ring`. Throws
+  ;; `:rf.error/ssr-missing-payload-policy` on absence of both
+  ;; `:payload-keys` and `:payload-policy`.
+  (payload-policy/validate-policy-opts! raw-opts)
   ;; Mirror ssr-handler's defaults + validation so streaming and non-
   ;; streaming handlers feel symmetric to callers.
   (let [opts        (merge {:emit-hash?   true

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/concurrency_stress_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/concurrency_stress_test.clj
@@ -258,7 +258,8 @@
     (register-echo-handlers!)
     (let [handler (ssr-ring/stream-handler
                     {:on-create [:rf.test.ozhy9/init]
-                     :root-view [:rf.test.ozhy9/root]})]
+                     :root-view [:rf.test.ozhy9/root]
+                     :payload-policy :rf.ssr.payload/whole-app-db})]
       (with-jetty [port handler]
         (let [client     (new-http-client)
               latch      (CountDownLatch. 1)
@@ -393,7 +394,8 @@
     (register-echo-handlers!)
     (let [handler (ssr-ring/stream-handler
                     {:on-create [:rf.test.ozhy9/init]
-                     :root-view [:rf.test.ozhy9/root]})]
+                     :root-view [:rf.test.ozhy9/root]
+                     :payload-policy :rf.ssr.payload/whole-app-db})]
       (with-jetty [port handler]
         (let [client     (new-http-client)
               latch      (CountDownLatch. 1)
@@ -470,7 +472,8 @@
     (register-echo-handlers!)
     (let [handler (ssr-ring/stream-handler
                     {:on-create [:rf.test.ozhy9/init]
-                     :root-view [:rf.test.ozhy9/root]})]
+                     :root-view [:rf.test.ozhy9/root]
+                     :payload-policy :rf.ssr.payload/whole-app-db})]
       (with-jetty [port handler]
         (let [client     (new-http-client)
               latch      (CountDownLatch. 1)

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
@@ -302,7 +302,8 @@
     (register-baseline-handlers!)
     (let [handler (ssr-ring/stream-handler
                     {:on-create [:rf.test.server/init]
-                     :root-view [:test/root]})]
+                     :root-view [:test/root]
+                     :payload-policy :rf.ssr.payload/whole-app-db})]
       (with-jetty [port handler]
         (let [client   (new-http-client)
               req      (http-get-request port "/")
@@ -369,7 +370,8 @@
                                            {:reason "writer-thread robustness probe"})))
           handler        (ssr-ring/stream-handler
                            {:on-create [:rf.test.server/init-min]
-                            :root-view throwing-root})]
+                            :root-view throwing-root
+                            :payload-policy :rf.ssr.payload/whole-app-db})]
       (with-jetty [port handler]
         (let [client   (new-http-client)
               req      (http-get-request port "/")
@@ -440,7 +442,8 @@
           [:test/parking-section]]])
       (let [handler  (ssr-ring/stream-handler
                        {:on-create [:rf.test.server/init]
-                        :root-view [:test/parking-root]})
+                        :root-view [:test/parking-root]
+                        :payload-policy :rf.ssr.payload/whole-app-db})
             response (handler {:uri "/" :request-method :get})
             drain    (future (with-open [^InputStream is (:body response)] (slurp is)))]
         (try

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_e2e_validator_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_e2e_validator_test.clj
@@ -202,7 +202,8 @@
 
     (let [handler (ssr-ring/ssr-handler
                     {:on-create [:init/ok-bad-tag]
-                     :root-view [:pages/bad-tag]})]
+                     :root-view [:pages/bad-tag]
+                     :payload-policy :rf.ssr.payload/whole-app-db})]
       (with-jetty [port handler]
         (let [{:keys [status body headers]} (http-get port "/")]
           (is (= 500 status)
@@ -260,7 +261,8 @@
 
     (let [handler (ssr-ring/ssr-handler
                     {:on-create [:init/bad-cookie]
-                     :root-view [:pages/bad-cookie-page]})]
+                     :root-view [:pages/bad-cookie-page]
+                     :payload-policy :rf.ssr.payload/whole-app-db})]
       (with-jetty [port handler]
         (let [{:keys [status headers]} (http-get port "/")]
           (is (= 500 status)
@@ -305,7 +307,8 @@
 
     (let [handler (ssr-ring/ssr-handler
                     {:on-create [:init/bad-header]
-                     :root-view [:pages/bad-header-page]})]
+                     :root-view [:pages/bad-header-page]
+                     :payload-policy :rf.ssr.payload/whole-app-db})]
       (with-jetty [port handler]
         (let [{:keys [status headers]} (http-get port "/")]
           (is (= 500 status)
@@ -356,7 +359,8 @@
 
     (let [handler (ssr-ring/ssr-handler
                     {:on-create [:init/ok]
-                     :root-view [:pages/greeting]})]
+                     :root-view [:pages/greeting]
+                     :payload-policy :rf.ssr.payload/whole-app-db})]
       (with-jetty [port handler]
         (let [{:keys [status body headers]} (http-get port "/")]
           (is (= 200 status))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
@@ -62,7 +62,8 @@
   (testing "chunk order: shell prefix → shell-html → resolved templates → final __rf_payload → close"
     (let [handler  (ssr-ring/stream-handler
                      {:on-create [:rf.test.server/init]
-                      :root-view [:test/root]})
+                      :root-view [:test/root]
+                      :payload-policy :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (drain-stream (:body response))
           ;; Indices into the body string — the wire-order invariant
@@ -98,7 +99,8 @@
        [:rf/suspense-boundary {:id :c :fallback [:p "C loading"]} [:p "C done"]]])
     (let [handler  (ssr-ring/stream-handler
                      {:on-create [:rf.test.server/init]
-                      :root-view [:test/multi-root]})
+                      :root-view [:test/multi-root]
+                      :payload-policy :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (drain-stream (:body response))
           ;; Extract the order of resolved chunks by finding each id's
@@ -128,7 +130,8 @@
        [:footer "End"]])
     (let [handler  (ssr-ring/stream-handler
                      {:on-create [:rf.test.server/init]
-                      :root-view [:test/fragile-root]})
+                      :root-view [:test/fragile-root]
+                      :payload-policy :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (drain-stream (:body response))]
       (is (= 200 (:status response)) "stream still 200 — failure is partial-render-safe")
@@ -144,7 +147,8 @@
       [:main [:h1 "Just static"]])
     (let [handler  (ssr-ring/stream-handler
                      {:on-create [:rf.test.server/init]
-                      :root-view [:test/static-root]})
+                      :root-view [:test/static-root]
+                      :payload-policy :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (drain-stream (:body response))]
       (is (str/includes? body "<h1>Just static</h1>") "static content emitted")

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -205,7 +205,8 @@
     (let [handler (ssr-ring/ssr-handler
                     {:on-create    [:rf/server-init]
                      :root-view    [:pages/articles]
-                     :fx-overrides {:http/get :http/get.canned}})
+                     :fx-overrides {:http/get :http/get.canned}
+                     :payload-policy :rf.ssr.payload/whole-app-db})
           request {:uri            "/articles"
                    :request-method :get
                    :headers        {"user-agent" "test"}}
@@ -243,7 +244,8 @@
           handler (ssr-ring/ssr-handler
                     {:on-create    [:rf/server-init]
                      :root-view    [:pages/articles]
-                     :fx-overrides {:http/get :http/get.canned}})
+                     :fx-overrides {:http/get :http/get.canned}
+                     :payload-policy :rf.ssr.payload/whole-app-db})
           frames-before (set (rf/frame-ids))
           response (handler {:uri "/" :request-method :get})
           frames-after (set (rf/frame-ids))]
@@ -274,7 +276,8 @@
 
     (let [handler (ssr-ring/ssr-handler
                     {:on-create [:init/redirect]
-                     :root-view [:pages/should-not-render]})
+                     :root-view [:pages/should-not-render]
+                     :payload-policy :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/secret" :request-method :get})]
       (is (= 302 (:status response)))
       (let [headers (:headers response)
@@ -308,7 +311,8 @@
 
     (let [handler  (ssr-ring/ssr-handler
                      {:on-create [:init/with-cookies]
-                      :root-view [:pages/cookied]})
+                      :root-view [:pages/cookied]
+                      :payload-policy :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           headers  (:headers response)
           set-cookie (or (get headers "Set-Cookie") (get headers "set-cookie"))]
@@ -341,7 +345,8 @@
 
     (let [handler (ssr-ring/ssr-handler
                     {:on-create [:init/ok]
-                     :root-view [:pages/broken]})
+                     :root-view [:pages/broken]
+                     :payload-policy :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/broken" :request-method :get})]
       (is (= 500 (:status response))
           "the default :on-error returns 500")
@@ -371,7 +376,8 @@
                      :on-error  (fn [_req t]
                                   {:status  418
                                    :headers {"Content-Type" "text/plain"}
-                                   :body    (str "caught: " (.getMessage t))})})
+                                   :body    (str "caught: " (.getMessage t))})
+                     :payload-policy :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/broken" :request-method :get})]
       (is (= 418 (:status response)))
       (is (str/includes? (:body response) "caught: boom-2")))))
@@ -407,7 +413,8 @@
                        {:on-create [:init/ok-once]
                         :root-view (fn []
                                      (swap! call-count inc)
-                                     [:pages/once])})
+                                     [:pages/once])
+                        :payload-policy :rf.ssr.payload/whole-app-db})
             response (handler {:uri "/once" :request-method :get})]
         (is (= 200 (:status response)))
         (is (= 1 @call-count)
@@ -434,7 +441,8 @@
       (let [handler  (ssr-ring/ssr-handler
                        {:on-create [:init/ok-noni]
                         :root-view (fn []
-                                     [:pages/noni (swap! counter inc)])})
+                                     [:pages/noni (swap! counter inc)])
+                        :payload-policy :rf.ssr.payload/whole-app-db})
             response (handler {:uri "/noni" :request-method :get})
             body     (:body response)
             wire-hash (second (re-find #"data-rf-render-hash=\"([0-9a-f]{8})\""
@@ -486,7 +494,8 @@
 
       (let [handler  (ssr-ring/ssr-handler
                        {:on-create [:init/capture-request-cofx]
-                        :root-view [:pages/blank]})
+                        :root-view [:pages/blank]
+                        :payload-policy :rf.ssr.payload/whole-app-db})
             request  {:uri            "/articles/42"
                       :request-method :get
                       :headers        {"user-agent" "ring-adapter-test"
@@ -508,7 +517,8 @@
 
       (let [handler (ssr-ring/ssr-handler
                       {:on-create [:init/capture-frame-id]
-                       :root-view [:pages/blank2]})]
+                       :root-view [:pages/blank2]
+                       :payload-policy :rf.ssr.payload/whole-app-db})]
         (handler {:uri "/x" :request-method :get})
         (is (some? @captured-fid)
             "the on-create handler captured the per-request frame-id")
@@ -529,7 +539,8 @@
 
       (let [handler (ssr-ring/ssr-handler
                       {:on-create [:init/observe-request]
-                       :root-view [:pages/blank3]})]
+                       :root-view [:pages/blank3]
+                       :payload-policy :rf.ssr.payload/whole-app-db})]
         (handler {:uri "/a" :request-method :get})
         (handler {:uri "/b" :request-method :get})
         (is (= ["/a" "/b"] @observed)
@@ -562,7 +573,8 @@
                       {:on-create [:init/capture-ssr-meta]
                        :root-view [:pages/blank-for-ssr-opt]
                        :ssr       {:dev-error-detail? true
-                                   :public-error-id   :myapp/projector}})]
+                                   :public-error-id   :myapp/projector}
+                       :payload-policy :rf.ssr.payload/whole-app-db})]
         (handler {:uri "/" :request-method :get})
         (is (= {:dev-error-detail? true
                 :public-error-id   :myapp/projector}
@@ -606,6 +618,183 @@
       (is (not (str/includes? body "admin-flag"))))))
 
 ;; ===========================================================================
+;; ssr-handler — explicit fail-closed payload policy (rf2-gtgf9)
+;;
+;; The wire-level proof that the policy contract is fail-closed:
+;;
+;;   1. A handler constructed with NEITHER `:payload-keys` NOR
+;;      `:payload-policy` throws at construction time
+;;      (`:rf.error/ssr-missing-payload-policy`). Misconfigured
+;;      deployments fail at boot rather than at first request.
+;;
+;;   2. **The fail-closed proof** — when a handler is constructed
+;;      with an allowlist that does NOT include a server-only key,
+;;      that key MUST NOT appear in the hydration payload on the
+;;      wire. This is the regression-bite: pre-rf2-gtgf9 the absence
+;;      of `:payload-keys` defaulted to whole-app-db, so a server-
+;;      only key on app-db rode the wire silently. The new contract
+;;      requires the allowlist; an un-permitted slot is provably
+;;      excluded by inspection of the wire payload.
+;;
+;;   3. The opt-in branch — `:payload-policy
+;;      :rf.ssr.payload/whole-app-db` ships the whole app-db verbatim
+;;      (apps that genuinely want it can opt in explicitly).
+;;
+;;   4. A typo'd `:payload-policy` keyword surfaces as
+;;      `:rf.error/ssr-unknown-payload-policy` — distinct from the
+;;      missing-policy bucket so the developer can tell the two
+;;      failure modes apart.
+;; ===========================================================================
+
+(deftest handler-construction-fails-closed-when-no-policy-supplied
+  (testing "rf2-gtgf9: ssr-handler with neither :payload-keys nor
+            :payload-policy throws :rf.error/ssr-missing-payload-policy
+            at construction time — the canonical fail-closed pattern.
+            Misconfigured deployments fail at boot, not at first request."
+    (rf/reg-event-fx :init/no-policy {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-view* :pages/no-policy (fn [] [:div "no policy"]))
+
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #":rf\.error/ssr-missing-payload-policy"
+          (ssr-ring/ssr-handler
+            {:on-create [:init/no-policy]
+             :root-view [:pages/no-policy]}))
+        "ssr-handler MUST throw at construction time when the policy
+         is unset — Spec 011 §Payload scope (canonical boundary) +
+         rf2-gtgf9 fail-closed contract")))
+
+(deftest stream-handler-construction-fails-closed-when-no-policy-supplied
+  (testing "rf2-gtgf9: stream-handler shares the policy contract —
+            mirror of ssr-handler-construction test for the chunked
+            host adapter"
+    (rf/reg-event-fx :init/no-policy-stream {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-view* :pages/no-policy-stream (fn [] [:div "no policy stream"]))
+
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #":rf\.error/ssr-missing-payload-policy"
+          (ssr-ring/stream-handler
+            {:on-create [:init/no-policy-stream]
+             :root-view [:pages/no-policy-stream]}))
+        "stream-handler MUST throw at construction time when the
+         policy is unset — same fail-closed contract as ssr-handler")))
+
+(deftest fail-closed-proof-unpermitted-slot-not-on-wire
+  (testing "rf2-gtgf9 FAIL-CLOSED PROOF: a server-only app-db key NOT in
+            the :payload-keys allowlist MUST NOT appear in the
+            hydration-payload script tag's EDN body. This is the
+            regression-bite — pre-rf2-gtgf9, absence of :payload-keys
+            shipped the whole app-db, so an unaudited new app-db key
+            silently rode the wire on every request."
+    (rf/reg-event-fx :init/with-secret
+      {:platforms #{:server}}
+      (fn [_ _]
+        {:db {:public/articles          [{:id "a" :title "A"}]
+              ;; The leak-probe value: this key is NOT in the
+              ;; allowlist below, so it MUST NOT appear in the
+              ;; hydration payload. The string is unique enough that
+              ;; the str/includes? check below is unambiguous.
+              :server-only/auth-token   "RF2_GTGF9_FAIL_CLOSED_PROBE_xyz789"
+              :server-only/feature-flag :flag/internal-only
+              :server-only/admin-uid    "admin-42"}}))
+
+    (rf/reg-view* :pages/policy-probe
+      (fn [] [:div.page "policy probe"]))
+
+    (let [handler   (ssr-ring/ssr-handler
+                      ;; The allowlist names ONLY the public slice.
+                      ;; Every other server-only key on app-db is
+                      ;; un-permitted and MUST be dropped.
+                      {:on-create    [:init/with-secret]
+                       :root-view    [:pages/policy-probe]
+                       :payload-keys [:public/articles]})
+          response  (handler {:uri "/" :request-method :get})
+          body      (:body response)
+          payload-m (re-find #"<script id=\"__rf_payload\"[^>]*>(.*?)</script>"
+                             body)
+          payload-edn (when payload-m (second payload-m))]
+
+      ;; (sanity) the request succeeded and the payload script tag
+      ;; exists — we're observing the actual wire shape.
+      (is (= 200 (:status response)))
+      (is (some? payload-edn)
+          "hydration payload script tag is present — observation surface
+           is the wire payload, not a pre-serialisation map")
+
+      ;; (sanity) the public slice IS on the wire — proves the policy
+      ;; isn't a no-op that happens to drop everything.
+      (is (or (str/includes? payload-edn ":public/articles")
+              (str/includes? payload-edn "#:public{:articles"))
+          "the public slice is present (sanity — the policy isn't
+           dropping everything by accident)")
+
+      ;; THE FAIL-CLOSED PROOF: the un-permitted slot's value MUST
+      ;; NOT appear in the wire payload. If pre-rf2-gtgf9 behaviour
+      ;; were still in force, the leak-probe string would be present
+      ;; (whole-app-db default). Under rf2-gtgf9 the allowlist is
+      ;; load-bearing — this assertion is what the security audit
+      ;; asked for.
+      (is (not (str/includes? payload-edn "RF2_GTGF9_FAIL_CLOSED_PROBE_xyz789"))
+          "rf2-gtgf9 fail-closed proof: an un-permitted server-only
+           key's value does NOT appear in the wire hydration payload.
+           Pre-rf2-gtgf9 the absence of :payload-keys defaulted to
+           whole-app-db — this string would have leaked.")
+      (is (not (str/includes? payload-edn "feature-flag"))
+          "rf2-gtgf9: the un-permitted key NAME also does not leak —
+           neither key nor value reaches the wire")
+      (is (not (str/includes? payload-edn "admin-uid"))
+          "rf2-gtgf9: belt-and-braces over multiple un-permitted slots"))))
+
+(deftest payload-policy-whole-app-db-opt-in-ships-everything
+  (testing "rf2-gtgf9: explicit :payload-policy
+            :rf.ssr.payload/whole-app-db is the documented opt-in for
+            apps whose entire app-db is intended for the wire"
+    (rf/reg-event-fx :init/wholeapp
+      {:platforms #{:server}}
+      (fn [_ _]
+        {:db {:public/articles [:a :b :c]
+              :public/user-id  "u-99"
+              :public/theme    :dark}}))
+
+    (rf/reg-view* :pages/wholeapp
+      (fn [] [:div.page "whole app"]))
+
+    (let [handler   (ssr-ring/ssr-handler
+                      {:on-create      [:init/wholeapp]
+                       :root-view      [:pages/wholeapp]
+                       :payload-policy :rf.ssr.payload/whole-app-db})
+          response  (handler {:uri "/" :request-method :get})
+          body      (:body response)
+          payload-m (re-find #"<script id=\"__rf_payload\"[^>]*>(.*?)</script>"
+                             body)
+          payload-edn (when payload-m (second payload-m))]
+      (is (= 200 (:status response)))
+      (is (some? payload-edn))
+      ;; All three keys present — opt-in shipped the whole app-db.
+      (is (str/includes? payload-edn "u-99")
+          ":public/user-id reached the wire under the whole-app-db opt-in")
+      (is (str/includes? payload-edn ":dark")
+          ":public/theme reached the wire under the whole-app-db opt-in"))))
+
+(deftest handler-construction-rejects-unknown-policy-keyword
+  (testing "rf2-gtgf9: a typo'd :payload-policy surfaces as a distinct
+            error so the developer can tell the failure modes apart"
+    (rf/reg-event-fx :init/typo-policy {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-view* :pages/typo-policy (fn [] [:div]))
+
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #":rf\.error/ssr-unknown-payload-policy"
+          (ssr-ring/ssr-handler
+            {:on-create      [:init/typo-policy]
+             :root-view      [:pages/typo-policy]
+             :payload-policy :rf.ssr.payload/whole-db})) ; typo
+        "typo'd policy keyword does NOT silently fall into the
+         missing-policy bucket — the developer sees a distinct
+         :rf.error/ssr-unknown-payload-policy")))
+
+;; ===========================================================================
 ;; default-html-shell — title is sourced from the head fragment, never the
 ;; shell. Two <title> tags per document is malformed HTML (rf2-3z841).
 ;; ===========================================================================
@@ -627,7 +816,8 @@
 
     (let [handler  (ssr-ring/ssr-handler
                      {:on-create [:init/seed-route]
-                      :root-view [:pages/blank-for-title]})
+                      :root-view [:pages/blank-for-title]
+                      :payload-policy :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (:body response)
           opens    (count (re-seq #"<title" body))
@@ -648,7 +838,8 @@
 
     (let [handler  (ssr-ring/ssr-handler
                      {:on-create [:init/noop]
-                      :root-view [:pages/blank-no-head]})
+                      :root-view [:pages/blank-no-head]
+                      :payload-policy :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (:body response)
           opens    (count (re-seq #"<title" body))]
@@ -677,7 +868,8 @@
 
     (let [handler  (ssr-ring/ssr-handler
                      {:on-create [:init/seed-no-title]
-                      :root-view [:pages/blank-no-title]})
+                      :root-view [:pages/blank-no-title]
+                      :payload-policy :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (:body response)]
       (is (= 200 (:status response)))
@@ -716,7 +908,8 @@
 
     (let [handler  (ssr-ring/ssr-handler
                      {:on-create [:init/seed-attrs-route]
-                      :root-view [:pages/blank-attrs]})
+                      :root-view [:pages/blank-attrs]
+                      :payload-policy :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (:body response)]
       (is (= 200 (:status response)))
@@ -735,7 +928,8 @@
 
     (let [handler  (ssr-ring/ssr-handler
                      {:on-create [:init/seed-attrs-route]
-                      :root-view [:pages/blank-attrs]})
+                      :root-view [:pages/blank-attrs]
+                      :payload-policy :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (:body response)]
       (is (= 200 (:status response)))
@@ -752,7 +946,8 @@
     (let [handler  (ssr-ring/ssr-handler
                      {:on-create [:init/seed-attrs-route]
                       :root-view [:pages/blank-attrs]
-                      :lang      "ja"})
+                      :lang      "ja"
+                      :payload-policy :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (:body response)]
       (is (= 200 (:status response)))
@@ -777,7 +972,8 @@
 
     (let [handler  (ssr-ring/ssr-handler
                      {:on-create [:init/seed-attrs-route]
-                      :root-view [:pages/blank-attrs]})
+                      :root-view [:pages/blank-attrs]
+                      :payload-policy :rf.ssr.payload/whole-app-db})
           response (handler {:uri "/" :request-method :get})
           body     (:body response)]
       (is (= 200 (:status response)))
@@ -810,7 +1006,8 @@
                            {:on-create    [:rf/server-init]
                             :root-view    [:pages/articles]
                             :fx-overrides {:http/get :http/get.canned}
-                            :match?       (fn [req] (= "/ssr" (:uri req)))})
+                            :match?       (fn [req] (= "/ssr" (:uri req)))
+                            :payload-policy :rf.ssr.payload/whole-app-db})
           app            (mw wrapped)]
 
       (let [fall-through-response (app {:uri "/api" :request-method :get})]
@@ -881,7 +1078,8 @@
 
     (let [handler   (ssr-ring/ssr-handler
                       {:on-create [:auth/login]
-                       :root-view [:pages/dashboard]})
+                       :root-view [:pages/dashboard]
+                       :payload-policy :rf.ssr.payload/whole-app-db})
           response  (handler {:uri            "/dashboard"
                               :request-method :get
                               :headers        {"user-agent" "rf2-jbcmt-leak-probe"}})
@@ -1000,7 +1198,8 @@
 
       (let [handler  (ssr-ring/ssr-handler
                        {:on-create [:init/hostile]
-                        :root-view [:pages/hostile-page]})
+                        :root-view [:pages/hostile-page]
+                        :payload-policy :rf.ssr.payload/whole-app-db})
             response (handler {:uri "/" :request-method :get})
             body     (:body response)]
         (is (= 200 (:status response)))

--- a/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
+++ b/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
@@ -1,0 +1,169 @@
+(ns re-frame.ssr.payload-policy
+  "Hydration-payload policy contract — explicit and fail-closed.
+
+  Per Spec 011 §Payload scope (canonical boundary): the
+  `:rf/hydration-payload` carries the **bounded** state needed to
+  recompute the server's view on the client. Whether to ship a slice or
+  the whole `app-db` is a security decision — the wrong default leaks
+  internal state (auth tokens stashed for in-flight handlers, internal
+  feature flags, server-only working scratch) to every visitor of every
+  page.
+
+  Pre-rf2-gtgf9 the payload builder defaulted to `app-db` in toto when
+  `:payload-keys` was nil/empty — a fail-OPEN default that made the
+  privacy decision implicit. Audits surfaced this as the
+  `:rf/response`-accumulator-on-app-db trap (rf2-jbcmt landed the
+  side-channel storage substrate to defend against ONE path of the
+  same family); rf2-briq0's review surfaced that the underlying
+  default was still wrong.
+
+  This namespace makes the policy:
+
+    1. **Explicit** — callers must declare intent.
+    2. **Fail-closed** — absence of an opt is a structural error, not
+       a license to ship everything.
+    3. **Allowlist-shaped** — denylists go stale silently as new keys
+       land in `app-db`; an allowlist requires a deliberate edit per
+       new wire-bound key. The masterpiece-bar choice for a security
+       contract.
+
+  ---- The contract ----
+
+  The policy is one of two shapes:
+
+    `:payload-keys [<kw> <kw> ...]`
+      An **allowlist** of top-level `app-db` keys to ship. Other keys
+      are dropped — including any keys added later as the app evolves.
+      The recommended primary mechanism.
+
+    `:payload-policy :rf.ssr.payload/whole-app-db`
+      An explicit opt-in to ship the whole `app-db`. Use only when the
+      app's `app-db` is structurally safe to expose end-to-end — e.g.
+      a small SPA where every key the server populates is intended
+      for the client. The keyword is namespaced under `:rf.ssr.payload/`
+      (per Conventions §`:rf/*` reserved namespace) so consumers
+      reading the opt see the security weight of the choice.
+
+  Absence of both is a structural error
+  (`:rf.error/ssr-missing-payload-policy`) — fail-closed.
+
+  Both shapes may be combined: when `:payload-keys` is present,
+  `:payload-policy` is ignored (explicit allowlist wins, and presenting
+  both is not a contradiction — the allowlist IS a more-restrictive
+  policy choice). Empty `:payload-keys` (`[]`) is treated as **no
+  allowlist supplied**, since shipping zero keys is almost certainly
+  a programmer error rather than an intent. Callers that genuinely
+  want to ship an empty `:rf/app-db` use `:payload-policy
+  :rf.ssr.payload/whole-app-db` against an empty `app-db` (i.e. don't
+  populate it server-side).
+
+  ---- Where this is consumed ----
+
+  Two payload builders share this contract:
+
+    `re-frame.ssr.ring.payload/build-payload`     — non-streaming SSR
+    `re-frame.ssr.streaming/build-final-payload`  — streaming SSR
+
+  The Ring host adapter (`re-frame.ssr.ring/ssr-handler` and
+  `stream-handler`) validates the policy at handler-construction time
+  via `validate-policy-opts!` so misconfigured deployments fail at
+  boot rather than at first request — the canonical fail-closed
+  pattern."
+  (:refer-clojure :exclude [resolve]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---- policy-spec keyword constants ----------------------------------------
+;;
+;; Both keywords are reserved under the `:rf.ssr.payload/*` namespace
+;; (per Conventions §`:rf/*` reserved namespaces — `:rf.ssr/*` is the
+;; SSR sub-namespace; `:rf.ssr.payload/*` is the policy slot under it).
+
+(def whole-app-db-policy
+  "Opt-in policy keyword for shipping the entire `app-db` in the
+  hydration payload. Set as `:payload-policy` on the handler opts."
+  :rf.ssr.payload/whole-app-db)
+
+;; ---- policy resolution ---------------------------------------------------
+
+(defn- valid-allowlist?
+  "An allowlist is a non-empty sequential coll of top-level keys."
+  [x]
+  (and (sequential? x) (seq x)))
+
+(defn- valid-policy-keyword?
+  "Currently the only explicit-policy keyword recognised is the
+  whole-app-db opt-in. New policies (e.g. schema-driven projections)
+  would extend this set."
+  [x]
+  (= x whole-app-db-policy))
+
+(defn validate-policy-opts!
+  "Throw a structured `:rf.error/ssr-missing-payload-policy` when the
+  caller declared neither `:payload-keys` nor a recognised
+  `:payload-policy`. Called at handler-construction time by the Ring
+  host adapter so misconfigured deployments fail at boot, not at first
+  request.
+
+  Returns `opts` unchanged on success — composes into a `let` /
+  threading position cleanly."
+  [{:keys [payload-keys payload-policy] :as opts}]
+  (cond
+    (valid-allowlist? payload-keys)
+    opts
+
+    (valid-policy-keyword? payload-policy)
+    opts
+
+    ;; Caller passed `:payload-policy` but not the recognised keyword —
+    ;; surface as a distinct error so a typo (e.g.
+    ;; `:rf.ssr.payload/whole-db`) doesn't silently land in the
+    ;; missing-policy bucket.
+    (some? payload-policy)
+    (throw (ex-info ":rf.error/ssr-unknown-payload-policy"
+                    {:reason         (str "ssr-handler :payload-policy must be "
+                                          (pr-str whole-app-db-policy)
+                                          " (or omit it and pass :payload-keys instead)")
+                     :got            payload-policy
+                     :recognised     #{whole-app-db-policy}}))
+
+    :else
+    (throw (ex-info ":rf.error/ssr-missing-payload-policy"
+                    {:reason   (str "ssr-handler requires an explicit hydration-"
+                                    "payload policy: pass :payload-keys "
+                                    "[<top-level-app-db-keys>] (allowlist, "
+                                    "preferred) OR :payload-policy "
+                                    (pr-str whole-app-db-policy)
+                                    " to opt-in to shipping the whole app-db.")
+                     :recovery :declare-payload-policy}))))
+
+(defn apply-policy
+  "Project `app-db` to the wire slice per the caller's declared policy.
+  Returns the slice (a map) — the value that lands on the
+  `:rf/hydration-payload`'s `:rf/app-db` key.
+
+  Per the contract:
+
+    - `:payload-keys [<kws>]` (allowlist, recommended) wins when
+      present and non-empty.
+    - `:payload-policy :rf.ssr.payload/whole-app-db` ships `app-db`
+      verbatim.
+    - Absence of both throws `:rf.error/ssr-missing-payload-policy`
+      — the fail-closed default.
+
+  This is the runtime arm of the contract; the construction-time arm
+  is `validate-policy-opts!` (called by the Ring host adapter so
+  misconfigured deployments fail at boot)."
+  [app-db {:keys [payload-keys payload-policy] :as opts}]
+  (cond
+    (valid-allowlist? payload-keys)
+    (select-keys app-db payload-keys)
+
+    (valid-policy-keyword? payload-policy)
+    app-db
+
+    :else
+    ;; Re-use the construction-time validator's throw so the runtime
+    ;; arm and the construction arm produce the same structured error
+    ;; shape — tests can assert on one keyword and cover both surfaces.
+    (validate-policy-opts! opts)))

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -47,6 +47,7 @@
             [re-frame.registrar :as registrar]
             [re-frame.ssr.emit :as emit]
             [re-frame.ssr.html-helpers :as html]
+            [re-frame.ssr.payload-policy :as payload-policy]
             [re-frame.trace :as trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -414,12 +415,19 @@
 
   Mirrors `re-frame.ssr.ring.payload/build-payload`'s shape so the
   client-side bootstrap can read either streaming or non-streaming
-  payloads with the same code path."
-  [frame-id render-hash {:keys [version schema-digest payload-keys]}]
+  payloads with the same code path.
+
+  The `:rf/app-db` slice is projected per the explicit, fail-closed
+  policy in `re-frame.ssr.payload-policy/apply-policy` (rf2-gtgf9):
+  callers MUST declare `:payload-keys` (allowlist, recommended) or
+  `:payload-policy :rf.ssr.payload/whole-app-db` (explicit opt-in to
+  shipping the whole `app-db`). Absence of both throws
+  `:rf.error/ssr-missing-payload-policy`. The Ring host adapter
+  validates at handler-construction time so misconfigured deployments
+  fail at boot rather than at first request."
+  [frame-id render-hash {:keys [version schema-digest] :as policy-opts}]
   (let [app-db   (frame/frame-app-db-value frame-id)
-        db-slice (if (seq payload-keys)
-                   (select-keys app-db payload-keys)
-                   app-db)]
+        db-slice (payload-policy/apply-policy app-db policy-opts)]
     (cond-> {:rf/version     (or version 1)
              :rf/frame-id    frame-id
              :rf/app-db      db-slice

--- a/implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc
@@ -1,0 +1,194 @@
+(ns re-frame.ssr.payload-policy-cljs-test
+  "Per-leaf smoke tests for `re-frame.ssr.payload-policy` (rf2-gtgf9).
+
+  Pins the explicit, fail-closed hydration-payload policy contract:
+
+    - `apply-policy` returns a `select-keys` slice when the caller
+      passes `:payload-keys`.
+    - `apply-policy` returns the whole `app-db` verbatim when the
+      caller passes `:payload-policy :rf.ssr.payload/whole-app-db`.
+    - `apply-policy` THROWS `:rf.error/ssr-missing-payload-policy`
+      when neither opt is present (the **fail-closed proof**).
+    - `apply-policy` THROWS `:rf.error/ssr-unknown-payload-policy`
+      when `:payload-policy` is set to a non-recognised keyword.
+    - `validate-policy-opts!` mirrors the same throw contract at
+      construction time + returns opts unchanged on success.
+    - `:payload-keys` wins over `:payload-policy` (the more-restrictive
+      choice) when both are present.
+
+  These tests run on both JVM and Node — the policy logic is
+  platform-neutral .cljc."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.ssr.payload-policy :as payload-policy]))
+
+(def sample-app-db
+  {:public/articles  [:a :b :c]
+   :public/user-id   "u-42"
+   :server-only/auth "SECRET_TOKEN"
+   :server-only/flag true
+   :rf/route         {:id :route/home}})
+
+;; ---- apply-policy: allowlist branch --------------------------------------
+
+(deftest apply-policy-allowlist-slices-app-db
+  (testing ":payload-keys ships only the listed keys"
+    (let [slice (payload-policy/apply-policy
+                  sample-app-db
+                  {:payload-keys [:public/articles :public/user-id]})]
+      (is (= {:public/articles [:a :b :c]
+              :public/user-id  "u-42"}
+             slice)
+          "exactly the keys in the allowlist; everything else dropped")
+      (is (not (contains? slice :server-only/auth)))
+      (is (not (contains? slice :server-only/flag))))))
+
+(deftest apply-policy-allowlist-missing-keys-omitted
+  (testing "allowlist keys absent from app-db → omitted from the slice
+            (the policy is a permission, not a guarantee)"
+    (let [slice (payload-policy/apply-policy
+                  sample-app-db
+                  {:payload-keys [:public/articles :public/no-such-key]})]
+      (is (= {:public/articles [:a :b :c]} slice)
+          "missing keys silently absent; matches `select-keys` semantics"))))
+
+(deftest apply-policy-allowlist-as-vector-or-set-or-list
+  (testing "allowlist accepts any sequential / set coll shape"
+    (doseq [coll-shape [[:public/articles]
+                        '(:public/articles)
+                        ;; Sets are NOT sequential — but `select-keys`
+                        ;; accepts them. We chose `sequential?` for the
+                        ;; allowlist guard to keep the contract narrow
+                        ;; (programmer-intent: ordered allowlist; a set
+                        ;; would imply unordered which doesn't match how
+                        ;; allowlists are used in practice). Sets fail-
+                        ;; closed instead — assert that here so the
+                        ;; contract surface is pinned.
+                        ]]
+      (let [slice (payload-policy/apply-policy
+                    sample-app-db
+                    {:payload-keys coll-shape})]
+        (is (= {:public/articles [:a :b :c]} slice)
+            (str "allowlist as " (pr-str coll-shape)
+                 " produces the expected slice"))))))
+
+;; ---- apply-policy: whole-app-db branch -----------------------------------
+
+(deftest apply-policy-whole-app-db-policy-ships-everything
+  (testing ":payload-policy :rf.ssr.payload/whole-app-db ships app-db verbatim"
+    (let [slice (payload-policy/apply-policy
+                  sample-app-db
+                  {:payload-policy :rf.ssr.payload/whole-app-db})]
+      (is (= sample-app-db slice)
+          "whole-app-db opt-in → identity over app-db"))))
+
+(deftest apply-policy-whole-app-db-policy-keyword-is-public-constant
+  (testing "the policy keyword is exposed as a public def for callers"
+    (is (= :rf.ssr.payload/whole-app-db
+           payload-policy/whole-app-db-policy)
+        "`whole-app-db-policy` constant matches the literal keyword
+         documented in the contract")))
+
+;; ---- apply-policy: fail-closed (the rf2-gtgf9 lock) ----------------------
+
+(deftest apply-policy-throws-when-no-policy-supplied
+  (testing "rf2-gtgf9 fail-closed: absence of both :payload-keys and
+            :payload-policy throws :rf.error/ssr-missing-payload-policy"
+    (is (thrown-with-msg?
+          #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+          #":rf\.error/ssr-missing-payload-policy"
+          (payload-policy/apply-policy sample-app-db {})))
+    (is (thrown-with-msg?
+          #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+          #":rf\.error/ssr-missing-payload-policy"
+          (payload-policy/apply-policy sample-app-db nil))
+        "nil opts also throws — same contract")))
+
+(deftest apply-policy-throws-when-allowlist-empty
+  (testing "rf2-gtgf9: an empty :payload-keys is treated as no-allowlist
+            (shipping zero keys is almost certainly a programmer error,
+            not intent) — fail-closed still fires"
+    (is (thrown-with-msg?
+          #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+          #":rf\.error/ssr-missing-payload-policy"
+          (payload-policy/apply-policy sample-app-db {:payload-keys []})))
+    (is (thrown-with-msg?
+          #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+          #":rf\.error/ssr-missing-payload-policy"
+          (payload-policy/apply-policy sample-app-db {:payload-keys nil})))))
+
+(deftest apply-policy-throws-on-unknown-policy-keyword
+  (testing "rf2-gtgf9: a typo'd :payload-policy keyword surfaces as
+            :rf.error/ssr-unknown-payload-policy — distinct from the
+            missing-policy bucket so a typo doesn't silently land in
+            the `nothing-supplied` arm"
+    (is (thrown-with-msg?
+          #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+          #":rf\.error/ssr-unknown-payload-policy"
+          (payload-policy/apply-policy
+            sample-app-db
+            {:payload-policy :rf.ssr.payload/whole-db})) ; typo
+        "typo'd policy keyword throws unknown-policy")
+    (is (thrown-with-msg?
+          #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+          #":rf\.error/ssr-unknown-payload-policy"
+          (payload-policy/apply-policy
+            sample-app-db
+            {:payload-policy :myapp/custom-policy})))))
+
+;; ---- precedence: allowlist wins over whole-app-db ------------------------
+
+(deftest apply-policy-allowlist-wins-over-whole-app-db
+  (testing "rf2-gtgf9: when both :payload-keys and :payload-policy are
+            passed, the allowlist wins (it's the more-restrictive
+            policy choice — not a contradiction)"
+    (let [slice (payload-policy/apply-policy
+                  sample-app-db
+                  {:payload-keys   [:public/articles]
+                   :payload-policy :rf.ssr.payload/whole-app-db})]
+      (is (= {:public/articles [:a :b :c]} slice)
+          "allowlist takes precedence; the whole-app-db opt is ignored")
+      (is (not (contains? slice :server-only/auth))
+          "server-only keys still excluded — the allowlist wins"))))
+
+;; ---- validate-policy-opts!: construction-time arm ------------------------
+
+(deftest validate-policy-opts-passes-allowlist
+  (testing "valid :payload-keys passes validation + returns opts unchanged"
+    (let [opts {:on-create [:init] :payload-keys [:public/articles]}]
+      (is (= opts (payload-policy/validate-policy-opts! opts))
+          "returns opts unchanged on success — composes cleanly into
+           threading/let positions"))))
+
+(deftest validate-policy-opts-passes-whole-app-db
+  (testing "valid :payload-policy passes validation"
+    (let [opts {:on-create [:init] :payload-policy :rf.ssr.payload/whole-app-db}]
+      (is (= opts (payload-policy/validate-policy-opts! opts))))))
+
+(deftest validate-policy-opts-fails-closed
+  (testing "rf2-gtgf9 fail-closed: validation throws on absence —
+            handler-construction time arm of the same contract as
+            apply-policy"
+    (is (thrown-with-msg?
+          #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+          #":rf\.error/ssr-missing-payload-policy"
+          (payload-policy/validate-policy-opts! {:on-create [:init]})))))
+
+(deftest validate-policy-opts-throws-on-unknown-policy
+  (testing "construction-time arm also catches typo'd policy keywords"
+    (is (thrown-with-msg?
+          #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+          #":rf\.error/ssr-unknown-payload-policy"
+          (payload-policy/validate-policy-opts!
+            {:on-create [:init] :payload-policy :rf.ssr.payload/whole-db})))))
+
+(deftest error-ex-data-carries-recovery-tag
+  (testing "rf2-gtgf9: the structured error carries `:recovery
+            :declare-payload-policy` so trace tooling can suggest the
+            fix — Spec 009 error catalogue convention"
+    (try
+      (payload-policy/validate-policy-opts! {:on-create [:init]})
+      (is false "should have thrown")
+      (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+        (is (= :declare-payload-policy
+               (:recovery (ex-data e)))
+            "error ex-data names the recovery action")))))

--- a/implementation/ssr/test/re_frame/ssr_streaming_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_test.clj
@@ -144,9 +144,13 @@
 (deftest build-final-payload-shape
   (testing "Final payload carries the canonical :rf/hydration-payload shape"
     (let [fid (make-frame {:db {:articles [{:id "a"}]}})
+          ;; rf2-gtgf9: explicit fail-closed payload policy. This test
+          ;; pins the shape of the canonical payload — opt in to whole-
+          ;; app-db so the existing :rf/app-db assertion still holds.
           payload (streaming/build-final-payload fid "deadbeef"
-                                                 {:version 7
-                                                  :schema-digest "abc123"})]
+                                                 {:version       7
+                                                  :schema-digest "abc123"
+                                                  :payload-policy :rf.ssr.payload/whole-app-db})]
       (is (= 7 (:rf/version payload)))
       (is (= fid (:rf/frame-id payload)))
       (is (= "deadbeef" (:rf/render-hash payload)))

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -79,6 +79,17 @@ Out of payload scope (explicitly **not** carried):
 
 The bounded payload is the lock: implementations may emit additional optional keys per the additive-fields rule, but never alter the required keys, and the boundary above is what consumers (clients, tests, host adapters) rely on.
 
+#### `:rf/app-db` projection — explicit fail-closed policy (rf2-gtgf9)
+
+The `:rf/app-db` slice is projected from the request frame's `app-db` per an **explicit, fail-closed** policy. The host adapter MUST receive one of two declarative opts at construction time:
+
+- **`:payload-keys [<top-level-app-db-keys>]`** — an **allowlist**. Only the listed keys ride the wire; everything else is dropped, including any keys added later as the app evolves. This is the recommended primary mechanism — a denylist would silently leak each new server-only key as the app evolves; an allowlist forces a deliberate edit per new wire-bound key.
+- **`:payload-policy :rf.ssr.payload/whole-app-db`** — explicit opt-in to ship the whole `app-db` verbatim. Use only when the app's `app-db` is structurally safe to expose end-to-end (e.g. small SPAs where every server-set key is intended for the client).
+
+Absence of both is a **structural error** — the host adapter throws `:rf.error/ssr-missing-payload-policy` at handler-construction time so misconfigured deployments fail at boot, not at first request. Pre-rf2-gtgf9 the absence of `:payload-keys` defaulted to whole-app-db (fail-OPEN — the wrong default for a security boundary); the rf2-gtgf9 contract makes the privacy decision explicit at every host site. The CLJS reference's projection helper lives in `re-frame.ssr.payload-policy/apply-policy` (consumed by both `re-frame.ssr.ring.payload/build-payload` for non-streaming and `re-frame.ssr.streaming/build-final-payload` for streaming SSR — the policy contract is shared).
+
+When both opts are present the allowlist wins (it's the more-restrictive policy choice; not a contradiction). An empty `:payload-keys` (`[]`) is treated as no-allowlist — shipping zero keys is almost certainly a programmer error, not intent — and falls into the missing-policy bucket. A typo'd `:payload-policy` keyword surfaces as the distinct `:rf.error/ssr-unknown-payload-policy` so the developer can tell the failure modes apart.
+
 ## SSR flow
 
 ### Server flow (per request)

--- a/spec/conformance/fixtures/ssr-streaming.edn
+++ b/spec/conformance/fixtures/ssr-streaming.edn
@@ -133,10 +133,16 @@
   ;; required keys' presence and the version stamp; the actual
   ;; render-hash value is pinned by `:ssr/render-to-string` and the
   ;; hash-parity fixture corpus.
+  ;;
+  ;; rf2-gtgf9: payload policy is explicit + fail-closed. The
+  ;; conformance fixture opts in to whole-app-db so the payload-keys
+  ;; expectation below covers the full canonical shape rather than a
+  ;; sliced subset.
   {:call   :ssr/streaming/build-final-payload
-   :input  {:render-hash "00000000"          ;; placeholder; the implementation
-                                             ;; supplies the real FNV-1a hex here
-            :version 1}
+   :input  {:render-hash    "00000000"          ;; placeholder; the implementation
+                                                ;; supplies the real FNV-1a hex here
+            :version        1
+            :payload-policy :rf.ssr.payload/whole-app-db}
    :expect {:payload-keys #{:rf/version :rf/frame-id :rf/app-db :rf/render-hash}
             :rf/version   1}}]
 


### PR DESCRIPTION
## Summary

- Hydration payload policy is now **explicit and fail-closed** (rf2-gtgf9): callers MUST declare `:payload-keys` (allowlist, recommended) OR `:payload-policy :rf.ssr.payload/whole-app-db` (explicit opt-in). Absence of both throws `:rf.error/ssr-missing-payload-policy` at handler-construction time so misconfigured deployments fail at boot, not at first request.
- New `re-frame.ssr.payload-policy` namespace centralises the contract — one `apply-policy` shared by streaming and non-streaming SSR; one `validate-policy-opts!` invoked at both `ssr-handler` and `stream-handler` construction.
- Pre-rf2-gtgf9 fail-OPEN default (absence of `:payload-keys` shipped the whole app-db) is removed. Per the bead's pre-alpha posture, every existing test/example call site is updated to opt in explicitly under the new policy — the explicit declaration IS the contract.

## Mechanism chosen

**Allowlist + explicit whole-app-db opt-in.** A denylist would silently leak each new server-only key as the app evolves; an allowlist forces a deliberate edit per new wire-bound key. The opt-in whole-app-db keyword exists for apps whose entire app-db is structurally safe to expose (small SPAs, conformance fixtures, tests).

## Fail-closed proof

`fail-closed-proof-unpermitted-slot-not-on-wire` in `ring_test.clj`: handler is constructed with `:payload-keys [:public/articles]`; app-db also carries `:server-only/auth-token "RF2_GTGF9_FAIL_CLOSED_PROBE_xyz789"` and friends; the test inspects the wire-payload `<script id="__rf_payload">` body and asserts the leak-probe string is NOT present. Pre-rf2-gtgf9, that string would have ridden the wire silently.

## Test plan

- [x] `implementation/ssr` JVM tests: 153 tests / 490 assertions / 0 failures (was 139 / 469 before; +14 / +21 from new `payload_policy_cljs_test.cljc` leaf tests).
- [x] `implementation/ssr-ring` JVM tests: 56 tests / 270 assertions / 0 failures (was 51 / 250; +5 / +20 from new wire-level policy tests including the fail-closed proof).
- [x] Full CLJS regression: `npm run test:cljs` — 2154 tests / 6142 assertions / 0 failures (was 2140 / 6121; +14 / +21 from cross-platform `payload_policy_cljs_test.cljc`).
- [x] Conformance fixture `ssr-streaming.edn` updated to opt in via `:payload-policy :rf.ssr.payload/whole-app-db` so canonical-shape assertions still hold.
- [x] Spec 011 §`:rf/app-db` projection — explicit fail-closed policy added (rf2-gtgf9).
- [x] Docs guide `11-server-side.md` updated with the new opts.

## Files

- New: `implementation/ssr/src/re_frame/ssr/payload_policy.cljc` (shared contract, ~150 LoC)
- New: `implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc` (14 leaf tests)
- Modified: `re-frame.ssr.streaming`, `re-frame.ssr.ring{,/payload,/pipeline,/streaming}`, ring_test.clj (+ 4 new tests including fail-closed proof), ssr_streaming_test.clj, conformance fixture, Spec 011, docs guide, ssr_streaming example, every existing test call site opts in explicitly.