### PR TITLE
test(conformance): sensitive-handler exception redaction fixture (rf2-wxe9t)

### DIFF
--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -50,6 +50,11 @@
             [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.cofx :as cofx]
+            ;; rf2-wxe9t — the always-on error-emit substrate is the
+            ;; fan-out path the conformance runner observes for the
+            ;; `:error-emit-records` expectation. Mirror of the JVM
+            ;; runner's require.
+            [re-frame.error-emit :as error-emit]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.flows :as flows]
@@ -269,7 +274,14 @@
   ;;    runner achieves the equivalent via `clear-trace-cbs!` +
   ;;    `(require 're-frame.ssr :reload)`; CLJS has no `:reload`,
   ;;    so the snapshot-restore path is the only correct one.
-  (reset! re-frame.trace/listeners baseline-trace-listeners))
+  (reset! re-frame.trace/listeners baseline-trace-listeners)
+  ;; 7. rf2-wxe9t — drop every corpus-wide error-emit listener so
+  ;;    a recorder installed by `collect-error-emit-records!` for
+  ;;    one fixture cannot fire against the next fixture's drains.
+  ;;    The registry is a `defonce` atom inside
+  ;;    `re-frame.error-emit`; without an explicit clear, the prior
+  ;;    fixture's recorder stays live across fixtures.
+  (error-emit/clear-error-emit-listeners!))
 
 ;; ---- fixture execution ----------------------------------------------------
 
@@ -502,6 +514,54 @@
   (let [traces (atom [])]
     (trace/register-trace-cb! [fixture-id] (fn [ev] (swap! traces conj ev)))
     traces))
+
+(defn- collect-error-emit-records!
+  "Per rf2-wxe9t: register a corpus-wide error-emit listener for the
+  duration of `fixture-id`'s run; each tight error-record fanned out
+  by `re-frame.error-emit/dispatch-on-error!` is appended to the
+  returned atom in firing order. The conformance harness uses the
+  captured records to assert the always-on substrate's `:sensitive?`
+  handler-meta redaction contract host-neutrally. Mirror of the JVM
+  runner."
+  [fixture-id]
+  (let [records (atom [])]
+    (error-emit/register-error-emit-listener!
+      [fixture-id ::records]
+      (fn [record] (swap! records conj record)))
+    records))
+
+(defn- check-error-emit-records
+  "Per rf2-wxe9t: partial-submap matcher for `:error-emit-records`,
+  mirror of `check-trace-emissions`. Expected entries are matched in
+  declaration order; each entry's key/value pairs must appear on an
+  actual record at-or-after the previous match. Returns a vector of
+  failure strings (empty when all matched)."
+  [actual-records expected-records]
+  (loop [actual    actual-records
+         expected  expected-records
+         failures  []]
+    (cond
+      (empty? expected)
+      failures
+
+      (empty? actual)
+      (conj failures (str "expected error-emit record not seen: "
+                          (pr-str (first expected))))
+
+      :else
+      (let [exp (first expected)
+            match-idx (->> actual
+                           (map-indexed vector)
+                           (some (fn [[i a]]
+                                   (when (every? (fn [[k v]]
+                                                   (= v (get a k)))
+                                                 exp)
+                                     i))))]
+        (if match-idx
+          (recur (drop (inc match-idx) actual) (rest expected) failures)
+          (recur actual (rest expected)
+                 (conj failures (str "expected error-emit record not seen: "
+                                     (pr-str exp)))))))))
 
 (defn- submap?
   "True if every key in expected appears in actual with a matching
@@ -794,6 +854,10 @@
           ;; Register the trace listener FIRST so registration-time
           ;; warnings are captured.
           traces       (collect-traces fid)
+          ;; rf2-wxe9t — capture the always-on error-emit substrate's
+          ;; tight error-records alongside the trace listener. Mirror
+          ;; of the JVM runner.
+          err-records  (collect-error-emit-records! fid)
           _            (realise-handlers fixture)
           _            (register-routes! fixture)
           ;; `:fixture/runtime :platform` declares the simulated host
@@ -895,6 +959,13 @@
                    :expected expected-val
                    :actual   (rf/subscribe-once frame-id qv)})))
             trace-failures (check-trace-emissions @traces (:trace-emissions expect))
+            ;; rf2-wxe9t — substrate-side error-emit records mirror of
+            ;; the JVM runner. A fixture without `:error-emit-records`
+            ;; yields nil failures and does not constrain the substrate.
+            error-emit-failures (when (contains? expect :error-emit-records)
+                                  (check-error-emit-records
+                                    @err-records
+                                    (:error-emit-records expect)))
             actual-effects (effects-routed-from-traces @traces)
             expected-effects (when (contains? expect :effects-routed)
                                (normalise-effects-routed (:effects-routed expect)))
@@ -921,6 +992,11 @@
         ;; mostly belt-and-braces — but it keeps the in-fixture-end
         ;; state from leaking error traces against a missing :rf/route.
         (trace/remove-trace-cb! fid)
+        ;; rf2-wxe9t — drop just this fixture's error-emit recorder so
+        ;; it does not leak into the next fixture's drains. The
+        ;; reset-runtime! call also clears the registry on next entry;
+        ;; this is belt-and-braces (mirror of the JVM runner).
+        (error-emit/unregister-error-emit-listener! [fid ::records])
         {:fixture-id   fid
          :passed?      (and (or (nil? expected-db) (submap? expected-db final-db))
                             (or (nil? expected-dbs)
@@ -929,6 +1005,7 @@
                             (every? #(= (:expected %) (:actual %)) sub-checks)
                             (empty? trace-failures)
                             (empty? effects-failures)
+                            (empty? error-emit-failures)
                             (or (nil? public-error-check)
                                 (:passed? public-error-check)))
          :final-db     final-db
@@ -940,6 +1017,8 @@
          :effects-failures   effects-failures
          :actual-effects     actual-effects
          :expected-effects   expected-effects
+         :error-emit-failures error-emit-failures
+         :actual-error-emit-records @err-records
          :public-error-check public-error-check}))
     (catch :default e
       {:fixture-id (:fixture/id fixture)
@@ -1047,6 +1126,12 @@
             (println "    actual effects routed:")
             (doseq [a (:actual-effects f)]
               (println "      " (pr-str a))))
+          (when (seq (:error-emit-failures f))
+            (doseq [eef (:error-emit-failures f)]
+              (println "    error-emit:" eef))
+            (println "    actual error-emit records:")
+            (doseq [r (:actual-error-emit-records f)]
+              (println "      " (pr-str r))))
           (when-let [pec (:public-error-check f)]
             (when-not (:passed? pec)
               (println "    public-error expected:" (:expected pec))

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -17,6 +17,13 @@
             [clojure.edn :as edn]
             [re-frame.core :as rf]
             [re-frame.cofx :as cofx]
+            ;; rf2-wxe9t — the always-on error-emit substrate (Spec 009
+            ;; §What IS available in production §Error-handler policy)
+            ;; is the fan-out path the conformance runner observes for
+            ;; the `:error-emit-records` expectation. Requiring the ns
+            ;; here makes its registry available without each fixture
+            ;; needing to know which artefact owns the substrate.
+            [re-frame.error-emit :as error-emit]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.flows :as flows]
@@ -206,6 +213,13 @@
   (reset! frame/frames {})
   (reset! flows/flows {})
   (reset! schemas/schemas-by-frame {})
+  ;; rf2-wxe9t — drop every corpus-wide error-emit listener so a
+  ;; listener installed by `collect-error-emit-records!` for one
+  ;; fixture cannot fire against the next fixture's drains. The
+  ;; registry is a `defonce` atom inside `re-frame.error-emit`;
+  ;; without an explicit clear, hot-reload semantics keep the prior
+  ;; fixture's recorder alive.
+  (error-emit/clear-error-emit-listeners!)
   ;; rf2-v0jwt — drop the per-frame epoch ring buffer (and the in-flight
   ;; capture buffer) between fixtures so `:epoch-records` assertions
   ;; observe THIS fixture's recorded epochs only.
@@ -521,6 +535,59 @@
   (let [traces (atom [])]
     (trace/register-trace-cb! [fixture-id] (fn [ev] (swap! traces conj ev)))
     traces))
+
+(defn- collect-error-emit-records!
+  "Per rf2-wxe9t: register a corpus-wide error-emit listener for the
+  duration of `fixture-id`'s run; each tight error-record (the
+  `re-frame.error-emit/dispatch-on-error!` fan-out shape — see
+  `re-frame.error-emit` ns docstring §Record shape) is appended to
+  the returned atom in firing order. The conformance harness uses
+  the captured records to assert the always-on substrate's
+  `:sensitive?` redaction contract host-neutrally.
+
+  The matching `unregister-error-emit-listener!` call happens at the
+  end of `run-fixture` so the listener does NOT leak into the next
+  fixture's drains. `reset-runtime!` also calls
+  `clear-error-emit-listeners!` belt-and-braces for safety."
+  [fixture-id]
+  (let [records (atom [])]
+    (error-emit/register-error-emit-listener!
+      [fixture-id ::records]
+      (fn [record] (swap! records conj record)))
+    records))
+
+(defn- check-error-emit-records
+  "Per rf2-wxe9t: partial-submap matcher for `:error-emit-records`,
+  mirror of `check-trace-emissions`. Expected entries are matched in
+  declaration order; each entry's key/value pairs must appear on an
+  actual record at-or-after the previous match. Returns a vector of
+  failure strings (empty when all matched)."
+  [actual-records expected-records]
+  (loop [actual    actual-records
+         expected  expected-records
+         failures  []]
+    (cond
+      (empty? expected)
+      failures
+
+      (empty? actual)
+      (conj failures (str "expected error-emit record not seen: "
+                          (pr-str (first expected))))
+
+      :else
+      (let [exp (first expected)
+            match-idx (->> actual
+                           (map-indexed vector)
+                           (some (fn [[i a]]
+                                   (when (every? (fn [[k v]]
+                                                   (= v (get a k)))
+                                                 exp)
+                                     i))))]
+        (if match-idx
+          (recur (drop (inc match-idx) actual) (rest expected) failures)
+          (recur actual (rest expected)
+                 (conj failures (str "expected error-emit record not seen: "
+                                     (pr-str exp)))))))))
 
 (defn- submap?
   "True if every key in expected appears in actual with a matching value.
@@ -909,6 +976,16 @@
           ;; (e.g. :rf.warning/route-shadowed-by-equal-score from reg-route)
           ;; are captured. realise-handlers and register-routes! run after.
           traces       (collect-traces fid)
+          ;; rf2-wxe9t — capture the always-on error-emit substrate's
+          ;; tight error-records in parallel with the trace listener.
+          ;; The two paths emit from ONE normative site in the router's
+          ;; handler-exception path (`re-frame.router/emit-handler-
+          ;; exception!`) but carry DIFFERENT shapes: trace gets the
+          ;; `:operation`/`:tags` envelope; the substrate listener gets
+          ;; the tight `{:error :event :event-id :frame :time :exception
+          ;; :elapsed-ms}` record with handler-meta `:sensitive?`
+          ;; redaction already applied to `:event`.
+          err-records  (collect-error-emit-records! fid)
           _            (realise-handlers fixture)
           _            (register-routes! fixture)
           frame-config (or (:fixture/frame-config fixture) {})
@@ -1022,6 +1099,15 @@
                    :expected expected-val
                    :actual   (rf/subscribe-once frame-id qv)})))
             trace-failures (check-trace-emissions @traces (:trace-emissions expect))
+            ;; rf2-wxe9t — substrate-side error-emit records (the
+            ;; corpus-wide listener fan-out). The matcher mirrors
+            ;; `check-trace-emissions` (positional partial-submap).
+            ;; A fixture without `:error-emit-records` yields nil
+            ;; failures and does not constrain the substrate.
+            error-emit-failures (when (contains? expect :error-emit-records)
+                                  (check-error-emit-records
+                                    @err-records
+                                    (:error-emit-records expect)))
             ;; rf2-v0jwt — :epoch-records — assert against the named frame's
             ;; recorded :rf/epoch-record ring. Each entry is a partial-shape
             ;; submap; useful for pinning the halted-cascade :outcome /
@@ -1060,6 +1146,11 @@
                    :actual   nil
                    :passed?  false})))]
         (trace/clear-trace-cbs!)
+        ;; rf2-wxe9t — drop just this fixture's error-emit recorder so
+        ;; it does not leak into the next fixture's drains. The
+        ;; reset-runtime! call at the top of the next fixture also
+        ;; clears the registry; this is belt-and-braces.
+        (error-emit/unregister-error-emit-listener! [fid ::records])
         {:fixture-id   fid
          :passed?      (and (or (nil? expected-db) (submap? expected-db final-db))
                             (or (nil? expected-dbs)
@@ -1069,6 +1160,7 @@
                             (empty? trace-failures)
                             (empty? effects-failures)
                             (empty? epoch-failures)
+                            (empty? error-emit-failures)
                             (or (nil? public-error-check)
                                 (:passed? public-error-check)))
          :final-db     final-db
@@ -1081,6 +1173,8 @@
          :actual-effects     actual-effects
          :expected-effects   expected-effects
          :epoch-failures     epoch-failures
+         :error-emit-failures error-emit-failures
+         :actual-error-emit-records @err-records
          :public-error-check public-error-check}))
     (catch Throwable e
       {:fixture-id (:fixture/id fixture)
@@ -1197,6 +1291,12 @@
           (when (seq (:epoch-failures f))
             (doseq [erf (:epoch-failures f)]
               (println "    epoch:" erf)))
+          (when (seq (:error-emit-failures f))
+            (doseq [eef (:error-emit-failures f)]
+              (println "    error-emit:" eef))
+            (println "    actual error-emit records:")
+            (doseq [r (:actual-error-emit-records f)]
+              (println "      " (pr-str r))))
           (when-let [pec (:public-error-check f)]
             (when-not (:passed? pec)
               (println "    public-error expected:" (:expected pec))

--- a/spec/conformance/fixtures/sensitive-handler-exception-redaction.edn
+++ b/spec/conformance/fixtures/sensitive-handler-exception-redaction.edn
@@ -1,0 +1,81 @@
+;; Conformance fixture: error/sensitive-handler-exception-redaction
+;; Per rf2-wxe9t (bead) and rf2-vnjfg (security audit) — a handler
+;; registered with `:sensitive? true` metadata throws on dispatch with a
+;; sensitive-looking payload. The always-on error-emit substrate MUST
+;; surface the failure to corpus-wide listeners with the event slot
+;; replaced by `:rf/redacted` (and the structured policy-fn event's
+;; `:tags :event` likewise scrubbed), regardless of host — the
+;; production-survivable error path is precisely the boundary that
+;; would otherwise ship credentials / PII off-box (Sentry, Honeybadger,
+;; Rollbar style forwarders).
+;;
+;; The fixture pins the substrate behaviour through the new
+;; `:error-emit-records` observable; the trace surface is also pinned
+;; for the public discriminators (`:operation`, `:op-type`, `:event-id`,
+;; `:exception-message`) that flow through unchanged so operators
+;; retain the triage signal. The companion unit tests
+;; `re-frame.on-error-test/sensitive-handler-meta-redacts-*` and
+;; `re-frame.on-error-elision-prod-test/sensitive-handler-error-record-redacted-under-prod`
+;; cover the same contract in dev and `:advanced` + `goog.DEBUG=false`
+;; respectively; this fixture is the host-neutral conformance gate.
+
+{:fixture/id           :error/sensitive-handler-exception-redaction
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/error :core/trace}
+ :fixture/doc          "A handler registered with :sensitive? true metadata throws on dispatch with a payload that includes credential-shaped data. The always-on error-emit substrate MUST surface :rf.error/handler-exception to corpus-wide listeners with the event slot replaced by :rf/redacted. Event-id, frame, and exception flow through unchanged for triage. Pins rf2-vnjfg's redaction guarantee end-to-end on every conformant host."
+
+ :fixture/registry
+ {:event {:counter/initialise
+          {:doc "Seed."}
+          :auth/sign-in
+          ;; The :sensitive? flag is the cross-cutting privacy escape
+          ;; hatch (Spec 009 §Privacy / sensitive data in traces; Spec
+          ;; Security §Privacy boundary). :no-redaction-needed? true
+          ;; opts out of the registration-time advisory
+          ;; (:rf.warning/sensitive-without-redaction); we are pinning
+          ;; the substrate-level redaction, not the schema- /
+          ;; with-redacted-interceptor path.
+          {:doc                   "Sign-in attempt with credential payload — always throws to drive the error path."
+           :sensitive?            true
+           :no-redaction-needed?  true}}
+  :sub   {:fired-events {:doc "Captures which events ran."}}}
+
+ :fixture/handlers
+ {:event {:counter/initialise [[:set [:fired] []]]
+          :auth/sign-in       [[:throw "auth failed"]]}
+  :sub   {:fired-events [[:get [:fired]]]}}
+
+ :fixture/frame-config {:on-create [:counter/initialise]}
+
+ :fixture/dispatches
+ ;; Dispatch the sensitive handler with credential-shaped payload. The
+ ;; raw payload is what the substrate MUST NOT ship to listeners.
+ [[:auth/sign-in {:username "ada" :password "shhh" :token "abc123"}]]
+
+ :fixture/expect
+ ;; Per rf2-vnjfg the error-emit substrate replaces the listener
+ ;; record's :event slot with the :rf/redacted sentinel when the
+ ;; failing handler is registered :sensitive? true. The fixture
+ ;; harness captures the always-on listener's records and partial-
+ ;; matches them here.
+ {:error-emit-records
+  [{:error    :rf.error/handler-exception
+    :event    :rf/redacted                                     ;; the raw {:username ... :password ... :token ...} MUST NOT appear
+    :event-id :auth/sign-in
+    :frame    :rf/default}]
+
+  ;; Trace surface — the per-frame trace cb sees the error with
+  ;; the public discriminators flowing through. The trace path's
+  ;; :tags :event slot is governed by schema-derived redaction (NOT
+  ;; the substrate-level handler-meta redaction); we therefore pin
+  ;; only the discriminators here. The substrate-level redaction
+  ;; assertion above (`:error-emit-records`) is the load-bearing
+  ;; check for handler-meta `:sensitive?`.
+  :trace-emissions
+  [{:operation :rf.error/handler-exception
+    :op-type   :error
+    :tags      {:event-id          :auth/sign-in
+                :failing-id        :auth/sign-in
+                :exception-message "auth failed"
+                :reason            "Event handler threw."}
+    :recovery  :no-recovery}]}}


### PR DESCRIPTION
## Summary

- Adds a host-neutral conformance fixture (`spec/conformance/fixtures/sensitive-handler-exception-redaction.edn`) pinning rf2-vnjfg's substrate-side redaction guarantee: a `:sensitive? true` handler that throws on dispatch MUST surface to corpus-wide error-emit listeners with the event slot replaced by `:rf/redacted` — protecting credentials / PII at the production-survivable error boundary (Sentry / Honeybadger / Rollbar forwarders).
- Extends both JVM (`conformance_test.clj`) and CLJS (`conformance_corpus_cljs_test.cljs`) runners with a per-fixture error-emit listener and a new `:fixture/expect :error-emit-records` partial-submap matcher (positional, mirror of `:trace-emissions`). Registry cleared between fixtures so the `defonce`-backed listener atom does not leak.
- Closes the conformance-corpus gap identified in the bead: unit-test coverage of the redaction predicate already exists in `re-frame.on-error-test` (dev) and `re-frame.on-error-elision-prod-test` (`:advanced` + `goog.DEBUG=false`); this fixture is the host-neutral conformance gate.

## Test plan

- [x] `clojure -M:test --namespace re-frame.conformance-test` — 1 test / 1 assertion, 0 failures
- [x] `npm run test:cljs` — 2140 tests / 6121 assertions, 0 failures
- [x] `npm run test:elision` — production 30/30 absent; control 30/30 present
- [x] Fixture-sabotage check confirmed the new `:error-emit-records` assertion is wired (corrupted sentinel → suite failed; restoration → suite passed)