### PR TITLE
fix(examples): repair causa-rigorous testbed regression from rf2-nb8if (rf2-043uz)

### DIFF
--- a/tools/causa/spec/Conventions.md
+++ b/tools/causa/spec/Conventions.md
@@ -81,14 +81,37 @@ The facade's `reg-view` body is either:
   composite-sub deref), OR
 - **Delegating** to a single plain Reagent fn from
   `<panel>-views.cljs`, when the body would exceed the facade's
-  cohesive scope:
+  cohesive scope. The leaf is invoked as a **plain function call**
+  (parens), not a Reagent component vector (brackets):
 
   ```clojure
   (rf/reg-view subscriptions-view
     "The Subscriptions panel's root view."
     []
-    [views/subscriptions-panel])
+    (views/subscriptions-panel))    ; parens — leaf body inlined
   ```
+
+  **Do not write `[views/subscriptions-panel]` here.** The vector
+  form would mount the leaf as a separate plain Reagent fn component;
+  it would drop out of the surrounding frame and any `subscribe` /
+  `dispatch` inside the leaf would silently route to `:rf/default`
+  (Spec 004 §Plain Reagent fns / Spec 006 §706). The plain-call form
+  keeps the leaf body executing within the facade reg-view wrapper's
+  render — the wrapper IS the in-flight Reagent component, so
+  `current-frame` reads `:rf/causa` from React context and the leaf's
+  subs/dispatches see the Causa frame. (rf2-043uz pinned this — the
+  AI Co-Pilot's slash popover never opened because the input-row
+  leaf's input-text subscribe was routed to `:rf/default` while the
+  dispatch wrote to `:rf/causa`.)
+
+  The same rule applies recursively to sibling leaves the view-leaf
+  itself invokes (`chrome` / `feed` / `input` / `conversation` /
+  `badges` / `rows` / `chain` / `sections`): if the sibling leaf
+  contains a `subscribe` whose key lives on the panel's frame, call
+  it with parens, not brackets. Sibling leaves that only `dispatch`
+  with an explicit `{:frame :rf/causa}` opt can use either form
+  (brackets are fine if a separate render boundary is wanted for
+  React-key / memoisation reasons).
 
   The leaf fn (`subscriptions-panel`) is a plain `defn`, not a
   `reg-view`. The facade is still where the registration happens; the

--- a/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot.cljs
@@ -19,20 +19,31 @@
             [day8.re-frame2-causa.panels.ai-co-pilot-subs :as subs]
             [day8.re-frame2-causa.panels.ai-co-pilot-views :as views]))
 
+;; Bodies invoke leaf fns as plain calls — `(views/foo)`, not the
+;; Reagent component vector `[views/foo]`. The leaf body executes
+;; during this reg-view wrapper's render, so its `subscribe` / `dispatch`
+;; calls resolve through the wrapper's React-context tier and reach
+;; `:rf/causa`. The vector form would mount the leaf as a separate
+;; plain Reagent fn component that drops out of the surrounding frame
+;; (Spec 004 §Plain Reagent fns) — `:rf/causa` subs would silently
+;; route to `:rf/default` and the `:rf.warning/plain-fn-under-non-
+;; default-frame-once` warning fires. See
+;; `tools/causa/spec/Conventions.md` §View body delegation.
+
 (rf/reg-view ai-co-pilot-rail
   "Open 320px right-rail form of the AI Co-Pilot."
   []
-  [views/ai-co-pilot-rail])
+  (views/ai-co-pilot-rail))
 
 (rf/reg-view ai-co-pilot-cue
   "Collapsed cue glyph form of the AI Co-Pilot."
   []
-  [views/ai-co-pilot-cue])
+  (views/ai-co-pilot-cue))
 
 (rf/reg-view ai-co-pilot-view
   "Canvas panel form of the AI Co-Pilot."
   []
-  [views/ai-co-pilot-view])
+  (views/ai-co-pilot-view))
 
 (defn install!
   "Idempotent install for the AI Co-Pilot panel's Causa-side

--- a/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot_views.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot_views.cljs
@@ -28,7 +28,13 @@
      [chrome/title-bar]
      [:div {:style {:flex 1 :overflow-y "auto"}}
       [conversation/conversation-view conversation]]
-     [input/input-row]]))
+     ;; Plain function call (not `[input/input-row]`) so the leaf's
+     ;; `:rf.causa/copilot-input-text` subscribe resolves to `:rf/causa`
+     ;; via this view's wrapper. A component-vector here would mount
+     ;; input-row as a separate plain Reagent fn — its subscribe would
+     ;; silently route to `:rf/default` (Spec 004 §Plain Reagent fns)
+     ;; and the slash popover would never appear. The rf2-043uz fix.
+     (input/input-row)]))
 
 (defn ai-co-pilot-cue
   "Collapsed `◇` cue glyph. The pulse stops after first use."
@@ -51,4 +57,10 @@
      [chrome/title-bar]
      [:div {:style {:flex 1 :overflow-y "auto"}}
       [conversation/conversation-view conversation]]
-     [input/input-row]]))
+     ;; Plain function call (not `[input/input-row]`) so the leaf's
+     ;; `:rf.causa/copilot-input-text` subscribe resolves to `:rf/causa`
+     ;; via this view's wrapper. A component-vector here would mount
+     ;; input-row as a separate plain Reagent fn — its subscribe would
+     ;; silently route to `:rf/default` (Spec 004 §Plain Reagent fns)
+     ;; and the slash popover would never appear. The rf2-043uz fix.
+     (input/input-row)]))

--- a/tools/causa/src/day8/re_frame2_causa/panels/mcp_server.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/mcp_server.cljs
@@ -30,9 +30,19 @@
             [day8.re-frame2-causa.panels.mcp-server-views :as views]))
 
 (rf/reg-view mcp-server-view
-  "The MCP Server panel's root view."
+  "The MCP Server panel's root view.
+
+  The body invokes the leaf as a plain function call —
+  `(views/mcp-server-view)`, not the Reagent component vector
+  `[views/mcp-server-view]`. That keeps the leaf body inlined into
+  this reg-view wrapper's render, so the leaf's `subscribe` /
+  `dispatch` calls reach `:rf/causa` through the wrapper's React-
+  context tier. The vector form would mount the leaf as a plain
+  Reagent fn component that drops out of the surrounding frame
+  (Spec 004 §Plain Reagent fns / Spec 006 §706); see
+  `tools/causa/spec/Conventions.md` §View body delegation."
   []
-  [views/mcp-server-view])
+  (views/mcp-server-view))
 
 (defn install!
   "Idempotent install for the MCP Server panel's Causa-side

--- a/tools/causa/src/day8/re_frame2_causa/panels/subscriptions.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/subscriptions.cljs
@@ -14,9 +14,19 @@
              :as views]))
 
 (rf/reg-view subscriptions-view
-  "The Subscriptions panel's root view."
+  "The Subscriptions panel's root view.
+
+  The body invokes the leaf as a plain function call —
+  `(views/subscriptions-panel)`, not the Reagent component vector
+  `[views/subscriptions-panel]`. That keeps the leaf body inlined into
+  this reg-view wrapper's render, so the leaf's `subscribe` /
+  `dispatch` calls reach `:rf/causa` through the wrapper's React-
+  context tier. The vector form would mount the leaf as a plain
+  Reagent fn component that drops out of the surrounding frame
+  (Spec 004 §Plain Reagent fns / Spec 006 §706); see
+  `tools/causa/spec/Conventions.md` §View body delegation."
   []
-  [views/subscriptions-panel])
+  (views/subscriptions-panel))
 
 (defn install!
   "Idempotent install for the Subscriptions panel's Causa-side


### PR DESCRIPTION
## Summary
- Closes the causa-rigorous Playwright timeout that has been failing every PR opened against `origin/main` since rf2-nb8if landed (commit 70fec308). Reproduced locally; root-caused; fixed.
- Root cause: three of the four reshaped facades delegate to a plain Reagent leaf via the component-vector form `[views/foo]`. That mounts the leaf as a separate plain Reagent fn component, which carries no `:contextType frame-context`, so its `subscribe` calls silently route to `:rf/default` instead of `:rf/causa` (Spec 004 §Plain Reagent fns / Spec 006 §706). The runtime already shouted `:rf.warning/plain-fn-under-non-default-frame-once` for `ai_co_pilot_input.input_row`.
- Fix: switch the facade delegations (and the rail/view → input-row site) from the component-vector form to a plain function call `(views/foo)`. The leaf body executes within the wrapper's render scope; `current-frame` reads `:rf/causa` from React context; subs/dispatches resolve correctly. `tools/causa/spec/Conventions.md` §View body delegation updated lockstep so the convention itself prevents this from recurring.

### Before / after — the failing locator

The spec waits on the slash popover that appears when the user types `/` into the co-pilot input:

```
- waiting for locator('[data-testid="rf-causa-copilot-slash-popover"]') to be visible
  → Timeout 5000ms exceeded
```

Pre-fix, the round-trip was: `dispatch [:rf.causa/copilot-set-input-text "/"]` (correctly tagged `{:frame :rf/causa}`) → `subscribe [:rf.causa/copilot-input-text]` (silently routed to `:rf/default`'s app-db, returning `""`). The popover sub stayed empty; the locator never resolved.

Post-fix the same subscribe reads `:rf/causa`, `input` becomes `"/"`, `slash-popover-matches` returns the eight slash commands, and the popover renders.

### Files changed

- `tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot.cljs` — three facade `reg-view`s switch `[views/...]` → `(views/...)`.
- `tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot_views.cljs` — sibling delegation to `input-row` switches `[input/input-row]` → `(input/input-row)` (two call sites, rail + canvas view).
- `tools/causa/src/day8/re_frame2_causa/panels/subscriptions.cljs` — facade `reg-view` switches form.
- `tools/causa/src/day8/re_frame2_causa/panels/mcp_server.cljs` — facade `reg-view` switches form.
- `tools/causa/spec/Conventions.md` — §View body delegation example fixed; explicit rule about brackets vs parens added; recursive-rule note for sibling leaves with subscribes.

## Test plan
- [x] Reproduced the failure locally on `origin/main`: `npm run test:examples` → 1/38 FAIL on `causa-rigorous` with the documented `[data-testid="rf-causa-copilot-slash-popover"]` timeout.
- [x] After fix, `npm run test:examples` → 38/38 pass, 0 failures.
- [x] `npm run test:cljs` (full node-runtime CLJS suite, 2140 tests / 6121 assertions) → 0 failures.
- [x] `clojure -M:test` from `tools/causa/` (535 tests / 1521 assertions) → 0 failures.
- [x] `scripts/test-fast-pr.sh` → PASS.

Closes rf2-043uz.